### PR TITLE
Tighten beta readiness gates

### DIFF
--- a/test/test_beta_readiness.py
+++ b/test/test_beta_readiness.py
@@ -21,6 +21,19 @@ def _load_module():
 def _write_package_pyproject(root: Path, rel_path: str, classifier: str) -> None:
     path = root / rel_path
     path.parent.mkdir(parents=True, exist_ok=True)
+    module = _load_module()
+    package_module = module.TYPING_POLICY_PACKAGE_MODULES.get(rel_path)
+    typing_policy = (
+        "\n".join(
+            [
+                "[tool.mypy]",
+                "disallow_untyped_defs = true",
+                "",
+            ]
+        )
+        if package_module is not None
+        else ""
+    )
     path.write_text(
         "\n".join(
             [
@@ -28,6 +41,7 @@ def _write_package_pyproject(root: Path, rel_path: str, classifier: str) -> None
                 'name = "demo"',
                 f'classifiers = ["{classifier}"]',
                 "",
+                typing_policy,
             ]
         ),
         encoding="utf-8",
@@ -40,12 +54,39 @@ def _write_release_package_set(root: Path, classifier: str) -> None:
         _write_package_pyproject(root, rel_path, classifier)
 
 
+def _readme_maturity_text(*, production_status: str = "Experimental") -> str:
+    return "\n".join(
+        [
+            "# AGILAB",
+            "",
+            "### Maturity snapshot",
+            "",
+            "| Capability | Status |",
+            "|---|---|",
+            "| Local run | Stable |",
+            "| Distributed (Dask) | Stable |",
+            "| UI Streamlit | Beta |",
+            "| MLflow | Beta |",
+            f"| Production | {production_status} |",
+            "",
+            "AGILAB is most mature in the bridge between notebook experimentation and",
+            "reproducible AI applications: local execution, environment control, and",
+            "analysis. Distributed execution is mature in the core runtime; remote cluster",
+            "mounts, credentials, and hardware stacks remain environment-dependent.",
+            "Production-grade MLOps features are delivered through integrations and are not",
+            "yet a packaged platform claim.",
+            "",
+        ]
+    )
+
+
 def _write_required_docs(root: Path, text: str = "Beta readiness\n") -> None:
     module = _load_module()
     for rel_path in module.PUBLIC_DOC_FILES:
         path = root / rel_path
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(text, encoding="utf-8")
+        payload = _readme_maturity_text() if rel_path == "README.md" else text
+        path.write_text(payload, encoding="utf-8")
 
 
 def test_package_classifier_planning_mode_accepts_alpha_with_info(tmp_path: Path) -> None:
@@ -125,6 +166,76 @@ def test_public_app_tree_allows_ignored_local_private_entries(tmp_path: Path) ->
     assert check.evidence == []
     assert "not release-blocking" in check.detail
     assert "private_project" in check.detail
+
+
+def test_typing_policy_accepts_root_mypy_and_module_override(tmp_path: Path) -> None:
+    module = _load_module()
+    _write_release_package_set(tmp_path, module.BETA_CLASSIFIER)
+    agi_core = tmp_path / "src/agilab/core/agi-core/pyproject.toml"
+    agi_core.write_text(
+        "\n".join(
+            [
+                "[project]",
+                'name = "agi-core"',
+                f'classifiers = ["{module.BETA_CLASSIFIER}"]',
+                "",
+                "[[tool.mypy.overrides]]",
+                'module = "agi_core.*"',
+                "disallow_untyped_defs = true",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    check = module.check_typing_policy(tmp_path)
+
+    assert check.success is True
+
+
+def test_typing_policy_rejects_missing_public_package_policy(tmp_path: Path) -> None:
+    module = _load_module()
+    _write_release_package_set(tmp_path, module.BETA_CLASSIFIER)
+    (tmp_path / "src/agilab/core/agi-env/pyproject.toml").write_text(
+        "\n".join(
+            [
+                "[project]",
+                'name = "agi-env"',
+                f'classifiers = ["{module.BETA_CLASSIFIER}"]',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    check = module.check_typing_policy(tmp_path)
+
+    assert check.success is False
+    assert "agi-env/pyproject.toml: disallow_untyped_defs not enforced for agi_env" in check.detail
+
+
+def test_public_maturity_positioning_accepts_audited_beta_scope(tmp_path: Path) -> None:
+    module = _load_module()
+    (tmp_path / "README.md").write_text(_readme_maturity_text(), encoding="utf-8")
+
+    check = module.check_public_maturity_positioning(tmp_path)
+
+    assert check.success is True
+    assert check.evidence == []
+    assert "audited beta scope" in check.detail
+
+
+def test_public_maturity_positioning_rejects_production_overclaim(tmp_path: Path) -> None:
+    module = _load_module()
+    (tmp_path / "README.md").write_text(
+        _readme_maturity_text(production_status="Stable"),
+        encoding="utf-8",
+    )
+
+    check = module.check_public_maturity_positioning(tmp_path)
+
+    assert check.success is False
+    assert "Production: expected Experimental, found Stable" in check.detail
 
 
 def test_final_gate_requires_network_and_clean_tree(tmp_path: Path) -> None:

--- a/tools/beta_readiness.py
+++ b/tools/beta_readiness.py
@@ -24,6 +24,13 @@ RELEASE_PACKAGE_PYPROJECTS = (
     "src/agilab/core/agi-cluster/pyproject.toml",
     "src/agilab/lib/agi-gui/pyproject.toml",
 )
+TYPING_POLICY_PACKAGE_MODULES = {
+    "pyproject.toml": "agilab",
+    "src/agilab/core/agi-core/pyproject.toml": "agi_core",
+    "src/agilab/core/agi-env/pyproject.toml": "agi_env",
+    "src/agilab/core/agi-node/pyproject.toml": "agi_node",
+    "src/agilab/core/agi-cluster/pyproject.toml": "agi_cluster",
+}
 RELEASE_PREFLIGHT_PROFILES = (
     "agi-env",
     "agi-core-combined",
@@ -38,6 +45,18 @@ PUBLIC_DOC_FILES = (
     "docs/source/index.rst",
     "docs/source/package-publishing-policy.rst",
     "docs/source/beta-readiness.rst",
+)
+README_MATURITY_STATUSES = {
+    "Local run": "Stable",
+    "Distributed (Dask)": "Stable",
+    "UI Streamlit": "Beta",
+    "MLflow": "Beta",
+    "Production": "Experimental",
+}
+README_MATURITY_SCOPE_MARKERS = (
+    "remote cluster\nmounts, credentials, and hardware stacks remain environment-dependent",
+    "Production-grade MLOps features are delivered through integrations",
+    "not\nyet a packaged platform claim",
 )
 ALLOWED_APP_ENTRIES = {
     ".DS_Store",
@@ -193,6 +212,56 @@ def check_release_preflight_profiles(repo_root: Path = REPO_ROOT) -> GateCheck:
     )
 
 
+def _mypy_policy_disallows_untyped_defs(payload: dict, module_name: str) -> bool:
+    tool = payload.get("tool", {})
+    mypy = tool.get("mypy", {}) if isinstance(tool, dict) else {}
+    if not isinstance(mypy, dict):
+        return False
+    if mypy.get("disallow_untyped_defs") is True:
+        return True
+
+    overrides = mypy.get("overrides", [])
+    if not isinstance(overrides, list):
+        return False
+    accepted_modules = {module_name, f"{module_name}.*"}
+    for override in overrides:
+        if not isinstance(override, dict) or override.get("disallow_untyped_defs") is not True:
+            continue
+        modules = override.get("module")
+        if isinstance(modules, str):
+            module_values = {modules}
+        elif isinstance(modules, list):
+            module_values = {str(item) for item in modules}
+        else:
+            module_values = set()
+        if module_values & accepted_modules:
+            return True
+    return False
+
+
+def check_typing_policy(repo_root: Path = REPO_ROOT) -> GateCheck:
+    missing: list[str] = []
+    for rel_path, module_name in TYPING_POLICY_PACKAGE_MODULES.items():
+        path = repo_root / rel_path
+        if not path.is_file():
+            missing.append(f"{rel_path}: missing pyproject")
+            continue
+        payload = _read_pyproject(path)
+        if not _mypy_policy_disallows_untyped_defs(payload, module_name):
+            missing.append(f"{rel_path}: disallow_untyped_defs not enforced for {module_name}")
+
+    return GateCheck(
+        "typing policy",
+        not missing,
+        (
+            "Release pyprojects enforce disallow_untyped_defs for public package code."
+            if not missing
+            else "Typing policy drift detected: " + "; ".join(missing)
+        ),
+        evidence=missing,
+    )
+
+
 def _top_level_app_entry(rel_path: str) -> str | None:
     parts = PurePosixPath(rel_path).parts
     if len(parts) < 4 or parts[:3] != ("src", "agilab", "apps"):
@@ -317,6 +386,68 @@ def check_docs_have_beta_readiness(repo_root: Path = REPO_ROOT, *, final: bool) 
     )
 
 
+def readme_maturity_statuses(repo_root: Path = REPO_ROOT) -> dict[str, str]:
+    readme_path = repo_root / "README.md"
+    if not readme_path.is_file():
+        return {}
+
+    lines = readme_path.read_text(encoding="utf-8").splitlines()
+    try:
+        start = lines.index("### Maturity snapshot")
+    except ValueError:
+        return {}
+
+    statuses: dict[str, str] = {}
+    for line in lines[start + 1 :]:
+        stripped = line.strip()
+        if not stripped:
+            if statuses:
+                break
+            continue
+        if not stripped.startswith("|"):
+            if statuses:
+                break
+            continue
+        cells = [cell.strip() for cell in stripped.strip("|").split("|")]
+        if len(cells) != 2 or cells[0] in {"Capability", "---"}:
+            continue
+        statuses[cells[0]] = cells[1]
+    return statuses
+
+
+def check_public_maturity_positioning(repo_root: Path = REPO_ROOT) -> GateCheck:
+    readme_path = repo_root / "README.md"
+    if not readme_path.is_file():
+        return GateCheck(
+            "public maturity positioning",
+            False,
+            "README.md is missing, so public maturity claims cannot be checked.",
+            evidence=["README.md"],
+        )
+
+    statuses = readme_maturity_statuses(repo_root)
+    mismatches = [
+        f"{capability}: expected {expected}, found {statuses.get(capability, '<missing>')}"
+        for capability, expected in README_MATURITY_STATUSES.items()
+        if statuses.get(capability) != expected
+    ]
+    readme = readme_path.read_text(encoding="utf-8")
+    missing_scope = [marker for marker in README_MATURITY_SCOPE_MARKERS if marker not in readme]
+    success = not mismatches and not missing_scope
+    detail = (
+        "README maturity snapshot matches the audited beta scope."
+        if success
+        else "README maturity snapshot drifted from audited scope."
+    )
+    evidence = mismatches + [f"missing scope marker: {marker}" for marker in missing_scope]
+    return GateCheck(
+        "public maturity positioning",
+        success,
+        detail if not evidence else f"{detail} " + "; ".join(evidence),
+        evidence=evidence,
+    )
+
+
 def check_git_clean(
     runner: CommandRunner = _run_command,
     *,
@@ -417,8 +548,10 @@ def run_gate(
         check_git_aligned(runner, final=final),
         check_package_classifiers(repo_root, final=final),
         check_release_preflight_profiles(repo_root),
+        check_typing_policy(repo_root),
         check_public_app_tree(repo_root, runner),
         check_docs_have_beta_readiness(repo_root, final=final),
+        check_public_maturity_positioning(repo_root),
     ]
     if include_network:
         checks.append(check_hf_space_public(runner, final=final))


### PR DESCRIPTION
## Summary
- add beta-readiness checks for release package typing policy
- add README maturity-positioning parsing and gate coverage
- extend beta-readiness tests for typing policy and production overclaim detection

## Validation
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files tools/beta_readiness.py test/test_beta_readiness.py`
- `uv --preview-features extra-build-dependencies run pytest -q test/test_beta_readiness.py`
- `uv --preview-features extra-build-dependencies run python -m py_compile tools/beta_readiness.py test/test_beta_readiness.py`
- `uv --preview-features extra-build-dependencies run python tools/coverage_badge_guard.py --changed-only --require-fresh-xml`