### PR TITLE
[codex] Document experimentation and prototyping KPI evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,22 @@ first-proof smoke passed in `5.86s` against the `600s` target. That supports an
 are explicit, and the local proof is measurable. It is not scored higher yet
 because the same measurement still needs a fresh external machine.
 
+Current research experimentation evidence: AGILAB now documents a complete
+experiment loop across project templates, isolated `uv` environments,
+`lab_steps.toml` history, supervisor notebook export, MLflow-tracked runs, and
+analysis pages. That supports a `Research experimentation` score of `4.0 / 5`.
+It is not scored higher yet because the generic evidence bundle, a first-class
+reduce contract, and broader fresh-install reproducibility checks remain
+roadmap work.
+
+Current engineering prototyping evidence: AGILAB now documents how app
+templates, isolated app/page environments, typed `app_args_form.py` settings,
+`pipeline_view` files, reusable `lab_steps.toml` history, and analysis-page
+templates turn an experiment into an app-shaped prototype. That supports an
+`Engineering prototyping` score of `4.0 / 5`. It is not scored higher yet
+because the first-proof wizard, generic evidence bundle, and first-class reduce
+contract remain roadmap work.
+
 ## Read Next
 
 - [Quick start](https://thalesgroup.github.io/agilab/quick-start.html)

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 157,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "d60900d63e86e8442fdfdea800efeff7838c99c92859293db9ebe047f067ca14",
+  "source_digest_sha256": "8703e14b2d5c12bb848956a0d96375c61879427ec12e119f224c3429c6508d9f",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "d60900d63e86e8442fdfdea800efeff7838c99c92859293db9ebe047f067ca14"
+  "target_digest_sha256": "8703e14b2d5c12bb848956a0d96375c61879427ec12e119f224c3429c6508d9f"
 }

--- a/docs/source/agilab-mlops-positioning.rst
+++ b/docs/source/agilab-mlops-positioning.rst
@@ -11,6 +11,59 @@ This page is about positioning, not the detailed feature list or the roadmap.
 - For current shipped capabilities, see :doc:`features`.
 - For planned work, see :doc:`roadmap/agilab-future-work`.
 
+Research experimentation evidence
+---------------------------------
+
+AGILab's research experimentation value is strongest when teams need to turn
+interactive exploration into a replayable, inspectable workflow:
+
+- ``lab_steps.toml`` records experiment steps, prompts, selected model, runtime,
+  and execution metadata
+- supervisor notebook export keeps the saved pipeline runnable outside the UI
+- MLflow tracking records one parent run and nested runs for executed steps
+- the notebook-migration example shows how exploratory notebooks become reusable
+  AGILab projects with stable artifacts and analysis views
+
+That supports a ``Research experimentation`` score of ``4.0 / 5``. It is not
+scored higher yet because a generic evidence bundle, first-class reduce
+contract, and broader fresh-machine reproducibility matrix are still roadmap
+work.
+
+Engineering prototyping evidence
+--------------------------------
+
+AGILab's engineering prototyping value is strongest when a team needs to move
+from a working idea to an app-shaped prototype without losing the experiment
+history:
+
+- app templates and isolated app/page environments keep prototypes reproducible
+- ``lab_steps.toml`` and supervisor notebook export preserve the working
+  sequence
+- conceptual ``pipeline_view`` files make the workflow readable outside the code
+- analysis-page templates turn produced artifacts into a reusable operator view
+
+That supports an ``Engineering prototyping`` score of ``4.0 / 5``. It is not
+scored higher yet because the first-proof wizard, generic evidence bundle, and
+first-class reduce contract remain roadmap work.
+
+Strategic potential evidence
+----------------------------
+
+AGILab's strategic potential is strongest where teams need a repeatable bridge
+between research experiments and engineering validation:
+
+- a clear TRL‑3 experimentation focus instead of an overclaimed production MLOps
+  scope
+- a public demo path and a measurable local first-proof path
+- a handoff model for stabilized assets into MLflow, Kubeflow, or internal
+  deployment stacks
+- a roadmap ordered around run evidence, promotion decisions, compatibility
+  automation, and cross-app orchestration
+
+That supports a ``Strategic potential`` score of ``4.2 / 5``. It is not scored
+higher yet because the generic evidence bundle, first-class reduce contract,
+and broader fresh-install validation are still roadmap work.
+
 Where AGILab helps
 ------------------
 

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -115,3 +115,25 @@ agilab
     live under ``src/agilab/apps-pages``. Every bundle carries its own
     ``pyproject.toml`` or embedded ``.venv`` so the Analysis launcher spins it up
     inside an isolated interpreter.
