### PR TITLE
[codex] Add UI robot release evidence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,7 @@ jobs:
             tools/install_release_proof_package.py \
             tools/public_proof_scenarios.py \
             tools/release_proof_report.py \
+            tools/ui_robot_evidence.py \
             tools/pypi_publish.py
 
       - name: Validate release proof manifest

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -1,9 +1,9 @@
 {
-  "file_count": 184,
+  "file_count": 185,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "ea2b5eb6c47a91172ba784f36b1595cdd8c262d24e84bf692456f3419dfddf19",
+  "source_digest_sha256": "795ed94beec63dfeb8a6a293baeeff35e326f5e4af92664d81b12ac09f3343c2",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "ea2b5eb6c47a91172ba784f36b1595cdd8c262d24e84bf692456f3419dfddf19"
+  "target_digest_sha256": "795ed94beec63dfeb8a6a293baeeff35e326f5e4af92664d81b12ac09f3343c2"
 }

--- a/docs/source/data/release_proof.toml
+++ b/docs/source/data/release_proof.toml
@@ -6,6 +6,7 @@ intro = [
 proof_bullets = [
   "The public GitHub Actions matrix validated the packaged first proof on Ubuntu, macOS, and Windows runners.",
   "The hosted Hugging Face Space opened the public AGILAB demo route during the release guardrail run.",
+  "The checked-in ``docs/source/data/ui_robot_evidence.json`` records the latest successful all-built-in UI robot matrix sweep, including app/page/widget counts and zero detected UI failures.",
   "The public demo scope includes the lightweight ``flight_project`` and ``meteo_forecast_project`` routes documented in :doc:`agilab-demo`.",
   "The release tag, PyPI package, public documentation, and hosted demo point to the same public product story: browser preview, local first proof, then source-checkout expansion.",
 ]
@@ -80,9 +81,10 @@ follow_up = "Use :doc:`quick-start` when you want the fuller source-checkout pat
 [maintenance]
 intro = "Maintainers can refresh the manifest from local release evidence and GitHub Actions evidence, render the page, and run the same consistency checks with one command:"
 commands = [
+  "uv --preview-features extra-build-dependencies run python tools/ui_robot_evidence.py --compact",
   "uv --preview-features extra-build-dependencies run python tools/release_proof_report.py --refresh-from-local --refresh-from-github --render --check --check-github-runs --compact",
 ]
-follow_up = "Pass ``--github-release-tag``, ``--github-release-url``, ``--hf-space-commit``, or ``--github-head-sha`` only when public evidence changes outside the default local repository and latest successful ``main`` workflow state."
+follow_up = "Pass ``--github-release-tag``, ``--github-release-url``, ``--hf-space-commit``, or ``--github-head-sha`` only when public evidence changes outside the default local repository and latest successful ``main`` workflow state. Use ``tools/ui_robot_evidence.py --run-id <run>`` when the release should pin a specific UI robot evidence run."
 
 [scope]
 paragraph = "This evidence proves the public package smoke, hosted demo availability at the time of validation, and documented first-proof routes. It does not certify every remote cluster topology, every GPU stack, private app repositories, cloud accounts, security posture, or long-running production operations. Those areas remain environment-dependent and are tracked in :doc:`compatibility-matrix`."

--- a/docs/source/data/ui_robot_evidence.json
+++ b/docs/source/data/ui_robot_evidence.json
@@ -1,0 +1,45 @@
+{
+  "artifact": {
+    "archive_download_url": "https://api.github.com/repos/ThalesGroup/agilab/actions/artifacts/6888141795/zip",
+    "exit_code": "0",
+    "expired": false,
+    "matrix_summary_file": "test-results/ui-robot-matrix/summary.json",
+    "name": "ui-robot-matrix-1",
+    "progress_log_bytes": 22794,
+    "progress_log_file": "test-results/ui-robot-matrix/isolated-core-pages.ndjson",
+    "required_files_present": true,
+    "scenario_summary_file": "test-results/ui-robot-matrix/isolated-core-pages.json",
+    "screenshot_count": 0,
+    "size_bytes": 4902
+  },
+  "generated_at": "2026-05-08T20:34:30Z",
+  "result": {
+    "app_count": 10,
+    "failed_count": 0,
+    "failed_scenarios": [],
+    "failure_samples": [],
+    "interacted_count": 348,
+    "page_count": 30,
+    "probed_count": 184,
+    "skipped_count": 0,
+    "status": "pass",
+    "success": true,
+    "total_duration_seconds": 411.5896649649999,
+    "widget_count": 532,
+    "within_target": true
+  },
+  "schema": "agilab.ui_robot_evidence.v1",
+  "source": {
+    "conclusion": "success",
+    "created_at": "2026-05-08T20:18:44Z",
+    "event": "workflow_dispatch",
+    "head_branch": "main",
+    "head_sha": "2a36df530b48ce992fdd1c388d47ab0f46b5239a",
+    "run_attempt": "1",
+    "run_id": "25577485125",
+    "run_url": "https://github.com/ThalesGroup/agilab/actions/runs/25577485125",
+    "status": "completed",
+    "updated_at": "2026-05-08T20:26:55Z",
+    "workflow": "ui-robot-matrix"
+  }
+}

--- a/docs/source/release-proof.rst
+++ b/docs/source/release-proof.rst
@@ -46,6 +46,9 @@ What was proved
   Ubuntu, macOS, and Windows runners.
 - The hosted Hugging Face Space opened the public AGILAB demo route during the
   release guardrail run.
+- The checked-in ``docs/source/data/ui_robot_evidence.json`` records the latest
+  successful all-built-in UI robot matrix sweep, including app/page/widget
+  counts and zero detected UI failures.
 - The public demo scope includes the lightweight ``flight_project`` and
   ``meteo_forecast_project`` routes documented in :doc:`agilab-demo`.
 - The release tag, PyPI package, public documentation, and hosted demo point to
@@ -78,11 +81,14 @@ command:
 
 .. code-block:: bash
 
+   uv --preview-features extra-build-dependencies run python tools/ui_robot_evidence.py --compact
    uv --preview-features extra-build-dependencies run python tools/release_proof_report.py --refresh-from-local --refresh-from-github --render --check --check-github-runs --compact
 
 Pass ``--github-release-tag``, ``--github-release-url``, ``--hf-space-commit``,
 or ``--github-head-sha`` only when public evidence changes outside the default
-local repository and latest successful ``main`` workflow state.
+local repository and latest successful ``main`` workflow state. Use
+``tools/ui_robot_evidence.py --run-id <run>`` when the release should pin a
+specific UI robot evidence run.
 
 Scope and limits
 ----------------

--- a/test/test_ci_workflow.py
+++ b/test/test_ci_workflow.py
@@ -16,6 +16,7 @@ def test_ci_workflow_includes_minimal_first_proof_contract() -> None:
     assert "Validate release proof GitHub run evidence" in text
     assert "GH_TOKEN: ${{ github.token }}" in text
     assert "python tools/release_proof_report.py --check --check-github-runs --compact" in text
+    assert "tools/ui_robot_evidence.py" in text
     assert "Validate first-proof command contract" in text
     assert "python src/agilab/first_proof_cli.py --print-only --json" in text
     assert "Validate public proof scenarios" in text

--- a/test/test_release_proof_report.py
+++ b/test/test_release_proof_report.py
@@ -37,6 +37,7 @@ def test_release_proof_manifest_renders_checked_in_page() -> None:
         "pypi_badge_version",
         "changelog_release",
         "readme_release_proof_link",
+        "ui_robot_evidence",
         "rendered_page",
     }
 
