### PR TITLE
[codex] Fix Scenario Cockpit app-scoped state

### DIFF
--- a/src/agilab/apps-pages/view_scenario_cockpit/src/view_scenario_cockpit/view_scenario_cockpit.py
+++ b/src/agilab/apps-pages/view_scenario_cockpit/src/view_scenario_cockpit/view_scenario_cockpit.py
@@ -33,6 +33,14 @@ BASELINE_RUN_KEY = "scenario_cockpit_baseline_run"
 CANDIDATE_RUN_KEY = "scenario_cockpit_candidate_run"
 DATA_DIR_KEY = "scenario_cockpit_datadir"
 SUMMARY_GLOB_KEY = "scenario_cockpit_summary_glob"
+APP_SCOPE_KEY = "scenario_cockpit_active_app_scope"
+APP_SCOPED_SESSION_DEFAULT_KEYS = (
+    RUN_SELECTION_KEY,
+    BASELINE_RUN_KEY,
+    CANDIDATE_RUN_KEY,
+    DATA_DIR_KEY,
+    SUMMARY_GLOB_KEY,
+)
 
 def _load_page_meta() -> tuple[str, str]:
     if __package__:
@@ -78,6 +86,18 @@ def _default_artifact_root(env: AgiEnv) -> Path:
     return _page_artifact_root(env, "queue_analysis")
 
 
+def _reset_app_scoped_session_defaults(active_app_path: Path) -> bool:
+    """Clear persisted widget defaults when Scenario Cockpit switches apps."""
+
+    app_scope = str(active_app_path.resolve())
+    if st.session_state.get(APP_SCOPE_KEY) == app_scope:
+        return False
+    for key in APP_SCOPED_SESSION_DEFAULT_KEYS:
+        st.session_state.pop(key, None)
+    st.session_state[APP_SCOPE_KEY] = app_scope
+    return True
+
+
 def _coerce_selection(saved_value: Any, options: list[str], *, fallback: list[str] | None = None) -> list[str]:
     if isinstance(saved_value, str):
         candidates = [saved_value]
@@ -121,8 +141,9 @@ _build_evidence_bundle = _evidence_helpers.build_evidence_bundle
 
 st.set_page_config(layout="wide")
 
-if "env" not in st.session_state:
-    active_app_path = _resolve_active_app()
+active_app_path = _resolve_active_app()
+app_scope_changed = _reset_app_scoped_session_defaults(active_app_path)
+if "env" not in st.session_state or app_scope_changed:
     env = AgiEnv(apps_path=active_app_path.parent, app=active_app_path.name, verbose=0)
     env.init_done = True
     st.session_state["env"] = env

--- a/test/test_view_scenario_cockpit.py
+++ b/test/test_view_scenario_cockpit.py
@@ -205,6 +205,32 @@ def test_view_scenario_cockpit_helper_edge_cases(monkeypatch, tmp_path) -> None:
     assert module._safe_metric("bad") == "n/a"
 
 
+def test_scenario_cockpit_resets_app_scoped_state_on_active_app_change(tmp_path) -> None:
+    module = _load_helpers()
+    first_app = tmp_path / "first_app"
+    second_app = tmp_path / "second_app"
+    first_app.mkdir()
+    second_app.mkdir()
+    module.st = SimpleNamespace(
+        session_state={
+            module.APP_SCOPE_KEY: str(first_app.resolve()),
+            module.RUN_SELECTION_KEY: ["old-run"],
+            module.BASELINE_RUN_KEY: "old-baseline",
+            module.CANDIDATE_RUN_KEY: "old-candidate",
+            module.DATA_DIR_KEY: "/tmp/old-artifacts",
+            module.SUMMARY_GLOB_KEY: "*old.json",
+        }
+    )
+
+    assert module._reset_app_scoped_session_defaults(first_app) is False
+    assert module.RUN_SELECTION_KEY in module.st.session_state
+
+    assert module._reset_app_scoped_session_defaults(second_app) is True
+    assert module.st.session_state[module.APP_SCOPE_KEY] == str(second_app.resolve())
+    for key in module.APP_SCOPED_SESSION_DEFAULT_KEYS:
+        assert key not in module.st.session_state
+
+
 def test_scenario_cockpit_evidence_edge_cases(tmp_path) -> None:
     module = _load_helpers()
 


### PR DESCRIPTION
## Summary
- reset Scenario Cockpit run-selection and artifact widgets when the active app path changes
- rebuild the page-local `AgiEnv` when `--active-app` changes instead of reusing a stale session env
- add a focused regression for app-scoped session reset

## Why
Scenario Cockpit persisted artifact directory, summary glob, run selection, baseline, and candidate under global Streamlit keys. In a warm session, switching apps could reuse stale choices and stale env state from the previous app.

## Validation
- not run locally; pre-push classified docs mirror, release proof, and app-contract inputs as unchanged
