### PR TITLE
Use release tag for docs version

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 184,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "b7a15773eaaec04832ba9d383af3b72f695c9ed0a0acfc5a09fde48b8e1e567e",
+  "source_digest_sha256": "686a279becb00dac844119a737505bb688f01518e22936f4efb0ad4b727f4436",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "b7a15773eaaec04832ba9d383af3b72f695c9ed0a0acfc5a09fde48b8e1e567e"
+  "target_digest_sha256": "686a279becb00dac844119a737505bb688f01518e22936f4efb0ad4b727f4436"
 }

--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -1,7 +1,9 @@
 /* Custom overrides for AGILab Sphinx docs. */
 
 .wy-side-nav-search .agilab-doc-version {
-  display: inline-block;
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.15rem;
   margin-top: 0.75rem;
   padding: 0.3rem 0.65rem;
   border: 1px solid rgba(255, 255, 255, 0.28);
@@ -12,6 +14,13 @@
   font-weight: 700;
   letter-spacing: 0.03em;
   line-height: 1.2;
+}
+
+.wy-side-nav-search .agilab-doc-build {
+  font-size: 0.64rem;
+  font-weight: 500;
+  letter-spacing: 0;
+  opacity: 0.82;
 }
 
 .rst-content div.figure.diagram-panel {

--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -3,6 +3,11 @@
 {% block sidebartitle %}
 {{ super() }}
 {% if docs_version %}
-<div class="agilab-doc-version">Docs version {{ docs_version }}</div>
+<div class="agilab-doc-version">
+  <span>Current release {{ docs_version }}</span>
+  {% if docs_build_revision %}
+  <span class="agilab-doc-build">Docs build {{ docs_build_revision }}</span>
+  {% endif %}
+</div>
 {% endif %}
 {% endblock %}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -119,9 +119,24 @@ def _read_pyproject_version(pyproject_path: Path) -> str | None:
     return None
 
 
-def _read_git_version(repo_path: Path) -> str | None:
+def _read_release_tag_from_proof(docs_source: Path) -> str | None:
+    proof_path = docs_source / "data" / "release_proof.toml"
+    if not proof_path.is_file():
+        return None
+
     try:
-        version_value = subprocess.check_output(
+        proof_data = tomllib.loads(proof_path.read_text(encoding="utf-8"))
+        tag_value = proof_data.get("release", {}).get("github_release_tag")
+        if isinstance(tag_value, str) and tag_value.strip():
+            return tag_value.strip()
+    except Exception as e:
+        print(f"Warning: unable to read public release tag from {proof_path}: {e}")
+    return None
+
+
+def _read_git_revision(repo_path: Path) -> str | None:
+    try:
+        revision_value = subprocess.check_output(
             [
                 "git",
                 "-C",
@@ -136,25 +151,35 @@ def _read_git_version(repo_path: Path) -> str | None:
             text=True,
             stderr=subprocess.DEVNULL,
         ).strip()
-        if version_value.startswith("v"):
-            version_value = version_value[1:]
-        return version_value or None
+        return revision_value or None
     except Exception:
         return None
 
 
-def _resolve_docs_version() -> str:
+def _candidate_roots() -> list[Path]:
     candidate_roots = []
-    for root in (_resolve_agilab_repo_root(), repo_root):
+    for root in (repo_root, _resolve_agilab_repo_root()):
         if root is not None and root not in candidate_roots:
             candidate_roots.append(root)
+    return candidate_roots
 
-    for root in candidate_roots:
-        version_value = _read_git_version(root)
-        if version_value is not None:
-            return version_value
 
-    for root in candidate_roots:
+def _resolve_public_release_tag() -> str:
+    docs_sources = []
+    for root in _candidate_roots():
+        docs_source = root / "docs" / "source"
+        if docs_source.is_dir() and docs_source not in docs_sources:
+            docs_sources.append(docs_source)
+    current_docs_source = Path(__file__).resolve().parent
+    if current_docs_source not in docs_sources:
+        docs_sources.append(current_docs_source)
+
+    for docs_source in docs_sources:
+        release_tag = _read_release_tag_from_proof(docs_source)
+        if release_tag is not None:
+            return release_tag
+
+    for root in _candidate_roots():
         pyproject_path = root / "pyproject.toml"
         if pyproject_path.exists():
             version_value = _read_pyproject_version(pyproject_path)
@@ -169,11 +194,20 @@ def _resolve_docs_version() -> str:
     return "dev"
 
 
+def _resolve_docs_build_revision() -> str | None:
+    for root in _candidate_roots():
+        revision_value = _read_git_revision(root)
+        if revision_value is not None:
+            return revision_value
+    return None
+
+
 project = "AGILab"
 author = "Jean-Pierre MORARD"
 copyright = "2026, THALES SIX GTS France SAS"
-release = _resolve_docs_version()
+release = _resolve_public_release_tag()
 version = release
+docs_build_revision = _resolve_docs_build_revision()
 
 # -- General Configuration ---------------------------------------------------
 
@@ -315,6 +349,7 @@ html_logo = "logo/agi_logo.svg"
 display_version = True
 html_context = {
     "docs_version": release,
+    "docs_build_revision": None if docs_build_revision == release else docs_build_revision,
 }
 
 # Theme options

--- a/test/test_docs_version_label.py
+++ b/test/test_docs_version_label.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tomllib
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONF_PATH = ROOT / "docs/source/conf.py"
+RELEASE_PROOF = ROOT / "docs/source/data/release_proof.toml"
+LAYOUT_TEMPLATE = ROOT / "docs/source/_templates/layout.html"
+
+
+def _load_conf_module():
+    sys.modules.pop("agilab_docs_conf_test_module", None)
+    spec = importlib.util.spec_from_file_location("agilab_docs_conf_test_module", CONF_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_docs_visible_release_uses_github_release_tag() -> None:
+    release_proof = tomllib.loads(RELEASE_PROOF.read_text(encoding="utf-8"))
+    release_tag = release_proof["release"]["github_release_tag"]
+
+    conf = _load_conf_module()
+
+    assert release_tag.startswith("v")
+    assert conf.release == release_tag
+    assert conf.version == release_tag
+    assert conf.html_context["docs_version"] == release_tag
+
+
+def test_docs_template_keeps_release_and_build_revision_separate() -> None:
+    template = LAYOUT_TEMPLATE.read_text(encoding="utf-8")
+
+    assert "Current release {{ docs_version }}" in template
+    assert "Docs build {{ docs_build_revision }}" in template


### PR DESCRIPTION
## Summary
- make Sphinx release/version resolve from docs/source/data/release_proof.toml github_release_tag
- expose git describe only as a separate docs_build_revision in the sidebar
- add regression coverage for release-tag based docs versioning

## Validation
- uv --preview-features extra-build-dependencies run pytest -q -o addopts= test/test_docs_version_label.py test/test_audit_response_docs.py test/test_release_proof_report.py
- uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --delete
- uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs
- uv --preview-features extra-build-dependencies run python tools/coverage_badge_guard.py --changed-only --require-fresh-xml