### PR TITLE
[codex] Refresh README KPI and docs alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,9 @@ AGILAB is best evaluated as an AI/ML experimentation workbench, not as a replace
   <a href="https://kaggle.com/kernels/welcome?src=https://github.com/ThalesGroup/agilab/blob/main/examples/notebook_quickstart/agi_core_kaggle_first_run.ipynb"><img src="https://img.shields.io/badge/agi--core-notebook-1D4ED8?style=for-the-badge" alt="agi-core notebook" /></a>
 </p>
 
-The public AGILAB Space opens the lightweight built-in `flight_project` path by
-default. Use it for the first proof that the web UI, execution path, and
-analysis page work. The UAV Relay Queue demo (`uav_relay_queue_project`) is the
-separate advanced RL/full-tour scenario referenced in the docs; it is not the
-default landing app.
+The public AGILAB Space is the fastest browser preview. It opens the lightweight
+`flight_project` path by default; advanced scenarios such as
+`uav_relay_queue_project` are documented in the demo guide.
 
 ## First Run
 
@@ -68,26 +66,15 @@ cd agilab
 uv --preview-features extra-build-dependencies run streamlit run src/agilab/About_agilab.py
 ```
 
-Follow the in-app pages from `PROJECT` to `ANALYSIS`. Success means fresh output under `~/log/execute/flight/` and a visible analysis result. To collect the same check as JSON:
+Follow the in-app pages from `PROJECT` to `ANALYSIS`. To collect the same check
+as JSON:
 
 ```bash
 uv --preview-features extra-build-dependencies run python tools/newcomer_first_proof.py --json
 ```
 
-The JSON proof writes a stable `run_manifest.json` under
-`~/log/execute/flight/`. That manifest records the proof command, Python and
-platform context, active app, timing, artifact references, and validation
-status so the wizard, compatibility report, KPI bundle, and release-decision
-gate share one factual run record.
-
-This path is intentionally CLI-first. PyCharm run configurations are maintained
-for contributors who want IDE debugging, but they are not required for install,
-execution, or analysis. The same flows are available from the web UI, shell
-commands, and checked-in wrappers under `tools/run_configs/`.
-
-To keep the first install bounded, AGILAB does not run the full test suite by
-default. Add `--test-root`, `--test-apps`, or `--test-core` only when you want
-installer-time validation rather than the fastest first proof.
+The JSON proof writes `run_manifest.json` under `~/log/execute/flight/`. For
+installer flags, IDE run configs, and troubleshooting, use the Quick Start docs.
 
 ## Published Package
 
@@ -102,313 +89,72 @@ Use it for a quick package-level check. For the most representative first proof,
 prefer the source-checkout `flight_project` path above because it exercises the
 same app installation, execution, and analysis flow documented in the web UI.
 
-## Notebook Pipeline Import
+## App Repository Updates
 
-AGILAB now exposes a notebook-to-pipeline import report:
-
-```bash
-uv --preview-features extra-build-dependencies run python tools/notebook_pipeline_import_report.py --compact
-uv --preview-features extra-build-dependencies run python tools/notebook_roundtrip_report.py --compact
-uv --preview-features extra-build-dependencies run python tools/notebook_union_environment_report.py --compact
-```
-
-The report reads a checked-in `.ipynb`, projects markdown cells, code cells,
-import hints, execution-count metadata, and artifact references into AGILAB
-pipeline-step metadata, and writes a round-tripped JSON proof plus a richer
-`lab_steps.toml` preview. The existing `PIPELINE` notebook upload path now uses
-the same importer. This is a `not_executed_import` contract: it proves
-notebook-to-pipeline import shape without executing notebook cells or claiming
-a single-kernel union environment.
-
-The notebook round-trip report validates
-`lab_steps.toml -> supervisor notebook -> import -> lab_steps preview` and
-checks that saved step description, prompt, model, code, runtime, import hints,
-and artifact references survive the round trip.
-
-The notebook union-environment report plans a `single-kernel union notebook`
-only when all steps share a compatible `runpy`/current-kernel runtime. Mixed
-runtimes or step environments are marked `supervisor_notebook_required`.
-
-## Data Connector Facility
-
-AGILAB now validates first-class SQL, OpenSearch, and object-storage connector
-definitions:
+When `APPS_REPOSITORY` points at an external apps repository, rerun the
+installer after app changes:
 
 ```bash
-uv --preview-features extra-build-dependencies run python tools/data_connector_facility_report.py --compact
+./install.sh --non-interactive --apps-repository /path/to/apps-repository --install-apps all
 ```
 
-The data connector facility report reads a plain-text TOML catalog, validates
-kind-specific required fields, requires environment references for remote
-credentials, and runs in `contract_validation_only` mode without opening live
-network connections.
-
-Connector-aware app/page resolution is covered by a separate report:
-
-```bash
-uv --preview-features extra-build-dependencies run python tools/data_connector_resolution_report.py --compact
-```
-
-The data connector resolution report resolves connector IDs from an
-app-settings-style sample, proves page-specific connector references for
-analysis views, preserves `legacy_path_fallback` rows for migration, and runs
-in `contract_resolution_only` mode without network probes.
-
-Connector health/status probes are planned behind an explicit operator opt-in
-boundary:
-
-```bash
-uv --preview-features extra-build-dependencies run python tools/data_connector_health_report.py --compact
-```
-
-The data connector health report emits a `health_probe_plan_only` proof for
-SQL, OpenSearch, and object-storage probes. Public evidence records planned
-probe types and `unknown_not_probed` statuses without opening networks or
-claiming live health.
-
-Operator-triggered health probes are exposed as explicit action rows:
-
-```bash
-uv --preview-features extra-build-dependencies run python tools/data_connector_health_actions_report.py --compact
-```
-
-The data connector health actions report runs in
-`operator_trigger_contract_only` mode, defines one opt-in action per connector
-probe, and keeps public evidence at zero executed network probes.
-
-Connector state and connector-derived provenance also have a static UI preview:
-
-```bash
-uv --preview-features extra-build-dependencies run python tools/data_connector_ui_preview_report.py --compact
-```
-
-The data connector UI preview report writes JSON+HTML evidence in
-`static_ui_preview_only` mode, rendering connector cards, page bindings,
-legacy fallbacks, and the health opt-in boundary without executing connector
-probes.
-
-The Release Decision page now renders the same connector state and
-connector-derived provenance through a live Streamlit component contract:
-
-```bash
-uv --preview-features extra-build-dependencies run python tools/data_connector_live_ui_report.py --compact
-```
-
-The data connector live UI report runs in `streamlit_render_contract_only`
-mode, proves the Release Decision hook, renders connector cards/page
-bindings/fallbacks/probe plans, and keeps network probes at zero.
-
-Built-in apps can now carry app-local connector catalogs next to
-`app_settings.toml`:
-
-```bash
-uv --preview-features extra-build-dependencies run python tools/data_connector_app_catalogs_report.py --compact
-```
-
-The data connector app catalogs report runs in `app_catalog_validation_only`
-mode, validates app-local connector catalogs for every non-template built-in
-app, preserves legacy path fallbacks, and keeps network probes at zero.
-
-## Reduce Contract
-
-AGILAB now exposes a first-class `agi_node` reduce contract for distributed
-work-plan results. `ReducePartial` captures worker outputs, `ReduceContract`
-declares merge semantics and validation hooks, and `ReduceArtifact` serializes
-the named reducer result with a stable schema.
-
-Existing apps can keep their app-owned aggregation while they migrate. The
-`execution_pandas_project` and `execution_polars_project` built-in benchmark
-apps, plus the user-facing `flight_project`, `meteo_forecast_project`,
-`uav_queue_project`, and `uav_relay_queue_project`, now emit named
-`reduce_summary_worker_<id>.json` `ReduceArtifact` files. The public reducer
-benchmark validates 8 partials / 80,000 synthetic items in `0.003s` against a
-`5.0s` target:
-
-```bash
-uv --preview-features extra-build-dependencies run python tools/reduce_contract_benchmark.py --json
-```
-
-The Release Decision evidence view discovers those reduce artifacts, validates
-their schema, and shows reducer name, partial count, artifact path, benchmark
-row/source/execution fields, flight trajectory row/aircraft/speed fields,
-meteo forecast MAE/RMSE/MAPE fields, and UAV queue-family packet/PDR fields
-when present.
-
-A repository guardrail now requires every non-template built-in app to expose a
-reducer contract. `mycode_project` is the only template-only exemption because
-it has placeholder worker hooks and no concrete merge output; future apps or
-templates must opt in when they start producing durable worker summaries.
-The compact public KPI evidence bundle reports this as
-`reduce_contract_adoption_guardrail`. The
-remaining scope is future adoption discipline, not the shared reducer interface,
-migrated artifacts, artifact surfacing, or the public benchmark.
-
-## Multi-app DAG Contract
-
-AGILAB now includes a first cross-app orchestration contract. The checked-in
-sample `docs/source/data/multi_app_dag_sample.json` links `uav_queue_project`
-to `uav_relay_queue_project` through a `queue_metrics` artifact handoff, and:
-
-```bash
-uv --preview-features extra-build-dependencies run python tools/multi_app_dag_report.py --compact
-```
-
-validates schema, built-in app nodes, acyclic dependencies, and artifact
-handoffs. This is a contract/report baseline, not a full cross-app runner yet.
-
-## Global Pipeline DAG Report
-
-AGILAB also exposes the first product-level DAG evidence view. It combines the
-multi-app DAG sample with the checked-in `pipeline_view.dot` files for
-`uav_queue_project` and `uav_relay_queue_project`:
-
-```bash
-uv --preview-features extra-build-dependencies run python tools/global_pipeline_dag_report.py --compact
-```
-
-The report emits one read-only graph with app nodes, app-local pipeline steps,
-and the cross-app `queue_metrics` artifact edge. It does not execute the apps,
-schedule retries, or provide operator UI state yet.
-
-## Global DAG Execution Plan
-
-The next runner-facing contract turns that graph into ordered runnable units
-without executing them:
-
-```bash
-uv --preview-features extra-build-dependencies run python tools/global_pipeline_execution_plan_report.py --compact
-```
-
-The report marks `queue_baseline` and `relay_followup` as
-`pending/not_executed`, records `relay_followup` as blocked on the
-`queue_metrics` artifact from `queue_baseline`, and keeps provenance back to
-the multi-app DAG sample plus each app-local `pipeline_view.dot`.
-
-## Global DAG Runner State
-
-AGILAB now projects that execution plan into read-only dispatch and operator
-state without executing apps:
-
-```bash
-uv --preview-features extra-build-dependencies run python tools/global_pipeline_runner_state_report.py --compact
-```
-
-The report marks `queue_baseline` as `runnable` and `relay_followup` as
-`blocked`, models `pending -> runnable -> completed/failed` plus retry and
-partial-rerun transitions, and records operator-facing readiness messages with
-provenance back to the execution plan, DAG sample, and `pipeline_view.dot`
-files. Full live operator UI remains future work.
-
-## Global DAG Dispatch Persistence
-
-AGILAB also includes the first persisted dispatch-state proof:
-
-```bash
-uv --preview-features extra-build-dependencies run python tools/global_pipeline_dispatch_state_report.py --compact
-```
-
-The report writes and reads back a persisted run-state JSON proof. It records
-`queue_baseline completed`, publishes `queue_metrics`, moves
-`relay_followup runnable`, and keeps timestamps, retry counters,
-partial-rerun flags, operator messages, and provenance. This is durable state
-transition evidence; the follow-on smoke below covers the real app-entry
-dispatch path across both DAG units.
-
-## Global DAG App Dispatch Smoke
-
-AGILAB now executes the two-unit global DAG through checked-in app entries:
-
-```bash
-uv --preview-features extra-build-dependencies run python tools/global_pipeline_app_dispatch_smoke_report.py --compact
-```
-
-The report runs real `queue_baseline` execution through `uav_queue_project`,
-then real `relay_followup` execution through `uav_relay_queue_project`. It
-writes `queue_metrics`, `relay_metrics`, and reducer artifacts into a temp
-workspace, persists the dispatch-state JSON, and records real queue_baseline
-and relay_followup execution. This is a full-DAG app-dispatch smoke, not live
-operator UI.
-
-## Global DAG Operator State
-
-AGILAB also projects that persisted full-DAG dispatch state into an
-operator-facing state contract:
-
-```bash
-uv --preview-features extra-build-dependencies run python tools/global_pipeline_operator_state_report.py --compact
-```
-
-The report reads the persisted full-DAG dispatch smoke state, exposes
-operator-visible state for both completed units, shows the queue-to-relay
-artifact handoff, and lists retry/partial-rerun actions available for future
-operator flows. This is a state contract, not live UI.
-
-## Global DAG Dependency View
-
-AGILAB now projects the operator-state proof into a cross-app dependency view:
-
-```bash
-uv --preview-features extra-build-dependencies run python tools/global_pipeline_dependency_view_report.py --compact
-```
-
-The report exposes upstream/downstream dependency visualization for
-`queue_baseline -> relay_followup`, including the `queue_metrics` artifact
-edge, producer/consumer apps, adjacency lists, artifact flow, and linkage back
-to the persisted operator-state proof. This is a dependency-view contract, not
-a live UI component.
-
-## Global DAG Live State Updates
-
-AGILAB now projects the dependency view into live orchestration-state updates:
-
-```bash
-uv --preview-features extra-build-dependencies run python tools/global_pipeline_live_state_updates_report.py --compact
-```
-
-The report emits a deterministic update stream for the full DAG: graph-ready,
-unit-state, artifact-state, dependency-state, and operator-action refresh
-payloads for `queue_baseline`, `relay_followup`, and `queue_metrics`. This is
-an update-payload contract, not a streaming service or UI renderer.
-
-## Global DAG Operator Actions
-
-AGILAB now executes persisted operator action requests through real app-entry
-replays:
-
-```bash
-uv --preview-features extra-build-dependencies run python tools/global_pipeline_operator_actions_report.py --compact
-```
-
-The report reads live-state update payloads, accepts `queue_baseline:retry` and
-`relay_followup:partial_rerun`, runs the corresponding queue and relay app
-entries, and persists the action outcomes plus output artifacts. This is retry
-and partial-rerun action execution, not a UI control surface.
-
-## Global DAG Operator UI
-
-AGILAB now renders the persisted global-DAG state into operator UI components:
-
-```bash
-uv --preview-features extra-build-dependencies run python tools/global_pipeline_operator_ui_report.py --compact
-```
-
-The report builds status, unit-card, dependency-graph, update-timeline,
-action-control, and artifact-table components, writes a static HTML proof, and
-verifies those operator UI components render persisted state and support
-operator actions. The components are reusable evidence; product page placement
-can evolve without changing the contract.
+Existing non-link app/page directories are moved to `<name>.previous.<timestamp>`
+before the repository copy is linked, so repository updates win over stale local
+copies. See
+[Service mode and paths](https://thalesgroup.github.io/agilab/service_mode_and_paths.html)
+for the full path contract.
+
+## Evidence And Scope
+
+The README is only the entry page. Detailed capability evidence, compatibility
+status, and roadmap scope live in:
+
+- [Features](https://thalesgroup.github.io/agilab/features.html)
+- [Compatibility matrix](https://thalesgroup.github.io/agilab/compatibility-matrix.html)
+- [MLOps positioning](https://thalesgroup.github.io/agilab/agilab-mlops-positioning.html)
+- [Future work](https://thalesgroup.github.io/agilab/roadmap/agilab-future-work.html)
+
+<!-- Evidence anchors for local public-evidence checks; rendered docs remain the
+source of truth for explanations.
+tools/newcomer_first_proof.py --json
+run_manifest.json
+tools/reduce_contract_benchmark.py --json
+tools/multi_app_dag_report.py --compact
+tools/global_pipeline_dag_report.py --compact
+tools/global_pipeline_execution_plan_report.py --compact
+tools/global_pipeline_runner_state_report.py --compact
+tools/global_pipeline_dispatch_state_report.py --compact
+tools/global_pipeline_app_dispatch_smoke_report.py --compact
+tools/global_pipeline_operator_state_report.py --compact
+tools/global_pipeline_dependency_view_report.py --compact
+tools/global_pipeline_live_state_updates_report.py --compact
+tools/global_pipeline_operator_actions_report.py --compact
+tools/global_pipeline_operator_ui_report.py --compact
+tools/notebook_pipeline_import_report.py --compact
+tools/notebook_roundtrip_report.py --compact
+tools/notebook_union_environment_report.py --compact
+tools/data_connector_facility_report.py --compact
+tools/data_connector_resolution_report.py --compact
+tools/data_connector_health_report.py --compact
+tools/data_connector_health_actions_report.py --compact
+tools/data_connector_runtime_adapters_report.py --compact
+tools/data_connector_ui_preview_report.py --compact
+tools/data_connector_live_ui_report.py --compact
+tools/data_connector_app_catalogs_report.py --compact
+-->
 
 ## Evaluation Snapshot
 
-CODEX 5.5 working scores, not production MLOps claims:
+Current CODEX 5.5 working scores, out of 5 and refreshed from the public KPI
+bundle, not production MLOps claims:
 
-| KPI | Score | Evidence | Limit |
+| KPI | Current score (/5) | Evidence | Limit |
 |---|---|---:|---|
-| Ease of adoption | `3.5 / 5` | Hosted Space, CLI-first local `flight_project` path, opt-in installer tests, local smoke: `5.86s` vs `600s`, and fresh external-machine smoke on April 25, 2026: `26.87s` vs `600s`. | Validated locally, on one external macOS machine, on AI Lightning, on Hugging Face, on one bare-metal cluster, and on one VM-based cluster. Remaining validation gap: Azure, AWS, and GCP cloud deployments. |
-| Research experimentation | `4.0 / 5` | Templates, isolated `uv`, `lab_steps.toml`, MLflow-tracked runs, analysis pages, shared `agi_node` reduce contract, surfaced pandas/polars benchmark, flight, meteo forecast, and UAV queue-family reduce artifacts, a non-template built-in app guardrail, public reduce benchmark: `0.003s` vs `5.0s`, multi-app DAG report, global pipeline DAG report, global execution-plan report, global runner-state report, global dispatch-state persistence report, global app-dispatch smoke report, global operator-state report, global dependency-view report, global live-update report, global operator-action report, global operator-UI report, notebook-to-pipeline import report, notebook round-trip report, notebook union-environment report, data connector facility report, data connector resolution report, data connector health report, data connector health actions report, data connector UI preview report, data connector live UI report, and data connector app catalogs report. | Future apps/templates must opt in when they produce concrete merge outputs. |
-| Engineering prototyping | `4.0 / 5` | `app_args_form.py`, `pipeline_view`, reusable history, analysis-page templates, a guided in-product first-proof wizard, stable `run_manifest.json` evidence consumed by the KPI bundle, the multi-app DAG contract, a read-only global pipeline graph, pending execution-plan units, read-only runnable/blocked operator state, persisted queue-to-relay dispatch-state transition proof, real two-unit global DAG app dispatch smoke, operator-visible retry/partial-rerun action state, cross-app upstream/downstream dependency visualization, deterministic full-DAG live-update payloads, retry/partial-rerun real app-entry action replay, reusable operator UI components, the notebook-to-pipeline import contract, compatible single-kernel union notebook planning, first-class connector definitions, connector-aware app/page resolution, opt-in connector health-probe planning, operator-triggered connector health action rows, static connector provenance UI preview, Release Decision connector provenance UI integration, and app-local connector catalogs. | Additional external replication beyond the current public first-proof paths is not claimed. |
+| Ease of adoption | `4.0 / 5` | Hosted Space, CLI-first local `flight_project` path, opt-in installer tests, local smoke: `5.86s` vs `600s`, fresh external-machine smoke on April 25, 2026: `26.87s` vs `600s`, plus AI Lightning, Hugging Face, bare-metal cluster, and VM-based cluster validation. | Remaining validation gap: Azure, AWS, and GCP cloud deployments. |
+| Research experimentation | `4.0 / 5` | Isolated `uv`, `lab_steps.toml`, MLflow-tracked runs, analysis pages, reduce artifacts, public reduce benchmark, notebook reports, connector reports, and multi-app/global DAG evidence summarized by the KPI bundle. | Future apps/templates must opt in when they produce concrete merge outputs. |
+| Engineering prototyping | `4.0 / 5` | `app_args_form.py`, `pipeline_view`, reusable history, analysis-page templates, first-proof wizard/manifest evidence, connector provenance UI contracts, and global DAG operator-state/action/UI contracts. | Additional external replication beyond the current public first-proof paths is not claimed. |
 | Production readiness | `3.0 / 5` | Release preflight, CI/coverage, service health gates, connector-registry release paths, provenance-tagged manifest-indexing, cross-release, and cross-run release-decision page export, security hardening checklist. | Production model serving, feature stores, online monitoring, drift detection, and enterprise governance are outside scope. |
-| Overall public evaluation | `3.6 / 5` | Mean of the four scored public KPIs: `(3.5 + 4.0 + 4.0 + 3.0) / 4 = 3.625`. Cross-KPI evidence bundle and workflow-backed compatibility report documented in the compatibility matrix. | Alpha-stage software; not a production MLOps platform. |
+| Overall public evaluation | `3.8 / 5` | Mean of the four scored public KPIs: `(4.0 + 4.0 + 4.0 + 3.0) / 4 = 3.75`. Cross-KPI evidence bundle and workflow-backed compatibility report documented in the compatibility matrix. | Alpha-stage software; not a production MLOps platform. |
 
 ## Read Next
 

--- a/README.pypi.md
+++ b/README.pypi.md
@@ -22,11 +22,9 @@ one coherent path before hardened assets move to deployment-focused systems.
 [![AGILAB Space](https://img.shields.io/badge/AGILAB-Space-0F766E?style=for-the-badge)](https://huggingface.co/spaces/jpmorard/agilab)
 [![agi-core notebook](https://img.shields.io/badge/agi--core-notebook-1D4ED8?style=for-the-badge)](https://kaggle.com/kernels/welcome?src=https://github.com/ThalesGroup/agilab/blob/main/examples/notebook_quickstart/agi_core_kaggle_first_run.ipynb)
 
-The public AGILAB Space opens the lightweight built-in `flight_project` path by
-default. Use it for the first proof that the web UI, execution path, and
-analysis page work. The UAV Relay Queue demo (`uav_relay_queue_project`) is the
-separate advanced RL/full-tour scenario referenced in the docs; it is not the
-default landing app.
+The public AGILAB Space is the fastest browser preview. It opens the lightweight
+`flight_project` path by default; advanced scenarios such as
+`uav_relay_queue_project` are documented in the demo guide.
 
 ## First Run
 
@@ -39,24 +37,15 @@ cd agilab
 uv --preview-features extra-build-dependencies run streamlit run src/agilab/About_agilab.py
 ```
 
