### PR TITLE
[codex] Clarify app repository update contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,11 @@ installer after app changes:
 ./install.sh --non-interactive --apps-repository /path/to/apps-repository --install-apps all
 ```
 
-Existing non-link app/page directories are moved to `<name>.previous.<timestamp>`
-before the repository copy is linked, so repository updates win over stale local
-copies. See
+During an update, the apps repository is treated as the source of truth. If the
+target app/page already exists as a real directory instead of a symlink, AGILAB
+backs it up as `<name>.previous.<timestamp>`, then links the repository copy in
+its place. After the update, AGILAB runs the repository version; the
+`.previous` directory is kept only for manual recovery. See
 [Service mode and paths](https://thalesgroup.github.io/agilab/service_mode_and_paths.html)
 for the full path contract.
 

--- a/README.pypi.md
+++ b/README.pypi.md
@@ -68,9 +68,12 @@ installer after app changes:
 ./install.sh --non-interactive --apps-repository /path/to/apps-repository --install-apps all
 ```
 
-Existing non-link app/page directories are moved to `<name>.previous.<timestamp>`
-before the repository copy is linked. The public service-mode path docs define
-the full update contract.
+During an update, the apps repository is treated as the source of truth. If the
+target app/page already exists as a real directory instead of a symlink, AGILAB
+backs it up as `<name>.previous.<timestamp>`, then links the repository copy in
+its place. After the update, AGILAB runs the repository version; the
+`.previous` directory is kept only for manual recovery. The public service-mode
+path docs define the full update contract.
 
 ## Evidence And Scope
 

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 161,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "a88be2b44610e36f5dd26d53cb49962af46b5418b16cf841dd9822334bda1905",
+  "source_digest_sha256": "6a7d7a323f59789923cb84d5d1a344cb223a2020ca215000f45351a3c6765157",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "a88be2b44610e36f5dd26d53cb49962af46b5418b16cf841dd9822334bda1905"
+  "target_digest_sha256": "6a7d7a323f59789923cb84d5d1a344cb223a2020ca215000f45351a3c6765157"
 }

--- a/docs/source/service_mode_and_paths.md
+++ b/docs/source/service_mode_and_paths.md
@@ -38,10 +38,12 @@ bootstrapper, etc.) now assume.
 2. Every valid `*_project` folder inside the repository apps directory is linked
    into the active end-user workspace (for example `~/agi-space/apps`). Existing
    links are recreated on rerun.
-3. If a selected repository app/page already exists locally as a real directory,
-   the installer moves it to `<name>.previous.<timestamp>` and links the
-   repository copy in its place. This makes app updates from the repository the
-   source of truth while keeping the old local directory recoverable.
+3. If a selected repository app/page already exists locally as a real directory
+   instead of a symlink, the installer does not overwrite it in place. It first
+   renames that local directory to `<name>.previous.<timestamp>` as a backup,
+   then creates the symlink to the repository copy. After the update, AGILAB
+   uses the repository version; the `.previous` directory is only a manual
+   recovery backup.
 4. If the apps repository directory is missing or unset, `AgiEnv` falls back to
    the location stored in `~/.local/share/agilab/.agilab-path` and copies the
    public apps instead of linking them.
@@ -63,8 +65,10 @@ ${APPS_REPOSITORY}/
 
 During startup `AgiEnv.get_projects()` automatically removes dangling symlinks
 under the end-user `apps` directory. If you move, rename, or update projects in
-the apps repository, rerun the installer so repository links are refreshed and
-any stale real directories are moved aside before the new links are created.
+the apps repository, rerun the installer. The rerun refreshes the symlinks so
+the repository copy becomes the active app/page. Any existing real directory at
+the target path is renamed to `.previous` first, so it is preserved but no
+longer used by AGILAB.
 
 ## Practical Checklist
 


### PR DESCRIPTION
## Summary

- Replaces the unclear “non-link app/page directories” wording with an explicit update contract.
- States that real directories are backed up as `.previous`, repository copies are linked, and AGILAB runs the repository version after update.
- Aligns README, PyPI README, and the service-mode path docs.

## Validation

- `git diff --check`
- `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp`
- `uv --preview-features extra-build-dependencies run pytest -q test/test_public_demo_links.py test/test_sync_docs_source.py`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --staged`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs`
