### PR TITLE
Remove deprecated pathspec pattern imports

### DIFF
--- a/src/agilab/core/agi-env/src/agi_env/agi_env.py
+++ b/src/agilab/core/agi-env/src/agi_env/agi_env.py
@@ -47,7 +47,6 @@ import tomlkit
 from typing import Tuple
 import logging
 from pathspec import PathSpec
-from pathspec.patterns import GitWildMatchPattern
 import py7zr
 import urllib.request
 import uuid

--- a/src/agilab/core/agi-env/src/agi_env/project_clone_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/project_clone_support.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any, Callable
 
 from pathspec import PathSpec
-from pathspec.patterns import GitWildMatchPattern
+from pathspec.gitignore import GitIgnoreSpec
 
 from .app_provider_registry import aliased_app_runtime_target
 
@@ -251,7 +251,7 @@ def clone_project(
             continue
         ignore_patterns.extend(line for line in lines if line.strip())
 
-    spec = PathSpec.from_lines(GitWildMatchPattern, ignore_patterns)
+    spec = GitIgnoreSpec.from_lines(ignore_patterns)
 
     try:
         if not dest_root.exists():

--- a/src/agilab/core/agi-env/src/agi_env/rename_gitignore_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/rename_gitignore_support.py
@@ -6,7 +6,7 @@ import re
 from pathlib import Path
 
 from pathspec import PathSpec
-from pathspec.patterns import GitWildMatchPattern
+from pathspec.gitignore import GitIgnoreSpec
 
 
 def replace_text_content(txt: str, rename_map: dict) -> str:
@@ -24,7 +24,7 @@ def load_gitignore_spec(gitignore_path: Path) -> PathSpec:
     """Load a gitignore file into a ``PathSpec``."""
 
     lines = gitignore_path.read_text(encoding="utf-8").splitlines()
-    return PathSpec.from_lines(GitWildMatchPattern, lines)
+    return GitIgnoreSpec.from_lines(lines)
 
 
 def is_relative_to(path: Path, other: Path) -> bool:

--- a/src/agilab/core/agi-env/test/test_agi_env.py
+++ b/src/agilab/core/agi-env/test/test_agi_env.py
@@ -10,6 +10,7 @@ from io import BytesIO
 from types import SimpleNamespace
 
 import pytest
+from pathspec.gitignore import GitIgnoreSpec
 from pathlib import Path
 from unittest import mock
 
@@ -2771,7 +2772,7 @@ def test_clone_directory_covers_symlink_readlink_fallback_and_existing_destinati
     existing_link.write_text("occupied\n", encoding="utf-8")
 
     env = object.__new__(AgiEnv)
-    spec = agi_env_module.PathSpec.from_lines(agi_env_module.GitWildMatchPattern, [])
+    spec = GitIgnoreSpec.from_lines([])
 
     original_readlink = os.readlink
     original_symlink = os.symlink

--- a/src/agilab/core/agi-env/test/test_project_clone_support.py
+++ b/src/agilab/core/agi-env/test/test_project_clone_support.py
@@ -3,8 +3,7 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
-from pathspec import PathSpec
-from pathspec.patterns import GitWildMatchPattern
+from pathspec.gitignore import GitIgnoreSpec
 
 from agi_env.content_renamer_support import ContentRenamer
 import agi_env.project_clone_support as project_clone_support
@@ -369,7 +368,7 @@ def test_clone_directory_and_cleanup_rename_cover_symlink_archive_syntax_and_tex
     source_root.mkdir()
     dest_root = tmp_path / "dest"
     rename_map = {"flight": "demo", "flight_telemetry_project": "demo_project"}
-    spec = PathSpec.from_lines(GitWildMatchPattern, [])
+    spec = GitIgnoreSpec.from_lines([])
 
     link_target = source_root / "target.txt"
     link_target.write_text("flight", encoding="utf-8")
@@ -427,7 +426,7 @@ def test_clone_directory_rewrites_valid_python_with_stdlib_ast_unparse(tmp_path:
     source_root.mkdir()
     dest_root = tmp_path / "dest"
     rename_map = {"flight": "demo", "Flight": "Demo"}
-    spec = PathSpec.from_lines(GitWildMatchPattern, [])
+    spec = GitIgnoreSpec.from_lines([])
     (source_root / "flight.py").write_text(
         "class Flight:\n"
         "    def run(self):\n"
@@ -459,7 +458,7 @@ def test_clone_directory_keeps_explicit_venv_symlink_when_gitignored(tmp_path: P
     dest_root = tmp_path / "dest"
     (source_root / ".venv").mkdir()
     (source_root / "ignored.txt").write_text("ignored", encoding="utf-8")
-    spec = PathSpec.from_lines(GitWildMatchPattern, [".venv/", "ignored.txt"])
+    spec = GitIgnoreSpec.from_lines([".venv/", "ignored.txt"])
 
     clone_directory(
         source_root,
@@ -481,7 +480,7 @@ def test_clone_directory_uses_windows_junction_when_venv_symlink_is_denied(tmp_p
     source_root.mkdir()
     dest_root = tmp_path / "dest"
     (source_root / ".venv").mkdir()
-    spec = PathSpec.from_lines(GitWildMatchPattern, [])
+    spec = GitIgnoreSpec.from_lines([])
     calls: list[list[str]] = []
 
     monkeypatch.setattr(project_clone_support.os, "name", "nt", raising=False)
@@ -520,7 +519,7 @@ def test_clone_directory_skips_venv_when_windows_linking_is_unavailable(tmp_path
     source_root.mkdir()
     dest_root = tmp_path / "dest"
     (source_root / ".venv").mkdir()
-    spec = PathSpec.from_lines(GitWildMatchPattern, [])
+    spec = GitIgnoreSpec.from_lines([])
 
     monkeypatch.setattr(project_clone_support.os, "name", "nt", raising=False)
     monkeypatch.setattr(
@@ -556,7 +555,7 @@ def test_clone_directory_skips_entries_that_are_neither_files_nor_directories(tm
     odd_entry.write_text("payload", encoding="utf-8")
     dest_root = tmp_path / "dest"
     dest_root.mkdir()
-    spec = PathSpec.from_lines(GitWildMatchPattern, [])
+    spec = GitIgnoreSpec.from_lines([])
 
     original_is_file = Path.is_file
     original_is_dir = Path.is_dir

--- a/src/agilab/pages/1_PROJECT.py
+++ b/src/agilab/pages/1_PROJECT.py
@@ -63,7 +63,7 @@ from agi_gui.pagelib import (
 )
 from agi_gui.ux_widgets import compact_choice
 from pathspec import PathSpec
-from pathspec.patterns import GitWildMatchPattern
+from pathspec.gitignore import GitIgnoreSpec
 from code_editor import code_editor
 from agi_env import AgiEnv
 from agi_env.app_provider_registry import resolve_installed_app_project
@@ -1206,7 +1206,7 @@ def read_gitignore(gitignore_path):
     except FileNotFoundError:
         patterns = []
 
-    return PathSpec.from_lines(GitWildMatchPattern, patterns)
+    return GitIgnoreSpec.from_lines(patterns)
 # -------------------- Project Cleaner -------------------- #
 
 

--- a/test/test_import_deprecation_hygiene.py
+++ b/test/test_import_deprecation_hygiene.py
@@ -36,7 +36,7 @@ def _parsed_python_files() -> list[tuple[Path, ast.AST]]:
     return parsed
 
 
-def test_runtime_source_does_not_import_deprecated_astor_or_distutils() -> None:
+def test_runtime_source_does_not_import_deprecated_apis() -> None:
     violations: list[str] = []
     for path, tree in _parsed_python_files():
         for node in ast.walk(tree):
@@ -49,6 +49,12 @@ def test_runtime_source_does_not_import_deprecated_astor_or_distutils() -> None:
                 root_name = (node.module or "").split(".", 1)[0]
                 if root_name in {"astor", "distutils"}:
                     violations.append(f"{path.relative_to(REPO_ROOT)} imports from {node.module}")
+                if node.module == "pathspec.patterns":
+                    for alias in node.names:
+                        if alias.name == "GitWildMatchPattern":
+                            violations.append(
+                                f"{path.relative_to(REPO_ROOT)} imports deprecated pathspec.patterns.GitWildMatchPattern"
+                            )
 
     assert violations == []
 

--- a/test/test_project_clone_policy.py
+++ b/test/test_project_clone_policy.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+from pathspec.gitignore import GitIgnoreSpec
 
 
 MODULE_PATH = Path("src/agilab/pages/1_PROJECT.py")
@@ -2127,7 +2128,7 @@ def test_process_files_reports_decode_errors(tmp_path: Path, monkeypatch):
     monkeypatch.setattr(Path, "read_text", _raise_decode)
     monkeypatch.setattr(module.st, "warning", warnings.append)
 
-    spec = module.PathSpec.from_lines(module.GitWildMatchPattern, [])
+    spec = GitIgnoreSpec.from_lines([])
     module.process_files(
         str(source_app),
         ["broken.py"],

--- a/tools/zip_all.py
+++ b/tools/zip_all.py
@@ -31,7 +31,7 @@ import os
 import posixpath
 import zipfile
 from pathspec import PathSpec
-from pathspec.patterns import GitWildMatchPattern
+from pathspec.gitignore import GitIgnoreSpec
 import argparse
 from pathlib import Path
 from functools import lru_cache
@@ -44,9 +44,9 @@ def read_gitignore_cached(gitignore_path):
     try:
         with open(gitignore_path, "r") as f:
             patterns = f.read().splitlines()
-        return PathSpec.from_lines(GitWildMatchPattern, patterns)
+        return GitIgnoreSpec.from_lines(patterns)
     except FileNotFoundError:
-        return PathSpec.from_lines(GitWildMatchPattern, [])
+        return GitIgnoreSpec.from_lines([])
 
 def _normalize_relpath(relpath: str) -> str:
     return relpath.replace(os.sep, "/")
@@ -287,7 +287,7 @@ if __name__ == "__main__":
     else:
         if verbose:
             print(f"No top-level .gitignore found at {top_gitignore}. No files will be filtered at this level.")
-        top_spec = PathSpec.from_lines(GitWildMatchPattern, [])
+        top_spec = GitIgnoreSpec.from_lines([])
 
     follow_names = FOLLOW_SYMLINK_NAMES_DEFAULT if follow_app_links else None
 


### PR DESCRIPTION
## Summary
- replace deprecated pathspec.patterns.GitWildMatchPattern imports with GitIgnoreSpec
- update project clone and zip helpers plus tests
- extend deprecation hygiene scan to catch future GitWildMatchPattern imports

## Local validation
- uv --preview-features extra-build-dependencies run --no-sync pytest -q -o addopts='' src/agilab/core/agi-env/test
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_import_deprecation_hygiene.py test/test_project_clone_policy.py::test_process_files_reports_decode_errors
- uv --preview-features extra-build-dependencies run python -m py_compile src/agilab/core/agi-env/src/agi_env/project_clone_support.py src/agilab/core/agi-env/src/agi_env/rename_gitignore_support.py src/agilab/pages/1_PROJECT.py tools/zip_all.py