### PR TITLE
Fix stale apps path precedence

### DIFF
--- a/.claude/skills/agilab-runbook/SKILL.md
+++ b/.claude/skills/agilab-runbook/SKILL.md
@@ -21,10 +21,10 @@ Use this skill when you need repo-specific “how we do things” guidance in `a
 - **High-frequency shortcuts**: prefer `./dev <shortcut>` for repeated local validation loops. The
   top shortcuts are `impact` for impact validation, `test` for targeted `pytest -q`, `regress` for
   GA-selected fast regression subsets, `flow` for one or more workflow parity profiles, `badge` for
-  the fresh coverage-badge guard, and `docs` for docs mirror sync plus stamp verification. `impact`
+  the explicit release/pre-release coverage-badge guard, and `docs` for docs mirror sync plus stamp verification. `impact`
   tells you what must be validated, `test` runs the narrow pytest slice, `regress` optimizes a likely
   regression subset from changed files and optional JUnit timings, `flow` matches local GitHub
-  workflow profiles, `badge` catches stale coverage badges, and `docs` keeps the public mirror
+  workflow profiles, `badge` checks badge freshness when intentionally requested, and `docs` keeps the public mirror
   aligned. Add `--print-only` to inspect the expanded commands.
 - **Run config parity**: after editing `.idea/runConfigurations/*.xml`, regenerate wrappers:
   - `uv --preview-features extra-build-dependencies run python tools/generate_runconfig_scripts.py`
@@ -49,9 +49,9 @@ Use this skill when you need repo-specific “how we do things” guidance in `a
   their `modules.xml` refs.
 - **Local-first validation**: do not jump to GitHub Actions when the same check can be run locally.
   Reproduce with the narrowest local command first: targeted `pytest`, isolated coverage commands,
-  `py_compile`, Sphinx builds, badge generation, or publish dry-runs. Use CI only for GitHub-only
-  behavior such as runner differences, OS/Python matrix coverage, permissions/secrets, or the final
-  publish/deploy step.
+  `py_compile`, Sphinx builds, or publish dry-runs. Reserve coverage badge generation for
+  release/pre-release validation or badge tooling changes. Use CI only for GitHub-only behavior such
+  as runner differences, OS/Python matrix coverage, permissions/secrets, or the final publish/deploy step.
 - **Impact triage first**: for non-trivial diffs, run
   `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --staged`
   before editing further or pushing. Use its output to decide:

--- a/.claude/skills/agilab-runbook/SKILL.md
+++ b/.claude/skills/agilab-runbook/SKILL.md
@@ -19,13 +19,15 @@ Use this skill when you need repo-specific “how we do things” guidance in `a
 - **No repo `uvx`**: do not run `uvx agilab` from this checkout (it will run the published wheel and ignore local changes).
 - **Process ownership**: treat existing terminals, Codex CLI sessions, dev servers, and other long-running processes as user-owned unless this turn started them. Do not use broad termination commands such as `pkill`, `killall`, `pkill -f`, or port-based `kill` pipelines that can match unrelated sessions. Stop only verified PIDs or tool sessions created for the active task. Do not use Codex CLI control shortcuts such as `/stop`, Esc interruption, or terminal-close actions to manage background terminals unless the terminal/session was created by this active task and its identity is verified. A status banner that says a background terminal is running is not ownership proof. If a port is busy, choose another port or ask before stopping its owner; do not try to "pause" another Codex CLI session from here.
 - **High-frequency shortcuts**: prefer `./dev <shortcut>` for repeated local validation loops. The
-  top shortcuts are `impact` for impact validation, `test` for targeted `pytest -q`, `regress` for
-  GA-selected fast regression subsets, `flow` for one or more workflow parity profiles, `badge` for
-  the explicit release/pre-release coverage-badge guard, and `docs` for docs mirror sync plus stamp verification. `impact`
-  tells you what must be validated, `test` runs the narrow pytest slice, `regress` optimizes a likely
-  regression subset from changed files and optional JUnit timings, `flow` matches local GitHub
-  workflow profiles, `badge` checks badge freshness when intentionally requested, and `docs` keeps the public mirror
-  aligned. Add `--print-only` to inspect the expanded commands.
+  top shortcuts are `impact` for impact validation, `bugfix` for impact plus a fast GA-selected
+  regression run, `test` for targeted `pytest -q`, `regress` for GA-selected fast regression subsets,
+  `flow` for one or more workflow parity profiles, `badge` for the explicit release/pre-release
+  coverage-badge guard, and `docs` for docs mirror sync plus stamp verification. `impact` tells you
+  what must be validated, `test` runs the narrow pytest slice, `bugfix` is the default low-load
+  pre-push loop for normal code fixes, `regress` optimizes a likely regression subset from changed
+  files and optional JUnit timings, `flow` matches local GitHub workflow profiles, `badge` checks
+  badge freshness when intentionally requested, and `docs` keeps the public mirror aligned. Add
+  `--print-only` to inspect the expanded commands.
 - **Run config parity**: after editing `.idea/runConfigurations/*.xml`, regenerate wrappers:
   - `uv --preview-features extra-build-dependencies run python tools/generate_runconfig_scripts.py`
 - **PyCharm source-root switching**: the JetBrains SDK named `uv (agilab)` is global and
@@ -59,6 +61,10 @@ Use this skill when you need repo-specific “how we do things” guidance in `a
   - which targeted tests are required
   - whether installer repros are mandatory
   - whether generated artifacts must be refreshed
+- **Diff-aware pre-push guards**: keep `git config core.hooksPath .githooks` enabled. The hook
+  uses `tools/pre_push_changed_files.py` to run docs mirror checks only for docs mirror inputs and
+  release-proof checks only for release-proof inputs. If classification fails, it runs all local
+  guards. Coverage badge freshness remains an explicit `./dev badge` or release/pre-release check.
 - **Install-log startup check**: before launching flows after installer changes or a reported install
   failure, inspect the latest installer log for errors. On macOS/Linux:
   `dir="$HOME/log/install_logs"; f=$(ls -1t "$dir"/*.log 2>/dev/null | head -1); [ -n "$f" ] && echo "Log: $f" && grep -Eai "error|exception|traceback|failed|fatal|denied|missing|not found" "$f" | tail -n 25 || echo "No logs found."`

--- a/.claude/skills/agilab-testing/SKILL.md
+++ b/.claude/skills/agilab-testing/SKILL.md
@@ -37,8 +37,8 @@ Use this skill when validating changes.
   files changed since the previous run; rerun only after edits that alter the
   impact surface.
 - Batch repeated artifact checks at the end of the edit loop:
-  docs mirror sync, coverage badge guard, skill mirror sync, Codex skill index
-  generation, and release dry-runs should not run once per skill.
+  docs mirror sync, release/pre-release coverage badge guard, skill mirror sync,
+  Codex skill index generation, and release dry-runs should not run once per skill.
 - Run cheap read-only inspections in parallel when possible, but keep write or
   generation commands serialized so generated files do not race.
 - If several workflow parity profiles are required, run each required profile

--- a/.codex/skills/agilab-runbook/SKILL.md
+++ b/.codex/skills/agilab-runbook/SKILL.md
@@ -21,10 +21,10 @@ Use this skill when you need repo-specific “how we do things” guidance in `a
 - **High-frequency shortcuts**: prefer `./dev <shortcut>` for repeated local validation loops. The
   top shortcuts are `impact` for impact validation, `test` for targeted `pytest -q`, `regress` for
   GA-selected fast regression subsets, `flow` for one or more workflow parity profiles, `badge` for
-  the fresh coverage-badge guard, and `docs` for docs mirror sync plus stamp verification. `impact`
+  the explicit release/pre-release coverage-badge guard, and `docs` for docs mirror sync plus stamp verification. `impact`
   tells you what must be validated, `test` runs the narrow pytest slice, `regress` optimizes a likely
   regression subset from changed files and optional JUnit timings, `flow` matches local GitHub
-  workflow profiles, `badge` catches stale coverage badges, and `docs` keeps the public mirror
+  workflow profiles, `badge` checks badge freshness when intentionally requested, and `docs` keeps the public mirror
   aligned. Add `--print-only` to inspect the expanded commands.
 - **Run config parity**: after editing `.idea/runConfigurations/*.xml`, regenerate wrappers:
   - `uv --preview-features extra-build-dependencies run python tools/generate_runconfig_scripts.py`
@@ -49,9 +49,9 @@ Use this skill when you need repo-specific “how we do things” guidance in `a
   their `modules.xml` refs.
 - **Local-first validation**: do not jump to GitHub Actions when the same check can be run locally.
   Reproduce with the narrowest local command first: targeted `pytest`, isolated coverage commands,
-  `py_compile`, Sphinx builds, badge generation, or publish dry-runs. Use CI only for GitHub-only
-  behavior such as runner differences, OS/Python matrix coverage, permissions/secrets, or the final
-  publish/deploy step.
+  `py_compile`, Sphinx builds, or publish dry-runs. Reserve coverage badge generation for
+  release/pre-release validation or badge tooling changes. Use CI only for GitHub-only behavior such
+  as runner differences, OS/Python matrix coverage, permissions/secrets, or the final publish/deploy step.
 - **Impact triage first**: for non-trivial diffs, run
   `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --staged`
   before editing further or pushing. Use its output to decide:

--- a/.codex/skills/agilab-runbook/SKILL.md
+++ b/.codex/skills/agilab-runbook/SKILL.md
@@ -19,13 +19,15 @@ Use this skill when you need repo-specific “how we do things” guidance in `a
 - **No repo `uvx`**: do not run `uvx agilab` from this checkout (it will run the published wheel and ignore local changes).
 - **Process ownership**: treat existing terminals, Codex CLI sessions, dev servers, and other long-running processes as user-owned unless this turn started them. Do not use broad termination commands such as `pkill`, `killall`, `pkill -f`, or port-based `kill` pipelines that can match unrelated sessions. Stop only verified PIDs or tool sessions created for the active task. Do not use Codex CLI control shortcuts such as `/stop`, Esc interruption, or terminal-close actions to manage background terminals unless the terminal/session was created by this active task and its identity is verified. A status banner that says a background terminal is running is not ownership proof. If a port is busy, choose another port or ask before stopping its owner; do not try to "pause" another Codex CLI session from here.
 - **High-frequency shortcuts**: prefer `./dev <shortcut>` for repeated local validation loops. The
-  top shortcuts are `impact` for impact validation, `test` for targeted `pytest -q`, `regress` for
-  GA-selected fast regression subsets, `flow` for one or more workflow parity profiles, `badge` for
-  the explicit release/pre-release coverage-badge guard, and `docs` for docs mirror sync plus stamp verification. `impact`
-  tells you what must be validated, `test` runs the narrow pytest slice, `regress` optimizes a likely
-  regression subset from changed files and optional JUnit timings, `flow` matches local GitHub
-  workflow profiles, `badge` checks badge freshness when intentionally requested, and `docs` keeps the public mirror
-  aligned. Add `--print-only` to inspect the expanded commands.
+  top shortcuts are `impact` for impact validation, `bugfix` for impact plus a fast GA-selected
+  regression run, `test` for targeted `pytest -q`, `regress` for GA-selected fast regression subsets,
+  `flow` for one or more workflow parity profiles, `badge` for the explicit release/pre-release
+  coverage-badge guard, and `docs` for docs mirror sync plus stamp verification. `impact` tells you
+  what must be validated, `test` runs the narrow pytest slice, `bugfix` is the default low-load
+  pre-push loop for normal code fixes, `regress` optimizes a likely regression subset from changed
+  files and optional JUnit timings, `flow` matches local GitHub workflow profiles, `badge` checks
+  badge freshness when intentionally requested, and `docs` keeps the public mirror aligned. Add
+  `--print-only` to inspect the expanded commands.
 - **Run config parity**: after editing `.idea/runConfigurations/*.xml`, regenerate wrappers:
   - `uv --preview-features extra-build-dependencies run python tools/generate_runconfig_scripts.py`
 - **PyCharm source-root switching**: the JetBrains SDK named `uv (agilab)` is global and
@@ -59,6 +61,10 @@ Use this skill when you need repo-specific “how we do things” guidance in `a
   - which targeted tests are required
   - whether installer repros are mandatory
   - whether generated artifacts must be refreshed
+- **Diff-aware pre-push guards**: keep `git config core.hooksPath .githooks` enabled. The hook
+  uses `tools/pre_push_changed_files.py` to run docs mirror checks only for docs mirror inputs and
+  release-proof checks only for release-proof inputs. If classification fails, it runs all local
+  guards. Coverage badge freshness remains an explicit `./dev badge` or release/pre-release check.
 - **Install-log startup check**: before launching flows after installer changes or a reported install
   failure, inspect the latest installer log for errors. On macOS/Linux:
   `dir="$HOME/log/install_logs"; f=$(ls -1t "$dir"/*.log 2>/dev/null | head -1); [ -n "$f" ] && echo "Log: $f" && grep -Eai "error|exception|traceback|failed|fatal|denied|missing|not found" "$f" | tail -n 25 || echo "No logs found."`

--- a/.codex/skills/agilab-testing/SKILL.md
+++ b/.codex/skills/agilab-testing/SKILL.md
@@ -37,8 +37,8 @@ Use this skill when validating changes.
   files changed since the previous run; rerun only after edits that alter the
   impact surface.
 - Batch repeated artifact checks at the end of the edit loop:
-  docs mirror sync, coverage badge guard, skill mirror sync, Codex skill index
-  generation, and release dry-runs should not run once per skill.
+  docs mirror sync, release/pre-release coverage badge guard, skill mirror sync,
+  Codex skill index generation, and release dry-runs should not run once per skill.
 - Run cheap read-only inspections in parallel when possible, but keep write or
   generation commands serialized so generated files do not race.
 - If several workflow parity profiles are required, run each required profile

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -20,6 +20,3 @@ uv --preview-features extra-build-dependencies run python tools/sync_docs_source
 uv --preview-features extra-build-dependencies run python tools/release_proof_report.py \
   --check \
   --quiet
-uv --preview-features extra-build-dependencies run python tools/coverage_badge_guard.py \
-  --changed-only \
-  --require-fresh-xml

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -9,14 +9,45 @@ if [[ "${AGILAB_SKIP_LOCAL_GUARDS:-}" == "1" ]]; then
 fi
 
 cd "$ROOT_DIR"
-uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py \
-  --verify-stamp \
-  --quiet
-uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py \
-  --check \
-  --delete \
-  --quiet \
-  --skip-missing-source
-uv --preview-features extra-build-dependencies run python tools/release_proof_report.py \
-  --check \
-  --quiet
+guard_state="$(
+  uv --preview-features extra-build-dependencies run python tools/pre_push_changed_files.py
+)"
+DOCS_CHANGED=1
+RELEASE_PROOF_CHANGED=1
+DETECTION_FAILED=1
+CHANGED_COUNT=0
+DETECTION_ERROR="missing guard-state output"
+while IFS='=' read -r key value; do
+  case "$key" in
+    DOCS_CHANGED) DOCS_CHANGED="$value" ;;
+    RELEASE_PROOF_CHANGED) RELEASE_PROOF_CHANGED="$value" ;;
+    DETECTION_FAILED) DETECTION_FAILED="$value" ;;
+    CHANGED_COUNT) CHANGED_COUNT="$value" ;;
+    DETECTION_ERROR) DETECTION_ERROR="$value" ;;
+  esac
+done <<< "$guard_state"
+
+if [[ "${DETECTION_FAILED:-0}" == "1" ]]; then
+  echo "[agilab pre-push] changed-file detection failed; running all local guards. ${DETECTION_ERROR:-}" >&2
+fi
+
+if [[ "${DOCS_CHANGED:-1}" == "1" ]]; then
+  uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py \
+    --verify-stamp \
+    --quiet
+  uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py \
+    --check \
+    --delete \
+    --quiet \
+    --skip-missing-source
+else
+  echo "[agilab pre-push] docs mirror inputs unchanged; skipping docs mirror guard." >&2
+fi
+
+if [[ "${RELEASE_PROOF_CHANGED:-1}" == "1" ]]; then
+  uv --preview-features extra-build-dependencies run python tools/release_proof_report.py \
+    --check \
+    --quiet
+else
+  echo "[agilab pre-push] release-proof inputs unchanged; skipping release-proof guard." >&2
+fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,14 +22,16 @@ Use this runbook whenever you:
   `uv --preview-features extra-build-dependencies run streamlit …`) so dependencies resolve inside the managed environments that
   ship with AGILab.
 - **High-frequency command shortcuts**: Use `./dev <shortcut>` for repeated local validation loops.
-  The top shortcuts are `impact` for impact validation, `test` for targeted `pytest -q`,
+  The top shortcuts are `impact` for impact validation, `bugfix` for impact plus a fast
+  GA-selected regression run, `test` for targeted `pytest -q`,
   `regress` for GA-selected fast regression subsets, `flow` for one or more workflow parity
   profiles, `badge` for the explicit release/pre-release coverage-badge guard, and `docs` for docs
   mirror sync plus stamp verification. `impact` tells you what must be validated, `test` runs the
-  narrow pytest slice, `regress` optimizes a likely regression subset from changed files and optional
-  JUnit timings, `flow` matches local GitHub workflow profiles, `badge` checks badge freshness when
-  intentionally requested, and `docs` keeps the public mirror aligned. Use `--print-only` to audit
-  the expanded commands.
+  narrow pytest slice, `bugfix` is the default low-load pre-push loop for normal code fixes,
+  `regress` optimizes a likely regression subset from changed files and optional JUnit timings,
+  `flow` matches local GitHub workflow profiles, `badge` checks badge freshness when intentionally
+  requested, and `docs` keeps the public mirror aligned. Use `--print-only` to audit the expanded
+  commands.
 - **Upgrade packaged tools first**: Before launching the published CLI with `uvx
   agilab`, run `uv --preview-features extra-build-dependencies tool install --upgrade agilab` to install or pick up the latest wheel.
 - **No repo uvx**: Reserve `uvx` for packaged installs outside this checkout. Launching
@@ -82,11 +84,11 @@ Use this runbook whenever you:
   artifacts such as skill indexes or run-config wrappers must be refreshed. Coverage badges are normally
   refreshed only for release/pre-release validation or badge tooling changes.
 - **Local pre-push guardrails**: Keep the repo hook enabled with
-  `git config core.hooksPath .githooks`. The pre-push hook verifies the
-  managed `docs/source` mirror stamp, compares the mirror against
-  `../thales_agilab/docs/source` when that canonical checkout is present, and
-  verifies release-proof metadata. Coverage badge freshness is intentionally not
-  part of the default bugfix pre-push path; run `./dev badge` or the `badges`
+  `git config core.hooksPath .githooks`. The pre-push hook first classifies the pushed
+  changed files with `tools/pre_push_changed_files.py`. It runs docs mirror checks only when
+  docs mirror inputs changed, and release-proof checks only when release-proof inputs changed.
+  If classification fails, it fails safe by running all local guards. Coverage badge freshness is
+  intentionally not part of the default bugfix pre-push path; run `./dev badge` or the `badges`
   workflow parity profile before release/pre-release publication. Bypass only with
   `AGILAB_SKIP_LOCAL_GUARDS=1` when the skipped
   guard is intentional and documented.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,11 +24,12 @@ Use this runbook whenever you:
 - **High-frequency command shortcuts**: Use `./dev <shortcut>` for repeated local validation loops.
   The top shortcuts are `impact` for impact validation, `test` for targeted `pytest -q`,
   `regress` for GA-selected fast regression subsets, `flow` for one or more workflow parity
-  profiles, `badge` for the fresh coverage-badge guard, and `docs` for docs mirror sync plus
-  stamp verification. `impact` tells you what must be validated, `test` runs the narrow pytest
-  slice, `regress` optimizes a likely regression subset from changed files and optional JUnit
-  timings, `flow` matches local GitHub workflow profiles, `badge` catches stale coverage badges,
-  and `docs` keeps the public mirror aligned. Use `--print-only` to audit the expanded commands.
+  profiles, `badge` for the explicit release/pre-release coverage-badge guard, and `docs` for docs
+  mirror sync plus stamp verification. `impact` tells you what must be validated, `test` runs the
+  narrow pytest slice, `regress` optimizes a likely regression subset from changed files and optional
+  JUnit timings, `flow` matches local GitHub workflow profiles, `badge` checks badge freshness when
+  intentionally requested, and `docs` keeps the public mirror aligned. Use `--print-only` to audit
+  the expanded commands.
 - **Upgrade packaged tools first**: Before launching the published CLI with `uvx
   agilab`, run `uv --preview-features extra-build-dependencies tool install --upgrade agilab` to install or pick up the latest wheel.
 - **No repo uvx**: Reserve `uvx` for packaged installs outside this checkout. Launching
@@ -50,8 +51,9 @@ Use this runbook whenever you:
   then `realign-local` on the checkout you keep working in.
 - **Local-first validation**: Do not trigger GitHub workflows when the same failure can be
   reproduced or validated locally. First run the narrowest local check that can prove the change:
-  targeted `pytest`, isolated coverage commands, `py_compile`, Sphinx builds, badge generation,
-  and release dry-runs. Reserve CI/workflow runs for GitHub-only behavior (runner differences,
+  targeted `pytest`, isolated coverage commands, `py_compile`, Sphinx builds, and release dry-runs.
+  Reserve coverage badge generation for release/pre-release validation or badge tooling changes.
+  Reserve CI/workflow runs for GitHub-only behavior (runner differences,
   OS/Python matrix coverage, permissions/secrets, Pages/PyPI publication, or final integration
   confirmation after local validation). When a change maps cleanly to one of the repo workflow
   profiles, prefer `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile <name>`
@@ -77,14 +79,16 @@ Use this runbook whenever you:
 - **Impact triage first**: For non-trivial diffs, run `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --staged`
   before edits or push. Use its output to decide whether the change is app-local vs shared-core,
   which targeted tests are required, whether install repros are mandatory, and whether generated
-  artifacts such as badges, skill indexes, or run-config wrappers must be refreshed.
+  artifacts such as skill indexes or run-config wrappers must be refreshed. Coverage badges are normally
+  refreshed only for release/pre-release validation or badge tooling changes.
 - **Local pre-push guardrails**: Keep the repo hook enabled with
   `git config core.hooksPath .githooks`. The pre-push hook verifies the
   managed `docs/source` mirror stamp, compares the mirror against
   `../thales_agilab/docs/source` when that canonical checkout is present, and
-  runs `tools/coverage_badge_guard.py --changed-only --require-fresh-xml` so
-  docs-source drift and stale coverage badge SVGs are blocked locally before
-  GitHub Actions. Bypass only with `AGILAB_SKIP_LOCAL_GUARDS=1` when the skipped
+  verifies release-proof metadata. Coverage badge freshness is intentionally not
+  part of the default bugfix pre-push path; run `./dev badge` or the `badges`
+  workflow parity profile before release/pre-release publication. Bypass only with
+  `AGILAB_SKIP_LOCAL_GUARDS=1` when the skipped
   guard is intentional and documented.
 - **Run config parity**: After touching `.idea/runConfigurations/*.xml`, regenerate
   the CLI wrappers with `uv --preview-features extra-build-dependencies run python tools/generate_runconfig_scripts.py` and commit
@@ -323,7 +327,7 @@ Use this runbook whenever you:
 4. Refresh any required generated artifacts in the same change:
    - `tools/run_configs/` after run configuration edits
    - `.codex/skills/.generated/skills_index.*` after shared skill edits
-   - `badges/coverage-*.svg` after coverage badge inputs change
+   - `badges/coverage-*.svg` only for release/pre-release coverage validation or badge tooling changes
 
 ### 4. Cluster SSH recovery after node reinstall or host-key rotation
 

--- a/src/agilab/about_page/bootstrap.py
+++ b/src/agilab/about_page/bootstrap.py
@@ -88,17 +88,37 @@ def default_agilab_path_file(
 
 
 def apps_path_from_agilab_path_file(agi_path_file: Path) -> Path:
-    """Resolve the apps directory from a packaged-install ``.agilab-path`` file."""
+    """Resolve the apps directory from a source or packaged-install ``.agilab-path`` file."""
     agilab_path = agi_path_file.read_text(encoding="utf-8").strip()
     if not agilab_path:
         raise FileNotFoundError(f"Empty .agilab-path at {agi_path_file}")
     before, sep, _after = agilab_path.rpartition(".venv")
     if not sep:
+        source_root = Path(agilab_path).expanduser()
+        if source_root.name == "agilab" and source_root.parent.name == "src":
+            try:
+                return (source_root / "apps").resolve(strict=False)
+            except OSError as path_err:
+                raise ValueError(f"Cannot resolve apps path from .agilab-path: {path_err}") from path_err
         raise ValueError(f"Malformed .agilab-path (missing .venv marker): {agilab_path!r}")
     try:
         return (Path(before).resolve(strict=False) / "apps").resolve(strict=False)
     except OSError as path_err:
         raise ValueError(f"Cannot resolve apps path from .agilab-path: {path_err}") from path_err
+
+
+def _looks_like_source_apps_path(path: Path | None) -> bool:
+    if path is None:
+        return False
+    try:
+        resolved = Path(path).resolve(strict=False)
+    except (OSError, RuntimeError, TypeError, ValueError):
+        resolved = Path(path)
+    return (
+        resolved.name == "apps"
+        and resolved.parent.name == "agilab"
+        and resolved.parent.parent.name == "src"
+    )
 
 
 def resolve_apps_path(
@@ -112,18 +132,31 @@ def resolve_apps_path(
 ) -> Path | None:
     """Resolve the apps path from CLI, user .env, or packaged install marker."""
     apps_arg = args.apps_path
+    marker_apps_path: Path | None = None
+    marker_error: Exception | None = None
+    agi_path_file = default_agilab_path_file(
+        os_name=os_name,
+        environ=environ,
+        home_path=home_path,
+    )
+    try:
+        marker_apps_path = apps_path_from_agilab_path_file(agi_path_file)
+    except (FileNotFoundError, ValueError) as exc:
+        marker_error = exc
+
+    if apps_arg is None and _looks_like_source_apps_path(marker_apps_path):
+        apps_arg = marker_apps_path
+
     if apps_arg is None:
         env_apps = load_env_file_map(env_file_path).get("APPS_PATH")
         if env_apps and env_apps.strip() and not env_apps.startswith("/path/to"):
             apps_arg = env_apps.strip()
 
     if apps_arg is None:
-        agi_path_file = default_agilab_path_file(
-            os_name=os_name,
-            environ=environ,
-            home_path=home_path,
-        )
-        apps_arg = apps_path_from_agilab_path_file(agi_path_file)
+        if marker_apps_path is not None:
+            apps_arg = marker_apps_path
+        elif marker_error is not None:
+            raise marker_error
 
     return Path(apps_arg).expanduser() if apps_arg else None
 

--- a/src/agilab/about_page/bootstrap.py
+++ b/src/agilab/about_page/bootstrap.py
@@ -114,11 +114,47 @@ def _looks_like_source_apps_path(path: Path | None) -> bool:
         resolved = Path(path).resolve(strict=False)
     except (OSError, RuntimeError, TypeError, ValueError):
         resolved = Path(path)
+    if resolved.name == "builtin":
+        resolved = resolved.parent
     return (
         resolved.name == "apps"
         and resolved.parent.name == "agilab"
         and resolved.parent.parent.name == "src"
     )
+
+
+def source_launch_env_updates(apps_path: Path | None) -> dict[str, str]:
+    """Return pre-init env overrides required for source-checkout launches."""
+    if not _looks_like_source_apps_path(apps_path):
+        return {}
+    try:
+        apps_path = Path(apps_path).expanduser().resolve(strict=False)
+    except (OSError, RuntimeError, TypeError, ValueError):
+        apps_path = Path(apps_path)
+    if apps_path.name == "builtin":
+        apps_path = apps_path.parent
+    return {
+        "APPS_PATH": str(apps_path),
+        "IS_SOURCE_ENV": "1",
+        "IS_WORKER_ENV": "0",
+    }
+
+
+def persist_preinit_launch_env(
+    agi_env_cls: Any,
+    updates: Mapping[str, str],
+    *,
+    environ: MutableMapping[str, str] | None = None,
+) -> None:
+    """Persist launch-critical env values before constructing ``AgiEnv``."""
+    if not updates:
+        return
+    environ = environ if environ is not None else os.environ
+    setter = getattr(agi_env_cls, "set_env_var", None)
+    for key, value in updates.items():
+        environ[key] = value
+        if callable(setter):
+            setter(key, value)
 
 
 def resolve_apps_path(
@@ -253,6 +289,9 @@ def persisted_active_app_request(env: Any, raw_value: Any) -> str | None:
                     return text
             except (TypeError, RuntimeError, ValueError, OSError):
                 continue
+        if normalize_active_app_input(env, name) is not None:
+            return name
+        return None
     projects = getattr(env, "projects", set()) or set()
     if name in projects:
         return name
@@ -555,6 +594,12 @@ def bootstrap_page_environment(
         return BootstrapResult(env=None, handled_recovery=True)
 
     streamlit.session_state["apps_path"] = str(apps_path)
+    preinit_updates = source_launch_env_updates(apps_path)
+    persist_preinit_launch_env(
+        ports.agi_env_cls,
+        preinit_updates,
+        environ=ports.environ,
+    )
 
     try:
         env = ports.agi_env_cls(apps_path=apps_path, verbose=1)
@@ -599,7 +644,7 @@ def bootstrap_page_environment(
     openai_missing = persist_bootstrap_env(
         env,
         apps_path=apps_path,
-        explicit_apps_path=bool(args.apps_path),
+        explicit_apps_path=bool(args.apps_path) or bool(preinit_updates),
         saved_env=saved_env,
         agi_env_cls=ports.agi_env_cls,
         clean_openai_key=clean_openai_key,

--- a/src/agilab/about_page/env_editor.py
+++ b/src/agilab/about_page/env_editor.py
@@ -357,11 +357,28 @@ def _refresh_env_from_file(env: Any) -> None:
         except (AttributeError, TypeError):
             pass
 
+    session_apps_path = None
+    try:
+        session_apps_path_value = st.session_state.get("apps_path")
+    except (AttributeError, TypeError):
+        session_apps_path_value = None
+    if session_apps_path_value:
+        try:
+            session_apps_path = Path(session_apps_path_value).expanduser().resolve()
+        except (OSError, RuntimeError, TypeError, ValueError):
+            session_apps_path = None
+
     new_apps_path = env_map.get("APPS_PATH", "").strip()
-    if new_apps_path and str(getattr(env, "apps_path", "")) != new_apps_path:
+    if new_apps_path:
         try:
             resolved = Path(new_apps_path).expanduser().resolve()
-            env.apps_path = resolved
+            # A running Streamlit session may have been launched from a source checkout
+            # while ~/.agilab/.env still points to a packaged agi-space install.
+            env.apps_path = (
+                session_apps_path
+                if session_apps_path and session_apps_path != resolved
+                else resolved
+            )
         except (OSError, RuntimeError, TypeError, ValueError):
             pass
 

--- a/src/agilab/core/agi-env/src/agi_env/bootstrap_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/bootstrap_support.py
@@ -88,14 +88,6 @@ def resolve_requested_apps_path(
     path_cls=Path,
 ) -> tuple[Path | None, Path | None]:
     """Resolve the effective apps root and any builtin root implied by an override path."""
-    if env_apps_path:
-        apps_path = path_cls(env_apps_path).expanduser()
-        try:
-            apps_path = apps_path.resolve()
-        except OSError:
-            pass
-        return apps_path, None
-
     if explicit_apps_path is not None:
         apps_path = path_cls(explicit_apps_path).expanduser()
         try:
@@ -104,14 +96,37 @@ def resolve_requested_apps_path(
             pass
         return apps_path, None
 
-    if active_app_override is not None:
+    def _is_absolute_path(value: Path) -> bool:
         try:
-            candidate_parent = active_app_override.parent.resolve()
+            return bool(value.is_absolute())
+        except AttributeError:
+            try:
+                return bool(path_cls(value).expanduser().is_absolute())
+            except (TypeError, ValueError):
+                return False
+
+    def _apps_path_from_active_override(value: Path) -> tuple[Path | None, Path | None]:
+        try:
+            candidate_parent = value.parent.resolve()
         except OSError:
-            candidate_parent = active_app_override.parent
+            candidate_parent = value.parent
         if candidate_parent.name == "builtin" and candidate_parent.parent.name == "apps":
             return candidate_parent.parent, candidate_parent
         return candidate_parent, None
+
+    if active_app_override is not None and _is_absolute_path(active_app_override):
+        return _apps_path_from_active_override(active_app_override)
+
+    if env_apps_path:
+        apps_path = path_cls(env_apps_path).expanduser()
+        try:
+            apps_path = apps_path.resolve()
+        except OSError:
+            pass
+        return apps_path, None
+
+    if active_app_override is not None:
+        return _apps_path_from_active_override(active_app_override)
 
     return None, None
 

--- a/src/agilab/core/agi-env/test/test_agi_env.py
+++ b/src/agilab/core/agi-env/test/test_agi_env.py
@@ -589,6 +589,45 @@ def test_active_app_override_uses_builtin_path_even_when_env_apps_path_is_set(tm
     assert env.worker_path == (builtin_app / "src" / "flight_worker" / "flight_worker.py").resolve()
 
 
+def test_explicit_apps_path_wins_over_stale_env_apps_path(tmp_path: Path, monkeypatch):
+    """A source launch must not be pulled back to a persisted agi-space APPS_PATH."""
+
+    agipath = AgiEnv.locate_agilab_installation(verbose=False)
+    fake_home = tmp_path / "fake_home"
+    fake_home.mkdir()
+    share_root = fake_home / ".local" / "share" / "agilab"
+    share_root.mkdir(parents=True, exist_ok=True)
+    (share_root / ".agilab-path").write_text(str(agipath) + "\n", encoding="utf-8")
+
+    stale_apps = tmp_path / "agi-space" / "apps"
+    (stale_apps / "builtin" / "flight_project").mkdir(parents=True, exist_ok=True)
+    env_dir = fake_home / ".agilab"
+    env_dir.mkdir(parents=True, exist_ok=True)
+    (env_dir / ".env").write_text(f"APPS_PATH={stale_apps}\nIS_SOURCE_ENV=1\n", encoding="utf-8")
+
+    source_apps = tmp_path / "agilab-src" / "src" / "agilab" / "apps"
+    builtin_app = source_apps / "builtin" / "flight_project"
+    (builtin_app / "src" / "flight").mkdir(parents=True, exist_ok=True)
+    (builtin_app / "src" / "flight_worker").mkdir(parents=True, exist_ok=True)
+    (builtin_app / "pyproject.toml").write_text("[project]\nname='flight-project'\n", encoding="utf-8")
+    (builtin_app / "uv_config.toml").write_text("[tool.uv]\n", encoding="utf-8")
+    (builtin_app / "src" / "flight" / "flight.py").write_text("class Flight:\n    pass\n", encoding="utf-8")
+    (builtin_app / "src" / "flight_worker" / "flight_worker.py").write_text(
+        "class BaseWorker:\n    pass\n\nclass FlightWorker(BaseWorker):\n    pass\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HOME", str(fake_home))
+    AgiEnv.reset()
+
+    env = AgiEnv(apps_path=source_apps, app="flight_project", verbose=0)
+
+    assert env.apps_path == source_apps.resolve()
+    assert env.active_app == builtin_app.resolve()
+    assert env.manager_path == (builtin_app / "src" / "flight" / "flight.py").resolve()
+    assert env.worker_path == (builtin_app / "src" / "flight_worker" / "flight_worker.py").resolve()
+
+
 def test_missing_flattened_active_app_falls_back_to_builtin_copy(tmp_path: Path, monkeypatch):
     """When a stale flattened app root exists, prefer the valid builtin copy."""
 

--- a/src/agilab/core/agi-env/test/test_bootstrap_support.py
+++ b/src/agilab/core/agi-env/test/test_bootstrap_support.py
@@ -65,7 +65,23 @@ def test_resolve_install_type_handles_default_worker_and_path_errors(tmp_path):
     assert resolve_install_type(_BrokenAppsPath()) == (0, False)
 
 
-def test_resolve_requested_apps_path_prefers_env_then_override(tmp_path):
+def test_resolve_requested_apps_path_prefers_explicit_apps_path_over_env(tmp_path):
+    env_apps = tmp_path / "agi-space" / "apps"
+    explicit_apps = tmp_path / "agilab-src" / "src" / "agilab" / "apps"
+    env_apps.mkdir(parents=True)
+    explicit_apps.mkdir(parents=True)
+
+    apps_path, builtin_root = resolve_requested_apps_path(
+        env_apps_path=str(env_apps),
+        explicit_apps_path=explicit_apps,
+        active_app_override=None,
+    )
+
+    assert apps_path == explicit_apps.resolve()
+    assert builtin_root is None
+
+
+def test_resolve_requested_apps_path_uses_env_when_no_explicit_root(tmp_path):
     env_apps = tmp_path / "env-apps"
     env_apps.mkdir()
     apps_path, builtin_root = resolve_requested_apps_path(
@@ -76,13 +92,19 @@ def test_resolve_requested_apps_path_prefers_env_then_override(tmp_path):
     assert apps_path == env_apps.resolve()
     assert builtin_root is None
 
+
+def test_resolve_requested_apps_path_prefers_absolute_active_override_over_env(tmp_path):
+    env_apps = tmp_path / "agi-space" / "apps"
+    env_apps.mkdir(parents=True)
     builtin_app = tmp_path / "apps" / "builtin" / "demo_project"
     builtin_app.mkdir(parents=True)
+
     apps_path, builtin_root = resolve_requested_apps_path(
-        env_apps_path="",
+        env_apps_path=str(env_apps),
         explicit_apps_path=None,
         active_app_override=builtin_app,
     )
+
     assert apps_path == builtin_app.parent.parent.resolve()
     assert builtin_root == builtin_app.parent.resolve()
 

--- a/src/agilab/page_bootstrap.py
+++ b/src/agilab/page_bootstrap.py
@@ -58,7 +58,7 @@ def _should_realign_session_env(
     expected_apps_path: Path,
 ) -> bool:
     if env_apps_path == expected_apps_path:
-        return False
+        return _is_agi_space_path(env_active_app_path)
     if recorded_apps_path == expected_apps_path:
         return True
     return any(

--- a/test/test_about_agilab_helpers.py
+++ b/test/test_about_agilab_helpers.py
@@ -503,6 +503,45 @@ def test_refresh_env_from_file_updates_env_map_and_apps_path(tmp_path, monkeypat
     assert about_agilab.st.session_state["env_file_mtime_ns"] == env_file.stat().st_mtime_ns
 
 
+def test_refresh_env_from_file_keeps_session_apps_path_over_stale_env_path(tmp_path, monkeypatch):
+    env_file = tmp_path / ".env"
+    stale_apps = tmp_path / "agi-space" / "apps"
+    source_apps = tmp_path / "agilab-src" / "src" / "agilab" / "apps"
+    stale_apps.mkdir(parents=True)
+    source_apps.mkdir(parents=True)
+    env_file.write_text(
+        "\n".join(
+            [
+                "OPENAI_MODEL=gpt-5.4",
+                f"APPS_PATH={stale_apps}",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(about_agilab, "ENV_FILE_PATH", env_file)
+    about_agilab.st.session_state.pop("env_file_mtime_ns", None)
+    previous_apps_path = about_agilab.st.session_state.get("apps_path")
+    about_agilab.st.session_state["apps_path"] = str(source_apps)
+
+    env = SimpleNamespace(
+        envars={},
+        apps_path=stale_apps,
+    )
+
+    try:
+        about_agilab._refresh_env_from_file(env)
+    finally:
+        if previous_apps_path is None:
+            about_agilab.st.session_state.pop("apps_path", None)
+        else:
+            about_agilab.st.session_state["apps_path"] = previous_apps_path
+
+    assert env.envars["OPENAI_MODEL"] == "gpt-5.4"
+    assert env.envars["APPS_PATH"] == str(stale_apps)
+    assert env.apps_path == source_apps.resolve()
+    assert about_agilab.st.session_state["env_file_mtime_ns"] == env_file.stat().st_mtime_ns
+
+
 def test_refresh_env_from_file_ignores_commented_template_defaults(tmp_path, monkeypatch):
     env_file = tmp_path / ".env"
     env_file.write_text(
@@ -570,6 +609,7 @@ def test_bootstrap_resolve_apps_path_prefers_cli_then_env(tmp_path):
         args,
         env_file_path=tmp_path / ".env",
         load_env_file_map=lambda _path: {"APPS_PATH": str(env_apps)},
+        home_path=tmp_path,
     ) == cli_apps
 
     args = bootstrap.parse_startup_args([])
@@ -577,6 +617,7 @@ def test_bootstrap_resolve_apps_path_prefers_cli_then_env(tmp_path):
         args,
         env_file_path=tmp_path / ".env",
         load_env_file_map=lambda _path: {"APPS_PATH": str(env_apps)},
+        home_path=tmp_path,
     ) == env_apps
 
 
@@ -587,6 +628,18 @@ def test_bootstrap_resolve_apps_path_from_agilab_path_file(tmp_path):
     marker.write_text(str(install_root / ".venv" / "bin" / "python"), encoding="utf-8")
 
     assert bootstrap.apps_path_from_agilab_path_file(marker) == (install_root / "apps").resolve(
+        strict=False
+    )
+
+
+def test_bootstrap_resolve_apps_path_from_source_agilab_path_file(tmp_path):
+    bootstrap = about_agilab._about_bootstrap
+    source_root = tmp_path / "agilab-src" / "src" / "agilab"
+    source_root.mkdir(parents=True)
+    marker = tmp_path / ".agilab-path"
+    marker.write_text(str(source_root), encoding="utf-8")
+
+    assert bootstrap.apps_path_from_agilab_path_file(marker) == (source_root / "apps").resolve(
         strict=False
     )
 
@@ -1119,6 +1172,26 @@ def test_bootstrap_resolve_apps_path_uses_marker_when_env_has_placeholder(tmp_pa
         load_env_file_map=lambda _path: {"APPS_PATH": "/path/to/apps"},
         home_path=tmp_path,
     ) == (install_root / "apps").resolve(strict=False)
+
+
+def test_bootstrap_resolve_apps_path_prefers_source_marker_over_stale_env(tmp_path):
+    bootstrap = about_agilab._about_bootstrap
+    source_root = tmp_path / "agilab-src" / "src" / "agilab"
+    source_apps = source_root / "apps"
+    stale_apps = tmp_path / "agi-space" / "apps"
+    source_root.mkdir(parents=True)
+    stale_apps.mkdir(parents=True)
+    marker = tmp_path / ".local/share/agilab/.agilab-path"
+    marker.parent.mkdir(parents=True)
+    marker.write_text(str(source_root), encoding="utf-8")
+
+    args = bootstrap.parse_startup_args([])
+    assert bootstrap.resolve_apps_path(
+        args,
+        env_file_path=tmp_path / ".env",
+        load_env_file_map=lambda _path: {"APPS_PATH": str(stale_apps)},
+        home_path=tmp_path,
+    ) == source_apps.resolve(strict=False)
 
 
 def test_bootstrap_active_app_helpers_handle_empty_same_and_failed_switch(tmp_path):

--- a/test/test_about_agilab_helpers.py
+++ b/test/test_about_agilab_helpers.py
@@ -254,6 +254,37 @@ def test_page_bootstrap_realigns_stale_agi_space_recorded_root(tmp_path):
     assert session_state["apps_path"] == str(source_apps)
 
 
+def test_page_bootstrap_realigns_stale_agi_space_active_app_with_current_source_root(tmp_path):
+    source_root = tmp_path / "agilab-src" / "src" / "agilab"
+    source_apps = source_root / "apps"
+    page_file = source_root / "pages" / "2_ORCHESTRATE.py"
+    source_project = source_apps / "builtin" / "flight_project"
+    stale_project = tmp_path / "agi-space" / "apps" / "builtin" / "flight_project"
+    page_file.parent.mkdir(parents=True)
+    source_project.mkdir(parents=True)
+    stale_project.mkdir(parents=True)
+
+    class FakeEnv:
+        def __init__(self, *, apps_path: Path, app: str = "flight_project", verbose: int | None = 1):
+            self.apps_path = apps_path
+            self.app = app
+            self.verbose = verbose
+            self.active_app = apps_path / "builtin" / app
+            self.init_done = True
+
+    env = FakeEnv(apps_path=source_apps)
+    env.active_app = stale_project
+    session_state = {
+        "env": env,
+        "apps_path": str(source_apps),
+    }
+
+    assert page_bootstrap.realign_session_env_with_page_root(session_state, page_file) is True
+    assert env.apps_path == source_apps
+    assert env.active_app == source_project
+    assert session_state["apps_path"] == str(source_apps)
+
+
 def test_page_bootstrap_keeps_session_env_when_recorded_root_differs(tmp_path):
     source_root = tmp_path / "agilab-src" / "src" / "agilab"
     source_apps = source_root / "apps"

--- a/test/test_about_agilab_helpers.py
+++ b/test/test_about_agilab_helpers.py
@@ -822,6 +822,83 @@ def test_bootstrap_page_environment_keeps_source_root_when_last_app_is_agi_space
     assert fake_st.query_params["active_app"] == "flight_project"
 
 
+def test_bootstrap_page_environment_repairs_enduser_env_before_source_agi_env_init(tmp_path, monkeypatch):
+    bootstrap = about_agilab._about_bootstrap
+    source_apps = tmp_path / "agilab-src" / "src" / "agilab" / "apps"
+    source_project = source_apps / "builtin" / "flight_project"
+    stale_apps = tmp_path / "agi-space" / "apps"
+    source_project.mkdir(parents=True)
+    stale_apps.mkdir(parents=True)
+    events: list[tuple[str, str]] = []
+    fake_environ: dict[str, str] = {}
+
+    class FakeAgiEnv:
+        persisted: dict[str, str] = {
+            "APPS_PATH": str(stale_apps),
+            "IS_SOURCE_ENV": "0",
+            "IS_WORKER_ENV": "0",
+        }
+
+        @classmethod
+        def set_env_var(cls, key: str, value: str) -> None:
+            events.append(("set", f"{key}={value}"))
+            cls.persisted[key] = value
+
+        def __init__(self, *, apps_path: Path, verbose: int = 1):
+            events.append(("init", f"IS_SOURCE_ENV={self.persisted.get('IS_SOURCE_ENV')}"))
+            self.apps_path = apps_path
+            self.builtin_apps_path = apps_path / "builtin"
+            self.apps_repository_root = None
+            self.verbose = verbose
+            self.app = "flight_project"
+            self.active_app = self.builtin_apps_path / self.app
+            self.projects = {"flight_project"}
+            self.is_source_env = self.persisted.get("IS_SOURCE_ENV") == "1"
+            self.is_worker_env = self.persisted.get("IS_WORKER_ENV") == "1"
+            self.OPENAI_API_KEY = ""
+            self.CLUSTER_CREDENTIALS = ""
+            self.envars = dict(self.persisted)
+            self.init_done = False
+
+    fake_st = _FakeStreamlit()
+    ports, _port_calls = _make_bootstrap_ports(
+        FakeAgiEnv,
+        services_enabled=False,
+        last_app=stale_apps / "builtin" / "flight_project",
+        environ=fake_environ,
+    )
+    monkeypatch.setattr(bootstrap, "resolve_apps_path", lambda *_args, **_kwargs: source_apps)
+
+    result = bootstrap.bootstrap_page_environment(
+        streamlit=fake_st,
+        env_file_path=tmp_path / ".env",
+        load_env_file_map=lambda _path: {
+            "APPS_PATH": str(stale_apps),
+            "IS_SOURCE_ENV": "0",
+            "IS_WORKER_ENV": "0",
+        },
+        logger=object(),
+        apply_active_app_request=lambda env, requested: bootstrap.apply_active_app_request(
+            env,
+            requested,
+            streamlit=fake_st,
+        ),
+        handle_data_root_failure=lambda *_args, **_kwargs: False,
+        refresh_env_from_file=lambda _env: None,
+        clean_openai_key=lambda value: value,
+        store_cluster_credentials=lambda *_args, **_kwargs: True,
+        argv=[],
+        ports=ports,
+    )
+
+    assert result.env.is_source_env is True
+    assert result.env.active_app == source_project
+    assert fake_environ["APPS_PATH"] == str(source_apps.resolve(strict=False))
+    assert fake_environ["IS_SOURCE_ENV"] == "1"
+    assert ("init", "IS_SOURCE_ENV=1") in events
+    assert events.index(("set", "IS_SOURCE_ENV=1")) < events.index(("init", "IS_SOURCE_ENV=1"))
+
+
 def test_bootstrap_normalize_active_app_input_skips_unresolvable_candidate(
     tmp_path,
     monkeypatch,
@@ -1072,10 +1149,6 @@ def test_bootstrap_sync_active_app_from_query_keeps_matching_query(tmp_path):
 
 
 def test_bootstrap_page_environment_success_path(tmp_path, monkeypatch):
-    import agi_env
-    import agi_gui.pagelib as pagelib
-    import agi_gui.ui_support as ui_support
-
     bootstrap = about_agilab._about_bootstrap
     apps_path = tmp_path / "apps"
     app_path = apps_path / "flight_project"
@@ -1114,12 +1187,25 @@ def test_bootstrap_page_environment_success_path(tmp_path, monkeypatch):
         warning=lambda message: fake_st.warnings.append(message),
         error=lambda _message: None,
     )
-    monkeypatch.setattr(bootstrap.os, "environ", fake_environ)
-    monkeypatch.setattr(agi_env, "AgiEnv", FakeAgiEnv)
-    monkeypatch.setattr(pagelib, "activate_mlflow", lambda _env: None)
-    monkeypatch.setattr(pagelib, "background_services_enabled", lambda: False)
-    monkeypatch.setattr(ui_support, "load_last_active_app", lambda: app_path)
-    monkeypatch.setattr(ui_support, "store_last_active_app", remembered_apps.append)
+    monkeypatch.setattr(
+        bootstrap,
+        "default_agilab_path_file",
+        lambda **_kwargs: tmp_path / "missing-agilab-path",
+    )
+    ports, port_calls = _make_bootstrap_ports(
+        FakeAgiEnv,
+        services_enabled=False,
+        last_app=app_path,
+        environ=fake_environ,
+    )
+    ports = bootstrap.BootstrapPorts(
+        agi_env_cls=ports.agi_env_cls,
+        activate_mlflow=ports.activate_mlflow,
+        background_services_enabled=ports.background_services_enabled,
+        load_last_active_app=ports.load_last_active_app,
+        store_last_active_app=remembered_apps.append,
+        environ=ports.environ,
+    )
 
     result = bootstrap.bootstrap_page_environment(
         streamlit=fake_st,
@@ -1131,6 +1217,7 @@ def test_bootstrap_page_environment_success_path(tmp_path, monkeypatch):
         refresh_env_from_file=refreshed_envs.append,
         clean_openai_key=lambda value: value,
         store_cluster_credentials=lambda *_args, **_kwargs: True,
+        ports=ports,
     )
 
     assert result.env is fake_st.session_state["env"]
@@ -1140,6 +1227,7 @@ def test_bootstrap_page_environment_success_path(tmp_path, monkeypatch):
     assert fake_st.session_state["first_run"] is False
     assert fake_st.query_params["active_app"] == "flight_project"
     assert remembered_apps == [apps_path / "flight_project"]
+    assert port_calls.activated == []
     assert refreshed_envs == [result.env]
     assert ("APPS_PATH", str(apps_path)) not in set_env_calls
     assert ("IS_SOURCE_ENV", "1") in set_env_calls
@@ -1192,6 +1280,49 @@ def test_bootstrap_resolve_apps_path_prefers_source_marker_over_stale_env(tmp_pa
         load_env_file_map=lambda _path: {"APPS_PATH": str(stale_apps)},
         home_path=tmp_path,
     ) == source_apps.resolve(strict=False)
+
+
+def test_bootstrap_source_launch_env_updates_normalizes_builtin_source_root(tmp_path):
+    bootstrap = about_agilab._about_bootstrap
+    source_builtin = tmp_path / "agilab-src" / "src" / "agilab" / "apps" / "builtin"
+
+    assert bootstrap.source_launch_env_updates(source_builtin) == {
+        "APPS_PATH": str(source_builtin.parent.resolve(strict=False)),
+        "IS_SOURCE_ENV": "1",
+        "IS_WORKER_ENV": "0",
+    }
+
+
+def test_bootstrap_persisted_active_app_ignores_cross_root_absolute_path(tmp_path):
+    bootstrap = about_agilab._about_bootstrap
+    source_apps = tmp_path / "agilab-src" / "src" / "agilab" / "apps"
+    stale_project = tmp_path / "agi-space" / "apps" / "builtin" / "private_project"
+    stale_project.mkdir(parents=True)
+    env = SimpleNamespace(
+        apps_path=source_apps,
+        builtin_apps_path=source_apps / "builtin",
+        apps_repository_root=None,
+        projects={"flight_project"},
+    )
+
+    assert bootstrap.persisted_active_app_request(env, stale_project) is None
+
+
+def test_bootstrap_persisted_active_app_maps_cross_root_absolute_path_to_local_project(tmp_path):
+    bootstrap = about_agilab._about_bootstrap
+    source_apps = tmp_path / "agilab-src" / "src" / "agilab" / "apps"
+    source_project = source_apps / "builtin" / "flight_project"
+    stale_project = tmp_path / "agi-space" / "apps" / "builtin" / "flight_project"
+    source_project.mkdir(parents=True)
+    stale_project.mkdir(parents=True)
+    env = SimpleNamespace(
+        apps_path=source_apps,
+        builtin_apps_path=source_apps / "builtin",
+        apps_repository_root=None,
+        projects=set(),
+    )
+
+    assert bootstrap.persisted_active_app_request(env, stale_project) == "flight_project"
 
 
 def test_bootstrap_active_app_helpers_handle_empty_same_and_failed_switch(tmp_path):

--- a/test/test_agilab_dev_shortcuts.py
+++ b/test/test_agilab_dev_shortcuts.py
@@ -27,6 +27,56 @@ def test_impact_shortcut_defaults_to_staged():
     ]
 
 
+def test_bugfix_shortcut_runs_impact_then_fast_regression_by_default():
+    assert agilab_dev.planned_commands(["bugfix"]) == [
+        [
+            "uv",
+            "--preview-features",
+            "extra-build-dependencies",
+            "run",
+            "python",
+            "tools/impact_validate.py",
+            "--staged",
+        ],
+        [
+            "uv",
+            "--preview-features",
+            "extra-build-dependencies",
+            "run",
+            "python",
+            "tools/ga_regression_selector.py",
+            "--staged",
+            "--run",
+        ],
+    ]
+
+
+def test_bugfix_shortcut_keeps_changed_file_arguments():
+    assert agilab_dev.planned_commands(["bugfix", "--files", "src/agilab/main_page.py"]) == [
+        [
+            "uv",
+            "--preview-features",
+            "extra-build-dependencies",
+            "run",
+            "python",
+            "tools/impact_validate.py",
+            "--files",
+            "src/agilab/main_page.py",
+        ],
+        [
+            "uv",
+            "--preview-features",
+            "extra-build-dependencies",
+            "run",
+            "python",
+            "tools/ga_regression_selector.py",
+            "--files",
+            "src/agilab/main_page.py",
+            "--run",
+        ],
+    ]
+
+
 def test_test_shortcut_keeps_pytest_arguments():
     assert agilab_dev.planned_commands(["test", "test/test_cluster_lan_discovery.py", "-k", "windows"]) == [
         [

--- a/test/test_impact_validate.py
+++ b/test/test_impact_validate.py
@@ -70,8 +70,8 @@ def test_analyze_paths_adds_badge_refresh_with_component_hint() -> None:
     assert any("test/test_generate_component_coverage_badges.py" in command for command in artifact.commands)
     assert any("--components agi-gui" in command for command in artifact.commands)
     assert any("tools/coverage_badge_guard.py" in command for command in artifact.commands)
-    guard = next(action for action in report.artifact_actions if action.key == "coverage-badge-guard")
-    assert "tools/coverage_badge_guard.py --changed-only --require-fresh-xml" in guard.commands[0]
+    assert all(action.key != "coverage-badge-guard" for action in report.artifact_actions)
+    assert all("--require-fresh-xml" not in command for command in artifact.commands)
     parity = next(action for action in report.artifact_actions if action.key == "workflow-parity-badges")
     assert "tools/workflow_parity.py --profile badges" in parity.commands[0]
 

--- a/test/test_pre_push_changed_files.py
+++ b/test/test_pre_push_changed_files.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "tools" / "pre_push_changed_files.py"
+
+spec = importlib.util.spec_from_file_location("pre_push_changed_files", MODULE_PATH)
+assert spec is not None and spec.loader is not None
+pre_push_changed_files = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = pre_push_changed_files
+spec.loader.exec_module(pre_push_changed_files)
+
+
+def test_classify_source_only_change_skips_docs_and_release_proof_guards():
+    state = pre_push_changed_files.classify_changed_files(["src/agilab/about_page/bootstrap.py"])
+
+    assert not state.docs_changed
+    assert not state.release_proof_changed
+
+
+def test_classify_docs_source_change_runs_docs_guard_only():
+    state = pre_push_changed_files.classify_changed_files(["docs/source/getting-started.rst"])
+
+    assert state.docs_changed
+    assert not state.release_proof_changed
+
+
+def test_classify_release_proof_change_runs_both_doc_related_guards():
+    state = pre_push_changed_files.classify_changed_files(["docs/source/release-proof.rst"])
+
+    assert state.docs_changed
+    assert state.release_proof_changed
+
+
+def test_classify_release_tool_change_runs_release_proof_guard_only():
+    state = pre_push_changed_files.classify_changed_files(["tools/release_proof_report.py"])
+
+    assert not state.docs_changed
+    assert state.release_proof_changed
+
+
+def test_pre_push_records_use_remote_sha_as_diff_base():
+    calls = []
+
+    def fake_git(args):
+        calls.append(list(args))
+        return "docs/source/getting-started.rst\nsrc/agilab/main_page.py"
+
+    stdin_text = "refs/heads/topic localsha refs/heads/topic remotesha\n"
+    changed = pre_push_changed_files.changed_files_from_pre_push(stdin_text, git=fake_git)
+
+    assert changed == ("docs/source/getting-started.rst", "src/agilab/main_page.py")
+    assert calls == [["diff", "--name-only", "--diff-filter=ACMR", "remotesha", "localsha"]]
+
+
+def test_render_shell_is_eval_friendly():
+    state = pre_push_changed_files.classify_changed_files(["docs/source/release-proof.rst"])
+
+    assert pre_push_changed_files.render_shell(state).splitlines() == [
+        "DOCS_CHANGED=1",
+        "RELEASE_PROOF_CHANGED=1",
+        "DETECTION_FAILED=0",
+        "CHANGED_COUNT=1",
+        "DETECTION_ERROR=",
+    ]

--- a/test/test_ui_pages.py
+++ b/test/test_ui_pages.py
@@ -619,6 +619,33 @@ def test_execute_page_realigns_stale_agi_space_session_env(mock_ui_env, tmp_path
     assert "agi-space" not in markdown_text
 
 
+def test_execute_page_realigns_stale_active_app_only_for_source_root(mock_ui_env, tmp_path):
+    """ORCHESTRATE header must not use an old agi-space active app when apps_path is already source."""
+    at = _app_test("src/agilab/pages/2_ORCHESTRATE.py")
+    source_apps = (Path(__file__).resolve().parents[1] / "src/agilab/apps").resolve()
+    source_project = source_apps / "builtin" / "flight_project"
+    stale_project = tmp_path / "agi-space" / "apps" / "builtin" / "flight_project"
+    stale_project.mkdir(parents=True)
+
+    env = AgiEnv(apps_path=source_apps, app="flight_project", verbose=0)
+    env.active_app = stale_project
+    env.init_done = True
+    env.st_resources = (Path(__file__).resolve().parents[1] / "src/agilab/resources").resolve()
+    at.session_state["env"] = env
+    at.session_state["apps_path"] = str(source_apps)
+    at.session_state["app_settings"] = {"args": {}, "cluster": {}}
+    _seed_env_editor_state(at, env)
+
+    at.run()
+
+    assert not at.exception
+    assert Path(at.session_state["env"].apps_path) == source_apps
+    assert Path(at.session_state["env"].active_app) == source_project
+    markdown_text = "\n".join(str(item.value) for item in at.markdown)
+    assert "agi-space" not in markdown_text
+    assert str(source_project / ".venv") in markdown_text
+
+
 def test_execute_page_install_robot_allows_benign_uv_self_update_warning(mock_ui_env):
     """Robot-style INSTALL regression for handled remote uv self-update warnings."""
 

--- a/tools/agilab_dev.py
+++ b/tools/agilab_dev.py
@@ -94,7 +94,7 @@ High-frequency mappings:
   test      -> Run targeted pytest with -q while keeping all extra pytest arguments.
   regress   -> Use the GA regression selector on staged files and run the selected pytest subset.
   flow      -> Run one or more workflow_parity profiles with repeated --profile flags.
-  badge     -> Check that coverage badge inputs are fresh for the files changed locally.
+  badge     -> Run the explicit release/pre-release coverage badge freshness guard.
   docs      -> Sync docs from the canonical docs checkout and verify the mirror stamp.
   skills    -> Sync repo skills from Claude to Codex, then validate and regenerate indexes.
 """

--- a/tools/agilab_dev.py
+++ b/tools/agilab_dev.py
@@ -44,6 +44,17 @@ def planned_commands(argv: Sequence[str]) -> list[list[str]]:
         forwarded = args or ["--staged"]
         return [_uv_python("tools/impact_validate.py", *forwarded)]
 
+    if command in {"bugfix", "fix"}:
+        forwarded = args or ["--staged"]
+        selector_args = list(forwarded)
+        if "--run" not in selector_args:
+            selector_args.append("--run")
+        impact_args = [item for item in forwarded if item != "--run"]
+        return [
+            _uv_python("tools/impact_validate.py", *impact_args),
+            _uv_python("tools/ga_regression_selector.py", *selector_args),
+        ]
+
     if command == "test":
         return [[*UV_RUN, "pytest", "-q", *args]]
 
@@ -82,6 +93,7 @@ def planned_commands(argv: Sequence[str]) -> list[list[str]]:
 def _usage() -> str:
     return """Usage:
   ./dev [--print-only] impact [impact_validate args]
+  ./dev [--print-only] bugfix [changed-file args]
   ./dev [--print-only] test [pytest args]
   ./dev [--print-only] regress [ga_regression_selector args]
   ./dev [--print-only] flow|profile <profile> [profile...] [workflow args]
@@ -91,6 +103,7 @@ def _usage() -> str:
 
 High-frequency mappings:
   impact    -> Analyze changed files and list the required local validations; defaults to --staged.
+  bugfix    -> Run impact triage, then run the GA-selected fast regression subset; defaults to --staged.
   test      -> Run targeted pytest with -q while keeping all extra pytest arguments.
   regress   -> Use the GA regression selector on staged files and run the selected pytest subset.
   flow      -> Run one or more workflow_parity profiles with repeated --profile flags.

--- a/tools/impact_validate.py
+++ b/tools/impact_validate.py
@@ -487,16 +487,6 @@ def analyze_paths(paths: list[str]) -> ImpactReport:
         )
 
     components = _component_hints(paths)
-    if components:
-        artifacts.append(
-            Action(
-                key="coverage-badge-guard",
-                summary="Run the local coverage badge guard before push so badge drift is caught before GitHub Actions.",
-                commands=[
-                    "uv --preview-features extra-build-dependencies run python tools/coverage_badge_guard.py --changed-only --require-fresh-xml"
-                ],
-            )
-        )
     if any(
         _matches_prefix(path, BADGE_PATH_PREFIXES)
         or "coverage-" in Path(path).name
@@ -518,7 +508,6 @@ def analyze_paths(paths: list[str]) -> ImpactReport:
         commands.append(
             "uv --preview-features extra-build-dependencies run python tools/coverage_badge_guard.py --components "
             + " ".join(components or ["agi-env", "agi-node", "agi-cluster", "agi-gui"])
-            + " --changed-only --require-fresh-xml"
         )
         artifacts.append(
             Action(

--- a/tools/pre_push_changed_files.py
+++ b/tools/pre_push_changed_files.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Classify changed files for fast local pre-push guardrails."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Iterable, Sequence
+
+
+ZERO_SHA = "0" * 40
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+DOCS_GUARD_PREFIXES = (
+    "docs/source/",
+)
+DOCS_GUARD_FILES = {
+    "docs/.docs_source_mirror_stamp.json",
+    "tools/sync_docs_source.py",
+    "test/test_sync_docs_source.py",
+}
+RELEASE_PROOF_GUARD_PREFIXES = (
+    "docs/source/data/release_proof",
+)
+RELEASE_PROOF_GUARD_FILES = {
+    "README.md",
+    "badges/pypi-version-agilab.svg",
+    "docs/source/release-proof.rst",
+    "pyproject.toml",
+    "test/test_release_proof_report.py",
+    "tools/release_proof_report.py",
+}
+
+
+GitRunner = Callable[[Sequence[str]], str]
+
+
+@dataclass(frozen=True)
+class GuardState:
+    changed_files: tuple[str, ...]
+    docs_changed: bool
+    release_proof_changed: bool
+    detection_failed: bool = False
+    error: str = ""
+
+
+def _run_git(args: Sequence[str]) -> str:
+    completed = subprocess.run(
+        ["git", *args],
+        cwd=REPO_ROOT,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    return completed.stdout.strip()
+
+
+def _split_lines(value: str) -> tuple[str, ...]:
+    return tuple(line.strip() for line in value.splitlines() if line.strip())
+
+
+def _remote_default_base(git: GitRunner) -> str:
+    try:
+        return git(["rev-parse", "--verify", "@{u}"])
+    except subprocess.CalledProcessError:
+        return git(["rev-parse", "--verify", "origin/main"])
+
+
+def _new_branch_base(local_sha: str, git: GitRunner) -> str:
+    candidates = ("origin/main", "main")
+    for candidate in candidates:
+        try:
+            base = git(["merge-base", local_sha, candidate])
+        except subprocess.CalledProcessError:
+            continue
+        if base:
+            return base
+    return f"{local_sha}^"
+
+
+def parse_pre_push_records(stdin_text: str) -> tuple[tuple[str, str, str, str], ...]:
+    records: list[tuple[str, str, str, str]] = []
+    for raw_line in stdin_text.splitlines():
+        parts = raw_line.split()
+        if len(parts) != 4:
+            continue
+        records.append((parts[0], parts[1], parts[2], parts[3]))
+    return tuple(records)
+
+
+def changed_files_from_pre_push(stdin_text: str, *, git: GitRunner = _run_git) -> tuple[str, ...]:
+    records = parse_pre_push_records(stdin_text)
+    changed: set[str] = set()
+
+    if not records:
+        base = _remote_default_base(git)
+        return tuple(sorted(_split_lines(git(["diff", "--name-only", "--diff-filter=ACMR", f"{base}...HEAD"]))))
+
+    for _local_ref, local_sha, _remote_ref, remote_sha in records:
+        if local_sha == ZERO_SHA:
+            continue
+        base = _new_branch_base(local_sha, git) if remote_sha == ZERO_SHA else remote_sha
+        changed.update(_split_lines(git(["diff", "--name-only", "--diff-filter=ACMR", base, local_sha])))
+    return tuple(sorted(changed))
+
+
+def _matches(path: str, *, prefixes: Iterable[str], files: set[str]) -> bool:
+    return path in files or any(path.startswith(prefix) for prefix in prefixes)
+
+
+def classify_changed_files(changed_files: Sequence[str]) -> GuardState:
+    docs_changed = any(
+        _matches(path, prefixes=DOCS_GUARD_PREFIXES, files=DOCS_GUARD_FILES)
+        for path in changed_files
+    )
+    release_proof_changed = any(
+        _matches(path, prefixes=RELEASE_PROOF_GUARD_PREFIXES, files=RELEASE_PROOF_GUARD_FILES)
+        for path in changed_files
+    )
+    return GuardState(
+        changed_files=tuple(sorted(set(changed_files))),
+        docs_changed=docs_changed,
+        release_proof_changed=release_proof_changed,
+    )
+
+
+def failed_detection_state(error: Exception) -> GuardState:
+    return GuardState(
+        changed_files=(),
+        docs_changed=True,
+        release_proof_changed=True,
+        detection_failed=True,
+        error=str(error),
+    )
+
+
+def _shell_bool(value: bool) -> str:
+    return "1" if value else "0"
+
+
+def render_shell(state: GuardState) -> str:
+    lines = [
+        f"DOCS_CHANGED={_shell_bool(state.docs_changed)}",
+        f"RELEASE_PROOF_CHANGED={_shell_bool(state.release_proof_changed)}",
+        f"DETECTION_FAILED={_shell_bool(state.detection_failed)}",
+        f"CHANGED_COUNT={len(state.changed_files)}",
+    ]
+    if state.error:
+        lines.append(f"DETECTION_ERROR={state.error.replace(chr(10), ' ')}")
+    else:
+        lines.append("DETECTION_ERROR=")
+    return "\n".join(lines)
+
+
+def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--format",
+        choices=("shell", "files"),
+        default="shell",
+        help="Output shell variables for the hook, or the changed file list.",
+    )
+    parser.add_argument(
+        "--changed-file",
+        action="append",
+        default=None,
+        help="Bypass git detection and classify this file. Useful for tests/debugging.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+
+    try:
+        changed_files = (
+            tuple(args.changed_file)
+            if args.changed_file is not None
+            else changed_files_from_pre_push(sys.stdin.read())
+        )
+        state = classify_changed_files(changed_files)
+    except Exception as exc:  # pragma: no cover - defensive hook fail-safe
+        state = failed_detection_state(exc)
+
+    if args.format == "files":
+        print("\n".join(state.changed_files))
+        return 0
+
+    print(render_shell(state))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- make explicit/source apps paths win over stale persisted APPS_PATH values
- make source .agilab-path markers override stale agi-space APPS_PATH during main-page bootstrap
- remove coverage badge freshness from the default bugfix pre-push path; keep it explicit for release/pre-release flows

## Validation
- uv --preview-features extra-build-dependencies run --no-sync pytest -q src/agilab/core/agi-env/test
- uv --preview-features extra-build-dependencies run pytest -q src/agilab/core/agi-env/test/test_bootstrap_support.py src/agilab/core/agi-env/test/test_agi_env.py test/test_about_agilab_helpers.py test/test_impact_validate.py test/test_agilab_dev_shortcuts.py
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile skills
- .githooks/pre-push