### PR TITLE
chore: prepare 2026.05.20 release

### DIFF
--- a/badges/coverage-agi-gui.svg
+++ b/badges/coverage-agi-gui.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="153" height="20" role="img" aria-label="agi-gui coverage: 98%">
+<svg xmlns="http://www.w3.org/2000/svg" width="153" height="20" role="img" aria-label="agi-gui coverage: 96%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="61.0" y="15" fill="#010101" fill-opacity=".3">agi-gui coverage</text>
   <text x="61.0" y="14">agi-gui coverage</text>
-  <text x="137.5" y="15" fill="#010101" fill-opacity=".3">98%</text>
-  <text x="137.5" y="14">98%</text>
+  <text x="137.5" y="15" fill="#010101" fill-opacity=".3">96%</text>
+  <text x="137.5" y="14">96%</text>
 </g>
 </svg>

--- a/badges/coverage-agilab.svg
+++ b/badges/coverage-agilab.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="146" height="20" role="img" aria-label="agilab coverage: 98%">
+<svg xmlns="http://www.w3.org/2000/svg" width="146" height="20" role="img" aria-label="agilab coverage: 96%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="57.5" y="15" fill="#010101" fill-opacity=".3">agilab coverage</text>
   <text x="57.5" y="14">agilab coverage</text>
-  <text x="130.5" y="15" fill="#010101" fill-opacity=".3">98%</text>
-  <text x="130.5" y="14">98%</text>
+  <text x="130.5" y="15" fill="#010101" fill-opacity=".3">96%</text>
+  <text x="130.5" y="14">96%</text>
 </g>
 </svg>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.18"
+version = "2026.05.20"
 name = "agilab"
 description = "AGILAB is a reproducible AI/ML workbench for engineering teams."
 requires-python = ">=3.11"
@@ -47,7 +47,7 @@ keywords = [
     "codex",
     "claude",
 ]
