### PR TITLE
feat: add Voila notebook proof bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Start with the public browser preview or the demo chooser:
 - [AGILAB Space](https://huggingface.co/spaces/jpmorard/agilab)
 - [Demo chooser](https://thalesgroup.github.io/agilab/demos.html)
 - [Excel workbook proof](https://thalesgroup.github.io/agilab/excel-users.html)
+- [Voila notebook proof](https://thalesgroup.github.io/agilab/voila-users.html)
 - [Cython worker speedup demo](https://thalesgroup.github.io/agilab/execution-playground.html)
 - [Rust/PyO3 native worker preview](https://thalesgroup.github.io/agilab/execution-playground.html#optional-rust-pyo3-worker-preview)
 - [Local quick start](#quick-start)
@@ -99,6 +100,11 @@ repository so other engineers can find it.
 For spreadsheet-first users, the packaged `excel_workbook_proof` preview keeps
 Excel as the familiar interface and writes a proof workbook, Power Query-friendly
 CSV files, and JSON hash evidence without requiring an Office add-in.
+
+For notebook-dashboard users, the packaged `voila_notebook_proof` preview keeps
+the notebook dashboard flow and writes a hide-code manifest, widget-to-args
+hints, an app-view plan, and JSON evidence without requiring Voila in the base
+install.
 
 ## Featured Opt-In App
 

--- a/README.pypi.md
+++ b/README.pypi.md
@@ -63,6 +63,7 @@ Start with the public browser preview or the demo chooser:
 - [AGILAB Space](https://huggingface.co/spaces/jpmorard/agilab)
 - [Demo chooser](https://thalesgroup.github.io/agilab/demos.html)
 - [Excel workbook proof](https://thalesgroup.github.io/agilab/excel-users.html)
+- [Voila notebook proof](https://thalesgroup.github.io/agilab/voila-users.html)
 - [Cython worker speedup demo](https://thalesgroup.github.io/agilab/execution-playground.html)
 - [Rust/PyO3 native worker preview](https://thalesgroup.github.io/agilab/execution-playground.html#optional-rust-pyo3-worker-preview)
 - [Local quick start](https://thalesgroup.github.io/agilab/quick-start.html)
@@ -75,6 +76,11 @@ repository so other engineers can find it.
 For spreadsheet-first users, the packaged `excel_workbook_proof` preview keeps
 Excel as the familiar interface and writes a proof workbook, Power Query-friendly
 CSV files, and JSON hash evidence without requiring an Office add-in.
+
+For notebook-dashboard users, the packaged `voila_notebook_proof` preview keeps
+the notebook dashboard flow and writes a hide-code manifest, widget-to-args
+hints, an app-view plan, and JSON evidence without requiring Voila in the base
+install.
 
 ## Featured Performance Demo
 

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -1,9 +1,9 @@
 {
-  "file_count": 219,
+  "file_count": 220,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "b0568cf67192854fcde77e38d5b573290028dc6223c125fc54e4c032d2fbaba3",
+  "source_digest_sha256": "f6f7f9bf841719cc92d635479bc00cf068bc194b36cd2a3286beb17dd8003e01",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "b0568cf67192854fcde77e38d5b573290028dc6223c125fc54e4c032d2fbaba3"
+  "target_digest_sha256": "f6f7f9bf841719cc92d635479bc00cf068bc194b36cd2a3286beb17dd8003e01"
 }

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -55,6 +55,7 @@ references, and example projects.
    Capabilities <features>
    Data connectors <data-connectors>
    AGILAB for Excel users <excel-users>
+   AGILAB for Voila users <voila-users>
    Proof capsule <proof-capsule>
    Public web demo <agilab-demo>
    Advanced proof pack <advanced-proof-pack>

--- a/docs/source/roadmap/agilab-future-work.md
+++ b/docs/source/roadmap/agilab-future-work.md
@@ -257,6 +257,10 @@ Current shipped baseline:
 - Excel-shaped proof preview from packaged examples: a workbook, refresh-friendly
   CSV folder, and JSON hash evidence, intentionally before any Office add-in or
   arbitrary workbook import claim
+- Voila-shaped notebook proof preview from packaged examples: a dashboard
+  notebook, hide-code manifest, widget-to-args migration hints, app-view plan,
+  static HTML preview, and JSON hash evidence, intentionally before any Voila
+  server integration or `agilab[voila]` claim
 
 Spreadsheet adoption bridge:
 
@@ -268,6 +272,17 @@ Spreadsheet adoption bridge:
   JSON evidence bundle for workbook runs
 - keep Office add-ins, macro execution, tenant deployment, and formula-preserving
   arbitrary workbook import as later product-expansion work, not current claims
+
+Notebook dashboard adoption bridge:
+
+- keep the shipped preview dependency-light and file-based until there is user
+  pull for deeper Voila integration
+- add a focused `agilab notebook-proof dashboard.ipynb --app-name <name>`
+  command only after the preview validates the user story
+- promote stable ipywidgets to app arguments while keeping app-specific
+  dashboard code inside the app project
+- keep a future `agilab[voila]` extra, server launch, and multi-user dashboard
+  deployment as later product-expansion work, not current claims
 
 Evidence Core roadmap:
 
@@ -1093,6 +1108,9 @@ Current shipped baseline:
   runtime or mixed-environment pipelines
 - this is intentionally not the same thing as flattening a multi-venv pipeline
   into one notebook kernel
+- packaged examples now include a dependency-light Voila-shaped notebook proof
+  preview that records widget-to-args hints, a hide-code manifest, an app-view
+  plan, and evidence hashes without launching a Voila server
 
 Suggested scope:
 

--- a/docs/source/voila-users.rst
+++ b/docs/source/voila-users.rst
@@ -1,0 +1,102 @@
+AGILAB for Voila users
+======================
+
+Voila users do not need a platform migration pitch first. The useful first
+question is smaller:
+
+   Can I keep a notebook dashboard as the familiar interface, then add app
+   boundaries, replay, and evidence when the workflow becomes important?
+
+AGILAB's current answer is a lightweight bridge: a Voila-shaped notebook,
+widget-to-argument mapping, a hide-code manifest, an app-view plan, and explicit
+evidence. This is not a full Voila server integration and it is not yet an
+``agilab[voila]`` runtime extra.
+
+What ships now
+--------------
+
+The packaged ``voila_notebook_proof`` preview creates a notebook-dashboard proof
+without adding Voila or ipywidgets as required dependencies:
+
+.. code-block:: bash
+
+   uv --preview-features extra-build-dependencies run python src/agilab/examples/voila_notebook_proof/preview_voila_notebook_proof.py
+
+It writes:
+
+.. code-block:: text
+
+   ~/log/execute/voila_notebook_proof/dashboard.ipynb
+   ~/log/execute/voila_notebook_proof/widget_to_args.json
+   ~/log/execute/voila_notebook_proof/hidden_code_manifest.json
+   ~/log/execute/voila_notebook_proof/agilab_app_view_plan.json
+   ~/log/execute/voila_notebook_proof/dashboard_app_preview.html
+   ~/log/execute/voila_notebook_proof/voila_notebook_evidence.json
+
+Open ``dashboard_app_preview.html`` to inspect the static adoption plan. Open
+``dashboard.ipynb`` to see the notebook shape that a future Voila runtime could
+serve.
+
+Why this is the right first bridge
+----------------------------------
+
+Voila already gives notebook users a direct path from notebooks to dashboards.
+AGILAB should not replace that habit. It should add the missing engineering
+boundary only when the notebook becomes a reusable application.
+
+The bridge keeps the responsibilities clear:
+
+.. list-table::
+   :header-rows: 1
+
+   * - User concern
+     - AGILAB response
+   * - I already have a notebook dashboard.
+     - Keep the notebook as an app-owned asset.
+   * - I want user controls.
+     - Map stable widgets to explicit app arguments.
+   * - I want cleaner presentation.
+     - Record a hide-code manifest as data.
+   * - I need reproducibility.
+     - Hash the notebook, sidecars, and evidence bundle.
+   * - I do not want a new deployment story yet.
+     - Use files first; keep Voila serving as an optional later runtime.
+
+Product direction
+-----------------
+
+The next product step is a focused command and UI path:
+
+.. code-block:: bash
+
+   agilab notebook-proof dashboard.ipynb --app-name sales_dashboard
+
+That should:
+
+- read a user-selected notebook;
+- extract stable widget defaults into app arguments;
+- preserve app-specific notebook and UI code inside the app folder;
+- write an app-view plan and evidence bundle;
+- optionally serve through Voila only when the user installs the Voila extra.
+
+The positioning is intentionally narrow:
+
+   Voila turns notebooks into apps. AGILAB turns notebook apps into
+   reproducible, evidence-backed workflows.
+
+What remains roadmap
+--------------------
+
+The preview does not yet claim:
+
+- a running Voila server from the AGILAB web UI;
+- an ``agilab[voila]`` extra;
+- automatic arbitrary notebook import into a full app project;
+- ipywidgets execution during preview generation;
+- multi-user dashboard deployment.
+
+Those are useful later only if notebook-dashboard users care about the bridge.
+For now, the adoption message should stay simple:
+
+   Keep the notebook dashboard. Use AGILAB to make the workflow replayable,
+   auditable, and easier to promote into an app.

--- a/src/agilab/examples/README.md
+++ b/src/agilab/examples/README.md
@@ -19,14 +19,15 @@ the command shape stable.
 | 4 | `notebook_migrations/skforecast_meteo_fr` | `weather_forecast_project` | Packaged migration source: notebooks, artifacts, lab stages, and pipeline view. |
 | 5 | `notebook_to_dask` | notebook import -> Dask pipeline | Read-only migration preview: code cells, artifact contracts, and a Dask pipeline view. |
 | 6 | `excel_workbook_proof` | spreadsheet bridge preview | Read-only Excel-shaped proof: workbook, Power Query-friendly CSVs, and evidence hashes. |
-| 7 | `mission_decision` | `mission_decision_project` | Deterministic mission-data decision run with richer artifacts. |
-| 8 | `global_dag_project` | `flight_telemetry_project` -> `weather_forecast_project` | Built-in app-owned global DAG contract: app nodes, artifact handoff, and runner-state preview. |
-| 9 | `inter_project_dag` | `flight_telemetry_project` -> `weather_forecast_project` | Standalone compatibility preview for the same cross-project DAG concept. |
-| 10 | `service_mode` | `mycode_project` | Read-only service lifecycle preview: start, status, health, stop. |
-| 11 | `mlflow_auto_tracking` | any pipeline app | Optional tracking preview: local evidence first, MLflow as the memory backend. |
-| 12 | `resilience_failure_injection` | UAV relay scenario contract | Read-only resilience preview: inject a relay failure, compare fixed/replanned/search/policy responses. |
-| 13 | `train_then_serve` | trained policy handoff contract | Read-only service handoff preview: model artifact, IO contract, prediction sample, and health gate. |
-| 14 | `native_rust_worker` | optional native worker preview | Read-only Rust/PyO3 skeleton: keep AGILAB orchestration in Python while moving only a typed hot kernel to Rust. |
+| 7 | `voila_notebook_proof` | notebook dashboard bridge preview | Read-only notebook-dashboard proof: Voila-shaped notebook, widget-to-args hints, app-view plan, and evidence hashes. |
+| 8 | `mission_decision` | `mission_decision_project` | Deterministic mission-data decision run with richer artifacts. |
+| 9 | `global_dag_project` | `flight_telemetry_project` -> `weather_forecast_project` | Built-in app-owned global DAG contract: app nodes, artifact handoff, and runner-state preview. |
+| 10 | `inter_project_dag` | `flight_telemetry_project` -> `weather_forecast_project` | Standalone compatibility preview for the same cross-project DAG concept. |
+| 11 | `service_mode` | `mycode_project` | Read-only service lifecycle preview: start, status, health, stop. |
+| 12 | `mlflow_auto_tracking` | any pipeline app | Optional tracking preview: local evidence first, MLflow as the memory backend. |
+| 13 | `resilience_failure_injection` | UAV relay scenario contract | Read-only resilience preview: inject a relay failure, compare fixed/replanned/search/policy responses. |
+| 14 | `train_then_serve` | trained policy handoff contract | Read-only service handoff preview: model artifact, IO contract, prediction sample, and health gate. |
+| 15 | `native_rust_worker` | optional native worker preview | Read-only Rust/PyO3 skeleton: keep AGILAB orchestration in Python while moving only a typed hot kernel to Rust. |
 
 ## Execution Map
 
@@ -36,7 +37,7 @@ app execution from read-only contract previews.
 | Class | Examples | What actually runs | Primary output |
 |---|---|---|---|
 | Installed `AGI_*.py` helpers | `flight_telemetry`, `mycode`, `weather_forecast`, `mission_decision` | Real `AGI.install` / `AGI.run` calls from `~/log/execute/<app>/` after the app installer seeds the scripts. | App artifacts in AGILAB share/export paths plus execution logs. |
-| Source/package read-only previews | `notebook_to_dask`, `excel_workbook_proof`, `inter_project_dag`, `service_mode`, `mlflow_auto_tracking`, `resilience_failure_injection`, `train_then_serve`, `native_rust_worker` | Deterministic Python preview scripts. They write local evidence and do not launch long-lived workers or hidden multi-app runs. | Preview JSON, CSV, workbook, or generated skeleton artifacts under `~/log/execute/<example>/` or the configured output path. |
+| Source/package read-only previews | `notebook_to_dask`, `excel_workbook_proof`, `voila_notebook_proof`, `inter_project_dag`, `service_mode`, `mlflow_auto_tracking`, `resilience_failure_injection`, `train_then_serve`, `native_rust_worker` | Deterministic Python preview scripts. They write local evidence and do not launch long-lived workers or hidden multi-app runs. | Preview JSON, CSV, workbook, notebook, dashboard-plan, or generated skeleton artifacts under `~/log/execute/<example>/` or the configured output path. |
 | Notebook migration assets | `notebook_migrations/skforecast_meteo_fr` | Packaged notebooks, artifacts, `lab_stages.toml`, and pipeline view used as migration source material. | Files to inspect or import; no service or cluster run is started by reading them. |
 
 Source-checkout commands use `uv --preview-features extra-build-dependencies run python ...`
@@ -81,6 +82,10 @@ From an installed package, locate one with
 - `excel_workbook_proof/preview_excel_workbook_proof.py` shows the low-friction
   spreadsheet bridge: result workbook, Power Query-friendly CSV folder, and
   JSON evidence hashes without an Office add-in.
+- `voila_notebook_proof/preview_voila_notebook_proof.py` shows the notebook
+  dashboard bridge: a Voila-shaped notebook, hide-code manifest,
+  widget-to-args migration hints, app-view plan, and JSON evidence hashes
+  without adding Voila to the base install.
 - `notebook_migrations/skforecast_meteo_fr` keeps the weather-forecast source
   notebooks, exported artifacts, migrated `lab_stages.toml`, and conceptual
   pipeline view in the packaged examples tree.
@@ -151,6 +156,8 @@ serving a policy. Use `native_rust_worker` when you want to explain the advanced
 native-worker lane without adding Rust to the base install. Use
 `excel_workbook_proof` when the stakeholder lives in
 Excel and needs to see workbook output plus refreshable CSV and evidence before
-they care about notebooks, DAGs, or clusters. Use `train_then_serve` when you
-want to explain what must be frozen after training before a policy becomes
-service-ready.
+they care about notebooks, DAGs, or clusters. Use `voila_notebook_proof` when
+the stakeholder already has a notebook dashboard and needs to see how AGILAB
+adds app boundaries, replay, and evidence without replacing the notebook-first
+flow. Use `train_then_serve` when you want to explain what must be frozen after
+training before a policy becomes service-ready.

--- a/src/agilab/examples/voila_notebook_proof/README.md
+++ b/src/agilab/examples/voila_notebook_proof/README.md
@@ -1,0 +1,82 @@
+# Voila Notebook Proof Preview
+
+## Purpose
+
+Show how a notebook dashboard can become an AGILAB app adoption bridge without
+requiring a Voila server, a notebook kernel, or ipywidgets during the preview.
+
+## What You Learn
+
+- how a notebook dashboard keeps a familiar stakeholder interface
+- how stable widgets map to AGILAB app arguments
+- where app-specific UI and worker code should live
+- which evidence files make the bridge auditable
+
+## Install
+
+From a source checkout, install the normal AGILAB development dependencies. No
+extra Voila dependency is required for this preview.
+
+```bash
+uv sync
+```
+
+## Run
+
+```bash
+uv --preview-features extra-build-dependencies run python src/agilab/examples/voila_notebook_proof/preview_voila_notebook_proof.py
+```
+
+Use a temporary output directory when testing:
+
+```bash
+uv --preview-features extra-build-dependencies run python src/agilab/examples/voila_notebook_proof/preview_voila_notebook_proof.py --output-dir /tmp/agilab-voila-proof --json
+```
+
+## Expected Input
+
+No external input is required. The script creates a small dashboard notebook and
+sidecar contracts from deterministic fixtures.
+
+## Expected Output
+
+The default output directory is:
+
+```text
+~/log/execute/voila_notebook_proof/
+```
+
+It contains:
+
+```text
+dashboard.ipynb
+widget_to_args.json
+hidden_code_manifest.json
+agilab_app_view_plan.json
+dashboard_app_preview.html
+voila_notebook_evidence.json
+```
+
+## Expected Preview
+
+Open `dashboard_app_preview.html` to inspect the static adoption plan. Open
+`dashboard.ipynb` to see the notebook shape that a future Voila runtime could
+serve.
+
+## Read The Script
+
+Start with `build_preview()`. It writes the notebook, widget-to-args contract,
+hide-code manifest, app-view plan, and evidence hashes.
+
+## Change One Thing
+
+Add one field to `widget_to_args_contract()`, rerun the preview, and compare the
+hashes in `voila_notebook_evidence.json`.
+
+## Troubleshooting
+
+- If `uv sync` is slow, run only the script with the checkout environment already
+  created.
+- If a generated path is not where you expect, pass `--output-dir`.
+- If you need a real Voila server, treat this preview as the contract first; the
+  optional runtime integration is still roadmap.

--- a/src/agilab/examples/voila_notebook_proof/preview_voila_notebook_proof.py
+++ b/src/agilab/examples/voila_notebook_proof/preview_voila_notebook_proof.py
@@ -1,0 +1,314 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_OUTPUT_DIR = Path.home() / "log" / "execute" / "voila_notebook_proof"
+SCHEMA = "agilab.example.voila_notebook_proof.evidence.v1"
+CREATED_AT = "2026-01-01T00:00:00Z"
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _artifact(path: Path, *, output_dir: Path) -> dict[str, Any]:
+    return {
+        "path": str(path.relative_to(output_dir)),
+        "bytes": path.stat().st_size,
+        "sha256": _sha256(path),
+    }
+
+
+def sample_notebook() -> dict[str, Any]:
+    """Return a small Voila-shaped notebook without importing runtime deps."""
+    return {
+        "cells": [
+            {
+                "cell_type": "markdown",
+                "metadata": {},
+                "source": [
+                    "# Sales risk dashboard\n",
+                    "\n",
+                    "This notebook keeps the interactive dashboard surface familiar while the "
+                    "AGILAB bridge extracts app arguments, code boundaries, and evidence.\n",
+                ],
+            },
+            {
+                "cell_type": "code",
+                "execution_count": None,
+                "metadata": {"agilab": {"role": "app_ui", "hide_input": True}},
+                "outputs": [],
+                "source": [
+                    "import ipywidgets as widgets\n",
+                    "region = widgets.Dropdown(options=['EU', 'NA', 'APAC'], value='EU', description='Region')\n",
+                    "min_margin = widgets.FloatSlider(value=0.18, min=0.0, max=0.5, step=0.01, description='Margin')\n",
+                    "include_forecast = widgets.Checkbox(value=True, description='Forecast')\n",
+                    "widgets.VBox([region, min_margin, include_forecast])\n",
+                ],
+            },
+            {
+                "cell_type": "code",
+                "execution_count": None,
+                "metadata": {"agilab": {"role": "worker_logic"}},
+                "outputs": [],
+                "source": [
+                    "def score_region(rows, *, region, min_margin, include_forecast):\n",
+                    "    selected = [row for row in rows if row['region'] == region]\n",
+                    "    risky = [row for row in selected if row['margin'] < min_margin]\n",
+                    "    return {\n",
+                    "        'region': region,\n",
+                    "        'rows': len(selected),\n",
+                    "        'risky_rows': len(risky),\n",
+                    "        'forecast_enabled': include_forecast,\n",
+                    "    }\n",
+                ],
+            },
+            {
+                "cell_type": "code",
+                "execution_count": None,
+                "metadata": {"agilab": {"role": "analysis_output", "hide_input": True}},
+                "outputs": [],
+                "source": [
+                    "rows = [\n",
+                    "    {'region': 'EU', 'margin': 0.14},\n",
+                    "    {'region': 'EU', 'margin': 0.22},\n",
+                    "    {'region': 'NA', 'margin': 0.19},\n",
+                    "]\n",
+                    "score_region(rows, region=region.value, min_margin=min_margin.value, include_forecast=include_forecast.value)\n",
+                ],
+            },
+            {
+                "cell_type": "markdown",
+                "metadata": {"agilab": {"role": "evidence_note"}},
+                "source": [
+                    "AGILAB can keep this notebook as the stakeholder-facing dashboard while "
+                    "promoting stable widgets into app arguments and recording hashes for "
+                    "the notebook, generated view plan, and evidence sidecars.\n",
+                ],
+            },
+        ],
+        "metadata": {
+            "kernelspec": {
+                "display_name": "Python 3",
+                "language": "python",
+                "name": "python3",
+            },
+            "language_info": {"name": "python", "pygments_lexer": "ipython3"},
+            "agilab": {
+                "preview": "voila_notebook_proof",
+                "optional_runtime": "voila",
+                "runtime_required_for_preview": False,
+            },
+        },
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+
+
+def widget_to_args_contract() -> dict[str, Any]:
+    return {
+        "schema": "agilab.example.voila_notebook_proof.widget_to_args.v1",
+        "source": "dashboard.ipynb",
+        "app_args": {
+            "region": {
+                "widget": "Dropdown",
+                "type": "str",
+                "default": "EU",
+                "choices": ["EU", "NA", "APAC"],
+            },
+            "min_margin": {
+                "widget": "FloatSlider",
+                "type": "float",
+                "default": 0.18,
+                "minimum": 0.0,
+                "maximum": 0.5,
+            },
+            "include_forecast": {
+                "widget": "Checkbox",
+                "type": "bool",
+                "default": True,
+            },
+        },
+        "migration_hint": (
+            "Promote stable ipywidgets to app_args_form.py fields; keep "
+            "notebook-only presentation cells inside the app project."
+        ),
+    }
+
+
+def hidden_code_manifest() -> dict[str, Any]:
+    return {
+        "schema": "agilab.example.voila_notebook_proof.hidden_code.v1",
+        "source": "dashboard.ipynb",
+        "cells": [
+            {"index": 1, "role": "app_ui", "hide_input": True},
+            {"index": 2, "role": "worker_logic", "hide_input": False},
+            {"index": 3, "role": "analysis_output", "hide_input": True},
+            {"index": 4, "role": "evidence_note", "hide_input": False},
+        ],
+        "note": (
+            "The preview records the hide-code contract as data. A future "
+            "Voila runtime can apply the same contract when serving the notebook."
+        ),
+    }
+
+
+def app_view_plan() -> dict[str, Any]:
+    return {
+        "schema": "agilab.example.voila_notebook_proof.app_view_plan.v1",
+        "current_preview": True,
+        "target_app": "sales_dashboard_project",
+        "app_owned_files": [
+            "notebooks/dashboard.ipynb",
+            "src/app_args_form.py",
+            "src/sales_dashboard/worker_logic.py",
+            "src/sales_dashboard/app_surface.py",
+        ],
+        "shared_pages_boundary": [
+            {
+                "component": "view_app_ui",
+                "responsibility": (
+                    "Generic AGILAB surface that opens an app-declared UI entrypoint; "
+                    "it must not know sales-dashboard semantics."
+                ),
+            }
+        ],
+        "notebook_user_path": [
+            "Keep the existing notebook dashboard visible.",
+            "Extract stable widgets into AGILAB app arguments.",
+            "Move reusable compute cells into worker code.",
+            "Write evidence and artifact hashes on every run.",
+        ],
+        "future_command": "agilab notebook-proof dashboard.ipynb --app-name sales_dashboard",
+    }
+
+
+def _html_preview(*, contract: dict[str, Any], plan: dict[str, Any]) -> str:
+    fields = "\n".join(
+        f"<li><code>{name}</code>: {spec['widget']} -> {spec['type']}</li>"
+        for name, spec in contract["app_args"].items()
+    )
+    steps = "\n".join(f"<li>{step}</li>" for step in plan["notebook_user_path"])
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>AGILAB Voila notebook proof preview</title>
+  <style>
+    body {{ font-family: system-ui, sans-serif; margin: 2rem; line-height: 1.5; color: #172033; }}
+    main {{ max-width: 860px; }}
+    code {{ background: #eef2f7; padding: 0.1rem 0.25rem; border-radius: 4px; }}
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Voila notebook proof preview</h1>
+    <p>This static preview shows the migration contract before any Voila server integration.</p>
+    <h2>Widget to app arguments</h2>
+    <ul>{fields}</ul>
+    <h2>Adoption path</h2>
+    <ol>{steps}</ol>
+  </main>
+</body>
+</html>
+"""
+
+
+def build_preview(output_dir: Path = DEFAULT_OUTPUT_DIR) -> dict[str, Any]:
+    output_dir = output_dir.expanduser().resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    notebook = sample_notebook()
+    contract = widget_to_args_contract()
+    hidden_manifest = hidden_code_manifest()
+    plan = app_view_plan()
+
+    paths = {
+        "dashboard_notebook": output_dir / "dashboard.ipynb",
+        "widget_to_args": output_dir / "widget_to_args.json",
+        "hidden_code_manifest": output_dir / "hidden_code_manifest.json",
+        "app_view_plan": output_dir / "agilab_app_view_plan.json",
+        "static_preview": output_dir / "dashboard_app_preview.html",
+    }
+
+    _write_json(paths["dashboard_notebook"], notebook)
+    _write_json(paths["widget_to_args"], contract)
+    _write_json(paths["hidden_code_manifest"], hidden_manifest)
+    _write_json(paths["app_view_plan"], plan)
+    paths["static_preview"].write_text(
+        _html_preview(contract=contract, plan=plan),
+        encoding="utf-8",
+    )
+
+    evidence = {
+        "schema": SCHEMA,
+        "created_at": CREATED_AT,
+        "source_runtime": "voila",
+        "voila_dependency_required_for_preview": False,
+        "optional_runtime": "voila",
+        "future_extra": "agilab[voila]",
+        "future_command": plan["future_command"],
+        "artifacts": {
+            name: _artifact(path, output_dir=output_dir)
+            for name, path in paths.items()
+        },
+        "current_limits": [
+            "This preview does not launch a Voila server.",
+            "It does not execute ipywidgets or notebook kernels.",
+            "It records the migration and evidence contracts as deterministic files.",
+        ],
+    }
+    evidence_path = output_dir / "voila_notebook_evidence.json"
+    _write_json(evidence_path, evidence)
+
+    summary = dict(evidence)
+    summary["artifacts"] = dict(evidence["artifacts"])
+    summary["artifacts"]["evidence"] = _artifact(evidence_path, output_dir=output_dir)
+    summary["output_dir"] = str(output_dir)
+    return summary
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Create a deterministic AGILAB preview for Voila notebook users."
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=DEFAULT_OUTPUT_DIR,
+        help=f"Directory for generated preview artifacts. Default: {DEFAULT_OUTPUT_DIR}",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print the summary as JSON.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    summary = build_preview(output_dir=args.output_dir)
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    else:
+        print(f"Wrote Voila notebook proof preview to {summary['output_dir']}")
+        print(f"Evidence: {summary['artifacts']['evidence']['path']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/agilab/lib/agi-apps/pyproject.toml
+++ b/src/agilab/lib/agi-apps/pyproject.toml
@@ -139,6 +139,7 @@ packages = [
     "notebook_to_dask/*.json",
     "notebook_to_dask/*.toml",
     "notebook_to_dask/*.ipynb",
+    "voila_notebook_proof/*.py",
     "notebook_quickstart/*.ipynb",
     "notebook_migrations/*/README.md",
     "notebook_migrations/*/analysis_artifacts/*.csv",

--- a/src/agilab/notebook_pipeline_import.py
+++ b/src/agilab/notebook_pipeline_import.py
@@ -17,8 +17,6 @@ import re
 import tomllib
 from typing import Any, Mapping
 
-import tomli_w
-
 
 SCHEMA = "agilab.notebook_pipeline_import.v1"
 PREFLIGHT_SCHEMA = "agilab.notebook_import_preflight.v1"
@@ -46,6 +44,17 @@ ARTIFACT_SUFFIXES = (
     ".txt",
     ".toml",
 )
+
+
+def _dump_toml(payload: Mapping[str, Any], stream: Any) -> None:
+    try:
+        import tomli_w
+    except ModuleNotFoundError as exc:
+        raise RuntimeError(
+            "Writing a notebook pipeline TOML preview requires tomli-w. "
+            "Install `agilab[ui]` or add `tomli-w>=1.2.0` to the active environment."
+        ) from exc
+    tomli_w.dump(payload, stream)
 
 INPUT_PATH_PREFIXES = ("data/", "input/", "inputs/", "raw/")
 OUTPUT_PATH_PREFIXES = ("artifact", "artifacts/", "output/", "outputs/", "result", "results/")
@@ -1847,7 +1856,7 @@ def write_lab_stages_preview(
     path = path.expanduser()
     path.parent.mkdir(parents=True, exist_ok=True)
     with open(path, "wb") as stream:
-        tomli_w.dump(preview, stream)
+        _dump_toml(preview, stream)
     return path
 
 

--- a/test/test_app_installer_packaging.py
+++ b/test/test_app_installer_packaging.py
@@ -58,6 +58,7 @@ EXAMPLE_PREVIEWS = {
     ),
     "service_mode": ("preview_service_mode.py",),
     "train_then_serve": ("preview_train_then_serve.py",),
+    "voila_notebook_proof": ("preview_voila_notebook_proof.py",),
 }
 DEPRECATED_EXAMPLE_DIR_NAMES = {
     "data_io_2026",
@@ -730,6 +731,37 @@ def test_excel_workbook_proof_preview_writes_workbook_refresh_and_evidence(tmp_p
     assert evidence["office_add_in_required"] is False
 
 
+def test_voila_notebook_proof_preview_writes_notebook_view_plan_and_evidence(
+    tmp_path: Path,
+) -> None:
+    script = EXAMPLES_ROOT / "voila_notebook_proof" / "preview_voila_notebook_proof.py"
+    spec = importlib.util.spec_from_file_location("voila_notebook_proof_preview_test", script)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+
+    preview = module.build_preview(output_dir=tmp_path)
+
+    notebook = json.loads((tmp_path / "dashboard.ipynb").read_text(encoding="utf-8"))
+    contract = json.loads((tmp_path / "widget_to_args.json").read_text(encoding="utf-8"))
+    plan = json.loads((tmp_path / "agilab_app_view_plan.json").read_text(encoding="utf-8"))
+    evidence = json.loads((tmp_path / "voila_notebook_evidence.json").read_text(encoding="utf-8"))
+
+    assert notebook["nbformat"] == 4
+    assert any("ipywidgets" in "".join(cell.get("source", [])) for cell in notebook["cells"])
+    assert contract["app_args"]["region"]["widget"] == "Dropdown"
+    assert "notebooks/dashboard.ipynb" in plan["app_owned_files"]
+    assert plan["shared_pages_boundary"][0]["component"] == "view_app_ui"
+    assert evidence["schema"] == module.SCHEMA
+    assert evidence["voila_dependency_required_for_preview"] is False
+    assert (
+        evidence["artifacts"]["dashboard_notebook"]["sha256"]
+        == preview["artifacts"]["dashboard_notebook"]["sha256"]
+    )
+    assert preview["artifacts"]["evidence"]["path"] == "voila_notebook_evidence.json"
+
+
 def test_native_rust_worker_preview_writes_pyo3_project_and_evidence(tmp_path: Path) -> None:
     script = EXAMPLES_ROOT / "native_rust_worker" / "preview_native_rust_worker.py"
     spec = importlib.util.spec_from_file_location("native_rust_worker_preview_test", script)
@@ -894,6 +926,7 @@ def test_packaged_example_readmes_are_included_as_package_data() -> None:
     assert "notebook_to_dask/*.json" in package_data
     assert "notebook_to_dask/*.toml" in package_data
     assert "notebook_to_dask/*.ipynb" in package_data
+    assert "voila_notebook_proof/*.py" in package_data
     assert "notebook_quickstart/*.ipynb" in package_data
     assert "notebook_migrations/*/README.md" in package_data
     assert "notebook_migrations/*/analysis_artifacts/*.csv" in package_data

--- a/test/test_data_connector_live_ui_report.py
+++ b/test/test_data_connector_live_ui_report.py
@@ -111,7 +111,8 @@ def test_data_connector_live_ui_recorder_and_fallback_helpers() -> None:
 
     assert payload["run_status"] == "ready_for_live_ui"
     assert payload["summary"]["operator_opt_in_required_for_health"] is False
-    assert module.REPO_ROOT.name == "agilab"
+    assert (module.REPO_ROOT / "pyproject.toml").is_file()
+    assert (module.REPO_ROOT / "src" / "agilab").is_dir()
 
     warning_recorder = core_module.StreamlitCallRecorder()
     core_module.render_connector_live_ui(

--- a/test/test_pipeline_ai.py
+++ b/test/test_pipeline_ai.py
@@ -83,6 +83,17 @@ def reset_pipeline_ai_test_state(isolate_home_for_root_tests):
         clear()
 
 
+def _mark_openai_sdk_present(monkeypatch) -> None:
+    real_find_spec = pipeline_ai.importlib.util.find_spec
+
+    def find_spec_with_openai(name: str, *args, **kwargs):
+        if name == "openai":
+            return SimpleNamespace()
+        return real_find_spec(name, *args, **kwargs)
+
+    monkeypatch.setattr(pipeline_ai.importlib.util, "find_spec", find_spec_with_openai)
+
+
 def test_extract_code_splits_detail_and_python_block():
     message = "Use this.\n```python\nprint('ok')\n```\nDone."
 
@@ -2329,6 +2340,7 @@ def test_chat_universal_offline_formats_sources_and_raises(monkeypatch):
 def test_ask_gpt_routes_to_selected_provider(monkeypatch):
     fake_st = SimpleNamespace(session_state={"lab_prompt": [], "lab_llm_provider": "gpt-oss"})
     monkeypatch.setattr(pipeline_ai, "st", fake_st)
+    _mark_openai_sdk_present(monkeypatch)
     monkeypatch.setattr(pipeline_ai, "chat_offline", lambda *args: ("```python\nprint(1)\n```", "gpt-oss"))
     result = pipeline_ai.ask_gpt("q", Path("df.csv"), "page", {})
     assert result[2:] == ["gpt-oss", "print(1)", ""]
@@ -2373,6 +2385,7 @@ demo_project = [
         }
     )
     monkeypatch.setattr(pipeline_ai, "st", fake_st)
+    _mark_openai_sdk_present(monkeypatch)
 
     def _chat_online(question, prompt, envars):
         captured["question"] = question
@@ -2404,6 +2417,7 @@ def test_ask_gpt_safe_actions_returns_validated_contract_and_code(monkeypatch):
         }
     )
     monkeypatch.setattr(pipeline_ai, "st", fake_st)
+    _mark_openai_sdk_present(monkeypatch)
 
     def _fake_chat_online(question, prompt, envars, **kwargs):
         captured["question"] = question
@@ -2617,6 +2631,7 @@ def test_ask_gpt_safe_actions_fails_closed_for_raw_python_and_unknown_column(mon
         }
     )
     monkeypatch.setattr(pipeline_ai, "st", fake_st)
+    _mark_openai_sdk_present(monkeypatch)
     responses = iter(
         [
             ("```python\nimport os\nos.system('whoami')\n```", "gpt-safe"),
@@ -2826,6 +2841,7 @@ def test_mistral_online_env_update_and_api_error(monkeypatch):
 def test_generated_action_dataframe_and_empty_safe_response_paths(monkeypatch, tmp_path):
     fake_st = SimpleNamespace(session_state={"lab_prompt": [], "lab_llm_provider": "openai"})
     monkeypatch.setattr(pipeline_ai, "st", fake_st)
+    _mark_openai_sdk_present(monkeypatch)
 
     assert pipeline_ai._dataframe_for_generated_actions(Path("df.csv"), load_df_cached=None) is None
     assert pipeline_ai._dataframe_for_generated_actions("", load_df_cached=lambda *_args, **_kwargs: pd.DataFrame()) is None


### PR DESCRIPTION
## Summary
- add a packaged `voila_notebook_proof` preview that writes a notebook dashboard, widget-to-args contract, hide-code manifest, app-view plan, static HTML preview, and JSON evidence
- document the Voila-user adoption bridge in README/PyPI/docs/roadmap
- keep notebook import read-only paths dependency-light and harden two validation tests for isolated worktrees/no-AI-extra environments

## Validation
- `uv --preview-features extra-build-dependencies run python -m py_compile src/agilab/examples/voila_notebook_proof/preview_voila_notebook_proof.py`
- `uv --preview-features extra-build-dependencies run python src/agilab/examples/voila_notebook_proof/preview_voila_notebook_proof.py --output-dir /tmp/agilab-voila-proof --json`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_pyproject_dependency_hygiene.py test/test_notebook_pipeline_import_report.py test/test_app_installer_packaging.py test/test_data_connector_live_ui_report.py test/test_pipeline_ai.py`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui`
- `git diff --check`