### PR TITLE
[codex] Refine PIPELINE data source picker

### DIFF
--- a/src/agilab/pages/3_PIPELINE.py
+++ b/src/agilab/pages/3_PIPELINE.py
@@ -10,7 +10,7 @@ import sys
 import sysconfig
 import subprocess
 import time
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
 import pandas as pd
 import re
@@ -488,6 +488,14 @@ def _apply_dataframe_picker_selection(
     return current_df_rel is not None and current_df_rel != picked_df_rel
 
 
+def _clear_dataframe_picker_selection(dataframe_key: str, *, picker_key: str | None = None) -> None:
+    if picker_key:
+        st.session_state.pop(f"{picker_key}:selected_paths", None)
+    st.session_state.pop(dataframe_key, None)
+    st.session_state.pop(f"{dataframe_key}_file", None)
+    st.session_state["df_file"] = None
+
+
 @st.cache_data(show_spinner=False)
 def _read_steps(steps_file: Path, module_key: str, mtime_ns: int) -> List[Dict[str, Any]]:
     """Read steps for a specific module key from a TOML file.
@@ -895,7 +903,7 @@ def sidebar_controls() -> None:
             inline_limit=6,
         )
 
-    df_files = find_files(lab_dir)
+    df_files = _filter_pipeline_dataframe_files(find_files(lab_dir))
     st.session_state.df_files = df_files
 
     if not steps_file.parent.exists():
@@ -906,55 +914,71 @@ def sidebar_controls() -> None:
     index = next((i for i, f in enumerate(df_files_rel) if f.name == DEFAULT_DF), 0)
     df_file_default = st.session_state.get("df_file")
     current_df_selection = st.session_state.get(key_df)
-    if current_df_selection is not None and current_df_selection not in df_files_rel:
+    if current_df_selection is not None and _resolve_dataframe_selection(
+        current_df_selection,
+        df_files_rel=df_files_rel,
+        export_root=Agi_export_abs,
+    ) is None:
         st.session_state.pop(key_df, None)
 
     picker_default: Path | None = None
-    if df_file_default:
+    if df_file_default and _resolve_dataframe_selection(
+        df_file_default,
+        df_files_rel=df_files_rel,
+        export_root=Agi_export_abs,
+    ):
         picker_default = Path(df_file_default)
     elif df_files_rel:
         picker_default = Agi_export_abs / df_files_rel[index]
     picker_key = f"{index_page_str}:dataframe_picker"
-    picked_df = agi_file_picker(
-        "Dataframe",
-        roots={lab_root: lab_dir},
-        key=picker_key,
-        patterns="*",
-        default=picker_default,
-        selection_mode="single",
-        allow_files=True,
-        allow_dirs=False,
-        recursive=True,
-        container=st.sidebar,
-        help="Browse and filter files under the active project workspace export directory.",
-    )
-    if picked_df:
-        try:
-            picked_df_rel = Path(picked_df).resolve(strict=False).relative_to(Agi_export_abs)
-        except ValueError:
-            st.sidebar.warning("Selected dataframe is outside the export directory.")
+
+    if df_files_rel:
+        picked_df = agi_file_picker(
+            "Data source",
+            roots={lab_root: lab_dir},
+            key=picker_key,
+            patterns=_PIPELINE_DATA_SOURCE_PATTERNS,
+            default=picker_default,
+            selection_mode="single",
+            allow_files=True,
+            allow_dirs=False,
+            recursive=True,
+            container=st.sidebar,
+            help="Select a dataframe-like artifact under the active project export directory.",
+        )
+        st.sidebar.caption("Used by generated pipeline steps.")
+        if picked_df:
+            try:
+                picked_df_rel = Path(picked_df).resolve(strict=False).relative_to(Agi_export_abs)
+            except ValueError:
+                st.sidebar.warning("Selected data source is outside the export directory.")
+            else:
+                if _resolve_dataframe_selection(
+                    picked_df_rel,
+                    df_files_rel=df_files_rel,
+                    export_root=Agi_export_abs,
+                ) is None:
+                    _clear_dataframe_picker_selection(key_df, picker_key=picker_key)
+                else:
+                    dataframe_changed = _apply_dataframe_picker_selection(
+                        picked_df_rel,
+                        dataframe_key=key_df,
+                        df_files_rel=df_files_rel,
+                        export_root=Agi_export_abs,
+                    )
+                    if dataframe_changed:
+                        st.session_state.pop(index_page_str, None)
+                        st.session_state.page_broken = True
         else:
-            dataframe_changed = _apply_dataframe_picker_selection(
-                picked_df_rel,
-                dataframe_key=key_df,
-                df_files_rel=df_files_rel,
-                export_root=Agi_export_abs,
-            )
-            if dataframe_changed:
-                st.session_state.pop(index_page_str, None)
-                st.session_state.page_broken = True
+            _clear_dataframe_picker_selection(key_df, picker_key=picker_key)
     else:
-        st.session_state.pop(key_df, None)
-        st.session_state.pop(f"{key_df}_file", None)
-        st.session_state["df_file"] = None
+        _clear_dataframe_picker_selection(key_df, picker_key=picker_key)
     if _resolve_dataframe_selection(
         st.session_state.get(key_df),
         df_files_rel=df_files_rel,
         export_root=Agi_export_abs,
     ) is None:
-        st.session_state.pop(key_df, None)
-        st.session_state.pop(f"{key_df}_file", None)
-        st.session_state["df_file"] = None
+        _clear_dataframe_picker_selection(key_df)
 
     # Persist sidebar selections into query params for reloads
     st.query_params.update(
@@ -1082,6 +1106,9 @@ _PIPELINE_DATAFRAME_SUFFIXES = {
     ".xls",
     ".xlsx",
 }
+_PIPELINE_DATA_SOURCE_PATTERNS = tuple(
+    f"*{suffix}" for suffix in sorted(_PIPELINE_DATAFRAME_SUFFIXES)
+)
 _PIPELINE_OUTPUT_EXCLUDED_NAMES = {
     STEPS_FILE_NAME,
     "notebook_import_pipeline_view.json",
@@ -1099,6 +1126,17 @@ _PIPELINE_OUTPUT_EXCLUDED_DIRS = {
     "build",
     "dist",
 }
+
+
+def _filter_pipeline_dataframe_files(files: Iterable[Path]) -> List[Path]:
+    return sorted(
+        (
+            Path(file)
+            for file in files
+            if Path(file).suffix.lower() in _PIPELINE_DATAFRAME_SUFFIXES
+        ),
+        key=str,
+    )
 
 
 def _pipeline_header_value_state(value: str, caption: str = "") -> str:

--- a/test/test_pipeline_page_helpers.py
+++ b/test/test_pipeline_page_helpers.py
@@ -254,6 +254,44 @@ def test_pipeline_on_df_change_uses_page_local_load_last_step(tmp_path, monkeypa
     assert steps_file.parent.exists()
 
 
+def test_filter_pipeline_dataframe_files_keeps_supported_sorted():
+    module = _load_pipeline_module()
+
+    files = [
+        Path("demo/notes.txt"),
+        Path("demo/b.JSONL"),
+        Path("demo/lab_steps.toml"),
+        Path("demo/a.csv"),
+        Path("demo/c.parquet"),
+    ]
+
+    assert module._filter_pipeline_dataframe_files(files) == [
+        Path("demo/a.csv"),
+        Path("demo/b.JSONL"),
+        Path("demo/c.parquet"),
+    ]
+    assert "*.csv" in module._PIPELINE_DATA_SOURCE_PATTERNS
+    assert "*" not in module._PIPELINE_DATA_SOURCE_PATTERNS
+
+
+def test_clear_dataframe_picker_selection_resets_page_and_picker_state(monkeypatch):
+    module = _load_pipeline_module()
+    session_state = {
+        "demodf": Path("demo/old.csv"),
+        "demodf_file": "/tmp/demo/old.csv",
+        "df_file": "/tmp/demo/old.csv",
+        "demo:dataframe_picker:selected_paths": ["/tmp/demo/old.csv"],
+    }
+    monkeypatch.setattr(module, "st", SimpleNamespace(session_state=session_state))
+
+    module._clear_dataframe_picker_selection("demodf", picker_key="demo:dataframe_picker")
+
+    assert "demodf" not in session_state
+    assert "demodf_file" not in session_state
+    assert "demo:dataframe_picker:selected_paths" not in session_state
+    assert session_state["df_file"] is None
+
+
 def test_dataframe_picker_apply_hydrates_initial_picker_selection(tmp_path, monkeypatch):
     module = _load_pipeline_module()
     session_state = {}


### PR DESCRIPTION
## Summary

Refines the PIPELINE sidebar data picker so it behaves like a data-source selector rather than a broad file browser.

- Renames the sidebar picker from `Dataframe` to `Data source`
- Filters picker candidates to dataframe-like artifacts already recognized by the PIPELINE page
- Hides/clears the picker state when the active project has no dataframe-like export
- Adds a short sidebar caption explaining that the selected source is used by generated pipeline steps
- Adds focused helper coverage for filtering and stale picker-state clearing

## Impact

The existing `st.session_state["df_file"]` contract is preserved, so generated pipeline steps and auto-fix paths still receive the selected data artifact. The sidebar is quieter for projects that have not exported data yet, and users no longer see unrelated files in this picker.

## Validation

- `python3 -m py_compile src/agilab/pages/3_PIPELINE.py test/test_pipeline_page_helpers.py`
- `git diff --check`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files src/agilab/pages/3_PIPELINE.py test/test_pipeline_page_helpers.py`
- `uv --preview-features extra-build-dependencies run pytest -q test/test_ui_pages.py test/test_pipeline_page_helpers.py`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-env --profile agi-node --profile agi-cluster`
- `uv --preview-features extra-build-dependencies run python tools/coverage_badge_guard.py --changed-only --require-fresh-xml`