### PR TITLE
Normalize app argument forms

### DIFF
--- a/src/agilab/apps/builtin/execution_pandas_project/src/app_args_form.py
+++ b/src/agilab/apps/builtin/execution_pandas_project/src/app_args_form.py
@@ -24,7 +24,7 @@ def _k(name: str) -> str:
 def _get_env():
     env = st.session_state.get("env") or st.session_state.get("_env")
     if env is None:
-        st.error("AGILab environment is not initialised yet. Return to the main page and try again.")
+        st.error("AGILAB environment is not initialised yet. Return to the main page and try again.")
         st.stop()
     return env
 

--- a/src/agilab/apps/builtin/execution_polars_project/src/app_args_form.py
+++ b/src/agilab/apps/builtin/execution_polars_project/src/app_args_form.py
@@ -24,7 +24,7 @@ def _k(name: str) -> str:
 def _get_env():
     env = st.session_state.get("env") or st.session_state.get("_env")
     if env is None:
-        st.error("AGILab environment is not initialised yet. Return to the main page and try again.")
+        st.error("AGILAB environment is not initialised yet. Return to the main page and try again.")
         st.stop()
     return env
 

--- a/src/agilab/apps/builtin/flight_telemetry_project/src/app_args_form.py
+++ b/src/agilab/apps/builtin/flight_telemetry_project/src/app_args_form.py
@@ -27,7 +27,7 @@ def _k(name: str) -> str:
 def _get_env():
     env = st.session_state.get("env") or st.session_state.get("_env")
     if env is None:
-        st.error("AGILab environment is not initialised yet. Return to the main page and try again.")
+        st.error("AGILAB environment is not initialised yet. Return to the main page and try again.")
         st.stop()
     return env
 

--- a/src/agilab/apps/builtin/meteo_forecast_project/src/app_args_form.py
+++ b/src/agilab/apps/builtin/meteo_forecast_project/src/app_args_form.py
@@ -24,7 +24,7 @@ def _k(name: str) -> str:
 def _get_env():
     env = st.session_state.get("env") or st.session_state.get("_env")
     if env is None:
-        st.error("AGILab environment is not initialised yet. Return to the main page and try again.")
+        st.error("AGILAB environment is not initialised yet. Return to the main page and try again.")
         st.stop()
     return env
 

--- a/src/agilab/apps/builtin/mission_decision_project/src/app_args_form.py
+++ b/src/agilab/apps/builtin/mission_decision_project/src/app_args_form.py
@@ -24,7 +24,7 @@ def _k(name: str) -> str:
 def _get_env():
     env = st.session_state.get("env") or st.session_state.get("_env")
     if env is None:
-        st.error("AGILab environment is not initialised yet. Return to the main page and try again.")
+        st.error("AGILAB environment is not initialised yet. Return to the main page and try again.")
         st.stop()
     return env
 

