### PR TITLE
[codex] Document production readiness KPI evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,15 @@ templates turn an experiment into an app-shaped prototype. That supports an
 because the first-proof wizard, generic evidence bundle, and first-class reduce
 contract remain roadmap work.
 
+Current production-readiness evidence: AGILAB is not positioned as a production
+MLOps backbone, but it now documents a controlled pilot path across release
+preflight tooling, CI/coverage workflows, service health gates, the
+compatibility matrix, the release-decision page, and the security hardening checklist.
+That supports a `Production readiness` score of `3.0 / 5`. It is not scored
+higher because production model serving, feature stores, online monitoring,
+drift detection, enterprise governance, and broad remote-topology certification
+remain outside the shipped scope.
+
 ## Read Next
 
 - [Quick start](https://thalesgroup.github.io/agilab/quick-start.html)

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 157,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "8703e14b2d5c12bb848956a0d96375c61879427ec12e119f224c3429c6508d9f",
+  "source_digest_sha256": "b30cba86605c84c9b19d301c1fc305d4eafb1d1fc55be6bc10276e6e96c9aaf7",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "8703e14b2d5c12bb848956a0d96375c61879427ec12e119f224c3429c6508d9f"
+  "target_digest_sha256": "b30cba86605c84c9b19d301c1fc305d4eafb1d1fc55be6bc10276e6e96c9aaf7"
 }

--- a/docs/source/agilab-mlops-positioning.rst
+++ b/docs/source/agilab-mlops-positioning.rst
@@ -46,6 +46,28 @@ That supports an ``Engineering prototyping`` score of ``4.0 / 5``. It is not
 scored higher yet because the first-proof wizard, generic evidence bundle, and
 first-class reduce contract remain roadmap work.
 
+Production readiness evidence
+-----------------------------
+
+AGILab's production-readiness story is strongest when it is judged as a
+controlled pilot and handoff workbench, not as a production MLOps platform:
+
+- release preflight tooling and workflow-parity profiles give maintainers local
+  checks before packaging or publishing
+- CI and component coverage workflows keep the public repository observable
+- the compatibility matrix marks which public paths are validated versus only
+  documented
+- service health gates expose JSON and Prometheus-compatible operator checks
+- the release-decision page applies artifact and KPI gates and exports
+  ``promotion_decision.json``
+- ``SECURITY.md`` documents supported versions, disclosure expectations, and a
+  deployment hardening checklist
+
+That supports a ``Production readiness`` score of ``3.0 / 5``. It is not scored
+higher because AGILab still does not provide production model serving, feature
+stores, online monitoring, drift detection, enterprise governance, or broad
+remote-topology certification.
+
 Strategic potential evidence
 ----------------------------
 
@@ -77,6 +99,10 @@ Where AGILab helps
 - **Lower operational overhead during experimentation**: useful work can happen
   before a team invests in production-serving, governance, or platform-heavy
   tooling.
+- **Controlled pilot handoff**: release preflight checks, compatibility
+  evidence, service health gates, and promotion-decision exports make it easier
+  to decide when an experiment is ready to leave AGILab for a hardened
+  production stack.
 
 What AGILab does *not* aim to cover
 -----------------------------------

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -137,3 +137,26 @@ single notebook but less ceremony than a production MLOps platform:
 That supports an ``Engineering prototyping`` score of ``4.0 / 5``. It is not
 scored higher yet because the first-proof wizard, generic evidence bundle, and
 first-class reduce contract remain roadmap work.
+
+Production-readiness controls
+-----------------------------
+
+AGILab ships a bounded set of controls for controlled pilots and handoff to a
+production platform:
+
+- ``tools/pypi_publish.py`` enforces release preflight checks before real PyPI
+  publication
+- workflow-parity profiles mirror selected GitHub Actions locally before a
+  maintainer relies on CI
+- the compatibility matrix separates validated public paths from documented
+  routes that still need broader certification
+- ``tools/service_health_check.py`` evaluates service status against SLA
+  thresholds and can emit JSON or Prometheus-compatible output
+- the release-decision analysis page compares baseline and candidate bundles,
+  applies artifact/KPI gates, and exports ``promotion_decision.json``
+- ``SECURITY.md`` provides the public vulnerability-reporting and deployment
+  hardening baseline
+
+That supports a ``Production readiness`` score of ``3.0 / 5``. It is not scored
+higher because AGILab remains a research and engineering workbench rather than
+a production serving, monitoring, governance, or certification platform.

--- a/test/test_public_demo_links.py
+++ b/test/test_public_demo_links.py
@@ -71,6 +71,17 @@ def test_readme_captures_engineering_prototyping_evidence() -> None:
     assert "templates" in readme
 
 
+def test_readme_captures_production_readiness_evidence() -> None:
+    readme = README.read_text(encoding="utf-8")
+
+    assert "Production readiness" in readme
+    assert "3.0 / 5" in readme
+    assert "service health gates" in readme
+    assert "release-decision page" in readme
+    assert "security hardening checklist" in readme
+    assert "production model serving" in readme
+
+
 def test_public_docs_expose_three_clear_adoption_routes() -> None:
     for path in ADOPTION_DOC_PAGES:
         text = path.read_text(encoding="utf-8")
@@ -114,6 +125,19 @@ def test_positioning_docs_capture_engineering_prototyping_evidence() -> None:
     assert "first-proof wizard" in text
 
 
+def test_positioning_docs_capture_production_readiness_evidence() -> None:
+    text = POSITIONING_DOC.read_text(encoding="utf-8")
+
+    assert "Production readiness evidence" in text
+    assert "Production readiness" in text
+    assert "3.0 / 5" in text
+    assert "workflow-parity profiles" in text
+    assert "compatibility matrix" in text
+    assert "service health gates" in text
+    assert "promotion_decision.json" in text
+    assert "online monitoring" in text
+
+
 def test_positioning_docs_capture_strategic_potential_evidence() -> None:
     text = POSITIONING_DOC.read_text(encoding="utf-8")
 
@@ -134,3 +158,15 @@ def test_features_docs_capture_engineering_prototyping_evidence() -> None:
     assert "app_args_form.py" in text
     assert "app_settings.toml" in text
     assert "pipeline_view.dot" in text
+
+
+def test_features_docs_capture_production_readiness_controls() -> None:
+    text = FEATURES_DOC.read_text(encoding="utf-8")
+
+    assert "Production-readiness controls" in text
+    assert "Production readiness" in text
+    assert "3.0 / 5" in text
+    assert "tools/pypi_publish.py" in text
+    assert "tools/service_health_check.py" in text
+    assert "promotion_decision.json" in text
+    assert "SECURITY.md" in text


### PR DESCRIPTION
## Summary

- Document the bounded `Production readiness = 3.0 / 5` evidence in the README.
- Add production-readiness evidence to the MLOps positioning page and feature controls page.
- Extend public documentation contract tests to cover the new README/docs claims.

## Validation

- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files README.md docs/.docs_source_mirror_stamp.json docs/source/agilab-mlops-positioning.rst docs/source/features.rst test/test_public_demo_links.py`
- `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp`
- `uv --preview-features extra-build-dependencies run pytest -q test/test_public_demo_links.py --tb=short`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs`
- `git diff --check`

## Notes

This intentionally keeps the claim scoped to controlled pilots and handoff. It does not position AGILAB as a production serving, monitoring, governance, or certification platform.