### PR TITLE
[codex] improve HF first-proof robot coverage

### DIFF
--- a/test/test_agilab_widget_robot_matrix.py
+++ b/test/test_agilab_widget_robot_matrix.py
@@ -96,7 +96,7 @@ def test_default_scenarios_cover_isolated_pages_and_current_home_actions() -> No
     assert "isolated-visual-baseline-core-pages" not in [scenario.name for scenario in scenarios]
     assert "isolated-cross-browser-core-pages" not in [scenario.name for scenario in scenarios]
     assert "hf-flight-telemetry-install" not in [scenario.name for scenario in scenarios]
-    assert "hf-flight-telemetry-visual-smoke" not in [scenario.name for scenario in scenarios]
+    assert "hf-first-proof-visual-smoke" not in [scenario.name for scenario in scenarios]
 
 
 def test_opt_in_browser_history_scenario_is_not_part_of_default_all() -> None:
@@ -145,7 +145,7 @@ def test_opt_in_mobile_and_release_evidence_scenarios_are_not_part_of_default_al
     browser_error = module.resolve_scenarios(["isolated-browser-error-core-pages"])[0]
     above_fold = module.resolve_scenarios(["isolated-above-fold-core-pages"])[0]
     visual_baseline = module.resolve_scenarios(["isolated-visual-baseline-core-pages"])[0]
-    hf_visual_smoke = module.resolve_scenarios(["hf-flight-telemetry-visual-smoke"])[0]
+    hf_visual_smoke = module.resolve_scenarios(["hf-first-proof-visual-smoke"])[0]
     cross_browser = module.resolve_scenarios(["isolated-cross-browser-core-pages"])[0]
 
     assert mobile.name not in default_names
@@ -511,29 +511,30 @@ def test_build_robot_command_enables_visual_baseline_controls(tmp_path) -> None:
 
 def test_build_robot_command_enables_hf_visual_smoke_controls(tmp_path) -> None:
     module = _load_module()
-    scenario = module.ALL_SCENARIOS["hf-flight-telemetry-visual-smoke"]
+    scenario = module.ALL_SCENARIOS["hf-first-proof-visual-smoke"]
     options = module.MatrixOptions(
-        apps="flight_telemetry_project",
+        apps="flight_telemetry_project,weather_forecast_project",
         output_dir=tmp_path,
         screenshot_dir=tmp_path / "screenshots",
         timeout_seconds=12.0,
         widget_timeout_seconds=2.0,
         quiet_progress=True,
         no_seed_demo_artifacts=False,
-        url="https://huggingface.co/spaces/jpmorard/agilab?active_app=flight_telemetry_project",
-        active_app="flight_telemetry_project",
+        url="https://huggingface.co/spaces/jpmorard/agilab",
     )
 
     argv, summary_path, progress_path = module.build_robot_command(scenario, options=options)
 
+    assert argv[argv.index("--apps") + 1] == "flight_telemetry_project,weather_forecast_project"
     assert argv[argv.index("--pages") + 1] == "HOME,ORCHESTRATE,WORKFLOW,ANALYSIS"
-    assert argv[argv.index("--url") + 1] == "https://huggingface.co/spaces/jpmorard/agilab?active_app=flight_telemetry_project"
+    assert argv[argv.index("--url") + 1] == "https://huggingface.co/spaces/jpmorard/agilab"
+    assert "--active-app" not in argv
     assert "--success-screenshot" in argv
     assert "--visual-mask-dynamic-regions" in argv
     assert "--above-fold-check" in argv
     assert "--browser-error-check" in argv
-    assert summary_path == tmp_path / "hf-flight-telemetry-visual-smoke.json"
-    assert progress_path == tmp_path / "hf-flight-telemetry-visual-smoke.ndjson"
+    assert summary_path == tmp_path / "hf-first-proof-visual-smoke.json"
+    assert progress_path == tmp_path / "hf-first-proof-visual-smoke.ndjson"
 
 
 def test_build_robot_command_enables_artifact_assertions_for_stateful_journey(tmp_path) -> None:

--- a/test/test_ui_robot_coverage_contract.py
+++ b/test/test_ui_robot_coverage_contract.py
@@ -4,6 +4,7 @@ import importlib.util
 import json
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 
 MODULE_PATH = Path("tools/ui_robot_coverage_contract.py").resolve()
