### PR TITLE
chore(media): keep only latest teaser upload pack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,7 +137,11 @@ src/agilab/apps/builtin/*/src/**/*.pyx
 !src/agilab/apps/builtin/data_io_2026_project/**
 _fcas_work
 .vscode/
-artifacts/demo_media/
+# Generated demo media: keep only lightweight upload metadata in Git.
+artifacts/demo_media/**
+!artifacts/demo_media/
+!artifacts/demo_media/flight/
+!artifacts/demo_media/flight/agilab_flight_youtube_pack.md
 exported_notebooks/
 src/agilab/apps/builtin/*/notebooks/lab_*.ipynb
 src/agilab/apps/builtin/*/notebooks/sitecustomize.py

--- a/artifacts/demo_media/flight/agilab_flight_youtube_pack.md
+++ b/artifacts/demo_media/flight/agilab_flight_youtube_pack.md
@@ -2,14 +2,9 @@
 
 ## Video
 
-- Public video: https://youtu.be/BsBjRSAXJZA
-- Local MP4 output: `artifacts/demo_media/flight/agilab_flight.mp4` (generated locally; not stored in Git)
-- Local GIF preview output: `artifacts/demo_media/flight/agilab_flight.gif` (generated locally; not stored in Git)
-- Local poster output: `artifacts/demo_media/flight/agilab_flight_poster.png` (generated locally; not stored in Git)
-- YouTube public URL: https://youtu.be/BsBjRSAXJZA
-- Removed previous audio upload: https://youtu.be/KsBe8lIahH4
-- Removed previous silent upload: https://youtu.be/c4aogHDh4do
+- Latest public video: https://youtu.be/BsBjRSAXJZA
 - YouTube Studio URL: https://studio.youtube.com/video/BsBjRSAXJZA
+- Repository policy: keep only this lightweight upload pack in Git. Generated MP4, GIF, and poster outputs under `artifacts/demo_media/flight/` are local artifacts and are not stored in Git.
 - Duration: 15.47 seconds
 - Format: 1920x1080, 30 fps, premium H.264 video + stereo AAC audio MP4
 - Video master: regenerated from source frames at CRF 12


### PR DESCRIPTION
## Summary

Keeps only the latest AGILAB flight teaser upload pack in the repository and reinforces that generated teaser renders stay out of Git.

## Details

- Keeps `artifacts/demo_media/flight/agilab_flight_youtube_pack.md` as the only tracked demo-media artifact.
- Updates the pack to reference only the latest public teaser: https://youtu.be/BsBjRSAXJZA.
- Removes stale references to prior removed teaser uploads from the pack.
- Narrows `.gitignore` so generated MP4/GIF/poster files remain ignored while the lightweight upload pack is explicitly allowed.

## Validation

```bash
git ls-files artifacts/demo_media
git check-ignore -q artifacts/demo_media/flight/agilab_flight.mp4
git check-ignore -q artifacts/demo_media/flight/agilab_flight.gif
git check-ignore -q artifacts/demo_media/flight/agilab_flight_poster.png
```

Confirmed only the markdown upload pack is tracked, while generated video assets are ignored.
