### PR TITLE
Align workflow skills with stage naming

### DIFF
--- a/.claude/skills/agilab-docs/SKILL.md
+++ b/.claude/skills/agilab-docs/SKILL.md
@@ -110,8 +110,8 @@ If you accidentally edit `docs/html` directly, discard that manual edit and rege
 - Do not claim reduced repository footprint unless the statement is backed by a
   concrete repository comparison; this is not an inherent AGILAB property.
 - When AGILAB lacks a first-class product primitive, state the current limit
-  plainly. Example: AGILAB can express dynamic behavior inside Python steps, but
-  it does not yet provide first-class runtime workflow-step expansion in
+  plainly. Example: AGILAB can express dynamic behavior inside Python stages, but
+  it does not yet provide first-class runtime workflow-stage expansion in
   `WORKFLOW`.
 
 ## Build / Validate

--- a/.claude/skills/agilab-product-reels/SKILL.md
+++ b/.claude/skills/agilab-product-reels/SKILL.md
@@ -39,7 +39,7 @@ Do not make a feature tour. A short reel needs one story only.
 
 ## Semantic Guardrails
 
-- Do not show an empty replayable step or empty generated snippet.
+- Do not show an empty replayable stage or empty generated snippet.
 - Do not end on decorative `ANALYSIS`; show real evidence.
 - Do not show a “map” without credible geographic meaning.
 - Do not imply unsupported product behavior.
@@ -55,7 +55,7 @@ If the content feels weak, improve the story before polishing the visuals.
 3. Decide which content must be visible in each page:
    - `PROJECT`: scenario or app context
    - `ORCHESTRATE`: runnable packaging / orchestration intent
-   - `WORKFLOW`: replayable snippet, saved step content, or workflow graph
+   - `WORKFLOW`: replayable snippet, saved stage content, or workflow graph
    - `ANALYSIS`: visible outcome or comparison evidence
 4. Generate or refresh the reel.
 5. Extract fresh frames and inspect them before treating the reel as ready.

--- a/.claude/skills/agilab-streamlit-pages/SKILL.md
+++ b/.claude/skills/agilab-streamlit-pages/SKILL.md
@@ -83,12 +83,12 @@ Use this skill when editing:
   For example, count ORCHESTRATE runs from `run_*.log` files under the app run
   environment instead of adding another persisted setting.
 - When a generic page has no app-specific semantic data, show an honest fallback such
-  as execution steps, output files, or discovered dataframes rather than inventing a
+  as execution stages, output files, or discovered dataframes rather than inventing a
   domain-specific metric.
 - Keep one navigation surface per action. If a page already exposes compact sidebar
   launch links, do not duplicate the same action as in-page sidecar cards, repeated
   `Open` buttons, or another selector unless the second surface adds a distinct
-  workflow step.
+  workflow stage.
 - For lightweight page routing, prefer compact Markdown/HTML links with encoded
   query parameters such as `current_page` over a selectbox plus `Open` button when
   the user only needs to jump to a target. Add a tiny helper to construct and test

--- a/.claude/skills/notebook-to-agilab-project/SKILL.md
+++ b/.claude/skills/notebook-to-agilab-project/SKILL.md
@@ -38,7 +38,7 @@ delivery.
 
 3. Map the sequence into AGILAB.
    - `PROJECT`: args and dataset location
-   - `WORKFLOW`: explicit ordered steps in `lab_stages.toml`
+   - `WORKFLOW`: explicit ordered stages in `lab_stages.toml`
    - `ANALYSIS`: one page that reads the exported artifacts
 
 4. Make the migration value explicit.

--- a/.claude/skills/pipeline-concept-view/SKILL.md
+++ b/.claude/skills/pipeline-concept-view/SKILL.md
@@ -17,7 +17,7 @@ view and clearer workflow semantics.
 - Add `pipeline_view.dot` or `pipeline_view.json`
 - Align a conceptual diagram with real app behavior
 - Keep `Conceptual view` and `Execution view` consistent
-- Review `lab_stages.toml` for readability and step naming quality
+- Review `lab_stages.toml` for readability and stage naming quality
 - Clarify inferred IO flow without changing runtime behavior
 
 ## Workflow
