### PR TITLE
fix(release): align built-in app manifests for 2026.05.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ publication, or evidence refreshes on an already published date version.
 
 ## [2026.05.23] - 2026-05-23
 
-GitHub Release: https://github.com/ThalesGroup/agilab/releases/tag/v2026.05.23
+GitHub Release: https://github.com/ThalesGroup/agilab/releases/tag/v2026.05.23-1
 
 ### Changed
 
@@ -691,4 +691,4 @@ GitHub Release: https://github.com/ThalesGroup/agilab/releases/tag/v2026.04.25
 [2026.05.18]: https://github.com/ThalesGroup/agilab/releases/tag/v2026.05.18
 [2026.05.20]: https://github.com/ThalesGroup/agilab/releases/tag/v2026.05.20
 [2026.05.22]: https://github.com/ThalesGroup/agilab/releases/tag/v2026.05.22-3
-[2026.05.23]: https://github.com/ThalesGroup/agilab/releases/tag/v2026.05.23
+[2026.05.23]: https://github.com/ThalesGroup/agilab/releases/tag/v2026.05.23-1

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 218,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "d65c03a95a2e84290637f7a28005f2561033480869f405fb5ec5a4d837801b87",
+  "source_digest_sha256": "8b6aaf5c2bf7e23c604dfaef059489b738fe67ff50691204ab71aa2056c32689",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "d65c03a95a2e84290637f7a28005f2561033480869f405fb5ec5a4d837801b87"
+  "target_digest_sha256": "8b6aaf5c2bf7e23c604dfaef059489b738fe67ff50691204ab71aa2056c32689"
 }

--- a/docs/source/data/release_proof.toml
+++ b/docs/source/data/release_proof.toml
@@ -25,8 +25,8 @@ package_extras = [
   "examples",
 ]
 pypi_url = "https://pypi.org/project/agilab/"
-github_release_tag = "v2026.05.23"
-github_release_url = "https://github.com/ThalesGroup/agilab/releases/tag/v2026.05.23"
+github_release_tag = "v2026.05.23-1"
+github_release_url = "https://github.com/ThalesGroup/agilab/releases/tag/v2026.05.23-1"
 hf_space_label = "jpmorard/agilab"
 hf_space_url = "https://huggingface.co/spaces/jpmorard/agilab"
 hf_space_commit = "7aeffb97767016d7ad285cc63fcdd9f6fb505c63"

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -28,7 +28,7 @@ branching into cluster mode, external app repositories, or broader workflows.
 
 For release-level evidence, use :doc:`release-proof`; it points to the
 `latest public GitHub release
-<https://github.com/ThalesGroup/agilab/releases/tag/v2026.05.23>`__,
+<https://github.com/ThalesGroup/agilab/releases/tag/v2026.05.23-1>`__,
 package proof, CI guardrails, and hosted demo status.
 
 This documentation then expands into architecture, service mode, API

--- a/docs/source/release-proof.rst
+++ b/docs/source/release-proof.rst
@@ -20,7 +20,7 @@ Current public release
    * - Package version
      - ``agilab[examples]==2026.05.23`` on `PyPI <https://pypi.org/project/agilab/>`__
    * - GitHub release
-     - `v2026.05.23 <https://github.com/ThalesGroup/agilab/releases/tag/v2026.05.23>`__
+     - `v2026.05.23-1 <https://github.com/ThalesGroup/agilab/releases/tag/v2026.05.23-1>`__
    * - Hosted demo
      - `jpmorard/agilab <https://huggingface.co/spaces/jpmorard/agilab>`__ at Space commit ``7aeffb97767016d7ad285cc63fcdd9f6fb505c63``
    * - Public guardrails

--- a/src/agilab/apps/builtin/execution_pandas_project/pyproject.toml
+++ b/src/agilab/apps/builtin/execution_pandas_project/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "execution_pandas_project"
-version = "2026.05.22"
+version = "2026.05.23"
 description = "Built-in AGILab execution playground using PandasWorker"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.22", "agi-node>=2026.05.22", "agi-cluster>=2026.05.22", "numpy", "pandas", "pydantic", "streamlit>=1.56,<1.57"]
