### PR TITLE
[codex] Add security adoption workflow

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 185,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "6292ca7f91c4d9ceacf67c4bcb9d2d0f2543480c8a4f2c0c5ca799d4e05d5701",
+  "source_digest_sha256": "b83a25605b79f90923b45135f75817de7e17a6c083c630abc058d2b6188cefb8",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "6292ca7f91c4d9ceacf67c4bcb9d2d0f2543480c8a4f2c0c5ca799d4e05d5701"
+  "target_digest_sha256": "b83a25605b79f90923b45135f75817de7e17a6c083c630abc058d2b6188cefb8"
 }

--- a/docs/source/beta-readiness.rst
+++ b/docs/source/beta-readiness.rst
@@ -59,9 +59,14 @@ publishing a beta-classified package:
 .. code-block:: bash
 
    uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-env --profile agi-core-combined --profile agi-gui --profile docs --profile installer --profile shared-core-typing --profile dependency-policy
+   uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile security-adoption
    uv --preview-features extra-build-dependencies run python tools/newcomer_first_proof.py --with-install
    uv --preview-features extra-build-dependencies run python tools/pypi_publish.py --repo testpypi --dry-run --verbose
    uv --preview-features extra-build-dependencies run python tools/hf_space_smoke.py --json
+
+The ``security-adoption`` profile writes ``test-results/security-check.json``
+as an advisory artifact. Use ``AGILAB_SECURITY_CHECK_STRICT=1`` only when the
+release manager wants adoption warnings to fail the gate.
 
 If any command fails, keep the public classifier at alpha and fix the underlying
 reproducibility, install, demo, or publication issue first.

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -124,10 +124,12 @@ installer to perform validation during setup. For a first proof, run the narrow
 ----------------------------------------------------------------
 ``uv`` emits this when you launch a command from an activated shell whose
 ``$VIRTUAL_ENV`` differs from the target project’s ``.venv`` directory. The message is
-informational—the command will still run using the project lock. AGILAB manages multiple
-virtualenvs per app and per install (shared/local), so seeing this warning is normal when
-you hop between them. If you truly want to reuse the activated environment, pass
-``--active`` to ``uv``; otherwise you can safely ignore the warning.
+informational—the command will still run using the project lock. AGILAB-managed PyCharm
+configs and launch wrappers clear ``VIRTUAL_ENV`` before invoking ``uv`` so a stale
+activated shell does not surface this warning. If you still see it, you are likely running
+``uv`` directly; run the matching ``tools/run_configs`` wrapper or unset ``VIRTUAL_ENV``
+first. Avoid ``--active`` for normal AGILAB launches because it intentionally reuses the
+currently activated environment instead of the target project environment.
 
 Why does a run create ``distribution.json``?
 --------------------------------------------

--- a/docs/source/quick-start.rst
+++ b/docs/source/quick-start.rst
@@ -255,6 +255,30 @@ For an external apps repository available on your machine::
       --test-apps \
       --test-core
 
+Shared or team adoption check
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Before moving from a single-user proof to a shared team workstation, internal
+cluster, or external apps repository, archive an advisory security-check report::
+
+    uv --preview-features extra-build-dependencies run agilab security-check --json > security-check.json
+
+The report checks local adoption risks such as floating ``APPS_REPOSITORY``
+checkouts, likely plaintext secrets in ``~/.agilab/.env``, public UI bind
+addresses, cluster-share isolation, optional local-model profiles, and missing
+SBOM / ``pip-audit`` evidence. It is advisory by default so first proof and
+local experimentation stay fast.
+
+Maintainers can produce the same artifact from the repo workflow-parity helper::
+
+    uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile security-adoption
+
+Use strict mode only for an explicit release or team gate where warnings should
+fail the job::
+
+    AGILAB_SECURITY_CHECK_STRICT=1 \
+    uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile security-adoption
+
 Clean source-validation runs should keep their disposable checkout and fake
 ``HOME`` outside the normal home directory. Use a cache-backed workspace so
 failed validation can still be inspected without polluting ``$HOME``::

--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -271,7 +271,12 @@ Unfortunatly when NumPy/Numba falls back to compiling from source you won’t se
 
 while running uv into a project from another one:
 warning: `VIRTUAL_ENV=.venv` does not match the project environment path `/path/to/checkout/src/agilab/apps/mycode_project/.venv` and will be ignored; use `--active` to target the active environment instead
-This is not a problem this because we dynamically change the venv. Just ignore it.
+This is an informational ``uv`` warning, but AGILAB-managed PyCharm configs and run
+wrappers clear ``VIRTUAL_ENV`` before invoking ``uv`` so normal launches should not print
+it. If it appears, you are probably running ``uv`` directly from an activated shell. Use
+the matching ``tools/run_configs`` wrapper or run ``unset VIRTUAL_ENV`` before the direct
+command. Do not add ``--active`` unless you intentionally want to reuse the currently
+activated virtual environment instead of the AGILAB project environment.
 
 <Python> Python
 -------------------

--- a/test/test_audit_response_docs.py
+++ b/test/test_audit_response_docs.py
@@ -121,6 +121,18 @@ def test_security_policy_addresses_public_audit_adoption_boundaries() -> None:
     assert "republish the documentation" in security
 
 
+def test_quick_start_documents_security_adoption_checkpoint() -> None:
+    quick_start = (DOCS_SOURCE / "quick-start.rst").read_text(encoding="utf-8")
+    beta_readiness = (DOCS_SOURCE / "beta-readiness.rst").read_text(encoding="utf-8")
+
+    assert "Shared or team adoption check" in quick_start
+    assert "agilab security-check --json > security-check.json" in quick_start
+    assert "workflow_parity.py --profile security-adoption" in quick_start
+    assert "AGILAB_SECURITY_CHECK_STRICT=1" in quick_start
+    assert "test-results/security-check.json" in beta_readiness
+    assert "AGILAB_SECURITY_CHECK_STRICT=1" in beta_readiness
+
+
 def test_readme_uses_recommended_workbench_positioning() -> None:
     readme = Path("README.md").read_text(encoding="utf-8")
 

--- a/test/test_security_adoption_check.py
+++ b/test/test_security_adoption_check.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+MODULE_PATH = Path("tools/security_adoption_check.py").resolve()
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("security_adoption_check_test_module", MODULE_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_adoption_check_writes_advisory_artifact_without_blocking(tmp_path: Path, monkeypatch, capsys):
+    module = _load_module()
+    monkeypatch.chdir(tmp_path)
+    output = tmp_path / "security-check.json"
+
+    rc = module.main(["--output", str(output)])
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert rc == 0
+    assert payload["schema"] == "agilab.security_check.v1"
+    assert payload["status"] == "warn"
+    assert "mode=advisory" in capsys.readouterr().out
+
+
+def test_adoption_check_strict_env_fails_on_warnings(tmp_path: Path, monkeypatch):
+    module = _load_module()
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AGILAB_SECURITY_CHECK_STRICT", "1")
+
+    rc = module.main(["--output", str(tmp_path / "security-check.json")])
+
+    assert rc == 1

--- a/test/test_workflow_parity.py
+++ b/test/test_workflow_parity.py
@@ -46,6 +46,7 @@ def test_profile_commands_cover_expected_coverage_and_docs_contracts() -> None:
     badges = profiles["badges"]
     strict_typing = profiles["shared-core-typing"][0]
     dependency_policy = profiles["dependency-policy"][0]
+    security_adoption = profiles["security-adoption"][0]
     cloud_emulators = profiles["cloud-emulators"]
     ui_robot_matrix = profiles["ui-robot-matrix"][0]
 
@@ -148,6 +149,14 @@ def test_profile_commands_cover_expected_coverage_and_docs_contracts() -> None:
     assert dependency_policy.label == "dependency policy"
     assert dependency_policy.argv[-1] == "test/test_pyproject_dependency_hygiene.py"
     assert "addopts=" in dependency_policy.argv
+    assert security_adoption.label == "security adoption check"
+    assert security_adoption.argv[-3:] == [
+        "tools/security_adoption_check.py",
+        "--output",
+        "test-results/security-check.json",
+    ]
+    assert security_adoption.ensure_dirs == ["test-results"]
+    assert security_adoption.remove_paths == ["test-results/security-check.json"]
     assert [command.label for command in cloud_emulators] == [
         "cloud emulator connector evidence",
         "cloud emulator connector tests",
@@ -178,6 +187,7 @@ def test_selected_profiles_uses_combined_core_profile_by_default() -> None:
     assert "cloud-emulators" in selected
     assert "agi-node" not in selected
     assert "agi-cluster" not in selected
+    assert "security-adoption" not in selected
     assert "ui-robot-matrix" not in selected
 
 

--- a/tools/security_adoption_check.py
+++ b/tools/security_adoption_check.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Write an advisory AGILAB security-check artifact for adoption gates."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+import json
+import os
+from pathlib import Path
+from typing import Sequence
+
+from agilab import security_check
+
+
+DEFAULT_OUTPUT = Path("test-results/security-check.json")
+STRICT_ENV_VAR = "AGILAB_SECURITY_CHECK_STRICT"
+
+
+def _truthy(value: str | None) -> bool:
+    return str(value or "").strip().lower() in {"1", "true", "yes", "on", "enabled"}
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run AGILAB's advisory security-check and persist a JSON artifact. "
+            "Warnings are non-blocking unless --strict or AGILAB_SECURITY_CHECK_STRICT=1 is set."
+        )
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+        help="JSON artifact path to write.",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Return non-zero when security-check reports advisory warnings.",
+    )
+    parser.add_argument("--env-file", type=Path, default=None, help="AGILAB .env file to inspect.")
+    parser.add_argument("--pip-audit-json", type=Path, default=None)
+    parser.add_argument("--sbom-json", type=Path, default=None)
+    parser.add_argument(
+        "--artifact-max-age-days",
+        type=int,
+        default=security_check.DEFAULT_ARTIFACT_MAX_AGE_DAYS,
+        help="Maximum accepted age for pip-audit/SBOM artifacts.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Also print the full JSON report to stdout.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(list(argv) if argv is not None else None)
+    strict = args.strict or _truthy(os.environ.get(STRICT_ENV_VAR))
+    report = security_check.build_report(
+        env_file=args.env_file,
+        now=datetime.now(timezone.utc),
+        pip_audit_json=args.pip_audit_json,
+        sbom_json=args.sbom_json,
+        artifact_max_age_days=args.artifact_max_age_days,
+    )
+
+    output = args.output.expanduser()
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        warnings = report["summary"]["warnings"]
+        mode = "strict" if strict else "advisory"
+        print(
+            f"security-check artifact: {output} "
+            f"status={report['status']} warnings={warnings} mode={mode}"
+        )
+
+    return 1 if strict and report["status"] != "pass" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/workflow_parity.py
+++ b/tools/workflow_parity.py
@@ -82,6 +82,7 @@ def _build_parser() -> argparse.ArgumentParser:
             "installer",
             "shared-core-typing",
             "dependency-policy",
+            "security-adoption",
             "cloud-emulators",
             "ui-robot-matrix",
         ],
@@ -141,6 +142,10 @@ def _profile_descriptions() -> dict[str, str]:
         "installer": "Run local installer parity checks including shell syntax and contract checks.",
         "shared-core-typing": "Run the curated shared-core strict mypy slice.",
         "dependency-policy": "Run dependency hygiene checks for runtime and release manifests.",
+        "security-adoption": (
+            "Write an advisory security-check JSON artifact; set "
+            "AGILAB_SECURITY_CHECK_STRICT=1 to fail on warnings."
+        ),
         "cloud-emulators": "Run account-free data connector emulator compatibility checks.",
         "ui-robot-matrix": "Run the opt-in full widget robot scenario matrix across public built-in apps.",
     }
@@ -159,6 +164,7 @@ def _profile_commands(args: argparse.Namespace) -> dict[str, list[CommandSpec]]:
         "installer": _installer_profile(args.app_path, args.worker_copy),
         "shared-core-typing": _shared_core_typing_profile(),
         "dependency-policy": _dependency_policy_profile(),
+        "security-adoption": _security_adoption_profile(),
         "cloud-emulators": _cloud_emulators_profile(),
         "ui-robot-matrix": _ui_robot_matrix_profile(),
     }
@@ -761,6 +767,27 @@ def _dependency_policy_profile() -> list[CommandSpec]:
     ]
 
 
+def _security_adoption_profile() -> list[CommandSpec]:
+    return [
+        CommandSpec(
+            label="security adoption check",
+            argv=[
+                "uv",
+                "--preview-features",
+                "extra-build-dependencies",
+                "run",
+                "python",
+                "tools/security_adoption_check.py",
+                "--output",
+                "test-results/security-check.json",
+            ],
+            timeout_seconds=2 * 60,
+            ensure_dirs=["test-results"],
+            remove_paths=["test-results/security-check.json"],
+        )
+    ]
+
+
 def _cloud_emulators_profile() -> list[CommandSpec]:
     return [
         CommandSpec(
@@ -821,7 +848,7 @@ def _ui_robot_matrix_profile() -> list[CommandSpec]:
 def _selected_profiles(args: argparse.Namespace) -> list[str]:
     if args.profile:
         return args.profile
-    opt_in_profiles = {"agi-node", "agi-cluster", "ui-robot-matrix"}
+    opt_in_profiles = {"agi-node", "agi-cluster", "security-adoption", "ui-robot-matrix"}
     return [name for name in _profile_descriptions() if name not in opt_in_profiles]
 
 


### PR DESCRIPTION
## Summary

Adds an opt-in `security-adoption` workflow parity profile that writes `test-results/security-check.json`, documents the shared/team adoption checkpoint, and keeps the docs mirror aligned.

The profile is advisory by default and only fails on warnings with `AGILAB_SECURITY_CHECK_STRICT=1` or `--strict`.

## Validation

- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_security_adoption_check.py test/test_security_check.py test/test_workflow_parity.py test/test_audit_response_docs.py`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile security-adoption`
- `AGILAB_SECURITY_CHECK_STRICT=1 uv --preview-features extra-build-dependencies run python tools/security_adoption_check.py --output /tmp/agilab-security-check-strict.json`
- local wheel smoke: `python -m agilab.lab_run security-check --json` from an isolated `uv --no-project` environment
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui`
- `uv --preview-features extra-build-dependencies run python tools/coverage_badge_guard.py --changed-only --require-fresh-xml`