### PR TITLE
Promote TeSciA diagnostic app package

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,8 +306,9 @@ Current packaging policy is conservative:
 - Promoted app payloads live in per-app packages such as
   `agi-app-mission-decision`, `agi-app-pandas-execution`,
   `agi-app-polars-execution`, `agi-app-flight-telemetry`, `agi-app-global-dag`,
-  `agi-app-weather-forecast`, and `agi-app-uav-relay-queue`; `agi-apps` is the
-  umbrella catalog/example package pulled in by the `ui` and `examples` extras.
+  `agi-app-weather-forecast`, `agi-app-tescia-diagnostic-project`, and
+  `agi-app-uav-relay-queue`; `agi-apps` is the umbrella catalog/example package
+  pulled in by the `ui` and `examples` extras.
 - Public analysis page bundles use decoupled `agi-page-*` package names such
   as `agi-page-feature-attribution`; `agi-pages` is the provider package pulled
   in by the `ui` and `pages` extras.

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 216,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "fccd51a6507f1be39e4f906a5661886deee386a361744ea29d81a8fcbece5b3c",
+  "source_digest_sha256": "7f76f94f3fbe77066ced73d032f5613de5448792a7944c0235586cf78fd63e1d",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "fccd51a6507f1be39e4f906a5661886deee386a361744ea29d81a8fcbece5b3c"
+  "target_digest_sha256": "7f76f94f3fbe77066ced73d032f5613de5448792a7944c0235586cf78fd63e1d"
 }

--- a/docs/source/package-publishing-policy.rst
+++ b/docs/source/package-publishing-policy.rst
@@ -99,15 +99,16 @@ installed apps without the monorepo checkout once that package is installed:
 - ``agi-app-uav-queue-project``
 - ``agi-app-uav-relay-queue``
 
-Seven app payload packages are promoted to PyPI in the current release plan:
+Eight app payload packages are promoted to PyPI in the current release plan:
 ``agi-app-mission-decision``, ``agi-app-pandas-execution``,
 ``agi-app-polars-execution``, ``agi-app-flight-telemetry``,
-``agi-app-global-dag``, ``agi-app-weather-forecast``, and
-``agi-app-uav-relay-queue``. The remaining app project payloads are also built
-as wheel and source-distribution artifacts and kept in the GitHub Release
-distribution archive until they are explicitly promoted. The payload is staged
-during package build, with local virtual environments, compiled artifacts,
-locks, and generated build outputs excluded.
+``agi-app-global-dag``, ``agi-app-weather-forecast``,
+``agi-app-tescia-diagnostic-project``, and ``agi-app-uav-relay-queue``. The
+remaining app project payload is also built as wheel and source-distribution
+artifacts and kept in the GitHub Release distribution archive until it is
+explicitly promoted. The payload is staged during package build, with local
+virtual environments, compiled artifacts, locks, and generated build outputs
+excluded.
 
 End users can add a trusted promoted app package to an existing AGILAB
 environment from ``PROJECT`` through ``Install PyPI app`` or from the CLI with

--- a/src/agilab/apps/builtin/tescia_diagnostic_project/src/tescia_diagnostic/__init__.py
+++ b/src/agilab/apps/builtin/tescia_diagnostic_project/src/tescia_diagnostic/__init__.py
@@ -9,12 +9,14 @@ from .app_args import (
     merge_args,
 )
 from .diagnostic import (
+    CASE_SCHEMA,
     diagnose_case,
     evidence_quality,
     rank_candidate_fixes,
     regression_coverage,
     student_score,
     summarize_report,
+    validate_case_payload,
 )
 from .generator import (
     DEFAULT_GPT_OSS_ENDPOINT,
@@ -43,6 +45,7 @@ __all__ = [
     "REDUCE_ARTIFACT_FILENAME_TEMPLATE",
     "REDUCE_ARTIFACT_NAME",
     "REDUCER_NAME",
+    "CASE_SCHEMA",
     "DEFAULT_GPT_OSS_ENDPOINT",
     "DEFAULT_GPT_OSS_MODEL",
     "DEFAULT_OLLAMA_ENDPOINT",
@@ -69,6 +72,7 @@ __all__ = [
     "regression_coverage",
     "student_score",
     "summarize_report",
+    "validate_case_payload",
     "validate_generated_cases",
     "write_reduce_artifact",
 ]

--- a/src/agilab/apps/builtin/tescia_diagnostic_project/src/tescia_diagnostic/diagnostic.py
+++ b/src/agilab/apps/builtin/tescia_diagnostic_project/src/tescia_diagnostic/diagnostic.py
@@ -6,6 +6,21 @@ from collections.abc import Mapping, Sequence
 from typing import Any
 
 
+CASE_SCHEMA = "agilab.tescia_diagnostic.cases.v1"
+
+_REQUIRED_CASE_FIELDS = {
+    "case_id",
+    "symptom",
+    "proposed_diagnosis",
+    "root_cause",
+    "plain_repro",
+    "weak_assumptions",
+    "evidence",
+    "candidate_fixes",
+    "regression_tests",
+}
+
+
 def _as_float(value: Any, default: float = 0.0) -> float:
     try:
         return float(value)
@@ -21,6 +36,62 @@ def _weighted_mean(rows: Sequence[Mapping[str, Any]], key: str) -> float:
     if not rows:
         return 0.0
     return round(sum(_as_float(row.get(key)) for row in rows) / len(rows), 4)
+
+
+def _require_float_range(value: Any, *, field: str, case_id: str) -> None:
+    try:
+        number = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"Case {case_id!r} field {field!r} must be numeric.") from exc
+    if not 0.0 <= number <= 1.0:
+        raise ValueError(f"Case {case_id!r} field {field!r} must be between 0.0 and 1.0.")
+
+
+def validate_case_payload(payload: Mapping[str, Any], *, expected_case_count: int | None = None) -> dict[str, Any]:
+    """Validate a TeSciA case file and return a normalized payload."""
+
+    if payload.get("schema") != CASE_SCHEMA:
+        raise ValueError(f"Diagnostic cases must declare schema {CASE_SCHEMA!r}.")
+    cases = payload.get("cases")
+    if not isinstance(cases, list) or not cases:
+        raise ValueError("Diagnostic cases must include a non-empty cases list.")
+    if expected_case_count is not None and len(cases) != expected_case_count:
+        raise ValueError(f"Diagnostic cases contain {len(cases)} case(s), expected {expected_case_count}.")
+
+    normalized_cases: list[dict[str, Any]] = []
+    for index, case in enumerate(cases):
+        if not isinstance(case, Mapping):
+            raise ValueError(f"Case #{index + 1} must be an object.")
+        case_id = str(case.get("case_id", f"case_{index + 1}"))
+        missing = sorted(field for field in _REQUIRED_CASE_FIELDS if field not in case)
+        if missing:
+            raise ValueError(f"Case {case_id!r} is missing fields: {', '.join(missing)}.")
+
+        evidence = case.get("evidence")
+        fixes = case.get("candidate_fixes")
+        tests = case.get("regression_tests")
+        if not isinstance(evidence, list) or len(evidence) < 2:
+            raise ValueError(f"Case {case_id!r} must include at least two evidence items.")
+        if not isinstance(fixes, list) or len(fixes) < 2:
+            raise ValueError(f"Case {case_id!r} must include at least two candidate fixes.")
+        if not isinstance(tests, list) or len(tests) < 2:
+            raise ValueError(f"Case {case_id!r} must include at least two regression tests.")
+
+        for row in evidence:
+            if not isinstance(row, Mapping):
+                raise ValueError(f"Case {case_id!r} has invalid evidence.")
+            _require_float_range(row.get("confidence"), field="evidence.confidence", case_id=case_id)
+            _require_float_range(row.get("relevance"), field="evidence.relevance", case_id=case_id)
+        for fix in fixes:
+            if not isinstance(fix, Mapping):
+                raise ValueError(f"Case {case_id!r} has invalid candidate fix.")
+            _require_float_range(fix.get("expected_impact"), field="fix.expected_impact", case_id=case_id)
+            _require_float_range(fix.get("blast_radius"), field="fix.blast_radius", case_id=case_id)
+            _require_float_range(fix.get("reversibility"), field="fix.reversibility", case_id=case_id)
+
+        normalized_cases.append(dict(case))
+
+    return {"schema": CASE_SCHEMA, "cases": normalized_cases}
 
 
 def evidence_quality(case: Mapping[str, Any]) -> float:
@@ -174,10 +245,12 @@ def summarize_report(report: Mapping[str, Any], *, worker_id: int = 0, source_fi
 
 
 __all__ = [
+    "CASE_SCHEMA",
     "diagnose_case",
     "evidence_quality",
     "rank_candidate_fixes",
     "regression_coverage",
     "student_score",
     "summarize_report",
+    "validate_case_payload",
 ]

--- a/src/agilab/apps/builtin/tescia_diagnostic_project/src/tescia_diagnostic/generator.py
+++ b/src/agilab/apps/builtin/tescia_diagnostic_project/src/tescia_diagnostic/generator.py
@@ -9,8 +9,8 @@ from typing import Any
 from urllib.error import URLError
 from urllib.request import Request, urlopen
 
+from .diagnostic import CASE_SCHEMA, validate_case_payload
 
-CASE_SCHEMA = "agilab.tescia_diagnostic.cases.v1"
 SUPPORTED_PROVIDERS = ("gpt-oss", "ollama")
 DEFAULT_GPT_OSS_ENDPOINT = "http://127.0.0.1:8000/v1/responses"
 DEFAULT_OLLAMA_ENDPOINT = "http://127.0.0.1:11434"
@@ -168,82 +168,13 @@ def _extract_json_object(text: str) -> Mapping[str, Any]:
     return payload
 
 
-def _require_float_range(value: Any, *, field: str, case_id: str) -> None:
-    try:
-        number = float(value)
-    except (TypeError, ValueError) as exc:
-        raise DiagnosticCaseGenerationError(
-            f"Case {case_id!r} field {field!r} must be numeric."
-        ) from exc
-    if not 0.0 <= number <= 1.0:
-        raise DiagnosticCaseGenerationError(
-            f"Case {case_id!r} field {field!r} must be between 0.0 and 1.0."
-        )
-
-
 def validate_generated_cases(payload: Mapping[str, Any], *, expected_case_count: int | None = None) -> dict[str, Any]:
     """Validate generated case JSON and return a normalized dict."""
 
-    if payload.get("schema") != CASE_SCHEMA:
-        raise DiagnosticCaseGenerationError(
-            f"Generated cases must declare schema {CASE_SCHEMA!r}."
-        )
-    cases = payload.get("cases")
-    if not isinstance(cases, list) or not cases:
-        raise DiagnosticCaseGenerationError("Generated cases must include a non-empty cases list.")
-    if expected_case_count is not None and len(cases) != expected_case_count:
-        raise DiagnosticCaseGenerationError(
-            f"Standalone AI returned {len(cases)} case(s), expected {expected_case_count}."
-        )
-
-    required_case_fields = {
-        "case_id",
-        "symptom",
-        "proposed_diagnosis",
-        "root_cause",
-        "plain_repro",
-        "weak_assumptions",
-        "evidence",
-        "candidate_fixes",
-        "regression_tests",
-    }
-    for index, case in enumerate(cases):
-        if not isinstance(case, Mapping):
-            raise DiagnosticCaseGenerationError(f"Case #{index + 1} must be an object.")
-        case_id = str(case.get("case_id", f"case_{index + 1}"))
-        missing = sorted(field for field in required_case_fields if field not in case)
-        if missing:
-            raise DiagnosticCaseGenerationError(
-                f"Case {case_id!r} is missing fields: {', '.join(missing)}."
-            )
-        evidence = case.get("evidence")
-        fixes = case.get("candidate_fixes")
-        tests = case.get("regression_tests")
-        if not isinstance(evidence, list) or len(evidence) < 2:
-            raise DiagnosticCaseGenerationError(
-                f"Case {case_id!r} must include at least two evidence items."
-            )
-        if not isinstance(fixes, list) or len(fixes) < 2:
-            raise DiagnosticCaseGenerationError(
-                f"Case {case_id!r} must include at least two candidate fixes."
-            )
-        if not isinstance(tests, list) or len(tests) < 2:
-            raise DiagnosticCaseGenerationError(
-                f"Case {case_id!r} must include at least two regression tests."
-            )
-        for row in evidence:
-            if not isinstance(row, Mapping):
-                raise DiagnosticCaseGenerationError(f"Case {case_id!r} has invalid evidence.")
-            _require_float_range(row.get("confidence"), field="evidence.confidence", case_id=case_id)
-            _require_float_range(row.get("relevance"), field="evidence.relevance", case_id=case_id)
-        for fix in fixes:
-            if not isinstance(fix, Mapping):
-                raise DiagnosticCaseGenerationError(f"Case {case_id!r} has invalid candidate fix.")
-            _require_float_range(fix.get("expected_impact"), field="fix.expected_impact", case_id=case_id)
-            _require_float_range(fix.get("blast_radius"), field="fix.blast_radius", case_id=case_id)
-            _require_float_range(fix.get("reversibility"), field="fix.reversibility", case_id=case_id)
-
-    return {"schema": CASE_SCHEMA, "cases": [dict(case) for case in cases]}
+    try:
+        return validate_case_payload(payload, expected_case_count=expected_case_count)
+    except ValueError as exc:
+        raise DiagnosticCaseGenerationError(str(exc)) from exc
 
 
 def _gpt_oss_payload(*, model: str, prompt: str, temperature: float) -> dict[str, Any]:

--- a/src/agilab/apps/builtin/tescia_diagnostic_project/src/tescia_diagnostic/reduction.py
+++ b/src/agilab/apps/builtin/tescia_diagnostic_project/src/tescia_diagnostic/reduction.py
@@ -45,6 +45,7 @@ _REQUIRED_PAYLOAD_KEYS = (
 def _merge_tescia_partials(partials: Sequence[ReducePartial]) -> dict[str, Any]:
     case_ids: set[str] = set()
     selected_fix_ids: set[str] = set()
+    case_count = 0
     evidence_sum = 0.0
     regression_sum = 0.0
     student_score_sum = 0.0
@@ -53,6 +54,7 @@ def _merge_tescia_partials(partials: Sequence[ReducePartial]) -> dict[str, Any]:
 
     for partial in partials:
         payload = partial.payload
+        case_count += int(payload["case_count"])
         case_ids.update(str(item) for item in payload["case_ids"])
         selected_fix_ids.update(str(item) for item in payload["selected_fix_ids"] if item)
         evidence_sum += float(payload["evidence_quality_sum"])
@@ -61,9 +63,9 @@ def _merge_tescia_partials(partials: Sequence[ReducePartial]) -> dict[str, Any]:
         actionable_count += int(payload["actionable_count"])
         needs_more_evidence_count += int(payload["needs_more_evidence_count"])
 
-    case_count = len(case_ids)
     return {
         "case_count": case_count,
+        "unique_case_count": len(case_ids),
         "actionable_count": actionable_count,
         "needs_more_evidence_count": needs_more_evidence_count,
         "evidence_quality_mean": round(evidence_sum / case_count, 4) if case_count else 0.0,

--- a/src/agilab/apps/builtin/tescia_diagnostic_project/src/tescia_diagnostic_worker/tescia_diagnostic_worker.py
+++ b/src/agilab/apps/builtin/tescia_diagnostic_project/src/tescia_diagnostic_worker/tescia_diagnostic_worker.py
@@ -13,7 +13,7 @@ from typing import Any
 import pandas as pd
 
 from agi_node.pandas_worker import PandasWorker
-from tescia_diagnostic.diagnostic import diagnose_case, summarize_report
+from tescia_diagnostic.diagnostic import diagnose_case, summarize_report, validate_case_payload
 from tescia_diagnostic.reduction import write_reduce_artifact
 
 logger = logging.getLogger(__name__)
@@ -100,10 +100,11 @@ class TesciaDiagnosticWorker(PandasWorker):
         payload = json.loads(source.read_text(encoding="utf-8"))
         if not isinstance(payload, dict):
             raise ValueError(f"Diagnostic file must contain a JSON object: {source}")
-        cases = payload.get("cases")
-        if not isinstance(cases, list) or not cases:
-            raise ValueError(f"Diagnostic file must declare a non-empty 'cases' list: {source}")
-        return [case for case in cases if isinstance(case, dict)]
+        try:
+            validated = validate_case_payload(payload)
+        except ValueError as exc:
+            raise ValueError(f"Invalid TeSciA diagnostic file {source}: {exc}") from exc
+        return validated["cases"]
 
     def work_pool(self, file_path):
         args = self._current_args()

--- a/src/agilab/lib/agi-app-tescia-diagnostic-project/README.md
+++ b/src/agilab/lib/agi-app-tescia-diagnostic-project/README.md
@@ -28,9 +28,10 @@ project without a monorepo checkout.
 pip install agi-app-tescia-diagnostic-project
 ```
 
-This package is not pulled by the `agi-apps` umbrella until it is promoted for a
-release. Install it directly when validating the diagnostic app package from an
-index or a locally built wheel.
+The `agi-apps` umbrella pulls this package on Python 3.13+ because the TeSciA
+diagnostic app uses the same Python floor as its packaged worker environment.
+Install it directly when validating the diagnostic app package from an index or
+a locally built wheel.
 
 ## Run In AGILAB
 

--- a/src/agilab/lib/agi-apps/README.md
+++ b/src/agilab/lib/agi-apps/README.md
@@ -8,12 +8,13 @@
 distributions. Promoted app payloads now live in focused PyPI packages:
 `agi-app-mission-decision`, `agi-app-pandas-execution`,
 `agi-app-polars-execution`, `agi-app-flight-telemetry`, `agi-app-global-dag`,
-`agi-app-weather-forecast`, and `agi-app-uav-relay-queue`.
+`agi-app-weather-forecast`, `agi-app-tescia-diagnostic-project`, and
+`agi-app-uav-relay-queue`.
 
 The umbrella keeps the lightweight `agilab.apps.install` helper and
 `agilab.examples` learning assets. It also bundles `mycode_project` as the
 single minimal built-in starter template. Real demos stay in focused
-`agi-app-*` payload packages; remaining app project packages stay as release
+`agi-app-*` payload packages; unpromoted app project packages stay as release
 artifacts until they are explicitly promoted.
 
 ## Quick Install

--- a/src/agilab/lib/agi-apps/pyproject.toml
+++ b/src/agilab/lib/agi-apps/pyproject.toml
@@ -31,7 +31,7 @@ keywords = [
     "workflow-orchestration",
 ]
 
-dependencies = ["agi-core==2026.05.20", "agi-app-mission-decision==2026.05.20", "agi-app-pandas-execution==2026.05.20", "agi-app-polars-execution==2026.05.20", "agi-app-flight-telemetry==2026.05.20", "agi-app-global-dag==2026.05.20", "agi-app-weather-forecast==2026.05.20", "agi-app-uav-relay-queue==2026.05.20; python_version >= '3.13'"]
+dependencies = ["agi-core==2026.05.20", "agi-app-mission-decision==2026.05.20", "agi-app-pandas-execution==2026.05.20", "agi-app-polars-execution==2026.05.20", "agi-app-flight-telemetry==2026.05.20", "agi-app-global-dag==2026.05.20", "agi-app-weather-forecast==2026.05.20", "agi-app-tescia-diagnostic-project==2026.05.20; python_version >= '3.13'", "agi-app-uav-relay-queue==2026.05.20; python_version >= '3.13'"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/pypi_app_packages.py
+++ b/src/agilab/pypi_app_packages.py
@@ -46,6 +46,7 @@ PROMOTED_PYPI_APP_PACKAGES: tuple[str, ...] = (
     "agi-app-mission-decision",
     "agi-app-pandas-execution",
     "agi-app-polars-execution",
+    "agi-app-tescia-diagnostic-project",
     "agi-app-uav-relay-queue",
     "agi-app-weather-forecast",
 )

--- a/test/test_pypi_app_packages.py
+++ b/test/test_pypi_app_packages.py
@@ -53,6 +53,7 @@ def test_requirement_normalization_commands_and_catalog_search():
     )
     assert module.pypi_app_package_name("agi-app-weather-forecast==2026.5.18") == "agi-app-weather-forecast"
     assert module.search_promoted_pypi_app_catalog("weather") == ("agi-app-weather-forecast",)
+    assert module.search_promoted_pypi_app_catalog("tescia") == ("agi-app-tescia-diagnostic-project",)
     assert module.pypi_app_install_command(
         "agi-app-weather-forecast",
         python_executable="/tmp/python",

--- a/test/test_tescia_diagnostic_project.py
+++ b/test/test_tescia_diagnostic_project.py
@@ -316,6 +316,37 @@ def test_tescia_reduce_contract_merges_case_summaries(monkeypatch) -> None:
     assert 85.0 <= artifact.payload["student_score_mean"] <= 100.0
 
 
+def test_tescia_reduce_contract_counts_duplicate_case_runs(monkeypatch) -> None:
+    monkeypatch.syspath_prepend(str(APP_SRC))
+
+    from tescia_diagnostic import build_reduce_artifact, partial_from_diagnostic_summary
+
+    first = {
+        "case_id": "duplicate_case",
+        "status": "actionable",
+        "root_cause": "root cause",
+        "selected_fix_id": "strong_fix",
+        "evidence_quality": 0.9,
+        "regression_coverage": 0.8,
+        "student_score": 90.0,
+        "weak_assumption_count": 1,
+        "regression_step_count": 2,
+    }
+    second = {**first, "status": "needs_more_evidence", "student_score": 50.0}
+
+    artifact = build_reduce_artifact(
+        (
+            partial_from_diagnostic_summary(first, partial_id="first"),
+            partial_from_diagnostic_summary(second, partial_id="second"),
+        )
+    )
+
+    assert artifact.payload["case_count"] == 2
+    assert artifact.payload["unique_case_count"] == 1
+    assert artifact.payload["case_ids"] == ["duplicate_case"]
+    assert artifact.payload["student_score_mean"] == 70.0
+
+
 def test_tescia_manager_seeds_sample_and_builds_distribution(monkeypatch, tmp_path) -> None:
     monkeypatch.syspath_prepend(str(APP_SRC))
 
@@ -429,3 +460,19 @@ def test_tescia_worker_exports_json_csv_and_reduce_artifacts(monkeypatch, tmp_pa
     ).is_file()
     export_root = env.AGILAB_EXPORT_ABS / env.target / "tescia_diagnostic"
     assert (export_root / "pipeline_dag_stale_preview" / "pipeline_dag_stale_preview_diagnostic_summary.csv").is_file()
+
+
+def test_tescia_worker_rejects_invalid_case_file(monkeypatch, tmp_path) -> None:
+    monkeypatch.syspath_prepend(str(APP_SRC))
+
+    from tescia_diagnostic_worker import TesciaDiagnosticWorker
+
+    payload = json.loads(SAMPLE_CASES.read_text(encoding="utf-8"))
+    payload["cases"][0]["candidate_fixes"][0]["expected_impact"] = 1.5
+    case_file = tmp_path / "bad_cases.json"
+    case_file.write_text(json.dumps(payload), encoding="utf-8")
+
+    worker = TesciaDiagnosticWorker()
+
+    with pytest.raises(ValueError, match="Invalid TeSciA diagnostic file.*between 0.0 and 1.0"):
+        worker._load_cases(case_file)

--- a/tools/package_split_contract.py
+++ b/tools/package_split_contract.py
@@ -42,6 +42,7 @@ PROMOTED_APP_PROJECT_PACKAGE_NAMES: tuple[str, ...] = (
     "agi-app-flight-telemetry",
     "agi-app-global-dag",
     "agi-app-weather-forecast",
+    "agi-app-tescia-diagnostic-project",
     "agi-app-uav-relay-queue",
 )
 


### PR DESCRIPTION
## Summary
- promote agi-app-tescia-diagnostic-project into the PyPI publish and catalog path
- reuse the same strict TeSciA case schema validator for bundled runtime files and standalone-AI generated files
- fix reducer aggregation so duplicate case runs preserve total run count and expose unique_case_count
- align AGILAB and public docs with the promoted TeSciA package state

## Validation
- uv --preview-features extra-build-dependencies run --no-sync pytest -q -o addopts='' test/test_tescia_diagnostic_project.py test/test_pypi_app_packages.py test/test_release_plan.py test/test_package_split_contract.py test/test_app_installer_packaging.py
- uv --preview-features extra-build-dependencies run --no-sync pytest -q -o addopts='' src/agilab/core/test/test_reduction_contract.py test/test_pyproject_dependency_hygiene.py test/test_pypi_app_packages.py test/test_tescia_diagnostic_project.py test/test_package_split_contract.py
- uv --preview-features extra-build-dependencies run --no-sync python tools/workflow_parity.py --profile docs
- uv --preview-features extra-build-dependencies run --no-sync python tools/workflow_parity.py --profile agi-gui
- uv --preview-features extra-build-dependencies run --no-sync python tools/release_plan.py --package agi-app-tescia-diagnostic-project --format text
- uv --preview-features extra-build-dependencies run --no-sync python tools/sync_docs_source.py --verify-stamp
- git diff --check