### PR TITLE
[codex] Avoid parquet engine dependency in agi-env tests

### DIFF
--- a/src/agilab/core/agi-env/test/test_pagelib_data_support.py
+++ b/src/agilab/core/agi-env/test/test_pagelib_data_support.py
@@ -116,7 +116,11 @@ def test_load_df_covers_empty_dir_parquet_first_column_index_and_non_file_path(t
     parquet_dir = tmp_path / "parquet-dataset"
     parquet_dir.mkdir()
     parquet_df = pd.DataFrame({"id": [1, 2], "value": [3, 4]})
-    parquet_df.to_parquet(parquet_dir / "part.parquet")
+    parquet_part = parquet_dir / "part.parquet"
+    parquet_part.write_text("parquet placeholder\n", encoding="utf-8")
+    single_parquet = tmp_path / "single.parquet"
+    single_parquet.write_text("parquet placeholder\n", encoding="utf-8")
+    monkeypatch.setattr(support.pd, "read_parquet", lambda _path: parquet_df.copy())
     loaded_parquet = support.load_df(parquet_dir)
     assert loaded_parquet is not None
     assert list(loaded_parquet["value"]) == [3, 4]
@@ -128,8 +132,6 @@ def test_load_df_covers_empty_dir_parquet_first_column_index_and_non_file_path(t
     assert loaded_latin is not None
     assert loaded_latin.iloc[0]["name"] == "café"
 
-    single_parquet = tmp_path / "single.parquet"
-    parquet_df.to_parquet(single_parquet)
     loaded_single = support.load_df(single_parquet, with_index=False)
     assert loaded_single is not None
     assert list(loaded_single["id"]) == [1, 2]


### PR DESCRIPTION
## Summary

Removes the implicit parquet writer dependency from the agi-env data-support test.

## Why

`test_load_df_covers_empty_dir_parquet_first_column_index_and_non_file_path` wrote parquet files with `DataFrame.to_parquet()`. That requires `pyarrow` or `fastparquet`, which are intentionally not part of the base agi-env test environment. The test only needs to cover `load_df()` dispatching to `pd.read_parquet`, so a lightweight reader stub is sufficient.

## Impact

Runtime code is unchanged. Base/core test environments can validate parquet-loading behavior without installing a heavy optional parquet engine.

## Validation

- `uv --preview-features extra-build-dependencies run --no-project --isolated --with-editable ./src/agilab/core/agi-env --with pytest --with pandas --with pydantic --with annotated-types --with tomlkit python -m pytest -q -o addopts='' src/agilab/core/agi-env/test/test_pagelib_data_support.py::test_load_df_covers_empty_dir_parquet_first_column_index_and_non_file_path`
- `uv --preview-features extra-build-dependencies run --no-project --isolated --with-editable ./src/agilab/core/agi-env --with pytest --with pandas --with pydantic --with annotated-types --with tomlkit python -m pytest -q -o addopts='' src/agilab/core/agi-env/test/test_pagelib_data_support.py`
- `uv --preview-features extra-build-dependencies run --no-sync pytest -q src/agilab/core/agi-env/test`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-env`
- `uv --preview-features extra-build-dependencies run python tools/coverage_badge_guard.py --changed-only --require-fresh-xml`
