### PR TITLE
[codex] Add agent evidence contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,15 +185,20 @@ Agent workflows can now produce AGILAB evidence directly. Use
 `agilab agent-run --agent codex --label "Review current diff" --tag review --metadata branch=main -- codex review`
 to execute a local coding-agent command and write a redacted
 `agilab.agent_run.v1` manifest plus local stdout/stderr artifacts under
-`~/log/agents/`. Command arguments are redacted by default and represented by
-an argv hash; pass `--include-command-args` only when the prompt/arguments are
-safe to store. Add `--protocol-adapter mcp` or `--capability app-as-tool` as
-metadata-only labels when experimenting with agent protocol bridges; the base
-package records those labels and lifecycle events without depending on the
-protocol stacks. Use `agilab agent-run list --agent codex --json` or
-the Python helpers `agilab.agent_run.trace_agent_run()` and
+`~/log/agents/`. Each run also writes an append-only
+`agilab.agent_trace.v1` stream in `agent_events.ndjson`, with typed events for
+session, command/tool, permission, compaction, rewind, and completion evidence.
+Command arguments are redacted by default and represented by an argv hash; pass
+`--include-command-args` only when the prompt/arguments are safe to store. Add
+`--protocol-adapter mcp` or `--capability app-as-tool` as metadata-only labels
+when experimenting with agent protocol bridges; the base package records those
+labels and lifecycle events without depending on the protocol stacks. Use
+`agilab agent-run list --agent codex --json` or the Python helpers
+`agilab.agent_run.trace_agent_run()` and
 `agilab.agent_run.list_agent_runs()` to create or consume run evidence from
-automation.
+automation. Provider/model capability context can be stamped with
+`--provider`, `--model`, project-local `.agilab/agents.json`, or global
+`~/.agilab/agents/agents.json`.
 
 Cluster/Dask support is intentionally part of the base runtime through
 `agi-core`. AGILAB keeps local, pool, and distributed back planes behind the

--- a/README.pypi.md
+++ b/README.pypi.md
@@ -155,15 +155,20 @@ Agent workflows can now produce AGILAB evidence directly. Use
 `agilab agent-run --agent codex --label "Review current diff" --tag review --metadata branch=main -- codex review`
 to execute a local coding-agent command and write a redacted
 `agilab.agent_run.v1` manifest plus local stdout/stderr artifacts under
-`~/log/agents/`. Command arguments are redacted by default and represented by
-an argv hash; pass `--include-command-args` only when the prompt/arguments are
-safe to store. Add `--protocol-adapter mcp` or `--capability app-as-tool` as
-metadata-only labels when experimenting with agent protocol bridges; the base
-package records those labels and lifecycle events without depending on the
-protocol stacks. Use `agilab agent-run list --agent codex --json` or
-the Python helpers `agilab.agent_run.trace_agent_run()` and
+`~/log/agents/`. Each run also writes an append-only
+`agilab.agent_trace.v1` stream in `agent_events.ndjson`, with typed events for
+session, command/tool, permission, compaction, rewind, and completion evidence.
+Command arguments are redacted by default and represented by an argv hash; pass
+`--include-command-args` only when the prompt/arguments are safe to store. Add
+`--protocol-adapter mcp` or `--capability app-as-tool` as metadata-only labels
+when experimenting with agent protocol bridges; the base package records those
+labels and lifecycle events without depending on the protocol stacks. Use
+`agilab agent-run list --agent codex --json` or the Python helpers
+`agilab.agent_run.trace_agent_run()` and
 `agilab.agent_run.list_agent_runs()` to create or consume run evidence from
-automation.
+automation. Provider/model capability context can be stamped with
+`--provider`, `--model`, project-local `.agilab/agents.json`, or global
+`~/.agilab/agents/agents.json`.
 
 Cluster/Dask support is intentionally part of the base runtime through
 `agi-core`. AGILAB keeps local, pool, and distributed back planes behind the

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 216,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "6eccd34835535474b19b39aaf604be782207ad6809ab893cc725f41bc1e7b326",
+  "source_digest_sha256": "d6fb5a0eb874464789adc39978bd6948fb06b12e34fb879e4ea3afca0241d297",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "6eccd34835535474b19b39aaf604be782207ad6809ab893cc725f41bc1e7b326"
+  "target_digest_sha256": "d6fb5a0eb874464789adc39978bd6948fb06b12e34fb879e4ea3afca0241d297"
 }

--- a/docs/source/agent-workflows.rst
+++ b/docs/source/agent-workflows.rst
@@ -56,8 +56,9 @@ evidence instead of only a tool-specific log::
 
    agilab agent-run --agent codex --label "Review current diff" --tag review --metadata branch=main -- codex review
 
-The command writes a redacted ``agilab.agent_run.v1`` manifest plus local
-``stdout.txt`` and ``stderr.txt`` artifacts under
+The command writes a redacted ``agilab.agent_run.v1`` manifest, local
+``stdout.txt`` / ``stderr.txt`` artifacts, and an append-only
+``agilab.agent_trace.v1`` event log under
 ``~/log/agents/<agent>/<run-id>/``. Environment override values passed with
 ``--env KEY=VALUE`` are redacted from the manifest. Command arguments are
 redacted by default and represented by an argv hash; pass
@@ -75,6 +76,56 @@ or from Python::
    from agilab.agent_run import list_agent_runs
 
    runs = list_agent_runs(agent="codex", limit=5)
+
+Agent evidence contract
+-----------------------
+
+AGILAB keeps the agent evidence layer deliberately small and provider-neutral:
+
+- ``agent_run_manifest.json`` records command identity, redacted arguments,
+  environment metadata, metadata-only protocol labels, provider/model
+  capability metadata when configured, and pointers to local artifacts.
+- ``agent_trace_meta.json`` describes the trace directory.
+- ``agent_events.ndjson`` is an append-only typed event stream. Current event
+  types include ``session_start``, ``command_start``, ``tool_start``,
+  ``tool_output``, ``tool_done``, ``permission_request``,
+  ``permission_resolved``, ``compact``, ``rewind``, and ``session_end``.
+- ``tool-output/`` is reserved for large or structured tool payloads that
+  should stay out of public JSON.
+
+The base package records protocol bridges as evidence labels only. Add
+``--protocol-adapter mcp`` or ``--capability app-as-tool`` when experimenting
+with agent protocol bridges without adding protocol-stack dependencies to the
+base runtime.
+
+The tool safety helpers expose the same control points for future agent tools:
+
+- permission tiers: ``readonly``, ``safe``, ``standard``, and ``operator``
+- deterministic confirmation tokens for operator-gated/destructive actions
+- before/after hooks that can approve, deny, redact, audit, or replace a tool
+  result before it is written back into evidence
+
+Agent configuration is layered from ``~/.agilab/agents/agents.json`` and then
+``.agilab/agents.json`` files from the project root to the current working
+directory. A minimal project-local file can stamp provider capability and
+permission context into future agent-run manifests::
+
+   {
+     "default": {"provider": "local-code"},
+     "permission": {"level": "standard"},
+     "providers": {
+       "local-code": {
+         "type": "ollama",
+         "model": "qwen2.5-coder:latest",
+         "capability": {"context_window": 32768}
+       }
+     }
+   }
+
+Use explicit CLI overrides when a run should carry a one-off provider or model
+label without changing project config::
+
+   agilab agent-run --provider openai --model gpt-5 --permission-level standard -- codex review
 
 Supported agent paths
 ---------------------

--- a/src/agilab/agent_config.py
+++ b/src/agilab/agent_config.py
@@ -1,0 +1,236 @@
+# BSD 3-Clause License
+#
+# Copyright (c) 2026, Jean-Pierre Morard, THALES SIX GTS France SAS
+"""Layered AGILAB agent configuration helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import json
+import os
+from pathlib import Path
+import re
+from typing import Any, Mapping
+
+from agilab.agent_provider_capabilities import ProviderCapability, resolve_provider_capability
+
+
+CONFIG_SCHEMA = "agilab.agent_config.v1"
+CONFIG_FILENAME = "agents.json"
+AGILAB_CONFIG_DIRNAME = ".agilab"
+AGENT_HOME_ENV = "AGILAB_AGENT_HOME"
+_ENV_REF_RE = re.compile(r"^\$\{([A-Za-z_][A-Za-z0-9_]*)\}$")
+_VALID_PERMISSION_LEVELS = frozenset({"readonly", "safe", "standard", "operator"})
+
+
+@dataclass(frozen=True)
+class AgentProviderConfig:
+    """Configured provider alias for AGILAB agent runs."""
+
+    name: str
+    provider: str
+    model: str
+    base_url: str = ""
+    api_key_env_var: str = ""
+    capability_overrides: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class AgentRuntimeConfig:
+    """Resolved global/project agent configuration."""
+
+    schema: str
+    default_provider: str
+    default_model: str
+    permission_level: str
+    trace_enabled: bool
+    providers: dict[str, AgentProviderConfig]
+    config_paths: tuple[Path, ...] = ()
+
+
+@dataclass(frozen=True)
+class ResolvedAgentProvider:
+    """Provider selection ready to stamp into an evidence manifest."""
+
+    name: str
+    provider: str
+    model: str
+    base_url: str
+    api_key_env_var: str
+    capability: ProviderCapability
+    config_paths: tuple[Path, ...] = ()
+
+
+def agent_home(environ: Mapping[str, str] | None = None) -> Path:
+    """Return the AGILAB agent home directory."""
+
+    env = environ or os.environ
+    raw = env.get(AGENT_HOME_ENV) or "~/.agilab/agents"
+    return Path(raw).expanduser().resolve(strict=False)
+
+
+def resolve_project_root(cwd: Path | str) -> Path:
+    """Return the nearest Git project root, or ``cwd`` when none exists."""
+
+    current = Path(cwd).expanduser().resolve(strict=False)
+    for candidate in (current, *current.parents):
+        if (candidate / ".git").exists():
+            return candidate
+    return current
+
+
+def project_dirs(cwd: Path | str, project: Path | str | None = None) -> list[Path]:
+    """Return directories from project to cwd, inclusive."""
+
+    current = Path(cwd).expanduser().resolve(strict=False)
+    root = Path(project).expanduser().resolve(strict=False) if project is not None else resolve_project_root(current)
+    dirs = [current]
+    while dirs[-1] != root:
+        parent = dirs[-1].parent
+        if parent == dirs[-1]:
+            break
+        dirs.append(parent)
+    return list(reversed(dirs))
+
+
+def discover_config_paths(cwd: Path | str, environ: Mapping[str, str] | None = None) -> list[Path]:
+    """Return existing config files ordered from global to most-specific project."""
+
+    paths: list[Path] = []
+    global_path = agent_home(environ) / CONFIG_FILENAME
+    if global_path.is_file():
+        paths.append(global_path)
+    for directory in project_dirs(cwd):
+        candidate = directory / AGILAB_CONFIG_DIRNAME / CONFIG_FILENAME
+        if candidate.is_file():
+            paths.append(candidate)
+    return paths
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _deep_merge(base: dict[str, Any], override: Mapping[str, Any]) -> dict[str, Any]:
+    merged = dict(base)
+    for key, value in override.items():
+        if isinstance(value, dict) and isinstance(merged.get(key), dict):
+            merged[key] = _deep_merge(dict(merged[key]), value)
+        else:
+            merged[key] = value
+    return merged
+
+
+def _as_bool(value: Any, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "yes", "on"}:
+            return True
+        if lowered in {"0", "false", "no", "off"}:
+            return False
+    return default
+
+
+def _normalize_permission_level(value: Any) -> str:
+    if not isinstance(value, str):
+        return "safe"
+    level = value.strip().lower().replace("_", "-")
+    if level == "yolo":
+        return "operator"
+    return level if level in _VALID_PERMISSION_LEVELS else "safe"
+
+
+def _parse_api_key_ref(value: Any) -> str:
+    if not isinstance(value, str):
+        return ""
+    stripped = value.strip()
+    match = _ENV_REF_RE.fullmatch(stripped)
+    return match.group(1) if match else ""
+
+
+def _provider_from_payload(name: str, payload: Mapping[str, Any]) -> AgentProviderConfig:
+    provider = str(payload.get("provider") or payload.get("type") or name).strip()
+    model = str(payload.get("model") or "").strip()
+    capability = payload.get("capability")
+    api_key_env_var = str(payload.get("api_key_env") or "").strip()
+    return AgentProviderConfig(
+        name=name,
+        provider=provider,
+        model=model,
+        base_url=str(payload.get("base_url") or "").strip(),
+        api_key_env_var=api_key_env_var or _parse_api_key_ref(payload.get("api_key")),
+        capability_overrides=dict(capability) if isinstance(capability, dict) else {},
+    )
+
+
+def load_agent_config(
+    cwd: Path | str | None = None,
+    *,
+    environ: Mapping[str, str] | None = None,
+) -> AgentRuntimeConfig:
+    """Load global and project-local AGILAB agent config files."""
+
+    resolved_cwd = Path(cwd or Path.cwd()).expanduser().resolve(strict=False)
+    paths = discover_config_paths(resolved_cwd, environ)
+    raw: dict[str, Any] = {}
+    for path in paths:
+        raw = _deep_merge(raw, _load_json(path))
+
+    default_payload = raw.get("default") if isinstance(raw.get("default"), dict) else {}
+    providers_payload = raw.get("providers") if isinstance(raw.get("providers"), dict) else {}
+    providers = {
+        str(name): _provider_from_payload(str(name), payload)
+        for name, payload in providers_payload.items()
+        if isinstance(payload, dict)
+    }
+
+    default_provider = str(default_payload.get("provider") or raw.get("default_provider") or "").strip()
+    default_model = str(default_payload.get("model") or raw.get("default_model") or "").strip()
+    permission_payload = raw.get("permission") if isinstance(raw.get("permission"), dict) else {}
+    permission_level = _normalize_permission_level(permission_payload.get("level") or raw.get("permission_level"))
+    trace_payload = raw.get("trace") if isinstance(raw.get("trace"), dict) else {}
+    trace_enabled = _as_bool(trace_payload.get("enabled", raw.get("trace_enabled")), True)
+
+    return AgentRuntimeConfig(
+        schema=CONFIG_SCHEMA,
+        default_provider=default_provider,
+        default_model=default_model,
+        permission_level=permission_level,
+        trace_enabled=trace_enabled,
+        providers=providers,
+        config_paths=tuple(paths),
+    )
+
+
+def resolve_agent_provider(
+    config: AgentRuntimeConfig,
+    *,
+    provider: str | None = None,
+    model: str | None = None,
+) -> ResolvedAgentProvider:
+    """Resolve selected provider/model plus capability metadata."""
+
+    requested_provider = str(provider or config.default_provider or "").strip()
+    selected = config.providers.get(requested_provider) if requested_provider else None
+    provider_type = selected.provider if selected else requested_provider
+    model_id = str(model or (selected.model if selected else "") or config.default_model or "").strip()
+    capability = resolve_provider_capability(
+        provider_type or requested_provider,
+        model_id,
+        overrides=selected.capability_overrides if selected else None,
+    )
+    return ResolvedAgentProvider(
+        name=selected.name if selected else requested_provider,
+        provider=capability.provider,
+        model=capability.model,
+        base_url=selected.base_url if selected else "",
+        api_key_env_var=selected.api_key_env_var if selected else "",
+        capability=capability,
+        config_paths=config.config_paths,
+    )

--- a/src/agilab/agent_provider_capabilities.py
+++ b/src/agilab/agent_provider_capabilities.py
@@ -1,0 +1,222 @@
+# BSD 3-Clause License
+#
+# Copyright (c) 2026, Jean-Pierre Morard, THALES SIX GTS France SAS
+"""Provider and model capability helpers for AGILAB agent workflows."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, Mapping
+
+
+CAPABILITY_SCHEMA = "agilab.agent_provider_capability.v1"
+
+
+@dataclass(frozen=True)
+class ProviderCapability:
+    """Conservative provider/model capability metadata."""
+
+    schema: str
+    provider: str
+    model: str
+    context_window: int | None = None
+    max_output_tokens: int | None = None
+    supports_reasoning: bool | None = None
+    supports_image_input: bool | None = None
+    supports_pdf_input: bool | None = None
+    source: str = "default"
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+_DEFAULT_PROVIDER_MODELS: dict[str, str] = {
+    "openai": "gpt-5.4-mini",
+    "mistral": "mistral-large-latest",
+    "openai-compatible": "openai-compatible",
+    "gpt-oss": "gpt-oss-120b",
+    "ollama": "qwen2.5-coder:latest",
+    "local": "local-model",
+}
+
+_PROVIDER_DEFAULTS: dict[str, dict[str, Any]] = {
+    "openai": {
+        "context_window": None,
+        "max_output_tokens": None,
+        "supports_reasoning": True,
+        "supports_image_input": True,
+        "supports_pdf_input": True,
+    },
+    "mistral": {
+        "context_window": None,
+        "max_output_tokens": None,
+        "supports_reasoning": False,
+        "supports_image_input": True,
+        "supports_pdf_input": False,
+    },
+    "openai-compatible": {
+        "context_window": None,
+        "max_output_tokens": None,
+        "supports_reasoning": None,
+        "supports_image_input": None,
+        "supports_pdf_input": None,
+    },
+    "gpt-oss": {
+        "context_window": None,
+        "max_output_tokens": None,
+        "supports_reasoning": True,
+        "supports_image_input": False,
+        "supports_pdf_input": False,
+    },
+    "ollama": {
+        "context_window": None,
+        "max_output_tokens": None,
+        "supports_reasoning": None,
+        "supports_image_input": False,
+        "supports_pdf_input": False,
+    },
+    "local": {
+        "context_window": None,
+        "max_output_tokens": None,
+        "supports_reasoning": None,
+        "supports_image_input": False,
+        "supports_pdf_input": False,
+    },
+}
+
+_MODEL_OVERRIDES: dict[tuple[str, str], dict[str, Any]] = {
+    ("openai", "gpt-5.4-mini"): {
+        "supports_reasoning": True,
+        "supports_image_input": True,
+        "supports_pdf_input": True,
+    },
+    ("openai", "gpt-5"): {
+        "supports_reasoning": True,
+        "supports_image_input": True,
+        "supports_pdf_input": True,
+    },
+    ("openai", "gpt-5-mini"): {
+        "supports_reasoning": True,
+        "supports_image_input": True,
+        "supports_pdf_input": True,
+    },
+    ("openai", "gpt-4.1"): {
+        "supports_reasoning": False,
+        "supports_image_input": True,
+        "supports_pdf_input": True,
+    },
+    ("gpt-oss", "gpt-oss-120b"): {
+        "supports_reasoning": True,
+        "supports_image_input": False,
+        "supports_pdf_input": False,
+    },
+}
+
+
+def normalize_provider(provider: str | None, model: str | None = None) -> str:
+    """Normalize provider aliases and infer a provider when only a model is known."""
+
+    raw = str(provider or "").strip().lower().replace("_", "-")
+    if raw in {"openai", "azure-openai"}:
+        return "openai"
+    if raw in {"mistral", "mistralai"}:
+        return "mistral"
+    if raw in {"openai-compatible", "openai-compatible-chat", "vllm", "litellm"}:
+        return "openai-compatible"
+    if raw in {"gpt-oss", "gptoss"}:
+        return "gpt-oss"
+    if raw in {"ollama", "uoaic"}:
+        return "ollama"
+    if raw in {"local", "local-llm"}:
+        return "local"
+    if raw:
+        return raw
+
+    model_id = str(model or "").strip().lower()
+    if model_id.startswith("gpt-oss"):
+        return "gpt-oss"
+    if model_id.startswith(("gpt-", "o", "text-embedding")):
+        return "openai"
+    if "mistral" in model_id or "ministral" in model_id:
+        return "mistral"
+    if any(token in model_id for token in ("qwen", "deepseek", "llama", "phi")):
+        return "ollama"
+    return "local"
+
+
+def default_model_for_provider(provider: str) -> str:
+    """Return a conservative default model label for ``provider``."""
+
+    normalized = normalize_provider(provider)
+    return _DEFAULT_PROVIDER_MODELS.get(normalized, normalized or "model")
+
+
+def _coerce_bool(value: Any) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "yes", "on"}:
+            return True
+        if lowered in {"0", "false", "no", "off"}:
+            return False
+    return None
+
+
+def _coerce_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _capability_overrides(raw: Mapping[str, Any] | None) -> dict[str, Any]:
+    if not raw:
+        return {}
+    payload: dict[str, Any] = {}
+    for key in ("context_window", "max_output_tokens"):
+        parsed = _coerce_int(raw.get(key))
+        if parsed is not None:
+            payload[key] = parsed
+    for key in ("supports_reasoning", "supports_image_input", "supports_pdf_input"):
+        parsed_bool = _coerce_bool(raw.get(key))
+        if parsed_bool is not None:
+            payload[key] = parsed_bool
+    return payload
+
+
+def resolve_provider_capability(
+    provider: str | None = None,
+    model: str | None = None,
+    *,
+    overrides: Mapping[str, Any] | None = None,
+) -> ProviderCapability:
+    """Resolve provider/model capability metadata with explicit overrides last."""
+
+    normalized_provider = normalize_provider(provider, model)
+    model_id = str(model or "").strip() or default_model_for_provider(normalized_provider)
+    payload = dict(_PROVIDER_DEFAULTS.get(normalized_provider, {}))
+    source = "provider-default"
+    model_payload = _MODEL_OVERRIDES.get((normalized_provider, model_id))
+    if model_payload:
+        payload.update(model_payload)
+        source = "model-default"
+    override_payload = _capability_overrides(overrides)
+    if override_payload:
+        payload.update(override_payload)
+        source = "override"
+
+    return ProviderCapability(
+        schema=CAPABILITY_SCHEMA,
+        provider=normalized_provider,
+        model=model_id,
+        context_window=payload.get("context_window") if isinstance(payload.get("context_window"), int) else None,
+        max_output_tokens=payload.get("max_output_tokens") if isinstance(payload.get("max_output_tokens"), int) else None,
+        supports_reasoning=payload.get("supports_reasoning") if isinstance(payload.get("supports_reasoning"), bool) else None,
+        supports_image_input=payload.get("supports_image_input") if isinstance(payload.get("supports_image_input"), bool) else None,
+        supports_pdf_input=payload.get("supports_pdf_input") if isinstance(payload.get("supports_pdf_input"), bool) else None,
+        source=source,
+    )

--- a/src/agilab/agent_run.py
+++ b/src/agilab/agent_run.py
@@ -17,6 +17,9 @@ from pathlib import Path
 from typing import Callable, Mapping, Sequence
 from uuid import uuid4
 
+from agilab.agent_config import load_agent_config, resolve_agent_provider
+from agilab.agent_tool_safety import normalize_permission_level
+from agilab.agent_trace import AgentTraceStore, trace_artifact_payload
 from agilab.secret_uri import redact_text
 
 
@@ -49,6 +52,12 @@ class AgentRunConfig:
     metadata: dict[str, str] = field(default_factory=dict)
     protocol_adapters: tuple[str, ...] = ()
     capabilities: tuple[str, ...] = ()
+    provider: str = ""
+    model: str = ""
+    permission_level: str = "safe"
+    trace_enabled: bool = True
+    provider_capability: dict[str, object] = field(default_factory=dict)
+    config_paths: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -71,6 +80,7 @@ class AgentRunSummary:
     manifest_path: Path
     stdout_path: Path | None
     stderr_path: Path | None
+    trace_events_path: Path | None
     duration_seconds: float
     tags: tuple[str, ...] = ()
     metadata: dict[str, object] = field(default_factory=dict)
@@ -170,11 +180,23 @@ def _context_payload(config: AgentRunConfig) -> dict[str, object]:
         redacted_value = redact_text(value)
         metadata[key] = redacted_value
         metadata_redacted[key] = redacted_value != value
