### PR TITLE
chore: remove retired environment aliases

### DIFF
--- a/.claude/skills/agilab-installer/SKILL.md
+++ b/.claude/skills/agilab-installer/SKILL.md
@@ -34,7 +34,7 @@ Use this skill when working on:
 - Full clean source validation from a new public clone:
   - `cache_root="${XDG_CACHE_HOME:-$HOME/.cache}/agilab/source_validate"; root="$cache_root/agilab_source_validate_clean_$(date +%Y%m%d_%H%M%S)"; mkdir -p "$root/home"; HOME="$root/home" git clone https://github.com/ThalesGroup/agilab.git "$root/home/agilab"`
   - `cd "$root/home/agilab" && git lfs install --local && git lfs pull`
-  - `HOME="$root/home" AGI_LOCAL_DIR="$PWD/localshare" ./install.sh --non-interactive --agi-share-dir "$PWD/clustershare" --install-apps builtin --test-root --test-core --test-apps --skip-offline`
+  - `HOME="$root/home" AGI_LOCAL_SHARE="$PWD/localshare" ./install.sh --non-interactive --agi-cluster-share "$PWD/clustershare" --install-apps builtin --test-root --test-core --test-apps --skip-offline`
 - Add core suites only when needed:
   - macOS/Linux: `./install.sh --install-apps --test-apps --test-core`
   - Windows: `.\install.ps1 -InstallApps -TestApps -TestCore`
@@ -53,7 +53,7 @@ Use this skill when working on:
   - Use an isolated `HOME` under the new validation root. Do not rely on the
     developer machine's `~/.agilab/.env`, `~/wenv`, `~/localshare`, or previous
     install logs when proving a release candidate.
-  - Pass both `--agi-share-dir "$PWD/clustershare"` and `AGI_LOCAL_DIR="$PWD/localshare"`
+  - Pass both `--agi-cluster-share "$PWD/clustershare"` and `AGI_LOCAL_SHARE="$PWD/localshare"`
     in the clean clone so cluster/local share values are written before root,
     core, app, and demo validation.
   - Run `git lfs pull` before install validation whenever built-in apps depend
@@ -64,7 +64,7 @@ Use this skill when working on:
 
 - **Installer env propagation order**
   - If app tests fail because paths point to stale `~/.agilab/.env` values even
-    though the current install command passed `--agi-share-dir` or `AGI_LOCAL_DIR`,
+    though the current install command passed `--agi-cluster-share` or `AGI_LOCAL_SHARE`,
     inspect whether the installer writes env values before validation phases run.
   - The env file must be updated before `--test-root`, `--test-core`, app
     installs, and app tests. A late write can make validation exercise an old

--- a/.claude/skills/agilab-testing/SKILL.md
+++ b/.claude/skills/agilab-testing/SKILL.md
@@ -158,7 +158,7 @@ validation, release, and Hugging Face sync in one flow.
   - clone `https://github.com/ThalesGroup/agilab.git` into a new directory under `$HOME`
   - run `git lfs install --local && git lfs pull`
   - run the installer with `--install-apps builtin --test-root --test-core --test-apps --skip-offline`
-  - set `AGI_LOCAL_DIR="$PWD/localshare"` and `--agi-share-dir "$PWD/clustershare"`
+  - set `AGI_LOCAL_SHARE="$PWD/localshare"` and `--agi-cluster-share "$PWD/clustershare"`
 - If the release includes a first-proof or demo claim, run the demo command from
   that same clean clone and record the produced artifact path plus key metrics.
 - Treat benign `uv self update` failures from package-manager-installed `uv` as

--- a/.codex/skills/agilab-installer/SKILL.md
+++ b/.codex/skills/agilab-installer/SKILL.md
@@ -34,7 +34,7 @@ Use this skill when working on:
 - Full clean source validation from a new public clone:
   - `cache_root="${XDG_CACHE_HOME:-$HOME/.cache}/agilab/source_validate"; root="$cache_root/agilab_source_validate_clean_$(date +%Y%m%d_%H%M%S)"; mkdir -p "$root/home"; HOME="$root/home" git clone https://github.com/ThalesGroup/agilab.git "$root/home/agilab"`
   - `cd "$root/home/agilab" && git lfs install --local && git lfs pull`
-  - `HOME="$root/home" AGI_LOCAL_DIR="$PWD/localshare" ./install.sh --non-interactive --agi-share-dir "$PWD/clustershare" --install-apps builtin --test-root --test-core --test-apps --skip-offline`
+  - `HOME="$root/home" AGI_LOCAL_SHARE="$PWD/localshare" ./install.sh --non-interactive --agi-cluster-share "$PWD/clustershare" --install-apps builtin --test-root --test-core --test-apps --skip-offline`
 - Add core suites only when needed:
   - macOS/Linux: `./install.sh --install-apps --test-apps --test-core`
   - Windows: `.\install.ps1 -InstallApps -TestApps -TestCore`
@@ -53,7 +53,7 @@ Use this skill when working on:
   - Use an isolated `HOME` under the new validation root. Do not rely on the
     developer machine's `~/.agilab/.env`, `~/wenv`, `~/localshare`, or previous
     install logs when proving a release candidate.
-  - Pass both `--agi-share-dir "$PWD/clustershare"` and `AGI_LOCAL_DIR="$PWD/localshare"`
+  - Pass both `--agi-cluster-share "$PWD/clustershare"` and `AGI_LOCAL_SHARE="$PWD/localshare"`
     in the clean clone so cluster/local share values are written before root,
     core, app, and demo validation.
   - Run `git lfs pull` before install validation whenever built-in apps depend
@@ -64,7 +64,7 @@ Use this skill when working on:
 
 - **Installer env propagation order**
   - If app tests fail because paths point to stale `~/.agilab/.env` values even
-    though the current install command passed `--agi-share-dir` or `AGI_LOCAL_DIR`,
+    though the current install command passed `--agi-cluster-share` or `AGI_LOCAL_SHARE`,
     inspect whether the installer writes env values before validation phases run.
   - The env file must be updated before `--test-root`, `--test-core`, app
     installs, and app tests. A late write can make validation exercise an old

--- a/.codex/skills/agilab-testing/SKILL.md
+++ b/.codex/skills/agilab-testing/SKILL.md
@@ -158,7 +158,7 @@ validation, release, and Hugging Face sync in one flow.
   - clone `https://github.com/ThalesGroup/agilab.git` into a new directory under `$HOME`
   - run `git lfs install --local && git lfs pull`
   - run the installer with `--install-apps builtin --test-root --test-core --test-apps --skip-offline`
-  - set `AGI_LOCAL_DIR="$PWD/localshare"` and `--agi-share-dir "$PWD/clustershare"`
+  - set `AGI_LOCAL_SHARE="$PWD/localshare"` and `--agi-cluster-share "$PWD/clustershare"`
 - If the release includes a first-proof or demo claim, run the demo command from
   that same clean clone and record the produced artifact path plus key metrics.
 - Treat benign `uv self update` failures from package-manager-installed `uv` as

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 184,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "c61a1773806f8cfbcc61db2ef5b3339ef498972405e7e7e9b6205f71698b59ba",
+  "source_digest_sha256": "1cb121696024b2f7ffeb5e0c1edceaffb9a10f54497e2f58922a65433bc75333",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "c61a1773806f8cfbcc61db2ef5b3339ef498972405e7e7e9b6205f71698b59ba"
+  "target_digest_sha256": "1cb121696024b2f7ffeb5e0c1edceaffb9a10f54497e2f58922a65433bc75333"
 }

--- a/docs/source/agi-env.rst
+++ b/docs/source/agi-env.rst
@@ -27,11 +27,10 @@ Share directory resolution
 ``AgiEnv.agi_share_path_abs``.
 The path is derived from environment settings using the following precedence:
 
-1. ``AGI_SHARE_DIR`` from the current process environment, then ``.env``. This is the user-facing override.
-2. ``AGI_CLUSTER_SHARE`` from the current process environment (e.g. ssh session, service unit), then ``.env``.
-3. ``AGI_CLUSTER_SHARE`` fallback ``clustershare/<user>`` when no explicit
+1. ``AGI_CLUSTER_SHARE`` from the current process environment, then ``.env``.
+2. ``AGI_CLUSTER_SHARE`` fallback ``clustershare/<user>`` when no explicit
    cluster share is configured.
-4. ``AGI_LOCAL_SHARE`` (default ``~/localshare``) when cluster mode is disabled.
+3. ``AGI_LOCAL_SHARE`` (default ``~/localshare``) when cluster mode is disabled.
 
 The ``<user>`` segment is derived from ``AGILAB_SHARE_USER``, then ``USER``,
 then ``USERNAME``, and is sanitised before being used as a path component.

--- a/docs/source/cluster.rst
+++ b/docs/source/cluster.rst
@@ -265,7 +265,6 @@ Keep the cluster-share setting portable when workers are not Windows:
 
 .. code-block:: powershell
 
-   $env:AGI_SHARE_DIR = "clustershare/agilab-two-node"
    $env:AGI_CLUSTER_SHARE = "clustershare/agilab-two-node"
 
 Seed SSH host trust from PowerShell when the Windows scheduler must SSH to a

--- a/docs/source/environment.rst
+++ b/docs/source/environment.rst
@@ -82,7 +82,7 @@ summarises the supported keys.
    * - ``AGILAB_LLM_TIMEOUT``
      - ``120``
      - Request timeout in seconds for the OpenAI-compatible assistant provider.
-   * - ``AGI_SHARE_DIR``
+   * - ``AGI_CLUSTER_SHARE``
      - ``clustershare/<user>`` (resolved under ``$HOME`` if relative).
      - User-facing knob for the shared datasets/outputs root. Prefer the relative
        user-scoped form so mixed macOS/Linux/Windows nodes can resolve it under