@@ -31,6 +32,25 @@ def test_ui_robot_coverage_contract_passes_for_current_matrix() -> None:
     for action in module.REQUIRED_HIGH_RISK_ACTIONS:
         assert payload["coverage"]["high_risk_actions"][action]
     assert payload["coverage"]["configured_apps_pages_scenarios"] == ["isolated-entry-and-app-pages"]
+    assert payload["coverage"]["hf_first_proof_apps"] == [
+        "flight_telemetry_project",
+        "weather_forecast_project",
+    ]
+    assert payload["coverage"]["hf_visual_smoke_profile_apps"] == [
+        "flight_telemetry_project",
+        "weather_forecast_project",
+    ]
+    assert payload["coverage"]["hf_visual_smoke_profile_scenarios"] == ["hf-first-proof-visual-smoke"]
+    assert payload["coverage"]["hf_robot_scenarios"]["hf-first-proof-visual-smoke"] == {
+        "actions": [],
+        "flags": ["above_fold_check", "browser_error_check", "success_screenshot"],
+        "pages": ["ANALYSIS", "HOME", "ORCHESTRATE", "WORKFLOW"],
+    }
+    assert payload["coverage"]["hf_robot_scenarios"]["hf-flight-telemetry-install"] == {
+        "actions": ["install"],
+        "flags": [],
+        "pages": ["ORCHESTRATE"],
+    }
 
 
 def test_ui_robot_coverage_contract_json_cli(capsys) -> None:
@@ -42,3 +62,84 @@ def test_ui_robot_coverage_contract_json_cli(capsys) -> None:
     payload = json.loads(capsys.readouterr().out)
     assert payload["success"] is True
     assert payload["schema"] == module.SCHEMA
+    assert payload["coverage"]["hf_robot_scenarios"]
+
+
+def test_ui_robot_coverage_contract_reports_hf_first_proof_gaps(monkeypatch) -> None:
+    module = _load_module()
+    core_scenario = SimpleNamespace(
+        name="core-selected-actions",
+        pages="HOME,PROJECT,ORCHESTRATE,WORKFLOW,ANALYSIS,SETTINGS",
+        apps_pages="none",
+        click_action_labels="INSTALL,CHECK distribute,Run -> Load -> Export",
+    )
+    incomplete_hf_visual = SimpleNamespace(
+        name="hf-first-proof-visual-smoke",
+        pages="HOME",
+        apps_pages="none",
+        click_action_labels="",
+        success_screenshot=False,
+        above_fold_check=False,
+        browser_error_check=False,
+    )
+    widget_robot = SimpleNamespace(
+        page_label=lambda page: str(page),
+        resolve_pages=lambda pages: [page.strip() for page in str(pages).split(",") if page.strip()],
+        parse_csv=lambda value: [part.strip() for part in str(value).split(",") if part.strip()],
+        _normalized_label=lambda value: str(value).strip().lower(),
+        public_builtin_apps=lambda: [SimpleNamespace(name="flight_telemetry_project")],
+        configured_apps_pages_for_app=lambda _app: [],
+    )
+    matrix = SimpleNamespace(
+        DEFAULT_SCENARIOS={"core-selected-actions": core_scenario},
+        ALL_SCENARIOS={
+            "core-selected-actions": core_scenario,
+            "hf-first-proof-visual-smoke": incomplete_hf_visual,
+        },
+        OPT_IN_SCENARIOS={"hf-first-proof-visual-smoke": incomplete_hf_visual},
+    )
+    hf_smoke = SimpleNamespace(profile_builtin_app_entries=lambda _profile: {"flight_project"})
+    workflow_parity = SimpleNamespace(
+        _profile_commands=lambda _args: {
+            "hf-visual-smoke-robot": [SimpleNamespace(argv=["--scenario", "legacy-hf-smoke"])]
+        }
+    )
+
+    def fake_load_module(_name, path):
+        if path == module.WIDGET_ROBOT_PATH:
+            return widget_robot
+        if path == module.MATRIX_PATH:
+            return matrix
+        if path == module.HF_SMOKE_PATH:
+            return hf_smoke
+        if path == module.WORKFLOW_PARITY_PATH:
+            return workflow_parity
+        raise AssertionError(f"unexpected module path: {path}")
+
+    monkeypatch.setattr(module, "_load_module", fake_load_module)
+
+    payload = module.evaluate_contract()
+
+    assert payload["success"] is False
+    details = [issue["detail"] for issue in payload["issues"]]
+    assert (
+        "first-proof HF profile is missing public demo apps: "
+        "flight_telemetry_project, weather_forecast_project"
+    ) in details
+    assert "first-proof HF profile still exposes stale demo apps: flight_project" in details
+    assert "hf-visual-smoke-robot does not run hf-first-proof-visual-smoke" in details
+    assert "hf-visual-smoke-robot is missing first-proof apps: flight_project" in details
+    assert any(
+        detail.startswith("hf-first-proof-visual-smoke is missing required pages:")
+        and "ANALYSIS" in detail
+        and "WORKFLOW" in detail
+        for detail in details
+    )
+    assert any(
+        detail.startswith("hf-first-proof-visual-smoke is missing required flags:")
+        and "above_fold_check" in detail
+        and "browser_error_check" in detail
+        and "success_screenshot" in detail
+        for detail in details
+    )
+    assert "hf-flight-telemetry-install is missing from the robot matrix" in details

