### PR TITLE
Add beta readiness gate

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -1,9 +1,9 @@
 {
-  "file_count": 168,
+  "file_count": 169,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "d879b45b497b9d20dbec8a55dcabe88198d2082bdc1e5068d929664bdba4a050",
+  "source_digest_sha256": "f628ebe77ce1c6801161d88bbab2dad57d59bcf27a8d7c7865e9529ed3f946c7",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "d879b45b497b9d20dbec8a55dcabe88198d2082bdc1e5068d929664bdba4a050"
+  "target_digest_sha256": "f628ebe77ce1c6801161d88bbab2dad57d59bcf27a8d7c7865e9529ed3f946c7"
 }

--- a/docs/source/beta-readiness.rst
+++ b/docs/source/beta-readiness.rst
@@ -1,0 +1,86 @@
+Beta readiness
+==============
+
+AGILAB should move from the PyPI ``Alpha`` classifier to ``Beta`` only after a
+single release candidate proves that the public adoption path is repeatable.
+This page is the maintainer checklist for that decision. It is intentionally
+stricter than the normal release preflight because a classifier change is a
+public maturity signal, not just a version bump.
+
+Decision rule
+-------------
+
+Promote the next public release to beta when all of these are true:
+
+- The repository is clean and ``HEAD`` matches ``origin/main``.
+- All release-package classifiers are switched together from
+  ``Development Status :: 3 - Alpha`` to ``Development Status :: 4 - Beta``.
+- The full PyPI release preflight passes locally.
+- The built-in ``flight_project`` first proof passes from a clean install path.
+- The public Hugging Face Space is public, running, and serves the same SHA as
+  the uploaded Space repository.
+- The Space source tree contains only public app entries under
+  ``src/agilab/apps``.
+- Public docs no longer describe the promoted release as alpha-stage software.
+- The release notes state the beta scope clearly: experimentation and
+  engineering prototyping, not production serving or enterprise MLOps.
+
+Executable gate
+---------------
+
+Use the beta readiness tool before editing classifiers:
+
+.. code-block:: bash
+
+   uv --preview-features extra-build-dependencies run python tools/beta_readiness.py
+
+This planning mode checks that the release machinery, public app tree, and beta
+documentation are present. It intentionally allows current ``Alpha`` classifiers
+so maintainers can run it before making the classifier change.
+
+After the classifier and docs wording have been updated for the release
+candidate, run the strict final gate:
+
+.. code-block:: bash
+
+   uv --preview-features extra-build-dependencies run python tools/beta_readiness.py --final --include-network
+
+The strict gate fails if any release package still carries the alpha classifier,
+if the local checkout is dirty, if the branch is not aligned with
+``origin/main``, or if the Hugging Face Space is not public and running the
+current uploaded SHA.
+
+Final RC commands
+-----------------
+
+The beta gate prints the final release-candidate commands. Run them before
+publishing a beta-classified package:
+
+.. code-block:: bash
+
+   uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-env --profile agi-core-combined --profile agi-gui --profile docs --profile installer --profile shared-core-typing
+   uv --preview-features extra-build-dependencies run python tools/newcomer_first_proof.py --with-install
+   uv --preview-features extra-build-dependencies run python tools/pypi_publish.py --repo testpypi --dry-run --verbose
+   uv --preview-features extra-build-dependencies run python tools/hf_space_smoke.py --json
+
+If any command fails, keep the public classifier at alpha and fix the underlying
+reproducibility, install, demo, or publication issue first.
+
+Scope of beta
+-------------
+
+The first beta should mean:
+
+- The public demo and local first proof are reliable enough for external
+  evaluators.
+- The project has repeatable release gates, docs, and packaging evidence.
+- Built-in examples can be installed and inspected without private repositories.
+
+It should not imply:
+
+- Production model serving.
+- Feature-store, drift-monitoring, or online retraining coverage.
+- Enterprise governance, audit workflow, or hardened multi-tenant deployment.
+- Cloud/Kubernetes production parity.
+
+Keep that scope explicit in release notes and public documentation.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -96,6 +96,7 @@ references, and example projects.
 
    agilab-github
    package-publishing-policy
+   beta-readiness
 
 .. toctree::
    :maxdepth: 2

--- a/test/test_beta_readiness.py
+++ b/test/test_beta_readiness.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+
+MODULE_PATH = Path("tools/beta_readiness.py").resolve()
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("beta_readiness_test_module", MODULE_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_package_pyproject(root: Path, rel_path: str, classifier: str) -> None:
+    path = root / rel_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "\n".join(
+            [
+                "[project]",
+                'name = "demo"',
+                f'classifiers = ["{classifier}"]',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_release_package_set(root: Path, classifier: str) -> None:
+    module = _load_module()
+    for rel_path in module.RELEASE_PACKAGE_PYPROJECTS:
+        _write_package_pyproject(root, rel_path, classifier)
+
+
+def _write_required_docs(root: Path, text: str = "Beta readiness\n") -> None:
+    module = _load_module()
+    for rel_path in module.PUBLIC_DOC_FILES:
+        path = root / rel_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+
+
+def test_package_classifier_planning_mode_accepts_alpha_with_info(tmp_path: Path) -> None:
+    module = _load_module()
+    _write_release_package_set(tmp_path, module.ALPHA_CLASSIFIER)
+
+    check = module.check_package_classifiers(tmp_path, final=False)
+
+    assert check.success is True
+    assert check.severity == "info"
+    assert "still say Alpha" in check.detail
+
+
+def test_package_classifier_final_mode_requires_beta(tmp_path: Path) -> None:
+    module = _load_module()
+    _write_release_package_set(tmp_path, module.ALPHA_CLASSIFIER)
+
+    check = module.check_package_classifiers(tmp_path, final=True)
+
+    assert check.success is False
+    assert "need beta classifiers" in check.detail
+
+
+def test_public_app_tree_rejects_non_public_entries(tmp_path: Path) -> None:
+    module = _load_module()
+    apps = tmp_path / "src/agilab/apps"
+    (apps / "builtin").mkdir(parents=True)
+    (apps / "private_project").mkdir()
+
+    check = module.check_public_app_tree(tmp_path)
+
+    assert check.success is False
+    assert check.evidence == ["private_project"]
+
+
+def test_final_gate_requires_network_and_clean_tree(tmp_path: Path) -> None:
+    module = _load_module()
+    _write_release_package_set(tmp_path, module.BETA_CLASSIFIER)
+    _write_required_docs(tmp_path)
+    apps = tmp_path / "src/agilab/apps"
+    (apps / "builtin").mkdir(parents=True)
+    (tmp_path / "tools").mkdir()
+    (tmp_path / "tools/pypi_publish.py").write_text(
+        repr(list(module.RELEASE_PREFLIGHT_PROFILES)),
+        encoding="utf-8",
+    )
+
+    def _runner(argv):
+        if argv == ["git", "status", "--porcelain=v1"]:
+            return subprocess.CompletedProcess(argv, 0, "", "")
+        if argv == ["git", "rev-parse", "HEAD"]:
+            return subprocess.CompletedProcess(argv, 0, "abc\n", "")
+        if argv == ["git", "rev-parse", "origin/main"]:
+            return subprocess.CompletedProcess(argv, 0, "abc\n", "")
+        raise AssertionError(f"unexpected command: {argv}")
+
+    summary = module.run_gate(
+        repo_root=tmp_path,
+        final=True,
+        include_network=False,
+        runner=_runner,
+    )
+
+    assert summary.success is False
+    assert any(check.name == "Hugging Face Space public" and not check.success for check in summary.checks)
+
+
+def test_hf_space_public_uses_runtime_raw_sha() -> None:
+    module = _load_module()
+
+    def _runner(argv):
+        assert argv == ["hf", "spaces", "info", "jpmorard/agilab", "--format", "json"]
+        return subprocess.CompletedProcess(
+            argv,
+            0,
+            (
+                '{"private": false, "sha": "abc123", '
+                '"runtime": {"stage": "RUNNING", "raw": {"sha": "abc123"}}}'
+            ),
+            "",
+        )
+
+    check = module.check_hf_space_public(_runner, final=True)
+
+    assert check.success is True
+    assert "runtime_sha=abc123" in check.detail
+
+
+def test_render_human_lists_required_final_commands(tmp_path: Path) -> None:
+    module = _load_module()
+    summary = module.GateSummary(
+        final=False,
+        include_network=False,
+        success=True,
+        checks=[module.GateCheck("demo", True, "ok")],
+        required_commands=["uv run demo"],
+    )
+
+    rendered = module.render_human(summary)
+
+    assert "verdict: PASS" in rendered
+    assert "uv run demo" in rendered

--- a/tools/beta_readiness.py
+++ b/tools/beta_readiness.py
@@ -1,0 +1,427 @@
+#!/usr/bin/env python3
+"""Check whether AGILAB is ready for a beta release promotion."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import tomllib
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Callable, Sequence
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BETA_CLASSIFIER = "Development Status :: 4 - Beta"
+ALPHA_CLASSIFIER = "Development Status :: 3 - Alpha"
+RELEASE_PACKAGE_PYPROJECTS = (
+    "pyproject.toml",
+    "src/agilab/core/agi-core/pyproject.toml",
+    "src/agilab/core/agi-env/pyproject.toml",
+    "src/agilab/core/agi-node/pyproject.toml",
+    "src/agilab/core/agi-cluster/pyproject.toml",
+    "src/agilab/lib/agi-gui/pyproject.toml",
+)
+RELEASE_PREFLIGHT_PROFILES = (
+    "agi-env",
+    "agi-core-combined",
+    "agi-gui",
+    "docs",
+    "installer",
+    "shared-core-typing",
+)
+PUBLIC_DOC_FILES = (
+    "README.md",
+    "docs/source/index.rst",
+    "docs/source/package-publishing-policy.rst",
+    "docs/source/beta-readiness.rst",
+)
+ALLOWED_APP_ENTRIES = {
+    ".DS_Store",
+    ".gitignore",
+    "README.md",
+    "__init__.py",
+    "__pycache__",
+    "builtin",
+    "install.py",
+    "src",
+    "templates",
+}
+FINAL_NETWORK_COMMANDS = (
+    "uv --preview-features extra-build-dependencies run python tools/hf_space_smoke.py --json",
+)
+FINAL_LOCAL_COMMANDS = (
+    "uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-env --profile agi-core-combined --profile agi-gui --profile docs --profile installer --profile shared-core-typing",
+    "uv --preview-features extra-build-dependencies run python tools/newcomer_first_proof.py --with-install",
+    "uv --preview-features extra-build-dependencies run python tools/pypi_publish.py --repo testpypi --dry-run --verbose",
+)
+
+
+CommandRunner = Callable[[Sequence[str]], subprocess.CompletedProcess[str]]
+
+
+@dataclass(frozen=True)
+class GateCheck:
+    name: str
+    success: bool
+    detail: str
+    severity: str = "error"
+    evidence: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class GateSummary:
+    final: bool
+    include_network: bool
+    success: bool
+    checks: list[GateCheck]
+    required_commands: list[str]
+
+
+def _run_command(argv: Sequence[str], *, cwd: Path = REPO_ROOT) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        list(argv),
+        cwd=str(cwd),
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def _read_pyproject(path: Path) -> dict:
+    with path.open("rb") as handle:
+        return tomllib.load(handle)
+
+
+def package_classifiers(repo_root: Path = REPO_ROOT) -> dict[str, list[str]]:
+    classifiers: dict[str, list[str]] = {}
+    for rel_path in RELEASE_PACKAGE_PYPROJECTS:
+        path = repo_root / rel_path
+        payload = _read_pyproject(path)
+        project = payload.get("project", {})
+        values = project.get("classifiers", [])
+        classifiers[rel_path] = [str(value) for value in values]
+    return classifiers
+
+
+def check_package_classifiers(repo_root: Path = REPO_ROOT, *, final: bool) -> GateCheck:
+    classifiers = package_classifiers(repo_root)
+    missing_status = [
+        path
+        for path, values in classifiers.items()
+        if not any(value.startswith("Development Status :: ") for value in values)
+    ]
+    if missing_status:
+        return GateCheck(
+            "package classifiers",
+            False,
+            "Missing Development Status classifier in: " + ", ".join(missing_status),
+            evidence=missing_status,
+        )
+
+    if final:
+        not_beta = [
+            path
+            for path, values in classifiers.items()
+            if BETA_CLASSIFIER not in values or ALPHA_CLASSIFIER in values
+        ]
+        return GateCheck(
+            "package classifiers",
+            not not_beta,
+            (
+                "All release packages are marked beta."
+                if not not_beta
+                else "Release packages still need beta classifiers: " + ", ".join(not_beta)
+            ),
+            evidence=not_beta,
+        )
+
+    alpha = [path for path, values in classifiers.items() if ALPHA_CLASSIFIER in values]
+    return GateCheck(
+        "package classifiers",
+        True,
+        (
+            "Development Status classifiers are present. "
+            f"{len(alpha)} package(s) still say Alpha; switch them only after the final gate passes."
+        ),
+        severity="info",
+        evidence=alpha,
+    )
+
+
+def _workflow_profiles(repo_root: Path = REPO_ROOT) -> set[str]:
+    workflow_path = repo_root / "tools" / "workflow_parity.py"
+    if not workflow_path.is_file():
+        return set()
+
+    sys.path.insert(0, str(repo_root / "tools"))
+    try:
+        import workflow_parity  # type: ignore
+
+        return set(workflow_parity._profile_descriptions())
+    finally:
+        try:
+            sys.path.remove(str(repo_root / "tools"))
+        except ValueError:
+            pass
+
+
+def check_release_preflight_profiles(repo_root: Path = REPO_ROOT) -> GateCheck:
+    workflow_profiles = _workflow_profiles(repo_root)
+    missing_workflow = [profile for profile in RELEASE_PREFLIGHT_PROFILES if profile not in workflow_profiles]
+
+    publish_text = (repo_root / "tools/pypi_publish.py").read_text(encoding="utf-8")
+    missing_publish = [
+        profile
+        for profile in RELEASE_PREFLIGHT_PROFILES
+        if f'"{profile}"' not in publish_text and f"'{profile}'" not in publish_text
+    ]
+    missing = sorted(set(missing_workflow + missing_publish))
+    return GateCheck(
+        "release preflight profiles",
+        not missing,
+        (
+            "PyPI release preflight includes the required local parity profiles."
+            if not missing
+            else "Missing release preflight profile(s): " + ", ".join(missing)
+        ),
+        evidence=missing,
+    )
+
+
+def check_public_app_tree(repo_root: Path = REPO_ROOT) -> GateCheck:
+    apps_dir = repo_root / "src/agilab/apps"
+    offenders: list[str] = []
+    for entry in sorted(apps_dir.iterdir(), key=lambda item: item.name):
+        if entry.name not in ALLOWED_APP_ENTRIES:
+            target = f"{entry.name} -> {entry.readlink()}" if entry.is_symlink() else entry.name
+            offenders.append(target)
+    return GateCheck(
+        "public app tree",
+        not offenders,
+        (
+            "src/agilab/apps contains only public deploy entries."
+            if not offenders
+            else "Non-public app entries found: " + ", ".join(offenders)
+        ),
+        evidence=offenders,
+    )
+
+
+def check_docs_have_beta_readiness(repo_root: Path = REPO_ROOT, *, final: bool) -> GateCheck:
+    missing = [path for path in PUBLIC_DOC_FILES if not (repo_root / path).is_file()]
+    if missing:
+        return GateCheck(
+            "beta readiness docs",
+            False,
+            "Missing public beta-readiness documentation: " + ", ".join(missing),
+            evidence=missing,
+        )
+
+    if final:
+        stale_alpha: list[str] = []
+        for rel_path in PUBLIC_DOC_FILES:
+            text = (repo_root / rel_path).read_text(encoding="utf-8").lower()
+            if "alpha-stage" in text or "development status :: 3 - alpha" in text:
+                stale_alpha.append(rel_path)
+        return GateCheck(
+            "beta readiness docs",
+            not stale_alpha,
+            (
+                "Public docs no longer present the promoted release as alpha."
+                if not stale_alpha
+                else "Public docs still contain alpha wording: " + ", ".join(stale_alpha)
+            ),
+            evidence=stale_alpha,
+        )
+
+    return GateCheck(
+        "beta readiness docs",
+        True,
+        "Public beta-readiness documentation is present.",
+        severity="info",
+    )
+
+
+def check_git_clean(
+    runner: CommandRunner = _run_command,
+    *,
+    allow_dirty: bool,
+) -> GateCheck:
+    result = runner(["git", "status", "--porcelain=v1"])
+    dirty_lines = [line for line in result.stdout.splitlines() if line.strip()]
+    success = result.returncode == 0 and (allow_dirty or not dirty_lines)
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "git status failed").strip()
+    elif dirty_lines and not allow_dirty:
+        detail = "Working tree has uncommitted changes."
+    elif dirty_lines:
+        detail = "Working tree is dirty, allowed for this non-final check."
+    else:
+        detail = "Working tree is clean."
+    return GateCheck("git clean", success, detail, evidence=dirty_lines)
+
+
+def check_git_aligned(
+    runner: CommandRunner = _run_command,
+    *,
+    final: bool,
+) -> GateCheck:
+    head = runner(["git", "rev-parse", "HEAD"])
+    origin = runner(["git", "rev-parse", "origin/main"])
+    if head.returncode != 0 or origin.returncode != 0:
+        detail = (head.stderr or origin.stderr or "Unable to resolve HEAD/origin/main").strip()
+        return GateCheck("git origin alignment", not final, detail, severity="warning")
+    head_sha = head.stdout.strip()
+    origin_sha = origin.stdout.strip()
+    return GateCheck(
+        "git origin alignment",
+        head_sha == origin_sha or not final,
+        (
+            "HEAD matches origin/main."
+            if head_sha == origin_sha
+            else f"HEAD {head_sha[:12]} differs from origin/main {origin_sha[:12]}."
+        ),
+        severity="error" if final else "info",
+        evidence=[] if head_sha == origin_sha else [head_sha, origin_sha],
+    )
+
+
+def check_hf_space_public(
+    runner: CommandRunner = _run_command,
+    *,
+    final: bool,
+) -> GateCheck:
+    result = runner(["hf", "spaces", "info", "jpmorard/agilab", "--format", "json"])
+    if result.returncode != 0:
+        return GateCheck(
+            "Hugging Face Space public",
+            not final,
+            "Unable to query HF Space: " + (result.stderr or result.stdout).strip(),
+            severity="error" if final else "warning",
+        )
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        return GateCheck(
+            "Hugging Face Space public",
+            False,
+            f"Unable to parse HF Space JSON: {exc}",
+        )
+    private = bool(payload.get("private"))
+    runtime = payload.get("runtime") if isinstance(payload.get("runtime"), dict) else {}
+    stage = str(runtime.get("stage", "unknown"))
+    runtime_raw = runtime.get("raw") if isinstance(runtime.get("raw"), dict) else {}
+    runtime_sha = str(runtime_raw.get("sha", ""))
+    repo_sha = str(payload.get("sha", ""))
+    success = not private and stage == "RUNNING" and bool(repo_sha) and runtime_sha == repo_sha
+    detail = (
+        f"private={private}, stage={stage}, repo_sha={repo_sha[:12]}, runtime_sha={runtime_sha[:12]}"
+    )
+    return GateCheck("Hugging Face Space public", success, detail)
+
+
+def build_required_commands(*, include_network: bool) -> list[str]:
+    commands = list(FINAL_LOCAL_COMMANDS)
+    if include_network:
+        commands.extend(FINAL_NETWORK_COMMANDS)
+    else:
+        commands.append("uv --preview-features extra-build-dependencies run python tools/hf_space_smoke.py --json")
+    return commands
+
+
+def run_gate(
+    *,
+    repo_root: Path = REPO_ROOT,
+    final: bool = False,
+    include_network: bool = False,
+    allow_dirty: bool = False,
+    runner: CommandRunner = _run_command,
+) -> GateSummary:
+    checks = [
+        check_git_clean(runner, allow_dirty=allow_dirty and not final),
+        check_git_aligned(runner, final=final),
+        check_package_classifiers(repo_root, final=final),
+        check_release_preflight_profiles(repo_root),
+        check_public_app_tree(repo_root),
+        check_docs_have_beta_readiness(repo_root, final=final),
+    ]
+    if include_network:
+        checks.append(check_hf_space_public(runner, final=final))
+    elif final:
+        checks.append(
+            GateCheck(
+                "Hugging Face Space public",
+                False,
+                "Final beta gate requires --include-network so the public Space SHA and runtime are verified.",
+            )
+        )
+
+    success = all(check.success or check.severity in {"info", "warning"} for check in checks)
+    if final:
+        success = all(check.success for check in checks)
+
+    return GateSummary(
+        final=final,
+        include_network=include_network,
+        success=success,
+        checks=checks,
+        required_commands=build_required_commands(include_network=include_network),
+    )
+
+
+def render_human(summary: GateSummary) -> str:
+    lines = [
+        "AGILAB beta-readiness gate",
+        f"mode: {'final' if summary.final else 'planning'}",
+        f"network: {'included' if summary.include_network else 'not included'}",
+        f"verdict: {'PASS' if summary.success else 'FAIL'}",
+        "",
+        "Checks:",
+    ]
+    for check in summary.checks:
+        status = "OK" if check.success else ("WARN" if check.severity == "warning" else "FAIL")
+        lines.append(f"- {check.name}: {status} - {check.detail}")
+    lines.extend(["", "Required final RC commands:"])
+    for command in summary.required_commands:
+        lines.append(f"- {command}")
+    return "\n".join(lines)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Check AGILAB beta release readiness.")
+    parser.add_argument("--final", action="store_true", help="Require the final beta promotion contract.")
+    parser.add_argument(
+        "--include-network",
+        action="store_true",
+        help="Query Hugging Face Space state as part of the gate.",
+    )
+    parser.add_argument(
+        "--allow-dirty",
+        action="store_true",
+        help="Allow a dirty worktree in planning mode. Ignored with --final.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    summary = run_gate(
+        final=args.final,
+        include_network=args.include_network,
+        allow_dirty=args.allow_dirty,
+    )
+    if args.json:
+        print(json.dumps(asdict(summary), indent=2))
+    else:
+        print(render_human(summary))
+    return 0 if summary.success else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `tools/beta_readiness.py` as an executable planning/final gate for beta promotion
- document beta readiness criteria and add the page to the public docs reference nav
- add regressions for classifier, public app tree, final network requirement, and human output behavior

## Validation
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts= test/test_beta_readiness.py test/test_project_clone_policy.py test/test_action_execution.py`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts= test/test_ui_pages.py test/test_beta_readiness.py test/test_project_clone_policy.py`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs`
- `uv --preview-features extra-build-dependencies run python -m py_compile 'src/agilab/pages/1_▶️ PROJECT.py' test/test_project_clone_policy.py test/test_beta_readiness.py tools/beta_readiness.py`
- Clean public worktree: `uv --preview-features extra-build-dependencies run python tools/beta_readiness.py --allow-dirty`

## Notes
- Local `coverage_badge_guard.py --changed-only --require-fresh-xml` could not complete because `coverage-agi-gui.xml` is missing and the full local `agi-gui` parity job was repeatedly terminated by duplicate background parity processes in this shared checkout.
- Unrelated local data-IO files are intentionally not included in this PR.
