### PR TITLE
Release AGILAB 2026.04.28.post1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,16 @@ and adopters a versioned, repository-local upgrade trail.
 - Added a versioned generated-snippet API guard so stale ORCHESTRATE snippets
   ask users to clean up and regenerate after core API changes.
 
+## [2026.04.28.post1] - 2026-04-28
+
+GitHub Release: https://github.com/ThalesGroup/agilab/releases/tag/v2026.04.28
+
+### Changed
+
+- Published AGILAB `2026.04.28.post1` to PyPI for `agi-env`, `agi-gui`, `agi-node`, `agi-cluster`, `agi-core`, and `agilab`.
+- Updated release metadata so public docs, changelog, PyPI, and GitHub Releases point to the same source tag.
+- Kept release automation active so future PyPI publishes create or update the matching GitHub Release after pushing the tag.
+
 ## [2026.4.27.post9] - 2026-04-27
 
 GitHub Release: https://github.com/ThalesGroup/agilab/releases/tag/v2026.04.27-7
@@ -200,3 +210,4 @@ GitHub Release: https://github.com/ThalesGroup/agilab/releases/tag/v2026.04.25
 [2026.4.27.post7]: https://github.com/ThalesGroup/agilab/releases/tag/v2026.04.27-5
 [2026.4.27.post8]: https://github.com/ThalesGroup/agilab/releases/tag/v2026.04.27-6
 [2026.4.27.post9]: https://github.com/ThalesGroup/agilab/releases/tag/v2026.04.27-7
+[2026.04.28.post1]: https://github.com/ThalesGroup/agilab/releases/tag/v2026.04.28

--- a/badges/pypi-version-agilab.svg
+++ b/badges/pypi-version-agilab.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="152" height="20" role="img" aria-label="pypi: v2026.4.27.post9">
+<svg xmlns="http://www.w3.org/2000/svg" width="158" height="20" role="img" aria-label="pypi: v2026.04.28.post1">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -6,17 +6,17 @@
   <stop offset="1" stop-opacity=".5"/>
 </linearGradient>
 <mask id="a">
-  <rect width="152" height="20" rx="3" fill="#fff"/>
+  <rect width="158" height="20" rx="3" fill="#fff"/>
 </mask>
 <g mask="url(#a)">
   <rect width="38" height="20" fill="#555"/>
-  <rect x="38" width="114" height="20" fill="#0a7aca"/>
-  <rect width="152" height="20" fill="url(#b)"/>
+  <rect x="38" width="120" height="20" fill="#0a7aca"/>
+  <rect width="158" height="20" fill="url(#b)"/>
 </g>
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="19" y="15" fill="#010101" fill-opacity=".3">pypi</text>
   <text x="19" y="14">pypi</text>
-  <text x="95" y="15" fill="#010101" fill-opacity=".3">v2026.4.27.post9</text>
-  <text x="95" y="14">v2026.4.27.post9</text>
+  <text x="98" y="15" fill="#010101" fill-opacity=".3">v2026.04.28.post1</text>
+  <text x="98" y="14">v2026.04.28.post1</text>
 </g>
 </svg>

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 168,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "8d08903521ab960ad264ee9453324925798600d18431f6e67c87dd644ed2fb9b",
+  "source_digest_sha256": "d879b45b497b9d20dbec8a55dcabe88198d2082bdc1e5068d929664bdba4a050",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "8d08903521ab960ad264ee9453324925798600d18431f6e67c87dd644ed2fb9b"
+  "target_digest_sha256": "d879b45b497b9d20dbec8a55dcabe88198d2082bdc1e5068d929664bdba4a050"
 }

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -17,7 +17,7 @@ If the local first proof fails, use :doc:`newcomer-troubleshooting` before
 branching into cluster mode, private app repositories, or broader workflows.
 
 For release-level evidence, inspect the `latest public GitHub release
-<https://github.com/ThalesGroup/agilab/releases/tag/v2026.04.27-7>`__.
+<https://github.com/ThalesGroup/agilab/releases/tag/v2026.04.28>`__.
 
 This documentation then expands into architecture, service mode, API
 references, and example projects.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.4.27.post9"
+version = "2026.04.28.post1"
 name = "agilab"
 description = "AGILAB is an end-to-end experimentation platform linking interactive development with scalable, reproducible execution orchestration."
 requires-python = ">=3.11"
@@ -36,7 +36,7 @@ keywords = [
     "jupyter",
     "ci-cd"
 ]
