### PR TITLE
fix(release): keep PyPI retention non-blocking

### DIFF
--- a/.claude/skills/agilab-release-verification/SKILL.md
+++ b/.claude/skills/agilab-release-verification/SKILL.md
@@ -98,7 +98,7 @@ workflow dispatch:
 - `publish-library-packages`: publishes selected split packages with PyPI Trusted Publishing.
 - `publish-agilab`: publishes the top-level `agilab` package.
 - `pypi-provenance-evidence`: verifies PyPI attestations after upload.
-- `pypi-release-retention`: prunes older public PyPI releases for selected projects.
+- `pypi-release-retention`: attempts to prune older public PyPI releases for selected projects; missing current releases remain a hard failure, while PyPI web-login cleanup blockage is recorded as a warning after provenance passes.
 - `publish-release-assets`: uploads release artifacts and supply-chain evidence to GitHub Releases.
 - `sync-hf-space`: deploys the public Hugging Face Space after release assets only when the umbrella `agilab` release is selected.
 - `sync-hf-space` also runs the hosted smoke check and records the deployed Space commit in release proof; package-only app/page publishes should skip it by release scope.
@@ -120,7 +120,8 @@ gh run view <run-id> --repo ThalesGroup/agilab --json status,conclusion,url,jobs
 
 Success requires the relevant publish, provenance, retention, release-assets,
 and `sync-hf-space` jobs to be successful or intentionally skipped by release
-scope.
+scope. A successful retention job can still report old-release cleanup warnings
+when PyPI blocks destructive web-management actions from the runner.
 
 ### GitHub Release
 
@@ -193,10 +194,11 @@ print(json.dumps({"missing_expected": missing, "stale_old_releases": stale}, sor
 PY
 ```
 
-After PyPI pruning, `missing_expected` and `stale_old_releases` must both be
-empty. If stale releases remain, distinguish between a retention job that
-concluded success and actual PyPI state; the job can be non-fatal when PyPI web
-login or reauthentication blocks deletion.
+After PyPI pruning, `missing_expected` must be empty. `stale_old_releases`
+should be empty when strict retention succeeds, but stale versions can remain as
+cleanup debt when PyPI web login, unrecognized-login confirmation, or
+reauthentication blocks deletion. Do not confuse that warning state with a
+failed publish or failed provenance check.
 
 ### Release Proof and Docs
 
@@ -307,9 +309,10 @@ after the badge/source change.
 - `sync-hf-space` failed immediately with a missing token: configure the
   repository `HF_TOKEN` secret from a valid local or service Hugging Face token,
   then rerun the workflow job or perform a clean-worktree manual sync.
-- PyPI retention stops at an interactive authentication prompt: verify
-  `PYPI_RELEASE_PRUNE_TOTP_SECRET` or a one-time `PYPI_RELEASE_PRUNE_OTP` is
-  configured. Do not weaken retention logic just to bypass 2FA.
+- PyPI retention records an interactive authentication or unrecognized-login
+  warning: verify `PYPI_RELEASE_PRUNE_TOTP_SECRET` or a one-time
+  `PYPI_RELEASE_PRUNE_OTP`, then use a self-hosted/static-IP runner or manual
+  cleanup from a confirmed device if strict one-release retention is required.
 - HF Space changed but release proof stale: inspect the `sync-hf-space` commit
   step before applying a manual docs refresh.
 - Release proof shows the new tag/commit but still mentions an old tag in a

--- a/.codex/skills/agilab-release-verification/SKILL.md
+++ b/.codex/skills/agilab-release-verification/SKILL.md
@@ -98,7 +98,7 @@ workflow dispatch:
 - `publish-library-packages`: publishes selected split packages with PyPI Trusted Publishing.
 - `publish-agilab`: publishes the top-level `agilab` package.
 - `pypi-provenance-evidence`: verifies PyPI attestations after upload.
-- `pypi-release-retention`: prunes older public PyPI releases for selected projects.
+- `pypi-release-retention`: attempts to prune older public PyPI releases for selected projects; missing current releases remain a hard failure, while PyPI web-login cleanup blockage is recorded as a warning after provenance passes.
 - `publish-release-assets`: uploads release artifacts and supply-chain evidence to GitHub Releases.
 - `sync-hf-space`: deploys the public Hugging Face Space after release assets only when the umbrella `agilab` release is selected.
 - `sync-hf-space` also runs the hosted smoke check and records the deployed Space commit in release proof; package-only app/page publishes should skip it by release scope.
@@ -120,7 +120,8 @@ gh run view <run-id> --repo ThalesGroup/agilab --json status,conclusion,url,jobs
 
 Success requires the relevant publish, provenance, retention, release-assets,
 and `sync-hf-space` jobs to be successful or intentionally skipped by release
-scope.
+scope. A successful retention job can still report old-release cleanup warnings
+when PyPI blocks destructive web-management actions from the runner.
 
 ### GitHub Release
 
@@ -193,10 +194,11 @@ print(json.dumps({"missing_expected": missing, "stale_old_releases": stale}, sor
 PY
 ```
 
-After PyPI pruning, `missing_expected` and `stale_old_releases` must both be
-empty. If stale releases remain, distinguish between a retention job that
-concluded success and actual PyPI state; the job can be non-fatal when PyPI web
-login or reauthentication blocks deletion.
+After PyPI pruning, `missing_expected` must be empty. `stale_old_releases`
+should be empty when strict retention succeeds, but stale versions can remain as
+cleanup debt when PyPI web login, unrecognized-login confirmation, or
+reauthentication blocks deletion. Do not confuse that warning state with a
+failed publish or failed provenance check.
 
 ### Release Proof and Docs
 
@@ -307,9 +309,10 @@ after the badge/source change.
 - `sync-hf-space` failed immediately with a missing token: configure the
   repository `HF_TOKEN` secret from a valid local or service Hugging Face token,
   then rerun the workflow job or perform a clean-worktree manual sync.
-- PyPI retention stops at an interactive authentication prompt: verify
-  `PYPI_RELEASE_PRUNE_TOTP_SECRET` or a one-time `PYPI_RELEASE_PRUNE_OTP` is
-  configured. Do not weaken retention logic just to bypass 2FA.
+- PyPI retention records an interactive authentication or unrecognized-login
+  warning: verify `PYPI_RELEASE_PRUNE_TOTP_SECRET` or a one-time
+  `PYPI_RELEASE_PRUNE_OTP`, then use a self-hosted/static-IP runner or manual
+  cleanup from a confirmed device if strict one-release retention is required.
 - HF Space changed but release proof stale: inspect the `sync-hf-space` commit
   step before applying a manual docs refresh.
 - Release proof shows the new tag/commit but still mentions an old tag in a

--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -679,6 +679,7 @@ jobs:
             --repo-root .
             --protect-versions-from-projects
             --confirm-delete
+            --allow-delete-failure-warning
             --direct-web-only
             --json
             --github-step-summary "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -234,9 +234,10 @@ Python and GitHub Actions manifests, release workflows publish per-profile
 `tools/profile_supply_chain_scan.py` can regenerate the same profile evidence
 locally. PyPI publication uses Trusted Publishing/OIDC and the release workflow
 runs `tools/pypi_provenance_check.py` after upload so missing PyPI attestations
-fail before GitHub release assets are published. The workflow then prunes older
-PyPI releases for each selected project so the current release version is the
-only retained public PyPI release before GitHub release assets are published.
+fail before GitHub release assets are published. The workflow then attempts to
+prune older PyPI releases for each selected project; missing current versions
+remain a hard failure, while PyPI web-login cleanup blockage is recorded as a
+warning so release assets can still be published after provenance succeeds.
 After release assets are published, the same workflow syncs the public Hugging
 Face Space, runs the hosted smoke test, and records the resulting Space commit
 in release proof.

--- a/test/test_pypi_publish_workflow.py
+++ b/test/test_pypi_publish_workflow.py
@@ -302,7 +302,7 @@ def test_pypi_publish_syncs_hf_space_only_for_umbrella_release() -> None:
     assert "git push origin HEAD:main" in text
 
 
-def test_pypi_publish_prunes_previous_pypi_releases_before_release_assets() -> None:
+def test_pypi_publish_attempts_previous_pypi_release_pruning_before_release_assets() -> None:
     text = WORKFLOW_PATH.read_text(encoding="utf-8")
 
     assert "pypi-release-retention:" in text
@@ -316,7 +316,7 @@ def test_pypi_publish_prunes_previous_pypi_releases_before_release_assets() -> N
     assert "tools/pypi_release_retention.py" in text
     assert "--confirm-delete" in text
     assert "--direct-web-only" in text
-    assert "--allow-delete-failure-warning" not in text
+    assert "--allow-delete-failure-warning" in text
     assert "--protect-versions-from-projects" in text
     assert "--repo-root ." in text
     assert "--protect-version \"$current_version\"" not in text

--- a/test/test_release_plan.py
+++ b/test/test_release_plan.py
@@ -176,16 +176,25 @@ publish-library-packages:
     assert "library package matrix must not be hard-coded in the workflow" in missing
 
 
-def test_release_plan_workflow_contract_rejects_warning_only_pypi_retention(tmp_path: Path) -> None:
+def test_release_plan_workflow_contract_requires_warning_capable_pypi_retention(
+    tmp_path: Path,
+) -> None:
     module = _load_module()
     workflow = tmp_path / "pypi-publish.yaml"
-    workflow.write_text("--allow-delete-failure-warning\n", encoding="utf-8")
+    workflow.write_text(
+        """
+pypi-release-retention:
+tools/pypi_release_retention.py
+""",
+        encoding="utf-8",
+    )
 
     missing = module.validate_workflow_contract(workflow)
 
     assert (
-        "PyPI release retention must fail closed in the release workflow: "
-        "forbidden '--allow-delete-failure-warning'"
+        "PyPI release retention must warn when PyPI web deletion is "
+        "operationally blocked after provenance passes: "
+        "missing '--allow-delete-failure-warning'"
     ) in missing
 
 

--- a/tools/release_plan.py
+++ b/tools/release_plan.py
@@ -333,6 +333,10 @@ def validate_workflow_contract(workflow_path: Path) -> list[str]:
             "workflow must support non-interactive PyPI 2FA for release pruning"
         ),
         "--confirm-delete": "workflow must make destructive PyPI retention explicit",
+        "--allow-delete-failure-warning": (
+            "PyPI release retention must warn when PyPI web deletion is "
+            "operationally blocked after provenance passes"
+        ),
         "needs.pypi-release-retention.result == 'success'": (
             "release assets must wait for PyPI release retention to finish"
         ),
@@ -360,16 +364,6 @@ def validate_workflow_contract(workflow_path: Path) -> list[str]:
         for fragment, description in required_fragments.items()
         if fragment not in text
     ]
-    forbidden_fragments = {
-        "--allow-delete-failure-warning": (
-            "PyPI release retention must fail closed in the release workflow"
-        ),
-    }
-    missing.extend(
-        f"{description}: forbidden {fragment!r}"
-        for fragment, description in forbidden_fragments.items()
-        if fragment in text
-    )
     if "\n          - package: " in text:
         missing.append("library package matrix must not be hard-coded in the workflow")
     return missing


### PR DESCRIPTION
## Summary
- record PyPI web-delete blockage as a retention warning after publish/provenance
- keep missing current PyPI versions and provenance failures as hard release gates
- align release workflow tests, README, and release-verification skills

## Validation
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_pypi_publish_workflow.py test/test_release_plan.py
- uv --preview-features extra-build-dependencies run python tools/release_plan.py --check-workflow .github/workflows/pypi-publish.yaml --format json --compact
- uv --preview-features extra-build-dependencies run python tools/pypi_trusted_publisher_contract.py --check-workflow .github/workflows/pypi-publish.yaml
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile skills
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui
- uv --preview-features extra-build-dependencies run python tools/generate_component_coverage_badges.py --components agi-gui agilab
- ./dev release