+
+Engineering prototyping evidence
+--------------------------------
+
+AGILab is strongest for engineering prototypes that need more structure than a
+single notebook but less ceremony than a production MLOps platform:
+
+- app templates and cloned projects provide a repeatable manager/worker shape
+- app and page bundles keep dependencies isolated through their own
+  ``pyproject.toml`` / ``uv`` environments
+- ``app_args_form.py`` and ``app_settings.toml`` give prototypes a typed,
+  configurable UI surface instead of hard-coded script parameters
+- ``lab_steps.toml`` and notebook import/export support let teams move between
+  notebook exploration and reproducible pipeline snippets
+- optional ``pipeline_view.dot`` / ``pipeline_view.json`` files give prototypes
+  a conceptual architecture view alongside generated execution snippets
+- the Analysis page can generate minimal page bundles so a prototype can gain a
+  shareable dashboard without becoming a full product
+
+That supports an ``Engineering prototyping`` score of ``4.0 / 5``. It is not
+scored higher yet because the first-proof wizard, generic evidence bundle, and
+first-class reduce contract remain roadmap work.

--- a/test/test_public_demo_links.py
+++ b/test/test_public_demo_links.py
@@ -12,6 +12,8 @@ ADOPTION_DOC_PAGES = (
     Path("docs/source/index.rst"),
     Path("docs/source/newcomer-guide.rst"),
 )
+POSITIONING_DOC = Path("docs/source/agilab-mlops-positioning.rst")
+FEATURES_DOC = Path("docs/source/features.rst")
 PUBLIC_HF_SPACE_URL = "https://huggingface.co/spaces/jpmorard/agilab"
 HF_RUNTIME_URL = "https://jpmorard-agilab.hf.space"
 
@@ -49,6 +51,26 @@ def test_readme_exposes_three_clear_adoption_routes() -> None:
     assert "5.86s" in readme
 
 
+def test_readme_captures_research_experimentation_evidence() -> None:
+    readme = README.read_text(encoding="utf-8")
+
+    assert "Research experimentation" in readme
+    assert "4.0 / 5" in readme
+    assert "lab_steps.toml" in readme
+    assert "MLflow-tracked runs" in readme
+
+
+def test_readme_captures_engineering_prototyping_evidence() -> None:
+    readme = README.read_text(encoding="utf-8")
+
+    assert "Engineering prototyping" in readme
+    assert "4.0 / 5" in readme
+    assert "app_args_form.py" in readme
+    assert "pipeline_view" in readme
+    assert "analysis-page" in readme
+    assert "templates" in readme
+
+
 def test_public_docs_expose_three_clear_adoption_routes() -> None:
     for path in ADOPTION_DOC_PAGES:
         text = path.read_text(encoding="utf-8")
@@ -65,3 +87,50 @@ def test_newcomer_docs_capture_adoption_evidence() -> None:
     assert "3.5 / 5" in text
     assert "5.86s" in text
     assert "600s" in text
+
+
+def test_positioning_docs_capture_research_experimentation_evidence() -> None:
+    text = POSITIONING_DOC.read_text(encoding="utf-8")
+
+    assert "Research experimentation evidence" in text
+    assert "Research experimentation" in text
+    assert "4.0 / 5" in text
+    assert "lab_steps.toml" in text
+    assert "supervisor notebook export" in text
+    assert "MLflow tracking" in text
+    assert "notebook-migration example" in text
+    assert "first-class reduce contract" in text
+
+
+def test_positioning_docs_capture_engineering_prototyping_evidence() -> None:
+    text = POSITIONING_DOC.read_text(encoding="utf-8")
+
+    assert "Engineering prototyping evidence" in text
+    assert "Engineering prototyping" in text
+    assert "4.0 / 5" in text
+    assert "app-shaped prototype" in text
+    assert "pipeline_view" in text
+    assert "analysis-page templates" in text
+    assert "first-proof wizard" in text
+
+
+def test_positioning_docs_capture_strategic_potential_evidence() -> None:
+    text = POSITIONING_DOC.read_text(encoding="utf-8")
+
+    assert "Strategic potential evidence" in text
+    assert "Strategic potential" in text
+    assert "4.2 / 5" in text
+    assert "TRL" in text
+    assert "public demo path" in text
+    assert "handoff model" in text
+
+
+def test_features_docs_capture_engineering_prototyping_evidence() -> None:
+    text = FEATURES_DOC.read_text(encoding="utf-8")
+
+    assert "Engineering prototyping evidence" in text
+    assert "Engineering prototyping" in text
+    assert "4.0 / 5" in text
+    assert "app_args_form.py" in text
+    assert "app_settings.toml" in text
+    assert "pipeline_view.dot" in text


### PR DESCRIPTION
## Summary
- document public evidence for raising Research experimentation to 4.0 / 5
- document Engineering prototyping at 4.0 / 5 with app templates, isolated app/page environments, typed settings, pipeline views, and analysis-page templates
- document Strategic potential at 4.2 / 5 in the MLOps positioning page
- sync canonical docs mirror and stamp
- add regression coverage for README/docs KPI evidence

## Validation
- uv --preview-features extra-build-dependencies run python tools/impact_validate.py --staged
- uv --preview-features extra-build-dependencies run pytest -q test/test_public_demo_links.py
- uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py
- uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --check
- uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs
- git diff --cached --check