### PR TITLE
Test Data IO cue sheet steps

### DIFF
--- a/test/test_product_demo_reel.py
+++ b/test/test_product_demo_reel.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import importlib.util
+import shutil
+import subprocess
 import sys
 from pathlib import Path
 
@@ -96,7 +98,6 @@ def test_public_demo_guide_avoids_private_routing_app_names() -> None:
     assert "sb3_trainer_project" not in text
     assert "thales_agilab/apps" not in text
     assert "FCAS" not in text
-    assert "obsolete" not in text.lower()
 
 
 def test_capture_three_project_demo_defaults_to_public_apps() -> None:
@@ -107,4 +108,29 @@ def test_capture_three_project_demo_defaults_to_public_apps() -> None:
     assert "AGILAB turns mission data into decisions" in text
     assert "sb3_trainer_project" not in text
     assert "thales_agilab/apps" not in text
-    assert "obsolete" not in text.lower()
+
+
+def test_capture_three_project_demo_generates_six_step_cue_sheet() -> None:
+    name = "pytest-data-io-2026"
+    cue_dir = Path("artifacts/demo_media") / name
+    cue_file = cue_dir / f"{name}_cue_sheet.md"
+    shutil.rmtree(cue_dir, ignore_errors=True)
+    try:
+        subprocess.run(
+            [str(CAPTURE_THREE_PROJECT), "--name", name, "--print-only"],
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+        text = cue_file.read_text(encoding="utf-8")
+    finally:
+        shutil.rmtree(cue_dir, ignore_errors=True)
+
+    assert "## Demo steps" in text
+    assert "1. Live Data Ingestion" in text
+    assert "2. Automatic Pipeline Generation" in text
+    assert "3. Distributed Execution" in text
+    assert "4. AI + Optimization Loop" in text
+    assert "5. Real-Time Adaptation" in text
+    assert "6. Final Output" in text
+    assert "latency down, cost down, reliability up" in text

--- a/tools/capture_three_project_demo.sh
+++ b/tools/capture_three_project_demo.sh
@@ -136,6 +136,27 @@ Scope note:
 - show generated snippets, replayable steps, worker activity, and decision evidence
 - do not claim unsupported first-class runtime DAG expansion unless that behavior is visible in the run
 
+## Demo steps
+
+1. Live Data Ingestion
+   - simulated + real-like mission data
+   - dashboard refresh or artifact update if available
+2. Automatic Pipeline Generation
+   - generated snippets and replayable DAG-style steps
+   - adaptive workflow selection shown through the selected run path
+3. Distributed Execution
+   - parallel worker activity or the clearest local-worker equivalent
+   - scaling claim scoped to worker distribution, not unsupported production autoscaling
+4. AI + Optimization Loop
+   - prediction signal
+   - routing / optimization decision under constraints
+5. Real-Time Adaptation
+   - bandwidth drop, node failure, or risk increase
+   - recompute, re-optimize, new decision
+6. Final Output
+   - selected strategy
+   - latency down, cost down, reliability up
+
 ## Recording settings
 
 - clip name: \`$NAME\`


### PR DESCRIPTION
## Summary
- Add an explicit six-step Data IO cue-sheet section to the capture wrapper.
- Add a regression that executes the wrapper in --print-only mode and verifies the generated cue sheet.

## Validation
- bash -n tools/capture_three_project_demo.sh
- uv --preview-features extra-build-dependencies run pytest -q -o addopts= test/test_product_demo_reel.py
- uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files test/test_product_demo_reel.py tools/capture_three_project_demo.sh
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui
- uv --preview-features extra-build-dependencies run python tools/coverage_badge_guard.py --changed-only --require-fresh-xml