### PR TITLE
[codex] Align Ruff style badge and skill guidance

### DIFF
--- a/.claude/skills/agilab-runbook/SKILL.md
+++ b/.claude/skills/agilab-runbook/SKILL.md
@@ -85,6 +85,12 @@ Use this skill when you need repo-specific “how we do things” guidance in `a
   uses `tools/pre_push_changed_files.py` to run docs mirror checks only for docs mirror inputs and
   release-proof checks only for release-proof inputs. If classification fails, it runs all local
   guards. Coverage badge freshness remains an explicit `./dev badge` or release/pre-release check.
+- **Public style badge alignment**: keep the code-style/style-guard signal in
+  `README.md` and `README.pypi.md` aligned with the actual repository guard. If
+  the public badge moves to a Ruff changed-files guard or another style tool,
+  update both README files, grep for stale `Black`, `black`, or `code%20style`
+  badge text, and avoid advertising a tool that is not wired into the local
+  validation path.
 - **Install-log startup check**: before launching flows after installer changes or a reported install
   failure, inspect the latest installer log for errors. On macOS/Linux:
   `dir="$HOME/log/install_logs"; f=$(ls -1t "$dir"/*.log 2>/dev/null | head -1); [ -n "$f" ] && echo "Log: $f" && grep -Eai "error|exception|traceback|failed|fatal|denied|missing|not found" "$f" | tail -n 25 || echo "No logs found."`

--- a/.codex/skills/agilab-runbook/SKILL.md
+++ b/.codex/skills/agilab-runbook/SKILL.md
@@ -85,6 +85,12 @@ Use this skill when you need repo-specific “how we do things” guidance in `a
   uses `tools/pre_push_changed_files.py` to run docs mirror checks only for docs mirror inputs and
   release-proof checks only for release-proof inputs. If classification fails, it runs all local
   guards. Coverage badge freshness remains an explicit `./dev badge` or release/pre-release check.
+- **Public style badge alignment**: keep the code-style/style-guard signal in
+  `README.md` and `README.pypi.md` aligned with the actual repository guard. If
+  the public badge moves to a Ruff changed-files guard or another style tool,
+  update both README files, grep for stale `Black`, `black`, or `code%20style`
+  badge text, and avoid advertising a tool that is not wired into the local
+  validation path.
 - **Install-log startup check**: before launching flows after installer changes or a reported install
   failure, inspect the latest installer log for errors. On macOS/Linux:
   `dir="$HOME/log/install_logs"; f=$(ls -1t "$dir"/*.log 2>/dev/null | head -1); [ -n "$f" ] && echo "Log: $f" && grep -Eai "error|exception|traceback|failed|fatal|denied|missing|not found" "$f" | tail -n 25 || echo "No logs found."`

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
   <a href="https://github.com/ThalesGroup/agilab/pulls"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs welcome" /></a>
   <a href="https://pypi.org/project/agilab/"><img src="https://img.shields.io/badge/wheel-yes-0F766E" alt="Wheel: yes" /></a>
   <a href="https://github.com/ThalesGroup/agilab"><img src="https://img.shields.io/github/repo-size/ThalesGroup/agilab" alt="Repo size" /></a>
-  <a href="https://github.com/psf/black"><img src="https://img.shields.io/badge/code%20style-black-000000.svg" alt="Black code style" /></a>
+  <a href="https://docs.astral.sh/ruff/"><img src="https://img.shields.io/badge/style%20guard-Ruff%20changed--files-0F766E" alt="Style guard: Ruff changed-files" /></a>
   <a href="https://orcid.org/0009-0003-5375-368X"><img src="https://img.shields.io/badge/ORCID-0009--0003--5375--368X-A6CE39?logo=orcid" alt="ORCID" /></a>
 </p>
 

--- a/README.pypi.md
+++ b/README.pypi.md
@@ -11,6 +11,7 @@
 [![Standard: Agent Skills](https://raw.githubusercontent.com/ThalesGroup/agilab/main/badges/agent-standard.svg)](https://agentskills.io/)
 [![Works with](https://raw.githubusercontent.com/ThalesGroup/agilab/main/badges/agent-works-with.svg)](https://github.com/ThalesGroup/agilab/blob/main/tools/agent_workflows.md)
 [![Agent API: CLI Python](https://raw.githubusercontent.com/ThalesGroup/agilab/main/badges/agent-api.svg)](https://github.com/ThalesGroup/agilab/blob/main/tools/agent_workflows.md)
+[![Style guard: Ruff changed-files](https://img.shields.io/badge/style%20guard-Ruff%20changed--files-0F766E)](https://docs.astral.sh/ruff/)
 
 # AGILAB
 


### PR DESCRIPTION
## Summary

- Replace the stale Black code-style badge in the GitHub README with the current Ruff changed-files style guard badge.
- Add the same Ruff style badge to the PyPI README for consistency.
- Update the AGILAB runbook skill so future badge/style-guard changes keep `README.md` and `README.pypi.md` aligned and avoid stale Black/code-style badge text.

## Why

The README still advertised Black even though the intended public style signal is now Ruff-based changed-file guarding. The skill update records the rule so future agents check both README variants instead of fixing only one surface.

## Validation

- `git diff --check HEAD~1..HEAD`
- `rg -n "black|Black|code%20style|style%20guard|Style guard|Ruff changed" README.md README.pypi.md`
- `uv --preview-features extra-build-dependencies run python tools/sync_agent_skills.py --skills agilab-runbook`
- `uv --preview-features extra-build-dependencies run python tools/codex_skills.py --root .codex/skills validate --strict`
- `uv --preview-features extra-build-dependencies run python tools/codex_skills.py --root .codex/skills generate`
- `uv --preview-features extra-build-dependencies run python tools/agent_skill_catalog.py --apply`
- `uv --preview-features extra-build-dependencies run python tools/generate_skill_badges.py`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile skills`
- local pre-push guard passed while pushing `codex/fix-ruff-readme-badge`