### PR TITLE
Add public app catalog docs

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -1,9 +1,9 @@
 {
-  "file_count": 217,
+  "file_count": 218,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "7c26f40be212e256a4dd4bc85433a322490350c9ac93dfb3c22217e9e1760934",
+  "source_digest_sha256": "a8d3afe123f5172b1a3eb12a59b80eb93f3dd268915aa9e4bb83fcdad11876cf",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "7c26f40be212e256a4dd4bc85433a322490350c9ac93dfb3c22217e9e1760934"
+  "target_digest_sha256": "a8d3afe123f5172b1a3eb12a59b80eb93f3dd268915aa9e4bb83fcdad11876cf"
 }

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -109,6 +109,7 @@ references, and example projects.
    :caption: Examples
 
    Demo chooser <demos>
+   Public app catalog <public-app-catalog>
    Execution playground <execution-playground>
    Industrial optimization examples <industrial-optimization-examples>
    Notebook migration example <notebook-migration-skforecast-meteo>

--- a/docs/source/package-publishing-policy.rst
+++ b/docs/source/package-publishing-policy.rst
@@ -86,6 +86,9 @@ package artifacts. Each package carries one project payload and exposes it
 through the ``agilab.apps`` entry point group so ``agi-env`` can resolve
 installed apps without the monorepo checkout once that package is installed:
 
+For a user-facing map from PROJECT names to package names, PyPI status, and
+recommended use cases, see :doc:`public-app-catalog`.
+
 - ``agi-app-mission-decision``
 - ``agi-app-pandas-execution``
 - ``agi-app-polars-execution``

--- a/docs/source/public-app-catalog.rst
+++ b/docs/source/public-app-catalog.rst
@@ -1,0 +1,111 @@
+Public app catalog
+==================
+
+This catalog maps the public AGILAB app names users see in PROJECT to the
+package or source status behind them. It is intentionally more exhaustive than
+the README: the README stays focused on the shortest adoption path, while this
+page is the reference for choosing an app.
+
+Status legend:
+
+- ``PyPI app package``: promoted by the current release plan and installable as
+  a standalone ``agi-app-*`` payload.
+- ``Release artifact``: built as an app payload artifact, but not currently
+  promoted to PyPI by the release plan.
+- ``Source built-in``: present in the public source checkout for development,
+  examples, or compatibility, without a separate promoted payload package.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 24 26 18 32
+
+   * - Project
+     - Package
+     - Status
+     - When to use it
+   * - ``flight_telemetry_project``
+     - ``agi-app-flight-telemetry``
+     - PyPI app package
+     - First proof and compact end-to-end data ingestion with map/network
+       analysis.
+   * - ``weather_forecast_project``
+     - ``agi-app-weather-forecast``
+     - PyPI app package
+     - Notebook-to-app migration using a small weather forecast dataset,
+       forecast metrics, and promotion evidence.
+   * - ``mission_decision_project``
+     - ``agi-app-mission-decision``
+     - PyPI app package
+     - Deterministic mission-decision evidence with scenario scoring,
+       re-planning, and decision artifacts.
+   * - ``execution_pandas_project``
+     - ``agi-app-pandas-execution``
+     - PyPI app package
+     - Synthetic worker execution playground for the Pandas path and reducer
+       evidence.
+   * - ``execution_polars_project``
+     - ``agi-app-polars-execution``
+     - PyPI app package
+     - Synthetic worker execution playground for the Polars path, comparable
+       with the Pandas app.
+   * - ``global_dag_project``
+     - ``agi-app-global-dag``
+     - PyPI app package
+     - Cross-app DAG template preview and artifact-handoff contract review.
+   * - ``pytorch_playground_project``
+     - ``agi-app-pytorch-playground``
+     - PyPI app package
+     - Reproducible PyTorch classifier playground with persisted controls and
+       evidence artifacts.
+   * - ``tescia_diagnostic_project``
+     - ``agi-app-tescia-diagnostic``
+     - PyPI app package
+     - Evidence-scored diagnostic reasoning cases, better-fix selection, and
+       regression-plan artifacts.
+   * - ``uav_relay_queue_project``
+     - ``agi-app-uav-relay-queue``
+     - PyPI app package
+     - Compact UAV relay queue scenario with relay-health, scenario-cockpit,
+       and network-map analysis.
+   * - ``uav_queue_project``
+     - ``agi-app-uav-queue-project``
+     - Release artifact
+     - Queue-policy proof generator and scenario-cockpit evidence source used
+       by the advanced proof pack.
+   * - ``mycode_project``
+     - None
+     - Source built-in
+     - Minimal app structure reference for adapting manager, worker, settings,
+       and app argument form code.
+   * - ``meteo_forecast_project``
+     - None
+     - Source built-in
+     - Source-checkout weather migration reference kept beside the packaged
+       ``weather_forecast_project`` path.
+
+Recommended first choices
+-------------------------
+
+- Start with ``flight_telemetry_project`` when you want the shortest proof that
+  AGILAB can install, execute, write evidence, and open analysis.
+- Use ``weather_forecast_project`` when the question is notebook migration and
+  reusable forecast artifacts.
+- Use ``pytorch_playground_project`` when you want a more visual AI/ML demo
+  with training evidence.
+- Use ``uav_relay_queue_project`` or ``uav_queue_project`` only after the first
+  proof, because they are better suited to advanced evidence and scenario
+  comparison.
+
+Package truth source
+--------------------
+
+The PyPI publication status comes from the generated release plan and the
+package split contract, not from this page by hand. If the release plan changes,
+update this catalog in the same documentation pass.
+
+See also:
+
+- :doc:`package-publishing-policy` for the package split and trusted publisher
+  contract.
+- :doc:`advanced-proof-pack` for the heavier evidence scenarios.
+- :doc:`execution-playground` for the Pandas/Polars execution comparison.

--- a/test/test_public_app_catalog.py
+++ b/test/test_public_app_catalog.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+import importlib.util
+import sys
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CATALOG_PATH = REPO_ROOT / "docs" / "source" / "public-app-catalog.rst"
+BUILTIN_APPS_PATH = REPO_ROOT / "src" / "agilab" / "apps" / "builtin"
+PACKAGE_SPLIT_CONTRACT_PATH = REPO_ROOT / "tools" / "package_split_contract.py"
+SPEC = importlib.util.spec_from_file_location("agilab_package_split_contract", PACKAGE_SPLIT_CONTRACT_PATH)
+assert SPEC and SPEC.loader
+package_split_contract = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = package_split_contract
+SPEC.loader.exec_module(package_split_contract)
+
+
+def test_public_app_catalog_lists_all_public_app_packages() -> None:
+    catalog = CATALOG_PATH.read_text(encoding="utf-8")
+
+    missing = [package for package, _project in package_split_contract.APP_PROJECT_PACKAGE_SPECS if package not in catalog]
+
+    assert missing == []
+
+
+def test_public_app_catalog_lists_all_builtin_projects() -> None:
+    catalog = CATALOG_PATH.read_text(encoding="utf-8")
+    builtin_projects = sorted(path.name for path in BUILTIN_APPS_PATH.glob("*_project") if path.is_dir())
+
+    missing = [project for project in builtin_projects if project not in catalog]
+
+    assert missing == []


### PR DESCRIPTION
## Summary
- Add a public app catalog page mapping PROJECT names to package names, publication status, and recommended use cases.
- Link the catalog from the docs sidebar and package publishing policy.
- Add a regression test so public app packages and built-in projects cannot silently miss the catalog.

## Validation
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_public_app_catalog.py
- uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp
- uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --delete
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs