### PR TITLE
[codex] Refine Streamlit page navigation skill guidance

### DIFF
--- a/.claude/skills/agilab-streamlit-pages/SKILL.md
+++ b/.claude/skills/agilab-streamlit-pages/SKILL.md
@@ -85,6 +85,18 @@ Use this skill when editing:
 - When a generic page has no app-specific semantic data, show an honest fallback such
   as execution steps, output files, or discovered dataframes rather than inventing a
   domain-specific metric.
+- Keep one navigation surface per action. If a page already exposes compact sidebar
+  launch links, do not duplicate the same action as in-page sidecar cards, repeated
+  `Open` buttons, or another selector unless the second surface adds a distinct
+  workflow step.
+- For lightweight page routing, prefer compact Markdown/HTML links with encoded
+  query parameters such as `current_page` over a selectbox plus `Open` button when
+  the user only needs to jump to a target. Add a tiny helper to construct and test
+  the encoded URL instead of inlining query-string formatting in the render block.
+- Treat legacy “default view” UI as configuration debt when a project already has a
+  selected view list. Persist the selected list in `pages.view_module`; remove stale
+  `default_view`/`default_views` values only when that behavior is intentionally
+  replaced by the new launcher model.
 - Update focused page tests when changing visible labels, header cards, or sidebar
   structure. Grep old wording before closing the task so stale copy does not survive in
   tests, docs, or screenshots.

--- a/.codex/skills/agilab-streamlit-pages/SKILL.md
+++ b/.codex/skills/agilab-streamlit-pages/SKILL.md
@@ -85,6 +85,18 @@ Use this skill when editing:
 - When a generic page has no app-specific semantic data, show an honest fallback such
   as execution steps, output files, or discovered dataframes rather than inventing a
   domain-specific metric.
+- Keep one navigation surface per action. If a page already exposes compact sidebar
+  launch links, do not duplicate the same action as in-page sidecar cards, repeated
+  `Open` buttons, or another selector unless the second surface adds a distinct
+  workflow step.
+- For lightweight page routing, prefer compact Markdown/HTML links with encoded
+  query parameters such as `current_page` over a selectbox plus `Open` button when
+  the user only needs to jump to a target. Add a tiny helper to construct and test
+  the encoded URL instead of inlining query-string formatting in the render block.
+- Treat legacy “default view” UI as configuration debt when a project already has a
+  selected view list. Persist the selected list in `pages.view_module`; remove stale
+  `default_view`/`default_views` values only when that behavior is intentionally
+  replaced by the new launcher model.
 - Update focused page tests when changing visible labels, header cards, or sidebar
   structure. Grep old wording before closing the task so stale copy does not survive in
   tests, docs, or screenshots.


### PR DESCRIPTION
## Summary

Updates the AGILAB Streamlit page skill guidance to discourage duplicate navigation surfaces and prefer compact query-parameter links for lightweight page routing.

The same guidance is synced into both repo-managed agent skill mirrors:

- `.claude/skills/agilab-streamlit-pages/SKILL.md`
- `.codex/skills/agilab-streamlit-pages/SKILL.md`

## Impact

This is documentation and agent-guidance only. It should make future ANALYSIS and similar page changes more consistent by steering agents away from repeated selectors, sidecar launch cards, and stale default-view UI.

## Validation

- `python3 tools/sync_agent_skills.py --skills agilab-streamlit-pages`
- `python3 tools/codex_skills.py --root .codex/skills validate --strict`
- `python3 tools/codex_skills.py --root .codex/skills generate`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files .claude/skills/agilab-streamlit-pages/SKILL.md .codex/skills/agilab-streamlit-pages/SKILL.md`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile skills`