### PR TITLE
feat(ui): add evidence cockpit run review

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 227,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "edb45dd4d06f3b0972106cf1a0f9ad31aba6d074194b61d52b54aca71dcb8698",
+  "source_digest_sha256": "45f05d361133e9ae9668887e190e941223e472555ae6be1afa1f876b1ea38779",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "edb45dd4d06f3b0972106cf1a0f9ad31aba6d074194b61d52b54aca71dcb8698"
+  "target_digest_sha256": "45f05d361133e9ae9668887e190e941223e472555ae6be1afa1f876b1ea38779"
 }

--- a/docs/source/agilab-mlops-positioning.rst
+++ b/docs/source/agilab-mlops-positioning.rst
@@ -266,11 +266,13 @@ controlled pilot and handoff workbench, not as a production MLOps platform:
   controlled-pilot boundary into an executable proof for service health,
   persisted artifacts, public-bind controls, secret redaction, and explicit
   failure modes
-- the release-decision page gates on the first-proof ``run_manifest.json``,
-  resolves artifact/log/export roots through the shared connector path registry,
-  imports external manifest evidence, applies artifact and KPI gates, and
-  exports ``promotion_decision.json`` plus ``manifest_index.json`` with connector
-  registry paths, manifest summary, import summary, provenance-tagged attachment
+- the Evidence Cockpit / release-decision page gates on the first-proof
+  ``run_manifest.json``, resolves artifact/log/export roots through the shared
+  connector path registry, imports external manifest evidence, applies artifact
+  and KPI gates, summarizes decision status, blocking gates, indexed evidence,
+  export readiness, and next action, and exports ``promotion_decision.json`` plus
+  ``manifest_index.json`` with the same cockpit summary, connector registry
+  paths, manifest summary, import summary, provenance-tagged attachment
   metadata, per-release evidence history, cross-release manifest comparison,
   cross-run evidence bundle comparison, and gate details
 - the standalone run-diff/counterfactual report gives those comparison claims a

--- a/docs/source/apps-pages.rst
+++ b/docs/source/apps-pages.rst
@@ -155,7 +155,7 @@ pulled by the umbrella dependency graph.
      - Included in ``agi-pages``.
    * - ``view_release_decision``
      - ``agi-page-promotion-gate``
-     - Baseline/candidate promotion-gate evidence review.
+     - Evidence cockpit for baseline/candidate run review, gates, and handoff decisions.
      - Included in ``agi-pages``.
    * - ``view_scenario_cockpit``
      - ``agi-page-scenario-cockpit``
@@ -304,11 +304,11 @@ Generic bridge for app-owned interactive Streamlit UIs.
 view_release_decision
 ^^^^^^^^^^^^^^^^^^^^^
 
-Promotion-gate page for baseline/candidate evidence bundles.
+Evidence cockpit for baseline/candidate run review and promotion gates.
 
 - Input: candidate and baseline evidence directories.
-- Output: gate checks, decision summary, and downloadable
-  ``promotion_decision.json`` evidence.
+- Output: cockpit summary, blocking-gate counts, indexed evidence history,
+  handoff checklist, and downloadable ``promotion_decision.json`` evidence.
 
 view_shap_explanation
 ^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -465,12 +465,14 @@ production platform:
 - ``tools/controlled_pilot_readiness_report.py --compact`` packages the
   controlled-pilot readiness proof for service health, persisted artifacts,
   public-bind controls, secret redaction, and explicit failure modes
-- the release-decision analysis page compares baseline and candidate bundles,
-  resolves artifact/log/export roots through the shared connector path registry,
-  gates on the first-proof ``run_manifest.json``, imports external manifest
-  evidence with ``--manifest`` / ``--manifest-dir`` style inputs, evaluates
-  artifact and KPI gates, and exports ``promotion_decision.json`` with connector
-  registry paths, manifest summary, import summary, provenance-tagged attachment
+- the Evidence Cockpit analysis page compares baseline and candidate bundles,
+  summarizes decision status, blocking gates, indexed evidence, and export
+  readiness, resolves artifact/log/export roots through the shared connector
+  path registry, gates on the first-proof ``run_manifest.json``, imports
+  external manifest evidence with ``--manifest`` / ``--manifest-dir`` style
+  inputs, evaluates artifact and KPI gates, and exports
+  ``promotion_decision.json`` with the cockpit summary, connector registry
+  paths, manifest summary, import summary, provenance-tagged attachment
   metadata, per-release ``manifest_index.json`` evidence history,
   cross-release manifest comparison, cross-run evidence bundle comparison, and
   gate details; it also imports ``ci_artifact_harvest.json`` evidence, displays

