### PR TITLE
[codex] Align PyTorch app surface routing

### DIFF
--- a/.claude/skills/agilab-streamlit-pages/SKILL.md
+++ b/.claude/skills/agilab-streamlit-pages/SKILL.md
@@ -48,6 +48,11 @@ Use this skill when editing:
   evidence export, make it an app project first. Keep any app-owned standalone
   Streamlit surface under that app project unless a separate generic analysis
   page reads only exported artifacts.
+- For an app-owned Streamlit surface that should appear as the app's primary
+  ANALYSIS experience, declare `[app_surface]` in the app's `app_settings.toml`
+  with a project-local entrypoint such as `pytorch_playground/app_surface.py`.
+  Keep `pages.view_module = []` when the app surface replaces generic page
+  launchers. Do not create a generic `apps-pages/view_<app>` bridge for this.
 
 ## Session State Rules (Avoid Common Crashes)
 

--- a/.codex/skills/agilab-streamlit-pages/SKILL.md
+++ b/.codex/skills/agilab-streamlit-pages/SKILL.md
@@ -48,6 +48,11 @@ Use this skill when editing:
   evidence export, make it an app project first. Keep any app-owned standalone
   Streamlit surface under that app project unless a separate generic analysis
   page reads only exported artifacts.
+- For an app-owned Streamlit surface that should appear as the app's primary
+  ANALYSIS experience, declare `[app_surface]` in the app's `app_settings.toml`
+  with a project-local entrypoint such as `pytorch_playground/app_surface.py`.
+  Keep `pages.view_module = []` when the app surface replaces generic page
+  launchers. Do not create a generic `apps-pages/view_<app>` bridge for this.
 
 ## Session State Rules (Avoid Common Crashes)
 

--- a/src/agilab/app_surface.py
+++ b/src/agilab/app_surface.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import sys
+import tomllib
+from collections.abc import Mapping
+from contextlib import contextmanager
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+APP_SURFACE_SECTION = "app_surface"
+
+
+def _read_app_settings(active_app: Path) -> dict[str, Any]:
+    settings_path = active_app / "src" / "app_settings.toml"
+    try:
+        with settings_path.open("rb") as stream:
+            payload = tomllib.load(stream)
+    except (OSError, tomllib.TOMLDecodeError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def app_surface_config(
+    active_app: str | Path | None,
+    config: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Return the declared app-owned UI surface configuration, if present."""
+    configured_surface = config.get(APP_SURFACE_SECTION) if isinstance(config, Mapping) else None
+    if isinstance(configured_surface, Mapping) and configured_surface.get("entrypoint"):
+        return dict(configured_surface)
+    if active_app is None:
+        return {}
+    seed_surface = _read_app_settings(Path(active_app).expanduser()).get(APP_SURFACE_SECTION)
+    if isinstance(seed_surface, Mapping) and seed_surface.get("entrypoint"):
+        return dict(seed_surface)
+    return {}
+
+
+def app_surface_title(config: Mapping[str, Any] | None) -> str:
+    if not isinstance(config, Mapping):
+        return "App Surface"
+    title = config.get("title")
+    return str(title).strip() or "App Surface"
+
+
+def resolve_app_surface_entrypoint(
+    active_app: str | Path | None,
+    entrypoint: object,
+) -> Path | None:
+    """Resolve an app-owned Streamlit surface entrypoint inside the active app."""
+    if active_app is None or not isinstance(entrypoint, (str, Path)):
+        return None
+    app_path = Path(active_app).expanduser().resolve()
+    entrypoint_path = Path(entrypoint).expanduser()
+    candidates: list[Path]
+    if entrypoint_path.is_absolute():
+        candidates = [entrypoint_path]
+    else:
+        candidates = [
+            app_path / "src" / entrypoint_path,
+            app_path / entrypoint_path,
+        ]
+    for candidate in candidates:
+        try:
+            resolved = candidate.resolve()
+        except (OSError, RuntimeError):
+            continue
+        if not resolved.is_file():
+            continue
+        try:
+            resolved.relative_to(app_path)
+        except ValueError:
+            continue
+        return resolved
+    return None
+
+
+def configured_app_surface_entrypoint(
+    active_app: str | Path | None,
+    config: Mapping[str, Any] | None = None,
+) -> Path | None:
+    surface_config = app_surface_config(active_app, config)
+    return resolve_app_surface_entrypoint(active_app, surface_config.get("entrypoint"))
+
+
+@contextmanager
+def _temporary_sys_path(paths: list[Path]):
+    previous = list(sys.path)
+    try:
+        for path in reversed(paths):
+            entry = str(path)
+            sys.path[:] = [existing for existing in sys.path if existing != entry]
+            sys.path.insert(0, entry)
+        yield
+    finally:
+        sys.path[:] = previous
+
+
+@contextmanager
+def _temporary_argv(entrypoint: Path, active_app: Path):
+    previous = list(sys.argv)
+    sys.argv = [str(entrypoint), "--active-app", str(active_app)]
+    try:
+        yield
+    finally:
+        sys.argv = previous
+
+
+def _load_module_from_path(entrypoint: Path) -> ModuleType:
+    digest = hashlib.sha1(str(entrypoint).encode("utf-8")).hexdigest()[:12]
+    module_name = f"_agilab_app_surface_{digest}"
+    spec = importlib.util.spec_from_file_location(module_name, entrypoint)
+    if spec is None or spec.loader is None:
+        raise ModuleNotFoundError(f"Unable to load app surface from {entrypoint}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def render_app_surface(
+    active_app: str | Path | None,
+    *,
+    mode: str,
+    config: Mapping[str, Any] | None = None,
+    env: Any | None = None,
+    container: Any | None = None,
+    streamlit: Any | None = None,
+) -> bool:
+    """Render an app-owned surface inline when its module exposes a render() hook."""
+    if active_app is None:
+        return False
+    active_app_path = Path(active_app).expanduser().resolve()
+    surface_config = app_surface_config(active_app_path, config)
+    entrypoint = resolve_app_surface_entrypoint(active_app_path, surface_config.get("entrypoint"))
+    if entrypoint is None:
+        return False
+    with _temporary_sys_path([active_app_path / "src", entrypoint.parent]), _temporary_argv(entrypoint, active_app_path):
+        module = _load_module_from_path(entrypoint)
+        render = getattr(module, "render", None)
+        if not callable(render):
+            return False
+        kwargs: dict[str, Any] = {
+            "mode": mode,
+            "active_app": active_app_path,
+        }
+        if env is not None:
+            kwargs["env"] = env
+        if container is not None:
+            kwargs["container"] = container
+        if streamlit is not None:
+            kwargs["streamlit"] = streamlit
+        render(**kwargs)
+    return True

--- a/src/agilab/apps-pages/view_training_analysis/src/view_training_analysis/view_training_analysis.py
+++ b/src/agilab/apps-pages/view_training_analysis/src/view_training_analysis/view_training_analysis.py
@@ -48,6 +48,7 @@ TAGS_KEY = f"{PAGE_KEY}_tags"
 X_AXIS_KEY = f"{PAGE_KEY}_x_axis"
 TRAINING_HISTORY_REL = Path("data/training_history.csv")
 SCALAR_FRAME_COLUMNS = ["tag", "step", "wall_time", "value"]
+EMBED_QUERY_VALUES = {"1", "true", "yes", "on"}
 
 
 def _ensure_repo_on_path() -> None:
@@ -158,6 +159,86 @@ def _get_first_nonempty_setting(sources: list[dict[str, Any]], *keys: str) -> st
             if isinstance(value, str) and value.strip():
                 return value.strip()
     return ""
+
+
+def _query_param_value(query_params: Any, key: str) -> str:
+    try:
+        value = query_params.get(key, "")
+    except AttributeError:
+        try:
+            value = query_params[key]
+        except (KeyError, TypeError):
+            return ""
+    if isinstance(value, (list, tuple)):
+        value = value[0] if value else ""
+    return str(value).strip()
+
+
+def _is_embed_mode(query_params: Any) -> bool:
+    return _query_param_value(query_params, "embed").lower() in EMBED_QUERY_VALUES
+
+
+def _render_embed_chrome() -> None:
+    st.markdown(
+        """
+        <style>
+        [data-testid="stHeader"],
+        [data-testid="stToolbar"],
+        footer {
+            visibility: hidden;
+            height: 0;
+        }
+        .block-container {
+            max-width: 100%;
+            padding-top: 0.75rem;
+            padding-bottom: 0.75rem;
+        }
+        [data-testid="stSidebar"] {
+            min-width: 14rem;
+            max-width: 18rem;
+        }
+        [data-testid="stSidebarContent"] {
+            padding-top: 0.75rem;
+        }
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )
+
+
+def _embedded_default_data_subpath(
+    env: AgiEnv,
+    base_choice: str,
+    rel_seed: str,
+    *,
+    embed_mode: bool,
+) -> str:
+    cleaned_seed = rel_seed.strip()
+    if not embed_mode or base_choice != "AGILAB_EXPORT" or cleaned_seed:
+        return cleaned_seed
+
+    export_root = Path(env.AGILAB_EXPORT_ABS)
+    candidates: list[str] = []
+    seen: set[str] = set()
+    for raw_value in (getattr(env, "target", ""), getattr(env, "app", "")):
+        candidate = str(raw_value).strip()
+        if not candidate or candidate in seen:
+            continue
+        seen.add(candidate)
+        candidates.append(candidate)
+        if candidate.endswith("_project"):
+            projectless = candidate[: -len("_project")]
+            if projectless and projectless not in seen:
+                seen.add(projectless)
+                candidates.append(projectless)
+
+    for candidate in candidates:
+        try:
+            if (export_root / candidate).exists():
+                return candidate
+        except OSError:
+            continue
+    return cleaned_seed
 
 
 def _resolve_base_path(
@@ -444,6 +525,8 @@ def _build_scalar_figure(
     scalar_df: pd.DataFrame,
     selected_tags: list[str],
     x_column: str,
+    *,
+    embed_mode: bool = False,
 ) -> go.Figure:
     rows, cols = _grid_shape(len(selected_tags))
     fig = make_subplots(
@@ -495,15 +578,33 @@ def _build_scalar_figure(
         fig.update_xaxes(title_text=x_title, row=row, col=col)
         fig.update_yaxes(title_text="value", row=row, col=col)
 
-    fig.update_layout(
-        height=max(360, 320 * rows),
-        margin={"l": 20, "r": 20, "t": 50, "b": 20},
-    )
+    layout: dict[str, Any] = {
+        "autosize": True,
+        "height": min(820, max(520, 360 * rows)) if embed_mode else max(360, 320 * rows),
+        "margin": {"l": 12, "r": 12, "t": 42, "b": 12}
+        if embed_mode
+        else {"l": 20, "r": 20, "t": 50, "b": 20},
+    }
+    if embed_mode:
+        layout["legend"] = {
+            "orientation": "h",
+            "yanchor": "bottom",
+            "y": 1.02,
+            "xanchor": "left",
+            "x": 0,
+        }
+    fig.update_layout(**layout)
     return fig
 
 
 def main() -> None:
-    st.set_page_config(layout="wide")
+    embed_mode = _is_embed_mode(getattr(st, "query_params", {}))
+    st.set_page_config(
+        layout="wide",
+        initial_sidebar_state="collapsed" if embed_mode else "auto",
+    )
+    if embed_mode:
+        _render_embed_chrome()
 
     if "env" not in st.session_state:
         active_app_path = _resolve_active_app()
@@ -515,11 +616,14 @@ def main() -> None:
 
     _ensure_app_settings_loaded(env)
 
-    render_logo("Training Analysis")
-    st.title("Training analysis")
-    st.caption(
-        "Browse TensorBoard scalar logs or AGILAB training-history artifacts and plot the metrics you need."
-    )
+    if embed_mode:
+        st.caption("Training analysis")
+    else:
+        render_logo("Training Analysis")
+        st.title("Training analysis")
+        st.caption(
+            "Browse TensorBoard scalar logs or AGILAB training-history artifacts and plot the metrics you need."
+        )
 
     page_state = _get_page_state()
     page_defaults = _get_page_defaults()
@@ -528,9 +632,10 @@ def main() -> None:
     base_options = ["AGI_CLUSTER_SHARE", "AGILAB_EXPORT", "Custom"]
     base_seed = _get_first_nonempty_setting(setting_sources, "base_dir_choice", "dataset_base_choice")
     if base_seed not in base_options:
-        base_seed = "AGI_CLUSTER_SHARE"
+        base_seed = "AGILAB_EXPORT" if embed_mode else "AGI_CLUSTER_SHARE"
     custom_seed = _get_first_nonempty_setting(setting_sources, "input_datadir", "dataset_custom_base")
     rel_seed = _get_first_nonempty_setting(setting_sources, "datadir_rel", "dataset_subpath")
+    rel_seed = _embedded_default_data_subpath(env, base_seed, rel_seed, embed_mode=embed_mode)
 
     if "base_dir_choice" not in st.session_state:
         st.session_state["base_dir_choice"] = base_seed
@@ -668,7 +773,7 @@ def main() -> None:
     else:
         st.subheader("Scalar plots")
         st.plotly_chart(
-            _build_scalar_figure(scalar_df, selected_tags, x_axis_option),
+            _build_scalar_figure(scalar_df, selected_tags, x_axis_option, embed_mode=embed_mode),
             width="stretch",
         )
 

--- a/src/agilab/apps/builtin/global_dag_project/src/pre_prompt.json
+++ b/src/agilab/apps/builtin/global_dag_project/src/pre_prompt.json
@@ -1,9 +1,10 @@
-{
-  "app": "global_dag_project",
-  "purpose": "Teach multi-app DAG orchestration with explicit artifact contracts.",
-  "guardrails": [
-    "Keep examples read-only unless the operator explicitly starts a controlled DAG run.",
-    "Do not imply both apps have executed when only a runner-state preview was produced.",
-    "Preserve the artifact handoff names when adapting the bundled template."
-  ]
-}
+[
+  {
+    "role": "system",
+    "content": "You are operating the Global DAG AGILAB demo. Keep examples read-only unless the operator explicitly starts a controlled DAG run, and preserve explicit artifact handoff names when adapting the bundled template."
+  },
+  {
+    "role": "user",
+    "content": "Explain or adapt the multi-app DAG orchestration plan with explicit artifact contracts and do not imply apps have executed when only a preview was produced."
+  }
+]

--- a/src/agilab/apps/builtin/mission_decision_project/src/pre_prompt.json
+++ b/src/agilab/apps/builtin/mission_decision_project/src/pre_prompt.json
@@ -1,4 +1,10 @@
-{
-  "system": "You are operating the public Mission Decision AGILAB demo. Keep outputs factual, deterministic, and focused on mission-data ingestion, optional FRED public-context evidence, adaptive pipeline execution, and decision evidence. Do not include non-public competitive positioning or non-public app names.",
-  "user": "Generate or explain the next Mission Decision mission-decision step using the configured public scenario and analysis artifacts."
-}
+[
+  {
+    "role": "system",
+    "content": "You are operating the public Mission Decision AGILAB demo. Keep outputs factual, deterministic, and focused on mission-data ingestion, optional FRED public-context evidence, adaptive pipeline execution, and decision evidence. Do not include non-public competitive positioning or non-public app names."
+  },
+  {
+    "role": "user",
+    "content": "Generate or explain the next Mission Decision mission-decision step using the configured public scenario and analysis artifacts."
+  }
+]

--- a/src/agilab/apps/builtin/pytorch_playground_project/README.md
+++ b/src/agilab/apps/builtin/pytorch_playground_project/README.md
@@ -26,7 +26,7 @@ configuration trains the clean-circles preset and exports evidence under
 The app also keeps a local Streamlit playground surface for interactive review:
 
 ```bash
-uv run streamlit run src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/playground_ui.py -- --active-app src/agilab/apps/builtin/pytorch_playground_project
+uv run streamlit run src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/app_surface.py -- --active-app src/agilab/apps/builtin/pytorch_playground_project
 ```
 
 ## Expected Inputs

--- a/src/agilab/apps/builtin/pytorch_playground_project/README.md
+++ b/src/agilab/apps/builtin/pytorch_playground_project/README.md
@@ -13,9 +13,15 @@ deterministic ZIP bundle.
 
 ## Run In AGILAB
 
-Select `pytorch_playground_project`, open `ORCHESTRATE`, adjust the sidebar
-fields, then run `INSTALL` and `RUN`. The default configuration trains the
-clean-circles preset and exports evidence under `pytorch_playground/evidence`.
+Select `pytorch_playground_project`, then open `ANALYSIS` for the app-owned
+PyTorch Playground surface. That single surface contains the interactive
+controls, decision boundary, training curves, neuron/loss views, and evidence
+download.
+
+Open `ORCHESTRATE` when you want the reproducible AGILAB execution path:
+adjust the sidebar fields, then run `INSTALL` and `RUN`. The default
+configuration trains the clean-circles preset and exports evidence under
+`pytorch_playground/evidence`.
 
 The app also keeps a local Streamlit playground surface for interactive review:
 
@@ -46,5 +52,7 @@ The worker writes:
 ## Scope
 
 This is a reproducible educational app for neural-network behavior and loss
-landscape inspection. It is not a model-serving platform, production training
-pipeline, or generic app-agnostic analysis page.
+landscape inspection. It owns its PyTorch-specific UI inside the app project;
+generic apps-pages are only optional artifact readers such as cross-run scalar
+inspection. It is not a model-serving platform, production training pipeline,
+or generic app-agnostic analysis page.

--- a/src/agilab/apps/builtin/pytorch_playground_project/pyproject.toml
+++ b/src/agilab/apps/builtin/pytorch_playground_project/pyproject.toml
@@ -34,6 +34,7 @@ agi-gui = { path = "../../../lib/agi-gui", editable = true }
 
 [tool.agilab.app]
 distribution_preview = false
+service_mode = false
 
 [build-system]
 requires = ["setuptools"]

--- a/src/agilab/apps/builtin/pytorch_playground_project/src/app_args_form.py
+++ b/src/agilab/apps/builtin/pytorch_playground_project/src/app_args_form.py
@@ -67,10 +67,42 @@ def _number_input(
     min_value: int | float,
     max_value: int | float,
     step: int | float,
+    disabled: bool = False,
 ) -> int | float:
     key = _field_key(env, name)
     _seed_widget_value(key, value)
-    return container.number_input(label, min_value=min_value, max_value=max_value, step=step, key=key)
+    return container.number_input(
+        label,
+        min_value=min_value,
+        max_value=max_value,
+        step=step,
+        key=key,
+        disabled=disabled,
+    )
+
+
+def _slider(
+    container: Any,
+    env: Any,
+    name: str,
+    label: str,
+    value: int | float,
+    *,
+    min_value: int | float,
+    max_value: int | float,
+    step: int | float,
+    disabled: bool = False,
+) -> int | float:
+    key = _field_key(env, name)
+    _seed_widget_value(key, value)
+    return container.slider(
+        label,
+        min_value=min_value,
+        max_value=max_value,
+        step=step,
+        key=key,
+        disabled=disabled,
+    )
 
 
 def _selectbox(container: Any, env: Any, name: str, label: str, options: tuple[str, ...], value: str) -> str:
@@ -84,74 +116,260 @@ def _feature_names(container: Any, env: Any, value: str) -> str:
     return _text_input(container, env, "feature_names", "Feature names", ",".join(selected))
 
 
-def _render_args_form(model: app_args.PytorchPlaygroundArgs, *, env: Any, container: Any) -> dict[str, Any]:
+def _render_dataset_fields(model: app_args.PytorchPlaygroundArgs, *, env: Any, container: Any) -> dict[str, Any]:
+    dataset_col, samples_col, noise_col, split_col = container.columns([1.25, 1.0, 1.0, 1.0])
     return {
-        "data_out": _text_input(container, env, "data_out", "Data out", model.data_out),
-        "dataset": _selectbox(container, env, "dataset", "Dataset", DATASETS, model.dataset),
-        "sample_count": _number_input(container, env, "sample_count", "Sample count", model.sample_count, min_value=64, max_value=1000, step=16),
-        "noise": _number_input(container, env, "noise", "Noise", model.noise, min_value=0.0, max_value=0.5, step=0.01),
-        "train_ratio": _number_input(container, env, "train_ratio", "Train ratio", model.train_ratio, min_value=0.5, max_value=0.95, step=0.05),
-        "hidden_layers": _text_input(container, env, "hidden_layers", "Hidden layers", model.hidden_layers),
-        "activation": _selectbox(container, env, "activation", "Activation", ACTIVATIONS, model.activation),
-        "optimizer": _selectbox(container, env, "optimizer", "Optimizer", OPTIMIZERS, model.optimizer),
-        "learning_rate": _number_input(container, env, "learning_rate", "Learning rate", model.learning_rate, min_value=0.001, max_value=0.2, step=0.001),
-        "epochs": _number_input(container, env, "epochs", "Epochs", model.epochs, min_value=10, max_value=300, step=10),
-        "batch_size": _number_input(container, env, "batch_size", "Batch size", model.batch_size, min_value=8, max_value=256, step=8),
-        "seed": _number_input(container, env, "seed", "Seed", model.seed, min_value=0, max_value=9999, step=1),
-        "feature_names": _feature_names(container, env, model.feature_names),
-        "grid_size": _number_input(container, env, "grid_size", "Grid size", model.grid_size, min_value=12, max_value=120, step=4),
-        "compute_loss_landscape": _checkbox(container, env, "compute_loss_landscape", "Compute loss landscape", model.compute_loss_landscape),
-        "landscape_resolution": _number_input(container, env, "landscape_resolution", "Landscape resolution", model.landscape_resolution, min_value=5, max_value=31, step=2),
-        "landscape_span": _number_input(container, env, "landscape_span", "Landscape span", model.landscape_span, min_value=0.1, max_value=1.5, step=0.05),
-        "reset_target": _checkbox(container, env, "reset_target", "Reset target", model.reset_target),
+        "dataset": _selectbox(dataset_col, env, "dataset", "Dataset", DATASETS, model.dataset),
+        "sample_count": int(
+            _slider(samples_col, env, "sample_count", "Samples", model.sample_count, min_value=64, max_value=1000, step=16)
+        ),
+        "noise": float(
+            _slider(noise_col, env, "noise", "Noise", model.noise, min_value=0.0, max_value=0.5, step=0.01)
+        ),
+        "train_ratio": float(
+            _slider(split_col, env, "train_ratio", "Train split", model.train_ratio, min_value=0.5, max_value=0.95, step=0.05)
+        ),
     }
 
 
-env = _get_env()
-defaults_model, defaults_payload, settings_path = load_args_state(env, args_module=app_args)
+def _render_model_fields(model: app_args.PytorchPlaygroundArgs, *, env: Any, container: Any) -> dict[str, Any]:
+    architecture_col, activation_col, optimizer_col = container.columns([1.6, 1.0, 1.0])
+    training_col, batch_col, learning_col, seed_col = container.columns([1.0, 1.0, 1.15, 1.0])
+    return {
+        "hidden_layers": _text_input(architecture_col, env, "hidden_layers", "Hidden layers", model.hidden_layers),
+        "activation": _selectbox(activation_col, env, "activation", "Activation", ACTIVATIONS, model.activation),
+        "optimizer": _selectbox(optimizer_col, env, "optimizer", "Optimizer", OPTIMIZERS, model.optimizer),
+        "epochs": int(
+            _slider(training_col, env, "epochs", "Epochs", model.epochs, min_value=10, max_value=300, step=10)
+        ),
+        "batch_size": int(
+            _slider(batch_col, env, "batch_size", "Batch", model.batch_size, min_value=8, max_value=256, step=8)
+        ),
+        "learning_rate": float(
+            _number_input(
+                learning_col,
+                env,
+                "learning_rate",
+                "Learning rate",
+                model.learning_rate,
+                min_value=0.001,
+                max_value=0.2,
+                step=0.001,
+            )
+        ),
+        "seed": int(_number_input(seed_col, env, "seed", "Seed", model.seed, min_value=0, max_value=9999, step=1)),
+    }
 
-artifact_target = str(getattr(env, "target", "") or getattr(env, "app", "") or "pytorch_playground_project")
-artifact_root = Path(getattr(env, "AGILAB_EXPORT_ABS", Path.home() / "export")) / artifact_target / "pytorch_playground"
 
-st.caption(
-    "PyTorch Playground is an executable app: ORCHESTRATE runs the configured "
-    "training job and exports replayable evidence."
-)
-st.caption(f"Analysis artifacts are exported to `{artifact_root}`.")
-
-with st.sidebar:
-    st.markdown("### PyTorch Playground")
-    st.caption("These fields are persisted as app arguments.")
-    form_values = _render_args_form(defaults_model, env=env, container=st.sidebar)
-
-try:
-    parsed = app_args.ensure_defaults(app_args.ArgsModel(**form_values), env=env)
-except ValidationError as exc:
-    st.error("\n".join(env.humanize_validation_errors(exc)))
-else:
-    try:
-        config = app_args.to_playground_config(parsed)
-    except ValueError as exc:
-        st.error(str(exc))
-    else:
-        persist_args(
-            app_args,
-            parsed,
-            settings_path=settings_path,
-            defaults_payload=defaults_payload,
+def _render_evidence_fields(model: app_args.PytorchPlaygroundArgs, *, env: Any, container: Any) -> dict[str, Any]:
+    path_col, grid_col, reset_col = container.columns([1.8, 1.0, 1.0])
+    values = {
+        "data_out": _text_input(path_col, env, "data_out", "Evidence path", model.data_out),
+        "grid_size": int(
+            _slider(grid_col, env, "grid_size", "Grid size", model.grid_size, min_value=12, max_value=120, step=4)
+        ),
+        "reset_target": _checkbox(reset_col, env, "reset_target", "Reset output", model.reset_target),
+    }
+    loss_col, resolution_col, span_col = container.columns([1.35, 1.0, 1.0])
+    compute_loss_landscape = _checkbox(
+        loss_col,
+        env,
+        "compute_loss_landscape",
+        "Loss landscape",
+        model.compute_loss_landscape,
+    )
+    values["compute_loss_landscape"] = compute_loss_landscape
+    values["landscape_resolution"] = int(
+        _slider(
+            resolution_col,
+            env,
+            "landscape_resolution",
+            "Resolution",
+            model.landscape_resolution,
+            min_value=5,
+            max_value=31,
+            step=2,
+            disabled=not compute_loss_landscape,
         )
-        st.code(
-            json.dumps(
-                {
-                    "dataset": config.dataset,
-                    "samples": config.sample_count,
-                    "features": list(config.feature_names),
-                    "hidden_layers": list(config.hidden_layers),
-                    "epochs": config.epochs,
-                    "loss_landscape": parsed.compute_loss_landscape,
-                },
-                indent=2,
-                sort_keys=True,
+    )
+    values["landscape_span"] = float(
+        _slider(
+            span_col,
+            env,
+            "landscape_span",
+            "Span",
+            model.landscape_span,
+            min_value=0.1,
+            max_value=1.5,
+            step=0.05,
+            disabled=not compute_loss_landscape,
+        )
+    )
+    return values
+
+
+def _render_wide_args_form(model: app_args.PytorchPlaygroundArgs, *, env: Any, container: Any) -> dict[str, Any]:
+    values: dict[str, Any] = {}
+    container.markdown("#### Dataset")
+    values.update(_render_dataset_fields(model, env=env, container=container))
+    values["feature_names"] = _feature_names(container, env, model.feature_names)
+    container.markdown("#### Model")
+    values.update(_render_model_fields(model, env=env, container=container))
+    container.markdown("#### Evidence")
+    values.update(_render_evidence_fields(model, env=env, container=container))
+    return values
+
+
+def _render_sidebar_args_form(model: app_args.PytorchPlaygroundArgs, *, env: Any, container: Any) -> dict[str, Any]:
+    values: dict[str, Any] = {}
+    container.markdown("#### Dataset")
+    values.update(
+        {
+            "dataset": _selectbox(container, env, "dataset", "Dataset", DATASETS, model.dataset),
+            "sample_count": int(
+                _slider(container, env, "sample_count", "Samples", model.sample_count, min_value=64, max_value=1000, step=16)
             ),
-            language="json",
-        )
+            "noise": float(_slider(container, env, "noise", "Noise", model.noise, min_value=0.0, max_value=0.5, step=0.01)),
+            "train_ratio": float(
+                _slider(container, env, "train_ratio", "Train split", model.train_ratio, min_value=0.5, max_value=0.95, step=0.05)
+            ),
+            "feature_names": _feature_names(container, env, model.feature_names),
+        }
+    )
+    container.markdown("#### Model")
+    values.update(
+        {
+            "hidden_layers": _text_input(container, env, "hidden_layers", "Hidden layers", model.hidden_layers),
+            "activation": _selectbox(container, env, "activation", "Activation", ACTIVATIONS, model.activation),
+            "optimizer": _selectbox(container, env, "optimizer", "Optimizer", OPTIMIZERS, model.optimizer),
+            "learning_rate": float(
+                _number_input(
+                    container,
+                    env,
+                    "learning_rate",
+                    "Learning rate",
+                    model.learning_rate,
+                    min_value=0.001,
+                    max_value=0.2,
+                    step=0.001,
+                )
+            ),
+            "epochs": int(_slider(container, env, "epochs", "Epochs", model.epochs, min_value=10, max_value=300, step=10)),
+            "batch_size": int(_slider(container, env, "batch_size", "Batch", model.batch_size, min_value=8, max_value=256, step=8)),
+            "seed": int(_number_input(container, env, "seed", "Seed", model.seed, min_value=0, max_value=9999, step=1)),
+        }
+    )
+    container.markdown("#### Evidence")
+    compute_loss_landscape = _checkbox(
+        container,
+        env,
+        "compute_loss_landscape",
+        "Loss landscape",
+        model.compute_loss_landscape,
+    )
+    values.update(
+        {
+            "data_out": _text_input(container, env, "data_out", "Evidence path", model.data_out),
+            "grid_size": int(_slider(container, env, "grid_size", "Grid size", model.grid_size, min_value=12, max_value=120, step=4)),
+            "compute_loss_landscape": compute_loss_landscape,
+            "landscape_resolution": int(
+                _slider(
+                    container,
+                    env,
+                    "landscape_resolution",
+                    "Resolution",
+                    model.landscape_resolution,
+                    min_value=5,
+                    max_value=31,
+                    step=2,
+                    disabled=not compute_loss_landscape,
+                )
+            ),
+            "landscape_span": float(
+                _slider(
+                    container,
+                    env,
+                    "landscape_span",
+                    "Span",
+                    model.landscape_span,
+                    min_value=0.1,
+                    max_value=1.5,
+                    step=0.05,
+                    disabled=not compute_loss_landscape,
+                )
+            ),
+            "reset_target": _checkbox(container, env, "reset_target", "Reset output", model.reset_target),
+        }
+    )
+    return values
+
+
+def _render_args_form(model: app_args.PytorchPlaygroundArgs, *, env: Any, container: Any, wide: bool = False) -> dict[str, Any]:
+    if wide:
+        return _render_wide_args_form(model, env=env, container=container)
+    return _render_sidebar_args_form(model, env=env, container=container)
+
+
+def render(*, env: Any | None = None, container: Any | None = None) -> None:
+    active_env = env or _get_env()
+    defaults_model, defaults_payload, settings_path = load_args_state(active_env, args_module=app_args)
+
+    artifact_target = str(getattr(active_env, "target", "") or getattr(active_env, "app", "") or "pytorch_playground_project")
+    artifact_root = (
+        Path(getattr(active_env, "AGILAB_EXPORT_ABS", Path.home() / "export"))
+        / artifact_target
+        / "pytorch_playground"
+    )
+    output_container = container or st
+    output_container.caption(
+        "PyTorch Playground is an executable app: ORCHESTRATE runs the configured "
+        "training job and exports replayable evidence."
+    )
+    output_container.caption(f"Analysis artifacts are exported to `{artifact_root}`.")
+
+    form_container = container or st.sidebar
+    if container is None:
+        with st.sidebar:
+            st.markdown("### PyTorch Playground")
+            st.caption("These fields are persisted as app arguments.")
+            form_values = _render_args_form(defaults_model, env=active_env, container=st.sidebar)
+    else:
+        form_container.markdown("### PyTorch Playground")
+        form_container.caption("These fields are persisted as app arguments.")
+        form_values = _render_args_form(defaults_model, env=active_env, container=form_container, wide=True)
+
+    try:
+        parsed = app_args.ensure_defaults(app_args.ArgsModel(**form_values), env=active_env)
+    except ValidationError as exc:
+        output_container.error("\n".join(active_env.humanize_validation_errors(exc)))
+    else:
+        try:
+            config = app_args.to_playground_config(parsed)
+        except ValueError as exc:
+            output_container.error(str(exc))
+        else:
+            persist_args(
+                app_args,
+                parsed,
+                settings_path=settings_path,
+                defaults_payload=defaults_payload,
+            )
+            output_container.code(
+                json.dumps(
+                    {
+                        "dataset": config.dataset,
+                        "samples": config.sample_count,
+                        "features": list(config.feature_names),
+                        "hidden_layers": list(config.hidden_layers),
+                        "epochs": config.epochs,
+                        "loss_landscape": parsed.compute_loss_landscape,
+                    },
+                    indent=2,
+                    sort_keys=True,
+                ),
+                language="json",
+            )
+
+
+if not globals().get("_AGILAB_APP_ARGS_FORM_IMPORT_ONLY", False):
+    render(env=globals().get("env"))

--- a/src/agilab/apps/builtin/pytorch_playground_project/src/app_settings.toml
+++ b/src/agilab/apps/builtin/pytorch_playground_project/src/app_settings.toml
@@ -36,6 +36,7 @@ max_unhealthy = 0
 max_restart_rate = 0.25
 
 [pages]
+restrict_to_view_module = true
 view_module = ["view_app_ui"]
 
 [pages.view_app_ui]

--- a/src/agilab/apps/builtin/pytorch_playground_project/src/app_settings.toml
+++ b/src/agilab/apps/builtin/pytorch_playground_project/src/app_settings.toml
@@ -37,8 +37,8 @@ max_restart_rate = 0.25
 
 [pages]
 restrict_to_view_module = true
-view_module = ["view_app_ui"]
+view_module = []
 
-[pages.view_app_ui]
+[app_surface]
 title = "PyTorch Playground"
-entrypoint = "pytorch_playground/playground_ui.py"
+entrypoint = "pytorch_playground/app_surface.py"

--- a/src/agilab/apps/builtin/pytorch_playground_project/src/pre_prompt.json
+++ b/src/agilab/apps/builtin/pytorch_playground_project/src/pre_prompt.json
@@ -1,4 +1,10 @@
-{
-  "description": "PyTorch Playground trains a small classifier on generated data and exports reproducible evidence.",
-  "suggested_prompt": "Tune the playground configuration, run it, and compare the exported evidence manifest with the previous run."
-}
+[
+  {
+    "role": "system",
+    "content": "You are operating the PyTorch Playground AGILAB app. Keep guidance focused on reproducible local training, generated datasets, explicit model settings, and exported evidence artifacts."
+  },
+  {
+    "role": "user",
+    "content": "Tune the playground configuration, run it, and compare the exported evidence manifest with the previous run."
+  }
+]

--- a/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/app_surface.py
+++ b/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/app_surface.py
@@ -52,9 +52,15 @@ def _resolve_active_app_path(active_app: Path | None = None) -> Path | None:
     if active_app is not None:
         candidate = Path(active_app).expanduser()
         return candidate.resolve() if candidate.exists() else None
-    from pytorch_playground.core import _resolve_active_app
 
-    return _resolve_active_app()
+    for index, arg in enumerate(sys.argv):
+        if arg == "--active-app" and index + 1 < len(sys.argv):
+            candidate = Path(sys.argv[index + 1]).expanduser()
+            return candidate.resolve() if candidate.exists() else None
+        if arg.startswith("--active-app="):
+            candidate = Path(arg.split("=", 1)[1]).expanduser()
+            return candidate.resolve() if candidate.exists() else None
+    return None
 
 
 def _load_orchestrate_args(active_app_path: Path):
@@ -64,6 +70,50 @@ def _load_orchestrate_args(active_app_path: Path):
     env = AgiEnv(apps_path=active_app_path.parent, app=active_app_path.name, verbose=0)
     args_model = app_args.ensure_defaults(app_args.load_args(env.app_settings_file), env=env)
     return env, args_model
+
+
+def _append_unique_path(paths: list[Path], path: Path) -> None:
+    try:
+        resolved = path.expanduser().resolve()
+    except (OSError, RuntimeError, TypeError, ValueError):
+        resolved = path.expanduser()
+    if resolved not in paths:
+        paths.append(resolved)
+
+
+def _analysis_evidence_dirs(env: Any, args_model: Any, active_app_path: Path) -> list[Path]:
+    paths: list[Path] = []
+    export_root = Path(getattr(env, "AGILAB_EXPORT_ABS", Path.home() / "export"))
+    for target in (
+        str(getattr(env, "target", "") or ""),
+        str(getattr(env, "app", "") or ""),
+        active_app_path.name,
+    ):
+        if target:
+            _append_unique_path(paths, export_root / target / "pytorch_playground")
+
+    data_out = Path(getattr(args_model, "data_out", "pytorch_playground/evidence"))
+    if not data_out.is_absolute():
+        resolve_share_path = getattr(env, "resolve_share_path", None)
+        if callable(resolve_share_path):
+            data_out = Path(resolve_share_path(data_out))
+    _append_unique_path(paths, data_out)
+    return paths
+
+
+def _has_evidence(paths: list[Path]) -> bool:
+    return any((path / "manifest.json").is_file() for path in paths)
+
+
+def _render_missing_evidence(paths: list[Path]) -> None:
+    import streamlit as st
+
+    st.set_page_config(page_title="PyTorch Playground", layout="wide")
+    st.title("PyTorch Playground")
+    st.info("No exported PyTorch evidence found yet. Run the app once from ORCHESTRATE, then return to ANALYSIS.")
+    if paths:
+        st.caption("Checked evidence locations:")
+        st.code("\n".join(str(path) for path in paths), language="text")
 
 
 def render(
@@ -81,13 +131,20 @@ def render(
         return
     if surface_mode in {"analysis", "full"}:
         active_app_path = _resolve_active_app_path(active_app)
-        from pytorch_playground import app_args, playground_ui
 
         if active_app_path is None:
+            from pytorch_playground import playground_ui
+
             playground_ui.main()
             return
         try:
-            _, args_model = _load_orchestrate_args(active_app_path)
+            runtime_env, args_model = _load_orchestrate_args(active_app_path)
+            evidence_dirs = _analysis_evidence_dirs(runtime_env, args_model, active_app_path)
+            if not _has_evidence(evidence_dirs):
+                _render_missing_evidence(evidence_dirs)
+                return
+            from pytorch_playground import app_args, playground_ui
+
             config = app_args.to_playground_config(args_model)
         except Exception as exc:
             import streamlit as st
@@ -101,6 +158,7 @@ def render(
             compute_loss_landscape=args_model.compute_loss_landscape,
             landscape_resolution=args_model.landscape_resolution,
             landscape_span=args_model.landscape_span,
+            evidence_dirs=evidence_dirs,
         )
         return
     raise ValueError(f"Unsupported PyTorch Playground app surface mode: {mode}")

--- a/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/app_surface.py
+++ b/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/app_surface.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+_APP_SRC = Path(__file__).resolve().parents[1]
+_SCRIPT_DIR = Path(__file__).resolve().parent
+
+
+def _prepend_sys_path(path: Path) -> None:
+    entry = str(path)
+    sys.path[:] = [existing for existing in sys.path if existing != entry]
+    sys.path.insert(0, entry)
+
+
+def _drop_shadowed_package_module() -> None:
+    module = sys.modules.get("pytorch_playground")
+    module_file = getattr(module, "__file__", None)
+    if module_file is None:
+        return
+    try:
+        shadows_package = Path(module_file).resolve() == (_SCRIPT_DIR / "pytorch_playground.py").resolve()
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return
+    if not shadows_package:
+        return
+    for name in list(sys.modules):
+        if name == "pytorch_playground" or name.startswith("pytorch_playground."):
+            sys.modules.pop(name, None)
+
+
+_prepend_sys_path(_APP_SRC)
+_drop_shadowed_package_module()
+
+
+def _load_app_args_form() -> ModuleType:
+    entrypoint = _APP_SRC / "app_args_form.py"
+    spec = importlib.util.spec_from_file_location("_pytorch_playground_app_args_form_surface", entrypoint)
+    if spec is None or spec.loader is None:
+        raise ModuleNotFoundError(f"Unable to load PyTorch Playground app form from {entrypoint}")
+    module = importlib.util.module_from_spec(spec)
+    module._AGILAB_APP_ARGS_FORM_IMPORT_ONLY = True
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _resolve_active_app_path(active_app: Path | None = None) -> Path | None:
+    if active_app is not None:
+        candidate = Path(active_app).expanduser()
+        return candidate.resolve() if candidate.exists() else None
+    from pytorch_playground.core import _resolve_active_app
+
+    return _resolve_active_app()
+
+
+def _load_orchestrate_args(active_app_path: Path):
+    from agi_env import AgiEnv
+    from pytorch_playground import app_args
+
+    env = AgiEnv(apps_path=active_app_path.parent, app=active_app_path.name, verbose=0)
+    args_model = app_args.ensure_defaults(app_args.load_args(env.app_settings_file), env=env)
+    return env, args_model
+
+
+def render(
+    *,
+    mode: str = "analysis",
+    active_app: Path | None = None,
+    env: Any | None = None,
+    container: Any | None = None,
+    streamlit: Any | None = None,
+) -> None:
+    surface_mode = str(mode or "analysis").lower()
+    if surface_mode == "configure":
+        app_args_form = _load_app_args_form()
+        app_args_form.render(env=env, container=container)
+        return
+    if surface_mode in {"analysis", "full"}:
+        active_app_path = _resolve_active_app_path(active_app)
+        from pytorch_playground import app_args, playground_ui
+
+        if active_app_path is None:
+            playground_ui.main()
+            return
+        try:
+            _, args_model = _load_orchestrate_args(active_app_path)
+            config = app_args.to_playground_config(args_model)
+        except Exception as exc:
+            import streamlit as st
+
+            st.error(f"Unable to load ORCHESTRATE app arguments: {exc}")
+            return
+        playground_ui.main(
+            config_override=config,
+            preset_label="ORCHESTRATE args",
+            interactive_controls=False,
+            compute_loss_landscape=args_model.compute_loss_landscape,
+            landscape_resolution=args_model.landscape_resolution,
+            landscape_span=args_model.landscape_span,
+        )
+        return
+    raise ValueError(f"Unsupported PyTorch Playground app surface mode: {mode}")
+
+
+def main() -> None:
+    render(mode="analysis")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/playground_ui.py
+++ b/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/playground_ui.py
@@ -1063,111 +1063,127 @@ def _render_summary(config: PlaygroundConfig, result: Mapping[str, Any]) -> None
             st.markdown(card, unsafe_allow_html=True)
 
 
-def main() -> None:
+def main(
+    *,
+    config_override: PlaygroundConfig | None = None,
+    preset_label: str | None = None,
+    interactive_controls: bool = True,
+    compute_loss_landscape: bool | None = None,
+    landscape_resolution: int = 21,
+    landscape_span: float = 0.75,
+) -> None:
     st.set_page_config(page_title=PAGE_TITLE, layout="wide")
     render_logo()
     _render_page_styles()
     active_app = _resolve_active_app()
     shared_config = _config_from_query_params(st.query_params)
 
-    with st.sidebar:
-        st.markdown("### Challenge")
-        preset_labels = tuple(PLAYGROUND_PRESETS)
-        preset_index = 0 if shared_config is not None else preset_labels.index(DEFAULT_PRESET)
-        preset_label = st.selectbox(
-            "Challenge preset",
-            preset_labels,
-            index=preset_index,
-            help="Preset only seeds the controls; every value stays editable.",
-        )
-        defaults = _preset_config(preset_label, shared_config)
-        preset_key = _safe_key_fragment(preset_label)
-        st.caption(_preset_story(preset_label, shared_config))
-        st.markdown("### Dataset")
-        dataset = st.selectbox("Dataset", DATASETS, index=DATASETS.index(defaults.dataset), key=f"pt_dataset_{preset_key}")
-        sample_count = st.slider("Samples", 64, 1000, defaults.sample_count, step=32, key=f"pt_samples_{preset_key}")
-        noise = st.slider("Noise", 0.0, 0.5, defaults.noise, step=0.01, key=f"pt_noise_{preset_key}")
-        train_ratio = st.slider("Train split", 0.5, 0.95, defaults.train_ratio, step=0.05, key=f"pt_split_{preset_key}")
-        feature_names = st.multiselect(
-            "Features",
-            FEATURES,
-            default=list(defaults.feature_names),
-            key=f"pt_features_{preset_key}",
-        )
-        st.markdown("### Network")
-        hidden_raw = st.text_input(
-            "Hidden layers",
-            value=",".join(str(width) for width in defaults.hidden_layers),
-            key=f"pt_layers_{preset_key}",
-            help="Comma-separated widths, for example 16,8.",
-        )
-        activation = st.selectbox(
-            "Activation",
-            ACTIVATIONS,
-            index=ACTIVATIONS.index(defaults.activation),
-            key=f"pt_activation_{preset_key}",
-        )
-        optimizer = st.selectbox(
-            "Optimizer",
-            OPTIMIZERS,
-            index=OPTIMIZERS.index(defaults.optimizer),
-            key=f"pt_optimizer_{preset_key}",
-        )
-        learning_rate = st.slider(
-            "Learning rate",
-            0.001,
-            0.2,
-            defaults.learning_rate,
-            step=0.001,
-            format="%.3f",
-            key=f"pt_lr_{preset_key}",
-        )
-        epochs = st.slider("Epochs", 10, 300, defaults.epochs, step=10, key=f"pt_epochs_{preset_key}")
-        batch_size = st.slider("Batch size", 8, 256, defaults.batch_size, step=8, key=f"pt_batch_{preset_key}")
-        grid_size = st.slider("Grid resolution", 12, 120, defaults.grid_size, step=4, key=f"pt_grid_{preset_key}")
-        seed = st.number_input("Seed", min_value=0, max_value=9999, value=defaults.seed, step=1, key=f"pt_seed_{preset_key}")
-        st.markdown("### Run")
-        train_requested = st.button("Train / refresh", type="primary", width="stretch")
-        st.caption("Controls are staged. Charts and evidence update only when you train.")
+    if interactive_controls:
+        with st.sidebar:
+            st.markdown("### Challenge")
+            preset_labels = tuple(PLAYGROUND_PRESETS)
+            preset_index = 0 if shared_config is not None else preset_labels.index(DEFAULT_PRESET)
+            preset_label = st.selectbox(
+                "Challenge preset",
+                preset_labels,
+                index=preset_index,
+                help="Preset only seeds the controls; every value stays editable.",
+            )
+            defaults = _preset_config(preset_label, shared_config)
+            preset_key = _safe_key_fragment(preset_label)
+            st.caption(_preset_story(preset_label, shared_config))
+            st.markdown("### Dataset")
+            dataset = st.selectbox("Dataset", DATASETS, index=DATASETS.index(defaults.dataset), key=f"pt_dataset_{preset_key}")
+            sample_count = st.slider("Samples", 64, 1000, defaults.sample_count, step=32, key=f"pt_samples_{preset_key}")
+            noise = st.slider("Noise", 0.0, 0.5, defaults.noise, step=0.01, key=f"pt_noise_{preset_key}")
+            train_ratio = st.slider("Train split", 0.5, 0.95, defaults.train_ratio, step=0.05, key=f"pt_split_{preset_key}")
+            feature_names = st.multiselect(
+                "Features",
+                FEATURES,
+                default=list(defaults.feature_names),
+                key=f"pt_features_{preset_key}",
+            )
+            st.markdown("### Network")
+            hidden_raw = st.text_input(
+                "Hidden layers",
+                value=",".join(str(width) for width in defaults.hidden_layers),
+                key=f"pt_layers_{preset_key}",
+                help="Comma-separated widths, for example 16,8.",
+            )
+            activation = st.selectbox(
+                "Activation",
+                ACTIVATIONS,
+                index=ACTIVATIONS.index(defaults.activation),
+                key=f"pt_activation_{preset_key}",
+            )
+            optimizer = st.selectbox(
+                "Optimizer",
+                OPTIMIZERS,
+                index=OPTIMIZERS.index(defaults.optimizer),
+                key=f"pt_optimizer_{preset_key}",
+            )
+            learning_rate = st.slider(
+                "Learning rate",
+                0.001,
+                0.2,
+                defaults.learning_rate,
+                step=0.001,
+                format="%.3f",
+                key=f"pt_lr_{preset_key}",
+            )
+            epochs = st.slider("Epochs", 10, 300, defaults.epochs, step=10, key=f"pt_epochs_{preset_key}")
+            batch_size = st.slider("Batch size", 8, 256, defaults.batch_size, step=8, key=f"pt_batch_{preset_key}")
+            grid_size = st.slider("Grid resolution", 12, 120, defaults.grid_size, step=4, key=f"pt_grid_{preset_key}")
+            seed = st.number_input("Seed", min_value=0, max_value=9999, value=defaults.seed, step=1, key=f"pt_seed_{preset_key}")
+            st.markdown("### Run")
+            train_requested = st.button("Train / refresh", type="primary", width="stretch")
+            st.caption("Controls are staged. Charts and evidence update only when you train.")
 
-    try:
-        hidden_layers = _parse_hidden_layers(hidden_raw)
-    except ValueError as exc:
-        st.error(str(exc))
-        st.stop()
+        try:
+            hidden_layers = _parse_hidden_layers(hidden_raw)
+        except ValueError as exc:
+            st.error(str(exc))
+            st.stop()
 
-    config = PlaygroundConfig(
-        dataset=dataset,
-        sample_count=sample_count,
-        noise=noise,
-        train_ratio=train_ratio,
-        hidden_layers=hidden_layers,
-        activation=activation,
-        optimizer=optimizer,
-        learning_rate=learning_rate,
-        epochs=epochs,
-        batch_size=batch_size,
-        seed=int(seed),
-        feature_names=tuple(feature_names or DEFAULT_FEATURES),
-        grid_size=grid_size,
-    )
-    shared_signature = _config_signature(shared_config) if shared_config is not None else ""
-    previous_shared_signature = str(_session_state_get(SHARED_CONFIG_SIGNATURE_STATE_KEY, ""))
-    force_shared_refresh = bool(shared_config is not None and shared_signature != previous_shared_signature)
-    _session_state_set(SHARED_CONFIG_SIGNATURE_STATE_KEY, shared_signature)
-    trained_config, trained_preset, pending_changes = _resolve_trained_config(
-        config,
-        preset_label,
-        train_requested=train_requested,
-        force_refresh=force_shared_refresh,
-    )
+        config = PlaygroundConfig(
+            dataset=dataset,
+            sample_count=sample_count,
+            noise=noise,
+            train_ratio=train_ratio,
+            hidden_layers=hidden_layers,
+            activation=activation,
+            optimizer=optimizer,
+            learning_rate=learning_rate,
+            epochs=epochs,
+            batch_size=batch_size,
+            seed=int(seed),
+            feature_names=tuple(feature_names or DEFAULT_FEATURES),
+            grid_size=grid_size,
+        )
+        shared_signature = _config_signature(shared_config) if shared_config is not None else ""
+        previous_shared_signature = str(_session_state_get(SHARED_CONFIG_SIGNATURE_STATE_KEY, ""))
+        force_shared_refresh = bool(shared_config is not None and shared_signature != previous_shared_signature)
+        _session_state_set(SHARED_CONFIG_SIGNATURE_STATE_KEY, shared_signature)
+        trained_config, trained_preset, pending_changes = _resolve_trained_config(
+            config,
+            str(preset_label),
+            train_requested=train_requested,
+            force_refresh=force_shared_refresh,
+        )
+    else:
+        trained_config = config_override or PlaygroundConfig()
+        trained_preset = preset_label or "ORCHESTRATE args"
+        pending_changes = False
     trained_config_dict = asdict(trained_config)
     result = _cached_train(trained_config_dict)
-    with st.sidebar:
-        st.caption(f"Charts show: {trained_preset}")
-        if pending_changes:
-            st.warning("Pending changes. Press Train / refresh to update the run.")
+    if interactive_controls:
+        with st.sidebar:
+            st.caption(f"Charts show: {trained_preset}")
+            if pending_changes:
+                st.warning("Pending changes. Press Train / refresh to update the run.")
     _render_hero(active_app, trained_preset, trained_config)
+    if not interactive_controls:
+        st.caption("Charts use the persisted ORCHESTRATE arguments for this app.")
     if result["status"] == "missing_torch":
         st.error(result["detail"])
     elif result["status"] != "ok":
@@ -1243,9 +1259,14 @@ def main() -> None:
         )
         controls, chart_area = st.columns([1, 3])
         with controls:
-            landscape_resolution = st.slider("Resolution", 5, 31, 21, step=2)
-            landscape_span = st.slider("Span", 0.1, 1.5, 0.75, step=0.05)
-            compute_landscape = st.checkbox("Compute landscape", value=False)
+            if interactive_controls:
+                landscape_resolution = st.slider("Resolution", 5, 31, 21, step=2)
+                landscape_span = st.slider("Span", 0.1, 1.5, 0.75, step=0.05)
+                compute_landscape = st.checkbox("Compute landscape", value=False)
+            else:
+                compute_landscape = bool(compute_loss_landscape)
+                st.metric("Resolution", int(landscape_resolution))
+                st.metric("Span", f"{float(landscape_span):.2f}")
         if result["status"] != "ok":
             st.info("Loss landscape is available after a successful PyTorch run.")
         elif compute_landscape:
@@ -1264,7 +1285,10 @@ def main() -> None:
                 )
                 st.dataframe(landscape.sort_values("validation_loss").head(8), width="stretch", hide_index=True)
         else:
-            st.info("Enable computation to evaluate a deterministic 2D loss projection around the trained weights.")
+            if interactive_controls:
+                st.info("Enable computation to evaluate a deterministic 2D loss projection around the trained weights.")
+            else:
+                st.info("Enable Loss landscape in ORCHESTRATE to evaluate a deterministic 2D projection.")
 
     with evidence_tab:
         _render_section_intro(

--- a/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/playground_ui.py
+++ b/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/playground_ui.py
@@ -12,7 +12,7 @@ import re
 import subprocess
 import sys
 import tempfile
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import asdict
 from pathlib import Path
 from typing import Any
@@ -475,6 +475,87 @@ def _cached_loss_landscape(payload: dict[str, Any], resolution: int, span: float
     if _use_isolated_torch_training():
         return _run_core_in_subprocess("loss_landscape", config, resolution=resolution, span=span)
     return _loss_landscape(config, resolution=resolution, span=span)
+
+
+def _read_json_file(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, TypeError, ValueError, json.JSONDecodeError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _read_evidence_frame(path: Path, empty: pd.DataFrame) -> pd.DataFrame:
+    try:
+        return pd.read_csv(path)
+    except (OSError, ValueError, pd.errors.EmptyDataError, pd.errors.ParserError):
+        return empty.copy()
+
+
+def _load_evidence_result(evidence_dir: Path) -> tuple[PlaygroundConfig, dict[str, Any], Path] | None:
+    root = Path(evidence_dir).expanduser()
+    manifest_path = root / "manifest.json"
+    if not manifest_path.is_file():
+        return None
+
+    manifest = _read_json_file(manifest_path)
+    config_payload = manifest.get("config")
+    if not isinstance(config_payload, Mapping):
+        config_payload = _read_json_file(root / "config" / "playground_config.json").get("config", {})
+    config = _config_from_payload({"config": config_payload})
+
+    samples = _read_evidence_frame(root / "data" / "samples.csv", pd.DataFrame(columns=["x1", "x2", "target"]))
+    history = _read_evidence_frame(
+        root / "data" / "training_history.csv",
+        pd.DataFrame(columns=["epoch", "train_loss", "validation_loss", "train_accuracy", "validation_accuracy"]),
+    )
+    grid = _read_evidence_frame(root / "data" / "decision_grid.csv", pd.DataFrame(columns=["x1", "x2", "probability"]))
+    network_layers = _read_evidence_frame(root / "model" / "network_layers.csv", _empty_network_layers())
+    activation_maps = _read_evidence_frame(root / "model" / "hidden_activation_maps.csv", _empty_activation_maps())
+    loss_landscape = _read_evidence_frame(root / "model" / "loss_landscape.csv", _empty_loss_landscape())
+    summary_payload = _read_json_file(root / "summary" / "run_summary.json")
+
+    summary = manifest.get("summary")
+    if not isinstance(summary, Mapping):
+        summary = summary_payload.get("summary", {})
+    landscape_summary = manifest.get("landscape_summary")
+    if not isinstance(landscape_summary, Mapping):
+        landscape_summary = summary_payload.get("landscape_summary", _loss_landscape_summary(loss_landscape))
+
+    return (
+        config,
+        {
+            "status": "ok",
+            "detail": "",
+            "samples": samples,
+            "history": history,
+            "grid": grid,
+            "network_layers": network_layers,
+            "activation_maps": activation_maps,
+            "loss_landscape": loss_landscape,
+            "summary": dict(summary) if isinstance(summary, Mapping) else {},
+            "landscape_summary": dict(landscape_summary) if isinstance(landscape_summary, Mapping) else {},
+        },
+        root,
+    )
+
+
+def _load_latest_evidence_result(
+    evidence_dirs: Sequence[str | Path] | None,
+) -> tuple[PlaygroundConfig, dict[str, Any], Path] | None:
+    candidates: list[tuple[float, Path]] = []
+    for raw_path in evidence_dirs or ():
+        root = Path(raw_path).expanduser()
+        manifest_path = root / "manifest.json"
+        try:
+            candidates.append((manifest_path.stat().st_mtime, root))
+        except OSError:
+            continue
+    for _mtime, root in sorted(candidates, reverse=True):
+        loaded = _load_evidence_result(root)
+        if loaded is not None:
+            return loaded
+    return None
 
 
 def _render_page_styles() -> None:
@@ -1071,6 +1152,7 @@ def main(
     compute_loss_landscape: bool | None = None,
     landscape_resolution: int = 21,
     landscape_span: float = 0.75,
+    evidence_dirs: Sequence[str | Path] | None = None,
 ) -> None:
     st.set_page_config(page_title=PAGE_TITLE, layout="wide")
     render_logo()
@@ -1171,11 +1253,20 @@ def main(
             force_refresh=force_shared_refresh,
         )
     else:
-        trained_config = config_override or PlaygroundConfig()
-        trained_preset = preset_label or "ORCHESTRATE args"
+        evidence_result = _load_latest_evidence_result(evidence_dirs)
+        if evidence_result is None:
+            trained_config = config_override or PlaygroundConfig()
+            _render_hero(active_app, preset_label or "ORCHESTRATE args", trained_config)
+            st.info("No exported PyTorch evidence found yet. Run the app once from ORCHESTRATE, then return to ANALYSIS.")
+            return
+        trained_config, result, evidence_root = evidence_result
+        trained_preset = preset_label or "Latest ORCHESTRATE evidence"
         pending_changes = False
+        st.caption(f"Loaded evidence from `{evidence_root}`.")
+
     trained_config_dict = asdict(trained_config)
-    result = _cached_train(trained_config_dict)
+    if interactive_controls:
+        result = _cached_train(trained_config_dict)
     if interactive_controls:
         with st.sidebar:
             st.caption(f"Charts show: {trained_preset}")
@@ -1194,11 +1285,12 @@ def main(
     _render_summary(trained_config, result)
     _render_guided_flow(pending_changes=pending_changes, result_status=str(result.get("status", "")))
     _render_interpretation_cards(result)
+    loaded_landscape = _result_frame(result, "loss_landscape", _empty_loss_landscape())
     landscape_result: dict[str, Any] = {
         "status": "not_computed",
         "detail": "",
-        "loss_landscape": _empty_loss_landscape(),
-        "landscape_summary": _loss_landscape_summary(_empty_loss_landscape()),
+        "loss_landscape": loaded_landscape,
+        "landscape_summary": result.get("landscape_summary", _loss_landscape_summary(loaded_landscape)),
     }
     decision_tab, activations_tab, landscape_tab, evidence_tab = st.tabs(
         ["Boundary lab", "Neuron lens", "Loss terrain", "Evidence pack"]
@@ -1270,7 +1362,12 @@ def main(
         if result["status"] != "ok":
             st.info("Loss landscape is available after a successful PyTorch run.")
         elif compute_landscape:
-            landscape_result = _cached_loss_landscape(trained_config_dict, int(landscape_resolution), float(landscape_span))
+            if interactive_controls:
+                landscape_result = _cached_loss_landscape(
+                    trained_config_dict,
+                    int(landscape_resolution),
+                    float(landscape_span),
+                )
             landscape = _result_frame(landscape_result, "loss_landscape", _empty_loss_landscape())
             summary = landscape_result.get("landscape_summary", _loss_landscape_summary(landscape))
             with controls:

--- a/src/agilab/lib/agi-app-mission-decision/src/agi_app_mission_decision/project/mission_decision_project/src/pre_prompt.json
+++ b/src/agilab/lib/agi-app-mission-decision/src/agi_app_mission_decision/project/mission_decision_project/src/pre_prompt.json
@@ -1,4 +1,10 @@
-{
-  "system": "You are operating the public Mission Decision AGILAB demo. Keep outputs factual, deterministic, and focused on mission-data ingestion, optional FRED public-context evidence, adaptive pipeline execution, and decision evidence. Do not include non-public competitive positioning or non-public app names.",
-  "user": "Generate or explain the next Mission Decision mission-decision step using the configured public scenario and analysis artifacts."
-}
+[
+  {
+    "role": "system",
+    "content": "You are operating the public Mission Decision AGILAB demo. Keep outputs factual, deterministic, and focused on mission-data ingestion, optional FRED public-context evidence, adaptive pipeline execution, and decision evidence. Do not include non-public competitive positioning or non-public app names."
+  },
+  {
+    "role": "user",
+    "content": "Generate or explain the next Mission Decision mission-decision step using the configured public scenario and analysis artifacts."
+  }
+]

--- a/src/agilab/lib/agi-app-pytorch-playground/README.md
+++ b/src/agilab/lib/agi-app-pytorch-playground/README.md
@@ -35,9 +35,14 @@ root.
 
 ## Run In AGILAB
 
-Select `pytorch_playground_project`, open `ORCHESTRATE`, tune the sidebar
-fields, then run `INSTALL` and `RUN`. Enable loss-landscape computation
-only when you want the heavier 3D projection in the evidence bundle.
+Select `pytorch_playground_project`, then open `ANALYSIS` for the app-owned
+PyTorch Playground surface. That surface contains the interactive controls,
+decision boundary, training curves, neuron/loss views, and evidence download.
+
+Open `ORCHESTRATE` when you want the reproducible AGILAB execution path: tune
+the sidebar fields, then run `INSTALL` and `RUN`. Enable loss-landscape
+computation only when you want the heavier 3D projection in the evidence
+bundle.
 
 ## Expected Inputs
 
@@ -59,4 +64,6 @@ auditable.
 ## Scope
 
 This is an educational reproducibility app. It is not a production trainer,
-model registry, serving stack, or generic app-agnostic analysis page.
+model registry, serving stack, or generic app-agnostic analysis page. The
+PyTorch-specific UI stays inside the app project; reusable apps-pages remain
+optional artifact readers for shared contracts.

--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/README.md
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/README.md
@@ -26,7 +26,7 @@ configuration trains the clean-circles preset and exports evidence under
 The app also keeps a local Streamlit playground surface for interactive review:
 
 ```bash
-uv run streamlit run src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/playground_ui.py -- --active-app src/agilab/apps/builtin/pytorch_playground_project
+uv run streamlit run src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/app_surface.py -- --active-app src/agilab/apps/builtin/pytorch_playground_project
 ```
 
 ## Expected Inputs

--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/README.md
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/README.md
@@ -13,9 +13,15 @@ deterministic ZIP bundle.
 
 ## Run In AGILAB
 
-Select `pytorch_playground_project`, open `ORCHESTRATE`, adjust the sidebar
-fields, then run `INSTALL` and `RUN`. The default configuration trains the
-clean-circles preset and exports evidence under `pytorch_playground/evidence`.
+Select `pytorch_playground_project`, then open `ANALYSIS` for the app-owned
+PyTorch Playground surface. That single surface contains the interactive
+controls, decision boundary, training curves, neuron/loss views, and evidence
+download.
+
+Open `ORCHESTRATE` when you want the reproducible AGILAB execution path:
+adjust the sidebar fields, then run `INSTALL` and `RUN`. The default
+configuration trains the clean-circles preset and exports evidence under
+`pytorch_playground/evidence`.
 
 The app also keeps a local Streamlit playground surface for interactive review:
 
@@ -46,5 +52,7 @@ The worker writes:
 ## Scope
 
 This is a reproducible educational app for neural-network behavior and loss
-landscape inspection. It is not a model-serving platform, production training
-pipeline, or generic app-agnostic analysis page.
+landscape inspection. It owns its PyTorch-specific UI inside the app project;
+generic apps-pages are only optional artifact readers such as cross-run scalar
+inspection. It is not a model-serving platform, production training pipeline,
+or generic app-agnostic analysis page.

--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/pyproject.toml
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/pyproject.toml
@@ -28,6 +28,7 @@ Changelog = "https://github.com/ThalesGroup/agilab/releases"
 
 [tool.agilab.app]
 distribution_preview = false
+service_mode = false
 
 [build-system]
 requires = ["setuptools"]

--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/app_args_form.py
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/app_args_form.py
@@ -67,10 +67,42 @@ def _number_input(
     min_value: int | float,
     max_value: int | float,
     step: int | float,
+    disabled: bool = False,
 ) -> int | float:
     key = _field_key(env, name)
     _seed_widget_value(key, value)
-    return container.number_input(label, min_value=min_value, max_value=max_value, step=step, key=key)
+    return container.number_input(
+        label,
+        min_value=min_value,
+        max_value=max_value,
+        step=step,
+        key=key,
+        disabled=disabled,
+    )
+
+
+def _slider(
+    container: Any,
+    env: Any,
+    name: str,
+    label: str,
+    value: int | float,
+    *,
+    min_value: int | float,
+    max_value: int | float,
+    step: int | float,
+    disabled: bool = False,
+) -> int | float:
+    key = _field_key(env, name)
+    _seed_widget_value(key, value)
+    return container.slider(
+        label,
+        min_value=min_value,
+        max_value=max_value,
+        step=step,
+        key=key,
+        disabled=disabled,
+    )
 
 
 def _selectbox(container: Any, env: Any, name: str, label: str, options: tuple[str, ...], value: str) -> str:
@@ -84,74 +116,260 @@ def _feature_names(container: Any, env: Any, value: str) -> str:
     return _text_input(container, env, "feature_names", "Feature names", ",".join(selected))
 
 
-def _render_args_form(model: app_args.PytorchPlaygroundArgs, *, env: Any, container: Any) -> dict[str, Any]:
+def _render_dataset_fields(model: app_args.PytorchPlaygroundArgs, *, env: Any, container: Any) -> dict[str, Any]:
+    dataset_col, samples_col, noise_col, split_col = container.columns([1.25, 1.0, 1.0, 1.0])
     return {
-        "data_out": _text_input(container, env, "data_out", "Data out", model.data_out),
-        "dataset": _selectbox(container, env, "dataset", "Dataset", DATASETS, model.dataset),
-        "sample_count": _number_input(container, env, "sample_count", "Sample count", model.sample_count, min_value=64, max_value=1000, step=16),
-        "noise": _number_input(container, env, "noise", "Noise", model.noise, min_value=0.0, max_value=0.5, step=0.01),
-        "train_ratio": _number_input(container, env, "train_ratio", "Train ratio", model.train_ratio, min_value=0.5, max_value=0.95, step=0.05),
-        "hidden_layers": _text_input(container, env, "hidden_layers", "Hidden layers", model.hidden_layers),
-        "activation": _selectbox(container, env, "activation", "Activation", ACTIVATIONS, model.activation),
-        "optimizer": _selectbox(container, env, "optimizer", "Optimizer", OPTIMIZERS, model.optimizer),
-        "learning_rate": _number_input(container, env, "learning_rate", "Learning rate", model.learning_rate, min_value=0.001, max_value=0.2, step=0.001),
-        "epochs": _number_input(container, env, "epochs", "Epochs", model.epochs, min_value=10, max_value=300, step=10),
-        "batch_size": _number_input(container, env, "batch_size", "Batch size", model.batch_size, min_value=8, max_value=256, step=8),
-        "seed": _number_input(container, env, "seed", "Seed", model.seed, min_value=0, max_value=9999, step=1),
-        "feature_names": _feature_names(container, env, model.feature_names),
-        "grid_size": _number_input(container, env, "grid_size", "Grid size", model.grid_size, min_value=12, max_value=120, step=4),
-        "compute_loss_landscape": _checkbox(container, env, "compute_loss_landscape", "Compute loss landscape", model.compute_loss_landscape),
-        "landscape_resolution": _number_input(container, env, "landscape_resolution", "Landscape resolution", model.landscape_resolution, min_value=5, max_value=31, step=2),
-        "landscape_span": _number_input(container, env, "landscape_span", "Landscape span", model.landscape_span, min_value=0.1, max_value=1.5, step=0.05),
-        "reset_target": _checkbox(container, env, "reset_target", "Reset target", model.reset_target),
+        "dataset": _selectbox(dataset_col, env, "dataset", "Dataset", DATASETS, model.dataset),
+        "sample_count": int(
+            _slider(samples_col, env, "sample_count", "Samples", model.sample_count, min_value=64, max_value=1000, step=16)
+        ),
+        "noise": float(
+            _slider(noise_col, env, "noise", "Noise", model.noise, min_value=0.0, max_value=0.5, step=0.01)
+        ),
+        "train_ratio": float(
+            _slider(split_col, env, "train_ratio", "Train split", model.train_ratio, min_value=0.5, max_value=0.95, step=0.05)
+        ),
     }
 
 
-env = _get_env()
-defaults_model, defaults_payload, settings_path = load_args_state(env, args_module=app_args)
+def _render_model_fields(model: app_args.PytorchPlaygroundArgs, *, env: Any, container: Any) -> dict[str, Any]:
+    architecture_col, activation_col, optimizer_col = container.columns([1.6, 1.0, 1.0])
+    training_col, batch_col, learning_col, seed_col = container.columns([1.0, 1.0, 1.15, 1.0])
+    return {
+        "hidden_layers": _text_input(architecture_col, env, "hidden_layers", "Hidden layers", model.hidden_layers),
+        "activation": _selectbox(activation_col, env, "activation", "Activation", ACTIVATIONS, model.activation),
+        "optimizer": _selectbox(optimizer_col, env, "optimizer", "Optimizer", OPTIMIZERS, model.optimizer),
+        "epochs": int(
+            _slider(training_col, env, "epochs", "Epochs", model.epochs, min_value=10, max_value=300, step=10)
+        ),
+        "batch_size": int(
+            _slider(batch_col, env, "batch_size", "Batch", model.batch_size, min_value=8, max_value=256, step=8)
+        ),
+        "learning_rate": float(
+            _number_input(
+                learning_col,
+                env,
+                "learning_rate",
+                "Learning rate",
+                model.learning_rate,
+                min_value=0.001,
+                max_value=0.2,
+                step=0.001,
+            )
+        ),
+        "seed": int(_number_input(seed_col, env, "seed", "Seed", model.seed, min_value=0, max_value=9999, step=1)),
+    }
 
-artifact_target = str(getattr(env, "target", "") or getattr(env, "app", "") or "pytorch_playground_project")
-artifact_root = Path(getattr(env, "AGILAB_EXPORT_ABS", Path.home() / "export")) / artifact_target / "pytorch_playground"
 
-st.caption(
-    "PyTorch Playground is an executable app: ORCHESTRATE runs the configured "
-    "training job and exports replayable evidence."
-)
-st.caption(f"Analysis artifacts are exported to `{artifact_root}`.")
-
-with st.sidebar:
-    st.markdown("### PyTorch Playground")
-    st.caption("These fields are persisted as app arguments.")
-    form_values = _render_args_form(defaults_model, env=env, container=st.sidebar)
-
-try:
-    parsed = app_args.ensure_defaults(app_args.ArgsModel(**form_values), env=env)
-except ValidationError as exc:
-    st.error("\n".join(env.humanize_validation_errors(exc)))
-else:
-    try:
-        config = app_args.to_playground_config(parsed)
-    except ValueError as exc:
-        st.error(str(exc))
-    else:
-        persist_args(
-            app_args,
-            parsed,
-            settings_path=settings_path,
-            defaults_payload=defaults_payload,
+def _render_evidence_fields(model: app_args.PytorchPlaygroundArgs, *, env: Any, container: Any) -> dict[str, Any]:
+    path_col, grid_col, reset_col = container.columns([1.8, 1.0, 1.0])
+    values = {
+        "data_out": _text_input(path_col, env, "data_out", "Evidence path", model.data_out),
+        "grid_size": int(
+            _slider(grid_col, env, "grid_size", "Grid size", model.grid_size, min_value=12, max_value=120, step=4)
+        ),
+        "reset_target": _checkbox(reset_col, env, "reset_target", "Reset output", model.reset_target),
+    }
+    loss_col, resolution_col, span_col = container.columns([1.35, 1.0, 1.0])
+    compute_loss_landscape = _checkbox(
+        loss_col,
+        env,
+        "compute_loss_landscape",
+        "Loss landscape",
+        model.compute_loss_landscape,
+    )
+    values["compute_loss_landscape"] = compute_loss_landscape
+    values["landscape_resolution"] = int(
+        _slider(
+            resolution_col,
+            env,
+            "landscape_resolution",
+            "Resolution",
+            model.landscape_resolution,
+            min_value=5,
+            max_value=31,
+            step=2,
+            disabled=not compute_loss_landscape,
         )
-        st.code(
-            json.dumps(
-                {
-                    "dataset": config.dataset,
-                    "samples": config.sample_count,
-                    "features": list(config.feature_names),
-                    "hidden_layers": list(config.hidden_layers),
-                    "epochs": config.epochs,
-                    "loss_landscape": parsed.compute_loss_landscape,
-                },
-                indent=2,
-                sort_keys=True,
+    )
+    values["landscape_span"] = float(
+        _slider(
+            span_col,
+            env,
+            "landscape_span",
+            "Span",
+            model.landscape_span,
+            min_value=0.1,
+            max_value=1.5,
+            step=0.05,
+            disabled=not compute_loss_landscape,
+        )
+    )
+    return values
+
+
+def _render_wide_args_form(model: app_args.PytorchPlaygroundArgs, *, env: Any, container: Any) -> dict[str, Any]:
+    values: dict[str, Any] = {}
+    container.markdown("#### Dataset")
+    values.update(_render_dataset_fields(model, env=env, container=container))
+    values["feature_names"] = _feature_names(container, env, model.feature_names)
+    container.markdown("#### Model")
+    values.update(_render_model_fields(model, env=env, container=container))
+    container.markdown("#### Evidence")
+    values.update(_render_evidence_fields(model, env=env, container=container))
+    return values
+
+
+def _render_sidebar_args_form(model: app_args.PytorchPlaygroundArgs, *, env: Any, container: Any) -> dict[str, Any]:
+    values: dict[str, Any] = {}
+    container.markdown("#### Dataset")
+    values.update(
+        {
+            "dataset": _selectbox(container, env, "dataset", "Dataset", DATASETS, model.dataset),
+            "sample_count": int(
+                _slider(container, env, "sample_count", "Samples", model.sample_count, min_value=64, max_value=1000, step=16)
             ),
-            language="json",
-        )
+            "noise": float(_slider(container, env, "noise", "Noise", model.noise, min_value=0.0, max_value=0.5, step=0.01)),
+            "train_ratio": float(
+                _slider(container, env, "train_ratio", "Train split", model.train_ratio, min_value=0.5, max_value=0.95, step=0.05)
+            ),
+            "feature_names": _feature_names(container, env, model.feature_names),
+        }
+    )
+    container.markdown("#### Model")
+    values.update(
+        {
+            "hidden_layers": _text_input(container, env, "hidden_layers", "Hidden layers", model.hidden_layers),
+            "activation": _selectbox(container, env, "activation", "Activation", ACTIVATIONS, model.activation),
+            "optimizer": _selectbox(container, env, "optimizer", "Optimizer", OPTIMIZERS, model.optimizer),
+            "learning_rate": float(
+                _number_input(
+                    container,
+                    env,
+                    "learning_rate",
+                    "Learning rate",
+                    model.learning_rate,
+                    min_value=0.001,
+                    max_value=0.2,
+                    step=0.001,
+                )
+            ),
+            "epochs": int(_slider(container, env, "epochs", "Epochs", model.epochs, min_value=10, max_value=300, step=10)),
+            "batch_size": int(_slider(container, env, "batch_size", "Batch", model.batch_size, min_value=8, max_value=256, step=8)),
+            "seed": int(_number_input(container, env, "seed", "Seed", model.seed, min_value=0, max_value=9999, step=1)),
+        }
+    )
+    container.markdown("#### Evidence")
+    compute_loss_landscape = _checkbox(
+        container,
+        env,
+        "compute_loss_landscape",
+        "Loss landscape",
+        model.compute_loss_landscape,
+    )
+    values.update(
+        {
+            "data_out": _text_input(container, env, "data_out", "Evidence path", model.data_out),
+            "grid_size": int(_slider(container, env, "grid_size", "Grid size", model.grid_size, min_value=12, max_value=120, step=4)),
+            "compute_loss_landscape": compute_loss_landscape,
+            "landscape_resolution": int(
+                _slider(
+                    container,
+                    env,
+                    "landscape_resolution",
+                    "Resolution",
+                    model.landscape_resolution,
+                    min_value=5,
+                    max_value=31,
+                    step=2,
+                    disabled=not compute_loss_landscape,
+                )
+            ),
+            "landscape_span": float(
+                _slider(
+                    container,
+                    env,
+                    "landscape_span",
+                    "Span",
+                    model.landscape_span,
+                    min_value=0.1,
+                    max_value=1.5,
+                    step=0.05,
+                    disabled=not compute_loss_landscape,
+                )
+            ),
+            "reset_target": _checkbox(container, env, "reset_target", "Reset output", model.reset_target),
+        }
+    )
+    return values
+
+
+def _render_args_form(model: app_args.PytorchPlaygroundArgs, *, env: Any, container: Any, wide: bool = False) -> dict[str, Any]:
+    if wide:
+        return _render_wide_args_form(model, env=env, container=container)
+    return _render_sidebar_args_form(model, env=env, container=container)
+
+
+def render(*, env: Any | None = None, container: Any | None = None) -> None:
+    active_env = env or _get_env()
+    defaults_model, defaults_payload, settings_path = load_args_state(active_env, args_module=app_args)
+
+    artifact_target = str(getattr(active_env, "target", "") or getattr(active_env, "app", "") or "pytorch_playground_project")
+    artifact_root = (
+        Path(getattr(active_env, "AGILAB_EXPORT_ABS", Path.home() / "export"))
+        / artifact_target
+        / "pytorch_playground"
+    )
+    output_container = container or st
+    output_container.caption(
+        "PyTorch Playground is an executable app: ORCHESTRATE runs the configured "
+        "training job and exports replayable evidence."
+    )
+    output_container.caption(f"Analysis artifacts are exported to `{artifact_root}`.")
+
+    form_container = container or st.sidebar
+    if container is None:
+        with st.sidebar:
+            st.markdown("### PyTorch Playground")
+            st.caption("These fields are persisted as app arguments.")
+            form_values = _render_args_form(defaults_model, env=active_env, container=st.sidebar)
+    else:
+        form_container.markdown("### PyTorch Playground")
+        form_container.caption("These fields are persisted as app arguments.")
+        form_values = _render_args_form(defaults_model, env=active_env, container=form_container, wide=True)
+
+    try:
+        parsed = app_args.ensure_defaults(app_args.ArgsModel(**form_values), env=active_env)
+    except ValidationError as exc:
+        output_container.error("\n".join(active_env.humanize_validation_errors(exc)))
+    else:
+        try:
+            config = app_args.to_playground_config(parsed)
+        except ValueError as exc:
+            output_container.error(str(exc))
+        else:
+            persist_args(
+                app_args,
+                parsed,
+                settings_path=settings_path,
+                defaults_payload=defaults_payload,
+            )
+            output_container.code(
+                json.dumps(
+                    {
+                        "dataset": config.dataset,
+                        "samples": config.sample_count,
+                        "features": list(config.feature_names),
+                        "hidden_layers": list(config.hidden_layers),
+                        "epochs": config.epochs,
+                        "loss_landscape": parsed.compute_loss_landscape,
+                    },
+                    indent=2,
+                    sort_keys=True,
+                ),
+                language="json",
+            )
+
+
+if not globals().get("_AGILAB_APP_ARGS_FORM_IMPORT_ONLY", False):
+    render(env=globals().get("env"))

--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/app_settings.toml
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/app_settings.toml
@@ -36,6 +36,7 @@ max_unhealthy = 0
 max_restart_rate = 0.25
 
 [pages]
+restrict_to_view_module = true
 view_module = ["view_app_ui"]
 
 [pages.view_app_ui]

--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/app_settings.toml
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/app_settings.toml
@@ -37,8 +37,8 @@ max_restart_rate = 0.25
 
 [pages]
 restrict_to_view_module = true
-view_module = ["view_app_ui"]
+view_module = []
 
-[pages.view_app_ui]
+[app_surface]
 title = "PyTorch Playground"
-entrypoint = "pytorch_playground/playground_ui.py"
+entrypoint = "pytorch_playground/app_surface.py"

--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pre_prompt.json
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pre_prompt.json
@@ -1,4 +1,10 @@
-{
-  "description": "PyTorch Playground trains a small classifier on generated data and exports reproducible evidence.",
-  "suggested_prompt": "Tune the playground configuration, run it, and compare the exported evidence manifest with the previous run."
-}
+[
+  {
+    "role": "system",
+    "content": "You are operating the PyTorch Playground AGILAB app. Keep guidance focused on reproducible local training, generated datasets, explicit model settings, and exported evidence artifacts."
+  },
+  {
+    "role": "user",
+    "content": "Tune the playground configuration, run it, and compare the exported evidence manifest with the previous run."
+  }
+]

--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground/app_surface.py
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground/app_surface.py
@@ -52,9 +52,15 @@ def _resolve_active_app_path(active_app: Path | None = None) -> Path | None:
     if active_app is not None:
         candidate = Path(active_app).expanduser()
         return candidate.resolve() if candidate.exists() else None
-    from pytorch_playground.core import _resolve_active_app
 
-    return _resolve_active_app()
+    for index, arg in enumerate(sys.argv):
+        if arg == "--active-app" and index + 1 < len(sys.argv):
+            candidate = Path(sys.argv[index + 1]).expanduser()
+            return candidate.resolve() if candidate.exists() else None
+        if arg.startswith("--active-app="):
+            candidate = Path(arg.split("=", 1)[1]).expanduser()
+            return candidate.resolve() if candidate.exists() else None
+    return None
 
 
 def _load_orchestrate_args(active_app_path: Path):
@@ -64,6 +70,50 @@ def _load_orchestrate_args(active_app_path: Path):
     env = AgiEnv(apps_path=active_app_path.parent, app=active_app_path.name, verbose=0)
     args_model = app_args.ensure_defaults(app_args.load_args(env.app_settings_file), env=env)
     return env, args_model
+
+
+def _append_unique_path(paths: list[Path], path: Path) -> None:
+    try:
+        resolved = path.expanduser().resolve()
+    except (OSError, RuntimeError, TypeError, ValueError):
+        resolved = path.expanduser()
+    if resolved not in paths:
+        paths.append(resolved)
+
+
+def _analysis_evidence_dirs(env: Any, args_model: Any, active_app_path: Path) -> list[Path]:
+    paths: list[Path] = []
+    export_root = Path(getattr(env, "AGILAB_EXPORT_ABS", Path.home() / "export"))
+    for target in (
+        str(getattr(env, "target", "") or ""),
+        str(getattr(env, "app", "") or ""),
+        active_app_path.name,
+    ):
+        if target:
+            _append_unique_path(paths, export_root / target / "pytorch_playground")
+
+    data_out = Path(getattr(args_model, "data_out", "pytorch_playground/evidence"))
+    if not data_out.is_absolute():
+        resolve_share_path = getattr(env, "resolve_share_path", None)
+        if callable(resolve_share_path):
+            data_out = Path(resolve_share_path(data_out))
+    _append_unique_path(paths, data_out)
+    return paths
+
+
+def _has_evidence(paths: list[Path]) -> bool:
+    return any((path / "manifest.json").is_file() for path in paths)
+
+
+def _render_missing_evidence(paths: list[Path]) -> None:
+    import streamlit as st
+
+    st.set_page_config(page_title="PyTorch Playground", layout="wide")
+    st.title("PyTorch Playground")
+    st.info("No exported PyTorch evidence found yet. Run the app once from ORCHESTRATE, then return to ANALYSIS.")
+    if paths:
+        st.caption("Checked evidence locations:")
+        st.code("\n".join(str(path) for path in paths), language="text")
 
 
 def render(
@@ -81,13 +131,20 @@ def render(
         return
     if surface_mode in {"analysis", "full"}:
         active_app_path = _resolve_active_app_path(active_app)
-        from pytorch_playground import app_args, playground_ui
 
         if active_app_path is None:
+            from pytorch_playground import playground_ui
+
             playground_ui.main()
             return
         try:
-            _, args_model = _load_orchestrate_args(active_app_path)
+            runtime_env, args_model = _load_orchestrate_args(active_app_path)
+            evidence_dirs = _analysis_evidence_dirs(runtime_env, args_model, active_app_path)
+            if not _has_evidence(evidence_dirs):
+                _render_missing_evidence(evidence_dirs)
+                return
+            from pytorch_playground import app_args, playground_ui
+
             config = app_args.to_playground_config(args_model)
         except Exception as exc:
             import streamlit as st
@@ -101,6 +158,7 @@ def render(
             compute_loss_landscape=args_model.compute_loss_landscape,
             landscape_resolution=args_model.landscape_resolution,
             landscape_span=args_model.landscape_span,
+            evidence_dirs=evidence_dirs,
         )
         return
     raise ValueError(f"Unsupported PyTorch Playground app surface mode: {mode}")

--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground/app_surface.py
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground/app_surface.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+_APP_SRC = Path(__file__).resolve().parents[1]
+_SCRIPT_DIR = Path(__file__).resolve().parent
+
+
+def _prepend_sys_path(path: Path) -> None:
+    entry = str(path)
+    sys.path[:] = [existing for existing in sys.path if existing != entry]
+    sys.path.insert(0, entry)
+
+
+def _drop_shadowed_package_module() -> None:
+    module = sys.modules.get("pytorch_playground")
+    module_file = getattr(module, "__file__", None)
+    if module_file is None:
+        return
+    try:
+        shadows_package = Path(module_file).resolve() == (_SCRIPT_DIR / "pytorch_playground.py").resolve()
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return
+    if not shadows_package:
+        return
+    for name in list(sys.modules):
+        if name == "pytorch_playground" or name.startswith("pytorch_playground."):
+            sys.modules.pop(name, None)
+
+
+_prepend_sys_path(_APP_SRC)
+_drop_shadowed_package_module()
+
+
+def _load_app_args_form() -> ModuleType:
+    entrypoint = _APP_SRC / "app_args_form.py"
+    spec = importlib.util.spec_from_file_location("_pytorch_playground_app_args_form_surface", entrypoint)
+    if spec is None or spec.loader is None:
+        raise ModuleNotFoundError(f"Unable to load PyTorch Playground app form from {entrypoint}")
+    module = importlib.util.module_from_spec(spec)
+    module._AGILAB_APP_ARGS_FORM_IMPORT_ONLY = True
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _resolve_active_app_path(active_app: Path | None = None) -> Path | None:
+    if active_app is not None:
+        candidate = Path(active_app).expanduser()
+        return candidate.resolve() if candidate.exists() else None
+    from pytorch_playground.core import _resolve_active_app
+
+    return _resolve_active_app()
+
+
+def _load_orchestrate_args(active_app_path: Path):
+    from agi_env import AgiEnv
+    from pytorch_playground import app_args
+
+    env = AgiEnv(apps_path=active_app_path.parent, app=active_app_path.name, verbose=0)
+    args_model = app_args.ensure_defaults(app_args.load_args(env.app_settings_file), env=env)
+    return env, args_model
+
+
+def render(
+    *,
+    mode: str = "analysis",
+    active_app: Path | None = None,
+    env: Any | None = None,
+    container: Any | None = None,
+    streamlit: Any | None = None,
+) -> None:
+    surface_mode = str(mode or "analysis").lower()
+    if surface_mode == "configure":
+        app_args_form = _load_app_args_form()
+        app_args_form.render(env=env, container=container)
+        return
+    if surface_mode in {"analysis", "full"}:
+        active_app_path = _resolve_active_app_path(active_app)
+        from pytorch_playground import app_args, playground_ui
+
+        if active_app_path is None:
+            playground_ui.main()
+            return
+        try:
+            _, args_model = _load_orchestrate_args(active_app_path)
+            config = app_args.to_playground_config(args_model)
+        except Exception as exc:
+            import streamlit as st
+
+            st.error(f"Unable to load ORCHESTRATE app arguments: {exc}")
+            return
+        playground_ui.main(
+            config_override=config,
+            preset_label="ORCHESTRATE args",
+            interactive_controls=False,
+            compute_loss_landscape=args_model.compute_loss_landscape,
+            landscape_resolution=args_model.landscape_resolution,
+            landscape_span=args_model.landscape_span,
+        )
+        return
+    raise ValueError(f"Unsupported PyTorch Playground app surface mode: {mode}")
+
+
+def main() -> None:
+    render(mode="analysis")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground/playground_ui.py
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground/playground_ui.py
@@ -1063,111 +1063,127 @@ def _render_summary(config: PlaygroundConfig, result: Mapping[str, Any]) -> None
             st.markdown(card, unsafe_allow_html=True)
 
 
-def main() -> None:
+def main(
+    *,
+    config_override: PlaygroundConfig | None = None,
+    preset_label: str | None = None,
+    interactive_controls: bool = True,
+    compute_loss_landscape: bool | None = None,
+    landscape_resolution: int = 21,
+    landscape_span: float = 0.75,
+) -> None:
     st.set_page_config(page_title=PAGE_TITLE, layout="wide")
     render_logo()
     _render_page_styles()
     active_app = _resolve_active_app()
     shared_config = _config_from_query_params(st.query_params)
 
-    with st.sidebar:
-        st.markdown("### Challenge")
-        preset_labels = tuple(PLAYGROUND_PRESETS)
-        preset_index = 0 if shared_config is not None else preset_labels.index(DEFAULT_PRESET)
-        preset_label = st.selectbox(
-            "Challenge preset",
-            preset_labels,
-            index=preset_index,
-            help="Preset only seeds the controls; every value stays editable.",
-        )
-        defaults = _preset_config(preset_label, shared_config)
-        preset_key = _safe_key_fragment(preset_label)
-        st.caption(_preset_story(preset_label, shared_config))
-        st.markdown("### Dataset")
-        dataset = st.selectbox("Dataset", DATASETS, index=DATASETS.index(defaults.dataset), key=f"pt_dataset_{preset_key}")
-        sample_count = st.slider("Samples", 64, 1000, defaults.sample_count, step=32, key=f"pt_samples_{preset_key}")
-        noise = st.slider("Noise", 0.0, 0.5, defaults.noise, step=0.01, key=f"pt_noise_{preset_key}")
-        train_ratio = st.slider("Train split", 0.5, 0.95, defaults.train_ratio, step=0.05, key=f"pt_split_{preset_key}")
-        feature_names = st.multiselect(
-            "Features",
-            FEATURES,
-            default=list(defaults.feature_names),
-            key=f"pt_features_{preset_key}",
-        )
-        st.markdown("### Network")
-        hidden_raw = st.text_input(
-            "Hidden layers",
-            value=",".join(str(width) for width in defaults.hidden_layers),
-            key=f"pt_layers_{preset_key}",
-            help="Comma-separated widths, for example 16,8.",
-        )
-        activation = st.selectbox(
-            "Activation",
-            ACTIVATIONS,
-            index=ACTIVATIONS.index(defaults.activation),
-            key=f"pt_activation_{preset_key}",
-        )
-        optimizer = st.selectbox(
-            "Optimizer",
-            OPTIMIZERS,
-            index=OPTIMIZERS.index(defaults.optimizer),
-            key=f"pt_optimizer_{preset_key}",
-        )
-        learning_rate = st.slider(
-            "Learning rate",
-            0.001,
-            0.2,
-            defaults.learning_rate,
-            step=0.001,
-            format="%.3f",
-            key=f"pt_lr_{preset_key}",
-        )
-        epochs = st.slider("Epochs", 10, 300, defaults.epochs, step=10, key=f"pt_epochs_{preset_key}")
-        batch_size = st.slider("Batch size", 8, 256, defaults.batch_size, step=8, key=f"pt_batch_{preset_key}")
-        grid_size = st.slider("Grid resolution", 12, 120, defaults.grid_size, step=4, key=f"pt_grid_{preset_key}")
-        seed = st.number_input("Seed", min_value=0, max_value=9999, value=defaults.seed, step=1, key=f"pt_seed_{preset_key}")
-        st.markdown("### Run")
-        train_requested = st.button("Train / refresh", type="primary", width="stretch")
-        st.caption("Controls are staged. Charts and evidence update only when you train.")
+    if interactive_controls:
+        with st.sidebar:
+            st.markdown("### Challenge")
+            preset_labels = tuple(PLAYGROUND_PRESETS)
+            preset_index = 0 if shared_config is not None else preset_labels.index(DEFAULT_PRESET)
+            preset_label = st.selectbox(
+                "Challenge preset",
+                preset_labels,
+                index=preset_index,
+                help="Preset only seeds the controls; every value stays editable.",
+            )
+            defaults = _preset_config(preset_label, shared_config)
+            preset_key = _safe_key_fragment(preset_label)
+            st.caption(_preset_story(preset_label, shared_config))
+            st.markdown("### Dataset")
+            dataset = st.selectbox("Dataset", DATASETS, index=DATASETS.index(defaults.dataset), key=f"pt_dataset_{preset_key}")
+            sample_count = st.slider("Samples", 64, 1000, defaults.sample_count, step=32, key=f"pt_samples_{preset_key}")
+            noise = st.slider("Noise", 0.0, 0.5, defaults.noise, step=0.01, key=f"pt_noise_{preset_key}")
+            train_ratio = st.slider("Train split", 0.5, 0.95, defaults.train_ratio, step=0.05, key=f"pt_split_{preset_key}")
+            feature_names = st.multiselect(
+                "Features",
+                FEATURES,
+                default=list(defaults.feature_names),
+                key=f"pt_features_{preset_key}",
+            )
+            st.markdown("### Network")
+            hidden_raw = st.text_input(
+                "Hidden layers",
+                value=",".join(str(width) for width in defaults.hidden_layers),
+                key=f"pt_layers_{preset_key}",
+                help="Comma-separated widths, for example 16,8.",
+            )
+            activation = st.selectbox(
+                "Activation",
+                ACTIVATIONS,
+                index=ACTIVATIONS.index(defaults.activation),
+                key=f"pt_activation_{preset_key}",
+            )
+            optimizer = st.selectbox(
+                "Optimizer",
+                OPTIMIZERS,
+                index=OPTIMIZERS.index(defaults.optimizer),
+                key=f"pt_optimizer_{preset_key}",
+            )
+            learning_rate = st.slider(
+                "Learning rate",
+                0.001,
+                0.2,
+                defaults.learning_rate,
+                step=0.001,
+                format="%.3f",
+                key=f"pt_lr_{preset_key}",
+            )
+            epochs = st.slider("Epochs", 10, 300, defaults.epochs, step=10, key=f"pt_epochs_{preset_key}")
+            batch_size = st.slider("Batch size", 8, 256, defaults.batch_size, step=8, key=f"pt_batch_{preset_key}")
+            grid_size = st.slider("Grid resolution", 12, 120, defaults.grid_size, step=4, key=f"pt_grid_{preset_key}")
+            seed = st.number_input("Seed", min_value=0, max_value=9999, value=defaults.seed, step=1, key=f"pt_seed_{preset_key}")
+            st.markdown("### Run")
+            train_requested = st.button("Train / refresh", type="primary", width="stretch")
+            st.caption("Controls are staged. Charts and evidence update only when you train.")
 
-    try:
-        hidden_layers = _parse_hidden_layers(hidden_raw)
-    except ValueError as exc:
-        st.error(str(exc))
-        st.stop()
+        try:
+            hidden_layers = _parse_hidden_layers(hidden_raw)
+        except ValueError as exc:
+            st.error(str(exc))
+            st.stop()
 
-    config = PlaygroundConfig(
-        dataset=dataset,
-        sample_count=sample_count,
-        noise=noise,
-        train_ratio=train_ratio,
-        hidden_layers=hidden_layers,
-        activation=activation,
-        optimizer=optimizer,
-        learning_rate=learning_rate,
-        epochs=epochs,
-        batch_size=batch_size,
-        seed=int(seed),
-        feature_names=tuple(feature_names or DEFAULT_FEATURES),
-        grid_size=grid_size,
-    )
-    shared_signature = _config_signature(shared_config) if shared_config is not None else ""
-    previous_shared_signature = str(_session_state_get(SHARED_CONFIG_SIGNATURE_STATE_KEY, ""))
-    force_shared_refresh = bool(shared_config is not None and shared_signature != previous_shared_signature)
-    _session_state_set(SHARED_CONFIG_SIGNATURE_STATE_KEY, shared_signature)
-    trained_config, trained_preset, pending_changes = _resolve_trained_config(
-        config,
-        preset_label,
-        train_requested=train_requested,
-        force_refresh=force_shared_refresh,
-    )
+        config = PlaygroundConfig(
+            dataset=dataset,
+            sample_count=sample_count,
+            noise=noise,
+            train_ratio=train_ratio,
+            hidden_layers=hidden_layers,
+            activation=activation,
+            optimizer=optimizer,
+            learning_rate=learning_rate,
+            epochs=epochs,
+            batch_size=batch_size,
+            seed=int(seed),
+            feature_names=tuple(feature_names or DEFAULT_FEATURES),
+            grid_size=grid_size,
+        )
+        shared_signature = _config_signature(shared_config) if shared_config is not None else ""
+        previous_shared_signature = str(_session_state_get(SHARED_CONFIG_SIGNATURE_STATE_KEY, ""))
+        force_shared_refresh = bool(shared_config is not None and shared_signature != previous_shared_signature)
+        _session_state_set(SHARED_CONFIG_SIGNATURE_STATE_KEY, shared_signature)
+        trained_config, trained_preset, pending_changes = _resolve_trained_config(
+            config,
+            str(preset_label),
+            train_requested=train_requested,
+            force_refresh=force_shared_refresh,
+        )
+    else:
+        trained_config = config_override or PlaygroundConfig()
+        trained_preset = preset_label or "ORCHESTRATE args"
+        pending_changes = False
     trained_config_dict = asdict(trained_config)
     result = _cached_train(trained_config_dict)
-    with st.sidebar:
-        st.caption(f"Charts show: {trained_preset}")
-        if pending_changes:
-            st.warning("Pending changes. Press Train / refresh to update the run.")
+    if interactive_controls:
+        with st.sidebar:
+            st.caption(f"Charts show: {trained_preset}")
+            if pending_changes:
+                st.warning("Pending changes. Press Train / refresh to update the run.")
     _render_hero(active_app, trained_preset, trained_config)
+    if not interactive_controls:
+        st.caption("Charts use the persisted ORCHESTRATE arguments for this app.")
     if result["status"] == "missing_torch":
         st.error(result["detail"])
     elif result["status"] != "ok":
@@ -1243,9 +1259,14 @@ def main() -> None:
         )
         controls, chart_area = st.columns([1, 3])
         with controls:
-            landscape_resolution = st.slider("Resolution", 5, 31, 21, step=2)
-            landscape_span = st.slider("Span", 0.1, 1.5, 0.75, step=0.05)
-            compute_landscape = st.checkbox("Compute landscape", value=False)
+            if interactive_controls:
+                landscape_resolution = st.slider("Resolution", 5, 31, 21, step=2)
+                landscape_span = st.slider("Span", 0.1, 1.5, 0.75, step=0.05)
+                compute_landscape = st.checkbox("Compute landscape", value=False)
+            else:
+                compute_landscape = bool(compute_loss_landscape)
+                st.metric("Resolution", int(landscape_resolution))
+                st.metric("Span", f"{float(landscape_span):.2f}")
         if result["status"] != "ok":
             st.info("Loss landscape is available after a successful PyTorch run.")
         elif compute_landscape:
@@ -1264,7 +1285,10 @@ def main() -> None:
                 )
                 st.dataframe(landscape.sort_values("validation_loss").head(8), width="stretch", hide_index=True)
         else:
-            st.info("Enable computation to evaluate a deterministic 2D loss projection around the trained weights.")
+            if interactive_controls:
+                st.info("Enable computation to evaluate a deterministic 2D loss projection around the trained weights.")
+            else:
+                st.info("Enable Loss landscape in ORCHESTRATE to evaluate a deterministic 2D projection.")
 
     with evidence_tab:
         _render_section_intro(

--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground/playground_ui.py
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground/playground_ui.py
@@ -12,7 +12,7 @@ import re
 import subprocess
 import sys
 import tempfile
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import asdict
 from pathlib import Path
 from typing import Any
@@ -475,6 +475,87 @@ def _cached_loss_landscape(payload: dict[str, Any], resolution: int, span: float
     if _use_isolated_torch_training():
         return _run_core_in_subprocess("loss_landscape", config, resolution=resolution, span=span)
     return _loss_landscape(config, resolution=resolution, span=span)
+
+
+def _read_json_file(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, TypeError, ValueError, json.JSONDecodeError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _read_evidence_frame(path: Path, empty: pd.DataFrame) -> pd.DataFrame:
+    try:
+        return pd.read_csv(path)
+    except (OSError, ValueError, pd.errors.EmptyDataError, pd.errors.ParserError):
+        return empty.copy()
+
+
+def _load_evidence_result(evidence_dir: Path) -> tuple[PlaygroundConfig, dict[str, Any], Path] | None:
+    root = Path(evidence_dir).expanduser()
+    manifest_path = root / "manifest.json"
+    if not manifest_path.is_file():
+        return None
+
+    manifest = _read_json_file(manifest_path)
+    config_payload = manifest.get("config")
+    if not isinstance(config_payload, Mapping):
+        config_payload = _read_json_file(root / "config" / "playground_config.json").get("config", {})
+    config = _config_from_payload({"config": config_payload})
+
+    samples = _read_evidence_frame(root / "data" / "samples.csv", pd.DataFrame(columns=["x1", "x2", "target"]))
+    history = _read_evidence_frame(
+        root / "data" / "training_history.csv",
+        pd.DataFrame(columns=["epoch", "train_loss", "validation_loss", "train_accuracy", "validation_accuracy"]),
+    )
+    grid = _read_evidence_frame(root / "data" / "decision_grid.csv", pd.DataFrame(columns=["x1", "x2", "probability"]))
+    network_layers = _read_evidence_frame(root / "model" / "network_layers.csv", _empty_network_layers())
+    activation_maps = _read_evidence_frame(root / "model" / "hidden_activation_maps.csv", _empty_activation_maps())
+    loss_landscape = _read_evidence_frame(root / "model" / "loss_landscape.csv", _empty_loss_landscape())
+    summary_payload = _read_json_file(root / "summary" / "run_summary.json")
+
+    summary = manifest.get("summary")
+    if not isinstance(summary, Mapping):
+        summary = summary_payload.get("summary", {})
+    landscape_summary = manifest.get("landscape_summary")
+    if not isinstance(landscape_summary, Mapping):
+        landscape_summary = summary_payload.get("landscape_summary", _loss_landscape_summary(loss_landscape))
+
+    return (
+        config,
+        {
+            "status": "ok",
+            "detail": "",
+            "samples": samples,
+            "history": history,
+            "grid": grid,
+            "network_layers": network_layers,
+            "activation_maps": activation_maps,
+            "loss_landscape": loss_landscape,
+            "summary": dict(summary) if isinstance(summary, Mapping) else {},
+            "landscape_summary": dict(landscape_summary) if isinstance(landscape_summary, Mapping) else {},
+        },
+        root,
+    )
+
+
+def _load_latest_evidence_result(
+    evidence_dirs: Sequence[str | Path] | None,
+) -> tuple[PlaygroundConfig, dict[str, Any], Path] | None:
+    candidates: list[tuple[float, Path]] = []
+    for raw_path in evidence_dirs or ():
+        root = Path(raw_path).expanduser()
+        manifest_path = root / "manifest.json"
+        try:
+            candidates.append((manifest_path.stat().st_mtime, root))
+        except OSError:
+            continue
+    for _mtime, root in sorted(candidates, reverse=True):
+        loaded = _load_evidence_result(root)
+        if loaded is not None:
+            return loaded
+    return None
 
 
 def _render_page_styles() -> None:
@@ -1071,6 +1152,7 @@ def main(
     compute_loss_landscape: bool | None = None,
     landscape_resolution: int = 21,
     landscape_span: float = 0.75,
+    evidence_dirs: Sequence[str | Path] | None = None,
 ) -> None:
     st.set_page_config(page_title=PAGE_TITLE, layout="wide")
     render_logo()
@@ -1171,11 +1253,20 @@ def main(
             force_refresh=force_shared_refresh,
         )
     else:
-        trained_config = config_override or PlaygroundConfig()
-        trained_preset = preset_label or "ORCHESTRATE args"
+        evidence_result = _load_latest_evidence_result(evidence_dirs)
+        if evidence_result is None:
+            trained_config = config_override or PlaygroundConfig()
+            _render_hero(active_app, preset_label or "ORCHESTRATE args", trained_config)
+            st.info("No exported PyTorch evidence found yet. Run the app once from ORCHESTRATE, then return to ANALYSIS.")
+            return
+        trained_config, result, evidence_root = evidence_result
+        trained_preset = preset_label or "Latest ORCHESTRATE evidence"
         pending_changes = False
+        st.caption(f"Loaded evidence from `{evidence_root}`.")
+
     trained_config_dict = asdict(trained_config)
-    result = _cached_train(trained_config_dict)
+    if interactive_controls:
+        result = _cached_train(trained_config_dict)
     if interactive_controls:
         with st.sidebar:
             st.caption(f"Charts show: {trained_preset}")
@@ -1194,11 +1285,12 @@ def main(
     _render_summary(trained_config, result)
     _render_guided_flow(pending_changes=pending_changes, result_status=str(result.get("status", "")))
     _render_interpretation_cards(result)
+    loaded_landscape = _result_frame(result, "loss_landscape", _empty_loss_landscape())
     landscape_result: dict[str, Any] = {
         "status": "not_computed",
         "detail": "",
-        "loss_landscape": _empty_loss_landscape(),
-        "landscape_summary": _loss_landscape_summary(_empty_loss_landscape()),
+        "loss_landscape": loaded_landscape,
+        "landscape_summary": result.get("landscape_summary", _loss_landscape_summary(loaded_landscape)),
     }
     decision_tab, activations_tab, landscape_tab, evidence_tab = st.tabs(
         ["Boundary lab", "Neuron lens", "Loss terrain", "Evidence pack"]
@@ -1270,7 +1362,12 @@ def main(
         if result["status"] != "ok":
             st.info("Loss landscape is available after a successful PyTorch run.")
         elif compute_landscape:
-            landscape_result = _cached_loss_landscape(trained_config_dict, int(landscape_resolution), float(landscape_span))
+            if interactive_controls:
+                landscape_result = _cached_loss_landscape(
+                    trained_config_dict,
+                    int(landscape_resolution),
+                    float(landscape_span),
+                )
             landscape = _result_frame(landscape_result, "loss_landscape", _empty_loss_landscape())
             summary = landscape_result.get("landscape_summary", _loss_landscape_summary(landscape))
             with controls:

--- a/src/agilab/orchestrate_page_support.py
+++ b/src/agilab/orchestrate_page_support.py
@@ -142,6 +142,13 @@ def app_distribution_preview_enabled(env_or_path: Any) -> bool:
     return app.get("distribution_preview") is not False
 
 
+def supports_service_mode(env_or_path: Any) -> bool:
+    """Return whether ORCHESTRATE should expose persistent service controls."""
+
+    app = _agilab_app_contract(env_or_path)
+    return app.get("service_mode") is not False
+
+
 def _agilab_app_contract(env_or_path: Any) -> Mapping[str, Any]:
     project_root = _project_root_from_env_or_path(env_or_path)
     if project_root is None:

--- a/src/agilab/pages/2_ORCHESTRATE.py
+++ b/src/agilab/pages/2_ORCHESTRATE.py
@@ -74,6 +74,7 @@ import_agilab_symbols(
         "serialize_args_payload": "serialize_args_payload",
         "strip_ansi": "strip_ansi",
         "supports_distribution_preview": "supports_distribution_preview",
+        "supports_service_mode": "supports_service_mode",
         "update_distribution_payload": "update_distribution_payload",
         "workplan_selection_key": "workplan_selection_key",
     },
@@ -1967,6 +1968,12 @@ async def _render_distribution_panel(
                     st.caption("Unable to resolve the worker environment path. Run INSTALL, then retry CHECK distribute.")
 
 
+def _execution_mode_options(env: Any) -> tuple[str, ...]:
+    if supports_service_mode(env):
+        return ("Run now", "Serve")
+    return ("Run now",)
+
+
 async def _render_run_panels(
     env: Any,
     *,
@@ -1992,14 +1999,19 @@ async def _render_run_panels(
     st.session_state.setdefault("run_log_cache", "")
 
     execution_view_key = f"orchestrate_execution_view__{env.app}"
-    execution_view = compact_choice(
-        st,
-        "Execution mode",
-        ("Run now", "Serve"),
-        key=execution_view_key,
-        help="Run now executes once and stops. Serve starts a persistent service with status and stop controls.",
-        fallback="radio",
-    )
+    execution_options = _execution_mode_options(env)
+    if len(execution_options) > 1:
+        execution_view = compact_choice(
+            st,
+            "Execution mode",
+            execution_options,
+            key=execution_view_key,
+            help="Run now executes once and stops. Serve starts a persistent service with status and stop controls.",
+            fallback="radio",
+        )
+    else:
+        execution_view = "Run now"
+        st.caption("Service mode is not available for this app.")
     show_run_panel = execution_view == "Run now"
     show_submit_panel = execution_view == "Serve"
 

--- a/src/agilab/pages/2_ORCHESTRATE.py
+++ b/src/agilab/pages/2_ORCHESTRATE.py
@@ -181,6 +181,17 @@ import_agilab_symbols(
 )
 import_agilab_symbols(
     globals(),
+    "agilab.app_surface",
+    {
+        "configured_app_surface_entrypoint": "configured_app_surface_entrypoint",
+        "render_app_surface": "render_app_surface",
+    },
+    current_file=__file__,
+    fallback_path=Path(__file__).resolve().parents[1] / "app_surface.py",
+    fallback_name="agilab_app_surface_fallback",
+)
+import_agilab_symbols(
+    globals(),
     "agilab.orchestrate_page_helpers",
     {
         "app_install_status": "_orchestrate_app_install_status",
@@ -1767,31 +1778,45 @@ async def _render_distribution_panel(
         snippet_exists = app_args_form.exists()
         snippet_not_empty = snippet_exists and app_args_form.stat().st_size > 1
 
-        toggle_key = "toggle_edit_ui"
-        if toggle_key not in st.session_state:
-            st.session_state[toggle_key] = not snippet_not_empty
+        surface_rendered = False
+        if configured_app_surface_entrypoint(project_path) is not None:
+            try:
+                with _with_app_args_env(args_env):
+                    surface_rendered = render_app_surface(
+                        project_path,
+                        mode="configure",
+                        env=args_env,
+                        container=st,
+                    )
+            except (SyntaxError, RuntimeError, OSError, TypeError, ValueError, AttributeError, ImportError) as e:
+                st.warning(e)
 
-        st.toggle("Edit", key=toggle_key, on_change=init_custom_ui, args=[app_args_form])
+        if not surface_rendered:
+            toggle_key = "toggle_edit_ui"
+            if toggle_key not in st.session_state:
+                st.session_state[toggle_key] = not snippet_not_empty
 
-        if st.session_state[toggle_key]:
-            with _with_app_args_env(args_env):
-                render_generic_ui()
-            if not snippet_exists:
-                with open(app_args_form, "w") as st_src:
-                    st_src.write("")
-        else:
-            if snippet_exists and snippet_not_empty:
-                try:
-                    with _with_app_args_env(args_env):
-                        runpy.run_path(app_args_form, init_globals={**globals(), "env": args_env})
-                except (SyntaxError, RuntimeError, OSError, TypeError, ValueError, AttributeError, ImportError) as e:
-                    st.warning(e)
-            else:
+            st.toggle("Edit", key=toggle_key, on_change=init_custom_ui, args=[app_args_form])
+
+            if st.session_state[toggle_key]:
                 with _with_app_args_env(args_env):
                     render_generic_ui()
                 if not snippet_exists:
                     with open(app_args_form, "w") as st_src:
                         st_src.write("")
+            else:
+                if snippet_exists and snippet_not_empty:
+                    try:
+                        with _with_app_args_env(args_env):
+                            runpy.run_path(app_args_form, init_globals={**globals(), "env": args_env})
+                    except (SyntaxError, RuntimeError, OSError, TypeError, ValueError, AttributeError, ImportError) as e:
+                        st.warning(e)
+                else:
+                    with _with_app_args_env(args_env):
+                        render_generic_ui()
+                    if not snippet_exists:
+                        with open(app_args_form, "w") as st_src:
+                            st_src.write("")
 
         if bool(cluster_params.get("cluster_enabled", False)):
             # Refresh mount table cache each rerun (mounts can appear/disappear while Streamlit stays alive).

--- a/src/agilab/pages/4_ANALYSIS.py
+++ b/src/agilab/pages/4_ANALYSIS.py
@@ -1466,7 +1466,7 @@ def _dedupe_preserve_order(values: list[str]) -> list[str]:
 _APP_UI_PAGE_KEY = "view_app_ui"
 
 
-def _declared_app_ui_page_config(active_app_path: Path | None) -> dict[str, str] | None:
+def _declared_app_pages_config(active_app_path: Path | None) -> dict[str, Any] | None:
     if active_app_path is None:
         return None
     settings_path = active_app_path / "src" / "app_settings.toml"
@@ -1477,6 +1477,13 @@ def _declared_app_ui_page_config(active_app_path: Path | None) -> dict[str, str]
         return None
     pages = seed_cfg.get("pages")
     if not isinstance(pages, dict):
+        return None
+    return pages
+
+
+def _declared_app_ui_page_config(active_app_path: Path | None) -> dict[str, str] | None:
+    pages = _declared_app_pages_config(active_app_path)
+    if pages is None:
         return None
     page_cfg = pages.get(_APP_UI_PAGE_KEY)
     if not isinstance(page_cfg, dict):
@@ -1493,6 +1500,7 @@ def _declared_app_ui_page_config(active_app_path: Path | None) -> dict[str, str]
 
 def _migrate_declared_app_ui_page_config(active_app_path: Path | None, cfg: dict) -> bool:
     """Copy an app-owned ANALYSIS UI declaration into stale per-user settings."""
+    seed_pages = _declared_app_pages_config(active_app_path)
     declared = _declared_app_ui_page_config(active_app_path)
     if declared is None:
         return False
@@ -1500,6 +1508,7 @@ def _migrate_declared_app_ui_page_config(active_app_path: Path | None, cfg: dict
     pages = cfg.setdefault("pages", {})
     if not isinstance(pages, dict):
         cfg["pages"] = pages = {}
+    changed = False
 
     raw_page_cfg = pages.get(_APP_UI_PAGE_KEY)
     has_page_cfg = (
@@ -1507,8 +1516,9 @@ def _migrate_declared_app_ui_page_config(active_app_path: Path | None, cfg: dict
         and isinstance(raw_page_cfg.get("entrypoint"), str)
         and bool(raw_page_cfg.get("entrypoint", "").strip())
     )
-    if has_page_cfg:
-        return False
+    if not has_page_cfg:
+        pages[_APP_UI_PAGE_KEY] = declared
+        changed = True
 
     raw_modules = pages.get("view_module")
     modules = (
@@ -1520,11 +1530,32 @@ def _migrate_declared_app_ui_page_config(active_app_path: Path | None, cfg: dict
         if isinstance(raw_modules, list)
         else []
     )
-    if _APP_UI_PAGE_KEY not in modules:
-        modules.insert(0, _APP_UI_PAGE_KEY)
-    pages["view_module"] = _dedupe_preserve_order(modules)
-    pages[_APP_UI_PAGE_KEY] = declared
-    return True
+    seed_restricts_views = bool(seed_pages and seed_pages.get("restrict_to_view_module") is True)
+    seed_modules = (
+        [
+            value.strip()
+            for value in seed_pages.get("view_module", [])
+            if isinstance(value, str) and value.strip()
+        ]
+        if isinstance(seed_pages, dict) and isinstance(seed_pages.get("view_module"), list)
+        else []
+    )
+    if seed_restricts_views:
+        desired_modules = _dedupe_preserve_order(seed_modules or [_APP_UI_PAGE_KEY])
+        if pages.get("restrict_to_view_module") is not True:
+            pages["restrict_to_view_module"] = True
+            changed = True
+        if pages.get("view_module") != desired_modules:
+            pages["view_module"] = desired_modules
+            changed = True
+    else:
+        if _APP_UI_PAGE_KEY not in modules:
+            modules.insert(0, _APP_UI_PAGE_KEY)
+        desired_modules = _dedupe_preserve_order(modules)
+        if pages.get("view_module") != desired_modules:
+            pages["view_module"] = desired_modules
+            changed = True
+    return changed
 
 
 def _migrate_legacy_analysis_page_config(project: str | None, cfg: dict) -> bool:

--- a/src/agilab/pages/4_ANALYSIS.py
+++ b/src/agilab/pages/4_ANALYSIS.py
@@ -2518,27 +2518,6 @@ async def _render_configured_app_surface(
     return True
 
 
-def _render_configured_app_surface_launcher(
-    active_app_path: Path | None,
-    cfg: dict,
-    *,
-    current_page: str | None = None,
-) -> None:
-    should_show = _query_param_is_truthy(
-        st.query_params.get(_APP_SURFACE_HIDE_QUERY_PARAM)
-    ) or _is_app_surface_overview_requested(current_page)
-    if not should_show:
-        return
-    entrypoint = configured_app_surface_entrypoint(active_app_path, cfg)
-    if entrypoint is None:
-        return
-    surface_title = app_surface_title(app_surface_config(active_app_path, cfg))
-    if st.button(f"Open {surface_title}", type="primary"):
-        for key in (_APP_SURFACE_HIDE_QUERY_PARAM, "current_page"):
-            if key in st.query_params:
-                del st.query_params[key]
-        st.rerun()
-
 async def main():
     # Navigation by query param
     qp = st.query_params
@@ -2605,7 +2584,6 @@ async def main():
         _write_config(app_settings, cfg)
     if await _render_configured_app_surface(active_app_path, cfg, current_page=current_page):
         return
-    _render_configured_app_surface_launcher(active_app_path, cfg, current_page=current_page)
     configured_views: list[str] = [
         str(v)
         for v in cfg.get("pages", {}).get("view_module", [])

--- a/src/agilab/pages/4_ANALYSIS.py
+++ b/src/agilab/pages/4_ANALYSIS.py
@@ -104,6 +104,18 @@ import_agilab_symbols(
     fallback_path=Path(__file__).resolve().parents[1] / "ui_performance.py",
     fallback_name="agilab_ui_performance_fallback",
 )
+import_agilab_symbols(
+    globals(),
+    "agilab.app_surface",
+    {
+        "app_surface_config": "app_surface_config",
+        "app_surface_title": "app_surface_title",
+        "configured_app_surface_entrypoint": "configured_app_surface_entrypoint",
+    },
+    current_file=__file__,
+    fallback_path=Path(__file__).resolve().parents[1] / "app_surface.py",
+    fallback_name="agilab_app_surface_fallback",
+)
 
 # Use modern TOML libraries
 import tomllib       # For reading TOML files (read as binary)
@@ -195,6 +207,9 @@ _ANALYSIS_VIEW_PROFILES = {
         "Use after dimensionality-reduction workflows.",
     ),
 }
+
+_APP_SURFACE_HIDE_QUERY_PARAM = "hide_app_surface"
+_TRUTHY_QUERY_VALUES = {"1", "true", "yes", "on"}
 
 _ANALYSIS_ARTIFACT_SUFFIXES = {
     ".csv",
@@ -1558,6 +1573,59 @@ def _migrate_declared_app_ui_page_config(active_app_path: Path | None, cfg: dict
     return changed
 
 
+def _migrate_declared_app_surface_config(active_app_path: Path | None, cfg: dict) -> bool:
+    """Copy an app-owned surface declaration and hide legacy page bridges."""
+    declared = app_surface_config(active_app_path)
+    if not declared:
+        return False
+
+    changed = False
+    if cfg.get("app_surface") != declared:
+        cfg["app_surface"] = declared
+        changed = True
+
+    pages = cfg.setdefault("pages", {})
+    if not isinstance(pages, dict):
+        cfg["pages"] = pages = {}
+        changed = True
+
+    seed_pages = _declared_app_pages_config(active_app_path)
+    seed_restricts_views = bool(seed_pages and seed_pages.get("restrict_to_view_module") is True)
+    seed_modules = (
+        [
+            value.strip()
+            for value in seed_pages.get("view_module", [])
+            if isinstance(value, str) and value.strip()
+        ]
+        if isinstance(seed_pages, dict) and isinstance(seed_pages.get("view_module"), list)
+        else []
+    )
+    if seed_restricts_views:
+        desired_modules = _dedupe_preserve_order(seed_modules)
+        if pages.get("restrict_to_view_module") is not True:
+            pages["restrict_to_view_module"] = True
+            changed = True
+        if pages.get("view_module") != desired_modules:
+            pages["view_module"] = desired_modules
+            changed = True
+
+    if _declared_app_ui_page_config(active_app_path) is None:
+        raw_modules = pages.get("view_module")
+        if isinstance(raw_modules, list):
+            desired_modules = [
+                value
+                for value in raw_modules
+                if not (isinstance(value, str) and value.strip() == _APP_UI_PAGE_KEY)
+            ]
+            if pages.get("view_module") != desired_modules:
+                pages["view_module"] = desired_modules
+                changed = True
+        if _APP_UI_PAGE_KEY in pages:
+            del pages[_APP_UI_PAGE_KEY]
+            changed = True
+    return changed
+
+
 def _migrate_legacy_analysis_page_config(project: str | None, cfg: dict) -> bool:
     """Migrate stale per-user analysis settings after app defaults change."""
     if project not in {"flight", "flight_telemetry_project"}:
@@ -1694,6 +1762,35 @@ async def _render_selected_view_route(current_page: str | None) -> bool:
         st.error(f"Failed to render view: {exc}")
         st.caption("Full traceback")
         st.code(traceback.format_exc(), language="text")
+    return True
+
+
+def _is_legacy_app_ui_route(current_page: str | None) -> bool:
+    if not current_page:
+        return False
+    value = str(current_page).strip()
+    if not value:
+        return False
+    path = Path(value)
+    return path.stem == _APP_UI_PAGE_KEY or _APP_UI_PAGE_KEY in path.parts
+
+
+def _is_app_surface_overview_requested(current_page: str | None) -> bool:
+    return str(current_page or "").strip().lower() == "main"
+
+
+def _consume_legacy_app_ui_route_for_app_surface(
+    current_page: str | None,
+    active_app_path: Path | None,
+) -> bool:
+    """Treat stale view_app_ui deep links as app-surface links when the app declares one."""
+    if not _is_legacy_app_ui_route(current_page):
+        return False
+    if configured_app_surface_entrypoint(active_app_path) is None:
+        return False
+    for key in ("current_page", _APP_SURFACE_HIDE_QUERY_PARAM):
+        if key in st.query_params:
+            del st.query_params[key]
     return True
 
 
@@ -2392,6 +2489,56 @@ def _write_config(path: Path, cfg: dict):
     except (OSError, ValueError) as e:
         st.error(f"Error updating configuration: {e}")
 
+
+def _query_param_is_truthy(value: object) -> bool:
+    if isinstance(value, (list, tuple)):
+        value = value[-1] if value else ""
+    return str(value or "").strip().lower() in _TRUTHY_QUERY_VALUES
+
+
+async def _render_configured_app_surface(
+    active_app_path: Path | None,
+    cfg: dict,
+    *,
+    current_page: str | None = None,
+) -> bool:
+    entrypoint = configured_app_surface_entrypoint(active_app_path, cfg)
+    if entrypoint is None:
+        return False
+    if _is_app_surface_overview_requested(current_page):
+        return False
+    if _query_param_is_truthy(st.query_params.get(_APP_SURFACE_HIDE_QUERY_PARAM)):
+        return False
+    surface_config = app_surface_config(active_app_path, cfg)
+    await render_view_page(
+        entrypoint,
+        title=app_surface_title(surface_config),
+        back_query_params={_APP_SURFACE_HIDE_QUERY_PARAM: "true"},
+    )
+    return True
+
+
+def _render_configured_app_surface_launcher(
+    active_app_path: Path | None,
+    cfg: dict,
+    *,
+    current_page: str | None = None,
+) -> None:
+    should_show = _query_param_is_truthy(
+        st.query_params.get(_APP_SURFACE_HIDE_QUERY_PARAM)
+    ) or _is_app_surface_overview_requested(current_page)
+    if not should_show:
+        return
+    entrypoint = configured_app_surface_entrypoint(active_app_path, cfg)
+    if entrypoint is None:
+        return
+    surface_title = app_surface_title(app_surface_config(active_app_path, cfg))
+    if st.button(f"Open {surface_title}", type="primary"):
+        for key in (_APP_SURFACE_HIDE_QUERY_PARAM, "current_page"):
+            if key in st.query_params:
+                del st.query_params[key]
+        st.rerun()
+
 async def main():
     # Navigation by query param
     qp = st.query_params
@@ -2434,6 +2581,8 @@ async def main():
     pages_root = Path(env.AGILAB_PAGES_ABS)
 
     # Route: only render a child surface when the param is concrete, not "main"/empty
+    if _consume_legacy_app_ui_route_for_app_surface(current_page, active_app_path):
+        current_page = None
     if await _render_selected_notebook_route(current_notebook):
         return
     if await _render_selected_view_route(current_page):
@@ -2448,10 +2597,15 @@ async def main():
     migrated_cfg = False
     if _migrate_declared_app_ui_page_config(active_app_path, cfg):
         migrated_cfg = True
+    if _migrate_declared_app_surface_config(active_app_path, cfg):
+        migrated_cfg = True
     if _migrate_legacy_analysis_page_config(project, cfg):
         migrated_cfg = True
     if migrated_cfg:
         _write_config(app_settings, cfg)
+    if await _render_configured_app_surface(active_app_path, cfg, current_page=current_page):
+        return
+    _render_configured_app_surface_launcher(active_app_path, cfg, current_page=current_page)
     configured_views: list[str] = [
         str(v)
         for v in cfg.get("pages", {}).get("view_module", [])
@@ -2696,20 +2850,31 @@ async def render_notebook_page(notebook_path: Path):
     st.iframe(url, height=900)
 
 
-async def render_view_page(view_path: Path):
+async def render_view_page(
+    view_path: Path,
+    *,
+    title: str | None = None,
+    show_back: bool = True,
+    back_query_params: dict[str, str] | None = None,
+):
     """Render a specific view by launching it as a sidecar app in its own venv and iframing it."""
     env = st.session_state['env']
     # Hide THIS page's sidebar while a child view is displayed
     _hide_parent_sidebar()
 
-    back_col, title_col, _ = st.columns([1, 6, 1])
-    with back_col:
-        if st.button("← Back to Analysis", type="primary"):
-            st.session_state["current_page"] = "main"
-            st.query_params["current_page"] = "main"
-            st.rerun()
-    with title_col:
-        st.subheader(f"View: `{view_path.stem}`")
+    if show_back:
+        back_col, title_col, _ = st.columns([1, 6, 1])
+        with back_col:
+            if st.button("← Back to Analysis", type="primary"):
+                st.session_state["current_page"] = "main"
+                st.query_params["current_page"] = "main"
+                for key, value in (back_query_params or {}).items():
+                    st.query_params[key] = value
+                st.rerun()
+        with title_col:
+            st.subheader(title or f"View: `{view_path.stem}`")
+    else:
+        st.subheader(title or view_path.stem.replace("_", " ").title())
 
     # --- sidecar per-view run + iframe embed ---
     # Unique key for port hashing (works even if two Page share the same filename)

--- a/test/test_analysis_page_helpers.py
+++ b/test/test_analysis_page_helpers.py
@@ -483,38 +483,6 @@ def test_legacy_view_app_ui_route_opens_declared_app_surface(tmp_path: Path, mon
     assert module._APP_SURFACE_HIDE_QUERY_PARAM not in fake_st.query_params
 
 
-def test_configured_app_surface_launcher_reopens_surface(tmp_path: Path, monkeypatch):
-    module = _load_analysis_module()
-    app = tmp_path / "demo_project"
-    surface = app / "src" / "demo" / "app_surface.py"
-    surface.parent.mkdir(parents=True)
-    surface.write_text("def render(**_kwargs): pass\n", encoding="utf-8")
-
-    def _raise_rerun():
-        raise RuntimeError("rerun")
-
-    fake_st = SimpleNamespace(
-        query_params={module._APP_SURFACE_HIDE_QUERY_PARAM: "true", "current_page": "main"},
-        button=lambda *_args, **_kwargs: True,
-        rerun=_raise_rerun,
-    )
-
-    monkeypatch.setattr(module, "st", fake_st)
-
-    try:
-        module._render_configured_app_surface_launcher(
-            app,
-            {"app_surface": {"title": "Demo Surface", "entrypoint": "demo/app_surface.py"}},
-        )
-    except RuntimeError as exc:
-        assert str(exc) == "rerun"
-    else:
-        raise AssertionError("App surface launcher should rerun the Streamlit page")
-
-    assert module._APP_SURFACE_HIDE_QUERY_PARAM not in fake_st.query_params
-    assert "current_page" not in fake_st.query_params
-
-
 def test_render_notebook_page_embeds_project_jupyter_sidecar(tmp_path: Path, monkeypatch):
     module = _load_analysis_module()
     project_root = tmp_path / "apps" / "flight_telemetry_project"

--- a/test/test_analysis_page_helpers.py
+++ b/test/test_analysis_page_helpers.py
@@ -357,6 +357,164 @@ def test_render_view_page_embeds_sidecar_with_streamlit_iframe(tmp_path: Path, m
     ]
 
 
+def test_render_view_page_back_button_sets_app_surface_overview_flag(tmp_path: Path, monkeypatch):
+    module = _load_analysis_module()
+    view_path = tmp_path / "view_demo.py"
+    view_path.write_text("", encoding="utf-8")
+
+    class _Column:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+    def _raise_rerun():
+        raise RuntimeError("rerun")
+
+    fake_logger = SimpleNamespace(info=lambda *_args, **_kwargs: None, error=lambda *_args, **_kwargs: None)
+    fake_env = SimpleNamespace(
+        apps_path=None,
+        target=None,
+        app=None,
+        active_app="",
+        AGILAB_LOG_ABS=tmp_path,
+        logger=fake_logger,
+    )
+    fake_st = SimpleNamespace(
+        session_state={"env": fake_env},
+        query_params={"current_page": str(view_path)},
+        columns=lambda _spec: [_Column(), _Column(), _Column()],
+        button=lambda *_args, **_kwargs: True,
+        subheader=lambda *_args, **_kwargs: None,
+        rerun=_raise_rerun,
+    )
+
+    monkeypatch.setattr(module, "st", fake_st)
+    monkeypatch.setattr(module, "_hide_parent_sidebar", lambda: None)
+
+    try:
+        asyncio.run(
+            module.render_view_page(
+                view_path,
+                back_query_params={module._APP_SURFACE_HIDE_QUERY_PARAM: "true"},
+            )
+        )
+    except RuntimeError as exc:
+        assert str(exc) == "rerun"
+    else:
+        raise AssertionError("Back action should rerun the Streamlit page")
+
+    assert fake_st.session_state["current_page"] == "main"
+    assert fake_st.query_params["current_page"] == "main"
+    assert fake_st.query_params[module._APP_SURFACE_HIDE_QUERY_PARAM] == "true"
+
+
+def test_render_configured_app_surface_skips_when_hidden_or_overview_requested(tmp_path: Path, monkeypatch):
+    module = _load_analysis_module()
+    app = tmp_path / "demo_project"
+    surface = app / "src" / "demo" / "app_surface.py"
+    surface.parent.mkdir(parents=True)
+    surface.write_text("def render(**_kwargs): pass\n", encoding="utf-8")
+    render_calls: list[Path] = []
+
+    async def _capture_render(path: Path, **_kwargs):
+        render_calls.append(path)
+
+    fake_st = SimpleNamespace(
+        query_params={module._APP_SURFACE_HIDE_QUERY_PARAM: "true"},
+    )
+
+    monkeypatch.setattr(module, "st", fake_st)
+    monkeypatch.setattr(module, "render_view_page", _capture_render)
+
+    rendered = asyncio.run(
+        module._render_configured_app_surface(
+            app,
+            {"app_surface": {"title": "Demo Surface", "entrypoint": "demo/app_surface.py"}},
+        )
+    )
+
+    assert rendered is False
+    assert render_calls == []
+
+    fake_st.query_params = {"current_page": "main"}
+    rendered = asyncio.run(
+        module._render_configured_app_surface(
+            app,
+            {"app_surface": {"title": "Demo Surface", "entrypoint": "demo/app_surface.py"}},
+            current_page="main",
+        )
+    )
+
+    assert rendered is False
+    assert render_calls == []
+
+
+def test_legacy_view_app_ui_route_opens_declared_app_surface(tmp_path: Path, monkeypatch):
+    module = _load_analysis_module()
+    app = tmp_path / "demo_project"
+    surface = app / "src" / "demo" / "app_surface.py"
+    surface.parent.mkdir(parents=True)
+    surface.write_text("def render(**_kwargs): pass\n", encoding="utf-8")
+    (app / "src" / "app_settings.toml").write_text(
+        "\n".join(
+            [
+                "[app_surface]",
+                'title = "Demo Surface"',
+                'entrypoint = "demo/app_surface.py"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    legacy_route = tmp_path / "apps-pages" / "view_app_ui" / "src" / "view_app_ui" / "view_app_ui.py"
+    fake_st = SimpleNamespace(
+        query_params={
+            "current_page": str(legacy_route),
+            module._APP_SURFACE_HIDE_QUERY_PARAM: "true",
+        },
+    )
+
+    monkeypatch.setattr(module, "st", fake_st)
+
+    assert module._consume_legacy_app_ui_route_for_app_surface(str(legacy_route), app) is True
+    assert "current_page" not in fake_st.query_params
+    assert module._APP_SURFACE_HIDE_QUERY_PARAM not in fake_st.query_params
+
+
+def test_configured_app_surface_launcher_reopens_surface(tmp_path: Path, monkeypatch):
+    module = _load_analysis_module()
+    app = tmp_path / "demo_project"
+    surface = app / "src" / "demo" / "app_surface.py"
+    surface.parent.mkdir(parents=True)
+    surface.write_text("def render(**_kwargs): pass\n", encoding="utf-8")
+
+    def _raise_rerun():
+        raise RuntimeError("rerun")
+
+    fake_st = SimpleNamespace(
+        query_params={module._APP_SURFACE_HIDE_QUERY_PARAM: "true", "current_page": "main"},
+        button=lambda *_args, **_kwargs: True,
+        rerun=_raise_rerun,
+    )
+
+    monkeypatch.setattr(module, "st", fake_st)
+
+    try:
+        module._render_configured_app_surface_launcher(
+            app,
+            {"app_surface": {"title": "Demo Surface", "entrypoint": "demo/app_surface.py"}},
+        )
+    except RuntimeError as exc:
+        assert str(exc) == "rerun"
+    else:
+        raise AssertionError("App surface launcher should rerun the Streamlit page")
+
+    assert module._APP_SURFACE_HIDE_QUERY_PARAM not in fake_st.query_params
+    assert "current_page" not in fake_st.query_params
+
+
 def test_render_notebook_page_embeds_project_jupyter_sidecar(tmp_path: Path, monkeypatch):
     module = _load_analysis_module()
     project_root = tmp_path / "apps" / "flight_telemetry_project"
@@ -723,6 +881,48 @@ def test_migrate_declared_app_ui_page_config_honors_restricted_seed_views(tmp_pa
     assert second_changed is False
     assert cfg["pages"]["restrict_to_view_module"] is True
     assert cfg["pages"]["view_module"] == ["view_app_ui"]
+
+
+def test_migrate_declared_app_surface_config_replaces_legacy_app_ui_bridge(tmp_path: Path):
+    module = _load_analysis_module()
+    app = tmp_path / "demo_project"
+    settings = app / "src" / "app_settings.toml"
+    settings.parent.mkdir(parents=True)
+    settings.write_text(
+        "\n".join(
+            [
+                "[pages]",
+                "restrict_to_view_module = true",
+                "view_module = []",
+                "",
+                "[app_surface]",
+                'title = "Demo Surface"',
+                'entrypoint = "demo/app_surface.py"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    cfg = {
+        "pages": {
+            "view_module": ["view_app_ui", "view_training_analysis"],
+            "view_app_ui": {"entrypoint": "demo/ui.py", "title": "Demo UI"},
+        }
+    }
+
+    changed = module._migrate_declared_app_surface_config(app, cfg)
+    second_changed = module._migrate_declared_app_surface_config(app, cfg)
+
+    assert changed is True
+    assert second_changed is False
+    assert cfg["app_surface"] == {
+        "title": "Demo Surface",
+        "entrypoint": "demo/app_surface.py",
+    }
+    assert cfg["pages"] == {
+        "restrict_to_view_module": True,
+        "view_module": [],
+    }
 
 
 def test_configured_view_options_restricts_to_declared_available_views(tmp_path: Path):

--- a/test/test_analysis_page_helpers.py
+++ b/test/test_analysis_page_helpers.py
@@ -689,6 +689,42 @@ def test_migrate_declared_app_ui_page_config_adds_app_ui_once(tmp_path: Path):
     }
 
 
+def test_migrate_declared_app_ui_page_config_honors_restricted_seed_views(tmp_path: Path):
+    module = _load_analysis_module()
+    app = tmp_path / "demo_project"
+    settings = app / "src" / "app_settings.toml"
+    settings.parent.mkdir(parents=True)
+    settings.write_text(
+        "\n".join(
+            [
+                "[pages]",
+                "restrict_to_view_module = true",
+                'view_module = ["view_app_ui"]',
+                "",
+                "[pages.view_app_ui]",
+                'title = "Demo UI"',
+                'entrypoint = "demo/ui.py"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    cfg = {
+        "pages": {
+            "view_module": ["view_app_ui", "view_training_analysis"],
+            "view_app_ui": {"entrypoint": "demo/ui.py", "title": "Demo UI"},
+        }
+    }
+
+    changed = module._migrate_declared_app_ui_page_config(app, cfg)
+    second_changed = module._migrate_declared_app_ui_page_config(app, cfg)
+
+    assert changed is True
+    assert second_changed is False
+    assert cfg["pages"]["restrict_to_view_module"] is True
+    assert cfg["pages"]["view_module"] == ["view_app_ui"]
+
+
 def test_configured_view_options_restricts_to_declared_available_views(tmp_path: Path):
     module = _load_analysis_module()
     view_maps = tmp_path / "view_maps.py"

--- a/test/test_app_installer_packaging.py
+++ b/test/test_app_installer_packaging.py
@@ -347,6 +347,18 @@ def test_app_template_pre_prompts_are_generic_and_dependency_neutral() -> None:
             assert fragment not in prompt_text, f"{prompt_path.relative_to(ROOT).as_posix()} contains {fragment!r}"
 
 
+def test_builtin_app_pre_prompts_are_workflow_message_lists() -> None:
+    prompt_paths = sorted(BUILTIN_APPS_ROOT.glob("*/src/pre_prompt.json"))
+    assert prompt_paths
+
+    for prompt_path in prompt_paths:
+        payload = json.loads(prompt_path.read_text(encoding="utf-8"))
+        assert isinstance(payload, list), prompt_path.relative_to(ROOT).as_posix()
+        assert all(isinstance(item, dict) for item in payload), prompt_path.relative_to(ROOT).as_posix()
+        assert all(isinstance(item.get("role"), str) for item in payload), prompt_path.relative_to(ROOT).as_posix()
+        assert all(isinstance(item.get("content"), str) for item in payload), prompt_path.relative_to(ROOT).as_posix()
+
+
 def test_packaged_app_source_assets_are_tracked_or_git_visible() -> None:
     tracked = _git_paths("ls-files")
     visible_untracked = _git_paths("ls-files", "--others", "--exclude-standard")

--- a/test/test_app_surface.py
+++ b/test/test_app_surface.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+MODULE_PATH = Path("src/agilab/app_surface.py")
+
+
+def _load_app_surface_module():
+    spec = importlib.util.spec_from_file_location("agilab_app_surface_tests", MODULE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_app_surface_project(tmp_path: Path) -> Path:
+    app = tmp_path / "demo_project"
+    surface = app / "src" / "demo" / "app_surface.py"
+    surface.parent.mkdir(parents=True)
+    (app / "src" / "app_settings.toml").write_text(
+        "\n".join(
+            [
+                "[app_surface]",
+                'title = "Demo Surface"',
+                'entrypoint = "demo/app_surface.py"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    surface.write_text(
+        "\n".join(
+            [
+                "def render(*, mode, active_app, env=None, container=None, streamlit=None):",
+                "    container.append({",
+                "        'mode': mode,",
+                "        'active_app': active_app.name,",
+                "        'env_app': getattr(env, 'app', None),",
+                "    })",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return app
+
+
+def test_app_surface_resolves_project_local_entrypoint(tmp_path: Path) -> None:
+    module = _load_app_surface_module()
+    app = _write_app_surface_project(tmp_path)
+
+    assert module.app_surface_config(app) == {
+        "title": "Demo Surface",
+        "entrypoint": "demo/app_surface.py",
+    }
+    assert module.configured_app_surface_entrypoint(app) == app / "src" / "demo" / "app_surface.py"
+
+
+def test_render_app_surface_calls_project_render_hook_and_restores_argv(tmp_path: Path) -> None:
+    module = _load_app_surface_module()
+    app = _write_app_surface_project(tmp_path)
+    events: list[dict[str, object]] = []
+    before_argv = list(sys.argv)
+
+    rendered = module.render_app_surface(
+        app,
+        mode="configure",
+        env=SimpleNamespace(app="demo_project"),
+        container=events,
+    )
+
+    assert rendered is True
+    assert events == [
+        {
+            "mode": "configure",
+            "active_app": "demo_project",
+            "env_app": "demo_project",
+        }
+    ]
+    assert sys.argv == before_argv

--- a/test/test_orchestrate_page_helpers.py
+++ b/test/test_orchestrate_page_helpers.py
@@ -1909,6 +1909,16 @@ def test_benchmark_display_date_uses_mtime_fallback(tmp_path: Path, monkeypatch)
     assert date_value == module.datetime.fromtimestamp(0).strftime("%Y-%m-%d %H:%M:%S")
 
 
+def test_execution_mode_options_hide_serve_when_app_disables_service_mode(monkeypatch):
+    module = _load_orchestrate_module()
+
+    monkeypatch.setattr(module, "supports_service_mode", lambda _env: False)
+    assert module._execution_mode_options(SimpleNamespace(app="pytorch_playground_project")) == ("Run now",)
+
+    monkeypatch.setattr(module, "supports_service_mode", lambda _env: True)
+    assert module._execution_mode_options(SimpleNamespace(app="flight_telemetry_project")) == ("Run now", "Serve")
+
+
 def test_benchmark_display_date_returns_empty_string_when_stat_fails(tmp_path: Path, monkeypatch):
     module = _load_orchestrate_module()
     benchmark = tmp_path / "benchmark.json"

--- a/test/test_orchestrate_page_support.py
+++ b/test/test_orchestrate_page_support.py
@@ -168,7 +168,10 @@ def test_supports_distribution_preview_requires_worker_runtime(tmp_path: Path):
     hidden_preview_app = tmp_path / "apps" / "pytorch_playground_project"
     hidden_preview_app.mkdir(parents=True)
     (hidden_preview_app / "pyproject.toml").write_text(
-        "[project]\nname='pytorch-playground-project'\n\n[tool.agilab.app]\ndistribution_preview=false\n",
+        (
+            "[project]\nname='pytorch-playground-project'\n\n"
+            "[tool.agilab.app]\ndistribution_preview=false\nservice_mode=false\n"
+        ),
         encoding="utf-8",
     )
 
@@ -197,6 +200,8 @@ def test_supports_distribution_preview_requires_worker_runtime(tmp_path: Path):
     assert not orchestrate_page_support.supports_distribution_preview(
         SimpleNamespace(active_app=hidden_preview_app, base_worker_cls="PandasWorker")
     )
+    assert not orchestrate_page_support.supports_service_mode(SimpleNamespace(active_app=hidden_preview_app))
+    assert orchestrate_page_support.supports_service_mode(SimpleNamespace(active_app=workerless_app))
 
 
 def test_workerless_snippets_use_manager_only_contract(tmp_path: Path):
@@ -259,11 +264,13 @@ def test_workerless_contract_helpers_cover_path_and_metadata_edges(
     (invalid_app / "pyproject.toml").write_text("[tool.agilab.app\n", encoding="utf-8")
     assert orchestrate_page_support.app_declares_workerless(invalid_app) is False
     assert orchestrate_page_support.app_distribution_preview_enabled(invalid_app) is True
+    assert orchestrate_page_support.supports_service_mode(invalid_app) is True
 
     app_without_contract = tmp_path / "no_contract_project"
     app_without_contract.mkdir()
     (app_without_contract / "pyproject.toml").write_text("[tool]\nagilab = []\n", encoding="utf-8")
     assert orchestrate_page_support.app_declares_workerless(app_without_contract) is False
+    assert orchestrate_page_support.supports_service_mode(app_without_contract) is True
 
     worker_path = tmp_path / "apps" / "demo_project" / "src" / "demo_worker" / "demo_worker.py"
     target_candidate = tmp_path / "apps" / "target_project" / "src" / "target_worker" / "target_worker.py"

--- a/test/test_pytorch_playground_app.py
+++ b/test/test_pytorch_playground_app.py
@@ -1006,7 +1006,9 @@ def test_pytorch_playground_hides_distribution_preview_by_contract() -> None:
     payload_pyproject = tomllib.loads((PACKAGE_PROJECT_PATH / "pyproject.toml").read_text(encoding="utf-8"))
 
     assert source_pyproject["tool"]["agilab"]["app"]["distribution_preview"] is False
+    assert source_pyproject["tool"]["agilab"]["app"]["service_mode"] is False
     assert payload_pyproject["tool"]["agilab"]["app"]["distribution_preview"] is False
+    assert payload_pyproject["tool"]["agilab"]["app"]["service_mode"] is False
 
 
 def test_pytorch_playground_app_args_form_uses_project_scoped_static_json() -> None:

--- a/test/test_pytorch_playground_app.py
+++ b/test/test_pytorch_playground_app.py
@@ -6,6 +6,7 @@ import importlib.util
 import json
 from pathlib import Path
 import sys
+from types import ModuleType
 from types import SimpleNamespace
 import zipfile
 
@@ -16,6 +17,9 @@ import pytest
 
 MODULE_PATH = Path(
     "src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/playground_ui.py"
+)
+APP_SURFACE_PATH = Path(
+    "src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/app_surface.py"
 )
 INIT_PATH = Path("src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/__init__.py")
 README_PATH = Path("src/agilab/lib/agi-app-pytorch-playground/README.md")
@@ -72,6 +76,86 @@ def test_playground_ui_import_prefers_package_when_streamlit_puts_script_dir_fir
             if name == "pytorch_playground" or name.startswith("pytorch_playground."):
                 sys.modules.pop(name, None)
         sys.modules.update(original_modules)
+
+
+def test_app_surface_import_prefers_package_when_streamlit_puts_script_dir_first(monkeypatch):
+    script_dir = APP_SURFACE_PATH.resolve().parent
+    project_src = PROJECT_SRC.resolve()
+    original_modules = {
+        name: module
+        for name, module in sys.modules.items()
+        if name == "pytorch_playground" or name.startswith("pytorch_playground.")
+    }
+    for name in original_modules:
+        sys.modules.pop(name, None)
+
+    fake_path = [
+        str(script_dir),
+        str(project_src),
+        *[
+            entry
+            for entry in sys.path
+            if entry not in {str(script_dir), str(project_src)}
+        ],
+    ]
+    monkeypatch.setattr(sys, "path", fake_path)
+
+    spec = importlib.util.spec_from_file_location("pytorch_playground_app_surface_path_order_test", APP_SURFACE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    try:
+        spec.loader.exec_module(module)
+        imported_package = importlib.import_module("pytorch_playground")
+        assert sys.path[0] == str(project_src)
+        assert Path(imported_package.__file__).name == "__init__.py"
+    finally:
+        sys.modules.pop(spec.name, None)
+        for name in list(sys.modules):
+            if name == "pytorch_playground" or name.startswith("pytorch_playground."):
+                sys.modules.pop(name, None)
+        sys.modules.update(original_modules)
+
+
+def test_app_surface_analysis_uses_orchestrate_args(monkeypatch):
+    spec = importlib.util.spec_from_file_location("pytorch_playground_app_surface_analysis_test", APP_SURFACE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+
+    calls: list[dict[str, object]] = []
+    fake_config = SimpleNamespace(dataset="circles")
+    fake_args = SimpleNamespace(
+        compute_loss_landscape=True,
+        landscape_resolution=17,
+        landscape_span=0.4,
+    )
+    fake_app_args = SimpleNamespace(to_playground_config=lambda args: fake_config)
+    fake_playground_ui = SimpleNamespace(main=lambda **kwargs: calls.append(kwargs))
+    fake_package = ModuleType("pytorch_playground")
+    fake_package.app_args = fake_app_args
+    fake_package.playground_ui = fake_playground_ui
+
+    monkeypatch.setitem(sys.modules, "pytorch_playground", fake_package)
+    monkeypatch.setattr(module, "_resolve_active_app_path", lambda _active_app=None: PROJECT_PATH.resolve())
+    monkeypatch.setattr(module, "_load_orchestrate_args", lambda _active_app_path: (SimpleNamespace(), fake_args))
+
+    try:
+        module.render(mode="analysis")
+    finally:
+        sys.modules.pop(spec.name, None)
+
+    assert calls == [
+        {
+            "config_override": fake_config,
+            "preset_label": "ORCHESTRATE args",
+            "interactive_controls": False,
+            "compute_loss_landscape": True,
+            "landscape_resolution": 17,
+            "landscape_span": 0.4,
+        }
+    ]
 
 
 def test_cached_train_uses_isolated_subprocess_in_streamlit_context() -> None:
@@ -910,9 +994,9 @@ def test_pytorch_playground_app_settings_default_to_single_worker() -> None:
 
     assert settings["cluster"]["workers"] == {"127.0.0.1": 1}
     assert settings["pages"]["restrict_to_view_module"] is True
-    assert settings["pages"]["view_module"] == ["view_app_ui"]
-    assert settings["pages"]["view_app_ui"]["entrypoint"] == "pytorch_playground/playground_ui.py"
-    assert settings["pages"]["view_app_ui"]["title"] == "PyTorch Playground"
+    assert settings["pages"]["view_module"] == []
+    assert settings["app_surface"]["entrypoint"] == "pytorch_playground/app_surface.py"
+    assert settings["app_surface"]["title"] == "PyTorch Playground"
 
 
 def test_pytorch_playground_hides_distribution_preview_by_contract() -> None:
@@ -934,6 +1018,9 @@ def test_pytorch_playground_app_args_form_uses_project_scoped_static_json() -> N
     assert "key=key" in source
     assert "st.json(" not in source
     assert ".multiselect(" not in source
+    assert "def _render_wide_args_form" in source
+    assert ".columns(" in source
+    assert "Loss landscape" in source
 
 
 def test_pytorch_playground_source_and_packaged_payload_stay_aligned() -> None:

--- a/test/test_pytorch_playground_app.py
+++ b/test/test_pytorch_playground_app.py
@@ -909,6 +909,7 @@ def test_pytorch_playground_app_settings_default_to_single_worker() -> None:
     settings = tomllib.loads((PROJECT_PATH / "src" / "app_settings.toml").read_text(encoding="utf-8"))
 
     assert settings["cluster"]["workers"] == {"127.0.0.1": 1}
+    assert settings["pages"]["restrict_to_view_module"] is True
     assert settings["pages"]["view_module"] == ["view_app_ui"]
     assert settings["pages"]["view_app_ui"]["entrypoint"] == "pytorch_playground/playground_ui.py"
     assert settings["pages"]["view_app_ui"]["title"] == "PyTorch Playground"

--- a/test/test_pytorch_playground_app.py
+++ b/test/test_pytorch_playground_app.py
@@ -136,10 +136,13 @@ def test_app_surface_analysis_uses_orchestrate_args(monkeypatch):
     fake_package = ModuleType("pytorch_playground")
     fake_package.app_args = fake_app_args
     fake_package.playground_ui = fake_playground_ui
+    evidence_dirs = [PROJECT_PATH.resolve() / "evidence"]
 
     monkeypatch.setitem(sys.modules, "pytorch_playground", fake_package)
     monkeypatch.setattr(module, "_resolve_active_app_path", lambda _active_app=None: PROJECT_PATH.resolve())
     monkeypatch.setattr(module, "_load_orchestrate_args", lambda _active_app_path: (SimpleNamespace(), fake_args))
+    monkeypatch.setattr(module, "_analysis_evidence_dirs", lambda _env, _args, _path: evidence_dirs)
+    monkeypatch.setattr(module, "_has_evidence", lambda paths: paths == evidence_dirs)
 
     try:
         module.render(mode="analysis")
@@ -154,8 +157,48 @@ def test_app_surface_analysis_uses_orchestrate_args(monkeypatch):
             "compute_loss_landscape": True,
             "landscape_resolution": 17,
             "landscape_span": 0.4,
+            "evidence_dirs": evidence_dirs,
         }
     ]
+
+
+def test_app_surface_analysis_no_evidence_avoids_playground_import(monkeypatch, tmp_path: Path):
+    spec = importlib.util.spec_from_file_location("pytorch_playground_app_surface_no_evidence_test", APP_SURFACE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+
+    evidence_dirs = [tmp_path / "missing-evidence"]
+    rendered: list[list[Path]] = []
+
+    fake_package = ModuleType("pytorch_playground")
+
+    def fail_on_import(_name: str):
+        raise AssertionError("playground_ui should not be imported before evidence exists")
+
+    fake_package.__getattr__ = fail_on_import  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(sys.modules, "pytorch_playground", fake_package)
+    monkeypatch.setattr(module, "_resolve_active_app_path", lambda _active_app=None: PROJECT_PATH.resolve())
+    monkeypatch.setattr(
+        module,
+        "_load_orchestrate_args",
+        lambda _active_app_path: (
+            SimpleNamespace(AGILAB_EXPORT_ABS=tmp_path / "export", target="pytorch_playground_project"),
+            SimpleNamespace(data_out=tmp_path / "evidence"),
+        ),
+    )
+    monkeypatch.setattr(module, "_analysis_evidence_dirs", lambda _env, _args, _path: evidence_dirs)
+    monkeypatch.setattr(module, "_has_evidence", lambda _paths: False)
+    monkeypatch.setattr(module, "_render_missing_evidence", lambda paths: rendered.append(list(paths)))
+
+    try:
+        module.render(mode="analysis")
+    finally:
+        sys.modules.pop(spec.name, None)
+
+    assert rendered == [evidence_dirs]
 
 
 def test_cached_train_uses_isolated_subprocess_in_streamlit_context() -> None:
@@ -533,6 +576,77 @@ def test_pytorch_playground_config_and_dataset_helper_edges(monkeypatch: pytest.
     np.testing.assert_allclose(ndarray_features, np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float32))
 
 
+def _minimal_playground_result(module, config) -> dict[str, object]:
+    samples = module._make_dataset(config)
+    history = pd.DataFrame(
+        {
+            "epoch": [0],
+            "train_loss": [0.5],
+            "validation_loss": [0.6],
+            "train_accuracy": [0.75],
+            "validation_accuracy": [0.7],
+        }
+    )
+    grid = pd.DataFrame(
+        {
+            "x1": [-1.0, 1.0, -1.0, 1.0],
+            "x2": [-1.0, -1.0, 1.0, 1.0],
+            "probability": [0.1, 0.9, 0.2, 0.8],
+        }
+    )
+    loss_landscape = pd.DataFrame(
+        [
+            {
+                "alpha": -0.2,
+                "beta": -0.2,
+                "train_loss": 0.62,
+                "validation_loss": 0.68,
+                "train_accuracy": 0.65,
+                "validation_accuracy": 0.6,
+                "is_center": False,
+            },
+            {
+                "alpha": 0.0,
+                "beta": 0.0,
+                "train_loss": 0.5,
+                "validation_loss": 0.55,
+                "train_accuracy": 0.75,
+                "validation_accuracy": 0.7,
+                "is_center": True,
+            },
+        ],
+        columns=module._empty_loss_landscape().columns,
+    )
+    return {
+        "status": "ok",
+        "detail": "",
+        "samples": samples,
+        "history": history,
+        "grid": grid,
+        "network_layers": module._empty_network_layers(),
+        "activation_maps": module._empty_activation_maps(),
+        "loss_landscape": loss_landscape,
+        "landscape_summary": module._loss_landscape_summary(loss_landscape),
+        "summary": {
+            "backend": "persisted",
+            "samples": int(len(samples)),
+            "features": int(len(config.feature_names)),
+            "train_accuracy": 0.75,
+            "validation_accuracy": 0.7,
+            "validation_loss": 0.55,
+        },
+    }
+
+
+def _write_playground_evidence_dir(module, root: Path, config, result: dict[str, object]) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    for relative_path, payload in module._evidence_artifact_files(config, result).items():
+        target = root / relative_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(payload)
+    (root / "manifest.json").write_bytes(module._json_bytes(module._build_evidence_manifest(config, result)))
+
+
 def test_pytorch_playground_evidence_pack_is_deterministic(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -600,6 +714,138 @@ def test_pytorch_playground_evidence_pack_is_deterministic(
     assert manifest["landscape_summary"]["center_validation_loss"] == pytest.approx(0.6)
     assert manifest["artifacts"]["data/samples.csv"]["sha256"] == hashlib.sha256(sample_bytes).hexdigest()
     assert manifest["artifacts"]["model/loss_landscape.csv"]["sha256"] == hashlib.sha256(landscape_bytes).hexdigest()
+
+
+def test_pytorch_playground_loads_latest_evidence_result(tmp_path: Path) -> None:
+    module = _load_module()
+    old_config = module.PlaygroundConfig(dataset="circles", sample_count=64, grid_size=12, seed=3)
+    latest_config = module.PlaygroundConfig(dataset="spiral", sample_count=96, grid_size=16, seed=7)
+    old_dir = tmp_path / "old"
+    latest_dir = tmp_path / "latest"
+
+    _write_playground_evidence_dir(module, old_dir, old_config, _minimal_playground_result(module, old_config))
+    _write_playground_evidence_dir(
+        module,
+        latest_dir,
+        latest_config,
+        _minimal_playground_result(module, latest_config),
+    )
+    module.os.utime(old_dir / "manifest.json", (1, 1))
+    module.os.utime(latest_dir / "manifest.json", (2, 2))
+
+    loaded = module._load_latest_evidence_result([old_dir, latest_dir])
+
+    assert loaded is not None
+    config, result, evidence_root = loaded
+    assert evidence_root == latest_dir
+    assert config.dataset == "spiral"
+    assert config.sample_count == 96
+    assert result["status"] == "ok"
+    assert result["summary"]["backend"] == "persisted"
+    assert len(result["samples"]) == 96
+    assert len(result["loss_landscape"]) == 2
+
+
+def test_pytorch_playground_analysis_uses_evidence_without_training(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    module = _load_module()
+
+    class FakeContext:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc):
+            return False
+
+        def metric(self, *_args, **_kwargs):
+            return None
+
+    class FakeStreamlit:
+        def __init__(self):
+            self.query_params = {}
+            self.session_state: dict[str, object] = {}
+            self.sidebar = FakeContext()
+            self.captions: list[str] = []
+            self.downloads: list[bytes] = []
+            self.code_payloads: list[tuple[str, str | None]] = []
+
+        def set_page_config(self, **_kwargs):
+            return None
+
+        def title(self, *_args, **_kwargs):
+            return None
+
+        def caption(self, message, **_kwargs):
+            self.captions.append(str(message))
+
+        def markdown(self, *_args, **_kwargs):
+            return None
+
+        def error(self, *_args, **_kwargs):
+            return None
+
+        def warning(self, *_args, **_kwargs):
+            return None
+
+        def info(self, *_args, **_kwargs):
+            return None
+
+        def columns(self, spec):
+            count = spec if isinstance(spec, int) else len(spec)
+            return [FakeContext() for _ in range(count)]
+
+        def tabs(self, labels):
+            return [FakeContext() for _ in labels]
+
+        def plotly_chart(self, *_args, **_kwargs):
+            return None
+
+        def dataframe(self, *_args, **_kwargs):
+            return None
+
+        def metric(self, *_args, **_kwargs):
+            return None
+
+        def download_button(self, _label, data, **_kwargs):
+            self.downloads.append(data)
+            return False
+
+        def code(self, body, **kwargs):
+            self.code_payloads.append((str(body), kwargs.get("language")))
+            return None
+
+    evidence_dir = tmp_path / "evidence"
+    config = module.PlaygroundConfig(dataset="spiral", sample_count=64, grid_size=12, seed=21)
+    _write_playground_evidence_dir(module, evidence_dir, config, _minimal_playground_result(module, config))
+
+    fake_st = FakeStreamlit()
+    monkeypatch.setattr(module, "st", fake_st)
+    monkeypatch.setattr(module, "render_logo", lambda: None)
+    monkeypatch.setattr(module, "_resolve_active_app", lambda: PROJECT_PATH.resolve())
+    monkeypatch.setattr(
+        module,
+        "_cached_train",
+        lambda _payload: (_ for _ in ()).throw(AssertionError("analysis must not train on render")),
+    )
+    monkeypatch.setattr(
+        module,
+        "_cached_loss_landscape",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("analysis must not compute landscape on render")),
+    )
+
+    module.main(
+        interactive_controls=False,
+        compute_loss_landscape=True,
+        evidence_dirs=[evidence_dir],
+    )
+
+    assert any(str(evidence_dir) in caption for caption in fake_st.captions)
+    assert fake_st.downloads
+    manifest = next(json.loads(body) for body, language in fake_st.code_payloads if language == "json")
+    assert manifest["backend"] == "persisted"
+    assert manifest["row_counts"]["samples"] == 64
 
 
 def test_pytorch_playground_loss_landscape_summary_marks_center_and_best() -> None:

--- a/test/test_view_training_analysis.py
+++ b/test/test_view_training_analysis.py
@@ -232,6 +232,16 @@ def test_view_training_analysis_builds_one_trace_per_run_and_metric() -> None:
     assert colors_by_run["routing_2"] != colors_by_run["routing_20"]
     assert colors_by_run["routing_12"] != colors_by_run["routing_20"]
 
+    embedded_fig = module._build_scalar_figure(
+        scalar_df,
+        ["rollout/ep_rew_mean", "train/approx_kl"],
+        "step",
+        embed_mode=True,
+    )
+    assert embedded_fig.layout.autosize is True
+    assert embedded_fig.layout.height > fig.layout.height
+    assert embedded_fig.layout.legend.orientation == "h"
+
 
 def test_view_training_analysis_normalizes_page_settings_and_paths(tmp_path: Path) -> None:
     module = _load_module()
@@ -245,10 +255,26 @@ def test_view_training_analysis_normalizes_page_settings_and_paths(tmp_path: Pat
 
     share_dir = tmp_path / "share"
     export_dir = tmp_path / "export"
-    env = SimpleNamespace(share_root_path=lambda: str(share_dir), AGILAB_EXPORT_ABS=str(export_dir))
+    export_target = export_dir / "pytorch_playground"
+    export_target.mkdir(parents=True)
+    env = SimpleNamespace(
+        app="pytorch_playground_project",
+        target="pytorch_playground",
+        share_root_path=lambda: str(share_dir),
+        AGILAB_EXPORT_ABS=str(export_dir),
+    )
     assert module._resolve_base_path(env, "AGI_CLUSTER_SHARE", "").resolve() == share_dir.resolve()
     assert module._resolve_base_path(env, "AGILAB_EXPORT", "").resolve() == export_dir.resolve()
     assert module._resolve_base_path(env, "CUSTOM", "~/custom-root") == Path("~/custom-root").expanduser()
+    assert module._query_param_value({"embed": ["true"]}, "embed") == "true"
+    assert module._is_embed_mode({"embed": "true"})
+    assert not module._is_embed_mode({"embed": "false"})
+    assert (
+        module._embedded_default_data_subpath(env, "AGILAB_EXPORT", "", embed_mode=True)
+        == "pytorch_playground"
+    )
+    assert module._embedded_default_data_subpath(env, "AGILAB_EXPORT", "manual", embed_mode=True) == "manual"
+    assert module._embedded_default_data_subpath(env, "AGILAB_EXPORT", "", embed_mode=False) == ""
 
     assert module._relative_label(tmp_path / "base" / "child", tmp_path / "base") == "child"
     assert module._relative_label(tmp_path / "outside", tmp_path / "base") == "outside"
@@ -684,7 +710,11 @@ def test_view_training_analysis_main_plots_selected_metrics(monkeypatch, tmp_pat
         )
 
     monkeypatch.setattr(module, "_load_scalar_frame", fake_load_scalar_frame)
-    monkeypatch.setattr(module, "_build_scalar_figure", lambda df, tags, axis: {"tags": tags, "axis": axis, "rows": len(df)})
+    monkeypatch.setattr(
+        module,
+        "_build_scalar_figure",
+        lambda df, tags, axis, **_kwargs: {"tags": tags, "axis": axis, "rows": len(df)},
+    )
 
     module.main()
 
@@ -695,6 +725,115 @@ def test_view_training_analysis_main_plots_selected_metrics(monkeypatch, tmp_pat
     assert "trainer_rels = [" in written
     assert "selected_tags = [" in written
     assert "\"metric/a\"" in written
+
+
+def test_view_training_analysis_embedded_mode_autoscales_export_target(monkeypatch, tmp_path: Path) -> None:
+    module = _load_module()
+    export_root = tmp_path / "export"
+    target_root = export_root / "pytorch_playground"
+    trainer_dir = target_root / "pytorch_playground"
+    run_file = trainer_dir / "data" / "training_history.csv"
+    run_file.parent.mkdir(parents=True)
+    settings_path = tmp_path / "app_settings.toml"
+    env = SimpleNamespace(
+        app="pytorch_playground_project",
+        target="pytorch_playground",
+        app_settings_file=settings_path,
+        share_root_path=lambda: str(tmp_path / "share"),
+        AGILAB_EXPORT_ABS=str(export_root),
+    )
+    page_configs: list[dict] = []
+    markdown_calls: list[tuple[str, bool]] = []
+    captions: list[str] = []
+    plotted: list[tuple[object, str]] = []
+    discovered_roots: list[Path] = []
+
+    def sidebar_selectbox(label, options, index=0, key=None, format_func=None):
+        if label == "X axis":
+            return "step"
+        return options[index]
+
+    def sidebar_multiselect(label, options, default=None, key=None):
+        if label == "Trainer outputs":
+            return list(options)
+        if label == "TensorBoard run folders":
+            return list(options)
+        if label == "TensorBoard variables":
+            return ["train_loss"]
+        return list(default or [])
+
+    module.st = SimpleNamespace(
+        query_params={"embed": "true", "active_app": "pytorch_playground_project"},
+        session_state={"env": env},
+        sidebar=SimpleNamespace(
+            radio=lambda *args, **kwargs: "AGILAB_EXPORT",
+            text_input=lambda *args, **kwargs: None,
+            caption=lambda *args, **kwargs: None,
+            selectbox=sidebar_selectbox,
+            multiselect=sidebar_multiselect,
+        ),
+        set_page_config=lambda **kwargs: page_configs.append(kwargs),
+        markdown=lambda body, unsafe_allow_html=False: markdown_calls.append((body, unsafe_allow_html)),
+        title=lambda *args, **kwargs: None,
+        caption=captions.append,
+        warning=lambda *args, **kwargs: None,
+        info=lambda *args, **kwargs: None,
+        error=lambda *args, **kwargs: None,
+        subheader=lambda *args, **kwargs: None,
+        plotly_chart=lambda fig, width=None: plotted.append((fig, width)),
+        stop=_stop,
+    )
+    monkeypatch.setattr(
+        module,
+        "render_logo",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("logo is hidden in embed mode")),
+    )
+
+    def fake_discover_training_roots(data_root: Path) -> list[Path]:
+        discovered_roots.append(data_root)
+        return [trainer_dir]
+
+    monkeypatch.setattr(module, "_discover_training_roots", fake_discover_training_roots)
+    monkeypatch.setattr(module, "_discover_run_labels", lambda trainers, data_root: {"training_history": run_file})
+    monkeypatch.setattr(
+        module,
+        "_load_scalar_frame",
+        lambda *_args, **_kwargs: pd.DataFrame(
+            {
+                "tag": ["train_loss", "train_loss"],
+                "step": [1, 2],
+                "wall_time": [10.0, 11.0],
+                "relative_time_s": [0.0, 1.0],
+                "timestamp": pd.to_datetime([10.0, 11.0], unit="s"),
+                "value": [0.8, 0.4],
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        module,
+        "_build_scalar_figure",
+        lambda df, tags, axis, *, embed_mode=False: {
+            "tags": tags,
+            "axis": axis,
+            "rows": len(df),
+            "embed_mode": embed_mode,
+        },
+    )
+
+    module.main()
+
+    assert page_configs == [{"layout": "wide", "initial_sidebar_state": "collapsed"}]
+    assert markdown_calls and markdown_calls[0][1] is True
+    assert captions == ["Training analysis"]
+    assert discovered_roots == [target_root.resolve()]
+    assert module.st.session_state["base_dir_choice"] == "AGILAB_EXPORT"
+    assert module.st.session_state["datadir_rel"] == "pytorch_playground"
+    assert plotted == [
+        (
+            {"tags": ["train_loss"], "axis": "step", "rows": 2, "embed_mode": True},
+            "stretch",
+        )
+    ]
 
 
 def test_view_training_analysis_handles_active_app_and_settings_error_paths(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add a generic app-surface contract for app-owned ANALYSIS experiences
- route PyTorch Playground ANALYSIS through persisted ORCHESTRATE args instead of duplicate sidebar controls
- migrate stale view_app_ui routes/back navigation and fix pre_prompt message-list schemas
- keep packaged PyTorch/Mission payloads aligned and update focused regressions

## Validation
- uv --preview-features extra-build-dependencies run python -m py_compile src/agilab/pages/4_ANALYSIS.py src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/app_surface.py src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/playground_ui.py
- uv --preview-features extra-build-dependencies run --extra ui pytest -q -o addopts='' test/test_pytorch_playground_app.py test/test_app_surface.py test/test_view_app_ui.py
- uv --preview-features extra-build-dependencies run --extra ui pytest -q -o addopts='' test/test_analysis_page_helpers.py
- git diff --check