### PR TITLE
[codex] Clarify notebook export core runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,14 @@
 AGILAB is an anti-lock-in reproducibility workbench for AI/ML engineering.
 It turns notebooks and scripts into executable, portable, evidence-backed apps
 while preserving a notebook export path.
-That means you do not lose your work if AGILAB is no longer the right runtime.
-Those apps can run locally or on distributed workers, and the
-workflow stays portable: export it back to a runnable notebook, and hand off
-tracking evidence to MLflow when that integration is enabled.
+That export is an `agi-core` runtime handoff: you can continue to run the saved
+project and stage contract with only the stable, production-grade core
+technology, without depending on the AGILAB UI or distributed worker layer.
+That means you do not lose your work if the AGILAB UI or distributed runtime is
+no longer the right interface. Those apps can run locally or on distributed
+workers, and the workflow stays portable: export it back to an `agi-core`
+notebook, inspect or adapt the Python stages, and hand off tracking evidence to
+MLflow when that integration is enabled.
 
 Use it to keep experimental AI work:
 
@@ -53,7 +57,7 @@ Use it to keep experimental AI work:
 - **controlled environments**
 - **local or distributed execution**
 - **reviewable run evidence**
-- **runnable outside AGILAB as exported notebooks**
+- **runnable outside the AGILAB UI as `agi-core` notebooks**
 - **optional MLflow integration**
 
 AGILAB complements MLflow and production MLOps platforms. It owns the
@@ -67,9 +71,10 @@ Notebook/script → AGILAB app → controlled execution → artifacts + evidence
 notebook / MLflow / UI handoff
 
 The flow is reversible where it matters for long-term reuse: WORKFLOW can export
-the saved pipeline as a runnable supervisor notebook, so the code, stage order,
-runtime hints, and review context remain usable in Jupyter-compatible tools even
-if you later decide AGILAB is no longer the right runtime for that work.
+the saved pipeline as a runnable `agi-core` supervisor notebook, so the code,
+stage order, runtime hints, and review context remain usable through the stable,
+production-grade core technology if the AGILAB UI or distributed runtime is no
+longer the right interface for that work.
 
 Start with the public browser preview or the demo chooser:
 

--- a/README.pypi.md
+++ b/README.pypi.md
@@ -17,10 +17,14 @@
 AGILAB is an anti-lock-in reproducibility workbench for AI/ML engineering.
 It turns notebooks and scripts into executable, portable, evidence-backed apps
 while preserving a notebook export path.
-That means you do not lose your work if AGILAB is no longer the right runtime.
-Those apps can run locally or on distributed workers, and the
-workflow stays portable: export it back to a runnable notebook, and hand off
-tracking evidence to MLflow when that integration is enabled.
+That export is an `agi-core` runtime handoff: you can continue to run the saved
+project and stage contract with only the stable, production-grade core
+technology, without depending on the AGILAB UI or distributed worker layer.
+That means you do not lose your work if the AGILAB UI or distributed runtime is
+no longer the right interface. Those apps can run locally or on distributed
+workers, and the workflow stays portable: export it back to an `agi-core`
+notebook, inspect or adapt the Python stages, and hand off tracking evidence to
+MLflow when that integration is enabled.
 
 Use it to keep experimental AI work:
 
@@ -28,7 +32,7 @@ Use it to keep experimental AI work:
 - **controlled environments**
 - **local or distributed execution**
 - **reviewable run evidence**
-- **runnable outside AGILAB as exported notebooks**
+- **runnable outside the AGILAB UI as `agi-core` notebooks**
 - **optional MLflow integration**
 
 AGILAB complements MLflow and production MLOps platforms. It owns the
@@ -42,10 +46,10 @@ Notebook/script -> AGILAB app -> controlled execution -> artifacts + evidence ->
 notebook / MLflow / UI handoff
 
 The flow is reversible where it matters for long-term reuse: WORKFLOW can