--- a/src/agilab/apps-pages/view_release_decision/README.md
+++ b/src/agilab/apps-pages/view_release_decision/README.md
@@ -1,9 +1,12 @@
 # view_release_decision
 
-Reusable Streamlit analysis page for baseline-vs-candidate promotion decisions.
+Reusable Streamlit evidence cockpit for baseline-vs-candidate run review and
+promotion decisions.
 
 Primary use:
 
+- see one cockpit summary for decision status, blocking gates, indexed evidence,
+  and export readiness
 - compare two exported metric bundles
 - resolve artifact, log, export, and first-proof paths through the shared connector path registry
 - gate promotion on first-proof `run_manifest.json`
@@ -15,6 +18,11 @@ Primary use:
 - maintain a per-artifact-root `manifest_index.json`
 - compare current evidence against prior indexed releases
 - compare full evidence bundles across runs
+
+The page is intentionally a review surface, not a production governance system:
+it helps answer whether a run is better, reproducible, reviewable, and ready to
+hand off through `promotion_decision.json`, notebook, MLflow, Quarto, or another
+production stack.
 
 Default search root:
 

--- a/src/agilab/apps-pages/view_release_decision/pyproject.toml
+++ b/src/agilab/apps-pages/view_release_decision/pyproject.toml
@@ -1,8 +1,8 @@
 [project]
 name = "agi-page-promotion-gate"
 version = "2026.05.26"
