### PR TITLE
Add overall KPI evidence bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,17 +123,16 @@ Current research experimentation evidence: AGILAB now documents a complete
 experiment loop across project templates, isolated `uv` environments,
 `lab_steps.toml` history, supervisor notebook export, MLflow-tracked runs, and
 analysis pages. That supports a `Research experimentation` score of `4.0 / 5`.
-It is not scored higher yet because the generic evidence bundle, a first-class
-reduce contract, and broader fresh-install reproducibility checks remain
-roadmap work.
+It is not scored higher yet because the first-class reduce contract and broader
+fresh-install reproducibility checks remain roadmap work.
 
 Current engineering prototyping evidence: AGILAB now documents how app
 templates, isolated app/page environments, typed `app_args_form.py` settings,
 `pipeline_view` files, reusable `lab_steps.toml` history, and analysis-page
 templates turn an experiment into an app-shaped prototype. That supports an
 `Engineering prototyping` score of `4.0 / 5`. It is not scored higher yet
-because the first-proof wizard, generic evidence bundle, and first-class reduce
-contract remain roadmap work.
+because the first-proof wizard, external replication evidence, and first-class
+reduce contract remain roadmap work.
 
 Current production-readiness evidence: AGILAB is not positioned as a production
 MLOps backbone, but it now documents a controlled pilot path across release
@@ -148,6 +147,19 @@ Maintainers can collect that evidence as JSON with:
 
 ```bash
 uv --preview-features extra-build-dependencies run python tools/production_readiness_report.py
+```
+
+Current overall public-evaluation evidence: the public review baseline was
+`3.2 / 5`. AGILAB now exposes a cross-KPI evidence bundle that combines the
+validated source-checkout first proof, public Hugging Face smoke contract,
+compatibility matrix, public docs links, and bounded production-readiness report.
+That supports moving the overall public score toward `3.5 / 5` without changing
+the alpha status or claiming production MLOps coverage.
+
+Maintainers can collect the cross-KPI bundle as JSON with:
+
+```bash
+uv --preview-features extra-build-dependencies run python tools/kpi_evidence_bundle.py
 ```
 
 ## Read Next

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 157,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "b30cba86605c84c9b19d301c1fc305d4eafb1d1fc55be6bc10276e6e96c9aaf7",
+  "source_digest_sha256": "d4aa51989b32bd5482abb57670851c0f1eaf45999d6674ff12894483319b04b4",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "b30cba86605c84c9b19d301c1fc305d4eafb1d1fc55be6bc10276e6e96c9aaf7"
+  "target_digest_sha256": "d4aa51989b32bd5482abb57670851c0f1eaf45999d6674ff12894483319b04b4"
 }

--- a/docs/source/compatibility-matrix.rst
+++ b/docs/source/compatibility-matrix.rst
@@ -41,9 +41,10 @@ Current public matrix
        with fresh output under ``~/log/execute/flight/``
      - Not a remote cluster proof
    * - AGILAB Hugging Face demo
-     - documented
-     - :doc:`demos` plus the public Hugging Face Space
-     - Self-serve AGILAB web UI demo hosted on Hugging Face Spaces
+     - validated
+     - ``uv run python tools/hf_space_smoke.py --json``
+     - Self-serve AGILAB web UI demo hosted on Hugging Face Spaces, including
+       route smoke and a public app-tree guardrail
      - Hosted demo environment; availability depends on Hugging Face Spaces uptime; not a remote cluster proof
    * - Service-mode operator surface
      - validated
@@ -72,7 +73,9 @@ Use it to answer three concrete questions:
 3. Which paths still need broader certification or automation work?
 
 Use :doc:`newcomer-guide` and :doc:`quick-start` for the actual onboarding
-flow. This page is only the support-status map.
+flow. This page is only the support-status map. Maintainers can collect the
+cross-KPI public evidence bundle with ``uv run python
+tools/kpi_evidence_bundle.py``.
 
 What remains roadmap work
 -------------------------
@@ -81,7 +84,7 @@ This first matrix closes the small, manual version of the compatibility item.
 The larger roadmap work is still open:
 
 - automatic generation from workflow evidence
-- promotion from a documented matrix to a workflow-backed compatibility report
+- broader promotion from this matrix to a workflow-backed compatibility report
 - integration with the first-proof wizard so newcomers land on one validated
   path instead of choosing routes too early
 - per-release compatibility status

