### PR TITLE
[codex] Add agent protocol event evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,10 @@ to execute a local coding-agent command and write a redacted
 `agilab.agent_run.v1` manifest plus local stdout/stderr artifacts under
 `~/log/agents/`. Command arguments are redacted by default and represented by
 an argv hash; pass `--include-command-args` only when the prompt/arguments are
-safe to store. Use `agilab agent-run list --agent codex --json` or
+safe to store. Add `--protocol-adapter mcp` or `--capability app-as-tool` as
+metadata-only labels when experimenting with agent protocol bridges; the base
+package records those labels and lifecycle events without depending on the
+protocol stacks. Use `agilab agent-run list --agent codex --json` or
 the Python helpers `agilab.agent_run.trace_agent_run()` and
 `agilab.agent_run.list_agent_runs()` to create or consume run evidence from
 automation.

--- a/README.pypi.md
+++ b/README.pypi.md
@@ -154,7 +154,10 @@ to execute a local coding-agent command and write a redacted
 `agilab.agent_run.v1` manifest plus local stdout/stderr artifacts under
 `~/log/agents/`. Command arguments are redacted by default and represented by
 an argv hash; pass `--include-command-args` only when the prompt/arguments are
-safe to store. Use `agilab agent-run list --agent codex --json` or
+safe to store. Add `--protocol-adapter mcp` or `--capability app-as-tool` as
+metadata-only labels when experimenting with agent protocol bridges; the base
+package records those labels and lifecycle events without depending on the
+protocol stacks. Use `agilab agent-run list --agent codex --json` or
 the Python helpers `agilab.agent_run.trace_agent_run()` and
 `agilab.agent_run.list_agent_runs()` to create or consume run evidence from
 automation.

--- a/src/agilab/agent_run.py
+++ b/src/agilab/agent_run.py
@@ -47,6 +47,8 @@ class AgentRunConfig:
     include_command_args: bool = False
     tags: tuple[str, ...] = ()
     metadata: dict[str, str] = field(default_factory=dict)
+    protocol_adapters: tuple[str, ...] = ()
+    capabilities: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -136,6 +138,17 @@ def _normalize_tags(raw_values: Sequence[str]) -> tuple[str, ...]:
     return tuple(tags)
 
 
+def _normalize_slug_values(raw_values: Sequence[str]) -> tuple[str, ...]:
+    values: list[str] = []
+    seen: set[str] = set()
+    for raw in raw_values:
+        clean = _slug(raw, "").casefold()
+        if clean and clean not in seen:
+            values.append(clean)
+            seen.add(clean)
+    return tuple(values)
+
+
 def _redacted_env_payload(env_overrides: dict[str, str]) -> dict[str, object]:
     return {
         "keys": sorted(env_overrides),
@@ -162,6 +175,36 @@ def _context_payload(config: AgentRunConfig) -> dict[str, object]:
         "metadata": metadata,
         "metadata_redacted": metadata_redacted,
     }
+
+
+def _protocol_payload(config: AgentRunConfig) -> dict[str, object]:
+    return {
+        "adapters": list(config.protocol_adapters),
+        "capabilities": list(config.capabilities),
+        "mode": "metadata-only" if config.protocol_adapters or config.capabilities else "none",
+        "dependency_boundary": (
+            "Protocol bridges are recorded as manifest metadata here; concrete MCP, A2A, "
+            "AG-UI, FastAPI, or similar adapters must stay behind optional integrations."
+        ),
+    }
+
+
+def _event_payload(
+    sequence: int,
+    event_type: str,
+    *,
+    timestamp: str,
+    status: str,
+    **fields: object,
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "sequence": sequence,
+        "timestamp": timestamp,
+        "type": event_type,
+        "status": status,
+    }
+    payload.update({key: value for key, value in fields.items() if value is not None})
+    return payload
 
 
 def _file_payload(path: Path) -> dict[str, object]:
