### PR TITLE
docs: add first-proof evidence badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
   <a href="https://pypi.org/project/agilab/"><img src="https://raw.githubusercontent.com/ThalesGroup/agilab/main/badges/pypi-version-agilab.svg" alt="PyPI version" /></a>
   <a href="https://thalesgroup.github.io/agilab/release-proof.html"><img src="https://img.shields.io/badge/version%20alignment-release%20proof-0F766E" alt="Version alignment release proof" /></a>
   <a href="https://thalesgroup.github.io/agilab/release-proof.html"><img src="https://img.shields.io/badge/supply%20chain-SBOM%20%2B%20audit%20%2B%20provenance-0F766E" alt="Supply chain: SBOM, audit, provenance" /></a>
+  <a href="https://thalesgroup.github.io/agilab/release-proof.html"><img src="https://img.shields.io/badge/first%20proof-passing-0F766E" alt="First proof: passing" /></a>
   <a href="https://opensource.org/licenses/BSD-3-Clause"><img src="https://img.shields.io/badge/License-BSD%203--Clause-blue.svg" alt="License: BSD 3-Clause" /></a>
   <a href="https://thalesgroup.github.io/agilab"><img src="https://img.shields.io/badge/Documentation-online-brightgreen.svg" alt="Documentation" /></a>
   <a href="https://github.com/ThalesGroup/agilab"><img src="https://img.shields.io/github/stars/ThalesGroup/agilab?style=flat&label=stars" alt="GitHub stars" /></a>

--- a/README.pypi.md
+++ b/README.pypi.md
@@ -1,6 +1,7 @@
 [![PyPI version](https://img.shields.io/pypi/v/agilab.svg?cacheSeconds=300)](https://pypi.org/project/agilab/)
 [![Version alignment](https://img.shields.io/badge/version%20alignment-release%20proof-0F766E)](https://thalesgroup.github.io/agilab/release-proof.html)
 [![Supply chain: SBOM, audit, provenance](https://img.shields.io/badge/supply%20chain-SBOM%20%2B%20audit%20%2B%20provenance-0F766E)](https://thalesgroup.github.io/agilab/release-proof.html)
+[![First proof: passing](https://img.shields.io/badge/first%20proof-passing-0F766E)](https://thalesgroup.github.io/agilab/release-proof.html)
 [![Supported Python Versions](https://img.shields.io/pypi/pyversions/agilab.svg)](https://pypi.org/project/agilab/)
 [![License: BSD 3-Clause](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 [![Docs](https://img.shields.io/badge/docs-online-brightgreen.svg)](https://thalesgroup.github.io/agilab)

--- a/test/test_public_demo_links.py
+++ b/test/test_public_demo_links.py
@@ -293,6 +293,19 @@ def test_readmes_expose_supply_chain_evidence_badge() -> None:
     )
 
 
+def test_readmes_expose_first_proof_evidence_badge() -> None:
+    readme = README.read_text(encoding="utf-8")
+    pypi_readme = PYPI_README.read_text(encoding="utf-8")
+    badge = "https://img.shields.io/badge/first%20proof-passing-0F766E"
+    release_proof = "https://thalesgroup.github.io/agilab/release-proof.html"
+
+    assert (
+        f'<a href="{release_proof}"><img src="{badge}" '
+        'alt="First proof: passing" /></a>'
+    ) in readme
+    assert f"[![First proof: passing]({badge})]({release_proof})" in pypi_readme
+
+
 def test_readme_first_proof_snippet_uses_console_script_without_manual_venv() -> None:
     readme = README.read_text(encoding="utf-8")
     local_proof = readme.split("### Local PyPI UI Proof", 1)[1].split(


### PR DESCRIPTION
## Summary

- add a first-proof evidence badge to the GitHub and PyPI README surfaces
- keep the badge linked to release proof rather than a standalone unsupported claim
- add a public README guard test for the badge

## Validation

- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_public_demo_links.py`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files README.md README.pypi.md test/test_public_demo_links.py`
- `git diff --check -- README.md README.pypi.md test/test_public_demo_links.py`
