### PR TITLE
[codex] split default install from UI extras

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   local-only-policy:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: repo-guardrails
 
 on:
   push:
-    branches: ["**"]
+    branches: ["main"]
   pull_request:
     branches: ["**"]
   workflow_dispatch:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
           OPENAI_API_KEY: "sk-test-first-launch-000000000000"
         run: |
           set -euo pipefail
-          uv --preview-features extra-build-dependencies run python tools/first_launch_robot.py --json --output first-launch-robot.json
+          uv --preview-features extra-build-dependencies run --extra ui python tools/first_launch_robot.py --json --output first-launch-robot.json
 
       - name: Validate security hygiene report
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,6 +19,10 @@ permissions:
   contents: read
   id-token: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   agi-env:
     runs-on: ubuntu-latest

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -325,8 +325,7 @@ jobs:
 
           run_gui_chunk reports \
             test/test_ci_provider_artifacts.py \
-            test/test_*_report.py \
-            test/test_*_workflow.py
+            test/test_*_report.py
 
           timeout 5m uv --preview-features extra-build-dependencies run --group dev \
             python -m coverage xml \

--- a/.github/workflows/docs-source-guard.yaml
+++ b/.github/workflows/docs-source-guard.yaml
@@ -30,6 +30,10 @@ permissions:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   verify:
     runs-on: ubuntu-latest
@@ -60,4 +64,4 @@ jobs:
       - name: Test docs/source guard tools
         run: |
           set -euo pipefail
-          uv --preview-features extra-build-dependencies run --extra ui pytest -q -o addopts='' test/test_sync_docs_source.py test/test_release_proof_report.py
+          uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_sync_docs_source.py test/test_release_proof_report.py

--- a/.github/workflows/docs-source-guard.yaml
+++ b/.github/workflows/docs-source-guard.yaml
@@ -60,4 +60,4 @@ jobs:
       - name: Test docs/source guard tools
         run: |
           set -euo pipefail
-          uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_sync_docs_source.py test/test_release_proof_report.py
+          uv --preview-features extra-build-dependencies run --extra ui pytest -q -o addopts='' test/test_sync_docs_source.py test/test_release_proof_report.py

--- a/.github/workflows/ensure-roadmap-label.yaml
+++ b/.github/workflows/ensure-roadmap-label.yaml
@@ -2,6 +2,7 @@ name: Ensure roadmap label
 
 on:
   push:
+    branches: ["main"]
     paths:
       - ".github/ISSUE_TEMPLATE/roadmap-vote.yml"
       - ".github/workflows/ensure-roadmap-label.yaml"

--- a/.github/workflows/ensure-roadmap-label.yaml
+++ b/.github/workflows/ensure-roadmap-label.yaml
@@ -11,6 +11,10 @@ permissions:
   contents: read
   issues: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   ensure-label:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ Start with the public browser preview or the demo chooser:
 python3 -m venv ~/.agilab-first-proof
 source ~/.agilab-first-proof/bin/activate
 python -m pip install --upgrade pip
-python -m pip install --upgrade agilab && python -m agilab.lab_run first-proof --json
+python -m pip install --upgrade "agilab[ui]"
+python -m agilab.lab_run first-proof --json --with-ui
 python -m agilab.lab_run
 ```
 
@@ -151,15 +152,18 @@ uv venv
 source .venv/bin/activate
 uv pip install --upgrade agilab
 python -m agilab.lab_run first-proof --json --max-seconds 60
+uv pip install --upgrade "agilab[ui]"
+python -m agilab.lab_run first-proof --json --with-ui --max-seconds 60
 python -m agilab.lab_run
 ```
 
 Use `python -m agilab.lab_run first-proof --json --max-seconds 60` for a quick
-package-level check from the same interpreter that installed AGILAB. The
-clean-install CI matrix enforces that runtime budget on Linux, macOS, and
-Windows. For the most representative full product run, prefer the source-checkout
-`flight_project` path above because it exercises the same app installation,
-execution, and analysis flow documented in the web UI.
+package-level CLI/core check from the same interpreter that installed AGILAB.
+The clean-install CI matrix enforces that runtime budget on Linux, macOS, and
+Windows. Install `agilab[ui]` before launching the local Streamlit app. For the
+most representative full product run, prefer the source-checkout `flight_project`
+path above because it exercises the same app installation, execution, and
+analysis flow documented in the web UI.
 
 If `agilab` still reports an older version after a package install, check the
 actual executable with `command -v agilab`. A `uv tool` shim such as

--- a/README.pypi.md
+++ b/README.pypi.md
@@ -30,8 +30,8 @@ Streamlit UI
 Try this first:
 
 ```bash
-pip install agilab
-agilab first-proof --json
+pip install "agilab[ui]"
+agilab first-proof --json --with-ui
 agilab
 ```
 
@@ -81,7 +81,7 @@ Follow the in-app pages from `PROJECT` to `ANALYSIS`. To collect the same check
 as JSON:
 
 ```bash
-uv --preview-features extra-build-dependencies run agilab first-proof --json
+uv --preview-features extra-build-dependencies run agilab first-proof --json --with-ui
 ```
 
 The JSON proof writes `run_manifest.json` under `~/log/execute/flight/`. For
@@ -92,13 +92,17 @@ installer flags, IDE run configs, and troubleshooting, use the Quick Start docs.
 ```bash
 pip install agilab
 agilab first-proof --json
+pip install "agilab[ui]"
+agilab first-proof --json --with-ui
 agilab
 ```
 
-This is the thinnest public entry point. Use `agilab first-proof --json` for a
-quick package-level check. For the most representative full product run, prefer
-the source-checkout `flight_project` path above because it exercises the same
-app installation, execution, and analysis flow documented in the web UI.
+The base install is the thinnest public CLI/core entry point. Use
+`agilab first-proof --json` for a quick package-level check. Install
+`agilab[ui]` before launching the local Streamlit app or running
+`agilab first-proof --with-ui`. For the most representative full product run,
+prefer the source-checkout `flight_project` path above because it exercises the
+same app installation, execution, and analysis flow documented in the web UI.
 
 ## App Repository Updates
 

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 185,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "b13aa8b63c8da5e3bd38d81b2eb96137d252b00f8fdedfd4eaeb5aa585788661",
+  "source_digest_sha256": "6292ca7f91c4d9ceacf67c4bcb9d2d0f2543480c8a4f2c0c5ca799d4e05d5701",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "b13aa8b63c8da5e3bd38d81b2eb96137d252b00f8fdedfd4eaeb5aa585788661"
+  "target_digest_sha256": "6292ca7f91c4d9ceacf67c4bcb9d2d0f2543480c8a4f2c0c5ca799d4e05d5701"
 }

--- a/docs/source/compatibility-matrix.rst
+++ b/docs/source/compatibility-matrix.rst
@@ -76,8 +76,8 @@ Current public matrix
      - validated
      - ``python -m pip install agilab`` then
        ``python -m agilab.lab_run first-proof --json --max-seconds 60``
-     - Clean public package install outside the source checkout, followed by
-       the packaged first-proof smoke
+     - Clean public base package install outside the source checkout, followed
+       by the packaged CLI/core first-proof smoke
      - Validates the released package, not unmerged branch contents; less
        representative than the source-checkout first proof
 
@@ -101,13 +101,13 @@ Platform coverage snapshot
      - validated
      - GitHub Actions clean install: ``python -m pip install agilab`` then
        ``python -m agilab.lab_run first-proof --json --max-seconds 60``
-     - validates the latest released package
+     - validates the latest released base package, not the local web UI extra
    * - macOS package
      - validated
      - GitHub Actions clean install: ``python -m pip install agilab`` then
        ``python -m agilab.lab_run first-proof --json --max-seconds 60``
-     - validates the latest released package on the macOS runner, not every
-       local Homebrew/PyCharm setup
+     - validates the latest released base package on the macOS runner, not
+       every local Homebrew/PyCharm setup or UI extra combination
    * - Windows / WSL2
      - validated for the clean package smoke; documented for WSL2/source flows
      - GitHub Actions clean install on ``windows-latest`` plus installer and

--- a/docs/source/data/compatibility_matrix.toml
+++ b/docs/source/data/compatibility_matrix.toml
@@ -68,5 +68,5 @@ surface = "PyPI package"
 primary_proof = "python -m pip install agilab && python -m agilab.lab_run first-proof --json --max-seconds 60"
 python = ["3.11+"]
 platforms = ["Linux CI", "macOS CI", "Windows CI"]
-scope = "Clean public package install outside the source checkout, followed by the packaged first-proof smoke"
-limits = ["Validates the released package, not unmerged branch contents", "Clean-install CI enforces the 60-second first-proof runtime budget on Linux, macOS, and Windows runners", "Less representative than the source-checkout first proof", "Not the main contributor workflow"]
+scope = "Clean public base package install outside the source checkout, followed by the packaged CLI/core first-proof smoke"
+limits = ["Validates the released package, not unmerged branch contents", "Clean-install CI enforces the 60-second first-proof runtime budget on Linux, macOS, and Windows runners", "Does not install the optional UI, MLflow, visualization, or local-LLM extras", "Less representative than the source-checkout first proof", "Not the main contributor workflow"]

--- a/docs/source/demos.rst
+++ b/docs/source/demos.rst
@@ -73,8 +73,8 @@ The static scenario contract is available as JSON:
    uv --preview-features extra-build-dependencies run python tools/public_proof_scenarios.py --first-proof-json first-proof.json --hf-smoke-json hf-space-smoke.json --output public-proof-scenarios.json
 
 **Local app proof**
-  Install the released package or use the source checkout, then run the public
-  first proof:
+  Install the released base package or use the source checkout, then run the
+  public first proof:
 
   .. code-block:: bash
 
@@ -82,6 +82,8 @@ The static scenario contract is available as JSON:
      python -m agilab.lab_run first-proof --json --max-seconds 60
 
   Stop when the command exits successfully and writes ``run_manifest.json``.
+  This package route is the CLI/core smoke. Install ``agilab[ui]`` and rerun
+  with ``--with-ui`` when you also want to boot the packaged local pages.
   The same route is available in the UI by following ``PROJECT`` ->
   ``ORCHESTRATE`` -> ``ANALYSIS`` with ``flight_project``.
 

--- a/docs/source/package-publishing-policy.rst
+++ b/docs/source/package-publishing-policy.rst
@@ -10,7 +10,8 @@ User-facing install surfaces
 
 For public users, the supported entry points are:
 
-- ``agilab``: the top-level UI and CLI package.
+- ``agilab``: the top-level CLI package. Add the ``ui`` extra for the local
+  Streamlit web interface.
 - ``agi-core``: the compact notebook/API runtime used by the public notebook
   examples.
 
@@ -44,11 +45,14 @@ Why keep them published
 
 Publishing these runtime packages keeps the release process reproducible:
 
-- ``pip install agilab`` and ``uvx agilab`` can resolve the exact package graph.
+- ``pip install agilab`` and ``uvx agilab`` can resolve the exact base package
+  graph for CLI and first-proof checks.
+- ``pip install "agilab[ui]"`` installs the matching ``agi-gui`` package and
+  Streamlit page dependencies for the local web interface.
 - ``agi-core`` can pin the matching ``agi-env``, ``agi-node``, and
   ``agi-cluster`` versions for a release.
-- ``agilab`` can pin the matching ``agi-gui`` version for the UI/page surface
-  without making worker-only installs depend on Streamlit.
+- ``agilab[ui]`` can pin the matching ``agi-gui`` version for the UI/page
+  surface without making CLI/core installs depend on Streamlit.
 - App worker environments can install the same runtime components in isolation
   from the manager environment.
 - CI and release evidence can validate the same dependency graph that external
@@ -60,8 +64,8 @@ Release rule
 For each public release, publish the runtime packages and ``agi-gui`` with the
 same version as ``agilab`` and ``agi-core`` unless a deliberate packaging
 migration removes that need. Do not skip ``agi-node``, ``agi-cluster``, or
-``agi-gui`` from the publish matrix while ``agi-core`` and ``agilab`` depend on
-them as external packages.
+``agi-gui`` from the publish matrix while ``agi-core`` and the ``agilab[ui]``
+extra depend on them as external packages.
 
 If AGILAB later embeds the ``agi_node`` and ``agi_cluster`` Python modules
 directly into a single wheel, that migration must update dependency metadata,

--- a/docs/source/quick-start.rst
+++ b/docs/source/quick-start.rst
@@ -24,7 +24,7 @@ Fast adoption path:
      - ``PROJECT`` -> ``ORCHESTRATE`` -> ``WORKFLOW`` -> ``ANALYSIS`` works
        locally.
    * - 3. Record evidence
-     - Run ``uv --preview-features extra-build-dependencies run agilab first-proof --json``.
+     - Run ``uv --preview-features extra-build-dependencies run agilab first-proof --json --with-ui``.
      - ``~/log/execute/flight/run_manifest.json`` reports ``status: pass``.
    * - 4. Expand
      - Choose notebook, package, private app, or cluster routes only after the
@@ -53,12 +53,19 @@ package, private-app, and cluster variables during the first 10 minutes.
 
    git pull --ff-only
    ./install.sh --install-apps
-   uv --preview-features extra-build-dependencies run agilab first-proof --json
+   uv --preview-features extra-build-dependencies run agilab first-proof --json --with-ui
 
-**Published package install or upgrade**::
+**Published package install or upgrade, CLI proof only**::
 
    uv --preview-features extra-build-dependencies tool install --upgrade agilab
    agilab first-proof --json
+
+Install the UI profile when you want the local Streamlit pages from the
+published package::
+
+   uv --preview-features extra-build-dependencies tool install --upgrade "agilab[ui]"
+   agilab first-proof --json --with-ui
+   agilab
 
 If you installed AGILAB inside an activated project environment instead of as a
 ``uv`` tool, upgrade that environment explicitly::
@@ -103,12 +110,13 @@ machine-readable proof record.
 
 2. **Run the first-proof CLI**::
 
-       uv --preview-features extra-build-dependencies run agilab first-proof --json
+       uv --preview-features extra-build-dependencies run agilab first-proof --json --with-ui
 
-   This is the public first-proof entry point. It checks that AGILAB imports,
-   boots the main page and ORCHESTRATE page against the built-in ``flight_project``,
-   and writes ``~/log/execute/flight/run_manifest.json`` with command,
-   environment, timing, artifact references, and validation status.
+   This is the public first-proof entry point with the UI profile enabled. It
+   checks that AGILAB imports, validates the core AGI request API, boots the
+   main page and ORCHESTRATE page against the built-in ``flight_project``, and
+   writes ``~/log/execute/flight/run_manifest.json`` with command, environment,
+   timing, artifact references, and validation status.
    The source-checkout developer evidence command is the same contract through
    ``tools/newcomer_first_proof.py --json``.
 
@@ -168,7 +176,7 @@ first-proof and compatibility-report commands to rerun.
 If you want the preflight to also check the built-in installer and seeded helper
 scripts::
 
-    uv --preview-features extra-build-dependencies run agilab first-proof --with-install
+    uv --preview-features extra-build-dependencies run agilab first-proof --json --with-ui --with-install
 
 The troubleshooting page covers the common first-run failures:
 
@@ -207,14 +215,21 @@ The dedicated docs page for this route is :doc:`agilab-demo`.
     source .venv/bin/activate
     uv pip install agilab
     python -m agilab.lab_run first-proof --json
+
+The base package install is intentionally CLI/core only. Install the UI profile
+before launching the local Streamlit app::
+
+    uv pip install "agilab[ui]"
+    python -m agilab.lab_run first-proof --json --with-ui
     python -m agilab.lab_run
 
 Optional feature stacks stay out of the base package install. Add
-``agilab[ai]`` for AI assistant features such as OpenAI, Mistral, and
-OpenAI-compatible endpoints like vLLM, and ``agilab[viz]`` for optional
-Plotly/matplotlib visualizations::
+``agilab[ui]`` for the local Streamlit pages, ``agilab[ai]`` for AI assistant
+features such as OpenAI, Mistral, and OpenAI-compatible endpoints like vLLM,
+``agilab[mlflow]`` for tracking, ``agilab[local-llm]`` for local model helpers,
+and ``agilab[viz]`` for optional Plotly/matplotlib visualizations::
 
-    uv pip install "agilab[ai,viz]"
+    uv pip install "agilab[ui,ai,viz,mlflow,local-llm]"
 
 **agi-core demo**:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,11 @@ keywords = [
     "codex",
     "claude",
 ]
-dependencies = ["agi-core==2026.05.08", "agi-gui==2026.05.08", "astor>=0.8.1", "legacy-cgi>=2.6.4; python_version >= '3.13'", "mlflow>=3.11.1", "mlx>=0.31.2; sys_platform == 'darwin' and platform_machine == 'arm64'", "mlx-lm>=0.31.3; sys_platform == 'darwin' and platform_machine == 'arm64'", "networkx>=3.6.1", "numpy>=1.14.1", "pandas>=2.3.0", "pathspec>=1.1.0", "pydantic>=2.13.3", "standard-imghdr>=3.13.0; python_version >= '3.13'", "streamlit>=1.56.0", "tomli_w>=1.2.0"]
+dependencies = [
+    "agi-core==2026.05.08",
+    "legacy-cgi>=2.6.4; python_version >= '3.13'",
+    "standard-imghdr>=3.13.0; python_version >= '3.13'",
+]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"
@@ -60,8 +64,35 @@ agilab = "agilab.lab_run:main"
 
 [project.optional-dependencies]
 ai = ["openai>=2.32.0"]
