### PR TITLE
Guard notebook export handoff proof

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 218,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "8dc3773501d751357bee864774555f67a9579f9a5ead0568e37f06deedd4dbb9",
+  "source_digest_sha256": "7a75520c6dde73c5a6a19244448199265542b314fbfd169906d4520f9cd7db5a",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "8dc3773501d751357bee864774555f67a9579f9a5ead0568e37f06deedd4dbb9"
+  "target_digest_sha256": "7a75520c6dde73c5a6a19244448199265542b314fbfd169906d4520f9cd7db5a"
 }

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -258,7 +258,9 @@ current public evaluation snapshot.
 - the release-proof profile includes the packaged notebook import lane:
   it creates ``flight_telemetry_from_notebook_project``, runs ``INSTALL``,
   executes the imported project, and opens ANALYSIS far enough to prove the
-  project notebook and analysis links are discoverable
+  project notebook and analysis links are discoverable; it also refreshes the
+  exported ``lab_stages.ipynb`` handoff and verifies the manifest, source cell
+  IDs, runtime roles, artifact references, and handoff file
 - ``tools/newcomer_first_proof.py --json`` writes
   ``~/log/execute/flight_telemetry/run_manifest.json`` so the first proof has one stable
   command/environment/timing/artifact/validation record that the release

--- a/docs/source/roadmap/agilab-future-work.md
+++ b/docs/source/roadmap/agilab-future-work.md
@@ -79,6 +79,9 @@ Concrete items:
   policy, and trusted-publisher contract
 - keep the imported-notebook release smoke in the mandatory release-proof
   profile, not as a separate best-effort demo path
+- keep the exported-notebook handoff smoke in the same release-proof lane so
+  the no-lock-in claim is guarded by manifest, source-cell, runtime-role, and
+  artifact-reference checks
 - require each shipped notebook sample to keep creating an installable and
   runnable app equivalent to its packaged example
 - keep PyPI, GitHub release proof, public docs, and Hugging Face demo text

--- a/src/agilab/notebook_export_support.py
+++ b/src/agilab/notebook_export_support.py
@@ -199,6 +199,13 @@ def _runtime_role_from_engine(value: Any) -> str:
     return ""
 
 
+def _normalize_notebook_runtime_role(value: Any) -> str:
+    normalized = str(value or "").strip().lower().replace("_", "-")
+    if normalized in {"manager", "worker"}:
+        return normalized
+    return ""
+
+
 def _allow_workspace_sibling_apps() -> bool:
     return _truthy_env(os.environ.get(ALLOW_WORKSPACE_SIBLING_APPS_ENV))
 
@@ -717,6 +724,64 @@ def _build_plain_notebook(toml_data: Dict[str, Any]) -> Dict[str, Any]:
     return notebook_data
 
 
