### PR TITLE
Document training history analysis artifacts

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 217,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "cab7bdcf00d834360f7f9c13aa271adbdbc6c5c86a8f85577f61e58755ade07d",
+  "source_digest_sha256": "5c864b112f1e46eae64f05c5997b7deb33b8def070c93fe6575849cd90b7f153",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "cab7bdcf00d834360f7f9c13aa271adbdbc6c5c86a8f85577f61e58755ade07d"
+  "target_digest_sha256": "5c864b112f1e46eae64f05c5997b7deb33b8def070c93fe6575849cd90b7f153"
 }

--- a/docs/source/apps-pages.rst
+++ b/docs/source/apps-pages.rst
@@ -163,7 +163,7 @@ pulled by the umbrella dependency graph.
      - Included in ``agi-pages``.
    * - ``view_training_analysis``
      - ``agi-page-training-report``
-     - Training run and TensorBoard scalar browser.
+     - Training run scalar browser for TensorBoard logs and AGILAB training-history CSV artifacts.
      - Included in ``agi-pages``.
 
 view_barycentric
@@ -304,7 +304,8 @@ view_training_analysis
 
 Training evidence page for scalar logs and model-training runs.
 
-- Input: TensorBoard-compatible scalar folders under an app export directory.
+- Input: TensorBoard-compatible scalar folders or ``data/training_history.csv``
+  artifacts under an app export directory.
 - Output: run selector, scalar trends, and training metadata for comparison.
 
 view_autoencoder_latentspace

--- a/src/agilab/apps-pages/README.md
+++ b/src/agilab/apps-pages/README.md
@@ -53,7 +53,7 @@ Quick start (dev checkout):
 
 - view_training_analysis
   - uv run streamlit run src/agilab/apps-pages/view_training_analysis/src/view_training_analysis/view_training_analysis.py -- --active-app src/agilab/apps/builtin/flight_telemetry_project
-  - Generic TensorBoard scalar browser for any app that exports trainer logs under a `tensorboard/` folder.
+  - Generic scalar browser for apps that export TensorBoard logs under `tensorboard/` or AGILAB training history under `data/training_history.csv`.
 
 - view_inference_analysis
   - uv run streamlit run src/agilab/apps-pages/view_inference_analysis/src/view_inference_analysis/view_inference_analysis.py -- --active-app src/agilab/apps/builtin/flight_telemetry_project


### PR DESCRIPTION
## Summary
- document that `view_training_analysis` reads TensorBoard logs and AGILAB `data/training_history.csv` artifacts
- update the apps-pages README quick-start description
- refresh the docs mirror stamp from canonical docs

## Validation
- `uv --preview-features extra-build-dependencies run --no-sync python tools/sync_docs_source.py --verify-stamp`
- clean PR CI will run docs/install guards without the local version-bump worktree edits