### PR TITLE
Refactor PROJECT clone action execution

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 167,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "7eca77e464c453d68d98535e88909f12796e638e36a54e7c972764428b6dc422",
+  "source_digest_sha256": "c1f97f052dc95b0bc28c23110b6ab20cf3ef4fdc3511d6a6bb0074133d45b4a7",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "7eca77e464c453d68d98535e88909f12796e638e36a54e7c972764428b6dc422"
+  "target_digest_sha256": "c1f97f052dc95b0bc28c23110b6ab20cf3ef4fdc3511d6a6bb0074133d45b4a7"
 }

--- a/docs/source/roadmap/workflow-maintainability-patterns.md
+++ b/docs/source/roadmap/workflow-maintainability-patterns.md
@@ -41,8 +41,10 @@ Use these patterns as the default direction for future workflow-page changes.
 - Ports and Adapters: partially done. `BootstrapPorts`, `Orchestrate*Deps`, and
   support modules exist, but not every external dependency is behind an
   injected adapter yet.
-- Command Result: partially done. Some command-like objects exist, but workflow
-  actions are not yet uniform typed command functions.
+- Command Result: partially done. `ActionResult`, `ActionSpec`, and
+  `run_streamlit_action` provide the first shared Streamlit command-result
+  primitive, with PROJECT clone creation as the first adopter. Other workflow
+  actions still need to move toward the same typed boundary.
 - Explicit State Machine: partially done. Global pipeline state helpers exist,
   but Pipeline editor, Pipeline run flow, and service mode still need one
   explicit workflow-state model.
@@ -58,16 +60,18 @@ Use these patterns as the default direction for future workflow-page changes.
 
 ## Recommended Sequence
 
-1. Add a minimal `PipelinePageState` / ViewModel builder.
-2. Derive selected lab, visible steps, stale-snippet status, lock/run status,
+1. Keep extending typed command-result actions from PROJECT clone creation to
+   the next high-friction workflow buttons.
+2. Add a minimal `PipelinePageState` / ViewModel builder.
+3. Derive selected lab, visible steps, stale-snippet status, lock/run status,
    and available actions from that state.
-3. Move `RUN` and `CLEAR LOGS` behind typed command functions.
-4. Add an explicit Pipeline workflow-state enum covering `empty`, `generated`,
+4. Move `RUN` and `CLEAR LOGS` behind typed command functions.
+5. Add an explicit Pipeline workflow-state enum covering `empty`, `generated`,
    `stale`, `runnable`, `running`, `failed`, and `complete`.
-5. Add `lab_steps.toml` schema metadata for newly saved pipeline files and a
+6. Add `lab_steps.toml` schema metadata for newly saved pipeline files and a
    clear refusal or refresh path for unsupported versions.
-6. Apply the same pattern to Orchestrate service mode after Pipeline is stable.
-7. Convert snippet templates and page widgets into typed registries once state
+7. Apply the same pattern to Orchestrate service mode after Pipeline is stable.
+8. Convert snippet templates and page widgets into typed registries once state
    and command boundaries are in place.
 
 ## First Slice Acceptance Criteria

--- a/src/agilab/action_execution.py
+++ b/src/agilab/action_execution.py
@@ -1,0 +1,110 @@
+"""Reusable action execution primitives for Streamlit workflow pages."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+ActionStatus = Literal["success", "warning", "error", "info"]
+
+
+@dataclass(frozen=True)
+class ActionResult:
+    """Structured outcome for a user-triggered workflow action."""
+
+    status: ActionStatus
+    title: str
+    detail: str | None = None
+    next_action: str | None = None
+    data: Mapping[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def success(
+        cls,
+        title: str,
+        *,
+        detail: str | None = None,
+        next_action: str | None = None,
+        data: Mapping[str, Any] | None = None,
+    ) -> "ActionResult":
+        return cls("success", title, detail=detail, next_action=next_action, data=data or {})
+
+    @classmethod
+    def warning(
+        cls,
+        title: str,
+        *,
+        detail: str | None = None,
+        next_action: str | None = None,
+        data: Mapping[str, Any] | None = None,
+    ) -> "ActionResult":
+        return cls("warning", title, detail=detail, next_action=next_action, data=data or {})
+
+    @classmethod
+    def error(
+        cls,
+        title: str,
+        *,
+        detail: str | None = None,
+        next_action: str | None = None,
+        data: Mapping[str, Any] | None = None,
+    ) -> "ActionResult":
+        return cls("error", title, detail=detail, next_action=next_action, data=data or {})
+
+    @classmethod
+    def info(
+        cls,
+        title: str,
+        *,
+        detail: str | None = None,
+        next_action: str | None = None,
+        data: Mapping[str, Any] | None = None,
+    ) -> "ActionResult":
+        return cls("info", title, detail=detail, next_action=next_action, data=data or {})
+
+
+@dataclass(frozen=True)
+class ActionSpec:
+    """User-facing metadata for a long-running page action."""
+
+    name: str
+    start_message: str
+    failure_title: str | None = None
+    failure_next_action: str | None = None
+
+
+def render_action_result(streamlit: Any, result: ActionResult) -> None:
+    """Render a structured action result through a Streamlit-compatible object."""
+
+    renderer = getattr(streamlit, result.status)
+    renderer(result.title)
+    if result.detail:
+        streamlit.info(result.detail)
+    if result.next_action:
+        streamlit.info(f"Next: {result.next_action}")
+
+
+def run_streamlit_action(
+    streamlit: Any,
+    spec: ActionSpec,
+    action: Callable[[], ActionResult],
+    *,
+    on_success: Callable[[ActionResult], Any] | None = None,
+) -> ActionResult:
+    """Run a Streamlit page action with consistent progress and result handling."""
+
+    try:
+        with streamlit.spinner(spec.start_message):
+            result = action()
+    except Exception as exc:
+        result = ActionResult.error(
+            spec.failure_title or f"{spec.name} failed.",
+            detail=str(exc),
+            next_action=spec.failure_next_action,
+        )
+
+    render_action_result(streamlit, result)
+    if result.status == "success" and on_success is not None:
+        on_success(result)
+    return result

--- a/src/agilab/pages/1_▶️ PROJECT.py
+++ b/src/agilab/pages/1_▶️ PROJECT.py
@@ -68,6 +68,16 @@ _page_bootstrap_module = import_agilab_module(
 )
 ensure_page_env = _page_bootstrap_module.ensure_page_env
 
+_action_execution_module = import_agilab_module(
+    "agilab.action_execution",
+    current_file=__file__,
+    fallback_path=Path(__file__).resolve().parents[1] / "action_execution.py",
+    fallback_name="agilab_action_execution_fallback",
+)
+ActionResult = _action_execution_module.ActionResult
+ActionSpec = _action_execution_module.ActionSpec
+run_streamlit_action = _action_execution_module.run_streamlit_action
+
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
 
 CLONE_ENV_STRATEGY_LABELS = {
@@ -1559,6 +1569,58 @@ def _render_pre_prompt(env):
         ace,
     )
 
+
+def _create_project_clone_action(
+    env: AgiEnv,
+    *,
+    clone_source: str | Path,
+    raw_project_name: str,
+    clone_env_strategy: str,
+) -> ActionResult:
+    raw = raw_project_name.strip()
+    if not raw:
+        return ActionResult.error("Project name must not be empty.")
+
+    new_name = normalize_project_name(raw)
+    if not new_name:
+        return ActionResult.error("Could not normalize project name.")
+
+    dest_root = env.apps_path / new_name
+    if dest_root.exists():
+        return ActionResult.warning(
+            f"Project '{new_name}' already exists.",
+            next_action="Choose another project name or remove the existing project first.",
+            data={"new_name": new_name, "dest_root": dest_root},
+        )
+
+    clone_source_path = Path(clone_source)
+    clone_source_root = _resolve_clone_source_root(env, clone_source_path)
+    env.clone_project(clone_source_path, Path(new_name))
+
+    if not dest_root.exists():
+        return ActionResult.error(
+            f"Error while creating '{new_name}'.",
+            next_action="Check the clone source, target path, and filesystem permissions.",
+            data={"new_name": new_name, "dest_root": dest_root},
+        )
+
+    status_message = _finalize_cloned_project_environment(
+        clone_source_root,
+        dest_root,
+        clone_env_strategy,
+    )
+    return ActionResult.success(
+        f"Project '{new_name}' created.",
+        detail=status_message,
+        data={
+            "new_name": new_name,
+            "dest_root": dest_root,
+            "clone_source": clone_source_path,
+            "clone_env_strategy": clone_env_strategy,
+        },
+    )
+
+
 def handle_project_creation():
     """
     Handle the 'Create' tab in the sidebar for project creation.
