### PR TITLE
Add release robustness audit tooling

### DIFF
--- a/.claude/skills/agilab-release-verification/SKILL.md
+++ b/.claude/skills/agilab-release-verification/SKILL.md
@@ -24,6 +24,7 @@ contract. Do not answer from memory.
 ```bash
 ./dev --print-only release
 uv --preview-features extra-build-dependencies run python tools/release_plan.py --check-workflow .github/workflows/pypi-publish.yaml
+uv --preview-features extra-build-dependencies run python tools/pypi_project_preflight.py
 rg -n "sync-hf-space|publish-release-assets|pypi-release-retention|release-proof|HF_TOKEN|hf_space_release_sync" .github/workflows/pypi-publish.yaml tools README.md docs/source
 ```
 
@@ -39,6 +40,7 @@ Run this before tagging or dispatching the release workflow:
 
 ```bash
 git status --short --branch --untracked-files=no
+./dev audit --strict
 ./dev release
 ```
 
@@ -47,6 +49,10 @@ dirty paths and ahead/behind state are explained.
 
 If `./dev release` fails, fix the local guard first unless the failure is
 explicitly GitHub-only, secret-dependent, or network/publication-dependent.
+If `tools/pypi_project_preflight.py` reports a `missing-project` blocker,
+register the pending trusted publisher before dispatching the release workflow.
+An existing PyPI project with a new unpublished version is normal; a missing
+project or newer PyPI version than the committed source is not.
 
 For a release that should prune old PyPI releases and sync Hugging Face, verify
 the required repository secrets exist before dispatching or rerunning the
@@ -133,10 +139,12 @@ publication.
 ```bash
 gh release list --repo ThalesGroup/agilab --limit 5
 gh release view <tag> --repo ThalesGroup/agilab
+uv run python tools/release_status.py --tag <tag>
 ```
 
 Check that assets exist and match the expected tag. Do not treat a tag alone as
-a release.
+a release. Prefer `tools/release_status.py` when you need one bounded tag-level
+truth check across GitHub Release assets and PyPI package versions.
 
 ### PyPI
 

--- a/.codex/skills/agilab-release-verification/SKILL.md
+++ b/.codex/skills/agilab-release-verification/SKILL.md
@@ -24,6 +24,7 @@ contract. Do not answer from memory.
 ```bash
 ./dev --print-only release
 uv --preview-features extra-build-dependencies run python tools/release_plan.py --check-workflow .github/workflows/pypi-publish.yaml
+uv --preview-features extra-build-dependencies run python tools/pypi_project_preflight.py
 rg -n "sync-hf-space|publish-release-assets|pypi-release-retention|release-proof|HF_TOKEN|hf_space_release_sync" .github/workflows/pypi-publish.yaml tools README.md docs/source
 ```
 
@@ -39,6 +40,7 @@ Run this before tagging or dispatching the release workflow:
 
 ```bash
 git status --short --branch --untracked-files=no
+./dev audit --strict
 ./dev release
 ```
 
@@ -47,6 +49,10 @@ dirty paths and ahead/behind state are explained.
 
 If `./dev release` fails, fix the local guard first unless the failure is
 explicitly GitHub-only, secret-dependent, or network/publication-dependent.
+If `tools/pypi_project_preflight.py` reports a `missing-project` blocker,
+register the pending trusted publisher before dispatching the release workflow.
+An existing PyPI project with a new unpublished version is normal; a missing
+project or newer PyPI version than the committed source is not.
 
 For a release that should prune old PyPI releases and sync Hugging Face, verify
 the required repository secrets exist before dispatching or rerunning the
@@ -133,10 +139,12 @@ publication.
 ```bash
 gh release list --repo ThalesGroup/agilab --limit 5
 gh release view <tag> --repo ThalesGroup/agilab
+uv run python tools/release_status.py --tag <tag>
 ```
 
 Check that assets exist and match the expected tag. Do not treat a tag alone as
-a release.
+a release. Prefer `tools/release_status.py` when you need one bounded tag-level
+truth check across GitHub Release assets and PyPI package versions.
 
 ### PyPI
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,7 @@ jobs:
             src/agilab/first_proof_cli.py \
             src/agilab/orchestrate_execute.py \
             src/agilab/pipeline_openai.py \
+            tools/agilab_audit.py \
             tools/agilab_web_robot.py \
             tools/newcomer_first_proof.py \
             tools/first_launch_robot.py \
@@ -69,6 +70,10 @@ jobs:
             tools/install_release_proof_package.py \
             tools/public_proof_scenarios.py \
             tools/release_proof_report.py \
+            tools/pypi_project_preflight.py \
+            tools/release_status.py \
+            tools/release_handoff.py \
+            tools/release_handoff_guard.py \
             tools/app_contract_matrix.py \
             tools/ui_robot_evidence.py \
             tools/ui_robot_matrix_aggregate.py \
@@ -78,6 +83,11 @@ jobs:
         run: |
           set -euo pipefail
           python tools/release_proof_report.py --check --compact
+
+      - name: Validate release handoff freshness
+        run: |
+          set -euo pipefail
+          python tools/release_handoff_guard.py --compact
 
       - name: Validate release proof GitHub run evidence
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,8 @@ Use this runbook whenever you:
   GA-selected regression run, `test` for targeted `pytest -q -o addopts=''`,
   `lint` for Ruff through the repo dev extra, `regress` for GA-selected fast regression subsets,
   `robust` for P0 fail-closed robustness scenarios, `app-contracts` for
-  built-in app/package/catalog/docs alignment,
+  built-in app/package/catalog/docs alignment, `audit` for local worktree/docs/release/PyPI
+  state,
   `flow` for one or more workflow parity profiles,
   `release` for local pre-tag release guards, `badge` for the explicit release/pre-release
   coverage-badge guard, and `docs` for docs mirror sync plus stamp verification. `impact` tells you what must be validated, `test` runs the