-    return {
+    payload: dict[str, object] = {
         "tags": list(config.tags),
         "metadata": metadata,
         "metadata_redacted": metadata_redacted,
+        "agent_config": {
+            "permission_level": config.permission_level,
+            "trace_enabled": config.trace_enabled,
+            "config_paths": list(config.config_paths),
+        },
     }
+    if config.provider or config.model or config.provider_capability:
+        payload["provider"] = {
+            "provider": config.provider,
+            "model": config.model,
+            "capability": config.provider_capability,
+        }
+    return payload
 
 
 def _protocol_payload(config: AgentRunConfig) -> dict[str, object]:
@@ -265,6 +287,10 @@ def create_agent_run_config(
     metadata: Mapping[str, str] | None = None,
     protocol_adapters: Sequence[str] = (),
     capabilities: Sequence[str] = (),
+    provider: str | None = None,
+    model: str | None = None,
+    permission_level: str | None = None,
+    trace_enabled: bool | None = None,
 ) -> AgentRunConfig:
     """Build a validated agent-run config with CLI-compatible defaults.
 
@@ -284,6 +310,20 @@ def create_agent_run_config(
     resolved_cwd = Path(cwd).expanduser().resolve() if cwd is not None else Path.cwd().resolve()
     if not resolved_cwd.is_dir():
         raise ValueError(f"cwd is not a directory: {resolved_cwd}")
+
+    agent_config = load_agent_config(resolved_cwd)
+    provider_name = ""
+    model_name = ""
+    provider_capability: dict[str, object] = {}
+    has_provider_context = any(
+        str(value or "").strip()
+        for value in (provider, model, agent_config.default_provider, agent_config.default_model)
+    )
+    if has_provider_context:
+        resolved_provider = resolve_agent_provider(agent_config, provider=provider, model=model)
+        provider_name = resolved_provider.provider
+        model_name = resolved_provider.model
+        provider_capability = resolved_provider.capability.as_dict()
 
     clean_run_id = _slug(run_id or "", "agent-run") if run_id and run_id.strip() else _new_run_id(agent)
     resolved_output_dir = (
@@ -309,6 +349,12 @@ def create_agent_run_config(
         metadata=dict(metadata or {}),
         protocol_adapters=_normalize_slug_values(protocol_adapters),
         capabilities=_normalize_slug_values(capabilities),
+        provider=provider_name,
+        model=model_name,
+        permission_level=normalize_permission_level(permission_level or agent_config.permission_level),
+        trace_enabled=agent_config.trace_enabled if trace_enabled is None else bool(trace_enabled),
+        provider_capability=provider_capability,
+        config_paths=tuple(str(path) for path in agent_config.config_paths),
     )
 
 
@@ -355,6 +401,7 @@ def build_planned_manifest(config: AgentRunConfig) -> dict[str, object]:
             "manifest": str(artifacts["manifest"]),
             "stdout": str(artifacts["stdout"]),
             "stderr": str(artifacts["stderr"]),
+            "agent_trace": trace_artifact_payload(config.output_dir),
         },
         "events": [
             _event_payload(
@@ -370,6 +417,7 @@ def build_planned_manifest(config: AgentRunConfig) -> dict[str, object]:
             "Command arguments are redacted by default; argv_sha256 preserves comparison without exposing prompts.",
             "Command output is stored in local artifact files, not embedded in the manifest.",
             "Environment override values are redacted from the manifest.",
+            "Agent trace events are stored as append-only NDJSON when trace_enabled is true.",
         ],
     }
 
@@ -386,6 +434,23 @@ def run_agent_command(
     stdout_path = artifacts["stdout"]
     stderr_path = artifacts["stderr"]
     manifest_path = artifacts["manifest"]
+    trace_store = AgentTraceStore(
+        config.output_dir,
+        run_id=config.run_id,
+        agent=config.agent,
+        label=config.label,
+        provider=config.provider,
+        model=config.model,
+    )
+    if config.trace_enabled:
+        trace_store.initialize(
+            {
+                "tags": list(config.tags),
+                "permission_level": config.permission_level,
+                "provider": config.provider,
+                "model": config.model,
+            }
+        )
 
     env = os.environ.copy()
     env.update(config.env_overrides)
@@ -402,6 +467,21 @@ def run_agent_command(
         )
     ]
     timed_out = False
+    if config.trace_enabled:
+        trace_store.append(
+            "session_start",
+            message=config.label,
+            metadata={
+                "agent": config.agent,
+                "tags": list(config.tags),
+                "permission_level": config.permission_level,
+            },
+        )
+        trace_store.append(
+            "command_start",
+            message=config.label,
+            metadata=_command_payload(config),
+        )
     try:
         proc = runner(
             list(config.command),
@@ -449,6 +529,23 @@ def run_agent_command(
             artifacts=["stdout", "stderr"],
         )
     )
+    if config.trace_enabled:
+        trace_store.append(
+            "command_done",
+            status=status,
+            message=f"command finished with returncode {returncode}",
+            metadata={
+                "returncode": returncode,
+                "stdout": _file_payload(stdout_path),
+                "stderr": _file_payload(stderr_path),
+            },
+        )
+        trace_store.append(
+            "session_end",
+            status=status,
+            message=f"agent run {status}",
+            metadata={"returncode": returncode},
+        )
     manifest: dict[str, object] = {
         "schema_version": 1,
         "kind": TRACE_KIND,
@@ -471,12 +568,14 @@ def run_agent_command(
             "manifest": str(manifest_path),
             "stdout": _file_payload(stdout_path),
             "stderr": _file_payload(stderr_path),
+            "agent_trace": trace_artifact_payload(config.output_dir),
         },
         "events": events,
         "notes": [
             "Command arguments are redacted by default; argv_sha256 preserves comparison without exposing prompts.",
             "Command output is stored in local artifact files, not embedded in the manifest.",
             "Environment override values are redacted from the manifest.",
+            "Agent trace events are stored as append-only NDJSON when trace_enabled is true.",
         ],
     }
     manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
@@ -499,6 +598,10 @@ def trace_agent_run(
     metadata: Mapping[str, str] | None = None,
     protocol_adapters: Sequence[str] = (),
     capabilities: Sequence[str] = (),
+    provider: str | None = None,
+    model: str | None = None,
+    permission_level: str | None = None,
+    trace_enabled: bool | None = None,
     runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
     perf_counter: Callable[[], float] = time.perf_counter,
 ) -> AgentRunResult:
@@ -519,6 +622,10 @@ def trace_agent_run(
         metadata=metadata,
         protocol_adapters=protocol_adapters,
         capabilities=capabilities,
+        provider=provider,
+        model=model,
+        permission_level=permission_level,
+        trace_enabled=trace_enabled,
     )
     return run_agent_command(config, runner=runner, perf_counter=perf_counter)
 
@@ -564,6 +671,12 @@ def summarize_agent_run(manifest_or_path: dict[str, object] | Path | str) -> Age
     raw_metadata = context_map.get("metadata", {})
 
     manifest_path = _path_from_artifact(artifact_map.get("manifest")) or Path("")
+    trace_payload = artifact_map.get("agent_trace")
+    trace_events_path = None
+    if isinstance(trace_payload, dict):
+        raw_events_path = trace_payload.get("events")
+        if isinstance(raw_events_path, str) and raw_events_path:
+            trace_events_path = Path(raw_events_path)
     return AgentRunSummary(
         run_id=str(manifest.get("run_id") or ""),
         agent=str(manifest.get("agent") or ""),
@@ -573,6 +686,7 @@ def summarize_agent_run(manifest_or_path: dict[str, object] | Path | str) -> Age
         manifest_path=manifest_path,
         stdout_path=_path_from_artifact(artifact_map.get("stdout")),
         stderr_path=_path_from_artifact(artifact_map.get("stderr")),
+        trace_events_path=trace_events_path,
         duration_seconds=float(timing_map.get("duration_seconds") or 0.0),
         tags=tuple(str(tag) for tag in raw_tags) if isinstance(raw_tags, list) else (),
         metadata=dict(raw_metadata) if isinstance(raw_metadata, dict) else {},
@@ -663,6 +777,10 @@ def _build_parser() -> argparse.ArgumentParser:
         default=[],
         help="Capability exercised by this run, for example app-as-tool, notebook-export, or evidence-review.",
     )
+    parser.add_argument("--provider", default="", help="Optional agent provider alias or type to stamp in evidence.")
+    parser.add_argument("--model", default="", help="Optional agent model id to stamp in evidence.")
+    parser.add_argument("--permission-level", default="", help="Agent permission level: readonly, safe, standard, or operator.")
+    parser.add_argument("--no-trace", action="store_true", help="Do not write the append-only agent_events.ndjson trace.")
     parser.add_argument("--json", action="store_true", help="Print the trace manifest JSON.")
     parser.add_argument("--print-only", action="store_true", help="Print the planned trace without executing the command.")
     parser.add_argument("--allow-failure", action="store_true", help="Return 0 even if the traced command fails.")
@@ -704,6 +822,10 @@ def parse_args(argv: Sequence[str]) -> AgentRunConfig:
             metadata=_parse_metadata(args.metadata),
             protocol_adapters=args.protocol_adapter,
             capabilities=args.capability,
+            provider=args.provider or None,
+            model=args.model or None,
+            permission_level=args.permission_level or None,
+            trace_enabled=False if args.no_trace else None,
         )
     except ValueError as exc:
         parser.error(str(exc))
@@ -729,6 +851,7 @@ def _summary_payload(summary: AgentRunSummary) -> dict[str, object]:
         "manifest": str(summary.manifest_path),
         "stdout": str(summary.stdout_path) if summary.stdout_path else None,
         "stderr": str(summary.stderr_path) if summary.stderr_path else None,
+        "trace_events": str(summary.trace_events_path) if summary.trace_events_path else None,
         "duration_seconds": summary.duration_seconds,
         "tags": list(summary.tags),
         "metadata": summary.metadata,

--- a/src/agilab/agent_tool_safety.py
+++ b/src/agilab/agent_tool_safety.py
@@ -11,7 +11,7 @@ import hashlib
 import json
 from pathlib import Path
 import re
-from typing import Any, Mapping
+from typing import Any, Callable, Mapping
 
 from agilab.secret_uri import redact_mapping, redact_text
 
@@ -38,6 +38,11 @@ _DESTRUCTIVE_WORDS = frozenset(
     }
 )
 _ACTION_TOKEN_RE = re.compile(r"[A-Za-z0-9]+")
+_PERMISSION_LEVELS = ("readonly", "safe", "standard", "operator")
+_PERMISSION_RANK = {level: index for index, level in enumerate(_PERMISSION_LEVELS)}
+_READONLY_WORDS = frozenset({"check", "find", "inspect", "list", "read", "search", "show", "status", "validate", "verify"})
+_STANDARD_WORDS = frozenset({"build", "execute", "install", "run", "smoke", "sync", "test"})
+_SAFE_WRITE_WORDS = frozenset({"add", "create", "edit", "export", "generate", "patch", "record", "update", "write"})
 
 
 class ToolConfirmationRequired(PermissionError):
@@ -53,6 +58,38 @@ class ToolSafetyDecision:
     risk: str
     reason: str
     confirmation_token: str | None = None
+
+
+@dataclass(frozen=True)
+class ToolPermissionDecision:
+    """Tiered permission decision for an agent tool invocation."""
+
+    action: str
+    allowed: bool
+    tier: str
+    level: str
+    reason: str
+    confirmation_token: str | None = None
+
+
+@dataclass(frozen=True)
+class ToolHookContext:
+    """Immutable context passed to AGILAB agent tool hooks."""
+
+    action: str
+    arguments: dict[str, Any]
+    metadata: dict[str, Any]
+    run_id: str = ""
+
+
+@dataclass(frozen=True)
+class ToolHookResult:
+    """Result passed between before/after AGILAB tool hooks."""
+
+    output: str
+    status: str = "pass"
+    metadata: dict[str, Any] | None = None
+    is_error: bool = False
 
 
 @dataclass(frozen=True)
@@ -89,6 +126,124 @@ def classify_tool_action(action: str, metadata: Mapping[str, Any] | None = None)
     if kind == "destructive":
         return "destructive"
     return "destructive" if _action_terms(action) & _DESTRUCTIVE_WORDS else "safe"
+
+
+def normalize_permission_level(level: str | None) -> str:
+    """Normalize a user-facing permission level."""
+
+    raw = str(level or "safe").strip().lower().replace("_", "-")
+    if raw == "yolo":
+        return "operator"
+    return raw if raw in _PERMISSION_RANK else "safe"
+
+
+def classify_tool_permission(action: str, metadata: Mapping[str, Any] | None = None) -> str:
+    """Classify an agent tool action into a permission tier.
+
+    Tiers intentionally stay conservative:
+
+    - ``readonly``: inspection-only actions
+    - ``safe``: local write/export actions
+    - ``standard``: execution/build/test actions
+    - ``operator``: destructive or explicitly operator-gated actions
+    """
+
+    meta = metadata or {}
+    explicit = str(meta.get("permission_tier") or meta.get("permission_level") or "").strip().lower()
+    explicit = "operator" if explicit == "yolo" else explicit
+    if explicit in _PERMISSION_RANK:
+        return explicit
+    if classify_tool_action(action, meta) == "destructive":
+        return "operator"
+    terms = _action_terms(action)
+    if terms & _STANDARD_WORDS:
+        return "standard"
+    if terms & _SAFE_WRITE_WORDS:
+        return "safe"
+    if terms & _READONLY_WORDS:
+        return "readonly"
+    return "safe"
+
+
+def evaluate_tool_permission(
+    action: str,
+    arguments: Mapping[str, Any] | None = None,
+    *,
+    level: str | None = None,
+    confirmation: str | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> ToolPermissionDecision:
+    """Evaluate an invocation against a tiered permission level."""
+
+    normalized_level = normalize_permission_level(level)
+    tier = classify_tool_permission(action, metadata)
+    if _PERMISSION_RANK[tier] <= _PERMISSION_RANK[normalized_level]:
+        return ToolPermissionDecision(
+            action=action,
+            allowed=True,
+            tier=tier,
+            level=normalized_level,
+            reason=f"{tier} action allowed by {normalized_level} permission level",
+        )
+    token = confirmation_token(action, arguments)
+    if tier == "operator" and confirmation == token:
+        return ToolPermissionDecision(
+            action=action,
+            allowed=True,
+            tier=tier,
+            level=normalized_level,
+            reason="operator action confirmed by explicit token",
+            confirmation_token=token,
+        )
+    return ToolPermissionDecision(
+        action=action,
+        allowed=False,
+        tier=tier,
+        level=normalized_level,
+        reason=f"{tier} action exceeds {normalized_level} permission level",
+        confirmation_token=token if tier == "operator" else None,
+    )
+
+
+BeforeToolHook = Callable[[ToolHookContext], ToolHookResult | None]
+AfterToolHook = Callable[[ToolHookContext, ToolHookResult], ToolHookResult | None]
+ToolRunner = Callable[[ToolHookContext], ToolHookResult]
+
+
+class ToolHookSet:
+    """Ordered before/after hooks for AGILAB agent-exposed tools."""
+
+    def __init__(self) -> None:
+        self._before: list[BeforeToolHook] = []
+        self._after: list[AfterToolHook] = []
+
+    def before_tool(self, hook: BeforeToolHook) -> BeforeToolHook:
+        self._before.append(hook)
+        return hook
+
+    def after_tool(self, hook: AfterToolHook) -> AfterToolHook:
+        self._after.append(hook)
+        return hook
+
+    def run_before(self, context: ToolHookContext) -> ToolHookResult | None:
+        for hook in self._before:
+            result = hook(context)
+            if result is not None:
+                return result
+        return None
+
+    def run_after(self, context: ToolHookContext, result: ToolHookResult) -> ToolHookResult:
+        current = result
+        for hook in self._after:
+            replacement = hook(context, current)
+            if replacement is not None:
+                current = replacement
+        return current
+
+    def execute(self, context: ToolHookContext, runner: ToolRunner) -> ToolHookResult:
+        skipped = self.run_before(context)
+        result = skipped if skipped is not None else runner(context)
+        return self.run_after(context, result)
 
 
 def confirmation_token(action: str, arguments: Mapping[str, Any] | None = None) -> str:

--- a/src/agilab/agent_trace.py
+++ b/src/agilab/agent_trace.py
@@ -1,0 +1,259 @@
+# BSD 3-Clause License
+#
+# Copyright (c) 2026, Jean-Pierre Morard, THALES SIX GTS France SAS
+"""Append-only evidence traces for AGILAB agent and tool runs."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from agilab.secret_uri import redact_mapping, redact_text
+
+
+TRACE_SCHEMA = "agilab.agent_trace.v1"
+META_FILENAME = "agent_trace_meta.json"
+EVENTS_FILENAME = "agent_events.ndjson"
+TOOL_OUTPUT_DIRNAME = "tool-output"
+VALID_EVENT_TYPES = frozenset(
+    {
+        "session_start",
+        "session_end",
+        "user_message",
+        "assistant_message",
+        "reasoning",
+        "tool_start",
+        "tool_output",
+        "tool_done",
+        "permission_request",
+        "permission_resolved",
+        "compact",
+        "rewind",
+        "command_start",
+        "command_done",
+        "error",
+    }
+)
+
+
+@dataclass(frozen=True)
+class AgentTraceEvent:
+    """One redacted append-only trace event."""
+
+    schema: str
+    event: str
+    run_id: str
+    sequence: int
+    created_at: str
+    status: str
+    message: str
+    metadata: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class AgentTraceSummary:
+    """Compact read-side summary for an agent trace directory."""
+
+    run_id: str
+    agent: str
+    label: str
+    event_count: int
+    events_path: Path
+    meta_path: Path
+    first_event: str
+    last_event: str
+    status: str
+
+
+def utc_now() -> str:
+    """Return an RFC3339-ish UTC timestamp used across trace records."""
+
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _event_from_mapping(payload: Mapping[str, Any]) -> AgentTraceEvent:
+    metadata = payload.get("metadata")
+    return AgentTraceEvent(
+        schema=str(payload.get("schema") or ""),
+        event=str(payload.get("event") or ""),
+        run_id=str(payload.get("run_id") or ""),
+        sequence=int(payload.get("sequence") or 0),
+        created_at=str(payload.get("created_at") or ""),
+        status=str(payload.get("status") or ""),
+        message=str(payload.get("message") or ""),
+        metadata=dict(metadata) if isinstance(metadata, dict) else {},
+    )
+
+
+def load_trace_events(path: Path | str) -> list[AgentTraceEvent]:
+    """Load events from an ``agent_events.ndjson`` file or a trace directory."""
+
+    candidate = Path(path).expanduser()
+    events_path = candidate / EVENTS_FILENAME if candidate.is_dir() else candidate
+    if not events_path.exists():
+        return []
+
+    events: list[AgentTraceEvent] = []
+    for line in events_path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            payload = json.loads(line)
+        except ValueError:
+            continue
+        if isinstance(payload, dict):
+            events.append(_event_from_mapping(payload))
+    return events
+
+
+class AgentTraceStore:
+    """Directory-backed append-only event store for one AGILAB agent run."""
+
+    def __init__(
+        self,
+        root: Path | str,
+        *,
+        run_id: str,
+        agent: str = "",
+        label: str = "",
+        provider: str = "",
+        model: str = "",
+    ) -> None:
+        self.root = Path(root).expanduser()
+        self.run_id = run_id
+        self.agent = agent
+        self.label = label
+        self.provider = provider
+        self.model = model
+
+    @property
+    def meta_path(self) -> Path:
+        return self.root / META_FILENAME
+
+    @property
+    def events_path(self) -> Path:
+        return self.root / EVENTS_FILENAME
+
+    @property
+    def tool_output_dir(self) -> Path:
+        return self.root / TOOL_OUTPUT_DIRNAME
+
+    def initialize(self, metadata: Mapping[str, Any] | None = None) -> dict[str, Any]:
+        """Create the trace directory and meta file if missing."""
+
+        self.root.mkdir(parents=True, exist_ok=True)
+        self.tool_output_dir.mkdir(parents=True, exist_ok=True)
+        if self.meta_path.exists():
+            return _read_json(self.meta_path)
+
+        payload: dict[str, Any] = {
+            "schema": TRACE_SCHEMA,
+            "run_id": self.run_id,
+            "agent": self.agent,
+            "label": self.label,
+            "provider": self.provider,
+            "model": self.model,
+            "created_at": utc_now(),
+            "events": str(self.events_path),
+            "tool_output_dir": str(self.tool_output_dir),
+            "metadata": redact_mapping(metadata or {}),
+        }
+        self.meta_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        self.events_path.touch(exist_ok=True)
+        return payload
+
+    def append(
+        self,
+        event: str,
+        *,
+        status: str = "running",
+        message: str = "",
+        metadata: Mapping[str, Any] | None = None,
+    ) -> AgentTraceEvent:
+        """Append one redacted event record and return it."""
+
+        if event not in VALID_EVENT_TYPES:
+            raise ValueError(f"Unsupported agent trace event {event!r}")
+        if not self.meta_path.exists():
+            self.initialize()
+
+        sequence = len(load_trace_events(self.events_path)) + 1
+        record = AgentTraceEvent(
+            schema=TRACE_SCHEMA,
+            event=event,
+            run_id=self.run_id,
+            sequence=sequence,
+            created_at=utc_now(),
+            status=status,
+            message=redact_text(message),
+            metadata=redact_mapping(metadata or {}),
+        )
+        with self.events_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(asdict(record), sort_keys=True) + "\n")
+        return record
+
+
+def summarize_trace(path: Path | str) -> AgentTraceSummary:
+    """Return a compact summary for a trace directory or events file."""
+
+    candidate = Path(path).expanduser()
+    root = candidate if candidate.is_dir() else candidate.parent
+    meta = _read_json(root / META_FILENAME)
+    events = load_trace_events(candidate)
+    return AgentTraceSummary(
+        run_id=str(meta.get("run_id") or (events[0].run_id if events else "")),
+        agent=str(meta.get("agent") or ""),
+        label=str(meta.get("label") or ""),
+        event_count=len(events),
+        events_path=root / EVENTS_FILENAME,
+        meta_path=root / META_FILENAME,
+        first_event=events[0].event if events else "",
+        last_event=events[-1].event if events else "",
+        status=events[-1].status if events else "",
+    )
+
+
+def trace_artifact_payload(root: Path | str) -> dict[str, Any]:
+    """Return manifest-ready metadata for a trace directory."""
+
+    root_path = Path(root).expanduser()
+    events_path = root_path / EVENTS_FILENAME
+    meta_path = root_path / META_FILENAME
+    events = load_trace_events(events_path)
+    return {
+        "schema": TRACE_SCHEMA,
+        "meta": str(meta_path),
+        "events": str(events_path),
+        "tool_output_dir": str(root_path / TOOL_OUTPUT_DIRNAME),
+        "event_count": len(events),
+        "event_types": [event.event for event in events],
+        "exists": events_path.exists(),
+    }
+
+
+def validate_event_sequence(events: Sequence[AgentTraceEvent]) -> list[str]:
+    """Return human-readable trace-sequence issues."""
+
+    issues: list[str] = []
+    expected = 1
+    for event in events:
+        if event.schema != TRACE_SCHEMA:
+            issues.append(f"event {event.sequence}: unsupported schema {event.schema!r}")
+        if event.event not in VALID_EVENT_TYPES:
+            issues.append(f"event {event.sequence}: unsupported event {event.event!r}")
+        if event.sequence != expected:
+            issues.append(f"event {event.sequence}: expected sequence {expected}")
+            expected = event.sequence
+        expected += 1
+    return issues

