### PR TITLE
[codex] clarify PyTorch playground evidence refresh

### DIFF
--- a/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/app_surface.py
+++ b/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/app_surface.py
@@ -189,7 +189,7 @@ def _render_run_button(
 ) -> None:
     import streamlit as st
 
-    if not container.button("Run training", type="primary", use_container_width=True):
+    if not container.button("Refresh evidence", type="primary", use_container_width=True):
         return
     try:
         runtime_env, args_model = _load_orchestrate_args(active_app_path)
@@ -198,7 +198,7 @@ def _render_run_button(
         )
         if callable(persist_current_args):
             args_model = persist_current_args(env=runtime_env)
-        with st.spinner("Running PyTorch training"):
+        with st.spinner("Refreshing PyTorch evidence"):
             summary = _run_playground_once(runtime_env, args_model)
     except Exception as exc:
         container.error(f"Run failed: {exc}")

--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground/app_surface.py
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground/app_surface.py
@@ -189,7 +189,7 @@ def _render_run_button(
 ) -> None:
     import streamlit as st
 
-    if not container.button("Run training", type="primary", use_container_width=True):
+    if not container.button("Refresh evidence", type="primary", use_container_width=True):
         return
     try:
         runtime_env, args_model = _load_orchestrate_args(active_app_path)
@@ -198,7 +198,7 @@ def _render_run_button(
         )
         if callable(persist_current_args):
             args_model = persist_current_args(env=runtime_env)
-        with st.spinner("Running PyTorch training"):
+        with st.spinner("Refreshing PyTorch evidence"):
             summary = _run_playground_once(runtime_env, args_model)
     except Exception as exc:
         container.error(f"Run failed: {exc}")

--- a/test/test_pytorch_playground_app.py
+++ b/test/test_pytorch_playground_app.py
@@ -447,8 +447,8 @@ def test_app_surface_full_run_button_executes_before_analysis(monkeypatch):
         def caption(self, message):
             events.append(("column_caption", (self.name, message)))
 
-        def button(self, *_args, **_kwargs):
-            events.append(("button", self.name))
+        def button(self, label, **kwargs):
+            events.append(("button", (self.name, label, kwargs)))
             return self.name == "controls"
 
         def error(self, message):
@@ -514,6 +514,11 @@ def test_app_surface_full_run_button_executes_before_analysis(monkeypatch):
 
     ordered = [kind for kind, _payload in events if kind in {"form", "button", "run", "analysis"}]
     assert ordered == ["button", "run", "form", "analysis"]
+    assert (
+        "button",
+        ("controls", "Refresh evidence", {"type": "primary", "use_container_width": True}),
+    ) in events
+    assert ("spinner", "Refreshing PyTorch evidence") in events
     assert load_calls == [PROJECT_PATH.resolve(), PROJECT_PATH.resolve()]
     assert ("column_success", "Run complete. Evidence refreshed (1 row).") in events
 


### PR DESCRIPTION
## Summary

Clarifies the PyTorch Playground ANALYSIS shortcut so it reads as an evidence refresh, not the formal ORCHESTRATE RUN action. The built-in app source and packaged `agi-app-pytorch-playground` payload copy stay aligned.

## Validation

- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_pytorch_playground_app.py -k 'app_surface_full_run_button_executes_before_analysis or app_surface_full_renders_orchestrate_form_and_analysis_together or source_and_packaged_payload_stay_aligned'` -> 3 passed
- `git diff --cached --check`