### PR TITLE
Add Data IO 2026 public demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,8 @@ src/agilab/apps/builtin/*
 !src/agilab/apps/builtin/uav_queue_project/**
 !src/agilab/apps/builtin/uav_relay_queue_project/
 !src/agilab/apps/builtin/uav_relay_queue_project/**
+!src/agilab/apps/builtin/data_io_2026_project/
+!src/agilab/apps/builtin/data_io_2026_project/**
 _fcas_work
 .vscode/
 artifacts/demo_media/

--- a/src/agilab/apps-pages/view_data_io_decision/README.md
+++ b/src/agilab/apps-pages/view_data_io_decision/README.md
@@ -1,0 +1,12 @@
+# Data IO Decision View
+
+Streamlit analysis page for the public Data IO 2026 built-in demo.
+
+The page reads the artifacts exported by `data_io_2026_project` and displays:
+
+- selected strategy
+- latency, cost, and reliability deltas versus no re-plan
+- generated pipeline stages
+- route scoring table
+- decision timeline
+- input sensor stream and feature evidence

--- a/src/agilab/apps-pages/view_data_io_decision/pyproject.toml
+++ b/src/agilab/apps-pages/view_data_io_decision/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "view-data-io-decision"
+version = "2026.04.28"
+requires-python = ">=3.13"
+dependencies = [
+    "agi-env",
+    "agi-gui",
+    "pandas>=2.3.0",
+]
+
+[tool.uv.sources]
+agi-gui = { path = "../../lib/agi-gui", editable = true }
+agi-env = { path = "../../core/agi-env", editable = true }

--- a/src/agilab/apps-pages/view_data_io_decision/src/view_data_io_decision/__init__.py
+++ b/src/agilab/apps-pages/view_data_io_decision/src/view_data_io_decision/__init__.py
@@ -1,0 +1,1 @@
+"""Data IO 2026 decision analysis page."""

--- a/src/agilab/apps-pages/view_data_io_decision/src/view_data_io_decision/view_data_io_decision.py
+++ b/src/agilab/apps-pages/view_data_io_decision/src/view_data_io_decision/view_data_io_decision.py
@@ -1,0 +1,221 @@
+# BSD 3-Clause License
+#
+# Copyright (c) 2026, Jean-Pierre Morard, THALES SIX GTS France SAS
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import streamlit as st
+
+
+def _ensure_repo_on_path() -> None:
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        candidate = parent / "agilab"
+        if candidate.is_dir():
+            src_root = candidate.parent
+            repo_root = src_root.parent
+            for entry in (str(src_root), str(repo_root)):
+                if entry not in sys.path:
+                    sys.path.insert(0, entry)
+            break
+
+
+_ensure_repo_on_path()
+
+from agi_env import AgiEnv
+from agi_gui.pagelib import render_logo
+
+RUN_SELECTION_KEY = "data_io_2026_selected_run"
+
+
+def _resolve_active_app() -> Path:
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--active-app", dest="active_app", type=str, required=True)
+    args, _ = parser.parse_known_args()
+    active_app_path = Path(args.active_app).expanduser().resolve()
+    if not active_app_path.exists():
+        st.error(f"Provided --active-app path not found: {active_app_path}")
+        st.stop()
+    return active_app_path
+
+
+def _default_artifact_root(env: AgiEnv) -> Path:
+    return Path(env.AGILAB_EXPORT_ABS) / env.target / "data_io_decision"
+
+
+def _discover_files(base: Path, pattern: str) -> list[Path]:
+    try:
+        return sorted([path for path in base.glob(pattern) if path.is_file()], key=lambda p: p.as_posix())
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return []
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _peer_path(summary_path: Path, suffix: str, extension: str) -> Path:
+    stem = summary_path.name.removesuffix("_summary_metrics.json")
+    return summary_path.with_name(f"{stem}_{suffix}.{extension}")
+
+
+def _relative_summary_label(path: Path, artifact_root: Path) -> str:
+    try:
+        return str(path.relative_to(artifact_root))
+    except (RuntimeError, TypeError, ValueError):
+        return path.name
+
+
+def _format_delta(value: Any, *, suffix: str = "%") -> str | None:
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    sign = "+" if numeric > 0 else ""
+    return f"{sign}{numeric:.1f}{suffix}"
+
+
+def _read_csv_if_present(path: Path) -> pd.DataFrame:
+    if not path.is_file():
+        return pd.DataFrame()
+    try:
+        return pd.read_csv(path)
+    except Exception:
+        return pd.DataFrame()
+
+
+st.set_page_config(layout="wide")
+
+if "env" not in st.session_state:
+    active_app_path = _resolve_active_app()
+    env = AgiEnv(apps_path=active_app_path.parent, app=active_app_path.name, verbose=0)
+    env.init_done = True
+    st.session_state["env"] = env
+else:
+    env = st.session_state["env"]
+
+render_logo("Data IO 2026 Decision")
+st.title("Data IO 2026 decision engine")
+st.caption(
+    "Inspect the public autonomous mission-data demo: pipeline generation, failure injection, "
+    "re-planning, and final decision evidence."
+)
+
+default_root = _default_artifact_root(env)
+artifact_root_value = st.sidebar.text_input(
+    "Artifact directory",
+    value=st.session_state.setdefault("data_io_2026_artifact_root", str(default_root)),
+    key="data_io_2026_artifact_root",
+)
+artifact_root = Path(artifact_root_value).expanduser()
+
+summary_pattern = st.sidebar.text_input(
+    "Summary glob",
+    value=st.session_state.setdefault("data_io_2026_summary_glob", "**/*_summary_metrics.json"),
+    key="data_io_2026_summary_glob",
+)
+
+if not artifact_root.exists():
+    st.warning(f"Artifact directory does not exist yet: {artifact_root}")
+    st.stop()
+
+summary_files = _discover_files(artifact_root, summary_pattern)
+if not summary_files:
+    st.warning(f"No summary metrics file found in {artifact_root} with pattern {summary_pattern!r}.")
+    st.stop()
+
+summary_label_to_path = {_relative_summary_label(path, artifact_root): path for path in summary_files}
+summary_labels = list(summary_label_to_path.keys())
+saved_run = st.session_state.get(RUN_SELECTION_KEY)
+default_index = summary_labels.index(saved_run) if saved_run in summary_labels else len(summary_labels) - 1
+selected_label = st.sidebar.selectbox(
+    "Run",
+    options=summary_labels,
+    index=default_index,
+    key=RUN_SELECTION_KEY,
+)
+summary_path = summary_label_to_path[selected_label]
+summary = _load_json(summary_path)
+
+st.subheader("Final decision")
+metric_cols = st.columns(4)
+metric_cols[0].metric("Selected strategy", str(summary.get("selected_strategy", "n/a")))
+metric_cols[1].metric(
+    "Latency selected",
+    f"{float(summary.get('latency_ms_selected', 0.0)):.1f} ms",
+    _format_delta(summary.get("latency_delta_pct_vs_no_replan")),
+    delta_color="inverse",
+)
+metric_cols[2].metric(
+    "Cost selected",
+    f"{float(summary.get('cost_selected', 0.0)):.1f}",
+    _format_delta(summary.get("cost_delta_pct_vs_no_replan")),
+    delta_color="inverse",
+)
+metric_cols[3].metric(
+    "Reliability selected",
+    f"{float(summary.get('reliability_selected', 0.0)):.3f}",
+    _format_delta(summary.get("reliability_delta_pct_vs_no_replan")),
+)
+
+st.caption(
+    "Deltas are measured against the no-replan outcome after the injected mission event. "
+    "Negative latency/cost and positive reliability indicate useful adaptation."
+)
+
+with st.expander("Summary metrics", expanded=False):
+    st.json(summary)
+
+pipeline_path = _peer_path(summary_path, "generated_pipeline", "json")
+decision_path = _peer_path(summary_path, "mission_decision", "json")
+pipeline = _load_json(pipeline_path) if pipeline_path.is_file() else {}
+decision = _load_json(decision_path) if decision_path.is_file() else {}
+
+left, right = st.columns([1.1, 1.0])
+with left:
+    st.subheader("Generated pipeline")
+    stages = pipeline.get("stages", []) if isinstance(pipeline, dict) else []
+    if stages:
+        st.dataframe(pd.DataFrame(stages), use_container_width=True, hide_index=True)
+    else:
+        st.info("No generated pipeline artifact found for this run.")
+with right:
+    st.subheader("Mission event")
+    events = decision.get("applied_events", []) if isinstance(decision, dict) else []
+    if events:
+        st.dataframe(pd.DataFrame(events), use_container_width=True, hide_index=True)
+    else:
+        st.info("No selected failure event was applied.")
+
+st.subheader("Route scoring")
+routes_df = _read_csv_if_present(_peer_path(summary_path, "candidate_routes", "csv"))
+if routes_df.empty:
+    st.info("No candidate route table found.")
+else:
+    st.dataframe(routes_df, use_container_width=True, hide_index=True)
+
+st.subheader("Decision timeline")
+timeline_df = _read_csv_if_present(_peer_path(summary_path, "decision_timeline", "csv"))
+if timeline_df.empty:
+    st.info("No decision timeline found.")
+else:
+    st.dataframe(timeline_df, use_container_width=True, hide_index=True)
+
+with st.expander("Input stream and feature evidence", expanded=False):
+    sensor_df = _read_csv_if_present(_peer_path(summary_path, "sensor_stream", "csv"))
+    feature_df = _read_csv_if_present(_peer_path(summary_path, "feature_table", "csv"))
+    if not sensor_df.empty:
+        st.markdown("Sensor and event stream")
+        st.dataframe(sensor_df, use_container_width=True, hide_index=True)
+    if not feature_df.empty:
+        st.markdown("Feature table")
+        st.dataframe(feature_df, use_container_width=True, hide_index=True)
+    if sensor_df.empty and feature_df.empty:
+        st.info("No stream or feature evidence artifacts found.")

