### PR TITLE
chore: refresh agi-node coverage badge

### DIFF
--- a/badges/coverage-agi-node.svg
+++ b/badges/coverage-agi-node.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="160" height="20" role="img" aria-label="agi-node coverage: 99%">
+<svg xmlns="http://www.w3.org/2000/svg" width="160" height="20" role="img" aria-label="agi-node coverage: 98%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="64.5" y="15" fill="#010101" fill-opacity=".3">agi-node coverage</text>
   <text x="64.5" y="14">agi-node coverage</text>
-  <text x="144.5" y="15" fill="#010101" fill-opacity=".3">99%</text>
-  <text x="144.5" y="14">99%</text>
+  <text x="144.5" y="15" fill="#010101" fill-opacity=".3">98%</text>
+  <text x="144.5" y="14">98%</text>
 </g>
 </svg>


### PR DESCRIPTION
## Summary
- refresh the agi-node static coverage badge from the latest merged coverage artifacts
- align the committed badge with the GitHub coverage workflow output

## Validation
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_generate_component_coverage_badges.py
- uv --preview-features extra-build-dependencies run python tools/coverage_badge_guard.py --components agi-node --require-fresh-xml
- uv --preview-features extra-build-dependencies run python tools/coverage_badge_guard.py --changed-only --require-fresh-xml
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile badges