### PR TITLE
Realign stale page env roots

### DIFF
--- a/src/agilab/page_bootstrap.py
+++ b/src/agilab/page_bootstrap.py
@@ -8,6 +8,24 @@ from pathlib import Path
 from typing import Any, Callable
 
 
+def _safe_resolved_path(value: Any) -> Path | None:
+    try:
+        return Path(value).expanduser().resolve(strict=False)
+    except (TypeError, RuntimeError, ValueError, OSError):
+        return None
+
+
+def _page_apps_path(current_file: str | Path) -> Path | None:
+    current_path = _safe_resolved_path(current_file)
+    if current_path is None:
+        return None
+    try:
+        apps_path = current_path.parents[1] / "apps"
+    except IndexError:
+        return None
+    return apps_path if apps_path.exists() else None
+
+
 def session_env_ready(
     session_state: Any,
     *,
@@ -18,6 +36,50 @@ def session_env_ready(
     if env_key not in session_state:
         return False
     return bool(getattr(session_state[env_key], "init_done", init_done_default))
+
+
+def realign_session_env_with_page_root(
+    session_state: Any,
+    current_file: str | Path,
+    *,
+    env_key: str = "env",
+) -> bool:
+    """Repair a stale page session env that belongs to a different AGILAB launch root."""
+    if env_key not in session_state:
+        return False
+    expected_apps_path = _page_apps_path(current_file)
+    if expected_apps_path is None:
+        return False
+
+    env = session_state[env_key]
+    env_apps_path = _safe_resolved_path(getattr(env, "apps_path", None))
+    recorded_apps_path = _safe_resolved_path(session_state.get("apps_path"))
+    if env_apps_path == expected_apps_path:
+        return False
+    if recorded_apps_path != expected_apps_path:
+        return False
+
+    app_name = Path(str(getattr(env, "app", "") or "")).name
+    if not app_name:
+        active_app = getattr(env, "active_app", None)
+        app_name = Path(str(active_app)).name if active_app else ""
+    if not app_name:
+        return False
+
+    previous_init_done = getattr(env, "init_done", None)
+    try:
+        type(env).__init__(
+            env,
+            apps_path=expected_apps_path,
+            app=app_name,
+            verbose=getattr(env, "verbose", None),
+        )
+        if previous_init_done is not None:
+            env.init_done = previous_init_done
+    except (AttributeError, OSError, RuntimeError, TypeError, ValueError):
+        return False
+    session_state["apps_path"] = str(expected_apps_path)
+    return True
 
 
 def load_about_page_module(
@@ -65,6 +127,7 @@ def ensure_page_env(
         streamlit.session_state,
         init_done_default=init_done_default,
     ):
+        realign_session_env_with_page_root(streamlit.session_state, current_file)
         return streamlit.session_state["env"]
 
     about_page = load_about_page_module(current_file, load_module=load_module)

--- a/test/test_about_agilab_helpers.py
+++ b/test/test_about_agilab_helpers.py
@@ -193,6 +193,55 @@ def test_page_bootstrap_session_env_ready_handles_missing_and_init_flags():
     assert page_bootstrap.session_env_ready({"env": env}) is True
 
 
+def test_page_bootstrap_realigns_stale_session_env_to_page_root(tmp_path):
+    source_root = tmp_path / "agilab-src" / "src" / "agilab"
+    source_apps = source_root / "apps"
+    page_file = source_root / "pages" / "2_ORCHESTRATE.py"
+    source_project = source_apps / "builtin" / "flight_project"
+    stale_apps = tmp_path / "agi-space" / "apps" / "builtin"
+    page_file.parent.mkdir(parents=True)
+    source_project.mkdir(parents=True)
+    stale_apps.mkdir(parents=True)
+
+    class FakeEnv:
+        def __init__(self, *, apps_path: Path, app: str = "flight_project", verbose: int | None = 1):
+            self.apps_path = apps_path
+            self.app = app
+            self.verbose = verbose
+            self.active_app = apps_path / "builtin" / app if apps_path.name == "apps" else apps_path / app
+            self.init_done = True
+
+    env = FakeEnv(apps_path=stale_apps)
+    session_state = {
+        "env": env,
+        "apps_path": str(source_apps),
+    }
+
+    assert page_bootstrap.realign_session_env_with_page_root(session_state, page_file) is True
+    assert env.apps_path == source_apps
+    assert env.active_app == source_project
+    assert session_state["apps_path"] == str(source_apps)
+    assert env.init_done is True
+
+
+def test_page_bootstrap_keeps_session_env_when_recorded_root_differs(tmp_path):
+    source_root = tmp_path / "agilab-src" / "src" / "agilab"
+    source_apps = source_root / "apps"
+    other_apps = tmp_path / "other" / "apps"
+    page_file = source_root / "pages" / "2_ORCHESTRATE.py"
+    page_file.parent.mkdir(parents=True)
+    source_apps.mkdir(parents=True)
+    other_apps.mkdir(parents=True)
+    env = SimpleNamespace(apps_path=other_apps, app="flight_project", init_done=True)
+    session_state = {
+        "env": env,
+        "apps_path": str(other_apps),
+    }
+
+    assert page_bootstrap.realign_session_env_with_page_root(session_state, page_file) is False
+    assert env.apps_path == other_apps
+
+
 def test_import_guard_error_is_rendered_as_code(monkeypatch):
     fake_st = _StoppingStreamlit()
     monkeypatch.setattr(about_agilab, "st", fake_st)


### PR DESCRIPTION
## Summary
- repair already-open Streamlit page sessions whose env root drifted from the current page checkout root
- only realign when session_state records the current page apps root, avoiding injected test/runtime envs
- add regression coverage for stale agi-space envs on ORCHESTRATE-style page loads

## Validation
- uv --preview-features extra-build-dependencies run pytest -q test/test_ui_pages.py::test_pipeline_page_restores_missing_export_stages_from_project_source test/test_about_agilab_helpers.py::test_page_bootstrap_realigns_stale_session_env_to_page_root test/test_about_agilab_helpers.py::test_page_bootstrap_keeps_session_env_when_recorded_root_differs
- uv --preview-features extra-build-dependencies run pytest -q test/test_about_agilab_helpers.py test/test_ui_pages.py::test_execute_page_cluster_settings
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui
- uv --preview-features extra-build-dependencies run python tools/coverage_badge_guard.py --changed-only --require-fresh-xml
- git diff --check