### PR TITLE
[codex] Fix View Maps 3D app-scoped state

### DIFF
--- a/src/agilab/apps-pages/view_maps_3d/src/view_maps_3d/view_maps_3d.py
+++ b/src/agilab/apps-pages/view_maps_3d/src/view_maps_3d/view_maps_3d.py
@@ -91,6 +91,57 @@ def _vm3d_key(name: str) -> str:
     return f"{PAGE_KEY_PREFIX}:{name}"
 
 
+APP_SCOPE_KEY = _vm3d_key("active_app_scope")
+APP_SCOPED_SESSION_KEY_PREFIXES = (f"{PAGE_KEY_PREFIX}:",)
+APP_SCOPED_SESSION_DEFAULT_KEYS = (
+    "env",
+    "IS_SOURCE_ENV",
+    "IS_WORKER_ENV",
+    "apps_path",
+    "app",
+    "project",
+    "projects",
+    "TABLE_MAX_ROWS",
+    "GUI_SAMPLING",
+    "datadir",
+    "beamdir",
+    "dataset_files",
+    "csv_files",
+    "beam_csv_files",
+    "df_file",
+    "df_files_selected",
+    "df_file_regex",
+    "df_select_mode",
+    "loaded_df",
+    "beam_file",
+    "beam_files",
+    "dfs_beams",
+    "file_ext_choice",
+    "coltype",
+    "discrete",
+    "continuous",
+    "lat",
+    "long",
+    "alt",
+)
+
+
+def _reset_app_scoped_session_state(active_app: Path) -> bool:
+    """Clear View Maps 3D state that belongs to a specific active app."""
+
+    app_scope = str(active_app.resolve())
+    if st.session_state.get(APP_SCOPE_KEY) == app_scope:
+        return False
+    for key in list(st.session_state.keys()):
+        if key in APP_SCOPED_SESSION_DEFAULT_KEYS or any(
+            isinstance(key, str) and key.startswith(prefix)
+            for prefix in APP_SCOPED_SESSION_KEY_PREFIXES
+        ):
+            st.session_state.pop(key, None)
+    st.session_state[APP_SCOPE_KEY] = app_scope
+    return True
+
+
 def _list_dataset_files(base_dir: Path, ext_choice: str = "all") -> list[Path]:
     candidates: list[tuple[int, Path]] = []
     extensions = DATASET_EXTENSIONS if ext_choice == "all" else (f".{ext_choice}",)
@@ -174,6 +225,7 @@ def _bootstrap_env_from_active_app() -> bool:
         candidate = Path(candidate_expr).expanduser()
         if not candidate.exists() or not candidate.is_dir():
             continue
+        _reset_app_scoped_session_state(candidate)
         try:
             env = AgiEnv(
                 apps_path=candidate.parent,
@@ -1314,6 +1366,7 @@ def main():
             st.error(f"Error: provided --active-app path not found: {active_app}")
             sys.exit(1)
 
+        _reset_app_scoped_session_state(active_app)
         # Short app name
         app = active_app.name
         st.session_state["apps_path"] = str(active_app.parent)

--- a/test/test_view_maps_3d.py
+++ b/test/test_view_maps_3d.py
@@ -637,6 +637,46 @@ def test_view_maps_3d_page_bootstrap_reuses_active_app_argument(monkeypatch, tmp
     assert fake_state["GUI_SAMPLING"] == 4
 
 
+def test_view_maps_3d_resets_app_scoped_state_on_active_app_change(monkeypatch, tmp_path) -> None:
+    module = _load_view_maps_3d_module()
+    fake_st = _FakeStreamlit()
+    first_app = tmp_path / "first_app"
+    second_app = tmp_path / "second_app"
+    first_app.mkdir()
+    second_app.mkdir()
+    fake_st.session_state = _State(
+        {
+            module.APP_SCOPE_KEY: str(first_app.resolve()),
+            "env": object(),
+            "datadir": "/tmp/old-data",
+            "beamdir": "/tmp/old-beams",
+            "dataset_files": ["old.csv"],
+            "loaded_df": object(),
+            "view_maps_3d:df_files_selected": ["old.csv"],
+            "view_maps_3d:last_datadir": "/tmp/old-data",
+            "unrelated": "keep",
+        }
+    )
+    monkeypatch.setattr(module, "st", fake_st)
+
+    assert module._reset_app_scoped_session_state(first_app) is False
+    assert "datadir" in fake_st.session_state
+
+    assert module._reset_app_scoped_session_state(second_app) is True
+    assert fake_st.session_state[module.APP_SCOPE_KEY] == str(second_app.resolve())
+    assert fake_st.session_state["unrelated"] == "keep"
+    for key in (
+        "env",
+        "datadir",
+        "beamdir",
+        "dataset_files",
+        "loaded_df",
+        "view_maps_3d:df_files_selected",
+        "view_maps_3d:last_datadir",
+    ):
+        assert key not in fake_st.session_state
+
+
 def test_view_maps_3d_page_rejects_invalid_datadir(monkeypatch, tmp_path) -> None:
     module = _load_view_maps_3d_module()
     settings_file = tmp_path / "app_settings.toml"


### PR DESCRIPTION
## Summary
- add an active-app scope guard for View Maps 3D page state
- clear page-owned data, beam, dataframe, and namespaced `view_maps_3d:*` state when `--active-app` changes
- apply the guard in both direct `main()` launch and fallback page bootstrap
- add a focused regression for same-app preservation and cross-app reset

## Why
View Maps 3D rebuilds runtime env on launch, but warm Streamlit sessions could retain the previous app's data directory, beam directory, selected datasets, loaded dataframe, and widget state.

## Validation
- not run locally; pre-push classified docs mirror, release proof, and app-contract inputs as unchanged
