### PR TITLE
Optimize PyPI release package selection

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -20,6 +20,11 @@ on:
       post_release_reason:
         description: "Critical hotfix justification required when allow_post_release is true."
         required: false
+      include_existing_pypi:
+        description: "Include package versions that already exist on PyPI to repair release assets. Default skips them."
+        required: false
+        type: boolean
+        default: false
   push:
     tags:
       - "v*.*.*"
@@ -204,6 +209,7 @@ jobs:
       library_selected: ${{ steps.release-plan.outputs.library_selected }}
       umbrella_selected: ${{ steps.release-plan.outputs.umbrella_selected }}
       pypi_publish_selected: ${{ steps.release-plan.outputs.pypi_publish_selected }}
+      pypi_existing_packages: ${{ steps.release-plan.outputs.pypi_existing_packages }}
       provenance_packages: ${{ steps.release-plan.outputs.provenance_packages }}
     steps:
       - name: Checkout repository
@@ -214,18 +220,26 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
+      - name: Install release-plan dependencies
+        run: python -m pip install --upgrade --no-cache-dir packaging
+
       - name: Render release package plan
         id: release-plan
         env:
           RELEASE_PACKAGES: ${{ github.event.inputs.packages || '' }}
           RELEASE_ROLES: ${{ github.event.inputs.roles || '' }}
+          INCLUDE_EXISTING_PYPI: ${{ github.event.inputs.include_existing_pypi || 'false' }}
         run: |
           set -euxo pipefail
           args=(
+            --repo-root .
             --github-output "$GITHUB_OUTPUT"
             --github-step-summary "$GITHUB_STEP_SUMMARY"
             --check-workflow .github/workflows/pypi-publish.yaml
           )
+          if [ "${INCLUDE_EXISTING_PYPI:-false}" != "true" ]; then
+            args+=(--skip-existing-pypi)
+          fi
           if [ -n "${RELEASE_PACKAGES:-}" ]; then
             args+=(--packages "$RELEASE_PACKAGES")
           fi
@@ -245,11 +259,15 @@ jobs:
         env:
           RELEASE_PACKAGES: ${{ github.event.inputs.packages || '' }}
           RELEASE_ROLES: ${{ github.event.inputs.roles || '' }}
+          INCLUDE_EXISTING_PYPI: ${{ github.event.inputs.include_existing_pypi || 'false' }}
           ALLOW_POST_RELEASE: ${{ github.event.inputs.allow_post_release || 'false' }}
           POST_RELEASE_REASON: ${{ github.event.inputs.post_release_reason || '' }}
         run: |
           set -euxo pipefail
-          args=(--github-step-summary "$GITHUB_STEP_SUMMARY")
+          args=(--repo-root . --github-step-summary "$GITHUB_STEP_SUMMARY")
+          if [ "${INCLUDE_EXISTING_PYPI:-false}" != "true" ]; then
+            args+=(--skip-existing-pypi)
+          fi
           if [ -n "${RELEASE_PACKAGES:-}" ]; then
             args+=(--packages "$RELEASE_PACKAGES")
           fi

--- a/README.md
+++ b/README.md
@@ -286,10 +286,13 @@ Python and GitHub Actions manifests, release workflows publish per-profile
 `tools/profile_supply_chain_scan.py` can regenerate the same profile evidence
 locally. PyPI publication uses Trusted Publishing/OIDC and the release workflow
 runs `tools/pypi_provenance_check.py` after upload so missing PyPI attestations
-fail before GitHub release assets are published. The workflow then attempts to
-prune older PyPI releases for each selected project; missing current versions
-or remaining stale releases are hard failures. If PyPI asks for unrecognized
-login confirmation, the workflow waits on the temporary
+fail before GitHub release assets are published. By default, the workflow omits
+selected PyPI projects whose current wheel/sdist artifacts already exist, so
+unchanged split packages do not enter upload, provenance, retention, or release
+asset jobs. For packages that still need publication, the workflow then attempts
+to prune older PyPI releases; missing current versions or remaining stale
+releases are hard failures. If PyPI asks for unrecognized login confirmation,
+the workflow waits on the temporary
 `PYPI_CONFIRM_LOGIN_URL` Actions variable instead of silently continuing. Release
 assets and Hugging Face sync only proceed after PyPI retention verifies that each
 selected project exposes only the current release. After release assets are

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 227,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "45f05d361133e9ae9668887e190e941223e472555ae6be1afa1f876b1ea38779",
+  "source_digest_sha256": "c99f9250668514b580bea3646ee3740ffcea0c5c42888fe3d22ac60e4ce21fe6",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "45f05d361133e9ae9668887e190e941223e472555ae6be1afa1f876b1ea38779"
+  "target_digest_sha256": "c99f9250668514b580bea3646ee3740ffcea0c5c42888fe3d22ac60e4ce21fe6"
 }

