### PR TITLE
Align docs mirror after parallel stage docs

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 228,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "832aa6c55f2cd579d25f15737d552640e1cd2c274f9f55e4dd19b295c91f0ef2",
+  "source_digest_sha256": "cc8e96e733341f9b20f0c1d1c74e55cf025fedf7ee94d071cd2d882f1c8e0e49",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "832aa6c55f2cd579d25f15737d552640e1cd2c274f9f55e4dd19b295c91f0ef2"
+  "target_digest_sha256": "cc8e96e733341f9b20f0c1d1c74e55cf025fedf7ee94d071cd2d882f1c8e0e49"
 }

--- a/docs/source/agilab-mlops-positioning.rst
+++ b/docs/source/agilab-mlops-positioning.rst
@@ -266,11 +266,13 @@ controlled pilot and handoff workbench, not as a production MLOps platform:
   controlled-pilot boundary into an executable proof for service health,
   persisted artifacts, public-bind controls, secret redaction, and explicit
   failure modes
-- the release-decision page gates on the first-proof ``run_manifest.json``,
-  resolves artifact/log/export roots through the shared connector path registry,
-  imports external manifest evidence, applies artifact and KPI gates, and
-  exports ``promotion_decision.json`` plus ``manifest_index.json`` with connector
-  registry paths, manifest summary, import summary, provenance-tagged attachment
+- the Evidence Cockpit / release-decision page gates on the first-proof
+  ``run_manifest.json``, resolves artifact/log/export roots through the shared
+  connector path registry, imports external manifest evidence, applies artifact
+  and KPI gates, summarizes decision status, blocking gates, indexed evidence,
+  export readiness, and next action, and exports ``promotion_decision.json`` plus
+  ``manifest_index.json`` with the same cockpit summary, connector registry
+  paths, manifest summary, import summary, provenance-tagged attachment
   metadata, per-release evidence history, cross-release manifest comparison,
   cross-run evidence bundle comparison, and gate details
 - the standalone run-diff/counterfactual report gives those comparison claims a

--- a/docs/source/apps-pages.rst
+++ b/docs/source/apps-pages.rst
@@ -155,7 +155,7 @@ pulled by the umbrella dependency graph.
      - Included in ``agi-pages``.
    * - ``view_release_decision``
      - ``agi-page-promotion-gate``
-     - Baseline/candidate promotion-gate evidence review.
+     - Evidence cockpit for baseline/candidate run review, gates, and handoff decisions.
      - Included in ``agi-pages``.
    * - ``view_scenario_cockpit``
      - ``agi-page-scenario-cockpit``
@@ -304,11 +304,11 @@ Generic bridge for app-owned interactive Streamlit UIs.
 view_release_decision
 ^^^^^^^^^^^^^^^^^^^^^
 
-Promotion-gate page for baseline/candidate evidence bundles.
+Evidence cockpit for baseline/candidate run review and promotion gates.
 
 - Input: candidate and baseline evidence directories.
-- Output: gate checks, decision summary, and downloadable
-  ``promotion_decision.json`` evidence.
+- Output: cockpit summary, blocking-gate counts, indexed evidence history,
+  handoff checklist, and downloadable ``promotion_decision.json`` evidence.
 
 view_shap_explanation
 ^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/data/release_proof.toml
+++ b/docs/source/data/release_proof.toml
@@ -29,7 +29,7 @@ github_release_tag = "v2026.05.26"
 github_release_url = "https://github.com/ThalesGroup/agilab/releases/tag/v2026.05.26"
 hf_space_label = "jpmorard/agilab"
 hf_space_url = "https://huggingface.co/spaces/jpmorard/agilab"
-hf_space_commit = "3f0c6d0614a87b6bf1b0038b66c5c45d7e716ca7"
+hf_space_commit = "18050bdca443754ada6a6d1f07911efd5f0b09c3"
 
 [[ci_runs]]
 id = "release-guardrails"

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -465,12 +465,14 @@ production platform:
 - ``tools/controlled_pilot_readiness_report.py --compact`` packages the
   controlled-pilot readiness proof for service health, persisted artifacts,
   public-bind controls, secret redaction, and explicit failure modes