@@ -28,7 +28,7 @@ view and clearer workflow semantics.
 4. Rename or regroup labels for business meaning rather than implementation noise.
 5. Keep the conceptual view in app-owned files.
 6. Let the generic UI render it when present.
-7. Update execution labels if the conceptual view or step review reveals naming drift.
+7. Update execution labels if the conceptual view or stage review reveals naming drift.
 8. Keep behavior unchanged unless the user explicitly wants runtime changes.
 
 ## Naming Boundary

--- a/.claude/skills/pipeline-concept-view/references/lab_stages_review.md
+++ b/.claude/skills/pipeline-concept-view/references/lab_stages_review.md
@@ -7,12 +7,12 @@ conceptual diagram.
 
 - prefer verbs for actions
 - prefer semantic names over generic `run trainer` labels
-- remove avoidable redundancy in step names
+- remove avoidable redundancy in stage names
 
 ## Flow
 
 - confirm execution order is intelligible
-- make install versus run steps obvious
+- make install versus run stages obvious
 - make outputs comparable and traceable
 
 ## Truthfulness

--- a/.claude/skills/scientific-svg-figures/SKILL.md
+++ b/.claude/skills/scientific-svg-figures/SKILL.md
@@ -30,7 +30,7 @@ Use one dominant structure per figure.
 - Architecture stack
   Use for system decomposition, layer interaction, deployment, or component boundaries.
 - Pipeline or workflow
-  Use for ordered steps, data flow, preprocessing/training/inference paths, or app orchestration.
+  Use for ordered stages, data flow, preprocessing/training/inference paths, or app orchestration.
 - Training loop or methodology
   Use for RL loops, optimization flow, actor/critic separation, feedback paths, or evaluation cycles.
 - Comparison grid

--- a/.codex/skills/agilab-docs/SKILL.md
+++ b/.codex/skills/agilab-docs/SKILL.md
@@ -110,8 +110,8 @@ If you accidentally edit `docs/html` directly, discard that manual edit and rege
 - Do not claim reduced repository footprint unless the statement is backed by a
   concrete repository comparison; this is not an inherent AGILAB property.
 - When AGILAB lacks a first-class product primitive, state the current limit
-  plainly. Example: AGILAB can express dynamic behavior inside Python steps, but
-  it does not yet provide first-class runtime workflow-step expansion in
+  plainly. Example: AGILAB can express dynamic behavior inside Python stages, but
+  it does not yet provide first-class runtime workflow-stage expansion in
   `WORKFLOW`.
 
 ## Build / Validate

--- a/.codex/skills/agilab-product-reels/SKILL.md
+++ b/.codex/skills/agilab-product-reels/SKILL.md
@@ -39,7 +39,7 @@ Do not make a feature tour. A short reel needs one story only.
 
 ## Semantic Guardrails
 
-- Do not show an empty replayable step or empty generated snippet.
+- Do not show an empty replayable stage or empty generated snippet.
 - Do not end on decorative `ANALYSIS`; show real evidence.
 - Do not show a “map” without credible geographic meaning.
 - Do not imply unsupported product behavior.
@@ -55,7 +55,7 @@ If the content feels weak, improve the story before polishing the visuals.
 3. Decide which content must be visible in each page:
    - `PROJECT`: scenario or app context
    - `ORCHESTRATE`: runnable packaging / orchestration intent
-   - `WORKFLOW`: replayable snippet, saved step content, or workflow graph
+   - `WORKFLOW`: replayable snippet, saved stage content, or workflow graph
    - `ANALYSIS`: visible outcome or comparison evidence
 4. Generate or refresh the reel.
 5. Extract fresh frames and inspect them before treating the reel as ready.

--- a/.codex/skills/agilab-streamlit-pages/SKILL.md
+++ b/.codex/skills/agilab-streamlit-pages/SKILL.md
@@ -83,12 +83,12 @@ Use this skill when editing:
   For example, count ORCHESTRATE runs from `run_*.log` files under the app run
   environment instead of adding another persisted setting.
 - When a generic page has no app-specific semantic data, show an honest fallback such
