### PR TITLE
chore(dev): provision Ruff through dev shortcut

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,11 @@ jobs:
           set -euo pipefail
           python tools/public_proof_scenarios.py --compact
 
+      - name: Validate Ruff local tool availability
+        run: |
+          set -euo pipefail
+          uv --preview-features extra-build-dependencies run --extra dev ruff --version
+
       - name: Validate app contract matrix
         run: |
           set -euo pipefail

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,12 +24,14 @@ Use this runbook whenever you:
 - **High-frequency command shortcuts**: Use `./dev <shortcut>` for repeated local validation loops.
   The top shortcuts are `impact` for impact validation, `bugfix` for impact plus a fast
   GA-selected regression run, `test` for targeted `pytest -q -o addopts=''`,
-  `regress` for GA-selected fast regression subsets, `robust` for P0 fail-closed
-  robustness scenarios, `app-contracts` for built-in app/package/catalog/docs alignment,
+  `lint` for Ruff through the repo dev extra, `regress` for GA-selected fast regression subsets,
+  `robust` for P0 fail-closed robustness scenarios, `app-contracts` for
+  built-in app/package/catalog/docs alignment,
   `flow` for one or more workflow parity profiles,
   `release` for local pre-tag release guards, `badge` for the explicit release/pre-release
   coverage-badge guard, and `docs` for docs mirror sync plus stamp verification. `impact` tells you what must be validated, `test` runs the
-  narrow pytest slice, `bugfix` is the default low-load pre-push loop for normal code fixes,
+  narrow pytest slice, `lint` provisions Ruff through `uv --extra dev` so it does not depend
+  on an already-synced local venv, `bugfix` is the default low-load pre-push loop for normal code fixes,
   `regress` optimizes a likely regression subset from changed files and optional JUnit timings,
   `robust` runs synthetic bad-state checks for cluster shares, public UI binds,
   service health gates, evidence manifests, notebook import, app settings, and UI routes,
@@ -37,7 +39,7 @@ Use this runbook whenever you:
   promoted PyPI package metadata, app catalog entries, and public docs rows; it is also
   part of the release shortcut and targeted pre-push guards,
   `flow` matches local GitHub workflow profiles, `release` checks impact, generated PyPI release