@@ -1596,36 +1658,29 @@ def handle_project_creation():
 
     create_clicked = st.sidebar.button("Create", type="primary", width="stretch")
     if create_clicked:
-        if not raw:
-            st.error("Project name must not be empty.")
-            return
-
-        new_name = normalize_project_name(raw)
-        if (env.apps_path / new_name).exists():
-            st.warning(f"Project '{new_name}' already exists.")
-            return
-
-        # clone it
-        clone_source_root = _resolve_clone_source_root(env, Path(st.session_state["clone_src"]))
-        env.clone_project(Path(st.session_state["clone_src"]), Path(new_name))
-
-        # verify
-        dest_root = env.apps_path / new_name
-        if dest_root.exists():
-            status_message = _finalize_cloned_project_environment(
-                clone_source_root,
-                dest_root,
-                clone_env_strategy,
-            )
-            st.success(f"Project '{new_name}' created.")
-            if status_message:
-                st.info(status_message)
+        def _activate_clone(result):
+            new_name = str(result.data["new_name"])
             env.change_app(new_name)
             st.session_state["switch_to_edit"] = True
             time.sleep(1.5)
             st.rerun()
-        else:
-            st.error(f"Error while creating '{new_name}'.")
+
+        run_streamlit_action(
+            st,
+            ActionSpec(
+                name="Create project",
+                start_message=f"Creating project '{raw or '<empty>'}'...",
+                failure_title="Project creation failed.",
+                failure_next_action="Check the clone source, target path, and filesystem permissions.",
+            ),
+            lambda: _create_project_clone_action(
+                env,
+                clone_source=st.session_state["clone_src"],
+                raw_project_name=raw,
+                clone_env_strategy=clone_env_strategy,
+            ),
+            on_success=_activate_clone,
+        )
     else:
         st.sidebar.info("Enter a project name and click 'Create'.")
 

--- a/test/test_action_execution.py
+++ b/test/test_action_execution.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+
+
+SRC_ROOT = Path(__file__).resolve().parents[1] / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+package_root = str(SRC_ROOT / "agilab")
+pkg = sys.modules.get("agilab")
+if pkg is not None and hasattr(pkg, "__path__"):
+    package_path = list(pkg.__path__)
+    if package_root not in package_path:
+        pkg.__path__ = [package_root, *package_path]
+importlib.invalidate_caches()
+
+action_execution = importlib.import_module("agilab.action_execution")
+
+
+class _FakeStreamlit:
+    def __init__(self):
+        self.messages: list[tuple[str, str]] = []
+        self.spinner_messages: list[str] = []
+
+    @contextmanager
+    def spinner(self, message: str):
+        self.spinner_messages.append(message)
+        yield
+
+    def success(self, message: str):
+        self.messages.append(("success", message))
+
+    def warning(self, message: str):
+        self.messages.append(("warning", message))
+
+    def error(self, message: str):
+        self.messages.append(("error", message))
+
+    def info(self, message: str):
+        self.messages.append(("info", message))
+
+
+def test_run_streamlit_action_renders_success_and_calls_callback():
+    fake_st = _FakeStreamlit()
+    callbacks: list[str] = []
+
+    result = action_execution.run_streamlit_action(
+        fake_st,
+        action_execution.ActionSpec(name="Demo", start_message="Working..."),
+        lambda: action_execution.ActionResult.success(
+            "Created.",
+            detail="Details",
+            next_action="Open it",
+            data={"name": "demo"},
+        ),
+        on_success=lambda action_result: callbacks.append(action_result.data["name"]),
+    )
+
+    assert result.status == "success"
+    assert fake_st.spinner_messages == ["Working..."]
+    assert fake_st.messages == [
+        ("success", "Created."),
+        ("info", "Details"),
+        ("info", "Next: Open it"),
+    ]
+    assert callbacks == ["demo"]
+
+
+def test_run_streamlit_action_converts_exceptions_to_action_errors():
+    fake_st = _FakeStreamlit()
+    callbacks: list[str] = []
+
+    def _raise():
+        raise RuntimeError("boom")
+
+    result = action_execution.run_streamlit_action(
+        fake_st,
+        action_execution.ActionSpec(
+            name="Demo",
+            start_message="Working...",
+            failure_title="Demo failed.",
+            failure_next_action="Retry later.",
+        ),
+        _raise,
+        on_success=lambda action_result: callbacks.append(action_result.title),
+    )
+
+    assert result.status == "error"
+    assert result.title == "Demo failed."
+    assert fake_st.messages == [
+        ("error", "Demo failed."),
+        ("info", "boom"),
+        ("info", "Next: Retry later."),
+    ]
+    assert callbacks == []
+
+
+def test_render_action_result_supports_warning_outcomes():
+    fake_st = _FakeStreamlit()
+
+    action_execution.render_action_result(
+        fake_st,
+        action_execution.ActionResult.warning(
+            "Already exists.",
+            next_action="Pick another name.",
+        ),
+    )
+
+    assert fake_st.messages == [
+        ("warning", "Already exists."),
+        ("info", "Next: Pick another name."),
+    ]