+def _metadata_string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value if str(item)]
+
+
+def _notebook_import_metadata_from_stage(raw_stage: Mapping[str, Any]) -> dict[str, Any]:
+    metadata: dict[str, Any] = {}
+    cell_id = str(raw_stage.get("NB_CELL_ID", "") or "")
+    if cell_id:
+        metadata["cell_id"] = cell_id
+
+    raw_cell_index = raw_stage.get("NB_CELL_INDEX")
+    if raw_cell_index not in (None, ""):
+        try:
+            metadata["source_cell_index"] = int(raw_cell_index)
+        except (TypeError, ValueError):
+            metadata["source_cell_index"] = str(raw_cell_index)
+
+    context_ids = _metadata_string_list(raw_stage.get("NB_CONTEXT_IDS", []))
+    if context_ids:
+        metadata["context_ids"] = context_ids
+
+    env_hints = _metadata_string_list(raw_stage.get("NB_ENV_HINTS", []))
+    if env_hints:
+        metadata["env_hints"] = env_hints
+
+    artifact_references = _metadata_string_list(raw_stage.get("NB_ARTIFACT_REFERENCES", []))
+    if artifact_references:
+        metadata["artifact_references"] = artifact_references
+
+    execution_mode = str(raw_stage.get("NB_EXECUTION_MODE", "") or "")
+    if execution_mode:
+        metadata["execution_mode"] = execution_mode
+
+    source_notebook = str(raw_stage.get("NB_SOURCE_NOTEBOOK", "") or "")
+    if source_notebook:
+        metadata["source_notebook"] = source_notebook
+
+    runtime_role = _normalize_notebook_runtime_role(raw_stage.get("NB_RUNTIME_ROLE", ""))
+    if runtime_role:
+        metadata["runtime_role"] = runtime_role
+
+    return metadata
+
+
+def _stage_runtime_role(stage: Mapping[str, Any]) -> str:
+    notebook_import = stage.get("notebook_import", {})
+    if isinstance(notebook_import, Mapping):
+        explicit_role = _normalize_notebook_runtime_role(notebook_import.get("runtime_role", ""))
+        if explicit_role:
+            return explicit_role
+    explicit_role = _normalize_notebook_runtime_role(stage.get("runtime_role", ""))
+    if explicit_role:
+        return explicit_role
+    return _runtime_role_from_engine(stage.get("runtime", ""))
+
+
 def _stage_records(toml_data: Dict[str, Any]) -> list[dict[str, Any]]:
     records: list[dict[str, Any]] = []
     global_index = 0
@@ -731,6 +796,7 @@ def _stage_records(toml_data: Dict[str, Any]) -> list[dict[str, Any]]:
                 model = str(raw_stage.get("M", "") or "")
                 runtime = str(raw_stage.get("R", "") or "")
                 env_root = _normalize_path(raw_stage.get("E", ""))
+                notebook_import = _notebook_import_metadata_from_stage(raw_stage)
             elif isinstance(raw_stage, str):
                 code_text = raw_stage
                 description = ""
@@ -738,23 +804,29 @@ def _stage_records(toml_data: Dict[str, Any]) -> list[dict[str, Any]]:
                 model = ""
                 runtime = ""
                 env_root = ""
+                notebook_import = {}
             else:
                 continue
             if not code_text:
                 continue
-            records.append(
-                {
-                    "index": global_index,
-                    "module": str(module),
-                    "module_index": module_index,
-                    "description": description,
-                    "question": question,
-                    "model": model,
-                    "runtime": runtime,
-                    "env": env_root,
-                    "code": code_text,
-                }
-            )
+            runtime_role = _normalize_notebook_runtime_role(
+                notebook_import.get("runtime_role", "")
+            ) or _runtime_role_from_engine(runtime)
+            record = {
+                "index": global_index,
+                "module": str(module),
+                "module_index": module_index,
+                "description": description,
+                "question": question,
+                "model": model,
+                "runtime": runtime,
+                "runtime_role": runtime_role,
+                "env": env_root,
+                "code": code_text,
+            }
+            if notebook_import:
+                record["notebook_import"] = notebook_import
+            records.append(record)
             global_index += 1
     return records
 
