### PR TITLE
[codex] Fix worker validation source paths

### DIFF
--- a/docs/source/snippets/agi_core_mycode_minimal_run.py
+++ b/docs/source/snippets/agi_core_mycode_minimal_run.py
@@ -1,18 +1,9 @@
-import asyncio
-
 from agi_cluster.agi_distributor import AGI
 
-
-async def main():
-    result = await AGI.run(
-        app_env,
-        scheduler="127.0.0.1",
-        workers={"127.0.0.1": 1},
-        mode=0,  # plain local Python execution
-    )
-    print(result)
-    return result
-
-
-if __name__ == "__main__":
-    asyncio.run(main())
+result = await AGI.run(
+    app_env,
+    scheduler="127.0.0.1",
+    workers={"127.0.0.1": 1},
+    mode=0,  # plain local Python execution
+)
+result

--- a/docs/source/snippets/agi_core_mycode_minimal_run.py
+++ b/docs/source/snippets/agi_core_mycode_minimal_run.py
@@ -1,9 +1,18 @@
+import asyncio
+
 from agi_cluster.agi_distributor import AGI
 
-result = await AGI.run(
-    app_env,
-    scheduler="127.0.0.1",
-    workers={"127.0.0.1": 1},
-    mode=0,  # plain local Python execution
-)
-result
+
+async def main():
+    result = await AGI.run(
+        app_env,
+        scheduler="127.0.0.1",
+        workers={"127.0.0.1": 1},
+        mode=0,  # plain local Python execution
+    )
+    print(result)
+    return result
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/agilab/core/agi-env/src/agi_env/process_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/process_support.py
@@ -37,6 +37,11 @@ INLINE_EXPORT_EXCEPTIONS = (OSError, TypeError, ValueError)
 _HOST_PATH_CLS = type(Path("."))
 
 
+def _is_virtualenv_path(path: Path) -> bool:
+    bin_dir = "Scripts" if os.name == "nt" else "bin"
+    return (path / "pyvenv.cfg").exists() or (path / bin_dir).exists()
+
+
 def normalize_path(path):
     """Return ``path`` coerced to a normalised string representation."""
 
@@ -113,7 +118,7 @@ def build_subprocess_env(
 
     extra_paths = list(pythonpath_entries or [])
     active_prefix = Path(sys_prefix or sys.prefix).resolve()
-    if venv_path and active_prefix != venv_path.resolve():
+    if venv_path and _is_virtualenv_path(venv_path) and active_prefix != venv_path.resolve():
         extra_paths = []
 
     process_env.pop("PYTHONPATH", None)

--- a/src/agilab/core/agi-env/src/agi_env/repository_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/repository_support.py
@@ -96,6 +96,8 @@ def collect_pythonpath_entries(
             init_file = path / "__init__.py"
         except TypeError:
             return path
+        if path.name == "src":
+            return path
         if init_file.exists():
             return path.parent
         return path

--- a/src/agilab/core/agi-env/test/test_process_support.py
+++ b/src/agilab/core/agi-env/test/test_process_support.py
@@ -94,6 +94,8 @@ def test_build_subprocess_env_strips_uv_run_recursion_depth(tmp_path: Path):
         "PYTHONHOME": "/tmp/home",
         "PATH": "/usr/bin",
     }
+    venv_dir = tmp_path / ".venv"
+    (venv_dir / "bin").mkdir(parents=True)
     foreign_source = tmp_path / "foreign-source"
     foreign_source.mkdir()
 
@@ -107,6 +109,26 @@ def test_build_subprocess_env_strips_uv_run_recursion_depth(tmp_path: Path):
     assert env.get("VIRTUAL_ENV") == str(tmp_path / ".venv")
     assert "UV_RUN_RECURSION_DEPTH" not in env
     assert "PYTHONPATH" not in env
+    assert "PYTHONHOME" not in env
+
+
+def test_build_subprocess_env_keeps_pythonpath_entries_for_staging_dir(tmp_path: Path):
+    class_entries = [str(tmp_path / "alpha"), str(tmp_path / "beta")]
+    base_env = {
+        "PYTHONPATH": "/tmp/ignored",
+        "PYTHONHOME": "/tmp/home",
+        "PATH": "/usr/bin",
+    }
+
+    env = process_support.build_subprocess_env(
+        base_env=base_env,
+        venv=tmp_path,
+        pythonpath_entries=class_entries,
+        sys_prefix=sys.prefix,
+    )
+
+    assert env["VIRTUAL_ENV"] == str(tmp_path / ".venv")
+    assert env["PYTHONPATH"] == os.pathsep.join(class_entries)
     assert "PYTHONHOME" not in env
 
 

--- a/src/agilab/core/agi-env/test/test_repository_support.py
+++ b/src/agilab/core/agi-env/test/test_repository_support.py
@@ -224,6 +224,35 @@ def test_collect_pythonpath_entries_uses_parent_when_init_file_exists(tmp_path: 
     assert entries[0] == str(package_parent.parent)
 
 
+def test_collect_pythonpath_entries_keeps_src_layout_root_with_init_file(tmp_path: Path):
+    src_root = tmp_path / "pkg" / "src"
+    src_root.mkdir(parents=True)
+    (src_root / "__init__.py").write_text("", encoding="utf-8")
+    env_pck = src_root / "agi_env"
+    env_pck.mkdir()
+
+    node_pck = tmp_path / "node" / "src" / "agi_node"
+    core_pck = tmp_path / "core" / "src" / "agi_core"
+    cluster_pck = tmp_path / "cluster" / "src" / "agi_cluster"
+    for pkg in (node_pck, core_pck, cluster_pck):
+        pkg.mkdir(parents=True)
+
+    entries = repository_support.collect_pythonpath_entries(
+        env_pck=env_pck,
+        node_pck=node_pck,
+        core_pck=core_pck,
+        cluster_pck=cluster_pck,
+        dist_abs=tmp_path / "dist",
+        app_src=tmp_path / "app_src",
+        wenv_abs=tmp_path / "wenv",
+        agilab_pck=tmp_path / "agilab_pck",
+        dedupe_paths_fn=lambda paths: [str(path) for path in paths],
+    )
+
+    assert entries[0] == str(src_root)
+    assert entries[1] == str(node_pck.parent)
+
+
 def test_configure_pythonpath_handles_empty_entries_and_preserves_existing_order():
     sys_path = ["/already-present"]
     environ = {}


### PR DESCRIPTION
## Summary
- keep AGILab source PYTHONPATH entries for worker staging directories while preserving isolation for real foreign virtualenvs
- keep `src` layout roots on PYTHONPATH even when `src/__init__.py` exists
- make the minimal run docs snippet compile as a standalone Python file

## Validation
- `/Users/jpm/agilab-validation/venv-catalina/bin/python -m pytest -q src/agilab/core/agi-env/test/test_process_support.py::test_build_subprocess_env_strips_uv_run_recursion_depth src/agilab/core/agi-env/test/test_process_support.py::test_build_subprocess_env_keeps_pythonpath_entries_for_staging_dir src/agilab/core/agi-env/test/test_process_support.py::test_build_subprocess_env_uses_pythonpath_entries_without_venv src/agilab/core/agi-env/test/test_process_support.py::test_build_subprocess_env_keeps_pythonpath_entries_for_current_venv src/agilab/core/agi-env/test/test_repository_support.py` -> 17 passed, 1 warning
- `/Users/jpm/agilab-validation/venv-catalina/bin/python -m py_compile docs/source/snippets/agi_core_mycode_minimal_run.py`
- used by sibling private app validation: 109 passed, 4 warnings