### PR TITLE
Hide analysis scaffold templates from launcher

### DIFF
--- a/src/agilab/pages/4_ANALYSIS.py
+++ b/src/agilab/pages/4_ANALYSIS.py
@@ -1049,6 +1049,7 @@ _ANALYSIS_DISCOVERY_SKIP_DIRS = {
     ".ruff_cache",
     ".venv",
     "__pycache__",
+    "templates",
     "venv",
 }
 _VIEW_DISCOVERY_CACHE: dict[Path, tuple[tuple[Any, ...], tuple[Path, ...]]] = {}
@@ -1120,7 +1121,11 @@ def _discover_views_uncached(pages_dir: Path) -> list[Path]:
         return []
 
     for entry in pages_dir.iterdir():
-        if entry.name.startswith(".") or entry.name.startswith("_"):
+        if (
+            entry.name in _ANALYSIS_DISCOVERY_SKIP_DIRS
+            or entry.name.startswith(".")
+            or entry.name.startswith("_")
+        ):
             continue
         if entry.is_dir():
             entrypoint = _find_view_entrypoint(entry)
@@ -1212,6 +1217,9 @@ def _find_view_entrypoint(view_root: Path) -> Path | None:
             return None
         return view_root.resolve()
 
+    if view_root.name in _ANALYSIS_DISCOVERY_SKIP_DIRS:
+        return None
+
     module = view_root.name
     candidates: list[Path] = [
         view_root / "src" / module / (module + ".py"),
@@ -1241,7 +1249,7 @@ def _find_view_entrypoint(view_root: Path) -> Path | None:
     # Fallback: for custom or cloned pages where folder/module names differ, pick a
     # deterministic entry script under the page bundle.
     fallback_files = []
-    skip_dir = {".venv", "venv", ".git", ".pytest_cache", "__pycache__", ".mypy_cache"}
+    skip_dir = set(_ANALYSIS_DISCOVERY_SKIP_DIRS)
     for dirpath, dirnames, filenames in os.walk(view_root):
         dirnames[:] = [
             d

--- a/test/test_analysis_page_helpers.py
+++ b/test/test_analysis_page_helpers.py
@@ -184,6 +184,23 @@ def test_discover_views_uses_cache_until_directory_signature_changes(tmp_path: P
     assert calls == [pages_root.resolve(), pages_root.resolve()]
 
 
+def test_discover_views_skips_scaffold_templates(tmp_path: Path):
+    module = _load_analysis_module()
+    module._VIEW_DISCOVERY_CACHE.clear()
+    pages_root = tmp_path / "apps-pages"
+    real_view_root = pages_root / "view_real" / "src" / "view_real"
+    template_root = pages_root / "templates" / "analysis_page_template" / "src" / "view_demo"
+    real_view_root.mkdir(parents=True)
+    template_root.mkdir(parents=True)
+    real_view = (real_view_root / "view_real.py").resolve()
+    template_view = (template_root / "view_demo.py").resolve()
+    real_view.write_text("def main(): pass\n", encoding="utf-8")
+    template_view.write_text("def main(): pass\n", encoding="utf-8")
+
+    assert module.discover_views(pages_root) == [real_view]
+    assert module._find_view_entry("templates", pages_root) is None
+
+
 def test_discover_project_notebooks_uses_cache_until_directory_signature_changes(
     tmp_path: Path,
     monkeypatch,


### PR DESCRIPTION
## Summary
- reserve apps-pages/templates for scaffold sources instead of runnable ANALYSIS views
- prevent direct template directory resolution from producing a sidebar entry
- add regression coverage that the blank template still exists while discovery skips it

## Validation
- uv --preview-features extra-build-dependencies run --with streamlit --with tomli-w --no-sync pytest -q -o addopts='' test/test_analysis_page_helpers.py
- uv --preview-features extra-build-dependencies run --with streamlit --with tomli-w --no-sync pytest -q -o addopts='' test/test_ui_pages.py test/test_analysis_page_helpers.py

Note: tools/workflow_parity.py --profile agi-gui was attempted and failed in the unrelated ORCHESTRATE pages-flow chunk on test_execute_page_cluster_settings while local run-button edits were intentionally kept out of this PR.