--- a/src/agilab/apps/builtin/mycode_project/src/app_args_form.py
+++ b/src/agilab/apps/builtin/mycode_project/src/app_args_form.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+from typing import Any
+
+import streamlit as st
+from pydantic import ValidationError
+
+_HERE = Path(__file__).resolve().parent
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+
+from mycode import MycodeArgs, dump_args, load_args
+
+
+PAGE_ID = "mycode_project:app_args_form"
+
+
+def _k(name: str) -> str:
+    return f"{PAGE_ID}:{name}"
+
+
+def _get_env():
+    env = st.session_state.get("env") or st.session_state.get("_env")
+    if env is None:
+        st.error("AGILAB environment is not initialised yet. Return to the main page and try again.")
+        st.stop()
+    return env
+
+
+def _load_current_args(settings_path: Path) -> MycodeArgs:
+    try:
+        return load_args(settings_path)
+    except Exception as exc:
+        st.warning(f"Unable to load Mycode args from `{settings_path}`: {exc}")
+        return MycodeArgs()
+
+
+env = _get_env()
+settings_path = Path(env.app_settings_file)
+current_args = _load_current_args(settings_path)
+current_payload = current_args.model_dump(mode="json")
+
+st.caption(
+    "Mycode is the minimal built-in app skeleton. Edit these paths and small run controls "
+    "before adapting the manager and worker code to your own workflow."
+)
+
+for key, default in (
+    ("data_in", str(current_payload.get("data_in", "mycode/dataset") or "mycode/dataset")),
+    ("data_out", str(current_payload.get("data_out", "mycode/dataframe") or "mycode/dataframe")),
+    ("files", str(current_payload.get("files", "*") or "*")),
+    ("nfile", int(current_payload.get("nfile", 1) or 1)),
+    ("nskip", int(current_payload.get("nskip", 0) or 0)),
+    ("nread", int(current_payload.get("nread", 0) or 0)),
+    ("reset_target", bool(current_payload.get("reset_target", False))),
+):
+    st.session_state.setdefault(_k(key), default)
+
+c1, c2, c3 = st.columns([2, 2, 1.2])
+with c1:
+    st.text_input("Input directory", key=_k("data_in"), help="Relative path under shared storage.")
+with c2:
+    st.text_input("Output directory", key=_k("data_out"), help="Relative path under shared storage.")
+with c3:
+    st.text_input("Files filter", key=_k("files"), help="Wildcard or regex consumed by your worker.")
+
+c4, c5, c6, c7 = st.columns([1.1, 1.1, 1.1, 1.1])
+with c4:
+    st.number_input("Number of files", key=_k("nfile"), min_value=0, step=1)
+with c5:
+    st.number_input("Lines to skip", key=_k("nskip"), min_value=0, step=1)
+with c6:
+    st.number_input("Lines to read", key=_k("nread"), min_value=0, step=1)
+with c7:
+    st.checkbox("Reset output", key=_k("reset_target"))
+
+candidate: dict[str, Any] = {
+    "files": (st.session_state.get(_k("files")) or "*").strip() or "*",
+    "nfile": st.session_state.get(_k("nfile"), 1),
+    "nskip": st.session_state.get(_k("nskip"), 0),
+    "nread": st.session_state.get(_k("nread"), 0),
+    "reset_target": bool(st.session_state.get(_k("reset_target"), False)),
+}
+
+data_in_raw = (st.session_state.get(_k("data_in")) or "").strip()
+data_out_raw = (st.session_state.get(_k("data_out")) or "").strip()
+if data_in_raw:
+    candidate["data_in"] = data_in_raw
+if data_out_raw:
+    candidate["data_out"] = data_out_raw
+
+try:
+    validated = MycodeArgs(**candidate)
+except ValidationError as exc:
+    st.error("Invalid Mycode parameters:")
+    if hasattr(env, "humanize_validation_errors"):
+        for msg in env.humanize_validation_errors(exc):
+            st.markdown(msg)
+    else:
+        st.code(str(exc))
+else:
+    validated_payload = validated.model_dump(mode="json")
+    if validated_payload != current_payload:
+        dump_args(validated, settings_path)
+        app_settings = st.session_state.get("app_settings")
+        if not isinstance(app_settings, dict):
+            app_settings = {}
+        app_settings.setdefault("cluster", {})
+        app_settings["args"] = validated_payload
+        st.session_state["app_settings"] = app_settings
+        st.session_state["is_args_from_ui"] = True
+        st.success(f"Saved to `{settings_path}`.")
+    else:
+        st.info("No changes to save.")
+
+    if hasattr(env, "resolve_share_path"):
+        resolved_data_in = env.resolve_share_path(validated.data_in)
+        resolved_data_out = env.resolve_share_path(validated.data_out)
+        st.caption(f"Resolved input: `{resolved_data_in}`  •  output: `{resolved_data_out}`")

--- a/src/agilab/apps/builtin/uav_queue_project/src/app_args_form.py
+++ b/src/agilab/apps/builtin/uav_queue_project/src/app_args_form.py
@@ -24,7 +24,7 @@ def _k(name: str) -> str:
 def _get_env():
     env = st.session_state.get("env") or st.session_state.get("_env")
     if env is None:
-        st.error("AGILab environment is not initialised yet. Return to the main page and try again.")
+        st.error("AGILAB environment is not initialised yet. Return to the main page and try again.")
         st.stop()
     return env
 

