### PR TITLE
[codex] Fix agi-env UI test collection without Streamlit

### DIFF
--- a/src/agilab/core/agi-env/test/conftest.py
+++ b/src/agilab/core/agi-env/test/conftest.py
@@ -1,0 +1,76 @@
+"""Test-only UI shims for agi-env's optional Streamlit helpers."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from collections.abc import Callable
+from datetime import date
+from typing import Any, TypeVar
+
+
+_F = TypeVar("_F", bound=Callable[..., Any])
+
+
+class _SessionState(dict[str, Any]):
+    def __getattr__(self, name: str) -> Any:
+        try:
+            return self[name]
+        except KeyError as exc:
+            raise AttributeError(name) from exc
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        self[name] = value
+
+
+class _NoopContainer:
+    def __getattr__(self, _name: str) -> Callable[..., None]:
+        def _noop(*_args: Any, **_kwargs: Any) -> None:
+            return None
+
+        return _noop
+
+
+class _StreamlitStub(types.ModuleType):
+    def __init__(self) -> None:
+        super().__init__("streamlit")
+        self.session_state = _SessionState()
+        self.sidebar = _NoopContainer()
+        self.query_params: dict[str, Any] = {}
+
+    def cache_data(self, func: _F | None = None, **_kwargs: Any) -> _F | Callable[[_F], _F]:
+        def _decorate(inner: _F) -> _F:
+            return inner
+
+        if func is None:
+            return _decorate
+        return _decorate(func)
+
+    def checkbox(self, _label: str, value: bool = False, **_kwargs: Any) -> bool:
+        return value
+
+    def number_input(self, _label: str, **kwargs: Any) -> Any:
+        return kwargs.get("value")
+
+    def text_area(self, _label: str, value: str = "", **_kwargs: Any) -> str:
+        return value
+
+    def text_input(self, _label: str, value: str = "", **_kwargs: Any) -> str:
+        return value
+
+    def selectbox(self, _label: str, options: list[Any], index: int = 0, **_kwargs: Any) -> Any:
+        return options[index]
+
+    def date_input(self, _label: str, value: date, **_kwargs: Any) -> date:
+        return value
+
+    def __getattr__(self, _name: str) -> Callable[..., None]:
+        def _noop(*_args: Any, **_kwargs: Any) -> None:
+            return None
+
+        return _noop
+
+
+if "streamlit" not in sys.modules and importlib.util.find_spec("streamlit") is None:
+    sys.modules["streamlit"] = _StreamlitStub()


### PR DESCRIPTION
## Summary

Adds a pytest-only Streamlit shim for agi-env optional UI helper tests.

## Why

After the agi-env / agi-gui split, runtime imports of `agi_env.pagelib` and `agi_env.streamlit_args` correctly require Streamlit via agi-gui. However, the agi-env test package still imports those modules at collection time. In a base/core test environment without Streamlit, pytest fails during collection before the optional-extra contract tests can run.

## Impact

This keeps runtime behavior unchanged: users still get the explicit `pip install agi-gui` hint when importing UI helpers without Streamlit. Only pytest collection gets a local stub when real Streamlit is absent.

## Validation

- `uv --preview-features extra-build-dependencies run --no-project --isolated --with-editable ./src/agilab/core/agi-env --with pytest --with pandas --with pydantic --with annotated-types --with tomlkit python -m pytest -q -o addopts='' src/agilab/core/agi-env/test/test_pagelib.py src/agilab/core/agi-env/test/test_streamlit_args.py`
- `uv --preview-features extra-build-dependencies run --no-project --isolated --with-editable ./src/agilab/core/agi-env --with pytest --with pandas --with pydantic --with annotated-types --with tomlkit python -m pytest -q -o addopts='' src/agilab/core/agi-env/test/test_optional_ui_split.py`
- `uv --preview-features extra-build-dependencies run --no-sync pytest -q src/agilab/core/agi-env/test`
- `uv --preview-features extra-build-dependencies run python tools/coverage_badge_guard.py --changed-only --require-fresh-xml`
