### PR TITLE
Simplify ANALYSIS sidebar view links

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 184,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "e526cdb43988edce499f96e557e4179d0d884f83bed33d42a5b7f2fc49ea78eb",
+  "source_digest_sha256": "e7504c20e2aa17c7573c6da45d1d84290eb27fd44cf9fa7f70bc59ecaa60b629",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "e526cdb43988edce499f96e557e4179d0d884f83bed33d42a5b7f2fc49ea78eb"
+  "target_digest_sha256": "e7504c20e2aa17c7573c6da45d1d84290eb27fd44cf9fa7f70bc59ecaa60b629"
 }

--- a/docs/source/explore-help.rst
+++ b/docs/source/explore-help.rst
@@ -27,9 +27,6 @@ Sidebar
   reachable, and falls back to the locally generated docs build when available.
 - Project selector that keeps the current application in sync with the rest of
   the suite.
-- ``Analysis view`` lets you open a selected view directly. If no view has been
-  selected yet, it lists every discovered view so you can launch one without
-  first editing the project configuration.
 - The currently selected project determines which views are stored inside its
   workspace ``app_settings.toml`` file under ``~/.agilab/apps/<project>/``
   in the ``[pages]`` section.
@@ -47,14 +44,14 @@ Main Content Area
 
    .. tab-item:: Configure
 
-      Use the multi-select control to choose which pages are shown as quick-access
-      shortcuts for analyzing the selected project. The selection is written to
-      ``~/.agilab/apps/<project>/app_settings.toml`` in the ``[pages]`` section
-      under ``view_module``. Only the names you choose are persisted for the
-      active project; every project keeps its own list. The workspace file is
-      seeded from the app's ``app_settings.toml`` source file (for example
-      ``<project>/app_settings.toml`` or ``<project>/src/app_settings.toml``)
-      the first time the app is loaded.
+      Use **Choose analysis views** to choose which pages are shown as
+      quick-access shortcuts for analyzing the selected project. The selection
+      is written to ``~/.agilab/apps/<project>/app_settings.toml`` in the
+      ``[pages]`` section under ``view_module``. Only the names you choose are
+      persisted for the active project; every project keeps its own list. The
+      workspace file is seeded from the app's ``app_settings.toml`` source file
+      (for example ``<project>/app_settings.toml`` or
+      ``<project>/src/app_settings.toml``) the first time the app is loaded.
 
       You can also create a complete starter bundle directly from this page using
       **Create analysis view**. It creates a minimal pyproject and runnable

--- a/src/agilab/pages/4_ANALYSIS.py
+++ b/src/agilab/pages/4_ANALYSIS.py
@@ -1427,136 +1427,24 @@ def _render_analysis_metric(label: str, value: str, caption: str = "") -> None:
     )
 
 
