### PR TITLE
[codex] Speed up node cluster worker startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,11 @@ Start with the public browser preview or the demo chooser:
   The versioned local kernel proof reports `0.620s` Python vs `0.002s` Cython
   on 100,000 rows x 32 passes, a checksum-matched `306x` speedup. That is a
   focused hot-loop result, not an end-to-end runtime promise.
+- [Flight Telemetry Project](src/agilab/apps/builtin/flight_telemetry_project)
+  is the real-world worker-only Cython example: the Polars ingestion and
+  artifact contract stay in Python, while the per-row haversine distance kernel
+  reports `speed_kernel_runtime`, `speed_dtype_contract`, and checksum evidence
+  in the reducer summary.
 
 ## [Quick Start](https://thalesgroup.github.io/agilab/quick-start.html)
 

--- a/README.pypi.md
+++ b/README.pypi.md
@@ -76,6 +76,11 @@ The versioned local kernel proof reports `0.620s` Python vs `0.002s` Cython
 on 100,000 rows x 32 passes, a checksum-matched `306x` speedup. That is a
 focused hot-loop result, not an end-to-end runtime promise.
 
+`flight_telemetry_project` is the real-world worker-only Cython example: the
+Polars ingestion and artifact contract stay in Python, while the per-row
+haversine distance kernel reports `speed_kernel_runtime`,
+`speed_dtype_contract`, and checksum evidence in the reducer summary.
+
 ## Quick Start
 
 [![AGILAB Space](https://img.shields.io/badge/AGILAB-Space-0F766E?style=for-the-badge)](https://huggingface.co/spaces/jpmorard/agilab)

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 218,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "f345a72c06caadc32047d110726eff721e15f2bb7c3ed6a47cdea3cfaeccad55",
+  "source_digest_sha256": "a4b6f40816375d057cb5f8bf54928ed26c1300333608e6c4a574496934f21a37",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "f345a72c06caadc32047d110726eff721e15f2bb7c3ed6a47cdea3cfaeccad55"
+  "target_digest_sha256": "a4b6f40816375d057cb5f8bf54928ed26c1300333608e6c4a574496934f21a37"
 }

--- a/docs/source/demos.rst
+++ b/docs/source/demos.rst
@@ -130,6 +130,12 @@ The static scenario contract is available as JSON:
   runs still include CSV reads, dataframe grouping, result writes, worker
   startup, and optional Dask/process orchestration.
 
+  For the real-world version of the same pattern, run
+  ``flight_telemetry_project``. Its Polars ingestion and map/network analysis
+  stay in Python, while the haversine speed kernel records
+  ``speed_kernel_runtime``, ``speed_dtype_contract``, and checksum evidence in
+  the reducer summary.
+
 **Distributed worker route**
   Use the same public app, then switch ORCHESTRATE from the local path to the
   configured worker or SSH-host path. Keep the demo bounded: prove that worker

--- a/docs/source/execution-playground.rst
+++ b/docs/source/execution-playground.rst
@@ -166,6 +166,12 @@ optional Dask/process orchestration. The reducer records ``kernel_mode``,
 ``kernel_runtime``, and ``dtype_contract`` so the output artifact makes that
 distinction explicit.
 
+The real-world companion is ``flight_telemetry_project``: it keeps Polars
+ingestion, output writing, pages, and reducer artifacts in Python, but moves the
+per-row haversine distance calculation into the same worker-only Cython pattern.
+Its reducer summary records ``speed_kernel_runtime``,
+``speed_dtype_contract``, and ``speed_kernel_checksum_m``.
+
 2-node 16-mode matrix
 ---------------------
 

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -68,7 +68,8 @@ agi-core
     that shared contract.
   - ``execution_polars_project`` emits comparable benchmark reduce artefacts;
     the user-facing ``flight_telemetry_project`` emits trajectory-summary
-    reduce artefacts; ``weather_forecast_project`` emits forecast-metrics
+    reduce artefacts and records worker-only Cython evidence for its haversine
+    speed kernel; ``weather_forecast_project`` emits forecast-metrics
     reduce artefacts; and ``uav_queue_project`` plus
     ``uav_relay_queue_project`` emit the same
     ``reduce_summary_worker_<id>.json`` artifact shape for queue metrics.

--- a/docs/source/flight-telemetry-project.rst
+++ b/docs/source/flight-telemetry-project.rst
@@ -9,6 +9,9 @@ Overview
 - Demonstrates how to orchestrate file-based distributions, run inside the
   cluster pool and keep the web interface responsive while the
   worker pipeline operates asynchronously.
+- Demonstrates the real-world worker-only Cython pattern: Polars ingestion,
+  output writing, pages, and reducer contracts stay in Python, while the
+  per-row haversine distance kernel can run as a typed compiled worker hot loop.
 - Bundles web-view lab material (``lab_stages.toml``) and prompt examples to help
   you reproduce the workflow showcased in AGILab live demos.
 
@@ -28,6 +31,11 @@ with Earth radius :math:`R` and angular differences
 The public demo stores this per-sample segment distance in the historical
 ``speed`` column so existing analysis pages and reducer contracts remain
 compatible.
+
+The worker also records ``speed_kernel_runtime``, ``speed_dtype_contract``, and
+``speed_kernel_checksum_m`` in the reducer summary. That makes Cython mode
+auditable without moving dataframe I/O, map/network analysis, or artifact
+generation out of normal Python.
 
 Public scope
 ------------
@@ -59,6 +67,8 @@ Worker (`flight_telemetry_worker.flight_telemetry_worker`)
   segment distances between samples, and partition files across the cluster.
 - Can be compiled by the AGILab dispatcher when Cython is enabled; generated
   ``.pyx``/``.c`` files are build artefacts, not source-of-truth files.
+- Keeps Cython scoped to the worker hot loop. The app manager, UI forms,
+  analysis pages, and reducer schema remain regular Python.
 - Demonstrates Windows-friendly path handling and data staging for managed
   environments.
 

--- a/docs/source/public-app-catalog.rst
+++ b/docs/source/public-app-catalog.rst
@@ -27,7 +27,8 @@ Status legend:
      - ``agi-app-flight-telemetry``
      - PyPI app package
      - First proof and compact end-to-end data ingestion with map/network
-       analysis.
+       analysis; also the real-world worker-only Cython example for a
+       haversine speed kernel with reducer evidence.
    * - ``weather_forecast_project``
      - ``agi-app-weather-forecast``
      - PyPI app package

--- a/src/agilab/apps/builtin/flight_telemetry_project/README.md
+++ b/src/agilab/apps/builtin/flight_telemetry_project/README.md
@@ -14,6 +14,9 @@ The project focuses on a simple but useful workflow:
 - validating the `PROJECT -> ORCHESTRATE -> WORKFLOW -> ANALYSIS` flow in one
   packaged public app
 - showing how a raw data source becomes a reusable dataset for visual exploration
+- demonstrating worker-only Cython acceleration on a real app: dataframe I/O,
+  analysis pages, and reducer artifacts stay in Python while the per-row
+  haversine distance kernel can run as a typed compiled worker hot loop
 
 ## What is not implemented in the public version
 
@@ -37,6 +40,8 @@ Workers also emit a `reduce_summary_worker_<id>.json` `ReduceArtifact` beside
 the dataframe outputs. That summary records the reducer name, row count,
 aircraft/source-file counts, written output files, and trajectory distance/time-span
 fields so Release Decision can surface the flight run as first-class evidence.
+It also records the speed-kernel runtime, the `float64-contiguous` dtype
+contract, and a distance checksum so Cython runs remain auditable.
 
 ## Typical flow
 

--- a/src/agilab/apps/builtin/flight_telemetry_project/src/flight_telemetry/reduction.py
+++ b/src/agilab/apps/builtin/flight_telemetry_project/src/flight_telemetry/reduction.py
@@ -45,6 +45,9 @@ _REQUIRED_PAYLOAD_KEYS = (
     "output_formats",
     "time_start",
     "time_end",
+    "speed_kernel_runtimes",
+    "speed_dtype_contracts",
+    "speed_kernel_checksum_m",
 )
 
 
@@ -69,10 +72,13 @@ def _merge_flight_partials(partials: Sequence[ReducePartial]) -> dict[str, Any]:
     aircraft: set[str] = set()
     output_files: set[str] = set()
     output_formats: set[str] = set()
+    speed_kernel_runtimes: set[str] = set()
+    speed_dtype_contracts: set[str] = set()
     row_count = 0
     speed_count = 0
     speed_sum_m = 0.0
     max_speed_m = 0.0
+    speed_kernel_checksum_m = 0.0
     time_start = ""
     time_end = ""
 
@@ -86,6 +92,9 @@ def _merge_flight_partials(partials: Sequence[ReducePartial]) -> dict[str, Any]:
         aircraft.update(str(item) for item in payload["aircraft"])
         output_files.update(str(item) for item in payload["output_files"])
         output_formats.update(str(item) for item in payload["output_formats"])
+        speed_kernel_runtimes.update(str(item) for item in payload["speed_kernel_runtimes"])
+        speed_dtype_contracts.update(str(item) for item in payload["speed_dtype_contracts"])
+        speed_kernel_checksum_m += float(payload["speed_kernel_checksum_m"])
         candidate_start = str(payload["time_start"])
         candidate_end = str(payload["time_end"])
         if candidate_start and (not time_start or candidate_start < time_start):
@@ -107,6 +116,9 @@ def _merge_flight_partials(partials: Sequence[ReducePartial]) -> dict[str, Any]:
         "speed_sum_m": round(speed_sum_m, 3),
         "mean_speed_m": round(speed_sum_m / speed_count, 3) if speed_count else 0.0,
         "max_speed_m": round(max_speed_m, 3),
+        "speed_kernel_runtimes": _sorted_strings(speed_kernel_runtimes),
+        "speed_dtype_contracts": _sorted_strings(speed_dtype_contracts),
+        "speed_kernel_checksum_m": round(speed_kernel_checksum_m, 6),
         "time_start": time_start,
         "time_end": time_end,
     }
