### PR TITLE
[codex] Add advisory security check

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -49,11 +49,45 @@ We appreciate coordinated disclosure and will keep you updated throughout the pr
 - Other fixes may be bundled into the next scheduled monthly update.
 - Release notes highlight CVE identifiers or internal tracking IDs where applicable.
 
+## Adoption Profile
+
+AGILAB is designed as a trusted-operator experimentation workbench. It can install apps,
+generate and execute Python snippets, launch worker environments, orchestrate local or
+distributed runs, and optionally start UI, tracking, or local-model tooling. Treat every app,
+notebook, generated snippet, and external apps repository as executable code until it has been
+reviewed.
+
+Recommended use without additional platform hardening:
+
+- Local research sandbox, notebook-to-app migration, reproducible experiment replay, and internal
+  demonstrations with non-sensitive data.
+- Single-operator or controlled lab environments where the operator owns the apps, dependencies,
+  datasets, secrets, and worker machines.
+
+Conditional use only after hardening:
+
+- Shared team deployments, internal clusters, local/remote LLM use, or external apps repositories.
+- Minimum controls: per-user isolation, container or VM boundaries, a dedicated OS user, restricted
+  outbound network access, bounded CPU/RAM, reviewed app code, scanned dependencies, controlled
+  logs, and secrets supplied outside repository or command-line arguments.
+
+Not recommended as-is:
+
+- public exposure without authentication, TLS, and sandboxing.
+- Multi-tenant service use, writable shared cluster directories, untrusted apps, sensitive or
+  regulated data, or production ML serving/governance/monitoring workloads.
+- Environments where AGILAB must be the only production MLOps control plane. Use production
+  serving, feature-store, monitoring, policy, and governance systems alongside AGILAB when those
+  controls are required.
+
 ## Hardening Checklist
 
 While AGILAB is open source, production-grade cluster deployments should be designed with your
 organization's security requirements in mind. At minimum:
 
+- Run AGILAB in a confined environment for shared or unknown workloads: container, VM, disposable
+  workspace, dedicated UID, no default access to personal secrets, CPU/RAM quotas, and restricted
+  network egress.
 - Run behind HTTPS and limit inbound network access to trusted operators.
 - Store API keys, model weights, and datasets outside of the repository, using a dedicated secrets
   manager where possible.
@@ -63,10 +97,18 @@ organization's security requirements in mind. At minimum:
 - Treat AGILAB command execution as a trusted-operator boundary. Shared deployments should restrict
   project roots, environment variables, writable paths, and network access according to the team
   threat model.
+- Run ``agilab security-check --json`` before shared adoption reviews. The command is advisory by
+  default and reports local risks such as floating ``APPS_REPOSITORY`` checkouts, plaintext
+  ``~/.agilab/.env`` secrets, exposed UI binds, cluster-share isolation issues, optional local-model
+  profiles, and missing SBOM / ``pip-audit`` evidence. Use ``--strict`` in CI or release gates when
+  warnings should fail the job.
 - Treat shell execution and install profiles as privileged operator surfaces. The installer can
   prepare development, local-model, and cluster dependencies; use an isolated lab machine or
   container for untrusted apps, and review dry-run/log output before enabling optional system-level
   profiles.
+- Treat ``APPS_REPOSITORY`` as an executable-code trust boundary. For shared use, only allow
+  repositories from an explicit allowlist, pin them to a reviewed commit SHA or immutable tag,
+  reject floating branches, and scan the repository before installing or linking apps/pages.
 - Treat the service queue as scheduler-owned state. Workers process ``*.task.json`` payloads with
   the ``agi.service.task.v1`` schema, and legacy ``*.task.pkl`` files are quarantined without
   deserialization. The queue directory must be writable only by the trusted scheduler/operator.
@@ -79,6 +121,16 @@ organization's security requirements in mind. At minimum:
   should use Trusted Publishing/OIDC, SBOM and vulnerability scan artifacts should be archived when
   available, and deployments that handle sensitive data need their own threat model and acceptance
   profile.
+- Generate supply-chain evidence for the actual install profile you deploy, not only for the base
+  package. At minimum, archive a CycloneDX SBOM and ``pip-audit`` report for each enabled profile
+  such as base CLI, ``agilab[ui]``, MLflow/tracking, offline/local-LLM tooling, and
+  worker/cluster extras.
+- Keep remote installer profiles opt-in. Prefer ``--dry-run`` first, disable local-model/Ollama and
+  cluster automation profiles unless they are needed, and review any staged remote shell installer
+  before running it on a developer workstation.
+- Keep public release proof synchronized with the GitHub tag and PyPI version. If release-proof
+  pages lag behind a published release, republish the documentation and re-run the docs-source guard
+  before using the page as audit evidence.
 
 For end-to-end secure deployments or bespoke threat modelling, please engage your Thales security
 contact or submit a request via <https://cpl.thalesgroup.com/fr/contact-us>.

--- a/badges/coverage-agi-gui.svg
+++ b/badges/coverage-agi-gui.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="153" height="20" role="img" aria-label="agi-gui coverage: 92%">
+<svg xmlns="http://www.w3.org/2000/svg" width="153" height="20" role="img" aria-label="agi-gui coverage: 91%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="61.0" y="15" fill="#010101" fill-opacity=".3">agi-gui coverage</text>
   <text x="61.0" y="14">agi-gui coverage</text>
-  <text x="137.5" y="15" fill="#010101" fill-opacity=".3">92%</text>
-  <text x="137.5" y="14">92%</text>
+  <text x="137.5" y="15" fill="#010101" fill-opacity=".3">91%</text>
+  <text x="137.5" y="14">91%</text>
 </g>
 </svg>

--- a/src/agilab/lab_run.py
+++ b/src/agilab/lab_run.py
@@ -107,6 +107,12 @@ def _run_first_proof(argv: list[str]) -> int:
     return first_proof_cli.main(argv)
 
 
+def _run_security_check(argv: list[str]) -> int:
+    from agilab import security_check
+
+    return security_check.main(argv)
+
+
 def _missing_ui_dependencies() -> list[str]:
     missing: list[str] = []
     for module_name, distribution_name in (
@@ -143,6 +149,8 @@ def main(argv: list[str] | None = None) -> int:
         return _run_doctor(raw_argv[1:])
     if raw_argv[:1] in (["first-proof"], ["first_proof"]):
         return _run_first_proof(raw_argv[1:])
+    if raw_argv[:1] in (["security-check"], ["security_check"]):
+        return _run_security_check(raw_argv[1:])
 
     parser = argparse.ArgumentParser(
         description="Run AGILAB application with custom options."

--- a/src/agilab/security_check.py
+++ b/src/agilab/security_check.py
@@ -1,0 +1,523 @@
+"""Advisory local security preflight for AGILAB adoption."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import json
+import os
+from pathlib import Path
+import re
+import sys
+import tomllib
+from typing import Any, Mapping, Sequence
+
+
+SCHEMA = "agilab.security_check.v1"
+SCHEMA_VERSION = 1
+DEFAULT_ARTIFACT_MAX_AGE_DAYS = 30
+SECRET_KEY_RE = re.compile(r"(KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL)", re.IGNORECASE)
+HEX_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+LOCAL_HOSTS = {"", "127.0.0.1", "localhost", "::1"}
+EXPOSED_HOSTS = {"0.0.0.0", "::"}
+PLACEHOLDER_SECRET_VALUES = {
+    "empty",
+    "none",
+    "null",
+    "placeholder",
+    "your-api-key",
+    "your-key",
+    "change-me",
+    "changeme",
+}
+
+
+@dataclass(frozen=True)
+class Check:
+    id: str
+    label: str
+    status: str
+    summary: str
+    remediation: str
+    details: Mapping[str, Any]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "label": self.label,
+            "status": self.status,
+            "summary": self.summary,
+            "remediation": self.remediation,
+            "details": dict(self.details),
+        }
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _truthy(value: str | None) -> bool:
+    return str(value or "").strip().lower() in {"1", "true", "yes", "on", "enabled"}
+
+
+def _parse_env_file(path: Path) -> dict[str, str]:
+    if not path.is_file():
+        return {}
+    result: dict[str, str] = {}
+    for raw_line in path.read_text(encoding="utf-8", errors="ignore").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip().removeprefix("export ").strip()
+        value = value.strip().strip("'\"")
+        if key:
+            result[key] = value
+    return result
+
+
+def _merged_config(environ: Mapping[str, str], env_file_values: Mapping[str, str]) -> dict[str, str]:
+    merged = dict(env_file_values)
+    merged.update({key: value for key, value in environ.items() if value is not None})
+    return merged
+
+
+def _resolve_path(raw_path: str | None, *, cwd: Path) -> Path | None:
+    value = str(raw_path or "").strip().strip("'\"")
+    if not value:
+        return None
+    path = Path(value).expanduser()
+    if not path.is_absolute():
+        path = cwd / path
+    return path
+
+
+def _resolve_git_dir(repo: Path) -> Path | None:
+    dot_git = repo / ".git"
+    if dot_git.is_dir():
+        return dot_git
+    if dot_git.is_file():
+        text = dot_git.read_text(encoding="utf-8", errors="ignore").strip()
+        if text.startswith("gitdir:"):
+            git_dir = Path(text.split(":", 1)[1].strip()).expanduser()
+            if not git_dir.is_absolute():
+                git_dir = dot_git.parent / git_dir
+            return git_dir
+    return None
+
+
+def _git_head_state(repo: Path) -> dict[str, Any]:
+    git_dir = _resolve_git_dir(repo)
+    if git_dir is None:
+        return {"is_git_checkout": False}
+    head_path = git_dir / "HEAD"
+    if not head_path.is_file():
+        return {"is_git_checkout": True, "head_state": "unknown"}
+    head = head_path.read_text(encoding="utf-8", errors="ignore").strip()
+    if head.startswith("ref:"):
+        ref = head.split(":", 1)[1].strip()
+        short = ref.removeprefix("refs/heads/").removeprefix("refs/tags/")
+        return {
+            "is_git_checkout": True,
+            "head_state": "branch" if ref.startswith("refs/heads/") else "ref",
+            "ref": ref,
+            "name": short,
+        }
+    if HEX_SHA_RE.match(head):
+        return {"is_git_checkout": True, "head_state": "detached", "commit": head}
+    return {"is_git_checkout": True, "head_state": "unknown", "head": head[:64]}
+
+
+def _check_apps_repository(config: Mapping[str, str], *, cwd: Path) -> Check:
+    path = _resolve_path(config.get("APPS_REPOSITORY"), cwd=cwd)
+    if path is None:
+        return Check(
+            "apps_repository_pin",
+            "External apps repository pinning",
+            "pass",
+            "APPS_REPOSITORY is not configured.",
+            "No action required unless you install external apps.",
+            {},
+        )
+    if not path.exists():
+        return Check(
+            "apps_repository_pin",
+            "External apps repository pinning",
+            "warn",
+            "APPS_REPOSITORY points to a missing path.",
+            "Point APPS_REPOSITORY to an allowlisted reviewed checkout, pinned commit, or immutable tag.",
+            {"path": str(path)},
+        )
+    if not path.is_dir():
+        return Check(
+            "apps_repository_pin",
+            "External apps repository pinning",
+            "warn",
+            "APPS_REPOSITORY is not a directory.",
+            "Use a reviewed Git checkout directory for external apps.",
+            {"path": str(path)},
+        )
+    git_state = _git_head_state(path)
+    if not git_state.get("is_git_checkout"):
+        return Check(
+            "apps_repository_pin",
+            "External apps repository pinning",
+            "warn",
+            "APPS_REPOSITORY is not a Git checkout.",
+            "Use an allowlisted Git checkout pinned to a commit SHA or immutable tag before shared use.",
+            {"path": str(path), **git_state},
+        )
+    if git_state.get("head_state") == "branch":
+        return Check(
+            "apps_repository_pin",
+            "External apps repository pinning",
+            "warn",
+            "APPS_REPOSITORY is on a floating branch.",
+            "Checkout a reviewed commit SHA or immutable tag before installing external apps in shared environments.",
+            {"path": str(path), **git_state},
+        )
+    return Check(
+        "apps_repository_pin",
+        "External apps repository pinning",
+        "pass",
+        "APPS_REPOSITORY is a Git checkout and is not on a floating branch.",
+        "Keep the referenced commit reviewed and scanned.",
+        {"path": str(path), **git_state},
+    )
+
+
+def _looks_like_secret_value(value: str) -> bool:
+    stripped = value.strip()
+    if not stripped:
+        return False
+    lower = stripped.lower()
+    if lower in PLACEHOLDER_SECRET_VALUES:
+        return False
+    if lower.startswith("sk-test"):
+        return False
+    return True
+
+
+def _check_persisted_secrets(env_file: Path, env_file_values: Mapping[str, str]) -> Check:
+    keys = sorted(
+        key
+        for key, value in env_file_values.items()
+        if SECRET_KEY_RE.search(key) and _looks_like_secret_value(value)
+    )
+    if not keys:
+        return Check(
+            "persisted_plaintext_secrets",
+            "Plaintext local secrets",
+            "pass",
+            "No likely sensitive secret values were found in the AGILAB env file.",
+            "Keep shared/sensitive secrets in a keyring, vault, or short-lived session environment.",
+            {"env_file": str(env_file), "secret_keys": []},
+        )
+    return Check(
+        "persisted_plaintext_secrets",
+        "Plaintext local secrets",
+        "warn",
+        "Likely sensitive keys are persisted in the AGILAB env file.",
+        "Move these values to a keyring, vault, or short-lived environment variables; avoid command-line secrets.",
+        {"env_file": str(env_file), "secret_keys": keys},
+    )
+
+
+def _check_cluster_share(config: Mapping[str, str], *, cwd: Path) -> Check:
+    cluster_share = _resolve_path(config.get("AGI_CLUSTER_SHARE"), cwd=cwd)
+    local_share = _resolve_path(config.get("AGI_LOCAL_SHARE"), cwd=cwd)
+    scheduler = str(config.get("AGI_SCHEDULER_IP") or "").strip()
+    workers = str(config.get("AGI_WORKERS") or config.get("AGI_CLUSTER_WORKERS") or "").strip()
+    cluster_requested = bool(cluster_share) and (scheduler not in LOCAL_HOSTS or bool(workers))
+    if not cluster_requested:
+        return Check(
+            "cluster_share_isolation",
+            "Cluster share isolation",
+            "pass",
+            "Cluster mode does not appear to be requested.",
+            "No action required for local-only use.",
+            {
+                "cluster_share": str(cluster_share) if cluster_share else None,
+                "scheduler": scheduler or None,
+                "workers_configured": bool(workers),
+            },
+        )
+    writable = cluster_share.exists() and os.access(cluster_share, os.W_OK) if cluster_share else False
+    same_as_local = bool(cluster_share and local_share and cluster_share.resolve() == local_share.resolve())
+    if writable or same_as_local:
+        return Check(
+            "cluster_share_isolation",
+            "Cluster share isolation",
+            "warn",
+            "Cluster mode appears enabled with a local writable or local-share-equivalent path.",
+            "Use a per-user shared mount with explicit worker-side path mapping; do not share one writable directory across users.",
+            {
+                "cluster_share": str(cluster_share),
+                "local_share": str(local_share) if local_share else None,
+                "scheduler": scheduler or None,
+                "workers_configured": bool(workers),
+                "cluster_share_exists": cluster_share.exists(),
+                "cluster_share_writable": writable,
+                "same_as_local_share": same_as_local,
+            },
+        )
+    return Check(
+        "cluster_share_isolation",
+        "Cluster share isolation",
+        "pass",
+        "Cluster mode appears configured without an obviously writable local share.",
+        "Validate the worker-side mount contract before running shared workloads.",
+        {
+            "cluster_share": str(cluster_share),
+            "local_share": str(local_share) if local_share else None,
+            "scheduler": scheduler or None,
+            "workers_configured": bool(workers),
+        },
+    )
+
+
+def _streamlit_config_address(home: Path) -> str | None:
+    config_path = home / ".streamlit" / "config.toml"
+    if not config_path.is_file():
+        return None
+    try:
+        payload = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    server = payload.get("server")
+    if not isinstance(server, dict):
+        return None
+    value = server.get("address")
+    return str(value).strip() if value is not None else None
+
+
+def _check_ui_exposure(config: Mapping[str, str], *, home: Path) -> Check:
+    host = (
+        config.get("STREAMLIT_SERVER_ADDRESS")
+        or config.get("AGILAB_UI_HOST")
+        or config.get("UVICORN_HOST")
+        or _streamlit_config_address(home)
+        or ""
+    ).strip()
+    if host not in EXPOSED_HOSTS:
+        return Check(
+            "ui_network_exposure",
+            "UI network exposure",
+            "pass",
+            "No public bind address was detected from environment or Streamlit config.",
+            "Keep local UI binds on 127.0.0.1 unless an authenticated TLS front end is configured.",
+            {"host": host or None},
+        )
+    auth_or_tls = any(
+        _truthy(config.get(name))
+        for name in (
+            "AGILAB_AUTH_REQUIRED",
+            "AGILAB_PUBLIC_AUTH",
+            "AGILAB_TLS_TERMINATED",
+            "STREAMLIT_AUTH_REQUIRED",
+        )
+    )
+    if auth_or_tls:
+        return Check(
+            "ui_network_exposure",
+            "UI network exposure",
+            "pass",
+            "UI binds publicly but an auth/TLS indicator is configured.",
+            "Verify the front-end control is actually enforced before exposing sensitive data.",
+            {"host": host, "auth_or_tls_indicator": True},
+        )
+    return Check(
+        "ui_network_exposure",
+        "UI network exposure",
+        "warn",
+        "UI appears configured to bind publicly without an auth/TLS indicator.",
+        "Bind to 127.0.0.1, or put AGILAB behind authentication and TLS before shared/public use.",
+        {"host": host, "auth_or_tls_indicator": False},
+    )
+
+
+def _check_optional_profiles(config: Mapping[str, str]) -> Check:
+    enabled: dict[str, str] = {}
+    for key in (
+        "INSTALL_LOCAL_MODELS",
+        "AGILAB_INSTALL_LOCAL_MODELS",
+        "AGILAB_INSTALL_PROFILE",
+        "LAB_LLM_PROVIDER",
+        "UOAIC_MODEL",
+        "UOAIC_OLLAMA_ENDPOINT",
+    ):
+        value = str(config.get(key) or "").strip()
+        if value:
+            enabled[key] = value
+    local_provider = enabled.get("LAB_LLM_PROVIDER", "").lower()
+    if local_provider and not (
+        local_provider.startswith("ollama") or "local" in local_provider or "vllm" in local_provider
+    ):
+        enabled.pop("LAB_LLM_PROVIDER", None)
+    if not enabled:
+        return Check(
+            "optional_runtime_profiles",
+            "Optional runtime profiles",
+            "pass",
+            "No optional local-model or installer profile indicators were detected.",
+            "Keep optional profiles disabled unless the deployment needs them.",
+            {"enabled_keys": []},
+        )
+    return Check(
+        "optional_runtime_profiles",
+        "Optional runtime profiles",
+        "warn",
+        "Optional local-model or installer profile indicators are configured.",
+        "Review dry-run output and supply-chain evidence before enabling local-model, Ollama, or cluster automation profiles.",
+        {"enabled_keys": sorted(enabled)},
+    )
+
+
+def _artifact_state(path: Path, *, now: datetime, max_age_days: int) -> dict[str, Any]:
+    if not path.is_file():
+        return {"path": str(path), "exists": False}
+    mtime = datetime.fromtimestamp(path.stat().st_mtime, timezone.utc)
+    age_days = (now - mtime).total_seconds() / 86400
+    return {
+        "path": str(path),
+        "exists": True,
+        "age_days": round(age_days, 3),
+        "fresh": age_days <= max_age_days,
+    }
+
+
+def _check_supply_chain_artifacts(
+    *,
+    cwd: Path,
+    now: datetime,
+    pip_audit_json: Path | None,
+    sbom_json: Path | None,
+    max_age_days: int,
+) -> Check:
+    pip_path = pip_audit_json or cwd / "pip-audit.json"
+    sbom_path = sbom_json or cwd / "sbom-cyclonedx.json"
+    pip_state = _artifact_state(pip_path, now=now, max_age_days=max_age_days)
+    sbom_state = _artifact_state(sbom_path, now=now, max_age_days=max_age_days)
+    fresh = bool(pip_state.get("fresh")) and bool(sbom_state.get("fresh"))
+    if fresh:
+        return Check(
+            "supply_chain_artifacts",
+            "Supply-chain scan artifacts",
+            "pass",
+            "Recent pip-audit and CycloneDX SBOM artifacts were found.",
+            "Regenerate these artifacts for each deployed install profile.",
+            {"pip_audit": pip_state, "sbom": sbom_state, "max_age_days": max_age_days},
+        )
+    return Check(
+        "supply_chain_artifacts",
+        "Supply-chain scan artifacts",
+        "warn",
+        "Recent pip-audit and CycloneDX SBOM artifacts were not both found.",
+        "Generate profile-specific artifacts: pip-audit --format json --output pip-audit.json and cyclonedx-py environment --output-format JSON --output-file sbom-cyclonedx.json.",
+        {"pip_audit": pip_state, "sbom": sbom_state, "max_age_days": max_age_days},
+    )
+
+
+def build_report(
+    *,
+    env_file: Path | None = None,
+    environ: Mapping[str, str] | None = None,
+    cwd: Path | None = None,
+    home: Path | None = None,
+    now: datetime | None = None,
+    pip_audit_json: Path | None = None,
+    sbom_json: Path | None = None,
+    artifact_max_age_days: int = DEFAULT_ARTIFACT_MAX_AGE_DAYS,
+) -> dict[str, Any]:
+    cwd = (cwd or Path.cwd()).resolve()
+    home = (home or Path.home()).resolve()
+    env_file = (env_file or home / ".agilab" / ".env").expanduser()
+    env_file_values = _parse_env_file(env_file)
+    config = _merged_config(environ or os.environ, env_file_values)
+    now = now or _utc_now()
+    checks = [
+        _check_apps_repository(config, cwd=cwd),
+        _check_persisted_secrets(env_file, env_file_values),
+        _check_cluster_share(config, cwd=cwd),
+        _check_ui_exposure(config, home=home),
+        _check_optional_profiles(config),
+        _check_supply_chain_artifacts(
+            cwd=cwd,
+            now=now,
+            pip_audit_json=pip_audit_json,
+            sbom_json=sbom_json,
+            max_age_days=artifact_max_age_days,
+        ),
+    ]
+    warning_count = sum(1 for check in checks if check.status == "warn")
+    status = "warn" if warning_count else "pass"
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "kind": "agilab.security_check",
+        "schema": SCHEMA,
+        "status": status,
+        "generated_at": now.isoformat(),
+        "summary": {
+            "check_count": len(checks),
+            "warnings": warning_count,
+            "env_file": str(env_file),
+            "advisory": True,
+        },
+        "checks": [check.as_dict() for check in checks],
+    }
+
+
+def _print_text(report: Mapping[str, Any]) -> None:
+    status = str(report.get("status", "unknown")).upper()
+    summary = report.get("summary") if isinstance(report.get("summary"), dict) else {}
+    warnings = summary.get("warnings", 0)
+    print(f"AGILAB security-check: {status} ({warnings} warning(s))")
+    for check in report.get("checks", []):
+        if not isinstance(check, dict):
+            continue
+        marker = str(check.get("status", "unknown")).upper()
+        print(f"- [{marker}] {check.get('label')}: {check.get('summary')}")
+        if check.get("status") == "warn":
+            print(f"  remediation: {check.get('remediation')}")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run an advisory AGILAB local security preflight."
+    )
+    parser.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Return a non-zero exit code when advisory warnings are found.",
+    )
+    parser.add_argument("--env-file", type=Path, default=None, help="AGILAB .env file to inspect.")
+    parser.add_argument("--pip-audit-json", type=Path, default=None)
+    parser.add_argument("--sbom-json", type=Path, default=None)
+    parser.add_argument(
+        "--artifact-max-age-days",
+        type=int,
+        default=DEFAULT_ARTIFACT_MAX_AGE_DAYS,
+        help="Maximum accepted age for pip-audit/SBOM artifacts.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(list(argv) if argv is not None else None)
+    report = build_report(
+        env_file=args.env_file,
+        pip_audit_json=args.pip_audit_json,
+        sbom_json=args.sbom_json,
+        artifact_max_age_days=args.artifact_max_age_days,
+    )
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        _print_text(report)
+    return 1 if args.strict and report["status"] != "pass" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/test_audit_response_docs.py
+++ b/test/test_audit_response_docs.py
@@ -99,6 +99,28 @@ def test_environment_docs_scope_local_secret_persistence() -> None:
     assert "not a shared secret manager" in environment
 
 
+def test_security_policy_addresses_public_audit_adoption_boundaries() -> None:
+    security = Path("SECURITY.md").read_text(encoding="utf-8")
+
+    assert "trusted-operator experimentation workbench" in security
+    assert "Recommended use without additional platform hardening" in security
+    assert "Conditional use only after hardening" in security
+    assert "Not recommended as-is" in security
+    assert "public exposure without authentication, TLS, and sandboxing" in security
+    assert "Multi-tenant service use" in security
+    assert "production ML serving" in security
+    assert "APPS_REPOSITORY" in security
+    assert "explicit allowlist" in security
+    assert "commit SHA or immutable tag" in security
+    assert "reject floating branches" in security
+    assert "CycloneDX SBOM" in security
+    assert "pip-audit" in security
+    assert "actual install profile" in security
+    assert "release-proof" in security
+    assert "GitHub tag and PyPI version" in security
+    assert "republish the documentation" in security
+
+
 def test_readme_uses_recommended_workbench_positioning() -> None:
     readme = Path("README.md").read_text(encoding="utf-8")
 

--- a/test/test_lab_run.py
+++ b/test/test_lab_run.py
@@ -100,6 +100,27 @@ def test_main_dispatches_first_proof_without_launching_streamlit(monkeypatch):
     assert captured == [["--json", "--with-install"]]
 
 
+def test_main_dispatches_security_check_without_launching_streamlit(monkeypatch):
+    monkeypatch.setattr(lab_run, "_guard_against_uvx_in_source_tree", lambda: None)
+    captured: list[list[str]] = []
+
+    def fake_security_check(argv: list[str]) -> int:
+        captured.append(argv)
+        return 37
+
+    monkeypatch.setattr(lab_run, "_run_security_check", fake_security_check)
+    monkeypatch.setattr(
+        lab_run,
+        "_load_streamlit_cli",
+        lambda: (_ for _ in ()).throw(AssertionError("streamlit should not be launched")),
+    )
+
+    rc = lab_run.main(["security-check", "--json", "--strict"])
+
+    assert rc == 37
+    assert captured == [["--json", "--strict"]]
+
+
 def test_main_reports_missing_ui_dependencies(monkeypatch):
     monkeypatch.setattr(lab_run, "_guard_against_uvx_in_source_tree", lambda: None)
     monkeypatch.setattr(lab_run, "_resolve_apps_path", lambda _value: None)

--- a/test/test_security_check.py
+++ b/test/test_security_check.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SECURITY_CHECK_PATH = ROOT / "src" / "agilab" / "security_check.py"
+SPEC = importlib.util.spec_from_file_location("agilab.security_check", SECURITY_CHECK_PATH)
+assert SPEC and SPEC.loader
+security_check = importlib.util.module_from_spec(SPEC)
+sys.modules["agilab.security_check"] = security_check
+SPEC.loader.exec_module(security_check)
+
+
+def _touch_now(path: Path) -> None:
+    path.write_text("{}", encoding="utf-8")
+
+
+def test_build_report_passes_for_clean_local_profile(tmp_path: Path):
+    cwd = tmp_path / "repo"
+    home = tmp_path / "home"
+    cwd.mkdir()
+    home.mkdir()
+    pip_audit = cwd / "pip-audit.json"
+    sbom = cwd / "sbom-cyclonedx.json"
+    _touch_now(pip_audit)
+    _touch_now(sbom)
+
+    report = security_check.build_report(
+        environ={},
+        cwd=cwd,
+        home=home,
+        now=datetime.now(timezone.utc),
+    )
+
+    assert report["schema"] == security_check.SCHEMA
+    assert report["schema_version"] == security_check.SCHEMA_VERSION
+    assert report["kind"] == "agilab.security_check"
+    assert report["status"] == "pass"
+    assert report["summary"]["warnings"] == 0
+    assert {check["status"] for check in report["checks"]} == {"pass"}
+
+
+def test_build_report_warns_on_adoption_risks_without_leaking_secret_values(tmp_path: Path):
+    cwd = tmp_path / "repo"
+    home = tmp_path / "home"
+    apps = tmp_path / "apps"
+    cluster_share = tmp_path / "clustershare"
+    env_file = home / ".agilab" / ".env"
+    cwd.mkdir()
+    home.mkdir()
+    apps.mkdir()
+    cluster_share.mkdir()
+    (apps / ".git").mkdir()
+    (apps / ".git" / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf-8")
+    env_file.parent.mkdir(parents=True)
+    env_file.write_text(
+        "\n".join(
+            [
+                f"APPS_REPOSITORY={apps}",
+                "OPENAI_API_KEY=sk-real-secret-should-not-print",
+                f"AGI_CLUSTER_SHARE={cluster_share}",
+                f"AGI_LOCAL_SHARE={cluster_share}",
+                "AGI_SCHEDULER_IP=192.0.2.10",
+                "STREAMLIT_SERVER_ADDRESS=0.0.0.0",
+                "INSTALL_LOCAL_MODELS=gpt-oss",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    report = security_check.build_report(
+        env_file=env_file,
+        environ={},
+        cwd=cwd,
+        home=home,
+        now=datetime.now(timezone.utc),
+    )
+
+    warning_ids = {
+        check["id"]
+        for check in report["checks"]
+        if check["status"] == "warn"
+    }
+    assert report["status"] == "warn"
+    assert warning_ids == {
+        "apps_repository_pin",
+        "persisted_plaintext_secrets",
+        "cluster_share_isolation",
+        "ui_network_exposure",
+        "optional_runtime_profiles",
+        "supply_chain_artifacts",
+    }
+    serialized = json.dumps(report, sort_keys=True)
+    assert "OPENAI_API_KEY" in serialized
+    assert "sk-real-secret-should-not-print" not in serialized
+
+
+def test_cli_json_strict_returns_nonzero_on_warnings(tmp_path: Path, monkeypatch, capsys):
+    monkeypatch.chdir(tmp_path)
+    env_file = tmp_path / ".env"
+    env_file.write_text("STREAMLIT_SERVER_ADDRESS=0.0.0.0\n", encoding="utf-8")
+
+    rc = security_check.main(["--json", "--strict", "--env-file", str(env_file)])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert rc == 1
+    assert payload["schema"] == security_check.SCHEMA
+    assert payload["status"] == "warn"
+
+
+def test_cli_default_is_advisory_even_when_warnings_exist(tmp_path: Path, monkeypatch, capsys):
+    monkeypatch.chdir(tmp_path)
+    env_file = tmp_path / ".env"
+    env_file.write_text("STREAMLIT_SERVER_ADDRESS=0.0.0.0\n", encoding="utf-8")
+
+    rc = security_check.main(["--env-file", str(env_file)])
+
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "AGILAB security-check: WARN" in captured.out
+    assert "UI network exposure" in captured.out

--- a/test/test_security_hygiene_report.py
+++ b/test/test_security_hygiene_report.py
@@ -61,6 +61,13 @@ def test_security_hygiene_report_passes_static_contract(tmp_path: Path) -> None:
     assert checks["codecov_uploads_are_blocking_gates"]["status"] == "pass"
     assert checks["local_secret_storage_is_developer_only"]["status"] == "pass"
     assert checks["release_evidence_scope_is_bounded"]["status"] == "pass"
+    assert checks["adoption_profile_go_no_go_documented"]["status"] == "pass"
+    assert checks["external_apps_repository_trust_boundary"]["status"] == "pass"
+    assert checks["supply_chain_profile_evidence_documented"]["status"] == "pass"
+    assert checks["release_proof_freshness_policy_documented"]["status"] == "pass"
+    assert checks["release_proof_freshness_policy_documented"]["details"]["version_aligned"] is True
+    assert checks["release_proof_freshness_policy_documented"]["details"]["tag_aligned"] is True
+    assert checks["release_proof_freshness_policy_documented"]["details"]["rendered_page_aligned"] is True
     assert checks["remote_installers_are_staged_before_execution"]["status"] == "pass"
     assert checks["installers_expose_dry_run_profiles"]["status"] == "pass"
     assert checks["central_command_runner_shell_fallback_is_syntax_gated"]["status"] == "pass"

--- a/tools/security_hygiene_report.py
+++ b/tools/security_hygiene_report.py
@@ -10,6 +10,7 @@ import os
 from pathlib import Path
 import platform
 import re
+import tomllib
 from typing import Any, Sequence
 
 
@@ -83,6 +84,13 @@ def _read_json_artifact(path: Path | None) -> tuple[bool, dict[str, Any] | list[
         return True, json.loads(path.read_text(encoding="utf-8")), None
     except Exception as exc:
         return True, None, str(exc)
+
+
+def _read_toml_artifact(path: Path) -> tuple[dict[str, Any] | None, str | None]:
+    try:
+        return tomllib.loads(path.read_text(encoding="utf-8")), None
+    except Exception as exc:
+        return None, str(exc)
 
 
 def _pip_audit_vulnerability_count(payload: dict[str, Any] | list[Any] | None) -> int | None:
@@ -290,6 +298,146 @@ def _release_evidence_scope_check(repo_root: Path, security_text: str) -> dict[s
     )
 
 
+def _adoption_profile_check(security_text: str) -> dict[str, Any]:
+    required_tokens = [
+        "trusted-operator experimentation workbench",
+        "Recommended use without additional platform hardening",
+        "Conditional use only after hardening",
+        "Not recommended as-is",
+        "public exposure without authentication, TLS, and sandboxing",
+        "Multi-tenant service use",
+        "production ML serving",
+    ]
+    missing = [token for token in required_tokens if token not in security_text]
+    return _check_result(
+        "adoption_profile_go_no_go_documented",
+        "Security adoption profile is documented",
+        not missing,
+        "SECURITY.md separates recommended sandbox use, conditional shared use, and no-go production/multi-tenant use",
+        evidence=["SECURITY.md"],
+        details={"missing_tokens": missing},
+    )
+
+
+def _external_apps_repository_policy_check(repo_root: Path, security_text: str) -> dict[str, Any]:
+    service_paths = _read_text(repo_root / "docs" / "source" / "service_mode_and_paths.md")
+    quick_start = _read_text(repo_root / "docs" / "source" / "quick-start.rst")
+    combined = f"{security_text}\n{service_paths}\n{quick_start}"
+    required_tokens = [
+        "APPS_REPOSITORY",
+        "executable-code trust boundary",
+        "explicit allowlist",
+        "commit SHA",
+        "immutable tag",
+        "reject floating branches",
+        "scan the repository",
+    ]
+    missing = [token for token in required_tokens if token not in combined]
+    return _check_result(
+        "external_apps_repository_trust_boundary",
+        "External apps repository trust boundary is documented",
+        not missing,
+        "External apps repositories are documented as executable code that must be allowlisted, pinned, reviewed, and scanned for shared use",
+        evidence=[
+            "SECURITY.md",
+            "docs/source/service_mode_and_paths.md",
+            "docs/source/quick-start.rst",
+        ],
+        details={"missing_tokens": missing},
+    )
+
+
+def _supply_chain_profile_evidence_check(security_text: str) -> dict[str, Any]:
+    required_tokens = [
+        "CycloneDX SBOM",
+        "pip-audit",
+        "actual install profile",
+        "base CLI",
+        "agilab[ui]",
+        "MLflow/tracking",
+        "offline/local-LLM",
+        "worker/cluster extras",
+    ]
+    missing = [token for token in required_tokens if token not in security_text]
+    return _check_result(
+        "supply_chain_profile_evidence_documented",
+        "Per-profile supply-chain evidence is documented",
+        not missing,
+        "SECURITY.md requires SBOM and pip-audit evidence for the actual enabled install profiles",
+        evidence=["SECURITY.md"],
+        details={
+            "missing_tokens": missing,
+            "pip_audit_command": PIP_AUDIT_COMMAND,
+            "sbom_command": SBOM_COMMAND,
+        },
+    )
+
+
+def _release_proof_freshness_check(repo_root: Path, security_text: str) -> dict[str, Any]:
+    pyproject, pyproject_error = _read_toml_artifact(repo_root / "pyproject.toml")
+    manifest, manifest_error = _read_toml_artifact(
+        repo_root / "docs" / "source" / "data" / "release_proof.toml"
+    )
+    release_proof = _read_text(repo_root / "docs" / "source" / "release-proof.rst")
+    release_manifest = _read_text(
+        repo_root / "docs" / "source" / "data" / "release_proof.toml"
+    )
+    combined = f"{security_text}\n{release_proof}\n{release_manifest}"
+    required_tokens = [
+        "GitHub tag",
+        "PyPI version",
+        "release-proof",
+        "republish the documentation",
+        "docs-source guard",
+        "github_release_tag",
+        "package_version",
+    ]
+    missing = [token for token in required_tokens if token not in combined]
+    project_version = str(((pyproject or {}).get("project") or {}).get("version") or "")
+    release = (manifest or {}).get("release") or {}
+    package_name = str(release.get("package_name") or "")
+    manifest_version = str(release.get("package_version") or "")
+    manifest_tag = str(release.get("github_release_tag") or "")
+    expected_tag = f"v{project_version}" if project_version else ""
+    version_aligned = bool(project_version) and manifest_version == project_version
+    tag_aligned = bool(expected_tag) and manifest_tag == expected_tag
+    rendered_page_aligned = (
+        bool(package_name)
+        and bool(manifest_version)
+        and f"{package_name}=={manifest_version}" in release_proof
+        and bool(manifest_tag)
+        and manifest_tag in release_proof
+    )
+    return _check_result(
+        "release_proof_freshness_policy_documented",
+        "Release-proof freshness policy is documented",
+        not missing
+        and pyproject_error is None
+        and manifest_error is None
+        and version_aligned
+        and tag_aligned
+        and rendered_page_aligned,
+        "SECURITY.md and release-proof data preserve the requirement that public proof stays aligned with GitHub tag and PyPI version",
+        evidence=[
+            "SECURITY.md",
+            "docs/source/release-proof.rst",
+            "docs/source/data/release_proof.toml",
+        ],
+        details={
+            "missing_tokens": missing,
+            "pyproject_error": pyproject_error,
+            "manifest_error": manifest_error,
+            "pyproject_version": project_version,
+            "manifest_package_version": manifest_version,
+            "expected_github_release_tag": expected_tag,
+            "manifest_github_release_tag": manifest_tag,
+            "version_aligned": version_aligned,
+            "tag_aligned": tag_aligned,
+            "rendered_page_aligned": rendered_page_aligned,
+        },
+    )
+
+
 def _remote_installer_staging_check(repo_root: Path) -> dict[str, Any]:
     files = [
         "install.sh",
@@ -476,6 +624,10 @@ def build_report(
         _coverage_upload_gate_check(repo_root),
         _local_secret_storage_policy_check(repo_root, security_text),
         _release_evidence_scope_check(repo_root, security_text),
+        _adoption_profile_check(security_text),
+        _external_apps_repository_policy_check(repo_root, security_text),
+        _supply_chain_profile_evidence_check(security_text),
+        _release_proof_freshness_check(repo_root, security_text),
         _remote_installer_staging_check(repo_root),
         _installer_dry_run_profile_check(repo_root),
         _central_command_runner_shell_gate_check(repo_root),


### PR DESCRIPTION
## Summary

Adds an advisory `agilab security-check` CLI command for local adoption/security preflight checks, expands SECURITY.md audit guidance, and extends the security hygiene report/test coverage.

## Validation

- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_security_check.py test/test_lab_run.py test/test_security_hygiene_report.py test/test_audit_response_docs.py`
- `uv --preview-features extra-build-dependencies run python -m agilab.lab_run security-check --json`
- `uv --preview-features extra-build-dependencies run python tools/security_hygiene_report.py --compact`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui`
- `uv --preview-features extra-build-dependencies run python tools/coverage_badge_guard.py --changed-only --require-fresh-xml`