### PR TITLE
[codex] Improve adoption onboarding and public demo checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,15 +42,29 @@ AGILAB is an open-source platform for reproducible AI and ML workflows.
 
 The core idea is simple: keep one app on one control path from setup to run to visible analysis instead of splitting the workflow across ad hoc scripts, environments, and notebooks.
 
-## Demo
+## Start Here
+
+| Goal | Route | Use when |
+|---|---|---|
+| See the UI now | [AGILAB demo](https://huggingface.co/spaces/jpmorard/agilab) | You want a browser-only look at the web UI before installing anything. |
+| Prove it locally | [Quick start](https://thalesgroup.github.io/agilab/quick-start.html) | You want the real source-checkout path with the built-in `flight_project`. Target: pass the first proof in 10 minutes. |
+| Use the API/notebook | [agi-core demo](https://kaggle.com/kernels/welcome?src=https://github.com/ThalesGroup/agilab/blob/main/examples/notebook_quickstart/agi_core_kaggle_first_run.ipynb) | You want the smaller `AgiEnv` / `AGI.run(...)` surface before the full UI. |
+
+## Public Demos
 
 <p>
   <a href="https://kaggle.com/kernels/welcome?src=https://github.com/ThalesGroup/agilab/blob/main/examples/notebook_quickstart/agi_core_kaggle_first_run.ipynb"><img src="https://img.shields.io/badge/agi--core-demo-1D4ED8?style=for-the-badge" alt="agi-core demo" /></a>
-  <a href="https://jpmorard-agilab.hf.space"><img src="https://img.shields.io/badge/AGILAB-demo-0F766E?style=for-the-badge" alt="AGILAB demo" /></a>
+  <a href="https://huggingface.co/spaces/jpmorard/agilab"><img src="https://img.shields.io/badge/AGILAB-demo-0F766E?style=for-the-badge" alt="AGILAB demo" /></a>
 </p>
 
 - `AGILAB demo`: self-serve public Hugging Face Spaces demo
 - `agi-core demo`: notebook-first runtime demo on Kaggle
+
+Maintainers can validate the public demo KPI with:
+
+```bash
+uv --preview-features extra-build-dependencies run python tools/hf_space_smoke.py --json
+```
 
 ## First Real Run
 
@@ -90,6 +104,13 @@ If that first proof fails, run:
 
 ```bash
 uv --preview-features extra-build-dependencies run python tools/newcomer_first_proof.py
+```
+
+To track the adoption KPI directly, collect the same proof as JSON. The default
+target is 10 minutes end to end:
+
+```bash
+uv --preview-features extra-build-dependencies run python tools/newcomer_first_proof.py --json
 ```
 
 ## Read Next

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -1,9 +1,9 @@
 {
-  "file_count": 154,
+  "file_count": 157,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "d12900cfdb98b9e3f89b21cc2108d7946d3686a9f8b3ea7d239a9a1e633c8f34",
+  "source_digest_sha256": "bf36c652d5ccbebceb3916e367f3ed906af2039be01ef8de4cec22f57f24504a",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "d12900cfdb98b9e3f89b21cc2108d7946d3686a9f8b3ea7d239a9a1e633c8f34"
+  "target_digest_sha256": "bf36c652d5ccbebceb3916e367f3ed906af2039be01ef8de4cec22f57f24504a"
 }

--- a/docs/source/demos.rst
+++ b/docs/source/demos.rst
@@ -17,7 +17,7 @@ Choose a demo
    :alt: agi-core demo
 
 .. image:: https://img.shields.io/badge/AGILAB-demo-0F766E?style=for-the-badge
-   :target: https://jpmorard-agilab.hf.space
+   :target: https://huggingface.co/spaces/jpmorard/agilab
    :alt: AGILAB demo
 
 What each route is for

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,14 +1,16 @@
 AGILab Documentation
 =====================
 
-If you are new to AGILab, start here:
+If you are new to AGILab, choose one route first:
 
-1. Read :doc:`newcomer-guide`.
-2. Follow :doc:`quick-start`.
-3. If the first proof fails, use :doc:`newcomer-troubleshooting`.
+- **See the UI now**: open :doc:`demos` for the public Hugging Face Space.
+- **Prove it locally**: follow :doc:`quick-start` with the built-in
+  ``flight_project``. Target: pass the first proof in 10 minutes.
+- **Use the API/notebook**: follow :doc:`notebook-quickstart` for the smaller
+  ``AgiEnv`` / ``AGI.run(...)`` surface.
 
-Use the built-in ``flight_project`` first. Keep cluster mode, notebook-first
-flows, and private-app repositories for later.
+If the local first proof fails, use :doc:`newcomer-troubleshooting` before
+branching into cluster mode, private app repositories, or broader workflows.
 
 This documentation then expands into architecture, service mode, API
 references, and example projects.

--- a/docs/source/newcomer-guide.rst
+++ b/docs/source/newcomer-guide.rst
@@ -7,6 +7,28 @@ run of the built-in ``flight_project`` from the web UI.
 This page gives the mental model only. :doc:`quick-start` owns the exact
 commands. :doc:`newcomer-troubleshooting` owns the first-failure path.
 
+Choose one route
+----------------
+
+.. list-table::
+   :header-rows: 1
+
+   * - Goal
+     - Route
+     - Use when
+   * - See the UI now
+     - :doc:`demos`
+     - You want a browser-only look at the AGILAB web UI before installing
+       anything.
+   * - Prove it locally
+     - :doc:`quick-start`
+     - You want the real source-checkout path with ``flight_project``. Target:
+       pass the first proof in 10 minutes.
+   * - Use the API/notebook
+     - :doc:`notebook-quickstart`
+     - You want the smaller ``AgiEnv`` / ``AGI.run(...)`` surface before the
+       full UI.
+
 The first proof is deliberately narrow:
 use a source checkout, run the built-in ``flight_project`` locally from the
 web UI, and confirm a visible result under ``~/log/execute/flight/``.

--- a/docs/source/notebook-quickstart.rst
+++ b/docs/source/notebook-quickstart.rst
@@ -63,34 +63,18 @@ Minimal notebook cells
 
 Cell 1: select the built-in MyCode example app.
 
-.. code-block:: python
-
-   from pathlib import Path
-   from agi_env import AgiEnv
-
-   APP = "mycode_project"  # built-in MyCode example app
-   app_env = AgiEnv(app=APP, verbose=1)
+.. literalinclude:: snippets/agi_core_mycode_minimal_app_env.py
+   :language: python
 
 Cell 2: run the smallest local ``AGI.run(...)`` shape.
 
-.. code-block:: python
-
-   from agi_cluster.agi_distributor import AGI
-
-   result = await AGI.run(
-       app_env,
-       scheduler="127.0.0.1",
-       workers={"127.0.0.1": 1},
-       mode=0,  # plain local Python execution
-   )
-   result
+.. literalinclude:: snippets/agi_core_mycode_minimal_run.py
+   :language: python
 
 Cell 3: inspect the run artifacts.
 
-.. code-block:: python
-
-   log_root = Path.home() / "log" / "execute" / "mycode"
-   print(log_root)
+.. literalinclude:: snippets/agi_core_mycode_log_root.py
+   :language: python
 
 How this maps back to the web UI
 --------------------------------

--- a/docs/source/quick-start.rst
+++ b/docs/source/quick-start.rst
@@ -101,7 +101,7 @@ Use these only after the local ``flight_project`` proof works once.
 **AGILAB demo**:
 
 .. image:: https://img.shields.io/badge/AGILAB-demo-0F766E?style=for-the-badge
-   :target: https://jpmorard-agilab.hf.space
+   :target: https://huggingface.co/spaces/jpmorard/agilab
    :alt: AGILAB demo
 
 Self-serve public AGILAB demo hosted on Hugging Face Spaces.

--- a/docs/source/snippets/agi_core_mycode_log_root.py
+++ b/docs/source/snippets/agi_core_mycode_log_root.py
@@ -1,0 +1,4 @@
+from pathlib import Path
+
+log_root = Path.home() / "log" / "execute" / "mycode"
+print(log_root)

--- a/docs/source/snippets/agi_core_mycode_minimal_app_env.py
+++ b/docs/source/snippets/agi_core_mycode_minimal_app_env.py
@@ -1,0 +1,4 @@
+from agi_env import AgiEnv
+
+APP = "mycode_project"  # built-in MyCode example app
+app_env = AgiEnv(app=APP, verbose=1)

--- a/docs/source/snippets/agi_core_mycode_minimal_run.py
+++ b/docs/source/snippets/agi_core_mycode_minimal_run.py
@@ -1,0 +1,9 @@
+from agi_cluster.agi_distributor import AGI
+
+result = await AGI.run(
+    app_env,
+    scheduler="127.0.0.1",
+    workers={"127.0.0.1": 1},
+    mode=0,  # plain local Python execution
+)
+result

--- a/test/test_hf_space_smoke.py
+++ b/test/test_hf_space_smoke.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+MODULE_PATH = Path("tools/hf_space_smoke.py").resolve()
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("hf_space_smoke_test_module", MODULE_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_build_space_url_encodes_current_page_query() -> None:
+    module = _load_module()
+    spec = module.route_specs()[3]
+
+    url = module.build_space_url("https://demo.hf.space/", spec)
+
+    assert url.startswith("https://demo.hf.space?")
+    assert "active_app=flight_project" in url
+    assert "current_page=%2Fapp%2Fsrc%2Fagilab%2Fapps-pages%2Fview_maps%2Fsrc%2Fview_maps%2Fview_maps.py" in url
+
+
+def test_private_app_entries_flags_only_direct_non_public_apps() -> None:
+    module = _load_module()
+
+    offenders = module.private_app_entries(
+        [
+            {"path": "src/agilab/apps/builtin"},
+            {"path": "src/agilab/apps/install.py"},
+            {"path": "src/agilab/apps/uav_graph_routing_project"},
+            {"path": "src/agilab/apps/builtin/flight_project"},
+        ]
+    )
+
+    assert offenders == ["uav_graph_routing_project"]
+
+
+def test_check_route_rejects_localhost_connection_body() -> None:
+    module = _load_module()
+
+    def _fetcher(_url: str, _timeout: float):
+        return 200, "iframe refused to connect to 127.0.0.1"
+
+    result = module.check_route(
+        "https://demo.hf.space",
+        module.RouteSpec("demo"),
+        timeout=1.0,
+        fetcher=_fetcher,
+        clock=iter([0.0, 0.2]).__next__,
+    )
+
+    assert result.success is False
+    assert "127.0.0.1" in result.detail
+
+
+def test_run_smoke_summarizes_routes_and_public_app_tree() -> None:
+    module = _load_module()
+    clock = iter([0.0, 0.1, 0.1, 0.3, 0.3, 0.6, 0.6, 1.0, 1.0, 1.5, 1.5, 2.1])
+
+    def _fetch_text(_url: str, _timeout: float):
+        return 200, "ok"
+
+    def _fetch_json(_url: str, _timeout: float):
+        return [{"path": "src/agilab/apps/builtin"}, {"path": "src/agilab/apps/install.py"}]
+
+    summary = module.run_smoke(
+        space_id="demo/agilab",
+        space_url="https://demo.hf.space",
+        timeout=1.0,
+        target_seconds=5.0,
+        fetch_text_fn=_fetch_text,
+        fetch_json_fn=_fetch_json,
+        clock=clock.__next__,
+    )
+
+    assert summary.success is True
+    assert summary.total_duration_seconds == 2.1
+    assert summary.within_target is True
+    assert [check.label for check in summary.checks][-1] == "public app tree"
+
+
+def test_main_json_returns_failure_for_private_app(monkeypatch, capsys) -> None:
+    module = _load_module()
+
+    def _run_smoke(**_kwargs):
+        return module.SmokeSummary(
+            success=False,
+            total_duration_seconds=1.0,
+            target_seconds=30.0,
+            within_target=False,
+            checks=[
+                module.CheckResult(
+                    label="public app tree",
+                    success=False,
+                    duration_seconds=1.0,
+                    detail="non-public app entries: private_project",
+                    url="https://huggingface.co/api/spaces/demo/agilab/tree/main/src/agilab/apps",
+                )
+            ],
+        )
+
+    monkeypatch.setattr(module, "run_smoke", _run_smoke)
+
+    exit_code = module.main(["--json"])
+
+    assert exit_code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["success"] is False
+    assert payload["checks"][0]["detail"] == "non-public app entries: private_project"

--- a/test/test_newcomer_first_proof.py
+++ b/test/test_newcomer_first_proof.py
@@ -71,6 +71,7 @@ def test_render_human_print_only_lists_commands() -> None:
     )
 
     assert "mode: print-only" in rendered
+    assert "kpi target: <=" in rendered
     assert "preinit smoke" in rendered
     assert "source ui smoke" in rendered
 
@@ -83,8 +84,52 @@ def test_main_print_only_json_emits_selected_commands(capsys) -> None:
     assert exit_code == 0
     payload = json.loads(capsys.readouterr().out)
     assert payload["with_install"] is True
+    assert payload["kpi_target_seconds"] == module.DEFAULT_MAX_SECONDS
     assert payload["commands"][0]["label"] == "preinit smoke"
     assert payload["commands"][-1]["label"] == "seeded script check"
+
+
+def test_summarize_kpi_tracks_duration_target_and_failed_step() -> None:
+    module = _load_module()
+
+    passing = [
+        module.ProofStepResult(
+            label="preinit smoke",
+            description="demo",
+            argv=["python", "-V"],
+            returncode=0,
+            duration_seconds=2.5,
+            stdout="",
+            env={},
+        ),
+        module.ProofStepResult(
+            label="source ui smoke",
+            description="demo",
+            argv=["python", "-V"],
+            returncode=0,
+            duration_seconds=3.0,
+            stdout="",
+            env={},
+        ),
+    ]
+
+    summary = module.summarize_kpi(command_count=2, results=passing, max_seconds=10.0)
+
+    assert summary["success"] is True
+    assert summary["passed_steps"] == 2
+    assert summary["expected_steps"] == 2
+    assert summary["failed_step"] is None
+    assert summary["total_duration_seconds"] == 5.5
+    assert summary["target_seconds"] == 10.0
+    assert summary["within_target"] is True
+
+    failing = [passing[0], passing[1].__class__(**{**passing[1].__dict__, "returncode": 7})]
+
+    failed_summary = module.summarize_kpi(command_count=2, results=failing, max_seconds=10.0)
+
+    assert failed_summary["success"] is False
+    assert failed_summary["failed_step"] == "source ui smoke"
+    assert failed_summary["within_target"] is False
 
 
 def test_run_proof_stops_on_first_failure() -> None:

--- a/test/test_public_demo_links.py
+++ b/test/test_public_demo_links.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+README = Path("README.md")
+PUBLIC_DOC_PAGES = (
+    Path("docs/source/demos.rst"),
+    Path("docs/source/quick-start.rst"),
+)
+ADOPTION_DOC_PAGES = (
+    Path("docs/source/index.rst"),
+    Path("docs/source/newcomer-guide.rst"),
+)
+PUBLIC_HF_SPACE_URL = "https://huggingface.co/spaces/jpmorard/agilab"
+HF_RUNTIME_URL = "https://jpmorard-agilab.hf.space"
+
+
+def test_readme_advertises_public_huggingface_space_page() -> None:
+    readme = README.read_text(encoding="utf-8")
+
+    assert PUBLIC_HF_SPACE_URL in readme
+    assert "AGILAB-demo" in readme
+    assert "self-serve public Hugging Face Spaces demo" in readme
+
+
+def test_readme_links_to_hf_space_page_not_runtime_host() -> None:
+    readme = README.read_text(encoding="utf-8")
+
+    assert HF_RUNTIME_URL not in readme
+
+
+def test_public_docs_link_to_hf_space_page_not_runtime_host() -> None:
+    for path in PUBLIC_DOC_PAGES:
+        text = path.read_text(encoding="utf-8")
+        assert PUBLIC_HF_SPACE_URL in text
+        assert HF_RUNTIME_URL not in text
+
+
+def test_readme_exposes_three_clear_adoption_routes() -> None:
+    readme = README.read_text(encoding="utf-8")
+
+    for phrase in ("See the UI now", "Prove it locally", "Use the API/notebook"):
+        assert phrase in readme
+    assert "Target: pass the first proof in 10 minutes" in readme
+    assert "tools/newcomer_first_proof.py --json" in readme
+
+
+def test_public_docs_expose_three_clear_adoption_routes() -> None:
+    for path in ADOPTION_DOC_PAGES:
+        text = path.read_text(encoding="utf-8")
+        for phrase in ("See the UI now", "Prove it locally", "Use the API/notebook"):
+            assert phrase in text
+        assert "10 minutes" in text

--- a/tools/hf_space_smoke.py
+++ b/tools/hf_space_smoke.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Smoke-check the AGILAB Hugging Face Space runtime."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import asdict, dataclass
+from typing import Any, Callable, Sequence
+
+
+DEFAULT_SPACE_ID = "jpmorard/agilab"
+DEFAULT_SPACE_URL = "https://jpmorard-agilab.hf.space"
+DEFAULT_TARGET_SECONDS = 30.0
+APP_TREE_PATH = "src/agilab/apps"
+ALLOWED_APP_ENTRIES = {
+    ".DS_Store",
+    ".gitignore",
+    "README.md",
+    "__init__.py",
+    "__pycache__",
+    "builtin",
+    "install.py",
+    "src",
+    "templates",
+}
+BAD_BODY_PATTERNS = (
+    "127.0.0.1",
+    "refused to connect",
+    "this site can't be reached",
+    "this site cannot be reached",
+)
+
+
+@dataclass(frozen=True)
+class RouteSpec:
+    label: str
+    path: str = ""
+    query: dict[str, str] | None = None
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    label: str
+    success: bool
+    duration_seconds: float
+    detail: str
+    url: str | None = None
+
+
+@dataclass(frozen=True)
+class SmokeSummary:
+    success: bool
+    total_duration_seconds: float
+    target_seconds: float
+    within_target: bool
+    checks: list[CheckResult]
+
+
+TextFetcher = Callable[[str, float], tuple[int, str]]
+JsonFetcher = Callable[[str, float], Any]
+Clock = Callable[[], float]
+
+
+def route_specs() -> list[RouteSpec]:
+    return [
+        RouteSpec("streamlit health", path="/_stcore/health"),
+        RouteSpec("base app"),
+        RouteSpec("flight project", query={"active_app": "flight_project"}),
+        RouteSpec(
+            "flight view_maps",
+            query={
+                "active_app": "flight_project",
+                "current_page": "/app/src/agilab/apps-pages/view_maps/src/view_maps/view_maps.py",
+            },
+        ),
+        RouteSpec(
+            "flight view_maps_network",
+            query={
+                "active_app": "flight_project",
+                "current_page": "/app/src/agilab/apps-pages/view_maps_network/src/view_maps_network/view_maps_network.py",
+            },
+        ),
+    ]
+
+
+def build_space_url(base_url: str, spec: RouteSpec) -> str:
+    url = base_url.rstrip("/") + spec.path
+    if spec.query:
+        url += "?" + urllib.parse.urlencode(spec.query)
+    return url
+
+
+def build_tree_api_url(space_id: str) -> str:
+    quoted_space = "/".join(urllib.parse.quote(part, safe="") for part in space_id.split("/"))
+    quoted_path = urllib.parse.quote(APP_TREE_PATH, safe="/")
+    return f"https://huggingface.co/api/spaces/{quoted_space}/tree/main/{quoted_path}"
+
+
+def fetch_text(url: str, timeout: float) -> tuple[int, str]:
+    request = urllib.request.Request(url, headers={"User-Agent": "agilab-hf-space-smoke/1.0"})
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        status = int(getattr(response, "status", response.getcode()))
+        body = response.read().decode("utf-8", errors="replace")
+    return status, body
+
+
+def fetch_json(url: str, timeout: float) -> Any:
+    status, body = fetch_text(url, timeout)
+    if status >= 400:
+        raise urllib.error.HTTPError(url, status, body, None, None)
+    return json.loads(body)
+
+
+def body_has_connection_failure(body: str) -> str | None:
+    normalized = body.lower()
+    for pattern in BAD_BODY_PATTERNS:
+        if pattern in normalized:
+            return pattern
+    return None
+
+
+def check_route(
+    base_url: str,
+    spec: RouteSpec,
+    *,
+    timeout: float,
+    fetcher: TextFetcher = fetch_text,
+    clock: Clock = time.perf_counter,
+) -> CheckResult:
+    url = build_space_url(base_url, spec)
+    start = clock()
+    try:
+        status, body = fetcher(url, timeout)
+    except Exception as exc:
+        return CheckResult(spec.label, False, clock() - start, f"request failed: {exc}", url)
+
+    duration = clock() - start
+    if status >= 400:
+        return CheckResult(spec.label, False, duration, f"HTTP {status}", url)
+    bad_pattern = body_has_connection_failure(body)
+    if bad_pattern:
+        return CheckResult(spec.label, False, duration, f"body contains {bad_pattern!r}", url)
+    return CheckResult(spec.label, True, duration, f"HTTP {status}", url)
+
+
+def _direct_app_entry_name(path_value: str) -> str | None:
+    prefix = APP_TREE_PATH + "/"
+    if not path_value.startswith(prefix):
+        return None
+    relative = path_value[len(prefix) :]
+    if not relative or "/" in relative:
+        return None
+    return relative
+
+
+def private_app_entries(entries: Sequence[dict[str, Any]]) -> list[str]:
+    offenders: list[str] = []
+    for entry in entries:
+        name = _direct_app_entry_name(str(entry.get("path", "")))
+        if name and name not in ALLOWED_APP_ENTRIES:
+            offenders.append(name)
+    return sorted(set(offenders))
+
+
+def check_public_app_tree(
+    space_id: str,
+    *,
+    timeout: float,
+    fetcher: JsonFetcher = fetch_json,
+    clock: Clock = time.perf_counter,
+) -> CheckResult:
+    url = build_tree_api_url(space_id)
+    start = clock()
+    try:
+        payload = fetcher(url, timeout)
+    except Exception as exc:
+        return CheckResult("public app tree", False, clock() - start, f"request failed: {exc}", url)
+
+    duration = clock() - start
+    if not isinstance(payload, list):
+        return CheckResult("public app tree", False, duration, "tree API returned non-list payload", url)
+    offenders = private_app_entries(payload)
+    if offenders:
+        return CheckResult(
+            "public app tree",
+            False,
+            duration,
+            "non-public app entries: " + ", ".join(offenders),
+            url,
+        )
+    return CheckResult("public app tree", True, duration, "no non-public app entries", url)
+
+
+def run_smoke(
+    *,
+    space_id: str = DEFAULT_SPACE_ID,
+    space_url: str = DEFAULT_SPACE_URL,
+    timeout: float = 20.0,
+    target_seconds: float = DEFAULT_TARGET_SECONDS,
+    fetch_text_fn: TextFetcher = fetch_text,
+    fetch_json_fn: JsonFetcher = fetch_json,
+    clock: Clock = time.perf_counter,
+) -> SmokeSummary:
+    checks = [
+        check_route(space_url, spec, timeout=timeout, fetcher=fetch_text_fn, clock=clock)
+        for spec in route_specs()
+    ]
+    checks.append(check_public_app_tree(space_id, timeout=timeout, fetcher=fetch_json_fn, clock=clock))
+    total = sum(check.duration_seconds for check in checks)
+    success = all(check.success for check in checks)
+    return SmokeSummary(
+        success=success,
+        total_duration_seconds=total,
+        target_seconds=target_seconds,
+        within_target=success and total <= target_seconds,
+        checks=checks,
+    )
+
+
+def render_human(summary: SmokeSummary, *, space_id: str, space_url: str) -> str:
+    lines = [
+        "AGILAB Hugging Face Space smoke",
+        f"space: {space_id}",
+        f"url: {space_url}",
+        f"verdict: {'PASS' if summary.success else 'FAIL'}",
+        (
+            "kpi: "
+            f"total={summary.total_duration_seconds:.2f}s "
+            f"target<={summary.target_seconds:.2f}s "
+            f"within_target={'yes' if summary.within_target else 'no'}"
+        ),
+    ]
+    for check in summary.checks:
+        status = "OK" if check.success else "FAIL"
+        lines.append(f"- {check.label}: {status} in {check.duration_seconds:.2f}s ({check.detail})")
+    return "\n".join(lines)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Smoke-check the public AGILAB Hugging Face Space.")
+    parser.add_argument("--space", default=DEFAULT_SPACE_ID, help=f"Space ID (default: {DEFAULT_SPACE_ID}).")
+    parser.add_argument("--url", default=DEFAULT_SPACE_URL, help=f"Space URL (default: {DEFAULT_SPACE_URL}).")
+    parser.add_argument("--timeout", type=float, default=20.0, help="Per-request timeout in seconds.")
+    parser.add_argument(
+        "--target-seconds",
+        type=float,
+        default=DEFAULT_TARGET_SECONDS,
+        help=f"KPI target for the whole smoke in seconds (default: {DEFAULT_TARGET_SECONDS}).",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+    if args.timeout <= 0:
+        parser.error("--timeout must be greater than 0")
+    if args.target_seconds <= 0:
+        parser.error("--target-seconds must be greater than 0")
+
+    summary = run_smoke(
+        space_id=args.space,
+        space_url=args.url,
+        timeout=args.timeout,
+        target_seconds=args.target_seconds,
+    )
+    if args.json:
+        print(json.dumps(asdict(summary), indent=2))
+    else:
+        print(render_human(summary, space_id=args.space, space_url=args.url))
+    return 0 if summary.success else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/newcomer_first_proof.py
+++ b/tools/newcomer_first_proof.py
@@ -18,6 +18,7 @@ from typing import Callable, Sequence
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_ACTIVE_APP = REPO_ROOT / "src/agilab/apps/builtin/flight_project"
+DEFAULT_MAX_SECONDS = 10 * 60
 UV_RUN_PYTHON = (
     "uv",
     "--preview-features",
@@ -78,6 +79,15 @@ def _build_parser() -> argparse.ArgumentParser:
         "--json",
         action="store_true",
         help="Emit machine-readable JSON.",
+    )
+    parser.add_argument(
+        "--max-seconds",
+        type=float,
+        default=float(DEFAULT_MAX_SECONDS),
+        help=(
+            "KPI target for total first-proof runtime in seconds "
+            f"(default: {DEFAULT_MAX_SECONDS})."
+        ),
     )
     return parser
 
@@ -267,6 +277,26 @@ def run_proof(
     return results
 
 
+def summarize_kpi(
+    *,
+    command_count: int,
+    results: Sequence[ProofStepResult],
+    max_seconds: float,
+) -> dict[str, object]:
+    total_seconds = sum(result.duration_seconds for result in results)
+    failed_step = next((result.label for result in results if result.returncode != 0), None)
+    success = len(results) == command_count and failed_step is None
+    return {
+        "success": success,
+        "passed_steps": sum(1 for result in results if result.returncode == 0),
+        "expected_steps": command_count,
+        "failed_step": failed_step,
+        "total_duration_seconds": total_seconds,
+        "target_seconds": max_seconds,
+        "within_target": success and total_seconds <= max_seconds,
+    }
+
+
 def render_human(
     *,
     active_app: Path,
@@ -274,6 +304,7 @@ def render_human(
     commands: Sequence[ProofCommand],
     results: Sequence[ProofStepResult] | None = None,
     print_only: bool = False,
+    max_seconds: float = float(DEFAULT_MAX_SECONDS),
 ) -> str:
     lines = [
         "AGILAB newcomer first-proof smoke",
@@ -281,15 +312,23 @@ def render_human(
     ]
     if print_only:
         lines.append("mode: print-only")
+        lines.append(f"kpi target: <= {max_seconds:.2f}s")
         for command in commands:
             lines.append(f"- {command.label}: {command.description}")
             lines.append(f"  $ {' '.join(shlex.quote(part) for part in command.argv)}")
         return "\n".join(lines)
 
     results = list(results or [])
-    success = bool(results) and len(results) == len(commands) and all(result.returncode == 0 for result in results)
+    summary = summarize_kpi(command_count=len(commands), results=results, max_seconds=max_seconds)
+    success = bool(summary["success"])
     verdict = "PASS" if success else "FAIL"
     lines.append(f"verdict: {verdict}")
+    lines.append(
+        "kpi: "
+        f"total={summary['total_duration_seconds']:.2f}s "
+        f"target<={summary['target_seconds']:.2f}s "
+        f"within_target={'yes' if summary['within_target'] else 'no'}"
+    )
     lines.append(
         "scope: preinit import smoke + About/ORCHESTRATE page boot"
         + (" + install/seeding" if with_install else "")
@@ -313,6 +352,8 @@ def render_human(
 def main(argv: Sequence[str] | None = None) -> int:
     parser = _build_parser()
     args = parser.parse_args(list(argv) if argv is not None else None)
+    if args.max_seconds <= 0:
+        parser.error("--max-seconds must be greater than 0")
 
     active_app = resolve_active_app(args.active_app)
     commands = build_proof_commands(active_app, with_install=args.with_install)
@@ -324,6 +365,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     {
                         "active_app": str(active_app),
                         "with_install": args.with_install,
+                        "kpi_target_seconds": args.max_seconds,
                         "commands": [
                             {
                                 "label": command.label,
@@ -344,19 +386,21 @@ def main(argv: Sequence[str] | None = None) -> int:
                     with_install=args.with_install,
                     commands=commands,
                     print_only=True,
+                    max_seconds=args.max_seconds,
                 )
             )
         return 0
 
     results = run_proof(commands)
-    success = len(results) == len(commands) and all(result.returncode == 0 for result in results)
+    summary = summarize_kpi(command_count=len(commands), results=results, max_seconds=args.max_seconds)
+    success = bool(summary["success"])
     if args.json:
         print(
             json.dumps(
                 {
                     "active_app": str(active_app),
                     "with_install": args.with_install,
-                    "success": success,
+                    **summary,
                     "results": [asdict(result) for result in results],
                 },
                 indent=2,
@@ -369,6 +413,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 with_install=args.with_install,
                 commands=commands,
                 results=results,
+                max_seconds=args.max_seconds,
             )
         )
         for result in results:


### PR DESCRIPTION
## Summary

- Add a clear README and docs first-route for newcomers: public HF demo, local first proof, or API/notebook path.
- Add a public Hugging Face Space smoke checker covering health, flight app routes, hosted map pages, and non-public app leakage.
- Extend newcomer first-proof KPI output and tests so the adoption target is measurable.

## Validation

- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --staged`
- `uv --preview-features extra-build-dependencies run pytest -q test/test_hf_space_smoke.py test/test_newcomer_first_proof.py test/test_public_demo_links.py` (`18 passed`)
- `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --source /Users/agi/PycharmProjects/thales_agilab/docs/source`
- `uv --preview-features extra-build-dependencies run python tools/hf_space_smoke.py --json --timeout 30 --target-seconds 30` (success, ~1.23s)
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs`

## Notes

This PR intentionally excludes local/private app directories and unrelated dirty worktree changes.