### PR TITLE
Use number-only skills badge

### DIFF
--- a/badges/skills.svg
+++ b/badges/skills.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="125" height="20" role="img" aria-label="Skills: 28 skills">
+<svg xmlns="http://www.w3.org/2000/svg" width="76" height="20" role="img" aria-label="Skills: 28">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -6,17 +6,17 @@
   <stop offset="1" stop-opacity=".5"/>
 </linearGradient>
 <mask id="a">
-  <rect width="125" height="20" rx="3" fill="#fff"/>
+  <rect width="76" height="20" rx="3" fill="#fff"/>
 </mask>
 <g mask="url(#a)">
   <rect width="52" height="20" fill="#555"/>
-  <rect x="52" width="73" height="20" fill="#0F766E"/>
-  <rect width="125" height="20" fill="url(#b)"/>
+  <rect x="52" width="24" height="20" fill="#0F766E"/>
+  <rect width="76" height="20" fill="url(#b)"/>
 </g>
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="26.0" y="15" fill="#010101" fill-opacity=".3">Skills</text>
   <text x="26.0" y="14">Skills</text>
-  <text x="88.5" y="15" fill="#010101" fill-opacity=".3">28 skills</text>
-  <text x="88.5" y="14">28 skills</text>
+  <text x="64.0" y="15" fill="#010101" fill-opacity=".3">28</text>
+  <text x="64.0" y="14">28</text>
 </g>
 </svg>

--- a/test/test_generate_skill_badges.py
+++ b/test/test_generate_skill_badges.py
@@ -31,13 +31,6 @@ def test_visible_skill_names_filters_hidden_dirs_and_files(tmp_path: Path) -> No
     assert names == {"alpha", "beta"}
 
 
-def test_format_skill_count_handles_singular_and_plural() -> None:
-    module = _load_module()
-
-    assert module.format_skill_count(1) == "1 skill"
-    assert module.format_skill_count(2) == "2 skills"
-
-
 def test_repo_skill_names_unions_agent_trees_and_extra_repo_without_double_counting(
     monkeypatch, tmp_path: Path
 ) -> None:
@@ -94,9 +87,9 @@ def test_main_generates_single_public_skill_badge_from_both_skill_trees(
     assert not (badge_dir / "skills-claude.svg").exists()
     content = (badge_dir / "skills.svg").read_text(encoding="utf-8")
     assert "Skills" in content
-    assert "2 skills" in content
-    assert "repo skills" not in content
-    assert "skills: 2 skills -> badges/skills.svg" in capsys.readouterr().out
+    assert "Skills: 2" in content
+    assert "2 skills" not in content
+    assert "skills: 2 -> badges/skills.svg" in capsys.readouterr().out
 
 
 def test_main_can_include_additional_local_repo_for_union_count(
@@ -131,9 +124,9 @@ def test_main_can_include_additional_local_repo_for_union_count(
 
     assert result == 0
     content = (badge_dir / "skills.svg").read_text(encoding="utf-8")
-    assert "3 skills" in content
-    assert "repo skills" not in content
-    assert "skills: 3 skills -> badges/skills.svg" in capsys.readouterr().out
+    assert "Skills: 3" in content
+    assert "3 skills" not in content
+    assert "skills: 3 -> badges/skills.svg" in capsys.readouterr().out
 
 
 def test_main_generates_public_agent_badges_by_default(monkeypatch, tmp_path: Path) -> None:
@@ -175,7 +168,9 @@ def test_main_generates_public_agent_badges_by_default(monkeypatch, tmp_path: Pa
     result = module.main()
 
     assert result == 0
-    assert "2 skills" in (badge_dir / "skills.svg").read_text(encoding="utf-8")
+    skill_badge = (badge_dir / "skills.svg").read_text(encoding="utf-8")
+    assert "Skills: 2" in skill_badge
+    assert "2 skills" not in skill_badge
     assert "Agent Skills" in (badge_dir / "agent-standard.svg").read_text(encoding="utf-8")
     assert "Codex Claude Continue Aider OpenCode" in (
         badge_dir / "agent-works-with.svg"

--- a/tools/generate_skill_badges.py
+++ b/tools/generate_skill_badges.py
@@ -96,11 +96,6 @@ def visible_skill_names(skills_dir: Path) -> set[str]:
     }
 
 
-def format_skill_count(count: int) -> str:
-    suffix = "skill" if count == 1 else "skills"
-    return f"{count} {suffix}"
-
-
 def repo_skill_names(include_repos: list[str]) -> set[str]:
     names: set[str] = set()
     for relative_dir in SKILL_TREE_DIRS:
@@ -112,7 +107,7 @@ def repo_skill_names(include_repos: list[str]) -> set[str]:
 
 
 def refresh_skill_badge(include_repos: list[str]) -> None:
-    value = format_skill_count(len(repo_skill_names(include_repos)))
+    value = str(len(repo_skill_names(include_repos)))
     svg = render_badge(str(SKILL_BADGE["label"]), value, str(SKILL_BADGE["color"]))
     badge_path = SKILL_BADGE["badge"]
     badge_path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- make the generated skills badge show only the numeric count
- update badge generator tests for the number-only contract

## Validation
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_generate_skill_badges.py
- uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files tools/generate_skill_badges.py test/test_generate_skill_badges.py badges/skills.svg --no-cache
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile skills