### PR TITLE
[codex] Harden PyCharm CE setup discovery

### DIFF
--- a/pycharm/setup_pycharm.py
+++ b/pycharm/setup_pycharm.py
@@ -564,6 +564,12 @@ class JdkTable:
         self.sdk_type = sdk_type
         self.jb_dirs = self.__jetbrains_dir()
         self.jdk_tables = self.__get_jdk_tables()
+        if not self.jdk_tables:
+            logging.warning(
+                "No PyCharm SDK table target found. Open PyCharm or PyCharm "
+                "Community Edition once to initialize JetBrains settings, then "
+                "rerun pycharm/setup_pycharm.py."
+            )
 
     def __jetbrains_dir(self) -> List[Path]:
         home = Path.home()

--- a/test/test_setup_pycharm.py
+++ b/test/test_setup_pycharm.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import logging
 from pathlib import Path
 import subprocess
 import sys
@@ -44,6 +45,43 @@ def _jdk_table_with_agilab_sdk(path: Path, project_root: Path) -> Path:
         encoding="utf-8",
     )
     return jdk_table
+
+
+def test_jdk_table_discovers_pycharm_community_sdk_table(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    home = tmp_path / "home"
+    ce_options = (
+        home
+        / "Library"
+        / "Application Support"
+        / "JetBrains"
+        / "PyCharmCE2026.1"
+        / "options"
+    )
+    ce_options.mkdir(parents=True)
+    monkeypatch.setattr(setup_pycharm.Path, "home", lambda: home)
+    monkeypatch.setattr(setup_pycharm.sys, "platform", "darwin")
+
+    table = setup_pycharm.JdkTable("Python SDK")
+
+    assert table.jdk_tables == [ce_options / "jdk.table.xml"]
+
+
+def test_jdk_table_warns_when_no_pycharm_sdk_target_exists(
+    tmp_path: Path,
+    monkeypatch,
+    caplog,
+) -> None:
+    monkeypatch.setattr(setup_pycharm.Path, "home", lambda: tmp_path / "home")
+    monkeypatch.setattr(setup_pycharm.sys, "platform", "darwin")
+
+    with caplog.at_level(logging.WARNING):
+        table = setup_pycharm.JdkTable("Python SDK")
+
+    assert table.jdk_tables == []
+    assert "Open PyCharm or PyCharm Community Edition once" in caplog.text
 
 
 def test_jdk_table_detects_conflicting_agilab_source_root(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Warn clearly when setup_pycharm cannot find a PyCharm SDK table target
- Add regression coverage for PyCharm Community Edition config discovery
- Add coverage for the no-target warning path

## Validation
- python3 -m py_compile pycharm/setup_pycharm.py test/test_setup_pycharm.py
- uv --preview-features extra-build-dependencies run pytest -q test/test_setup_pycharm.py
- uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files pycharm/setup_pycharm.py test/test_setup_pycharm.py
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui
- uv --preview-features extra-build-dependencies run python tools/coverage_badge_guard.py --changed-only --require-fresh-xml
- git diff --check