@@ -38,6 +39,7 @@ Use this runbook whenever you:
   `app-contracts` checks built-in app structure, worker manifests, reducer contracts,
   promoted PyPI package metadata, app catalog entries, and public docs rows; it is also
   part of the release shortcut and targeted pre-push guards,
+  `audit` is the quick robustness check before handoff between machines,
   `flow` matches local GitHub workflow profiles, `release` checks impact, generated PyPI release
   plan, trusted-publisher contract, Ruff availability, dependency policy, strict typing, docs, and badges before a tag,
   `badge` checks badge freshness when intentionally requested, and `docs` keeps the public mirror

--- a/test/test_agilab_dev_shortcuts.py
+++ b/test/test_agilab_dev_shortcuts.py
@@ -201,6 +201,20 @@ def test_app_contracts_shortcut_keeps_matrix_arguments():
     ]
 
 
+def test_audit_shortcut_runs_agilab_audit():
+    assert agilab_dev.planned_commands(["audit", "--no-network"]) == [
+        [
+            "uv",
+            "--preview-features",
+            "extra-build-dependencies",
+            "run",
+            "python",
+            "tools/agilab_audit.py",
+            "--no-network",
+        ]
+    ]
+
+
 def test_main_keeps_machine_readable_shortcut_stdout_clean(capsys, monkeypatch):
     calls = []
 
@@ -307,6 +321,14 @@ def test_release_shortcut_runs_local_release_guards():
             "run",
             "python",
             "tools/pypi_release_version_policy.py",
+        ],
+        [
+            "uv",
+            "--preview-features",
+            "extra-build-dependencies",
+            "run",
+            "python",
+            "tools/pypi_project_preflight.py",
         ],
         [
             "uv",

--- a/test/test_release_robustness_tools.py
+++ b/test/test_release_robustness_tools.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_tool(name: str):
+    path = ROOT / "tools" / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(f"{name}_test_module", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+pending_publisher = _load_tool("pypi_pending_trusted_publisher")
+pypi_project_preflight = _load_tool("pypi_project_preflight")
+release_handoff_guard = _load_tool("release_handoff_guard")
+release_status = _load_tool("release_status")
+
+
+def _planned_project(version: str = "2026.05.26") -> pypi_project_preflight.PlannedPyPIProject:
+    return pypi_project_preflight.PlannedPyPIProject(
+        package="agi-page-live-artifacts",
+        project="src/agilab/apps-pages/view_live_artifacts",
+        pypi_project="agi-page-live-artifacts",
+        pypi_environment="pypi-agi-page-live-artifacts",
+        artifact_policy="wheel+sdist",
+        version=version,
+    )
+
+
+def test_pypi_project_preflight_reports_missing_project_with_pending_command() -> None:
+    status = pypi_project_preflight.classify_project(
+        _planned_project(),
+        fetch_json=lambda _name: None,
+    )
+
+    assert status.status == "missing-project"
+    assert status.pending_publisher_command is not None
+    assert "pypi-pending-trusted-publisher.yaml" in status.pending_publisher_command
+    assert "project_name=agi-page-live-artifacts" in status.pending_publisher_command
+    assert "pypi_environment=pypi-agi-page-live-artifacts" in status.pending_publisher_command
+
+
+def test_pypi_project_preflight_treats_pep440_normalized_version_as_current() -> None:
+    status = pypi_project_preflight.classify_project(
+        _planned_project(version="2026.05.26"),
+        fetch_json=lambda _name: {
+            "info": {"version": "2026.5.26"},
+            "releases": {"2026.5.26": []},
+        },
+    )
+
+    assert status.status == "current"
+    assert status.latest == "2026.5.26"
+
+
+def test_pypi_project_preflight_allows_existing_project_with_unpublished_version() -> None:
+    report = pypi_project_preflight.build_report(
+        fetch_json=lambda _name: {
+            "info": {"version": "2026.5.25"},
+            "releases": {"2026.5.25": []},
+        },
+        package_names=["agi-page-live-artifacts"],
+    )
+
+    assert report["status"] == "pass"
+    assert report["summary"]["to_publish"] == 1
+    assert report["blockers"] == []
+
+
+def test_release_status_derives_package_version_from_release_tag() -> None:
+    assert release_status.package_version_from_tag("v2026.05.23-2") == "2026.05.23"
+    assert release_status.package_version_from_tag("refs/tags/v2026.05.26") == "2026.05.26"
+
+
+def test_release_handoff_guard_requires_archiving_old_handoffs(tmp_path: Path) -> None:
+    handoff = tmp_path / "v2026.05.23-2-other-machine.md"
+    handoff.write_text("# AGILAB release handoff for v2026.05.23-2\n", encoding="utf-8")
+
+    assert release_handoff_guard.stale_handoffs(
+        handoff_dir=tmp_path,
+        latest_tag="v2026.05.26",
+    ) == [handoff]
+
+    handoff.write_text(
+        "# AGILAB release handoff for v2026.05.23-2\n\nStatus: archived\n",
+        encoding="utf-8",
+    )
+
+    assert release_handoff_guard.stale_handoffs(
+        handoff_dir=tmp_path,
+        latest_tag="v2026.05.26",
+    ) == []
+
+
+def test_pending_publisher_confirm_url_freshness_blocks_stale_variable() -> None:
+    payload = pending_publisher.GitHubActionsVariable(
+        value="https://pypi.org/account/confirm-login/?token=fresh",
+        updated_at=100.0,
+    )
+
+    assert not pending_publisher._github_variable_is_fresh(
+        payload,
+        minimum_updated_at=200.0,
+        allow_existing=False,
+    )
+    assert pending_publisher._github_variable_is_fresh(
+        payload,
+        minimum_updated_at=200.0,
+        allow_existing=True,
+    )

--- a/tools/agilab_audit.py
+++ b/tools/agilab_audit.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Audit local AGILAB repository, release, docs, and PyPI robustness state."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import subprocess
+import sys
+from typing import Any, Sequence
+
+try:
+    from pypi_project_preflight import build_report as pypi_preflight_report
+except ModuleNotFoundError:  # pragma: no cover - used when imported as tools.*
+    from tools.pypi_project_preflight import build_report as pypi_preflight_report
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_VERSION = "agilab.audit.v1"
+
+
+def _run(command: list[str], *, cwd: Path = ROOT, timeout: int = 60) -> tuple[int, str, str]:
+    completed = subprocess.run(
+        command,
+        cwd=cwd,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=timeout,
+        check=False,
+    )
+    return completed.returncode, completed.stdout.strip(), completed.stderr.strip()
+
+
+def _git(args: list[str], *, cwd: Path = ROOT) -> tuple[int, str, str]:
+    return _run(["git", *args], cwd=cwd)
+
+
+def _worktrees() -> list[dict[str, str]]:
+    rc, out, err = _git(["worktree", "list", "--porcelain"])
+    if rc:
+        return [{"error": err or out}]
+    entries: list[dict[str, str]] = []
+    current: dict[str, str] = {}
+    for line in out.splitlines():
+        if not line:
+            if current:
+                entries.append(current)
+                current = {}
+            continue
+        key, _, value = line.partition(" ")
+        current[key] = value
+    if current:
+        entries.append(current)
+    return entries
+
+
+def _audit_worktree(path: Path, *, fetch: bool) -> dict[str, Any]:
+    if fetch:
+        _git(["fetch", "--prune", "origin"], cwd=path)
+    rc, status, err = _git(["status", "--short", "--branch", "--untracked-files=no"], cwd=path)
+    branch_rc, branch, _branch_err = _git(["branch", "--show-current"], cwd=path)
+    head_rc, head, _head_err = _git(["rev-parse", "--short", "HEAD"], cwd=path)
+    upstream_rc, upstream, _upstream_err = _git(
+        ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
+        cwd=path,
+    )
+    main_rc, main_counts, _main_err = _git(["rev-list", "--left-right", "--count", "HEAD...origin/main"], cwd=path)
+    warnings: list[str] = []
+    dirty_lines = [line for line in status.splitlines() if line and not line.startswith("## ")]
+    if dirty_lines:
+        warnings.append("tracked changes present")
+    if branch_rc == 0 and not branch:
+        warnings.append("detached HEAD")
+    if main_rc == 0:
+        ahead, behind = (int(part) for part in main_counts.split())
+        if behind:
+            warnings.append(f"behind origin/main by {behind}")
+        if ahead:
+            warnings.append(f"ahead of origin/main by {ahead}")
+    return {
+        "path": str(path),
+        "status": status if rc == 0 else err,
+        "branch": branch if branch_rc == 0 and branch else None,
+        "detached": branch_rc == 0 and not branch,
+        "head": head if head_rc == 0 else None,
+        "upstream": upstream if upstream_rc == 0 else None,
+        "ahead_behind_origin_main": main_counts if main_rc == 0 else None,
+        "warnings": warnings,
+    }
+
+
+def _command_check(name: str, command: list[str], *, timeout: int = 120) -> dict[str, Any]:
+    rc, out, err = _run(command, timeout=timeout)
+    return {
+        "name": name,
+        "status": "pass" if rc == 0 else "fail",
+        "returncode": rc,
+        "summary": (out or err).splitlines()[-1] if (out or err) else "",
+    }
+
+
+def build_report(*, fetch: bool = True, network: bool = True) -> dict[str, Any]:
+    worktree_reports = [
+        _audit_worktree(Path(entry["worktree"]), fetch=fetch)
+        for entry in _worktrees()
+        if "worktree" in entry
+    ]
+    checks = [
+        _command_check(
+            "docs-mirror-stamp",
+            [sys.executable, "tools/sync_docs_source.py", "--verify-stamp"],
+        ),
+        _command_check(
+            "release-proof",
+            [sys.executable, "tools/release_proof_report.py", "--check", "--compact"],
+        ),
+        _command_check(
+            "release-handoff-guard",
+            [sys.executable, "tools/release_handoff_guard.py", "--compact"],
+        ),
+    ]
+    pypi_report: dict[str, Any] | None = None
+    if network:
+        pypi_report = pypi_preflight_report(repo_root=ROOT)
+    warnings = [
+        f"{report['path']}: {warning}"
+        for report in worktree_reports
+        for warning in report["warnings"]
+    ]
+    failed_checks = [check for check in checks if check["status"] != "pass"]
+    if pypi_report and pypi_report["status"] != "pass":
+        warnings.append(f"PyPI preflight blockers: {pypi_report['summary']['blockers']}")
+    status = "pass" if not warnings and not failed_checks else "warn"
+    return {
+        "schema": SCHEMA_VERSION,
+        "status": status,
+        "worktrees": worktree_reports,
+        "checks": checks,
+        "pypi_preflight": pypi_report,
+        "warnings": warnings,
+    }
+
+
+def render_text(report: dict[str, Any]) -> str:
+    lines = ["AGILAB audit", f"status: {report['status']}", ""]
+    lines.append("Worktrees:")
+    for worktree in report["worktrees"]:
+        label = worktree["branch"] or "detached"
+        lines.append(f"- {worktree['path']}: {label} {worktree['head']}")
+        for warning in worktree["warnings"]:
+            lines.append(f"  warning: {warning}")
+    lines.append("")
+    lines.append("Checks:")
+    for check in report["checks"]:
+        lines.append(f"- {check['name']}: {check['status']} {check['summary']}")
+    if report.get("pypi_preflight"):
+        summary = report["pypi_preflight"]["summary"]
+        lines.append("")
+        lines.append(
+            "PyPI preflight: "
+            f"{report['pypi_preflight']['status']} "
+            f"({summary['current']}/{summary['checked']} current, {summary['blockers']} blockers)"
+        )
+    if report["warnings"]:
+        lines.append("")
+        lines.append("Warnings:")
+        lines.extend(f"- {warning}" for warning in report["warnings"])
+    return "\n".join(lines)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--no-fetch", action="store_true")
+    parser.add_argument("--no-network", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--strict", action="store_true", help="Exit non-zero on warnings.")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    report = build_report(fetch=not args.no_fetch, network=not args.no_network)
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(render_text(report))
+    return 2 if args.strict and report["status"] != "pass" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/agilab_dev.py
+++ b/tools/agilab_dev.py
@@ -74,6 +74,9 @@ def planned_commands(argv: Sequence[str]) -> list[list[str]]:
     if command in {"app-contracts", "apps-contracts"}:
         return [_uv_python("tools/app_contract_matrix.py", *args)]
 
+    if command == "audit":
+        return [_uv_python("tools/agilab_audit.py", *args)]
+
     if command in {"flow", "profile"}:
         profiles, extras = _split_leading_values(args, command_name=command)
         profile_args: list[str] = []
@@ -94,6 +97,7 @@ def planned_commands(argv: Sequence[str]) -> list[list[str]]:
                 ".github/workflows/pypi-publish.yaml",
             ),
             _uv_python("tools/pypi_release_version_policy.py"),
+            _uv_python("tools/pypi_project_preflight.py"),
             _uv_python(
                 "tools/pypi_trusted_publisher_contract.py",
                 "--check-workflow",
@@ -150,6 +154,7 @@ def _usage() -> str:
   ./dev [--print-only] regress [ga_regression_selector args]
   ./dev [--print-only] robust [robustness_matrix args]
   ./dev [--print-only] app-contracts [app_contract_matrix args]
+  ./dev [--print-only] audit [agilab_audit args]
   ./dev [--print-only] flow|profile <profile> [profile...] [workflow args]
   ./dev [--print-only] typing [workflow-parity options]
   ./dev [--print-only] release [impact_validate args]
@@ -165,9 +170,10 @@ High-frequency mappings:
   regress   -> Use the GA regression selector on staged files and run the selected pytest subset.
   robust    -> Run the P0 robustness matrix of fail-closed bad-state scenarios.
   app-contracts -> Check built-in app, PyPI package, app catalog, and public-doc alignment.
+  audit     -> Audit local AGILAB worktrees, release proof, docs mirror, PyPI projects, and latest release truth.
   flow      -> Run one or more workflow_parity profiles with repeated --profile flags.
   typing    -> Run the forward shared-core ty typing profile. Mypy remains the curated temporary release guard under shared-core-typing.
-  release   -> Run local release guards: impact, generated PyPI plan, release cadence, trusted publisher contract, Ruff availability, docs, dependency policy, typing, and badge freshness.
+  release   -> Run local release guards: impact, generated PyPI plan, release cadence, PyPI project preflight, trusted publisher contract, Ruff availability, docs, dependency policy, typing, and badge freshness.
   badge     -> Run the explicit release/pre-release coverage badge freshness guard.
   docs      -> Sync docs from the canonical docs checkout and verify the mirror stamp.
   skills    -> Sync repo skills from Claude to Codex, validate, regenerate indexes/catalog/badges, and scan skill risk.

--- a/tools/pypi_pending_trusted_publisher.py
+++ b/tools/pypi_pending_trusted_publisher.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
 import html
 import json
 import os
@@ -78,6 +79,12 @@ class RegistrationResult:
     registered: bool
     already_registered: bool
     dry_run: bool = False
+
+
+@dataclass(frozen=True)
+class GitHubActionsVariable:
+    value: str
+    updated_at: float | None
 
 
 def _normalize_html(text: str) -> str:
@@ -200,12 +207,24 @@ def _response_diagnostic(text: str) -> str:
     return " || ".join(snippets)[:2400]
 
 
-def _fetch_github_actions_variable(
+def _parse_github_timestamp(value: str | None) -> float | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.timestamp()
+
+
+def _fetch_github_actions_variable_payload(
     *,
     repository: str,
     variable: str,
     token: str,
-) -> str | None:
+) -> GitHubActionsVariable | None:
     api_url = f"https://api.github.com/repos/{repository}/actions/variables/{variable}"
     request = urllib.request.Request(
         api_url,
@@ -226,7 +245,39 @@ def _fetch_github_actions_variable(
             f"GitHub Actions variable lookup failed with HTTP {exc.code}"
         ) from exc
     value = str(payload.get("value") or "").strip()
-    return value or None
+    if not value:
+        return None
+    return GitHubActionsVariable(
+        value=value,
+        updated_at=_parse_github_timestamp(str(payload.get("updated_at") or "")),
+    )
+
+
+def _fetch_github_actions_variable(
+    *,
+    repository: str,
+    variable: str,
+    token: str,
+) -> str | None:
+    payload = _fetch_github_actions_variable_payload(
+        repository=repository,
+        variable=variable,
+        token=token,
+    )
+    return payload.value if payload else None
+
+
+def _github_variable_is_fresh(
+    payload: GitHubActionsVariable,
+    *,
+    minimum_updated_at: float,
+    allow_existing: bool,
+) -> bool:
+    if allow_existing:
+        return True
+    if payload.updated_at is None:
+        return False
+    return payload.updated_at >= minimum_updated_at
 
 
 def _wait_for_github_confirm_login_url(
@@ -236,16 +287,31 @@ def _wait_for_github_confirm_login_url(
     token: str,
     timeout: float,
     poll_delay: float,
+    allow_existing: bool = False,
 ) -> str | None:
+    minimum_updated_at = time.time() - 10.0
     deadline = time.monotonic() + max(0.0, timeout)
+    stale_reported = False
     while time.monotonic() <= deadline:
-        value = _fetch_github_actions_variable(
+        payload = _fetch_github_actions_variable_payload(
             repository=repository,
             variable=variable,
             token=token,
         )
-        if value:
-            return value
+        if payload and _github_variable_is_fresh(
+            payload,
+            minimum_updated_at=minimum_updated_at,
+            allow_existing=allow_existing,
+        ):
+            return payload.value
+        if payload and not stale_reported:
+            stale_reported = True
+            print(
+                "Ignoring stale PyPI login confirmation URL from GitHub Actions "
+                f"variable {variable!r}; set a fresh URL from the current PyPI "
+                "email for this runner attempt.",
+                file=sys.stderr,
+            )
         time.sleep(max(1.0, poll_delay))
     return None
 
@@ -473,6 +539,15 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         type=float,
         default=5.0,
     )
+    parser.add_argument(
+        "--allow-existing-github-confirm-login-url",
+        action="store_true",
+        help=(
+            "Allow a pre-existing PYPI_CONFIRM_LOGIN_URL value. The default is "
+            "to ignore values older than this workflow attempt so stale email "
+            "links cannot be reused accidentally."
+        ),
+    )
     parser.add_argument("--github-token", default=os.environ.get("GITHUB_TOKEN"))
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument("--json", action="store_true")
@@ -523,6 +598,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     token=args.github_token,
                     timeout=args.github_confirm_login_timeout,
                     poll_delay=args.github_confirm_login_poll_delay,
+                    allow_existing=args.allow_existing_github_confirm_login_url,
                 )
 
         result = register_pending_github_publisher(

--- a/tools/pypi_project_preflight.py
+++ b/tools/pypi_project_preflight.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Preflight selected AGILAB PyPI projects before release dispatch."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict, dataclass
+import json
+from pathlib import Path
+from typing import Any, Callable, Sequence
+import urllib.error
+import urllib.parse
+import urllib.request
+
+from packaging.version import InvalidVersion, Version
+
+try:
+    from pypi_distribution_state import DistributionStateError, read_project_metadata
+    from release_plan import release_plan
+except ModuleNotFoundError:  # pragma: no cover - used when imported as tools.*
+    from tools.pypi_distribution_state import DistributionStateError, read_project_metadata
+    from tools.release_plan import release_plan
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_VERSION = "agilab.pypi_project_preflight.v1"
+
+
+@dataclass(frozen=True)
+class PlannedPyPIProject:
+    package: str
+    project: str
+    pypi_project: str
+    pypi_environment: str
+    artifact_policy: str
+    version: str
+
+
+@dataclass(frozen=True)
+class PyPIProjectStatus:
+    package: str
+    project: str
+    pypi_project: str
+    pypi_environment: str
+    artifact_policy: str
+    version: str
+    status: str
+    latest: str | None = None
+    release_count: int = 0
+    pending_publisher_command: str | None = None
+    error: str | None = None
+
+
+def fetch_pypi_json(project_name: str) -> dict[str, Any] | None:
+    url = f"https://pypi.org/pypi/{urllib.parse.quote(project_name)}/json"
+    request = urllib.request.Request(
+        url,
+        headers={"Cache-Control": "no-cache", "Pragma": "no-cache"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return json.load(response)
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return None
+        raise RuntimeError(f"could not fetch PyPI metadata for {project_name}: HTTP {exc.code}") from exc
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"could not fetch PyPI metadata for {project_name}: {exc}") from exc
+
+
+def _project_version(repo_root: Path, project: str) -> str:
+    try:
+        _name, version = read_project_metadata(repo_root / project)
+    except DistributionStateError as exc:
+        raise RuntimeError(str(exc)) from exc
+    return str(version)
+
+
+def _split_values(values: Sequence[str] | None) -> list[str]:
+    tokens: list[str] = []
+    for value in values or ():
+        tokens.extend(token for token in value.replace(",", " ").split() if token)
+    return tokens
+
+
+def selected_pypi_projects(
+    *,
+    repo_root: Path = ROOT,
+    package_names: Sequence[str] | None = None,
+    roles: Sequence[str] | None = None,
+) -> list[PlannedPyPIProject]:
+    plan = release_plan(package_names=package_names, roles=roles, repo_root=repo_root)
+    entries = [
+        entry
+        for entry in plan["library_matrix"]
+        if entry.get("publish_to_pypi") == "true"
+    ]
+    umbrella = plan["umbrella_package"]
+    if plan.get("umbrella_selected") == "true" and umbrella.get("publish_to_pypi") == "true":
+        entries.append(umbrella)
+    projects: list[PlannedPyPIProject] = []
+    for entry in entries:
+        projects.append(
+            PlannedPyPIProject(
+                package=entry["package"],
+                project=entry["project"],
+                pypi_project=entry["pypi_project"],
+                pypi_environment=entry["pypi_environment"],
+                artifact_policy=entry["artifact_policy"],
+                version=_project_version(repo_root, entry["project"]),
+            )
+        )
+    return projects
+
+
+def pending_publisher_command(project: PlannedPyPIProject) -> str:
+    return (
+        "gh workflow run pypi-pending-trusted-publisher.yaml "
+        "-R ThalesGroup/agilab --ref main "
+        f"-f project_name={project.pypi_project} "
+        f"-f pypi_environment={project.pypi_environment}"
+    )
+
+
+def _release_versions(payload: dict[str, Any]) -> list[Version]:
+    versions: list[Version] = []
+    for raw_version in payload.get("releases") or {}:
+        try:
+            versions.append(Version(str(raw_version)))
+        except InvalidVersion:
+            continue
+    return versions
+
+
+def classify_project(
+    project: PlannedPyPIProject,
+    *,
+    fetch_json: Callable[[str], dict[str, Any] | None] = fetch_pypi_json,
+) -> PyPIProjectStatus:
+    try:
+        payload = fetch_json(project.pypi_project)
+    except RuntimeError as exc:
+        return PyPIProjectStatus(
+            package=project.package,
+            project=project.project,
+            pypi_project=project.pypi_project,
+            pypi_environment=project.pypi_environment,
+            artifact_policy=project.artifact_policy,
+            version=project.version,
+            status="error",
+            error=str(exc),
+        )
+    if payload is None:
+        return PyPIProjectStatus(
+            package=project.package,
+            project=project.project,
+            pypi_project=project.pypi_project,
+            pypi_environment=project.pypi_environment,
+            artifact_policy=project.artifact_policy,
+            version=project.version,
+            status="missing-project",
+            pending_publisher_command=pending_publisher_command(project),
+        )
+
+    releases = _release_versions(payload)
+    expected = Version(project.version)
+    latest = max(releases) if releases else None
+    if expected in set(releases):
+        status = "current"
+    elif latest is not None and latest > expected:
+        status = "newer-on-pypi"
+    elif latest is None:
+        status = "empty-project"
+    else:
+        status = "missing-version"
+    return PyPIProjectStatus(
+        package=project.package,
+        project=project.project,
+        pypi_project=project.pypi_project,
+        pypi_environment=project.pypi_environment,
+        artifact_policy=project.artifact_policy,
+        version=project.version,
+        status=status,
+        latest=str(latest) if latest is not None else None,
+        release_count=len(releases),
+        pending_publisher_command=(
+            pending_publisher_command(project)
+            if status in {"missing-project", "empty-project"}
+            else None
+        ),
+    )
+
+
+def build_report(
+    *,
+    repo_root: Path = ROOT,
+    package_names: Sequence[str] | None = None,
+    roles: Sequence[str] | None = None,
+    fetch_json: Callable[[str], dict[str, Any] | None] = fetch_pypi_json,
+) -> dict[str, Any]:
+    statuses = [
+        classify_project(project, fetch_json=fetch_json)
+        for project in selected_pypi_projects(
+            repo_root=repo_root,
+            package_names=package_names,
+            roles=roles,
+        )
+    ]
+    blockers = [
+        status
+        for status in statuses
+        if status.status in {"missing-project", "empty-project", "newer-on-pypi", "error"}
+    ]
+    return {
+        "schema": SCHEMA_VERSION,
+        "repo_root": str(repo_root),
+        "status": "pass" if not blockers else "fail",
+        "summary": {
+            "checked": len(statuses),
+            "current": sum(1 for status in statuses if status.status == "current"),
+            "to_publish": sum(1 for status in statuses if status.status == "missing-version"),
+            "blockers": len(blockers),
+        },
+        "projects": [asdict(status) for status in statuses],
+        "blockers": [asdict(status) for status in blockers],
+    }
+
+
+def render_text(report: dict[str, Any]) -> str:
+    lines = [
+        "AGILAB PyPI project preflight",
+        f"status: {report['status']}",
+        f"checked: {report['summary']['checked']}",
+        f"current: {report['summary']['current']}",
+        f"to publish: {report['summary']['to_publish']}",
+        f"blockers: {report['summary']['blockers']}",
+        "",
+    ]
+    if report["blockers"]:
+        lines.append("Blockers:")
+        for blocker in report["blockers"]:
+            lines.append(
+                f"- {blocker['pypi_project']}: {blocker['status']} "
+                f"(expected {blocker['version']}, latest {blocker['latest'] or 'n/a'})"
+            )
+            if blocker.get("pending_publisher_command"):
+                lines.append(f"  pending publisher: {blocker['pending_publisher_command']}")
+    return "\n".join(lines)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=ROOT)
+    parser.add_argument("--package", dest="packages", action="append")
+    parser.add_argument("--role", dest="roles", action="append")
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--allow-blockers", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    report = build_report(
+        repo_root=args.repo_root.resolve(),
+        package_names=_split_values(args.packages),
+        roles=_split_values(args.roles),
+    )
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(render_text(report))
+    return 0 if report["status"] == "pass" or args.allow_blockers else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/regression_fresh_install.py
+++ b/tools/regression_fresh_install.py
@@ -49,6 +49,44 @@ def _site_packages_root(agi_space: Path) -> Path:
     raise FileNotFoundError(f"Could not locate site-packages under {agi_space / '.venv'}")
 
 
+def _has_streamlit(python_bin: Path, *, env: dict[str, str]) -> bool:
+    return (
+        subprocess.run(
+            [str(python_bin), "-c", "import streamlit"],
+            cwd=REPO_ROOT,
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        ).returncode
+        == 0
+    )
+
+
+def _ensure_ui_extra(python_bin: Path, *, env: dict[str, str]) -> None:
+    """Install the UI extra before running Streamlit-specific smoke checks."""
+
+    if _has_streamlit(python_bin, env=env):
+        print("fresh-install-ui-extra: already present")
+        return
+
+    result = _run(
+        [
+            "uv",
+            "--preview-features",
+            "extra-build-dependencies",
+            "pip",
+            "install",
+            "--python",
+            str(python_bin),
+            ".[ui]",
+        ],
+        env=env,
+        cwd=REPO_ROOT,
+    )
+    print(result.stdout)
+
+
 def _streamlit_smoke(python_bin: Path, site_packages: Path, *, env: dict[str, str]) -> None:
     smoke_code = textwrap.dedent(
         f"""
@@ -146,6 +184,7 @@ def main() -> int:
         )
         print(import_check.stdout)
 
+        _ensure_ui_extra(python_bin, env=env)
         _streamlit_smoke(python_bin, site_packages, env=env)
         print(f"Fresh install regression passed. Scratch home: {home_dir}")
         return 0

--- a/tools/release_handoff.py
+++ b/tools/release_handoff.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Generate a release handoff from current AGILAB release preflight state."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import re
+import subprocess
+from typing import Any, Sequence
+
+try:
+    from pypi_project_preflight import build_report
+except ModuleNotFoundError:  # pragma: no cover - used when imported as tools.*
+    from tools.pypi_project_preflight import build_report
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_VERSION = "agilab.release_handoff.v1"
+
+
+def _run_text(command: list[str]) -> str:
+    completed = subprocess.run(
+        command,
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    return completed.stdout.strip() if completed.returncode == 0 else ""
+
+
+def _safe_filename(tag: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_.-]+", "-", tag.strip()).strip("-")
+
+
+def default_output_path(tag: str) -> Path:
+    return ROOT / "tools" / "release_handoffs" / f"{_safe_filename(tag)}-handoff.md"
+
+
+def render_handoff(tag: str, preflight: dict[str, Any]) -> str:
+    head = _run_text(["git", "rev-parse", "HEAD"]) or "unknown"
+    guardrails = _run_text(
+        [
+            "gh",
+            "run",
+            "list",
+            "--repo",
+            "ThalesGroup/agilab",
+            "--workflow",
+            "repo-guardrails",
+            "--branch",
+            "main",
+            "--limit",
+            "1",
+            "--json",
+            "databaseId,status,conclusion,headSha,url",
+        ]
+    )
+    blockers = preflight["blockers"]
+    lines = [
+        f"# AGILAB release handoff for {tag}",
+        "",
+        "Status: current",
+        "",
+        "Generated from repository state. Do not reuse old PyPI confirmation URLs.",
+        "",
+        "## Prepared repository state",
+        "",
+        f"- Current HEAD: `{head}`",
+        f"- PyPI preflight status: `{preflight['status']}`",
+        f"- PyPI projects checked: `{preflight['summary']['checked']}`",
+        f"- PyPI blockers: `{preflight['summary']['blockers']}`",
+    ]
+    if guardrails:
+        lines.extend(["- Latest main guardrail run JSON:", "", "```json", guardrails, "```"])
+    lines.extend(["", "## Pending trusted publishers", ""])
+    if not blockers:
+        lines.append("No missing PyPI projects were detected. Dispatch the release workflow directly.")
+    else:
+        for blocker in blockers:
+            command = blocker.get("pending_publisher_command") or (
+                "gh workflow run pypi-pending-trusted-publisher.yaml "
+                "-R ThalesGroup/agilab --ref main "
+                f"-f project_name={blocker['pypi_project']} "
+                f"-f pypi_environment={blocker['pypi_environment']}"
+            )
+            lines.extend(
+                [
+                    f"### {blocker['pypi_project']}",
+                    "",
+                    f"- Status: `{blocker['status']}`",
+                    f"- Expected version: `{blocker['version']}`",
+                    f"- Environment: `{blocker['pypi_environment']}`",
+                    "",
+                    "```bash",
+                    command,
+                    "```",
+                    "",
+                ]
+            )
+    lines.extend(
+        [
+            "## Release dispatch",
+            "",
+            "```bash",
+            "gh workflow run pypi-publish.yaml \\",
+            "  -R ThalesGroup/agilab \\",
+            "  --ref main \\",
+            f"  -f release_tag={tag}",
+            "```",
+            "",
+            "## Release watch",
+            "",
+            "```bash",
+            "run_id=$(gh run list -R ThalesGroup/agilab \\",
+            "  --workflow pypi-publish.yaml \\",
+            "  --limit 1 \\",
+            "  --json databaseId \\",
+            "  --jq '.[0].databaseId')",
+            "gh run watch -R ThalesGroup/agilab \"$run_id\" --exit-status",
+            "```",
+            "",
+            "## Post-release truth check",
+            "",
+            "```bash",
+            f"uv run python tools/release_status.py --tag {tag}",
+            "```",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--json", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    preflight = build_report(repo_root=ROOT)
+    output = args.output or default_output_path(args.tag)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(render_handoff(args.tag, preflight), encoding="utf-8")
+    result = {
+        "schema": SCHEMA_VERSION,
+        "tag": args.tag,
+        "output": str(output),
+        "preflight_status": preflight["status"],
+        "blockers": preflight["summary"]["blockers"],
+    }
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        print(f"wrote {output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/release_handoff_guard.py
+++ b/tools/release_handoff_guard.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Guard against stale release handoff files presented as current."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import tomllib
+from pathlib import Path
+from typing import Sequence
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HANDOFF_DIR = ROOT / "tools" / "release_handoffs"
+PROOF_MANIFEST = ROOT / "docs" / "source" / "data" / "release_proof.toml"
+TAG_RE = re.compile(r"v\d{4}\.\d{2}\.\d{2}(?:-\d+)?")
+
+
+def _tag_key(tag: str) -> tuple[int, int, int, int]:
+    body = tag.removeprefix("v")
+    suffix = 0
+    if "-" in body:
+        body, raw_suffix = body.rsplit("-", 1)
+        suffix = int(raw_suffix) if raw_suffix.isdigit() else 0
+    year, month, day = (int(part) for part in body.split("."))
+    return year, month, day, suffix
+
+
+def latest_release_tag(manifest: Path = PROOF_MANIFEST) -> str:
+    payload = tomllib.loads(manifest.read_text(encoding="utf-8"))
+    release = payload.get("release", {})
+    tag = str(release.get("github_release_tag") or "")
+    if not TAG_RE.fullmatch(tag):
+        raise RuntimeError(f"could not determine latest release tag from {manifest}")
+    return tag
+
+
+def handoff_tag(path: Path) -> str | None:
+    text = path.read_text(encoding="utf-8")
+    match = TAG_RE.search(path.name) or TAG_RE.search(text)
+    return match.group(0) if match else None
+
+
+def is_archived(path: Path) -> bool:
+    head = "\n".join(path.read_text(encoding="utf-8").splitlines()[:20]).lower()
+    return "status: archived" in head
+
+
+def stale_handoffs(
+    *,
+    handoff_dir: Path = HANDOFF_DIR,
+    latest_tag: str | None = None,
+) -> list[Path]:
+    latest = latest_tag or latest_release_tag()
+    latest_key = _tag_key(latest)
+    stale: list[Path] = []
+    for path in sorted(handoff_dir.glob("*.md")):
+        tag = handoff_tag(path)
+        if tag is None:
+            continue
+        if _tag_key(tag) < latest_key and not is_archived(path):
+            stale.append(path)
+    return stale
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--handoff-dir", type=Path, default=HANDOFF_DIR)
+    parser.add_argument("--latest-tag")
+    parser.add_argument("--compact", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    stale = stale_handoffs(handoff_dir=args.handoff_dir, latest_tag=args.latest_tag)
+    if stale:
+        if args.compact:
+            print("stale release handoffs: " + ", ".join(str(path) for path in stale))
+        else:
+            print("Stale release handoffs must be marked with `Status: archived`:")
+            for path in stale:
+                print(f"- {path}")
+        return 2
+    print("release handoff guard passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/release_handoffs/v2026.05.23-2-other-machine.md
+++ b/tools/release_handoffs/v2026.05.23-2-other-machine.md
@@ -1,5 +1,10 @@
 # AGILAB release handoff for v2026.05.23-2
 
+Status: archived
+
+This handoff was superseded by the later public release recorded in
+`docs/source/data/release_proof.toml`. Keep it for historical recovery only.
+
 Use this handoff when finishing the `v2026.05.23-2` publication from another
 machine or a self-hosted/static-IP runner.
 

--- a/tools/release_status.py
+++ b/tools/release_status.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Check public release truth for an AGILAB release tag."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+from pathlib import Path
+from typing import Any, Sequence
+
+from packaging.version import InvalidVersion, Version
+
+try:
+    from pypi_project_preflight import fetch_pypi_json, selected_pypi_projects
+except ModuleNotFoundError:  # pragma: no cover - used when imported as tools.*
+    from tools.pypi_project_preflight import fetch_pypi_json, selected_pypi_projects
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_VERSION = "agilab.release_status.v1"
+
+
+def package_version_from_tag(tag: str) -> str:
+    value = tag.strip()
+    if value.startswith("refs/tags/"):
+        value = value.removeprefix("refs/tags/")
+    value = value.removeprefix("v")
+    return re.sub(r"-\d+$", "", value)
+
+
+def _run_json(command: list[str]) -> tuple[dict[str, Any] | None, str | None]:
+    completed = subprocess.run(
+        command,
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if completed.returncode:
+        return None, completed.stderr.strip() or completed.stdout.strip()
+    try:
+        return json.loads(completed.stdout), None
+    except json.JSONDecodeError as exc:
+        return None, str(exc)
+
+
+def github_release_status(tag: str) -> dict[str, Any]:
+    payload, error = _run_json(
+        [
+            "gh",
+            "release",
+            "view",
+            tag,
+            "--repo",
+            "ThalesGroup/agilab",
+            "--json",
+            "tagName,isDraft,isPrerelease,publishedAt,url,assets",
+        ]
+    )
+    if error:
+        return {"status": "fail", "error": error, "tag": tag}
+    assets = payload.get("assets") or []
+    return {
+        "status": "pass",
+        "tag": payload.get("tagName"),
+        "url": payload.get("url"),
+        "published_at": payload.get("publishedAt"),
+        "is_draft": payload.get("isDraft"),
+        "is_prerelease": payload.get("isPrerelease"),
+        "asset_count": len(assets),
+    }
+
+
+def _versions(payload: dict[str, Any]) -> set[Version]:
+    versions: set[Version] = set()
+    for raw_version in payload.get("releases") or {}:
+        try:
+            versions.add(Version(str(raw_version)))
+        except InvalidVersion:
+            continue
+    return versions
+
+
+def pypi_version_status(expected_version: str, *, repo_root: Path = ROOT) -> list[dict[str, Any]]:
+    expected = Version(expected_version)
+    statuses: list[dict[str, Any]] = []
+    for project in selected_pypi_projects(repo_root=repo_root):
+        payload = fetch_pypi_json(project.pypi_project)
+        if payload is None:
+            statuses.append(
+                {
+                    "pypi_project": project.pypi_project,
+                    "status": "missing-project",
+                    "expected": expected_version,
+                    "latest": None,
+                }
+            )
+            continue
+        raw_latest = str(payload.get("info", {}).get("version") or "")
+        statuses.append(
+            {
+                "pypi_project": project.pypi_project,
+                "status": "pass" if expected in _versions(payload) else "missing-version",
+                "expected": expected_version,
+                "latest": raw_latest or None,
+            }
+        )
+    return statuses
+
+
+def build_report(tag: str, *, package_version: str | None = None, repo_root: Path = ROOT) -> dict[str, Any]:
+    expected = package_version or package_version_from_tag(tag)
+    release = github_release_status(tag)
+    pypi = pypi_version_status(expected, repo_root=repo_root)
+    pypi_failures = [item for item in pypi if item["status"] != "pass"]
+    status = "pass" if release["status"] == "pass" and not pypi_failures else "fail"
+    return {
+        "schema": SCHEMA_VERSION,
+        "tag": tag,
+        "expected_package_version": expected,
+        "status": status,
+        "github_release": release,
+        "pypi": pypi,
+        "summary": {
+            "pypi_checked": len(pypi),
+            "pypi_failures": len(pypi_failures),
+            "release_asset_count": release.get("asset_count", 0),
+        },
+    }
+
+
+def render_text(report: dict[str, Any]) -> str:
+    lines = [
+        "AGILAB release status",
+        f"tag: {report['tag']}",
+        f"expected package version: {report['expected_package_version']}",
+        f"status: {report['status']}",
+        f"github release assets: {report['summary']['release_asset_count']}",
+        f"pypi failures: {report['summary']['pypi_failures']}",
+    ]
+    failures = [item for item in report["pypi"] if item["status"] != "pass"]
+    if failures:
+        lines.append("")
+        lines.append("PyPI failures:")
+        for item in failures:
+            lines.append(f"- {item['pypi_project']}: {item['status']} latest={item['latest']}")
+    return "\n".join(lines)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--package-version")
+    parser.add_argument("--repo-root", type=Path, default=ROOT)
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--allow-failures", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    report = build_report(
+        args.tag,
+        package_version=args.package_version,
+        repo_root=args.repo_root.resolve(),
+    )
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(render_text(report))
+    return 0 if report["status"] == "pass" or args.allow_failures else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a local `./dev audit` entrypoint for repo/docs/release/PyPI robustness checks
- add release robustness helpers for PyPI project preflight, release status, handoff generation, and stale handoff detection
- guard CI against stale release handoffs and stale PyPI confirm-login variables
- update release verification skill guidance and tests

## Validation
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' --import-mode=importlib test/test_agilab_dev_shortcuts.py test/test_release_robustness_tools.py test/test_pypi_pending_trusted_publisher.py`
