### PR TITLE
[codex] Harden notebook export app discovery

### DIFF
--- a/src/agilab/notebook_export_support.py
+++ b/src/agilab/notebook_export_support.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import sys
 import textwrap
 from dataclasses import asdict, dataclass
@@ -12,6 +13,8 @@ import tomllib
 
 DEFAULT_NOTEBOOK_EXPORT_MODE = "supervisor"
 PYCHARM_NOTEBOOK_MIRROR_ROOT = "exported_notebooks"
+ALLOW_WORKSPACE_SIBLING_APPS_ENV = "AGILAB_NOTEBOOK_EXPORT_ALLOW_WORKSPACE_SIBLINGS"
+APPS_REPOSITORY_ENV_KEYS = ("APPS_REPOSITORY", "AGILAB_APPS_REPOSITORY")
 
 PYCHARM_NOTEBOOK_SITECUSTOMIZE = """\
 from __future__ import annotations
@@ -129,6 +132,7 @@ class NotebookExportContext:
     pages_root: str = ""
     repo_root: str = ""
     export_mode: str = DEFAULT_NOTEBOOK_EXPORT_MODE
+    allow_workspace_sibling_apps: bool = False
     related_pages: tuple[RelatedPageExport, ...] = ()
 
 
@@ -165,6 +169,33 @@ def _looks_like_source_checkout(root: Path) -> bool:
     return (root / "src" / "agilab").exists() and ((root / ".git").exists() or (root / ".idea").exists())
 
 
+def _truthy_env(value: str | None) -> bool:
+    return str(value or "").strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def _allow_workspace_sibling_apps() -> bool:
+    return _truthy_env(os.environ.get(ALLOW_WORKSPACE_SIBLING_APPS_ENV))
+
+
+def _project_name_candidates(project_name: str | None) -> tuple[str, ...]:
+    text = str(project_name or "").strip()
+    if not text:
+        return ()
+    candidates: list[str] = []
+
+    def _add(candidate: str) -> None:
+        candidate = str(candidate or "").strip()
+        if candidate and candidate not in candidates:
+            candidates.append(candidate)
+
+    _add(text)
+    if text.endswith("_project"):
+        _add(text.removesuffix("_project"))
+    else:
+        _add(f"{text}_project")
+    return tuple(candidates)
+
+
 def _resolve_pycharm_repo_root(
     export_context: NotebookExportContext | None,
     *,
@@ -190,7 +221,11 @@ def _normalize_repo_root_hint(value: str | Path | None) -> str:
     return str(path)
 
 
-def _iter_checkout_workspace_apps_dirs(repo_root_hint: str | Path | None) -> Iterable[Path]:
+def _iter_checkout_workspace_apps_dirs(
+    repo_root_hint: str | Path | None,
+    *,
+    allow_siblings: bool = False,
+) -> Iterable[Path]:
     repo_root = _normalize_repo_root_hint(repo_root_hint)
     if not repo_root:
         return
@@ -212,6 +247,9 @@ def _iter_checkout_workspace_apps_dirs(repo_root_hint: str | Path | None) -> Ite
 
     yield from _emit(checkout_root / "src" / "agilab" / "apps")
     yield from _emit(checkout_root / "apps")
+
+    if not allow_siblings:
+        return
 
     workspace_root = checkout_root.parent
     try:
@@ -284,7 +322,7 @@ def _app_root_matches_project(app_root: str | Path | None, project_name: str) ->
     if not app_root:
         return False
     try:
-        return Path(app_root).expanduser().name == project_name
+        return Path(app_root).expanduser().name in _project_name_candidates(project_name)
     except (OSError, RuntimeError, TypeError, ValueError):
         return False
 
@@ -297,6 +335,7 @@ def _iter_valid_app_roots(
 ) -> Iterable[str]:
     seen: set[str] = set()
     project_name = str(project_name or "").strip()
+    project_candidates = _project_name_candidates(project_name)
 
     def _emit(
         candidate: str | Path | None,
@@ -325,8 +364,9 @@ def _iter_valid_app_roots(
         apps_root = _normalize_path(apps_dir)
         if not apps_root:
             continue
-        yield from _emit(Path(apps_root) / project_name)
-        yield from _emit(Path(apps_root) / "builtin" / project_name)
+        for candidate_name in project_candidates:
+            yield from _emit(Path(apps_root) / candidate_name)
+            yield from _emit(Path(apps_root) / "builtin" / candidate_name)
 
 
 def _load_related_pages_from_settings(settings_path: Path | None) -> tuple[str, ...]:
@@ -476,6 +516,7 @@ def build_notebook_export_context(
         except (OSError, RuntimeError, TypeError, ValueError):
             repo_root = ""
     repo_apps_dir = Path(repo_root) / "src" / "agilab" / "apps" if repo_root else None
+    allow_workspace_sibling_apps = _allow_workspace_sibling_apps()
     active_app = next(
         iter(
             _iter_valid_app_roots(
@@ -489,7 +530,10 @@ def build_notebook_export_context(
                     getattr(env, "builtin_apps_path", None),
                     getattr(env, "apps_repository_root", None),
                     repo_apps_dir,
-                    *_iter_checkout_workspace_apps_dirs(repo_root),
+                    *_iter_checkout_workspace_apps_dirs(
+                        repo_root,
+                        allow_siblings=allow_workspace_sibling_apps,
+                    ),
                 ),
             )
         ),
@@ -520,6 +564,7 @@ def build_notebook_export_context(
         app_settings_file=str(settings_file) if settings_file is not None else "",
         pages_root=pages_root,
         repo_root=repo_root,
+        allow_workspace_sibling_apps=allow_workspace_sibling_apps,
         related_pages=related_page_records,
     )
 
@@ -666,9 +711,38 @@ def _helper_cell(payload: dict[str, Any]) -> str:
             if not path_value:
                 return False
             try:
-                return Path(path_value).expanduser().name == project_name
+                return Path(path_value).expanduser().name in _project_name_candidates(project_name)
             except Exception:
                 return False
+
+
+        def _project_name_candidates(project_name):
+            text = str(project_name or "").strip()
+            if not text:
+                return []
+            candidates = []
+
+            def add(candidate):
+                candidate = str(candidate or "").strip()
+                if candidate and candidate not in candidates:
+                    candidates.append(candidate)
+
+            add(text)
+            if text.endswith("_project"):
+                add(text.removesuffix("_project"))
+            else:
+                add(f"{{text}}_project")
+            return candidates
+
+
+        def _truthy_env(name):
+            return str(os.environ.get(name) or "").strip().lower() in {{"1", "true", "yes", "y", "on"}}
+
+
+        def _allow_workspace_sibling_apps():
+            return bool(AGILAB_NOTEBOOK_EXPORT.get("allow_workspace_sibling_apps")) or _truthy_env(
+                "AGILAB_NOTEBOOK_EXPORT_ALLOW_WORKSPACE_SIBLINGS"
+            )
 
 
         def _looks_like_source_checkout(path_value):
@@ -727,25 +801,27 @@ def _helper_cell(payload: dict[str, Any]) -> str:
                 yield from emit(repo_root / "src" / "agilab" / "apps")
                 yield from emit(repo_root / "apps")
 
-                workspace_root = repo_root.parent
-                try:
-                    siblings = sorted(
-                        candidate
-                        for candidate in workspace_root.iterdir()
-                        if candidate.is_dir() and candidate != repo_root
-                    )
-                except OSError:
-                    siblings = []
-                for sibling in siblings:
-                    yield from emit(sibling / "apps")
-                    yield from emit(sibling / "src" / "agilab" / "apps")
+                if _allow_workspace_sibling_apps():
+                    workspace_root = repo_root.parent
+                    try:
+                        siblings = sorted(
+                            candidate
+                            for candidate in workspace_root.iterdir()
+                            if candidate.is_dir() and candidate != repo_root
+                        )
+                    except OSError:
+                        siblings = []
+                    for sibling in siblings:
+                        yield from emit(sibling / "apps")
+                        yield from emit(sibling / "src" / "agilab" / "apps")
 
-            apps_repository = str(os.environ.get("APPS_REPOSITORY") or "").strip()
-            if apps_repository:
-                repo_path = Path(apps_repository).expanduser()
-                yield from emit(repo_path)
-                yield from emit(repo_path / "apps")
-                yield from emit(repo_path / "src" / "agilab" / "apps")
+            for env_key in ("APPS_REPOSITORY", "AGILAB_APPS_REPOSITORY"):
+                apps_repository = str(os.environ.get(env_key) or "").strip()
+                if apps_repository:
+                    repo_path = Path(apps_repository).expanduser()
+                    yield from emit(repo_path)
+                    yield from emit(repo_path / "apps")
+                    yield from emit(repo_path / "src" / "agilab" / "apps")
 
 
         def resolve_active_app_root(app_name=None):
@@ -757,18 +833,19 @@ def _helper_cell(payload: dict[str, Any]) -> str:
 
             if project_name:
                 for apps_dir in _candidate_apps_directories():
-                    for candidate in (apps_dir / project_name, apps_dir / "builtin" / project_name):
-                        candidate_text = _normalized_path(candidate)
-                        if _is_valid_active_app_root(candidate_text):
-                            AGILAB_NOTEBOOK_EXPORT["active_app"] = candidate_text
-                            return candidate_text
+                    for project_candidate in _project_name_candidates(project_name):
+                        for candidate in (apps_dir / project_candidate, apps_dir / "builtin" / project_candidate):
+                            candidate_text = _normalized_path(candidate)
+                            if _is_valid_active_app_root(candidate_text):
+                                AGILAB_NOTEBOOK_EXPORT["active_app"] = candidate_text
+                                return candidate_text
 
             raise ValueError(
                 "Unable to resolve a valid AGILAB app root for exported notebook "
                 f"project={{project_name or app_name or '<unknown>'}}. "
                 f"Current active_app={{active_app or '<missing>'}}. "
                 "Re-export the notebook from AGILAB with the correct project selected, "
-                "or set APPS_REPOSITORY so the project root can be discovered."
+                "or set APPS_REPOSITORY / AGILAB_APPS_REPOSITORY so the project root can be discovered."
             )
 
 
@@ -1188,6 +1265,7 @@ def build_notebook_document(
         "pages_root": export_context.pages_root,
         "repo_root": export_context.repo_root,
         "export_mode": export_context.export_mode,
+        "allow_workspace_sibling_apps": export_context.allow_workspace_sibling_apps,
         "related_pages": [asdict(page) for page in export_context.related_pages],
         "steps": step_records,
         "steps_file": str(Path(toml_path)),

--- a/test/test_pipeline_editor.py
+++ b/test/test_pipeline_editor.py
@@ -1431,7 +1431,7 @@ def test_build_notebook_export_context_ignores_valid_active_app_for_other_projec
     assert tuple(page.module for page in context.related_pages) == ("view_demo",)
 
 
-def test_build_notebook_export_context_normalizes_repo_root_hint_and_prefers_sibling_workspace_apps_dir(
+def test_build_notebook_export_context_normalizes_repo_root_hint_without_sibling_workspace_scan(
     tmp_path,
 ):
     workspace_root = tmp_path / "workspace"
@@ -1472,6 +1472,96 @@ def test_build_notebook_export_context_normalizes_repo_root_hint_and_prefers_sib
     )
 
     assert context.repo_root == str(public_repo)
+    assert context.active_app == ""
+    assert tuple(page.module for page in context.related_pages) == ("view_demo",)
+
+
+def test_build_notebook_export_context_can_scan_sibling_workspace_when_enabled(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("AGILAB_NOTEBOOK_EXPORT_ALLOW_WORKSPACE_SIBLINGS", "1")
+    workspace_root = tmp_path / "workspace"
+    public_repo = workspace_root / "agilab"
+    (public_repo / "src" / "agilab").mkdir(parents=True, exist_ok=True)
+    (public_repo / ".idea").mkdir(parents=True, exist_ok=True)
+
+    pages_root = public_repo / "src" / "agilab" / "apps-pages"
+    page_script = pages_root / "view_demo" / "src" / "view_demo" / "view_demo.py"
+    page_script.parent.mkdir(parents=True, exist_ok=True)
+    page_script.write_text("print('page')\n", encoding="utf-8")
+
+    private_repo = workspace_root / "thales_agilab"
+    source_app = private_repo / "apps" / "demo_project"
+    (source_app / "src").mkdir(parents=True, exist_ok=True)
+    (source_app / "pyproject.toml").write_text("[project]\nname='demo_project'\n", encoding="utf-8")
+    (source_app / "src" / "app_settings.toml").write_text("[pages]\nview_module=['view_demo']\n", encoding="utf-8")
+
+    workspace_settings = tmp_path / ".agilab" / "apps" / "demo_project" / "app_settings.toml"
+    workspace_settings.parent.mkdir(parents=True, exist_ok=True)
+    workspace_settings.write_text("[pages]\nview_module=['view_demo']\n", encoding="utf-8")
+
+    env = SimpleNamespace(
+        AGILAB_PAGES_ABS=pages_root,
+        active_app="",
+        app_settings_file=workspace_settings,
+        apps_repository_root="",
+        resolve_user_app_settings_file=lambda app_name, ensure_exists=False: workspace_settings,
+        find_source_app_settings_file=lambda app_name: None,
+        read_agilab_path=lambda: public_repo / "src" / "agilab",
+    )
+
+    context = pipeline_editor.build_notebook_export_context(
+        env,
+        Path("demo_project"),
+        tmp_path / "export" / "demo_project" / "lab_steps.toml",
+        project_name="demo_project",
+    )
+
+    assert context.repo_root == str(public_repo)
+    assert context.active_app == str(source_app)
+    assert context.allow_workspace_sibling_apps is True
+    assert tuple(page.module for page in context.related_pages) == ("view_demo",)
+
+
+def test_build_notebook_export_context_accepts_project_suffix_alias(tmp_path):
+    pages_root = tmp_path / "apps-pages"
+    page_script = pages_root / "view_demo" / "src" / "view_demo" / "view_demo.py"
+    page_script.parent.mkdir(parents=True, exist_ok=True)
+    page_script.write_text("print('page')\n", encoding="utf-8")
+
+    source_app = tmp_path / "apps" / "uav_graph_routing_project"
+    (source_app / "src").mkdir(parents=True, exist_ok=True)
+    (source_app / "pyproject.toml").write_text(
+        "[project]\nname='uav_graph_routing_project'\n",
+        encoding="utf-8",
+    )
+    (source_app / "src" / "app_settings.toml").write_text("[pages]\nview_module=['view_demo']\n", encoding="utf-8")
+
+    workspace_settings = tmp_path / ".agilab" / "apps" / "uav_graph_routing" / "app_settings.toml"
+    workspace_settings.parent.mkdir(parents=True, exist_ok=True)
+    workspace_settings.write_text("[pages]\nview_module=['view_demo']\n", encoding="utf-8")
+
+    env = SimpleNamespace(
+        AGILAB_PAGES_ABS=pages_root,
+        active_app=source_app,
+        app_settings_file=workspace_settings,
+        apps_path=tmp_path / "apps",
+        builtin_apps_path=tmp_path / "apps" / "builtin",
+        apps_repository_root="",
+        resolve_user_app_settings_file=lambda app_name, ensure_exists=False: workspace_settings,
+        find_source_app_settings_file=lambda app_name: source_app / "src" / "app_settings.toml",
+        read_agilab_path=lambda: tmp_path / "repo",
+    )
+
+    context = pipeline_editor.build_notebook_export_context(
+        env,
+        Path("uav_graph_routing"),
+        tmp_path / "export" / "uav_graph_routing" / "lab_steps.toml",
+        project_name="uav_graph_routing",
+    )
+
+    assert context.project_name == "uav_graph_routing"
     assert context.active_app == str(source_app)
     assert tuple(page.module for page in context.related_pages) == ("view_demo",)
 
@@ -1638,9 +1728,11 @@ def test_notebook_helper_replays_app_shorthand_steps_as_agi_run_scripts(tmp_path
     ) in captured["script"]
 
 
+@pytest.mark.parametrize("env_key", ["APPS_REPOSITORY", "AGILAB_APPS_REPOSITORY"])
 def test_notebook_helper_replays_app_shorthand_steps_from_apps_repository_when_active_app_is_stale(
     tmp_path,
     monkeypatch,
+    env_key,
 ):
     export_dir = tmp_path / "export" / "demo_project"
     export_dir.mkdir(parents=True, exist_ok=True)
@@ -1701,7 +1793,7 @@ def test_notebook_helper_replays_app_shorthand_steps_from_apps_repository_when_a
         return _Result()
 
     original_run = namespace["subprocess"].run
-    monkeypatch.setenv("APPS_REPOSITORY", str(repo_apps))
+    monkeypatch.setenv(env_key, str(repo_apps))
     try:
         namespace["subprocess"].run = _fake_run
         namespace["run_agilab_step"](0, capture_output=False)
@@ -1797,9 +1889,18 @@ def test_notebook_helper_replays_app_shorthand_steps_when_active_app_is_other_pr
     assert "flight_project" not in captured["script"]
 
 
+@pytest.mark.parametrize(
+    ("allow_siblings", "expect_private_resolution"),
+    [(False, False), (True, True)],
+)
 def test_notebook_helper_replays_app_shorthand_steps_from_sibling_workspace_when_active_app_is_missing(
     tmp_path,
+    monkeypatch,
+    allow_siblings,
+    expect_private_resolution,
 ):
+    if allow_siblings:
+        monkeypatch.setenv("AGILAB_NOTEBOOK_EXPORT_ALLOW_WORKSPACE_SIBLINGS", "1")
     workspace_root = tmp_path / "workspace"
     public_repo = workspace_root / "agilab"
     (public_repo / "src" / "agilab").mkdir(parents=True, exist_ok=True)
@@ -1866,6 +1967,11 @@ def test_notebook_helper_replays_app_shorthand_steps_from_sibling_workspace_when
     original_run = namespace["subprocess"].run
     try:
         namespace["subprocess"].run = _fake_run
+        if not expect_private_resolution:
+            with pytest.raises(ValueError, match="Unable to resolve a valid AGILAB app root"):
+                namespace["run_agilab_step"](0, capture_output=False)
+            assert captured == {}
+            return
         namespace["run_agilab_step"](0, capture_output=False)
     finally:
         namespace["subprocess"].run = original_run


### PR DESCRIPTION
## Summary

Harden notebook export app discovery so exported notebooks no longer discover sibling workspace/private apps by default.

This keeps public notebook exports from implicitly resolving private repositories while preserving an explicit opt-in path for standalone/private workflows through `AGILAB_NOTEBOOK_EXPORT_ALLOW_WORKSPACE_SIBLINGS=1`.

Also normalizes `foo` / `foo_project` app matching and supports both `APPS_REPOSITORY` and `AGILAB_APPS_REPOSITORY` inside exported notebook helper code.

## Validation

- `uv --preview-features extra-build-dependencies run python -m py_compile src/agilab/notebook_export_support.py test/test_pipeline_editor.py`
- `uv --preview-features extra-build-dependencies run pytest -q test/test_pipeline_editor.py -k "notebook or pycharm"`
- `uv --preview-features extra-build-dependencies run pytest -q test/test_pipeline_editor.py`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files src/agilab/notebook_export_support.py test/test_pipeline_editor.py`
- `git diff --cached --check`
