### PR TITLE
Link README surfaces to public app catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ Advanced scenarios such as `mission_decision_project`,
 `execution_pandas_project`, `execution_polars_project`, and
 `uav_relay_queue_project` are collected in the
 [Advanced Proof Pack](https://thalesgroup.github.io/agilab/advanced-proof-pack.html).
+For the full project/package/status matrix, see the
+[Public App Catalog](https://thalesgroup.github.io/agilab/public-app-catalog.html).
 The default hosted flight journey covers `PROJECT`, `ORCHESTRATE`, `WORKFLOW`,
 and `ANALYSIS`, including bundled flight analysis views.
 

--- a/README.pypi.md
+++ b/README.pypi.md
@@ -84,6 +84,8 @@ Advanced scenarios such as `mission_decision_project`,
 `execution_pandas_project`, `execution_polars_project`, and
 `uav_relay_queue_project` are collected in the
 [Advanced Proof Pack](https://thalesgroup.github.io/agilab/advanced-proof-pack.html).
+For the full project/package/status matrix, see the
+[Public App Catalog](https://thalesgroup.github.io/agilab/public-app-catalog.html).
 
 If startup fails, run a progressive fallback:
 


### PR DESCRIPTION
## Summary
- Add a concise Public App Catalog link to README.md.
- Add the same link to README.pypi.md so PyPI readers can find the full project/package/status matrix.

## Validation
- uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files README.md README.pypi.md
- rg -n "Public App Catalog|public-app-catalog" README.md README.pypi.md
- git diff --check