### PR TITLE
Add built-in app args form smoke matrix

### DIFF
--- a/src/agilab/apps/builtin/flight_telemetry_project/src/app_args_form.py
+++ b/src/agilab/apps/builtin/flight_telemetry_project/src/app_args_form.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
 import os
+import sys
 from datetime import date
 from pathlib import Path
 from typing import Any
 
 import streamlit as st
 from pydantic import ValidationError
+
+_HERE = Path(__file__).resolve().parent
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
 
 from flight_telemetry import (
     FlightArgs,

--- a/src/agilab/apps/builtin/global_dag_project/src/global_dag/__init__.py
+++ b/src/agilab/apps/builtin/global_dag_project/src/global_dag/__init__.py
@@ -1,4 +1,11 @@
 from .app_args import ArgsModel, GlobalDagArgs, dump_args, load_args
-from .global_dag import GlobalDag, GlobalDagApp
 
 __all__ = ["ArgsModel", "GlobalDag", "GlobalDagApp", "GlobalDagArgs", "dump_args", "load_args"]
+
+
+def __getattr__(name: str):
+    if name in {"GlobalDag", "GlobalDagApp"}:
+        from .global_dag import GlobalDag, GlobalDagApp
+
+        return {"GlobalDag": GlobalDag, "GlobalDagApp": GlobalDagApp}[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/src/app_args_form.py
+++ b/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/src/app_args_form.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
 import os
+import sys
 from datetime import date
 from pathlib import Path
 from typing import Any
 
 import streamlit as st
 from pydantic import ValidationError
+
+_HERE = Path(__file__).resolve().parent
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
 
 from flight_telemetry import (
     FlightArgs,

--- a/test/test_app_args_form_normalization.py
+++ b/test/test_app_args_form_normalization.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 from pathlib import Path
+import shutil
 from types import SimpleNamespace
 import tomllib
 
+import pytest
 from streamlit.testing.v1 import AppTest
 
 
@@ -53,7 +55,10 @@ PACKAGED_FORM_PAIRS = (
 )
 
 
-class _MycodeEnv(SimpleNamespace):
+class _BuiltinFormEnv(SimpleNamespace):
+    def share_root_path(self):
+        return self.share_root
+
     def resolve_share_path(self, value):
         path = Path(value)
         if path.is_absolute():
@@ -70,6 +75,27 @@ def _app_args_forms() -> list[Path]:
     for pattern in APP_ARGS_FORM_PATTERNS:
         paths.update(APP_ARGS_FORM_ROOT.glob(pattern))
     return sorted(paths)
+
+
+def _builtin_app_args_forms() -> list[Path]:
+    return sorted(Path("src/agilab/apps/builtin").glob("*_project/src/app_args_form.py"))
+
+
+def _app_name_from_form(form_path: Path) -> str:
+    return form_path.parent.parent.name
+
+
+def _seed_settings_for_form(form_path: Path, tmp_path: Path) -> Path:
+    app_name = _app_name_from_form(form_path)
+    settings_root = tmp_path / app_name
+    settings_root.mkdir(parents=True, exist_ok=True)
+    settings_file = settings_root / "app_settings.toml"
+    source_settings = form_path.parent / "app_settings.toml"
+    if source_settings.is_file():
+        shutil.copyfile(source_settings, settings_file)
+    else:
+        settings_file.write_text("[args]\n", encoding="utf-8")
+    return settings_file
 
 
 def test_all_app_args_form_files_are_non_empty() -> None:
@@ -99,12 +125,43 @@ def test_packaged_app_args_forms_match_builtin_sources() -> None:
         assert source_path.read_text(encoding="utf-8") == packaged_path.read_text(encoding="utf-8")
 
 
+@pytest.mark.parametrize(
+    "form_path",
+    _builtin_app_args_forms(),
+    ids=lambda path: _app_name_from_form(path),
+)
+def test_builtin_app_args_form_renders_without_streamlit_exception(
+    form_path: Path,
+    tmp_path: Path,
+) -> None:
+    app_name = _app_name_from_form(form_path)
+    settings_file = _seed_settings_for_form(form_path, tmp_path)
+    env = _BuiltinFormEnv(
+        AGILAB_EXPORT_ABS=str(tmp_path / "export"),
+        active_app=str(form_path.parent.parent),
+        app=app_name,
+        app_settings_file=str(settings_file),
+        apps_path=str(form_path.parents[2]),
+        envars={},
+        share_root=tmp_path / "share",
+        target=app_name,
+    )
+
+    at = AppTest.from_file(str(form_path), default_timeout=30)
+    at.session_state["env"] = env
+    at.session_state["_env"] = env
+    at.session_state["app_settings"] = {"args": {}, "cluster": {}}
+
+    at.run()
+
+    assert not at.exception
+
+
 def test_mycode_app_args_form_renders_and_persists_args(tmp_path: Path) -> None:
-    settings_root = tmp_path / "mycode_project"
-    settings_root.mkdir()
-    settings_file = settings_root / "app_settings.toml"
+    settings_file = tmp_path / "mycode_project" / "app_settings.toml"
+    settings_file.parent.mkdir()
     settings_file.write_text("[args]\n", encoding="utf-8")
-    env = _MycodeEnv(
+    env = _BuiltinFormEnv(
         app_settings_file=str(settings_file),
         share_root=tmp_path / "share",
     )


### PR DESCRIPTION
## Summary
- add an AppTest smoke matrix for every built-in app_args_form.py
- make the Flight args form self-bootstrap its local app package imports
- make global_dag package imports lazy so rendering app args does not import the full manager stack

## Validation
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_app_args_form_normalization.py
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_ui_pages.py -k 'flight_telemetry_project_app_args_form or flight_app_args_form_import or app_args_form_no_changes or app_args_form_exposes_only_file_source'
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_app_installer_packaging.py
- uv --preview-features extra-build-dependencies run python tools/impact_validate.py --staged
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui