### PR TITLE
Refactor Pipeline page state model

### DIFF
--- a/src/agilab/pipeline_lab.py
+++ b/src/agilab/pipeline_lab.py
@@ -64,6 +64,16 @@ _snippet_source_guidance = _pipeline_steps_module.snippet_source_guidance
 _step_label_for_multiselect = _pipeline_steps_module.step_label_for_multiselect
 _step_summary = _pipeline_steps_module.step_summary
 
+_pipeline_page_state_module = import_agilab_module(
+    "agilab.pipeline_page_state",
+    current_file=__file__,
+    fallback_path=Path(__file__).resolve().parent / "pipeline_page_state.py",
+    fallback_name="agilab_pipeline_page_state_fallback",
+)
+PipelinePageStateDeps = _pipeline_page_state_module.PipelinePageStateDeps
+build_pipeline_page_state = _pipeline_page_state_module.build_pipeline_page_state
+clear_pipeline_run_logs = _pipeline_page_state_module.clear_pipeline_run_logs
+
 _pipeline_runtime_module = import_agilab_module(
     "agilab.pipeline_runtime",
     current_file=__file__,
@@ -495,6 +505,26 @@ def display_lab_tab(
     st.session_state.setdefault(run_logs_key, [])
     expander_state_key = f"{safe_prefix}_expander_open"
     expander_state: Dict[int, bool] = st.session_state.setdefault(expander_state_key, {})
+
+    def _build_page_state(*, include_lock: bool = False):
+        return build_pipeline_page_state(
+            index_page=index_page_str,
+            steps_file=steps_file,
+            steps=persisted_steps,
+            sequence=st.session_state.get(sequence_state_key, []),
+            session_state=st.session_state,
+            env=env,
+            deps=PipelinePageStateDeps(
+                is_displayable_step=lambda entry: _is_displayable_step(dict(entry)),
+                is_runnable_step=lambda entry: _pipeline_steps_module.is_runnable_step(dict(entry)),
+                step_summary=lambda entry: _step_summary(dict(entry), width=80),
+                step_label=lambda idx, entry: _step_label_for_multiselect(idx, dict(entry), env=env),
+                find_legacy_agi_run_steps=_pipeline_steps_module.find_legacy_agi_run_steps,
+                inspect_pipeline_run_lock=_inspect_pipeline_run_lock if include_lock else None,
+            ),
+        )
+
+    render_page_state = _build_page_state()
 
     @st.fragment
     def _render_pipeline_step_fragment(step: int, entry: Dict[str, Any]) -> None:
@@ -1169,13 +1199,14 @@ def display_lab_tab(
         with st.expander("Conceptual view", expanded=False):
             st.graphviz_chart(conceptual_dot, width="content")
 
+    render_steps = [persisted_steps[item.index] for item in render_page_state.visible_steps]
     render_pipeline_view(
-        persisted_steps,
+        render_steps,
         title="Execution view" if conceptual_dot else "Pipeline view",
     )
 
-    for step, entry in enumerate(persisted_steps):
-        _render_pipeline_step_fragment(step, entry)
+    for visible_step in render_page_state.visible_steps:
+        _render_pipeline_step_fragment(visible_step.index, persisted_steps[visible_step.index])
 
     # Add-step expander to append a new step at the end
     new_q_key = f"{safe_prefix}_new_q"
@@ -1337,7 +1368,7 @@ def display_lab_tab(
     sequence_state_key = f"{index_page_str}__run_sequence"
     sequence_widget_key = f"{safe_prefix}_run_sequence_widget"
     if total_steps > 0:
-        sequence_options = list(range(total_steps))
+        sequence_options = [item.index for item in render_page_state.visible_steps]
         stored_sequence = [idx for idx in st.session_state.get(sequence_state_key, sequence_options) if idx in sequence_options]
         stored_sequence = stored_sequence or sequence_options
         st.session_state[sequence_state_key] = stored_sequence
@@ -1366,7 +1397,11 @@ def display_lab_tab(
             st.session_state[sequence_state_key] = final_sequence
             _persist_sequence_preferences(module_path, steps_file, final_sequence)
 
-    lock_state = _inspect_pipeline_run_lock(env)
+    page_state = _build_page_state(include_lock=True)
+    if page_state.stale_step_refs and page_state.run_disabled_reason:
+        st.warning(page_state.run_disabled_reason)
+
+    lock_state = page_state.lock_state
     if lock_state:
         owner_text = str(lock_state.get("owner_text") or "unknown owner")
         stale_reason = lock_state.get("stale_reason")
@@ -1390,9 +1425,10 @@ def display_lab_tab(
         run_all_clicked = st.button(
             "Run pipeline",
             key=f"{index_page_str}_run_all",
-            help="Execute every step sequentially using its saved virtual environment.",
+            help=page_state.run_disabled_reason or "Execute every step sequentially using its saved virtual environment.",
             type="secondary",
             width="stretch",
+            disabled=not page_state.can_run,
         )
     with force_col:
         if lock_state:
@@ -1403,6 +1439,7 @@ def display_lab_tab(
                     help="Remove the stale pipeline lock and start a new run.",
                     type="primary",
                     width="stretch",
+                    disabled=not page_state.can_force_run,
                 )
             elif st.session_state.get(force_run_confirm_key, False):
                 force_run_clicked = st.button(
@@ -1411,6 +1448,7 @@ def display_lab_tab(
                     help="Remove the current lock and start a new run. Use this only if the previous run is gone.",
                     type="primary",
                     width="stretch",
+                    disabled=not page_state.can_force_run,
                 )
             else:
                 force_run_arm_clicked = st.button(
@@ -1419,7 +1457,15 @@ def display_lab_tab(
                     help="Use only when a previous pipeline run was interrupted and left a lock behind.",
                     type="secondary",
                     width="stretch",
+                    disabled=not page_state.can_force_run,
                 )
+
+    if run_all_clicked and not page_state.can_run:
+        st.warning(page_state.run_disabled_reason or "Pipeline cannot run in the current state.")
+        run_all_clicked = False
+    if force_run_clicked and not page_state.can_force_run:
+        st.warning(page_state.run_disabled_reason or "Pipeline cannot be force-run in the current state.")
+        force_run_clicked = False
 
     if force_run_arm_clicked:
         st.session_state[force_run_confirm_key] = True
@@ -1505,6 +1551,7 @@ def display_lab_tab(
 
     if run_all_clicked or force_run_clicked:
         st.session_state.pop(force_run_confirm_key, None)
+        st.session_state[f"{index_page_str}__last_run_status"] = "running"
         run_placeholder = _get_run_placeholder(index_page_str)
         log_file_path, log_error = _prepare_run_log_file(index_page_str, env, prefix="pipeline")
         if log_file_path:
@@ -1534,10 +1581,12 @@ def display_lab_tab(
                         force_lock_clear=force_run_clicked,
                     )
                 except Exception:
+                    st.session_state[f"{index_page_str}__last_run_status"] = "failed"
                     run_status.update(label="Pipeline run failed. Inspect Run logs.", state="error", expanded=True)
                     toast(st, "Pipeline run failed. Inspect Run logs.", state="error")
                     raise
                 else:
+                    st.session_state[f"{index_page_str}__last_run_status"] = "complete"
                     run_status.update(label="Pipeline run finished. Inspect Run logs.", state="complete", expanded=False)
                     toast(st, "Pipeline run finished. Inspect Run logs.", state="success")
         finally:
@@ -1594,8 +1643,11 @@ def display_lab_tab(
             width="stretch",
         )
         if clear_logs:
-            st.session_state[run_logs_key] = []
-            toast(st, "Page run logs cleared; saved log files are untouched.", state="info")
+            result = clear_pipeline_run_logs(st.session_state, index_page_str)
+            if result.ok:
+                toast(st, result.message, state="info")
+            else:
+                st.warning(result.message)
         log_placeholder = st.empty()
         st.session_state[run_placeholder_key] = log_placeholder
         logs = st.session_state.get(run_logs_key, [])

--- a/src/agilab/pipeline_page_state.py
+++ b/src/agilab/pipeline_page_state.py
@@ -1,0 +1,274 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any, Callable, Mapping, MutableMapping, Optional, Sequence, Tuple
+
+
+class PipelineWorkflowStatus(str, Enum):
+    EMPTY = "empty"
+    GENERATED = "generated"
+    STALE = "stale"
+    RUNNABLE = "runnable"
+    RUNNING = "running"
+    FAILED = "failed"
+    COMPLETE = "complete"
+
+
+class PipelineCommandStatus(str, Enum):
+    SUCCESS = "success"
+    REFUSED = "refused"
+    FAILED = "failed"
+    NO_OP = "no-op"
+
+
+@dataclass(frozen=True)
+class PipelineCommandResult:
+    status: PipelineCommandStatus
+    message: str
+    details: Mapping[str, Any] = field(default_factory=dict)
+
+    @property
+    def ok(self) -> bool:
+        return self.status in {PipelineCommandStatus.SUCCESS, PipelineCommandStatus.NO_OP}
+
+
+@dataclass(frozen=True)
+class PipelineVisibleStep:
+    index: int
+    label: str
+    summary: str
+    runnable: bool
+
+
+@dataclass(frozen=True)
+class PipelinePageState:
+    index_page: str
+    steps_file: Path
+    status: PipelineWorkflowStatus
+    total_steps: int
+    visible_steps: Tuple[PipelineVisibleStep, ...]
+    execution_sequence: Tuple[int, ...]
+    stale_step_refs: Tuple[Mapping[str, Any], ...]
+    lock_state: Optional[Mapping[str, Any]]
+    run_logs: Tuple[str, ...]
+    last_run_log_file: str
+    runnable_step_count: int
+    can_run: bool
+    can_force_run: bool
+    run_disabled_reason: str
+
+
+def _default_is_displayable_step(entry: Mapping[str, Any]) -> bool:
+    question = entry.get("Q", "")
+    if isinstance(question, str) and question.strip():
+        return True
+    code = entry.get("C", "")
+    return isinstance(code, str) and bool(code.strip())
+
+
+def _default_is_runnable_step(entry: Mapping[str, Any]) -> bool:
+    code = entry.get("C", "")
+    return isinstance(code, str) and bool(code.strip())
+
+
+def _default_step_summary(entry: Mapping[str, Any]) -> str:
+    question = str(entry.get("Q") or "").strip()
+    if question:
+        return " ".join(question.split())
+    code = str(entry.get("C") or "").strip()
+    if code:
+        return " ".join(code.splitlines()[0].split())
+    return ""
+
+
+def _default_step_label(idx: int, entry: Mapping[str, Any]) -> str:
+    summary = _default_step_summary(entry)
+    return f"Step {idx + 1}: {summary}" if summary else f"Step {idx + 1}"
+
+
+def _default_find_legacy_steps(
+    _steps: Sequence[Mapping[str, Any]],
+    _sequence: Sequence[int],
+) -> Sequence[Mapping[str, Any]]:
+    return ()
+
+
+@dataclass(frozen=True)
+class PipelinePageStateDeps:
+    is_displayable_step: Callable[[Mapping[str, Any]], bool] = _default_is_displayable_step
+    is_runnable_step: Callable[[Mapping[str, Any]], bool] = _default_is_runnable_step
+    step_summary: Callable[[Mapping[str, Any]], str] = _default_step_summary
+    step_label: Callable[[int, Mapping[str, Any]], str] = _default_step_label
+    find_legacy_agi_run_steps: Callable[
+        [Sequence[Mapping[str, Any]], Sequence[int]], Sequence[Mapping[str, Any]]
+    ] = _default_find_legacy_steps
+    inspect_pipeline_run_lock: Optional[Callable[[Any], Optional[Mapping[str, Any]]]] = None
+
+
+def normalize_execution_sequence(total_steps: int, sequence: Optional[Sequence[Any]]) -> Tuple[int, ...]:
+    """Return a valid execution order, defaulting to all steps when selection is empty."""
+    selected: list[int] = []
+    seen: set[int] = set()
+    for raw in sequence or ():
+        try:
+            idx = int(raw)
+        except (TypeError, ValueError):
+            continue
+        if 0 <= idx < total_steps and idx not in seen:
+            selected.append(idx)
+            seen.add(idx)
+    if not selected and total_steps:
+        selected = list(range(total_steps))
+    return tuple(selected)
+
+
+def _coerce_steps(steps: Sequence[Mapping[str, Any]]) -> Tuple[Mapping[str, Any], ...]:
+    coerced: list[Mapping[str, Any]] = []
+    for entry in steps:
+        if isinstance(entry, Mapping):
+            coerced.append(entry)
+    return tuple(coerced)
+
+
+def _format_stale_step_refs(stale_steps: Sequence[Mapping[str, Any]]) -> str:
+    refs: list[str] = []
+    for item in stale_steps[:5]:
+        step = item.get("step", "?")
+        line = item.get("line", "?")
+        summary = str(item.get("summary") or "").strip()
+        project = str(item.get("project") or "").strip()
+        label = f"step {step}, line {line}"
+        if project:
+            label += f", {project}"
+        if summary:
+            label += f": {summary}"
+        refs.append(label)
+    if len(stale_steps) > 5:
+        refs.append(f"{len(stale_steps) - 5} more")
+    return "; ".join(refs)
+
+
+def build_pipeline_page_state(
+    *,
+    index_page: str,
+    steps_file: Path,
+    steps: Sequence[Mapping[str, Any]],
+    sequence: Optional[Sequence[Any]],
+    session_state: Mapping[str, Any],
+    env: Any = None,
+    deps: PipelinePageStateDeps = PipelinePageStateDeps(),
+) -> PipelinePageState:
+    """Build a pure view-model for the Pipeline workflow controls."""
+    step_entries = _coerce_steps(steps)
+    total_steps = len(step_entries)
+    execution_sequence = normalize_execution_sequence(total_steps, sequence)
+
+    visible_steps: list[PipelineVisibleStep] = []
+    for idx, entry in enumerate(step_entries):
+        if not deps.is_displayable_step(entry):
+            continue
+        visible_steps.append(
+            PipelineVisibleStep(
+                index=idx,
+                label=str(deps.step_label(idx, entry)),
+                summary=str(deps.step_summary(entry)),
+                runnable=bool(deps.is_runnable_step(entry)),
+            )
+        )
+
+    stale_step_refs = tuple(dict(item) for item in deps.find_legacy_agi_run_steps(step_entries, execution_sequence))
+    lock_state = deps.inspect_pipeline_run_lock(env) if deps.inspect_pipeline_run_lock else None
+    lock_state = dict(lock_state) if isinstance(lock_state, Mapping) else None
+    active_lock = bool(lock_state and not lock_state.get("is_stale"))
+    stale_lock = bool(lock_state and lock_state.get("is_stale"))
+
+    selected_runnable = {
+        step.index
+        for step in visible_steps
+        if step.runnable and step.index in execution_sequence
+    }
+    runnable_step_count = len(selected_runnable)
+    run_logs_key = f"{index_page}__run_logs"
+    raw_logs = session_state.get(run_logs_key, ())
+    run_logs = tuple(str(line) for line in raw_logs) if isinstance(raw_logs, Sequence) and not isinstance(raw_logs, str) else ()
+    last_status = str(session_state.get(f"{index_page}__last_run_status") or "").strip().lower()
+    last_run_log_file = str(session_state.get(f"{index_page}__last_run_log_file") or "")
+
+    run_disabled_reason = ""
+    if stale_step_refs:
+        detail = _format_stale_step_refs(stale_step_refs)
+        run_disabled_reason = (
+            "Selected steps contain stale AGI.run snippets that must be regenerated "
+            f"before execution: {detail}."
+        )
+        status = PipelineWorkflowStatus.STALE
+    elif active_lock:
+        owner = str(lock_state.get("owner_text") or "unknown owner") if lock_state else "unknown owner"
+        run_disabled_reason = f"Pipeline is already running or locked by {owner}."
+        status = PipelineWorkflowStatus.RUNNING
+    elif stale_lock:
+        status = PipelineWorkflowStatus.STALE
+    elif not visible_steps:
+        run_disabled_reason = f"No visible pipeline steps were loaded from {steps_file}."
+        status = PipelineWorkflowStatus.EMPTY
+    elif runnable_step_count == 0:
+        run_disabled_reason = "No selected pipeline step contains runnable code."
+        status = PipelineWorkflowStatus.GENERATED
+    elif last_status in {"failed", "error"}:
+        status = PipelineWorkflowStatus.FAILED
+    elif last_status in {"complete", "completed", "success", "succeeded"}:
+        status = PipelineWorkflowStatus.COMPLETE
+    else:
+        status = PipelineWorkflowStatus.RUNNABLE
+
+    can_run = not run_disabled_reason and runnable_step_count > 0
+    can_force_run = bool(lock_state) and not stale_step_refs and runnable_step_count > 0
+
+    return PipelinePageState(
+        index_page=index_page,
+        steps_file=Path(steps_file),
+        status=status,
+        total_steps=total_steps,
+        visible_steps=tuple(visible_steps),
+        execution_sequence=execution_sequence,
+        stale_step_refs=stale_step_refs,
+        lock_state=lock_state,
+        run_logs=run_logs,
+        last_run_log_file=last_run_log_file,
+        runnable_step_count=runnable_step_count,
+        can_run=can_run,
+        can_force_run=can_force_run,
+        run_disabled_reason=run_disabled_reason,
+    )
+
+
+def clear_pipeline_run_logs(
+    session_state: MutableMapping[str, Any],
+    index_page: str,
+) -> PipelineCommandResult:
+    """Clear displayed Pipeline logs without touching steps or saved log files."""
+    key = f"{index_page}__run_logs"
+    try:
+        logs = session_state.get(key, [])
+        if not logs:
+            session_state.setdefault(key, [])
+            return PipelineCommandResult(
+                status=PipelineCommandStatus.NO_OP,
+                message="No page run logs to clear.",
+                details={"key": key},
+            )
+        count = len(logs) if hasattr(logs, "__len__") else 0
+        session_state[key] = []
+    except Exception as exc:
+        return PipelineCommandResult(
+            status=PipelineCommandStatus.FAILED,
+            message=f"Could not clear page run logs: {exc}",
+            details={"key": key, "error": str(exc)},
+        )
+    return PipelineCommandResult(
+        status=PipelineCommandStatus.SUCCESS,
+        message="Page run logs cleared; saved log files are untouched.",
+        details={"key": key, "count": count},
+    )

--- a/test/test_pipeline_lab.py
+++ b/test/test_pipeline_lab.py
@@ -952,6 +952,45 @@ def test_display_lab_tab_existing_steps_updates_sequence_and_runtime_selection(m
     assert render_calls
 
 
+def test_display_lab_tab_renders_from_page_state_visible_steps(monkeypatch, tmp_path):
+    render_calls = []
+    fake_st = _FakeStreamlit(
+        {
+            "demo": [0, "", "", "", "", "", 0],
+            "demo__run_sequence": [0, 1],
+        }
+    )
+    monkeypatch.setattr(pipeline_lab, "st", fake_st)
+    monkeypatch.setattr(pipeline_lab, "code_editor", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(pipeline_lab, "get_custom_buttons", lambda: [])
+    monkeypatch.setattr(pipeline_lab, "get_info_bar", lambda: {})
+    monkeypatch.setattr(pipeline_lab, "get_css_text", lambda: {})
+    monkeypatch.setattr(pipeline_lab, "get_available_virtualenvs", lambda _env: [])
+    monkeypatch.setattr(pipeline_lab, "normalize_runtime_path", lambda raw: str(raw) if raw else "")
+    monkeypatch.setattr(pipeline_lab, "_is_valid_runtime_root", lambda raw: bool(raw))
+    monkeypatch.setattr(pipeline_lab, "get_existing_snippets", lambda *_args, **_kwargs: {})
+
+    env = SimpleNamespace(active_app=tmp_path / "flight_project", envars={}, app="flight_project")
+    deps = _make_lab_deps(
+        load_all_steps=lambda *_args, **_kwargs: [
+            {"D": "", "Q": "", "M": "", "C": "", "E": ""},
+            {"D": "", "Q": "visible", "M": "m", "C": "print('visible')", "E": ""},
+        ],
+        load_pipeline_conceptual_dot=lambda *_args, **_kwargs: (None, None),
+        render_pipeline_view=lambda *args, **kwargs: render_calls.append((args, kwargs)),
+        inspect_pipeline_run_lock=lambda *_args, **_kwargs: None,
+    )
+
+    pipeline_lab.display_lab_tab(tmp_path, "demo", tmp_path / "lab_steps.toml", tmp_path / "flight_project", env, deps)
+
+    rendered_steps = render_calls[-1][0][0]
+    assert [step["Q"] for step in rendered_steps] == ["visible"]
+    assert fake_st.session_state["demo__run_sequence"] == [1]
+    assert fake_st.session_state["demo_run_sequence_widget"] == [1]
+    assert 1 in fake_st.session_state["demo__engine_map"]
+    assert 0 not in fake_st.session_state["demo__engine_map"]
+
+
 def test_display_lab_tab_existing_steps_warns_for_empty_add_snippet(monkeypatch, tmp_path):
     snippet_path = tmp_path / "AGI_run_empty.py"
     snippet_path.write_text("", encoding="utf-8")
@@ -1198,6 +1237,51 @@ def test_display_lab_tab_run_pipeline_and_delete_all(monkeypatch, tmp_path):
     assert bumped
     assert any("Run pipeline started" in str(message) for message in pushed_logs)
     assert fake_st.messages.count(("rerun", "called")) >= 2
+
+
+def test_display_lab_tab_refuses_run_when_page_state_detects_legacy_snippet(monkeypatch, tmp_path):
+    run_calls = []
+    legacy_code = (
+        "from agi_cluster.agi_distributor import AGI\n"
+        "async def main(app_env):\n"
+        "    await AGI.run(app_env, mode=0)\n"
+    )
+    fake_st = _FakeStreamlit(
+        {
+            "demo": [0, "", "", "", "", "", 1],
+            "demo__run_sequence": [0],
+        },
+        buttons={"demo_run_all": True},
+        multiselects={"demo_run_sequence_widget": [0]},
+    )
+    monkeypatch.setattr(pipeline_lab, "st", fake_st)
+    monkeypatch.setattr(pipeline_lab, "code_editor", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(pipeline_lab, "get_available_virtualenvs", lambda _env: [])
+    monkeypatch.setattr(pipeline_lab, "normalize_runtime_path", lambda raw: str(raw) if raw else "")
+    monkeypatch.setattr(pipeline_lab, "_is_valid_runtime_root", lambda raw: bool(raw))
+    monkeypatch.setattr(pipeline_lab, "get_existing_snippets", lambda *_args, **_kwargs: {})
+    monkeypatch.setattr(pipeline_lab, "get_custom_buttons", lambda: [])
+    monkeypatch.setattr(pipeline_lab, "get_info_bar", lambda: {})
+    monkeypatch.setattr(pipeline_lab, "get_css_text", lambda: {})
+
+    deps = _make_lab_deps(
+        load_all_steps=lambda *_args, **_kwargs: [
+            {"D": "", "Q": "legacy run", "M": "m", "C": legacy_code, "E": "", "R": "agi.run"}
+        ],
+        load_pipeline_conceptual_dot=lambda *_args, **_kwargs: (None, None),
+        render_pipeline_view=lambda *_args, **_kwargs: None,
+        inspect_pipeline_run_lock=lambda *_args, **_kwargs: None,
+        run_all_steps=lambda *args, **kwargs: run_calls.append((args, kwargs)),
+    )
+    env = SimpleNamespace(active_app=tmp_path / "flight_project", envars={}, app="flight_project")
+
+    pipeline_lab.display_lab_tab(tmp_path, "demo", tmp_path / "lab_steps.toml", tmp_path / "flight_project", env, deps)
+
+    assert run_calls == []
+    assert any(
+        kind == "warning" and "stale AGI.run snippets" in message
+        for kind, message in fake_st.messages
+    )
 
 
 def test_display_lab_tab_existing_steps_generates_new_step(monkeypatch, tmp_path):

--- a/test/test_pipeline_page_state.py
+++ b/test/test_pipeline_page_state.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _load_module(module_name: str, relative_path: str):
+    module_path = Path(relative_path)
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+pipeline_page_state = _load_module("agilab.pipeline_page_state", "src/agilab/pipeline_page_state.py")
+
+
+def _deps(**overrides: Any):
+    defaults = dict(
+        is_displayable_step=lambda entry: bool(entry.get("Q") or entry.get("C")),
+        is_runnable_step=lambda entry: bool(str(entry.get("C") or "").strip()),
+        step_summary=lambda entry: str(entry.get("Q") or entry.get("C") or ""),
+        step_label=lambda idx, entry: f"Step {idx + 1}: {entry.get('Q') or 'code'}",
+        find_legacy_agi_run_steps=lambda _steps, _sequence: [],
+        inspect_pipeline_run_lock=None,
+    )
+    defaults.update(overrides)
+    return pipeline_page_state.PipelinePageStateDeps(**defaults)
+
+
+def test_pipeline_page_state_keeps_visible_steps_when_logs_are_missing_or_cleared(tmp_path):
+    steps = [{"Q": "generate trajectories", "C": "print('run')"}]
+    session_state: dict[str, Any] = {}
+
+    state_without_logs = pipeline_page_state.build_pipeline_page_state(
+        index_page="demo",
+        steps_file=tmp_path / "lab_steps.toml",
+        steps=steps,
+        sequence=[0],
+        session_state=session_state,
+        deps=_deps(),
+    )
+
+    session_state["demo__run_logs"] = ["old log"]
+    result = pipeline_page_state.clear_pipeline_run_logs(session_state, "demo")
+    state_after_clear = pipeline_page_state.build_pipeline_page_state(
+        index_page="demo",
+        steps_file=tmp_path / "lab_steps.toml",
+        steps=steps,
+        sequence=[0],
+        session_state=session_state,
+        deps=_deps(),
+    )
+
+    assert result.status is pipeline_page_state.PipelineCommandStatus.SUCCESS
+    assert state_without_logs.visible_steps[0].label == "Step 1: generate trajectories"
+    assert state_after_clear.visible_steps == state_without_logs.visible_steps
+    assert state_after_clear.run_logs == ()
+    assert state_after_clear.can_run is True
+
+
+def test_pipeline_page_state_refuses_stale_legacy_snippets_before_runtime(tmp_path):
+    stale_ref = {"step": 1, "line": 4, "summary": "legacy run", "project": "flight_project"}
+
+    state = pipeline_page_state.build_pipeline_page_state(
+        index_page="demo",
+        steps_file=tmp_path / "lab_steps.toml",
+        steps=[{"Q": "legacy run", "C": "await AGI.run(app_env, mode=0)"}],
+        sequence=[0],
+        session_state={},
+        deps=_deps(find_legacy_agi_run_steps=lambda _steps, _sequence: [stale_ref]),
+    )
+
+    assert state.status is pipeline_page_state.PipelineWorkflowStatus.STALE
+    assert state.can_run is False
+    assert state.can_force_run is False
+    assert state.stale_step_refs == (stale_ref,)
+    assert "stale AGI.run snippets" in state.run_disabled_reason
+    assert "step 1, line 4" in state.run_disabled_reason
+
+
+def test_pipeline_page_state_active_lock_disables_normal_run_but_allows_force_recovery(tmp_path):
+    state = pipeline_page_state.build_pipeline_page_state(
+        index_page="demo",
+        steps_file=tmp_path / "lab_steps.toml",
+        steps=[{"Q": "run", "C": "print('run')"}],
+        sequence=[0],
+        session_state={},
+        env=object(),
+        deps=_deps(
+            inspect_pipeline_run_lock=lambda _env: {
+                "owner_text": "pid 123",
+                "is_stale": False,
+            }
+        ),
+    )
+
+    assert state.status is pipeline_page_state.PipelineWorkflowStatus.RUNNING
+    assert state.can_run is False
+    assert state.can_force_run is True
+    assert "pid 123" in state.run_disabled_reason
+
+
+def test_pipeline_page_state_stale_lock_is_explicit_and_forceable(tmp_path):
+    state = pipeline_page_state.build_pipeline_page_state(
+        index_page="demo",
+        steps_file=tmp_path / "lab_steps.toml",
+        steps=[{"Q": "run", "C": "print('run')"}],
+        sequence=[0],
+        session_state={},
+        env=object(),
+        deps=_deps(
+            inspect_pipeline_run_lock=lambda _env: {
+                "owner_text": "pid 123",
+                "is_stale": True,
+                "stale_reason": "heartbeat expired",
+            }
+        ),
+    )
+
+    assert state.status is pipeline_page_state.PipelineWorkflowStatus.STALE
+    assert state.can_run is True
+    assert state.can_force_run is True
+    assert state.lock_state["stale_reason"] == "heartbeat expired"
+
+
+def test_clear_pipeline_run_logs_returns_noop_and_failure_results():
+    empty_state: dict[str, Any] = {}
+    noop = pipeline_page_state.clear_pipeline_run_logs(empty_state, "demo")
+    assert noop.status is pipeline_page_state.PipelineCommandStatus.NO_OP
+    assert empty_state["demo__run_logs"] == []
+
+    class BrokenState(dict):
+        def __setitem__(self, key, value):
+            raise RuntimeError("blocked")
+
+    failed = pipeline_page_state.clear_pipeline_run_logs(
+        BrokenState({"demo__run_logs": ["line"]}),
+        "demo",
+    )
+    assert failed.status is pipeline_page_state.PipelineCommandStatus.FAILED
+    assert "blocked" in failed.message


### PR DESCRIPTION
## Summary
- add a pure Pipeline page state/view-model with explicit workflow and command result statuses
- render Pipeline steps and execution sequence from visible PageState steps
- disable/refuse invalid runs before runtime execution, including stale AGI.run snippets
- clear displayed run logs through a typed command result without affecting visible steps

## Validation
- uv --preview-features extra-build-dependencies run pytest -q test/test_pipeline_lab.py test/test_pipeline_page_state.py
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-env
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-core-combined
- uv --preview-features extra-build-dependencies run python tools/coverage_badge_guard.py --changed-only --require-fresh-xml