### PR TITLE
Add opt-in UI robot matrix workflow

### DIFF
--- a/.github/workflows/ui-robot-matrix.yml
+++ b/.github/workflows/ui-robot-matrix.yml
@@ -1,0 +1,173 @@
+name: ui-robot-matrix
+
+on:
+  workflow_dispatch:
+    inputs:
+      apps:
+        description: "Built-in apps to sweep: all or comma-separated app names."
+        required: false
+        default: "all"
+      timeout:
+        description: "Per-widget timeout in seconds."
+        required: false
+        default: "90"
+      widget_timeout:
+        description: "Low-level widget action timeout in seconds."
+        required: false
+        default: "3"
+  schedule:
+    - cron: "43 2 * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ui-robot-matrix-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  all-builtin-isolated-core-pages:
+    runs-on: ubuntu-latest
+    timeout-minutes: 70
+    env:
+      AGILAB_DISABLE_BACKGROUND_SERVICES: "1"
+      OPENAI_API_KEY: "sk-test-ui-robot-000000000000"
+      PYTHONUNBUFFERED: "1"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.13"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
+        with:
+          version: "0.10.7"
+
+      - name: Install Playwright browser
+        run: |
+          set -euo pipefail
+          uv --preview-features extra-build-dependencies run --with playwright python -m playwright install --with-deps chromium
+
+      - name: Run all-builtin UI robot matrix
+        env:
+          INPUT_APPS: ${{ github.event.inputs.apps }}
+          INPUT_TIMEOUT: ${{ github.event.inputs.timeout }}
+          INPUT_WIDGET_TIMEOUT: ${{ github.event.inputs.widget_timeout }}
+        run: |
+          set -euo pipefail
+          mkdir -p test-results/ui-robot-matrix screenshots/ui-robot-matrix
+          robot_apps="${INPUT_APPS:-all}"
+          robot_timeout="${INPUT_TIMEOUT:-90}"
+          robot_widget_timeout="${INPUT_WIDGET_TIMEOUT:-3}"
+          set +e
+          uv --preview-features extra-build-dependencies run --with playwright python tools/agilab_widget_robot_matrix.py \
+            --scenario isolated-core-pages \
+            --apps "${robot_apps}" \
+            --timeout "${robot_timeout}" \
+            --widget-timeout "${robot_widget_timeout}" \
+            --json \
+            --quiet-progress \
+            --output-dir test-results/ui-robot-matrix \
+            --screenshot-dir screenshots/ui-robot-matrix \
+            | tee test-results/ui-robot-matrix/summary.json
+          status="${PIPESTATUS[0]}"
+          set -e
+          echo "${status}" > test-results/ui-robot-matrix/exit-code.txt
+          exit "${status}"
+
+      - name: Summarize UI robot matrix
+        if: always()
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          summary_path = Path("test-results/ui-robot-matrix/summary.json")
+          summary_file = Path(os.environ["GITHUB_STEP_SUMMARY"])
+
+          def cell(value: object, *, limit: int = 200) -> str:
+              text = str(value if value is not None else "")
+              return text.replace("\n", " ").replace("|", "\\|")[:limit]
+
+          lines = ["## UI robot matrix"]
+          if not summary_path.is_file():
+              lines.append("")
+              lines.append("No JSON summary was produced. Check the uploaded progress log and screenshots.")
+          else:
+              try:
+                  summary = json.loads(summary_path.read_text(encoding="utf-8"))
+              except json.JSONDecodeError as exc:
+                  summary = {"success": False, "error": f"invalid JSON summary: {exc}"}
+
+              status = "PASS" if summary.get("success") is True else "FAIL"
+              lines.extend(
+                  [
+                      "",
+                      f"- Status: `{status}`",
+                      f"- Pages: `{summary.get('page_count', 0)}`",
+                      f"- Widgets: `{summary.get('widget_count', 0)}`",
+                      f"- Interacted: `{summary.get('interacted_count', 0)}`",
+                      f"- Probed: `{summary.get('probed_count', 0)}`",
+                      f"- Failed: `{summary.get('failed_count', 0)}`",
+                      "",
+                      "| Scenario | Status | Pages | Widgets | Interacted | Probed | Failed | Duration s |",
+                      "|---|---:|---:|---:|---:|---:|---:|---:|",
+                  ]
+              )
+              for scenario in summary.get("scenarios") or []:
+                  scenario_status = "PASS" if scenario.get("success") is True else "FAIL"
+                  lines.append(
+                      "| "
+                      + " | ".join(
+                          [
+                              cell(scenario.get("name")),
+                              scenario_status,
+                              cell(scenario.get("page_count", 0)),
+                              cell(scenario.get("widget_count", 0)),
+                              cell(scenario.get("interacted_count", 0)),
+                              cell(scenario.get("probed_count", 0)),
+                              cell(scenario.get("failed_count", 0)),
+                              cell(f"{float(scenario.get('duration_seconds') or 0):.1f}"),
+                          ]
+                      )
+                      + " |"
+                  )
+
+              samples = summary.get("failure_samples") or []
+              lines.append("")
+              lines.append("### Failure Samples")
+              if samples:
+                  for sample in samples[:20]:
+                      lines.append(
+                          "- "
+                          f"`{cell(sample.get('scenario'))}` "
+                          f"`{cell(sample.get('app'))}` "
+                          f"`{cell(sample.get('page'))}` "
+                          f"`{cell(sample.get('kind'))}` "
+                          f"`{cell(sample.get('label'))}`: "
+                          f"{cell(sample.get('detail'), limit=400)}"
+                      )
+              else:
+                  lines.append("No failure samples recorded.")
+
+          with summary_file.open("a", encoding="utf-8") as fh:
+              fh.write("\n".join(lines))
+              fh.write("\n")
+          PY
+
+      - name: Upload UI robot artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        if: always()
+        with:
+          name: ui-robot-matrix-${{ github.run_attempt }}
+          path: |
+            test-results/ui-robot-matrix/**
+            screenshots/ui-robot-matrix/**
+          if-no-files-found: ignore
+          retention-days: 14

--- a/test/test_agilab_widget_robot_matrix.py
+++ b/test/test_agilab_widget_robot_matrix.py
@@ -55,6 +55,7 @@ def test_build_robot_command_contains_scenario_controls(tmp_path) -> None:
     options = module.MatrixOptions(
         apps="flight_project",
         output_dir=tmp_path,
+        screenshot_dir=tmp_path / "screenshots",
         timeout_seconds=12.0,
         widget_timeout_seconds=2.0,
         quiet_progress=True,
@@ -74,6 +75,7 @@ def test_build_robot_command_contains_scenario_controls(tmp_path) -> None:
     assert argv[argv.index("--click-action-labels") + 1] == "CHECK distribute,Run -> Load -> Export"
     assert argv[argv.index("--preselect-labels") + 1] == "Run now"
     assert argv[argv.index("--browser") + 1] == "webkit"
+    assert argv[argv.index("--screenshot-dir") + 1] == str(tmp_path / "screenshots" / "current-home-actions")
     assert "--headful" in argv
     assert "--quiet-progress" in argv
     assert "--no-seed-demo-artifacts" in argv
@@ -89,6 +91,7 @@ def test_build_robot_command_enables_artifact_assertions_for_stateful_journey(tm
     options = module.MatrixOptions(
         apps="flight_project",
         output_dir=tmp_path,
+        screenshot_dir=None,
         timeout_seconds=12.0,
         widget_timeout_seconds=2.0,
         quiet_progress=True,
@@ -106,6 +109,7 @@ def test_build_robot_command_enables_workflow_artifact_assertions_for_core_sweep
     options = module.MatrixOptions(
         apps="flight_project",
         output_dir=tmp_path,
+        screenshot_dir=None,
         timeout_seconds=12.0,
         widget_timeout_seconds=2.0,
         quiet_progress=True,
@@ -123,6 +127,7 @@ def test_run_matrix_aggregates_json_summaries(tmp_path) -> None:
     options = module.MatrixOptions(
         apps="flight_project",
         output_dir=tmp_path,
+        screenshot_dir=None,
         timeout_seconds=10.0,
         widget_timeout_seconds=1.0,
         quiet_progress=True,
@@ -176,6 +181,7 @@ def test_run_matrix_fail_fast_stops_on_first_failed_scenario(tmp_path) -> None:
     options = module.MatrixOptions(
         apps="flight_project",
         output_dir=tmp_path,
+        screenshot_dir=None,
         timeout_seconds=10.0,
         widget_timeout_seconds=1.0,
         quiet_progress=True,

--- a/test/test_ci_workflow.py
+++ b/test/test_ci_workflow.py
@@ -4,6 +4,7 @@ from pathlib import Path
 WORKFLOW_PATH = Path(".github/workflows/ci.yml")
 DOCS_SOURCE_GUARD_WORKFLOW_PATH = Path(".github/workflows/docs-source-guard.yaml")
 DOCS_PUBLISH_WORKFLOW_PATH = Path(".github/workflows/docs-publish.yaml")
+UI_ROBOT_MATRIX_WORKFLOW_PATH = Path(".github/workflows/ui-robot-matrix.yml")
 
 
 def test_ci_workflow_includes_minimal_first_proof_contract() -> None:
@@ -56,3 +57,25 @@ def test_docs_workflows_block_stale_release_proof_github_runs() -> None:
 
     guard_text = DOCS_SOURCE_GUARD_WORKFLOW_PATH.read_text(encoding="utf-8")
     assert "actions: read" in guard_text
+
+
+def test_ui_robot_matrix_workflow_is_opt_in_or_nightly_only() -> None:
+    text = UI_ROBOT_MATRIX_WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    assert "name: ui-robot-matrix" in text
+    assert "workflow_dispatch:" in text
+    assert "schedule:" in text
+    assert "pull_request:" not in text
+    assert "\n  push:" not in text
+    assert "all-builtin-isolated-core-pages:" in text
+    assert "tools/agilab_widget_robot_matrix.py" in text
+    assert "--scenario isolated-core-pages" in text
+    assert "--apps \"${robot_apps}\"" in text
+    assert "--json" in text
+    assert "--quiet-progress" in text
+    assert "--output-dir test-results/ui-robot-matrix" in text
+    assert "--screenshot-dir screenshots/ui-robot-matrix" in text
+    assert "failure_samples" in text
+    assert "GITHUB_STEP_SUMMARY" in text
+    assert "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7" in text
+    assert "AGILAB_DISABLE_BACKGROUND_SERVICES: \"1\"" in text

--- a/test/test_github_actions_node_runtime.py
+++ b/test/test_github_actions_node_runtime.py
@@ -31,6 +31,7 @@ def _workflow_files() -> list[Path]:
 def test_github_actions_use_node24_compatible_major_versions() -> None:
     failures: list[str] = []
     uses_pattern = re.compile(r"uses:\s+([\w.-]+/[\w.-]+)@([^\s#]+)")
+    pinned_sha_pattern = re.compile(r"^[0-9a-f]{40}$")
 
     for workflow in _workflow_files():
         for line_no, line in enumerate(workflow.read_text(encoding="utf-8").splitlines(), start=1):
@@ -41,9 +42,16 @@ def test_github_actions_use_node24_compatible_major_versions() -> None:
             allowed_refs = NODE24_COMPATIBLE_ACTIONS.get(action)
             if allowed_refs is None:
                 continue
-            if ref not in allowed_refs:
+            effective_ref = ref
+            if pinned_sha_pattern.fullmatch(ref):
+                comment_match = re.search(r"#\s*(v\d+)\b", line)
+                if not comment_match:
+                    failures.append(f"{workflow}:{line_no}: {action}@{ref} should include a '# vN' major comment")
+                    continue
+                effective_ref = comment_match.group(1)
+            if effective_ref not in allowed_refs:
                 failures.append(
-                    f"{workflow}:{line_no}: {action}@{ref} should use one of {sorted(allowed_refs)}"
+                    f"{workflow}:{line_no}: {action}@{effective_ref} should use one of {sorted(allowed_refs)}"
                 )
 
     assert failures == []

--- a/test/test_workflow_parity.py
+++ b/test/test_workflow_parity.py
@@ -156,10 +156,12 @@ def test_profile_commands_cover_expected_coverage_and_docs_contracts() -> None:
     assert cloud_emulators[1].argv[-1] == "test/test_data_connector_cloud_emulator_report.py"
     assert ui_robot_matrix.label == "ui robot matrix"
     assert ui_robot_matrix.timeout_seconds == 60 * 60
-    assert ui_robot_matrix.remove_paths == ["test-results/ui-robot-matrix"]
+    assert ui_robot_matrix.remove_paths == ["test-results/ui-robot-matrix", "screenshots/ui-robot-matrix"]
     assert "tools/agilab_widget_robot_matrix.py" in ui_robot_matrix.argv
     assert "--quiet-progress" in ui_robot_matrix.argv
     assert "--json" in ui_robot_matrix.argv
+    assert "--screenshot-dir" in ui_robot_matrix.argv
+    assert "screenshots/ui-robot-matrix" in ui_robot_matrix.argv
     assert _has_with_dependency(ui_robot_matrix.argv, "playwright")
 
 

--- a/tools/agilab_widget_robot_matrix.py
+++ b/tools/agilab_widget_robot_matrix.py
@@ -41,6 +41,7 @@ class RobotScenario:
 class MatrixOptions:
     apps: str
     output_dir: Path
+    screenshot_dir: Path | None
     timeout_seconds: float
     widget_timeout_seconds: float
     quiet_progress: bool
@@ -132,6 +133,7 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--apps", default="all", help="Built-in apps or app paths to pass to the widget robot.")
     parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    parser.add_argument("--screenshot-dir", type=Path, help="Directory for failure screenshots and manifest files.")
     parser.add_argument("--timeout", type=float, default=90.0)
     parser.add_argument("--widget-timeout", type=float, default=3.0)
     parser.add_argument("--browser", choices=("chromium", "firefox", "webkit"), default="chromium")
@@ -165,6 +167,7 @@ def options_from_args(args: argparse.Namespace) -> MatrixOptions:
     return MatrixOptions(
         apps=args.apps,
         output_dir=args.output_dir,
+        screenshot_dir=args.screenshot_dir,
         timeout_seconds=args.timeout,
         widget_timeout_seconds=args.widget_timeout,
         quiet_progress=args.quiet_progress,
@@ -245,6 +248,8 @@ def build_robot_command(
         argv.append("--headful")
     if options.quiet_progress:
         argv.append("--quiet-progress")
+    if options.screenshot_dir is not None:
+        argv.extend(["--screenshot-dir", str(options.screenshot_dir / scenario.name)])
     return argv, summary_path, progress_path
 
 

--- a/tools/workflow_parity.py
+++ b/tools/workflow_parity.py
@@ -803,9 +803,11 @@ def _ui_robot_matrix_profile() -> list[CommandSpec]:
                 "--quiet-progress",
                 "--output-dir",
                 "test-results/ui-robot-matrix",
+                "--screenshot-dir",
+                "screenshots/ui-robot-matrix",
             ],
             timeout_seconds=60 * 60,
-            remove_paths=["test-results/ui-robot-matrix"],
+            remove_paths=["test-results/ui-robot-matrix", "screenshots/ui-robot-matrix"],
         )
     ]
 


### PR DESCRIPTION
## Summary
- Add a manual/nightly `ui-robot-matrix` workflow for the all-builtin isolated core-page robot sweep.
- Upload JSON summary, NDJSON progress logs, exit code, and failure screenshots/manifest artifacts.
- Add workflow guard tests and fix the pinned-action Node major guard so SHA-pinned actions are checked via their `# vN` comments.
- Align local `ui-robot-matrix` workflow parity with screenshot capture.

## Validation
- `uv --preview-features extra-build-dependencies run pytest -q test/test_ci_workflow.py test/test_github_actions_node_runtime.py test/test_agilab_widget_robot_matrix.py test/test_workflow_parity.py`
- `uv --preview-features extra-build-dependencies run --with playwright python tools/agilab_widget_robot_matrix.py --scenario isolated-core-pages --apps flight_project --json --quiet-progress --print-only --output-dir /tmp/agilab-ui-robot-matrix-check --screenshot-dir /tmp/agilab-ui-robot-matrix-shots`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files .github/workflows/ui-robot-matrix.yml tools/agilab_widget_robot_matrix.py tools/workflow_parity.py test/test_ci_workflow.py test/test_github_actions_node_runtime.py test/test_agilab_widget_robot_matrix.py test/test_workflow_parity.py`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui`
- `uv --preview-features extra-build-dependencies run python tools/generate_component_coverage_badges.py --components agi-gui agilab`
- `uv --preview-features extra-build-dependencies run python tools/coverage_badge_guard.py --changed-only --require-fresh-xml`
- `git diff --check`
- workflow YAML parse smoke
