### PR TITLE
[codex] improve agent run Python API

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,9 @@ to execute a local coding-agent command and write a redacted
 `~/log/agents/`. Command arguments are redacted by default and represented by
 an argv hash; pass `--include-command-args` only when the prompt/arguments are
 safe to store. Use `agilab agent-run list --agent codex --json` or
-`agilab.agent_run.list_agent_runs()` to consume previous run evidence.
+the Python helpers `agilab.agent_run.trace_agent_run()` and
+`agilab.agent_run.list_agent_runs()` to create or consume run evidence from
+automation.
 
 Cluster/Dask support is intentionally part of the base runtime through
 `agi-core`. AGILAB keeps local, pool, and distributed back planes behind the

--- a/README.pypi.md
+++ b/README.pypi.md
@@ -154,7 +154,9 @@ to execute a local coding-agent command and write a redacted
 `~/log/agents/`. Command arguments are redacted by default and represented by
 an argv hash; pass `--include-command-args` only when the prompt/arguments are
 safe to store. Use `agilab agent-run list --agent codex --json` or
-`agilab.agent_run.list_agent_runs()` to consume previous run evidence.
+the Python helpers `agilab.agent_run.trace_agent_run()` and
+`agilab.agent_run.list_agent_runs()` to create or consume run evidence from
+automation.
 
 Cluster/Dask support is intentionally part of the base runtime through
 `agi-core`. AGILAB keeps local, pool, and distributed back planes behind the

--- a/src/agilab/agent_run.py
+++ b/src/agilab/agent_run.py
@@ -14,7 +14,7 @@ import subprocess
 import sys
 import time
 from pathlib import Path
-from typing import Callable, Sequence
+from typing import Callable, Mapping, Sequence
 from uuid import uuid4
 
 from agilab.secret_uri import redact_text
@@ -204,6 +204,67 @@ def _command_payload(config: AgentRunConfig) -> dict[str, object]:
     }
 
 