-dependencies = ["agi-core==2026.05.18", "legacy-cgi>=2.6.4; python_version >= '3.13'", "standard-imghdr>=3.13.0; python_version >= '3.13'"]
+dependencies = ["agi-core==2026.05.20", "legacy-cgi>=2.6.4; python_version >= '3.13'", "standard-imghdr>=3.13.0; python_version >= '3.13'"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"
@@ -62,11 +62,11 @@ agilab = "agilab.lab_run:main"
 
 [project.optional-dependencies]
 ai = ["openai>=2.32.0"]
-ui = ["agi-apps==2026.05.18", "agi-pages==2026.05.18", "agi-gui==2026.05.18", "networkx>=3.6.1", "pandas>=2.3.0", "streamlit>=1.56,<1.57", "tomli_w>=1.2.0"]
+ui = ["agi-apps==2026.05.20", "agi-pages==2026.05.20", "agi-gui==2026.05.20", "networkx>=3.6.1", "pandas>=2.3.0", "streamlit>=1.56,<1.57", "tomli_w>=1.2.0"]
 viz = ["matplotlib>=3.10.0", "plotly>=6.7.0"]
 mlflow = ["mlflow>=3.11.1"]
-examples = ["agi-apps==2026.05.18", "jupyterlab>=4.4.0", "matplotlib>=3.10.0", "plotly>=6.7.0"]
-pages = ["agi-pages==2026.05.18"]
+examples = ["agi-apps==2026.05.20", "jupyterlab>=4.4.0", "matplotlib>=3.10.0", "plotly>=6.7.0"]
+pages = ["agi-pages==2026.05.20"]
 agents = ["openai>=2.32.0"]
 local-llm = ["accelerate>=0.34.2; python_version >= '3.12'", "gpt-oss>=0.0.8; python_version >= '3.12'", "langchain-core>=1.3.3; python_version >= '3.12'", "mlx>=0.31.2; sys_platform == 'darwin' and platform_machine == 'arm64'", "mlx-lm>=0.31.3; sys_platform == 'darwin' and platform_machine == 'arm64'", "mlx-vlm>=0.5.0; sys_platform == 'darwin' and platform_machine == 'arm64'", "requests>=2.32.0; python_version >= '3.12'", "torch>=2.8.0; python_version >= '3.12'", "transformers>=4.57.0; python_version >= '3.12'", "universal-offline-ai-chatbot>=0.1.0; python_version >= '3.12'"]
 offline = ["accelerate>=0.34.2; python_version >= '3.12'", "gpt-oss>=0.0.8; python_version >= '3.12'", "langchain-core>=1.3.3; python_version >= '3.12'", "mlx>=0.31.2; sys_platform == 'darwin' and platform_machine == 'arm64'", "mlx-lm>=0.31.3; sys_platform == 'darwin' and platform_machine == 'arm64'", "mlx-vlm>=0.5.0; sys_platform == 'darwin' and platform_machine == 'arm64'", "requests>=2.32.0; python_version >= '3.12'", "torch>=2.8.0; python_version >= '3.12'", "transformers>=4.57.0; python_version >= '3.12'", "universal-offline-ai-chatbot>=0.1.0; python_version >= '3.12'"]

--- a/src/agilab/apps-pages/view_barycentric/pyproject.toml
+++ b/src/agilab/apps-pages/view_barycentric/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-simplex-map"
-version = "2026.05.19.post1"
+version = "2026.05.20"
 description = "AGILAB page bundle for simplex projection and barycentric analysis."
 readme = { text = "AGILAB page bundle for simplex projection and barycentric analysis.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_data_io_decision/pyproject.toml
+++ b/src/agilab/apps-pages/view_data_io_decision/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-decision-evidence"
-version = "2026.05.19.post1"
+version = "2026.05.20"
 description = "AGILAB page bundle for decision evidence review."
 readme = { text = "AGILAB page bundle for decision evidence review.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_forecast_analysis/pyproject.toml
+++ b/src/agilab/apps-pages/view_forecast_analysis/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-timeseries-forecast"
-version = "2026.05.19.post1"
+version = "2026.05.20"
 description = "AGILAB page bundle for time-series forecast review."
 readme = { text = "AGILAB page bundle for time-series forecast review.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_inference_analysis/pyproject.toml
+++ b/src/agilab/apps-pages/view_inference_analysis/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-inference-report"
-version = "2026.05.19.post1"
+version = "2026.05.20"
 description = "AGILAB page bundle for inference result reporting."
 readme = { text = "AGILAB page bundle for inference result reporting.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_maps/pyproject.toml
+++ b/src/agilab/apps-pages/view_maps/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-geospatial-map"
-version = "2026.05.19.post1"
+version = "2026.05.20"
 description = "AGILAB page bundle for 2D geospatial map exploration."
 readme = { text = "AGILAB page bundle for 2D geospatial map exploration.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_maps_3d/pyproject.toml
+++ b/src/agilab/apps-pages/view_maps_3d/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-geospatial-3d"
-version = "2026.05.19.post1"
+version = "2026.05.20"
 description = "AGILAB page bundle for 3D geospatial exploration."
 readme = { text = "AGILAB page bundle for 3D geospatial exploration.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_maps_network/pyproject.toml
+++ b/src/agilab/apps-pages/view_maps_network/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-network-map"
-version = "2026.05.19.post1"
+version = "2026.05.20"
 description = "AGILAB page bundle for network-aware geospatial analysis."
 readme = { text = "AGILAB page bundle for network-aware geospatial analysis.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_pytorch_playground/pyproject.toml
+++ b/src/agilab/apps-pages/view_pytorch_playground/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-pytorch-playground"
-version = "2026.05.19.post1"
+version = "2026.05.20"
 description = "Opt-in AGILAB page bundle for interactive PyTorch classifier experiments."
 readme = { text = "Opt-in AGILAB page bundle for interactive PyTorch classifier experiments.", content-type = "text/markdown" }
 requires-python = ">=3.12"

--- a/src/agilab/apps-pages/view_queue_resilience/pyproject.toml
+++ b/src/agilab/apps-pages/view_queue_resilience/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-queue-health"
-version = "2026.05.19.post1"
+version = "2026.05.20"
 description = "AGILAB page bundle for queue health and resilience evidence."
 readme = { text = "AGILAB page bundle for queue health and resilience evidence.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_relay_resilience/pyproject.toml
+++ b/src/agilab/apps-pages/view_relay_resilience/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-relay-health"
-version = "2026.05.19.post1"
+version = "2026.05.20"
 description = "AGILAB page bundle for relay health and resilience evidence."
 readme = { text = "AGILAB page bundle for relay health and resilience evidence.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_release_decision/pyproject.toml
+++ b/src/agilab/apps-pages/view_release_decision/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-promotion-gate"
-version = "2026.05.19.post1"
+version = "2026.05.20"
 description = "AGILAB page bundle for promotion-gate evidence review."
 readme = { text = "AGILAB page bundle for promotion-gate evidence review.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_scenario_cockpit/pyproject.toml
+++ b/src/agilab/apps-pages/view_scenario_cockpit/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-scenario-cockpit"
-version = "2026.05.19.post1"
+version = "2026.05.20"
 description = "AGILAB page bundle for scenario evidence comparison."
 readme = { text = "AGILAB page bundle for scenario evidence comparison.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_shap_explanation/pyproject.toml
+++ b/src/agilab/apps-pages/view_shap_explanation/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-feature-attribution"
-version = "2026.05.19.post1"
+version = "2026.05.20"
 description = "AGILAB page bundle for feature-attribution evidence."
 readme = { text = "AGILAB page bundle for feature-attribution evidence.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_training_analysis/pyproject.toml
+++ b/src/agilab/apps-pages/view_training_analysis/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-training-report"
-version = "2026.05.19.post1"
+version = "2026.05.20"
 description = "AGILAB page bundle for training run reporting."
 readme = { text = "AGILAB page bundle for training run reporting.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps/builtin/data_io_2026_project/pyproject.toml
+++ b/src/agilab/apps/builtin/data_io_2026_project/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "data_io_2026_project"
-version = "2026.05.18"
+version = "2026.05.20"
 description = "Built-in AGILAB Data IO 2026 autonomous mission decision demo"
 requires-python = ">=3.13"
-dependencies = ["agi-env>=2026.05.18", "agi-node>=2026.05.18", "agi-cluster>=2026.05.18", "pandas>=2.3.0", "pydantic", "streamlit>=1.56,<1.57"]
+dependencies = ["agi-env>=2026.05.20", "agi-node>=2026.05.20", "agi-cluster>=2026.05.20", "pandas>=2.3.0", "pydantic", "streamlit>=1.56,<1.57"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/data_io_2026_project/src/data_io_2026_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/data_io_2026_project/src/data_io_2026_worker/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "data_io_2026_project"
-version = "2026.05.18"
+version = "2026.05.20"
 description = "Built-in AGILAB Data IO 2026 autonomous mission decision demo"
 requires-python = ">=3.13"
-dependencies = ["agi-env>=2026.05.18", "agi-node>=2026.05.18", "pandas>=2.3.0", "pydantic"]
+dependencies = ["agi-env>=2026.05.20", "agi-node>=2026.05.20", "pandas>=2.3.0", "pydantic"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/execution_pandas_project/pyproject.toml
+++ b/src/agilab/apps/builtin/execution_pandas_project/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "execution_pandas_project"
-version = "2026.05.18"
+version = "2026.05.20"
 description = "Built-in AGILab execution playground using PandasWorker"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.18", "agi-node>=2026.05.18", "agi-cluster>=2026.05.18", "numpy", "pandas", "pydantic", "streamlit>=1.56,<1.57"]
+dependencies = ["agi-env>=2026.05.20", "agi-node>=2026.05.20", "agi-cluster>=2026.05.20", "numpy", "pandas", "pydantic", "streamlit>=1.56,<1.57"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/execution_pandas_project/src/execution_pandas_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/execution_pandas_project/src/execution_pandas_worker/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "execution_pandas_project"
-version = "2026.05.18"
+version = "2026.05.20"
 description = "Built-in AGILab execution playground using PandasWorker"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.18", "agi-node>=2026.05.18", "numpy", "pandas", "pydantic"]
+dependencies = ["agi-env>=2026.05.20", "agi-node>=2026.05.20", "numpy", "pandas", "pydantic"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/execution_polars_project/pyproject.toml
+++ b/src/agilab/apps/builtin/execution_polars_project/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "execution_polars_project"
-version = "2026.05.18"
+version = "2026.05.20"
 description = "Built-in AGILab execution playground using PolarsWorker"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.18", "agi-node>=2026.05.18", "agi-cluster>=2026.05.18", "polars", "pydantic", "streamlit>=1.56,<1.57"]
+dependencies = ["agi-env>=2026.05.20", "agi-node>=2026.05.20", "agi-cluster>=2026.05.20", "polars", "pydantic", "streamlit>=1.56,<1.57"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/execution_polars_project/src/execution_polars_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/execution_polars_project/src/execution_polars_worker/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "execution_polars_project"
-version = "2026.05.18"
+version = "2026.05.20"
 description = "Built-in AGILab execution playground using PolarsWorker"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.18", "agi-node>=2026.05.18", "polars", "pydantic"]
+dependencies = ["agi-env>=2026.05.20", "agi-node>=2026.05.20", "polars", "pydantic"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/flight_telemetry_project/pyproject.toml
+++ b/src/agilab/apps/builtin/flight_telemetry_project/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "flight_telemetry_project"
-version = "2026.05.18"
+version = "2026.05.20"
 description = "Built-in AGILab example app (flight-telemetry preprocessing)"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.18", "agi-node>=2026.05.18", "agi-cluster>=2026.05.18", "polars[rtcompat]", "pydantic", "py7zr", "streamlit>=1.56,<1.57"]
+dependencies = ["agi-env>=2026.05.20", "agi-node>=2026.05.20", "agi-cluster>=2026.05.20", "polars[rtcompat]", "pydantic", "py7zr", "streamlit>=1.56,<1.57"]
 
 [tool.agilab]
 runtime_target = "flight_telemetry"

--- a/src/agilab/apps/builtin/flight_telemetry_project/src/flight_telemetry_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/flight_telemetry_project/src/flight_telemetry_worker/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "flight_telemetry_project"
-version = "2026.05.18"
+version = "2026.05.20"
 description = ""
 requires-python = ">=3.11,<3.14"
 readme = "README.md"
-dependencies = ["agi-env>=2026.05.18", "agi-node>=2026.05.18", "polars", "pydantic"]
+dependencies = ["agi-env>=2026.05.20", "agi-node>=2026.05.20", "polars", "pydantic"]
 
 [[project.authors]]
 name = "Jean-Pierre Morard"

--- a/src/agilab/apps/builtin/global_dag_project/pyproject.toml
+++ b/src/agilab/apps/builtin/global_dag_project/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "global_dag_project"
-version = "2026.05.18"
+version = "2026.05.20"
 description = "Built-in AGILAB global DAG example project"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.18", "agi-node>=2026.05.18", "agi-cluster>=2026.05.18", "polars", "pydantic", "streamlit>=1.56,<1.57"]
+dependencies = ["agi-env>=2026.05.20", "agi-node>=2026.05.20", "agi-cluster>=2026.05.20", "polars", "pydantic", "streamlit>=1.56,<1.57"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/global_dag_project/src/global_dag_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/global_dag_project/src/global_dag_worker/pyproject.toml
@@ -1,8 +1,8 @@
 [project]
 name = "global_dag_worker"
-version = "2026.05.18"
+version = "2026.05.20"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.18", "agi-node>=2026.05.18", "polars"]
+dependencies = ["agi-env>=2026.05.20", "agi-node>=2026.05.20", "polars"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/meteo_forecast_project/pyproject.toml
+++ b/src/agilab/apps/builtin/meteo_forecast_project/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "meteo_forecast_project"
-version = "2026.05.18"
+version = "2026.05.20"
 description = "Built-in AGILab weather forecasting example migrated from notebooks"
 requires-python = ">=3.13"
-dependencies = ["agi-env>=2026.05.18", "agi-node>=2026.05.18", "agi-cluster>=2026.05.18", "pandas>=2.3.0", "pydantic", "scikit-learn", "skforecast>=0.19,<0.20", "streamlit>=1.56,<1.57"]
+dependencies = ["agi-env>=2026.05.20", "agi-node>=2026.05.20", "agi-cluster>=2026.05.20", "pandas>=2.3.0", "pydantic", "scikit-learn", "skforecast>=0.19,<0.20", "streamlit>=1.56,<1.57"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/meteo_forecast_project/src/meteo_forecast_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/meteo_forecast_project/src/meteo_forecast_worker/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "meteo_forecast_project"
-version = "2026.05.18"
+version = "2026.05.20"
 description = "Built-in AGILab weather forecasting example migrated from notebooks"
 requires-python = ">=3.13"
-dependencies = ["agi-env>=2026.05.18", "agi-node>=2026.05.18", "pandas>=2.3.0", "pydantic", "scikit-learn", "skforecast>=0.19,<0.20"]
+dependencies = ["agi-env>=2026.05.20", "agi-node>=2026.05.20", "pandas>=2.3.0", "pydantic", "scikit-learn", "skforecast>=0.19,<0.20"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/mission_decision_project/pyproject.toml
+++ b/src/agilab/apps/builtin/mission_decision_project/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "mission_decision_project"
-version = "2026.05.18"
+version = "2026.05.20"
 description = "Built-in AGILAB Mission Decision autonomous demo"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.18", "agi-node>=2026.05.18", "agi-cluster>=2026.05.18", "pandas>=2.3.0", "pydantic", "streamlit>=1.56,<1.57"]
+dependencies = ["agi-env>=2026.05.20", "agi-node>=2026.05.20", "agi-cluster>=2026.05.20", "pandas>=2.3.0", "pydantic", "streamlit>=1.56,<1.57"]
 
 [tool.agilab]
 runtime_target = "data_io_2026"

--- a/src/agilab/apps/builtin/mission_decision_project/src/data_io_2026_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/mission_decision_project/src/data_io_2026_worker/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "mission_decision_project"
-version = "2026.05.18"
+version = "2026.05.20"
 description = "Built-in AGILAB Mission Decision autonomous demo"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.18", "agi-node>=2026.05.18", "pandas>=2.3.0", "pydantic"]
+dependencies = ["agi-env>=2026.05.20", "agi-node>=2026.05.20", "pandas>=2.3.0", "pydantic"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/mycode_project/pyproject.toml
+++ b/src/agilab/apps/builtin/mycode_project/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "mycode_project"
-version = "2026.05.18"
+version = "2026.05.20"
 description = "Built-in AGILab example app template (minimal manager + worker)"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.18", "agi-node>=2026.05.18", "agi-cluster>=2026.05.18", "polars", "pydantic", "streamlit>=1.56,<1.57"]
+dependencies = ["agi-env>=2026.05.20", "agi-node>=2026.05.20", "agi-cluster>=2026.05.20", "polars", "pydantic", "streamlit>=1.56,<1.57"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/mycode_project/src/mycode_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/mycode_project/src/mycode_worker/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "mycode_project"
-version = "2026.05.18"
+version = "2026.05.20"
 description = "Built-in AGILab example app template (minimal manager + worker)"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.18", "agi-node>=2026.05.18", "polars", "pydantic"]
+dependencies = ["agi-env>=2026.05.20", "agi-node>=2026.05.20", "polars", "pydantic"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/tescia_diagnostic_project/pyproject.toml
+++ b/src/agilab/apps/builtin/tescia_diagnostic_project/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "tescia_diagnostic_project"
-version = "2026.05.18"
+version = "2026.05.20"
 description = "Built-in AGILAB TeSciA-style diagnostic reasoning example"
 requires-python = ">=3.13"
-dependencies = ["agi-env>=2026.05.18", "agi-node>=2026.05.18", "agi-cluster>=2026.05.18", "pandas>=2.3.0", "pydantic", "streamlit>=1.56,<1.57"]
+dependencies = ["agi-env>=2026.05.20", "agi-node>=2026.05.20", "agi-cluster>=2026.05.20", "pandas>=2.3.0", "pydantic", "streamlit>=1.56,<1.57"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/tescia_diagnostic_project/src/tescia_diagnostic_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/tescia_diagnostic_project/src/tescia_diagnostic_worker/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "tescia_diagnostic_project"
-version = "2026.05.18"
+version = "2026.05.20"
 description = "Built-in AGILAB TeSciA-style diagnostic reasoning example"
 requires-python = ">=3.13"
-dependencies = ["agi-env>=2026.05.18", "agi-node>=2026.05.18", "pandas>=2.3.0", "pydantic"]
+dependencies = ["agi-env>=2026.05.20", "agi-node>=2026.05.20", "pandas>=2.3.0", "pydantic"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/uav_queue_project/pyproject.toml
+++ b/src/agilab/apps/builtin/uav_queue_project/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "uav_queue_project"
-version = "2026.05.18"
+version = "2026.05.20"
 description = "Built-in AGILAB lightweight UAV relay queue example"
 requires-python = ">=3.13"
-dependencies = ["agi-env>=2026.05.18", "agi-node>=2026.05.18", "agi-cluster>=2026.05.18", "networkx", "pandas>=2.3.0", "pydantic", "simpy>=4.1,<5", "streamlit>=1.56,<1.57"]
+dependencies = ["agi-env>=2026.05.20", "agi-node>=2026.05.20", "agi-cluster>=2026.05.20", "networkx", "pandas>=2.3.0", "pydantic", "simpy>=4.1,<5", "streamlit>=1.56,<1.57"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/uav_queue_project/src/uav_queue_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/uav_queue_project/src/uav_queue_worker/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "uav_queue_project"
-version = "2026.05.18"
+version = "2026.05.20"
 description = "Built-in AGILAB lightweight UAV relay queue example"
 requires-python = ">=3.13"
-dependencies = ["agi-env>=2026.05.18", "agi-node>=2026.05.18", "networkx", "pandas>=2.3.0", "pydantic", "simpy>=4.1,<5"]
+dependencies = ["agi-env>=2026.05.20", "agi-node>=2026.05.20", "networkx", "pandas>=2.3.0", "pydantic", "simpy>=4.1,<5"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/uav_relay_queue_project/pyproject.toml
+++ b/src/agilab/apps/builtin/uav_relay_queue_project/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "uav_relay_queue_project"
-version = "2026.05.18"
+version = "2026.05.20"
 description = "Built-in AGILAB lightweight UAV relay queue example"
 requires-python = ">=3.13"
-dependencies = ["agi-env>=2026.05.18", "agi-node>=2026.05.18", "agi-cluster>=2026.05.18", "networkx", "pandas>=2.3.0", "pydantic", "simpy>=4.1,<5", "streamlit>=1.56,<1.57"]
+dependencies = ["agi-env>=2026.05.20", "agi-node>=2026.05.20", "agi-cluster>=2026.05.20", "networkx", "pandas>=2.3.0", "pydantic", "simpy>=4.1,<5", "streamlit>=1.56,<1.57"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/uav_relay_queue_project/src/uav_relay_queue_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/uav_relay_queue_project/src/uav_relay_queue_worker/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "uav_relay_queue_project"
-version = "2026.05.18"
+version = "2026.05.20"
 description = "Built-in AGILAB lightweight UAV relay queue example"
 requires-python = ">=3.13"
-dependencies = ["agi-env>=2026.05.18", "agi-node>=2026.05.18", "networkx", "pandas>=2.3.0", "pydantic", "simpy>=4.1,<5"]
+dependencies = ["agi-env>=2026.05.20", "agi-node>=2026.05.20", "networkx", "pandas>=2.3.0", "pydantic", "simpy>=4.1,<5"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/weather_forecast_project/pyproject.toml
+++ b/src/agilab/apps/builtin/weather_forecast_project/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "weather_forecast_project"
-version = "2026.05.18"
+version = "2026.05.20"
 description = "Built-in AGILab weather forecasting example migrated from notebooks"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.18", "agi-node>=2026.05.18", "agi-cluster>=2026.05.18", "pandas>=2.3.0", "pydantic", "scikit-learn", "skforecast>=0.19,<0.20", "streamlit>=1.56,<1.57"]
+dependencies = ["agi-env>=2026.05.20", "agi-node>=2026.05.20", "agi-cluster>=2026.05.20", "pandas>=2.3.0", "pydantic", "scikit-learn", "skforecast>=0.19,<0.20", "streamlit>=1.56,<1.57"]
 
 [tool.agilab]
 runtime_target = "weather_forecast"

--- a/src/agilab/apps/builtin/weather_forecast_project/src/weather_forecast_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/weather_forecast_project/src/weather_forecast_worker/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "weather_forecast_project"
-version = "2026.05.18"
+version = "2026.05.20"
 description = "Built-in AGILab weather forecasting example migrated from notebooks"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.18", "agi-node>=2026.05.18", "pandas>=2.3.0", "pydantic", "scikit-learn", "skforecast>=0.19,<0.20"]
+dependencies = ["agi-env>=2026.05.20", "agi-node>=2026.05.20", "pandas>=2.3.0", "pydantic", "scikit-learn", "skforecast>=0.19,<0.20"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }

--- a/src/agilab/core/agi-cluster/pyproject.toml
+++ b/src/agilab/core/agi-cluster/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.18"
+version = "2026.05.20"
 name = "agi-cluster"
 description = "Distributed cluster orchestration layer for AGILAB workers over local and SSH backends"
 requires-python = ">=3.11"
@@ -35,7 +35,7 @@ keywords = [
     "job-scheduling",
     "mlops",
 ]
-dependencies = ["agi-env==2026.05.18", "agi-node==2026.05.18", "asyncssh", "dask[distributed]", "humanize", "numpy", "packaging", "polars", "psutil", "scikit-learn", "tomlkit"]
+dependencies = ["agi-env==2026.05.20", "agi-node==2026.05.20", "asyncssh", "dask[distributed]", "humanize", "numpy", "packaging", "polars", "psutil", "scikit-learn", "tomlkit"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/core/agi-core/pyproject.toml
+++ b/src/agilab/core/agi-core/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.18"
+version = "2026.05.20"
 name = "agi-core"
 description = "Meta-package that installs and wires agi-env, agi-node, and agi-cluster together"
 readme = "README.md"
@@ -30,7 +30,7 @@ keywords = [
   "distributed-computing",
   "distributed-execution",
 ]
-dependencies = ["agi-env==2026.05.18", "agi-node==2026.05.18", "agi-cluster==2026.05.18"]
+dependencies = ["agi-env==2026.05.20", "agi-node==2026.05.20", "agi-cluster==2026.05.20"]
 
 [project.urls]
 Homepage = "https://github.com/ThalesGroup/agilab"

--- a/src/agilab/core/agi-env/pyproject.toml
+++ b/src/agilab/core/agi-env/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.18"
+version = "2026.05.20"
 name = "agi-env"
 description = "Environment bootstrap package for AGILAB with virtualenv, path, and runtime helpers"
 requires-python = ">=3.11"

--- a/src/agilab/core/agi-node/pyproject.toml
+++ b/src/agilab/core/agi-node/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.18"
+version = "2026.05.20"
 name = "agi-node"
 description = "Distributed worker orchestration and execution support library for AGILAB"
 requires-python = ">=3.11"
@@ -35,7 +35,7 @@ keywords = [
     "pandas",
     "polars",
 ]
-dependencies = ["agi-env==2026.05.18", "cython", "humanize", "numpy", "pandas", "parso", "polars", "psutil", "py7zr", "setuptools"]
+dependencies = ["agi-env==2026.05.20", "cython", "humanize", "numpy", "pandas", "parso", "polars", "psutil", "py7zr", "setuptools"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/lib/agi-app-flight-telemetry/pyproject.toml
+++ b/src/agilab/lib/agi-app-flight-telemetry/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.18"
+version = "2026.05.20"
 name = "agi-app-flight-telemetry"
 description = "AGILAB flight-telemetry ingestion demo with reusable dataframe and map-analysis outputs"
 requires-python = ">=3.11"

--- a/src/agilab/lib/agi-app-global-dag/pyproject.toml
+++ b/src/agilab/lib/agi-app-global-dag/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.18"
+version = "2026.05.20"
 name = "agi-app-global-dag"
 description = "AGILAB cross-app DAG preview showing artifact handoffs between demo projects"
 requires-python = ">=3.11"

--- a/src/agilab/lib/agi-app-mission-decision/pyproject.toml
+++ b/src/agilab/lib/agi-app-mission-decision/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.18"
+version = "2026.05.20"
 name = "agi-app-mission-decision"
 description = "Deterministic AGILAB mission-decision workflow with scenario scoring and evidence artifacts"
 requires-python = ">=3.11"

--- a/src/agilab/lib/agi-app-pandas-execution/pyproject.toml
+++ b/src/agilab/lib/agi-app-pandas-execution/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.18"
+version = "2026.05.20"
 name = "agi-app-pandas-execution"
 description = "AGILAB Pandas execution benchmark for deterministic worker and reducer validation"
 requires-python = ">=3.11"

--- a/src/agilab/lib/agi-app-polars-execution/pyproject.toml
+++ b/src/agilab/lib/agi-app-polars-execution/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.18"
+version = "2026.05.20"
 name = "agi-app-polars-execution"
 description = "AGILAB Polars execution benchmark for deterministic worker and reducer validation"
 requires-python = ">=3.11"

--- a/src/agilab/lib/agi-app-tescia-diagnostic-project/pyproject.toml
+++ b/src/agilab/lib/agi-app-tescia-diagnostic-project/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.18"
+version = "2026.05.20"
 name = "agi-app-tescia-diagnostic-project"
 description = "AGILAB TeSciA-style diagnostic workflow with evidence scoring and regression-plan artifacts"
 requires-python = ">=3.13"

--- a/src/agilab/lib/agi-app-uav-queue-project/pyproject.toml
+++ b/src/agilab/lib/agi-app-uav-queue-project/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.18"
+version = "2026.05.20"
 name = "agi-app-uav-queue-project"
 description = "AGILAB UAV queue simulation demo with scenario evidence and network-map artifacts"
 requires-python = ">=3.13"

--- a/src/agilab/lib/agi-app-uav-relay-queue/pyproject.toml
+++ b/src/agilab/lib/agi-app-uav-relay-queue/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.18"
+version = "2026.05.20"
 name = "agi-app-uav-relay-queue"
 description = "AGILAB UAV relay queue simulation demo with routing, delay, and resilience artifacts"
 requires-python = ">=3.13"

--- a/src/agilab/lib/agi-app-weather-forecast/pyproject.toml
+++ b/src/agilab/lib/agi-app-weather-forecast/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.18"
+version = "2026.05.20"
 name = "agi-app-weather-forecast"
 description = "AGILAB weather-forecast notebook-migration demo with forecast analysis artifacts"
 requires-python = ">=3.11"

--- a/src/agilab/lib/agi-apps/pyproject.toml
+++ b/src/agilab/lib/agi-apps/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.18"
+version = "2026.05.20"
 name = "agi-apps"
 description = "AGILAB public app package umbrella and example assets"
 requires-python = ">=3.11"
@@ -31,7 +31,7 @@ keywords = [
     "workflow-orchestration",
 ]
 
-dependencies = ["agi-core==2026.05.18", "agi-app-mission-decision==2026.05.18", "agi-app-pandas-execution==2026.05.18", "agi-app-polars-execution==2026.05.18", "agi-app-flight-telemetry==2026.05.18", "agi-app-global-dag==2026.05.18", "agi-app-weather-forecast==2026.05.18", "agi-app-uav-relay-queue==2026.05.18; python_version >= '3.13'"]
+dependencies = ["agi-core==2026.05.20", "agi-app-mission-decision==2026.05.20", "agi-app-pandas-execution==2026.05.20", "agi-app-polars-execution==2026.05.20", "agi-app-flight-telemetry==2026.05.20", "agi-app-global-dag==2026.05.20", "agi-app-weather-forecast==2026.05.20", "agi-app-uav-relay-queue==2026.05.20; python_version >= '3.13'"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/lib/agi-gui/pyproject.toml
+++ b/src/agilab/lib/agi-gui/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.18"
+version = "2026.05.20"
 name = "agi-gui"
 description = "AGILAB Streamlit UI dependency bundle and compatibility imports"
 requires-python = ">=3.11"
@@ -32,7 +32,7 @@ keywords = [
     "python",
 ]
 
-dependencies = ["agi-env==2026.05.18", "streamlit>=1.56,<1.57", "streamlit_code_editor", "watchdog"]
+dependencies = ["agi-env==2026.05.20", "streamlit>=1.56,<1.57", "streamlit_code_editor", "watchdog"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/lib/agi-pages/pyproject.toml
+++ b/src/agilab/lib/agi-pages/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.18"
+version = "2026.05.20"
 name = "agi-pages"
 description = "AGILAB public analysis page umbrella and provider package"
 requires-python = ">=3.11"
@@ -34,7 +34,7 @@ keywords = [
     "page-bundles",
 ]
 
-dependencies = ["agi-gui==2026.05.18"]
+dependencies = ["agi-gui==2026.05.20"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/test/test_view_barycentric.py
+++ b/test/test_view_barycentric.py
@@ -94,6 +94,10 @@ class _State(dict):
 
 
 def _load_module():
+    # Load Streamlit/Plotly before installing fake scientific dependencies so
+    # their global module state is initialized against the real environment.
+    import streamlit  # noqa: F401
+
     fake_barviz = ModuleType("barviz")
     exec(BARVIZ_STUB, fake_barviz.__dict__)
 


### PR DESCRIPTION
## Summary
- Bump the full AGILAB public package graph to `2026.05.20`.
- Align bundled app manifests and core dependency lower bounds with the release graph.
- Refresh affected coverage badges after the release validation run.
- Add the barycentric page import-isolation regression fix needed by repeated page tests.

## Validation
- `uv --preview-features extra-build-dependencies run --no-sync pytest src/agilab/core/agi-env/test`
- `uv --preview-features extra-build-dependencies run --no-sync pytest src/agilab/core/test`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_pyproject_dependency_hygiene.py test/test_view_barycentric.py test/test_view_forecast_analysis.py test/test_view_inference_analysis.py test/test_view_maps.py test/test_view_maps_3d.py test/test_view_maps_network.py test/test_view_maps_network_edge_selection.py`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui`
- `uv lock --check`
- `uv --preview-features extra-build-dependencies run python tools/release_plan.py --check-workflow .github/workflows/pypi-publish.yaml --format json --compact`
- top-level wheel metadata check for `agilab-2026.5.20`
- `./dev release`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile badges`