@@ -160,6 +172,21 @@ def partial_from_flight_frame(
     speed_values = df["speed"].drop_nulls()
     speed_count = len(speed_values)
     output_file_names = sorted({Path(str(path)).name for path in output_files if str(path)})
+    speed_kernel_runtimes = (
+        _sorted_unique_strings(df["speed_kernel_runtime"])
+        if "speed_kernel_runtime" in df.columns
+        else []
+    )
+    speed_dtype_contracts = (
+        _sorted_unique_strings(df["speed_dtype_contract"])
+        if "speed_dtype_contract" in df.columns
+        else []
+    )
+    speed_kernel_checksums = (
+        df["speed_kernel_checksum_m"].drop_nulls()
+        if "speed_kernel_checksum_m" in df.columns
+        else pl.Series("speed_kernel_checksum_m", [])
+    )
     payload = {
         "flight_run_count": 1,
         "row_count": int(df.height),
@@ -173,6 +200,11 @@ def partial_from_flight_frame(
         "speed_count": speed_count,
         "speed_sum_m": float(speed_values.sum()) if speed_count else 0.0,
         "max_speed_m": float(speed_values.max()) if speed_count else 0.0,
+        "speed_kernel_runtimes": speed_kernel_runtimes,
+        "speed_dtype_contracts": speed_dtype_contracts,
+        "speed_kernel_checksum_m": (
+            float(speed_kernel_checksums.max()) if len(speed_kernel_checksums) else 0.0
+        ),
         "time_start": _timestamp(df["date"].min()),
         "time_end": _timestamp(df["date"].max()),
     }

--- a/src/agilab/apps/builtin/flight_telemetry_project/src/flight_telemetry_worker/flight_telemetry_worker.py
+++ b/src/agilab/apps/builtin/flight_telemetry_project/src/flight_telemetry_worker/flight_telemetry_worker.py
@@ -13,6 +13,8 @@ import traceback
 from datetime import datetime as dt
 from pathlib import Path
 
+import cython
+import numpy as np
 from agi_env import normalize_path
 from agi_node import MutableNamespace
 from agi_node.polars_worker import PolarsWorker
@@ -25,6 +27,14 @@ logger = AgiLogger.get_logger(__name__)
 import polars as pl
 
 _EARTH_RADIUS_M = 6_371_000.0
+SPEED_DTYPE_CONTRACT = "float64-contiguous"
+SPEED_KERNEL_COLUMN = "speed_kernel_runtime"
+SPEED_DTYPE_COLUMN = "speed_dtype_contract"
+SPEED_KERNEL_CHECKSUM_COLUMN = "speed_kernel_checksum_m"
+
+
+def _kernel_runtime_label() -> str:
+    return "cython" if cython.compiled else "python"
 
 
 def _haversine_distance_m(row) -> float:
@@ -45,6 +55,85 @@ def _haversine_distance_m(row) -> float:
         + math.cos(lat1) * math.cos(lat2) * math.sin(dlon / 2.0) ** 2
     )
     return 2.0 * _EARTH_RADIUS_M * math.asin(math.sqrt(min(1.0, a)))
+
+
+def _as_contiguous_float64(series: pl.Series) -> np.ndarray:
+    return np.ascontiguousarray(
+        series.cast(pl.Float64, strict=False).fill_null(float("nan")).to_numpy(),
+        dtype=np.float64,
+    )
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def _haversine_distance_kernel(
+    prev_lat_values: cython.double[::1],
+    prev_long_values: cython.double[::1],
+    lat_values: cython.double[::1],
+    long_values: cython.double[::1],
+    distance_out: cython.double[::1],
+) -> cython.double:
+    """Fill distance output through a Cython-friendly typed numeric loop."""
+    n_rows: cython.Py_ssize_t = lat_values.shape[0]
+    row_idx: cython.Py_ssize_t
+    lat1: cython.double = 0.0
+    lon1: cython.double = 0.0
+    lat2: cython.double = 0.0
+    lon2: cython.double = 0.0
+    dlat: cython.double = 0.0
+    dlon: cython.double = 0.0
+    a_value: cython.double = 0.0
+    distance: cython.double = 0.0
+    checksum: cython.double = 0.0
+
+    for row_idx in range(n_rows):
+        lat1 = prev_lat_values[row_idx]
+        lon1 = prev_long_values[row_idx]
+        lat2 = lat_values[row_idx]
+        lon2 = long_values[row_idx]
+
+        if lat1 != lat1 or lon1 != lon1 or lat2 != lat2 or lon2 != lon2:
+            distance = 0.0
+        else:
+            lat1 = math.radians(lat1)
+            lon1 = math.radians(lon1)
+            lat2 = math.radians(lat2)
+            lon2 = math.radians(lon2)
+            dlat = lat2 - lat1
+            dlon = lon2 - lon1
+            a_value = (
+                math.sin(dlat / 2.0) ** 2
+                + math.cos(lat1) * math.cos(lat2) * math.sin(dlon / 2.0) ** 2
+            )
+            if a_value > 1.0:
+                a_value = 1.0
+            distance = 2.0 * _EARTH_RADIUS_M * math.asin(math.sqrt(a_value))
+
+        distance_out[row_idx] = distance
+        checksum += distance
+
+    return checksum
+
+
+def _haversine_distance_series(df: pl.DataFrame) -> tuple[pl.Series, str, str, float]:
+    prev_lat_values = _as_contiguous_float64(df["prev_lat"])
+    prev_long_values = _as_contiguous_float64(df["prev_long"])
+    lat_values = _as_contiguous_float64(df["lat"])
+    long_values = _as_contiguous_float64(df["long"])
+    distance_values = np.empty(len(df), dtype=np.float64)
+    checksum = _haversine_distance_kernel(
+        prev_lat_values,
+        prev_long_values,
+        lat_values,
+        long_values,
+        distance_values,
+    )
+    return (
+        pl.Series(distance_values),
+        _kernel_runtime_label(),
+        SPEED_DTYPE_CONTRACT,
+        float(checksum),
+    )
 
 
 class FlightTelemetryWorker(PolarsWorker):
@@ -76,14 +165,13 @@ class FlightTelemetryWorker(PolarsWorker):
         and add it under the legacy ``speed`` column name used by this demo.
         Assumes that the previous coordinate columns are already present.
         """
+        speed_values, kernel_runtime, dtype_contract, checksum = _haversine_distance_series(df)
         df = df.with_columns(
             [
-                pl.struct(["prev_lat", "prev_long", "lat", "long"])
-                .map_elements(
-                    _haversine_distance_m,
-                    return_dtype=pl.Float64,
-                )
-                .alias(new_column_name),
+                speed_values.alias(new_column_name),
+                pl.lit(kernel_runtime).alias(SPEED_KERNEL_COLUMN),
+                pl.lit(dtype_contract).alias(SPEED_DTYPE_COLUMN),
+                pl.lit(round(checksum, 6)).alias(SPEED_KERNEL_CHECKSUM_COLUMN),
             ]
         )
         return df

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/capacity_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/capacity_support.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 import pickle
+import time
 from copy import deepcopy
 from datetime import timedelta
 from pathlib import Path
@@ -19,6 +20,8 @@ from agi_node.agi_dispatcher.base_worker import BaseWorker
 
 
 logger = logging.getLogger(__name__)
+CALIBRATION_CACHE_TTL_SECONDS_ENV = "AGILAB_CALIBRATION_CACHE_TTL_SECONDS"
+DEFAULT_CALIBRATION_CACHE_TTL_SECONDS = 300.0
 
 
 def _is_cython_installed(env: AgiEnv) -> bool:
@@ -58,6 +61,68 @@ def _node_count(workers: Mapping[str, int] | None) -> int:
         return 1
     hosts = {_worker_host(worker) for worker in workers if _worker_host(worker)}
     return max(len(hosts), 1)
+
+
+def _calibration_cache_ttl(env: Any) -> float:
+    raw = os.environ.get(CALIBRATION_CACHE_TTL_SECONDS_ENV)
+    if raw is None:
+        envars = getattr(env, "envars", None)
+        if isinstance(envars, Mapping):
+            raw = envars.get(CALIBRATION_CACHE_TTL_SECONDS_ENV)
+    if raw is None:
+        return DEFAULT_CALIBRATION_CACHE_TTL_SECONDS
+    try:
+        return max(float(raw), 0.0)
+    except (TypeError, ValueError):
+        return DEFAULT_CALIBRATION_CACHE_TTL_SECONDS
+
+
+def _calibration_signature(agi_cls: Any) -> dict[str, Any]:
+    env = getattr(agi_cls, "env", None)
+    return {
+        "workers": sorted((getattr(agi_cls, "_workers", {}) or {}).items()),
+        "dask_workers": sorted(str(worker) for worker in (getattr(agi_cls, "_dask_workers", []) or [])),
+        "share": str(getattr(env, "share", "") or ""),
+        "local_share": str(getattr(env, "localshare", "") or getattr(env, "local_share", "") or ""),
+        "cluster_share": str(getattr(env, "clustershare", "") or getattr(env, "cluster_share", "") or ""),
+        "capacity_predictor_id": id(getattr(agi_cls, "_capacity_predictor", None)),
+    }
+
+
+def _restore_calibration_cache(agi_cls: Any, *, now: float) -> bool:
+    ttl_seconds = _calibration_cache_ttl(getattr(agi_cls, "env", None))
+    if ttl_seconds <= 0:
+        return False
+    cache = getattr(agi_cls, "_calibration_cache", None)
+    if not isinstance(cache, dict):
+        return False
+    if cache.get("signature") != _calibration_signature(agi_cls):
+        return False
+    try:
+        measured_at = float(cache.get("measured_at"))
+    except (TypeError, ValueError):
+        return False
+    if now - measured_at > ttl_seconds:
+        return False
+    workers_info = cache.get("workers_info")
+    capacity = cache.get("capacity")
+    if not isinstance(workers_info, dict) or not isinstance(capacity, dict):
+        return False
+    agi_cls.workers_info = deepcopy(workers_info)
+    agi_cls._capacity = deepcopy(capacity)
+    return True
+
+
+def _store_calibration_cache(agi_cls: Any, *, now: float) -> None:
+    ttl_seconds = _calibration_cache_ttl(getattr(agi_cls, "env", None))
+    if ttl_seconds <= 0:
+        return
+    agi_cls._calibration_cache = {
+        "signature": _calibration_signature(agi_cls),
+        "measured_at": now,
+        "workers_info": deepcopy(getattr(agi_cls, "workers_info", {})),
+        "capacity": deepcopy(getattr(agi_cls, "_capacity", {})),
+    }
 
 
 def _best_single_node_host(agi_cls: Any, workers: Mapping[str, int]) -> str:
@@ -395,6 +460,11 @@ async def benchmark_dask_modes(
 
 
 async def calibration(agi_cls: Any, log: Any = logger) -> None:
+    now = time.time()
+    if _restore_calibration_cache(agi_cls, now=now):
+        log.info("Reusing cached worker capacity calibration.")
+        return
+
     res_workers_info = agi_cls._dask_client.gather(
         [
             agi_cls._dask_client.run(
@@ -454,6 +524,7 @@ async def calibration(agi_cls: Any, log: Any = logger) -> None:
     agi_cls._capacity = dict(
         sorted(workers_capacity.items(), key=lambda item: item[1], reverse=True)
     )
+    _store_calibration_cache(agi_cls, now=now)
 
 
 def train_capacity(agi_cls: Any, train_home: Path, log: Any = logger) -> None:

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_build_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_build_support.py
@@ -1,3 +1,5 @@
+import hashlib
+import json
 import logging
 import os
 import shutil
@@ -9,6 +11,9 @@ from agi_env.share_runtime_support import python_supports_free_threading
 
 
 logger = logging.getLogger(__name__)
+BUILD_CACHE_SCHEMA = "agilab-worker-build-cache-v1"
+DISABLE_BUILD_CACHE_ENV = "AGILAB_DISABLE_WORKER_BUILD_CACHE"
+BUILD_CACHE_HASH_LIMIT = 8 * 1024 * 1024
 
 
 def _sorted_glob_matches(root: Path, pattern: str) -> list[Path]:
@@ -77,6 +82,178 @@ def _project_uv(env: Any) -> str:
         return str(env.uv)
     cmd_prefix = str(env.envars.get("127.0.0.1_CMD_PREFIX", "")).strip()
     return " ".join(part for part in (cmd_prefix, "PYTHON_GIL=0", env.uv) if part)
+
+
+def _env_truthy(envars: Any, key: str) -> bool:
+    try:
+        raw = envars.get(key)
+    except (AttributeError, RuntimeError, TypeError):
+        raw = None
+    if raw is None:
+        raw = os.environ.get(key)
+    if raw is None:
+        return False
+    if isinstance(raw, bool):
+        return raw
+    if isinstance(raw, (int, float)):
+        try:
+            return int(raw) == 1
+        except (TypeError, ValueError):
+            return False
+    return str(raw).strip().lower() in {"1", "true", "yes", "on", "enabled"}
+
+
+def _build_cache_enabled(env: Any) -> bool:
+    return not _env_truthy(getattr(env, "envars", {}), DISABLE_BUILD_CACHE_ENV)
+
+
+def _file_fingerprint(path: Path) -> dict[str, Any] | None:
+    try:
+        stat_result = path.stat()
+    except FileNotFoundError:
+        return None
+    if not path.is_file():
+        return None
+    payload: dict[str, Any] = {
+        "path": str(path.resolve(strict=False)),
+        "size": stat_result.st_size,
+        "mtime_ns": stat_result.st_mtime_ns,
+    }
+    if stat_result.st_size <= BUILD_CACHE_HASH_LIMIT:
+        digest = hashlib.sha256()
+        try:
+            with path.open("rb") as stream:
+                for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+                    digest.update(chunk)
+            payload["sha256"] = digest.hexdigest()
+        except OSError:
+            pass
+    return payload
+
+
+def _optional_file_fingerprint(value: Any) -> dict[str, Any] | None:
+    if not value:
+        return None
+    try:
+        return _file_fingerprint(Path(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _directory_fingerprint(root: Path) -> list[dict[str, Any]]:
+    if not root.exists():
+        return []
+    ignored_parts = {".venv", "__pycache__", ".pytest_cache", "build", "dist"}
+    fingerprints: list[dict[str, Any]] = []
+    for candidate in sorted(root.rglob("*"), key=lambda path: path.as_posix()):
+        if not candidate.is_file():
+            continue
+        if any(part in ignored_parts for part in candidate.relative_to(root).parts):
+            continue
+        file_fp = _file_fingerprint(candidate)
+        if file_fp is None:
+            continue
+        file_fp["rel"] = candidate.relative_to(root).as_posix()
+        fingerprints.append(file_fp)
+    return fingerprints
+
+
+def _build_cache_path(wenv_abs: Path) -> Path:
+    return wenv_abs / "dist" / ".agilab-worker-build-cache.json"
+
+
+def _load_build_cache(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _write_build_cache(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _worker_build_cache_payload(
+    *,
+    env: Any,
+    packages: str,
+    worker_group: str | None,
+    is_cy: bool,
+    module_cmd: str,
+    core_install_commands: list[str],
+) -> dict[str, Any]:
+    app_path = Path(env.active_app)
+    worker_pyproject_src = _worker_pyproject_source(env)
+    return {
+        "schema": BUILD_CACHE_SCHEMA,
+        "base_worker_cls": str(getattr(env, "base_worker_cls", "")),
+        "worker_group": worker_group,
+        "packages": packages,
+        "is_cython": bool(is_cy),
+        "pyvers_worker": str(getattr(env, "pyvers_worker", "")),
+        "module_cmd": module_cmd,
+        "core_install_commands": core_install_commands,
+        "active_app": str(app_path.resolve(strict=False)),
+        "app_src": _directory_fingerprint(app_path / "src"),
+        "worker_pyproject": _file_fingerprint(worker_pyproject_src),
+        "manager_pyproject": _optional_file_fingerprint(getattr(env, "manager_pyproject", None)),
+        "uvproject": _optional_file_fingerprint(getattr(env, "uvproject", None)),
+    }
+
+
+def _worker_build_outputs_exist(wenv_abs: Path, *, is_cy: bool) -> bool:
+    if not _sorted_glob_matches(wenv_abs / "dist", "*.egg"):
+        return False
+    if is_cy and _latest_glob_match(wenv_abs / "dist", "*_cy.*") is None:
+        return False
+    return True
+
+
+def _worker_build_cache_hit(
+    *,
+    env: Any,
+    packages: str,
+    worker_group: str | None,
+    is_cy: bool,
+    module_cmd: str,
+    core_install_commands: list[str],
+) -> bool:
+    if not _build_cache_enabled(env):
+        return False
+    payload = _worker_build_cache_payload(
+        env=env,
+        packages=packages,
+        worker_group=worker_group,
+        is_cy=is_cy,
+        module_cmd=module_cmd,
+        core_install_commands=core_install_commands,
+    )
+    cached = _load_build_cache(_build_cache_path(env.wenv_abs))
+    return cached == payload and _worker_build_outputs_exist(env.wenv_abs, is_cy=is_cy)
+
+
+def _record_worker_build_cache(
+    *,
+    env: Any,
+    packages: str,
+    worker_group: str | None,
+    is_cy: bool,
+    module_cmd: str,
+    core_install_commands: list[str],
+) -> None:
+    if not _build_cache_enabled(env) or not _worker_build_outputs_exist(env.wenv_abs, is_cy=is_cy):
+        return
+    payload = _worker_build_cache_payload(
+        env=env,
+        packages=packages,
+        worker_group=worker_group,
+        is_cy=is_cy,
+        module_cmd=module_cmd,
+        core_install_commands=core_install_commands,
+    )
+    _write_build_cache(_build_cache_path(env.wenv_abs), payload)
 
 
 def _worker_pyproject_source(env: Any) -> Path:
@@ -217,6 +394,7 @@ async def build_lib_local(
     module_cmd = _build_module_command(env)
     app_path_arg = f"\"{app_path}\""
     wenv_arg = f"\"{wenv_abs}\""
+    core_install_commands = _core_install_commands(env=env, uv=uv, app_path_arg=app_path_arg)
 
     _stage_worker_build_project(
         agi_cls,
@@ -226,7 +404,31 @@ async def build_lib_local(
         validate_worker_uv_sources_fn=validate_worker_uv_sources_fn,
     )
 
-    for cmd in _core_install_commands(env=env, uv=uv, app_path_arg=app_path_arg):
+    cache_hit = _worker_build_cache_hit(
+        env=env,
+        packages=packages,
+        worker_group=worker_group,
+        is_cy=bool(is_cy),
+        module_cmd=module_cmd,
+        core_install_commands=core_install_commands,
+    )
+    if cache_hit:
+        log.info(
+            "Worker build cache hit for %s; reusing existing build artifacts.",
+            getattr(env, "target_worker", "worker"),
+        )
+        _upload_built_eggs(agi_cls._dask_client, wenv_abs / "dist")
+        if is_cy:
+            _copy_cython_worker_lib(
+                wenv_abs=wenv_abs,
+                pyvers_worker=env.pyvers_worker,
+                build_output="",
+                failure_message="cached build_ext output is missing",
+                log=log,
+            )
+        return
+
+    for cmd in core_install_commands:
         await run_fn(cmd, app_path)
 
     cmd = _bdist_egg_command(
@@ -257,6 +459,15 @@ async def build_lib_local(
             failure_message=cmd,
             log=log,
         )
+
+    _record_worker_build_cache(
+        env=env,
+        packages=packages,
+        worker_group=worker_group,
+        is_cy=bool(is_cy),
+        module_cmd=module_cmd,
+        core_install_commands=core_install_commands,
+    )
 
 
 async def build_lib_remote(agi_cls: Any, *, log: Any = logger) -> None:

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime_distribution_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime_distribution_support.py
@@ -21,10 +21,70 @@ _SYNC_RETRY_EXCEPTIONS = (ConnectionError, OSError, RuntimeError, TimeoutError)
 _STOP_RETRY_EXCEPTIONS = (ConnectionError, OSError, RuntimeError, TimeoutError)
 _TOP_LEVEL_UI_MODULE_SUFFIX = "_args_form.py"
 _TOP_LEVEL_UI_BYTECODE_SUFFIX = "_args_form."
+_SYNC_POLL_DELAYS_SECONDS = (0.2, 0.5, 1.0, 3.0)
 
 
 def _sorted_glob_matches(root: Path, pattern: str) -> list[Path]:
     return sorted(root.glob(pattern), key=lambda candidate: candidate.name)
+
+
+def _sync_poll_delay(attempt: int) -> float:
+    if attempt < 0:
+        attempt = 0
+    if attempt >= len(_SYNC_POLL_DELAYS_SECONDS):
+        return _SYNC_POLL_DELAYS_SECONDS[-1]
+    return _SYNC_POLL_DELAYS_SECONDS[attempt]
+
+
+def _local_dask_worker_command(uv_cmd: str, wenv_abs: Path, scheduler: str, pid_file: str) -> list[str]:
+    if os.name == "nt":
+        dask_exe = wenv_abs / ".venv" / "Scripts" / "dask.exe"
+    else:
+        dask_exe = wenv_abs / ".venv" / "bin" / "dask"
+    if dask_exe.exists():
+        return [
+            str(dask_exe),
+            "worker",
+            f"tcp://{scheduler}",
+            "--no-nanny",
+            "--pid-file",
+            str(wenv_abs / pid_file),
+        ]
+    return [
+        *shlex.split(str(uv_cmd), posix=os.name != "nt"),
+        "--project",
+        str(wenv_abs),
+        "run",
+        "--no-sync",
+        "dask",
+        "worker",
+        f"tcp://{scheduler}",
+        "--no-nanny",
+        "--pid-file",
+        str(wenv_abs / pid_file),
+    ]
+
+
+def _record_phase_timing(agi_cls: Any, phase: str, seconds: float) -> None:
+    timings = getattr(agi_cls, "_phase_timings", None)
+    if not isinstance(timings, list):
+        timings = []
+        setattr(agi_cls, "_phase_timings", timings)
+    timings.append({"phase": phase, "seconds": round(float(seconds), 6)})
+
+
+async def _run_timed_phase(
+    agi_cls: Any,
+    phase: str,
+    awaitable_factory: Callable[[], Any],
+    *,
+    time_fn: Callable[[], float] = time.time,
+) -> Any:
+    started_at = time_fn()
+    try:
+        return await awaitable_factory()
+    finally:
+        _record_phase_timing(agi_cls, phase, time_fn() - started_at)
 
 
 def _is_top_level_ui_artifact(name: str) -> bool:
@@ -294,19 +354,12 @@ async def start(
                 pid_file = f"dask_worker_{i}_{j}.pid"
                 if is_local:
                     wenv_abs = env.wenv_abs
-                    local_cmd = [
-                        *shlex.split(str(env.uv), posix=os.name != "nt"),
-                        "--project",
-                        str(wenv_abs),
-                        "run",
-                        "--no-sync",
-                        "dask",
-                        "worker",
-                        f"tcp://{agi_cls._scheduler}",
-                        "--no-nanny",
-                        "--pid-file",
-                        str(wenv_abs / pid_file),
-                    ]
+                    local_cmd = _local_dask_worker_command(
+                        str(env.uv),
+                        wenv_abs,
+                        agi_cls._scheduler,
+                        pid_file,
+                    )
                     process_env = background_jobs_support.background_env_from_prefixes(cmd_prefix, dask_env)
                     agi_cls._exec_bg(local_cmd, str(wenv_abs), env=process_env)
                 else:
@@ -350,6 +403,7 @@ async def sync(
         return
     start_time = time_fn()
     expected_workers = sum(agi_cls._workers.values())
+    poll_attempt = 0
 
     while True:
         try:
@@ -357,7 +411,8 @@ async def sync(
             workers_info = info.get("workers")
             if workers_info is None:
                 log.info("Scheduler info 'workers' not ready yet.")
-                await sleep_fn(3)
+                await sleep_fn(_sync_poll_delay(poll_attempt))
+                poll_attempt += 1
                 if time_fn() - start_time > timeout:
                     log.error("Timeout waiting for scheduler workers info.")
                     raise TimeoutError("Timed out waiting for scheduler workers info")
@@ -377,11 +432,13 @@ async def sync(
             if time_fn() - start_time > timeout:
                 log.error("Timeout waiting for all workers. {remaining} workers missing.")
                 raise TimeoutError("Timed out waiting for all workers to attach")
-            await sleep_fn(3)
+            await sleep_fn(_sync_poll_delay(poll_attempt))
+            poll_attempt += 1
 
         except _SYNC_RETRY_EXCEPTIONS as exc:
             log.info(f"Exception in _sync: {exc}")
-            await sleep_fn(1)
+            await sleep_fn(_sync_poll_delay(poll_attempt))
+            poll_attempt += 1
             if time_fn() - start_time > timeout:
                 raise TimeoutError(f"Timeout waiting for all workers due to exception: {exc}")
 
@@ -530,22 +587,53 @@ async def main(
 ) -> Any:
     cond_clean = True
     agi_cls._jobs = background_job_manager_factory()
+    agi_cls._phase_timings = []
 
     if (agi_cls._mode & agi_cls._DEPLOYEMENT_MASK) == agi_cls._SIMULATE_MODE:
         res = await agi_cls._run()
     elif agi_cls._mode >= agi_cls._INSTALL_MODE:
         started_at = time_fn()
         agi_cls._clean_dirs_local()
-        await agi_cls._prepare_local_env()
+        await _run_timed_phase(
+            agi_cls,
+            "prepare-local-env",
+            lambda: agi_cls._prepare_local_env(),
+            time_fn=time_fn,
+        )
         if agi_cls._mode & agi_cls.DASK_MODE:
-            await agi_cls._prepare_cluster_env(scheduler)
-        await agi_cls._deploy_application(scheduler)
+            await _run_timed_phase(
+                agi_cls,
+                "prepare-cluster-env",
+                lambda: agi_cls._prepare_cluster_env(scheduler),
+                time_fn=time_fn,
+            )
+        await _run_timed_phase(
+            agi_cls,
+            "deploy-application",
+            lambda: agi_cls._deploy_application(scheduler),
+            time_fn=time_fn,
+        )
         res = time_fn() - started_at
     elif agi_cls._mode & agi_cls.DASK_MODE:
-        await agi_cls._start(scheduler)
-        res = await agi_cls._distribute()
+        await _run_timed_phase(
+            agi_cls,
+            "start-dask",
+            lambda: agi_cls._start(scheduler),
+            time_fn=time_fn,
+        )
+        res = await _run_timed_phase(
+            agi_cls,
+            "distribute",
+            lambda: agi_cls._distribute(),
+            time_fn=time_fn,
+        )
         agi_cls._update_capacity()
-        await agi_cls._stop()
+        await _run_timed_phase(
+            agi_cls,
+            "stop-dask",
+            lambda: agi_cls._stop(),
+            time_fn=time_fn,
+        )
     else:
         res = await agi_cls._run()
 

--- a/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/base_worker_execution_support.py
+++ b/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/base_worker_execution_support.py
@@ -387,6 +387,7 @@ def _measure_worker_write_speed(
     os_module: Any,
     open_fn: Callable[..., Any] = open,
     size: int = 10 * 1024 * 1024,
+    settle_seconds: float = 0.0,
 ) -> list[float]:
     file_path = os_module.path.join(path, str(worker).replace(":", "_"))
     start = time_module.time()
@@ -394,7 +395,8 @@ def _measure_worker_write_speed(
         stream.write("\x00" * size)
 
     elapsed = time_module.time() - start
-    time_module.sleep(1)
+    if settle_seconds > 0:
+        time_module.sleep(settle_seconds)
     os_module.remove(file_path)
     return [size / elapsed]
 

--- a/src/agilab/core/test/test_agi_distributor_capacity_support.py
+++ b/src/agilab/core/test/test_agi_distributor_capacity_support.py
@@ -30,6 +30,7 @@ def _reset_agi_capacity_state():
         "workers_info",
         "_run_time",
         "_capacity",
+        "_calibration_cache",
         "env",
         "target_path",
         "_target",
@@ -51,6 +52,7 @@ def _reset_agi_capacity_state():
         AGI.workers_info = {}
         AGI._run_time = []
         AGI._capacity = {}
+        AGI._calibration_cache = {}
         AGI.env = None
         AGI.target_path = None
         AGI._target = None
@@ -607,6 +609,70 @@ async def test_calibration_computes_normalized_capacity():
 
     assert AGI.workers_info["127.0.0.1:8787"]["label"] == 4.0
     assert AGI._capacity["127.0.0.1:8787"] == 1.0
+
+
+@pytest.mark.asyncio
+async def test_calibration_reuses_fresh_topology_cache(monkeypatch):
+    class _Client:
+        def __init__(self):
+            self.run_calls = 0
+
+        def run(self, *_args, **_kwargs):
+            self.run_calls += 1
+            return {
+                "tcp://127.0.0.1:8787": {
+                    "ram_total": [10.0],
+                    "ram_available": [5.0],
+                    "cpu_count": [4.0],
+                    "cpu_frequency": [2.5],
+                    "network_speed": [1.0],
+                }
+            }
+
+        def gather(self, payload):
+            return payload
+
+    monkeypatch.setattr(capacity_support.time, "time", lambda: 100.0)
+    AGI.env = SimpleNamespace(envars={"AGILAB_CALIBRATION_CACHE_TTL_SECONDS": "300"})
+    AGI._dask_client = _Client()
+    AGI._dask_workers = ["127.0.0.1:8787"]
+    AGI._workers = {"127.0.0.1": 1}
+    AGI._capacity_predictor = SimpleNamespace(predict=lambda _data: [4.0])
+
+    await capacity_support.calibration(AGI)
+    AGI._capacity = {}
+    AGI.workers_info = {}
+    await capacity_support.calibration(AGI)
+
+    assert AGI._dask_client.run_calls == 1
+    assert AGI._capacity == {"127.0.0.1:8787": 1.0}
+    assert AGI.workers_info["127.0.0.1:8787"]["label"] == 4.0
+
+
+@pytest.mark.asyncio
+async def test_calibration_cache_can_be_disabled(monkeypatch):
+    class _Client:
+        def __init__(self):
+            self.run_calls = 0
+
+        def run(self, *_args, **_kwargs):
+            self.run_calls += 1
+            return {}
+
+        def gather(self, payload):
+            return payload
+
+    monkeypatch.setattr(capacity_support.time, "time", lambda: 100.0)
+    AGI.env = SimpleNamespace(envars={"AGILAB_CALIBRATION_CACHE_TTL_SECONDS": "0"})
+    AGI._dask_client = _Client()
+    AGI._dask_workers = []
+    AGI._workers = {"127.0.0.1": 1}
+    AGI._capacity_predictor = SimpleNamespace(predict=lambda _data: [1.0])
+
+    await capacity_support.calibration(AGI)
+    await capacity_support.calibration(AGI)
+
+    assert AGI._dask_client.run_calls == 2
 
 
 @pytest.mark.asyncio

--- a/src/agilab/core/test/test_agi_distributor_deployment_build_support.py
+++ b/src/agilab/core/test/test_agi_distributor_deployment_build_support.py
@@ -176,7 +176,9 @@ def test_copy_cython_worker_lib_prefers_latest_output(tmp_path):
 
 def _build_env(tmp_path: Path, *, base_worker_cls: str = "PandasWorker", free_threading: bool = False):
     app_path = tmp_path / "app"
-    app_path.mkdir(parents=True, exist_ok=True)
+    app_src = app_path / "src" / "demo_worker"
+    app_src.mkdir(parents=True, exist_ok=True)
+    (app_src / "demo_worker.py").write_text("VALUE = 1\n", encoding="utf-8")
     wenv_abs = tmp_path / "wenv"
     (wenv_abs / "dist").mkdir(parents=True, exist_ok=True)
     worker_pyproject = tmp_path / "worker_pyproject.toml"
@@ -205,6 +207,7 @@ def _build_env(tmp_path: Path, *, base_worker_cls: str = "PandasWorker", free_th
         is_source_env=False,
         verbose=0,
         pyvers_worker="3.13",
+        target_worker="demo_worker",
     )
 
 
@@ -241,6 +244,86 @@ async def test_build_lib_local_non_cython_uploads_egg(tmp_path):
     assert any("pip install agi-env agi-node" in cmd for cmd, _ in commands)
     assert any("bdist_egg" in cmd for cmd, _ in commands)
     assert str(egg_path) in uploads
+
+
+@pytest.mark.asyncio
+async def test_build_lib_local_reuses_cached_worker_artifacts(tmp_path):
+    env = _build_env(tmp_path)
+    egg_path = env.wenv_abs / "dist" / "demo.egg"
+    egg_path.write_text("egg", encoding="utf-8")
+    uploads: list[str] = []
+    commands: list[tuple[str, str]] = []
+
+    class _Client:
+        def upload_file(self, path):
+            uploads.append(path)
+
+    async def _fake_run(cmd, cwd):
+        commands.append((cmd, str(cwd)))
+        return ""
+
+    AGI.env = env
+    AGI._mode = AGI.PYTHON_MODE
+    AGI._dask_client = _Client()
+    AGI.agi_workers = {"pandas": "pandas-worker"}
+
+    await deployment_build_support.build_lib_local(
+        AGI,
+        ensure_optional_extras_fn=uv_source_support.ensure_optional_extras,
+        stage_uv_sources_fn=uv_source_support.stage_uv_sources_for_copied_pyproject,
+        validate_worker_uv_sources_fn=uv_source_support.validate_worker_uv_sources,
+        run_fn=_fake_run,
+    )
+    first_command_count = len(commands)
+
+    await deployment_build_support.build_lib_local(
+        AGI,
+        ensure_optional_extras_fn=uv_source_support.ensure_optional_extras,
+        stage_uv_sources_fn=uv_source_support.stage_uv_sources_for_copied_pyproject,
+        validate_worker_uv_sources_fn=uv_source_support.validate_worker_uv_sources,
+        run_fn=_fake_run,
+    )
+
+    assert first_command_count > 0
+    assert len(commands) == first_command_count
+    assert uploads == [str(egg_path), str(egg_path)]
+
+
+@pytest.mark.asyncio
+async def test_build_lib_local_cache_invalidates_when_source_changes(tmp_path):
+    env = _build_env(tmp_path)
+    egg_path = env.wenv_abs / "dist" / "demo.egg"
+    egg_path.write_text("egg", encoding="utf-8")
+    commands: list[tuple[str, str]] = []
+
+    async def _fake_run(cmd, cwd):
+        commands.append((cmd, str(cwd)))
+        return ""
+
+    AGI.env = env
+    AGI._mode = AGI.PYTHON_MODE
+    AGI._dask_client = None
+    AGI.agi_workers = {"pandas": "pandas-worker"}
+
+    await deployment_build_support.build_lib_local(
+        AGI,
+        ensure_optional_extras_fn=uv_source_support.ensure_optional_extras,
+        stage_uv_sources_fn=uv_source_support.stage_uv_sources_for_copied_pyproject,
+        validate_worker_uv_sources_fn=uv_source_support.validate_worker_uv_sources,
+        run_fn=_fake_run,
+    )
+    first_command_count = len(commands)
+    (env.active_app / "src" / "demo_worker" / "demo_worker.py").write_text("VALUE = 2\n", encoding="utf-8")
+
+    await deployment_build_support.build_lib_local(
+        AGI,
+        ensure_optional_extras_fn=uv_source_support.ensure_optional_extras,
+        stage_uv_sources_fn=uv_source_support.stage_uv_sources_for_copied_pyproject,
+        validate_worker_uv_sources_fn=uv_source_support.validate_worker_uv_sources,
+        run_fn=_fake_run,
+    )
+
+    assert len(commands) > first_command_count
 
 
 @pytest.mark.asyncio

--- a/src/agilab/core/test/test_agi_distributor_runtime_distribution_support.py
+++ b/src/agilab/core/test/test_agi_distributor_runtime_distribution_support.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from types import SimpleNamespace
 from zipfile import ZipFile
@@ -30,6 +31,7 @@ def _reset_agi_runtime_distribution_state():
         "_work_plan",
         "_work_plan_metadata",
         "_capacity",
+        "_phase_timings",
         "_dask_log_level",
         "_rapids_enabled",
         "_workers_data_path",
@@ -53,6 +55,7 @@ def _reset_agi_runtime_distribution_state():
         AGI._work_plan = None
         AGI._work_plan_metadata = None
         AGI._capacity = None
+        AGI._phase_timings = []
         AGI._dask_log_level = "critical"
         AGI._rapids_enabled = False
         AGI._workers_data_path = None
@@ -113,6 +116,23 @@ def test_sanitize_worker_upload_artifacts_removes_top_level_ui_modules(tmp_path)
     assert "__pycache__/app_args_form.cpython-313.pyc" not in names
     assert "demo_worker/app_args_form.py" in names
     assert top_level == "demo_worker\n"
+
+
+def test_local_dask_worker_command_uses_direct_venv_executable_when_available(tmp_path):
+    wenv_abs = tmp_path / "wenv"
+    dask_exe = wenv_abs / ".venv" / ("Scripts/dask.exe" if os.name == "nt" else "bin/dask")
+    dask_exe.parent.mkdir(parents=True, exist_ok=True)
+    dask_exe.write_text("", encoding="utf-8")
+
+    command = runtime_distribution_support._local_dask_worker_command(
+        "uv",
+        wenv_abs,
+        "127.0.0.1:8786",
+        "worker.pid",
+    )
+
+    assert command[:3] == [str(dask_exe), "worker", "tcp://127.0.0.1:8786"]
+    assert "--no-sync" not in command
 
 
 @pytest.mark.asyncio
@@ -1305,8 +1325,10 @@ async def test_sync_waits_until_expected_workers():
     AGI._workers = {"127.0.0.1": 1, "10.0.0.2": 1}
     fake_client = _FakeClient()
     AGI._dask_client = fake_client
+    sleep_delays: list[float] = []
 
-    async def _fake_sleep(_delay):
+    async def _fake_sleep(delay):
+        sleep_delays.append(delay)
         return None
 
     await runtime_distribution_support.sync(
@@ -1316,6 +1338,7 @@ async def test_sync_waits_until_expected_workers():
         sleep_fn=_fake_sleep,
     )
     assert fake_client.calls >= 3
+    assert sleep_delays == [0.2, 0.5]
 
 
 @pytest.mark.asyncio
@@ -1457,7 +1480,7 @@ async def test_main_branches_simulate_install_dask_and_local(monkeypatch):
     )
     assert result == "run-result"
 
-    times = iter([10.0, 14.5])
+    times = iter([10.0, 10.1, 10.2, 10.3, 10.4, 10.5, 10.6, 14.5])
     AGI._mode = AGI._INSTALL_MODE | AGI.DASK_MODE
     result = await runtime_distribution_support.main(
         AGI,
@@ -1466,6 +1489,11 @@ async def test_main_branches_simulate_install_dask_and_local(monkeypatch):
         time_fn=lambda: next(times),
     )
     assert result == 4.5
+    assert [entry["phase"] for entry in AGI._phase_timings] == [
+        "prepare-local-env",
+        "prepare-cluster-env",
+        "deploy-application",
+    ]
 
     AGI._mode = AGI.DASK_MODE
     result = await runtime_distribution_support.main(

--- a/src/agilab/core/test/test_base_worker_execution_support.py
+++ b/src/agilab/core/test/test_base_worker_execution_support.py
@@ -778,6 +778,7 @@ def test_resolve_worker_info_path_normalizes_share_path_and_skips_existing_dir()
 def test_measure_worker_write_speed_writes_probe_file_and_removes_it():
     removed_paths: list[str] = []
     written_payloads: list[str] = []
+    sleep_calls: list[float] = []
     time_values = iter([1.0, 3.0])
 
     class _FakeStream:
@@ -795,7 +796,7 @@ def test_measure_worker_write_speed_writes_probe_file_and_removes_it():
         worker="127.0.0.1:8787",
         time_module=SimpleNamespace(
             time=lambda: next(time_values),
-            sleep=lambda *_args, **_kwargs: None,
+            sleep=lambda delay: sleep_calls.append(delay),
         ),
         os_module=SimpleNamespace(
             path=SimpleNamespace(join=base_worker_mod.os.path.join),
@@ -811,6 +812,41 @@ def test_measure_worker_write_speed_writes_probe_file_and_removes_it():
     # same helper to stay portable.
     assert removed_paths == [os.path.join("/tmp/share", "127.0.0.1_8787")]
     assert write_speed == [4.0]
+    assert sleep_calls == []
+
+
+def test_measure_worker_write_speed_can_request_settle_sleep():
+    sleep_calls: list[float] = []
+    time_values = iter([1.0, 2.0])
+
+    class _FakeStream:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def write(self, _payload):
+            return None
+
+    write_speed = execution_support._measure_worker_write_speed(
+        path="/tmp/share",
+        worker="worker",
+        time_module=SimpleNamespace(
+            time=lambda: next(time_values),
+            sleep=lambda delay: sleep_calls.append(delay),
+        ),
+        os_module=SimpleNamespace(
+            path=SimpleNamespace(join=base_worker_mod.os.path.join),
+            remove=lambda _path: None,
+        ),
+        open_fn=lambda *_args, **_kwargs: _FakeStream(),
+        size=4,
+        settle_seconds=0.25,
+    )
+
+    assert write_speed == [4.0]
+    assert sleep_calls == [0.25]
 
 
 def test_baseworker_build_verbose_non_managed_path_updates_sys_path(monkeypatch, tmp_path):

--- a/src/agilab/lib/agi-app-flight-telemetry/README.md
+++ b/src/agilab/lib/agi-app-flight-telemetry/README.md
@@ -14,6 +14,11 @@ Use this package to run a compact flight-data ingestion demo: raw public sample
 files are converted into a reusable dataframe dataset, then inspected through
 AGILAB analysis pages such as maps and network-style trajectory views.
 
+It also demonstrates AGILAB's worker-only Cython pattern on a real app. The
+Polars ingestion, output writing, and reducer artifact contract stay in Python,
+while the per-row haversine distance kernel can run as a typed compiled worker
+hot loop and reports runtime/checksum evidence.
+
 ## Installed Project
 
 The distribution name is `agi-app-flight-telemetry`; the AGILAB project name is
@@ -49,6 +54,8 @@ required for the default proof.
 The run writes the processed flight dataframe, reducer summaries, and
 analysis-ready artifacts under the project output paths. Open `ANALYSIS` with
 `view_maps` or `view_maps_network` to inspect the generated evidence.
+The reducer summary includes `speed_kernel_runtime`, `speed_dtype_contract`,
+and `speed_kernel_checksum_m` fields for the worker-only Cython path.
 
 ## Change One Thing
 

--- a/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/README.md
+++ b/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/README.md
@@ -14,6 +14,9 @@ The project focuses on a simple but useful workflow:
 - validating the `PROJECT -> ORCHESTRATE -> WORKFLOW -> ANALYSIS` flow in one
   packaged public app
 - showing how a raw data source becomes a reusable dataset for visual exploration
+- demonstrating worker-only Cython acceleration on a real app: dataframe I/O,
+  analysis pages, and reducer artifacts stay in Python while the per-row
+  haversine distance kernel can run as a typed compiled worker hot loop
 
 ## What is not implemented in the public version
 
@@ -37,6 +40,8 @@ Workers also emit a `reduce_summary_worker_<id>.json` `ReduceArtifact` beside
 the dataframe outputs. That summary records the reducer name, row count,
 aircraft/source-file counts, written output files, and trajectory distance/time-span
 fields so Release Decision can surface the flight run as first-class evidence.
+It also records the speed-kernel runtime, the `float64-contiguous` dtype
+contract, and a distance checksum so Cython runs remain auditable.
 
 ## Typical flow
 

--- a/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/src/flight_telemetry/reduction.py
+++ b/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/src/flight_telemetry/reduction.py
@@ -45,6 +45,9 @@ _REQUIRED_PAYLOAD_KEYS = (
     "output_formats",
     "time_start",
     "time_end",
+    "speed_kernel_runtimes",
+    "speed_dtype_contracts",
+    "speed_kernel_checksum_m",
 )
 
 
@@ -69,10 +72,13 @@ def _merge_flight_partials(partials: Sequence[ReducePartial]) -> dict[str, Any]:
     aircraft: set[str] = set()
     output_files: set[str] = set()
     output_formats: set[str] = set()
+    speed_kernel_runtimes: set[str] = set()
+    speed_dtype_contracts: set[str] = set()
     row_count = 0
     speed_count = 0
     speed_sum_m = 0.0
     max_speed_m = 0.0
+    speed_kernel_checksum_m = 0.0
     time_start = ""
     time_end = ""
 
@@ -86,6 +92,9 @@ def _merge_flight_partials(partials: Sequence[ReducePartial]) -> dict[str, Any]:
         aircraft.update(str(item) for item in payload["aircraft"])
         output_files.update(str(item) for item in payload["output_files"])
         output_formats.update(str(item) for item in payload["output_formats"])
+        speed_kernel_runtimes.update(str(item) for item in payload["speed_kernel_runtimes"])
+        speed_dtype_contracts.update(str(item) for item in payload["speed_dtype_contracts"])
+        speed_kernel_checksum_m += float(payload["speed_kernel_checksum_m"])
         candidate_start = str(payload["time_start"])
         candidate_end = str(payload["time_end"])
         if candidate_start and (not time_start or candidate_start < time_start):
@@ -107,6 +116,9 @@ def _merge_flight_partials(partials: Sequence[ReducePartial]) -> dict[str, Any]:
         "speed_sum_m": round(speed_sum_m, 3),
         "mean_speed_m": round(speed_sum_m / speed_count, 3) if speed_count else 0.0,
         "max_speed_m": round(max_speed_m, 3),
+        "speed_kernel_runtimes": _sorted_strings(speed_kernel_runtimes),
+        "speed_dtype_contracts": _sorted_strings(speed_dtype_contracts),
+        "speed_kernel_checksum_m": round(speed_kernel_checksum_m, 6),
         "time_start": time_start,
         "time_end": time_end,
     }
@@ -160,6 +172,21 @@ def partial_from_flight_frame(
     speed_values = df["speed"].drop_nulls()
     speed_count = len(speed_values)
     output_file_names = sorted({Path(str(path)).name for path in output_files if str(path)})
+    speed_kernel_runtimes = (
+        _sorted_unique_strings(df["speed_kernel_runtime"])
+        if "speed_kernel_runtime" in df.columns
+        else []
+    )
+    speed_dtype_contracts = (
+        _sorted_unique_strings(df["speed_dtype_contract"])
+        if "speed_dtype_contract" in df.columns
+        else []
+    )
+    speed_kernel_checksums = (
+        df["speed_kernel_checksum_m"].drop_nulls()
+        if "speed_kernel_checksum_m" in df.columns
+        else pl.Series("speed_kernel_checksum_m", [])
+    )
     payload = {
         "flight_run_count": 1,
         "row_count": int(df.height),
@@ -173,6 +200,11 @@ def partial_from_flight_frame(
         "speed_count": speed_count,
         "speed_sum_m": float(speed_values.sum()) if speed_count else 0.0,
         "max_speed_m": float(speed_values.max()) if speed_count else 0.0,
+        "speed_kernel_runtimes": speed_kernel_runtimes,
+        "speed_dtype_contracts": speed_dtype_contracts,
+        "speed_kernel_checksum_m": (
+            float(speed_kernel_checksums.max()) if len(speed_kernel_checksums) else 0.0
+        ),
         "time_start": _timestamp(df["date"].min()),
         "time_end": _timestamp(df["date"].max()),
     }

--- a/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/src/flight_telemetry_worker/flight_telemetry_worker.py
+++ b/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/src/flight_telemetry_worker/flight_telemetry_worker.py
@@ -13,6 +13,8 @@ import traceback
 from datetime import datetime as dt
 from pathlib import Path
 
+import cython
+import numpy as np
 from agi_env import normalize_path
 from agi_node import MutableNamespace
 from agi_node.polars_worker import PolarsWorker
@@ -25,6 +27,14 @@ logger = AgiLogger.get_logger(__name__)
 import polars as pl
 
 _EARTH_RADIUS_M = 6_371_000.0
+SPEED_DTYPE_CONTRACT = "float64-contiguous"
+SPEED_KERNEL_COLUMN = "speed_kernel_runtime"
+SPEED_DTYPE_COLUMN = "speed_dtype_contract"
+SPEED_KERNEL_CHECKSUM_COLUMN = "speed_kernel_checksum_m"
+
+
+def _kernel_runtime_label() -> str:
+    return "cython" if cython.compiled else "python"
 
 
 def _haversine_distance_m(row) -> float:
@@ -45,6 +55,85 @@ def _haversine_distance_m(row) -> float:
         + math.cos(lat1) * math.cos(lat2) * math.sin(dlon / 2.0) ** 2
     )
     return 2.0 * _EARTH_RADIUS_M * math.asin(math.sqrt(min(1.0, a)))
+
+
+def _as_contiguous_float64(series: pl.Series) -> np.ndarray:
+    return np.ascontiguousarray(
+        series.cast(pl.Float64, strict=False).fill_null(float("nan")).to_numpy(),
+        dtype=np.float64,
+    )
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def _haversine_distance_kernel(
+    prev_lat_values: cython.double[::1],
+    prev_long_values: cython.double[::1],
+    lat_values: cython.double[::1],
+    long_values: cython.double[::1],
+    distance_out: cython.double[::1],
+) -> cython.double:
+    """Fill distance output through a Cython-friendly typed numeric loop."""
+    n_rows: cython.Py_ssize_t = lat_values.shape[0]
+    row_idx: cython.Py_ssize_t
+    lat1: cython.double = 0.0
+    lon1: cython.double = 0.0
+    lat2: cython.double = 0.0
+    lon2: cython.double = 0.0
+    dlat: cython.double = 0.0
+    dlon: cython.double = 0.0
+    a_value: cython.double = 0.0
+    distance: cython.double = 0.0
+    checksum: cython.double = 0.0
+
+    for row_idx in range(n_rows):
+        lat1 = prev_lat_values[row_idx]
+        lon1 = prev_long_values[row_idx]
+        lat2 = lat_values[row_idx]
+        lon2 = long_values[row_idx]
+
+        if lat1 != lat1 or lon1 != lon1 or lat2 != lat2 or lon2 != lon2:
+            distance = 0.0
+        else:
+            lat1 = math.radians(lat1)
+            lon1 = math.radians(lon1)
+            lat2 = math.radians(lat2)
+            lon2 = math.radians(lon2)
+            dlat = lat2 - lat1
+            dlon = lon2 - lon1
+            a_value = (
+                math.sin(dlat / 2.0) ** 2
+                + math.cos(lat1) * math.cos(lat2) * math.sin(dlon / 2.0) ** 2
+            )
+            if a_value > 1.0:
+                a_value = 1.0
+            distance = 2.0 * _EARTH_RADIUS_M * math.asin(math.sqrt(a_value))
+
+        distance_out[row_idx] = distance
+        checksum += distance
+
+    return checksum
+
+
+def _haversine_distance_series(df: pl.DataFrame) -> tuple[pl.Series, str, str, float]:
+    prev_lat_values = _as_contiguous_float64(df["prev_lat"])
+    prev_long_values = _as_contiguous_float64(df["prev_long"])
+    lat_values = _as_contiguous_float64(df["lat"])
+    long_values = _as_contiguous_float64(df["long"])
+    distance_values = np.empty(len(df), dtype=np.float64)
+    checksum = _haversine_distance_kernel(
+        prev_lat_values,
+        prev_long_values,
+        lat_values,
+        long_values,
+        distance_values,
+    )
+    return (
+        pl.Series(distance_values),
+        _kernel_runtime_label(),
+        SPEED_DTYPE_CONTRACT,
+        float(checksum),
+    )
 
 
 class FlightTelemetryWorker(PolarsWorker):
@@ -76,14 +165,13 @@ class FlightTelemetryWorker(PolarsWorker):
         and add it under the legacy ``speed`` column name used by this demo.
         Assumes that the previous coordinate columns are already present.
         """
+        speed_values, kernel_runtime, dtype_contract, checksum = _haversine_distance_series(df)
         df = df.with_columns(
             [
-                pl.struct(["prev_lat", "prev_long", "lat", "long"])
-                .map_elements(
-                    _haversine_distance_m,
-                    return_dtype=pl.Float64,
-                )
-                .alias(new_column_name),
+                speed_values.alias(new_column_name),
+                pl.lit(kernel_runtime).alias(SPEED_KERNEL_COLUMN),
+                pl.lit(dtype_contract).alias(SPEED_DTYPE_COLUMN),
+                pl.lit(round(checksum, 6)).alias(SPEED_KERNEL_CHECKSUM_COLUMN),
             ]
         )
         return df

--- a/test/test_flight_telemetry_project_runtime_args.py
+++ b/test/test_flight_telemetry_project_runtime_args.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import math
 import sys
 import tomllib
 from datetime import date
@@ -41,6 +42,20 @@ def test_flight_telemetry_project_declares_polars_runtime_compat():
 
     assert "polars[rtcompat]" in project["dependencies"]
     assert "geopy" not in project["dependencies"]
+
+
+def test_flight_telemetry_project_declares_worker_only_cython_contract():
+    repo_root = Path(__file__).resolve().parents[1]
+    app_root = repo_root / "src" / "agilab" / "apps" / "builtin" / "flight_telemetry_project"
+    settings = tomllib.loads((app_root / "src" / "app_settings.toml").read_text(encoding="utf-8"))
+    worker_project = tomllib.loads(
+        (app_root / "src" / "flight_telemetry_worker" / "pyproject.toml").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    assert settings["cluster"]["cython"] is True
+    assert {"setuptools", "cython"} <= set(worker_project["build-system"]["requires"])
 
 
 class _FakeEnv:
@@ -351,6 +366,24 @@ def test_flight_telemetry_worker_helper_and_error_branches(monkeypatch, tmp_path
     assert worker_module._haversine_distance_m({"prev_lat": None, "prev_long": 2, "lat": 3, "long": 4}) == 0.0
     assert worker_module._haversine_distance_m({"prev_lat": "bad", "prev_long": 2, "lat": 3, "long": 4}) == 0.0
     assert worker_module._haversine_distance_m({"prev_lat": 48.0, "prev_long": 2.0, "lat": 48.001, "long": 2.001}) > 0
+    kernel_df = pl.DataFrame(
+        {
+            "prev_lat": pl.Series("prev_lat", [None, 48.0, "bad"], strict=False),
+            "prev_long": [None, 2.0, 2.0],
+            "lat": [48.0, 48.001, 48.002],
+            "long": [2.0, 2.001, 2.002],
+        }
+    )
+    kernel_series, runtime, dtype_contract, checksum = worker_module._haversine_distance_series(kernel_df)
+    expected = worker_module._haversine_distance_m(
+        {"prev_lat": 48.0, "prev_long": 2.0, "lat": 48.001, "long": 2.001}
+    )
+    assert kernel_series.to_list()[0] == 0.0
+    assert math.isclose(kernel_series.to_list()[1], expected, rel_tol=1e-12)
+    assert kernel_series.to_list()[2] == 0.0
+    assert math.isclose(checksum, expected, rel_tol=1e-12)
+    assert runtime in {"python", "cython"}
+    assert dtype_contract == worker_module.SPEED_DTYPE_CONTRACT
 
     worker = object.__new__(FlightWorker)
     worker.pool_init({"args": MutableNamespace(data_source="file")})
@@ -466,6 +499,9 @@ def test_flight_reduce_contract_merges_trajectory_partials(monkeypatch):
     assert artifact.payload["output_formats"] == ["parquet"]
     assert artifact.payload["mean_speed_m"] == 50.0
     assert artifact.payload["max_speed_m"] == 100.0
+    assert artifact.payload["speed_kernel_runtimes"] == []
+    assert artifact.payload["speed_dtype_contracts"] == []
+    assert artifact.payload["speed_kernel_checksum_m"] == 0.0
     assert artifact.payload["time_start"] == "2021-01-01T00:00:00"
     assert artifact.payload["time_end"] == "2021-01-01T00:02:00"
 
@@ -537,6 +573,16 @@ def test_flight_telemetry_worker_emits_reduce_artifact(monkeypatch, tmp_path):
 
     result = worker.work_pool(str(source.relative_to(tmp_path)))
     assert "source_file" in result.columns
+    assert "speed_kernel_runtime" in result.columns
+    assert "speed_dtype_contract" in result.columns
+    assert "speed_kernel_checksum_m" in result.columns
+    assert result.select("speed_dtype_contract").unique().to_series().to_list() == [
+        "float64-contiguous"
+    ]
+    assert result.select("speed_kernel_runtime").unique().to_series().to_list()[0] in {
+        "python",
+        "cython",
+    }
     absolute_result = worker.work_pool(str(source))
     assert absolute_result.select("source_file").unique().to_series().to_list() == ["01_track.csv"]
 
@@ -559,3 +605,6 @@ def test_flight_telemetry_worker_emits_reduce_artifact(monkeypatch, tmp_path):
     assert artifact.payload["output_formats"] == ["parquet"]
     assert artifact.payload["mean_speed_m"] > 0.0
     assert artifact.payload["max_speed_m"] > 0.0
+    assert artifact.payload["speed_kernel_runtimes"][0] in {"python", "cython"}
+    assert artifact.payload["speed_dtype_contracts"] == ["float64-contiguous"]
+    assert artifact.payload["speed_kernel_checksum_m"] > 0.0


### PR DESCRIPTION
## Summary
- cache unchanged worker build artifacts to avoid repeated local worker rebuilds
- reduce cluster startup overhead by batching capacity/runtime checks
- add flight telemetry Cython evidence and docs updates

## Validation
- `uv --preview-features extra-build-dependencies run --no-sync pytest -q -o addopts='' src/agilab/core/test/test_reduction_contract.py src/agilab/core/test/test_base_worker_execution_support.py src/agilab/core/test/test_agi_distributor_capacity_support.py src/agilab/core/test/test_agi_distributor_deployment_build_support.py src/agilab/core/test/test_agi_distributor_runtime_distribution_support.py` -> 150 passed
- `uv --preview-features extra-build-dependencies run --no-sync pytest src/agilab/core/test` -> 949 passed, 2 skipped
- `uv --preview-features extra-build-dependencies run --no-sync pytest -q -o addopts='' test/test_flight_telemetry_project_runtime_args.py` -> 14 passed
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui` -> pass
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs` -> pass

Note: the active local checkout switched to another dirty branch during validation, so this PR was opened from the already-pushed `codex/speed-up-node-cluster` branch without staging local checkout changes.