-  as execution steps, output files, or discovered dataframes rather than inventing a
+  as execution stages, output files, or discovered dataframes rather than inventing a
   domain-specific metric.
 - Keep one navigation surface per action. If a page already exposes compact sidebar
   launch links, do not duplicate the same action as in-page sidecar cards, repeated
   `Open` buttons, or another selector unless the second surface adds a distinct
-  workflow step.
+  workflow stage.
 - For lightweight page routing, prefer compact Markdown/HTML links with encoded
   query parameters such as `current_page` over a selectbox plus `Open` button when
   the user only needs to jump to a target. Add a tiny helper to construct and test

--- a/.codex/skills/notebook-to-agilab-project/SKILL.md
+++ b/.codex/skills/notebook-to-agilab-project/SKILL.md
@@ -38,7 +38,7 @@ delivery.
 
 3. Map the sequence into AGILAB.
    - `PROJECT`: args and dataset location
-   - `WORKFLOW`: explicit ordered steps in `lab_stages.toml`
+   - `WORKFLOW`: explicit ordered stages in `lab_stages.toml`
    - `ANALYSIS`: one page that reads the exported artifacts
 
 4. Make the migration value explicit.

--- a/.codex/skills/pipeline-concept-view/SKILL.md
+++ b/.codex/skills/pipeline-concept-view/SKILL.md
@@ -17,7 +17,7 @@ view and clearer workflow semantics.
 - Add `pipeline_view.dot` or `pipeline_view.json`
 - Align a conceptual diagram with real app behavior
 - Keep `Conceptual view` and `Execution view` consistent
-- Review `lab_stages.toml` for readability and step naming quality
+- Review `lab_stages.toml` for readability and stage naming quality
 - Clarify inferred IO flow without changing runtime behavior
 
 ## Workflow
@@ -28,7 +28,7 @@ view and clearer workflow semantics.
 4. Rename or regroup labels for business meaning rather than implementation noise.
 5. Keep the conceptual view in app-owned files.
 6. Let the generic UI render it when present.
-7. Update execution labels if the conceptual view or step review reveals naming drift.
+7. Update execution labels if the conceptual view or stage review reveals naming drift.
 8. Keep behavior unchanged unless the user explicitly wants runtime changes.
 
 ## Naming Boundary

--- a/.codex/skills/pipeline-concept-view/references/lab_stages_review.md
+++ b/.codex/skills/pipeline-concept-view/references/lab_stages_review.md
@@ -7,12 +7,12 @@ conceptual diagram.
 
 - prefer verbs for actions
 - prefer semantic names over generic `run trainer` labels
-- remove avoidable redundancy in step names
+- remove avoidable redundancy in stage names
 
 ## Flow
 
 - confirm execution order is intelligible
-- make install versus run steps obvious
+- make install versus run stages obvious
 - make outputs comparable and traceable
 
 ## Truthfulness

--- a/.codex/skills/scientific-svg-figures/SKILL.md
+++ b/.codex/skills/scientific-svg-figures/SKILL.md
@@ -30,7 +30,7 @@ Use one dominant structure per figure.
 - Architecture stack
   Use for system decomposition, layer interaction, deployment, or component boundaries.
 - Pipeline or workflow
-  Use for ordered steps, data flow, preprocessing/training/inference paths, or app orchestration.
+  Use for ordered stages, data flow, preprocessing/training/inference paths, or app orchestration.
 - Training loop or methodology
   Use for RL loops, optimization flow, actor/critic separation, feedback paths, or evaluation cycles.
 - Comparison grid


### PR DESCRIPTION
## Summary
- replace remaining AGILAB workflow-specific skill wording from step to stage
- sync canonical Claude skills into Codex skills
- keep generic CI/planning step wording untouched

## Validation
- python3 tools/sync_agent_skills.py --skills pipeline-concept-view notebook-to-agilab-project agilab-streamlit-pages agilab-product-reels agilab-docs scientific-svg-figures
- python3 tools/codex_skills.py --root .codex/skills validate --strict
- python3 tools/codex_skills.py --root .codex/skills generate
- rg old workflow-specific step terms in repo-managed skills
- git diff --check