+ui = [
+    "agi-gui==2026.05.08",
+    "networkx>=3.6.1",
+    "pandas>=2.3.0",
+    "streamlit>=1.56.0",
+    "tomli_w>=1.2.0",
+]
 viz = ["matplotlib>=3.10.0", "plotly>=6.7.0"]
-offline = ["accelerate>=0.34.2; python_version >= '3.12'", "gpt-oss>=0.0.8; python_version >= '3.12'", "requests>=2.32.0; python_version >= '3.12'", "torch>=2.8.0; python_version >= '3.12'", "transformers>=4.57.0; python_version >= '3.12'", "universal-offline-ai-chatbot>=0.1.0; python_version >= '3.12'"]
+mlflow = ["mlflow>=3.11.1"]
+local-llm = [
+    "accelerate>=0.34.2; python_version >= '3.12'",
+    "gpt-oss>=0.0.8; python_version >= '3.12'",
+    "mlx>=0.31.2; sys_platform == 'darwin' and platform_machine == 'arm64'",
+    "mlx-lm>=0.31.3; sys_platform == 'darwin' and platform_machine == 'arm64'",
+    "requests>=2.32.0; python_version >= '3.12'",
+    "torch>=2.8.0; python_version >= '3.12'",
+    "transformers>=4.57.0; python_version >= '3.12'",
+    "universal-offline-ai-chatbot>=0.1.0; python_version >= '3.12'",
+]
+offline = [
+    "accelerate>=0.34.2; python_version >= '3.12'",
+    "gpt-oss>=0.0.8; python_version >= '3.12'",
+    "mlx>=0.31.2; sys_platform == 'darwin' and platform_machine == 'arm64'",
+    "mlx-lm>=0.31.3; sys_platform == 'darwin' and platform_machine == 'arm64'",
+    "requests>=2.32.0; python_version >= '3.12'",
+    "torch>=2.8.0; python_version >= '3.12'",
+    "transformers>=4.57.0; python_version >= '3.12'",
+    "universal-offline-ai-chatbot>=0.1.0; python_version >= '3.12'",
+]
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,9 @@ class build_py(_build_py):
     def run(self):
         super().run()
         sanitizer = _load_sanitizer()
+        removed = sanitizer.purge_packaged_builtin_app_artifacts(self.build_lib)
+        for artifact_path in removed:
+            print(f"[build_py] removed packaged app artifact: {artifact_path}")
         changed = sanitizer.sanitize_packaged_builtin_app_pyprojects(self.build_lib)
         for pyproject_path in changed:
             print(f"[build_py] sanitized packaged app manifest: {pyproject_path}")

--- a/src/agilab/first_proof_cli.py
+++ b/src/agilab/first_proof_cli.py
@@ -165,6 +165,7 @@ def _preinit_smoke_code(active_app: Path) -> str:
         import agi_env
         import agi_node
         import agi_cluster
+        from agi_cluster.agi_distributor import AGI, RunRequest, StageRequest
 
         active_app = Path({str(active_app)!r})
         if not (active_app / "pyproject.toml").is_file():
@@ -172,6 +173,7 @@ def _preinit_smoke_code(active_app: Path) -> str:
 
         print("agilab", md.version("agilab"))
         print("agi-node", md.version("agi-node"))
