### PR TITLE
docs: add AGILAB 50-star promotion kit

### DIFF
--- a/PROMOTE.md
+++ b/PROMOTE.md
@@ -1,0 +1,184 @@
+# Promote AGILAB To 50 Stars
+
+AGILAB's next public adoption target is simple: make the repository easier to
+discover, try, and remember until it reaches 50 GitHub stars.
+
+This page is a maintainer-ready launch kit. It keeps the message honest:
+AGILAB is not another all-in-one MLOps platform. It is a reproducibility
+workbench that turns AI/ML notebooks and scripts into executable,
+evidence-backed apps with a path back to notebooks and MLflow.
+
+## One-Line Pitch
+
+AGILAB turns AI/ML notebooks and scripts into reproducible executable apps with
+evidence, notebook export, and optional MLflow handoff.
+
+## Public Links
+
+- GitHub: <https://github.com/ThalesGroup/agilab>
+- Docs: <https://thalesgroup.github.io/agilab/>
+- Browser preview: <https://huggingface.co/spaces/jpmorard/agilab>
+- PyPI: <https://pypi.org/project/agilab/>
+- Demo chooser: <https://thalesgroup.github.io/agilab/demos.html>
+- Cython worker speedup demo:
+  <https://thalesgroup.github.io/agilab/execution-playground.html>
+
+## Best Hooks
+
+Use one hook per post. Do not pitch the whole platform at once.
+
+| Audience | Hook | Link |
+|---|---|---|
+| Data scientists | Turn notebook work into a replayable app, then export it back to a runnable notebook. | Docs quick start |
+| ML engineers | Add evidence and repeatable execution around experiments without replacing MLflow. | README / MLOps positioning |
+| Python performance users | Compare a plain Python worker with a typed Cython hot-loop worker using checksum evidence. | Execution playground |
+| AI agent builders | Capture agent or workflow runs as reviewable local evidence. | Agent workflows |
+| Educators | Use PyTorch Playground or TeSciA as reproducible teaching apps with artifacts. | Public app catalog |
+
+## README Callout
+
+Use this exact short ask near public entry points:
+
+> If AGILAB helps you make AI/ML experiments reproducible, please star the
+> repository so other engineers can find it.
+
+## Copy-Paste Posts
+
+### LinkedIn Short
+
+AGILAB is an open-source reproducibility workbench for AI/ML engineering.
+
+It turns notebooks and scripts into executable apps with:
+
+- controlled environments
+- local or distributed execution
+- evidence artifacts
+- analysis pages
+- notebook export
+- optional MLflow handoff
+
+The first useful path is local: prove one run, inspect the evidence, then decide
+whether package, notebook, MLflow, or cluster paths make sense.
+
+Repo: https://github.com/ThalesGroup/agilab
+Browser preview: https://huggingface.co/spaces/jpmorard/agilab
+
+If this kind of notebook-to-evidence workflow is useful to you, a GitHub star
+helps other AI/ML engineers discover it.
+
+### Technical Post
+
+Most AI/ML prototypes fail to become reusable because the notebook, environment,
+execution steps, and review evidence drift apart.
+
+AGILAB tries to close that gap:
+
+Notebook/script -> executable app -> controlled run -> artifacts + evidence ->
+analysis view -> notebook or MLflow handoff.
+
+It is not a replacement for MLflow or production MLOps. It owns the
+reproducibility and evidence layer around experimental work.
+
+Start here:
+
+- Quick start: https://thalesgroup.github.io/agilab/quick-start.html
+- Public preview: https://huggingface.co/spaces/jpmorard/agilab
+- Repo: https://github.com/ThalesGroup/agilab
+
+### Cython Demo Post
+
+AGILAB now includes a worker-level Cython speedup demo.
+
+The point is not to pretend that every pipeline becomes hundreds of times
+faster. The demo isolates one hot numeric loop, keeps the surrounding Pandas I/O
+and evidence in Python, then compares Python and Cython execution with checksum
+evidence.
+
+That makes the benchmark reviewable instead of just impressive.
+
+Demo: https://thalesgroup.github.io/agilab/execution-playground.html
+Repo: https://github.com/ThalesGroup/agilab
+
+### Hugging Face Community Post
+
+I published a browser preview for AGILAB, an open-source AI/ML reproducibility
+workbench.
+
+The hosted Space is the fastest way to see the workflow before installing:
+
+1. choose a public app
+2. run a reproducible local-style proof
+3. inspect generated evidence and analysis pages
+
+Space: https://huggingface.co/spaces/jpmorard/agilab
+GitHub: https://github.com/ThalesGroup/agilab
+
+Feedback is useful, especially on the first-run path and notebook-to-app story.
+
+### Reddit Or Hacker News Draft
+
+Title:
+
+Show HN: AGILAB, a reproducibility workbench for AI/ML notebooks and scripts
+
+Body:
+
+AGILAB is an open-source workbench for turning AI/ML notebooks and scripts into
+replayable apps with evidence artifacts.
+
+The target use case is the gap between exploratory notebooks and production
+MLOps: you want controlled execution, reviewable artifacts, analysis pages, and
+a path back to a runnable notebook or MLflow handoff.
+
+It is not meant to replace MLflow or a production platform. It is closer to a
+local reproducibility and evidence layer around experimental AI work.
+
+Repo: https://github.com/ThalesGroup/agilab
+Browser preview: https://huggingface.co/spaces/jpmorard/agilab
+Docs: https://thalesgroup.github.io/agilab/
+
+I would especially value feedback on the first 10-minute proof and whether the
+notebook export story is clear.
+
+## 60-Second Demo Script
+
+Use one app only. The safest broad teaser is `flight_telemetry_project`.
+
+| Time | Screen | Message |
+|---|---|---|
+| 0-5s | GitHub or Space landing | "AGILAB turns AI/ML scripts into reproducible executable apps." |
+| 5-15s | PROJECT | "Start from a public app or notebook." |
+| 15-30s | ORCHESTRATE | "Run locally first; cluster comes later." |
+| 30-45s | WORKFLOW | "Keep the stage contract inspectable and exportable." |
+| 45-57s | ANALYSIS | "Review artifacts, evidence, and analysis views." |
+| 57-60s | GitHub star badge | "If this helps your workflow, star the repo." |
+
+## Outreach Checklist
+
+- Confirm the current release proof and hosted Space are green.
+- Pin one GitHub issue labelled `good first issue`.
+- Post one notebook-to-evidence message.
+- Post one Cython benchmark message.
+- Ask internal users to star only if they can explain the use case in one
+  sentence.
+- Reply to comments with links to the quick start, not broad feature claims.
+- Track stars, PyPI downloads, HF likes, docs visits, and first-proof failures
+  weekly until the repository reaches 50 stars.
+
+## What Not To Claim
+
+- Do not claim AGILAB is a complete production MLOps platform.
+- Do not claim benchmark speedups beyond the declared workload.
+- Do not imply cluster setup is required for the first proof.
+- Do not present roadmap items such as full proof capsules as already shipped.
+- Do not promise enterprise governance, RBAC, drift monitoring, or regulated
+  production serving.
+
+## Success Definition
+
+The 50-star campaign is working when a new visitor can answer three questions in
+under two minutes:
+
+1. What is AGILAB for?
+2. What can I try without installing anything?
+3. Why should I star or revisit the repository?

--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ Start with the public browser preview or the demo chooser:
 - [Cython worker speedup demo](https://thalesgroup.github.io/agilab/execution-playground.html)
 - [Local quick start](#quick-start)
 - [Demo capture guide](https://thalesgroup.github.io/agilab/demo_capture_script.html)
+- [50-star promotion kit](PROMOTE.md)
+
+If AGILAB helps you make AI/ML experiments reproducible, please star the
+repository so other engineers can find it.
 
 ## Featured Opt-In App
 

--- a/README.pypi.md
+++ b/README.pypi.md
@@ -65,6 +65,10 @@ Start with the public browser preview or the demo chooser:
 - [Cython worker speedup demo](https://thalesgroup.github.io/agilab/execution-playground.html)
 - [Local quick start](https://thalesgroup.github.io/agilab/quick-start.html)
 - [Demo capture guide](https://thalesgroup.github.io/agilab/demo_capture_script.html)
+- [50-star promotion kit](https://github.com/ThalesGroup/agilab/blob/main/PROMOTE.md)
+
+If AGILAB helps you make AI/ML experiments reproducible, please star the
+repository so other engineers can find it.
 
 ## Featured Performance Demo
 


### PR DESCRIPTION
## Summary
- add a maintainer-ready 50-star promotion kit with copy-paste posts, demo script, outreach checklist, and claim guardrails
- add a README and PyPI README link to the promotion kit
- add a visible GitHub star ask near the public demo links

## Validation
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files PROMOTE.md README.md README.pypi.md`
- `uv --preview-features extra-build-dependencies run --with tomli-w pytest -q -o addopts="" test/test_github_ai_scraper_discoverability.py test/test_public_demo_links.py`
- `git diff --check`

Note: this PR was prepared from a clean worktree based on `origin/main` and intentionally excludes unrelated local Excel/Rust/app edits present in the main checkout.