### PR TITLE
[codex] Clarify release proof badge scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p>
   <a href="https://pypi.org/project/agilab/"><img src="https://raw.githubusercontent.com/ThalesGroup/agilab/main/badges/pypi-version-agilab.svg" alt="PyPI version" /></a>
-  <a href="https://thalesgroup.github.io/agilab/release-proof.html"><img src="https://img.shields.io/badge/version%20alignment-release%20proof-0F766E" alt="Version alignment release proof" /></a>
+  <a href="https://thalesgroup.github.io/agilab/release-proof.html"><img src="https://img.shields.io/badge/release%20proof-latest%20proven%20release-0F766E" alt="Latest proven release proof" /></a>
   <a href="https://thalesgroup.github.io/agilab/release-proof.html"><img src="https://img.shields.io/badge/supply%20chain-SBOM%20%2B%20audit%20%2B%20provenance-0F766E" alt="Supply chain: SBOM, audit, provenance" /></a>
   <a href="https://thalesgroup.github.io/agilab/release-proof.html"><img src="https://img.shields.io/badge/first%20proof-passing-0F766E" alt="First proof: passing" /></a>
   <a href="https://opensource.org/licenses/BSD-3-Clause"><img src="https://img.shields.io/badge/License-BSD%203--Clause-blue.svg" alt="License: BSD 3-Clause" /></a>

--- a/README.pypi.md
+++ b/README.pypi.md
@@ -1,5 +1,5 @@
 [![PyPI version](https://img.shields.io/pypi/v/agilab.svg?cacheSeconds=300)](https://pypi.org/project/agilab/)
-[![Version alignment](https://img.shields.io/badge/version%20alignment-release%20proof-0F766E)](https://thalesgroup.github.io/agilab/release-proof.html)
+[![Latest proven release](https://img.shields.io/badge/release%20proof-latest%20proven%20release-0F766E)](https://thalesgroup.github.io/agilab/release-proof.html)
 [![Supply chain: SBOM, audit, provenance](https://img.shields.io/badge/supply%20chain-SBOM%20%2B%20audit%20%2B%20provenance-0F766E)](https://thalesgroup.github.io/agilab/release-proof.html)
 [![First proof: passing](https://img.shields.io/badge/first%20proof-passing-0F766E)](https://thalesgroup.github.io/agilab/release-proof.html)
 [![Supported Python Versions](https://img.shields.io/pypi/pyversions/agilab.svg)](https://pypi.org/project/agilab/)

--- a/test/test_public_demo_links.py
+++ b/test/test_public_demo_links.py
@@ -205,7 +205,7 @@ def test_pypi_readme_tracks_public_readme_contract() -> None:
     assert pypi_readme.count("agilab[ui]") == 1
 
 
-def test_source_package_version_contract_is_explicit_and_current() -> None:
+def test_source_package_version_contract_is_explicit_and_proven_release_scoped() -> None:
     readme = README.read_text(encoding="utf-8")
     pypi_readme = PYPI_README.read_text(encoding="utf-8")
     pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
@@ -223,13 +223,15 @@ def test_source_package_version_contract_is_explicit_and_current() -> None:
     agi_apps_version = agi_apps_pyproject["project"]["version"]
     optional_dependencies = pyproject["project"]["optional-dependencies"]
 
-    assert Version(source_version) == Version(package_version)
+    assert Version(package_version) <= Version(source_version)
     assert Version(core_version) <= Version(source_version)
     assert Version(agi_apps_version) <= Version(source_version)
     assert f"agi-apps=={agi_apps_version}" in optional_dependencies["ui"]
     assert f"agi-apps=={agi_apps_version}" in optional_dependencies["examples"]
-    assert "version%20alignment-release%20proof" in readme
-    assert "version%20alignment-release%20proof" in pypi_readme
+    assert "release%20proof-latest%20proven%20release" in readme
+    assert "release%20proof-latest%20proven%20release" in pypi_readme
+    assert "version%20alignment-release%20proof" not in readme
+    assert "version%20alignment-release%20proof" not in pypi_readme
     assert "main` branch and root `pyproject.toml" in readme
     assert "main` branch and root `pyproject.toml" in pypi_readme
     assert "release tag, PyPI package version, docs, CI, coverage, and demo proof" in readme


### PR DESCRIPTION
## What changed

- Renames the README and PyPI README badge from `version alignment / release proof` to `release proof / latest proven release`.
- Updates the public-demo-link regression to match the documented source-vs-release contract.
- Keeps the guard aligned with `tools/release_proof_report.py`: the release proof package version must not be newer than the active source version, but `main` can move ahead before the next proof refresh.

## Why

The old badge wording was too absolute once `main` and PyPI moved to `2026.05.28` while the checked-in release proof still records the last fully proven release, `2026.05.26`.

## Checks

- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_public_demo_links.py -k source_package_version_contract`
- `uv --preview-features extra-build-dependencies run python tools/release_proof_report.py --check --compact`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files README.md README.pypi.md test/test_public_demo_links.py`
