### PR TITLE
docs: record 2026.05.20 release proof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,16 @@ publication, or evidence refreshes on an already published date version.
 - Added a versioned generated-snippet API guard so stale ORCHESTRATE snippets
   ask users to clean up and regenerate after core API changes.
 
+## [2026.05.20] - 2026-05-19
+
+GitHub Release: https://github.com/ThalesGroup/agilab/releases/tag/v2026.05.20
+
+### Changed
+
+- Published AGILAB `2026.05.20` to PyPI for `agi-env`, `agi-gui`, `agi-page-simplex-map`, `agi-page-decision-evidence`, `agi-page-timeseries-forecast`, `agi-page-inference-report`, `agi-page-geospatial-map`, `agi-page-geospatial-3d`, `agi-page-network-map`, `agi-page-queue-health`, `agi-page-relay-health`, `agi-page-scenario-cockpit`, `agi-page-promotion-gate`, `agi-page-feature-attribution`, `agi-page-training-report`, `agi-page-pytorch-playground`, `agi-pages`, `agi-node`, `agi-cluster`, `agi-core`, `agi-app-mission-decision`, `agi-app-pandas-execution`, `agi-app-polars-execution`, `agi-app-flight-telemetry`, `agi-app-global-dag`, `agi-app-weather-forecast`, `agi-app-uav-relay-queue`, `agi-apps`, and `agilab`.
+- Updated release metadata so public docs, changelog, PyPI, and GitHub Releases point to the same source tag.
+- Kept release automation active so future PyPI publishes create or update the matching GitHub Release after pushing the tag.
+
 ## [2026.05.18] - 2026-05-18
 
 GitHub Release: https://github.com/ThalesGroup/agilab/releases/tag/v2026.05.18
@@ -656,3 +666,4 @@ GitHub Release: https://github.com/ThalesGroup/agilab/releases/tag/v2026.04.25
 [2026.05.17.post1]: https://github.com/ThalesGroup/agilab/releases/tag/v2026.05.17-5
 [2026.05.17.post2]: https://github.com/ThalesGroup/agilab/releases/tag/v2026.05.17-6
 [2026.05.18]: https://github.com/ThalesGroup/agilab/releases/tag/v2026.05.18
+[2026.05.20]: https://github.com/ThalesGroup/agilab/releases/tag/v2026.05.20

--- a/badges/pypi-version-agilab.svg
+++ b/badges/pypi-version-agilab.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="125" height="20" role="img" aria-label="pypi: v2026.05.18">
+<svg xmlns="http://www.w3.org/2000/svg" width="125" height="20" role="img" aria-label="pypi: v2026.05.20">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="19" y="15" fill="#010101" fill-opacity=".3">pypi</text>
   <text x="19" y="14">pypi</text>
-  <text x="81.5" y="15" fill="#010101" fill-opacity=".3">v2026.05.18</text>
-  <text x="81.5" y="14">v2026.05.18</text>
+  <text x="81.5" y="15" fill="#010101" fill-opacity=".3">v2026.05.20</text>
+  <text x="81.5" y="14">v2026.05.20</text>
 </g>
 </svg>

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 216,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "118acee210d6943abb8fb33377e8d7da5c9809b654e784e32ca0c0daf2c24f8f",
+  "source_digest_sha256": "bf32446df48d361162c7c6d7832e4455ef80442271cc9e6f47c42f6f5ee67fd9",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "118acee210d6943abb8fb33377e8d7da5c9809b654e784e32ca0c0daf2c24f8f"
+  "target_digest_sha256": "bf32446df48d361162c7c6d7832e4455ef80442271cc9e6f47c42f6f5ee67fd9"
 }

--- a/docs/source/data/release_proof.toml
+++ b/docs/source/data/release_proof.toml
@@ -20,16 +20,16 @@ related_pages = [
 
 [release]
 package_name = "agilab"
-package_version = "2026.05.18"
+package_version = "2026.05.20"
 package_extras = [
   "examples",
 ]
 pypi_url = "https://pypi.org/project/agilab/"
-github_release_tag = "v2026.05.18"
-github_release_url = "https://github.com/ThalesGroup/agilab/releases/tag/v2026.05.18"
+github_release_tag = "v2026.05.20"
+github_release_url = "https://github.com/ThalesGroup/agilab/releases/tag/v2026.05.20"
 hf_space_label = "jpmorard/agilab"
 hf_space_url = "https://huggingface.co/spaces/jpmorard/agilab"
-hf_space_commit = "a0607024b14e76e965c327bdeadab3aec69b8f7e"
+hf_space_commit = "0318f466aefb6c60fbfa78cfa4054c7c2aba0e59"
 
 [[ci_runs]]
 id = "release-guardrails"

--- a/docs/source/release-proof.rst
+++ b/docs/source/release-proof.rst
@@ -18,11 +18,11 @@ Current public release
    * - Item
      - Public evidence
    * - Package version
-     - ``agilab[examples]==2026.05.18`` on `PyPI <https://pypi.org/project/agilab/>`__
+     - ``agilab[examples]==2026.05.20`` on `PyPI <https://pypi.org/project/agilab/>`__
    * - GitHub release
-     - `v2026.05.18 <https://github.com/ThalesGroup/agilab/releases/tag/v2026.05.18>`__
+     - `v2026.05.20 <https://github.com/ThalesGroup/agilab/releases/tag/v2026.05.20>`__
    * - Hosted demo
-     - `jpmorard/agilab <https://huggingface.co/spaces/jpmorard/agilab>`__ at Space commit ``a0607024b14e76e965c327bdeadab3aec69b8f7e``
+     - `jpmorard/agilab <https://huggingface.co/spaces/jpmorard/agilab>`__ at Space commit ``0318f466aefb6c60fbfa78cfa4054c7c2aba0e59``
    * - Public guardrails
      - `repo-guardrails run 25970993906 <https://github.com/ThalesGroup/agilab/actions/runs/25970993906>`__ passed repository guardrails and clean package first-proof jobs
    * - Docs source guard
@@ -41,7 +41,7 @@ What was proved
 
   .. code-block:: bash
 
-     python -m pip install "agilab[examples]==2026.05.18"
+     python -m pip install "agilab[examples]==2026.05.20"
      python -m agilab.lab_run first-proof --json --max-seconds 60
 
 - The public GitHub Actions matrix validated the packaged first proof on
@@ -70,7 +70,7 @@ the current source checkout:
    python -m venv .venv
    . .venv/bin/activate
    python -m pip install --upgrade pip
-   python -m pip install "agilab[examples]==2026.05.18"
+   python -m pip install "agilab[examples]==2026.05.20"
    python -m agilab.lab_run first-proof --json --max-seconds 60
 
 Use :doc:`quick-start` when you want the fuller source-checkout path with the


### PR DESCRIPTION
## Summary
- update the static PyPI badge and changelog entry for 2026.05.20
- refresh the public release proof with the deployed Hugging Face Space commit
- refresh the docs mirror stamp

## Validation
- uv --preview-features extra-build-dependencies run --no-sync python tools/release_proof_report.py --refresh-from-local --github-release-tag v2026.05.20 --github-release-url https://github.com/ThalesGroup/agilab/releases/tag/v2026.05.20 --hf-space-commit 0318f466aefb6c60fbfa78cfa4054c7c2aba0e59 --render --check --check-github-runs --compact
- uv --preview-features extra-build-dependencies run --no-sync python tools/sync_docs_source.py --verify-stamp