--- a/docs/source/data/compatibility_matrix.toml
+++ b/docs/source/data/compatibility_matrix.toml
@@ -1,6 +1,6 @@
 [metadata]
 version = 1
-updated = "2026-04-20"
+updated = "2026-04-24"
 owner = "manual-public-docs"
 purpose = "Public compatibility and demo-tour slice for AGILAB"
 notes = "Manual matrix. Workflow-backed automation and broader certification remain roadmap work. Newcomer proof and full public tour are intentionally tracked as separate public paths."
@@ -30,12 +30,12 @@ limits = ["Local path only", "Not a remote cluster proof"]
 [[entries]]
 id = "agilab-hf-demo"
 label = "AGILAB Hugging Face demo"
-status = "documented"
+status = "validated"
 surface = "public hosted demo"
-primary_proof = "demos.rst plus the public Hugging Face Space"
+primary_proof = "uv --preview-features extra-build-dependencies run python tools/hf_space_smoke.py --json"
 python = ["3.11+"]
 platforms = ["macOS", "Linux", "WSL2"]
-scope = "Self-serve AGILAB web UI demo hosted on Hugging Face Spaces"
+scope = "Self-serve AGILAB web UI demo hosted on Hugging Face Spaces, including route smoke and public app-tree guardrail"
 limits = ["Hosted demo environment", "Not a remote cluster proof", "Availability depends on Hugging Face Spaces uptime"]
 
 [[entries]]

