### PR TITLE
[codex] Simplify multi-app DAG UX

### DIFF
--- a/src/agilab/pipeline_lab.py
+++ b/src/agilab/pipeline_lab.py
@@ -1867,7 +1867,15 @@ def _render_global_runner_state_view(
     failed_col.metric("Failed", int(summary.get("failed_count", 0) or 0))
 
     dag_dot = _global_dag_dot(state)
-    if dag_dot:
+    show_graph = bool(
+        dag_dot
+        and st.checkbox(
+            "Show graph",
+            key=f"{index_page_str}_global_runner_show_graph",
+            help="Render the generated graph when the current screen has enough room.",
+        )
+    )
+    if show_graph:
         st.graphviz_chart(dag_dot, width="stretch")
 
     rows = _state_units_for_display(state)
@@ -2025,15 +2033,10 @@ def _render_global_runner_state_panel(
         if save_notice:
             st.success(str(save_notice))
 
-        st.caption(
-            "Coordinate app stages through artifact contracts. Use project steps below for single-app execution."
-        )
-        st.caption(
-            "Safety boundary: preview dispatch updates runner state only; it does not claim live app execution."
-        )
-        st.markdown("**1. Choose a starting point**")
+        st.caption("Select a workflow, review readiness, and run only controlled templates.")
+        st.markdown("**Choose workflow**")
         dag_source = st.selectbox(
-            "DAG source",
+            "Workflow source",
             source_options,
             key=source_key,
             help=(
@@ -2086,7 +2089,7 @@ def _render_global_runner_state_panel(
             if not app_template_options:
                 st.info("No app DAG template is bundled for this active project yet.")
             selected_dag_text = st.selectbox(
-                "DAG template",
+                "App template",
                 app_template_options or [""],
                 key=app_template_key,
                 format_func=lambda value: _global_dag_label(value, repo_root),
@@ -2094,7 +2097,7 @@ def _render_global_runner_state_panel(
             )
         elif dag_source == GLOBAL_DAG_SOURCE_SAMPLES:
             selected_dag_text = st.selectbox(
-                "DAG sample",
+                "Sample",
                 sample_options or [""],
                 key=library_key,
                 format_func=lambda value: _global_dag_label(value, repo_root),
@@ -2104,7 +2107,7 @@ def _render_global_runner_state_panel(
             if not workspace_options:
                 st.info("No workspace DAG draft has been saved for this project yet.")
             selected_dag_text = st.selectbox(
-                "Workspace DAG",
+                "Saved draft",
                 workspace_options or [""],
                 key=workspace_key,
                 format_func=lambda value: _global_dag_label(value, repo_root),
@@ -2112,7 +2115,7 @@ def _render_global_runner_state_panel(
             )
         else:
             selected_dag_text = st.text_input(
-                "Custom DAG path",
+                "Custom JSON path",
                 key=dag_input_key,
                 help=(
                     "Relative paths resolve from the AGILAB checkout root. Custom DAGs stay preview-only "
@@ -2126,6 +2129,44 @@ def _render_global_runner_state_panel(
             st.warning(load_error)
 
         token = _global_dag_source_token(dag_text)
+        reset_clicked = action_button(
+            st,
+            "Reset preview state",
+            key=f"{index_page_str}_global_runner_reset",
+            kind="reset",
+            help="Rebuild the preview runner state from the selected workflow.",
+        )
+        edit_contract_key = f"{index_page_str}_global_runner_edit_contract_{token}"
+        edit_contract = st.checkbox(
+            "Edit workflow contract",
+            key=edit_contract_key,
+            help="Change stages, artifacts, connections, or save a new contract.",
+        )
+        if not edit_contract:
+            try:
+                state, state_path, dag_path = _load_or_create_global_runner_state(
+                    env,
+                    lab_dir,
+                    dag_path=dag_path,
+                    reset=reset_clicked,
+                )
+                dag_engine = _global_dag_engine(repo_root, lab_dir, dag_path)
+            except Exception as exc:
+                st.error("Multi-app DAG orchestration preview is unavailable.")
+                st.caption("Full diagnostic")
+                st.code(str(exc), language="text")
+                return
+
+            _render_global_runner_state_view(
+                state=state,
+                state_path=state_path,
+                dag_path=dag_path,
+                dag_engine=dag_engine,
+                repo_root=repo_root,
+                index_page_str=index_page_str,
+            )
+            return
+
         metadata_keys = {
             "dag_id": f"{index_page_str}_global_runner_dag_id_{token}",
             "label": f"{index_page_str}_global_runner_label_{token}",
@@ -2135,7 +2176,7 @@ def _render_global_runner_state_panel(
         st.session_state.setdefault(metadata_keys["label"], str(base_payload.get("label", "")))
         st.session_state.setdefault(metadata_keys["description"], str(base_payload.get("description", "")))
 
-        st.markdown("**2. Describe the DAG**")
+        st.markdown("**Describe workflow**")
         metadata_cols = st.columns([1, 1], gap="medium")
         dag_id = metadata_cols[0].text_input(
             "DAG id",
@@ -2194,7 +2235,7 @@ def _render_global_runner_state_panel(
         ):
             st.session_state[table_keys["stages"]] = default_stage_ids
 
-        st.markdown("**3. Define stages**")
+        st.markdown("**Choose stages**")
         selected_stage_ids = st.multiselect(
             "Stages",
             stage_option_ids,
@@ -2209,7 +2250,7 @@ def _render_global_runner_state_panel(
         else:
             st.warning("Select at least two stages to form a valid multi-app DAG.")
 
-        st.markdown("**4. Define artifacts**")
+        st.markdown("**Choose artifacts**")
         artifact_options = _global_dag_artifact_options(selected_stage_ids, tables)
         artifact_option_keys = list(artifact_options)
         default_artifact_keys = _default_artifact_keys(artifact_options, tables)
@@ -2232,7 +2273,7 @@ def _render_global_runner_state_panel(
         else:
             st.warning("Select at least one produced artifact before connecting stages.")
 
-        st.markdown("**5. Connect stages**")
+        st.markdown("**Connect stages**")
         selected_artifact_options = {
             key: artifact_options[key]
             for key in selected_artifact_keys
@@ -2323,13 +2364,6 @@ def _render_global_runner_state_panel(
                     "dag_templates directory so it can execute from this view."
                 ),
             )
-        reset_clicked = action_button(
-            st,
-            "Reset preview state",
-            key=f"{index_page_str}_global_runner_reset",
-            kind="reset",
-            help="Rebuild the preview runner state from the selected DAG contract.",
-        )
         if validate_clicked:
             validation_error = _global_dag_validation_error(editor_text, repo_root)
             if validation_error:

--- a/src/agilab/pipeline_lab.py
+++ b/src/agilab/pipeline_lab.py
@@ -193,7 +193,7 @@ logger = logging.getLogger(__name__)
 GLOBAL_RUNNER_STATE_FILENAME = "runner_state.json"
 GLOBAL_DAG_SAMPLE_RELATIVE_PATH = Path("docs/source/data/multi_app_dag_sample.json")
 GLOBAL_DAG_FLIGHT_SAMPLE_RELATIVE_PATH = Path("docs/source/data/multi_app_dag_flight_sample.json")
-GLOBAL_DAG_EMPTY_STATE = "No global DAG units are available."
+GLOBAL_DAG_EMPTY_STATE = "No workplan stages are available."
 GLOBAL_DAG_DRAFT_DIRNAME = "global_dags"
 GLOBAL_DAG_NODE_COLUMNS = ["id", "app", "purpose"]
 GLOBAL_DAG_ARTIFACT_COLUMNS = ["node", "id", "kind", "path"]
@@ -968,6 +968,122 @@ def _state_units_for_display(state: Dict[str, Any]) -> list[dict[str, str]]:
     return rows
 
 
+def _workplan_artifact_id(row: Any) -> str:
+    if not isinstance(row, dict):
+        return ""
+    return str(row.get("artifact", "") or row.get("id", "") or "").strip()
+
+
+def _global_dag_workplan_state(unit: dict[str, Any]) -> str:
+    status = str(
+        unit.get("dispatch_status", "")
+        or unit.get("status", "")
+        or unit.get("plan_status", "")
+        or ""
+    ).strip()
+    return {
+        "blocked": "waiting",
+        "completed": "done",
+        "failed": "failed",
+        "planned": "planned",
+        "runnable": "ready",
+        "running": "running",
+        "stale": "stale",
+    }.get(status, status or "planned")
+
+
+def _global_dag_workplan_needs(unit: dict[str, Any]) -> str:
+    dependencies = unit.get("artifact_dependencies", [])
+    if not isinstance(dependencies, list):
+        return "none"
+    labels: list[str] = []
+    for dependency in dependencies:
+        if not isinstance(dependency, dict):
+            continue
+        artifact_id = _workplan_artifact_id(dependency)
+        producer = str(dependency.get("from", "") or "").strip()
+        if artifact_id and producer:
+            labels.append(f"{artifact_id} from {producer}")
+        elif artifact_id:
+            labels.append(artifact_id)
+    return ", ".join(labels) if labels else "none"
+
+
+def _global_dag_workplan_produces(unit: dict[str, Any]) -> str:
+    produced = unit.get("produces", [])
+    if not isinstance(produced, list):
+        return "none"
+    labels = [_workplan_artifact_id(artifact) for artifact in produced]
+    labels = [label for label in labels if label]
+    return ", ".join(labels) if labels else "none"
+
+
+def _global_dag_workplan_rows_for_display(state: Dict[str, Any]) -> list[dict[str, str]]:
+    units = state.get("units", [])
+    if not isinstance(units, list):
+        return []
+    rows: list[dict[str, str]] = []
+    for unit in units:
+        if not isinstance(unit, dict):
+            continue
+        rows.append(
+            {
+                "stage": str(unit.get("id", "")),
+                "app": str(unit.get("app", "")),
+                "runs": _global_dag_executor_label(unit),
+                "needs": _global_dag_workplan_needs(unit),
+                "produces": _global_dag_workplan_produces(unit),
+                "state": _global_dag_workplan_state(unit),
+            }
+        )
+    return rows
+
+
+def _render_project_step_snippet_preview(
+    snippet_rows: list[dict[str, str]] | None,
+    *,
+    index_page_str: str,
+) -> None:
+    if not snippet_rows:
+        return
+    show_snippets = st.checkbox(
+        "Show snippet code",
+        key=f"{index_page_str}_global_runner_show_snippets",
+        help="Review the Python code for one project step, like ORCHESTRATE generated snippets.",
+    )
+    if not show_snippets:
+        return
+
+    row_by_unit = {row["unit"]: row for row in snippet_rows}
+    options = list(row_by_unit)
+    selected_key = f"{index_page_str}_global_runner_snippet_step"
+    if st.session_state.get(selected_key) not in row_by_unit:
+        st.session_state[selected_key] = options[0]
+
+    def _format_snippet_option(unit_id: str) -> str:
+        row = row_by_unit.get(str(unit_id))
+        return str(row.get("label", unit_id)) if row else str(unit_id)
+
+    selected_unit = st.selectbox(
+        "Snippet step",
+        options,
+        key=selected_key,
+        format_func=_format_snippet_option,
+        help="Choose the project step whose snippet should be shown.",
+    )
+    row = row_by_unit.get(str(selected_unit), snippet_rows[0])
+    source = str(row.get("source", "") or "").strip()
+    model = str(row.get("model", "") or "").strip()
+    prompt = str(row.get("prompt", "") or "").strip()
+    if source:
+        st.caption(f"Snippet source: `{source}`")
+    if model:
+        st.caption(f"Model: `{model}`")
+    if prompt:
+        st.caption(f"Prompt: {prompt}")
+    st.code(str(row.get("code", "") or "# Empty snippet"), language="python")
+
+
 def _artifact_handoffs_for_display(state: Dict[str, Any]) -> list[dict[str, str]]:
     available = _available_artifact_ids(state)
     units = state.get("units", [])
@@ -1123,7 +1239,7 @@ def _global_dag_readiness_summary(state: Dict[str, Any]) -> dict[str, Any]:
 
 def _render_global_dag_readiness(state: Dict[str, Any]) -> None:
     summary = _global_dag_readiness_summary(state)
-    st.markdown("**DAG readiness**")
+    st.markdown("**Workplan readiness**")
     stage_col, dependency_col, runnable_col, blocked_col = st.columns(4)
     stage_col.metric("Stages", int(summary["stage_count"]))
     dependency_col.metric("Dependencies", int(summary["dependency_count"]))
@@ -1267,6 +1383,29 @@ def _pipeline_steps_digest(pipeline_steps: list[dict[str, Any]]) -> str:
     ]
     payload = json.dumps(normalized, sort_keys=True, ensure_ascii=True)
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _pipeline_step_snippet_rows(pipeline_steps: list[dict[str, Any]] | None) -> list[dict[str, str]]:
+    rows: list[dict[str, str]] = []
+    for index, step in enumerate(_pipeline_dag_step_rows(pipeline_steps)):
+        code = str(step.get("C", "") or "")
+        if not code.strip():
+            continue
+        unit_id = _pipeline_step_unit_id(index)
+        summary = _pipeline_step_purpose(step, index)
+        label = f"{unit_id} - {summary}" if summary else unit_id
+        rows.append(
+            {
+                "unit": unit_id,
+                "label": label,
+                "summary": summary,
+                "prompt": str(step.get("Q", "") or "").strip(),
+                "model": str(step.get("M", "") or "").strip(),
+                "source": _orchestrate_snippet_source(step),
+                "code": code,
+            }
+        )
+    return rows
 
 
 def _path_mtime(path_text: str | Path | None) -> float | None:
@@ -1840,6 +1979,7 @@ def _render_global_runner_state_view(
     repo_root: Path,
     index_page_str: str,
     dag_label_override: str = "",
+    project_step_snippet_rows: list[dict[str, str]] | None = None,
 ) -> None:
     summary = state.get("summary", {})
     if not isinstance(summary, dict):
@@ -1878,14 +2018,27 @@ def _render_global_runner_state_view(
     if show_graph:
         st.graphviz_chart(dag_dot, width="stretch")
 
-    rows = _state_units_for_display(state)
-    if rows:
-        st.dataframe(rows, hide_index=True, width="stretch")
+    workplan_rows = _global_dag_workplan_rows_for_display(state)
+    if workplan_rows:
+        st.caption("Multi-app workplan")
+        st.dataframe(workplan_rows, hide_index=True, width="stretch")
     else:
         st.caption(GLOBAL_DAG_EMPTY_STATE)
+    _render_project_step_snippet_preview(
+        project_step_snippet_rows,
+        index_page_str=index_page_str,
+    )
 
     artifact_rows = _artifact_handoffs_for_display(state)
-    if artifact_rows:
+    show_artifacts = bool(
+        artifact_rows
+        and st.checkbox(
+            "Show artifact details",
+            key=f"{index_page_str}_global_runner_show_artifacts",
+            help="Inspect the raw artifact handoffs used to derive the workplan needs and outputs.",
+        )
+    )
+    if show_artifacts:
         st.caption("Artifact handoffs")
         st.dataframe(artifact_rows, hide_index=True, width="stretch")
 
@@ -2033,10 +2186,10 @@ def _render_global_runner_state_panel(
         if save_notice:
             st.success(str(save_notice))
 
-        st.caption("Select a workflow, review readiness, and run only controlled templates.")
-        st.markdown("**Choose workflow**")
+        st.caption("Select a workplan, review readiness, and run only controlled templates.")
+        st.markdown("**Choose workplan**")
         dag_source = st.selectbox(
-            "Workflow source",
+            "Workplan source",
             source_options,
             key=source_key,
             help=(
@@ -2083,6 +2236,7 @@ def _render_global_runner_state_panel(
                 repo_root=repo_root,
                 index_page_str=index_page_str,
                 dag_label_override="Project steps",
+                project_step_snippet_rows=_pipeline_step_snippet_rows(project_step_rows),
             )
             return
         if dag_source == GLOBAL_DAG_SOURCE_APP_TEMPLATES:
@@ -2134,11 +2288,11 @@ def _render_global_runner_state_panel(
             "Reset preview state",
             key=f"{index_page_str}_global_runner_reset",
             kind="reset",
-            help="Rebuild the preview runner state from the selected workflow.",
+            help="Rebuild the preview runner state from the selected workplan.",
         )
         edit_contract_key = f"{index_page_str}_global_runner_edit_contract_{token}"
         edit_contract = st.checkbox(
-            "Edit workflow contract",
+            "Edit workplan",
             key=edit_contract_key,
             help="Change stages, artifacts, connections, or save a new contract.",
         )
@@ -2176,7 +2330,7 @@ def _render_global_runner_state_panel(
         st.session_state.setdefault(metadata_keys["label"], str(base_payload.get("label", "")))
         st.session_state.setdefault(metadata_keys["description"], str(base_payload.get("description", "")))
 
-        st.markdown("**Describe workflow**")
+        st.markdown("**Describe workplan**")
         metadata_cols = st.columns([1, 1], gap="medium")
         dag_id = metadata_cols[0].text_input(
             "DAG id",
@@ -2235,7 +2389,7 @@ def _render_global_runner_state_panel(
         ):
             st.session_state[table_keys["stages"]] = default_stage_ids
 
-        st.markdown("**Choose stages**")
+        st.markdown("**Build workplan**")
         selected_stage_ids = st.multiselect(
             "Stages",
             stage_option_ids,
@@ -2250,7 +2404,7 @@ def _render_global_runner_state_panel(
         else:
             st.warning("Select at least two stages to form a valid multi-app DAG.")
 
-        st.markdown("**Choose artifacts**")
+        st.markdown("**Choose outputs**")
         artifact_options = _global_dag_artifact_options(selected_stage_ids, tables)
         artifact_option_keys = list(artifact_options)
         default_artifact_keys = _default_artifact_keys(artifact_options, tables)
@@ -2273,7 +2427,7 @@ def _render_global_runner_state_panel(
         else:
             st.warning("Select at least one produced artifact before connecting stages.")
 
-        st.markdown("**Connect stages**")
+        st.markdown("**Link stages**")
         selected_artifact_options = {
             key: artifact_options[key]
             for key in selected_artifact_keys
@@ -2293,7 +2447,7 @@ def _render_global_runner_state_panel(
         ):
             st.session_state[table_keys["edges"]] = default_handoff_keys
         selected_handoff_keys = st.multiselect(
-            "Stage connections",
+            "Artifact handoffs",
             handoff_option_keys,
             key=table_keys["edges"],
             format_func=lambda key: _handoff_option_label(key, handoff_options),

--- a/src/agilab/pipeline_lab.py
+++ b/src/agilab/pipeline_lab.py
@@ -793,6 +793,38 @@ def _selected_handoff_rows(
     return [handoff_options[key] for key in handoff_keys if key in handoff_options]
 
 
+def _workplan_output_rows(artifact_rows: list[dict[str, str]]) -> list[dict[str, str]]:
+    return [
+        {
+            "stage": row.get("node", ""),
+            "produces": row.get("id", ""),
+            "kind": row.get("kind", ""),
+            "path": row.get("path", ""),
+        }
+        for row in artifact_rows
+    ]
+
+
+def _need_option_label(option_key: str, need_options: dict[str, dict[str, str]]) -> str:
+    need = need_options.get(option_key, {})
+    target = need.get("to", "")
+    artifact = need.get("artifact", "")
+    source = need.get("from", "")
+    return f"{target} needs {artifact} from {source}"
+
+
+def _workplan_need_rows(need_rows: list[dict[str, str]]) -> list[dict[str, str]]:
+    return [
+        {
+            "stage": row.get("to", ""),
+            "needs": row.get("artifact", ""),
+            "from": row.get("from", ""),
+            "handoff": row.get("handoff", ""),
+        }
+        for row in need_rows
+    ]
+
+
 def _consumes_rows_from_handoffs(
     handoff_rows: list[dict[str, str]],
     artifact_options: dict[str, dict[str, str]],
@@ -2379,8 +2411,7 @@ def _render_global_runner_state_panel(
         table_keys = {
             "stages": f"{index_page_str}_global_runner_stages_{token}",
             "produces": f"{index_page_str}_global_runner_produces_{token}",
-            "consumes": f"{index_page_str}_global_runner_consumes_{token}",
-            "edges": f"{index_page_str}_global_runner_edges_{token}",
+            "needs": f"{index_page_str}_global_runner_needs_{token}",
         }
         selected_stage_ids = st.session_state.get(table_keys["stages"])
         if (
@@ -2404,7 +2435,7 @@ def _render_global_runner_state_panel(
         else:
             st.warning("Select at least two stages to form a valid multi-app DAG.")
 
-        st.markdown("**Choose outputs**")
+        st.markdown("**Stage outputs**")
         artifact_options = _global_dag_artifact_options(selected_stage_ids, tables)
         artifact_option_keys = list(artifact_options)
         default_artifact_keys = _default_artifact_keys(artifact_options, tables)
@@ -2415,52 +2446,52 @@ def _render_global_runner_state_panel(
         ):
             st.session_state[table_keys["produces"]] = default_artifact_keys
         selected_artifact_keys = st.multiselect(
-            "Produced artifacts",
+            "Produces",
             artifact_option_keys,
             key=table_keys["produces"],
             format_func=lambda key: _artifact_option_label(key, artifact_options),
-            help="Choose artifacts exposed by the selected stages. No node ids need to be typed.",
+            help="Choose outputs exposed by the selected stages. Workplan needs can use these outputs.",
         )
         produces_value = _selected_artifact_rows(selected_artifact_keys, artifact_options)
         if produces_value:
-            st.dataframe(produces_value, hide_index=True, width="stretch")
+            st.dataframe(_workplan_output_rows(produces_value), hide_index=True, width="stretch")
         else:
-            st.warning("Select at least one produced artifact before connecting stages.")
+            st.warning("Select at least one output before adding stage needs.")
 
-        st.markdown("**Link stages**")
+        st.markdown("**Stage needs**")
         selected_artifact_options = {
             key: artifact_options[key]
             for key in selected_artifact_keys
             if key in artifact_options
         }
-        handoff_options = _global_dag_handoff_options(
+        need_options = _global_dag_handoff_options(
             selected_stage_ids,
             selected_artifact_options,
             base_payload,
         )
-        handoff_option_keys = list(handoff_options)
-        default_handoff_keys = _default_handoff_keys(handoff_options, base_payload)
-        selected_handoff_keys = st.session_state.get(table_keys["edges"])
+        need_option_keys = list(need_options)
+        default_need_keys = _default_handoff_keys(need_options, base_payload)
+        selected_need_keys = st.session_state.get(table_keys["needs"])
         if (
-            not isinstance(selected_handoff_keys, list)
-            or any(key not in handoff_options for key in selected_handoff_keys)
+            not isinstance(selected_need_keys, list)
+            or any(key not in need_options for key in selected_need_keys)
         ):
-            st.session_state[table_keys["edges"]] = default_handoff_keys
-        selected_handoff_keys = st.multiselect(
-            "Artifact handoffs",
-            handoff_option_keys,
-            key=table_keys["edges"],
-            format_func=lambda key: _handoff_option_label(key, handoff_options),
-            help="Choose artifact handoffs between selected stages instead of typing from/to ids.",
+            st.session_state[table_keys["needs"]] = default_need_keys
+        selected_need_keys = st.multiselect(
+            "Needs",
+            need_option_keys,
+            key=table_keys["needs"],
+            format_func=lambda key: _need_option_label(key, need_options),
+            help="Choose which stage needs an output from another stage. Artifact handoffs are generated automatically.",
         )
-        edges_value = _selected_handoff_rows(selected_handoff_keys, handoff_options)
+        edges_value = _selected_handoff_rows(selected_need_keys, need_options)
         consumes_value = _consumes_rows_from_handoffs(edges_value, selected_artifact_options)
         if edges_value:
-            st.dataframe(edges_value, hide_index=True, width="stretch")
+            st.dataframe(_workplan_need_rows(edges_value), hide_index=True, width="stretch")
         else:
-            st.warning("Select at least one stage connection to create a runnable cross-app DAG.")
+            st.warning("Select at least one stage need to create a cross-app workplan.")
         if consumes_value:
-            st.caption("Consumed artifacts inferred from selected connections")
+            st.caption("Consumed artifacts are derived from selected needs.")
             st.dataframe(consumes_value, hide_index=True, width="stretch")
 
         visual_payload = _global_dag_payload_from_visual_editor(

--- a/test/test_pipeline_lab.py
+++ b/test/test_pipeline_lab.py
@@ -774,7 +774,7 @@ def test_global_runner_panel_uses_flight_two_app_dag_and_persists_state(monkeypa
     edit_token = pipeline_lab._global_dag_source_token(
         "src/agilab/apps/builtin/flight_project/dag_templates/flight_to_meteo.json"
     )
-    assert ("Edit workflow contract", f"demo_global_runner_edit_contract_{edit_token}") in fake_st.checkbox_calls
+    assert ("Edit workplan", f"demo_global_runner_edit_contract_{edit_token}") in fake_st.checkbox_calls
     assert not fake_st.multiselect_calls
 
 
@@ -909,13 +909,42 @@ def test_global_runner_panel_renders_project_steps_as_preview_dag(monkeypatch, t
     assert all(call[0] != "demo_global_runner_run_next_stage" for call in fake_st.button_calls)
     assert any(call[0] == "demo_global_runner_dispatch_next" for call in fake_st.button_calls)
     assert ("Show graph", "demo_global_runner_show_graph") in fake_st.checkbox_calls
+    assert ("Show snippet code", "demo_global_runner_show_snippets") in fake_st.checkbox_calls
     assert not fake_st.graphviz_sources
-    unit_tables = [
+    assert not any(kind == "code" and "print('load')" in message for kind, message in fake_st.messages)
+    workplan_tables = [
         table
         for table in fake_st.dataframes
-        if isinstance(table, list) and table and isinstance(table[0], dict) and "unit" in table[0]
+        if isinstance(table, list) and table and isinstance(table[0], dict) and "stage" in table[0]
     ]
-    assert any(row["unit"] == "step_001" and row["executor"] == "runpy" for table in unit_tables for row in table)
+    assert any(row["stage"] == "step_001" and row["runs"] == "runpy" for table in workplan_tables for row in table)
+
+
+def test_global_runner_panel_shows_selected_project_step_snippet_code(monkeypatch, tmp_path):
+    steps = [
+        {"D": "Load data", "Q": "Load input dataframe", "M": "gpt-a", "C": "print('load')", "E": "", "R": ""},
+        {"D": "Train model", "Q": "Train model", "M": "gpt-b", "C": "print('train')", "E": "", "R": ""},
+    ]
+    fake_st = _FakeStreamlit(
+        checkboxes={"demo_global_runner_show_snippets": True},
+        selectboxes={"demo_global_runner_snippet_step": "step_002"},
+    )
+    monkeypatch.setattr(pipeline_lab, "st", fake_st)
+    env = SimpleNamespace(app="demo_project", target="demo_project")
+
+    pipeline_lab._render_global_runner_state_panel(
+        env,
+        tmp_path,
+        "demo",
+        pipeline_steps=steps,
+        steps_file=tmp_path / "lab_steps.toml",
+    )
+
+    assert ("Show snippet code", "demo_global_runner_show_snippets") in fake_st.checkbox_calls
+    assert fake_st.session_state["demo_global_runner_snippet_step"] == "step_002"
+    assert any(kind == "caption" and message == "Prompt: Train model" for kind, message in fake_st.messages)
+    assert any(kind == "code" and "print('train')" in message for kind, message in fake_st.messages)
+    assert not any(kind == "code" and "print('load')" in message for kind, message in fake_st.messages)
 
 
 def test_global_runner_panel_project_steps_dispatch_is_preview_only(monkeypatch, tmp_path):
@@ -1445,7 +1474,7 @@ def test_global_runner_panel_saves_visual_editor_as_workspace_draft(monkeypatch,
         for label, _options, key in fake_st.multiselect_calls
     )
     assert any(
-        label == "Stage connections" and key == f"demo_global_runner_edges_{token}"
+        label == "Artifact handoffs" and key == f"demo_global_runner_edges_{token}"
         for label, _options, key in fake_st.multiselect_calls
     )
     assert not fake_st.data_editor_calls
@@ -1653,12 +1682,17 @@ def test_global_runner_panel_saves_reloads_and_runs_executable_app_template(monk
     assert alpha["contract_execution"]["summary_metrics"]["stage_completed"] == 1
     assert alpha["execution_contract"] == {"entrypoint": "alpha_project.alpha"}
     assert beta["execution_contract"] == {"entrypoint": "beta_project.beta"}
-    unit_tables = [
+    workplan_tables = [
         table
         for table in fake_st.dataframes
-        if isinstance(table, list) and table and isinstance(table[0], dict) and "executor" in table[0]
+        if isinstance(table, list) and table and isinstance(table[0], dict) and "runs" in table[0]
     ]
-    assert any(row["executor"] == "alpha_project.alpha" for table in unit_tables for row in table)
+    assert any(row["stage"] == "alpha" and row["runs"] == "alpha_project.alpha" for table in workplan_tables for row in table)
+    assert any(
+        row["stage"] == "beta" and row["needs"] == "alpha_metrics from alpha"
+        for table in workplan_tables
+        for row in table
+    )
     assert any("exec: alpha_project.alpha" in source for source in fake_st.graphviz_sources)
     assert any(kind == "success" and "Executed `alpha`" in message for kind, message in fake_st.messages)
 

--- a/test/test_pipeline_lab.py
+++ b/test/test_pipeline_lab.py
@@ -110,6 +110,7 @@ class _FakeStreamlit:
         self.dataframes: list[object] = []
         self.graphviz_sources: list[str] = []
         self.multiselect_calls: list[tuple[str, list[object], str | None]] = []
+        self.checkbox_calls: list[tuple[str, str | None]] = []
         self.text_area_labels: list[str] = []
         self.column_config = _FakeColumnConfig()
 
@@ -186,6 +187,7 @@ class _FakeStreamlit:
         return self.session_state[key]
 
     def checkbox(self, _label, value=False, key=None, **_kwargs):
+        self.checkbox_calls.append((str(_label), key))
         lookup_key = key or _label
         checked = self._checkboxes.get(lookup_key, self.session_state.get(lookup_key, value))
         self.session_state[lookup_key] = bool(checked)
@@ -769,6 +771,11 @@ def test_global_runner_panel_uses_flight_two_app_dag_and_persists_state(monkeypa
         "Next action: Dispatch `flight_context`.",
     ) in fake_st.messages
     assert ("dataframe", "2") in fake_st.messages
+    edit_token = pipeline_lab._global_dag_source_token(
+        "src/agilab/apps/builtin/flight_project/dag_templates/flight_to_meteo.json"
+    )
+    assert ("Edit workflow contract", f"demo_global_runner_edit_contract_{edit_token}") in fake_st.checkbox_calls
+    assert not fake_st.multiselect_calls
 
 
 def test_global_runner_panel_uses_active_app_dag_template(monkeypatch, tmp_path):
@@ -901,7 +908,8 @@ def test_global_runner_panel_renders_project_steps_as_preview_dag(monkeypatch, t
     assert ("metric", "Execution mode=Preview-only") in fake_st.messages
     assert all(call[0] != "demo_global_runner_run_next_stage" for call in fake_st.button_calls)
     assert any(call[0] == "demo_global_runner_dispatch_next" for call in fake_st.button_calls)
-    assert any("step_001" in source and "artifact:step_001_complete" in source for source in fake_st.graphviz_sources)
+    assert ("Show graph", "demo_global_runner_show_graph") in fake_st.checkbox_calls
+    assert not fake_st.graphviz_sources
     unit_tables = [
         table
         for table in fake_st.dataframes
@@ -1054,7 +1062,8 @@ def test_global_runner_panel_renders_project_steps_synced_from_pipeline_logs(mon
                 "Running step 2...",
                 'Step 2: engine=runpy, env=default, summary="train"',
             ],
-        }
+        },
+        checkboxes={"demo_global_runner_show_graph": True},
     )
     monkeypatch.setattr(pipeline_lab, "st", fake_st)
     env = SimpleNamespace(app="demo_project", target="demo_project")
@@ -1348,6 +1357,7 @@ def test_global_runner_panel_recreates_state_when_selected_dag_changes(monkeypat
             "demo_global_runner_dag_path": "docs/source/data/multi_app_dag_sample.json",
         },
         selectboxes={"demo_global_runner_source": pipeline_lab.GLOBAL_DAG_SOURCE_CUSTOM},
+        checkboxes={"demo_global_runner_show_graph": True},
     )
     monkeypatch.setattr(pipeline_lab, "st", fake_st)
     env = SimpleNamespace(app="flight_project", target="flight_project")
@@ -1410,6 +1420,7 @@ def test_global_runner_panel_saves_visual_editor_as_workspace_draft(monkeypatch,
             f"demo_global_runner_label_{token}": "Edited flight DAG",
         },
         buttons={"demo_global_runner_save_draft": True},
+        checkboxes={f"demo_global_runner_edit_contract_{token}": True},
     )
     monkeypatch.setattr(pipeline_lab, "st", fake_st)
     env = SimpleNamespace(app="flight_project", target="flight_project")
@@ -1451,6 +1462,7 @@ def test_global_runner_panel_reports_invalid_visual_editor_as_code(monkeypatch, 
             f"demo_global_runner_dag_id_{token}": "",
         },
         buttons={"demo_global_runner_validate": True},
+        checkboxes={f"demo_global_runner_edit_contract_{token}": True},
     )
     monkeypatch.setattr(pipeline_lab, "st", fake_st)
     env = SimpleNamespace(app="flight_project", target="flight_project")
@@ -1553,7 +1565,10 @@ def test_global_runner_panel_saves_executable_app_template(monkeypatch, tmp_path
             f"demo_global_runner_label_{token}": "Alpha beta executable",
         },
         buttons={"demo_global_runner_save_app_template": True},
-        checkboxes={f"demo_global_runner_controlled_contract_{token}": True},
+        checkboxes={
+            f"demo_global_runner_edit_contract_{token}": True,
+            f"demo_global_runner_controlled_contract_{token}": True,
+        },
     )
     monkeypatch.setattr(pipeline_lab, "st", fake_st)
     monkeypatch.setattr(pipeline_lab, "_repo_root_for_global_dag", lambda: repo_root)
@@ -1611,7 +1626,10 @@ def test_global_runner_panel_saves_reloads_and_runs_executable_app_template(monk
             f"demo_global_runner_label_{token}": "Alpha beta executable",
         },
         buttons={"demo_global_runner_save_app_template": True},
-        checkboxes={f"demo_global_runner_controlled_contract_{token}": True},
+        checkboxes={
+            f"demo_global_runner_edit_contract_{token}": True,
+            f"demo_global_runner_controlled_contract_{token}": True,
+        },
     )
     monkeypatch.setattr(pipeline_lab, "st", fake_st)
     monkeypatch.setattr(pipeline_lab, "_repo_root_for_global_dag", lambda: repo_root)
@@ -1620,6 +1638,7 @@ def test_global_runner_panel_saves_reloads_and_runs_executable_app_template(monk
 
     pipeline_lab._render_global_runner_state_panel(env, lab_dir, "demo")
     fake_st._buttons = {"demo_global_runner_run_next_stage": True}
+    fake_st._checkboxes["demo_global_runner_show_graph"] = True
     pipeline_lab._render_global_runner_state_panel(env, lab_dir, "demo")
 
     template_rel = "src/agilab/apps/builtin/alpha_project/dag_templates/alpha-beta-executable.json"

--- a/test/test_pipeline_lab.py
+++ b/test/test_pipeline_lab.py
@@ -1470,13 +1470,24 @@ def test_global_runner_panel_saves_visual_editor_as_workspace_draft(monkeypatch,
     assert "Edit DAG JSON draft" not in fake_st.text_area_labels
     assert any(label == "Stages" for label, _options, _key in fake_st.multiselect_calls)
     assert any(
-        label == "Produced artifacts" and key == f"demo_global_runner_produces_{token}"
+        label == "Produces" and key == f"demo_global_runner_produces_{token}"
         for label, _options, key in fake_st.multiselect_calls
     )
     assert any(
-        label == "Artifact handoffs" and key == f"demo_global_runner_edges_{token}"
+        label == "Needs" and key == f"demo_global_runner_needs_{token}"
         for label, _options, key in fake_st.multiselect_calls
     )
+    draft_payload = json.loads(draft_path.read_text(encoding="utf-8"))
+    assert draft_payload["edges"] == [
+        {
+            "from": "flight_context",
+            "to": "meteo_forecast_review",
+            "artifact": "flight_reduce_summary",
+            "handoff": "Use flight trajectory reduce summary as the forecast-review context.",
+        }
+    ]
+    meteo_node = next(node for node in draft_payload["nodes"] if node["id"] == "meteo_forecast_review")
+    assert meteo_node["consumes"][0]["id"] == "flight_reduce_summary"
     assert not fake_st.data_editor_calls
 
 


### PR DESCRIPTION
## Summary

- Simplifies the PIPELINE Multi-app DAG orchestration panel so the default path is workflow selection plus readiness/status review.
- Moves contract editing, artifact/stage wiring, validation, and save actions behind an explicit `Edit workflow contract` toggle.
- Hides the Graphviz DAG by default behind `Show graph` so unreadably small graphs do not clutter the normal workflow.

## Validation

- `python3 -m py_compile src/agilab/pipeline_lab.py test/test_pipeline_lab.py`
- `uv --preview-features extra-build-dependencies run pytest -q test/test_pipeline_lab.py`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-env --profile agi-core-combined`
- `uv --preview-features extra-build-dependencies run python tools/coverage_badge_guard.py --changed-only --require-fresh-xml`