### PR TITLE
Sharpen Data IO demo proof points

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 167,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "a781d7e29fa39232891283c94f96a8d8281827090f9a3c8e5d8d66192163b007",
+  "source_digest_sha256": "7eca77e464c453d68d98535e88909f12796e638e36a54e7c972764428b6dc422",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "a781d7e29fa39232891283c94f96a8d8281827090f9a3c8e5d8d66192163b007"
+  "target_digest_sha256": "7eca77e464c453d68d98535e88909f12796e638e36a54e7c972764428b6dc422"
 }

--- a/docs/source/demo_capture_script.md
+++ b/docs/source/demo_capture_script.md
@@ -107,7 +107,9 @@ uv --preview-features extra-build-dependencies run --with imageio-ffmpeg \
 
 Use this when one app is not enough and the audience needs a sharper story:
 mission data enters AGILAB, computation is distributed, constraints change, and
-the system returns a decision.
+the system returns a decision. The positioning is intentionally execution-first:
+chatbot-style demos answer questions, while this demo shows a reproducible path
+from data to action.
 
 This is not a chatbot or short teaser. Treat it as a technical hero demo and
 keep the recording in the `70-75s` final range.
@@ -145,6 +147,31 @@ Important scope note:
   optimization demos may live in an external apps checkout
 - keep dynamic-pipeline claims grounded in visible AGILAB steps, generated
   snippets, worker activity, and replayable evidence
+- do not publish competitor-specific claims in the public guide; keep the public
+  wording focused on AGILAB capability and evidence
+
+Scenario and pipeline:
+
+- inputs: sensor-style streams, network / satcom status, and operational
+  constraints such as latency, bandwidth, and risk
+- objective: optimize routing and decision-making under dynamic constraints
+- pipeline shape: data, cleaning, feature extraction, model selection,
+  optimization / RL, simulation, decision
+- output: selected strategy plus latency, cost, and reliability metrics
+
+Demo steps:
+
+1. Live Data Ingestion: simulated and real-like mission data, ending on an
+   artifact or dashboard refresh.
+2. Automatic Pipeline Generation: generated snippets and replayable DAG-style
+   steps, with adaptive workflow selection shown through the selected run path.
+3. Distributed Execution: visible worker activity or the clearest local-worker
+   equivalent, with scaling claims scoped to worker distribution.
+4. AI + Optimization Loop: prediction signal plus routing / optimization under
+   constraints.
+5. Real-Time Adaptation: bandwidth drop, node failure, or risk increase followed
+   by recompute, re-optimize, and a new decision.
+6. Final Output: selected strategy plus latency, cost, and reliability metrics.
 
 Use this asset for technical audiences. Do not replace the broad one-app intro
 video with it for first-time visitors.
@@ -164,9 +191,32 @@ Keep the act discipline strict:
 - use one fast `ORCHESTRATE` proof frame per act
 - flash `PIPELINE` only long enough to prove replayability
 - end each act on evidence, then cut immediately
+- make distributed execution the key moment: show worker activity or the
+  clearest available local-worker equivalent
 - show the failure injection as a before/after decision change, not as a long
   training sequence
 - close on metrics: latency, cost, and reliability
+
+Recommended narration:
+
+- opening: "Most AI demos answer questions. This one takes decisions."
+- mid-demo: "This is not a model. This is an autonomous system."
+- closing: "AGILAB turns mission data into an executable decision."
+
+Optional add-on:
+
+- air-gapped mode with no internet access and local models only, when the
+  environment is configured and validated
+
+Winning criteria:
+
+| Criteria | Strength |
+|---|---|
+| Innovation | Autonomous pipeline path |
+| Scalability | Distributed worker execution |
+| Real use case | Mission / network optimization |
+| AI depth | ML + optimization / orchestration |
+| Differentiation | Not a chatbot |
 
 If interactive screen capture is not possible from your environment, build the
 coherent synthetic composite instead:

--- a/test/test_product_demo_reel.py
+++ b/test/test_product_demo_reel.py
@@ -89,9 +89,14 @@ def test_public_demo_guide_avoids_private_routing_app_names() -> None:
     assert "Data IO 2026 autonomous decision demo" in text
     assert "agilab-data-io-2026" in text
     assert "routing / optimization project" in text
+    assert "chatbot-style demos answer questions" in text
+    assert "sensor-style streams" in text
+    assert "air-gapped mode" in text
+    assert "Mission / network optimization" in text
     assert "sb3_trainer_project" not in text
     assert "thales_agilab/apps" not in text
     assert "FCAS" not in text
+    assert "obsolete" not in text.lower()
 
 
 def test_capture_three_project_demo_defaults_to_public_apps() -> None:
@@ -99,5 +104,7 @@ def test_capture_three_project_demo_defaults_to_public_apps() -> None:
 
     assert "agilab-data-io-2026" in text
     assert "src/agilab/apps/builtin/uav_relay_queue_project" in text
+    assert "AGILAB turns mission data into decisions" in text
     assert "sb3_trainer_project" not in text
     assert "thales_agilab/apps" not in text