@@ -136,7 +136,7 @@ Cluster isolation note
 For cluster-enabled use cases, treat the share directory as part of the user's
 workspace contract, not as a generic team dropbox.
 
-- The default ``AGI_SHARE_DIR`` / ``AGI_CLUSTER_SHARE`` root is user-scoped.
+- The default ``AGI_CLUSTER_SHARE`` root is user-scoped.
 - If you override it, keep one root per user.
 - Each user should also use their own real worker login account or explicit
   ``user@host`` targets when connecting to the cluster.

--- a/docs/source/execute-help.rst
+++ b/docs/source/execute-help.rst
@@ -291,7 +291,7 @@ directly.
 
 Default output path:
 
-- ``${AGI_SHARE_DIR}/service/<app_target>/health.json``.
+- ``${AGI_CLUSTER_SHARE}/service/<app_target>/health.json``.
 
 Custom output path:
 

--- a/docs/source/service-mode.rst
+++ b/docs/source/service-mode.rst
@@ -139,7 +139,7 @@ Use this checker for automation/monitoring:
 
 Health JSON is written by default to:
 
-- ``${AGI_SHARE_DIR}/service/<app_target>/health.json``
+- ``${AGI_CLUSTER_SHARE}/service/<app_target>/health.json``
 
 Operator snapshot JSON written from the ORCHESTRATE page is stored at:
 

--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -119,7 +119,7 @@ E - macOS NFS server checklist:
 
 Use this quick list when you need a shared dataset folder between Macs (for example, a cluster
 controller exporting ``/Users/<user>/data`` to another workstation). Replace ``<nfs_server_ip>`` with
-your server IP and adjust mount paths as needed. The default ``AGI_SHARE_DIR`` is
+your server IP and adjust mount paths as needed. The default ``AGI_CLUSTER_SHARE`` is
 ``clustershare/<user>`` under ``$HOME``. For cluster-enabled apps, that path must be mounted
 and writable on every node: ``AgiEnv`` now fails fast instead of silently falling back
 to ``AGI_LOCAL_SHARE`` or ``$HOME/localshare``. Ensure the chosen path exists and is writable.

--- a/install.ps1
+++ b/install.ps1
@@ -9,8 +9,8 @@ param(
     [switch]$InstallApps,
     [switch]$TestApps,
     [switch]$TestCore,
-    [string]$AgiShareDir,
-    [string]$AgiLocalDir,
+    [string]$AgiClusterShare,
+    [string]$AgiLocalShare,
     [string]$InstallAppsList,
     [switch]$NonInteractive
 )
@@ -111,7 +111,7 @@ $LocalDir = Join-Path $env:LOCALAPPDATA "agilab"
 Ensure-Directory $LocalDir
 $AgiPathFile = Join-Path $LocalDir ".agilab-path"
 
