### PR TITLE
Cache Streamlit UI discovery

### DIFF
--- a/src/agilab/app_template_registry.py
+++ b/src/agilab/app_template_registry.py
@@ -7,9 +7,15 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from agilab.ui_performance import child_path_signatures, ui_discovery_cache_enabled
+
 
 APP_TEMPLATE_SCHEMA = "agilab.app_template_registry.v1"
 APP_TEMPLATE_SUFFIX = "_app_template"
+_APP_TEMPLATE_DISCOVERY_CACHE: dict[
+    tuple[str, bool, bool, tuple[tuple[str, bool, int, int], ...]],
+    "AppTemplateRegistry",
+] = {}
 
 
 @dataclass(frozen=True, slots=True)
@@ -137,6 +143,16 @@ def discover_app_templates(
     if root is None or not root.exists() or not root.is_dir():
         return AppTemplateRegistry()
 
+    cache_key = _app_template_discovery_cache_key(
+        root,
+        require_pyproject=require_pyproject,
+        require_settings=require_settings,
+    )
+    if ui_discovery_cache_enabled():
+        cached = _APP_TEMPLATE_DISCOVERY_CACHE.get(cache_key)
+        if cached is not None:
+            return cached
+
     templates: list[AppTemplateSpec] = []
     for template_dir in sorted(
         (path for path in root.iterdir() if path.is_dir() and not path.name.startswith(".")),
@@ -152,7 +168,13 @@ def discover_app_templates(
         )
         if template is not None:
             templates.append(template)
-    return AppTemplateRegistry(templates)
+    registry = AppTemplateRegistry(templates)
+    if ui_discovery_cache_enabled():
+        cache_prefix = cache_key[:3]
+        for stale_key in [key for key in _APP_TEMPLATE_DISCOVERY_CACHE if key[:3] == cache_prefix]:
+            _APP_TEMPLATE_DISCOVERY_CACHE.pop(stale_key, None)
+        _APP_TEMPLATE_DISCOVERY_CACHE[cache_key] = registry
+    return registry
 
 
 def discover_app_template(
@@ -195,6 +217,30 @@ def _coerce_root(value: str | Path) -> Path | None:
         return Path(value).expanduser().resolve(strict=False)
     except (OSError, RuntimeError, TypeError, ValueError):
         return None
+
+
+def clear_app_template_discovery_cache() -> None:
+    """Clear the in-process app-template discovery cache."""
+
+    _APP_TEMPLATE_DISCOVERY_CACHE.clear()
+
+
+def _app_template_discovery_cache_key(
+    root: Path,
+    *,
+    require_pyproject: bool,
+    require_settings: bool,
+) -> tuple[str, bool, bool, tuple[tuple[str, bool, int, int], ...]]:
+    return (
+        root.as_posix(),
+        bool(require_pyproject),
+        bool(require_settings),
+        child_path_signatures(
+            root,
+            child_suffix=APP_TEMPLATE_SUFFIX,
+            extra_relative_paths=("pyproject.toml", "src", "src/app_settings.toml"),
+        ),
+    )
 
 
 def _normalize_template_name(value: str) -> str:

--- a/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/playground_ui.py
+++ b/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/playground_ui.py
@@ -6,11 +6,15 @@ from __future__ import annotations
 
 import html
 import json
+import os
+import pickle
+import re
+import subprocess
+import sys
+import tempfile
 from collections.abc import Mapping
 from dataclasses import asdict
 from pathlib import Path
-import re
-import sys
 from typing import Any
 
 import numpy as np
@@ -39,6 +43,13 @@ except Exception:  # pragma: no cover - workers import evidence helpers without 
 
     st = _StreamlitStub()  # type: ignore[assignment]
 
+
+def _prepend_sys_path(path: Path) -> None:
+    entry = str(path)
+    sys.path[:] = [existing for existing in sys.path if existing != entry]
+    sys.path.insert(0, entry)
+
+
 def _ensure_repo_on_path() -> None:
     here = Path(__file__).resolve()
     for parent in here.parents:
@@ -55,8 +66,7 @@ def _ensure_repo_on_path() -> None:
 _ensure_repo_on_path()
 
 _APP_SRC = Path(__file__).resolve().parents[1]
-if str(_APP_SRC) not in sys.path:
-    sys.path.insert(0, str(_APP_SRC))
+_prepend_sys_path(_APP_SRC)
 
 try:  # noqa: E402
     import pytorch_playground.core as _playground_core
@@ -210,6 +220,205 @@ def __getattr__(name: str) -> Any:
 
 
 PAGE_TITLE = "PyTorch playground"
+
+
+_ISOLATED_CORE_RUNNER = r"""
+from __future__ import annotations
+
+import pickle
+import sys
+from pathlib import Path
+
+from pytorch_playground.core import PlaygroundConfig, _loss_landscape, _train_playground
+
+
+def _config_from_payload(payload: dict[str, object]) -> PlaygroundConfig:
+    return PlaygroundConfig(
+        dataset=str(payload["dataset"]),
+        sample_count=int(payload["sample_count"]),
+        noise=float(payload["noise"]),
+        train_ratio=float(payload["train_ratio"]),
+        hidden_layers=tuple(int(value) for value in payload["hidden_layers"]),
+        activation=str(payload["activation"]),
+        optimizer=str(payload["optimizer"]),
+        learning_rate=float(payload["learning_rate"]),
+        epochs=int(payload["epochs"]),
+        batch_size=int(payload["batch_size"]),
+        seed=int(payload["seed"]),
+        feature_names=tuple(str(value) for value in payload["feature_names"]),
+        grid_size=int(payload["grid_size"]),
+    )
+
+
+input_path = Path(sys.argv[1])
+output_path = Path(sys.argv[2])
+request = pickle.loads(input_path.read_bytes())
+try:
+    config = _config_from_payload(request["config"])
+    if request["action"] == "train":
+        result = _train_playground(config)
+    elif request["action"] == "loss_landscape":
+        result = _loss_landscape(
+            config,
+            resolution=int(request["resolution"]),
+            span=float(request["span"]),
+        )
+    else:
+        raise ValueError(f"Unknown isolated playground action: {request['action']}")
+except BaseException as exc:
+    output = {"ok": False, "error_type": type(exc).__name__, "error": str(exc)}
+else:
+    output = {"ok": True, "result": result}
+
+output_path.write_bytes(pickle.dumps(output, protocol=pickle.HIGHEST_PROTOCOL))
+"""
+
+
+def _config_from_cache_payload(payload: Mapping[str, Any]) -> PlaygroundConfig:
+    return PlaygroundConfig(
+        dataset=str(payload["dataset"]),
+        sample_count=int(payload["sample_count"]),
+        noise=float(payload["noise"]),
+        train_ratio=float(payload["train_ratio"]),
+        hidden_layers=tuple(int(value) for value in payload["hidden_layers"]),
+        activation=str(payload["activation"]),
+        optimizer=str(payload["optimizer"]),
+        learning_rate=float(payload["learning_rate"]),
+        epochs=int(payload["epochs"]),
+        batch_size=int(payload["batch_size"]),
+        seed=int(payload["seed"]),
+        feature_names=tuple(str(value) for value in payload["feature_names"]),
+        grid_size=int(payload["grid_size"]),
+    )
+
+
+def _streamlit_script_context_active() -> bool:
+    try:
+        from streamlit.runtime.scriptrunner import get_script_run_ctx
+    except Exception:
+        return False
+    return get_script_run_ctx(suppress_warning=True) is not None
+
+
+def _use_isolated_torch_training() -> bool:
+    return torch is not None and nn is not None and _streamlit_script_context_active()
+
+
+def _tail_diagnostic(text: str, *, line_limit: int = 8, char_limit: int = 1600) -> str:
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    return "\n".join(lines[-line_limit:])[:char_limit]
+
+
+def _training_error_result(config: PlaygroundConfig, detail: str) -> dict[str, Any]:
+    samples = _make_dataset(config)
+    return {
+        "status": "error",
+        "detail": detail,
+        "samples": samples,
+        "history": pd.DataFrame(columns=["epoch", "train_loss", "validation_loss", "train_accuracy", "validation_accuracy"]),
+        "grid": pd.DataFrame(columns=["x1", "x2", "probability"]),
+        "network_layers": _empty_network_layers(),
+        "activation_maps": _empty_activation_maps(),
+        "summary": {
+            "backend": "error",
+            "samples": int(len(samples)),
+            "features": int(len(config.feature_names)),
+        },
+    }
+
+
+def _loss_landscape_error_result(detail: str) -> dict[str, Any]:
+    return {
+        "status": "error",
+        "detail": detail,
+        "loss_landscape": _empty_loss_landscape(),
+        "landscape_summary": {"status": "error", "points": 0},
+    }
+
+
+def _format_isolated_runner_failure(
+    action: str,
+    *,
+    returncode: int | None = None,
+    error: str = "",
+    stderr: str = "",
+) -> str:
+    detail = f"PyTorch {action.replace('_', ' ')} failed in the isolated Streamlit UI runner"
+    if returncode is not None:
+        detail = f"{detail} (exit code {returncode})"
+    diagnostics = _tail_diagnostic("\n".join(part for part in (error, stderr) if part))
+    if diagnostics:
+        detail = f"{detail}: {diagnostics}"
+    else:
+        detail = f"{detail}."
+    return detail
+
+
+def _run_core_in_subprocess(
+    action: str,
+    config: PlaygroundConfig,
+    *,
+    resolution: int | None = None,
+    span: float | None = None,
+) -> dict[str, Any]:
+    request = {
+        "action": action,
+        "config": asdict(config),
+        "resolution": int(resolution or 0),
+        "span": float(span or 0.0),
+    }
+    with tempfile.TemporaryDirectory(prefix="agilab-pytorch-playground-") as tmp_dir:
+        tmp_path = Path(tmp_dir)
+        input_path = tmp_path / "request.pkl"
+        output_path = tmp_path / "response.pkl"
+        input_path.write_bytes(pickle.dumps(request, protocol=pickle.HIGHEST_PROTOCOL))
+        env = os.environ.copy()
+        project_src = str(_APP_SRC)
+        python_path = env.get("PYTHONPATH", "")
+        env["PYTHONPATH"] = project_src if not python_path else os.pathsep.join((project_src, python_path))
+        env.setdefault("PYTHONFAULTHANDLER", "1")
+        try:
+            completed = subprocess.run(
+                [sys.executable, "-c", _ISOLATED_CORE_RUNNER, str(input_path), str(output_path)],
+                cwd=str(_APP_SRC.parent),
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=180,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as exc:
+            detail = _format_isolated_runner_failure(action, error=f"timed out after {exc.timeout} seconds")
+            if action == "train":
+                return _training_error_result(config, detail)
+            return _loss_landscape_error_result(detail)
+
+        if completed.returncode != 0 or not output_path.is_file():
+            detail = _format_isolated_runner_failure(action, returncode=completed.returncode, stderr=completed.stderr)
+            if action == "train":
+                return _training_error_result(config, detail)
+            return _loss_landscape_error_result(detail)
+
+        response = pickle.loads(output_path.read_bytes())
+
+    if not isinstance(response, Mapping) or not response.get("ok"):
+        detail = _format_isolated_runner_failure(
+            action,
+            error=f"{response.get('error_type', 'Error')}: {response.get('error', '')}" if isinstance(response, Mapping) else "",
+        )
+        if action == "train":
+            return _training_error_result(config, detail)
+        return _loss_landscape_error_result(detail)
+
+    result = response.get("result")
+    if not isinstance(result, dict):
+        detail = _format_isolated_runner_failure(action, error="runner returned an invalid payload")
+        if action == "train":
+            return _training_error_result(config, detail)
+        return _loss_landscape_error_result(detail)
+    return result
+
+
 def _session_state_get(key: str, default: Any = None) -> Any:
     state = getattr(st, "session_state", None)
     if state is None:
@@ -254,41 +463,17 @@ def _resolve_trained_config(
 
 @st.cache_data(show_spinner=False)
 def _cached_train(payload: dict[str, Any]) -> dict[str, Any]:
-    config = PlaygroundConfig(
-        dataset=str(payload["dataset"]),
-        sample_count=int(payload["sample_count"]),
-        noise=float(payload["noise"]),
-        train_ratio=float(payload["train_ratio"]),
-        hidden_layers=tuple(int(value) for value in payload["hidden_layers"]),
-        activation=str(payload["activation"]),
-        optimizer=str(payload["optimizer"]),
-        learning_rate=float(payload["learning_rate"]),
-        epochs=int(payload["epochs"]),
-        batch_size=int(payload["batch_size"]),
-        seed=int(payload["seed"]),
-        feature_names=tuple(str(value) for value in payload["feature_names"]),
-        grid_size=int(payload["grid_size"]),
-    )
+    config = _config_from_cache_payload(payload)
+    if _use_isolated_torch_training():
+        return _run_core_in_subprocess("train", config)
     return _train_playground(config)
 
 
 @st.cache_data(show_spinner=False)
 def _cached_loss_landscape(payload: dict[str, Any], resolution: int, span: float) -> dict[str, Any]:
-    config = PlaygroundConfig(
-        dataset=str(payload["dataset"]),
-        sample_count=int(payload["sample_count"]),
-        noise=float(payload["noise"]),
-        train_ratio=float(payload["train_ratio"]),
-        hidden_layers=tuple(int(value) for value in payload["hidden_layers"]),
-        activation=str(payload["activation"]),
-        optimizer=str(payload["optimizer"]),
-        learning_rate=float(payload["learning_rate"]),
-        epochs=int(payload["epochs"]),
-        batch_size=int(payload["batch_size"]),
-        seed=int(payload["seed"]),
-        feature_names=tuple(str(value) for value in payload["feature_names"]),
-        grid_size=int(payload["grid_size"]),
-    )
+    config = _config_from_cache_payload(payload)
+    if _use_isolated_torch_training():
+        return _run_core_in_subprocess("loss_landscape", config, resolution=resolution, span=span)
     return _loss_landscape(config, resolution=resolution, span=span)
 
 
@@ -985,6 +1170,8 @@ def main() -> None:
     _render_hero(active_app, trained_preset, trained_config)
     if result["status"] == "missing_torch":
         st.error(result["detail"])
+    elif result["status"] != "ok":
+        st.error(str(result.get("detail", "PyTorch training failed.")))
     if pending_changes:
         st.warning("Controls changed. The visible charts and evidence still show the last trained run.")
 

--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground/playground_ui.py
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground/playground_ui.py
@@ -6,11 +6,15 @@ from __future__ import annotations
 
 import html
 import json
+import os
+import pickle
+import re
+import subprocess
+import sys
+import tempfile
 from collections.abc import Mapping
 from dataclasses import asdict
 from pathlib import Path
-import re
-import sys
 from typing import Any
 
 import numpy as np
@@ -39,6 +43,13 @@ except Exception:  # pragma: no cover - workers import evidence helpers without 
 
     st = _StreamlitStub()  # type: ignore[assignment]
 
+
+def _prepend_sys_path(path: Path) -> None:
+    entry = str(path)
+    sys.path[:] = [existing for existing in sys.path if existing != entry]
+    sys.path.insert(0, entry)
+
+
 def _ensure_repo_on_path() -> None:
     here = Path(__file__).resolve()
     for parent in here.parents:
@@ -55,8 +66,7 @@ def _ensure_repo_on_path() -> None:
 _ensure_repo_on_path()
 
 _APP_SRC = Path(__file__).resolve().parents[1]
-if str(_APP_SRC) not in sys.path:
-    sys.path.insert(0, str(_APP_SRC))
+_prepend_sys_path(_APP_SRC)
 
 try:  # noqa: E402
     import pytorch_playground.core as _playground_core
@@ -210,6 +220,205 @@ def __getattr__(name: str) -> Any:
 
 
 PAGE_TITLE = "PyTorch playground"
+
+
+_ISOLATED_CORE_RUNNER = r"""
+from __future__ import annotations
+
+import pickle
+import sys
+from pathlib import Path
+
+from pytorch_playground.core import PlaygroundConfig, _loss_landscape, _train_playground
+
+
+def _config_from_payload(payload: dict[str, object]) -> PlaygroundConfig:
+    return PlaygroundConfig(
+        dataset=str(payload["dataset"]),
+        sample_count=int(payload["sample_count"]),
+        noise=float(payload["noise"]),
+        train_ratio=float(payload["train_ratio"]),
+        hidden_layers=tuple(int(value) for value in payload["hidden_layers"]),
+        activation=str(payload["activation"]),
+        optimizer=str(payload["optimizer"]),
+        learning_rate=float(payload["learning_rate"]),
+        epochs=int(payload["epochs"]),
+        batch_size=int(payload["batch_size"]),
+        seed=int(payload["seed"]),
+        feature_names=tuple(str(value) for value in payload["feature_names"]),
+        grid_size=int(payload["grid_size"]),
+    )
+
+
+input_path = Path(sys.argv[1])
+output_path = Path(sys.argv[2])
+request = pickle.loads(input_path.read_bytes())
+try:
+    config = _config_from_payload(request["config"])
+    if request["action"] == "train":
+        result = _train_playground(config)
+    elif request["action"] == "loss_landscape":
+        result = _loss_landscape(
+            config,
+            resolution=int(request["resolution"]),
+            span=float(request["span"]),
+        )
+    else:
+        raise ValueError(f"Unknown isolated playground action: {request['action']}")
+except BaseException as exc:
+    output = {"ok": False, "error_type": type(exc).__name__, "error": str(exc)}
+else:
+    output = {"ok": True, "result": result}
+
+output_path.write_bytes(pickle.dumps(output, protocol=pickle.HIGHEST_PROTOCOL))
+"""
+
+
+def _config_from_cache_payload(payload: Mapping[str, Any]) -> PlaygroundConfig:
+    return PlaygroundConfig(
+        dataset=str(payload["dataset"]),
+        sample_count=int(payload["sample_count"]),
+        noise=float(payload["noise"]),
+        train_ratio=float(payload["train_ratio"]),
+        hidden_layers=tuple(int(value) for value in payload["hidden_layers"]),
+        activation=str(payload["activation"]),
+        optimizer=str(payload["optimizer"]),
+        learning_rate=float(payload["learning_rate"]),
+        epochs=int(payload["epochs"]),
+        batch_size=int(payload["batch_size"]),
+        seed=int(payload["seed"]),
+        feature_names=tuple(str(value) for value in payload["feature_names"]),
+        grid_size=int(payload["grid_size"]),
+    )
+
+
+def _streamlit_script_context_active() -> bool:
+    try:
+        from streamlit.runtime.scriptrunner import get_script_run_ctx
+    except Exception:
+        return False
+    return get_script_run_ctx(suppress_warning=True) is not None
+
+
+def _use_isolated_torch_training() -> bool:
+    return torch is not None and nn is not None and _streamlit_script_context_active()
+
+
+def _tail_diagnostic(text: str, *, line_limit: int = 8, char_limit: int = 1600) -> str:
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    return "\n".join(lines[-line_limit:])[:char_limit]
+
+
+def _training_error_result(config: PlaygroundConfig, detail: str) -> dict[str, Any]:
+    samples = _make_dataset(config)
+    return {
+        "status": "error",
+        "detail": detail,
+        "samples": samples,
+        "history": pd.DataFrame(columns=["epoch", "train_loss", "validation_loss", "train_accuracy", "validation_accuracy"]),
+        "grid": pd.DataFrame(columns=["x1", "x2", "probability"]),
+        "network_layers": _empty_network_layers(),
+        "activation_maps": _empty_activation_maps(),
+        "summary": {
+            "backend": "error",
+            "samples": int(len(samples)),
+            "features": int(len(config.feature_names)),
+        },
+    }
+
+
+def _loss_landscape_error_result(detail: str) -> dict[str, Any]:
+    return {
+        "status": "error",
+        "detail": detail,
+        "loss_landscape": _empty_loss_landscape(),
+        "landscape_summary": {"status": "error", "points": 0},
+    }
+
+
+def _format_isolated_runner_failure(
+    action: str,
+    *,
+    returncode: int | None = None,
+    error: str = "",
+    stderr: str = "",
+) -> str:
+    detail = f"PyTorch {action.replace('_', ' ')} failed in the isolated Streamlit UI runner"
+    if returncode is not None:
+        detail = f"{detail} (exit code {returncode})"
+    diagnostics = _tail_diagnostic("\n".join(part for part in (error, stderr) if part))
+    if diagnostics:
+        detail = f"{detail}: {diagnostics}"
+    else:
+        detail = f"{detail}."
+    return detail
+
+
+def _run_core_in_subprocess(
+    action: str,
+    config: PlaygroundConfig,
+    *,
+    resolution: int | None = None,
+    span: float | None = None,
+) -> dict[str, Any]:
+    request = {
+        "action": action,
+        "config": asdict(config),
+        "resolution": int(resolution or 0),
+        "span": float(span or 0.0),
+    }
+    with tempfile.TemporaryDirectory(prefix="agilab-pytorch-playground-") as tmp_dir:
+        tmp_path = Path(tmp_dir)
+        input_path = tmp_path / "request.pkl"
+        output_path = tmp_path / "response.pkl"
+        input_path.write_bytes(pickle.dumps(request, protocol=pickle.HIGHEST_PROTOCOL))
+        env = os.environ.copy()
+        project_src = str(_APP_SRC)
+        python_path = env.get("PYTHONPATH", "")
+        env["PYTHONPATH"] = project_src if not python_path else os.pathsep.join((project_src, python_path))
+        env.setdefault("PYTHONFAULTHANDLER", "1")
+        try:
+            completed = subprocess.run(
+                [sys.executable, "-c", _ISOLATED_CORE_RUNNER, str(input_path), str(output_path)],
+                cwd=str(_APP_SRC.parent),
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=180,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as exc:
+            detail = _format_isolated_runner_failure(action, error=f"timed out after {exc.timeout} seconds")
+            if action == "train":
+                return _training_error_result(config, detail)
+            return _loss_landscape_error_result(detail)
+
+        if completed.returncode != 0 or not output_path.is_file():
+            detail = _format_isolated_runner_failure(action, returncode=completed.returncode, stderr=completed.stderr)
+            if action == "train":
+                return _training_error_result(config, detail)
+            return _loss_landscape_error_result(detail)
+
+        response = pickle.loads(output_path.read_bytes())
+
+    if not isinstance(response, Mapping) or not response.get("ok"):
+        detail = _format_isolated_runner_failure(
+            action,
+            error=f"{response.get('error_type', 'Error')}: {response.get('error', '')}" if isinstance(response, Mapping) else "",
+        )
+        if action == "train":
+            return _training_error_result(config, detail)
+        return _loss_landscape_error_result(detail)
+
+    result = response.get("result")
+    if not isinstance(result, dict):
+        detail = _format_isolated_runner_failure(action, error="runner returned an invalid payload")
+        if action == "train":
+            return _training_error_result(config, detail)
+        return _loss_landscape_error_result(detail)
+    return result
+
+
 def _session_state_get(key: str, default: Any = None) -> Any:
     state = getattr(st, "session_state", None)
     if state is None:
@@ -254,41 +463,17 @@ def _resolve_trained_config(
 
 @st.cache_data(show_spinner=False)
 def _cached_train(payload: dict[str, Any]) -> dict[str, Any]:
-    config = PlaygroundConfig(
-        dataset=str(payload["dataset"]),
-        sample_count=int(payload["sample_count"]),
-        noise=float(payload["noise"]),
-        train_ratio=float(payload["train_ratio"]),
-        hidden_layers=tuple(int(value) for value in payload["hidden_layers"]),
-        activation=str(payload["activation"]),
-        optimizer=str(payload["optimizer"]),
-        learning_rate=float(payload["learning_rate"]),
-        epochs=int(payload["epochs"]),
-        batch_size=int(payload["batch_size"]),
-        seed=int(payload["seed"]),
-        feature_names=tuple(str(value) for value in payload["feature_names"]),
-        grid_size=int(payload["grid_size"]),
-    )
+    config = _config_from_cache_payload(payload)
+    if _use_isolated_torch_training():
+        return _run_core_in_subprocess("train", config)
     return _train_playground(config)
 
 
 @st.cache_data(show_spinner=False)
 def _cached_loss_landscape(payload: dict[str, Any], resolution: int, span: float) -> dict[str, Any]:
-    config = PlaygroundConfig(
-        dataset=str(payload["dataset"]),
-        sample_count=int(payload["sample_count"]),
-        noise=float(payload["noise"]),
-        train_ratio=float(payload["train_ratio"]),
-        hidden_layers=tuple(int(value) for value in payload["hidden_layers"]),
-        activation=str(payload["activation"]),
-        optimizer=str(payload["optimizer"]),
-        learning_rate=float(payload["learning_rate"]),
-        epochs=int(payload["epochs"]),
-        batch_size=int(payload["batch_size"]),
-        seed=int(payload["seed"]),
-        feature_names=tuple(str(value) for value in payload["feature_names"]),
-        grid_size=int(payload["grid_size"]),
-    )
+    config = _config_from_cache_payload(payload)
+    if _use_isolated_torch_training():
+        return _run_core_in_subprocess("loss_landscape", config, resolution=resolution, span=span)
     return _loss_landscape(config, resolution=resolution, span=span)
 
 
@@ -985,6 +1170,8 @@ def main() -> None:
     _render_hero(active_app, trained_preset, trained_config)
     if result["status"] == "missing_torch":
         st.error(result["detail"])
+    elif result["status"] != "ok":
+        st.error(str(result.get("detail", "PyTorch training failed.")))
     if pending_changes:
         st.warning("Controls changed. The visible charts and evidence still show the last trained run.")
 

--- a/src/agilab/main_page.py
+++ b/src/agilab/main_page.py
@@ -16,6 +16,12 @@ import time
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 from agi_env.agi_logger import AgiLogger
+from agilab.ui_performance import (
+    UI_TIMING_SESSION_KEY,
+    UI_TIMING_TRACE_ENV_KEY,
+    record_ui_timing_span,
+    ui_timing_trace_enabled,
+)
 
 try:
     from agilab.streamlit_theme_env import apply_streamlit_theme_environment, packaged_streamlit_config_path
@@ -352,13 +358,67 @@ def _render_page_load_timing(
     perf_counter: Callable[[], float] = time.perf_counter,
 ) -> None:
     """Render opt-in page load timing without adding default UI noise."""
+    elapsed_ms = max(0.0, (perf_counter() - started_at) * 1000.0)
+    if ui_timing_trace_enabled():
+        _record_ui_timing_span(
+            page_label,
+            started_at,
+            category="page",
+            streamlit=streamlit,
+            perf_counter=perf_counter,
+        )
+        _render_ui_timing_trace(streamlit=streamlit)
     if not _page_load_timing_enabled():
         return
-    elapsed_ms = max(0.0, (perf_counter() - started_at) * 1000.0)
     try:
         streamlit.sidebar.caption(f"{page_label} loaded in {elapsed_ms:.0f} ms")
     except (AttributeError, RuntimeError, TypeError, ValueError):
         logger.info("%s loaded in %.0f ms", page_label, elapsed_ms)
+
+
+def _record_ui_timing_span(
+    label: str,
+    started_at: float,
+    *,
+    category: str,
+    streamlit: Any = st,
+    perf_counter: Callable[[], float] = time.perf_counter,
+) -> None:
+    if not ui_timing_trace_enabled():
+        return
+    record_ui_timing_span(
+        getattr(streamlit, "session_state", {}),
+        label=label,
+        started_at=started_at,
+        category=category,
+        perf_counter=perf_counter,
+    )
+
+
+def _render_ui_timing_trace(*, streamlit: Any = st, max_spans: int = 6) -> None:
+    if not ui_timing_trace_enabled():
+        return
+    try:
+        spans = list(streamlit.session_state.get(UI_TIMING_SESSION_KEY, ()))
+    except (AttributeError, RuntimeError, TypeError, ValueError):
+        return
+    if not spans:
+        return
+    lines = []
+    for span in spans[-max(1, max_spans) :]:
+        try:
+            label = str(span.get("label", ""))
+            category = str(span.get("category", ""))
+            elapsed_ms = float(span.get("elapsed_ms", "0") or 0.0)
+        except (AttributeError, TypeError, ValueError):
+            continue
+        lines.append(f"{label} [{category}] {elapsed_ms:.0f} ms")
+    if not lines:
+        return
+    try:
+        streamlit.sidebar.caption("UI trace: " + " | ".join(lines))
+    except (AttributeError, RuntimeError, TypeError, ValueError):
+        logger.info("UI trace: %s", " | ".join(lines))
 
 
 def get_about_content() -> dict[str, str]:
@@ -816,13 +876,17 @@ def _render_about_page_entry() -> None:
     started_at = time.perf_counter()
     resources_path = _about_resources_path()
     _render_navigation_page_shell(resources_path)
+    bootstrap_started_at = time.perf_counter()
     env = _ensure_navigation_environment(resources_path, rerun_after_bootstrap=False)
+    _record_ui_timing_span("ABOUT:bootstrap", bootstrap_started_at, category="bootstrap")
     if env is None:
         return
+    render_started_at = time.perf_counter()
     show_banner_and_intro(resources_path, env)
     openai_status_banner(env)
     # Quick hint for operators: where to check install errors
     page(env)
+    _record_ui_timing_span("ABOUT:render", render_started_at, category="render")
     _render_page_load_timing("ABOUT", started_at)
 
 
@@ -831,10 +895,14 @@ def _render_settings_page_entry() -> None:
     started_at = time.perf_counter()
     resources_path = _about_resources_path()
     _render_navigation_page_shell(resources_path)
+    bootstrap_started_at = time.perf_counter()
     env = _ensure_navigation_environment(resources_path, rerun_after_bootstrap=False)
+    _record_ui_timing_span("SETTINGS:bootstrap", bootstrap_started_at, category="bootstrap")
     if env is None:
         return
+    render_started_at = time.perf_counter()
     settings_page(env)
+    _record_ui_timing_span("SETTINGS:render", render_started_at, category="render")
     _render_page_load_timing("SETTINGS", started_at)
 
 
@@ -926,17 +994,25 @@ def _page_file_runner(page_file: Path) -> Callable[[], None]:
 
     def _run_page() -> None:
         started_at = time.perf_counter()
+        page_label = page_file.stem
+        bootstrap_started_at = time.perf_counter()
         if _ensure_navigation_environment(_about_resources_path(), rerun_after_bootstrap=True) is None:
+            _record_ui_timing_span(f"{page_label}:bootstrap", bootstrap_started_at, category="bootstrap")
             return
+        _record_ui_timing_span(f"{page_label}:bootstrap", bootstrap_started_at, category="bootstrap")
+        import_started_at = time.perf_counter()
         module = _load_page_module(page_file)
+        _record_ui_timing_span(f"{page_label}:import", import_started_at, category="import")
         main_fn = getattr(module, "main", None)
         if main_fn is None:
             raise AttributeError(f"Page {page_file} does not expose a main() function")
+        render_started_at = time.perf_counter()
         if inspect.iscoroutinefunction(main_fn):
             asyncio.run(main_fn())
         else:
             main_fn()
-        _render_page_load_timing(page_file.stem, started_at)
+        _record_ui_timing_span(f"{page_label}:render", render_started_at, category="render")
+        _render_page_load_timing(page_label, started_at)
 
     _run_page.__name__ = f"run_{page_file.stem}"
     return _run_page

--- a/src/agilab/page_bundle_registry.py
+++ b/src/agilab/page_bundle_registry.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from agilab.template_contracts import TemplateContract, load_optional_template_contract
+from agilab.ui_performance import ui_discovery_cache_enabled
 
 
 PAGE_BUNDLE_SCHEMA = "agilab.page_bundle_registry.v1"
@@ -15,6 +16,10 @@ PAGE_TEMPLATE_SCHEMA = "agilab.page_template_registry.v1"
 PAGE_TEMPLATE_SUFFIX = "_page_template"
 PAGE_BUNDLE_ENTRYPOINT_NAMES = ("{module}.py", "main.py", "app.py")
 _PAGE_BUNDLE_DISCOVERY_CACHE: dict[tuple[str, bool, bool, tuple[tuple[str, bool, int, int], ...]], "PageBundleRegistry"] = {}
+_PAGE_TEMPLATE_DISCOVERY_CACHE: dict[
+    tuple[str, bool, bool, tuple[tuple[str, bool, int, int], ...]],
+    "PageTemplateRegistry",
+] = {}
 
 
 @dataclass(frozen=True, slots=True)
@@ -264,9 +269,10 @@ def discover_page_bundles(
         require_pyproject=require_pyproject,
         require_contract=require_contract,
     )
-    cached = _PAGE_BUNDLE_DISCOVERY_CACHE.get(cache_key)
-    if cached is not None:
-        return cached
+    if ui_discovery_cache_enabled():
+        cached = _PAGE_BUNDLE_DISCOVERY_CACHE.get(cache_key)
+        if cached is not None:
+            return cached
 
     bundles: list[PageBundleSpec] = []
     for script_path in sorted(root.glob("*.py")):
@@ -290,12 +296,13 @@ def discover_page_bundles(
         if bundle is not None:
             bundles.append(bundle)
     registry = PageBundleRegistry(bundles)
-    cache_prefix = cache_key[:3]
-    for stale_key in [
-        key for key in _PAGE_BUNDLE_DISCOVERY_CACHE if key[:3] == cache_prefix
-    ]:
-        _PAGE_BUNDLE_DISCOVERY_CACHE.pop(stale_key, None)
-    _PAGE_BUNDLE_DISCOVERY_CACHE[cache_key] = registry
+    if ui_discovery_cache_enabled():
+        cache_prefix = cache_key[:3]
+        for stale_key in [
+            key for key in _PAGE_BUNDLE_DISCOVERY_CACHE if key[:3] == cache_prefix
+        ]:
+            _PAGE_BUNDLE_DISCOVERY_CACHE.pop(stale_key, None)
+        _PAGE_BUNDLE_DISCOVERY_CACHE[cache_key] = registry
     return registry
 
 
@@ -310,6 +317,16 @@ def discover_page_templates(
     root = _coerce_root(templates_root)
     if root is None or not root.exists() or not root.is_dir():
         return PageTemplateRegistry()
+
+    cache_key = _page_template_discovery_cache_key(
+        root,
+        require_pyproject=require_pyproject,
+        require_contract=require_contract,
+    )
+    if ui_discovery_cache_enabled():
+        cached = _PAGE_TEMPLATE_DISCOVERY_CACHE.get(cache_key)
+        if cached is not None:
+            return cached
 
     templates: list[PageTemplateSpec] = []
     for template_dir in sorted(
@@ -326,7 +343,15 @@ def discover_page_templates(
         )
         if template is not None:
             templates.append(template)
-    return PageTemplateRegistry(templates)
+    registry = PageTemplateRegistry(templates)
+    if ui_discovery_cache_enabled():
+        cache_prefix = cache_key[:3]
+        for stale_key in [
+            key for key in _PAGE_TEMPLATE_DISCOVERY_CACHE if key[:3] == cache_prefix
+        ]:
+            _PAGE_TEMPLATE_DISCOVERY_CACHE.pop(stale_key, None)
+        _PAGE_TEMPLATE_DISCOVERY_CACHE[cache_key] = registry
+    return registry
 
 
 def discover_page_bundle(
@@ -464,6 +489,7 @@ def clear_page_bundle_discovery_cache() -> None:
     """Clear the in-process apps-page discovery cache."""
 
     _PAGE_BUNDLE_DISCOVERY_CACHE.clear()
+    _PAGE_TEMPLATE_DISCOVERY_CACHE.clear()
 
 
 def _stat_signature(path: Path, *, label: str | None = None) -> tuple[str, bool, int, int] | None:
@@ -549,6 +575,32 @@ def _page_bundle_discovery_cache_key(
             continue
         if child.is_dir():
             signatures.extend(_page_bundle_dir_signature(child))
+    return (
+        root.as_posix(),
+        bool(require_pyproject),
+        bool(require_contract),
+        tuple(signatures),
+    )
+
+
+def _page_template_discovery_cache_key(
+    root: Path,
+    *,
+    require_pyproject: bool,
+    require_contract: bool,
+) -> tuple[str, bool, bool, tuple[tuple[str, bool, int, int], ...]]:
+    signatures: list[tuple[str, bool, int, int]] = []
+    root_signature = _stat_signature(root, label=".")
+    if root_signature is not None:
+        signatures.append(root_signature)
+    try:
+        children = sorted(root.iterdir(), key=lambda path: path.name.casefold())
+    except OSError:
+        children = []
+    for child in children:
+        if child.name.startswith(".") or not child.is_dir() or not _is_template_name(child.name):
+            continue
+        signatures.extend(_page_bundle_dir_signature(child))
     return (
         root.as_posix(),
         bool(require_pyproject),

--- a/src/agilab/pages/4_ANALYSIS.py
+++ b/src/agilab/pages/4_ANALYSIS.py
@@ -108,6 +108,7 @@ from agi_gui.pagelib import (
 from agi_gui.ux_widgets import compact_choice
 from agi_env import AgiEnv
 from agi_env.app_settings_support import prepare_app_settings_for_write
+from agilab.ui_performance import ui_discovery_cache_enabled
 from agi_gui.ui_support import load_last_active_app, store_last_active_app
 
 logger = logging.getLogger(__name__)
@@ -1058,7 +1059,7 @@ _NOTEBOOK_DISCOVERY_CACHE: dict[Path, tuple[tuple[Any, ...], dict[str, Path]]] =
 
 def _analysis_discovery_cache_enabled(environ: Any = os.environ) -> bool:
     value = str(environ.get(ANALYSIS_DISCOVERY_CACHE_DISABLE_ENV, "")).strip().lower()
-    return value not in {"1", "true", "yes", "on"}
+    return value not in {"1", "true", "yes", "on"} and ui_discovery_cache_enabled(environ)
 
 
 def _directory_tree_signature(root: Path, *, file_suffixes: tuple[str, ...]) -> tuple[Any, ...]:

--- a/src/agilab/ui_performance.py
+++ b/src/agilab/ui_performance.py
@@ -1,0 +1,117 @@
+"""Small UI performance helpers for Streamlit rerun paths."""
+
+from __future__ import annotations
+
+import os
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Callable, Iterable
+
+
+UI_DISCOVERY_CACHE_DISABLE_ENV = "AGILAB_DISABLE_UI_DISCOVERY_CACHE"
+UI_TIMING_TRACE_ENV_KEY = "AGILAB_UI_TIMING_TRACE"
+UI_TIMING_SESSION_KEY = "agilab_ui_timing_spans"
+DEFAULT_TIMING_LIMIT = 40
+
+
+@dataclass(frozen=True, slots=True)
+class UiTimingSpan:
+    """One opt-in timing sample from the Streamlit UI rerun path."""
+
+    label: str
+    category: str
+    elapsed_ms: float
+
+    def as_row(self) -> dict[str, str]:
+        row = asdict(self)
+        row["elapsed_ms"] = f"{self.elapsed_ms:.1f}"
+        return {key: str(value) for key, value in row.items()}
+
+
+def flag_enabled(value: object) -> bool:
+    """Return True for common environment-style truthy values."""
+
+    return str(value or "").strip().lower() in {"1", "true", "yes", "on", "debug"}
+
+
+def ui_discovery_cache_enabled(environ: Any = os.environ) -> bool:
+    """Return whether in-process UI discovery caches should be used."""
+
+    return not flag_enabled(environ.get(UI_DISCOVERY_CACHE_DISABLE_ENV, ""))
+
+
+def ui_timing_trace_enabled(environ: Any = os.environ) -> bool:
+    """Return whether detailed UI timing spans should be recorded."""
+
+    return flag_enabled(environ.get(UI_TIMING_TRACE_ENV_KEY, ""))
+
+
+def path_stat_signature(path: Path, *, label: str | None = None) -> tuple[str, bool, int, int] | None:
+    """Return a stable stat signature for one path, or None when unavailable."""
+
+    try:
+        stat = path.stat()
+    except OSError:
+        return None
+    name = label if label is not None else path.name
+    return (name, path.is_dir(), stat.st_mtime_ns, stat.st_size)
+
+
+def child_path_signatures(
+    root: Path,
+    *,
+    child_suffix: str,
+    extra_relative_paths: Iterable[str] = (),
+    include_root: bool = True,
+) -> tuple[tuple[str, bool, int, int], ...]:
+    """Return a cheap invalidation signature for top-level UI registry folders."""
+
+    signatures: list[tuple[str, bool, int, int]] = []
+    if include_root:
+        root_signature = path_stat_signature(root, label=".")
+        if root_signature is not None:
+            signatures.append(root_signature)
+    try:
+        children = sorted(root.iterdir(), key=lambda path: path.name.casefold())
+    except OSError:
+        return tuple(signatures)
+
+    relative_paths = tuple(Path(raw_path) for raw_path in extra_relative_paths)
+    for child in children:
+        if child.name.startswith(".") or not child.is_dir() or not child.name.endswith(child_suffix):
+            continue
+        child_signature = path_stat_signature(child)
+        if child_signature is not None:
+            signatures.append(child_signature)
+        for relative_path in relative_paths:
+            candidate = child / relative_path
+            signature = path_stat_signature(
+                candidate,
+                label=f"{child.name}/{relative_path.as_posix()}",
+            )
+            if signature is not None:
+                signatures.append(signature)
+    return tuple(signatures)
+
+
+def record_ui_timing_span(
+    session_state: Any,
+    *,
+    label: str,
+    started_at: float,
+    category: str = "page",
+    perf_counter: Callable[[], float] = time.perf_counter,
+    limit: int = DEFAULT_TIMING_LIMIT,
+) -> UiTimingSpan:
+    """Append one timing span to Streamlit session state and return it."""
+
+    elapsed_ms = max(0.0, (perf_counter() - started_at) * 1000.0)
+    span = UiTimingSpan(label=str(label), category=str(category), elapsed_ms=elapsed_ms)
+    try:
+        spans = list(session_state.get(UI_TIMING_SESSION_KEY, ()))
+        spans.append(span.as_row())
+        session_state[UI_TIMING_SESSION_KEY] = spans[-max(1, int(limit)) :]
+    except (AttributeError, RuntimeError, TypeError, ValueError):
+        pass
+    return span

--- a/test/test_app_template_registry.py
+++ b/test/test_app_template_registry.py
@@ -19,6 +19,7 @@ from agilab.app_template_registry import (
     APP_TEMPLATE_SCHEMA,
     AppTemplateRegistry,
     AppTemplateSpec,
+    clear_app_template_discovery_cache,
     discover_app_template,
     discover_app_templates,
 )
@@ -62,6 +63,42 @@ def test_discover_app_templates_can_require_manifest_and_settings(tmp_path: Path
         "missing_pyproject_app_template",
         "missing_settings_app_template",
     )
+
+
+def test_discover_app_templates_reuses_cache_until_directory_signature_changes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clear_app_template_discovery_cache()
+    monkeypatch.delenv("AGILAB_DISABLE_UI_DISCOVERY_CACHE", raising=False)
+    _write_template(tmp_path, "first_app_template")
+
+    first = discover_app_templates(tmp_path)
+    second = discover_app_templates(tmp_path)
+
+    assert second is first
+
+    _write_template(tmp_path, "second_app_template")
+    third = discover_app_templates(tmp_path)
+
+    assert third is not first
+    assert third.names() == ("first_app_template", "second_app_template")
+    clear_app_template_discovery_cache()
+
+
+def test_discover_app_templates_cache_can_be_disabled(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clear_app_template_discovery_cache()
+    monkeypatch.setenv("AGILAB_DISABLE_UI_DISCOVERY_CACHE", "1")
+    _write_template(tmp_path, "first_app_template")
+
+    first = discover_app_templates(tmp_path)
+    second = discover_app_templates(tmp_path)
+
+    assert second is not first
+    clear_app_template_discovery_cache()
 
 
 def test_discover_app_template_resolves_one_template(tmp_path: Path) -> None:

--- a/test/test_page_bundle_registry.py
+++ b/test/test_page_bundle_registry.py
@@ -129,6 +129,21 @@ def test_discover_page_bundles_reuses_cache_until_directory_signature_changes(tm
     clear_page_bundle_discovery_cache()
 
 
+def test_discover_page_bundles_cache_can_be_disabled(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clear_page_bundle_discovery_cache()
+    monkeypatch.setenv("AGILAB_DISABLE_UI_DISCOVERY_CACHE", "1")
+    _write_bundle(tmp_path, "view_first")
+
+    first = discover_page_bundles(tmp_path)
+    second = discover_page_bundles(tmp_path)
+
+    assert second is not first
+    clear_page_bundle_discovery_cache()
+
+
 def test_discover_page_bundle_loads_contract_metadata(tmp_path: Path) -> None:
     script = _write_bundle(tmp_path, "view_demo")
     contract_path = _write_contract(script.parents[2])
@@ -333,6 +348,33 @@ def test_page_template_registry_discovers_contract_templates(tmp_path: Path) -> 
     assert discover_page_template(tmp_path, "analysis_page_template") == template
     with pytest.raises(ValueError, match="must end with '_page_template'"):
         PageTemplateSpec("analysis_page", tmp_path / "x", tmp_path / "x" / "pyproject.toml")
+
+
+def test_discover_page_templates_reuses_cache_until_directory_signature_changes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clear_page_bundle_discovery_cache()
+    monkeypatch.delenv("AGILAB_DISABLE_UI_DISCOVERY_CACHE", raising=False)
+    template_root = tmp_path / "first_page_template"
+    template_root.mkdir()
+    (template_root / "pyproject.toml").write_text("[project]\nname='first'\n", encoding="utf-8")
+    _write_contract(template_root)
+
+    first = discover_page_templates(tmp_path)
+    second = discover_page_templates(tmp_path)
+
+    assert second is first
+
+    second_template = tmp_path / "second_page_template"
+    second_template.mkdir()
+    (second_template / "pyproject.toml").write_text("[project]\nname='second'\n", encoding="utf-8")
+    _write_contract(second_template)
+    third = discover_page_templates(tmp_path)
+
+    assert third is not first
+    assert third.names() == ("first_page_template", "second_page_template")
+    clear_page_bundle_discovery_cache()
 
 
 def test_template_contract_helpers_handle_missing_and_malformed_optional_fields(tmp_path: Path) -> None:

--- a/test/test_pytorch_playground_app.py
+++ b/test/test_pytorch_playground_app.py
@@ -36,6 +36,215 @@ def _load_module():
     return module
 
 
+def test_playground_ui_import_prefers_package_when_streamlit_puts_script_dir_first(monkeypatch):
+    script_dir = MODULE_PATH.resolve().parent
+    project_src = PROJECT_SRC.resolve()
+    original_modules = {
+        name: module
+        for name, module in sys.modules.items()
+        if name == "pytorch_playground" or name.startswith("pytorch_playground.")
+    }
+    for name in original_modules:
+        sys.modules.pop(name, None)
+
+    fake_path = [
+        str(script_dir),
+        str(project_src),
+        *[
+            entry
+            for entry in sys.path
+            if entry not in {str(script_dir), str(project_src)}
+        ],
+    ]
+    monkeypatch.setattr(sys, "path", fake_path)
+
+    spec = importlib.util.spec_from_file_location("pytorch_playground_streamlit_path_order_test", MODULE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    try:
+        spec.loader.exec_module(module)
+        assert sys.path[0] == str(project_src)
+        assert module._playground_core.__name__ == "pytorch_playground.core"
+    finally:
+        sys.modules.pop(spec.name, None)
+        for name in list(sys.modules):
+            if name == "pytorch_playground" or name.startswith("pytorch_playground."):
+                sys.modules.pop(name, None)
+        sys.modules.update(original_modules)
+
+
+def test_cached_train_uses_isolated_subprocess_in_streamlit_context() -> None:
+    module = _load_module()
+    if module.torch is None:
+        pytest.skip("torch is not installed in this validation environment")
+
+    from streamlit.testing.v1 import AppTest
+
+    module_path = str(MODULE_PATH.resolve())
+    script = f"""
+from dataclasses import asdict
+import importlib.util
+from pathlib import Path
+import sys
+
+import streamlit as st
+
+path = Path({module_path!r})
+spec = importlib.util.spec_from_file_location("pytorch_playground_streamlit_subprocess_regression", path)
+module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+config = module.PlaygroundConfig(sample_count=64, epochs=1, grid_size=12, hidden_layers=(4,))
+result = module._cached_train(asdict(config))
+st.write(f"status={{result['status']}}")
+st.write(f"backend={{result['summary'].get('backend')}}")
+"""
+    app = AppTest.from_string(script, default_timeout=60)
+    app.run()
+
+    assert list(app.exception) == []
+    assert [item.value for item in app.markdown] == ["status=ok", "backend=torch"]
+
+
+def test_isolated_runner_success_serializes_request_and_pythonpath(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_module()
+    config = module.PlaygroundConfig(sample_count=24, epochs=1, grid_size=8, hidden_layers=(4,))
+    captured: dict[str, object] = {}
+
+    def fake_run(cmd, **kwargs):
+        input_path = Path(cmd[-2])
+        output_path = Path(cmd[-1])
+        request = module.pickle.loads(input_path.read_bytes())
+        captured["request"] = request
+        captured["pythonpath"] = kwargs["env"]["PYTHONPATH"]
+        output_path.write_bytes(
+            module.pickle.dumps(
+                {"ok": True, "result": {"status": "ok", "summary": {"backend": "torch"}}},
+                protocol=module.pickle.HIGHEST_PROTOCOL,
+            )
+        )
+        return SimpleNamespace(returncode=0, stderr="")
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    result = module._run_core_in_subprocess("train", config)
+
+    assert result["status"] == "ok"
+    assert result["summary"]["backend"] == "torch"
+    assert captured["request"]["action"] == "train"
+    assert captured["request"]["config"]["hidden_layers"] == (4,)
+    assert str(module._APP_SRC) in str(captured["pythonpath"]).split(module.os.pathsep)
+
+
+def test_isolated_runner_failure_paths_return_displayable_error_results(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_module()
+    config = module.PlaygroundConfig(sample_count=20, epochs=1, grid_size=8)
+
+    def timeout_run(*_args, **_kwargs):
+        raise module.subprocess.TimeoutExpired(cmd="python", timeout=180)
+
+    monkeypatch.setattr(module.subprocess, "run", timeout_run)
+    train_timeout = module._run_core_in_subprocess("train", config)
+    landscape_timeout = module._run_core_in_subprocess("loss_landscape", config, resolution=5, span=0.2)
+
+    assert train_timeout["status"] == "error"
+    assert "timed out after 180" in train_timeout["detail"]
+    assert train_timeout["samples"].shape[0] == 20
+    assert landscape_timeout["status"] == "error"
+    assert landscape_timeout["loss_landscape"].empty
+
+    def nonzero_run(_cmd, **_kwargs):
+        return SimpleNamespace(returncode=7, stderr="fatal line\n")
+
+    monkeypatch.setattr(module.subprocess, "run", nonzero_run)
+    train_nonzero = module._run_core_in_subprocess("train", config)
+    nonzero_result = module._run_core_in_subprocess("loss_landscape", config, resolution=5, span=0.2)
+    assert train_nonzero["status"] == "error"
+    assert train_nonzero["history"].empty
+    assert nonzero_result["status"] == "error"
+    assert "exit code 7" in nonzero_result["detail"]
+    assert "fatal line" in nonzero_result["detail"]
+
+    def payload_run(payload):
+        def fake_run(cmd, **_kwargs):
+            Path(cmd[-1]).write_bytes(module.pickle.dumps(payload, protocol=module.pickle.HIGHEST_PROTOCOL))
+            return SimpleNamespace(returncode=0, stderr="")
+
+        return fake_run
+
+    monkeypatch.setattr(module.subprocess, "run", payload_run({"ok": False, "error_type": "ValueError", "error": "bad payload"}))
+    failed_payload = module._run_core_in_subprocess("train", config)
+    assert failed_payload["status"] == "error"
+    assert "ValueError: bad payload" in failed_payload["detail"]
+
+    monkeypatch.setattr(module.subprocess, "run", payload_run(["not", "a", "mapping"]))
+    malformed_payload = module._run_core_in_subprocess("loss_landscape", config, resolution=5, span=0.2)
+    assert malformed_payload["status"] == "error"
+    assert malformed_payload["landscape_summary"]["status"] == "error"
+
+    monkeypatch.setattr(module.subprocess, "run", payload_run({"ok": True, "result": []}))
+    invalid_result = module._run_core_in_subprocess("train", config)
+    invalid_landscape = module._run_core_in_subprocess("loss_landscape", config, resolution=5, span=0.2)
+    assert invalid_result["status"] == "error"
+    assert "runner returned an invalid payload" in invalid_result["detail"]
+    assert invalid_landscape["status"] == "error"
+    assert invalid_landscape["loss_landscape"].empty
+
+
+def test_cached_train_and_loss_landscape_route_to_isolated_runner(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_module()
+    config = module.PlaygroundConfig(sample_count=28, epochs=1, grid_size=8, seed=101)
+    calls: list[tuple[str, int | None, float | None]] = []
+
+    def fake_run_core(action, _config, *, resolution=None, span=None):
+        calls.append((action, resolution, span))
+        if action == "train":
+            return {"status": "ok", "summary": {"backend": "isolated"}}
+        return {"status": "ok", "loss_landscape": pd.DataFrame(), "landscape_summary": {"points": 0}}
+
+    monkeypatch.setattr(module, "_use_isolated_torch_training", lambda: True)
+    monkeypatch.setattr(module, "_run_core_in_subprocess", fake_run_core)
+
+    train_result = module._cached_train(module.asdict(config))
+    landscape_result = module._cached_loss_landscape(module.asdict(config), resolution=7, span=0.3)
+
+    assert train_result["summary"]["backend"] == "isolated"
+    assert landscape_result["landscape_summary"]["points"] == 0
+    assert calls == [("train", None, None), ("loss_landscape", 7, 0.3)]
+
+
+def test_playground_ui_helper_error_and_display_edges(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_module()
+    fake_st = SimpleNamespace(session_state={module.TRAINED_CONFIG_STATE_KEY: "bad payload"})
+    monkeypatch.setattr(module, "st", fake_st)
+
+    config = module.PlaygroundConfig(sample_count=64, epochs=10, grid_size=12)
+    trained, preset, pending = module._resolve_trained_config(
+        config,
+        module.DEFAULT_PRESET,
+        train_requested=False,
+    )
+
+    assert trained == config
+    assert preset == module.DEFAULT_PRESET
+    assert pending is False
+    assert module._streamlit_script_context_active() is False
+    assert module._session_state_get("missing", "fallback") == "fallback"
+    monkeypatch.setattr(module, "st", SimpleNamespace())
+    assert module._session_state_get("missing", "fallback") == "fallback"
+    assert module._format_percent("bad") == "0%"
+    assert module._format_percent(float("nan")) == "0%"
+    assert module._confidence_score(pd.DataFrame({"probability": []})) == 0.0
+    assert module._class_balance(pd.DataFrame({"target": []})) == "no samples"
+    assert module._performance_band({"validation_accuracy": 0.95})[0] == "Strong fit"
+    assert module._performance_band({"validation_accuracy": 0.80})[0] == "Learning visible"
+    assert module._gap_band({"train_accuracy": 0.90, "validation_accuracy": 0.80})[0] == "Watch the gap"
+    assert module._gap_band({"train_accuracy": 0.95, "validation_accuracy": 0.70})[0] == "Likely overfit"
+    assert module._confidence_band(pd.DataFrame({"probability": [0.1, 0.9]}))[0] == "Decisive boundary"
+    assert module._confidence_band(pd.DataFrame({"probability": [0.30, 0.70]}))[0] == "Boundary forming"
+
+
 def _runtime_payload_files(root: Path) -> set[Path]:
     return {
         path.relative_to(root)

--- a/test/test_ui_pages.py
+++ b/test/test_ui_pages.py
@@ -753,6 +753,39 @@ def test_page_load_timing_is_opt_in_sidebar_diagnostic(monkeypatch):
     assert captions == ["PROJECT loaded in 123 ms"]
 
 
+def test_ui_timing_trace_records_phase_spans_without_page_load_caption(monkeypatch):
+    main_page = _import_agilab_module("agilab.main_page")
+    captions = []
+    fake_streamlit = SimpleNamespace(
+        sidebar=SimpleNamespace(caption=captions.append),
+        session_state={},
+    )
+
+    monkeypatch.delenv(main_page.PAGE_LOAD_TIMING_ENV_KEY, raising=False)
+    monkeypatch.setenv(main_page.UI_TIMING_TRACE_ENV_KEY, "1")
+    main_page._record_ui_timing_span(
+        "PROJECT:bootstrap",
+        10.0,
+        category="bootstrap",
+        streamlit=fake_streamlit,
+        perf_counter=lambda: 10.015,
+    )
+    main_page._render_page_load_timing(
+        "PROJECT",
+        10.0,
+        streamlit=fake_streamlit,
+        perf_counter=lambda: 10.123,
+    )
+
+    assert fake_streamlit.session_state[main_page.UI_TIMING_SESSION_KEY][0] == {
+        "label": "PROJECT:bootstrap",
+        "category": "bootstrap",
+        "elapsed_ms": "15.0",
+    }
+    assert any("PROJECT:bootstrap [bootstrap] 15 ms" in caption for caption in captions)
+    assert all(caption != "PROJECT loaded in 123 ms" for caption in captions)
+
+
 def test_agilab_main_page_env_editor_shows_worker_python_override(mock_ui_env):
     home_root = mock_ui_env["apps_dir"].parent
     env_file = home_root / ".agilab" / ".env"

--- a/test/test_ui_performance.py
+++ b/test/test_ui_performance.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+
+
+SRC_ROOT = Path(__file__).resolve().parents[1] / "src"
+MODULE_PATH = SRC_ROOT / "agilab" / "ui_performance.py"
+spec = importlib.util.spec_from_file_location("agilab_ui_performance_test_module", MODULE_PATH)
+assert spec is not None and spec.loader is not None
+ui_performance = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = ui_performance
+spec.loader.exec_module(ui_performance)
+
+
+def test_ui_performance_env_flags_are_explicit() -> None:
+    assert ui_performance.flag_enabled("1") is True
+    assert ui_performance.flag_enabled("debug") is True
+    assert ui_performance.flag_enabled("off") is False
+    assert ui_performance.flag_enabled(None) is False
+
+    assert ui_performance.ui_discovery_cache_enabled({}) is True
+    assert ui_performance.ui_discovery_cache_enabled({"AGILAB_DISABLE_UI_DISCOVERY_CACHE": "yes"}) is False
+    assert ui_performance.ui_timing_trace_enabled({}) is False
+    assert ui_performance.ui_timing_trace_enabled({"AGILAB_UI_TIMING_TRACE": "on"}) is True
+
+
+def test_child_path_signatures_cover_expected_registry_inputs(tmp_path: Path) -> None:
+    template = tmp_path / "demo_app_template"
+    hidden = tmp_path / ".hidden_app_template"
+    ignored = tmp_path / "demo_project"
+    template.mkdir()
+    hidden.mkdir()
+    ignored.mkdir()
+    (template / "pyproject.toml").write_text("[project]\nname='demo'\n", encoding="utf-8")
+    (template / "src").mkdir()
+    (template / "src" / "app_settings.toml").write_text("[cluster]\n", encoding="utf-8")
+
+    signatures = ui_performance.child_path_signatures(
+        tmp_path,
+        child_suffix="_app_template",
+        extra_relative_paths=("pyproject.toml", "src", "src/app_settings.toml", "missing.toml"),
+    )
+
+    labels = [signature[0] for signature in signatures]
+    assert labels == [
+        ".",
+        "demo_app_template",
+        "demo_app_template/pyproject.toml",
+        "demo_app_template/src",
+        "demo_app_template/src/app_settings.toml",
+    ]
+    assert ui_performance.path_stat_signature(tmp_path / "missing") is None
+
+
+def test_child_path_signatures_tolerates_unreadable_root() -> None:
+    class BrokenRoot:
+        def iterdir(self):
+            raise OSError("unreadable")
+
+    assert ui_performance.child_path_signatures(
+        BrokenRoot(),  # type: ignore[arg-type]
+        child_suffix="_app_template",
+        include_root=False,
+    ) == ()
+
+
+def test_record_ui_timing_span_clamps_and_limits_session_rows() -> None:
+    session_state: dict[str, object] = {}
+
+    first = ui_performance.record_ui_timing_span(
+        session_state,
+        label="ABOUT:bootstrap",
+        category="bootstrap",
+        started_at=10.0,
+        perf_counter=lambda: 10.015,
+        limit=2,
+    )
+    ui_performance.record_ui_timing_span(
+        session_state,
+        label="ABOUT:render",
+        category="render",
+        started_at=20.0,
+        perf_counter=lambda: 19.0,
+        limit=2,
+    )
+    ui_performance.record_ui_timing_span(
+        session_state,
+        label="ABOUT:total",
+        started_at=30.0,
+        perf_counter=lambda: 30.1,
+        limit=2,
+    )
+
+    assert first.as_row() == {
+        "label": "ABOUT:bootstrap",
+        "category": "bootstrap",
+        "elapsed_ms": "15.0",
+    }
+    assert session_state[ui_performance.UI_TIMING_SESSION_KEY] == [
+        {"label": "ABOUT:render", "category": "render", "elapsed_ms": "0.0"},
+        {"label": "ABOUT:total", "category": "page", "elapsed_ms": "100.0"},
+    ]
+
+    class BadSession:
+        def get(self, *_args, **_kwargs):
+            raise RuntimeError("session unavailable")
+
+    span = ui_performance.record_ui_timing_span(
+        BadSession(),
+        label="bad",
+        started_at=1.0,
+        perf_counter=lambda: 1.001,
+    )
+    assert span.as_row()["elapsed_ms"] == "1.0"


### PR DESCRIPTION
## Summary
- add `agilab.ui_performance` helpers for opt-in Streamlit timing traces and shared UI discovery cache controls
- cache app-template and apps-page template discovery with stat-based invalidation, and route page-bundle/ANALYSIS discovery through the same global cache disable flag
- record ABOUT/SETTINGS/page bootstrap/import/render spans when `AGILAB_UI_TIMING_TRACE=1` is set, while keeping the default UI silent

## Validation
- `uv --preview-features extra-build-dependencies run --group dev --extra ui pytest -q -o addopts='' test/test_ui_performance.py test/test_app_template_registry.py test/test_page_bundle_registry.py test/test_ui_pages.py`
- `uv --preview-features extra-build-dependencies run --no-sync python -m py_compile src/agilab/ui_performance.py src/agilab/app_template_registry.py src/agilab/page_bundle_registry.py src/agilab/main_page.py src/agilab/pages/4_ANALYSIS.py`
- `uv --preview-features extra-build-dependencies run --no-sync python tools/impact_validate.py --files src/agilab/ui_performance.py src/agilab/app_template_registry.py src/agilab/page_bundle_registry.py src/agilab/main_page.py src/agilab/pages/4_ANALYSIS.py test/test_ui_performance.py test/test_app_template_registry.py test/test_page_bundle_registry.py test/test_ui_pages.py`
- `uv --preview-features extra-build-dependencies run --no-sync python tools/workflow_parity.py --profile agi-gui`
- `git diff --cached --check`

## Notes
- Existing local PyTorch playground edits were left unstaged and are not part of this PR.
