### PR TITLE
Add worker import preflight to UI robot

### DIFF
--- a/test/test_agilab_widget_robot.py
+++ b/test/test_agilab_widget_robot.py
@@ -639,7 +639,77 @@ def test_current_home_action_preflight_allows_disabled_cluster_with_missing_shar
         active_app_query="flight_project",
         page_name="ORCHESTRATE",
         action_button_policy="click-selected",
+        click_action_labels=["INSTALL"],
+        runtime_isolation="current-home",
+        server_env={"AGI_CLUSTER_ENABLED": "0"},
+        home_root=fake_home,
+    )
+
+    assert detail is None
+
+
+def test_current_home_action_preflight_blocks_missing_worker_dependency(tmp_path, monkeypatch) -> None:
+    module = _load_module()
+    fake_home = tmp_path / "home"
+    worker_root = fake_home / "wenv" / "meteo_forecast_worker"
+    worker_root.mkdir(parents=True)
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(module.shutil, "which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+
+    def fake_run(argv, cwd, capture_output, text, check, timeout):
+        calls.append(
+            {
+                "argv": argv,
+                "cwd": cwd,
+                "capture_output": capture_output,
+                "text": text,
+                "check": check,
+                "timeout": timeout,
+            }
+        )
+        return module.subprocess.CompletedProcess(
+            argv,
+            1,
+            stdout="",
+            stderr="ModuleNotFoundError: No module named 'skforecast'\n",
+        )
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    detail = module.current_home_action_preflight_blocker(
+        app_name="meteo_forecast_project",
+        active_app_query="meteo_forecast_project",
+        page_name="ORCHESTRATE",
+        action_button_policy="click-selected",
         click_action_labels=["Run -> Load -> Export"],
+        runtime_isolation="current-home",
+        server_env={"AGI_CLUSTER_ENABLED": "0"},
+        home_root=fake_home,
+    )
+
+    assert detail is not None
+    assert "environment_blocked" in detail
+    assert "meteo_forecast_project" in detail
+    assert "meteo_forecast_worker" in detail
+    assert "skforecast" in detail
+    assert "Run INSTALL" in detail
+    assert calls
+    argv = calls[0]["argv"]
+    assert argv[:6] == ["/usr/bin/uv", "--quiet", "run", "--no-sync", "--project", str(worker_root)]
+    assert argv[-1] == "meteo_forecast_worker"
+    assert calls[0]["cwd"] == worker_root
+
+
+def test_current_home_action_preflight_does_not_block_install_when_worker_missing(tmp_path) -> None:
+    module = _load_module()
+    fake_home = tmp_path / "home"
+
+    detail = module.current_home_action_preflight_blocker(
+        app_name="meteo_forecast_project",
+        active_app_query="meteo_forecast_project",
+        page_name="ORCHESTRATE",
+        action_button_policy="click-selected",
+        click_action_labels=["INSTALL"],
         runtime_isolation="current-home",
         server_env={"AGI_CLUSTER_ENABLED": "0"},
         home_root=fake_home,

--- a/tools/agilab_widget_robot.py
+++ b/tools/agilab_widget_robot.py
@@ -9,6 +9,8 @@ import importlib.util
 import json
 import os
 import re
+import shutil
+import subprocess
 import sys
 import tempfile
 import time
@@ -84,6 +86,13 @@ CURRENT_HOME_PREFLIGHT_ACTION_LABELS = (
     "Run -> Load -> Export",
     "Run now",
 )
+CURRENT_HOME_WORKER_IMPORT_PREFLIGHT_ACTION_LABELS = (
+    "CHECK distribute",
+    "DISTRIBUTE",
+    "Run -> Load -> Export",
+    "Run now",
+)
+CURRENT_HOME_WORKER_IMPORT_TIMEOUT_SECONDS = 20.0
 BROWSER_ISSUE_FATAL_NEEDLES = (
     "agi execution failed",
     "build failed",
@@ -1392,6 +1401,87 @@ def _current_home_preflight_action_requested(click_action_labels: Sequence[str])
     )
 
 
+def _current_home_worker_import_preflight_requested(click_action_labels: Sequence[str]) -> bool:
+    selected = [_normalized_label(label) for label in click_action_labels if _normalized_label(label)]
+    required = [_normalized_label(label) for label in CURRENT_HOME_WORKER_IMPORT_PREFLIGHT_ACTION_LABELS]
+    return any(
+        expected == label or expected in label or label in expected
+        for label in selected
+        for expected in required
+    )
+
+
+def _worker_python_import_command(worker_root: Path, worker_package: str) -> list[str]:
+    uv_bin = shutil.which("uv") or "uv"
+    probe = (
+        "import importlib, sys\n"
+        "module = sys.argv[1]\n"
+        "importlib.import_module(module)\n"
+        "print(f'import-ok:{module}')\n"
+    )
+    return [
+        uv_bin,
+        "--quiet",
+        "run",
+        "--no-sync",
+        "--project",
+        str(worker_root),
+        "python",
+        "-c",
+        probe,
+        worker_package,
+    ]
+
+
+def _current_home_worker_import_issue(
+    *,
+    app_name: str,
+    home_root: Path,
+) -> str | None:
+    target = app_target_name(app_name)
+    worker_package = f"{target}_worker"
+    worker_root = home_root / "wenv" / worker_package
+    if not worker_root.is_dir():
+        return (
+            f"installed worker project is missing: {worker_root}. "
+            f"Run INSTALL for {app_name} before running backend ORCHESTRATE actions."
+        )
+
+    command = _worker_python_import_command(worker_root, worker_package)
+    try:
+        result = subprocess.run(
+            command,
+            cwd=worker_root,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=CURRENT_HOME_WORKER_IMPORT_TIMEOUT_SECONDS,
+        )
+    except FileNotFoundError as exc:
+        return f"unable to run worker import probe because `uv` was not found: {exc}"
+    except subprocess.TimeoutExpired as exc:
+        return (
+            f"worker import probe timed out after {CURRENT_HOME_WORKER_IMPORT_TIMEOUT_SECONDS:.1f}s "
+            f"for {worker_package}: {exc}"
+        )
+
+    if result.returncode == 0:
+        return None
+
+    detail = "\n".join(
+        part.strip()
+        for part in (result.stderr, result.stdout)
+        if part and part.strip()
+    )
+    if not detail:
+        detail = f"exit code {result.returncode}"
+    return (
+        f"installed worker project failed import probe: {worker_root}. "
+        f"Module `{worker_package}` could not be imported with the current worker environment. "
+        f"{_short_detail(detail, limit=900)}"
+    )
+
+
 def current_home_action_preflight_blocker(
     *,
     app_name: str,
@@ -1413,34 +1503,42 @@ def current_home_action_preflight_blocker(
     env = dict(server_env or {})
     env_file = home / ".agilab" / ".env"
     env_values = _load_dotenv_map(env_file)
-    if not _current_home_cluster_enabled(
+    cluster_enabled = _current_home_cluster_enabled(
         app_name=app_name,
         active_app_query=active_app_query,
         home_root=home,
         server_env=env,
         env_values=env_values,
-    ):
-        return None
+    )
 
-    cluster_share = _strip_config_value(env_values.get("AGI_CLUSTER_SHARE") or env.get("AGI_CLUSTER_SHARE") or str(home / "clustershare"))
-    local_share = _strip_config_value(env_values.get("AGI_LOCAL_SHARE") or env.get("AGI_LOCAL_SHARE") or str(home / "localshare"))
-    cluster_path = _home_relative_path(cluster_share, home_root=home)
-    local_path = _home_relative_path(local_share, home_root=home)
-    if _same_configured_path(cluster_path, local_path):
-        return (
-            "environment_blocked: current-home ORCHESTRATE selected actions were not clicked because "
-            f"cluster mode is enabled for {app_name} but AGI_CLUSTER_SHARE and AGI_LOCAL_SHARE both resolve "
-            f"to {cluster_path}. Set AGI_CLUSTER_SHARE to a distinct mounted shared path, or disable "
-            f"cluster mode in {home / '.agilab' / 'apps' / app_name / 'app_settings.toml'}."
-        )
-    if not _is_writable_directory(cluster_path):
-        return (
-            "environment_blocked: current-home ORCHESTRATE selected actions were not clicked because "
-            f"cluster mode is enabled for {app_name} but AGI_CLUSTER_SHARE={str(cluster_path)!r} is not a "
-            f"writable directory. Mount/create that path or disable cluster mode in "
-            f"{home / '.agilab' / 'apps' / app_name / 'app_settings.toml'} before rerunning the UI robot. "
-            f"env={env_file}"
-        )
+    if cluster_enabled:
+        cluster_share = _strip_config_value(env_values.get("AGI_CLUSTER_SHARE") or env.get("AGI_CLUSTER_SHARE") or str(home / "clustershare"))
+        local_share = _strip_config_value(env_values.get("AGI_LOCAL_SHARE") or env.get("AGI_LOCAL_SHARE") or str(home / "localshare"))
+        cluster_path = _home_relative_path(cluster_share, home_root=home)
+        local_path = _home_relative_path(local_share, home_root=home)
+        if _same_configured_path(cluster_path, local_path):
+            return (
+                "environment_blocked: current-home ORCHESTRATE selected actions were not clicked because "
+                f"cluster mode is enabled for {app_name} but AGI_CLUSTER_SHARE and AGI_LOCAL_SHARE both resolve "
+                f"to {cluster_path}. Set AGI_CLUSTER_SHARE to a distinct mounted shared path, or disable "
+                f"cluster mode in {home / '.agilab' / 'apps' / app_name / 'app_settings.toml'}."
+            )
+        if not _is_writable_directory(cluster_path):
+            return (
+                "environment_blocked: current-home ORCHESTRATE selected actions were not clicked because "
+                f"cluster mode is enabled for {app_name} but AGI_CLUSTER_SHARE={str(cluster_path)!r} is not a "
+                f"writable directory. Mount/create that path or disable cluster mode in "
+                f"{home / '.agilab' / 'apps' / app_name / 'app_settings.toml'} before rerunning the UI robot. "
+                f"env={env_file}"
+            )
+    if _current_home_worker_import_preflight_requested(click_action_labels):
+        worker_issue = _current_home_worker_import_issue(app_name=app_name, home_root=home)
+        if worker_issue is not None:
+            return (
+                "environment_blocked: current-home ORCHESTRATE selected actions were not clicked because "
+                f"the installed worker environment for {app_name} is not ready. {worker_issue} "
+                "Run INSTALL, then rerun the UI robot before manual RUN / LOAD / EXPORT validation."
+            )
     return None
 
 


### PR DESCRIPTION
## Summary
- add current-home ORCHESTRATE worker import preflight for backend actions
- probe ~/wenv/<target>_worker with uv run --no-sync before clicking run/distribute actions
- add regression coverage for meteo_forecast_project missing skforecast and install-only behavior

## Validation
- uv --preview-features extra-build-dependencies run pytest -q test/test_agilab_widget_robot.py test/test_agilab_widget_robot_full.py test/test_agilab_widget_robot_matrix.py
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui
- uv --preview-features extra-build-dependencies run python tools/coverage_badge_guard.py --changed-only --require-fresh-xml