### PR TITLE
[codex] Align notebook runtime skill guidance

### DIFF
--- a/.claude/skills/agilab-docs/SKILL.md
+++ b/.claude/skills/agilab-docs/SKILL.md
@@ -93,6 +93,11 @@ If you accidentally edit `docs/html` directly, discard that manual edit and rege
   constants, request objects, and stable wrappers over private `AGI._*`
   internals, raw mode bitmasks, stale generated scripts, or legacy event-loop
   snippets.
+- When describing notebook export, position it as a runnable `agi-core` runtime
+  handoff, not as a UI-only fallback or a local sidecar feature. The public
+  claim is that users can keep stage order, runtime hints, review context, and
+  executable notebook code usable through the stable core runtime even when the
+  AGILAB UI or distributed runtime is not used.
 - When updating public examples, add or refresh a stale-snippet grep/test for the
   old pattern so outdated snippets do not reappear in README, `docs/source`,
   canonical docs, or Hugging Face copy.

--- a/.claude/skills/agilab-huggingface-spaces/SKILL.md
+++ b/.claude/skills/agilab-huggingface-spaces/SKILL.md
@@ -92,8 +92,10 @@ public app IDs directly.
 Keep the skill aligned with the README contract:
 - the Space README presents AGILAB as an anti-lock-in reproducibility workbench,
   not as a generic AI platform
-- the default and advanced Space cards both mention runnable notebook export as
-  the user exit path: review, handoff, and reuse outside AGILAB
+- the default and advanced Space cards both describe notebook export as an
+  `agi-core` runtime handoff: review, handoff, and reuse without the AGILAB UI
+  or distributed worker layer, while still relying on the stable core runtime
+  and the exported project's dependencies
 - the Space exposes the AGILAB Streamlit interface
 - Space mode is single-container only
 - local Dask multi-worker execution may be demonstrated inside that container
@@ -188,7 +190,7 @@ Before touching the Space deployment, verify:
    - secret names
    - Space-card metadata, including a real pictographic `emoji:` value such as
      `🧪` rather than a textual alias like `lab_coat`
-   - anti-lock-in / runnable-notebook-export positioning
+   - anti-lock-in / `agi-core` notebook-export positioning
    - profile app/page lists
    - target repo content
    - current public app IDs, especially `flight_project` and
@@ -296,15 +298,15 @@ hf download "$space" pyproject.toml README.md Dockerfile \
   --revision "$space_sha" \
   --local-dir "$tmpdir"
 rg -n '^version = |^name = ' "$tmpdir/pyproject.toml"
-rg -n 'Anti-lock-in|anti-lock-in|runnable notebooks|Notebook export exit path|flight_telemetry_project|weather_forecast_project|flight_project|meteo_forecast_project|AGILAB_HF_BUILTIN_APPS' \
+rg -n 'Anti-lock-in|anti-lock-in|agi-core|core runtime|Notebook export exit path|flight_telemetry_project|weather_forecast_project|flight_project|meteo_forecast_project|AGILAB_HF_BUILTIN_APPS' \
   "$tmpdir/README.md" "$tmpdir/Dockerfile"
 ```
 
 Treat an old `pyproject.toml` version, missing current app IDs, or old app IDs
 such as `flight_telemetry_project` / `weather_forecast_project` in deployed
 profile files as a failed alignment, even if the live HTTP smoke passes. Treat
-missing anti-lock-in / notebook-export copy as a Space-card alignment failure,
-even when the runtime itself is healthy.
+missing anti-lock-in / `agi-core` notebook-export copy as a Space-card
+alignment failure, even when the runtime itself is healthy.
 
 If the Space is stuck in `RUNNING_BUILDING` or `RUNNING_APP_STARTING`, inspect
 the relevant logs before making another upload:

--- a/.claude/skills/agilab-runbook/SKILL.md
+++ b/.claude/skills/agilab-runbook/SKILL.md
@@ -190,18 +190,25 @@ Use this skill when you need repo-specific “how we do things” guidance in `a
     `agilab adoption-report --json --strict` for automation
   - treat `safe_to_expand=true` as permission to try the next demo/notebook lane,
     not as production, shared-workstation, secrets, public-exposure, or cluster approval