--- a/docs/source/package-publishing-policy.rst
+++ b/docs/source/package-publishing-policy.rst
@@ -224,13 +224,24 @@ and release-candidate versions such as ``YYYY.MM.DDrc1`` are acceptable for
 preview validation, but those rehearsals are not the source of truth for a real
 final release.
 
+By default, the GitHub PyPI workflow asks ``tools/release_plan.py`` to omit
+selected PyPI packages whose expected wheel/sdist artifacts for the committed
+project version already exist on PyPI. Those skipped packages are not sent to
+the build/upload matrix, PyPI provenance verification, release retention, or
+GitHub release-asset assembly. This keeps split packages independent in
+practice: unchanged packages do not need a new version and do not trigger slow
+PyPI web cleanup. Use the manual ``include_existing_pypi=true`` dispatch input
+only when intentionally repairing release assets from already-published PyPI
+artifacts.
+
 After PyPI provenance passes, the release workflow attempts to keep one retained
-PyPI release per selected PyPI project. ``tools/pypi_release_retention.py`` reads
-the selected release-plan projects, confirms that each package's own committed
-project version is visible, then tries to delete older releases before GitHub
-release assets are published. This allows split packages to advance
-independently while keeping retention from deleting another package's current
-version. This is a destructive PyPI web-management operation, separate from
+PyPI release per selected PyPI project that still needs publication in the
+optimized release plan. ``tools/pypi_release_retention.py`` reads the selected
+release-plan projects, confirms that each package's own committed project
+version is visible, then tries to delete older releases before GitHub release
+assets are published. This allows split packages to advance independently while
+keeping retention from deleting another package's current version. This is a
+destructive PyPI web-management operation, separate from
 Trusted Publishing, so the workflow uses ``PYPI_RELEASE_PRUNE_USERNAME`` and
 ``PYPI_RELEASE_PRUNE_PASSWORD`` repository secrets. PyPI accounts with two-factor
 authentication can use non-interactive authentication through

--- a/test/test_pypi_publish_workflow.py
+++ b/test/test_pypi_publish_workflow.py
@@ -8,7 +8,7 @@ import sys
 REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT / "tools"))
 
-from package_split_contract import LIBRARY_PACKAGE_CONTRACTS, PACKAGE_NAMES, UMBRELLA_PACKAGE_CONTRACT
+from package_split_contract import LIBRARY_PACKAGE_CONTRACTS, PACKAGE_NAMES, UMBRELLA_PACKAGE_CONTRACT  # noqa: E402
 
 
 WORKFLOW_PATH = REPO_ROOT / ".github/workflows/pypi-publish.yaml"
@@ -116,10 +116,13 @@ def test_pypi_publish_skips_existing_artifacts_and_requires_trusted_auth() -> No
     assert "roles:" in text
     assert "allow_post_release:" in text
     assert "post_release_reason:" in text
+    assert "include_existing_pypi:" in text
     assert "RELEASE_PACKAGES" in text
     assert "RELEASE_ROLES" in text
+    assert "INCLUDE_EXISTING_PYPI" in text
     assert "--packages \"$RELEASE_PACKAGES\"" in text
     assert "--roles \"$RELEASE_ROLES\"" in text
+    assert "--skip-existing-pypi" in text
     assert "id-token: write" in text
     assert "name: ${{ matrix.pypi_environment }}" in text
     assert "name: pypi-agilab" in text
@@ -138,7 +141,9 @@ def test_pypi_publish_skips_existing_artifacts_and_requires_trusted_auth() -> No
     assert "library_selected: ${{ steps.release-plan.outputs.library_selected }}" in text
     assert "umbrella_selected: ${{ steps.release-plan.outputs.umbrella_selected }}" in text
     assert "pypi_publish_selected: ${{ steps.release-plan.outputs.pypi_publish_selected }}" in text
