### PR TITLE
[codex] Add agent API badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
   <a href="AGENT_SKILLS.md"><img src="https://raw.githubusercontent.com/ThalesGroup/agilab/main/badges/skills.svg" alt="Skills" /></a>
   <a href="https://agentskills.io/"><img src="https://raw.githubusercontent.com/ThalesGroup/agilab/main/badges/agent-standard.svg" alt="Standard: Agent Skills" /></a>
   <a href="tools/agent_workflows.md"><img src="https://raw.githubusercontent.com/ThalesGroup/agilab/main/badges/agent-works-with.svg" alt="Works with Codex Claude Continue Aider and OpenCode" /></a>
+  <a href="tools/agent_workflows.md"><img src="https://raw.githubusercontent.com/ThalesGroup/agilab/main/badges/agent-api.svg" alt="Agent API: CLI Python" /></a>
   <a href="docs/source/environment.rst"><img src="https://img.shields.io/badge/Language-python%20free--threaded%20%26%20cythonized-5B6CFF" alt="Language Python free-threaded and Cythonized" /></a>
   <a href="https://github.com/ThalesGroup/agilab/pulls"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs welcome" /></a>
   <a href="https://pypi.org/project/agilab/"><img src="https://img.shields.io/badge/wheel-yes-0F766E" alt="Wheel: yes" /></a>

--- a/README.pypi.md
+++ b/README.pypi.md
@@ -10,6 +10,7 @@
 [![Skills](https://raw.githubusercontent.com/ThalesGroup/agilab/main/badges/skills.svg)](https://github.com/ThalesGroup/agilab/blob/main/AGENT_SKILLS.md)
 [![Standard: Agent Skills](https://raw.githubusercontent.com/ThalesGroup/agilab/main/badges/agent-standard.svg)](https://agentskills.io/)
 [![Works with](https://raw.githubusercontent.com/ThalesGroup/agilab/main/badges/agent-works-with.svg)](https://github.com/ThalesGroup/agilab/blob/main/tools/agent_workflows.md)
+[![Agent API: CLI Python](https://raw.githubusercontent.com/ThalesGroup/agilab/main/badges/agent-api.svg)](https://github.com/ThalesGroup/agilab/blob/main/tools/agent_workflows.md)
 
 # AGILAB
 

--- a/badges/agent-api.svg
+++ b/badges/agent-api.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="153" height="20" role="img" aria-label="Agent API: CLI Python">
+<linearGradient id="b" x2="0" y2="100%">
+  <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
+  <stop offset=".1" stop-opacity=".1"/>
+  <stop offset=".9" stop-opacity=".3"/>
+  <stop offset="1" stop-opacity=".5"/>
+</linearGradient>
+<mask id="a">
+  <rect width="153" height="20" rx="3" fill="#fff"/>
+</mask>
+<g mask="url(#a)">
+  <rect width="73" height="20" fill="#555"/>
+  <rect x="73" width="80" height="20" fill="#5B6CFF"/>
+  <rect width="153" height="20" fill="url(#b)"/>
+</g>
+<g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+  <text x="36.5" y="15" fill="#010101" fill-opacity=".3">Agent API</text>
+  <text x="36.5" y="14">Agent API</text>
+  <text x="113.0" y="15" fill="#010101" fill-opacity=".3">CLI Python</text>
+  <text x="113.0" y="14">CLI Python</text>
+</g>
+</svg>

--- a/test/test_agent_workflows.py
+++ b/test/test_agent_workflows.py
@@ -94,7 +94,7 @@ def test_agent_skill_badges_catalog_and_resource_preflight_are_documented() -> N
     readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
     pypi_readme = (REPO_ROOT / "README.pypi.md").read_text(encoding="utf-8")
 
-    for badge in ("skills.svg", "agent-standard.svg", "agent-works-with.svg"):
+    for badge in ("skills.svg", "agent-standard.svg", "agent-works-with.svg", "agent-api.svg"):
         assert badge in readme
         assert badge in pypi_readme
 

--- a/test/test_generate_skill_badges.py
+++ b/test/test_generate_skill_badges.py
@@ -168,6 +168,12 @@ def test_main_generates_public_agent_badges_by_default(monkeypatch, tmp_path: Pa
                 "badge": badge_dir / "agent-works-with.svg",
                 "color": "#0F766E",
             },
+            "agent-api": {
+                "label": "Agent API",
+                "value": "CLI Python",
+                "badge": badge_dir / "agent-api.svg",
+                "color": "#5B6CFF",
+            },
         },
     )
     monkeypatch.setattr(sys, "argv", ["generate_skill_badges.py"])
@@ -179,4 +185,7 @@ def test_main_generates_public_agent_badges_by_default(monkeypatch, tmp_path: Pa
     assert "Agent Skills" in (badge_dir / "agent-standard.svg").read_text(encoding="utf-8")
     assert "Codex Claude Continue Aider OpenCode" in (
         badge_dir / "agent-works-with.svg"
+    ).read_text(encoding="utf-8")
+    assert "Agent API: CLI Python" in (
+        badge_dir / "agent-api.svg"
     ).read_text(encoding="utf-8")

--- a/test/test_public_demo_links.py
+++ b/test/test_public_demo_links.py
@@ -260,6 +260,11 @@ def test_readme_agent_skill_badges_use_raw_urls_for_public_renderers() -> None:
         'src="https://raw.githubusercontent.com/ThalesGroup/agilab/main/badges/skills.svg" '
         'alt="Skills" /></a>'
     ) in readme
+    assert (
+        '<a href="tools/agent_workflows.md"><img '
+        'src="https://raw.githubusercontent.com/ThalesGroup/agilab/main/badges/agent-api.svg" '
+        'alt="Agent API: CLI Python" /></a>'
+    ) in readme
     assert "badges/agent-skills.svg" not in readme
     assert 'src="badges/skills-codex.svg"' not in readme
     assert 'src="badges/skills-claude.svg"' not in readme

--- a/tools/generate_skill_badges.py
+++ b/tools/generate_skill_badges.py
@@ -33,6 +33,12 @@ AGENT_BADGES = {
         "badge": REPO_ROOT / "badges" / "agent-works-with.svg",
         "color": "#0F766E",
     },
+    "agent-api": {
+        "label": "Agent API",
+        "value": "CLI Python",
+        "badge": REPO_ROOT / "badges" / "agent-api.svg",
+        "color": "#5B6CFF",
+    },
 }
 
 


### PR DESCRIPTION
## Summary

Add a public badge that makes AGILAB's agent API surface visible from the README and PyPI page.

- generate `badges/agent-api.svg` from `tools/generate_skill_badges.py`
- link the badge from `README.md` and `README.pypi.md` to `tools/agent_workflows.md`
- cover the badge in the existing public README/badge tests

## Why

AGILAB now exposes `agilab agent-run` and the Python helpers such as `agilab.agent_run.trace_agent_run()`. The new badge makes that agent API availability visible next to the existing Skills, Agent Skills standard, and Works with badges.

## Validation

- `uv --preview-features extra-build-dependencies run --with tomli-w pytest -q -o addopts='' test/test_generate_skill_badges.py test/test_agent_workflows.py test/test_public_demo_links.py`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files README.md README.pypi.md badges/agent-api.svg tools/generate_skill_badges.py test/test_generate_skill_badges.py test/test_agent_workflows.py test/test_public_demo_links.py --no-cache`
- `git diff --check`