--- a/src/agilab/apps/builtin/uav_relay_queue_project/src/app_args_form.py
+++ b/src/agilab/apps/builtin/uav_relay_queue_project/src/app_args_form.py
@@ -24,7 +24,7 @@ def _k(name: str) -> str:
 def _get_env():
     env = st.session_state.get("env") or st.session_state.get("_env")
     if env is None:
-        st.error("AGILab environment is not initialised yet. Return to the main page and try again.")
+        st.error("AGILAB environment is not initialised yet. Return to the main page and try again.")
         st.stop()
     return env
 

--- a/src/agilab/apps/builtin/weather_forecast_project/src/app_args_form.py
+++ b/src/agilab/apps/builtin/weather_forecast_project/src/app_args_form.py
@@ -24,7 +24,7 @@ def _k(name: str) -> str:
 def _get_env():
     env = st.session_state.get("env") or st.session_state.get("_env")
     if env is None:
-        st.error("AGILab environment is not initialised yet. Return to the main page and try again.")
+        st.error("AGILAB environment is not initialised yet. Return to the main page and try again.")
         st.stop()
     return env
 

--- a/src/agilab/apps/templates/dag_app_template/src/app_args_form.py
+++ b/src/agilab/apps/templates/dag_app_template/src/app_args_form.py
@@ -7,10 +7,7 @@ from dag_app import DagAppArgs as ArgsModel
 
 
 def _get_env():
-    try:
-        return st.session_state["_env"]
-    except KeyError:
-        return None
+    return st.session_state.get("env") or st.session_state.get("_env")
 
 
 def render() -> None:

--- a/src/agilab/apps/templates/fireducks_app_template/src/app_args_form.py
+++ b/src/agilab/apps/templates/fireducks_app_template/src/app_args_form.py
@@ -7,10 +7,7 @@ from fireducks_app import FireducksAppArgs as ArgsModel
 
 
 def _get_env():
-    try:
-        return st.session_state["_env"]
-    except KeyError:
-        return None
+    return st.session_state.get("env") or st.session_state.get("_env")
 
 
 def render() -> None:

--- a/src/agilab/apps/templates/pandas_app_template/src/app_args_form.py
+++ b/src/agilab/apps/templates/pandas_app_template/src/app_args_form.py
@@ -7,10 +7,7 @@ from pandas_app import PandasAppArgs as ArgsModel
 
 
 def _get_env():
-    try:
-        return st.session_state["_env"]
-    except KeyError:
-        return None
+    return st.session_state.get("env") or st.session_state.get("_env")
 
 
 def render() -> None:

--- a/src/agilab/apps/templates/polars_app_template/src/app_args_form.py
+++ b/src/agilab/apps/templates/polars_app_template/src/app_args_form.py
@@ -7,10 +7,7 @@ from polars_app import PolarsAppArgs as ArgsModel
 
 
 def _get_env():
-    try:
-        return st.session_state["_env"]
-    except KeyError:
-        return None
+    return st.session_state.get("env") or st.session_state.get("_env")
 
 
 def render() -> None:

--- a/src/agilab/apps/templates/simple_app_template/src/app_args_form.py
+++ b/src/agilab/apps/templates/simple_app_template/src/app_args_form.py
@@ -7,10 +7,7 @@ from simple_app import SimpleAppArgs as ArgsModel
 
 
 def _get_env():
-    try:
-        return st.session_state["_env"]
-    except KeyError:
-        return None
+    return st.session_state.get("env") or st.session_state.get("_env")
 
 
 def render() -> None:

--- a/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/src/app_args_form.py
+++ b/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/src/app_args_form.py
@@ -27,7 +27,7 @@ def _k(name: str) -> str:
 def _get_env():
     env = st.session_state.get("env") or st.session_state.get("_env")
     if env is None:
-        st.error("AGILab environment is not initialised yet. Return to the main page and try again.")
+        st.error("AGILAB environment is not initialised yet. Return to the main page and try again.")
         st.stop()
     return env
 

--- a/src/agilab/lib/agi-app-mission-decision/src/agi_app_mission_decision/project/mission_decision_project/src/app_args_form.py
+++ b/src/agilab/lib/agi-app-mission-decision/src/agi_app_mission_decision/project/mission_decision_project/src/app_args_form.py
@@ -24,7 +24,7 @@ def _k(name: str) -> str:
 def _get_env():
     env = st.session_state.get("env") or st.session_state.get("_env")
     if env is None:
