### PR TITLE
perf(ui): cache PROJECT editor resources

### DIFF
--- a/src/agilab/pages/1_PROJECT.py
+++ b/src/agilab/pages/1_PROJECT.py
@@ -28,6 +28,7 @@ import re
 import importlib.util
 import sys
 from types import SimpleNamespace
+from typing import Any
 
 os.environ.setdefault(
     "STREAMLIT_CONFIG_FILE",
@@ -1356,6 +1357,43 @@ def read_gitignore(gitignore_path):
         patterns = []
 
     return GitIgnoreSpec.from_lines(patterns)
+
+
+_PROJECT_EDITOR_RESOURCE_FILES = (
+    "custom_buttons.json",
+    "info_bar.json",
+    "code_editor.scss",
+)
+
+
+def _project_editor_resource_fingerprint(
+    resources_path: str | Path,
+) -> tuple[tuple[str, int, int], ...]:
+    """Return a lightweight invalidation key for static PROJECT editor resources."""
+
+    resources_root = Path(resources_path)
+    fingerprints: list[tuple[str, int, int]] = []
+    for filename in _PROJECT_EDITOR_RESOURCE_FILES:
+        stat = (resources_root / filename).stat()
+        fingerprints.append((filename, stat.st_mtime_ns, stat.st_size))
+    return tuple(fingerprints)
+
+
+@st.cache_data(show_spinner=False)
+def _load_project_editor_resources(
+    resources_path: str,
+    resource_fingerprint: tuple[tuple[str, int, int], ...],
+) -> tuple[list[Any], Any, str]:
+    """Load static PROJECT editor resources once per file version."""
+
+    del resource_fingerprint
+    resources_root = Path(resources_path)
+    with (resources_root / "custom_buttons.json").open(encoding="utf-8") as f:
+        custom_buttons = normalize_custom_buttons(json.load(f))
+    with (resources_root / "info_bar.json").open(encoding="utf-8") as f:
+        info_bar = json.load(f)
+    css_text = (resources_root / "code_editor.scss").read_text(encoding="utf-8")
+    return custom_buttons, info_bar, css_text
 
 
 # -------------------- Project Cleaner -------------------- #
@@ -4616,12 +4654,10 @@ def page():
     # Load .agi_resources
 
     try:
-        with open(env.st_resources / "custom_buttons.json") as f:
-            CUSTOM_BUTTONS = normalize_custom_buttons(json.load(f))
-        with open(env.st_resources / "info_bar.json") as f:
-            INFO_BAR = json.load(f)
-        with open(env.st_resources / "code_editor.scss") as f:
-            CSS_TEXT = f.read()
+        CUSTOM_BUTTONS, INFO_BAR, CSS_TEXT = _load_project_editor_resources(
+            str(env.st_resources),
+            _project_editor_resource_fingerprint(env.st_resources),
+        )
     except FileNotFoundError as e:
         st.error(f"Resource file not found: {e}")
         return

--- a/test/test_project_clone_policy.py
+++ b/test/test_project_clone_policy.py
@@ -72,6 +72,76 @@ def _extract_toolbar_buttons(payload):
     return buttons
 
 
+def _write_project_editor_resources(
+    resources: Path,
+    *,
+    button_name: str = "Copy",
+    info_name: str = "python",
+    css_text: str = ".editor { color: #111; }\n",
+) -> None:
+    resources.mkdir(parents=True, exist_ok=True)
+    (resources / "custom_buttons.json").write_text(
+        json.dumps({"buttons": [{"name": button_name}]}),
+        encoding="utf-8",
+    )
+    (resources / "info_bar.json").write_text(
+        json.dumps({"info": [{"name": info_name}]}),
+        encoding="utf-8",
+    )
+    (resources / "code_editor.scss").write_text(css_text, encoding="utf-8")
+
+
+def test_project_editor_resources_cache_invalidates_when_resource_files_change(
+    tmp_path: Path,
+):
+    module = _load_project_module()
+    resources = tmp_path / "resources"
+    _write_project_editor_resources(resources, button_name="Copy")
+    module._load_project_editor_resources.clear()
+
+    first_fingerprint = module._project_editor_resource_fingerprint(resources)
+    first_buttons, first_info_bar, first_css = module._load_project_editor_resources(
+        str(resources),
+        first_fingerprint,
+    )
+
+    assert first_buttons == [{"name": "Copy"}]
+    assert first_info_bar == {"info": [{"name": "python"}]}
+    assert first_css == ".editor { color: #111; }\n"
+
+    _write_project_editor_resources(
+        resources,
+        button_name="Run",
+        css_text=".editor { color: #222; }\n",
+    )
+    future_mtime = max(item[1] for item in first_fingerprint) + 1_000_000_000
+    os.utime(resources / "custom_buttons.json", ns=(future_mtime, future_mtime))
+    os.utime(resources / "code_editor.scss", ns=(future_mtime, future_mtime))
+
+    second_fingerprint = module._project_editor_resource_fingerprint(resources)
+    second_buttons, second_info_bar, second_css = module._load_project_editor_resources(
+        str(resources),
+        second_fingerprint,
+    )
+
+    assert second_fingerprint != first_fingerprint
+    assert second_buttons == [{"name": "Run"}]
+    assert second_info_bar == first_info_bar
+    assert second_css == ".editor { color: #222; }\n"
+
+
+def test_project_editor_resource_fingerprint_reports_missing_static_file(
+    tmp_path: Path,
+):
+    module = _load_project_module()
+    resources = tmp_path / "resources"
+    _write_project_editor_resources(resources)
+    (resources / "code_editor.scss").unlink()
+
+    with pytest.raises(FileNotFoundError, match="code_editor\\.scss"):
+        module._project_editor_resource_fingerprint(resources)
+
+
 def test_finalize_cloned_project_environment_detaches_shared_venv(tmp_path: Path):
     module = _load_project_module()
     source_root = tmp_path / "source_project"


### PR DESCRIPTION
## Summary

Caches static PROJECT editor resources so PROJECT page reruns no longer reread `custom_buttons.json`, `info_bar.json`, and `code_editor.scss` every time.

## Why

This is the first safe Streamlit acceleration slice. The PROJECT page was doing repeated static resource I/O during reruns even though these files only change when the packaged UI resources change.

## Details

- Adds a lightweight mtime/size fingerprint for PROJECT editor resource files.
- Loads the editor resource bundle through `st.cache_data`.
- Keeps invalidation explicit when any resource file changes.
- Adds focused regressions for cache invalidation and missing resource reporting.

## Validation

```bash
uv --preview-features extra-build-dependencies run --extra ui pytest -q -o addopts='' test/test_project_clone_policy.py -k project_editor_resource
```

Result: `2 passed, 80 deselected`.