--- a/src/agilab/apps/builtin/data_io_2026_project/README.md
+++ b/src/agilab/apps/builtin/data_io_2026_project/README.md
@@ -1,0 +1,31 @@
+# Data IO 2026 Project
+
+Autonomous mission-data decision demo for AGILAB.
+
+This built-in app turns a compact mission scenario into a repeatable decision loop:
+
+1. Ingest mission data from simulated sensors, network status, and operational constraints.
+2. Generate the pipeline stages required for the scenario.
+3. Distribute scenario execution across AGILAB workers.
+4. Score candidate routes with a deterministic optimization policy.
+5. Inject a mission event and re-plan.
+6. Export a final decision with latency, cost, and reliability deltas.
+
+The app is intentionally deterministic so it can be used in public demos, automated tests,
+and Hugging Face Spaces without private datasets or external services.
+
+## Outputs
+
+Each run writes artifacts under `data_io_2026/results` and mirrors the analysis-ready
+bundle under `export/<target>/data_io_decision`:
+
+- `*_summary_metrics.json`
+- `*_mission_decision.json`
+- `*_generated_pipeline.json`
+- `*_sensor_stream.csv`
+- `*_feature_table.csv`
+- `*_candidate_routes.csv`
+- `*_decision_timeline.csv`
+
+Open `view_data_io_decision` from the ANALYSIS page to inspect the selected strategy,
+the pre/post-failure metrics, and the adaptation timeline.

--- a/src/agilab/apps/builtin/data_io_2026_project/lab_steps.toml
+++ b/src/agilab/apps/builtin/data_io_2026_project/lab_steps.toml
@@ -1,0 +1,8 @@
+data_io_2026 = [
+  { D = "Ingest mission data", Q = "Load the public Data IO 2026 mission scenario with sensor, satcom, and constraint inputs.", M = "", C = "APP = 'data_io_2026_project'\ndata_in = 'data_io_2026/scenarios'\nfiles = '*.json'", R = "runpy" },
+  { D = "Generate the adaptive pipeline", Q = "Select the required cleaning, feature, scoring, failure-detection, re-planning, and decision stages from the scenario contract.", M = "", C = "APP = 'data_io_2026_project'\nfailure_kind = 'bandwidth_drop'\nadaptation_mode = 'auto_replan'", R = "runpy" },
+  { D = "Distribute scenario execution", Q = "Partition mission scenario files across available workers and produce worker-visible metadata.", M = "", C = "APP = 'data_io_2026_project'\nworkers = {'127.0.0.1': 1}", R = "runpy" },
+  { D = "Optimize the routing decision", Q = "Score candidate routes against latency, cost, reliability, and risk constraints.", M = "", C = "APP = 'data_io_2026_project'\nobjective = 'balanced_mission'", R = "runpy" },
+  { D = "Inject failure and re-plan", Q = "Apply a bandwidth-drop event to the initially selected route, recompute candidate scores, and select the adapted strategy.", M = "", C = "APP = 'data_io_2026_project'\nfailure_kind = 'bandwidth_drop'", R = "runpy" },
+  { D = "Export final decision evidence", Q = "Write the summary metrics, generated pipeline, decision timeline, and route comparison artifacts for ANALYSIS.", M = "", C = "APP = 'data_io_2026_project'\ndata_out = 'data_io_2026/results'", R = "runpy" },
+]

--- a/src/agilab/apps/builtin/data_io_2026_project/pipeline_view.dot
+++ b/src/agilab/apps/builtin/data_io_2026_project/pipeline_view.dot
@@ -1,0 +1,17 @@
+digraph data_io_2026_pipeline {
+  rankdir=LR;
+  graph [fontname="Helvetica", fontsize=10];
+  node [shape=box, style="rounded,filled", fillcolor="#F5F7FA", color="#24435C", fontname="Helvetica", fontsize=10];
+  edge [color="#3B6D8C", arrowsize=0.8];
+
+  ingest [label="Mission data ingestion\nsensors + satcom + constraints"];
+  clean [label="Cleaning and normalization\nquality gates"];
+  features [label="Feature extraction\nlatency + bandwidth + risk"];
+  pipeline [label="Adaptive pipeline selection\nscenario-driven stages"];
+  optimize [label="Decision optimization\nroute scoring"];
+  adapt [label="Failure injection + re-plan\nbandwidth drop / node event"];
+  evidence [label="Decision evidence\nmetrics + timeline + artifacts"];
+  analysis [label="AGILAB ANALYSIS\nview_data_io_decision"];
+
+  ingest -> clean -> features -> pipeline -> optimize -> adapt -> evidence -> analysis;
+}

