### PR TITLE
chore(release): prepare 2026.05.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,19 @@ publication, or evidence refreshes on an already published date version.
 - Added a versioned generated-snippet API guard so stale ORCHESTRATE snippets
   ask users to clean up and regenerate after core API changes.
 
+## [2026.05.23] - 2026-05-23
+
+GitHub Release: https://github.com/ThalesGroup/agilab/releases/tag/v2026.05.23
+
+### Changed
+
+- Published AGILAB `2026.05.23` to PyPI for the current public package set.
+- Preserved notebook-import provenance in exported notebook handoffs so the
+  no-lock-in path keeps source notebook, source cell, runtime-role, environment
+  hint, and artifact-reference metadata.
+- Updated release metadata so public docs, changelog, PyPI, and GitHub Releases point to the same source tag.
+- Kept release automation active so future PyPI publishes create or update the matching GitHub Release after pushing the tag.
+
 ## [2026.05.22] - 2026-05-22
 
 GitHub Release: https://github.com/ThalesGroup/agilab/releases/tag/v2026.05.22-3
@@ -678,3 +691,4 @@ GitHub Release: https://github.com/ThalesGroup/agilab/releases/tag/v2026.04.25
 [2026.05.18]: https://github.com/ThalesGroup/agilab/releases/tag/v2026.05.18
 [2026.05.20]: https://github.com/ThalesGroup/agilab/releases/tag/v2026.05.20
 [2026.05.22]: https://github.com/ThalesGroup/agilab/releases/tag/v2026.05.22-3
+[2026.05.23]: https://github.com/ThalesGroup/agilab/releases/tag/v2026.05.23

--- a/badges/pypi-version-agilab.svg
+++ b/badges/pypi-version-agilab.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="125" height="20" role="img" aria-label="pypi: v2026.05.22">
+<svg xmlns="http://www.w3.org/2000/svg" width="125" height="20" role="img" aria-label="pypi: v2026.05.23">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="19" y="15" fill="#010101" fill-opacity=".3">pypi</text>
   <text x="19" y="14">pypi</text>
-  <text x="81.5" y="15" fill="#010101" fill-opacity=".3">v2026.05.22</text>
-  <text x="81.5" y="14">v2026.05.22</text>
+  <text x="81.5" y="15" fill="#010101" fill-opacity=".3">v2026.05.23</text>
+  <text x="81.5" y="14">v2026.05.23</text>
 </g>
 </svg>

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 218,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "7a75520c6dde73c5a6a19244448199265542b314fbfd169906d4520f9cd7db5a",
+  "source_digest_sha256": "d65c03a95a2e84290637f7a28005f2561033480869f405fb5ec5a4d837801b87",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "7a75520c6dde73c5a6a19244448199265542b314fbfd169906d4520f9cd7db5a"
+  "target_digest_sha256": "d65c03a95a2e84290637f7a28005f2561033480869f405fb5ec5a4d837801b87"
 }

