### PR TITLE
Tighten ty release gate and PyPI trusted publisher workflow

### DIFF
--- a/.github/workflows/pypi-pending-trusted-publisher.yaml
+++ b/.github/workflows/pypi-pending-trusted-publisher.yaml
@@ -3,6 +3,10 @@ name: pypi-pending-trusted-publisher
 on:
   workflow_dispatch:
     inputs:
+      runner:
+        description: "Runner label for this workflow. Use ubuntu-latest or self-hosted."
+        required: false
+        default: "ubuntu-latest"
       project_name:
         description: "PyPI project name to be created by the next trusted publish."
         required: true
@@ -28,7 +32,7 @@ permissions:
 
 jobs:
   register:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -60,7 +64,7 @@ jobs:
             --environment "${{ inputs.pypi_environment }}" \
             --github-confirm-login-repository "$GITHUB_REPOSITORY" \
             --github-confirm-login-variable "PYPI_CONFIRM_LOGIN_URL" \
-            --github-confirm-login-timeout 180 \
+            --github-confirm-login-timeout 900 \
             --github-token "${PYPI_CONFIRM_READER_TOKEN:-$GITHUB_TOKEN}" \
             --json \
             --github-step-summary "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -76,6 +76,7 @@ jobs:
             --profile ui-frontend-smoke \
             --profile agi-core-combined \
             --profile shared-core-typing \
+            --profile ty-typing \
             --profile dependency-policy \
             --profile release-proof
 

--- a/badges/coverage-agi-cluster.svg
+++ b/badges/coverage-agi-cluster.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="181" height="20" role="img" aria-label="agi-cluster coverage: 97%">
+<svg xmlns="http://www.w3.org/2000/svg" width="181" height="20" role="img" aria-label="agi-cluster coverage: 96%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="75.0" y="15" fill="#010101" fill-opacity=".3">agi-cluster coverage</text>
   <text x="75.0" y="14">agi-cluster coverage</text>
-  <text x="165.5" y="15" fill="#010101" fill-opacity=".3">97%</text>
-  <text x="165.5" y="14">97%</text>
+  <text x="165.5" y="15" fill="#010101" fill-opacity=".3">96%</text>
+  <text x="165.5" y="14">96%</text>
 </g>
 </svg>

--- a/badges/coverage-agi-core.svg
+++ b/badges/coverage-agi-core.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="160" height="20" role="img" aria-label="agi-core coverage: 97%">
+<svg xmlns="http://www.w3.org/2000/svg" width="160" height="20" role="img" aria-label="agi-core coverage: 96%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="64.5" y="15" fill="#010101" fill-opacity=".3">agi-core coverage</text>
   <text x="64.5" y="14">agi-core coverage</text>
-  <text x="144.5" y="15" fill="#010101" fill-opacity=".3">97%</text>
-  <text x="144.5" y="14">97%</text>
+  <text x="144.5" y="15" fill="#010101" fill-opacity=".3">96%</text>
+  <text x="144.5" y="14">96%</text>
 </g>
 </svg>

--- a/badges/coverage-agi-gui.svg
+++ b/badges/coverage-agi-gui.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="153" height="20" role="img" aria-label="agi-gui coverage: 97%">
+<svg xmlns="http://www.w3.org/2000/svg" width="153" height="20" role="img" aria-label="agi-gui coverage: 96%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="61.0" y="15" fill="#010101" fill-opacity=".3">agi-gui coverage</text>
   <text x="61.0" y="14">agi-gui coverage</text>
-  <text x="137.5" y="15" fill="#010101" fill-opacity=".3">97%</text>
-  <text x="137.5" y="14">97%</text>
+  <text x="137.5" y="15" fill="#010101" fill-opacity=".3">96%</text>
+  <text x="137.5" y="14">96%</text>
 </g>
 </svg>

--- a/badges/coverage-agilab.svg
+++ b/badges/coverage-agilab.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="146" height="20" role="img" aria-label="agilab coverage: 97%">
+<svg xmlns="http://www.w3.org/2000/svg" width="146" height="20" role="img" aria-label="agilab coverage: 96%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="57.5" y="15" fill="#010101" fill-opacity=".3">agilab coverage</text>
   <text x="57.5" y="14">agilab coverage</text>
-  <text x="130.5" y="15" fill="#010101" fill-opacity=".3">97%</text>
-  <text x="130.5" y="14">97%</text>
+  <text x="130.5" y="15" fill="#010101" fill-opacity=".3">96%</text>
+  <text x="130.5" y="14">96%</text>
 </g>
 </svg>

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/agi_distributor.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/agi_distributor.py
@@ -221,7 +221,7 @@ class AGI:
         # At the top of __init__:
         if hasattr(AGI, "_instantiated") and AGI._instantiated:
             raise RuntimeError("AGI class is a singleton. Only one instance allowed per process.")
-        AGI._instantiated = True
+        AGI._instantiated = True  # ty: ignore[unresolved-attribute]
 
     @staticmethod
     async def run(
@@ -595,8 +595,8 @@ class AGI:
             ip: str,
             local_path: Path,
             remote_path: Path,
-            user: str = None,
-            password: str = None
+            user: str = None,  # ty: ignore[invalid-parameter-default]
+            password: str = None  # ty: ignore[invalid-parameter-default]
     ):
         await transport_support.send_file(
             env,
@@ -609,7 +609,7 @@ class AGI:
         )
 
     @staticmethod
-    async def send_files(env: AgiEnv, ip: str, files: list[Path], remote_dir: Path, user: str = None):
+    async def send_files(env: AgiEnv, ip: str, files: list[Path], remote_dir: Path, user: str = None):  # ty: ignore[invalid-parameter-default]
         await transport_support.send_files(
             AGI,
             env,
@@ -643,7 +643,7 @@ class AGI:
             run_path_fn=runpy.run_path,
             sys_module=sys,
             path_cls=Path,
-            detect_export_cmd_fn=AGI._detect_export_cmd,
+            detect_export_cmd_fn=AGI._detect_export_cmd,  # ty: ignore[invalid-argument-type]
             log=logger,
         )
 
@@ -760,7 +760,7 @@ class AGI:
             wenv_rel,
             options_worker,
             agi_version_missing_on_pypi_fn=runtime_misc_support.agi_version_missing_on_pypi,
-            worker_site_packages_dir_fn=uv_source_support.worker_site_packages_dir,
+            worker_site_packages_dir_fn=uv_source_support.worker_site_packages_dir,  # ty: ignore[invalid-argument-type]
             write_staged_uv_sources_pth_fn=uv_source_support.write_staged_uv_sources_pth,
             runtime_file=__file__,
             run_fn=AgiEnv.run,
@@ -790,7 +790,7 @@ class AGI:
     async def _uninstall_modules() -> None:
         await deployment_prepare_support.uninstall_modules(
             AGI,
-            AGI.env,
+            AGI.env,  # ty: ignore[invalid-argument-type]
             run_fn=AgiEnv.run,
             log=logger,
         )

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/background_jobs_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/background_jobs_support.py
@@ -38,7 +38,7 @@ class BackgroundProcessManager:
         if cwd in (None, ""):
             return None
         try:
-            candidate = Path(cast(str | Path, cwd)).expanduser()
+            candidate = Path(cast(str | Path, cwd)).expanduser()  # ty: ignore[redundant-cast]
         except _NORMALIZE_CWD_EXCEPTIONS:
             return None
         return str(candidate) if candidate.is_dir() else None

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/cli.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/cli.py
@@ -220,7 +220,7 @@ def kill(exclude_pids=None):
 
 def unzip(wenv=None):
     try:
-        root = Path(wenv)
+        root = Path(wenv)  # ty: ignore[invalid-argument-type]
         root_src = root / 'src'
         logger.info(f"Ensuring src directory exists at {root_src}")
         root_src.mkdir(parents=True, exist_ok=True)

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_local_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_local_support.py
@@ -31,7 +31,7 @@ from agi_env import AgiEnv
 logger = logging.getLogger(__name__)
 FORCE_REMOVE_EXCEPTIONS = (OSError, shutil.Error)
 DEPENDENCY_PARSE_EXCEPTIONS = (InvalidRequirement,)
-PYPROJECT_PARSE_EXCEPTIONS = (OSError, tomlkit.exceptions.ParseError)
+PYPROJECT_PARSE_EXCEPTIONS = (OSError, tomlkit.exceptions.ParseError)  # ty: ignore[possibly-missing-submodule]
 PYTHON_VERSION_RE = re.compile(r"(\d+)(?:\.(\d+))?(?:\.(\d+))?")
 SHARED_WORKER_VENV_ENV = "AGILAB_SHARED_WORKER_VENV"
 SHARED_WORKER_VENV_DIR_ENV = "AGILAB_SHARED_WORKER_VENV_DIR"