--- a/src/agilab/apps/builtin/data_io_2026_project/pyproject.toml
+++ b/src/agilab/apps/builtin/data_io_2026_project/pyproject.toml
@@ -1,0 +1,23 @@
+[project]
+name = "data_io_2026_project"
+version = "2026.04.28"
+description = "Built-in AGILAB Data IO 2026 autonomous mission decision demo"
+requires-python = ">=3.13"
+dependencies = [
+  "agi-env",
+  "agi-node",
+  "pandas>=2.3.0",
+  "pydantic",
+  "streamlit>=1.56.0",
+]
+
+[tool.uv.sources]
+agi-env = { path = "../../../core/agi-env", editable = true }
+agi-node = { path = "../../../core/agi-node", editable = true }
+
+[tool.setuptools.package-data]
+data_io_2026 = ["sample_data/*.json"]
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/src/agilab/apps/builtin/data_io_2026_project/src/app_args_form.py
+++ b/src/agilab/apps/builtin/data_io_2026_project/src/app_args_form.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+from typing import Any
+
+import streamlit as st
+from pydantic import ValidationError
+
+_HERE = Path(__file__).resolve().parent
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+
+from data_io_2026 import DataIo2026Args, dump_args, load_args
+
+
+PAGE_ID = "data_io_2026_project:app_args_form"
+
+
+def _k(name: str) -> str:
+    return f"{PAGE_ID}:{name}"
+
+
+def _get_env():
+    env = st.session_state.get("env") or st.session_state.get("_env")
+    if env is None:
+        st.error("AGILab environment is not initialised yet. Return to the main page and try again.")
+        st.stop()
+    return env
+
+
+def _load_current_args(settings_path: Path) -> DataIo2026Args:
+    try:
+        return load_args(settings_path)
+    except Exception as exc:
+        st.warning(f"Unable to load Data IO 2026 args from `{settings_path}`: {exc}")
+        return DataIo2026Args()
+
+
+env = _get_env()
+settings_path = Path(env.app_settings_file)
+current_args = _load_current_args(settings_path)
+current_payload = current_args.model_dump(mode="json")
+
+try:
+    share_root = env.share_root_path()
+except Exception:
+    share_root = None
+
+artifact_root = Path(getattr(env, "AGILAB_EXPORT_ABS", Path.home() / "export")) / env.target / "data_io_decision"
+
+st.caption(
+    "This built-in app runs the public Data IO 2026 mission-decision demo: "
+    "ingest mission data, generate the pipeline, inject a failure, re-plan, and export evidence."
+)
+if share_root:
+    st.caption(f"Current shared root: `{share_root}`")
+st.caption(f"Analysis artifacts are exported to `{artifact_root}`.")
+
+defaults = {
+    "data_in": str(current_payload.get("data_in", "") or ""),
+    "data_out": str(current_payload.get("data_out", "") or ""),
+    "files": str(current_payload.get("files", "*.json") or "*.json"),
+    "nfile": int(current_payload.get("nfile", 1) or 1),
+    "objective": str(current_payload.get("objective", "balanced_mission") or "balanced_mission"),
+    "adaptation_mode": str(current_payload.get("adaptation_mode", "auto_replan") or "auto_replan"),
+    "failure_kind": str(current_payload.get("failure_kind", "bandwidth_drop") or "bandwidth_drop"),
+    "latency_weight": float(current_payload.get("latency_weight", 0.65) or 0.65),
+    "cost_weight": float(current_payload.get("cost_weight", 0.12) or 0.12),
+    "reliability_weight": float(current_payload.get("reliability_weight", 0.16) or 0.16),
+    "risk_weight": float(current_payload.get("risk_weight", 0.07) or 0.07),
+    "random_seed": int(current_payload.get("random_seed", 2026) or 2026),
+    "reset_target": bool(current_payload.get("reset_target", False)),
+}
+for key, value in defaults.items():
+    st.session_state.setdefault(_k(key), value)
+
+c1, c2, c3, c4 = st.columns([2, 2, 1.2, 1.2])
+with c1:
+    st.text_input("Scenario directory", key=_k("data_in"))
+with c2:
+    st.text_input("Results directory", key=_k("data_out"))
+with c3:
+    st.text_input("Files glob", key=_k("files"))
+with c4:
+    st.number_input("Number of files", key=_k("nfile"), min_value=1, step=1)
+
+c5, c6, c7, c8 = st.columns([1.4, 1.4, 1.3, 1.0])
+with c5:
+    st.selectbox(
+        "Objective",
+        options=["balanced_mission", "latency_first", "resilience_first"],
+        key=_k("objective"),
+    )
+with c6:
+    st.selectbox("Adaptation", options=["auto_replan", "observe_only"], key=_k("adaptation_mode"))
+with c7:
+    st.selectbox("Failure mode", options=["bandwidth_drop", "node_failure", "combined"], key=_k("failure_kind"))
+with c8:
+    st.checkbox("Reset output", key=_k("reset_target"))
+
+c9, c10, c11, c12, c13 = st.columns([1, 1, 1, 1, 1])
+with c9:
+    st.number_input("Latency weight", key=_k("latency_weight"), min_value=0.0, max_value=1.0, step=0.01)
+with c10:
+    st.number_input("Cost weight", key=_k("cost_weight"), min_value=0.0, max_value=1.0, step=0.01)
+with c11:
+    st.number_input("Reliability weight", key=_k("reliability_weight"), min_value=0.0, max_value=1.0, step=0.01)
+with c12:
+    st.number_input("Risk weight", key=_k("risk_weight"), min_value=0.0, max_value=1.0, step=0.01)
+with c13:
+    st.number_input("Random seed", key=_k("random_seed"), min_value=0, step=1)
+
+candidate: dict[str, Any] = {
+    "files": (st.session_state.get(_k("files")) or "*.json").strip() or "*.json",
+    "nfile": st.session_state.get(_k("nfile"), 1),
+    "objective": st.session_state.get(_k("objective")) or "balanced_mission",
+    "adaptation_mode": st.session_state.get(_k("adaptation_mode")) or "auto_replan",
+    "failure_kind": st.session_state.get(_k("failure_kind")) or "bandwidth_drop",
+    "latency_weight": st.session_state.get(_k("latency_weight"), 0.65),
+    "cost_weight": st.session_state.get(_k("cost_weight"), 0.12),
+    "reliability_weight": st.session_state.get(_k("reliability_weight"), 0.16),
+    "risk_weight": st.session_state.get(_k("risk_weight"), 0.07),
+    "random_seed": st.session_state.get(_k("random_seed"), 2026),
+    "reset_target": bool(st.session_state.get(_k("reset_target"), False)),
+}
+
+data_in_raw = (st.session_state.get(_k("data_in")) or "").strip()
+data_out_raw = (st.session_state.get(_k("data_out")) or "").strip()
+if data_in_raw:
+    candidate["data_in"] = data_in_raw
+if data_out_raw:
+    candidate["data_out"] = data_out_raw
+
+try:
+    validated = DataIo2026Args(**candidate)
+except ValidationError as exc:
+    st.error("Invalid Data IO 2026 parameters:")
+    if hasattr(env, "humanize_validation_errors"):
+        for msg in env.humanize_validation_errors(exc):
+            st.markdown(msg)
+    else:
+        st.code(str(exc))
+else:
+    validated_payload = validated.model_dump(mode="json")
+    if validated_payload != current_payload:
+        dump_args(validated, settings_path)
+        app_settings = st.session_state.get("app_settings")
+        if not isinstance(app_settings, dict):
+            app_settings = {}
+        app_settings.setdefault("cluster", {})
+        app_settings["args"] = validated_payload
+        app_settings.setdefault("pages", {})
+        app_settings["pages"]["default_view"] = "view_data_io_decision"
+        app_settings["pages"]["view_module"] = ["view_data_io_decision"]
+        st.session_state["app_settings"] = app_settings
+        st.session_state["is_args_from_ui"] = True
+        st.success(f"Saved to `{settings_path}`.")
+    else:
+        st.info("No changes to save.")
+
+    resolved_data_in = env.resolve_share_path(validated.data_in)
+    resolved_data_out = env.resolve_share_path(validated.data_out)
+    if not any(resolved_data_in.glob(validated.files)):
+        st.info("No matching scenario file exists yet. The bundled public scenario will be seeded on first run.")
+    st.caption(
+        f"Resolved input: `{resolved_data_in}`  -  results: `{resolved_data_out}`  -  "
+        f"analysis artifacts: `{artifact_root}`"
+    )
+    st.caption(
+        "Default behavior selects a fast direct route first, injects a bandwidth drop, "
+        "then re-plans toward a more reliable relay route."
+    )

--- a/src/agilab/apps/builtin/data_io_2026_project/src/app_settings.toml
+++ b/src/agilab/apps/builtin/data_io_2026_project/src/app_settings.toml
@@ -1,0 +1,36 @@
+[args]
+data_in = "data_io_2026/scenarios"
+data_out = "data_io_2026/results"
+files = "*.json"
+nfile = 1
+objective = "balanced_mission"
+adaptation_mode = "auto_replan"
+failure_kind = "bandwidth_drop"
+latency_weight = 0.65
+cost_weight = 0.12
+reliability_weight = 0.16
+risk_weight = 0.07
+random_seed = 2026
+reset_target = false
+
+[cluster]
+verbose = 1
+cython = false
+pool = false
+rapids = false
+cluster_enabled = false
+
+[cluster.service_health]
+allow_idle = false
+max_unhealthy = 0
+max_restart_rate = 0.25
+
+[legacy_paths]
+data_in = "data_io_2026/scenarios"
+data_out = "data_io_2026/results"
+
+[pages]
+default_view = "view_data_io_decision"
+view_module = [
+    "view_data_io_decision",
+]

--- a/src/agilab/apps/builtin/data_io_2026_project/src/data_io_2026/__init__.py
+++ b/src/agilab/apps/builtin/data_io_2026_project/src/data_io_2026/__init__.py
@@ -1,0 +1,36 @@
+"""Application surface for the public Data IO 2026 demo."""
+
+from .app_args import (
+    DataIo2026Args,
+    DataIo2026ArgsTD,
+    dump_args,
+    ensure_defaults,
+    load_args,
+    merge_args,
+)
+from .artifacts import (
+    MissionWeights,
+    apply_failure_events,
+    build_decision_artifacts,
+    build_generated_pipeline,
+    choose_route,
+    score_routes,
+)
+from .data_io_2026 import DataIo2026, DataIo2026App
+
+__all__ = [
+    "DataIo2026",
+    "DataIo2026App",
+    "DataIo2026Args",
+    "DataIo2026ArgsTD",
+    "MissionWeights",
+    "apply_failure_events",
+    "build_decision_artifacts",
+    "build_generated_pipeline",
+    "choose_route",
+    "dump_args",
+    "ensure_defaults",
+    "load_args",
+    "merge_args",
+    "score_routes",
+]

