### PR TITLE
[codex] Fix Maps Network app-scoped state

### DIFF
--- a/src/agilab/apps-pages/view_maps_network/src/view_maps_network/view_maps_network.py
+++ b/src/agilab/apps-pages/view_maps_network/src/view_maps_network/view_maps_network.py
@@ -160,6 +160,96 @@ def _active_app_context_from_env(env: Any) -> tuple[str, Path]:
     return app_name, Path(app_name)
 
 
+APP_SCOPE_KEY = "view_maps_network:active_app_scope"
+APP_SCOPED_SESSION_KEY_PREFIXES = ("view_maps_network:",)
+APP_SCOPED_SESSION_DEFAULT_KEYS = (
+    "env",
+    "IS_SOURCE_ENV",
+    "IS_WORKER_ENV",
+    "apps_path",
+    "app",
+    "app_settings",
+    "project",
+    "projects",
+    "TABLE_MAX_ROWS",
+    "GUI_SAMPLING",
+    "base_dir_choice",
+    "input_datadir",
+    "datadir_rel",
+    "datadir_rel_select",
+    "datadir_rel_custom",
+    "datadir",
+    "file_ext_choice",
+    "csv_files",
+    "_prev_csv_files_rel",
+    "df_file",
+    "df_files",
+    "df_select_mode",
+    "df_file_regex",
+    "loaded_df",
+    "id_col",
+    "flight_id_col",
+    "time_col",
+    "df_cols",
+    "_prev_df_selection_sig",
+    "edges_file",
+    "edges_file_input",
+    "edges_file_choice",
+    "edges_file_custom",
+    "link_multiselect",
+    "show_map",
+    "show_graph",
+    "show_topology_links",
+    "show_terrain",
+    "show_trajectory_traces",
+    "show_cloud_heatmap",
+    "cloud_heatmap_sat_path",
+    "cloud_heatmap_ivdl_path",
+    "cloud_heatmap_stride",
+    "cloud_heatmap_min_weight",
+    "jitter_overlap",
+    "show_metrics",
+    "map_marker_style",
+    "allocations_file",
+    "alloc_path_input",
+    "allocations_file_choice",
+    "allocations_file_custom",
+    "baseline_allocations_file",
+    "baseline_alloc_path_input",
+    "baseline_alloc_file_choice",
+    "baseline_alloc_file_custom",
+    "traj_glob",
+    "traj_glob_input",
+    "traj_glob_choice",
+    "traj_glob_custom",
+    "layout_type_select",
+    "metric_type_select",
+    "selected_time",
+    "selected_time_idx",
+    "alloc_time_index",
+    "_alloc_time_index_qp",
+    "_alloc_pair_qp",
+    "alloc_demand_pair_focus",
+    "color_map",
+    "color_map_key",
+)
+
+
+def _reset_app_scoped_session_state(active_app_path: Path) -> bool:
+    """Clear Maps Network state that belongs to a specific active app."""
+
+    app_scope = str(active_app_path.resolve())
+    if st.session_state.get(APP_SCOPE_KEY) == app_scope:
+        return False
+    for key in list(st.session_state.keys()):
+        if key in APP_SCOPED_SESSION_DEFAULT_KEYS or any(
+            key.startswith(prefix) for prefix in APP_SCOPED_SESSION_KEY_PREFIXES
+        ):
+            st.session_state.pop(key, None)
+    st.session_state[APP_SCOPE_KEY] = app_scope
+    return True
+
+
 def _render_app_page_context(app: str, active_app: Path) -> None:
     columns = st.columns(2)
     with columns[0]:
@@ -263,8 +353,9 @@ def _list_subdirectories(base: Path) -> list[str]:
 
 st.title(":world_map: Maps Network Graph")
 
-if 'env' not in st.session_state:
-    active_app_path = _resolve_active_app()
+active_app_path = _resolve_active_app()
+app_scope_changed = _reset_app_scoped_session_state(active_app_path)
+if 'env' not in st.session_state or app_scope_changed:
     app_name = active_app_path.name
     env = AgiEnv(apps_path=active_app_path.parent, app=app_name, verbose=0)
     env.init_done = True

--- a/test/test_view_maps_network.py
+++ b/test/test_view_maps_network.py
@@ -1433,6 +1433,30 @@ def test_view_maps_network_handles_settings_and_active_app_error_paths(
 
     assert any("Provided --active-app path not found" in message for message in errors)
 
+    first_app = tmp_path / "first_app"
+    second_app = tmp_path / "second_app"
+    first_app.mkdir()
+    second_app.mkdir()
+    module.st = SimpleNamespace(
+        session_state={
+            module.APP_SCOPE_KEY: str(first_app.resolve()),
+            "env": object(),
+            "app_settings": {"view_maps_network": {"df_file": "stale.csv"}},
+            "base_dir_choice": "Custom",
+            "datadir": "/tmp/old-data",
+            "view_maps_network:selected_flights_filter": ["old-flight"],
+            "unrelated": "keep",
+        }
+    )
+    assert module._reset_app_scoped_session_state(first_app) is False
+    assert "app_settings" in module.st.session_state
+
+    assert module._reset_app_scoped_session_state(second_app) is True
+    assert module.st.session_state[module.APP_SCOPE_KEY] == str(second_app.resolve())
+    assert module.st.session_state["unrelated"] == "keep"
+    for key in ("env", "app_settings", "base_dir_choice", "datadir", "view_maps_network:selected_flights_filter"):
+        assert key not in module.st.session_state
+
     invalid_settings = tmp_path / "invalid.toml"
     invalid_settings.write_text("[broken", encoding="utf-8")
     module.st = SimpleNamespace(session_state={})


### PR DESCRIPTION
## Summary
- add an active-app scope guard for Maps Network page state
- rebuild `AgiEnv` when `--active-app` changes instead of reusing stale session env
- clear cached `app_settings`, data-file selections, graph/map controls, allocation controls, and namespaced `view_maps_network:*` state only on active-app changes
- add a focused regression for same-app preservation and cross-app reset

## Why
Maps Network caches both runtime env and app settings in Streamlit session state. In a warm session, switching apps could reuse the previous app's settings, paths, selected data files, and map/allocation controls.

## Validation
- not run locally; pre-push classified docs mirror, release proof, and app-contract inputs as unchanged
