### PR TITLE
[codex] Harden UI robot evidence trend checks

### DIFF
--- a/.github/workflows/ui-robot-matrix.yml
+++ b/.github/workflows/ui-robot-matrix.yml
@@ -94,6 +94,8 @@ jobs:
             --glob "test-results/ui-robot-matrix/*.ndjson" \
             --max-total-seconds 5400 \
             --max-mean-page-seconds 180 \
+            --strict \
+            --strict-budget \
             --output test-results/ui-robot-matrix/trend-report.json \
             | tee test-results/ui-robot-matrix/trend-report.txt
           {

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 214,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "ce8724292b02d38c65a2ebd630ecd18e36690410891580ef0a7e5c962a1c4a27",
+  "source_digest_sha256": "b6b5ad85a39ec222010ad5bb844cdb03b96f5b9cd0392235d8f0ca2ab29a3051",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "ce8724292b02d38c65a2ebd630ecd18e36690410891580ef0a7e5c962a1c4a27"
+  "target_digest_sha256": "b6b5ad85a39ec222010ad5bb844cdb03b96f5b9cd0392235d8f0ca2ab29a3051"
 }

--- a/docs/source/data/ui_robot_evidence.json
+++ b/docs/source/data/ui_robot_evidence.json
@@ -10,7 +10,9 @@
     "required_files_present": true,
     "scenario_summary_file": "test-results/ui-robot-matrix/isolated-core-pages.json",
     "screenshot_count": 0,
-    "size_bytes": 4902
+    "size_bytes": 4902,
+    "trend_report_file": "test-results/ui-robot-matrix/trend-report.json",
+    "trend_report_schema": "agilab.ui_robot_trend_report.v1"
   },
   "generated_at": "2026-05-08T20:34:30Z",
   "result": {
@@ -25,6 +27,18 @@
     "status": "pass",
     "success": true,
     "total_duration_seconds": 411.5896649649999,
+    "trend": {
+      "budget_violation_count": 0,
+      "failed_page_count": 0,
+      "flaky_page_count": 0,
+      "mean_page_duration_seconds": 13.71965549883333,
+      "page_count": 30,
+      "parse_error_count": 0,
+      "schema": "agilab.ui_robot_trend_report.v1",
+      "slow_page_count": 0,
+      "success": true,
+      "total_duration_seconds": 411.5896649649999
+    },
     "widget_count": 532,
     "within_target": true
   },

--- a/src/agilab/orchestrate_execute.py
+++ b/src/agilab/orchestrate_execute.py
@@ -36,6 +36,17 @@ _NETWORKX_ERROR_TYPE = getattr(nx, "NetworkXError", RuntimeError) if nx is not N
 _PREVIEW_LOAD_EXCEPTIONS = (OSError, RuntimeError, TypeError, ValueError, _NETWORKX_ERROR_TYPE)
 
 
+@dataclass(frozen=True)
+class _PreviewCandidate:
+    path: Path
+    stat_result: os.stat_result
+    suffix_rank: int
+
+    @property
+    def mtime(self) -> float:
+        return self.stat_result.st_mtime
+
+
 def _networkx_unavailable_message() -> str:
     return (
         f"networkx unavailable: {_NETWORKX_IMPORT_ERROR}. "
@@ -224,30 +235,74 @@ def _run_stderr_indicates_failure(stderr: Any) -> bool:
     return bool(text.strip()) and any(pattern in text for pattern in RUN_FATAL_STDERR_PATTERNS)
 
 
-def _preview_candidate_paths(candidate_roots: list[Path]) -> list[Path]:
-    search_files: list[Path] = []
+def _preview_suffix_rank() -> dict[str, int]:
+    return {
+        Path(pattern).suffix.lower(): index
+        for index, pattern in enumerate(PREVIEW_FILE_PATTERNS)
+        if Path(pattern).suffix
+    }
+
+
+def _preview_candidate_records(candidate_roots: list[Path]) -> list[_PreviewCandidate]:
+    suffix_rank = _preview_suffix_rank()
+    records: list[_PreviewCandidate] = []
     seen_files: set[str] = set()
 
-    def _append_candidate(candidate: Path) -> bool:
-        if len(search_files) >= PREVIEW_MAX_SEARCH_FILES:
-            return False
+    def _append_candidate(bucket: list[_PreviewCandidate], candidate: Path, stat_result: os.stat_result) -> None:
+        suffix = candidate.suffix.lower()
+        rank = suffix_rank.get(suffix)
+        if rank is None:
+            return
         key = str(candidate)
         if key in seen_files:
-            return True
+            return
         seen_files.add(key)
-        search_files.append(candidate)
-        return True
+        bucket.append(_PreviewCandidate(path=candidate, stat_result=stat_result, suffix_rank=rank))
+
+    def _walk_directory(root: Path, bucket: list[_PreviewCandidate]) -> None:
+        stack = [root]
+        while stack:
+            current = stack.pop()
+            try:
+                with os.scandir(current) as entries:
+                    dirs: list[Path] = []
+                    for entry in entries:
+                        try:
+                            if entry.is_dir(follow_symlinks=False):
+                                dirs.append(Path(entry.path))
+                                continue
+                            if not entry.is_file(follow_symlinks=False):
+                                continue
+                            path = Path(entry.path)
+                            if path.suffix.lower() not in suffix_rank:
+                                continue
+                            _append_candidate(bucket, path, entry.stat(follow_symlinks=False))
+                        except OSError:
+                            continue
+                    stack.extend(sorted(dirs, key=lambda path: str(path), reverse=True))
+            except OSError:
+                continue
 
     for root in candidate_roots:
-        if root.is_dir():
-            for pattern in PREVIEW_FILE_PATTERNS:
-                for candidate in sorted(root.rglob(pattern), key=lambda path: str(path)):
-                    if not _append_candidate(candidate):
-                        return search_files
-        elif root.is_file():
-            if not _append_candidate(root):
-                return search_files
-    return search_files
+        root_records: list[_PreviewCandidate] = []
+        try:
+            root_stat = root.stat()
+        except (FileNotFoundError, OSError):
+            continue
+        if stat.S_ISDIR(root_stat.st_mode):
+            _walk_directory(root, root_records)
+            root_records.sort(key=lambda record: (record.suffix_rank, str(record.path)))
+        elif stat.S_ISREG(root_stat.st_mode):
+            _append_candidate(root_records, root, root_stat)
+        for record in root_records:
+            if len(records) >= PREVIEW_MAX_SEARCH_FILES:
+                return records
+            records.append(record)
+    return records
+
+
+def _preview_candidate_paths(candidate_roots: list[Path]) -> list[Path]:
+    return [record.path for record in _preview_candidate_records(candidate_roots)]
 
 
 def _is_preview_metadata_file(file_path: Path) -> bool:
@@ -256,27 +311,25 @@ def _is_preview_metadata_file(file_path: Path) -> bool:
 
 
 def find_preview_target(candidate_roots: list[Path]) -> tuple[Optional[Path], list[Path]]:
-    search_files = _preview_candidate_paths(candidate_roots)
+    search_records = _preview_candidate_records(candidate_roots)
 
-    filtered_records: list[tuple[Path, float]] = []
-    for file_path in search_files:
+    filtered_records: list[_PreviewCandidate] = []
+    for record in search_records:
+        file_path = record.path
         if _is_preview_metadata_file(file_path):
             continue
-        try:
-            file_stat = file_path.stat()
-        except (FileNotFoundError, OSError):
-            continue
+        file_stat = record.stat_result
         if not stat.S_ISREG(file_stat.st_mode):
             continue
         if file_stat.st_size <= 0 or file_stat.st_size > PREVIEW_MAX_FILE_BYTES:
             continue
-        filtered_records.append((file_path, file_stat.st_mtime))
+        filtered_records.append(record)
 
     if not filtered_records:
         return None, []
 
-    filtered_files = [file_path for file_path, _mtime in filtered_records]
-    target_file = max(filtered_records, key=lambda item: (item[1], str(item[0])))[0]
+    filtered_files = [record.path for record in filtered_records]
+    target_file = max(filtered_records, key=lambda record: (record.mtime, str(record.path))).path
     try:
         target_file.stat()
     except (FileNotFoundError, OSError):

--- a/src/agilab/repository_knowledge.py
+++ b/src/agilab/repository_knowledge.py
@@ -54,7 +54,7 @@ def _is_excluded(path: Path) -> bool:
 
 
 def _relative(repo_root: Path, path: Path) -> str:
-    return str(path.resolve().relative_to(repo_root)).replace("\\", "/")
+    return str(path.resolve().relative_to(repo_root.resolve())).replace("\\", "/")
 
 
 def _read_text(path: Path) -> str:
@@ -110,14 +110,16 @@ def _file_record(
     kind: str,
     *,
     stat_result: os.stat_result | None = None,
+    content_hash: str | None = None,
 ) -> dict[str, Any]:
     stat_result = stat_result or path.stat()
+    content_hash = content_hash or _sha256(path)
     record: dict[str, Any] = {
         "path": _relative(repo_root, path),
         "kind": kind,
         "suffix": path.suffix,
         "size_bytes": stat_result.st_size,
-        "sha256": _sha256(path),
+        "sha256": content_hash,
     }
     if path.suffix == ".py":
         record.update(_python_outline(path))
@@ -188,15 +190,18 @@ def _record_signature(
     path: Path,
     kind: str,
     stat_result: os.stat_result | None = None,
+    content_hash: str | None = None,
 ) -> dict[str, Any]:
     stat_result = stat_result or path.stat()
+    content_hash = content_hash or _sha256(path)
     return {
-        "repo_root": str(repo_root),
+        "repo_root": str(repo_root.resolve()),
         "path": _relative(repo_root, path),
         "kind": kind,
         "suffix": path.suffix,
         "size": stat_result.st_size,
         "mtime_ns": stat_result.st_mtime_ns,
+        "sha256": content_hash,
     }
 
 
@@ -216,7 +221,7 @@ def _cached_record(cache_state: Mapping[str, Any], signature: Mapping[str, Any])
         or record.get("kind") != signature.get("kind")
         or record.get("suffix") != signature.get("suffix")
         or record.get("size_bytes") != signature.get("size")
-        or not isinstance(record.get("sha256"), str)
+        or record.get("sha256") != signature.get("sha256")
     ):
         return None
     return dict(record)
