### PR TITLE
Add pandas Cython speedup reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Start with the public browser preview or the demo chooser:
 
 - [AGILAB Space](https://huggingface.co/spaces/jpmorard/agilab)
 - [Demo chooser](https://thalesgroup.github.io/agilab/demos.html)
+- [Cython worker speedup demo](https://thalesgroup.github.io/agilab/execution-playground.html)
 - [Local quick start](#quick-start)
 - [Demo capture guide](https://thalesgroup.github.io/agilab/demo_capture_script.html)
 
@@ -96,6 +97,16 @@ Start with the public browser preview or the demo chooser:
   synthetic datasets, hidden-layer activation maps, network diagnostics, and
   the **Loss landscape** view. It is a reproducible app project, not a generic
   app-agnostic analysis page, and loss landscape is part of that project.
+
+## Featured Performance Demo
+
+- [Execution Pandas Project](src/agilab/apps/builtin/execution_pandas_project)
+  is the Cython worker speedup demo. It keeps Pandas I/O and reducer evidence
+  in Python, then isolates the hot scoring loop as a typed contiguous
+  `float64` kernel so AGILAB can compare Python and Cython execution honestly.
+  The versioned local kernel proof reports `0.620s` Python vs `0.002s` Cython
+  on 100,000 rows x 32 passes, a checksum-matched `306x` speedup. That is a
+  focused hot-loop result, not an end-to-end runtime promise.
 
 ## [Quick Start](https://thalesgroup.github.io/agilab/quick-start.html)
 
@@ -116,8 +127,8 @@ For a zero-install browser preview, open the public
 lightweight `flight_telemetry_project` path by default and exposes the
 `weather_forecast_project` notebook-migration demo with forecast analysis views.
 Advanced scenarios such as `mission_decision_project`,
-`execution_pandas_project`, `execution_polars_project`, and
-`uav_relay_queue_project` are collected in the
+the `execution_pandas_project` Cython worker speedup demo,
+`execution_polars_project`, and `uav_relay_queue_project` are collected in the
 [Advanced Proof Pack](https://thalesgroup.github.io/agilab/advanced-proof-pack.html).
 For the full project/package/status matrix, see the
 [Public App Catalog](https://thalesgroup.github.io/agilab/public-app-catalog.html).

--- a/README.pypi.md
+++ b/README.pypi.md
@@ -62,8 +62,19 @@ Start with the public browser preview or the demo chooser:
 
 - [AGILAB Space](https://huggingface.co/spaces/jpmorard/agilab)
 - [Demo chooser](https://thalesgroup.github.io/agilab/demos.html)
+- [Cython worker speedup demo](https://thalesgroup.github.io/agilab/execution-playground.html)
 - [Local quick start](https://thalesgroup.github.io/agilab/quick-start.html)
 - [Demo capture guide](https://thalesgroup.github.io/agilab/demo_capture_script.html)
+
+## Featured Performance Demo
+
+`execution_pandas_project` is the Cython worker speedup demo. It keeps Pandas
+I/O and reducer evidence in Python, then isolates the hot scoring loop as a
+typed contiguous `float64` kernel so AGILAB can compare Python and Cython
+execution honestly.
+The versioned local kernel proof reports `0.620s` Python vs `0.002s` Cython
+on 100,000 rows x 32 passes, a checksum-matched `306x` speedup. That is a
+focused hot-loop result, not an end-to-end runtime promise.
 
 ## Quick Start
 
@@ -82,8 +93,8 @@ For a zero-install browser preview, open the public
 lightweight `flight_telemetry_project` path by default and exposes the
 `weather_forecast_project` notebook-migration demo with forecast analysis views.
 Advanced scenarios such as `mission_decision_project`,
-`execution_pandas_project`, `execution_polars_project`, and
-`uav_relay_queue_project` are collected in the
+the `execution_pandas_project` Cython worker speedup demo,
+`execution_polars_project`, and `uav_relay_queue_project` are collected in the
 [Advanced Proof Pack](https://thalesgroup.github.io/agilab/advanced-proof-pack.html).
 For the full project/package/status matrix, see the
 [Public App Catalog](https://thalesgroup.github.io/agilab/public-app-catalog.html).

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 218,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "dab6b6e8cdc36f4fead5cf2749ddd60e1a2f29c2a8bc29d382b2e4719dccb269",
+  "source_digest_sha256": "f345a72c06caadc32047d110726eff721e15f2bb7c3ed6a47cdea3cfaeccad55",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "dab6b6e8cdc36f4fead5cf2749ddd60e1a2f29c2a8bc29d382b2e4719dccb269"
+  "target_digest_sha256": "f345a72c06caadc32047d110726eff721e15f2bb7c3ed6a47cdea3cfaeccad55"
 }

--- a/docs/source/advanced-proof-pack.rst
+++ b/docs/source/advanced-proof-pack.rst
@@ -25,9 +25,14 @@ What belongs here
        inject an event, re-plan, and export a decision bundle.
      - Select the built-in app, run ``ORCHESTRATE``, then open
        ``view_data_io_decision``.
-   * - ``execution_pandas_project`` / ``execution_polars_project``
-     - Execution-model benchmarking: AGILAB pool/Dask/Cython choices are
-       measured separately from dataframe-library choice.
+   * - ``execution_pandas_project``
+     - Cython worker speedup demo: a Pandas worker keeps dataframe I/O and
+       reducer evidence in Python while the hot scoring loop runs as a typed
+       contiguous ``float64`` kernel.
+     - Use :doc:`execution-playground`.
+   * - ``execution_polars_project``
+     - Execution-model benchmarking for the comparable threaded dataframe
+       worker path.
      - Use :doc:`execution-playground`.
    * - ``uav_queue_project`` / ``uav_relay_queue_project``
      - Network-style experiment analysis: queue buildup, packet drops, routing
@@ -81,8 +86,10 @@ Run these in this order when you need a compact but convincing evaluation pass:
    story because it shows an input-to-decision workflow, not only a data
    transform.
 2. **Execution credibility**: :doc:`execution-playground`. This is the best
-   technical story because it separates Pandas, Polars, pool, Dask, and Cython
-   effects. The Cython proof is kernel-scoped and records its dtype contract.
+   technical story because ``execution_pandas_project`` provides the Cython
+   worker speedup demo, while the paired Polars app separates dataframe-library,
+   pool, Dask, and Cython effects. The Cython proof is kernel-scoped and records
+   its dtype contract.
 3. **Network analysis**: ``uav_relay_queue_project``. This is the best visual
    story because the same run can feed queue analysis and generic network maps.
 4. **Tracking memory**: ``mlflow_auto_tracking`` preview. This is the best

--- a/docs/source/agilab-demo.rst
+++ b/docs/source/agilab-demo.rst
@@ -44,8 +44,10 @@ Use :doc:`advanced-proof-pack` when the first proof is complete and you want to
 show the deeper built-in assets without making the newcomer route longer:
 
 - ``mission_decision_project`` for a deterministic mission-decision workflow.
-- ``execution_pandas_project`` and ``execution_polars_project`` for
-  execution-model benchmarking, including the Cython typed-kernel proof.
+- ``execution_pandas_project`` for the Cython worker speedup demo: a typed
+  contiguous ``float64`` hot loop with Python/Cython runtime evidence.
+- ``execution_polars_project`` for the comparable threaded dataframe-worker
+  benchmark.
 - ``uav_relay_queue_project`` for queue analysis, topology, trajectories, and
   ``view_maps_network``.
 - ``service_mode`` and data connector reports for operator and integration

--- a/docs/source/demos.rst
+++ b/docs/source/demos.rst
@@ -45,7 +45,8 @@ What each route is for
   the hosted ``weather_forecast_project`` analysis route.
 - **Advanced Proof Pack**: use :doc:`advanced-proof-pack` after the first demo
   when you want the deeper packaged proof routes: ``mission_decision_project``,
-  ``execution_pandas_project`` / ``execution_polars_project``, UAV queue
+  the ``execution_pandas_project`` Cython worker speedup demo,
+  ``execution_polars_project``, UAV queue
   analysis with ``uav_relay_queue_project``, ``service_mode`` previews,
   ``inter_project_dag`` previews, ``mlflow_auto_tracking`` previews,
   ``resilience_failure_injection`` previews, ``train_then_serve`` previews,
@@ -107,6 +108,27 @@ The static scenario contract is available as JSON:
   packaged local pages and ``agi-pages`` analysis views.
   The same route is available in the UI by following ``PROJECT`` ->
   ``ORCHESTRATE`` -> ``ANALYSIS`` with ``flight_telemetry_project``.
+
+**Cython worker speedup demo**
+  Use :doc:`execution-playground` when the demo objective is performance
+  engineering rather than a domain story. Select ``execution_pandas_project``,
+  keep the default ``typed_numeric`` kernel and Cython setting, run
+  ``INSTALL`` then ``EXECUTE``, and inspect the reducer evidence for
+  ``kernel_mode``, ``kernel_runtime``, and ``dtype_contract``.
+  The versioned local kernel proof records ``0.620s`` Python vs ``0.002s``
+  Cython on 100,000 rows x 32 passes, with matching checksums and a ``306x``
+  hot-loop speedup.
+
+  For a short command-line proof of the compiled hot loop, run:
+
+  .. code-block:: bash
+
+     uv --preview-features extra-build-dependencies run python tools/benchmark_execution_pandas_cython_kernel.py --rows 100000 --compute-passes 32 --repeats 3 --warmups 1
+
+  Stop when the Python and Cython checksums match and the report shows the
+  Cython runtime separately. This is a kernel-scoped speedup demo; full AGILAB
+  runs still include CSV reads, dataframe grouping, result writes, worker
+  startup, and optional Dask/process orchestration.
 
 **Distributed worker route**
   Use the same public app, then switch ORCHESTRATE from the local path to the

--- a/docs/source/execution-playground.rst
+++ b/docs/source/execution-playground.rst
@@ -129,15 +129,21 @@ Raw benchmark artifacts are versioned under:
 Typed Cython kernel proof
 -------------------------
 
-``execution_pandas_project`` now includes a second workload shape for the hot
-numeric section: ``kernel_mode = "typed_numeric"``. This is the default for the
-app. It converts the scoring columns to contiguous ``float64`` arrays and runs
-the repeated score/checksum loop through a Cython-compatible typed function.
+``execution_pandas_project`` is the reference worker app for an explicit
+Cython/C-speedup path. It uses ``kernel_mode = "typed_numeric"`` by default,
+enables Cython in its app settings, converts the scoring columns to contiguous
+``float64`` arrays, and runs the repeated score/checksum loop through a
+Cython-compatible typed function.
 
 That distinction matters: wrapping Pandas calls in Cython is not a useful proof
 of Cython acceleration, because Pandas is already executing compiled kernels.
 The typed kernel keeps the surrounding app realistic while giving Cython a
 numeric loop where fixed dtypes can remove Python object dispatch.
+
+The worker manifest declares Cython as a build requirement, so this app is the
+recommended starting point when you need to show how a normal AGILAB worker can
+carry a compiled hot path without moving the surrounding dataframe I/O and
+artifact contract out of Python.
 
 The kernel-only evidence helper compiles the actual worker source in a temporary
 Cython extension, then compares the same ``_typed_numeric_score_kernel`` through

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -62,11 +62,15 @@ agi-core
   - AGILab now exposes a shared ``agi_node`` reduce contract with explicit
     partial inputs, reducer merge semantics, and a standard reduce artefact
     schema.
-  - ``execution_pandas_project`` and ``execution_polars_project`` emit named
-    benchmark reduce artefacts through that shared contract; the user-facing
-    ``flight_telemetry_project`` emits trajectory-summary reduce artefacts;
-    ``weather_forecast_project`` emits forecast-metrics reduce artefacts; and
-    ``uav_queue_project`` plus ``uav_relay_queue_project`` emit the same
+  - ``execution_pandas_project`` is the Cython worker speedup demo: it emits
+    named benchmark reduce artefacts and records ``typed_numeric`` kernel mode,
+    Python/Cython runtime, and the ``float64-contiguous`` dtype contract through
+    that shared contract.
+  - ``execution_polars_project`` emits comparable benchmark reduce artefacts;
+    the user-facing ``flight_telemetry_project`` emits trajectory-summary
+    reduce artefacts; ``weather_forecast_project`` emits forecast-metrics
+    reduce artefacts; and ``uav_queue_project`` plus
+    ``uav_relay_queue_project`` emit the same
     ``reduce_summary_worker_<id>.json`` artifact shape for queue metrics.
   - The Release Decision evidence view discovers those artefacts, validates
     their schema, and displays reducer name, partial count, artifact path,

--- a/docs/source/public-app-catalog.rst
+++ b/docs/source/public-app-catalog.rst
@@ -41,7 +41,8 @@ Status legend:
    * - ``execution_pandas_project``
      - ``agi-app-pandas-execution``
      - PyPI app package
-     - Synthetic worker execution playground for the Pandas path and reducer
+     - Cython worker speedup demo for the Pandas path: typed contiguous
+       ``float64`` kernel, Python/Cython runtime evidence, and reducer
        evidence.
    * - ``execution_polars_project``
      - ``agi-app-polars-execution``

--- a/src/agilab/apps/builtin/execution_pandas_project/README.md
+++ b/src/agilab/apps/builtin/execution_pandas_project/README.md
@@ -1,14 +1,14 @@
 # Execution Pandas Project
 
-`execution_pandas_project` is a built-in AGILAB execution playground for the
-`PandasWorker` path.
+`execution_pandas_project` is the built-in AGILAB reference app for a
+`PandasWorker` with an explicit Cython/C-speedup path.
 
 The app generates a deterministic CSV workload, distributes file batches across
 available workers, runs a pandas aggregation workload, and writes result files
 plus a reduce artifact that AGILAB analysis pages can inspect. Its default
-`typed_numeric` kernel converts hot columns to contiguous `float64` arrays so
-Cython mode has a real typed loop to accelerate instead of only wrapping Pandas
-calls.
+`typed_numeric` kernel converts hot columns to contiguous `float64` arrays.
+The app enables Cython mode by default so AGILAB can compile a real typed loop
+instead of only wrapping Pandas calls.
 
 ## What It Shows
 
@@ -16,6 +16,7 @@ calls.
 - worker distribution over multiple CSV partitions
 - pandas-based compute and aggregation through the AGILAB worker contract
 - a Cython-favorable typed numeric kernel with explicit dtype metadata
+- a worker build manifest that declares Cython as a build requirement
 - output parity artifacts for comparing execution modes and worker behavior
 
 ## Typical Flow

--- a/src/agilab/apps/builtin/execution_pandas_project/src/app_settings.toml
+++ b/src/agilab/apps/builtin/execution_pandas_project/src/app_settings.toml
@@ -14,7 +14,7 @@ reset_target = false
 
 [cluster]
 verbose = 1
-cython = false
+cython = true
 pool = false
 rapids = false
 cluster_enabled = false

--- a/src/agilab/apps/builtin/execution_pandas_project/src/execution_pandas_worker/execution_pandas_worker.py
+++ b/src/agilab/apps/builtin/execution_pandas_project/src/execution_pandas_worker/execution_pandas_worker.py
@@ -91,6 +91,28 @@ def _as_contiguous_float64(series: pd.Series) -> np.ndarray:
     return np.ascontiguousarray(series.to_numpy(dtype=np.float64, copy=False))
 
 
+def _tail_checksum_from_arrays(
+    x_values: np.ndarray,
+    y_values: np.ndarray,
+    signal_values: np.ndarray,
+    weight_values: np.ndarray,
+    *,
+    pass_count: int,
+    sample_stride: int = 64,
+) -> float:
+    loop_passes = max(pass_count, 1) * 8
+    if sample_stride <= 0 or len(x_values) == 0:
+        return 0.0
+    x_sample = x_values[::sample_stride]
+    y_sample = y_values[::sample_stride]
+    signal_sample = signal_values[::sample_stride]
+    weight_sample = weight_values[::sample_stride]
+    values = x_sample + y_sample * 0.01
+    for _ in range(loop_passes):
+        values = np.abs((values * 1.0000007) + signal_sample * 0.17 - weight_sample * 0.03)
+    return float(values.sum())
+
+
 class ExecutionPandasWorker(PandasWorker):
     """Execute the benchmark workload through the PandasWorker path."""
 
@@ -132,21 +154,13 @@ class ExecutionPandasWorker(PandasWorker):
     def _python_tail_checksum(self, df: pd.DataFrame) -> float:
         """Add a small GIL-bound scalar tail so execution modes separate more clearly."""
         args = self._current_args()
-        loop_passes = max(int(getattr(args, "compute_passes", 1)), 1) * 8
-        sample_stride = 64
-        checksum = 0.0
-        x_values = df["x"].to_list()
-        y_values = df["y"].to_list()
-        signal_values = df["signal"].to_list()
-        weight_values = df["weight"].to_list()
-        for idx in range(0, len(x_values), sample_stride):
-            value = float(x_values[idx]) + float(y_values[idx]) * 0.01
-            signal = float(signal_values[idx])
-            weight = float(weight_values[idx])
-            for _ in range(loop_passes):
-                value = abs((value * 1.0000007) + signal * 0.17 - weight * 0.03)
-            checksum += value
-        return checksum
+        return _tail_checksum_from_arrays(
+            _as_contiguous_float64(df["x"]),
+            _as_contiguous_float64(df["y"]),
+            _as_contiguous_float64(df["signal"]),
+            _as_contiguous_float64(df["weight"]),
+            pass_count=max(int(getattr(args, "compute_passes", 1)), 1),
+        )
 
     def _prepare_dataframe_scores(self, df: pd.DataFrame, passes: int) -> float:
         for idx in range(passes):
@@ -159,13 +173,38 @@ class ExecutionPandasWorker(PandasWorker):
         return self._python_tail_checksum(df)
 
     def _prepare_typed_numeric_scores(self, df: pd.DataFrame, passes: int) -> float:
+        x_values = _as_contiguous_float64(df["x"])
+        y_values = _as_contiguous_float64(df["y"])
+        signal_values = _as_contiguous_float64(df["signal"])
+        weight_values = _as_contiguous_float64(df["weight"])
         score_0 = np.empty(len(df), dtype=np.float64)
         score_last = np.empty(len(df), dtype=np.float64)
+        if not cython.compiled:
+            score_0[:] = np.abs(
+                (x_values * 1.3) - (y_values * 0.35) + (signal_values * weight_values)
+            )
+            last_idx = passes - 1
+            score_last[:] = np.abs(
+                (x_values * (last_idx + 1.3))
+                - (y_values * (0.35 + last_idx * 0.05))
+                + (signal_values * weight_values)
+            )
+            checksum = _tail_checksum_from_arrays(
+                x_values,
+                y_values,
+                signal_values,
+                weight_values,
+                pass_count=passes,
+            )
+            df["score_0"] = score_0
+            df[f"score_{passes - 1}"] = score_last
+            return float(checksum)
+
         checksum = _typed_numeric_score_kernel(
-            _as_contiguous_float64(df["x"]),
-            _as_contiguous_float64(df["y"]),
-            _as_contiguous_float64(df["signal"]),
-            _as_contiguous_float64(df["weight"]),
+            x_values,
+            y_values,
+            signal_values,
+            weight_values,
             score_0,
             score_last,
             passes,

--- a/src/agilab/apps/builtin/execution_pandas_project/src/execution_pandas_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/execution_pandas_project/src/execution_pandas_worker/pyproject.toml
@@ -10,5 +10,5 @@ agi-env = { path = "../../../../../core/agi-env", editable = true }
 agi-node = { path = "../../../../../core/agi-node", editable = true }
 
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools", "cython"]
 build-backend = "setuptools.build_meta"

--- a/src/agilab/apps/builtin/execution_pandas_project/test/test_execution_pandas_project.py
+++ b/src/agilab/apps/builtin/execution_pandas_project/test/test_execution_pandas_project.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import json
 import sys
 import time
+import tomllib
 from pathlib import Path
 from types import SimpleNamespace
 
+import numpy as np
 import pandas as pd
 
 from agi_node.reduction import ReduceArtifact
@@ -26,7 +28,14 @@ from execution_pandas.reduction import (
     partial_from_result_frame,
     reduce_artifact_path,
 )
-from execution_pandas_worker.execution_pandas_worker import ExecutionPandasWorker
+from execution_pandas_worker.execution_pandas_worker import (
+    ExecutionPandasWorker,
+    _tail_checksum_from_arrays,
+)
+
+
+def _load_toml(path: Path) -> dict:
+    return tomllib.loads(path.read_text(encoding="utf-8"))
 
 
 def _make_env(tmp_path: Path) -> SimpleNamespace:
@@ -45,6 +54,22 @@ def _make_env(tmp_path: Path) -> SimpleNamespace:
         AGI_LOCAL_SHARE=str(share_root),
         target="execution_pandas_project",
     )
+
+
+def test_execution_pandas_declares_cython_worker_reference_contract() -> None:
+    settings = _load_toml(APP_ROOT / "src" / "app_settings.toml")
+    worker_manifest = _load_toml(
+        APP_ROOT / "src" / "execution_pandas_worker" / "pyproject.toml"
+    )
+
+    build_requires = {
+        str(requirement).split(">", 1)[0].split("=", 1)[0].lower()
+        for requirement in worker_manifest["build-system"]["requires"]
+    }
+
+    assert settings["args"]["kernel_mode"] == "typed_numeric"
+    assert settings["cluster"]["cython"] is True
+    assert {"setuptools", "cython"} <= build_requires
 
 
 def test_execution_pandas_generates_dataset_and_distribution(tmp_path: Path) -> None:
@@ -101,6 +126,35 @@ def test_execution_pandas_worker_processes_a_file(tmp_path: Path) -> None:
     assert set(result["kernel_mode"]) == {"typed_numeric"}
     assert set(result["kernel_runtime"]) == {"python"}
     assert set(result["dtype_contract"]) == {"float64-contiguous"}
+
+
+def test_execution_pandas_vectorized_tail_checksum_matches_scalar_reference() -> None:
+    x_values = np.asarray([1.5, 2.0, 3.5, 5.0, 8.0], dtype=np.float64)
+    y_values = np.asarray([0.2, 0.4, 0.6, 0.8, 1.0], dtype=np.float64)
+    signal_values = np.asarray([0.1, -0.2, 0.3, -0.4, 0.5], dtype=np.float64)
+    weight_values = np.asarray([1.0, 1.1, 1.2, 1.3, 1.4], dtype=np.float64)
+    pass_count = 3
+    sample_stride = 2
+
+    expected = 0.0
+    for idx in range(0, len(x_values), sample_stride):
+        value = float(x_values[idx]) + float(y_values[idx]) * 0.01
+        signal = float(signal_values[idx])
+        weight = float(weight_values[idx])
+        for _ in range(pass_count * 8):
+            value = abs((value * 1.0000007) + signal * 0.17 - weight * 0.03)
+        expected += value
+
+    actual = _tail_checksum_from_arrays(
+        x_values,
+        y_values,
+        signal_values,
+        weight_values,
+        pass_count=pass_count,
+        sample_stride=sample_stride,
+    )
+
+    assert actual == expected
 
 
 def test_execution_pandas_typed_kernel_matches_dataframe_scores(tmp_path: Path) -> None:

--- a/src/agilab/lib/agi-app-pandas-execution/README.md
+++ b/src/agilab/lib/agi-app-pandas-execution/README.md
@@ -6,13 +6,15 @@
 
 `agi-app-pandas-execution` publishes the `execution_pandas_project` AGILAB app
 as a self-contained PyPI payload. It is a small execution benchmark for the
-Pandas worker path.
+Pandas worker path with an explicit Cython/C-speedup kernel.
 
 ## Purpose
 
 Use this package to validate AGILAB manager/worker distribution with a
 deterministic tabular workload. It generates CSV partitions, processes them with
 Pandas, and writes reducer evidence that can be compared across run modes.
+The default `typed_numeric` kernel exposes a contiguous `float64` hot loop so
+Cython mode has real scalar work to compile instead of wrapping Pandas calls.
 
 ## Installed Project
 
@@ -34,7 +36,8 @@ package in isolation.
 ## Run In AGILAB
 
 Select `execution_pandas_project`, open `ORCHESTRATE`, then run `INSTALL` and
-`EXECUTE`. Keep the default local settings for a first proof, then increase
+`EXECUTE`. Keep the default local settings for a first proof, or disable Cython
+when you specifically want to compare the pure Python worker path. Increase
 partitions or worker count when you want a stronger distribution check.
 
 ## Expected Inputs


### PR DESCRIPTION
## Summary
- enable the execution_pandas_project Cython worker reference path by default
- document the Cython worker speedup demo in README and public docs
- add a NumPy fallback for source/dev typed_numeric execution so uncompiled workers stay fast
- cover the worker manifest/settings contract and checksum parity

## Local validation
- PYTHONPATH=src/agilab/core/agi-env/src:src/agilab/core/agi-node/src:src/agilab/apps/builtin/execution_pandas_project/src uv --preview-features extra-build-dependencies run --no-sync pytest -q -o addopts='' --import-mode=importlib src/agilab/apps/builtin/execution_pandas_project/test/test_execution_pandas_project.py
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' src/agilab/core/agi-env/test/test_app_settings_support.py test/test_pyproject_dependency_hygiene.py
- uv --preview-features extra-build-dependencies run python tools/benchmark_execution_pandas_cython_kernel.py --rows 100000 --compute-passes 32 --repeats 3 --warmups 1
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui