### PR TITLE
Guard public app catalog statuses

### DIFF
--- a/test/test_public_app_catalog.py
+++ b/test/test_public_app_catalog.py
@@ -14,12 +14,78 @@ sys.modules[SPEC.name] = package_split_contract
 SPEC.loader.exec_module(package_split_contract)
 
 
+def _catalog_rows() -> dict[str, dict[str, str]]:
+    lines = CATALOG_PATH.read_text(encoding="utf-8").splitlines()
+    rows: dict[str, dict[str, str]] = {}
+    current: list[str] = []
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("* - "):
+            if len(current) >= 4 and current[0] != "Project":
+                rows[current[0]] = {
+                    "package": current[1],
+                    "status": current[2],
+                    "use": " ".join(current[3:]),
+                }
+            current = [stripped.removeprefix("* - ").strip("`")]
+        elif stripped.startswith("- ") and current:
+            current.append(stripped.removeprefix("- ").strip("`"))
+        elif current and len(current) >= 4 and stripped and not stripped.startswith((".. ", ":")):
+            current[-1] = f"{current[-1]} {stripped}".strip()
+    if len(current) >= 4 and current[0] != "Project":
+        rows[current[0]] = {
+            "package": current[1],
+            "status": current[2],
+            "use": " ".join(current[3:]),
+        }
+    return rows
+
+
+def _project_name_for_package(package_path: str) -> str:
+    package_root = REPO_ROOT / package_path
+    for pyproject_path in sorted(package_root.glob("src/*/project/*_project/pyproject.toml")):
+        return pyproject_path.parent.name
+
+    provider_init_path = next(package_root.glob("src/*/__init__.py"))
+    for line in provider_init_path.read_text(encoding="utf-8").splitlines():
+        if line.startswith("PROJECT_NAME"):
+            return line.split("=", 1)[1].strip().strip("'\"")
+    raise AssertionError(f"Unable to resolve project name for {package_path}")
+
+
 def test_public_app_catalog_lists_all_public_app_packages() -> None:
     catalog = CATALOG_PATH.read_text(encoding="utf-8")
 
     missing = [package for package, _project in package_split_contract.APP_PROJECT_PACKAGE_SPECS if package not in catalog]
 
     assert missing == []
+
+
+def test_public_app_catalog_status_matches_release_contract() -> None:
+    rows = _catalog_rows()
+    promoted_packages = set(package_split_contract.PROMOTED_APP_PROJECT_PACKAGE_NAMES)
+
+    expected: dict[str, tuple[str, str]] = {}
+    for package, package_path in package_split_contract.APP_PROJECT_PACKAGE_SPECS:
+        project_name = _project_name_for_package(package_path)
+        status = "PyPI app package" if package in promoted_packages else "Release artifact"
+        expected[project_name] = (package, status)
+    for project_path in sorted(BUILTIN_APPS_PATH.glob("*_project")):
+        expected.setdefault(project_path.name, ("None", "Source built-in"))
+
+    mismatches = {
+        project: {
+            "expected": {"package": package, "status": status},
+            "actual": {
+                "package": rows.get(project, {}).get("package"),
+                "status": rows.get(project, {}).get("status"),
+            },
+        }
+        for project, (package, status) in sorted(expected.items())
+        if rows.get(project, {}).get("package") != package or rows.get(project, {}).get("status") != status
+    }
+
+    assert mismatches == {}
 
 
 def test_public_app_catalog_lists_all_builtin_projects() -> None:


### PR DESCRIPTION
## Summary
- Parse the public app catalog table in tests.
- Verify each listed app package/project status matches tools/package_split_contract.py.
- Cover source-only built-ins so they cannot accidentally claim a PyPI payload.

## Validation
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_public_app_catalog.py
- uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files test/test_public_app_catalog.py