### PR TITLE
[codex] Add DAG dual concept figure and pipeline tests

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -9,6 +9,14 @@ if [[ "${AGILAB_SKIP_LOCAL_GUARDS:-}" == "1" ]]; then
 fi
 
 cd "$ROOT_DIR"
+uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py \
+  --verify-stamp \
+  --quiet
+uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py \
+  --check \
+  --delete \
+  --quiet \
+  --skip-missing-source
 uv --preview-features extra-build-dependencies run python tools/coverage_badge_guard.py \
   --changed-only \
   --require-fresh-xml

--- a/.github/workflows/docs-source-guard.yaml
+++ b/.github/workflows/docs-source-guard.yaml
@@ -44,6 +44,7 @@ jobs:
         run: |
           set -euo pipefail
           uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp --quiet
+          uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --check --delete --quiet --skip-missing-source
 
       - name: Test docs/source sync tool
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,11 +46,13 @@ Use this runbook whenever you:
   which targeted tests are required, whether install repros are mandatory, and whether generated
   artifacts such as badges, skill indexes, or run-config wrappers must be refreshed.
 - **Local pre-push guardrails**: Keep the repo hook enabled with
-  `git config core.hooksPath .githooks`. The pre-push hook runs
-  `tools/coverage_badge_guard.py --changed-only --require-fresh-xml` so stale
-  coverage badge SVGs are blocked locally before GitHub Actions. Bypass only
-  with `AGILAB_SKIP_LOCAL_GUARDS=1` when the skipped guard is intentional and
-  documented.
+  `git config core.hooksPath .githooks`. The pre-push hook verifies the
+  managed `docs/source` mirror stamp, compares the mirror against
+  `../thales_agilab/docs/source` when that canonical checkout is present, and
+  runs `tools/coverage_badge_guard.py --changed-only --require-fresh-xml` so
+  docs-source drift and stale coverage badge SVGs are blocked locally before
+  GitHub Actions. Bypass only with `AGILAB_SKIP_LOCAL_GUARDS=1` when the skipped
+  guard is intentional and documented.
 - **Run config parity**: After touching `.idea/runConfigurations/*.xml`, regenerate
   the CLI wrappers with `uv --preview-features extra-build-dependencies run python tools/generate_runconfig_scripts.py` and commit
   the results (`tools/run_configs/`).

--- a/badges/coverage-agi-core.svg
+++ b/badges/coverage-agi-core.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="160" height="20" role="img" aria-label="agi-core coverage: 98%">
+<svg xmlns="http://www.w3.org/2000/svg" width="160" height="20" role="img" aria-label="agi-core coverage: 99%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="64.5" y="15" fill="#010101" fill-opacity=".3">agi-core coverage</text>
   <text x="64.5" y="14">agi-core coverage</text>
-  <text x="144.5" y="15" fill="#010101" fill-opacity=".3">98%</text>
-  <text x="144.5" y="14">98%</text>
+  <text x="144.5" y="15" fill="#010101" fill-opacity=".3">99%</text>
+  <text x="144.5" y="14">99%</text>
 </g>
 </svg>

--- a/badges/coverage-agi-env.svg
+++ b/badges/coverage-agi-env.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="153" height="20" role="img" aria-label="agi-env coverage: 98%">
+<svg xmlns="http://www.w3.org/2000/svg" width="153" height="20" role="img" aria-label="agi-env coverage: 99%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="61.0" y="15" fill="#010101" fill-opacity=".3">agi-env coverage</text>
   <text x="61.0" y="14">agi-env coverage</text>
-  <text x="137.5" y="15" fill="#010101" fill-opacity=".3">98%</text>
-  <text x="137.5" y="14">98%</text>
+  <text x="137.5" y="15" fill="#010101" fill-opacity=".3">99%</text>
+  <text x="137.5" y="14">99%</text>
 </g>
 </svg>

--- a/badges/coverage-agi-node.svg
+++ b/badges/coverage-agi-node.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="160" height="20" role="img" aria-label="agi-node coverage: 98%">
+<svg xmlns="http://www.w3.org/2000/svg" width="160" height="20" role="img" aria-label="agi-node coverage: 99%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="64.5" y="15" fill="#010101" fill-opacity=".3">agi-node coverage</text>
   <text x="64.5" y="14">agi-node coverage</text>
-  <text x="144.5" y="15" fill="#010101" fill-opacity=".3">98%</text>
-  <text x="144.5" y="14">98%</text>
+  <text x="144.5" y="15" fill="#010101" fill-opacity=".3">99%</text>
+  <text x="144.5" y="14">99%</text>
 </g>
 </svg>

--- a/badges/coverage-agilab.svg
+++ b/badges/coverage-agilab.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="146" height="20" role="img" aria-label="agilab coverage: 95%">
+<svg xmlns="http://www.w3.org/2000/svg" width="146" height="20" role="img" aria-label="agilab coverage: 96%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="57.5" y="15" fill="#010101" fill-opacity=".3">agilab coverage</text>
   <text x="57.5" y="14">agilab coverage</text>
-  <text x="130.5" y="15" fill="#010101" fill-opacity=".3">95%</text>
-  <text x="130.5" y="14">95%</text>
+  <text x="130.5" y="15" fill="#010101" fill-opacity=".3">96%</text>
+  <text x="130.5" y="14">96%</text>
 </g>
 </svg>

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -1,9 +1,9 @@
 {
-  "file_count": 163,
+  "file_count": 164,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "fb8cfacf644ca9f579ba35866bdd2a956c279658692a962a304b4b4990ce36e9",
+  "source_digest_sha256": "0ab6679a07c65a0af1be9fd7539070dc6f803af550913c44f8af33d44648c2f2",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "fb8cfacf644ca9f579ba35866bdd2a956c279658692a962a304b4b4990ce36e9"
+  "target_digest_sha256": "0ab6679a07c65a0af1be9fd7539070dc6f803af550913c44f8af33d44648c2f2"
 }

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 164,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "0ab6679a07c65a0af1be9fd7539070dc6f803af550913c44f8af33d44648c2f2",
+  "source_digest_sha256": "28fe5634103f32b3a69d1fcd51fbd27d7b9c75e51ec17f104ea6c5cc8bc70a0c",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "0ab6679a07c65a0af1be9fd7539070dc6f803af550913c44f8af33d44648c2f2"
+  "target_digest_sha256": "28fe5634103f32b3a69d1fcd51fbd27d7b9c75e51ec17f104ea6c5cc8bc70a0c"
 }

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 164,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "28fe5634103f32b3a69d1fcd51fbd27d7b9c75e51ec17f104ea6c5cc8bc70a0c",
+  "source_digest_sha256": "3618f1544b72bbd236186171c2bfe1cda8fa1e027a6dc27369a35cb8e56641cb",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "28fe5634103f32b3a69d1fcd51fbd27d7b9c75e51ec17f104ea6c5cc8bc70a0c"
+  "target_digest_sha256": "3618f1544b72bbd236186171c2bfe1cda8fa1e027a6dc27369a35cb8e56641cb"
 }

--- a/docs/source/agilab-demo.rst
+++ b/docs/source/agilab-demo.rst
@@ -1,8 +1,10 @@
+:orphan:
+
 AGILAB Demo
 ===========
 
 Use this page when you want the public hosted AGILAB web UI first. This is the
