### PR TITLE
feat(installer): add shared worker venv cache

### DIFF
--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_local_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_local_support.py
@@ -1,11 +1,14 @@
 import getpass
+import hashlib
 import json
 import logging
 import os
+import platform
 import re
 import shutil
 import stat
 import subprocess
+from shlex import quote
 from importlib.metadata import PackageNotFoundError, distribution as pkg_distribution, version as pkg_version
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -24,6 +27,8 @@ FORCE_REMOVE_EXCEPTIONS = (OSError, shutil.Error)
 DEPENDENCY_PARSE_EXCEPTIONS = (InvalidRequirement,)
 PYPROJECT_PARSE_EXCEPTIONS = (OSError, tomlkit.exceptions.ParseError)
 PYTHON_VERSION_RE = re.compile(r"(\d+)(?:\.(\d+))?(?:\.(\d+))?")
+SHARED_WORKER_VENV_ENV = "AGILAB_SHARED_WORKER_VENV"
+SHARED_WORKER_VENV_DIR_ENV = "AGILAB_SHARED_WORKER_VENV_DIR"
 
 
 def _latest_glob_match(root: Path, pattern: str) -> Path | None:
@@ -170,6 +175,10 @@ def _project_venv_python(project: Path, *, os_name: str = os.name) -> Path:
     return project / ".venv" / "bin" / "python"
 
 
+def _project_venv_root(project: Path) -> Path:
+    return project / ".venv"
+
+
 def _python_version_tuple(value: str | None) -> tuple[int, ...] | None:
     if not value:
         return None
