### PR TITLE
feat(tools): add robustness matrix guard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,11 +24,14 @@ Use this runbook whenever you:
 - **High-frequency command shortcuts**: Use `./dev <shortcut>` for repeated local validation loops.
   The top shortcuts are `impact` for impact validation, `bugfix` for impact plus a fast
   GA-selected regression run, `test` for targeted `pytest -q -o addopts=''`,
-  `regress` for GA-selected fast regression subsets, `flow` for one or more workflow parity
-  profiles, `release` for local pre-tag release guards, `badge` for the explicit release/pre-release
+  `regress` for GA-selected fast regression subsets, `robust` for P0 fail-closed
+  robustness scenarios, `flow` for one or more workflow parity profiles,
+  `release` for local pre-tag release guards, `badge` for the explicit release/pre-release
   coverage-badge guard, and `docs` for docs mirror sync plus stamp verification. `impact` tells you what must be validated, `test` runs the
   narrow pytest slice, `bugfix` is the default low-load pre-push loop for normal code fixes,
   `regress` optimizes a likely regression subset from changed files and optional JUnit timings,
+  `robust` runs synthetic bad-state checks for cluster shares, public UI binds,
+  service health gates, evidence manifests, notebook import, app settings, and UI routes,
   `flow` matches local GitHub workflow profiles, `release` checks impact, generated PyPI release
   plan, trusted-publisher contract, dependency policy, strict typing, docs, and badges before a tag,
   `badge` checks badge freshness when intentionally requested, and `docs` keeps the public mirror

--- a/README.md
+++ b/README.md
@@ -328,6 +328,11 @@ hash-verifiable `.agipack` archive for portable handoff with
 signing with `agilab sign proof.agipack --key signer.pem --signature
 proof.agipack.sig.json` and trust-policy verification with `agilab verify
 proof.agipack --signature proof.agipack.sig.json --trust-policy policy.toml`.
+For fail-closed evidence, maintainers can run `./dev robust`; it executes a P0
+robustness matrix of synthetic bad states covering cluster shares, public UI
+binds, service health gates, evidence manifests, notebook import, app settings,
+and Streamlit route contracts. A scenario passes only when the bad state is
+rejected with a clear remediation and replay command.
 External Sigstore/SLSA attestation binding, native lineage or observability
 transport, durable ML metadata, rich app-authored cards, and enterprise
 governance integrations remain roadmap work. See the

--- a/test/test_agilab_dev_shortcuts.py
+++ b/test/test_agilab_dev_shortcuts.py
@@ -108,6 +108,42 @@ def test_regress_shortcut_keeps_selector_arguments():
     ]
 
 
+def test_robust_shortcut_runs_p0_robustness_matrix_by_default():
+    assert agilab_dev.planned_commands(["robust"]) == [
+        [
+            "uv",
+            "--preview-features",
+            "extra-build-dependencies",
+            "run",
+            "python",
+            "tools/robustness_matrix.py",
+        ]
+    ]
+
+
+def test_robust_shortcut_keeps_matrix_arguments():
+    assert agilab_dev.planned_commands(
+        [
+            "robustness",
+            "--scenario",
+            "public_streamlit_bind_without_controls_refused",
+            "--compact",
+        ]
+    ) == [
+        [
+            "uv",
+            "--preview-features",
+            "extra-build-dependencies",
+            "run",
+            "python",
+            "tools/robustness_matrix.py",
+            "--scenario",
+            "public_streamlit_bind_without_controls_refused",
+            "--compact",
+        ]
+    ]
+
+
 def test_main_keeps_machine_readable_shortcut_stdout_clean(capsys, monkeypatch):
     calls = []
 

