### PR TITLE
ci: update coverage cache actions to Node 24

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -245,7 +245,7 @@ jobs:
         run: mkdir -p test-results
 
       - name: Restore agi-gui timing history
-        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: test-results/coverage-agi-gui-timing-cache
           key: agi-gui-junit-timings-${{ runner.os }}-${{ github.ref_name }}-${{ github.run_id }}
@@ -428,7 +428,7 @@ jobs:
 
       - name: Save agi-gui timing history
         if: always() && hashFiles('test-results/coverage-agi-gui-timing-cache/*.xml') != ''
-        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: test-results/coverage-agi-gui-timing-cache
           key: agi-gui-junit-timings-${{ runner.os }}-${{ github.ref_name }}-${{ github.run_id }}

--- a/test/test_github_actions_node_runtime.py
+++ b/test/test_github_actions_node_runtime.py
@@ -8,6 +8,8 @@ WORKFLOW_GLOBS = ("*.yml", "*.yaml")
 WORKFLOW_DIR = Path(".github/workflows")
 
 NODE24_COMPATIBLE_ACTIONS = {
+    "actions/cache/restore": {"v5"},
+    "actions/cache/save": {"v5"},
     "actions/checkout": {"v5", "v6"},
     "actions/setup-python": {"v6"},
     "actions/upload-artifact": {"v6", "v7"},
@@ -30,7 +32,7 @@ def _workflow_files() -> list[Path]:
 
 def test_github_actions_use_node24_compatible_major_versions() -> None:
     failures: list[str] = []
-    uses_pattern = re.compile(r"uses:\s+([\w.-]+/[\w.-]+)@([^\s#]+)")
+    uses_pattern = re.compile(r"uses:\s+([\w.-]+/[\w.-]+(?:/[\w.-]+)*)@([^\s#]+)")
     pinned_sha_pattern = re.compile(r"^[0-9a-f]{40}$")
 
     for workflow in _workflow_files():


### PR DESCRIPTION
## Summary
- update coverage workflow cache restore/save actions from actions/cache v4.2.4 to v5.0.5
- extend the GitHub Actions Node runtime guard to cover sub-actions such as actions/cache/restore and actions/cache/save

## Validation
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_coverage_workflow.py test/test_github_actions_node_runtime.py test/test_ci_workflow.py test/test_workflow_parity.py
- uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files .github/workflows/coverage.yml test/test_github_actions_node_runtime.py