-        st.error("AGILab environment is not initialised yet. Return to the main page and try again.")
+        st.error("AGILAB environment is not initialised yet. Return to the main page and try again.")
         st.stop()
     return env
 

--- a/src/agilab/lib/agi-app-uav-relay-queue/src/agi_app_uav_relay_queue/project/uav_relay_queue_project/src/app_args_form.py
+++ b/src/agilab/lib/agi-app-uav-relay-queue/src/agi_app_uav_relay_queue/project/uav_relay_queue_project/src/app_args_form.py
@@ -24,7 +24,7 @@ def _k(name: str) -> str:
 def _get_env():
     env = st.session_state.get("env") or st.session_state.get("_env")
     if env is None:
-        st.error("AGILab environment is not initialised yet. Return to the main page and try again.")
+        st.error("AGILAB environment is not initialised yet. Return to the main page and try again.")
         st.stop()
     return env
 
@@ -138,7 +138,11 @@ else:
         app_settings.setdefault("cluster", {})
         app_settings["args"] = validated_payload
         app_settings.setdefault("pages", {})
-        app_settings["pages"]["view_module"] = ["view_relay_resilience", "view_maps_network"]
+        app_settings["pages"]["view_module"] = [
+            "view_scenario_cockpit",
+            "view_relay_resilience",
+            "view_maps_network",
+        ]
         st.session_state["app_settings"] = app_settings
         st.session_state["is_args_from_ui"] = True
         st.success(f"Saved to `{settings_path}`.")

--- a/src/agilab/lib/agi-app-weather-forecast/src/agi_app_weather_forecast/project/weather_forecast_project/src/app_args_form.py
+++ b/src/agilab/lib/agi-app-weather-forecast/src/agi_app_weather_forecast/project/weather_forecast_project/src/app_args_form.py
@@ -24,7 +24,7 @@ def _k(name: str) -> str:
 def _get_env():
     env = st.session_state.get("env") or st.session_state.get("_env")
     if env is None:
-        st.error("AGILab environment is not initialised yet. Return to the main page and try again.")
+        st.error("AGILAB environment is not initialised yet. Return to the main page and try again.")
         st.stop()
     return env
 

