### PR TITLE
Docs: surface PyTorch playground location

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,14 @@ Start with the public browser preview or the demo chooser:
 - [Local quick start](#quick-start)
 - [Demo capture guide](https://thalesgroup.github.io/agilab/demo_capture_script.html)
 
+## Featured Optional Analysis Pages
+
+- [PyTorch Playground](src/agilab/apps-pages/view_pytorch_playground)
+  (`agi-page-pytorch-playground`) is the opt-in classifier playground for
+  synthetic datasets, hidden-layer activation maps, network diagnostics, and
+  the **Loss landscape** tab. Loss landscape is inside this page; it is not a
+  separate `view_loss_landscape` GitHub folder.
+
 ## [Quick Start](https://thalesgroup.github.io/agilab/quick-start.html)
 
 <p>

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 216,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "2e87196b5d505d9c0575ce1c0ab0605c17a62f1dd14d5de09ff73f692338eb5f",
+  "source_digest_sha256": "2afb206e8045e2d94faec598febf29e3fba825b5b53b3f23dd9d3c70e714fc84",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "2e87196b5d505d9c0575ce1c0ab0605c17a62f1dd14d5de09ff73f692338eb5f"
+  "target_digest_sha256": "2afb206e8045e2d94faec598febf29e3fba825b5b53b3f23dd9d3c70e714fc84"
 }

--- a/docs/source/apps-pages.rst
+++ b/docs/source/apps-pages.rst
@@ -14,6 +14,10 @@ Page bundles are standalone dashboards that complement the built-in workflow
 pages. In the UI they appear alongside the main pages, but they run in their
 own sidecar web process.
 
+Looking for the PyTorch playground or loss landscape? Use
+``view_pytorch_playground``. The loss-landscape projection is a tab inside that
+page, not a separate ``view_loss_landscape`` package.
+
 What is a page bundle?
 ----------------------
 
@@ -134,7 +138,8 @@ pulled by the umbrella dependency graph.
      - Included in ``agi-pages``.
    * - ``view_pytorch_playground``
      - ``agi-page-pytorch-playground``
-     - Interactive PyTorch classifier playground with evidence-pack export.
+     - Interactive PyTorch classifier playground with Loss landscape tab and
+       evidence-pack export.
      - Standalone published page package; intentionally outside ``agi-pages``
        because ``torch`` is a heavy runtime dependency.
    * - ``view_queue_resilience``
@@ -312,7 +317,7 @@ PyTorch classifier playground for small synthetic datasets.
 
 - Input: interactive dataset and model configuration from the page controls.
 - Output: training curves, hidden-layer activation maps, network diagnostics,
-  optional loss-landscape projection, and a hashed evidence-pack download.
+  Loss landscape tab, and a hashed evidence-pack download.
 - It is published as the standalone ``agi-page-pytorch-playground`` package but
   remains outside the ``agi-pages`` umbrella because ``torch`` is a heavy runtime
   dependency.

--- a/src/agilab/apps-pages/README.md
+++ b/src/agilab/apps-pages/README.md
@@ -5,6 +5,10 @@ active app and its exported datasets.
 
 Page projects depend on `agi-gui`, the shared UI package under `src/agilab/lib/agi-gui`.
 
+Looking for the PyTorch playground or loss landscape? Use
+`view_pytorch_playground`. The loss-landscape projection is a tab inside that
+page, not a separate `view_loss_landscape` directory.
+
 Quick start (dev checkout):
 
 - view_maps


### PR DESCRIPTION
## Summary
- add a README pointer to the optional PyTorch Playground analysis page
- clarify in apps-pages docs that loss landscape is a tab inside `view_pytorch_playground`, not a separate page package
- sync the public docs mirror stamp from the canonical docs source

## Validation
- `uv --preview-features extra-build-dependencies run --no-sync python tools/sync_docs_source.py --verify-stamp`
- `uv --preview-features extra-build-dependencies run --no-sync python tools/impact_validate.py --files README.md docs/.docs_source_mirror_stamp.json docs/source/apps-pages.rst src/agilab/apps-pages/README.md`
- `uv --preview-features extra-build-dependencies run --no-sync python tools/workflow_parity.py --profile docs`
- `uv --preview-features extra-build-dependencies run --no-sync python tools/workflow_parity.py --profile agi-gui`