### PR TITLE
Fix Catalina validation path handling

### DIFF
--- a/src/agilab/core/agi-env/src/agi_env/process_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/process_support.py
@@ -34,21 +34,20 @@ INLINE_PATH_EXPORT = re.compile(
 PATH_RESOLVE_EXCEPTIONS = (OSError, UnsupportedOperation)
 REGEX_OPERATION_EXCEPTIONS = (re.error, TypeError, ValueError)
 INLINE_EXPORT_EXCEPTIONS = (OSError, TypeError, ValueError)
+_HOST_PATH_CLS = type(Path("."))
 
 
 def normalize_path(path):
     """Return ``path`` coerced to a normalised string representation."""
 
-    if str(path) == "":
-        candidate = Path(".")
-    else:
-        candidate = Path(path)
+    raw_path = "." if str(path) == "" else str(path)
     if os.name == "nt":
         try:
-            candidate = candidate.expanduser().resolve(strict=False)
+            candidate = _HOST_PATH_CLS(raw_path).expanduser().resolve(strict=False)
         except PATH_RESOLVE_EXCEPTIONS:
-            candidate = candidate.expanduser()
+            candidate = _HOST_PATH_CLS(raw_path).expanduser()
         return str(PureWindowsPath(candidate))
+    candidate = Path(raw_path)
     return str(PurePosixPath(candidate))
 
 

--- a/src/agilab/core/agi-env/test/test_process_support.py
+++ b/src/agilab/core/agi-env/test/test_process_support.py
@@ -50,10 +50,11 @@ def test_fix_windows_drive_returns_non_string_inputs_unchanged(monkeypatch):
 def test_normalize_path_windows_resolve_fallback(monkeypatch):
     original_os_name = os.name
     original_resolve = Path.resolve
+    posix_path_cls = type(Path("/tmp"))
     monkeypatch.setattr(process_support.os, "name", "nt", raising=False)
 
     def _patched_resolve(self, *args, **kwargs):
-        if self == Path("demo"):
+        if self == posix_path_cls("demo"):
             raise OSError("boom")
         return original_resolve(self, *args, **kwargs)
 

--- a/src/agilab/core/test/test_agi_dispatcher_scripts.py
+++ b/src/agilab/core/test/test_agi_dispatcher_scripts.py
@@ -2759,11 +2759,12 @@ def test_build_force_remove_tree_windows_skips_recursive_chmod(tmp_path, monkeyp
     target.mkdir(parents=True, exist_ok=True)
     removed = []
     run_calls = []
+    posix_path_cls = type(Path("/tmp"))
 
     monkeypatch.setattr(build_mod.os, "name", "nt", raising=False)
     monkeypatch.setattr(build_mod.os, "chmod", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(build_mod.subprocess, "run", lambda *args, **kwargs: run_calls.append((args, kwargs)))
-    monkeypatch.setattr(build_mod.shutil, "rmtree", lambda path: removed.append(Path(path)))
+    monkeypatch.setattr(build_mod.shutil, "rmtree", lambda path: removed.append(posix_path_cls(path)))
 
     build_mod._force_remove_tree(target)
 

--- a/src/agilab/core/test/test_base_worker_execution_support.py
+++ b/src/agilab/core/test/test_base_worker_execution_support.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import io
+import itertools
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -721,7 +722,7 @@ def test_baseworker_get_worker_info_creates_temp_share_dir(monkeypatch, tmp_path
         lambda: SimpleNamespace(current=3200),
     )
     monkeypatch.setattr(base_worker_mod.time, "sleep", lambda *_args, **_kwargs: None)
-    time_values = iter([1.0, 2.0])
+    time_values = itertools.count(1.0)
     monkeypatch.setattr(base_worker_mod.time, "time", lambda: next(time_values))
     monkeypatch.setattr(
         base_worker_mod.os,

--- a/src/agilab/orchestrate_execute.py
+++ b/src/agilab/orchestrate_execute.py
@@ -1,7 +1,7 @@
 import json
 import os
 import shutil
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable, Optional
@@ -41,6 +41,9 @@ class OrchestrateExecuteDeps:
     log_display_max_lines: int
     live_log_min_height: int
     install_log_height: int
+
+    def __replace__(self, **changes: Any) -> "OrchestrateExecuteDeps":
+        return replace(self, **changes)
 
 
 def collect_candidate_roots(env: Any, active_args: dict[str, Any] | None) -> list[Path]:


### PR DESCRIPTION
## Summary
- Add a `__replace__` compatibility hook to `OrchestrateExecuteDeps`.
- Stabilize Windows-path simulation tests on POSIX hosts by avoiding `WindowsPath` construction after `os.name` is monkeypatched.
- Make the mocked worker-info clock unbounded so full-suite ordering does not exhaust it.

## Validation
- Targeted Catalina run: 9 passed in 43.16s