--- a/test/test_app_args_form_normalization.py
+++ b/test/test_app_args_form_normalization.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+import tomllib
+
+from streamlit.testing.v1 import AppTest
+
+
+APP_ARGS_FORM_ROOT = Path("src/agilab")
+APP_ARGS_FORM_PATTERNS = (
+    "apps/builtin/*_project/src/app_args_form.py",
+    "apps/templates/*_template/src/app_args_form.py",
+    "lib/agi-app-*/src/*/project/*_project/src/app_args_form.py",
+)
+
+PACKAGED_FORM_PAIRS = (
+    (
+        Path("src/agilab/apps/builtin/flight_telemetry_project/src/app_args_form.py"),
+        Path(
+            "src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/"
+            "project/flight_telemetry_project/src/app_args_form.py"
+        ),
+    ),
+    (
+        Path("src/agilab/apps/builtin/mission_decision_project/src/app_args_form.py"),
+        Path(
+            "src/agilab/lib/agi-app-mission-decision/src/agi_app_mission_decision/"
+            "project/mission_decision_project/src/app_args_form.py"
+        ),
+    ),
+    (
+        Path("src/agilab/apps/builtin/pytorch_playground_project/src/app_args_form.py"),
+        Path(
+            "src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/"
+            "project/pytorch_playground_project/src/app_args_form.py"
+        ),
+    ),
+    (
+        Path("src/agilab/apps/builtin/uav_relay_queue_project/src/app_args_form.py"),
+        Path(
+            "src/agilab/lib/agi-app-uav-relay-queue/src/agi_app_uav_relay_queue/"
+            "project/uav_relay_queue_project/src/app_args_form.py"
+        ),
+    ),
+    (
+        Path("src/agilab/apps/builtin/weather_forecast_project/src/app_args_form.py"),
+        Path(
+            "src/agilab/lib/agi-app-weather-forecast/src/agi_app_weather_forecast/"
+            "project/weather_forecast_project/src/app_args_form.py"
+        ),
+    ),
+)
+
+
+class _MycodeEnv(SimpleNamespace):
+    def resolve_share_path(self, value):
+        path = Path(value)
+        if path.is_absolute():
+            return path
+        return self.share_root / path
+
+    @staticmethod
+    def humanize_validation_errors(exc):
+        return [str(item) for item in exc.errors()]
+
+
+def _app_args_forms() -> list[Path]:
+    paths: set[Path] = set()
+    for pattern in APP_ARGS_FORM_PATTERNS:
+        paths.update(APP_ARGS_FORM_ROOT.glob(pattern))
+    return sorted(paths)
+
+
+def test_all_app_args_form_files_are_non_empty() -> None:
+    empty_forms = [str(path) for path in _app_args_forms() if not path.read_text(encoding="utf-8").strip()]
+    assert empty_forms == []
+
+
+def test_app_args_form_environment_wording_is_normalized() -> None:
+    offenders = [
+        str(path)
+        for path in _app_args_forms()
+        if "AGILab environment" in path.read_text(encoding="utf-8")
+    ]
+    assert offenders == []
+
+
+def test_template_forms_accept_public_and_private_env_session_keys() -> None:
+    template_forms = sorted(Path("src/agilab/apps/templates").glob("*_template/src/app_args_form.py"))
+    assert template_forms
+    for path in template_forms:
+        source = path.read_text(encoding="utf-8")
+        assert 'st.session_state.get("env") or st.session_state.get("_env")' in source
+
+
+def test_packaged_app_args_forms_match_builtin_sources() -> None:
+    for source_path, packaged_path in PACKAGED_FORM_PAIRS:
+        assert source_path.read_text(encoding="utf-8") == packaged_path.read_text(encoding="utf-8")
+
+
+def test_mycode_app_args_form_renders_and_persists_args(tmp_path: Path) -> None:
+    settings_root = tmp_path / "mycode_project"
+    settings_root.mkdir()
+    settings_file = settings_root / "app_settings.toml"
+    settings_file.write_text("[args]\n", encoding="utf-8")
+    env = _MycodeEnv(
+        app_settings_file=str(settings_file),
+        share_root=tmp_path / "share",
+    )
+
+    at = AppTest.from_file(
+        "src/agilab/apps/builtin/mycode_project/src/app_args_form.py",
+        default_timeout=20,
+    )
+    at.session_state["env"] = env
+    at.session_state["app_settings"] = {"args": {}, "cluster": {}}
+
+    at.run()
+
+    assert not at.exception
+    assert at.text_input(key="mycode_project:app_args_form:data_in").value == "mycode/dataset"
+    assert at.text_input(key="mycode_project:app_args_form:data_out").value == "mycode/dataframe"
+    assert at.text_input(key="mycode_project:app_args_form:files").value == "*"
+
+    at.text_input(key="mycode_project:app_args_form:files").set_value("*.csv")
+    at.number_input(key="mycode_project:app_args_form:nfile").set_value(3)
+    at.number_input(key="mycode_project:app_args_form:nskip").set_value(2)
+    at.checkbox(key="mycode_project:app_args_form:reset_target").set_value(True)
+    at.run()
+
+    assert not at.exception
+    assert any("Saved to" in message.value for message in at.success)
+    with settings_file.open("rb") as stream:
+        persisted = tomllib.load(stream)
+    assert persisted["args"]["files"] == "*.csv"
+    assert persisted["args"]["nfile"] == 3
+    assert persisted["args"]["nskip"] == 2
+    assert persisted["args"]["reset_target"] is True
+    assert at.session_state["app_settings"]["args"]["files"] == "*.csv"


### PR DESCRIPTION
## Summary
- add the missing Streamlit argument form for mycode_project
- normalize template env lookup to accept both env and _env session keys
- align packaged app form copies with built-in sources and add guardrails for empty/drifted forms

## Validation
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_app_args_form_normalization.py
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_execution_playground_forms.py test/test_weather_forecast_form.py test/test_tescia_diagnostic_project.py::test_tescia_app_args_form_exposes_standalone_ai_controls
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_app_installer_packaging.py
- uv --preview-features extra-build-dependencies run python tools/impact_validate.py --staged
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui