### PR TITLE
[codex] Expose AGILAB demo in docs sidebar

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -1,9 +1,9 @@
 {
-  "file_count": 161,
+  "file_count": 162,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "6a7d7a323f59789923cb84d5d1a344cb223a2020ca215000f45351a3c6765157",
+  "source_digest_sha256": "733656b93516c8cdd326d0eb1199c60e4bfe405d62e49b7b59e84cbd24fa65ef",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "6a7d7a323f59789923cb84d5d1a344cb223a2020ca215000f45351a3c6765157"
+  "target_digest_sha256": "733656b93516c8cdd326d0eb1199c60e4bfe405d62e49b7b59e84cbd24fa65ef"
 }

--- a/docs/source/agilab-demo.rst
+++ b/docs/source/agilab-demo.rst
@@ -1,0 +1,47 @@
+AGILAB Demo
+===========
+
+Use this page when you want the public hosted AGILAB web UI first. This is the
+sidebar-visible counterpart to :doc:`notebook-quickstart`, which is the
+notebook-first ``agi-core`` demo.
+
+Start here
+----------
+
+Open the public Hugging Face Space:
+
+.. image:: https://img.shields.io/badge/AGILAB-demo-0F766E?style=for-the-badge
+   :target: https://huggingface.co/spaces/jpmorard/agilab
+   :alt: AGILAB demo
+
+- `Open AGILAB Space <https://huggingface.co/spaces/jpmorard/agilab>`_
+
+What will happen
+----------------
+
+The hosted demo opens the lightweight built-in ``flight_project`` path by
+default. Use it to inspect the browser-first AGILAB flow:
+
+- select the project from the web UI
+- follow the execution path from ``PROJECT`` to ``ORCHESTRATE``
+- inspect the generated run artifacts from ``ANALYSIS``
+
+This is a public preview route. It is not a replacement for the local
+:doc:`quick-start` proof when you need to validate your own machine,
+environment, or app repository.
+
+What success looks like
+-----------------------
+
+You are past the hosted-demo hurdle when the Space loads and the default
+``flight_project`` route is available from the AGILAB UI. For evidence scope,
+use :doc:`compatibility-matrix`; it separates validated public routes from
+cloud/provider combinations that remain open.
+
+Related pages
+-------------
+
+- :doc:`demos` for the public demo chooser.
+- :doc:`quick-start` for the recommended local first proof.
+- :doc:`notebook-quickstart` for the ``agi-core`` notebook demo.
+- :doc:`compatibility-matrix` for the validation status of public routes.

--- a/docs/source/demos.rst
+++ b/docs/source/demos.rst
@@ -23,10 +23,10 @@ Choose a demo
 What each route is for
 ----------------------
 
-- **AGILAB demo**: self-serve public Hugging Face Spaces route for the AGILAB
-  web UI. It opens the lightweight built-in ``flight_project`` path by default,
-  so use it as the public first proof for project selection, execution, and
-  analysis.
+- **AGILAB demo**: use :doc:`agilab-demo` for the self-serve public Hugging Face
+  Spaces route for the AGILAB web UI. It opens the lightweight built-in
+  ``flight_project`` path by default, so use it as the public first proof for
+  project selection, execution, and analysis.
 - **agi-core demo**: notebook-first runtime path. Use this if you want the
   smaller ``AgiEnv`` / ``AGI.run(...)`` surface before the web UI.
 - **Quick start**: the safest truthful first proof of the full product path.
@@ -48,6 +48,7 @@ See also
 --------
 
 - :doc:`quick-start`
+- :doc:`agilab-demo`
 - :doc:`notebook-quickstart`
 - :doc:`newcomer-guide`
 - :doc:`compatibility-matrix`

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,7 +3,7 @@ AGILab Documentation
 
 If you are new to AGILab, choose one route first:
 
-- **See the UI now**: open :doc:`demos` for the public Hugging Face Space.
+- **See the UI now**: open :doc:`agilab-demo` for the public Hugging Face Space.
 - **Prove it locally**: follow :doc:`quick-start` with the built-in
   ``flight_project``. Target: pass the first proof in 10 minutes.
 - **Use the API/notebook**: follow :doc:`notebook-quickstart` for the smaller
@@ -33,6 +33,7 @@ references, and example projects.
 
    introduction
    features