--- a/test/test_workflow_parity.py
+++ b/test/test_workflow_parity.py
@@ -519,10 +519,13 @@ def test_profile_commands_cover_expected_coverage_and_docs_contracts() -> None:
     assert "screenshots/hf-install-robot" in hf_install_robot.argv
     assert "test-results/hf-install-robot/failure-bundles" in hf_install_robot.argv
     assert _has_with_dependency(hf_install_robot.argv, "playwright")
-    assert hf_visual_smoke_robot.label == "hf flight telemetry visual smoke robot"
+    assert hf_visual_smoke_robot.label == "hf first-proof visual smoke robot"
     assert hf_visual_smoke_robot.timeout_seconds == 25 * 60
     assert hf_visual_smoke_robot.remove_paths == ["test-results/hf-visual-smoke-robot", "screenshots/hf-visual-smoke-robot"]
-    assert "hf-flight-telemetry-visual-smoke" in hf_visual_smoke_robot.argv
+    assert "hf-first-proof-visual-smoke" in hf_visual_smoke_robot.argv
+    assert "flight_telemetry_project,weather_forecast_project" in hf_visual_smoke_robot.argv
+    assert "https://huggingface.co/spaces/jpmorard/agilab" in hf_visual_smoke_robot.argv
+    assert "--active-app" not in hf_visual_smoke_robot.argv
     assert "screenshots/hf-visual-smoke-robot" in hf_visual_smoke_robot.argv
     assert _has_with_dependency(hf_visual_smoke_robot.argv, "playwright")
 
@@ -644,6 +647,14 @@ def test_ui_robot_profile_selection_covers_change_classes() -> None:
         "ui-trend-robot",
     ]
     assert module.select_ui_robot_profiles_for_files([".github/workflows/huggingface.yml"]) == [
+        "hf-install-robot",
+        "hf-visual-smoke-robot",
+    ]
+    assert module.select_ui_robot_profiles_for_files(["tools/hf_space_smoke.py"]) == [
+        "hf-install-robot",
+        "hf-visual-smoke-robot",
+    ]
+    assert module.select_ui_robot_profiles_for_files(["tools/hf_space_release_sync.py"]) == [
         "hf-install-robot",
         "hf-visual-smoke-robot",
     ]

--- a/tools/agilab_widget_robot_matrix.py
+++ b/tools/agilab_widget_robot_matrix.py
@@ -471,11 +471,12 @@ OPT_IN_SCENARIOS: dict[str, RobotScenario] = {
         above_fold_check=True,
         browser_error_check=True,
     ),