+dependencies = ["agi-env>=2026.05.23", "agi-node>=2026.05.23", "agi-cluster>=2026.05.23", "numpy", "pandas", "pydantic", "streamlit>=1.56,<1.57"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/execution_pandas_project/src/execution_pandas_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/execution_pandas_project/src/execution_pandas_worker/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "execution_pandas_project"
-version = "2026.05.22"
+version = "2026.05.23"
 description = "Built-in AGILab execution playground using PandasWorker"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.22", "agi-node>=2026.05.22", "numpy", "pandas", "pydantic"]
+dependencies = ["agi-env>=2026.05.23", "agi-node>=2026.05.23", "numpy", "pandas", "pydantic"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/execution_polars_project/pyproject.toml
+++ b/src/agilab/apps/builtin/execution_polars_project/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "execution_polars_project"
-version = "2026.05.22"
+version = "2026.05.23"
 description = "Built-in AGILab execution playground using PolarsWorker"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.22", "agi-node>=2026.05.22", "agi-cluster>=2026.05.22", "polars", "pydantic", "streamlit>=1.56,<1.57"]
+dependencies = ["agi-env>=2026.05.23", "agi-node>=2026.05.23", "agi-cluster>=2026.05.23", "polars", "pydantic", "streamlit>=1.56,<1.57"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/execution_polars_project/src/execution_polars_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/execution_polars_project/src/execution_polars_worker/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "execution_polars_project"
-version = "2026.05.22"
+version = "2026.05.23"
 description = "Built-in AGILab execution playground using PolarsWorker"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.22", "agi-node>=2026.05.22", "polars", "pydantic"]
+dependencies = ["agi-env>=2026.05.23", "agi-node>=2026.05.23", "polars", "pydantic"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/flight_telemetry_project/pyproject.toml
+++ b/src/agilab/apps/builtin/flight_telemetry_project/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "flight_telemetry_project"
-version = "2026.05.22"
+version = "2026.05.23"
 description = "Built-in AGILab example app (flight-telemetry preprocessing)"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.22", "agi-node>=2026.05.22", "agi-cluster>=2026.05.22", "polars[rtcompat]", "pydantic", "py7zr", "streamlit>=1.56,<1.57"]
+dependencies = ["agi-env>=2026.05.23", "agi-node>=2026.05.23", "agi-cluster>=2026.05.23", "polars[rtcompat]", "pydantic", "py7zr", "streamlit>=1.56,<1.57"]
 
 [tool.agilab]
 runtime_target = "flight_telemetry"

--- a/src/agilab/apps/builtin/flight_telemetry_project/src/flight_telemetry_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/flight_telemetry_project/src/flight_telemetry_worker/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "flight_telemetry_project"
-version = "2026.05.22"
+version = "2026.05.23"
 description = ""
 requires-python = ">=3.11,<3.14"
 readme = "README.md"
-dependencies = ["agi-env>=2026.05.22", "agi-node>=2026.05.22", "polars", "pydantic"]
+dependencies = ["agi-env>=2026.05.23", "agi-node>=2026.05.23", "polars", "pydantic"]
 
 [[project.authors]]
 name = "Jean-Pierre Morard"

--- a/src/agilab/apps/builtin/global_dag_project/pyproject.toml
+++ b/src/agilab/apps/builtin/global_dag_project/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "global_dag_project"
-version = "2026.05.22"
+version = "2026.05.23"
 description = "Built-in AGILAB global DAG example project"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.22", "agi-node>=2026.05.22", "agi-cluster>=2026.05.22", "polars", "pydantic", "streamlit>=1.56,<1.57"]
+dependencies = ["agi-env>=2026.05.23", "agi-node>=2026.05.23", "agi-cluster>=2026.05.23", "polars", "pydantic", "streamlit>=1.56,<1.57"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/global_dag_project/src/global_dag_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/global_dag_project/src/global_dag_worker/pyproject.toml
@@ -1,8 +1,8 @@
 [project]
 name = "global_dag_worker"
-version = "2026.05.22"
+version = "2026.05.23"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.22", "agi-node>=2026.05.22", "polars"]
+dependencies = ["agi-env>=2026.05.23", "agi-node>=2026.05.23", "polars"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/meteo_forecast_project/pyproject.toml
+++ b/src/agilab/apps/builtin/meteo_forecast_project/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "meteo_forecast_project"
-version = "2026.05.22"
+version = "2026.05.23"
 description = "Built-in AGILab weather forecasting example migrated from notebooks"
 requires-python = ">=3.13"
-dependencies = ["agi-env>=2026.05.22", "agi-node>=2026.05.22", "agi-cluster>=2026.05.22", "pandas>=2.3.0", "pydantic", "scikit-learn", "skforecast>=0.19,<0.20", "streamlit>=1.56,<1.57"]
+dependencies = ["agi-env>=2026.05.23", "agi-node>=2026.05.23", "agi-cluster>=2026.05.23", "pandas>=2.3.0", "pydantic", "scikit-learn", "skforecast>=0.19,<0.20", "streamlit>=1.56,<1.57"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/meteo_forecast_project/src/meteo_forecast_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/meteo_forecast_project/src/meteo_forecast_worker/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "meteo_forecast_project"
-version = "2026.05.22"
+version = "2026.05.23"
 description = "Built-in AGILab weather forecasting example migrated from notebooks"
 requires-python = ">=3.13"
-dependencies = ["agi-env>=2026.05.22", "agi-node>=2026.05.22", "pandas>=2.3.0", "pydantic", "scikit-learn", "skforecast>=0.19,<0.20"]
+dependencies = ["agi-env>=2026.05.23", "agi-node>=2026.05.23", "pandas>=2.3.0", "pydantic", "scikit-learn", "skforecast>=0.19,<0.20"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/mission_decision_project/pyproject.toml
+++ b/src/agilab/apps/builtin/mission_decision_project/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "mission_decision_project"
-version = "2026.05.22"
+version = "2026.05.23"
 description = "Built-in AGILAB Mission Decision autonomous demo"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.22", "agi-node>=2026.05.22", "agi-cluster>=2026.05.22", "pandas>=2.3.0", "pydantic", "streamlit>=1.56,<1.57"]
+dependencies = ["agi-env>=2026.05.23", "agi-node>=2026.05.23", "agi-cluster>=2026.05.23", "pandas>=2.3.0", "pydantic", "streamlit>=1.56,<1.57"]
 
 [tool.agilab]
 runtime_target = "mission_decision"

--- a/src/agilab/apps/builtin/mission_decision_project/src/mission_decision_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/mission_decision_project/src/mission_decision_worker/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "mission_decision_project"
-version = "2026.05.22"
+version = "2026.05.23"
 description = "Built-in AGILAB Mission Decision autonomous demo"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.22", "agi-node>=2026.05.22", "pandas>=2.3.0", "pydantic"]
+dependencies = ["agi-env>=2026.05.23", "agi-node>=2026.05.23", "pandas>=2.3.0", "pydantic"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/mycode_project/pyproject.toml
+++ b/src/agilab/apps/builtin/mycode_project/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "mycode_project"
-version = "2026.05.22"
+version = "2026.05.23"
 description = "Built-in AGILab example app template (minimal manager + worker)"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.22", "agi-node>=2026.05.22", "agi-cluster>=2026.05.22", "polars", "pydantic", "streamlit>=1.56,<1.57"]
+dependencies = ["agi-env>=2026.05.23", "agi-node>=2026.05.23", "agi-cluster>=2026.05.23", "polars", "pydantic", "streamlit>=1.56,<1.57"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/mycode_project/src/mycode_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/mycode_project/src/mycode_worker/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "mycode_project"
-version = "2026.05.22"
+version = "2026.05.23"
 description = "Built-in AGILab example app template (minimal manager + worker)"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.22", "agi-node>=2026.05.22", "polars", "pydantic"]
+dependencies = ["agi-env>=2026.05.23", "agi-node>=2026.05.23", "polars", "pydantic"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/pytorch_playground_project/pyproject.toml
+++ b/src/agilab/apps/builtin/pytorch_playground_project/pyproject.toml
@@ -1,14 +1,14 @@
 [project]
 name = "pytorch_playground_project"
-version = "2026.05.22"
+version = "2026.05.23"
 description = "Built-in AGILab app for reproducible PyTorch classifier playground experiments."
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "agi-env>=2026.05.22",
-    "agi-node>=2026.05.22",
-    "agi-cluster>=2026.05.22",
-    "agi-gui>=2026.05.22",
+    "agi-env>=2026.05.23",
+    "agi-node>=2026.05.23",
+    "agi-cluster>=2026.05.23",
+    "agi-gui>=2026.05.23",
     "numpy>=2.2",
     "pandas>=2.3.0",
     "plotly>=6.3.0",

--- a/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground_worker/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "pytorch_playground_worker"
-version = "2026.05.22"
+version = "2026.05.23"
 description = "Worker package for the AGILAB PyTorch playground app"
 requires-python = ">=3.12"
 dependencies = [
-    "agi-env>=2026.05.22",
-    "agi-node>=2026.05.22",
+    "agi-env>=2026.05.23",
+    "agi-node>=2026.05.23",
     "numpy>=2.2",
     "pandas>=2.3.0",
     "pydantic",

--- a/src/agilab/apps/builtin/tescia_diagnostic_project/pyproject.toml
+++ b/src/agilab/apps/builtin/tescia_diagnostic_project/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "tescia_diagnostic_project"
-version = "2026.05.22"
+version = "2026.05.23"
 description = "Built-in AGILAB TeSciA-style diagnostic reasoning example"
 requires-python = ">=3.13"
-dependencies = ["agi-env>=2026.05.22", "agi-node>=2026.05.22", "agi-cluster>=2026.05.22", "pandas>=2.3.0", "pydantic", "streamlit>=1.56,<1.57"]
+dependencies = ["agi-env>=2026.05.23", "agi-node>=2026.05.23", "agi-cluster>=2026.05.23", "pandas>=2.3.0", "pydantic", "streamlit>=1.56,<1.57"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/tescia_diagnostic_project/src/tescia_diagnostic_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/tescia_diagnostic_project/src/tescia_diagnostic_worker/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "tescia_diagnostic_project"
-version = "2026.05.22"
+version = "2026.05.23"
 description = "Built-in AGILAB TeSciA-style diagnostic reasoning example"
 requires-python = ">=3.13"
-dependencies = ["agi-env>=2026.05.22", "agi-node>=2026.05.22", "pandas>=2.3.0", "pydantic"]
+dependencies = ["agi-env>=2026.05.23", "agi-node>=2026.05.23", "pandas>=2.3.0", "pydantic"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/uav_queue_project/pyproject.toml
+++ b/src/agilab/apps/builtin/uav_queue_project/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "uav_queue_project"
-version = "2026.05.22"
+version = "2026.05.23"
 description = "Built-in AGILAB lightweight UAV relay queue example"
 requires-python = ">=3.13"
-dependencies = ["agi-env>=2026.05.22", "agi-node>=2026.05.22", "agi-cluster>=2026.05.22", "networkx", "pandas>=2.3.0", "pydantic", "simpy>=4.1,<5", "streamlit>=1.56,<1.57"]
+dependencies = ["agi-env>=2026.05.23", "agi-node>=2026.05.23", "agi-cluster>=2026.05.23", "networkx", "pandas>=2.3.0", "pydantic", "simpy>=4.1,<5", "streamlit>=1.56,<1.57"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/uav_queue_project/src/uav_queue_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/uav_queue_project/src/uav_queue_worker/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "uav_queue_project"
-version = "2026.05.22"
+version = "2026.05.23"
 description = "Built-in AGILAB lightweight UAV relay queue example"
 requires-python = ">=3.13"
-dependencies = ["agi-env>=2026.05.22", "agi-node>=2026.05.22", "networkx", "pandas>=2.3.0", "pydantic", "simpy>=4.1,<5"]
+dependencies = ["agi-env>=2026.05.23", "agi-node>=2026.05.23", "networkx", "pandas>=2.3.0", "pydantic", "simpy>=4.1,<5"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/uav_relay_queue_project/pyproject.toml
+++ b/src/agilab/apps/builtin/uav_relay_queue_project/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "uav_relay_queue_project"
-version = "2026.05.22"
+version = "2026.05.23"
 description = "Built-in AGILAB lightweight UAV relay queue example"
 requires-python = ">=3.13"
-dependencies = ["agi-env>=2026.05.22", "agi-node>=2026.05.22", "agi-cluster>=2026.05.22", "networkx", "pandas>=2.3.0", "pydantic", "simpy>=4.1,<5", "streamlit>=1.56,<1.57"]
+dependencies = ["agi-env>=2026.05.23", "agi-node>=2026.05.23", "agi-cluster>=2026.05.23", "networkx", "pandas>=2.3.0", "pydantic", "simpy>=4.1,<5", "streamlit>=1.56,<1.57"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/uav_relay_queue_project/src/uav_relay_queue_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/uav_relay_queue_project/src/uav_relay_queue_worker/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "uav_relay_queue_project"
-version = "2026.05.22"
+version = "2026.05.23"
 description = "Built-in AGILAB lightweight UAV relay queue example"
 requires-python = ">=3.13"
-dependencies = ["agi-env>=2026.05.22", "agi-node>=2026.05.22", "networkx", "pandas>=2.3.0", "pydantic", "simpy>=4.1,<5"]
+dependencies = ["agi-env>=2026.05.23", "agi-node>=2026.05.23", "networkx", "pandas>=2.3.0", "pydantic", "simpy>=4.1,<5"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/weather_forecast_project/pyproject.toml
+++ b/src/agilab/apps/builtin/weather_forecast_project/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "weather_forecast_project"
-version = "2026.05.22"
+version = "2026.05.23"
 description = "Built-in AGILab weather forecasting example migrated from notebooks"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.22", "agi-node>=2026.05.22", "agi-cluster>=2026.05.22", "pandas>=2.3.0", "pydantic", "scikit-learn", "skforecast>=0.19,<0.20", "streamlit>=1.56,<1.57"]
+dependencies = ["agi-env>=2026.05.23", "agi-node>=2026.05.23", "agi-cluster>=2026.05.23", "pandas>=2.3.0", "pydantic", "scikit-learn", "skforecast>=0.19,<0.20", "streamlit>=1.56,<1.57"]
 
 [tool.agilab]
 runtime_target = "weather_forecast"

--- a/src/agilab/apps/builtin/weather_forecast_project/src/weather_forecast_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/weather_forecast_project/src/weather_forecast_worker/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "weather_forecast_project"
-version = "2026.05.22"
+version = "2026.05.23"
 description = "Built-in AGILab weather forecasting example migrated from notebooks"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.22", "agi-node>=2026.05.22", "pandas>=2.3.0", "pydantic", "scikit-learn", "skforecast>=0.19,<0.20"]
+dependencies = ["agi-env>=2026.05.23", "agi-node>=2026.05.23", "pandas>=2.3.0", "pydantic", "scikit-learn", "skforecast>=0.19,<0.20"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }


### PR DESCRIPTION
## Summary
- align built-in app and worker pyproject versions/lower bounds to 2026.05.23
- move public release-proof references to retry tag v2026.05.23-1 after the first tag failed before publication
- keep PyPI package version at 2026.05.23

## Validation
- tools/supply_chain_attestation_report.py --compact
- pytest -q -o addopts='' test/test_supply_chain_attestation_report.py
- tools/release_proof_report.py --check --compact
- tools/sync_docs_source.py --verify-stamp
- tools/workflow_parity.py --profile agi-gui
- ./dev release
- tools/workflow_parity.py --profile release-proof