### PR TITLE
Harden agi-gui coverage manifest wait

### DIFF
--- a/tools/workflow_parity.py
+++ b/tools/workflow_parity.py
@@ -51,7 +51,7 @@ AGI_GUI_COVERAGE_CHUNKS = (
     "reports",
 )
 AGI_GUI_COVERAGE_MANIFEST_SCHEMA = "agilab.workflow_parity.agi_gui_coverage_chunk.v1"
-AGI_GUI_COVERAGE_MANIFEST_WAIT_SECONDS = 10.0
+AGI_GUI_COVERAGE_MANIFEST_WAIT_SECONDS = 30.0
 UI_ROBOT_MATRIX_SHARDS = (
     (
         "core",


### PR DESCRIPTION
## Summary
- Increase the agi-gui coverage manifest wait budget to avoid local parity false negatives when coverage chunk artifacts appear slightly after pytest output on macOS.

## Validation
- uv --preview-features extra-build-dependencies run --extra ui pytest -q -o addopts='' test/test_workflow_parity.py
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui