### PR TITLE
[codex] add evidence claims verifier contract

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -1,9 +1,9 @@
 {
-  "file_count": 214,
+  "file_count": 216,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "b7517fd01d5bf2bd99005e45b3005a21a3da80ecb1069f592f0c2347723f1ced",
+  "source_digest_sha256": "5a9a7244224213988d675b6cf9e3cfbc456643fad9ed1cda0eea1a7a548de4ec",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "b7517fd01d5bf2bd99005e45b3005a21a3da80ecb1069f592f0c2347723f1ced"
+  "target_digest_sha256": "5a9a7244224213988d675b6cf9e3cfbc456643fad9ed1cda0eea1a7a548de4ec"
 }

--- a/docs/source/evidence-claims-policy.rst
+++ b/docs/source/evidence-claims-policy.rst
@@ -1,0 +1,121 @@
+Evidence Claims Policy
+======================
+
+AGILAB evidence is an engineering and reproducibility contract. It helps a
+reviewer understand what ran, which artifacts were produced, which package and
+release were used, and which checks were available at the time. It is not a
+legal opinion, a compliance certification, or a substitute for a production
+governance platform.
+
+This page defines the public-claim boundary for evidence wording in README
+files, docs, release notes, demos, and badges.
+
+Allowed Claims
+--------------
+
+Use these phrases only when the linked implementation or artifact exists.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Claim
+     - Required support
+   * - AGILAB records reproducibility evidence.
+     - A run manifest, stage metadata, or artifact manifest is written.
+   * - AGILAB release proof ties together package, CI, docs, and demo evidence.
+     - The public :doc:`release-proof` page references the current release.
+   * - AGILAB can export a workflow back to a runnable notebook.
+     - The workflow has a notebook export manifest or exported notebook.
+   * - AGILAB can hand evidence to MLflow when the integration is enabled.
+     - The MLflow route is explicitly enabled and the run records the handoff.
+   * - AGILAB UI robot evidence captures public UI behavior.
+     - The robot run stores screenshots, traces, HAR, video, or aggregate JSON.
+   * - AGILAB verifier checks are deterministic engineering checks.
+     - The verifier only recomputes local evidence, hashes, references, and
+       schema contracts; it does not rerun the workflow.
+
+Forbidden Claims And Replacements
+---------------------------------
+
+Do not use the left-hand phrasing as a positive public claim. Use the right-hand
+replacement instead.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Avoid
+     - Use instead
+   * - EU AI Act compliant
+     - designed toward auditability and reproducible engineering evidence
+   * - EU AI Act ready
+     - evidence-assisted review for teams mapping their own obligations
+   * - tamper-proof
+     - tamper-evident only when a shipped verifier recomputes hashes
+   * - certified
+     - supported by local tests, release proof, or published artifacts
+   * - regulator-ready
+     - reviewable by operators and auditors as engineering evidence
+   * - court-admissible evidence
+     - structured evidence bundle for independent review
+   * - production-grade governance
+     - controlled evaluation and shared-use hardening boundary
+   * - full audit trail
+     - bounded evidence trail for the documented AGILAB workflow
+   * - cryptographically anchored
+     - package provenance, hashes, or attestations only for the exact shipped path
+   * - SLSA compliant
+     - supply-chain evidence using Trusted Publishing, hashes, SBOM, audit, and
+       provenance where the release proof shows those artifacts
+
+Verifier Claim Boundary
+-----------------------
+
+The verifier contract is deliberately read-only:
+
+* it may load manifests and evidence bundles
+* it may recompute content hashes and reference closure
+* it may validate schema versions and expected files
+* it may compare release metadata against local evidence
+* it must not rerun user code, notebook cells, cluster jobs, or UI workflows
+* it must not claim legal compliance, certification, production readiness, or
+  external auditor approval
+
+Stable Verifier Codes
+---------------------
+
+AGILAB verifier-style tools should prefer stable, machine-readable codes. The
+initial public contract is:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Code
+     - Meaning
+   * - ``AGI_VERIFY_OK``
+     - Verification completed without a detected evidence failure.
+   * - ``AGI_VERIFY_MANIFEST_MISSING``
+     - A required manifest is absent.
+   * - ``AGI_VERIFY_SCHEMA_ERROR``
+     - A manifest or evidence file has an unsupported shape.
+   * - ``AGI_VERIFY_ARTIFACT_HASH_FAILED``
+     - An artifact hash does not match the recorded value.
+   * - ``AGI_VERIFY_REFERENCE_DANGLING``
+     - A manifest reference points to a missing file or event.
+   * - ``AGI_VERIFY_NOTEBOOK_EXPORT_FAILED``
+     - A notebook export manifest or exported notebook is incomplete.
+   * - ``AGI_VERIFY_MLFLOW_REF_DANGLING``
+     - An MLflow handoff reference is present but cannot be resolved locally.
+   * - ``AGI_VERIFY_RELEASE_PROOF_MISMATCH``
+     - Release evidence disagrees with package, tag, docs, or CI metadata.
+   * - ``AGI_VERIFY_UNSUPPORTED_CLAIM``
+     - A public claim is broader than the evidence can support.
+
+These codes are engineering outcomes. They do not certify legal compliance,
+security posture, production suitability, or audit admissibility.
+
+Maintenance Rule
+----------------
+
+When a new public evidence claim is added, update this page in the same change
+as the implementation or artifact that supports the claim. If the claim is only
+roadmap, say so explicitly and keep it out of badges and release-proof language.