@@ -231,10 +236,11 @@ def _record_with_cache(
     updated_entries: dict[str, Any] | None,
 ) -> dict[str, Any]:
     stat_result = path.stat()
-    signature = _record_signature(repo_root, path, kind, stat_result)
+    content_hash = _sha256(path)
+    signature = _record_signature(repo_root, path, kind, stat_result, content_hash)
     record = _cached_record(cache_state or {}, signature)
     if record is None:
-        record = _file_record(repo_root, path, kind, stat_result=stat_result)
+        record = _file_record(repo_root, path, kind, stat_result=stat_result, content_hash=content_hash)
     if updated_entries is not None:
         updated_entries[str(signature["path"])] = {"signature": signature, "record": record}
     return record

--- a/test/test_ci_artifact_harvest_report.py
+++ b/test/test_ci_artifact_harvest_report.py
@@ -4,6 +4,9 @@ import importlib.util
 import json
 import sys
 from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
 
 SRC_ROOT = Path("src").resolve()
 if str(SRC_ROOT) not in sys.path:
@@ -77,6 +80,64 @@ def test_ci_artifact_harvest_report_passes(tmp_path: Path) -> None:
     }
 
 
+def test_ci_artifact_harvest_report_path_setup_handles_package_paths(tmp_path: Path, monkeypatch) -> None:
+    module = _load_module(REPORT_PATH, "ci_artifact_harvest_path_setup_test_module")
+    repo_root = tmp_path / "repo"
+    src_root = repo_root / "src"
+    package_root = src_root / "agilab"
+    package_root.mkdir(parents=True)
+    monkeypatch.setattr(sys, "path", [entry for entry in sys.path if entry not in {str(repo_root), str(src_root)}])
+
+    list_package = SimpleNamespace(__path__=[])
+    monkeypatch.setitem(sys.modules, "agilab", list_package)
+    module._ensure_repo_on_path(repo_root)
+
+    assert sys.path[:2] == [str(repo_root), str(src_root)]
+    assert list_package.__path__ == [str(package_root)]
+
+    tuple_package = SimpleNamespace(__path__=())
+    monkeypatch.setitem(sys.modules, "agilab", tuple_package)
+    module._ensure_repo_on_path(repo_root)
+
+    assert tuple_package.__path__ == [str(package_root)]
+
+
+def test_ci_artifact_harvest_report_artifact_index_shapes(tmp_path: Path) -> None:
+    module = _load_module(REPORT_PATH, "ci_artifact_harvest_index_shapes_test_module")
+    list_index = tmp_path / "list-index.json"
+    list_index.write_text(json.dumps([{"kind": "run_manifest"}, "ignored"]), encoding="utf-8")
+    object_index = tmp_path / "object-index.json"
+    object_index.write_text(
+        json.dumps({"release_id": "release-123", "artifacts": [{"kind": "run_manifest"}, "ignored"]}),
+        encoding="utf-8",
+    )
+    bad_artifacts = tmp_path / "bad-artifacts.json"
+    bad_artifacts.write_text(json.dumps({"artifacts": {}}), encoding="utf-8")
+    bad_root = tmp_path / "bad-root.json"
+    bad_root.write_text(json.dumps("bad"), encoding="utf-8")
+
+    assert module._read_artifact_index(None) == (None, module.DEFAULT_RELEASE_ID)
+    assert module._read_artifact_index(list_index) == ([{"kind": "run_manifest"}], module.DEFAULT_RELEASE_ID)
+    assert module._read_artifact_index(object_index) == ([{"kind": "run_manifest"}], "release-123")
+    with pytest.raises(ValueError, match="artifacts list"):
+        module._read_artifact_index(bad_artifacts)
+    with pytest.raises(ValueError, match="JSON list or object"):
+        module._read_artifact_index(bad_root)
+
+
+def test_ci_artifact_harvest_report_docs_failure_and_temporary_output(tmp_path: Path) -> None:
+    module = _load_module(REPORT_PATH, "ci_artifact_harvest_docs_failure_test_module")
+    docs_check = module._docs_check(tmp_path / "missing-repo")
+
+    assert docs_check["status"] == "fail"
+    assert "error" in docs_check["details"]
+
+    report = module.build_report(repo_root=Path.cwd())
+
+    assert report["status"] == "pass"
+    assert report["summary"]["round_trip_ok"] is True
+
+
 def test_ci_artifact_harvest_persists_release_mapping(tmp_path: Path) -> None:
     module = _load_module(REPORT_PATH, "ci_artifact_harvest_json_test_module")
     output_path = tmp_path / "ci_artifact_harvest.json"
@@ -104,6 +165,22 @@ def test_ci_artifact_harvest_persists_release_mapping(tmp_path: Path) -> None:
     assert payload["provenance"]["queries_ci_provider"] is False
     assert payload["provenance"]["executes_network_probe"] is False
     assert payload["provenance"]["executes_commands"] is False