-- the release-decision analysis page compares baseline and candidate bundles,
-  resolves artifact/log/export roots through the shared connector path registry,
-  gates on the first-proof ``run_manifest.json``, imports external manifest
-  evidence with ``--manifest`` / ``--manifest-dir`` style inputs, evaluates
-  artifact and KPI gates, and exports ``promotion_decision.json`` with connector
-  registry paths, manifest summary, import summary, provenance-tagged attachment
+- the Evidence Cockpit analysis page compares baseline and candidate bundles,
+  summarizes decision status, blocking gates, indexed evidence, and export
+  readiness, resolves artifact/log/export roots through the shared connector
+  path registry, gates on the first-proof ``run_manifest.json``, imports
+  external manifest evidence with ``--manifest`` / ``--manifest-dir`` style
+  inputs, evaluates artifact and KPI gates, and exports
+  ``promotion_decision.json`` with the cockpit summary, connector registry
+  paths, manifest summary, import summary, provenance-tagged attachment
   metadata, per-release ``manifest_index.json`` evidence history,
   cross-release manifest comparison, cross-run evidence bundle comparison, and
   gate details; it also imports ``ci_artifact_harvest.json`` evidence, displays

--- a/docs/source/package-publishing-policy.rst
+++ b/docs/source/package-publishing-policy.rst
@@ -224,13 +224,24 @@ and release-candidate versions such as ``YYYY.MM.DDrc1`` are acceptable for
 preview validation, but those rehearsals are not the source of truth for a real
 final release.
 
+By default, the GitHub PyPI workflow asks ``tools/release_plan.py`` to omit
+selected PyPI packages whose expected wheel/sdist artifacts for the committed
+project version already exist on PyPI. Those skipped packages are not sent to
+the build/upload matrix, PyPI provenance verification, release retention, or
+GitHub release-asset assembly. This keeps split packages independent in
+practice: unchanged packages do not need a new version and do not trigger slow
+PyPI web cleanup. Use the manual ``include_existing_pypi=true`` dispatch input
+only when intentionally repairing release assets from already-published PyPI
+artifacts.
+
 After PyPI provenance passes, the release workflow attempts to keep one retained
-PyPI release per selected PyPI project. ``tools/pypi_release_retention.py`` reads
-the selected release-plan projects, confirms that each package's own committed
-project version is visible, then tries to delete older releases before GitHub
-release assets are published. This allows split packages to advance
-independently while keeping retention from deleting another package's current
-version. This is a destructive PyPI web-management operation, separate from
+PyPI release per selected PyPI project that still needs publication in the
+optimized release plan. ``tools/pypi_release_retention.py`` reads the selected
+release-plan projects, confirms that each package's own committed project
+version is visible, then tries to delete older releases before GitHub release
+assets are published. This allows split packages to advance independently while
+keeping retention from deleting another package's current version. This is a
+destructive PyPI web-management operation, separate from
 Trusted Publishing, so the workflow uses ``PYPI_RELEASE_PRUNE_USERNAME`` and
 ``PYPI_RELEASE_PRUNE_PASSWORD`` repository secrets. PyPI accounts with two-factor
 authentication can use non-interactive authentication through

--- a/docs/source/packaged-examples.rst
+++ b/docs/source/packaged-examples.rst
@@ -1,109 +1,124 @@
 Packaged Examples
 =================
 
-AGILAB ships small public examples that teach one workflow at a time. Some
-examples install and run a built-in app through ``AGI_*`` helper scripts. Other
-examples are read-only previews that write deterministic evidence without
-starting workers, services, or private integrations.
+This page is the rendered public catalog for examples shipped under
+``src/agilab/examples``. Use it when you need the full list in one place. Use
+:doc:`demos` when you need a shorter route chooser.
 
-This page is the Packaged example catalog for public examples.
+The examples are split into executable app helpers, deterministic read-only
+previews, and notebook migration assets. The read-only previews intentionally
+avoid hidden services, private data, and long-lived workers.
 
-Use the source catalog as the executable index:
+Catalog
+-------
 
-.. code-block:: bash
-
-   uv --preview-features extra-build-dependencies run python -m py_compile $(find src/agilab/examples -name '*.py' -print)
-
-Learning path
--------------
-
-.. list-table::
+.. list-table:: Packaged example catalog
    :header-rows: 1