-Follow the in-app pages from `PROJECT` to `ANALYSIS`. Success means fresh output
-under `~/log/execute/flight/` and a visible analysis result. To collect the same
-check as JSON:
+Follow the in-app pages from `PROJECT` to `ANALYSIS`. To collect the same check
+as JSON:
 
 ```bash
 uv --preview-features extra-build-dependencies run python tools/newcomer_first_proof.py --json
 ```
 
-The JSON proof writes a stable `run_manifest.json` under
-`~/log/execute/flight/`. That manifest records the proof command, Python and
-platform context, active app, timing, artifact references, and validation
-status so the wizard, compatibility report, KPI bundle, and release-decision
-gate share one factual run record.
-
-This path is intentionally CLI-first. PyCharm run configurations are maintained
-for contributors who want IDE debugging, but they are not required for install,
-execution, or analysis. The same flows are available from the web UI, shell
-commands, and checked-in wrappers.
+The JSON proof writes `run_manifest.json` under `~/log/execute/flight/`. For
+installer flags, IDE run configs, and troubleshooting, use the Quick Start docs.
 
 ## Install The Published Package
 
@@ -70,302 +59,38 @@ For the most representative first proof, prefer the source-checkout
 `flight_project` path above because it exercises the same app installation,
 execution, and analysis flow documented in the web UI.
 
