### PR TITLE
docs: add parallel stage preview excerpt

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 228,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "85d3bba9d8eac64c1c4e8f1b3a4fbe2ad5436afc7ac33a2daf924c71cda6ce55",
+  "source_digest_sha256": "96293f08da18151e69913c1dffe33df33d4da703dbb3386464dc184b178a1c45",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "85d3bba9d8eac64c1c4e8f1b3a4fbe2ad5436afc7ac33a2daf924c71cda6ce55"
+  "target_digest_sha256": "96293f08da18151e69913c1dffe33df33d4da703dbb3386464dc184b178a1c45"
 }

--- a/docs/source/parallel-stages.rst
+++ b/docs/source/parallel-stages.rst
@@ -117,6 +117,21 @@ compares two policies on three files and eight available cores:
   partitions.
 - unsplittable small files cap useful workers to three.
 
+The important part of the preview is small enough to scan in a terminal:
+
+.. code-block:: text
+
+   input_files: 3
+   available_cores: 8
+   splittable_large_files:
+     effective_workers: 8
+     planned_partitions: 64
+   unsplittable_small_files:
+     effective_workers: 3
+     planned_partitions: 3
+
+That is the core rule: parallelize partitions, not raw file count.
+
 Recommended sequence
 --------------------
 

--- a/src/agilab/examples/parallel_stage/README.md
+++ b/src/agilab/examples/parallel_stage/README.md
@@ -72,6 +72,21 @@ The JSON contains two policy outcomes:
 - `unsplittable_small_files`: caps useful workers to three because only three
   independent units exist.
 
+The key preview values are:
+
+```text
+input_files: 3
+available_cores: 8
+splittable_large_files:
+  effective_workers: 8
+  planned_partitions: 64
+unsplittable_small_files:
+  effective_workers: 3
+  planned_partitions: 3
+```
+
+That is the core rule: parallelize partitions, not raw file count.
+
 ## Read The Script
 
 Open `preview_parallel_stage.py` and look for these functions first:


### PR DESCRIPTION
Closes #239.\n\n## Summary\n- Add a scan-friendly terminal excerpt to the parallel-stage docs showing 3 input files, 8 cores, 64 splittable partitions, and 3 useful workers for unsplittable files.\n- Mirror the same teaching excerpt in the packaged parallel-stage example README.\n- Refresh the docs source mirror stamp from canonical docs.\n\n## Validation\n- uv --preview-features extra-build-dependencies run python src/agilab/examples/parallel_stage/preview_parallel_stage.py --no-output\n- uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp\n- uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files docs/.docs_source_mirror_stamp.json docs/source/parallel-stages.rst src/agilab/examples/parallel_stage/README.md\n- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs\n\nNote: docs profile passed with the existing non-fatal Sphinx autodoc warning for agi_gui import in the isolated worktree.