### PR TITLE
[codex] improve HF first-proof app-pages robot coverage

### DIFF
--- a/test/test_agilab_widget_robot_matrix.py
+++ b/test/test_agilab_widget_robot_matrix.py
@@ -95,8 +95,9 @@ def test_default_scenarios_cover_isolated_pages_and_current_home_actions() -> No
     assert "isolated-above-fold-core-pages" not in [scenario.name for scenario in scenarios]
     assert "isolated-visual-baseline-core-pages" not in [scenario.name for scenario in scenarios]
     assert "isolated-cross-browser-core-pages" not in [scenario.name for scenario in scenarios]
-    assert "hf-flight-telemetry-install" not in [scenario.name for scenario in scenarios]
+    assert "hf-first-proof-install" not in [scenario.name for scenario in scenarios]
     assert "hf-first-proof-visual-smoke" not in [scenario.name for scenario in scenarios]
+    assert "hf-first-proof-app-pages-visual-smoke" not in [scenario.name for scenario in scenarios]
 
 
 def test_opt_in_browser_history_scenario_is_not_part_of_default_all() -> None:
@@ -118,10 +119,10 @@ def test_opt_in_hf_install_scenario_is_not_part_of_default_all() -> None:
     module = _load_module()
 
     default_scenarios = module.resolve_scenarios(["all"])
-    hf_scenario = module.resolve_scenarios(["hf-flight-telemetry-install"])[0]
+    hf_scenario = module.resolve_scenarios(["hf-first-proof-install"])[0]
 
-    assert "hf-flight-telemetry-install" not in [scenario.name for scenario in default_scenarios]
-    assert hf_scenario.name == "hf-flight-telemetry-install"
+    assert "hf-first-proof-install" not in [scenario.name for scenario in default_scenarios]
+    assert hf_scenario.name == "hf-first-proof-install"
     assert hf_scenario.pages == "ORCHESTRATE"
     assert hf_scenario.apps_pages == "none"
     assert hf_scenario.action_button_policy == "click-selected"
@@ -146,6 +147,7 @@ def test_opt_in_mobile_and_release_evidence_scenarios_are_not_part_of_default_al
     above_fold = module.resolve_scenarios(["isolated-above-fold-core-pages"])[0]
     visual_baseline = module.resolve_scenarios(["isolated-visual-baseline-core-pages"])[0]
     hf_visual_smoke = module.resolve_scenarios(["hf-first-proof-visual-smoke"])[0]
+    hf_apps_pages_smoke = module.resolve_scenarios(["hf-first-proof-app-pages-visual-smoke"])[0]
     cross_browser = module.resolve_scenarios(["isolated-cross-browser-core-pages"])[0]
 
     assert mobile.name not in default_names
@@ -160,6 +162,7 @@ def test_opt_in_mobile_and_release_evidence_scenarios_are_not_part_of_default_al
     assert above_fold.name not in default_names
     assert visual_baseline.name not in default_names
     assert hf_visual_smoke.name not in default_names
+    assert hf_apps_pages_smoke.name not in default_names
     assert cross_browser.name not in default_names
     assert mobile.viewport_width == 390
     assert mobile.viewport_height == 844
@@ -273,33 +276,32 @@ def test_options_from_args_controls_result_cache(tmp_path) -> None:
 
 def test_build_robot_command_covers_hosted_hf_install_action(tmp_path) -> None:
     module = _load_module()
-    scenario = module.ALL_SCENARIOS["hf-flight-telemetry-install"]
+    scenario = module.ALL_SCENARIOS["hf-first-proof-install"]
     options = module.MatrixOptions(
-        apps="flight_telemetry_project",
+        apps="flight_telemetry_project,weather_forecast_project",
         output_dir=tmp_path,
         screenshot_dir=tmp_path / "screenshots",
         timeout_seconds=90.0,
         widget_timeout_seconds=3.0,
         quiet_progress=True,
         no_seed_demo_artifacts=True,
-        url="https://huggingface.co/spaces/jpmorard/agilab?active_app=flight_telemetry_project",
-        active_app="flight_telemetry_project",
+        url="https://huggingface.co/spaces/jpmorard/agilab",
     )
 
     argv, summary_path, progress_path = module.build_robot_command(scenario, options=options)
 
-    assert argv[argv.index("--apps") + 1] == "flight_telemetry_project"
+    assert argv[argv.index("--apps") + 1] == "flight_telemetry_project,weather_forecast_project"
     assert argv[argv.index("--pages") + 1] == "ORCHESTRATE"
     assert argv[argv.index("--apps-pages") + 1] == "none"
     assert argv[argv.index("--action-button-policy") + 1] == "click-selected"
     assert argv[argv.index("--click-action-labels") + 1] == "INSTALL"
     assert argv[argv.index("--missing-selected-action-policy") + 1] == "fail"
     assert argv[argv.index("--action-timeout") + 1] == "600.0"
-    assert argv[argv.index("--url") + 1] == "https://huggingface.co/spaces/jpmorard/agilab?active_app=flight_telemetry_project"
-    assert argv[argv.index("--active-app") + 1] == "flight_telemetry_project"
-    assert argv[argv.index("--screenshot-dir") + 1] == str(tmp_path / "screenshots" / "hf-flight-telemetry-install")
-    assert summary_path == tmp_path / "hf-flight-telemetry-install.json"
-    assert progress_path == tmp_path / "hf-flight-telemetry-install.ndjson"
+    assert argv[argv.index("--url") + 1] == "https://huggingface.co/spaces/jpmorard/agilab"
+    assert "--active-app" not in argv
+    assert argv[argv.index("--screenshot-dir") + 1] == str(tmp_path / "screenshots" / "hf-first-proof-install")
+    assert summary_path == tmp_path / "hf-first-proof-install.json"
+    assert progress_path == tmp_path / "hf-first-proof-install.ndjson"
 
 
 def test_build_robot_command_enables_browser_history_check(tmp_path) -> None:
@@ -535,6 +537,35 @@ def test_build_robot_command_enables_hf_visual_smoke_controls(tmp_path) -> None:
     assert "--browser-error-check" in argv
     assert summary_path == tmp_path / "hf-first-proof-visual-smoke.json"
     assert progress_path == tmp_path / "hf-first-proof-visual-smoke.ndjson"
+
+
+def test_build_robot_command_enables_hf_app_pages_visual_smoke_controls(tmp_path) -> None:
+    module = _load_module()
+    scenario = module.ALL_SCENARIOS["hf-first-proof-app-pages-visual-smoke"]
+    options = module.MatrixOptions(
+        apps="flight_telemetry_project,weather_forecast_project",
+        output_dir=tmp_path,
+        screenshot_dir=tmp_path / "screenshots",
+        timeout_seconds=12.0,
+        widget_timeout_seconds=2.0,
+        quiet_progress=True,
+        no_seed_demo_artifacts=False,
+        url="https://huggingface.co/spaces/jpmorard/agilab",
+    )
+
+    argv, summary_path, progress_path = module.build_robot_command(scenario, options=options)
+
+    assert argv[argv.index("--apps") + 1] == "flight_telemetry_project,weather_forecast_project"
+    assert argv[argv.index("--pages") + 1] == "none"
+    assert argv[argv.index("--apps-pages") + 1] == "view_maps,view_forecast_analysis,view_release_decision"
+    assert argv[argv.index("--url") + 1] == "https://huggingface.co/spaces/jpmorard/agilab"
+    assert "--active-app" not in argv
+    assert "--success-screenshot" in argv
+    assert "--visual-mask-dynamic-regions" in argv
+    assert "--above-fold-check" in argv
+    assert "--browser-error-check" in argv
+    assert summary_path == tmp_path / "hf-first-proof-app-pages-visual-smoke.json"
+    assert progress_path == tmp_path / "hf-first-proof-app-pages-visual-smoke.ndjson"
 
 
 def test_build_robot_command_enables_artifact_assertions_for_stateful_journey(tmp_path) -> None:

--- a/test/test_ui_robot_coverage_contract.py
+++ b/test/test_ui_robot_coverage_contract.py
@@ -36,18 +36,34 @@ def test_ui_robot_coverage_contract_passes_for_current_matrix() -> None:
         "flight_telemetry_project",
         "weather_forecast_project",
     ]
+    assert payload["coverage"]["hf_install_profile_apps"] == [
+        "flight_telemetry_project",
+        "weather_forecast_project",
+    ]
+    assert payload["coverage"]["hf_install_profile_scenarios"] == ["hf-first-proof-install"]
     assert payload["coverage"]["hf_visual_smoke_profile_apps"] == [
         "flight_telemetry_project",
         "weather_forecast_project",
     ]
-    assert payload["coverage"]["hf_visual_smoke_profile_scenarios"] == ["hf-first-proof-visual-smoke"]
+    assert payload["coverage"]["hf_visual_smoke_profile_scenarios"] == [
+        "hf-first-proof-app-pages-visual-smoke",
+        "hf-first-proof-visual-smoke",
+    ]
     assert payload["coverage"]["hf_robot_scenarios"]["hf-first-proof-visual-smoke"] == {
         "actions": [],
+        "apps_pages": [],
         "flags": ["above_fold_check", "browser_error_check", "success_screenshot"],
         "pages": ["ANALYSIS", "HOME", "ORCHESTRATE", "WORKFLOW"],
     }
-    assert payload["coverage"]["hf_robot_scenarios"]["hf-flight-telemetry-install"] == {
+    assert payload["coverage"]["hf_robot_scenarios"]["hf-first-proof-app-pages-visual-smoke"] == {
+        "actions": [],
+        "apps_pages": ["view_forecast_analysis", "view_maps", "view_release_decision"],
+        "flags": ["above_fold_check", "browser_error_check", "success_screenshot"],
+        "pages": [],
+    }
+    assert payload["coverage"]["hf_robot_scenarios"]["hf-first-proof-install"] == {
         "actions": ["install"],
+        "apps_pages": [],
         "flags": [],
         "pages": ["ORCHESTRATE"],
     }
@@ -101,7 +117,8 @@ def test_ui_robot_coverage_contract_reports_hf_first_proof_gaps(monkeypatch) -> 
     hf_smoke = SimpleNamespace(profile_builtin_app_entries=lambda _profile: {"flight_project"})
     workflow_parity = SimpleNamespace(
         _profile_commands=lambda _args: {
-            "hf-visual-smoke-robot": [SimpleNamespace(argv=["--scenario", "legacy-hf-smoke"])]
+            "hf-install-robot": [SimpleNamespace(argv=["--scenario", "legacy-hf-install"])],
+            "hf-visual-smoke-robot": [SimpleNamespace(argv=["--scenario", "legacy-hf-smoke"])],
         }
     )
 
@@ -128,7 +145,10 @@ def test_ui_robot_coverage_contract_reports_hf_first_proof_gaps(monkeypatch) -> 
     ) in details
     assert "first-proof HF profile still exposes stale demo apps: flight_project" in details
     assert "hf-visual-smoke-robot does not run hf-first-proof-visual-smoke" in details
+    assert "hf-visual-smoke-robot does not run hf-first-proof-app-pages-visual-smoke" in details
     assert "hf-visual-smoke-robot is missing first-proof apps: flight_project" in details
+    assert "hf-install-robot does not run hf-first-proof-install" in details
+    assert "hf-install-robot is missing first-proof apps: flight_project" in details
     assert any(
         detail.startswith("hf-first-proof-visual-smoke is missing required pages:")
         and "ANALYSIS" in detail
@@ -142,4 +162,5 @@ def test_ui_robot_coverage_contract_reports_hf_first_proof_gaps(monkeypatch) -> 
         and "success_screenshot" in detail
         for detail in details
     )
-    assert "hf-flight-telemetry-install is missing from the robot matrix" in details
+    assert "hf-first-proof-app-pages-visual-smoke is missing from the robot matrix" in details
+    assert "hf-first-proof-install is missing from the robot matrix" in details

--- a/test/test_workflow_parity.py
+++ b/test/test_workflow_parity.py
@@ -509,13 +509,14 @@ def test_profile_commands_cover_expected_coverage_and_docs_contracts() -> None:
     assert "isolated-cross-browser-core-pages" in ui_cross_browser_robot[2].argv
     assert ui_cross_browser_robot[2].argv[ui_cross_browser_robot[2].argv.index("--browser") + 1] == "webkit"
     assert all(_has_with_dependency(command.argv, "playwright") for command in ui_cross_browser_robot)
-    assert hf_install_robot.label == "hf flight telemetry install robot"
+    assert hf_install_robot.label == "hf first-proof install robot"
     assert hf_install_robot.timeout_seconds == 25 * 60
     assert hf_install_robot.remove_paths == ["test-results/hf-install-robot", "screenshots/hf-install-robot"]
     assert "tools/agilab_widget_robot_matrix.py" in hf_install_robot.argv
-    assert "hf-flight-telemetry-install" in hf_install_robot.argv
-    assert "flight_telemetry_project" in hf_install_robot.argv
-    assert "https://huggingface.co/spaces/jpmorard/agilab?active_app=flight_telemetry_project" in hf_install_robot.argv
+    assert "hf-first-proof-install" in hf_install_robot.argv
+    assert "flight_telemetry_project,weather_forecast_project" in hf_install_robot.argv
+    assert "https://huggingface.co/spaces/jpmorard/agilab" in hf_install_robot.argv
+    assert "--active-app" not in hf_install_robot.argv
     assert "screenshots/hf-install-robot" in hf_install_robot.argv
     assert "test-results/hf-install-robot/failure-bundles" in hf_install_robot.argv
     assert _has_with_dependency(hf_install_robot.argv, "playwright")
@@ -523,6 +524,7 @@ def test_profile_commands_cover_expected_coverage_and_docs_contracts() -> None:
     assert hf_visual_smoke_robot.timeout_seconds == 25 * 60
     assert hf_visual_smoke_robot.remove_paths == ["test-results/hf-visual-smoke-robot", "screenshots/hf-visual-smoke-robot"]
     assert "hf-first-proof-visual-smoke" in hf_visual_smoke_robot.argv
+    assert "hf-first-proof-app-pages-visual-smoke" in hf_visual_smoke_robot.argv
     assert "flight_telemetry_project,weather_forecast_project" in hf_visual_smoke_robot.argv
     assert "https://huggingface.co/spaces/jpmorard/agilab" in hf_visual_smoke_robot.argv
     assert "--active-app" not in hf_visual_smoke_robot.argv

--- a/tools/agilab_widget_robot_matrix.py
+++ b/tools/agilab_widget_robot_matrix.py
@@ -490,6 +490,24 @@ OPT_IN_SCENARIOS: dict[str, RobotScenario] = {
         above_fold_check=True,
         browser_error_check=True,
     ),