@@ -234,6 +243,106 @@ def _remove_project_venv_if_mismatched(
     return False
 
 
+def _env_value(envars: Any, key: str) -> str | None:
+    raw = os.environ.get(key)
+    if raw is None:
+        try:
+            raw = envars.get(key)
+        except (AttributeError, RuntimeError, TypeError):
+            raw = None
+    if raw is None:
+        return None
+    value = str(raw).strip().strip("\"'").strip()
+    return value or None
+
+
+def _env_truthy(envars: Any, key: str) -> bool:
+    raw = _env_value(envars, key)
+    if raw is None:
+        return False
+    return raw.lower() in {"1", "true", "yes", "on"}
+
+
+def _file_fingerprint(path: Path) -> dict[str, Any]:
+    try:
+        return {
+            "path": path.name,
+            "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+        }
+    except OSError:
+        return {"path": path.name, "missing": True}
+
+
+def _shared_worker_venv_cache_key(
+    *,
+    active_app: Path,
+    wenv_abs: Path,
+    python_version: str,
+    run_type: Any,
+    options_worker: str,
+    worker_core_add_specs: list[str],
+    hw_rapids_capable: bool,
+) -> str:
+    payload = {
+        "schema": "agilab-worker-venv-v1",
+        "os_name": os.name,
+        "platform": platform.system(),
+        "machine": platform.machine(),
+        "python_version": str(python_version),
+        "run_type": str(run_type),
+        "options_worker": options_worker.strip(),
+        "hw_rapids_capable": bool(hw_rapids_capable),
+        "active_app": str(active_app.resolve(strict=False)),
+        "worker_pyproject": _file_fingerprint(wenv_abs / "pyproject.toml"),
+        "worker_uv_config": _file_fingerprint(wenv_abs / "uv_config.toml"),
+        "app_pyproject": _file_fingerprint(active_app / "pyproject.toml"),
+        "app_uv_config": _file_fingerprint(active_app / "uv_config.toml"),
+        "worker_core_add_specs": sorted(str(spec) for spec in worker_core_add_specs),
+    }
+    digest = hashlib.sha256(json.dumps(payload, sort_keys=True).encode("utf-8")).hexdigest()[:16]
+    py_label = re.sub(r"[^A-Za-z0-9_.-]+", "_", str(python_version)).strip("._-") or "python"
+    platform_label = re.sub(
+        r"[^A-Za-z0-9_.-]+",
+        "_",
+        f"{platform.system().lower()}-{platform.machine().lower()}",
+    ).strip("._-")
+    return f"py{py_label}-{platform_label}-{digest}"
+
+
+def _shared_worker_venv_project(
+    envars: Any,
+    *,
+    active_app: Path,
+    wenv_abs: Path,
+    python_version: str,
+    run_type: Any,
+    options_worker: str,
+    worker_core_add_specs: list[str],
+    hw_rapids_capable: bool,
+) -> Path | None:
+    if not _env_truthy(envars, SHARED_WORKER_VENV_ENV):
+        return None
+
+    raw_root = _env_value(envars, SHARED_WORKER_VENV_DIR_ENV)
+    if raw_root:
+        cache_root = Path(raw_root).expanduser()
+        if not cache_root.is_absolute():
+            cache_root = (wenv_abs.parent / cache_root).resolve(strict=False)
+    else:
+        cache_root = wenv_abs.parent / ".runtime-cache"
+
+    cache_key = _shared_worker_venv_cache_key(
+        active_app=active_app,
+        wenv_abs=wenv_abs,
+        python_version=python_version,
+        run_type=run_type,
+        options_worker=options_worker,
+        worker_core_add_specs=worker_core_add_specs,
+        hw_rapids_capable=hw_rapids_capable,
+    )
+    return cache_root / cache_key
+
+
 async def _ensure_project_venv(
     uv_cmd: str,
     project: Path,
@@ -241,12 +350,22 @@ async def _ensure_project_venv(
     run_fn: Callable[..., Any],
     os_name: str = os.name,
     python_version: str | None = None,
+    venv_project: Path | None = None,
 ) -> None:
-    if _project_venv_matches(project, os_name=os_name, python_version=python_version):
+    effective_venv_project = venv_project or project
+    if _project_venv_matches(
+        effective_venv_project,
+        os_name=os_name,
+        python_version=python_version,
+    ):
         return
-    _remove_project_venv_if_mismatched(project, os_name=os_name, python_version=python_version)
+    _remove_project_venv_if_mismatched(
+        effective_venv_project,
+        os_name=os_name,
+        python_version=python_version,
+    )
     python_arg = f" --python {python_version}" if python_version else ""
-    cmd = f'{uv_cmd} venv --allow-existing{python_arg} "{project / ".venv"}"'
+    cmd = f'{uv_cmd} venv --allow-existing{python_arg} "{_project_venv_root(effective_venv_project)}"'
     await run_fn(cmd, project)
 
 
@@ -260,6 +379,7 @@ async def _install_into_project_venv(
     editable: bool = False,
     no_deps: bool = True,
     python_version: str | None = None,
+    venv_project: Path | None = None,
 ) -> None:
     await _ensure_project_venv(
         uv_cmd,
@@ -267,8 +387,9 @@ async def _install_into_project_venv(
         run_fn=run_fn,
         os_name=os_name,
         python_version=python_version,
+        venv_project=venv_project,
     )
-    venv_python = _project_venv_python(project, os_name=os_name)
+    venv_python = _project_venv_python(venv_project or project, os_name=os_name)
     package_spec = str(package_ref)
     editable_flag = "-e " if editable else ""
     no_deps_flag = "--no-deps " if no_deps else ""
@@ -429,7 +550,7 @@ def _shell_env_prefix(env_overrides: dict[str, str], *, os_name: str = os.name) 
         return ""
     if os_name == "nt":
         return "".join(f'set "{key}={value}" && ' for key, value in env_overrides.items())
-    return "".join(f"{key}={value} " for key, value in env_overrides.items())
+    return "".join(f"{key}={quote(value)} " for key, value in env_overrides.items())
 
 
 def _uv_offline_flag(envars: Any) -> str:
@@ -857,6 +978,29 @@ async def deploy_local_worker(
             if spec
         ]
 
+    worker_venv_project = _shared_worker_venv_project(
+        getattr(env, "envars", {}),
+        active_app=app_path,
+        wenv_abs=wenv_abs,
+        python_version=pyvers_worker,
+        run_type=run_type,
+        options_worker=options_worker,
+        worker_core_add_specs=worker_core_add_specs,
+        hw_rapids_capable=hw_rapids_capable,
+    )
+    if worker_venv_project is None:
+        worker_venv_project = wenv_abs
+    else:
+        worker_venv_project.mkdir(parents=True, exist_ok=True)
+        _force_remove(wenv_abs / ".venv", env_logger=getattr(env, "logger", None))
+        uv_worker = (
+            cmd_prefix
+            + _shell_env_prefix({"UV_PROJECT_ENVIRONMENT": str(_project_venv_root(worker_venv_project))})
+            + env.uv_worker
+        )
+        if env.verbose > 0:
+            log.info("Using shared worker venv cache at %s", _project_venv_root(worker_venv_project))
+
     if (
         (not env.is_source_env)
         and (not env.is_worker_env)
@@ -872,7 +1016,7 @@ async def deploy_local_worker(
         )
 
     _remove_project_venv_if_mismatched(
-        wenv_abs,
+        worker_venv_project,
         env_logger=getattr(env, "logger", None),
         python_version=pyvers_worker,
     )
@@ -918,7 +1062,7 @@ async def deploy_local_worker(
         await run_fn(cmd_worker, wenv_abs)
 
     write_staged_uv_sources_pth_fn(
-        worker_site_packages_dir_fn(wenv_abs, env.pyvers_worker, windows=(os.name == "nt")),
+        worker_site_packages_dir_fn(worker_venv_project, env.pyvers_worker, windows=(os.name == "nt")),
         wenv_abs / "_uv_sources",
     )
 
@@ -952,6 +1096,7 @@ async def deploy_local_worker(
                     wenv_abs,
                     install_spec,
                     run_fn=run_fn,
+                    venv_project=worker_venv_project,
                 )
 
         python_dirs = env.pyvers_worker.split(".")
@@ -959,7 +1104,9 @@ async def deploy_local_worker(
             python_dir = f"{python_dirs[0]}.{python_dirs[1].removesuffix('t')}t"
         else:
             python_dir = f"{python_dirs[0]}.{python_dirs[1]}"
-        site_packages_worker = wenv_abs / ".venv" / "lib" / f"python{python_dir}" / "site-packages"
+        site_packages_worker = (
+            worker_venv_project / ".venv" / "lib" / f"python{python_dir}" / "site-packages"
+        )
         _cleanup_editable(site_packages_worker)
     else:
         editable_flags = "--no-deps " if env.is_source_env else ""
@@ -980,6 +1127,7 @@ async def deploy_local_worker(
             editable=True,
             no_deps=bool(editable_flags),
             python_version=env.pyvers_worker,
+            venv_project=worker_venv_project,
         )
 
         menv = env.agi_node
@@ -999,6 +1147,7 @@ async def deploy_local_worker(
             editable=True,
             no_deps=bool(editable_flags),
             python_version=env.pyvers_worker,
+            venv_project=worker_venv_project,
         )
 
     editable_flags = "--no-deps " if env.is_source_env else ""
@@ -1010,6 +1159,7 @@ async def deploy_local_worker(
         editable=True,
         no_deps=bool(editable_flags),
         python_version=env.pyvers_worker,
+        venv_project=worker_venv_project,
     )
 
     dest = wenv_abs / "src" / env.target_worker

--- a/src/agilab/core/test/test_agi_distributor_deployment_local_support.py
+++ b/src/agilab/core/test/test_agi_distributor_deployment_local_support.py
@@ -142,9 +142,10 @@ def test_deploy_local_worker_venv_cleanup_is_conditional() -> None:
     source = Path(deployment_local_support.__file__).read_text(encoding="utf-8")
 
     assert '_force_remove(app_path / ".venv"' not in source
-    assert '_force_remove(wenv_abs / ".venv"' not in source
     assert "_remove_project_venv_if_mismatched(\n        app_path," in source
-    assert "_remove_project_venv_if_mismatched(\n        wenv_abs," in source
+    assert "_remove_project_venv_if_mismatched(\n        worker_venv_project," in source
+    assert "if worker_venv_project is None:" in source
+    assert '_force_remove(wenv_abs / ".venv"' in source
 
 
 def test_cleanup_editable_ignores_missing_entries():
@@ -327,6 +328,75 @@ def test_remove_project_venv_if_mismatched_removes_broken_venv(tmp_path):
 
     assert removed is True
     assert not venv_root.exists()
+
+
+def test_shared_worker_venv_project_is_disabled_by_default(monkeypatch, tmp_path):
+    monkeypatch.delenv("AGILAB_SHARED_WORKER_VENV", raising=False)
+    app_path = tmp_path / "app"
+    wenv_abs = tmp_path / "wenv"
+    app_path.mkdir()
+    wenv_abs.mkdir()
+
+    assert (
+        deployment_local_support._shared_worker_venv_project(
+            {},
+            active_app=app_path,
+            wenv_abs=wenv_abs,
+            python_version="3.13",
+            run_type="sync",
+            options_worker="",
+            worker_core_add_specs=[],
+            hw_rapids_capable=False,
+        )
+        is None
+    )
+
+
+def test_shared_worker_venv_project_uses_compatible_cache_key(monkeypatch, tmp_path):
+    monkeypatch.setenv("AGILAB_SHARED_WORKER_VENV", "1")
+    app_path = tmp_path / "app"
+    wenv_abs = tmp_path / "wenv"
+    app_path.mkdir()
+    wenv_abs.mkdir()
+    (app_path / "pyproject.toml").write_text("[project]\nname='app'\n", encoding="utf-8")
+    (wenv_abs / "pyproject.toml").write_text("[project]\nname='worker'\n", encoding="utf-8")
+
+    first = deployment_local_support._shared_worker_venv_project(
+        {},
+        active_app=app_path,
+        wenv_abs=wenv_abs,
+        python_version="3.13",
+        run_type="sync",
+        options_worker=" --extra pandas-worker",
+        worker_core_add_specs=["/core/agi-env", "/core/agi-node"],
+        hw_rapids_capable=False,
+    )
+    second = deployment_local_support._shared_worker_venv_project(
+        {},
+        active_app=app_path,
+        wenv_abs=wenv_abs,
+        python_version="3.13",
+        run_type="sync",
+        options_worker=" --extra pandas-worker",
+        worker_core_add_specs=["/core/agi-node", "/core/agi-env"],
+        hw_rapids_capable=False,
+    )
+    changed = deployment_local_support._shared_worker_venv_project(
+        {},
+        active_app=app_path,
+        wenv_abs=wenv_abs,
+        python_version="3.13",
+        run_type="sync",
+        options_worker=" --extra polars-worker",
+        worker_core_add_specs=["/core/agi-env", "/core/agi-node"],
+        hw_rapids_capable=False,
+    )
+
+    assert first == second
+    assert first is not None
+    assert first.parent == wenv_abs.parent / ".runtime-cache"
+    assert first.name.startswith("py3.13-")
+    assert changed != first
 
 
 @pytest.mark.asyncio
@@ -1119,6 +1189,96 @@ async def test_deploy_local_worker_non_source_flow(tmp_path):
     assert any("AGI_CLUSTER_ENABLED=0" in cmd and "demo.post_install" in cmd for cmd, _ in commands)
     assert any(f'"{app_path}"' in cmd and "demo.post_install" in cmd for cmd, _ in commands)
     assert any("threaded" in cmd for cmd, _ in commands)
+
+
+@pytest.mark.asyncio
+async def test_deploy_local_worker_shared_worker_venv_uses_runtime_cache(tmp_path):
+    app_path = tmp_path / "app"
+    app_path.mkdir(parents=True, exist_ok=True)
+    (app_path / "pyproject.toml").write_text("[project]\nname='demo-app'\n", encoding="utf-8")
+
+    agi_env_root = tmp_path / "agi_env"
+    (agi_env_root / "src" / "agi_env" / "resources").mkdir(parents=True, exist_ok=True)
+    (agi_env_root / "src" / "agi_env" / "resources" / "sample.txt").write_text("x", encoding="utf-8")
+    agi_node_root = tmp_path / "agi_node"
+    agi_node_root.mkdir(parents=True, exist_ok=True)
+
+    cluster_pck = tmp_path / "cluster_pck"
+    (cluster_pck / "agi_distributor").mkdir(parents=True, exist_ok=True)
+    (cluster_pck / "agi_distributor" / "cli.py").write_text("print('cli')", encoding="utf-8")
+
+    wenv_abs = tmp_path / "worker_env"
+    wenv_abs.mkdir(parents=True, exist_ok=True)
+    (wenv_abs / "pyproject.toml").write_text("[project]\nname='worker-app'\n", encoding="utf-8")
+    (wenv_abs / ".venv").mkdir()
+
+    env = SimpleNamespace(
+        is_source_env=False,
+        is_worker_env=False,
+        install_type=1,
+        agi_env=agi_env_root,
+        agi_node=agi_node_root,
+        active_app=app_path,
+        wenv_abs=wenv_abs,
+        wenv_rel=Path("worker_env"),
+        uv="uv",
+        uv_worker="uv",
+        python_version="3.13",
+        pyvers_worker="3.13",
+        envars={"AGILAB_SHARED_WORKER_VENV": "1"},
+        verbose=1,
+        env_pck=agi_env_root / "src" / "agi_env",
+        dataset_archive=tmp_path / "missing.7z",
+        target_worker="demo_worker",
+        post_install_rel="demo.post_install",
+        user=getpass.getuser(),
+        cluster_pck=cluster_pck,
+        logger=SimpleNamespace(warn=lambda *_a, **_k: None),
+    )
+    commands = []
+
+    async def _fake_run(cmd, cwd):
+        commands.append((cmd, str(cwd)))
+        return ""
+
+    async def _fake_build():
+        return None
+
+    async def _fake_uninstall():
+        return None
+
+    agi_cls = SimpleNamespace(
+        env=env,
+        _run_type="sync",
+        _mode=0,
+        DASK_MODE=4,
+        _rapids_enabled=False,
+        _install_done_local=False,
+        _hardware_supports_rapids=lambda: False,
+        _build_lib_local=_fake_build,
+        _uninstall_modules=_fake_uninstall,
+    )
+
+    await _call_deploy_local_worker(
+        agi_cls,
+        app_path,
+        Path("worker_env"),
+        " --extra pandas-worker",
+        agi_version_missing_on_pypi_fn=lambda _p: False,
+        run_fn=_fake_run,
+        set_env_var_fn=lambda *_a, **_k: None,
+        log=mock.Mock(),
+    )
+
+    cache_root = wenv_abs.parent / ".runtime-cache"
+    worker_commands = [cmd for cmd, cwd in commands if cwd == str(wenv_abs)]
+    manager_commands = [cmd for cmd, cwd in commands if cwd == str(app_path)]
+
+    assert not (wenv_abs / ".venv").exists()
+    assert cache_root.exists()
+    assert any("UV_PROJECT_ENVIRONMENT=" in cmd and str(cache_root) in cmd for cmd in worker_commands)
+    assert any(f'pip install --python "{cache_root}' in cmd for cmd in worker_commands)
+    assert not any("UV_PROJECT_ENVIRONMENT=" in cmd for cmd in manager_commands)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Adds an opt-in shared worker virtual-environment cache for local AGILAB worker installs.

The cache is enabled with `AGILAB_SHARED_WORKER_VENV=1`, with an optional `AGILAB_SHARED_WORKER_VENV_DIR` override. Default behavior is unchanged.

## Why

Repeated app installs can create many app-local worker `.venv` directories with equivalent runtime dependencies. This change lets compatible worker installs share a runtime cache while keeping app/build artifacts isolated.

## Safety

The cache key includes platform, architecture, Python version, app and worker manifests, worker options, RAPIDS mode, and local core install specs. It does not share environments across machines and does not blindly merge incompatible apps.

## Validation

- `uv --preview-features extra-build-dependencies run python -m py_compile src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_local_support.py`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' src/agilab/core/test/test_agi_distributor_deployment_local_support.py` -> 71 passed
- `uv --preview-features extra-build-dependencies run --no-sync pytest -q -o addopts='' src/agilab/core/test` -> 913 passed, 2 skipped

## Note

`coverage_badge_guard.py --changed-only --require-fresh-xml` is blocked in this local checkout by missing `agi-gui` coverage XML from unrelated dirty UI/docs work, not by this two-file branch diff.
