### PR TITLE
Read training history artifacts in analysis page

### DIFF
--- a/src/agilab/apps-pages/view_training_analysis/src/view_training_analysis/view_training_analysis.py
+++ b/src/agilab/apps-pages/view_training_analysis/src/view_training_analysis/view_training_analysis.py
@@ -46,6 +46,8 @@ RUN_ROOTS_KEY = f"{PAGE_KEY}_run_roots"
 TRAINERS_KEY = f"{PAGE_KEY}_trainers"
 TAGS_KEY = f"{PAGE_KEY}_tags"
 X_AXIS_KEY = f"{PAGE_KEY}_x_axis"
+TRAINING_HISTORY_REL = Path("data/training_history.csv")
+SCALAR_FRAME_COLUMNS = ["tag", "step", "wall_time", "value"]
 
 
 def _ensure_repo_on_path() -> None:
@@ -195,6 +197,24 @@ def _discover_tensorboard_roots(data_root: Path) -> list[Path]:
     return sorted(trainer_roots, key=lambda path: path.as_posix())
 
 
+def _discover_training_history_roots(data_root: Path) -> list[Path]:
+    if not data_root.exists():
+        return []
+    roots: set[Path] = set()
+    for history_file in data_root.rglob(TRAINING_HISTORY_REL.name):
+        if history_file.is_file() and history_file.parent.name == TRAINING_HISTORY_REL.parent.name:
+            roots.add(history_file.parent.parent.resolve())
+    return sorted(roots, key=lambda path: path.as_posix())
+
+
+def _discover_training_roots(data_root: Path) -> list[Path]:
+    roots = {
+        *(_discover_tensorboard_roots(data_root)),
+        *(_discover_training_history_roots(data_root)),
+    }
+    return sorted(roots, key=lambda path: path.as_posix())
+
+
 def _discover_run_directories(tensorboard_dir: Path) -> list[Path]:
     if not tensorboard_dir.exists():
         return []