-## Notebook Pipeline Import
+## App Repository Updates
 
-AGILAB now exposes a notebook-to-pipeline import report:
-
-```bash
-uv --preview-features extra-build-dependencies run python tools/notebook_pipeline_import_report.py --compact
-uv --preview-features extra-build-dependencies run python tools/notebook_roundtrip_report.py --compact
-uv --preview-features extra-build-dependencies run python tools/notebook_union_environment_report.py --compact
-```
-
-The report reads a checked-in `.ipynb`, projects markdown cells, code cells,
-import hints, execution-count metadata, and artifact references into AGILAB
-pipeline-step metadata, and writes a round-tripped JSON proof plus a richer
-`lab_steps.toml` preview. The existing `PIPELINE` notebook upload path now uses
-the same importer. This is a `not_executed_import` contract: it proves
-notebook-to-pipeline import shape without executing notebook cells or claiming
-a single-kernel union environment.
-
-The notebook round-trip report validates
-`lab_steps.toml -> supervisor notebook -> import -> lab_steps preview` and
-checks that saved step description, prompt, model, code, runtime, import hints,
-and artifact references survive the round trip.
-
-The notebook union-environment report plans a `single-kernel union notebook`
-only when all steps share a compatible `runpy`/current-kernel runtime. Mixed
-runtimes or step environments are marked `supervisor_notebook_required`.
-
-## Data Connector Facility
-
-AGILAB now validates first-class SQL, OpenSearch, and object-storage connector
-definitions:
+When `APPS_REPOSITORY` points at an external apps repository, rerun the
+installer after app changes:
 
 ```bash
-uv --preview-features extra-build-dependencies run python tools/data_connector_facility_report.py --compact
+./install.sh --non-interactive --apps-repository /path/to/apps-repository --install-apps all
 ```
 
-The data connector facility report reads a plain-text TOML catalog, validates
-kind-specific required fields, requires environment references for remote
-credentials, and runs in `contract_validation_only` mode without opening live
-network connections.
-
-Connector-aware app/page resolution is covered by a separate report:
-
-```bash
-uv --preview-features extra-build-dependencies run python tools/data_connector_resolution_report.py --compact
-```
-
-The data connector resolution report resolves connector IDs from an
-app-settings-style sample, proves page-specific connector references for
-analysis views, preserves `legacy_path_fallback` rows for migration, and runs
-in `contract_resolution_only` mode without network probes.
-
-Connector health/status probes are planned behind an explicit operator opt-in
-boundary:
-
-```bash
-uv --preview-features extra-build-dependencies run python tools/data_connector_health_report.py --compact
-```
-
-The data connector health report emits a `health_probe_plan_only` proof for
-SQL, OpenSearch, and object-storage probes. Public evidence records planned
-probe types and `unknown_not_probed` statuses without opening networks or
-claiming live health.
-
-Operator-triggered health probes are exposed as explicit action rows:
-
-```bash
-uv --preview-features extra-build-dependencies run python tools/data_connector_health_actions_report.py --compact
-```
-
-The data connector health actions report runs in
-`operator_trigger_contract_only` mode, defines one opt-in action per connector
-probe, and keeps public evidence at zero executed network probes.
-
-Connector state and connector-derived provenance also have a static UI preview:
-
-```bash
-uv --preview-features extra-build-dependencies run python tools/data_connector_ui_preview_report.py --compact
-```
-
-The data connector UI preview report writes JSON+HTML evidence in
-`static_ui_preview_only` mode, rendering connector cards, page bindings,
-legacy fallbacks, and the health opt-in boundary without executing connector
-probes.
-
-The Release Decision page now renders the same connector state and
-connector-derived provenance through a live Streamlit component contract:
-
-```bash
-uv --preview-features extra-build-dependencies run python tools/data_connector_live_ui_report.py --compact
-```
-
-The data connector live UI report runs in `streamlit_render_contract_only`
-mode, proves the Release Decision hook, renders connector cards/page
-bindings/fallbacks/probe plans, and keeps network probes at zero.
-
-Built-in apps can now carry app-local connector catalogs next to
-`app_settings.toml`:
-
-```bash
-uv --preview-features extra-build-dependencies run python tools/data_connector_app_catalogs_report.py --compact
-```
-
-The data connector app catalogs report runs in `app_catalog_validation_only`
-mode, validates app-local connector catalogs for every non-template built-in
-app, preserves legacy path fallbacks, and keeps network probes at zero.
-
-## Reduce Contract
-
-AGILAB now exposes a first-class `agi_node` reduce contract for distributed
-work-plan results. `ReducePartial` captures worker outputs, `ReduceContract`
-declares merge semantics and validation hooks, and `ReduceArtifact` serializes
-the named reducer result with a stable schema.
-
-Existing apps can keep their app-owned aggregation while they migrate. The
-`execution_pandas_project` and `execution_polars_project` built-in benchmark
-apps, plus the user-facing `meteo_forecast_project`, `uav_queue_project`, and
-`uav_relay_queue_project`, now emit named `reduce_summary_worker_<id>.json`
-`ReduceArtifact` files. The public reducer benchmark validates 8 partials /
-80,000 synthetic items in `0.003s` against a `5.0s` target:
-
-```bash
-uv --preview-features extra-build-dependencies run python tools/reduce_contract_benchmark.py --json
-```
-
-The compact public KPI evidence bundle reports this as
-`reduce_contract_adoption_guardrail`. The
-remaining scope is future adoption discipline, not the shared reducer interface,
-migrated artifacts, artifact surfacing, or the public benchmark.
-
-## Multi-app DAG Contract
-
-AGILAB now includes a first cross-app orchestration contract. The checked-in
-sample `docs/source/data/multi_app_dag_sample.json` links `uav_queue_project`
-to `uav_relay_queue_project` through a `queue_metrics` artifact handoff, and:
-
-```bash
-uv --preview-features extra-build-dependencies run python tools/multi_app_dag_report.py --compact
-```
-
-validates schema, built-in app nodes, acyclic dependencies, and artifact
-handoffs. This is a contract/report baseline, not a full cross-app runner yet.
-
-## Global Pipeline DAG Report
-
-AGILAB also exposes the first product-level DAG evidence view. It combines the
-multi-app DAG sample with the checked-in `pipeline_view.dot` files for
-`uav_queue_project` and `uav_relay_queue_project`:
-
-```bash
-uv --preview-features extra-build-dependencies run python tools/global_pipeline_dag_report.py --compact
-```
-
-The report emits one read-only graph with app nodes, app-local pipeline steps,
-and the cross-app `queue_metrics` artifact edge. It does not execute the apps,
-schedule retries, or provide operator UI state yet.
-
-## Global DAG Execution Plan
-
-The next runner-facing contract turns that graph into ordered runnable units
-without executing them:
-
-```bash
-uv --preview-features extra-build-dependencies run python tools/global_pipeline_execution_plan_report.py --compact
-```
-
-The report marks `queue_baseline` and `relay_followup` as
-`pending/not_executed`, records `relay_followup` as blocked on the
-`queue_metrics` artifact from `queue_baseline`, and keeps provenance back to
-the multi-app DAG sample plus each app-local `pipeline_view.dot`.
-
-## Global DAG Runner State
-
-AGILAB now projects that execution plan into read-only dispatch and operator
-state without executing apps:
-
-```bash
-uv --preview-features extra-build-dependencies run python tools/global_pipeline_runner_state_report.py --compact
-```
-
-The report marks `queue_baseline` as `runnable` and `relay_followup` as
-`blocked`, models `pending -> runnable -> completed/failed` plus retry and
-partial-rerun transitions, and records operator-facing readiness messages with
-provenance back to the execution plan, DAG sample, and `pipeline_view.dot`
-files. Full live operator UI remains future work.
-
-## Global DAG Dispatch Persistence
-
-AGILAB also includes the first persisted dispatch-state proof:
-
-```bash
-uv --preview-features extra-build-dependencies run python tools/global_pipeline_dispatch_state_report.py --compact
-```
-
-The report writes and reads back a persisted run-state JSON proof. It records
-`queue_baseline completed`, publishes `queue_metrics`, moves
-`relay_followup runnable`, and keeps timestamps, retry counters,
-partial-rerun flags, operator messages, and provenance. This is durable state
-transition evidence; the follow-on smoke below covers the real app-entry
-dispatch path across both DAG units.
-
-## Global DAG App Dispatch Smoke
-
-AGILAB now executes the two-unit global DAG through checked-in app entries:
-
-```bash
-uv --preview-features extra-build-dependencies run python tools/global_pipeline_app_dispatch_smoke_report.py --compact
-```
-
-The report runs real `queue_baseline` execution through `uav_queue_project`,
-then real `relay_followup` execution through `uav_relay_queue_project`. It
-writes `queue_metrics`, `relay_metrics`, and reducer artifacts into a temp
-workspace, persists the dispatch-state JSON, and records real queue_baseline
-and relay_followup execution. This is a full-DAG app-dispatch smoke, not live
-operator UI.
-
-## Global DAG Operator State
-
-AGILAB also projects that persisted full-DAG dispatch state into an
-operator-facing state contract:
-
-```bash
-uv --preview-features extra-build-dependencies run python tools/global_pipeline_operator_state_report.py --compact
-```
-
-The report reads the persisted full-DAG dispatch smoke state, exposes
-operator-visible state for both completed units, shows the queue-to-relay
-artifact handoff, and lists retry/partial-rerun actions available for future
-operator flows. This is a state contract, not live UI.
-
-## Global DAG Dependency View
-
-AGILAB now projects the operator-state proof into a cross-app dependency view:
-
-```bash
-uv --preview-features extra-build-dependencies run python tools/global_pipeline_dependency_view_report.py --compact
-```
-
-The report exposes upstream/downstream dependency visualization for
-`queue_baseline -> relay_followup`, including the `queue_metrics` artifact
-edge, producer/consumer apps, adjacency lists, artifact flow, and linkage back
-to the persisted operator-state proof. This is a dependency-view contract, not
-a live UI component.
-
-## Global DAG Live State Updates
-
-AGILAB now projects the dependency view into live orchestration-state updates:
-
-```bash
-uv --preview-features extra-build-dependencies run python tools/global_pipeline_live_state_updates_report.py --compact
-```
-
-The report emits a deterministic update stream for the full DAG: graph-ready,
-unit-state, artifact-state, dependency-state, and operator-action refresh
-payloads for `queue_baseline`, `relay_followup`, and `queue_metrics`. This is
-an update-payload contract, not a streaming service or UI renderer.
-
-## Global DAG Operator Actions
-
-AGILAB now executes persisted operator action requests through real app-entry
-replays:
-
-```bash
-uv --preview-features extra-build-dependencies run python tools/global_pipeline_operator_actions_report.py --compact
-```
-
-The report reads live-state update payloads, accepts `queue_baseline:retry` and
-`relay_followup:partial_rerun`, runs the corresponding queue and relay app
-entries, and persists the action outcomes plus output artifacts. This is retry
-and partial-rerun action execution, not a UI control surface.
-
-## Global DAG Operator UI
-
-AGILAB now renders the persisted global-DAG state into operator UI components:
-
-```bash
-uv --preview-features extra-build-dependencies run python tools/global_pipeline_operator_ui_report.py --compact
-```
-
-The report builds status, unit-card, dependency-graph, update-timeline,
-action-control, and artifact-table components, writes a static HTML proof, and
-verifies those operator UI components render persisted state and support
-operator actions. The components are reusable evidence; product page placement
-can evolve without changing the contract.
+Existing non-link app/page directories are moved to `<name>.previous.<timestamp>`
+before the repository copy is linked. The public service-mode path docs define
+the full update contract.
+
+## Evidence And Scope
+
+The PyPI README is only the install entry page. Detailed capability evidence,
+compatibility status, and roadmap scope live in the public docs:
+
+- Features: https://thalesgroup.github.io/agilab/features.html
+- Compatibility matrix: https://thalesgroup.github.io/agilab/compatibility-matrix.html
+- MLOps positioning: https://thalesgroup.github.io/agilab/agilab-mlops-positioning.html
+- Future work: https://thalesgroup.github.io/agilab/roadmap/agilab-future-work.html
 
 ## Evaluation Snapshot
 
