### PR TITLE
[codex] Improve PyTorch playground quality

### DIFF
--- a/src/agilab/apps/builtin/pytorch_playground_project/src/app_args_form.py
+++ b/src/agilab/apps/builtin/pytorch_playground_project/src/app_args_form.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 import sys
+from typing import Any
 
 import streamlit as st
 from pydantic import ValidationError
@@ -10,8 +12,11 @@ _HERE = Path(__file__).resolve().parent
 if str(_HERE) not in sys.path:
     sys.path.insert(0, str(_HERE))
 
-from agi_env.streamlit_args import load_args_state, persist_args, render_form
+from agi_env.streamlit_args import load_args_state, persist_args
 from pytorch_playground import app_args
+from pytorch_playground.core import ACTIVATIONS, DATASETS, FEATURES, OPTIMIZERS, _coerce_feature_names
+
+APP_FORM_ID = "pytorch_playground_args"
 
 
 def _get_env():
@@ -22,10 +27,93 @@ def _get_env():
     return env
 
 
+def _project_key(env: Any) -> str:
+    return str(
+        getattr(env, "active_app", "")
+        or getattr(env, "app", "")
+        or getattr(env, "target", "")
+        or "pytorch_playground_project"
+    )
+
+
+def _field_key(env: Any, name: str) -> str:
+    return f"{APP_FORM_ID}:{_project_key(env)}:{name}"
+
+
+def _seed_widget_value(key: str, value: Any) -> None:
+    if key not in st.session_state:
+        st.session_state[key] = value
+
+
+def _text_input(container: Any, env: Any, name: str, label: str, value: Any) -> str:
+    key = _field_key(env, name)
+    _seed_widget_value(key, str(value))
+    return str(container.text_input(label, key=key))
+
+
+def _checkbox(container: Any, env: Any, name: str, label: str, value: bool) -> bool:
+    key = _field_key(env, name)
+    _seed_widget_value(key, bool(value))
+    return bool(container.checkbox(label, key=key))
+
+
+def _number_input(
+    container: Any,
+    env: Any,
+    name: str,
+    label: str,
+    value: int | float,
+    *,
+    min_value: int | float,
+    max_value: int | float,
+    step: int | float,
+) -> int | float:
+    key = _field_key(env, name)
+    _seed_widget_value(key, value)
+    return container.number_input(label, min_value=min_value, max_value=max_value, step=step, key=key)
+
+
+def _selectbox(container: Any, env: Any, name: str, label: str, options: tuple[str, ...], value: str) -> str:
+    key = _field_key(env, name)
+    _seed_widget_value(key, value if value in options else options[0])
+    return str(container.selectbox(label, options=options, key=key))
+
+
+def _feature_names(container: Any, env: Any, value: str) -> str:
+    key = _field_key(env, "feature_names")
+    _seed_widget_value(key, list(_coerce_feature_names(value)))
+    selected = container.multiselect("Feature names", options=list(FEATURES), key=key)
+    return ",".join(str(item) for item in selected) if selected else app_args.DEFAULT_FEATURE_NAMES
+
+
+def _render_args_form(model: app_args.PytorchPlaygroundArgs, *, env: Any, container: Any) -> dict[str, Any]:
+    return {
+        "data_out": _text_input(container, env, "data_out", "Data out", model.data_out),
+        "dataset": _selectbox(container, env, "dataset", "Dataset", DATASETS, model.dataset),
+        "sample_count": _number_input(container, env, "sample_count", "Sample count", model.sample_count, min_value=64, max_value=1000, step=16),
+        "noise": _number_input(container, env, "noise", "Noise", model.noise, min_value=0.0, max_value=0.5, step=0.01),
+        "train_ratio": _number_input(container, env, "train_ratio", "Train ratio", model.train_ratio, min_value=0.5, max_value=0.95, step=0.05),
+        "hidden_layers": _text_input(container, env, "hidden_layers", "Hidden layers", model.hidden_layers),
+        "activation": _selectbox(container, env, "activation", "Activation", ACTIVATIONS, model.activation),
+        "optimizer": _selectbox(container, env, "optimizer", "Optimizer", OPTIMIZERS, model.optimizer),
+        "learning_rate": _number_input(container, env, "learning_rate", "Learning rate", model.learning_rate, min_value=0.001, max_value=0.2, step=0.001),
+        "epochs": _number_input(container, env, "epochs", "Epochs", model.epochs, min_value=10, max_value=300, step=10),
+        "batch_size": _number_input(container, env, "batch_size", "Batch size", model.batch_size, min_value=8, max_value=256, step=8),
+        "seed": _number_input(container, env, "seed", "Seed", model.seed, min_value=0, max_value=9999, step=1),
+        "feature_names": _feature_names(container, env, model.feature_names),
+        "grid_size": _number_input(container, env, "grid_size", "Grid size", model.grid_size, min_value=12, max_value=120, step=4),
+        "compute_loss_landscape": _checkbox(container, env, "compute_loss_landscape", "Compute loss landscape", model.compute_loss_landscape),
+        "landscape_resolution": _number_input(container, env, "landscape_resolution", "Landscape resolution", model.landscape_resolution, min_value=5, max_value=31, step=2),
+        "landscape_span": _number_input(container, env, "landscape_span", "Landscape span", model.landscape_span, min_value=0.1, max_value=1.5, step=0.05),
+        "reset_target": _checkbox(container, env, "reset_target", "Reset target", model.reset_target),
+    }
+
+
 env = _get_env()
 defaults_model, defaults_payload, settings_path = load_args_state(env, args_module=app_args)
 
-artifact_root = Path(getattr(env, "AGILAB_EXPORT_ABS", Path.home() / "export")) / env.target / "pytorch_playground"
+artifact_target = str(getattr(env, "target", "") or getattr(env, "app", "") or "pytorch_playground_project")
+artifact_root = Path(getattr(env, "AGILAB_EXPORT_ABS", Path.home() / "export")) / artifact_target / "pytorch_playground"
 
 st.caption(
     "PyTorch Playground is an executable app: ORCHESTRATE runs the configured "
@@ -36,7 +124,7 @@ st.caption(f"Analysis artifacts are exported to `{artifact_root}`.")
 with st.sidebar:
     st.markdown("### PyTorch Playground")
     st.caption("These fields are persisted as app arguments.")
-    form_values = render_form(defaults_model, container=st.sidebar)
+    form_values = _render_args_form(defaults_model, env=env, container=st.sidebar)
 
 try:
     parsed = app_args.ensure_defaults(app_args.ArgsModel(**form_values), env=env)
@@ -54,13 +142,18 @@ else:
             settings_path=settings_path,
             defaults_payload=defaults_payload,
         )