-  - for team handoff, keep the manifest, exported `notebooks/lab_stages.ipynb`,
-    compatibility-report output, and redacted strict security-check output together
+  - for team handoff, keep the manifest, exported `agi-core`
+    `notebooks/lab_stages.ipynb`, compatibility-report output, and redacted
+    strict security-check output together. The notebook handoff removes
+    dependence on the AGILAB UI/distributed-worker layer, but it still relies on
+    the stable core runtime and the exported project's dependencies.
 - PyPI app-package management:
   - search: `agilab app search flight`
-  - preflight: `agilab app check agi-app-flight-project --json`
-  - install: `agilab app install agi-app-flight-project`
+  - preflight: `agilab app check agi-app-flight-telemetry --json`
+  - install: `agilab app install agi-app-flight-telemetry`
   - inventory/update/remove: `agilab app list`, `agilab app update <package>`,
     `agilab app remove <package>`
 - Publish dry-run (TestPyPI): `cd "$PROJECT_DIR" && uv --preview-features extra-build-dependencies run python tools/pypi_publish.py --repo testpypi --dry-run --verbose`
 - Publish to PyPI: `cd "$PROJECT_DIR" && uv --preview-features extra-build-dependencies run python tools/pypi_publish.py --repo pypi --verbose --git-tag --git-commit-version --git-reset-on-failure`
   - Real PyPI publishes now require the GitHub CLI (`gh`) because `tools/pypi_publish.py` creates or updates the matching GitHub Release after pushing the tag.
-  - Real PyPI does not auto-select `.postN` when the date version already exists. If `YYYY.MM.DD` is already published, choose an explicit next version such as the next release date or `--version YYYY.MM.DD.post1`; dry-run that exact command first, then publish with the same explicit version.
+  - Real PyPI does not auto-select `.postN` when the date version already
+    exists. Normal public releases should move to a deliberate new date-based
+    version or a release candidate/TestPyPI rehearsal first. Use `.postN` only
+    for a documented critical hotfix and pass the workflow's explicit
+    `allow_post_release` / reason controls.
   - On publish retries, the top-level `agilab` artifact may already exist while split runtime/app/page packages still need publication. Let the preflight/release plan decide what remains instead of checking only the root package.
   - Add `--delete-former-github-release` only when the public release page should keep a single current GitHub Release. This deletes the previous GitHub Release entry after the new one is created, but keeps the previous git tag and PyPI files.
   - Add `--delete-pypi-release <version>` only when a specific old PyPI version must be removed from the selected packages. This uses an exact `pypi-cleanup --version-regex` match, requires real PyPI web-login credentials in `[pypi_cleanup]`, and cannot use API tokens or trusted publishing credentials.

--- a/.claude/skills/notebook-to-agilab-project/SKILL.md
+++ b/.claude/skills/notebook-to-agilab-project/SKILL.md
@@ -156,8 +156,9 @@ ANALYSIS notebook launcher:
   directory and persist notebook selection alongside view selection.
 - Do not describe notebooks or AGI snippets as local-runtime-only. Only the
   embedded ANALYSIS Jupyter sidecar is local interactive UI; exported notebooks
-  and snippets can be reused wherever their runtime and dependencies are
-  available.
+  are `agi-core` runtime handoffs and snippets can be reused wherever their
+  runtime and dependencies are available. The export is an exit from the
+  AGILAB UI/distributed-worker layer, not from the stable core technology.
 
 ## References
 

--- a/.claude/skills/notebook-to-agilab-project/references/migration-checklist.md
+++ b/.claude/skills/notebook-to-agilab-project/references/migration-checklist.md
@@ -25,6 +25,9 @@
 - AGI snippets remain a valid reuse surface for code-centric logic; do not
   describe notebook/snippet reuse as local-runtime-only. Only the embedded
   ANALYSIS Jupyter sidecar is the local interactive launch path.
+- Exported notebooks remain runnable through `agi-core` plus the exported
+  project's dependencies. Present notebook export as an exit from the AGILAB UI
+  or distributed-worker layer, not as a dependency-free artifact.
 
 ## Migration value to show
 

--- a/.codex/skills/agilab-docs/SKILL.md
+++ b/.codex/skills/agilab-docs/SKILL.md
@@ -93,6 +93,11 @@ If you accidentally edit `docs/html` directly, discard that manual edit and rege
   constants, request objects, and stable wrappers over private `AGI._*`
   internals, raw mode bitmasks, stale generated scripts, or legacy event-loop
   snippets.
