### PR TITLE
Fix stale agi-space page env realignment

### DIFF
--- a/src/agilab/page_bootstrap.py
+++ b/src/agilab/page_bootstrap.py
@@ -26,6 +26,47 @@ def _page_apps_path(current_file: str | Path) -> Path | None:
     return apps_path if apps_path.exists() else None
 
 
+def _is_agi_space_path(path: Path | None) -> bool:
+    return path is not None and "agi-space" in path.parts
+
+
+def _find_page_app(expected_apps_path: Path, requested_name: str) -> Path | None:
+    name = Path(str(requested_name)).name
+    if not name:
+        return None
+    variants = [name]
+    if name.endswith("_project"):
+        variants.append(name.removesuffix("_project"))
+    else:
+        variants.append(f"{name}_project")
+
+    for variant in variants:
+        for candidate in (
+            expected_apps_path / variant,
+            expected_apps_path / "builtin" / variant,
+        ):
+            if candidate.exists():
+                return candidate
+    return None
+
+
+def _should_realign_session_env(
+    *,
+    env_apps_path: Path | None,
+    env_active_app_path: Path | None,
+    recorded_apps_path: Path | None,
+    expected_apps_path: Path,
+) -> bool:
+    if env_apps_path == expected_apps_path:
+        return False
+    if recorded_apps_path == expected_apps_path:
+        return True
+    return any(
+        _is_agi_space_path(path)
+        for path in (env_apps_path, env_active_app_path, recorded_apps_path)
+    )
+
+
 def session_env_ready(
     session_state: Any,
     *,
@@ -54,16 +95,22 @@ def realign_session_env_with_page_root(
     env = session_state[env_key]
     env_apps_path = _safe_resolved_path(getattr(env, "apps_path", None))
     recorded_apps_path = _safe_resolved_path(session_state.get("apps_path"))
-    if env_apps_path == expected_apps_path:
-        return False
-    if recorded_apps_path != expected_apps_path:
+    env_active_app_path = _safe_resolved_path(getattr(env, "active_app", None))
+    if not _should_realign_session_env(
+        env_apps_path=env_apps_path,
+        env_active_app_path=env_active_app_path,
+        recorded_apps_path=recorded_apps_path,
+        expected_apps_path=expected_apps_path,
+    ):
         return False
 
     app_name = Path(str(getattr(env, "app", "") or "")).name
     if not app_name:
-        active_app = getattr(env, "active_app", None)
-        app_name = Path(str(active_app)).name if active_app else ""
-    if not app_name:
+        app_name = env_active_app_path.name if env_active_app_path else ""
+    page_app = _find_page_app(expected_apps_path, app_name)
+    if page_app is None and env_active_app_path is not None:
+        page_app = _find_page_app(expected_apps_path, env_active_app_path.name)
+    if page_app is None:
         return False
 
     previous_init_done = getattr(env, "init_done", None)
@@ -71,7 +118,7 @@ def realign_session_env_with_page_root(
         type(env).__init__(
             env,
             apps_path=expected_apps_path,
-            app=app_name,
+            app=page_app.name,
             verbose=getattr(env, "verbose", None),
         )
         if previous_init_done is not None:

--- a/src/agilab/pages/2_ORCHESTRATE.py
+++ b/src/agilab/pages/2_ORCHESTRATE.py
@@ -98,6 +98,7 @@ import_agilab_symbols(
     "agilab.page_bootstrap",
     {
         "ensure_page_env": "_ensure_page_env",
+        "realign_session_env_with_page_root": "_realign_session_env_with_page_root",
     },
     current_file=__file__,
     fallback_path=Path(__file__).resolve().parents[1] / "page_bootstrap.py",
@@ -1932,6 +1933,9 @@ async def page() -> None:
         return
 
     current_app, changed_from_query = resolve_active_app(env)
+    if _realign_session_env_with_page_root(st.session_state, __file__):
+        current_app = env.app
+        changed_from_query = True
     if changed_from_query:
         st.session_state["project_changed"] = True
 

--- a/test/test_about_agilab_helpers.py
+++ b/test/test_about_agilab_helpers.py
@@ -224,6 +224,36 @@ def test_page_bootstrap_realigns_stale_session_env_to_page_root(tmp_path):
     assert env.init_done is True
 
 
+def test_page_bootstrap_realigns_stale_agi_space_recorded_root(tmp_path):
+    source_root = tmp_path / "agilab-src" / "src" / "agilab"
+    source_apps = source_root / "apps"
+    page_file = source_root / "pages" / "2_ORCHESTRATE.py"
+    source_project = source_apps / "builtin" / "flight_project"
+    stale_apps = tmp_path / "agi-space" / "apps"
+    page_file.parent.mkdir(parents=True)
+    source_project.mkdir(parents=True)
+    (stale_apps / "builtin" / "flight_project").mkdir(parents=True)
+
+    class FakeEnv:
+        def __init__(self, *, apps_path: Path, app: str = "flight_project", verbose: int | None = 1):
+            self.apps_path = apps_path
+            self.app = app
+            self.verbose = verbose
+            self.active_app = apps_path / "builtin" / app
+            self.init_done = True
+
+    env = FakeEnv(apps_path=stale_apps)
+    session_state = {
+        "env": env,
+        "apps_path": str(stale_apps),
+    }
+
+    assert page_bootstrap.realign_session_env_with_page_root(session_state, page_file) is True
+    assert env.apps_path == source_apps
+    assert env.active_app == source_project
+    assert session_state["apps_path"] == str(source_apps)
+
+
 def test_page_bootstrap_keeps_session_env_when_recorded_root_differs(tmp_path):
     source_root = tmp_path / "agilab-src" / "src" / "agilab"
     source_apps = source_root / "apps"

--- a/test/test_ui_pages.py
+++ b/test/test_ui_pages.py
@@ -591,6 +591,34 @@ def test_execute_page_cluster_settings(mock_ui_env):
     assert at.session_state[scheduler_key] == "127.0.0.1:8786"
 
 
+def test_execute_page_realigns_stale_agi_space_session_env(mock_ui_env, tmp_path):
+    """Source ORCHESTRATE must not keep an old installed agi-space active app."""
+    at = _app_test("src/agilab/pages/2_ORCHESTRATE.py")
+    source_apps = (Path(__file__).resolve().parents[1] / "src/agilab/apps").resolve()
+    source_project = source_apps / "builtin" / "flight_project"
+    stale_apps = tmp_path / "agi-space" / "apps"
+    stale_project = stale_apps / "builtin" / "flight_project"
+    stale_project.mkdir(parents=True)
+
+    env = AgiEnv(apps_path=source_apps, app="flight_project", verbose=0)
+    env.apps_path = stale_apps
+    env.active_app = stale_project
+    env.init_done = True
+    env.st_resources = (Path(__file__).resolve().parents[1] / "src/agilab/resources").resolve()
+    at.session_state["env"] = env
+    at.session_state["apps_path"] = str(stale_apps)
+    at.session_state["app_settings"] = {"args": {}, "cluster": {}}
+    _seed_env_editor_state(at, env)
+
+    at.run()
+
+    assert not at.exception
+    assert Path(at.session_state["env"].apps_path) == source_apps
+    assert Path(at.session_state["env"].active_app) == source_project
+    markdown_text = "\n".join(str(item.value) for item in at.markdown)
+    assert "agi-space" not in markdown_text
+
+
 def test_execute_page_install_robot_allows_benign_uv_self_update_warning(mock_ui_env):
     """Robot-style INSTALL regression for handled remote uv self-update warnings."""
 


### PR DESCRIPTION
## Summary
- realign stale Streamlit page envs that still point at an installed agi-space root
- repair ORCHESTRATE again after query/last-active project resolution so persisted agi-space paths cannot switch the page back
- add unit and AppTest regressions for the exact stale agi-space manager-env path case

## Validation
- uv --preview-features extra-build-dependencies run pytest -q test/test_ui_pages.py test/test_about_agilab_helpers.py
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui
- uv --preview-features extra-build-dependencies run python tools/coverage_badge_guard.py --changed-only --require-fresh-xml
- git diff --check