-    "hf-flight-telemetry-visual-smoke": RobotScenario(
-        name="hf-flight-telemetry-visual-smoke",
+    "hf-first-proof-visual-smoke": RobotScenario(
+        name="hf-first-proof-visual-smoke",
         description=(
-            "Capture hosted Hugging Face screenshots for entry, ORCHESTRATE, "
-            "WORKFLOW, and ANALYSIS without firing install/run actions."
+            "Capture hosted Hugging Face screenshots for first-proof demo apps "
+            "across entry, ORCHESTRATE, WORKFLOW, and ANALYSIS without firing "
+            "install/run actions."
         ),
         pages="HOME,ORCHESTRATE,WORKFLOW,ANALYSIS",
         apps_pages="none",

--- a/tools/ui_robot_coverage_contract.py
+++ b/tools/ui_robot_coverage_contract.py
@@ -15,9 +15,23 @@ from typing import Any, Sequence
 REPO_ROOT = Path(__file__).resolve().parents[1]
 WIDGET_ROBOT_PATH = REPO_ROOT / "tools" / "agilab_widget_robot.py"
 MATRIX_PATH = REPO_ROOT / "tools" / "agilab_widget_robot_matrix.py"
+HF_SMOKE_PATH = REPO_ROOT / "tools" / "hf_space_smoke.py"
+WORKFLOW_PARITY_PATH = REPO_ROOT / "tools" / "workflow_parity.py"
 SCHEMA = "agilab.ui_robot_coverage_contract.v1"
 REQUIRED_CORE_PAGES = ("HOME", "PROJECT", "ORCHESTRATE", "WORKFLOW", "ANALYSIS", "SETTINGS")
 REQUIRED_HIGH_RISK_ACTIONS = ("INSTALL", "CHECK distribute", "Run -> Load -> Export")
+REQUIRED_HF_FIRST_PROOF_APPS = ("flight_telemetry_project", "weather_forecast_project")
+FORBIDDEN_HF_FIRST_PROOF_APPS = ("flight_project", "meteo_forecast_project")
+REQUIRED_HF_ROBOT_SCENARIOS = {
+    "hf-first-proof-visual-smoke": {
+        "pages": ("HOME", "ORCHESTRATE", "WORKFLOW", "ANALYSIS"),
+        "flags": ("success_screenshot", "above_fold_check", "browser_error_check"),
+    },
+    "hf-flight-telemetry-install": {
+        "pages": ("ORCHESTRATE",),
+        "actions": ("INSTALL",),
+    },
+}
 
 
 @dataclass(frozen=True)
@@ -48,9 +62,26 @@ def _scenario_action_labels(widget_robot: Any, scenario: Any) -> set[str]:
     }
 
 
+def _scenario_flags(scenario: Any) -> set[str]:
+    return {
+        flag
+        for flag in ("success_screenshot", "above_fold_check", "browser_error_check")
+        if bool(getattr(scenario, flag, False))
+    }
+
+
+def _argv_value(argv: Sequence[str], option: str) -> str:
+    try:
+        return argv[argv.index(option) + 1]
+    except (ValueError, IndexError):
+        return ""
+
+
 def evaluate_contract() -> dict[str, Any]:
     widget_robot = _load_module("agilab_widget_robot_contract", WIDGET_ROBOT_PATH)
     matrix = _load_module("agilab_widget_robot_matrix_contract", MATRIX_PATH)
+    hf_smoke = _load_module("hf_space_smoke_contract", HF_SMOKE_PATH)
+    workflow_parity = _load_module("workflow_parity_contract", WORKFLOW_PARITY_PATH)
     issues: list[CoverageIssue] = []
     default_scenarios = list(matrix.DEFAULT_SCENARIOS.values())
     all_scenarios = list(matrix.ALL_SCENARIOS.values())
@@ -100,6 +131,99 @@ def evaluate_contract() -> dict[str, Any]:
     if built_in_apps and not default_apps_all:
         issues.append(CoverageIssue("built_in_app_matrix", "default robot matrix has no scenarios for --apps all"))
 
+    hf_first_proof_apps = sorted(hf_smoke.profile_builtin_app_entries("first-proof"))
+    missing_hf_apps = sorted(set(REQUIRED_HF_FIRST_PROOF_APPS) - set(hf_first_proof_apps))
+    forbidden_hf_apps = sorted(set(FORBIDDEN_HF_FIRST_PROOF_APPS) & set(hf_first_proof_apps))
+    if missing_hf_apps:
+        issues.append(
+            CoverageIssue(
+                "hf_public_demo_app",
+                "first-proof HF profile is missing public demo apps: " + ", ".join(missing_hf_apps),
+            )
+        )
+    if forbidden_hf_apps:
+        issues.append(
+            CoverageIssue(
+                "hf_public_demo_app",
+                "first-proof HF profile still exposes stale demo apps: " + ", ".join(forbidden_hf_apps),
+            )
+        )
+
+    scenario_by_name = {scenario.name: scenario for scenario in all_scenarios}
+    hf_robot_scenarios: dict[str, dict[str, list[str]]] = {}
+    for scenario_name, requirements in REQUIRED_HF_ROBOT_SCENARIOS.items():
+        scenario = scenario_by_name.get(scenario_name)
+        if scenario is None:
+            issues.append(CoverageIssue("hf_robot_scenario", f"{scenario_name} is missing from the robot matrix"))
+            continue
+        pages = sorted(_scenario_pages(widget_robot, scenario))
+        actions = sorted(_scenario_action_labels(widget_robot, scenario))
+        flags = sorted(_scenario_flags(scenario))
+        hf_robot_scenarios[scenario_name] = {
+            "pages": pages,
+            "actions": actions,
+            "flags": flags,
+        }
+        missing_pages = sorted(set(requirements.get("pages", ())) - set(pages))
+        if missing_pages:
+            issues.append(
+                CoverageIssue(
+                    "hf_robot_scenario",
+                    f"{scenario_name} is missing required pages: " + ", ".join(missing_pages),
+                )
+            )
+        missing_actions = sorted(
+            {
+                widget_robot._normalized_label(action)
+                for action in requirements.get("actions", ())
+                if widget_robot._normalized_label(action) not in actions
+            }
+        )
+        if missing_actions:
+            issues.append(
+                CoverageIssue(
+                    "hf_robot_scenario",
+                    f"{scenario_name} is missing required actions: " + ", ".join(missing_actions),
+                )
+            )
+        missing_flags = sorted(set(requirements.get("flags", ())) - set(flags))
+        if missing_flags:
+            issues.append(
+                CoverageIssue(
+                    "hf_robot_scenario",
+                    f"{scenario_name} is missing required flags: " + ", ".join(missing_flags),
+                )
+            )
+
+    parity_profiles = workflow_parity._profile_commands(
+        argparse.Namespace(components=(), skills=(), app_path=None, worker_copy=None)
+    )
+    hf_visual_smoke_profile_apps: list[str] = []
+    hf_visual_smoke_profile_scenarios: list[str] = []
+    for command in parity_profiles.get("hf-visual-smoke-robot", []):
+        scenario = _argv_value(command.argv, "--scenario")
+        if scenario:
+            hf_visual_smoke_profile_scenarios.append(scenario)
+        if scenario == "hf-first-proof-visual-smoke":
+            hf_visual_smoke_profile_apps.extend(widget_robot.parse_csv(_argv_value(command.argv, "--apps")))
+    hf_visual_smoke_profile_apps = sorted(set(hf_visual_smoke_profile_apps))
+    hf_visual_smoke_profile_scenarios = sorted(set(hf_visual_smoke_profile_scenarios))
+    missing_profile_apps = sorted(set(hf_first_proof_apps) - set(hf_visual_smoke_profile_apps))
+    if "hf-first-proof-visual-smoke" not in hf_visual_smoke_profile_scenarios:
+        issues.append(
+            CoverageIssue(
+                "hf_robot_profile",
+                "hf-visual-smoke-robot does not run hf-first-proof-visual-smoke",
+            )
+        )
+    if missing_profile_apps:
+        issues.append(
+            CoverageIssue(
+                "hf_robot_profile",
+                "hf-visual-smoke-robot is missing first-proof apps: " + ", ".join(missing_profile_apps),
+            )
+        )
+
     return {
         "schema": SCHEMA,
         "success": not issues,
@@ -111,6 +235,10 @@ def evaluate_contract() -> dict[str, Any]:
             "configured_apps_pages": configured_apps_pages,
             "configured_apps_pages_scenarios": configured_scenarios,
             "high_risk_actions": action_to_scenarios,
+            "hf_first_proof_apps": hf_first_proof_apps,
+            "hf_visual_smoke_profile_apps": hf_visual_smoke_profile_apps,
+            "hf_visual_smoke_profile_scenarios": hf_visual_smoke_profile_scenarios,
+            "hf_robot_scenarios": hf_robot_scenarios,
             "default_scenarios": [scenario.name for scenario in default_scenarios],
             "opt_in_scenarios": sorted(set(matrix.OPT_IN_SCENARIOS)),
         },
@@ -128,6 +256,7 @@ def render_human(payload: dict[str, Any]) -> str:
     lines.append(f"built_in_apps={len(coverage.get('built_in_apps', []))}")
     lines.append(f"default_scenarios={len(coverage.get('default_scenarios', []))}")
     lines.append(f"opt_in_scenarios={len(coverage.get('opt_in_scenarios', []))}")
+    lines.append(f"hf_robot_scenarios={len(coverage.get('hf_robot_scenarios', []))}")
     return "\n".join(lines)
 
 

--- a/tools/workflow_parity.py
+++ b/tools/workflow_parity.py
@@ -316,7 +316,7 @@ def _profile_descriptions() -> dict[str, str]:
         "ui-trend-robot": "Summarize widget robot NDJSON progress logs for failures, flakes, and slow pages.",
         "ui-cross-browser-robot": "Run the opt-in Firefox and WebKit widget robot smoke scenarios.",
         "hf-install-robot": "Run the hosted Hugging Face flight telemetry INSTALL action robot.",
-        "hf-visual-smoke-robot": "Capture hosted Hugging Face visual smoke screenshots without firing install actions.",
+        "hf-visual-smoke-robot": "Capture hosted Hugging Face first-proof visual smoke screenshots without firing install actions.",
     }
 
 
