### PR TITLE
docs: align newcomer onboarding flow and update docs skill

### DIFF
--- a/.codex/skills/agilab-docs/SKILL.md
+++ b/.codex/skills/agilab-docs/SKILL.md
@@ -3,7 +3,7 @@ name: agilab-docs
 description: Documentation workflow for AGILAB (sources vs generated HTML, public constraints, consistency checks).
 license: BSD-3-Clause (see repo LICENSE)
 metadata:
-  updated: 2026-04-03
+  updated: 2026-04-08
 ---
 
 # Docs Skill (AGILAB)
@@ -81,13 +81,32 @@ If you accidentally edit `docs/html` directly, discard that manual edit and rege
 ## Build / Validate
 
 - Local Sphinx build (from `agilab` repo root):
-  - `uv --preview-features extra-build-dependencies run --project ../thales_agilab --group sphinx python -m sphinx -b html ../thales_agilab/docs/source docs/html`
+- Local Sphinx build (from `../thales_agilab` repo root):
+  - `uv sync --group sphinx --dev` (or equivalent environment bootstrap command in your `uv` version).
+  - `uv run sphinx-build -n -q -b html docs/source docs/_build/html`
+    - Keep `--group sphinx` variants if your installed `uv` supports it for your workflow.
+  - Prefer this path when validating canonical docs edits; only sync to `../agilab/docs/source`
+    when the page is published through the `agilab` repo workflow.
+- Quick mirror validation (from `../thales_agilab`):
+  - verify the canonical change is present in `../thales_agilab/docs/source`.
+  - then mirror only the touched files into `../agilab/docs/source`.
+  - rebuild the local public mirror with your project-specific docs command if needed before publish.
 - Publish workflow check (AGILAB public site):
   - `gh workflow run docs-publish.yaml -R ThalesGroup/agilab --ref main`
   - `gh run view <run-id> -R ThalesGroup/agilab --json status,conclusion,url`
   - for a slow or opaque deploy, prefer:
     - `gh run view <run-id> -R ThalesGroup/agilab --json status,conclusion,jobs,url`
-    instead of waiting blindly on a watcher
+      instead of waiting blindly on a watcher
+
+## Newcomer Documentation Review
+
+- Before publishing, do a quick onboarding-focused pass on any edited page:
+  - installation flow is executable as written.
+  - environment paths are source-agnostic where possible (especially for
+    `apps` and workspace directories).
+  - any `app_settings.toml` mention explains both valid seed locations:
+    `<project>/app_settings.toml` and `<project>/src/app_settings.toml`.
+  - external links and labels are clear, not placeholder or contradictory.
 - Regenerate run-config wrappers after `.idea/runConfigurations` changes:
   - `uv --preview-features extra-build-dependencies run python tools/generate_runconfig_scripts.py`
 

--- a/docs/source/apps-pages.rst
+++ b/docs/source/apps-pages.rst
@@ -46,9 +46,10 @@ the per-user workspace copy of ``app_settings.toml``:
    view_module = ["view_maps_network", "view_barycentric"]
 
 The file lives at ``~/.agilab/apps/<project>/app_settings.toml`` and is seeded
-from ``src/<project>/src/app_settings.toml`` on first use. You can edit it
-manually (PROJECT → APP-SETTINGS) or use Analysis → Configure, which writes the
-same list for you.
+from the app's versioned ``app_settings.toml`` source file (for example
+``<project>/app_settings.toml`` or ``<project>/src/app_settings.toml``) on first
+use. You can edit it manually (PROJECT → APP-SETTINGS) or use Analysis →
+Configure, which writes the same list for you.
 
 Included page bundles
 ---------------------

--- a/docs/source/architecture.rst
+++ b/docs/source/architecture.rst
@@ -118,9 +118,10 @@ Runtime flow
    an example in ``src/agilab/examples/<app>/AGI_run_*.py``.
 2. The script instantiates ``AgiEnv`` with the desired ``apps_dir`` and ``app``.
    ``AgiEnv`` resolves symlinks, copies optional data bundles, seeds
-   ``~/.agilab/apps/<app>/app_settings.toml`` from the versioned
-   ``src/app_settings.toml`` when needed, and loads overrides from that
-   workspace copy.
+   ``~/.agilab/apps/<app>/app_settings.toml`` from the app's versioned
+   source ``app_settings.toml`` (``<project>/app_settings.toml`` or
+   ``<project>/src/app_settings.toml``) when needed, and loads overrides from
+   that workspace copy.
 3. ``AGI.run`` (or ``AGI.get_distrib`` / ``AGI.install``) selects the dispatcher
    mode, builds or reuses the worker wheel, and starts a scheduler locally or on
    the configured SSH hosts.

--- a/docs/source/edit-help.rst
+++ b/docs/source/edit-help.rst
@@ -83,8 +83,9 @@ Main Content Area
   - ``APP-SETTINGS`` opens the per-user workspace
     ``~/.agilab/apps/<project>/app_settings.toml``. AGILab keeps the ``[args]``
     and ``[pages]`` sections in sync with the Orchestrate and Analysis pages.
-    The file is seeded from the versioned ``src/app_settings.toml`` when the app
-    is first loaded.
+    The file is seeded from the app's versioned source ``app_settings.toml``
+    (``<project>/app_settings.toml`` or ``<project>/src/app_settings.toml``)
+    when the app is first loaded.
   - ``README`` allows quick edits to the project ``README.md``.
   - ``APP-ARGS`` targets ``app_args.py`` in the app package. Use it to
     synchronise default arguments with the Orchestrate page.

--- a/docs/source/execute-help.rst
+++ b/docs/source/execute-help.rst
@@ -11,7 +11,7 @@ application. It generates ready-to-run snippets, streams logs back into the UI
 and keeps the per-user ``app_settings.toml`` workspace copy synchronised so
 that installs, distribution checks and runs are reproducible. The mutable file
 now lives under ``~/.agilab/apps/<app>/app_settings.toml`` and is seeded from
-the app's versioned ``src/app_settings.toml`` on first use.
+the app's versioned ``app_settings.toml`` source file on first use.
 
 Page snapshot
 -------------
@@ -183,7 +183,8 @@ Use these checks if Orchestrate actions do not behave as expected:
 - If the generated snippet looks wrong, compare ``[args]`` in
   ``~/.agilab/apps/<project>/app_settings.toml`` with the values shown in
   ``app_args_form.py``. If the workspace copy is missing, AGILab will reseed it
-  from ``src/<project>/src/app_settings.toml``.
+  from the app source copy (``<project>/app_settings.toml`` or
+  ``src/<project>/src/app_settings.toml``).
 - If ``RUN`` returns import errors, verify the target virtual environment contains
   the same versions as ``src/<project>/pyproject.toml`` and re-run install.
 - If no logs appear, confirm the log expansion is expanded and that the runtime

--- a/docs/source/explore-help.rst
+++ b/docs/source/explore-help.rst
@@ -69,8 +69,9 @@ Main Content Area
       ``~/.agilab/apps/<project>/app_settings.toml`` in the ``[pages]`` section
       under ``view_module``. Only the names you choose are persisted for the
       active project; every project keeps its own list. The workspace file is
-      seeded from ``src/<project>/src/app_settings.toml`` the first time the
-      app is loaded.
+      seeded from the app's ``app_settings.toml`` source file (for example
+      ``<project>/app_settings.toml`` or ``<project>/src/app_settings.toml``)
+      the first time the app is loaded.
 
       You can also create a complete starter bundle directly from this page using
       **Create** in the ``Create from template`` tab. It creates a minimal

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -9,10 +9,10 @@ AGILab delivers a single, notebook-like workflow where you can run each cell/sni
 
 AGI framework offers 2 user interfaces:
 
- - `agi-core` an API interface to interface directly in your python program on a `dask cluster <https://openai.com>`_
- - `agilab` a WEB interface that generate the agi-core API call in a snippet and offer `openai <https://openai.com>`_ code assitant.
+ - ``agi-core``: an API interface callable directly from your Python program.
+ - ``agilab``: a web interface that generates ``agi-core`` calls and can render generated snippets for execution.
 
