### PR TITLE
fix: handle canonical PyPI release versions

### DIFF
--- a/test/test_pypi_publish.py
+++ b/test/test_pypi_publish.py
@@ -275,6 +275,67 @@ def test_compute_unified_version_never_drops_below_latest_release(monkeypatch) -
     }
 
 
+def test_compute_unified_version_handles_pypi_canonicalized_date_posts(monkeypatch) -> None:
+    module = _load_pypi_publish()
+
+    class _FixedDatetime:
+        @staticmethod
+        def now(_tz):
+            return datetime(2026, 4, 28, 10, 0, 0, tzinfo=timezone.utc)
+
+    releases = {
+        "agi-env": {"2026.4.28.post2"},
+        "agi-node": {"2026.4.28.post1"},
+        "agilab": {"2026.4.28.post2"},
+    }
+
+    monkeypatch.setattr(module, "datetime", _FixedDatetime)
+    monkeypatch.setattr(
+        module,
+        "pypi_releases",
+        lambda name, _repo: releases.get(name, set()),
+    )
+
+    chosen, collisions = module.compute_unified_version(
+        ["agi-env", "agi-node", "agilab"],
+        "pypi",
+        None,
+    )
+
+    assert chosen == "2026.04.28.post3"
+    assert collisions == {
+        "agi-env": ["2026.4.28.post2"],
+        "agi-node": ["2026.4.28.post1"],
+        "agilab": ["2026.4.28.post2"],
+    }
+
+
+def test_compute_unified_version_treats_explicit_canonical_collision_as_used(monkeypatch) -> None:
+    module = _load_pypi_publish()
+
+    releases = {
+        "agi-env": {"2026.4.28.post2"},
+        "agilab": {"2026.4.28.post2"},
+    }
+    monkeypatch.setattr(
+        module,
+        "pypi_releases",
+        lambda name, _repo: releases.get(name, set()),
+    )
+
+    chosen, collisions = module.compute_unified_version(
+        ["agi-env", "agilab"],
+        "pypi",
+        "2026.04.28.post2",
+    )
+
+    assert chosen == "2026.04.28.post3"
+    assert collisions == {
+        "agi-env": ["2026.4.28.post2"],
+        "agilab": ["2026.4.28.post2"],
+    }
+
+
 def test_compute_unified_version_rejects_free_explicit_version_below_latest_release(monkeypatch) -> None:
     module = _load_pypi_publish()
 

--- a/tools/pypi_publish.py
+++ b/tools/pypi_publish.py
@@ -479,6 +479,17 @@ def safe_ver(x: str) -> Version:
         return Version("0")
 
 
+def versions_equivalent(left: str, right: str) -> bool:
+    try:
+        return Version(left) == Version(right)
+    except InvalidVersion:
+        return left == right
+
+
+def release_exists(candidate: str, releases: set[str]) -> bool:
+    return any(versions_equivalent(candidate, release) for release in releases)
+
+
 def max_base_across_packages(package_names: List[str], repo_target: str) -> str:
     all_versions = set()
     for n in package_names:
@@ -508,18 +519,18 @@ def next_free_post_for_all(package_names: List[str], repo_target: str, base: str
     k_start = 1
     for releases in per_pkg.values():
         max_post = 0
-        if base in releases:
+        release_parts = [split_base_and_post(release) for release in releases]
+        if any(post is None and versions_equivalent(release_base, base) for release_base, post in release_parts):
             max_post = 0
-        for v in releases:
-            b, post = split_base_and_post(v)
-            if b == base and post is not None and post > max_post:
+        for release_base, post in release_parts:
+            if versions_equivalent(release_base, base) and post is not None and post > max_post:
                 max_post = post
         k_start = max(k_start, max_post + 1)
 
     k = k_start
     while True:
         cand = f"{base}.post{k}"
-        if all(cand not in per_pkg[n] for n in package_names):
+        if all(not release_exists(cand, per_pkg[name]) for name in package_names):
             return cand
         k += 1
 
@@ -531,7 +542,11 @@ def compute_unified_version(core_names: List[str], repo_target: str, base_versio
         provided = base_version
         provided_base = normalize_base(provided)
         existing_by_pkg = {n: pypi_releases(n, repo_target) for n in core_names}
-        provided_in_use = any(provided in rels for rels in existing_by_pkg.values())
+        provided_in_use = any(
+            versions_equivalent(provided, release)
+            for rels in existing_by_pkg.values()
+            for release in rels
+        )
         if not provided_in_use:
             chosen = provided
             base = provided_base
@@ -561,11 +576,11 @@ def compute_unified_version(core_names: List[str], repo_target: str, base_versio
     for n in core_names:
         rels = pypi_releases(n, repo_target)
         hits: List[str] = []
-        if base in rels:
-            hits.append(base)
         for v in rels:
             b, post = split_base_and_post(v)
-            if b == base and v != base and safe_ver(v) < safe_ver(chosen):
+            if not versions_equivalent(b, base):
+                continue
+            if post is None or safe_ver(v) < safe_ver(chosen):
                 hits.append(v)
         collisions[n] = sorted(set(hits), key=safe_ver)
 


### PR DESCRIPTION
## Summary
- compare PyPI release versions with PEP 440 equality instead of raw strings
- preserve the repo's zero-padded date version format while detecting PyPI-canonicalized releases like 2026.4.28.post2
- add regressions for automatic and explicit version collision handling

## Validation
- uv --preview-features extra-build-dependencies run python -m py_compile tools/pypi_publish.py test/test_pypi_publish.py
- uv --preview-features extra-build-dependencies run pytest -q test/test_pypi_publish.py test/test_pypi_publish_workflow.py
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui
- uv --preview-features extra-build-dependencies run python tools/generate_component_coverage_badges.py --components agi-gui agilab
- uv --preview-features extra-build-dependencies run python tools/coverage_badge_guard.py --changed-only --require-fresh-xml
- uv --preview-features extra-build-dependencies run python tools/pypi_publish.py --repo pypi --dry-run --verbose