### PR TITLE
[codex] Fix View Maps app-scoped state

### DIFF
--- a/src/agilab/apps-pages/view_maps/src/view_maps/view_maps.py
+++ b/src/agilab/apps-pages/view_maps/src/view_maps/view_maps.py
@@ -109,6 +109,51 @@ def _vm_key(name: str) -> str:
     return f"{PAGE_KEY_PREFIX}:{name}"
 
 
+APP_SCOPE_KEY = _vm_key("active_app_scope")
+APP_SCOPED_SESSION_KEY_PREFIXES = (f"{PAGE_KEY_PREFIX}:", "_view_maps_")
+APP_SCOPED_SESSION_DEFAULT_KEYS = (
+    "env",
+    "IS_SOURCE_ENV",
+    "IS_WORKER_ENV",
+    "apps_path",
+    "app",
+    "project",
+    "projects",
+    "TABLE_MAX_ROWS",
+    "GUI_SAMPLING",
+    "datadir",
+    "datadir_str",
+    "dataset_files",
+    "file_ext_choice",
+    "df_select_mode",
+    "df_files_selected",
+    "df_file",
+    "df_file_regex",
+    "loaded_df",
+    "coltype",
+    "discrete",
+    "continuous",
+    "lat",
+    "long",
+)
+
+
+def _reset_app_scoped_session_state(active_app: Path) -> bool:
+    """Clear View Maps state that belongs to a specific active app."""
+
+    app_scope = str(active_app.resolve())
+    if st.session_state.get(APP_SCOPE_KEY) == app_scope:
+        return False
+    for key in list(st.session_state.keys()):
+        if key in APP_SCOPED_SESSION_DEFAULT_KEYS or any(
+            isinstance(key, str) and key.startswith(prefix)
+            for prefix in APP_SCOPED_SESSION_KEY_PREFIXES
+        ):
+            st.session_state.pop(key, None)
+    st.session_state[APP_SCOPE_KEY] = app_scope
+    return True
+
+
 def _discover_dataset_files(datadir: Path, ext_choice: str) -> list[Path]:
     files: list[Path] = []
     extensions = DATASET_EXTENSIONS if ext_choice == "all" else (f".{ext_choice}",)
@@ -915,6 +960,7 @@ def main():
             st.error(f"Error: provided --active-app path not found: {active_app}")
             sys.exit(1)
 
+        _reset_app_scoped_session_state(active_app)
         if "coltype" not in st.session_state:
             st.session_state["coltype"] = var[0]
 

--- a/test/test_view_maps.py
+++ b/test/test_view_maps.py
@@ -731,6 +731,44 @@ def test_view_maps_main_initializes_env_and_invokes_page(tmp_path, monkeypatch) 
     assert str(active_app) in fake_st.calls["code"]
 
 
+def test_view_maps_resets_app_scoped_state_on_active_app_change(tmp_path, monkeypatch) -> None:
+    module = _load_view_maps_module()
+    fake_st = _FakeStreamlit()
+    first_app = tmp_path / "first_app"
+    second_app = tmp_path / "second_app"
+    first_app.mkdir()
+    second_app.mkdir()
+    fake_st.session_state = _State(
+        {
+            module.APP_SCOPE_KEY: str(first_app.resolve()),
+            "env": object(),
+            "datadir": "/tmp/old-data",
+            "dataset_files": ["old.csv"],
+            "loaded_df": object(),
+            "view_maps:df_files_selected": ["old.csv"],
+            "_view_maps_last_target": "old-target",
+            "unrelated": "keep",
+        }
+    )
+    monkeypatch.setattr(module, "st", fake_st)
+
+    assert module._reset_app_scoped_session_state(first_app) is False
+    assert "datadir" in fake_st.session_state
+
+    assert module._reset_app_scoped_session_state(second_app) is True
+    assert fake_st.session_state[module.APP_SCOPE_KEY] == str(second_app.resolve())
+    assert fake_st.session_state["unrelated"] == "keep"
+    for key in (
+        "env",
+        "datadir",
+        "dataset_files",
+        "loaded_df",
+        "view_maps:df_files_selected",
+        "_view_maps_last_target",
+    ):
+        assert key not in fake_st.session_state
+
+
 def test_view_maps_bootstrap_keeps_absolute_app_path_out_of_main_status() -> None:
     source = MODULE_PATH.read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- add an active-app scope guard for View Maps page state
- clear page-owned data/map selections when `--active-app` changes
- preserve same-app state and unrelated session keys
- add a focused regression for cross-app reset behavior

## Why
View Maps rebuilds its runtime env on each launch, but data directory, dataset-file, map column, sampling, and namespaced `view_maps:*` state can persist in a warm Streamlit session. Switching apps could therefore reuse stale selections from the previous project.

## Validation
- not run locally; pre-push classified docs mirror, release proof, and app-contract inputs as unchanged