-   :widths: 24 32 44
+   :widths: 24 24 52
 
    * - Example
-     - Class
-     - Main lesson
+     - Route
+     - What it proves
    * - ``flight_telemetry``
-     - Installed app helper
-     - First proof: install one app, run one file, inspect map-ready output.
+     - Executable app helper
+     - First proof for ``flight_telemetry_project``: install, run, and inspect
+       map-ready telemetry output.
    * - ``mycode``
-     - Installed app helper
-     - Smallest worker template and execution smoke.
+     - Executable app helper
+     - Smallest worker template and local execution smoke.
    * - ``weather_forecast``
-     - Installed app helper
-     - Turn a notebook-style forecast into a reproducible app run.
-   * - ``notebook_migrations``
-     - Migration source assets
-     - Notebooks, artifacts, lab stages, and conceptual pipeline view, including ``notebook_migrations/skforecast_meteo_fr``.
+     - Executable app helper
+     - Notebook-style forecast turned into a reproducible AGILAB app run.
+   * - ``mission_decision``
+     - Executable app helper
+     - Deterministic mission-data decision run with richer artifacts.
+   * - ``sklearn_pipeline``
+     - Executable app helper
+     - Classic ML proof with dataset generation, fitted pipeline, predictions,
+       metrics, model artifact, and hash manifest.
    * - ``notebook_quickstart``
-     - Notebook examples
-     - First-run, Colab, Kaggle, benchmark, and worker-path notebook samples.
+     - Notebook route
+     - Colab, Kaggle, and local agi-core notebooks for the smallest runtime
+       surface.
+   * - ``notebook_migrations``
+     - Notebook migration assets
+     - Packaged migration source material such as notebooks, analysis
+       artifacts, ``lab_stages.toml``, and pipeline views.
    * - ``notebook_to_dask``
      - Read-only preview
-     - Notebook cells, artifact contracts, and a Dask pipeline view.
+     - Notebook cells, artifact contracts, and Dask pipeline view before a real
+       app conversion.
    * - ``parallel_stage``
      - Read-only preview
-     - Plan parallelism from function, split rule, reducer, and partition count.
+     - Function, split rule, reducer, chunk partitions, and useful-worker
+       capping when file count is lower than core count.
    * - ``excel_workbook_proof``
      - Read-only preview
-     - Workbook output, refreshable CSVs, and evidence hashes.
+     - Excel-shaped workbook output, Power Query-friendly CSVs, and evidence
+       hashes.
    * - ``sqlite_connector_proof``
      - Read-only preview
-     - Local database query, CSV result, and evidence hashes.
+     - Local SQLite schema, parameterized read-only query, CSV output, and
+       database evidence.
    * - ``voila_notebook_proof``
      - Read-only preview
-     - Notebook dashboard handoff with widget-to-args hints.
-   * - ``sklearn_pipeline``
-     - Installed app helper
-     - Deterministic ML pipeline, metrics, model artifact, and hashes.
-   * - ``mission_decision``
-     - Installed app helper
-     - Deterministic mission-data decision run with richer artifacts.
+     - Voila-shaped notebook dashboard proof with widget-to-args migration hints
+       and app-view plan.
    * - ``inter_project_dag``
      - Read-only preview
-     - Cross-project DAG artifact handoff and runner-state preview.
+     - Cross-project DAG compatibility route using explicit artifact handoff.
    * - ``service_mode``
      - Read-only preview
-     - Service lifecycle and health-gate planning.
+     - Service lifecycle contract: start, status, health, and stop semantics
+       without launching a persistent worker.
    * - ``mlflow_auto_tracking``
      - Read-only preview
-     - Optional MLflow memory around AGILAB evidence.
+     - Optional MLflow tracking around AGILAB execution evidence, not a parallel
+       model registry.
    * - ``resilience_failure_injection``
      - Read-only preview
-     - Compare fixed, replanned, search, and policy responses.
+     - Controlled relay-failure scenario comparing fixed, replanned, search, and
+       policy responses.
    * - ``train_then_serve``
      - Read-only preview