-sidebar-visible counterpart to :doc:`notebook-quickstart`, which is the
+hosted web UI counterpart to :doc:`notebook-quickstart`, which is the
 notebook-first ``agi-core`` demo.
 
 Start here

--- a/docs/source/diagrams/dag_dual_concept.svg
+++ b/docs/source/diagrams/dag_dual_concept.svg
@@ -1,29 +1,31 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="880" viewBox="0 0 1400 880" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="900" viewBox="0 0 1400 900" role="img" aria-labelledby="title desc">
   <title id="title">AGILab dual DAG concept</title>
-  <desc id="desc">Diagram showing one AGILab DAG contract projected into a conceptual review view and an execution runner view, linked by stable node IDs, artifact names, and provenance.</desc>
+  <desc id="desc">Diagram showing one AGILab DAG contract projected into a conceptual review view and an execution runner view, linked by stable node IDs, artifact names, status records, and provenance.</desc>
   <defs>
     <style>
       .bg { fill: #f7f6f2; }
-      .title { font: 700 34px "DejaVu Sans", Arial, sans-serif; fill: #1c2b32; }
-      .subtitle { font: 500 18px "DejaVu Sans", Arial, sans-serif; fill: #4f626b; }
-      .source { fill: #fffdf8; stroke: #60727a; stroke-width: 2; }
-      .concept-lane { fill: #e9f3fb; stroke: #3a7199; stroke-width: 2.4; }
-      .execution-lane { fill: #f4efe3; stroke: #94722f; stroke-width: 2.4; }
-      .bridge { fill: #eef2ee; stroke: #5f756e; stroke-width: 2; }
-      .concept-node { fill: #fbfdff; stroke: #3a7199; stroke-width: 2; }
-      .execution-node { fill: #fffdf8; stroke: #94722f; stroke-width: 2; }
+      .title { font: 700 34px Arial, Helvetica, sans-serif; fill: #1c2b32; }
+      .subtitle { font: 500 18px Arial, Helvetica, sans-serif; fill: #4f626b; }
+      .source { fill: #fffdf8; stroke: #60727a; stroke-width: 2.2; }
+      .concept-lane { fill: #e8f3fb; stroke: #2f719f; stroke-width: 2.6; }
+      .execution-lane { fill: #f4efe3; stroke: #98712c; stroke-width: 2.6; }
+      .bridge { fill: #edf3ef; stroke: #5f756e; stroke-width: 2; }
+      .concept-node { fill: #fbfdff; stroke: #2f719f; stroke-width: 2; }
+      .execution-node { fill: #fffdf8; stroke: #98712c; stroke-width: 2; }
       .source-node { fill: #f8fbfb; stroke: #60727a; stroke-width: 1.8; }
-      .lane-title { font: 700 23px "DejaVu Sans", Arial, sans-serif; fill: #20313a; }
-      .lane-note { font: 500 15px "DejaVu Sans", Arial, sans-serif; fill: #536770; }
-      .box-title { font: 700 17px "DejaVu Sans", Arial, sans-serif; fill: #1f2e35; }
-      .body { font: 15px "DejaVu Sans", Arial, sans-serif; fill: #263942; }
-      .small { font: 13.5px "DejaVu Sans", Arial, sans-serif; fill: #56666d; }
+      .lane-title { font: 700 24px Arial, Helvetica, sans-serif; fill: #20313a; }
+      .lane-note { font: 500 15.5px Arial, Helvetica, sans-serif; fill: #536770; }
+      .box-title { font: 700 17px Arial, Helvetica, sans-serif; fill: #1f2e35; }
+      .body { font: 15.2px Arial, Helvetica, sans-serif; fill: #263942; }
+      .small { font: 13.5px Arial, Helvetica, sans-serif; fill: #56666d; }
+      .label-pill { fill: #fffdf8; stroke: #bac6c7; stroke-width: 1.2; }
+      .label-text { font: 700 12.5px Arial, Helvetica, sans-serif; fill: #51666e; }
       .chip { fill: #ffffff; stroke: #bac6c7; stroke-width: 1.3; }
-      .chip-text { font: 700 14px "DejaVu Sans", Arial, sans-serif; fill: #2f454d; }
-      .concept-arrow { stroke: #2d6f9f; stroke-width: 3.2; fill: none; marker-end: url(#arrowConcept); }
-      .execution-arrow { stroke: #8b6724; stroke-width: 3.2; fill: none; marker-end: url(#arrowExecution); }
+      .chip-text { font: 700 14px Arial, Helvetica, sans-serif; fill: #2f454d; }
+      .concept-arrow { stroke: #2d6f9f; stroke-width: 3.4; fill: none; marker-end: url(#arrowConcept); }
+      .execution-arrow { stroke: #8b6724; stroke-width: 3.4; fill: none; marker-end: url(#arrowExecution); }
       .source-arrow { stroke: #60727a; stroke-width: 3; fill: none; marker-end: url(#arrowSource); }
-      .trace { stroke: #738987; stroke-width: 2.2; stroke-dasharray: 8 8; fill: none; }
+      .trace { stroke: #738987; stroke-width: 2.1; stroke-dasharray: 8 8; fill: none; }
       .divider { stroke: #c7d1d2; stroke-width: 1.4; stroke-dasharray: 5 7; }
     </style>
     <marker id="arrowConcept" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto">
@@ -37,144 +39,147 @@
     </marker>
   </defs>
 
-  <rect class="bg" x="0" y="0" width="1400" height="880"/>
+  <rect class="bg" x="0" y="0" width="1400" height="900"/>
 
   <text class="title" x="700" y="56" text-anchor="middle">Dual DAG concept</text>
   <text class="subtitle" x="700" y="88" text-anchor="middle">One workflow contract, two synchronized projections: readable intent above, executable state below.</text>
 
   <g id="source-contract">
-    <rect class="source" x="56" y="280" width="230" height="276" rx="24" ry="24"/>
-    <text class="lane-title" x="171" y="322" text-anchor="middle">DAG contract</text>
-    <text class="lane-note" x="171" y="348" text-anchor="middle">single source of truth</text>
+    <rect class="source" x="40" y="292" width="220" height="296" rx="24" ry="24"/>
+    <text class="lane-title" x="150" y="330" text-anchor="middle">DAG contract</text>
+    <text class="lane-note" x="150" y="356" text-anchor="middle">single source of truth</text>
 
-    <rect class="source-node" x="86" y="380" width="170" height="42" rx="14" ry="14"/>
-    <text class="chip-text" x="171" y="407" text-anchor="middle">multi_app_dag.json</text>
+    <rect class="source-node" x="70" y="390" width="160" height="44" rx="14" ry="14"/>
+    <text class="chip-text" x="150" y="418" text-anchor="middle">multi_app_dag.json</text>
 
-    <rect class="source-node" x="86" y="438" width="170" height="42" rx="14" ry="14"/>
-    <text class="chip-text" x="171" y="465" text-anchor="middle">pipeline_view.dot</text>
+    <rect class="source-node" x="70" y="454" width="160" height="44" rx="14" ry="14"/>
+    <text class="chip-text" x="150" y="482" text-anchor="middle">pipeline_view.dot</text>
 
-    <rect class="source-node" x="86" y="496" width="170" height="42" rx="14" ry="14"/>
-    <text class="chip-text" x="171" y="523" text-anchor="middle">artifact edges</text>
+    <rect class="source-node" x="70" y="518" width="160" height="44" rx="14" ry="14"/>
+    <text class="chip-text" x="150" y="546" text-anchor="middle">artifact edges</text>
   </g>
 
   <g id="conceptual-view">
-    <rect class="concept-lane" x="330" y="126" width="1014" height="258" rx="28" ry="28"/>
-    <text class="lane-title" x="366" y="166">Conceptual DAG view</text>
-    <text class="lane-note" x="366" y="193">Reviewer-facing view: what the workflow means, where artifacts move, and why dependencies exist.</text>
+    <rect class="concept-lane" x="330" y="120" width="1020" height="276" rx="28" ry="28"/>
+    <text class="lane-title" x="366" y="160">Conceptual DAG view</text>
+    <text class="lane-note" x="366" y="188">Reviewer-facing: what the workflow means, where artifacts move, and why dependencies exist.</text>
 
-    <rect class="concept-node" x="366" y="228" width="188" height="102" rx="16" ry="16"/>
-    <text class="box-title" x="460" y="258" text-anchor="middle">Domain nodes</text>
-    <text class="body" x="386" y="284">
+    <rect class="concept-node" x="362" y="228" width="200" height="116" rx="16" ry="16"/>
+    <text class="box-title" x="462" y="260" text-anchor="middle">Domain nodes</text>
+    <text class="body" x="386" y="288">
       <tspan x="386" dy="0">Apps and named</tspan>
-      <tspan x="386" dy="20">workflow steps.</tspan>
+      <tspan x="386" dy="21">workflow steps.</tspan>
     </text>
-    <text class="small" x="386" y="320">Example: queue baseline</text>
+    <text class="small" x="386" y="326">Example: queue baseline</text>
 
-    <rect class="concept-node" x="616" y="228" width="188" height="102" rx="16" ry="16"/>
-    <text class="box-title" x="710" y="258" text-anchor="middle">Local pipeline</text>
-    <text class="body" x="636" y="284">
-      <tspan x="636" dy="0">App-level steps from</tspan>
-      <tspan x="636" dy="20">pipeline_view files.</tspan>
+    <rect class="concept-node" x="615" y="228" width="200" height="116" rx="16" ry="16"/>
+    <text class="box-title" x="715" y="260" text-anchor="middle">Local pipeline</text>
+    <text class="body" x="639" y="288">
+      <tspan x="639" dy="0">App-level steps from</tspan>
+      <tspan x="639" dy="21">pipeline_view files.</tspan>
     </text>
-    <text class="small" x="636" y="320">Readable expansion</text>
+    <text class="small" x="639" y="326">Readable expansion</text>
 
-    <rect class="concept-node" x="866" y="228" width="188" height="102" rx="16" ry="16"/>
-    <text class="box-title" x="960" y="258" text-anchor="middle">Artifact handoff</text>
-    <text class="body" x="886" y="284">
-      <tspan x="886" dy="0">Explicit cross-app</tspan>
-      <tspan x="886" dy="20">data dependency.</tspan>
+    <rect class="concept-node" x="868" y="228" width="200" height="116" rx="16" ry="16"/>
+    <text class="box-title" x="968" y="260" text-anchor="middle">Artifact handoff</text>
+    <text class="body" x="892" y="288">
+      <tspan x="892" dy="0">Explicit cross-app</tspan>
+      <tspan x="892" dy="21">data dependency.</tspan>
     </text>
-    <text class="small" x="886" y="320">Example: queue_metrics</text>
+    <text class="small" x="892" y="326">Example: queue_metrics</text>
 
-    <rect class="concept-node" x="1116" y="228" width="188" height="102" rx="16" ry="16"/>
-    <text class="box-title" x="1210" y="258" text-anchor="middle">Review map</text>
-    <text class="body" x="1136" y="284">
-      <tspan x="1136" dy="0">Clear graph for design,</tspan>
-      <tspan x="1136" dy="20">QA, and documentation.</tspan>
+    <rect class="concept-node" x="1121" y="228" width="200" height="116" rx="16" ry="16"/>
+    <text class="box-title" x="1221" y="260" text-anchor="middle">Review map</text>
+    <text class="body" x="1145" y="288">
+      <tspan x="1145" dy="0">Clear graph for design,</tspan>
+      <tspan x="1145" dy="21">QA, and documentation.</tspan>
     </text>
-    <text class="small" x="1136" y="320">No runner side effects</text>
+    <text class="small" x="1145" y="326">No runner side effects</text>
 
-    <path class="concept-arrow" d="M 554 279 L 602 279"/>
-    <path class="concept-arrow" d="M 804 279 L 852 279"/>
-    <path class="concept-arrow" d="M 1054 279 L 1102 279"/>
+    <path class="concept-arrow" d="M 562 286 L 600 286"/>
+    <path class="concept-arrow" d="M 815 286 L 853 286"/>
+    <path class="concept-arrow" d="M 1068 286 L 1106 286"/>
   </g>
 
   <g id="projection-bridge">
-    <rect class="bridge" x="464" y="404" width="746" height="62" rx="22" ry="22"/>
-    <text class="box-title" x="837" y="431" text-anchor="middle">Shared identity keeps both views aligned</text>
-    <text class="body" x="837" y="454" text-anchor="middle">stable node IDs, artifact names, status records, and provenance paths</text>
+    <rect class="bridge" x="454" y="418" width="780" height="66" rx="22" ry="22"/>
+    <text class="box-title" x="844" y="446" text-anchor="middle">Shared identity keeps both views aligned</text>
+    <text class="body" x="844" y="470" text-anchor="middle">stable node IDs, artifact names, status records, and provenance paths</text>
 
-    <path class="trace" d="M 460 330 L 460 404"/>
-    <path class="trace" d="M 710 330 L 710 404"/>
-    <path class="trace" d="M 960 330 L 960 404"/>
-    <path class="trace" d="M 1210 330 L 1210 404"/>
-    <path class="trace" d="M 460 466 L 460 540"/>
-    <path class="trace" d="M 710 466 L 710 540"/>
-    <path class="trace" d="M 960 466 L 960 540"/>
-    <path class="trace" d="M 1210 466 L 1210 540"/>
+    <path class="trace" d="M 462 344 L 462 418"/>
+    <path class="trace" d="M 715 344 L 715 418"/>
+    <path class="trace" d="M 968 344 L 968 418"/>
+    <path class="trace" d="M 1221 344 L 1221 418"/>
+    <path class="trace" d="M 462 484 L 462 600"/>
+    <path class="trace" d="M 715 484 L 715 600"/>
+    <path class="trace" d="M 968 484 L 968 600"/>
+    <path class="trace" d="M 1221 484 L 1221 600"/>
   </g>
 
   <g id="execution-view">
-    <rect class="execution-lane" x="330" y="486" width="1014" height="258" rx="28" ry="28"/>
-    <text class="lane-title" x="366" y="526">Execution DAG view</text>
-    <text class="lane-note" x="366" y="553">Runner-facing view: which units can run, which artifacts are available, and what the operator can do next.</text>
+    <rect class="execution-lane" x="330" y="500" width="1020" height="276" rx="28" ry="28"/>
+    <text class="lane-title" x="366" y="540">Execution DAG view</text>
+    <text class="lane-note" x="366" y="568">Runner-facing: which units can run, which artifacts are available, and what the operator can do next.</text>
 
-    <rect class="execution-node" x="366" y="588" width="188" height="102" rx="16" ry="16"/>
-    <text class="box-title" x="460" y="618" text-anchor="middle">Plan units</text>
-    <text class="body" x="386" y="644">
+    <rect class="execution-node" x="362" y="608" width="200" height="116" rx="16" ry="16"/>
+    <text class="box-title" x="462" y="640" text-anchor="middle">Plan units</text>
+    <text class="body" x="386" y="668">
       <tspan x="386" dy="0">Topological order and</tspan>
-      <tspan x="386" dy="20">runnable work items.</tspan>
+      <tspan x="386" dy="21">runnable work items.</tspan>
     </text>
-    <text class="small" x="386" y="680">pending to runnable</text>
+    <text class="small" x="386" y="706">pending to runnable</text>
 
-    <rect class="execution-node" x="616" y="588" width="188" height="102" rx="16" ry="16"/>
-    <text class="box-title" x="710" y="618" text-anchor="middle">Readiness gates</text>
-    <text class="body" x="636" y="644">
-      <tspan x="636" dy="0">Blocked until upstream</tspan>
-      <tspan x="636" dy="20">artifacts are present.</tspan>
+    <rect class="execution-node" x="615" y="608" width="200" height="116" rx="16" ry="16"/>
+    <text class="box-title" x="715" y="640" text-anchor="middle">Readiness gates</text>
+    <text class="body" x="639" y="668">
+      <tspan x="639" dy="0">Blocked until upstream</tspan>
+      <tspan x="639" dy="21">artifacts are present.</tspan>
     </text>
-    <text class="small" x="636" y="680">runnable or blocked</text>
+    <text class="small" x="639" y="706">runnable or blocked</text>
 
-    <rect class="execution-node" x="866" y="588" width="188" height="102" rx="16" ry="16"/>
-    <text class="box-title" x="960" y="618" text-anchor="middle">Dispatch state</text>
-    <text class="body" x="886" y="644">
-      <tspan x="886" dy="0">Persisted outputs, retry</tspan>
-      <tspan x="886" dy="20">counters, and timestamps.</tspan>
+    <rect class="execution-node" x="868" y="608" width="200" height="116" rx="16" ry="16"/>
+    <text class="box-title" x="968" y="640" text-anchor="middle">Dispatch state</text>
+    <text class="body" x="892" y="668">
+      <tspan x="892" dy="0">Persisted outputs, retry</tspan>
+      <tspan x="892" dy="21">counters, and timing.</tspan>
     </text>
-    <text class="small" x="886" y="680">auditable state</text>
+    <text class="small" x="892" y="706">auditable state</text>
 
-    <rect class="execution-node" x="1116" y="588" width="188" height="102" rx="16" ry="16"/>
-    <text class="box-title" x="1210" y="618" text-anchor="middle">Operator UI</text>
-    <text class="body" x="1136" y="644">
-      <tspan x="1136" dy="0">Status, dependency view,</tspan>
-      <tspan x="1136" dy="20">retry, and partial rerun.</tspan>
+    <rect class="execution-node" x="1121" y="608" width="200" height="116" rx="16" ry="16"/>
+    <text class="box-title" x="1221" y="640" text-anchor="middle">Operator UI</text>
+    <text class="body" x="1145" y="668">
+      <tspan x="1145" dy="0">Status, dependency view,</tspan>
+      <tspan x="1145" dy="21">retry, and partial rerun.</tspan>
     </text>
-    <text class="small" x="1136" y="680">actionable controls</text>
+    <text class="small" x="1145" y="706">actionable controls</text>
 
-    <path class="execution-arrow" d="M 554 639 L 602 639"/>
-    <path class="execution-arrow" d="M 804 639 L 852 639"/>
-    <path class="execution-arrow" d="M 1054 639 L 1102 639"/>
+    <path class="execution-arrow" d="M 562 666 L 600 666"/>
+    <path class="execution-arrow" d="M 815 666 L 853 666"/>
+    <path class="execution-arrow" d="M 1068 666 L 1106 666"/>
   </g>
 
   <g id="source-projections">
-    <path class="source-arrow" d="M 286 365 C 302 365 304 254 352 254"/>
-    <path class="source-arrow" d="M 286 486 C 302 486 304 614 352 614"/>
-    <text class="small" x="300" y="318" text-anchor="middle">readable</text>
-    <text class="small" x="302" y="589" text-anchor="middle">runnable</text>
+    <path class="source-arrow" d="M 260 392 C 302 392 294 286 348 286"/>
+    <rect class="label-pill" x="268" y="318" width="86" height="28" rx="12" ry="12"/>
+    <text class="label-text" x="311" y="336" text-anchor="middle">review view</text>
+
+    <path class="source-arrow" d="M 260 504 C 302 504 294 666 348 666"/>
+    <rect class="label-pill" x="268" y="574" width="86" height="28" rx="12" ry="12"/>
+    <text class="label-text" x="311" y="592" text-anchor="middle">runner view</text>
   </g>
 
   <g id="footer">
-    <line class="divider" x1="56" y1="784" x2="1344" y2="784"/>
-    <rect class="chip" x="188" y="810" width="250" height="42" rx="16" ry="16"/>
-    <text class="chip-text" x="313" y="836" text-anchor="middle">one contract, no duplicate graph</text>
+    <line class="divider" x1="56" y1="806" x2="1344" y2="806"/>
+    <rect class="chip" x="182" y="828" width="262" height="42" rx="16" ry="16"/>
+    <text class="chip-text" x="313" y="854" text-anchor="middle">one contract, no duplicate graph</text>
 
-    <rect class="chip" x="492" y="810" width="236" height="42" rx="16" ry="16"/>
-    <text class="chip-text" x="610" y="836" text-anchor="middle">conceptual view explains intent</text>
+    <rect class="chip" x="486" y="828" width="248" height="42" rx="16" ry="16"/>
+    <text class="chip-text" x="610" y="854" text-anchor="middle">conceptual view explains intent</text>
 
-    <rect class="chip" x="782" y="810" width="226" height="42" rx="16" ry="16"/>
-    <text class="chip-text" x="895" y="836" text-anchor="middle">execution view drives state</text>
+    <rect class="chip" x="776" y="828" width="238" height="42" rx="16" ry="16"/>
+    <text class="chip-text" x="895" y="854" text-anchor="middle">execution view drives state</text>
 
-    <rect class="chip" x="1062" y="810" width="248" height="42" rx="16" ry="16"/>
-    <text class="chip-text" x="1186" y="836" text-anchor="middle">provenance links them together</text>
+    <rect class="chip" x="1056" y="828" width="260" height="42" rx="16" ry="16"/>
+    <text class="chip-text" x="1186" y="854" text-anchor="middle">provenance links them together</text>
   </g>
 </svg>

--- a/docs/source/diagrams/dag_dual_concept.svg
+++ b/docs/source/diagrams/dag_dual_concept.svg
@@ -1,0 +1,180 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="880" viewBox="0 0 1400 880" role="img" aria-labelledby="title desc">
+  <title id="title">AGILab dual DAG concept</title>
+  <desc id="desc">Diagram showing one AGILab DAG contract projected into a conceptual review view and an execution runner view, linked by stable node IDs, artifact names, and provenance.</desc>
+  <defs>
+    <style>
+      .bg { fill: #f7f6f2; }
+      .title { font: 700 34px "DejaVu Sans", Arial, sans-serif; fill: #1c2b32; }
+      .subtitle { font: 500 18px "DejaVu Sans", Arial, sans-serif; fill: #4f626b; }
+      .source { fill: #fffdf8; stroke: #60727a; stroke-width: 2; }
+      .concept-lane { fill: #e9f3fb; stroke: #3a7199; stroke-width: 2.4; }
+      .execution-lane { fill: #f4efe3; stroke: #94722f; stroke-width: 2.4; }
+      .bridge { fill: #eef2ee; stroke: #5f756e; stroke-width: 2; }
+      .concept-node { fill: #fbfdff; stroke: #3a7199; stroke-width: 2; }
+      .execution-node { fill: #fffdf8; stroke: #94722f; stroke-width: 2; }
+      .source-node { fill: #f8fbfb; stroke: #60727a; stroke-width: 1.8; }
+      .lane-title { font: 700 23px "DejaVu Sans", Arial, sans-serif; fill: #20313a; }
+      .lane-note { font: 500 15px "DejaVu Sans", Arial, sans-serif; fill: #536770; }
+      .box-title { font: 700 17px "DejaVu Sans", Arial, sans-serif; fill: #1f2e35; }
+      .body { font: 15px "DejaVu Sans", Arial, sans-serif; fill: #263942; }
+      .small { font: 13.5px "DejaVu Sans", Arial, sans-serif; fill: #56666d; }
+      .chip { fill: #ffffff; stroke: #bac6c7; stroke-width: 1.3; }
+      .chip-text { font: 700 14px "DejaVu Sans", Arial, sans-serif; fill: #2f454d; }
+      .concept-arrow { stroke: #2d6f9f; stroke-width: 3.2; fill: none; marker-end: url(#arrowConcept); }
+      .execution-arrow { stroke: #8b6724; stroke-width: 3.2; fill: none; marker-end: url(#arrowExecution); }
+      .source-arrow { stroke: #60727a; stroke-width: 3; fill: none; marker-end: url(#arrowSource); }
+      .trace { stroke: #738987; stroke-width: 2.2; stroke-dasharray: 8 8; fill: none; }
+      .divider { stroke: #c7d1d2; stroke-width: 1.4; stroke-dasharray: 5 7; }
+    </style>
+    <marker id="arrowConcept" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto">
+      <path d="M 0 0 L 12 6 L 0 12 z" fill="#2d6f9f"/>
+    </marker>
+    <marker id="arrowExecution" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto">
+      <path d="M 0 0 L 12 6 L 0 12 z" fill="#8b6724"/>
+    </marker>
+    <marker id="arrowSource" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto">
+      <path d="M 0 0 L 12 6 L 0 12 z" fill="#60727a"/>
+    </marker>
+  </defs>
+
+  <rect class="bg" x="0" y="0" width="1400" height="880"/>
+
+  <text class="title" x="700" y="56" text-anchor="middle">Dual DAG concept</text>
+  <text class="subtitle" x="700" y="88" text-anchor="middle">One workflow contract, two synchronized projections: readable intent above, executable state below.</text>
+
+  <g id="source-contract">
+    <rect class="source" x="56" y="280" width="230" height="276" rx="24" ry="24"/>
+    <text class="lane-title" x="171" y="322" text-anchor="middle">DAG contract</text>
+    <text class="lane-note" x="171" y="348" text-anchor="middle">single source of truth</text>
+
+    <rect class="source-node" x="86" y="380" width="170" height="42" rx="14" ry="14"/>
+    <text class="chip-text" x="171" y="407" text-anchor="middle">multi_app_dag.json</text>
+
+    <rect class="source-node" x="86" y="438" width="170" height="42" rx="14" ry="14"/>
+    <text class="chip-text" x="171" y="465" text-anchor="middle">pipeline_view.dot</text>
+
+    <rect class="source-node" x="86" y="496" width="170" height="42" rx="14" ry="14"/>
+    <text class="chip-text" x="171" y="523" text-anchor="middle">artifact edges</text>
+  </g>
+
+  <g id="conceptual-view">
+    <rect class="concept-lane" x="330" y="126" width="1014" height="258" rx="28" ry="28"/>
+    <text class="lane-title" x="366" y="166">Conceptual DAG view</text>
+    <text class="lane-note" x="366" y="193">Reviewer-facing view: what the workflow means, where artifacts move, and why dependencies exist.</text>
+
+    <rect class="concept-node" x="366" y="228" width="188" height="102" rx="16" ry="16"/>
+    <text class="box-title" x="460" y="258" text-anchor="middle">Domain nodes</text>
+    <text class="body" x="386" y="284">
+      <tspan x="386" dy="0">Apps and named</tspan>
+      <tspan x="386" dy="20">workflow steps.</tspan>
+    </text>
+    <text class="small" x="386" y="320">Example: queue baseline</text>
+
+    <rect class="concept-node" x="616" y="228" width="188" height="102" rx="16" ry="16"/>
+    <text class="box-title" x="710" y="258" text-anchor="middle">Local pipeline</text>
+    <text class="body" x="636" y="284">
+      <tspan x="636" dy="0">App-level steps from</tspan>
+      <tspan x="636" dy="20">pipeline_view files.</tspan>
+    </text>
+    <text class="small" x="636" y="320">Readable expansion</text>
+
+    <rect class="concept-node" x="866" y="228" width="188" height="102" rx="16" ry="16"/>
+    <text class="box-title" x="960" y="258" text-anchor="middle">Artifact handoff</text>
+    <text class="body" x="886" y="284">
+      <tspan x="886" dy="0">Explicit cross-app</tspan>
+      <tspan x="886" dy="20">data dependency.</tspan>
+    </text>
+    <text class="small" x="886" y="320">Example: queue_metrics</text>
+
+    <rect class="concept-node" x="1116" y="228" width="188" height="102" rx="16" ry="16"/>
+    <text class="box-title" x="1210" y="258" text-anchor="middle">Review map</text>
+    <text class="body" x="1136" y="284">
+      <tspan x="1136" dy="0">Clear graph for design,</tspan>
+      <tspan x="1136" dy="20">QA, and documentation.</tspan>
+    </text>
+    <text class="small" x="1136" y="320">No runner side effects</text>
+
+    <path class="concept-arrow" d="M 554 279 L 602 279"/>
+    <path class="concept-arrow" d="M 804 279 L 852 279"/>
+    <path class="concept-arrow" d="M 1054 279 L 1102 279"/>
+  </g>
+
+  <g id="projection-bridge">
+    <rect class="bridge" x="464" y="404" width="746" height="62" rx="22" ry="22"/>
+    <text class="box-title" x="837" y="431" text-anchor="middle">Shared identity keeps both views aligned</text>
+    <text class="body" x="837" y="454" text-anchor="middle">stable node IDs, artifact names, status records, and provenance paths</text>
+
+    <path class="trace" d="M 460 330 L 460 404"/>
+    <path class="trace" d="M 710 330 L 710 404"/>
+    <path class="trace" d="M 960 330 L 960 404"/>
+    <path class="trace" d="M 1210 330 L 1210 404"/>
+    <path class="trace" d="M 460 466 L 460 540"/>
+    <path class="trace" d="M 710 466 L 710 540"/>
+    <path class="trace" d="M 960 466 L 960 540"/>
+    <path class="trace" d="M 1210 466 L 1210 540"/>
+  </g>
+
+  <g id="execution-view">
+    <rect class="execution-lane" x="330" y="486" width="1014" height="258" rx="28" ry="28"/>
+    <text class="lane-title" x="366" y="526">Execution DAG view</text>
+    <text class="lane-note" x="366" y="553">Runner-facing view: which units can run, which artifacts are available, and what the operator can do next.</text>
+
+    <rect class="execution-node" x="366" y="588" width="188" height="102" rx="16" ry="16"/>
+    <text class="box-title" x="460" y="618" text-anchor="middle">Plan units</text>
+    <text class="body" x="386" y="644">
+      <tspan x="386" dy="0">Topological order and</tspan>
+      <tspan x="386" dy="20">runnable work items.</tspan>
+    </text>
+    <text class="small" x="386" y="680">pending to runnable</text>
+
+    <rect class="execution-node" x="616" y="588" width="188" height="102" rx="16" ry="16"/>
+    <text class="box-title" x="710" y="618" text-anchor="middle">Readiness gates</text>
+    <text class="body" x="636" y="644">
+      <tspan x="636" dy="0">Blocked until upstream</tspan>
+      <tspan x="636" dy="20">artifacts are present.</tspan>
+    </text>
+    <text class="small" x="636" y="680">runnable or blocked</text>
+
+    <rect class="execution-node" x="866" y="588" width="188" height="102" rx="16" ry="16"/>
+    <text class="box-title" x="960" y="618" text-anchor="middle">Dispatch state</text>
+    <text class="body" x="886" y="644">
+      <tspan x="886" dy="0">Persisted outputs, retry</tspan>
+      <tspan x="886" dy="20">counters, and timestamps.</tspan>
+    </text>
+    <text class="small" x="886" y="680">auditable state</text>
+
+    <rect class="execution-node" x="1116" y="588" width="188" height="102" rx="16" ry="16"/>
+    <text class="box-title" x="1210" y="618" text-anchor="middle">Operator UI</text>
+    <text class="body" x="1136" y="644">
+      <tspan x="1136" dy="0">Status, dependency view,</tspan>
+      <tspan x="1136" dy="20">retry, and partial rerun.</tspan>
+    </text>
+    <text class="small" x="1136" y="680">actionable controls</text>
+
+    <path class="execution-arrow" d="M 554 639 L 602 639"/>
+    <path class="execution-arrow" d="M 804 639 L 852 639"/>
+    <path class="execution-arrow" d="M 1054 639 L 1102 639"/>
+  </g>
+
+  <g id="source-projections">
+    <path class="source-arrow" d="M 286 365 C 302 365 304 254 352 254"/>
+    <path class="source-arrow" d="M 286 486 C 302 486 304 614 352 614"/>
+    <text class="small" x="300" y="318" text-anchor="middle">readable</text>
+    <text class="small" x="302" y="589" text-anchor="middle">runnable</text>
+  </g>
+
+  <g id="footer">
+    <line class="divider" x1="56" y1="784" x2="1344" y2="784"/>
+    <rect class="chip" x="188" y="810" width="250" height="42" rx="16" ry="16"/>
+    <text class="chip-text" x="313" y="836" text-anchor="middle">one contract, no duplicate graph</text>
+
+    <rect class="chip" x="492" y="810" width="236" height="42" rx="16" ry="16"/>
+    <text class="chip-text" x="610" y="836" text-anchor="middle">conceptual view explains intent</text>
+
+    <rect class="chip" x="782" y="810" width="226" height="42" rx="16" ry="16"/>
+    <text class="chip-text" x="895" y="836" text-anchor="middle">execution view drives state</text>
+
+    <rect class="chip" x="1062" y="810" width="248" height="42" rx="16" ry="16"/>
+    <text class="chip-text" x="1186" y="836" text-anchor="middle">provenance links them together</text>
+  </g>
+</svg>

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -272,6 +272,19 @@ single notebook but less ceremony than a production MLOps platform:
   the same harvest input without querying live provider APIs; opt-in
   ``--live-gitlab`` can query and download a GitLab CI pipeline when operator
   credentials are available
+
+The DAG evidence below has two synchronized projections: a reviewer-facing
+conceptual graph and a runner-facing execution state graph. Both stay anchored
+to the same contract, artifact names, stable node IDs, and provenance.
+
+.. figure:: diagrams/dag_dual_concept.svg
+   :alt: AGILab dual DAG concept showing one contract projected into conceptual and execution views.
+   :align: center
+   :width: 100%
+
+   One DAG contract drives both the readable workflow review view and the
+   executable runner-state view without duplicating the graph.
+
 - the multi-app DAG contract now validates app-to-app dependencies and
   artifact handoffs with ``tools/multi_app_dag_report.py --compact`` against
   ``docs/source/data/multi_app_dag_sample.json``; the first sample links

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -33,7 +33,6 @@ references, and example projects.
 
    introduction
    features
-   AGILAB Demo <agilab-demo>
    notebook-quickstart
    notebook-advanced
    agilab

--- a/docs/source/quick-start.rst
+++ b/docs/source/quick-start.rst
@@ -134,7 +134,7 @@ Use these only after the local ``flight_project`` proof works once.
    :alt: AGILAB demo
 
 Self-serve public AGILAB demo hosted on Hugging Face Spaces.
-The sidebar-visible docs page for this route is :doc:`agilab-demo`.
+The dedicated docs page for this route is :doc:`agilab-demo`.
 
 **Published package route** (fastest install, less representative of the full product path)::
 

--- a/test/test_pipeline_run_controls.py
+++ b/test/test_pipeline_run_controls.py
@@ -223,6 +223,101 @@ def test_pipeline_run_controls_acquire_refresh_release_and_busy_lock(tmp_path, m
     assert module._acquire_pipeline_run_lock(env, "page", force=True) is None
 
 
+def test_pipeline_run_controls_edge_branches_for_logs_ttl_and_lock_payloads(tmp_path, monkeypatch):
+    module = _import_pipeline_run_controls()
+    fake_st = _FakeStreamlit()
+    monkeypatch.setattr(module, "st", fake_st)
+
+    placeholder = _FakePlaceholder()
+    bad_log_path = tmp_path / "bad-log-dir"
+    bad_log_path.mkdir()
+    fake_st.session_state["page__run_log_file"] = str(bad_log_path)
+    module._push_run_log("page", "cannot append", placeholder)
+    assert placeholder.codes[-1] == "cannot append"
+
+    calls: list[object] = []
+
+    class _RerunStreamlit(_FakeStreamlit):
+        def rerun(self, scope=None):
+            calls.append(scope)
+            if scope == "fragment":
+                raise module.StreamlitAPIException("fragment unavailable")
+
+    monkeypatch.setattr(module, "st", _RerunStreamlit(fake_st.session_state))
+    module._rerun_fragment_or_app()
+    assert calls == ["fragment", None]
+
+    monkeypatch.delenv("AGILAB_PIPELINE_LOCK_TTL_SEC", raising=False)
+    assert module._pipeline_lock_ttl_seconds() == module.PIPELINE_LOCK_DEFAULT_TTL_SEC
+    monkeypatch.setenv("AGILAB_PIPELINE_LOCK_TTL_SEC", "not-a-number")
+    assert module._pipeline_lock_ttl_seconds() == module.PIPELINE_LOCK_DEFAULT_TTL_SEC
+    monkeypatch.setenv("AGILAB_PIPELINE_LOCK_TTL_SEC", "-1")
+    assert module._pipeline_lock_ttl_seconds() == module.PIPELINE_LOCK_DEFAULT_TTL_SEC
+    monkeypatch.setenv("AGILAB_PIPELINE_LOCK_TTL_SEC", "2.5")
+    assert module._pipeline_lock_ttl_seconds() == 2.5
+
+    missing = tmp_path / "missing.lock"
+    invalid = tmp_path / "invalid.lock"
+    list_payload = tmp_path / "list.lock"
+    invalid.write_text("{", encoding="utf-8")
+    list_payload.write_text("[]", encoding="utf-8")
+    assert module._read_pipeline_lock_payload(missing) == {}
+    assert module._read_pipeline_lock_payload(invalid) == {}
+    assert module._read_pipeline_lock_payload(list_payload) == {}
+
+    monkeypatch.setattr(module.os, "kill", lambda *_args: None)
+    assert module._pipeline_lock_owner_alive({"host": socket.gethostname(), "pid": os.getpid()}) is True
+
+    placeholder_obj = object()
+    fake_st.session_state["page__run_placeholder"] = placeholder_obj
+    assert module._get_run_placeholder("page") is placeholder_obj
+
+
+def test_pipeline_run_controls_lock_failure_branches(tmp_path, monkeypatch):
+    module = _import_pipeline_run_controls()
+    fake_st = _FakeStreamlit()
+    monkeypatch.setattr(module, "st", fake_st)
+    env = SimpleNamespace(app="demo", target="demo")
+
+    locked_dir = tmp_path / "lock-as-dir"
+    locked_dir.mkdir()
+    monkeypatch.setattr(module, "_inspect_pipeline_run_lock", lambda _env: {"path": locked_dir})
+    assert module._clear_pipeline_run_lock(env, "page", reason="unit-test") is False
+    assert any(kind == "error" and "Unable to remove pipeline lock" in msg for kind, msg in fake_st.messages)
+
+    lock_path = tmp_path / "cannot-open.lock"
+    monkeypatch.setattr(module, "_pipeline_lock_path", lambda _env: lock_path)
+    monkeypatch.setattr(module.os, "open", lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("disk full")))
+    assert module._acquire_pipeline_run_lock(env, "page") is None
+    assert any(kind == "error" and "Unable to acquire pipeline lock" in msg for kind, msg in fake_st.messages)
+
+    module._refresh_pipeline_run_lock(None)
+    module._refresh_pipeline_run_lock({})
+    module._refresh_pipeline_run_lock({"path": tmp_path / "missing.lock", "token": "token"})
+
+    refresh_lock = tmp_path / "refresh.lock"
+    refresh_lock.write_text(json.dumps({"token": "other"}), encoding="utf-8")
+    module._refresh_pipeline_run_lock({"path": refresh_lock, "token": "token"})
+    assert json.loads(refresh_lock.read_text(encoding="utf-8")) == {"token": "other"}
+
+    refresh_lock.write_text(json.dumps({"token": "token"}), encoding="utf-8")
+    monkeypatch.setattr(module.os, "replace", lambda *_args: (_ for _ in ()).throw(OSError("replace failed")))
+    module._refresh_pipeline_run_lock({"path": refresh_lock, "token": "token"})
+
+    module._release_pipeline_run_lock(None, "page")
+    module._release_pipeline_run_lock({}, "page")
+    module._release_pipeline_run_lock({"path": tmp_path / "missing-release.lock", "token": "token"}, "page")
+
+    release_lock = tmp_path / "release.lock"
+    release_lock.write_text(json.dumps({"token": "other"}), encoding="utf-8")
+    module._release_pipeline_run_lock({"path": release_lock, "token": "token"}, "page")
+    assert release_lock.exists()
+
+    release_dir = tmp_path / "release-dir"
+    release_dir.mkdir()
+    module._release_pipeline_run_lock({"path": release_dir, "token": "token"}, "page")
+
+
 def test_pipeline_run_controls_run_all_steps_executes_runpy_and_agi_run(tmp_path, monkeypatch):
     module = _import_pipeline_run_controls()
     snippet_file = tmp_path / "snippet.py"
@@ -375,3 +470,73 @@ def test_pipeline_run_controls_run_all_steps_handles_early_exits(tmp_path, monke
         stream_run_command_fn=lambda *_args, **_kwargs: "",
     )
     assert fake_st.session_state["page__run_logs"].count("Run pipeline invoked.") == 3
+
+
+def test_pipeline_run_controls_run_all_steps_without_mlflow_tracks_runpy_no_output(tmp_path, monkeypatch):
+    module = _import_pipeline_run_controls()
+    snippet_file = tmp_path / "snippet.py"
+    snippet_file.write_text("print('snippet')", encoding="utf-8")
+    fake_st = _FakeStreamlit(
+        {
+            "page": [7, "old desc", "old q", "old model", "old code", "old detail", 0],
+            "snippet_file": str(snippet_file),
+            "lab_selected_venv": "",
+            "lab_selected_engine": "old-engine",
+        }
+    )
+    monkeypatch.setattr(module, "st", fake_st)
+
+    run_lab_calls: list[dict] = []
+    releases: list[dict] = []
+
+    @contextmanager
+    def no_mlflow_run(*_args, **_kwargs):
+        yield None
+
+    monkeypatch.setattr(module._pipeline_runtime, "mlflow_tracking_uri", lambda _env: "")
+    monkeypatch.setattr(module._pipeline_runtime, "start_mlflow_run", no_mlflow_run)
+    monkeypatch.setattr(module._pipeline_runtime, "build_mlflow_process_env", lambda _env, *, run_id=None: {})
+    monkeypatch.setattr(
+        module._pipeline_runtime,
+        "label_for_step_runtime",
+        lambda runtime, *, engine, code: f"{engine}:{runtime or 'default'}",
+    )
+    monkeypatch.setattr(module._pipeline_runtime, "is_valid_runtime_root", lambda _value: False)
+    monkeypatch.setattr(module._pipeline_steps, "normalize_runtime_path", lambda value: str(value or ""))
+    monkeypatch.setattr(module._pipeline_steps, "is_runnable_step", lambda entry: bool(entry.get("C")))
+    monkeypatch.setattr(module._pipeline_steps, "step_summary", lambda entry, width=80: entry.get("Q", ""))
+    monkeypatch.setattr(module, "_acquire_pipeline_run_lock", lambda *_args, **_kwargs: {"path": "lock", "token": "t"})
+    monkeypatch.setattr(module, "_refresh_pipeline_run_lock", lambda _handle: None)
+    monkeypatch.setattr(module, "_release_pipeline_run_lock", lambda handle, *_args, **_kwargs: releases.append(handle))
+    monkeypatch.setattr(
+        module,
+        "run_lab",
+        lambda payload, snippet, copilot, **kwargs: run_lab_calls.append(
+            {"payload": payload, "snippet": snippet, "copilot": copilot, "kwargs": kwargs}
+        ) or "",
+    )
+
+    env = SimpleNamespace(app="demo", active_app="", copilot_file=tmp_path / "copilot.py")
+    module.run_all_steps(
+        tmp_path / "lab",
+        "page",
+        tmp_path / "steps" / "lab_steps.toml",
+        tmp_path / "module.py",
+        env,
+        load_all_steps_fn=lambda *_args: [{"D": "desc", "Q": "question", "M": "model", "C": "print(1)"}],
+        stream_run_command_fn=lambda *_args, **_kwargs: "should not run",
+    )
+
+    assert run_lab_calls == [
+        {
+            "payload": ["desc", "question", "print(1)"],
+            "snippet": str(snippet_file),
+            "copilot": env.copilot_file,
+            "kwargs": {"env_overrides": {}},
+        }
+    ]
+    assert any(kind == "success" and "Executed 1 step." in message for kind, message in fake_st.messages)
+    assert any("runpy executed (no captured stdout)" in line for line in fake_st.session_state["page__run_logs"])
+    assert fake_st.session_state["page"][0] == 7
+    assert fake_st.session_state["lab_selected_engine"] == "old-engine"
+    assert releases == [{"path": "lock", "token": "t"}]

--- a/test/test_sync_docs_source.py
+++ b/test/test_sync_docs_source.py
@@ -111,6 +111,26 @@ def test_main_check_and_apply_modes(tmp_path: Path, capsys) -> None:
     assert payload["managed_target"] == "docs/source"
 
 
+def test_main_can_skip_missing_canonical_source_for_local_guards(tmp_path: Path, capsys) -> None:
+    module = _load_module()
+    target = tmp_path / "target"
+    target.mkdir()
+
+    exit_code = module.main(
+        [
+            "--source",
+            str(tmp_path / "missing-source"),
+            "--target",
+            str(target),
+            "--check",
+            "--skip-missing-source",
+        ]
+    )
+
+    assert exit_code == 0
+    assert "skipped mirror drift check" in capsys.readouterr().out
+
+
 def test_verify_stamp_passes_after_apply(tmp_path: Path, capsys) -> None:
     module = _load_module()
     source = tmp_path / "source"

--- a/tools/sync_docs_source.py
+++ b/tools/sync_docs_source.py
@@ -226,6 +226,16 @@ def build_parser() -> argparse.ArgumentParser:
             "target tree. This does not require access to the canonical source tree."
         ),
     )
+    parser.add_argument(
+        "--skip-missing-source",
+        action="store_true",
+        help=(
+            "When the canonical source checkout is absent, skip source-to-target "
+            "drift checks instead of failing. This is intended for local hooks "
+            "and public CI jobs that should enforce the comparison only when "
+            "the sibling docs checkout is available."
+        ),
+    )
     return parser
 
 
@@ -245,6 +255,10 @@ def main(argv: list[str] | None = None) -> int:
 
     source = args.source.expanduser().resolve()
     if not source.exists():
+        if args.skip_missing_source and not args.apply:
+            if not args.quiet:
+                print(f"canonical docs source not found; skipped mirror drift check: {source}")
+            return 0
         parser.error(f"source directory not found: {source}")
     if not source.is_dir():
         parser.error(f"source path is not a directory: {source}")


### PR DESCRIPTION
## Summary

- Add the mirrored public documentation SVG at `docs/source/diagrams/dag_dual_concept.svg`, synced from the canonical `jpmorard/thales_agilab` docs source tree.
- Embed the dual DAG figure in the mirrored `docs/source/features.rst` DAG evidence section.
- Add a docs mirror drift guard: local pre-push now verifies the mirror stamp and compares `docs/source` against `../thales_agilab/docs/source` when the canonical checkout is present; CI keeps verifying the mirror stamp and exercises the optional comparison path.
- Include the staged pipeline run-controls test additions that were already present in the working tree and requested for push.
- Refresh coverage badge SVGs so the local coverage badge guard passes with the generated `agi-gui` coverage XML.
- Keep the paired canonical docs/report PR aligned, including the refreshed FCAS report Annex D LOC/implementation-footprint metrics and branch-aware docs verification.

Canonical docs source PR: https://github.com/jpmorard/thales_agilab/pull/3

## Validation

- `xmllint --noout /Users/agi/PycharmProjects/thales_agilab/docs/source/diagrams/dag_dual_concept.svg`
- `xmllint --noout docs/source/diagrams/dag_dual_concept.svg`
- `rsvg-convert -w 1400 -h 900 docs/source/diagrams/dag_dual_concept.svg -o /tmp/dag_dual_concept_public.png`
- `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp --quiet`
- `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --check --delete --quiet --skip-missing-source`
- `.githooks/pre-push`
- `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --check --delete --quiet`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_sync_docs_source.py` (`9 passed`)
- `uv --preview-features extra-build-dependencies run pytest test/test_pipeline_run_controls.py` (`8 passed`)
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui` (`1067 passed`)
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_generate_component_coverage_badges.py` (`9 passed`)
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile badges`
- `uv --preview-features extra-build-dependencies run python tools/coverage_badge_guard.py --changed-only --require-fresh-xml`
- `uv --preview-features extra-build-dependencies run python tools/generate_skill_badges.py` (`codex: 23 skills`, `claude: 23 skills`)
- `uv --preview-features extra-build-dependencies run python tools/codex_skills.py --root .codex/skills validate --strict` (`OK: validated 23 skills`)
- `uv --preview-features extra-build-dependencies run python tools/hf_space_smoke.py --json`
- `uv --preview-features extra-build-dependencies run --with playwright python tools/agilab_web_robot.py --url https://jpmorard-agilab.hf.space --active-app flight_project --analysis-view view_maps --screenshot-dir /tmp/agilab-hf-robot-screens --json`
- `AGILAB_RUN_FULL_UI_ROBOT=1 AGILAB_WIDGET_ROBOT_URL=https://huggingface.co/spaces/jpmorard/agilab AGILAB_WIDGET_ROBOT_APPS=flight_project AGILAB_WIDGET_ROBOT_PAGES=HOME AGILAB_WIDGET_ROBOT_APPS_PAGES=configured uv --preview-features extra-build-dependencies run --with playwright pytest -q -o addopts='' -m ui_robot test/test_agilab_widget_robot_full.py` (`1 passed`)
- Canonical docs PR `docs-verify` push and PR checks passed on `jpmorard/thales_agilab` commit `6702ec54`.
