### PR TITLE
test: include evidence contract in GUI coverage

### DIFF
--- a/badges/coverage-agi-gui.svg
+++ b/badges/coverage-agi-gui.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="153" height="20" role="img" aria-label="agi-gui coverage: 95%">
+<svg xmlns="http://www.w3.org/2000/svg" width="153" height="20" role="img" aria-label="agi-gui coverage: 96%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="61.0" y="15" fill="#010101" fill-opacity=".3">agi-gui coverage</text>
   <text x="61.0" y="14">agi-gui coverage</text>
-  <text x="137.5" y="15" fill="#010101" fill-opacity=".3">95%</text>
-  <text x="137.5" y="14">95%</text>
+  <text x="137.5" y="15" fill="#010101" fill-opacity=".3">96%</text>
+  <text x="137.5" y="14">96%</text>
 </g>
 </svg>

--- a/test/test_coverage_shard_plan.py
+++ b/test/test_coverage_shard_plan.py
@@ -52,6 +52,7 @@ def test_static_plan_preserves_fallback_chunks_when_timings_are_missing(tmp_path
     assert list(chunks) == list(module.AGI_GUI_CHUNKS)
     assert "src/agilab/lib/agi-gui/test/test_agi_gui_package.py" in chunks["support"]
     assert "src/agilab/test" not in chunks["support"]
+    assert "test/test_evidence_contract.py" in chunks["support"]
     assert "test/test_env_footprint.py" in chunks["support"]
     assert "test/test_pytorch_playground_app.py" in chunks["support"]
     assert "test/test_python_versions.py" in chunks["support"]

--- a/tools/coverage_shard_plan.py
+++ b/tools/coverage_shard_plan.py
@@ -58,6 +58,7 @@ STATIC_AGI_GUI_CHUNKS: tuple[tuple[str, tuple[str, ...]], ...] = (
             "test/test_dag_distributed_submitter.py",
             "test/test_agilab_dev_shortcuts.py",
             "test/test_ga_regression_selector.py",
+            "test/test_evidence_contract.py",
             "test/test_evidence_graph.py",
             "test/test_env_file_utils.py",
             "test/test_env_footprint.py",


### PR DESCRIPTION
## Summary
- schedule the existing evidence contract tests in the AGI-GUI coverage support shard
- add a shard-plan regression so the test cannot silently fall out again
- refresh the AGI-GUI coverage badge from 95% to 96%

## Validation
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_coverage_shard_plan.py test/test_evidence_contract.py
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_coverage_shard_plan.py test/test_generate_component_coverage_badges.py
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile badges
- uv --preview-features extra-build-dependencies run python tools/impact_validate.py --staged