### PR TITLE
Derive pipeline page actions from state

### DIFF
--- a/src/agilab/pipeline_lab.py
+++ b/src/agilab/pipeline_lab.py
@@ -71,6 +71,7 @@ _pipeline_page_state_module = import_agilab_module(
     fallback_name="agilab_pipeline_page_state_fallback",
 )
 PipelinePageStateDeps = _pipeline_page_state_module.PipelinePageStateDeps
+PipelineAction = _pipeline_page_state_module.PipelineAction
 build_pipeline_page_state = _pipeline_page_state_module.build_pipeline_page_state
 clear_pipeline_run_logs = _pipeline_page_state_module.clear_pipeline_run_logs
 
@@ -524,6 +525,7 @@ def display_lab_tab(
             steps=persisted_steps,
             sequence=st.session_state.get(sequence_state_key, []),
             session_state=st.session_state,
+            selected_lab=lab_dir,
             env=env,
             deps=PipelinePageStateDeps(
                 is_displayable_step=lambda entry: _is_displayable_step(dict(entry)),
@@ -1431,49 +1433,69 @@ def display_lab_tab(
     force_run_confirm_key = f"{index_page_str}_confirm_force_run"
     run_col, force_col = st.columns(2)
     with run_col:
+        run_blocked_reason = page_state.blocked_actions.get(
+            PipelineAction.RUN_PIPELINE,
+            "",
+        )
         run_all_clicked = st.button(
             "Run pipeline",
             key=f"{index_page_str}_run_all",
-            help=page_state.run_disabled_reason or "Execute every step sequentially using its saved virtual environment.",
+            help=run_blocked_reason or "Execute every step sequentially using its saved virtual environment.",
             type="secondary",
             width="stretch",
-            disabled=not page_state.can_run,
+            disabled=PipelineAction.RUN_PIPELINE not in page_state.available_actions,
         )
     with force_col:
         if lock_state:
+            force_blocked_reason = page_state.blocked_actions.get(
+                PipelineAction.FORCE_RUN,
+                "",
+            )
             if lock_state.get("is_stale"):
                 force_run_clicked = st.button(
                     "Clear stale lock and run",
                     key=f"{index_page_str}_force_run_stale",
-                    help="Remove the stale pipeline lock and start a new run.",
+                    help=force_blocked_reason or "Remove the stale pipeline lock and start a new run.",
                     type="primary",
                     width="stretch",
-                    disabled=not page_state.can_force_run,
+                    disabled=PipelineAction.FORCE_RUN not in page_state.available_actions,
                 )
             elif st.session_state.get(force_run_confirm_key, False):
                 force_run_clicked = st.button(
                     "Confirm force unlock",
                     key=f"{index_page_str}_force_run_confirm",
-                    help="Remove the current lock and start a new run. Use this only if the previous run is gone.",
+                    help=force_blocked_reason
+                    or "Remove the current lock and start a new run. Use this only if the previous run is gone.",
                     type="primary",
                     width="stretch",
-                    disabled=not page_state.can_force_run,
+                    disabled=PipelineAction.FORCE_RUN not in page_state.available_actions,
                 )
             else:
                 force_run_arm_clicked = st.button(
                     "Force unlock and run",
                     key=f"{index_page_str}_force_run_arm",
-                    help="Use only when a previous pipeline run was interrupted and left a lock behind.",
+                    help=force_blocked_reason
+                    or "Use only when a previous pipeline run was interrupted and left a lock behind.",
                     type="secondary",
                     width="stretch",
-                    disabled=not page_state.can_force_run,
+                    disabled=PipelineAction.FORCE_RUN not in page_state.available_actions,
                 )
 
-    if run_all_clicked and not page_state.can_run:
-        st.warning(page_state.run_disabled_reason or "Pipeline cannot run in the current state.")
+    if run_all_clicked and PipelineAction.RUN_PIPELINE not in page_state.available_actions:
+        st.warning(
+            page_state.blocked_actions.get(
+                PipelineAction.RUN_PIPELINE,
+                "Pipeline cannot run in the current state.",
+            )
+        )
         run_all_clicked = False
-    if force_run_clicked and not page_state.can_force_run:
-        st.warning(page_state.run_disabled_reason or "Pipeline cannot be force-run in the current state.")
+    if force_run_clicked and PipelineAction.FORCE_RUN not in page_state.available_actions:
+        st.warning(
+            page_state.blocked_actions.get(
+                PipelineAction.FORCE_RUN,
+                "Pipeline cannot be force-run in the current state.",
+            )
+        )
         force_run_clicked = False
 
     if force_run_arm_clicked:
@@ -1645,6 +1667,7 @@ def display_lab_tab(
         )
 
     with st.expander("Run logs", expanded=True):
+        log_page_state = _build_page_state()
         clear_logs = st.button(
             "Clear logs",
             key=f"{index_page_str}__clear_logs_global",
@@ -1657,13 +1680,14 @@ def display_lab_tab(
                 toast(st, result.message, state="info")
             else:
                 st.warning(result.message)
+            log_page_state = _build_page_state()
         log_placeholder = st.empty()
         st.session_state[run_placeholder_key] = log_placeholder
-        logs = st.session_state.get(run_logs_key, [])
+        logs = list(log_page_state.run_logs)
         if logs:
             log_placeholder.code("\n".join(logs))
         else:
             log_placeholder.caption("No runs recorded yet.")
-        last_log_file = st.session_state.get(f"{index_page_str}__last_run_log_file")
+        last_log_file = log_page_state.last_run_log_file
         if last_log_file:
             st.caption(f"Most recent run log: {last_log_file}")

--- a/src/agilab/pipeline_page_state.py
+++ b/src/agilab/pipeline_page_state.py
@@ -23,6 +23,13 @@ class PipelineCommandStatus(str, Enum):
     NO_OP = "no-op"
 
 
+class PipelineAction(str, Enum):
+    ADD_STEP = "add_step"
+    CLEAR_LOGS = "clear_logs"
+    RUN_PIPELINE = "run_pipeline"
+    FORCE_RUN = "force_run"
+
+
 @dataclass(frozen=True)
 class PipelineCommandResult:
     status: PipelineCommandStatus
@@ -46,6 +53,7 @@ class PipelineVisibleStep:
 class PipelinePageState:
     index_page: str
     steps_file: Path
+    selected_lab: str
     status: PipelineWorkflowStatus
     total_steps: int
     visible_steps: Tuple[PipelineVisibleStep, ...]
@@ -58,6 +66,8 @@ class PipelinePageState:
     can_run: bool
     can_force_run: bool
     run_disabled_reason: str
+    available_actions: Tuple[PipelineAction, ...]
+    blocked_actions: Mapping[PipelineAction, str]
 
 
 def _default_is_displayable_step(entry: Mapping[str, Any]) -> bool:
@@ -150,6 +160,70 @@ def _format_stale_step_refs(stale_steps: Sequence[Mapping[str, Any]]) -> str:
     return "; ".join(refs)
 
 
+def _selected_lab_name(raw: Any, steps_file: Path, env: Any = None) -> str:
+    candidates = [
+        raw,
+        getattr(env, "selected_lab", None),
+        getattr(env, "lab", None),
+        steps_file.parent,
+        getattr(env, "app", None),
+    ]
+    for candidate in candidates:
+        if candidate in (None, ""):
+            continue
+        try:
+            text = str(candidate).strip()
+        except (OSError, RuntimeError, TypeError, ValueError):
+            continue
+        if not text:
+            continue
+        try:
+            path = Path(text)
+        except (OSError, RuntimeError, TypeError, ValueError):
+            return text
+        name = path.name.strip()
+        return name or text
+    return ""
+
+
+def _derive_actions(
+    *,
+    can_run: bool,
+    can_force_run: bool,
+    lock_state: Optional[Mapping[str, Any]],
+    run_disabled_reason: str,
+    runnable_step_count: int,
+    stale_step_refs: Sequence[Mapping[str, Any]],
+) -> tuple[Tuple[PipelineAction, ...], Mapping[PipelineAction, str]]:
+    available: list[PipelineAction] = [
+        PipelineAction.ADD_STEP,
+        PipelineAction.CLEAR_LOGS,
+    ]
+    blocked: dict[PipelineAction, str] = {}
+
+    if can_run:
+        available.append(PipelineAction.RUN_PIPELINE)
+    else:
+        blocked[PipelineAction.RUN_PIPELINE] = (
+            run_disabled_reason or "Pipeline cannot run in the current state."
+        )
+
+    if can_force_run:
+        available.append(PipelineAction.FORCE_RUN)
+    else:
+        if stale_step_refs:
+            reason = run_disabled_reason or "Stale snippets must be regenerated before force-run."
+        elif runnable_step_count == 0:
+            reason = run_disabled_reason or "No selected pipeline step contains runnable code."
+        elif not lock_state:
+            reason = "No pipeline lock is present."
+        else:
+            reason = run_disabled_reason or "Pipeline cannot be force-run in the current state."
+        blocked[PipelineAction.FORCE_RUN] = reason
+
+    return tuple(available), blocked
+
+
 def build_pipeline_page_state(
     *,
     index_page: str,
@@ -157,6 +231,7 @@ def build_pipeline_page_state(
     steps: Sequence[Mapping[str, Any]],
     sequence: Optional[Sequence[Any]],
     session_state: Mapping[str, Any],
+    selected_lab: Any = None,
     env: Any = None,
     deps: PipelinePageStateDeps = PipelinePageStateDeps(),
 ) -> PipelinePageState:
@@ -225,10 +300,19 @@ def build_pipeline_page_state(
 
     can_run = not run_disabled_reason and runnable_step_count > 0
     can_force_run = bool(lock_state) and not stale_step_refs and runnable_step_count > 0
+    available_actions, blocked_actions = _derive_actions(
+        can_run=can_run,
+        can_force_run=can_force_run,
+        lock_state=lock_state,
+        run_disabled_reason=run_disabled_reason,
+        runnable_step_count=runnable_step_count,
+        stale_step_refs=stale_step_refs,
+    )
 
     return PipelinePageState(
         index_page=index_page,
         steps_file=Path(steps_file),
+        selected_lab=_selected_lab_name(selected_lab, Path(steps_file), env=env),
         status=status,
         total_steps=total_steps,
         visible_steps=tuple(visible_steps),
@@ -241,6 +325,8 @@ def build_pipeline_page_state(
         can_run=can_run,
         can_force_run=can_force_run,
         run_disabled_reason=run_disabled_reason,
+        available_actions=available_actions,
+        blocked_actions=blocked_actions,
     )
 
 

--- a/test/test_pipeline_page_state.py
+++ b/test/test_pipeline_page_state.py
@@ -42,6 +42,7 @@ def test_pipeline_page_state_keeps_visible_steps_when_logs_are_missing_or_cleare
         steps=steps,
         sequence=[0],
         session_state=session_state,
+        selected_lab=tmp_path / "mission_lab",
         deps=_deps(),
     )
 
@@ -57,10 +58,47 @@ def test_pipeline_page_state_keeps_visible_steps_when_logs_are_missing_or_cleare
     )
 
     assert result.status is pipeline_page_state.PipelineCommandStatus.SUCCESS
+    assert state_without_logs.selected_lab == "mission_lab"
     assert state_without_logs.visible_steps[0].label == "Step 1: generate trajectories"
     assert state_after_clear.visible_steps == state_without_logs.visible_steps
     assert state_after_clear.run_logs == ()
     assert state_after_clear.can_run is True
+    assert pipeline_page_state.PipelineAction.RUN_PIPELINE in state_after_clear.available_actions
+    assert pipeline_page_state.PipelineAction.CLEAR_LOGS in state_after_clear.available_actions
+    assert state_after_clear.blocked_actions[pipeline_page_state.PipelineAction.FORCE_RUN] == (
+        "No pipeline lock is present."
+    )
+
+
+def test_pipeline_page_state_derives_blocked_actions_for_empty_and_stale_labs(tmp_path):
+    empty_state = pipeline_page_state.build_pipeline_page_state(
+        index_page="demo",
+        steps_file=tmp_path / "empty_lab" / "lab_steps.toml",
+        steps=[],
+        sequence=[],
+        session_state={},
+        deps=_deps(),
+    )
+    assert empty_state.selected_lab == "empty_lab"
+    assert pipeline_page_state.PipelineAction.RUN_PIPELINE not in empty_state.available_actions
+    assert "No visible pipeline steps" in empty_state.blocked_actions[pipeline_page_state.PipelineAction.RUN_PIPELINE]
+
+    stale_state = pipeline_page_state.build_pipeline_page_state(
+        index_page="demo",
+        steps_file=tmp_path / "lab_steps.toml",
+        steps=[{"Q": "legacy run", "C": "await AGI.run(app_env, mode=0)"}],
+        sequence=[0],
+        session_state={},
+        deps=_deps(
+            find_legacy_agi_run_steps=lambda _steps, _sequence: [
+                {"step": 1, "line": 4, "summary": "legacy run"}
+            ]
+        ),
+    )
+    assert pipeline_page_state.PipelineAction.ADD_STEP in stale_state.available_actions
+    assert pipeline_page_state.PipelineAction.RUN_PIPELINE not in stale_state.available_actions
+    assert pipeline_page_state.PipelineAction.FORCE_RUN not in stale_state.available_actions
+    assert "stale AGI.run snippets" in stale_state.blocked_actions[pipeline_page_state.PipelineAction.RUN_PIPELINE]
 
 
 def test_pipeline_page_state_refuses_stale_legacy_snippets_before_runtime(tmp_path):


### PR DESCRIPTION
## Summary
- extend PipelinePageState with selected lab metadata and derived action availability
- use derived actions for PIPELINE run and force-run controls
- render run logs from refreshed page state after clearing logs

## Validation
- uv --preview-features extra-build-dependencies run pytest -q test/test_pipeline_lab.py test/test_pipeline_page_state.py
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui
- uv --preview-features extra-build-dependencies run python tools/coverage_badge_guard.py --changed-only --require-fresh-xml