### PR TITLE
chore(release): bump packages to 2026.05.28

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.26"
+version = "2026.05.28"
 name = "agilab"
 description = "AGILAB is a reproducible AI/ML workbench for engineering teams."
 requires-python = ">=3.11"
@@ -44,7 +44,7 @@ keywords = [
     "agentic-ai",
     "free-threaded-python",
 ]
-dependencies = ["agi-core==2026.05.26", "legacy-cgi>=2.6.4,<3; python_version >= '3.13'", "standard-imghdr>=3.13.0,<4; python_version >= '3.13'"]
+dependencies = ["agi-core==2026.05.28", "legacy-cgi>=2.6.4,<3; python_version >= '3.13'", "standard-imghdr>=3.13.0,<4; python_version >= '3.13'"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"
@@ -60,13 +60,13 @@ agilab-mcp = "agilab_mcp.server:main"
 
 [project.optional-dependencies]
 ai = ["openai>=2.32.0,<3"]
-ui = ["agi-apps==2026.05.26", "agi-pages==2026.05.26", "agi-gui==2026.05.26", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "streamlit>=1.56,<1.57", "tomli_w>=1.2.0,<2"]
+ui = ["agi-apps==2026.05.28", "agi-pages==2026.05.28", "agi-gui==2026.05.28", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "streamlit>=1.56,<1.57", "tomli_w>=1.2.0,<2"]
 viz = ["matplotlib>=3.10.0,<4", "plotly>=6.7.0,<7"]
 mlflow = ["mlflow>=3.11.1,<4", "idna>=3.15,<4", "starlette>=1.0.1,<2"]
 bridges = ["duckdb>=1.4.0,<2"]
 notebook = ["ipykernel>=6.29.0,<7", "nbclient>=0.10.0,<1", "nbformat>=5.10.0,<6"]
-examples = ["agi-apps==2026.05.26", "jupyterlab>=4.4.0,<5", "matplotlib>=3.10.0,<4", "plotly>=6.7.0,<7"]
-pages = ["agi-pages==2026.05.26"]
+examples = ["agi-apps==2026.05.28", "jupyterlab>=4.4.0,<5", "matplotlib>=3.10.0,<4", "plotly>=6.7.0,<7"]
+pages = ["agi-pages==2026.05.28"]
 proof = ["cryptography>=46.0.0,<47"]
 agents = ["openai>=2.32.0,<3"]
 local-llm = ["accelerate>=0.34.2,<1; python_version >= '3.12'", "fastapi>=0.124.4,!=0.136.3,<1; python_version >= '3.12'", "gpt-oss>=0.0.8,<0.1; python_version >= '3.12'", "langchain-core>=1.3.3,<2; python_version >= '3.12'", "langsmith>=0.8.0,<1; python_version >= '3.12'", "mlx>=0.31.2,<0.32; sys_platform == 'darwin' and platform_machine == 'arm64'", "mlx-lm>=0.31.3,<0.32; sys_platform == 'darwin' and platform_machine == 'arm64'", "mlx-vlm>=0.5.0,<0.6; sys_platform == 'darwin' and platform_machine == 'arm64'", "requests>=2.32.0,<3; python_version >= '3.12'", "torch>=2.8.0,<3; python_version >= '3.12'", "transformers>=4.57.0,<6; python_version >= '3.12'", "universal-offline-ai-chatbot>=0.1.0,<0.2; python_version >= '3.12'"]

--- a/src/agilab/apps-pages/view_app_ui/pyproject.toml
+++ b/src/agilab/apps-pages/view_app_ui/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-app-ui"
-version = "2026.05.26"
+version = "2026.05.28"
 description = "AGILAB page bundle for app-owned interactive Streamlit UIs."
 readme = { text = "AGILAB page bundle for app-owned interactive Streamlit UIs.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_barycentric/pyproject.toml
+++ b/src/agilab/apps-pages/view_barycentric/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-simplex-map"
-version = "2026.05.26"
+version = "2026.05.28"
 description = "AGILAB page bundle for simplex projection and barycentric analysis."
 readme = { text = "AGILAB page bundle for simplex projection and barycentric analysis.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_data_io_decision/pyproject.toml
+++ b/src/agilab/apps-pages/view_data_io_decision/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-decision-evidence"
-version = "2026.05.26"
+version = "2026.05.28"
 description = "AGILAB page bundle for decision evidence review."
 readme = { text = "AGILAB page bundle for decision evidence review.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_forecast_analysis/pyproject.toml
+++ b/src/agilab/apps-pages/view_forecast_analysis/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-timeseries-forecast"
-version = "2026.05.26"
+version = "2026.05.28"
 description = "AGILAB page bundle for time-series forecast review."
 readme = { text = "AGILAB page bundle for time-series forecast review.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_inference_analysis/pyproject.toml
+++ b/src/agilab/apps-pages/view_inference_analysis/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-inference-report"
-version = "2026.05.26"
+version = "2026.05.28"
 description = "AGILAB page bundle for inference result reporting."
 readme = { text = "AGILAB page bundle for inference result reporting.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_live_artifacts/pyproject.toml
+++ b/src/agilab/apps-pages/view_live_artifacts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-live-artifacts"
-version = "2026.05.26"
+version = "2026.05.28"
 description = "AGILAB page bundle for live artifact and evidence monitoring."
 readme = { text = "AGILAB page bundle for live artifact and evidence monitoring.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_maps/pyproject.toml
+++ b/src/agilab/apps-pages/view_maps/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-geospatial-map"
-version = "2026.05.26"
+version = "2026.05.28"
 description = "AGILAB page bundle for 2D geospatial map exploration."
 readme = { text = "AGILAB page bundle for 2D geospatial map exploration.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_maps_3d/pyproject.toml
+++ b/src/agilab/apps-pages/view_maps_3d/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-geospatial-3d"
-version = "2026.05.26"
+version = "2026.05.28"
 description = "AGILAB page bundle for 3D geospatial exploration."
 readme = { text = "AGILAB page bundle for 3D geospatial exploration.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_maps_network/pyproject.toml
+++ b/src/agilab/apps-pages/view_maps_network/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-network-map"
-version = "2026.05.26"
+version = "2026.05.28"
 description = "AGILAB page bundle for network-aware geospatial analysis."
 readme = { text = "AGILAB page bundle for network-aware geospatial analysis.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_queue_resilience/pyproject.toml
+++ b/src/agilab/apps-pages/view_queue_resilience/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-queue-health"
-version = "2026.05.26"
+version = "2026.05.28"
 description = "AGILAB page bundle for queue health and resilience evidence."
 readme = { text = "AGILAB page bundle for queue health and resilience evidence.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_relay_resilience/pyproject.toml
+++ b/src/agilab/apps-pages/view_relay_resilience/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-relay-health"
-version = "2026.05.26"
+version = "2026.05.28"
 description = "AGILAB page bundle for relay health and resilience evidence."
 readme = { text = "AGILAB page bundle for relay health and resilience evidence.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_release_decision/pyproject.toml
+++ b/src/agilab/apps-pages/view_release_decision/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-promotion-gate"
-version = "2026.05.26"
+version = "2026.05.28"
 description = "AGILAB page bundle for evidence-cockpit run review and promotion gates."
 readme = { text = "AGILAB page bundle for evidence-cockpit run review and promotion gates.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_scenario_cockpit/pyproject.toml
+++ b/src/agilab/apps-pages/view_scenario_cockpit/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-scenario-cockpit"
-version = "2026.05.26"
+version = "2026.05.28"
 description = "AGILAB page bundle for scenario evidence comparison."
 readme = { text = "AGILAB page bundle for scenario evidence comparison.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_shap_explanation/pyproject.toml
+++ b/src/agilab/apps-pages/view_shap_explanation/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-feature-attribution"
-version = "2026.05.26"
+version = "2026.05.28"
 description = "AGILAB page bundle for feature-attribution evidence."
 readme = { text = "AGILAB page bundle for feature-attribution evidence.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_training_analysis/pyproject.toml
+++ b/src/agilab/apps-pages/view_training_analysis/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-training-report"
-version = "2026.05.26"
+version = "2026.05.28"
 description = "AGILAB page bundle for training run reporting."
 readme = { text = "AGILAB page bundle for training run reporting.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps/builtin/execution_pandas_project/pyproject.toml
+++ b/src/agilab/apps/builtin/execution_pandas_project/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "execution_pandas_project"
-version = "2026.05.26"
+version = "2026.05.28"
 description = "Built-in AGILab execution playground using PandasWorker"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.26", "agi-node>=2026.05.26", "agi-cluster>=2026.05.26", "numpy>=2.2,<3", "pandas>=2.3.0,<4", "pydantic>=2.11,<3", "streamlit>=1.56,<1.57"]
+dependencies = ["agi-env>=2026.05.28", "agi-node>=2026.05.28", "agi-cluster>=2026.05.28", "numpy>=2.2,<3", "pandas>=2.3.0,<4", "pydantic>=2.11,<3", "streamlit>=1.56,<1.57"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/execution_pandas_project/src/execution_pandas_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/execution_pandas_project/src/execution_pandas_worker/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "execution_pandas_project"
-version = "2026.05.26"
+version = "2026.05.28"
 description = "Built-in AGILab execution playground using PandasWorker"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.26", "agi-node>=2026.05.26", "numpy>=2.2,<3", "pandas>=2.3.0,<4", "pydantic>=2.11,<3"]
+dependencies = ["agi-env>=2026.05.28", "agi-node>=2026.05.28", "numpy>=2.2,<3", "pandas>=2.3.0,<4", "pydantic>=2.11,<3"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/execution_polars_project/pyproject.toml
+++ b/src/agilab/apps/builtin/execution_polars_project/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "execution_polars_project"
-version = "2026.05.26"
+version = "2026.05.28"
 description = "Built-in AGILab execution playground using PolarsWorker"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.26", "agi-node>=2026.05.26", "agi-cluster>=2026.05.26", "polars>=1.35,<2", "pydantic>=2.11,<3", "streamlit>=1.56,<1.57"]
+dependencies = ["agi-env>=2026.05.28", "agi-node>=2026.05.28", "agi-cluster>=2026.05.28", "polars>=1.35,<2", "pydantic>=2.11,<3", "streamlit>=1.56,<1.57"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/execution_polars_project/src/execution_polars_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/execution_polars_project/src/execution_polars_worker/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "execution_polars_project"
-version = "2026.05.26"
+version = "2026.05.28"
 description = "Built-in AGILab execution playground using PolarsWorker"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.26", "agi-node>=2026.05.26", "polars>=1.35,<2", "pydantic>=2.11,<3"]
+dependencies = ["agi-env>=2026.05.28", "agi-node>=2026.05.28", "polars>=1.35,<2", "pydantic>=2.11,<3"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/flight_telemetry_project/pyproject.toml
+++ b/src/agilab/apps/builtin/flight_telemetry_project/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "flight_telemetry_project"
-version = "2026.05.26"
+version = "2026.05.28"
 description = "Built-in AGILab example app (flight-telemetry preprocessing)"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.26", "agi-node>=2026.05.26", "agi-cluster>=2026.05.26", "polars[rtcompat]>=1.35,<2", "pydantic>=2.11,<3", "py7zr>=1.1,<2", "streamlit>=1.56,<1.57"]
+dependencies = ["agi-env>=2026.05.28", "agi-node>=2026.05.28", "agi-cluster>=2026.05.28", "polars[rtcompat]>=1.35,<2", "pydantic>=2.11,<3", "py7zr>=1.1,<2", "streamlit>=1.56,<1.57"]
 
 [tool.agilab]
 runtime_target = "flight_telemetry"

--- a/src/agilab/apps/builtin/flight_telemetry_project/src/flight_telemetry_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/flight_telemetry_project/src/flight_telemetry_worker/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "flight_telemetry_project"
-version = "2026.05.26"
+version = "2026.05.28"
 description = ""
 requires-python = ">=3.11,<3.14"
 readme = "README.md"
-dependencies = ["agi-env>=2026.05.26", "agi-node>=2026.05.26", "polars>=1.35,<2", "pydantic>=2.11,<3"]
+dependencies = ["agi-env>=2026.05.28", "agi-node>=2026.05.28", "polars>=1.35,<2", "pydantic>=2.11,<3"]
 
 [[project.authors]]
 name = "Jean-Pierre Morard"

--- a/src/agilab/apps/builtin/global_dag_project/pyproject.toml
+++ b/src/agilab/apps/builtin/global_dag_project/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "global_dag_project"
-version = "2026.05.26"
+version = "2026.05.28"
 description = "Built-in AGILAB global DAG example project"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.26", "agi-node>=2026.05.26", "agi-cluster>=2026.05.26", "polars>=1.35,<2", "pydantic>=2.11,<3", "streamlit>=1.56,<1.57"]
+dependencies = ["agi-env>=2026.05.28", "agi-node>=2026.05.28", "agi-cluster>=2026.05.28", "polars>=1.35,<2", "pydantic>=2.11,<3", "streamlit>=1.56,<1.57"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/global_dag_project/src/global_dag_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/global_dag_project/src/global_dag_worker/pyproject.toml
@@ -1,8 +1,8 @@
 [project]
 name = "global_dag_worker"
-version = "2026.05.26"
+version = "2026.05.28"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.26", "agi-node>=2026.05.26", "polars>=1.35,<2"]
+dependencies = ["agi-env>=2026.05.28", "agi-node>=2026.05.28", "polars>=1.35,<2"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/meteo_forecast_project/pyproject.toml
+++ b/src/agilab/apps/builtin/meteo_forecast_project/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "meteo_forecast_project"
-version = "2026.05.26"
+version = "2026.05.28"
 description = "Built-in AGILab weather forecasting example migrated from notebooks"
 requires-python = ">=3.13"
-dependencies = ["agi-env>=2026.05.26", "agi-node>=2026.05.26", "agi-cluster>=2026.05.26", "pandas>=2.3.0,<4", "pydantic>=2.11,<3", "scikit-learn>=1.7.2,<2", "skforecast>=0.19,<0.20", "streamlit>=1.56,<1.57"]
+dependencies = ["agi-env>=2026.05.28", "agi-node>=2026.05.28", "agi-cluster>=2026.05.28", "pandas>=2.3.0,<4", "pydantic>=2.11,<3", "scikit-learn>=1.7.2,<2", "skforecast>=0.19,<0.20", "streamlit>=1.56,<1.57"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/meteo_forecast_project/src/meteo_forecast_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/meteo_forecast_project/src/meteo_forecast_worker/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "meteo_forecast_project"
-version = "2026.05.26"
+version = "2026.05.28"
 description = "Built-in AGILab weather forecasting example migrated from notebooks"
 requires-python = ">=3.13"
-dependencies = ["agi-env>=2026.05.26", "agi-node>=2026.05.26", "pandas>=2.3.0,<4", "pydantic>=2.11,<3", "scikit-learn>=1.7.2,<2", "skforecast>=0.19,<0.20"]
+dependencies = ["agi-env>=2026.05.28", "agi-node>=2026.05.28", "pandas>=2.3.0,<4", "pydantic>=2.11,<3", "scikit-learn>=1.7.2,<2", "skforecast>=0.19,<0.20"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/mission_decision_project/pyproject.toml
+++ b/src/agilab/apps/builtin/mission_decision_project/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "mission_decision_project"
-version = "2026.05.26"
+version = "2026.05.28"
 description = "Built-in AGILAB Mission Decision autonomous demo"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.26", "agi-node>=2026.05.26", "agi-cluster>=2026.05.26", "pandas>=2.3.0,<4", "pydantic>=2.11,<3", "streamlit>=1.56,<1.57"]
+dependencies = ["agi-env>=2026.05.28", "agi-node>=2026.05.28", "agi-cluster>=2026.05.28", "pandas>=2.3.0,<4", "pydantic>=2.11,<3", "streamlit>=1.56,<1.57"]
 
 [tool.agilab]
 runtime_target = "mission_decision"

--- a/src/agilab/apps/builtin/mission_decision_project/src/mission_decision_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/mission_decision_project/src/mission_decision_worker/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "mission_decision_project"
-version = "2026.05.26"
+version = "2026.05.28"
 description = "Built-in AGILAB Mission Decision autonomous demo"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.26", "agi-node>=2026.05.26", "pandas>=2.3.0,<4", "pydantic>=2.11,<3"]
+dependencies = ["agi-env>=2026.05.28", "agi-node>=2026.05.28", "pandas>=2.3.0,<4", "pydantic>=2.11,<3"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/mycode_project/pyproject.toml
+++ b/src/agilab/apps/builtin/mycode_project/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "mycode_project"
-version = "2026.05.26"
+version = "2026.05.28"
 description = "Built-in AGILab example app template (minimal manager + worker)"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.26", "agi-node>=2026.05.26", "agi-cluster>=2026.05.26", "polars>=1.35,<2", "pydantic>=2.11,<3", "streamlit>=1.56,<1.57"]
+dependencies = ["agi-env>=2026.05.28", "agi-node>=2026.05.28", "agi-cluster>=2026.05.28", "polars>=1.35,<2", "pydantic>=2.11,<3", "streamlit>=1.56,<1.57"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/mycode_project/src/mycode_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/mycode_project/src/mycode_worker/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "mycode_project"
-version = "2026.05.26"
+version = "2026.05.28"
 description = "Built-in AGILab example app template (minimal manager + worker)"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.26", "agi-node>=2026.05.26", "polars>=1.35,<2", "pydantic>=2.11,<3"]
+dependencies = ["agi-env>=2026.05.28", "agi-node>=2026.05.28", "polars>=1.35,<2", "pydantic>=2.11,<3"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/pytorch_playground_project/pyproject.toml
+++ b/src/agilab/apps/builtin/pytorch_playground_project/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "pytorch_playground_project"
-version = "2026.05.26"
+version = "2026.05.28"
 description = "Built-in AGILab app for reproducible PyTorch classifier playground experiments."
 readme = "README.md"
 requires-python = ">=3.12"
-dependencies = ["agi-env>=2026.05.26", "agi-node>=2026.05.26", "agi-cluster>=2026.05.26", "agi-gui>=2026.05.26", "numpy>=2.2,<3", "pandas>=2.3.0,<4", "plotly>=6.3.0,<7", "pydantic>=2.11,<3", "streamlit>=1.56,<1.57", "torch>=2.8.0,<3"]
+dependencies = ["agi-env>=2026.05.28", "agi-node>=2026.05.28", "agi-cluster>=2026.05.28", "agi-gui>=2026.05.28", "numpy>=2.2,<3", "pandas>=2.3.0,<4", "plotly>=6.3.0,<7", "pydantic>=2.11,<3", "streamlit>=1.56,<1.57", "torch>=2.8.0,<3"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground_worker/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "pytorch_playground_worker"
-version = "2026.05.26"
+version = "2026.05.28"
 description = "Worker package for the AGILAB PyTorch playground app"
 requires-python = ">=3.12"
-dependencies = ["agi-env>=2026.05.26", "agi-node>=2026.05.26", "numpy>=2.2,<3", "pandas>=2.3.0,<4", "pydantic>=2.11,<3", "torch>=2.8.0,<3"]
+dependencies = ["agi-env>=2026.05.28", "agi-node>=2026.05.28", "numpy>=2.2,<3", "pandas>=2.3.0,<4", "pydantic>=2.11,<3", "torch>=2.8.0,<3"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/r_stage_smoke_project/pyproject.toml
+++ b/src/agilab/apps/builtin/r_stage_smoke_project/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "r_stage_smoke_project"
-version = "2026.05.26"
+version = "2026.05.28"
 description = "Built-in AGILAB smoke app for Rscript JSON/artifact stage execution"
 readme = "README.md"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.26", "agi-node>=2026.05.26", "agi-cluster>=2026.05.26", "pandas>=2.3.0,<4", "pydantic>=2.11,<3", "streamlit>=1.56,<1.57"]
+dependencies = ["agi-env>=2026.05.28", "agi-node>=2026.05.28", "agi-cluster>=2026.05.28", "pandas>=2.3.0,<4", "pydantic>=2.11,<3", "streamlit>=1.56,<1.57"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/apps/builtin/r_stage_smoke_project/src/r_stage_smoke_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/r_stage_smoke_project/src/r_stage_smoke_worker/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "r_stage_smoke_project"
-version = "2026.05.26"
+version = "2026.05.28"
 description = "Worker package for the AGILAB R stage smoke app"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.26", "agi-node>=2026.05.26", "pandas>=2.3.0,<4", "pydantic>=2.11,<3"]
+dependencies = ["agi-env>=2026.05.28", "agi-node>=2026.05.28", "pandas>=2.3.0,<4", "pydantic>=2.11,<3"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/sklearn_pipeline_project/pyproject.toml
+++ b/src/agilab/apps/builtin/sklearn_pipeline_project/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "sklearn_pipeline_project"
-version = "2026.05.26"
+version = "2026.05.28"
 description = "Built-in AGILAB scikit-learn pipeline app with model, metrics, predictions, and evidence manifest"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.26", "agi-node>=2026.05.26", "agi-cluster>=2026.05.26", "joblib>=1.5,<2", "pandas>=2.3.0,<4", "pydantic>=2.11,<3", "scikit-learn>=1.7.2,<2", "streamlit>=1.56,<1.57"]
+dependencies = ["agi-env>=2026.05.28", "agi-node>=2026.05.28", "agi-cluster>=2026.05.28", "joblib>=1.5,<2", "pandas>=2.3.0,<4", "pydantic>=2.11,<3", "scikit-learn>=1.7.2,<2", "streamlit>=1.56,<1.57"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/apps/builtin/sklearn_pipeline_project/src/sklearn_pipeline_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/sklearn_pipeline_project/src/sklearn_pipeline_worker/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "sklearn_pipeline_worker"
-version = "2026.05.26"
+version = "2026.05.28"
 description = "Worker package for the AGILAB scikit-learn pipeline app"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.26", "agi-node>=2026.05.26", "joblib>=1.5,<2", "pandas>=2.3.0,<4", "pydantic>=2.11,<3", "scikit-learn>=1.7.2,<2"]
+dependencies = ["agi-env>=2026.05.28", "agi-node>=2026.05.28", "joblib>=1.5,<2", "pandas>=2.3.0,<4", "pydantic>=2.11,<3", "scikit-learn>=1.7.2,<2"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/tescia_diagnostic_project/pyproject.toml
+++ b/src/agilab/apps/builtin/tescia_diagnostic_project/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "tescia_diagnostic_project"
-version = "2026.05.26"
+version = "2026.05.28"
 description = "Built-in AGILAB TeSciA-style diagnostic reasoning example"
 requires-python = ">=3.13"
-dependencies = ["agi-env>=2026.05.26", "agi-node>=2026.05.26", "agi-cluster>=2026.05.26", "pandas>=2.3.0,<4", "pydantic>=2.11,<3", "streamlit>=1.56,<1.57"]
+dependencies = ["agi-env>=2026.05.28", "agi-node>=2026.05.28", "agi-cluster>=2026.05.28", "pandas>=2.3.0,<4", "pydantic>=2.11,<3", "streamlit>=1.56,<1.57"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/tescia_diagnostic_project/src/tescia_diagnostic_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/tescia_diagnostic_project/src/tescia_diagnostic_worker/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "tescia_diagnostic_project"
-version = "2026.05.26"
+version = "2026.05.28"
 description = "Built-in AGILAB TeSciA-style diagnostic reasoning example"
 requires-python = ">=3.13"
-dependencies = ["agi-env>=2026.05.26", "agi-node>=2026.05.26", "pandas>=2.3.0,<4", "pydantic>=2.11,<3"]
+dependencies = ["agi-env>=2026.05.28", "agi-node>=2026.05.28", "pandas>=2.3.0,<4", "pydantic>=2.11,<3"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/uav_queue_project/pyproject.toml
+++ b/src/agilab/apps/builtin/uav_queue_project/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "uav_queue_project"
-version = "2026.05.26"
+version = "2026.05.28"
 description = "Built-in AGILAB lightweight UAV relay queue example"
 requires-python = ">=3.13"
-dependencies = ["agi-env>=2026.05.26", "agi-node>=2026.05.26", "agi-cluster>=2026.05.26", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "pydantic>=2.11,<3", "simpy>=4.1,<5", "streamlit>=1.56,<1.57"]
+dependencies = ["agi-env>=2026.05.28", "agi-node>=2026.05.28", "agi-cluster>=2026.05.28", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "pydantic>=2.11,<3", "simpy>=4.1,<5", "streamlit>=1.56,<1.57"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/uav_queue_project/src/uav_queue_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/uav_queue_project/src/uav_queue_worker/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "uav_queue_project"
-version = "2026.05.26"
+version = "2026.05.28"
 description = "Built-in AGILAB lightweight UAV relay queue example"
 requires-python = ">=3.13"
-dependencies = ["agi-env>=2026.05.26", "agi-node>=2026.05.26", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "pydantic>=2.11,<3", "simpy>=4.1,<5"]
+dependencies = ["agi-env>=2026.05.28", "agi-node>=2026.05.28", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "pydantic>=2.11,<3", "simpy>=4.1,<5"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/uav_relay_queue_project/pyproject.toml
+++ b/src/agilab/apps/builtin/uav_relay_queue_project/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "uav_relay_queue_project"
-version = "2026.05.26"
+version = "2026.05.28"
 description = "Built-in AGILAB lightweight UAV relay queue example"
 requires-python = ">=3.13"
-dependencies = ["agi-env>=2026.05.26", "agi-node>=2026.05.26", "agi-cluster>=2026.05.26", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "pydantic>=2.11,<3", "simpy>=4.1,<5", "streamlit>=1.56,<1.57"]
+dependencies = ["agi-env>=2026.05.28", "agi-node>=2026.05.28", "agi-cluster>=2026.05.28", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "pydantic>=2.11,<3", "simpy>=4.1,<5", "streamlit>=1.56,<1.57"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/uav_relay_queue_project/src/uav_relay_queue_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/uav_relay_queue_project/src/uav_relay_queue_worker/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "uav_relay_queue_project"
-version = "2026.05.26"
+version = "2026.05.28"
 description = "Built-in AGILAB lightweight UAV relay queue example"
 requires-python = ">=3.13"
-dependencies = ["agi-env>=2026.05.26", "agi-node>=2026.05.26", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "pydantic>=2.11,<3", "simpy>=4.1,<5"]
+dependencies = ["agi-env>=2026.05.28", "agi-node>=2026.05.28", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "pydantic>=2.11,<3", "simpy>=4.1,<5"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/weather_forecast_project/pyproject.toml
+++ b/src/agilab/apps/builtin/weather_forecast_project/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "weather_forecast_project"
-version = "2026.05.26"
+version = "2026.05.28"
 description = "Built-in AGILab weather forecasting example migrated from notebooks"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.26", "agi-node>=2026.05.26", "agi-cluster>=2026.05.26", "pandas>=2.3.0,<4", "pydantic>=2.11,<3", "scikit-learn>=1.7.2,<2", "skforecast>=0.19,<0.20", "streamlit>=1.56,<1.57"]
+dependencies = ["agi-env>=2026.05.28", "agi-node>=2026.05.28", "agi-cluster>=2026.05.28", "pandas>=2.3.0,<4", "pydantic>=2.11,<3", "scikit-learn>=1.7.2,<2", "skforecast>=0.19,<0.20", "streamlit>=1.56,<1.57"]
 
 [tool.agilab]
 runtime_target = "weather_forecast"

--- a/src/agilab/apps/builtin/weather_forecast_project/src/weather_forecast_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/weather_forecast_project/src/weather_forecast_worker/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "weather_forecast_project"
-version = "2026.05.26"
+version = "2026.05.28"
 description = "Built-in AGILab weather forecasting example migrated from notebooks"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.26", "agi-node>=2026.05.26", "pandas>=2.3.0,<4", "pydantic>=2.11,<3", "scikit-learn>=1.7.2,<2", "skforecast>=0.19,<0.20"]
+dependencies = ["agi-env>=2026.05.28", "agi-node>=2026.05.28", "pandas>=2.3.0,<4", "pydantic>=2.11,<3", "scikit-learn>=1.7.2,<2", "skforecast>=0.19,<0.20"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }

--- a/src/agilab/core/agi-cluster/pyproject.toml
+++ b/src/agilab/core/agi-cluster/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.26"
+version = "2026.05.28"
 name = "agi-cluster"
 description = "Distributed cluster orchestration layer for AGILAB workers over local and SSH backends"
 requires-python = ">=3.11"
@@ -35,7 +35,7 @@ keywords = [
     "job-scheduling",
     "mlops",
 ]
-dependencies = ["agi-env==2026.05.26", "agi-node==2026.05.26", "asyncssh>=2.23,<3", "dask[distributed]>=2026.3,<2027.0", "humanize>=4.10,<5", "numpy>=2.2,<3", "packaging>=25,<27", "polars>=1.35,<2", "psutil>=7,<8", "scikit-learn>=1.7.2,<2", "tomlkit>=0.13,<1"]
+dependencies = ["agi-env==2026.05.28", "agi-node==2026.05.28", "asyncssh>=2.23,<3", "dask[distributed]>=2026.3,<2027.0", "humanize>=4.10,<5", "numpy>=2.2,<3", "packaging>=25,<27", "polars>=1.35,<2", "psutil>=7,<8", "scikit-learn>=1.7.2,<2", "tomlkit>=0.13,<1"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/core/agi-core/pyproject.toml
+++ b/src/agilab/core/agi-core/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.26"
+version = "2026.05.28"
 name = "agi-core"
 description = "Meta-package that installs and wires agi-env, agi-node, and agi-cluster together"
 readme = "README.md"
@@ -30,7 +30,7 @@ keywords = [
   "distributed-computing",
   "distributed-execution",
 ]
-dependencies = ["agi-env==2026.05.26", "agi-node==2026.05.26", "agi-cluster==2026.05.26"]
+dependencies = ["agi-env==2026.05.28", "agi-node==2026.05.28", "agi-cluster==2026.05.28"]
 
 [project.urls]
 Homepage = "https://github.com/ThalesGroup/agilab"

--- a/src/agilab/core/agi-env/pyproject.toml
+++ b/src/agilab/core/agi-env/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.26"
+version = "2026.05.28"
 name = "agi-env"
 description = "Environment bootstrap package for AGILAB with virtualenv, path, and runtime helpers"
 requires-python = ">=3.11"

--- a/src/agilab/core/agi-node/pyproject.toml
+++ b/src/agilab/core/agi-node/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.26"
+version = "2026.05.28"
 name = "agi-node"
 description = "Distributed worker orchestration and execution support library for AGILAB"
 requires-python = ">=3.11"
@@ -35,7 +35,7 @@ keywords = [
     "pandas",
     "polars",
 ]
-dependencies = ["agi-env==2026.05.26", "cython>=3.1,<4", "humanize>=4.10,<5", "numpy>=2.2,<3", "pandas>=2.3,<4", "parso>=0.8,<1", "polars>=1.35,<2", "psutil>=7,<8", "py7zr>=1.1,<2", "setuptools>=68,<82"]
+dependencies = ["agi-env==2026.05.28", "cython>=3.1,<4", "humanize>=4.10,<5", "numpy>=2.2,<3", "pandas>=2.3,<4", "parso>=0.8,<1", "polars>=1.35,<2", "psutil>=7,<8", "py7zr>=1.1,<2", "setuptools>=68,<82"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/lib/agi-app-flight-telemetry/pyproject.toml
+++ b/src/agilab/lib/agi-app-flight-telemetry/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.26"
+version = "2026.05.28"
 name = "agi-app-flight-telemetry"
 description = "AGILAB flight-telemetry ingestion demo with reusable dataframe and map-analysis outputs"
 requires-python = ">=3.11"

--- a/src/agilab/lib/agi-app-global-dag/pyproject.toml
+++ b/src/agilab/lib/agi-app-global-dag/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.26"
+version = "2026.05.28"
 name = "agi-app-global-dag"
 description = "AGILAB cross-app DAG preview showing artifact handoffs between demo projects"
 requires-python = ">=3.11"

--- a/src/agilab/lib/agi-app-mission-decision/pyproject.toml
+++ b/src/agilab/lib/agi-app-mission-decision/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.26"
+version = "2026.05.28"
 name = "agi-app-mission-decision"
 description = "Deterministic AGILAB mission-decision workflow with scenario scoring and evidence artifacts"
 requires-python = ">=3.11"

--- a/src/agilab/lib/agi-app-pandas-execution/pyproject.toml
+++ b/src/agilab/lib/agi-app-pandas-execution/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.26"
+version = "2026.05.28"
 name = "agi-app-pandas-execution"
 description = "AGILAB Pandas execution benchmark for deterministic worker and reducer validation"
 requires-python = ">=3.11"

--- a/src/agilab/lib/agi-app-polars-execution/pyproject.toml
+++ b/src/agilab/lib/agi-app-polars-execution/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.26"
+version = "2026.05.28"
 name = "agi-app-polars-execution"
 description = "AGILAB Polars execution benchmark for deterministic worker and reducer validation"
 requires-python = ">=3.11"

--- a/src/agilab/lib/agi-app-pytorch-playground/pyproject.toml
+++ b/src/agilab/lib/agi-app-pytorch-playground/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.26"
+version = "2026.05.28"
 name = "agi-app-pytorch-playground"
 description = "AGILAB PyTorch playground app for reproducible neural-network experiments"
 requires-python = ">=3.12"

--- a/src/agilab/lib/agi-app-sklearn-pipeline/pyproject.toml
+++ b/src/agilab/lib/agi-app-sklearn-pipeline/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.26"
+version = "2026.05.28"
 name = "agi-app-sklearn-pipeline"
 description = "AGILAB scikit-learn pipeline app with model, metrics, predictions, and evidence manifest"
 requires-python = ">=3.11"

--- a/src/agilab/lib/agi-app-tescia-diagnostic/pyproject.toml
+++ b/src/agilab/lib/agi-app-tescia-diagnostic/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.26"
+version = "2026.05.28"
 name = "agi-app-tescia-diagnostic"
 description = "AGILAB TeSciA-style diagnostic workflow with evidence scoring and regression-plan artifacts"
 requires-python = ">=3.13"

--- a/src/agilab/lib/agi-app-uav-queue-project/pyproject.toml
+++ b/src/agilab/lib/agi-app-uav-queue-project/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.26"
+version = "2026.05.28"
 name = "agi-app-uav-queue-project"
 description = "AGILAB UAV queue simulation demo with scenario evidence and network-map artifacts"
 requires-python = ">=3.13"

--- a/src/agilab/lib/agi-app-uav-relay-queue/pyproject.toml
+++ b/src/agilab/lib/agi-app-uav-relay-queue/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.26"
+version = "2026.05.28"
 name = "agi-app-uav-relay-queue"
 description = "AGILAB UAV relay queue simulation demo with routing, delay, and resilience artifacts"
 requires-python = ">=3.13"

--- a/src/agilab/lib/agi-app-weather-forecast/pyproject.toml
+++ b/src/agilab/lib/agi-app-weather-forecast/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.26"
+version = "2026.05.28"
 name = "agi-app-weather-forecast"
 description = "AGILAB weather-forecast notebook-migration demo with forecast analysis artifacts"
 requires-python = ">=3.11"

--- a/src/agilab/lib/agi-apps/pyproject.toml
+++ b/src/agilab/lib/agi-apps/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.26"
+version = "2026.05.28"
 name = "agi-apps"
 description = "AGILAB public app package umbrella and example assets"
 requires-python = ">=3.11"
@@ -31,7 +31,7 @@ keywords = [
     "workflow-orchestration",
 ]
 
-dependencies = ["agi-core==2026.05.26", "agi-app-mission-decision==2026.05.26", "agi-app-pandas-execution==2026.05.26", "agi-app-polars-execution==2026.05.26", "agi-app-flight-telemetry==2026.05.26", "agi-app-global-dag==2026.05.26", "agi-app-weather-forecast==2026.05.26", "agi-app-sklearn-pipeline==2026.05.26", "agi-app-pytorch-playground==2026.05.26; python_version >= '3.12'", "agi-app-tescia-diagnostic==2026.05.26; python_version >= '3.13'", "agi-app-uav-relay-queue==2026.05.26; python_version >= '3.13'"]
+dependencies = ["agi-core==2026.05.28", "agi-app-mission-decision==2026.05.28", "agi-app-pandas-execution==2026.05.28", "agi-app-polars-execution==2026.05.28", "agi-app-flight-telemetry==2026.05.28", "agi-app-global-dag==2026.05.28", "agi-app-weather-forecast==2026.05.28", "agi-app-sklearn-pipeline==2026.05.28", "agi-app-pytorch-playground==2026.05.28; python_version >= '3.12'", "agi-app-tescia-diagnostic==2026.05.28; python_version >= '3.13'", "agi-app-uav-relay-queue==2026.05.28; python_version >= '3.13'"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/lib/agi-gui/pyproject.toml
+++ b/src/agilab/lib/agi-gui/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.26"
+version = "2026.05.28"
 name = "agi-gui"
 description = "AGILAB Streamlit UI dependency bundle and compatibility imports"
 requires-python = ">=3.11"
@@ -32,7 +32,7 @@ keywords = [
     "python",
 ]
 
-dependencies = ["agi-env==2026.05.26", "streamlit>=1.56,<1.57", "streamlit_code_editor>=0.1.22,<0.2", "watchdog>=6,<7"]
+dependencies = ["agi-env==2026.05.28", "streamlit>=1.56,<1.57", "streamlit_code_editor>=0.1.22,<0.2", "watchdog>=6,<7"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/lib/agi-pages/pyproject.toml
+++ b/src/agilab/lib/agi-pages/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.26"
+version = "2026.05.28"
 name = "agi-pages"
 description = "AGILAB public analysis page umbrella and provider package"
 requires-python = ">=3.11"
@@ -34,7 +34,7 @@ keywords = [
     "page-bundles",
 ]
 
-dependencies = ["agi-gui==2026.05.26"]
+dependencies = ["agi-gui==2026.05.28"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"


### PR DESCRIPTION
## Summary
- bump AGILAB package metadata to 2026.05.28 across publishable projects
- keep public release-proof metadata on the current published release; the release workflow updates it after publish/HF sync

## Validation
- ./dev release
