### PR TITLE
Document non-mutating Streamlit launches in runbook skill

### DIFF
--- a/.claude/skills/agilab-pypi-release-maintenance/SKILL.md
+++ b/.claude/skills/agilab-pypi-release-maintenance/SKILL.md
@@ -199,7 +199,10 @@ weakening the protected-release check.
 When retention cleanup runs from GitHub Actions against many split packages:
 
 - PyPI may require an unrecognized-login confirmation URL from the same runner
-  IP before direct web fallback can delete releases.
+  IP before direct web fallback can delete releases. The workflow expects that
+  URL in the repository Actions variable `PYPI_CONFIRM_LOGIN_URL`; if the
+  variable is absent or stale, the cleanup will wait for the configured timeout
+  and then fail without deleting anything.
 - `pypi-cleanup` can fail to parse PyPI's release delete form with `No CSFR`
   / `No CSRF`; the direct web fallback is the intended recovery route.
 - When PyPI 2FA uses TOTP, do not reuse the same generated code across package
@@ -211,6 +214,57 @@ When retention cleanup runs from GitHub Actions against many split packages:
 - Remove temporary confirmation handoff variables or short-lived reader tokens
   after the run. Keep only the normal release-prune credentials that are part
   of the repository maintenance contract.
+
+## Deprecated Package Cleanup
+
+Use this when a stale PyPI project remains visible after a package rename or
+package-split cleanup, for example an old page package whose source path no
+longer exists in the current repository.
+
+First prove the package is really deprecated:
+
+- check the current release plan and package split contract;
+- verify the PyPI project metadata live, especially `project_urls.Source`;
+- confirm the source path referenced by PyPI no longer exists or is no longer a
+  publish target;
+- identify the replacement package name, if any.
+
+Do not confuse a deprecated package with a package that is expected but missing
+from PyPI. For example, if the release plan expects `agi-app-...` but PyPI
+returns 404 for it, that package needs publication, not deletion.
+
+Current-matrix cleanup wrappers such as `tools/pypi_publish.py --packages ...`
+only accept packages that still belong to the current release plan. If the stale
+PyPI project is no longer in the matrix, use `tools/pypi_release_retention.py`
+or `pypi-cleanup` directly against the exact legacy PyPI project name.
+
+For a stale package with several releases, prefer this sequence:
+
+1. Query the exact visible releases from live PyPI JSON.
+2. Run a `pypi-cleanup --query-only` dry-run with exact version regexes.
+3. Delete older releases one exact version at a time, protecting the latest
+   temporarily if using the retention workflow.
+4. Verify live PyPI JSON after every successful deletion.
+
+Deleting the final remaining release is effectively PyPI project removal. Treat
+that as a separate owner action: do not use `--delete-project` from automation
+unless the operator explicitly confirms the package name, understands that the
+project reservation may be affected, and has valid PyPI web credentials.
+
+If cleanup is blocked:
+
+- local `pypi-cleanup` login failure means local web credentials are invalid or
+  PyPI is rejecting that device/session;
+- GitHub Actions failure after `No CSFR` / `No CSRF` plus a login redirect means
+  PyPI likely needs an unrecognized-login confirmation URL;
+- fetch the URL from the PyPI email, then set it for the next retry:
+
+```bash
+gh variable set PYPI_CONFIRM_LOGIN_URL --repo ThalesGroup/agilab --body '<pypi-confirm-login-url>'
+```
+
+After the workflow consumes the URL, remove or rotate the variable so future
+cleanup runs do not reuse an expired confirmation link.
 
 ## Publication Reuse Behavior
 

--- a/.claude/skills/agilab-runbook/SKILL.md
+++ b/.claude/skills/agilab-runbook/SKILL.md
@@ -45,6 +45,14 @@ Use this skill when you need repo-specific “how we do things” guidance in `a
   `~/.agilab/.env` keys such as `APPS_PATH` and `IS_SOURCE_ENV`. Restart Streamlit after
   fixing bootstrap code because `st.session_state["env"]` and `env.active_app` can retain
   stale paths across reruns.
+- **Source Streamlit launches must be non-mutating by default**: if starting
+  `agilab run (dev)` prints `Uninstalled ...` or `Installed ...`, inspect both
+  the outer run-config command and any launcher-spawned inner `uv run` command.
+  The selected default app is not the cause; uv is reconciling the project
+  environment or the `ui` extra. Runtime launchers should preserve `UV_NO_SYNC`
+  and use `uv run --no-sync` for the inner Streamlit command. Do dependency
+  bootstrap explicitly with `uv sync --extra ui` or a clearly named sync flag
+  before launch, not silently during normal UI startup.
 - **PyPI app management**: promoted public apps can be managed through the PROJECT page
   `Install PyPI app` flow or `agilab app search/check/install/list/update/remove`.
   This route installs `agi-app-*` packages into the selected Python environment and

--- a/.codex/skills/agilab-pypi-release-maintenance/SKILL.md
+++ b/.codex/skills/agilab-pypi-release-maintenance/SKILL.md
@@ -199,7 +199,10 @@ weakening the protected-release check.
 When retention cleanup runs from GitHub Actions against many split packages:
 
 - PyPI may require an unrecognized-login confirmation URL from the same runner
-  IP before direct web fallback can delete releases.
+  IP before direct web fallback can delete releases. The workflow expects that
+  URL in the repository Actions variable `PYPI_CONFIRM_LOGIN_URL`; if the
+  variable is absent or stale, the cleanup will wait for the configured timeout
+  and then fail without deleting anything.
 - `pypi-cleanup` can fail to parse PyPI's release delete form with `No CSFR`
   / `No CSRF`; the direct web fallback is the intended recovery route.
 - When PyPI 2FA uses TOTP, do not reuse the same generated code across package
@@ -211,6 +214,57 @@ When retention cleanup runs from GitHub Actions against many split packages:
 - Remove temporary confirmation handoff variables or short-lived reader tokens
   after the run. Keep only the normal release-prune credentials that are part
   of the repository maintenance contract.
+
+## Deprecated Package Cleanup
+
+Use this when a stale PyPI project remains visible after a package rename or
+package-split cleanup, for example an old page package whose source path no
+longer exists in the current repository.
+
+First prove the package is really deprecated:
+
+- check the current release plan and package split contract;
+- verify the PyPI project metadata live, especially `project_urls.Source`;
+- confirm the source path referenced by PyPI no longer exists or is no longer a
+  publish target;
+- identify the replacement package name, if any.
+
+Do not confuse a deprecated package with a package that is expected but missing
+from PyPI. For example, if the release plan expects `agi-app-...` but PyPI
+returns 404 for it, that package needs publication, not deletion.
+
+Current-matrix cleanup wrappers such as `tools/pypi_publish.py --packages ...`
+only accept packages that still belong to the current release plan. If the stale
+PyPI project is no longer in the matrix, use `tools/pypi_release_retention.py`
+or `pypi-cleanup` directly against the exact legacy PyPI project name.
+
+For a stale package with several releases, prefer this sequence:
+
+1. Query the exact visible releases from live PyPI JSON.
+2. Run a `pypi-cleanup --query-only` dry-run with exact version regexes.
+3. Delete older releases one exact version at a time, protecting the latest
+   temporarily if using the retention workflow.
+4. Verify live PyPI JSON after every successful deletion.
+
+Deleting the final remaining release is effectively PyPI project removal. Treat
+that as a separate owner action: do not use `--delete-project` from automation
+unless the operator explicitly confirms the package name, understands that the
+project reservation may be affected, and has valid PyPI web credentials.
+
+If cleanup is blocked:
+
+- local `pypi-cleanup` login failure means local web credentials are invalid or
+  PyPI is rejecting that device/session;
+- GitHub Actions failure after `No CSFR` / `No CSRF` plus a login redirect means
+  PyPI likely needs an unrecognized-login confirmation URL;
+- fetch the URL from the PyPI email, then set it for the next retry:
+
+```bash
+gh variable set PYPI_CONFIRM_LOGIN_URL --repo ThalesGroup/agilab --body '<pypi-confirm-login-url>'
+```
+
+After the workflow consumes the URL, remove or rotate the variable so future
+cleanup runs do not reuse an expired confirmation link.
 
 ## Publication Reuse Behavior
 

--- a/.codex/skills/agilab-runbook/SKILL.md
+++ b/.codex/skills/agilab-runbook/SKILL.md
@@ -45,6 +45,14 @@ Use this skill when you need repo-specific “how we do things” guidance in `a
   `~/.agilab/.env` keys such as `APPS_PATH` and `IS_SOURCE_ENV`. Restart Streamlit after
   fixing bootstrap code because `st.session_state["env"]` and `env.active_app` can retain
   stale paths across reruns.
+- **Source Streamlit launches must be non-mutating by default**: if starting
+  `agilab run (dev)` prints `Uninstalled ...` or `Installed ...`, inspect both
+  the outer run-config command and any launcher-spawned inner `uv run` command.
+  The selected default app is not the cause; uv is reconciling the project
+  environment or the `ui` extra. Runtime launchers should preserve `UV_NO_SYNC`
+  and use `uv run --no-sync` for the inner Streamlit command. Do dependency
+  bootstrap explicitly with `uv sync --extra ui` or a clearly named sync flag
+  before launch, not silently during normal UI startup.
 - **PyPI app management**: promoted public apps can be managed through the PROJECT page
   `Install PyPI app` flow or `agilab app search/check/install/list/update/remove`.
   This route installs `agi-app-*` packages into the selected Python environment and


### PR DESCRIPTION
## Summary
- update the AGILAB runbook skill to explain that source Streamlit runtime launches should not mutate .venv
- sync the canonical Claude skill change into the repo Codex skill mirror

## Validation
- python3 tools/sync_agent_skills.py --skills agilab-runbook
- python3 tools/codex_skills.py --root .codex/skills validate --strict
- python3 tools/codex_skills.py --root .codex/skills generate
- python3 tools/agent_skill_catalog.py --apply
- python3 tools/generate_skill_badges.py
- python3 tools/skill_security_scan.py --roots .claude/skills .codex/skills --fail-on critical
- uv --preview-features extra-build-dependencies run --no-sync python tools/workflow_parity.py --profile skills