### PR TITLE
[codex] Preserve UI robot trend summaries on failure

### DIFF
--- a/.github/workflows/ui-robot-matrix.yml
+++ b/.github/workflows/ui-robot-matrix.yml
@@ -90,6 +90,7 @@ jobs:
         if: always()
         run: |
           set -euo pipefail
+          set +e
           uv --preview-features extra-build-dependencies run python tools/ui_robot_trend_report.py \
             --glob "test-results/ui-robot-matrix/*.ndjson" \
             --max-total-seconds 5400 \
@@ -98,11 +99,14 @@ jobs:
             --strict-budget \
             --output test-results/ui-robot-matrix/trend-report.json \
             | tee test-results/ui-robot-matrix/trend-report.txt
+          trend_status="${PIPESTATUS[0]}"
+          set -e
           {
             echo ""
             echo "## UI robot trend"
             cat test-results/ui-robot-matrix/trend-report.txt
           } >> "$GITHUB_STEP_SUMMARY"
+          exit "${trend_status}"
 
       - name: Summarize UI robot matrix
         if: always()

--- a/test/test_ci_workflow.py
+++ b/test/test_ci_workflow.py
@@ -170,6 +170,8 @@ def test_ui_robot_matrix_workflow_is_opt_in_or_nightly_only() -> None:
     assert "--strict-budget" in text
     assert "--output test-results/ui-robot-matrix/trend-report.json" in text
     assert "test-results/ui-robot-matrix/trend-report.txt" in text
+    assert 'trend_status="${PIPESTATUS[0]}"' in text
+    assert 'exit "${trend_status}"' in text
     assert "## UI robot trend" in text
     assert "failure_samples" in text
     assert "GITHUB_STEP_SUMMARY" in text


### PR DESCRIPTION
## Summary
- keep the trend report command status while still writing its text into the GitHub step summary
- assert the workflow preserves and exits with that captured status

## Validation
- uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files .github/workflows/ui-robot-matrix.yml test/test_ci_workflow.py
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_ci_workflow.py
- git diff --check