-export the saved pipeline as a runnable supervisor notebook, so the code, stage
-order, runtime hints, and review context remain usable in Jupyter-compatible
-tools even if you later decide AGILAB is no longer the right runtime for that
-work.
+export the saved pipeline as a runnable `agi-core` supervisor notebook, so the
+code, stage order, runtime hints, and review context remain usable through the
+stable, production-grade core technology if the AGILAB UI or distributed
+runtime is no longer the right interface for that work.
 
 Start with the public browser preview or the demo chooser:
 

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 216,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "d6fb5a0eb874464789adc39978bd6948fb06b12e34fb879e4ea3afca0241d297",
+  "source_digest_sha256": "118acee210d6943abb8fb33377e8d7da5c9809b654e784e32ca0c0daf2c24f8f",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "d6fb5a0eb874464789adc39978bd6948fb06b12e34fb879e4ea3afca0241d297"
+  "target_digest_sha256": "118acee210d6943abb8fb33377e8d7da5c9809b654e784e32ca0c0daf2c24f8f"
 }

--- a/docs/source/architecture-five-minutes.rst
+++ b/docs/source/architecture-five-minutes.rst
@@ -4,7 +4,10 @@ Architecture in 5 minutes
 AGILAB is an anti-lock-in reproducibility workbench for AI/ML engineering
 teams. It bridges local interactive development, distributed execution, and
 result analysis while preserving an exit path: workflows can be exported back
-to runnable notebooks if AGILAB stops being the right runtime for a project.
+to runnable ``agi-core`` notebooks if the AGILAB UI or distributed runtime is
+no longer the right interface for a project. That export keeps execution on the
+stable, production-grade core technology while preserving the project and stage
+contract.
 
 Use this page for the mental model before opening the detailed architecture
 reference. The global map shows the current level of abstraction: AGILAB is not

--- a/docs/source/evidence-claims-policy.rst
+++ b/docs/source/evidence-claims-policy.rst
@@ -24,8 +24,9 @@ Use these phrases only when the linked implementation or artifact exists.
      - A run manifest, stage metadata, or artifact manifest is written.
    * - AGILAB release proof ties together package, CI, docs, and demo evidence.
      - The public :doc:`release-proof` page references the current release.
-   * - AGILAB can export a workflow back to a runnable notebook.
-     - The workflow has a notebook export manifest or exported notebook.
+   * - AGILAB can export a workflow back to a runnable ``agi-core`` notebook.
+     - The workflow has a notebook export manifest or exported notebook that
+       declares the stable, production-grade ``agi-core`` runtime dependency.
    * - AGILAB can hand evidence to MLflow when the integration is enabled.
      - The MLflow route is explicitly enabled and the run records the handoff.
    * - AGILAB UI robot evidence captures public UI behavior.

--- a/docs/source/execute-help.rst
+++ b/docs/source/execute-help.rst
@@ -224,8 +224,9 @@ For a first pass through the UI, follow this sequence exactly:
    confirm the work plan matches the selected workers.
 4. Open ``Run`` and copy or export the generated ``AGI.run`` snippet.
 5. Optionally open ``Notebook`` to download the current orchestration recipe as
-   a runnable notebook for review, handoff, or reuse if AGILAB is no longer the
-   runtime you want to keep.
+   a runnable ``agi-core`` notebook for review, handoff, or reuse if the AGILAB
+   UI or distributed runtime is no longer the interface you want to keep. This
+   keeps execution on the stable, production-grade core technology.
 6. In :doc:`experiment-help`, import or regenerate that snippet as a WORKFLOW
    stage instead of retyping it.
 

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -140,9 +140,10 @@ What is the difference between notebook import and notebook export?
 
 Notebook import turns an existing ``.ipynb`` into AGILAB project stages after
 preflight checks and explicit role review. Notebook export takes an AGILAB
-WORKFLOW pipeline and writes a runnable notebook that preserves the saved stage
-contract. Import helps you enter AGILAB; export helps you leave or hand off the
-work without losing it.
+WORKFLOW pipeline and writes a runnable ``agi-core`` notebook that preserves
+the saved stage contract. Import helps you enter AGILAB; export helps you leave
+the UI or hand off the work without losing it, while still running on the
+stable, production-grade core technology.
 
 Packages, apps, and release evidence
 ------------------------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,9 +3,12 @@ AGILab Documentation
 
 AGILAB turns experimental AI/ML notebooks and scripts into executable,
 portable, evidence-backed applications that can run locally or on distributed
-workers. Workflows stay portable: export them back to runnable notebooks, keep
-reproducibility evidence, and hand off tracking evidence to MLflow when that
-integration is enabled.
+workers. Workflows stay portable: export them back to runnable ``agi-core``
+notebooks, keep reproducibility evidence, and hand off tracking evidence to
+MLflow when that integration is enabled. The notebook export is an ``agi-core``
+runtime handoff: you can continue to run the saved project and stage contract
+with only the stable, production-grade core technology, without depending on
+the AGILAB UI or distributed worker layer.
 
 If you are new to AGILab, choose one route first:
 

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -11,8 +11,8 @@ What AGILab is
 
 AGILab turns experimental AI/ML notebooks and scripts into executable,
 portable, evidence-backed applications that can run locally or on distributed
-workers, while keeping a handoff path to runnable notebooks and MLflow tracking
-evidence.
+workers, while keeping a handoff path to runnable ``agi-core`` notebooks and
+MLflow tracking evidence.
 
 It is a framework and web UI for running Python data, ML, and RL projects
 through one visible workflow: create the app, execute it under controlled

--- a/docs/source/proof-capsule.rst
+++ b/docs/source/proof-capsule.rst
@@ -44,7 +44,8 @@ A complete proof capsule should contain these parts:
        to rerun the application.
      - ``lab_stages.toml``, app settings seeds, and exported run manifests.
    * - Notebook bridge
-     - Imported notebook provenance or exported runnable notebook for handoff.
+     - Imported notebook provenance or exported runnable ``agi-core`` notebook
+       for handoff.
      - WORKFLOW notebook import/export and notebook export manifests.
    * - Tracking handoff
      - MLflow run identifiers or exported tracking metadata when MLflow is

--- a/docs/source/quick-start.rst
+++ b/docs/source/quick-start.rst
@@ -198,8 +198,9 @@ machine-readable proof record.
    notebook -> PROJECT ``Create`` -> ORCHESTRATE ``INSTALL`` -> ORCHESTRATE
    ``EXECUTE`` -> ANALYSIS -> WORKFLOW ``Download pipeline notebook``. The last
    step is the no-lock-in check: the work remains available as
-   ``lab_stages.ipynb`` if AGILAB is no longer the right runtime for the
-   project.
+   ``lab_stages.ipynb`` running on the stable, production-grade ``agi-core``
+   technology if the AGILAB UI or distributed runtime is no longer the right
+   interface for the project.
 
    The landing page also shows an adoption gate. Treat it as a go/no-go for
    widening from one user to a controlled team trial: one first proof must have a

--- a/test/test_audit_response_docs.py
+++ b/test/test_audit_response_docs.py
@@ -17,7 +17,8 @@ def test_architecture_five_minutes_page_exposes_layer_map() -> None:
 
     assert "Architecture in 5 minutes" in page
     assert "anti-lock-in reproducibility workbench" in page
-    assert "workflows can be exported back to runnable notebooks" in normalized_page
+    assert "workflows can be exported back to runnable ``agi-core`` notebooks" in normalized_page
+    assert "stable, production-grade core technology" in normalized_page
     assert "Streamlit UI, CLI wrappers, or notebook entry points" in page
     assert "AgiEnv: settings, project selection, app paths, logs, local workspace" in page
     assert "Dask back-plane and optional MLflow tracking" in page

--- a/test/test_notebook_export_docs.py
+++ b/test/test_notebook_export_docs.py
@@ -26,12 +26,14 @@ def test_pipeline_docs_sell_runnable_supervisor_notebook_export() -> None:
 def test_readme_leads_with_anti_lock_in_notebook_export_value() -> None:
     readme = Path("README.md").read_text(encoding="utf-8")
     headline_window = readme[readme.index("# AGILAB") : readme.index("## Core Flow")]