@@ -441,7 +441,9 @@ def select_ui_robot_profiles_for_files(paths: Sequence[str]) -> list[str]:
             }
         ):
             profiles.add("ui-frontend-smoke")
-        if "huggingface" in lower or lower.startswith(("docker/", "spaces/", ".github/workflows/huggingface")):
+        if "huggingface" in lower or lower.startswith(
+            ("docker/", "spaces/", ".github/workflows/huggingface", "tools/hf_space_", "test/test_hf_space_")
+        ):
             profiles.update({"hf-visual-smoke-robot", "hf-install-robot"})
         if lower.startswith(("tools/workflow_parity.py", "test/test_workflow_parity.py")):
             profiles.update({"ui-robot-contract", "ui-robot-canary", "ui-frontend-smoke"})
@@ -1480,7 +1482,7 @@ def _hf_install_robot_profile() -> list[CommandSpec]:
 def _hf_visual_smoke_robot_profile() -> list[CommandSpec]:
     return [
         CommandSpec(
-            label="hf flight telemetry visual smoke robot",
+            label="hf first-proof visual smoke robot",
             argv=[
                 "uv",
                 "--preview-features",
@@ -1491,13 +1493,11 @@ def _hf_visual_smoke_robot_profile() -> list[CommandSpec]:
                 "python",
                 "tools/agilab_widget_robot_matrix.py",
                 "--scenario",
-                "hf-flight-telemetry-visual-smoke",
+                "hf-first-proof-visual-smoke",
                 "--apps",
-                "flight_telemetry_project",
+                "flight_telemetry_project,weather_forecast_project",
                 "--url",
-                "https://huggingface.co/spaces/jpmorard/agilab?active_app=flight_telemetry_project",
-                "--active-app",
-                "flight_telemetry_project",
+                "https://huggingface.co/spaces/jpmorard/agilab",
                 "--json",
                 "--quiet-progress",
                 "--output-dir",


### PR DESCRIPTION
## Summary
- extend the UI robot coverage contract to verify hosted HF first-proof app coverage
- rename the hosted visual smoke scenario to the app-agnostic first-proof scenario
- ensure workflow parity selects HF robot profiles for hf_space tooling changes

## Validation
- uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files tools/agilab_widget_robot_matrix.py tools/ui_robot_coverage_contract.py tools/workflow_parity.py test/test_agilab_widget_robot_matrix.py test/test_ui_robot_coverage_contract.py test/test_workflow_parity.py
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_agilab_widget_robot_matrix.py test/test_ui_robot_coverage_contract.py test/test_workflow_parity.py
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_ci_workflow.py
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile ui-robot-contract
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile hf-visual-smoke-robot --print-only
- git diff --check