+   AGILAB Demo <agilab-demo>
    notebook-quickstart
    notebook-advanced
    agilab

--- a/docs/source/newcomer-guide.rst
+++ b/docs/source/newcomer-guide.rst
@@ -17,7 +17,7 @@ Choose one route
      - Route
      - Use when
    * - See the UI now
-     - :doc:`demos`
+     - :doc:`agilab-demo`
      - You want a browser-only look at the AGILAB web UI before installing
        anything.
    * - Prove it locally
@@ -109,7 +109,9 @@ Where to go next
 
 - :doc:`quick-start` for the exact first-proof commands.
 - :doc:`newcomer-troubleshooting` if the local ``flight_project`` proof fails.
-- :doc:`demos` if you want the public demo chooser instead of a local install.
+- :doc:`agilab-demo` if you want the public hosted web UI instead of a local
+  install.
+- :doc:`demos` if you want the public demo chooser.
 - :doc:`notebook-quickstart` only if you intentionally choose the
   ``agi-core`` notebook path.
 - :doc:`distributed-workers` only after the local proof works and you are ready

--- a/docs/source/quick-start.rst
+++ b/docs/source/quick-start.rst
@@ -134,6 +134,7 @@ Use these only after the local ``flight_project`` proof works once.
    :alt: AGILAB demo
 
 Self-serve public AGILAB demo hosted on Hugging Face Spaces.
+The sidebar-visible docs page for this route is :doc:`agilab-demo`.
 
 **Published package route** (fastest install, less representative of the full product path)::
 

--- a/test/test_public_demo_links.py
+++ b/test/test_public_demo_links.py
@@ -8,6 +8,7 @@ PYPI_README = Path("README.pypi.md")
 AGI_CORE_README = Path("src/agilab/core/agi-core/README.md")
 CHANGELOG = Path("CHANGELOG.md")
 PUBLIC_DOC_PAGES = (
+    Path("docs/source/agilab-demo.rst"),
     Path("docs/source/demos.rst"),
     Path("docs/source/quick-start.rst"),
 )
@@ -95,6 +96,22 @@ def test_public_docs_link_to_hf_space_page_not_runtime_host() -> None:
         text = path.read_text(encoding="utf-8")
         assert PUBLIC_HF_SPACE_URL in text
         assert HF_RUNTIME_URL not in text
+
+
+def test_docs_sidebar_exposes_both_public_demo_lanes() -> None:
+    index = Path("docs/source/index.rst").read_text(encoding="utf-8")
+    demos = Path("docs/source/demos.rst").read_text(encoding="utf-8")
+    agilab_demo = Path("docs/source/agilab-demo.rst").read_text(encoding="utf-8")
+    use_sidebar_block = index.split(":caption: Use", 1)[1].split(":caption: Build", 1)[0]
+
+    assert "AGILAB Demo <agilab-demo>" in index
+    assert "notebook-quickstart" in index
+    assert "AGILAB Demo <agilab-demo>" in use_sidebar_block
+    assert "notebook-quickstart" in use_sidebar_block
+    assert use_sidebar_block.index("AGILAB Demo <agilab-demo>") < use_sidebar_block.index("notebook-quickstart")
+    assert ":doc:`agilab-demo`" in demos
+    assert ":doc:`notebook-quickstart`" in demos
+    assert "sidebar-visible counterpart" in agilab_demo
 
 
 def test_readme_uses_quick_start_link_with_badges_not_a_route_table() -> None:


### PR DESCRIPTION
## Summary

- Adds a sidebar-visible `AGILAB Demo` docs page for the hosted Hugging Face Space route.
- Places `AGILAB Demo` before `agi-core Demo` in the `Use` toctree so both public demo lanes are visible consistently.
- Updates the demo chooser, quick start, and newcomer guide to link to the new page.

## Validation

- `git diff --check`
- `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp`
- `uv --preview-features extra-build-dependencies run pytest -q test/test_public_demo_links.py test/test_sync_docs_source.py`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files docs/source/agilab-demo.rst docs/source/demos.rst docs/source/index.rst docs/source/newcomer-guide.rst docs/source/quick-start.rst docs/.docs_source_mirror_stamp.json test/test_public_demo_links.py`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs`