-        st.json(
-            {
-                "dataset": config.dataset,
-                "samples": config.sample_count,
-                "features": list(config.feature_names),
-                "hidden_layers": list(config.hidden_layers),
-                "epochs": config.epochs,
-                "loss_landscape": parsed.compute_loss_landscape,
-            }
+        st.code(
+            json.dumps(
+                {
+                    "dataset": config.dataset,
+                    "samples": config.sample_count,
+                    "features": list(config.feature_names),
+                    "hidden_layers": list(config.hidden_layers),
+                    "epochs": config.epochs,
+                    "loss_landscape": parsed.compute_loss_landscape,
+                },
+                indent=2,
+                sort_keys=True,
+            ),
+            language="json",
         )

--- a/src/agilab/apps/builtin/pytorch_playground_project/src/app_settings.toml
+++ b/src/agilab/apps/builtin/pytorch_playground_project/src/app_settings.toml
@@ -28,7 +28,7 @@ scheduler = "127.0.0.1:8786"
 workers_data_path = ""
 
 [cluster.workers]
-"127.0.0.1" = 2
+"127.0.0.1" = 1
 
 [cluster.service_health]
 allow_idle = false

--- a/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/app_args.py
+++ b/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/app_args.py
@@ -102,7 +102,7 @@ def ensure_defaults(args: PytorchPlaygroundArgs, **_: Any) -> PytorchPlaygroundA
 
 
 def to_playground_config(args: PytorchPlaygroundArgs):
-    from .playground_ui import PlaygroundConfig, _coerce_feature_names, _parse_hidden_layers
+    from .core import PlaygroundConfig, _coerce_feature_names, _parse_hidden_layers
 
     return PlaygroundConfig(
         dataset=args.dataset,

--- a/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/core.py
+++ b/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/core.py
@@ -1,0 +1,946 @@
+# BSD 3-Clause License
+#
+# Copyright (c) 2026, Jean-Pierre Morard, THALES SIX GTS France SAS
+
+"""UI-independent PyTorch playground training and evidence primitives."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import binascii
+import hashlib
+import io
+import json
+import re
+import zipfile
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+try:  # pragma: no cover - exercised conditionally in environments with torch
+    import torch
+    from torch import nn
+except Exception:  # pragma: no cover - lightweight environments may omit torch
+    torch = None  # type: ignore[assignment]
+    nn = None  # type: ignore[assignment]
+
+DATASETS = ("circles", "xor", "spiral", "gaussian")
+FEATURES = (
+    "x1",
+    "x2",
+    "x1_squared",
+    "x2_squared",
+    "x1_x2",
+    "sin_x1",
+    "sin_x2",
+)
+DEFAULT_FEATURES = ("x1", "x2", "x1_squared", "x2_squared", "x1_x2")
+ACTIVATIONS = ("tanh", "relu", "sigmoid", "identity")
+OPTIMIZERS = ("Adam", "SGD")
+CONFIG_SCHEMA = "agilab.pytorch_playground_config.v1"
+EVIDENCE_SCHEMA = "agilab.pytorch_playground_evidence.v1"
+ZIP_TIMESTAMP = (2026, 1, 1, 0, 0, 0)
+CUSTOM_PRESET = "Custom / shared link"
+DEFAULT_PRESET = "Instant wow: clean circles"
+TRAINED_CONFIG_STATE_KEY = "pytorch_playground_trained_config"
+TRAINED_PRESET_STATE_KEY = "pytorch_playground_trained_preset"
+SHARED_CONFIG_SIGNATURE_STATE_KEY = "pytorch_playground_shared_signature"
+
+
+class _FallbackPlotlyFigure(dict):
+    @property
+    def data(self) -> tuple[object, ...]:
+        return tuple(self.get("data", ()))
+
+
+def _plotly_unavailable_figure(kind: str, trace_count: int = 0) -> _FallbackPlotlyFigure:
+    return _FallbackPlotlyFigure(
+        {
+            "data": [{"type": "scatter", "x": [], "y": []} for _ in range(max(0, int(trace_count)))],
+            "layout": {
+                "title": f"{kind} chart unavailable",
+                "template": "plotly_dark",
+            },
+        }
+    )
+
+
+@dataclass(frozen=True)
+class PlaygroundConfig:
+    dataset: str = "circles"
+    sample_count: int = 256
+    noise: float = 0.12
+    train_ratio: float = 0.75
+    hidden_layers: tuple[int, ...] = (8, 8)
+    activation: str = "tanh"
+    optimizer: str = "Adam"
+    learning_rate: float = 0.03
+    epochs: int = 80
+    batch_size: int = 32
+    seed: int = 7
+    feature_names: tuple[str, ...] = DEFAULT_FEATURES
+    grid_size: int = 80
+
+
+PLAYGROUND_PRESETS: dict[str, PlaygroundConfig] = {
+    CUSTOM_PRESET: PlaygroundConfig(),
+    "Instant wow: clean circles": PlaygroundConfig(
+        dataset="circles",
+        sample_count=320,
+        noise=0.08,
+        hidden_layers=(12, 12),
+        learning_rate=0.035,
+        epochs=90,
+        grid_size=88,
+        seed=11,
+    ),
+    "Feature puzzle: XOR": PlaygroundConfig(
+        dataset="xor",
+        sample_count=352,
+        noise=0.06,
+        hidden_layers=(16, 8),
+        activation="relu",
+        learning_rate=0.025,
+        epochs=120,
+        feature_names=("x1", "x2", "x1_x2", "x1_squared", "x2_squared"),
+        grid_size=84,
+        seed=19,
+    ),
+    "Hard mode: spiral": PlaygroundConfig(
+        dataset="spiral",
+        sample_count=448,
+        noise=0.10,
+        hidden_layers=(24, 16, 8),
+        activation="tanh",
+        learning_rate=0.02,
+        epochs=160,
+        batch_size=48,
+        feature_names=("x1", "x2", "sin_x1", "sin_x2", "x1_x2"),
+        grid_size=96,
+        seed=29,
+    ),
+    "Fast baseline: gaussian": PlaygroundConfig(
+        dataset="gaussian",
+        sample_count=256,
+        noise=0.14,
+        hidden_layers=(6,),
+        learning_rate=0.04,
+        epochs=60,
+        feature_names=("x1", "x2"),
+        grid_size=72,
+        seed=5,
+    ),
+}
+
+PRESET_STORIES: dict[str, str] = {
+    CUSTOM_PRESET: "Use the current controls, or open a shared configuration token.",
+    "Instant wow: clean circles": "A compact nonlinear boundary that should become visibly crisp in one run.",
+    "Feature puzzle: XOR": "Shows why engineered features and hidden layers matter.",
+    "Hard mode: spiral": "A harder visual challenge for seeing capacity, noise, and loss terrain.",
+    "Fast baseline: gaussian": "A quick sanity check where a tiny network should separate the classes.",
+}
+
+
+def _resolve_active_app() -> Path | None:
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--active-app", dest="active_app", type=str)
+    args, _ = parser.parse_known_args()
+    if not args.active_app:
+        return None
+    active_app = Path(args.active_app).expanduser().resolve()
+    return active_app if active_app.exists() else None
+
+
+def _parse_hidden_layers(raw: str) -> tuple[int, ...]:
+    cleaned = raw.strip()
+    if not cleaned:
+        return ()
+    values: list[int] = []
+    for token in re.split(r"[,\s;]+", cleaned):
+        if not token:
+            continue
+        try:
+            width = int(token)
+        except ValueError as exc:
+            raise ValueError(f"Hidden layer width must be an integer: {token}") from exc
+        if width < 1 or width > 256:
+            raise ValueError("Hidden layer widths must be between 1 and 256.")
+        values.append(width)
+    if len(values) > 6:
+        raise ValueError("Use at most six hidden layers.")
+    return tuple(values)
+
+
+def _bounded_int(value: Any, *, default: int, minimum: int, maximum: int) -> int:
+    try:
+        number = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(minimum, min(maximum, number))
+
+
+def _bounded_float(value: Any, *, default: float, minimum: float, maximum: float) -> float:
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return default
+    if not np.isfinite(number):
+        return default
+    return float(max(minimum, min(maximum, number)))
+
+
+def _coerce_hidden_layers(value: Any, default: tuple[int, ...] = (8, 8)) -> tuple[int, ...]:
+    if isinstance(value, str):
+        try:
+            return _parse_hidden_layers(value)
+        except ValueError:
+            return default
+    if isinstance(value, (list, tuple)):
+        try:
+            return _parse_hidden_layers(",".join(str(item) for item in value))
+        except ValueError:
+            return default
+    return default
+
+
+def _coerce_feature_names(value: Any, default: tuple[str, ...] = DEFAULT_FEATURES) -> tuple[str, ...]:
+    if isinstance(value, str):
+        raw_values = [token.strip() for token in value.split(",")]
+    elif isinstance(value, (list, tuple)):
+        raw_values = [str(token).strip() for token in value]
+    else:
+        raw_values = list(default)
+    selected = tuple(name for name in raw_values if name in FEATURES)
+    return selected or default
+
+
+def _config_payload(config: PlaygroundConfig) -> dict[str, Any]:
+    payload = asdict(config)
+    payload["hidden_layers"] = list(config.hidden_layers)
+    payload["feature_names"] = list(config.feature_names)
+    return {"schema": CONFIG_SCHEMA, "config": payload}
+
+
+def _config_from_payload(payload: Mapping[str, Any]) -> PlaygroundConfig:
+    raw_config = payload.get("config", payload)
+    if not isinstance(raw_config, Mapping):
+        raw_config = {}
+    default = PlaygroundConfig()
+    dataset = str(raw_config.get("dataset", default.dataset))
+    activation = str(raw_config.get("activation", default.activation))
+    optimizer = str(raw_config.get("optimizer", default.optimizer))
+    return PlaygroundConfig(
+        dataset=dataset if dataset in DATASETS else default.dataset,
+        sample_count=_bounded_int(raw_config.get("sample_count"), default=default.sample_count, minimum=64, maximum=1000),
+        noise=_bounded_float(raw_config.get("noise"), default=default.noise, minimum=0.0, maximum=0.5),
+        train_ratio=_bounded_float(raw_config.get("train_ratio"), default=default.train_ratio, minimum=0.5, maximum=0.95),
+        hidden_layers=_coerce_hidden_layers(raw_config.get("hidden_layers"), default.hidden_layers),
+        activation=activation if activation in ACTIVATIONS else default.activation,
+        optimizer=optimizer if optimizer in OPTIMIZERS else default.optimizer,
+        learning_rate=_bounded_float(raw_config.get("learning_rate"), default=default.learning_rate, minimum=0.001, maximum=0.2),
+        epochs=_bounded_int(raw_config.get("epochs"), default=default.epochs, minimum=10, maximum=300),
+        batch_size=_bounded_int(raw_config.get("batch_size"), default=default.batch_size, minimum=8, maximum=256),
+        seed=_bounded_int(raw_config.get("seed"), default=default.seed, minimum=0, maximum=9999),
+        feature_names=_coerce_feature_names(raw_config.get("feature_names"), default.feature_names),
+        grid_size=_bounded_int(raw_config.get("grid_size"), default=default.grid_size, minimum=12, maximum=120),
+    )
+
+
+def _encode_share_config(config: PlaygroundConfig) -> str:
+    raw = json.dumps(_config_payload(config), sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def _decode_share_config(raw: str) -> PlaygroundConfig | None:
+    if not raw:
+        return None
+    try:
+        padding = "=" * (-len(raw) % 4)
+        payload = json.loads(base64.urlsafe_b64decode((raw + padding).encode("ascii")).decode("utf-8"))
+    except (binascii.Error, UnicodeDecodeError, ValueError, TypeError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, Mapping):
+        return None
+    return _config_from_payload(payload)
+
+
+def _first_query_value(value: Any) -> str | None:
+    if isinstance(value, (list, tuple)):
+        if not value:
+            return None
+        value = value[0]
+    if value is None:
+        return None
+    return str(value)
+
+
+def _config_from_query_params(params: Mapping[str, Any]) -> PlaygroundConfig | None:
+    for key in ("pytorch_playground", "config"):
+        token = _first_query_value(params.get(key))
+        decoded = _decode_share_config(token or "")
+        if decoded is not None:
+            return decoded
+    return None
+
+
+def _safe_key_fragment(raw: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "_", raw.lower()).strip("_") or "custom"
+
+
+def _preset_config(label: str, shared_config: PlaygroundConfig | None = None) -> PlaygroundConfig:
+    if label == CUSTOM_PRESET and shared_config is not None:
+        return shared_config
+    return PLAYGROUND_PRESETS.get(label, PLAYGROUND_PRESETS[CUSTOM_PRESET])
+
+
+def _preset_story(label: str, shared_config: PlaygroundConfig | None = None) -> str:
+    if label == CUSTOM_PRESET and shared_config is not None:
+        return "Loaded from the URL token. Adjust any control to fork the experiment."
+    return PRESET_STORIES.get(label, PRESET_STORIES[CUSTOM_PRESET])
+
+
+def _config_state_payload(config: PlaygroundConfig) -> dict[str, Any]:
+    return _config_payload(config)["config"]
+
+
+def _config_signature(config: PlaygroundConfig) -> str:
+    return json.dumps(_config_state_payload(config), sort_keys=True, separators=(",", ":"))
+
+
+def _make_dataset(config: PlaygroundConfig) -> pd.DataFrame:
+    rng = np.random.default_rng(config.seed)
+    count = max(16, int(config.sample_count))
+    dataset = config.dataset if config.dataset in DATASETS else "circles"
+    noise = max(0.0, float(config.noise))
+
+    if dataset == "xor":
+        points = rng.uniform(-1.0, 1.0, size=(count, 2))
+        points += rng.normal(0.0, noise, size=points.shape)
+        labels = (points[:, 0] * points[:, 1] < 0.0).astype(int)
+    elif dataset == "spiral":
+        points, labels = _make_spiral_dataset(rng, count, noise)
+    elif dataset == "gaussian":
+        points, labels = _make_gaussian_dataset(rng, count, noise)
+    else:
+        points, labels = _make_circle_dataset(rng, count, noise)
+
+    order = rng.permutation(len(labels))
+    frame = pd.DataFrame(
+        {
+            "x1": points[order, 0].astype(float),
+            "x2": points[order, 1].astype(float),
+            "target": labels[order].astype(int),
+        }
+    )
+    return frame.reset_index(drop=True)
+
+
+def _make_circle_dataset(
+    rng: np.random.Generator,
+    count: int,
+    noise: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    inner_count = count // 2
+    outer_count = count - inner_count
+    inner_theta = rng.uniform(0.0, 2.0 * np.pi, size=inner_count)
+    outer_theta = rng.uniform(0.0, 2.0 * np.pi, size=outer_count)
+    inner_radius = 0.42 + rng.normal(0.0, noise, size=inner_count)
+    outer_radius = 0.95 + rng.normal(0.0, noise, size=outer_count)
+    inner = np.column_stack((inner_radius * np.cos(inner_theta), inner_radius * np.sin(inner_theta)))
+    outer = np.column_stack((outer_radius * np.cos(outer_theta), outer_radius * np.sin(outer_theta)))
+    points = np.vstack((inner, outer))
+    labels = np.concatenate((np.zeros(inner_count, dtype=int), np.ones(outer_count, dtype=int)))
+    return points, labels
+
+
+def _make_spiral_dataset(
+    rng: np.random.Generator,
+    count: int,
+    noise: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    first_count = count // 2
+    second_count = count - first_count
+    points_by_class: list[np.ndarray] = []
+    labels_by_class: list[np.ndarray] = []
+    for class_id, class_count in enumerate((first_count, second_count)):
+        radius = np.linspace(0.12, 1.0, class_count)
+        theta = class_id * np.pi + 4.2 * radius + rng.normal(0.0, noise * 2.0, size=class_count)
+        points = np.column_stack((radius * np.cos(theta), radius * np.sin(theta)))
+        points += rng.normal(0.0, noise * 0.35, size=points.shape)
+        points_by_class.append(points)
+        labels_by_class.append(np.full(class_count, class_id, dtype=int))
+    return np.vstack(points_by_class), np.concatenate(labels_by_class)
+
+
+def _make_gaussian_dataset(
+    rng: np.random.Generator,
+    count: int,
+    noise: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    first_count = count // 2
+    second_count = count - first_count
+    spread = 0.24 + noise
+    first = rng.normal(loc=(-0.45, -0.25), scale=spread, size=(first_count, 2))
+    second = rng.normal(loc=(0.45, 0.30), scale=spread, size=(second_count, 2))
+    points = np.vstack((first, second))
+    labels = np.concatenate((np.zeros(first_count, dtype=int), np.ones(second_count, dtype=int)))
+    return points, labels
+
+
+def _feature_matrix(samples: pd.DataFrame | np.ndarray, feature_names: tuple[str, ...]) -> np.ndarray:
+    if isinstance(samples, pd.DataFrame):
+        x1 = samples["x1"].to_numpy(dtype=float)
+        x2 = samples["x2"].to_numpy(dtype=float)
+    else:
+        points = np.asarray(samples, dtype=float)
+        x1 = points[:, 0]
+        x2 = points[:, 1]
+
+    values_by_name = {
+        "x1": x1,
+        "x2": x2,
+        "x1_squared": x1**2,
+        "x2_squared": x2**2,
+        "x1_x2": x1 * x2,
+        "sin_x1": np.sin(np.pi * x1),
+        "sin_x2": np.sin(np.pi * x2),
+    }
+    selected = [name for name in feature_names if name in values_by_name]
+    if not selected:
+        selected = ["x1", "x2"]
+    return np.column_stack([values_by_name[name] for name in selected]).astype(np.float32)
+
+
+def _activation_module(name: str):
+    if nn is None:
+        raise RuntimeError("PyTorch is not available.")
+    if name == "relu":
+        return nn.ReLU()
+    if name == "sigmoid":
+        return nn.Sigmoid()
+    if name == "identity":
+        return nn.Identity()
+    return nn.Tanh()
+
+
+def _build_model(input_dim: int, config: PlaygroundConfig):
+    if nn is None:
+        raise RuntimeError("PyTorch is not available.")
+    layers: list[Any] = []
+    previous_dim = input_dim
+    for width in config.hidden_layers:
+        layers.append(nn.Linear(previous_dim, width))
+        layers.append(_activation_module(config.activation))
+        previous_dim = width
+    layers.append(nn.Linear(previous_dim, 2))
+    return nn.Sequential(*layers)
+
+
+def _empty_network_layers() -> pd.DataFrame:
+    return pd.DataFrame(
+        columns=[
+            "layer",
+            "kind",
+            "input_features",
+            "output_features",
+            "parameters",
+            "weight_mean",
+            "weight_std",
+            "weight_max_abs",
+            "bias_mean",
+            "bias_std",
+            "bias_max_abs",
+        ]
+    )
+
+
+def _empty_activation_maps() -> pd.DataFrame:
+    return pd.DataFrame(columns=["layer", "neuron", "x1", "x2", "activation"])
+
+
+def _empty_loss_landscape() -> pd.DataFrame:
+    return pd.DataFrame(
+        columns=[
+            "alpha",
+            "beta",
+            "train_loss",
+            "validation_loss",
+            "train_accuracy",
+            "validation_accuracy",
+            "is_center",
+        ]
+    )
+
+
+def _array_stats(values: np.ndarray) -> dict[str, float]:
+    flattened = np.asarray(values, dtype=float).ravel()
+    if flattened.size == 0:
+        return {"mean": 0.0, "std": 0.0, "max_abs": 0.0}
+    return {
+        "mean": float(np.mean(flattened)),
+        "std": float(np.std(flattened)),
+        "max_abs": float(np.max(np.abs(flattened))),
+    }
+
+
+def _network_layers(model) -> pd.DataFrame:
+    if nn is None:
+        return _empty_network_layers()
+    linear_layers = [layer for layer in model if isinstance(layer, nn.Linear)]
+    rows: list[dict[str, Any]] = []
+    for index, layer in enumerate(linear_layers):
+        weight = layer.weight.detach().cpu().numpy()
+        bias = layer.bias.detach().cpu().numpy() if layer.bias is not None else np.array([], dtype=float)
+        weight_stats = _array_stats(weight)
+        bias_stats = _array_stats(bias)
+        rows.append(
+            {
+                "layer": index + 1,
+                "kind": "output" if index == len(linear_layers) - 1 else "hidden",
+                "input_features": int(layer.in_features),
+                "output_features": int(layer.out_features),
+                "parameters": int(weight.size + bias.size),
+                "weight_mean": weight_stats["mean"],
+                "weight_std": weight_stats["std"],
+                "weight_max_abs": weight_stats["max_abs"],
+                "bias_mean": bias_stats["mean"],
+                "bias_std": bias_stats["std"],
+                "bias_max_abs": bias_stats["max_abs"],
+            }
+        )
+    return pd.DataFrame(rows, columns=_empty_network_layers().columns)
+
+
+def _grid_points(config: PlaygroundConfig) -> pd.DataFrame:
+    axis = np.linspace(-1.35, 1.35, max(12, int(config.grid_size)))
+    xx, yy = np.meshgrid(axis, axis)
+    return pd.DataFrame({"x1": xx.ravel(), "x2": yy.ravel()})
+
+
+def _hidden_activation_maps(
+    model,
+    config: PlaygroundConfig,
+    mean: np.ndarray,
+    std: np.ndarray,
+    *,
+    max_neurons: int = 8,
+) -> pd.DataFrame:
+    if torch is None or nn is None or not config.hidden_layers:
+        return _empty_activation_maps()
+
+    grid_points = _grid_points(config)
+    grid_features = (_feature_matrix(grid_points, config.feature_names) - mean) / std
+    activation_frames: list[pd.DataFrame] = []
+    hidden_layer_index = 0
+    pending_hidden_layer = False
+
+    model.eval()
+    with torch.no_grad():
+        values = torch.tensor(grid_features, dtype=torch.float32)
+        for layer in model:
+            values = layer(values)
+            if isinstance(layer, nn.Linear):
+                pending_hidden_layer = hidden_layer_index < len(config.hidden_layers)
+                continue
+            if not pending_hidden_layer:
+                continue
+
+            activations = values.detach().cpu().numpy()
+            neuron_count = min(activations.shape[1], max(1, int(max_neurons)))
+            for neuron_index in range(neuron_count):
+                frame = grid_points.copy()
+                frame.insert(0, "neuron", neuron_index + 1)
+                frame.insert(0, "layer", hidden_layer_index + 1)
+                frame["activation"] = activations[:, neuron_index].astype(float)
+                activation_frames.append(frame)
+            hidden_layer_index += 1
+            pending_hidden_layer = False
+
+    if not activation_frames:
+        return _empty_activation_maps()
+    return pd.concat(activation_frames, ignore_index=True)
+
+
+def _prepare_training_data(config: PlaygroundConfig) -> dict[str, Any]:
+    samples = _make_dataset(config)
+    features = _feature_matrix(samples, config.feature_names)
+    labels = samples["target"].to_numpy(dtype=np.int64)
+    rng = np.random.default_rng(config.seed + 101)
+    indices = rng.permutation(len(labels))
+    train_count = min(len(labels) - 1, max(2, int(round(len(labels) * config.train_ratio))))
+    train_indices = indices[:train_count]
+    validation_indices = indices[train_count:]
+    if len(validation_indices) == 0:
+        validation_indices = train_indices
+
+    mean = features[train_indices].mean(axis=0, keepdims=True)
+    std = features[train_indices].std(axis=0, keepdims=True)
+    std[std < 1e-6] = 1.0
+    features = (features - mean) / std
+
+    x_train = torch.tensor(features[train_indices], dtype=torch.float32)
+    y_train = torch.tensor(labels[train_indices], dtype=torch.long)
+    x_validation = torch.tensor(features[validation_indices], dtype=torch.float32)
+    y_validation = torch.tensor(labels[validation_indices], dtype=torch.long)
+    return {
+        "samples": samples,
+        "features": features,
+        "labels": labels,
+        "train_indices": train_indices,
+        "validation_indices": validation_indices,
+        "mean": mean,
+        "std": std,
+        "x_train": x_train,
+        "y_train": y_train,
+        "x_validation": x_validation,
+        "y_validation": y_validation,
+    }
+
+
+def _classification_metrics(model, loss_fn, x_values, y_values) -> dict[str, float]:
+    logits = model(x_values)
+    loss = loss_fn(logits, y_values).item()
+    accuracy = (logits.argmax(dim=1) == y_values).float().mean().item()
+    return {"loss": float(loss), "accuracy": float(accuracy)}
+
+
+def _fit_model(config: PlaygroundConfig, training_data: Mapping[str, Any]) -> tuple[Any, Any, pd.DataFrame]:
+    features = training_data["features"]
+    x_train = training_data["x_train"]
+    y_train = training_data["y_train"]
+    x_validation = training_data["x_validation"]
+    y_validation = training_data["y_validation"]
+    model = _build_model(features.shape[1], config)
+    loss_fn = nn.CrossEntropyLoss()
+    if config.optimizer == "SGD":
+        optimizer = torch.optim.SGD(model.parameters(), lr=config.learning_rate)
+    else:
+        optimizer = torch.optim.Adam(model.parameters(), lr=config.learning_rate)
+
+    history_rows: list[dict[str, float | int]] = []
+    epochs = max(1, int(config.epochs))
+    batch_size = max(4, min(int(config.batch_size), len(x_train)))
+    log_every = max(1, epochs // 40)
+
+    _append_history_row(history_rows, model, loss_fn, x_train, y_train, x_validation, y_validation, 0)
+    for epoch in range(1, epochs + 1):
+        model.train()
+        batch_order = torch.randperm(len(x_train))
+        for start in range(0, len(x_train), batch_size):
+            batch_indices = batch_order[start : start + batch_size]
+            optimizer.zero_grad()
+            batch_logits = model(x_train[batch_indices])
+            batch_loss = loss_fn(batch_logits, y_train[batch_indices])
+            batch_loss.backward()
+            optimizer.step()
+
+        if epoch == epochs or epoch % log_every == 0:
+            _append_history_row(history_rows, model, loss_fn, x_train, y_train, x_validation, y_validation, epoch)
+
+    return model, loss_fn, pd.DataFrame(history_rows)
+
+
+def _train_playground(config: PlaygroundConfig) -> dict[str, Any]:
+    if torch is None or nn is None:
+        samples = _make_dataset(config)
+        return {
+            "status": "missing_torch",
+            "detail": "Install the app dependencies to enable PyTorch training.",
+            "samples": samples,
+            "history": pd.DataFrame(columns=["epoch", "train_loss", "validation_loss", "train_accuracy", "validation_accuracy"]),
+            "grid": pd.DataFrame(columns=["x1", "x2", "probability"]),
+            "network_layers": _empty_network_layers(),
+            "activation_maps": _empty_activation_maps(),
+            "summary": {
+                "backend": "missing",
+                "samples": int(len(samples)),
+                "features": int(len(config.feature_names)),
+            },
+        }
+
+    torch.manual_seed(config.seed)
+    training_data = _prepare_training_data(config)
+    samples = training_data["samples"]
+    features = training_data["features"]
+    mean = training_data["mean"]
+    std = training_data["std"]
+    model, _loss_fn, history = _fit_model(config, training_data)
+    grid = _decision_grid(model, config, mean, std)
+    network_layers = _network_layers(model)
+    activation_maps = _hidden_activation_maps(model, config, mean, std)
+    final = history.iloc[-1].to_dict() if not history.empty else {}
+    return {
+        "status": "ok",
+        "detail": "",
+        "samples": samples,
+        "history": history,
+        "grid": grid,
+        "network_layers": network_layers,
+        "activation_maps": activation_maps,
+        "summary": {
+            "backend": "torch",
+            "samples": int(len(samples)),
+            "features": int(features.shape[1]),
+            "hidden_layers": list(config.hidden_layers),
+            "train_accuracy": float(final.get("train_accuracy", 0.0)),
+            "validation_accuracy": float(final.get("validation_accuracy", 0.0)),
+            "validation_loss": float(final.get("validation_loss", 0.0)),
+        },
+    }
+
+
+def _append_history_row(
+    rows: list[dict[str, float | int]],
+    model,
+    loss_fn,
+    x_train,
+    y_train,
+    x_validation,
+    y_validation,
+    epoch: int,
+) -> None:
+    model.eval()
+    with torch.no_grad():
+        train_metrics = _classification_metrics(model, loss_fn, x_train, y_train)
+        validation_metrics = _classification_metrics(model, loss_fn, x_validation, y_validation)
+    rows.append(
+        {
+            "epoch": int(epoch),
+            "train_loss": train_metrics["loss"],
+            "validation_loss": validation_metrics["loss"],
+            "train_accuracy": train_metrics["accuracy"],
+            "validation_accuracy": validation_metrics["accuracy"],
+        }
+    )
+
+
+def _decision_grid(model, config: PlaygroundConfig, mean: np.ndarray, std: np.ndarray) -> pd.DataFrame:
+    grid_points = _grid_points(config)
+    grid_features = (_feature_matrix(grid_points, config.feature_names) - mean) / std
+    model.eval()
+    with torch.no_grad():
+        logits = model(torch.tensor(grid_features, dtype=torch.float32))
+        probabilities = torch.softmax(logits, dim=1)[:, 1].cpu().numpy()
+    grid_points["probability"] = probabilities.astype(float)
+    return grid_points
+
+
+def _model_state_vector(model):
+    return torch.cat([parameter.detach().flatten().cpu() for parameter in model.parameters()])
+
+
+def _assign_model_state_vector(model, vector) -> None:
+    offset = 0
+    for parameter in model.parameters():
+        item_count = parameter.numel()
+        values = vector[offset : offset + item_count].reshape(parameter.shape).to(parameter.device, dtype=parameter.dtype)
+        parameter.data.copy_(values)
+        offset += item_count
+
+
+def _landscape_directions(center, seed: int) -> tuple[Any, Any]:
+    generator = torch.Generator()
+    generator.manual_seed(int(seed) + 7001)
+    first = torch.randn(center.shape, generator=generator, dtype=center.dtype)
+    second = torch.randn(center.shape, generator=generator, dtype=center.dtype)
+    first_norm = first.norm().clamp_min(1e-12)
+    first = first / first_norm
+    second = second - torch.dot(second, first) * first
+    second_norm = second.norm().clamp_min(1e-12)
+    second = second / second_norm
+    scale = center.norm().clamp_min(1.0)
+    return first * scale, second * scale
+
+
+def _normalized_landscape_resolution(value: int) -> int:
+    resolution = max(5, min(31, int(value)))
+    if resolution % 2 == 0:
+        resolution += 1
+    return resolution
+
+
+def _loss_landscape_summary(landscape: pd.DataFrame) -> dict[str, Any]:
+    if landscape.empty:
+        return {"status": "not_computed", "points": 0}
+    center_candidates = landscape[landscape["is_center"]]
+    center = center_candidates.iloc[0] if not center_candidates.empty else landscape.iloc[len(landscape) // 2]
+    best = landscape.loc[landscape["validation_loss"].idxmin()]
+    max_validation_loss = float(landscape["validation_loss"].max())
+    center_loss = float(center["validation_loss"])
+    return {
+        "status": "ok",
+        "points": int(len(landscape)),
+        "center_validation_loss": center_loss,
+        "center_train_loss": float(center["train_loss"]),
+        "center_validation_accuracy": float(center["validation_accuracy"]),
+        "best_validation_loss": float(best["validation_loss"]),
+        "best_alpha": float(best["alpha"]),
+        "best_beta": float(best["beta"]),
+        "best_delta": float(best["validation_loss"] - center_loss),
+        "sharpness": float(max(0.0, max_validation_loss - center_loss)),
+    }
+
+
+def _loss_landscape(config: PlaygroundConfig, *, resolution: int = 21, span: float = 0.75) -> dict[str, Any]:
+    if torch is None or nn is None:
+        return {
+            "status": "missing_torch",
+            "detail": "Install the app dependencies to enable the loss landscape.",
+            "loss_landscape": _empty_loss_landscape(),
+            "landscape_summary": _loss_landscape_summary(_empty_loss_landscape()),
+        }
+
+    torch.manual_seed(config.seed)
+    training_data = _prepare_training_data(config)
+    model, loss_fn, _history = _fit_model(config, training_data)
+    center = _model_state_vector(model)
+    first_direction, second_direction = _landscape_directions(center, config.seed)
+    resolution = _normalized_landscape_resolution(resolution)
+    span = max(0.05, min(2.0, float(span)))
+    axis = np.linspace(-span, span, resolution)
+    rows: list[dict[str, float | bool]] = []
+
+    try:
+        model.eval()
+        with torch.no_grad():
+            for alpha in axis:
+                for beta in axis:
+                    candidate = center + float(alpha) * first_direction + float(beta) * second_direction
+                    _assign_model_state_vector(model, candidate)
+                    train_metrics = _classification_metrics(model, loss_fn, training_data["x_train"], training_data["y_train"])
+                    validation_metrics = _classification_metrics(
+                        model,
+                        loss_fn,
+                        training_data["x_validation"],
+                        training_data["y_validation"],
+                    )
+                    rows.append(
+                        {
+                            "alpha": float(alpha),
+                            "beta": float(beta),
+                            "train_loss": train_metrics["loss"],
+                            "validation_loss": validation_metrics["loss"],
+                            "train_accuracy": train_metrics["accuracy"],
+                            "validation_accuracy": validation_metrics["accuracy"],
+                            "is_center": bool(np.isclose(alpha, 0.0) and np.isclose(beta, 0.0)),
+                        }
+                    )
+    finally:
+        _assign_model_state_vector(model, center)
+
+    landscape = pd.DataFrame(rows, columns=_empty_loss_landscape().columns)
+    return {
+        "status": "ok",
+        "detail": "",
+        "loss_landscape": landscape,
+        "landscape_summary": _loss_landscape_summary(landscape),
+    }
+
+
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(item) for item in value]
+    if isinstance(value, np.integer):
+        return int(value)
+    if isinstance(value, np.floating):
+        number = float(value)
+        return number if np.isfinite(number) else None
+    if isinstance(value, float):
+        return value if np.isfinite(value) else None
+    return value
+
+
+def _json_bytes(payload: Mapping[str, Any]) -> bytes:
+    return json.dumps(_json_safe(payload), indent=2, sort_keys=True).encode("utf-8") + b"\n"
+
+
+def _dataframe_csv_bytes(frame: pd.DataFrame) -> bytes:
+    return frame.to_csv(index=False, float_format="%.10g").encode("utf-8")
+
+
+def _artifact_hash(payload: bytes) -> dict[str, Any]:
+    return {"sha256": hashlib.sha256(payload).hexdigest(), "bytes": len(payload)}
+
+
+def _result_frame(result: Mapping[str, Any], key: str, empty: pd.DataFrame) -> pd.DataFrame:
+    value = result.get(key)
+    return value if isinstance(value, pd.DataFrame) else empty
+
+
+def _evidence_artifact_files(config: PlaygroundConfig, result: Mapping[str, Any]) -> dict[str, bytes]:
+    samples = _result_frame(result, "samples", pd.DataFrame(columns=["x1", "x2", "target"]))
+    history = _result_frame(result, "history", pd.DataFrame(columns=["epoch", "train_loss", "validation_loss", "train_accuracy", "validation_accuracy"]))
+    grid = _result_frame(result, "grid", pd.DataFrame(columns=["x1", "x2", "probability"]))
+    network_layers = _result_frame(result, "network_layers", _empty_network_layers())
+    activation_maps = _result_frame(result, "activation_maps", _empty_activation_maps())
+    loss_landscape = _result_frame(result, "loss_landscape", _empty_loss_landscape())
+    return {
+        "config/playground_config.json": _json_bytes(_config_payload(config)),
+        "data/samples.csv": _dataframe_csv_bytes(samples),
+        "data/training_history.csv": _dataframe_csv_bytes(history),
+        "data/decision_grid.csv": _dataframe_csv_bytes(grid),
+        "model/network_layers.csv": _dataframe_csv_bytes(network_layers),
+        "model/hidden_activation_maps.csv": _dataframe_csv_bytes(activation_maps),
+        "model/loss_landscape.csv": _dataframe_csv_bytes(loss_landscape),
+        "summary/run_summary.json": _json_bytes(
+            {
+                "schema": EVIDENCE_SCHEMA,
+                "summary": result.get("summary", {}),
+                "landscape_summary": result.get("landscape_summary", _loss_landscape_summary(loss_landscape)),
+            }
+        ),
+    }
+
+
+def _build_evidence_manifest(config: PlaygroundConfig, result: Mapping[str, Any]) -> dict[str, Any]:
+    files = _evidence_artifact_files(config, result)
+    samples = _result_frame(result, "samples", pd.DataFrame())
+    history = _result_frame(result, "history", pd.DataFrame())
+    grid = _result_frame(result, "grid", pd.DataFrame())
+    network_layers = _result_frame(result, "network_layers", _empty_network_layers())
+    activation_maps = _result_frame(result, "activation_maps", _empty_activation_maps())
+    loss_landscape = _result_frame(result, "loss_landscape", _empty_loss_landscape())
+    return {
+        "schema": EVIDENCE_SCHEMA,
+        "config_schema": CONFIG_SCHEMA,
+        "app": "pytorch_playground_project",
+        "backend": result.get("summary", {}).get("backend", "unknown"),
+        "torch_version": getattr(torch, "__version__", None) if torch is not None else None,
+        "config": _config_payload(config)["config"],
+        "summary": result.get("summary", {}),
+        "landscape_summary": result.get("landscape_summary", _loss_landscape_summary(loss_landscape)),
+        "row_counts": {
+            "samples": int(len(samples)),
+            "training_history": int(len(history)),
+            "decision_grid": int(len(grid)),
+            "network_layers": int(len(network_layers)),
+            "hidden_activation_maps": int(len(activation_maps)),
+            "loss_landscape": int(len(loss_landscape)),
+        },
+        "artifacts": {name: _artifact_hash(payload) for name, payload in sorted(files.items())},
+    }
+
+
+def _deterministic_zip_bytes(files: Mapping[str, bytes]) -> bytes:
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, mode="w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for name in sorted(files):
+            info = zipfile.ZipInfo(name, ZIP_TIMESTAMP)
+            info.compress_type = zipfile.ZIP_DEFLATED
+            info.external_attr = 0o644 << 16
+            archive.writestr(info, files[name])
+    return buffer.getvalue()
+
+
+def _build_evidence_pack(config: PlaygroundConfig, result: Mapping[str, Any]) -> bytes:
+    files = _evidence_artifact_files(config, result)
+    files["manifest.json"] = _json_bytes(_build_evidence_manifest(config, result))
+    return _deterministic_zip_bytes(files)
+

--- a/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/playground_ui.py
+++ b/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/playground_ui.py
@@ -4,16 +4,10 @@
 
 from __future__ import annotations
 
-import argparse
-import base64
-import binascii
-import hashlib
 import html
-import io
 import json
-import zipfile
 from collections.abc import Mapping
-from dataclasses import asdict, dataclass
+from dataclasses import asdict
 from pathlib import Path
 import re
 import sys
@@ -45,14 +39,6 @@ except Exception:  # pragma: no cover - workers import evidence helpers without 
 
     st = _StreamlitStub()  # type: ignore[assignment]
 
-try:  # pragma: no cover - exercised conditionally in environments with torch
-    import torch
-    from torch import nn
-except Exception:  # pragma: no cover - lightweight environments may omit torch
-    torch = None  # type: ignore[assignment]
-    nn = None  # type: ignore[assignment]
-
-
 def _ensure_repo_on_path() -> None:
     here = Path(__file__).resolve()
     for parent in here.parents:
@@ -68,6 +54,99 @@ def _ensure_repo_on_path() -> None:
 
 _ensure_repo_on_path()
 
+_APP_SRC = Path(__file__).resolve().parents[1]
+if str(_APP_SRC) not in sys.path:
+    sys.path.insert(0, str(_APP_SRC))
+
+try:  # noqa: E402
+    import pytorch_playground.core as _playground_core
+    from pytorch_playground.core import (
+        ACTIVATIONS,
+        CONFIG_SCHEMA,
+        CUSTOM_PRESET,
+        DATASETS,
+        DEFAULT_FEATURES,
+        DEFAULT_PRESET,
+        EVIDENCE_SCHEMA,
+        FEATURES,
+        OPTIMIZERS,
+        PLAYGROUND_PRESETS,
+        PRESET_STORIES,
+        SHARED_CONFIG_SIGNATURE_STATE_KEY,
+        TRAINED_CONFIG_STATE_KEY,
+        TRAINED_PRESET_STATE_KEY,
+        PlaygroundConfig,
+        _build_evidence_manifest,
+        _build_evidence_pack,
+        _coerce_feature_names,
+        _config_from_payload,
+        _config_from_query_params,
+        _config_payload,
+        _config_signature,
+        _config_state_payload,
+        _decode_share_config,
+        _empty_activation_maps,
+        _empty_loss_landscape,
+        _empty_network_layers,
+        _encode_share_config,
+        _json_safe,
+        _loss_landscape,
+        _loss_landscape_summary,
+        _make_dataset,
+        _parse_hidden_layers,
+        _plotly_unavailable_figure,
+        _preset_config,
+        _preset_story,
+        _resolve_active_app,
+        _result_frame,
+        _safe_key_fragment,
+        _train_playground,
+    )
+except ModuleNotFoundError:  # pragma: no cover - direct script execution fallback
+    import core as _playground_core
+    from core import (
+        ACTIVATIONS,
+        CONFIG_SCHEMA,
+        CUSTOM_PRESET,
+        DATASETS,
+        DEFAULT_FEATURES,
+        DEFAULT_PRESET,
+        EVIDENCE_SCHEMA,
+        FEATURES,
+        OPTIMIZERS,
+        PLAYGROUND_PRESETS,
+        PRESET_STORIES,
+        SHARED_CONFIG_SIGNATURE_STATE_KEY,
+        TRAINED_CONFIG_STATE_KEY,
+        TRAINED_PRESET_STATE_KEY,
+        PlaygroundConfig,
+        _build_evidence_manifest,
+        _build_evidence_pack,
+        _coerce_feature_names,
+        _config_from_payload,
+        _config_from_query_params,
+        _config_payload,
+        _config_signature,
+        _config_state_payload,
+        _decode_share_config,
+        _empty_activation_maps,
+        _empty_loss_landscape,
+        _empty_network_layers,
+        _encode_share_config,
+        _json_safe,
+        _loss_landscape,
+        _loss_landscape_summary,
+        _make_dataset,
+        _parse_hidden_layers,
+        _plotly_unavailable_figure,
+        _preset_config,
+        _preset_story,
+        _resolve_active_app,
+        _result_frame,
+        _safe_key_fragment,
+        _train_playground,
+    )
+
 try:  # noqa: E402
     from agi_gui.pagelib import render_logo
 except Exception:  # pragma: no cover - headless worker/test environments
@@ -75,290 +154,62 @@ except Exception:  # pragma: no cover - headless worker/test environments
         return None
 
 
+torch = _playground_core.torch
+nn = _playground_core.nn
+
+
+def _call_core(name: str, *args, **kwargs):
+    previous_torch = _playground_core.torch
+    previous_nn = _playground_core.nn
+    _playground_core.torch = torch
+    _playground_core.nn = nn
+    try:
+        return getattr(_playground_core, name)(*args, **kwargs)
+    finally:
+        _playground_core.torch = previous_torch
+        _playground_core.nn = previous_nn
+
+
+def _activation_module(name: str):
+    return _call_core("_activation_module", name)
+
+
+def _build_model(input_dim: int, config: PlaygroundConfig):
+    return _call_core("_build_model", input_dim, config)
+
+
+def _hidden_activation_maps(*args, **kwargs) -> pd.DataFrame:
+    return _call_core("_hidden_activation_maps", *args, **kwargs)
+
+
+def _network_layers(model) -> pd.DataFrame:
+    return _call_core("_network_layers", model)
+
+
+def _prepare_training_data(config: PlaygroundConfig) -> dict[str, Any]:
+    return _call_core("_prepare_training_data", config)
+
+
+def _decision_grid(*args, **kwargs) -> pd.DataFrame:
+    return _call_core("_decision_grid", *args, **kwargs)
+
+
+def _train_playground(config: PlaygroundConfig) -> dict[str, Any]:
+    return _call_core("_train_playground", config)
+
+
+def _loss_landscape(config: PlaygroundConfig, *, resolution: int = 21, span: float = 0.75) -> dict[str, Any]:
+    return _call_core("_loss_landscape", config, resolution=resolution, span=span)
+
+
+def __getattr__(name: str) -> Any:
+    try:
+        return getattr(_playground_core, name)
+    except AttributeError as exc:
+        raise AttributeError(name) from exc
+
+
 PAGE_TITLE = "PyTorch playground"
-DATASETS = ("circles", "xor", "spiral", "gaussian")
-FEATURES = (
-    "x1",
-    "x2",
-    "x1_squared",
-    "x2_squared",
-    "x1_x2",
-    "sin_x1",
-    "sin_x2",
-)
-DEFAULT_FEATURES = ("x1", "x2", "x1_squared", "x2_squared", "x1_x2")
-ACTIVATIONS = ("tanh", "relu", "sigmoid", "identity")
-OPTIMIZERS = ("Adam", "SGD")
-CONFIG_SCHEMA = "agilab.pytorch_playground_config.v1"
-EVIDENCE_SCHEMA = "agilab.pytorch_playground_evidence.v1"
-ZIP_TIMESTAMP = (2026, 1, 1, 0, 0, 0)
-CUSTOM_PRESET = "Custom / shared link"
-DEFAULT_PRESET = "Instant wow: clean circles"
-TRAINED_CONFIG_STATE_KEY = "pytorch_playground_trained_config"
-TRAINED_PRESET_STATE_KEY = "pytorch_playground_trained_preset"
-SHARED_CONFIG_SIGNATURE_STATE_KEY = "pytorch_playground_shared_signature"
-
-
-class _FallbackPlotlyFigure(dict):
-    @property
-    def data(self) -> tuple[object, ...]:
-        return tuple(self.get("data", ()))
-
-
-def _plotly_unavailable_figure(kind: str, trace_count: int = 0) -> _FallbackPlotlyFigure:
-    return _FallbackPlotlyFigure(
-        {
-            "data": [{"type": "scatter", "x": [], "y": []} for _ in range(max(0, int(trace_count)))],
-            "layout": {
-                "title": f"{kind} chart unavailable",
-                "template": "plotly_dark",
-            },
-        }
-    )
-
-
-@dataclass(frozen=True)
-class PlaygroundConfig:
-    dataset: str = "circles"
-    sample_count: int = 256
-    noise: float = 0.12
-    train_ratio: float = 0.75
-    hidden_layers: tuple[int, ...] = (8, 8)
-    activation: str = "tanh"
-    optimizer: str = "Adam"
-    learning_rate: float = 0.03
-    epochs: int = 80
-    batch_size: int = 32
-    seed: int = 7
-    feature_names: tuple[str, ...] = DEFAULT_FEATURES
-    grid_size: int = 80
-
-
-PLAYGROUND_PRESETS: dict[str, PlaygroundConfig] = {
-    CUSTOM_PRESET: PlaygroundConfig(),
-    "Instant wow: clean circles": PlaygroundConfig(
-        dataset="circles",
-        sample_count=320,
-        noise=0.08,
-        hidden_layers=(12, 12),
-        learning_rate=0.035,
-        epochs=90,
-        grid_size=88,
-        seed=11,
-    ),
-    "Feature puzzle: XOR": PlaygroundConfig(
-        dataset="xor",
-        sample_count=352,
-        noise=0.06,
-        hidden_layers=(16, 8),
-        activation="relu",
-        learning_rate=0.025,
-        epochs=120,
-        feature_names=("x1", "x2", "x1_x2", "x1_squared", "x2_squared"),
-        grid_size=84,
-        seed=19,
-    ),
-    "Hard mode: spiral": PlaygroundConfig(
-        dataset="spiral",
-        sample_count=448,
-        noise=0.10,
-        hidden_layers=(24, 16, 8),
-        activation="tanh",
-        learning_rate=0.02,
-        epochs=160,
-        batch_size=48,
-        feature_names=("x1", "x2", "sin_x1", "sin_x2", "x1_x2"),
-        grid_size=96,
-        seed=29,
-    ),
-    "Fast baseline: gaussian": PlaygroundConfig(
-        dataset="gaussian",
-        sample_count=256,
-        noise=0.14,
-        hidden_layers=(6,),
-        learning_rate=0.04,
-        epochs=60,
-        feature_names=("x1", "x2"),
-        grid_size=72,
-        seed=5,
-    ),
-}
-
-PRESET_STORIES: dict[str, str] = {
-    CUSTOM_PRESET: "Use the current controls, or open a shared configuration token.",
-    "Instant wow: clean circles": "A compact nonlinear boundary that should become visibly crisp in one run.",
-    "Feature puzzle: XOR": "Shows why engineered features and hidden layers matter.",
-    "Hard mode: spiral": "A harder visual challenge for seeing capacity, noise, and loss terrain.",
-    "Fast baseline: gaussian": "A quick sanity check where a tiny network should separate the classes.",
-}
-
-
-def _resolve_active_app() -> Path | None:
-    parser = argparse.ArgumentParser(add_help=False)
-    parser.add_argument("--active-app", dest="active_app", type=str)
-    args, _ = parser.parse_known_args()
-    if not args.active_app:
-        return None
-    active_app = Path(args.active_app).expanduser().resolve()
-    return active_app if active_app.exists() else None
-
-
-def _parse_hidden_layers(raw: str) -> tuple[int, ...]:
-    cleaned = raw.strip()
-    if not cleaned:
-        return ()
-    values: list[int] = []
-    for token in re.split(r"[,\s;]+", cleaned):
-        if not token:
-            continue
-        try:
-            width = int(token)
-        except ValueError as exc:
-            raise ValueError(f"Hidden layer width must be an integer: {token}") from exc
-        if width < 1 or width > 256:
-            raise ValueError("Hidden layer widths must be between 1 and 256.")
-        values.append(width)
-    if len(values) > 6:
-        raise ValueError("Use at most six hidden layers.")
-    return tuple(values)
-
-
-def _bounded_int(value: Any, *, default: int, minimum: int, maximum: int) -> int:
-    try:
-        number = int(value)
-    except (TypeError, ValueError):
-        return default
-    return max(minimum, min(maximum, number))
-
-
-def _bounded_float(value: Any, *, default: float, minimum: float, maximum: float) -> float:
-    try:
-        number = float(value)
-    except (TypeError, ValueError):
-        return default
-    if not np.isfinite(number):
-        return default
-    return float(max(minimum, min(maximum, number)))
-
-
-def _coerce_hidden_layers(value: Any, default: tuple[int, ...] = (8, 8)) -> tuple[int, ...]:
-    if isinstance(value, str):
-        try:
-            return _parse_hidden_layers(value)
-        except ValueError:
-            return default
-    if isinstance(value, (list, tuple)):
-        try:
-            return _parse_hidden_layers(",".join(str(item) for item in value))
-        except ValueError:
-            return default
-    return default
-
-
-def _coerce_feature_names(value: Any, default: tuple[str, ...] = DEFAULT_FEATURES) -> tuple[str, ...]:
-    if isinstance(value, str):
-        raw_values = [token.strip() for token in value.split(",")]
-    elif isinstance(value, (list, tuple)):
-        raw_values = [str(token).strip() for token in value]
-    else:
-        raw_values = list(default)
-    selected = tuple(name for name in raw_values if name in FEATURES)
-    return selected or default
-
-
-def _config_payload(config: PlaygroundConfig) -> dict[str, Any]:
-    payload = asdict(config)
-    payload["hidden_layers"] = list(config.hidden_layers)
-    payload["feature_names"] = list(config.feature_names)
-    return {"schema": CONFIG_SCHEMA, "config": payload}
-
-
-def _config_from_payload(payload: Mapping[str, Any]) -> PlaygroundConfig:
-    raw_config = payload.get("config", payload)
-    if not isinstance(raw_config, Mapping):
-        raw_config = {}
-    default = PlaygroundConfig()
-    dataset = str(raw_config.get("dataset", default.dataset))
-    activation = str(raw_config.get("activation", default.activation))
-    optimizer = str(raw_config.get("optimizer", default.optimizer))
-    return PlaygroundConfig(
-        dataset=dataset if dataset in DATASETS else default.dataset,
-        sample_count=_bounded_int(raw_config.get("sample_count"), default=default.sample_count, minimum=64, maximum=1000),
-        noise=_bounded_float(raw_config.get("noise"), default=default.noise, minimum=0.0, maximum=0.5),
-        train_ratio=_bounded_float(raw_config.get("train_ratio"), default=default.train_ratio, minimum=0.5, maximum=0.95),
-        hidden_layers=_coerce_hidden_layers(raw_config.get("hidden_layers"), default.hidden_layers),
-        activation=activation if activation in ACTIVATIONS else default.activation,
-        optimizer=optimizer if optimizer in OPTIMIZERS else default.optimizer,
-        learning_rate=_bounded_float(raw_config.get("learning_rate"), default=default.learning_rate, minimum=0.001, maximum=0.2),
-        epochs=_bounded_int(raw_config.get("epochs"), default=default.epochs, minimum=10, maximum=300),
-        batch_size=_bounded_int(raw_config.get("batch_size"), default=default.batch_size, minimum=8, maximum=256),
-        seed=_bounded_int(raw_config.get("seed"), default=default.seed, minimum=0, maximum=9999),
-        feature_names=_coerce_feature_names(raw_config.get("feature_names"), default.feature_names),
-        grid_size=_bounded_int(raw_config.get("grid_size"), default=default.grid_size, minimum=12, maximum=120),
-    )
-
-
-def _encode_share_config(config: PlaygroundConfig) -> str:
-    raw = json.dumps(_config_payload(config), sort_keys=True, separators=(",", ":")).encode("utf-8")
-    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
-
-
-def _decode_share_config(raw: str) -> PlaygroundConfig | None:
-    if not raw:
-        return None
-    try:
-        padding = "=" * (-len(raw) % 4)
-        payload = json.loads(base64.urlsafe_b64decode((raw + padding).encode("ascii")).decode("utf-8"))
-    except (binascii.Error, UnicodeDecodeError, ValueError, TypeError, json.JSONDecodeError):
-        return None
-    if not isinstance(payload, Mapping):
-        return None
-    return _config_from_payload(payload)
-
-
-def _first_query_value(value: Any) -> str | None:
-    if isinstance(value, (list, tuple)):
-        if not value:
-            return None
-        value = value[0]
-    if value is None:
-        return None
-    return str(value)
-
-
-def _config_from_query_params(params: Mapping[str, Any]) -> PlaygroundConfig | None:
-    for key in ("pytorch_playground", "config"):
-        token = _first_query_value(params.get(key))
-        decoded = _decode_share_config(token or "")
-        if decoded is not None:
-            return decoded
-    return None
-
-
-def _safe_key_fragment(raw: str) -> str:
-    return re.sub(r"[^a-z0-9]+", "_", raw.lower()).strip("_") or "custom"
-
-
-def _preset_config(label: str, shared_config: PlaygroundConfig | None = None) -> PlaygroundConfig:
-    if label == CUSTOM_PRESET and shared_config is not None:
-        return shared_config
-    return PLAYGROUND_PRESETS.get(label, PLAYGROUND_PRESETS[CUSTOM_PRESET])
-
-
-def _preset_story(label: str, shared_config: PlaygroundConfig | None = None) -> str:
-    if label == CUSTOM_PRESET and shared_config is not None:
-        return "Loaded from the URL token. Adjust any control to fork the experiment."
-    return PRESET_STORIES.get(label, PRESET_STORIES[CUSTOM_PRESET])
-
-
-def _config_state_payload(config: PlaygroundConfig) -> dict[str, Any]:
-    return _config_payload(config)["config"]
-
-
-def _config_signature(config: PlaygroundConfig) -> str:
-    return json.dumps(_config_state_payload(config), sort_keys=True, separators=(",", ":"))
-
-
 def _session_state_get(key: str, default: Any = None) -> Any:
     state = getattr(st, "session_state", None)
     if state is None:
@@ -401,536 +252,6 @@ def _resolve_trained_config(
     return trained_config, trained_preset, _config_signature(current_config) != _config_signature(trained_config)
 
 
-def _make_dataset(config: PlaygroundConfig) -> pd.DataFrame:
-    rng = np.random.default_rng(config.seed)
-    count = max(16, int(config.sample_count))
-    dataset = config.dataset if config.dataset in DATASETS else "circles"
-    noise = max(0.0, float(config.noise))
-
-    if dataset == "xor":
-        points = rng.uniform(-1.0, 1.0, size=(count, 2))
-        points += rng.normal(0.0, noise, size=points.shape)
-        labels = (points[:, 0] * points[:, 1] < 0.0).astype(int)
-    elif dataset == "spiral":
-        points, labels = _make_spiral_dataset(rng, count, noise)
-    elif dataset == "gaussian":
-        points, labels = _make_gaussian_dataset(rng, count, noise)
-    else:
-        points, labels = _make_circle_dataset(rng, count, noise)
-
-    order = rng.permutation(len(labels))
-    frame = pd.DataFrame(
-        {
-            "x1": points[order, 0].astype(float),
-            "x2": points[order, 1].astype(float),
-            "target": labels[order].astype(int),
-        }
-    )
-    return frame.reset_index(drop=True)
-
-
-def _make_circle_dataset(
-    rng: np.random.Generator,
-    count: int,
-    noise: float,
-) -> tuple[np.ndarray, np.ndarray]:
-    inner_count = count // 2
-    outer_count = count - inner_count
-    inner_theta = rng.uniform(0.0, 2.0 * np.pi, size=inner_count)
-    outer_theta = rng.uniform(0.0, 2.0 * np.pi, size=outer_count)
-    inner_radius = 0.42 + rng.normal(0.0, noise, size=inner_count)
-    outer_radius = 0.95 + rng.normal(0.0, noise, size=outer_count)
-    inner = np.column_stack((inner_radius * np.cos(inner_theta), inner_radius * np.sin(inner_theta)))
-    outer = np.column_stack((outer_radius * np.cos(outer_theta), outer_radius * np.sin(outer_theta)))
-    points = np.vstack((inner, outer))
-    labels = np.concatenate((np.zeros(inner_count, dtype=int), np.ones(outer_count, dtype=int)))
-    return points, labels
-
-
-def _make_spiral_dataset(
-    rng: np.random.Generator,
-    count: int,
-    noise: float,
-) -> tuple[np.ndarray, np.ndarray]:
-    first_count = count // 2
-    second_count = count - first_count
-    points_by_class: list[np.ndarray] = []
-    labels_by_class: list[np.ndarray] = []
-    for class_id, class_count in enumerate((first_count, second_count)):
-        radius = np.linspace(0.12, 1.0, class_count)
-        theta = class_id * np.pi + 4.2 * radius + rng.normal(0.0, noise * 2.0, size=class_count)
-        points = np.column_stack((radius * np.cos(theta), radius * np.sin(theta)))
-        points += rng.normal(0.0, noise * 0.35, size=points.shape)
-        points_by_class.append(points)
-        labels_by_class.append(np.full(class_count, class_id, dtype=int))
-    return np.vstack(points_by_class), np.concatenate(labels_by_class)
-
-
-def _make_gaussian_dataset(
-    rng: np.random.Generator,
-    count: int,
-    noise: float,
-) -> tuple[np.ndarray, np.ndarray]:
-    first_count = count // 2
-    second_count = count - first_count
-    spread = 0.24 + noise
-    first = rng.normal(loc=(-0.45, -0.25), scale=spread, size=(first_count, 2))
-    second = rng.normal(loc=(0.45, 0.30), scale=spread, size=(second_count, 2))
-    points = np.vstack((first, second))
-    labels = np.concatenate((np.zeros(first_count, dtype=int), np.ones(second_count, dtype=int)))
-    return points, labels
-
-
-def _feature_matrix(samples: pd.DataFrame | np.ndarray, feature_names: tuple[str, ...]) -> np.ndarray:
-    if isinstance(samples, pd.DataFrame):
-        x1 = samples["x1"].to_numpy(dtype=float)
-        x2 = samples["x2"].to_numpy(dtype=float)
-    else:
-        points = np.asarray(samples, dtype=float)
-        x1 = points[:, 0]
-        x2 = points[:, 1]
-
-    values_by_name = {
-        "x1": x1,
-        "x2": x2,
-        "x1_squared": x1**2,
-        "x2_squared": x2**2,
-        "x1_x2": x1 * x2,
-        "sin_x1": np.sin(np.pi * x1),
-        "sin_x2": np.sin(np.pi * x2),
-    }
-    selected = [name for name in feature_names if name in values_by_name]
-    if not selected:
-        selected = ["x1", "x2"]
-    return np.column_stack([values_by_name[name] for name in selected]).astype(np.float32)
-
-
-def _activation_module(name: str):
-    if nn is None:
-        raise RuntimeError("PyTorch is not available.")
-    if name == "relu":
-        return nn.ReLU()
-    if name == "sigmoid":
-        return nn.Sigmoid()
-    if name == "identity":
-        return nn.Identity()
-    return nn.Tanh()
-
-
-def _build_model(input_dim: int, config: PlaygroundConfig):
-    if nn is None:
-        raise RuntimeError("PyTorch is not available.")
-    layers: list[Any] = []
-    previous_dim = input_dim
-    for width in config.hidden_layers:
-        layers.append(nn.Linear(previous_dim, width))
-        layers.append(_activation_module(config.activation))
-        previous_dim = width
-    layers.append(nn.Linear(previous_dim, 2))
-    return nn.Sequential(*layers)
-
-
-def _empty_network_layers() -> pd.DataFrame:
-    return pd.DataFrame(
-        columns=[
-            "layer",
-            "kind",
-            "input_features",
-            "output_features",
-            "parameters",
-            "weight_mean",
-            "weight_std",
-            "weight_max_abs",
-            "bias_mean",
-            "bias_std",
-            "bias_max_abs",
-        ]
-    )
-
-
-def _empty_activation_maps() -> pd.DataFrame:
-    return pd.DataFrame(columns=["layer", "neuron", "x1", "x2", "activation"])
-
-
-def _empty_loss_landscape() -> pd.DataFrame:
-    return pd.DataFrame(
-        columns=[
-            "alpha",
-            "beta",
-            "train_loss",
-            "validation_loss",
-            "train_accuracy",
-            "validation_accuracy",
-            "is_center",
-        ]
-    )
-
-
-def _array_stats(values: np.ndarray) -> dict[str, float]:
-    flattened = np.asarray(values, dtype=float).ravel()
-    if flattened.size == 0:
-        return {"mean": 0.0, "std": 0.0, "max_abs": 0.0}
-    return {
-        "mean": float(np.mean(flattened)),
-        "std": float(np.std(flattened)),
-        "max_abs": float(np.max(np.abs(flattened))),
-    }
-
-
-def _network_layers(model) -> pd.DataFrame:
-    if nn is None:
-        return _empty_network_layers()
-    linear_layers = [layer for layer in model if isinstance(layer, nn.Linear)]
-    rows: list[dict[str, Any]] = []
-    for index, layer in enumerate(linear_layers):
-        weight = layer.weight.detach().cpu().numpy()
-        bias = layer.bias.detach().cpu().numpy() if layer.bias is not None else np.array([], dtype=float)
-        weight_stats = _array_stats(weight)
-        bias_stats = _array_stats(bias)
-        rows.append(
-            {
-                "layer": index + 1,
-                "kind": "output" if index == len(linear_layers) - 1 else "hidden",
-                "input_features": int(layer.in_features),
-                "output_features": int(layer.out_features),
-                "parameters": int(weight.size + bias.size),
-                "weight_mean": weight_stats["mean"],
-                "weight_std": weight_stats["std"],
-                "weight_max_abs": weight_stats["max_abs"],
-                "bias_mean": bias_stats["mean"],
-                "bias_std": bias_stats["std"],
-                "bias_max_abs": bias_stats["max_abs"],
-            }
-        )
-    return pd.DataFrame(rows, columns=_empty_network_layers().columns)
-
-
-def _grid_points(config: PlaygroundConfig) -> pd.DataFrame:
-    axis = np.linspace(-1.35, 1.35, max(12, int(config.grid_size)))
-    xx, yy = np.meshgrid(axis, axis)
-    return pd.DataFrame({"x1": xx.ravel(), "x2": yy.ravel()})
-
-
-def _hidden_activation_maps(
-    model,
-    config: PlaygroundConfig,
-    mean: np.ndarray,
-    std: np.ndarray,
-    *,
-    max_neurons: int = 8,
-) -> pd.DataFrame:
-    if torch is None or nn is None or not config.hidden_layers:
-        return _empty_activation_maps()
-
-    grid_points = _grid_points(config)
-    grid_features = (_feature_matrix(grid_points, config.feature_names) - mean) / std
-    activation_frames: list[pd.DataFrame] = []
-    hidden_layer_index = 0
-    pending_hidden_layer = False
-
-    model.eval()
-    with torch.no_grad():
-        values = torch.tensor(grid_features, dtype=torch.float32)
-        for layer in model:
-            values = layer(values)
-            if isinstance(layer, nn.Linear):
-                pending_hidden_layer = hidden_layer_index < len(config.hidden_layers)
-                continue
-            if not pending_hidden_layer:
-                continue
-
-            activations = values.detach().cpu().numpy()
-            neuron_count = min(activations.shape[1], max(1, int(max_neurons)))
-            for neuron_index in range(neuron_count):
-                frame = grid_points.copy()
-                frame.insert(0, "neuron", neuron_index + 1)
-                frame.insert(0, "layer", hidden_layer_index + 1)
-                frame["activation"] = activations[:, neuron_index].astype(float)
-                activation_frames.append(frame)
-            hidden_layer_index += 1
-            pending_hidden_layer = False
-
-    if not activation_frames:
-        return _empty_activation_maps()
-    return pd.concat(activation_frames, ignore_index=True)
-
-
-def _prepare_training_data(config: PlaygroundConfig) -> dict[str, Any]:
-    samples = _make_dataset(config)
-    features = _feature_matrix(samples, config.feature_names)
-    labels = samples["target"].to_numpy(dtype=np.int64)
-    rng = np.random.default_rng(config.seed + 101)
-    indices = rng.permutation(len(labels))
-    train_count = min(len(labels) - 1, max(2, int(round(len(labels) * config.train_ratio))))
-    train_indices = indices[:train_count]
-    validation_indices = indices[train_count:]
-    if len(validation_indices) == 0:
-        validation_indices = train_indices
-
-    mean = features[train_indices].mean(axis=0, keepdims=True)
-    std = features[train_indices].std(axis=0, keepdims=True)
-    std[std < 1e-6] = 1.0
-    features = (features - mean) / std
-
-    x_train = torch.tensor(features[train_indices], dtype=torch.float32)
-    y_train = torch.tensor(labels[train_indices], dtype=torch.long)
-    x_validation = torch.tensor(features[validation_indices], dtype=torch.float32)
-    y_validation = torch.tensor(labels[validation_indices], dtype=torch.long)
-    return {
-        "samples": samples,
-        "features": features,
-        "labels": labels,
-        "train_indices": train_indices,
-        "validation_indices": validation_indices,
-        "mean": mean,
-        "std": std,
-        "x_train": x_train,
-        "y_train": y_train,
-        "x_validation": x_validation,
-        "y_validation": y_validation,
-    }
-
-
-def _classification_metrics(model, loss_fn, x_values, y_values) -> dict[str, float]:
-    logits = model(x_values)
-    loss = loss_fn(logits, y_values).item()
-    accuracy = (logits.argmax(dim=1) == y_values).float().mean().item()
-    return {"loss": float(loss), "accuracy": float(accuracy)}
-
-
-def _fit_model(config: PlaygroundConfig, training_data: Mapping[str, Any]) -> tuple[Any, Any, pd.DataFrame]:
-    features = training_data["features"]
-    x_train = training_data["x_train"]
-    y_train = training_data["y_train"]
-    x_validation = training_data["x_validation"]
-    y_validation = training_data["y_validation"]
-    model = _build_model(features.shape[1], config)
-    loss_fn = nn.CrossEntropyLoss()
-    if config.optimizer == "SGD":
-        optimizer = torch.optim.SGD(model.parameters(), lr=config.learning_rate)
-    else:
-        optimizer = torch.optim.Adam(model.parameters(), lr=config.learning_rate)
-
-    history_rows: list[dict[str, float | int]] = []
-    epochs = max(1, int(config.epochs))
-    batch_size = max(4, min(int(config.batch_size), len(x_train)))
-    log_every = max(1, epochs // 40)
-
-    _append_history_row(history_rows, model, loss_fn, x_train, y_train, x_validation, y_validation, 0)
-    for epoch in range(1, epochs + 1):
-        model.train()
-        batch_order = torch.randperm(len(x_train))
-        for start in range(0, len(x_train), batch_size):
-            batch_indices = batch_order[start : start + batch_size]
-            optimizer.zero_grad()
-            batch_logits = model(x_train[batch_indices])
-            batch_loss = loss_fn(batch_logits, y_train[batch_indices])
-            batch_loss.backward()
-            optimizer.step()
-
-        if epoch == epochs or epoch % log_every == 0:
-            _append_history_row(history_rows, model, loss_fn, x_train, y_train, x_validation, y_validation, epoch)
-
-    return model, loss_fn, pd.DataFrame(history_rows)
-
-
-def _train_playground(config: PlaygroundConfig) -> dict[str, Any]:
-    if torch is None or nn is None:
-        samples = _make_dataset(config)
-        return {
-            "status": "missing_torch",
-            "detail": "Install the app dependencies to enable PyTorch training.",
-            "samples": samples,
-            "history": pd.DataFrame(columns=["epoch", "train_loss", "validation_loss", "train_accuracy", "validation_accuracy"]),
-            "grid": pd.DataFrame(columns=["x1", "x2", "probability"]),
-            "network_layers": _empty_network_layers(),
-            "activation_maps": _empty_activation_maps(),
-            "summary": {
-                "backend": "missing",
-                "samples": int(len(samples)),
-                "features": int(len(config.feature_names)),
-            },
-        }
-
-    torch.manual_seed(config.seed)
-    training_data = _prepare_training_data(config)
-    samples = training_data["samples"]
-    features = training_data["features"]
-    mean = training_data["mean"]
-    std = training_data["std"]
-    model, _loss_fn, history = _fit_model(config, training_data)
-    grid = _decision_grid(model, config, mean, std)
-    network_layers = _network_layers(model)
-    activation_maps = _hidden_activation_maps(model, config, mean, std)
-    final = history.iloc[-1].to_dict() if not history.empty else {}
-    return {
-        "status": "ok",
-        "detail": "",
-        "samples": samples,
-        "history": history,
-        "grid": grid,
-        "network_layers": network_layers,
-        "activation_maps": activation_maps,
-        "summary": {
-            "backend": "torch",
-            "samples": int(len(samples)),
-            "features": int(features.shape[1]),
-            "hidden_layers": list(config.hidden_layers),
-            "train_accuracy": float(final.get("train_accuracy", 0.0)),
-            "validation_accuracy": float(final.get("validation_accuracy", 0.0)),
-            "validation_loss": float(final.get("validation_loss", 0.0)),
-        },
-    }
-
-
-def _append_history_row(
-    rows: list[dict[str, float | int]],
-    model,
-    loss_fn,
-    x_train,
-    y_train,
-    x_validation,
-    y_validation,
-    epoch: int,
-) -> None:
-    model.eval()
-    with torch.no_grad():
-        train_metrics = _classification_metrics(model, loss_fn, x_train, y_train)
-        validation_metrics = _classification_metrics(model, loss_fn, x_validation, y_validation)
-    rows.append(
-        {
-            "epoch": int(epoch),
-            "train_loss": train_metrics["loss"],
-            "validation_loss": validation_metrics["loss"],
-            "train_accuracy": train_metrics["accuracy"],
-            "validation_accuracy": validation_metrics["accuracy"],
-        }
-    )
-
-
-def _decision_grid(model, config: PlaygroundConfig, mean: np.ndarray, std: np.ndarray) -> pd.DataFrame:
-    grid_points = _grid_points(config)
-    grid_features = (_feature_matrix(grid_points, config.feature_names) - mean) / std
-    model.eval()
-    with torch.no_grad():
-        logits = model(torch.tensor(grid_features, dtype=torch.float32))
-        probabilities = torch.softmax(logits, dim=1)[:, 1].cpu().numpy()
-    grid_points["probability"] = probabilities.astype(float)
-    return grid_points
-
-
-def _model_state_vector(model):
-    return torch.cat([parameter.detach().flatten().cpu() for parameter in model.parameters()])
-
-
-def _assign_model_state_vector(model, vector) -> None:
-    offset = 0
-    for parameter in model.parameters():
-        item_count = parameter.numel()
-        values = vector[offset : offset + item_count].reshape(parameter.shape).to(parameter.device, dtype=parameter.dtype)
-        parameter.data.copy_(values)
-        offset += item_count
-
-
-def _landscape_directions(center, seed: int) -> tuple[Any, Any]:
-    generator = torch.Generator()
-    generator.manual_seed(int(seed) + 7001)
-    first = torch.randn(center.shape, generator=generator, dtype=center.dtype)
-    second = torch.randn(center.shape, generator=generator, dtype=center.dtype)
-    first_norm = first.norm().clamp_min(1e-12)
-    first = first / first_norm
-    second = second - torch.dot(second, first) * first
-    second_norm = second.norm().clamp_min(1e-12)
-    second = second / second_norm
-    scale = center.norm().clamp_min(1.0)
-    return first * scale, second * scale
-
-
-def _normalized_landscape_resolution(value: int) -> int:
-    resolution = max(5, min(31, int(value)))
-    if resolution % 2 == 0:
-        resolution += 1
-    return resolution
-
-
-def _loss_landscape_summary(landscape: pd.DataFrame) -> dict[str, Any]:
-    if landscape.empty:
-        return {"status": "not_computed", "points": 0}
-    center_candidates = landscape[landscape["is_center"]]
-    center = center_candidates.iloc[0] if not center_candidates.empty else landscape.iloc[len(landscape) // 2]
-    best = landscape.loc[landscape["validation_loss"].idxmin()]
-    max_validation_loss = float(landscape["validation_loss"].max())
-    center_loss = float(center["validation_loss"])
-    return {
-        "status": "ok",
-        "points": int(len(landscape)),
-        "center_validation_loss": center_loss,
-        "center_train_loss": float(center["train_loss"]),
-        "center_validation_accuracy": float(center["validation_accuracy"]),
-        "best_validation_loss": float(best["validation_loss"]),
-        "best_alpha": float(best["alpha"]),
-        "best_beta": float(best["beta"]),
-        "best_delta": float(best["validation_loss"] - center_loss),
-        "sharpness": float(max(0.0, max_validation_loss - center_loss)),
-    }
-
-
-def _loss_landscape(config: PlaygroundConfig, *, resolution: int = 21, span: float = 0.75) -> dict[str, Any]:
-    if torch is None or nn is None:
-        return {
-            "status": "missing_torch",
-            "detail": "Install the app dependencies to enable the loss landscape.",
-            "loss_landscape": _empty_loss_landscape(),
-            "landscape_summary": _loss_landscape_summary(_empty_loss_landscape()),
-        }
-
-    torch.manual_seed(config.seed)
-    training_data = _prepare_training_data(config)
-    model, loss_fn, _history = _fit_model(config, training_data)
-    center = _model_state_vector(model)
-    first_direction, second_direction = _landscape_directions(center, config.seed)
-    resolution = _normalized_landscape_resolution(resolution)
-    span = max(0.05, min(2.0, float(span)))
-    axis = np.linspace(-span, span, resolution)
-    rows: list[dict[str, float | bool]] = []
-
-    try:
-        model.eval()
-        with torch.no_grad():
-            for alpha in axis:
-                for beta in axis:
-                    candidate = center + float(alpha) * first_direction + float(beta) * second_direction
-                    _assign_model_state_vector(model, candidate)
-                    train_metrics = _classification_metrics(model, loss_fn, training_data["x_train"], training_data["y_train"])
-                    validation_metrics = _classification_metrics(
-                        model,
-                        loss_fn,
-                        training_data["x_validation"],
-                        training_data["y_validation"],
-                    )
-                    rows.append(
-                        {
-                            "alpha": float(alpha),
-                            "beta": float(beta),
-                            "train_loss": train_metrics["loss"],
-                            "validation_loss": validation_metrics["loss"],
-                            "train_accuracy": train_metrics["accuracy"],
-                            "validation_accuracy": validation_metrics["accuracy"],
-                            "is_center": bool(np.isclose(alpha, 0.0) and np.isclose(beta, 0.0)),
-                        }
-                    )
-    finally:
-        _assign_model_state_vector(model, center)
-
-    landscape = pd.DataFrame(rows, columns=_empty_loss_landscape().columns)
-    return {
-        "status": "ok",
-        "detail": "",
-        "loss_landscape": landscape,
-        "landscape_summary": _loss_landscape_summary(landscape),
-    }
-
-
 @st.cache_data(show_spinner=False)
 def _cached_train(payload: dict[str, Any]) -> dict[str, Any]:
     config = PlaygroundConfig(
@@ -971,123 +292,18 @@ def _cached_loss_landscape(payload: dict[str, Any], resolution: int, span: float
     return _loss_landscape(config, resolution=resolution, span=span)
 
 
-def _json_safe(value: Any) -> Any:
-    if isinstance(value, Mapping):
-        return {str(key): _json_safe(item) for key, item in value.items()}
-    if isinstance(value, (list, tuple)):
-        return [_json_safe(item) for item in value]
-    if isinstance(value, np.integer):
-        return int(value)
-    if isinstance(value, np.floating):
-        number = float(value)
-        return number if np.isfinite(number) else None
-    if isinstance(value, float):
-        return value if np.isfinite(value) else None
-    return value
-
-
-def _json_bytes(payload: Mapping[str, Any]) -> bytes:
-    return json.dumps(_json_safe(payload), indent=2, sort_keys=True).encode("utf-8") + b"\n"
-
-
-def _dataframe_csv_bytes(frame: pd.DataFrame) -> bytes:
-    return frame.to_csv(index=False, float_format="%.10g").encode("utf-8")
-
-
-def _artifact_hash(payload: bytes) -> dict[str, Any]:
-    return {"sha256": hashlib.sha256(payload).hexdigest(), "bytes": len(payload)}
-
-
-def _result_frame(result: Mapping[str, Any], key: str, empty: pd.DataFrame) -> pd.DataFrame:
-    value = result.get(key)
-    return value if isinstance(value, pd.DataFrame) else empty
-
-
-def _evidence_artifact_files(config: PlaygroundConfig, result: Mapping[str, Any]) -> dict[str, bytes]:
-    samples = _result_frame(result, "samples", pd.DataFrame(columns=["x1", "x2", "target"]))
-    history = _result_frame(result, "history", pd.DataFrame(columns=["epoch", "train_loss", "validation_loss", "train_accuracy", "validation_accuracy"]))
-    grid = _result_frame(result, "grid", pd.DataFrame(columns=["x1", "x2", "probability"]))
-    network_layers = _result_frame(result, "network_layers", _empty_network_layers())
-    activation_maps = _result_frame(result, "activation_maps", _empty_activation_maps())
-    loss_landscape = _result_frame(result, "loss_landscape", _empty_loss_landscape())
-    return {
-        "config/playground_config.json": _json_bytes(_config_payload(config)),
-        "data/samples.csv": _dataframe_csv_bytes(samples),
-        "data/training_history.csv": _dataframe_csv_bytes(history),
-        "data/decision_grid.csv": _dataframe_csv_bytes(grid),
-        "model/network_layers.csv": _dataframe_csv_bytes(network_layers),
-        "model/hidden_activation_maps.csv": _dataframe_csv_bytes(activation_maps),
-        "model/loss_landscape.csv": _dataframe_csv_bytes(loss_landscape),
-        "summary/run_summary.json": _json_bytes(
-            {
-                "schema": EVIDENCE_SCHEMA,
-                "summary": result.get("summary", {}),
-                "landscape_summary": result.get("landscape_summary", _loss_landscape_summary(loss_landscape)),
-            }
-        ),
-    }
-
-
-def _build_evidence_manifest(config: PlaygroundConfig, result: Mapping[str, Any]) -> dict[str, Any]:
-    files = _evidence_artifact_files(config, result)
-    samples = _result_frame(result, "samples", pd.DataFrame())
-    history = _result_frame(result, "history", pd.DataFrame())
-    grid = _result_frame(result, "grid", pd.DataFrame())
-    network_layers = _result_frame(result, "network_layers", _empty_network_layers())
-    activation_maps = _result_frame(result, "activation_maps", _empty_activation_maps())
-    loss_landscape = _result_frame(result, "loss_landscape", _empty_loss_landscape())
-    return {
-        "schema": EVIDENCE_SCHEMA,
-        "config_schema": CONFIG_SCHEMA,
-        "app": "pytorch_playground_project",
-        "backend": result.get("summary", {}).get("backend", "unknown"),
-        "torch_version": getattr(torch, "__version__", None) if torch is not None else None,
-        "config": _config_payload(config)["config"],
-        "summary": result.get("summary", {}),
-        "landscape_summary": result.get("landscape_summary", _loss_landscape_summary(loss_landscape)),
-        "row_counts": {
-            "samples": int(len(samples)),
-            "training_history": int(len(history)),
-            "decision_grid": int(len(grid)),
-            "network_layers": int(len(network_layers)),
-            "hidden_activation_maps": int(len(activation_maps)),
-            "loss_landscape": int(len(loss_landscape)),
-        },
-        "artifacts": {name: _artifact_hash(payload) for name, payload in sorted(files.items())},
-    }
-
-
-def _deterministic_zip_bytes(files: Mapping[str, bytes]) -> bytes:
-    buffer = io.BytesIO()
-    with zipfile.ZipFile(buffer, mode="w", compression=zipfile.ZIP_DEFLATED) as archive:
-        for name in sorted(files):
-            info = zipfile.ZipInfo(name, ZIP_TIMESTAMP)
-            info.compress_type = zipfile.ZIP_DEFLATED
-            info.external_attr = 0o644 << 16
-            archive.writestr(info, files[name])
-    return buffer.getvalue()
-
-
-def _build_evidence_pack(config: PlaygroundConfig, result: Mapping[str, Any]) -> bytes:
-    files = _evidence_artifact_files(config, result)
-    files["manifest.json"] = _json_bytes(_build_evidence_manifest(config, result))
-    return _deterministic_zip_bytes(files)
-
-
 def _render_page_styles() -> None:
     st.markdown(
         """
 <style>
 .agilab-pt-hero {
-  border: 1px solid rgba(125, 211, 252, 0.22);
-  border-radius: 28px;
-  padding: 1.45rem 1.55rem;
+  border: 1px solid rgba(125, 211, 252, 0.24);
+  border-left: 4px solid #38bdf8;
+  border-radius: 8px;
+  padding: 1rem 1.1rem;
   margin: 0.25rem 0 1rem;
-  background:
-    radial-gradient(circle at 12% 10%, rgba(56, 189, 248, 0.34), transparent 28%),
-    radial-gradient(circle at 84% 18%, rgba(251, 113, 133, 0.28), transparent 30%),
-    linear-gradient(135deg, rgba(8, 18, 34, 0.96), rgba(15, 23, 42, 0.90));
-  box-shadow: 0 24px 70px rgba(2, 6, 23, 0.28);
+  background: rgba(12, 18, 32, 0.92);
+  box-shadow: 0 12px 32px rgba(2, 6, 23, 0.22);
 }
 .agilab-pt-kicker {
   color: #7dd3fc;
@@ -1098,9 +314,9 @@ def _render_page_styles() -> None:
 }
 .agilab-pt-hero h1 {
   color: #f8fafc;
-  font-size: clamp(2.0rem, 5vw, 4.5rem);
-  line-height: 0.95;
-  margin: 0.25rem 0 0.7rem;
+  font-size: 2.35rem;
+  line-height: 1.05;
+  margin: 0.2rem 0 0.55rem;
 }
 .agilab-pt-hero p {
   color: #cbd5e1;
@@ -1116,18 +332,18 @@ def _render_page_styles() -> None:
 }
 .agilab-pt-chip {
   border: 1px solid rgba(226, 232, 240, 0.22);
-  border-radius: 999px;
+  border-radius: 8px;
   color: #e2e8f0;
   background: rgba(15, 23, 42, 0.55);
-  padding: 0.38rem 0.72rem;
+  padding: 0.34rem 0.58rem;
   font-size: 0.82rem;
 }
 .agilab-pt-card {
   border: 1px solid rgba(148, 163, 184, 0.22);
-  border-radius: 22px;
+  border-radius: 8px;
   padding: 1rem;
   min-height: 9.25rem;
-  background: linear-gradient(180deg, rgba(15, 23, 42, 0.88), rgba(8, 13, 26, 0.78));
+  background: rgba(11, 18, 32, 0.84);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
 }
 .agilab-pt-card strong {
@@ -1166,13 +382,13 @@ def _render_page_styles() -> None:
 }
 .agilab-pt-step {
   border: 1px solid rgba(148, 163, 184, 0.20);
-  border-radius: 18px;
+  border-radius: 8px;
   padding: 0.85rem 0.9rem;
   background: rgba(15, 23, 42, 0.58);
 }
 .agilab-pt-step-active {
   border-color: rgba(251, 191, 36, 0.64);
-  background: linear-gradient(180deg, rgba(120, 53, 15, 0.55), rgba(15, 23, 42, 0.62));
+  background: rgba(88, 55, 16, 0.38);
 }
 .agilab-pt-step-ready {
   border-color: rgba(34, 197, 94, 0.46);
@@ -1187,7 +403,7 @@ def _render_page_styles() -> None:
 }
 .agilab-pt-insight {
   border: 1px solid rgba(125, 211, 252, 0.18);
-  border-radius: 18px;
+  border-radius: 8px;
   padding: 0.9rem;
   background: rgba(8, 13, 26, 0.66);
   min-height: 7rem;
@@ -1881,7 +1097,7 @@ def main() -> None:
             mime="application/zip",
         )
         st.code(f"?pytorch_playground={_encode_share_config(trained_config)}", language="text")
-        st.json(manifest)
+        st.code(json.dumps(_json_safe(manifest), indent=2, sort_keys=True), language="json")
 
 
 if __name__ == "__main__":

--- a/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/pytorch_playground.py
+++ b/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/pytorch_playground.py
@@ -59,7 +59,13 @@ class PytorchPlayground(BaseWorker):
     @property
     def analysis_artifact_dir(self) -> Path:
         export_root = Path(getattr(self.env, "AGILAB_EXPORT_ABS", Path.home() / "export"))
-        return export_root / self.env.target / "pytorch_playground"
+        target = str(
+            getattr(self.env, "target", "")
+            or getattr(self.env, "app", "")
+            or getattr(self.env, "active_app", "")
+            or "pytorch_playground_project"
+        )
+        return export_root / target / "pytorch_playground"
 
     @classmethod
     def from_toml(
@@ -85,8 +91,12 @@ class PytorchPlayground(BaseWorker):
         return self.args.model_dump(mode="json")
 
     def build_distribution(self, workers):
-        work_plan = [[["pytorch_playground"]]]
-        metadata = [[{"run": "pytorch_playground", "work_items": 1}]]
+        try:
+            worker_count = max(1, int(workers))
+        except (TypeError, ValueError):
+            worker_count = 1
+        work_plan = [[["pytorch_playground"]]] + [[] for _ in range(worker_count - 1)]
+        metadata = [[{"run": "pytorch_playground", "work_items": 1}]] + [[] for _ in range(worker_count - 1)]
         return work_plan, metadata, "run", "work_items", "items"
 
 

--- a/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground_worker/pytorch_playground_worker.py
+++ b/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground_worker/pytorch_playground_worker.py
@@ -14,7 +14,7 @@ import pandas as pd
 from agi_node.agi_dispatcher import BaseWorker
 from agi_node.pandas_worker import PandasWorker
 from pytorch_playground import PytorchPlaygroundArgs, to_playground_config
-from pytorch_playground.playground_ui import (
+from pytorch_playground.core import (
     _build_evidence_manifest,
     _build_evidence_pack,
     _evidence_artifact_files,
@@ -75,7 +75,7 @@ class PytorchPlaygroundWorker(PandasWorker):
         self.args.data_out = data_out
         self.data_out = data_out
         if self.args.reset_target and self.data_out.exists():
-            shutil.rmtree(self.data_out)
+            shutil.rmtree(self.data_out, ignore_errors=True)
         self.data_out.mkdir(parents=True, exist_ok=True)
         self.artifact_dir = _artifact_dir(self.env, "pytorch_playground")
         self.artifact_dir.mkdir(parents=True, exist_ok=True)

--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/app_args_form.py
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/app_args_form.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 import sys
+from typing import Any
 
 import streamlit as st
 from pydantic import ValidationError
@@ -10,8 +12,11 @@ _HERE = Path(__file__).resolve().parent
 if str(_HERE) not in sys.path:
     sys.path.insert(0, str(_HERE))
 
-from agi_env.streamlit_args import load_args_state, persist_args, render_form
+from agi_env.streamlit_args import load_args_state, persist_args
 from pytorch_playground import app_args
+from pytorch_playground.core import ACTIVATIONS, DATASETS, FEATURES, OPTIMIZERS, _coerce_feature_names
+
+APP_FORM_ID = "pytorch_playground_args"
 
 
 def _get_env():
@@ -22,10 +27,93 @@ def _get_env():
     return env
 
 
+def _project_key(env: Any) -> str:
+    return str(
+        getattr(env, "active_app", "")
+        or getattr(env, "app", "")
+        or getattr(env, "target", "")
+        or "pytorch_playground_project"
+    )
+
+
+def _field_key(env: Any, name: str) -> str:
+    return f"{APP_FORM_ID}:{_project_key(env)}:{name}"
+
+
+def _seed_widget_value(key: str, value: Any) -> None:
+    if key not in st.session_state:
+        st.session_state[key] = value
+
+
+def _text_input(container: Any, env: Any, name: str, label: str, value: Any) -> str:
+    key = _field_key(env, name)
+    _seed_widget_value(key, str(value))
+    return str(container.text_input(label, key=key))
+
+
+def _checkbox(container: Any, env: Any, name: str, label: str, value: bool) -> bool:
+    key = _field_key(env, name)
+    _seed_widget_value(key, bool(value))
+    return bool(container.checkbox(label, key=key))
+
+
+def _number_input(
+    container: Any,
+    env: Any,
+    name: str,
+    label: str,
+    value: int | float,
+    *,
+    min_value: int | float,
+    max_value: int | float,
+    step: int | float,
+) -> int | float:
+    key = _field_key(env, name)
+    _seed_widget_value(key, value)
+    return container.number_input(label, min_value=min_value, max_value=max_value, step=step, key=key)
+
+
+def _selectbox(container: Any, env: Any, name: str, label: str, options: tuple[str, ...], value: str) -> str:
+    key = _field_key(env, name)
+    _seed_widget_value(key, value if value in options else options[0])
+    return str(container.selectbox(label, options=options, key=key))
+
+
+def _feature_names(container: Any, env: Any, value: str) -> str:
+    key = _field_key(env, "feature_names")
+    _seed_widget_value(key, list(_coerce_feature_names(value)))
+    selected = container.multiselect("Feature names", options=list(FEATURES), key=key)
+    return ",".join(str(item) for item in selected) if selected else app_args.DEFAULT_FEATURE_NAMES
+
+
+def _render_args_form(model: app_args.PytorchPlaygroundArgs, *, env: Any, container: Any) -> dict[str, Any]:
+    return {
+        "data_out": _text_input(container, env, "data_out", "Data out", model.data_out),
+        "dataset": _selectbox(container, env, "dataset", "Dataset", DATASETS, model.dataset),
+        "sample_count": _number_input(container, env, "sample_count", "Sample count", model.sample_count, min_value=64, max_value=1000, step=16),
+        "noise": _number_input(container, env, "noise", "Noise", model.noise, min_value=0.0, max_value=0.5, step=0.01),
+        "train_ratio": _number_input(container, env, "train_ratio", "Train ratio", model.train_ratio, min_value=0.5, max_value=0.95, step=0.05),
+        "hidden_layers": _text_input(container, env, "hidden_layers", "Hidden layers", model.hidden_layers),
+        "activation": _selectbox(container, env, "activation", "Activation", ACTIVATIONS, model.activation),
+        "optimizer": _selectbox(container, env, "optimizer", "Optimizer", OPTIMIZERS, model.optimizer),
+        "learning_rate": _number_input(container, env, "learning_rate", "Learning rate", model.learning_rate, min_value=0.001, max_value=0.2, step=0.001),
+        "epochs": _number_input(container, env, "epochs", "Epochs", model.epochs, min_value=10, max_value=300, step=10),
+        "batch_size": _number_input(container, env, "batch_size", "Batch size", model.batch_size, min_value=8, max_value=256, step=8),
+        "seed": _number_input(container, env, "seed", "Seed", model.seed, min_value=0, max_value=9999, step=1),
+        "feature_names": _feature_names(container, env, model.feature_names),
+        "grid_size": _number_input(container, env, "grid_size", "Grid size", model.grid_size, min_value=12, max_value=120, step=4),
+        "compute_loss_landscape": _checkbox(container, env, "compute_loss_landscape", "Compute loss landscape", model.compute_loss_landscape),
+        "landscape_resolution": _number_input(container, env, "landscape_resolution", "Landscape resolution", model.landscape_resolution, min_value=5, max_value=31, step=2),
+        "landscape_span": _number_input(container, env, "landscape_span", "Landscape span", model.landscape_span, min_value=0.1, max_value=1.5, step=0.05),
+        "reset_target": _checkbox(container, env, "reset_target", "Reset target", model.reset_target),
+    }
+
+
 env = _get_env()
 defaults_model, defaults_payload, settings_path = load_args_state(env, args_module=app_args)
 
-artifact_root = Path(getattr(env, "AGILAB_EXPORT_ABS", Path.home() / "export")) / env.target / "pytorch_playground"
+artifact_target = str(getattr(env, "target", "") or getattr(env, "app", "") or "pytorch_playground_project")
+artifact_root = Path(getattr(env, "AGILAB_EXPORT_ABS", Path.home() / "export")) / artifact_target / "pytorch_playground"
 
 st.caption(
     "PyTorch Playground is an executable app: ORCHESTRATE runs the configured "
@@ -36,7 +124,7 @@ st.caption(f"Analysis artifacts are exported to `{artifact_root}`.")
 with st.sidebar:
     st.markdown("### PyTorch Playground")
     st.caption("These fields are persisted as app arguments.")
-    form_values = render_form(defaults_model, container=st.sidebar)
+    form_values = _render_args_form(defaults_model, env=env, container=st.sidebar)
 
 try:
     parsed = app_args.ensure_defaults(app_args.ArgsModel(**form_values), env=env)
@@ -54,13 +142,18 @@ else:
             settings_path=settings_path,
             defaults_payload=defaults_payload,
         )
-        st.json(
-            {
-                "dataset": config.dataset,
-                "samples": config.sample_count,
-                "features": list(config.feature_names),
-                "hidden_layers": list(config.hidden_layers),
-                "epochs": config.epochs,
-                "loss_landscape": parsed.compute_loss_landscape,
-            }
+        st.code(
+            json.dumps(
+                {
+                    "dataset": config.dataset,
+                    "samples": config.sample_count,
+                    "features": list(config.feature_names),
+                    "hidden_layers": list(config.hidden_layers),
+                    "epochs": config.epochs,
+                    "loss_landscape": parsed.compute_loss_landscape,
+                },
+                indent=2,
+                sort_keys=True,
+            ),
+            language="json",
         )

--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/app_settings.toml
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/app_settings.toml
@@ -28,7 +28,7 @@ scheduler = "127.0.0.1:8786"
 workers_data_path = ""
 
 [cluster.workers]
-"127.0.0.1" = 2
+"127.0.0.1" = 1
 
 [cluster.service_health]
 allow_idle = false

--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground/app_args.py
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground/app_args.py
@@ -102,7 +102,7 @@ def ensure_defaults(args: PytorchPlaygroundArgs, **_: Any) -> PytorchPlaygroundA
 
 
 def to_playground_config(args: PytorchPlaygroundArgs):
-    from .playground_ui import PlaygroundConfig, _coerce_feature_names, _parse_hidden_layers
+    from .core import PlaygroundConfig, _coerce_feature_names, _parse_hidden_layers
 
     return PlaygroundConfig(
         dataset=args.dataset,

--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground/core.py
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground/core.py
@@ -1,0 +1,946 @@
+# BSD 3-Clause License
+#
+# Copyright (c) 2026, Jean-Pierre Morard, THALES SIX GTS France SAS
+
+"""UI-independent PyTorch playground training and evidence primitives."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import binascii
+import hashlib
+import io
+import json
+import re
+import zipfile
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+try:  # pragma: no cover - exercised conditionally in environments with torch
+    import torch
+    from torch import nn
+except Exception:  # pragma: no cover - lightweight environments may omit torch
+    torch = None  # type: ignore[assignment]
+    nn = None  # type: ignore[assignment]
+
+DATASETS = ("circles", "xor", "spiral", "gaussian")
+FEATURES = (
+    "x1",
+    "x2",
+    "x1_squared",
+    "x2_squared",
+    "x1_x2",
+    "sin_x1",
+    "sin_x2",
+)
+DEFAULT_FEATURES = ("x1", "x2", "x1_squared", "x2_squared", "x1_x2")
+ACTIVATIONS = ("tanh", "relu", "sigmoid", "identity")
+OPTIMIZERS = ("Adam", "SGD")
+CONFIG_SCHEMA = "agilab.pytorch_playground_config.v1"
+EVIDENCE_SCHEMA = "agilab.pytorch_playground_evidence.v1"
+ZIP_TIMESTAMP = (2026, 1, 1, 0, 0, 0)
+CUSTOM_PRESET = "Custom / shared link"
+DEFAULT_PRESET = "Instant wow: clean circles"
+TRAINED_CONFIG_STATE_KEY = "pytorch_playground_trained_config"
+TRAINED_PRESET_STATE_KEY = "pytorch_playground_trained_preset"
+SHARED_CONFIG_SIGNATURE_STATE_KEY = "pytorch_playground_shared_signature"
+
+
+class _FallbackPlotlyFigure(dict):
+    @property
+    def data(self) -> tuple[object, ...]:
+        return tuple(self.get("data", ()))
+
+
+def _plotly_unavailable_figure(kind: str, trace_count: int = 0) -> _FallbackPlotlyFigure:
+    return _FallbackPlotlyFigure(
+        {
+            "data": [{"type": "scatter", "x": [], "y": []} for _ in range(max(0, int(trace_count)))],
+            "layout": {
+                "title": f"{kind} chart unavailable",
+                "template": "plotly_dark",
+            },
+        }
+    )
+
+
+@dataclass(frozen=True)
+class PlaygroundConfig:
+    dataset: str = "circles"
+    sample_count: int = 256
+    noise: float = 0.12
+    train_ratio: float = 0.75
+    hidden_layers: tuple[int, ...] = (8, 8)
+    activation: str = "tanh"
+    optimizer: str = "Adam"
+    learning_rate: float = 0.03
+    epochs: int = 80
+    batch_size: int = 32
+    seed: int = 7
+    feature_names: tuple[str, ...] = DEFAULT_FEATURES
+    grid_size: int = 80
+
+
+PLAYGROUND_PRESETS: dict[str, PlaygroundConfig] = {
+    CUSTOM_PRESET: PlaygroundConfig(),
+    "Instant wow: clean circles": PlaygroundConfig(
+        dataset="circles",
+        sample_count=320,
+        noise=0.08,
+        hidden_layers=(12, 12),
+        learning_rate=0.035,
+        epochs=90,
+        grid_size=88,
+        seed=11,
+    ),
+    "Feature puzzle: XOR": PlaygroundConfig(
+        dataset="xor",
+        sample_count=352,
+        noise=0.06,
+        hidden_layers=(16, 8),
+        activation="relu",
+        learning_rate=0.025,
+        epochs=120,
+        feature_names=("x1", "x2", "x1_x2", "x1_squared", "x2_squared"),
+        grid_size=84,
+        seed=19,
+    ),
+    "Hard mode: spiral": PlaygroundConfig(
+        dataset="spiral",
+        sample_count=448,
+        noise=0.10,
+        hidden_layers=(24, 16, 8),
+        activation="tanh",
+        learning_rate=0.02,
+        epochs=160,
+        batch_size=48,
+        feature_names=("x1", "x2", "sin_x1", "sin_x2", "x1_x2"),
+        grid_size=96,
+        seed=29,
+    ),
+    "Fast baseline: gaussian": PlaygroundConfig(
+        dataset="gaussian",
+        sample_count=256,
+        noise=0.14,
+        hidden_layers=(6,),
+        learning_rate=0.04,
+        epochs=60,
+        feature_names=("x1", "x2"),
+        grid_size=72,
+        seed=5,
+    ),
+}
+
+PRESET_STORIES: dict[str, str] = {
+    CUSTOM_PRESET: "Use the current controls, or open a shared configuration token.",
+    "Instant wow: clean circles": "A compact nonlinear boundary that should become visibly crisp in one run.",
+    "Feature puzzle: XOR": "Shows why engineered features and hidden layers matter.",
+    "Hard mode: spiral": "A harder visual challenge for seeing capacity, noise, and loss terrain.",
+    "Fast baseline: gaussian": "A quick sanity check where a tiny network should separate the classes.",
+}
+
+
+def _resolve_active_app() -> Path | None:
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--active-app", dest="active_app", type=str)
+    args, _ = parser.parse_known_args()
+    if not args.active_app:
+        return None
+    active_app = Path(args.active_app).expanduser().resolve()
+    return active_app if active_app.exists() else None
+
+
+def _parse_hidden_layers(raw: str) -> tuple[int, ...]:
+    cleaned = raw.strip()
+    if not cleaned:
+        return ()
+    values: list[int] = []
+    for token in re.split(r"[,\s;]+", cleaned):
+        if not token:
+            continue
+        try:
+            width = int(token)
+        except ValueError as exc:
+            raise ValueError(f"Hidden layer width must be an integer: {token}") from exc
+        if width < 1 or width > 256:
+            raise ValueError("Hidden layer widths must be between 1 and 256.")
+        values.append(width)
+    if len(values) > 6:
+        raise ValueError("Use at most six hidden layers.")
+    return tuple(values)
+
+
+def _bounded_int(value: Any, *, default: int, minimum: int, maximum: int) -> int:
+    try:
+        number = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(minimum, min(maximum, number))
+
+
+def _bounded_float(value: Any, *, default: float, minimum: float, maximum: float) -> float:
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return default
+    if not np.isfinite(number):
+        return default
+    return float(max(minimum, min(maximum, number)))
+
+
+def _coerce_hidden_layers(value: Any, default: tuple[int, ...] = (8, 8)) -> tuple[int, ...]:
+    if isinstance(value, str):
+        try:
+            return _parse_hidden_layers(value)
+        except ValueError:
+            return default
+    if isinstance(value, (list, tuple)):
+        try:
+            return _parse_hidden_layers(",".join(str(item) for item in value))
+        except ValueError:
+            return default
+    return default
+
+
+def _coerce_feature_names(value: Any, default: tuple[str, ...] = DEFAULT_FEATURES) -> tuple[str, ...]:
+    if isinstance(value, str):
+        raw_values = [token.strip() for token in value.split(",")]
+    elif isinstance(value, (list, tuple)):
+        raw_values = [str(token).strip() for token in value]
+    else:
+        raw_values = list(default)
+    selected = tuple(name for name in raw_values if name in FEATURES)
+    return selected or default
+
+
+def _config_payload(config: PlaygroundConfig) -> dict[str, Any]:
+    payload = asdict(config)
+    payload["hidden_layers"] = list(config.hidden_layers)
+    payload["feature_names"] = list(config.feature_names)
+    return {"schema": CONFIG_SCHEMA, "config": payload}
+
+
+def _config_from_payload(payload: Mapping[str, Any]) -> PlaygroundConfig:
+    raw_config = payload.get("config", payload)
+    if not isinstance(raw_config, Mapping):
+        raw_config = {}
+    default = PlaygroundConfig()
+    dataset = str(raw_config.get("dataset", default.dataset))
+    activation = str(raw_config.get("activation", default.activation))
+    optimizer = str(raw_config.get("optimizer", default.optimizer))
+    return PlaygroundConfig(
+        dataset=dataset if dataset in DATASETS else default.dataset,
+        sample_count=_bounded_int(raw_config.get("sample_count"), default=default.sample_count, minimum=64, maximum=1000),
+        noise=_bounded_float(raw_config.get("noise"), default=default.noise, minimum=0.0, maximum=0.5),
+        train_ratio=_bounded_float(raw_config.get("train_ratio"), default=default.train_ratio, minimum=0.5, maximum=0.95),
+        hidden_layers=_coerce_hidden_layers(raw_config.get("hidden_layers"), default.hidden_layers),
+        activation=activation if activation in ACTIVATIONS else default.activation,
+        optimizer=optimizer if optimizer in OPTIMIZERS else default.optimizer,
+        learning_rate=_bounded_float(raw_config.get("learning_rate"), default=default.learning_rate, minimum=0.001, maximum=0.2),
+        epochs=_bounded_int(raw_config.get("epochs"), default=default.epochs, minimum=10, maximum=300),
+        batch_size=_bounded_int(raw_config.get("batch_size"), default=default.batch_size, minimum=8, maximum=256),
+        seed=_bounded_int(raw_config.get("seed"), default=default.seed, minimum=0, maximum=9999),
+        feature_names=_coerce_feature_names(raw_config.get("feature_names"), default.feature_names),
+        grid_size=_bounded_int(raw_config.get("grid_size"), default=default.grid_size, minimum=12, maximum=120),
+    )
+
+
+def _encode_share_config(config: PlaygroundConfig) -> str:
+    raw = json.dumps(_config_payload(config), sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def _decode_share_config(raw: str) -> PlaygroundConfig | None:
+    if not raw:
+        return None
+    try:
+        padding = "=" * (-len(raw) % 4)
+        payload = json.loads(base64.urlsafe_b64decode((raw + padding).encode("ascii")).decode("utf-8"))
+    except (binascii.Error, UnicodeDecodeError, ValueError, TypeError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, Mapping):
+        return None
+    return _config_from_payload(payload)
+
+
+def _first_query_value(value: Any) -> str | None:
+    if isinstance(value, (list, tuple)):
+        if not value:
+            return None
+        value = value[0]
+    if value is None:
+        return None
+    return str(value)
+
+
+def _config_from_query_params(params: Mapping[str, Any]) -> PlaygroundConfig | None:
+    for key in ("pytorch_playground", "config"):
+        token = _first_query_value(params.get(key))
+        decoded = _decode_share_config(token or "")
+        if decoded is not None:
+            return decoded
+    return None
+
+
+def _safe_key_fragment(raw: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "_", raw.lower()).strip("_") or "custom"
+
+
+def _preset_config(label: str, shared_config: PlaygroundConfig | None = None) -> PlaygroundConfig:
+    if label == CUSTOM_PRESET and shared_config is not None:
+        return shared_config
+    return PLAYGROUND_PRESETS.get(label, PLAYGROUND_PRESETS[CUSTOM_PRESET])
+
+
+def _preset_story(label: str, shared_config: PlaygroundConfig | None = None) -> str:
+    if label == CUSTOM_PRESET and shared_config is not None:
+        return "Loaded from the URL token. Adjust any control to fork the experiment."
+    return PRESET_STORIES.get(label, PRESET_STORIES[CUSTOM_PRESET])
+
+
+def _config_state_payload(config: PlaygroundConfig) -> dict[str, Any]:
+    return _config_payload(config)["config"]
+
+
+def _config_signature(config: PlaygroundConfig) -> str:
+    return json.dumps(_config_state_payload(config), sort_keys=True, separators=(",", ":"))
+
+
+def _make_dataset(config: PlaygroundConfig) -> pd.DataFrame:
+    rng = np.random.default_rng(config.seed)
+    count = max(16, int(config.sample_count))
+    dataset = config.dataset if config.dataset in DATASETS else "circles"
+    noise = max(0.0, float(config.noise))
+
+    if dataset == "xor":
+        points = rng.uniform(-1.0, 1.0, size=(count, 2))
+        points += rng.normal(0.0, noise, size=points.shape)
+        labels = (points[:, 0] * points[:, 1] < 0.0).astype(int)
+    elif dataset == "spiral":
+        points, labels = _make_spiral_dataset(rng, count, noise)
+    elif dataset == "gaussian":
+        points, labels = _make_gaussian_dataset(rng, count, noise)
+    else:
+        points, labels = _make_circle_dataset(rng, count, noise)
+
+    order = rng.permutation(len(labels))
+    frame = pd.DataFrame(
+        {
+            "x1": points[order, 0].astype(float),
+            "x2": points[order, 1].astype(float),
+            "target": labels[order].astype(int),
+        }
+    )
+    return frame.reset_index(drop=True)
+
+
+def _make_circle_dataset(
+    rng: np.random.Generator,
+    count: int,
+    noise: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    inner_count = count // 2
+    outer_count = count - inner_count
+    inner_theta = rng.uniform(0.0, 2.0 * np.pi, size=inner_count)
+    outer_theta = rng.uniform(0.0, 2.0 * np.pi, size=outer_count)
+    inner_radius = 0.42 + rng.normal(0.0, noise, size=inner_count)
+    outer_radius = 0.95 + rng.normal(0.0, noise, size=outer_count)
+    inner = np.column_stack((inner_radius * np.cos(inner_theta), inner_radius * np.sin(inner_theta)))
+    outer = np.column_stack((outer_radius * np.cos(outer_theta), outer_radius * np.sin(outer_theta)))
+    points = np.vstack((inner, outer))
+    labels = np.concatenate((np.zeros(inner_count, dtype=int), np.ones(outer_count, dtype=int)))
+    return points, labels
+
+
+def _make_spiral_dataset(
+    rng: np.random.Generator,
+    count: int,
+    noise: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    first_count = count // 2
+    second_count = count - first_count
+    points_by_class: list[np.ndarray] = []
+    labels_by_class: list[np.ndarray] = []
+    for class_id, class_count in enumerate((first_count, second_count)):
+        radius = np.linspace(0.12, 1.0, class_count)
+        theta = class_id * np.pi + 4.2 * radius + rng.normal(0.0, noise * 2.0, size=class_count)
+        points = np.column_stack((radius * np.cos(theta), radius * np.sin(theta)))
+        points += rng.normal(0.0, noise * 0.35, size=points.shape)
+        points_by_class.append(points)
+        labels_by_class.append(np.full(class_count, class_id, dtype=int))
+    return np.vstack(points_by_class), np.concatenate(labels_by_class)
+
+
+def _make_gaussian_dataset(
+    rng: np.random.Generator,
+    count: int,
+    noise: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    first_count = count // 2
+    second_count = count - first_count
+    spread = 0.24 + noise
+    first = rng.normal(loc=(-0.45, -0.25), scale=spread, size=(first_count, 2))
+    second = rng.normal(loc=(0.45, 0.30), scale=spread, size=(second_count, 2))
+    points = np.vstack((first, second))
+    labels = np.concatenate((np.zeros(first_count, dtype=int), np.ones(second_count, dtype=int)))
+    return points, labels
+
+
+def _feature_matrix(samples: pd.DataFrame | np.ndarray, feature_names: tuple[str, ...]) -> np.ndarray:
+    if isinstance(samples, pd.DataFrame):
+        x1 = samples["x1"].to_numpy(dtype=float)
+        x2 = samples["x2"].to_numpy(dtype=float)
+    else:
+        points = np.asarray(samples, dtype=float)
+        x1 = points[:, 0]
+        x2 = points[:, 1]
+
+    values_by_name = {
+        "x1": x1,
+        "x2": x2,
+        "x1_squared": x1**2,
+        "x2_squared": x2**2,
+        "x1_x2": x1 * x2,
+        "sin_x1": np.sin(np.pi * x1),
+        "sin_x2": np.sin(np.pi * x2),
+    }
+    selected = [name for name in feature_names if name in values_by_name]
+    if not selected:
+        selected = ["x1", "x2"]
+    return np.column_stack([values_by_name[name] for name in selected]).astype(np.float32)
+
+
+def _activation_module(name: str):
+    if nn is None:
+        raise RuntimeError("PyTorch is not available.")
+    if name == "relu":
+        return nn.ReLU()
+    if name == "sigmoid":
+        return nn.Sigmoid()
+    if name == "identity":
+        return nn.Identity()
+    return nn.Tanh()
+
+
+def _build_model(input_dim: int, config: PlaygroundConfig):
+    if nn is None:
+        raise RuntimeError("PyTorch is not available.")
+    layers: list[Any] = []
+    previous_dim = input_dim
+    for width in config.hidden_layers:
+        layers.append(nn.Linear(previous_dim, width))
+        layers.append(_activation_module(config.activation))
+        previous_dim = width
+    layers.append(nn.Linear(previous_dim, 2))
+    return nn.Sequential(*layers)
+
+
+def _empty_network_layers() -> pd.DataFrame:
+    return pd.DataFrame(
+        columns=[
+            "layer",
+            "kind",
+            "input_features",
+            "output_features",
+            "parameters",
+            "weight_mean",
+            "weight_std",
+            "weight_max_abs",
+            "bias_mean",
+            "bias_std",
+            "bias_max_abs",
+        ]
+    )
+
+
+def _empty_activation_maps() -> pd.DataFrame:
+    return pd.DataFrame(columns=["layer", "neuron", "x1", "x2", "activation"])
+
+
+def _empty_loss_landscape() -> pd.DataFrame:
+    return pd.DataFrame(
+        columns=[
+            "alpha",
+            "beta",
+            "train_loss",
+            "validation_loss",
+            "train_accuracy",
+            "validation_accuracy",
+            "is_center",
+        ]
+    )
+
+
+def _array_stats(values: np.ndarray) -> dict[str, float]:
+    flattened = np.asarray(values, dtype=float).ravel()
+    if flattened.size == 0:
+        return {"mean": 0.0, "std": 0.0, "max_abs": 0.0}
+    return {
+        "mean": float(np.mean(flattened)),
+        "std": float(np.std(flattened)),
+        "max_abs": float(np.max(np.abs(flattened))),
+    }
+
+
+def _network_layers(model) -> pd.DataFrame:
+    if nn is None:
+        return _empty_network_layers()
+    linear_layers = [layer for layer in model if isinstance(layer, nn.Linear)]
+    rows: list[dict[str, Any]] = []
+    for index, layer in enumerate(linear_layers):
+        weight = layer.weight.detach().cpu().numpy()
+        bias = layer.bias.detach().cpu().numpy() if layer.bias is not None else np.array([], dtype=float)
+        weight_stats = _array_stats(weight)
+        bias_stats = _array_stats(bias)
+        rows.append(
+            {
+                "layer": index + 1,
+                "kind": "output" if index == len(linear_layers) - 1 else "hidden",
+                "input_features": int(layer.in_features),
+                "output_features": int(layer.out_features),
+                "parameters": int(weight.size + bias.size),
+                "weight_mean": weight_stats["mean"],
+                "weight_std": weight_stats["std"],
+                "weight_max_abs": weight_stats["max_abs"],
+                "bias_mean": bias_stats["mean"],
+                "bias_std": bias_stats["std"],
+                "bias_max_abs": bias_stats["max_abs"],
+            }
+        )
+    return pd.DataFrame(rows, columns=_empty_network_layers().columns)
+
+
+def _grid_points(config: PlaygroundConfig) -> pd.DataFrame:
+    axis = np.linspace(-1.35, 1.35, max(12, int(config.grid_size)))
+    xx, yy = np.meshgrid(axis, axis)
+    return pd.DataFrame({"x1": xx.ravel(), "x2": yy.ravel()})
+
+
+def _hidden_activation_maps(
+    model,
+    config: PlaygroundConfig,
+    mean: np.ndarray,
+    std: np.ndarray,
+    *,
+    max_neurons: int = 8,
+) -> pd.DataFrame:
+    if torch is None or nn is None or not config.hidden_layers:
+        return _empty_activation_maps()
+
+    grid_points = _grid_points(config)
+    grid_features = (_feature_matrix(grid_points, config.feature_names) - mean) / std
+    activation_frames: list[pd.DataFrame] = []
+    hidden_layer_index = 0
+    pending_hidden_layer = False
+
+    model.eval()
+    with torch.no_grad():
+        values = torch.tensor(grid_features, dtype=torch.float32)
+        for layer in model:
+            values = layer(values)
+            if isinstance(layer, nn.Linear):
+                pending_hidden_layer = hidden_layer_index < len(config.hidden_layers)
+                continue
+            if not pending_hidden_layer:
+                continue
+
+            activations = values.detach().cpu().numpy()
+            neuron_count = min(activations.shape[1], max(1, int(max_neurons)))
+            for neuron_index in range(neuron_count):
+                frame = grid_points.copy()
+                frame.insert(0, "neuron", neuron_index + 1)
+                frame.insert(0, "layer", hidden_layer_index + 1)
+                frame["activation"] = activations[:, neuron_index].astype(float)
+                activation_frames.append(frame)
+            hidden_layer_index += 1
+            pending_hidden_layer = False
+
+    if not activation_frames:
+        return _empty_activation_maps()
+    return pd.concat(activation_frames, ignore_index=True)
+
+
+def _prepare_training_data(config: PlaygroundConfig) -> dict[str, Any]:
+    samples = _make_dataset(config)
+    features = _feature_matrix(samples, config.feature_names)
+    labels = samples["target"].to_numpy(dtype=np.int64)
+    rng = np.random.default_rng(config.seed + 101)
+    indices = rng.permutation(len(labels))
+    train_count = min(len(labels) - 1, max(2, int(round(len(labels) * config.train_ratio))))
+    train_indices = indices[:train_count]
+    validation_indices = indices[train_count:]
+    if len(validation_indices) == 0:
+        validation_indices = train_indices
+
+    mean = features[train_indices].mean(axis=0, keepdims=True)
+    std = features[train_indices].std(axis=0, keepdims=True)
+    std[std < 1e-6] = 1.0
+    features = (features - mean) / std
+
+    x_train = torch.tensor(features[train_indices], dtype=torch.float32)
+    y_train = torch.tensor(labels[train_indices], dtype=torch.long)
+    x_validation = torch.tensor(features[validation_indices], dtype=torch.float32)
+    y_validation = torch.tensor(labels[validation_indices], dtype=torch.long)
+    return {
+        "samples": samples,
+        "features": features,
+        "labels": labels,
+        "train_indices": train_indices,
+        "validation_indices": validation_indices,
+        "mean": mean,
+        "std": std,
+        "x_train": x_train,
+        "y_train": y_train,
+        "x_validation": x_validation,
+        "y_validation": y_validation,
+    }
+
+
+def _classification_metrics(model, loss_fn, x_values, y_values) -> dict[str, float]:
+    logits = model(x_values)
+    loss = loss_fn(logits, y_values).item()
+    accuracy = (logits.argmax(dim=1) == y_values).float().mean().item()
+    return {"loss": float(loss), "accuracy": float(accuracy)}
+
+
+def _fit_model(config: PlaygroundConfig, training_data: Mapping[str, Any]) -> tuple[Any, Any, pd.DataFrame]:
+    features = training_data["features"]
+    x_train = training_data["x_train"]
+    y_train = training_data["y_train"]
+    x_validation = training_data["x_validation"]
+    y_validation = training_data["y_validation"]
+    model = _build_model(features.shape[1], config)
+    loss_fn = nn.CrossEntropyLoss()
+    if config.optimizer == "SGD":
+        optimizer = torch.optim.SGD(model.parameters(), lr=config.learning_rate)
+    else:
+        optimizer = torch.optim.Adam(model.parameters(), lr=config.learning_rate)
+
+    history_rows: list[dict[str, float | int]] = []
+    epochs = max(1, int(config.epochs))
+    batch_size = max(4, min(int(config.batch_size), len(x_train)))
+    log_every = max(1, epochs // 40)
+
+    _append_history_row(history_rows, model, loss_fn, x_train, y_train, x_validation, y_validation, 0)
+    for epoch in range(1, epochs + 1):
+        model.train()
+        batch_order = torch.randperm(len(x_train))
+        for start in range(0, len(x_train), batch_size):
+            batch_indices = batch_order[start : start + batch_size]
+            optimizer.zero_grad()
+            batch_logits = model(x_train[batch_indices])
+            batch_loss = loss_fn(batch_logits, y_train[batch_indices])
+            batch_loss.backward()
+            optimizer.step()
+
+        if epoch == epochs or epoch % log_every == 0:
+            _append_history_row(history_rows, model, loss_fn, x_train, y_train, x_validation, y_validation, epoch)
+
+    return model, loss_fn, pd.DataFrame(history_rows)
+
+
+def _train_playground(config: PlaygroundConfig) -> dict[str, Any]:
+    if torch is None or nn is None:
+        samples = _make_dataset(config)
+        return {
+            "status": "missing_torch",
+            "detail": "Install the app dependencies to enable PyTorch training.",
+            "samples": samples,
+            "history": pd.DataFrame(columns=["epoch", "train_loss", "validation_loss", "train_accuracy", "validation_accuracy"]),
+            "grid": pd.DataFrame(columns=["x1", "x2", "probability"]),
+            "network_layers": _empty_network_layers(),
+            "activation_maps": _empty_activation_maps(),
+            "summary": {
+                "backend": "missing",
+                "samples": int(len(samples)),
+                "features": int(len(config.feature_names)),
+            },
+        }
+
+    torch.manual_seed(config.seed)
+    training_data = _prepare_training_data(config)
+    samples = training_data["samples"]
+    features = training_data["features"]
+    mean = training_data["mean"]
+    std = training_data["std"]
+    model, _loss_fn, history = _fit_model(config, training_data)
+    grid = _decision_grid(model, config, mean, std)
+    network_layers = _network_layers(model)
+    activation_maps = _hidden_activation_maps(model, config, mean, std)
+    final = history.iloc[-1].to_dict() if not history.empty else {}
+    return {
+        "status": "ok",
+        "detail": "",
+        "samples": samples,
+        "history": history,
+        "grid": grid,
+        "network_layers": network_layers,
+        "activation_maps": activation_maps,
+        "summary": {
+            "backend": "torch",
+            "samples": int(len(samples)),
+            "features": int(features.shape[1]),
+            "hidden_layers": list(config.hidden_layers),
+            "train_accuracy": float(final.get("train_accuracy", 0.0)),
+            "validation_accuracy": float(final.get("validation_accuracy", 0.0)),
+            "validation_loss": float(final.get("validation_loss", 0.0)),
+        },
+    }
+
+
+def _append_history_row(
+    rows: list[dict[str, float | int]],
+    model,
+    loss_fn,
+    x_train,
+    y_train,
+    x_validation,
+    y_validation,
+    epoch: int,
+) -> None:
+    model.eval()
+    with torch.no_grad():
+        train_metrics = _classification_metrics(model, loss_fn, x_train, y_train)
+        validation_metrics = _classification_metrics(model, loss_fn, x_validation, y_validation)
+    rows.append(
+        {
+            "epoch": int(epoch),
+            "train_loss": train_metrics["loss"],
+            "validation_loss": validation_metrics["loss"],
+            "train_accuracy": train_metrics["accuracy"],
+            "validation_accuracy": validation_metrics["accuracy"],
+        }
+    )
+
+
+def _decision_grid(model, config: PlaygroundConfig, mean: np.ndarray, std: np.ndarray) -> pd.DataFrame:
+    grid_points = _grid_points(config)
+    grid_features = (_feature_matrix(grid_points, config.feature_names) - mean) / std
+    model.eval()
+    with torch.no_grad():
+        logits = model(torch.tensor(grid_features, dtype=torch.float32))
+        probabilities = torch.softmax(logits, dim=1)[:, 1].cpu().numpy()
+    grid_points["probability"] = probabilities.astype(float)
+    return grid_points
+
+
+def _model_state_vector(model):
+    return torch.cat([parameter.detach().flatten().cpu() for parameter in model.parameters()])
+
+
+def _assign_model_state_vector(model, vector) -> None:
+    offset = 0
+    for parameter in model.parameters():
+        item_count = parameter.numel()
+        values = vector[offset : offset + item_count].reshape(parameter.shape).to(parameter.device, dtype=parameter.dtype)
+        parameter.data.copy_(values)
+        offset += item_count
+
+
+def _landscape_directions(center, seed: int) -> tuple[Any, Any]:
+    generator = torch.Generator()
+    generator.manual_seed(int(seed) + 7001)
+    first = torch.randn(center.shape, generator=generator, dtype=center.dtype)
+    second = torch.randn(center.shape, generator=generator, dtype=center.dtype)
+    first_norm = first.norm().clamp_min(1e-12)
+    first = first / first_norm
+    second = second - torch.dot(second, first) * first
+    second_norm = second.norm().clamp_min(1e-12)
+    second = second / second_norm
+    scale = center.norm().clamp_min(1.0)
+    return first * scale, second * scale
+
+
+def _normalized_landscape_resolution(value: int) -> int:
+    resolution = max(5, min(31, int(value)))
+    if resolution % 2 == 0:
+        resolution += 1
+    return resolution
+
+
+def _loss_landscape_summary(landscape: pd.DataFrame) -> dict[str, Any]:
+    if landscape.empty:
+        return {"status": "not_computed", "points": 0}
+    center_candidates = landscape[landscape["is_center"]]
+    center = center_candidates.iloc[0] if not center_candidates.empty else landscape.iloc[len(landscape) // 2]
+    best = landscape.loc[landscape["validation_loss"].idxmin()]
+    max_validation_loss = float(landscape["validation_loss"].max())
+    center_loss = float(center["validation_loss"])
+    return {
+        "status": "ok",
+        "points": int(len(landscape)),
+        "center_validation_loss": center_loss,
+        "center_train_loss": float(center["train_loss"]),
+        "center_validation_accuracy": float(center["validation_accuracy"]),
+        "best_validation_loss": float(best["validation_loss"]),
+        "best_alpha": float(best["alpha"]),
+        "best_beta": float(best["beta"]),
+        "best_delta": float(best["validation_loss"] - center_loss),
+        "sharpness": float(max(0.0, max_validation_loss - center_loss)),
+    }
+
+
+def _loss_landscape(config: PlaygroundConfig, *, resolution: int = 21, span: float = 0.75) -> dict[str, Any]:
+    if torch is None or nn is None:
+        return {
+            "status": "missing_torch",
+            "detail": "Install the app dependencies to enable the loss landscape.",
+            "loss_landscape": _empty_loss_landscape(),
+            "landscape_summary": _loss_landscape_summary(_empty_loss_landscape()),
+        }
+
+    torch.manual_seed(config.seed)
+    training_data = _prepare_training_data(config)
+    model, loss_fn, _history = _fit_model(config, training_data)
+    center = _model_state_vector(model)
+    first_direction, second_direction = _landscape_directions(center, config.seed)
+    resolution = _normalized_landscape_resolution(resolution)
+    span = max(0.05, min(2.0, float(span)))
+    axis = np.linspace(-span, span, resolution)
+    rows: list[dict[str, float | bool]] = []
+
+    try:
+        model.eval()
+        with torch.no_grad():
+            for alpha in axis:
+                for beta in axis:
+                    candidate = center + float(alpha) * first_direction + float(beta) * second_direction
+                    _assign_model_state_vector(model, candidate)
+                    train_metrics = _classification_metrics(model, loss_fn, training_data["x_train"], training_data["y_train"])
+                    validation_metrics = _classification_metrics(
+                        model,
+                        loss_fn,
+                        training_data["x_validation"],
+                        training_data["y_validation"],
+                    )
+                    rows.append(
+                        {
+                            "alpha": float(alpha),
+                            "beta": float(beta),
+                            "train_loss": train_metrics["loss"],
+                            "validation_loss": validation_metrics["loss"],
+                            "train_accuracy": train_metrics["accuracy"],
+                            "validation_accuracy": validation_metrics["accuracy"],
+                            "is_center": bool(np.isclose(alpha, 0.0) and np.isclose(beta, 0.0)),
+                        }
+                    )
+    finally:
+        _assign_model_state_vector(model, center)
+
+    landscape = pd.DataFrame(rows, columns=_empty_loss_landscape().columns)
+    return {
+        "status": "ok",
+        "detail": "",
+        "loss_landscape": landscape,
+        "landscape_summary": _loss_landscape_summary(landscape),
+    }
+
+
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(item) for item in value]
+    if isinstance(value, np.integer):
+        return int(value)
+    if isinstance(value, np.floating):
+        number = float(value)
+        return number if np.isfinite(number) else None
+    if isinstance(value, float):
+        return value if np.isfinite(value) else None
+    return value
+
+
+def _json_bytes(payload: Mapping[str, Any]) -> bytes:
+    return json.dumps(_json_safe(payload), indent=2, sort_keys=True).encode("utf-8") + b"\n"
+
+
+def _dataframe_csv_bytes(frame: pd.DataFrame) -> bytes:
+    return frame.to_csv(index=False, float_format="%.10g").encode("utf-8")
+
+
+def _artifact_hash(payload: bytes) -> dict[str, Any]:
+    return {"sha256": hashlib.sha256(payload).hexdigest(), "bytes": len(payload)}
+
+
+def _result_frame(result: Mapping[str, Any], key: str, empty: pd.DataFrame) -> pd.DataFrame:
+    value = result.get(key)
+    return value if isinstance(value, pd.DataFrame) else empty
+
+
+def _evidence_artifact_files(config: PlaygroundConfig, result: Mapping[str, Any]) -> dict[str, bytes]:
+    samples = _result_frame(result, "samples", pd.DataFrame(columns=["x1", "x2", "target"]))
+    history = _result_frame(result, "history", pd.DataFrame(columns=["epoch", "train_loss", "validation_loss", "train_accuracy", "validation_accuracy"]))
+    grid = _result_frame(result, "grid", pd.DataFrame(columns=["x1", "x2", "probability"]))
+    network_layers = _result_frame(result, "network_layers", _empty_network_layers())
+    activation_maps = _result_frame(result, "activation_maps", _empty_activation_maps())
+    loss_landscape = _result_frame(result, "loss_landscape", _empty_loss_landscape())
+    return {
+        "config/playground_config.json": _json_bytes(_config_payload(config)),
+        "data/samples.csv": _dataframe_csv_bytes(samples),
+        "data/training_history.csv": _dataframe_csv_bytes(history),
+        "data/decision_grid.csv": _dataframe_csv_bytes(grid),
+        "model/network_layers.csv": _dataframe_csv_bytes(network_layers),
+        "model/hidden_activation_maps.csv": _dataframe_csv_bytes(activation_maps),
+        "model/loss_landscape.csv": _dataframe_csv_bytes(loss_landscape),
+        "summary/run_summary.json": _json_bytes(
+            {
+                "schema": EVIDENCE_SCHEMA,
+                "summary": result.get("summary", {}),
+                "landscape_summary": result.get("landscape_summary", _loss_landscape_summary(loss_landscape)),
+            }
+        ),
+    }
+
+
+def _build_evidence_manifest(config: PlaygroundConfig, result: Mapping[str, Any]) -> dict[str, Any]:
+    files = _evidence_artifact_files(config, result)
+    samples = _result_frame(result, "samples", pd.DataFrame())
+    history = _result_frame(result, "history", pd.DataFrame())
+    grid = _result_frame(result, "grid", pd.DataFrame())
+    network_layers = _result_frame(result, "network_layers", _empty_network_layers())
+    activation_maps = _result_frame(result, "activation_maps", _empty_activation_maps())
+    loss_landscape = _result_frame(result, "loss_landscape", _empty_loss_landscape())
+    return {
+        "schema": EVIDENCE_SCHEMA,
+        "config_schema": CONFIG_SCHEMA,
+        "app": "pytorch_playground_project",
+        "backend": result.get("summary", {}).get("backend", "unknown"),
+        "torch_version": getattr(torch, "__version__", None) if torch is not None else None,
+        "config": _config_payload(config)["config"],
+        "summary": result.get("summary", {}),
+        "landscape_summary": result.get("landscape_summary", _loss_landscape_summary(loss_landscape)),
+        "row_counts": {
+            "samples": int(len(samples)),
+            "training_history": int(len(history)),
+            "decision_grid": int(len(grid)),
+            "network_layers": int(len(network_layers)),
+            "hidden_activation_maps": int(len(activation_maps)),
+            "loss_landscape": int(len(loss_landscape)),
+        },
+        "artifacts": {name: _artifact_hash(payload) for name, payload in sorted(files.items())},
+    }
+
+
+def _deterministic_zip_bytes(files: Mapping[str, bytes]) -> bytes:
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, mode="w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for name in sorted(files):
+            info = zipfile.ZipInfo(name, ZIP_TIMESTAMP)
+            info.compress_type = zipfile.ZIP_DEFLATED
+            info.external_attr = 0o644 << 16
+            archive.writestr(info, files[name])
+    return buffer.getvalue()
+
+
+def _build_evidence_pack(config: PlaygroundConfig, result: Mapping[str, Any]) -> bytes:
+    files = _evidence_artifact_files(config, result)
+    files["manifest.json"] = _json_bytes(_build_evidence_manifest(config, result))
+    return _deterministic_zip_bytes(files)
+

--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground/playground_ui.py
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground/playground_ui.py
@@ -4,16 +4,10 @@
 
 from __future__ import annotations
 
-import argparse
-import base64
-import binascii
-import hashlib
 import html
-import io
 import json
-import zipfile
 from collections.abc import Mapping
-from dataclasses import asdict, dataclass
+from dataclasses import asdict
 from pathlib import Path
 import re
 import sys
@@ -45,14 +39,6 @@ except Exception:  # pragma: no cover - workers import evidence helpers without 
 
     st = _StreamlitStub()  # type: ignore[assignment]
 
-try:  # pragma: no cover - exercised conditionally in environments with torch
-    import torch
-    from torch import nn
-except Exception:  # pragma: no cover - lightweight environments may omit torch
-    torch = None  # type: ignore[assignment]
-    nn = None  # type: ignore[assignment]
-
-
 def _ensure_repo_on_path() -> None:
     here = Path(__file__).resolve()
     for parent in here.parents:
@@ -68,6 +54,99 @@ def _ensure_repo_on_path() -> None:
 
 _ensure_repo_on_path()
 
+_APP_SRC = Path(__file__).resolve().parents[1]
+if str(_APP_SRC) not in sys.path:
+    sys.path.insert(0, str(_APP_SRC))
+
+try:  # noqa: E402
+    import pytorch_playground.core as _playground_core
+    from pytorch_playground.core import (
+        ACTIVATIONS,
+        CONFIG_SCHEMA,
+        CUSTOM_PRESET,
+        DATASETS,
+        DEFAULT_FEATURES,
+        DEFAULT_PRESET,
+        EVIDENCE_SCHEMA,
+        FEATURES,
+        OPTIMIZERS,
+        PLAYGROUND_PRESETS,
+        PRESET_STORIES,
+        SHARED_CONFIG_SIGNATURE_STATE_KEY,
+        TRAINED_CONFIG_STATE_KEY,
+        TRAINED_PRESET_STATE_KEY,
+        PlaygroundConfig,
+        _build_evidence_manifest,
+        _build_evidence_pack,
+        _coerce_feature_names,
+        _config_from_payload,
+        _config_from_query_params,
+        _config_payload,
+        _config_signature,
+        _config_state_payload,
+        _decode_share_config,
+        _empty_activation_maps,
+        _empty_loss_landscape,
+        _empty_network_layers,
+        _encode_share_config,
+        _json_safe,
+        _loss_landscape,
+        _loss_landscape_summary,
+        _make_dataset,
+        _parse_hidden_layers,
+        _plotly_unavailable_figure,
+        _preset_config,
+        _preset_story,
+        _resolve_active_app,
+        _result_frame,
+        _safe_key_fragment,
+        _train_playground,
+    )
+except ModuleNotFoundError:  # pragma: no cover - direct script execution fallback
+    import core as _playground_core
+    from core import (
+        ACTIVATIONS,
+        CONFIG_SCHEMA,
+        CUSTOM_PRESET,
+        DATASETS,
+        DEFAULT_FEATURES,
+        DEFAULT_PRESET,
+        EVIDENCE_SCHEMA,
+        FEATURES,
+        OPTIMIZERS,
+        PLAYGROUND_PRESETS,
+        PRESET_STORIES,
+        SHARED_CONFIG_SIGNATURE_STATE_KEY,
+        TRAINED_CONFIG_STATE_KEY,
+        TRAINED_PRESET_STATE_KEY,
+        PlaygroundConfig,
+        _build_evidence_manifest,
+        _build_evidence_pack,
+        _coerce_feature_names,
+        _config_from_payload,
+        _config_from_query_params,
+        _config_payload,
+        _config_signature,
+        _config_state_payload,
+        _decode_share_config,
+        _empty_activation_maps,
+        _empty_loss_landscape,
+        _empty_network_layers,
+        _encode_share_config,
+        _json_safe,
+        _loss_landscape,
+        _loss_landscape_summary,
+        _make_dataset,
+        _parse_hidden_layers,
+        _plotly_unavailable_figure,
+        _preset_config,
+        _preset_story,
+        _resolve_active_app,
+        _result_frame,
+        _safe_key_fragment,
+        _train_playground,
+    )
+
 try:  # noqa: E402
     from agi_gui.pagelib import render_logo
 except Exception:  # pragma: no cover - headless worker/test environments
@@ -75,290 +154,62 @@ except Exception:  # pragma: no cover - headless worker/test environments
         return None
 
 
+torch = _playground_core.torch
+nn = _playground_core.nn
+
+
+def _call_core(name: str, *args, **kwargs):
+    previous_torch = _playground_core.torch
+    previous_nn = _playground_core.nn
+    _playground_core.torch = torch
+    _playground_core.nn = nn
+    try:
+        return getattr(_playground_core, name)(*args, **kwargs)
+    finally:
+        _playground_core.torch = previous_torch
+        _playground_core.nn = previous_nn
+
+
+def _activation_module(name: str):
+    return _call_core("_activation_module", name)
+
+
+def _build_model(input_dim: int, config: PlaygroundConfig):
+    return _call_core("_build_model", input_dim, config)
+
+
+def _hidden_activation_maps(*args, **kwargs) -> pd.DataFrame:
+    return _call_core("_hidden_activation_maps", *args, **kwargs)
+
+
+def _network_layers(model) -> pd.DataFrame:
+    return _call_core("_network_layers", model)
+
+
+def _prepare_training_data(config: PlaygroundConfig) -> dict[str, Any]:
+    return _call_core("_prepare_training_data", config)
+
+
+def _decision_grid(*args, **kwargs) -> pd.DataFrame:
+    return _call_core("_decision_grid", *args, **kwargs)
+
+
+def _train_playground(config: PlaygroundConfig) -> dict[str, Any]:
+    return _call_core("_train_playground", config)
+
+
+def _loss_landscape(config: PlaygroundConfig, *, resolution: int = 21, span: float = 0.75) -> dict[str, Any]:
+    return _call_core("_loss_landscape", config, resolution=resolution, span=span)
+
+
+def __getattr__(name: str) -> Any:
+    try:
+        return getattr(_playground_core, name)
+    except AttributeError as exc:
+        raise AttributeError(name) from exc
+
+
 PAGE_TITLE = "PyTorch playground"
-DATASETS = ("circles", "xor", "spiral", "gaussian")
-FEATURES = (
-    "x1",
-    "x2",
-    "x1_squared",
-    "x2_squared",
-    "x1_x2",
-    "sin_x1",
-    "sin_x2",
-)
-DEFAULT_FEATURES = ("x1", "x2", "x1_squared", "x2_squared", "x1_x2")
-ACTIVATIONS = ("tanh", "relu", "sigmoid", "identity")
-OPTIMIZERS = ("Adam", "SGD")
-CONFIG_SCHEMA = "agilab.pytorch_playground_config.v1"
-EVIDENCE_SCHEMA = "agilab.pytorch_playground_evidence.v1"
-ZIP_TIMESTAMP = (2026, 1, 1, 0, 0, 0)
-CUSTOM_PRESET = "Custom / shared link"
-DEFAULT_PRESET = "Instant wow: clean circles"
-TRAINED_CONFIG_STATE_KEY = "pytorch_playground_trained_config"
-TRAINED_PRESET_STATE_KEY = "pytorch_playground_trained_preset"
-SHARED_CONFIG_SIGNATURE_STATE_KEY = "pytorch_playground_shared_signature"
-
-
-class _FallbackPlotlyFigure(dict):
-    @property
-    def data(self) -> tuple[object, ...]:
-        return tuple(self.get("data", ()))
-
-
-def _plotly_unavailable_figure(kind: str, trace_count: int = 0) -> _FallbackPlotlyFigure:
-    return _FallbackPlotlyFigure(
-        {
-            "data": [{"type": "scatter", "x": [], "y": []} for _ in range(max(0, int(trace_count)))],
-            "layout": {
-                "title": f"{kind} chart unavailable",
-                "template": "plotly_dark",
-            },
-        }
-    )
-
-
-@dataclass(frozen=True)
-class PlaygroundConfig:
-    dataset: str = "circles"
-    sample_count: int = 256
-    noise: float = 0.12
-    train_ratio: float = 0.75
-    hidden_layers: tuple[int, ...] = (8, 8)
-    activation: str = "tanh"
-    optimizer: str = "Adam"
-    learning_rate: float = 0.03
-    epochs: int = 80
-    batch_size: int = 32
-    seed: int = 7
-    feature_names: tuple[str, ...] = DEFAULT_FEATURES
-    grid_size: int = 80
-
-
-PLAYGROUND_PRESETS: dict[str, PlaygroundConfig] = {
-    CUSTOM_PRESET: PlaygroundConfig(),
-    "Instant wow: clean circles": PlaygroundConfig(
-        dataset="circles",
-        sample_count=320,
-        noise=0.08,
-        hidden_layers=(12, 12),
-        learning_rate=0.035,
-        epochs=90,
-        grid_size=88,
-        seed=11,
-    ),
-    "Feature puzzle: XOR": PlaygroundConfig(
-        dataset="xor",
-        sample_count=352,
-        noise=0.06,
-        hidden_layers=(16, 8),
-        activation="relu",
-        learning_rate=0.025,
-        epochs=120,
-        feature_names=("x1", "x2", "x1_x2", "x1_squared", "x2_squared"),
-        grid_size=84,
-        seed=19,
-    ),
-    "Hard mode: spiral": PlaygroundConfig(
-        dataset="spiral",
-        sample_count=448,
-        noise=0.10,
-        hidden_layers=(24, 16, 8),
-        activation="tanh",
-        learning_rate=0.02,
-        epochs=160,
-        batch_size=48,
-        feature_names=("x1", "x2", "sin_x1", "sin_x2", "x1_x2"),
-        grid_size=96,
-        seed=29,
-    ),
-    "Fast baseline: gaussian": PlaygroundConfig(
-        dataset="gaussian",
-        sample_count=256,
-        noise=0.14,
-        hidden_layers=(6,),
-        learning_rate=0.04,
-        epochs=60,
-        feature_names=("x1", "x2"),
-        grid_size=72,
-        seed=5,
-    ),
-}
-
-PRESET_STORIES: dict[str, str] = {
-    CUSTOM_PRESET: "Use the current controls, or open a shared configuration token.",
-    "Instant wow: clean circles": "A compact nonlinear boundary that should become visibly crisp in one run.",
-    "Feature puzzle: XOR": "Shows why engineered features and hidden layers matter.",
-    "Hard mode: spiral": "A harder visual challenge for seeing capacity, noise, and loss terrain.",
-    "Fast baseline: gaussian": "A quick sanity check where a tiny network should separate the classes.",
-}
-
-
-def _resolve_active_app() -> Path | None:
-    parser = argparse.ArgumentParser(add_help=False)
-    parser.add_argument("--active-app", dest="active_app", type=str)
-    args, _ = parser.parse_known_args()
-    if not args.active_app:
-        return None
-    active_app = Path(args.active_app).expanduser().resolve()
-    return active_app if active_app.exists() else None
-
-
-def _parse_hidden_layers(raw: str) -> tuple[int, ...]:
-    cleaned = raw.strip()
-    if not cleaned:
-        return ()
-    values: list[int] = []
-    for token in re.split(r"[,\s;]+", cleaned):
-        if not token:
-            continue
-        try:
-            width = int(token)
-        except ValueError as exc:
-            raise ValueError(f"Hidden layer width must be an integer: {token}") from exc
-        if width < 1 or width > 256:
-            raise ValueError("Hidden layer widths must be between 1 and 256.")
-        values.append(width)
-    if len(values) > 6:
-        raise ValueError("Use at most six hidden layers.")
-    return tuple(values)
-
-
-def _bounded_int(value: Any, *, default: int, minimum: int, maximum: int) -> int:
-    try:
-        number = int(value)
-    except (TypeError, ValueError):
-        return default
-    return max(minimum, min(maximum, number))
-
-
-def _bounded_float(value: Any, *, default: float, minimum: float, maximum: float) -> float:
-    try:
-        number = float(value)
-    except (TypeError, ValueError):
-        return default
-    if not np.isfinite(number):
-        return default
-    return float(max(minimum, min(maximum, number)))
-
-
-def _coerce_hidden_layers(value: Any, default: tuple[int, ...] = (8, 8)) -> tuple[int, ...]:
-    if isinstance(value, str):
-        try:
-            return _parse_hidden_layers(value)
-        except ValueError:
-            return default
-    if isinstance(value, (list, tuple)):
-        try:
-            return _parse_hidden_layers(",".join(str(item) for item in value))
-        except ValueError:
-            return default
-    return default
-
-
-def _coerce_feature_names(value: Any, default: tuple[str, ...] = DEFAULT_FEATURES) -> tuple[str, ...]:
-    if isinstance(value, str):
-        raw_values = [token.strip() for token in value.split(",")]
-    elif isinstance(value, (list, tuple)):
-        raw_values = [str(token).strip() for token in value]
-    else:
-        raw_values = list(default)
-    selected = tuple(name for name in raw_values if name in FEATURES)
-    return selected or default
-
-
-def _config_payload(config: PlaygroundConfig) -> dict[str, Any]:
-    payload = asdict(config)
-    payload["hidden_layers"] = list(config.hidden_layers)
-    payload["feature_names"] = list(config.feature_names)
-    return {"schema": CONFIG_SCHEMA, "config": payload}
-
-
-def _config_from_payload(payload: Mapping[str, Any]) -> PlaygroundConfig:
-    raw_config = payload.get("config", payload)
-    if not isinstance(raw_config, Mapping):
-        raw_config = {}
-    default = PlaygroundConfig()
-    dataset = str(raw_config.get("dataset", default.dataset))
-    activation = str(raw_config.get("activation", default.activation))
-    optimizer = str(raw_config.get("optimizer", default.optimizer))
-    return PlaygroundConfig(
-        dataset=dataset if dataset in DATASETS else default.dataset,
-        sample_count=_bounded_int(raw_config.get("sample_count"), default=default.sample_count, minimum=64, maximum=1000),
-        noise=_bounded_float(raw_config.get("noise"), default=default.noise, minimum=0.0, maximum=0.5),
-        train_ratio=_bounded_float(raw_config.get("train_ratio"), default=default.train_ratio, minimum=0.5, maximum=0.95),
-        hidden_layers=_coerce_hidden_layers(raw_config.get("hidden_layers"), default.hidden_layers),
-        activation=activation if activation in ACTIVATIONS else default.activation,
-        optimizer=optimizer if optimizer in OPTIMIZERS else default.optimizer,
-        learning_rate=_bounded_float(raw_config.get("learning_rate"), default=default.learning_rate, minimum=0.001, maximum=0.2),
-        epochs=_bounded_int(raw_config.get("epochs"), default=default.epochs, minimum=10, maximum=300),
-        batch_size=_bounded_int(raw_config.get("batch_size"), default=default.batch_size, minimum=8, maximum=256),
-        seed=_bounded_int(raw_config.get("seed"), default=default.seed, minimum=0, maximum=9999),
-        feature_names=_coerce_feature_names(raw_config.get("feature_names"), default.feature_names),
-        grid_size=_bounded_int(raw_config.get("grid_size"), default=default.grid_size, minimum=12, maximum=120),
-    )
-
-
-def _encode_share_config(config: PlaygroundConfig) -> str:
-    raw = json.dumps(_config_payload(config), sort_keys=True, separators=(",", ":")).encode("utf-8")
-    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
-
-
-def _decode_share_config(raw: str) -> PlaygroundConfig | None:
-    if not raw:
-        return None
-    try:
-        padding = "=" * (-len(raw) % 4)
-        payload = json.loads(base64.urlsafe_b64decode((raw + padding).encode("ascii")).decode("utf-8"))
-    except (binascii.Error, UnicodeDecodeError, ValueError, TypeError, json.JSONDecodeError):
-        return None
-    if not isinstance(payload, Mapping):
-        return None
-    return _config_from_payload(payload)
-
-
-def _first_query_value(value: Any) -> str | None:
-    if isinstance(value, (list, tuple)):
-        if not value:
-            return None
-        value = value[0]
-    if value is None:
-        return None
-    return str(value)
-
-
-def _config_from_query_params(params: Mapping[str, Any]) -> PlaygroundConfig | None:
-    for key in ("pytorch_playground", "config"):
-        token = _first_query_value(params.get(key))
-        decoded = _decode_share_config(token or "")
-        if decoded is not None:
-            return decoded
-    return None
-
-
-def _safe_key_fragment(raw: str) -> str:
-    return re.sub(r"[^a-z0-9]+", "_", raw.lower()).strip("_") or "custom"
-
-
-def _preset_config(label: str, shared_config: PlaygroundConfig | None = None) -> PlaygroundConfig:
-    if label == CUSTOM_PRESET and shared_config is not None:
-        return shared_config
-    return PLAYGROUND_PRESETS.get(label, PLAYGROUND_PRESETS[CUSTOM_PRESET])
-
-
-def _preset_story(label: str, shared_config: PlaygroundConfig | None = None) -> str:
-    if label == CUSTOM_PRESET and shared_config is not None:
-        return "Loaded from the URL token. Adjust any control to fork the experiment."
-    return PRESET_STORIES.get(label, PRESET_STORIES[CUSTOM_PRESET])
-
-
-def _config_state_payload(config: PlaygroundConfig) -> dict[str, Any]:
-    return _config_payload(config)["config"]
-
-
-def _config_signature(config: PlaygroundConfig) -> str:
-    return json.dumps(_config_state_payload(config), sort_keys=True, separators=(",", ":"))
-
-
 def _session_state_get(key: str, default: Any = None) -> Any:
     state = getattr(st, "session_state", None)
     if state is None:
@@ -401,536 +252,6 @@ def _resolve_trained_config(
     return trained_config, trained_preset, _config_signature(current_config) != _config_signature(trained_config)
 
 
-def _make_dataset(config: PlaygroundConfig) -> pd.DataFrame:
-    rng = np.random.default_rng(config.seed)
-    count = max(16, int(config.sample_count))
-    dataset = config.dataset if config.dataset in DATASETS else "circles"
-    noise = max(0.0, float(config.noise))
-
-    if dataset == "xor":
-        points = rng.uniform(-1.0, 1.0, size=(count, 2))
-        points += rng.normal(0.0, noise, size=points.shape)
-        labels = (points[:, 0] * points[:, 1] < 0.0).astype(int)
-    elif dataset == "spiral":
-        points, labels = _make_spiral_dataset(rng, count, noise)
-    elif dataset == "gaussian":
-        points, labels = _make_gaussian_dataset(rng, count, noise)
-    else:
-        points, labels = _make_circle_dataset(rng, count, noise)
-
-    order = rng.permutation(len(labels))
-    frame = pd.DataFrame(
-        {
-            "x1": points[order, 0].astype(float),
-            "x2": points[order, 1].astype(float),
-            "target": labels[order].astype(int),
-        }
-    )
-    return frame.reset_index(drop=True)
-
-
-def _make_circle_dataset(
-    rng: np.random.Generator,
-    count: int,
-    noise: float,
-) -> tuple[np.ndarray, np.ndarray]:
-    inner_count = count // 2
-    outer_count = count - inner_count
-    inner_theta = rng.uniform(0.0, 2.0 * np.pi, size=inner_count)
-    outer_theta = rng.uniform(0.0, 2.0 * np.pi, size=outer_count)
-    inner_radius = 0.42 + rng.normal(0.0, noise, size=inner_count)
-    outer_radius = 0.95 + rng.normal(0.0, noise, size=outer_count)
-    inner = np.column_stack((inner_radius * np.cos(inner_theta), inner_radius * np.sin(inner_theta)))
-    outer = np.column_stack((outer_radius * np.cos(outer_theta), outer_radius * np.sin(outer_theta)))
-    points = np.vstack((inner, outer))
-    labels = np.concatenate((np.zeros(inner_count, dtype=int), np.ones(outer_count, dtype=int)))
-    return points, labels
-
-
-def _make_spiral_dataset(
-    rng: np.random.Generator,
-    count: int,
-    noise: float,
-) -> tuple[np.ndarray, np.ndarray]:
-    first_count = count // 2
-    second_count = count - first_count
-    points_by_class: list[np.ndarray] = []
-    labels_by_class: list[np.ndarray] = []
-    for class_id, class_count in enumerate((first_count, second_count)):
-        radius = np.linspace(0.12, 1.0, class_count)
-        theta = class_id * np.pi + 4.2 * radius + rng.normal(0.0, noise * 2.0, size=class_count)
-        points = np.column_stack((radius * np.cos(theta), radius * np.sin(theta)))
-        points += rng.normal(0.0, noise * 0.35, size=points.shape)
-        points_by_class.append(points)
-        labels_by_class.append(np.full(class_count, class_id, dtype=int))
-    return np.vstack(points_by_class), np.concatenate(labels_by_class)
-
-
-def _make_gaussian_dataset(
-    rng: np.random.Generator,
-    count: int,
-    noise: float,
-) -> tuple[np.ndarray, np.ndarray]:
-    first_count = count // 2
-    second_count = count - first_count
-    spread = 0.24 + noise
-    first = rng.normal(loc=(-0.45, -0.25), scale=spread, size=(first_count, 2))
-    second = rng.normal(loc=(0.45, 0.30), scale=spread, size=(second_count, 2))
-    points = np.vstack((first, second))
-    labels = np.concatenate((np.zeros(first_count, dtype=int), np.ones(second_count, dtype=int)))
-    return points, labels
-
-
-def _feature_matrix(samples: pd.DataFrame | np.ndarray, feature_names: tuple[str, ...]) -> np.ndarray:
-    if isinstance(samples, pd.DataFrame):
-        x1 = samples["x1"].to_numpy(dtype=float)
-        x2 = samples["x2"].to_numpy(dtype=float)
-    else:
-        points = np.asarray(samples, dtype=float)
-        x1 = points[:, 0]
-        x2 = points[:, 1]
-
-    values_by_name = {
-        "x1": x1,
-        "x2": x2,
-        "x1_squared": x1**2,
-        "x2_squared": x2**2,
-        "x1_x2": x1 * x2,
-        "sin_x1": np.sin(np.pi * x1),
-        "sin_x2": np.sin(np.pi * x2),
-    }
-    selected = [name for name in feature_names if name in values_by_name]
-    if not selected:
-        selected = ["x1", "x2"]
-    return np.column_stack([values_by_name[name] for name in selected]).astype(np.float32)
-
-
-def _activation_module(name: str):
-    if nn is None:
-        raise RuntimeError("PyTorch is not available.")
-    if name == "relu":
-        return nn.ReLU()
-    if name == "sigmoid":
-        return nn.Sigmoid()
-    if name == "identity":
-        return nn.Identity()
-    return nn.Tanh()
-
-
-def _build_model(input_dim: int, config: PlaygroundConfig):
-    if nn is None:
-        raise RuntimeError("PyTorch is not available.")
-    layers: list[Any] = []
-    previous_dim = input_dim
-    for width in config.hidden_layers:
-        layers.append(nn.Linear(previous_dim, width))
-        layers.append(_activation_module(config.activation))
-        previous_dim = width
-    layers.append(nn.Linear(previous_dim, 2))
-    return nn.Sequential(*layers)
-
-
-def _empty_network_layers() -> pd.DataFrame:
-    return pd.DataFrame(
-        columns=[
-            "layer",
-            "kind",
-            "input_features",
-            "output_features",
-            "parameters",
-            "weight_mean",
-            "weight_std",
-            "weight_max_abs",
-            "bias_mean",
-            "bias_std",
-            "bias_max_abs",
-        ]
-    )
-
-
-def _empty_activation_maps() -> pd.DataFrame:
-    return pd.DataFrame(columns=["layer", "neuron", "x1", "x2", "activation"])
-
-
-def _empty_loss_landscape() -> pd.DataFrame:
-    return pd.DataFrame(
-        columns=[
-            "alpha",
-            "beta",
-            "train_loss",
-            "validation_loss",
-            "train_accuracy",
-            "validation_accuracy",
-            "is_center",
-        ]
-    )
-
-
-def _array_stats(values: np.ndarray) -> dict[str, float]:
-    flattened = np.asarray(values, dtype=float).ravel()
-    if flattened.size == 0:
-        return {"mean": 0.0, "std": 0.0, "max_abs": 0.0}
-    return {
-        "mean": float(np.mean(flattened)),
-        "std": float(np.std(flattened)),
-        "max_abs": float(np.max(np.abs(flattened))),
-    }
-
-
-def _network_layers(model) -> pd.DataFrame:
-    if nn is None:
-        return _empty_network_layers()
-    linear_layers = [layer for layer in model if isinstance(layer, nn.Linear)]
-    rows: list[dict[str, Any]] = []
-    for index, layer in enumerate(linear_layers):
-        weight = layer.weight.detach().cpu().numpy()
-        bias = layer.bias.detach().cpu().numpy() if layer.bias is not None else np.array([], dtype=float)
-        weight_stats = _array_stats(weight)
-        bias_stats = _array_stats(bias)
-        rows.append(
-            {
-                "layer": index + 1,
-                "kind": "output" if index == len(linear_layers) - 1 else "hidden",
-                "input_features": int(layer.in_features),
-                "output_features": int(layer.out_features),
-                "parameters": int(weight.size + bias.size),
-                "weight_mean": weight_stats["mean"],
-                "weight_std": weight_stats["std"],
-                "weight_max_abs": weight_stats["max_abs"],
-                "bias_mean": bias_stats["mean"],
-                "bias_std": bias_stats["std"],
-                "bias_max_abs": bias_stats["max_abs"],
-            }
-        )
-    return pd.DataFrame(rows, columns=_empty_network_layers().columns)
-
-
-def _grid_points(config: PlaygroundConfig) -> pd.DataFrame:
-    axis = np.linspace(-1.35, 1.35, max(12, int(config.grid_size)))
-    xx, yy = np.meshgrid(axis, axis)
-    return pd.DataFrame({"x1": xx.ravel(), "x2": yy.ravel()})
-
-
-def _hidden_activation_maps(
-    model,
-    config: PlaygroundConfig,
-    mean: np.ndarray,
-    std: np.ndarray,
-    *,
-    max_neurons: int = 8,
-) -> pd.DataFrame:
-    if torch is None or nn is None or not config.hidden_layers:
-        return _empty_activation_maps()
-
-    grid_points = _grid_points(config)
-    grid_features = (_feature_matrix(grid_points, config.feature_names) - mean) / std
-    activation_frames: list[pd.DataFrame] = []
-    hidden_layer_index = 0
-    pending_hidden_layer = False
-
-    model.eval()
-    with torch.no_grad():
-        values = torch.tensor(grid_features, dtype=torch.float32)
-        for layer in model:
-            values = layer(values)
-            if isinstance(layer, nn.Linear):
-                pending_hidden_layer = hidden_layer_index < len(config.hidden_layers)
-                continue
-            if not pending_hidden_layer:
-                continue
-
-            activations = values.detach().cpu().numpy()
-            neuron_count = min(activations.shape[1], max(1, int(max_neurons)))
-            for neuron_index in range(neuron_count):
-                frame = grid_points.copy()
-                frame.insert(0, "neuron", neuron_index + 1)
-                frame.insert(0, "layer", hidden_layer_index + 1)
-                frame["activation"] = activations[:, neuron_index].astype(float)
-                activation_frames.append(frame)
-            hidden_layer_index += 1
-            pending_hidden_layer = False
-
-    if not activation_frames:
-        return _empty_activation_maps()
-    return pd.concat(activation_frames, ignore_index=True)
-
-
-def _prepare_training_data(config: PlaygroundConfig) -> dict[str, Any]:
-    samples = _make_dataset(config)
-    features = _feature_matrix(samples, config.feature_names)
-    labels = samples["target"].to_numpy(dtype=np.int64)
-    rng = np.random.default_rng(config.seed + 101)
-    indices = rng.permutation(len(labels))
-    train_count = min(len(labels) - 1, max(2, int(round(len(labels) * config.train_ratio))))
-    train_indices = indices[:train_count]
-    validation_indices = indices[train_count:]
-    if len(validation_indices) == 0:
-        validation_indices = train_indices
-
-    mean = features[train_indices].mean(axis=0, keepdims=True)
-    std = features[train_indices].std(axis=0, keepdims=True)
-    std[std < 1e-6] = 1.0
-    features = (features - mean) / std
-
-    x_train = torch.tensor(features[train_indices], dtype=torch.float32)
-    y_train = torch.tensor(labels[train_indices], dtype=torch.long)
-    x_validation = torch.tensor(features[validation_indices], dtype=torch.float32)
-    y_validation = torch.tensor(labels[validation_indices], dtype=torch.long)
-    return {
-        "samples": samples,
-        "features": features,
-        "labels": labels,
-        "train_indices": train_indices,
-        "validation_indices": validation_indices,
-        "mean": mean,
-        "std": std,
-        "x_train": x_train,
-        "y_train": y_train,
-        "x_validation": x_validation,
-        "y_validation": y_validation,
-    }
-
-
-def _classification_metrics(model, loss_fn, x_values, y_values) -> dict[str, float]:
-    logits = model(x_values)
-    loss = loss_fn(logits, y_values).item()
-    accuracy = (logits.argmax(dim=1) == y_values).float().mean().item()
-    return {"loss": float(loss), "accuracy": float(accuracy)}
-
-
-def _fit_model(config: PlaygroundConfig, training_data: Mapping[str, Any]) -> tuple[Any, Any, pd.DataFrame]:
-    features = training_data["features"]
-    x_train = training_data["x_train"]
-    y_train = training_data["y_train"]
-    x_validation = training_data["x_validation"]
-    y_validation = training_data["y_validation"]
-    model = _build_model(features.shape[1], config)
-    loss_fn = nn.CrossEntropyLoss()
-    if config.optimizer == "SGD":
-        optimizer = torch.optim.SGD(model.parameters(), lr=config.learning_rate)
-    else:
-        optimizer = torch.optim.Adam(model.parameters(), lr=config.learning_rate)
-
-    history_rows: list[dict[str, float | int]] = []
-    epochs = max(1, int(config.epochs))
-    batch_size = max(4, min(int(config.batch_size), len(x_train)))
-    log_every = max(1, epochs // 40)
-
-    _append_history_row(history_rows, model, loss_fn, x_train, y_train, x_validation, y_validation, 0)
-    for epoch in range(1, epochs + 1):
-        model.train()
-        batch_order = torch.randperm(len(x_train))
-        for start in range(0, len(x_train), batch_size):
-            batch_indices = batch_order[start : start + batch_size]
-            optimizer.zero_grad()
-            batch_logits = model(x_train[batch_indices])
-            batch_loss = loss_fn(batch_logits, y_train[batch_indices])
-            batch_loss.backward()
-            optimizer.step()
-
-        if epoch == epochs or epoch % log_every == 0:
-            _append_history_row(history_rows, model, loss_fn, x_train, y_train, x_validation, y_validation, epoch)
-
-    return model, loss_fn, pd.DataFrame(history_rows)
-
-
-def _train_playground(config: PlaygroundConfig) -> dict[str, Any]:
-    if torch is None or nn is None:
-        samples = _make_dataset(config)
-        return {
-            "status": "missing_torch",
-            "detail": "Install the app dependencies to enable PyTorch training.",
-            "samples": samples,
-            "history": pd.DataFrame(columns=["epoch", "train_loss", "validation_loss", "train_accuracy", "validation_accuracy"]),
-            "grid": pd.DataFrame(columns=["x1", "x2", "probability"]),
-            "network_layers": _empty_network_layers(),
-            "activation_maps": _empty_activation_maps(),
-            "summary": {
-                "backend": "missing",
-                "samples": int(len(samples)),
-                "features": int(len(config.feature_names)),
-            },
-        }
-
-    torch.manual_seed(config.seed)
-    training_data = _prepare_training_data(config)
-    samples = training_data["samples"]
-    features = training_data["features"]
-    mean = training_data["mean"]
-    std = training_data["std"]
-    model, _loss_fn, history = _fit_model(config, training_data)
-    grid = _decision_grid(model, config, mean, std)
-    network_layers = _network_layers(model)
-    activation_maps = _hidden_activation_maps(model, config, mean, std)
-    final = history.iloc[-1].to_dict() if not history.empty else {}
-    return {
-        "status": "ok",
-        "detail": "",
-        "samples": samples,
-        "history": history,
-        "grid": grid,
-        "network_layers": network_layers,
-        "activation_maps": activation_maps,
-        "summary": {
-            "backend": "torch",
-            "samples": int(len(samples)),
-            "features": int(features.shape[1]),
-            "hidden_layers": list(config.hidden_layers),
-            "train_accuracy": float(final.get("train_accuracy", 0.0)),
-            "validation_accuracy": float(final.get("validation_accuracy", 0.0)),
-            "validation_loss": float(final.get("validation_loss", 0.0)),
-        },
-    }
-
-
-def _append_history_row(
-    rows: list[dict[str, float | int]],
-    model,
-    loss_fn,
-    x_train,
-    y_train,
-    x_validation,
-    y_validation,
-    epoch: int,
-) -> None:
-    model.eval()
-    with torch.no_grad():
-        train_metrics = _classification_metrics(model, loss_fn, x_train, y_train)
-        validation_metrics = _classification_metrics(model, loss_fn, x_validation, y_validation)
-    rows.append(
-        {
-            "epoch": int(epoch),
-            "train_loss": train_metrics["loss"],
-            "validation_loss": validation_metrics["loss"],
-            "train_accuracy": train_metrics["accuracy"],
-            "validation_accuracy": validation_metrics["accuracy"],
-        }
-    )
-
-
-def _decision_grid(model, config: PlaygroundConfig, mean: np.ndarray, std: np.ndarray) -> pd.DataFrame:
-    grid_points = _grid_points(config)
-    grid_features = (_feature_matrix(grid_points, config.feature_names) - mean) / std
-    model.eval()
-    with torch.no_grad():
-        logits = model(torch.tensor(grid_features, dtype=torch.float32))
-        probabilities = torch.softmax(logits, dim=1)[:, 1].cpu().numpy()
-    grid_points["probability"] = probabilities.astype(float)
-    return grid_points
-
-
-def _model_state_vector(model):
-    return torch.cat([parameter.detach().flatten().cpu() for parameter in model.parameters()])
-
-
-def _assign_model_state_vector(model, vector) -> None:
-    offset = 0
-    for parameter in model.parameters():
-        item_count = parameter.numel()
-        values = vector[offset : offset + item_count].reshape(parameter.shape).to(parameter.device, dtype=parameter.dtype)
-        parameter.data.copy_(values)
-        offset += item_count
-
-
-def _landscape_directions(center, seed: int) -> tuple[Any, Any]:
-    generator = torch.Generator()
-    generator.manual_seed(int(seed) + 7001)
-    first = torch.randn(center.shape, generator=generator, dtype=center.dtype)
-    second = torch.randn(center.shape, generator=generator, dtype=center.dtype)
-    first_norm = first.norm().clamp_min(1e-12)
-    first = first / first_norm
-    second = second - torch.dot(second, first) * first
-    second_norm = second.norm().clamp_min(1e-12)
-    second = second / second_norm
-    scale = center.norm().clamp_min(1.0)
-    return first * scale, second * scale
-
-
-def _normalized_landscape_resolution(value: int) -> int:
-    resolution = max(5, min(31, int(value)))
-    if resolution % 2 == 0:
-        resolution += 1
-    return resolution
-
-
-def _loss_landscape_summary(landscape: pd.DataFrame) -> dict[str, Any]:
-    if landscape.empty:
-        return {"status": "not_computed", "points": 0}
-    center_candidates = landscape[landscape["is_center"]]
-    center = center_candidates.iloc[0] if not center_candidates.empty else landscape.iloc[len(landscape) // 2]
-    best = landscape.loc[landscape["validation_loss"].idxmin()]
-    max_validation_loss = float(landscape["validation_loss"].max())
-    center_loss = float(center["validation_loss"])
-    return {
-        "status": "ok",
-        "points": int(len(landscape)),
-        "center_validation_loss": center_loss,
-        "center_train_loss": float(center["train_loss"]),
-        "center_validation_accuracy": float(center["validation_accuracy"]),
-        "best_validation_loss": float(best["validation_loss"]),
-        "best_alpha": float(best["alpha"]),
-        "best_beta": float(best["beta"]),
-        "best_delta": float(best["validation_loss"] - center_loss),
-        "sharpness": float(max(0.0, max_validation_loss - center_loss)),
-    }
-
-
-def _loss_landscape(config: PlaygroundConfig, *, resolution: int = 21, span: float = 0.75) -> dict[str, Any]:
-    if torch is None or nn is None:
-        return {
-            "status": "missing_torch",
-            "detail": "Install the app dependencies to enable the loss landscape.",
-            "loss_landscape": _empty_loss_landscape(),
-            "landscape_summary": _loss_landscape_summary(_empty_loss_landscape()),
-        }
-
-    torch.manual_seed(config.seed)
-    training_data = _prepare_training_data(config)
-    model, loss_fn, _history = _fit_model(config, training_data)
-    center = _model_state_vector(model)
-    first_direction, second_direction = _landscape_directions(center, config.seed)
-    resolution = _normalized_landscape_resolution(resolution)
-    span = max(0.05, min(2.0, float(span)))
-    axis = np.linspace(-span, span, resolution)
-    rows: list[dict[str, float | bool]] = []
-
-    try:
-        model.eval()
-        with torch.no_grad():
-            for alpha in axis:
-                for beta in axis:
-                    candidate = center + float(alpha) * first_direction + float(beta) * second_direction
-                    _assign_model_state_vector(model, candidate)
-                    train_metrics = _classification_metrics(model, loss_fn, training_data["x_train"], training_data["y_train"])
-                    validation_metrics = _classification_metrics(
-                        model,
-                        loss_fn,
-                        training_data["x_validation"],
-                        training_data["y_validation"],
-                    )
-                    rows.append(
-                        {
-                            "alpha": float(alpha),
-                            "beta": float(beta),
-                            "train_loss": train_metrics["loss"],
-                            "validation_loss": validation_metrics["loss"],
-                            "train_accuracy": train_metrics["accuracy"],
-                            "validation_accuracy": validation_metrics["accuracy"],
-                            "is_center": bool(np.isclose(alpha, 0.0) and np.isclose(beta, 0.0)),
-                        }
-                    )
-    finally:
-        _assign_model_state_vector(model, center)
-
-    landscape = pd.DataFrame(rows, columns=_empty_loss_landscape().columns)
-    return {
-        "status": "ok",
-        "detail": "",
-        "loss_landscape": landscape,
-        "landscape_summary": _loss_landscape_summary(landscape),
-    }
-
-
 @st.cache_data(show_spinner=False)
 def _cached_train(payload: dict[str, Any]) -> dict[str, Any]:
     config = PlaygroundConfig(
@@ -971,123 +292,18 @@ def _cached_loss_landscape(payload: dict[str, Any], resolution: int, span: float
     return _loss_landscape(config, resolution=resolution, span=span)
 
 
-def _json_safe(value: Any) -> Any:
-    if isinstance(value, Mapping):
-        return {str(key): _json_safe(item) for key, item in value.items()}
-    if isinstance(value, (list, tuple)):
-        return [_json_safe(item) for item in value]
-    if isinstance(value, np.integer):
-        return int(value)
-    if isinstance(value, np.floating):
-        number = float(value)
-        return number if np.isfinite(number) else None
-    if isinstance(value, float):
-        return value if np.isfinite(value) else None
-    return value
-
-
-def _json_bytes(payload: Mapping[str, Any]) -> bytes:
-    return json.dumps(_json_safe(payload), indent=2, sort_keys=True).encode("utf-8") + b"\n"
-
-
-def _dataframe_csv_bytes(frame: pd.DataFrame) -> bytes:
-    return frame.to_csv(index=False, float_format="%.10g").encode("utf-8")
-
-
-def _artifact_hash(payload: bytes) -> dict[str, Any]:
-    return {"sha256": hashlib.sha256(payload).hexdigest(), "bytes": len(payload)}
-
-
-def _result_frame(result: Mapping[str, Any], key: str, empty: pd.DataFrame) -> pd.DataFrame:
-    value = result.get(key)
-    return value if isinstance(value, pd.DataFrame) else empty
-
-
-def _evidence_artifact_files(config: PlaygroundConfig, result: Mapping[str, Any]) -> dict[str, bytes]:
-    samples = _result_frame(result, "samples", pd.DataFrame(columns=["x1", "x2", "target"]))
-    history = _result_frame(result, "history", pd.DataFrame(columns=["epoch", "train_loss", "validation_loss", "train_accuracy", "validation_accuracy"]))
-    grid = _result_frame(result, "grid", pd.DataFrame(columns=["x1", "x2", "probability"]))
-    network_layers = _result_frame(result, "network_layers", _empty_network_layers())
-    activation_maps = _result_frame(result, "activation_maps", _empty_activation_maps())
-    loss_landscape = _result_frame(result, "loss_landscape", _empty_loss_landscape())
-    return {
-        "config/playground_config.json": _json_bytes(_config_payload(config)),
-        "data/samples.csv": _dataframe_csv_bytes(samples),
-        "data/training_history.csv": _dataframe_csv_bytes(history),
-        "data/decision_grid.csv": _dataframe_csv_bytes(grid),
-        "model/network_layers.csv": _dataframe_csv_bytes(network_layers),
-        "model/hidden_activation_maps.csv": _dataframe_csv_bytes(activation_maps),
-        "model/loss_landscape.csv": _dataframe_csv_bytes(loss_landscape),
-        "summary/run_summary.json": _json_bytes(
-            {
-                "schema": EVIDENCE_SCHEMA,
-                "summary": result.get("summary", {}),
-                "landscape_summary": result.get("landscape_summary", _loss_landscape_summary(loss_landscape)),
-            }
-        ),
-    }
-
-
-def _build_evidence_manifest(config: PlaygroundConfig, result: Mapping[str, Any]) -> dict[str, Any]:
-    files = _evidence_artifact_files(config, result)
-    samples = _result_frame(result, "samples", pd.DataFrame())
-    history = _result_frame(result, "history", pd.DataFrame())
-    grid = _result_frame(result, "grid", pd.DataFrame())
-    network_layers = _result_frame(result, "network_layers", _empty_network_layers())
-    activation_maps = _result_frame(result, "activation_maps", _empty_activation_maps())
-    loss_landscape = _result_frame(result, "loss_landscape", _empty_loss_landscape())
-    return {
-        "schema": EVIDENCE_SCHEMA,
-        "config_schema": CONFIG_SCHEMA,
-        "app": "pytorch_playground_project",
-        "backend": result.get("summary", {}).get("backend", "unknown"),
-        "torch_version": getattr(torch, "__version__", None) if torch is not None else None,
-        "config": _config_payload(config)["config"],
-        "summary": result.get("summary", {}),
-        "landscape_summary": result.get("landscape_summary", _loss_landscape_summary(loss_landscape)),
-        "row_counts": {
-            "samples": int(len(samples)),
-            "training_history": int(len(history)),
-            "decision_grid": int(len(grid)),
-            "network_layers": int(len(network_layers)),
-            "hidden_activation_maps": int(len(activation_maps)),
-            "loss_landscape": int(len(loss_landscape)),
-        },
-        "artifacts": {name: _artifact_hash(payload) for name, payload in sorted(files.items())},
-    }
-
-
-def _deterministic_zip_bytes(files: Mapping[str, bytes]) -> bytes:
-    buffer = io.BytesIO()
-    with zipfile.ZipFile(buffer, mode="w", compression=zipfile.ZIP_DEFLATED) as archive:
-        for name in sorted(files):
-            info = zipfile.ZipInfo(name, ZIP_TIMESTAMP)
-            info.compress_type = zipfile.ZIP_DEFLATED
-            info.external_attr = 0o644 << 16
-            archive.writestr(info, files[name])
-    return buffer.getvalue()
-
-
-def _build_evidence_pack(config: PlaygroundConfig, result: Mapping[str, Any]) -> bytes:
-    files = _evidence_artifact_files(config, result)
-    files["manifest.json"] = _json_bytes(_build_evidence_manifest(config, result))
-    return _deterministic_zip_bytes(files)
-
-
 def _render_page_styles() -> None:
     st.markdown(
         """
 <style>
 .agilab-pt-hero {
-  border: 1px solid rgba(125, 211, 252, 0.22);
-  border-radius: 28px;
-  padding: 1.45rem 1.55rem;
+  border: 1px solid rgba(125, 211, 252, 0.24);
+  border-left: 4px solid #38bdf8;
+  border-radius: 8px;
+  padding: 1rem 1.1rem;
   margin: 0.25rem 0 1rem;
-  background:
-    radial-gradient(circle at 12% 10%, rgba(56, 189, 248, 0.34), transparent 28%),
-    radial-gradient(circle at 84% 18%, rgba(251, 113, 133, 0.28), transparent 30%),
-    linear-gradient(135deg, rgba(8, 18, 34, 0.96), rgba(15, 23, 42, 0.90));
-  box-shadow: 0 24px 70px rgba(2, 6, 23, 0.28);
+  background: rgba(12, 18, 32, 0.92);
+  box-shadow: 0 12px 32px rgba(2, 6, 23, 0.22);
 }
 .agilab-pt-kicker {
   color: #7dd3fc;
@@ -1098,9 +314,9 @@ def _render_page_styles() -> None:
 }
 .agilab-pt-hero h1 {
   color: #f8fafc;
-  font-size: clamp(2.0rem, 5vw, 4.5rem);
-  line-height: 0.95;
-  margin: 0.25rem 0 0.7rem;
+  font-size: 2.35rem;
+  line-height: 1.05;
+  margin: 0.2rem 0 0.55rem;
 }
 .agilab-pt-hero p {
   color: #cbd5e1;
@@ -1116,18 +332,18 @@ def _render_page_styles() -> None:
 }
 .agilab-pt-chip {
   border: 1px solid rgba(226, 232, 240, 0.22);
-  border-radius: 999px;
+  border-radius: 8px;
   color: #e2e8f0;
   background: rgba(15, 23, 42, 0.55);
-  padding: 0.38rem 0.72rem;
+  padding: 0.34rem 0.58rem;
   font-size: 0.82rem;
 }
 .agilab-pt-card {
   border: 1px solid rgba(148, 163, 184, 0.22);
-  border-radius: 22px;
+  border-radius: 8px;
   padding: 1rem;
   min-height: 9.25rem;
-  background: linear-gradient(180deg, rgba(15, 23, 42, 0.88), rgba(8, 13, 26, 0.78));
+  background: rgba(11, 18, 32, 0.84);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
 }
 .agilab-pt-card strong {
@@ -1166,13 +382,13 @@ def _render_page_styles() -> None:
 }
 .agilab-pt-step {
   border: 1px solid rgba(148, 163, 184, 0.20);
-  border-radius: 18px;
+  border-radius: 8px;
   padding: 0.85rem 0.9rem;
   background: rgba(15, 23, 42, 0.58);
 }
 .agilab-pt-step-active {
   border-color: rgba(251, 191, 36, 0.64);
-  background: linear-gradient(180deg, rgba(120, 53, 15, 0.55), rgba(15, 23, 42, 0.62));
+  background: rgba(88, 55, 16, 0.38);
 }
 .agilab-pt-step-ready {
   border-color: rgba(34, 197, 94, 0.46);
@@ -1187,7 +403,7 @@ def _render_page_styles() -> None:
 }
 .agilab-pt-insight {
   border: 1px solid rgba(125, 211, 252, 0.18);
-  border-radius: 18px;
+  border-radius: 8px;
   padding: 0.9rem;
   background: rgba(8, 13, 26, 0.66);
   min-height: 7rem;
@@ -1881,7 +1097,7 @@ def main() -> None:
             mime="application/zip",
         )
         st.code(f"?pytorch_playground={_encode_share_config(trained_config)}", language="text")
-        st.json(manifest)
+        st.code(json.dumps(_json_safe(manifest), indent=2, sort_keys=True), language="json")
 
 
 if __name__ == "__main__":

--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground/pytorch_playground.py
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground/pytorch_playground.py
@@ -59,7 +59,13 @@ class PytorchPlayground(BaseWorker):
     @property
     def analysis_artifact_dir(self) -> Path:
         export_root = Path(getattr(self.env, "AGILAB_EXPORT_ABS", Path.home() / "export"))
-        return export_root / self.env.target / "pytorch_playground"
+        target = str(
+            getattr(self.env, "target", "")
+            or getattr(self.env, "app", "")
+            or getattr(self.env, "active_app", "")
+            or "pytorch_playground_project"
+        )
+        return export_root / target / "pytorch_playground"
 
     @classmethod
     def from_toml(
@@ -85,8 +91,12 @@ class PytorchPlayground(BaseWorker):
         return self.args.model_dump(mode="json")
 
     def build_distribution(self, workers):
-        work_plan = [[["pytorch_playground"]]]
-        metadata = [[{"run": "pytorch_playground", "work_items": 1}]]
+        try:
+            worker_count = max(1, int(workers))
+        except (TypeError, ValueError):
+            worker_count = 1
+        work_plan = [[["pytorch_playground"]]] + [[] for _ in range(worker_count - 1)]
+        metadata = [[{"run": "pytorch_playground", "work_items": 1}]] + [[] for _ in range(worker_count - 1)]
         return work_plan, metadata, "run", "work_items", "items"
 
 

--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground_worker/pytorch_playground_worker.py
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground_worker/pytorch_playground_worker.py
@@ -14,7 +14,7 @@ import pandas as pd
 from agi_node.agi_dispatcher import BaseWorker
 from agi_node.pandas_worker import PandasWorker
 from pytorch_playground import PytorchPlaygroundArgs, to_playground_config
-from pytorch_playground.playground_ui import (
+from pytorch_playground.core import (
     _build_evidence_manifest,
     _build_evidence_pack,
     _evidence_artifact_files,
@@ -75,7 +75,7 @@ class PytorchPlaygroundWorker(PandasWorker):
         self.args.data_out = data_out
         self.data_out = data_out
         if self.args.reset_target and self.data_out.exists():
-            shutil.rmtree(self.data_out)
+            shutil.rmtree(self.data_out, ignore_errors=True)
         self.data_out.mkdir(parents=True, exist_ok=True)
         self.artifact_dir = _artifact_dir(self.env, "pytorch_playground")
         self.artifact_dir.mkdir(parents=True, exist_ok=True)

--- a/test/test_pytorch_playground_app.py
+++ b/test/test_pytorch_playground_app.py
@@ -652,16 +652,59 @@ def test_pytorch_playground_app_args_convert_to_playground_config(monkeypatch: p
     assert config.sample_count == 96
 
 
+def test_pytorch_playground_distribution_marks_extra_workers_idle(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.syspath_prepend(str(PROJECT_SRC.resolve()))
+    manager_module = importlib.import_module("pytorch_playground.pytorch_playground")
+
+    manager = manager_module.PytorchPlayground.__new__(manager_module.PytorchPlayground)
+    work_plan, metadata, id_name, count_name, label = manager.build_distribution(3)
+
+    assert work_plan == [[["pytorch_playground"]], [], []]
+    assert metadata == [[{"run": "pytorch_playground", "work_items": 1}], [], []]
+    assert (id_name, count_name, label) == ("run", "work_items", "items")
+
+
+def test_pytorch_playground_analysis_artifact_dir_uses_env_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.syspath_prepend(str(PROJECT_SRC.resolve()))
+    manager_module = importlib.import_module("pytorch_playground.pytorch_playground")
+
+    manager = manager_module.PytorchPlayground.__new__(manager_module.PytorchPlayground)
+    manager.env = SimpleNamespace(AGILAB_EXPORT_ABS=tmp_path, app="custom_playground")
+
+    assert manager.analysis_artifact_dir == tmp_path / "custom_playground" / "pytorch_playground"
+
+
+def test_pytorch_playground_app_settings_default_to_single_worker() -> None:
+    import tomllib
+
+    settings = tomllib.loads((PROJECT_PATH / "src" / "app_settings.toml").read_text(encoding="utf-8"))
+
+    assert settings["cluster"]["workers"] == {"127.0.0.1": 1}
+
+
+def test_pytorch_playground_app_args_form_uses_project_scoped_static_json() -> None:
+    source = (PROJECT_PATH / "src" / "app_args_form.py").read_text(encoding="utf-8")
+
+    assert "render_form(" not in source
+    assert "APP_FORM_ID" in source
+    assert "def _field_key" in source
+    assert "key=key" in source
+    assert "st.json(" not in source
+
+
 def test_pytorch_playground_worker_exports_evidence_without_torch(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
     monkeypatch.syspath_prepend(str(PROJECT_SRC.resolve()))
-    ui_module = importlib.import_module("pytorch_playground.playground_ui")
+    core_module = importlib.import_module("pytorch_playground.core")
     worker_module = importlib.import_module("pytorch_playground_worker.pytorch_playground_worker")
     args_module = importlib.import_module("pytorch_playground.app_args")
-    monkeypatch.setattr(ui_module, "torch", None)
-    monkeypatch.setattr(ui_module, "nn", None)
+    monkeypatch.setattr(core_module, "torch", None)
+    monkeypatch.setattr(core_module, "nn", None)
 
     worker = worker_module.PytorchPlaygroundWorker.__new__(worker_module.PytorchPlaygroundWorker)
     worker.args = args_module.PytorchPlaygroundArgs(
@@ -711,7 +754,7 @@ def test_pytorch_playground_main_covers_empty_and_error_ui_paths(monkeypatch: py
             self.infos: list[str] = []
             self.warnings: list[str] = []
             self.downloads: list[bytes] = []
-            self.json_payloads: list[dict[str, object]] = []
+            self.code_payloads: list[tuple[str, str | None]] = []
 
         def set_page_config(self, **_kwargs):
             return None
@@ -778,12 +821,12 @@ def test_pytorch_playground_main_covers_empty_and_error_ui_paths(monkeypatch: py
             self.downloads.append(data)
             return False
 
-        def code(self, *_args, **_kwargs):
+        def code(self, body, **kwargs):
+            self.code_payloads.append((str(body), kwargs.get("language")))
             return None
 
         def json(self, payload, **_kwargs):
-            self.json_payloads.append(payload)
-            return None
+            raise AssertionError(f"st.json should not be used by PyTorch Playground: {payload!r}")
 
     def empty_result(status: str = "ok") -> dict[str, object]:
         return {
@@ -814,7 +857,8 @@ def test_pytorch_playground_main_covers_empty_and_error_ui_paths(monkeypatch: py
     module.main()
     assert any("Hidden activation maps" in message for message in ok_st.infos)
     assert any("Enable computation" in message for message in ok_st.infos)
-    assert ok_st.json_payloads[0]["row_counts"]["loss_landscape"] == 0
+    manifest = next(json.loads(body) for body, language in ok_st.code_payloads if language == "json")
+    assert manifest["row_counts"]["loss_landscape"] == 0
 
     missing_st = FakeStreamlit(checkbox=True)
     monkeypatch.setattr(module, "st", missing_st)
@@ -852,7 +896,7 @@ def test_pytorch_playground_main_renders_with_fake_streamlit(monkeypatch: pytest
             self.session_state: dict[str, object] = {}
             self.sidebar = FakeContext()
             self.downloads: list[bytes] = []
-            self.json_payloads: list[dict[str, object]] = []
+            self.code_payloads: list[tuple[str, str | None]] = []
 
         def set_page_config(self, **_kwargs):
             return None
@@ -919,12 +963,12 @@ def test_pytorch_playground_main_renders_with_fake_streamlit(monkeypatch: pytest
             self.downloads.append(data)
             return False
 
-        def code(self, *_args, **_kwargs):
+        def code(self, body, **kwargs):
+            self.code_payloads.append((str(body), kwargs.get("language")))
             return None
 
         def json(self, payload, **_kwargs):
-            self.json_payloads.append(payload)
-            return None
+            raise AssertionError(f"st.json should not be used by PyTorch Playground: {payload!r}")
 
     fake_st = FakeStreamlit()
     config = module.PlaygroundConfig(sample_count=64, grid_size=12, hidden_layers=(2,))
@@ -1011,7 +1055,8 @@ def test_pytorch_playground_main_renders_with_fake_streamlit(monkeypatch: pytest
     module.main()
 
     assert fake_st.downloads
-    assert fake_st.json_payloads[0]["schema"] == module.EVIDENCE_SCHEMA
+    manifest = next(json.loads(body) for body, language in fake_st.code_payloads if language == "json")
+    assert manifest["schema"] == module.EVIDENCE_SCHEMA
 
 
 def test_pytorch_playground_app_provider_and_package_docs() -> None:


### PR DESCRIPTION
## Summary
- move PyTorch playground training/evidence primitives into UI-independent core modules
- avoid Streamlit st.json frontend chunk loading and scope sidebar widget keys per app
- align built-in and packaged payload copies, worker distribution, artifact fallback, and focused regressions

## Validation
- py_compile on changed PyTorch playground source and packaged payload files
- pytest -q -o addopts='' src/agilab/core/agi-env/test/test_app_settings_support.py test/test_pytorch_playground_app.py
- git diff --check
- Streamlit frontend smoke on localhost:8515
- direct /ORCHESTRATE?active_app=pytorch_playground_project smoke: status 200, no page errors, no failed static JS/CSS requests