@@ -844,20 +916,24 @@ def _stage_cell_manifest_records(notebook_data: Mapping[str, Any]) -> list[dict[
         stage_cell = agilab_metadata.get("stage_cell", {})
         if not isinstance(stage_cell, Mapping) or not stage_cell:
             continue
-        records.append(
-            {
-                "cell_index": index,
-                "cell_id": str(cell.get("id", "") or ""),
-                "kind": str(stage_cell.get("kind", "") or ""),
-                "stage_index": stage_cell.get("stage_index"),
-                "stage_id": str(stage_cell.get("stage_id", "") or ""),
-                "module": str(stage_cell.get("module", "") or ""),
-                "module_index": stage_cell.get("module_index"),
-                "runtime": str(stage_cell.get("runtime", "") or ""),
-                "runtime_role": str(stage_cell.get("runtime_role", "") or agilab_metadata.get("runtime_role", "") or ""),
-                "env": str(stage_cell.get("env", "") or ""),
-            }
-        )
+        record = {
+            "cell_index": index,
+            "cell_id": str(cell.get("id", "") or ""),
+            "kind": str(stage_cell.get("kind", "") or ""),
+            "stage_index": stage_cell.get("stage_index"),
+            "stage_id": str(stage_cell.get("stage_id", "") or ""),
+            "module": str(stage_cell.get("module", "") or ""),
+            "module_index": stage_cell.get("module_index"),
+            "runtime": str(stage_cell.get("runtime", "") or ""),
+            "runtime_role": str(
+                stage_cell.get("runtime_role", "") or agilab_metadata.get("runtime_role", "") or ""
+            ),
+            "env": str(stage_cell.get("env", "") or ""),
+        }
+        notebook_import = stage_cell.get("notebook_import", {})
+        if isinstance(notebook_import, Mapping) and notebook_import:
+            record["notebook_import"] = dict(notebook_import)
+        records.append(record)
     return records
 
 
@@ -900,18 +976,20 @@ def _stage_source_hashes(metadata: Mapping[str, Any]) -> list[dict[str, Any]]:
     for offset, stage in enumerate(stage for stage in stages if isinstance(stage, Mapping)):
         stage_index = int(stage.get("index", offset) or 0)
         source = str(stage.get("code", "") or "")
-        records.append(
-            {
-                "stage_index": stage_index,
-                "stage_id": f"supervisor-stage-{stage_index + 1}",
-                "module": str(stage.get("module", "") or ""),
-                "module_index": stage.get("module_index"),
-                "source_sha256": _sha256_text(source),
-                "source_hash": _sha256_text(source)[:16],
-                "runtime": str(stage.get("runtime", "") or ""),
-                "runtime_role": _runtime_role_from_engine(stage.get("runtime", "")),
-            }
-        )
+        record = {
+            "stage_index": stage_index,
+            "stage_id": f"supervisor-stage-{stage_index + 1}",
+            "module": str(stage.get("module", "") or ""),
+            "module_index": stage.get("module_index"),
+            "source_sha256": _sha256_text(source),
+            "source_hash": _sha256_text(source)[:16],
+            "runtime": str(stage.get("runtime", "") or ""),
+            "runtime_role": _stage_runtime_role(stage),
+        }
+        notebook_import = stage.get("notebook_import", {})
+        if isinstance(notebook_import, Mapping) and notebook_import:
+            record["notebook_import"] = dict(notebook_import)
+        records.append(record)
     return records
 
 
@@ -923,21 +1001,23 @@ def _stage_manifest_records(metadata: Mapping[str, Any]) -> list[dict[str, Any]]
     for offset, stage in enumerate(stage for stage in stages if isinstance(stage, Mapping)):
         stage_index = int(stage.get("index", offset) or 0)
         runtime = str(stage.get("runtime", "") or "")
-        records.append(
-            {
-                "stage_index": stage_index,
-                "stage_id": f"supervisor-stage-{stage_index + 1}",
-                "module": str(stage.get("module", "") or ""),
-                "module_index": stage.get("module_index"),
-                "description": str(stage.get("description", "") or ""),
-                "question": str(stage.get("question", "") or ""),
-                "model": str(stage.get("model", "") or ""),
-                "runtime": runtime,
-                "runtime_role": _runtime_role_from_engine(runtime),
-                "env": str(stage.get("env", "") or ""),
-                "source_hash": _sha256_text(str(stage.get("code", "") or ""))[:16],
-            }
-        )
+        record = {
+            "stage_index": stage_index,
+            "stage_id": f"supervisor-stage-{stage_index + 1}",
+            "module": str(stage.get("module", "") or ""),
+            "module_index": stage.get("module_index"),
+            "description": str(stage.get("description", "") or ""),
+            "question": str(stage.get("question", "") or ""),
+            "model": str(stage.get("model", "") or ""),
+            "runtime": runtime,
+            "runtime_role": _stage_runtime_role(stage),
+            "env": str(stage.get("env", "") or ""),
+            "source_hash": _sha256_text(str(stage.get("code", "") or ""))[:16],
+        }
+        notebook_import = stage.get("notebook_import", {})
+        if isinstance(notebook_import, Mapping) and notebook_import:
+            record["notebook_import"] = dict(notebook_import)
+        records.append(record)
     return records
 
 
@@ -2446,7 +2526,7 @@ def _stage_runner_cell(stage: dict[str, Any]) -> str:
 def _stage_cell_metadata(stage: dict[str, Any], *, kind: str) -> dict[str, Any]:
     stage_index = int(stage.get("index", 0) or 0)
     runtime = str(stage.get("runtime", "") or "")
-    runtime_role = _runtime_role_from_engine(runtime)
+    runtime_role = _stage_runtime_role(stage)
     stage_cell = {
         "schema": NOTEBOOK_EXPORT_STAGE_CELL_SCHEMA,
         "kind": kind,
@@ -2462,6 +2542,9 @@ def _stage_cell_metadata(stage: dict[str, Any], *, kind: str) -> dict[str, Any]:
     }
     if runtime_role:
         stage_cell["runtime_role"] = runtime_role
+    notebook_import = stage.get("notebook_import", {})
+    if isinstance(notebook_import, Mapping) and notebook_import:
+        stage_cell["notebook_import"] = dict(notebook_import)
 
     agilab_payload: dict[str, Any] = {
         "schema": NOTEBOOK_EXPORT_SCHEMA,
@@ -2469,11 +2552,40 @@ def _stage_cell_metadata(stage: dict[str, Any], *, kind: str) -> dict[str, Any]:
     }
     if runtime_role:
         agilab_payload["runtime_role"] = runtime_role
+    if isinstance(notebook_import, Mapping) and notebook_import:
+        agilab_payload["notebook_import"] = dict(notebook_import)
 
     metadata: dict[str, Any] = {"agilab": agilab_payload}
     if runtime_role:
         metadata["tags"] = [f"agilab.runtime.{runtime_role}"]
     return metadata
+
+
+def _stage_notebook_import_context_lines(stage: Mapping[str, Any]) -> list[str]:
+    notebook_import = stage.get("notebook_import", {})
+    if not isinstance(notebook_import, Mapping) or not notebook_import:
+        return []
+
+    lines = ["", "Notebook import metadata:"]
+    source_notebook = str(notebook_import.get("source_notebook", "") or "")
+    cell_id = str(notebook_import.get("cell_id", "") or "")
+    source_cell_index = notebook_import.get("source_cell_index")
+    if source_notebook:
+        lines.append(f"- Source notebook: `{source_notebook}`")
+    if cell_id or source_cell_index not in (None, ""):
+        cell_bits = []
+        if cell_id:
+            cell_bits.append(f"id `{cell_id}`")
+        if source_cell_index not in (None, ""):
+            cell_bits.append(f"index `{source_cell_index}`")
+        lines.append("- Source cell: " + ", ".join(cell_bits))
+    env_hints = _metadata_string_list(notebook_import.get("env_hints", []))
+    if env_hints:
+        lines.append("- Environment hints: " + ", ".join(f"`{hint}`" for hint in env_hints))
+    artifacts = _metadata_string_list(notebook_import.get("artifact_references", []))
+    if artifacts:
+        lines.append("- Artifact references: " + ", ".join(f"`{artifact}`" for artifact in artifacts))
+    return lines
 
 
 def _agilab_notebook_payload(
@@ -2578,6 +2690,7 @@ def build_notebook_document(
                         f"- Question: `{stage.get('question') or ''}`",
                         f"- Runtime: `{stage.get('runtime') or 'runpy'}`",
                         f"- Environment root: `{stage.get('env') or '(current kernel / controller default)'}`",
+                        *_stage_notebook_import_context_lines(stage),
                         "",
                         f"- Edit the next cell if you want to override the saved stage source.",
                         f"- The runner cell below it replays the stage with its recorded runtime. Running the whole notebook executes those runner cells too.",

--- a/test/test_pipeline_editor.py
+++ b/test/test_pipeline_editor.py
@@ -2509,6 +2509,68 @@ def test_notebook_export_manifest_and_verifier_edge_helpers(tmp_path):
     assert checks["stage_source_99"]["status"] == "fail"
 
 
+def test_notebook_export_preserves_import_provenance_metadata(tmp_path):
+    support = notebook_export_support
+    stages_file = tmp_path / "lab_stages.toml"
+    toml_data = {
+        "flight_telemetry_from_notebook_project": [
+            {
+                "D": "Build summary artifacts",
+                "Q": "Imported cell-4 from notebook",
+                "C": "print('summary')\n",
+                "R": "runpy",
+                "NB_CELL_ID": "cell-4",
+                "NB_CELL_INDEX": 4,
+                "NB_CONTEXT_IDS": ["markdown-3"],
+                "NB_ENV_HINTS": ["json", "pandas", "pathlib"],
+                "NB_ARTIFACT_REFERENCES": ["data/flights.csv", "artifacts/summary.json"],
+                "NB_EXECUTION_MODE": "not_executed_import",
+                "NB_SOURCE_NOTEBOOK": "notebooks/source/flight_telemetry_from_notebook.ipynb",
+                "NB_RUNTIME_ROLE": "worker",
+            }
+        ]
+    }
+    context = support.NotebookExportContext(
+        project_name="flight_telemetry_from_notebook_project",
+        module_path="flight_telemetry_from_notebook_project",
+        artifact_dir=str(tmp_path),
+    )
+
+    notebook = support.build_notebook_document(toml_data, stages_file, export_context=context)
+    manifest = support.build_notebook_export_manifest(notebook, stages_file.with_suffix(".ipynb"))
+
+    notebook_stage = notebook["metadata"]["agilab"]["stages"][0]
+    stage = manifest["stages"][0]
+    source_cell = next(cell for cell in manifest["stage_cells"] if cell["kind"] == "source")
+    runner_cell = next(cell for cell in manifest["stage_cells"] if cell["kind"] == "runner")
+    expected_import = {
+        "cell_id": "cell-4",
+        "source_cell_index": 4,
+        "context_ids": ["markdown-3"],
+        "env_hints": ["json", "pandas", "pathlib"],
+        "artifact_references": ["data/flights.csv", "artifacts/summary.json"],
+        "execution_mode": "not_executed_import",
+        "source_notebook": "notebooks/source/flight_telemetry_from_notebook.ipynb",
+        "runtime_role": "worker",
+    }
+
+    assert notebook_stage["notebook_import"] == expected_import
+    assert stage["notebook_import"] == expected_import
+    assert stage["runtime_role"] == "worker"
+    assert source_cell["notebook_import"] == expected_import
+    assert runner_cell["notebook_import"] == expected_import
+    assert source_cell["runtime_role"] == "worker"
+    context_cell_source = "".join(notebook["cells"][4]["source"])
+    assert (
+        "Source notebook: `notebooks/source/flight_telemetry_from_notebook.ipynb`"
+        in context_cell_source
+    )
+    assert (
+        "Artifact references: `data/flights.csv`, `artifacts/summary.json`"
+        in context_cell_source
+    )
+
+
 def test_save_stage_handles_invalid_indices_and_runtime_map_failures(monkeypatch, tmp_path):
     stages_file = tmp_path / "lab_stages.toml"
     errors: list[str] = []

--- a/test/test_source_clone_regression.py
+++ b/test/test_source_clone_regression.py
@@ -373,6 +373,191 @@ asyncio.run(main())
             f"payload={execute_payload!r}; log={execute_log}\n{tail}"
         )
 
+    export_code = r"""
+import json
+import os
+from pathlib import Path
+
+from agi_env import AgiEnv
+from agilab.notebook_export_support import (
+    build_notebook_export_context,
+    notebook_export_manifest_path,
+    verify_notebook_export_manifest,
+)
+from agilab.pipeline_editor import refresh_notebook_export
+
+root = Path.cwd()
+marker = "NOTEBOOK_IMPORT_EXPORT_HANDOFF_SMOKE"
+project_name = os.environ["AGILAB_NOTEBOOK_IMPORT_PROJECT"]
+apps_path = root / "src/agilab/apps"
+app_root = apps_path / project_name
+stages_file = app_root / "lab_stages.toml"
+
+app_env = AgiEnv(apps_path=apps_path, app=project_name, verbose=0)
+app_env.init_done = True
+export_context = build_notebook_export_context(
+    app_env,
+    project_name,
+    stages_file,
+    project_name=project_name,
+)
+notebook_path = refresh_notebook_export(stages_file, export_context=export_context)
+if notebook_path is None:
+    print(marker + "=" + json.dumps({"status": "fail", "phase": "refresh"}, sort_keys=True))
+    raise SystemExit(1)
+
+manifest_path = notebook_export_manifest_path(notebook_path)
+manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+notebook = json.loads(Path(notebook_path).read_text(encoding="utf-8"))
+verification = verify_notebook_export_manifest(notebook_path)
+stage_records = [stage for stage in manifest.get("stages", []) if isinstance(stage, dict)]
+stage_cells = [cell for cell in manifest.get("stage_cells", []) if isinstance(cell, dict)]
+source_cells = [cell for cell in stage_cells if cell.get("kind") == "source"]
+runner_cells = [cell for cell in stage_cells if cell.get("kind") == "runner"]
+stage_imports = [
+    stage.get("notebook_import", {})
+    for stage in stage_records
+    if isinstance(stage.get("notebook_import", {}), dict)
+]
+source_imports = [
+    cell.get("notebook_import", {})
+    for cell in source_cells
+    if isinstance(cell.get("notebook_import", {}), dict)
+]
+
+compile_errors = []
+for index, cell in enumerate(notebook.get("cells", [])):
+    if not isinstance(cell, dict) or cell.get("cell_type") != "code":
+        continue
+    source = cell.get("source", [])
+    source_text = source if isinstance(source, str) else "".join(str(line) for line in source)
+    try:
+        compile(source_text, f"{notebook_path}#cell-{index}", "exec")
+    except SyntaxError as exc:
+        compile_errors.append(f"cell-{index}: {exc}")
+
+artifact_references = sorted(
+    {
+        str(artifact)
+        for metadata in stage_imports
+        for artifact in metadata.get("artifact_references", [])
+        if str(artifact)
+    }
+)
+env_hints = sorted(
+    {
+        str(hint)
+        for metadata in stage_imports
+        for hint in metadata.get("env_hints", [])
+        if str(hint)
+    }
+)
+source_cell_indexes = [
+    metadata.get("source_cell_index")
+    for metadata in stage_imports
+    if metadata.get("source_cell_index") is not None
+]
+source_notebooks = sorted(
+    {
+        str(metadata.get("source_notebook"))
+        for metadata in stage_imports
+        if str(metadata.get("source_notebook", ""))
+    }
+)
+runtime_roles = [str(stage.get("runtime_role", "")) for stage in stage_records]
+mirror_path_text = str(manifest.get("mirror_path", "") or "")
+mirror_exists = bool(mirror_path_text and Path(mirror_path_text).is_file())
+handoff_path_text = str(manifest.get("handoff_path", "") or "")
+handoff_text = Path(handoff_path_text).read_text(encoding="utf-8") if handoff_path_text else ""
+
+checks = {
+    "verification_ok": bool(verification.get("ok")),
+    "stage_count": manifest.get("stage_count") == 2,
+    "source_cell_count": len(source_cells) == 2,
+    "runner_cell_count": len(runner_cells) == 2,
+    "stage_import_count": len(stage_imports) == 2,
+    "source_import_count": len(source_imports) == 2,
+    "source_cell_indexes": source_cell_indexes == [2, 4],
+    "artifact_references": {
+        "data/flights.csv",
+        "artifacts/summary.json",
+    }.issubset(set(artifact_references)),
+    "env_hints": {"pandas", "pathlib"}.issubset(set(env_hints)),
+    "runtime_roles": runtime_roles == ["manager", "manager"],
+    "source_notebook": source_notebooks == ["notebooks/source/flight_telemetry_from_notebook.ipynb"],
+    "mirror_exists": mirror_exists,
+    "handoff_has_validation": "validate_agilab_export()" in handoff_text,
+    "compile": not compile_errors,
+}
+failed_checks = sorted(name for name, ok in checks.items() if not ok)
+print(marker + "=" + json.dumps({
+    "status": "pass" if not failed_checks else "fail",
+    "project_name": project_name,
+    "notebook_path": str(notebook_path),
+    "manifest_path": str(manifest_path),
+    "handoff_path": handoff_path_text,
+    "mirror_path": mirror_path_text,
+    "manifest_schema": str(manifest.get("schema", "")),
+    "stage_count": manifest.get("stage_count"),
+    "source_cell_count": len(source_cells),
+    "runner_cell_count": len(runner_cells),
+    "source_cell_indexes": source_cell_indexes,
+    "artifact_references": artifact_references,
+    "env_hints": env_hints,
+    "runtime_roles": runtime_roles,
+    "source_notebooks": source_notebooks,
+    "verification_ok": bool(verification.get("ok")),
+    "verification_failed_checks": [
+        str(check.get("id", ""))
+        for check in verification.get("checks", [])
+        if isinstance(check, dict) and check.get("status") != "pass"
+    ],
+    "failed_checks": failed_checks,
+    "compile_errors": compile_errors,
+}, sort_keys=True))
+"""
+    export_log = clone_root / ".notebook-import-release-export-handoff.log"
+    with export_log.open("w", encoding="utf-8") as log_stream:
+        export = subprocess.run(
+            [
+                "uv",
+                "--preview-features",
+                "extra-build-dependencies",
+                "run",
+                "--extra",
+                "ui",
+                "python",
+                "-c",
+                export_code,
+            ],
+            cwd=clone_root,
+            check=False,
+            stdout=log_stream,
+            stderr=subprocess.STDOUT,
+            text=True,
+            env=execute_env,
+            timeout=4 * 60,
+        )
+    payload["export_returncode"] = export.returncode
+    export_output = export_log.read_text(encoding="utf-8", errors="replace")
+    if export.returncode:
+        tail = "\n".join(export_output.splitlines()[-100:])
+        raise AssertionError(
+            f"notebook import export handoff smoke failed with {export.returncode}; "
+            f"log={export_log}\n{tail}"
+        )
+    export_payload = _extract_marked_json(
+        export_output,
+        "NOTEBOOK_IMPORT_EXPORT_HANDOFF_SMOKE",
+    )
+    payload["export_handoff"] = export_payload
+    if export_payload.get("status") != "pass":
+        tail = "\n".join(export_output.splitlines()[-100:])
+        raise AssertionError(
+            "notebook import export handoff smoke did not pass; "
+            f"payload={export_payload!r}; log={export_log}\n{tail}"
+        )
+
     return payload
 
 
@@ -453,6 +638,7 @@ def test_newcomer_first_proof_passes_from_fresh_source_clone(tmp_path: Path) -> 
     assert notebook_payload["stage_count"] == 2
     assert notebook_payload["install_returncode"] == 0
     assert notebook_payload["execute_returncode"] == 0
+    assert notebook_payload["export_returncode"] == 0
     assert notebook_payload["contract_schema"] == "agilab.notebook_import_contract.v1"
     assert notebook_payload["contract_stage_count"] == 2
     assert notebook_payload["runtime_roles"] == ["manager", "manager"]
@@ -468,3 +654,23 @@ def test_newcomer_first_proof_passes_from_fresh_source_clone(tmp_path: Path) -> 
         output_file.endswith((".parquet", ".csv", ".json"))
         for output_file in execute_analysis["output_files"]
     )
+    export_handoff = notebook_payload["export_handoff"]
+    assert export_handoff["status"] == "pass"
+    assert export_handoff["project_name"] == "flight_telemetry_from_notebook_project"
+    assert export_handoff["manifest_schema"] == "agilab.notebook_export_manifest.v1"
+    assert export_handoff["stage_count"] == 2
+    assert export_handoff["source_cell_count"] == 2
+    assert export_handoff["runner_cell_count"] == 2
+    assert export_handoff["source_cell_indexes"] == [2, 4]
+    assert export_handoff["runtime_roles"] == ["manager", "manager"]
+    assert export_handoff["source_notebooks"] == [
+        "notebooks/source/flight_telemetry_from_notebook.ipynb"
+    ]
+    assert {"data/flights.csv", "artifacts/summary.json"}.issubset(
+        set(export_handoff["artifact_references"])
+    )
+    assert {"pandas", "pathlib"}.issubset(set(export_handoff["env_hints"]))
+    assert export_handoff["verification_ok"] is True
+    assert export_handoff["verification_failed_checks"] == []
+    assert export_handoff["failed_checks"] == []
+    assert export_handoff["compile_errors"] == []

--- a/test/test_workflow_parity.py
+++ b/test/test_workflow_parity.py
@@ -284,7 +284,7 @@ def test_profile_commands_cover_expected_coverage_and_docs_contracts() -> None:
     assert dependency_policy.label == "dependency policy"
     assert dependency_policy.argv[-1] == "test/test_pyproject_dependency_hygiene.py"
     assert "addopts=" in dependency_policy.argv
-    assert release_proof.label == "fresh source clone first-proof plus notebook import proof"
+    assert release_proof.label == "fresh source clone first-proof plus notebook import/export proof"
     assert release_proof.env["AGILAB_RUN_RELEASE_PROOF_SLOW"] == "1"
     assert release_proof.timeout_seconds == 15 * 60
     assert "-m" in release_proof.argv

--- a/tools/workflow_parity.py
+++ b/tools/workflow_parity.py
@@ -1198,7 +1198,7 @@ def _dependency_policy_profile() -> list[CommandSpec]:
 def _release_proof_profile() -> list[CommandSpec]:
     return [
         CommandSpec(
-            label="fresh source clone first-proof plus notebook import proof",
+            label="fresh source clone first-proof plus notebook import/export proof",
             argv=[
                 "uv",
                 "--preview-features",


### PR DESCRIPTION
## Summary
- preserve notebook-import provenance in supervisor notebook exports
- extend the fresh-clone release-proof lane to verify the exported notebook handoff manifest, stage cells, runtime roles, artifact references, and syntax
- align the public docs mirror with the stronger release-proof claim

## Validation
- uv --preview-features extra-build-dependencies run python -m py_compile src/agilab/notebook_export_support.py test/test_pipeline_editor.py test/test_source_clone_regression.py tools/workflow_parity.py test/test_workflow_parity.py
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_pipeline_editor.py test/test_source_clone_regression.py test/test_workflow_parity.py
- uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files src/agilab/notebook_export_support.py test/test_pipeline_editor.py test/test_source_clone_regression.py tools/workflow_parity.py test/test_workflow_parity.py docs/source/features.rst docs/source/roadmap/agilab-future-work.md docs/.docs_source_mirror_stamp.json
- uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp
- uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --delete
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile release-proof