--- a/docs/source/evidence-taxonomy.rst
+++ b/docs/source/evidence-taxonomy.rst
@@ -1,0 +1,105 @@
+Evidence Taxonomy
+=================
+
+AGILAB evidence should be easy to inspect without rerunning the workflow. This
+taxonomy defines the first shared vocabulary for run manifests, proof bundles,
+notebook exports, UI robot evidence, MLflow handoff records, and release proof.
+
+Common Event Envelope
+---------------------
+
+Evidence events should use a small common envelope when they are serialized into
+JSON evidence bundles:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Field
+     - Meaning
+   * - ``schema_version``
+     - Version of the evidence event schema.
+   * - ``event_type``
+     - One of the event names listed below.
+   * - ``run_id``
+     - AGILAB run, proof, robot, release, or agent-run identifier.
+   * - ``seq``
+     - Monotonic sequence number within the evidence bundle.
+   * - ``created_at_utc``
+     - UTC timestamp recorded by the producing tool.
+   * - ``artifact_sha256``
+     - SHA-256 of the referenced artifact when the event has one.
+   * - ``prev_event_hash``
+     - Optional previous event hash for future tamper-evident chains.
+   * - ``event_hash``
+     - Optional hash of the canonicalized event envelope and payload.
+   * - ``payload``
+     - Event-specific metadata. It must not contain secrets or large raw
+       artifacts.
+
+Event Types
+-----------
+
+.. list-table::
+   :header-rows: 1
+
+   * - Event type
+     - Purpose
+   * - ``run_manifest_event``
+     - Records the top-level run manifest, selected app, environment, and
+       command boundary.
+   * - ``stage_transition_event``
+     - Records a workflow, DAG, or pipeline stage state transition.
+   * - ``artifact_event``
+     - Records a produced file, directory manifest, or content hash.
+   * - ``notebook_export_event``
+     - Records an exported notebook or notebook export manifest.
+   * - ``mlflow_handoff_event``
+     - Records an MLflow tracking or registry handoff when that integration is
+       enabled.
+   * - ``ui_robot_event``
+     - Records screenshots, traces, HAR, video, aggregate JSON, and replay
+       commands from UI robot validation.
+   * - ``agent_run_event``
+     - Records a coding-agent or assistant-backed command through the AGILAB
+       agent-run evidence surface.
+   * - ``policy_check_event``
+     - Records a deterministic policy or promotion gate decision.
+   * - ``release_proof_event``
+     - Records release tag, package, docs, CI, coverage, SBOM, audit, or
+       provenance evidence used in release proof.
+
+Redaction Rules
+---------------
+
+Evidence payloads must not store secrets, raw prompts that contain credentials,
+full notebook outputs with sensitive data, or large artifact bodies. Prefer:
+
+* content hashes over raw content
+* stable reason codes over free text when a code is enough
+* local file references over embedded blobs
+* explicit ``redacted`` markers when a field was intentionally removed
+
+Verifier Scope
+--------------
+
+A verifier consumes this taxonomy to check evidence without rerunning work. It
+may validate:
+
+* schema versions
+* required event fields
+* monotonic sequence numbers
+* artifact hash matches
+* reference closure
+* release-proof metadata consistency
+
+It must not validate facts outside the evidence bundle, such as legal
+compliance, model correctness, production suitability, or whether an external
+auditor accepts the evidence.
+
+Roadmap Boundary
+----------------
+
+Optional ``prev_event_hash`` and ``event_hash`` fields make room for a future
+tamper-evident chain. Until that verifier is shipped and referenced from the
+release proof, public wording must stay at "hash-backed evidence" or
+"designed toward tamper-evident chains", not "tamper-proof".

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -38,6 +38,8 @@ references, and example projects.
    Newcomer guide <newcomer-guide>
    Local first proof <quick-start>
    Release proof <release-proof>
+   Evidence claims policy <evidence-claims-policy>
+   Evidence taxonomy <evidence-taxonomy>
    First-failure recovery <newcomer-troubleshooting>
    Compatibility matrix <compatibility-matrix>
 