--- a/test/test_project_clone_policy.py
+++ b/test/test_project_clone_policy.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.util
 import os
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -79,6 +80,72 @@ def test_repair_renamed_project_environment_moves_real_venv(tmp_path: Path):
     assert not source_venv.exists()
     assert not source_venv.is_symlink()
     assert (dest_venv / "marker.txt").read_text(encoding="utf-8") == "ok"
+
+
+def test_create_project_clone_action_creates_project_and_reports_strategy(tmp_path: Path):
+    module = _load_project_module()
+    clone_calls: list[tuple[Path, Path]] = []
+
+    def _clone_project(source: Path, target: Path):
+        clone_calls.append((source, target))
+        (tmp_path / target).mkdir()
+
+    env = SimpleNamespace(apps_path=tmp_path, clone_project=_clone_project)
+
+    result = module._create_project_clone_action(
+        env,
+        clone_source="source_project",
+        raw_project_name="New Demo",
+        clone_env_strategy="detach_venv",
+    )
+
+    assert result.status == "success"
+    assert result.title == "Project 'new_demo_project' created."
+    assert result.detail is not None
+    assert "without sharing" in result.detail
+    assert result.data["new_name"] == "new_demo_project"
+    assert clone_calls == [(Path("source_project"), Path("new_demo_project"))]
+    assert (tmp_path / "new_demo_project").is_dir()
+
+
+def test_create_project_clone_action_rejects_duplicate_names(tmp_path: Path):
+    module = _load_project_module()
+    clone_calls: list[tuple[Path, Path]] = []
+    (tmp_path / "existing_project").mkdir()
+    env = SimpleNamespace(
+        apps_path=tmp_path,
+        clone_project=lambda source, target: clone_calls.append((source, target)),
+    )
+
+    result = module._create_project_clone_action(
+        env,
+        clone_source="source_project",
+        raw_project_name="Existing",
+        clone_env_strategy="detach_venv",
+    )
+
+    assert result.status == "warning"
+    assert result.title == "Project 'existing_project' already exists."
+    assert result.next_action is not None
+    assert "Choose another project name" in result.next_action
+    assert clone_calls == []
+
+
+def test_create_project_clone_action_reports_missing_clone_output(tmp_path: Path):
+    module = _load_project_module()
+    env = SimpleNamespace(apps_path=tmp_path, clone_project=lambda _source, _target: None)
+
+    result = module._create_project_clone_action(
+        env,
+        clone_source="source_project",
+        raw_project_name="Missing Output",
+        clone_env_strategy="detach_venv",
+    )
+
+    assert result.status == "error"
+    assert result.title == "Error while creating 'missing_output_project'."
+    assert result.next_action is not None
+    assert "filesystem permissions" in result.next_action
 
 
 def test_safe_remove_path_collects_probe_errors(monkeypatch):


### PR DESCRIPTION
## Summary
- Add typed Streamlit action/result primitives for workflow buttons
- Move PROJECT clone creation behind a testable action function
- Update maintainability roadmap with the first command-result adopter

## Validation
- uv --preview-features extra-build-dependencies run pytest -q -o addopts= test/test_action_execution.py test/test_project_clone_policy.py test/test_product_demo_reel.py
- uv --preview-features extra-build-dependencies run python -m py_compile src/agilab/action_execution.py 'src/agilab/pages/1_▶️ PROJECT.py'
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui
- uv --preview-features extra-build-dependencies run python tools/coverage_badge_guard.py --changed-only --require-fresh-xml