-  plan, trusted-publisher contract, dependency policy, strict typing, docs, and badges before a tag,
+  plan, trusted-publisher contract, Ruff availability, dependency policy, strict typing, docs, and badges before a tag,
   `badge` checks badge freshness when intentionally requested, and `docs` keeps the public mirror
   aligned. Use `--print-only` to audit the expanded commands.
 - **Upgrade packaged tools first**: Before launching the published CLI with `uvx

--- a/README.md
+++ b/README.md
@@ -338,6 +338,9 @@ checks that built-in apps, worker manifests, reducer expectations, promoted PyPI
 app packages, the app catalog, and public app docs stay aligned. The same guard
 runs in release validation, CI, and targeted pre-push checks when those inputs
 change.
+For style tooling, maintainers should run `./dev lint`; it executes Ruff through
+the repo `dev` extra so a fresh checkout provisions the tool instead of relying
+on an already-synced local environment.
 External Sigstore/SLSA attestation binding, native lineage or observability
 transport, durable ML metadata, rich app-authored cards, and enterprise
 governance integrations remain roadmap work. See the

--- a/test/test_agilab_dev_shortcuts.py
+++ b/test/test_agilab_dev_shortcuts.py
@@ -77,6 +77,36 @@ def test_test_shortcut_keeps_pytest_arguments():
     ]
 
 
+def test_lint_shortcut_provisions_ruff_from_dev_extra_by_default():
+    assert agilab_dev.planned_commands(["lint"]) == [
+        [
+            "uv",
+            "--preview-features",
+            "extra-build-dependencies",
+            "run",
+            "--extra",
+            "dev",
+            "ruff",
+            "check",
+        ]
+    ]
+
+
+def test_ruff_shortcut_keeps_ruff_arguments():
+    assert agilab_dev.planned_commands(["ruff", "--version"]) == [
+        [
+            "uv",
+            "--preview-features",
+            "extra-build-dependencies",
+            "run",
+            "--extra",
+            "dev",
+            "ruff",
+            "--version",
+        ]
+    ]
+
+
 def test_regress_shortcut_defaults_to_staged_ga_run():
     assert agilab_dev.planned_commands(["regress"]) == [
         [
@@ -287,6 +317,16 @@ def test_release_shortcut_runs_local_release_guards():
             "tools/pypi_trusted_publisher_contract.py",
             "--check-workflow",
             ".github/workflows/pypi-publish.yaml",
+        ],
+        [
+            "uv",
+            "--preview-features",
+            "extra-build-dependencies",
+            "run",
+            "--extra",
+            "dev",
+            "ruff",
+            "--version",
         ],
         [
             "uv",

--- a/test/test_ci_workflow.py
+++ b/test/test_ci_workflow.py
@@ -165,6 +165,7 @@ def test_ci_workflow_includes_minimal_first_proof_contract() -> None:
     assert "python tools/install_release_proof_package.py --retries 20 --delay-seconds 15" in text
     assert "python -m pip install agilab" not in text
     assert "agilab first-proof --json --no-manifest --max-seconds 60" in text
+    assert "uv --preview-features extra-build-dependencies run --extra dev ruff --version" in text
     assert "tools/app_contract_matrix.py --output app-contract-matrix.json --quiet" in text
     assert "app-contract-matrix.json" in text
     assert "tools/ui_robot_matrix_aggregate.py" in text

--- a/tools/agilab_dev.py
+++ b/tools/agilab_dev.py
@@ -18,6 +18,10 @@ def _uv_python(*args: str) -> list[str]:
     return [*UV_RUN, "python", *args]
 
 
+def _uv_dev(*args: str) -> list[str]:
+    return [*UV_RUN, "--extra", "dev", *args]
+
+
 def _split_leading_values(args: Sequence[str], *, command_name: str) -> tuple[list[str], list[str]]:
     values: list[str] = []
     rest: list[str] = []
@@ -54,6 +58,12 @@ def planned_commands(argv: Sequence[str]) -> list[list[str]]:
     if command == "test":
         return [[*UV_RUN, "pytest", "-q", "-o", "addopts=", "--import-mode=importlib", *args]]
 
+    if command == "lint":
+        return [_uv_dev("ruff", "check", *args)]
+
+    if command == "ruff":
+        return [_uv_dev("ruff", *(args or ["check"]))]
+
     if command in {"regress", "ga-regress"}:
         forwarded = args or ["--staged", "--run"]
         return [_uv_python("tools/ga_regression_selector.py", *forwarded)]
@@ -89,6 +99,7 @@ def planned_commands(argv: Sequence[str]) -> list[list[str]]:
                 "--check-workflow",
                 ".github/workflows/pypi-publish.yaml",
             ),
+            _uv_dev("ruff", "--version"),
             _uv_python("tools/app_contract_matrix.py", "--quiet"),
             _uv_python(
                 "tools/workflow_parity.py",
@@ -135,6 +146,7 @@ def _usage() -> str:
   ./dev [--print-only] impact [impact_validate args]
   ./dev [--print-only] bugfix [changed-file args]
   ./dev [--print-only] test [pytest args]
+  ./dev [--print-only] lint|ruff [ruff args]
   ./dev [--print-only] regress [ga_regression_selector args]
   ./dev [--print-only] robust [robustness_matrix args]
   ./dev [--print-only] app-contracts [app_contract_matrix args]
@@ -149,12 +161,13 @@ High-frequency mappings:
   impact    -> Analyze changed files and list the required local validations; defaults to --staged.
   bugfix    -> Run impact triage, then run the GA-selected fast regression subset; defaults to --staged.
   test      -> Run targeted pytest with -q and repo-wide coverage disabled, while keeping all extra pytest arguments.
+  lint      -> Run Ruff through the repo dev extra; defaults to `ruff check`.
   regress   -> Use the GA regression selector on staged files and run the selected pytest subset.
   robust    -> Run the P0 robustness matrix of fail-closed bad-state scenarios.
   app-contracts -> Check built-in app, PyPI package, app catalog, and public-doc alignment.
   flow      -> Run one or more workflow_parity profiles with repeated --profile flags.
   typing    -> Run the forward shared-core ty typing profile. Mypy remains the curated temporary release guard under shared-core-typing.
-  release   -> Run local release guards: impact, generated PyPI plan, release cadence, trusted publisher contract, docs, dependency policy, typing, and badge freshness.
+  release   -> Run local release guards: impact, generated PyPI plan, release cadence, trusted publisher contract, Ruff availability, docs, dependency policy, typing, and badge freshness.
   badge     -> Run the explicit release/pre-release coverage badge freshness guard.
   docs      -> Sync docs from the canonical docs checkout and verify the mirror stamp.
   skills    -> Sync repo skills from Claude to Codex, validate, regenerate indexes/catalog/badges, and scan skill risk.


### PR DESCRIPTION
Prevents the local missing-Ruff failure from recurring by routing supported Ruff usage through uv's dev extra instead of relying on an already-synced venv.\n\nChanges:\n- Adds ./dev lint and ./dev ruff shortcuts. ./dev lint defaults to ruff check and always uses uv run --extra dev.\n- Adds a Ruff availability guard to ./dev release.\n- Adds a repo-guardrails CI step that runs uv run --extra dev ruff --version.\n- Documents the supported Ruff entrypoint in README and AGENTS.\n- Tests the command contract so the --extra dev behavior cannot silently regress.\n\nValidation:\n- ./dev ruff --version\n- ./dev lint tools/agilab_dev.py test/test_agilab_dev_shortcuts.py test/test_ci_workflow.py\n- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_agilab_dev_shortcuts.py test/test_ci_workflow.py test/test_pyproject_dependency_hygiene.py\n- uv --preview-features extra-build-dependencies run python -m py_compile tools/agilab_dev.py\n- uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files tools/agilab_dev.py test/test_agilab_dev_shortcuts.py test/test_ci_workflow.py README.md AGENTS.md .github/workflows/ci.yml\n- git diff --check