--- a/test/test_evidence_claims_policy.py
+++ b/test/test_evidence_claims_policy.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+DOCS_SOURCE = Path("docs/source")
+CLAIMS_POLICY = DOCS_SOURCE / "evidence-claims-policy.rst"
+EVIDENCE_TAXONOMY = DOCS_SOURCE / "evidence-taxonomy.rst"
+INDEX = DOCS_SOURCE / "index.rst"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_evidence_claim_pages_are_linked_from_docs_index() -> None:
+    index = _read(INDEX)
+
+    assert "Evidence claims policy <evidence-claims-policy>" in index
+    assert "Evidence taxonomy <evidence-taxonomy>" in index
+
+
+def test_evidence_claim_policy_declares_allowed_and_forbidden_boundaries() -> None:
+    text = _read(CLAIMS_POLICY)
+
+    for phrase in (
+        "AGILAB evidence is an engineering and reproducibility contract",
+        "Allowed Claims",
+        "Forbidden Claims And Replacements",
+        "Verifier Claim Boundary",
+        "Stable Verifier Codes",
+        "must not claim legal compliance",
+        "These codes are engineering outcomes",
+    ):
+        assert phrase in text
+
+    replacements = {
+        "EU AI Act compliant": "designed toward auditability",
+        "EU AI Act ready": "evidence-assisted review",
+        "tamper-proof": "tamper-evident only when a shipped verifier recomputes hashes",
+        "certified": "supported by local tests, release proof, or published artifacts",
+        "regulator-ready": "reviewable by operators and auditors as engineering evidence",
+        "court-admissible evidence": "structured evidence bundle for independent review",
+        "production-grade governance": "controlled evaluation and shared-use hardening boundary",
+        "full audit trail": "bounded evidence trail for the documented AGILAB workflow",
+        "cryptographically anchored": "package provenance, hashes, or attestations",
+        "SLSA compliant": "supply-chain evidence using Trusted Publishing",
+    }
+    for unsupported, replacement in replacements.items():
+        assert unsupported in text
+        assert replacement in text
+
+
+def test_evidence_taxonomy_declares_events_and_read_only_verifier_scope() -> None:
+    text = _read(EVIDENCE_TAXONOMY)
+
+    for event_type in (
+        "run_manifest_event",
+        "stage_transition_event",
+        "artifact_event",
+        "notebook_export_event",
+        "mlflow_handoff_event",
+        "ui_robot_event",
+        "agent_run_event",
+        "policy_check_event",
+        "release_proof_event",
+    ):
+        assert event_type in text
+
+    for field in (
+        "schema_version",
+        "event_type",
+        "run_id",
+        "seq",
+        "artifact_sha256",
+        "prev_event_hash",
+        "event_hash",
+    ):
+        assert field in text
+
+    assert "without rerunning work" in text
+    assert "must not validate facts outside the evidence bundle" in text
+    assert "designed toward tamper-evident chains" in text
+
+
+def test_public_entry_points_do_not_make_unsupported_evidence_claims() -> None:
+    public_text = "\n".join(
+        _read(path)
+        for path in (
+            Path("README.md"),
+            Path("README.pypi.md"),
+            DOCS_SOURCE / "index.rst",
+            DOCS_SOURCE / "release-proof.rst",
+            DOCS_SOURCE / "security-adoption.rst",
+        )
+    )
+
+    unsupported_positive_claims = (
+        "EU AI Act compliant",
+        "EU AI Act ready",
+        "tamper-proof",
+        "regulator-ready",
+        "court-admissible evidence",
+        "production-grade governance",
+        "full audit trail",
+        "SLSA compliant",
+        "certified audit evidence",
+    )
+    for claim in unsupported_positive_claims:
+        assert claim not in public_text
+
+
+def test_verifier_error_code_contract_is_machine_readable() -> None:
+    text = _read(CLAIMS_POLICY)
+
+    expected_codes = (
+        "AGI_VERIFY_OK",
+        "AGI_VERIFY_MANIFEST_MISSING",
+        "AGI_VERIFY_SCHEMA_ERROR",
+        "AGI_VERIFY_ARTIFACT_HASH_FAILED",
+        "AGI_VERIFY_REFERENCE_DANGLING",
+        "AGI_VERIFY_NOTEBOOK_EXPORT_FAILED",
+        "AGI_VERIFY_MLFLOW_REF_DANGLING",
+        "AGI_VERIFY_RELEASE_PROOF_MISMATCH",
+        "AGI_VERIFY_UNSUPPORTED_CLAIM",
+    )
+    for code in expected_codes:
+        assert f"``{code}``" in text
+
+    assert len(expected_codes) == len(set(expected_codes))


### PR DESCRIPTION
## Summary
- add public evidence-claim boundary docs with allowed and forbidden wording
- add an evidence taxonomy and read-only verifier-code contract
- add regression coverage so unsupported public evidence claims and docs links do not drift

## Validation
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files docs/source/evidence-claims-policy.rst docs/source/evidence-taxonomy.rst docs/source/index.rst docs/.docs_source_mirror_stamp.json test/test_evidence_claims_policy.py`
- `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_evidence_claims_policy.py`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs`