+    "hf-first-proof-app-pages-visual-smoke": RobotScenario(
+        name="hf-first-proof-app-pages-visual-smoke",
+        description=(
+            "Capture hosted Hugging Face screenshots for the first-proof apps-page "
+            "bundles exposed by public demo routes."
+        ),
+        pages="none",
+        apps_pages="view_maps,view_forecast_analysis,view_release_decision",
+        runtime_isolation="isolated",
+        action_button_policy="trial",
+        action_timeout_seconds=30.0,
+        page_timeout_seconds=420.0,
+        target_seconds=1200.0,
+        success_screenshot=True,
+        visual_mask_dynamic_regions=True,
+        above_fold_check=True,
+        browser_error_check=True,
+    ),
     "current-home-first-proof-golden-path": RobotScenario(
         name="current-home-first-proof-golden-path",
         description=(
@@ -510,11 +528,11 @@ OPT_IN_SCENARIOS: dict[str, RobotScenario] = {
         assert_analysis_artifacts=True,
         success_screenshot=True,
     ),
-    "hf-flight-telemetry-install": RobotScenario(
-        name="hf-flight-telemetry-install",
+    "hf-first-proof-install": RobotScenario(
+        name="hf-first-proof-install",
         description=(
-            "Run the hosted Hugging Face flight telemetry INSTALL action and fail "
-            "on fatal install feedback rendered in the page or action log."
+            "Run the hosted Hugging Face first-proof app INSTALL actions and "
+            "fail on fatal install feedback rendered in the page or action log."
         ),
         pages="ORCHESTRATE",
         apps_pages="none",

--- a/tools/ui_robot_coverage_contract.py
+++ b/tools/ui_robot_coverage_contract.py
@@ -22,12 +22,17 @@ REQUIRED_CORE_PAGES = ("HOME", "PROJECT", "ORCHESTRATE", "WORKFLOW", "ANALYSIS",
 REQUIRED_HIGH_RISK_ACTIONS = ("INSTALL", "CHECK distribute", "Run -> Load -> Export")
 REQUIRED_HF_FIRST_PROOF_APPS = ("flight_telemetry_project", "weather_forecast_project")
 FORBIDDEN_HF_FIRST_PROOF_APPS = ("flight_project", "meteo_forecast_project")
+REQUIRED_HF_FIRST_PROOF_APPS_PAGES = ("view_forecast_analysis", "view_maps", "view_release_decision")
 REQUIRED_HF_ROBOT_SCENARIOS = {
     "hf-first-proof-visual-smoke": {
         "pages": ("HOME", "ORCHESTRATE", "WORKFLOW", "ANALYSIS"),
         "flags": ("success_screenshot", "above_fold_check", "browser_error_check"),
     },
-    "hf-flight-telemetry-install": {
+    "hf-first-proof-app-pages-visual-smoke": {
+        "apps_pages": REQUIRED_HF_FIRST_PROOF_APPS_PAGES,
+        "flags": ("success_screenshot", "above_fold_check", "browser_error_check"),
+    },
+    "hf-first-proof-install": {
         "pages": ("ORCHESTRATE",),
         "actions": ("INSTALL",),
     },
@@ -62,6 +67,14 @@ def _scenario_action_labels(widget_robot: Any, scenario: Any) -> set[str]:
     }
 
 
+def _scenario_apps_pages(widget_robot: Any, scenario: Any) -> set[str]:
+    return {
+        name
+        for name in widget_robot.parse_csv(str(getattr(scenario, "apps_pages", "")))
+        if name and name != "none"
+    }
+
+
 def _scenario_flags(scenario: Any) -> set[str]:
     return {
         flag
@@ -75,6 +88,10 @@ def _argv_value(argv: Sequence[str], option: str) -> str:
         return argv[argv.index(option) + 1]
     except (ValueError, IndexError):
         return ""
+
+
+def _argv_values(argv: Sequence[str], option: str) -> list[str]:
+    return [argv[index + 1] for index, value in enumerate(argv[:-1]) if value == option]
 
 
 def evaluate_contract() -> dict[str, Any]:
@@ -159,8 +176,10 @@ def evaluate_contract() -> dict[str, Any]:
         pages = sorted(_scenario_pages(widget_robot, scenario))
         actions = sorted(_scenario_action_labels(widget_robot, scenario))
         flags = sorted(_scenario_flags(scenario))
+        apps_pages = sorted(_scenario_apps_pages(widget_robot, scenario))
         hf_robot_scenarios[scenario_name] = {
             "pages": pages,
+            "apps_pages": apps_pages,
             "actions": actions,
             "flags": flags,
         }
@@ -186,6 +205,14 @@ def evaluate_contract() -> dict[str, Any]:
                     f"{scenario_name} is missing required actions: " + ", ".join(missing_actions),
                 )
             )
+        missing_apps_pages = sorted(set(requirements.get("apps_pages", ())) - set(apps_pages))
+        if missing_apps_pages:
+            issues.append(
+                CoverageIssue(
+                    "hf_robot_scenario",
+                    f"{scenario_name} is missing required apps-pages: " + ", ".join(missing_apps_pages),
+                )
+            )
         missing_flags = sorted(set(requirements.get("flags", ())) - set(flags))
         if missing_flags:
             issues.append(
@@ -198,13 +225,37 @@ def evaluate_contract() -> dict[str, Any]:
     parity_profiles = workflow_parity._profile_commands(
         argparse.Namespace(components=(), skills=(), app_path=None, worker_copy=None)
     )
+    hf_install_profile_apps: list[str] = []
+    hf_install_profile_scenarios: list[str] = []
+    for command in parity_profiles.get("hf-install-robot", []):
+        scenarios = _argv_values(command.argv, "--scenario")
+        hf_install_profile_scenarios.extend(scenarios)
+        if "hf-first-proof-install" in scenarios:
+            hf_install_profile_apps.extend(widget_robot.parse_csv(_argv_value(command.argv, "--apps")))
+    hf_install_profile_apps = sorted(set(hf_install_profile_apps))
+    hf_install_profile_scenarios = sorted(set(hf_install_profile_scenarios))
+    missing_install_profile_apps = sorted(set(hf_first_proof_apps) - set(hf_install_profile_apps))
+    if "hf-first-proof-install" not in hf_install_profile_scenarios:
+        issues.append(
+            CoverageIssue(
+                "hf_robot_profile",
+                "hf-install-robot does not run hf-first-proof-install",
+            )
+        )
+    if missing_install_profile_apps:
+        issues.append(
+            CoverageIssue(
+                "hf_robot_profile",
+                "hf-install-robot is missing first-proof apps: " + ", ".join(missing_install_profile_apps),
+            )
+        )
+
     hf_visual_smoke_profile_apps: list[str] = []
     hf_visual_smoke_profile_scenarios: list[str] = []
     for command in parity_profiles.get("hf-visual-smoke-robot", []):
-        scenario = _argv_value(command.argv, "--scenario")
-        if scenario:
-            hf_visual_smoke_profile_scenarios.append(scenario)
-        if scenario == "hf-first-proof-visual-smoke":
+        scenarios = _argv_values(command.argv, "--scenario")
+        hf_visual_smoke_profile_scenarios.extend(scenarios)
+        if "hf-first-proof-visual-smoke" in scenarios:
             hf_visual_smoke_profile_apps.extend(widget_robot.parse_csv(_argv_value(command.argv, "--apps")))
     hf_visual_smoke_profile_apps = sorted(set(hf_visual_smoke_profile_apps))
     hf_visual_smoke_profile_scenarios = sorted(set(hf_visual_smoke_profile_scenarios))
@@ -214,6 +265,13 @@ def evaluate_contract() -> dict[str, Any]:
             CoverageIssue(
                 "hf_robot_profile",
                 "hf-visual-smoke-robot does not run hf-first-proof-visual-smoke",
+            )
+        )
+    if "hf-first-proof-app-pages-visual-smoke" not in hf_visual_smoke_profile_scenarios:
+        issues.append(
+            CoverageIssue(
+                "hf_robot_profile",
+                "hf-visual-smoke-robot does not run hf-first-proof-app-pages-visual-smoke",
             )
         )
     if missing_profile_apps:
@@ -236,6 +294,8 @@ def evaluate_contract() -> dict[str, Any]:
             "configured_apps_pages_scenarios": configured_scenarios,
             "high_risk_actions": action_to_scenarios,
             "hf_first_proof_apps": hf_first_proof_apps,
+            "hf_install_profile_apps": hf_install_profile_apps,
+            "hf_install_profile_scenarios": hf_install_profile_scenarios,
             "hf_visual_smoke_profile_apps": hf_visual_smoke_profile_apps,
             "hf_visual_smoke_profile_scenarios": hf_visual_smoke_profile_scenarios,
             "hf_robot_scenarios": hf_robot_scenarios,

--- a/tools/workflow_parity.py
+++ b/tools/workflow_parity.py
@@ -315,7 +315,7 @@ def _profile_descriptions() -> dict[str, str]:
         "ui-visual-baseline-robot": "Capture masked UI screenshots and compare them with screenshot baselines.",
         "ui-trend-robot": "Summarize widget robot NDJSON progress logs for failures, flakes, and slow pages.",
         "ui-cross-browser-robot": "Run the opt-in Firefox and WebKit widget robot smoke scenarios.",
-        "hf-install-robot": "Run the hosted Hugging Face flight telemetry INSTALL action robot.",
+        "hf-install-robot": "Run the hosted Hugging Face first-proof INSTALL action robot.",
         "hf-visual-smoke-robot": "Capture hosted Hugging Face first-proof visual smoke screenshots without firing install actions.",
     }
 
@@ -1446,7 +1446,7 @@ def _ui_artifact_capture_robot_profile() -> list[CommandSpec]:
 def _hf_install_robot_profile() -> list[CommandSpec]:
     return [
         CommandSpec(
-            label="hf flight telemetry install robot",
+            label="hf first-proof install robot",
             argv=[
                 "uv",
                 "--preview-features",
@@ -1457,13 +1457,11 @@ def _hf_install_robot_profile() -> list[CommandSpec]:
                 "python",
                 "tools/agilab_widget_robot_matrix.py",
                 "--scenario",
-                "hf-flight-telemetry-install",
+                "hf-first-proof-install",
                 "--apps",
-                "flight_telemetry_project",
+                "flight_telemetry_project,weather_forecast_project",
                 "--url",
-                "https://huggingface.co/spaces/jpmorard/agilab?active_app=flight_telemetry_project",
-                "--active-app",
-                "flight_telemetry_project",
+                "https://huggingface.co/spaces/jpmorard/agilab",
                 "--json",
                 "--quiet-progress",
                 "--output-dir",
@@ -1494,6 +1492,8 @@ def _hf_visual_smoke_robot_profile() -> list[CommandSpec]:
                 "tools/agilab_widget_robot_matrix.py",
                 "--scenario",
                 "hf-first-proof-visual-smoke",
+                "--scenario",
+                "hf-first-proof-app-pages-visual-smoke",
                 "--apps",
                 "flight_telemetry_project,weather_forecast_project",
                 "--url",


### PR DESCRIPTION
## Summary
- add a hosted HF first-proof apps-pages visual smoke scenario for public demo routes
- make the hosted HF install robot first-proof app agnostic across flight and weather apps
- extend the UI robot coverage contract to verify install/profile/app-page scenario drift, including repeated --scenario options

## Validation
- uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files tools/agilab_widget_robot_matrix.py tools/ui_robot_coverage_contract.py tools/workflow_parity.py test/test_agilab_widget_robot_matrix.py test/test_ui_robot_coverage_contract.py test/test_workflow_parity.py
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_agilab_widget_robot_matrix.py test/test_ui_robot_coverage_contract.py test/test_workflow_parity.py
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile ui-robot-contract
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile hf-install-robot --profile hf-visual-smoke-robot --print-only
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_ci_workflow.py
- git diff --check