+def create_agent_run_config(
+    command: Sequence[str],
+    *,
+    agent: str = "agent",
+    label: str = "Agent run",
+    cwd: Path | str | None = None,
+    output_dir: Path | str | None = None,
+    run_id: str | None = None,
+    timeout_seconds: float = float(DEFAULT_TIMEOUT_SECONDS),
+    env_overrides: Mapping[str, str] | None = None,
+    print_only: bool = False,
+    json_output: bool = False,
+    allow_failure: bool = False,
+    include_command_args: bool = False,
+    tags: Sequence[str] = (),
+    metadata: Mapping[str, str] | None = None,
+) -> AgentRunConfig:
+    """Build a validated agent-run config with CLI-compatible defaults.
+
+    This is the Python API equivalent of ``agilab agent-run`` argument
+    resolution. It intentionally accepts an argv sequence, not a shell string,
+    so callers do not accidentally depend on shell parsing or quoting.
+    """
+
+    if isinstance(command, str):
+        raise ValueError("command must be an argv sequence, not a shell string")
+    command_tuple = tuple(str(part) for part in command)
+    if not command_tuple:
+        raise ValueError("command cannot be empty")
+    if timeout_seconds <= 0:
+        raise ValueError("timeout_seconds must be > 0")
+
+    resolved_cwd = Path(cwd).expanduser().resolve() if cwd is not None else Path.cwd().resolve()
+    if not resolved_cwd.is_dir():
+        raise ValueError(f"cwd is not a directory: {resolved_cwd}")
+
+    clean_run_id = _slug(run_id or "", "agent-run") if run_id and run_id.strip() else _new_run_id(agent)
+    resolved_output_dir = (
+        Path(output_dir).expanduser().resolve()
+        if output_dir is not None
+        else _default_output_dir(agent, clean_run_id)
+    )
+
+    return AgentRunConfig(
+        agent=agent,
+        label=label,
+        command=command_tuple,
+        cwd=resolved_cwd,
+        output_dir=resolved_output_dir,
+        run_id=clean_run_id,
+        timeout_seconds=float(timeout_seconds),
+        env_overrides=dict(env_overrides or {}),
+        print_only=bool(print_only),
+        json_output=bool(json_output),
+        allow_failure=bool(allow_failure),
+        include_command_args=bool(include_command_args),
+        tags=_normalize_tags(tags),
+        metadata=dict(metadata or {}),
+    )
+
+
 def _environment_payload(cwd: Path) -> dict[str, object]:
     repo_root = _detect_repo_root(cwd)
     return {
@@ -330,6 +391,42 @@ def run_agent_command(
     }
     manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     return AgentRunResult(manifest=manifest, returncode=returncode)
+
+
+def trace_agent_run(
+    command: Sequence[str],
+    *,
+    agent: str = "agent",
+    label: str = "Agent run",
+    cwd: Path | str | None = None,
+    output_dir: Path | str | None = None,
+    run_id: str | None = None,
+    timeout_seconds: float = float(DEFAULT_TIMEOUT_SECONDS),
+    env_overrides: Mapping[str, str] | None = None,
+    allow_failure: bool = False,
+    include_command_args: bool = False,
+    tags: Sequence[str] = (),
+    metadata: Mapping[str, str] | None = None,
+    runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+    perf_counter: Callable[[], float] = time.perf_counter,
+) -> AgentRunResult:
+    """Trace an agent command directly from Python and write AGILAB evidence."""
+
+    config = create_agent_run_config(
+        command,
+        agent=agent,
+        label=label,
+        cwd=cwd,
+        output_dir=output_dir,
+        run_id=run_id,
+        timeout_seconds=timeout_seconds,
+        env_overrides=env_overrides,
+        allow_failure=allow_failure,
+        include_command_args=include_command_args,
+        tags=tags,
+        metadata=metadata,
+    )
+    return run_agent_command(config, runner=runner, perf_counter=perf_counter)
 
 
 def load_agent_run_manifest(path: Path | str) -> dict[str, object]:
@@ -483,29 +580,25 @@ def parse_args(argv: Sequence[str]) -> AgentRunConfig:
     if args.timeout <= 0:
         parser.error("--timeout must be > 0")
 
-    cwd = Path(args.cwd).expanduser().resolve() if args.cwd else Path.cwd().resolve()
-    if not cwd.is_dir():
-        parser.error(f"--cwd is not a directory: {cwd}")
-    env_overrides = _parse_env_overrides(args.env)
-    metadata = _parse_metadata(args.metadata)
-    run_id = _slug(args.run_id, "agent-run") if args.run_id.strip() else _new_run_id(args.agent)
-    output_dir = Path(args.output_dir).expanduser().resolve() if args.output_dir else _default_output_dir(args.agent, run_id)
-    return AgentRunConfig(
-        agent=args.agent,
-        label=args.label,
-        command=command,
-        cwd=cwd,
-        output_dir=output_dir,
-        run_id=run_id,
-        timeout_seconds=float(args.timeout),
-        env_overrides=env_overrides,
-        print_only=bool(args.print_only),
-        json_output=bool(args.json),
-        allow_failure=bool(args.allow_failure),
-        include_command_args=bool(args.include_command_args),
-        tags=_normalize_tags(args.tag),
-        metadata=metadata,
-    )
+    try:
+        return create_agent_run_config(
+            command,
+            agent=args.agent,
+            label=args.label,
+            cwd=Path(args.cwd).expanduser().resolve() if args.cwd else None,
+            output_dir=Path(args.output_dir).expanduser().resolve() if args.output_dir else None,
+            run_id=args.run_id,
+            timeout_seconds=float(args.timeout),
+            env_overrides=_parse_env_overrides(args.env),
+            print_only=bool(args.print_only),
+            json_output=bool(args.json),
+            allow_failure=bool(args.allow_failure),
+            include_command_args=bool(args.include_command_args),
+            tags=args.tag,
+            metadata=_parse_metadata(args.metadata),
+        )
+    except ValueError as exc:
+        parser.error(str(exc))
 
 
 def _build_list_parser() -> argparse.ArgumentParser:

--- a/test/test_agent_run.py
+++ b/test/test_agent_run.py
@@ -145,6 +145,56 @@ def test_agent_run_manifest_context_supports_tags_and_metadata(tmp_path: Path, c
     assert "env://OPENAI_API_KEY" not in json.dumps(payload)
 
 
+def test_agent_run_public_python_api_uses_cli_defaults(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_module()
+    monkeypatch.setenv("AGILAB_LOG_ABS", str(tmp_path / "logs"))
+
+    config = module.create_agent_run_config(
+        [sys.executable, "-c", "print('api')"],
+        agent="Codex Agent",
+        label="Python API smoke",
+        cwd=ROOT,
+        run_id="api run",
+        env_overrides={"OPENAI_API_KEY": "sk-secret"},
+        tags=("review", "Review", "api smoke"),
+        metadata={"branch": "main", "token": "hidden"},
+    )
+
+    assert config.run_id == "api-run"
+    assert config.output_dir == tmp_path / "logs" / "agents" / "Codex-Agent" / "api-run"
+    assert config.cwd == ROOT
+    assert config.tags == ("review", "api-smoke")
+    assert config.metadata == {"branch": "main", "token": "hidden"}
+
+
+def test_trace_agent_run_public_python_api_executes_and_redacts(tmp_path: Path) -> None:
+    module = _load_module()
+
+    result = module.trace_agent_run(
+        [sys.executable, "-c", "print('api ok')"],
+        agent="codex",
+        label="Python API trace",
+        cwd=ROOT,
+        output_dir=tmp_path,
+        run_id="api-trace",
+        env_overrides={"OPENAI_API_KEY": "sk-secret"},
+        metadata={"note": "using env://OPENAI_API_KEY"},
+        tags=("api",),
+    )
+
+    assert result.returncode == 0
+    assert result.manifest["status"] == "pass"
+    assert result.manifest["run_id"] == "api-trace"
+    assert result.manifest["command"]["argv"] == [sys.executable, "<2 argument(s) redacted>"]
+    assert result.manifest["command"]["env_overrides"]["keys"] == ["OPENAI_API_KEY"]
+    assert result.manifest["context"]["metadata"]["note"] == "using <secret-ref>"
+    assert "sk-secret" not in json.dumps(result.manifest)
+    assert (tmp_path / module.STDOUT_FILENAME).read_text(encoding="utf-8").strip() == "api ok"
+    summary = module.summarize_agent_run(tmp_path)
+    assert summary.run_id == "api-trace"
+    assert summary.tags == ("api",)
+
+
 def test_agent_run_executes_command_and_writes_local_artifacts(tmp_path: Path, capsys) -> None:
     module = _load_module()
 
@@ -316,6 +366,14 @@ def test_agent_run_defaults_and_helper_error_paths(tmp_path: Path, monkeypatch: 
         module._parse_env_overrides(["BROKEN"])
     with pytest.raises(ValueError, match="KEY cannot be empty"):
         module._parse_env_overrides([" =value"])
+    with pytest.raises(ValueError, match="command cannot be empty"):
+        module.create_agent_run_config([], cwd=ROOT)
+    with pytest.raises(ValueError, match="argv sequence"):
+        module.create_agent_run_config("codex review", cwd=ROOT)
+    with pytest.raises(ValueError, match="timeout_seconds must be > 0"):
+        module.create_agent_run_config([sys.executable], cwd=ROOT, timeout_seconds=0)
+    with pytest.raises(ValueError, match="cwd is not a directory"):
+        module.create_agent_run_config([sys.executable], cwd=tmp_path / "missing")
 
     missing_payload = module._file_payload(tmp_path / "missing.txt")
     assert missing_payload == {

--- a/test/test_agent_workflows.py
+++ b/test/test_agent_workflows.py
@@ -81,3 +81,5 @@ def test_agent_run_evidence_command_is_documented() -> None:
         assert "agilab agent-run --agent codex" in text
         assert "agilab.agent_run.v1" in text
         assert "~/log/agents/" in text
+    assert "trace_agent_run" in agent_workflows
+    assert "agilab.agent_run.trace_agent_run()" in readme

--- a/tools/agent_workflows.md
+++ b/tools/agent_workflows.md
@@ -37,7 +37,15 @@ agilab agent-run list --agent codex --json
 or from Python:
 
 ```python
-from agilab.agent_run import list_agent_runs
+from agilab.agent_run import list_agent_runs, trace_agent_run
+
+result = trace_agent_run(
+    ["codex", "review"],
+    agent="codex",
+    label="Review current diff",
+    tags=("review",),
+    metadata={"branch": "main"},
+)
 
 runs = list_agent_runs(agent="codex", limit=5)
 ```


### PR DESCRIPTION
## Summary
- add a CLI-compatible Python config builder for agent run evidence
- add trace_agent_run() so automation can create redacted agent-run manifests without constructing dataclasses manually
- document the Python API and cover it with focused regression tests

## Validation
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_agent_run.py test/test_agent_workflows.py test/test_lab_run.py test/test_pyproject_dependency_hygiene.py