@@ -220,6 +263,8 @@ def create_agent_run_config(
     include_command_args: bool = False,
     tags: Sequence[str] = (),
     metadata: Mapping[str, str] | None = None,
+    protocol_adapters: Sequence[str] = (),
+    capabilities: Sequence[str] = (),
 ) -> AgentRunConfig:
     """Build a validated agent-run config with CLI-compatible defaults.
 
@@ -262,6 +307,8 @@ def create_agent_run_config(
         include_command_args=bool(include_command_args),
         tags=_normalize_tags(tags),
         metadata=dict(metadata or {}),
+        protocol_adapters=_normalize_slug_values(protocol_adapters),
+        capabilities=_normalize_slug_values(capabilities),
     )
 
 
@@ -285,6 +332,7 @@ def _artifact_paths(output_dir: Path) -> dict[str, Path]:
 def build_planned_manifest(config: AgentRunConfig) -> dict[str, object]:
     """Build a trace manifest without executing the command."""
     artifacts = _artifact_paths(config.output_dir)
+    planned_at = _utc_now()
     return {
         "schema_version": 1,
         "kind": TRACE_KIND,
@@ -295,6 +343,7 @@ def build_planned_manifest(config: AgentRunConfig) -> dict[str, object]:
         "returncode": None,
         "command": _command_payload(config),
         "context": _context_payload(config),
+        "protocols": _protocol_payload(config),
         "environment": _environment_payload(config.cwd),
         "timing": {
             "started_at": None,
@@ -307,6 +356,16 @@ def build_planned_manifest(config: AgentRunConfig) -> dict[str, object]:
             "stdout": str(artifacts["stdout"]),
             "stderr": str(artifacts["stderr"]),
         },
+        "events": [
+            _event_payload(
+                1,
+                "agent.run.planned",
+                timestamp=planned_at,
+                status="planned",
+                protocol_adapters=list(config.protocol_adapters),
+                capabilities=list(config.capabilities),
+            )
+        ],
         "notes": [
             "Command arguments are redacted by default; argv_sha256 preserves comparison without exposing prompts.",
             "Command output is stored in local artifact files, not embedded in the manifest.",
@@ -332,6 +391,16 @@ def run_agent_command(
     env.update(config.env_overrides)
     started_at = _utc_now()
     started = perf_counter()
+    events: list[dict[str, object]] = [
+        _event_payload(
+            1,
+            "agent.run.started",
+            timestamp=started_at,
+            status="running",
+            protocol_adapters=list(config.protocol_adapters),
+            capabilities=list(config.capabilities),
+        )
+    ]
     timed_out = False
     try:
         proc = runner(
@@ -357,10 +426,29 @@ def run_agent_command(
         stderr = (stderr + f"\nTimed out after {config.timeout_seconds:.0f}s").strip()
     duration_seconds = perf_counter() - started
     finished_at = _utc_now()
+    events.append(
+        _event_payload(
+            2,
+            "agent.command.timeout" if timed_out else "agent.command.completed",
+            timestamp=finished_at,
+            status="timeout" if timed_out else "completed",
+            returncode=returncode,
+            duration_seconds=duration_seconds,
+        )
+    )
 
     stdout_path.write_text(stdout, encoding="utf-8")
     stderr_path.write_text(stderr, encoding="utf-8")
     status = "pass" if returncode == 0 else "timeout" if timed_out else "fail"
+    events.append(
+        _event_payload(
+            3,
+            "agent.artifacts.written",
+            timestamp=finished_at,
+            status=status,
+            artifacts=["stdout", "stderr"],
+        )
+    )
     manifest: dict[str, object] = {
         "schema_version": 1,
         "kind": TRACE_KIND,
@@ -371,6 +459,7 @@ def run_agent_command(
         "returncode": returncode,
         "command": _command_payload(config),
         "context": _context_payload(config),
+        "protocols": _protocol_payload(config),
         "environment": _environment_payload(config.cwd),
         "timing": {
             "started_at": started_at,
@@ -383,6 +472,7 @@ def run_agent_command(
             "stdout": _file_payload(stdout_path),
             "stderr": _file_payload(stderr_path),
         },
+        "events": events,
         "notes": [
             "Command arguments are redacted by default; argv_sha256 preserves comparison without exposing prompts.",
             "Command output is stored in local artifact files, not embedded in the manifest.",
@@ -407,6 +497,8 @@ def trace_agent_run(
     include_command_args: bool = False,
     tags: Sequence[str] = (),
     metadata: Mapping[str, str] | None = None,
+    protocol_adapters: Sequence[str] = (),
+    capabilities: Sequence[str] = (),
     runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
     perf_counter: Callable[[], float] = time.perf_counter,
 ) -> AgentRunResult:
@@ -425,6 +517,8 @@ def trace_agent_run(
         include_command_args=include_command_args,
         tags=tags,
         metadata=metadata,
+        protocol_adapters=protocol_adapters,
+        capabilities=capabilities,
     )
     return run_agent_command(config, runner=runner, perf_counter=perf_counter)
 
@@ -557,6 +651,18 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--env", action="append", default=[], help="Environment override passed to the command as KEY=VALUE.")
     parser.add_argument("--metadata", action="append", default=[], help="Structured manifest context as KEY=VALUE.")
     parser.add_argument("--tag", action="append", default=[], help="Tag stored in the manifest context. May be repeated.")
+    parser.add_argument(
+        "--protocol-adapter",
+        action="append",
+        default=[],
+        help="Protocol bridge observed or intended for this run, for example mcp, a2a, ag-ui, or fastapi.",
+    )
+    parser.add_argument(
+        "--capability",
+        action="append",
+        default=[],
+        help="Capability exercised by this run, for example app-as-tool, notebook-export, or evidence-review.",
+    )
     parser.add_argument("--json", action="store_true", help="Print the trace manifest JSON.")
     parser.add_argument("--print-only", action="store_true", help="Print the planned trace without executing the command.")
     parser.add_argument("--allow-failure", action="store_true", help="Return 0 even if the traced command fails.")
@@ -596,6 +702,8 @@ def parse_args(argv: Sequence[str]) -> AgentRunConfig:
             include_command_args=bool(args.include_command_args),
             tags=args.tag,
             metadata=_parse_metadata(args.metadata),
+            protocol_adapters=args.protocol_adapter,
+            capabilities=args.capability,
         )
     except ValueError as exc:
         parser.error(str(exc))

--- a/test/test_agent_run.py
+++ b/test/test_agent_run.py
@@ -51,6 +51,12 @@ def test_agent_run_print_only_json_is_redacted(tmp_path: Path, capsys) -> None:
             str(tmp_path),
             "--env",
             "OPENAI_API_KEY=sk-secret",
+            "--protocol-adapter",
+            "AG-UI",
+            "--protocol-adapter",
+            "ag ui",
+            "--capability",
+            "app as tool",
             "--json",
             "--print-only",
             "--",
@@ -71,6 +77,12 @@ def test_agent_run_print_only_json_is_redacted(tmp_path: Path, capsys) -> None:
     assert payload["command"]["env_overrides"]["keys"] == ["OPENAI_API_KEY"]
     assert payload["command"]["env_overrides"]["value_redacted"]["OPENAI_API_KEY"] is True
     assert payload["command"]["env_overrides"]["secret_like"]["OPENAI_API_KEY"] is True
+    assert payload["protocols"]["adapters"] == ["ag-ui"]
+    assert payload["protocols"]["capabilities"] == ["app-as-tool"]
+    assert payload["protocols"]["mode"] == "metadata-only"
+    assert payload["events"][0]["type"] == "agent.run.planned"
+    assert payload["events"][0]["protocol_adapters"] == ["ag-ui"]
+    assert payload["events"][0]["capabilities"] == ["app-as-tool"]
     assert "sk-secret" not in json.dumps(payload)
     assert "review" not in json.dumps(payload)
 
@@ -158,6 +170,8 @@ def test_agent_run_public_python_api_uses_cli_defaults(tmp_path: Path, monkeypat
         env_overrides={"OPENAI_API_KEY": "sk-secret"},
         tags=("review", "Review", "api smoke"),
         metadata={"branch": "main", "token": "hidden"},
+        protocol_adapters=("mcp", "MCP"),
+        capabilities=("evidence review",),
     )
 
     assert config.run_id == "api-run"
@@ -165,6 +179,8 @@ def test_agent_run_public_python_api_uses_cli_defaults(tmp_path: Path, monkeypat
     assert config.cwd == ROOT
     assert config.tags == ("review", "api-smoke")
     assert config.metadata == {"branch": "main", "token": "hidden"}
+    assert config.protocol_adapters == ("mcp",)
+    assert config.capabilities == ("evidence-review",)
 
 
 def test_trace_agent_run_public_python_api_executes_and_redacts(tmp_path: Path) -> None:
@@ -180,6 +196,8 @@ def test_trace_agent_run_public_python_api_executes_and_redacts(tmp_path: Path) 
         env_overrides={"OPENAI_API_KEY": "sk-secret"},
         metadata={"note": "using env://OPENAI_API_KEY"},
         tags=("api",),
+        protocol_adapters=("mcp",),
+        capabilities=("agent-as-tool",),
     )
 
     assert result.returncode == 0
@@ -188,6 +206,13 @@ def test_trace_agent_run_public_python_api_executes_and_redacts(tmp_path: Path) 
     assert result.manifest["command"]["argv"] == [sys.executable, "<2 argument(s) redacted>"]
     assert result.manifest["command"]["env_overrides"]["keys"] == ["OPENAI_API_KEY"]
     assert result.manifest["context"]["metadata"]["note"] == "using <secret-ref>"
+    assert result.manifest["protocols"]["adapters"] == ["mcp"]
+    assert result.manifest["protocols"]["capabilities"] == ["agent-as-tool"]
+    assert [event["type"] for event in result.manifest["events"]] == [
+        "agent.run.started",
+        "agent.command.completed",
+        "agent.artifacts.written",
+    ]
     assert "sk-secret" not in json.dumps(result.manifest)
     assert (tmp_path / module.STDOUT_FILENAME).read_text(encoding="utf-8").strip() == "api ok"
     summary = module.summarize_agent_run(tmp_path)
@@ -226,6 +251,13 @@ def test_agent_run_executes_command_and_writes_local_artifacts(tmp_path: Path, c
     assert payload["artifacts"]["manifest"] == str(manifest_path)
     assert payload["artifacts"]["stdout"]["line_count"] == 1
     assert payload["artifacts"]["stderr"]["line_count"] == 1
+    assert payload["protocols"]["mode"] == "none"
+    assert [event["type"] for event in payload["events"]] == [
+        "agent.run.started",
+        "agent.command.completed",
+        "agent.artifacts.written",
+    ]
+    assert payload["events"][1]["returncode"] == 0
     assert stdout_path.read_text(encoding="utf-8").strip() == "ok"
     assert stderr_path.read_text(encoding="utf-8").strip() == "warn"
     assert json.loads(manifest_path.read_text(encoding="utf-8"))["run_id"] == "agent-success"
@@ -344,6 +376,12 @@ def test_agent_run_timeout_records_timeout_status(tmp_path: Path) -> None:
     assert result.returncode == 124
     assert result.manifest["status"] == "timeout"
     assert result.manifest["timing"]["duration_seconds"] == 2.0
+    assert [event["type"] for event in result.manifest["events"]] == [
+        "agent.run.started",
+        "agent.command.timeout",
+        "agent.artifacts.written",
+    ]
+    assert result.manifest["events"][1]["returncode"] == 124
     assert "Timed out after 1s" in (tmp_path / "stderr.txt").read_text(encoding="utf-8")
 
 

--- a/test/test_agent_workflows.py
+++ b/test/test_agent_workflows.py
@@ -81,5 +81,9 @@ def test_agent_run_evidence_command_is_documented() -> None:
         assert "agilab agent-run --agent codex" in text
         assert "agilab.agent_run.v1" in text
         assert "~/log/agents/" in text
+    for text in (agent_workflows, readme):
+        assert "--protocol-adapter" in text
+        assert "--capability" in text
+        assert "metadata-only" in text
     assert "trace_agent_run" in agent_workflows
     assert "agilab.agent_run.trace_agent_run()" in readme

--- a/tools/agent_workflows.md
+++ b/tools/agent_workflows.md
@@ -28,7 +28,17 @@ from the manifest. Pass `--include-command-args` only when the prompt/arguments
 are safe to store.
 
 Use `--tag` and `--metadata KEY=VALUE` for structured, non-secret context that
-other tools can query later. Read previous run evidence from the CLI:
+other tools can query later. Use `--protocol-adapter` for metadata-only bridge
+labels such as `mcp`, `a2a`, `ag-ui`, or `fastapi`, and `--capability` for the
+agent capability exercised by the run. These fields make protocol or
+agent-as-tool experiments reviewable without adding those protocol stacks to the
+base package.
+
+Each manifest also carries a compact `events` timeline. It records the planned
+or started run, command completion or timeout, and artifact write event so later
+adapters can map the same evidence into streaming protocols.
+
+Read previous run evidence from the CLI:
 
 ```bash
 agilab agent-run list --agent codex --json


### PR DESCRIPTION
## Summary

Add protocol-neutral metadata and lifecycle events to `agilab agent-run` evidence.

- records `protocols.adapters` and `protocols.capabilities` from new CLI/Python API fields
- writes a compact `events` timeline for planned, started, command-completed/timeout, and artifact-written states
- documents the metadata-only protocol boundary in README, PyPI README, and the repo agent workflow guide

## Why

This gives AGILAB a bridge point for MCP/A2A/AG-UI/FastAPI-style agent integrations without adding those protocol stacks to the base package or changing the current redaction contract.

## Validation

- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_agent_run.py test/test_agent_workflows.py`
- `uv --preview-features extra-build-dependencies run python -m py_compile src/agilab/agent_run.py`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files README.md README.pypi.md src/agilab/agent_run.py test/test_agent_run.py test/test_agent_workflows.py tools/agent_workflows.md`