--- a/test/test_kpi_evidence_bundle.py
+++ b/test/test_kpi_evidence_bundle.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+MODULE_PATH = Path("tools/kpi_evidence_bundle.py").resolve()
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("kpi_evidence_bundle_test_module", MODULE_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_build_bundle_passes_static_public_evidence_contracts() -> None:
+    module = _load_module()
+
+    bundle = module.build_bundle(run_hf_smoke=False)
+
+    assert bundle["kpi"] == "Overall public evaluation"
+    assert bundle["supported_score"] == "3.5 / 5"
+    assert bundle["baseline_review_score"] == "3.2 / 5"
+    assert bundle["status"] == "pass"
+    assert bundle["summary"]["hf_smoke_executed"] is False
+    check_ids = {check["id"] for check in bundle["checks"]}
+    assert check_ids == {
+        "compatibility_matrix_public_paths",
+        "newcomer_first_proof_contract",
+        "hf_space_smoke_contract",
+        "production_readiness_report_contract",
+        "docs_mirror_stamp",
+        "public_docs_evidence_links",
+    }
+
+
+def test_compatibility_matrix_requires_hf_demo_validated() -> None:
+    module = _load_module()
+
+    check = module._check_compatibility_matrix(Path.cwd())
+
+    assert check["status"] == "pass"
+    assert check["details"]["actual_statuses"]["agilab-hf-demo"] == "validated"
+
+
+def test_optional_hf_smoke_run_is_explicit(monkeypatch) -> None:
+    module = _load_module()
+
+    @dataclass(frozen=True)
+    class _FakeCheck:
+        label: str
+        success: bool
+        duration_seconds: float
+        detail: str
+        url: str | None = None
+
+    @dataclass(frozen=True)
+    class _FakeRoute:
+        label: str
+
+    @dataclass(frozen=True)
+    class _FakeSummary:
+        success: bool
+        total_duration_seconds: float
+        target_seconds: float
+        within_target: bool
+        checks: list[_FakeCheck]
+
+    class _FakeHfSmoke:
+        DEFAULT_SPACE_ID = "jpmorard/agilab"
+        DEFAULT_SPACE_URL = "https://jpmorard-agilab.hf.space"
+
+        @staticmethod
+        def route_specs():
+            return [
+                _FakeRoute(label)
+                for label in (
+                    "streamlit health",
+                    "base app",
+                    "flight project",
+                    "flight view_maps",
+                    "flight view_maps_network",
+                )
+            ]
+
+        @staticmethod
+        def check_public_app_tree():
+            return None
+
+        @staticmethod
+        def run_smoke():
+            return _FakeSummary(
+                success=True,
+                total_duration_seconds=1.0,
+                target_seconds=30.0,
+                within_target=True,
+                checks=[_FakeCheck("public app tree", True, 1.0, "ok")],
+            )
+
+    original_loader = module._load_tool_module
+
+    def _load_tool_module(repo_root, name):
+        if name == "hf_space_smoke":
+            return _FakeHfSmoke
+        return original_loader(repo_root, name)
+
+    monkeypatch.setattr(module, "_load_tool_module", _load_tool_module)
+
+    bundle = module.build_bundle(run_hf_smoke=True)
+
+    assert bundle["status"] == "pass"
+    assert bundle["summary"]["hf_smoke_executed"] is True
+    check = next(check for check in bundle["checks"] if check["id"] == "hf_space_smoke_run")
+    assert check["executed"] is True
+    assert check["details"]["checks"][0]["label"] == "public app tree"
+
+
+def test_main_emits_json_and_returns_success(capsys) -> None:
+    module = _load_module()
+
+    exit_code = module.main(["--compact"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["kpi"] == "Overall public evaluation"
+    assert payload["status"] == "pass"
+    assert payload["summary"]["failed"] == 0

--- a/test/test_public_demo_links.py
+++ b/test/test_public_demo_links.py
@@ -14,6 +14,8 @@ ADOPTION_DOC_PAGES = (
 )
 POSITIONING_DOC = Path("docs/source/agilab-mlops-positioning.rst")
 FEATURES_DOC = Path("docs/source/features.rst")
+COMPATIBILITY_DOC = Path("docs/source/compatibility-matrix.rst")
+COMPATIBILITY_MATRIX = Path("docs/source/data/compatibility_matrix.toml")
 PUBLIC_HF_SPACE_URL = "https://huggingface.co/spaces/jpmorard/agilab"
 HF_RUNTIME_URL = "https://jpmorard-agilab.hf.space"
 
@@ -82,6 +84,16 @@ def test_readme_captures_production_readiness_evidence() -> None:
     assert "security hardening checklist" in normalized
     assert "production model serving" in readme
     assert "tools/production_readiness_report.py" in readme
+
+
+def test_readme_captures_overall_public_evaluation_evidence() -> None:
+    readme = README.read_text(encoding="utf-8")
+
+    assert "overall public-evaluation evidence" in readme
+    assert "3.2 / 5" in readme
+    assert "3.5 / 5" in readme
+    assert "cross-KPI evidence bundle" in readme
+    assert "tools/kpi_evidence_bundle.py" in readme
 
 
 def test_readme_links_to_mlops_positioning_page() -> None:
@@ -179,3 +191,15 @@ def test_features_docs_capture_production_readiness_controls() -> None:
     assert "tools/service_health_check.py" in text
     assert "promotion_decision.json" in text
     assert "SECURITY.md" in text
+
+
+def test_compatibility_matrix_marks_public_hf_demo_validated() -> None:
+    matrix = COMPATIBILITY_MATRIX.read_text(encoding="utf-8")
+    doc = COMPATIBILITY_DOC.read_text(encoding="utf-8")
+
+    assert 'id = "agilab-hf-demo"' in matrix
+    assert 'status = "validated"' in matrix
+    assert "tools/hf_space_smoke.py --json" in matrix
+    assert "AGILAB Hugging Face demo" in doc
+    assert "tools/hf_space_smoke.py --json" in doc
+    assert "tools/kpi_evidence_bundle.py" in doc

--- a/tools/kpi_evidence_bundle.py
+++ b/tools/kpi_evidence_bundle.py
@@ -1,0 +1,372 @@
+#!/usr/bin/env python3
+"""Emit cross-KPI public evidence for AGILAB review/adoption scoring."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict
+import importlib.util
+import json
+from pathlib import Path
+import sys
+from typing import Any, Sequence
+import tomllib
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SUPPORTED_OVERALL_SCORE = "3.5 / 5"
+BASELINE_REVIEW_SCORE = "3.2 / 5"
+REQUIRED_MATRIX_STATUSES = {
+    "source-checkout-first-proof": "validated",
+    "web-ui-local-first-proof": "validated",
+    "agilab-hf-demo": "validated",
+    "service-mode-operator-surface": "validated",
+    "notebook-quickstart": "documented",
+    "published-package-route": "documented",
+}
+
+
+def _load_tool_module(repo_root: Path, name: str) -> Any:
+    module_path = repo_root / "tools" / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(f"{name}_for_kpi_bundle", module_path)
+    if not spec or not spec.loader:
+        raise RuntimeError(f"unable to load tool module: {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _check_result(
+    check_id: str,
+    label: str,
+    passed: bool,
+    summary: str,
+    *,
+    evidence: Sequence[str] = (),
+    details: dict[str, Any] | None = None,
+    executed: bool = False,
+) -> dict[str, Any]:
+    return {
+        "id": check_id,
+        "label": label,
+        "status": "pass" if passed else "fail",
+        "summary": summary,
+        "executed": executed,
+        "evidence": list(evidence),
+        "details": details or {},
+    }
+
+
+def _load_matrix_entries(repo_root: Path) -> list[dict[str, Any]]:
+    matrix_path = repo_root / "docs" / "source" / "data" / "compatibility_matrix.toml"
+    with matrix_path.open("rb") as stream:
+        payload = tomllib.load(stream)
+    entries = payload.get("entries", [])
+    if not isinstance(entries, list):
+        raise TypeError("compatibility matrix entries must be a list")
+    return [entry for entry in entries if isinstance(entry, dict)]
+
+
+def _check_compatibility_matrix(repo_root: Path) -> dict[str, Any]:
+    try:
+        entries = _load_matrix_entries(repo_root)
+        statuses = {str(entry.get("id")): str(entry.get("status")) for entry in entries}
+        missing = sorted(set(REQUIRED_MATRIX_STATUSES) - set(statuses))
+        mismatched = {
+            entry_id: {"expected": expected, "actual": statuses.get(entry_id)}
+            for entry_id, expected in REQUIRED_MATRIX_STATUSES.items()
+            if statuses.get(entry_id) != expected
+        }
+        ok = not missing and not mismatched
+        details = {
+            "required_statuses": REQUIRED_MATRIX_STATUSES,
+            "actual_statuses": {
+                entry_id: statuses.get(entry_id)
+                for entry_id in sorted(REQUIRED_MATRIX_STATUSES)
+            },
+            "missing": missing,
+            "mismatched": mismatched,
+        }
+    except Exception as exc:
+        ok = False
+        details = {"error": str(exc)}
+    return _check_result(
+        "compatibility_matrix_public_paths",
+        "Compatibility matrix public paths",
+        ok,
+        (
+            "compatibility matrix distinguishes validated public paths from documented alternatives"
+            if ok
+            else "compatibility matrix no longer matches the public evidence contract"
+        ),
+        evidence=["docs/source/data/compatibility_matrix.toml"],
+        details=details,
+    )
+
+
+def _check_newcomer_first_proof_contract(repo_root: Path) -> dict[str, Any]:
+    try:
+        newcomer_first_proof = _load_tool_module(repo_root, "newcomer_first_proof")
+        active_app = newcomer_first_proof.DEFAULT_ACTIVE_APP
+        commands = newcomer_first_proof.build_proof_commands(active_app, with_install=False)
+        labels = [command.label for command in commands]
+        ok = (
+            labels == ["preinit smoke", "source ui smoke"]
+            and float(newcomer_first_proof.DEFAULT_MAX_SECONDS) == 600.0
+            and active_app.name == "flight_project"
+        )
+        details = {
+            "active_app": str(active_app),
+            "labels": labels,
+            "target_seconds": newcomer_first_proof.DEFAULT_MAX_SECONDS,
+            "command_count": len(commands),
+        }
+    except Exception as exc:
+        ok = False
+        details = {"error": str(exc)}
+    return _check_result(
+        "newcomer_first_proof_contract",
+        "Newcomer first-proof contract",
+        ok,
+        (
+            "source-checkout newcomer proof is executable and targets the public flight_project"
+            if ok
+            else "source-checkout newcomer proof contract is incomplete"
+        ),
+        evidence=["tools/newcomer_first_proof.py", "README.md"],
+        details=details,
+    )
+
+
+def _check_hf_space_smoke_contract(repo_root: Path) -> dict[str, Any]:
+    try:
+        hf_space_smoke = _load_tool_module(repo_root, "hf_space_smoke")
+        specs = hf_space_smoke.route_specs()
+        labels = [spec.label for spec in specs]
+        required_labels = {
+            "streamlit health",
+            "base app",
+            "flight project",
+            "flight view_maps",
+            "flight view_maps_network",
+        }
+        ok = (
+            required_labels.issubset(labels)
+            and hf_space_smoke.DEFAULT_SPACE_ID == "jpmorard/agilab"
+            and callable(hf_space_smoke.check_public_app_tree)
+        )
+        details = {
+            "space_id": hf_space_smoke.DEFAULT_SPACE_ID,
+            "space_url": hf_space_smoke.DEFAULT_SPACE_URL,
+            "labels": labels,
+            "required_labels": sorted(required_labels),
+        }
+    except Exception as exc:
+        ok = False
+        details = {"error": str(exc)}
+    return _check_result(
+        "hf_space_smoke_contract",
+        "Hugging Face Space smoke contract",
+        ok,
+        (
+            "HF smoke covers public routes and guards against non-public app entries"
+            if ok
+            else "HF smoke contract is incomplete"
+        ),
+        evidence=["tools/hf_space_smoke.py", "README.md"],
+        details=details,
+    )
+
+
+def _run_hf_space_smoke(repo_root: Path) -> dict[str, Any]:
+    try:
+        hf_space_smoke = _load_tool_module(repo_root, "hf_space_smoke")
+        summary = hf_space_smoke.run_smoke()
+        details = asdict(summary)
+        ok = bool(summary.success)
+        summary_text = (
+            "public HF Space smoke passed"
+            if ok
+            else "public HF Space smoke failed"
+        )
+    except Exception as exc:
+        ok = False
+        summary_text = str(exc)
+        details = {"error": str(exc)}
+    return _check_result(
+        "hf_space_smoke_run",
+        "Hugging Face Space smoke run",
+        ok,
+        summary_text,
+        evidence=["tools/hf_space_smoke.py", "https://huggingface.co/spaces/jpmorard/agilab"],
+        details=details,
+        executed=True,
+    )
+
+
+def _check_production_readiness_report(repo_root: Path) -> dict[str, Any]:
+    try:
+        production_readiness_report = _load_tool_module(repo_root, "production_readiness_report")
+        report = production_readiness_report.build_report(repo_root=repo_root, run_docs_profile=False)
+        ok = report.get("status") == "pass" and report.get("supported_score") == "3.0 / 5"
+        details = {
+            "status": report.get("status"),
+            "supported_score": report.get("supported_score"),
+            "summary": report.get("summary"),
+            "check_ids": [check.get("id") for check in report.get("checks", [])],
+        }
+    except Exception as exc:
+        ok = False
+        details = {"error": str(exc)}
+    return _check_result(
+        "production_readiness_report_contract",
+        "Production-readiness report contract",
+        ok,
+        (
+            "production-readiness evidence report passes and preserves the 3.0 / 5 scope limit"
+            if ok
+            else "production-readiness evidence report is failing or overclaiming"
+        ),
+        evidence=["tools/production_readiness_report.py"],
+        details=details,
+    )
+
+
+def _check_docs_mirror_stamp(repo_root: Path) -> dict[str, Any]:
+    try:
+        sync_docs_source = _load_tool_module(repo_root, "sync_docs_source")
+        ok, message = sync_docs_source.verify_mirror_stamp(repo_root / "docs" / "source")
+    except Exception as exc:
+        ok, message = False, str(exc)
+    return _check_result(
+        "docs_mirror_stamp",
+        "Docs mirror stamp",
+        ok,
+        message,
+        evidence=["docs/.docs_source_mirror_stamp.json", "tools/sync_docs_source.py"],
+    )
+
+
+def _check_public_docs_links(repo_root: Path) -> dict[str, Any]:
+    paths = [
+        repo_root / "README.md",
+        repo_root / "docs" / "source" / "compatibility-matrix.rst",
+        repo_root / "docs" / "source" / "demos.rst",
+        repo_root / "docs" / "source" / "quick-start.rst",
+    ]
+    required = {
+        "README.md": [
+            "tools/kpi_evidence_bundle.py",
+            "tools/hf_space_smoke.py --json",
+            "tools/newcomer_first_proof.py --json",
+            "tools/production_readiness_report.py",
+        ],
+        "docs/source/compatibility-matrix.rst": [
+            "AGILAB Hugging Face demo",
+            "validated",
+            "tools/hf_space_smoke.py --json",
+        ],
+        "docs/source/demos.rst": ["https://huggingface.co/spaces/jpmorard/agilab"],
+        "docs/source/quick-start.rst": ["tools/newcomer_first_proof.py"],
+    }
+    missing: dict[str, list[str]] = {}
+    try:
+        for path in paths:
+            rel = str(path.relative_to(repo_root))
+            text = _read_text(path)
+            missing_for_path = [needle for needle in required[rel] if needle not in text]
+            if missing_for_path:
+                missing[rel] = missing_for_path
+        ok = not missing
+        details = {"missing": missing}
+    except Exception as exc:
+        ok = False
+        details = {"error": str(exc), "missing": missing}
+    return _check_result(
+        "public_docs_evidence_links",
+        "Public docs evidence links",
+        ok,
+        (
+            "README and public docs expose the machine-readable evidence commands"
+            if ok
+            else "README or public docs are missing evidence command references"
+        ),
+        evidence=[str(path.relative_to(repo_root)) for path in paths],
+        details=details,
+    )
+
+
+def build_bundle(
+    *,
+    repo_root: Path = REPO_ROOT,
+    run_hf_smoke: bool = False,
+) -> dict[str, Any]:
+    repo_root = repo_root.resolve()
+    checks = [
+        _check_compatibility_matrix(repo_root),
+        _check_newcomer_first_proof_contract(repo_root),
+        _check_hf_space_smoke_contract(repo_root),
+        _check_production_readiness_report(repo_root),
+        _check_docs_mirror_stamp(repo_root),
+        _check_public_docs_links(repo_root),
+    ]
+    if run_hf_smoke:
+        checks.append(_run_hf_space_smoke(repo_root))
+
+    passed = sum(1 for check in checks if check["status"] == "pass")
+    failed = sum(1 for check in checks if check["status"] == "fail")
+    return {
+        "kpi": "Overall public evaluation",
+        "supported_score": SUPPORTED_OVERALL_SCORE,
+        "baseline_review_score": BASELINE_REVIEW_SCORE,
+        "status": "pass" if failed == 0 else "fail",
+        "summary": {
+            "passed": passed,
+            "failed": failed,
+            "total": len(checks),
+            "hf_smoke_executed": run_hf_smoke,
+        },
+        "rationale": (
+            "Supports moving the public review from 3.2 / 5 toward 3.5 / 5 by "
+            "combining validated adoption, hosted-demo, research/prototype, and "
+            "bounded production-readiness evidence. It does not change the alpha "
+            "status or claim production MLOps coverage."
+        ),
+        "checks": checks,
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Emit machine-readable evidence for AGILAB's overall public evaluation KPI."
+    )
+    parser.add_argument(
+        "--run-hf-smoke",
+        action="store_true",
+        help="Also execute the public Hugging Face Space smoke test. Default only checks the smoke contract.",
+    )
+    parser.add_argument(
+        "--compact",
+        action="store_true",
+        help="Emit compact JSON without indentation.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(list(argv) if argv is not None else None)
+    bundle = build_bundle(run_hf_smoke=args.run_hf_smoke)
+    if args.compact:
+        print(json.dumps(bundle, sort_keys=True, separators=(",", ":")))
+    else:
+        print(json.dumps(bundle, indent=2, sort_keys=True))
+    return 0 if bundle["status"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a machine-readable cross-KPI public evidence bundle for overall public evaluation
- mark the public Hugging Face demo compatibility slice as validated by the HF smoke tool
- document the overall public-evaluation evidence path and cover it with tests

## Validation
- uv --preview-features extra-build-dependencies run pytest -q test/test_kpi_evidence_bundle.py test/test_public_demo_links.py test/test_production_readiness_report.py test/test_hf_space_smoke.py test/test_newcomer_first_proof.py
- uv --preview-features extra-build-dependencies run python tools/kpi_evidence_bundle.py --compact
- uv --preview-features extra-build-dependencies run python tools/kpi_evidence_bundle.py --compact --run-hf-smoke
- uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --source /Users/agi/PycharmProjects/thales_agilab/docs/source --target docs/source --verify-stamp
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs
- git diff --check