### PR TITLE
[codex] update public demo guardrails

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 214,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "0c80669b61bb54681c38f30dff724a59095019ca49198521c37420930ca504ce",
+  "source_digest_sha256": "9212500693daad6e62df233bb96afa4a27b582bf1aa0747c63cb24eeea953cec",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "0c80669b61bb54681c38f30dff724a59095019ca49198521c37420930ca504ce"
+  "target_digest_sha256": "9212500693daad6e62df233bb96afa4a27b582bf1aa0747c63cb24eeea953cec"
 }

--- a/docs/source/demos.rst
+++ b/docs/source/demos.rst
@@ -59,8 +59,8 @@ What each route is for
   Use :doc:`quick-start` if you want the recommended local run instead of a
   public demo.
 
-Four short demos
-----------------
+Short demo routes
+-----------------
 
 Use these as narrow product demos. They are intentionally generic and should
 not depend on private apps or app-specific claims.

--- a/test/test_audit_response_docs.py
+++ b/test/test_audit_response_docs.py
@@ -50,10 +50,10 @@ def test_compatibility_matrix_promotes_clean_package_install_evidence() -> None:
     assert "--first-proof-json first-proof.json --hf-smoke-json hf-space-smoke.json" in docs
 
 
-def test_demo_page_keeps_three_generic_demo_routes() -> None:
+def test_demo_page_keeps_generic_demo_routes() -> None:
     demos = (DOCS_SOURCE / "demos.rst").read_text(encoding="utf-8")
 
-    assert "Four short demos" in demos
+    assert "Short demo routes" in demos
     assert "Local app proof" in demos
     assert "Distributed worker route" in demos
     assert "MLflow tracking route" in demos
@@ -172,7 +172,9 @@ def test_adoption_guide_uses_current_first_proof_wizard() -> None:
 
 def test_quick_start_documents_security_adoption_checkpoint() -> None:
     quick_start = (DOCS_SOURCE / "quick-start.rst").read_text(encoding="utf-8")
-    beta_readiness = (DOCS_SOURCE / "beta-readiness.rst").read_text(encoding="utf-8")
+    security_adoption = (DOCS_SOURCE / "security-adoption.rst").read_text(
+        encoding="utf-8"
+    )
 
     assert "Shared or team adoption check" in quick_start
     assert ":doc:`security-adoption`" in quick_start
@@ -181,9 +183,9 @@ def test_quick_start_documents_security_adoption_checkpoint() -> None:
     assert "AGILAB_APPS_REPOSITORY_ALLOWLIST" in quick_start
     assert "workflow_parity.py --profile security-adoption" in quick_start
     assert "AGILAB_SECURITY_CHECK_STRICT=1" in quick_start
-    assert "test-results/security-check.json" in beta_readiness
-    assert "using the ``shared`` adoption profile" in beta_readiness
-    assert "AGILAB_SECURITY_CHECK_STRICT=1" in beta_readiness
+    assert "security-check.json" in security_adoption
+    assert "security-check --profile shared" in security_adoption
+    assert "AGILAB_SECURITY_CHECK_STRICT=1" in security_adoption
 
 
 def test_readme_uses_recommended_workbench_positioning() -> None:
@@ -225,9 +227,11 @@ def test_proof_capsule_direction_is_explicit_without_fake_cli_claims() -> None:
     assert "SBOM" in combined
     assert "pip-audit" in combined
     assert "wheel hashes" in combined
-    assert "roadmap targets, not\npublished CLI commands today" in readme
-    assert "not yet shipped\nas one archive file or one ``agilab prove`` command" in docs_page
-    assert "define the proof capsule schema before adding a public `.agipack` archive" in roadmap
+    assert "The first public proof-pack layer now adds" in readme
+    assert "A signed `.agipack` archive" in readme
+    assert "remain roadmap work" in readme
+    assert "directory of plain JSON evidence, not yet a signed ``.agipack`` archive" in docs_page
+    assert "operate on `run_manifest.json` and write plain JSON" in roadmap
 
 
 def test_quick_start_documents_public_install_tiers() -> None:

--- a/test/test_hf_space_release_sync.py
+++ b/test/test_hf_space_release_sync.py
@@ -39,3 +39,62 @@ def test_generated_space_readme_uses_valid_hf_emoji_metadata() -> None:
 
     assert "emoji: 🧪" in module.README_TEMPLATE
     assert "emoji: lab_coat" not in module.README_TEMPLATE
+
+
+def test_first_proof_profile_uses_public_weather_demo() -> None:
+    module = _load_module()
+
+    apps, pages = module.profile_entries("first-proof")
+
+    assert apps == ("flight_telemetry_project", "weather_forecast_project")
+    assert pages == ("view_maps", "view_forecast_analysis", "view_release_decision")
+
+
+def test_stage_space_tree_prunes_private_app_entries_before_validation(tmp_path: Path) -> None:
+    module = _load_module()
+    repo = tmp_path / "repo"
+    stage = tmp_path / "stage"
+    stage.mkdir()
+
+    (repo / "src/agilab/apps/builtin/flight_telemetry_project").mkdir(parents=True)
+    (repo / "src/agilab/apps/builtin/weather_forecast_project").mkdir(parents=True)
+    (repo / "src/agilab/apps/private_project").mkdir(parents=True)
+    for page in ("view_maps", "view_forecast_analysis", "view_release_decision"):
+        (repo / "src/agilab/apps-pages" / page).mkdir(parents=True)
+    (repo / "src/agilab").mkdir(parents=True, exist_ok=True)
+    (repo / "docker").mkdir()
+    (repo / "src/agilab/main_page.py").write_text("print('ok')\n", encoding="utf-8")
+    (repo / "src/agilab/apps/private_project/secret.txt").write_text("private\n", encoding="utf-8")
+    (repo / "pyproject.toml").write_text("[project]\nname='agilab'\n", encoding="utf-8")
+    (repo / "uv_config.toml").write_text("", encoding="utf-8")
+    (repo / "docker/install.sh").write_text("#!/usr/bin/env sh\n", encoding="utf-8")
+
+    summary = module.stage_space_tree(repo, stage, profile="first-proof")
+
+    assert summary["apps"] == ["flight_telemetry_project", "weather_forecast_project"]
+    assert not (stage / "src/agilab/apps/private_project").exists()
+    assert (stage / "src/agilab/apps/builtin/flight_telemetry_project").is_dir()
+    assert (stage / "src/agilab/apps/builtin/weather_forecast_project").is_dir()
+
+
+def test_hosted_smoke_receives_profile(monkeypatch, tmp_path: Path) -> None:
+    module = _load_module()
+    captured: list[list[str]] = []
+
+    def _run_command(command):
+        captured.append(list(command))
+        return '{"success": true}'
+
+    monkeypatch.setattr(module, "run_command", _run_command)
+
+    smoke = module.run_hosted_smoke(
+        tmp_path,
+        space_id="demo/agilab",
+        profile="advanced",
+        timeout=1.0,
+        target_seconds=2.0,
+    )
+
+    assert smoke == {"success": True}
+    assert "--profile" in captured[0]
+    assert captured[0][captured[0].index("--profile") + 1] == "advanced"

--- a/test/test_public_demo_links.py
+++ b/test/test_public_demo_links.py
@@ -429,7 +429,7 @@ def test_public_demo_docs_define_flight_and_meteo_routes() -> None:
     assert "``view_release_decision``" in demos
     assert "notebook-migration-skforecast-meteo" in demos
     assert "Notebook migration route" in demos
-    assert "Four short demos" in demos
+    assert "Short demo routes" in demos
     assert "``uav_relay_queue_project`` is the UAV Relay Queue RL demo" in demos
 
     for phrase in (


### PR DESCRIPTION
## Summary

- renames the public demo section heading from `Four short demos` to `Short demo routes`
- updates public docs guardrail assertions after the beta-readiness page removal
- adds HF Space release-sync regression coverage for first-proof profile selection, private app pruning, and hosted smoke profile forwarding
- refreshes the docs mirror stamp from the canonical docs source

## Validation

- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files docs/.docs_source_mirror_stamp.json docs/source/demos.rst test/test_audit_response_docs.py test/test_hf_space_release_sync.py test/test_public_demo_links.py test/test_apps_pages_docs.py`
- `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_apps_pages_docs.py test/test_audit_response_docs.py test/test_hf_space_release_sync.py test/test_public_demo_links.py`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs`