+    assert "pypi_existing_packages: ${{ steps.release-plan.outputs.pypi_existing_packages }}" in text
     assert "provenance_packages: ${{ steps.release-plan.outputs.provenance_packages }}" in text
+    assert "python -m pip install --upgrade --no-cache-dir packaging" in text
     assert "include: ${{ fromJSON(needs.release-plan.outputs.library_matrix) }}" in text
     assert "needs.release-plan.outputs.library_selected == 'true'" in text
     assert "needs.release-plan.outputs.umbrella_selected == 'true'" in text

--- a/test/test_pypi_release_version_policy.py
+++ b/test/test_pypi_release_version_policy.py
@@ -79,3 +79,33 @@ def test_selected_public_versions_reads_filtered_package_versions(tmp_path, monk
     assert policy.selected_public_versions(tmp_path, package_names=("agilab",)) == {
         "agilab": "2026.05.18rc1"
     }
+
+
+def test_public_package_entries_can_reuse_release_plan_skip_existing_mode(
+    tmp_path, monkeypatch
+) -> None:
+    policy = _load_policy()
+    observed = {}
+
+    def fake_release_plan(**kwargs):
+        observed.update(kwargs)
+        return {
+            "library_matrix": [{"package": "agi-env", "publish_to_pypi": "true"}],
+            "umbrella_package": {"package": "agilab", "publish_to_pypi": "true"},
+            "umbrella_selected": "false",
+        }
+
+    monkeypatch.setattr(policy, "release_plan", fake_release_plan)
+
+    entries = policy.public_package_entries(
+        repo_root=tmp_path,
+        package_names=("agi-env",),
+        roles=("runtime-component",),
+        skip_existing_pypi=True,
+    )
+
+    assert entries == [{"package": "agi-env", "publish_to_pypi": "true"}]
+    assert observed["repo_root"] == tmp_path
+    assert observed["package_names"] == ("agi-env",)
+    assert observed["roles"] == ("runtime-component",)
+    assert observed["skip_existing_pypi"] is True

--- a/test/test_release_plan.py
+++ b/test/test_release_plan.py
@@ -12,7 +12,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 MODULE_PATH = REPO_ROOT / "tools" / "release_plan.py"
 sys.path.insert(0, str(REPO_ROOT / "tools"))
 
-from package_split_contract import (
+from package_split_contract import (  # noqa: E402
     LIBRARY_PACKAGE_CONTRACTS,
     PROMOTED_APP_PROJECT_PACKAGE_NAMES,
     UMBRELLA_PACKAGE_CONTRACT,
@@ -88,6 +88,7 @@ def test_release_plan_github_output_is_compact_and_parseable(tmp_path: Path) -> 
     assert values["library_selected"] == "true"
     assert values["umbrella_selected"] == "true"
     assert values["pypi_publish_selected"] == "true"
+    assert values["pypi_existing_packages"] == ""
     assert "agi-env" in values["provenance_packages"]
     assert "\n" not in values["library_matrix"]
 
@@ -105,6 +106,40 @@ def test_release_plan_provenance_packages_match_selected_public_publish_set() ->
     expected.append(UMBRELLA_PACKAGE_CONTRACT.name)
 
     assert payload["provenance_packages"] == expected
+
+
+def test_release_plan_can_skip_pypi_packages_whose_artifacts_already_exist() -> None:
+    module = _load_module()
+
+    payload = module.release_plan(
+        skip_existing_pypi=True,
+        pypi_artifacts_exist=lambda package, _repo_root: package["package"] in {"agi-env", "agilab"},
+    )
+
+    selected_names = {package["package"] for package in payload["library_matrix"]}
+    assert "agi-env" not in selected_names
+    assert all(package["publish_to_pypi"] == "true" for package in payload["library_matrix"])
+    assert "agilab" not in payload["provenance_packages"]
+    assert payload["umbrella_selected"] == "false"
+    assert payload["pypi_existing_packages"] == ["agi-env", "agilab"]
+    assert payload["pypi_selection_mode"] == "missing-artifacts"
+    assert payload["pypi_publish_selected"] == "true"
+
+
+def test_release_plan_reports_no_publish_when_only_selected_package_already_exists() -> None:
+    module = _load_module()
+
+    payload = module.release_plan(
+        package_names=["agilab"],
+        skip_existing_pypi=True,
+        pypi_artifacts_exist=lambda _package, _repo_root: True,
+    )
+
+    assert payload["library_matrix"] == []
+    assert payload["umbrella_selected"] == "false"
+    assert payload["pypi_publish_selected"] == "false"
+    assert payload["provenance_packages"] == []
+    assert payload["pypi_existing_packages"] == ["agilab"]
 
 
 def test_release_plan_public_packages_default_to_wheel_and_sdist() -> None:

--- a/tools/pypi_release_version_policy.py
+++ b/tools/pypi_release_version_policy.py
@@ -70,8 +70,15 @@ def public_package_entries(
     *,
     package_names: Sequence[str] | None = None,
     roles: Sequence[str] | None = None,
+    repo_root: Path = Path.cwd(),
+    skip_existing_pypi: bool = False,
 ) -> list[dict[str, str]]:
-    payload = release_plan(package_names=package_names, roles=roles)
+    payload = release_plan(
+        package_names=package_names,
+        roles=roles,
+        repo_root=repo_root,
+        skip_existing_pypi=skip_existing_pypi,
+    )
     entries = [
         package
         for package in payload["library_matrix"]
@@ -97,10 +104,16 @@ def selected_public_versions(
     *,
     package_names: Sequence[str] | None = None,
     roles: Sequence[str] | None = None,
+    skip_existing_pypi: bool = False,
 ) -> dict[str, str]:
     return {
         package["package"]: read_project_version(repo_root, package["project"])
-        for package in public_package_entries(package_names=package_names, roles=roles)
+        for package in public_package_entries(
+            package_names=package_names,
+            roles=roles,
+            repo_root=repo_root,
+            skip_existing_pypi=skip_existing_pypi,
+        )
     }
 
 
@@ -146,6 +159,14 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         help="Critical hotfix justification required when --allow-post-release is set.",
     )
     parser.add_argument(
+        "--skip-existing-pypi",
+        action="store_true",
+        help=(
+            "Validate only selected PyPI packages whose current project version is not "
+            "already complete on PyPI."
+        ),
+    )
+    parser.add_argument(
         "--github-step-summary",
         type=Path,
         default=None,
@@ -162,6 +183,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             args.repo_root.resolve(),
             package_names=split_filter_values(args.packages),
             roles=split_filter_values(args.roles),
+            skip_existing_pypi=args.skip_existing_pypi,
         )
         result = validate_public_release_versions(
             package_versions,

--- a/tools/release_plan.py
+++ b/tools/release_plan.py
@@ -8,7 +8,7 @@ import json
 import os
 import re
 from pathlib import Path
-from typing import Any, Sequence
+from typing import Any, Callable, Sequence
 
 try:
     from package_split_contract import (
@@ -41,6 +41,7 @@ PYPI_PUBLISH_ROLES = {
 
 
 PACKAGE_ROLES = tuple(sorted({package.role for package in PACKAGE_CONTRACTS}))
+PyPIArtifactExists = Callable[[dict[str, str], Path], bool]
 
 
 def _package_entry(package: Any) -> dict[str, str]:
@@ -92,21 +93,81 @@ def _publish_packages(payload: dict[str, Any]) -> list[str]:
     return packages
 
 
+def _pypi_artifacts_exist(package: dict[str, str], repo_root: Path) -> bool:
+    try:
+        from pypi_distribution_state import (
+            DistributionStateError,
+            all_distributions_exist,
+            analyze_expected_project_distributions,
+        )
+    except ModuleNotFoundError:  # pragma: no cover - used when imported as tools.*
+        from tools.pypi_distribution_state import (
+            DistributionStateError,
+            all_distributions_exist,
+            analyze_expected_project_distributions,
+        )
+
+    try:
+        states = analyze_expected_project_distributions(
+            package=package["package"],
+            project=(repo_root / package["project"]).resolve(),
+            artifact_policy=package["artifact_policy"],
+        )
+    except DistributionStateError as exc:
+        raise ValueError(
+            f"Could not evaluate existing PyPI artifacts for {package['package']}: {exc}"
+        ) from exc
+    return all_distributions_exist(states)
+
+
+def _filter_existing_pypi_packages(
+    packages: Sequence[dict[str, str]],
+    *,
+    repo_root: Path,
+    skip_existing_pypi: bool,
+    pypi_artifacts_exist: PyPIArtifactExists | None,
+) -> tuple[list[dict[str, str]], list[str]]:
+    if not skip_existing_pypi:
+        return list(packages), []
+
+    exists = pypi_artifacts_exist or _pypi_artifacts_exist
+    selected: list[dict[str, str]] = []
+    skipped: list[str] = []
+    for package in packages:
+        if package["publish_to_pypi"] != "true":
+            continue
+        if exists(package, repo_root):
+            skipped.append(package["package"])
+            continue
+        selected.append(package)
+    return selected, skipped
+
+
 def library_matrix(
     *,
     package_names: Sequence[str] | None = None,
     roles: Sequence[str] | None = None,
+    repo_root: Path | None = None,
+    skip_existing_pypi: bool = False,
+    pypi_artifacts_exist: PyPIArtifactExists | None = None,
 ) -> list[dict[str, str]]:
     """Return the GitHub matrix entries for publishable library packages."""
 
     package_filter = set(package_names or ())
     role_filter = set(roles or ())
     _validate_filters(package_names, roles)
-    return [
+    packages = [
         _package_entry(package)
         for package in LIBRARY_PACKAGE_CONTRACTS
         if _selected(package, package_filter, role_filter)
     ]
+    selected, _skipped = _filter_existing_pypi_packages(
+        packages,
+        repo_root=(repo_root or Path.cwd()).resolve(),
+        skip_existing_pypi=skip_existing_pypi,
+        pypi_artifacts_exist=pypi_artifacts_exist,
+    )
+    return selected
 
 
 def umbrella_package() -> dict[str, str]:
@@ -119,20 +180,42 @@ def release_plan(
     *,
     package_names: Sequence[str] | None = None,
     roles: Sequence[str] | None = None,
+    repo_root: Path | None = None,
+    skip_existing_pypi: bool = False,
+    pypi_artifacts_exist: PyPIArtifactExists | None = None,
 ) -> dict[str, Any]:
     """Return the complete release package plan."""
 
     package_filter = set(package_names or ())
     role_filter = set(roles or ())
     _validate_filters(package_names, roles)
-    matrix = library_matrix(package_names=package_names, roles=roles)
+    resolved_repo_root = (repo_root or Path.cwd()).resolve()
+    candidate_matrix = [
+        _package_entry(package)
+        for package in LIBRARY_PACKAGE_CONTRACTS
+        if _selected(package, package_filter, role_filter)
+    ]
+    matrix, skipped_existing = _filter_existing_pypi_packages(
+        candidate_matrix,
+        repo_root=resolved_repo_root,
+        skip_existing_pypi=skip_existing_pypi,
+        pypi_artifacts_exist=pypi_artifacts_exist,
+    )
     umbrella_selected = _selected(UMBRELLA_PACKAGE_CONTRACT, package_filter, role_filter)
+    umbrella = umbrella_package()
+    if skip_existing_pypi and umbrella_selected and umbrella["publish_to_pypi"] == "true":
+        exists = pypi_artifacts_exist or _pypi_artifacts_exist
+        if exists(umbrella, resolved_repo_root):
+            umbrella_selected = False
+            skipped_existing.append(umbrella["package"])
     payload: dict[str, Any] = {
         "schema_version": SCHEMA_VERSION,
         "library_matrix": matrix,
-        "umbrella_package": umbrella_package(),
+        "umbrella_package": umbrella,
         "library_selected": "true" if matrix else "false",
         "umbrella_selected": "true" if umbrella_selected else "false",
+        "pypi_selection_mode": "missing-artifacts" if skip_existing_pypi else "all-selected",
+        "pypi_existing_packages": skipped_existing,
     }
     publish_packages = _publish_packages(payload)
     payload["pypi_publish_selected"] = "true" if publish_packages else "false"
@@ -153,6 +236,9 @@ def format_text(payload: dict[str, Any]) -> str:
         f"library selected: {payload['library_selected']}",
         f"umbrella selected: {payload['umbrella_selected']}",
         f"PyPI publish selected: {payload['pypi_publish_selected']}",
+        f"PyPI selection mode: {payload['pypi_selection_mode']}",
+        "PyPI packages already present: "
+        + (", ".join(payload["pypi_existing_packages"]) or "(none)"),
         "",
         "Library packages:",
     ]
@@ -184,6 +270,8 @@ def format_markdown(payload: dict[str, Any]) -> str:
         f"- Library selected: `{payload['library_selected']}`",
         f"- Umbrella selected: `{payload['umbrella_selected']}`",
         f"- PyPI publication selected: `{payload['pypi_publish_selected']}`",
+        f"- PyPI selection mode: `{payload['pypi_selection_mode']}`",
+        f"- PyPI packages already present: `{', '.join(payload['pypi_existing_packages']) or '(none)'}`",
         f"- Provenance packages: `{', '.join(payload['provenance_packages']) or '(none)'}`",
         "",
         "| Selected | Package | Project | PyPI environment | Artifact policy | Publish to PyPI |",
@@ -213,6 +301,7 @@ def write_github_output(path: Path, payload: dict[str, Any]) -> None:
         f"library_selected={payload['library_selected']}",
         f"umbrella_selected={payload['umbrella_selected']}",
         f"pypi_publish_selected={payload['pypi_publish_selected']}",
+        "pypi_existing_packages=" + " ".join(payload["pypi_existing_packages"]),
         "provenance_packages=" + " ".join(payload["provenance_packages"]),
     ]
     with path.open("a", encoding="utf-8") as handle:
@@ -245,8 +334,23 @@ def validate_workflow_contract(workflow_path: Path) -> list[str]:
         "pypi_publish_selected: ${{ steps.release-plan.outputs.pypi_publish_selected }}": (
             "release-plan job must expose whether any PyPI publication is selected"
         ),
+        "pypi_existing_packages: ${{ steps.release-plan.outputs.pypi_existing_packages }}": (
+            "release-plan job must expose packages skipped because current PyPI artifacts already exist"
+        ),
         "provenance_packages: ${{ steps.release-plan.outputs.provenance_packages }}": (
             "release-plan job must expose the selected provenance package list"
+        ),
+        "include_existing_pypi:": (
+            "workflow must provide an explicit override for rebuilding assets from existing PyPI artifacts"
+        ),
+        "INCLUDE_EXISTING_PYPI": (
+            "workflow must propagate the explicit existing-PyPI override"
+        ),
+        "--skip-existing-pypi": (
+            "workflow must omit already-published package versions from publish/provenance/retention by default"
+        ),
+        "python -m pip install --upgrade --no-cache-dir packaging": (
+            "release-plan job must install the lightweight dependency needed for PyPI artifact checks"
         ),
         "include: ${{ fromJSON(needs.release-plan.outputs.library_matrix) }}": (
             "library publish matrix must be generated from the release plan"
@@ -420,6 +524,20 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         default=[],
         help="Limit the release plan to comma- or space-separated package roles.",
     )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path.cwd(),
+        help="Repository root used to read selected package versions for PyPI artifact checks.",
+    )
+    parser.add_argument(
+        "--skip-existing-pypi",
+        action="store_true",
+        help=(
+            "Omit selected PyPI packages when all expected artifacts for the current "
+            "project version already exist on PyPI."
+        ),
+    )
     return parser.parse_args(argv)
 
 
@@ -429,6 +547,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         payload = release_plan(
             package_names=_split_filter_values(args.packages),
             roles=_split_filter_values(args.roles),
+            repo_root=args.repo_root.resolve(),
+            skip_existing_pypi=args.skip_existing_pypi,
         )
     except ValueError as exc:
         print(f"ERROR: {exc}")


### PR DESCRIPTION
## Summary
- skip already-complete PyPI package versions in the generated release plan
- keep provenance, retention, and release assets limited to packages that still need publication
- document the default optimized path and the manual include_existing_pypi repair override

## Validation
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_pypi_publish_workflow.py test/test_pypi_release_version_policy.py test/test_release_plan.py
- uv --preview-features extra-build-dependencies run --extra dev ruff check tools/release_plan.py tools/pypi_release_version_policy.py test/test_release_plan.py test/test_pypi_publish_workflow.py test/test_pypi_release_version_policy.py
- uv --preview-features extra-build-dependencies run python tools/release_plan.py --check-workflow .github/workflows/pypi-publish.yaml --format json --compact
- uv --preview-features extra-build-dependencies run python tools/pypi_release_version_policy.py --skip-existing-pypi
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs
- live release_plan(skip_existing_pypi=True): 0 matrix packages, 0 provenance packages, 33 already-existing PyPI packages