### PR TITLE
[codex] Add project notebook launcher

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 186,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "d6ef1fe8f912e0292689fdf0626ee91db65066f945813a2758f2d8b6672919a7",
+  "source_digest_sha256": "5104ab74efdb230ac0bb2ad916eae4b7a0df91dcf6528ddcd63a458c60756798",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "d6ef1fe8f912e0292689fdf0626ee91db65066f945813a2758f2d8b6672919a7"
+  "target_digest_sha256": "5104ab74efdb230ac0bb2ad916eae4b7a0df91dcf6528ddcd63a458c60756798"
 }

--- a/docs/source/agilab-help.rst
+++ b/docs/source/agilab-help.rst
@@ -6,7 +6,8 @@ This page maps the built-in AGILab web pages and shows how they fit together.
 The main web interface exposes one navigation surface for:
 
 - **Core pages** (Project, Orchestrate, Workflow, Analysis), and
-- **Page bundles** (optional dashboards launched from Analysis).
+- **Page bundles and project notebooks** (optional sidecar surfaces launched
+  from Analysis).
 
 How pages are presented
 -----------------------
@@ -23,7 +24,8 @@ Core pages
 - :doc:`edit-help` — **PROJECT**: inspect and modify project sources and settings.
 - :doc:`execute-help` — **ORCHESTRATE**: install workers, generate distributions, and run pipelines.
 - :doc:`experiment-help` — **WORKFLOW**: iterate in ``lab_stages.toml``, run snippets against exported data, and export a runnable supervisor notebook for use outside the AGILAB UI.
-- :doc:`explore-help` — **ANALYSIS**: discover, configure, and launch page bundles.
+- :doc:`explore-help` — **ANALYSIS**: discover, configure, and launch page bundles
+  and project notebooks.
 
 Core page tour
 --------------
@@ -58,8 +60,8 @@ Use this as a page map, not as the newcomer proof path:
 3. Move to :doc:`experiment-help` (Workflow) to import or iterate that
    generated stage in ``lab_stages.toml`` and export a runnable supervisor
    notebook when you want the pipeline outside the AGILAB UI.
-4. Open :doc:`explore-help` (Analysis) to configure and launch page bundles for
-   deeper views.
+4. Open :doc:`explore-help` (Analysis) to configure and launch page bundles or
+   project notebooks for deeper views.
 
 Public navigation split
 -----------------------

--- a/docs/source/experiment-help.rst
+++ b/docs/source/experiment-help.rst
@@ -210,8 +210,10 @@ not just a static dump of code cells.
 * You can open it outside the AGILAB UI in Jupyter-compatible tools such as
   JupyterLab or PyCharm.
 * For a source checkout, prefer the project-local mirror under
-  ``<app-project>/notebooks/lab_stages.ipynb`` and launch it from that app
-  project explicitly, for example:
+  ``<app-project>/notebooks/lab_stages.ipynb``. ANALYSIS discovers notebooks in
+  that directory and exposes selected entries in its sidebar ``Notebooks``
+  section. You can also launch the notebook from the app project explicitly, for
+  example:
 
   .. code-block:: bash
 

--- a/docs/source/explore-help.rst
+++ b/docs/source/explore-help.rst
@@ -6,10 +6,11 @@ ANALYSIS
 
 Introduction
 ------------
-The **Analysis** page is the catalog and launcher for installed analysis views.
+The **Analysis** page is the catalog and launcher for installed analysis views
+and project notebooks.
 
-It lets you choose which views belong to the active project and launch them in
-isolated sidecar sessions.
+It lets you choose which views and notebooks belong to the active project and
+launch them in isolated sidecar sessions.
 
 Page snapshot
 -------------
@@ -19,7 +20,7 @@ Page snapshot
    :align: center
    :class: diagram-panel diagram-wide
 
-   ANALYSIS exposes the available page bundles, stores the selected views per project, and launches them as sidecar dashboards.
+   ANALYSIS exposes available page bundles and project notebooks, stores the selected launchers per project, and opens them as sidecar dashboards.
 
 Sidebar
 -------
@@ -30,9 +31,13 @@ Sidebar
 - ``Analysis views`` lists compact launch links for the selected views. If no
   view has been selected yet, it lists every discovered view so you can launch
   one without first editing the project configuration.
-- The currently selected project determines which views are stored inside its
-  workspace ``app_settings.toml`` file under ``~/.agilab/apps/<project>/``
-  in the ``[pages]`` section.
+- ``Notebooks`` appears below ``Analysis views`` when the active project has
+  ``.ipynb`` files under ``<project>/notebooks``. If no notebook has been
+  selected yet, it lists every discovered project notebook.
+- The currently selected project determines which views and notebooks are
+  stored inside its workspace ``app_settings.toml`` file under
+  ``~/.agilab/apps/<project>/`` in the ``[pages]`` and ``[notebooks]``
+  sections.
 
 Main Content Area
 -----------------
@@ -62,6 +67,13 @@ Main Content Area
       customized. Use **Starting point** when you want to begin from a blank
       template or duplicate an existing app page before clicking **Create**.
 
+      Use **Choose notebooks** to choose which project notebooks are shown as
+      sidebar shortcuts for the selected project. AGILab discovers notebooks
+      under ``<app-project>/notebooks`` recursively, ignores hidden folders and
+      ``.ipynb_checkpoints``, and stores the selected relative notebook paths in
+      ``~/.agilab/apps/<project>/app_settings.toml`` under
+      ``[notebooks].selected``.
+
    .. tab-item:: Launch
 
       Each selected view appears as a compact sidebar link. Opening it launches
@@ -70,6 +82,11 @@ Main Content Area
       directories pointed to ``${AGILAB_VENVS_ABS}`` and
       ``${AGILAB_PAGES_VENVS_ABS}``). The child app is then embedded via iframe
       and a ``Back to Analysis`` control keeps navigation lightweight.
+
+      Each selected notebook appears below the view links. Opening it launches a
+      local JupyterLab sidecar rooted at the active app project and embeds the
+      selected notebook from ``<app-project>/notebooks``. This keeps notebooks
+      project-local while leaving page bundles in ``${AGILAB_PAGES_ABS}``.
 
 Tips & Notes
 ------------
@@ -84,6 +101,10 @@ Tips & Notes
   dashboard and the generic topology map.
 - AGILab caches the list per project, so the Analysis grid reflects the exact
   configuration stored in ``app_settings.toml``.
+- Project notebooks are ordinary ``.ipynb`` files owned by the app project. Use
+  the ``notebooks`` directory for exported supervisor notebooks such as
+  ``lab_stages.ipynb`` and for additional notebooks that explain or inspect that
+  project.
 - If a view needs its own Python environment, place it alongside the page
   bundle (``.venv`` or ``venv``) or in the shared directories referenced by the
   ``AGILAB_VENVS_ABS`` / ``AGILAB_PAGES_VENVS_ABS`` environment variables.
@@ -104,6 +125,11 @@ If analysis view discovery is unexpected, use these checks:
   that your browser blocks mixed local/remote content.
 - If the selected bundle list is not saved, check write permission on
   ``~/.agilab/apps/<project>/app_settings.toml``.
+- If ``Notebooks`` is missing, confirm the active project has at least one
+  ``.ipynb`` file under ``<app-project>/notebooks`` and that the file is not in
+  ``.ipynb_checkpoints`` or another hidden folder.
+- If a notebook launch opens a blank frame, confirm JupyterLab can start locally
+  for that project and that your browser allows the embedded ``127.0.0.1`` frame.
 - If ``view_maps_network`` opens but shows no UAV queue data, point the data
   directory to one run folder such as
   ``~/export/uav_relay_queue/queue_analysis/<artifact_stem>/`` rather than the parent

