### PR TITLE
Docs: clarify local adoption value

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ workers, and the workflow stays portable: export it back to an `agi-core`
 notebook, inspect or adapt the Python stages, and hand off tracking evidence to
 MLflow when that integration is enabled.
 
+You do not need a cluster to get AGILAB's core value. The primary adoption path
+is local: turn a notebook or script into a replayable app with evidence,
+artifacts, analysis views, and a notebook or MLflow handoff. Cluster execution is
+a scale-out option after that local proof works.
+
 Use it to keep experimental AI work:
 
 - **one-command setup**

--- a/README.pypi.md
+++ b/README.pypi.md
@@ -27,6 +27,11 @@ workers, and the workflow stays portable: export it back to an `agi-core`
 notebook, inspect or adapt the Python stages, and hand off tracking evidence to
 MLflow when that integration is enabled.
 
+You do not need a cluster to get AGILAB's core value. The primary adoption path
+is local: turn a notebook or script into a replayable app with evidence,
+artifacts, analysis views, and a notebook or MLflow handoff. Cluster execution is
+a scale-out option after that local proof works.
+
 Use it to keep experimental AI work:
 
 - **one-command setup**

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 216,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "7f76f94f3fbe77066ced73d032f5613de5448792a7944c0235586cf78fd63e1d",
+  "source_digest_sha256": "2e87196b5d505d9c0575ce1c0ab0605c17a62f1dd14d5de09ff73f692338eb5f",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "7f76f94f3fbe77066ced73d032f5613de5448792a7944c0235586cf78fd63e1d"
+  "target_digest_sha256": "2e87196b5d505d9c0575ce1c0ab0605c17a62f1dd14d5de09ff73f692338eb5f"
 }

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -260,6 +260,10 @@ Do I need a cluster or shared folder for the first proof?
 No. The first proof is local by design. Cluster mode is a later validation
 step.
 
+AGILAB's core adoption value is still available without cluster mode: local
+reproducible execution, app/page handoff, proof artifacts, and notebook or
+MLflow export.
+
 If cluster mode is requested, AGILAB requires an explicit usable cluster share
 that is distinct from the local share. It should fail fast instead of silently
 falling back to ``localshare``. Validate a cluster share before a full run with

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -14,6 +14,11 @@ portable, evidence-backed applications that can run locally or on distributed
 workers, while keeping a handoff path to runnable ``agi-core`` notebooks and
 MLflow tracking evidence.
 
+You do not need a cluster to get that core value. The primary adoption path is
+local: turn a notebook or script into a replayable app with evidence,
+artifacts, analysis views, and a notebook or MLflow handoff. Cluster execution
+is a scale-out option after the local proof works.
+
 It is a framework and web UI for running Python data, ML, and RL projects
 through one visible workflow: create the app, execute it under controlled
 runtime choices, inspect artifacts and evidence, then export the result to a


### PR DESCRIPTION
## Summary
- make the README and PyPI README explicitly state that AGILAB's core value does not require a cluster
- add the same local-first positioning to the Introduction page and the FAQ cluster question
- sync the canonical docs mirror stamp from the sibling docs source

## Validation
- `uv --preview-features extra-build-dependencies run --no-sync python tools/sync_docs_source.py --verify-stamp`
- `uv --preview-features extra-build-dependencies run --no-sync python tools/impact_validate.py --files README.md README.pypi.md docs/.docs_source_mirror_stamp.json docs/source/introduction.rst docs/source/faq.rst`
- `uv --preview-features extra-build-dependencies run --no-sync python tools/workflow_parity.py --profile docs`