--- a/test/test_agent_config_and_capabilities.py
+++ b/test/test_agent_config_and_capabilities.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CAPABILITY_MODULE_PATH = ROOT / "src" / "agilab" / "agent_provider_capabilities.py"
+CONFIG_MODULE_PATH = ROOT / "src" / "agilab" / "agent_config.py"
+
+
+def _load_capability_module():
+    previous_package = sys.modules.get("agilab")
+    sys.modules.pop("agilab.agent_provider_capabilities", None)
+    package = types.ModuleType("agilab")
+    package.__path__ = [str(ROOT / "src" / "agilab")]  # type: ignore[attr-defined]
+    package.__file__ = str(ROOT / "src" / "agilab" / "__init__.py")
+    package.__package__ = "agilab"
+    sys.modules["agilab"] = package
+    spec = importlib.util.spec_from_file_location("agilab.agent_provider_capabilities", CAPABILITY_MODULE_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        if previous_package is None:
+            sys.modules.pop("agilab", None)
+        else:
+            sys.modules["agilab"] = previous_package
+    return module
+
+
+def _load_config_module():
+    previous_package = sys.modules.get("agilab")
+    previous_capability = sys.modules.get("agilab.agent_provider_capabilities")
+    sys.modules.pop("agilab.agent_config", None)
+    package = types.ModuleType("agilab")
+    package.__path__ = [str(ROOT / "src" / "agilab")]  # type: ignore[attr-defined]
+    package.__file__ = str(ROOT / "src" / "agilab" / "__init__.py")
+    package.__package__ = "agilab"
+    sys.modules["agilab"] = package
+    _load_capability_module()
+    spec = importlib.util.spec_from_file_location("agilab.agent_config", CONFIG_MODULE_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        if previous_capability is None:
+            sys.modules.pop("agilab.agent_provider_capabilities", None)
+        else:
+            sys.modules["agilab.agent_provider_capabilities"] = previous_capability
+        if previous_package is None:
+            sys.modules.pop("agilab", None)
+        else:
+            sys.modules["agilab"] = previous_package
+    return module
+
+
+def test_provider_capability_infers_and_overrides_model_features() -> None:
+    module = _load_capability_module()
+
+    openai = module.resolve_provider_capability(model="gpt-5")
+    local = module.resolve_provider_capability(model="qwen2.5-coder:latest")
+    overridden = module.resolve_provider_capability(
+        "openai-compatible",
+        "private-model",
+        overrides={
+            "context_window": "65536",
+            "max_output_tokens": 4096,
+            "supports_reasoning": "true",
+            "supports_image_input": "false",
+        },
+    )
+
+    assert openai.provider == "openai"
+    assert module.default_model_for_provider("openai") == "gpt-5.4-mini"
+    assert openai.supports_reasoning is True
+    assert openai.supports_image_input is True
+    assert local.provider == "ollama"
+    assert local.supports_pdf_input is False
+    assert overridden.provider == "openai-compatible"
+    assert overridden.context_window == 65536
+    assert overridden.max_output_tokens == 4096
+    assert overridden.supports_reasoning is True
+    assert overridden.supports_image_input is False
+    assert overridden.source == "override"
+
+
+def test_agent_config_layers_global_and_project_files(tmp_path: Path) -> None:
+    module = _load_config_module()
+    home = tmp_path / "home"
+    project = tmp_path / "repo"
+    child = project / "sub"
+    (project / ".git").mkdir(parents=True)
+    (project / ".agilab").mkdir()
+    (home).mkdir()
+    child.mkdir(parents=True)
+    (home / module.CONFIG_FILENAME).write_text(
+        json.dumps(
+            {
+                "default": {"provider": "openai-main", "model": "gpt-5"},
+                "permission": {"level": "readonly"},
+                "providers": {
+                    "openai-main": {
+                        "type": "openai",
+                        "model": "gpt-5",
+                        "api_key_env": "OPENAI_API_KEY",
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    (project / ".agilab" / module.CONFIG_FILENAME).write_text(
+        json.dumps(
+            {
+                "default": {"provider": "local-code"},
+                "permission": {"level": "standard"},
+                "trace": {"enabled": False},
+                "providers": {
+                    "local-code": {
+                        "type": "ollama",
+                        "model": "qwen2.5-coder:latest",
+                        "capability": {"context_window": 32768},
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    config = module.load_agent_config(child, environ={module.AGENT_HOME_ENV: str(home)})
+    provider = module.resolve_agent_provider(config)
+
+    assert [path.name for path in config.config_paths] == [module.CONFIG_FILENAME, module.CONFIG_FILENAME]
+    assert config.default_provider == "local-code"
+    assert config.default_model == "gpt-5"
+    assert config.permission_level == "standard"
+    assert config.trace_enabled is False
+    assert config.providers["openai-main"].api_key_env_var == "OPENAI_API_KEY"
+    assert provider.name == "local-code"
+    assert provider.provider == "ollama"
+    assert provider.model == "qwen2.5-coder:latest"
+    assert provider.capability.context_window == 32768
+
+
+def test_agent_config_handles_missing_or_invalid_files(tmp_path: Path) -> None:
+    module = _load_config_module()
+
+    config = module.load_agent_config(tmp_path, environ={module.AGENT_HOME_ENV: str(tmp_path / "missing")})
+    provider = module.resolve_agent_provider(config, provider="gpt-oss", model="gpt-oss-120b")
+
+    assert config.schema == module.CONFIG_SCHEMA
+    assert config.config_paths == ()
+    assert config.permission_level == "safe"
+    assert provider.provider == "gpt-oss"
+    assert provider.capability.supports_reasoning is True

--- a/test/test_agent_run.py
+++ b/test/test_agent_run.py
@@ -83,6 +83,8 @@ def test_agent_run_print_only_json_is_redacted(tmp_path: Path, capsys) -> None:
     assert payload["events"][0]["type"] == "agent.run.planned"
     assert payload["events"][0]["protocol_adapters"] == ["ag-ui"]
     assert payload["events"][0]["capabilities"] == ["app-as-tool"]
+    assert payload["artifacts"]["agent_trace"]["events"] == str(tmp_path / "agent_events.ndjson")
+    assert payload["artifacts"]["agent_trace"]["exists"] is False
     assert "sk-secret" not in json.dumps(payload)
     assert "review" not in json.dumps(payload)
 
@@ -160,6 +162,7 @@ def test_agent_run_manifest_context_supports_tags_and_metadata(tmp_path: Path, c
 def test_agent_run_public_python_api_uses_cli_defaults(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     module = _load_module()
     monkeypatch.setenv("AGILAB_LOG_ABS", str(tmp_path / "logs"))
+    monkeypatch.setenv("AGILAB_AGENT_HOME", str(tmp_path / "agent-home"))
 
     config = module.create_agent_run_config(
         [sys.executable, "-c", "print('api')"],
@@ -181,10 +184,15 @@ def test_agent_run_public_python_api_uses_cli_defaults(tmp_path: Path, monkeypat
     assert config.metadata == {"branch": "main", "token": "hidden"}
     assert config.protocol_adapters == ("mcp",)
     assert config.capabilities == ("evidence-review",)
+    assert config.permission_level == "safe"
+    assert config.trace_enabled is True
+    assert config.provider == ""
+    assert config.model == ""
 
 
-def test_trace_agent_run_public_python_api_executes_and_redacts(tmp_path: Path) -> None:
+def test_trace_agent_run_public_python_api_executes_and_redacts(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     module = _load_module()
+    monkeypatch.setenv("AGILAB_AGENT_HOME", str(tmp_path / "agent-home"))
 
     result = module.trace_agent_run(
         [sys.executable, "-c", "print('api ok')"],
@@ -218,6 +226,49 @@ def test_trace_agent_run_public_python_api_executes_and_redacts(tmp_path: Path) 
     summary = module.summarize_agent_run(tmp_path)
     assert summary.run_id == "api-trace"
     assert summary.tags == ("api",)
+    assert summary.trace_events_path == tmp_path / "agent_events.ndjson"
+    events = (tmp_path / "agent_events.ndjson").read_text(encoding="utf-8")
+    assert "session_start" in events
+    assert "command_done" in events
+    assert "sk-secret" not in events
+
+
+def test_agent_run_stamps_provider_config_and_permission_level(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_module()
+    agent_home = tmp_path / "agent-home"
+    agent_home.mkdir()
+    monkeypatch.setenv("AGILAB_AGENT_HOME", str(agent_home))
+    (agent_home / "agents.json").write_text(
+        json.dumps(
+            {
+                "default": {"provider": "local-code"},
+                "permission": {"level": "standard"},
+                "providers": {
+                    "local-code": {
+                        "type": "ollama",
+                        "model": "qwen2.5-coder:latest",
+                        "capability": {"context_window": 32768},
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    payload = module.build_planned_manifest(
+        module.create_agent_run_config(
+            [sys.executable, "-c", "print('ok')"],
+            cwd=ROOT,
+            output_dir=tmp_path / "run",
+            run_id="configured",
+        )
+    )
+
+    assert payload["context"]["agent_config"]["permission_level"] == "standard"
+    assert payload["context"]["agent_config"]["config_paths"] == [str(agent_home / "agents.json")]
+    assert payload["context"]["provider"]["provider"] == "ollama"
+    assert payload["context"]["provider"]["model"] == "qwen2.5-coder:latest"
+    assert payload["context"]["provider"]["capability"]["context_window"] == 32768
 
 
 def test_agent_run_executes_command_and_writes_local_artifacts(tmp_path: Path, capsys) -> None:
@@ -258,9 +309,17 @@ def test_agent_run_executes_command_and_writes_local_artifacts(tmp_path: Path, c
         "agent.artifacts.written",
     ]
     assert payload["events"][1]["returncode"] == 0
+    assert payload["artifacts"]["agent_trace"]["event_count"] == 4
+    assert payload["artifacts"]["agent_trace"]["event_types"] == [
+        "session_start",
+        "command_start",
+        "command_done",
+        "session_end",
+    ]
     assert stdout_path.read_text(encoding="utf-8").strip() == "ok"
     assert stderr_path.read_text(encoding="utf-8").strip() == "warn"
     assert json.loads(manifest_path.read_text(encoding="utf-8"))["run_id"] == "agent-success"
+    assert "command finished with returncode 0" in (tmp_path / "agent_events.ndjson").read_text(encoding="utf-8")
 
 
 def test_agent_run_read_side_helpers_and_list_command(tmp_path: Path, capsys) -> None:
@@ -318,6 +377,7 @@ def test_agent_run_read_side_helpers_and_list_command(tmp_path: Path, capsys) ->
     assert summary.manifest_path == codex_dir / module.MANIFEST_FILENAME
     assert summary.stdout_path == codex_dir / module.STDOUT_FILENAME
     assert summary.stderr_path == codex_dir / module.STDERR_FILENAME
+    assert summary.trace_events_path == codex_dir / "agent_events.ndjson"
     assert summary.tags == ("review",)
     assert summary.metadata == {"branch": "main"}
 
@@ -328,6 +388,7 @@ def test_agent_run_read_side_helpers_and_list_command(tmp_path: Path, capsys) ->
     listed = json.loads(capsys.readouterr().out)
     assert [item["run_id"] for item in listed] == ["agent-codex"]
     assert listed[0]["metadata"] == {"branch": "main"}
+    assert listed[0]["trace_events"] == str(codex_dir / "agent_events.ndjson")
 
 
 def test_agent_run_failure_returns_command_status_and_manifest(tmp_path: Path, capsys) -> None:

--- a/test/test_agent_tool_safety.py
+++ b/test/test_agent_tool_safety.py
@@ -88,6 +88,91 @@ def test_destructive_agent_tool_invocation_requires_stable_confirmation() -> Non
     assert confirmed.reason == "destructive action confirmed by operator token"
 
 
+def test_permission_tiers_classify_and_gate_agent_actions() -> None:
+    module = _load_module()
+
+    readonly = module.evaluate_tool_permission("inspect_project", level="readonly")
+    safe_denied = module.evaluate_tool_permission("write_report", level="readonly")
+    standard_denied = module.evaluate_tool_permission("run_tests", level="safe")
+    operator_denied = module.evaluate_tool_permission("delete_output", {"path": "/tmp/out"}, level="standard")
+    token = module.confirmation_token("delete_output", {"path": "/tmp/out"})
+    operator_allowed = module.evaluate_tool_permission(
+        "delete_output",
+        {"path": "/tmp/out"},
+        level="standard",
+        confirmation=token,
+    )
+
+    assert readonly.allowed is True
+    assert readonly.tier == "readonly"
+    assert safe_denied.allowed is False
+    assert safe_denied.tier == "safe"
+    assert standard_denied.allowed is False
+    assert standard_denied.tier == "standard"
+    assert operator_denied.allowed is False
+    assert operator_denied.tier == "operator"
+    assert operator_denied.confirmation_token == token
+    assert operator_allowed.allowed is True
+    assert operator_allowed.reason == "operator action confirmed by explicit token"
+    assert module.normalize_permission_level("yolo") == "operator"
+
+
+def test_permission_tiers_honor_explicit_metadata() -> None:
+    module = _load_module()
+
+    decision = module.evaluate_tool_permission(
+        "archive_project",
+        level="safe",
+        metadata={"permission_tier": "standard"},
+    )
+
+    assert decision.allowed is False
+    assert decision.tier == "standard"
+
+
+def test_tool_hook_set_can_skip_and_rewrite_tool_results() -> None:
+    module = _load_module()
+    hooks = module.ToolHookSet()
+    calls: list[str] = []
+
+    @hooks.before_tool
+    def before(ctx):
+        calls.append(f"before:{ctx.action}")
+        if ctx.action == "blocked":
+            return module.ToolHookResult(output="blocked", status="denied", is_error=True)
+        return None
+
+    @hooks.after_tool
+    def after(ctx, result):
+        calls.append(f"after:{ctx.action}:{result.status}")
+        if result.status == "pass":
+            return module.ToolHookResult(
+                output=f"{result.output} audited",
+                status=result.status,
+                metadata={"audited": True},
+            )
+        return None
+
+    def runner(ctx):
+        calls.append(f"run:{ctx.action}")
+        return module.ToolHookResult(output="ok")
+
+    allowed = hooks.execute(module.ToolHookContext("inspect", {}, {}, run_id="run"), runner)
+    blocked = hooks.execute(module.ToolHookContext("blocked", {}, {}, run_id="run"), runner)
+
+    assert allowed.output == "ok audited"
+    assert allowed.metadata == {"audited": True}
+    assert blocked.output == "blocked"
+    assert blocked.is_error is True
+    assert calls == [
+        "before:inspect",
+        "run:inspect",
+        "after:inspect:pass",
+        "before:blocked",
+        "after:blocked:denied",
+    ]
+
+
 def test_require_tool_invocation_allowed_raises_for_unconfirmed_destructive_action() -> None:
     module = _load_module()
     with pytest.raises(module.ToolConfirmationRequired, match="requires explicit operator confirmation"):

--- a/test/test_agent_trace.py
+++ b/test/test_agent_trace.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SECRET_MODULE_PATH = ROOT / "src" / "agilab" / "secret_uri.py"
+MODULE_PATH = ROOT / "src" / "agilab" / "agent_trace.py"
+
+
+def _load_secret_module() -> object:
+    spec = importlib.util.spec_from_file_location("agilab.secret_uri", SECRET_MODULE_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_module():
+    previous_package = sys.modules.get("agilab")
+    previous_secret = sys.modules.get("agilab.secret_uri")
+    sys.modules.pop("agilab.agent_trace", None)
+    package = types.ModuleType("agilab")
+    package.__path__ = [str(ROOT / "src" / "agilab")]  # type: ignore[attr-defined]
+    package.__file__ = str(ROOT / "src" / "agilab" / "__init__.py")
+    package.__package__ = "agilab"
+    sys.modules["agilab"] = package
+    _load_secret_module()
+    spec = importlib.util.spec_from_file_location("agilab.agent_trace", MODULE_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        if previous_secret is None:
+            sys.modules.pop("agilab.secret_uri", None)
+        else:
+            sys.modules["agilab.secret_uri"] = previous_secret
+        if previous_package is None:
+            sys.modules.pop("agilab", None)
+        else:
+            sys.modules["agilab"] = previous_package
+    return module
+
+
+def test_agent_trace_store_writes_redacted_append_only_events(tmp_path: Path) -> None:
+    module = _load_module()
+    store = module.AgentTraceStore(
+        tmp_path,
+        run_id="agent-run",
+        agent="codex",
+        label="Review",
+        provider="openai",
+        model="gpt-5",
+    )
+
+    meta = store.initialize({"OPENAI_API_KEY": "sk-secret", "safe": "visible"})
+    start = store.append("session_start", message="using env://OPENAI_API_KEY")
+    done = store.append(
+        "tool_done",
+        status="pass",
+        message="OPENAI_API_KEY=sk-secret",
+        metadata={"token": "sk-secret", "safe": "ok"},
+    )
+
+    raw = store.events_path.read_text(encoding="utf-8")
+    loaded = module.load_trace_events(tmp_path)
+    summary = module.summarize_trace(tmp_path)
+    artifact = module.trace_artifact_payload(tmp_path)
+
+    assert meta["schema"] == module.TRACE_SCHEMA
+    assert meta["metadata"]["OPENAI_API_KEY"] == "<redacted>"
+    assert start.sequence == 1
+    assert done.sequence == 2
+    assert [event.event for event in loaded] == ["session_start", "tool_done"]
+    assert loaded[0].message == "using <secret-ref>"
+    assert loaded[1].metadata["token"] == "<redacted>"
+    assert "sk-secret" not in raw
+    assert summary.event_count == 2
+    assert summary.last_event == "tool_done"
+    assert artifact["event_count"] == 2
+    assert artifact["event_types"] == ["session_start", "tool_done"]
+
+
+def test_agent_trace_rejects_unknown_events_and_validates_sequence(tmp_path: Path) -> None:
+    module = _load_module()
+    store = module.AgentTraceStore(tmp_path, run_id="run")
+
+    try:
+        store.append("not-real")
+    except ValueError as exc:
+        assert "Unsupported agent trace event" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("unknown event should fail")
+
+    broken = [
+        module.AgentTraceEvent(
+            schema=module.TRACE_SCHEMA,
+            event="session_start",
+            run_id="run",
+            sequence=1,
+            created_at="now",
+            status="running",
+            message="",
+            metadata={},
+        ),
+        module.AgentTraceEvent(
+            schema="other",
+            event="unknown",
+            run_id="run",
+            sequence=3,
+            created_at="now",
+            status="running",
+            message="",
+            metadata={},
+        ),
+    ]
+
+    issues = module.validate_event_sequence(broken)
+
+    assert any("unsupported schema" in issue for issue in issues)
+    assert any("unsupported event" in issue for issue in issues)
+    assert any("expected sequence 2" in issue for issue in issues)
+
+
+def test_load_trace_events_ignores_invalid_lines(tmp_path: Path) -> None:
+    module = _load_module()
+    events_path = tmp_path / module.EVENTS_FILENAME
+    events_path.write_text(
+        "\n".join(
+            [
+                "{not-json",
+                json.dumps(
+                    {
+                        "schema": module.TRACE_SCHEMA,
+                        "event": "session_start",
+                        "run_id": "run",
+                        "sequence": 1,
+                        "created_at": "now",
+                        "status": "running",
+                        "message": "",
+                        "metadata": {},
+                    }
+                ),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    assert [event.sequence for event in module.load_trace_events(tmp_path)] == [1]

--- a/test/test_agent_workflows.py
+++ b/test/test_agent_workflows.py
@@ -80,12 +80,15 @@ def test_agent_run_evidence_command_is_documented() -> None:
     for text in (agent_workflows, public_docs, readme):
         assert "agilab agent-run --agent codex" in text
         assert "agilab.agent_run.v1" in text
+        assert "agilab.agent_trace.v1" in text
         assert "~/log/agents/" in text
     for text in (agent_workflows, readme):
         assert "--protocol-adapter" in text
         assert "--capability" in text
         assert "metadata-only" in text
     assert "trace_agent_run" in agent_workflows
+    assert "agent_events.ndjson" in agent_workflows
+    assert "permission tiers" in agent_workflows
     assert "agilab.agent_run.trace_agent_run()" in readme
 
 

--- a/tools/agent_workflows.md
+++ b/tools/agent_workflows.md
@@ -62,6 +62,9 @@ agilab agent-run --agent codex --label "Review current diff" --tag review --meta
 
 The command writes a redacted `agilab.agent_run.v1` manifest plus local
 `stdout.txt` and `stderr.txt` artifacts under `~/log/agents/<agent>/<run-id>/`.
+It also writes an append-only `agilab.agent_trace.v1` event stream in
+`agent_events.ndjson` and reserves `tool-output/` for large or structured tool
+payloads.
 Command arguments are redacted by default and represented by an argv hash;
 environment override values passed with `--env KEY=VALUE` are also redacted
 from the manifest. Pass `--include-command-args` only when the prompt/arguments
@@ -99,6 +102,22 @@ result = trace_agent_run(
 
 runs = list_agent_runs(agent="codex", limit=5)
 ```
+
+Agent-run evidence now has a stable low-level contract:
+
+- `agent_run_manifest.json` records command identity, redacted argv/env
+  metadata, optional provider/model capability context, and artifact paths.
+- `agent_trace_meta.json` describes the trace directory.
+- `agent_events.ndjson` appends typed events such as `session_start`,
+  `command_start`, `tool_start`, `tool_output`, `tool_done`,
+  `permission_request`, `permission_resolved`, `compact`, `rewind`, and
+  `session_end`.
+- `agilab.agent_tool_safety` exposes permission tiers (`readonly`, `safe`,
+  `standard`, `operator`) and before/after hooks for future agent-exposed
+  tools.
+- Agent provider defaults can be layered through `~/.agilab/agents/agents.json`
+  and project-local `.agilab/agents.json` files. Use `--provider`, `--model`,
+  and `--permission-level` for one-off CLI evidence labels.
 
 ## CLI-first references
 


### PR DESCRIPTION
## Summary
- adds a persistent `agilab.agent_trace.v1` NDJSON trace beside `agilab.agent_run.v1` manifests
- adds layered agent provider/config helpers and provider capability stamping
- extends tool safety with permission tiers and before/after hook primitives
- updates agent workflow docs, README text, and tests while preserving protocol-adapter metadata labels

## Validation
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_agent_trace.py test/test_agent_config_and_capabilities.py test/test_agent_tool_safety.py test/test_agent_run.py test/test_agent_workflows.py`
- `uv --preview-features extra-build-dependencies run python -m py_compile src/agilab/agent_trace.py src/agilab/agent_config.py src/agilab/agent_provider_capabilities.py src/agilab/agent_tool_safety.py src/agilab/agent_run.py`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files README.md README.pypi.md docs/source/agent-workflows.rst docs/.docs_source_mirror_stamp.json src/agilab/agent_run.py src/agilab/agent_tool_safety.py src/agilab/agent_trace.py src/agilab/agent_config.py src/agilab/agent_provider_capabilities.py test/test_agent_run.py test/test_agent_tool_safety.py test/test_agent_trace.py test/test_agent_config_and_capabilities.py test/test_agent_workflows.py tools/agent_workflows.md`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs`
- `uv --preview-features extra-build-dependencies run ruff check src/agilab/agent_run.py src/agilab/agent_tool_safety.py src/agilab/agent_trace.py src/agilab/agent_config.py src/agilab/agent_provider_capabilities.py test/test_agent_run.py test/test_agent_tool_safety.py test/test_agent_trace.py test/test_agent_config_and_capabilities.py test/test_agent_workflows.py`