### PR TITLE
[codex] fix project selector navigation

### DIFF
--- a/src/agilab/page_project_selector.py
+++ b/src/agilab/page_project_selector.py
@@ -2,8 +2,14 @@
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 from typing import Any, Callable, Iterable
+
+NAVIGATION_PAGE_ROUTES_ATTR = "_NAVIGATION_PAGE_ROUTES"
+PROJECT_ROUTE_ID = "project"
+PROJECT_PAGE_PATH = Path("pages/1_PROJECT.py")
+MAIN_NAVIGATION_MODULES = ("__main__", "agilab.main_page")
 
 
 def _unique_project_names(projects: Iterable[Any]) -> list[str]:
@@ -31,6 +37,27 @@ def _refresh_project_names(streamlit: Any, projects: Iterable[Any]) -> list[str]
         return _unique_project_names(refreshed)
     except (AttributeError, OSError, RuntimeError, TypeError, ValueError):
         return _unique_project_names(projects)
+
+
+def _registered_navigation_page(route_id: str) -> Any | None:
+    """Return a registered ``st.Page`` object from the active main navigation run."""
+    for module_name in MAIN_NAVIGATION_MODULES:
+        module = sys.modules.get(module_name)
+        routes = getattr(module, NAVIGATION_PAGE_ROUTES_ATTR, None)
+        if isinstance(routes, dict) and routes.get(route_id) is not None:
+            return routes[route_id]
+    return None
+
+
+def switch_to_project_page(streamlit: Any, *, active_app: str | None = None) -> bool:
+    """Switch to PROJECT using the active ``st.navigation`` page when available."""
+    switch_page = getattr(streamlit, "switch_page", None)
+    if not callable(switch_page):
+        return False
+    if active_app is not None:
+        streamlit.query_params["active_app"] = str(active_app)
+    switch_page(_registered_navigation_page(PROJECT_ROUTE_ID) or PROJECT_PAGE_PATH)
+    return True
 
 
 def render_project_selector(
@@ -74,8 +101,7 @@ def render_project_selector(
     )
     if show_edit_button:
         if edit_host.button(edit_label, key=f"{key}__edit", help=f"Edit {selection}.", width="stretch"):
-            streamlit.query_params["active_app"] = selection
-            streamlit.switch_page(Path("pages/1_PROJECT.py"))
+            switch_to_project_page(streamlit, active_app=selection)
     if selection != current:
         on_change(selection)
     return selection

--- a/src/agilab/pages/3_WORKFLOW.py
+++ b/src/agilab/pages/3_WORKFLOW.py
@@ -40,6 +40,7 @@ _page_project_selector_module = load_local_module(
     fallback_path=Path(__file__).resolve().parents[1] / "page_project_selector.py",
     fallback_name="agilab_page_project_selector_fallback",
 )
+switch_to_project_page = _page_project_selector_module.switch_to_project_page
 _page_docs_module = load_local_module(
     "agilab.page_docs",
     current_file=__file__,
@@ -933,8 +934,7 @@ def sidebar_controls() -> None:
         help=f"Edit {selected_lab}.",
         width="stretch",
     ):
-        st.query_params["active_app"] = selected_lab
-        st.switch_page(Path("pages/1_PROJECT.py"))
+        switch_to_project_page(st, active_app=selected_lab)
     st.session_state["lab_dir_selectbox"] = selected_lab
     st.session_state["lab_dir"] = selected_lab
     if selected_lab != persisted_lab:

--- a/test/test_page_project_selector.py
+++ b/test/test_page_project_selector.py
@@ -141,3 +141,48 @@ def test_project_selector_edit_button_updates_query_and_switches_page() -> None:
     assert streamlit.query_params["active_app"] == "beta_project"
     assert switched == [Path("pages/1_PROJECT.py")]
     assert changed == ["beta_project"]
+
+
+def test_project_selector_edit_button_prefers_registered_navigation_page(monkeypatch) -> None:
+    module = _load_module()
+    route = object()
+    switched: list[object] = []
+
+    class SelectorHost:
+        @staticmethod
+        def selectbox(_label, options, *, index=0, **_kwargs):
+            assert index == 0
+            return options[index]
+
+    class EditHost:
+        @staticmethod
+        def button(_label, **_kwargs):
+            return True
+
+    monkeypatch.setitem(
+        sys.modules,
+        "agilab.main_page",
+        SimpleNamespace(_NAVIGATION_PAGE_ROUTES={"project": route}),
+    )
+    monkeypatch.delattr(sys.modules["__main__"], "_NAVIGATION_PAGE_ROUTES", raising=False)
+
+    streamlit = SimpleNamespace(
+        session_state={},
+        sidebar=SimpleNamespace(
+            info=lambda *_args, **_kwargs: None,
+            columns=lambda *_args, **_kwargs: (SelectorHost(), EditHost()),
+        ),
+        query_params={},
+        switch_page=switched.append,
+    )
+
+    selection = module.render_project_selector(
+        streamlit,
+        ["alpha_project", "beta_project"],
+        "alpha_project",
+        on_change=lambda _selected: None,
+    )
+
+    assert selection == "alpha_project"
+    assert streamlit.query_params["active_app"] == "alpha_project"
+    assert switched == [route]

--- a/test/test_ui_pages.py
+++ b/test/test_ui_pages.py
@@ -648,8 +648,11 @@ def test_agilab_navigation_hides_about_and_settings_from_visible_page_list():
     assert 'title="WORKFLOW"' in source
     assert 'title="ANALYSIS"' in source
     assert "streamlit.sidebar.columns([0.76, 0.24], vertical_alignment=\"bottom\")" in selector_source
-    assert 'streamlit.switch_page(Path("pages/1_PROJECT.py"))' in selector_source
-    assert 'st.switch_page(Path("pages/1_PROJECT.py"))' in pipeline_source
+    assert 'PROJECT_PAGE_PATH = Path("pages/1_PROJECT.py")' in selector_source
+    assert "switch_to_project_page(streamlit, active_app=selection)" in selector_source
+    assert "switch_to_project_page(st, active_app=selected_lab)" in pipeline_source
+    assert 'streamlit.switch_page(Path("pages/1_PROJECT.py"))' not in selector_source
+    assert 'st.switch_page(Path("pages/1_PROJECT.py"))' not in pipeline_source
     assert 'st.sidebar.markdown(f"### [MLflow]({mlflow_url})")' in pipeline_source
     assert 'st.sidebar.columns([0.64, 0.36], vertical_alignment="center")' not in pipeline_source
     assert "stLinkButton" not in pipeline_source


### PR DESCRIPTION
## Summary
- Route PROJECT edit actions through the registered `st.navigation` page object when available.
- Reuse the same PROJECT navigation helper from WORKFLOW.
- Add a focused regression proving the selector prefers the registered page over the legacy file path.

## Root Cause
`st.switch_page(Path("pages/1_PROJECT.py"))` is no longer valid when AGILAB registers PROJECT as a callable `st.Page(...)` in `main_page.py`. Streamlit only accepts registered page objects or exact supported page paths, so the ORCHESTRATE sidebar edit button could raise `Could not find page: pages/1_PROJECT.py`.

## Validation
- `uv --preview-features extra-build-dependencies run --group dev --extra ui pytest -q -o addopts='' test/test_page_project_selector.py test/test_ui_pages.py`
- Initial fresh-venv run hit a cold-start AppTest timeout in `test_agilab_main_page_env_editor`; the failed test passed on immediate rerun, and the full focused slice then passed.
