### PR TITLE
[codex] Tighten HF first-proof robot coverage

### DIFF
--- a/test/test_ui_robot_coverage_contract.py
+++ b/test/test_ui_robot_coverage_contract.py
@@ -41,6 +41,11 @@ def test_ui_robot_coverage_contract_passes_for_current_matrix() -> None:
         "weather_forecast_project",
     ]
     assert payload["coverage"]["hf_install_profile_scenarios"] == ["hf-first-proof-install"]
+    assert payload["coverage"]["hf_first_proof_pages"] == [
+        "view_forecast_analysis",
+        "view_maps",
+        "view_release_decision",
+    ]
     assert payload["coverage"]["hf_visual_smoke_profile_apps"] == [
         "flight_telemetry_project",
         "weather_forecast_project",
@@ -119,7 +124,10 @@ def test_ui_robot_coverage_contract_reports_hf_first_proof_gaps(monkeypatch) -> 
         },
         OPT_IN_SCENARIOS={"hf-first-proof-visual-smoke": incomplete_hf_visual},
     )
-    hf_smoke = SimpleNamespace(profile_builtin_app_entries=lambda _profile: {"flight_project"})
+    hf_smoke = SimpleNamespace(
+        profile_builtin_app_entries=lambda _profile: {"flight_project"},
+        profile_page_entries=lambda _profile: {"view_maps"},
+    )
     workflow_parity = SimpleNamespace(
         _profile_commands=lambda _args: {
             "hf-install-robot": [SimpleNamespace(argv=["--scenario", "legacy-hf-install"])],
@@ -149,6 +157,10 @@ def test_ui_robot_coverage_contract_reports_hf_first_proof_gaps(monkeypatch) -> 
         "flight_telemetry_project, weather_forecast_project"
     ) in details
     assert "first-proof HF profile still exposes stale demo apps: flight_project" in details
+    assert (
+        "first-proof HF profile is missing public demo pages: "
+        "view_forecast_analysis, view_release_decision"
+    ) in details
     assert "hf-visual-smoke-robot does not run hf-first-proof-visual-smoke" in details
     assert "hf-visual-smoke-robot does not run hf-first-proof-app-pages-visual-smoke" in details
     assert "hf-visual-smoke-robot is missing first-proof apps: flight_project" in details

--- a/test/test_workflow_parity.py
+++ b/test/test_workflow_parity.py
@@ -525,6 +525,7 @@ def test_profile_commands_cover_expected_coverage_and_docs_contracts() -> None:
     assert hf_visual_smoke_robot.remove_paths == ["test-results/hf-visual-smoke-robot", "screenshots/hf-visual-smoke-robot"]
     assert "hf-first-proof-visual-smoke" in hf_visual_smoke_robot.argv
     assert "hf-first-proof-app-pages-visual-smoke" in hf_visual_smoke_robot.argv
+    assert hf_visual_smoke_robot.argv.count("--scenario") == 2
     assert "flight_telemetry_project,weather_forecast_project" in hf_visual_smoke_robot.argv
     assert "https://huggingface.co/spaces/jpmorard/agilab" in hf_visual_smoke_robot.argv
     assert "--active-app" not in hf_visual_smoke_robot.argv

--- a/tools/ui_robot_coverage_contract.py
+++ b/tools/ui_robot_coverage_contract.py
@@ -21,15 +21,15 @@ SCHEMA = "agilab.ui_robot_coverage_contract.v1"
 REQUIRED_CORE_PAGES = ("HOME", "PROJECT", "ORCHESTRATE", "WORKFLOW", "ANALYSIS", "SETTINGS")
 REQUIRED_HIGH_RISK_ACTIONS = ("INSTALL", "CHECK distribute", "Run -> Load -> Export")
 REQUIRED_HF_FIRST_PROOF_APPS = ("flight_telemetry_project", "weather_forecast_project")
+REQUIRED_HF_FIRST_PROOF_PAGES = ("view_forecast_analysis", "view_maps", "view_release_decision")
 FORBIDDEN_HF_FIRST_PROOF_APPS = ("flight_project", "meteo_forecast_project")
-REQUIRED_HF_FIRST_PROOF_APPS_PAGES = ("view_forecast_analysis", "view_maps", "view_release_decision")
 REQUIRED_HF_ROBOT_SCENARIOS = {
     "hf-first-proof-visual-smoke": {
         "pages": ("HOME", "PROJECT", "ORCHESTRATE", "WORKFLOW", "ANALYSIS"),
         "flags": ("success_screenshot", "above_fold_check", "browser_error_check"),
     },
     "hf-first-proof-app-pages-visual-smoke": {
-        "apps_pages": REQUIRED_HF_FIRST_PROOF_APPS_PAGES,
+        "apps_pages": REQUIRED_HF_FIRST_PROOF_PAGES,
         "flags": ("success_screenshot", "above_fold_check", "browser_error_check"),
     },
     "hf-first-proof-install": {
@@ -165,6 +165,15 @@ def evaluate_contract() -> dict[str, Any]:
                 "first-proof HF profile still exposes stale demo apps: " + ", ".join(forbidden_hf_apps),
             )
         )
+    hf_first_proof_pages = sorted(hf_smoke.profile_page_entries("first-proof"))
+    missing_hf_pages = sorted(set(REQUIRED_HF_FIRST_PROOF_PAGES) - set(hf_first_proof_pages))
+    if missing_hf_pages:
+        issues.append(
+            CoverageIssue(
+                "hf_public_demo_page",
+                "first-proof HF profile is missing public demo pages: " + ", ".join(missing_hf_pages),
+            )
+        )
 
     scenario_by_name = {scenario.name: scenario for scenario in all_scenarios}
     hf_robot_scenarios: dict[str, dict[str, list[str]]] = {}
@@ -225,41 +234,31 @@ def evaluate_contract() -> dict[str, Any]:
     parity_profiles = workflow_parity._profile_commands(
         argparse.Namespace(components=(), skills=(), app_path=None, worker_copy=None)
     )
-    hf_install_profile_apps: list[str] = []
-    hf_install_profile_scenarios: list[str] = []
-    for command in parity_profiles.get("hf-install-robot", []):
-        scenarios = _argv_values(command.argv, "--scenario")
-        hf_install_profile_scenarios.extend(scenarios)
-        if "hf-first-proof-install" in scenarios:
-            hf_install_profile_apps.extend(widget_robot.parse_csv(_argv_value(command.argv, "--apps")))
-    hf_install_profile_apps = sorted(set(hf_install_profile_apps))
-    hf_install_profile_scenarios = sorted(set(hf_install_profile_scenarios))
-    missing_install_profile_apps = sorted(set(hf_first_proof_apps) - set(hf_install_profile_apps))
-    if "hf-first-proof-install" not in hf_install_profile_scenarios:
-        issues.append(
-            CoverageIssue(
-                "hf_robot_profile",
-                "hf-install-robot does not run hf-first-proof-install",
-            )
-        )
-    if missing_install_profile_apps:
-        issues.append(
-            CoverageIssue(
-                "hf_robot_profile",
-                "hf-install-robot is missing first-proof apps: " + ", ".join(missing_install_profile_apps),
-            )
-        )
-
     hf_visual_smoke_profile_apps: list[str] = []
     hf_visual_smoke_profile_scenarios: list[str] = []
+    hf_install_profile_apps: list[str] = []
+    hf_install_profile_scenarios: list[str] = []
+    hf_visual_smoke_required_scenarios = {
+        "hf-first-proof-visual-smoke",
+        "hf-first-proof-app-pages-visual-smoke",
+    }
+    hf_install_required_scenarios = {"hf-first-proof-install"}
     for command in parity_profiles.get("hf-visual-smoke-robot", []):
         scenarios = _argv_values(command.argv, "--scenario")
         hf_visual_smoke_profile_scenarios.extend(scenarios)
-        if "hf-first-proof-visual-smoke" in scenarios:
+        if hf_visual_smoke_required_scenarios.intersection(scenarios):
             hf_visual_smoke_profile_apps.extend(widget_robot.parse_csv(_argv_value(command.argv, "--apps")))
+    for command in parity_profiles.get("hf-install-robot", []):
+        scenarios = _argv_values(command.argv, "--scenario")
+        hf_install_profile_scenarios.extend(scenarios)
+        if hf_install_required_scenarios.intersection(scenarios):
+            hf_install_profile_apps.extend(widget_robot.parse_csv(_argv_value(command.argv, "--apps")))
     hf_visual_smoke_profile_apps = sorted(set(hf_visual_smoke_profile_apps))
     hf_visual_smoke_profile_scenarios = sorted(set(hf_visual_smoke_profile_scenarios))
+    hf_install_profile_apps = sorted(set(hf_install_profile_apps))
+    hf_install_profile_scenarios = sorted(set(hf_install_profile_scenarios))
     missing_profile_apps = sorted(set(hf_first_proof_apps) - set(hf_visual_smoke_profile_apps))
+    missing_install_profile_apps = sorted(set(hf_first_proof_apps) - set(hf_install_profile_apps))
     if "hf-first-proof-visual-smoke" not in hf_visual_smoke_profile_scenarios:
         issues.append(
             CoverageIssue(
@@ -308,6 +307,7 @@ def evaluate_contract() -> dict[str, Any]:
             "configured_apps_pages_scenarios": configured_scenarios,
             "high_risk_actions": action_to_scenarios,
             "hf_first_proof_apps": hf_first_proof_apps,
+            "hf_first_proof_pages": hf_first_proof_pages,
             "hf_install_profile_apps": hf_install_profile_apps,
             "hf_install_profile_scenarios": hf_install_profile_scenarios,
             "hf_visual_smoke_profile_apps": hf_visual_smoke_profile_apps,


### PR DESCRIPTION
## Summary
- enforce the HF first-proof public page bundle in the UI robot coverage contract
- make the HF visual-smoke profile account for both the app-page and core-page smoke scenarios
- add regression assertions for the current parity profile and missing-page diagnostics

## Validation
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_agilab_widget_robot_matrix.py test/test_ui_robot_coverage_contract.py test/test_workflow_parity.py`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files test/test_ui_robot_coverage_contract.py test/test_workflow_parity.py tools/ui_robot_coverage_contract.py`
- `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp --quiet`
- `uv --preview-features extra-build-dependencies run python tools/ui_robot_coverage_contract.py --json`
