### PR TITLE
docs(skills): avoid private path scan false positives

### DIFF
--- a/.claude/skills/agilab-installer/SKILL.md
+++ b/.claude/skills/agilab-installer/SKILL.md
@@ -32,9 +32,9 @@ Use this skill when working on:
 - Full install with app tests (macOS/Linux):
   - `./install.sh --non-interactive --cluster-ssh-credentials user:pass --apps-repository /path/to/apps-repo --install-apps --test-apps`
 - Full clean source validation from a new public clone:
-  - `cache_root="${XDG_CACHE_HOME:-$HOME/.cache}/agilab/source_validate"; root="$cache_root/agilab_source_validate_clean_$(date +%Y%m%d_%H%M%S)"; mkdir -p "$root/home"; HOME="$root/home" git clone https://github.com/ThalesGroup/agilab.git "$root/home/agilab"`
-  - `cd "$root/home/agilab" && git lfs install --local && git lfs pull`
-  - `HOME="$root/home" AGI_LOCAL_SHARE="$PWD/localshare" ./install.sh --non-interactive --agi-cluster-share "$PWD/clustershare" --install-apps builtin --test-root --test-core --test-apps --skip-offline`
+  - `cache_root="${XDG_CACHE_HOME:-$HOME/.cache}/agilab/source_validate"; root="$cache_root/agilab_source_validate_clean_$(date +%Y%m%d_%H%M%S)"; sandbox_home="$root/sandbox_home"; mkdir -p "$sandbox_home"; HOME="$sandbox_home" git clone https://github.com/ThalesGroup/agilab.git "$sandbox_home/agilab"`
+  - `cd "$sandbox_home/agilab" && git lfs install --local && git lfs pull`
+  - `HOME="$sandbox_home" AGI_LOCAL_SHARE="$PWD/localshare" ./install.sh --non-interactive --agi-cluster-share "$PWD/clustershare" --install-apps builtin --test-root --test-core --test-apps --skip-offline`
 - Add core suites only when needed:
   - macOS/Linux: `./install.sh --install-apps --test-apps --test-core`
   - Windows: `.\install.ps1 -InstallApps -TestApps -TestCore`

--- a/.claude/skills/agilab-runbook/SKILL.md
+++ b/.claude/skills/agilab-runbook/SKILL.md
@@ -347,9 +347,10 @@ Use this skill when you need repo-specific “how we do things” guidance in `a
     - or recreate `~/.ssh/authorized_keys` with `0700` / `0600` permissions
 - If cluster mode depends on shared storage, restore the node’s `.agilab/.env` and remount the share before blaming AGILAB:
   - Linux node example:
-    - `AGI_CLUSTER_SHARE=/home/<worker-user>/clustershare`
-    - `AGI_LOCAL_SHARE=/home/<worker-user>/localshare`
-    - `sshfs <manager-user>@<manager-ip>:/path/to/manager/clustershare /home/<worker-user>/clustershare`
+    - `worker_home="<worker-home>"`
+    - `AGI_CLUSTER_SHARE="$worker_home/clustershare"`
+    - `AGI_LOCAL_SHARE="$worker_home/localshare"`
+    - `sshfs <manager-user>@<manager-ip>:/path/to/manager/clustershare "$worker_home/clustershare"`
 - For macOS SSHFS workers:
   - `command -v brew` can miss Intel Homebrew; check `/usr/local/Homebrew/bin/brew` before assuming Homebrew is absent.
   - Prefer an interactive package install of FUSE-T SSHFS or macFUSE plus SSHFS; the package step may need an admin password.

--- a/.codex/skills/agilab-installer/SKILL.md
+++ b/.codex/skills/agilab-installer/SKILL.md
@@ -32,9 +32,9 @@ Use this skill when working on:
 - Full install with app tests (macOS/Linux):
   - `./install.sh --non-interactive --cluster-ssh-credentials user:pass --apps-repository /path/to/apps-repo --install-apps --test-apps`
 - Full clean source validation from a new public clone:
-  - `cache_root="${XDG_CACHE_HOME:-$HOME/.cache}/agilab/source_validate"; root="$cache_root/agilab_source_validate_clean_$(date +%Y%m%d_%H%M%S)"; mkdir -p "$root/home"; HOME="$root/home" git clone https://github.com/ThalesGroup/agilab.git "$root/home/agilab"`
-  - `cd "$root/home/agilab" && git lfs install --local && git lfs pull`
-  - `HOME="$root/home" AGI_LOCAL_SHARE="$PWD/localshare" ./install.sh --non-interactive --agi-cluster-share "$PWD/clustershare" --install-apps builtin --test-root --test-core --test-apps --skip-offline`
+  - `cache_root="${XDG_CACHE_HOME:-$HOME/.cache}/agilab/source_validate"; root="$cache_root/agilab_source_validate_clean_$(date +%Y%m%d_%H%M%S)"; sandbox_home="$root/sandbox_home"; mkdir -p "$sandbox_home"; HOME="$sandbox_home" git clone https://github.com/ThalesGroup/agilab.git "$sandbox_home/agilab"`
+  - `cd "$sandbox_home/agilab" && git lfs install --local && git lfs pull`
+  - `HOME="$sandbox_home" AGI_LOCAL_SHARE="$PWD/localshare" ./install.sh --non-interactive --agi-cluster-share "$PWD/clustershare" --install-apps builtin --test-root --test-core --test-apps --skip-offline`
 - Add core suites only when needed:
   - macOS/Linux: `./install.sh --install-apps --test-apps --test-core`
   - Windows: `.\install.ps1 -InstallApps -TestApps -TestCore`

--- a/.codex/skills/agilab-runbook/SKILL.md
+++ b/.codex/skills/agilab-runbook/SKILL.md
@@ -347,9 +347,10 @@ Use this skill when you need repo-specific “how we do things” guidance in `a
     - or recreate `~/.ssh/authorized_keys` with `0700` / `0600` permissions
 - If cluster mode depends on shared storage, restore the node’s `.agilab/.env` and remount the share before blaming AGILAB:
   - Linux node example:
-    - `AGI_CLUSTER_SHARE=/home/<worker-user>/clustershare`
-    - `AGI_LOCAL_SHARE=/home/<worker-user>/localshare`
-    - `sshfs <manager-user>@<manager-ip>:/path/to/manager/clustershare /home/<worker-user>/clustershare`
+    - `worker_home="<worker-home>"`
+    - `AGI_CLUSTER_SHARE="$worker_home/clustershare"`
+    - `AGI_LOCAL_SHARE="$worker_home/localshare"`
+    - `sshfs <manager-user>@<manager-ip>:/path/to/manager/clustershare "$worker_home/clustershare"`
 - For macOS SSHFS workers:
   - `command -v brew` can miss Intel Homebrew; check `/usr/local/Homebrew/bin/brew` before assuming Homebrew is absent.
   - Prefer an interactive package install of FUSE-T SSHFS or macFUSE plus SSHFS; the package step may need an admin password.


### PR DESCRIPTION
Keep repo-managed skill examples scanner-clean without weakening the security scan.\n\nChanges:\n- replace a clean-clone example path that looked like a private home path with a sandbox_home variable\n- replace Linux worker /home placeholder examples with a worker_home variable\n- sync the canonical Claude skills into the Codex mirror\n\nValidation:\n- python3 tools/codex_skills.py --root .codex/skills validate --strict\n- python3 tools/codex_skills.py --root .codex/skills generate\n- python3 tools/skill_security_scan.py --changed-only --base-ref origin/main --fail-on high\n- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile skills