### PR TITLE
Fix packaged first-proof release

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,5 @@ include README.md
 include LICENSE
 include pyproject.toml
 include MANIFEST.in
+include setup.py
+include tools/package_wheel_sanitizer.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -228,6 +228,7 @@ package-dir = {"" = "src"}
 where = ["src"]
 include = [
     "agilab",
+    "agilab.about_page*",
     "agilab.resources*",
 ]
 exclude = [
@@ -244,6 +245,7 @@ exclude = [
 agilab = [
     "resources/*.*",
     "resources/help/*",
+    "examples/*/AGI_*.py",
     "pages/*.py",
     "apps/install.py",
     "apps/builtin/*/pyproject.toml",

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+from setuptools import setup
+from setuptools.command.build_py import build_py as _build_py
+
+
+def _load_sanitizer():
+    module_path = Path(__file__).resolve().parent / "tools" / "package_wheel_sanitizer.py"
+    spec = importlib.util.spec_from_file_location("agilab_package_wheel_sanitizer", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load package wheel sanitizer from {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class build_py(_build_py):
+    def run(self):
+        super().run()
+        sanitizer = _load_sanitizer()
+        changed = sanitizer.sanitize_packaged_builtin_app_pyprojects(self.build_lib)
+        for pyproject_path in changed:
+            print(f"[build_py] sanitized packaged app manifest: {pyproject_path}")
+
+
+setup(cmdclass={"build_py": build_py})

--- a/src/agilab/apps/install.py
+++ b/src/agilab/apps/install.py
@@ -28,6 +28,21 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+
+def _package_root() -> Path:
+    """Return the installed or source ``agilab`` package directory."""
+
+    return Path(__file__).resolve().parents[1]
+
+
+def _app_dir_candidates(app_slug: str) -> list[Path]:
+    package_root = _package_root()
+    return [
+        package_root / "apps" / "builtin" / f"{app_slug}_project",
+        package_root / "apps" / f"{app_slug}_project",
+    ]
+
+
 def _inject_source_core_paths(script_path: str | os.PathLike[str], sys_path: list[str]) -> None:
     repo_root = Path(script_path).resolve().parents[3]
     core_root = repo_root / "src" / "agilab" / "core"
@@ -68,8 +83,7 @@ def _seed_example_scripts(app_slug: str) -> None:
     if not app_slug:
         return
 
-    repo_root = Path(__file__).resolve().parents[3]
-    examples_dir = repo_root / "src" / "agilab" / "examples" / app_slug
+    examples_dir = _package_root() / "examples" / app_slug
     if not examples_dir.exists():
         return
 
@@ -94,9 +108,8 @@ def _seed_lab_steps(app_slug: str) -> None:
     if not app_slug:
         return
 
-    repo_root = Path(__file__).resolve().parents[3]
-    app_dir = repo_root / "src" / "agilab" / "apps" / f"{app_slug}_project"
-    if not app_dir.exists():
+    app_dir = next((candidate for candidate in _app_dir_candidates(app_slug) if candidate.exists()), None)
+    if app_dir is None:
         return
 
     export_root = Path(os.environ.get("AGI_EXPORT_DIR", Path.home() / "export")).expanduser()
@@ -124,8 +137,10 @@ def _seed_app_settings(app_slug: str) -> None:
     if not app_slug:
         return
 
-    repo_root = Path(__file__).resolve().parents[3]
-    app_dir = repo_root / "src" / "agilab" / "apps" / f"{app_slug}_project" / "src"
+    project_dir = next((candidate for candidate in _app_dir_candidates(app_slug) if candidate.exists()), None)
+    if project_dir is None:
+        return
+    app_dir = project_dir / "src"
     source = app_dir / "app_settings.toml"
     if not source.exists():
         return

--- a/test/test_app_installer_packaging.py
+++ b/test/test_app_installer_packaging.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "src/agilab/apps/install.py"
+
+
+def _load_installer(monkeypatch, tmp_path: Path):
+    sys.modules.pop("agilab_app_install_test_module", None)
+    app_path = tmp_path / "demo_project"
+    app_path.mkdir()
+    monkeypatch.setattr(sys, "argv", ["install.py", str(app_path)])
+    spec = importlib.util.spec_from_file_location("agilab_app_install_test_module", MODULE_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_seed_example_scripts_uses_packaged_examples_dir(tmp_path: Path, monkeypatch) -> None:
+    module = _load_installer(monkeypatch, tmp_path)
+    package_root = tmp_path / "site-packages" / "agilab"
+    examples_dir = package_root / "examples" / "flight"
+    examples_dir.mkdir(parents=True)
+    (examples_dir / "AGI_install_flight.py").write_text("# install\n", encoding="utf-8")
+    (examples_dir / "AGI_run_flight.py").write_text("# run\n", encoding="utf-8")
+    monkeypatch.setattr(module, "_package_root", lambda: package_root)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+
+    module._seed_example_scripts("flight")
+
+    execute_dir = tmp_path / "home" / "log" / "execute" / "flight"
+    assert (execute_dir / "AGI_install_flight.py").read_text(encoding="utf-8") == "# install\n"
+    assert (execute_dir / "AGI_run_flight.py").read_text(encoding="utf-8") == "# run\n"
+
+
+def test_app_dir_candidates_prefer_packaged_builtin_apps(tmp_path: Path, monkeypatch) -> None:
+    module = _load_installer(monkeypatch, tmp_path)
+    package_root = tmp_path / "site-packages" / "agilab"
+    monkeypatch.setattr(module, "_package_root", lambda: package_root)
+
+    assert module._app_dir_candidates("flight") == [
+        package_root / "apps" / "builtin" / "flight_project",
+        package_root / "apps" / "flight_project",
+    ]

--- a/test/test_first_proof_cli.py
+++ b/test/test_first_proof_cli.py
@@ -163,3 +163,14 @@ def test_package_data_includes_app_installer_for_with_install() -> None:
     package_data = pyproject["tool"]["setuptools"]["package-data"]["agilab"]
 
     assert "apps/install.py" in package_data
+    assert "examples/*/AGI_*.py" in package_data
+
+
+def test_package_discovery_includes_about_page_helpers() -> None:
+    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+
+    package_includes = set(pyproject["tool"]["setuptools"]["packages"]["find"]["include"])
+
+    assert "agilab.about_page*" in package_includes
+    for helper in ("bootstrap.py", "env_editor.py", "layout.py", "onboarding.py"):
+        assert (ROOT / "src" / "agilab" / "about_page" / helper).is_file()

--- a/test/test_package_wheel_sanitizer.py
+++ b/test/test_package_wheel_sanitizer.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+MODULE_PATH = Path("tools/package_wheel_sanitizer.py").resolve()
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("package_wheel_sanitizer_test_module", MODULE_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_strip_packaged_core_uv_sources_removes_empty_source_section() -> None:
+    module = _load_module()
+
+    sanitized = module.strip_packaged_core_uv_sources(
+        "\n".join(
+            [
+                "[project]",
+                'name = "flight_project"',
+                'dependencies = ["agi-env", "agi-node"]',
+                "",
+                "[tool.uv.sources]",
+                'agi-env = { path = "../../../core/agi-env", editable = true }',
+                'agi-node = { path = "../../../core/agi-node", editable = true }',
+                "",
+                "[build-system]",
+                'requires = ["setuptools"]',
+                "",
+            ]
+        )
+    )
+
+    assert "[tool.uv.sources]" not in sanitized
+    assert 'dependencies = ["agi-env", "agi-node"]' in sanitized
+    assert "[build-system]" in sanitized
+
+
+def test_strip_packaged_core_uv_sources_preserves_non_core_sources() -> None:
+    module = _load_module()
+
+    sanitized = module.strip_packaged_core_uv_sources(
+        "\n".join(
+            [
+                "[tool.uv.sources]",
+                'agi-env = { path = "../../../core/agi-env", editable = true }',
+                'demo-lib = { path = "../demo-lib", editable = true }',
+                "",
+            ]
+        )
+    )
+
+    assert "agi-env" not in sanitized
+    assert "[tool.uv.sources]" in sanitized
+    assert "demo-lib" in sanitized
+
+
+def test_sanitize_packaged_builtin_app_pyprojects_updates_build_tree(tmp_path: Path) -> None:
+    module = _load_module()
+    pyproject = tmp_path / "agilab/apps/builtin/flight_project/pyproject.toml"
+    pyproject.parent.mkdir(parents=True)
+    pyproject.write_text(
+        "\n".join(
+            [
+                "[project]",
+                'name = "flight_project"',
+                'dependencies = ["agi-env"]',
+                "",
+                "[tool.uv.sources]",
+                'agi-env = { path = "../../../core/agi-env", editable = true }',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    changed = module.sanitize_packaged_builtin_app_pyprojects(tmp_path)
+
+    assert changed == [pyproject]
+    assert "[tool.uv.sources]" not in pyproject.read_text(encoding="utf-8")

--- a/test/test_pypi_publish.py
+++ b/test/test_pypi_publish.py
@@ -127,6 +127,96 @@ def test_pypi_releases_uses_simple_index_when_json_is_stale(monkeypatch) -> None
     assert module.pypi_releases("agilab", "pypi") == {"2026.4.18", "2026.4.19"}
 
 
+def test_sync_builtin_app_versions_pins_internal_runtime_deps(tmp_path, monkeypatch) -> None:
+    module = _load_pypi_publish()
+    monkeypatch.setattr(module, "REPO_ROOT", tmp_path)
+    pyproject = tmp_path / "src/agilab/apps/builtin/flight_project/pyproject.toml"
+    pyproject.parent.mkdir(parents=True)
+    pyproject.write_text(
+        "\n".join(
+            [
+                "[project]",
+                'name = "flight_project"',
+                'version = "2026.04.28.post3"',
+                'dependencies = ["agi-env", "agi-node>=2026.04.28.post3", "streamlit"]',
+                "",
+                "[tool.uv.sources]",
+                'agi-env = { path = "../../../core/agi-env", editable = true }',
+                'agi-node = { path = "../../../core/agi-node", editable = true }',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    updated = module.sync_builtin_app_versions(
+        "2026.04.28.post4",
+        {"agi-env": "2026.04.28.post4", "agi-node": "2026.04.28.post4"},
+    )
+
+    text = pyproject.read_text(encoding="utf-8")
+    assert updated == [pyproject]
+    assert 'version = "2026.04.28.post4"' in text
+    assert '"agi-env==2026.04.28.post4"' in text
+    assert '"agi-node==2026.04.28.post4"' in text
+    assert "[tool.uv.sources]" in text
+
+
+def test_main_syncs_builtin_apps_before_umbrella_build(tmp_path, monkeypatch) -> None:
+    module = _load_pypi_publish()
+
+    umbrella_pyproject = tmp_path / "pyproject.toml"
+    umbrella_pyproject.write_text(
+        "[project]\nname = 'agilab'\nversion = '2026.04.28.post3'\ndependencies = []\n",
+        encoding="utf-8",
+    )
+    cfg = module.Cfg(
+        repo="testpypi",
+        dist="both",
+        skip_existing=True,
+        retries=1,
+        dry_run=False,
+        verbose=False,
+        version="2026.04.28.post4",
+        purge_before=False,
+        purge_after=False,
+        cleanup_only=False,
+        clean_days=None,
+        clean_delete_project=False,
+        cleanup_user=None,
+        cleanup_pass=None,
+        cleanup_timeout=0,
+        skip_cleanup=True,
+        yank_previous=False,
+        git_tag=False,
+        git_commit_version=False,
+        git_reset_on_failure=True,
+        pypirc_check=False,
+        packages=["agilab"],
+        gen_docs=False,
+    )
+    order: list[str] = []
+
+    monkeypatch.setattr(module, "parse_args", lambda: object())
+    monkeypatch.setattr(module, "make_cfg", lambda _args: cfg)
+    monkeypatch.setattr(module, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(module, "CORE", [])
+    monkeypatch.setattr(module, "UMBRELLA", ("agilab", umbrella_pyproject, tmp_path))
+    monkeypatch.setattr(module, "pypi_releases", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(module, "remove_symlinks_for_umbrella", lambda: [])
+    monkeypatch.setattr(module, "restore_symlinks", lambda _entries: None)
+    monkeypatch.setattr(module, "update_selected_badges", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(module, "sync_builtin_app_versions", lambda *_args, **_kwargs: order.append("sync-builtin"))
+    monkeypatch.setattr(module, "uv_build_repo_root", lambda *_args, **_kwargs: order.append("build-root"))
+    monkeypatch.setattr(module, "dist_files_root", lambda: [str(tmp_path / "dist" / "agilab.whl")])
+    monkeypatch.setattr(module, "twine_check", lambda _files: None)
+    monkeypatch.setattr(module, "twine_upload", lambda *_args, **_kwargs: None)
+
+    module.main()
+
+    assert order == ["sync-builtin", "build-root"]
+
+
 def test_require_safe_pypi_release_rejects_missing_repo_sync_flags() -> None:
     module = _load_pypi_publish()
 
@@ -790,7 +880,7 @@ def test_main_updates_badges_before_build(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(module, "pypi_releases", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(module, "remove_symlinks_for_umbrella", lambda: [])
     monkeypatch.setattr(module, "restore_symlinks", lambda _entries: None)
-    monkeypatch.setattr(module, "sync_builtin_app_versions", lambda _version: None)
+    monkeypatch.setattr(module, "sync_builtin_app_versions", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(module, "dist_files", lambda _project_dir: [str(project_dir / "dist" / "fake.whl")])
     monkeypatch.setattr(module, "twine_check", lambda _files: None)
     monkeypatch.setattr(module, "twine_upload", lambda *_args, **_kwargs: None)
@@ -857,13 +947,18 @@ def test_main_runs_release_preflight_before_build(tmp_path, monkeypatch) -> None
     monkeypatch.setattr(module, "pypi_releases", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(module, "remove_symlinks_for_umbrella", lambda: [])
     monkeypatch.setattr(module, "restore_symlinks", lambda _entries: None)
-    monkeypatch.setattr(module, "sync_builtin_app_versions", lambda _version: None)
+    monkeypatch.setattr(module, "sync_builtin_app_versions", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(module, "dist_files", lambda _project_dir: [str(project_dir / "dist" / "fake.whl")])
     monkeypatch.setattr(module, "twine_check", lambda _files: None)
     monkeypatch.setattr(module, "twine_upload", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(module, "update_selected_badges", lambda *_args, **_kwargs: order.append("badge"))
     monkeypatch.setattr(module, "uv_build_project", lambda *_args, **_kwargs: order.append("build"))
     monkeypatch.setattr(module, "run_release_preflight", lambda _cfg: order.append("preflight"))
+    monkeypatch.setattr(
+        module,
+        "run_pre_upload_release_guard",
+        lambda *_args, **_kwargs: order.append("pre-upload-guard"),
+    )
     monkeypatch.setattr(module, "git_commit_version", lambda *_args, **_kwargs: order.append("commit"))
     monkeypatch.setattr(module, "compute_date_tag", lambda: "2026.03.23")
     monkeypatch.setattr(module, "update_public_release_references", lambda *_args, **_kwargs: order.append("release-refs"))
@@ -872,7 +967,7 @@ def test_main_runs_release_preflight_before_build(tmp_path, monkeypatch) -> None
 
     module.main()
 
-    assert order[:3] == ["preflight", "badge", "build"]
+    assert order[:4] == ["preflight", "badge", "build", "pre-upload-guard"]
 
 
 def test_main_dry_run_restores_release_files(tmp_path, monkeypatch) -> None:
@@ -923,7 +1018,7 @@ def test_main_dry_run_restores_release_files(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(module, "pypi_releases", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(module, "remove_symlinks_for_umbrella", lambda: [])
     monkeypatch.setattr(module, "restore_symlinks", lambda _entries: None)
-    monkeypatch.setattr(module, "sync_builtin_app_versions", lambda _version: None)
+    monkeypatch.setattr(module, "sync_builtin_app_versions", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(module, "dist_files", lambda _project_dir: [])
     monkeypatch.setattr(module, "update_selected_badges", lambda *_args, **_kwargs: None)
 
@@ -980,7 +1075,7 @@ def test_main_dry_run_does_not_report_stale_dist_artifacts(tmp_path, monkeypatch
     monkeypatch.setattr(module, "pypi_releases", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(module, "remove_symlinks_for_umbrella", lambda: [])
     monkeypatch.setattr(module, "restore_symlinks", lambda _entries: None)
-    monkeypatch.setattr(module, "sync_builtin_app_versions", lambda _version: None)
+    monkeypatch.setattr(module, "sync_builtin_app_versions", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(
         module,
         "dist_files",
@@ -1060,7 +1155,7 @@ def test_main_refreshes_badges_before_collision_rebuild(tmp_path, monkeypatch) -
     monkeypatch.setattr(module, "pypi_releases", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(module, "remove_symlinks_for_umbrella", lambda: [])
     monkeypatch.setattr(module, "restore_symlinks", lambda _entries: None)
-    monkeypatch.setattr(module, "sync_builtin_app_versions", lambda _version: None)
+    monkeypatch.setattr(module, "sync_builtin_app_versions", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(module, "dist_files", lambda _project_dir: [str(project_dir / "dist" / "fake.whl")])
     monkeypatch.setattr(module, "twine_check", lambda _files: None)
     monkeypatch.setattr(module, "twine_upload", _twine_upload)
@@ -1149,7 +1244,7 @@ def test_main_does_not_reset_release_files_after_success(tmp_path, monkeypatch) 
     monkeypatch.setattr(module, "pypi_releases", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(module, "remove_symlinks_for_umbrella", lambda: [])
     monkeypatch.setattr(module, "restore_symlinks", lambda _entries: None)
-    monkeypatch.setattr(module, "sync_builtin_app_versions", lambda _version: None)
+    monkeypatch.setattr(module, "sync_builtin_app_versions", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(module, "dist_files", lambda _project_dir: [str(project_dir / "dist" / "fake.whl")])
     monkeypatch.setattr(module, "twine_check", lambda _files: None)
     monkeypatch.setattr(module, "twine_upload", lambda *_args, **_kwargs: None)
@@ -1209,13 +1304,18 @@ def test_main_commits_before_tagging(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(module, "pypi_releases", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(module, "remove_symlinks_for_umbrella", lambda: [])
     monkeypatch.setattr(module, "restore_symlinks", lambda _entries: None)
-    monkeypatch.setattr(module, "sync_builtin_app_versions", lambda _version: None)
+    monkeypatch.setattr(module, "sync_builtin_app_versions", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(module, "dist_files", lambda _project_dir: [str(project_dir / "dist" / "fake.whl")])
     monkeypatch.setattr(module, "twine_check", lambda _files: None)
     monkeypatch.setattr(module, "twine_upload", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(module, "update_selected_badges", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(module, "uv_build_project", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(module, "run_release_preflight", lambda _cfg: order.append("preflight"))
+    monkeypatch.setattr(
+        module,
+        "run_pre_upload_release_guard",
+        lambda *_args, **_kwargs: order.append("pre-upload-guard"),
+    )
     monkeypatch.setattr(module, "git_commit_version", lambda *_args, **_kwargs: order.append("commit"))
     monkeypatch.setattr(module, "compute_date_tag", lambda: "2026.03.23")
     monkeypatch.setattr(module, "update_public_release_references", lambda *_args, **_kwargs: order.append("release-refs"))
@@ -1224,7 +1324,7 @@ def test_main_commits_before_tagging(tmp_path, monkeypatch) -> None:
 
     module.main()
 
-    assert order == ["preflight", "release-refs", "commit", "tag", "github-release"]
+    assert order == ["preflight", "pre-upload-guard", "release-refs", "commit", "tag", "github-release"]
 
 
 def test_git_commit_version_pushes_branch_when_requested(monkeypatch) -> None:
@@ -1472,13 +1572,18 @@ def test_main_generates_docs_before_docs_commit_and_tag(tmp_path, monkeypatch) -
     monkeypatch.setattr(module, "pypi_releases", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(module, "remove_symlinks_for_umbrella", lambda: [])
     monkeypatch.setattr(module, "restore_symlinks", lambda _entries: None)
-    monkeypatch.setattr(module, "sync_builtin_app_versions", lambda _version: None)
+    monkeypatch.setattr(module, "sync_builtin_app_versions", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(module, "dist_files", lambda _project_dir: [str(project_dir / "dist" / "fake.whl")])
     monkeypatch.setattr(module, "twine_check", lambda _files: None)
-    monkeypatch.setattr(module, "twine_upload", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(module, "twine_upload", lambda *_args, **_kwargs: order.append("upload"))
     monkeypatch.setattr(module, "update_selected_badges", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(module, "uv_build_project", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(module, "run_release_preflight", lambda _cfg: order.append("preflight"))
+    monkeypatch.setattr(
+        module,
+        "run_pre_upload_release_guard",
+        lambda *_args, **_kwargs: order.append("pre-upload-guard"),
+    )
     monkeypatch.setattr(module, "generate_docs_in_docs_repository", lambda: order.append("gen-docs"))
     monkeypatch.setattr(module, "git_commit_version", lambda *_args, **_kwargs: order.append("commit"))
     monkeypatch.setattr(module, "git_commit_docs_repository", lambda *_args, **_kwargs: order.append("commit-docs"))
@@ -1489,7 +1594,71 @@ def test_main_generates_docs_before_docs_commit_and_tag(tmp_path, monkeypatch) -
 
     module.main()
 
-    assert order == ["preflight", "gen-docs", "release-refs", "commit", "commit-docs", "tag", "github-release"]
+    assert order == [
+        "preflight",
+        "pre-upload-guard",
+        "upload",
+        "gen-docs",
+        "release-refs",
+        "commit",
+        "commit-docs",
+        "tag",
+        "github-release",
+    ]
+
+
+def test_pre_upload_release_guard_runs_before_irreversible_upload(monkeypatch) -> None:
+    module = _load_pypi_publish()
+
+    cfg = module.Cfg(
+        repo="pypi",
+        dist="both",
+        skip_existing=True,
+        retries=1,
+        dry_run=False,
+        verbose=False,
+        version="2026.04.23",
+        purge_before=False,
+        purge_after=False,
+        cleanup_only=False,
+        clean_days=None,
+        clean_delete_project=False,
+        cleanup_user=None,
+        cleanup_pass=None,
+        cleanup_timeout=0,
+        skip_cleanup=True,
+        yank_previous=False,
+        git_tag=True,
+        git_commit_version=True,
+        git_reset_on_failure=True,
+        pypirc_check=False,
+        packages=["agilab"],
+        gen_docs=False,
+    )
+    calls: list[str] = []
+
+    monkeypatch.setattr(module, "update_public_demo_release_test", lambda _tag: calls.append("public-demo-test"))
+    monkeypatch.setattr(module, "run_release_preflight", lambda _cfg: calls.append("preflight"))
+
+    def fake_run(cmd, **_kwargs):
+        command_text = " ".join(str(part) for part in cmd)
+        if "generate_component_coverage_badges.py" in command_text:
+            calls.append("coverage-badges")
+        elif "coverage_badge_guard.py" in command_text:
+            calls.append("coverage-guard")
+        else:
+            calls.append(command_text)
+
+    monkeypatch.setattr(module, "run", fake_run)
+
+    module.run_pre_upload_release_guard(
+        cfg,
+        planned_tag="2026.04.23",
+        chosen_version="2026.04.23.post1",
+        version_targets=["agilab"],
+    )
+
+    assert calls == ["public-demo-test", "preflight", "coverage-badges", "coverage-guard"]
 
 
 def test_main_resets_release_files_only_when_publish_fails(tmp_path, monkeypatch) -> None:
@@ -1539,7 +1708,7 @@ def test_main_resets_release_files_only_when_publish_fails(tmp_path, monkeypatch
     monkeypatch.setattr(module, "pypi_releases", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(module, "remove_symlinks_for_umbrella", lambda: [])
     monkeypatch.setattr(module, "restore_symlinks", lambda _entries: None)
-    monkeypatch.setattr(module, "sync_builtin_app_versions", lambda _version: None)
+    monkeypatch.setattr(module, "sync_builtin_app_versions", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(module, "dist_files", lambda _project_dir: [str(project_dir / "dist" / "fake.whl")])
     monkeypatch.setattr(module, "twine_check", lambda _files: None)
     monkeypatch.setattr(

--- a/tools/package_wheel_sanitizer.py
+++ b/tools/package_wheel_sanitizer.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+PACKAGED_CORE_SOURCE_NAMES = frozenset(
+    {
+        "agi-env",
+        "agi-node",
+        "agi-core",
+        "agi-cluster",
+        "agilab",
+    }
+)
+
+_SECTION_RE = re.compile(r"^\s*\[[^\]]+\]\s*(?:#.*)?$")
+_UV_SOURCES_RE = re.compile(r"^\s*\[tool\.uv\.sources\]\s*(?:#.*)?$")
+_SOURCE_ENTRY_RE = re.compile(r"^\s*([A-Za-z0-9_.-]+)\s*=.*$")
+
+
+def _has_toml_entries(lines: list[str]) -> bool:
+    for line in lines:
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#"):
+            return True
+    return False
+
+
+def strip_packaged_core_uv_sources(text: str) -> str:
+    """Remove source-checkout AGILAB uv sources from packaged app manifests."""
+
+    lines = text.splitlines(keepends=True)
+    output: list[str] = []
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        if not _UV_SOURCES_RE.match(line):
+            output.append(line)
+            index += 1
+            continue
+
+        header = line
+        index += 1
+        block: list[str] = []
+        while index < len(lines) and not _SECTION_RE.match(lines[index]):
+            block.append(lines[index])
+            index += 1
+
+        kept_block: list[str] = []
+        for block_line in block:
+            match = _SOURCE_ENTRY_RE.match(block_line)
+            if match and match.group(1) in PACKAGED_CORE_SOURCE_NAMES:
+                continue
+            kept_block.append(block_line)
+
+        if _has_toml_entries(kept_block):
+            output.append(header)
+            output.extend(kept_block)
+        elif output and output[-1].strip() and index < len(lines) and lines[index].strip():
+            output.append("\n")
+
+    return "".join(output)
+
+
+def sanitize_packaged_builtin_app_pyprojects(build_lib: str | Path) -> list[Path]:
+    """Sanitize built-in app manifests inside setuptools' build/lib tree."""
+
+    builtin_root = Path(build_lib) / "agilab" / "apps" / "builtin"
+    if not builtin_root.exists():
+        return []
+
+    changed: list[Path] = []
+    for pyproject_path in sorted(builtin_root.glob("*_project/pyproject.toml")):
+        original = pyproject_path.read_text(encoding="utf-8")
+        sanitized = strip_packaged_core_uv_sources(original)
+        if sanitized == original:
+            continue
+        pyproject_path.write_text(sanitized, encoding="utf-8")
+        changed.append(pyproject_path)
+    return changed

--- a/tools/pypi_publish.py
+++ b/tools/pypi_publish.py
@@ -269,10 +269,12 @@ def builtin_app_pyprojects() -> List[pathlib.Path]:
     )
 
 
-def sync_builtin_app_versions(new_version: str) -> List[pathlib.Path]:
+def sync_builtin_app_versions(new_version: str, pins: Dict[str, str] | None = None) -> List[pathlib.Path]:
     updated: List[pathlib.Path] = []
     for pyproject_path in builtin_app_pyprojects():
         set_version_in_pyproject(pyproject_path, new_version)
+        if pins:
+            pin_internal_deps(pyproject_path, pins)
         rel = pyproject_path.relative_to(REPO_ROOT)
         print(f"[version] builtin app {rel}: {new_version}")
         updated.append(pyproject_path)
@@ -457,6 +459,45 @@ def run_release_preflight(cfg: Cfg) -> None:
         cmd.extend(["--profile", profile])
     print("[preflight] Running required local release preflight: " + ", ".join(profiles))
     run(cmd, cwd=REPO_ROOT)
+
+
+def run_pre_upload_release_guard(
+    cfg: Cfg,
+    *,
+    planned_tag: str | None,
+    chosen_version: str,
+    version_targets: list[str],
+) -> None:
+    """Prove release metadata is locally pushable before irreversible upload."""
+    if cfg.repo != "pypi" or cfg.dry_run or cfg.cleanup_only:
+        return
+    if planned_tag is not None:
+        update_public_demo_release_test(planned_tag)
+    print(f"[preflight] Running pre-upload release metadata guard for {chosen_version}")
+    run_release_preflight(cfg)
+    run(
+        [
+            sys.executable,
+            "tools/generate_component_coverage_badges.py",
+            "--components",
+            "agi-env",
+            "agi-node",
+            "agi-cluster",
+            "agi-gui",
+            "agi-core",
+            "agilab",
+        ],
+        cwd=REPO_ROOT,
+    )
+    run(
+        [
+            sys.executable,
+            "tools/coverage_badge_guard.py",
+            "--changed-only",
+            "--require-fresh-xml",
+        ],
+        cwd=REPO_ROOT,
+    )
 
 
 def split_base_and_post(ver: str) -> Tuple[str, int | None]:
@@ -1718,6 +1759,7 @@ def main():
         print(f"[plan] Unified version: {chosen}")
         date_tag = normalize_base(chosen)  # date base (YYYY.MM.DD)
         print(f"[plan] Tag base (UTC): {date_tag}")
+        planned_tag = compute_date_tag() if cfg.repo == "pypi" and cfg.git_tag else None
         if cfg.dry_run:
             print("[dry-run] Collisions per package:")
             for n in version_targets:
@@ -1739,6 +1781,9 @@ def main():
         pins = current_versions.copy()
         for name in selected_core_names:
             pins[name] = chosen
+
+        if sync_builtin_versions:
+            sync_builtin_app_versions(chosen, pins)
 
         # Update README badges before building so the packaged long_description
         # and uploaded PyPI page embed the new versioned badge immediately.
@@ -1781,15 +1826,19 @@ def main():
                     print(f"[build] umbrella: {', '.join(root_files)}")
             all_files.extend(root_files)
 
-        if sync_builtin_versions:
-            sync_builtin_app_versions(chosen)
-
         # Dry-run end
         if cfg.dry_run:
             print("[dry-run] Would twine check & upload:")
             for f in all_files:
                 print("  -", f)
             return
+
+        run_pre_upload_release_guard(
+            cfg,
+            planned_tag=planned_tag,
+            chosen_version=chosen,
+            version_targets=version_targets,
+        )
 
         # Twine
         twine_check(all_files)
@@ -1809,13 +1858,19 @@ def main():
                 uv_build_project(project, cfg.dist)
                 all_files2.extend(dist_files(project))
             if build_umbrella:
+                if sync_builtin_versions:
+                    sync_builtin_app_versions(chosen2, pins2)
                 _, umbrella_toml, _ = UMBRELLA
                 set_version_in_pyproject(umbrella_toml, chosen2)
                 pin_internal_deps(umbrella_toml, pins2)
                 uv_build_repo_root(cfg.dist)
                 all_files2.extend(dist_files_root())
-            if sync_builtin_versions:
-                sync_builtin_app_versions(chosen2)
+            run_pre_upload_release_guard(
+                cfg,
+                planned_tag=planned_tag,
+                chosen_version=chosen2,
+                version_targets=version_targets,
+            )
             twine_check(all_files2)
             globals()['UPLOAD_COLLISION_DETECTED'] = False
             globals()['UPLOAD_SUCCESS_COUNT'] = 0
@@ -1843,7 +1898,7 @@ def main():
         # Git tag/commit (optional)
         if cfg.git_commit_version or (cfg.repo == "pypi" and cfg.git_tag):
             with defer_sigint("release metadata finalization") as deferred_interrupt:
-                tag = compute_date_tag() if cfg.repo == "pypi" and cfg.git_tag else None
+                tag = planned_tag if cfg.repo == "pypi" and cfg.git_tag else None
                 if tag is not None:
                     update_public_release_references(tag, chosen, version_targets)
                 if cfg.git_commit_version:


### PR DESCRIPTION
## Summary
- include about_page helpers and first-proof examples in the agilab wheel
- sanitize packaged built-in app manifests so wheel installs do not use source checkout uv paths
- run release metadata and coverage guards before irreversible PyPI upload

## Validation
- targeted installer/release pytest slices
- agi-gui workflow parity
- local wheel first-proof with install passed
- source flight install smoke passed
- coverage badge guard passed