-$DefaultShareDir = if ($AgiShareDir) { $AgiShareDir } elseif ($env:AGI_SHARE_DIR) { $env:AGI_SHARE_DIR } else { Join-Path $env:USERPROFILE "clustershare" }
+$DefaultShareDir = if ($AgiClusterShare) { $AgiClusterShare } elseif ($env:AGI_CLUSTER_SHARE) { $env:AGI_CLUSTER_SHARE } else { Join-Path $env:USERPROFILE "clustershare" }
 function Get-EnvValueFromFile {
     param([string]$FilePath, [string]$Key)
     if (-not (Test-Path -LiteralPath $FilePath)) { return "" }
@@ -121,13 +121,12 @@ function Get-EnvValueFromFile {
     return $value
 }
 if (-not $DefaultShareDir) {
-    $DefaultShareDir = Get-EnvValueFromFile (Join-Path $env:USERPROFILE ".agilab\.env") "AGI_SHARE_DIR"
+    $DefaultShareDir = Get-EnvValueFromFile (Join-Path $env:USERPROFILE ".agilab\.env") "AGI_CLUSTER_SHARE"
 }
 if (-not $DefaultShareDir) {
-    $DefaultShareDir = Get-EnvValueFromFile (Join-Path $InstallPathFull ".agilab\.env") "AGI_SHARE_DIR"
+    $DefaultShareDir = Get-EnvValueFromFile (Join-Path $InstallPathFull ".agilab\.env") "AGI_CLUSTER_SHARE"
 }
-$DefaultLocalShare = if ($AgiLocalDir) { $AgiLocalDir }
-    elseif ($env:AGI_LOCAL_DIR) { $env:AGI_LOCAL_DIR }
+$DefaultLocalShare = if ($AgiLocalShare) { $AgiLocalShare }
     elseif ($env:AGI_LOCAL_SHARE) { $env:AGI_LOCAL_SHARE }
     else { Join-Path $env:USERPROFILE "localshare" }
 
@@ -161,14 +160,14 @@ function Ensure-ShareDir {
     if ([string]::IsNullOrWhiteSpace($ShareDir)) {
         if ($NonInteractiveMode) {
             if (-not [string]::IsNullOrWhiteSpace($ClusterCredentials)) {
-                Write-Failure "AGI_SHARE_DIR not provided and cluster credentials specified; cannot proceed in non-interactive mode."
+                Write-Failure "AGI_CLUSTER_SHARE not provided and cluster credentials specified; cannot proceed in non-interactive mode."
                 exit 1
             }
             $ShareDir = $FallbackDir
         } else {
-            $ShareDir = Read-Host "Enter AGI_SHARE_DIR path (or press Enter to abort)"
+            $ShareDir = Read-Host "Enter AGI_CLUSTER_SHARE path (or press Enter to abort)"
             if ([string]::IsNullOrWhiteSpace($ShareDir)) {
-                Write-Failure "AGI_SHARE_DIR not provided. Aborting."
+                Write-Failure "AGI_CLUSTER_SHARE not provided. Aborting."
                 exit 1
             }
         }
@@ -178,12 +177,12 @@ function Ensure-ShareDir {
     $FallbackDir = Normalize-UserPath $FallbackDir
 
     if (-not [string]::IsNullOrWhiteSpace($ShareDir)) {
-        Write-Info ("AGI_SHARE_DIR resolved to: {0}" -f $ShareDir)
+        Write-Info ("AGI_CLUSTER_SHARE resolved to: {0}" -f $ShareDir)
     }
 
     if (Test-ShareMounted -Path $ShareDir) {
-        $env:AGI_SHARE_DIR = $ShareDir
-        if (-not $env:AGI_LOCAL_DIR) { $env:AGI_LOCAL_DIR = $FallbackDir }
+        $env:AGI_CLUSTER_SHARE = $ShareDir
+        if (-not $env:AGI_LOCAL_SHARE) { $env:AGI_LOCAL_SHARE = $FallbackDir }
         return
     }
 
@@ -192,30 +191,30 @@ function Ensure-ShareDir {
             Write-Failure "$ShareDir is not mounted. Cluster installs require the shared path; aborting (non-interactive)."
             exit 1
         }
-        Write-Warn ("AGI_SHARE_DIR {0} unavailable; non-interactive mode: using fallback {1}." -f $ShareDir, $FallbackDir)
+        Write-Warn ("AGI_CLUSTER_SHARE {0} unavailable; non-interactive mode: using fallback {1}." -f $ShareDir, $FallbackDir)
         Ensure-Directory $FallbackDir
-        $env:AGI_LOCAL_DIR = $FallbackDir
-        $env:AGI_SHARE_DIR = $FallbackDir
+        $env:AGI_LOCAL_SHARE = $FallbackDir
+        $env:AGI_CLUSTER_SHARE = $FallbackDir
         return
     }
 
-    Write-Warn "AGI_SHARE_DIR is unavailable at $ShareDir."
+    Write-Warn "AGI_CLUSTER_SHARE is unavailable at $ShareDir."
     Write-Host "Choose an option:" -ForegroundColor Yellow
     Write-Host "  1) Use local fallback at $FallbackDir"
     Write-Host "  2) Wait for $ShareDir to be mounted (mandatory for cluster installs; timeout 120s)"
     $choice = Read-Host "Enter 1 or 2 (default: 1)"
     if ($choice -eq "" -or $choice -eq "1") {
         Ensure-Directory $FallbackDir
-        $env:AGI_LOCAL_DIR = $FallbackDir
-        $env:AGI_SHARE_DIR = $FallbackDir
-        Write-Success "Using local fallback AGI_LOCAL_DIR=$env:AGI_LOCAL_DIR"
+        $env:AGI_LOCAL_SHARE = $FallbackDir
+        $env:AGI_CLUSTER_SHARE = $FallbackDir
+        Write-Success "Using local fallback AGI_LOCAL_SHARE=$env:AGI_LOCAL_SHARE"
     }
     elseif ($choice -eq "2") {
         Write-Info "Waiting for $ShareDir to become available (timeout 120s)..."
         $waited = 0
         while ($waited -lt 120) {
             if (Test-Path -LiteralPath $ShareDir) {
-                $env:AGI_SHARE_DIR = $ShareDir
+                $env:AGI_CLUSTER_SHARE = $ShareDir
                 Write-Success "$ShareDir is available. Continuing."
                 return
             }
@@ -278,12 +277,12 @@ if (-not $ResolvedLocalShare) {
 
 if (-not $NonInteractiveMode) {
     $shareDisplay = if ($ResolvedShareDir) { $ResolvedShareDir } else { "<unset>" }
-    $shareInput = Read-Host "AGI_SHARE_DIR is '$shareDisplay'. Press Enter to accept or type a new path"
+    $shareInput = Read-Host "AGI_CLUSTER_SHARE is '$shareDisplay'. Press Enter to accept or type a new path"
     if (-not [string]::IsNullOrWhiteSpace($shareInput)) {
         $ResolvedShareDir = Normalize-UserPath $shareInput
     }
     $localDisplay = if ($ResolvedLocalShare) { $ResolvedLocalShare } else { "<unset>" }
-    $localInput = Read-Host "AGI_LOCAL_DIR fallback is '$localDisplay'. Press Enter to accept or type a new path"
+    $localInput = Read-Host "AGI_LOCAL_SHARE fallback is '$localDisplay'. Press Enter to accept or type a new path"
     if (-not [string]::IsNullOrWhiteSpace($localInput)) {
         $ResolvedLocalShare = Normalize-UserPath $localInput
     }
@@ -482,7 +481,6 @@ function Write-AgiPath {
     $agilabPath = Join-Path $env:USERPROFILE ".agilab"
     Ensure-Directory $agilabPath
     $agilabRoot | Set-Content -Encoding UTF8 -Path $AgiPathFile
-    [Environment]::SetEnvironmentVariable('AGI_ROOT', $agilabRoot, [EnvironmentVariableTarget]::User)
     Write-Success "Installation root path recorded in $AgiPathFile"
 }
 

--- a/install.sh
+++ b/install.sh
@@ -74,13 +74,13 @@ default_agi_share_user() {
     printf '%s\n' "${safe_user:-user}"
 }
 
-default_agi_share_dir() {
+default_agi_cluster_share() {
     printf 'clustershare/%s\n' "$(default_agi_share_user)"
 }
 
 AGI_INSTALL_PATH="$(realpath '.')"
-# Default share dir (can be overridden via --agi-share-dir or env)
-AGI_SHARE_DIR="${AGI_SHARE_DIR:-}"
+# Default share dir (can be overridden via --agi-cluster-share or env)
+AGI_CLUSTER_SHARE="${AGI_CLUSTER_SHARE:-}"
 CURRENT_PATH="$(realpath '.')"
 CLUSTER_CREDENTIALS="${CLUSTER_CREDENTIALS:-}"
 OPENAI_API_KEY="${OPENAI_API_KEY:-}"
@@ -135,7 +135,7 @@ guard_ephemeral_validation_env() {
 
     local suspect=""
     local candidate
-    for candidate in "${AGI_INSTALL_PATH:-}" "${AGI_SHARE_DIR:-}" "${AGI_LOCAL_DIR:-}"; do
+    for candidate in "${AGI_INSTALL_PATH:-}" "${AGI_CLUSTER_SHARE:-}" "${AGI_LOCAL_SHARE:-}"; do
         if looks_ephemeral_validation_path "$candidate"; then
             suspect="$candidate"
             break
@@ -157,15 +157,15 @@ guard_ephemeral_validation_env() {
 
 USER_ENV_FILE="$HOME/.agilab/.env"
 REPO_ENV_FILE="$AGI_INSTALL_PATH/.agilab/.env"
-ENV_SHARE_USER="$(read_env_var "$USER_ENV_FILE" AGI_SHARE_DIR)"
-ENV_SHARE_REPO="$(read_env_var "$REPO_ENV_FILE" AGI_SHARE_DIR)"
-DEFAULT_SHARE_DIR="${AGI_SHARE_DIR:-${ENV_SHARE_USER:-$ENV_SHARE_REPO}}"
+ENV_SHARE_USER="$(read_env_var "$USER_ENV_FILE" AGI_CLUSTER_SHARE)"
+ENV_SHARE_REPO="$(read_env_var "$REPO_ENV_FILE" AGI_CLUSTER_SHARE)"
+DEFAULT_SHARE_DIR="${AGI_CLUSTER_SHARE:-${ENV_SHARE_USER:-$ENV_SHARE_REPO}}"
 if [[ -z "$DEFAULT_SHARE_DIR" ]]; then
-    DEFAULT_SHARE_DIR="$(default_agi_share_dir)"
+    DEFAULT_SHARE_DIR="$(default_agi_cluster_share)"
 fi
-AGI_SHARE_DIR="${AGI_SHARE_DIR:-$DEFAULT_SHARE_DIR}"
-AGI_LOCAL_DIR="${AGI_LOCAL_DIR:-${AGI_LOCAL_SHARE:-$HOME/localshare}}"
-DEFAULT_LOCAL_SHARE="$AGI_LOCAL_DIR"
+AGI_CLUSTER_SHARE="${AGI_CLUSTER_SHARE:-$DEFAULT_SHARE_DIR}"
+AGI_LOCAL_SHARE="${AGI_LOCAL_SHARE:-$HOME/localshare}"
+DEFAULT_LOCAL_SHARE="$AGI_LOCAL_SHARE"
 
 is_exported_nfs() {
     local path="$1"
@@ -223,7 +223,7 @@ ensure_share_dir() {
         local shadow_share="$requested_share"
 
         if [[ -z "$shadow_share" || "$shadow_share" == "$local_fallback" ]]; then
-            shadow_share="$HOME/$(default_agi_share_dir)"
+            shadow_share="$HOME/$(default_agi_cluster_share)"
         fi
 
         if mkdir -p "$shadow_share" 2>/dev/null; then
@@ -231,7 +231,7 @@ ensure_share_dir() {
             return 0
         fi
 
-        shadow_share="$HOME/$(default_agi_share_dir)"
+        shadow_share="$HOME/$(default_agi_cluster_share)"
         mkdir -p "$shadow_share" || {
             echo -e "${RED}Failed to create fallback cluster share ${shadow_share}.${NC}"
             exit 1
@@ -243,13 +243,13 @@ ensure_share_dir() {
         if (( NON_INTERACTIVE )); then
             share_dir="$fallback_dir"
         elif [[ -t 0 ]]; then
-            read -rp "Enter AGI_SHARE_DIR path (or press Enter to abort): " share_dir
+            read -rp "Enter AGI_CLUSTER_SHARE path (or press Enter to abort): " share_dir
             if [[ -z "$share_dir" ]]; then
-                echo -e "${RED}AGI_SHARE_DIR not provided. Aborting.${NC}"
+                echo -e "${RED}AGI_CLUSTER_SHARE not provided. Aborting.${NC}"
                 exit 1
             fi
         else
-            echo -e "${YELLOW}AGI_SHARE_DIR not set and no TTY available. Using fallback ${fallback_dir}.${NC}"
+            echo -e "${YELLOW}AGI_CLUSTER_SHARE not set and no TTY available. Using fallback ${fallback_dir}.${NC}"
             share_dir="$fallback_dir"
         fi
     fi
@@ -264,13 +264,13 @@ ensure_share_dir() {
         [[ "$fallback_dir" != /* ]] && fallback_dir="$HOME/$fallback_dir"
     fi
     if [[ -n "$share_dir" ]]; then
-        echo -e "${BLUE}AGI_SHARE_DIR resolved to: ${share_dir}${NC}"
+        echo -e "${BLUE}AGI_CLUSTER_SHARE resolved to: ${share_dir}${NC}"
     fi
 
     # If the share is already mounted, accept it and return.
     if is_exported_nfs "$share_dir" || share_is_mounted "$share_dir"; then
-        export AGI_SHARE_DIR="$share_dir"
-        export AGI_LOCAL_DIR="${AGI_LOCAL_DIR:-$fallback_dir}"
+        export AGI_CLUSTER_SHARE="$share_dir"
+        export AGI_LOCAL_SHARE="${AGI_LOCAL_SHARE:-$fallback_dir}"
         return 0
     fi
 
@@ -281,10 +281,10 @@ ensure_share_dir() {
         fi
         local cluster_shadow
         cluster_shadow="$(ensure_distinct_cluster_fallback "$share_dir" "$fallback_dir")"
-        echo -e "${YELLOW}AGI_SHARE_DIR ${share_dir} unavailable; non-interactive mode: using local fallback ${fallback_dir} and local cluster shadow ${cluster_shadow}.${NC}"
+        echo -e "${YELLOW}AGI_CLUSTER_SHARE ${share_dir} unavailable; non-interactive mode: using local fallback ${fallback_dir} and local cluster shadow ${cluster_shadow}.${NC}"
         mkdir -p "$fallback_dir" || { echo -e "${RED}Failed to create fallback ${fallback_dir}.${NC}"; exit 1; }
-        export AGI_LOCAL_DIR="$fallback_dir"
-        export AGI_SHARE_DIR="$cluster_shadow"
+        export AGI_LOCAL_SHARE="$fallback_dir"
+        export AGI_CLUSTER_SHARE="$cluster_shadow"
         return 0
     fi
 
@@ -300,7 +300,7 @@ ensure_share_dir() {
         fi
     }
 
-    echo -e "${YELLOW}AGI_SHARE_DIR is unavailable at ${share_dir}.${NC}"
+    echo -e "${YELLOW}AGI_CLUSTER_SHARE is unavailable at ${share_dir}.${NC}"
     echo -e "Choose an option:"
     echo -e "  1) Use local fallback at ${fallback_dir} and keep a distinct local cluster shadow"
     echo -e "  2) Wait for ${share_dir} to be mounted (mandatory for cluster installs; will timeout)"
@@ -311,16 +311,16 @@ ensure_share_dir() {
             local cluster_shadow
             cluster_shadow="$(ensure_distinct_cluster_fallback "$share_dir" "$fallback_dir")"
             mkdir -p "$fallback_dir" || { echo -e "${RED}Failed to create fallback ${fallback_dir}.${NC}"; exit 1; }
-            export AGI_LOCAL_DIR="$fallback_dir"
-            export AGI_SHARE_DIR="$cluster_shadow"
-            echo -e "${GREEN}Using local fallback AGI_LOCAL_DIR=${AGI_LOCAL_DIR} with AGI_SHARE_DIR=${AGI_SHARE_DIR}.${NC}"
+            export AGI_LOCAL_SHARE="$fallback_dir"
+            export AGI_CLUSTER_SHARE="$cluster_shadow"
+            echo -e "${GREEN}Using local fallback AGI_LOCAL_SHARE=${AGI_LOCAL_SHARE} with AGI_CLUSTER_SHARE=${AGI_CLUSTER_SHARE}.${NC}"
             ;;
         2)
             echo -e "${BLUE}Waiting for ${share_dir} to become available (timeout 120s)...${NC}"
             local waited=0
             while [[ $waited -lt 120 ]]; do
                 if [[ -d "$share_dir" ]]; then
-                    export AGI_SHARE_DIR="$share_dir"
+                    export AGI_CLUSTER_SHARE="$share_dir"
                     echo -e "${GREEN}${share_dir} is available. Continuing.${NC}"
                     return 0
                 fi
@@ -335,8 +335,8 @@ ensure_share_dir() {
             local cluster_shadow
             cluster_shadow="$(ensure_distinct_cluster_fallback "$share_dir" "$fallback_dir")"
             mkdir -p "$fallback_dir" || { echo -e "${RED}Failed to create fallback ${fallback_dir}.${NC}"; exit 1; }
-            export AGI_LOCAL_DIR="$fallback_dir"
-            export AGI_SHARE_DIR="$cluster_shadow"
+            export AGI_LOCAL_SHARE="$fallback_dir"
+            export AGI_CLUSTER_SHARE="$cluster_shadow"
             ;;
     esac
 }
@@ -636,8 +636,8 @@ set_locale() {
 
 
 verify_share_dir() {
-    local share_dir="${AGI_SHARE_DIR:-$HOME/$(default_agi_share_dir)}"
-    local local_dir="${AGI_LOCAL_DIR:-}"
+    local share_dir="${AGI_CLUSTER_SHARE:-$HOME/$(default_agi_cluster_share)}"
+    local local_dir="${AGI_LOCAL_SHARE:-}"
     local home_prefix="$HOME/"
     [[ "$share_dir" == "~"* ]] && share_dir="${share_dir/#\~/$HOME}"
 
@@ -646,7 +646,7 @@ verify_share_dir() {
         if [[ -d "$share_dir" ]]; then
             return 0
         fi
-        echo -e "${RED}Local AGI_SHARE_DIR missing:${NC} expected data dir at '$share_dir'."
+        echo -e "${RED}Local AGI_CLUSTER_SHARE missing:${NC} expected data dir at '$share_dir'."
         exit 1
     fi
 
@@ -664,8 +664,8 @@ verify_share_dir() {
         return 0
     fi
 
-    echo -e "${RED}AGI_SHARE_DIR missing:${NC} expected mounted data share at '$share_dir'."
-    echo -e "${YELLOW}Mount your cluster share or export AGI_SHARE_DIR to the correct path, then rerun install.sh.${NC}"
+    echo -e "${RED}AGI_CLUSTER_SHARE missing:${NC} expected mounted data share at '$share_dir'."
+    echo -e "${YELLOW}Mount your cluster share or export AGI_CLUSTER_SHARE to the correct path, then rerun install.sh.${NC}"
     exit 1
 }
 
@@ -845,8 +845,8 @@ update_environment() {
         echo "AGI_PYTHON_VERSION=\"$AGI_PYTHON_VERSION\""
         echo "AGI_PYTHON_FREE_THREADED=\"$AGI_PYTHON_FREE_THREADED\""
         echo "APPS_REPOSITORY=\"$APPS_REPOSITORY\""
-        echo "AGI_CLUSTER_SHARE=\"$AGI_SHARE_DIR\""
-        echo "AGI_LOCAL_SHARE=\"$AGI_LOCAL_DIR\""
+        echo "AGI_CLUSTER_SHARE=\"$AGI_CLUSTER_SHARE\""
+        echo "AGI_LOCAL_SHARE=\"$AGI_LOCAL_SHARE\""
         echo "AGI_INTERNET_ON=\"$AGI_INTERNET_ON\""
         echo "IS_SOURCE_ENV=\"1\""
     } > "$ENV_FILE"
@@ -1170,8 +1170,8 @@ print_dry_run_plan() {
     echo "AGILAB installer dry-run plan"
     echo "install_path: ${AGI_INSTALL_PATH}"
     echo "source: ${SOURCE}"
-    echo "agi_share_dir: ${AGI_SHARE_DIR:-<default clustershare>}"
-    echo "agi_local_dir: ${AGI_LOCAL_DIR:-${DEFAULT_LOCAL_SHARE:-<default localshare>}}"
+    echo "agi_cluster_share: ${AGI_CLUSTER_SHARE:-<default clustershare>}"
+    echo "agi_local_share: ${AGI_LOCAL_SHARE:-${DEFAULT_LOCAL_SHARE:-<default localshare>}}"
     echo "apps_repository: ${APPS_REPOSITORY:-<not set>}"
     echo "install_apps: ${apps_plan}"
     echo "test_root: ${TEST_ROOT_FLAG}"
@@ -1196,7 +1196,7 @@ print_dry_run_plan() {
 }
 
 usage() {
-  echo "Usage: CLUSTER_CREDENTIALS=<user[:password]> OPENAI_API_KEY=<api-key> $0 [--agi-share-dir <path>] [--install-path <path> --apps-repository <path>] [--source local|pypi|testpypi] [--install-apps [app1,app2,...|all|builtin]] [--test-root] [--test-apps|--apps-test] [--test-core]"
+  echo "Usage: CLUSTER_CREDENTIALS=<user[:password]> OPENAI_API_KEY=<api-key> $0 [--agi-cluster-share <path>] [--install-path <path> --apps-repository <path>] [--source local|pypi|testpypi] [--install-apps [app1,app2,...|all|builtin]] [--test-root] [--test-apps|--apps-test] [--test-core]"
   echo "       [--dry-run]       Print the install plan without changing environments or installing dependencies"
   echo "       [--skip-offline]  (or set SKIP_OFFLINE=1)"
   echo "       [--install-local-models gpt-oss,qwen,deepseek,qwen3,qwen3-coder,ministral,phi4-mini]"
@@ -1217,7 +1217,7 @@ done
 
 while [[ "$#" -gt 0 ]]; do
     case $1 in
-        --agi-share-dir)       AGI_SHARE_DIR="$2"; shift 2;;
+        --agi-cluster-share)       AGI_CLUSTER_SHARE="$2"; shift 2;;
         --install-path)
             if (( DRY_RUN )); then
                 AGI_INSTALL_PATH="$(resolve_cli_path_arg "$2")"
@@ -1303,22 +1303,22 @@ if (( DRY_RUN )); then
     exit 0
 fi
 
-# Confirm or override AGI_SHARE_DIR when interactive (relative paths are resolved under \$HOME)
+# Confirm or override AGI_CLUSTER_SHARE when interactive (relative paths are resolved under \$HOME)
 if [[ -t 0 ]] && (( ! NON_INTERACTIVE )); then
-    read -rp "AGI_SHARE_DIR is '$AGI_SHARE_DIR' (relative paths resolve under \$HOME). Press Enter to accept or type a new path: " share_input
+    read -rp "AGI_CLUSTER_SHARE is '$AGI_CLUSTER_SHARE' (relative paths resolve under \$HOME). Press Enter to accept or type a new path: " share_input
     if [[ -n "$share_input" ]]; then
-        AGI_SHARE_DIR="$share_input"
+        AGI_CLUSTER_SHARE="$share_input"
     fi
 fi
 
 if [[ -t 0 ]] && (( ! NON_INTERACTIVE )); then
-    local_default="${AGI_LOCAL_DIR:-$DEFAULT_LOCAL_SHARE}"
-    read -rp "AGI_LOCAL_DIR fallback is '${local_default}'. Press Enter to accept or type a new path: " local_input
+    local_default="${AGI_LOCAL_SHARE:-$DEFAULT_LOCAL_SHARE}"
+    read -rp "AGI_LOCAL_SHARE fallback is '${local_default}'. Press Enter to accept or type a new path: " local_input
     if [[ -n "$local_input" ]]; then
-        AGI_LOCAL_DIR="$local_input"
+        AGI_LOCAL_SHARE="$local_input"
         DEFAULT_LOCAL_SHARE="$local_input"
     else
-        AGI_LOCAL_DIR="$local_default"
+        AGI_LOCAL_SHARE="$local_default"
         DEFAULT_LOCAL_SHARE="$local_default"
     fi
 fi
@@ -1342,7 +1342,7 @@ find . \( -name "uv.lock" -o -name "dist" -o -name "build" -o -name "*egg-info" 
 
 check_internet
 guard_ephemeral_validation_env
-ensure_share_dir "$AGI_SHARE_DIR" "$AGI_LOCAL_DIR"
+ensure_share_dir "$AGI_CLUSTER_SHARE" "$AGI_LOCAL_SHARE"
 set_locale
 verify_share_dir
 install_dependencies

--- a/src/agilab/about_page/env_editor.py
+++ b/src/agilab/about_page/env_editor.py
@@ -93,7 +93,7 @@ def _resolve_share_dir_path(raw_value: str, *, home_path: Path) -> Path:
     try:
         share_dir = Path(str(raw_value)).expanduser()
     except (TypeError, ValueError) as exc:
-        raise ValueError("AGI_SHARE_DIR is not a valid filesystem path.") from exc
+        raise ValueError("AGI_CLUSTER_SHARE is not a valid filesystem path.") from exc
 
     if not share_dir.is_absolute():
         share_dir = home_path.expanduser() / share_dir
@@ -101,7 +101,7 @@ def _resolve_share_dir_path(raw_value: str, *, home_path: Path) -> Path:
     try:
         return share_dir.resolve(strict=False)
     except (OSError, ValueError) as exc:
-        raise ValueError(f"AGI_SHARE_DIR cannot be resolved: {exc}") from exc
+        raise ValueError(f"AGI_CLUSTER_SHARE cannot be resolved: {exc}") from exc
 
 
 def _refresh_share_dir(env: Any, new_value: str) -> None:
@@ -126,20 +126,20 @@ def _refresh_share_dir(env: Any, new_value: str) -> None:
     try:
         env.data_root = env.ensure_data_root()
     except (AttributeError, OSError, RuntimeError, TypeError, ValueError) as exc:
-        st.warning(f"AGI_SHARE_DIR update saved but data directory is still unreachable: {exc}")
+        st.warning(f"AGI_CLUSTER_SHARE update saved but data directory is still unreachable: {exc}")
 
 
 def _handle_data_root_failure(exc: Exception, *, agi_env_cls: Any) -> bool:
     """Render a recovery UI when the AGI share directory is unavailable."""
     message = str(exc)
-    if "AGI_SHARE_DIR" not in message and "data directory" not in message:
+    if "AGI_CLUSTER_SHARE" not in message and "data directory" not in message:
         return False
 
     agi_env_cls._ensure_defaults()
     current_value = (
         st.session_state.get("agi_share_path_override_input")
-        or agi_env_cls.envars.get("AGI_SHARE_DIR")
-        or os.environ.get("AGI_SHARE_DIR")
+        or agi_env_cls.envars.get("AGI_CLUSTER_SHARE")
+        or os.environ.get("AGI_CLUSTER_SHARE")
         or agi_env_cls.envars.get("AGI_LOCAL_SHARE")
         or ""
     )
@@ -147,7 +147,7 @@ def _handle_data_root_failure(exc: Exception, *, agi_env_cls: Any) -> bool:
 
     st.error(
         "AGILAB cannot reach the configured AGI share directory. "
-        "Mount the expected path or override `AGI_SHARE_DIR` before continuing."
+        "Mount the expected path or override `AGI_CLUSTER_SHARE` before continuing."
     )
     st.code(message)
     st.info(
@@ -161,21 +161,21 @@ def _handle_data_root_failure(exc: Exception, *, agi_env_cls: Any) -> bool:
         st.session_state[key] = str(current_value)
 
     with st.form("agi_share_path_override_form"):
-        st.text_input("New AGI_SHARE_DIR", key=key, help="Provide an absolute or home-relative path")
+        st.text_input("New AGI_CLUSTER_SHARE", key=key, help="Provide an absolute or home-relative path")
         submitted = st.form_submit_button("Save and retry", width="stretch")
 
     if submitted:
         new_value = (st.session_state.get(key) or "").strip()
         if not new_value:
-            st.warning("AGI_SHARE_DIR cannot be empty.")
+            st.warning("AGI_CLUSTER_SHARE cannot be empty.")
         else:
             try:
                 _resolve_share_dir_path(new_value, home_path=Path(agi_env_cls.home_abs))
             except ValueError as share_exc:
                 st.warning(str(share_exc))
                 return True
-            agi_env_cls.set_env_var("AGI_SHARE_DIR", new_value)
-            st.success(f"Saved AGI_SHARE_DIR = {new_value}. Reloading...")
+            agi_env_cls.set_env_var("AGI_CLUSTER_SHARE", new_value)
+            st.success(f"Saved AGI_CLUSTER_SHARE = {new_value}. Reloading...")
             st.session_state["first_run"] = True
             st.rerun()
     return True
@@ -488,8 +488,8 @@ def _render_env_editor(env: Any, help_file: Path | None = None) -> None:
             if CLUSTER_CREDENTIALS_KEY in combined_updates:
                 env.CLUSTER_CREDENTIALS = combined_updates[CLUSTER_CREDENTIALS_KEY]
 
-            new_share = combined_updates.get("AGI_SHARE_DIR")
-            if new_share is not None and new_share.strip() and new_share.strip() != existing_values.get("AGI_SHARE_DIR"):
+            new_share = combined_updates.get("AGI_CLUSTER_SHARE")
+            if new_share is not None and new_share.strip() and new_share.strip() != existing_values.get("AGI_CLUSTER_SHARE"):
                 _refresh_share_dir(env, new_share.strip())
 
             st.session_state["env_editor_feedback"] = "Environment variables updated."

--- a/src/agilab/apps-pages/README.md
+++ b/src/agilab/apps-pages/README.md
@@ -46,7 +46,7 @@ Quick start (dev checkout):
 
 Notes
 - The `--active-app` points to a `*_project` folder (e.g., `src/agilab/apps/builtin/flight_project`).
-- Each page falls back to `AGILAB_APP` env var, then tries a default `flight_project` under the saved `~/.local/share/agilab/.agilab-path` if not provided.
+- Each page falls back to `APP_DEFAULT` env var, then tries a default `flight_project` under the saved `~/.local/share/agilab/.agilab-path` if not provided.
 - Data directory defaults to the app’s export folder (e.g. `~/export/<app>`); adjust in the sidebar if needed.
 - AGILAB Analysis can scaffold new custom page bundles from the same panel:
   - Use **Create** to generate a minimal complete bundle.

--- a/src/agilab/apps-pages/view_inference_analysis/src/view_inference_analysis/view_inference_analysis.py
+++ b/src/agilab/apps-pages/view_inference_analysis/src/view_inference_analysis/view_inference_analysis.py
@@ -60,7 +60,7 @@ HEATMAP_MAX_COLUMNS = 2
 BEARER_MAX_COLUMNS = 3
 HEATMAP_GRID_COLOR = "rgba(217, 222, 231, 0.35)"
 
-BASE_CHOICES = ("AGI_SHARE_DIR", "AGILAB_EXPORT", "Custom")
+BASE_CHOICES = ("AGI_CLUSTER_SHARE", "AGILAB_EXPORT", "Custom")
 AGGREGATIONS = ("mean", "sum", "median", "min", "max", "std", "count")
 STEP_AXIS_CANDIDATES = ("time_index", "decision", "step", "time_idx")
 TIME_AXIS_CANDIDATES = ("t_now_s", "time_s", "time", "t")
@@ -213,7 +213,7 @@ def _default_dataset_subpath(env: AgiEnv, active_app_path: Path) -> str:
 
 
 def _resolve_base_path(env: AgiEnv, base_choice: str, custom_base: str) -> Path | None:
-    if base_choice == "AGI_SHARE_DIR":
+    if base_choice == "AGI_CLUSTER_SHARE":
         return Path(env.share_root_path())
     if base_choice == "AGILAB_EXPORT":
         path = Path(env.AGILAB_EXPORT_ABS)
@@ -1348,9 +1348,9 @@ def main() -> None:
         st.session_state[ENV_KEY] = env
 
     page_defaults = _get_page_defaults(env)
-    default_base_choice = str(page_defaults.get("dataset_base_choice") or "AGI_SHARE_DIR")
+    default_base_choice = str(page_defaults.get("dataset_base_choice") or "AGI_CLUSTER_SHARE")
     if default_base_choice not in BASE_CHOICES:
-        default_base_choice = "AGI_SHARE_DIR"
+        default_base_choice = "AGI_CLUSTER_SHARE"
     default_custom_base = str(page_defaults.get("dataset_custom_base") or "")
     default_subpath = str(
         page_defaults.get("dataset_subpath") or _default_dataset_subpath(env, active_app_path)
@@ -1400,7 +1400,7 @@ def main() -> None:
     glob_patterns = _coerce_str_list(st.session_state[GLOBS_KEY]) or ["**/allocations_steps.json"]
 
     if dataset_root is None:
-        st.warning("Provide a custom base directory or switch back to AGI_SHARE_DIR / AGILAB_EXPORT.")
+        st.warning("Provide a custom base directory or switch back to AGI_CLUSTER_SHARE / AGILAB_EXPORT.")
         st.stop()
 
     st.info(f"Resolved dataset root: `{dataset_root}`")

--- a/src/agilab/apps-pages/view_maps_network/src/view_maps_network/view_maps_network.py
+++ b/src/agilab/apps-pages/view_maps_network/src/view_maps_network/view_maps_network.py
@@ -3248,7 +3248,7 @@ def page():
     # Data directory + presets (base paths without app suffix)
     export_base = env.AGILAB_EXPORT_ABS
     share_base = env.share_root_path()
-    base_options = ["AGI_SHARE_DIR", "AGILAB_EXPORT", "Custom"]
+    base_options = ["AGI_CLUSTER_SHARE", "AGILAB_EXPORT", "Custom"]
     base_default = qp_base or st.session_state.get("base_dir_choice") or base_seed or "AGILAB_EXPORT"
     if base_default not in base_options:
         base_default = "AGILAB_EXPORT"
@@ -3261,7 +3261,7 @@ def page():
     )
 
     base_path: Path
-    if base_choice == "AGI_SHARE_DIR":  # pragma: no cover - simple UI radio passthrough
+    if base_choice == "AGI_CLUSTER_SHARE":  # pragma: no cover - simple UI radio passthrough
         base_path = share_base
     elif base_choice == "AGILAB_EXPORT":
         base_path = export_base

--- a/src/agilab/apps-pages/view_training_analysis/src/view_training_analysis/view_training_analysis.py
+++ b/src/agilab/apps-pages/view_training_analysis/src/view_training_analysis/view_training_analysis.py
@@ -163,7 +163,7 @@ def _resolve_base_path(
     base_choice: str,
     custom_base: str,
 ) -> Path:
-    if base_choice == "AGI_SHARE_DIR":
+    if base_choice == "AGI_CLUSTER_SHARE":
         return Path(env.share_root_path())
     if base_choice == "AGILAB_EXPORT":
         path = Path(env.AGILAB_EXPORT_ABS)
@@ -435,10 +435,10 @@ def main() -> None:
     page_defaults = _get_page_defaults()
     setting_sources = [page_state, page_defaults]
 
-    base_options = ["AGI_SHARE_DIR", "AGILAB_EXPORT", "Custom"]
+    base_options = ["AGI_CLUSTER_SHARE", "AGILAB_EXPORT", "Custom"]
     base_seed = _get_first_nonempty_setting(setting_sources, "base_dir_choice", "dataset_base_choice")
     if base_seed not in base_options:
-        base_seed = "AGI_SHARE_DIR"
+        base_seed = "AGI_CLUSTER_SHARE"
     custom_seed = _get_first_nonempty_setting(setting_sources, "input_datadir", "dataset_custom_base")
     rel_seed = _get_first_nonempty_setting(setting_sources, "datadir_rel", "dataset_subpath")
 

--- a/src/agilab/apps/builtin/flight_project/src/app_args_form.py
+++ b/src/agilab/apps/builtin/flight_project/src/app_args_form.py
@@ -91,7 +91,7 @@ except Exception:
     share_root = None
 
 st.caption(
-    "Paths are resolved relative to `AGI_SHARE_DIR` (shared storage)."
+    "Paths are resolved relative to `AGI_CLUSTER_SHARE` (shared storage)."
     + (f" Current share root: `{share_root}`." if share_root else "")
     + " This public built-in app runs file-based Flight input only."
 )

--- a/src/agilab/apps/builtin/flight_project/src/app_settings.toml
+++ b/src/agilab/apps/builtin/flight_project/src/app_settings.toml
@@ -70,7 +70,7 @@ excluded_views = [
 ]
 
 [pages.view_maps_network]
-dataset_base_choice = "AGI_SHARE_DIR"
+dataset_base_choice = "AGI_CLUSTER_SHARE"
 dataset_custom_base = ""
 dataset_subpath = "flight/dataframe"
 default_traj_globs = [
@@ -79,7 +79,7 @@ default_traj_globs = [
 ]
 
 [view_maps_network]
-base_dir_choice = "AGI_SHARE_DIR"
+base_dir_choice = "AGI_CLUSTER_SHARE"
 input_datadir = ""
 datadir_rel = "flight/dataframe"
 file_ext_choice = "all"

--- a/src/agilab/apps/install.py
+++ b/src/agilab/apps/install.py
@@ -190,9 +190,9 @@ _seed_app_settings(module)
 
 
 def resolve_share_mount() -> Path:
-    """Return the absolute path that AGI_SHARE_DIR should resolve to."""
+    """Return the absolute path that AGI_CLUSTER_SHARE should resolve to."""
 
-    share_dir_raw = os.environ.get("AGI_SHARE_DIR")
+    share_dir_raw = os.environ.get("AGI_CLUSTER_SHARE")
     share_dir = (
         Path(share_dir_raw)
         if share_dir_raw
@@ -226,7 +226,7 @@ def ensure_data_storage(env: AgiEnv) -> None:
     except FileNotFoundError as exc:
         raise RuntimeError(
             f"Required data directory {data_root} is unavailable. "
-            f"Verify AGI_SHARE_DIR ({share_hint_str}) is mounted before running install."
+            f"Verify AGI_CLUSTER_SHARE ({share_hint_str}) is mounted before running install."
         ) from exc
     except OSError as exc:
         if exc.errno in {
@@ -238,7 +238,7 @@ def ensure_data_storage(env: AgiEnv) -> None:
         }:
             raise RuntimeError(
                 f"Unable to reach data directory {data_root} ({exc.strerror or exc}). "
-                f"Verify AGI_SHARE_DIR ({share_hint_str}) is mounted before running install."
+                f"Verify AGI_CLUSTER_SHARE ({share_hint_str}) is mounted before running install."
             ) from exc
         raise
 
@@ -316,11 +316,11 @@ async def main():
             if any(token in str(err) for token in share_error_tokens):
                 resolved_share = resolve_share_mount()
                 share_label = os.environ.get(
-                    "AGI_SHARE_DIR",
+                    "AGI_CLUSTER_SHARE",
                     default_cluster_share(environ=os.environ),
                 )
                 print(
-                    "[ERROR] AGI_SHARE_DIR '%s' is not mounted (expected path: %s). "
+                    "[ERROR] AGI_CLUSTER_SHARE '%s' is not mounted (expected path: %s). "
                     "Mount the share before running install."
                     % (share_label, resolved_share),
                     file=sys.stderr,

--- a/src/agilab/core/agi-env/src/agi_env/runtime_bootstrap_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/runtime_bootstrap_support.py
@@ -117,7 +117,7 @@ def resolve_share_runtime_config(
         or default_cluster_share(environ=environ)
     )
 
-    share_dir_override = clean_envar_value_fn(envars, "AGI_SHARE_DIR", fallback_to_process=True)
+    share_dir_override = clean_envar_value_fn(envars, "AGI_CLUSTER_SHARE", fallback_to_process=True)
     if share_dir_override is not None:
         cluster_share = share_dir_override
         try:

--- a/src/agilab/core/agi-env/test/test_agi_env.py
+++ b/src/agilab/core/agi-env/test/test_agi_env.py
@@ -29,7 +29,6 @@ _AGIENV_PROCESS_ENV_KEYS = {
     "AGI_EXPORT_DIR",
     "AGI_LOCAL_SHARE",
     "AGI_LOG_DIR",
-    "AGI_SHARE_DIR",
     "AGILAB_SHARE_USER",
     "APP_DEFAULT",
     "APPS_PATH",
@@ -351,7 +350,6 @@ def test_user_workspace_app_settings_override_source_cluster_toggle(tmp_path: Pa
 
     monkeypatch.setenv("HOME", str(fake_home))
     monkeypatch.delenv("AGI_CLUSTER_SHARE", raising=False)
-    monkeypatch.delenv("AGI_SHARE_DIR", raising=False)
 
     fake_apps = tmp_path / "apps"
     fake_app = fake_apps / "mycode_project"
@@ -382,7 +380,6 @@ def test_cluster_share_missing_raises_for_cluster_enabled_app(tmp_path: Path, mo
         "AGI_CLUSTER_ENABLED=1\nAGI_CLUSTER_SHARE=/nonexistent_cluster_share\n"
     )
     monkeypatch.delenv("AGI_CLUSTER_SHARE", raising=False)
-    monkeypatch.delenv("AGI_SHARE_DIR", raising=False)
     share_dir = fake_home / ".local" / "share" / "agilab"
     share_dir.mkdir(parents=True, exist_ok=True)
     (share_dir / ".agilab-path").write_text(str(agipath) + "\n")
@@ -427,7 +424,6 @@ def test_cluster_enabled_raises_when_app_src_invalid(tmp_path: Path, monkeypatch
     )
     monkeypatch.setenv("HOME", str(fake_home))
     monkeypatch.delenv("AGI_CLUSTER_SHARE", raising=False)
-    monkeypatch.delenv("AGI_SHARE_DIR", raising=False)
 
     # Create an app with an unusable `src` entry to mimic a transient broken path
     # during local build steps (e.g. pre-Cython local compilation).
@@ -461,7 +457,6 @@ def test_cluster_enabled_from_process_env_when_app_src_invalid(tmp_path: Path, m
     monkeypatch.setenv("AGI_CLUSTER_SHARE", str(share_dir / "cluster_shared"))
     (share_dir / "cluster_shared").mkdir(exist_ok=True, parents=True)
 
-    monkeypatch.delenv("AGI_SHARE_DIR", raising=False)
     fake_apps = tmp_path / "apps"
     bad_app = fake_apps / "broken_project"
     bad_app.mkdir(parents=True, exist_ok=True)
@@ -496,7 +491,7 @@ def test_cluster_share_same_as_local_share_raises(tmp_path: Path, monkeypatch):
     )
 
     monkeypatch.setenv("HOME", str(fake_home))
-    monkeypatch.delenv("AGI_SHARE_DIR", raising=False)
+    monkeypatch.delenv("AGI_CLUSTER_SHARE", raising=False)
 
     fake_apps = tmp_path / "apps"
     fake_app = fake_apps / app_name
@@ -2345,7 +2340,7 @@ def test_share_root_resolution_worker_uses_runtime_home_and_init_honours_share_o
     (share_dir / ".agilab-path").write_text(str(agipath) + "\n", encoding="utf-8")
     (fake_home / ".agilab").mkdir(parents=True, exist_ok=True)
     (fake_home / ".agilab" / ".env").write_text(
-        "AGI_SHARE_DIR=cluster_mount\nSTREAMLIT_SERVER_MAX_MESSAGE_SIZE=256\nIS_SOURCE_ENV=yes\n",
+        "AGI_CLUSTER_SHARE=cluster_mount\nSTREAMLIT_SERVER_MAX_MESSAGE_SIZE=256\nIS_SOURCE_ENV=yes\n",
         encoding="utf-8",
     )
 

--- a/src/agilab/core/agi-env/test/test_runtime_bootstrap_support.py
+++ b/src/agilab/core/agi-env/test/test_runtime_bootstrap_support.py
@@ -282,7 +282,7 @@ def test_sync_repository_apps_skips_probe_errors_and_logs_created_symlink(tmp_pa
 
 
 def test_resolve_share_runtime_config_applies_share_dir_override(tmp_path):
-    envars = {"AGI_SHARE_DIR": "cluster_mount"}
+    envars = {"AGI_CLUSTER_SHARE": "cluster_mount"}
 
     result = resolve_share_runtime_config(
         envars=envars,
@@ -309,7 +309,7 @@ def test_resolve_share_runtime_config_ignores_unsettable_override(tmp_path):
             raise TypeError("immutable")
 
     result = resolve_share_runtime_config(
-        envars=_BrokenEnvars({"AGI_SHARE_DIR": "cluster_mount"}),
+        envars=_BrokenEnvars({"AGI_CLUSTER_SHARE": "cluster_mount"}),
         environ={"AGI_LOCAL_SHARE": "local", "AGI_CLUSTER_SHARE": "cluster"},
         is_worker_env=False,
         resolve_workspace_settings_fn=lambda: None,

--- a/src/agilab/orchestrate_cluster.py
+++ b/src/agilab/orchestrate_cluster.py
@@ -129,7 +129,7 @@ def persist_env_var_if_changed(
 def _describe_share_path(env: Any) -> str:
     share_raw = env.agi_share_path
     if not share_raw:
-        return "not set. Set `AGI_SHARE_DIR` to a shared mount (or symlink to one) so remote workers can read outputs."
+        return "not set. Set `AGI_CLUSTER_SHARE` to a shared mount (or symlink to one) so remote workers can read outputs."
 
     share_display = str(share_raw)
     resolved_display: Optional[Path] = None
@@ -286,7 +286,7 @@ def _env_cluster_share_setting(env: Any) -> str | None:
     raw_value = getattr(env, "AGI_CLUSTER_SHARE", None)
     envars = getattr(env, "envars", None)
     if not raw_value and isinstance(envars, dict):
-        raw_value = envars.get("AGI_CLUSTER_SHARE") or envars.get("AGI_SHARE_DIR")
+        raw_value = envars.get("AGI_CLUSTER_SHARE")
     if not raw_value:
         raw_value = getattr(env, "agi_share_path", None)
     if not raw_value:

--- a/src/agilab/pages/2_ORCHESTRATE.py
+++ b/src/agilab/pages/2_ORCHESTRATE.py
@@ -505,7 +505,6 @@ class _ShareRootOverrideEnv:
         env_vars = getattr(self._env, "envars", None)
         payload = dict(env_vars) if isinstance(env_vars, dict) else {}
         payload["AGI_CLUSTER_SHARE"] = str(self._share_root)
-        payload["AGI_SHARE_DIR"] = str(self._share_root)
         return payload
 
     def share_root_path(self) -> Path:
@@ -589,8 +588,8 @@ def _cluster_args_share_warning(env: Any, cluster_params: dict[str, Any]) -> str
         f"Cluster is enabled but the data directory `{share_resolved}` appears local. "
         f"(detected fstype: `{fstype}`) "
         "Set `AGI_CLUSTER_SHARE` to the scheduler-side source path and `Workers Data Path` "
-        "to the worker-side SSHFS/shared mount target, "
-        "or set `AGI_SHARE_DIR` to a shared mount/symlink when not using the cluster-share contract."
+        "to the worker-side SSHFS/shared mount target, or point `AGI_CLUSTER_SHARE` "
+        "at a shared mount/symlink when not using the SSHFS cluster-share contract."
         f"{extra}"
     )
 

--- a/src/agilab/pages/4_ANALYSIS.py
+++ b/src/agilab/pages/4_ANALYSIS.py
@@ -635,7 +635,7 @@ def _initialize_analysis_env(requested_app: str | None) -> AgiEnv:
         active_app_path = _resolve_app_path(apps_path, st.session_state.get("app"))
 
     if active_app_path is None:
-        active_app_path = _resolve_app_path(apps_path, os.environ.get("AGILAB_APP"))
+        active_app_path = _resolve_app_path(apps_path, os.environ.get("APP_DEFAULT"))
 
     if active_app_path is None:
         last_app = load_last_active_app()
@@ -647,7 +647,7 @@ def _initialize_analysis_env(requested_app: str | None) -> AgiEnv:
 
     if active_app_path is None:
         st.error(
-            "Could not determine the active project. Please select a project first or set AGILAB_APP."
+            "Could not determine the active project. Please select a project first or set APP_DEFAULT."
         )
         st.stop()
 

--- a/src/agilab/pipeline_openai.py
+++ b/src/agilab/pipeline_openai.py
@@ -133,7 +133,6 @@ def make_openai_client_and_model(envars: Dict[str, str], api_key: str):
     base_url = (
         envars.get("OPENAI_BASE_URL")
         or os.getenv("OPENAI_BASE_URL")
-        or os.getenv("OPENAI_API_BASE")
         or ""
     )
     azure_endpoint = (

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -69,7 +69,6 @@ def isolate_home_for_root_tests(tmp_path, monkeypatch):
     monkeypatch.setenv("HOME", str(fake_home))
     monkeypatch.delenv("AGI_CLUSTER_ENABLED", raising=False)
     monkeypatch.delenv("AGI_CLUSTER_SHARE", raising=False)
-    monkeypatch.delenv("AGI_SHARE_DIR", raising=False)
     monkeypatch.delenv("APPS_REPOSITORY", raising=False)
     monkeypatch.delenv("APP_DEFAULT", raising=False)
     # Root tests must not inherit developer-shell secrets. Individual tests that

--- a/test/test_about_agilab_helpers.py
+++ b/test/test_about_agilab_helpers.py
@@ -1329,7 +1329,7 @@ def test_resolve_share_dir_path_accepts_relative_value(tmp_path):
 
 
 def test_resolve_share_dir_path_rejects_invalid_value(tmp_path):
-    with pytest.raises(ValueError, match="AGI_SHARE_DIR"):
+    with pytest.raises(ValueError, match="AGI_CLUSTER_SHARE"):
         about_agilab._resolve_share_dir_path("\0bad-path", home_path=tmp_path)
 
 

--- a/test/test_env_contract_aliases.py
+++ b/test/test_env_contract_aliases.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+THIS_FILE = Path(__file__).resolve()
+SCAN_TARGETS = (
+    "install.sh",
+    "install.ps1",
+    "README.md",
+    "AGENTS.md",
+    "src",
+    "tools",
+    "test",
+    "docs/source",
+    ".claude/skills",
+    ".codex/skills",
+)
+RETIRED_ENV_SURFACES = (
+    "AGI_LOCAL_DIR",
+    "AGI_SHARE_DIR",
+    "OPENAI_API_BASE",
+    "AGILAB_APP",
+    "AGI_ROOT",
+    "--agi-share-dir",
+    "AgiShareDir",
+    "AgiLocalDir",
+)
+
+
+def _iter_text_files(root: Path):
+    if root.is_file():
+        yield root
+        return
+    for path in sorted(root.rglob("*")):
+        if path == THIS_FILE or not path.is_file():
+            continue
+        if any(part in {".git", ".venv", "build", "__pycache__", ".pytest_cache"} for part in path.parts):
+            continue
+        yield path
+
+
+def test_retired_environment_aliases_do_not_reappear() -> None:
+    findings: list[str] = []
+    for target in SCAN_TARGETS:
+        root = REPO_ROOT / target
+        if not root.exists():
+            continue
+        for path in _iter_text_files(root):
+            try:
+                text = path.read_text(encoding="utf-8")
+            except UnicodeDecodeError:
+                continue
+            for retired in RETIRED_ENV_SURFACES:
+                if retired in text:
+                    findings.append(f"{path.relative_to(REPO_ROOT)}: contains {retired}")
+
+    assert findings == []

--- a/test/test_install_local_models.py
+++ b/test/test_install_local_models.py
@@ -108,14 +108,14 @@ def test_root_installer_default_share_dir_is_user_scoped() -> None:
     script_text = INSTALL_SH.read_text(encoding="utf-8")
     function_body = "\n".join(
         [
-            _extract_function(script_text, "default_agi_share_user", "default_agi_share_dir"),
-            _extract_function(script_text, "default_agi_share_dir"),
+            _extract_function(script_text, "default_agi_share_user", "default_agi_cluster_share"),
+            _extract_function(script_text, "default_agi_cluster_share"),
         ]
     )
     bash_script = f"""#!/usr/bin/env bash
 set -euo pipefail
 {function_body}
-USER='alice@example.com' default_agi_share_dir
+USER='alice@example.com' default_agi_cluster_share
 """
     completed = subprocess.run(
         ["bash", "-c", bash_script],
@@ -125,7 +125,7 @@ USER='alice@example.com' default_agi_share_dir
     )
 
     assert completed.stdout.strip() == "clustershare/alice_example.com"
-    assert 'AGI_SHARE_DIR="${AGI_SHARE_DIR:-clustershare}"' not in script_text
+    assert 'AGI_CLUSTER_SHARE="${AGI_CLUSTER_SHARE:-clustershare}"' not in script_text
 
 
 def test_root_installer_refuses_ephemeral_validation_paths_with_real_home() -> None:
@@ -143,8 +143,8 @@ YELLOW=''
 NC=''
 HOME=/home/agilab-user
 AGI_INSTALL_PATH=/home/agilab-user/agilab-release-check-demo/agilab
-AGI_SHARE_DIR=/home/agilab-user/agilab-release-check-demo/agilab/clustershare
-AGI_LOCAL_DIR=/home/agilab-user/agilab-release-check-demo/agilab/localshare
+AGI_CLUSTER_SHARE=/home/agilab-user/agilab-release-check-demo/agilab/clustershare
+AGI_LOCAL_SHARE=/home/agilab-user/agilab-release-check-demo/agilab/localshare
 {function_body}
 guard_ephemeral_validation_env
 """
@@ -173,8 +173,8 @@ YELLOW=''
 NC=''
 HOME=/home/agilab-user/agilab-release-check-demo/home
 AGI_INSTALL_PATH=/home/agilab-user/agilab-release-check-demo/agilab
-AGI_SHARE_DIR=/home/agilab-user/agilab-release-check-demo/agilab/clustershare
-AGI_LOCAL_DIR=/home/agilab-user/agilab-release-check-demo/agilab/localshare
+AGI_CLUSTER_SHARE=/home/agilab-user/agilab-release-check-demo/agilab/clustershare
+AGI_LOCAL_SHARE=/home/agilab-user/agilab-release-check-demo/agilab/localshare
 {function_body}
 guard_ephemeral_validation_env
 """
@@ -193,7 +193,7 @@ def test_app_installer_uses_same_user_scoped_share_default() -> None:
 
     assert "from agi_env.runtime_bootstrap_support import default_cluster_share" in apps_install_text
     assert "Path(default_cluster_share(environ=os.environ))" in apps_install_text
-    assert 'os.environ.get("AGI_SHARE_DIR",default_cluster_share(environ=os.environ),' in compact_text
+    assert 'os.environ.get("AGI_CLUSTER_SHARE",default_cluster_share(environ=os.environ),' in compact_text
 
 
 def test_enduser_installer_normalizes_requested_local_models_and_deduplicates_aliases() -> None:

--- a/test/test_ui_pages.py
+++ b/test/test_ui_pages.py
@@ -368,9 +368,9 @@ def load_args_from_toml(path):
     # Patch sys.argv and env variables
     with patch("sys.argv", test_argv):
         with patch.dict(os.environ, {
-            "AGILAB_APP": "flight_project",
+            "APP_DEFAULT": "flight_project",
             "AGILAB_DISABLE_BACKGROUND_SERVICES": "1",
-            "AGI_SHARE_DIR": str(tmp_path),
+            "AGI_CLUSTER_SHARE": str(tmp_path),
             "AGI_EXPORT_DIR": str(export_dir),
             "AGI_LOG_DIR": str(log_dir),
             "AGI_LOCAL_SHARE": str(local_share_dir),

--- a/test/test_view_inference_analysis.py
+++ b/test/test_view_inference_analysis.py
@@ -323,7 +323,7 @@ def test_view_inference_analysis_loads_page_defaults_from_app_settings(tmp_path:
     settings_path.write_text(
         f"""
 [pages.{module.PAGE_KEY}]
-base_choice = "AGI_SHARE_DIR"
+base_choice = "AGI_CLUSTER_SHARE"
 selected_files = ["allocations/run_a.csv"]
 """,
         encoding="utf-8",
@@ -333,9 +333,9 @@ selected_files = ["allocations/run_a.csv"]
     payload = module._load_app_settings(env)
     defaults = module._get_page_defaults(env)
 
-    assert payload["pages"][module.PAGE_KEY]["base_choice"] == "AGI_SHARE_DIR"
+    assert payload["pages"][module.PAGE_KEY]["base_choice"] == "AGI_CLUSTER_SHARE"
     assert defaults == {
-        "base_choice": "AGI_SHARE_DIR",
+        "base_choice": "AGI_CLUSTER_SHARE",
         "selected_files": ["allocations/run_a.csv"],
     }
 
@@ -410,7 +410,7 @@ def test_view_inference_analysis_coerces_string_lists_and_resolves_dataset_paths
 
     env.target = ""
     assert module._default_dataset_subpath(env, tmp_path / "demo_project") == "demo/pipeline"
-    assert module._resolve_base_path(env, "AGI_SHARE_DIR", "") == share_root
+    assert module._resolve_base_path(env, "AGI_CLUSTER_SHARE", "") == share_root
     assert module._resolve_base_path(env, "AGILAB_EXPORT", "") == export_root
     assert export_root.exists()
     assert module._resolve_base_path(env, "custom", str(custom_root)) == custom_root

--- a/test/test_view_maps_network.py
+++ b/test/test_view_maps_network.py
@@ -101,7 +101,7 @@ def test_view_maps_network_reads_builtin_flight_page_defaults(monkeypatch, tmp_p
     module.st = SimpleNamespace(session_state={"app_settings": app_settings})
     settings = module._get_view_maps_page_settings()
 
-    assert settings["dataset_base_choice"] == "AGI_SHARE_DIR"
+    assert settings["dataset_base_choice"] == "AGI_CLUSTER_SHARE"
     assert settings["dataset_subpath"] == "flight/dataframe"
     assert settings["default_traj_globs"] == [
         "flight/dataframe/*.parquet",
@@ -157,7 +157,7 @@ def test_view_maps_network_persists_app_settings(tmp_path: Path, monkeypatch) ->
         session_state={
             "app_settings": {
                 "view_maps_network": {
-                    "dataset_base_choice": "AGI_SHARE_DIR",
+                    "dataset_base_choice": "AGI_CLUSTER_SHARE",
                     "df_file": None,
                     "df_files": ["export.csv", None],
                 }
@@ -169,7 +169,7 @@ def test_view_maps_network_persists_app_settings(tmp_path: Path, monkeypatch) ->
 
     written = settings_path.read_text(encoding="utf-8")
     assert "view_maps_network" in written
-    assert 'dataset_base_choice = "AGI_SHARE_DIR"' in written
+    assert 'dataset_base_choice = "AGI_CLUSTER_SHARE"' in written
     parsed = tomllib.loads(written)
     assert parsed["__meta__"] == {"schema": "agilab.app_settings.v1", "version": 1}
     assert parsed["view_maps_network"]["df_file"] == ""
@@ -1122,7 +1122,7 @@ def test_view_maps_network_unexpected_helper_errors_propagate(monkeypatch, tmp_p
     settings_path = tmp_path / "app_settings.toml"
     settings_path.write_text(
         "[view_maps_network]\n"
-        'dataset_base_choice = "AGI_SHARE_DIR"\n',
+        'dataset_base_choice = "AGI_CLUSTER_SHARE"\n',
         encoding="utf-8",
     )
 

--- a/test/test_view_training_analysis.py
+++ b/test/test_view_training_analysis.py
@@ -227,7 +227,7 @@ def test_view_training_analysis_normalizes_page_settings_and_paths(tmp_path: Pat
     share_dir = tmp_path / "share"
     export_dir = tmp_path / "export"
     env = SimpleNamespace(share_root_path=lambda: str(share_dir), AGILAB_EXPORT_ABS=str(export_dir))
-    assert module._resolve_base_path(env, "AGI_SHARE_DIR", "").resolve() == share_dir.resolve()
+    assert module._resolve_base_path(env, "AGI_CLUSTER_SHARE", "").resolve() == share_dir.resolve()
     assert module._resolve_base_path(env, "AGILAB_EXPORT", "").resolve() == export_dir.resolve()
     assert module._resolve_base_path(env, "CUSTOM", "~/custom-root") == Path("~/custom-root").expanduser()
 
@@ -514,7 +514,7 @@ def test_view_training_analysis_main_bootstraps_env_when_missing(monkeypatch, tm
         module.main()
 
     assert module.st.session_state["env"].app == "trainer_project"
-    assert module.st.session_state["base_dir_choice"] == "AGI_SHARE_DIR"
+    assert module.st.session_state["base_dir_choice"] == "AGI_CLUSTER_SHARE"
     assert module.st.session_state["input_datadir"] == ""
     assert module.st.session_state["datadir_rel"] == ""
     assert module.st.session_state[module.X_AXIS_KEY] == "step"

--- a/tools/regression_fresh_install.py
+++ b/tools/regression_fresh_install.py
@@ -119,7 +119,7 @@ def main() -> int:
     env.update(
         {
             "HOME": str(home_dir),
-            "AGI_SHARE_DIR": str(share_dir),
+            "AGI_CLUSTER_SHARE": str(share_dir),
             "AGILAB_DISABLE_BACKGROUND_SERVICES": "1",
             "OPENAI_API_KEY": "sk-test-fresh-install-000000000000",
             "CLUSTER_CREDENTIALS": "user:password",

--- a/tools/service_health_check.py
+++ b/tools/service_health_check.py
@@ -41,7 +41,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--health-output-path",
         default="",
-        help="Optional output path for health JSON (absolute or AGI_SHARE_DIR-relative).",
+        help="Optional output path for health JSON (absolute or AGI_CLUSTER_SHARE-relative).",
     )
     parser.add_argument(
         "--allow-idle",


### PR DESCRIPTION
## Summary
- Standardize runtime/install/docs/UI surfaces on AGI_CLUSTER_SHARE, AGI_LOCAL_SHARE, APP_DEFAULT, and OPENAI_BASE_URL.
- Remove retired alias reads/writes: AGI_SHARE_DIR, AGI_LOCAL_DIR, AGILAB_APP, OPENAI_API_BASE, AGI_ROOT, and --agi-share-dir.
- Add a regression guard so retired env aliases cannot reappear in source, docs, tools, tests, or repo-managed skills.

## Validation
- bash -n install.sh src/agilab/install_apps.sh
- PowerShell Parser.ParseFile install.ps1
- python3 tools/sync_agent_skills.py --skills agilab-installer agilab-testing
- python3 tools/codex_skills.py --root .codex/skills validate --strict
- python3 tools/codex_skills.py --root .codex/skills generate
- uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile skills
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile installer --app-path src/agilab/apps/builtin/flight_project --worker-copy src/agilab/apps/builtin/flight_project/src/flight_worker
- uv --preview-features extra-build-dependencies run --no-sync pytest -q src/agilab/core/agi-env/test
- uv --preview-features extra-build-dependencies run pytest -q -o addopts= test/test_cluster_flight_validation.py test/test_cluster_lan_discovery.py test/test_install_apps_discovery.py test/test_install_contract_check.py test/test_install_local_models.py test/test_install_release_proof_package.py test/test_orchestrate_cluster.py test/test_ui_pages.py test/test_pipeline_openai.py test/test_pipeline_openai_compatible.py test/test_env_contract_aliases.py test/test_service_health_check.py test/test_about_agilab_helpers.py test/test_view_inference_analysis.py test/test_view_maps_network.py test/test_view_training_analysis.py
- uv sync --project src/agilab/apps/builtin/flight_project
- AGILAB_DISABLE_BACKGROUND_SERVICES=1 uv --preview-features extra-build-dependencies run python src/agilab/apps/install.py src/agilab/apps/builtin/flight_project --verbose 1
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-env
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui
- uv --preview-features extra-build-dependencies run python tools/coverage_badge_guard.py --changed-only --require-fresh-xml
- rg no-ignore retired-alias sweep