-     - Freeze a trained policy before serving.
+     - Handoff from trained policy artifact to service contract, prediction
+       sample, and health gate.
    * - ``native_rust_worker``
      - Read-only preview
-     - Keep AGILAB orchestration in Python while moving a typed hot kernel to Rust.
+     - PyO3/maturin native-worker skeleton for moving only a measured hot kernel
+       to Rust while orchestration stays in Python.
 
-Parallel-stage example
-----------------------
+Execution Map
+-------------
 
-Use ``parallel_stage`` before enabling pool or Dask execution when file count is
-lower than core count. It teaches the rule used by :doc:`parallel-stages`:
-
-.. code-block:: text
-
-   if files are large and splittable:
-       create chunk partitions until workers have enough work
-   else:
-       cap useful workers to file_count
-
-Run it from a source checkout:
+Use installed ``AGI_*.py`` helpers when you want to run a real built-in app from
+``~/log/execute/<app>/`` after AGILAB has seeded the scripts. Use preview
+scripts when you want deterministic evidence without starting services or
+distributed workers.
 
 .. code-block:: bash
 
-   uv --preview-features extra-build-dependencies run python src/agilab/examples/parallel_stage/preview_parallel_stage.py
+   python ~/log/execute/flight_telemetry/AGI_install_flight_telemetry.py
+   python ~/log/execute/flight_telemetry/AGI_run_flight_telemetry.py
 
-The preview writes ``~/log/execute/parallel_stage/parallel_stage_preview.json``
-and does not start workers.
+Preview scripts are run from a source checkout through ``uv`` so dependencies
+come from the checkout environment:
 
-Where to edit
+.. code-block:: bash
+
+   uv --preview-features extra-build-dependencies run python src/agilab/examples/parallel_stage/preview_parallel_stage.py --output /tmp/parallel_stage_preview.json
+   uv --preview-features extra-build-dependencies run python src/agilab/examples/sqlite_connector_proof/preview_sqlite_connector_proof.py --output-dir /tmp/agilab-sqlite-proof
+   uv --preview-features extra-build-dependencies run python src/agilab/examples/notebook_to_dask/preview_notebook_to_dask.py --output /tmp/notebook_to_dask_preview.json
+
+Related Pages
 -------------
 
-The source README at ``src/agilab/examples/README.md`` is the detailed catalog.
-Each example directory also has its own ``README.md`` with purpose, input,
-output, safe adaptation, and troubleshooting notes.
+- :doc:`quick-start` for the shortest local first proof.
+- :doc:`demos` for a compact demo route chooser.
+- :doc:`parallel-stages` for function, split rule, reducer, and partition
+  planning before pool or Dask execution.
+- :doc:`advanced-proof-pack` for the deeper proof routes.
+- :doc:`notebook-quickstart` and :doc:`notebook-advanced` for notebook-first
+  examples.
+- :doc:`excel-users`, :doc:`voila-users`, and :doc:`data-connectors` for
+  stakeholder-specific bridge examples.

--- a/docs/source/release-proof.rst
+++ b/docs/source/release-proof.rst
@@ -22,7 +22,7 @@ Current public release
    * - GitHub release
      - `v2026.05.26 <https://github.com/ThalesGroup/agilab/releases/tag/v2026.05.26>`__
    * - Hosted demo
-     - `jpmorard/agilab <https://huggingface.co/spaces/jpmorard/agilab>`__ at Space commit ``3f0c6d0614a87b6bf1b0038b66c5c45d7e716ca7``
+     - `jpmorard/agilab <https://huggingface.co/spaces/jpmorard/agilab>`__ at Space commit ``18050bdca443754ada6a6d1f07911efd5f0b09c3``
    * - Public guardrails
      - `repo-guardrails run 26418364385 <https://github.com/ThalesGroup/agilab/actions/runs/26418364385>`__ passed repository guardrails and clean package first-proof jobs
    * - Docs source guard


### PR DESCRIPTION
## Summary
- resync public AGILAB docs mirror after canonical docs PR jpmorard/thales_agilab#30
- refresh mirror stamp and canonical docs updates for packaged examples, release proof, package policy, and feature pages

## Validation
- `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' --import-mode=importlib test/test_app_installer_packaging.py::test_packaged_example_catalog_has_rendered_docs_page`