-CODEX 5.5 working scores, not production MLOps claims:
-
-| KPI | Score | Evidence | Limit |
-|---|---|---:|---|
-| Ease of adoption | `3.5 / 5` | Hosted Space, CLI-first local `flight_project` path, opt-in installer tests, local smoke: `5.86s` vs `600s`, and fresh external-machine smoke on April 25, 2026: `26.87s` vs `600s`. | Validated locally, on one external macOS machine, on AI Lightning, on Hugging Face, on one bare-metal cluster, and on one VM-based cluster. Remaining validation gap: Azure, AWS, and GCP cloud deployments. |
-| Research experimentation | `4.0 / 5` | Templates, isolated `uv`, `lab_steps.toml`, MLflow-tracked runs, analysis pages, shared `agi_node` reduce contract, surfaced pandas/polars benchmark, flight, meteo forecast, and UAV queue-family reduce artifacts, a non-template built-in app guardrail, public reduce benchmark: `0.003s` vs `5.0s`, multi-app DAG report, global pipeline DAG report, global execution-plan report, global runner-state report, global dispatch-state persistence report, global app-dispatch smoke report, global operator-state report, global dependency-view report, global live-update report, global operator-action report, global operator-UI report, notebook-to-pipeline import report, notebook round-trip report, notebook union-environment report, data connector facility report, data connector resolution report, data connector health report, data connector health actions report, data connector UI preview report, data connector live UI report, and data connector app catalogs report. | Future apps/templates must opt in when they produce concrete merge outputs. |
-| Engineering prototyping | `4.0 / 5` | `app_args_form.py`, `pipeline_view`, reusable history, analysis-page templates, a guided in-product first-proof wizard, stable `run_manifest.json` evidence consumed by the KPI bundle, the multi-app DAG contract, a read-only global pipeline graph, pending execution-plan units, read-only runnable/blocked operator state, persisted queue-to-relay dispatch-state transition proof, real two-unit global DAG app dispatch smoke, operator-visible retry/partial-rerun action state, cross-app upstream/downstream dependency visualization, deterministic full-DAG live-update payloads, retry/partial-rerun real app-entry action replay, reusable operator UI components, the notebook-to-pipeline import contract, compatible single-kernel union notebook planning, first-class connector definitions, connector-aware app/page resolution, opt-in connector health-probe planning, operator-triggered connector health action rows, static connector provenance UI preview, Release Decision connector provenance UI integration, and app-local connector catalogs. | Additional external replication beyond the current public first-proof paths is not claimed. |
-| Production readiness | `3.0 / 5` | Release preflight, CI/coverage, service health gates, connector-registry release paths, provenance-tagged manifest-indexing, cross-release, and cross-run release-decision page export, security hardening checklist. | Production model serving, feature stores, online monitoring, drift detection, and enterprise governance are outside scope. |
-| Overall public evaluation | `3.6 / 5` | Mean of the four scored public KPIs: `(3.5 + 4.0 + 4.0 + 3.0) / 4 = 3.625`. Cross-KPI evidence bundle and workflow-backed compatibility report documented in the compatibility matrix. | Alpha-stage software; not a production MLOps platform. |
+Current public evaluation is `3.8 / 5`, from the four public KPI scores:
+adoption `4.0 / 5`, research experimentation `4.0 / 5`, engineering
+prototyping `4.0 / 5`, and production readiness `3.0 / 5`. This is an AI/ML
+experimentation-workbench score, not a production MLOps claim. Validation
+includes local and external macOS checks, AI Lightning, Hugging Face, one
+bare-metal cluster, and one VM-based cluster. Azure, AWS, and GCP deployments
+remain validation gaps.
 
 ## Read Next
 

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 161,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "54efb148173e41bb627f5a2abb42291fe0156179d5533082159e85cf8f985a3b",
+  "source_digest_sha256": "a88be2b44610e36f5dd26d53cb49962af46b5418b16cf841dd9822334bda1905",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "54efb148173e41bb627f5a2abb42291fe0156179d5533082159e85cf8f985a3b"
+  "target_digest_sha256": "a88be2b44610e36f5dd26d53cb49962af46b5418b16cf841dd9822334bda1905"
 }

--- a/docs/source/compatibility-matrix.rst
+++ b/docs/source/compatibility-matrix.rst
@@ -117,6 +117,7 @@ smokes with:
    uv --preview-features extra-build-dependencies run python tools/data_connector_resolution_report.py --compact
    uv --preview-features extra-build-dependencies run python tools/data_connector_health_report.py --compact
    uv --preview-features extra-build-dependencies run python tools/data_connector_health_actions_report.py --compact
+   uv --preview-features extra-build-dependencies run python tools/data_connector_runtime_adapters_report.py --compact
    uv --preview-features extra-build-dependencies run python tools/data_connector_ui_preview_report.py --compact
    uv --preview-features extra-build-dependencies run python tools/data_connector_live_ui_report.py --compact
    uv --preview-features extra-build-dependencies run python tools/data_connector_app_catalogs_report.py --compact
@@ -145,6 +146,7 @@ consumes that report and includes the ``multi_app_dag_report_contract``,
 ``data_connector_resolution_report_contract``,
 ``data_connector_health_report_contract``,
 ``data_connector_health_actions_report_contract``,
+``data_connector_runtime_adapters_report_contract``,
 ``data_connector_ui_preview_report_contract``,
 ``data_connector_live_ui_report_contract``,
 ``data_connector_app_catalogs_report_contract``, and
@@ -176,6 +178,8 @@ plan connector health/status probes behind operator opt-in without executing
 network checks,
 expose operator-triggered health probe action rows without executing network
 checks in public evidence,
+bind credentialed connector adapters to runtime operations and health actions
+while deferring credential values and executing no network probes,
 render connector state and connector-derived provenance as static JSON+HTML
 preview evidence,
 wire connector state and connector-derived provenance into the Release Decision

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -182,6 +182,11 @@ single notebook but less ceremony than a production MLOps platform:
   ``tools/data_connector_health_actions_report.py --compact`` in
   ``operator_trigger_contract_only`` mode; it exposes operator-triggered health
   probes as explicit action rows while keeping public network execution at zero
+- the data connector runtime adapters report validates
+  ``tools/data_connector_runtime_adapters_report.py --compact`` in
+  ``runtime_adapter_contract_only`` mode; it binds credentialed connector adapters
+  to runtime operations and health actions while deferring credential values and
+  keeping public network execution at zero
 - the data connector UI preview report validates
   ``tools/data_connector_ui_preview_report.py --compact`` in
   ``static_ui_preview_only`` mode; it renders connector state and

--- a/docs/source/newcomer-guide.rst
+++ b/docs/source/newcomer-guide.rst
@@ -59,11 +59,12 @@ The JSON proof writes ``~/log/execute/flight/run_manifest.json``. That manifest
 is the portable first-proof run record: command, Python/platform context, active
 app, timing, artifact references, and validation status.
 
-That supports an ``Ease of adoption`` score of ``3.5 / 5``: the public demo
+That supports an ``Ease of adoption`` score of ``4.0 / 5``: the public demo
 works, the first routes are explicit, PyCharm is optional, installer tests are
-opt-in, and the source-checkout proof now has one fresh external-machine
-replication. It is not scored higher yet because broader OS and network
-replication remains open.
+opt-in, and the source-checkout proof now has local, fresh external macOS,
+AI Lightning, Hugging Face, bare-metal cluster, and VM-based cluster validation.
+It is not scored higher yet because Azure, AWS, and GCP deployment validation
+remains open.
 
 What to ignore on day 1
 -----------------------

--- a/docs/source/quick-start.rst
+++ b/docs/source/quick-start.rst
@@ -168,6 +168,11 @@ your machine::
       --test-apps \
       --test-core
 
