### PR TITLE
docs: backfill release feature changelog notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,31 +50,78 @@ publication, or evidence refreshes on an already published date version.
 
 GitHub Release: https://github.com/ThalesGroup/agilab/releases/tag/v2026.05.28
 
+### Added
+
+- Added an Evidence Cockpit run-review surface for inspecting evidence-backed
+  run and proof context.
+- Added app-contract and robustness matrix guard tooling so app/package/catalog
+  contracts and P0 robustness scenarios can be checked explicitly.
+- Added the packaged parallel-stage planning example and docs for reviewing
+  partition/reducer contracts before moving from local execution to pool or
+  Dask-style workers.
+- Added AGILAB flight teaser media and release collateral for the public demo
+  path.
+
 ### Changed
 
 - Published AGILAB `2026.05.28` to PyPI for `agi-env`, `agi-gui`, `agi-page-app-ui`, `agi-page-simplex-map`, `agi-page-decision-evidence`, `agi-page-timeseries-forecast`, `agi-page-inference-report`, `agi-page-live-artifacts`, `agi-page-geospatial-map`, `agi-page-geospatial-3d`, `agi-page-network-map`, `agi-page-queue-health`, `agi-page-relay-health`, `agi-page-scenario-cockpit`, `agi-page-promotion-gate`, `agi-page-feature-attribution`, `agi-page-training-report`, `agi-pages`, `agi-node`, `agi-cluster`, `agi-core`, `agi-app-mission-decision`, `agi-app-pandas-execution`, `agi-app-polars-execution`, `agi-app-flight-telemetry`, `agi-app-global-dag`, `agi-app-weather-forecast`, `agi-app-sklearn-pipeline`, `agi-app-pytorch-playground`, `agi-app-tescia-diagnostic`, `agi-app-uav-relay-queue`, `agi-apps`, and `agilab`.
 - Updated release metadata so public docs, changelog, PyPI, and GitHub Releases point to the same source tag.
 - Kept release automation active so future PyPI publishes create or update the matching GitHub Release after pushing the tag.
+- Hardened fresh public install smoke coverage by ensuring UI extras are
+  installed for clean-install validation.
+- Optimized release automation so already-published PyPI packages can be
+  skipped while package contracts, release assets, and retention handling remain
+  guarded.
 
 ## [2026.05.26] - 2026-05-26
 
 GitHub Release: https://github.com/ThalesGroup/agilab/releases/tag/v2026.05.26
+
+### Added
+
+- Added the promoted sklearn pipeline proof example and packaged app path.
+- Added a notebook sandbox bridge and notebook demo helpers for safer
+  notebook-to-AGILAB handoff flows.
+- Added audience bridge MVPs and roadmap documentation for Quarto/R, Excel,
+  notebook, and evidence-oriented adopter paths.
+- Added an R stage smoke app to validate R as an external stage runtime rather
+  than a separate worker architecture.
+- Added environment health diagnostics and clearer first-run security intake
+  guidance.
 
 ### Changed
 
 - Published AGILAB `2026.05.26` to PyPI for `agi-env`, `agi-gui`, `agi-page-app-ui`, `agi-page-simplex-map`, `agi-page-decision-evidence`, `agi-page-timeseries-forecast`, `agi-page-inference-report`, `agi-page-live-artifacts`, `agi-page-geospatial-map`, `agi-page-geospatial-3d`, `agi-page-network-map`, `agi-page-queue-health`, `agi-page-relay-health`, `agi-page-scenario-cockpit`, `agi-page-promotion-gate`, `agi-page-feature-attribution`, `agi-page-training-report`, `agi-pages`, `agi-node`, `agi-cluster`, `agi-core`, `agi-app-mission-decision`, `agi-app-pandas-execution`, `agi-app-polars-execution`, `agi-app-flight-telemetry`, `agi-app-global-dag`, `agi-app-weather-forecast`, `agi-app-sklearn-pipeline`, `agi-app-pytorch-playground`, `agi-app-tescia-diagnostic`, `agi-app-uav-relay-queue`, `agi-apps`, and `agilab`.
 - Updated release metadata so public docs, changelog, PyPI, and GitHub Releases point to the same source tag.
 - Kept release automation active so future PyPI publishes create or update the matching GitHub Release after pushing the tag.
+- Hardened static audit boundaries, dependency policy release gates, and
+  release-readiness checks around PyPI retention and stale release metadata.
 
 ## [2026.05.25] - 2026-05-25
 
 GitHub Release: https://github.com/ThalesGroup/agilab/releases/tag/v2026.05.25
+
+### Added
+
+- Added a Kubernetes Job preview command (`agilab kubernetes-job`) that
+  generates deterministic `batch/v1` Job manifests for running packaged AGILAB
+  commands in an existing Kubernetes cluster.
+- Added proof-capsule archive and signing contract support for stronger
+  evidence handoff experiments.
+- Added Voila notebook and Excel workbook proof bridges for notebook-first and
+  spreadsheet-first adopters.
+- Added a SQLite connector proof example and public demo route clarification.
+- Added TeSciA classroom intake/progress flows and live-mode coverage.
+- Added a pandas Cython speedup reference for execution-mode comparison docs.
 
 ### Changed
 
 - Published AGILAB `2026.05.25` to PyPI for `agi-env`, `agi-gui`, `agi-page-app-ui`, `agi-page-simplex-map`, `agi-page-decision-evidence`, `agi-page-timeseries-forecast`, `agi-page-inference-report`, `agi-page-live-artifacts`, `agi-page-geospatial-map`, `agi-page-geospatial-3d`, `agi-page-network-map`, `agi-page-queue-health`, `agi-page-relay-health`, `agi-page-scenario-cockpit`, `agi-page-promotion-gate`, `agi-page-feature-attribution`, `agi-page-training-report`, `agi-pages`, `agi-node`, `agi-cluster`, `agi-core`, `agi-app-mission-decision`, `agi-app-pandas-execution`, `agi-app-polars-execution`, `agi-app-flight-telemetry`, `agi-app-global-dag`, `agi-app-weather-forecast`, `agi-app-pytorch-playground`, `agi-app-tescia-diagnostic`, `agi-app-uav-relay-queue`, `agi-apps`, and `agilab`.
 - Updated release metadata so public docs, changelog, PyPI, and GitHub Releases point to the same source tag.
 - Kept release automation active so future PyPI publishes create or update the matching GitHub Release after pushing the tag.
+- Hardened apps/pages runtime validation, agent capability boundaries, evidence
+  safety, payload dependency bounds, robot UI coverage, and stale trace-lock
+  cleanup.
 
 ## [2026.05.23] - 2026-05-23
 


### PR DESCRIPTION
## Summary\n- Backfill missing user-facing feature notes for the 2026.05.25, 2026.05.26, and 2026.05.28 release entries.\n- Add the Kubernetes Job preview to the 2026.05.25 changelog entry.\n- Keep publication/proof bullets intact while making the release history more useful to adopters.\n\n## Validation\n- uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files CHANGELOG.md\n- git diff --check -- CHANGELOG.md