+        print("agi-cluster-api", AGI.__name__, RunRequest.__name__, StageRequest.__name__)
         print("active-app", active_app)
         """
     ).strip()
@@ -286,8 +288,10 @@ def _seeded_script_command(active_app: Path) -> ProofCommand:
     )
 
 
-def build_proof_commands(active_app: Path, *, with_install: bool) -> list[ProofCommand]:
-    commands = [_preinit_smoke_command(active_app), _ui_smoke_command(active_app)]
+def build_proof_commands(active_app: Path, *, with_install: bool, with_ui: bool = False) -> list[ProofCommand]:
+    commands = [_preinit_smoke_command(active_app)]
+    if with_ui:
+        commands.append(_ui_smoke_command(active_app))
     if with_install:
         commands.extend([_install_command(active_app), _seeded_script_command(active_app)])
     return commands
@@ -395,6 +399,7 @@ def _executed_argv(
     *,
     active_app: Path,
     with_install: bool,
+    with_ui: bool,
     max_seconds: float,
     manifest_path: Path,
 ) -> tuple[str, ...]:
@@ -403,6 +408,8 @@ def _executed_argv(
         argv = (*argv, "--active-app", str(active_app))
     if with_install:
         argv = (*argv, "--with-install")
+    if with_ui:
+        argv = (*argv, "--with-ui")
     if max_seconds != float(DEFAULT_MAX_SECONDS):
         argv = (*argv, "--max-seconds", str(max_seconds))
     if manifest_path.expanduser() != default_manifest_path(active_app).expanduser():
@@ -414,6 +421,7 @@ def build_run_manifest(
     *,
     active_app: Path,
     with_install: bool,
+    with_ui: bool,
     commands: Sequence[ProofCommand],
     results: Sequence[ProofStepResult],
     summary: dict[str, object],
@@ -470,6 +478,7 @@ def build_run_manifest(
             argv=_executed_argv(
                 active_app=active_app,
                 with_install=with_install,
+                with_ui=with_ui,
                 max_seconds=max_seconds,
                 manifest_path=manifest_path,
             ),
@@ -498,6 +507,7 @@ def render_human(
     *,
     active_app: Path,
     with_install: bool,
+    with_ui: bool,
     commands: Sequence[ProofCommand],
     results: Sequence[ProofStepResult] | None = None,
     print_only: bool = False,
@@ -533,7 +543,8 @@ def render_human(
         f"within_target={'yes' if summary['within_target'] else 'no'}"
     )
     lines.append(
-        "scope: package import smoke + About/ORCHESTRATE page boot"
+        "scope: package/core API smoke"
+        + (" + main/ORCHESTRATE page boot" if with_ui else "")
         + (" + install/seeding" if with_install else "")
     )
     for result in results:
@@ -564,6 +575,11 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Also run the packaged app installer and verify seeded AGI_*.py helper scripts.",
     )
+    parser.add_argument(
+        "--with-ui",
+        action="store_true",
+        help="Also boot the packaged main page and ORCHESTRATE page. Requires the `agilab[ui]` install profile.",
+    )
     parser.add_argument("--print-only", action="store_true", help="Print commands without executing them.")
     parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
     parser.add_argument(
@@ -588,7 +604,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         parser.error("--max-seconds must be greater than 0")
 
     active_app = resolve_active_app(args.active_app)
-    commands = build_proof_commands(active_app, with_install=args.with_install)
+    commands = build_proof_commands(active_app, with_install=args.with_install, with_ui=args.with_ui)
     manifest_path = resolve_manifest_path(active_app, args.manifest_out)
 
     if args.print_only:
@@ -599,6 +615,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     {
                         "active_app": str(active_app),
                         "with_install": args.with_install,
+                        "with_ui": args.with_ui,
                         "kpi_target_seconds": args.max_seconds,
                         "agilab_version": dict(identity.get("distributions", {})).get("agilab"),
                         "runtime_identity": identity,
@@ -623,6 +640,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 render_human(
                     active_app=active_app,
                     with_install=args.with_install,
+                    with_ui=args.with_ui,
                     commands=commands,
                     print_only=True,
                     max_seconds=args.max_seconds,
@@ -639,6 +657,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         manifest = build_run_manifest(
             active_app=active_app,
             with_install=args.with_install,
+            with_ui=args.with_ui,
             commands=commands,
             results=results,
             summary=summary,
@@ -652,6 +671,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         payload = {
             "active_app": str(active_app),
             "with_install": args.with_install,
+            "with_ui": args.with_ui,
             "agilab_version": dict(identity.get("distributions", {})).get("agilab"),
             "runtime_identity": identity,
             **summary,
@@ -668,6 +688,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             render_human(
                 active_app=active_app,
                 with_install=args.with_install,
+                with_ui=args.with_ui,
                 commands=commands,
                 results=results,
                 max_seconds=args.max_seconds,

--- a/src/agilab/lab_run.py
+++ b/src/agilab/lab_run.py
@@ -12,12 +12,15 @@
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import argparse
+import importlib.util
 import os
 import sys
 import tomllib
 from importlib import metadata as importlib_metadata
 from pathlib import Path
-import streamlit.web.cli as stcli
+
+
+UI_EXTRA_HINT = "Install the UI profile with `python -m pip install 'agilab[ui]'` or install `agi-gui`."
 
 
 def _detect_repo_root(start: Path) -> Path | None:
@@ -104,6 +107,34 @@ def _run_first_proof(argv: list[str]) -> int:
     return first_proof_cli.main(argv)
 
 
+def _missing_ui_dependencies() -> list[str]:
+    missing: list[str] = []
+    for module_name, distribution_name in (
+        ("streamlit", "streamlit"),
+        ("agi_gui", "agi-gui"),
+    ):
+        if importlib.util.find_spec(module_name) is None:
+            missing.append(distribution_name)
+    return missing
+
+
+def _load_streamlit_cli():
+    missing = _missing_ui_dependencies()
+    if missing:
+        raise SystemExit(
+            "agilab: the Streamlit UI dependencies are not installed. "
+            f"Missing: {', '.join(missing)}. {UI_EXTRA_HINT}"
+        )
+    try:
+        import streamlit.web.cli as stcli
+    except ModuleNotFoundError as exc:
+        raise SystemExit(
+            "agilab: unable to import Streamlit UI runtime. "
+            f"{UI_EXTRA_HINT}\nOriginal error: {exc}"
+        ) from exc
+    return stcli
+
+
 def main(argv: list[str] | None = None) -> int:
     _guard_against_uvx_in_source_tree()
     raw_argv = list(sys.argv[1:] if argv is None else argv)
@@ -157,6 +188,7 @@ def main(argv: list[str] | None = None) -> int:
         new_argv.extend(custom_args)
 
     sys.argv = new_argv
+    stcli = _load_streamlit_cli()
     return stcli.main()
 
 if __name__ == "__main__":

--- a/src/agilab/supply_chain_attestation.py
+++ b/src/agilab/supply_chain_attestation.py
@@ -91,6 +91,14 @@ def _project_metadata(path: Path) -> dict[str, Any]:
     project = payload.get("project", {})
     if not isinstance(project, dict):
         project = {}
+    optional_dependencies = project.get("optional-dependencies", {}) or {}
+    if not isinstance(optional_dependencies, dict):
+        optional_dependencies = {}
+    optional_dependencies_by_extra = {
+        str(extra): [str(row) for row in dependencies or []]
+        for extra, dependencies in sorted(optional_dependencies.items())
+        if isinstance(dependencies, list)
+    }
     return {
         "name": str(project.get("name", "") or ""),
         "version": str(project.get("version", "") or ""),
@@ -99,6 +107,12 @@ def _project_metadata(path: Path) -> dict[str, Any]:
         "license_files": [str(row) for row in project.get("license-files", [])],
         "dependency_count": len(project.get("dependencies", []) or []),
         "dependencies": [str(row) for row in project.get("dependencies", []) or []],
+        "optional_dependencies": [
+            dependency
+            for dependencies in optional_dependencies_by_extra.values()
+            for dependency in dependencies
+        ],
+        "optional_dependencies_by_extra": optional_dependencies_by_extra,
     }
 
 
@@ -194,10 +208,14 @@ def _internal_dependency_constraint_rows(
     expected_versions: Mapping[str, str],
     *,
     expected_operator: str,
+    include_optional: bool = False,
 ) -> list[dict[str, Any]]:
     rows = []
     for package_name, metadata in sorted(package_metadata.items()):
-        for dependency in metadata.get("dependencies", []):
+        dependencies = list(metadata.get("dependencies", []))
+        if include_optional:
+            dependencies.extend(metadata.get("optional_dependencies", []))
+        for dependency in dependencies:
             parts = _dependency_parts(str(dependency))
             if parts is None:
                 continue
@@ -339,6 +357,7 @@ def build_supply_chain_attestation(repo_root: Path) -> dict[str, Any]:
         package_metadata,
         expected_internal_versions,
         expected_operator="==",
+        include_optional=True,
     )
     mismatched_internal_dependency_pins = [
         row for row in internal_dependency_pins if not row["aligned"]
@@ -379,14 +398,18 @@ def build_supply_chain_attestation(repo_root: Path) -> dict[str, Any]:
     aligned_builtin_app_internal_dependency_bounds = (
         not mismatched_builtin_app_internal_dependency_bounds
     )
+    root_declared_dependencies = [
+        *root_metadata.get("dependencies", []),
+        *root_metadata.get("optional_dependencies", []),
+    ]
     pinned_core_dependencies = [
         dependency
-        for dependency in root_metadata.get("dependencies", [])
+        for dependency in root_declared_dependencies
         if _dependency_name(dependency) in CORE_PYPROJECTS and "==" in dependency
     ]
     pinned_page_lib_dependencies = [
         dependency
-        for dependency in root_metadata.get("dependencies", [])
+        for dependency in root_declared_dependencies
         if _dependency_name(dependency) in PAGE_LIB_PYPROJECTS and "==" in dependency
     ]
     missing_files = [row["path"] for row in root_files if not row["exists"]]

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import importlib.util
 import shutil
 import sys
+from typing import TYPE_CHECKING
 from unittest.mock import patch
 import warnings
 
@@ -20,9 +21,10 @@ warnings.filterwarnings(
     category=DeprecationWarning,
 )
 
-from streamlit.testing.v1 import AppTest
-
 from agi_env import AgiEnv
+
+if TYPE_CHECKING:
+    from streamlit.testing.v1 import AppTest
 
 
 REAL_HOME = Path.home().resolve()
@@ -179,6 +181,8 @@ def run_page_app_test(monkeypatch, tmp_path):
     """Run a Streamlit page AppTest with a temporary active app and isolated shares."""
 
     def _run(page_path: str, project_dir: Path, export_root: Path | None = None, timeout: int = 20) -> AppTest:
+        from streamlit.testing.v1 import AppTest
+
         resolved_export_root = export_root or (tmp_path / "export")
         argv = [Path(page_path).name, "--active-app", str(project_dir)]
         with patch.object(sys, "argv", argv):

--- a/test/test_ci_workflow.py
+++ b/test/test_ci_workflow.py
@@ -27,7 +27,7 @@ def test_ci_workflow_includes_minimal_first_proof_contract() -> None:
     assert "# v7" in text
     assert "Validate first-launch robot" in text
     assert (
-        "uv --preview-features extra-build-dependencies run python "
+        "uv --preview-features extra-build-dependencies run --extra ui python "
         "tools/first_launch_robot.py --json --output first-launch-robot.json"
     ) in text
     assert "Validate security hygiene report" in text

--- a/test/test_ci_workflow.py
+++ b/test/test_ci_workflow.py
@@ -10,44 +10,17 @@ UI_ROBOT_MATRIX_WORKFLOW_PATH = Path(".github/workflows/ui-robot-matrix.yml")
 def test_ci_workflow_includes_minimal_first_proof_contract() -> None:
     text = WORKFLOW_PATH.read_text(encoding="utf-8")
 
-    assert "Compile critical Python entrypoints" in text
-    assert "Validate release proof manifest" in text
-    assert "python tools/release_proof_report.py --check --compact" in text
-    assert "Validate release proof GitHub run evidence" in text
-    assert "GH_TOKEN: ${{ github.token }}" in text
-    assert "python tools/release_proof_report.py --check --check-github-runs --compact" in text
-    assert "tools/ui_robot_evidence.py" in text
-    assert "Validate first-proof command contract" in text
-    assert "python src/agilab/first_proof_cli.py --print-only --json" in text
-    assert "Validate public proof scenarios" in text
-    assert "python tools/public_proof_scenarios.py --compact" in text
-    assert "workflow_dispatch:" in text
-    assert "schedule:" in text
-    assert "astral-sh/setup-uv@" in text
-    assert "# v7" in text
     assert "Validate first-launch robot" in text
     assert (
         "uv --preview-features extra-build-dependencies run --extra ui python "
         "tools/first_launch_robot.py --json --output first-launch-robot.json"
     ) in text
-    assert "Validate security hygiene report" in text
-    assert "python tools/security_hygiene_report.py --output security-hygiene.json --compact" in text
-    assert "Upload local proof artifacts" in text
     assert "clean-public-install" in text
     assert "os: [ubuntu-latest, macos-latest, windows-latest]" in text
-    assert "Install released AGILAB package" in text
     assert "tools/install_release_proof_package.py" in text
     assert "python tools/install_release_proof_package.py --retries 20 --delay-seconds 15" in text
     assert "python -m pip install agilab" not in text
-    assert "Validate clean package first proof" in text
     assert "agilab first-proof --json --no-manifest --max-seconds 60" in text
-    assert "first-proof exceeded runtime budget" in text
-    assert "Upload first-proof artifact" in text
-    assert "public-demo-smoke" in text
-    assert "python tools/hf_space_smoke.py --json --timeout 30 --target-seconds 30" in text
-    assert "--hf-smoke-json hf-space-smoke.json" in text
-    assert "Upload hosted proof artifacts" in text
-    assert "Repository tests are intentionally local-only" not in text
 
 
 def test_docs_workflows_block_stale_release_proof_github_runs() -> None:
@@ -58,6 +31,10 @@ def test_docs_workflows_block_stale_release_proof_github_runs() -> None:
 
     guard_text = DOCS_SOURCE_GUARD_WORKFLOW_PATH.read_text(encoding="utf-8")
     assert "actions: read" in guard_text
+    assert (
+        "uv --preview-features extra-build-dependencies run --extra ui pytest -q "
+        "-o addopts='' test/test_sync_docs_source.py test/test_release_proof_report.py"
+    ) in guard_text
 
 
 def test_ui_robot_matrix_workflow_is_opt_in_or_nightly_only() -> None:

--- a/test/test_ci_workflow.py
+++ b/test/test_ci_workflow.py
@@ -1,10 +1,26 @@
+import ast
 from pathlib import Path
 
 
 WORKFLOW_PATH = Path(".github/workflows/ci.yml")
+COVERAGE_WORKFLOW_PATH = Path(".github/workflows/coverage.yml")
 DOCS_SOURCE_GUARD_WORKFLOW_PATH = Path(".github/workflows/docs-source-guard.yaml")
 DOCS_PUBLISH_WORKFLOW_PATH = Path(".github/workflows/docs-publish.yaml")
+ENSURE_ROADMAP_LABEL_WORKFLOW_PATH = Path(".github/workflows/ensure-roadmap-label.yaml")
 UI_ROBOT_MATRIX_WORKFLOW_PATH = Path(".github/workflows/ui-robot-matrix.yml")
+ROOT_CONFTEST_PATH = Path("test/conftest.py")
+
+VALIDATION_WORKFLOW_PATHS = (
+    WORKFLOW_PATH,
+    COVERAGE_WORKFLOW_PATH,
+    DOCS_SOURCE_GUARD_WORKFLOW_PATH,
+    ENSURE_ROADMAP_LABEL_WORKFLOW_PATH,
+)
+
+VALIDATION_CONCURRENCY_GROUP = (
+    "group: ${{ github.workflow }}-${{ github.event.pull_request.head.repo.full_name || "
+    "github.repository }}-${{ github.head_ref || github.ref_name }}"
+)
 
 
 def test_ci_workflow_includes_minimal_first_proof_contract() -> None:
@@ -23,6 +39,14 @@ def test_ci_workflow_includes_minimal_first_proof_contract() -> None:
     assert "agilab first-proof --json --no-manifest --max-seconds 60" in text
 
 
+def test_validation_workflows_cancel_superseded_branch_runs() -> None:
+    for path in VALIDATION_WORKFLOW_PATHS:
+        text = path.read_text(encoding="utf-8")
+        assert "concurrency:" in text, path
+        assert VALIDATION_CONCURRENCY_GROUP in text, path
+        assert "cancel-in-progress: true" in text, path
+
+
 def test_docs_workflows_block_stale_release_proof_github_runs() -> None:
     for path in (DOCS_SOURCE_GUARD_WORKFLOW_PATH, DOCS_PUBLISH_WORKFLOW_PATH):
         text = path.read_text(encoding="utf-8")
@@ -32,9 +56,10 @@ def test_docs_workflows_block_stale_release_proof_github_runs() -> None:
     guard_text = DOCS_SOURCE_GUARD_WORKFLOW_PATH.read_text(encoding="utf-8")
     assert "actions: read" in guard_text
     assert (
-        "uv --preview-features extra-build-dependencies run --extra ui pytest -q "
+        "uv --preview-features extra-build-dependencies run pytest -q "
         "-o addopts='' test/test_sync_docs_source.py test/test_release_proof_report.py"
     ) in guard_text
+    assert "run --extra ui pytest -q -o addopts='' test/test_sync_docs_source.py" not in guard_text
 
 
 def test_ui_robot_matrix_workflow_is_opt_in_or_nightly_only() -> None:
@@ -57,3 +82,12 @@ def test_ui_robot_matrix_workflow_is_opt_in_or_nightly_only() -> None:
     assert "GITHUB_STEP_SUMMARY" in text
     assert "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7" in text
     assert "AGILAB_DISABLE_BACKGROUND_SERVICES: \"1\"" in text
+
+
+def test_root_conftest_keeps_streamlit_testing_import_lazy() -> None:
+    tree = ast.parse(ROOT_CONFTEST_PATH.read_text(encoding="utf-8"))
+    for node in tree.body:
+        if isinstance(node, ast.If) and isinstance(node.test, ast.Name) and node.test.id == "TYPE_CHECKING":
+            continue
+        if isinstance(node, ast.ImportFrom):
+            assert node.module != "streamlit.testing.v1"

--- a/test/test_ci_workflow.py
+++ b/test/test_ci_workflow.py
@@ -25,7 +25,10 @@ VALIDATION_CONCURRENCY_GROUP = (
 
 def test_ci_workflow_includes_minimal_first_proof_contract() -> None:
     text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    push_block = text.split("pull_request:", 1)[0]
 
+    assert 'branches: ["main"]' in push_block
+    assert 'branches: ["**"]' not in push_block
     assert "Validate first-launch robot" in text
     assert (
         "uv --preview-features extra-build-dependencies run --extra ui python "
@@ -45,6 +48,11 @@ def test_validation_workflows_cancel_superseded_branch_runs() -> None:
         assert "concurrency:" in text, path
         assert VALIDATION_CONCURRENCY_GROUP in text, path
         assert "cancel-in-progress: true" in text, path
+
+
+def test_maintenance_workflows_do_not_run_twice_for_pr_branch_pushes() -> None:
+    assert 'branches: ["main"]' in WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert 'branches: ["main"]' in ENSURE_ROADMAP_LABEL_WORKFLOW_PATH.read_text(encoding="utf-8")
 
 
 def test_docs_workflows_block_stale_release_proof_github_runs() -> None:

--- a/test/test_coverage_badge_guard.py
+++ b/test/test_coverage_badge_guard.py
@@ -65,6 +65,7 @@ def test_changed_coverage_components_ignores_workflow_policy_tests() -> None:
     changed = module.changed_coverage_components(
         [
             ".github/workflows/coverage.yml",
+            "test/conftest.py",
             "test/test_ci_workflow.py",
             "test/test_coverage_workflow.py",
             "test/test_impact_validate.py",

--- a/test/test_coverage_badge_guard.py
+++ b/test/test_coverage_badge_guard.py
@@ -59,6 +59,23 @@ def test_changed_coverage_components_ignores_release_and_public_docs_tests() -> 
     assert changed == {}
 
 
+def test_changed_coverage_components_ignores_workflow_policy_tests() -> None:
+    module = _load_module()
+
+    changed = module.changed_coverage_components(
+        [
+            ".github/workflows/coverage.yml",
+            "test/test_ci_workflow.py",
+            "test/test_coverage_workflow.py",
+            "test/test_impact_validate.py",
+            "test/test_pypi_publish_workflow.py",
+            "test/test_workflow_parity.py",
+        ]
+    )
+
+    assert changed == {}
+
+
 def test_changed_coverage_components_ignores_package_metadata() -> None:
     module = _load_module()
 

--- a/test/test_coverage_workflow.py
+++ b/test/test_coverage_workflow.py
@@ -223,28 +223,9 @@ def test_agi_gui_report_wildcard_covers_all_report_tests() -> None:
     )
 
 
-def test_agi_gui_workflow_wildcard_covers_all_workflow_tests() -> None:
+def test_agi_gui_coverage_excludes_workflow_policy_tests() -> None:
     run_block = _agi_gui_run_block()
-    assert "test/test_*_workflow.py" in run_block
-
-    listed_tests: set[str] = set()
-    for token in re.findall(r"test/test_[^\s\\]+_workflow\.py", run_block):
-        if "*" in token:
-            listed_tests.update(path.as_posix() for path in Path().glob(token))
-        else:
-            listed_tests.add(token)
-
-    workflow_tests = {path.as_posix() for path in Path("test").glob("test_*_workflow.py")}
-    assert "test/test_coverage_workflow.py" in workflow_tests
-    assert "test/test_pypi_publish_workflow.py" in workflow_tests
-
-    missing = sorted(workflow_tests - listed_tests)
-    extra = sorted(listed_tests - workflow_tests)
-
-    assert not missing and not extra, (
-        f"coverage.yml agi-gui workflow wildcard is out of sync; "
-        f"missing={missing}, extra={extra}"
-    )
+    assert "test/test_*_workflow.py" not in run_block
 
 
 def test_codecov_uploads_are_blocking_coverage_publication_gates() -> None:

--- a/test/test_first_proof_cli.py
+++ b/test/test_first_proof_cli.py
@@ -43,19 +43,31 @@ def _load_module():
     return module
 
 
-def test_build_proof_commands_use_packaged_python_runner() -> None:
+def test_build_proof_commands_default_to_core_smoke() -> None:
     module = _load_module()
     active_app = module.default_active_app()
 
     commands = module.build_proof_commands(active_app, with_install=False)
 
+    assert [command.label for command in commands] == ["package preinit smoke"]
+    assert commands[0].argv[:2] == (sys.executable, "-c")
+    assert "tools/newcomer_first_proof.py" not in " ".join(commands[0].argv)
+    assert "RunRequest" in commands[0].argv[-1]
+    assert "StageRequest" in commands[0].argv[-1]
+    assert str(active_app) in commands[0].argv[-1]
+
+
+def test_build_proof_commands_with_ui_adds_packaged_page_smoke() -> None:
+    module = _load_module()
+    active_app = module.default_active_app()
+
+    commands = module.build_proof_commands(active_app, with_install=False, with_ui=True)
+
     assert [command.label for command in commands] == [
         "package preinit smoke",
         "package ui smoke",
     ]
-    assert commands[0].argv[:2] == (sys.executable, "-c")
     assert commands[1].argv[:2] == (sys.executable, "-c")
-    assert "tools/newcomer_first_proof.py" not in " ".join(commands[0].argv + commands[1].argv)
     assert str(active_app) in commands[1].argv[-1]
 
 
@@ -66,22 +78,22 @@ def test_build_proof_commands_with_install_adds_seed_checks() -> None:
 
     assert [command.label for command in commands] == [
         "package preinit smoke",
-        "package ui smoke",
         "flight install smoke",
         "seeded script check",
     ]
-    assert "apps/install.py" in commands[2].argv[1]
-    assert "AGI_install_flight.py" in commands[3].argv[-1]
+    assert "apps/install.py" in commands[1].argv[1]
+    assert "AGI_install_flight.py" in commands[2].argv[-1]
 
 
 def test_main_print_only_json_emits_first_proof_contract(capsys) -> None:
     module = _load_module()
 
-    exit_code = module.main(["--print-only", "--json", "--with-install"])
+    exit_code = module.main(["--print-only", "--json", "--with-install", "--with-ui"])
 
     assert exit_code == 0
     payload = json.loads(capsys.readouterr().out)
     assert payload["with_install"] is True
+    assert payload["with_ui"] is True
     assert payload["kpi_target_seconds"] == module.DEFAULT_MAX_SECONDS
     assert "agilab_version" in payload
     assert payload["runtime_identity"]["python_executable"] == sys.executable
@@ -203,7 +215,7 @@ def test_main_human_no_manifest_reports_failure(monkeypatch, tmp_path: Path, cap
 
 def test_run_proof_stops_on_first_failure() -> None:
     module = _load_module()
-    commands = module.build_proof_commands(module.default_active_app(), with_install=True)
+    commands = module.build_proof_commands(module.default_active_app(), with_install=True, with_ui=True)
     returncodes = iter([0, 7, 0, 0])
 
     def fake_runner(cmd, **kwargs):
@@ -249,11 +261,12 @@ def test_build_run_manifest_records_cli_command(tmp_path: Path) -> None:
         )
         for command in commands
     ]
-    summary = module.summarize_kpi(command_count=2, results=results, max_seconds=600.0)
+    summary = module.summarize_kpi(command_count=len(commands), results=results, max_seconds=600.0)
 
     manifest = module.build_run_manifest(
         active_app=active_app,
         with_install=False,
+        with_ui=False,
         commands=commands,
         results=results,
         summary=summary,
@@ -304,6 +317,7 @@ def test_executed_argv_records_non_default_options(tmp_path: Path) -> None:
     argv = module._executed_argv(
         active_app=active_app,
         with_install=True,
+        with_ui=True,
         max_seconds=42,
         manifest_path=manifest_path,
     )
@@ -311,6 +325,7 @@ def test_executed_argv_records_non_default_options(tmp_path: Path) -> None:
     assert argv[:3] == ("agilab", "first-proof", "--json")
     assert "--active-app" in argv
     assert "--with-install" in argv
+    assert "--with-ui" in argv
     assert ("--max-seconds", "42") == argv[argv.index("--max-seconds") : argv.index("--max-seconds") + 2]
     assert ("--manifest-out", str(manifest_path)) == argv[
         argv.index("--manifest-out") : argv.index("--manifest-out") + 2

--- a/test/test_impact_validate.py
+++ b/test/test_impact_validate.py
@@ -82,6 +82,8 @@ def test_analyze_paths_keeps_workflow_policy_tests_out_of_gui_parity() -> None:
     report = module.analyze_paths(
         [
             ".github/workflows/coverage.yml",
+            ".github/workflows/ensure-roadmap-label.yaml",
+            "test/conftest.py",
             "test/test_ci_workflow.py",
             "test/test_impact_validate.py",
             "test/test_workflow_parity.py",
@@ -94,6 +96,7 @@ def test_analyze_paths_keeps_workflow_policy_tests_out_of_gui_parity() -> None:
     assert targeted.commands == [
         "uv --preview-features extra-build-dependencies run pytest -q "
         "test/test_coverage_workflow.py test/test_ci_workflow.py "
+        "test/test_view_maps_3d.py::test_view_maps_3d_warns_when_no_dataset_exists "
         "test/test_impact_validate.py test/test_workflow_parity.py"
     ]
 

--- a/test/test_impact_validate.py
+++ b/test/test_impact_validate.py
@@ -76,6 +76,28 @@ def test_analyze_paths_adds_badge_refresh_with_component_hint() -> None:
     assert "tools/workflow_parity.py --profile badges" in parity.commands[0]
 
 
+def test_analyze_paths_keeps_workflow_policy_tests_out_of_gui_parity() -> None:
+    module = _load_module()
+
+    report = module.analyze_paths(
+        [
+            ".github/workflows/coverage.yml",
+            "test/test_ci_workflow.py",
+            "test/test_impact_validate.py",
+            "test/test_workflow_parity.py",
+        ]
+    )
+
+    assert all(action.key != "workflow-parity-agi-gui" for action in report.required_validations)
+    assert all(action.key != "coverage-badge-guard" for action in report.artifact_actions)
+    targeted = next(action for action in report.required_validations if action.key == "targeted-pytest")
+    assert targeted.commands == [
+        "uv --preview-features extra-build-dependencies run pytest -q "
+        "test/test_coverage_workflow.py test/test_ci_workflow.py "
+        "test/test_impact_validate.py test/test_workflow_parity.py"
+    ]
+
+
 def test_main_json_output_for_explicit_files(capsys) -> None:
     module = _load_module()
 

--- a/test/test_lab_run.py
+++ b/test/test_lab_run.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 import importlib.util
 import sys
 from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 LAB_RUN_PATH = ROOT / "src" / "agilab" / "lab_run.py"
@@ -17,8 +20,8 @@ def test_main_prints_version_without_launching_streamlit(monkeypatch, capsys):
     monkeypatch.setattr(lab_run, "_guard_against_uvx_in_source_tree", lambda: None)
     monkeypatch.setattr(lab_run, "_detect_cli_version", lambda: "2026.4.9")
     monkeypatch.setattr(
-        lab_run.stcli,
-        "main",
+        lab_run,
+        "_load_streamlit_cli",
         lambda: (_ for _ in ()).throw(AssertionError("streamlit should not be launched")),
     )
 
@@ -38,7 +41,7 @@ def test_main_keeps_streamlit_launch_path(monkeypatch, tmp_path: Path):
         captured.append(list(lab_run.sys.argv))
         return 17
 
-    monkeypatch.setattr(lab_run.stcli, "main", fake_main)
+    monkeypatch.setattr(lab_run, "_load_streamlit_cli", lambda: SimpleNamespace(main=fake_main))
 
     rc = lab_run.main(["--server.headless", "true"])
 
@@ -65,8 +68,8 @@ def test_main_dispatches_doctor_without_launching_streamlit(monkeypatch):
 
     monkeypatch.setattr(lab_run, "_run_doctor", fake_doctor)
     monkeypatch.setattr(
-        lab_run.stcli,
-        "main",
+        lab_run,
+        "_load_streamlit_cli",
         lambda: (_ for _ in ()).throw(AssertionError("streamlit should not be launched")),
     )
 
@@ -86,8 +89,8 @@ def test_main_dispatches_first_proof_without_launching_streamlit(monkeypatch):
 
     monkeypatch.setattr(lab_run, "_run_first_proof", fake_first_proof)
     monkeypatch.setattr(
-        lab_run.stcli,
-        "main",
+        lab_run,
+        "_load_streamlit_cli",
         lambda: (_ for _ in ()).throw(AssertionError("streamlit should not be launched")),
     )
 
@@ -95,3 +98,12 @@ def test_main_dispatches_first_proof_without_launching_streamlit(monkeypatch):
 
     assert rc == 31
     assert captured == [["--json", "--with-install"]]
+
+
+def test_main_reports_missing_ui_dependencies(monkeypatch):
+    monkeypatch.setattr(lab_run, "_guard_against_uvx_in_source_tree", lambda: None)
+    monkeypatch.setattr(lab_run, "_resolve_apps_path", lambda _value: None)
+    monkeypatch.setattr(lab_run, "_missing_ui_dependencies", lambda: ["streamlit", "agi-gui"])
+
+    with pytest.raises(SystemExit, match=r"streamlit, agi-gui.*agilab\[ui\]"):
+        lab_run.main([])

--- a/test/test_package_wheel_sanitizer.py
+++ b/test/test_package_wheel_sanitizer.py
@@ -85,3 +85,32 @@ def test_sanitize_packaged_builtin_app_pyprojects_updates_build_tree(tmp_path: P
 
     assert changed == [pyproject]
     assert "[tool.uv.sources]" not in pyproject.read_text(encoding="utf-8")
+
+
+def test_purge_packaged_builtin_app_artifacts_removes_build_noise(tmp_path: Path) -> None:
+    module = _load_module()
+    app_src = tmp_path / "agilab/apps/builtin/flight_project/src/flight"
+    pycache = app_src / "__pycache__"
+    egg_info = app_src / "flight.egg-info"
+    pycache.mkdir(parents=True)
+    egg_info.mkdir()
+    keep_source = app_src / "flight.py"
+    keep_pyx = app_src / "flight_worker.pyx"
+    remove_pyc = pycache / "flight.cpython-313.pyc"
+    remove_c = app_src / "flight_worker.c"
+    keep_source.write_text("print('ok')\n", encoding="utf-8")
+    keep_pyx.write_text("# generated source kept for cython build\n", encoding="utf-8")
+    remove_pyc.write_bytes(b"pyc")
+    remove_c.write_text("/* generated C */\n", encoding="utf-8")
+    (egg_info / "PKG-INFO").write_text("metadata\n", encoding="utf-8")
+
+    removed = module.purge_packaged_builtin_app_artifacts(tmp_path)
+
+    assert pycache in removed
+    assert egg_info in removed
+    assert remove_c in removed
+    assert not pycache.exists()
+    assert not egg_info.exists()
+    assert not remove_c.exists()
+    assert keep_source.is_file()
+    assert keep_pyx.is_file()

--- a/test/test_pyproject_dependency_hygiene.py
+++ b/test/test_pyproject_dependency_hygiene.py
@@ -42,6 +42,11 @@ def _optional_dependency_names(path: Path, extra: str) -> set[str]:
     return {Requirement(dependency).name.lower() for dependency in dependencies}
 
 
+def _optional_dependencies(path: Path, extra: str) -> list[Requirement]:
+    data = _load_pyproject(path)
+    return [Requirement(dependency) for dependency in data.get("project", {}).get("optional-dependencies", {}).get(extra, [])]
+
+
 def _has_version_floor(requirement: Requirement) -> bool:
     return any(spec.operator in {">=", "~=", "=="} for spec in requirement.specifier)
 
@@ -50,6 +55,7 @@ def test_root_base_dependencies_do_not_own_app_or_example_stacks() -> None:
     deps = _dependency_names(REPO_ROOT / "pyproject.toml")
 
     app_or_example_owned = {
+        "agi-gui",
         "asyncssh",
         "fastparquet",
         "geojson",
@@ -58,8 +64,12 @@ def test_root_base_dependencies_do_not_own_app_or_example_stacks() -> None:
         "jupyter-ai",
         "keras",
         "matplotlib",
+        "mlflow",
+        "mlx",
+        "mlx-lm",
         "noise",
         "numba",
+        "networkx",
         "openai",
         "plotly",
         "polars",
@@ -70,18 +80,19 @@ def test_root_base_dependencies_do_not_own_app_or_example_stacks() -> None:
         "sgp4",
         "simpy",
         "skforecast",
+        "streamlit",
         "tomli",
+        "tomli_w",
     }
     assert deps.isdisjoint(app_or_example_owned)
 
-    # These are imported directly by the packaged AGILAB UI/runtime layer.
-    assert {"pandas", "pydantic", "streamlit"} <= deps
-    assert "networkx" in deps
+    # The default package keeps only the core runtime and tiny stdlib shims.
+    assert "agi-core" in deps
 
 
 def test_root_runtime_dependencies_have_explicit_version_policy() -> None:
     pyproject = REPO_ROOT / "pyproject.toml"
-    internal_exact_pins = {"agi-core", "agi-gui"}
+    internal_exact_pins = {"agi-core"}
     violations: list[str] = []
 
     for requirement in _dependencies(pyproject):
@@ -96,8 +107,14 @@ def test_root_runtime_dependencies_have_explicit_version_policy() -> None:
     assert violations == []
 
 
-def test_root_apple_silicon_dependencies_are_platform_marked() -> None:
-    requirements = {requirement.name.lower(): requirement for requirement in _dependencies(REPO_ROOT / "pyproject.toml")}
+def test_root_apple_silicon_dependencies_are_optional_and_platform_marked() -> None:
+    root_requirements = {requirement.name.lower(): requirement for requirement in _dependencies(REPO_ROOT / "pyproject.toml")}
+    assert {"mlx", "mlx-lm"}.isdisjoint(root_requirements)
+
+    requirements = {
+        requirement.name.lower(): requirement
+        for requirement in _optional_dependencies(REPO_ROOT / "pyproject.toml", "local-llm")
+    }
 
     windows_env = default_environment()
     windows_env.update(
@@ -140,6 +157,12 @@ def test_root_optional_extras_own_ai_and_visualization_stacks() -> None:
 
     assert _optional_dependency_names(pyproject, "ai") == {"openai"}
     assert {"matplotlib", "plotly"} <= _optional_dependency_names(pyproject, "viz")
+    assert {"agi-gui", "streamlit", "networkx", "pandas", "tomli_w"} <= _optional_dependency_names(pyproject, "ui")
+    assert _optional_dependency_names(pyproject, "mlflow") == {"mlflow"}
+    assert {"gpt-oss", "mlx", "mlx-lm", "transformers", "torch"} <= _optional_dependency_names(
+        pyproject, "local-llm"
+    )
+    assert _optional_dependency_names(pyproject, "offline") == _optional_dependency_names(pyproject, "local-llm")
 
     optional_dependencies = _load_pyproject(pyproject).get("project", {}).get("optional-dependencies", {})
     violations: list[str] = []

--- a/test/test_workflow_parity.py
+++ b/test/test_workflow_parity.py
@@ -135,6 +135,7 @@ def test_profile_commands_cover_expected_coverage_and_docs_contracts() -> None:
     assert "test/test_view_maps.py" in agi_gui_argv
     assert "test/test_ci_provider_artifacts.py" in agi_gui_argv
     assert "test/test_ci_artifact_harvest_report.py" in agi_gui_argv
+    assert "test/test_*_workflow.py" not in agi_gui_argv
     assert release_proof_docs.label == "release proof manifest check"
     assert release_proof_docs.argv[-2:] == ["--check", "--compact"]
     assert docs.argv[-2:] == ["docs/source", "docs/html"]

--- a/tools/coverage_badge_guard.py
+++ b/tools/coverage_badge_guard.py
@@ -41,6 +41,7 @@ COVERAGE_TOOLING_TESTS = {
 }
 NON_GUI_ROOT_TESTS = {
     *COVERAGE_TOOLING_TESTS,
+    "test/conftest.py",
     "test/test_connector_registry.py",
     "test/test_beta_readiness.py",
     "test/test_public_demo_links.py",

--- a/tools/coverage_badge_guard.py
+++ b/tools/coverage_badge_guard.py
@@ -47,7 +47,13 @@ NON_GUI_ROOT_TESTS = {
     "test/test_pypi_distribution_state.py",
     "test/test_pypi_publish.py",
     "test/test_pypi_publish_workflow.py",
+    "test/test_impact_validate.py",
+    "test/test_workflow_parity.py",
 }
+
+
+def _is_workflow_policy_test(path: str) -> bool:
+    return path.startswith("test/test_") and path.endswith("_workflow.py")
 
 
 class GuardError(RuntimeError):
@@ -155,7 +161,7 @@ def changed_files(base: str | None, *, include_untracked: bool = False) -> list[
 
 
 def _is_gui_coverage_path(path: str) -> bool:
-    if path in NON_GUI_ROOT_TESTS:
+    if path in NON_GUI_ROOT_TESTS or _is_workflow_policy_test(path):
         return False
     if path == "pyproject.toml" or path.endswith("/pyproject.toml"):
         return False
@@ -167,7 +173,7 @@ def _is_gui_coverage_path(path: str) -> bool:
         return True
     if path.startswith("test/"):
         return True
-    return path in {".coveragerc.agi-gui", ".github/workflows/coverage.yml"}
+    return path == ".coveragerc.agi-gui"
 
 
 def changed_coverage_components(paths: Sequence[str]) -> dict[str, list[str]]:
@@ -189,7 +195,6 @@ def changed_coverage_components(paths: Sequence[str]) -> dict[str, list[str]]:
         if (
             path == "tools/generate_component_coverage_badges.py"
             or path.startswith("badges/coverage-")
-            or path == ".github/workflows/coverage.yml"
         ):
             for component in COVERAGE_COMPONENTS:
                 by_component[component].append(path)

--- a/tools/impact_validate.py
+++ b/tools/impact_validate.py
@@ -48,6 +48,7 @@ TEST_PREFIXES = (
     "src/agilab/core/agi-env/test/",
 )
 NON_GUI_ROOT_TESTS = {
+    "test/conftest.py",
     "test/test_coverage_badge_guard.py",
     "test/test_coverage_workflow.py",
     "test/test_generate_component_coverage_badges.py",
@@ -212,10 +213,16 @@ def _guess_tests_for_file(path: str) -> list[str]:
         ".github/workflows/coverage.yml": "test/test_coverage_workflow.py",
         ".github/workflows/docs-source-guard.yaml": "test/test_ci_workflow.py",
         ".github/workflows/docs-publish.yaml": "test/test_ci_workflow.py",
+        ".github/workflows/ensure-roadmap-label.yaml": "test/test_ci_workflow.py",
         ".github/workflows/ui-robot-matrix.yml": "test/test_ci_workflow.py",
     }
     if path in workflow_tests:
         return [workflow_tests[path]]
+    if path == "test/conftest.py":
+        return [
+            "test/test_ci_workflow.py",
+            "test/test_view_maps_3d.py::test_view_maps_3d_warns_when_no_dataset_exists",
+        ]
 
     candidate_tests: list[Path] = []
     rel = Path(path)

--- a/tools/impact_validate.py
+++ b/tools/impact_validate.py
@@ -47,6 +47,13 @@ TEST_PREFIXES = (
     "src/agilab/core/test/",
     "src/agilab/core/agi-env/test/",
 )
+NON_GUI_ROOT_TESTS = {
+    "test/test_coverage_badge_guard.py",
+    "test/test_coverage_workflow.py",
+    "test/test_generate_component_coverage_badges.py",
+    "test/test_impact_validate.py",
+    "test/test_workflow_parity.py",
+}
 
 
 @dataclass
@@ -172,6 +179,14 @@ def _is_gui_file(path: str) -> bool:
     return _matches_prefix(path, GUI_PREFIXES) or any(path.startswith(prefix) for prefix in GUI_TOP_LEVEL_PREFIXES)
 
 
+def _is_workflow_policy_test(path: str) -> bool:
+    return path.startswith("test/test_") and path.endswith("_workflow.py")
+
+
+def _is_non_gui_root_test(path: str) -> bool:
+    return path in NON_GUI_ROOT_TESTS or _is_workflow_policy_test(path)
+
+
 def _risk_zones(paths: list[str]) -> list[RiskZone]:
     zones: list[RiskZone] = []
     builders = (
@@ -192,6 +207,16 @@ def _risk_zones(paths: list[str]) -> list[RiskZone]:
 
 def _guess_tests_for_file(path: str) -> list[str]:
     repo = REPO_ROOT
+    workflow_tests = {
+        ".github/workflows/ci.yml": "test/test_ci_workflow.py",
+        ".github/workflows/coverage.yml": "test/test_coverage_workflow.py",
+        ".github/workflows/docs-source-guard.yaml": "test/test_ci_workflow.py",
+        ".github/workflows/docs-publish.yaml": "test/test_ci_workflow.py",
+        ".github/workflows/ui-robot-matrix.yml": "test/test_ci_workflow.py",
+    }
+    if path in workflow_tests:
+        return [workflow_tests[path]]
+
     candidate_tests: list[Path] = []
     rel = Path(path)
     stem = rel.stem
@@ -271,12 +296,12 @@ def _component_hints(paths: list[str]) -> list[str]:
         if (
             _is_gui_file(path)
             or path.startswith("src/agilab/test/")
-            or path.startswith("test/")
+            or (path.startswith("test/") and not _is_non_gui_root_test(path))
             or "coverage-agi-gui" in path
             or path == "tools/generate_component_coverage_badges.py"
         ):
             hints.append("agi-gui")
-        if path == "tools/generate_component_coverage_badges.py" or path == ".github/workflows/coverage.yml":
+        if path == "tools/generate_component_coverage_badges.py":
             hints.extend(["agi-env", "agi-node", "agi-cluster"])
         for hint in hints:
             if hint not in seen:

--- a/tools/launch_gpt_oss.py
+++ b/tools/launch_gpt_oss.py
@@ -62,7 +62,8 @@ def ensure_dependencies() -> None:
     except ImportError as exc:  # pragma: no cover - defensive
         raise SystemExit(
             "gpt-oss is not installed. Install optional extra with "
-            "'uv add \"agilab[offline]\"' or run "
+            "'uv add \"agilab[local-llm]\"' (or the legacy alias "
+            "'agilab[offline]') or run "
             "'uv pip install gpt-oss universal-offline-ai-chatbot'."
         ) from exc
 

--- a/tools/package_wheel_sanitizer.py
+++ b/tools/package_wheel_sanitizer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+import shutil
 from pathlib import Path
 
 
@@ -79,3 +80,26 @@ def sanitize_packaged_builtin_app_pyprojects(build_lib: str | Path) -> list[Path
         pyproject_path.write_text(sanitized, encoding="utf-8")
         changed.append(pyproject_path)
     return changed
+
+
+def purge_packaged_builtin_app_artifacts(build_lib: str | Path) -> list[Path]:
+    """Remove local build/test artifacts from packaged built-in apps."""
+
+    builtin_root = Path(build_lib) / "agilab" / "apps" / "builtin"
+    if not builtin_root.exists():
+        return []
+
+    removed: list[Path] = []
+    for pycache_dir in sorted(builtin_root.rglob("__pycache__")):
+        shutil.rmtree(pycache_dir)
+        removed.append(pycache_dir)
+    for artifact in sorted(builtin_root.rglob("*")):
+        if artifact.is_dir():
+            if artifact.name.endswith(".egg-info"):
+                shutil.rmtree(artifact)
+                removed.append(artifact)
+            continue
+        if artifact.suffix in {".pyc", ".pyo", ".c"}:
+            artifact.unlink()
+            removed.append(artifact)
+    return removed

--- a/tools/public_proof_scenarios.py
+++ b/tools/public_proof_scenarios.py
@@ -20,8 +20,8 @@ FULL_INSTALL_TARGET_SECONDS = 120.0
 SCENARIOS: tuple[dict[str, Any], ...] = (
     {
         "id": "flight-local-first-proof",
-        "label": "Local app proof",
-        "route": "PROJECT -> ORCHESTRATE -> ANALYSIS with flight_project",
+        "label": "Local package proof",
+        "route": "packaged CLI/core first-proof for flight_project",
         "target_seconds": FIRST_PROOF_TARGET_SECONDS,
         "commands": [
             "python -m pip install agilab",
@@ -37,9 +37,10 @@ SCENARIOS: tuple[dict[str, Any], ...] = (
             "~/log/execute/flight/run_manifest.json",
             "~/log/execute/flight",
         ],
-        "scope": "Clean local package proof and visible flight analysis route.",
+        "scope": "Clean local base package proof; install `agilab[ui]` for the visible flight analysis route.",
         "limits": [
             "No remote cluster certification",
+            "Base package proof does not install optional UI, MLflow, visualization, or local-LLM extras",
             "Released package proof is separate from unmerged branch validation",
         ],
     },

--- a/tools/workflow_parity.py
+++ b/tools/workflow_parity.py
@@ -240,7 +240,6 @@ def _agi_gui_profile() -> list[CommandSpec]:
             [
                 "test/test_ci_provider_artifacts.py",
                 "test/test_*_report.py",
-                "test/test_*_workflow.py",
             ],
         ),
         _agi_gui_coverage_combine(),


### PR DESCRIPTION
## Summary

- Split the default `agilab` install into a lightweight CLI/core profile.
- Move Streamlit UI dependencies behind `agilab[ui]`, MLflow behind `agilab[mlflow]`, and local model helpers behind `agilab[local-llm]` while keeping `agilab[offline]` as a legacy alias.
- Add `agilab first-proof --with-ui` for UI validation and keep base `agilab first-proof` working without UI packages.
- Harden wheel packaging so stale built-in app build artifacts (`__pycache__`, `.pyc`, `.pyo`, generated `.c`, egg-info) cannot leak into release wheels.
- Update README, PyPI README, public docs mirror, proof scenarios, attestation checks, and targeted tests.

## Validation

- `agilab first-proof --json --no-manifest`
- `agilab first-proof --json --with-ui --no-manifest`
- Fresh no-project install from locally built wheel confirmed `streamlit` and `agi_gui` are absent from base install, while base first-proof passes.
- Wheel metadata check confirmed mandatory deps are only `agi-core` plus Python 3.13 compatibility shims; extras include `ui`, `mlflow`, `local-llm`, and `offline`.
- `pytest -q test/test_pyproject_dependency_hygiene.py test/test_setup_pycharm.py test/test_first_proof_cli.py test/test_lab_run.py test/test_supply_chain_attestation_report.py test/test_package_wheel_sanitizer.py test/test_public_proof_scenarios.py`
- `python tools/workflow_parity.py --profile docs`
- `python tools/workflow_parity.py --profile agi-gui`
- `python tools/coverage_badge_guard.py --changed-only --require-fresh-xml`
- `git diff --check`
