### PR TITLE
[codex] Add PyPI discoverability metadata to page packages

### DIFF
--- a/src/agilab/apps-pages/view_autoencoder_latentspace/pyproject.toml
+++ b/src/agilab/apps-pages/view_autoencoder_latentspace/pyproject.toml
@@ -4,6 +4,14 @@ version = "2025.12.12"
 description = "AGILAB page bundle for latent-space projection and autoencoder exploration."
 readme = { text = "AGILAB page bundle for latent-space projection and autoencoder exploration.", content-type = "text/markdown" }
 requires-python = ">=3.12,<3.13"
+keywords = [
+    "agilab",
+    "thalesgroup",
+    "streamlit",
+    "analysis",
+    "page-bundle",
+    "reproducibility",
+]
 dependencies = [
     "agi-env>=2026.05.12.post3,<2027.0",
     "agi-gui>=2026.05.12.post3,<2027.0",
@@ -16,6 +24,15 @@ dependencies = [
 
 [project.entry-points."agilab.pages"]
 view_autoencoder_latentspace = "view_autoencoder_latentspace:bundle_root"
+
+[project.urls]
+Documentation = "https://thalesgroup.github.io/agilab"
+Source = "https://github.com/ThalesGroup/agilab/tree/main/src/agilab/apps-pages/view_autoencoder_latentspace"
+Issues = "https://github.com/ThalesGroup/agilab/issues"
+Homepage = "https://github.com/ThalesGroup/agilab"
+Repository = "https://github.com/ThalesGroup/agilab"
+Discussions = "https://github.com/ThalesGroup/agilab/discussions"
+Changelog = "https://github.com/ThalesGroup/agilab/releases"
 
 [tool.uv.sources]
 agi-gui = { path = "../../lib/agi-gui", editable = true }

--- a/src/agilab/apps-pages/view_barycentric/pyproject.toml
+++ b/src/agilab/apps-pages/view_barycentric/pyproject.toml
@@ -4,6 +4,14 @@ version = "2026.05.18"
 description = "AGILAB page bundle for simplex projection and barycentric analysis."
 readme = { text = "AGILAB page bundle for simplex projection and barycentric analysis.", content-type = "text/markdown" }
 requires-python = ">=3.11"
+keywords = [
+    "agilab",
+    "thalesgroup",
+    "streamlit",
+    "analysis",
+    "page-bundle",
+    "reproducibility",
+]
 dependencies = [
     "agi-gui>=2026.05.12.post3,<2027.0",
     "plotly>=6.3.0",
@@ -19,6 +27,15 @@ view_barycentric = "view_barycentric:bundle_root"
 
 
 
+
+[project.urls]
+Documentation = "https://thalesgroup.github.io/agilab"
+Source = "https://github.com/ThalesGroup/agilab/tree/main/src/agilab/apps-pages/view_barycentric"
+Issues = "https://github.com/ThalesGroup/agilab/issues"
+Homepage = "https://github.com/ThalesGroup/agilab"
+Repository = "https://github.com/ThalesGroup/agilab"
+Discussions = "https://github.com/ThalesGroup/agilab/discussions"
+Changelog = "https://github.com/ThalesGroup/agilab/releases"
 
 [tool.uv.sources]
 agi-gui = { path = "../../lib/agi-gui", editable = true }

--- a/src/agilab/apps-pages/view_barycentric/pyproject.toml
+++ b/src/agilab/apps-pages/view_barycentric/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-simplex-map"
-version = "2026.05.18"
+version = "2026.05.19.post1"
 description = "AGILAB page bundle for simplex projection and barycentric analysis."
 readme = { text = "AGILAB page bundle for simplex projection and barycentric analysis.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_data_io_decision/pyproject.toml
+++ b/src/agilab/apps-pages/view_data_io_decision/pyproject.toml
@@ -4,6 +4,14 @@ version = "2026.05.18"
 description = "AGILAB page bundle for decision evidence review."
 readme = { text = "AGILAB page bundle for decision evidence review.", content-type = "text/markdown" }
 requires-python = ">=3.11"
+keywords = [
+    "agilab",
+    "thalesgroup",
+    "streamlit",
+    "analysis",
+    "page-bundle",
+    "reproducibility",
+]
 dependencies = [
     "agi-env>=2026.05.12.post3,<2027.0",
     "agi-gui>=2026.05.12.post3,<2027.0",
@@ -16,6 +24,15 @@ view_data_io_decision = "view_data_io_decision:bundle_root"
 
 
 
+
+[project.urls]
+Documentation = "https://thalesgroup.github.io/agilab"
+Source = "https://github.com/ThalesGroup/agilab/tree/main/src/agilab/apps-pages/view_data_io_decision"
+Issues = "https://github.com/ThalesGroup/agilab/issues"
+Homepage = "https://github.com/ThalesGroup/agilab"
+Repository = "https://github.com/ThalesGroup/agilab"
+Discussions = "https://github.com/ThalesGroup/agilab/discussions"
+Changelog = "https://github.com/ThalesGroup/agilab/releases"
 
 [tool.uv.sources]
 agi-gui = { path = "../../lib/agi-gui", editable = true }

--- a/src/agilab/apps-pages/view_data_io_decision/pyproject.toml
+++ b/src/agilab/apps-pages/view_data_io_decision/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-decision-evidence"
-version = "2026.05.18"
+version = "2026.05.19.post1"
 description = "AGILAB page bundle for decision evidence review."
 readme = { text = "AGILAB page bundle for decision evidence review.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_forecast_analysis/pyproject.toml
+++ b/src/agilab/apps-pages/view_forecast_analysis/pyproject.toml
@@ -4,6 +4,14 @@ version = "2026.05.18"
 description = "AGILAB page bundle for time-series forecast review."
 readme = { text = "AGILAB page bundle for time-series forecast review.", content-type = "text/markdown" }
 requires-python = ">=3.11"
+keywords = [
+    "agilab",
+    "thalesgroup",
+    "streamlit",
+    "analysis",
+    "page-bundle",
+    "reproducibility",
+]
 dependencies = [
     "agi-gui>=2026.05.12.post3,<2027.0",
     "agi-node>=2026.05.12.post3,<2027.0",
@@ -16,6 +24,15 @@ view_forecast_analysis = "view_forecast_analysis:bundle_root"
 
 
 
+
+[project.urls]
+Documentation = "https://thalesgroup.github.io/agilab"
+Source = "https://github.com/ThalesGroup/agilab/tree/main/src/agilab/apps-pages/view_forecast_analysis"
+Issues = "https://github.com/ThalesGroup/agilab/issues"
+Homepage = "https://github.com/ThalesGroup/agilab"
+Repository = "https://github.com/ThalesGroup/agilab"
+Discussions = "https://github.com/ThalesGroup/agilab/discussions"
+Changelog = "https://github.com/ThalesGroup/agilab/releases"
 
 [tool.uv.sources]
 agi-gui = { path = "../../lib/agi-gui", editable = true }

--- a/src/agilab/apps-pages/view_forecast_analysis/pyproject.toml
+++ b/src/agilab/apps-pages/view_forecast_analysis/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-timeseries-forecast"
-version = "2026.05.18"
+version = "2026.05.19.post1"
 description = "AGILAB page bundle for time-series forecast review."
 readme = { text = "AGILAB page bundle for time-series forecast review.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_inference_analysis/pyproject.toml
+++ b/src/agilab/apps-pages/view_inference_analysis/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-inference-report"
-version = "2026.05.18"
+version = "2026.05.19.post1"
 description = "AGILAB page bundle for inference result reporting."
 readme = { text = "AGILAB page bundle for inference result reporting.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_inference_analysis/pyproject.toml
+++ b/src/agilab/apps-pages/view_inference_analysis/pyproject.toml
@@ -4,6 +4,14 @@ version = "2026.05.18"
 description = "AGILAB page bundle for inference result reporting."
 readme = { text = "AGILAB page bundle for inference result reporting.", content-type = "text/markdown" }
 requires-python = ">=3.11"
+keywords = [
+    "agilab",
+    "thalesgroup",
+    "streamlit",
+    "analysis",
+    "page-bundle",
+    "reproducibility",
+]
 dependencies = [
     "agi-gui>=2026.05.12.post3,<2027.0",
     "pandas>=2.3.0",
@@ -16,6 +24,15 @@ view_inference_analysis = "view_inference_analysis:bundle_root"
 
 
 
+
+[project.urls]
+Documentation = "https://thalesgroup.github.io/agilab"
+Source = "https://github.com/ThalesGroup/agilab/tree/main/src/agilab/apps-pages/view_inference_analysis"
+Issues = "https://github.com/ThalesGroup/agilab/issues"
+Homepage = "https://github.com/ThalesGroup/agilab"
+Repository = "https://github.com/ThalesGroup/agilab"
+Discussions = "https://github.com/ThalesGroup/agilab/discussions"
+Changelog = "https://github.com/ThalesGroup/agilab/releases"
 
 [tool.uv.sources]
 agi-gui = { path = "../../lib/agi-gui", editable = true }

--- a/src/agilab/apps-pages/view_maps/pyproject.toml
+++ b/src/agilab/apps-pages/view_maps/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-geospatial-map"
-version = "2026.05.18"
+version = "2026.05.19.post1"
 description = "AGILAB page bundle for 2D geospatial map exploration."
 readme = { text = "AGILAB page bundle for 2D geospatial map exploration.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_maps/pyproject.toml
+++ b/src/agilab/apps-pages/view_maps/pyproject.toml
@@ -4,6 +4,14 @@ version = "2026.05.18"
 description = "AGILAB page bundle for 2D geospatial map exploration."
 readme = { text = "AGILAB page bundle for 2D geospatial map exploration.", content-type = "text/markdown" }
 requires-python = ">=3.11"
+keywords = [
+    "agilab",
+    "thalesgroup",
+    "streamlit",
+    "analysis",
+    "page-bundle",
+    "reproducibility",
+]
 dependencies = [
     "agi-gui>=2026.05.12.post3,<2027.0",
     "agi-node>=2026.05.12.post3,<2027.0",
@@ -17,6 +25,15 @@ view_maps = "view_maps:bundle_root"
 
 
 
+
+[project.urls]
+Documentation = "https://thalesgroup.github.io/agilab"
+Source = "https://github.com/ThalesGroup/agilab/tree/main/src/agilab/apps-pages/view_maps"
+Issues = "https://github.com/ThalesGroup/agilab/issues"
+Homepage = "https://github.com/ThalesGroup/agilab"
+Repository = "https://github.com/ThalesGroup/agilab"
+Discussions = "https://github.com/ThalesGroup/agilab/discussions"
+Changelog = "https://github.com/ThalesGroup/agilab/releases"
 
 [tool.uv.sources]
 agi-gui = { path = "../../lib/agi-gui", editable = true }

--- a/src/agilab/apps-pages/view_maps_3d/pyproject.toml
+++ b/src/agilab/apps-pages/view_maps_3d/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-geospatial-3d"
-version = "2026.05.18"
+version = "2026.05.19.post1"
 description = "AGILAB page bundle for 3D geospatial exploration."
 readme = { text = "AGILAB page bundle for 3D geospatial exploration.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_maps_3d/pyproject.toml
+++ b/src/agilab/apps-pages/view_maps_3d/pyproject.toml
@@ -4,6 +4,14 @@ version = "2026.05.18"
 description = "AGILAB page bundle for 3D geospatial exploration."
 readme = { text = "AGILAB page bundle for 3D geospatial exploration.", content-type = "text/markdown" }
 requires-python = ">=3.11"
+keywords = [
+    "agilab",
+    "thalesgroup",
+    "streamlit",
+    "analysis",
+    "page-bundle",
+    "reproducibility",
+]
 dependencies = [
     "agi-gui>=2026.05.12.post3,<2027.0",
     "agi-node>=2026.05.12.post3,<2027.0",
@@ -18,6 +26,15 @@ view_maps_3d = "view_maps_3d:bundle_root"
 
 
 
+
+[project.urls]
+Documentation = "https://thalesgroup.github.io/agilab"
+Source = "https://github.com/ThalesGroup/agilab/tree/main/src/agilab/apps-pages/view_maps_3d"
+Issues = "https://github.com/ThalesGroup/agilab/issues"
+Homepage = "https://github.com/ThalesGroup/agilab"
+Repository = "https://github.com/ThalesGroup/agilab"
+Discussions = "https://github.com/ThalesGroup/agilab/discussions"
+Changelog = "https://github.com/ThalesGroup/agilab/releases"
 
 [tool.uv.sources]
 agi-gui = { path = "../../lib/agi-gui", editable = true }

--- a/src/agilab/apps-pages/view_maps_network/pyproject.toml
+++ b/src/agilab/apps-pages/view_maps_network/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-network-map"
-version = "2026.05.18"
+version = "2026.05.19.post1"
 description = "AGILAB page bundle for network-aware geospatial analysis."
 readme = { text = "AGILAB page bundle for network-aware geospatial analysis.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_maps_network/pyproject.toml
+++ b/src/agilab/apps-pages/view_maps_network/pyproject.toml
@@ -4,6 +4,14 @@ version = "2026.05.18"
 description = "AGILAB page bundle for network-aware geospatial analysis."
 readme = { text = "AGILAB page bundle for network-aware geospatial analysis.", content-type = "text/markdown" }
 requires-python = ">=3.11"
+keywords = [
+    "agilab",
+    "thalesgroup",
+    "streamlit",
+    "analysis",
+    "page-bundle",
+    "reproducibility",
+]
 dependencies = [
     "agi-gui>=2026.05.12.post3,<2027.0",
     "agi-node>=2026.05.12.post3,<2027.0",
@@ -25,6 +33,15 @@ view_maps_network = "view_maps_network:bundle_root"
 
 
 
+
+[project.urls]
+Documentation = "https://thalesgroup.github.io/agilab"
+Source = "https://github.com/ThalesGroup/agilab/tree/main/src/agilab/apps-pages/view_maps_network"
+Issues = "https://github.com/ThalesGroup/agilab/issues"
+Homepage = "https://github.com/ThalesGroup/agilab"
+Repository = "https://github.com/ThalesGroup/agilab"
+Discussions = "https://github.com/ThalesGroup/agilab/discussions"
+Changelog = "https://github.com/ThalesGroup/agilab/releases"
 
 [tool.uv.sources]
 agi-gui = { path = "../../lib/agi-gui", editable = true }

--- a/src/agilab/apps-pages/view_pytorch_playground/pyproject.toml
+++ b/src/agilab/apps-pages/view_pytorch_playground/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-pytorch-playground"
-version = "2026.05.19"
+version = "2026.05.19.post1"
 description = "Opt-in AGILAB page bundle for interactive PyTorch classifier experiments."
 readme = { text = "Opt-in AGILAB page bundle for interactive PyTorch classifier experiments.", content-type = "text/markdown" }
 requires-python = ">=3.12"

--- a/src/agilab/apps-pages/view_pytorch_playground/pyproject.toml
+++ b/src/agilab/apps-pages/view_pytorch_playground/pyproject.toml
@@ -4,6 +4,14 @@ version = "2026.05.19"
 description = "Opt-in AGILAB page bundle for interactive PyTorch classifier experiments."
 readme = { text = "Opt-in AGILAB page bundle for interactive PyTorch classifier experiments.", content-type = "text/markdown" }
 requires-python = ">=3.12"
+keywords = [
+    "agilab",
+    "thalesgroup",
+    "streamlit",
+    "analysis",
+    "page-bundle",
+    "reproducibility",
+]
 dependencies = [
     "agi-gui>=2026.05.12.post3,<2027.0",
     "numpy>=2.2",
@@ -18,6 +26,15 @@ view_pytorch_playground = "view_pytorch_playground:bundle_root"
 
 
 
+
+[project.urls]
+Documentation = "https://thalesgroup.github.io/agilab"
+Source = "https://github.com/ThalesGroup/agilab/tree/main/src/agilab/apps-pages/view_pytorch_playground"
+Issues = "https://github.com/ThalesGroup/agilab/issues"
+Homepage = "https://github.com/ThalesGroup/agilab"
+Repository = "https://github.com/ThalesGroup/agilab"
+Discussions = "https://github.com/ThalesGroup/agilab/discussions"
+Changelog = "https://github.com/ThalesGroup/agilab/releases"
 
 [tool.uv.sources]
 agi-gui = { path = "../../lib/agi-gui", editable = true }

--- a/src/agilab/apps-pages/view_queue_resilience/pyproject.toml
+++ b/src/agilab/apps-pages/view_queue_resilience/pyproject.toml
@@ -4,6 +4,14 @@ version = "2026.05.18"
 description = "AGILAB page bundle for queue health and resilience evidence."
 readme = { text = "AGILAB page bundle for queue health and resilience evidence.", content-type = "text/markdown" }
 requires-python = ">=3.11"
+keywords = [
+    "agilab",
+    "thalesgroup",
+    "streamlit",
+    "analysis",
+    "page-bundle",
+    "reproducibility",
+]
 dependencies = [
     "agi-gui>=2026.05.12.post3,<2027.0",
     "agi-node>=2026.05.12.post3,<2027.0",
@@ -16,6 +24,15 @@ view_queue_resilience = "view_queue_resilience:bundle_root"
 
 
 
+
+[project.urls]
+Documentation = "https://thalesgroup.github.io/agilab"
+Source = "https://github.com/ThalesGroup/agilab/tree/main/src/agilab/apps-pages/view_queue_resilience"
+Issues = "https://github.com/ThalesGroup/agilab/issues"
+Homepage = "https://github.com/ThalesGroup/agilab"
+Repository = "https://github.com/ThalesGroup/agilab"
+Discussions = "https://github.com/ThalesGroup/agilab/discussions"
+Changelog = "https://github.com/ThalesGroup/agilab/releases"
 
 [tool.uv.sources]
 agi-gui = { path = "../../lib/agi-gui", editable = true }

--- a/src/agilab/apps-pages/view_queue_resilience/pyproject.toml
+++ b/src/agilab/apps-pages/view_queue_resilience/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-queue-health"
-version = "2026.05.18"
+version = "2026.05.19.post1"
 description = "AGILAB page bundle for queue health and resilience evidence."
 readme = { text = "AGILAB page bundle for queue health and resilience evidence.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_relay_resilience/pyproject.toml
+++ b/src/agilab/apps-pages/view_relay_resilience/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-relay-health"
-version = "2026.05.18"
+version = "2026.05.19.post1"
 description = "AGILAB page bundle for relay health and resilience evidence."
 readme = { text = "AGILAB page bundle for relay health and resilience evidence.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_relay_resilience/pyproject.toml
+++ b/src/agilab/apps-pages/view_relay_resilience/pyproject.toml
@@ -4,6 +4,14 @@ version = "2026.05.18"
 description = "AGILAB page bundle for relay health and resilience evidence."
 readme = { text = "AGILAB page bundle for relay health and resilience evidence.", content-type = "text/markdown" }
 requires-python = ">=3.11"
+keywords = [
+    "agilab",
+    "thalesgroup",
+    "streamlit",
+    "analysis",
+    "page-bundle",
+    "reproducibility",
+]
 dependencies = [
     "agi-gui>=2026.05.12.post3,<2027.0",
     "agi-node>=2026.05.12.post3,<2027.0",
@@ -16,6 +24,15 @@ view_relay_resilience = "view_relay_resilience:bundle_root"
 
 
 
+
+[project.urls]
+Documentation = "https://thalesgroup.github.io/agilab"
+Source = "https://github.com/ThalesGroup/agilab/tree/main/src/agilab/apps-pages/view_relay_resilience"
+Issues = "https://github.com/ThalesGroup/agilab/issues"
+Homepage = "https://github.com/ThalesGroup/agilab"
+Repository = "https://github.com/ThalesGroup/agilab"
+Discussions = "https://github.com/ThalesGroup/agilab/discussions"
+Changelog = "https://github.com/ThalesGroup/agilab/releases"
 
 [tool.uv.sources]
 agi-gui = { path = "../../lib/agi-gui", editable = true }

--- a/src/agilab/apps-pages/view_release_decision/pyproject.toml
+++ b/src/agilab/apps-pages/view_release_decision/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-promotion-gate"
-version = "2026.05.18"
+version = "2026.05.19.post1"
 description = "AGILAB page bundle for promotion-gate evidence review."
 readme = { text = "AGILAB page bundle for promotion-gate evidence review.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_release_decision/pyproject.toml
+++ b/src/agilab/apps-pages/view_release_decision/pyproject.toml
@@ -4,6 +4,14 @@ version = "2026.05.18"
 description = "AGILAB page bundle for promotion-gate evidence review."
 readme = { text = "AGILAB page bundle for promotion-gate evidence review.", content-type = "text/markdown" }
 requires-python = ">=3.11"
+keywords = [
+    "agilab",
+    "thalesgroup",
+    "streamlit",
+    "analysis",
+    "page-bundle",
+    "reproducibility",
+]
 dependencies = [
     "agi-gui>=2026.05.12.post3,<2027.0",
     "agi-node>=2026.05.12.post3,<2027.0",
@@ -16,6 +24,15 @@ view_release_decision = "view_release_decision:bundle_root"
 
 
 
+
+[project.urls]
+Documentation = "https://thalesgroup.github.io/agilab"
+Source = "https://github.com/ThalesGroup/agilab/tree/main/src/agilab/apps-pages/view_release_decision"
+Issues = "https://github.com/ThalesGroup/agilab/issues"
+Homepage = "https://github.com/ThalesGroup/agilab"
+Repository = "https://github.com/ThalesGroup/agilab"
+Discussions = "https://github.com/ThalesGroup/agilab/discussions"
+Changelog = "https://github.com/ThalesGroup/agilab/releases"
 
 [tool.uv.sources]
 agi-gui = { path = "../../lib/agi-gui", editable = true }

--- a/src/agilab/apps-pages/view_scenario_cockpit/pyproject.toml
+++ b/src/agilab/apps-pages/view_scenario_cockpit/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-scenario-cockpit"
-version = "2026.05.18"
+version = "2026.05.19.post1"
 description = "AGILAB page bundle for scenario evidence comparison."
 readme = { text = "AGILAB page bundle for scenario evidence comparison.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_scenario_cockpit/pyproject.toml
+++ b/src/agilab/apps-pages/view_scenario_cockpit/pyproject.toml
@@ -4,6 +4,14 @@ version = "2026.05.18"
 description = "AGILAB page bundle for scenario evidence comparison."
 readme = { text = "AGILAB page bundle for scenario evidence comparison.", content-type = "text/markdown" }
 requires-python = ">=3.11"
+keywords = [
+    "agilab",
+    "thalesgroup",
+    "streamlit",
+    "analysis",
+    "page-bundle",
+    "reproducibility",
+]
 dependencies = [
     "agi-gui>=2026.05.12.post3,<2027.0",
     "agi-node>=2026.05.12.post3,<2027.0",
@@ -13,6 +21,15 @@ dependencies = [
 [project.entry-points."agilab.pages"]
 view_scenario_cockpit = "view_scenario_cockpit:bundle_root"
 
+
+[project.urls]
+Documentation = "https://thalesgroup.github.io/agilab"
+Source = "https://github.com/ThalesGroup/agilab/tree/main/src/agilab/apps-pages/view_scenario_cockpit"
+Issues = "https://github.com/ThalesGroup/agilab/issues"
+Homepage = "https://github.com/ThalesGroup/agilab"
+Repository = "https://github.com/ThalesGroup/agilab"
+Discussions = "https://github.com/ThalesGroup/agilab/discussions"
+Changelog = "https://github.com/ThalesGroup/agilab/releases"
 
 [tool.uv.sources]
 agi-gui = { path = "../../lib/agi-gui", editable = true }

--- a/src/agilab/apps-pages/view_shap_explanation/pyproject.toml
+++ b/src/agilab/apps-pages/view_shap_explanation/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-feature-attribution"
-version = "2026.05.18"
+version = "2026.05.19.post1"
 description = "AGILAB page bundle for feature-attribution evidence."
 readme = { text = "AGILAB page bundle for feature-attribution evidence.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_shap_explanation/pyproject.toml
+++ b/src/agilab/apps-pages/view_shap_explanation/pyproject.toml
@@ -4,6 +4,14 @@ version = "2026.05.18"
 description = "AGILAB page bundle for feature-attribution evidence."
 readme = { text = "AGILAB page bundle for feature-attribution evidence.", content-type = "text/markdown" }
 requires-python = ">=3.11"
+keywords = [
+    "agilab",
+    "thalesgroup",
+    "streamlit",
+    "analysis",
+    "page-bundle",
+    "reproducibility",
+]
 dependencies = [
     "agi-gui>=2026.05.13,<2027.0",
     "agi-node>=2026.05.13,<2027.0",
@@ -16,6 +24,15 @@ view_shap_explanation = "view_shap_explanation:bundle_root"
 
 
 
+
+[project.urls]
+Documentation = "https://thalesgroup.github.io/agilab"
+Source = "https://github.com/ThalesGroup/agilab/tree/main/src/agilab/apps-pages/view_shap_explanation"
+Issues = "https://github.com/ThalesGroup/agilab/issues"
+Homepage = "https://github.com/ThalesGroup/agilab"
+Repository = "https://github.com/ThalesGroup/agilab"
+Discussions = "https://github.com/ThalesGroup/agilab/discussions"
+Changelog = "https://github.com/ThalesGroup/agilab/releases"
 
 [tool.uv.sources]
 agi-gui = { path = "../../lib/agi-gui", editable = true }

--- a/src/agilab/apps-pages/view_training_analysis/pyproject.toml
+++ b/src/agilab/apps-pages/view_training_analysis/pyproject.toml
@@ -4,6 +4,14 @@ version = "2026.05.18"
 description = "AGILAB page bundle for training run reporting."
 readme = { text = "AGILAB page bundle for training run reporting.", content-type = "text/markdown" }
 requires-python = ">=3.11"
+keywords = [
+    "agilab",
+    "thalesgroup",
+    "streamlit",
+    "analysis",
+    "page-bundle",
+    "reproducibility",
+]
 dependencies = [
     "agi-gui>=2026.05.12.post3,<2027.0",
     "pandas>=2.3.0",
@@ -17,6 +25,15 @@ view_training_analysis = "view_training_analysis:bundle_root"
 
 
 
+
+[project.urls]
+Documentation = "https://thalesgroup.github.io/agilab"
+Source = "https://github.com/ThalesGroup/agilab/tree/main/src/agilab/apps-pages/view_training_analysis"
+Issues = "https://github.com/ThalesGroup/agilab/issues"
+Homepage = "https://github.com/ThalesGroup/agilab"
+Repository = "https://github.com/ThalesGroup/agilab"
+Discussions = "https://github.com/ThalesGroup/agilab/discussions"
+Changelog = "https://github.com/ThalesGroup/agilab/releases"
 
 [tool.uv.sources]
 agi-gui = { path = "../../lib/agi-gui", editable = true }

--- a/src/agilab/apps-pages/view_training_analysis/pyproject.toml
+++ b/src/agilab/apps-pages/view_training_analysis/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-training-report"
-version = "2026.05.18"
+version = "2026.05.19.post1"
 description = "AGILAB page bundle for training run reporting."
 readme = { text = "AGILAB page bundle for training run reporting.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/test/test_package_split_contract.py
+++ b/test/test_package_split_contract.py
@@ -91,6 +91,39 @@ def test_package_contract_matches_pyproject_names_paths_and_roles() -> None:
         assert data["project"]["version"]
 
 
+def test_page_package_pyprojects_declare_pypi_discoverability_metadata() -> None:
+    required_keywords = {
+        "agilab",
+        "thalesgroup",
+        "streamlit",
+        "page-bundle",
+        "reproducibility",
+    }
+    required_url_keys = {
+        "Documentation",
+        "Source",
+        "Issues",
+        "Homepage",
+        "Repository",
+        "Discussions",
+        "Changelog",
+    }
+
+    for pyproject in sorted((REPO_ROOT / "src/agilab/apps-pages").glob("*/pyproject.toml")):
+        data = _load_toml(pyproject)
+        project = data["project"]
+        package_name = project["name"]
+        keywords = {str(keyword).lower() for keyword in project.get("keywords", [])}
+        urls = project.get("urls", {})
+
+        assert required_keywords <= keywords, package_name
+        assert required_url_keys <= set(urls), package_name
+        assert urls["Documentation"] == "https://thalesgroup.github.io/agilab"
+        assert urls["Repository"] == "https://github.com/ThalesGroup/agilab"
+        assert urls["Homepage"] == "https://github.com/ThalesGroup/agilab"
+        assert urls["Source"].endswith(f"/{pyproject.parent.name}"), package_name
+
+
 def test_internal_dependencies_follow_bundle_or_asset_version_policy() -> None:
     versions = {
         package.name: _load_toml(pyproject_path(REPO_ROOT, package))["project"]["version"]


### PR DESCRIPTION
## Summary

Adds PyPI discoverability metadata to every published AGILAB page-package manifest so `thalesgroup` and AGILAB repository searches can find the split `agi-page-*` packages after their next release.

## Details

- Adds common `keywords` including `thalesgroup` to page-package `pyproject.toml` files.
- Adds `Documentation`, `Source`, `Issues`, `Homepage`, `Repository`, `Discussions`, and `Changelog` project URLs for each page package.
- Adds a package-split regression that fails if a future page package is missing the discoverability metadata.
- Bumps the 14 publishable page-bundle packages to `2026.05.19.post1` so the metadata can be uploaded to PyPI without replacing an existing distribution.

## Release Dispatch

After merge, dispatch `pypi-publish` with:

- `release_tag`: `v2026.05.19.post1-page-metadata`
- `roles`: `page-bundle`
- `allow_post_release`: `true`
- `post_release_reason`: `critical package metadata repair`

This scope publishes page bundles only. The umbrella `agilab` package and Hugging Face Space sync are intentionally skipped because `roles=page-bundle` leaves `umbrella_selected=false`.

## Validation

- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_package_split_contract.py test/test_pyproject_dependency_hygiene.py`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_package_split_contract.py test/test_pyproject_dependency_hygiene.py test/test_release_plan.py test/test_pypi_release_version_policy.py`
- `uv --preview-features extra-build-dependencies run python tools/release_plan.py --roles page-bundle --check-workflow .github/workflows/pypi-publish.yaml --format json --compact`
- `uv --preview-features extra-build-dependencies run python tools/pypi_release_version_policy.py --roles page-bundle --allow-post-release --post-release-reason 'critical package metadata repair'`
- Local wheel metadata smoke for `agi-page-network-map`, confirming version `2026.5.19.post1`, `Keywords` contains `thalesgroup`, and `Project-URL` contains `ThalesGroup/agilab`.
- Live PyPI JSON collision check confirmed `2026.5.19.post1` does not already exist for any publishable page-bundle package.
