### PR TITLE
Add public changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,59 @@
+# Changelog
+
+All notable public AGILAB changes are summarized here. GitHub Releases remain
+the publication surface for tagged release artifacts; this file gives reviewers
+and adopters a versioned, repository-local upgrade trail.
+
+## [2026.04.25] - 2026-04-24
+
+GitHub Release: https://github.com/ThalesGroup/agilab/releases/tag/v2026.04.25
+
+### Added
+
+- Added `tools/kpi_evidence_bundle.py`, a machine-readable cross-KPI evidence
+  bundle for overall public evaluation.
+- Added `tools/production_readiness_report.py` evidence reporting for the
+  bounded production-readiness pilot scope.
+- Added public Hugging Face Space smoke checks covering Streamlit health, base
+  app, `flight_project`, `view_maps`, `view_maps_network`, and public app-tree
+  guardrails.
+- Added public KPI evidence in README/docs for ease of adoption, research
+  experimentation, engineering prototyping, strategic potential, and production
+  readiness.
+
+### Changed
+
+- Promoted the public AGILAB Hugging Face demo compatibility slice from
+  `documented` to `validated` after smoke coverage and private-app guardrails.
+- Published the first GitHub Release page for AGILAB so external reviewers can
+  inspect release notes without relying only on tags or PyPI metadata.
+- Made benchmark mode selection explicit in the public runtime flow.
+- Clarified MLOps positioning: AGILAB is a research/prototyping workbench and
+  controlled pilot surface, not a production MLOps replacement.
+
+### Fixed
+
+- Fixed hosted analysis-page routing so public demo views do not fall back to
+  `127.0.0.1`.
+- Fixed missing Flight seed dataset handling on Hugging Face Spaces.
+- Fixed notebook export/app-root handling for public first-run snippets.
+- Fixed view-map network settings persistence and related public analysis-page
+  behavior.
+
+### Validation
+
+- `tools/kpi_evidence_bundle.py --compact --run-hf-smoke`: pass, including live
+  Hugging Face route checks and no non-public app entries.
+- `tools/sync_docs_source.py --verify-stamp`: pass.
+- Pull request checks for the evidence bundle and release-readiness changes:
+  pass.
+
+### Scope Limits
+
+- AGILAB is still alpha-stage public software.
+- This release improves release ergonomics, public evidence, and demo
+  reliability; it does not add production model serving, feature stores, online
+  monitoring, drift detection, enterprise governance, or broad remote-topology
+  certification.
+
+[2026.04.25]: https://github.com/ThalesGroup/agilab/releases/tag/v2026.04.25

--- a/README.md
+++ b/README.md
@@ -171,4 +171,5 @@ uv --preview-features extra-build-dependencies run python tools/kpi_evidence_bun
 - [MLOps positioning](https://thalesgroup.github.io/agilab/agilab-mlops-positioning.html)
 - [Documentation](https://thalesgroup.github.io/agilab)
 - [Flight project guide](https://thalesgroup.github.io/agilab/flight-project.html)
+- [Changelog](CHANGELOG.md)
 - [Developer runbook](AGENTS.md)

--- a/test/test_public_demo_links.py
+++ b/test/test_public_demo_links.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 
 README = Path("README.md")
+CHANGELOG = Path("CHANGELOG.md")
 PUBLIC_DOC_PAGES = (
     Path("docs/source/demos.rst"),
     Path("docs/source/quick-start.rst"),
@@ -101,6 +102,22 @@ def test_readme_links_to_mlops_positioning_page() -> None:
 
     assert "MLOps positioning" in readme
     assert "https://thalesgroup.github.io/agilab/agilab-mlops-positioning.html" in readme
+
+
+def test_readme_links_to_public_changelog() -> None:
+    readme = README.read_text(encoding="utf-8")
+
+    assert "[Changelog](CHANGELOG.md)" in readme
+
+
+def test_changelog_documents_current_public_release() -> None:
+    changelog = CHANGELOG.read_text(encoding="utf-8")
+
+    assert "## [2026.04.25] - 2026-04-24" in changelog
+    assert "https://github.com/ThalesGroup/agilab/releases/tag/v2026.04.25" in changelog
+    assert "tools/kpi_evidence_bundle.py" in changelog
+    assert "Hugging Face Space smoke checks" in changelog
+    assert "AGILAB is still alpha-stage public software" in changelog
 
 
 def test_public_docs_expose_three_clear_adoption_routes() -> None:


### PR DESCRIPTION
## Summary
- add repository-local CHANGELOG.md for the 2026.04.25 public release
- link the changelog from README
- cover the changelog and README link with public demo/docs tests

## Validation
- uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files CHANGELOG.md README.md test/test_public_demo_links.py
- uv --preview-features extra-build-dependencies run pytest -q test/test_public_demo_links.py
- git diff --check