--- a/src/agilab/apps/builtin/data_io_2026_project/src/data_io_2026/app_args.py
+++ b/src/agilab/apps/builtin/data_io_2026_project/src/data_io_2026/app_args.py
@@ -1,0 +1,100 @@
+"""Argument helpers for the public Data IO 2026 demo."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Literal, TypedDict
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from agi_env.app_args import dump_model_to_toml, load_model_from_toml, merge_model_data
+
+
+class DataIo2026Args(BaseModel):
+    """Runtime parameters for the autonomous mission-data decision demo."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    data_in: Path = Field(default_factory=lambda: Path("data_io_2026/scenarios"))
+    data_out: Path = Field(default_factory=lambda: Path("data_io_2026/results"))
+    files: str = "*.json"
+    nfile: int = Field(default=1, ge=1, le=25)
+    objective: Literal["balanced_mission", "latency_first", "resilience_first"] = "balanced_mission"
+    adaptation_mode: Literal["auto_replan", "observe_only"] = "auto_replan"
+    failure_kind: Literal["bandwidth_drop", "node_failure", "combined"] = "bandwidth_drop"
+    latency_weight: float = Field(default=0.65, ge=0.0, le=1.0)
+    cost_weight: float = Field(default=0.12, ge=0.0, le=1.0)
+    reliability_weight: float = Field(default=0.16, ge=0.0, le=1.0)
+    risk_weight: float = Field(default=0.07, ge=0.0, le=1.0)
+    random_seed: int = Field(default=2026, ge=0)
+    reset_target: bool = False
+
+    @model_validator(mode="after")
+    def _validate_consistency(self) -> "DataIo2026Args":
+        self.files = self.files.strip() or "*.json"
+        total = (
+            self.latency_weight
+            + self.cost_weight
+            + self.reliability_weight
+            + self.risk_weight
+        )
+        if total <= 0:
+            raise ValueError("At least one optimization weight must be positive")
+        return self
+
+
+class DataIo2026ArgsTD(TypedDict, total=False):
+    data_in: str
+    data_out: str
+    files: str
+    nfile: int
+    objective: str
+    adaptation_mode: str
+    failure_kind: str
+    latency_weight: float
+    cost_weight: float
+    reliability_weight: float
+    risk_weight: float
+    random_seed: int
+    reset_target: bool
+
+
+ArgsModel = DataIo2026Args
+ArgsOverrides = DataIo2026ArgsTD
+
+
+def load_args(settings_path: str | Path, *, section: str = "args") -> DataIo2026Args:
+    return load_model_from_toml(DataIo2026Args, settings_path, section=section)
+
+
+def merge_args(
+    base: DataIo2026Args,
+    overrides: DataIo2026ArgsTD | None = None,
+) -> DataIo2026Args:
+    return merge_model_data(base, overrides)
+
+
+def dump_args(
+    args: DataIo2026Args,
+    settings_path: str | Path,
+    *,
+    section: str = "args",
+    create_missing: bool = True,
+) -> None:
+    dump_model_to_toml(args, settings_path, section=section, create_missing=create_missing)
+
+
+def ensure_defaults(args: DataIo2026Args, **_: Any) -> DataIo2026Args:
+    return args
+
+
+__all__ = [
+    "ArgsModel",
+    "ArgsOverrides",
+    "DataIo2026Args",
+    "DataIo2026ArgsTD",
+    "dump_args",
+    "ensure_defaults",
+    "load_args",
+    "merge_args",
+]