-There is share components `agi-env` a share component to set the environment and `agi-gui` the Graphic User Interface engine
+Shared components include ``agi-env`` (environment setup), ``agi-node`` (runtime orchestration), and ``agi-cluster`` (multi-node execution support).
 
 agi-core
 --------
@@ -52,7 +52,7 @@ agi-core
 
 - **Optimized Run-Mode Selection:**
 
-  - Chooses the best run-mode from 8 available combinations, when rapids is enables it adds 8 more.
+  - Chooses the best run-mode from up to 16 combinations (8 base modes and an optional RAPIDS variant).
 
 
 agilab

--- a/docs/source/quick-start.rst
+++ b/docs/source/quick-start.rst
@@ -47,21 +47,33 @@ Install AGILab
 
        mkdir ~/agi-workspace && cd ~/agi-workspace
 
-2. **Install the published wheel** using `uv <https://docs.astral.sh/uv/>`_::
+2. **Create a managed environment** (uv-first and source-agnostic)::
 
-       uv add agilab
+       uv venv
+       source .venv/bin/activate
 
-3. **Launch the web interface** (runs inside the managed virtual environment)::
+3. **Install AGILab (published wheel)**::
+
+       uv pip install agilab
+
+4. **Launch the web interface** (runs inside the managed virtual environment)::
 
        uv run agilab
 
-   The ORCHESTRATE page opens automatically. Point the sidebar to your apps
-   directory (defaults to ``~/agi-workspace/src/agilab/apps``).
+The ORCHESTRATE page opens automatically. Point the sidebar to the folder that
+contains your AGILab projects (for example a checked-out app repository, or a
+path you set with ``APPS_PATH``).
 
-4. **Run the sample ``mycode`` app** either from the UI or the CLI
-   mirror::
+5. **Run an example app**
 
+   If you are working from a source checkout, run the sample from the local
+   ``src/`` tree::
+
+       cd /path/to/agilab-checkout
        uv run python src/agilab/examples/mycode/AGI_run_mycode.py
+
+   The same project can be exercised from the web interface by selecting it in
+   PROJECT, then using ORCHESTRATE and PIPELINE.
 
    This script constructs an ``AgiEnv``, bundles the worker, and executes a
    full AGI run so you can inspect the generated logs under
@@ -116,8 +128,9 @@ workflow. ``pycharm/setup_pycharm.py`` mirrors web interface run configurations 
    inputs you provide, keeping IDE and CLI flows in sync. Field defaults are
    read from each app's per-user workspace copy
    ``~/.agilab/apps/<app>/app_settings.toml`` before the form renders. That
-   workspace file is seeded from the versioned ``src/app_settings.toml`` on
-   first use, so update the workspace copy when you need local baselines and
+   workspace file is seeded from the versioned ``app_settings.toml`` source file
+   (for example ``<project>/app_settings.toml`` or ``<project>/src/app_settings.toml``)
+   on first use, so update the workspace copy when you need local baselines and
    update the source seed only when you intend to change the shipped defaults.
 
 Next steps


### PR DESCRIPTION
## Summary
- Standardized newcomer-facing docs in public docs pages to avoid ambiguous paths and unclear workflow language.
- Clarified app settings seed source paths and execution/setup wording in AGILAB docs.
- Updated docs skill instructions to match working local docs flow:
  - use `uv sync --group sphinx --dev` for dependency bootstrap
  - build from `thales_agilab/docs/source` via `uv run sphinx-build -n -q -b html docs/source docs/_build/html`
- Added a newcomer-focused review checklist in `agilab-docs` skill.

## Changed files
- `.codex/skills/agilab-docs/SKILL.md`
- `docs/source/apps-pages.rst`
- `docs/source/architecture.rst`
- `docs/source/edit-help.rst`
- `docs/source/execute-help.rst`
- `docs/source/explore-help.rst`
- `docs/source/features.rst`
- `docs/source/quick-start.rst`

## Notes
- `sphinx-build` warnings observed are documentation reference warnings unrelated to these content edits and were pre-existing in scope.