### PR TITLE
[codex] Harden PyTorch playground regression evidence

### DIFF
--- a/src/agilab/apps/builtin/pytorch_playground_project/src/app_args_form.py
+++ b/src/agilab/apps/builtin/pytorch_playground_project/src/app_args_form.py
@@ -14,7 +14,7 @@ if str(_HERE) not in sys.path:
 
 from agi_env.streamlit_args import load_args_state, persist_args
 from pytorch_playground import app_args
-from pytorch_playground.core import ACTIVATIONS, DATASETS, FEATURES, OPTIMIZERS, _coerce_feature_names
+from pytorch_playground.core import ACTIVATIONS, DATASETS, OPTIMIZERS, _coerce_feature_names
 
 APP_FORM_ID = "pytorch_playground_args"
 
@@ -80,10 +80,8 @@ def _selectbox(container: Any, env: Any, name: str, label: str, options: tuple[s
 
 
 def _feature_names(container: Any, env: Any, value: str) -> str:
-    key = _field_key(env, "feature_names")
-    _seed_widget_value(key, list(_coerce_feature_names(value)))
-    selected = container.multiselect("Feature names", options=list(FEATURES), key=key)
-    return ",".join(str(item) for item in selected) if selected else app_args.DEFAULT_FEATURE_NAMES
+    selected = _coerce_feature_names(value)
+    return _text_input(container, env, "feature_names", "Feature names", ",".join(selected))
 
 
 def _render_args_form(model: app_args.PytorchPlaygroundArgs, *, env: Any, container: Any) -> dict[str, Any]:

--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/app_args_form.py
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/app_args_form.py
@@ -14,7 +14,7 @@ if str(_HERE) not in sys.path:
 
 from agi_env.streamlit_args import load_args_state, persist_args
 from pytorch_playground import app_args
-from pytorch_playground.core import ACTIVATIONS, DATASETS, FEATURES, OPTIMIZERS, _coerce_feature_names
+from pytorch_playground.core import ACTIVATIONS, DATASETS, OPTIMIZERS, _coerce_feature_names
 
 APP_FORM_ID = "pytorch_playground_args"
 
@@ -80,10 +80,8 @@ def _selectbox(container: Any, env: Any, name: str, label: str, options: tuple[s
 
 
 def _feature_names(container: Any, env: Any, value: str) -> str:
-    key = _field_key(env, "feature_names")
-    _seed_widget_value(key, list(_coerce_feature_names(value)))
-    selected = container.multiselect("Feature names", options=list(FEATURES), key=key)
-    return ",".join(str(item) for item in selected) if selected else app_args.DEFAULT_FEATURE_NAMES
+    selected = _coerce_feature_names(value)
+    return _text_input(container, env, "feature_names", "Feature names", ",".join(selected))
 
 
 def _render_args_form(model: app_args.PytorchPlaygroundArgs, *, env: Any, container: Any) -> dict[str, Any]:

--- a/test/test_agilab_widget_robot.py
+++ b/test/test_agilab_widget_robot.py
@@ -1783,6 +1783,16 @@ def test_browser_issue_capture_filters_noise_and_records_fatal_console() -> None
         kind="http.500",
         detail="HTTP 500 https://demo/api/run",
     )
+    module._record_browser_issue(
+        issues,
+        kind="http.404",
+        detail="HTTP 404 http://demo/ORCHESTRATE/_stcore/health",
+    )
+    module._record_browser_issue(
+        issues,
+        kind="http.404",
+        detail="HTTP 404 http://demo/ORCHESTRATE/_stcore/host-config",
+    )
 
     assert issues == [
         {"kind": "console.error", "detail": "Uncaught RuntimeError: AGI execution failed."},

--- a/test/test_agilab_widget_robot_full.py
+++ b/test/test_agilab_widget_robot_full.py
@@ -205,3 +205,74 @@ def test_full_public_orchestrate_widget_robot_sweep() -> None:
         }
         actual_apps = {page["app"] for page in payload["pages"]}
         assert expected_apps <= actual_apps
+
+
+@pytest.mark.ui_robot
+def test_pytorch_playground_orchestrate_screenshot_robot(tmp_path: Path) -> None:
+    """Opt-in browser evidence for the PyTorch playground ORCHESTRATE page.
+
+    Run with:
+    REPO_ROOT="$(git rev-parse --show-toplevel)"
+    cd "$REPO_ROOT"
+    AGILAB_RUN_PYTORCH_PLAYGROUND_UI_ROBOT=1 uv --preview-features extra-build-dependencies run --with playwright pytest -q -o addopts='' -m ui_robot "$REPO_ROOT/test/test_agilab_widget_robot_full.py::test_pytorch_playground_orchestrate_screenshot_robot"
+    """
+
+    if os.environ.get("AGILAB_RUN_PYTORCH_PLAYGROUND_UI_ROBOT") != "1":
+        pytest.skip("set AGILAB_RUN_PYTORCH_PLAYGROUND_UI_ROBOT=1 to run the PyTorch playground screenshot robot")
+
+    screenshot_dir = tmp_path / "screenshots"
+    json_output = tmp_path / "pytorch-playground-orchestrate.json"
+    progress_log = tmp_path / "pytorch-playground-orchestrate.ndjson"
+    command = [
+        sys.executable,
+        str(REPO_ROOT / "tools/agilab_widget_robot.py"),
+        "--apps",
+        "pytorch_playground_project",
+        "--pages",
+        "ORCHESTRATE",
+        "--apps-pages",
+        "none",
+        "--json",
+        "--json-output",
+        str(json_output),
+        "--progress-log",
+        str(progress_log),
+        "--screenshot-dir",
+        str(screenshot_dir),
+        "--interaction-mode",
+        "actionability",
+        "--action-button-policy",
+        "trial",
+        "--combination-mode",
+        "off",
+        "--runtime-isolation",
+        os.environ.get("AGILAB_PYTORCH_PLAYGROUND_ROBOT_RUNTIME_ISOLATION", "current-home"),
+        "--success-screenshot",
+        "--browser-error-check",
+        "--layout-integrity-check",
+        "--timeout",
+        os.environ.get("AGILAB_PYTORCH_PLAYGROUND_ROBOT_TIMEOUT", "60"),
+        "--widget-timeout",
+        os.environ.get("AGILAB_PYTORCH_PLAYGROUND_ROBOT_WIDGET_TIMEOUT", "5"),
+        "--target-seconds",
+        os.environ.get("AGILAB_PYTORCH_PLAYGROUND_ROBOT_TARGET_SECONDS", "180"),
+        "--quiet-progress",
+    ]
+
+    completed = _run_widget_robot(command)
+    if "playwright install" in completed.stdout.lower() or "no module named playwright" in completed.stdout.lower():
+        pytest.skip("Playwright is not installed; run `uv run --with playwright python -m playwright install chromium`")
+    assert completed.returncode == 0, completed.stdout
+    payload = json.loads(completed.stdout)
+    assert payload["success"] is True
+    assert payload["failed_count"] == 0
+    assert payload["page_count"] == 1
+    page = payload["pages"][0]
+    assert page["app"] == "pytorch_playground_project"
+    assert page["page"] == "ORCHESTRATE"
+    assert page["status"] == "passed"
+    assert page["widget_count"] >= 3
+    screenshots = sorted(screenshot_dir.rglob("*.png"))
+    assert screenshots
+    assert (screenshot_dir / "screenshot_manifest.json").is_file()
+    assert json.loads(json_output.read_text(encoding="utf-8"))["success"] is True

--- a/test/test_pytorch_playground_app.py
+++ b/test/test_pytorch_playground_app.py
@@ -20,7 +20,11 @@ MODULE_PATH = Path(
 INIT_PATH = Path("src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/__init__.py")
 README_PATH = Path("src/agilab/lib/agi-app-pytorch-playground/README.md")
 PROJECT_PATH = Path("src/agilab/apps/builtin/pytorch_playground_project")
+PACKAGE_PROJECT_PATH = Path(
+    "src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project"
+)
 PROJECT_SRC = PROJECT_PATH / "src"
+EXPECTED_SOURCE_PAYLOAD_DIFFS = {Path("pytorch_playground_worker/pyproject.toml")}
 
 
 def _load_module():
@@ -30,6 +34,18 @@ def _load_module():
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)
     return module
+
+
+def _runtime_payload_files(root: Path) -> set[Path]:
+    return {
+        path.relative_to(root)
+        for path in root.rglob("*")
+        if path.is_file()
+        and "__pycache__" not in path.parts
+        and ".venv" not in path.parts
+        and path.suffix != ".pyc"
+        and not any(part.endswith(".egg-info") for part in path.parts)
+    }
 
 
 def test_pytorch_playground_dataset_generation_is_deterministic() -> None:
@@ -693,6 +709,28 @@ def test_pytorch_playground_app_args_form_uses_project_scoped_static_json() -> N
     assert "def _field_key" in source
     assert "key=key" in source
     assert "st.json(" not in source
+    assert ".multiselect(" not in source
+
+
+def test_pytorch_playground_source_and_packaged_payload_stay_aligned() -> None:
+    source_root = PROJECT_PATH / "src"
+    payload_root = PACKAGE_PROJECT_PATH / "src"
+    source_files = _runtime_payload_files(source_root)
+    payload_files = _runtime_payload_files(payload_root)
+
+    assert source_files == payload_files
+
+    mismatches = [
+        str(relative)
+        for relative in sorted(source_files - EXPECTED_SOURCE_PAYLOAD_DIFFS)
+        if (source_root / relative).read_bytes() != (payload_root / relative).read_bytes()
+    ]
+    assert mismatches == []
+
+    source_worker_manifest = (source_root / "pytorch_playground_worker" / "pyproject.toml").read_text(encoding="utf-8")
+    payload_worker_manifest = (payload_root / "pytorch_playground_worker" / "pyproject.toml").read_text(encoding="utf-8")
+    assert "[tool.uv.sources]" in source_worker_manifest
+    assert "[tool.uv.sources]" not in payload_worker_manifest
 
 
 def test_pytorch_playground_worker_exports_evidence_without_torch(
@@ -725,6 +763,53 @@ def test_pytorch_playground_worker_exports_evidence_without_torch(
     assert manifest["app"] == "pytorch_playground_project"
     assert (tmp_path / "out" / "pytorch_playground_evidence.zip").is_file()
     assert (tmp_path / "export" / "pytorch_playground_project" / "pytorch_playground" / "manifest.json").is_file()
+
+
+def test_pytorch_playground_worker_exports_real_torch_evidence_when_available(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.syspath_prepend(str(PROJECT_SRC.resolve()))
+    core_module = importlib.import_module("pytorch_playground.core")
+    if core_module.torch is None:
+        pytest.skip("torch is not installed in this validation environment")
+
+    worker_module = importlib.import_module("pytorch_playground_worker.pytorch_playground_worker")
+    args_module = importlib.import_module("pytorch_playground.app_args")
+
+    worker = worker_module.PytorchPlaygroundWorker.__new__(worker_module.PytorchPlaygroundWorker)
+    worker.args = args_module.PytorchPlaygroundArgs(
+        data_out=tmp_path / "out",
+        dataset="gaussian",
+        sample_count=40,
+        hidden_layers="4",
+        feature_names="x1,x2",
+        epochs=2,
+        batch_size=16,
+        grid_size=12,
+        compute_loss_landscape=True,
+        landscape_resolution=5,
+        landscape_span=0.2,
+        reset_target=True,
+    ).model_dump(mode="json")
+    worker.env = SimpleNamespace(target="pytorch_playground_project", AGILAB_EXPORT_ABS=tmp_path / "export")
+    worker._worker_id = 0
+
+    worker.start()
+    summary = worker.work_pool("pytorch_playground")
+
+    assert summary.iloc[0]["backend"] == "torch"
+    assert summary.iloc[0]["loss_landscape_points"] == 25
+    manifest = json.loads((tmp_path / "out" / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["backend"] == "torch"
+    assert manifest["row_counts"]["training_history"] >= 2
+    assert manifest["row_counts"]["decision_grid"] == 144
+    assert manifest["row_counts"]["loss_landscape"] == 25
+    assert manifest["torch_version"]
+    archive_path = tmp_path / "out" / "pytorch_playground_evidence.zip"
+    with zipfile.ZipFile(archive_path, "r") as archive:
+        assert "manifest.json" in archive.namelist()
+        assert json.loads(archive.read("manifest.json").decode("utf-8"))["backend"] == "torch"
 
 
 def test_pytorch_playground_main_covers_empty_and_error_ui_paths(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tools/agilab_widget_robot.py
+++ b/tools/agilab_widget_robot.py
@@ -206,6 +206,8 @@ BROWSER_ISSUE_IGNORE_NEEDLES = (
     "favicon",
     "failed to load resource",
     "net::err_aborted",
+    "/_stcore/health",
+    "/_stcore/host-config",
     "websocket",
 )
 PAGE_EXPECTED_TEXT = {


### PR DESCRIPTION
## Summary
- add parity coverage so the built-in PyTorch playground and packaged app payload do not drift
- add real torch evidence regression coverage when torch is available
- add an opt-in ORCHESTRATE screenshot robot for the PyTorch playground
- remove the app-args multiselect that caused layout overlap in ORCHESTRATE
- filter noisy nested Streamlit _stcore health/host-config 404s from browser-error robot checks

## Validation
- `uv --preview-features extra-build-dependencies run --extra ui pytest -q -o addopts='' test/test_agilab_widget_robot.py test/test_agilab_widget_robot_full.py test/test_pytorch_playground_app.py test/test_agilab_widget_robot_matrix.py`
- `AGILAB_RUN_PYTORCH_PLAYGROUND_UI_ROBOT=1 uv --preview-features extra-build-dependencies run --extra ui --with playwright pytest -q -o addopts='' -m ui_robot test/test_agilab_widget_robot_full.py::test_pytorch_playground_orchestrate_screenshot_robot`
- direct `tools/agilab_widget_robot.py` PyTorch ORCHESTRATE screenshot run wrote `/tmp/agilab-pytorch-playground-orchestrate-screenshots/`
- real torch evidence run wrote `/tmp/agilab-pytorch-playground-real-evidence/`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui`
- `git diff --check`