+Rerunning the installer refreshes repository app/page links. If a selected
+repository app or page already exists locally as a real directory, the installer
+moves it to ``<name>.previous.<timestamp>`` and links the repository copy so app
+updates are picked up.
+
 ``--test-root`` runs the installer-managed AGILAB package tests. For the full
 repository pytest suite from a source checkout, run it separately::
 

--- a/docs/source/service_mode_and_paths.md
+++ b/docs/source/service_mode_and_paths.md
@@ -28,22 +28,27 @@ bootstrapper, etc.) now assume.
   open-source apps. |
 | `~/agi-space/.venv` | The virtual environment that executes the web interface in
   service mode. |
-| `~/agi-space/apps` | Populated with symlinks to the selected app templates. |
+| `~/agi-space/apps` | Populated with links to selected built-in and repository app projects. |
 
 ## How App Symlinks Are Resolved
 
-1. When `AgiEnv` initialises with `install_type == 0`, it first looks for
-   `APPS_REPOSITORY/src/agilab/apps`.
-2. Every `*_project` folder inside that repository directory is symlinked into
-   the active end-user workspace (e.g. `~/agi-space/apps`). Existing links are
-   recreated only when the target changed.
-3. If the apps repository directory is missing or unset, `AgiEnv` falls back to the location
-   stored in `~/.local/share/agilab/.agilab-path` and copies the public apps
-   instead of linking them.
+1. The installer discovers `apps` and `apps-pages` under `APPS_REPOSITORY`.
+   Direct children are preferred; nested `src/agilab/apps` and
+   `src/agilab/apps-pages` layouts are also accepted.
+2. Every valid `*_project` folder inside the repository apps directory is linked
+   into the active end-user workspace (for example `~/agi-space/apps`). Existing
+   links are recreated on rerun.
+3. If a selected repository app/page already exists locally as a real directory,
+   the installer moves it to `<name>.previous.<timestamp>` and links the
+   repository copy in its place. This makes app updates from the repository the
+   source of truth while keeping the old local directory recoverable.
+4. If the apps repository directory is missing or unset, `AgiEnv` falls back to
+   the location stored in `~/.local/share/agilab/.agilab-path` and copies the
+   public apps instead of linking them.
 
 Because the apps repository (when configured) is the primary source of truth,
 make sure the installer writes the up-to-date path to `APPS_REPOSITORY` and that
-the repository exposes the expected sub-tree:
+the repository exposes an installable apps tree:
 
 ```
 ${APPS_REPOSITORY}/
@@ -54,17 +59,17 @@ ${APPS_REPOSITORY}/
       ...
 ```
 
-## Cleaning Up Broken Links
+## Updating App Links
 
-During startup `AgiEnv.get_projects()` automatically removes any dangling
-symlinks under the end-user `apps` directory.  If you move or rename projects in
-the apps repository, the next launch will drop stale links and recreate them
-using the up-to-date path.
+During startup `AgiEnv.get_projects()` automatically removes dangling symlinks
+under the end-user `apps` directory. If you move, rename, or update projects in
+the apps repository, rerun the installer so repository links are refreshed and
+any stale real directories are moved aside before the new links are created.
 
 ## Practical Checklist
 
 1. Point `APPS_REPOSITORY` at the root of the apps repository (when used).
 2. Run the installer (or rerun `install_apps.sh`) so `~/.local/share/agilab/.env`
-   is refreshed.
+   is refreshed and app/page links are updated.
 3. Restart the end-user web interface app.  The sidebar project selector should now
-  only list apps that resolve inside `APPS_REPOSITORY`.
+   only list apps that resolve inside `APPS_REPOSITORY`.

--- a/test/test_kpi_evidence_bundle.py
+++ b/test/test_kpi_evidence_bundle.py
@@ -25,17 +25,17 @@ def test_build_bundle_passes_static_public_evidence_contracts() -> None:
     bundle = module.build_bundle(run_hf_smoke=False)
 
     assert bundle["kpi"] == "Overall public evaluation"
-    assert bundle["supported_score"] == "3.6 / 5"
+    assert bundle["supported_score"] == "3.8 / 5"
     assert bundle["baseline_review_score"] == "3.2 / 5"
     assert bundle["status"] == "pass"
     assert bundle["summary"]["hf_smoke_executed"] is False
     assert bundle["summary"]["score_components"] == {
-        "Ease of adoption": "3.5 / 5",
+        "Ease of adoption": "4.0 / 5",
         "Research experimentation": "4.0 / 5",
         "Engineering prototyping": "4.0 / 5",
         "Production readiness": "3.0 / 5",
     }
-    assert bundle["summary"]["score_formula"] == "(3.5 + 4.0 + 4.0 + 3.0) / 4 = 3.625"
+    assert bundle["summary"]["score_formula"] == "(4.0 + 4.0 + 4.0 + 3.0) / 4 = 3.75"
     check_ids = {check["id"] for check in bundle["checks"]}
     assert check_ids == {
         "workflow_compatibility_report",
@@ -59,6 +59,7 @@ def test_build_bundle_passes_static_public_evidence_contracts() -> None:
         "data_connector_resolution_report_contract",
         "data_connector_health_report_contract",
         "data_connector_health_actions_report_contract",
+        "data_connector_runtime_adapters_report_contract",
         "data_connector_ui_preview_report_contract",
         "data_connector_live_ui_report_contract",
         "data_connector_app_catalogs_report_contract",
@@ -483,6 +484,36 @@ def test_data_connector_health_actions_report_contract_exposes_operator_triggers
     assert check["details"]["summary"]["result_status_values"] == ["unknown_not_probed"]
     assert "data_connector_health_actions_operator_trigger" in check["details"]["check_ids"]
     assert "data_connector_health_actions_no_network" in check["details"]["check_ids"]
+
+
+def test_data_connector_runtime_adapters_report_contract_exposes_bindings() -> None:
+    module = _load_module()
+
+    check = module._check_data_connector_runtime_adapters_report(Path.cwd())
+
+    assert check["status"] == "pass"
+    assert check["details"]["summary"]["schema"] == (
+        "agilab.data_connector_runtime_adapters.v1"
+    )
+    assert check["details"]["summary"]["run_status"] == "ready_for_runtime_binding"
+    assert check["details"]["summary"]["execution_mode"] == "runtime_adapter_contract_only"
+    assert check["details"]["summary"]["connector_count"] == 3
+    assert check["details"]["summary"]["adapter_count"] == 3
+    assert check["details"]["summary"]["runtime_ready_count"] == 3
+    assert check["details"]["summary"]["credential_deferred_count"] == 2
+    assert check["details"]["summary"]["no_credential_required_count"] == 1
+    assert check["details"]["summary"]["operator_opt_in_required_count"] == 3
+    assert check["details"]["summary"]["health_action_binding_count"] == 3
+    assert check["details"]["summary"]["executed_adapter_count"] == 0
+    assert check["details"]["summary"]["network_probe_count"] == 0
+    assert check["details"]["summary"]["credential_value_materialized_count"] == 0
+    assert check["details"]["summary"]["operations"] == [
+        "object_storage_prefix_list",
+        "opensearch_index_head",
+        "read_only_connectivity_check",
+    ]
+    assert "data_connector_runtime_adapters_rows" in check["details"]["check_ids"]
+    assert "data_connector_runtime_adapters_no_network" in check["details"]["check_ids"]
 
 
 def test_data_connector_ui_preview_report_contract_renders_connector_state() -> None:

--- a/test/test_public_demo_links.py
+++ b/test/test_public_demo_links.py
@@ -125,7 +125,7 @@ def test_readme_uses_quick_start_link_with_badges_not_a_route_table() -> None:
     assert "PROJECT` -> select" not in readme
     assert "tools/newcomer_first_proof.py --json" in readme
     assert "Ease of adoption" in readme
-    assert "3.5 / 5" in readme
+    assert "4.0 / 5" in readme
     assert "5.86s" in readme
 
 
@@ -172,10 +172,10 @@ def test_readme_captures_overall_public_evaluation_evidence() -> None:
     assert "project setup, environment management, execution, and result analysis" in readme
     assert "Overall public evaluation" in readme
     assert "3.2 / 5` ->" not in readme
-    assert "3.6 / 5" in readme
+    assert "3.8 / 5" in readme
     assert "Mean of the four scored public KPIs" in readme
-    assert "(3.5 + 4.0 + 4.0 + 3.0) / 4 = 3.625" in readme
-    assert "3.5 / 5" in readme
+    assert "(4.0 + 4.0 + 4.0 + 3.0) / 4 = 3.75" in readme
+    assert "4.0 / 5" in readme
     assert "cross-kpi evidence bundle" in readme.lower()
 
 
@@ -228,7 +228,7 @@ def test_newcomer_docs_capture_adoption_evidence() -> None:
 
     assert "Adoption evidence" in text
     assert "Ease of adoption" in text
-    assert "3.5 / 5" in text
+    assert "4.0 / 5" in text
     assert "5.86s" in text
     assert "600s" in text
 

--- a/tools/kpi_evidence_bundle.py
+++ b/tools/kpi_evidence_bundle.py
@@ -18,7 +18,7 @@ from typing import Any, Sequence
 REPO_ROOT = Path(__file__).resolve().parents[1]
 BASELINE_REVIEW_SCORE = "3.2 / 5"
 KPI_COMPONENT_SCORES = {
-    "Ease of adoption": Decimal("3.5"),
+    "Ease of adoption": Decimal("4.0"),
     "Research experimentation": Decimal("4.0"),
     "Engineering prototyping": Decimal("4.0"),
     "Production readiness": Decimal("3.0"),
@@ -1296,6 +1296,64 @@ def _check_data_connector_health_actions_report(repo_root: Path) -> dict[str, An
     )
 
 
+def _check_data_connector_runtime_adapters_report(repo_root: Path) -> dict[str, Any]:
+    try:
+        data_connector_report = _load_tool_module(
+            repo_root,
+            "data_connector_runtime_adapters_report",
+        )
+        report = data_connector_report.build_report(repo_root=repo_root)
+        summary = report.get("summary", {})
+        ok = (
+            report.get("status") == "pass"
+            and summary.get("schema") == "agilab.data_connector_runtime_adapters.v1"
+            and summary.get("run_status") == "ready_for_runtime_binding"
+            and summary.get("execution_mode") == "runtime_adapter_contract_only"
+            and summary.get("connector_count") == 3
+            and summary.get("adapter_count") == 3
+            and summary.get("runtime_ready_count") == 3
+            and summary.get("credential_deferred_count") == 2
+            and summary.get("no_credential_required_count") == 1
+            and summary.get("operator_opt_in_required_count") == 3
+            and summary.get("health_action_binding_count") == 3
+            and summary.get("executed_adapter_count") == 0
+            and summary.get("network_probe_count") == 0
+            and summary.get("credential_value_materialized_count") == 0
+            and summary.get("operations")
+            == [
+                "object_storage_prefix_list",
+                "opensearch_index_head",
+                "read_only_connectivity_check",
+            ]
+            and summary.get("round_trip_ok") is True
+        )
+        details = {
+            "status": report.get("status"),
+            "summary": summary,
+            "check_ids": [check.get("id") for check in report.get("checks", [])],
+        }
+    except Exception as exc:
+        ok = False
+        details = {"error": str(exc)}
+    return _check_result(
+        "data_connector_runtime_adapters_report_contract",
+        "Data connector runtime adapters report contract",
+        ok,
+        (
+            "data connector runtime adapters report exposes credentialed "
+            "runtime bindings without executing network checks"
+            if ok
+            else "data connector runtime adapters report is failing or disconnected"
+        ),
+        evidence=[
+            "tools/data_connector_runtime_adapters_report.py",
+            "src/agilab/data_connector_runtime_adapters.py",
+            "src/agilab/data_connector_facility.py",
+        ],
+        details=details,
+    )
+
+
 def _check_data_connector_ui_preview_report(repo_root: Path) -> dict[str, Any]:
     try:
         data_connector_report = _load_tool_module(
@@ -1641,6 +1699,7 @@ def _check_public_docs_links(repo_root: Path) -> dict[str, Any]:
             "tools/data_connector_resolution_report.py --compact",
             "tools/data_connector_health_report.py --compact",
             "tools/data_connector_health_actions_report.py --compact",
+            "tools/data_connector_runtime_adapters_report.py --compact",
             "tools/data_connector_ui_preview_report.py --compact",
             "tools/data_connector_live_ui_report.py --compact",
             "tools/data_connector_app_catalogs_report.py --compact",
@@ -1673,6 +1732,7 @@ def _check_public_docs_links(repo_root: Path) -> dict[str, Any]:
             "tools/data_connector_resolution_report.py",
             "tools/data_connector_health_report.py",
             "tools/data_connector_health_actions_report.py",
+            "tools/data_connector_runtime_adapters_report.py",
             "tools/data_connector_ui_preview_report.py",
             "tools/data_connector_live_ui_report.py",
             "tools/data_connector_app_catalogs_report.py",
@@ -1741,6 +1801,7 @@ def build_bundle(
         _check_data_connector_resolution_report(repo_root),
         _check_data_connector_health_report(repo_root),
         _check_data_connector_health_actions_report(repo_root),
+        _check_data_connector_runtime_adapters_report(repo_root),
         _check_data_connector_ui_preview_report(repo_root),
         _check_data_connector_live_ui_report(repo_root),
         _check_data_connector_app_catalogs_report(repo_root),
@@ -1775,9 +1836,9 @@ def build_bundle(
             "score_rounding": "one decimal, half up",
         },
         "rationale": (
-            "Supports an overall public evaluation of 3.6 / 5 as the one-decimal "
-            "mean of the four scored public KPIs: adoption, research "
-            "experimentation, engineering prototyping, and bounded "
+            f"Supports an overall public evaluation of {SUPPORTED_OVERALL_SCORE} "
+            "as the one-decimal mean of the four scored public KPIs: adoption, "
+            "research experimentation, engineering prototyping, and bounded "
             "production-readiness evidence. It does not change the alpha status "
             "or claim production MLOps coverage."
         ),


### PR DESCRIPTION
## Summary

- Simplifies README and README.pypi to reduce overlap with the docs.
- Aligns public docs with the app-repository/update positioning.
- Raises the adoption KPI to 4.0 / 5 and the overall public evaluation to 3.8 / 5, while keeping production readiness bounded at 3.0 / 5.

## Validation

- `git diff --check`
- `uv --preview-features extra-build-dependencies run python tools/kpi_evidence_bundle.py --compact`
- `uv --preview-features extra-build-dependencies run pytest -q test/test_public_demo_links.py test/test_kpi_evidence_bundle.py test/test_sync_docs_source.py`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --staged`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs`
