### PR TITLE
Ensure MLflow extra for source dev UI

### DIFF
--- a/pycharm/setup_pycharm.py
+++ b/pycharm/setup_pycharm.py
@@ -282,7 +282,10 @@ def _bootstrap_project_venv(project_dir: Path) -> Optional[Path]:
     return venv_python_for(project_dir)
 
 
-ROOT_UI_IMPORT_MODULES = ("agi_gui", "streamlit", "tomli_w")
+ROOT_DEV_EXTRA_IMPORT_MODULES = {
+    "ui": ("agi_gui", "streamlit", "tomli_w"),
+    "mlflow": ("mlflow",),
+}
 
 
 def _project_declares_extra(project_dir: Path, extra: str) -> bool:
@@ -331,16 +334,28 @@ def _missing_import_modules(python_path: Path, modules: Iterable[str]) -> list[s
     return module_names
 
 
+def _declared_root_dev_extras(cfg: Config) -> tuple[list[str], list[str]]:
+    extras: list[str] = []
+    modules: list[str] = []
+    for extra, extra_modules in ROOT_DEV_EXTRA_IMPORT_MODULES.items():
+        if not _project_declares_extra(cfg.ROOT, extra):
+            continue
+        extras.append(extra)
+        modules.extend(extra_modules)
+    return extras, modules
+
+
 def ensure_project_ui_environment(cfg: Config) -> Optional[Path]:
     """Ensure source-checkout UI run configs can run with UV_NO_SYNC=1."""
 
-    if not _project_declares_extra(cfg.ROOT, "ui"):
+    extras, modules = _declared_root_dev_extras(cfg)
+    if not extras:
         return venv_python_for(cfg.ROOT)
 
     root_python = venv_python_for(cfg.ROOT)
-    missing = list(ROOT_UI_IMPORT_MODULES)
+    missing = modules
     if root_python:
-        missing = _missing_import_modules(root_python, ROOT_UI_IMPORT_MODULES)
+        missing = _missing_import_modules(root_python, modules)
         if not missing:
             return root_python
 
@@ -354,15 +369,19 @@ def ensure_project_ui_environment(cfg: Config) -> Optional[Path]:
         if root_python is None
         else f"missing modules: {', '.join(missing)}"
     )
-    logging.info("Syncing %s with the ui extra (%s).", cfg.ROOT.name, reason)
+    logging.info("Syncing %s with dev UI extra(s) %s (%s).", cfg.ROOT.name, ", ".join(extras), reason)
+    sync_args = [uv_bin, "sync", "--project", "."]
+    for extra in extras:
+        sync_args.extend(["--extra", extra])
+    sync_args.extend(["--preview-features", "python-upgrade"])
     try:
         subprocess.run(
-            [uv_bin, "sync", "--project", ".", "--extra", "ui", "--preview-features", "python-upgrade"],
+            sync_args,
             cwd=cfg.ROOT,
             check=True,
         )
     except subprocess.CalledProcessError as exc:
-        logging.warning("uv sync --extra ui failed for %s: %s", cfg.ROOT.name, exc)
+        logging.warning("uv sync with dev UI extra(s) failed for %s: %s", cfg.ROOT.name, exc)
         return root_python
 
     return venv_python_for(cfg.ROOT)

--- a/test/test_setup_pycharm.py
+++ b/test/test_setup_pycharm.py
@@ -413,7 +413,7 @@ def test_rebinds_root_run_configs_to_checkout_sdk(tmp_path: Path) -> None:
     assert _option(app, "SDK_NAME") == "uv (flight_project)"
 
 
-def test_ensure_project_ui_environment_syncs_missing_ui_extra(tmp_path: Path, monkeypatch) -> None:
+def test_ensure_project_ui_environment_syncs_missing_dev_ui_extra(tmp_path: Path, monkeypatch) -> None:
     root = tmp_path / "agilab-src"
     root.mkdir()
     (root / "pyproject.toml").write_text(
@@ -422,6 +422,7 @@ def test_ensure_project_ui_environment_syncs_missing_ui_extra(tmp_path: Path, mo
 name = "agilab"
 
 [project.optional-dependencies]
+mlflow = ["mlflow"]
 ui = ["agi-gui", "streamlit", "tomli_w"]
 """,
         encoding="utf-8",
@@ -438,7 +439,7 @@ ui = ["agi-gui", "streamlit", "tomli_w"]
         lambda project_dir: python_path if project_dir == root else None,
     )
     monkeypatch.setattr(setup_pycharm, "_find_uv_binary", lambda: "/usr/bin/uv")
-    monkeypatch.setattr(setup_pycharm, "_missing_import_modules", lambda _python, _modules: ["tomli_w"])
+    monkeypatch.setattr(setup_pycharm, "_missing_import_modules", lambda _python, _modules: ["mlflow"])
 
     def fake_run(argv, cwd, check):
         calls.append((argv, cwd, check))
@@ -449,7 +450,18 @@ ui = ["agi-gui", "streamlit", "tomli_w"]
     assert setup_pycharm.ensure_project_ui_environment(cfg) == python_path
     assert calls == [
         (
-            ["/usr/bin/uv", "sync", "--project", ".", "--extra", "ui", "--preview-features", "python-upgrade"],
+            [
+                "/usr/bin/uv",
+                "sync",
+                "--project",
+                ".",
+                "--extra",
+                "ui",
+                "--extra",
+                "mlflow",
+                "--preview-features",
+                "python-upgrade",
+            ],
             root,
             True,
         )
@@ -465,6 +477,7 @@ def test_ensure_project_ui_environment_skips_when_ui_modules_import(tmp_path: Pa
 name = "agilab"
 
 [project.optional-dependencies]
+mlflow = ["mlflow"]
 ui = ["agi-gui", "streamlit", "tomli_w"]
 """,
         encoding="utf-8",


### PR DESCRIPTION
## Summary
- make source checkout PyCharm setup sync all declared dev UI extras, including mlflow
- keep Streamlit/tomli_w/agi_gui and MLflow import probes in one source-dev guard
- add regression coverage for the missing-mlflow repair path

## Validation
- uv --preview-features extra-build-dependencies run pytest -q test/test_setup_pycharm.py
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui
- uv --preview-features extra-build-dependencies run python tools/coverage_badge_guard.py --changed-only --require-fresh-xml