+- When describing notebook export, position it as a runnable `agi-core` runtime
+  handoff, not as a UI-only fallback or a local sidecar feature. The public
+  claim is that users can keep stage order, runtime hints, review context, and
+  executable notebook code usable through the stable core runtime even when the
+  AGILAB UI or distributed runtime is not used.
 - When updating public examples, add or refresh a stale-snippet grep/test for the
   old pattern so outdated snippets do not reappear in README, `docs/source`,
   canonical docs, or Hugging Face copy.

--- a/.codex/skills/agilab-huggingface-spaces/SKILL.md
+++ b/.codex/skills/agilab-huggingface-spaces/SKILL.md
@@ -92,8 +92,10 @@ public app IDs directly.
 Keep the skill aligned with the README contract:
 - the Space README presents AGILAB as an anti-lock-in reproducibility workbench,
   not as a generic AI platform
-- the default and advanced Space cards both mention runnable notebook export as
-  the user exit path: review, handoff, and reuse outside AGILAB
+- the default and advanced Space cards both describe notebook export as an
+  `agi-core` runtime handoff: review, handoff, and reuse without the AGILAB UI
+  or distributed worker layer, while still relying on the stable core runtime
+  and the exported project's dependencies
 - the Space exposes the AGILAB Streamlit interface
 - Space mode is single-container only
 - local Dask multi-worker execution may be demonstrated inside that container
@@ -188,7 +190,7 @@ Before touching the Space deployment, verify:
    - secret names
    - Space-card metadata, including a real pictographic `emoji:` value such as
      `🧪` rather than a textual alias like `lab_coat`
-   - anti-lock-in / runnable-notebook-export positioning
+   - anti-lock-in / `agi-core` notebook-export positioning
    - profile app/page lists
    - target repo content
    - current public app IDs, especially `flight_project` and
@@ -296,15 +298,15 @@ hf download "$space" pyproject.toml README.md Dockerfile \
   --revision "$space_sha" \
   --local-dir "$tmpdir"
 rg -n '^version = |^name = ' "$tmpdir/pyproject.toml"
-rg -n 'Anti-lock-in|anti-lock-in|runnable notebooks|Notebook export exit path|flight_telemetry_project|weather_forecast_project|flight_project|meteo_forecast_project|AGILAB_HF_BUILTIN_APPS' \
+rg -n 'Anti-lock-in|anti-lock-in|agi-core|core runtime|Notebook export exit path|flight_telemetry_project|weather_forecast_project|flight_project|meteo_forecast_project|AGILAB_HF_BUILTIN_APPS' \
   "$tmpdir/README.md" "$tmpdir/Dockerfile"
 ```
 
 Treat an old `pyproject.toml` version, missing current app IDs, or old app IDs
 such as `flight_telemetry_project` / `weather_forecast_project` in deployed
 profile files as a failed alignment, even if the live HTTP smoke passes. Treat
-missing anti-lock-in / notebook-export copy as a Space-card alignment failure,
-even when the runtime itself is healthy.
+missing anti-lock-in / `agi-core` notebook-export copy as a Space-card
+alignment failure, even when the runtime itself is healthy.
 
 If the Space is stuck in `RUNNING_BUILDING` or `RUNNING_APP_STARTING`, inspect
 the relevant logs before making another upload:

--- a/.codex/skills/agilab-runbook/SKILL.md
+++ b/.codex/skills/agilab-runbook/SKILL.md
@@ -190,18 +190,25 @@ Use this skill when you need repo-specific “how we do things” guidance in `a
     `agilab adoption-report --json --strict` for automation
   - treat `safe_to_expand=true` as permission to try the next demo/notebook lane,
     not as production, shared-workstation, secrets, public-exposure, or cluster approval
-  - for team handoff, keep the manifest, exported `notebooks/lab_stages.ipynb`,
-    compatibility-report output, and redacted strict security-check output together
+  - for team handoff, keep the manifest, exported `agi-core`
+    `notebooks/lab_stages.ipynb`, compatibility-report output, and redacted
+    strict security-check output together. The notebook handoff removes
+    dependence on the AGILAB UI/distributed-worker layer, but it still relies on
+    the stable core runtime and the exported project's dependencies.
 - PyPI app-package management:
   - search: `agilab app search flight`
