### PR TITLE
test: isolate barycentric fake dependencies

### DIFF
--- a/test/test_view_barycentric.py
+++ b/test/test_view_barycentric.py
@@ -12,6 +12,13 @@ import pytest
 
 
 MODULE_PATH = Path("src/agilab/apps-pages/view_barycentric/src/view_barycentric/view_barycentric.py")
+FAKE_DEP_MODULES = (
+    "barviz",
+    "scipy",
+    "scipy.signal",
+    "sklearn",
+    "sklearn.preprocessing",
+)
 
 BARVIZ_STUB = """
 from types import SimpleNamespace
@@ -91,6 +98,18 @@ class _State(dict):
 
     def __setattr__(self, item, value):
         self[item] = value
+
+
+@pytest.fixture(autouse=True)
+def _restore_page_dependency_modules():
+    sentinel = object()
+    original_modules = {name: sys.modules.get(name, sentinel) for name in FAKE_DEP_MODULES}
+    yield
+    for name, original in original_modules.items():
+        if original is sentinel:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = original
 
 
 def _load_module():


### PR DESCRIPTION
## Summary
- restore scientific dependency modules after barycentric page tests
- prevent fake scipy/sklearn modules seeded for AppTest from leaking into later report tests
- fixes the post-merge timing-balanced coverage failure where production-readiness ran after barycentric tests

## Validation
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_view_barycentric.py
- uv --preview-features extra-build-dependencies run --group dev --extra ui --extra viz pytest -q --maxfail=1 --disable-warnings -o addopts='' -m 'not integration' test/test_view_barycentric.py test/test_production_readiness_report.py::test_build_report_passes_static_production_readiness_contracts
- local reproduction of the failed timing-balanced pipeline shard: 716 passed
- uv --preview-features extra-build-dependencies run python tools/impact_validate.py --staged