-dependencies = ["agi-core==2026.4.27.post9", "agi-gui==2026.4.27.post9", "astor", "legacy-cgi; python_version >= '3.13'", "matplotlib", "mlflow", "networkx", "numpy>=1.14.1", "openai", "pandas>=2.3.0", "pathspec", "plotly", "pydantic", "standard-imghdr; python_version >= '3.13'", "streamlit>=1.56.0", "tomli_w"]
+dependencies = ["agi-core==2026.04.28.post1", "agi-gui==2026.04.28.post1", "astor", "legacy-cgi; python_version >= '3.13'", "matplotlib", "mlflow", "networkx", "numpy>=1.14.1", "openai", "pandas>=2.3.0", "pathspec", "plotly", "pydantic", "standard-imghdr; python_version >= '3.13'", "streamlit>=1.56.0", "tomli_w"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"
@@ -51,6 +51,8 @@ agilab = "agilab.lab_run:main"
 
 [project.optional-dependencies]
 offline = ["accelerate>=0.34.2; python_version >= '3.12'", "gpt-oss>=0.0.8; python_version >= '3.12'", "requests>=2.32.0; python_version >= '3.12'", "torch>=2.8.0; python_version >= '3.12'", "transformers>=4.57.0; python_version >= '3.12'", "universal-offline-ai-chatbot>=0.1.0; python_version >= '3.12'"]
+
+
 
 
 

--- a/src/agilab/apps/builtin/execution_pandas_project/pyproject.toml
+++ b/src/agilab/apps/builtin/execution_pandas_project/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "execution_pandas_project"
-version = "2026.4.27.post9"
+version = "2026.04.28.post1"
 description = "Built-in AGILab execution playground using PandasWorker"
 requires-python = ">=3.11"
 dependencies = [

--- a/src/agilab/apps/builtin/execution_polars_project/pyproject.toml
+++ b/src/agilab/apps/builtin/execution_polars_project/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "execution_polars_project"
-version = "2026.4.27.post9"
+version = "2026.04.28.post1"
 description = "Built-in AGILab execution playground using PolarsWorker"
 requires-python = ">=3.11"
 dependencies = [

--- a/src/agilab/apps/builtin/flight_project/pyproject.toml
+++ b/src/agilab/apps/builtin/flight_project/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flight_project"
-version = "2026.4.27.post9"
+version = "2026.04.28.post1"
 description = "Built-in AGILab example app (flight telemetry preprocessing)"
 requires-python = ">=3.11"
 dependencies = [

--- a/src/agilab/apps/builtin/meteo_forecast_project/pyproject.toml
+++ b/src/agilab/apps/builtin/meteo_forecast_project/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "meteo_forecast_project"
-version = "2026.4.27.post9"
+version = "2026.04.28.post1"
 description = "Built-in AGILab weather forecasting example migrated from notebooks"
 requires-python = ">=3.13"
 dependencies = [

--- a/src/agilab/apps/builtin/mycode_project/pyproject.toml
+++ b/src/agilab/apps/builtin/mycode_project/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mycode_project"
-version = "2026.4.27.post9"
+version = "2026.04.28.post1"
 description = "Built-in AGILab example app template (minimal manager + worker)"
 requires-python = ">=3.11"
 dependencies = [

--- a/src/agilab/apps/builtin/uav_queue_project/pyproject.toml
+++ b/src/agilab/apps/builtin/uav_queue_project/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uav_queue_project"
-version = "2026.4.27.post9"
+version = "2026.04.28.post1"
 description = "Built-in AGILAB lightweight UAV relay queue example"
 requires-python = ">=3.13"
 dependencies = [

--- a/src/agilab/apps/builtin/uav_relay_queue_project/pyproject.toml
+++ b/src/agilab/apps/builtin/uav_relay_queue_project/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uav_relay_queue_project"
-version = "2026.4.27.post9"
+version = "2026.04.28.post1"
 description = "Built-in AGILAB lightweight UAV relay queue example"
 requires-python = ">=3.13"
 dependencies = [

--- a/src/agilab/core/agi-cluster/pyproject.toml
+++ b/src/agilab/core/agi-cluster/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.4.27.post9"
+version = "2026.04.28.post1"
 name = "agi-cluster"
 description = "Distributed cluster orchestration layer for AGILAB workers over local and SSH backends"
 requires-python = ">=3.11"
@@ -35,7 +35,7 @@ keywords = [
     "agi",
     "datascience",
 ]
-dependencies = ["agi-env==2026.4.27.post9", "agi-node==2026.4.27.post9", "asyncssh", "dask[distributed]", "humanize", "numpy", "packaging", "polars", "psutil", "scikit-learn", "tomlkit"]
+dependencies = ["agi-env==2026.04.28.post1", "agi-node==2026.04.28.post1", "asyncssh", "dask[distributed]", "humanize", "numpy", "packaging", "polars", "psutil", "scikit-learn", "tomlkit"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"
@@ -45,6 +45,8 @@ Homepage = "https://github.com/ThalesGroup/agilab"
 Repository = "https://github.com/ThalesGroup/agilab"
 Discussions = "https://github.com/ThalesGroup/agilab/discussions"
 Changelog = "https://github.com/ThalesGroup/agilab/releases"
+
+
 
 
 

--- a/src/agilab/core/agi-core/pyproject.toml
+++ b/src/agilab/core/agi-core/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.4.27.post9"
+version = "2026.04.28.post1"
 name = "agi-core"
 description = "Meta-package that installs and wires agi-env, agi-node, and agi-cluster together"
 readme = "README.md"
@@ -27,7 +27,7 @@ keywords = [
   "agi",
   "streamlit",
 ]
-dependencies = ["agi-env==2026.4.27.post9", "agi-node==2026.4.27.post9", "agi-cluster==2026.4.27.post9"]
+dependencies = ["agi-env==2026.04.28.post1", "agi-node==2026.04.28.post1", "agi-cluster==2026.04.28.post1"]
 
 [project.urls]
 Homepage = "https://github.com/ThalesGroup/agilab"
@@ -36,6 +36,8 @@ Documentation = "https://thalesgroup.github.io/agilab"
 Repository = "https://github.com/ThalesGroup/agilab"
 Discussions = "https://github.com/ThalesGroup/agilab/discussions"
 Changelog = "https://github.com/ThalesGroup/agilab/releases"
+
+
 
 
 

--- a/src/agilab/core/agi-env/pyproject.toml
+++ b/src/agilab/core/agi-env/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.4.27.post9"
+version = "2026.04.28.post1"
 name = "agi-env"
 description = "Environment bootstrap package for AGILAB with virtualenv, path, and runtime helpers"
 requires-python = ">=3.11"
@@ -53,6 +53,7 @@ Homepage = "https://github.com/ThalesGroup/agilab"
 Repository = "https://github.com/ThalesGroup/agilab"
 Discussions = "https://github.com/ThalesGroup/agilab/discussions"
 Changelog = "https://github.com/ThalesGroup/agilab/releases"
+
 
 
 

--- a/src/agilab/core/agi-node/pyproject.toml
+++ b/src/agilab/core/agi-node/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.4.27.post9"
+version = "2026.04.28.post1"
 name = "agi-node"
 description = "Distributed worker orchestration and execution support library for AGILAB"
 requires-python = ">=3.11"
@@ -35,7 +35,7 @@ keywords = [
     "python",
     "ai-operations",
 ]
-dependencies = ["agi-env==2026.4.27.post9", "cython", "humanize", "numpy", "pandas", "parso", "polars", "psutil", "py7zr", "setuptools"]
+dependencies = ["agi-env==2026.04.28.post1", "cython", "humanize", "numpy", "pandas", "parso", "polars", "psutil", "py7zr", "setuptools"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"
@@ -45,6 +45,8 @@ Homepage = "https://github.com/ThalesGroup/agilab"
 Repository = "https://github.com/ThalesGroup/agilab"
 Discussions = "https://github.com/ThalesGroup/agilab/discussions"
 Changelog = "https://github.com/ThalesGroup/agilab/releases"
+
+
 
 
 

--- a/src/agilab/lib/agi-gui/pyproject.toml
+++ b/src/agilab/lib/agi-gui/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.4.27.post9"
+version = "2026.04.28.post1"
 name = "agi-gui"
 description = "AGILAB Streamlit UI dependency bundle and compatibility imports"
 requires-python = ">=3.11"
@@ -32,7 +32,7 @@ keywords = [
     "python",
 ]
 
-dependencies = ["agi-env==2026.4.27.post9", "streamlit>=1.56.0", "streamlit-modal", "streamlit_code_editor", "streamlit_extras", "watchdog"]
+dependencies = ["agi-env==2026.04.28.post1", "streamlit>=1.56.0", "streamlit-modal", "streamlit_code_editor", "streamlit_extras", "watchdog"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"
@@ -42,6 +42,8 @@ Homepage = "https://github.com/ThalesGroup/agilab"
 Repository = "https://github.com/ThalesGroup/agilab"
 Discussions = "https://github.com/ThalesGroup/agilab/discussions"
 Changelog = "https://github.com/ThalesGroup/agilab/releases"
+
+
 
 
 

--- a/test/test_public_demo_links.py
+++ b/test/test_public_demo_links.py
@@ -27,7 +27,7 @@ AGI_CORE_NOTEBOOK_BADGE = "https://img.shields.io/badge/agi--core-notebook-1D4ED
 HF_RUNTIME_URL = "https://jpmorard-agilab.hf.space"
 QUICK_START_URL = "https://thalesgroup.github.io/agilab/quick-start.html"
 RELEASES_URL = "https://github.com/ThalesGroup/agilab/releases"
-LATEST_RELEASE_URL = f"{RELEASES_URL}/tag/v2026.04.27-7"
+LATEST_RELEASE_URL = f"{RELEASES_URL}/tag/v2026.04.28"
 
 
 def test_readme_advertises_public_huggingface_space_page() -> None:


### PR DESCRIPTION
## Summary
- Bump AGILAB packages and built-in apps to 2026.04.28.post1
- Refresh PyPI badge, changelog, docs release link, and latest-release test constant
- Publish GitHub Release v2026.04.28 and PyPI artifacts

## Validation
- PyPI publish release preflight passed: agi-env, agi-core-combined, agi-gui, docs, installer, shared-core-typing
- twine check passed for all 12 wheel/sdist artifacts
- PyPI upload completed for agi-env, agi-gui, agi-node, agi-cluster, agi-core, agilab