--- a/src/agilab/core/agi-env/src/agi_env/mlflow_store.py
+++ b/src/agilab/core/agi-env/src/agi_env/mlflow_store.py
@@ -41,6 +41,10 @@ MLFLOW_RUNTIME_EXCEPTIONS = tuple(
 _MLFLOW_CLI_BOOTSTRAP = "from mlflow.cli import cli; cli()"
 
 
+class MissingMlflowCliError(RuntimeError):
+    """Raised when the optional MLflow CLI is not available."""
+
+
 def mlflow_subprocess_env(base_env: dict[str, str] | None = None) -> dict[str, str]:
     """Return an environment safe for MLflow CLI subprocess imports."""
     env = dict(os.environ if base_env is None else base_env)
@@ -69,7 +73,7 @@ def mlflow_cli_argv(
         return [executable, *args]
     if _module_available("mlflow.cli", find_spec_fn=find_spec_fn):
         return [sys_executable, "-c", _MLFLOW_CLI_BOOTSTRAP, *args]
-    raise RuntimeError(
+    raise MissingMlflowCliError(
         "MLflow CLI is required but not installed in this environment. "
         "Install `agilab[mlflow]` or `mlflow` before starting the MLflow server."
     )

--- a/src/agilab/core/agi-env/src/agi_env/pagelib.py
+++ b/src/agilab/core/agi-env/src/agi_env/pagelib.py
@@ -131,6 +131,8 @@ _MLFLOW_SCHEMA_RESET_MARKERS = (
 )
 def background_services_enabled() -> bool:
     """Return False under automated UI tests or when explicitly disabled."""
+    if st.session_state.get("mlflow_autostart_disabled"):
+        return False
     disable_flag = os.getenv("AGILAB_DISABLE_BACKGROUND_SERVICES", "").strip().lower()
     if disable_flag in {"1", "true", "yes", "on"}:
         return False

--- a/src/agilab/core/agi-env/src/agi_env/pagelib_runtime_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/pagelib_runtime_support.py
@@ -179,6 +179,8 @@ def activate_mlflow(
     """Start the local MLflow server and persist its runtime state."""
     if not env:
         return None
+    if session_state.get("mlflow_autostart_disabled"):
+        return False
 
     session_state["rapids_default"] = True
     tracking_dir = resolve_mlflow_tracking_dir_fn(env)
@@ -218,6 +220,15 @@ def activate_mlflow(
         session_state["server_started"] = True
         session_state["mlflow_port"] = port
         return True
+    except mlflow_store.MissingMlflowCliError as exc:
+        session_state["server_started"] = False
+        session_state["mlflow_autostart_disabled"] = True
+        session_state["mlflow_status_message"] = str(exc)
+        session_state.pop("mlflow_port", None)
+        warning = getattr(streamlit, "warning", None)
+        if callable(warning):
+            warning(f"MLflow is optional and was not started automatically. {exc}")
+        return False
     except (RuntimeError, OSError, ValueError, AttributeError) as exc:
         session_state["server_started"] = False
         session_state.pop("mlflow_port", None)

--- a/src/agilab/core/agi-env/test/test_pagelib.py
+++ b/src/agilab/core/agi-env/test/test_pagelib.py
@@ -127,6 +127,13 @@ def test_background_services_enabled_respects_streamlit_testing_state(monkeypatc
     assert pagelib.background_services_enabled() is False
 
 
+def test_background_services_enabled_respects_mlflow_autostart_disabled(monkeypatch):
+    monkeypatch.delenv("AGILAB_DISABLE_BACKGROUND_SERVICES", raising=False)
+    monkeypatch.setattr(pagelib, "st", SimpleNamespace(session_state={"mlflow_autostart_disabled": True}))
+
+    assert pagelib.background_services_enabled() is False
+
+
 def test_background_services_enabled_defaults_to_true(monkeypatch):
     monkeypatch.delenv("AGILAB_DISABLE_BACKGROUND_SERVICES", raising=False)
     monkeypatch.setattr(pagelib, "st", SimpleNamespace(session_state={}))

--- a/src/agilab/core/agi-env/test/test_pagelib_runtime_support.py
+++ b/src/agilab/core/agi-env/test/test_pagelib_runtime_support.py
@@ -215,6 +215,64 @@ def test_activate_mlflow_support_handles_none_timeout_and_runtime_failure(
     assert any("Failed to start the server" in message for message in messages)
 
 
+def test_activate_mlflow_support_disables_autostart_when_cli_is_missing(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    errors: list[str] = []
+    warnings: list[str] = []
+    session_state = {}
+
+    def _missing_cli(_args, **_kwargs):
+        raise pagelib_runtime_support.mlflow_store.MissingMlflowCliError("install `agilab[mlflow]`")
+
+    monkeypatch.setattr(pagelib_runtime_support.mlflow_store, "mlflow_cli_argv", _missing_cli)
+
+    started = pagelib_runtime_support.activate_mlflow(
+        SimpleNamespace(MLFLOW_TRACKING_DIR="", home_abs=tmp_path),
+        session_state=session_state,
+        streamlit=SimpleNamespace(
+            error=lambda message: errors.append(str(message)),
+            warning=lambda message: warnings.append(str(message)),
+        ),
+        logger=SimpleNamespace(info=lambda _message: None),
+        resolve_mlflow_tracking_dir_fn=lambda _env: tmp_path / ".mlflow",
+        ensure_default_mlflow_experiment_fn=lambda _path: "sqlite:///tmp/mlflow.db",
+        ensure_mlflow_backend_ready_fn=lambda _path: "sqlite:///tmp/mlflow.db",
+        resolve_mlflow_artifact_dir_fn=lambda _path: tmp_path / "artifacts",
+        next_free_port_fn=lambda: 50123,
+        wait_for_listen_port_fn=lambda _port: True,
+        subproc_fn=lambda *_args: (_ for _ in ()).throw(AssertionError("server should not launch")),
+        cwd=str(tmp_path),
+    )
+
+    assert started is False
+    assert errors == []
+    assert warnings == ["MLflow is optional and was not started automatically. install `agilab[mlflow]`"]
+    assert session_state["server_started"] is False
+    assert session_state["mlflow_autostart_disabled"] is True
+    assert session_state["mlflow_status_message"] == "install `agilab[mlflow]`"
+
+    assert (
+        pagelib_runtime_support.activate_mlflow(
+            SimpleNamespace(MLFLOW_TRACKING_DIR="", home_abs=tmp_path),
+            session_state=session_state,
+            streamlit=SimpleNamespace(error=errors.append, warning=warnings.append),
+            logger=SimpleNamespace(info=lambda _message: None),
+            resolve_mlflow_tracking_dir_fn=lambda _env: tmp_path / ".mlflow",
+            ensure_default_mlflow_experiment_fn=lambda _path: "sqlite:///tmp/mlflow.db",
+            ensure_mlflow_backend_ready_fn=lambda _path: "sqlite:///tmp/mlflow.db",
+            resolve_mlflow_artifact_dir_fn=lambda _path: tmp_path / "artifacts",
+            next_free_port_fn=lambda: 50123,
+            wait_for_listen_port_fn=lambda _port: True,
+            subproc_fn=lambda *_args: (_ for _ in ()).throw(AssertionError("server should not relaunch")),
+            cwd=str(tmp_path),
+        )
+        is False
+    )
+    assert len(warnings) == 1
+
+
 def test_activate_gpt_oss_support_clears_empty_checkpoint_and_extra_args(monkeypatch):
     session_state = {
         "gpt_oss_checkpoint": "  ",

--- a/src/agilab/notebook_pipeline_import.py
+++ b/src/agilab/notebook_pipeline_import.py
@@ -514,7 +514,7 @@ def _build_from_supervisor_metadata(
             {
                 "id": f"supervisor-stage-{stage_index}",
                 "order": len(pipeline_stages) + 1,
-                "source_cell_index": 0,
+                "source_cell_index": stage_index,
                 "cell_type": "code",
                 "execution_count": None,
                 "source_lines": source.splitlines(keepends=True),

--- a/src/agilab/orchestrate_distribution.py
+++ b/src/agilab/orchestrate_distribution.py
@@ -4,9 +4,16 @@ import textwrap
 from collections import defaultdict
 from typing import Any
 
-import networkx as nx
 import pandas as pd
 import streamlit as st
+
+try:
+    import networkx as nx
+except ModuleNotFoundError as exc:
+    nx = None  # type: ignore[assignment]
+    _NETWORKX_IMPORT_ERROR = exc
+else:
+    _NETWORKX_IMPORT_ERROR = None
 
 try:
     import matplotlib.pyplot as plt
@@ -17,6 +24,19 @@ except ModuleNotFoundError as exc:
     _MATPLOTLIB_IMPORT_ERROR = exc
 else:
     _MATPLOTLIB_IMPORT_ERROR = None
+
+
+def _networkx_unavailable_message() -> str:
+    return (
+        f"networkx unavailable: {_NETWORKX_IMPORT_ERROR}. "
+        "Install the UI dependencies with `pip install 'agilab[ui]'` or run `uv sync --extra ui`."
+    )
+
+
+def _require_networkx():
+    if nx is None:
+        raise RuntimeError(_networkx_unavailable_message())
+    return nx
 
 
 def import_plotly_graph_objects(import_module_fn=importlib.import_module):
@@ -30,13 +50,14 @@ def import_plotly_graph_objects(import_module_fn=importlib.import_module):
 
 def draw_distribution(graph, partition_key, show_leaf_list, title) -> None:
     """Shared drawing routine for distribution or DAG graphs."""
+    nx_module = _require_networkx()
     if plt is None or Patch is None:
         raise RuntimeError(
             f"matplotlib unavailable: {_MATPLOTLIB_IMPORT_ERROR}. "
             "Install the optional visualization dependencies with `pip install 'agilab[viz]'`."
         )
 
-    pos = nx.multipartite_layout(graph, subset_key="level", align="horizontal")
+    pos = nx_module.multipartite_layout(graph, subset_key="level", align="horizontal")
     pos = {k: (-x, -y) for k, (x, y) in pos.items()}
 
     ip_nodes = [n for n, d in graph.nodes(data=True) if d.get("level") == 0]
@@ -47,12 +68,16 @@ def draw_distribution(graph, partition_key, show_leaf_list, title) -> None:
     plt.figure(figsize=(12, 8))
     plt.margins(x=0.1, y=0.1)
 
-    nx.draw_networkx_nodes(graph, pos, nodelist=ip_nodes, node_color="royalblue", node_shape="o", node_size=1500)
-    nx.draw_networkx_nodes(graph, pos, nodelist=worker_nodes, node_color="skyblue", node_shape="o", node_size=1500)
-    nx.draw_networkx_nodes(graph, pos, nodelist=partition_nodes, node_color="lightgreen", node_shape="s", node_size=1500)
+    nx_module.draw_networkx_nodes(graph, pos, nodelist=ip_nodes, node_color="royalblue", node_shape="o", node_size=1500)
+    nx_module.draw_networkx_nodes(graph, pos, nodelist=worker_nodes, node_color="skyblue", node_shape="o", node_size=1500)
+    nx_module.draw_networkx_nodes(
+        graph, pos, nodelist=partition_nodes, node_color="lightgreen", node_shape="s", node_size=1500
+    )
     if show_leaf_list:
-        nx.draw_networkx_nodes(graph, pos, nodelist=leaf_nodes, node_color="lightgrey", node_shape="s", node_size=1000)
-    nx.draw_networkx_edges(graph, pos)
+        nx_module.draw_networkx_nodes(
+            graph, pos, nodelist=leaf_nodes, node_color="lightgrey", node_shape="s", node_size=1000
+        )
+    nx_module.draw_networkx_edges(graph, pos)
 
     ax = plt.gca()
     for node in graph.nodes():
@@ -70,9 +95,9 @@ def draw_distribution(graph, partition_key, show_leaf_list, title) -> None:
             bbox=dict(facecolor="white", edgecolor="none", pad=1.0, alpha=1.0),
         )
 
-    edge_labels = nx.get_edge_attributes(graph, "weight")
+    edge_labels = nx_module.get_edge_attributes(graph, "weight")
     if edge_labels:
-        nx.draw_networkx_edge_labels(graph, pos, edge_labels=edge_labels, font_size=6)
+        nx_module.draw_networkx_edge_labels(graph, pos, edge_labels=edge_labels, font_size=6)
 
     patches = [
         Patch(facecolor="royalblue", label="Host IP"),
@@ -129,6 +154,10 @@ def extract_chunk_info(chunk, partition_key, weights_key) -> tuple[Any, Any]:
 
 def show_tree(workers, work_plan_metadata, work_plan, partition_key, weights_key, show_leaf_list=False) -> None:
     """Display the distribution tree of the workload."""
+    if nx is None:
+        st.warning(_networkx_unavailable_message())
+        return
+
     total = 0
     total_per_host = defaultdict(int)
     workers_works = defaultdict(list)
@@ -186,6 +215,10 @@ def show_tree(workers, work_plan_metadata, work_plan, partition_key, weights_key
 
 def show_graph(workers, work_plan_metadata, work_plan, partition_key, weights_key, show_leaf_list=False) -> None:
     """Display a directed acyclic graph based on workplan metadata."""
+    if nx is None:
+        st.warning(_networkx_unavailable_message())
+        return
+
     total = 0
     total_per_host = defaultdict(int)
     workers_works = defaultdict(list)

--- a/src/agilab/orchestrate_execute.py
+++ b/src/agilab/orchestrate_execute.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import os
 import shutil
@@ -8,11 +10,19 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable, Optional
 
-import networkx as nx
-from networkx.readwrite import json_graph
 import pandas as pd
 import streamlit as st
 from code_editor import code_editor
+
+try:
+    import networkx as nx
+    from networkx.readwrite import json_graph
+except ModuleNotFoundError as exc:
+    nx = None  # type: ignore[assignment]
+    json_graph = None  # type: ignore[assignment]
+    _NETWORKX_IMPORT_ERROR = exc
+else:
+    _NETWORKX_IMPORT_ERROR = None
 
 try:
     import matplotlib.pyplot as plt
@@ -21,6 +31,27 @@ except ModuleNotFoundError as exc:
     _MATPLOTLIB_IMPORT_ERROR = exc
 else:
     _MATPLOTLIB_IMPORT_ERROR = None
+
+_NETWORKX_ERROR_TYPE = getattr(nx, "NetworkXError", RuntimeError) if nx is not None else RuntimeError
+_PREVIEW_LOAD_EXCEPTIONS = (OSError, RuntimeError, TypeError, ValueError, _NETWORKX_ERROR_TYPE)
+
+
+def _networkx_unavailable_message() -> str:
+    return (
+        f"networkx unavailable: {_NETWORKX_IMPORT_ERROR}. "
+        "Install the UI dependencies with `pip install 'agilab[ui]'` or run `uv sync --extra ui`."
+    )
+
+
+def _require_networkx():
+    if nx is None:
+        raise RuntimeError(_networkx_unavailable_message())
+    return nx
+
+
+def _is_networkx_graph(value: object) -> bool:
+    return nx is not None and isinstance(value, nx.Graph)
+
 
 from agi_env import AgiEnv
 from agi_gui.pagelib import cached_load_df, find_files, open_new_tab, render_dataframe_preview, save_csv
@@ -269,7 +300,8 @@ def render_execute_notice(streamlit_api, session_state) -> None:
     renderer(message)
 
 
-def _render_graph_preview(graph_preview: nx.Graph, source_preview_name: Optional[str]) -> None:
+def _render_graph_preview(graph_preview: "nx.Graph", source_preview_name: Optional[str]) -> None:
+    nx_module = _require_networkx()
     if plt is None:
         raise RuntimeError(
             f"matplotlib unavailable: {_MATPLOTLIB_IMPORT_ERROR}. "
@@ -278,10 +310,10 @@ def _render_graph_preview(graph_preview: nx.Graph, source_preview_name: Optional
 
     st.caption("Graph preview generated from JSON output")
     fig, ax = plt.subplots(figsize=(8, 6))
-    pos = nx.spring_layout(graph_preview, seed=42)
-    nx.draw_networkx_nodes(graph_preview, pos, node_color="skyblue", ax=ax)
-    nx.draw_networkx_edges(graph_preview, pos, ax=ax, alpha=0.5)
-    nx.draw_networkx_labels(graph_preview, pos, ax=ax, font_size=9)
+    pos = nx_module.spring_layout(graph_preview, seed=42)
+    nx_module.draw_networkx_nodes(graph_preview, pos, node_color="skyblue", ax=ax)
+    nx_module.draw_networkx_edges(graph_preview, pos, ax=ax, alpha=0.5)
+    nx_module.draw_networkx_labels(graph_preview, pos, ax=ax, font_size=9)
     ax.axis("off")
     st.pyplot(fig, width="stretch")
     plt.close(fig)
@@ -723,6 +755,8 @@ async def render_execute_section(
                     elif suffix == ".json":
                         payload = json.loads(target_file.read_text())
                         if isinstance(payload, dict) and "nodes" in payload and "links" in payload:
+                            if json_graph is None:
+                                raise RuntimeError(_networkx_unavailable_message())
                             graph = json_graph.node_link_graph(payload, directed=payload.get("directed", True))
                             st.session_state["loaded_df"] = None
                             st.session_state["_force_export_open"] = False
@@ -741,8 +775,9 @@ async def render_execute_section(
                             st.info(message)
                             load_notice = ("info", message)
                     elif suffix == ".gml":
-                        graph = nx.read_gml(target_file)
-                        edge_df = nx.to_pandas_edgelist(graph)
+                        nx_module = _require_networkx()
+                        graph = nx_module.read_gml(target_file)
+                        edge_df = nx_module.to_pandas_edgelist(graph)
                         if not edge_df.empty:
                             st.session_state["loaded_df"] = edge_df
                             st.session_state["_force_export_open"] = True
@@ -770,7 +805,7 @@ async def render_execute_section(
                         st.warning(f"Unsupported file format: {target_file.suffix}")
                 except json.JSONDecodeError as exc:
                     st.error(f"Failed to decode JSON from {target_file.name}: {exc}")
-                except (OSError, RuntimeError, TypeError, ValueError, nx.NetworkXError) as exc:
+                except _PREVIEW_LOAD_EXCEPTIONS as exc:
                     st.error(f"Unable to load {target_file.name}: {exc}")
                 if loaded_output_changed:
                     if load_notice:
@@ -974,7 +1009,7 @@ async def render_execute_section(
         )
         if source_preview_name:
             st.caption(f"Previewing {source_preview_name}")
-    elif isinstance(graph_preview, nx.Graph):
+    elif _is_networkx_graph(graph_preview):
         try:
             _render_graph_preview(graph_preview, source_preview_name)
         except (OSError, RuntimeError, TypeError, ValueError) as exc:

--- a/src/agilab/pages/3_WORKFLOW.py
+++ b/src/agilab/pages/3_WORKFLOW.py
@@ -564,15 +564,22 @@ def _render_notebook_actions(
         )
 
         key = index_page_str + "import_notebook"
+        import_module_dir = stages_file.parent
+        view_manifest_dir = _resolve_active_app_project_dir(env, project_name)
         st.markdown("##### Import")
         st.file_uploader(
             "Import notebook",
             type="ipynb",
             key=key,
             on_change=on_preview_notebook_import,
-            args=(key, module_path, index_page_str),
+            args=(key, import_module_dir, index_page_str, view_manifest_dir),
         )
-        render_notebook_import_preview(module_path, stages_file, index_page_str)
+        render_notebook_import_preview(
+            import_module_dir,
+            stages_file,
+            index_page_str,
+            view_manifest_dir=view_manifest_dir,
+        )
 
         export_context = build_notebook_export_context(
             env,
@@ -796,6 +803,52 @@ def _canonical_pipeline_project_modules(env: AgiEnv, raw_modules: List[str]) -> 
     # canonical *_project directory is known.
     _add(getattr(env, "target", ""))
     return modules
+
+
+def _resolve_active_app_project_dir(env: AgiEnv, project_name: str) -> Path | None:
+    raw_names = [project_name, getattr(env, "app", None), getattr(env, "target", None)]
+    app_names = [str(name).strip() for name in raw_names if str(name or "").strip()]
+    candidates: list[Any] = []
+    for root_attr in ("apps_path", "builtin_apps_path"):
+        root = getattr(env, root_attr, None)
+        if not root:
+            continue
+        for app_name in app_names:
+            candidates.append(Path(root) / app_name)
+    apps_path = getattr(env, "apps_path", None)
+    if apps_path:
+        for app_name in app_names:
+            candidates.append(Path(apps_path) / "builtin" / app_name)
+    for attr in ("active_app", "active_app_path", "app_path"):
+        value = getattr(env, attr, None)
+        if not value:
+            continue
+        try:
+            candidate = Path(value).expanduser()
+        except (OSError, TypeError, ValueError):
+            continue
+        if app_names and candidate.name not in app_names:
+            continue
+        candidates.append(candidate)
+
+    seen: set[Path] = set()
+    for raw_candidate in candidates:
+        try:
+            candidate = Path(raw_candidate).expanduser()
+        except (OSError, TypeError, ValueError):
+            continue
+        if not candidate.is_absolute() and len(candidate.parts) <= 1:
+            continue
+        try:
+            resolved = candidate.resolve()
+        except (OSError, RuntimeError):
+            resolved = candidate
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        if resolved.is_dir():
+            return resolved
+    return None
 
 
 def sidebar_controls() -> None:

--- a/src/agilab/pages/4_ANALYSIS.py
+++ b/src/agilab/pages/4_ANALYSIS.py
@@ -1560,6 +1560,8 @@ def _render_analysis_workspace_overview(
     *,
     selection_state: Any,
     available_view_count: int,
+    selected_notebook_count: int,
+    available_notebook_count: int,
 ) -> None:
     artifact_summary = _scan_analysis_artifacts(_active_analysis_data_root(env))
     artifact_count = int(artifact_summary["count"])
@@ -1570,9 +1572,16 @@ def _render_analysis_workspace_overview(
     latest_value = latest_label if artifact_count else "No output"
     latest_caption = "latest file timestamp" if artifact_count else "run a project first"
     views_caption = f"{selected_count} linked to {project_label}" if selected_count else "choose views below"
+    notebooks_caption = (
+        f"{selected_notebook_count} linked to {project_label}"
+        if selected_notebook_count
+        else "choose notebooks below"
+        if available_notebook_count
+        else "no notebooks found"
+    )
 
     with st.container(border=True):
-        cols = st.columns(3)
+        cols = st.columns(4)
         with cols[0]:
             suffix = "+" if artifact_summary["truncated"] else ""
             _render_analysis_metric("Output files", f"{artifact_count}{suffix}", latest_label)
@@ -1580,6 +1589,12 @@ def _render_analysis_workspace_overview(
             _render_analysis_metric("Latest output", latest_value, latest_caption)
         with cols[2]:
             _render_analysis_metric("Views selected", f"{selected_count}/{available_view_count}", views_caption)
+        with cols[3]:
+            _render_analysis_metric(
+                "Notebooks selected",
+                f"{selected_notebook_count}/{available_notebook_count}",
+                notebooks_caption,
+            )
 
         if not artifact_summary["exists"]:
             st.info("Run ORCHESTRATE or WORKFLOW to create analysis outputs.")
@@ -2099,6 +2114,8 @@ async def main():
         env,
         selection_state=selection_state,
         available_view_count=len(view_names),
+        selected_notebook_count=len(selected_notebooks),
+        available_notebook_count=len(notebook_names),
     )
 
     with st.expander("Choose analysis views", expanded=False):

--- a/src/agilab/pages/4_ANALYSIS.py
+++ b/src/agilab/pages/4_ANALYSIS.py
@@ -19,6 +19,7 @@ import socket
 import time
 import hashlib
 import html
+import json
 import re
 import inspect
 from typing import Any, Union
@@ -1858,6 +1859,17 @@ def _notebook_lab_tree_path(notebook_path: Path, project_root: Path) -> str:
     return quote(rel_path.as_posix(), safe="/")
 
 
+def _notebook_iframe_tornado_settings_arg() -> str:
+    """Return Jupyter headers that allow the local Streamlit parent to embed Lab."""
+    settings = {
+        "headers": {
+            "Content-Security-Policy": "frame-ancestors *;",
+            "X-Frame-Options": "",
+        }
+    }
+    return shlex.quote(json.dumps(settings, separators=(",", ":")))
+
+
 def _ensure_notebook_sidecar(
     notebook_key: str,
     notebook_path: Path,
@@ -1880,15 +1892,16 @@ def _ensure_notebook_sidecar(
 
     project_home = str(project_root.resolve())
     project_home_quoted = shlex.quote(project_home)
-    notebook_arg = shlex.quote(str(notebook_path.resolve()))
+    tornado_settings = _notebook_iframe_tornado_settings_arg()
     run_cmd = (
         f"{uv} --preview-features extra-build-dependencies run "
         f"--project {project_home_quoted} --with jupyterlab --with ipykernel "
-        f"jupyter lab {notebook_arg} --no-browser "
+        f"jupyter lab --no-browser "
         f"--ServerApp.ip=127.0.0.1 --ServerApp.port={port} "
         f"--ServerApp.open_browser=False --ServerApp.token= --ServerApp.password= "
         f"--ServerApp.allow_origin={shlex.quote('*')} --ServerApp.disable_check_xsrf=True "
-        f"--ServerApp.root_dir={project_home_quoted}"
+        f"--ServerApp.root_dir={project_home_quoted} "
+        f"--ServerApp.tornado_settings={tornado_settings}"
     )
     env.logger.info("Starting project notebook sidecar: %s", run_cmd)
     attempts.append(f"Trying JupyterLab sidecar rooted at: {project_home}")

--- a/src/agilab/pages/4_ANALYSIS.py
+++ b/src/agilab/pages/4_ANALYSIS.py
@@ -26,7 +26,7 @@ import asyncio
 import shlex
 import importlib.util
 import traceback
-from urllib.parse import urlencode
+from urllib.parse import quote, urlencode
 import shutil
 
 from pathlib import Path
@@ -194,6 +194,16 @@ _ANALYSIS_ARTIFACT_SUFFIXES = {
     ".jpeg",
     ".svg",
     ".html",
+}
+
+_NOTEBOOK_IGNORED_DIRS = {
+    ".git",
+    ".ipynb_checkpoints",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".venv",
+    "__pycache__",
+    "venv",
 }
 
 _MINIMAL_PAGE_TEMPLATE_PYPROJECT = """[project]
@@ -628,6 +638,33 @@ def _store_active_app(env: AgiEnv) -> None:
         pass
 
 
+def _active_app_path_for_env(env: Any) -> Path | None:
+    """Resolve the active project path from the current Analysis page environment."""
+    apps_path_value = getattr(env, "apps_path", None)
+    if apps_path_value:
+        for name in (getattr(env, "target", None), getattr(env, "app", None)):
+            if not name:
+                continue
+            resolved = _resolve_app_path(Path(apps_path_value), str(name))
+            if resolved is not None:
+                return resolved
+
+    active_app_value = getattr(env, "active_app", None)
+    if active_app_value:
+        candidate = Path(active_app_value)
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _active_app_arg_for_env(env: Any) -> str:
+    active_app_path = _active_app_path_for_env(env)
+    if active_app_path is not None:
+        return str(active_app_path)
+    active_app_value = getattr(env, "active_app", None)
+    return str(active_app_value) if active_app_value else ""
+
+
 def _initialize_analysis_env(requested_app: str | None) -> AgiEnv:
     apps_path_value = st.session_state.get("apps_path")
     apps_path = Path(apps_path_value).expanduser() if apps_path_value else None
@@ -892,6 +929,36 @@ def discover_views(pages_dir: Union[str, Path]) -> list[Path]:
             out.add(entry.resolve())
 
     return sorted(out, key=lambda p: (p.as_posix(), p.name))
+
+
+def discover_project_notebooks(project_root: str | Path | None) -> dict[str, Path]:
+    """Return project notebook labels mapped to concrete files under <project>/notebooks."""
+    if project_root is None:
+        return {}
+    try:
+        notebooks_root = (Path(project_root).expanduser() / "notebooks").resolve()
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return {}
+    if not notebooks_root.is_dir():
+        return {}
+
+    discovered: dict[str, Path] = {}
+    try:
+        notebook_paths = sorted(notebooks_root.rglob("*.ipynb"), key=lambda path: path.as_posix())
+    except OSError:
+        return {}
+    for notebook_path in notebook_paths:
+        try:
+            rel_path = notebook_path.resolve().relative_to(notebooks_root)
+        except (OSError, ValueError):
+            continue
+        if any(part in _NOTEBOOK_IGNORED_DIRS or part.startswith(".") for part in rel_path.parts):
+            continue
+        if notebook_path.name.endswith("-checkpoint.ipynb"):
+            continue
+        if notebook_path.is_file():
+            discovered[rel_path.as_posix()] = notebook_path.resolve()
+    return discovered
 
 
 def _find_view_entrypoint(view_root: Path) -> Path | None:
@@ -1235,6 +1302,31 @@ def _configured_view_options(
     return _dedupe_preserve_order(options)
 
 
+def _normalize_notebook_name(value: object) -> str:
+    if not isinstance(value, str):
+        return ""
+    normalized = value.strip().replace("\\", "/")
+    while normalized.startswith("/"):
+        normalized = normalized[1:]
+    return normalized
+
+
+def _configured_notebook_options(
+    configured_notebooks: object,
+    available_notebooks: list[str],
+) -> list[str]:
+    """Resolve persisted notebook selections into available multiselect options."""
+    if not isinstance(configured_notebooks, list):
+        return []
+    available = set(available_notebooks)
+    options: list[str] = []
+    for value in configured_notebooks:
+        normalized = _normalize_notebook_name(value)
+        if normalized in available:
+            options.append(normalized)
+    return _dedupe_preserve_order(options)
+
+
 async def _render_selected_view_route(current_page: str | None) -> bool:
     """Render a selected analysis view route and surface one explicit user-facing failure."""
     if not current_page or current_page in ("", "main"):
@@ -1243,6 +1335,19 @@ async def _render_selected_view_route(current_page: str | None) -> bool:
         await render_view_page(Path(current_page))
     except (RuntimeError, OSError, TypeError, ValueError, AttributeError, KeyError, ImportError) as exc:
         st.error(f"Failed to render view: {exc}")
+        st.caption("Full traceback")
+        st.code(traceback.format_exc(), language="text")
+    return True
+
+
+async def _render_selected_notebook_route(current_notebook: str | None) -> bool:
+    """Render a selected notebook route and surface one explicit user-facing failure."""
+    if not current_notebook or current_notebook in ("", "main"):
+        return False
+    try:
+        await render_notebook_page(Path(current_notebook))
+    except (RuntimeError, OSError, TypeError, ValueError, AttributeError, KeyError, ImportError) as exc:
+        st.error(f"Failed to render notebook: {exc}")
         st.caption("Full traceback")
         st.code(traceback.format_exc(), language="text")
     return True
@@ -1488,6 +1593,13 @@ def _analysis_sidebar_view_url(project: str | None, view_path: Path) -> str:
     return f"?{urlencode(params)}"
 
 
+def _analysis_sidebar_notebook_url(project: str | None, notebook_path: Path) -> str:
+    params = {"current_notebook": str(notebook_path.resolve())}
+    if project:
+        params["active_app"] = project
+    return f"?{urlencode(params)}"
+
+
 def _render_analysis_sidebar_view_launcher(
     *,
     project: str | None,
@@ -1538,6 +1650,55 @@ def _render_analysis_sidebar_view_launcher(
         )
     for display_label in missing_views:
         st.sidebar.caption(f"Missing: {display_label}")
+
+
+def _render_analysis_sidebar_notebook_launcher(
+    *,
+    project: str | None,
+    selected_notebooks: list[str],
+    notebook_names: list[str],
+    notebook_lookup: dict[str, Path],
+) -> None:
+    launch_options = list(dict.fromkeys(selected_notebooks or notebook_names))
+    if not launch_options:
+        return
+
+    linked_notebooks = set(selected_notebooks)
+    st.sidebar.markdown("### Notebooks")
+    link_rows: list[str] = []
+    missing_notebooks: list[str] = []
+    for notebook_name in launch_options:
+        notebook_path = notebook_lookup.get(notebook_name)
+        display_label = notebook_name
+        if notebook_path is None:
+            missing_notebooks.append(display_label)
+            continue
+        link_href = html.escape(_analysis_sidebar_notebook_url(project, notebook_path), quote=True)
+        link_label = html.escape(display_label)
+        link_weight = "650" if notebook_name in linked_notebooks else "450"
+        link_rows.append(
+            "<div class='agilab-analysis-notebook-link'>"
+            f"<a href='{link_href}' style='font-weight:{link_weight};'>{link_label}</a>"
+            "</div>"
+        )
+
+    if link_rows:
+        st.sidebar.markdown(
+            (
+                "<style>"
+                ".agilab-analysis-notebook-links{display:flex;flex-direction:column;"
+                "gap:.12rem;margin:.1rem 0 .45rem 0;}"
+                ".agilab-analysis-notebook-link a{font-size:.88rem;line-height:1.18;text-decoration:none;}"
+                ".agilab-analysis-notebook-link a:hover{text-decoration:underline;}"
+                "</style>"
+                "<div class='agilab-analysis-notebook-links'>"
+                + "".join(link_rows)
+                + "</div>"
+            ),
+            unsafe_allow_html=True,
+        )
+    for display_label in missing_notebooks:
+        st.sidebar.caption(f"Missing notebook: {display_label}")
 
 
 def _render_custom_analysis_page_authoring(
@@ -1667,6 +1828,95 @@ async def _render_view_page_inline(view_path: Path, active_app: str) -> None:
                 pass
         sys.modules.pop(module_name, None)
 
+
+def _project_root_for_notebook(notebook_path: Path, active_app_path: Path | None) -> Path:
+    resolved_notebook = notebook_path.resolve()
+    if active_app_path is not None:
+        try:
+            resolved_notebook.relative_to((active_app_path / "notebooks").resolve())
+            return active_app_path.resolve()
+        except (OSError, ValueError):
+            pass
+    for parent in resolved_notebook.parents:
+        if parent.name == "notebooks":
+            return parent.parent
+    return active_app_path.resolve() if active_app_path is not None else resolved_notebook.parent
+
+
+def _notebook_log_paths(notebook_path: Path, logs_root: Path) -> tuple[str, str]:
+    stem = re.sub(r"[^0-9A-Za-z_-]", "_", notebook_path.stem) or "notebook"
+    token = _short_page_token(notebook_path)
+    base = logs_root / f"notebook_{stem}_{token}"
+    return str(base.with_suffix(".log")), str(base.with_suffix(".err"))
+
+
+def _notebook_lab_tree_path(notebook_path: Path, project_root: Path) -> str:
+    try:
+        rel_path = notebook_path.resolve().relative_to(project_root.resolve())
+    except (OSError, ValueError):
+        rel_path = Path(notebook_path.name)
+    return quote(rel_path.as_posix(), safe="/")
+
+
+def _ensure_notebook_sidecar(
+    notebook_key: str,
+    notebook_path: Path,
+    port: int,
+    project_root: Path,
+) -> bool:
+    """Start a local JupyterLab sidecar rooted at the active project."""
+    if _is_port_open(port):
+        return True
+    env = st.session_state["env"]
+    ip = "127.0.0.1"
+    cmd_prefix = env.envars.get(f"{ip}_CMD_PREFIX", "")
+    uv = cmd_prefix + env.uv
+    attempts: list[str] = []
+    last_error = ""
+
+    log_file, err_file = _notebook_log_paths(notebook_path, env.AGILAB_LOG_ABS)
+    env.out_log = log_file
+    env.err_log = err_file
+
+    project_home = str(project_root.resolve())
+    project_home_quoted = shlex.quote(project_home)
+    notebook_arg = shlex.quote(str(notebook_path.resolve()))
+    run_cmd = (
+        f"{uv} --preview-features extra-build-dependencies run "
+        f"--project {project_home_quoted} --with jupyterlab --with ipykernel "
+        f"jupyter lab {notebook_arg} --no-browser "
+        f"--ServerApp.ip=127.0.0.1 --ServerApp.port={port} "
+        f"--ServerApp.open_browser=False --ServerApp.token= --ServerApp.password= "
+        f"--ServerApp.allow_origin={shlex.quote('*')} --ServerApp.disable_check_xsrf=True "
+        f"--ServerApp.root_dir={project_home_quoted}"
+    )
+    env.logger.info("Starting project notebook sidecar: %s", run_cmd)
+    attempts.append(f"Trying JupyterLab sidecar rooted at: {project_home}")
+    run_process = exec_bg(env, run_cmd, cwd=project_home)
+
+    for _ in range(240):
+        if _is_port_open(port):
+            return True
+        if run_process.poll() is not None:
+            break
+        time.sleep(0.1)
+
+    if run_process.poll() is not None and run_process.returncode != 0:
+        last_error = f"Notebook sidecar exited with code {run_process.returncode} for {project_home}"
+        attempts.append(last_error)
+        env.logger.error(last_error)
+    elif run_process.poll() is None:
+        _terminate_process_quietly(run_process)
+        last_error = f"Notebook sidecar did not open port {port} for {project_home}"
+        attempts.append(last_error)
+        env.logger.error(last_error)
+
+    if last_error:
+        env.logger.error("Failed to start notebook sidecar for %s", notebook_path)
+    st.session_state[f"notebook_sidecar_attempts__{notebook_key}"] = attempts
+    return False
+
+
 # --- helper: hide the parent (this page's) Streamlit sidebar when embedding a child ---
 def _hide_parent_sidebar():
     st.markdown(
@@ -1712,6 +1962,7 @@ async def main():
     # Navigation by query param
     qp = st.query_params
     current_page = qp.get("current_page")
+    current_notebook = qp.get("current_notebook")
     requested_app = qp.get("active_app")
 
     if 'env' not in st.session_state:
@@ -1747,7 +1998,9 @@ async def main():
     custom_view_lookup: dict[str, Path] = {}
     pages_root = Path(env.AGILAB_PAGES_ABS)
 
-    # Route: only render a view when the param is a concrete path, not "main"/empty
+    # Route: only render a child surface when the param is concrete, not "main"/empty
+    if await _render_selected_notebook_route(current_notebook):
+        return
     if await _render_selected_view_route(current_page):
         return
 
@@ -1808,6 +2061,27 @@ async def main():
     if st.session_state.get(selection_key) != widget_selection:
         st.session_state[selection_key] = widget_selection
 
+    active_app_path = _active_app_path_for_env(env)
+    notebook_lookup = discover_project_notebooks(active_app_path)
+    notebook_names = list(notebook_lookup.keys())
+    notebook_selection_key = f"notebook_selection__{project or 'default'}"
+    notebooks_cfg = cfg.get("notebooks", {})
+    notebooks_cfg = notebooks_cfg if isinstance(notebooks_cfg, dict) else {}
+    has_notebook_session_selection = notebook_selection_key in st.session_state
+    if has_notebook_session_selection:
+        notebook_widget_selection = _configured_notebook_options(
+            st.session_state.get(notebook_selection_key, []),
+            notebook_names,
+        )
+    else:
+        notebook_widget_selection = _configured_notebook_options(
+            notebooks_cfg.get("selected", []),
+            notebook_names,
+        )
+    if st.session_state.get(notebook_selection_key) != notebook_widget_selection:
+        st.session_state[notebook_selection_key] = notebook_widget_selection
+    selected_notebooks = list(notebook_widget_selection)
+
     _render_analysis_workspace_overview(
         env,
         selection_state=selection_state,
@@ -1823,6 +2097,15 @@ async def main():
             format_func=lambda option: _view_label(option, set(resolved_pages.keys())),
             help="Selected views are persisted in the active project's app settings.",
         )
+
+    if notebook_names:
+        with st.expander("Choose notebooks", expanded=False):
+            selected_notebooks = st.multiselect(
+                "Notebooks",
+                notebook_names,
+                key=notebook_selection_key,
+                help="Selected notebooks are persisted in the active project's app settings.",
+            )
 
     pages_cfg_for_selection = dict(pages_cfg)
     selected_view_set = set(selected_views)
@@ -1849,12 +2132,19 @@ async def main():
         has_session_selection=True,
     )
     selected_views = list(selection_state.selected_views)
+    selected_notebooks = [name for name in selected_notebooks if name in notebook_lookup]
     _render_analysis_sidebar_view_launcher(
         project=project,
         selected_views=selected_views,
         view_names=view_names,
         resolved_pages=resolved_pages,
         custom_view_lookup=custom_view_lookup,
+    )
+    _render_analysis_sidebar_notebook_launcher(
+        project=project,
+        selected_notebooks=selected_notebooks,
+        notebook_names=notebook_names,
+        notebook_lookup=notebook_lookup,
     )
 
     persisted_pages = cfg.setdefault("pages", {})
@@ -1871,6 +2161,16 @@ async def main():
     if "default_view" in persisted_pages:
         del persisted_pages["default_view"]
         config_changed = True
+
+    if notebook_names or isinstance(cfg.get("notebooks"), dict):
+        persisted_notebooks = cfg.setdefault("notebooks", {})
+        if not isinstance(persisted_notebooks, dict):
+            persisted_notebooks = {}
+            cfg["notebooks"] = persisted_notebooks
+            config_changed = True
+        if persisted_notebooks.get("selected") != selected_notebooks:
+            persisted_notebooks["selected"] = selected_notebooks
+            config_changed = True
     if config_changed:
         _write_config(app_settings, cfg)
 
@@ -1882,6 +2182,77 @@ async def main():
         custom_view_lookup=custom_view_lookup,
         all_available_views=all_available_views,
     )
+
+
+async def render_notebook_page(notebook_path: Path):
+    """Render a project notebook by launching JupyterLab as a project-rooted sidecar."""
+    env = st.session_state["env"]
+    resolved_notebook = Path(notebook_path).expanduser().resolve()
+    if resolved_notebook.suffix.lower() != ".ipynb":
+        raise ValueError(f"Selected notebook is not an .ipynb file: {resolved_notebook}")
+    if not resolved_notebook.exists():
+        raise FileNotFoundError(f"Notebook does not exist: {resolved_notebook}")
+
+    active_app_path = _active_app_path_for_env(env)
+    project_root = _project_root_for_notebook(resolved_notebook, active_app_path)
+    try:
+        notebook_label = resolved_notebook.relative_to(project_root / "notebooks").as_posix()
+    except ValueError:
+        notebook_label = resolved_notebook.name
+
+    _hide_parent_sidebar()
+
+    back_col, title_col, _ = st.columns([1, 6, 1])
+    with back_col:
+        if st.button("← Back to Analysis", type="primary"):
+            st.query_params["current_notebook"] = ""
+            st.query_params["current_page"] = "main"
+            st.rerun()
+    with title_col:
+        st.subheader(f"Notebook: `{notebook_label}`")
+
+    if _is_hosted_analysis_runtime(env):
+        st.warning("Notebook sidecars are available in local AGILAB runtimes only.")
+        return
+
+    notebook_key = f"{notebook_label}|{project_root.as_posix()}"
+    port = _port_for(f"notebook|{notebook_key}")
+    sidecar_ready = _ensure_notebook_sidecar(notebook_key, resolved_notebook, port, project_root)
+
+    qp = st.query_params
+    extras = {}
+    for key, value in qp.items():
+        if key in {"current_page", "current_notebook"}:
+            continue
+        extras[key] = value
+    extras["embed"] = "true"
+    query = urlencode(extras, doseq=True)
+    notebook_url_path = _notebook_lab_tree_path(resolved_notebook, project_root)
+    if not sidecar_ready:
+        env.logger.error("Notebook sidecar failed to start for %s on port %s.", resolved_notebook, port)
+        log_file, err_file = _notebook_log_paths(resolved_notebook, env.AGILAB_LOG_ABS)
+        logs = Path(log_file)
+        errors = Path(err_file)
+        st.error("The notebook sidecar did not start correctly.", icon="⚠️")
+        st.caption("If this persists, check logs and sidecar attempts below.")
+        with st.expander("Notebook sidecar logs", expanded=True):
+            if logs.exists():
+                st.code(logs.read_text(encoding="utf-8", errors="ignore"), language="bash")
+            else:
+                st.write("No log file found.")
+            if errors.exists():
+                st.code(errors.read_text(encoding="utf-8", errors="ignore"), language="bash")
+            else:
+                st.write("No error log file found.")
+            sidecar_attempts = st.session_state.get(f"notebook_sidecar_attempts__{notebook_key}", [])
+            if sidecar_attempts:
+                st.markdown("Attempt summary:")
+                st.code("\n".join(sidecar_attempts), language="bash")
+        return
+    url = f"http://127.0.0.1:{port}/lab/tree/{notebook_url_path}?{query}"
+    env.logger.info("notebook url: %s", url)
+    st.iframe(url, height=900)
+
 
 async def render_view_page(view_path: Path):
     """Render a specific view by launching it as a sidecar app in its own venv and iframing it."""
@@ -1901,23 +2272,7 @@ async def render_view_page(view_path: Path):
     # --- sidecar per-view run + iframe embed ---
     # Unique key for port hashing (works even if two Page share the same filename)
     view_key = f"{view_path.stem}|{view_path.parent.as_posix()}"
-    active_app_path: Path | None = None
-    if env.apps_path:
-        for name in (env.target, env.app):
-            if name:
-                candidate = Path(env.apps_path) / name
-                if candidate.exists():
-                    active_app_path = candidate
-                    break
-    if active_app_path is None and env.active_app:
-        candidate = Path(env.active_app)
-        if candidate.exists():
-            active_app_path = candidate
-
-    if active_app_path is None and env.active_app:
-        active_app_arg = str(env.active_app)
-    else:
-        active_app_arg = str(active_app_path) if active_app_path else ""
+    active_app_arg = _active_app_arg_for_env(env)
 
     if _is_hosted_analysis_runtime(env):
         env.logger.info("Hosted runtime detected; rendering analysis view inline: %s", view_path)
@@ -1931,7 +2286,7 @@ async def render_view_page(view_path: Path):
     qp = st.query_params
     extras = {}
     for k, v in qp.items():
-        if k == "current_page":
+        if k in {"current_page", "current_notebook"}:
             continue
         extras[k] = v
     extras["embed"] = "true"

--- a/src/agilab/pipeline_editor.py
+++ b/src/agilab/pipeline_editor.py
@@ -184,6 +184,28 @@ def _notebook_import_module_name(module_dir: Path) -> str:
     return module or "lab_stages"
 
 
+def _notebook_import_preview_is_safe(preview: Dict[str, Any]) -> bool:
+    preflight = preview.get("preflight", {})
+    return isinstance(preflight, dict) and preflight.get("safe_to_import") is True
+
+
+def _notebook_import_blocking_detail(preflight: Any) -> str:
+    if not isinstance(preflight, dict):
+        return "Notebook preflight did not produce a valid report."
+    risks = preflight.get("risks", [])
+    if isinstance(risks, list):
+        messages: list[str] = []
+        for risk in risks:
+            if not isinstance(risk, dict) or risk.get("level") != "error":
+                continue
+            message = str(risk.get("message") or risk.get("rule") or "").strip()
+            if message:
+                messages.append(message)
+        if messages:
+            return "; ".join(messages[:3])
+    return "Notebook import preflight marked this notebook unsafe to import."
+
+
 def build_notebook_import_preview(
     uploaded_file: Any,
     module_dir: Path,
@@ -233,6 +255,8 @@ def write_notebook_import_preview(
     preview: Dict[str, Any],
     module_dir: Path,
     stages_file: Path,
+    *,
+    view_manifest_dir: Path | None = None,
 ) -> int:
     """Persist a previously built notebook import preview."""
     module_dir = Path(module_dir)
@@ -250,7 +274,7 @@ def write_notebook_import_preview(
     contract_path = module_dir / "notebook_import_contract.json"
     pipeline_view_path = module_dir / "notebook_import_pipeline_view.json"
     view_plan_path = module_dir / "notebook_import_view_plan.json"
-    view_manifest_path = discover_notebook_import_view_manifest(module_dir)
+    view_manifest_path = discover_notebook_import_view_manifest(view_manifest_dir or module_dir)
     write_notebook_import_contract(
         contract_path,
         notebook_import,
@@ -910,14 +934,25 @@ def notebook_to_toml(
     uploaded_file: Any,
     toml_file_name: str,
     module_dir: Path,
+    *,
+    view_manifest_dir: Path | None = None,
 ) -> int:
     """Convert uploaded Jupyter notebook file to a TOML file."""
     preview = build_notebook_import_preview(uploaded_file, module_dir)
     if preview is None:
         return 0
+    if not _notebook_import_preview_is_safe(preview):
+        detail = _notebook_import_blocking_detail(preview.get("preflight", {}))
+        _emit_streamlit_message("error", f"Notebook import is blocked: {detail}")
+        return 0
     try:
         stages_file = Path(module_dir) / toml_file_name
-        return write_notebook_import_preview(preview, module_dir, stages_file)
+        return write_notebook_import_preview(
+            preview,
+            module_dir,
+            stages_file,
+            view_manifest_dir=view_manifest_dir,
+        )
     except (OSError, TypeError, ValueError) as e:
         _emit_streamlit_message("error", f"Failed to save TOML file: {e}")
         logger.error(
@@ -931,6 +966,7 @@ def on_preview_notebook_import(
     key: str,
     module_dir: Path,
     index_page: str,
+    view_manifest_dir: Path | None = None,
 ) -> None:
     """Build a notebook import preview from the sidebar uploader without writing files."""
     uploaded_file = st.session_state.get(key)
@@ -965,6 +1001,8 @@ def confirm_notebook_import_preview(
     module_dir: Path,
     stages_file: Path,
     index_page: str,
+    *,
+    view_manifest_dir: Path | None = None,
 ) -> int:
     """Persist the current notebook import preview and update editor state."""
     preview_key = _notebook_import_preview_key(index_page)
@@ -972,8 +1010,17 @@ def confirm_notebook_import_preview(
     if not isinstance(preview, dict):
         _emit_streamlit_message("error", "No notebook import preview is available.")
         return 0
+    if not _notebook_import_preview_is_safe(preview):
+        detail = _notebook_import_blocking_detail(preview.get("preflight", {}))
+        _emit_streamlit_message("error", f"Notebook import is blocked: {detail}")
+        return 0
     try:
-        cell_count = write_notebook_import_preview(preview, module_dir, stages_file)
+        cell_count = write_notebook_import_preview(
+            preview,
+            module_dir,
+            stages_file,
+            view_manifest_dir=view_manifest_dir,
+        )
     except (OSError, TypeError, ValueError) as exc:
         _emit_streamlit_message("error", f"Failed to save notebook import preview: {exc}")
         logger.error(
@@ -1003,6 +1050,8 @@ def render_notebook_import_preview(
     module_dir: Path,
     stages_file: Path,
     index_page: str,
+    *,
+    view_manifest_dir: Path | None = None,
 ) -> None:
     """Render confirm/cancel controls for the current notebook import preview."""
     preview = st.session_state.get(_notebook_import_preview_key(index_page))
@@ -1021,11 +1070,23 @@ def render_notebook_import_preview(
             f"{int(summary.get('output_count', 0) or 0)} output(s), "
             f"{int(risk_counts.get('warning', 0) or 0)} warning(s)."
         )
+    if not _notebook_import_preview_is_safe(preview):
+        error = getattr(sidebar, "error", None)
+        if callable(error):
+            error(f"Notebook import blocked: {_notebook_import_blocking_detail(preflight)}")
     button = getattr(sidebar, "button", None)
     if not callable(button):
         return
-    if button("Import preview", key=f"{index_page}__confirm_notebook_import"):
-        confirm_notebook_import_preview(module_dir, stages_file, index_page)
+    if _notebook_import_preview_is_safe(preview) and button(
+        "Import preview",
+        key=f"{index_page}__confirm_notebook_import",
+    ):
+        confirm_notebook_import_preview(
+            module_dir,
+            stages_file,
+            index_page,
+            view_manifest_dir=view_manifest_dir,
+        )
     if button("Cancel import", key=f"{index_page}__cancel_notebook_import"):
         cancel_notebook_import_preview(index_page)
 

--- a/test/test_analysis_page_helpers.py
+++ b/test/test_analysis_page_helpers.py
@@ -90,6 +90,48 @@ def test_analysis_sidebar_view_url_encodes_project_and_path(tmp_path: Path):
     assert "view+maps.py" in url or "view%20maps.py" in url
 
 
+def test_analysis_sidebar_notebook_url_encodes_project_and_path(tmp_path: Path):
+    module = _load_analysis_module()
+    notebook_path = tmp_path / "flight notebook.ipynb"
+
+    url = module._analysis_sidebar_notebook_url("flight_project", notebook_path)
+
+    assert url.startswith("?")
+    assert "active_app=flight_project" in url
+    assert "current_notebook=" in url
+    assert "flight+notebook.ipynb" in url or "flight%20notebook.ipynb" in url
+
+
+def test_discover_project_notebooks_skips_checkpoints_and_sorts(tmp_path: Path):
+    module = _load_analysis_module()
+    project_root = tmp_path / "flight_project"
+    notebooks_root = project_root / "notebooks"
+    (notebooks_root / "extra").mkdir(parents=True)
+    (notebooks_root / ".ipynb_checkpoints").mkdir()
+    (notebooks_root / "lab_stages.ipynb").write_text("{}", encoding="utf-8")
+    (notebooks_root / "extra" / "demo.ipynb").write_text("{}", encoding="utf-8")
+    (notebooks_root / ".ipynb_checkpoints" / "lab_stages-checkpoint.ipynb").write_text(
+        "{}",
+        encoding="utf-8",
+    )
+
+    notebooks = module.discover_project_notebooks(project_root)
+
+    assert list(notebooks) == ["extra/demo.ipynb", "lab_stages.ipynb"]
+    assert notebooks["lab_stages.ipynb"] == (notebooks_root / "lab_stages.ipynb").resolve()
+
+
+def test_configured_notebook_options_filters_unavailable_entries():
+    module = _load_analysis_module()
+
+    selected = module._configured_notebook_options(
+        ["lab_stages.ipynb", "missing.ipynb", "extra\\demo.ipynb", "lab_stages.ipynb"],
+        ["extra/demo.ipynb", "lab_stages.ipynb"],
+    )
+
+    assert selected == ["lab_stages.ipynb", "extra/demo.ipynb"]
+
+
 def test_resolve_discovered_views_skips_broken_entry(tmp_path: Path, monkeypatch):
     module = _load_analysis_module()
     good_view = tmp_path / "good_view.py"
@@ -189,6 +231,55 @@ def test_render_view_page_embeds_sidecar_with_streamlit_iframe(tmp_path: Path, m
 
     assert calls == [
         ("http://127.0.0.1:8765/?datadir_rel=sample&embed=true", {"height": 900})
+    ]
+
+
+def test_render_notebook_page_embeds_project_jupyter_sidecar(tmp_path: Path, monkeypatch):
+    module = _load_analysis_module()
+    project_root = tmp_path / "apps" / "flight_project"
+    notebook_path = project_root / "notebooks" / "lab_stages.ipynb"
+    notebook_path.parent.mkdir(parents=True)
+    notebook_path.write_text("{}", encoding="utf-8")
+    calls: list[tuple[str, dict[str, object]]] = []
+
+    class _Column:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+    fake_logger = SimpleNamespace(info=lambda *_args, **_kwargs: None, error=lambda *_args, **_kwargs: None)
+    fake_env = SimpleNamespace(
+        apps_path=project_root.parent,
+        target=None,
+        app="flight_project",
+        active_app="",
+        AGILAB_LOG_ABS=tmp_path,
+        logger=fake_logger,
+    )
+    fake_st = SimpleNamespace(
+        session_state={"env": fake_env},
+        query_params={"current_notebook": str(notebook_path), "active_app": "flight_project"},
+        columns=lambda _spec: [_Column(), _Column(), _Column()],
+        button=lambda *_args, **_kwargs: False,
+        subheader=lambda *_args, **_kwargs: None,
+        iframe=lambda src, **kwargs: calls.append((src, kwargs)),
+    )
+
+    monkeypatch.setattr(module, "st", fake_st)
+    monkeypatch.setattr(module, "_hide_parent_sidebar", lambda: None)
+    monkeypatch.setattr(module, "_is_hosted_analysis_runtime", lambda _env: False)
+    monkeypatch.setattr(module, "_ensure_notebook_sidecar", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(module, "_port_for", lambda _key: 8766)
+
+    asyncio.run(module.render_notebook_page(notebook_path))
+
+    assert calls == [
+        (
+            "http://127.0.0.1:8766/lab/tree/notebooks/lab_stages.ipynb?active_app=flight_project&embed=true",
+            {"height": 900},
+        )
     ]
 
 

--- a/test/test_analysis_page_helpers.py
+++ b/test/test_analysis_page_helpers.py
@@ -283,6 +283,51 @@ def test_render_notebook_page_embeds_project_jupyter_sidecar(tmp_path: Path, mon
     ]
 
 
+def test_ensure_notebook_sidecar_starts_lab_root_and_allows_iframe(tmp_path: Path, monkeypatch):
+    module = _load_analysis_module()
+    project_root = tmp_path / "apps" / "flight_project"
+    notebook_path = project_root / "notebooks" / "lab_stages.ipynb"
+    notebook_path.parent.mkdir(parents=True)
+    notebook_path.write_text("{}", encoding="utf-8")
+    commands: list[tuple[str, str]] = []
+    port_checks = iter([False, True])
+
+    class _FakeProcess:
+        returncode = None
+
+        def poll(self):
+            return None
+
+    fake_logger = SimpleNamespace(info=lambda *_args, **_kwargs: None, error=lambda *_args, **_kwargs: None)
+    fake_env = SimpleNamespace(
+        envars={},
+        uv="uv --quiet",
+        AGILAB_LOG_ABS=tmp_path,
+        logger=fake_logger,
+    )
+    fake_st = SimpleNamespace(session_state={"env": fake_env})
+
+    monkeypatch.setattr(module, "st", fake_st)
+    monkeypatch.setattr(module, "_is_port_open", lambda _port: next(port_checks))
+
+    def _fake_exec_bg(_env, cmd: str, cwd: str, process_env=None):
+        commands.append((cmd, cwd))
+        return _FakeProcess()
+
+    monkeypatch.setattr(module, "exec_bg", _fake_exec_bg)
+
+    assert module._ensure_notebook_sidecar("notebook-key", notebook_path, 8766, project_root) is True
+
+    assert len(commands) == 1
+    command, cwd = commands[0]
+    assert cwd == str(project_root.resolve())
+    assert "jupyter lab --no-browser" in command
+    assert str(notebook_path.resolve()) not in command
+    assert "--ServerApp.root_dir=" in command
+    assert "--ServerApp.tornado_settings=" in command
+    assert "frame-ancestors *;" in command
+
+
 def test_resolve_default_view_accepts_named_view(tmp_path: Path):
     module = _load_analysis_module()
     view_path = tmp_path / "view_maps_network.py"

--- a/test/test_notebook_import_preflight.py
+++ b/test/test_notebook_import_preflight.py
@@ -131,6 +131,44 @@ def test_notebook_import_preflight_flags_generic_risks_and_contract(tmp_path: Pa
     assert "artifacts/orders.parquet" in view_plan["matched_views"][0]["matched_artifacts"]
 
 
+def test_supervisor_notebook_import_preserves_artifact_role_inference() -> None:
+    core_module = _load_module(CORE_PATH, "notebook_import_preflight_supervisor_roles_module")
+    source = "\n".join(
+        [
+            "import pandas as pd",
+            "df = pd.read_csv('shared/orders.csv')",
+            "df.to_parquet('shared/summary.parquet')",
+        ]
+    )
+    imported = core_module.build_notebook_pipeline_import(
+        notebook={
+            "cells": [],
+            "metadata": {
+                "agilab": {
+                    "stages": [
+                        {
+                            "description": "Build shared summary",
+                            "question": "Summarize orders.",
+                            "code": source,
+                        }
+                    ]
+                }
+            },
+            "nbformat": 4,
+            "nbformat_minor": 5,
+        },
+        source_notebook="supervisor.ipynb",
+    )
+
+    preflight = core_module.build_notebook_import_preflight(imported)
+
+    assert imported["source"]["import_mode"] == "agilab_supervisor_metadata"
+    assert imported["pipeline_stages"][0]["source_cell_index"] == 1
+    assert preflight["artifact_contract"]["inputs"] == ["shared/orders.csv"]
+    assert preflight["artifact_contract"]["outputs"] == ["shared/summary.parquet"]
+    assert preflight["artifact_contract"]["unknown"] == []
+
+
 def test_notebook_import_preflight_report_writes_contract(tmp_path: Path) -> None:
     module = _load_module(REPORT_PATH, "notebook_import_preflight_report_test_module")
     notebook_path = tmp_path / "risky.ipynb"

--- a/test/test_orchestrate_distribution.py
+++ b/test/test_orchestrate_distribution.py
@@ -401,6 +401,55 @@ def test_orchestrate_distribution_import_fallback_sets_matplotlib_error():
     assert isinstance(module._MATPLOTLIB_IMPORT_ERROR, ModuleNotFoundError)
 
 
+def test_orchestrate_distribution_import_fallback_sets_networkx_error():
+    module = _load_module_with_missing(
+        "agilab.orchestrate_distribution_no_networkx",
+        "src/agilab/orchestrate_distribution.py",
+        "networkx",
+    )
+    warnings: list[str] = []
+
+    module.st = SimpleNamespace(warning=warnings.append)
+
+    assert module.nx is None
+    assert isinstance(module._NETWORKX_IMPORT_ERROR, ModuleNotFoundError)
+    module.show_tree(["127.0.0.1-0"], [[("p1", 1)]], [[["file.csv"]]], "partition", "size")
+    assert warnings
+    assert "agilab[ui]" in warnings[0]
+
+
+def test_orchestrate_page_import_survives_missing_networkx():
+    module_name = "agilab_page_orchestrate_missing_networkx"
+    module_path = Path("src/agilab/pages/2_ORCHESTRATE.py")
+    original_import = __import__
+    removed_modules = {
+        name: sys.modules.pop(name, None)
+        for name in ("agilab.orchestrate_distribution", "agilab.orchestrate_execute")
+    }
+
+    def _patched_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name in {"networkx", "networkx.readwrite"}:
+            raise ModuleNotFoundError(name)
+        return original_import(name, globals, locals, fromlist, level)
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr("builtins.__import__", _patched_import)
+        importlib.invalidate_caches()
+        spec = importlib.util.spec_from_file_location(module_name, module_path)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+        try:
+            spec.loader.exec_module(module)
+        finally:
+            for name, previous in removed_modules.items():
+                if previous is not None:
+                    sys.modules[name] = previous
+
+    assert callable(module.show_graph)
+    assert callable(module.render_execute_section)
+
+
 def test_workload_barchart_emits_plotly_figure(monkeypatch):
     plotted = []
 

--- a/test/test_orchestrate_execute.py
+++ b/test/test_orchestrate_execute.py
@@ -36,8 +36,8 @@ def _import_agilab_module(module_name: str):
 orchestrate_execute = _import_agilab_module("agilab.orchestrate_execute")
 
 
-def _load_orchestrate_execute_with_missing_matplotlib():
-    module_name = "agilab.orchestrate_execute_missing_matplotlib"
+def _load_orchestrate_execute_with_missing(module_suffix: str, *missing_modules: str):
+    module_name = f"agilab.orchestrate_execute_missing_{module_suffix}"
     module_path = Path("src/agilab/orchestrate_execute.py")
     spec = importlib.util.spec_from_file_location(module_name, module_path)
     assert spec is not None and spec.loader is not None
@@ -45,7 +45,7 @@ def _load_orchestrate_execute_with_missing_matplotlib():
     original_import = __import__
 
     def _patched_import(name, globals=None, locals=None, fromlist=(), level=0):
-        if name in {"matplotlib", "matplotlib.pyplot"}:
+        if name in missing_modules:
             raise ModuleNotFoundError(name)
         return original_import(name, globals, locals, fromlist, level)
 
@@ -59,6 +59,14 @@ def _load_orchestrate_execute_with_missing_matplotlib():
     finally:
         builtins.__import__ = previous
     return module
+
+
+def _load_orchestrate_execute_with_missing_matplotlib():
+    return _load_orchestrate_execute_with_missing("matplotlib", "matplotlib", "matplotlib.pyplot")
+
+
+def _load_orchestrate_execute_with_missing_networkx():
+    return _load_orchestrate_execute_with_missing("networkx", "networkx", "networkx.readwrite")
 
 
 def test_collect_candidate_roots_deduplicates_paths(tmp_path):
@@ -480,6 +488,17 @@ def test_render_graph_preview_requires_matplotlib(monkeypatch):
 
     with pytest.raises(RuntimeError, match="matplotlib unavailable"):
         orchestrate_execute._render_graph_preview(graph, None)
+
+
+def test_orchestrate_execute_import_survives_missing_networkx():
+    module = _load_orchestrate_execute_with_missing_networkx()
+
+    assert module.nx is None
+    assert module.json_graph is None
+    assert isinstance(module._NETWORKX_IMPORT_ERROR, ModuleNotFoundError)
+    assert module._is_networkx_graph(object()) is False
+    with pytest.raises(RuntimeError, match=r"agilab\[ui\]"):
+        module._render_graph_preview(object(), None)
 
 
 @pytest.mark.parametrize(

--- a/test/test_pipeline_editor.py
+++ b/test/test_pipeline_editor.py
@@ -1078,6 +1078,163 @@ optional_artifacts = ["data/*.csv"]
     assert ("revision", "bump") in messages
 
 
+def test_confirm_notebook_import_preview_uses_app_manifest_without_writing_to_app(monkeypatch, tmp_path):
+    messages: list[tuple[str, str]] = []
+    uploaded = SimpleNamespace(
+        name="flight.ipynb",
+        type="application/x-ipynb+json",
+        read=lambda: json.dumps(
+            {
+                "cells": [
+                    {"cell_type": "markdown", "source": ["# Flight analysis\n"]},
+                    {
+                        "cell_type": "code",
+                        "source": [
+                            "import pandas as pd\n",
+                            "df = pd.read_csv('flight/raw/input.csv')\n",
+                            "df.to_parquet('flight/dataframe/output.parquet')\n",
+                        ],
+                    },
+                ]
+            }
+        ).encode("utf-8"),
+    )
+    fake_st = SimpleNamespace(
+        session_state=_State({"idx": [0, "", "", "", "", "", 0]}),
+        error=lambda message, *args, **kwargs: messages.append(("error", message)),
+        info=lambda message, *args, **kwargs: messages.append(("info", message)),
+        warning=lambda message, *args, **kwargs: messages.append(("warning", message)),
+        success=lambda message, *args, **kwargs: messages.append(("success", message)),
+    )
+    monkeypatch.setattr(pipeline_editor, "st", fake_st)
+    monkeypatch.setattr(pipeline_editor, "_bump_history_revision", lambda: messages.append(("revision", "bump")))
+
+    export_dir = tmp_path / "exported_notebooks" / "flight_project"
+    app_dir = tmp_path / "apps" / "builtin" / "flight_project"
+    app_dir.mkdir(parents=True)
+    (app_dir / "notebook_import_views.toml").write_text(
+        """
+schema = "agilab.notebook_import_views.v1"
+app = "flight_project"
+
+[[views]]
+id = "flight_maps"
+module = "view_maps"
+required_artifacts_any = ["flight/dataframe/*.parquet"]
+optional_artifacts = ["flight/raw/*.csv"]
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    preview = pipeline_editor.build_notebook_import_preview(uploaded, export_dir)
+    fake_st.session_state["idx__notebook_import_preview"] = preview
+
+    count = pipeline_editor.confirm_notebook_import_preview(
+        export_dir,
+        export_dir / "lab_stages.toml",
+        "idx",
+        view_manifest_dir=app_dir,
+    )
+
+    view_plan = json.loads((export_dir / "notebook_import_view_plan.json").read_text(encoding="utf-8"))
+    assert count == 1
+    assert (export_dir / "lab_stages.toml").is_file()
+    assert (export_dir / "notebook_import_contract.json").is_file()
+    assert not (app_dir / "notebook_import_contract.json").exists()
+    assert view_plan["status"] == "matched"
+    assert view_plan["matched_views"][0]["module"] == "view_maps"
+    assert set(view_plan["matched_views"][0]["matched_artifacts"]) == {
+        "flight/dataframe/output.parquet",
+        "flight/raw/input.csv",
+    }
+    assert ("revision", "bump") in messages
+
+
+def test_confirm_notebook_import_preview_blocks_unsafe_preflight(monkeypatch, tmp_path):
+    messages: list[tuple[str, str]] = []
+    uploaded = SimpleNamespace(
+        name="empty.ipynb",
+        type="application/x-ipynb+json",
+        read=lambda: json.dumps(
+            {"cells": [{"cell_type": "markdown", "source": ["# Notes only\n"]}]}
+        ).encode("utf-8"),
+    )
+    fake_st = SimpleNamespace(
+        session_state=_State({"idx": [0, "", "", "", "", "", 0]}),
+        error=lambda message, *args, **kwargs: messages.append(("error", message)),
+        success=lambda message, *args, **kwargs: messages.append(("success", message)),
+    )
+    monkeypatch.setattr(pipeline_editor, "st", fake_st)
+    monkeypatch.setattr(pipeline_editor, "_bump_history_revision", lambda: messages.append(("revision", "bump")))
+
+    module_dir = tmp_path / "demo_project"
+    preview = pipeline_editor.build_notebook_import_preview(uploaded, module_dir)
+    fake_st.session_state["idx__notebook_import_preview"] = preview
+
+    count = pipeline_editor.confirm_notebook_import_preview(
+        module_dir,
+        module_dir / "lab_stages.toml",
+        "idx",
+    )
+
+    assert count == 0
+    assert not (module_dir / "lab_stages.toml").exists()
+    assert not (module_dir / "notebook_import_contract.json").exists()
+    assert "idx__notebook_import_preview" in fake_st.session_state
+    assert "page_broken" not in fake_st.session_state
+    assert messages == [
+        ("error", "Notebook import is blocked: Notebook import produced no runnable code cells.")
+    ]
+
+
+def test_render_notebook_import_preview_hides_import_button_for_blocked_preflight(monkeypatch, tmp_path):
+    messages: list[tuple[str, str]] = []
+    button_labels: list[str] = []
+
+    def _button(label, *args, **kwargs):
+        button_labels.append(label)
+        return True
+
+    sidebar = SimpleNamespace(
+        caption=lambda message, *args, **kwargs: messages.append(("caption", message)),
+        error=lambda message, *args, **kwargs: messages.append(("error", message)),
+        button=_button,
+    )
+    fake_st = SimpleNamespace(
+        session_state=_State(
+            {
+                "idx__notebook_import_preview": {
+                    "cell_count": 0,
+                    "preflight": {
+                        "safe_to_import": False,
+                        "summary": {"pipeline_stage_count": 0, "input_count": 0, "output_count": 0},
+                        "risk_counts": {"error": 1},
+                        "risks": [
+                            {
+                                "level": "error",
+                                "message": "Notebook import produced no runnable code cells.",
+                            }
+                        ],
+                    },
+                }
+            }
+        ),
+        sidebar=sidebar,
+    )
+    monkeypatch.setattr(pipeline_editor, "st", fake_st)
+
+    pipeline_editor.render_notebook_import_preview(
+        tmp_path / "demo_project",
+        tmp_path / "demo_project" / "lab_stages.toml",
+        "idx",
+    )
+
+    assert button_labels == ["Cancel import"]
+    assert "idx__notebook_import_preview" not in fake_st.session_state
+    assert ("error", "Notebook import blocked: Notebook import produced no runnable code cells.") in messages
+
+
 def test_display_history_tab_filters_and_saves_editor_content(monkeypatch, tmp_path):
     stages_file = tmp_path / "lab_stages.toml"
     stages_file.write_text(

--- a/test/test_ui_pages.py
+++ b/test/test_ui_pages.py
@@ -1053,6 +1053,10 @@ def test_flight_app_args_form_hf_seed_dataset_missing_is_informational(monkeypat
 
 def test_explore_page_multiselect(mock_ui_env):
     """Test the EXPLORE page multiselect and button rendering."""
+    notebooks_dir = mock_ui_env["project_dir"] / "notebooks"
+    notebooks_dir.mkdir()
+    (notebooks_dir / "lab_stages.ipynb").write_text("{}", encoding="utf-8")
+
     at = _app_test("src/agilab/pages/4_ANALYSIS.py")
     at.query_params["current_page"] = "main"
     env = AgiEnv(apps_path=mock_ui_env["apps_dir"], app="flight_project", verbose=0)
@@ -1091,6 +1095,10 @@ def test_explore_page_multiselect(mock_ui_env):
     assert "agilab-analysis-view-links" in sidebar_markdown
     assert "current_page=" in sidebar_markdown
     assert "view_maps" in sidebar_markdown
+    assert "### Notebooks" in sidebar_markdown
+    assert "agilab-analysis-notebook-links" in sidebar_markdown
+    assert "current_notebook=" in sidebar_markdown
+    assert "lab_stages.ipynb" in sidebar_markdown
     sidebar_buttons = [button.label for button in at.sidebar.button]
     assert "view_maps" not in sidebar_buttons
     assert not [selectbox for selectbox in at.sidebar.selectbox if selectbox.key == "analysis_sidebar_view__flight_project"]
@@ -1100,6 +1108,8 @@ def test_explore_page_multiselect(mock_ui_env):
     ms = at.multiselect(key=selection_key)
     
     assert "view_maps" in ms.options
+    notebook_ms = at.multiselect(key="notebook_selection__flight_project")
+    assert "lab_stages.ipynb" in notebook_ms.options
     
     # Select it
     ms.select("view_maps").run()
@@ -1223,6 +1233,52 @@ def test_explore_page_sidebar_view_selection_persists(mock_ui_env):
     assert "view_maps" not in reloaded_sidebar_markdown
     assert "view_barycentric" in reloaded_sidebar_markdown
     assert "current_page=" in reloaded_sidebar_markdown
+
+
+def test_explore_page_sidebar_notebook_selection_persists(mock_ui_env):
+    """ANALYSIS persists selected project notebook launcher links."""
+    notebooks_dir = mock_ui_env["project_dir"] / "notebooks"
+    (notebooks_dir / "extra").mkdir(parents=True)
+    (notebooks_dir / "lab_stages.ipynb").write_text("{}", encoding="utf-8")
+    (notebooks_dir / "extra" / "demo.ipynb").write_text("{}", encoding="utf-8")
+
+    at = _app_test("src/agilab/pages/4_ANALYSIS.py")
+    at.query_params["current_page"] = "main"
+    env = AgiEnv(apps_path=mock_ui_env["apps_dir"], app="flight_project", verbose=0)
+    settings_file = env.resolve_user_app_settings_file("flight_project")
+    settings_file.write_text(
+        "[pages]\nview_module = []\n[notebooks]\nselected = []\n",
+        encoding="utf-8",
+    )
+    at.session_state["env"] = env
+
+    at.run()
+
+    assert not at.exception
+    selection_key = "notebook_selection__flight_project"
+    at.multiselect(key=selection_key).select("extra/demo.ipynb").run()
+
+    assert not at.exception
+    with settings_file.open("rb") as f:
+        settings_payload = tomllib.load(f)
+    assert settings_payload["notebooks"]["selected"] == ["extra/demo.ipynb"]
+    sidebar_markdown = "\n".join(str(item.value) for item in at.sidebar.markdown)
+    assert "### Notebooks" in sidebar_markdown
+    assert "extra/demo.ipynb" in sidebar_markdown
+    assert "lab_stages.ipynb" not in sidebar_markdown
+    assert "current_notebook=" in sidebar_markdown
+
+    reloaded = _app_test("src/agilab/pages/4_ANALYSIS.py")
+    reloaded.query_params["current_page"] = "main"
+    reloaded.session_state["env"] = env
+    reloaded.run()
+
+    assert not reloaded.exception
+    assert reloaded.session_state[selection_key] == ["extra/demo.ipynb"]
+    reloaded_sidebar_markdown = "\n".join(str(item.value) for item in reloaded.sidebar.markdown)
+    assert "extra/demo.ipynb" in reloaded_sidebar_markdown
+    assert "lab_stages.ipynb" not in reloaded_sidebar_markdown
+    assert "current_notebook=" in reloaded_sidebar_markdown
 
 
 def test_explore_page_sidebar_links_initialize_from_view_module(mock_ui_env):

--- a/test/test_ui_pages.py
+++ b/test/test_ui_pages.py
@@ -1082,6 +1082,7 @@ def test_explore_page_multiselect(mock_ui_env):
     assert "Output files" in markdown_text
     assert "Latest output" in markdown_text
     assert "Views selected" in markdown_text
+    assert "Notebooks selected" in markdown_text
     assert "Available views" not in markdown_text
     assert "selected / available" not in markdown_text
     assert "agilab-header-value--incomplete" in markdown_text
@@ -1262,6 +1263,10 @@ def test_explore_page_sidebar_notebook_selection_persists(mock_ui_env):
     with settings_file.open("rb") as f:
         settings_payload = tomllib.load(f)
     assert settings_payload["notebooks"]["selected"] == ["extra/demo.ipynb"]
+    markdown_text = "\n".join(str(item.value) for item in at.markdown)
+    assert "Notebooks selected" in markdown_text
+    assert "1 linked to flight_project" in markdown_text
+    assert "agilab-header-value agilab-header-value--ready'>1/2</div>" in markdown_text
     sidebar_markdown = "\n".join(str(item.value) for item in at.sidebar.markdown)
     assert "### Notebooks" in sidebar_markdown
     assert "extra/demo.ipynb" in sidebar_markdown
@@ -1275,6 +1280,10 @@ def test_explore_page_sidebar_notebook_selection_persists(mock_ui_env):
 
     assert not reloaded.exception
     assert reloaded.session_state[selection_key] == ["extra/demo.ipynb"]
+    reloaded_markdown = "\n".join(str(item.value) for item in reloaded.markdown)
+    assert "Notebooks selected" in reloaded_markdown
+    assert "1 linked to flight_project" in reloaded_markdown
+    assert "agilab-header-value agilab-header-value--ready'>1/2</div>" in reloaded_markdown
     reloaded_sidebar_markdown = "\n".join(str(item.value) for item in reloaded.sidebar.markdown)
     assert "extra/demo.ipynb" in reloaded_sidebar_markdown
     assert "lab_stages.ipynb" not in reloaded_sidebar_markdown
@@ -1414,6 +1423,26 @@ def test_workflow_dag_project_keeps_dataframe_load_export_controls_hidden(tmp_pa
     assert "Export" not in labels
     assert "Delete output" not in labels
     assert "No dataframe export found yet" not in page_text
+
+
+def test_workflow_notebook_manifest_dir_prefers_selected_project(tmp_path):
+    workflow_page = _import_agilab_module("agilab.pages.3_WORKFLOW")
+    apps_root = tmp_path / "apps"
+    active_project = apps_root / "alpha_project"
+    selected_project = apps_root / "beta_project"
+    active_project.mkdir(parents=True)
+    selected_project.mkdir()
+    env = SimpleNamespace(
+        apps_path=apps_root,
+        builtin_apps_path=apps_root / "builtin",
+        active_app=active_project,
+        app="alpha_project",
+        target="alpha_project",
+    )
+
+    resolved = workflow_page._resolve_active_app_project_dir(env, "beta_project")
+
+    assert resolved == selected_project.resolve()
 
 
 def test_pipeline_page_restores_missing_export_stages_from_project_source(mock_ui_env):


### PR DESCRIPTION
## Summary

- Add project-local notebook discovery under `<project>/notebooks` to the Analysis page.
- Add a per-project `Notebooks` sidebar launcher below `Analysis views`, with selections persisted in `[notebooks].selected`.
- Add a `current_notebook` route that starts a project-rooted JupyterLab sidecar and embeds the selected notebook.
- Cover notebook discovery, URL routing, iframe launch, and Streamlit page persistence.

## Validation

- `uv --preview-features extra-build-dependencies run pytest -q test/test_analysis_page_helpers.py test/test_ui_pages.py`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui`

## Notes

Unrelated untracked project directories in the local checkout were left unstaged.