-  - preflight: `agilab app check agi-app-flight-project --json`
-  - install: `agilab app install agi-app-flight-project`
+  - preflight: `agilab app check agi-app-flight-telemetry --json`
+  - install: `agilab app install agi-app-flight-telemetry`
   - inventory/update/remove: `agilab app list`, `agilab app update <package>`,
     `agilab app remove <package>`
 - Publish dry-run (TestPyPI): `cd "$PROJECT_DIR" && uv --preview-features extra-build-dependencies run python tools/pypi_publish.py --repo testpypi --dry-run --verbose`
 - Publish to PyPI: `cd "$PROJECT_DIR" && uv --preview-features extra-build-dependencies run python tools/pypi_publish.py --repo pypi --verbose --git-tag --git-commit-version --git-reset-on-failure`
   - Real PyPI publishes now require the GitHub CLI (`gh`) because `tools/pypi_publish.py` creates or updates the matching GitHub Release after pushing the tag.
-  - Real PyPI does not auto-select `.postN` when the date version already exists. If `YYYY.MM.DD` is already published, choose an explicit next version such as the next release date or `--version YYYY.MM.DD.post1`; dry-run that exact command first, then publish with the same explicit version.
+  - Real PyPI does not auto-select `.postN` when the date version already
+    exists. Normal public releases should move to a deliberate new date-based
+    version or a release candidate/TestPyPI rehearsal first. Use `.postN` only
+    for a documented critical hotfix and pass the workflow's explicit
+    `allow_post_release` / reason controls.
   - On publish retries, the top-level `agilab` artifact may already exist while split runtime/app/page packages still need publication. Let the preflight/release plan decide what remains instead of checking only the root package.
   - Add `--delete-former-github-release` only when the public release page should keep a single current GitHub Release. This deletes the previous GitHub Release entry after the new one is created, but keeps the previous git tag and PyPI files.
   - Add `--delete-pypi-release <version>` only when a specific old PyPI version must be removed from the selected packages. This uses an exact `pypi-cleanup --version-regex` match, requires real PyPI web-login credentials in `[pypi_cleanup]`, and cannot use API tokens or trusted publishing credentials.

--- a/.codex/skills/notebook-to-agilab-project/SKILL.md
+++ b/.codex/skills/notebook-to-agilab-project/SKILL.md
@@ -156,8 +156,9 @@ ANALYSIS notebook launcher:
   directory and persist notebook selection alongside view selection.
 - Do not describe notebooks or AGI snippets as local-runtime-only. Only the
   embedded ANALYSIS Jupyter sidecar is local interactive UI; exported notebooks
-  and snippets can be reused wherever their runtime and dependencies are
-  available.
+  are `agi-core` runtime handoffs and snippets can be reused wherever their
+  runtime and dependencies are available. The export is an exit from the
+  AGILAB UI/distributed-worker layer, not from the stable core technology.
 
 ## References
 

--- a/.codex/skills/notebook-to-agilab-project/references/migration-checklist.md
+++ b/.codex/skills/notebook-to-agilab-project/references/migration-checklist.md
@@ -25,6 +25,9 @@
 - AGI snippets remain a valid reuse surface for code-centric logic; do not
   describe notebook/snippet reuse as local-runtime-only. Only the embedded
   ANALYSIS Jupyter sidecar is the local interactive launch path.
+- Exported notebooks remain runnable through `agi-core` plus the exported
+  project's dependencies. Present notebook export as an exit from the AGILAB UI
+  or distributed-worker layer, not as a dependency-free artifact.
 
 ## Migration value to show
 


### PR DESCRIPTION
## Summary
- align AGILAB docs, runbook, Hugging Face, and notebook migration skills with the notebook export positioning
- describe exported notebooks as an `agi-core` runtime handoff rather than a UI-only/local fallback
- refresh mirrored Codex skill copies and keep generated catalogs unchanged

## Validation
- `python3 tools/sync_agent_skills.py --skills agilab-docs agilab-huggingface-spaces agilab-runbook notebook-to-agilab-project`
- `python3 tools/codex_skills.py --root .codex/skills validate --strict`
- `python3 tools/codex_skills.py --root .codex/skills generate`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files $(git diff --name-only)`
- `python3 tools/agent_skill_catalog.py --apply`
- `python3 tools/generate_skill_badges.py`
- `python3 tools/skill_security_scan.py --roots .claude/skills .codex/skills --fail-on critical`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile skills`
