### PR TITLE
test: cover service submit orchestration

### DIFF
--- a/src/agilab/orchestrate_services.py
+++ b/src/agilab/orchestrate_services.py
@@ -33,6 +33,7 @@ SERVICE_SESSION_DEFAULTS: dict[str, Any] = {
     "service_log_cache": "",
     "service_status_cache": "idle",
     "service_snapshot_path_cache": "",
+    "service_last_submit_cache": {},
     "service_poll_interval": DEFAULT_SERVICE_POLL_INTERVAL_SEC,
     "service_stop_timeout": DEFAULT_SERVICE_STOP_TIMEOUT_SEC,
     "service_shutdown_on_stop": True,
@@ -100,6 +101,7 @@ class ServiceWorkflowStatus(str, Enum):
 
 class OrchestrateServiceAction(str, Enum):
     START = "start"
+    SUBMIT = "submit"
     STATUS = "status"
     HEALTH_GATE = "health"
     EXPORT_SNAPSHOT = "export_snapshot"
@@ -215,14 +217,23 @@ def build_orchestrate_service_state(
 
     all_actions = (
         OrchestrateServiceAction.START,
+        OrchestrateServiceAction.SUBMIT,
         OrchestrateServiceAction.STATUS,
         OrchestrateServiceAction.HEALTH_GATE,
         OrchestrateServiceAction.EXPORT_SNAPSHOT,
         OrchestrateServiceAction.STOP,
     )
     if enabled:
-        available_actions = all_actions
         blocked_actions: dict[OrchestrateServiceAction, str] = {}
+        available_actions_list = list(all_actions)
+        if status not in {
+            ServiceWorkflowStatus.RUNNING,
+            ServiceWorkflowStatus.DEGRADED,
+            ServiceWorkflowStatus.UNKNOWN,
+        }:
+            available_actions_list.remove(OrchestrateServiceAction.SUBMIT)
+            blocked_actions[OrchestrateServiceAction.SUBMIT] = "Start service before submitting work."
+        available_actions = tuple(available_actions_list)
     else:
         available_actions = ()
         blocked_actions = {
@@ -319,6 +330,47 @@ async def main():
         cleanup_failed_max_files={int(service_cleanup_failed_max_files)},
         cleanup_heartbeat_max_files={int(service_cleanup_heartbeat_max_files)},
         {args_serialized}
+    )
+    print(res)
+    return res
+
+if __name__ == "__main__":
+    asyncio.run(main())""")
+
+
+def _service_submit_task_name(env: Any) -> str:
+    target = str(getattr(env, "target", "") or getattr(env, "app", "") or "agilab").strip()
+    return f"{target or 'agilab'}-service-run"
+
+
+def build_service_submit_snippet(
+    *,
+    env: Any,
+    verbose: int,
+    workers: str,
+    args_serialized: str,
+) -> str:
+    arguments = [
+        "app_env",
+        f"workers={workers}",
+        f"task_name={json.dumps(_service_submit_task_name(env))}",
+    ]
+    serialized_args = args_serialized.strip().rstrip(",")
+    if serialized_args:
+        arguments.append(serialized_args)
+    argument_block = ",\n        ".join(arguments)
+    return textwrap.dedent(f"""
+import asyncio
+from agi_cluster.agi_distributor import AGI
+from agi_env import AgiEnv
+
+APPS_PATH = "{snippet_apps_path(env)}"
+APP = "{env.app}"
+
+async def main():
+    app_env = AgiEnv(apps_path=APPS_PATH, app=APP, verbose={verbose})
+    res = await AGI.submit(
+        {argument_block}
     )
     print(res)
     return res
@@ -626,12 +678,19 @@ async def render_service_panel(
 
         preview_action = st.selectbox(
             "Service snippet action",
-            options=["start", "status", "health", "stop"],
+            options=["start", "submit", "status", "health", "stop"],
             index=0,
             key="service_snippet_action",
         )
-        st.code(
-            build_service_snippet(
+        preview_snippet = (
+            build_service_submit_snippet(
+                env=env,
+                verbose=verbose,
+                workers=workers,
+                args_serialized=st.session_state.args_serialized,
+            )
+            if preview_action == "submit"
+            else build_service_snippet(
                 env=env,
                 verbose=verbose,
                 service_action=preview_action,
@@ -649,17 +708,27 @@ async def render_service_panel(
                 service_cleanup_failed_max_files=int(service_cleanup_failed_max_files),
                 service_cleanup_heartbeat_max_files=int(service_cleanup_heartbeat_max_files),
                 args_serialized=st.session_state.args_serialized,
-            ),
+            )
+        )
+        st.code(
+            preview_snippet,
             language="python",
         )
 
-        start_col, status_col, health_col, export_col, stop_col = st.columns(5)
+        start_col, submit_col, status_col, health_col, export_col, stop_col = st.columns(6)
         start_service_clicked = action_button(
             start_col,
             "START service",
             key="service_start_btn",
             kind="run",
             disabled=not service_state.can(OrchestrateServiceAction.START),
+        )
+        submit_service_clicked = action_button(
+            submit_col,
+            "SUBMIT job",
+            key="service_submit_btn",
+            kind="run",
+            disabled=not service_state.can(OrchestrateServiceAction.SUBMIT),
         )
         status_service_clicked = action_button(
             status_col,
@@ -765,7 +834,7 @@ async def render_service_panel(
                 return ActionResult.error(
                     "Unsupported service action.",
                     detail=f"Unknown service action: {action_name}",
-                    next_action="Use START, STATUS, HEALTH gate, EXPORT snapshot, or STOP.",
+                    next_action="Use START, SUBMIT, STATUS, HEALTH gate, EXPORT snapshot, or STOP.",
                     data={"action": action_name},
                 )
             current_state = build_orchestrate_service_state(
@@ -777,10 +846,11 @@ async def render_service_panel(
                 heartbeat_timeout_sec=float(service_heartbeat_timeout),
             )
             if not current_state.can(action):
+                blocked_detail = current_state.blocked_actions.get(action, "Service action is blocked.")
                 return ActionResult.warning(
                     "Service action is unavailable.",
-                    detail=current_state.blocked_actions.get(action, "Service action is blocked."),
-                    next_action="Enable Cluster in deployment settings before using service mode.",
+                    detail=blocked_detail,
+                    next_action=blocked_detail,
                     data={"action": action.value, "status": current_state.status.value},
                 )
 
@@ -819,24 +889,33 @@ async def render_service_panel(
                 )
 
             _render_logs()
-            cmd_service = build_service_snippet(
-                env=env,
-                verbose=verbose,
-                service_action=action_name,
-                service_mode=current_state.mode,
-                scheduler=scheduler,
-                workers=workers,
-                service_poll_interval=float(service_poll_interval),
-                service_shutdown_on_stop=bool(service_shutdown_on_stop),
-                service_stop_timeout=float(service_stop_timeout),
-                service_heartbeat_timeout=float(service_heartbeat_timeout),
-                service_cleanup_done_ttl_hours=float(service_cleanup_done_ttl_hours),
-                service_cleanup_failed_ttl_hours=float(service_cleanup_failed_ttl_hours),
-                service_cleanup_heartbeat_ttl_hours=float(service_cleanup_heartbeat_ttl_hours),
-                service_cleanup_done_max_files=int(service_cleanup_done_max_files),
-                service_cleanup_failed_max_files=int(service_cleanup_failed_max_files),
-                service_cleanup_heartbeat_max_files=int(service_cleanup_heartbeat_max_files),
-                args_serialized=st.session_state.args_serialized,
+            cmd_service = (
+                build_service_submit_snippet(
+                    env=env,
+                    verbose=verbose,
+                    workers=workers,
+                    args_serialized=st.session_state.args_serialized,
+                )
+                if action is OrchestrateServiceAction.SUBMIT
+                else build_service_snippet(
+                    env=env,
+                    verbose=verbose,
+                    service_action=action_name,
+                    service_mode=current_state.mode,
+                    scheduler=scheduler,
+                    workers=workers,
+                    service_poll_interval=float(service_poll_interval),
+                    service_shutdown_on_stop=bool(service_shutdown_on_stop),
+                    service_stop_timeout=float(service_stop_timeout),
+                    service_heartbeat_timeout=float(service_heartbeat_timeout),
+                    service_cleanup_done_ttl_hours=float(service_cleanup_done_ttl_hours),
+                    service_cleanup_failed_ttl_hours=float(service_cleanup_failed_ttl_hours),
+                    service_cleanup_heartbeat_ttl_hours=float(service_cleanup_heartbeat_ttl_hours),
+                    service_cleanup_done_max_files=int(service_cleanup_done_max_files),
+                    service_cleanup_failed_max_files=int(service_cleanup_failed_max_files),
+                    service_cleanup_heartbeat_max_files=int(service_cleanup_heartbeat_max_files),
+                    args_serialized=st.session_state.args_serialized,
+                )
             )
             service_stdout = ""
             service_stderr = ""
@@ -870,8 +949,32 @@ async def render_service_panel(
                 deps.append_log_lines(local_log, service_stderr)
 
             result_payload = deps.extract_result_dict_from_output(service_stdout)
-            if isinstance(result_payload, dict) and isinstance(result_payload.get("status"), str):
+            display_status = st.session_state.get("service_status_cache", "unknown")
+            if action is OrchestrateServiceAction.SUBMIT and isinstance(result_payload, dict):
+                st.session_state["service_last_submit_cache"] = result_payload
+                submit_status = str(result_payload.get("status") or "").strip()
+                if submit_status:
+                    display_status = submit_status
+                if submit_status == "queued":
+                    st.session_state["service_status_cache"] = "running"
+                    display_status = "queued"
+                elif submit_status:
+                    st.session_state["service_status_cache"] = submit_status
+                queued_files = result_payload.get("queued_files") or []
+                task_id = result_payload.get("task_id")
+                queue_dir = result_payload.get("queue_dir")
+                if task_id:
+                    deps.append_log_lines(local_log, f"service_task_id={task_id}")
+                if queue_dir:
+                    deps.append_log_lines(local_log, f"service_queue_dir={queue_dir}")
+                if queued_files:
+                    deps.append_log_lines(local_log, "=== Service queued files ===")
+                    for queued_file in queued_files:
+                        deps.append_log_lines(local_log, str(queued_file))
+                _render_service_operator_summary()
+            elif isinstance(result_payload, dict) and isinstance(result_payload.get("status"), str):
                 st.session_state["service_status_cache"] = result_payload["status"]
+                display_status = st.session_state["service_status_cache"]
                 if st.session_state["service_status_cache"] in {"stopped", "idle"}:
                     st.session_state["service_health_cache"] = []
                     _render_service_health_table()
@@ -955,12 +1058,14 @@ async def render_service_panel(
                     )
             return ActionResult.success(
                 f"Service action '{action_name}' completed with status "
-                f"'{st.session_state.get('service_status_cache', 'unknown')}'.",
+                f"'{display_status}'.",
                 data={"action": action_name, "payload": result_payload},
             )
 
         if start_service_clicked:
             render_action_result(st, await _execute_service_action("start"))
+        elif submit_service_clicked:
+            render_action_result(st, await _execute_service_action("submit"))
         elif status_service_clicked:
             render_action_result(st, await _execute_service_action("status"))
         elif health_gate_clicked:

--- a/test/test_orchestrate_services.py
+++ b/test/test_orchestrate_services.py
@@ -85,6 +85,22 @@ def test_service_path_and_status_helpers_cover_defensive_edges(tmp_path):
     ) is orchestrate_services.ServiceWorkflowStatus.UNKNOWN
 
 
+def test_snippet_apps_path_falls_back_when_app_is_missing_or_probe_fails(monkeypatch):
+    assert orchestrate_services.snippet_apps_path(SimpleNamespace(apps_path="/tmp/apps", app="")) == "/tmp/apps"
+
+    class FailingPathMeta(type):
+        def __instancecheck__(cls, instance):
+            return False
+
+    class FailingPath(metaclass=FailingPathMeta):
+        def __new__(cls, _value):
+            raise RuntimeError("path probe failed")
+
+    monkeypatch.setattr(orchestrate_services, "Path", FailingPath)
+
+    assert orchestrate_services.snippet_apps_path(SimpleNamespace(apps_path="/tmp/apps", app="demo")) == "/tmp/apps"
+
+
 def test_service_mode_flags_and_defaults_are_named_constants():
     assert orchestrate_services.SERVICE_MODE_POOL == 1
     assert orchestrate_services.SERVICE_MODE_CYTHON == 2
@@ -179,6 +195,34 @@ def test_build_service_snippet_embeds_core_parameters():
     assert 'APP = "demo"' in snippet
     assert "cleanup_failed_max_files=22" in snippet
     assert "foo=1, bar=2" in snippet
+
+
+def test_build_service_submit_snippet_embeds_workers_task_and_args():
+    snippet = orchestrate_services.build_service_submit_snippet(
+        env=SimpleNamespace(apps_path="/tmp/apps", app="demo_project", target="demo"),
+        verbose=2,
+        workers="{'127.0.0.1': 1}",
+        args_serialized="foo=1, bar='x'",
+    )
+
+    assert "AGI.submit(" in snippet
+    assert 'APP = "demo_project"' in snippet
+    assert "workers={'127.0.0.1': 1}" in snippet
+    assert 'task_name="demo-service-run"' in snippet
+    assert "foo=1, bar='x'" in snippet
+
+
+def test_build_service_submit_snippet_omits_empty_args_and_defaults_task_name():
+    snippet = orchestrate_services.build_service_submit_snippet(
+        env=SimpleNamespace(apps_path="/tmp/apps", app="demo_project"),
+        verbose=2,
+        workers="{'127.0.0.1': 1}",
+        args_serialized=" , ",
+    )
+
+    assert 'task_name="demo_project-service-run"' in snippet
+    assert "workers={'127.0.0.1': 1}," in snippet
+    assert "foo=" not in snippet
 
 
 def test_build_service_snippet_preserves_builtin_apps_path(tmp_path):
@@ -309,7 +353,39 @@ def test_build_orchestrate_service_state_blocks_actions_when_cluster_disabled():
     assert state.blocked_actions[orchestrate_services.OrchestrateServiceAction.START].startswith(
         "Enable Cluster"
     )
+    assert state.blocked_actions[orchestrate_services.OrchestrateServiceAction.SUBMIT].startswith(
+        "Enable Cluster"
+    )
     assert state.summary["tracked_workers"] == 0
+
+
+def test_build_orchestrate_service_state_blocks_submit_until_service_running():
+    state = orchestrate_services.build_orchestrate_service_state(
+        session_state={"service_status_cache": "idle"},
+        cluster_params={"cluster_enabled": True, "pool": True},
+        allow_idle=False,
+        max_unhealthy=0,
+        max_restart_rate=0.25,
+        heartbeat_timeout_sec=10.0,
+    )
+
+    assert orchestrate_services.OrchestrateServiceAction.START in state.available_actions
+    assert orchestrate_services.OrchestrateServiceAction.SUBMIT not in state.available_actions
+    assert state.blocked_actions[orchestrate_services.OrchestrateServiceAction.SUBMIT] == (
+        "Start service before submitting work."
+    )
+
+    running_state = orchestrate_services.build_orchestrate_service_state(
+        session_state={"service_status_cache": "running"},
+        cluster_params={"cluster_enabled": True, "pool": True},
+        allow_idle=False,
+        max_unhealthy=0,
+        max_restart_rate=0.25,
+        heartbeat_timeout_sec=10.0,
+    )
+
+    assert orchestrate_services.OrchestrateServiceAction.SUBMIT in running_state.available_actions
+    assert running_state.blocked_actions == {}
 
 
 def test_build_orchestrate_service_state_classifies_running_degraded_and_snapshot():
@@ -409,6 +485,7 @@ def _service_st(session_state, *, clicked: str | None = None):
     def columns(count):
         keys = [
             "service_start_btn",
+            "service_submit_btn",
             "service_status_btn",
             "service_health_gate_btn",
             "service_export_btn",
@@ -567,6 +644,201 @@ def test_render_service_panel_health_gate_action(monkeypatch, tmp_path):
     assert fake_st._placeholders[1].last_df is not None
     assert fake_st._placeholders[2].last_info is not None
     assert "Unhealthy workers: `1`" in fake_st._placeholders[2].last_info
+
+
+def test_render_service_panel_submit_action_queues_work(monkeypatch, tmp_path):
+    session_state = _SessionState(
+        {
+            "args_serialized": "foo=1",
+            "app_settings": {"cluster": {}},
+            "service_status_cache": "running",
+        }
+    )
+    fake_st = _service_st(session_state, clicked="service_submit_btn")
+    monkeypatch.setattr(orchestrate_services, "st", fake_st)
+
+    submit_payload = {
+        "status": "queued",
+        "task_id": "task-1",
+        "queue_dir": str(tmp_path / "queue"),
+        "queued_files": [str(tmp_path / "queue" / "task-1.json")],
+    }
+    captured: dict[str, object] = {}
+
+    async def fake_run_agi(cmd, **kwargs):
+        captured["cmd"] = cmd
+        callback = kwargs["log_callback"]
+        callback("submit streamed line")
+        return ("{'status': 'queued'}", "")
+
+    deps = orchestrate_services.OrchestrateServiceDeps(
+        reset_traceback_skip=lambda: None,
+        append_log_lines=lambda lines, payload: lines.append(payload),
+        extract_result_dict_from_output=lambda raw: submit_payload,
+        evaluate_service_health_gate=lambda *args, **kwargs: (0, "ok", {}),
+        coerce_bool_setting=lambda value, default: default if value is None else bool(value),
+        coerce_int_setting=lambda value, default, minimum=0: max(minimum, default if value is None else int(value)),
+        coerce_float_setting=lambda value, default, minimum=0.0, maximum=1.0: min(
+            maximum,
+            max(minimum, default if value is None else float(value)),
+        ),
+        write_app_settings_toml=lambda path, payload: payload,
+        clear_load_toml_cache=lambda: None,
+        log_display_max_lines=100,
+        install_log_height=320,
+    )
+    env = SimpleNamespace(
+        app="demo_project",
+        target="demo",
+        apps_path=tmp_path,
+        app_settings_file=tmp_path / "app_settings.toml",
+        run_agi=fake_run_agi,
+        snippet_tail="print('tail')",
+    )
+
+    asyncio.run(
+        orchestrate_services.render_service_panel(
+            env=env,
+            project_path=tmp_path,
+            cluster_params={"cluster_enabled": True, "pool": True, "service_health": {}},
+            verbose=1,
+            scheduler='"127.0.0.1:8786"',
+            workers="{'127.0.0.1': 1}",
+            deps=deps,
+        )
+    )
+
+    assert "AGI.submit(" in str(captured["cmd"])
+    assert "foo=1" in str(captured["cmd"])
+    assert session_state["service_status_cache"] == "running"
+    assert session_state["service_last_submit_cache"] == submit_payload
+    assert "task-1.json" in session_state["service_log_cache"]
+    assert any("completed with status 'queued'" in msg for msg in fake_st._success_messages)
+
+
+def test_render_service_panel_submit_action_records_nonqueued_status(monkeypatch, tmp_path):
+    session_state = _SessionState(
+        {
+            "args_serialized": "",
+            "app_settings": {"cluster": {}},
+            "service_status_cache": "running",
+        }
+    )
+    fake_st = _service_st(session_state, clicked="service_submit_btn")
+    monkeypatch.setattr(orchestrate_services, "st", fake_st)
+
+    submit_payload = {"status": "failed"}
+
+    async def fake_run_agi(*_args, **_kwargs):
+        return ("{'status': 'failed'}", "")
+
+    deps = orchestrate_services.OrchestrateServiceDeps(
+        reset_traceback_skip=lambda: None,
+        append_log_lines=lambda lines, payload: lines.append(payload),
+        extract_result_dict_from_output=lambda raw: submit_payload,
+        evaluate_service_health_gate=lambda *args, **kwargs: (0, "ok", {}),
+        coerce_bool_setting=lambda value, default: default if value is None else bool(value),
+        coerce_int_setting=lambda value, default, minimum=0: max(minimum, default if value is None else int(value)),
+        coerce_float_setting=lambda value, default, minimum=0.0, maximum=1.0: min(
+            maximum,
+            max(minimum, default if value is None else float(value)),
+        ),
+        write_app_settings_toml=lambda path, payload: payload,
+        clear_load_toml_cache=lambda: None,
+        log_display_max_lines=100,
+        install_log_height=320,
+    )
+    env = SimpleNamespace(
+        app="demo_project",
+        target="demo",
+        apps_path=tmp_path,
+        app_settings_file=tmp_path / "app_settings.toml",
+        run_agi=fake_run_agi,
+        snippet_tail="print('tail')",
+    )
+
+    asyncio.run(
+        orchestrate_services.render_service_panel(
+            env=env,
+            project_path=tmp_path,
+            cluster_params={"cluster_enabled": True, "pool": True, "service_health": {}},
+            verbose=1,
+            scheduler='"127.0.0.1:8786"',
+            workers="{'127.0.0.1': 1}",
+            deps=deps,
+        )
+    )
+
+    assert session_state["service_status_cache"] == "failed"
+    assert session_state["service_last_submit_cache"] == submit_payload
+    assert any("completed with status 'failed'" in msg for msg in fake_st._success_messages)
+
+    submit_payload = {}
+    second_session_state = _SessionState(
+        {
+            "args_serialized": "",
+            "app_settings": {"cluster": {}},
+            "service_status_cache": "running",
+        }
+    )
+    second_fake_st = _service_st(second_session_state, clicked="service_submit_btn")
+    monkeypatch.setattr(orchestrate_services, "st", second_fake_st)
+
+    asyncio.run(
+        orchestrate_services.render_service_panel(
+            env=env,
+            project_path=tmp_path,
+            cluster_params={"cluster_enabled": True, "pool": True, "service_health": {}},
+            verbose=1,
+            scheduler='"127.0.0.1:8786"',
+            workers="{'127.0.0.1': 1}",
+            deps=deps,
+        )
+    )
+
+    assert second_session_state["service_status_cache"] == "running"
+    assert second_session_state["service_last_submit_cache"] == {}
+    assert any("completed with status 'running'" in msg for msg in second_fake_st._success_messages)
+
+
+def test_render_service_panel_blocks_submit_when_service_is_not_running(monkeypatch, tmp_path):
+    session_state = _SessionState(
+        {
+            "args_serialized": "foo=1",
+            "app_settings": {"cluster": {}},
+            "service_status_cache": "idle",
+        }
+    )
+    fake_st = _service_st(session_state, clicked="service_submit_btn")
+    monkeypatch.setattr(orchestrate_services, "st", fake_st)
+
+    async def unexpected_run_agi(*_args, **_kwargs):
+        raise AssertionError("submit should be blocked before invoking AGI")
+
+    env = SimpleNamespace(
+        app="demo_project",
+        target="demo",
+        apps_path=tmp_path,
+        app_settings_file=tmp_path / "app_settings.toml",
+        run_agi=unexpected_run_agi,
+        snippet_tail="print('tail')",
+    )
+
+    asyncio.run(
+        orchestrate_services.render_service_panel(
+            env=env,
+            project_path=tmp_path,
+            cluster_params={"cluster_enabled": True, "pool": True, "service_health": {}},
+            verbose=1,
+            scheduler='"127.0.0.1:8786"',
+            workers="{'127.0.0.1': 1}",
+            deps=_deps(),
+        )
+    )
+
+    assert session_state["service_status_cache"] == "idle"
+    assert any("Service action is unavailable." in msg for msg in fake_st._warning_messages)
+    assert any("Start service before submitting work." in msg for msg in fake_st._info_messages)
 
 
 def test_render_service_panel_source_env_uses_controller_runtime(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- add service submit orchestration path and snippet support
- cover queued, failed, empty-status, and blocked submit cases
- raise focused orchestrate_services.py coverage to 99% with full branch coverage

## Validation
- uv --preview-features extra-build-dependencies run --no-sync --with streamlit pytest -q -o addopts='' test/test_orchestrate_services.py
- COVERAGE_FILE=.coverage.service-submit uv --preview-features extra-build-dependencies run --no-sync --with coverage --with streamlit coverage run -m pytest -q -o addopts='' test/test_orchestrate_services.py
- uv --preview-features extra-build-dependencies run --no-sync --with coverage coverage report --data-file=.coverage.service-submit -m src/agilab/orchestrate_services.py
- uv --preview-features extra-build-dependencies run --no-sync --with streamlit --with tomli-w pytest -q -o addopts='' test/test_orchestrate_services.py test/test_orchestrate_page_support.py test/test_orchestrate_page_helpers.py
- uv --preview-features extra-build-dependencies run --no-sync python tools/workflow_parity.py --profile agi-gui