--- a/docs/source/data/release_proof.toml
+++ b/docs/source/data/release_proof.toml
@@ -20,13 +20,13 @@ related_pages = [
 
 [release]
 package_name = "agilab"
-package_version = "2026.05.22"
+package_version = "2026.05.23"
 package_extras = [
   "examples",
 ]
 pypi_url = "https://pypi.org/project/agilab/"
-github_release_tag = "v2026.05.22-3"
-github_release_url = "https://github.com/ThalesGroup/agilab/releases/tag/v2026.05.22-3"
+github_release_tag = "v2026.05.23"
+github_release_url = "https://github.com/ThalesGroup/agilab/releases/tag/v2026.05.23"
 hf_space_label = "jpmorard/agilab"
 hf_space_url = "https://huggingface.co/spaces/jpmorard/agilab"
 hf_space_commit = "7aeffb97767016d7ad285cc63fcdd9f6fb505c63"

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -28,7 +28,7 @@ branching into cluster mode, external app repositories, or broader workflows.
 
 For release-level evidence, use :doc:`release-proof`; it points to the
 `latest public GitHub release
-<https://github.com/ThalesGroup/agilab/releases/tag/v2026.05.22-3>`__,
+<https://github.com/ThalesGroup/agilab/releases/tag/v2026.05.23>`__,
 package proof, CI guardrails, and hosted demo status.
 
 This documentation then expands into architecture, service mode, API

--- a/docs/source/release-proof.rst
+++ b/docs/source/release-proof.rst
@@ -18,9 +18,9 @@ Current public release
    * - Item
      - Public evidence
    * - Package version
-     - ``agilab[examples]==2026.05.22`` on `PyPI <https://pypi.org/project/agilab/>`__
+     - ``agilab[examples]==2026.05.23`` on `PyPI <https://pypi.org/project/agilab/>`__
    * - GitHub release
-     - `v2026.05.22-3 <https://github.com/ThalesGroup/agilab/releases/tag/v2026.05.22-3>`__
+     - `v2026.05.23 <https://github.com/ThalesGroup/agilab/releases/tag/v2026.05.23>`__
    * - Hosted demo
      - `jpmorard/agilab <https://huggingface.co/spaces/jpmorard/agilab>`__ at Space commit ``7aeffb97767016d7ad285cc63fcdd9f6fb505c63``
    * - Public guardrails
@@ -41,7 +41,7 @@ What was proved
 
   .. code-block:: bash
 
-     python -m pip install "agilab[examples]==2026.05.22"
+     python -m pip install "agilab[examples]==2026.05.23"
      python -m agilab.lab_run first-proof --json --max-seconds 60
 
 - The public GitHub Actions matrix validated the packaged first proof on
@@ -70,7 +70,7 @@ the current source checkout:
    python -m venv .venv
    . .venv/bin/activate
    python -m pip install --upgrade pip
-   python -m pip install "agilab[examples]==2026.05.22"
+   python -m pip install "agilab[examples]==2026.05.23"
    python -m agilab.lab_run first-proof --json --max-seconds 60
 
 Use :doc:`quick-start` when you want the fuller source-checkout path with the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.22"
+version = "2026.05.23"
 name = "agilab"
 description = "AGILAB is a reproducible AI/ML workbench for engineering teams."
 requires-python = ">=3.11"
@@ -47,7 +47,7 @@ keywords = [
     "codex",
     "claude",
 ]
-dependencies = ["agi-core==2026.05.22", "legacy-cgi>=2.6.4; python_version >= '3.13'", "standard-imghdr>=3.13.0; python_version >= '3.13'"]
+dependencies = ["agi-core==2026.05.23", "legacy-cgi>=2.6.4; python_version >= '3.13'", "standard-imghdr>=3.13.0; python_version >= '3.13'"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"
@@ -62,15 +62,17 @@ agilab = "agilab.lab_run:main"
 
 [project.optional-dependencies]
 ai = ["openai>=2.32.0"]
-ui = ["agi-apps==2026.05.22", "agi-pages==2026.05.22", "agi-gui==2026.05.22", "networkx>=3.6.1", "pandas>=2.3.0", "streamlit>=1.56,<1.57", "tomli_w>=1.2.0"]
+ui = ["agi-apps==2026.05.23", "agi-pages==2026.05.23", "agi-gui==2026.05.23", "networkx>=3.6.1", "pandas>=2.3.0", "streamlit>=1.56,<1.57", "tomli_w>=1.2.0"]
 viz = ["matplotlib>=3.10.0", "plotly>=6.7.0"]
 mlflow = ["mlflow>=3.11.1", "idna>=3.15", "starlette>=1.0.1"]
-examples = ["agi-apps==2026.05.22", "jupyterlab>=4.4.0", "matplotlib>=3.10.0", "plotly>=6.7.0"]
-pages = ["agi-pages==2026.05.22"]
+examples = ["agi-apps==2026.05.23", "jupyterlab>=4.4.0", "matplotlib>=3.10.0", "plotly>=6.7.0"]
+pages = ["agi-pages==2026.05.23"]
 agents = ["openai>=2.32.0"]
 local-llm = ["accelerate>=0.34.2; python_version >= '3.12'", "gpt-oss>=0.0.8; python_version >= '3.12'", "langchain-core>=1.3.3; python_version >= '3.12'", "langsmith>=0.8.0; python_version >= '3.12'", "mlx>=0.31.2; sys_platform == 'darwin' and platform_machine == 'arm64'", "mlx-lm>=0.31.3; sys_platform == 'darwin' and platform_machine == 'arm64'", "mlx-vlm>=0.5.0; sys_platform == 'darwin' and platform_machine == 'arm64'", "requests>=2.32.0; python_version >= '3.12'", "torch>=2.8.0; python_version >= '3.12'", "transformers>=4.57.0; python_version >= '3.12'", "universal-offline-ai-chatbot>=0.1.0; python_version >= '3.12'"]
 offline = ["accelerate>=0.34.2; python_version >= '3.12'", "gpt-oss>=0.0.8; python_version >= '3.12'", "langchain-core>=1.3.3; python_version >= '3.12'", "langsmith>=0.8.0; python_version >= '3.12'", "mlx>=0.31.2; sys_platform == 'darwin' and platform_machine == 'arm64'", "mlx-lm>=0.31.3; sys_platform == 'darwin' and platform_machine == 'arm64'", "mlx-vlm>=0.5.0; sys_platform == 'darwin' and platform_machine == 'arm64'", "requests>=2.32.0; python_version >= '3.12'", "torch>=2.8.0; python_version >= '3.12'", "transformers>=4.57.0; python_version >= '3.12'", "universal-offline-ai-chatbot>=0.1.0; python_version >= '3.12'"]
 dev = ["build>=1.3.0", "cyclonedx-bom>=7.2.1", "pip-audit>=2.9.0", "pytest>=9.0.0", "pytest-asyncio>=1.3.0", "pytest-cov>=7.0.0", "tomlkit>=0.13.0", "twine>=6.2.0", "wheel>=0.45.0"]
+
+
 
 
 

--- a/src/agilab/apps-pages/view_app_ui/pyproject.toml
+++ b/src/agilab/apps-pages/view_app_ui/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-app-ui"
-version = "2026.05.22"
+version = "2026.05.23"
 description = "AGILAB page bundle for app-owned interactive Streamlit UIs."
 readme = { text = "AGILAB page bundle for app-owned interactive Streamlit UIs.", content-type = "text/markdown" }
 requires-python = ">=3.11"
@@ -27,6 +27,7 @@ Homepage = "https://github.com/ThalesGroup/agilab"
 Repository = "https://github.com/ThalesGroup/agilab"
 Discussions = "https://github.com/ThalesGroup/agilab/discussions"
 Changelog = "https://github.com/ThalesGroup/agilab/releases"
+
 
 
 

--- a/src/agilab/apps-pages/view_barycentric/pyproject.toml
+++ b/src/agilab/apps-pages/view_barycentric/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-simplex-map"
-version = "2026.05.22"
+version = "2026.05.23"
 description = "AGILAB page bundle for simplex projection and barycentric analysis."
 readme = { text = "AGILAB page bundle for simplex projection and barycentric analysis.", content-type = "text/markdown" }
 requires-python = ">=3.11"
@@ -36,6 +36,7 @@ Homepage = "https://github.com/ThalesGroup/agilab"
 Repository = "https://github.com/ThalesGroup/agilab"
 Discussions = "https://github.com/ThalesGroup/agilab/discussions"
 Changelog = "https://github.com/ThalesGroup/agilab/releases"
+
 
 
 

--- a/src/agilab/apps-pages/view_data_io_decision/pyproject.toml
+++ b/src/agilab/apps-pages/view_data_io_decision/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-decision-evidence"
-version = "2026.05.22"
+version = "2026.05.23"
 description = "AGILAB page bundle for decision evidence review."
 readme = { text = "AGILAB page bundle for decision evidence review.", content-type = "text/markdown" }
 requires-python = ">=3.11"
@@ -33,6 +33,7 @@ Homepage = "https://github.com/ThalesGroup/agilab"
 Repository = "https://github.com/ThalesGroup/agilab"
 Discussions = "https://github.com/ThalesGroup/agilab/discussions"
 Changelog = "https://github.com/ThalesGroup/agilab/releases"
+
 
 
 

--- a/src/agilab/apps-pages/view_forecast_analysis/pyproject.toml
+++ b/src/agilab/apps-pages/view_forecast_analysis/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-timeseries-forecast"
-version = "2026.05.22"
+version = "2026.05.23"
 description = "AGILAB page bundle for time-series forecast review."
 readme = { text = "AGILAB page bundle for time-series forecast review.", content-type = "text/markdown" }
 requires-python = ">=3.11"
@@ -33,6 +33,7 @@ Homepage = "https://github.com/ThalesGroup/agilab"
 Repository = "https://github.com/ThalesGroup/agilab"
 Discussions = "https://github.com/ThalesGroup/agilab/discussions"
 Changelog = "https://github.com/ThalesGroup/agilab/releases"
+
 
 
 

--- a/src/agilab/apps-pages/view_inference_analysis/pyproject.toml
+++ b/src/agilab/apps-pages/view_inference_analysis/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-inference-report"
-version = "2026.05.22"
+version = "2026.05.23"
 description = "AGILAB page bundle for inference result reporting."
 readme = { text = "AGILAB page bundle for inference result reporting.", content-type = "text/markdown" }
 requires-python = ">=3.11"
@@ -33,6 +33,7 @@ Homepage = "https://github.com/ThalesGroup/agilab"
 Repository = "https://github.com/ThalesGroup/agilab"
 Discussions = "https://github.com/ThalesGroup/agilab/discussions"
 Changelog = "https://github.com/ThalesGroup/agilab/releases"
+
 
 
 

--- a/src/agilab/apps-pages/view_maps/pyproject.toml
+++ b/src/agilab/apps-pages/view_maps/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-geospatial-map"
-version = "2026.05.22"
+version = "2026.05.23"
 description = "AGILAB page bundle for 2D geospatial map exploration."
 readme = { text = "AGILAB page bundle for 2D geospatial map exploration.", content-type = "text/markdown" }
 requires-python = ">=3.11"
@@ -34,6 +34,7 @@ Homepage = "https://github.com/ThalesGroup/agilab"
 Repository = "https://github.com/ThalesGroup/agilab"
 Discussions = "https://github.com/ThalesGroup/agilab/discussions"
 Changelog = "https://github.com/ThalesGroup/agilab/releases"
+
 
 
 

--- a/src/agilab/apps-pages/view_maps_3d/pyproject.toml
+++ b/src/agilab/apps-pages/view_maps_3d/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-geospatial-3d"
-version = "2026.05.22"
+version = "2026.05.23"
 description = "AGILAB page bundle for 3D geospatial exploration."
 readme = { text = "AGILAB page bundle for 3D geospatial exploration.", content-type = "text/markdown" }
 requires-python = ">=3.11"
@@ -35,6 +35,7 @@ Homepage = "https://github.com/ThalesGroup/agilab"
 Repository = "https://github.com/ThalesGroup/agilab"
 Discussions = "https://github.com/ThalesGroup/agilab/discussions"
 Changelog = "https://github.com/ThalesGroup/agilab/releases"
+
 
 
 

--- a/src/agilab/apps-pages/view_maps_network/pyproject.toml
+++ b/src/agilab/apps-pages/view_maps_network/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-network-map"
-version = "2026.05.22"
+version = "2026.05.23"
 description = "AGILAB page bundle for network-aware geospatial analysis."
 readme = { text = "AGILAB page bundle for network-aware geospatial analysis.", content-type = "text/markdown" }
 requires-python = ">=3.11"
@@ -42,6 +42,7 @@ Homepage = "https://github.com/ThalesGroup/agilab"
 Repository = "https://github.com/ThalesGroup/agilab"
 Discussions = "https://github.com/ThalesGroup/agilab/discussions"
 Changelog = "https://github.com/ThalesGroup/agilab/releases"
+
 
 
 

--- a/src/agilab/apps-pages/view_queue_resilience/pyproject.toml
+++ b/src/agilab/apps-pages/view_queue_resilience/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-queue-health"
-version = "2026.05.22"
+version = "2026.05.23"
 description = "AGILAB page bundle for queue health and resilience evidence."
 readme = { text = "AGILAB page bundle for queue health and resilience evidence.", content-type = "text/markdown" }
 requires-python = ">=3.11"
@@ -33,6 +33,7 @@ Homepage = "https://github.com/ThalesGroup/agilab"
 Repository = "https://github.com/ThalesGroup/agilab"
 Discussions = "https://github.com/ThalesGroup/agilab/discussions"
 Changelog = "https://github.com/ThalesGroup/agilab/releases"
+
 
 
 

--- a/src/agilab/apps-pages/view_relay_resilience/pyproject.toml
+++ b/src/agilab/apps-pages/view_relay_resilience/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-relay-health"
-version = "2026.05.22"
+version = "2026.05.23"
 description = "AGILAB page bundle for relay health and resilience evidence."
 readme = { text = "AGILAB page bundle for relay health and resilience evidence.", content-type = "text/markdown" }
 requires-python = ">=3.11"
@@ -33,6 +33,7 @@ Homepage = "https://github.com/ThalesGroup/agilab"
 Repository = "https://github.com/ThalesGroup/agilab"
 Discussions = "https://github.com/ThalesGroup/agilab/discussions"
 Changelog = "https://github.com/ThalesGroup/agilab/releases"
+
 
 
 

--- a/src/agilab/apps-pages/view_release_decision/pyproject.toml
+++ b/src/agilab/apps-pages/view_release_decision/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-promotion-gate"
-version = "2026.05.22"
+version = "2026.05.23"
 description = "AGILAB page bundle for promotion-gate evidence review."
 readme = { text = "AGILAB page bundle for promotion-gate evidence review.", content-type = "text/markdown" }
 requires-python = ">=3.11"
@@ -33,6 +33,7 @@ Homepage = "https://github.com/ThalesGroup/agilab"
 Repository = "https://github.com/ThalesGroup/agilab"
 Discussions = "https://github.com/ThalesGroup/agilab/discussions"
 Changelog = "https://github.com/ThalesGroup/agilab/releases"
+
 
 
 

--- a/src/agilab/apps-pages/view_scenario_cockpit/pyproject.toml
+++ b/src/agilab/apps-pages/view_scenario_cockpit/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-scenario-cockpit"
-version = "2026.05.22"
+version = "2026.05.23"
 description = "AGILAB page bundle for scenario evidence comparison."
 readme = { text = "AGILAB page bundle for scenario evidence comparison.", content-type = "text/markdown" }
 requires-python = ">=3.11"
@@ -30,6 +30,7 @@ Homepage = "https://github.com/ThalesGroup/agilab"
 Repository = "https://github.com/ThalesGroup/agilab"
 Discussions = "https://github.com/ThalesGroup/agilab/discussions"
 Changelog = "https://github.com/ThalesGroup/agilab/releases"
+
 
 
 

--- a/src/agilab/apps-pages/view_shap_explanation/pyproject.toml
+++ b/src/agilab/apps-pages/view_shap_explanation/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-feature-attribution"
-version = "2026.05.22"
+version = "2026.05.23"
 description = "AGILAB page bundle for feature-attribution evidence."
 readme = { text = "AGILAB page bundle for feature-attribution evidence.", content-type = "text/markdown" }
 requires-python = ">=3.11"
@@ -33,6 +33,7 @@ Homepage = "https://github.com/ThalesGroup/agilab"
 Repository = "https://github.com/ThalesGroup/agilab"
 Discussions = "https://github.com/ThalesGroup/agilab/discussions"
 Changelog = "https://github.com/ThalesGroup/agilab/releases"
+
 
 
 

--- a/src/agilab/apps-pages/view_training_analysis/pyproject.toml
+++ b/src/agilab/apps-pages/view_training_analysis/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-training-report"
-version = "2026.05.22"
+version = "2026.05.23"
 description = "AGILAB page bundle for training run reporting."
 readme = { text = "AGILAB page bundle for training run reporting.", content-type = "text/markdown" }
 requires-python = ">=3.11"
@@ -34,6 +34,7 @@ Homepage = "https://github.com/ThalesGroup/agilab"
 Repository = "https://github.com/ThalesGroup/agilab"
 Discussions = "https://github.com/ThalesGroup/agilab/discussions"
 Changelog = "https://github.com/ThalesGroup/agilab/releases"
+
 
 
 

--- a/src/agilab/core/agi-cluster/pyproject.toml
+++ b/src/agilab/core/agi-cluster/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.22"
+version = "2026.05.23"
 name = "agi-cluster"
 description = "Distributed cluster orchestration layer for AGILAB workers over local and SSH backends"
 requires-python = ">=3.11"
@@ -35,7 +35,7 @@ keywords = [
     "job-scheduling",
     "mlops",
 ]
-dependencies = ["agi-env==2026.05.22", "agi-node==2026.05.22", "asyncssh", "dask[distributed]", "humanize", "numpy", "packaging", "polars", "psutil", "scikit-learn", "tomlkit"]
+dependencies = ["agi-env==2026.05.23", "agi-node==2026.05.23", "asyncssh", "dask[distributed]", "humanize", "numpy", "packaging", "polars", "psutil", "scikit-learn", "tomlkit"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"
@@ -45,6 +45,8 @@ Homepage = "https://github.com/ThalesGroup/agilab"
 Repository = "https://github.com/ThalesGroup/agilab"
 Discussions = "https://github.com/ThalesGroup/agilab/discussions"
 Changelog = "https://github.com/ThalesGroup/agilab/releases"
+
+
 
 
 

--- a/src/agilab/core/agi-core/pyproject.toml
+++ b/src/agilab/core/agi-core/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.22"
+version = "2026.05.23"
 name = "agi-core"
 description = "Meta-package that installs and wires agi-env, agi-node, and agi-cluster together"
 readme = "README.md"
@@ -30,7 +30,7 @@ keywords = [
   "distributed-computing",
   "distributed-execution",
 ]
-dependencies = ["agi-env==2026.05.22", "agi-node==2026.05.22", "agi-cluster==2026.05.22"]
+dependencies = ["agi-env==2026.05.23", "agi-node==2026.05.23", "agi-cluster==2026.05.23"]
 
 [project.urls]
 Homepage = "https://github.com/ThalesGroup/agilab"
@@ -39,6 +39,8 @@ Documentation = "https://thalesgroup.github.io/agilab"
 Repository = "https://github.com/ThalesGroup/agilab"
 Discussions = "https://github.com/ThalesGroup/agilab/discussions"
 Changelog = "https://github.com/ThalesGroup/agilab/releases"
+
+
 
 
 

--- a/src/agilab/core/agi-env/pyproject.toml
+++ b/src/agilab/core/agi-env/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.22"
+version = "2026.05.23"
 name = "agi-env"
 description = "Environment bootstrap package for AGILAB with virtualenv, path, and runtime helpers"
 requires-python = ">=3.11"
@@ -54,6 +54,7 @@ Homepage = "https://github.com/ThalesGroup/agilab"
 Repository = "https://github.com/ThalesGroup/agilab"
 Discussions = "https://github.com/ThalesGroup/agilab/discussions"
 Changelog = "https://github.com/ThalesGroup/agilab/releases"
+
 
 
 

--- a/src/agilab/core/agi-node/pyproject.toml
+++ b/src/agilab/core/agi-node/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.22"
+version = "2026.05.23"
 name = "agi-node"
 description = "Distributed worker orchestration and execution support library for AGILAB"
 requires-python = ">=3.11"
@@ -35,7 +35,7 @@ keywords = [
     "pandas",
     "polars",
 ]
-dependencies = ["agi-env==2026.05.22", "cython", "humanize", "numpy", "pandas", "parso", "polars", "psutil", "py7zr", "setuptools"]
+dependencies = ["agi-env==2026.05.23", "cython", "humanize", "numpy", "pandas", "parso", "polars", "psutil", "py7zr", "setuptools"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"
@@ -45,6 +45,8 @@ Homepage = "https://github.com/ThalesGroup/agilab"
 Repository = "https://github.com/ThalesGroup/agilab"
 Discussions = "https://github.com/ThalesGroup/agilab/discussions"
 Changelog = "https://github.com/ThalesGroup/agilab/releases"
+
+
 
 
 

--- a/src/agilab/lib/agi-app-flight-telemetry/pyproject.toml
+++ b/src/agilab/lib/agi-app-flight-telemetry/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.22"
+version = "2026.05.23"
 name = "agi-app-flight-telemetry"
 description = "AGILAB flight-telemetry ingestion demo with reusable dataframe and map-analysis outputs"
 requires-python = ">=3.11"
@@ -44,6 +44,7 @@ Changelog = "https://github.com/ThalesGroup/agilab/releases"
 [project.entry-points."agilab.apps"]
 flight_telemetry = "agi_app_flight_telemetry:project_root"
 flight_telemetry_project = "agi_app_flight_telemetry:project_root"
+
 
 
 

--- a/src/agilab/lib/agi-app-global-dag/pyproject.toml
+++ b/src/agilab/lib/agi-app-global-dag/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.22"
+version = "2026.05.23"
 name = "agi-app-global-dag"
 description = "AGILAB cross-app DAG preview showing artifact handoffs between demo projects"
 requires-python = ">=3.11"
@@ -44,6 +44,7 @@ Changelog = "https://github.com/ThalesGroup/agilab/releases"
 [project.entry-points."agilab.apps"]
 global_dag = "agi_app_global_dag:project_root"
 global_dag_project = "agi_app_global_dag:project_root"
+
 
 
 

--- a/src/agilab/lib/agi-app-mission-decision/pyproject.toml
+++ b/src/agilab/lib/agi-app-mission-decision/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.22"
+version = "2026.05.23"
 name = "agi-app-mission-decision"
 description = "Deterministic AGILAB mission-decision workflow with scenario scoring and evidence artifacts"
 requires-python = ">=3.11"
@@ -44,6 +44,7 @@ Changelog = "https://github.com/ThalesGroup/agilab/releases"
 [project.entry-points."agilab.apps"]
 mission_decision = "agi_app_mission_decision:project_root"
 mission_decision_project = "agi_app_mission_decision:project_root"
+
 
 
 

--- a/src/agilab/lib/agi-app-pandas-execution/pyproject.toml
+++ b/src/agilab/lib/agi-app-pandas-execution/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.22"
+version = "2026.05.23"
 name = "agi-app-pandas-execution"
 description = "AGILAB Pandas execution benchmark for deterministic worker and reducer validation"
 requires-python = ">=3.11"
@@ -44,6 +44,7 @@ Changelog = "https://github.com/ThalesGroup/agilab/releases"
 [project.entry-points."agilab.apps"]
 execution_pandas = "agi_app_pandas_execution:project_root"
 execution_pandas_project = "agi_app_pandas_execution:project_root"
+
 
 
 

--- a/src/agilab/lib/agi-app-polars-execution/pyproject.toml
+++ b/src/agilab/lib/agi-app-polars-execution/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.22"
+version = "2026.05.23"
 name = "agi-app-polars-execution"
 description = "AGILAB Polars execution benchmark for deterministic worker and reducer validation"
 requires-python = ">=3.11"
@@ -44,6 +44,7 @@ Changelog = "https://github.com/ThalesGroup/agilab/releases"
 [project.entry-points."agilab.apps"]
 execution_polars = "agi_app_polars_execution:project_root"
 execution_polars_project = "agi_app_polars_execution:project_root"
+
 
 
 

--- a/src/agilab/lib/agi-app-pytorch-playground/pyproject.toml
+++ b/src/agilab/lib/agi-app-pytorch-playground/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.22"
+version = "2026.05.23"
 name = "agi-app-pytorch-playground"
 description = "AGILAB PyTorch playground app for reproducible neural-network experiments"
 requires-python = ">=3.12"
@@ -44,6 +44,7 @@ Changelog = "https://github.com/ThalesGroup/agilab/releases"
 [project.entry-points."agilab.apps"]
 pytorch_playground = "agi_app_pytorch_playground:project_root"
 pytorch_playground_project = "agi_app_pytorch_playground:project_root"
+
 
 
 

--- a/src/agilab/lib/agi-app-tescia-diagnostic/pyproject.toml
+++ b/src/agilab/lib/agi-app-tescia-diagnostic/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.22"
+version = "2026.05.23"
 name = "agi-app-tescia-diagnostic"
 description = "AGILAB TeSciA-style diagnostic workflow with evidence scoring and regression-plan artifacts"
 requires-python = ">=3.13"
@@ -42,6 +42,7 @@ Changelog = "https://github.com/ThalesGroup/agilab/releases"
 [project.entry-points."agilab.apps"]
 tescia_diagnostic = "agi_app_tescia_diagnostic:project_root"
 tescia_diagnostic_project = "agi_app_tescia_diagnostic:project_root"
+
 
 
 

--- a/src/agilab/lib/agi-app-uav-queue-project/pyproject.toml
+++ b/src/agilab/lib/agi-app-uav-queue-project/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.22"
+version = "2026.05.23"
 name = "agi-app-uav-queue-project"
 description = "AGILAB UAV queue simulation demo with scenario evidence and network-map artifacts"
 requires-python = ">=3.13"
@@ -42,6 +42,7 @@ Changelog = "https://github.com/ThalesGroup/agilab/releases"
 [project.entry-points."agilab.apps"]
 uav_queue = "agi_app_uav_queue_project:project_root"
 uav_queue_project = "agi_app_uav_queue_project:project_root"
+
 
 
 

--- a/src/agilab/lib/agi-app-uav-relay-queue/pyproject.toml
+++ b/src/agilab/lib/agi-app-uav-relay-queue/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.22"
+version = "2026.05.23"
 name = "agi-app-uav-relay-queue"
 description = "AGILAB UAV relay queue simulation demo with routing, delay, and resilience artifacts"
 requires-python = ">=3.13"
@@ -42,6 +42,7 @@ Changelog = "https://github.com/ThalesGroup/agilab/releases"
 [project.entry-points."agilab.apps"]
 uav_relay_queue = "agi_app_uav_relay_queue:project_root"
 uav_relay_queue_project = "agi_app_uav_relay_queue:project_root"
+
 
 
 

--- a/src/agilab/lib/agi-app-weather-forecast/pyproject.toml
+++ b/src/agilab/lib/agi-app-weather-forecast/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.22"
+version = "2026.05.23"
 name = "agi-app-weather-forecast"
 description = "AGILAB weather-forecast notebook-migration demo with forecast analysis artifacts"
 requires-python = ">=3.11"
@@ -44,6 +44,7 @@ Changelog = "https://github.com/ThalesGroup/agilab/releases"
 [project.entry-points."agilab.apps"]
 weather_forecast = "agi_app_weather_forecast:project_root"
 weather_forecast_project = "agi_app_weather_forecast:project_root"
+
 
 
 

--- a/src/agilab/lib/agi-apps/pyproject.toml
+++ b/src/agilab/lib/agi-apps/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.22"
+version = "2026.05.23"
 name = "agi-apps"
 description = "AGILAB public app package umbrella and example assets"
 requires-python = ">=3.11"
@@ -31,7 +31,7 @@ keywords = [
     "workflow-orchestration",
 ]
 
-dependencies = ["agi-core==2026.05.22", "agi-app-mission-decision==2026.05.22", "agi-app-pandas-execution==2026.05.22", "agi-app-polars-execution==2026.05.22", "agi-app-flight-telemetry==2026.05.22", "agi-app-global-dag==2026.05.22", "agi-app-weather-forecast==2026.05.22", "agi-app-pytorch-playground==2026.05.22; python_version >= '3.12'", "agi-app-tescia-diagnostic==2026.05.22; python_version >= '3.13'", "agi-app-uav-relay-queue==2026.05.22; python_version >= '3.13'"]
+dependencies = ["agi-core==2026.05.23", "agi-app-mission-decision==2026.05.23", "agi-app-pandas-execution==2026.05.23", "agi-app-polars-execution==2026.05.23", "agi-app-flight-telemetry==2026.05.23", "agi-app-global-dag==2026.05.23", "agi-app-weather-forecast==2026.05.23", "agi-app-pytorch-playground==2026.05.23; python_version >= '3.12'", "agi-app-tescia-diagnostic==2026.05.23; python_version >= '3.13'", "agi-app-uav-relay-queue==2026.05.23; python_version >= '3.13'"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"
@@ -41,6 +41,8 @@ Homepage = "https://github.com/ThalesGroup/agilab"
 Repository = "https://github.com/ThalesGroup/agilab"
 Discussions = "https://github.com/ThalesGroup/agilab/discussions"
 Changelog = "https://github.com/ThalesGroup/agilab/releases"
+
+
 
 
 

--- a/src/agilab/lib/agi-gui/pyproject.toml
+++ b/src/agilab/lib/agi-gui/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.22"
+version = "2026.05.23"
 name = "agi-gui"
 description = "AGILAB Streamlit UI dependency bundle and compatibility imports"
 requires-python = ">=3.11"
@@ -32,7 +32,7 @@ keywords = [
     "python",
 ]
 
-dependencies = ["agi-env==2026.05.22", "streamlit>=1.56,<1.57", "streamlit_code_editor", "watchdog"]
+dependencies = ["agi-env==2026.05.23", "streamlit>=1.56,<1.57", "streamlit_code_editor", "watchdog"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"
@@ -42,6 +42,8 @@ Homepage = "https://github.com/ThalesGroup/agilab"
 Repository = "https://github.com/ThalesGroup/agilab"
 Discussions = "https://github.com/ThalesGroup/agilab/discussions"
 Changelog = "https://github.com/ThalesGroup/agilab/releases"
+
+
 
 
 

--- a/src/agilab/lib/agi-pages/pyproject.toml
+++ b/src/agilab/lib/agi-pages/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.22"
+version = "2026.05.23"
 name = "agi-pages"
 description = "AGILAB public analysis page umbrella and provider package"
 requires-python = ">=3.11"
@@ -34,7 +34,7 @@ keywords = [
     "page-bundles",
 ]
 
-dependencies = ["agi-gui==2026.05.22"]
+dependencies = ["agi-gui==2026.05.23"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"
@@ -44,6 +44,8 @@ Homepage = "https://github.com/ThalesGroup/agilab"
 Repository = "https://github.com/ThalesGroup/agilab"
 Discussions = "https://github.com/ThalesGroup/agilab/discussions"
 Changelog = "https://github.com/ThalesGroup/agilab/releases"
+
+
 
 
 


### PR DESCRIPTION
## Summary
- bump AGILAB and public split package metadata to 2026.05.23
- refresh release proof docs and PyPI version badge for v2026.05.23
- preserve the release note for notebook import/export handoff provenance

## Validation
- uv lock --check
- tools/release_plan.py --check-workflow .github/workflows/pypi-publish.yaml
- tools/pypi_release_version_policy.py
- tools/pypi_trusted_publisher_contract.py --check-workflow .github/workflows/pypi-publish.yaml
- tools/sync_docs_source.py --verify-stamp
- wheel metadata check for agilab 2026.05.23 internal dependencies
- ./dev release
- tools/workflow_parity.py --profile release-proof