### PR TITLE
[codex] Avoid parquet engine dependency in worker tests

### DIFF
--- a/src/agilab/core/test/conftest.py
+++ b/src/agilab/core/test/conftest.py
@@ -11,3 +11,18 @@ def reset_agienv_singleton():
     AgiEnv.reset()
     yield
     AgiEnv.reset()
+
+
+@pytest.fixture
+def pandas_parquet_io_stub(monkeypatch):
+    """Exercise parquet dispatch without requiring pyarrow/fastparquet."""
+    import pandas as pd
+
+    def _to_parquet_stub(self, path, *_args, **_kwargs):
+        self.to_csv(path, index=False)
+
+    def _read_parquet_stub(path, *_args, **_kwargs):
+        return pd.read_csv(path)
+
+    monkeypatch.setattr(pd.DataFrame, "to_parquet", _to_parquet_stub)
+    monkeypatch.setattr(pd, "read_parquet", _read_parquet_stub)

--- a/src/agilab/core/test/test_fireducks_worker.py
+++ b/src/agilab/core/test/test_fireducks_worker.py
@@ -116,7 +116,8 @@ def test_work_done_csv(worker_csv):
     assert df_read["col"].tolist() == [1, 2]
 
 
-def test_work_done_parquet(worker_parquet):
+def test_work_done_parquet(worker_parquet, pandas_parquet_io_stub):
+    _ = pandas_parquet_io_stub
     worker_parquet.work_done(pd.DataFrame({"col": [3, 4]}))
     output_file = worker_parquet.data_out / "0_output.parquet"
     assert output_file.exists()

--- a/src/agilab/core/test/test_pandas_worker.py
+++ b/src/agilab/core/test/test_pandas_worker.py
@@ -159,7 +159,8 @@ def test_work_done_csv(worker_csv):
     assert df_read["col"].tolist() == [1, 2, 3]
 
 
-def test_work_done_parquet(worker_parquet):
+def test_work_done_parquet(worker_parquet, pandas_parquet_io_stub):
+    _ = pandas_parquet_io_stub
     df = pd.DataFrame({"col": [4, 5, 6]})
     worker_parquet.work_done(df)
     output_file = worker_parquet.data_out / "0_output.parquet"


### PR DESCRIPTION
## Summary

Removes the implicit parquet engine dependency from the pandas/fireducks worker tests.

## Why

The worker tests exercised parquet output by calling pandas `to_parquet()` and `read_parquet()` directly. In a base validation environment without `pyarrow` or `fastparquet`, that fails before the worker behavior can be asserted.

## Impact

Runtime worker behavior is unchanged. The tests now use an explicit pytest fixture that stubs pandas parquet I/O with CSV-backed placeholder files, so they still verify output path and format dispatch without requiring optional parquet engines.

## Validation

- `uv --preview-features extra-build-dependencies run --no-project --isolated --with-editable ./src/agilab/core/agi-env --with-editable ./src/agilab/core/agi-node --with-editable ./src/agilab/core/agi-cluster --with-editable ./src/agilab/core/agi-core --with sqlalchemy --with pytest --with pytest-asyncio --with pandas --with psutil --with dask --with distributed --with humanize --with polars --with scikit-learn --with tomlkit python -m pytest -q -o addopts='' src/agilab/core/test/test_pandas_worker.py::test_work_done_parquet src/agilab/core/test/test_fireducks_worker.py::test_work_done_parquet`
- `uv --preview-features extra-build-dependencies run --no-project --isolated --with-editable ./src/agilab/core/agi-env --with-editable ./src/agilab/core/agi-node --with-editable ./src/agilab/core/agi-cluster --with-editable ./src/agilab/core/agi-core --with sqlalchemy --with pytest --with pytest-asyncio --with pandas --with psutil --with dask --with distributed --with humanize --with polars --with scikit-learn --with tomlkit python -m pytest -q -o addopts='' src/agilab/core/test/test_pandas_worker.py src/agilab/core/test/test_fireducks_worker.py`
- `uv --preview-features extra-build-dependencies run pytest -q src/agilab/core/test/conftest.py src/agilab/core/test/test_fireducks_worker.py src/agilab/core/test/test_pandas_worker.py`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-core-combined`
- `uv --preview-features extra-build-dependencies run python tools/coverage_badge_guard.py --changed-only --require-fresh-xml`
