### PR TITLE
[codex] Update AGILAB premium teaser YouTube URL

### DIFF
--- a/artifacts/demo_media/flight/agilab_flight_youtube_pack.md
+++ b/artifacts/demo_media/flight/agilab_flight_youtube_pack.md
@@ -5,9 +5,10 @@
 - MP4: `artifacts/demo_media/flight/agilab_flight.mp4`
 - GIF preview: `artifacts/demo_media/flight/agilab_flight.gif`
 - Poster: `artifacts/demo_media/flight/agilab_flight_poster.png`
-- YouTube public URL: https://youtu.be/KsBe8lIahH4
+- YouTube public URL: https://youtu.be/BsBjRSAXJZA
+- Previous audio upload: https://youtu.be/KsBe8lIahH4
 - Previous silent upload: https://youtu.be/c4aogHDh4do
-- YouTube Studio URL: https://studio.youtube.com/video/KsBe8lIahH4
+- YouTube Studio URL: https://studio.youtube.com/video/BsBjRSAXJZA
 - Duration: 15.47 seconds
 - Format: 1920x1080, 30 fps, premium H.264 video + stereo AAC audio MP4
 - Video master: regenerated from source frames at CRF 12


### PR DESCRIPTION
## What changed

- Updates the AGILAB flight teaser upload pack with the current premium YouTube URL.
- Keeps the previous audio and silent uploads for traceability.

## Why

The premium teaser master was uploaded as a new YouTube video, so the repo metadata should point to the current public URL.

## Checks

- Metadata-only update.