@@ -1378,13 +1378,13 @@ def _write_manager_sync_overlay(
     project_name = project.get("name")
 
     tool = doc.get("tool")
-    if tool is None or not isinstance(tool, tomlkit.items.Table):
+    if tool is None or not isinstance(tool, tomlkit.items.Table):  # ty: ignore[possibly-missing-submodule]
         tool = tomlkit.table()
     uv = tool.get("uv")
-    if uv is None or not isinstance(uv, tomlkit.items.Table):
+    if uv is None or not isinstance(uv, tomlkit.items.Table):  # ty: ignore[possibly-missing-submodule]
         uv = tomlkit.table()
     sources = uv.get("sources")
-    if sources is None or not isinstance(sources, tomlkit.items.Table):
+    if sources is None or not isinstance(sources, tomlkit.items.Table):  # ty: ignore[possibly-missing-submodule]
         sources = tomlkit.table()
 
     if isinstance(project_name, str):
@@ -1486,7 +1486,7 @@ def _update_pyproject_dependencies(
     if deps is None:
         deps = tomlkit.array()
     else:
-        if not isinstance(deps, tomlkit.items.Array):
+        if not isinstance(deps, tomlkit.items.Array):  # ty: ignore[possibly-missing-submodule]
             arr = tomlkit.array()
             for item in deps:
                 arr.append(item)

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/run_request_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/run_request_support.py
@@ -84,7 +84,7 @@ class RunRequest:
     def to_dispatch_kwargs(self) -> dict[str, Any]:
         payload = self.to_app_kwargs()
         if self.stages:
-            payload[RUN_STAGES_KEY] = [stage.to_payload() for stage in self.stages]
+            payload[RUN_STAGES_KEY] = [stage.to_payload() for stage in self.stages]  # ty: ignore[unresolved-attribute]
         return payload
 
     def to_target_kwargs(self) -> dict[str, Any]:

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/service_lifecycle_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/service_lifecycle_support.py
@@ -89,7 +89,7 @@ def _submit_service_worker_inits(
             client.submit(
                 BaseWorker._new,
                 env=0 if getattr(env, "debug", False) else None,
-                app=env.target_worker,
+                app=env.target_worker,  # ty: ignore[unresolved-attribute]
                 mode=agi_cls._mode,
                 verbose=agi_cls.verbose,
                 worker_id=worker_id,
@@ -141,7 +141,7 @@ async def service_recover(
 
     try:
         agi_cls.env = env
-        agi_cls.target_path = env.manager_path
+        agi_cls.target_path = env.manager_path  # ty: ignore[unresolved-attribute]
         agi_cls._target = env.target
         agi_cls._mode = int(state.get("mode", agi_cls.DASK_MODE))
         agi_cls._mode_auto = False

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/uv_source_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/uv_source_support.py
@@ -93,7 +93,7 @@ def ensure_optional_extras(pyproject_file: Path, extras: Set[str]) -> None:
         project_tbl = tomlkit.table()
 
     optional_tbl = project_tbl.get("optional-dependencies")
-    if optional_tbl is None or not isinstance(optional_tbl, tomlkit.items.Table):
+    if optional_tbl is None or not isinstance(optional_tbl, tomlkit.items.Table):  # ty: ignore[possibly-missing-submodule]
         optional_tbl = tomlkit.table()
 
     for extra in sorted({e for e in extras if isinstance(e, str) and e.strip()}):

--- a/src/agilab/core/agi-env/src/agi_env/agi_env.py
+++ b/src/agilab/core/agi-env/src/agi_env/agi_env.py
@@ -183,7 +183,7 @@ def _optional_agi_pages_bundles_root() -> Path | None:
     if importlib.util.find_spec("agi_pages") is None:
         return None
     try:
-        import agi_pages  # type: ignore
+        import agi_pages
     except (ImportError, AttributeError, TypeError, OSError):
         return None
     bundles_root = getattr(agi_pages, "bundles_root", None)
@@ -209,7 +209,7 @@ def _resolve_worker_hook(filename: str) -> Path | None:
     return resolve_worker_hook(filename, module_file=__file__)
 
 
-_resolve_worker_hook.cache_clear = resolve_worker_hook.cache_clear  # type: ignore[attr-defined]
+_resolve_worker_hook.cache_clear = resolve_worker_hook.cache_clear  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
 
 
 def _select_hook(local_candidate: Path, fallback_filename: str, hook_label: str) -> tuple[Path, bool]:
@@ -377,7 +377,7 @@ class AgiEnv(metaclass=_AgiEnvMeta):
         self.resources_path = home_abs / self._agi_resources.name
         env_path = self.resources_path / ".env"
         self.benchmark = self.resources_path / "benchmark.json"
-        self.envars = _load_dotenv_values(env_path, verbose=verbose)
+        self.envars = _load_dotenv_values(env_path, verbose=verbose)  # ty: ignore[invalid-argument-type]
         logger.debug(f"env path: {env_path}")
         envars = self.envars
         repo_agilab_dir = Path(__file__).resolve().parents[4]
@@ -593,21 +593,21 @@ class AgiEnv(metaclass=_AgiEnvMeta):
             self.user = "agi"
             return
 
-        if self.worker_path.exists():
+        if self.worker_path.exists():  # ty: ignore[unresolved-attribute]
             self.base_worker_cls, self._base_worker_module = self.get_base_worker_cls(
-                self.worker_path, self.target_worker_class
+                self.worker_path, self.target_worker_class  # ty: ignore[unresolved-attribute]
             )
         else:
             self.base_worker_cls, self._base_worker_module = (None, None)
             # In packaged end‑user environments, worker sources may be absent by design.
             # Proceed without exiting; the installer will materialize required files under wenv.
             if (not self.is_source_env) and (not self.is_worker_env):
-                AgiEnv.logger.debug(
-                    f"Missing {self.target_worker_class} definition; expected {self.worker_path} (packaged end-user env)"
+                AgiEnv.logger.debug(  # ty: ignore[unresolved-attribute]
+                    f"Missing {self.target_worker_class} definition; expected {self.worker_path} (packaged end-user env)"  # ty: ignore[unresolved-attribute]
                 )
             else:
-                AgiEnv.logger.info(
-                    f"Missing {self.target_worker_class} definition; expected {self.worker_path}"
+                AgiEnv.logger.info(  # ty: ignore[unresolved-attribute]
+                    f"Missing {self.target_worker_class} definition; expected {self.worker_path}"  # ty: ignore[unresolved-attribute]
                 )
 
         envars = self.envars
@@ -619,9 +619,9 @@ class AgiEnv(metaclass=_AgiEnvMeta):
         ssh_key_env = ssh_key_env.strip() if isinstance(ssh_key_env, str) else ""
         self.ssh_key_path = str(Path(ssh_key_env).expanduser()) if ssh_key_env else None
 
-        self.projects = self.get_projects(self.apps_path, self.builtin_apps_path)
+        self.projects = self.get_projects(self.apps_path, self.builtin_apps_path)  # ty: ignore[invalid-argument-type]
         if not self.projects:
-            AgiEnv.logger.info(f"Could not find any target project app in {self.agilab_pck / 'apps'}.")
+            AgiEnv.logger.info(f"Could not find any target project app in {self.agilab_pck / 'apps'}.")  # ty: ignore[unresolved-attribute]
 
         self.setup_app = self.active_app / "build.py"
         self.setup_app_module = "agi_node.agi_dispatcher.build"
@@ -665,14 +665,14 @@ class AgiEnv(metaclass=_AgiEnvMeta):
                 try:
                     self.unzip_data(Path(dataset_archive), self.app_data_rel, force_extract=True)
                 except (OSError, RuntimeError, ValueError, TypeError) as exc:  # pragma: no cover - defensive guard
-                    AgiEnv.logger.warning(
+                    AgiEnv.logger.warning(  # ty: ignore[unresolved-attribute]
                         "Failed to extract packaged dataset %s: %s",
                         dataset_archive,
                         exc,
                     )
 
-        _ensure_dir(self.app_src)
-        app_src_str = str(self.app_src)
+        _ensure_dir(self.app_src)  # ty: ignore[unresolved-attribute]
+        app_src_str = str(self.app_src)  # ty: ignore[unresolved-attribute]
         if app_src_str not in sys.path:
             sys.path.append(app_src_str)
 
@@ -716,9 +716,9 @@ class AgiEnv(metaclass=_AgiEnvMeta):
             node_pck=self.node_pck,
             core_pck=self.core_pck,
             cluster_pck=self.cluster_pck,
-            dist_abs=self.dist_abs,
-            app_src=self.app_src,
-            wenv_abs=self.wenv_abs,
+            dist_abs=self.dist_abs,  # ty: ignore[unresolved-attribute]
+            app_src=self.app_src,  # ty: ignore[unresolved-attribute]
+            wenv_abs=self.wenv_abs,  # ty: ignore[unresolved-attribute]
             agilab_pck=self.agilab_pck,
             dedupe_paths_fn=self._dedupe_paths,
         )
@@ -792,7 +792,7 @@ class AgiEnv(metaclass=_AgiEnvMeta):
     def set_env_var(key: str, value: str):
         """Persist ``key``/``value`` in :attr:`envars`, ``os.environ`` and the ``.env`` file."""
         AgiEnv._ensure_defaults()
-        AgiEnv.envars[key] = value
+        AgiEnv.envars[key] = value  # ty: ignore[invalid-assignment]
         os.environ[key] = str(value)
         AgiEnv._update_env_file({key: value})
 
@@ -845,7 +845,7 @@ class AgiEnv(metaclass=_AgiEnvMeta):
                 cls.resources_path = Path(".agilab").resolve()
         if getattr(cls, "envars", None) is None or not isinstance(cls.envars, dict):
             try:
-                env_path = cls.resources_path / ".env"
+                env_path = cls.resources_path / ".env"  # ty: ignore[unsupported-operator]
                 cls.envars = _load_dotenv_values(env_path, verbose=False)
             except (OSError, RuntimeError, TypeError, ValueError):
                 cls.envars = {}
@@ -887,14 +887,14 @@ class AgiEnv(metaclass=_AgiEnvMeta):
 
     def _update_env_file(updates: dict):
         AgiEnv._ensure_defaults()
-        env_file = AgiEnv.resources_path / ".env"
+        env_file = AgiEnv.resources_path / ".env"  # ty: ignore[unsupported-operator]
         write_env_updates(env_file, updates)
 
     def _init_resources(self, resources_src):
         """Replicate ``resources_src`` into the managed ``.agilab`` tree."""
 
         src_env_path = resources_src / ".env"
-        dest_env_file = self.resources_path / ".env"
+        dest_env_file = self.resources_path / ".env"  # ty: ignore[unsupported-operator]
         if not dest_env_file.exists():
             _ensure_dir(dest_env_file.parent)
             shutil.copy(src_env_path, dest_env_file)
@@ -902,7 +902,7 @@ class AgiEnv(metaclass=_AgiEnvMeta):
             for file in files:
                 src_file = Path(root) / file
                 relative_path = src_file.relative_to(resources_src)
-                dest_file = self.resources_path / relative_path
+                dest_file = self.resources_path / relative_path  # ty: ignore[unsupported-operator]
                 _ensure_dir(dest_file.parent)
                 if not dest_file.exists():
                     shutil.copy(src_file, dest_file)
@@ -917,18 +917,18 @@ class AgiEnv(metaclass=_AgiEnvMeta):
         if not self.is_source_env:
             for extra in extras:
                 src_extra = self.st_resources / extra
-                dest_extra = self.resources_path / extra
+                dest_extra = self.resources_path / extra  # ty: ignore[unsupported-operator]
                 if src_extra.exists() and not dest_extra.exists():
                     _ensure_dir(dest_extra.parent)
                     shutil.copy(src_extra, dest_extra)
         else:
             for extra in extras:
-                dest_extra = self.resources_path / extra
+                dest_extra = self.resources_path / extra  # ty: ignore[unsupported-operator]
                 try:
                     if dest_extra.exists():
                         dest_extra.unlink()
                 except OSError:
-                    AgiEnv.logger.warning(f"Could not remove legacy resource {dest_extra}")
+                    AgiEnv.logger.warning(f"Could not remove legacy resource {dest_extra}")  # ty: ignore[unresolved-attribute]
 
     def _init_projects(self):
         """Identify available projects and align state with the selected target."""
@@ -936,7 +936,7 @@ class AgiEnv(metaclass=_AgiEnvMeta):
         if self.apps_repository_root is None:
             self.apps_repository_root = self._get_apps_repository_root()
 
-        self.projects = self.get_projects(self.apps_path, self.builtin_apps_path, self.apps_repository_root)
+        self.projects = self.get_projects(self.apps_path, self.builtin_apps_path, self.apps_repository_root)  # ty: ignore[invalid-argument-type]
         for idx, project in enumerate(self.projects):
             if self.target == project[:-8].replace("-", "_"):
                 self.app = self.apps_path / project
@@ -963,11 +963,11 @@ class AgiEnv(metaclass=_AgiEnvMeta):
                 if project_path.is_symlink() and not project_path.exists():
                     try:
                         project_path.unlink()
-                        AgiEnv.logger.info(
+                        AgiEnv.logger.info(  # ty: ignore[unresolved-attribute]
                             f"Removed dangling project symlink: {project_path}"
                         )
                     except OSError as exc:
-                        AgiEnv.logger.warning(
+                        AgiEnv.logger.warning(  # ty: ignore[unresolved-attribute]
                             f"Failed to remove dangling project symlink {project_path}: {exc}"
                         )
                     continue
@@ -1019,7 +1019,7 @@ class AgiEnv(metaclass=_AgiEnvMeta):
         if not link_root:
             return False
 
-        candidate = link_root / self.app
+        candidate = link_root / self.app  # ty: ignore[unsupported-operator]
         if not candidate.exists():
             return False
 
@@ -1032,7 +1032,7 @@ class AgiEnv(metaclass=_AgiEnvMeta):
 
         if not AgiEnv.create_symlink(candidate, dest):
             return False
-        AgiEnv.logger.info("Created apps repository symlink: %s -> %s", dest, candidate)
+        AgiEnv.logger.info("Created apps repository symlink: %s -> %s", dest, candidate)  # ty: ignore[unresolved-attribute]
         return True
 
     @staticmethod
@@ -1050,7 +1050,7 @@ class AgiEnv(metaclass=_AgiEnvMeta):
         return app_settings_source_roots(
             target_app=app_name or self.app,
             current_app=self.app,
-            app_src=self.app_src,
+            app_src=self.app_src,  # ty: ignore[unresolved-attribute]
             active_app=self.active_app,
             apps_path=self.apps_path,
             builtin_apps_path=self.builtin_apps_path,
@@ -1064,7 +1064,7 @@ class AgiEnv(metaclass=_AgiEnvMeta):
         return find_versioned_app_settings_file(
             target_app=app_name or self.app,
             current_app=self.app,
-            app_src=self.app_src,
+            app_src=self.app_src,  # ty: ignore[unresolved-attribute]
             active_app=self.active_app,
             apps_path=self.apps_path,
             builtin_apps_path=self.builtin_apps_path,
@@ -1086,7 +1086,7 @@ class AgiEnv(metaclass=_AgiEnvMeta):
         """
         return resolve_workspace_app_settings_file(
             target_app=app_name or self.app or self.target,
-            resources_path=self.resources_path,
+            resources_path=self.resources_path,  # ty: ignore[invalid-argument-type]
             ensure_exists=ensure_exists,
             find_source_file=self.find_source_app_settings_file,
         )
@@ -1101,7 +1101,7 @@ class AgiEnv(metaclass=_AgiEnvMeta):
 
     def mode2str(self, mode):
         """Encode a bitmask ``mode`` into readable ``pcdr`` flag form."""
-        return mode_to_str(mode, hw_rapids_capable=self.hw_rapids_capable)
+        return mode_to_str(mode, hw_rapids_capable=self.hw_rapids_capable)  # ty: ignore[invalid-argument-type]
 
     @staticmethod
     def mode2int(mode):
@@ -1139,7 +1139,7 @@ class AgiEnv(metaclass=_AgiEnvMeta):
         self.AGILAB_LOG_ABS = log_connector.path
         runenv_base = self.AGILAB_LOG_ABS / "execute"
         _ensure_dir(runenv_base)
-        self.runenv = runenv_base / self.target
+        self.runenv = runenv_base / self.target  # ty: ignore[unsupported-operator]
         _ensure_dir(self.runenv)
         export_connector = resolve_connector_root(
             self,
@@ -1184,7 +1184,7 @@ class AgiEnv(metaclass=_AgiEnvMeta):
 
         self.AGILAB_PAGES_ABS = pages_root
         if not self.AGILAB_PAGES_ABS.exists():
-            AgiEnv.logger.info(f"AGILAB_PAGES_ABS missing: {self.AGILAB_PAGES_ABS}")
+            AgiEnv.logger.info(f"AGILAB_PAGES_ABS missing: {self.AGILAB_PAGES_ABS}")  # ty: ignore[unresolved-attribute]
         self.copilot_file = self.agilab_pck / "agi_codex.py"
 
 
@@ -1228,11 +1228,11 @@ class AgiEnv(metaclass=_AgiEnvMeta):
 
 
     def _init_apps(self):
-        app_settings_source_file = self.find_source_app_settings_file() or (self.app_src / "app_settings.toml")
+        app_settings_source_file = self.find_source_app_settings_file() or (self.app_src / "app_settings.toml")  # ty: ignore[unresolved-attribute]
         self.app_settings_source_file = app_settings_source_file
         self.app_settings_file = self.resolve_user_app_settings_file()
 
-        app_args_form = self.app_src / "app_args_form.py"
+        app_args_form = self.app_src / "app_args_form.py"  # ty: ignore[unresolved-attribute]
         app_args_form.touch(exist_ok=True)
         self.app_args_form = app_args_form
 
@@ -1240,11 +1240,11 @@ class AgiEnv(metaclass=_AgiEnvMeta):
         dest = self.resources_path
         src = self.agilab_pck / "resources"
         if src.exists():
-            dest.mkdir(parents=True, exist_ok=True)
+            dest.mkdir(parents=True, exist_ok=True)  # ty: ignore[unresolved-attribute]
             for file in src.iterdir():
                 if not file.is_file():
                     continue
-                dest_file = dest / file.name
+                dest_file = dest / file.name  # ty: ignore[unsupported-operator]
                 if dest_file.exists():
                     continue
                 shutil.copy(file, dest_file)
@@ -1308,7 +1308,7 @@ class AgiEnv(metaclass=_AgiEnvMeta):
             build_env_fn=AgiEnv._build_env,
         )
 
-    async def run_agi(self, code, log_callback=None, venv: Path = None, type=None):
+    async def run_agi(self, code, log_callback=None, venv: Path = None, type=None):  # ty: ignore[invalid-parameter-default]
         """Asynchronous version of run_agi for use within an async context."""
         return await run_agi_snippet(
             code=code,
@@ -1448,7 +1448,7 @@ class AgiEnv(metaclass=_AgiEnvMeta):
             bool: True if admin, False otherwise.
         """
         try:
-            return ctypes.windll.shell32.IsUserAnAdmin()
+            return ctypes.windll.shell32.IsUserAnAdmin()  # ty: ignore[unresolved-attribute]
         except (AttributeError, OSError, RuntimeError):
             return False
 
@@ -1484,7 +1484,7 @@ class AgiEnv(metaclass=_AgiEnvMeta):
             dest (Path): Destination symlink path.
         """
         # Define necessary Windows API functions and constants
-        CreateSymbolicLink = ctypes.windll.kernel32.CreateSymbolicLinkW
+        CreateSymbolicLink = ctypes.windll.kernel32.CreateSymbolicLinkW  # ty: ignore[unresolved-attribute]
         CreateSymbolicLink.restype = wintypes.BOOL
         CreateSymbolicLink.argtypes = [wintypes.LPCWSTR, wintypes.LPCWSTR, wintypes.DWORD]
 
@@ -1507,7 +1507,7 @@ class AgiEnv(metaclass=_AgiEnvMeta):
             if logger:
                 logger.info(f"Created symbolic link for .venv: {dest} -> {source}")
         else:
-            error_code = ctypes.GetLastError()
+            error_code = ctypes.GetLastError()  # ty: ignore[unresolved-attribute]
             logger = AgiEnv.logger
             if logger:
                 logger.info(
@@ -1523,7 +1523,7 @@ class AgiEnv(metaclass=_AgiEnvMeta):
         clone_app_project(
             target_project,
             dest_project,
-            apps_path=self.apps_path,
+            apps_path=self.apps_path,  # ty: ignore[invalid-argument-type]
             home_abs=self.home_abs,
             projects=self.projects,
             logger=AgiEnv.logger,
@@ -1567,7 +1567,7 @@ class AgiEnv(metaclass=_AgiEnvMeta):
     def unzip_data(
         self,
         archive_path: Path,
-        extract_to: Path | str = None,
+        extract_to: Path | str = None,  # ty: ignore[invalid-parameter-default]
         *,
         force_extract: bool = False,
     ):
@@ -1584,22 +1584,22 @@ class AgiEnv(metaclass=_AgiEnvMeta):
             ensure_dir_fn=_ensure_dir,
             sevenzip_file_cls=py7zr.SevenZipFile,
             rmtree_fn=shutil.rmtree,
-            environ=os.environ,
+            environ=os.environ,  # ty: ignore[invalid-argument-type]
         )
 
 
     @staticmethod
     def check_internet():
-        AgiEnv.logger.info("Checking internet connectivity...")
+        AgiEnv.logger.info("Checking internet connectivity...")  # ty: ignore[unresolved-attribute]
         try:
             # HEAD request to Google
             req = urllib.request.Request("https://www.google.com", method="HEAD")
             with urllib.request.urlopen(req, timeout=3) as resp:
                 pass  # Success if no exception
         except OSError:
-            AgiEnv.logger.error("No internet connection detected. Aborting.")
+            AgiEnv.logger.error("No internet connection detected. Aborting.")  # ty: ignore[unresolved-attribute]
             return False
-        AgiEnv.logger.info("Internet connection is OK.")
+        AgiEnv.logger.info("Internet connection is OK.")  # ty: ignore[unresolved-attribute]
         return True
 
 

--- a/src/agilab/core/agi-env/src/agi_env/agi_logger.py
+++ b/src/agilab/core/agi-env/src/agi_env/agi_logger.py
@@ -97,7 +97,7 @@ def _render_log_message(record: logging.LogRecord) -> str:
 
 def _render_venv_label(prefix: str, *, os_name: str) -> str:
     if not prefix:
-        return COLORS["classname"] + "<unknown>" + RESET
+        return COLORS["classname"] + "<unknown>" + RESET  # ty: ignore[unsupported-operator]
     parts = prefix.split("\\") if os_name == "nt" else prefix.split("/")
     return parts[-2] if len(parts) >= 2 else prefix
 
@@ -216,12 +216,12 @@ class LogFormatter(logging.Formatter):
         self.verbose = verbose
 
     def format(self, record):
-        level_color = COLORS["level"].get(record.levelname, "")
+        level_color = COLORS["level"].get(record.levelname, "")  # ty: ignore[unresolved-attribute]
         levelname = level_color
 
         venv_str = _render_venv_label(sys.prefix, os_name=os.name)
         functionName_str = _render_record_origin(record)
-        message = COLORS["msg"] + _render_log_message(record) + RESET
+        message = COLORS["msg"] + _render_log_message(record) + RESET  # ty: ignore[unsupported-operator]
         if not hasattr(record, "subprocess"):
             return levelname + venv_str + '.' + functionName_str + ' ' + message
         return f"{message}"

--- a/src/agilab/core/agi-env/src/agi_env/app_settings_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/app_settings_support.py
@@ -134,7 +134,7 @@ def candidate_app_settings_path(base: object) -> Path | None:
     """Return a safe candidate path for ``app_settings.toml`` or ``None``."""
 
     try:
-        base_path = Path(base)
+        base_path = Path(base)  # ty: ignore[invalid-argument-type]
     except PATH_VALUE_EXCEPTIONS:
         return None
 

--- a/src/agilab/core/agi-env/src/agi_env/bootstrap_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/bootstrap_support.py
@@ -253,7 +253,7 @@ def resolve_active_app_selection(
                 projects=[
                     SimpleNamespace(name=project.name, project_root=project, provider=project.name)
                     for project in installed_app_projects
-                ],
+                ],  # ty: ignore[invalid-argument-type]
             )
             if installed_app is not None:
                 active_app = installed_app

--- a/src/agilab/core/agi-env/src/agi_env/credential_store_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/credential_store_support.py
@@ -39,7 +39,7 @@ def _load_keyring_module(keyring_module: Any = None) -> Any:
     if keyring_module is not None:
         return keyring_module
     try:
-        import keyring  # type: ignore
+        import keyring
     except ImportError:
         return None
     return keyring

--- a/src/agilab/core/agi-env/src/agi_env/data_archive_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/data_archive_support.py
@@ -44,7 +44,7 @@ def unzip_data(
     ensure_dir_fn: Callable[[str | Path], Path],
     sevenzip_file_cls: type[Any],
     rmtree_fn: Callable[..., Any],
-    environ: dict[str, str] = os.environ,
+    environ: dict[str, str] = os.environ,  # ty: ignore[invalid-parameter-default]
 ) -> None:
     """Extract a `.7z` dataset archive into the app share directory."""
 

--- a/src/agilab/core/agi-env/src/agi_env/execution_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/execution_support.py
@@ -195,7 +195,7 @@ async def run(
     verbose: int = 0,
     logger: Any = None,
     build_env_fn: Callable[[Path | str | None], dict[str, str]] | None = None,
-) -> str | int:
+) -> str | int:  # ty: ignore[invalid-return-type]
     """Run a shell command and stream output in real time."""
 
     if verbose > 0:
@@ -296,7 +296,7 @@ async def run_bg(
     if env_override:
         process_env.update(env_override)
 
-    cmd = inject_uv_preview_flag(cmd)
+    cmd = inject_uv_preview_flag(cmd)  # ty: ignore[invalid-assignment]
     result: list[str] = []
 
     proc = await _spawn_process(
@@ -324,7 +324,7 @@ async def run_bg(
 
     if returncode != 0:
         _raise_nonzero_process_result(
-            returncode=returncode,
+            returncode=returncode,  # ty: ignore[invalid-argument-type]
             cmd=cmd,
             logger=logger,
             simple_message=True,
@@ -364,7 +364,7 @@ async def run_async(
     proc = None
     try:
         proc = await _spawn_process(
-            cmd=cmd,
+            cmd=cmd,  # ty: ignore[invalid-argument-type]
             cwd=cwd,
             process_env=process_env,
             shell_executable=shell_executable,
@@ -388,11 +388,11 @@ async def run_async(
             command_context=f"Error during: {cmd}",
         )
 
-    rc = proc.returncode
+    rc = proc.returncode  # ty: ignore[unresolved-attribute]
     if rc != 0:
         _raise_nonzero_process_result(
-            returncode=rc,
-            cmd=cmd,
+            returncode=rc,  # ty: ignore[invalid-argument-type]
+            cmd=cmd,  # ty: ignore[invalid-argument-type]
             logger=logger,
             result=result,
         )

--- a/src/agilab/core/agi-env/src/agi_env/mlflow_store.py
+++ b/src/agilab/core/agi-env/src/agi_env/mlflow_store.py
@@ -17,7 +17,7 @@ from importlib.util import find_spec
 import os
 from pathlib import Path
 try:
-    from pathlib import UnsupportedOperation  # Python 3.13+
+    from pathlib import UnsupportedOperation  # Python 3.13+  # ty: ignore[unresolved-import]
 except ImportError:  # pragma: no cover - older Pythons
     UnsupportedOperation = NotImplementedError  # type: ignore[assignment]
 import shutil

--- a/src/agilab/core/agi-env/src/agi_env/package_layout_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/package_layout_support.py
@@ -37,7 +37,7 @@ def resolve_agilab_package_context(
 
     agilab_spec = find_spec_fn("agilab")
     if agilab_spec and getattr(agilab_spec, "origin", None):
-        package_dir = path_cls(agilab_spec.origin).resolve().parent
+        package_dir = path_cls(agilab_spec.origin).resolve().parent  # ty: ignore[invalid-argument-type]
     else:
         package_dir = repo_agilab_dir
     package_dir = package_dir.resolve()
@@ -92,7 +92,7 @@ def resolve_package_layout(
         cli_spec = find_spec_fn("agi_cluster.agi_distributor.cli")
     except ModuleNotFoundError:
         cli_spec = None
-    cli = path_cls(cli_spec.origin) if cli_spec and getattr(cli_spec, "origin", None) else cluster_pck / "agi_distributor/cli.py"
+    cli = path_cls(cli_spec.origin) if cli_spec and getattr(cli_spec, "origin", None) else cluster_pck / "agi_distributor/cli.py"  # ty: ignore[invalid-argument-type]
 
     return PackageLayout(
         agilab_pck=installed_package_dir,

--- a/src/agilab/core/agi-env/src/agi_env/pagelib.py
+++ b/src/agilab/core/agi-env/src/agi_env/pagelib.py
@@ -836,7 +836,7 @@ def save_csv(df, path: Path, sep=",") -> bool:
         path (Path): The file path to save the CSV.
         sep (str): The separator to use in the CSV file.
     """
-    path, error_message = resolve_export_target(path)
+    path, error_message = resolve_export_target(path)  # ty: ignore[invalid-assignment]
     if error_message:
         st.error(error_message)
         return False
@@ -1051,7 +1051,7 @@ def sidebar_views():
         find_files_fn=find_files,
         resolve_default_selection_fn=resolve_default_selection,
         build_sidebar_dataframe_selection_fn=build_sidebar_dataframe_selection,
-        on_lab_change_fn=on_lab_change,
+        on_lab_change_fn=on_lab_change,  # ty: ignore[unresolved-reference]
         on_df_change_fn=on_df_change,
         path_cls=Path,
     )

--- a/src/agilab/core/agi-env/src/agi_env/pagelib_navigation_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/pagelib_navigation_support.py
@@ -169,13 +169,13 @@ def build_sidebar_dataframe_selection(
     )
     key_df = f"{index_page}df"
     default_index = next(
-        (i for i, rel_path in enumerate(df_files_rel) if rel_path.name == "default_df"),
+        (i for i, rel_path in enumerate(df_files_rel) if rel_path.name == "default_df"),  # ty: ignore[unresolved-attribute]
         0,
     )
     return SidebarDataframeSelection(
         module_path=Path(lab_dir_name),
-        df_files_rel=df_files_rel,
-        index_page=index_page,
+        df_files_rel=df_files_rel,  # ty: ignore[invalid-argument-type]
+        index_page=index_page,  # ty: ignore[invalid-argument-type]
         key_df=key_df,
         default_index=default_index,
     )

--- a/src/agilab/core/agi-env/src/agi_env/pagelib_preview_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/pagelib_preview_support.py
@@ -11,7 +11,7 @@ def resolve_preview_nrows(explicit_nrows: object, session_max_rows: object) -> i
     if raw_value is None:
         return None
     try:
-        value = int(raw_value)
+        value = int(raw_value)  # ty: ignore[invalid-argument-type]
     except (TypeError, ValueError):
         return None
     return None if value == 0 else value

--- a/src/agilab/core/agi-env/src/agi_env/pagelib_runtime_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/pagelib_runtime_support.py
@@ -256,7 +256,7 @@ def activate_gpt_oss(
 
     session_state.pop("gpt_oss_autostart_failed", None)
     try:
-        import gpt_oss  # noqa: F401
+        import gpt_oss  # noqa: F401  # ty: ignore[unresolved-import]
     except ImportError:
         streamlit.warning("Install `gpt-oss` (`pip install gpt-oss`) to enable the offline assistant.")
         session_state["gpt_oss_autostart_failed"] = True

--- a/src/agilab/core/agi-env/src/agi_env/process_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/process_support.py
@@ -13,7 +13,7 @@ from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Iterable, Mapping, MutableMapping, Sequence
 
 try:
-    from pathlib import UnsupportedOperation
+    from pathlib import UnsupportedOperation  # ty: ignore[unresolved-import]
 except ImportError:
     from io import UnsupportedOperation
 

--- a/src/agilab/core/agi-env/src/agi_env/project_clone_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/project_clone_support.py
@@ -15,7 +15,7 @@ from pathspec.gitignore import GitIgnoreSpec
 from .app_provider_registry import aliased_app_runtime_target
 
 try:
-    from pathlib import UnsupportedOperation
+    from pathlib import UnsupportedOperation  # ty: ignore[unresolved-import]
 except ImportError:
     from io import UnsupportedOperation
 

--- a/src/agilab/core/agi-env/src/agi_env/source_analysis_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/source_analysis_support.py
@@ -36,7 +36,7 @@ def get_functions_and_attributes(
 
     for node in ast.walk(tree):
         for child in ast.iter_child_nodes(node):
-            child.parent = node  # type: ignore[attr-defined]
+            child.parent = node  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
 
     function_names: list[str] = []
     attribute_names: list[str] = []

--- a/src/agilab/core/agi-env/src/agi_env/ui_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/ui_support.py
@@ -23,7 +23,7 @@ from .ui_state_support import (
 )
 
 try:  # pragma: no cover - standard-library availability differs by Python version
-    from importlib import metadata as _importlib_metadata  # type: ignore
+    from importlib import metadata as _importlib_metadata
 except ImportError:  # pragma: no cover
     _importlib_metadata = None  # type: ignore
 

--- a/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/agi_dispatcher.py
+++ b/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/agi_dispatcher.py
@@ -47,7 +47,7 @@ class WorkDispatcher:
 
     def __init__(self, args=None):
         """Store ``args`` for later use when evaluating distribution plans."""
-        WorkDispatcher.args = args
+        WorkDispatcher.args = args  # ty: ignore[invalid-assignment]
 
     @staticmethod
     def _split_dispatch_args(args):
@@ -214,7 +214,7 @@ class WorkDispatcher:
     nchunk2: int,
     weights: List[Any],
     capacities: Optional[List[Any]] = None,
-    workers: Dict = None,
+    workers: Dict = None,  # ty: ignore[invalid-parameter-default]
     verbose: int = 0,
     threshold: int = 12,
 ) -> List[List[List[Any]]]:
@@ -236,15 +236,15 @@ class WorkDispatcher:
         """
         if not workers:
             workers = workers_default
-        capacities = WorkDispatcher._normalize_worker_capacities(capacities, workers)
+        capacities = WorkDispatcher._normalize_worker_capacities(capacities, workers)  # ty: ignore[invalid-assignment]
 
         if len(weights) > 1:
             if nchunk2 < threshold:
                 logging.info(f"optimal - workers capacities {capacities} - {nchunk2} works to be done")
-                chunks = WorkDispatcher._make_chunks_optimal(weights, capacities)
+                chunks = WorkDispatcher._make_chunks_optimal(weights, capacities)  # ty: ignore[invalid-argument-type]
             else:
                 logging.info(f"fastest - workers capacities {capacities} - {nchunk2} works to be done")
-                chunks = WorkDispatcher._make_chunks_fastest(weights, capacities)
+                chunks = WorkDispatcher._make_chunks_fastest(weights, capacities)  # ty: ignore[invalid-argument-type]
 
             return chunks
 
@@ -305,11 +305,11 @@ class WorkDispatcher:
             racine = True
 
         if not subsets:  # finished when all subsets are partitioned
-            return [chunks, max(chunks_sizes)]
+            return [chunks, max(chunks_sizes)]  # ty: ignore[invalid-argument-type]
 
         # Optimisation: We check if the weighted difference between the biggest and the smalest chunk
         # is more than the weighted sum of the remaining subsets
-        if max(chunks_sizes) > min(
+        if max(chunks_sizes) > min(  # ty: ignore[invalid-argument-type]
                 np.array(chunks_sizes + sum([i[1] for i in subsets])) / chkweights
         ):
             # If yes, we won't make the biggest chunk bigger by filling the smallest chunk
@@ -320,15 +320,15 @@ class WorkDispatcher:
             chunks_sizes[smallest_chunk_index] += (
                     sum([i[1] for i in subsets]) / chkweights[smallest_chunk_index]
             )
-            return [chunks, max(chunks_sizes)]
+            return [chunks, max(chunks_sizes)]  # ty: ignore[invalid-argument-type]
 
         chunks_choices = []
         chunks_choices_max_size = np.array([])
         inserted_chunk_sizes = []
         for i in range(nchk):
             # We add the next subset to the ith chunk if we haven't already tried a similar chunk
-            if (chunks_sizes[i], chkweights[i]) not in inserted_chunk_sizes:
-                inserted_chunk_sizes.append((chunks_sizes[i], chkweights[i]))
+            if (chunks_sizes[i], chkweights[i]) not in inserted_chunk_sizes:  # ty: ignore[not-subscriptable]
+                inserted_chunk_sizes.append((chunks_sizes[i], chkweights[i]))  # ty: ignore[not-subscriptable]
                 subsets2 = deepcopy(subsets)[1:]
                 chunk_pool = deepcopy(chunks)
                 chunk_pool[i].append(subsets[0])

--- a/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/base_worker.py
+++ b/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/base_worker.py
@@ -374,7 +374,7 @@ class BaseWorker(ArtifactContract, abc.ABC):
 
         merged_args = cls._apply_managed_pc_path_overrides(merged_args, env=env)
 
-        return cls(env, args=merged_args)
+        return cls(env, args=merged_args)  # ty: ignore[too-many-positional-arguments, unknown-argument]
 
     def to_toml(
         self,
@@ -426,7 +426,7 @@ class BaseWorker(ArtifactContract, abc.ABC):
         logger.info(f"worker #{self._worker_id}: {self._worker} - mode: {self._mode}"
                         )
         with BaseWorker._service_lock:
-            is_active = BaseWorker._service_active.get(self._worker_id)
+            is_active = BaseWorker._service_active.get(self._worker_id)  # ty: ignore[invalid-argument-type]
         if is_active:
             try:
                 BaseWorker.break_loop()
@@ -499,7 +499,7 @@ class BaseWorker(ArtifactContract, abc.ABC):
                 json_module=json,
                 os_module=os,
                 time_module=time,
-            )
+            )  # ty: ignore[invalid-assignment]
 
         start_time = time.time()
         logger.info(
@@ -802,7 +802,7 @@ class BaseWorker(ArtifactContract, abc.ABC):
             if fallback_base is None:
                 fallback_base = Path.home()
             fallback_target = env.target if env else Path(normalized_output).name
-            fallback = fallback_base / fallback_target
+            fallback = fallback_base / fallback_target  # ty: ignore[unsupported-operator]
             try:
                 fallback = _ensure_output_dir(fallback / target_subdir)
                 normalized_output = normalize_path(fallback)
@@ -971,13 +971,13 @@ class BaseWorker(ArtifactContract, abc.ABC):
 
     @staticmethod
     def _new(
-            env: AgiEnv=None,
-            app: str=None,
+            env: AgiEnv=None,  # ty: ignore[invalid-parameter-default]
+            app: str=None,  # ty: ignore[invalid-parameter-default]
             mode: int=0,
             verbose: int=0,
             worker_id: int=0,
             worker: str="localhost",
-            args: dict=None,
+            args: dict=None,  # ty: ignore[invalid-parameter-default]
     ):
         """new worker instance
         Args:
@@ -1024,7 +1024,7 @@ class BaseWorker(ArtifactContract, abc.ABC):
         """
         return execution_support.collect_worker_info(
             share_path=BaseWorker._share_path,
-            worker=BaseWorker._worker,
+            worker=BaseWorker._worker,  # ty: ignore[invalid-argument-type]
             normalize_path_fn=normalize_path,
             logger_obj=logger,
             psutil_module=psutil,

--- a/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/build.py
+++ b/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/build.py
@@ -18,7 +18,7 @@ from collections.abc import Mapping
 try:
     from .bootstrap_source_paths import bootstrap_core_source_paths
 except ImportError:  # pragma: no cover - script execution fallback
-    from bootstrap_source_paths import bootstrap_core_source_paths
+    from bootstrap_source_paths import bootstrap_core_source_paths  # ty: ignore[unresolved-import]
 
 bootstrap_core_source_paths(source_file=__file__)
 
@@ -170,7 +170,7 @@ def find_sys_prefix(base_dir: str) -> str:
     base = Path(base_dir).expanduser()
     python_dirs = sorted(base.glob("Python???"))
     if python_dirs:
-        AgiEnv.logger.info(f"Found Python directory: {python_dirs[0]}")
+        AgiEnv.logger.info(f"Found Python directory: {python_dirs[0]}")  # ty: ignore[unresolved-attribute]
         return str(python_dirs[0])
     return sys.prefix
 
@@ -195,38 +195,38 @@ def create_symlink_for_module(env, pck: str) -> list[Path]:
     try:
         dest = dest.absolute()
     except FileNotFoundError:
-        AgiEnv.logger.error(f"Source path does not exist: {src_abs}")
+        AgiEnv.logger.error(f"Source path does not exist: {src_abs}")  # ty: ignore[unresolved-attribute]
         raise FileNotFoundError(f"Source path does not exist: {src_abs}")
 
     if not dest.parent.exists():
-        AgiEnv.logger.info(f"Creating directory: {dest.parent}")
+        AgiEnv.logger.info(f"Creating directory: {dest.parent}")  # ty: ignore[unresolved-attribute]
         logger.info(f"mkdir {dest.parent}")
         dest.parent.mkdir(parents=True, exist_ok=True)
 
     if not dest.exists():
-        AgiEnv.logger.info(f"Linking {src_abs} -> {dest}")
+        AgiEnv.logger.info(f"Linking {src_abs} -> {dest}")  # ty: ignore[unresolved-attribute]
         if AgiEnv._is_managed_pc:
             try:
                 AgiEnv.create_junction_windows(src_abs, dest)
             except OSError as link_err:
-                AgiEnv.logger.error(f"Failed to create link from {src_abs} to {dest}: {link_err}")
+                AgiEnv.logger.error(f"Failed to create link from {src_abs} to {dest}: {link_err}")  # ty: ignore[unresolved-attribute]
                 raise
         else:
             try:
                 AgiEnv.create_symlink(src_abs, dest)
                 created_links.append(dest)
-                AgiEnv.logger.info(f"Symlink created: {dest} -> {src_abs}")
+                AgiEnv.logger.info(f"Symlink created: {dest} -> {src_abs}")  # ty: ignore[unresolved-attribute]
             except OSError as symlink_err:
-                AgiEnv.logger.warning(f"Symlink creation failed: {symlink_err}. Trying hard link instead.")
+                AgiEnv.logger.warning(f"Symlink creation failed: {symlink_err}. Trying hard link instead.")  # ty: ignore[unresolved-attribute]
                 try:
                     os.link(src_abs, dest)
                     created_links.append(dest)
-                    AgiEnv.logger.info(f"Hard link created: {dest} -> {src_abs}")
+                    AgiEnv.logger.info(f"Hard link created: {dest} -> {src_abs}")  # ty: ignore[unresolved-attribute]
                 except OSError as link_err:
-                    AgiEnv.logger.error(f"Failed to create link from {src_abs} to {dest}: {link_err}")
+                    AgiEnv.logger.error(f"Failed to create link from {src_abs} to {dest}: {link_err}")  # ty: ignore[unresolved-attribute]
                     raise
     else:
-        AgiEnv.logger.debug(f"Link already exists for {dest}")
+        AgiEnv.logger.debug(f"Link already exists for {dest}")  # ty: ignore[unresolved-attribute]
 
     return created_links
 
@@ -258,7 +258,7 @@ def cleanup_links(links: list[Path]) -> None:
     for link in links:
         try:
             if link.is_symlink() or link.exists():
-                AgiEnv.logger.info(f"Removing link or file: {link}")
+                AgiEnv.logger.info(f"Removing link or file: {link}")  # ty: ignore[unresolved-attribute]
                 if link.is_dir() and not link.is_symlink():
                     shutil.rmtree(link)
                 else:
@@ -278,7 +278,7 @@ def cleanup_links(links: list[Path]) -> None:
                     continue
                 break
         except OSError as e:
-            AgiEnv.logger.warning(f"Failed to remove {link}: {e}")
+            AgiEnv.logger.warning(f"Failed to remove {link}: {e}")  # ty: ignore[unresolved-attribute]
 
 # Also scrub any hardcoded -L flags that point to nowhere
 def _keep_lflag(arg: str) -> bool:
@@ -499,7 +499,7 @@ def _postprocess_bdist_egg_output(
     if cleanup_links_fn is None:
         cleanup_links_fn = cleanup_links
     if os_system_fn is None:
-        os_system_fn = os.system
+        os_system_fn = os.system  # ty: ignore[deprecated]
     if zip_cls is None:
         zip_cls = ZipFile
     if log is None:
@@ -803,7 +803,7 @@ def _prepare_setup_artifacts(
     if cmd == "build_ext":
         ext_modules = configure_build_ext_modules_fn(
             active_app=active_app,
-            build_dir=build_dir,
+            build_dir=build_dir,  # ty: ignore[invalid-argument-type]
             remaining_args=remaining_args,
             worker_module=worker_module,
             pyvers_worker=env.pyvers_worker,

--- a/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/post_install.py
+++ b/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/post_install.py
@@ -21,7 +21,7 @@ import py7zr
 try:
     from .bootstrap_source_paths import bootstrap_core_source_paths
 except ImportError:  # pragma: no cover - script execution fallback
-    from bootstrap_source_paths import bootstrap_core_source_paths
+    from bootstrap_source_paths import bootstrap_core_source_paths  # ty: ignore[unresolved-import]
 
 bootstrap_core_source_paths(source_file=__file__)
 

--- a/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/pre_install.py
+++ b/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/pre_install.py
@@ -59,7 +59,7 @@ from agi_env import AgiEnv
 try:
     from .cython_type_preprocess import preprocess_source
 except ImportError:  # pragma: no cover - script execution fallback
-    from cython_type_preprocess import preprocess_source
+    from cython_type_preprocess import preprocess_source  # ty: ignore[unresolved-import]
 
 
 def get_decorator_name(decorator_node):

--- a/src/agilab/core/agi-node/src/agi_node/fireducks_worker/fireducks_worker.py
+++ b/src/agilab/core/agi-node/src/agi_node/fireducks_worker/fireducks_worker.py
@@ -23,10 +23,10 @@ from typing import Any
 import pandas as pd
 
 try:  # pragma: no cover - optional dependency
-    import fireducks  # noqa: F401
+    import fireducks  # noqa: F401  # ty: ignore[unresolved-import]
     _HAS_FIREDUCKS = True
 except ImportError:  # pragma: no cover - optional dependency
-    fireducks = None  # type: ignore
+    fireducks = None
     _HAS_FIREDUCKS = False
 
 from agi_node.agi_dispatcher import BaseWorker
@@ -79,7 +79,7 @@ class FireducksWorker(BaseWorker):
     def work_pool(self, x: Any = None) -> pd.DataFrame:
         """Execute a single task and return a pandas DataFrame."""
         logger.info("fireducks.work_pool")
-        result = self._actual_work_pool(x)
+        result = self._actual_work_pool(x)  # ty: ignore[unresolved-attribute]
         df = self._ensure_pandas(result)
         return df if df is not None else pd.DataFrame()
 
@@ -88,14 +88,14 @@ class FireducksWorker(BaseWorker):
         df_pd = self._ensure_pandas(df)
         if df_pd is None:
             df_pd = pd.DataFrame()
-        PandasWorker.work_done(self, df_pd)
+        PandasWorker.work_done(self, df_pd)  # ty: ignore[invalid-argument-type]
 
     # Reuse PandasWorker orchestration so FireducksWorker mirrors BaseWorker direct subclasses.
     def works(self, workers_plan: Any, workers_plan_metadata: Any) -> float:  # type: ignore[override]
-        return PandasWorker.works(self, workers_plan, workers_plan_metadata)
+        return PandasWorker.works(self, workers_plan, workers_plan_metadata)  # ty: ignore[invalid-argument-type]
 
     def _exec_multi_process(self, workers_plan: Any, workers_plan_metadata: Any) -> None:
-        PandasWorker._exec_multi_process(self, workers_plan, workers_plan_metadata)
+        PandasWorker._exec_multi_process(self, workers_plan, workers_plan_metadata)  # ty: ignore[invalid-argument-type]
 
     def _exec_mono_process(self, workers_plan: Any, workers_plan_metadata: Any) -> None:
-        PandasWorker._exec_mono_process(self, workers_plan, workers_plan_metadata)
+        PandasWorker._exec_mono_process(self, workers_plan, workers_plan_metadata)  # ty: ignore[invalid-argument-type]

--- a/src/agilab/core/agi-node/src/agi_node/pandas_worker/pandas_worker.py
+++ b/src/agilab/core/agi-node/src/agi_node/pandas_worker/pandas_worker.py
@@ -56,7 +56,7 @@ class PandasWorker(BaseWorker):
         args (dict): Configuration arguments for the worker.
     """
 
-    def work_pool(self, x: any = None) -> pd.DataFrame:
+    def work_pool(self, x: any = None) -> pd.DataFrame:  # ty: ignore[invalid-type-form]
         """
         Processes a single task.
 
@@ -70,9 +70,9 @@ class PandasWorker(BaseWorker):
 
         # Call the actual work_pool method, which should return a pandas DataFrame.
         # Ensure that the original _actual_work_pool method is refactored accordingly.
-        return self._actual_work_pool(x)
+        return self._actual_work_pool(x)  # ty: ignore[unresolved-attribute]
 
-    def work_done(self, df: pd.DataFrame = None) -> None:
+    def work_done(self, df: pd.DataFrame = None) -> None:  # ty: ignore[invalid-parameter-default]
         """
         Handles the post-processing of the DataFrame after `work_pool` execution.
 
@@ -98,7 +98,7 @@ class PandasWorker(BaseWorker):
         else:
             raise ValueError("Unsupported output format")
 
-    def works(self, workers_plan: any, workers_plan_metadata: any) -> float:
+    def works(self, workers_plan: any, workers_plan_metadata: any) -> float:  # ty: ignore[invalid-type-form]
         """
         Executes worker tasks based on the distribution tree.
 
@@ -110,7 +110,7 @@ class PandasWorker(BaseWorker):
             float: Execution time in seconds.
         """
         if workers_plan:
-            if self._mode & 4:
+            if self._mode & 4:  # ty: ignore[unsupported-operator]
                 self._exec_multi_process(workers_plan, workers_plan_metadata)
             else:
                 self._exec_mono_process(workers_plan, workers_plan_metadata)
@@ -121,7 +121,7 @@ class PandasWorker(BaseWorker):
             BaseWorker._t0 = time.time()
         return time.time() - BaseWorker._t0
 
-    def _exec_multi_process(self, workers_plan: any, workers_plan_metadata: any) -> None:
+    def _exec_multi_process(self, workers_plan: any, workers_plan_metadata: any) -> None:  # ty: ignore[invalid-type-form]
         """
         Executes tasks in multiprocessing mode.
 
@@ -133,7 +133,7 @@ class PandasWorker(BaseWorker):
         if isinstance(workers_plan, list):
             for i in workers_plan[self._worker_id]:
                 works += i
-            ncore = max(min(len(works), int(os.cpu_count())), 1)
+            ncore = max(min(len(works), int(os.cpu_count())), 1)  # ty: ignore[invalid-argument-type]
         else:
             ncore = 1
 
@@ -142,11 +142,11 @@ class PandasWorker(BaseWorker):
             f" - work_pool x {len(works)}",
         )
 
-        self.work_init()
+        self.work_init()  # ty: ignore[unresolved-attribute]
         for work_id, work in enumerate(workers_plan[self._worker_id]):
             list_df = []
             df = pd.DataFrame()
-            ncore = max(min(len(work), int(os.cpu_count())), 1)
+            ncore = max(min(len(work), int(os.cpu_count())), 1)  # ty: ignore[invalid-argument-type]
 
             if os.name == "nt":
                 process_factory_type = "spawn"
@@ -159,8 +159,8 @@ class PandasWorker(BaseWorker):
             with ProcessPoolExecutor(
                 # mp_context=mp_ctx,
                 max_workers=ncore,
-                initializer=self.pool_init,
-                initargs=(self.pool_vars,),
+                initializer=self.pool_init,  # ty: ignore[unresolved-attribute]
+                initargs=(self.pool_vars,),  # ty: ignore[unresolved-attribute]
             ) as exec:
                 dfs = exec.map(self.work_pool, work)
 
@@ -178,7 +178,7 @@ class PandasWorker(BaseWorker):
 
             self.work_done(df if not df.empty else pd.DataFrame())
 
-    def _exec_mono_process(self, workers_plan: any, workers_plan_metadata: any) -> None:
+    def _exec_mono_process(self, workers_plan: any, workers_plan_metadata: any) -> None:  # ty: ignore[invalid-type-form]
         """
         Executes tasks in single-threaded mode.
 
@@ -186,7 +186,7 @@ class PandasWorker(BaseWorker):
             workers_plan (any): Distribution tree structure.
             workers_plan_metadata (any): Additional information about the workers.
         """
-        self.work_init()
+        self.work_init()  # ty: ignore[unresolved-attribute]
         for work_id, work in enumerate(workers_plan[self._worker_id]):
             list_df = []
             df = pd.DataFrame()

--- a/src/agilab/core/agi-node/src/agi_node/polars_worker/polars_worker.py
+++ b/src/agilab/core/agi-node/src/agi_node/polars_worker/polars_worker.py
@@ -57,7 +57,7 @@ class PolarsWorker(BaseWorker):
         args (dict): Configuration arguments for the worker.
     """
 
-    def work_pool(self, x: any = None) -> pl.DataFrame:
+    def work_pool(self, x: any = None) -> pl.DataFrame:  # ty: ignore[invalid-type-form]
         """
         Processes a single task.
 
@@ -71,9 +71,9 @@ class PolarsWorker(BaseWorker):
 
         # Call the actual work_pool method, which should return a Polars DataFrame.
         # Ensure that the original _actual_work_pool method is refactored accordingly.
-        return self._actual_work_pool(x)
+        return self._actual_work_pool(x)  # ty: ignore[unresolved-attribute]
 
-    def work_done(self, df: pl.DataFrame = None) -> None:
+    def work_done(self, df: pl.DataFrame = None) -> None:  # ty: ignore[invalid-parameter-default]
         """
         Handles the post-processing of the DataFrame after `work_pool` execution.
 
@@ -102,7 +102,7 @@ class PolarsWorker(BaseWorker):
         else:
             raise ValueError("Unsupported output format")
 
-    def works(self, workers_plan: any, workers_plan_metadata: any) -> float:
+    def works(self, workers_plan: any, workers_plan_metadata: any) -> float:  # ty: ignore[invalid-type-form]
         """
         Executes worker tasks based on the distribution tree.
 
@@ -114,7 +114,7 @@ class PolarsWorker(BaseWorker):
             float: Execution time in seconds.
         """
         if workers_plan:
-            if self._mode & 4:
+            if self._mode & 4:  # ty: ignore[unsupported-operator]
                 self._exec_multi_process(workers_plan, workers_plan_metadata)
             else:
                 self._exec_mono_process(workers_plan, workers_plan_metadata)
@@ -126,7 +126,7 @@ class PolarsWorker(BaseWorker):
         return time.time() - BaseWorker._t0
 
 
-    def _exec_multi_process(self, workers_plan: any, workers_plan_metadata: any) -> None:
+    def _exec_multi_process(self, workers_plan: any, workers_plan_metadata: any) -> None:  # ty: ignore[invalid-type-form]
         """
         Executes tasks in multiprocessing mode.
 
@@ -139,17 +139,17 @@ class PolarsWorker(BaseWorker):
         if isinstance(workers_plan, list):
             for i in workers_plan[self._worker_id]:
                 works += i
-            ncore = max(min(len(works), int(os.cpu_count())), 1)
+            ncore = max(min(len(works), int(os.cpu_count())), 1)  # ty: ignore[invalid-argument-type]
 
         logging.info(
             f"PolarsWorker.work - ncore {ncore} - worker_id #{self._worker_id}"
             f" - work_pool x {len(works)}",
         )
-        self.work_init()
+        self.work_init()  # ty: ignore[unresolved-attribute]
         for work_id, work in enumerate(workers_plan[self._worker_id]):
             list_df = []
             df = pl.DataFrame()
-            ncore = max(min(len(work), int(os.cpu_count())), 1)
+            ncore = max(min(len(work), int(os.cpu_count())), 1)  # ty: ignore[invalid-argument-type]
 
             if os.name == "nt":
                 process_factory_type = "spawn"
@@ -161,8 +161,8 @@ class PolarsWorker(BaseWorker):
             with ThreadPoolExecutor(
                 #mp_context=mp_ctx,
                 max_workers=ncore,
-                initializer=self.pool_init,
-                initargs=(self.pool_vars,),
+                initializer=self.pool_init,  # ty: ignore[unresolved-attribute]
+                initargs=(self.pool_vars,),  # ty: ignore[unresolved-attribute]
             ) as exec:
                 # Map each work item to work_pool.
                 dfs = exec.map(self.work_pool, work)
@@ -186,7 +186,7 @@ class PolarsWorker(BaseWorker):
             # Handle the concatenated DataFrame.
             self.work_done(df if not df.is_empty() else pl.DataFrame())
 
-    def _exec_mono_process(self, workers_plan: any, workers_plan_metadata: any) -> None:
+    def _exec_mono_process(self, workers_plan: any, workers_plan_metadata: any) -> None:  # ty: ignore[invalid-type-form]
         """
         Executes tasks in single-threaded mode.
 
@@ -194,7 +194,7 @@ class PolarsWorker(BaseWorker):
             workers_plan (any): Distribution tree structure.
             workers_plan_metadata (any): Additional information about the workers.
         """
-        self.work_init()
+        self.work_init()  # ty: ignore[unresolved-attribute]
         for work_id, work in enumerate(workers_plan[self._worker_id]):
             list_df = []
             df = pl.DataFrame()

--- a/src/agilab/pipeline_ai.py
+++ b/src/agilab/pipeline_ai.py
@@ -5,6 +5,8 @@ import importlib.metadata as importlib_metadata
 import importlib.util
 import logging
 import os
+import urllib.error
+import urllib.request
 from contextlib import nullcontext
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple

--- a/test/test_agilab_dev_shortcuts.py
+++ b/test/test_agilab_dev_shortcuts.py
@@ -170,6 +170,21 @@ def test_workflow_profile_shortcut_repeats_profile_flags_and_keeps_options():
     ]
 
 
+def test_typing_shortcut_invokes_ty_typing_profile():
+    assert agilab_dev.planned_commands(["typing"]) == [
+        [
+            "uv",
+            "--preview-features",
+            "extra-build-dependencies",
+            "run",
+            "python",
+            "tools/workflow_parity.py",
+            "--profile",
+            "ty-typing",
+        ]
+    ]
+
+
 def test_release_shortcut_runs_local_release_guards():
     assert agilab_dev.planned_commands(["release"]) == [
         [

--- a/test/test_pypi_publish.py
+++ b/test/test_pypi_publish.py
@@ -502,6 +502,7 @@ def test_release_preflight_profiles_only_for_real_pypi() -> None:
         "docs",
         "installer",
         "shared-core-typing",
+        "ty-typing",
         "dependency-policy",
         "release-proof",
     ]

--- a/test/test_pypi_publish_workflow.py
+++ b/test/test_pypi_publish_workflow.py
@@ -100,6 +100,7 @@ def test_pypi_publish_release_tests_use_local_parity_profiles() -> None:
     assert "--profile ui-frontend-smoke" in text
     assert "--profile agi-core-combined" in text
     assert "--profile shared-core-typing" in text
+    assert "--profile ty-typing" in text
     assert "--profile dependency-policy" in text
     assert "--profile release-proof" in text
     assert "uv run --dev --project agi-cluster python -m pytest" not in text

--- a/test/test_view_live_artifacts.py
+++ b/test/test_view_live_artifacts.py
@@ -28,12 +28,15 @@ def _set_mtime(path: Path, value: int) -> None:
 def test_live_artifacts_parse_patterns_and_format_helpers() -> None:
     module = _load_module()
 
+    assert module.parse_patterns(None) == module.DEFAULT_PATTERNS
     assert module.parse_patterns(" **/*.json ; **/*.json\n*.log ,, ") == ("**/*.json", "*.log")
     assert module.parse_patterns(("", " ", "a", "a", "b")) == ("a", "b")
     assert module.parse_patterns("") == module.DEFAULT_PATTERNS
     assert module.format_patterns(["a", "a", " b "]) == "a, b"
     assert module.format_bytes(None) == "0 B"
+    assert module.format_bytes("not-a-size") == "0 B"
     assert module.format_bytes(1024) == "1.0 KB"
+    assert module.format_bytes(1024**4) == "1.0 TB"
     assert module.refresh_run_every(False, 1) is None
     assert module.refresh_run_every(True, "bad") == "5s"
     assert module.refresh_run_every(True, 0) == "1s"
@@ -100,10 +103,15 @@ def test_live_artifacts_preview_handles_json_text_images_metadata_and_errors(tmp
     invalid_json.write_text("{", encoding="utf-8")
 
     assert module.read_artifact_preview(json_path).value == {"status": "ok"}
+    module.MAX_JSON_PREVIEW_BYTES = 1
+    large_json_preview = module.read_artifact_preview(json_path)
+    assert large_json_preview.kind == "text"
+    assert large_json_preview.value == '{"status": "ok"}'
     text_preview = module.read_artifact_preview(text_path, max_bytes=4)
     assert text_preview.kind == "text"
     assert text_preview.value == "... 6789"
     assert text_preview.truncated is True
+    assert module._read_tail_text(text_path, max_bytes=20) == "0123456789"
     assert module.read_artifact_preview(image_path).kind == "image"
     metadata = module.read_artifact_preview(binary_path)
     assert metadata.kind == "metadata"
@@ -131,6 +139,51 @@ def test_live_artifacts_root_candidates_use_export_target_and_runenv(tmp_path: P
     }
 
 
+def test_live_artifacts_root_candidates_fall_back_to_app_and_project_venv(tmp_path: Path) -> None:
+    module = _load_module()
+    env = SimpleNamespace(
+        AGILAB_EXPORT_ABS=tmp_path / "export",
+        target="",
+        app="demo_project",
+        runenv="",
+    )
+    app_path = tmp_path / "apps" / "demo_project"
+
+    candidates = module.root_candidates(env, app_path)
+
+    assert candidates["Export artifacts"] == tmp_path / "export" / "demo_project"
+    assert candidates["Run environment"] == app_path / ".venv"
+    assert candidates["App project"] == app_path
+
+
+def test_live_artifacts_active_env_reuses_matching_session_env(monkeypatch, tmp_path: Path) -> None:
+    module = _load_module()
+    active_app = tmp_path / "apps" / "demo_project"
+    active_app.mkdir(parents=True)
+    current_env = SimpleNamespace(app="demo_project", apps_path=active_app.parent)
+    fake_streamlit = SimpleNamespace(session_state={"env": current_env})
+    monkeypatch.setattr(module, "st", fake_streamlit)
+
+    env = module._active_env(active_app)
+
+    assert env is current_env
+
+
+def test_live_artifacts_resolve_active_app_delegates_to_runtime(monkeypatch, tmp_path: Path) -> None:
+    module = _load_module()
+    fake_streamlit = SimpleNamespace(error=object(), stop=object())
+    monkeypatch.setattr(module, "st", fake_streamlit)
+
+    def fake_resolve_active_app_path(*, error_fn, stop_fn):
+        assert error_fn is fake_streamlit.error
+        assert stop_fn is fake_streamlit.stop
+        return tmp_path / "apps" / "demo_project"
+
+    monkeypatch.setattr(module, "resolve_active_app_path", fake_resolve_active_app_path)
+
+    assert module._resolve_active_app() == tmp_path / "apps" / "demo_project"
+
+
 def test_live_artifacts_rebuilds_env_when_session_env_points_to_another_apps_root(
     monkeypatch,
     tmp_path: Path,
@@ -155,6 +208,261 @@ def test_live_artifacts_rebuilds_env_when_session_env_points_to_another_apps_roo
     assert env is fake_streamlit.session_state["env"]
     assert created == [(active_app.parent, "demo_project", 0)]
     assert getattr(env, "init_done") is True
+
+
+def test_live_artifacts_render_controls_initializes_state_and_refreshes(monkeypatch, tmp_path: Path) -> None:
+    module = _load_module()
+    app_path = tmp_path / "apps" / "demo_project"
+    app_path.mkdir(parents=True)
+    env = SimpleNamespace(
+        AGILAB_EXPORT_ABS=tmp_path / "export",
+        target="",
+        app="demo_project",
+        runenv="",
+    )
+    app_name = app_path.name
+    state = {
+        module._state_key(app_name, "root_choice"): "Custom path",
+        module._state_key(app_name, "custom_root"): str(tmp_path / "custom"),
+        module._state_key(app_name, "patterns"): " **/*.json ; *.log ; **/*.json ",
+        module._state_key(app_name, "limit"): 12,
+        module._state_key(app_name, "live_refresh"): False,
+        module._state_key(app_name, "interval"): "not-valid",
+    }
+
+    class FakeSidebar:
+        def __init__(self, session_state: dict[str, object]) -> None:
+            self.session_state = session_state
+
+        def selectbox(self, _label: str, _options, *, key: str):
+            return self.session_state[key]
+
+        def text_input(self, _label: str, *, key: str):
+            return self.session_state[key]
+
+        def text_area(self, _label: str, *, key: str, height: int):
+            assert height == 92
+            return self.session_state[key]
+
+        def number_input(self, _label: str, *, min_value: int, max_value: int, step: int, key: str):
+            assert (min_value, max_value, step) == (1, module.MAX_DISCOVERED_FILES, 10)
+            return self.session_state[key]
+
+        def toggle(self, _label: str, *, key: str):
+            return self.session_state[key]
+
+        def button(self, _label: str, *, type: str, width: str) -> bool:
+            assert (type, width) == ("secondary", "stretch")
+            return True
+
+    class FakeStreamlit:
+        def __init__(self) -> None:
+            self.session_state = state
+            self.sidebar = FakeSidebar(self.session_state)
+            self.rerun_called = False
+
+        def rerun(self) -> None:
+            self.rerun_called = True
+
+    fake_streamlit = FakeStreamlit()
+    monkeypatch.setattr(module, "st", fake_streamlit)
+
+    selected_root, patterns, max_files, live_refresh, interval_seconds = module._render_controls(env, app_path)
+
+    assert selected_root == tmp_path / "custom"
+    assert patterns == ("**/*.json", "*.log")
+    assert max_files == 12
+    assert live_refresh is False
+    assert interval_seconds == 5
+    assert fake_streamlit.rerun_called is True
+
+
+def test_live_artifacts_render_preview_handles_all_preview_kinds(monkeypatch, tmp_path: Path) -> None:
+    module = _load_module()
+    json_path = tmp_path / "state.json"
+    json_path.write_text('{"status": "ok"}', encoding="utf-8")
+    text_path = tmp_path / "worker.log"
+    text_path.write_text("x" * (module.PREVIEW_BYTES + 1), encoding="utf-8")
+    image_path = tmp_path / "plot.png"
+    image_path.write_bytes(b"png")
+    binary_path = tmp_path / "payload.bin"
+    binary_path.write_bytes(b"\x00\x01")
+    missing_path = tmp_path / "missing.json"
+
+    class FakeStreamlit:
+        def __init__(self) -> None:
+            self.captions: list[str] = []
+            self.errors: list[str] = []
+            self.codes: list[str] = []
+            self.json_values: list[object] = []
+            self.images: list[tuple[str, str]] = []
+
+        def selectbox(self, _label: str, *, options, key: str):
+            assert key == f"{module.PAGE_KEY}_preview_artifact"
+            return options[0]
+
+        def caption(self, value: str) -> None:
+            self.captions.append(value)
+
+        def error(self, value: str) -> None:
+            self.errors.append(value)
+
+        def code(self, value: str, *, language: str) -> None:
+            assert language == "text"
+            self.codes.append(value)
+
+        def json(self, value: object, *, expanded: bool) -> None:
+            assert expanded is False
+            self.json_values.append(value)
+
+        def image(self, value: str, *, caption: str) -> None:
+            self.images.append((value, caption))
+
+    def record(path: Path, kind: str) -> object:
+        size = path.stat().st_size if path.exists() else 0
+        return module.ArtifactRecord(
+            path=path,
+            relative_path=path.name,
+            size=size,
+            mtime_ns=1,
+            mtime_iso="1970-01-01T00:00:00+00:00",
+            kind=kind,
+        )
+
+    fake_streamlit = FakeStreamlit()
+    monkeypatch.setattr(module, "st", fake_streamlit)
+
+    module._render_preview(())
+    module._render_preview((record(json_path, "json"),))
+    module._render_preview((record(text_path, "text"),))
+    module._render_preview((record(image_path, "image"),))
+    module._render_preview((record(binary_path, "binary"),))
+    module._render_preview((record(missing_path, "json"),))
+
+    assert fake_streamlit.json_values[0] == {"status": "ok"}
+    assert any("Showing the latest portion" in value for value in fake_streamlit.captions)
+    assert fake_streamlit.images == [(str(image_path), "plot.png")]
+    assert fake_streamlit.json_values[1]["size"] == "2 B"
+    assert fake_streamlit.errors == ["Preview unavailable."]
+    assert fake_streamlit.codes[-1]
+
+
+def test_live_artifacts_render_artifacts_panel_handles_empty_missing_and_populated_roots(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    module = _load_module()
+
+    class FakeColumn:
+        def __init__(self, sink: list[tuple[str, str]]) -> None:
+            self.sink = sink
+
+        def metric(self, label: str, value: str) -> None:
+            self.sink.append((label, value))
+
+    class FakeStreamlit:
+        def __init__(self) -> None:
+            self.metrics: list[tuple[str, str]] = []
+            self.warnings: list[str] = []
+            self.infos: list[str] = []
+            self.captions: list[str] = []
+            self.subheaders: list[str] = []
+            self.dataframes: list[list[dict[str, object]]] = []
+
+        def columns(self, count: int):
+            assert count == 4
+            return [FakeColumn(self.metrics) for _ in range(count)]
+
+        def warning(self, value: str) -> None:
+            self.warnings.append(value)
+
+        def info(self, value: str) -> None:
+            self.infos.append(value)
+
+        def caption(self, value: str) -> None:
+            self.captions.append(value)
+
+        def subheader(self, value: str) -> None:
+            self.subheaders.append(value)
+
+        def dataframe(self, rows, *, width: str, hide_index: bool) -> None:
+            assert (width, hide_index) == ("stretch", True)
+            self.dataframes.append(list(rows))
+
+    fake_streamlit = FakeStreamlit()
+    previewed: list[tuple[object, ...]] = []
+    monkeypatch.setattr(module, "st", fake_streamlit)
+    monkeypatch.setattr(module, "_render_preview", lambda records: previewed.append(tuple(records)))
+
+    module._render_artifacts_panel(tmp_path / "missing", ("**/*.json",), 10)
+
+    empty_root = tmp_path / "empty"
+    empty_root.mkdir()
+    module._render_artifacts_panel(empty_root, ("**/*.json",), 10)
+
+    root = tmp_path / "artifacts"
+    root.mkdir()
+    manifest = root / "analysis_manifest.json"
+    manifest.write_text('{"ok": true}', encoding="utf-8")
+    log = root / "worker.log"
+    log.write_text("started\n", encoding="utf-8")
+    _set_mtime(manifest, 2_000_000_000)
+    _set_mtime(log, 1_000_000_000)
+    module._render_artifacts_panel(root, ("**/*.json", "**/*.log"), 10)
+
+    assert fake_streamlit.warnings == [f"Artifact root does not exist yet: {tmp_path / 'missing'}"]
+    assert fake_streamlit.infos == ["No matching artifacts found."]
+    assert "Manifest candidates" in fake_streamlit.subheaders
+    assert "Artifacts" in fake_streamlit.subheaders
+    assert any(value.startswith("Latest update: analysis_manifest.json") for value in fake_streamlit.captions)
+    assert any(value.startswith("Signature: ") for value in fake_streamlit.captions)
+    assert len(fake_streamlit.dataframes) == 2
+    assert [record.relative_path for record in previewed[0]] == ["analysis_manifest.json", "worker.log"]
+
+
+def test_live_artifacts_main_wires_page_controls_and_panel(monkeypatch, tmp_path: Path) -> None:
+    module = _load_module()
+    app_path = tmp_path / "apps" / "demo_project"
+    env = SimpleNamespace()
+    calls: list[tuple[str, object]] = []
+
+    class FakeStreamlit:
+        def set_page_config(self, *, layout: str) -> None:
+            calls.append(("set_page_config", layout))
+
+        def title(self, value: str) -> None:
+            calls.append(("title", value))
+
+        def caption(self, value: str) -> None:
+            calls.append(("caption", value))
+
+    monkeypatch.setattr(module, "st", FakeStreamlit())
+    monkeypatch.setattr(module, "_resolve_active_app", lambda: app_path)
+    monkeypatch.setattr(module, "_active_env", lambda active_app_path: env)
+    monkeypatch.setattr(module, "render_logo", lambda title: calls.append(("logo", title)))
+    monkeypatch.setattr(
+        module,
+        "_render_controls",
+        lambda control_env, active_app_path: (tmp_path / "artifacts", ("**/*.json",), 5, False, 10),
+    )
+    monkeypatch.setattr(
+        module,
+        "_render_live_or_static_panel",
+        lambda root, patterns, max_files, live_refresh, interval_seconds: calls.append(
+            ("panel", (root, patterns, max_files, live_refresh, interval_seconds))
+        ),
+    )
+
+    module.main()
+
+    assert calls == [
+        ("set_page_config", "wide"),
+        ("logo", "Live Artifacts"),
+        ("title", "Live artifacts"),
+        ("caption", "Monitor exported evidence, manifests, logs, and lightweight artifacts for the active app."),
+        ("caption", f"Root: {tmp_path / 'artifacts'}"),
+        ("panel", (tmp_path / "artifacts", ("**/*.json",), 5, False, 10)),
+    ]
 
 
 def test_live_artifacts_live_fragment_uses_streamlit_run_every(monkeypatch, tmp_path: Path) -> None:

--- a/test/test_workflow_parity.py
+++ b/test/test_workflow_parity.py
@@ -119,6 +119,19 @@ def test_expand_repo_globs_preserves_unmatched_patterns() -> None:
     assert "missing-ui-robot-*.py" in expanded
 
 
+def test_ty_typing_profile_omits_missing_optional_stubs(monkeypatch, tmp_path: Path) -> None:
+    module = _load_module()
+    monkeypatch.setattr(module, "REPO_ROOT", tmp_path)
+
+    command = module._shared_core_ty_typing_profile()[0]
+
+    assert command.label == "shared-core strict ty typing"
+    assert "--error-on-warning" in command.argv
+    assert "--warn" not in command.argv
+    assert "stubs" not in _option_values(command.argv, "--extra-search-path")
+    assert "stubs" not in command.argv
+
+
 def test_profile_commands_cover_expected_coverage_and_docs_contracts() -> None:
     module = _load_module()
     args = SimpleNamespace(components=None, skills=None, app_path=None, worker_copy=None)
@@ -141,6 +154,9 @@ def test_profile_commands_cover_expected_coverage_and_docs_contracts() -> None:
     docs = docs_commands[2]
     badges = profiles["badges"]
     strict_typing = profiles["shared-core-typing"][0]
+    descriptions = module._profile_descriptions()
+    assert "temporary strict mypy release guard" in descriptions["shared-core-typing"]
+    assert "forward shared-core strict ty" in descriptions["ty-typing"]
     dependency_policy = profiles["dependency-policy"][0]
     release_proof = profiles["release-proof"][0]
     security_adoption = profiles["security-adoption"][0]

--- a/tools/agilab_dev.py
+++ b/tools/agilab_dev.py
@@ -65,6 +65,9 @@ def planned_commands(argv: Sequence[str]) -> list[list[str]]:
             profile_args.extend(["--profile", profile])
         return [_uv_python("tools/workflow_parity.py", *profile_args, *extras)]
 
+    if command in {"typing", "ty"}:
+        return [_uv_python("tools/workflow_parity.py", "--profile", "ty-typing", *args)]
+
     if command in {"release", "pre-release"}:
         forwarded = args or ["--staged"]
         return [
@@ -127,6 +130,7 @@ def _usage() -> str:
   ./dev [--print-only] test [pytest args]
   ./dev [--print-only] regress [ga_regression_selector args]
   ./dev [--print-only] flow|profile <profile> [profile...] [workflow args]
+  ./dev [--print-only] typing [workflow-parity options]
   ./dev [--print-only] release [impact_validate args]
   ./dev [--print-only] badge|guard [coverage_badge_guard args]
   ./dev [--print-only] docs
@@ -138,6 +142,7 @@ High-frequency mappings:
   test      -> Run targeted pytest with -q and repo-wide coverage disabled, while keeping all extra pytest arguments.
   regress   -> Use the GA regression selector on staged files and run the selected pytest subset.
   flow      -> Run one or more workflow_parity profiles with repeated --profile flags.
+  typing    -> Run the forward shared-core ty typing profile. Mypy remains the curated temporary release guard under shared-core-typing.
   release   -> Run local release guards: impact, generated PyPI plan, release cadence, trusted publisher contract, docs, dependency policy, typing, and badge freshness.
   badge     -> Run the explicit release/pre-release coverage badge freshness guard.
   docs      -> Sync docs from the canonical docs checkout and verify the mirror stamp.

--- a/tools/beta_readiness.py
+++ b/tools/beta_readiness.py
@@ -38,6 +38,7 @@ RELEASE_PREFLIGHT_PROFILES = (
     "docs",
     "installer",
     "shared-core-typing",
+    "ty-typing",
     "dependency-policy",
 )
 PUBLIC_DOC_FILES = (
@@ -73,7 +74,7 @@ FINAL_NETWORK_COMMANDS = (
     "uv --preview-features extra-build-dependencies run python tools/hf_space_smoke.py --json",
 )
 FINAL_LOCAL_COMMANDS = (
-    "uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-env --profile agi-core-combined --profile agi-gui --profile docs --profile installer --profile shared-core-typing --profile dependency-policy",
+    "uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-env --profile agi-core-combined --profile agi-gui --profile docs --profile installer --profile shared-core-typing --profile ty-typing --profile dependency-policy",
     "uv --preview-features extra-build-dependencies run python tools/newcomer_first_proof.py --with-install",
     "uv --preview-features extra-build-dependencies run python tools/pypi_publish.py --repo testpypi --dry-run --verbose",
 )

--- a/tools/pypi_pending_trusted_publisher.py
+++ b/tools/pypi_pending_trusted_publisher.py
@@ -290,7 +290,12 @@ def _open_publishing_settings(
     raise RuntimeError(
         "PyPI redirected back to login while opening account publishing "
         "settings after password/TOTP authentication. PyPI likely requires "
-        "unrecognized-login email confirmation from the same runner IP."
+        "unrecognized-login email confirmation from the same runner IP that "
+        "started the login attempt. "
+        "Set repository variable PYPI_CONFIRM_LOGIN_URL from the confirmation "
+        "email link, then rerun with the same project inputs. "
+        "If this repeats on GitHub-hosted runners, switch this workflow to a "
+        "self-hosted/static-IP runner and retry."
     )
 
 

--- a/tools/pypi_publish.py
+++ b/tools/pypi_publish.py
@@ -638,6 +638,7 @@ def release_preflight_profiles(cfg: Cfg) -> list[str]:
         "docs",
         "installer",
         "shared-core-typing",
+        "ty-typing",
         "dependency-policy",
         "release-proof",
     ]

--- a/tools/workflow_parity.py
+++ b/tools/workflow_parity.py
@@ -170,6 +170,7 @@ def _build_parser() -> argparse.ArgumentParser:
             "skills",
             "installer",
             "shared-core-typing",
+            "ty-typing",
             "dependency-policy",
             "release-proof",
             "security-adoption",
@@ -277,6 +278,10 @@ def _build_parser() -> argparse.ArgumentParser:
 
 
 def _profile_descriptions() -> dict[str, str]:
+    # Typing migration policy:
+    # - ty-typing is the forward strict type-checking path.
+    # - shared-core-typing keeps mypy as the curated temporary release guard until
+    #   ty has proven equivalent signal on the shared-core slice.
     return {
         "agi-env": "Run the local equivalent of the agi-env coverage workflow job.",
         "agi-core-combined": "Run the shared core test suite once and emit both agi-node and agi-cluster coverage XML files.",
@@ -287,7 +292,8 @@ def _profile_descriptions() -> dict[str, str]:
         "badges": "Refresh component coverage badges from local coverage XML files.",
         "skills": "Validate and regenerate the repo Codex skill mirror outputs.",
         "installer": "Run local installer parity checks including shell syntax and contract checks.",
-        "shared-core-typing": "Run the curated shared-core strict mypy slice.",
+        "shared-core-typing": "Run the curated temporary strict mypy release guard for shared core.",
+        "ty-typing": "Run the forward shared-core strict ty type-check slice.",
         "dependency-policy": "Run dependency hygiene checks for runtime and release manifests.",
         "release-proof": "Run expensive release-proof gates such as fresh-clone first-proof install validation.",
         "security-adoption": (
@@ -333,6 +339,7 @@ def _profile_commands(args: argparse.Namespace) -> dict[str, list[CommandSpec]]:
         "skills": _skills_profile(args.skills),
         "installer": _installer_profile(args.app_path, args.worker_copy),
         "shared-core-typing": _shared_core_typing_profile(),
+        "ty-typing": _shared_core_ty_typing_profile(),
         "dependency-policy": _dependency_policy_profile(),
         "release-proof": _release_proof_profile(),
         "security-adoption": _security_adoption_profile(),
@@ -1220,6 +1227,49 @@ def _shared_core_typing_profile() -> list[CommandSpec]:
     ]
 
 
+def _shared_core_ty_target_paths() -> list[str]:
+    paths = [
+        "src/agilab/core/agi-core/src",
+        "src/agilab/core/agi-env/src",
+        "src/agilab/core/agi-node/src",
+        "src/agilab/core/agi-cluster/src",
+    ]
+    if (REPO_ROOT / "stubs").is_dir():
+        paths.append("stubs")
+    return paths
+
+
+def _shared_core_ty_typing_profile() -> list[CommandSpec]:
+    target_paths = _shared_core_ty_target_paths()
+    extra_search_path_args = [
+        item
+        for path in target_paths
+        for item in ("--extra-search-path", path)
+    ]
+    return [
+        CommandSpec(
+            label="shared-core strict ty typing",
+            argv=[
+                "uv",
+                "--preview-features",
+                "extra-build-dependencies",
+                "run",
+                "--with",
+                "ty",
+                "python",
+                "-m",
+                "ty",
+                "check",
+                "--project",
+                ".",
+                "--error-on-warning",
+                *extra_search_path_args,
+                *target_paths,
+            ],
+        )
+    ]
+
+
 def _dependency_policy_profile() -> list[CommandSpec]:
     return [
         CommandSpec(
@@ -2039,6 +2089,7 @@ def _selected_profiles(args: argparse.Namespace) -> list[str]:
         "release-proof",
         "security-adoption",
         "production-readiness",
+        "ty-typing",
         "ui-robot-matrix",
         "ui-robot-contract",
         "ui-robot-canary",


### PR DESCRIPTION
## Summary
- tightens the shared-core `ty-typing` release gate with strict warning handling and optional stub discovery
- wires the ty gate into release/preflight tooling and PyPI publish workflow coverage
- improves the pending trusted-publisher workflow so runner choice can support same-device PyPI login confirmation
- refreshes component coverage badges after the targeted validation pass

## Validation
- `uv --preview-features extra-build-dependencies run python tools/release_plan.py --check-workflow .github/workflows/pypi-publish.yaml`
- `uv --preview-features extra-build-dependencies run python tools/pypi_release_version_policy.py`
- `uv --preview-features extra-build-dependencies run python tools/pypi_trusted_publisher_contract.py --check-workflow .github/workflows/pypi-publish.yaml`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile dependency-policy --profile shared-core-typing --profile docs --profile ty-typing --no-result-cache`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-env --no-result-cache`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-core-combined --no-result-cache`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui --no-result-cache`
- `uv --preview-features extra-build-dependencies run python tools/coverage_badge_guard.py --changed-only --require-fresh-xml`
- `python -m py_compile` over staged Python files