+
+
+def test_ci_artifact_harvest_report_cli_modes(tmp_path: Path, capsys) -> None:
+    module = _load_module(REPORT_PATH, "ci_artifact_harvest_cli_test_module")
+    output_path = tmp_path / "ci_artifact_harvest.json"
+
+    assert module.main(["--output", str(output_path), "--compact"]) == 0
+    compact = capsys.readouterr().out
+    assert "\n" not in compact.strip()
+    assert json.loads(compact)["status"] == "pass"
+    assert output_path.is_file()
+
+    assert module.main([]) == 0
+    pretty = capsys.readouterr().out
+    assert "\n  " in pretty
+    assert json.loads(pretty)["status"] == "pass"
 
 
 def test_ci_artifact_harvest_report_accepts_provider_artifact_index(

--- a/test/test_ci_workflow.py
+++ b/test/test_ci_workflow.py
@@ -1,5 +1,9 @@
 import ast
+import importlib.util
+import shlex
+import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 
 WORKFLOW_PATH = Path(".github/workflows/ci.yml")
@@ -9,6 +13,7 @@ DOCS_PUBLISH_WORKFLOW_PATH = Path(".github/workflows/docs-publish.yaml")
 ENSURE_ROADMAP_LABEL_WORKFLOW_PATH = Path(".github/workflows/ensure-roadmap-label.yaml")
 UI_ROBOT_MATRIX_WORKFLOW_PATH = Path(".github/workflows/ui-robot-matrix.yml")
 ROOT_CONFTEST_PATH = Path("test/conftest.py")
+WORKFLOW_PARITY_PATH = Path("tools/workflow_parity.py")
 
 VALIDATION_WORKFLOW_PATHS = (
     WORKFLOW_PATH,
@@ -21,6 +26,68 @@ VALIDATION_CONCURRENCY_GROUP = (
     "group: ${{ github.workflow }}-${{ github.event.pull_request.head.repo.full_name || "
     "github.repository }}-${{ github.head_ref || github.ref_name }}"
 )
+
+
+def _load_workflow_parity_module():
+    spec = importlib.util.spec_from_file_location("ci_workflow_parity_test_module", WORKFLOW_PARITY_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _ui_robot_matrix_workflow_argv() -> list[str]:
+    lines = UI_ROBOT_MATRIX_WORKFLOW_PATH.read_text(encoding="utf-8").splitlines()
+    start = next(index for index, line in enumerate(lines) if "tools/agilab_widget_robot_matrix.py" in line)
+    fragments: list[str] = []
+    for line in lines[start:]:
+        stripped = line.strip()
+        if stripped.startswith("| tee "):
+            break
+        fragments.append(stripped.removesuffix("\\").strip())
+    return shlex.split(" ".join(fragments))
+
+
+def _ui_robot_matrix_parity_argv() -> list[str]:
+    module = _load_workflow_parity_module()
+    args = SimpleNamespace(components=None, skills=None, app_path=None, worker_copy=None)
+    return list(module._profile_commands(args)["ui-robot-matrix"][0].argv)
+
+
+def _option_values(argv: list[str], option: str) -> list[str]:
+    return [argv[index + 1] for index, arg in enumerate(argv[:-1]) if arg == option]
+
+
+def _single_option(argv: list[str], option: str) -> str:
+    values = _option_values(argv, option)
+    assert len(values) == 1
+    return values[0]
+
+
+def _ui_robot_matrix_option(argv: list[str], option: str) -> str:
+    value = _single_option(argv, option)
+    workflow_defaults = {
+        "--apps": {"${robot_apps}": "all"},
+        "--timeout": {"${robot_timeout}": "90"},
+        "--widget-timeout": {"${robot_widget_timeout}": "3"},
+    }
+    return workflow_defaults.get(option, {}).get(value, value)
+
+
+def _ui_robot_matrix_command_contract(argv: list[str]) -> dict[str, object]:
+    return {
+        "script": "tools/agilab_widget_robot_matrix.py" in argv,
+        "scenarios": _option_values(argv, "--scenario"),
+        "apps": _ui_robot_matrix_option(argv, "--apps"),
+        "timeout": _ui_robot_matrix_option(argv, "--timeout"),
+        "widget_timeout": _ui_robot_matrix_option(argv, "--widget-timeout"),
+        "json": "--json" in argv,
+        "quiet_progress": "--quiet-progress" in argv,
+        "output_dir": _single_option(argv, "--output-dir"),
+        "screenshot_dir": _single_option(argv, "--screenshot-dir"),
+        "failure_bundle_dir": _single_option(argv, "--failure-bundle-dir"),
+    }
 
 
 def test_ci_workflow_includes_minimal_first_proof_contract() -> None:
@@ -99,6 +166,8 @@ def test_ui_robot_matrix_workflow_is_opt_in_or_nightly_only() -> None:
     assert "--failure-bundle-dir test-results/ui-robot-matrix/failure-bundles" in text
     assert "tools/ui_robot_trend_report.py" in text
     assert '--glob "test-results/ui-robot-matrix/*.ndjson"' in text
+    assert "--strict" in text
+    assert "--strict-budget" in text
     assert "--output test-results/ui-robot-matrix/trend-report.json" in text
     assert "test-results/ui-robot-matrix/trend-report.txt" in text
     assert "## UI robot trend" in text
@@ -106,6 +175,13 @@ def test_ui_robot_matrix_workflow_is_opt_in_or_nightly_only() -> None:
     assert "GITHUB_STEP_SUMMARY" in text
     assert "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7" in text
     assert "AGILAB_DISABLE_BACKGROUND_SERVICES: \"1\"" in text
+
+
+def test_ui_robot_matrix_workflow_command_matches_local_workflow_parity() -> None:
+    workflow_contract = _ui_robot_matrix_command_contract(_ui_robot_matrix_workflow_argv())
+    parity_contract = _ui_robot_matrix_command_contract(_ui_robot_matrix_parity_argv())
+
+    assert workflow_contract == parity_contract
 
 
 def test_root_conftest_keeps_streamlit_testing_import_lazy() -> None:

--- a/test/test_coverage_timing_report.py
+++ b/test/test_coverage_timing_report.py
@@ -115,3 +115,61 @@ def test_missing_junit_files_emit_empty_report(capsys) -> None:
 
     assert exit_code == 0
     assert "No AGI-GUI JUnit timing files were found." in capsys.readouterr().out
+
+
+def test_expand_paths_deduplicates_and_skips_non_files(tmp_path: Path, monkeypatch) -> None:
+    module = _load_module()
+    monkeypatch.setattr(module, "REPO_ROOT", tmp_path)
+    results = tmp_path / "test-results"
+    results.mkdir()
+    junit = results / "junit-agi-gui-support.xml"
+    junit.write_text("<testsuites />", encoding="utf-8")
+    directory_match = results / "junit-agi-gui-directory.xml"
+    directory_match.mkdir()
+
+    paths = module._expand_paths(
+        [
+            "test-results/junit-agi-gui-*.xml",
+            "test-results/junit-agi-gui-support.xml",
+        ]
+    )
+
+    assert paths == [junit]
+
+
+def test_load_records_handles_artifact_directory_chunks_and_bad_junit(tmp_path: Path, capsys) -> None:
+    module = _load_module()
+    artifact_dir = tmp_path / "coverage-gui-junit-custom"
+    artifact_dir.mkdir()
+    junit = artifact_dir / "results.xml"
+    bad_junit = artifact_dir / "bad.xml"
+    _write_junit(
+        junit,
+        [
+            ("", "missing_classname", "not-a-number"),
+            ("test_lonely_module", "top_level", -3.0),
+            ("package.test_nested", "nested", 0.5),
+        ],
+    )
+    bad_junit.write_text("<testsuites>", encoding="utf-8")
+
+    records = module.load_records([str(junit), str(bad_junit)])
+
+    assert [record.chunk for record in records] == ["custom", "custom", "custom"]
+    assert [record.test_path for record in records] == [
+        "unknown",
+        "test/test_lonely_module.py",
+        "package/test_nested.py",
+    ]
+    assert [record.seconds for record in records] == [0.0, 0.0, 0.5]
+    assert "ignoring unreadable JUnit" in capsys.readouterr().err
+
+
+def test_unknown_chunks_sort_after_known_chunks_when_tied() -> None:
+    module = _load_module()
+
+    known = module.ChunkTiming(chunk="support", files=1, tests=1, seconds=1.0, percentage=50.0)
+    unknown = module.ChunkTiming(chunk="custom", files=1, tests=1, seconds=1.0, percentage=50.0)
+
+    assert sorted([unknown, known], key=module._chunk_sort_key) == [known, unknown]
+    assert module._chunk_from_path(Path("plain-results.xml")) == "unknown"

--- a/test/test_orchestrate_execute.py
+++ b/test/test_orchestrate_execute.py
@@ -308,7 +308,7 @@ def test_find_preview_target_returns_none_when_latest_file_disappears(tmp_path, 
     def flaky_stat(self: Path, *args, **kwargs):
         if self == newest_csv:
             newest_calls["count"] += 1
-            if newest_calls["count"] >= 4:
+            if newest_calls["count"] >= 2:
                 raise FileNotFoundError("simulated race")
         return original_stat(self, *args, **kwargs)
 
@@ -355,15 +355,35 @@ def test_preview_candidate_paths_are_sorted_before_search_cap(tmp_path, monkeypa
     first.write_text("a,b\n1,2\n", encoding="utf-8")
     second.write_text("a,b\n3,4\n", encoding="utf-8")
 
-    def fake_rglob(self, pattern):
-        if self == root and pattern == "*.csv":
-            return [second, first]
-        return []
-
-    monkeypatch.setattr(orchestrate_execute.Path, "rglob", fake_rglob)
     monkeypatch.setattr(orchestrate_execute, "PREVIEW_MAX_SEARCH_FILES", 1)
 
     assert orchestrate_execute._preview_candidate_paths([root]) == [first]
+
+
+def test_preview_candidate_paths_scan_once_and_preserve_suffix_priority(tmp_path, monkeypatch):
+    root = tmp_path / "output"
+    root.mkdir()
+    csv_file = root / "a.csv"
+    parquet_file = root / "z.parquet"
+    json_file = root / "b.json"
+    csv_file.write_text("a,b\n1,2\n", encoding="utf-8")
+    parquet_file.write_text("parquet", encoding="utf-8")
+    json_file.write_text('{"ok": true}', encoding="utf-8")
+
+    original_rglob = orchestrate_execute.Path.rglob
+
+    def guarded_rglob(self: Path, *args, **kwargs):
+        if self == root:
+            pytest.fail("preview discovery should not call rglob per suffix")
+        return original_rglob(self, *args, **kwargs)
+
+    monkeypatch.setattr(
+        orchestrate_execute.Path,
+        "rglob",
+        guarded_rglob,
+    )
+
+    assert orchestrate_execute._preview_candidate_paths([root]) == [parquet_file, csv_file, json_file]
 
 
 def test_preview_candidate_paths_removes_duplicates_across_roots(tmp_path):
@@ -434,7 +454,17 @@ def test_execute_notice_and_preview_target_defensive_edges(monkeypatch, tmp_path
 
     directory_candidate = tmp_path / "candidate-dir"
     directory_candidate.mkdir()
-    monkeypatch.setattr(orchestrate_execute, "_preview_candidate_paths", lambda _roots: [directory_candidate])
+    monkeypatch.setattr(
+        orchestrate_execute,
+        "_preview_candidate_records",
+        lambda _roots: [
+            orchestrate_execute._PreviewCandidate(
+                path=directory_candidate,
+                stat_result=directory_candidate.stat(),
+                suffix_rank=0,
+            )
+        ],
+    )
 
     assert orchestrate_execute.find_preview_target([tmp_path]) == (None, [])
 

--- a/test/test_release_proof_report.py
+++ b/test/test_release_proof_report.py
@@ -265,10 +265,25 @@ def test_release_proof_ui_robot_evidence_check_validates_github_run(
             "total_duration_seconds": 411.6,
             "within_target": True,
         },
+        trend_report={
+            "schema": ui_robot_evidence.TREND_REPORT_SCHEMA,
+            "success": True,
+            "summary": {
+                "page_count": 30,
+                "failed_page_count": 0,
+                "flaky_page_count": 0,
+                "slow_page_count": 0,
+                "parse_error_count": 0,
+                "budget_violation_count": 0,
+                "total_duration_seconds": 411.6,
+                "mean_page_duration_seconds": 13.72,
+            },
+        },
         artifact_checks={
             "required_files_present": True,
             "exit_code": "0",
             "progress_log_bytes": 3,
+            "trend_report_schema": ui_robot_evidence.TREND_REPORT_SCHEMA,
         },
         generated_at="2026-05-08T20:30:00Z",
     )

--- a/test/test_repository_knowledge_report.py
+++ b/test/test_repository_knowledge_report.py
@@ -293,10 +293,10 @@ def test_repository_knowledge_record_cache_invalidates_changed_files(tmp_path: P
 
     first_records = module._records(repo_root, record_cache_path=cache_path)
     first_record = next(record for record in first_records if record["path"] == "src/agilab/module.py")
+    original_stat = module_path.stat()
 
     module_path.write_text('"""Two."""\nVALUE = 1\n', encoding="utf-8")
-    stat_result = module_path.stat()
-    os.utime(module_path, ns=(stat_result.st_atime_ns + 1_000_000, stat_result.st_mtime_ns + 1_000_000))
+    os.utime(module_path, ns=(original_stat.st_atime_ns, original_stat.st_mtime_ns))
 
     second_records = module._records(repo_root, record_cache_path=cache_path)
     second_record = next(record for record in second_records if record["path"] == "src/agilab/module.py")
@@ -304,6 +304,23 @@ def test_repository_knowledge_record_cache_invalidates_changed_files(tmp_path: P
     assert first_record["docstring"] == "One."
     assert second_record["docstring"] == "Two."
     assert second_record["sha256"] != first_record["sha256"]
+
+
+def test_repository_knowledge_relative_paths_accept_symlinked_repo_root(tmp_path: Path) -> None:
+    module = _load_module(CORE_PATH, "repository_knowledge_symlink_root_module")
+    repo_root = tmp_path / "repo"
+    module_path = repo_root / "src" / "agilab" / "module.py"
+    module_path.parent.mkdir(parents=True)
+    module_path.write_text('"""Linked."""\nVALUE = 1\n', encoding="utf-8")
+    link_root = tmp_path / "repo-link"
+    try:
+        link_root.symlink_to(repo_root, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"directory symlinks are not available: {exc}")
+
+    records = module._records(link_root, record_cache_path=tmp_path / "record-cache.json")
+
+    assert any(record["path"] == "src/agilab/module.py" for record in records)
 
 
 def test_repository_knowledge_record_cache_helpers_reject_bad_payloads(
@@ -409,6 +426,7 @@ def test_repository_knowledge_record_cache_rejects_invalid_entries(tmp_path: Pat
         "kind": "package_source",
         "suffix": ".py",
         "size": 12,
+        "sha256": "abc",
     }
     valid_record = {
         "path": "src/agilab/module.py",
@@ -424,6 +442,13 @@ def test_repository_knowledge_record_cache_rejects_invalid_entries(tmp_path: Pat
     assert (
         module._cached_record(
             {"entries": {"src/agilab/module.py": {"signature": signature, "record": {**valid_record, "sha256": 3}}}},
+            signature,
+        )
+        is None
+    )
+    assert (
+        module._cached_record(
+            {"entries": {"src/agilab/module.py": {"signature": signature, "record": {**valid_record, "sha256": "def"}}}},
             signature,
         )
         is None

--- a/test/test_ui_robot_evidence.py
+++ b/test/test_ui_robot_evidence.py
@@ -2,8 +2,12 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import runpy
 import sys
 from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
 
 
 MODULE_PATH = Path("tools/ui_robot_evidence.py").resolve()
@@ -75,6 +79,40 @@ def _scenario_summary() -> dict[str, object]:
     }
 
 
+def _trend_report() -> dict[str, object]:
+    return {
+        "schema": "agilab.ui_robot_trend_report.v1",
+        "success": True,
+        "summary": {
+            "page_count": 30,
+            "failed_page_count": 0,
+            "flaky_page_count": 0,
+            "slow_page_count": 0,
+            "parse_error_count": 0,
+            "budget_violation_count": 0,
+            "total_duration_seconds": 411.6,
+            "mean_page_duration_seconds": 13.72,
+        },
+    }
+
+
+def _write_artifact_payloads(root: Path, *, trend_report: dict[str, object] | None = None) -> Path:
+    artifact_root = root / "ui-robot-matrix-1" / "test-results" / "ui-robot-matrix"
+    artifact_root.mkdir(parents=True)
+    (artifact_root / "summary.json").write_text(json.dumps(_matrix_summary()), encoding="utf-8")
+    (artifact_root / "isolated-core-pages.json").write_text(
+        json.dumps(_scenario_summary()),
+        encoding="utf-8",
+    )
+    (artifact_root / "isolated-core-pages.ndjson").write_text("{}\n", encoding="utf-8")
+    (artifact_root / "trend-report.json").write_text(
+        json.dumps(_trend_report() if trend_report is None else trend_report),
+        encoding="utf-8",
+    )
+    (artifact_root / "exit-code.txt").write_text("0\n", encoding="utf-8")
+    return artifact_root
+
+
 def test_select_latest_successful_run_skips_failed_runs() -> None:
     module = _load_module()
     failed = {**_successful_run(), "databaseId": 1, "conclusion": "failure"}
@@ -86,24 +124,140 @@ def test_select_latest_successful_run_skips_failed_runs() -> None:
     assert selected["workflowName"] == "ui-robot-matrix"
 
 
+def test_github_cli_fetchers_and_artifact_metadata(monkeypatch, tmp_path: Path) -> None:
+    module = _load_module()
+    calls: list[list[str]] = []
+
+    def _fake_run(argv, **_kwargs):
+        calls.append(list(argv))
+        if argv[:3] == ["gh", "run", "list"]:
+            return SimpleNamespace(returncode=0, stdout=json.dumps([{**_successful_run(), "conclusion": "failure"}, _successful_run()]), stderr="")
+        if argv[:3] == ["gh", "run", "view"]:
+            return SimpleNamespace(returncode=0, stdout=json.dumps(_successful_run()), stderr="")
+        if argv[:2] == ["gh", "api"]:
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps(
+                    {
+                        "artifacts": [
+                            "ignored",
+                            {"name": "other", "expired": False},
+                            {
+                                "name": "ui-robot-matrix-1",
+                                "expired": False,
+                                "size_in_bytes": 123,
+                                "archive_download_url": "https://example.invalid/artifact.zip",
+                            },
+                        ]
+                    }
+                ),
+                stderr="",
+            )
+        raise AssertionError(argv)
+
+    monkeypatch.setattr(module.subprocess, "run", _fake_run)
+
+    latest = module.fetch_latest_successful_run(repo="ThalesGroup/agilab", branch="main", limit=2, repo_root=tmp_path)
+    viewed = module.fetch_run("25577485125", repo="ThalesGroup/agilab", repo_root=tmp_path)
+    artifact = module.fetch_artifact_metadata("25577485125", repo="ThalesGroup/agilab", repo_root=tmp_path)
+
+    assert latest["databaseId"] == "25577485125"
+    assert viewed["workflowName"] == module.WORKFLOW_NAME
+    assert artifact == {
+        "name": "ui-robot-matrix-1",
+        "expired": False,
+        "size_bytes": 123,
+        "archive_download_url": "https://example.invalid/artifact.zip",
+    }
+    assert "--branch" in calls[0]
+    assert f"{module.WORKFLOW_NAME}.yml" in calls[0]
+    assert "databaseId" in module._github_fields()
+
+
+def test_github_cli_errors_and_bad_payloads(monkeypatch, tmp_path: Path) -> None:
+    module = _load_module()
+
+    with pytest.raises(RuntimeError, match="no successful"):
+        module.select_latest_successful_run([])
+
+    monkeypatch.setattr(module, "_run_gh_json", lambda *_args, **_kwargs: {})
+    with pytest.raises(RuntimeError, match="JSON list"):
+        module.fetch_latest_successful_run(repo="repo", branch=None, limit=1, repo_root=tmp_path)
+
+    monkeypatch.setattr(module, "_run_gh_json", lambda *_args, **_kwargs: [])
+    with pytest.raises(RuntimeError, match="JSON object"):
+        module.fetch_run("1", repo="repo", repo_root=tmp_path)
+
+    monkeypatch.setattr(module, "_run_gh_json", lambda *_args, **_kwargs: {"artifacts": {}})
+    with pytest.raises(RuntimeError, match="artifacts list"):
+        module.fetch_artifact_metadata("1", repo="repo", repo_root=tmp_path)
+
+    monkeypatch.setattr(module, "_run_gh_json", lambda *_args, **_kwargs: {"artifacts": [{"name": "other"}]})
+    with pytest.raises(RuntimeError, match="no 'ui-robot-matrix' artifact"):
+        module.fetch_artifact_metadata("1", repo="repo", repo_root=tmp_path)
+
+    bad_json = tmp_path / "bad.json"
+    bad_json.write_text("[]", encoding="utf-8")
+    with pytest.raises(ValueError, match="JSON object"):
+        module._load_json(bad_json)
+
+
+def test_command_wrappers_report_errors_and_download_recreates_destination(monkeypatch, tmp_path: Path) -> None:
+    module = _load_module()
+
+    monkeypatch.setattr(
+        module.subprocess,
+        "run",
+        lambda *_args, **_kwargs: SimpleNamespace(returncode=2, stdout="", stderr="denied"),
+    )
+    with pytest.raises(RuntimeError, match="denied"):
+        module._run_gh_json(["run", "list"], repo_root=tmp_path)
+    with pytest.raises(RuntimeError, match="denied"):
+        module._run_command(["gh", "version"], repo_root=tmp_path)
+
+    monkeypatch.setattr(
+        module.subprocess,
+        "run",
+        lambda *_args, **_kwargs: SimpleNamespace(returncode=0, stdout="not json", stderr=""),
+    )
+    with pytest.raises(RuntimeError, match="invalid JSON"):
+        module._run_gh_json(["run", "list"], repo_root=tmp_path)
+
+    destination = tmp_path / "artifact"
+    destination.mkdir()
+    (destination / "stale.txt").write_text("old", encoding="utf-8")
+    commands: list[list[str]] = []
+
+    def _fake_run_command(args, *, repo_root):
+        commands.append(list(args))
+
+    monkeypatch.setattr(module, "_run_command", _fake_run_command)
+
+    result = module.download_artifact(
+        "123",
+        repo="ThalesGroup/agilab",
+        artifact_name="ui-robot-matrix-1",
+        destination=destination,
+        repo_root=tmp_path,
+    )
+
+    assert result == destination
+    assert destination.is_dir()
+    assert not (destination / "stale.txt").exists()
+    assert commands[0][:4] == ["gh", "run", "download", "123"]
+
+
 def test_load_artifact_payloads_and_build_evidence_contract(tmp_path: Path) -> None:
     module = _load_module()
-    artifact_root = tmp_path / "ui-robot-matrix-1" / "test-results" / "ui-robot-matrix"
-    artifact_root.mkdir(parents=True)
-    (artifact_root / "summary.json").write_text(json.dumps(_matrix_summary()), encoding="utf-8")
-    (artifact_root / "isolated-core-pages.json").write_text(
-        json.dumps(_scenario_summary()),
-        encoding="utf-8",
-    )
-    (artifact_root / "isolated-core-pages.ndjson").write_text("{}\n", encoding="utf-8")
-    (artifact_root / "exit-code.txt").write_text("0\n", encoding="utf-8")
+    _write_artifact_payloads(tmp_path)
 
-    matrix_summary, scenario_summary, artifact_checks = module.load_artifact_payloads(tmp_path)
+    matrix_summary, scenario_summary, trend_report, artifact_checks = module.load_artifact_payloads(tmp_path)
     evidence = module.build_evidence(
         run=_successful_run(),
         artifact=_artifact(),
         matrix_summary=matrix_summary,
         scenario_summary=scenario_summary,
+        trend_report=trend_report,
         artifact_checks=artifact_checks,
         generated_at="2026-05-08T20:30:00Z",
     )
@@ -114,8 +268,28 @@ def test_load_artifact_payloads_and_build_evidence_contract(tmp_path: Path) -> N
     assert evidence["result"]["status"] == "pass"
     assert evidence["result"]["app_count"] == 10
     assert evidence["result"]["failed_count"] == 0
+    assert evidence["result"]["trend"]["schema"] == module.TREND_REPORT_SCHEMA
+    assert evidence["result"]["trend"]["failed_page_count"] == 0
+    assert evidence["artifact"]["trend_report_file"].endswith("trend-report.json")
     assert evidence["artifact"]["required_files_present"] is True
     assert report["status"] == "pass"
+
+
+def test_load_artifact_payloads_requires_trend_report(tmp_path: Path) -> None:
+    module = _load_module()
+    artifact_root = _write_artifact_payloads(tmp_path)
+    (artifact_root / "trend-report.json").unlink()
+
+    with pytest.raises(FileNotFoundError, match="trend_report"):
+        module.load_artifact_payloads(tmp_path)
+
+
+def test_load_artifact_payloads_rejects_bad_trend_schema(tmp_path: Path) -> None:
+    module = _load_module()
+    _write_artifact_payloads(tmp_path, trend_report={"schema": "wrong.schema", "success": True, "summary": {}})
+
+    with pytest.raises(ValueError, match=module.TREND_REPORT_SCHEMA):
+        module.load_artifact_payloads(tmp_path)
 
 
 def test_validate_evidence_rejects_failed_robot_result() -> None:
@@ -126,6 +300,7 @@ def test_validate_evidence_rejects_failed_robot_result() -> None:
         artifact=_artifact(),
         matrix_summary={**_matrix_summary(), "success": False, "failed_count": 1},
         scenario_summary=scenario,
+        trend_report=_trend_report(),
         artifact_checks={"required_files_present": True, "exit_code": "1"},
         generated_at="2026-05-08T20:30:00Z",
     )
@@ -137,6 +312,57 @@ def test_validate_evidence_rejects_failed_robot_result() -> None:
     assert failed_ids == {"artifact", "robot_result"}
 
 
+def test_validate_evidence_rejects_missing_trend_report() -> None:
+    module = _load_module()
+    evidence = module.build_evidence(
+        run=_successful_run(),
+        artifact=_artifact(),
+        matrix_summary=_matrix_summary(),
+        scenario_summary=_scenario_summary(),
+        trend_report={"schema": "wrong.schema", "success": True, "summary": {}},
+        artifact_checks={"required_files_present": True, "exit_code": "0", "progress_log_bytes": 3},
+        generated_at="2026-05-08T20:30:00Z",
+    )
+
+    report = module.build_report(evidence)
+
+    assert report["status"] == "fail"
+    failed_ids = {check["id"] for check in report["checks"] if check["status"] == "fail"}
+    assert failed_ids == {"artifact", "trend_report", "robot_result"}
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["failed_page_count", "flaky_page_count", "parse_error_count", "budget_violation_count"],
+)
+def test_validate_evidence_rejects_unhealthy_trend_report(field: str) -> None:
+    module = _load_module()
+    trend_report = _trend_report()
+    trend_summary = dict(trend_report["summary"])
+    trend_summary[field] = 1
+    trend_report["summary"] = trend_summary
+    evidence = module.build_evidence(
+        run=_successful_run(),
+        artifact=_artifact(),
+        matrix_summary=_matrix_summary(),
+        scenario_summary=_scenario_summary(),
+        trend_report=trend_report,
+        artifact_checks={
+            "required_files_present": True,
+            "exit_code": "0",
+            "progress_log_bytes": 3,
+            "trend_report_schema": "agilab.ui_robot_trend_report.v1",
+        },
+        generated_at="2026-05-08T20:30:00Z",
+    )
+
+    report = module.build_report(evidence)
+
+    assert report["status"] == "fail"
+    failed_ids = {check["id"] for check in report["checks"] if check["status"] == "fail"}
+    assert failed_ids == {"trend_report", "robot_result"}
+
+
 def test_main_check_validates_existing_evidence_file(tmp_path: Path, capsys) -> None:
     module = _load_module()
     evidence = module.build_evidence(
@@ -144,7 +370,13 @@ def test_main_check_validates_existing_evidence_file(tmp_path: Path, capsys) -> 
         artifact=_artifact(),
         matrix_summary=_matrix_summary(),
         scenario_summary=_scenario_summary(),
-        artifact_checks={"required_files_present": True, "exit_code": "0", "progress_log_bytes": 3},
+        trend_report=_trend_report(),
+        artifact_checks={
+            "required_files_present": True,
+            "exit_code": "0",
+            "progress_log_bytes": 3,
+            "trend_report_schema": "agilab.ui_robot_trend_report.v1",
+        },
         generated_at="2026-05-08T20:30:00Z",
     )
     output = tmp_path / "ui_robot_evidence.json"
@@ -156,3 +388,144 @@ def test_main_check_validates_existing_evidence_file(tmp_path: Path, capsys) -> 
     assert exit_code == 0
     assert payload["schema"] == module.SCHEMA
     assert payload["status"] == "pass"
+
+
+def test_refresh_evidence_uses_artifact_dir_and_download_paths(monkeypatch, tmp_path: Path) -> None:
+    module = _load_module()
+    artifact_root = _write_artifact_payloads(tmp_path / "existing-artifact")
+    monkeypatch.setattr(module, "fetch_run", lambda run_id, *, repo, repo_root: _successful_run())
+    monkeypatch.setattr(module, "fetch_latest_successful_run", lambda *, repo, branch, limit, repo_root: _successful_run())
+    monkeypatch.setattr(module, "fetch_artifact_metadata", lambda run_id, *, repo, repo_root: _artifact())
+
+    evidence = module.refresh_evidence(
+        repo="ThalesGroup/agilab",
+        branch=None,
+        run_id="25577485125",
+        run_limit=1,
+        artifact_dir=artifact_root,
+        repo_root=tmp_path,
+    )
+
+    assert evidence["result"]["status"] == "pass"
+
+    def _fake_download_artifact(_run_id, *, repo, artifact_name, destination, repo_root):
+        _write_artifact_payloads(destination)
+        return destination
+
+    monkeypatch.setattr(module, "download_artifact", _fake_download_artifact)
+    evidence = module.refresh_evidence(
+        repo="ThalesGroup/agilab",
+        branch="main",
+        run_id=None,
+        run_limit=1,
+        artifact_dir=None,
+        repo_root=tmp_path,
+    )
+
+    assert evidence["result"]["trend"]["schema"] == module.TREND_REPORT_SCHEMA
+
+
+def test_refresh_evidence_rejects_expired_artifact(monkeypatch, tmp_path: Path) -> None:
+    module = _load_module()
+    monkeypatch.setattr(module, "fetch_run", lambda run_id, *, repo, repo_root: _successful_run())
+    monkeypatch.setattr(module, "fetch_artifact_metadata", lambda run_id, *, repo, repo_root: {**_artifact(), "expired": True})
+
+    with pytest.raises(RuntimeError, match="expired"):
+        module.refresh_evidence(
+            repo="ThalesGroup/agilab",
+            branch=None,
+            run_id="25577485125",
+            run_limit=1,
+            artifact_dir=tmp_path,
+            repo_root=tmp_path,
+        )
+
+
+def test_main_refresh_quiet_writes_evidence(monkeypatch, tmp_path: Path, capsys) -> None:
+    module = _load_module()
+    artifact_root = _write_artifact_payloads(tmp_path / "artifact")
+    output = tmp_path / "ui_robot_evidence.json"
+    monkeypatch.setattr(module, "fetch_latest_successful_run", lambda *, repo, branch, limit, repo_root: _successful_run())
+    monkeypatch.setattr(module, "fetch_artifact_metadata", lambda run_id, *, repo, repo_root: _artifact())
+
+    exit_code = module.main(["--artifact-dir", str(artifact_root), "--output", str(output), "--quiet"])
+
+    assert exit_code == 0
+    assert capsys.readouterr().out == ""
+    assert json.loads(output.read_text(encoding="utf-8"))["schema"] == module.SCHEMA
+
+
+def test_load_artifact_payloads_reports_external_files_by_name(monkeypatch, tmp_path: Path) -> None:
+    module = _load_module()
+    artifact_dir = tmp_path / "selected-artifact"
+    artifact_dir.mkdir()
+    external_artifact = _write_artifact_payloads(tmp_path / "external-artifact")
+
+    def _fake_find_artifact_file(_root: Path, filename: str) -> Path:
+        matches = list(external_artifact.rglob(filename))
+        assert matches
+        return matches[0]
+
+    monkeypatch.setattr(module, "_find_artifact_file", _fake_find_artifact_file)
+
+    _, _, _, artifact_checks = module.load_artifact_payloads(artifact_dir)
+
+    assert artifact_checks["matrix_summary_file"] == "summary.json"
+    assert artifact_checks["progress_log_file"] == "isolated-core-pages.ndjson"
+
+
+def test_main_check_pretty_prints_and_status_helper(tmp_path: Path, capsys) -> None:
+    module = _load_module()
+    evidence = module.build_evidence(
+        run=_successful_run(),
+        artifact=_artifact(),
+        matrix_summary=_matrix_summary(),
+        scenario_summary=_scenario_summary(),
+        trend_report=_trend_report(),
+        artifact_checks={
+            "required_files_present": True,
+            "exit_code": "0",
+            "progress_log_bytes": 3,
+            "trend_report_schema": "agilab.ui_robot_trend_report.v1",
+        },
+        generated_at="2026-05-08T20:30:00Z",
+    )
+    output = tmp_path / "ui_robot_evidence.json"
+    module.write_evidence(output, evidence)
+
+    assert module.evidence_status(evidence) == "pass"
+    assert module.main(["--check", "--output", str(output)]) == 0
+
+    stdout = capsys.readouterr().out
+    assert '"status": "pass"' in stdout
+    failed_evidence = {
+        **evidence,
+        "artifact": {**evidence["artifact"], "required_files_present": False},
+    }
+    assert module.evidence_status(failed_evidence) == "fail"
+
+
+def test_script_entrypoint_exits_with_main_status(monkeypatch, tmp_path: Path) -> None:
+    module = _load_module()
+    evidence = module.build_evidence(
+        run=_successful_run(),
+        artifact=_artifact(),
+        matrix_summary=_matrix_summary(),
+        scenario_summary=_scenario_summary(),
+        trend_report=_trend_report(),
+        artifact_checks={
+            "required_files_present": True,
+            "exit_code": "0",
+            "progress_log_bytes": 3,
+            "trend_report_schema": "agilab.ui_robot_trend_report.v1",
+        },
+        generated_at="2026-05-08T20:30:00Z",
+    )
+    output = tmp_path / "ui_robot_evidence.json"
+    module.write_evidence(output, evidence)
+    monkeypatch.setattr(sys, "argv", [str(MODULE_PATH), "--check", "--output", str(output), "--quiet"])
+
+    with pytest.raises(SystemExit) as exc_info:
+        runpy.run_path(str(MODULE_PATH), run_name="__main__")
+
+    assert exc_info.value.code == 0

--- a/test/test_workflow_parity.py
+++ b/test/test_workflow_parity.py
@@ -43,6 +43,7 @@ def _cache_args(cache_path: Path, *, no_result_cache: bool = False) -> SimpleNam
         app_path=None,
         worker_copy=None,
         keep_going=False,
+        result_cache=True,
         result_cache_path=str(cache_path),
         no_result_cache=no_result_cache,
         select_ui_robot_profiles=False,
@@ -910,6 +911,7 @@ def test_result_cache_helpers_round_trip_successful_profile(tmp_path, monkeypatc
     outside.write_text("outside", encoding="utf-8")
     cache_path = tmp_path / ".pytest_cache" / "agilab" / "workflow_parity_results.json"
     args = SimpleNamespace(
+        result_cache=True,
         no_result_cache=False,
         result_cache_path=str(cache_path),
         changed_file=[changed.as_posix()],
@@ -918,6 +920,7 @@ def test_result_cache_helpers_round_trip_successful_profile(tmp_path, monkeypatc
     )
 
     assert module._result_cache_enabled(args, module._run_command) is True
+    assert module._result_cache_enabled(SimpleNamespace(result_cache=False, no_result_cache=False), module._run_command) is False
     assert module._result_cache_enabled(SimpleNamespace(no_result_cache=True), module._run_command) is False
     assert module._result_cache_enabled(args, lambda _spec: None) is False
     assert module._result_cache_path(args) == cache_path
@@ -997,6 +1000,7 @@ def test_result_cache_helpers_reject_invalid_payloads_and_prune(tmp_path, monkey
     assert module._command_result_from_cache({"label": "bad", "argv": [], "env": [], "returncode": 0, "cwd": "."}) is None
     assert module._command_result_from_cache({"label": "bad", "argv": [], "env": {}, "returncode": "0", "cwd": "."}) is None
     assert module._profile_result_from_cache(None) is None
+    assert module._profile_result_from_cache({"profile": 3, "description": "desc", "success": True, "commands": []}) is None
     assert module._profile_result_from_cache({"profile": "skills", "description": "desc", "success": True, "commands": {}}) is None
     assert module._profile_result_from_cache(
         {"profile": "skills", "description": "desc", "success": True, "commands": [{"label": "bad"}]}
@@ -1004,8 +1008,17 @@ def test_result_cache_helpers_reject_invalid_payloads_and_prune(tmp_path, monkey
     assert module._cached_run_results({"entries": []}, "key", ["skills"]) is None
     assert module._cached_run_results({"entries": {"key": {"profiles": ["docs"], "results": []}}}, "key", ["skills"]) is None
     assert module._cached_run_results({"entries": {"key": {"profiles": ["skills"], "results": {}}}}, "key", ["skills"]) is None
+    assert (
+        module._cached_run_results(
+            {"entries": {"key": {"profiles": ["skills"], "results": [{"profile": 3}]}}},
+            "key",
+            ["skills"],
+        )
+        is None
+    )
 
     entries = {
+        "invalid": "not-a-cache-entry",
         "old": {"stored_at": 1.0},
         "middle": {"stored_at": 2.0},
         "new": {"stored_at": 3.0},
@@ -1017,6 +1030,35 @@ def test_result_cache_helpers_reject_invalid_payloads_and_prune(tmp_path, monkey
     bad_state = {"schema": module.RESULT_CACHE_SCHEMA, "entries": []}
     module._write_result_cache(cache_path, bad_state)
     assert json.loads(cache_path.read_text(encoding="utf-8"))["entries"] == []
+    missing_entries_path = tmp_path / "missing-entries.json"
+    module._store_run_results(
+        missing_entries_path,
+        {"schema": module.RESULT_CACHE_SCHEMA, "entries": []},
+        "key",
+        ["skills"],
+        [],
+    )
+    assert not missing_entries_path.exists()
+
+
+def test_result_cache_helpers_cover_git_and_signature_failures(tmp_path, monkeypatch) -> None:
+    module = _load_module()
+    monkeypatch.setattr(module, "REPO_ROOT", tmp_path)
+
+    def _failing_git_run(_argv, **_kwargs):
+        return SimpleNamespace(returncode=1, stdout="", stderr="fatal")
+
+    monkeypatch.setattr(module.subprocess, "run", _failing_git_run)
+    assert module._git_head() == ""
+
+    target = tmp_path / "hash-error.txt"
+    target.write_text("content", encoding="utf-8")
+    monkeypatch.setattr(module, "_file_sha256", lambda _path: (_ for _ in ()).throw(OSError("denied")))
+
+    signature = module._file_signature("hash-error.txt")
+
+    assert signature["state"] == "file"
+    assert signature["sha256_error"] == "OSError"
 
 
 def test_main_print_only_json_lists_selected_profile_commands(capsys) -> None:

--- a/tools/ui_robot_evidence.py
+++ b/tools/ui_robot_evidence.py
@@ -16,6 +16,7 @@ from typing import Any, Mapping, Sequence
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_OUTPUT = REPO_ROOT / "docs" / "source" / "data" / "ui_robot_evidence.json"
 SCHEMA = "agilab.ui_robot_evidence.v1"
+TREND_REPORT_SCHEMA = "agilab.ui_robot_trend_report.v1"
 WORKFLOW_NAME = "ui-robot-matrix"
 DEFAULT_BRANCH = "main"
 DEFAULT_REPO = "ThalesGroup/agilab"
@@ -38,6 +39,7 @@ REQUIRED_ARTIFACT_FILES = {
     "matrix_summary": "summary.json",
     "scenario_summary": "isolated-core-pages.json",
     "progress_log": "isolated-core-pages.ndjson",
+    "trend_report": "trend-report.json",
     "exit_code": "exit-code.txt",
 }
 
@@ -211,7 +213,7 @@ def _load_json(path: Path) -> dict[str, Any]:
     return payload
 
 
-def load_artifact_payloads(artifact_dir: Path) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+def load_artifact_payloads(artifact_dir: Path) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any]]:
     paths = {
         key: _find_artifact_file(artifact_dir, filename)
         for key, filename in REQUIRED_ARTIFACT_FILES.items()
@@ -224,6 +226,9 @@ def load_artifact_payloads(artifact_dir: Path) -> tuple[dict[str, Any], dict[str
 
     matrix_summary = _load_json(paths["matrix_summary"])  # type: ignore[arg-type]
     scenario_summary = _load_json(paths["scenario_summary"])  # type: ignore[arg-type]
+    trend_report = _load_json(paths["trend_report"])  # type: ignore[arg-type]
+    if trend_report.get("schema") != TREND_REPORT_SCHEMA:
+        raise ValueError(f"{paths['trend_report']} must use schema {TREND_REPORT_SCHEMA}")
     exit_code_text = paths["exit_code"].read_text(encoding="utf-8").strip()  # type: ignore[union-attr]
     progress_path = paths["progress_log"]  # type: ignore[assignment]
     screenshot_count = sum(1 for path in artifact_dir.rglob("*.png") if path.is_file())
@@ -244,8 +249,10 @@ def load_artifact_payloads(artifact_dir: Path) -> tuple[dict[str, Any], dict[str
         "matrix_summary_file": _relative(paths["matrix_summary"]),
         "scenario_summary_file": _relative(paths["scenario_summary"]),
         "progress_log_file": _relative(progress_path),
+        "trend_report_file": _relative(paths["trend_report"]),
+        "trend_report_schema": str(trend_report.get("schema", "") or ""),
     }
-    return matrix_summary, scenario_summary, artifact_checks
+    return matrix_summary, scenario_summary, trend_report, artifact_checks
 
 
 def _int_value(payload: Mapping[str, Any], key: str) -> int:
@@ -256,21 +263,43 @@ def _float_value(payload: Mapping[str, Any], key: str) -> float:
     return float(payload.get(key) or 0.0)
 
 
+def _trend_summary(trend_report: Mapping[str, Any]) -> Mapping[str, Any]:
+    summary = trend_report.get("summary")
+    return summary if isinstance(summary, Mapping) else {}
+
+
+def _trend_health_ok(trend_summary: Mapping[str, Any]) -> bool:
+    return (
+        _int_value(trend_summary, "failed_page_count") == 0
+        and _int_value(trend_summary, "flaky_page_count") == 0
+        and _int_value(trend_summary, "parse_error_count") == 0
+        and _int_value(trend_summary, "budget_violation_count") == 0
+    )
+
+
 def build_evidence(
     *,
     run: Mapping[str, Any],
     artifact: Mapping[str, Any],
     matrix_summary: Mapping[str, Any],
     scenario_summary: Mapping[str, Any],
+    trend_report: Mapping[str, Any],
     artifact_checks: Mapping[str, Any],
     generated_at: str | None = None,
 ) -> dict[str, Any]:
     failed_count = _int_value(scenario_summary, "failed_count")
     skipped_count = _int_value(scenario_summary, "skipped_count")
+    trend_summary = _trend_summary(trend_report)
+    trend_valid = (
+        trend_report.get("schema") == TREND_REPORT_SCHEMA
+        and trend_report.get("success") is True
+        and _trend_health_ok(trend_summary)
+    )
     success = (
         is_successful_ui_robot_run(run)
         and matrix_summary.get("success") is True
         and scenario_summary.get("success") is True
+        and trend_valid
         and failed_count == 0
         and str(artifact_checks.get("exit_code", "")) == "0"
         and not bool(artifact.get("expired"))
@@ -312,6 +341,18 @@ def build_evidence(
             "within_target": bool(scenario_summary.get("within_target")),
             "failed_scenarios": list(matrix_summary.get("failed_scenarios") or []),
             "failure_samples": list(matrix_summary.get("failure_samples") or []),
+            "trend": {
+                "schema": str(trend_report.get("schema", "") or ""),
+                "success": bool(trend_report.get("success")),
+                "page_count": _int_value(trend_summary, "page_count"),
+                "failed_page_count": _int_value(trend_summary, "failed_page_count"),
+                "flaky_page_count": _int_value(trend_summary, "flaky_page_count"),
+                "slow_page_count": _int_value(trend_summary, "slow_page_count"),
+                "parse_error_count": _int_value(trend_summary, "parse_error_count"),
+                "budget_violation_count": _int_value(trend_summary, "budget_violation_count"),
+                "total_duration_seconds": _float_value(trend_summary, "total_duration_seconds"),
+                "mean_page_duration_seconds": _float_value(trend_summary, "mean_page_duration_seconds"),
+            },
         },
     }
 
@@ -324,6 +365,7 @@ def validate_evidence(evidence: Mapping[str, Any]) -> list[dict[str, Any]]:
     source = evidence.get("source") if isinstance(evidence.get("source"), Mapping) else {}
     artifact = evidence.get("artifact") if isinstance(evidence.get("artifact"), Mapping) else {}
     result = evidence.get("result") if isinstance(evidence.get("result"), Mapping) else {}
+    trend = result.get("trend") if isinstance(result.get("trend"), Mapping) else {}
     checks = [
         {
             "id": "schema",
@@ -358,10 +400,25 @@ def validate_evidence(evidence: Mapping[str, Any]) -> list[dict[str, Any]]:
                 if artifact.get("name")
                 and artifact.get("required_files_present") is True
                 and artifact.get("exit_code") == "0"
+                and artifact.get("trend_report_schema") == TREND_REPORT_SCHEMA
                 and artifact.get("expired") is False
                 else "fail"
             ),
-            "summary": "robot artifact includes summary, progress log, and zero exit code",
+            "summary": "robot artifact includes summary, progress log, trend report, and zero exit code",
+        },
+        {
+            "id": "trend_report",
+            "status": (
+                "pass"
+                if trend.get("schema") == TREND_REPORT_SCHEMA
+                and trend.get("success") is True
+                and trend.get("failed_page_count") == 0
+                and trend.get("flaky_page_count") == 0
+                and trend.get("parse_error_count") == 0
+                and trend.get("budget_violation_count") == 0
+                else "fail"
+            ),
+            "summary": "UI robot trend report is present, valid, parse-error free, and within health budgets",
         },
         {
             "id": "robot_result",
@@ -403,7 +460,7 @@ def refresh_evidence(
 
     if artifact_dir is not None:
         work_dir = artifact_dir
-        matrix_summary, scenario_summary, artifact_checks = load_artifact_payloads(work_dir)
+        matrix_summary, scenario_summary, trend_report, artifact_checks = load_artifact_payloads(work_dir)
     else:
         with tempfile.TemporaryDirectory(prefix="agilab-ui-robot-evidence-") as tmp:
             work_dir = download_artifact(
@@ -413,12 +470,13 @@ def refresh_evidence(
                 destination=Path(tmp),
                 repo_root=repo_root,
             )
-            matrix_summary, scenario_summary, artifact_checks = load_artifact_payloads(work_dir)
+            matrix_summary, scenario_summary, trend_report, artifact_checks = load_artifact_payloads(work_dir)
     return build_evidence(
         run=run,
         artifact=artifact,
         matrix_summary=matrix_summary,
         scenario_summary=scenario_summary,
+        trend_report=trend_report,
         artifact_checks=artifact_checks,
     )
 

--- a/tools/workflow_parity.py
+++ b/tools/workflow_parity.py
@@ -177,6 +177,15 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Continue running later profiles even if one command fails.",
     )
     parser.add_argument(
+        "--result-cache",
+        action="store_true",
+        help=(
+            "Opt in to reusing successful local workflow parity results. Keep this "
+            "disabled for artifact-generating profiles such as docs, badges, skills, "
+            "and release checks."
+        ),
+    )
+    parser.add_argument(
         "--result-cache-path",
         default=str(DEFAULT_RESULT_CACHE_PATH),
         help=(
@@ -1238,6 +1247,12 @@ def _ui_robot_matrix_profile() -> list[CommandSpec]:
                 "isolated-project-rename-sidebar",
                 "--scenario",
                 "isolated-settings-page",
+                "--apps",
+                "all",
+                "--timeout",
+                "90",
+                "--widget-timeout",
+                "3",
                 "--json",
                 "--quiet-progress",
                 "--output-dir",
@@ -1929,7 +1944,11 @@ def _run_command(spec: CommandSpec) -> CommandResult:
 
 
 def _result_cache_enabled(args: argparse.Namespace, runner: Callable[[CommandSpec], CommandResult]) -> bool:
-    return runner is _run_command and not bool(getattr(args, "no_result_cache", False))
+    return (
+        runner is _run_command
+        and bool(getattr(args, "result_cache", False))
+        and not bool(getattr(args, "no_result_cache", False))
+    )
 
 
 def _result_cache_path(args: argparse.Namespace) -> Path:


### PR DESCRIPTION
## Summary
- require the UI robot trend report in release evidence artifacts
- make trend health part of evidence status and docs release-proof checks
- align the GitHub UI robot matrix workflow with the local workflow parity command
- speed up preview discovery and make repository knowledge cache invalidation content-aware

## Validation
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_ci_workflow.py test/test_ui_robot_evidence.py test/test_orchestrate_execute.py test/test_repository_knowledge_report.py test/test_ci_artifact_harvest_report.py test/test_coverage_timing_report.py test/test_release_proof_report.py test/test_workflow_parity.py
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui --profile docs
- uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp
- git diff --check