### PR TITLE
Start pipeline runs through command result

### DIFF
--- a/src/agilab/pipeline_lab.py
+++ b/src/agilab/pipeline_lab.py
@@ -74,6 +74,7 @@ PipelinePageStateDeps = _pipeline_page_state_module.PipelinePageStateDeps
 PipelineAction = _pipeline_page_state_module.PipelineAction
 build_pipeline_page_state = _pipeline_page_state_module.build_pipeline_page_state
 clear_pipeline_run_logs = _pipeline_page_state_module.clear_pipeline_run_logs
+start_pipeline_run_command = _pipeline_page_state_module.start_pipeline_run_command
 
 _pipeline_runtime_module = import_agilab_module(
     "agilab.pipeline_runtime",
@@ -1581,22 +1582,22 @@ def display_lab_tab(
             st.rerun()
 
     if run_all_clicked or force_run_clicked:
-        st.session_state.pop(force_run_confirm_key, None)
-        st.session_state[f"{index_page_str}__last_run_status"] = "running"
-        run_placeholder = _get_run_placeholder(index_page_str)
-        log_file_path, log_error = _prepare_run_log_file(index_page_str, env, prefix="pipeline")
-        if log_file_path:
-            _push_run_log(
-                index_page_str,
-                f"Run pipeline started… logs will be saved to {log_file_path}",
-                run_placeholder,
-            )
-        else:
-            _push_run_log(
-                index_page_str,
-                f"Run pipeline started… (unable to prepare log file: {log_error})",
-                run_placeholder,
-            )
+        requested_action = PipelineAction.FORCE_RUN if force_run_clicked else PipelineAction.RUN_PIPELINE
+        start_result = start_pipeline_run_command(
+            page_state=page_state,
+            requested_action=requested_action,
+            session_state=st.session_state,
+            env=env,
+            prepare_run_log_file=_prepare_run_log_file,
+            get_run_placeholder=_get_run_placeholder,
+            push_run_log=_push_run_log,
+            force_confirm_key=force_run_confirm_key,
+        )
+        if not start_result.ok:
+            st.warning(start_result.message)
+            st.rerun()
+            return
+        run_placeholder = start_result.details.get("log_placeholder")
         # Collapse all step expanders after running the pipeline
         st.session_state[expander_state_key] = {}
         try:
@@ -1609,7 +1610,7 @@ def display_lab_tab(
                         module_path,
                         env,
                         log_placeholder=run_placeholder,
-                        force_lock_clear=force_run_clicked,
+                        force_lock_clear=bool(start_result.details.get("force_lock_clear")),
                     )
                 except Exception:
                     st.session_state[f"{index_page_str}__last_run_status"] = "failed"

--- a/src/agilab/pipeline_page_state.py
+++ b/src/agilab/pipeline_page_state.py
@@ -358,3 +358,65 @@ def clear_pipeline_run_logs(
         message="Page run logs cleared; saved log files are untouched.",
         details={"key": key, "count": count},
     )
+
+
+def start_pipeline_run_command(
+    *,
+    page_state: PipelinePageState,
+    requested_action: PipelineAction,
+    session_state: MutableMapping[str, Any],
+    env: Any,
+    prepare_run_log_file: Callable[..., tuple[Any, Any]],
+    get_run_placeholder: Callable[..., Any],
+    push_run_log: Callable[..., Any],
+    force_confirm_key: str | None = None,
+) -> PipelineCommandResult:
+    """Prepare a Pipeline run from typed state before Streamlit renders progress."""
+    if requested_action not in {PipelineAction.RUN_PIPELINE, PipelineAction.FORCE_RUN}:
+        return PipelineCommandResult(
+            status=PipelineCommandStatus.REFUSED,
+            message=f"Unsupported pipeline action: {requested_action}.",
+            details={"action": requested_action},
+        )
+
+    if requested_action not in page_state.available_actions:
+        return PipelineCommandResult(
+            status=PipelineCommandStatus.REFUSED,
+            message=page_state.blocked_actions.get(
+                requested_action,
+                "Pipeline cannot run in the current state.",
+            ),
+            details={"action": requested_action, "status": page_state.status},
+        )
+
+    if force_confirm_key:
+        session_state.pop(force_confirm_key, None)
+    session_state[f"{page_state.index_page}__last_run_status"] = "running"
+
+    try:
+        run_placeholder = get_run_placeholder(page_state.index_page)
+        log_file_path, log_error = prepare_run_log_file(page_state.index_page, env, prefix="pipeline")
+        if log_file_path:
+            message = f"Run pipeline started... logs will be saved to {log_file_path}"
+        else:
+            message = f"Run pipeline started... (unable to prepare log file: {log_error})"
+        push_run_log(page_state.index_page, message, run_placeholder)
+    except Exception as exc:
+        session_state[f"{page_state.index_page}__last_run_status"] = "failed"
+        return PipelineCommandResult(
+            status=PipelineCommandStatus.FAILED,
+            message=f"Could not start pipeline run: {exc}",
+            details={"action": requested_action, "error": str(exc)},
+        )
+
+    return PipelineCommandResult(
+        status=PipelineCommandStatus.SUCCESS,
+        message=message,
+        details={
+            "action": requested_action,
+            "force_lock_clear": requested_action is PipelineAction.FORCE_RUN,
+            "log_file_path": str(log_file_path) if log_file_path else "",
+            "log_error": str(log_error or ""),
+            "log_placeholder": run_placeholder,
+        },
+    )

--- a/test/test_pipeline_page_state.py
+++ b/test/test_pipeline_page_state.py
@@ -101,6 +101,139 @@ def test_pipeline_page_state_derives_blocked_actions_for_empty_and_stale_labs(tm
     assert "stale AGI.run snippets" in stale_state.blocked_actions[pipeline_page_state.PipelineAction.RUN_PIPELINE]
 
 
+def test_start_pipeline_run_command_refuses_blocked_actions_without_side_effects(tmp_path):
+    session_state: dict[str, Any] = {}
+    state = pipeline_page_state.build_pipeline_page_state(
+        index_page="demo",
+        steps_file=tmp_path / "lab_steps.toml",
+        steps=[],
+        sequence=[],
+        session_state=session_state,
+        deps=_deps(),
+    )
+    calls: list[str] = []
+
+    result = pipeline_page_state.start_pipeline_run_command(
+        page_state=state,
+        requested_action=pipeline_page_state.PipelineAction.RUN_PIPELINE,
+        session_state=session_state,
+        env=object(),
+        prepare_run_log_file=lambda *_args, **_kwargs: calls.append("prepare"),
+        get_run_placeholder=lambda *_args, **_kwargs: calls.append("placeholder"),
+        push_run_log=lambda *_args, **_kwargs: calls.append("push"),
+        force_confirm_key="demo_confirm_force_run",
+    )
+
+    assert result.status is pipeline_page_state.PipelineCommandStatus.REFUSED
+    assert "No visible pipeline steps" in result.message
+    assert session_state == {}
+    assert calls == []
+
+
+def test_start_pipeline_run_command_sets_running_status_and_logs_path(tmp_path):
+    session_state: dict[str, Any] = {"demo_confirm_force_run": True}
+    pushed: list[tuple[str, str, object]] = []
+    placeholder = object()
+    state = pipeline_page_state.build_pipeline_page_state(
+        index_page="demo",
+        steps_file=tmp_path / "lab_steps.toml",
+        steps=[{"Q": "run", "C": "print('run')"}],
+        sequence=[0],
+        session_state=session_state,
+        deps=_deps(),
+    )
+
+    result = pipeline_page_state.start_pipeline_run_command(
+        page_state=state,
+        requested_action=pipeline_page_state.PipelineAction.RUN_PIPELINE,
+        session_state=session_state,
+        env=object(),
+        prepare_run_log_file=lambda *_args, **_kwargs: (tmp_path / "pipeline.log", None),
+        get_run_placeholder=lambda *_args, **_kwargs: placeholder,
+        push_run_log=lambda index_page, message, log_placeholder: pushed.append(
+            (index_page, message, log_placeholder)
+        ),
+        force_confirm_key="demo_confirm_force_run",
+    )
+
+    assert result.status is pipeline_page_state.PipelineCommandStatus.SUCCESS
+    assert result.details["force_lock_clear"] is False
+    assert result.details["log_file_path"] == str(tmp_path / "pipeline.log")
+    assert result.details["log_placeholder"] is placeholder
+    assert session_state["demo__last_run_status"] == "running"
+    assert "demo_confirm_force_run" not in session_state
+    assert pushed == [
+        (
+            "demo",
+            f"Run pipeline started... logs will be saved to {tmp_path / 'pipeline.log'}",
+            placeholder,
+        )
+    ]
+
+
+def test_start_pipeline_run_command_force_run_continues_without_log_file(tmp_path):
+    session_state: dict[str, Any] = {}
+    pushed: list[str] = []
+    state = pipeline_page_state.build_pipeline_page_state(
+        index_page="demo",
+        steps_file=tmp_path / "lab_steps.toml",
+        steps=[{"Q": "run", "C": "print('run')"}],
+        sequence=[0],
+        session_state=session_state,
+        env=object(),
+        deps=_deps(
+            inspect_pipeline_run_lock=lambda _env: {
+                "owner_text": "pid 123",
+                "is_stale": True,
+            }
+        ),
+    )
+
+    result = pipeline_page_state.start_pipeline_run_command(
+        page_state=state,
+        requested_action=pipeline_page_state.PipelineAction.FORCE_RUN,
+        session_state=session_state,
+        env=object(),
+        prepare_run_log_file=lambda *_args, **_kwargs: (None, "no log"),
+        get_run_placeholder=lambda *_args, **_kwargs: None,
+        push_run_log=lambda _index_page, message, _placeholder: pushed.append(message),
+    )
+
+    assert result.status is pipeline_page_state.PipelineCommandStatus.SUCCESS
+    assert result.details["force_lock_clear"] is True
+    assert result.details["log_error"] == "no log"
+    assert pushed == ["Run pipeline started... (unable to prepare log file: no log)"]
+
+
+def test_start_pipeline_run_command_marks_failed_when_logging_raises(tmp_path):
+    session_state: dict[str, Any] = {}
+    state = pipeline_page_state.build_pipeline_page_state(
+        index_page="demo",
+        steps_file=tmp_path / "lab_steps.toml",
+        steps=[{"Q": "run", "C": "print('run')"}],
+        sequence=[0],
+        session_state=session_state,
+        deps=_deps(),
+    )
+
+    def _raise_push(*_args, **_kwargs):
+        raise RuntimeError("push blocked")
+
+    result = pipeline_page_state.start_pipeline_run_command(
+        page_state=state,
+        requested_action=pipeline_page_state.PipelineAction.RUN_PIPELINE,
+        session_state=session_state,
+        env=object(),
+        prepare_run_log_file=lambda *_args, **_kwargs: (tmp_path / "pipeline.log", None),
+        get_run_placeholder=lambda *_args, **_kwargs: None,
+        push_run_log=_raise_push,
+    )
+
+    assert result.status is pipeline_page_state.PipelineCommandStatus.FAILED
+    assert "push blocked" in result.message
+    assert session_state["demo__last_run_status"] == "failed"
+
+
 def test_pipeline_page_state_refuses_stale_legacy_snippets_before_runtime(tmp_path):
     stale_ref = {"step": 1, "line": 4, "summary": "legacy run", "project": "flight_project"}
 


### PR DESCRIPTION
## Summary
- add a typed start_pipeline_run_command for PIPELINE run startup
- refuse blocked run actions before side effects
- keep Streamlit rendering/progress around the command result

## Validation
- uv --preview-features extra-build-dependencies run pytest -q test/test_pipeline_lab.py test/test_pipeline_page_state.py
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui
- uv --preview-features extra-build-dependencies run python tools/coverage_badge_guard.py --changed-only --require-fresh-xml