@@ -255,9 +275,13 @@ def _discover_run_labels(
     run_entries: list[tuple[Path, Path, str]] = []
     for trainer_root in sorted(trainer_roots, key=lambda path: path.as_posix()):
         tensorboard_dir = trainer_root / "tensorboard"
-        for run_dir in _discover_run_directories(tensorboard_dir):
+        run_dirs = _discover_run_directories(tensorboard_dir)
+        for run_dir in run_dirs:
             run_label = _relative_label(run_dir, tensorboard_dir)
             run_entries.append((trainer_root, run_dir, run_label))
+        history_file = trainer_root / TRAINING_HISTORY_REL
+        if not run_dirs and history_file.is_file():
+            run_entries.append((trainer_root, history_file.resolve(), "training_history"))
 
     if not include_trainer_prefix:
         return {run_label: run_dir for _, run_dir, run_label in run_entries}
@@ -322,8 +346,74 @@ def _load_event_accumulator():
     return EventAccumulator
 
 
+def _empty_scalar_frame() -> pd.DataFrame:
+    return pd.DataFrame(columns=SCALAR_FRAME_COLUMNS)
+
+
+def _load_training_history_frame(history_file: Path) -> pd.DataFrame:
+    try:
+        history = pd.read_csv(history_file)
+    except (OSError, pd.errors.EmptyDataError, pd.errors.ParserError):
+        return _empty_scalar_frame()
+    if history.empty:
+        return _empty_scalar_frame()
+
+    if "epoch" in history.columns:
+        step_values = pd.to_numeric(history["epoch"], errors="coerce")
+    elif "step" in history.columns:
+        step_values = pd.to_numeric(history["step"], errors="coerce")
+    else:
+        step_values = pd.Series(range(len(history)), index=history.index, dtype="float64")
+
+    if "wall_time" in history.columns:
+        wall_time_values = pd.to_numeric(history["wall_time"], errors="coerce")
+    else:
+        wall_time_values = step_values.astype("float64")
+
+    numeric_metrics: dict[str, pd.Series] = {}
+    for column in history.columns:
+        if column in {"epoch", "step", "wall_time", "relative_time_s", "timestamp"}:
+            continue
+        values = pd.to_numeric(history[column], errors="coerce")
+        if values.notna().any():
+            numeric_metrics[str(column)] = values
+
+    rows: list[dict[str, Any]] = []
+    for row_index, row in history.iterrows():
+        step = step_values.loc[row_index]
+        wall_time = wall_time_values.loc[row_index]
+        if pd.isna(step):
+            continue
+        if pd.isna(wall_time):
+            wall_time = step
+        for column, values in numeric_metrics.items():
+            value = values.loc[row_index]
+            if pd.isna(value):
+                continue
+            rows.append(
+                {
+                    "tag": str(column),
+                    "step": int(step),
+                    "wall_time": float(wall_time),
+                    "value": float(value),
+                }
+            )
+
+    df = pd.DataFrame(rows, columns=SCALAR_FRAME_COLUMNS)
+    if df.empty:
+        return df
+    df = df.sort_values(["tag", "step", "wall_time"], kind="stable").reset_index(drop=True)
+    df["relative_time_s"] = df["wall_time"] - float(df["wall_time"].min())
+    df["timestamp"] = pd.to_datetime(df["wall_time"], unit="s", utc=True).dt.tz_convert(None)
+    return df
+
+
 @st.cache_data(show_spinner=False)
 def _load_scalar_frame(run_dir_str: str) -> pd.DataFrame:
+    run_path = Path(run_dir_str)
+    if run_path.is_file() and run_path.name == TRAINING_HISTORY_REL.name:
+        return _load_training_history_frame(run_path)
+
     EventAccumulator = _load_event_accumulator()
     accumulator = EventAccumulator(run_dir_str)
     accumulator.Reload()
@@ -428,7 +518,7 @@ def main() -> None:
     render_logo("Training Analysis")
     st.title("Training analysis")
     st.caption(
-        "Browse TensorBoard scalar logs from one or more trainer outputs and plot the metrics you need."
+        "Browse TensorBoard scalar logs or AGILAB training-history artifacts and plot the metrics you need."
     )
 
     page_state = _get_page_state()
@@ -474,9 +564,9 @@ def main() -> None:
         _persist_app_settings(env)
         st.stop()
 
-    trainer_roots = _discover_tensorboard_roots(data_root)
+    trainer_roots = _discover_training_roots(data_root)
     if not trainer_roots:
-        st.warning(f"No TensorBoard trainers found under {data_root}.")
+        st.warning(f"No TensorBoard or training-history outputs found under {data_root}.")
         page_state.update(
             {
                 "base_dir_choice": base_choice,

--- a/test/test_view_training_analysis.py
+++ b/test/test_view_training_analysis.py
@@ -57,6 +57,25 @@ def test_view_training_analysis_discovers_trainers_and_runs(tmp_path: Path) -> N
     run_dirs = module._discover_run_directories(trainer_b_root)
     assert run_dirs == [trainer_b_root.resolve(), trainer_b_run.resolve()]
 
+    artifact_root = tmp_path / "pipeline" / "pytorch_playground" / "data"
+    artifact_root.mkdir(parents=True)
+    (artifact_root / "training_history.csv").write_text(
+        "epoch,train_loss,validation_loss\n1,0.4,0.5\n",
+        encoding="utf-8",
+    )
+
+    assert module._discover_training_history_roots(tmp_path / "pipeline") == [
+        tmp_path / "pipeline" / "pytorch_playground"
+    ]
+    assert module._discover_training_roots(tmp_path / "pipeline") == sorted(
+        [
+            tmp_path / "pipeline" / "pytorch_playground",
+            tmp_path / "pipeline" / "trainer_a",
+            tmp_path / "pipeline" / "trainer_b",
+        ],
+        key=lambda path: path.as_posix(),
+    )
+
 
 def test_view_training_analysis_labels_runs_across_multiple_trainers(tmp_path: Path) -> None:
     module = _load_module()
@@ -321,6 +340,36 @@ def test_view_training_analysis_handles_tensorboard_helper_edge_cases(monkeypatc
     assert module._load_scalar_frame(str(tmp_path)).empty
 
 
+def test_view_training_analysis_loads_training_history_csv_as_scalars(tmp_path: Path) -> None:
+    module = _load_module()
+
+    trainer_root = tmp_path / "export" / "pytorch_playground" / "pytorch_playground"
+    history_file = trainer_root / "data" / "training_history.csv"
+    history_file.parent.mkdir(parents=True)
+    history_file.write_text(
+        "epoch,train_loss,validation_loss,train_accuracy,note\n"
+        "1,0.8,0.9,0.55,warmup\n"
+        "2,0.4,0.5,0.75,better\n",
+        encoding="utf-8",
+    )
+
+    run_labels = module._discover_run_labels([trainer_root], tmp_path / "export")
+    assert run_labels == {"training_history": history_file.resolve()}
+
+    module._load_scalar_frame.clear()
+    scalar_df = module._load_scalar_frame(str(history_file))
+
+    assert scalar_df[["tag", "step", "value"]].to_dict("records") == [
+        {"tag": "train_accuracy", "step": 1, "value": 0.55},
+        {"tag": "train_accuracy", "step": 2, "value": 0.75},
+        {"tag": "train_loss", "step": 1, "value": 0.8},
+        {"tag": "train_loss", "step": 2, "value": 0.4},
+        {"tag": "validation_loss", "step": 1, "value": 0.9},
+        {"tag": "validation_loss", "step": 2, "value": 0.5},
+    ]
+    assert scalar_df["relative_time_s"].tolist() == [0.0, 1.0, 0.0, 1.0, 0.0, 1.0]
+
+
 def test_view_training_analysis_additional_helper_and_entrypoint_branches(monkeypatch, tmp_path: Path) -> None:
     module = _load_module()
 
@@ -508,7 +557,7 @@ def test_view_training_analysis_main_bootstraps_env_when_missing(monkeypatch, tm
     monkeypatch.setattr(module, "render_logo", lambda *args, **kwargs: None)
     monkeypatch.setattr(module, "_resolve_active_app", lambda: active_app)
     monkeypatch.setattr(module, "AgiEnv", FakeEnv)
-    monkeypatch.setattr(module, "_discover_tensorboard_roots", lambda root: [])
+    monkeypatch.setattr(module, "_discover_training_roots", lambda root: [])
 
     with pytest.raises(_StopCalled):
         module.main()
@@ -518,7 +567,7 @@ def test_view_training_analysis_main_bootstraps_env_when_missing(monkeypatch, tm
     assert module.st.session_state["input_datadir"] == ""
     assert module.st.session_state["datadir_rel"] == ""
     assert module.st.session_state[module.X_AXIS_KEY] == "step"
-    assert any("No TensorBoard trainers found" in message for message in warnings_seen)
+    assert any("No TensorBoard or training-history outputs found" in message for message in warnings_seen)
 
 
 def test_view_training_analysis_main_plots_selected_metrics(monkeypatch, tmp_path: Path) -> None:
@@ -578,7 +627,7 @@ def test_view_training_analysis_main_plots_selected_metrics(monkeypatch, tmp_pat
         stop=_stop,
     )
     monkeypatch.setattr(module, "render_logo", lambda *args, **kwargs: None)
-    monkeypatch.setattr(module, "_discover_tensorboard_roots", lambda root: [trainer_dir])
+    monkeypatch.setattr(module, "_discover_training_roots", lambda root: [trainer_dir])
     monkeypatch.setattr(module, "_discover_run_directories", lambda root: [run_a, run_b])
 
     def fake_load_scalar_frame(run_dir_str: str) -> pd.DataFrame:
@@ -727,16 +776,16 @@ def test_view_training_analysis_main_warns_when_no_trainers_or_runs(monkeypatch,
     monkeypatch.setattr(module, "render_logo", lambda *args, **kwargs: None)
 
     module.st = _base_st()
-    monkeypatch.setattr(module, "_discover_tensorboard_roots", lambda root: [])
+    monkeypatch.setattr(module, "_discover_training_roots", lambda root: [])
     with pytest.raises(_StopCalled):
         module.main()
-    assert any("No TensorBoard trainers found" in message for message in warnings_seen)
+    assert any("No TensorBoard or training-history outputs found" in message for message in warnings_seen)
 
     warnings_seen.clear()
     trainer_dir = data_root / "trainer_a"
     trainer_dir.mkdir()
     module.st = _base_st()
-    monkeypatch.setattr(module, "_discover_tensorboard_roots", lambda root: [trainer_dir])
+    monkeypatch.setattr(module, "_discover_training_roots", lambda root: [trainer_dir])
     monkeypatch.setattr(module, "_discover_run_directories", lambda root: [])
     with pytest.raises(_StopCalled):
         module.main()
@@ -803,7 +852,7 @@ def test_view_training_analysis_main_handles_selection_and_metric_edge_cases(mon
         )
 
     monkeypatch.setattr(module, "render_logo", lambda *args, **kwargs: None)
-    monkeypatch.setattr(module, "_discover_tensorboard_roots", lambda root: [trainer_dir])
+    monkeypatch.setattr(module, "_discover_training_roots", lambda root: [trainer_dir])
     monkeypatch.setattr(module, "_discover_run_directories", lambda root: [run_a, run_b])
 
     module.st = _base_st([], [])


### PR DESCRIPTION
## Summary
- let the training analysis page discover AGILAB `data/training_history.csv` artifacts when TensorBoard logs are absent
- normalize training-history CSV metrics into scalar frames for existing plots
- cover discovery, labels, CSV loading, and updated warning paths

## Validation
- `uv --preview-features extra-build-dependencies run --no-sync python tools/impact_validate.py --files src/agilab/apps-pages/view_training_analysis/src/view_training_analysis/view_training_analysis.py test/test_view_training_analysis.py`
- `uv --preview-features extra-build-dependencies run --with plotly --no-sync pytest -q -o addopts='' test/test_view_training_analysis.py`
- `git diff --check -- src/agilab/apps-pages/view_training_analysis/src/view_training_analysis/view_training_analysis.py test/test_view_training_analysis.py`