### PR TITLE
perf(ui): limit ORCHESTRATE log viewer rendering

### DIFF
--- a/src/agilab/orchestrate_execute.py
+++ b/src/agilab/orchestrate_execute.py
@@ -394,6 +394,17 @@ def render_execute_notice(streamlit_api, session_state) -> None:
     renderer(message)
 
 
+def run_log_view_body(log_text: str, max_lines: int) -> tuple[str, int]:
+    """Return the run-log body to render and the number of omitted older lines."""
+
+    if max_lines <= 0:
+        return log_text, 0
+    lines = log_text.splitlines()
+    if len(lines) <= max_lines:
+        return log_text, 0
+    return "\n".join(lines[-max_lines:]), len(lines) - max_lines
+
+
 def _render_graph_preview(graph_preview: "nx.Graph", source_preview_name: Optional[str]) -> None:
     nx_module = _require_networkx()
     plt_module = _require_matplotlib()
@@ -460,12 +471,23 @@ async def render_execute_section(
         return f"ORCHESTRATE {log_path}" if log_path else "ORCHESTRATE"
 
     def _render_run_log_viewer(log_text: str, *, key: str) -> None:
+        visible_log_text, omitted_log_lines = run_log_view_body(
+            log_text,
+            deps.log_display_max_lines,
+        )
+        if omitted_log_lines:
+            st.caption(
+                "Showing the latest "
+                f"{deps.log_display_max_lines} run-log lines "
+                f"({omitted_log_lines} older lines omitted from the viewer). "
+                "Use the download action for the full log."
+            )
         render_pinnable_code_editor(
             st,
             code_editor,
             RUN_LOGS_PIN_ID,
             title=_run_log_pin_title(),
-            body=log_text,
+            body=visible_log_text,
             key=key,
             body_format="code",
             language="text",

--- a/test/test_orchestrate_execute.py
+++ b/test/test_orchestrate_execute.py
@@ -786,6 +786,23 @@ def _make_execute_deps(message_log: list[tuple[str, str]], state: _State):
     )
 
 
+def test_run_log_view_body_keeps_short_logs_unchanged():
+    body, omitted = orchestrate_execute.run_log_view_body("line 1\nline 2", max_lines=5)
+
+    assert body == "line 1\nline 2"
+    assert omitted == 0
+
+
+def test_run_log_view_body_tails_long_logs():
+    body, omitted = orchestrate_execute.run_log_view_body(
+        "\n".join(f"line {index}" for index in range(1, 8)),
+        max_lines=3,
+    )
+
+    assert body == "line 5\nline 6\nline 7"
+    assert omitted == 4
+
+
 @pytest.mark.asyncio
 async def test_render_execute_section_loads_csv_preview_and_exports(monkeypatch, tmp_path):
     data_root = tmp_path / "data"


### PR DESCRIPTION
## Summary

Limits ORCHESTRATE run-log rendering to the latest configured log lines so long runs do not push very large log bodies through the Streamlit code editor on each rerun.

## Why

The full run log remains useful for download and evidence, but rendering the whole body in the interactive viewer can make Streamlit reruns feel slow for long-running jobs.

## Details

- Adds a small helper that returns a rendered run-log tail plus omitted-line count.
- Keeps short logs unchanged.
- Shows a caption when older lines are omitted from the viewer.
- Keeps the full log body in session state and download actions.

## Validation

```bash
uv --preview-features extra-build-dependencies run --extra ui pytest -q -o addopts='' test/test_orchestrate_execute.py -k run_log_view_body
```

Result: `2 passed, 75 deselected`.
