### PR TITLE
Harden apps-pages runtime and robot validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Start with the public browser preview or the demo chooser:
 - [Demo chooser](https://thalesgroup.github.io/agilab/demos.html)
 - [Excel workbook proof](https://thalesgroup.github.io/agilab/excel-users.html)
 - [Cython worker speedup demo](https://thalesgroup.github.io/agilab/execution-playground.html)
+- [Rust/PyO3 native worker preview](https://thalesgroup.github.io/agilab/execution-playground.html#optional-rust-pyo3-worker-preview)
 - [Local quick start](#quick-start)
 - [Demo capture guide](https://thalesgroup.github.io/agilab/demo_capture_script.html)
 - [50-star promotion kit](PROMOTE.md)

--- a/README.pypi.md
+++ b/README.pypi.md
@@ -64,6 +64,7 @@ Start with the public browser preview or the demo chooser:
 - [Demo chooser](https://thalesgroup.github.io/agilab/demos.html)
 - [Excel workbook proof](https://thalesgroup.github.io/agilab/excel-users.html)
 - [Cython worker speedup demo](https://thalesgroup.github.io/agilab/execution-playground.html)
+- [Rust/PyO3 native worker preview](https://thalesgroup.github.io/agilab/execution-playground.html#optional-rust-pyo3-worker-preview)
 - [Local quick start](https://thalesgroup.github.io/agilab/quick-start.html)
 - [Demo capture guide](https://thalesgroup.github.io/agilab/demo_capture_script.html)
 - [50-star promotion kit](https://github.com/ThalesGroup/agilab/blob/main/PROMOTE.md)

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 219,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "0c85f5498e7c754ef51c7e92f2f80d1a7b841d62664651f5f6413abd8fc7abf4",
+  "source_digest_sha256": "b0568cf67192854fcde77e38d5b573290028dc6223c125fc54e4c032d2fbaba3",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "0c85f5498e7c754ef51c7e92f2f80d1a7b841d62664651f5f6413abd8fc7abf4"
+  "target_digest_sha256": "b0568cf67192854fcde77e38d5b573290028dc6223c125fc54e4c032d2fbaba3"
 }

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 219,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "3f1d9ea893dc3a460744899638930121689afe1fdf1f209b7f0b33794566c4c1",
+  "source_digest_sha256": "0c85f5498e7c754ef51c7e92f2f80d1a7b841d62664651f5f6413abd8fc7abf4",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "3f1d9ea893dc3a460744899638930121689afe1fdf1f209b7f0b33794566c4c1"
+  "target_digest_sha256": "0c85f5498e7c754ef51c7e92f2f80d1a7b841d62664651f5f6413abd8fc7abf4"
 }

--- a/docs/source/demos.rst
+++ b/docs/source/demos.rst
@@ -136,6 +136,21 @@ The static scenario contract is available as JSON:
   ``speed_kernel_runtime``, ``speed_dtype_contract``, and checksum evidence in
   the reducer summary.
 
+**Rust/PyO3 native-worker preview**
+  Use the packaged ``native_rust_worker`` preview when the demo objective is to
+  show AGILAB's native-worker extension boundary without adding Rust to the base
+  install:
+
+  .. code-block:: bash
+
+     uv --preview-features extra-build-dependencies run python src/agilab/examples/native_rust_worker/preview_native_rust_worker.py --output-dir /tmp/agilab-rust-worker
+
+  Stop when ``native_rust_worker_evidence.json`` and the generated
+  ``rust_worker`` PyO3/maturin skeleton are visible. This is an advanced worker
+  extension preview: AGILAB orchestration and evidence stay in Python, only a
+  measured typed hot kernel moves to Rust, and compiling the generated extension
+  remains an explicit follow-up step.
+
 **Distributed worker route**
   Use the same public app, then switch ORCHESTRATE from the local path to the
   configured worker or SSH-host path. Keep the demo bounded: prove that worker

--- a/docs/source/execution-playground.rst
+++ b/docs/source/execution-playground.rst
@@ -172,6 +172,43 @@ per-row haversine distance calculation into the same worker-only Cython pattern.
 Its reducer summary records ``speed_kernel_runtime``,
 ``speed_dtype_contract``, and ``speed_kernel_checksum_m``.
 
+Optional Rust/PyO3 worker preview
+---------------------------------
+
+AGILAB can also host native Rust code behind a Python worker boundary, but this
+is deliberately an optional advanced lane rather than a base dependency.
+
+Use the packaged ``native_rust_worker`` preview when you want to show the
+architecture without requiring every AGILAB install to carry a Rust toolchain:
+
+.. code-block:: bash
+
+   uv --preview-features extra-build-dependencies run python src/agilab/examples/native_rust_worker/preview_native_rust_worker.py --output-dir /tmp/agilab-rust-worker
+
+The preview writes a small PyO3/maturin project, a Python worker wrapper, a
+sample payload, and ``native_rust_worker_evidence.json``. It does not compile
+Rust by default. The evidence records the Python reference checksum, generated
+file hashes, the build backend, and the intended AGILAB boundary:
+
+- orchestration, dataframe I/O, reducers, paths, and evidence stay in Python
+- only the measured typed hot kernel moves to Rust
+- the base AGILAB install remains unchanged
+
+Build the generated project only when you actually want to execute the native
+extension:
+
+.. code-block:: bash
+
+   cd /tmp/agilab-rust-worker/rust_worker
+   uv tool install maturin
+   maturin develop --release
+   python worker_wrapper.py --payload sample_payload.json --output native_result.json
+
+Read this as a worker-extension contract, not a migration strategy. Cython is
+still the first AGILAB-native acceleration path for typed Python kernels. Use
+Rust/PyO3 when ownership, safety, an existing Rust crate, or a long-lived native
+library justifies the extra wheel and toolchain complexity.
+
 2-node 16-mode matrix
 ---------------------
 

--- a/docs/source/proof-capsule.rst
+++ b/docs/source/proof-capsule.rst
@@ -5,8 +5,10 @@ The product north star for AGILAB is a portable proof capsule: a reviewable
 bundle that lets another operator verify what ran, where it ran, which
 artifacts were produced, and how the work can be replayed or handed off.
 
-AGILAB now ships a first proof-pack layer around ``run_manifest.json``. It is a
-directory of plain JSON evidence, not yet a signed ``.agipack`` archive.
+AGILAB now ships a first proof-pack layer around ``run_manifest.json``. It can
+write either a directory of plain JSON evidence or an unsigned, hash-verifiable
+``.agipack`` archive for portable handoff. Detached signatures and external
+attestation binding remain separate roadmap layers.
 
 Why this matters
 ----------------
@@ -80,9 +82,13 @@ The shipped first layer operates on a run manifest:
 .. code-block:: bash
 
    agilab prove ~/log/execute/flight_telemetry/run_manifest.json --output-dir proof-pack
+   agilab prove ~/log/execute/flight_telemetry/run_manifest.json --export proof.agipack
    agilab verify ~/log/execute/flight_telemetry/run_manifest.json --strict
+   agilab verify proof.agipack --strict
    agilab replay ~/log/execute/flight_telemetry/run_manifest.json
+   agilab replay proof.agipack
    agilab export-lineage ~/log/execute/flight_telemetry/run_manifest.json --format all --output-dir proof-pack
+   agilab export-traces proof.agipack --output-dir proof-pack
    agilab policy-check ~/log/execute/flight_telemetry/run_manifest.json --strict
    agilab cards ~/log/execute/flight_telemetry/run_manifest.json --output-dir proof-pack
    agilab metadata-store ~/log/execute/flight_telemetry/run_manifest.json --store ~/.agilab/metadata-store.json
@@ -98,16 +104,13 @@ The proof pack includes:
 * model, dataset, prompt, and evaluation cards generated from available
   manifest evidence
 
-Replay is safe by default: ``agilab replay`` prints the recorded command and
-requires ``--execute`` before launching it.
-
-The reserved archive shape remains roadmap work:
-
-.. code-block:: bash
-
-   agilab prove . --profile audit --export proof.agipack
-   agilab verify proof.agipack
-   agilab replay proof.agipack
+The ``.agipack`` archive contains the same proof-pack files plus
+``agipack-manifest.json`` with per-entry SHA-256 hashes and sizes.
+``agilab verify proof.agipack`` checks the ZIP inventory, the recorded hashes,
+the run-manifest snapshot, and the proof-pack manifest. Replay is safe by
+default: ``agilab replay`` prints the recorded command from either
+``run_manifest.json`` or ``proof.agipack`` and requires ``--execute`` before
+launching it.
 
 Until a signed archive verifier exists, keep using the existing first-proof and
 adoption commands as the entry evidence:
@@ -123,8 +126,8 @@ Roadmap boundary
 
 The following items remain planned work, not shipped capability:
 
-* signed ``.agipack`` archives with detached hashes and Sigstore/SLSA
-  references
+* signed ``.agipack`` archives with detached signatures, Sigstore/SLSA
+  references, and external attestation verification
 * transport to an external OpenLineage backend
 * native OpenTelemetry SDK/OTLP spans across UI, worker build, distributed
   execution, notebook export, MLflow handoff, and agent runs

--- a/docs/source/roadmap/agilab-future-work.md
+++ b/docs/source/roadmap/agilab-future-work.md
@@ -220,9 +220,11 @@ Concrete items:
   and compatibility profiles as first-class outputs
 - keep the first public proof-pack CLI layer small and verifiable:
   `agilab prove`, `agilab verify`, `agilab replay`,
-  `agilab export-lineage`, `agilab policy-check`, `agilab cards`, and
-  `agilab metadata-store` operate on `run_manifest.json` and write plain JSON
-  evidence before AGILab claims a signed capsule archive
+  `agilab export-lineage`, `agilab export-traces`, `agilab policy-check`,
+  `agilab cards`, and `agilab metadata-store` operate on `run_manifest.json`,
+  write plain JSON evidence, and export an unsigned, hash-verifiable
+  `.agipack` archive before AGILab claims detached signing or external
+  attestation verification for capsules
 - introduce an Evidence Core contract that bundles the run manifest, workflow
   snapshot, environment lock, artifact hashes, notebook import/export manifest,
   optional MLflow references, policy checks, and verifier results as one

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ keywords = [
     "codex",
     "claude",
 ]
-dependencies = ["agi-core==2026.05.23", "legacy-cgi>=2.6.4; python_version >= '3.13'", "standard-imghdr>=3.13.0; python_version >= '3.13'"]
+dependencies = ["agi-core==2026.05.23", "legacy-cgi>=2.6.4,<3; python_version >= '3.13'", "standard-imghdr>=3.13.0,<4; python_version >= '3.13'"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"
@@ -61,16 +61,16 @@ Changelog = "https://github.com/ThalesGroup/agilab/releases"
 agilab = "agilab.lab_run:main"
 
 [project.optional-dependencies]
-ai = ["openai>=2.32.0"]
-ui = ["agi-apps==2026.05.23", "agi-pages==2026.05.23", "agi-gui==2026.05.23", "networkx>=3.6.1", "pandas>=2.3.0", "streamlit>=1.56,<1.57", "tomli_w>=1.2.0"]
-viz = ["matplotlib>=3.10.0", "plotly>=6.7.0"]
-mlflow = ["mlflow>=3.11.1", "idna>=3.15", "starlette>=1.0.1"]
-examples = ["agi-apps==2026.05.23", "jupyterlab>=4.4.0", "matplotlib>=3.10.0", "plotly>=6.7.0"]
+ai = ["openai>=2.32.0,<3"]
+ui = ["agi-apps==2026.05.23", "agi-pages==2026.05.23", "agi-gui==2026.05.23", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "streamlit>=1.56,<1.57", "tomli_w>=1.2.0,<2"]
+viz = ["matplotlib>=3.10.0,<4", "plotly>=6.7.0,<7"]
+mlflow = ["mlflow>=3.11.1,<4", "idna>=3.15,<4", "starlette>=1.0.1,<2"]
+examples = ["agi-apps==2026.05.23", "jupyterlab>=4.4.0,<5", "matplotlib>=3.10.0,<4", "plotly>=6.7.0,<7"]
 pages = ["agi-pages==2026.05.23"]
-agents = ["openai>=2.32.0"]
-local-llm = ["accelerate>=0.34.2; python_version >= '3.12'", "gpt-oss>=0.0.8; python_version >= '3.12'", "langchain-core>=1.3.3; python_version >= '3.12'", "langsmith>=0.8.0; python_version >= '3.12'", "mlx>=0.31.2; sys_platform == 'darwin' and platform_machine == 'arm64'", "mlx-lm>=0.31.3; sys_platform == 'darwin' and platform_machine == 'arm64'", "mlx-vlm>=0.5.0; sys_platform == 'darwin' and platform_machine == 'arm64'", "requests>=2.32.0; python_version >= '3.12'", "torch>=2.8.0; python_version >= '3.12'", "transformers>=4.57.0; python_version >= '3.12'", "universal-offline-ai-chatbot>=0.1.0; python_version >= '3.12'"]
-offline = ["accelerate>=0.34.2; python_version >= '3.12'", "gpt-oss>=0.0.8; python_version >= '3.12'", "langchain-core>=1.3.3; python_version >= '3.12'", "langsmith>=0.8.0; python_version >= '3.12'", "mlx>=0.31.2; sys_platform == 'darwin' and platform_machine == 'arm64'", "mlx-lm>=0.31.3; sys_platform == 'darwin' and platform_machine == 'arm64'", "mlx-vlm>=0.5.0; sys_platform == 'darwin' and platform_machine == 'arm64'", "requests>=2.32.0; python_version >= '3.12'", "torch>=2.8.0; python_version >= '3.12'", "transformers>=4.57.0; python_version >= '3.12'", "universal-offline-ai-chatbot>=0.1.0; python_version >= '3.12'"]
-dev = ["build>=1.3.0", "cyclonedx-bom>=7.2.1", "pip-audit>=2.9.0", "pytest>=9.0.0", "pytest-asyncio>=1.3.0", "pytest-cov>=7.0.0", "tomlkit>=0.13.0", "twine>=6.2.0", "wheel>=0.45.0"]
+agents = ["openai>=2.32.0,<3"]
+local-llm = ["accelerate>=0.34.2,<1; python_version >= '3.12'", "gpt-oss>=0.0.8,<0.1; python_version >= '3.12'", "langchain-core>=1.3.3,<2; python_version >= '3.12'", "langsmith>=0.8.0,<1; python_version >= '3.12'", "mlx>=0.31.2,<0.32; sys_platform == 'darwin' and platform_machine == 'arm64'", "mlx-lm>=0.31.3,<0.32; sys_platform == 'darwin' and platform_machine == 'arm64'", "mlx-vlm>=0.5.0,<0.6; sys_platform == 'darwin' and platform_machine == 'arm64'", "requests>=2.32.0,<3; python_version >= '3.12'", "torch>=2.8.0,<3; python_version >= '3.12'", "transformers>=4.57.0,<6; python_version >= '3.12'", "universal-offline-ai-chatbot>=0.1.0,<0.2; python_version >= '3.12'"]
+offline = ["accelerate>=0.34.2,<1; python_version >= '3.12'", "gpt-oss>=0.0.8,<0.1; python_version >= '3.12'", "langchain-core>=1.3.3,<2; python_version >= '3.12'", "langsmith>=0.8.0,<1; python_version >= '3.12'", "mlx>=0.31.2,<0.32; sys_platform == 'darwin' and platform_machine == 'arm64'", "mlx-lm>=0.31.3,<0.32; sys_platform == 'darwin' and platform_machine == 'arm64'", "mlx-vlm>=0.5.0,<0.6; sys_platform == 'darwin' and platform_machine == 'arm64'", "requests>=2.32.0,<3; python_version >= '3.12'", "torch>=2.8.0,<3; python_version >= '3.12'", "transformers>=4.57.0,<6; python_version >= '3.12'", "universal-offline-ai-chatbot>=0.1.0,<0.2; python_version >= '3.12'"]
+dev = ["build>=1.3.0,<2", "cyclonedx-bom>=7.2.1,<8", "pip-audit>=2.9.0,<3", "pytest>=9.0.0,<10", "pytest-asyncio>=1.3.0,<2", "pytest-cov>=7.0.0,<8", "tomlkit>=0.13.0,<1", "twine>=6.2.0,<7", "wheel>=0.45.0,<1"]
 
 
 

--- a/src/agilab/apps-pages/view_app_ui/pyproject.toml
+++ b/src/agilab/apps-pages/view_app_ui/pyproject.toml
@@ -13,6 +13,7 @@ keywords = [
     "reproducibility",
 ]
 dependencies = [
+    "agi-pages>=2026.05.23,<2027.0",
     "agi-gui>=2026.05.21,<2027.0",
 ]
 
@@ -32,5 +33,6 @@ Changelog = "https://github.com/ThalesGroup/agilab/releases"
 
 
 [tool.uv.sources]
+agi-pages = { path = "../../lib/agi-pages", editable = true }
 agi-gui = { path = "../../lib/agi-gui", editable = true }
 agi-env = { path = "../../core/agi-env", editable = true }

--- a/src/agilab/apps-pages/view_app_ui/src/view_app_ui/view_app_ui.py
+++ b/src/agilab/apps-pages/view_app_ui/src/view_app_ui/view_app_ui.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-import argparse
 import importlib.util
 from pathlib import Path
 import sys
@@ -13,6 +12,10 @@ from types import ModuleType
 from typing import Any
 
 import streamlit as st
+from agi_pages.runtime import (
+    ensure_repo_on_path as _page_ensure_repo_on_path,
+    resolve_active_app_path,
+)
 
 
 PAGE_KEY = "view_app_ui"
@@ -26,29 +29,14 @@ def _safe_page_config() -> None:
 
 
 def _ensure_repo_on_path() -> None:
-    here = Path(__file__).resolve()
-    for parent in here.parents:
-        candidate = parent / "agilab"
-        if candidate.is_dir():
-            src_root = candidate.parent
-            repo_root = src_root.parent
-            for entry in (str(src_root), str(repo_root)):
-                if entry not in sys.path:
-                    sys.path.insert(0, entry)
-            break
+    _page_ensure_repo_on_path(__file__)
 
 
 _ensure_repo_on_path()
 
 
 def _resolve_active_app(argv: list[str] | None = None) -> Path:
-    parser = argparse.ArgumentParser(add_help=False)
-    parser.add_argument("--active-app", dest="active_app", type=str, required=True)
-    args, _ = parser.parse_known_args(argv)
-    active_app_path = Path(args.active_app).expanduser().resolve()
-    if not active_app_path.exists():
-        raise FileNotFoundError(f"Provided --active-app path not found: {active_app_path}")
-    return active_app_path
+    return resolve_active_app_path(argv)
 
 
 def _read_toml(path: Path) -> dict[str, Any]:

--- a/src/agilab/apps-pages/view_autoencoder_latentspace/pyproject.toml
+++ b/src/agilab/apps-pages/view_autoencoder_latentspace/pyproject.toml
@@ -16,11 +16,11 @@ dependencies = [
     "agi-env>=2026.05.12.post3,<2027.0",
     "agi-node>=2026.05.12.post3,<2027.0",
     "agi-gui>=2026.05.12.post3,<2027.0",
-    "barviz>=1.2.2",
-    "sqlalchemy>=2.0.43",
-    "keras>=3.11.3",
+    "barviz>=1.2.2,<1.3",
+    "sqlalchemy>=2.0.43,<3",
+    "keras>=3.11.3,<4",
     "tensorflow==2.19.1",
-    "scikit-learn>=1.7.2",
+    "scikit-learn>=1.7.2,<2",
 ]
 
 [project.entry-points."agilab.pages"]

--- a/src/agilab/apps-pages/view_barycentric/pyproject.toml
+++ b/src/agilab/apps-pages/view_barycentric/pyproject.toml
@@ -17,10 +17,10 @@ dependencies = [
     "agi-node>=2026.05.12.post3,<2027.0",
     "agi-gui>=2026.05.12.post3,<2027.0",
     "plotly>=6.3.0",
-    "barviz>=1.2.2",
-    "scikit-learn>=1.7.2",
+    "barviz>=1.2.2,<1.3",
+    "scikit-learn>=1.7.2,<2",
     "scipy>=1.16,<2",
-    "sqlalchemy>=2.0.43",
+    "sqlalchemy>=2.0.43,<3",
 ]
 
 [project.entry-points."agilab.pages"]

--- a/src/agilab/apps-pages/view_data_io_decision/pyproject.toml
+++ b/src/agilab/apps-pages/view_data_io_decision/pyproject.toml
@@ -13,6 +13,7 @@ keywords = [
     "reproducibility",
 ]
 dependencies = [
+    "agi-pages>=2026.05.23,<2027.0",
     "agi-env>=2026.05.12.post3,<2027.0",
     "agi-node>=2026.05.12.post3,<2027.0",
     "agi-gui>=2026.05.12.post3,<2027.0",
@@ -39,6 +40,7 @@ Changelog = "https://github.com/ThalesGroup/agilab/releases"
 
 
 [tool.uv.sources]
+agi-pages = { path = "../../lib/agi-pages", editable = true }
 agi-gui = { path = "../../lib/agi-gui", editable = true }
 agi-env = { path = "../../core/agi-env", editable = true }
 agi-node = { path = "../../core/agi-node", editable = true }

--- a/src/agilab/apps-pages/view_data_io_decision/src/view_data_io_decision/view_data_io_decision.py
+++ b/src/agilab/apps-pages/view_data_io_decision/src/view_data_io_decision/view_data_io_decision.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-import argparse
 import json
 import sys
 from pathlib import Path
@@ -12,19 +11,17 @@ from typing import Any
 
 import pandas as pd
 import streamlit as st
+from agi_pages.runtime import (
+    artifact_root as _page_artifact_root,
+    discover_files as _page_discover_files,
+    ensure_repo_on_path as _page_ensure_repo_on_path,
+    relative_label as _page_relative_label,
+    resolve_active_app_path,
+)
 
 
 def _ensure_repo_on_path() -> None:
-    here = Path(__file__).resolve()
-    for parent in here.parents:
-        candidate = parent / "agilab"
-        if candidate.is_dir():
-            src_root = candidate.parent
-            repo_root = src_root.parent
-            for entry in (str(src_root), str(repo_root)):
-                if entry not in sys.path:
-                    sys.path.insert(0, entry)
-            break
+    _page_ensure_repo_on_path(__file__)
 
 
 _ensure_repo_on_path()
@@ -38,25 +35,15 @@ SUMMARY_GLOB_KEY = "decision_evidence_summary_glob"
 
 
 def _resolve_active_app() -> Path:
-    parser = argparse.ArgumentParser(add_help=False)
-    parser.add_argument("--active-app", dest="active_app", type=str, required=True)
-    args, _ = parser.parse_known_args()
-    active_app_path = Path(args.active_app).expanduser().resolve()
-    if not active_app_path.exists():
-        st.error(f"Provided --active-app path not found: {active_app_path}")
-        st.stop()
-    return active_app_path
+    return resolve_active_app_path(error_fn=st.error, stop_fn=st.stop)
 
 
 def _default_artifact_root(env: AgiEnv) -> Path:
-    return Path(env.AGILAB_EXPORT_ABS) / env.target / "data_io_decision"
+    return _page_artifact_root(env, "data_io_decision")
 
 
 def _discover_files(base: Path, pattern: str) -> list[Path]:
-    try:
-        return sorted([path for path in base.glob(pattern) if path.is_file()], key=lambda p: p.as_posix())
-    except (OSError, RuntimeError, TypeError, ValueError):
-        return []
+    return _page_discover_files(base, pattern)
 
 
 def _load_json(path: Path) -> dict[str, Any]:
@@ -69,10 +56,7 @@ def _peer_path(summary_path: Path, suffix: str, extension: str) -> Path:
 
 
 def _relative_summary_label(path: Path, artifact_root: Path) -> str:
-    try:
-        return str(path.relative_to(artifact_root))
-    except (RuntimeError, TypeError, ValueError):
-        return path.name
+    return _page_relative_label(path, artifact_root)
 
 
 def _format_delta(value: Any, *, suffix: str = "%") -> str | None:

--- a/src/agilab/apps-pages/view_forecast_analysis/pyproject.toml
+++ b/src/agilab/apps-pages/view_forecast_analysis/pyproject.toml
@@ -13,6 +13,7 @@ keywords = [
     "reproducibility",
 ]
 dependencies = [
+    "agi-pages>=2026.05.23,<2027.0",
     "agi-env>=2026.05.12.post3,<2027.0",
     "agi-gui>=2026.05.12.post3,<2027.0",
     "agi-node>=2026.05.12.post3,<2027.0",
@@ -39,6 +40,7 @@ Changelog = "https://github.com/ThalesGroup/agilab/releases"
 
 
 [tool.uv.sources]
+agi-pages = { path = "../../lib/agi-pages", editable = true }
 agi-gui = { path = "../../lib/agi-gui", editable = true }
 agi-env = { path = "../../core/agi-env", editable = true }
 agi-node = { path = "../../core/agi-node", editable = true }

--- a/src/agilab/apps-pages/view_forecast_analysis/src/view_forecast_analysis/view_forecast_analysis.py
+++ b/src/agilab/apps-pages/view_forecast_analysis/src/view_forecast_analysis/view_forecast_analysis.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-import argparse
 import json
 import sys
 from pathlib import Path
@@ -12,19 +11,17 @@ from typing import Any
 
 import pandas as pd
 import streamlit as st
+from agi_pages.runtime import (
+    artifact_root as _page_artifact_root,
+    discover_files as _page_discover_files,
+    ensure_repo_on_path as _page_ensure_repo_on_path,
+    resolve_active_app_path,
+    safe_float,
+)
 
 
 def _ensure_repo_on_path() -> None:
-    here = Path(__file__).resolve()
-    for parent in here.parents:
-        candidate = parent / "agilab"
-        if candidate.is_dir():
-            src_root = candidate.parent
-            repo_root = src_root.parent
-            for entry in (str(src_root), str(repo_root)):
-                if entry not in sys.path:
-                    sys.path.insert(0, entry)
-            break
+    _page_ensure_repo_on_path(__file__)
 
 
 _ensure_repo_on_path()
@@ -34,32 +31,19 @@ from agi_gui.pagelib import render_logo
 
 
 def _resolve_active_app() -> Path:
-    parser = argparse.ArgumentParser(add_help=False)
-    parser.add_argument("--active-app", dest="active_app", type=str, required=True)
-    args, _ = parser.parse_known_args()
-    active_app_path = Path(args.active_app).expanduser().resolve()
-    if not active_app_path.exists():
-        st.error(f"Provided --active-app path not found: {active_app_path}")
-        st.stop()
-    return active_app_path
+    return resolve_active_app_path(error_fn=st.error, stop_fn=st.stop)
 
 
 def _default_artifact_root(env: AgiEnv) -> Path:
-    return Path(env.AGILAB_EXPORT_ABS) / env.target / "forecast_analysis"
+    return _page_artifact_root(env, "forecast_analysis")
 
 
 def _discover_files(base: Path, pattern: str) -> list[Path]:
-    try:
-        return sorted([path for path in base.glob(pattern) if path.is_file()], key=lambda p: p.as_posix())
-    except (OSError, RuntimeError, TypeError, ValueError):
-        return []
+    return _page_discover_files(base, pattern)
 
 
 def _safe_float(value: Any) -> float | None:
-    try:
-        return float(value)
-    except (TypeError, ValueError, OverflowError):
-        return None
+    return safe_float(value)
 
 
 def _load_metrics(path: Path) -> dict[str, Any]:

--- a/src/agilab/apps-pages/view_queue_resilience/pyproject.toml
+++ b/src/agilab/apps-pages/view_queue_resilience/pyproject.toml
@@ -13,6 +13,7 @@ keywords = [
     "reproducibility",
 ]
 dependencies = [
+    "agi-pages>=2026.05.23,<2027.0",
     "agi-env>=2026.05.12.post3,<2027.0",
     "agi-gui>=2026.05.12.post3,<2027.0",
     "agi-node>=2026.05.12.post3,<2027.0",
@@ -39,6 +40,7 @@ Changelog = "https://github.com/ThalesGroup/agilab/releases"
 
 
 [tool.uv.sources]
+agi-pages = { path = "../../lib/agi-pages", editable = true }
 agi-gui = { path = "../../lib/agi-gui", editable = true }
 agi-env = { path = "../../core/agi-env", editable = true }
 agi-node = { path = "../../core/agi-node", editable = true }

--- a/src/agilab/apps-pages/view_queue_resilience/src/view_queue_resilience/view_queue_resilience.py
+++ b/src/agilab/apps-pages/view_queue_resilience/src/view_queue_resilience/view_queue_resilience.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-import argparse
 import importlib.util
 import json
 import sys
@@ -13,19 +12,17 @@ from typing import Any
 
 import pandas as pd
 import streamlit as st
+from agi_pages.runtime import (
+    artifact_root as _page_artifact_root,
+    discover_files as _page_discover_files,
+    ensure_repo_on_path as _page_ensure_repo_on_path,
+    resolve_active_app_path,
+    safe_metric,
+)
 
 
 def _ensure_repo_on_path() -> None:
-    here = Path(__file__).resolve()
-    for parent in here.parents:
-        candidate = parent / "agilab"
-        if candidate.is_dir():
-            src_root = candidate.parent
-            repo_root = src_root.parent
-            for entry in (str(src_root), str(repo_root)):
-                if entry not in sys.path:
-                    sys.path.insert(0, entry)
-            break
+    _page_ensure_repo_on_path(__file__)
 
 
 _ensure_repo_on_path()
@@ -53,25 +50,15 @@ PAGE_LOGO, PAGE_TITLE = _load_page_meta()
 
 
 def _resolve_active_app() -> Path:
-    parser = argparse.ArgumentParser(add_help=False)
-    parser.add_argument("--active-app", dest="active_app", type=str, required=True)
-    args, _ = parser.parse_known_args()
-    active_app_path = Path(args.active_app).expanduser().resolve()
-    if not active_app_path.exists():
-        st.error(f"Provided --active-app path not found: {active_app_path}")
-        st.stop()
-    return active_app_path
+    return resolve_active_app_path(error_fn=st.error, stop_fn=st.stop)
 
 
 def _default_artifact_root(env: AgiEnv) -> Path:
-    return Path(env.AGILAB_EXPORT_ABS) / env.target / "queue_analysis"
+    return _page_artifact_root(env, "queue_analysis")
 
 
 def _discover_files(base: Path, pattern: str) -> list[Path]:
-    try:
-        return sorted([path for path in base.glob(pattern) if path.is_file()], key=lambda p: p.as_posix())
-    except (OSError, RuntimeError, TypeError, ValueError):
-        return []
+    return _page_discover_files(base, pattern)
 
 
 def _load_json(path: Path) -> dict[str, Any]:
@@ -84,10 +71,7 @@ def _peer_csv(path: Path, suffix: str) -> Path:
 
 
 def _safe_metric(value: Any) -> str:
-    try:
-        return f"{float(value):.3f}"
-    except (TypeError, ValueError, OverflowError):
-        return "n/a"
+    return safe_metric(value)
 
 
 st.set_page_config(layout="wide")

--- a/src/agilab/apps-pages/view_relay_resilience/pyproject.toml
+++ b/src/agilab/apps-pages/view_relay_resilience/pyproject.toml
@@ -13,6 +13,7 @@ keywords = [
     "reproducibility",
 ]
 dependencies = [
+    "agi-pages>=2026.05.23,<2027.0",
     "agi-env>=2026.05.12.post3,<2027.0",
     "agi-gui>=2026.05.12.post3,<2027.0",
     "agi-node>=2026.05.12.post3,<2027.0",
@@ -39,6 +40,7 @@ Changelog = "https://github.com/ThalesGroup/agilab/releases"
 
 
 [tool.uv.sources]
+agi-pages = { path = "../../lib/agi-pages", editable = true }
 agi-gui = { path = "../../lib/agi-gui", editable = true }
 agi-env = { path = "../../core/agi-env", editable = true }
 agi-node = { path = "../../core/agi-node", editable = true }

--- a/src/agilab/apps-pages/view_relay_resilience/src/view_relay_resilience/view_relay_resilience.py
+++ b/src/agilab/apps-pages/view_relay_resilience/src/view_relay_resilience/view_relay_resilience.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-import argparse
 import json
 import sys
 from pathlib import Path
@@ -12,19 +11,18 @@ from typing import Any
 
 import pandas as pd
 import streamlit as st
+from agi_pages.runtime import (
+    artifact_root as _page_artifact_root,
+    discover_files as _page_discover_files,
+    ensure_repo_on_path as _page_ensure_repo_on_path,
+    relative_label as _page_relative_label,
+    resolve_active_app_path,
+    safe_metric,
+)
 
 
 def _ensure_repo_on_path() -> None:
-    here = Path(__file__).resolve()
-    for parent in here.parents:
-        candidate = parent / "agilab"
-        if candidate.is_dir():
-            src_root = candidate.parent
-            repo_root = src_root.parent
-            for entry in (str(src_root), str(repo_root)):
-                if entry not in sys.path:
-                    sys.path.insert(0, entry)
-            break
+    _page_ensure_repo_on_path(__file__)
 
 
 _ensure_repo_on_path()
@@ -38,25 +36,15 @@ REFERENCE_RUN_KEY = "relay_resilience_reference_run"
 
 
 def _resolve_active_app() -> Path:
-    parser = argparse.ArgumentParser(add_help=False)
-    parser.add_argument("--active-app", dest="active_app", type=str, required=True)
-    args, _ = parser.parse_known_args()
-    active_app_path = Path(args.active_app).expanduser().resolve()
-    if not active_app_path.exists():
-        st.error(f"Provided --active-app path not found: {active_app_path}")
-        st.stop()
-    return active_app_path
+    return resolve_active_app_path(error_fn=st.error, stop_fn=st.stop)
 
 
 def _default_artifact_root(env: AgiEnv) -> Path:
-    return Path(env.AGILAB_EXPORT_ABS) / env.target / "queue_analysis"
+    return _page_artifact_root(env, "queue_analysis")
 
 
 def _discover_files(base: Path, pattern: str) -> list[Path]:
-    try:
-        return sorted([path for path in base.glob(pattern) if path.is_file()], key=lambda p: p.as_posix())
-    except (OSError, RuntimeError, TypeError, ValueError):
-        return []
+    return _page_discover_files(base, pattern)
 
 
 def _load_json(path: Path) -> dict[str, Any]:
@@ -69,17 +57,11 @@ def _peer_csv(path: Path, suffix: str) -> Path:
 
 
 def _safe_metric(value: Any) -> str:
-    try:
-        return f"{float(value):.3f}"
-    except (TypeError, ValueError, OverflowError):
-        return "n/a"
+    return safe_metric(value)
 
 
 def _relative_summary_label(path: Path, artifact_root: Path) -> str:
-    try:
-        return str(path.relative_to(artifact_root))
-    except (RuntimeError, TypeError, ValueError):
-        return path.name
+    return _page_relative_label(path, artifact_root)
 
 
 def _coerce_selection(saved_value: Any, options: list[str], *, fallback: str | None = None) -> list[str]:

--- a/src/agilab/apps-pages/view_scenario_cockpit/pyproject.toml
+++ b/src/agilab/apps-pages/view_scenario_cockpit/pyproject.toml
@@ -13,6 +13,7 @@ keywords = [
     "reproducibility",
 ]
 dependencies = [
+    "agi-pages>=2026.05.23,<2027.0",
     "agi-env>=2026.05.12.post3,<2027.0",
     "agi-gui>=2026.05.12.post3,<2027.0",
     "agi-node>=2026.05.12.post3,<2027.0",
@@ -36,6 +37,7 @@ Changelog = "https://github.com/ThalesGroup/agilab/releases"
 
 
 [tool.uv.sources]
+agi-pages = { path = "../../lib/agi-pages", editable = true }
 agi-gui = { path = "../../lib/agi-gui", editable = true }
 agi-env = { path = "../../core/agi-env", editable = true }
 agi-node = { path = "../../core/agi-node", editable = true }

--- a/src/agilab/apps-pages/view_scenario_cockpit/src/view_scenario_cockpit/evidence.py
+++ b/src/agilab/apps-pages/view_scenario_cockpit/src/view_scenario_cockpit/evidence.py
@@ -6,14 +6,18 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
 import hashlib
 import json
-import math
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
 import pandas as pd
+from agi_pages.runtime import (
+    discover_files,
+    relative_label,
+    safe_float,
+)
 
 
 EVIDENCE_SCHEMA = "agilab.scenario_evidence_bundle.v1"
@@ -30,13 +34,6 @@ PIPELINE_ARTIFACTS = (
 )
 
 
-def discover_files(base: Path, pattern: str) -> list[Path]:
-    try:
-        return sorted([path for path in base.glob(pattern) if path.is_file()], key=lambda p: p.as_posix())
-    except (OSError, RuntimeError, TypeError, ValueError):
-        return []
-
-
 def load_json(path: Path) -> dict[str, Any]:
     return json.loads(path.read_text(encoding="utf-8"))
 
@@ -44,13 +41,6 @@ def load_json(path: Path) -> dict[str, Any]:
 def peer_file(path: Path, suffix: str) -> Path:
     stem = path.name.removesuffix("_summary_metrics.json")
     return path.with_name(f"{stem}_{suffix}.csv")
-
-
-def relative_label(path: Path, artifact_root: Path) -> str:
-    try:
-        return str(path.relative_to(artifact_root))
-    except (RuntimeError, TypeError, ValueError):
-        return path.name
 
 
 def scenario_row(summary_path: Path, artifact_root: Path) -> dict[str, Any]:
@@ -121,16 +111,6 @@ def build_comparison_frame(
         "summary_path",
     ]
     return comparison_df[[column for column in ordered_columns if column in comparison_df.columns]]
-
-
-def safe_float(value: Any) -> float | None:
-    try:
-        numeric = float(value)
-    except (TypeError, ValueError, OverflowError):
-        return None
-    if math.isnan(numeric) or math.isinf(numeric):
-        return None
-    return numeric
 
 
 def json_safe(value: Any) -> Any:

--- a/src/agilab/apps-pages/view_scenario_cockpit/src/view_scenario_cockpit/view_scenario_cockpit.py
+++ b/src/agilab/apps-pages/view_scenario_cockpit/src/view_scenario_cockpit/view_scenario_cockpit.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-import argparse
 import importlib.util
 import json
 import sys
@@ -13,19 +12,15 @@ from typing import Any
 
 import pandas as pd
 import streamlit as st
+from agi_pages.runtime import (
+    artifact_root as _page_artifact_root,
+    ensure_repo_on_path as _page_ensure_repo_on_path,
+    resolve_active_app_path,
+)
 
 
 def _ensure_repo_on_path() -> None:
-    here = Path(__file__).resolve()
-    for parent in here.parents:
-        candidate = parent / "agilab"
-        if candidate.is_dir():
-            src_root = candidate.parent
-            repo_root = src_root.parent
-            for entry in (str(src_root), str(repo_root)):
-                if entry not in sys.path:
-                    sys.path.insert(0, entry)
-            break
+    _page_ensure_repo_on_path(__file__)
 
 
 _ensure_repo_on_path()
@@ -77,18 +72,11 @@ PAGE_LOGO, PAGE_TITLE = _load_page_meta()
 
 
 def _resolve_active_app() -> Path:
-    parser = argparse.ArgumentParser(add_help=False)
-    parser.add_argument("--active-app", dest="active_app", type=str, required=True)
-    args, _ = parser.parse_known_args()
-    active_app_path = Path(args.active_app).expanduser().resolve()
-    if not active_app_path.exists():
-        st.error(f"Provided --active-app path not found: {active_app_path}")
-        st.stop()
-    return active_app_path
+    return resolve_active_app_path(error_fn=st.error, stop_fn=st.stop)
 
 
 def _default_artifact_root(env: AgiEnv) -> Path:
-    return Path(env.AGILAB_EXPORT_ABS) / env.target / "queue_analysis"
+    return _page_artifact_root(env, "queue_analysis")
 
 
 def _coerce_selection(saved_value: Any, options: list[str], *, fallback: list[str] | None = None) -> list[str]:

--- a/src/agilab/apps-pages/view_shap_explanation/pyproject.toml
+++ b/src/agilab/apps-pages/view_shap_explanation/pyproject.toml
@@ -13,6 +13,7 @@ keywords = [
     "reproducibility",
 ]
 dependencies = [
+    "agi-pages>=2026.05.23,<2027.0",
     "agi-env>=2026.05.13,<2027.0",
     "agi-gui>=2026.05.13,<2027.0",
     "agi-node>=2026.05.13,<2027.0",
@@ -39,6 +40,7 @@ Changelog = "https://github.com/ThalesGroup/agilab/releases"
 
 
 [tool.uv.sources]
+agi-pages = { path = "../../lib/agi-pages", editable = true }
 agi-gui = { path = "../../lib/agi-gui", editable = true }
 agi-env = { path = "../../core/agi-env", editable = true }
 agi-node = { path = "../../core/agi-node", editable = true }

--- a/src/agilab/apps-pages/view_shap_explanation/src/view_shap_explanation/view_shap_explanation.py
+++ b/src/agilab/apps-pages/view_shap_explanation/src/view_shap_explanation/view_shap_explanation.py
@@ -4,14 +4,20 @@
 
 from __future__ import annotations
 
-import argparse
-import json
 import sys
 from pathlib import Path
 from typing import Any
 
 import pandas as pd
 import streamlit as st
+from agi_pages.runtime import (
+    artifact_root as _page_artifact_root,
+    discover_files as _page_discover_files,
+    ensure_repo_on_path as _page_ensure_repo_on_path,
+    load_json_object,
+    resolve_active_app_path,
+    safe_float,
+)
 
 
 FEATURE_ALIASES = ("feature", "feature_name", "column", "name")
@@ -28,16 +34,7 @@ WIDE_EXCLUDE_COLUMNS = {
 
 
 def _ensure_repo_on_path() -> None:
-    here = Path(__file__).resolve()
-    for parent in here.parents:
-        candidate = parent / "agilab"
-        if candidate.is_dir():
-            src_root = candidate.parent
-            repo_root = src_root.parent
-            for entry in (str(src_root), str(repo_root)):
-                if entry not in sys.path:
-                    sys.path.insert(0, entry)
-            break
+    _page_ensure_repo_on_path(__file__)
 
 
 _ensure_repo_on_path()
@@ -47,32 +44,19 @@ from agi_gui.pagelib import render_logo
 
 
 def _resolve_active_app() -> Path:
-    parser = argparse.ArgumentParser(add_help=False)
-    parser.add_argument("--active-app", dest="active_app", type=str, required=True)
-    args, _ = parser.parse_known_args()
-    active_app_path = Path(args.active_app).expanduser().resolve()
-    if not active_app_path.exists():
-        st.error(f"Provided --active-app path not found: {active_app_path}")
-        st.stop()
-    return active_app_path
+    return resolve_active_app_path(error_fn=st.error, stop_fn=st.stop)
 
 
 def _default_artifact_root(env: AgiEnv) -> Path:
-    return Path(env.AGILAB_EXPORT_ABS) / env.target / "shap_explanation"
+    return _page_artifact_root(env, "shap_explanation")
 
 
 def _discover_files(base: Path, pattern: str) -> list[Path]:
-    try:
-        return sorted([path for path in base.glob(pattern) if path.is_file()], key=lambda p: p.as_posix())
-    except (OSError, RuntimeError, TypeError, ValueError):
-        return []
+    return _page_discover_files(base, pattern)
 
 
 def _safe_float(value: Any) -> float | None:
-    try:
-        return float(value)
-    except (TypeError, ValueError, OverflowError):
-        return None
+    return safe_float(value)
 
 
 def _first_existing_column(df: pd.DataFrame, aliases: tuple[str, ...]) -> str | None:
@@ -91,13 +75,7 @@ def _load_table(path: Path) -> pd.DataFrame:
 
 
 def _load_json(path: Path | None) -> dict[str, Any]:
-    if path is None:
-        return {}
-    try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError, TypeError, ValueError):
-        return {}
-    return payload if isinstance(payload, dict) else {}
+    return load_json_object(path)
 
 
 def _coerce_shap_frame(df: pd.DataFrame) -> pd.DataFrame:

--- a/src/agilab/apps-pages/view_training_analysis/pyproject.toml
+++ b/src/agilab/apps-pages/view_training_analysis/pyproject.toml
@@ -13,6 +13,7 @@ keywords = [
     "reproducibility",
 ]
 dependencies = [
+    "agi-pages>=2026.05.23,<2027.0",
     "agi-env>=2026.05.12.post3,<2027.0",
     "agi-node>=2026.05.12.post3,<2027.0",
     "agi-gui>=2026.05.12.post3,<2027.0",
@@ -41,6 +42,7 @@ Changelog = "https://github.com/ThalesGroup/agilab/releases"
 
 
 [tool.uv.sources]
+agi-pages = { path = "../../lib/agi-pages", editable = true }
 agi-gui = { path = "../../lib/agi-gui", editable = true }
 agi-env = { path = "../../core/agi-env", editable = true }
 agi-node = { path = "../../core/agi-node", editable = true }

--- a/src/agilab/apps-pages/view_training_analysis/src/view_training_analysis/view_training_analysis.py
+++ b/src/agilab/apps-pages/view_training_analysis/src/view_training_analysis/view_training_analysis.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-import argparse
 from collections import Counter
 import math
 import sys
@@ -18,6 +17,10 @@ from plotly.subplots import make_subplots
 import streamlit as st
 import tomllib
 from agi_env.app_settings_support import prepare_app_settings_for_write
+from agi_pages.runtime import (
+    ensure_repo_on_path as _page_ensure_repo_on_path,
+    resolve_active_app_path,
+)
 
 try:
     import tomli_w as _toml_writer  # type: ignore[import-not-found]
@@ -52,16 +55,7 @@ EMBED_QUERY_VALUES = {"1", "true", "yes", "on"}
 
 
 def _ensure_repo_on_path() -> None:
-    here = Path(__file__).resolve()
-    for parent in here.parents:
-        candidate = parent / "agilab"
-        if candidate.is_dir():
-            src_root = candidate.parent
-            repo_root = src_root.parent
-            for entry in (str(src_root), str(repo_root)):
-                if entry not in sys.path:
-                    sys.path.insert(0, entry)
-            break
+    _page_ensure_repo_on_path(__file__)
 
 
 _ensure_repo_on_path()
@@ -71,14 +65,7 @@ from agi_gui.pagelib import render_logo
 
 
 def _resolve_active_app() -> Path:
-    parser = argparse.ArgumentParser(add_help=False)
-    parser.add_argument("--active-app", dest="active_app", type=str, required=True)
-    args, _ = parser.parse_known_args()
-    active_app_path = Path(args.active_app).expanduser().resolve()
-    if not active_app_path.exists():
-        st.error(f"Provided --active-app path not found: {active_app_path}")
-        st.stop()
-    return active_app_path
+    return resolve_active_app_path(error_fn=st.error, stop_fn=st.stop)
 
 
 def _ensure_app_settings_loaded(env: AgiEnv) -> None:

--- a/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/app_surface.py
+++ b/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/app_surface.py
@@ -189,7 +189,7 @@ def _render_run_button(
 ) -> None:
     import streamlit as st
 
-    if not container.button("Refresh evidence", type="primary", use_container_width=True):
+    if not container.button("Refresh evidence", type="primary", width="stretch"):
         return
     try:
         runtime_env, args_model = _load_orchestrate_args(active_app_path)

--- a/src/agilab/apps/builtin/tescia_diagnostic_project/src/tescia_diagnostic/app_surface.py
+++ b/src/agilab/apps/builtin/tescia_diagnostic_project/src/tescia_diagnostic/app_surface.py
@@ -563,7 +563,7 @@ def render(*, mode: str = "analysis", active_app: Path | None = None, **_kwargs:
             learner_level=learner_level,
             curriculum_id=curriculum_id,
         )
-        st.dataframe(catalog_rows(filtered), use_container_width=True, hide_index=True)
+        st.dataframe(catalog_rows(filtered), width="stretch", hide_index=True)
 
     with answer_tab:
         case_ids = [str(case["case_id"]) for case in cases]
@@ -584,7 +584,7 @@ def render(*, mode: str = "analysis", active_app: Path | None = None, **_kwargs:
             ),
             confidence=st.slider("Confidence", 0.0, 1.0, float(case.get("student_answer", {}).get("confidence", 0.75))),
         )
-        if st.button("Evaluate answer", type="primary", use_container_width=True):
+        if st.button("Evaluate answer", type="primary", width="stretch"):
             try:
                 scored = score_student_submission(case, answer)
             except ValueError as exc:
@@ -598,13 +598,13 @@ def render(*, mode: str = "analysis", active_app: Path | None = None, **_kwargs:
                     diagnostic_report_to_markdown(scored),
                     file_name=f"{selected_id}_correction.md",
                     mime="text/markdown",
-                    use_container_width=True,
+                    width="stretch",
                 )
 
     with classroom_tab:
         actions, refresh_options = st.columns([1.2, 2.0])
         with actions:
-            if st.button("Refresh classroom artifacts", key="tescia_classroom_refresh", use_container_width=True):
+            if st.button("Refresh classroom artifacts", key="tescia_classroom_refresh", width="stretch"):
                 try:
                     st.cache_data.clear()
                 except Exception:
@@ -632,7 +632,7 @@ def render(*, mode: str = "analysis", active_app: Path | None = None, **_kwargs:
                     accept_multiple_files=True,
                     key="tescia_classroom_uploads",
                 )
-                if st.button("Save classroom uploads", key="tescia_save_classroom_uploads", use_container_width=True):
+                if st.button("Save classroom uploads", key="tescia_save_classroom_uploads", width="stretch"):
                     try:
                         saved_paths = save_classroom_uploads(list(uploads or []), classroom_inbox_dir)
                     except Exception as exc:
@@ -658,22 +658,22 @@ def render(*, mode: str = "analysis", active_app: Path | None = None, **_kwargs:
         m2.metric("Students", classroom_report["unique_student_count"])
         m3.metric("Average score", classroom_report["average_score"])
         m4.metric("Needs attention", classroom_report["needs_attention_count"])
-        st.dataframe(classroom_progress_rows(classroom_report), use_container_width=True, hide_index=True)
-        st.dataframe(classroom_heatmap_rows(classroom_report), use_container_width=True, hide_index=True)
-        st.dataframe(classroom_intervention_rows(classroom_report), use_container_width=True, hide_index=True)
+        st.dataframe(classroom_progress_rows(classroom_report), width="stretch", hide_index=True)
+        st.dataframe(classroom_heatmap_rows(classroom_report), width="stretch", hide_index=True)
+        st.dataframe(classroom_intervention_rows(classroom_report), width="stretch", hide_index=True)
         st.download_button(
             "Download teacher summary",
             classroom_report_to_markdown(classroom_report),
             file_name="classroom_teacher_summary.md",
             mime="text/markdown",
-            use_container_width=True,
+            width="stretch",
         )
         st.download_button(
             "Download classroom batch JSON",
             json.dumps(classroom_submission_template(cases), indent=2, sort_keys=True),
             file_name="tescia_classroom_submissions.json",
             mime="application/json",
-            use_container_width=True,
+            width="stretch",
         )
         if live_refresh:
             time.sleep(float(refresh_seconds))
@@ -709,7 +709,7 @@ def render(*, mode: str = "analysis", active_app: Path | None = None, **_kwargs:
                 {"curriculum_id": key, "exercise_count": value}
                 for key, value in coverage["curriculum_id_counts"].items()
             ],
-            use_container_width=True,
+            width="stretch",
             hide_index=True,
         )
 

--- a/src/agilab/core/agi-cluster/pyproject.toml
+++ b/src/agilab/core/agi-cluster/pyproject.toml
@@ -35,7 +35,7 @@ keywords = [
     "job-scheduling",
     "mlops",
 ]
-dependencies = ["agi-env==2026.05.23", "agi-node==2026.05.23", "asyncssh", "dask[distributed]", "humanize", "numpy", "packaging", "polars", "psutil", "scikit-learn", "tomlkit"]
+dependencies = ["agi-env==2026.05.23", "agi-node==2026.05.23", "asyncssh>=2.23,<3", "dask[distributed]>=2026.3,<2027.0", "humanize>=4.10,<5", "numpy>=2.2,<3", "packaging>=25,<27", "polars>=1.35,<2", "psutil>=7,<8", "scikit-learn>=1.7.2,<2", "tomlkit>=0.13,<1"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/core/agi-env/pyproject.toml
+++ b/src/agilab/core/agi-env/pyproject.toml
@@ -37,12 +37,12 @@ keywords = [
 ]
 
 dependencies = [
-    "pathspec",
-    "psutil",
-    "py7zr",
-    "pydantic",
-    "python-dotenv",
-    "tomlkit",
+    "pathspec>=1.1,<2",
+    "psutil>=7,<8",
+    "py7zr>=1.1,<2",
+    "pydantic>=2.11,<3",
+    "python-dotenv>=1,<2",
+    "tomlkit>=0.13,<1",
 ]
 
 [project.urls]

--- a/src/agilab/core/agi-node/pyproject.toml
+++ b/src/agilab/core/agi-node/pyproject.toml
@@ -35,7 +35,7 @@ keywords = [
     "pandas",
     "polars",
 ]
-dependencies = ["agi-env==2026.05.23", "cython", "humanize", "numpy", "pandas", "parso", "polars", "psutil", "py7zr", "setuptools"]
+dependencies = ["agi-env==2026.05.23", "cython>=3.1,<4", "humanize>=4.10,<5", "numpy>=2.2,<3", "pandas>=2.3,<4", "parso>=0.8,<1", "polars>=1.35,<2", "psutil>=7,<8", "py7zr>=1.1,<2", "setuptools>=68,<82"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/examples/README.md
+++ b/src/agilab/examples/README.md
@@ -26,6 +26,7 @@ the command shape stable.
 | 11 | `mlflow_auto_tracking` | any pipeline app | Optional tracking preview: local evidence first, MLflow as the memory backend. |
 | 12 | `resilience_failure_injection` | UAV relay scenario contract | Read-only resilience preview: inject a relay failure, compare fixed/replanned/search/policy responses. |
 | 13 | `train_then_serve` | trained policy handoff contract | Read-only service handoff preview: model artifact, IO contract, prediction sample, and health gate. |
+| 14 | `native_rust_worker` | optional native worker preview | Read-only Rust/PyO3 skeleton: keep AGILAB orchestration in Python while moving only a typed hot kernel to Rust. |
 
 ## Execution Map
 
@@ -35,7 +36,7 @@ app execution from read-only contract previews.
 | Class | Examples | What actually runs | Primary output |
 |---|---|---|---|
 | Installed `AGI_*.py` helpers | `flight_telemetry`, `mycode`, `weather_forecast`, `mission_decision` | Real `AGI.install` / `AGI.run` calls from `~/log/execute/<app>/` after the app installer seeds the scripts. | App artifacts in AGILAB share/export paths plus execution logs. |
-| Source/package read-only previews | `notebook_to_dask`, `excel_workbook_proof`, `inter_project_dag`, `service_mode`, `mlflow_auto_tracking`, `resilience_failure_injection`, `train_then_serve` | Deterministic Python preview scripts. They write local evidence and do not launch long-lived workers or hidden multi-app runs. | Preview JSON, CSV, or workbook artifacts under `~/log/execute/<example>/` or the configured output path. |
+| Source/package read-only previews | `notebook_to_dask`, `excel_workbook_proof`, `inter_project_dag`, `service_mode`, `mlflow_auto_tracking`, `resilience_failure_injection`, `train_then_serve`, `native_rust_worker` | Deterministic Python preview scripts. They write local evidence and do not launch long-lived workers or hidden multi-app runs. | Preview JSON, CSV, workbook, or generated skeleton artifacts under `~/log/execute/<example>/` or the configured output path. |
 | Notebook migration assets | `notebook_migrations/skforecast_meteo_fr` | Packaged notebooks, artifacts, `lab_stages.toml`, and pipeline view used as migration source material. | Files to inspect or import; no service or cluster run is started by reading them. |
 
 Source-checkout commands use `uv --preview-features extra-build-dependencies run python ...`
@@ -95,6 +96,11 @@ From an installed package, locate one with
 - `train_then_serve/preview_train_then_serve.py` reads a
   `uav_relay_queue_project` built-in service template and shows the handoff
   from a trained policy artifact to a service contract.
+- `native_rust_worker/preview_native_rust_worker.py` writes a PyO3/maturin
+  skeleton for a worker-owned native hot kernel, plus evidence that keeps the
+  AGILAB boundary explicit: orchestration and artifacts stay in Python, the
+  measured CPU-bound kernel can move to Rust when the packaging cost is worth
+  it.
 - `data_in` and `data_out` are share-root relative paths, so examples stay
   portable across machines.
 - Run modes use named AGI constants instead of magic numbers, and keep Cython
@@ -141,7 +147,9 @@ workers for an already-working app. Use `mlflow_auto_tracking` when you want
 to show tracking as optional memory around AGILAB execution, not a competing
 experiment system. Use `resilience_failure_injection` when you want to explain
 fixed versus adaptive behavior on the same degraded scenario before training or
-serving a policy. Use `excel_workbook_proof` when the stakeholder lives in
+serving a policy. Use `native_rust_worker` when you want to explain the advanced
+native-worker lane without adding Rust to the base install. Use
+`excel_workbook_proof` when the stakeholder lives in
 Excel and needs to see workbook output plus refreshable CSV and evidence before
 they care about notebooks, DAGs, or clusters. Use `train_then_serve` when you
 want to explain what must be frozen after training before a policy becomes

--- a/src/agilab/examples/native_rust_worker/README.md
+++ b/src/agilab/examples/native_rust_worker/README.md
@@ -1,0 +1,130 @@
+# Native Rust Worker Example
+
+## Purpose
+
+Shows the optional Rust/PyO3 acceleration lane for an AGILAB worker:
+
+```text
+Python AGILAB worker -> typed hot kernel in Rust -> Python evidence and artifacts
+```
+
+The preview writes a small `maturin` project with a PyO3 extension module, a
+worker wrapper, a sample payload, and machine-readable evidence. It does not
+compile Rust by default, so the packaged example stays runnable on machines
+without a Rust toolchain.
+
+## What You Learn
+
+- Rust can be used as a worker-owned hot-kernel implementation without moving
+  AGILAB orchestration, dataframe I/O, reducers, or evidence out of Python.
+- `maturin` plus PyO3 is the production-oriented Rust extension path.
+- This is an advanced, optional lane. It should not become a base AGILAB
+  dependency and should not replace the existing Cython worker proof.
+- The useful boundary is small: move only typed, CPU-bound code that has a
+  measured bottleneck.
+
+## Install
+
+There is no AGILAB project install for this preview. Install AGILAB first. To
+only generate the skeleton, Python is enough.
+
+To build the generated native module afterwards, install Rust and `maturin`:
+
+```bash
+uv tool install maturin
+```
+
+## Run
+
+From a source checkout:
+
+```bash
+uv --preview-features extra-build-dependencies run python src/agilab/examples/native_rust_worker/preview_native_rust_worker.py
+```
+
+From an installed AGILAB package, locate the packaged script:
+
+```bash
+python -c "from pathlib import Path; import agilab; print(Path(agilab.__file__).with_name('examples') / 'native_rust_worker' / 'preview_native_rust_worker.py')"
+```
+
+Then run it:
+
+```bash
+python preview_native_rust_worker.py
+```
+
+## Expected Input
+
+The script creates a deterministic numeric payload:
+
+- `values`
+- `weights`
+- `passes`
+
+It does not read private data and does not require a compiler for the preview
+step.
+
+## Expected Output
+
+The script writes:
+
+```text
+~/log/execute/native_rust_worker/native_rust_worker_evidence.json
+~/log/execute/native_rust_worker/rust_worker/pyproject.toml
+~/log/execute/native_rust_worker/rust_worker/Cargo.toml
+~/log/execute/native_rust_worker/rust_worker/src/lib.rs
+~/log/execute/native_rust_worker/rust_worker/python/agilab_native_worker_demo/__init__.py
+~/log/execute/native_rust_worker/rust_worker/worker_wrapper.py
+~/log/execute/native_rust_worker/rust_worker/sample_payload.json
+```
+
+Read `native_rust_worker_evidence.json` first. It records the Python reference
+checksum, the generated file hashes, the build backend, and the AGILAB boundary
+between Python orchestration and Rust native code.
+
+## Expected Preview
+
+The generated project is a proof skeleton, not a published wheel:
+
+| Artifact | Purpose |
+|---|---|
+| `Cargo.toml` | Rust crate metadata and PyO3 dependency. |
+| `pyproject.toml` | `maturin` build configuration for Python packaging. |
+| `src/lib.rs` | Native `score_kernel` exposed as a Python function. |
+| `worker_wrapper.py` | Python side of the worker-owned hot-kernel call. |
+| `native_rust_worker_evidence.json` | Hashes and adoption-boundary evidence. |
+
+## Read The Script
+
+Open `preview_native_rust_worker.py` and look for these functions first:
+
+- `python_reference_score()` keeps a Python checksum for the same kernel.
+- `build_preview()` writes the Rust/PyO3 project skeleton and evidence.
+- `main()` exposes the deterministic preview as a local command.
+
+## Change One Thing
+
+Run the preview with a custom output directory:
+
+```bash
+uv --preview-features extra-build-dependencies run python src/agilab/examples/native_rust_worker/preview_native_rust_worker.py --output-dir /tmp/agilab-rust-worker
+```
+
+Then open `/tmp/agilab-rust-worker/rust_worker/src/lib.rs`, change the kernel,
+and rebuild from inside the generated `rust_worker` directory:
+
+```bash
+maturin develop --release
+python worker_wrapper.py --payload sample_payload.json --output native_result.json
+```
+
+## Troubleshooting
+
+- If `maturin` is missing, install it with `uv tool install maturin`.
+- If Rust is missing, install the Rust toolchain before building the generated
+  module. The preview itself does not require Rust.
+- If import fails after editing `src/lib.rs`, rerun `maturin develop --release`
+  from inside the generated `rust_worker` directory.
+- If the native score differs from the Python reference, treat that as a kernel
+  correctness bug before benchmarking speed.

--- a/src/agilab/examples/native_rust_worker/preview_native_rust_worker.py
+++ b/src/agilab/examples/native_rust_worker/preview_native_rust_worker.py
@@ -1,0 +1,310 @@
+from __future__ import annotations
+
+import argparse
+from hashlib import sha256
+import json
+from pathlib import Path
+from textwrap import dedent
+from typing import Any, Sequence
+
+
+DEFAULT_OUTPUT_DIR = Path.home() / "log" / "execute" / "native_rust_worker"
+SCHEMA = "agilab.example.native_rust_worker.evidence.v1"
+CREATED_AT = "2026-01-01T00:00:00Z"
+SAMPLE_VALUES = tuple(float(index) / 10.0 for index in range(1, 129))
+SAMPLE_WEIGHTS = tuple(1.0 + ((index % 7) * 0.125) for index in range(1, 129))
+DEFAULT_PASSES = 24
+
+
+PYPROJECT_TOML = """\
+[build-system]
+requires = ["maturin>=1.9,<2"]
+build-backend = "maturin"
+
+[project]
+name = "agilab-native-worker-demo"
+version = "0.1.0"
+requires-python = ">=3.11"
+description = "Optional Rust/PyO3 hot-kernel demo for an AGILAB worker."
+readme = "README.md"
+
+[tool.maturin]
+python-source = "python"
+module-name = "agilab_native_worker_demo._native"
+features = ["pyo3/extension-module"]
+"""
+
+
+CARGO_TOML = """\
+[package]
+name = "agilab-native-worker-demo"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+name = "_native"
+crate-type = ["cdylib"]
+path = "src/lib.rs"
+
+[dependencies]
+pyo3 = { version = "0.28", features = ["extension-module"] }
+"""
+
+
+RUST_LIB_RS = """\
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+
+#[pyfunction]
+fn score_kernel(values: Vec<f64>, weights: Vec<f64>, passes: usize) -> PyResult<f64> {
+    if values.len() != weights.len() {
+        return Err(PyValueError::new_err("values and weights must have the same length"));
+    }
+    let mut score = 0.0_f64;
+    for pass_index in 0..passes {
+        let scale = 1.0 + (pass_index as f64 * 0.0001);
+        for (value, weight) in values.iter().zip(weights.iter()) {
+            let adjusted = value * weight * scale;
+            score += adjusted.sin().abs() + adjusted.cos().abs() * 0.5;
+        }
+    }
+    Ok(score)
+}
+
+#[pymodule]
+fn _native(module: &Bound<'_, PyModule>) -> PyResult<()> {
+    module.add_function(wrap_pyfunction!(score_kernel, module)?)?;
+    Ok(())
+}
+"""
+
+
+PYTHON_INIT = """\
+from __future__ import annotations
+
+
+try:
+    from ._native import score_kernel
+except ImportError as exc:  # pragma: no cover - requires a local Rust build
+    raise RuntimeError(
+        "The Rust extension is not built. Run `maturin develop --release` "
+        "inside the generated rust_worker directory first."
+    ) from exc
+
+
+__all__ = ["score_kernel"]
+"""
+
+
+WORKER_WRAPPER = """\
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+
+
+def python_reference_score(values: list[float], weights: list[float], passes: int) -> float:
+    score = 0.0
+    for pass_index in range(passes):
+        scale = 1.0 + (pass_index * 0.0001)
+        for value, weight in zip(values, weights, strict=True):
+            adjusted = value * weight * scale
+            score += abs(math.sin(adjusted)) + abs(math.cos(adjusted)) * 0.5
+    return score
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run the generated Rust hot-kernel wrapper.")
+    parser.add_argument("--payload", type=Path, default=Path("sample_payload.json"))
+    parser.add_argument("--output", type=Path, default=Path("native_result.json"))
+    args = parser.parse_args()
+
+    payload = json.loads(args.payload.read_text(encoding="utf-8"))
+    values = [float(value) for value in payload["values"]]
+    weights = [float(value) for value in payload["weights"]]
+    passes = int(payload["passes"])
+
+    from agilab_native_worker_demo import score_kernel
+
+    native_score = score_kernel(values, weights, passes)
+    reference_score = python_reference_score(values, weights, passes)
+    args.output.write_text(
+        json.dumps(
+            {
+                "native_score": native_score,
+                "python_reference_score": reference_score,
+                "absolute_delta": abs(native_score - reference_score),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\\n",
+        encoding="utf-8",
+    )
+    print(args.output)
+
+
+if __name__ == "__main__":
+    main()
+"""
+
+
+README = """\
+# AGILAB Native Rust Worker Skeleton
+
+This generated project is a worker-owned hot-kernel skeleton. AGILAB keeps the
+app orchestration, dataframe I/O, artifact paths, and evidence in Python; the
+small CPU-bound kernel lives in Rust and is exposed to Python through PyO3.
+
+It is intentionally not part of the AGILAB base install. Build it only when a
+worker has a measured hot loop that benefits from native code.
+
+## Build
+
+```bash
+uv tool install maturin
+maturin develop --release
+```
+
+## Run
+
+```bash
+python worker_wrapper.py --payload sample_payload.json --output native_result.json
+```
+
+## AGILAB Integration Pattern
+
+1. Keep the normal AGILAB worker class and reducer artifacts in Python.
+2. Move only the typed, CPU-bound kernel into `src/lib.rs`.
+3. Import the built extension from the worker implementation.
+4. Record the runtime, checksum, dtype contract, and fallback path in the
+   reducer output.
+"""
+
+
+def python_reference_score(
+    values: Sequence[float],
+    weights: Sequence[float],
+    passes: int,
+) -> float:
+    import math
+
+    if len(values) != len(weights):
+        raise ValueError("values and weights must have the same length")
+    score = 0.0
+    for pass_index in range(passes):
+        scale = 1.0 + (pass_index * 0.0001)
+        for value, weight in zip(values, weights, strict=True):
+            adjusted = value * weight * scale
+            score += abs(math.sin(adjusted)) + abs(math.cos(adjusted)) * 0.5
+    return score
+
+
+def _write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(dedent(text).strip() + "\n", encoding="utf-8")
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _hash_file(path: Path) -> str:
+    digest = sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _artifact(path: Path) -> dict[str, str]:
+    return {"path": str(path), "sha256": _hash_file(path)}
+
+
+def build_preview(*, output_dir: Path = DEFAULT_OUTPUT_DIR) -> dict[str, Any]:
+    output_dir = output_dir.expanduser()
+    rust_worker = output_dir / "rust_worker"
+    package_dir = rust_worker / "python" / "agilab_native_worker_demo"
+    source_dir = rust_worker / "src"
+
+    payload = {
+        "values": list(SAMPLE_VALUES),
+        "weights": list(SAMPLE_WEIGHTS),
+        "passes": DEFAULT_PASSES,
+    }
+    score = python_reference_score(SAMPLE_VALUES, SAMPLE_WEIGHTS, DEFAULT_PASSES)
+    reference = {
+        "sample_count": len(SAMPLE_VALUES),
+        "passes": DEFAULT_PASSES,
+        "python_reference_score": round(score, 12),
+        "checksum": sha256(f"{score:.12f}".encode("utf-8")).hexdigest(),
+    }
+
+    files = {
+        "pyproject": rust_worker / "pyproject.toml",
+        "cargo": rust_worker / "Cargo.toml",
+        "readme": rust_worker / "README.md",
+        "rust_lib": source_dir / "lib.rs",
+        "python_init": package_dir / "__init__.py",
+        "worker_wrapper": rust_worker / "worker_wrapper.py",
+        "sample_payload": rust_worker / "sample_payload.json",
+    }
+    _write_text(files["pyproject"], PYPROJECT_TOML)
+    _write_text(files["cargo"], CARGO_TOML)
+    _write_text(files["readme"], README)
+    _write_text(files["rust_lib"], RUST_LIB_RS)
+    _write_text(files["python_init"], PYTHON_INIT)
+    _write_text(files["worker_wrapper"], WORKER_WRAPPER)
+    _write_json(files["sample_payload"], payload)
+
+    artifacts = {name: _artifact(path) for name, path in files.items()}
+    evidence = {
+        "schema": SCHEMA,
+        "created_at": CREATED_AT,
+        "execution_model": "python_worker_with_optional_rust_hot_kernel",
+        "base_install_impact": "none",
+        "requires_rust_toolchain_for_native_run": True,
+        "recommended_build_backend": "maturin",
+        "python_binding": "PyO3",
+        "agilab_boundary": {
+            "stays_in_python": [
+                "AGILAB app orchestration",
+                "worker class",
+                "dataframe I/O",
+                "artifact and evidence writing",
+            ],
+            "moves_to_rust": ["typed CPU-bound hot kernel"],
+        },
+        "python_reference": reference,
+        "artifacts": artifacts,
+        "commands": [
+            "uv tool install maturin",
+            "cd rust_worker && maturin develop --release",
+            "cd rust_worker && python worker_wrapper.py --payload sample_payload.json --output native_result.json",
+        ],
+        "notes": [
+            "This preview does not compile Rust by default.",
+            "Use Cython first when the worker hot path already maps cleanly to typed Python.",
+            "Use Rust/PyO3 when ownership, safety, or a reusable native crate justifies the packaging cost.",
+        ],
+    }
+    evidence_path = output_dir / "native_rust_worker_evidence.json"
+    _write_json(evidence_path, evidence)
+    evidence["artifacts"]["evidence"] = _artifact(evidence_path)
+    _write_json(evidence_path, evidence)
+    return evidence
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Create the AGILAB Rust/PyO3 worker preview.")
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    args = parser.parse_args()
+    evidence = build_preview(output_dir=args.output_dir)
+    print(json.dumps(evidence, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground/app_surface.py
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground/app_surface.py
@@ -189,7 +189,7 @@ def _render_run_button(
 ) -> None:
     import streamlit as st
 
-    if not container.button("Refresh evidence", type="primary", use_container_width=True):
+    if not container.button("Refresh evidence", type="primary", width="stretch"):
         return
     try:
         runtime_env, args_model = _load_orchestrate_args(active_app_path)

--- a/src/agilab/lib/agi-apps/pyproject.toml
+++ b/src/agilab/lib/agi-apps/pyproject.toml
@@ -134,6 +134,7 @@ packages = [
     "excel_workbook_proof/*.py",
     "inter_project_dag/*.py",
     "mlflow_auto_tracking/*.py",
+    "native_rust_worker/*.py",
     "notebook_to_dask/*.py",
     "notebook_to_dask/*.json",
     "notebook_to_dask/*.toml",

--- a/src/agilab/lib/agi-gui/pyproject.toml
+++ b/src/agilab/lib/agi-gui/pyproject.toml
@@ -32,7 +32,7 @@ keywords = [
     "python",
 ]
 
-dependencies = ["agi-env==2026.05.23", "streamlit>=1.56,<1.57", "streamlit_code_editor", "watchdog"]
+dependencies = ["agi-env==2026.05.23", "streamlit>=1.56,<1.57", "streamlit_code_editor>=0.1.22,<0.2", "watchdog>=6,<7"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/lib/agi-pages/src/agi_pages/__init__.py
+++ b/src/agilab/lib/agi-pages/src/agi_pages/__init__.py
@@ -21,6 +21,16 @@ from .chart_spec import (
     render_notebook,
     render_streamlit,
 )
+from .runtime import (
+    artifact_root,
+    discover_files,
+    ensure_repo_on_path,
+    load_json_object,
+    relative_label,
+    resolve_active_app_path,
+    safe_float,
+    safe_metric,
+)
 
 PAGE_BUNDLE_ENTRYPOINT_NAMES = ("{module}.py", "main.py", "app.py")
 PAGE_BUNDLE_ENTRYPOINT_GROUP = "agilab.pages"
@@ -323,15 +333,23 @@ __all__ = [
     "ChartData",
     "ChartSpec",
     "PageBundle",
+    "artifact_root",
     "build_chart_spec",
     "bundles_root",
     "chart_spec_to_static_html",
+    "discover_files",
+    "ensure_repo_on_path",
     "inline_renderer_target",
     "iter_bundles",
+    "load_json_object",
     "normalize_chart_data",
     "option_from_data",
+    "relative_label",
     "render_notebook",
     "render_streamlit",
+    "resolve_active_app_path",
     "resolve_bundle",
+    "safe_float",
+    "safe_metric",
     "script_path",
 ]

--- a/src/agilab/lib/agi-pages/src/agi_pages/runtime.py
+++ b/src/agilab/lib/agi-pages/src/agi_pages/runtime.py
@@ -1,0 +1,105 @@
+"""Shared runtime helpers for AGILAB analysis page bundles."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+from typing import Any, Callable
+
+
+def ensure_repo_on_path(anchor: str | Path) -> None:
+    """Add the AGILAB source and repository roots for direct source launches."""
+
+    here = Path(anchor).resolve()
+    for parent in here.parents:
+        candidate = parent / "agilab"
+        if candidate.is_dir():
+            src_root = candidate.parent
+            repo_root = src_root.parent
+            for entry in (str(src_root), str(repo_root)):
+                if entry not in sys.path:
+                    sys.path.insert(0, entry)
+            break
+
+
+def resolve_active_app_path(
+    argv: list[str] | None = None,
+    *,
+    error_fn: Callable[[str], Any] | None = None,
+    stop_fn: Callable[[], Any] | None = None,
+) -> Path:
+    """Resolve ``--active-app`` from page CLI arguments."""
+
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--active-app", dest="active_app", type=str, required=True)
+    args, _ = parser.parse_known_args(argv)
+    active_app_path = Path(args.active_app).expanduser().resolve()
+    if active_app_path.exists():
+        return active_app_path
+
+    message = f"Provided --active-app path not found: {active_app_path}"
+    if error_fn is not None:
+        error_fn(message)
+    if stop_fn is not None:
+        stop_fn()
+    raise FileNotFoundError(message)
+
+
+def artifact_root(env: Any, page_subdir: str) -> Path:
+    """Return the conventional export root for one page bundle."""
+
+    return Path(env.AGILAB_EXPORT_ABS) / env.target / page_subdir
+
+
+def discover_files(base: Path, pattern: str) -> list[Path]:
+    """Return matching files in deterministic order, swallowing invalid glob roots."""
+
+    try:
+        return sorted([path for path in base.glob(pattern) if path.is_file()], key=lambda path: path.as_posix())
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return []
+
+
+def load_json_object(path: Path | None) -> dict[str, Any]:
+    """Read a JSON object from disk, returning an empty object for missing or non-object payloads."""
+
+    if path is None:
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, TypeError, ValueError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def relative_label(path: Path, artifact_root_path: Path) -> str:
+    """Return a stable label relative to an artifact root when possible."""
+
+    try:
+        return str(path.relative_to(artifact_root_path))
+    except (RuntimeError, TypeError, ValueError):
+        return path.name
+
+
+def safe_float(value: Any) -> float | None:
+    """Coerce a value to float for page metrics."""
+
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    if math.isnan(numeric) or math.isinf(numeric):
+        return None
+    return numeric
+
+
+def safe_metric(value: Any, *, digits: int = 3) -> str:
+    """Format a numeric page metric or return ``n/a``."""
+
+    numeric = safe_float(value)
+    if numeric is None:
+        return "n/a"
+    return f"{numeric:.{digits}f}"

--- a/test/test_agi_pages_runtime.py
+++ b/test/test_agi_pages_runtime.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from agi_pages import runtime
+
+
+def test_agi_pages_runtime_resolves_active_app_and_reports_missing(tmp_path: Path) -> None:
+    app = tmp_path / "demo_project"
+    app.mkdir()
+
+    assert runtime.resolve_active_app_path(["--active-app", str(app)]) == app.resolve()
+
+    errors: list[str] = []
+    stops = 0
+
+    def stop() -> None:
+        nonlocal stops
+        stops += 1
+
+    with pytest.raises(FileNotFoundError, match="Provided --active-app path not found"):
+        runtime.resolve_active_app_path(
+            ["--active-app", str(tmp_path / "missing")],
+            error_fn=errors.append,
+            stop_fn=stop,
+        )
+
+    assert stops == 1
+    assert errors and "Provided --active-app path not found" in errors[0]
+
+    with pytest.raises(FileNotFoundError, match="Provided --active-app path not found"):
+        runtime.resolve_active_app_path(["--active-app", str(tmp_path / "missing_without_callbacks")])
+
+
+def test_agi_pages_runtime_file_helpers_are_deterministic(tmp_path: Path) -> None:
+    root = tmp_path / "artifacts"
+    (root / "b").mkdir(parents=True)
+    (root / "a").mkdir()
+    b_file = root / "b" / "metrics.json"
+    a_file = root / "a" / "metrics.json"
+    b_file.write_text('{"run": "b"}', encoding="utf-8")
+    a_file.write_text('{"run": "a"}', encoding="utf-8")
+    list_file = root / "list.json"
+    malformed_file = root / "malformed.json"
+    list_file.write_text("[1, 2]", encoding="utf-8")
+    malformed_file.write_text("{", encoding="utf-8")
+
+    class BrokenBase:
+        def glob(self, _pattern: str):
+            raise OSError("glob unavailable")
+
+    assert runtime.artifact_root(
+        SimpleNamespace(AGILAB_EXPORT_ABS=tmp_path / "export", target="demo"),
+        "forecast",
+    ) == tmp_path / "export" / "demo" / "forecast"
+    assert runtime.discover_files(root, "**/metrics.json") == [a_file, b_file]
+    assert runtime.discover_files(root / "missing", "[") == []
+    assert runtime.discover_files(BrokenBase(), "*.json") == []
+    assert runtime.load_json_object(a_file) == {"run": "a"}
+    assert runtime.load_json_object(None) == {}
+    assert runtime.load_json_object(tmp_path / "missing.json") == {}
+    assert runtime.load_json_object(list_file) == {}
+    assert runtime.load_json_object(malformed_file) == {}
+    assert runtime.relative_label(a_file, root) == "a/metrics.json"
+    assert runtime.relative_label(tmp_path / "outside.json", root) == "outside.json"
+    assert runtime.safe_float("1.25") == 1.25
+    assert runtime.safe_float(float("nan")) is None
+    assert runtime.safe_float(float("inf")) is None
+    assert runtime.safe_float(object()) is None
+    assert runtime.safe_metric("bad") == "n/a"
+    assert runtime.safe_metric(1.23456, digits=2) == "1.23"
+
+
+def test_agi_pages_runtime_ensure_repo_on_path(monkeypatch, tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    src_root = repo_root / "src"
+    page_file = src_root / "agilab" / "apps-pages" / "view_demo" / "src" / "view_demo" / "view_demo.py"
+    page_file.parent.mkdir(parents=True)
+    page_file.write_text("# page\n", encoding="utf-8")
+
+    monkeypatch.setattr(sys, "path", [])
+    runtime.ensure_repo_on_path(page_file)
+
+    assert str(src_root) in sys.path
+    assert str(repo_root) in sys.path
+    first_path = list(sys.path)
+
+    runtime.ensure_repo_on_path(page_file)
+
+    assert sys.path == first_path
+
+
+def test_agi_pages_runtime_ensure_repo_on_path_ignores_unmatched_anchor(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(sys, "path", [])
+
+    runtime.ensure_repo_on_path(tmp_path / "outside.py")
+
+    assert sys.path == []

--- a/test/test_agilab_web_robot.py
+++ b/test/test_agilab_web_robot.py
@@ -790,7 +790,14 @@ class _FakeFileChooserContext:
 
 
 class _FakeBrowserPage:
-    def __init__(self, *, chooser_error: Exception | None = None, url_error: Exception | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        chooser_error: Exception | None = None,
+        goto_error: Exception | None = None,
+        selector_error: Exception | None = None,
+        url_error: Exception | None = None,
+    ) -> None:
         self.url = "about:blank"
         self.body_text = ""
         self.launch_headless: bool | None = None
@@ -798,9 +805,13 @@ class _FakeBrowserPage:
         self.selected_files: list[str] = []
         self.visited: list[str] = []
         self.chooser_error = chooser_error
+        self.goto_error = goto_error
+        self.selector_error = selector_error
         self.url_error = url_error
 
     def goto(self, url: str, *, wait_until: str, timeout: float) -> None:
+        if self.goto_error is not None:
+            raise self.goto_error
         assert wait_until == "domcontentloaded"
         self.url = url
         self.visited.append(url)
@@ -814,6 +825,11 @@ class _FakeBrowserPage:
             self.body_text = "First proof Upload"
 
     def wait_for_selector(self, selector: str, *, timeout: float) -> None:
+        if (
+            self.selector_error is not None
+            and selector == "[data-testid='stFileUploader'], [data-testid='stFileUploaderDropzone']"
+        ):
+            raise self.selector_error
         assert selector in {
             "[data-testid='stApp']",
             "[data-testid='stFileUploader'], [data-testid='stFileUploaderDropzone']",
@@ -896,6 +912,65 @@ def test_run_browser_robot_reports_upload_handoff_failure(monkeypatch, tmp_path:
     assert "screenshot=" in steps[-1].detail
 
 
+def test_run_browser_robot_reports_upload_button_failure(monkeypatch, tmp_path: Path) -> None:
+    module = _load_module()
+    page = _FakeBrowserPage()
+    PlaywrightError, _TimeoutError = _install_fake_playwright(monkeypatch, module, page)
+    page.chooser_error = PlaywrightError("chooser blocked")
+
+    steps = module.run_browser_robot(
+        base_url="http://demo",
+        active_app_query="flight",
+        browser_name="chromium",
+        headless=True,
+        timeout=1.0,
+        screenshot_dir=tmp_path,
+    )
+
+    assert steps[-1].label == "about upload button"
+    assert steps[-1].success is False
+    assert "could not open file chooser" in steps[-1].detail
+    assert "screenshot=" in steps[-1].detail
+
+
+def test_run_browser_robot_reports_project_uploader_failure(monkeypatch, tmp_path: Path) -> None:
+    module = _load_module()
+    page = _FakeBrowserPage()
+    PlaywrightError, _TimeoutError = _install_fake_playwright(monkeypatch, module, page)
+    page.selector_error = PlaywrightError("uploader missing")
+
+    steps = module.run_browser_robot(
+        base_url="http://demo",
+        active_app_query="flight",
+        browser_name="chromium",
+        headless=True,
+        timeout=1.0,
+        screenshot_dir=tmp_path,
+    )
+
+    assert steps[-1].label == "project notebook uploader"
+    assert steps[-1].success is False
+    assert "PROJECT notebook uploader not visible" in steps[-1].detail
+    assert "screenshot=" in steps[-1].detail
+
+
+def test_run_browser_robot_reports_outer_playwright_failure(monkeypatch) -> None:
+    module = _load_module()
+    page = _FakeBrowserPage()
+    PlaywrightError, _TimeoutError = _install_fake_playwright(monkeypatch, module, page)
+    page.goto_error = PlaywrightError("browser crashed")
+
+    steps = module.run_browser_robot(
+        base_url="http://demo",
+        active_app_query="flight",
+        browser_name="webkit",
+        headless=True,
+        timeout=1.0,
+    )
+
+    assert steps == [module.RobotStep("browser robot", False, 0.0, "playwright failed: browser crashed", "http://demo")]
+
+
 def test_run_frontend_smoke_covers_browser_hydration(monkeypatch) -> None:
     module = _load_module()
     page = _FakeBrowserPage()
@@ -929,15 +1004,68 @@ def test_run_frontend_smoke_covers_browser_hydration(monkeypatch) -> None:
     assert page.launch_headless is False
 
 
-def test_main_local_json_handles_health_success_and_process_exit(capsys, monkeypatch) -> None:
+def test_run_frontend_smoke_returns_static_asset_failure_without_browser(monkeypatch) -> None:
     module = _load_module()
+    static_step = module.RobotStep("frontend static assets", False, 0.01, "bad MIME", "http://demo/")
+    monkeypatch.setattr(module, "assert_frontend_static_assets", lambda *_args, **_kwargs: static_step)
+    monkeypatch.setattr(
+        module,
+        "_load_playwright",
+        lambda: (_ for _ in ()).throw(AssertionError("browser should not load")),
+    )
 
+    steps = module.run_frontend_smoke(
+        base_url="http://demo",
+        active_app_query="flight",
+        browser_name="chromium",
+        headless=True,
+        timeout=1.0,
+    )
+
+    assert steps == [static_step]
+
+
+def test_run_frontend_smoke_reports_playwright_failure(monkeypatch) -> None:
+    module = _load_module()
+    page = _FakeBrowserPage()
+    PlaywrightError, _TimeoutError = _install_fake_playwright(monkeypatch, module, page)
+    page.goto_error = PlaywrightError("hydration crashed")
+    monkeypatch.setattr(
+        module,
+        "assert_frontend_static_assets",
+        lambda landing_url, *, opener: module.RobotStep(
+            "frontend static assets",
+            True,
+            0.01,
+            "ok",
+            landing_url,
+        ),
+    )
+
+    steps = module.run_frontend_smoke(
+        base_url="http://demo",
+        active_app_query="flight",
+        browser_name="chromium",
+        headless=True,
+        timeout=1.0,
+    )
+
+    assert steps[-1] == module.RobotStep(
+        "frontend browser hydration",
+        False,
+        0.0,
+        "playwright failed: hydration crashed",
+        "http://demo/?active_app=flight",
+    )
+
+
+def _patch_local_server(monkeypatch, module, *, health_success: bool) -> None:
     class _Process:
         returncode = 9
 
         @staticmethod
-        def poll() -> int:
-            return 9
+        def poll() -> int | None:
+            return None if health_success else 9
 
     class _Server:
         process = _Process()
@@ -962,8 +1090,20 @@ def test_main_local_json_handles_health_success_and_process_exit(capsys, monkeyp
     monkeypatch.setattr(
         module,
         "wait_for_streamlit_health",
-        lambda *_args, **_kwargs: module.RobotStep("streamlit health", False, 0.2, "not ready", "http://demo"),
+        lambda *_args, **_kwargs: module.RobotStep(
+            "streamlit health",
+            health_success,
+            0.2,
+            "HTTP 200" if health_success else "not ready",
+            "http://demo",
+        ),
     )
+
+
+def test_main_local_json_handles_health_success_and_process_exit(capsys, monkeypatch) -> None:
+    module = _load_module()
+
+    _patch_local_server(monkeypatch, module, health_success=False)
 
     code = module.main(["--json", "--port", "8765", "--timeout", "1"])
 
@@ -971,6 +1111,57 @@ def test_main_local_json_handles_health_success_and_process_exit(capsys, monkeyp
     payload = json.loads(capsys.readouterr().out)
     assert [step["label"] for step in payload["steps"]] == ["streamlit health", "streamlit process"]
     assert "process exited with 9" in payload["steps"][1]["detail"]
+
+
+def test_main_local_json_runs_frontend_smoke_after_healthy_server(capsys, monkeypatch, tmp_path: Path) -> None:
+    module = _load_module()
+    _patch_local_server(monkeypatch, module, health_success=True)
+    calls: list[dict] = []
+
+    def fake_frontend_smoke(**kwargs):
+        calls.append(kwargs)
+        return [module.RobotStep("frontend landing hydration", True, 0.3, "ok", kwargs["base_url"])]
+
+    monkeypatch.setattr(module, "run_frontend_smoke", fake_frontend_smoke)
+
+    code = module.main(
+        [
+            "--json",
+            "--frontend-smoke-only",
+            "--port",
+            "8765",
+            "--timeout",
+            "1",
+            "--screenshot-dir",
+            str(tmp_path),
+        ]
+    )
+
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert [step["label"] for step in payload["steps"]] == ["streamlit health", "frontend landing hydration"]
+    assert calls[0]["base_url"] == "http://127.0.0.1:8765"
+    assert calls[0]["screenshot_dir"] == tmp_path.resolve()
+
+
+def test_main_local_json_runs_full_robot_after_healthy_server(capsys, monkeypatch) -> None:
+    module = _load_module()
+    _patch_local_server(monkeypatch, module, health_success=True)
+    calls: list[dict] = []
+
+    def fake_browser_robot(**kwargs):
+        calls.append(kwargs)
+        return [module.RobotStep("analysis page", True, 0.4, "ok", kwargs["base_url"])]
+
+    monkeypatch.setattr(module, "run_browser_robot", fake_browser_robot)
+
+    code = module.main(["--json", "--port", "8765", "--timeout", "1", "--analysis-view", "view_maps"])
+
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert [step["label"] for step in payload["steps"]] == ["streamlit health", "analysis page"]
+    assert calls[0]["analysis_view"] == "view_maps"
+    assert calls[0]["analysis_view_path"] == str(module.ANALYSIS_VIEW_PATHS["view_maps"].resolve())
 
 
 def test_render_human_non_json_output_includes_route_and_step_details(capsys) -> None:

--- a/test/test_agilab_web_robot.py
+++ b/test/test_agilab_web_robot.py
@@ -494,3 +494,507 @@ def test_main_print_only_returns_analysis_view_path_for_remote_app_with_custom_r
     assert code == 0
     payload = json.loads(capsys.readouterr().out)
     assert payload["analysis_view_path"] == "/custom/src/agilab/apps-pages/view_maps_network/src/view_maps_network/view_maps_network.py"
+
+
+def test_frontend_asset_discovery_deduplicates_and_resolves_relative_urls() -> None:
+    module = _load_module()
+
+    class _Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc):
+            return None
+
+        def read(self) -> str:
+            return (
+                '<script type="module" src="./static/js/app.js"></script>'
+                '<script src="./static/js/app.js"></script>'
+                '<link rel="stylesheet" href="/static/css/app.css">'
+            )
+
+    assets = module.discover_frontend_assets(
+        "http://demo/app/?active_app=flight",
+        opener=lambda _url: _Response(),
+    )
+
+    assert [(asset.kind, asset.url) for asset in assets] == [
+        ("script", "http://demo/app/static/js/app.js"),
+        ("stylesheet", "http://demo/static/css/app.css"),
+    ]
+
+
+def test_frontend_static_asset_check_reports_missing_script_and_open_errors() -> None:
+    module = _load_module()
+
+    class _Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc):
+            return None
+
+        def read(self) -> bytes:
+            return b'<link rel="stylesheet" href="/static/css/app.css">'
+
+    missing_script = module.assert_frontend_static_assets("http://demo/", opener=lambda _url: _Response())
+
+    assert missing_script.success is False
+    assert "no JavaScript frontend assets discovered" in missing_script.detail
+
+    failed_open = module.assert_frontend_static_assets(
+        "http://demo/",
+        opener=lambda _url: (_ for _ in ()).throw(RuntimeError("network down")),
+    )
+
+    assert failed_open.success is False
+    assert "frontend asset check failed: network down" in failed_open.detail
+
+
+def test_response_helpers_handle_header_variants_and_text_payloads() -> None:
+    module = _load_module()
+
+    class _HeadersContentType:
+        @staticmethod
+        def get_content_type() -> str:
+            return "Application/JSON"
+
+    class _HeadersGet:
+        @staticmethod
+        def get(_name: str, _default: str = "") -> str:
+            return "text/css; charset=utf-8"
+
+    class _GetHeaderResponse:
+        @staticmethod
+        def getheader(_name: str, _default: str = "") -> str:
+            return "text/javascript; charset=utf-8"
+
+    class _StringResponse:
+        @staticmethod
+        def read() -> str:
+            return "already decoded"
+
+    assert module._response_content_type(type("R", (), {"headers": _HeadersContentType()})()) == "application/json"
+    assert module._response_content_type(type("R", (), {"headers": _HeadersGet()})()) == "text/css"
+    assert module._response_content_type(_GetHeaderResponse()) == "text/javascript"
+    assert module._response_content_type(object()) == ""
+    assert module._read_response_text(_StringResponse()) == "already decoded"
+
+
+def test_screenshot_manifest_failure_does_not_hide_screenshot(tmp_path: Path, monkeypatch) -> None:
+    module = _load_module()
+
+    class _Page:
+        @staticmethod
+        def screenshot(*, path: str, full_page: bool) -> None:
+            assert full_page is True
+            Path(path).write_bytes(b"not a real png")
+
+    monkeypatch.setattr(
+        module,
+        "build_page_shots_manifest",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("manifest failed")),
+    )
+
+    screenshot = module._screenshot(_Page(), tmp_path, "bad page")
+
+    assert screenshot == str(tmp_path / "bad-page.png")
+    assert (tmp_path / "bad-page.png").read_bytes() == b"not a real png"
+    assert not (tmp_path / "screenshot_manifest.json").exists()
+
+
+def test_assert_page_healthy_reports_rejected_and_missing_text(tmp_path: Path) -> None:
+    module = _load_module()
+
+    class _Locator:
+        def __init__(self, text: str = "", count: int = 0) -> None:
+            self.text = text
+            self._count = count
+
+        def count(self) -> int:
+            return self._count
+
+        def inner_text(self, *, timeout: int) -> str:
+            return self.text
+
+    class _Page:
+        url = "http://demo/"
+
+        def __init__(self, body: str) -> None:
+            self.body = body
+            self.waits: list[int] = []
+
+        def wait_for_selector(self, *_args, **_kwargs) -> None:
+            return None
+
+        def wait_for_timeout(self, ms: int) -> None:
+            self.waits.append(ms)
+
+        def screenshot(self, *, path: str, full_page: bool) -> None:
+            assert full_page is True
+            Path(path).write_bytes(b"png")
+
+        def locator(self, selector: str) -> _Locator:
+            if selector == "body":
+                return _Locator(self.body)
+            return _Locator(count=0)
+
+    rejected = module.assert_page_healthy(
+        _Page("Traceback: synthetic failure"),
+        label="analysis rejected",
+        expect_any=("ANALYSIS",),
+        timeout_ms=0,
+        screenshot_dir=tmp_path,
+    )
+    missing = module.assert_page_healthy(
+        _Page("healthy but incomplete"),
+        label="analysis missing",
+        expect_any=("ANALYSIS", "Choose pages"),
+        timeout_ms=0,
+        screenshot_dir=tmp_path,
+    )
+
+    assert rejected.success is False
+    assert "rejected pattern 'traceback'" in rejected.detail
+    assert "screenshot=" in rejected.detail
+    assert missing.success is False
+    assert "missing expected text: ANALYSIS | Choose pages" in missing.detail
+
+
+def test_main_remote_json_uses_patched_browser_robot(capsys, monkeypatch) -> None:
+    module = _load_module()
+
+    monkeypatch.setattr(
+        module,
+        "run_browser_robot",
+        lambda **_kwargs: [module.RobotStep("remote browser", True, 1.25, "ok", "http://demo/")],
+    )
+
+    code = module.main(["--url", "http://demo", "--json", "--target-seconds", "2"])
+
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["success"] is True
+    assert payload["within_target"] is True
+    assert payload["steps"][0]["label"] == "remote browser"
+
+
+def test_main_remote_frontend_smoke_json_reports_setup_failure(capsys, monkeypatch) -> None:
+    module = _load_module()
+
+    def _raise_setup(**_kwargs):
+        raise RuntimeError("Playwright missing")
+
+    monkeypatch.setattr(module, "run_frontend_smoke", _raise_setup)
+
+    code = module.main(["--url", "http://demo", "--frontend-smoke-only", "--json"])
+
+    assert code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["success"] is False
+    assert payload["steps"][0]["label"] == "browser setup"
+    assert payload["steps"][0]["detail"] == "Playwright missing"
+
+
+def _install_fake_playwright(monkeypatch, module, page):
+    class FakePlaywrightError(Exception):
+        pass
+
+    class FakePlaywrightTimeoutError(Exception):
+        pass
+
+    class FakeContext:
+        closed = False
+
+        def new_page(self):
+            return page
+
+        def close(self) -> None:
+            self.closed = True
+
+    class FakeBrowser:
+        closed = False
+
+        def __init__(self) -> None:
+            self.context = FakeContext()
+
+        def new_context(self, *, viewport):
+            assert viewport == {"width": 1440, "height": 1000}
+            return self.context
+
+        def close(self) -> None:
+            self.closed = True
+
+    class FakeBrowserType:
+        def launch(self, *, headless):
+            page.launch_headless = headless
+            return FakeBrowser()
+
+    class FakePlaywright:
+        chromium = FakeBrowserType()
+        firefox = FakeBrowserType()
+        webkit = FakeBrowserType()
+
+    class FakeSyncPlaywright:
+        def __enter__(self):
+            return FakePlaywright()
+
+        def __exit__(self, *_exc):
+            return None
+
+    monkeypatch.setattr(
+        module,
+        "_load_playwright",
+        lambda: (FakePlaywrightError, FakePlaywrightTimeoutError, FakeSyncPlaywright),
+    )
+    return FakePlaywrightError, FakePlaywrightTimeoutError
+
+
+class _FakeLocator:
+    def __init__(self, page, *, selector: str, count: int = 0) -> None:
+        self.page = page
+        self.selector = selector
+        self._count = count
+
+    def count(self) -> int:
+        return self._count
+
+    def inner_text(self, *, timeout: int) -> str:
+        assert self.selector == "body"
+        return self.page.body_text
+
+    def click(self, *, timeout: float) -> None:
+        self.page.clicked_selectors.append((self.selector, timeout))
+
+
+class _FakeFileChooser:
+    def __init__(self, page) -> None:
+        self.page = page
+
+    def set_files(self, path: str) -> None:
+        self.page.selected_files.append(Path(path).name)
+
+
+class _FakeFileChooserContext:
+    def __init__(self, page, error: Exception | None = None) -> None:
+        self.value = _FakeFileChooser(page)
+        self.error = error
+
+    def __enter__(self):
+        if self.error is not None:
+            raise self.error
+        return self
+
+    def __exit__(self, *_exc):
+        return None
+
+
+class _FakeBrowserPage:
+    def __init__(self, *, chooser_error: Exception | None = None, url_error: Exception | None = None) -> None:
+        self.url = "about:blank"
+        self.body_text = ""
+        self.launch_headless: bool | None = None
+        self.clicked_selectors: list[tuple[str, float]] = []
+        self.selected_files: list[str] = []
+        self.visited: list[str] = []
+        self.chooser_error = chooser_error
+        self.url_error = url_error
+
+    def goto(self, url: str, *, wait_until: str, timeout: float) -> None:
+        assert wait_until == "domcontentloaded"
+        self.url = url
+        self.visited.append(url)
+        if "ORCHESTRATE" in url:
+            self.body_text = "ORCHESTRATE INSTALL EXECUTE"
+        elif "ANALYSIS" in url and "current_page=" in url:
+            self.body_text = "View: selected analysis view"
+        elif "ANALYSIS" in url:
+            self.body_text = "ANALYSIS Choose pages View:"
+        else:
+            self.body_text = "First proof Upload"
+
+    def wait_for_selector(self, selector: str, *, timeout: float) -> None:
+        assert selector in {
+            "[data-testid='stApp']",
+            "[data-testid='stFileUploader'], [data-testid='stFileUploaderDropzone']",
+        }
+
+    def wait_for_url(self, _pattern, *, timeout: float) -> None:
+        if self.url_error is not None:
+            raise self.url_error
+        self.url = "http://demo/PROJECT?active_app=flight"
+        self.body_text = "PROJECT notebook uploader"
+
+    def expect_file_chooser(self, *, timeout: float):
+        return _FakeFileChooserContext(self, self.chooser_error)
+
+    def locator(self, selector: str):
+        if selector == "body":
+            return _FakeLocator(self, selector=selector)
+        if selector == "[data-testid='stException']":
+            return _FakeLocator(self, selector=selector, count=0)
+        return _FakeLocator(self, selector=selector)
+
+    def screenshot(self, *, path: str, full_page: bool) -> None:
+        assert full_page is True
+        Path(path).write_bytes(b"png")
+
+
+def test_run_browser_robot_covers_full_happy_path_with_analysis_view(monkeypatch) -> None:
+    module = _load_module()
+    page = _FakeBrowserPage()
+    _install_fake_playwright(monkeypatch, module, page)
+
+    steps = module.run_browser_robot(
+        base_url="http://demo",
+        active_app_query="flight",
+        browser_name="chromium",
+        headless=True,
+        timeout=1.0,
+        analysis_view="view_maps",
+        analysis_view_path="/app/view_maps.py",
+    )
+
+    assert [step.label for step in steps] == [
+        "landing navigation",
+        "landing page",
+        "about upload button",
+        "notebook upload handoff",
+        "project notebook uploader",
+        "orchestrate navigation",
+        "orchestrate page",
+        "analysis navigation",
+        "analysis page",
+        "view_maps navigation",
+        "view_maps analysis view",
+    ]
+    assert all(step.success for step in steps)
+    assert page.launch_headless is True
+    assert page.clicked_selectors == [("[data-testid='stFileUploaderDropzone'] button", 1000.0)]
+    assert page.selected_files == ["agilab-web-robot-upload.ipynb"]
+    assert page.visited[-1].endswith("active_app=flight&current_page=%2Fapp%2Fview_maps.py")
+
+
+def test_run_browser_robot_reports_upload_handoff_failure(monkeypatch, tmp_path: Path) -> None:
+    module = _load_module()
+    page = _FakeBrowserPage()
+    PlaywrightError, _TimeoutError = _install_fake_playwright(monkeypatch, module, page)
+    page.url_error = PlaywrightError("PROJECT did not load")
+
+    steps = module.run_browser_robot(
+        base_url="http://demo",
+        active_app_query="flight",
+        browser_name="chromium",
+        headless=True,
+        timeout=1.0,
+        screenshot_dir=tmp_path,
+    )
+
+    assert steps[-1].label == "notebook upload handoff"
+    assert steps[-1].success is False
+    assert "PROJECT did not open after notebook upload" in steps[-1].detail
+    assert "screenshot=" in steps[-1].detail
+
+
+def test_run_frontend_smoke_covers_browser_hydration(monkeypatch) -> None:
+    module = _load_module()
+    page = _FakeBrowserPage()
+    _install_fake_playwright(monkeypatch, module, page)
+    monkeypatch.setattr(
+        module,
+        "assert_frontend_static_assets",
+        lambda landing_url, *, opener: module.RobotStep(
+            "frontend static assets",
+            True,
+            0.01,
+            "ok",
+            landing_url,
+        ),
+    )
+
+    steps = module.run_frontend_smoke(
+        base_url="http://demo",
+        active_app_query="flight",
+        browser_name="firefox",
+        headless=False,
+        timeout=1.0,
+    )
+
+    assert [step.label for step in steps] == [
+        "frontend static assets",
+        "frontend browser navigation",
+        "frontend landing hydration",
+    ]
+    assert all(step.success for step in steps)
+    assert page.launch_headless is False
+
+
+def test_main_local_json_handles_health_success_and_process_exit(capsys, monkeypatch) -> None:
+    module = _load_module()
+
+    class _Process:
+        returncode = 9
+
+        @staticmethod
+        def poll() -> int:
+            return 9
+
+    class _Server:
+        process = _Process()
+
+        def __init__(self, argv, *, env, url) -> None:
+            self.argv = argv
+            self.env = env
+            self.url = url
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc):
+            return None
+
+        @staticmethod
+        def output_tail() -> str:
+            return "server died"
+
+    monkeypatch.setattr(module, "StreamlitServer", _Server)
+    monkeypatch.setattr(module, "build_server_env", lambda: {"ENV": "1"})
+    monkeypatch.setattr(
+        module,
+        "wait_for_streamlit_health",
+        lambda *_args, **_kwargs: module.RobotStep("streamlit health", False, 0.2, "not ready", "http://demo"),
+    )
+
+    code = module.main(["--json", "--port", "8765", "--timeout", "1"])
+
+    assert code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert [step["label"] for step in payload["steps"]] == ["streamlit health", "streamlit process"]
+    assert "process exited with 9" in payload["steps"][1]["detail"]
+
+
+def test_render_human_non_json_output_includes_route_and_step_details(capsys) -> None:
+    module = _load_module()
+    summary = module.RobotSummary(
+        success=False,
+        total_duration_seconds=2.5,
+        target_seconds=2.0,
+        within_target=False,
+        steps=[module.RobotStep("analysis", False, 2.5, "missing View:", "http://demo/ANALYSIS")],
+    )
+
+    text = module.render_human(
+        summary=summary,
+        launch_command=["uv", "run", "streamlit"],
+        base_url="http://demo",
+    )
+
+    assert "$ uv run streamlit" in text
+    assert "verdict: FAIL" in text
+    assert "within_target=no" in text
+    assert "- analysis: FAIL in 2.50s - missing View:" in text
+
+    assert module.main(["--print-only", "--port", "8765"]) == 0
+    human = capsys.readouterr().out
+    assert "mode: print-only" in human
+    assert "route: landing Upload chooser -> PROJECT notebook handoff -> ORCHESTRATE -> ANALYSIS" in human

--- a/test/test_agilab_widget_robot.py
+++ b/test/test_agilab_widget_robot.py
@@ -63,6 +63,7 @@ def test_settings_page_has_stable_robot_expectations() -> None:
         "Environment variables",
     )
     assert module.PAGE_MIN_WIDGETS["SETTINGS"] == 5
+    assert module.PAGE_MIN_WIDGETS[""] == 2
 
 
 def test_append_route_query_preserves_active_app_and_adds_deep_link() -> None:
@@ -2148,6 +2149,39 @@ def test_wait_for_page_ready_returns_after_initialization_clears() -> None:
     module.wait_for_page_ready(_Page(), timeout_ms=1000)
 
     assert waits
+
+
+def test_wait_for_page_ready_ignores_hidden_initialization_text() -> None:
+    module = _load_module()
+    waits: list[int] = []
+
+    class _HiddenText:
+        def count(self):
+            return 1
+
+        def nth(self, _index):
+            return self
+
+        def is_visible(self, timeout):
+            return False
+
+    class _Spinner:
+        def count(self):
+            return 0
+
+    class _Page:
+        def get_by_text(self, _pattern):
+            return _HiddenText()
+
+        def locator(self, _selector):
+            return _Spinner()
+
+        def wait_for_timeout(self, ms):
+            waits.append(ms)
+
+    module.wait_for_page_ready(_Page(), timeout_ms=1000)
+
+    assert waits == [module.PAGE_READY_STABILIZE_MS]
 
 
 def test_summarize_counts_interactions_and_failures() -> None:

--- a/test/test_agilab_widget_robot_matrix.py
+++ b/test/test_agilab_widget_robot_matrix.py
@@ -40,11 +40,12 @@ def test_default_scenarios_cover_isolated_pages_and_current_home_actions() -> No
     assert isolated.runtime_isolation == "isolated"
     assert isolated.action_button_policy == "trial"
     assert isolated.assert_workflow_artifacts is True
-    assert entry.pages == "HOME"
+    assert entry.pages == "none"
     assert entry.apps_pages == "configured"
     assert entry.runtime_isolation == "isolated"
-    assert entry.action_button_policy == "safe-click"
+    assert entry.action_button_policy == "trial"
     assert entry.action_timeout_seconds == 30.0
+    assert entry.max_action_clicks_per_page == 0
     assert project.pages == "PROJECT"
     assert project.apps_pages == "none"
     assert project.runtime_isolation == "isolated"
@@ -910,11 +911,12 @@ def test_build_robot_command_covers_entry_shell_and_configured_app_pages(tmp_pat
 
     argv, summary_path, progress_path = module.build_robot_command(scenario, options=options)
 
-    assert argv[argv.index("--pages") + 1] == "HOME"
+    assert argv[argv.index("--pages") + 1] == "none"
     assert argv[argv.index("--apps-pages") + 1] == "configured"
     assert argv[argv.index("--runtime-isolation") + 1] == "isolated"
-    assert argv[argv.index("--action-button-policy") + 1] == "safe-click"
+    assert argv[argv.index("--action-button-policy") + 1] == "trial"
     assert argv[argv.index("--action-timeout") + 1] == "30.0"
+    assert argv[argv.index("--max-action-clicks-per-page") + 1] == "0"
     assert argv[argv.index("--screenshot-dir") + 1] == str(
         tmp_path / "screenshots" / "isolated-entry-and-app-pages"
     )

--- a/test/test_app_installer_packaging.py
+++ b/test/test_app_installer_packaging.py
@@ -5,6 +5,7 @@ import asyncio
 import importlib.util
 import json
 import py_compile
+import runpy
 import subprocess
 import sys
 import tomllib
@@ -45,6 +46,7 @@ EXAMPLE_PREVIEWS = {
     "excel_workbook_proof": ("preview_excel_workbook_proof.py",),
     "inter_project_dag": ("preview_inter_project_dag.py",),
     "mlflow_auto_tracking": ("preview_mlflow_auto_tracking.py",),
+    "native_rust_worker": ("preview_native_rust_worker.py",),
     "notebook_to_dask": (
         "preview_notebook_to_dask.py",
         "notebook_to_dask_sample.ipynb",
@@ -728,6 +730,74 @@ def test_excel_workbook_proof_preview_writes_workbook_refresh_and_evidence(tmp_p
     assert evidence["office_add_in_required"] is False
 
 
+def test_native_rust_worker_preview_writes_pyo3_project_and_evidence(tmp_path: Path) -> None:
+    script = EXAMPLES_ROOT / "native_rust_worker" / "preview_native_rust_worker.py"
+    spec = importlib.util.spec_from_file_location("native_rust_worker_preview_test", script)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+
+    preview = module.build_preview(output_dir=tmp_path)
+
+    rust_worker = tmp_path / "rust_worker"
+    evidence_path = tmp_path / "native_rust_worker_evidence.json"
+    rust_source = rust_worker / "src" / "lib.rs"
+    pyproject = rust_worker / "pyproject.toml"
+    assert evidence_path.is_file()
+    assert rust_source.is_file()
+    assert pyproject.is_file()
+    assert (rust_worker / "Cargo.toml").is_file()
+    assert (rust_worker / "worker_wrapper.py").is_file()
+    assert (rust_worker / "sample_payload.json").is_file()
+    assert (rust_worker / "python" / "agilab_native_worker_demo" / "__init__.py").is_file()
+    assert "build-backend = \"maturin\"" in pyproject.read_text(encoding="utf-8")
+    assert "#[pyfunction]" in rust_source.read_text(encoding="utf-8")
+    evidence = json.loads(evidence_path.read_text(encoding="utf-8"))
+    assert evidence["schema"] == module.SCHEMA
+    assert evidence["base_install_impact"] == "none"
+    assert evidence["requires_rust_toolchain_for_native_run"] is True
+    assert evidence["recommended_build_backend"] == "maturin"
+    assert evidence["python_binding"] == "PyO3"
+    assert evidence["python_reference"]["checksum"] == preview["python_reference"]["checksum"]
+    assert "rust_lib" in evidence["artifacts"]
+
+
+def test_native_rust_worker_preview_cli_and_reference_validation(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    script = EXAMPLES_ROOT / "native_rust_worker" / "preview_native_rust_worker.py"
+    spec = importlib.util.spec_from_file_location("native_rust_worker_preview_cli_test", script)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+
+    assert module.python_reference_score([1.0], [2.0], 0) == 0.0
+    with pytest.raises(ValueError, match="same length"):
+        module.python_reference_score([1.0], [], 1)
+
+    cli_output = tmp_path / "cli-preview"
+    monkeypatch.setattr(sys, "argv", [script.name, "--output-dir", str(cli_output)])
+    module.main()
+    printed = json.loads(capsys.readouterr().out)
+
+    assert printed["schema"] == module.SCHEMA
+    assert printed["artifacts"]["evidence"]["path"] == str(cli_output / "native_rust_worker_evidence.json")
+
+    script_output = tmp_path / "script-preview"
+    monkeypatch.setattr(sys, "argv", [script.name, "--output-dir", str(script_output)])
+    runpy.run_path(str(script), run_name="__main__")
+    printed_from_script = json.loads(capsys.readouterr().out)
+
+    assert printed_from_script["schema"] == module.SCHEMA
+    assert printed_from_script["artifacts"]["evidence"]["path"] == str(
+        script_output / "native_rust_worker_evidence.json"
+    )
+
+
 def test_packaged_agi_example_catalog_matches_seeded_scripts() -> None:
     scripts = sorted(EXAMPLES_ROOT.glob("*/AGI_*.py"))
 
@@ -819,6 +889,7 @@ def test_packaged_example_readmes_are_included_as_package_data() -> None:
     assert "excel_workbook_proof/*.py" in package_data
     assert "inter_project_dag/*.py" in package_data
     assert "mlflow_auto_tracking/*.py" in package_data
+    assert "native_rust_worker/*.py" in package_data
     assert "notebook_to_dask/*.py" in package_data
     assert "notebook_to_dask/*.json" in package_data
     assert "notebook_to_dask/*.toml" in package_data

--- a/test/test_first_launch_robot.py
+++ b/test/test_first_launch_robot.py
@@ -4,6 +4,7 @@ import importlib.util
 import json
 import sys
 from pathlib import Path
+import types
 
 
 MODULE_PATH = Path("tools/first_launch_robot.py").resolve()
@@ -42,3 +43,96 @@ def test_first_launch_robot_passes_static_first_surface(tmp_path: Path) -> None:
     assert module.main(["--target-seconds", "90", "--timeout", "90", "--output", str(output), "--json"]) == 0
     persisted = json.loads(output.read_text(encoding="utf-8"))
     assert persisted["status"] == "pass", json.dumps(persisted, indent=2, sort_keys=True)
+
+
+def test_first_launch_robot_helpers_cover_empty_values_and_docs_import_failure(monkeypatch) -> None:
+    module = _load_module()
+
+    class Widget:
+        def __init__(self, value):
+            self.value = value
+
+    assert module._widget_values([Widget("kept"), Widget(None)], "value") == ["kept"]
+    assert module._contains_any(["one", "two"], ["missing"]) is False
+    src_root = str(module.REPO_ROOT / "src")
+    monkeypatch.setattr(module.sys, "path", [path for path in module.sys.path if path != src_root])
+    monkeypatch.setattr(module.importlib.util, "spec_from_file_location", lambda *_args, **_kwargs: None)
+
+    docs_menu = module._docs_menu_items()
+
+    assert "cannot load page docs module" in docs_menu["_error"]
+    assert module.sys.path[0] == src_root
+
+
+def test_first_launch_robot_marks_env_missing_when_session_state_probe_fails(monkeypatch) -> None:
+    module = _load_module()
+
+    class BrokenSessionState:
+        def __contains__(self, _key):
+            raise RuntimeError("session unavailable")
+
+    class FakeApp:
+        exception: list[object] = []
+        markdown: list[object] = []
+        caption: list[object] = []
+        button: list[object] = []
+        session_state = BrokenSessionState()
+
+        def run(self, *, timeout):
+            return self
+
+    class FakeAppTest:
+        @staticmethod
+        def from_file(_path, *, default_timeout):
+            return FakeApp()
+
+    streamlit = types.ModuleType("streamlit")
+    testing = types.ModuleType("streamlit.testing")
+    v1 = types.ModuleType("streamlit.testing.v1")
+    v1.AppTest = FakeAppTest
+    monkeypatch.setitem(sys.modules, "streamlit", streamlit)
+    monkeypatch.setitem(sys.modules, "streamlit.testing", testing)
+    monkeypatch.setitem(sys.modules, "streamlit.testing.v1", v1)
+    monkeypatch.setattr(module, "_docs_menu_items", lambda: {})
+
+    report = module.build_report(timeout=1.0, target_seconds=999.0)
+
+    checks = {check["id"]: check for check in report["checks"]}
+    assert checks["first_launch_no_exceptions"]["status"] == "pass"
+    assert checks["first_launch_env_initialized"]["status"] == "fail"
+
+
+def test_first_launch_robot_main_reports_human_failure(capsys, monkeypatch) -> None:
+    module = _load_module()
+
+    monkeypatch.setattr(
+        module,
+        "build_report",
+        lambda **_kwargs: {
+            "status": "fail",
+            "checks": [
+                {
+                    "label": "First launch renders without exceptions",
+                    "status": "fail",
+                    "summary": "synthetic failure",
+                }
+            ],
+        },
+    )
+
+    assert module.main(["--target-seconds", "1", "--timeout", "1"]) == 1
+    output = capsys.readouterr().out
+    assert "AGILAB first-launch robot: FAIL" in output
+    assert "synthetic failure" in output
+
+
+def test_first_launch_robot_rejects_non_positive_timeouts() -> None:
+    module = _load_module()
+
+    for option in ("--timeout", "--target-seconds"):
+        try:
+            module.main([option, "0"])
+        except SystemExit as exc:
+            assert exc.code == 2
+        else:  # pragma: no cover - assertion guard
+            raise AssertionError(f"expected parser error for {option}")

--- a/test/test_pyproject_dependency_hygiene.py
+++ b/test/test_pyproject_dependency_hygiene.py
@@ -55,6 +55,15 @@ def _has_version_floor(requirement: Requirement) -> bool:
     return any(spec.operator in {">=", "~=", "=="} for spec in requirement.specifier)
 
 
+def _has_upper_bound(requirement: Requirement) -> bool:
+    return any(spec.operator in {"<", "<="} for spec in requirement.specifier)
+
+
+def _is_internal_requirement(requirement: Requirement) -> bool:
+    name = requirement.name.lower().replace("_", "-")
+    return name == "agilab" or name.startswith("agi-")
+
+
 def _requires_python_floor(requires_python: str) -> tuple[int, int] | None:
     floor: tuple[int, int] | None = None
     for specifier in SpecifierSet(requires_python):
@@ -153,6 +162,8 @@ def test_root_runtime_dependencies_have_explicit_version_policy() -> None:
             continue
         if not _has_version_floor(requirement):
             violations.append(f"{requirement}: missing lower bound or compatible version floor")
+        if not _has_upper_bound(requirement):
+            violations.append(f"{requirement}: missing upper bound")
 
     assert violations == []
 
@@ -275,6 +286,8 @@ def test_root_optional_extras_own_ai_and_visualization_stacks() -> None:
             requirement = Requirement(dependency)
             if not _has_version_floor(requirement):
                 violations.append(f"{extra_name}: {requirement}")
+            if not _is_internal_requirement(requirement) and not _has_upper_bound(requirement):
+                violations.append(f"{extra_name}: {requirement} missing upper bound")
 
     assert violations == []
 
@@ -558,5 +571,53 @@ def test_shared_core_third_party_dependencies_avoid_exact_runtime_pins() -> None
                 continue
             if any(spec.operator == "==" for spec in requirement.specifier):
                 violations.append(f"{relative_path}: {requirement}")
+
+    assert violations == []
+
+
+def test_shared_core_third_party_dependencies_have_bounded_runtime_windows() -> None:
+    pyprojects = [
+        REPO_ROOT / "src/agilab/core/agi-env/pyproject.toml",
+        REPO_ROOT / "src/agilab/core/agi-node/pyproject.toml",
+        REPO_ROOT / "src/agilab/core/agi-cluster/pyproject.toml",
+    ]
+
+    violations: list[str] = []
+    for pyproject in pyprojects:
+        relative_path = pyproject.relative_to(REPO_ROOT).as_posix()
+        for requirement in _dependencies(pyproject):
+            if _is_internal_requirement(requirement):
+                continue
+            if not _has_version_floor(requirement):
+                violations.append(f"{relative_path}: {requirement} missing lower bound")
+            if not _has_upper_bound(requirement):
+                violations.append(f"{relative_path}: {requirement} missing upper bound")
+
+    assert violations == []
+
+
+def test_stale_or_component_ui_dependencies_are_bounded() -> None:
+    checked = {
+        "src/agilab/lib/agi-gui/pyproject.toml": {"streamlit_code_editor", "watchdog"},
+        "src/agilab/apps-pages/view_barycentric/pyproject.toml": {"barviz", "scikit-learn", "sqlalchemy"},
+        "src/agilab/apps-pages/view_autoencoder_latentspace/pyproject.toml": {
+            "barviz",
+            "keras",
+            "scikit-learn",
+            "sqlalchemy",
+        },
+    }
+
+    violations: list[str] = []
+    for relative_path, requirement_names in checked.items():
+        requirements = {requirement.name.lower(): requirement for requirement in _dependencies(REPO_ROOT / relative_path)}
+        missing = requirement_names - set(requirements)
+        if missing:
+            violations.append(f"{relative_path}: missing expected dependencies {sorted(missing)}")
+            continue
+        for requirement_name in sorted(requirement_names):
+            requirement = requirements[requirement_name]
+            if not _has_version_floor(requirement) or not _has_upper_bound(requirement):
+                violations.append(f"{relative_path}: {requirement} must have lower and upper bounds")
 
     assert violations == []

--- a/test/test_pytorch_playground_app.py
+++ b/test/test_pytorch_playground_app.py
@@ -516,7 +516,7 @@ def test_app_surface_full_run_button_executes_before_analysis(monkeypatch):
     assert ordered == ["button", "run", "form", "analysis"]
     assert (
         "button",
-        ("controls", "Refresh evidence", {"type": "primary", "use_container_width": True}),
+        ("controls", "Refresh evidence", {"type": "primary", "width": "stretch"}),
     ) in events
     assert ("spinner", "Refreshing PyTorch evidence") in events
     assert load_calls == [PROJECT_PATH.resolve(), PROJECT_PATH.resolve()]

--- a/test/test_streamlit_156_adoption.py
+++ b/test/test_streamlit_156_adoption.py
@@ -5,8 +5,17 @@ from pathlib import Path
 import tomllib
 
 SRC_ROOT = Path(__file__).resolve().parents[1] / "src"
-if str(SRC_ROOT) not in sys.path:
-    sys.path.insert(0, str(SRC_ROOT))
+try:
+    sys.path.remove(str(SRC_ROOT))
+except ValueError:
+    pass
+sys.path.insert(0, str(SRC_ROOT))
+
+loaded_agilab = sys.modules.get("agilab")
+if loaded_agilab is not None:
+    loaded_paths = [Path(path).resolve(strict=False) for path in getattr(loaded_agilab, "__path__", ())]
+    if (SRC_ROOT / "agilab").resolve(strict=False) not in loaded_paths:
+        sys.modules.pop("agilab", None)
 
 from agilab import streamlit_theme_env  # noqa: E402
 
@@ -97,12 +106,15 @@ def test_streamlit_theme_values_ignore_missing_malformed_and_non_theme_configs(t
     missing = tmp_path / "missing.toml"
     malformed = tmp_path / "malformed.toml"
     non_theme = tmp_path / "server.toml"
+    non_mapping_theme = tmp_path / "theme-string.toml"
     malformed.write_text("[theme\n", encoding="utf-8")
     non_theme.write_text("[server]\nheadless = true\n", encoding="utf-8")
+    non_mapping_theme.write_text('theme = "dark"\n', encoding="utf-8")
 
     assert streamlit_theme_env.load_streamlit_theme_values(missing) == {}
     assert streamlit_theme_env.load_streamlit_theme_values(malformed) == {}
     assert streamlit_theme_env.load_streamlit_theme_values(non_theme) == {}
+    assert streamlit_theme_env.load_streamlit_theme_values(non_mapping_theme) == {}
 
 
 def test_streamlit_theme_environment_preserves_existing_values_and_skips_empty_theme_values(tmp_path) -> None:

--- a/test/test_ui_robot_coverage_contract.py
+++ b/test/test_ui_robot_coverage_contract.py
@@ -303,6 +303,25 @@ def test_ui_robot_coverage_contract_reports_empty_public_app_inventory(monkeypat
     assert {"kind": "built_in_apps", "detail": "no public built-in apps were discovered"} in payload["issues"]
 
 
+def test_ui_robot_coverage_contract_reports_missing_public_demo_wording(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    module = _load_module()
+    demo_doc = tmp_path / "demos.rst"
+    demo_doc.write_text("Public demos\n============\n", encoding="utf-8")
+    monkeypatch.setattr(module, "DEMOS_DOC_PATH", demo_doc)
+
+    payload = module.evaluate_contract()
+
+    assert payload["success"] is False
+    assert any(
+        issue["kind"] == "public_demo_docs"
+        and "demos page is missing robot/proof coverage wording" in issue["detail"]
+        for issue in payload["issues"]
+    )
+
+
 def test_ui_robot_coverage_contract_reports_matrix_and_pytorch_gaps(monkeypatch, capsys) -> None:
     module = _load_module()
     app = SimpleNamespace(name="demo_project")

--- a/test/test_ui_robot_matrix_aggregate.py
+++ b/test/test_ui_robot_matrix_aggregate.py
@@ -305,12 +305,64 @@ def test_discovery_helpers_ignore_invalid_inputs(tmp_path: Path) -> None:
     missing_shard = tmp_path / "missing-shard" / module.SHARD_MANIFEST_FILENAME
     missing_shard.parent.mkdir()
     missing_shard.write_text(json.dumps({"schema": module.SHARD_MANIFEST_SCHEMA}), encoding="utf-8")
+    malformed_shard = tmp_path / "malformed" / module.SHARD_MANIFEST_FILENAME
+    malformed_shard.parent.mkdir()
+    malformed_shard.write_text("{", encoding="utf-8")
 
     assert module._relative(Path("/definitely/outside"), tmp_path) == "/definitely/outside"
     assert module._resolve_manifest_path(bad_manifest, "") is None
     assert module._shard_from_summary_path(tmp_path / "plain" / "summary.json") == "plain"
     assert module._scenario_from_bundle_manifest(bad_manifest) == ""
     assert module.discover_shard_manifests(tmp_path) == {}
+
+
+def test_discover_failure_bundles_tolerates_manifest_load_race(tmp_path: Path, monkeypatch) -> None:
+    module = _load_module()
+    shard_root = tmp_path / "shard"
+    manifest_path = shard_root / "failure-bundles" / "race" / "_scenario" / "manifest.json"
+    manifest_path.parent.mkdir(parents=True)
+    manifest_path.write_text(json.dumps({"scenario": "race", "command": ["python"]}), encoding="utf-8")
+
+    def flaky_load_json(path: Path):
+        if path == manifest_path:
+            raise json.JSONDecodeError("race", "{", 0)
+        return {}
+
+    monkeypatch.setattr(module, "_scenario_from_bundle_manifest", lambda _path: "race")
+    monkeypatch.setattr(module, "_load_json", flaky_load_json)
+
+    bundles = module.discover_failure_bundles(tmp_path, shard_root, manifest_paths=[manifest_path])
+
+    assert bundles["race"][0]["scenario"] == "race"
+    assert "failure_artifact_retry" not in bundles["race"][0]
+
+
+def test_load_shard_payload_ignores_non_mapping_failure_samples(tmp_path: Path) -> None:
+    module = _load_module()
+    shard_root = _write_shard(tmp_path, "core", success=False, failed_count=1, exit_code="1")
+    summary_path = shard_root / "summary.json"
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    summary["failure_samples"] = [
+        "not-a-sample",
+        {
+            "scenario": "core-scenario",
+            "app": "flight_telemetry_project",
+            "page": "ORCHESTRATE",
+        },
+    ]
+    summary_path.write_text(json.dumps(summary), encoding="utf-8")
+
+    payload = module._load_shard_payload(
+        tmp_path,
+        "core",
+        shard_dir=shard_root,
+        summary_path=summary_path,
+        trend_path=shard_root / "trend-report.json",
+        exit_code_path=shard_root / "exit-code.txt",
+    )
+
+    assert len(payload["failure_samples"]) == 1
+    assert payload["failure_samples"][0]["scenario"] == "core-scenario"
 
 
 def test_render_markdown_includes_failure_replay_command(tmp_path: Path) -> None:
@@ -329,6 +381,43 @@ def test_render_markdown_includes_failure_replay_command(tmp_path: Path) -> None
     ) in markdown
     assert "Artifact retry: `FAIL`" in markdown
     assert "Trace: `" in markdown
+    assert "HAR: `" in markdown
+    assert "Video: `" in markdown
+
+
+def test_render_markdown_handles_minimal_retry_without_artifact_paths() -> None:
+    module = _load_module()
+
+    markdown = module.render_markdown(
+        {
+            "success": False,
+            "summary": {"shard_count": 1, "expected_shard_count": 1},
+            "missing_shards": [],
+            "shards": [
+                {
+                    "name": "core",
+                    "success": False,
+                    "scenario_count": 1,
+                    "trend": {"success": False},
+                }
+            ],
+            "failure_samples": [
+                {
+                    "shard": "core",
+                    "scenario": "demo",
+                    "failure_artifact_retry": {"success": True},
+                    "failure_artifact_retry_status": "PASS",
+                }
+            ],
+        }
+    )
+
+    assert "Artifact retry: `PASS`" in markdown
+    assert "Bundle:" not in markdown
+    assert "Replay:" not in markdown
+    assert "Trace:" not in markdown
+    assert "HAR:" not in markdown
+    assert "Video:" not in markdown
 
 
 def test_render_markdown_skips_non_mapping_rows() -> None:

--- a/test/test_view_forecast_analysis.py
+++ b/test/test_view_forecast_analysis.py
@@ -125,16 +125,16 @@ def test_view_forecast_analysis_helper_branches(monkeypatch, tmp_path) -> None:
     module_path.parent.mkdir(parents=True)
     module_path.write_text("# stub\n", encoding="utf-8")
     monkeypatch.setattr(module, "__file__", str(module_path))
-    monkeypatch.setattr(module.sys, "path", [])
+    monkeypatch.setattr(sys, "path", [])
     module._ensure_repo_on_path()
-    assert str(src_root) in module.sys.path
-    assert str(repo_root) in module.sys.path
+    assert str(src_root) in sys.path
+    assert str(repo_root) in sys.path
 
     errors: list[str] = []
     def stop_now():
         raise RuntimeError("stop")
     module.st = SimpleNamespace(error=errors.append, stop=stop_now)
-    monkeypatch.setattr(module.sys, "argv", [Path(PAGE_PATH).name, "--active-app", str(tmp_path / "missing_app")])
+    monkeypatch.setattr(sys, "argv", [Path(PAGE_PATH).name, "--active-app", str(tmp_path / "missing_app")])
     with pytest.raises(RuntimeError, match="stop"):
         module._resolve_active_app()
     assert any("Provided --active-app path not found" in message for message in errors)

--- a/test/test_view_queue_resilience.py
+++ b/test/test_view_queue_resilience.py
@@ -231,10 +231,10 @@ def test_view_queue_resilience_helper_branches(monkeypatch, tmp_path) -> None:
         encoding="utf-8",
     )
     monkeypatch.setattr(module, "__file__", str(module_path))
-    monkeypatch.setattr(module.sys, "path", [])
+    monkeypatch.setattr(sys, "path", [])
     module._ensure_repo_on_path()
-    assert str(src_root) in module.sys.path
-    assert str(repo_root) in module.sys.path
+    assert str(src_root) in sys.path
+    assert str(repo_root) in sys.path
 
     logo, title = module._load_page_meta()
     assert logo == "queued.svg"
@@ -244,7 +244,7 @@ def test_view_queue_resilience_helper_branches(monkeypatch, tmp_path) -> None:
     def stop_now():
         raise RuntimeError("stop")
     module.st = SimpleNamespace(error=errors.append, stop=stop_now)
-    monkeypatch.setattr(module.sys, "argv", [Path(PAGE_PATH).name, "--active-app", str(tmp_path / "missing_app")])
+    monkeypatch.setattr(sys, "argv", [Path(PAGE_PATH).name, "--active-app", str(tmp_path / "missing_app")])
     with pytest.raises(RuntimeError, match="stop"):
         module._resolve_active_app()
     assert any("Provided --active-app path not found" in message for message in errors)

--- a/test/test_view_relay_resilience.py
+++ b/test/test_view_relay_resilience.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 
@@ -289,16 +290,16 @@ def test_view_relay_resilience_helper_branches(monkeypatch, tmp_path) -> None:
     module_path.parent.mkdir(parents=True)
     module_path.write_text("# stub\n", encoding="utf-8")
     monkeypatch.setattr(module, "__file__", str(module_path))
-    monkeypatch.setattr(module.sys, "path", [])
+    monkeypatch.setattr(sys, "path", [])
     module._ensure_repo_on_path()
-    assert str(src_root) in module.sys.path
-    assert str(repo_root) in module.sys.path
+    assert str(src_root) in sys.path
+    assert str(repo_root) in sys.path
 
     errors: list[str] = []
     def stop_now():
         raise RuntimeError("stop")
     module.st = SimpleNamespace(error=errors.append, stop=stop_now)
-    monkeypatch.setattr(module.sys, "argv", [Path(PAGE_PATH).name, "--active-app", str(tmp_path / "missing_app")])
+    monkeypatch.setattr(sys, "argv", [Path(PAGE_PATH).name, "--active-app", str(tmp_path / "missing_app")])
     with pytest.raises(RuntimeError, match="stop"):
         module._resolve_active_app()
     assert any("Provided --active-app path not found" in message for message in errors)

--- a/test/test_view_scenario_cockpit.py
+++ b/test/test_view_scenario_cockpit.py
@@ -180,9 +180,9 @@ def test_view_scenario_cockpit_helper_edge_cases(monkeypatch, tmp_path) -> None:
     module = _load_helpers()
 
     module.__file__ = str(tmp_path / "outside" / "view_scenario_cockpit.py")
-    monkeypatch.setattr(module.sys, "path", [])
+    monkeypatch.setattr(sys, "path", [])
     module._ensure_repo_on_path()
-    assert module.sys.path == []
+    assert sys.path == []
 
     errors: list[str] = []
 
@@ -190,7 +190,7 @@ def test_view_scenario_cockpit_helper_edge_cases(monkeypatch, tmp_path) -> None:
         raise RuntimeError("stop")
 
     module.st = SimpleNamespace(error=errors.append, stop=stop_now)
-    monkeypatch.setattr(module.sys, "argv", [Path(PAGE_PATH).name, "--active-app", str(tmp_path / "missing_app")])
+    monkeypatch.setattr(sys, "argv", [Path(PAGE_PATH).name, "--active-app", str(tmp_path / "missing_app")])
     with pytest.raises(RuntimeError, match="stop"):
         module._resolve_active_app()
     assert any("Provided --active-app path not found" in message for message in errors)

--- a/test/test_view_shap_explanation.py
+++ b/test/test_view_shap_explanation.py
@@ -136,10 +136,10 @@ def test_view_shap_explanation_helper_branches(monkeypatch, tmp_path: Path) -> N
     module_path.parent.mkdir(parents=True)
     module_path.write_text("# stub\n", encoding="utf-8")
     monkeypatch.setattr(module, "__file__", str(module_path))
-    monkeypatch.setattr(module.sys, "path", [])
+    monkeypatch.setattr(sys, "path", [])
     module._ensure_repo_on_path()
-    assert str(src_root) in module.sys.path
-    assert str(repo_root) in module.sys.path
+    assert str(src_root) in sys.path
+    assert str(repo_root) in sys.path
 
     errors: list[str] = []
 
@@ -147,7 +147,7 @@ def test_view_shap_explanation_helper_branches(monkeypatch, tmp_path: Path) -> N
         raise RuntimeError("stop")
 
     module.st = SimpleNamespace(error=errors.append, stop=stop_now)
-    monkeypatch.setattr(module.sys, "argv", [Path(PAGE_PATH).name, "--active-app", str(tmp_path / "missing_app")])
+    monkeypatch.setattr(sys, "argv", [Path(PAGE_PATH).name, "--active-app", str(tmp_path / "missing_app")])
     with pytest.raises(RuntimeError, match="stop"):
         module._resolve_active_app()
     assert any("Provided --active-app path not found" in message for message in errors)

--- a/test/test_view_training_analysis.py
+++ b/test/test_view_training_analysis.py
@@ -319,11 +319,11 @@ def test_view_training_analysis_repo_path_and_setting_helpers(monkeypatch, tmp_p
     module_path.write_text("# stub\n", encoding="utf-8")
 
     monkeypatch.setattr(module, "__file__", str(module_path))
-    monkeypatch.setattr(module.sys, "path", [])
+    monkeypatch.setattr(sys, "path", [])
     module._ensure_repo_on_path()
 
-    assert str(src_root) in module.sys.path
-    assert str(repo_root) in module.sys.path
+    assert str(src_root) in sys.path
+    assert str(repo_root) in sys.path
 
     module.st = SimpleNamespace(session_state={"app_settings": {"kept": True}})
     module._ensure_app_settings_loaded(SimpleNamespace(app_settings_file=tmp_path / "missing.toml"))

--- a/test/test_workflow_parity.py
+++ b/test/test_workflow_parity.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import re
+import runpy
 import subprocess
 import sys
 from pathlib import Path
@@ -77,6 +78,18 @@ def _parity_agi_gui_targets(module) -> dict[str, list[str]]:
         ignore_index = command.argv.index("--ignore=src/agilab/test/test_model_returns_code.py")
         targets_by_chunk[match.group(1)] = command.argv[ignore_index + 1 :]
     return targets_by_chunk
+
+
+def test_coverage_shard_plan_module_fails_closed_when_loader_is_missing(monkeypatch) -> None:
+    module = _load_module()
+    monkeypatch.setattr(module.importlib.util, "spec_from_file_location", lambda *_args, **_kwargs: None)
+
+    try:
+        module._coverage_shard_plan_module()
+    except RuntimeError as exc:
+        assert "cannot load coverage shard planner" in str(exc)
+    else:
+        raise AssertionError("_coverage_shard_plan_module should fail when the module spec is missing")
 
 
 def test_agi_gui_workflow_parity_matches_coverage_workflow_targets() -> None:
@@ -225,6 +238,7 @@ def test_profile_commands_cover_expected_coverage_and_docs_contracts() -> None:
     assert "'coverage', 'combine'" in agi_gui_combine_argv
     assert "--keep" in agi_gui_combine_argv
     assert agi_gui_combine.env["COVERAGE_FILE"] == ".coverage.agi-gui"
+    assert module.AGI_GUI_COVERAGE_MANIFEST_WAIT_SECONDS >= 90.0
     assert "Missing agi-gui coverage manifests" in agi_gui_combine_argv
     assert "coverage_db_paths" in agi_gui_combine_argv
     assert "range(120)" not in agi_gui_combine_argv
@@ -722,6 +736,12 @@ def test_ui_robot_profile_selection_covers_change_classes() -> None:
     assert module.select_ui_robot_profiles_for_files([".github/workflows/coverage.yml"]) == [
         "ui-robot-contract",
         "ui-robot-canary",
+        "ui-trend-robot",
+    ]
+    assert module.select_ui_robot_profiles_for_files([".github/workflows/ci.yml"]) == [
+        "ui-robot-contract",
+        "ui-robot-canary",
+        "ui-frontend-smoke",
         "ui-trend-robot",
     ]
     assert module.select_ui_robot_profiles_for_files(["src/agilab/pages/project.py"]) == [
@@ -1332,3 +1352,17 @@ def test_main_accepts_production_readiness_profile(capsys) -> None:
         "test-results/production-readiness.json",
         "--compact",
     ]
+
+
+def test_workflow_parity_module_entrypoint_lists_profiles(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(sys, "argv", ["workflow_parity.py", "--list-profiles", "--json"])
+
+    try:
+        runpy.run_path(MODULE_PATH.as_posix(), run_name="__main__")
+    except SystemExit as exc:
+        assert exc.code == 0
+    else:
+        raise AssertionError("workflow_parity __main__ should terminate through SystemExit")
+
+    listed = json.loads(capsys.readouterr().out)
+    assert "skills" in listed

--- a/tools/agilab_widget_robot.py
+++ b/tools/agilab_widget_robot.py
@@ -220,7 +220,7 @@ PAGE_EXPECTED_TEXT = {
     "WORKFLOW": ("WORKFLOW", "Workflow", "Run"),
     "ANALYSIS": ("ANALYSIS", "Choose pages", "View:"),
 }
-PAGE_MIN_WIDGETS = {"": 5, "PROJECT": 5, "SETTINGS": 5, "ORCHESTRATE": 5, "WORKFLOW": 3, "ANALYSIS": 3}
+PAGE_MIN_WIDGETS = {"": 2, "PROJECT": 5, "SETTINGS": 5, "ORCHESTRATE": 5, "WORKFLOW": 3, "ANALYSIS": 3}
 PAGE_ABOVE_FOLD_EXPECTED_LABELS = {
     "HOME": ("AGILAB", "Start here"),
     "PROJECT": ("PROJECT", "Active app", "Project"),
@@ -1802,16 +1802,39 @@ def build_seeded_server_env(
     return SeededRuntime(env, home_root, export_root, share_root, cluster_share_root)
 
 
+def _any_visible_locator(locator: Any, *, timeout_ms: float = 100.0, limit: int = 8) -> bool:
+    try:
+        count = locator.count()
+    except Exception:
+        return False
+    for index in range(min(count, limit)):
+        try:
+            if locator.nth(index).is_visible(timeout=timeout_ms):
+                return True
+        except Exception:
+            continue
+    return False
+
+
+def _initializing_environment_visible(page: Any) -> bool:
+    try:
+        locator = page.get_by_text(re.compile("initializing environment", re.IGNORECASE))
+    except Exception:
+        try:
+            return "initializing environment" in page.locator("body").inner_text(timeout=1000).lower()
+        except Exception:
+            return False
+    return _any_visible_locator(locator)
+
+
 def wait_for_page_ready(page: Any, *, timeout_ms: float) -> None:  # pragma: no cover - live browser path
     deadline = time.perf_counter() + timeout_ms / 1000.0
     while time.perf_counter() < deadline:
         try:
-            text = page.locator("body").inner_text(timeout=1000).lower()
-            spinner_count = page.locator("[data-testid='stSpinner']").count()
+            spinner_visible = _any_visible_locator(page.locator("[data-testid='stSpinner']"))
         except Exception:
-            text = ""
-            spinner_count = 0
-        if "initializing environment" not in text and spinner_count == 0:
+            spinner_visible = False
+        if not spinner_visible and not _initializing_environment_visible(page):
             page.wait_for_timeout(PAGE_READY_STABILIZE_MS)
             return
         page.wait_for_timeout(PAGE_READY_POLL_MS)

--- a/tools/agilab_widget_robot_matrix.py
+++ b/tools/agilab_widget_robot_matrix.py
@@ -53,6 +53,7 @@ class RobotScenario:
     action_timeout_seconds: float = 90.0
     page_timeout_seconds: float = 420.0
     target_seconds: float = 1800.0
+    max_action_clicks_per_page: int = 25
     assert_orchestrate_artifacts: bool = False
     assert_workflow_artifacts: bool = False
     assert_analysis_artifacts: bool = False
@@ -163,15 +164,16 @@ DEFAULT_SCENARIOS: dict[str, RobotScenario] = {
     "isolated-entry-and-app-pages": RobotScenario(
         name="isolated-entry-and-app-pages",
         description=(
-            "Sweep the entry shell plus each app's configured analysis "
-            "views with an isolated runtime and guarded safe-click navigation."
+            "Sweep each app's configured analysis views with an isolated runtime. "
+            "HOME stays covered by the dedicated core page scenarios."
         ),
-        pages="HOME",
+        pages="none",
         apps_pages="configured",
         runtime_isolation="isolated",
-        action_button_policy="safe-click",
+        action_button_policy="trial",
         action_timeout_seconds=30.0,
         page_timeout_seconds=300.0,
+        max_action_clicks_per_page=0,
     ),
     "isolated-project-page": RobotScenario(
         name="isolated-project-page",
@@ -728,6 +730,8 @@ def build_robot_command(
         scenario.missing_selected_action_policy,
         "--action-timeout",
         str(scenario.action_timeout_seconds),
+        "--max-action-clicks-per-page",
+        str(scenario.max_action_clicks_per_page),
         "--runtime-isolation",
         scenario.runtime_isolation,
     ]

--- a/tools/workflow_parity.py
+++ b/tools/workflow_parity.py
@@ -51,7 +51,7 @@ AGI_GUI_COVERAGE_CHUNKS = (
     "reports",
 )
 AGI_GUI_COVERAGE_MANIFEST_SCHEMA = "agilab.workflow_parity.agi_gui_coverage_chunk.v1"
-AGI_GUI_COVERAGE_MANIFEST_WAIT_SECONDS = 30.0
+AGI_GUI_COVERAGE_MANIFEST_WAIT_SECONDS = 120.0
 UI_ROBOT_MATRIX_SHARDS = (
     (
         "core",


### PR DESCRIPTION
Summary:
- factor shared apps-pages runtime helpers and bound external dependency windows
- add the native Rust/PyO3 worker preview and public docs links
- harden UI/web robot coverage, Streamlit 1.56 width usage, and agi-gui manifest waiting
- refresh docs mirror drift from the canonical docs source

Validation:
- pytest narrow page/runtime/native/robot slice: 442 passed
- py_compile for packaged examples
- agi-env tests: 683 passed
- shared core tests: 951 passed, 2 skipped
- docs + dependency-policy workflow parity: pass
- agi-gui workflow parity: pass
- test_agilab_web_robot + test_sync_docs_source: 52 passed
- native Rust worker preview generated evidence successfully
- git diff --check