### PR TITLE
[codex] Harden PyPI version and dry-run handling

### DIFF
--- a/test/test_pypi_publish.py
+++ b/test/test_pypi_publish.py
@@ -240,6 +240,62 @@ def test_release_preflight_profiles_only_for_real_pypi() -> None:
     assert profiles == ["agi-env", "agi-core-combined", "agi-gui", "docs", "installer", "shared-core-typing"]
 
 
+def test_compute_unified_version_never_drops_below_latest_release(monkeypatch) -> None:
+    module = _load_pypi_publish()
+
+    class _FixedDatetime:
+        @staticmethod
+        def now(_tz):
+            return datetime(2026, 4, 24, 10, 0, 0, tzinfo=timezone.utc)
+
+    releases = {
+        "agi-env": {"2026.4.25"},
+        "agi-node": {"2026.4.25"},
+        "agilab": {"2026.4.25"},
+    }
+
+    monkeypatch.setattr(module, "datetime", _FixedDatetime)
+    monkeypatch.setattr(
+        module,
+        "pypi_releases",
+        lambda name, _repo: releases.get(name, set()),
+    )
+
+    chosen, collisions = module.compute_unified_version(
+        ["agi-env", "agi-node", "agilab"],
+        "pypi",
+        None,
+    )
+
+    assert chosen == "2026.4.25.post1"
+    assert collisions == {
+        "agi-env": ["2026.4.25"],
+        "agi-node": ["2026.4.25"],
+        "agilab": ["2026.4.25"],
+    }
+
+
+def test_compute_unified_version_rejects_free_explicit_version_below_latest_release(monkeypatch) -> None:
+    module = _load_pypi_publish()
+
+    releases = {
+        "agi-env": {"2026.4.25"},
+        "agilab": {"2026.4.25"},
+    }
+    monkeypatch.setattr(
+        module,
+        "pypi_releases",
+        lambda name, _repo: releases.get(name, set()),
+    )
+
+    try:
+        module.compute_unified_version(["agi-env", "agilab"], "pypi", "2026.4.24.post1")
+    except SystemExit as exc:
+        assert "Computed version 2026.4.24.post1 is lower than existing release 2026.4.25" in str(exc)
+    else:
+        raise AssertionError("compute_unified_version() should reject computed lower versions")
+
+
 def test_compute_date_tag_without_collision(monkeypatch) -> None:
     module = _load_pypi_publish()
 
@@ -648,6 +704,69 @@ def test_main_dry_run_restores_release_files(tmp_path, monkeypatch) -> None:
     module.main()
 
     assert pyproject.read_text(encoding="utf-8") == original_text