-description = "AGILAB page bundle for promotion-gate evidence review."
-readme = { text = "AGILAB page bundle for promotion-gate evidence review.", content-type = "text/markdown" }
+description = "AGILAB page bundle for evidence-cockpit run review and promotion gates."
+readme = { text = "AGILAB page bundle for evidence-cockpit run review and promotion gates.", content-type = "text/markdown" }
 requires-python = ">=3.11"
 keywords = [
     "agilab",

--- a/src/agilab/apps-pages/view_release_decision/src/view_release_decision/view_release_decision.py
+++ b/src/agilab/apps-pages/view_release_decision/src/view_release_decision/view_release_decision.py
@@ -1446,6 +1446,138 @@ def _evidence_bundle_comparison_summary(rows: list[dict[str, Any]], candidate_pa
     }
 
 
+def _count_rows_with_status(rows: list[dict[str, Any]], status: str) -> int:
+    return sum(1 for row in rows if str(row.get("status", "")) == status)
+
+
+def _build_evidence_cockpit_summary(
+    *,
+    decision_status: str,
+    decision_summary: str,
+    artifact_root: Path,
+    baseline_path: Path,
+    candidate_path: Path,
+    metrics_files: list[Path],
+    artifact_rows: list[dict[str, Any]],
+    metric_rows: list[dict[str, Any]],
+    run_manifest_rows: list[dict[str, Any]],
+    run_manifest_summary: dict[str, Any],
+    imported_manifest_summary: dict[str, Any],
+    ci_artifact_harvest_summary: dict[str, Any],
+    manifest_index_summary: dict[str, Any],
+    evidence_bundle_comparison_summary: dict[str, Any],
+    reduce_artifact_rows: list[dict[str, Any]],
+) -> dict[str, Any]:
+    artifact_fail_count = _count_rows_with_status(artifact_rows, "fail")
+    metric_fail_count = _count_rows_with_status(metric_rows, "fail")
+    manifest_fail_count = _count_rows_with_status(run_manifest_rows, "fail")
+    ci_gate_status = str(ci_artifact_harvest_summary.get("gate_status", "not_configured"))
+    ci_fail_count = 1 if ci_gate_status == "fail" else 0
+    explicit_blocking_count = (
+        artifact_fail_count
+        + metric_fail_count
+        + manifest_fail_count
+        + ci_fail_count
+    )
+    comparison_blocking_count = int(
+        evidence_bundle_comparison_summary.get("blocking_count", 0) or 0
+    )
+    status_label = {
+        "promotable": "Ready to export",
+        "blocked": "Blocked",
+        "needs_review": "Needs review",
+    }.get(decision_status, decision_status or "Unknown")
+    next_action = {
+        "promotable": "Export promotion_decision.json, then hand off through notebook, MLflow, Quarto, or your production stack.",
+        "blocked": "Fix failing manifest, artifact, KPI, or CI evidence gates before sharing this run.",
+        "needs_review": "Select distinct baseline/candidate runs or add standardized KPI evidence before promotion.",
+    }.get(decision_status, "Review the evidence tables and export only after the decision is understood.")
+    return {
+        "schema": "agilab.evidence_cockpit_summary.v1",
+        "status": decision_status,
+        "status_label": status_label,
+        "summary": decision_summary,
+        "next_action": next_action,
+        "artifact_root": str(artifact_root),
+        "baseline_bundle_root": str(baseline_path.parent),
+        "candidate_bundle_root": str(candidate_path.parent),
+        "baseline_metrics_file": str(baseline_path),
+        "candidate_metrics_file": str(candidate_path),
+        "run_manifest_path": str(run_manifest_summary.get("path", "")),
+        "metrics_file_count": len(metrics_files),
+        "artifact_gate_count": len(artifact_rows),
+        "artifact_gate_fail_count": artifact_fail_count,
+        "kpi_gate_count": len(metric_rows),
+        "kpi_gate_fail_count": metric_fail_count,
+        "run_manifest_gate_count": len(run_manifest_rows),
+        "run_manifest_gate_fail_count": manifest_fail_count,
+        "run_manifest_status": run_manifest_summary.get("status", ""),
+        "run_manifest_loaded": bool(run_manifest_summary.get("loaded")),
+        "imported_manifest_count": int(imported_manifest_summary.get("loaded_manifest_count", 0) or 0),
+        "validated_imported_manifest_count": int(
+            imported_manifest_summary.get("validated_manifest_count", 0) or 0
+        ),
+        "ci_artifact_harvest_gate_status": ci_gate_status,
+        "ci_artifact_harvest_validated_count": int(
+            ci_artifact_harvest_summary.get("validated_harvest_count", 0) or 0
+        ),
+        "indexed_release_count": int(manifest_index_summary.get("release_count", 0) or 0),
+        "indexed_manifest_count": int(manifest_index_summary.get("manifest_count", 0) or 0),
+        "reduce_artifact_count": len(reduce_artifact_rows),
+        "valid_reduce_artifact_count": sum(1 for row in reduce_artifact_rows if row.get("status") == "pass"),
+        "explicit_blocking_gate_count": explicit_blocking_count,
+        "comparison_blocking_count": comparison_blocking_count,
+        "export_ready": decision_status == "promotable",
+    }
+
+
+def _render_evidence_cockpit_summary(st_api: Any, summary: dict[str, Any]) -> None:
+    st_api.subheader("Run review cockpit")
+    st_api.caption(
+        "Baseline -> candidate -> gates -> decision -> portable handoff. "
+        "Use this section to decide whether the run is better, reproducible, reviewable, and ready to share."
+    )
+    status_col, gates_col, history_col, export_col = st_api.columns(4)
+    status_col.metric("Decision", summary["status_label"])
+    gates_col.metric(
+        "Blocking gates",
+        str(summary["explicit_blocking_gate_count"]),
+        help="Failing manifest, artifact, KPI, or CI artifact-harvest gates.",
+    )
+    history_col.metric(
+        "Indexed evidence",
+        str(summary["indexed_release_count"]),
+        help="Prior candidate bundles already recorded in manifest_index.json.",
+    )
+    export_col.metric(
+        "Export",
+        "ready" if summary["export_ready"] else "not ready",
+        help="Whether promotion_decision.json should be exported as shareable evidence.",
+    )
+    st_api.markdown(f"**Next action:** {summary['next_action']}")
+    st_api.caption(
+        f"Baseline: `{Path(summary['baseline_bundle_root']).name}` | "
+        f"Candidate: `{Path(summary['candidate_bundle_root']).name}` | "
+        f"Metrics files discovered: {summary['metrics_file_count']} | "
+        f"Valid reduce artifacts: {summary['valid_reduce_artifact_count']}"
+    )
+    handoff_commands = ["# Add a passing run_manifest.json before exporting proof-pack handoffs."]
+    if summary["run_manifest_loaded"]:
+        run_manifest_path = str(summary["run_manifest_path"])
+        handoff_commands = [
+            f"agilab verify {shlex.quote(run_manifest_path)}",
+            f"agilab export quarto --run {shlex.quote(run_manifest_path)} --output report.qmd",
+            f"agilab export mlflow --run {shlex.quote(run_manifest_path)} --output mlflow_handoff.json",
+        ]
+    with st_api.expander("Handoff checklist", expanded=False):
+        st_api.markdown(
+            "- Keep `promotion_decision.json` with the candidate artifacts.\n"
+            "- Keep `manifest_index.json` with the artifact root for later run comparison.\n"
+            "- Export to notebook, MLflow, Quarto, or a production stack only after the cockpit decision is understood."
+        )
+        st_api.code("\n".join(handoff_commands), language="bash")
+
+
 def _write_manifest_index(path: Path, payload: dict[str, Any]) -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
@@ -1838,6 +1970,7 @@ def _decision_payload(
     evidence_bundle_comparison_summary: dict[str, Any],
     connector_registry_rows: list[dict[str, Any]],
     connector_registry_summary: dict[str, Any],
+    evidence_cockpit_summary: dict[str, Any],
     status: str,
     summary: str,
     tolerance_pct: float,
@@ -1857,6 +1990,7 @@ def _decision_payload(
         "status": status,
         "summary": summary,
         "tolerance_pct": tolerance_pct,
+        "evidence_cockpit_summary": evidence_cockpit_summary,
         "baseline_metadata": _metadata_subset(baseline_payload),
         "candidate_metadata": _metadata_subset(candidate_payload),
         "run_manifest_path": str(run_manifest_path),
@@ -1948,10 +2082,10 @@ else:
     env = st.session_state["env"]
 _reset_app_scoped_session_defaults(st, env)
 
-render_logo("Release Decision")
-st.title("Release decision")
+render_logo("Evidence Cockpit")
+st.title("Evidence cockpit")
 st.caption(
-    "Compare a candidate bundle against a baseline, apply explicit evidence gates, and export a promotion decision."
+    "Review baseline versus candidate evidence, explain gate failures, and export a portable promotion decision."
 )
 
 connector_registry = _connector_path_registry(env)
@@ -2140,6 +2274,23 @@ decision_status, decision_summary = _decision_status(
     manifest_rows=run_manifest_rows,
     ci_artifact_harvest_summary=ci_artifact_harvest_summary,
 )
+evidence_cockpit_summary = _build_evidence_cockpit_summary(
+    decision_status=decision_status,
+    decision_summary=decision_summary,
+    artifact_root=artifact_root,
+    baseline_path=baseline_path,
+    candidate_path=candidate_path,
+    metrics_files=metrics_files,
+    artifact_rows=artifact_rows,
+    metric_rows=metric_rows,
+    run_manifest_rows=run_manifest_rows,
+    run_manifest_summary=run_manifest_summary,
+    imported_manifest_summary=imported_manifest_summary,
+    ci_artifact_harvest_summary=ci_artifact_harvest_summary,
+    manifest_index_summary=manifest_index_summary,
+    evidence_bundle_comparison_summary=evidence_bundle_comparison_summary,
+    reduce_artifact_rows=reduce_artifact_rows,
+)
 payload = _decision_payload(
     env=env,
     artifact_root=artifact_root,
@@ -2165,10 +2316,13 @@ payload = _decision_payload(
     evidence_bundle_comparison_summary=evidence_bundle_comparison_summary,
     connector_registry_rows=connector_registry_rows,
     connector_registry_summary=connector_registry_summary,
+    evidence_cockpit_summary=evidence_cockpit_summary,
     status=decision_status,
     summary=decision_summary,
     tolerance_pct=tolerance_pct,
 )
+
+_render_evidence_cockpit_summary(st, evidence_cockpit_summary)
 
 if decision_status == "promotable":
     st.success(f"Promotable: {decision_summary}")

--- a/src/agilab/pages/4_ANALYSIS.py
+++ b/src/agilab/pages/4_ANALYSIS.py
@@ -187,9 +187,9 @@ _ANALYSIS_VIEW_PROFILES = {
         "Use for long-running local or distributed runs that write incremental artifacts.",
     ),
     "view_release_decision": (
-        "Release decision",
-        "Aggregate run evidence into pass/fail release support.",
-        "Use before publishing a demo, package, or validation result.",
+        "Evidence cockpit",
+        "Review baseline/candidate runs, evidence gates, and portable handoff decisions.",
+        "Use after a run when you need to decide whether evidence is ready to share.",
     ),
     "view_shap_explanation": (
         "SHAP explanation",

--- a/test/test_view_release_decision.py
+++ b/test/test_view_release_decision.py
@@ -397,7 +397,8 @@ def test_view_release_decision_renders_promotable_candidate_and_exports_json(tmp
     at = _run_release_page(tmp_path, monkeypatch, project_dir)
 
     assert not at.exception
-    assert any(title.value == "Release decision" for title in at.title)
+    assert any(title.value == "Evidence cockpit" for title in at.title)
+    assert any(header.value == "Run review cockpit" for header in at.subheader)
     assert any("Promotable" in message.value for message in at.success)
     assert any(header.value == "Connector path registry" for header in at.subheader)
     connector_live_ui = at.session_state["release_decision_connector_live_ui"]
@@ -414,6 +415,10 @@ def test_view_release_decision_renders_promotable_candidate_and_exports_json(tmp
     assert decision_path.is_file()
     payload = json.loads(decision_path.read_text(encoding="utf-8"))
     assert payload["status"] == "promotable"
+    assert payload["evidence_cockpit_summary"]["status_label"] == "Ready to export"
+    assert payload["evidence_cockpit_summary"]["export_ready"] is True
+    assert payload["evidence_cockpit_summary"]["explicit_blocking_gate_count"] == 0
+    assert payload["evidence_cockpit_summary"]["candidate_bundle_root"] == str(candidate_root)
     assert payload["candidate_bundle_root"] == str(candidate_root)
     assert payload["connector_registry_summary"]["paths"]["artifact_root"] == str(export_root)
     assert {
@@ -871,6 +876,32 @@ def test_view_release_decision_helper_branches(monkeypatch, tmp_path) -> None:
     )
     assert manifest_status == "blocked"
     assert "manifest gate" in manifest_summary
+
+    cockpit_summary = module._build_evidence_cockpit_summary(
+        decision_status=manifest_status,
+        decision_summary=manifest_summary,
+        artifact_root=tmp_path / "artifact_root",
+        baseline_path=tmp_path / "artifact_root" / "run_a" / "metrics.json",
+        candidate_path=tmp_path / "artifact_root" / "run_b" / "metrics.json",
+        metrics_files=[
+            tmp_path / "artifact_root" / "run_a" / "metrics.json",
+            tmp_path / "artifact_root" / "run_b" / "metrics.json",
+        ],
+        artifact_rows=[{"status": "pass"}],
+        metric_rows=[{"status": "pass"}],
+        run_manifest_rows=bad_rows,
+        run_manifest_summary=bad_summary,
+        imported_manifest_summary={"loaded_manifest_count": 0, "validated_manifest_count": 0},
+        ci_artifact_harvest_summary={"gate_status": "not_configured"},
+        manifest_index_summary={"release_count": 0, "manifest_count": 0},
+        evidence_bundle_comparison_summary={"blocking_count": 0},
+        reduce_artifact_rows=[{"status": "pass"}],
+    )
+    assert cockpit_summary["schema"] == "agilab.evidence_cockpit_summary.v1"
+    assert cockpit_summary["status_label"] == "Blocked"
+    assert cockpit_summary["explicit_blocking_gate_count"] == 1
+    assert cockpit_summary["export_ready"] is False
+    assert "Fix failing" in cockpit_summary["next_action"]
 
     import_args = (
         f"uv run python tools/compatibility_report.py --manifest {bad_manifest} "


### PR DESCRIPTION
Add an Evidence Cockpit summary to the release-decision page so run review is visible as baseline/candidate evidence, blocking gates, export readiness, next action, and handoff commands.

Also relabel the ANALYSIS entry, export the cockpit summary inside promotion_decision.json, update tests, and sync the public docs mirror from the canonical docs source.

Local validation:
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_view_release_decision.py test/test_pyproject_dependency_hygiene.py test/test_ui_pages.py
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui
- uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp
- git diff --check