### PR TITLE
Add v2026.05.23-2 release handoff

### DIFF
--- a/tools/release_handoffs/v2026.05.23-2-other-machine.md
+++ b/tools/release_handoffs/v2026.05.23-2-other-machine.md
@@ -1,0 +1,124 @@
+# AGILAB release handoff for v2026.05.23-2
+
+Use this handoff when finishing the `v2026.05.23-2` publication from another
+machine or a self-hosted/static-IP runner.
+
+## Prepared repository state
+
+- `main` includes PR `#223` at merge commit
+  `9d4761059f116d361ba89b6989fe7b635c071244`.
+- Latest `main` repo guardrails passed:
+  <https://github.com/ThalesGroup/agilab/actions/runs/26411258063>
+- Local release gate passed on the preparing checkout:
+  `./dev release`
+- `PYPI_CONFIRM_LOGIN_URL` was cleared before this handoff. Do not reuse old
+  PyPI confirmation links.
+- `PYPI_TRUSTED_PUBLISHING=true` is set in repository variables.
+- Required release secrets were present:
+  `HF_TOKEN`, `PYPI_RELEASE_PRUNE_USERNAME`,
+  `PYPI_RELEASE_PRUNE_PASSWORD`, and `PYPI_RELEASE_PRUNE_TOTP_SECRET`.
+
+## Remaining blocker
+
+The PyPI project `agi-page-live-artifacts` does not exist yet. Register a PyPI
+pending trusted publisher for it before dispatching `pypi-publish.yaml`.
+
+Pending trusted publisher values:
+
+| Field | Value |
+|---|---|
+| PyPI project | `agi-page-live-artifacts` |
+| GitHub owner | `ThalesGroup` |
+| GitHub repository | `agilab` |
+| Workflow filename | `pypi-publish.yaml` |
+| Environment | `pypi-agi-page-live-artifacts` |
+
+## Option A: manual PyPI UI path
+
+1. Log into PyPI from the publishing machine.
+2. Add a pending GitHub trusted publisher with the values above.
+3. Dispatch the release workflow:
+
+```bash
+gh workflow run pypi-publish.yaml \
+  -R ThalesGroup/agilab \
+  --ref main \
+  -f release_tag=v2026.05.23-2
+```
+
+## Option B: self-hosted/static-IP runner path
+
+Start the self-hosted runner on the publishing machine, then dispatch pending
+publisher registration on that runner:
+
+```bash
+gh workflow run pypi-pending-trusted-publisher.yaml \
+  -R ThalesGroup/agilab \
+  --ref main \
+  -f runner=self-hosted \
+  -f project_name=agi-page-live-artifacts \
+  -f pypi_environment=pypi-agi-page-live-artifacts
+```
+
+Watch the pending-publisher run:
+
+```bash
+run_id=$(gh run list -R ThalesGroup/agilab \
+  --workflow pypi-pending-trusted-publisher.yaml \
+  --limit 1 \
+  --json databaseId \
+  --jq '.[0].databaseId')
+gh run watch -R ThalesGroup/agilab "$run_id" --exit-status
+```
+
+If PyPI emails a confirm-login URL, set the fresh URL as the repo variable so
+the same runner consumes it:
+
+```bash
+gh variable set PYPI_CONFIRM_LOGIN_URL \
+  -R ThalesGroup/agilab \
+  --body 'https://pypi.org/account/confirm-login/?token=FRESH_TOKEN_FROM_EMAIL'
+```
+
+After pending publisher registration succeeds, clear the temporary URL:
+
+```bash
+gh variable delete PYPI_CONFIRM_LOGIN_URL -R ThalesGroup/agilab
+```
+
+Then dispatch the release workflow:
+
+```bash
+gh workflow run pypi-publish.yaml \
+  -R ThalesGroup/agilab \
+  --ref main \
+  -f release_tag=v2026.05.23-2
+```
+
+## Release watch
+
+```bash
+run_id=$(gh run list -R ThalesGroup/agilab \
+  --workflow pypi-publish.yaml \
+  --limit 1 \
+  --json databaseId \
+  --jq '.[0].databaseId')
+gh run watch -R ThalesGroup/agilab "$run_id" --exit-status
+```
+
+## Post-release quick truth checks
+
+```bash
+uv run python - <<'PY'
+import json
+import urllib.request
+
+for name in ["agi-page-live-artifacts", "agilab"]:
+    payload = json.load(
+        urllib.request.urlopen(f"https://pypi.org/pypi/{name}/json", timeout=30)
+    )
+    print(name, payload["info"]["version"])
+PY
+
+gh release view v2026.05.23-2 -R ThalesGroup/agilab
+```


### PR DESCRIPTION
## Summary
- adds a tracked release handoff for finishing `v2026.05.23-2` from another machine
- records the missing `agi-page-live-artifacts` pending trusted publisher values
- includes the exact GitHub workflow commands and post-release truth checks

## Validation
- not run; documentation-only handoff file