--- a/src/agilab/apps/builtin/data_io_2026_project/src/data_io_2026/artifacts.py
+++ b/src/agilab/apps/builtin/data_io_2026_project/src/data_io_2026/artifacts.py
@@ -1,0 +1,439 @@
+"""Deterministic artifact generation for the public Data IO 2026 demo."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+@dataclass(frozen=True)
+class MissionWeights:
+    latency: float = 0.65
+    cost: float = 0.12
+    reliability: float = 0.16
+    risk: float = 0.07
+
+    @classmethod
+    def from_args(cls, args: Any) -> "MissionWeights":
+        objective = str(getattr(args, "objective", "balanced_mission"))
+        if objective == "latency_first":
+            return cls(latency=0.78, cost=0.08, reliability=0.10, risk=0.04).normalised()
+        if objective == "resilience_first":
+            return cls(latency=0.32, cost=0.08, reliability=0.42, risk=0.18).normalised()
+        return cls(
+            latency=float(getattr(args, "latency_weight", 0.65)),
+            cost=float(getattr(args, "cost_weight", 0.12)),
+            reliability=float(getattr(args, "reliability_weight", 0.16)),
+            risk=float(getattr(args, "risk_weight", 0.07)),
+        ).normalised()
+
+    def normalised(self) -> "MissionWeights":
+        total = self.latency + self.cost + self.reliability + self.risk
+        if total <= 0:
+            return MissionWeights()
+        return MissionWeights(
+            latency=self.latency / total,
+            cost=self.cost / total,
+            reliability=self.reliability / total,
+            risk=self.risk / total,
+        )
+
+
+def _clamp(value: float, *, low: float = 0.0, high: float = 1.0) -> float:
+    return max(low, min(high, value))
+
+
+def _safe_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError, OverflowError):
+        return default
+
+
+def _pct_delta(new_value: float, reference: float) -> float | None:
+    if reference == 0:
+        return None
+    return round(((new_value - reference) / reference) * 100.0, 3)
+
+
+def _event_matches(event: Mapping[str, Any], failure_kind: str) -> bool:
+    event_kind = str(event.get("kind", ""))
+    if failure_kind == "combined":
+        return event_kind in {"bandwidth_drop", "node_failure"}
+    return event_kind == failure_kind
+
+
+def _route_key(route: Mapping[str, Any]) -> str:
+    return str(route.get("route_id") or route.get("label") or "route")
+
+
+def apply_failure_events(
+    routes: list[dict[str, Any]],
+    events: list[dict[str, Any]],
+    *,
+    failure_kind: str,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Apply selected mission events to route candidates."""
+
+    updated = [deepcopy(route) for route in routes]
+    applied: list[dict[str, Any]] = []
+    for event in events:
+        if not _event_matches(event, failure_kind):
+            continue
+        target_route = str(event.get("target_route", ""))
+        for route in updated:
+            if _route_key(route) != target_route:
+                continue
+            route["latency_ms"] = round(
+                _safe_float(route.get("latency_ms")) * _safe_float(event.get("latency_multiplier"), 1.0),
+                3,
+            )
+            route["cost"] = round(
+                _safe_float(route.get("cost")) * _safe_float(event.get("cost_multiplier"), 1.0),
+                3,
+            )
+            route["bandwidth_mbps"] = round(
+                _safe_float(route.get("bandwidth_mbps")) * _safe_float(event.get("bandwidth_factor"), 1.0),
+                3,
+            )
+            route["reliability"] = round(
+                _clamp(_safe_float(route.get("reliability")) + _safe_float(event.get("reliability_delta"))),
+                4,
+            )
+            route["risk"] = round(
+                _clamp(_safe_float(route.get("risk")) + _safe_float(event.get("risk_delta"))),
+                4,
+            )
+            route["active_event"] = event.get("kind")
+            applied.append(dict(event))
+    return updated, applied
+
+
+def score_routes(
+    routes: list[dict[str, Any]],
+    *,
+    weights: MissionWeights,
+    phase: str,
+) -> list[dict[str, Any]]:
+    """Score route candidates. Lower score is better."""
+
+    max_latency = max((_safe_float(route.get("latency_ms")) for route in routes), default=1.0) or 1.0
+    max_cost = max((_safe_float(route.get("cost")) for route in routes), default=1.0) or 1.0
+    max_risk = max((_safe_float(route.get("risk")) for route in routes), default=1.0) or 1.0
+
+    scored: list[dict[str, Any]] = []
+    for route in routes:
+        latency = _safe_float(route.get("latency_ms"))
+        cost = _safe_float(route.get("cost"))
+        reliability = _clamp(_safe_float(route.get("reliability")))
+        risk = _clamp(_safe_float(route.get("risk")))
+        score = (
+            weights.latency * (latency / max_latency)
+            + weights.cost * (cost / max_cost)
+            + weights.reliability * (1.0 - reliability)
+            + weights.risk * (risk / max_risk)
+        )
+        row = {
+            "phase": phase,
+            "route_id": _route_key(route),
+            "label": str(route.get("label", _route_key(route))),
+            "latency_ms": round(latency, 3),
+            "cost": round(cost, 3),
+            "reliability": round(reliability, 4),
+            "risk": round(risk, 4),
+            "bandwidth_mbps": round(_safe_float(route.get("bandwidth_mbps")), 3),
+            "score": round(score, 6),
+            "active_event": route.get("active_event", ""),
+        }
+        scored.append(row)
+    return sorted(scored, key=lambda item: (item["score"], item["latency_ms"], item["route_id"]))
+
+
+def choose_route(scored_routes: list[dict[str, Any]]) -> dict[str, Any]:
+    if not scored_routes:
+        raise ValueError("No route candidates available")
+    return dict(scored_routes[0])
+
+
+def _selected_route(rows: list[dict[str, Any]], route_id: str) -> dict[str, Any]:
+    for row in rows:
+        if row.get("route_id") == route_id:
+            return dict(row)
+    raise ValueError(f"Route {route_id!r} not found")
+
+
+def build_generated_pipeline(
+    scenario: Mapping[str, Any],
+    *,
+    failure_kind: str,
+    adaptation_mode: str,
+) -> dict[str, Any]:
+    """Build a scenario-driven conceptual pipeline contract."""
+
+    source_count = len(scenario.get("sources", []) or [])
+    route_count = len(scenario.get("routes", []) or [])
+    event_count = len(
+        [
+            event
+            for event in scenario.get("events", []) or []
+            if isinstance(event, dict) and _event_matches(event, failure_kind)
+        ]
+    )
+    stages = [
+        {
+            "stage_id": "ingest",
+            "label": "Live data ingestion",
+            "reason": f"{source_count} source streams declared",
+        },
+        {
+            "stage_id": "clean",
+            "label": "Cleaning and normalization",
+            "reason": "quality fields are present on mission sources",
+        },
+        {
+            "stage_id": "features",
+            "label": "Feature extraction",
+            "reason": "route latency, bandwidth, cost, reliability, and risk are available",
+        },
+        {
+            "stage_id": "score",
+            "label": "Model selection and route scoring",
+            "reason": f"{route_count} candidate routes declared",
+        },
+    ]
+    if event_count:
+        stages.append(
+            {
+                "stage_id": "detect_event",
+                "label": "Mission event detection",
+                "reason": f"{event_count} selected failure event(s) are active",
+            }
+        )
+    if adaptation_mode == "auto_replan":
+        stages.append(
+            {
+                "stage_id": "replan",
+                "label": "Optimization re-plan",
+                "reason": "automatic adaptation mode is enabled",
+            }
+        )
+    stages.append(
+        {
+            "stage_id": "decision",
+            "label": "Decision evidence export",
+            "reason": "ANALYSIS requires auditable metrics and timeline artifacts",
+        }
+    )
+    return {
+        "schema": "agilab.data_io_2026.pipeline.v1",
+        "scenario": scenario.get("scenario", "mission"),
+        "dynamic": True,
+        "failure_kind": failure_kind,
+        "adaptation_mode": adaptation_mode,
+        "stages": stages,
+    }
+
+
+def build_decision_artifacts(scenario: Mapping[str, Any], args: Any) -> dict[str, Any]:
+    """Return all public demo artifacts for one mission scenario."""
+
+    scenario_name = str(scenario.get("scenario") or "mission_decision_demo")
+    failure_kind = str(getattr(args, "failure_kind", "bandwidth_drop"))
+    adaptation_mode = str(getattr(args, "adaptation_mode", "auto_replan"))
+    weights = MissionWeights.from_args(args)
+    routes = [dict(route) for route in scenario.get("routes", []) or []]
+    events = [dict(event) for event in scenario.get("events", []) or []]
+    if not routes:
+        raise ValueError(f"Scenario {scenario_name!r} declares no candidate routes")
+
+    baseline_scored = score_routes(routes, weights=weights, phase="baseline")
+    initial_choice = choose_route(baseline_scored)
+    failed_routes, applied_events = apply_failure_events(
+        routes,
+        events,
+        failure_kind=failure_kind,
+    )
+    post_failure_scored = score_routes(failed_routes, weights=weights, phase="post_failure")
+    degraded_initial = _selected_route(post_failure_scored, str(initial_choice["route_id"]))
+    adapted_choice = (
+        choose_route(post_failure_scored)
+        if adaptation_mode == "auto_replan"
+        else degraded_initial
+    )
+    pipeline = build_generated_pipeline(
+        scenario,
+        failure_kind=failure_kind,
+        adaptation_mode=adaptation_mode,
+    )
+
+    latency_delta_pct = _pct_delta(
+        _safe_float(adapted_choice["latency_ms"]),
+        _safe_float(degraded_initial["latency_ms"]),
+    )
+    cost_delta_pct = _pct_delta(
+        _safe_float(adapted_choice["cost"]),
+        _safe_float(degraded_initial["cost"]),
+    )
+    reliability_delta_pct = _pct_delta(
+        _safe_float(adapted_choice["reliability"]),
+        _safe_float(degraded_initial["reliability"]),
+    )
+
+    artifact_stem = scenario_name.replace(" ", "_")
+    summary = {
+        "schema": "agilab.data_io_2026.summary.v1",
+        "scenario": scenario_name,
+        "artifact_stem": artifact_stem,
+        "status": "pass",
+        "objective": getattr(args, "objective", "balanced_mission"),
+        "adaptation_mode": adaptation_mode,
+        "failure_kind": failure_kind,
+        "selected_strategy": adapted_choice["route_id"],
+        "initial_strategy": initial_choice["route_id"],
+        "degraded_initial_strategy": degraded_initial["route_id"],
+        "latency_ms_initial": initial_choice["latency_ms"],
+        "latency_ms_without_replan": degraded_initial["latency_ms"],
+        "latency_ms_selected": adapted_choice["latency_ms"],
+        "latency_delta_pct_vs_no_replan": latency_delta_pct,
+        "cost_without_replan": degraded_initial["cost"],
+        "cost_selected": adapted_choice["cost"],
+        "cost_delta_pct_vs_no_replan": cost_delta_pct,
+        "reliability_without_replan": degraded_initial["reliability"],
+        "reliability_selected": adapted_choice["reliability"],
+        "reliability_delta_pct_vs_no_replan": reliability_delta_pct,
+        "risk_selected": adapted_choice["risk"],
+        "pipeline_stage_count": len(pipeline["stages"]),
+        "generated_pipeline": True,
+        "applied_event_count": len(applied_events),
+    }
+
+    sources = [dict(source) for source in scenario.get("sources", []) or []]
+    sensor_stream = []
+    for index, source in enumerate(sources):
+        sensor_stream.append(
+            {
+                "time_s": index * 4,
+                "source_id": source.get("source_id", f"source_{index}"),
+                "kind": source.get("kind", "stream"),
+                "rate_hz": source.get("rate_hz", 1.0),
+                "quality": source.get("quality", 1.0),
+                "event": "",
+            }
+        )
+    for event in applied_events:
+        sensor_stream.append(
+            {
+                "time_s": event.get("time_s", 0.0),
+                "source_id": event.get("target_route", ""),
+                "kind": event.get("kind", ""),
+                "rate_hz": 0.0,
+                "quality": 0.0,
+                "event": event.get("description", ""),
+            }
+        )
+    sensor_stream = sorted(sensor_stream, key=lambda item: _safe_float(item.get("time_s")))
+
+    constraints = dict(scenario.get("constraints", {}) or {})
+    feature_table = [
+        {
+            "feature": "source_count",
+            "value": len(sources),
+            "unit": "streams",
+            "source": "scenario",
+        },
+        {
+            "feature": "route_count",
+            "value": len(routes),
+            "unit": "routes",
+            "source": "scenario",
+        },
+        {
+            "feature": "latency_budget_ms",
+            "value": constraints.get("latency_budget_ms"),
+            "unit": "ms",
+            "source": "constraints",
+        },
+        {
+            "feature": "risk_ceiling",
+            "value": constraints.get("risk_ceiling"),
+            "unit": "ratio",
+            "source": "constraints",
+        },
+        {
+            "feature": "min_reliability",
+            "value": constraints.get("min_reliability"),
+            "unit": "ratio",
+            "source": "constraints",
+        },
+    ]
+
+    decision_timeline = [
+        {
+            "step": 1,
+            "phase": "ingest",
+            "decision": f"Loaded {len(sources)} streams and {len(routes)} route candidates",
+            "selected_strategy": "",
+        },
+        {
+            "step": 2,
+            "phase": "pipeline",
+            "decision": f"Generated {len(pipeline['stages'])} pipeline stages",
+            "selected_strategy": "",
+        },
+        {
+            "step": 3,
+            "phase": "baseline_decision",
+            "decision": f"Initial best route: {initial_choice['route_id']}",
+            "selected_strategy": initial_choice["route_id"],
+        },
+        {
+            "step": 4,
+            "phase": "failure",
+            "decision": f"Applied {len(applied_events)} selected failure event(s)",
+            "selected_strategy": degraded_initial["route_id"],
+        },
+        {
+            "step": 5,
+            "phase": "replan",
+            "decision": f"Adapted best route: {adapted_choice['route_id']}",
+            "selected_strategy": adapted_choice["route_id"],
+        },
+        {
+            "step": 6,
+            "phase": "evidence",
+            "decision": "Exported decision metrics and analysis artifacts",
+            "selected_strategy": adapted_choice["route_id"],
+        },
+    ]
+
+    mission_decision = {
+        "scenario": scenario_name,
+        "objective": scenario.get("objective", ""),
+        "selected_strategy": adapted_choice,
+        "initial_strategy": initial_choice,
+        "degraded_initial_strategy": degraded_initial,
+        "applied_events": applied_events,
+        "constraints": constraints,
+    }
+
+    return {
+        "artifact_stem": artifact_stem,
+        "summary": summary,
+        "mission_decision": mission_decision,
+        "generated_pipeline": pipeline,
+        "sensor_stream": sensor_stream,
+        "feature_table": feature_table,
+        "candidate_routes": baseline_scored + post_failure_scored,
+        "decision_timeline": decision_timeline,
+    }
+
+
+__all__ = [
+    "MissionWeights",
+    "apply_failure_events",
+    "build_decision_artifacts",
+    "build_generated_pipeline",
+    "choose_route",
+    "score_routes",
+]

--- a/src/agilab/apps/builtin/data_io_2026_project/src/data_io_2026/data_io_2026.py
+++ b/src/agilab/apps/builtin/data_io_2026_project/src/data_io_2026/data_io_2026.py
@@ -1,0 +1,135 @@
+"""Manager for the public Data IO 2026 built-in demo."""
+
+from __future__ import annotations
+
+import logging
+import shutil
+from pathlib import Path
+from typing import Any
+
+from pydantic import ValidationError
+
+from agi_node.agi_dispatcher import BaseWorker, WorkDispatcher
+
+from .app_args import ArgsOverrides, DataIo2026Args, dump_args, ensure_defaults, load_args, merge_args
+
+logger = logging.getLogger(__name__)
+
+
+class DataIo2026(BaseWorker):
+    """Manager that seeds mission scenarios and builds worker distribution plans."""
+
+    worker_vars: dict[str, Any] = {}
+
+    def __init__(
+        self,
+        env,
+        args: DataIo2026Args | None = None,
+        **kwargs: ArgsOverrides,
+    ) -> None:
+        self.env = env
+        self._ensure_managed_pc_share_dir(env)
+        self.verbose = int(kwargs.pop("verbose", getattr(env, "verbose", 0) or 0))
+
+        if args is None:
+            try:
+                args = DataIo2026Args(**kwargs)
+            except ValidationError as exc:
+                raise ValueError(f"Invalid DataIo2026 arguments: {exc}") from exc
+
+        self.args = ensure_defaults(args, env=env)
+        self.args = self._apply_managed_pc_paths(self.args)
+        self.args.data_in = env.resolve_share_path(self.args.data_in)
+        self.args.data_out = env.resolve_share_path(self.args.data_out)
+        self.data_out = self.args.data_out
+
+        self.args.data_in.mkdir(parents=True, exist_ok=True)
+        self._ensure_dataset(self.args.data_in)
+
+        if self.args.reset_target and self.data_out.exists():
+            shutil.rmtree(self.data_out, ignore_errors=True, onerror=WorkDispatcher._onerror)
+        self.data_out.mkdir(parents=True, exist_ok=True)
+        self.analysis_artifact_dir.mkdir(parents=True, exist_ok=True)
+
+        WorkDispatcher.args = self.args.model_dump(mode="json")
+
+    @property
+    def analysis_artifact_dir(self) -> Path:
+        export_root = Path(getattr(self.env, "AGILAB_EXPORT_ABS", Path.home() / "export"))
+        return export_root / self.env.target / "data_io_decision"
+
+    def _sample_dataset_source(self) -> Path:
+        return Path(__file__).resolve().parent / "sample_data" / "mission_decision_demo.json"
+
+    def _ensure_dataset(self, data_in: Path) -> None:
+        existing = sorted(data_in.glob(self.args.files))
+        if existing:
+            return
+        sample = self._sample_dataset_source()
+        if not sample.is_file():
+            raise FileNotFoundError(f"Bundled Data IO 2026 scenario missing: {sample}")
+        destination = data_in / sample.name
+        shutil.copy2(sample, destination)
+        logger.info("Seeded Data IO 2026 sample scenario at %s", destination)
+
+    @classmethod
+    def from_toml(
+        cls,
+        env,
+        settings_path: str | Path = "app_settings.toml",
+        section: str = "args",
+        **overrides: ArgsOverrides,
+    ) -> "DataIo2026":
+        base = load_args(settings_path, section=section)
+        merged = ensure_defaults(merge_args(base, overrides or None), env=env)
+        return cls(env, args=merged)
+
+    def to_toml(
+        self,
+        settings_path: str | Path = "app_settings.toml",
+        section: str = "args",
+        create_missing: bool = True,
+    ) -> None:
+        dump_args(self.args, settings_path, section=section, create_missing=create_missing)
+
+    def as_dict(self) -> dict[str, Any]:
+        return self.args.model_dump(mode="json")
+
+    def build_distribution(self, workers):
+        files = sorted(self.args.data_in.glob(self.args.files))
+        if self.args.nfile > 0:
+            files = files[: self.args.nfile]
+        if not files:
+            raise FileNotFoundError(
+                f"No mission scenario file found in {self.args.data_in} with pattern {self.args.files!r}"
+            )
+
+        weights = [(str(path), max(int(path.stat().st_size // 1024), 1)) for path in files]
+        if len(weights) == 1:
+            worker_chunks = [[weights[0]]]
+        else:
+            worker_chunks = WorkDispatcher.make_chunks(
+                len(weights),
+                weights,
+                workers=workers,
+                verbose=self.verbose,
+                threshold=12,
+            )
+
+        work_plan = []
+        metadata = []
+        for chunk in worker_chunks:
+            file_batch = [file_path for file_path, _ in chunk]
+            total_size_kb = sum(size_kb for _, size_kb in chunk)
+            batch_label = Path(file_batch[0]).name if len(file_batch) == 1 else f"{len(file_batch)} files"
+            work_plan.append([file_batch])
+            metadata.append([{"scenario": batch_label, "size_kb": total_size_kb}])
+
+        return work_plan, metadata, "scenario", "size_kb", "KB"
+
+
+class DataIo2026App(DataIo2026):
+    """Compatibility alias retaining the descriptive *App suffix."""
+
+
+__all__ = ["DataIo2026", "DataIo2026App"]

--- a/src/agilab/apps/builtin/data_io_2026_project/src/data_io_2026/sample_data/mission_decision_demo.json
+++ b/src/agilab/apps/builtin/data_io_2026_project/src/data_io_2026/sample_data/mission_decision_demo.json
@@ -1,0 +1,83 @@
+{
+  "scenario": "mission_decision_demo",
+  "title": "Data IO 2026 mission data decision scenario",
+  "objective": "Choose the most resilient route under latency, cost, reliability, and risk constraints.",
+  "constraints": {
+    "latency_budget_ms": 125.0,
+    "risk_ceiling": 0.35,
+    "min_reliability": 0.9
+  },
+  "sources": [
+    {
+      "source_id": "eo_sensor",
+      "kind": "sensor_stream",
+      "rate_hz": 2.0,
+      "quality": 0.96
+    },
+    {
+      "source_id": "satcom_status",
+      "kind": "network_status",
+      "rate_hz": 1.0,
+      "quality": 0.93
+    },
+    {
+      "source_id": "mission_constraints",
+      "kind": "operator_constraints",
+      "rate_hz": 0.2,
+      "quality": 0.98
+    }
+  ],
+  "routes": [
+    {
+      "route_id": "direct_satcom",
+      "label": "Direct satcom route",
+      "latency_ms": 82.0,
+      "cost": 64.0,
+      "reliability": 0.92,
+      "risk": 0.22,
+      "bandwidth_mbps": 18.0
+    },
+    {
+      "route_id": "relay_mesh",
+      "label": "Relay mesh route",
+      "latency_ms": 104.0,
+      "cost": 46.0,
+      "reliability": 0.96,
+      "risk": 0.16,
+      "bandwidth_mbps": 12.0
+    },
+    {
+      "route_id": "fallback_store_forward",
+      "label": "Store-and-forward fallback",
+      "latency_ms": 132.0,
+      "cost": 38.0,
+      "reliability": 0.98,
+      "risk": 0.10,
+      "bandwidth_mbps": 8.0
+    }
+  ],
+  "events": [
+    {
+      "time_s": 32.0,
+      "kind": "bandwidth_drop",
+      "target_route": "direct_satcom",
+      "description": "Simulated satcom capacity drop on the initially preferred direct route.",
+      "bandwidth_factor": 0.35,
+      "latency_multiplier": 1.85,
+      "cost_multiplier": 1.06,
+      "reliability_delta": -0.12,
+      "risk_delta": 0.16
+    },
+    {
+      "time_s": 48.0,
+      "kind": "node_failure",
+      "target_route": "relay_mesh",
+      "description": "Optional relay degradation event used when the combined failure mode is selected.",
+      "bandwidth_factor": 0.70,
+      "latency_multiplier": 1.18,
+      "cost_multiplier": 1.04,
+      "reliability_delta": -0.05,
+      "risk_delta": 0.07
+    }
+  ]
+}

--- a/src/agilab/apps/builtin/data_io_2026_project/src/data_io_2026_worker/__init__.py
+++ b/src/agilab/apps/builtin/data_io_2026_project/src/data_io_2026_worker/__init__.py
@@ -1,0 +1,5 @@
+"""Worker surface for the public Data IO 2026 demo."""
+
+from .data_io_2026_worker import DataIo2026Worker
+
+__all__ = ["DataIo2026Worker"]

--- a/src/agilab/apps/builtin/data_io_2026_project/src/data_io_2026_worker/data_io_2026_worker.py
+++ b/src/agilab/apps/builtin/data_io_2026_project/src/data_io_2026_worker/data_io_2026_worker.py
@@ -1,0 +1,161 @@
+"""Worker for the public Data IO 2026 autonomous mission decision demo."""
+
+from __future__ import annotations
+
+import csv
+import json
+import logging
+import re
+import shutil
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from agi_node.agi_dispatcher import BaseWorker
+from agi_node.pandas_worker import PandasWorker
+from data_io_2026 import DataIo2026Args
+from data_io_2026.artifacts import build_decision_artifacts
+
+logger = logging.getLogger(__name__)
+_runtime: dict[str, object] = {}
+
+
+def _sanitize_slug(value: str) -> str:
+    cleaned = re.sub(r"[^0-9A-Za-z_-]+", "_", value.strip())
+    cleaned = cleaned.strip("_")
+    return cleaned or "data_io_2026_run"
+
+
+def _write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def _write_csv(path: Path, rows: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fieldnames: list[str] = []
+    for row in rows:
+        for key in row:
+            if key not in fieldnames:
+                fieldnames.append(key)
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _args_with_defaults(value: Any) -> SimpleNamespace:
+    if isinstance(value, dict):
+        raw = dict(value)
+    elif isinstance(value, SimpleNamespace):
+        raw = vars(value).copy()
+    else:
+        raw = vars(value).copy()
+    defaults = DataIo2026Args().model_dump(mode="json")
+    defaults.update({key: val for key, val in raw.items() if not key.startswith("_")})
+    return SimpleNamespace(**defaults)
+
+
+class DataIo2026Worker(PandasWorker):
+    """Execute one mission scenario and export decision evidence artifacts."""
+
+    pool_vars: dict[str, object] = {}
+
+    def start(self):
+        global _runtime
+        self.args = _args_with_defaults(self.args)
+
+        data_paths = self.setup_data_directories(
+            source_path=self.args.data_in,
+            target_path=self.args.data_out,
+            target_subdir="results",
+            reset_target=bool(getattr(self.args, "reset_target", False)),
+        )
+        self.args.data_in = data_paths.normalized_input
+        self.args.data_out = data_paths.normalized_output
+        self.data_out = data_paths.output_path
+        self.artifact_dir = Path(self.env.AGILAB_EXPORT_ABS) / self.env.target / "data_io_decision"
+        self.artifact_dir.mkdir(parents=True, exist_ok=True)
+        self.pool_vars = {"args": self.args}
+        _runtime = self.pool_vars
+
+    def pool_init(self, worker_vars):
+        global _runtime
+        _runtime = worker_vars
+
+    def _current_args(self) -> SimpleNamespace:
+        args = _runtime.get("args", self.args)
+        if isinstance(args, dict):
+            return SimpleNamespace(**args)
+        return args
+
+    def work_init(self) -> None:
+        return None
+
+    def works(self, workers_plan: Any, workers_plan_metadata: Any) -> float:
+        """Execute assigned mission scenario batches."""
+
+        assigned_batches: list[Any] = []
+        if isinstance(workers_plan, list) and len(workers_plan) > self._worker_id:
+            worker_batches = workers_plan[self._worker_id]
+            if isinstance(worker_batches, list):
+                assigned_batches = worker_batches
+
+        self.work_init()
+        for batch in assigned_batches:
+            work_items = list(batch) if isinstance(batch, (list, tuple)) else [batch]
+            for work_item in work_items:
+                result = self.work_pool(work_item)
+                self.work_done(result)
+
+        self.stop()
+
+        if BaseWorker._t0 is None:
+            BaseWorker._t0 = time.time()
+        return time.time() - BaseWorker._t0
+
+    def _load_scenario(self, file_path: str | Path) -> dict[str, Any]:
+        source = Path(str(file_path)).expanduser()
+        payload = json.loads(source.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict):
+            raise ValueError(f"Scenario file must contain a JSON object: {source}")
+        if not isinstance(payload.get("routes"), list):
+            raise ValueError(f"Scenario file must declare candidate routes: {source}")
+        return payload
+
+    def work_pool(self, file_path):
+        scenario = self._load_scenario(file_path)
+        artifacts = build_decision_artifacts(scenario, self._current_args())
+        artifacts["source_file"] = str(file_path)
+        artifacts["worker_id"] = int(getattr(self, "_worker_id", 0))
+        return artifacts
+
+    def _write_artifact_bundle(self, root: Path, artifacts: dict[str, Any]) -> None:
+        stem = _sanitize_slug(str(artifacts["artifact_stem"]))
+        run_root = root / stem
+        if run_root.exists() and bool(getattr(self._current_args(), "reset_target", False)):
+            shutil.rmtree(run_root)
+        run_root.mkdir(parents=True, exist_ok=True)
+
+        summary = dict(artifacts["summary"])
+        summary["worker_id"] = artifacts.get("worker_id", 0)
+        summary["source_file"] = artifacts.get("source_file", "")
+
+        _write_json(run_root / f"{stem}_summary_metrics.json", summary)
+        _write_json(run_root / f"{stem}_mission_decision.json", artifacts["mission_decision"])
+        _write_json(run_root / f"{stem}_generated_pipeline.json", artifacts["generated_pipeline"])
+        _write_csv(run_root / f"{stem}_sensor_stream.csv", artifacts["sensor_stream"])
+        _write_csv(run_root / f"{stem}_feature_table.csv", artifacts["feature_table"])
+        _write_csv(run_root / f"{stem}_candidate_routes.csv", artifacts["candidate_routes"])
+        _write_csv(run_root / f"{stem}_decision_timeline.csv", artifacts["decision_timeline"])
+
+    def work_done(self, artifacts: dict[str, Any] | None = None) -> None:
+        if not artifacts:
+            return
+        self._write_artifact_bundle(Path(self.data_out), artifacts)
+        self._write_artifact_bundle(self.artifact_dir, artifacts)
+        logger.info("wrote Data IO 2026 decision artifacts for %s", artifacts["artifact_stem"])
+
+
+__all__ = ["DataIo2026Worker"]

--- a/src/agilab/apps/builtin/data_io_2026_project/src/pre_prompt.json
+++ b/src/agilab/apps/builtin/data_io_2026_project/src/pre_prompt.json
@@ -1,0 +1,4 @@
+{
+  "system": "You are operating the public Data IO 2026 AGILAB demo. Keep outputs factual, deterministic, and focused on mission-data ingestion, adaptive pipeline execution, and decision evidence. Do not include non-public competitive positioning or non-public app names.",
+  "user": "Generate or explain the next Data IO 2026 mission-decision step using the configured public scenario and analysis artifacts."
+}

--- a/test/test_data_io_2026_project.py
+++ b/test/test_data_io_2026_project.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import json
+import sys
+import tomllib
+from pathlib import Path
+from types import SimpleNamespace
+
+import pandas as pd
+from agi_node.pandas_worker import PandasWorker
+
+
+APP_ROOT = Path("src/agilab/apps/builtin/data_io_2026_project").resolve()
+SRC_ROOT = APP_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from data_io_2026 import DataIo2026, DataIo2026Args, build_decision_artifacts
+from data_io_2026_worker import DataIo2026Worker
+from data_io_2026_worker.data_io_2026_worker import _args_with_defaults
+
+
+def _make_env(tmp_path: Path) -> SimpleNamespace:
+    share_root = tmp_path / "share"
+    share_root.mkdir(parents=True, exist_ok=True)
+    export_root = tmp_path / "export"
+    export_root.mkdir(parents=True, exist_ok=True)
+
+    def _resolve_share_path(path):
+        candidate = Path(path)
+        return candidate if candidate.is_absolute() else share_root / candidate
+
+    return SimpleNamespace(
+        verbose=0,
+        resolve_share_path=_resolve_share_path,
+        home_abs=tmp_path,
+        _is_managed_pc=False,
+        AGI_LOCAL_SHARE=str(share_root),
+        AGILAB_EXPORT_ABS=export_root,
+        target="data_io_2026",
+    )
+
+
+def test_data_io_2026_manager_seeds_public_scenario_and_distribution(tmp_path: Path) -> None:
+    env = _make_env(tmp_path)
+    manager = DataIo2026(env, args=DataIo2026Args())
+
+    files = sorted(manager.args.data_in.glob("*.json"))
+    assert len(files) == 1
+    assert files[0].name == "mission_decision_demo.json"
+    assert manager.analysis_artifact_dir == env.AGILAB_EXPORT_ABS / "data_io_2026" / "data_io_decision"
+
+    work_plan, metadata, partition_key, weights_key, unit = manager.build_distribution({"127.0.0.1": 1})
+
+    assert len(work_plan) == 1
+    assert len(work_plan[0][0]) == 1
+    assert metadata[0][0]["scenario"] == "mission_decision_demo.json"
+    assert partition_key == "scenario"
+    assert weights_key == "size_kb"
+    assert unit == "KB"
+
+
+def test_data_io_2026_decision_artifacts_replan_after_bandwidth_drop() -> None:
+    scenario_path = SRC_ROOT / "data_io_2026" / "sample_data" / "mission_decision_demo.json"
+    scenario = json.loads(scenario_path.read_text(encoding="utf-8"))
+
+    artifacts = build_decision_artifacts(scenario, DataIo2026Args())
+    summary = artifacts["summary"]
+
+    assert summary["initial_strategy"] == "direct_satcom"
+    assert summary["selected_strategy"] == "relay_mesh"
+    assert summary["latency_delta_pct_vs_no_replan"] < 0
+    assert summary["cost_delta_pct_vs_no_replan"] < 0
+    assert summary["reliability_delta_pct_vs_no_replan"] > 0
+    assert summary["pipeline_stage_count"] == len(artifacts["generated_pipeline"]["stages"])
+    assert {row["phase"] for row in artifacts["candidate_routes"]} == {"baseline", "post_failure"}
+    assert len(artifacts["decision_timeline"]) == 6
+
+
+def test_data_io_2026_worker_exports_analysis_artifacts(tmp_path: Path) -> None:
+    env = _make_env(tmp_path)
+    manager = DataIo2026(env, args=DataIo2026Args(reset_target=True))
+    source = sorted(manager.args.data_in.glob("*.json"))[0]
+
+    worker = DataIo2026Worker()
+    worker.env = env
+    worker.args = manager.args.model_dump(mode="json")
+    worker._worker_id = 0
+    worker.worker_id = 0
+    worker.verbose = 0
+    worker.start()
+
+    result = worker.work_pool(str(source))
+    worker.work_done(result)
+
+    for root in (
+        Path(worker.data_out) / "mission_decision_demo",
+        env.AGILAB_EXPORT_ABS / env.target / "data_io_decision" / "mission_decision_demo",
+    ):
+        summary_path = root / "mission_decision_demo_summary_metrics.json"
+        assert summary_path.is_file()
+        summary = json.loads(summary_path.read_text(encoding="utf-8"))
+        assert summary["selected_strategy"] == "relay_mesh"
+        assert summary["initial_strategy"] == "direct_satcom"
+        assert summary["worker_id"] == 0
+
+        pipeline_path = root / "mission_decision_demo_generated_pipeline.json"
+        decision_path = root / "mission_decision_demo_mission_decision.json"
+        assert pipeline_path.is_file()
+        assert decision_path.is_file()
+
+        routes_df = pd.read_csv(root / "mission_decision_demo_candidate_routes.csv")
+        timeline_df = pd.read_csv(root / "mission_decision_demo_decision_timeline.csv")
+        sensor_df = pd.read_csv(root / "mission_decision_demo_sensor_stream.csv")
+        feature_df = pd.read_csv(root / "mission_decision_demo_feature_table.csv")
+
+        assert {"phase", "route_id", "latency_ms", "score"} <= set(routes_df.columns)
+        assert {"step", "phase", "decision", "selected_strategy"} <= set(timeline_df.columns)
+        assert {"source_id", "kind", "quality", "event"} <= set(sensor_df.columns)
+        assert {"feature", "value", "unit", "source"} <= set(feature_df.columns)
+
+
+def test_data_io_2026_worker_args_fill_missing_defaults() -> None:
+    args = _args_with_defaults({"data_in": "custom/in"})
+
+    assert args.data_in == "custom/in"
+    assert args.data_out == "data_io_2026/results"
+    assert args.files == "*.json"
+    assert args.failure_kind == "bandwidth_drop"
+
+
+def test_data_io_2026_public_analysis_config_and_wording() -> None:
+    settings = tomllib.loads((SRC_ROOT / "app_settings.toml").read_text(encoding="utf-8"))
+
+    assert settings["pages"]["default_view"] == "view_data_io_decision"
+    assert settings["pages"]["view_module"] == ["view_data_io_decision"]
+
+    public_files = [
+        APP_ROOT / "README.md",
+        APP_ROOT / "lab_steps.toml",
+        APP_ROOT / "pipeline_view.dot",
+        SRC_ROOT / "pre_prompt.json",
+        Path("src/agilab/apps-pages/view_data_io_decision/README.md"),
+    ]
+    public_text = "\n".join(path.read_text(encoding="utf-8") for path in public_files).lower()
+    assert "fred" not in public_text
+    assert "obsolete" not in public_text
+    assert "private project" not in public_text
+
+
+def test_data_io_2026_worker_is_installable_supported_worker() -> None:
+    assert issubclass(DataIo2026Worker, PandasWorker)


### PR DESCRIPTION
## Summary
- add the public `data_io_2026_project` built-in demo with deterministic decision artifacts
- add the `view_data_io_decision` analysis page for inspecting demo outputs
- unignore the new built-in project so it is included in public source and HF deploys

## Validation
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_beta_readiness.py test/test_data_io_2026_project.py test/test_pyproject_dependency_hygiene.py src/agilab/core/agi-env/test/test_app_settings_support.py test/test_app_args.py src/agilab/core/agi-env/test/test_app_args.py` (47 passed)
- `uv --preview-features extra-build-dependencies run python -m py_compile ...` for the new app/page/test modules
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files $(git diff --name-only origin/main...HEAD | tr '\n' ' ')`
- clean-worktree beta planning gate: `uv --preview-features extra-build-dependencies run python tools/beta_readiness.py` (PASS)

Note: local `agi-gui` full coverage was attempted repeatedly but SIGTERM'd under local resource/session pressure. The branch was pushed with `AGILAB_SKIP_LOCAL_GUARDS=1`; CI should run the full clean-runner coverage gate.
