### PR TITLE
Fix PyPI retention confirmation session

### DIFF
--- a/.github/workflows/pypi-release-retention.yaml
+++ b/.github/workflows/pypi-release-retention.yaml
@@ -54,6 +54,7 @@ jobs:
             --packages "$packages" \
             --protect-version "${{ inputs.protect_version }}" \
             --confirm-delete \
+            --direct-web-only \
             --json \
             --github-step-summary "$GITHUB_STEP_SUMMARY" \
             --github-confirm-login-repository "$GITHUB_REPOSITORY" \

--- a/test/test_pypi_release_retention.py
+++ b/test/test_pypi_release_retention.py
@@ -247,6 +247,44 @@ def test_delete_release_falls_back_when_pypi_cleanup_cannot_parse_delete_form(mo
     assert "direct PyPI web fallback" in capsys.readouterr().err
 
 
+def test_delete_release_can_use_direct_web_only(monkeypatch, capsys) -> None:
+    module = _load_module()
+    fallback_calls = []
+
+    def fail_run(*args, **kwargs):
+        raise AssertionError("pypi-cleanup should not run in direct-web-only mode")
+
+    def fake_fallback(**kwargs):
+        fallback_calls.append(kwargs)
+
+    monkeypatch.setattr(module.subprocess, "run", fail_run)
+    monkeypatch.setattr(module, "delete_release_via_pypi_web", fake_fallback)
+
+    module.delete_release(
+        package="agilab",
+        version="2026.05.17",
+        repo="pypi",
+        username="maintainer",
+        password="secret",
+        auth_code="123456",
+        direct_web_only=True,
+    )
+
+    assert fallback_calls == [
+        {
+            "package": "agilab",
+            "version": "2026.05.17",
+            "repo": "pypi",
+            "username": "maintainer",
+            "password": "secret",
+            "auth_code": "123456",
+            "totp_secret": None,
+            "confirm_login_url_provider": None,
+        }
+    ]
+    assert "direct PyPI web deletion" in capsys.readouterr().err
+
+
 def test_delete_form_parser_accepts_empty_action_and_fills_confirmation_fields() -> None:
     module = _load_module()
 
@@ -484,6 +522,7 @@ def test_main_deletes_old_versions_and_verifies_retention(monkeypatch, capsys) -
         auth_code=None,
         totp_secret=None,
         confirm_login_url_provider=None,
+        direct_web_only=False,
         verbose=False,
     ):
         deletes.append((package, version, username, password, auth_code))
@@ -539,6 +578,7 @@ def test_main_deletes_old_versions_with_disaligned_protected_versions(monkeypatc
         auth_code=None,
         totp_secret=None,
         confirm_login_url_provider=None,
+        direct_web_only=False,
         verbose=False,
     ):
         deletes.append((package, version))
@@ -597,6 +637,7 @@ def test_main_rotates_totp_between_package_deletions(monkeypatch) -> None:
         auth_code=None,
         totp_secret=None,
         confirm_login_url_provider=None,
+        direct_web_only=False,
         verbose=False,
     ):
         deletes.append((package, auth_code, totp_secret))

--- a/tools/pypi_release_retention.py
+++ b/tools/pypi_release_retention.py
@@ -605,8 +605,32 @@ def delete_release(
     auth_code: str | None = None,
     totp_secret: str | None = None,
     confirm_login_url_provider: Callable[[], str | None] | None = None,
+    direct_web_only: bool = False,
     verbose: bool = False,
 ) -> None:
+    if direct_web_only:
+        print(
+            "[pypi-retention] using direct PyPI web deletion",
+            file=sys.stderr,
+        )
+        try:
+            delete_release_via_pypi_web(
+                package=package,
+                version=version,
+                repo=repo,
+                username=username,
+                password=password,
+                auth_code=auth_code,
+                totp_secret=totp_secret,
+                confirm_login_url_provider=confirm_login_url_provider,
+            )
+        except Exception as exc:
+            raise SystemExit(
+                "ERROR: direct PyPI web deletion failed for "
+                f"{package} {version}: {exc}"
+            ) from exc
+        return
+
     cmd = [
         "pypi-cleanup",
         "--version-regex",
@@ -817,6 +841,15 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument("--json", action="store_true")
     parser.add_argument("--verbose", action="store_true")
+    parser.add_argument(
+        "--direct-web-only",
+        action="store_true",
+        help=(
+            "Use the in-process PyPI web deletion flow directly instead of "
+            "trying pypi-cleanup first. This keeps unrecognized-login "
+            "confirmation tied to the deletion session."
+        ),
+    )
     parser.add_argument("--verify-attempts", type=int, default=6)
     parser.add_argument("--retry-delay", type=float, default=10.0)
     parser.add_argument(
@@ -931,6 +964,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     auth_code=auth_code,
                     totp_secret=rotating_totp_secret,
                     confirm_login_url_provider=confirm_provider,
+                    direct_web_only=args.direct_web_only,
                     verbose=args.verbose,
                 )
                 if rotating_totp_secret:


### PR DESCRIPTION
## Summary\n- add a direct PyPI web deletion mode for retention cleanup\n- run the manual retention workflow in direct mode so PyPI confirmation applies to the deletion session\n- cover the direct mode with a focused unit test\n\n## Validation\n- ./dev test test/test_pypi_release_retention.py test/test_pypi_publish_workflow.py -q\n- pypi-release-retention run 26295438396 succeeded for agilab, keeping 2026.5.21.post1\n- PyPI JSON now lists only agilab 2026.5.21.post1