--- a/test/test_robustness_matrix.py
+++ b/test/test_robustness_matrix.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import sys
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "tools" / "robustness_matrix.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("robustness_matrix_test_module", MODULE_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_robustness_matrix_p0_passes_against_current_contracts() -> None:
+    module = _load_module()
+
+    report = module.build_report(repo_root=Path.cwd())
+
+    assert report["schema"] == module.SCHEMA
+    assert report["status"] == "pass"
+    assert report["profile"] == "p0"
+    assert report["summary"]["scenario_count"] >= 10
+    assert report["summary"]["failed"] == 0
+    assert report["summary"]["cleanup_status"] == "removed"
+    scenarios = {scenario["id"]: scenario for scenario in report["scenarios"]}
+    assert scenarios["cluster_share_same_as_local_fails_closed"]["status"] == "pass"
+    assert scenarios["cluster_share_missing_fails_closed"]["status"] == "pass"
+    assert scenarios["public_streamlit_bind_without_controls_refused"]["status"] == "pass"
+    assert scenarios["missing_run_manifest_fails_verification"]["status"] == "pass"
+    assert scenarios["invalid_notebook_import_fails_preflight"]["status"] == "pass"
+    assert scenarios["streamlit_routes_do_not_hardcode_pages_directory"]["status"] == "pass"
+    assert "replay_command" in scenarios["invalid_run_manifest_fails_verification"]
+
+
+def test_robustness_matrix_reports_synthetic_failed_scenario() -> None:
+    module = _load_module()
+
+    def _bad_state_was_accepted(_repo_root: Path, _tmp_root: Path):
+        return module.ScenarioObservation(
+            passed=False,
+            observed="bad state was accepted",
+            details={"accepted": True},
+        )
+
+    scenario = module.RobustnessScenario(
+        id="synthetic_bad_state",
+        domain="test",
+        fault="Synthetic bad state.",
+        expected_behavior="Reject the bad state.",
+        remediation="Fix the synthetic scenario.",
+        replay_command="python tools/robustness_matrix.py --scenario synthetic_bad_state",
+        runner=_bad_state_was_accepted,
+    )
+
+    report = module.build_report(repo_root=Path.cwd(), scenario_specs=[scenario])
+
+    assert report["status"] == "fail"
+    assert report["summary"]["failed"] == 1
+    assert report["scenarios"][0]["status"] == "fail"
+    assert report["scenarios"][0]["observed"] == "bad state was accepted"
+    assert report["scenarios"][0]["cleanup_status"] == "removed"
+
+
+def test_robustness_matrix_unknown_scenario_returns_cli_usage_error(capsys) -> None:
+    module = _load_module()
+
+    code = module.main(["--scenario", "does_not_exist", "--compact"])
+
+    captured = capsys.readouterr()
+    assert code == 2
+    assert "Unknown robustness scenario" in captured.err
+    assert captured.out == ""
+
+
+def test_robustness_matrix_cli_writes_output_and_compact_json(tmp_path: Path, capsys) -> None:
+    module = _load_module()
+    output = tmp_path / "robustness.json"
+
+    code = module.main(
+        [
+            "--scenario",
+            "public_streamlit_bind_without_controls_refused",
+            "--output",
+            str(output),
+            "--compact",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert code == 0
+    stdout_payload = json.loads(captured.out)
+    persisted_payload = json.loads(output.read_text(encoding="utf-8"))
+    assert stdout_payload["status"] == "pass"
+    assert persisted_payload["status"] == "pass"
+    assert stdout_payload["summary"]["scenario_count"] == 1
+    assert persisted_payload["scenarios"][0]["id"] == "public_streamlit_bind_without_controls_refused"
+
+
+def test_robustness_matrix_lists_scenarios(capsys) -> None:
+    module = _load_module()
+
+    code = module.main(["--list-scenarios"])
+
+    captured = capsys.readouterr()
+    assert code == 0
+    assert "cluster_share_same_as_local_fails_closed\tcluster" in captured.out
+    assert "streamlit_routes_do_not_hardcode_pages_directory\tui-routing" in captured.out

--- a/tools/agilab_dev.py
+++ b/tools/agilab_dev.py
@@ -58,6 +58,9 @@ def planned_commands(argv: Sequence[str]) -> list[list[str]]:
         forwarded = args or ["--staged", "--run"]
         return [_uv_python("tools/ga_regression_selector.py", *forwarded)]
 
+    if command in {"robust", "robustness"}:
+        return [_uv_python("tools/robustness_matrix.py", *args)]
+
     if command in {"flow", "profile"}:
         profiles, extras = _split_leading_values(args, command_name=command)
         profile_args: list[str] = []
@@ -129,6 +132,7 @@ def _usage() -> str:
   ./dev [--print-only] bugfix [changed-file args]
   ./dev [--print-only] test [pytest args]
   ./dev [--print-only] regress [ga_regression_selector args]
+  ./dev [--print-only] robust [robustness_matrix args]
   ./dev [--print-only] flow|profile <profile> [profile...] [workflow args]
   ./dev [--print-only] typing [workflow-parity options]
   ./dev [--print-only] release [impact_validate args]
@@ -141,6 +145,7 @@ High-frequency mappings:
   bugfix    -> Run impact triage, then run the GA-selected fast regression subset; defaults to --staged.
   test      -> Run targeted pytest with -q and repo-wide coverage disabled, while keeping all extra pytest arguments.
   regress   -> Use the GA regression selector on staged files and run the selected pytest subset.
+  robust    -> Run the P0 robustness matrix of fail-closed bad-state scenarios.
   flow      -> Run one or more workflow_parity profiles with repeated --profile flags.
   typing    -> Run the forward shared-core ty typing profile. Mypy remains the curated temporary release guard under shared-core-typing.
   release   -> Run local release guards: impact, generated PyPI plan, release cadence, trusted publisher contract, docs, dependency policy, typing, and badge freshness.

--- a/tools/robustness_matrix.py
+++ b/tools/robustness_matrix.py
@@ -1,0 +1,575 @@
+#!/usr/bin/env python3
+"""Run AGILAB P0 robustness scenarios against known bad states."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import importlib.util
+import json
+from pathlib import Path
+import re
+import sys
+import tempfile
+from typing import Any, Callable, Sequence
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = "agilab.robustness_matrix.v1"
+DEFAULT_PROFILE = "p0"
+
+
+def _ensure_repo_on_path(repo_root: Path) -> None:
+    candidates = (
+        repo_root / "src",
+        repo_root / "src" / "agilab" / "core" / "agi-env" / "src",
+        repo_root / "src" / "agilab" / "core" / "agi-cluster" / "src",
+        repo_root / "src" / "agilab" / "core" / "agi-node" / "src",
+        repo_root / "src" / "agilab" / "core" / "agi-core" / "src",
+        repo_root,
+    )
+    for candidate in candidates:
+        value = str(candidate)
+        if value not in sys.path:
+            sys.path.insert(0, value)
+
+
+def _load_tool_module(repo_root: Path, name: str):
+    module_path = repo_root / "tools" / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(f"agilab_robustness_{name}", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Cannot load tool module: {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@dataclass(frozen=True)
+class ScenarioObservation:
+    passed: bool
+    observed: str
+    details: dict[str, Any] | None = None
+    evidence: Sequence[str] = ()
+
+
+@dataclass(frozen=True)
+class RobustnessScenario:
+    id: str
+    domain: str
+    fault: str
+    expected_behavior: str
+    remediation: str
+    replay_command: str
+    runner: Callable[[Path, Path], ScenarioObservation]
+    profiles: tuple[str, ...] = (DEFAULT_PROFILE,)
+
+
+def _replay_command(scenario_id: str) -> str:
+    return f"./dev robust --scenario {scenario_id} --compact"
+
+
+def _check_exception(
+    func: Callable[[], Any],
+    *,
+    expected_type: type[BaseException],
+    required_tokens: Sequence[str],
+) -> ScenarioObservation:
+    try:
+        func()
+    except expected_type as exc:
+        message = str(exc)
+        missing = [token for token in required_tokens if token not in message]
+        return ScenarioObservation(
+            passed=not missing,
+            observed=message,
+            details={"missing_message_tokens": missing, "exception_type": type(exc).__name__},
+        )
+    except Exception as exc:  # pragma: no cover - defensive contract reporting.
+        return ScenarioObservation(
+            passed=False,
+            observed=f"Unexpected exception type {type(exc).__name__}: {exc}",
+            details={"exception_type": type(exc).__name__},
+        )
+    return ScenarioObservation(
+        passed=False,
+        observed=f"Expected {expected_type.__name__}, but the bad state was accepted.",
+        details={"exception_type": ""},
+    )
+
+
+def _cluster_share_same_as_local(repo_root: Path, tmp_root: Path) -> ScenarioObservation:
+    del repo_root
+    from agi_env.share_mount_support import resolve_share_path
+
+    share = tmp_root / "same-share"
+    share.mkdir()
+    env_path = tmp_root / ".env"
+    env_path.write_text("AGI_CLUSTER_SHARE=same-share\nAGI_LOCAL_SHARE=same-share\n", encoding="utf-8")
+
+    return _check_exception(
+        lambda: resolve_share_path(
+            cluster_share=str(share),
+            local_share=str(share),
+            cluster_enabled=True,
+            env_path=env_path,
+            home_path=tmp_root,
+        ),
+        expected_type=RuntimeError,
+        required_tokens=("requires AGI_CLUSTER_SHARE to be distinct", str(env_path)),
+    )
+
+
+def _cluster_share_missing(repo_root: Path, tmp_root: Path) -> ScenarioObservation:
+    del repo_root
+    from agi_env.share_mount_support import resolve_share_path
+
+    local_share = tmp_root / "localshare"
+    local_share.mkdir()
+    cluster_share = tmp_root / "missing-clustershare"
+    env_path = tmp_root / ".env"
+    env_path.write_text(
+        f"AGI_CLUSTER_SHARE={cluster_share}\nAGI_LOCAL_SHARE={local_share}\n",
+        encoding="utf-8",
+    )
+
+    return _check_exception(
+        lambda: resolve_share_path(
+            cluster_share=str(cluster_share),
+            local_share=str(local_share),
+            cluster_enabled=True,
+            env_path=env_path,
+            home_path=tmp_root,
+        ),
+        expected_type=RuntimeError,
+        required_tokens=("requires AGI_CLUSTER_SHARE to be mounted and writable", str(env_path)),
+    )
+
+
+def _public_bind_without_controls(repo_root: Path, tmp_root: Path) -> ScenarioObservation:
+    del tmp_root
+    _ensure_repo_on_path(repo_root)
+    from agilab.ui_public_bind_guard import PublicBindPolicyError, enforce_public_bind_policy
+
+    return _check_exception(
+        lambda: enforce_public_bind_policy({"AGILAB_UI_HOST": "0.0.0.0"}),
+        expected_type=PublicBindPolicyError,
+        required_tokens=("refuses to bind", "auth/TLS", "AGILAB_PUBLIC_BIND_OK"),
+    )
+
+
+def _public_bind_incomplete_controls(repo_root: Path, tmp_root: Path) -> ScenarioObservation:
+    del tmp_root
+    _ensure_repo_on_path(repo_root)
+    from agilab.ui_public_bind_guard import PublicBindPolicyError, enforce_public_bind_policy
+
+    return _check_exception(
+        lambda: enforce_public_bind_policy(
+            {"AGILAB_UI_HOST": "0.0.0.0", "AGILAB_PUBLIC_BIND_OK": "1"}
+        ),
+        expected_type=PublicBindPolicyError,
+        required_tokens=("refuses to bind", "auth/TLS", "AGILAB_PUBLIC_BIND_OK"),
+    )
+
+
+def _service_health_unhealthy_workers(repo_root: Path, tmp_root: Path) -> ScenarioObservation:
+    del tmp_root
+    service_health_check = _load_tool_module(repo_root, "service_health_check")
+    exit_code, message, details = service_health_check._evaluate_health(
+        {"status": "running", "workers_unhealthy_count": 2, "workers_running_count": 4},
+        allow_idle=False,
+        max_unhealthy=0,
+        max_restart_rate=0.25,
+    )
+    return ScenarioObservation(
+        passed=exit_code == 2 and "exceeds limit" in message,
+        observed=message,
+        details={"exit_code": exit_code, **details},
+        evidence=("tools/service_health_check.py",),
+    )
+
+
+def _service_health_idle_without_override(repo_root: Path, tmp_root: Path) -> ScenarioObservation:
+    del tmp_root
+    service_health_check = _load_tool_module(repo_root, "service_health_check")
+    exit_code, message, details = service_health_check._evaluate_health(
+        {"status": "idle", "workers_unhealthy_count": 0, "workers_running_count": 1},
+        allow_idle=False,
+        max_unhealthy=0,
+        max_restart_rate=0.25,
+    )
+    return ScenarioObservation(
+        passed=exit_code == 4 and "use --allow-idle" in message,
+        observed=message,
+        details={"exit_code": exit_code, **details},
+        evidence=("tools/service_health_check.py",),
+    )
+
+
+def _missing_run_manifest_fails_verification(repo_root: Path, tmp_root: Path) -> ScenarioObservation:
+    _ensure_repo_on_path(repo_root)
+    from agilab.evidence_contract import verify_manifest
+
+    manifest_path = tmp_root / "missing-run_manifest.json"
+    report = verify_manifest(manifest_path)
+    checks = {check["id"]: check for check in report.get("checks", [])}
+    manifest_check = checks.get("manifest_exists", {})
+    return ScenarioObservation(
+        passed=report.get("status") == "fail" and manifest_check.get("status") == "fail",
+        observed=str(manifest_check.get("summary", "")),
+        details={
+            "report_status": report.get("status"),
+            "check_status": manifest_check.get("status"),
+            "manifest_path": str(manifest_path),
+        },
+        evidence=("src/agilab/evidence_contract.py",),
+    )
+
+
+def _invalid_run_manifest_fails_verification(repo_root: Path, tmp_root: Path) -> ScenarioObservation:
+    _ensure_repo_on_path(repo_root)
+    from agilab.evidence_contract import verify_manifest
+
+    manifest_path = tmp_root / "run_manifest.json"
+    manifest_path.write_text("{not valid json\n", encoding="utf-8")
+    report = verify_manifest(manifest_path)
+    checks = {check["id"]: check for check in report.get("checks", [])}
+    schema_check = checks.get("manifest_schema_supported", {})
+    return ScenarioObservation(
+        passed=report.get("status") == "fail" and schema_check.get("status") == "fail",
+        observed=str(schema_check.get("summary", "")),
+        details={
+            "report_status": report.get("status"),
+            "check_status": schema_check.get("status"),
+            "manifest_path": str(manifest_path),
+        },
+        evidence=("src/agilab/evidence_contract.py",),
+    )
+
+
+def _invalid_notebook_import_fails_preflight(repo_root: Path, tmp_root: Path) -> ScenarioObservation:
+    notebook_import_preflight = _load_tool_module(repo_root, "notebook_import_preflight")
+    notebook_path = tmp_root / "bad.ipynb"
+    notebook_path.write_text(
+        json.dumps({"cells": "not-a-list", "metadata": {}, "nbformat": 4, "nbformat_minor": 5}),
+        encoding="utf-8",
+    )
+    report = notebook_import_preflight.build_report(notebook_path=notebook_path)
+    checks = {check["id"]: check for check in report.get("checks", [])}
+    load_check = checks.get("notebook_import_preflight_load", {})
+    return ScenarioObservation(
+        passed=report.get("status") == "fail" and "cells must be a list" in str(load_check),
+        observed=str(load_check.get("summary", "")),
+        details={"report_status": report.get("status"), "load_check": load_check},
+        evidence=("tools/notebook_import_preflight.py", "src/agilab/notebook_pipeline_import.py"),
+    )
+
+
+def _unsupported_app_settings_schema(repo_root: Path, tmp_root: Path) -> ScenarioObservation:
+    del repo_root, tmp_root
+    from agi_env.app_settings_support import prepare_app_settings_for_write
+
+    return _check_exception(
+        lambda: prepare_app_settings_for_write(
+            {"__meta__": {"schema": "agilab.app_settings.v1", "version": 999}}
+        ),
+        expected_type=ValueError,
+        required_tokens=("Unsupported app_settings.toml schema version", "upgrade AGILAB"),
+    )
+
+
+def _conflicting_app_settings_run_payload(repo_root: Path, tmp_root: Path) -> ScenarioObservation:
+    del repo_root, tmp_root
+    from agi_env.app_settings_support import prepare_app_settings_for_write
+
+    return _check_exception(
+        lambda: prepare_app_settings_for_write({"args": {"args": [], "stages": []}}),
+        expected_type=ValueError,
+        required_tokens=("cannot contain both", "legacy 'args.args'", "current 'args.stages'"),
+    )
+
+
+def _streamlit_route_static_guard(repo_root: Path, tmp_root: Path) -> ScenarioObservation:
+    del tmp_root
+    scan_roots = (
+        repo_root / "src" / "agilab" / "main_page.py",
+        repo_root / "src" / "agilab" / "about_page",
+        repo_root / "src" / "agilab" / "pages",
+    )
+    pattern = re.compile(r"switch_page\(\s*Path\(\s*[\"']pages/")
+    offenders: list[str] = []
+    for root in scan_roots:
+        paths = [root] if root.is_file() else sorted(root.rglob("*.py"))
+        for path in paths:
+            text = path.read_text(encoding="utf-8", errors="ignore")
+            if pattern.search(text):
+                offenders.append(str(path.relative_to(repo_root)))
+    return ScenarioObservation(
+        passed=not offenders,
+        observed=(
+            "No hard-coded Streamlit pages/<n> routes found."
+            if not offenders
+            else "Hard-coded Streamlit page routes found."
+        ),
+        details={"offenders": offenders},
+        evidence=tuple(str(path.relative_to(repo_root)) for path in scan_roots),
+    )
+
+
+SCENARIOS: tuple[RobustnessScenario, ...] = (
+    RobustnessScenario(
+        id="cluster_share_same_as_local_fails_closed",
+        domain="cluster",
+        fault="Cluster mode points AGI_CLUSTER_SHARE and AGI_LOCAL_SHARE to the same directory.",
+        expected_behavior="Reject the configuration instead of silently falling back to localshare.",
+        remediation="Set AGI_CLUSTER_SHARE to an explicit mounted cluster share distinct from AGI_LOCAL_SHARE.",
+        replay_command=_replay_command("cluster_share_same_as_local_fails_closed"),
+        runner=_cluster_share_same_as_local,
+    ),
+    RobustnessScenario(
+        id="cluster_share_missing_fails_closed",
+        domain="cluster",
+        fault="Cluster mode is enabled but AGI_CLUSTER_SHARE is missing or not writable.",
+        expected_behavior="Reject the run before dispatch so workers cannot diverge on local storage.",
+        remediation="Mount the cluster share, run agilab doctor share setup, or disable cluster mode.",
+        replay_command=_replay_command("cluster_share_missing_fails_closed"),
+        runner=_cluster_share_missing,
+    ),
+    RobustnessScenario(
+        id="public_streamlit_bind_without_controls_refused",
+        domain="ui-security",
+        fault="Streamlit is configured to bind 0.0.0.0 without explicit auth/TLS controls.",
+        expected_behavior="Fail before exposing the UI publicly.",
+        remediation="Use 127.0.0.1 or set AGILAB_PUBLIC_BIND_OK=1 plus an auth/TLS indicator.",
+        replay_command=_replay_command("public_streamlit_bind_without_controls_refused"),
+        runner=_public_bind_without_controls,
+    ),
+    RobustnessScenario(
+        id="public_streamlit_bind_incomplete_controls_refused",
+        domain="ui-security",
+        fault="Public bind opt-in is set without an auth or TLS indicator.",
+        expected_behavior="Fail because both explicit opt-in and protection evidence are required.",
+        remediation="Add AGILAB_TLS_TERMINATED=1 or an auth-required indicator, or bind locally.",
+        replay_command=_replay_command("public_streamlit_bind_incomplete_controls_refused"),
+        runner=_public_bind_incomplete_controls,
+    ),
+    RobustnessScenario(
+        id="service_unhealthy_workers_block_promotion",
+        domain="service",
+        fault="Service health reports unhealthy workers above the configured threshold.",
+        expected_behavior="Return a non-zero health gate code and a concise reason.",
+        remediation="Restart or redeploy the unhealthy workers, then rerun service health.",
+        replay_command=_replay_command("service_unhealthy_workers_block_promotion"),
+        runner=_service_health_unhealthy_workers,
+    ),
+    RobustnessScenario(
+        id="service_idle_requires_explicit_override",
+        domain="service",
+        fault="Service status is idle while allow_idle is disabled.",
+        expected_behavior="Block the health gate unless the operator explicitly accepts idle services.",
+        remediation="Use --allow-idle only when idle is valid for this service profile.",
+        replay_command=_replay_command("service_idle_requires_explicit_override"),
+        runner=_service_health_idle_without_override,
+    ),
+    RobustnessScenario(
+        id="missing_run_manifest_fails_verification",
+        domain="evidence",
+        fault="The run_manifest.json path is missing.",
+        expected_behavior="Verification fails with manifest_exists rather than treating evidence as optional.",
+        remediation="Rerun the project or point the verifier to the correct run_manifest.json.",
+        replay_command=_replay_command("missing_run_manifest_fails_verification"),
+        runner=_missing_run_manifest_fails_verification,
+    ),
+    RobustnessScenario(
+        id="invalid_run_manifest_fails_verification",
+        domain="evidence",
+        fault="The run_manifest.json file exists but is invalid JSON/schema.",
+        expected_behavior="Verification fails at schema loading with a stable evidence report.",
+        remediation="Regenerate run evidence from AGILAB instead of editing manifest JSON by hand.",
+        replay_command=_replay_command("invalid_run_manifest_fails_verification"),
+        runner=_invalid_run_manifest_fails_verification,
+    ),
+    RobustnessScenario(
+        id="invalid_notebook_import_fails_preflight",
+        domain="notebook-import",
+        fault="Notebook import receives an invalid notebook cell structure.",
+        expected_behavior="Preflight fails without executing cells.",
+        remediation="Use a valid .ipynb and rerun notebook import preflight before project creation.",
+        replay_command=_replay_command("invalid_notebook_import_fails_preflight"),
+        runner=_invalid_notebook_import_fails_preflight,
+    ),
+    RobustnessScenario(
+        id="unsupported_app_settings_schema_fails_closed",
+        domain="app-settings",
+        fault="app_settings.toml declares a future unsupported schema version.",
+        expected_behavior="Refuse the file instead of silently rewriting unknown settings.",
+        remediation="Upgrade AGILAB before editing settings produced by a newer release.",
+        replay_command=_replay_command("unsupported_app_settings_schema_fails_closed"),
+        runner=_unsupported_app_settings_schema,
+    ),
+    RobustnessScenario(
+        id="conflicting_app_settings_run_payload_fails_closed",
+        domain="app-settings",
+        fault="app_settings.toml contains both legacy args.args and current args.stages.",
+        expected_behavior="Refuse ambiguous run payloads instead of choosing one silently.",
+        remediation="Keep only args.stages in current app settings.",
+        replay_command=_replay_command("conflicting_app_settings_run_payload_fails_closed"),
+        runner=_conflicting_app_settings_run_payload,
+    ),
+    RobustnessScenario(
+        id="streamlit_routes_do_not_hardcode_pages_directory",
+        domain="ui-routing",
+        fault="A wizard or page hard-codes Streamlit pages/<n> paths.",
+        expected_behavior="Use central page routing so installed packages and source launches agree.",
+        remediation="Route via the central page registry or current Streamlit navigation objects.",
+        replay_command=_replay_command("streamlit_routes_do_not_hardcode_pages_directory"),
+        runner=_streamlit_route_static_guard,
+    ),
+)
+
+
+def _scenario_to_result(
+    scenario: RobustnessScenario,
+    observation: ScenarioObservation,
+) -> dict[str, Any]:
+    return {
+        "id": scenario.id,
+        "domain": scenario.domain,
+        "status": "pass" if observation.passed else "fail",
+        "fault": scenario.fault,
+        "expected_behavior": scenario.expected_behavior,
+        "observed": observation.observed,
+        "remediation": scenario.remediation,
+        "replay_command": scenario.replay_command,
+        "evidence": list(observation.evidence),
+        "details": observation.details or {},
+        "cleanup_status": "pending",
+    }
+
+
+def _selected_scenarios(
+    *,
+    profile: str,
+    scenario_ids: Sequence[str] = (),
+    scenario_specs: Sequence[RobustnessScenario] | None = None,
+) -> list[RobustnessScenario]:
+    specs = list(SCENARIOS if scenario_specs is None else scenario_specs)
+    known_ids = {scenario.id for scenario in specs}
+    unknown = sorted(set(scenario_ids) - known_ids)
+    if unknown:
+        raise ValueError(f"Unknown robustness scenario(s): {', '.join(unknown)}")
+    if scenario_ids:
+        wanted = set(scenario_ids)
+        return [scenario for scenario in specs if scenario.id in wanted]
+    if profile == "all":
+        return specs
+    return [scenario for scenario in specs if profile in scenario.profiles]
+
+
+def build_report(
+    *,
+    repo_root: Path = REPO_ROOT,
+    profile: str = DEFAULT_PROFILE,
+    scenario_ids: Sequence[str] = (),
+    scenario_specs: Sequence[RobustnessScenario] | None = None,
+) -> dict[str, Any]:
+    repo_root = repo_root.resolve()
+    _ensure_repo_on_path(repo_root)
+    selected = _selected_scenarios(
+        profile=profile,
+        scenario_ids=scenario_ids,
+        scenario_specs=scenario_specs,
+    )
+    results: list[dict[str, Any]] = []
+    cleanup_status = "not_started"
+    with tempfile.TemporaryDirectory(prefix="agilab-robustness-") as raw_tmp:
+        tmp_root = Path(raw_tmp)
+        for scenario in selected:
+            scenario_tmp = tmp_root / scenario.id
+            scenario_tmp.mkdir(parents=True, exist_ok=True)
+            try:
+                observation = scenario.runner(repo_root, scenario_tmp)
+            except Exception as exc:  # pragma: no cover - defensive report boundary.
+                observation = ScenarioObservation(
+                    passed=False,
+                    observed=f"Scenario raised unexpected {type(exc).__name__}: {exc}",
+                    details={"exception_type": type(exc).__name__},
+                )
+            results.append(_scenario_to_result(scenario, observation))
+        cleanup_path = tmp_root
+    cleanup_status = "removed" if not cleanup_path.exists() else "left_on_disk"
+    for result in results:
+        result["cleanup_status"] = cleanup_status
+
+    failed = [result for result in results if result["status"] != "pass"]
+    domains = sorted({result["domain"] for result in results})
+    return {
+        "report": "AGILAB robustness matrix",
+        "schema": SCHEMA,
+        "status": "pass" if not failed and results else "fail",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "profile": profile,
+        "summary": {
+            "scenario_count": len(results),
+            "passed": len(results) - len(failed),
+            "failed": len(failed),
+            "domains": domains,
+            "cleanup_status": cleanup_status,
+        },
+        "scenarios": results,
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run synthetic P0 robustness scenarios. A scenario passes when the "
+            "known bad state is rejected with a clear recovery contract."
+        )
+    )
+    parser.add_argument(
+        "--profile",
+        choices=(DEFAULT_PROFILE, "all"),
+        default=DEFAULT_PROFILE,
+        help="Scenario profile to run.",
+    )
+    parser.add_argument(
+        "--scenario",
+        action="append",
+        default=[],
+        help="Run one scenario id. Can be repeated.",
+    )
+    parser.add_argument("--output", type=Path, default=None, help="Optional JSON output path.")
+    parser.add_argument("--compact", action="store_true", help="Emit compact JSON.")
+    parser.add_argument("--json", action="store_true", help="Alias for --compact.")
+    parser.add_argument("--list-scenarios", action="store_true", help="List scenario ids and exit.")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(list(argv) if argv is not None else None)
+    if args.list_scenarios:
+        for scenario in SCENARIOS:
+            print(f"{scenario.id}\t{scenario.domain}")
+        return 0
+    try:
+        report = build_report(profile=args.profile, scenario_ids=args.scenario)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(report, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    if args.compact or args.json:
+        print(json.dumps(report, sort_keys=True, separators=(",", ":")))
+    else:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    return 0 if report["status"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Add a local P0 robustness matrix for synthetic fail-closed bad-state scenarios.

The new `./dev robust` shortcut runs `tools/robustness_matrix.py`, which verifies that known bad states fail clearly with remediation and replay commands across cluster shares, public UI binds, service health, run manifests, notebook import, app settings, and Streamlit routes.

Local validation:
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_robustness_matrix.py test/test_agilab_dev_shortcuts.py
- uv --preview-features extra-build-dependencies run python -m py_compile tools/robustness_matrix.py tools/agilab_dev.py
- ./dev robust --compact
- uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files tools/robustness_matrix.py test/test_robustness_matrix.py tools/agilab_dev.py test/test_agilab_dev_shortcuts.py AGENTS.md README.md
- git diff --check