### PR TITLE
Fix stale active app root on source launch

### DIFF
--- a/src/agilab/about_page/bootstrap.py
+++ b/src/agilab/about_page/bootstrap.py
@@ -139,18 +139,49 @@ def normalize_active_app_input(env: Any, raw_value: Optional[str]) -> Path | Non
     except (TypeError, RuntimeError, ValueError):
         return None
 
+    def add_root_candidate(root: Any, app_name: str) -> None:
+        if not root or not app_name:
+            return
+        try:
+            candidates.append((Path(root) / app_name).resolve())
+        except (TypeError, RuntimeError, ValueError, OSError):
+            return
+
+    def prepend_root_candidate(root: Any, app_name: str) -> None:
+        if not root or not app_name:
+            return
+        try:
+            candidates.insert(0, (Path(root) / app_name).resolve())
+        except (TypeError, RuntimeError, ValueError, OSError):
+            return
+
     if provided.is_absolute():
         candidates.append(provided)
     else:
         candidates.append((Path.cwd() / provided).resolve())
-        candidates.append((env.apps_path / provided).resolve())
-        candidates.append((env.apps_path / provided.name).resolve())
+        add_root_candidate(getattr(env, "apps_path", None), str(provided))
+        add_root_candidate(getattr(env, "apps_path", None), provided.name)
+        add_root_candidate(getattr(env, "builtin_apps_path", None), str(provided))
+        add_root_candidate(getattr(env, "builtin_apps_path", None), provided.name)
+        add_root_candidate(getattr(env, "apps_repository_root", None), str(provided))
+        add_root_candidate(getattr(env, "apps_repository_root", None), provided.name)
 
+    projects = getattr(env, "projects", set()) or set()
     if not provided.is_absolute():
-        if raw_value in env.projects:
-            candidates.insert(0, (env.apps_path / raw_value).resolve())
-        elif provided.name in env.projects:
-            candidates.insert(0, (env.apps_path / provided.name).resolve())
+        if raw_value in projects:
+            for root in (
+                getattr(env, "apps_repository_root", None),
+                getattr(env, "builtin_apps_path", None),
+                getattr(env, "apps_path", None),
+            ):
+                prepend_root_candidate(root, raw_value)
+        elif provided.name in projects:
+            for root in (
+                getattr(env, "apps_repository_root", None),
+                getattr(env, "builtin_apps_path", None),
+                getattr(env, "apps_path", None),
+            ):
+                prepend_root_candidate(root, provided.name)
 
     for candidate in candidates:
         try:
@@ -160,6 +191,39 @@ def normalize_active_app_input(env: Any, raw_value: Optional[str]) -> Path | Non
         if candidate.exists():
             return candidate
     return None
+
+
+def persisted_active_app_request(env: Any, raw_value: Any) -> str | None:
+    """Resolve persisted app state as an app identity, not as authority over the launch root."""
+    text = str(raw_value or "").strip()
+    if not text:
+        return None
+    try:
+        path = Path(text).expanduser()
+        name = path.name
+    except (TypeError, RuntimeError, ValueError):
+        return text
+    if path.is_absolute():
+        try:
+            resolved_path = path.resolve(strict=False)
+        except OSError:
+            resolved_path = path
+        for root in (
+            getattr(env, "apps_path", None),
+            getattr(env, "builtin_apps_path", None),
+            getattr(env, "apps_repository_root", None),
+        ):
+            if not root:
+                continue
+            try:
+                if resolved_path.is_relative_to(Path(root).resolve(strict=False)):
+                    return text
+            except (TypeError, RuntimeError, ValueError, OSError):
+                continue
+    projects = getattr(env, "projects", set()) or set()
+    if name in projects:
+        return name
+    return text
 
 
 def _normalized_existing_or_requested_path(raw_value: Any) -> Path | None:
@@ -479,7 +543,7 @@ def bootstrap_page_environment(
     if not requested_app:
         last_app = ports.load_last_active_app()
         if last_app:
-            requested_app = str(last_app)
+            requested_app = persisted_active_app_request(env, last_app)
     apply_active_app_request(env, requested_app)
 
     env.init_done = True

--- a/test/test_about_agilab_helpers.py
+++ b/test/test_about_agilab_helpers.py
@@ -611,6 +611,85 @@ def test_bootstrap_active_app_store_path_prefers_real_active_app(tmp_path):
     assert bootstrap.active_app_store_path(env) == active_app
 
 
+def test_bootstrap_normalize_active_app_input_finds_builtin_project_name(tmp_path):
+    bootstrap = about_agilab._about_bootstrap
+    apps_path = tmp_path / "src" / "agilab" / "apps"
+    builtin_path = apps_path / "builtin"
+    active_app = builtin_path / "flight_project"
+    active_app.mkdir(parents=True)
+    env = SimpleNamespace(
+        apps_path=apps_path,
+        builtin_apps_path=builtin_path,
+        apps_repository_root=None,
+        projects={"flight_project"},
+    )
+
+    assert bootstrap.normalize_active_app_input(env, "flight_project") == active_app.resolve()
+
+
+def test_bootstrap_page_environment_keeps_source_root_when_last_app_is_agi_space(tmp_path):
+    bootstrap = about_agilab._about_bootstrap
+    source_apps = tmp_path / "agilab-src" / "src" / "agilab" / "apps"
+    source_builtin = source_apps / "builtin"
+    source_project = source_builtin / "flight_project"
+    stale_project = tmp_path / "agi-space" / "apps" / "builtin" / "flight_project"
+    source_project.mkdir(parents=True)
+    stale_project.mkdir(parents=True)
+    requested_apps: list[str | None] = []
+
+    class FakeAgiEnv:
+        def __init__(self, *, apps_path: Path, app: str = "flight_project", verbose: int = 1):
+            self.apps_path = apps_path
+            self.builtin_apps_path = apps_path / "builtin"
+            self.apps_repository_root = None
+            self.verbose = verbose
+            self.app = app
+            self.active_app = self.builtin_apps_path / app
+            self.projects = {"flight_project"}
+            self.is_source_env = True
+            self.is_worker_env = False
+            self.OPENAI_API_KEY = ""
+            self.CLUSTER_CREDENTIALS = ""
+            self.envars = {}
+            self.init_done = False
+
+        @staticmethod
+        def set_env_var(_key: str, _value: str) -> None:
+            return None
+
+    def apply_request(env, requested):
+        requested_apps.append(requested)
+        return bootstrap.apply_active_app_request(env, requested, streamlit=fake_st)
+
+    fake_st = _FakeStreamlit()
+    ports, port_calls = _make_bootstrap_ports(
+        FakeAgiEnv,
+        services_enabled=False,
+        last_app=stale_project,
+        environ={},
+    )
+
+    result = bootstrap.bootstrap_page_environment(
+        streamlit=fake_st,
+        env_file_path=tmp_path / ".env",
+        load_env_file_map=lambda _path: {},
+        logger=object(),
+        apply_active_app_request=apply_request,
+        handle_data_root_failure=lambda *_args, **_kwargs: False,
+        refresh_env_from_file=lambda _env: None,
+        clean_openai_key=lambda value: value,
+        store_cluster_credentials=lambda *_args, **_kwargs: True,
+        argv=["--apps-path", str(source_apps)],
+        ports=ports,
+    )
+
+    assert result.env.active_app == source_project
+    assert result.env.apps_path == source_apps
+    assert requested_apps == ["flight_project"]
+    assert port_calls.stored == [source_project]
+    assert fake_st.query_params["active_app"] == "flight_project"
+
+
 def test_bootstrap_normalize_active_app_input_skips_unresolvable_candidate(
     tmp_path,
     monkeypatch,


### PR DESCRIPTION
## Summary
- treat persisted last-active-app paths as project identity when they point outside the current launch roots
- resolve name-only active app requests against builtin and apps repository roots, not only the apps parent
- add regression coverage for stale agi-space state during source launches

## Validation
- uv --preview-features extra-build-dependencies run pytest -q test/test_about_agilab_helpers.py::test_bootstrap_normalize_active_app_input_finds_builtin_project_name test/test_about_agilab_helpers.py::test_bootstrap_page_environment_keeps_source_root_when_last_app_is_agi_space
- uv --preview-features extra-build-dependencies run pytest -q test/test_about_agilab_helpers.py test/test_ui_pages.py::test_execute_page_cluster_settings
- uv --preview-features extra-build-dependencies run pytest -q src/agilab/core/agi-env/test/test_bootstrap_support.py test/test_about_agilab_helpers.py
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui
- uv --preview-features extra-build-dependencies run python tools/coverage_badge_guard.py --changed-only --require-fresh-xml
- direct source-launch stale path repro