### PR TITLE
[codex] test: improve project selector coverage

### DIFF
--- a/test/test_page_project_selector.py
+++ b/test/test_page_project_selector.py
@@ -12,7 +12,7 @@ MODULE_PATH = ROOT / "src/agilab/page_project_selector.py"
 
 
 def _load_module():
-    module_name = "agilab_page_project_selector_test_module"
+    module_name = "agilab.page_project_selector"
     sys.modules.pop(module_name, None)
     spec = importlib.util.spec_from_file_location(module_name, MODULE_PATH)
     assert spec and spec.loader
@@ -60,6 +60,36 @@ def test_render_project_selector_keeps_missing_current_in_sorted_options() -> No
 
     assert selection == "current_project"
     assert calls == [["Alpha_project", "current_project", "zeta_project"]]
+
+
+def test_render_project_selector_can_hide_edit_button_and_keep_valid_state() -> None:
+    module = _load_module()
+    events: list[str] = []
+
+    class Sidebar:
+        def selectbox(self, _label, options, *, index=0, **_kwargs):
+            assert options == ["alpha_project"]
+            assert index == 0
+            return options[index]
+
+    streamlit = SimpleNamespace(
+        session_state={"project_selectbox": "alpha_project"},
+        sidebar=Sidebar(),
+        query_params={},
+        switch_page=lambda *_args, **_kwargs: events.append("switch"),
+    )
+
+    selection = module.render_project_selector(
+        streamlit,
+        ["alpha_project"],
+        "alpha_project",
+        on_change=events.append,
+        show_edit_button=False,
+    )
+
+    assert selection == "alpha_project"
+    assert streamlit.session_state["project_selectbox"] == "alpha_project"
+    assert events == []
 
 
 def test_project_selector_handles_refresh_failure_and_empty_projects() -> None:
@@ -186,3 +216,57 @@ def test_project_selector_edit_button_prefers_registered_navigation_page(monkeyp
     assert selection == "alpha_project"
     assert streamlit.query_params["active_app"] == "alpha_project"
     assert switched == [route]
+
+
+def test_registered_navigation_page_prefers_main_module_route(monkeypatch) -> None:
+    module = _load_module()
+    main_route = object()
+    fallback_route = object()
+
+    monkeypatch.setattr(
+        sys.modules["__main__"],
+        "_NAVIGATION_PAGE_ROUTES",
+        {"project": main_route},
+        raising=False,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "agilab.main_page",
+        SimpleNamespace(_NAVIGATION_PAGE_ROUTES={"project": fallback_route}),
+    )
+
+    assert module._registered_navigation_page("project") is main_route
+
+
+def test_registered_navigation_page_ignores_missing_or_invalid_routes(monkeypatch) -> None:
+    module = _load_module()
+
+    monkeypatch.setattr(sys.modules["__main__"], "_NAVIGATION_PAGE_ROUTES", ["project"], raising=False)
+    monkeypatch.setitem(
+        sys.modules,
+        "agilab.main_page",
+        SimpleNamespace(_NAVIGATION_PAGE_ROUTES={"project": None, "analysis": object()}),
+    )
+
+    assert module._registered_navigation_page("project") is None
+
+
+def test_switch_to_project_page_handles_missing_switch_page_without_side_effects() -> None:
+    module = _load_module()
+    streamlit = SimpleNamespace(query_params={})
+
+    assert module.switch_to_project_page(streamlit, active_app="alpha_project") is False
+    assert streamlit.query_params == {}
+
+
+def test_switch_to_project_page_can_use_fallback_path_without_active_app(monkeypatch) -> None:
+    module = _load_module()
+    switched: list[Path] = []
+    streamlit = SimpleNamespace(query_params={"keep": "value"}, switch_page=switched.append)
+
+    monkeypatch.delattr(sys.modules["__main__"], "_NAVIGATION_PAGE_ROUTES", raising=False)
+    monkeypatch.setitem(sys.modules, "agilab.main_page", SimpleNamespace(_NAVIGATION_PAGE_ROUTES={}))
+
+    assert module.switch_to_project_page(streamlit) is True
+    assert streamlit.query_params == {"keep": "value"}
+    assert switched == [Path("pages/1_PROJECT.py")]


### PR DESCRIPTION
## Summary
- Attribute the project selector unit test import to `agilab.page_project_selector` so focused coverage reports the real source module.
- Add branch coverage for hidden edit-button rendering, registered navigation route selection, missing routes, and fallback PROJECT navigation.

## Validation
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_page_project_selector.py`
- `COVERAGE_FILE=/tmp/.coverage-project-selector-push uv --preview-features extra-build-dependencies run pytest -q -o addopts='' --cov=agilab.page_project_selector --cov-report=term-missing test/test_page_project_selector.py` reported `100%` for `src/agilab/page_project_selector.py`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files test/test_page_project_selector.py`
- `git diff --check`