### PR TITLE
[codex] Improve PyTorch playground coverage UI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,22 +162,22 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Check release package is visible on PyPI
+      - name: Check release package is installable from PyPI
         id: release-package
         shell: bash
         run: |
           set -euo pipefail
-          if python tools/install_release_proof_package.py --check-available-only; then
+          if python tools/install_release_proof_package.py --check-installable-only; then
             echo "available=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           echo "available=false" >> "$GITHUB_OUTPUT"
           if [[ "${GITHUB_EVENT_NAME}" == "schedule" || "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
-            echo "ERROR: release-proof package is not visible on PyPI during a strict ${GITHUB_EVENT_NAME} guardrail run." >&2
+            echo "ERROR: release-proof package is not installable from PyPI during a strict ${GITHUB_EVENT_NAME} guardrail run." >&2
             exit 1
           fi
-          echo "::notice::Release-proof package is not visible on PyPI yet; skipping clean public install for this ${GITHUB_EVENT_NAME} run to avoid racing the tag publish workflow."
+          echo "::notice::Release-proof package is not installable from PyPI yet; skipping clean public install for this ${GITHUB_EVENT_NAME} run to avoid racing the tag publish workflow or stale split-package dependencies."
 
       - name: Install released AGILAB package
         if: steps.release-package.outputs.available == 'true'

--- a/src/agilab/apps/builtin/pytorch_playground_project/src/app_args_form.py
+++ b/src/agilab/apps/builtin/pytorch_playground_project/src/app_args_form.py
@@ -582,11 +582,12 @@ def render(
         / "pytorch_playground"
     )
     output_container = container or st
-    output_container.caption(
-        "PyTorch Playground is an executable app: ORCHESTRATE runs the configured "
-        "training job and exports replayable evidence."
-    )
-    output_container.caption(f"Analysis artifacts are exported to `{artifact_root}`.")
+    if not compact:
+        output_container.caption(
+            "PyTorch Playground is an executable app: ORCHESTRATE runs the configured "
+            "training job and exports replayable evidence."
+        )
+        output_container.caption(f"Analysis artifacts are exported to `{artifact_root}`.")
     snippet_rendered = False
     if compact and container is not None:
         try:
@@ -610,7 +611,6 @@ def render(
     else:
         form_container.markdown("### Settings")
         if compact:
-            form_container.caption("Quick fields are enough for most runs. Advanced controls stay collapsed.")
             form_values = _render_compact_args_form(defaults_model, env=active_env, container=form_container)
         else:
             form_container.caption("These fields are persisted as app arguments.")

--- a/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/app_surface.py
+++ b/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/app_surface.py
@@ -216,7 +216,6 @@ def _render_full_surface(
     app_args_form = _load_app_args_form()
     with controls_column:
         controls_column.markdown("### Run")
-        controls_column.caption("Adjust the next run, refresh evidence, then inspect the result on the left.")
         _render_run_button(active_app_path, container=controls_column, app_args_form=app_args_form)
         app_args_form.render(env=env or runtime_env, container=controls_column, wide=False, compact=True)
     with analysis_column:

--- a/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/playground_ui.py
+++ b/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/playground_ui.py
@@ -219,7 +219,7 @@ def __getattr__(name: str) -> Any:
         raise AttributeError(name) from exc
 
 
-PAGE_TITLE = "PyTorch playground"
+PAGE_TITLE = "PyTorch Playground"
 
 
 _ISOLATED_CORE_RUNNER = r"""
@@ -563,16 +563,16 @@ def _render_page_styles() -> None:
         """
 <style>
 .agilab-pt-hero {
-  border: 1px solid rgba(125, 211, 252, 0.24);
-  border-left: 4px solid #38bdf8;
+  border: 1px solid rgba(247, 242, 232, 0.18);
+  border-left: 4px solid var(--agilab-value-ready, #72d6b4);
   border-radius: 8px;
   padding: 1rem 1.1rem;
   margin: 0.25rem 0 1rem;
-  background: rgba(12, 18, 32, 0.92);
-  box-shadow: 0 12px 32px rgba(2, 6, 23, 0.22);
+  background: linear-gradient(135deg, rgba(8, 17, 31, 0.94), rgba(18, 43, 51, 0.86) 56%, rgba(38, 48, 25, 0.78));
+  box-shadow: 0 16px 44px rgba(7, 17, 31, 0.16), inset 0 1px 0 rgba(255,255,255,0.08);
 }
 .agilab-pt-kicker {
-  color: #7dd3fc;
+  color: var(--agilab-value-ready, #72d6b4);
   font-size: 0.78rem;
   font-weight: 800;
   letter-spacing: 0.14em;
@@ -603,6 +603,35 @@ def _render_page_styles() -> None:
   background: rgba(15, 23, 42, 0.55);
   padding: 0.34rem 0.58rem;
   font-size: 0.82rem;
+}
+.agilab-pt-summary-banner {
+  border: 1px solid rgba(247, 242, 232, 0.18);
+  border-radius: 8px;
+  padding: 0.95rem 1.05rem;
+  margin: 0.2rem 0 0.85rem;
+  background: linear-gradient(135deg, rgba(8, 17, 31, 0.94), rgba(18, 43, 51, 0.86));
+  box-shadow: 0 12px 32px rgba(7, 17, 31, 0.14), inset 0 1px 0 rgba(255,255,255,0.07);
+}
+.agilab-pt-summary-kicker {
+  color: rgba(247, 242, 232, 0.68);
+  font-size: 0.7rem;
+  font-weight: 820;
+  letter-spacing: 0.085em;
+  line-height: 1.15;
+  text-transform: uppercase;
+}
+.agilab-pt-summary-headline {
+  color: #f7f2e8;
+  font-size: 1.35rem;
+  font-weight: 860;
+  line-height: 1.15;
+  margin-top: 0.3rem;
+}
+.agilab-pt-summary-context {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin-top: 0.75rem;
 }
 .agilab-pt-card {
   border: 1px solid rgba(148, 163, 184, 0.22);
@@ -694,14 +723,23 @@ def _render_page_styles() -> None:
     )
 
 
-def _format_percent(value: Any) -> str:
+def _finite_number(value: Any, default: float = 0.0) -> float:
     try:
         number = float(value)
     except (TypeError, ValueError):
-        number = 0.0
+        return default
     if not np.isfinite(number):
-        number = 0.0
+        return default
+    return number
+
+
+def _format_percent(value: Any) -> str:
+    number = _finite_number(value)
     return f"{max(0.0, min(1.0, number)) * 100:.0f}%"
+
+
+def _format_percentage_points(value: Any) -> str:
+    return f"{abs(_finite_number(value)) * 100:.1f} pp"
 
 
 def _confidence_score(grid: pd.DataFrame) -> float:
@@ -731,18 +769,70 @@ def _parameter_count(layers: pd.DataFrame) -> int:
 
 
 def _generalization_gap(summary: Mapping[str, Any]) -> float:
-    train_accuracy = float(summary.get("train_accuracy", 0.0) or 0.0)
-    validation_accuracy = float(summary.get("validation_accuracy", 0.0) or 0.0)
+    train_accuracy = _finite_number(summary.get("train_accuracy", 0.0))
+    validation_accuracy = _finite_number(summary.get("validation_accuracy", 0.0))
     gap = train_accuracy - validation_accuracy
     return gap if np.isfinite(gap) else 0.0
 
 
-def _metric_card(label: str, value: str, note: str) -> str:
+def _run_quality_label(validation_accuracy: float, gap: float) -> str:
+    if validation_accuracy >= 0.9 and gap <= 0.05:
+        return "Strong run"
+    if validation_accuracy >= 0.8 and gap <= 0.12:
+        return "Usable run"
+    if validation_accuracy >= 0.7:
+        return "Learning run"
+    return "Needs tuning"
+
+
+def _gap_quality_label(gap: float) -> str:
+    if gap <= 0:
+        return "validation matches train"
+    if gap <= 0.05:
+        return "low overfit"
+    if gap <= 0.12:
+        return "moderate overfit"
+    return "high overfit"
+
+
+def _gap_state(gap: float) -> str:
+    return "ready" if gap <= 0.12 else "incomplete"
+
+
+def _decision_confidence_note(confidence: float) -> str:
+    if confidence >= 0.65:
+        return "clear boundary"
+    if confidence >= 0.35:
+        return "boundary forming"
+    return "soft boundary"
+
+
+def _summary_sample_count(summary: Mapping[str, Any], samples: pd.DataFrame) -> int:
+    try:
+        count = int(summary.get("samples", len(samples)) or len(samples))
+    except (TypeError, ValueError, OverflowError):
+        count = len(samples)
+    return count if count >= 0 else len(samples)
+
+
+def _metric_card(label: str, value: str, note: str, *, state: str = "ready") -> str:
+    css_state = html.escape(state)
     return (
-        '<div class="agilab-pt-card">'
-        f"<strong>{html.escape(label)}</strong>"
-        f'<div class="agilab-pt-value">{html.escape(value)}</div>'
-        f'<div class="agilab-pt-note">{html.escape(note)}</div>'
+        f'<div class="agilab-header-card agilab-header-card--{css_state}">'
+        f'<div class="agilab-header-label">{html.escape(label)}</div>'
+        f'<div class="agilab-header-value agilab-header-value--{css_state}">{html.escape(value)}</div>'
+        f'<div class="agilab-header-caption">{html.escape(note)}</div>'
+        "</div>"
+    )
+
+
+def _summary_banner(headline: str, chips: Sequence[str]) -> str:
+    chip_html = "".join(f'<span class="agilab-pt-chip">{html.escape(chip)}</span>' for chip in chips)
+    return (
+        '<div class="agilab-pt-summary-banner">'
+        '<div class="agilab-pt-summary-kicker">Run quality</div>'
+        f'<div class="agilab-pt-summary-headline">{html.escape(headline)}</div>'
+        f'<div class="agilab-pt-summary-context">{chip_html}</div>'
         "</div>"
     )
 
@@ -850,18 +940,16 @@ def _render_hero(active_app: Path | None, preset_label: str, config: PlaygroundC
 def _render_compact_header(active_app: Path | None, preset_label: str, config: PlaygroundConfig) -> None:
     app_label = active_app.name if active_app is not None else "standalone"
     network = "-".join(str(width) for width in config.hidden_layers) or "linear"
-    st.caption(
-        " · ".join(
-            (
-                preset_label,
-                f"app: {app_label}",
-                f"dataset: {config.dataset}",
-                f"features: {len(config.feature_names)}",
-                f"network: {network}",
-                f"epochs: {config.epochs}",
-            )
-        )
-    )
+    columns = st.columns(4)
+    cards = [
+        _metric_card("Surface", PAGE_TITLE, "embedded ANALYSIS", state="neutral"),
+        _metric_card("Source", preset_label, f"app: {app_label}", state="neutral"),
+        _metric_card("Dataset", config.dataset, f"{len(config.feature_names)} feature(s)", state="neutral"),
+        _metric_card("Network", network, f"{config.epochs} epochs", state="neutral"),
+    ]
+    for column, card in zip(columns, cards, strict=False):
+        with column:
+            st.markdown(card, unsafe_allow_html=True)
 
 
 def _render_section_intro(title: str, text: str) -> None:
@@ -1148,13 +1236,37 @@ def _render_summary(config: PlaygroundConfig, result: Mapping[str, Any]) -> None
     samples = _result_frame(result, "samples", pd.DataFrame(columns=["x1", "x2", "target"]))
     grid = _result_frame(result, "grid", pd.DataFrame(columns=["x1", "x2", "probability"]))
     network_layers = _result_frame(result, "network_layers", _empty_network_layers())
+    validation_accuracy = _finite_number(summary.get("validation_accuracy", 0.0))
     gap = _generalization_gap(summary)
-    columns = st.columns(4)
+    confidence = _confidence_score(grid)
+    sample_count = _summary_sample_count(summary, samples)
+    parameter_count = _parameter_count(network_layers)
+    headline = (
+        f"{_run_quality_label(validation_accuracy, gap)}: "
+        f"{_format_percent(validation_accuracy)} validation, {_gap_quality_label(gap)}"
+    )
+    st.markdown(
+        _summary_banner(
+            headline,
+            [
+                f"{parameter_count:,} params",
+                f"{len(config.hidden_layers)} hidden layer(s)",
+                f"{sample_count:,} samples",
+                _class_balance(samples),
+            ],
+        ),
+        unsafe_allow_html=True,
+    )
+    columns = st.columns(3)
     cards = [
-        _metric_card("Validation", _format_percent(summary.get("validation_accuracy", 0.0)), f"gap vs train: {gap:+.1%}"),
-        _metric_card("Boundary confidence", _format_percent(_confidence_score(grid)), "mean distance from indecision"),
-        _metric_card("Model size", f"{_parameter_count(network_layers):,}", f"{len(config.hidden_layers)} hidden layer(s)"),
-        _metric_card("Dataset", f"{int(summary.get('samples', len(samples))):,}", _class_balance(samples)),
+        _metric_card("Validation", _format_percent(validation_accuracy), "held-out accuracy"),
+        _metric_card("Train-val gap", _format_percentage_points(gap), _gap_quality_label(gap), state=_gap_state(gap)),
+        _metric_card(
+            "Decision confidence",
+            _format_percent(confidence),
+            _decision_confidence_note(confidence),
+            state="ready" if confidence >= 0.35 else "incomplete",
+        ),
     ]
     for column, card in zip(columns, cards, strict=False):
         with column:

--- a/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/playground_ui.py
+++ b/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/playground_ui.py
@@ -633,6 +633,156 @@ def _render_page_styles() -> None:
   gap: 0.45rem;
   margin-top: 0.75rem;
 }
+.agilab-pt-compact-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin: 0.15rem 0 0.65rem;
+}
+.agilab-pt-run-panel {
+  display: grid;
+  grid-template-columns: minmax(13rem, 1fr) minmax(24rem, 2fr);
+  gap: 0.85rem 1rem;
+  align-items: stretch;
+  border: 1px solid rgba(247, 242, 232, 0.18);
+  border-radius: 8px;
+  padding: 0.85rem 0.95rem;
+  margin: 0.15rem 0 0.7rem;
+  background: linear-gradient(135deg, rgba(8, 17, 31, 0.94), rgba(18, 43, 51, 0.86));
+  box-shadow: 0 12px 32px rgba(7, 17, 31, 0.14), inset 0 1px 0 rgba(255,255,255,0.07);
+}
+.agilab-pt-run-main {
+  min-width: 0;
+}
+.agilab-pt-run-kicker {
+  color: rgba(247, 242, 232, 0.68);
+  font-size: 0.68rem;
+  font-weight: 820;
+  letter-spacing: 0.085em;
+  line-height: 1.15;
+  text-transform: uppercase;
+}
+.agilab-pt-run-headline {
+  color: #f7f2e8;
+  font-size: 1.32rem;
+  font-weight: 860;
+  line-height: 1.12;
+  margin-top: 0.28rem;
+}
+.agilab-pt-run-note {
+  color: rgba(247, 242, 232, 0.62);
+  font-size: 0.85rem;
+  line-height: 1.3;
+  margin-top: 0.35rem;
+}
+.agilab-pt-run-metrics {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.55rem;
+}
+.agilab-pt-run-metric {
+  min-width: 0;
+  border: 1px solid rgba(247, 242, 232, 0.14);
+  border-radius: 8px;
+  padding: 0.6rem 0.68rem;
+  background: rgba(247, 242, 232, 0.035);
+}
+.agilab-pt-run-metric-label {
+  color: rgba(247, 242, 232, 0.62);
+  font-size: 0.68rem;
+  font-weight: 820;
+  letter-spacing: 0.075em;
+  line-height: 1.15;
+  text-transform: uppercase;
+}
+.agilab-pt-run-metric-value {
+  color: #f7f2e8;
+  font-size: 1.12rem;
+  font-weight: 860;
+  line-height: 1.05;
+  margin-top: 0.24rem;
+}
+.agilab-pt-run-metric-note {
+  color: rgba(247, 242, 232, 0.58);
+  font-size: 0.74rem;
+  line-height: 1.25;
+  margin-top: 0.22rem;
+}
+.agilab-pt-run-context {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.42rem;
+  margin-top: -0.05rem;
+}
+.agilab-header-card {
+  position: relative;
+  display: grid;
+  grid-template-rows: auto minmax(1.65rem, 1fr) auto;
+  align-content: stretch;
+  box-sizing: border-box;
+  width: 100%;
+  height: 100%;
+  min-height: 6.25rem;
+  padding: 0.78rem 0.86rem 0.72rem 0.95rem;
+  border: 1px solid rgba(247, 242, 232, 0.16);
+  border-radius: 8px;
+  background: linear-gradient(145deg, rgba(255,255,255,0.075), rgba(255,255,255,0.025)), rgba(247, 242, 232, 0.03);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.075), 0 10px 28px rgba(0,0,0,0.12);
+  overflow: hidden;
+}
+.agilab-header-card::before {
+  content: "";
+  position: absolute;
+  inset: 0.62rem auto 0.62rem 0.52rem;
+  width: 3px;
+  border-radius: 999px;
+  background: rgba(247, 242, 232, 0.78);
+  opacity: 0.82;
+}
+.agilab-header-card--ready::before {
+  background: #72d6b4;
+}
+.agilab-header-card--incomplete::before {
+  background: #ffbe5e;
+}
+.agilab-header-label {
+  position: relative;
+  z-index: 1;
+  color: rgba(247, 242, 232, 0.68);
+  font-size: 0.7rem;
+  font-weight: 820;
+  letter-spacing: 0.085em;
+  line-height: 1.15;
+  text-transform: uppercase;
+}
+.agilab-header-value {
+  position: relative;
+  z-index: 1;
+  align-self: center;
+  margin-top: 0.22rem;
+  color: #f7f2e8;
+  font-size: 1.28rem;
+  font-weight: 860;
+  line-height: 1.1;
+  overflow-wrap: anywhere;
+}
+.agilab-header-value--ready {
+  color: #72d6b4 !important;
+}
+.agilab-header-value--incomplete {
+  color: #ffbe5e !important;
+}
+.agilab-header-caption {
+  position: relative;
+  z-index: 1;
+  align-self: end;
+  margin-top: 0.45rem;
+  color: rgba(247, 242, 232, 0.60);
+  font-size: 0.75rem;
+  line-height: 1.3;
+  overflow-wrap: anywhere;
+}
 .agilab-pt-card {
   border: 1px solid rgba(148, 163, 184, 0.22);
   border-radius: 8px;
@@ -714,6 +864,10 @@ def _render_page_styles() -> None:
 }
 @media (max-width: 860px) {
   .agilab-pt-guide {
+    grid-template-columns: 1fr;
+  }
+  .agilab-pt-run-panel,
+  .agilab-pt-run-metrics {
     grid-template-columns: 1fr;
   }
 }
@@ -837,6 +991,59 @@ def _summary_banner(headline: str, chips: Sequence[str]) -> str:
     )
 
 
+def _summary_chips(
+    *,
+    config: PlaygroundConfig,
+    samples: pd.DataFrame,
+    parameter_count: int,
+    sample_count: int,
+) -> list[str]:
+    return [
+        f"{parameter_count:,} params",
+        f"{len(config.hidden_layers)} hidden layer(s)",
+        f"{sample_count:,} samples",
+        _class_balance(samples),
+    ]
+
+
+def _compact_metric(label: str, value: str, note: str) -> str:
+    return (
+        '<div class="agilab-pt-run-metric">'
+        f'<div class="agilab-pt-run-metric-label">{html.escape(label)}</div>'
+        f'<div class="agilab-pt-run-metric-value">{html.escape(value)}</div>'
+        f'<div class="agilab-pt-run-metric-note">{html.escape(note)}</div>'
+        "</div>"
+    )
+
+
+def _compact_summary_panel(
+    *,
+    run_quality: str,
+    gap_note: str,
+    confidence_note: str,
+    validation_value: str,
+    gap_value: str,
+    confidence_value: str,
+    chips: Sequence[str],
+) -> str:
+    chip_html = "".join(f'<span class="agilab-pt-chip">{html.escape(chip)}</span>' for chip in chips)
+    return (
+        '<div class="agilab-pt-run-panel">'
+        '<div class="agilab-pt-run-main">'
+        '<div class="agilab-pt-run-kicker">Run quality</div>'
+        f'<div class="agilab-pt-run-headline">{html.escape(run_quality)}</div>'
+        f'<div class="agilab-pt-run-note">{html.escape(gap_note)}</div>'
+        "</div>"
+        '<div class="agilab-pt-run-metrics">'
+        + _compact_metric("Validation", validation_value, "held-out accuracy")
+        + _compact_metric("Train-val gap", gap_value, gap_note)
+        + _compact_metric("Decision confidence", confidence_value, confidence_note)
+        + "</div>"
+        f'<div class="agilab-pt-run-context">{chip_html}</div>'
+        "</div>"
+    )
+
+
 def _guide_step(title: str, text: str, css_class: str) -> str:
     return (
         f'<div class="agilab-pt-step {html.escape(css_class)}">'
@@ -940,16 +1147,20 @@ def _render_hero(active_app: Path | None, preset_label: str, config: PlaygroundC
 def _render_compact_header(active_app: Path | None, preset_label: str, config: PlaygroundConfig) -> None:
     app_label = active_app.name if active_app is not None else "standalone"
     network = "-".join(str(width) for width in config.hidden_layers) or "linear"
-    columns = st.columns(4)
-    cards = [
-        _metric_card("Surface", PAGE_TITLE, "embedded ANALYSIS", state="neutral"),
-        _metric_card("Source", preset_label, f"app: {app_label}", state="neutral"),
-        _metric_card("Dataset", config.dataset, f"{len(config.feature_names)} feature(s)", state="neutral"),
-        _metric_card("Network", network, f"{config.epochs} epochs", state="neutral"),
+    chips = [
+        preset_label,
+        f"app: {app_label}",
+        f"dataset: {config.dataset}",
+        f"features: {len(config.feature_names)}",
+        f"network: {network}",
+        f"epochs: {config.epochs}",
     ]
-    for column, card in zip(columns, cards, strict=False):
-        with column:
-            st.markdown(card, unsafe_allow_html=True)
+    st.markdown(
+        '<div class="agilab-pt-compact-meta">'
+        + "".join(f'<span class="agilab-pt-chip">{html.escape(chip)}</span>' for chip in chips)
+        + "</div>",
+        unsafe_allow_html=True,
+    )
 
 
 def _render_section_intro(title: str, text: str) -> None:
@@ -1231,7 +1442,7 @@ def _loss_landscape_figure(landscape: pd.DataFrame) -> go.Figure:
     return figure
 
 
-def _render_summary(config: PlaygroundConfig, result: Mapping[str, Any]) -> None:
+def _render_summary(config: PlaygroundConfig, result: Mapping[str, Any], *, compact: bool = False) -> None:
     summary = result.get("summary", {})
     samples = _result_frame(result, "samples", pd.DataFrame(columns=["x1", "x2", "target"]))
     grid = _result_frame(result, "grid", pd.DataFrame(columns=["x1", "x2", "probability"]))
@@ -1241,30 +1452,51 @@ def _render_summary(config: PlaygroundConfig, result: Mapping[str, Any]) -> None
     confidence = _confidence_score(grid)
     sample_count = _summary_sample_count(summary, samples)
     parameter_count = _parameter_count(network_layers)
+    run_quality = _run_quality_label(validation_accuracy, gap)
+    gap_note = _gap_quality_label(gap)
+    confidence_note = _decision_confidence_note(confidence)
+    validation_value = _format_percent(validation_accuracy)
+    gap_value = _format_percentage_points(gap)
+    confidence_value = _format_percent(confidence)
+    chips = _summary_chips(
+        config=config,
+        samples=samples,
+        parameter_count=parameter_count,
+        sample_count=sample_count,
+    )
+    if compact:
+        st.markdown(
+            _compact_summary_panel(
+                run_quality=run_quality,
+                gap_note=gap_note,
+                confidence_note=confidence_note,
+                validation_value=validation_value,
+                gap_value=gap_value,
+                confidence_value=confidence_value,
+                chips=chips,
+            ),
+            unsafe_allow_html=True,
+        )
+        return
     headline = (
-        f"{_run_quality_label(validation_accuracy, gap)}: "
-        f"{_gap_quality_label(gap)}, {_decision_confidence_note(confidence)}"
+        f"{run_quality}: "
+        f"{gap_note}, {confidence_note}"
     )
     st.markdown(
         _summary_banner(
             headline,
-            [
-                f"{parameter_count:,} params",
-                f"{len(config.hidden_layers)} hidden layer(s)",
-                f"{sample_count:,} samples",
-                _class_balance(samples),
-            ],
+            chips,
         ),
         unsafe_allow_html=True,
     )
     columns = st.columns(3)
     cards = [
-        _metric_card("Validation", _format_percent(validation_accuracy), "held-out accuracy"),
-        _metric_card("Train-val gap", _format_percentage_points(gap), _gap_quality_label(gap), state=_gap_state(gap)),
+        _metric_card("Validation", validation_value, "held-out accuracy"),
+        _metric_card("Train-val gap", gap_value, gap_note, state=_gap_state(gap)),
         _metric_card(
             "Decision confidence",
-            _format_percent(confidence),
-            _decision_confidence_note(confidence),
+            confidence_value,
+            confidence_note,
             state="ready" if confidence >= 0.35 else "incomplete",
         ),
     ]
@@ -1394,7 +1626,8 @@ def main(
         trained_config, result, evidence_root = evidence_result
         trained_preset = preset_label or "Latest ORCHESTRATE evidence"
         pending_changes = False
-        st.caption(f"Loaded evidence from `{evidence_root}`.")
+        if not compact:
+            st.caption(f"Loaded evidence from `{evidence_root}`.")
 
     trained_config_dict = asdict(trained_config)
     if interactive_controls:
@@ -1408,7 +1641,7 @@ def main(
         _render_compact_header(active_app, trained_preset, trained_config)
     else:
         _render_hero(active_app, trained_preset, trained_config)
-    if not interactive_controls:
+    if not interactive_controls and not compact:
         st.caption("Charts use the persisted ORCHESTRATE arguments for this app.")
     if result["status"] == "missing_torch":
         st.error(result["detail"])
@@ -1417,7 +1650,7 @@ def main(
     if pending_changes:
         st.warning("Controls changed. The visible charts and evidence still show the last trained run.")
 
-    _render_summary(trained_config, result)
+    _render_summary(trained_config, result, compact=compact)
     if not compact:
         _render_guided_flow(pending_changes=pending_changes, result_status=str(result.get("status", "")))
         _render_interpretation_cards(result)

--- a/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/playground_ui.py
+++ b/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/playground_ui.py
@@ -1243,7 +1243,7 @@ def _render_summary(config: PlaygroundConfig, result: Mapping[str, Any]) -> None
     parameter_count = _parameter_count(network_layers)
     headline = (
         f"{_run_quality_label(validation_accuracy, gap)}: "
-        f"{_format_percent(validation_accuracy)} validation, {_gap_quality_label(gap)}"
+        f"{_gap_quality_label(gap)}, {_decision_confidence_note(confidence)}"
     )
     st.markdown(
         _summary_banner(

--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/app_args_form.py
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/app_args_form.py
@@ -582,11 +582,12 @@ def render(
         / "pytorch_playground"
     )
     output_container = container or st
-    output_container.caption(
-        "PyTorch Playground is an executable app: ORCHESTRATE runs the configured "
-        "training job and exports replayable evidence."
-    )
-    output_container.caption(f"Analysis artifacts are exported to `{artifact_root}`.")
+    if not compact:
+        output_container.caption(
+            "PyTorch Playground is an executable app: ORCHESTRATE runs the configured "
+            "training job and exports replayable evidence."
+        )
+        output_container.caption(f"Analysis artifacts are exported to `{artifact_root}`.")
     snippet_rendered = False
     if compact and container is not None:
         try:
@@ -610,7 +611,6 @@ def render(
     else:
         form_container.markdown("### Settings")
         if compact:
-            form_container.caption("Quick fields are enough for most runs. Advanced controls stay collapsed.")
             form_values = _render_compact_args_form(defaults_model, env=active_env, container=form_container)
         else:
             form_container.caption("These fields are persisted as app arguments.")

--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground/app_surface.py
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground/app_surface.py
@@ -216,7 +216,6 @@ def _render_full_surface(
     app_args_form = _load_app_args_form()
     with controls_column:
         controls_column.markdown("### Run")
-        controls_column.caption("Adjust the next run, refresh evidence, then inspect the result on the left.")
         _render_run_button(active_app_path, container=controls_column, app_args_form=app_args_form)
         app_args_form.render(env=env or runtime_env, container=controls_column, wide=False, compact=True)
     with analysis_column:

--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground/playground_ui.py
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground/playground_ui.py
@@ -219,7 +219,7 @@ def __getattr__(name: str) -> Any:
         raise AttributeError(name) from exc
 
 
-PAGE_TITLE = "PyTorch playground"
+PAGE_TITLE = "PyTorch Playground"
 
 
 _ISOLATED_CORE_RUNNER = r"""
@@ -563,16 +563,16 @@ def _render_page_styles() -> None:
         """
 <style>
 .agilab-pt-hero {
-  border: 1px solid rgba(125, 211, 252, 0.24);
-  border-left: 4px solid #38bdf8;
+  border: 1px solid rgba(247, 242, 232, 0.18);
+  border-left: 4px solid var(--agilab-value-ready, #72d6b4);
   border-radius: 8px;
   padding: 1rem 1.1rem;
   margin: 0.25rem 0 1rem;
-  background: rgba(12, 18, 32, 0.92);
-  box-shadow: 0 12px 32px rgba(2, 6, 23, 0.22);
+  background: linear-gradient(135deg, rgba(8, 17, 31, 0.94), rgba(18, 43, 51, 0.86) 56%, rgba(38, 48, 25, 0.78));
+  box-shadow: 0 16px 44px rgba(7, 17, 31, 0.16), inset 0 1px 0 rgba(255,255,255,0.08);
 }
 .agilab-pt-kicker {
-  color: #7dd3fc;
+  color: var(--agilab-value-ready, #72d6b4);
   font-size: 0.78rem;
   font-weight: 800;
   letter-spacing: 0.14em;
@@ -603,6 +603,35 @@ def _render_page_styles() -> None:
   background: rgba(15, 23, 42, 0.55);
   padding: 0.34rem 0.58rem;
   font-size: 0.82rem;
+}
+.agilab-pt-summary-banner {
+  border: 1px solid rgba(247, 242, 232, 0.18);
+  border-radius: 8px;
+  padding: 0.95rem 1.05rem;
+  margin: 0.2rem 0 0.85rem;
+  background: linear-gradient(135deg, rgba(8, 17, 31, 0.94), rgba(18, 43, 51, 0.86));
+  box-shadow: 0 12px 32px rgba(7, 17, 31, 0.14), inset 0 1px 0 rgba(255,255,255,0.07);
+}
+.agilab-pt-summary-kicker {
+  color: rgba(247, 242, 232, 0.68);
+  font-size: 0.7rem;
+  font-weight: 820;
+  letter-spacing: 0.085em;
+  line-height: 1.15;
+  text-transform: uppercase;
+}
+.agilab-pt-summary-headline {
+  color: #f7f2e8;
+  font-size: 1.35rem;
+  font-weight: 860;
+  line-height: 1.15;
+  margin-top: 0.3rem;
+}
+.agilab-pt-summary-context {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin-top: 0.75rem;
 }
 .agilab-pt-card {
   border: 1px solid rgba(148, 163, 184, 0.22);
@@ -694,14 +723,23 @@ def _render_page_styles() -> None:
     )
 
 
-def _format_percent(value: Any) -> str:
+def _finite_number(value: Any, default: float = 0.0) -> float:
     try:
         number = float(value)
     except (TypeError, ValueError):
-        number = 0.0
+        return default
     if not np.isfinite(number):
-        number = 0.0
+        return default
+    return number
+
+
+def _format_percent(value: Any) -> str:
+    number = _finite_number(value)
     return f"{max(0.0, min(1.0, number)) * 100:.0f}%"
+
+
+def _format_percentage_points(value: Any) -> str:
+    return f"{abs(_finite_number(value)) * 100:.1f} pp"
 
 
 def _confidence_score(grid: pd.DataFrame) -> float:
@@ -731,18 +769,70 @@ def _parameter_count(layers: pd.DataFrame) -> int:
 
 
 def _generalization_gap(summary: Mapping[str, Any]) -> float:
-    train_accuracy = float(summary.get("train_accuracy", 0.0) or 0.0)
-    validation_accuracy = float(summary.get("validation_accuracy", 0.0) or 0.0)
+    train_accuracy = _finite_number(summary.get("train_accuracy", 0.0))
+    validation_accuracy = _finite_number(summary.get("validation_accuracy", 0.0))
     gap = train_accuracy - validation_accuracy
     return gap if np.isfinite(gap) else 0.0
 
 
-def _metric_card(label: str, value: str, note: str) -> str:
+def _run_quality_label(validation_accuracy: float, gap: float) -> str:
+    if validation_accuracy >= 0.9 and gap <= 0.05:
+        return "Strong run"
+    if validation_accuracy >= 0.8 and gap <= 0.12:
+        return "Usable run"
+    if validation_accuracy >= 0.7:
+        return "Learning run"
+    return "Needs tuning"
+
+
+def _gap_quality_label(gap: float) -> str:
+    if gap <= 0:
+        return "validation matches train"
+    if gap <= 0.05:
+        return "low overfit"
+    if gap <= 0.12:
+        return "moderate overfit"
+    return "high overfit"
+
+
+def _gap_state(gap: float) -> str:
+    return "ready" if gap <= 0.12 else "incomplete"
+
+
+def _decision_confidence_note(confidence: float) -> str:
+    if confidence >= 0.65:
+        return "clear boundary"
+    if confidence >= 0.35:
+        return "boundary forming"
+    return "soft boundary"
+
+
+def _summary_sample_count(summary: Mapping[str, Any], samples: pd.DataFrame) -> int:
+    try:
+        count = int(summary.get("samples", len(samples)) or len(samples))
+    except (TypeError, ValueError, OverflowError):
+        count = len(samples)
+    return count if count >= 0 else len(samples)
+
+
+def _metric_card(label: str, value: str, note: str, *, state: str = "ready") -> str:
+    css_state = html.escape(state)
     return (
-        '<div class="agilab-pt-card">'
-        f"<strong>{html.escape(label)}</strong>"
-        f'<div class="agilab-pt-value">{html.escape(value)}</div>'
-        f'<div class="agilab-pt-note">{html.escape(note)}</div>'
+        f'<div class="agilab-header-card agilab-header-card--{css_state}">'
+        f'<div class="agilab-header-label">{html.escape(label)}</div>'
+        f'<div class="agilab-header-value agilab-header-value--{css_state}">{html.escape(value)}</div>'
+        f'<div class="agilab-header-caption">{html.escape(note)}</div>'
+        "</div>"
+    )
+
+
+def _summary_banner(headline: str, chips: Sequence[str]) -> str:
+    chip_html = "".join(f'<span class="agilab-pt-chip">{html.escape(chip)}</span>' for chip in chips)
+    return (
+        '<div class="agilab-pt-summary-banner">'
+        '<div class="agilab-pt-summary-kicker">Run quality</div>'
+        f'<div class="agilab-pt-summary-headline">{html.escape(headline)}</div>'
+        f'<div class="agilab-pt-summary-context">{chip_html}</div>'
         "</div>"
     )
 
@@ -850,18 +940,16 @@ def _render_hero(active_app: Path | None, preset_label: str, config: PlaygroundC
 def _render_compact_header(active_app: Path | None, preset_label: str, config: PlaygroundConfig) -> None:
     app_label = active_app.name if active_app is not None else "standalone"
     network = "-".join(str(width) for width in config.hidden_layers) or "linear"
-    st.caption(
-        " · ".join(
-            (
-                preset_label,
-                f"app: {app_label}",
-                f"dataset: {config.dataset}",
-                f"features: {len(config.feature_names)}",
-                f"network: {network}",
-                f"epochs: {config.epochs}",
-            )
-        )
-    )
+    columns = st.columns(4)
+    cards = [
+        _metric_card("Surface", PAGE_TITLE, "embedded ANALYSIS", state="neutral"),
+        _metric_card("Source", preset_label, f"app: {app_label}", state="neutral"),
+        _metric_card("Dataset", config.dataset, f"{len(config.feature_names)} feature(s)", state="neutral"),
+        _metric_card("Network", network, f"{config.epochs} epochs", state="neutral"),
+    ]
+    for column, card in zip(columns, cards, strict=False):
+        with column:
+            st.markdown(card, unsafe_allow_html=True)
 
 
 def _render_section_intro(title: str, text: str) -> None:
@@ -1148,13 +1236,37 @@ def _render_summary(config: PlaygroundConfig, result: Mapping[str, Any]) -> None
     samples = _result_frame(result, "samples", pd.DataFrame(columns=["x1", "x2", "target"]))
     grid = _result_frame(result, "grid", pd.DataFrame(columns=["x1", "x2", "probability"]))
     network_layers = _result_frame(result, "network_layers", _empty_network_layers())
+    validation_accuracy = _finite_number(summary.get("validation_accuracy", 0.0))
     gap = _generalization_gap(summary)
-    columns = st.columns(4)
+    confidence = _confidence_score(grid)
+    sample_count = _summary_sample_count(summary, samples)
+    parameter_count = _parameter_count(network_layers)
+    headline = (
+        f"{_run_quality_label(validation_accuracy, gap)}: "
+        f"{_format_percent(validation_accuracy)} validation, {_gap_quality_label(gap)}"
+    )
+    st.markdown(
+        _summary_banner(
+            headline,
+            [
+                f"{parameter_count:,} params",
+                f"{len(config.hidden_layers)} hidden layer(s)",
+                f"{sample_count:,} samples",
+                _class_balance(samples),
+            ],
+        ),
+        unsafe_allow_html=True,
+    )
+    columns = st.columns(3)
     cards = [
-        _metric_card("Validation", _format_percent(summary.get("validation_accuracy", 0.0)), f"gap vs train: {gap:+.1%}"),
-        _metric_card("Boundary confidence", _format_percent(_confidence_score(grid)), "mean distance from indecision"),
-        _metric_card("Model size", f"{_parameter_count(network_layers):,}", f"{len(config.hidden_layers)} hidden layer(s)"),
-        _metric_card("Dataset", f"{int(summary.get('samples', len(samples))):,}", _class_balance(samples)),
+        _metric_card("Validation", _format_percent(validation_accuracy), "held-out accuracy"),
+        _metric_card("Train-val gap", _format_percentage_points(gap), _gap_quality_label(gap), state=_gap_state(gap)),
+        _metric_card(
+            "Decision confidence",
+            _format_percent(confidence),
+            _decision_confidence_note(confidence),
+            state="ready" if confidence >= 0.35 else "incomplete",
+        ),
     ]
     for column, card in zip(columns, cards, strict=False):
         with column:

--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground/playground_ui.py
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground/playground_ui.py
@@ -633,6 +633,156 @@ def _render_page_styles() -> None:
   gap: 0.45rem;
   margin-top: 0.75rem;
 }
+.agilab-pt-compact-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin: 0.15rem 0 0.65rem;
+}
+.agilab-pt-run-panel {
+  display: grid;
+  grid-template-columns: minmax(13rem, 1fr) minmax(24rem, 2fr);
+  gap: 0.85rem 1rem;
+  align-items: stretch;
+  border: 1px solid rgba(247, 242, 232, 0.18);
+  border-radius: 8px;
+  padding: 0.85rem 0.95rem;
+  margin: 0.15rem 0 0.7rem;
+  background: linear-gradient(135deg, rgba(8, 17, 31, 0.94), rgba(18, 43, 51, 0.86));
+  box-shadow: 0 12px 32px rgba(7, 17, 31, 0.14), inset 0 1px 0 rgba(255,255,255,0.07);
+}
+.agilab-pt-run-main {
+  min-width: 0;
+}
+.agilab-pt-run-kicker {
+  color: rgba(247, 242, 232, 0.68);
+  font-size: 0.68rem;
+  font-weight: 820;
+  letter-spacing: 0.085em;
+  line-height: 1.15;
+  text-transform: uppercase;
+}
+.agilab-pt-run-headline {
+  color: #f7f2e8;
+  font-size: 1.32rem;
+  font-weight: 860;
+  line-height: 1.12;
+  margin-top: 0.28rem;
+}
+.agilab-pt-run-note {
+  color: rgba(247, 242, 232, 0.62);
+  font-size: 0.85rem;
+  line-height: 1.3;
+  margin-top: 0.35rem;
+}
+.agilab-pt-run-metrics {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.55rem;
+}
+.agilab-pt-run-metric {
+  min-width: 0;
+  border: 1px solid rgba(247, 242, 232, 0.14);
+  border-radius: 8px;
+  padding: 0.6rem 0.68rem;
+  background: rgba(247, 242, 232, 0.035);
+}
+.agilab-pt-run-metric-label {
+  color: rgba(247, 242, 232, 0.62);
+  font-size: 0.68rem;
+  font-weight: 820;
+  letter-spacing: 0.075em;
+  line-height: 1.15;
+  text-transform: uppercase;
+}
+.agilab-pt-run-metric-value {
+  color: #f7f2e8;
+  font-size: 1.12rem;
+  font-weight: 860;
+  line-height: 1.05;
+  margin-top: 0.24rem;
+}
+.agilab-pt-run-metric-note {
+  color: rgba(247, 242, 232, 0.58);
+  font-size: 0.74rem;
+  line-height: 1.25;
+  margin-top: 0.22rem;
+}
+.agilab-pt-run-context {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.42rem;
+  margin-top: -0.05rem;
+}
+.agilab-header-card {
+  position: relative;
+  display: grid;
+  grid-template-rows: auto minmax(1.65rem, 1fr) auto;
+  align-content: stretch;
+  box-sizing: border-box;
+  width: 100%;
+  height: 100%;
+  min-height: 6.25rem;
+  padding: 0.78rem 0.86rem 0.72rem 0.95rem;
+  border: 1px solid rgba(247, 242, 232, 0.16);
+  border-radius: 8px;
+  background: linear-gradient(145deg, rgba(255,255,255,0.075), rgba(255,255,255,0.025)), rgba(247, 242, 232, 0.03);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.075), 0 10px 28px rgba(0,0,0,0.12);
+  overflow: hidden;
+}
+.agilab-header-card::before {
+  content: "";
+  position: absolute;
+  inset: 0.62rem auto 0.62rem 0.52rem;
+  width: 3px;
+  border-radius: 999px;
+  background: rgba(247, 242, 232, 0.78);
+  opacity: 0.82;
+}
+.agilab-header-card--ready::before {
+  background: #72d6b4;
+}
+.agilab-header-card--incomplete::before {
+  background: #ffbe5e;
+}
+.agilab-header-label {
+  position: relative;
+  z-index: 1;
+  color: rgba(247, 242, 232, 0.68);
+  font-size: 0.7rem;
+  font-weight: 820;
+  letter-spacing: 0.085em;
+  line-height: 1.15;
+  text-transform: uppercase;
+}
+.agilab-header-value {
+  position: relative;
+  z-index: 1;
+  align-self: center;
+  margin-top: 0.22rem;
+  color: #f7f2e8;
+  font-size: 1.28rem;
+  font-weight: 860;
+  line-height: 1.1;
+  overflow-wrap: anywhere;
+}
+.agilab-header-value--ready {
+  color: #72d6b4 !important;
+}
+.agilab-header-value--incomplete {
+  color: #ffbe5e !important;
+}
+.agilab-header-caption {
+  position: relative;
+  z-index: 1;
+  align-self: end;
+  margin-top: 0.45rem;
+  color: rgba(247, 242, 232, 0.60);
+  font-size: 0.75rem;
+  line-height: 1.3;
+  overflow-wrap: anywhere;
+}
 .agilab-pt-card {
   border: 1px solid rgba(148, 163, 184, 0.22);
   border-radius: 8px;
@@ -714,6 +864,10 @@ def _render_page_styles() -> None:
 }
 @media (max-width: 860px) {
   .agilab-pt-guide {
+    grid-template-columns: 1fr;
+  }
+  .agilab-pt-run-panel,
+  .agilab-pt-run-metrics {
     grid-template-columns: 1fr;
   }
 }
@@ -837,6 +991,59 @@ def _summary_banner(headline: str, chips: Sequence[str]) -> str:
     )
 
 
+def _summary_chips(
+    *,
+    config: PlaygroundConfig,
+    samples: pd.DataFrame,
+    parameter_count: int,
+    sample_count: int,
+) -> list[str]:
+    return [
+        f"{parameter_count:,} params",
+        f"{len(config.hidden_layers)} hidden layer(s)",
+        f"{sample_count:,} samples",
+        _class_balance(samples),
+    ]
+
+
+def _compact_metric(label: str, value: str, note: str) -> str:
+    return (
+        '<div class="agilab-pt-run-metric">'
+        f'<div class="agilab-pt-run-metric-label">{html.escape(label)}</div>'
+        f'<div class="agilab-pt-run-metric-value">{html.escape(value)}</div>'
+        f'<div class="agilab-pt-run-metric-note">{html.escape(note)}</div>'
+        "</div>"
+    )
+
+
+def _compact_summary_panel(
+    *,
+    run_quality: str,
+    gap_note: str,
+    confidence_note: str,
+    validation_value: str,
+    gap_value: str,
+    confidence_value: str,
+    chips: Sequence[str],
+) -> str:
+    chip_html = "".join(f'<span class="agilab-pt-chip">{html.escape(chip)}</span>' for chip in chips)
+    return (
+        '<div class="agilab-pt-run-panel">'
+        '<div class="agilab-pt-run-main">'
+        '<div class="agilab-pt-run-kicker">Run quality</div>'
+        f'<div class="agilab-pt-run-headline">{html.escape(run_quality)}</div>'
+        f'<div class="agilab-pt-run-note">{html.escape(gap_note)}</div>'
+        "</div>"
+        '<div class="agilab-pt-run-metrics">'
+        + _compact_metric("Validation", validation_value, "held-out accuracy")
+        + _compact_metric("Train-val gap", gap_value, gap_note)
+        + _compact_metric("Decision confidence", confidence_value, confidence_note)
+        + "</div>"
+        f'<div class="agilab-pt-run-context">{chip_html}</div>'
+        "</div>"
+    )
+
+
 def _guide_step(title: str, text: str, css_class: str) -> str:
     return (
         f'<div class="agilab-pt-step {html.escape(css_class)}">'
@@ -940,16 +1147,20 @@ def _render_hero(active_app: Path | None, preset_label: str, config: PlaygroundC
 def _render_compact_header(active_app: Path | None, preset_label: str, config: PlaygroundConfig) -> None:
     app_label = active_app.name if active_app is not None else "standalone"
     network = "-".join(str(width) for width in config.hidden_layers) or "linear"
-    columns = st.columns(4)
-    cards = [
-        _metric_card("Surface", PAGE_TITLE, "embedded ANALYSIS", state="neutral"),
-        _metric_card("Source", preset_label, f"app: {app_label}", state="neutral"),
-        _metric_card("Dataset", config.dataset, f"{len(config.feature_names)} feature(s)", state="neutral"),
-        _metric_card("Network", network, f"{config.epochs} epochs", state="neutral"),
+    chips = [
+        preset_label,
+        f"app: {app_label}",
+        f"dataset: {config.dataset}",
+        f"features: {len(config.feature_names)}",
+        f"network: {network}",
+        f"epochs: {config.epochs}",
     ]
-    for column, card in zip(columns, cards, strict=False):
-        with column:
-            st.markdown(card, unsafe_allow_html=True)
+    st.markdown(
+        '<div class="agilab-pt-compact-meta">'
+        + "".join(f'<span class="agilab-pt-chip">{html.escape(chip)}</span>' for chip in chips)
+        + "</div>",
+        unsafe_allow_html=True,
+    )
 
 
 def _render_section_intro(title: str, text: str) -> None:
@@ -1231,7 +1442,7 @@ def _loss_landscape_figure(landscape: pd.DataFrame) -> go.Figure:
     return figure
 
 
-def _render_summary(config: PlaygroundConfig, result: Mapping[str, Any]) -> None:
+def _render_summary(config: PlaygroundConfig, result: Mapping[str, Any], *, compact: bool = False) -> None:
     summary = result.get("summary", {})
     samples = _result_frame(result, "samples", pd.DataFrame(columns=["x1", "x2", "target"]))
     grid = _result_frame(result, "grid", pd.DataFrame(columns=["x1", "x2", "probability"]))
@@ -1241,30 +1452,51 @@ def _render_summary(config: PlaygroundConfig, result: Mapping[str, Any]) -> None
     confidence = _confidence_score(grid)
     sample_count = _summary_sample_count(summary, samples)
     parameter_count = _parameter_count(network_layers)
+    run_quality = _run_quality_label(validation_accuracy, gap)
+    gap_note = _gap_quality_label(gap)
+    confidence_note = _decision_confidence_note(confidence)
+    validation_value = _format_percent(validation_accuracy)
+    gap_value = _format_percentage_points(gap)
+    confidence_value = _format_percent(confidence)
+    chips = _summary_chips(
+        config=config,
+        samples=samples,
+        parameter_count=parameter_count,
+        sample_count=sample_count,
+    )
+    if compact:
+        st.markdown(
+            _compact_summary_panel(
+                run_quality=run_quality,
+                gap_note=gap_note,
+                confidence_note=confidence_note,
+                validation_value=validation_value,
+                gap_value=gap_value,
+                confidence_value=confidence_value,
+                chips=chips,
+            ),
+            unsafe_allow_html=True,
+        )
+        return
     headline = (
-        f"{_run_quality_label(validation_accuracy, gap)}: "
-        f"{_gap_quality_label(gap)}, {_decision_confidence_note(confidence)}"
+        f"{run_quality}: "
+        f"{gap_note}, {confidence_note}"
     )
     st.markdown(
         _summary_banner(
             headline,
-            [
-                f"{parameter_count:,} params",
-                f"{len(config.hidden_layers)} hidden layer(s)",
-                f"{sample_count:,} samples",
-                _class_balance(samples),
-            ],
+            chips,
         ),
         unsafe_allow_html=True,
     )
     columns = st.columns(3)
     cards = [
-        _metric_card("Validation", _format_percent(validation_accuracy), "held-out accuracy"),
-        _metric_card("Train-val gap", _format_percentage_points(gap), _gap_quality_label(gap), state=_gap_state(gap)),
+        _metric_card("Validation", validation_value, "held-out accuracy"),
+        _metric_card("Train-val gap", gap_value, gap_note, state=_gap_state(gap)),
         _metric_card(
             "Decision confidence",
-            _format_percent(confidence),
-            _decision_confidence_note(confidence),
+            confidence_value,
+            confidence_note,
             state="ready" if confidence >= 0.35 else "incomplete",
         ),
     ]
@@ -1394,7 +1626,8 @@ def main(
         trained_config, result, evidence_root = evidence_result
         trained_preset = preset_label or "Latest ORCHESTRATE evidence"
         pending_changes = False
-        st.caption(f"Loaded evidence from `{evidence_root}`.")
+        if not compact:
+            st.caption(f"Loaded evidence from `{evidence_root}`.")
 
     trained_config_dict = asdict(trained_config)
     if interactive_controls:
@@ -1408,7 +1641,7 @@ def main(
         _render_compact_header(active_app, trained_preset, trained_config)
     else:
         _render_hero(active_app, trained_preset, trained_config)
-    if not interactive_controls:
+    if not interactive_controls and not compact:
         st.caption("Charts use the persisted ORCHESTRATE arguments for this app.")
     if result["status"] == "missing_torch":
         st.error(result["detail"])
@@ -1417,7 +1650,7 @@ def main(
     if pending_changes:
         st.warning("Controls changed. The visible charts and evidence still show the last trained run.")
 
-    _render_summary(trained_config, result)
+    _render_summary(trained_config, result, compact=compact)
     if not compact:
         _render_guided_flow(pending_changes=pending_changes, result_status=str(result.get("status", "")))
         _render_interpretation_cards(result)

--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground/playground_ui.py
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground/playground_ui.py
@@ -1243,7 +1243,7 @@ def _render_summary(config: PlaygroundConfig, result: Mapping[str, Any]) -> None
     parameter_count = _parameter_count(network_layers)
     headline = (
         f"{_run_quality_label(validation_accuracy, gap)}: "
-        f"{_format_percent(validation_accuracy)} validation, {_gap_quality_label(gap)}"
+        f"{_gap_quality_label(gap)}, {_decision_confidence_note(confidence)}"
     )
     st.markdown(
         _summary_banner(

--- a/src/agilab/pages/4_ANALYSIS.py
+++ b/src/agilab/pages/4_ANALYSIS.py
@@ -1601,7 +1601,7 @@ def _migrate_declared_app_surface_config(active_app_path: Path | None, cfg: dict
         else []
     )
     if seed_restricts_views:
-        desired_modules = _dedupe_preserve_order(seed_modules)
+        desired_modules = _dedupe_preserve_order(seed_modules or [_APP_UI_PAGE_KEY])
         if pages.get("restrict_to_view_module") is not True:
             pages["restrict_to_view_module"] = True
             changed = True
@@ -1610,16 +1610,6 @@ def _migrate_declared_app_surface_config(active_app_path: Path | None, cfg: dict
             changed = True
 
     if _declared_app_ui_page_config(active_app_path) is None:
-        raw_modules = pages.get("view_module")
-        if isinstance(raw_modules, list):
-            desired_modules = [
-                value
-                for value in raw_modules
-                if not (isinstance(value, str) and value.strip() == _APP_UI_PAGE_KEY)
-            ]
-            if pages.get("view_module") != desired_modules:
-                pages["view_module"] = desired_modules
-                changed = True
         if _APP_UI_PAGE_KEY in pages:
             del pages[_APP_UI_PAGE_KEY]
             changed = True

--- a/test/test_analysis_page_helpers.py
+++ b/test/test_analysis_page_helpers.py
@@ -889,8 +889,38 @@ def test_migrate_declared_app_surface_config_replaces_legacy_app_ui_bridge(tmp_p
     }
     assert cfg["pages"] == {
         "restrict_to_view_module": True,
-        "view_module": [],
+        "view_module": ["view_app_ui"],
     }
+
+
+def test_migrate_declared_app_surface_config_keeps_single_sidebar_launcher(tmp_path: Path):
+    module = _load_analysis_module()
+    app = tmp_path / "demo_project"
+    settings = app / "src" / "app_settings.toml"
+    settings.parent.mkdir(parents=True)
+    settings.write_text(
+        "\n".join(
+            [
+                "[pages]",
+                "restrict_to_view_module = true",
+                "view_module = []",
+                "",
+                "[app_surface]",
+                'title = "Demo Surface"',
+                'entrypoint = "demo/app_surface.py"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    cfg = {"pages": {"view_module": []}}
+
+    changed = module._migrate_declared_app_surface_config(app, cfg)
+
+    assert changed is True
+    assert cfg["pages"]["restrict_to_view_module"] is True
+    assert cfg["pages"]["view_module"] == ["view_app_ui"]
+    assert "view_app_ui" not in cfg["pages"]
 
 
 def test_configured_view_options_restricts_to_declared_available_views(tmp_path: Path):

--- a/test/test_ci_workflow.py
+++ b/test/test_ci_workflow.py
@@ -159,8 +159,8 @@ def test_ci_workflow_includes_minimal_first_proof_contract() -> None:
     assert "clean-public-install" in text
     assert "os: [ubuntu-latest, macos-latest, windows-latest]" in text
     assert "tools/install_release_proof_package.py" in text
-    assert "Check release package is visible on PyPI" in text
-    assert "python tools/install_release_proof_package.py --check-available-only" in text
+    assert "Check release package is installable from PyPI" in text
+    assert "python tools/install_release_proof_package.py --check-installable-only" in text
     assert "steps.release-package.outputs.available == 'true'" in text
     assert "GITHUB_EVENT_NAME" in text
     assert "python tools/install_release_proof_package.py --retries 20 --delay-seconds 15" in text

--- a/test/test_coverage_shard_plan.py
+++ b/test/test_coverage_shard_plan.py
@@ -52,6 +52,7 @@ def test_static_plan_preserves_fallback_chunks_when_timings_are_missing(tmp_path
     assert list(chunks) == list(module.AGI_GUI_CHUNKS)
     assert "src/agilab/lib/agi-gui/test/test_agi_gui_package.py" in chunks["support"]
     assert "test/test_env_footprint.py" in chunks["support"]
+    assert "test/test_pytorch_playground_app.py" in chunks["support"]
     assert chunks["pages-flow"] == [
         "test/test_ui_pages.py",
         "-k",

--- a/test/test_coverage_workflow.py
+++ b/test/test_coverage_workflow.py
@@ -167,6 +167,12 @@ def test_agi_gui_coverage_includes_pages_lib_package_tests() -> None:
     assert "src/agilab/lib/agi-gui/test" in run_block
 
 
+def test_agi_gui_coverage_includes_pytorch_playground_app_surface_regressions() -> None:
+    run_block = _agi_gui_run_block()
+
+    assert "test/test_pytorch_playground_app.py" in run_block
+
+
 def test_agi_gui_coverage_uses_parallel_chunk_matrix_profile() -> None:
     run_block = _agi_gui_run_block()
     combine_block = _agi_gui_combine_block()

--- a/test/test_install_release_proof_package.py
+++ b/test/test_install_release_proof_package.py
@@ -144,3 +144,42 @@ def test_pypi_release_visible_returns_false_when_release_is_absent() -> None:
         "2026.05.12.post3",
         opener=opener,
     )
+
+
+def test_pypi_release_installable_uses_pip_dry_run_exact_spec() -> None:
+    module = _load_module()
+    calls: list[list[str]] = []
+
+    def runner(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+        calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, returncode=0)
+
+    assert module.pypi_release_installable(
+        "agilab[examples]==2026.05.20",
+        runner=runner,
+    )
+
+    assert calls == [
+        [
+            module.sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--dry-run",
+            "--ignore-installed",
+            "--no-cache-dir",
+            "agilab[examples]==2026.05.20",
+        ]
+    ]
+
+
+def test_pypi_release_installable_returns_false_when_resolution_fails() -> None:
+    module = _load_module()
+
+    def runner(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(cmd, returncode=1)
+
+    assert not module.pypi_release_installable(
+        "agilab[examples]==2026.05.20",
+        runner=runner,
+    )

--- a/test/test_pytorch_playground_app.py
+++ b/test/test_pytorch_playground_app.py
@@ -1291,7 +1291,8 @@ def test_pytorch_playground_summary_uses_shared_header_style(monkeypatch: pytest
     assert "agilab-header-card" in markup
     assert "Surface" in markup
     assert "PyTorch Playground" in markup
-    assert "Strong run: 96% validation, low overfit" in markup
+    assert "Strong run: low overfit, clear boundary" in markup
+    assert markup.count("96%") == 1
     assert "Train-val gap" in markup
     assert "3.8 pp" in markup
     assert "Decision confidence" in markup

--- a/test/test_pytorch_playground_app.py
+++ b/test/test_pytorch_playground_app.py
@@ -1244,6 +1244,65 @@ def test_pytorch_playground_evidence_and_figure_helpers_cover_fallbacks(monkeypa
     assert module._cached_loss_landscape(module.asdict(config), 4, 0.5)["status"] == "missing_torch"
 
 
+def test_pytorch_playground_summary_uses_shared_header_style(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_module()
+    rendered: list[str] = []
+
+    class FakeColumn:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc):
+            return False
+
+    class FakeStreamlit:
+        def columns(self, spec):
+            count = spec if isinstance(spec, int) else len(spec)
+            return [FakeColumn() for _ in range(count)]
+
+        def markdown(self, body, **_kwargs):
+            rendered.append(str(body))
+
+    monkeypatch.setattr(module, "st", FakeStreamlit())
+
+    config = module.PlaygroundConfig(hidden_layers=(16, 8), feature_names=("x1", "x2"))
+    samples = pd.DataFrame(
+        {
+            "x1": [0.0, 0.1, 0.2, 0.3],
+            "x2": [0.0, 0.1, 0.2, 0.3],
+            "target": [0, 0, 1, 1],
+        }
+    )
+    result = {
+        "samples": samples,
+        "grid": pd.DataFrame({"probability": [0.0, 1.0]}),
+        "network_layers": pd.DataFrame({"parameters": [100, 154]}),
+        "summary": {
+            "train_accuracy": 0.998,
+            "validation_accuracy": 0.96,
+            "samples": 320,
+        },
+    }
+
+    module._render_compact_header(PROJECT_PATH.resolve(), "ORCHESTRATE args", config)
+    module._render_summary(config, result)
+
+    markup = "\n".join(rendered)
+    assert "agilab-header-card" in markup
+    assert "Surface" in markup
+    assert "PyTorch Playground" in markup
+    assert "Strong run: 96% validation, low overfit" in markup
+    assert "Train-val gap" in markup
+    assert "3.8 pp" in markup
+    assert "Decision confidence" in markup
+    assert "254 params" in markup
+    assert "2 hidden layer(s)" in markup
+    assert "320 samples" in markup
+    assert "50/50% class split" in markup
+    assert "Boundary confidence" not in markup
+    assert "mean distance from indecision" not in markup
+
+
 def test_pytorch_playground_fake_nn_covers_model_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
     module = _load_module()
 

--- a/test/test_pytorch_playground_app.py
+++ b/test/test_pytorch_playground_app.py
@@ -339,6 +339,7 @@ def test_app_surface_full_renders_orchestrate_form_and_analysis_together(monkeyp
 
     assert ("page_config", {"page_title": "PyTorch Playground", "layout": "wide"}) in events
     assert ("columns", [0.70, 0.30]) in events
+    assert not any(kind == "column_caption" for kind, _payload in events)
 
     form_event = next(payload for kind, payload in events if kind == "form")
     assert form_event["env"] is fake_runtime_env
@@ -1347,8 +1348,7 @@ def test_pytorch_playground_summary_uses_shared_header_style(monkeypatch: pytest
 
     markup = "\n".join(rendered)
     assert "agilab-header-card" in markup
-    assert "Surface" in markup
-    assert "PyTorch Playground" in markup
+    assert "ORCHESTRATE args" in markup
     assert "Strong run: low overfit, clear boundary" in markup
     assert markup.count("96%") == 1
     assert "Train-val gap" in markup
@@ -1360,6 +1360,52 @@ def test_pytorch_playground_summary_uses_shared_header_style(monkeypatch: pytest
     assert "50/50% class split" in markup
     assert "Boundary confidence" not in markup
     assert "mean distance from indecision" not in markup
+
+
+def test_pytorch_playground_compact_summary_keeps_tabs_close(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_module()
+    rendered: list[str] = []
+
+    class FakeStreamlit:
+        def markdown(self, body, **_kwargs):
+            rendered.append(str(body))
+
+    monkeypatch.setattr(module, "st", FakeStreamlit())
+
+    config = module.PlaygroundConfig(hidden_layers=(16, 8), feature_names=("x1", "x2"))
+    samples = pd.DataFrame(
+        {
+            "x1": [0.0, 0.1, 0.2, 0.3],
+            "x2": [0.0, 0.1, 0.2, 0.3],
+            "target": [0, 0, 1, 1],
+        }
+    )
+    result = {
+        "samples": samples,
+        "grid": pd.DataFrame({"probability": [0.0, 1.0]}),
+        "network_layers": pd.DataFrame({"parameters": [100, 154]}),
+        "summary": {
+            "train_accuracy": 0.998,
+            "validation_accuracy": 0.96,
+            "samples": 320,
+        },
+    }
+
+    module._render_compact_header(PROJECT_PATH.resolve(), "ORCHESTRATE args", config)
+    module._render_summary(config, result, compact=True)
+
+    markup = "\n".join(rendered)
+    assert "agilab-pt-compact-meta" in markup
+    assert "agilab-pt-run-panel" in markup
+    assert "agilab-header-card" not in markup
+    assert "Strong run: low overfit" not in markup
+    assert "Strong run" in markup
+    assert markup.count("96%") == 1
+    assert "ORCHESTRATE args" in markup
+    assert "app: pytorch_playground_project" in markup
+    assert "Validation" in markup
+    assert "Train-val gap" in markup
+    assert "Decision confidence" in markup
 
 
 def test_pytorch_playground_fake_nn_covers_model_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1638,6 +1684,7 @@ def test_pytorch_playground_app_args_form_uses_project_scoped_static_json() -> N
     assert "def _render_wide_args_form" in source
     assert "def _render_compact_args_form" in source
     assert "def persist_current_args" in source
+    assert "Quick fields are enough" not in source
     assert ".columns(" in source
     assert "Loss landscape" in source
     assert "def _build_synced_run_snippet" in source

--- a/test/test_pytorch_playground_app.py
+++ b/test/test_pytorch_playground_app.py
@@ -117,6 +117,60 @@ def test_app_surface_import_prefers_package_when_streamlit_puts_script_dir_first
         sys.modules.update(original_modules)
 
 
+def test_app_surface_drops_shadowing_script_module(monkeypatch):
+    spec = importlib.util.spec_from_file_location("pytorch_playground_app_surface_shadow_test", APP_SURFACE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+
+    shadow = ModuleType("pytorch_playground")
+    shadow.__file__ = str(APP_SURFACE_PATH.resolve().parent / "pytorch_playground.py")
+    child = ModuleType("pytorch_playground.core")
+    monkeypatch.setitem(sys.modules, "pytorch_playground", shadow)
+    monkeypatch.setitem(sys.modules, "pytorch_playground.core", child)
+
+    try:
+        module._drop_shadowed_package_module()
+    finally:
+        sys.modules.pop(spec.name, None)
+
+    assert "pytorch_playground" not in sys.modules
+    assert "pytorch_playground.core" not in sys.modules
+
+
+def test_app_surface_resolves_active_app_from_argv_and_evidence_dirs(monkeypatch, tmp_path: Path):
+    spec = importlib.util.spec_from_file_location("pytorch_playground_app_surface_paths_test", APP_SURFACE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+
+    app_path = tmp_path / "pytorch_playground_project"
+    app_path.mkdir()
+    monkeypatch.setattr(sys, "argv", ["app_surface.py", "--active-app", str(app_path)])
+
+    env = SimpleNamespace(
+        AGILAB_EXPORT_ABS=tmp_path / "export",
+        target="pytorch_target",
+        app="pytorch_playground_project",
+    )
+    args = SimpleNamespace(data_out="pytorch_playground/evidence")
+
+    try:
+        resolved = module._resolve_active_app_path()
+        evidence_dirs = module._analysis_evidence_dirs(env, args, app_path)
+    finally:
+        sys.modules.pop(spec.name, None)
+
+    assert resolved == app_path.resolve()
+    assert evidence_dirs == [
+        (tmp_path / "export" / "pytorch_target" / "pytorch_playground").resolve(),
+        (tmp_path / "export" / "pytorch_playground_project" / "pytorch_playground").resolve(),
+        Path("pytorch_playground/evidence").resolve(),
+    ]
+
+
 def test_app_surface_analysis_uses_orchestrate_args(monkeypatch):
     spec = importlib.util.spec_from_file_location("pytorch_playground_app_surface_analysis_test", APP_SURFACE_PATH)
     assert spec is not None and spec.loader is not None
@@ -1085,6 +1139,10 @@ def test_pytorch_playground_analysis_uses_evidence_without_training(
         "_cached_loss_landscape",
         lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("analysis must not compute landscape on render")),
     )
+    monkeypatch.setattr(module, "_decision_figure", lambda *_args, **_kwargs: "decision-figure")
+    monkeypatch.setattr(module, "_history_figure", lambda *_args, **_kwargs: "history-figure")
+    monkeypatch.setattr(module, "_network_figure", lambda *_args, **_kwargs: "network-figure")
+    monkeypatch.setattr(module, "_loss_landscape_figure", lambda *_args, **_kwargs: "landscape-figure")
 
     module.main(
         interactive_controls=False,

--- a/test/test_ui_pages.py
+++ b/test/test_ui_pages.py
@@ -1471,6 +1471,63 @@ def test_explore_page_sidebar_view_selection_persists(mock_ui_env):
     assert "current_page=" in reloaded_sidebar_markdown
 
 
+def test_explore_page_app_surface_back_keeps_single_app_ui_sidebar_view(mock_ui_env):
+    """Returning from an app surface keeps the sidebar scoped to the app UI launcher."""
+    pages_dir = mock_ui_env["pages_dir"]
+    (pages_dir / "view_app_ui.py").write_text(
+        "import streamlit as st\n\n"
+        "def main():\n"
+        "    st.write('app ui bridge')\n",
+        encoding="utf-8",
+    )
+    (pages_dir / "view_other.py").write_text(
+        "import streamlit as st\n\n"
+        "def main():\n"
+        "    st.write('other view')\n",
+        encoding="utf-8",
+    )
+    app_surface = mock_ui_env["project_dir"] / "src" / "demo" / "app_surface.py"
+    app_surface.parent.mkdir(parents=True)
+    app_surface.write_text("def render(**_kwargs): pass\n", encoding="utf-8")
+    settings_payload = (
+        "[pages]\n"
+        "restrict_to_view_module = true\n"
+        "view_module = []\n"
+        "\n"
+        "[app_surface]\n"
+        "title = 'Demo Surface'\n"
+        "entrypoint = 'demo/app_surface.py'\n"
+    )
+    (mock_ui_env["project_dir"] / "src" / "app_settings.toml").write_text(
+        settings_payload,
+        encoding="utf-8",
+    )
+
+    at = _app_test("src/agilab/pages/4_ANALYSIS.py")
+    at.query_params["current_page"] = "main"
+    at.query_params["hide_app_surface"] = "true"
+    env = AgiEnv(apps_path=mock_ui_env["apps_dir"], app="flight_telemetry_project", verbose=0)
+    env.AGILAB_PAGES_ABS = str(pages_dir)
+    env.resolve_user_app_settings_file("flight_telemetry_project").write_text(
+        settings_payload,
+        encoding="utf-8",
+    )
+    at.session_state["env"] = env
+
+    at.run()
+
+    assert not at.exception
+    sidebar_markdown = "\n".join(str(item.value) for item in at.sidebar.markdown)
+    assert "view_app_ui" in sidebar_markdown
+    assert "view_other" not in sidebar_markdown
+    assert "current_page=" in sidebar_markdown
+    with env.resolve_user_app_settings_file("flight_telemetry_project").open("rb") as f:
+        persisted = tomllib.load(f)
+    assert persisted["pages"]["restrict_to_view_module"] is True
+    assert persisted["pages"]["view_module"] == ["view_app_ui"]
+    assert "view_app_ui" not in persisted["pages"]
+
+
 def test_explore_page_sidebar_notebook_selection_persists(mock_ui_env):
     """ANALYSIS persists selected project notebook launcher links."""
     notebooks_dir = mock_ui_env["project_dir"] / "notebooks"

--- a/tools/coverage_shard_plan.py
+++ b/tools/coverage_shard_plan.py
@@ -52,6 +52,7 @@ STATIC_AGI_GUI_CHUNKS: tuple[tuple[str, tuple[str, ...]], ...] = (
             "test/test_analysis_page_helpers.py",
             "test/test_about_agilab_helpers.py",
             "test/test_app_template_registry.py",
+            "test/test_pytorch_playground_app.py",
             "test/test_code_editor_support.py",
             "test/test_cluster_flight_validation.py",
             "test/test_cluster_lan_discovery.py",

--- a/tools/install_release_proof_package.py
+++ b/tools/install_release_proof_package.py
@@ -101,6 +101,25 @@ def _show_available_versions(package_name: str, runner: Runner) -> None:
     runner([sys.executable, "-m", "pip", "index", "versions", package_name])
 
 
+def pypi_release_installable(
+    package_spec: str,
+    *,
+    runner: Runner = _run,
+) -> bool:
+    """Return whether pip can resolve the manifest-pinned release spec."""
+    cmd = [
+        sys.executable,
+        "-m",
+        "pip",
+        "install",
+        "--dry-run",
+        "--ignore-installed",
+        "--no-cache-dir",
+        package_spec,
+    ]
+    return int(runner(cmd).returncode) == 0
+
+
 def install_with_retry(
     package_name: str,
     package_spec: str,
@@ -170,15 +189,36 @@ def main(argv: Sequence[str] | None = None) -> int:
             "release tag."
         ),
     )
+    parser.add_argument(
+        "--check-installable-only",
+        action="store_true",
+        help=(
+            "Exit 0 only when pip can resolve the exact release-proof package "
+            "spec from PyPI. This is stricter than visibility and catches stale "
+            "split-package dependencies."
+        ),
+    )
     args = parser.parse_args(argv)
 
     package_name, package_version, package_spec = release_package_spec(args.manifest)
+    if args.check_available_only and args.check_installable_only:
+        parser.error("--check-available-only and --check-installable-only are mutually exclusive")
     if args.check_available_only:
         if pypi_release_visible(package_name, package_version):
             print(f"[install] {package_name} {package_version} is visible on PyPI")
             return 0
         print(
             f"[install] {package_name} {package_version} is not visible on PyPI",
+            file=sys.stderr,
+        )
+        _show_available_versions(package_name, _run)
+        return 1
+    if args.check_installable_only:
+        if pypi_release_installable(package_spec):
+            print(f"[install] {package_spec} is installable from PyPI")
+            return 0
+        print(
+            f"[install] {package_spec} is not installable from PyPI",
             file=sys.stderr,
         )
         _show_available_versions(package_name, _run)


### PR DESCRIPTION
## Summary
- refresh the PyTorch Playground analysis header and run-quality summary with shared header-card styling
- harden summary formatting for invalid numeric values and negative sample counts
- preserve the app-surface sidebar scope when returning to ANALYSIS
- avoid duplicate validation summary controls in the PyTorch playground UI
- add `test/test_pytorch_playground_app.py` to the `agi-gui` coverage shard plan and guard it with workflow/shard-plan tests
- add focused app-surface helper coverage for active-app path resolution, evidence directory derivation, and shadowed-module cleanup

## Validation
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files tools/coverage_shard_plan.py test/test_coverage_shard_plan.py test/test_coverage_workflow.py test/test_pytorch_playground_app.py`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_coverage_shard_plan.py test/test_coverage_workflow.py test/test_pytorch_playground_app.py`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui`
- `uv --preview-features extra-build-dependencies run python tools/generate_component_coverage_badges.py --components agi-gui agilab` (no tracked badge diff; both remain `96%`)
- `uv --preview-features extra-build-dependencies run python tools/coverage_badge_guard.py --changed-only --require-fresh-xml`

Coverage XML refreshed locally: `coverage-agi-gui.xml` line-rate `96.04%` (`41782/43505`).
