### PR TITLE
[codex] Mark removed AGILAB teaser uploads

### DIFF
--- a/artifacts/demo_media/flight/agilab_flight_youtube_pack.md
+++ b/artifacts/demo_media/flight/agilab_flight_youtube_pack.md
@@ -6,8 +6,8 @@
 - GIF preview: `artifacts/demo_media/flight/agilab_flight.gif`
 - Poster: `artifacts/demo_media/flight/agilab_flight_poster.png`
 - YouTube public URL: https://youtu.be/BsBjRSAXJZA
-- Previous audio upload: https://youtu.be/KsBe8lIahH4
-- Previous silent upload: https://youtu.be/c4aogHDh4do
+- Removed previous audio upload: https://youtu.be/KsBe8lIahH4
+- Removed previous silent upload: https://youtu.be/c4aogHDh4do
 - YouTube Studio URL: https://studio.youtube.com/video/BsBjRSAXJZA
 - Duration: 15.47 seconds
 - Format: 1920x1080, 30 fps, premium H.264 video + stereo AAC audio MP4


### PR DESCRIPTION
## What changed

- Marks the former AGILAB teaser YouTube uploads as removed in the upload pack.
- Keeps the current premium public URL as the active video.

## Why

The previous YouTube uploads were deleted, so the repo metadata should not present them as active previous uploads.

## Checks

- Metadata-only update.