+    compact_headline = _compact(headline_window)
 
     assert "anti-lock-in reproducibility workbench" in headline_window
     assert "executable, portable, evidence-backed apps" in headline_window
-    assert "export it back to a runnable notebook" in headline_window
+    assert "export it back to an `agi-core` notebook" in compact_headline
     assert "you do not lose your work" in headline_window
-    assert "runnable outside AGILAB as exported notebooks" in headline_window
+    assert "stable, production-grade core technology" in compact_headline
+    assert "runnable outside the AGILAB UI as `agi-core` notebooks" in headline_window
     assert "reviewable run evidence" in headline_window
 
 
@@ -44,9 +46,10 @@ def test_docs_overview_leads_with_no_lock_in_notebook_export_value() -> None:
     compact_architecture = _compact(architecture)
 
     assert "executable, portable, evidence-backed applications" in compact_index
-    assert "export them back to runnable notebooks" in compact_index
+    assert "export them back to runnable ``agi-core`` notebooks" in compact_index
+    assert "stable, production-grade core technology" in compact_index
     assert "anti-lock-in reproducibility workbench" in compact_architecture
-    assert "workflows can be exported back to runnable notebooks" in compact_architecture
+    assert "workflows can be exported back to runnable ``agi-core`` notebooks" in compact_architecture
 
 
 def test_agilab_help_mentions_pipeline_notebook_export() -> None:

--- a/test/test_public_demo_links.py
+++ b/test/test_public_demo_links.py
@@ -146,15 +146,18 @@ def test_pypi_readme_tracks_public_readme_contract() -> None:
     readme = README.read_text(encoding="utf-8")
     pypi_readme = PYPI_README.read_text(encoding="utf-8")
     pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+    compact_readme = " ".join(readme.split())
+    compact_pypi_readme = " ".join(pypi_readme.split())
 
     assert pyproject["project"]["readme"] == "README.pypi.md"
 
     synced_fragments = (
         "AGILAB is an anti-lock-in reproducibility workbench for AI/ML engineering.",
         "It turns notebooks and scripts into executable, portable, evidence-backed apps",
-        "you do not lose your work if AGILAB is no longer the right runtime.",
+        "you do not lose your work if the AGILAB UI or distributed runtime is",
         "reviewable run evidence",
-        "runnable outside AGILAB as exported notebooks",
+        "runnable outside the AGILAB UI as `agi-core` notebooks",
+        "production-grade core technology",
         "AGILAB complements MLflow and production MLOps platforms.",
         "## Core Flow",
         "### Local PyPI UI Proof",
@@ -180,8 +183,8 @@ def test_pypi_readme_tracks_public_readme_contract() -> None:
         "Package publishing policy",
     )
     for fragment in synced_fragments:
-        assert fragment in readme
-        assert fragment in pypi_readme
+        assert fragment in readme or fragment in compact_readme
+        assert fragment in pypi_readme or fragment in compact_pypi_readme
 
     stale_fragments = (
         "Try this first",


### PR DESCRIPTION
## Summary

- Clarifies README and PyPI README wording so notebook export is described as an `agi-core` runtime handoff, not a dependency-free export.
- Updates public docs to state that exported notebooks continue to run with the stable, production-grade core technology without depending on the AGILAB UI or distributed worker layer.
- Updates documentation regression tests to lock the new positioning.

## Validation

- `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files README.md README.pypi.md docs/source/index.rst docs/source/architecture-five-minutes.rst docs/source/introduction.rst docs/source/faq.rst docs/source/execute-help.rst docs/source/evidence-claims-policy.rst docs/source/proof-capsule.rst docs/source/quick-start.rst test/test_notebook_export_docs.py test/test_audit_response_docs.py test/test_public_demo_links.py --no-cache`
- `uv --preview-features extra-build-dependencies run --with tomli-w pytest -q -o addopts='' test/test_audit_response_docs.py test/test_notebook_export_docs.py test/test_public_demo_links.py`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs`