### PR TITLE
[codex] Fix Queue Resilience app-scoped state

### DIFF
--- a/src/agilab/apps-pages/view_queue_resilience/src/view_queue_resilience/view_queue_resilience.py
+++ b/src/agilab/apps-pages/view_queue_resilience/src/view_queue_resilience/view_queue_resilience.py
@@ -30,6 +30,15 @@ from agi_env import AgiEnv
 from agi_gui.pagelib import render_logo
 
 
+DATA_DIR_KEY = "queue_resilience_datadir"
+SUMMARY_GLOB_KEY = "queue_resilience_summary_glob"
+APP_SCOPE_KEY = "queue_resilience_active_app_scope"
+APP_SCOPED_SESSION_DEFAULT_KEYS = (
+    DATA_DIR_KEY,
+    SUMMARY_GLOB_KEY,
+)
+
+
 def _load_page_meta() -> tuple[str, str]:
     if __package__:
         from .page_meta import PAGE_LOGO, PAGE_TITLE
@@ -60,6 +69,18 @@ def _discover_files(base: Path, pattern: str) -> list[Path]:
     return _page_discover_files(base, pattern)
 
 
+def _reset_app_scoped_session_defaults(active_app_path: Path) -> bool:
+    """Clear persisted Queue Resilience defaults when the active app changes."""
+
+    app_scope = str(active_app_path.resolve())
+    if st.session_state.get(APP_SCOPE_KEY) == app_scope:
+        return False
+    for key in APP_SCOPED_SESSION_DEFAULT_KEYS:
+        st.session_state.pop(key, None)
+    st.session_state[APP_SCOPE_KEY] = app_scope
+    return True
+
+
 def _load_json(path: Path) -> dict[str, Any]:
     return json.loads(path.read_text(encoding="utf-8"))
 
@@ -75,8 +96,9 @@ def _safe_metric(value: Any) -> str:
 
 st.set_page_config(layout="wide")
 
-if "env" not in st.session_state:
-    active_app_path = _resolve_active_app()
+active_app_path = _resolve_active_app()
+app_scope_changed = _reset_app_scoped_session_defaults(active_app_path)
+if "env" not in st.session_state or app_scope_changed:
     env = AgiEnv(apps_path=active_app_path.parent, app=active_app_path.name, verbose=0)
     env.init_done = True
     st.session_state["env"] = env
@@ -96,17 +118,17 @@ st.info(
 )
 
 default_root = _default_artifact_root(env)
-st.session_state.setdefault("queue_resilience_datadir", str(default_root))
+st.session_state.setdefault(DATA_DIR_KEY, str(default_root))
 artifact_root_value = st.sidebar.text_input(
     "Artifact directory",
-    key="queue_resilience_datadir",
+    key=DATA_DIR_KEY,
 )
 artifact_root = Path(artifact_root_value).expanduser()
 
-st.session_state.setdefault("queue_resilience_summary_glob", "**/*_summary_metrics.json")
+st.session_state.setdefault(SUMMARY_GLOB_KEY, "**/*_summary_metrics.json")
 metrics_pattern = st.sidebar.text_input(
     "Summary glob",
-    key="queue_resilience_summary_glob",
+    key=SUMMARY_GLOB_KEY,
 )
 
 summary_files = _discover_files(artifact_root, metrics_pattern) if artifact_root.exists() else []

--- a/test/test_view_queue_resilience.py
+++ b/test/test_view_queue_resilience.py
@@ -269,6 +269,29 @@ def test_view_queue_resilience_package_meta_and_discover_exception(monkeypatch, 
     assert module._discover_files(broken_base, "*.json") == []
 
 
+def test_view_queue_resilience_resets_app_scoped_state_on_active_app_change(tmp_path) -> None:
+    module = _load_queue_helpers()
+    first_app = tmp_path / "first_app"
+    second_app = tmp_path / "second_app"
+    first_app.mkdir()
+    second_app.mkdir()
+    module.st = SimpleNamespace(
+        session_state={
+            module.APP_SCOPE_KEY: str(first_app.resolve()),
+            module.DATA_DIR_KEY: "/tmp/old-artifacts",
+            module.SUMMARY_GLOB_KEY: "*old.json",
+        }
+    )
+
+    assert module._reset_app_scoped_session_defaults(first_app) is False
+    assert module.DATA_DIR_KEY in module.st.session_state
+
+    assert module._reset_app_scoped_session_defaults(second_app) is True
+    assert module.st.session_state[module.APP_SCOPE_KEY] == str(second_app.resolve())
+    for key in module.APP_SCOPED_SESSION_DEFAULT_KEYS:
+        assert key not in module.st.session_state
+
+
 def test_view_queue_resilience_reuses_existing_session_env(tmp_path, create_temp_app_project, monkeypatch) -> None:
     project_dir = create_temp_app_project(
         "uav_queue_project",
@@ -308,6 +331,7 @@ def test_view_queue_resilience_reuses_existing_session_env(tmp_path, create_temp
             target="uav_queue",
             st_resources=tmp_path / "resources",
         )
+        at.session_state["queue_resilience_active_app_scope"] = str(project_dir.resolve())
         at.run()
 
     assert not at.exception


### PR DESCRIPTION
## Summary
- reset Queue Resilience artifact-directory and summary-glob widgets when the active app path changes
- rebuild the page-local `AgiEnv` when `--active-app` changes instead of reusing stale session state
- add a focused regression for app-scoped session reset while preserving same-app session env reuse

## Why
Queue Resilience persisted app-specific Streamlit widget values under global keys. In a warm session, switching apps could point the page at artifacts from the previous app.

## Validation
- not run locally; pre-push classified docs mirror, release proof, and app-contract inputs as unchanged