+    assert "obsolete" not in text.lower()

--- a/tools/capture_three_project_demo.sh
+++ b/tools/capture_three_project_demo.sh
@@ -98,13 +98,43 @@ Preferred cut: \`70-75s\` final runtime with hard transitions and no idle waitin
 
 ## Goal
 
-Show AGILAB as a mission-data decision engine, not a chatbot:
+Core idea: show AGILAB as an autonomous mission-data decision engine:
 
 - ingest raw mission-like data
-- build and replay the pipeline path
+- build and replay the pipeline path from generated snippets and visible steps
 - distribute computation across workers
 - adapt after a bandwidth or node failure
 - return an optimized routing decision with visible metrics
+
+## Differentiation
+
+- chatbot-style demos focus on interaction
+- this demo focuses on impact and execution
+- positioning line: \`AGILAB turns mission data into decisions.\`
+
+## Scenario
+
+Context:
+
+- sensor-style streams
+- network / satcom status
+- operational constraints:
+  - latency
+  - bandwidth
+  - risk
+
+Objective:
+
+- optimize routing and decision-making under dynamic constraints
+
+## Pipeline overview
+
+\`Data -> Cleaning -> Feature extraction -> Model selection -> Optimization / RL -> Simulation -> Decision\`
+
+Scope note:
+
+- show generated snippets, replayable steps, worker activity, and decision evidence
+- do not claim unsupported first-class runtime DAG expansion unless that behavior is visible in the run
 
 ## Recording settings
 
@@ -132,6 +162,7 @@ Show AGILAB as a mission-data decision engine, not a chatbot:
 
 - select \`execution_pandas_project\` in \`PROJECT\`
 - frame the generated files as mission telemetry, sensor logs, or network status
+- show dashboard refresh or artifact update if available
 - show only the highest-signal ingestion settings:
   - \`nfile\`
   - \`rows_per_file\`
@@ -146,6 +177,7 @@ Show AGILAB as a mission-data decision engine, not a chatbot:
 
 - select \`meteo_forecast_project\` in \`PROJECT\`
 - frame the forecast as a constraint signal for the decision engine
+- present this as model selection / prediction, not a standalone weather demo
 - show only the minimal prediction context:
   - station
   - lag / horizon
@@ -160,9 +192,12 @@ Show AGILAB as a mission-data decision engine, not a chatbot:
 
 - switch to \`$RL_APP_LABEL\`
 - show one routing or optimization choice only:
+  - \`queue_aware\`
+  - or \`shortest_path\` baseline comparison
   - \`PPO-GNN\`
   - or \`Path Actor-Critic\`
 - move to \`ORCHESTRATE\` and show visible worker / cluster activity
+- make this the key moment in the cut
 - if a non-local worker is used, make the shared workers data path visible and avoid local-only paths
 - flash \`PIPELINE\` only if replayable optimization or inference steps are already visible
 - finish on one visible decision proof:
@@ -193,6 +228,32 @@ Show AGILAB as a mission-data decision engine, not a chatbot:
 - closing sentence:
   - \`This is not a model. This is an autonomous system path from mission data to decision.\`
 - keep the closing frame static and short
+
+## Technical stack callouts
+
+- \`AgiEnv\`: environment orchestration
+- \`AgiNode / AgiCluster\`: distributed execution
+- \`Dask / worker execution\`: parallel computing path when enabled
+- ML + optimization / RL: decision loop
+- Streamlit: operator visualization
+
+## Optional add-on
+
+Air-gapped mode:
+
+- no internet access
+- local models only
+- use this only when the environment is configured and validated
+
+## Winning criteria
+
+| Criteria | Strength |
+|---|---|
+| Innovation | Autonomous pipeline path |
+| Scalability | Distributed worker execution |
+| Real use case | Mission / network optimization |
+| AI depth | ML + optimization / orchestration |
+| Differentiation | Not a chatbot |
 
 ## Recording constraints
 


### PR DESCRIPTION
## Summary
- Add execution-first positioning for the Data IO 2026 demo narrative.
- Add scenario, pipeline, differentiation, optional air-gapped, and winning-criteria guidance.
- Align the capture cue sheet and product-reel regressions with the public demo guide.
- Refresh the docs mirror stamp from the canonical docs source.

## Validation
- bash -n tools/capture_three_project_demo.sh
- uv --preview-features extra-build-dependencies run pytest -q -o addopts= test/test_product_demo_reel.py
- uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files docs/.docs_source_mirror_stamp.json docs/source/demo_capture_script.md test/test_product_demo_reel.py tools/capture_three_project_demo.sh
- uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --source /Users/agi/PycharmProjects/thales_agilab/docs/source --verify-stamp --quiet
- uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --source /Users/agi/PycharmProjects/thales_agilab/docs/source --check --delete --quiet --skip-missing-source
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-env
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-core-combined
- uv --preview-features extra-build-dependencies run python tools/coverage_badge_guard.py --changed-only --require-fresh-xml