@@ -62,6 +63,7 @@ def test_release_proof_refresh_from_local_updates_manifest_and_page(
     data_dir = docs_source / "data"
     data_dir.mkdir(parents=True)
     shutil.copyfile(Path("docs/source/data/release_proof.toml"), data_dir / "release_proof.toml")
+    shutil.copyfile(Path("docs/source/data/ui_robot_evidence.json"), data_dir / "ui_robot_evidence.json")
 
     exit_code = module.main(
         [
@@ -205,6 +207,80 @@ def test_release_proof_github_run_check_detects_failed_or_stale_runs(monkeypatch
     assert check["status"] == "fail"
     assert "not successful" in " ".join(check["details"]["failures"])
     assert "stale" in " ".join(check["details"]["failures"])
+
+
+def test_release_proof_ui_robot_evidence_check_validates_github_run(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    module = _load_module()
+    ui_robot_evidence = module._load_ui_robot_evidence_module()
+    run = {
+        "attempt": 1,
+        "conclusion": "success",
+        "createdAt": "2026-05-08T20:18:44Z",
+        "databaseId": 25577485125,
+        "event": "workflow_dispatch",
+        "headBranch": "main",
+        "headSha": "abc123",
+        "name": "ui-robot-matrix",
+        "status": "completed",
+        "updatedAt": "2026-05-08T20:26:55Z",
+        "url": "https://github.com/ThalesGroup/agilab/actions/runs/25577485125",
+        "workflowName": "ui-robot-matrix",
+    }
+    evidence = ui_robot_evidence.build_evidence(
+        run=run,
+        artifact={
+            "name": "ui-robot-matrix-1",
+            "expired": False,
+            "size_bytes": 4902,
+            "archive_download_url": "https://api.github.com/repos/ThalesGroup/agilab/actions/artifacts/1/zip",
+        },
+        matrix_summary={
+            "success": True,
+            "failed_count": 0,
+            "failed_scenarios": [],
+            "failure_samples": [],
+        },
+        scenario_summary={
+            "success": True,
+            "app_count": 10,
+            "page_count": 30,
+            "widget_count": 532,
+            "interacted_count": 348,
+            "probed_count": 184,
+            "skipped_count": 0,
+            "failed_count": 0,
+            "total_duration_seconds": 411.6,
+            "within_target": True,
+        },
+        artifact_checks={
+            "required_files_present": True,
+            "exit_code": "0",
+            "progress_log_bytes": 3,
+        },
+        generated_at="2026-05-08T20:30:00Z",
+    )
+    evidence_path = tmp_path / "ui_robot_evidence.json"
+    ui_robot_evidence.write_evidence(evidence_path, evidence)
+
+    def fake_gh_json(args):
+        assert args[:2] == ["run", "view"]
+        return run
+
+    monkeypatch.setattr(module, "_run_gh_json", fake_gh_json)
+
+    check = module._ui_robot_evidence_check(
+        evidence_path,
+        repo_root=Path.cwd(),
+        github_repo="ThalesGroup/agilab",
+        check_github_runs=True,
+    )
+
+    assert check["status"] == "pass"
+    assert check["details"]["run_id"] == "25577485125"
+    assert check["details"]["failed_count"] == 0
 
 
 def test_release_proof_renderer_fails_unknown_template_key(tmp_path: Path) -> None:

--- a/test/test_ui_robot_evidence.py
+++ b/test/test_ui_robot_evidence.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+MODULE_PATH = Path("tools/ui_robot_evidence.py").resolve()
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("ui_robot_evidence_test_module", MODULE_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _successful_run() -> dict[str, object]:
+    return {
+        "attempt": 1,
+        "conclusion": "success",
+        "createdAt": "2026-05-08T20:18:44Z",
+        "databaseId": 25577485125,
+        "event": "workflow_dispatch",
+        "headBranch": "main",
+        "headSha": "abc123",
+        "name": "ui-robot-matrix",
+        "status": "completed",
+        "updatedAt": "2026-05-08T20:26:55Z",
+        "url": "https://github.com/ThalesGroup/agilab/actions/runs/25577485125",
+        "workflowName": "ui-robot-matrix",
+    }
+
+
+def _artifact() -> dict[str, object]:
+    return {
+        "name": "ui-robot-matrix-1",
+        "expired": False,
+        "size_bytes": 4902,
+        "archive_download_url": "https://api.github.com/repos/ThalesGroup/agilab/actions/artifacts/1/zip",
+    }
+
+
+def _matrix_summary() -> dict[str, object]:
+    return {
+        "schema": "agilab.widget_robot_matrix.v1",
+        "success": True,
+        "page_count": 30,
+        "widget_count": 532,
+        "interacted_count": 348,
+        "probed_count": 184,
+        "skipped_count": 0,
+        "failed_count": 0,
+        "duration_seconds": 438.2,
+        "failed_scenarios": [],
+        "failure_samples": [],
+    }
+
+
+def _scenario_summary() -> dict[str, object]:
+    return {
+        "success": True,
+        "app_count": 10,
+        "page_count": 30,
+        "widget_count": 532,
+        "interacted_count": 348,
+        "probed_count": 184,
+        "skipped_count": 0,
+        "failed_count": 0,
+        "total_duration_seconds": 411.6,
+        "within_target": True,
+    }
+
+
+def test_select_latest_successful_run_skips_failed_runs() -> None:
+    module = _load_module()
+    failed = {**_successful_run(), "databaseId": 1, "conclusion": "failure"}
+    success = _successful_run()
+
+    selected = module.select_latest_successful_run([failed, success])
+
+    assert selected["databaseId"] == "25577485125"
+    assert selected["workflowName"] == "ui-robot-matrix"
+
+
+def test_load_artifact_payloads_and_build_evidence_contract(tmp_path: Path) -> None:
+    module = _load_module()
+    artifact_root = tmp_path / "ui-robot-matrix-1" / "test-results" / "ui-robot-matrix"
+    artifact_root.mkdir(parents=True)
+    (artifact_root / "summary.json").write_text(json.dumps(_matrix_summary()), encoding="utf-8")
+    (artifact_root / "isolated-core-pages.json").write_text(
+        json.dumps(_scenario_summary()),
+        encoding="utf-8",
+    )
+    (artifact_root / "isolated-core-pages.ndjson").write_text("{}\n", encoding="utf-8")
+    (artifact_root / "exit-code.txt").write_text("0\n", encoding="utf-8")
+
+    matrix_summary, scenario_summary, artifact_checks = module.load_artifact_payloads(tmp_path)
+    evidence = module.build_evidence(
+        run=_successful_run(),
+        artifact=_artifact(),
+        matrix_summary=matrix_summary,
+        scenario_summary=scenario_summary,
+        artifact_checks=artifact_checks,
+        generated_at="2026-05-08T20:30:00Z",
+    )
+    report = module.build_report(evidence)
+
+    assert evidence["schema"] == module.SCHEMA
+    assert evidence["source"]["run_id"] == "25577485125"
+    assert evidence["result"]["status"] == "pass"
+    assert evidence["result"]["app_count"] == 10
+    assert evidence["result"]["failed_count"] == 0
+    assert evidence["artifact"]["required_files_present"] is True
+    assert report["status"] == "pass"
+
+
+def test_validate_evidence_rejects_failed_robot_result() -> None:
+    module = _load_module()
+    scenario = {**_scenario_summary(), "success": False, "failed_count": 1}
+    evidence = module.build_evidence(
+        run=_successful_run(),
+        artifact=_artifact(),
+        matrix_summary={**_matrix_summary(), "success": False, "failed_count": 1},
+        scenario_summary=scenario,
+        artifact_checks={"required_files_present": True, "exit_code": "1"},
+        generated_at="2026-05-08T20:30:00Z",
+    )
+
+    report = module.build_report(evidence)
+
+    assert report["status"] == "fail"
+    failed_ids = {check["id"] for check in report["checks"] if check["status"] == "fail"}
+    assert failed_ids == {"artifact", "robot_result"}
+
+
+def test_main_check_validates_existing_evidence_file(tmp_path: Path, capsys) -> None:
+    module = _load_module()
+    evidence = module.build_evidence(
+        run=_successful_run(),
+        artifact=_artifact(),
+        matrix_summary=_matrix_summary(),
+        scenario_summary=_scenario_summary(),
+        artifact_checks={"required_files_present": True, "exit_code": "0", "progress_log_bytes": 3},
+        generated_at="2026-05-08T20:30:00Z",
+    )
+    output = tmp_path / "ui_robot_evidence.json"
+    module.write_evidence(output, evidence)
+
+    exit_code = module.main(["--check", "--output", str(output), "--compact"])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert payload["schema"] == module.SCHEMA
+    assert payload["status"] == "pass"

--- a/tools/agilab_widget_robot.py
+++ b/tools/agilab_widget_robot.py
@@ -2576,8 +2576,10 @@ def _wait_for_action_outcome(
     settle_action_labels: Sequence[str] = (),
     allow_idle_settle: bool = False,
 ) -> tuple[str | None, bool]:
-    deadline = time.perf_counter() + timeout_ms / 1000.0
-    min_observation_deadline = time.perf_counter() + min(5.0, timeout_ms / 1000.0)
+    start = time.perf_counter()
+    timeout_seconds = timeout_ms / 1000.0
+    deadline = start + timeout_seconds
+    min_observation_deadline = start + min(5.0, timeout_seconds)
     busy_seen = False
     soft_feedback_seen = False
     idle_seen = 0

--- a/tools/release_proof_report.py
+++ b/tools/release_proof_report.py
@@ -6,11 +6,13 @@ from __future__ import annotations
 import argparse
 import copy
 from datetime import UTC, datetime
+import importlib.util
 import json
 from pathlib import Path
 import re
 from string import Formatter
 import subprocess
+import sys
 import textwrap
 from typing import Any, Mapping, Sequence
 import tomllib
@@ -19,6 +21,7 @@ import tomllib
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_DOCS_SOURCE = REPO_ROOT / "docs" / "source"
 MANIFEST_RELATIVE_PATH = Path("data/release_proof.toml")
+UI_ROBOT_EVIDENCE_RELATIVE_PATH = Path("data/ui_robot_evidence.json")
 OUTPUT_RELATIVE_PATH = Path("release-proof.rst")
 SCHEMA = "agilab.release_proof.v1"
 GITHUB_RUN_FIELDS = (
@@ -719,6 +722,106 @@ def _github_ci_runs_check(
     )
 
 
+def _load_ui_robot_evidence_module() -> Any:
+    module_path = REPO_ROOT / "tools" / "ui_robot_evidence.py"
+    spec = importlib.util.spec_from_file_location("ui_robot_evidence_for_release_proof", module_path)
+    if not spec or not spec.loader:
+        raise RuntimeError(f"unable to load UI robot evidence tool: {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _ui_robot_evidence_check(
+    evidence_path: Path,
+    *,
+    repo_root: Path,
+    github_repo: str | None,
+    check_github_runs: bool,
+) -> dict[str, Any]:
+    try:
+        ui_robot_evidence = _load_ui_robot_evidence_module()
+        evidence = ui_robot_evidence.load_evidence(evidence_path)
+        validation_checks = ui_robot_evidence.validate_evidence(evidence)
+    except Exception as exc:
+        return _check_result(
+            "ui_robot_evidence",
+            False,
+            "UI robot release evidence is missing or malformed",
+            evidence=[str(evidence_path)],
+            details={"error": str(exc)},
+        )
+
+    source = evidence.get("source") if isinstance(evidence.get("source"), Mapping) else {}
+    result = evidence.get("result") if isinstance(evidence.get("result"), Mapping) else {}
+    failures = [
+        f"{check['id']}: {check['summary']}"
+        for check in validation_checks
+        if check.get("status") != "pass"
+    ]
+    github_run: dict[str, Any] | None = None
+    if check_github_runs:
+        try:
+            repo = _resolve_github_repo(repo_root, github_repo)
+            run_id = str(source.get("run_id", "") or "")
+            raw = _run_gh_json(
+                [
+                    "run",
+                    "view",
+                    run_id,
+                    "--repo",
+                    repo,
+                    "--json",
+                    _github_json_fields(),
+                ]
+            )
+            if not isinstance(raw, Mapping):
+                raise RuntimeError("gh run view did not return an object")
+            github_run = _normalize_github_run(raw)
+            if github_run["workflowName"] != ui_robot_evidence.WORKFLOW_NAME:
+                failures.append(
+                    "github: workflow mismatch: "
+                    f"expected {ui_robot_evidence.WORKFLOW_NAME}, got {github_run['workflowName']}"
+                )
+            if not _github_run_is_success(raw):
+                failures.append(
+                    "github: run is not successful: "
+                    f"status={github_run['status']} conclusion={github_run['conclusion']}"
+                )
+            if source.get("run_url") and github_run["url"] and source.get("run_url") != github_run["url"]:
+                failures.append("github: evidence run URL differs from GitHub run URL")
+            if source.get("head_sha") and github_run["headSha"] and source.get("head_sha") != github_run["headSha"]:
+                failures.append("github: evidence head SHA differs from GitHub run head SHA")
+        except Exception as exc:
+            failures.append(f"github: {exc}")
+
+    return _check_result(
+        "ui_robot_evidence",
+        not failures,
+        (
+            "UI robot matrix evidence is present, successful, and references a valid run"
+            if not failures
+            else "UI robot matrix evidence is missing, failed, or inconsistent"
+        ),
+        evidence=[str(evidence_path.relative_to(repo_root)) if evidence_path.is_relative_to(repo_root) else str(evidence_path)],
+        details={
+            "run_id": source.get("run_id", ""),
+            "run_url": source.get("run_url", ""),
+            "head_sha": source.get("head_sha", ""),
+            "app_count": result.get("app_count", 0),
+            "page_count": result.get("page_count", 0),
+            "widget_count": result.get("widget_count", 0),
+            "interacted_count": result.get("interacted_count", 0),
+            "probed_count": result.get("probed_count", 0),
+            "failed_count": result.get("failed_count", 0),
+            "validation_checks": validation_checks,
+            "github_run": github_run,
+            "failures": failures,
+        },
+    )
+
+
 def build_report(
     *,
     manifest_path: Path,
@@ -805,6 +908,14 @@ def build_report(
             _ci_run_urls_are_consistent(ci_runs),
             "CI run URLs match their run IDs",
             evidence=[str(manifest_path)],
+        )
+    )
+    checks.append(
+        _ui_robot_evidence_check(
+            manifest_path.parent / UI_ROBOT_EVIDENCE_RELATIVE_PATH.name,
+            repo_root=repo_root,
+            github_repo=github_repo,
+            check_github_runs=check_github_runs,
         )
     )
     if check_github_runs:

--- a/tools/ui_robot_evidence.py
+++ b/tools/ui_robot_evidence.py
@@ -1,0 +1,491 @@
+#!/usr/bin/env python3
+"""Refresh and validate release evidence from the UI robot matrix workflow."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import UTC, datetime
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+from typing import Any, Mapping, Sequence
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_OUTPUT = REPO_ROOT / "docs" / "source" / "data" / "ui_robot_evidence.json"
+SCHEMA = "agilab.ui_robot_evidence.v1"
+WORKFLOW_NAME = "ui-robot-matrix"
+DEFAULT_BRANCH = "main"
+DEFAULT_REPO = "ThalesGroup/agilab"
+DEFAULT_RUN_LIMIT = 20
+GITHUB_RUN_FIELDS = (
+    "attempt",
+    "conclusion",
+    "createdAt",
+    "databaseId",
+    "event",
+    "headBranch",
+    "headSha",
+    "name",
+    "status",
+    "updatedAt",
+    "url",
+    "workflowName",
+)
+REQUIRED_ARTIFACT_FILES = {
+    "matrix_summary": "summary.json",
+    "scenario_summary": "isolated-core-pages.json",
+    "progress_log": "isolated-core-pages.ndjson",
+    "exit_code": "exit-code.txt",
+}
+
+
+def utc_now_iso() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _run_gh_json(args: Sequence[str], *, repo_root: Path = REPO_ROOT) -> Any:
+    completed = subprocess.run(
+        ["gh", *args],
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout).strip()
+        raise RuntimeError(f"gh {' '.join(args)} failed: {detail}")
+    try:
+        return json.loads(completed.stdout or "null")
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"gh {' '.join(args)} returned invalid JSON: {exc}") from exc
+
+
+def _run_command(args: Sequence[str], *, repo_root: Path = REPO_ROOT) -> None:
+    completed = subprocess.run(
+        list(args),
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout).strip()
+        raise RuntimeError(f"{' '.join(args)} failed: {detail}")
+
+
+def _github_fields() -> str:
+    return ",".join(GITHUB_RUN_FIELDS)
+
+
+def normalize_run(row: Mapping[str, Any]) -> dict[str, str]:
+    return {field: str(row.get(field, "") or "") for field in GITHUB_RUN_FIELDS}
+
+
+def is_successful_ui_robot_run(row: Mapping[str, Any]) -> bool:
+    return (
+        str(row.get("workflowName", "")) == WORKFLOW_NAME
+        and str(row.get("status", "")) == "completed"
+        and str(row.get("conclusion", "")) == "success"
+        and bool(str(row.get("databaseId", "") or ""))
+        and bool(row.get("url"))
+    )
+
+
+def select_latest_successful_run(rows: Sequence[Mapping[str, Any]]) -> dict[str, str]:
+    for row in rows:
+        if is_successful_ui_robot_run(row):
+            return normalize_run(row)
+    raise RuntimeError(f"no successful {WORKFLOW_NAME!r} workflow run found")
+
+
+def fetch_latest_successful_run(
+    *,
+    repo: str,
+    branch: str | None,
+    limit: int,
+    repo_root: Path = REPO_ROOT,
+) -> dict[str, str]:
+    args = [
+        "run",
+        "list",
+        "--repo",
+        repo,
+        "--workflow",
+        f"{WORKFLOW_NAME}.yml",
+        "--limit",
+        str(limit),
+        "--json",
+        _github_fields(),
+    ]
+    if branch:
+        args.extend(["--branch", branch])
+    rows = _run_gh_json(args, repo_root=repo_root)
+    if not isinstance(rows, list):
+        raise RuntimeError("gh run list did not return a JSON list")
+    return select_latest_successful_run([row for row in rows if isinstance(row, Mapping)])
+
+
+def fetch_run(run_id: str, *, repo: str, repo_root: Path = REPO_ROOT) -> dict[str, str]:
+    raw = _run_gh_json(
+        [
+            "run",
+            "view",
+            run_id,
+            "--repo",
+            repo,
+            "--json",
+            _github_fields(),
+        ],
+        repo_root=repo_root,
+    )
+    if not isinstance(raw, Mapping):
+        raise RuntimeError("gh run view did not return a JSON object")
+    return normalize_run(raw)
+
+
+def fetch_artifact_metadata(run_id: str, *, repo: str, repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    raw = _run_gh_json(
+        [
+            "api",
+            f"repos/{repo}/actions/runs/{run_id}/artifacts",
+        ],
+        repo_root=repo_root,
+    )
+    artifacts = raw.get("artifacts") if isinstance(raw, Mapping) else None
+    if not isinstance(artifacts, list):
+        raise RuntimeError("GitHub artifacts response did not contain an artifacts list")
+    for artifact in artifacts:
+        if not isinstance(artifact, Mapping):
+            continue
+        if str(artifact.get("name", "") or "").startswith(WORKFLOW_NAME):
+            return {
+                "name": str(artifact.get("name", "") or ""),
+                "expired": bool(artifact.get("expired")),
+                "size_bytes": int(artifact.get("size_in_bytes") or 0),
+                "archive_download_url": str(artifact.get("archive_download_url", "") or ""),
+            }
+    raise RuntimeError(f"no {WORKFLOW_NAME!r} artifact found for run {run_id}")
+
+
+def download_artifact(
+    run_id: str,
+    *,
+    repo: str,
+    artifact_name: str,
+    destination: Path,
+    repo_root: Path = REPO_ROOT,
+) -> Path:
+    if destination.exists():
+        shutil.rmtree(destination)
+    destination.mkdir(parents=True, exist_ok=True)
+    _run_command(
+        [
+            "gh",
+            "run",
+            "download",
+            run_id,
+            "--repo",
+            repo,
+            "--name",
+            artifact_name,
+            "--dir",
+            str(destination),
+        ],
+        repo_root=repo_root,
+    )
+    return destination
+
+
+def _find_artifact_file(root: Path, filename: str) -> Path | None:
+    matches = sorted(path for path in root.rglob(filename) if path.is_file())
+    return matches[0] if matches else None
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return payload
+
+
+def load_artifact_payloads(artifact_dir: Path) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    paths = {
+        key: _find_artifact_file(artifact_dir, filename)
+        for key, filename in REQUIRED_ARTIFACT_FILES.items()
+    }
+    missing = [key for key, path in paths.items() if path is None]
+    if missing:
+        raise FileNotFoundError(
+            f"missing required UI robot artifact file(s): {', '.join(missing)}"
+        )
+
+    matrix_summary = _load_json(paths["matrix_summary"])  # type: ignore[arg-type]
+    scenario_summary = _load_json(paths["scenario_summary"])  # type: ignore[arg-type]
+    exit_code_text = paths["exit_code"].read_text(encoding="utf-8").strip()  # type: ignore[union-attr]
+    progress_path = paths["progress_log"]  # type: ignore[assignment]
+    screenshot_count = sum(1 for path in artifact_dir.rglob("*.png") if path.is_file())
+
+    def _relative(path: Path | None) -> str:
+        if path is None:
+            return ""
+        try:
+            return str(path.relative_to(artifact_dir))
+        except ValueError:
+            return path.name
+
+    artifact_checks = {
+        "required_files_present": True,
+        "exit_code": exit_code_text,
+        "progress_log_bytes": progress_path.stat().st_size,
+        "screenshot_count": screenshot_count,
+        "matrix_summary_file": _relative(paths["matrix_summary"]),
+        "scenario_summary_file": _relative(paths["scenario_summary"]),
+        "progress_log_file": _relative(progress_path),
+    }
+    return matrix_summary, scenario_summary, artifact_checks
+
+
+def _int_value(payload: Mapping[str, Any], key: str) -> int:
+    return int(payload.get(key) or 0)
+
+
+def _float_value(payload: Mapping[str, Any], key: str) -> float:
+    return float(payload.get(key) or 0.0)
+
+
+def build_evidence(
+    *,
+    run: Mapping[str, Any],
+    artifact: Mapping[str, Any],
+    matrix_summary: Mapping[str, Any],
+    scenario_summary: Mapping[str, Any],
+    artifact_checks: Mapping[str, Any],
+    generated_at: str | None = None,
+) -> dict[str, Any]:
+    failed_count = _int_value(scenario_summary, "failed_count")
+    skipped_count = _int_value(scenario_summary, "skipped_count")
+    success = (
+        is_successful_ui_robot_run(run)
+        and matrix_summary.get("success") is True
+        and scenario_summary.get("success") is True
+        and failed_count == 0
+        and str(artifact_checks.get("exit_code", "")) == "0"
+        and not bool(artifact.get("expired"))
+    )
+    return {
+        "schema": SCHEMA,
+        "generated_at": generated_at or utc_now_iso(),
+        "source": {
+            "workflow": WORKFLOW_NAME,
+            "run_id": str(run.get("databaseId", "") or ""),
+            "run_url": str(run.get("url", "") or ""),
+            "run_attempt": str(run.get("attempt", "") or ""),
+            "head_branch": str(run.get("headBranch", "") or ""),
+            "head_sha": str(run.get("headSha", "") or ""),
+            "event": str(run.get("event", "") or ""),
+            "created_at": str(run.get("createdAt", "") or ""),
+            "updated_at": str(run.get("updatedAt", "") or ""),
+            "status": str(run.get("status", "") or ""),
+            "conclusion": str(run.get("conclusion", "") or ""),
+        },
+        "artifact": {
+            "name": str(artifact.get("name", "") or ""),
+            "expired": bool(artifact.get("expired")),
+            "size_bytes": int(artifact.get("size_bytes") or 0),
+            "archive_download_url": str(artifact.get("archive_download_url", "") or ""),
+            **dict(artifact_checks),
+        },
+        "result": {
+            "status": "pass" if success else "fail",
+            "success": success,
+            "app_count": _int_value(scenario_summary, "app_count"),
+            "page_count": _int_value(scenario_summary, "page_count"),
+            "widget_count": _int_value(scenario_summary, "widget_count"),
+            "interacted_count": _int_value(scenario_summary, "interacted_count"),
+            "probed_count": _int_value(scenario_summary, "probed_count"),
+            "skipped_count": skipped_count,
+            "failed_count": failed_count,
+            "total_duration_seconds": _float_value(scenario_summary, "total_duration_seconds"),
+            "within_target": bool(scenario_summary.get("within_target")),
+            "failed_scenarios": list(matrix_summary.get("failed_scenarios") or []),
+            "failure_samples": list(matrix_summary.get("failure_samples") or []),
+        },
+    }
+
+
+def load_evidence(path: Path) -> dict[str, Any]:
+    return _load_json(path)
+
+
+def validate_evidence(evidence: Mapping[str, Any]) -> list[dict[str, Any]]:
+    source = evidence.get("source") if isinstance(evidence.get("source"), Mapping) else {}
+    artifact = evidence.get("artifact") if isinstance(evidence.get("artifact"), Mapping) else {}
+    result = evidence.get("result") if isinstance(evidence.get("result"), Mapping) else {}
+    checks = [
+        {
+            "id": "schema",
+            "status": "pass" if evidence.get("schema") == SCHEMA else "fail",
+            "summary": f"evidence schema is {SCHEMA}",
+        },
+        {
+            "id": "workflow_run",
+            "status": (
+                "pass"
+                if source.get("workflow") == WORKFLOW_NAME
+                and source.get("run_id")
+                and source.get("run_url")
+                else "fail"
+            ),
+            "summary": "evidence references a UI robot matrix GitHub run",
+        },
+        {
+            "id": "run_success",
+            "status": (
+                "pass"
+                if source.get("status") == "completed"
+                and source.get("conclusion") == "success"
+                else "fail"
+            ),
+            "summary": "GitHub run completed successfully",
+        },
+        {
+            "id": "artifact",
+            "status": (
+                "pass"
+                if artifact.get("name")
+                and artifact.get("required_files_present") is True
+                and artifact.get("exit_code") == "0"
+                and artifact.get("expired") is False
+                else "fail"
+            ),
+            "summary": "robot artifact includes summary, progress log, and zero exit code",
+        },
+        {
+            "id": "robot_result",
+            "status": (
+                "pass"
+                if result.get("success") is True
+                and result.get("failed_count") == 0
+                and result.get("within_target") is True
+                else "fail"
+            ),
+            "summary": "robot matrix succeeded with zero failures within target",
+        },
+    ]
+    return checks
+
+
+def evidence_status(evidence: Mapping[str, Any]) -> str:
+    return "pass" if all(check["status"] == "pass" for check in validate_evidence(evidence)) else "fail"
+
+
+def refresh_evidence(
+    *,
+    repo: str,
+    branch: str | None,
+    run_id: str | None,
+    run_limit: int,
+    artifact_dir: Path | None,
+    repo_root: Path = REPO_ROOT,
+) -> dict[str, Any]:
+    run = fetch_run(run_id, repo=repo, repo_root=repo_root) if run_id else fetch_latest_successful_run(
+        repo=repo,
+        branch=branch,
+        limit=run_limit,
+        repo_root=repo_root,
+    )
+    artifact = fetch_artifact_metadata(str(run["databaseId"]), repo=repo, repo_root=repo_root)
+    if bool(artifact.get("expired")):
+        raise RuntimeError(f"artifact {artifact.get('name')} for run {run['databaseId']} is expired")
+
+    if artifact_dir is not None:
+        work_dir = artifact_dir
+        matrix_summary, scenario_summary, artifact_checks = load_artifact_payloads(work_dir)
+    else:
+        with tempfile.TemporaryDirectory(prefix="agilab-ui-robot-evidence-") as tmp:
+            work_dir = download_artifact(
+                str(run["databaseId"]),
+                repo=repo,
+                artifact_name=str(artifact["name"]),
+                destination=Path(tmp),
+                repo_root=repo_root,
+            )
+            matrix_summary, scenario_summary, artifact_checks = load_artifact_payloads(work_dir)
+    return build_evidence(
+        run=run,
+        artifact=artifact,
+        matrix_summary=matrix_summary,
+        scenario_summary=scenario_summary,
+        artifact_checks=artifact_checks,
+    )
+
+
+def build_report(evidence: Mapping[str, Any]) -> dict[str, Any]:
+    checks = validate_evidence(evidence)
+    failed = [check for check in checks if check["status"] != "pass"]
+    return {
+        "schema": SCHEMA,
+        "status": "pass" if not failed else "fail",
+        "source": dict(evidence.get("source") or {}),
+        "result": dict(evidence.get("result") or {}),
+        "summary": {
+            "check_count": len(checks),
+            "passed": len(checks) - len(failed),
+            "failed": len(failed),
+        },
+        "checks": checks,
+    }
+
+
+def write_evidence(path: Path, evidence: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(evidence, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument("--repo", default=DEFAULT_REPO)
+    parser.add_argument("--branch", default=DEFAULT_BRANCH)
+    parser.add_argument("--run-id", default=None, help="Use an exact GitHub Actions run ID.")
+    parser.add_argument("--run-limit", type=int, default=DEFAULT_RUN_LIMIT)
+    parser.add_argument(
+        "--artifact-dir",
+        type=Path,
+        default=None,
+        help="Use an already downloaded artifact directory instead of downloading from GitHub.",
+    )
+    parser.add_argument("--check", action="store_true", help="Validate the existing output file.")
+    parser.add_argument("--compact", action="store_true", help="Emit compact JSON.")
+    parser.add_argument("--quiet", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(list(argv) if argv is not None else None)
+    if args.check:
+        evidence = load_evidence(args.output)
+    else:
+        evidence = refresh_evidence(
+            repo=args.repo,
+            branch=args.branch or None,
+            run_id=args.run_id,
+            run_limit=args.run_limit,
+            artifact_dir=args.artifact_dir,
+        )
+        write_evidence(args.output, evidence)
+
+    report = build_report(evidence)
+    if not args.quiet:
+        if args.compact:
+            print(json.dumps(report, sort_keys=True, separators=(",", ":")))
+        else:
+            print(json.dumps(report, indent=2, sort_keys=True))
+    return 0 if report["status"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds durable release-proof evidence for the all-built-in UI robot matrix by checking in `docs/source/data/ui_robot_evidence.json` and adding `tools/ui_robot_evidence.py` to refresh or validate it from GitHub Actions artifacts.

The release proof report now validates that evidence, optionally cross-checks the referenced GitHub run, and the docs page explains the maintenance command. CI also compiles the new evidence tool.

This also fixes a deterministic timing edge in `tools/agilab_widget_robot.py`: short idle-settle waits now derive timeout and observation deadlines from the same clock sample, preventing false `settled=False` failures at the timeout boundary.

## Validation

- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files ...`
- `uv --preview-features extra-build-dependencies run pytest -q test/test_ci_artifact_harvest_report.py test/test_ci_provider_artifacts.py test/test_ci_workflow.py test/test_release_proof_report.py test/test_ui_robot_evidence.py`
- `uv --preview-features extra-build-dependencies run pytest -q test/test_agilab_widget_robot.py test/test_agilab_widget_robot_full.py test/test_agilab_widget_robot_matrix.py`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs`
- `uv --preview-features extra-build-dependencies run python tools/ui_robot_evidence.py --check --compact`
- `uv --preview-features extra-build-dependencies run python tools/release_proof_report.py --check --check-github-runs --compact`
- `uv --preview-features extra-build-dependencies run python tools/coverage_badge_guard.py --changed-only --require-fresh-xml`
- `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --delete`
- `git diff --check`