+
+
+def test_main_dry_run_does_not_report_stale_dist_artifacts(tmp_path, monkeypatch, capsys) -> None:
+    module = _load_pypi_publish()
+
+    project_dir = tmp_path / "agi-env"
+    project_dir.mkdir(parents=True)
+    pyproject = project_dir / "pyproject.toml"
+    pyproject.write_text(
+        "[project]\nname = 'agi-env'\nversion = '2026.03.16'\ndependencies = []\n",
+        encoding="utf-8",
+    )
+    stale_dist = project_dir / "dist" / "agi_env-2026.03.16-py3-none-any.whl"
+    stale_dist.parent.mkdir()
+    stale_dist.write_text("stale", encoding="utf-8")
+
+    cfg = module.Cfg(
+        repo="testpypi",
+        dist="both",
+        skip_existing=True,
+        retries=1,
+        dry_run=True,
+        verbose=False,
+        version="2026.03.23",
+        purge_before=False,
+        purge_after=False,
+        cleanup_only=False,
+        clean_days=None,
+        clean_delete_project=False,
+        cleanup_user=None,
+        cleanup_pass=None,
+        cleanup_timeout=0,
+        skip_cleanup=True,
+        yank_previous=False,
+        git_tag=False,
+        git_commit_version=False,
+        git_reset_on_failure=False,
+        pypirc_check=False,
+        packages=["agi-env"],
+        gen_docs=False,
+    )
+
+    monkeypatch.setattr(module, "parse_args", lambda: object())
+    monkeypatch.setattr(module, "make_cfg", lambda _args: cfg)
+    monkeypatch.setattr(module, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(module, "CORE", [("agi-env", pyproject, project_dir)])
+    monkeypatch.setattr(module, "UMBRELLA", ("agilab", tmp_path / "missing.toml", tmp_path))
+    monkeypatch.setattr(module, "pypi_releases", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(module, "remove_symlinks_for_umbrella", lambda: [])
+    monkeypatch.setattr(module, "restore_symlinks", lambda _entries: None)
+    monkeypatch.setattr(module, "sync_builtin_app_versions", lambda _version: None)
+    monkeypatch.setattr(
+        module,
+        "dist_files",
+        lambda _project_dir: (_ for _ in ()).throw(AssertionError("dry-run must not read dist")),
+    )
+    monkeypatch.setattr(module, "update_selected_badges", lambda *_args, **_kwargs: None)
+
+    module.main()
+
+    output = capsys.readouterr().out
+    assert str(stale_dist) not in output
+    assert "[build] agi-env: (dry-run would build both artifacts for 2026.03.23)" in output
 
 
 def test_main_refreshes_badges_before_collision_rebuild(tmp_path, monkeypatch) -> None:

--- a/tools/pypi_publish.py
+++ b/tools/pypi_publish.py
@@ -457,6 +457,18 @@ def max_base_across_packages(package_names: List[str], repo_target: str) -> str:
     return max(bases, key=safe_ver)
 
 
+def latest_existing_release(package_names: List[str], repo_target: str) -> str | None:
+    latest: str | None = None
+    for name in package_names:
+        releases = {v for v in pypi_releases(name, repo_target) if v and v != "0.0.0.post0"}
+        if not releases:
+            continue
+        candidate = max(releases, key=safe_ver)
+        if latest is None or safe_ver(candidate) > safe_ver(latest):
+            latest = candidate
+    return latest
+
+
 def next_free_post_for_all(package_names: List[str], repo_target: str, base: str) -> str:
     per_pkg = {n: pypi_releases(n, repo_target) for n in package_names}
 
@@ -495,9 +507,23 @@ def compute_unified_version(core_names: List[str], repo_target: str, base_versio
             base = provided_base
             chosen = next_free_post_for_all(core_names, repo_target, base)
     else:
-        base = datetime.now(timezone.utc).strftime("%Y.%m.%d")
+        today_base = datetime.now(timezone.utc).strftime("%Y.%m.%d")
+        latest = latest_existing_release(core_names, repo_target)
+        latest_base = normalize_base(latest) if latest else None
+        base = (
+            latest_base
+            if latest_base is not None and safe_ver(latest_base) > safe_ver(today_base)
+            else today_base
+        )
         # if no releases at all, still .post1 to keep everything uniform
         chosen = next_free_post_for_all(core_names, repo_target, base)
+
+    latest = latest_existing_release(core_names, repo_target)
+    if latest is not None and safe_ver(chosen) < safe_ver(latest):
+        raise SystemExit(
+            f"ERROR: Computed version {chosen} is lower than existing release "
+            f"{latest} on {repo_target}. Choose an explicit --version >= the latest release."
+        )
 
     # report collisions that influenced bump
     for n in core_names:
@@ -1291,14 +1317,7 @@ def main():
     version_targets = selected_core_names + ([UMBRELLA[0]] if build_umbrella else [])
 
     if cfg.version is not None:
-        latest_existing: str | None = None
-        for name in version_targets:
-            releases = {v for v in pypi_releases(name, cfg.repo) if v and v != "0.0.0.post0"}
-            if not releases:
-                continue
-            candidate = max(releases, key=safe_ver)
-            if latest_existing is None or safe_ver(candidate) > safe_ver(latest_existing):
-                latest_existing = candidate
+        latest_existing = latest_existing_release(version_targets, cfg.repo)
         if latest_existing is not None and safe_ver(cfg.version) < safe_ver(latest_existing):
             raise SystemExit(
                 f"ERROR: Explicit --version {cfg.version} is lower than existing release "
@@ -1369,11 +1388,14 @@ def main():
             except Exception as e:
                 raise SystemExit(f"fatal: Could not update version in {toml}\n{e}")
             pin_internal_deps(toml, pins)
-            if not cfg.dry_run:
+            if cfg.dry_run:
+                print(f"[build] {name}: (dry-run would build {cfg.dist} artifacts for {chosen})")
+                files = []
+            else:
                 uv_build_project(project, cfg.dist)
-            files = dist_files(project)
-            if files:
-                print(f"[build] {name}: {', '.join(files)}")
+                files = dist_files(project)
+                if files:
+                    print(f"[build] {name}: {', '.join(files)}")
             all_files.extend(files)
 
         # umbrella
@@ -1384,11 +1406,14 @@ def main():
             except Exception as e:
                 raise SystemExit(f"fatal: Could not update version in {umbrella_toml}\n{e}")
             pin_internal_deps(umbrella_toml, pins)
-            if not cfg.dry_run:
+            if cfg.dry_run:
+                print(f"[build] umbrella: (dry-run would build {cfg.dist} artifacts for {chosen})")
+                root_files = []
+            else:
                 uv_build_repo_root(cfg.dist)
-            root_files = dist_files_root()
-            if root_files:
-                print(f"[build] umbrella: {', '.join(root_files)}")
+                root_files = dist_files_root()
+                if root_files:
+                    print(f"[build] umbrella: {', '.join(root_files)}")
             all_files.extend(root_files)
 
         if sync_builtin_versions:


### PR DESCRIPTION
## Summary

Harden the PyPI publish helper so automatic version selection never moves below the latest existing release, even when the current date is earlier than the most recent published package version.

Also make dry-run build output deterministic by reporting the artifacts that would be built instead of reading stale files from `dist/`.

## Validation

- `uv --preview-features extra-build-dependencies run pytest -q test/test_pypi_publish.py`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files tools/pypi_publish.py test/test_pypi_publish.py`
- `git diff --check`