-def _render_analysis_workspace_overview(
-    env: Any,
-    *,
-    selection_state: Any,
-    available_view_count: int,
-) -> None:
-    artifact_summary = _scan_analysis_artifacts(_active_analysis_data_root(env))
-    artifact_count = int(artifact_summary["count"])
-    default_views = tuple(getattr(selection_state, "default_view_names", ()) or ())
-    default_count = len(default_views)
-    selected_views = tuple(getattr(selection_state, "selected_views", ()) or ())
-    selected_count = len(selected_views)
-    latest_label = _format_analysis_latest(artifact_summary["latest"])
-    latest_value = latest_label if artifact_count else "No output"
-    latest_caption = "latest file timestamp" if artifact_count else "run a project first"
-    views_caption = (
-        f"{default_count} open by default"
-        if default_count
-        else "no default view selected" if selected_count else "choose views below"
-    )
-
-    with st.container(border=True):
-        cols = st.columns(3)
-        with cols[0]:
-            suffix = "+" if artifact_summary["truncated"] else ""
-            _render_analysis_metric("Output files", f"{artifact_count}{suffix}", latest_label)
-        with cols[1]:
-            _render_analysis_metric("Latest output", latest_value, latest_caption)
-        with cols[2]:
-            _render_analysis_metric("Views selected", f"{selected_count}/{available_view_count}", views_caption)
-
-        if not artifact_summary["exists"]:
-            st.info("Run ORCHESTRATE or PIPELINE to create analysis outputs.")
-        elif not artifact_summary["examples"]:
-            st.info("No output files detected yet.")
-
-
-def _analysis_default_checkbox_key(project: str | None, view_path: Path) -> str:
-    return f"analysis_default_view__{project or 'default'}__{_short_page_token(view_path)}"
-
-
-def _sync_analysis_default_checkbox_state(
-    *,
-    project: str | None,
+def _analysis_config_view_module(
     selected_views: list[str],
     resolved_pages: dict[str, Path],
-    custom_view_lookup: dict[str, Path],
-    selection_state: Any,
-) -> None:
-    current_defaults = tuple(getattr(selection_state, "default_view_names", ()) or ())
-    view_tokens: list[str] = []
-    resolved_selected: list[tuple[str, Path]] = []
-    for view_name in selected_views:
-        view_path = _resolve_view_path(view_name, resolved_pages, custom_view_lookup)
-        if view_path is None:
-            continue
-        view_tokens.append(f"{view_name}:{_short_page_token(view_path)}")
-        resolved_selected.append((view_name, view_path))
-
-    sync_payload = "|".join([*current_defaults, "--", *view_tokens])
-    sync_token = hashlib.sha1(sync_payload.encode("utf-8")).hexdigest()[:12]
-    sync_key = f"analysis_default_view_sync__{project or 'default'}"
-    if st.session_state.get(sync_key) == sync_token:
-        return
-
-    default_set = set(current_defaults)
-    for view_name, view_path in resolved_selected:
-        st.session_state[_analysis_default_checkbox_key(project, view_path)] = view_name in default_set
-    st.session_state[sync_key] = sync_token
-
-
-def _render_analysis_view_cards(
-    *,
-    project: str | None,
-    selected_views: list[str],
-    resolved_pages: dict[str, Path],
-    custom_view_lookup: dict[str, Path],
-    selection_state: Any,
 ) -> list[str]:
-    st.markdown("### Analysis views")
-    if not selected_views:
-        st.info("Select a view in Choose analysis views.")
-        return []
+    payload: list[str] = []
+    for view_name in selected_views:
+        if view_name in resolved_pages:
+            payload.append(view_name)
+        else:
+            payload.append(str(Path(view_name).resolve()))
+    return payload
 
-    builtin_names = set(resolved_pages.keys())
-    cols = st.columns(min(len(selected_views), 3) or 1)
-    checked_default_views: list[str] = []
-    current_defaults = tuple(getattr(selection_state, "default_view_names", ()) or ())
-    _sync_analysis_default_checkbox_state(
-        project=project,
-        selected_views=selected_views,
-        resolved_pages=resolved_pages,
-        custom_view_lookup=custom_view_lookup,
-        selection_state=selection_state,
-    )
-    for index, view_name in enumerate(selected_views):
-        view_path = _resolve_view_path(view_name, resolved_pages, custom_view_lookup)
-        if view_path is None:
-            st.error(f"Page '{view_name}' not found.")
-            continue
-        _, purpose, _ = _analysis_view_profile(view_name)
-        display_label = _view_label(view_name, builtin_names)
-        is_default = view_name in current_defaults
-        with cols[index % len(cols)]:
-            with st.container(border=True):
-                st.markdown(f"#### {display_label}")
-                st.write(purpose)
-                action_cols = st.columns([0.68, 0.32])
-                with action_cols[0]:
-                    if st.button(
-                        "Open",
-                        type="primary" if is_default else "secondary",
-                        width="stretch",
-                        key=f"analysis_open_view__{_short_page_token(view_path)}",
-                    ):
-                        view_str = str(view_path.resolve())
-                        st.session_state["current_page"] = view_str
-                        st.query_params["current_page"] = view_str
-                        st.rerun()
-                with action_cols[1]:
-                    checkbox_key = _analysis_default_checkbox_key(project, view_path)
-                    st.session_state.setdefault(checkbox_key, is_default)
-                    checked = st.checkbox(
-                        "Open by default",
-                        key=checkbox_key,
-                        help=f"Open {display_label} by default in ANALYSIS.",
-                    )
-                if checked:
-                    checked_default_views.append(view_name)
-    return checked_default_views
+
+def _analysis_sidebar_view_url(project: str | None, view_path: Path) -> str:
+    params = {"current_page": str(view_path.resolve())}
+    if project:
+        params["active_app"] = project
+    return f"?{urlencode(params)}"
 
 
 def _render_analysis_sidebar_view_launcher(
@@ -1573,35 +1461,77 @@ def _render_analysis_sidebar_view_launcher(
         return
 
     builtin_names = set(resolved_pages.keys())
-    selector_key = f"analysis_sidebar_view__{project or 'default'}"
-    current_value = st.session_state.get(selector_key)
-    if current_value not in launch_options and selector_key in st.session_state:
-        del st.session_state[selector_key]
-        current_value = None
-    selected_index = launch_options.index(current_value) if current_value in launch_options else 0
-    selected_view = st.sidebar.selectbox(
-        "Analysis view",
-        launch_options,
-        index=selected_index,
-        key=selector_key,
-        format_func=lambda option: _view_label(option, builtin_names),
-        help="Open a selected analysis view. If no view is selected yet, all discovered views are available.",
-    )
-    view_path = _resolve_view_path(selected_view, resolved_pages, custom_view_lookup)
-    if st.sidebar.button(
-        "Open",
-        type="primary",
-        width="stretch",
-        key=f"analysis_sidebar_open_view__{project or 'default'}",
-        disabled=view_path is None,
-    ):
+    linked_views = set(selected_views)
+    st.sidebar.markdown("### Analysis views")
+    link_rows: list[str] = []
+    missing_views: list[str] = []
+    for view_name in launch_options:
+        view_path = _resolve_view_path(view_name, resolved_pages, custom_view_lookup)
+        display_label = _view_label(view_name, builtin_names)
         if view_path is None:
-            st.sidebar.error(f"Page '{selected_view}' not found.")
-            return
-        view_str = str(view_path.resolve())
-        st.session_state["current_page"] = view_str
-        st.query_params["current_page"] = view_str
-        st.rerun()
+            missing_views.append(display_label)
+            continue
+        link_href = html.escape(_analysis_sidebar_view_url(project, view_path), quote=True)
+        link_label = html.escape(display_label)
+        link_weight = "650" if view_name in linked_views else "450"
+        link_rows.append(
+            "<div class='agilab-analysis-view-link'>"
+            f"<a href='{link_href}' style='font-weight:{link_weight};'>{link_label}</a>"
+            "</div>"
+        )
+
+    if link_rows:
+        st.sidebar.markdown(
+            (
+                "<style>"
+                ".agilab-analysis-view-links{display:flex;flex-direction:column;gap:.12rem;margin:.1rem 0 .45rem 0;}"
+                ".agilab-analysis-view-link a{font-size:.88rem;line-height:1.18;text-decoration:none;}"
+                ".agilab-analysis-view-link a:hover{text-decoration:underline;}"
+                "</style>"
+                "<div class='agilab-analysis-view-links'>"
+                + "".join(link_rows)
+                + "</div>"
+            ),
+            unsafe_allow_html=True,
+        )
+    for display_label in missing_views:
+        st.sidebar.caption(f"Missing: {display_label}")
+
+
+def _render_analysis_workspace_overview(
+    env: Any,
+    *,
+    selection_state: Any,
+    available_view_count: int,
+) -> None:
+    artifact_summary = _scan_analysis_artifacts(_active_analysis_data_root(env))
+    artifact_count = int(artifact_summary["count"])
+    project_label = str(getattr(env, "app", "") or getattr(env, "target", "") or "project")
+    selected_views = tuple(getattr(selection_state, "selected_views", ()) or ())
+    selected_count = len(selected_views)
+    latest_label = _format_analysis_latest(artifact_summary["latest"])
+    latest_value = latest_label if artifact_count else "No output"
+    latest_caption = "latest file timestamp" if artifact_count else "run a project first"
+    views_caption = (
+        f"{selected_count} linked to {project_label}"
+        if selected_count
+        else "choose views below"
+    )
+
+    with st.container(border=True):
+        cols = st.columns(3)
+        with cols[0]:
+            suffix = "+" if artifact_summary["truncated"] else ""
+            _render_analysis_metric("Output files", f"{artifact_count}{suffix}", latest_label)
+        with cols[1]:
+            _render_analysis_metric("Latest output", latest_value, latest_caption)
+        with cols[2]:
+            _render_analysis_metric("Views selected", f"{selected_count}/{available_view_count}", views_caption)
+
+        if not artifact_summary["exists"]:
+            st.info("Run ORCHESTRATE or PIPELINE to create analysis outputs.")
+        elif not artifact_summary["examples"]:
+            st.info("No output files detected yet.")
 
 
 def _render_custom_analysis_page_authoring(
@@ -1879,7 +1809,7 @@ async def main():
     )
 
     with st.expander("Choose analysis views", expanded=False):
-        st.caption("Select which views appear as quick-access cards for this project.")
+        st.caption("Select which views appear in the sidebar launcher for this project.")
         selected_views = st.multiselect(
             "Analysis views",
             view_names,
@@ -1923,32 +1853,23 @@ async def main():
 
     persisted_pages = cfg.setdefault("pages", {})
     config_changed = False
-    normalized_config = list(selection_state.config_view_module)
+
+    normalized_config = _analysis_config_view_module(selected_views, resolved_pages)
     if persisted_pages.get("view_module") != normalized_config:
         persisted_pages["view_module"] = normalized_config
         config_changed = True
 
-    requested_defaults = _render_analysis_view_cards(
-        project=project,
-        selected_views=selected_views,
-        resolved_pages=resolved_pages,
-        custom_view_lookup=custom_view_lookup,
-        selection_state=selection_state,
-    )
-    current_defaults = [
+    retained_defaults = [
         view_name
         for view_name in tuple(getattr(selection_state, "default_view_names", ()) or ())
         if view_name in selected_views
     ]
-    default_changed = False
-    if requested_defaults != current_defaults:
-        default_changed = True
-    if requested_defaults:
-        if persisted_pages.get("default_views") != requested_defaults:
-            persisted_pages["default_views"] = requested_defaults
+    if retained_defaults:
+        if persisted_pages.get("default_views") != retained_defaults:
+            persisted_pages["default_views"] = retained_defaults
             config_changed = True
-        if persisted_pages.get("default_view") != requested_defaults[0]:
-            persisted_pages["default_view"] = requested_defaults[0]
+        if persisted_pages.get("default_view") != retained_defaults[0]:
+            persisted_pages["default_view"] = retained_defaults[0]
             config_changed = True
     else:
         if "default_views" in persisted_pages:
@@ -1959,8 +1880,6 @@ async def main():
             config_changed = True
     if config_changed:
         _write_config(app_settings, cfg)
-    if default_changed:
-        st.rerun()
 
     _render_custom_analysis_page_authoring(
         project=project,

--- a/test/test_analysis_page_helpers.py
+++ b/test/test_analysis_page_helpers.py
@@ -272,6 +272,18 @@ def test_configured_view_options_restricts_to_declared_available_views(tmp_path:
     assert options == ["view_maps", "view_maps_network"]
 
 
+def test_analysis_sidebar_view_url_encodes_project_and_path(tmp_path: Path):
+    module = _load_analysis_module()
+    view_path = tmp_path / "view maps.py"
+
+    url = module._analysis_sidebar_view_url("flight_project", view_path)
+
+    assert url.startswith("?")
+    assert "active_app=flight_project" in url
+    assert "current_page=" in url
+    assert "view+maps.py" in url or "view%20maps.py" in url
+
+
 def test_excluded_view_options_normalizes_configured_names():
     module = _load_analysis_module()
     cfg = {"pages": {"excluded_views": [" view_maps_network ", "", 42]}}

--- a/test/test_ui_pages.py
+++ b/test/test_ui_pages.py
@@ -844,9 +844,13 @@ def test_explore_page_multiselect(mock_ui_env):
     sidebar_markdown = "\n".join(str(item.value) for item in at.sidebar.markdown)
     assert "### Active project" not in sidebar_markdown
     assert all(text_input.key != "project_filter" for text_input in at.sidebar.text_input)
-    sidebar_view = at.sidebar.selectbox(key="analysis_sidebar_view__flight_project")
-    assert sidebar_view.label == "Analysis view"
-    assert "view_maps" in sidebar_view.options
+    assert "### Analysis views" in sidebar_markdown
+    assert "agilab-analysis-view-links" in sidebar_markdown
+    assert "current_page=" in sidebar_markdown
+    assert "view_maps" in sidebar_markdown
+    sidebar_buttons = [button.label for button in at.sidebar.button]
+    assert "view_maps" not in sidebar_buttons
+    assert all(selectbox.key != "analysis_sidebar_view__flight_project" for selectbox in at.sidebar.selectbox)
     
     # Check that 'dummy_view' is an option in the multiselect
     selection_key = f"view_selection__flight_project"
@@ -858,10 +862,10 @@ def test_explore_page_multiselect(mock_ui_env):
     ms.select("view_maps").run()
     assert not at.exception
     
-    # Ensure that the button was created for it
+    # Launching is handled by the sidebar links, not by duplicate in-page sidecar buttons.
     btns = [b.label for b in at.button]
     assert "Open view_maps" not in btns
-    assert "Open" in btns
+    assert "Open" not in btns
 
 
 def test_explore_page_default_view_does_not_mutate_widget_state_after_render(mock_ui_env):
@@ -906,15 +910,15 @@ def test_explore_page_default_view_does_not_mutate_widget_state_after_render(moc
     assert at.session_state["view_selection__flight_project"] == ["view_default"]
     assert at.query_params.get("current_page") in (None, "", "main")
     markdown_text = "\n".join(str(item.value) for item in at.markdown)
-    assert "Analysis views" in markdown_text
+    assert "Views selected" in markdown_text
     assert "default view rendered" not in markdown_text
-    sidebar_view = at.sidebar.selectbox(key="analysis_sidebar_view__flight_project")
-    assert sidebar_view.label == "Analysis view"
-    assert sidebar_view.value == "view_default"
+    sidebar_markdown = "\n".join(str(item.value) for item in at.sidebar.markdown)
+    assert "view_default" in sidebar_markdown
+    assert "current_page=" in sidebar_markdown
 
 
-def test_explore_page_default_view_setting_persists(mock_ui_env):
-    """ANALYSIS view cards let users set multiple default views."""
+def test_explore_page_link_view_setting_persists(mock_ui_env):
+    """ANALYSIS sidebar view links persist from the project view selection."""
     at = _app_test("src/agilab/pages/4_ANALYSIS.py")
     at.query_params["current_page"] = "main"
     env = AgiEnv(apps_path=mock_ui_env["apps_dir"], app="flight_project", verbose=0)
@@ -927,38 +931,33 @@ def test_explore_page_default_view_setting_persists(mock_ui_env):
     at.multiselect(key=selection_key).select("view_maps").select("view_barycentric").run()
 
     assert not at.exception
-    view_maps_default = next(
-        checkbox
-        for checkbox in at.checkbox
-        if checkbox.label == "Open by default" and "view_maps" in str(checkbox.help)
-    )
-    view_maps_default.set_value(True).run()
-
-    assert not at.exception
-    view_barycentric_default = next(
-        checkbox
-        for checkbox in at.checkbox
-        if checkbox.label == "Open by default" and "view_barycentric" in str(checkbox.help)
-    )
-    view_barycentric_default.set_value(True).run()
-
-    assert not at.exception
     settings_file = env.resolve_user_app_settings_file("flight_project")
     with settings_file.open("rb") as f:
         settings_payload = tomllib.load(f)
     pages_payload = settings_payload["pages"]
-    assert pages_payload["default_views"] == ["view_maps", "view_barycentric"]
+    assert pages_payload["view_module"] == ["view_maps", "view_barycentric"]
+    assert pages_payload["default_views"] == ["view_maps"]
     assert pages_payload["default_view"] == "view_maps"
-    assert "view_maps" in pages_payload["view_module"]
-    assert "view_barycentric" in pages_payload["view_module"]
     markdown_text = "\n".join(str(item.value) for item in at.markdown)
     assert "Views selected" in markdown_text
-    assert "2 open by default" in markdown_text
+    assert "2 linked to flight_project" in markdown_text
     assert "agilab-header-value agilab-header-value--ready'>2/" in markdown_text
     assert "Available views" not in markdown_text
     assert "selected / available" not in markdown_text
-    assert "view_maps" in markdown_text
-    assert "view_barycentric" in markdown_text
+    sidebar_markdown = "\n".join(str(item.value) for item in at.sidebar.markdown)
+    assert "view_maps" in sidebar_markdown
+    assert "view_barycentric" in sidebar_markdown
+    assert "current_page=" in sidebar_markdown
+
+    at.multiselect(key=selection_key).unselect("view_maps").run()
+
+    assert not at.exception
+    with settings_file.open("rb") as f:
+        settings_payload = tomllib.load(f)
+    pages_payload = settings_payload["pages"]
+    assert pages_payload["view_module"] == ["view_barycentric"]
+    assert "default_views" not in pages_payload
+    assert "default_view" not in pages_payload
 
     reloaded = _app_test("src/agilab/pages/4_ANALYSIS.py")
     reloaded.query_params["current_page"] = "main"
@@ -966,21 +965,47 @@ def test_explore_page_default_view_setting_persists(mock_ui_env):
     reloaded.run()
 
     assert not reloaded.exception
-    reloaded_defaults = [
-        checkbox
-        for checkbox in reloaded.checkbox
-        if checkbox.label == "Open by default"
-        and checkbox.value
-        and ("view_maps" in str(checkbox.help) or "view_barycentric" in str(checkbox.help))
-    ]
-    assert {str(checkbox.help).split("Open ", 1)[1].split(" by", 1)[0] for checkbox in reloaded_defaults} == {
-        "view_maps",
-        "view_barycentric",
-    }
+    assert reloaded.session_state["view_selection__flight_project"] == ["view_barycentric"]
     reloaded_markdown = "\n".join(str(item.value) for item in reloaded.markdown)
     assert "Views selected" in reloaded_markdown
-    assert "agilab-header-value agilab-header-value--ready'>2/" in reloaded_markdown
+    assert "1 linked to flight_project" in reloaded_markdown
+    assert "agilab-header-value agilab-header-value--ready'>1/" in reloaded_markdown
     assert "Available views" not in reloaded_markdown
+    reloaded_sidebar_markdown = "\n".join(str(item.value) for item in reloaded.sidebar.markdown)
+    assert "view_barycentric" in reloaded_sidebar_markdown
+    assert "view_maps" not in reloaded_sidebar_markdown
+
+
+def test_explore_page_sidebar_links_initialize_from_view_module(mock_ui_env):
+    """Selected analysis views render in the sidebar even when another view is the default."""
+    at = _app_test("src/agilab/pages/4_ANALYSIS.py")
+    at.query_params["current_page"] = "main"
+    env = AgiEnv(apps_path=mock_ui_env["apps_dir"], app="flight_project", verbose=0)
+    settings_file = env.resolve_user_app_settings_file("flight_project")
+    settings_file.write_text(
+        (
+            "[pages]\n"
+            "view_module = ['view_maps', 'view_maps_3d']\n"
+            "default_view = 'view_maps_3d'\n"
+            "default_views = ['view_maps_3d']\n"
+        ),
+        encoding="utf-8",
+    )
+    at.session_state["env"] = env
+
+    at.run()
+
+    assert not at.exception
+    sidebar_markdown = "\n".join(str(item.value) for item in at.sidebar.markdown)
+    assert "view_maps" in sidebar_markdown
+    assert "view_maps_3d" in sidebar_markdown
+    assert "current_page=" in sidebar_markdown
+    with settings_file.open("rb") as f:
+        settings_payload = tomllib.load(f)
+    pages_payload = settings_payload["pages"]
+    assert pages_payload["view_module"] == ["view_maps", "view_maps_3d"]
+    assert pages_payload["default_views"] == ["view_maps_3d"]
+    assert pages_payload["default_view"] == "view_maps_3d"
 
 
 def test_experiment_page_load(mock_ui_env):
@@ -1177,7 +1202,7 @@ def test_execute_service_snippet_maps_runtime_health_settings():
 
 
 def test_explore_page_multiple_views_selected(mock_ui_env):
-    """Test selecting multiple views and verifying a button is rendered for each."""
+    """Test selecting multiple views renders sidebar launch links."""
     at = _app_test("src/agilab/pages/4_ANALYSIS.py")
     at.query_params["current_page"] = "main"
     env = AgiEnv(apps_path=mock_ui_env["apps_dir"], app="flight_project", verbose=0)
@@ -1195,11 +1220,15 @@ def test_explore_page_multiple_views_selected(mock_ui_env):
     btns = [b.label for b in at.button]
     assert "Open view_maps" not in btns
     assert "Open view_barycentric" not in btns
-    assert btns.count("Open") >= 2
+    assert "Open" not in btns
+    sidebar_markdown = "\n".join(str(item.value) for item in at.sidebar.markdown)
+    assert "view_maps" in sidebar_markdown
+    assert "view_barycentric" in sidebar_markdown
+    assert "current_page=" in sidebar_markdown
 
 
 def test_explore_page_deselect_view(mock_ui_env):
-    """Test selecting then deselecting a view removes its button."""
+    """Selecting then deselecting a view removes it from sidebar launch links."""
     at = _app_test("src/agilab/pages/4_ANALYSIS.py")
     at.query_params["current_page"] = "main"
     env = AgiEnv(apps_path=mock_ui_env["apps_dir"], app="flight_project", verbose=0)
@@ -1224,7 +1253,10 @@ def test_explore_page_deselect_view(mock_ui_env):
     ]
     assert "Open view_maps" not in btns
     assert "Open view_barycentric" not in btns
-    assert len(card_open_buttons) == 1
+    assert not card_open_buttons
+    sidebar_markdown = "\n".join(str(item.value) for item in at.sidebar.markdown)
+    assert "view_maps" not in sidebar_markdown
+    assert "view_barycentric" in sidebar_markdown
 
 
 def test_app_args_form_no_changes(mock_ui_env):


### PR DESCRIPTION
## Summary
- replace the ANALYSIS sidebar selectbox/open-button pair with direct sidebar view links
- persist the selected view list into each project's `pages.view_module` config and retain configured defaults only while they remain selected
- remove the duplicate main-page analysis view card launcher and update tests around sidebar links
- sync the public docs mirror from the canonical `explore-help.rst` wording

## Validation
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files docs/.docs_source_mirror_stamp.json docs/source/explore-help.rst src/agilab/pages/4_ANALYSIS.py test/test_analysis_page_helpers.py test/test_ui_pages.py`
- `uv --preview-features extra-build-dependencies run python -m py_compile src/agilab/pages/4_ANALYSIS.py test/test_analysis_page_helpers.py test/test_ui_pages.py`
- `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp`
- `uv --preview-features extra-build-dependencies run pytest -q test/test_ui_pages.py::test_explore_page_link_view_setting_persists test/test_ui_pages.py::test_explore_page_multiple_views_selected test/test_ui_pages.py::test_agilab_main_page_env_editor`
- `uv --preview-features extra-build-dependencies run pytest -q test/test_ui_pages.py test/test_analysis_page_helpers.py`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-env`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-core-combined`
- `uv --preview-features extra-build-dependencies run python tools/coverage_badge_guard.py --changed-only --require-fresh-xml`