### PR TITLE
Add architecture scorecard hardening evidence

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -1,9 +1,9 @@
 {
-  "file_count": 228,
+  "file_count": 230,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "96293f08da18151e69913c1dffe33df33d4da703dbb3386464dc184b178a1c45",
+  "source_digest_sha256": "6ae6c142da928afced73e4c2828264514d0e466b4d37dd9e834752014aa34064",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "96293f08da18151e69913c1dffe33df33d4da703dbb3386464dc184b178a1c45"
+  "target_digest_sha256": "6ae6c142da928afced73e4c2828264514d0e466b4d37dd9e834752014aa34064"
 }

--- a/docs/source/architecture-scorecard.rst
+++ b/docs/source/architecture-scorecard.rst
@@ -1,0 +1,81 @@
+Architecture scorecard
+======================
+
+This page records AGILAB's architecture self-assessment from repository
+evidence. It is not a production MLOps certification, not a security
+certification, and not a multi-tenant production platform score.
+
+Current supported score
+-----------------------
+
+``4.5 / 5`` for the evidence-first workbench architecture.
+
+The scope is deliberately narrow: AGILAB has an excellent architecture for
+turning AI/ML experiments, notebooks, app runs, and agent-assisted workflows
+into replayable evidence. The same score is conditional for shared or
+multi-tenant production use because tenant isolation, enterprise auth, RBAC,
+production rollback, and regulated serving remain deployment responsibilities
+outside the current AGILAB core.
+
+Executable scorecard
+--------------------
+
+Run the scorecard locally:
+
+.. code-block:: bash
+
+   uv --preview-features extra-build-dependencies run python tools/architecture_scorecard.py --compact
+
+The production-readiness profile also consumes this scorecard:
+
+.. code-block:: bash
+
+   uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile production-readiness
+
+What must stay true
+-------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 28 42 30
+
+   * - Architecture dimension
+     - Excellent means
+     - Evidence gate
+   * - Control, payload, and evidence planes
+     - UI, CLI, notebooks, manager runtime, worker runtime, artifacts, and
+       proof files have clear responsibilities.
+     - ``architecture_plane_boundaries``
+   * - Runtime guardrails
+     - Known bad states fail closed for public UI binds, cluster shares,
+       missing manifests, notebook imports, service health, and routes.
+     - ``architecture_runtime_guardrails``
+   * - Supply chain and release proof
+     - Release artifacts, provenance, SBOM/audit planning, and release proof
+       are checked by tooling rather than prose.
+     - ``architecture_supply_chain_release_proof``
+   * - Remote execution hardening
+     - Dynamic SSH command fragments such as worker paths, scheduler
+       addresses, and PID paths are quoted by a central builder.
+     - ``architecture_remote_execution_hardening``
+   * - Capacity model trust boundary
+     - The optional pickle capacity predictor is loaded only from the trusted
+       resources root and world-writable files are refused.
+     - ``architecture_capacity_model_trust_boundary``
+   * - Claim boundary
+     - Public wording says exactly what the architecture proves and does not
+       promote roadmap or production-platform claims as shipped features.
+     - ``architecture_claim_boundary``
+
+Score movement rule
+-------------------
+
+The score can increase only when a repository check links the claim to an
+executable report, test, manifest, workflow, or public proof artifact. It must
+decrease or become conditional when the evidence is missing, advisory-only, or
+depends on manual trust.
+
+Use this page as the architecture evidence index. Use
+:doc:`architecture-five-minutes` for the mental model, :doc:`architecture` for
+the full stack reference, and :doc:`agilab-mlops-positioning` for the production
+boundary.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -77,6 +77,7 @@ references, and example projects.
 
    Architecture in 5 minutes <architecture-five-minutes>
    Product architecture <architecture>
+   Architecture scorecard <architecture-scorecard>
    AGI Core architecture <agi-core-architecture>
    MLOps positioning <agilab-mlops-positioning>
    Learning workflows <learning-workflows>

--- a/src/agilab/apps-pages/view_maps_3d/src/view_maps_3d/view_maps_3d.py
+++ b/src/agilab/apps-pages/view_maps_3d/src/view_maps_3d/view_maps_3d.py
@@ -91,6 +91,57 @@ def _vm3d_key(name: str) -> str:
     return f"{PAGE_KEY_PREFIX}:{name}"
 
 
+APP_SCOPE_KEY = _vm3d_key("active_app_scope")
+APP_SCOPED_SESSION_KEY_PREFIXES = (f"{PAGE_KEY_PREFIX}:",)
+APP_SCOPED_SESSION_DEFAULT_KEYS = (
+    "env",
+    "IS_SOURCE_ENV",
+    "IS_WORKER_ENV",
+    "apps_path",
+    "app",
+    "project",
+    "projects",
+    "TABLE_MAX_ROWS",
+    "GUI_SAMPLING",
+    "datadir",
+    "beamdir",
+    "dataset_files",
+    "csv_files",
+    "beam_csv_files",
+    "df_file",
+    "df_files_selected",
+    "df_file_regex",
+    "df_select_mode",
+    "loaded_df",
+    "beam_file",
+    "beam_files",
+    "dfs_beams",
+    "file_ext_choice",
+    "coltype",
+    "discrete",
+    "continuous",
+    "lat",
+    "long",
+    "alt",
+)
+
+
+def _reset_app_scoped_session_state(active_app: Path) -> bool:
+    """Clear View Maps 3D state that belongs to a specific active app."""
+
+    app_scope = str(active_app.resolve())
+    if st.session_state.get(APP_SCOPE_KEY) == app_scope:
+        return False
+    for key in list(st.session_state.keys()):
+        if key in APP_SCOPED_SESSION_DEFAULT_KEYS or any(
+            isinstance(key, str) and key.startswith(prefix)
+            for prefix in APP_SCOPED_SESSION_KEY_PREFIXES
+        ):
+            st.session_state.pop(key, None)
+    st.session_state[APP_SCOPE_KEY] = app_scope
+    return True
+
+
 def _list_dataset_files(base_dir: Path, ext_choice: str = "all") -> list[Path]:
     candidates: list[tuple[int, Path]] = []
     extensions = DATASET_EXTENSIONS if ext_choice == "all" else (f".{ext_choice}",)
@@ -174,6 +225,7 @@ def _bootstrap_env_from_active_app() -> bool:
         candidate = Path(candidate_expr).expanduser()
         if not candidate.exists() or not candidate.is_dir():
             continue
+        _reset_app_scoped_session_state(candidate)
         try:
             env = AgiEnv(
                 apps_path=candidate.parent,
@@ -1314,6 +1366,7 @@ def main():
             st.error(f"Error: provided --active-app path not found: {active_app}")
             sys.exit(1)
 
+        _reset_app_scoped_session_state(active_app)
         # Short app name
         app = active_app.name
         st.session_state["apps_path"] = str(active_app.parent)

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime_distribution_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime_distribution_support.py
@@ -65,6 +65,37 @@ def _local_dask_worker_command(uv_cmd: str, wenv_abs: Path, scheduler: str, pid_
     ]
 
 
+def _remote_prefix(value: Any) -> str:
+    text = str(value or "")
+    if text and not text.endswith(" "):
+        text += " "
+    return text
+
+
+def _remote_path(value: Path | str) -> str:
+    return shlex.quote(str(value))
+
+
+def _remote_dask_worker_command(
+    *,
+    cmd_prefix: str,
+    dask_env: str,
+    uv_cmd: str,
+    wenv_rel: Path | str,
+    scheduler: str,
+    pid_file: str,
+) -> str:
+    uv_parts = " ".join(shlex.quote(part) for part in shlex.split(str(uv_cmd), posix=True))
+    worker_path = Path(wenv_rel)
+    return (
+        f"{_remote_prefix(cmd_prefix)}"
+        f"{_remote_prefix(dask_env)}"
+        f"{uv_parts} --project {_remote_path(worker_path)} run --no-sync "
+        f"dask worker {shlex.quote(f'tcp://{scheduler}')} --no-nanny "
+        f"--pid-file {_remote_path(worker_path.parent / pid_file)}"
+    )
+
+
 def _record_phase_timing(agi_cls: Any, phase: str, seconds: float) -> None:
     timings = getattr(agi_cls, "_phase_timings", None)
     if not isinstance(timings, list):
@@ -364,10 +395,13 @@ async def start(
                     agi_cls._exec_bg(local_cmd, str(wenv_abs), env=process_env)
                 else:
                     wenv_rel = env.wenv_rel
-                    remote_cmd = (
-                        f'{cmd_prefix}{dask_env}{env.uv} --project {wenv_rel} run --no-sync '
-                        f'dask worker '
-                        f'tcp://{agi_cls._scheduler} --no-nanny --pid-file {wenv_rel.parent / pid_file}'
+                    remote_cmd = _remote_dask_worker_command(
+                        cmd_prefix=cmd_prefix,
+                        dask_env=dask_env,
+                        uv_cmd=str(env.uv),
+                        wenv_rel=wenv_rel,
+                        scheduler=agi_cls._scheduler,
+                        pid_file=pid_file,
                     )
                     create_task_fn(agi_cls.exec_ssh_async(ip, remote_cmd))
                     log.info(f"Launched remote worker in background on {ip}: {remote_cmd}")

--- a/test/test_architecture_scorecard.py
+++ b/test/test_architecture_scorecard.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import shlex
+import stat
+import sys
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ARCHITECTURE_SCORECARD = REPO_ROOT / "tools" / "architecture_scorecard.py"
+AGI_CLUSTER_SRC = REPO_ROOT / "src" / "agilab" / "core" / "agi-cluster" / "src"
+AGI_ENV_SRC = REPO_ROOT / "src" / "agilab" / "core" / "agi-env" / "src"
+
+
+def _load_file_module(name: str, path: Path):
+    sys.modules.pop(name, None)
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_cluster_module(name: str):
+    for candidate in (AGI_CLUSTER_SRC, AGI_ENV_SRC):
+        value = str(candidate)
+        if value not in sys.path:
+            sys.path.insert(0, value)
+    return _load_file_module(
+        f"agilab_architecture_scorecard_{name}",
+        AGI_CLUSTER_SRC / "agi_cluster" / "agi_distributor" / f"{name}.py",
+    )
+
+
+def test_architecture_scorecard_passes_current_evidence() -> None:
+    module = _load_file_module("architecture_scorecard_test_module", ARCHITECTURE_SCORECARD)
+
+    report = module.build_report(repo_root=REPO_ROOT)
+    checks = {check["id"]: check for check in report["checks"]}
+
+    assert report["schema"] == module.SCHEMA
+    assert report["status"] == "pass"
+    assert report["supported_score"] == "4.5 / 5"
+    assert "not external certification" in report["summary"]["score_boundary"]
+    assert checks["architecture_remote_execution_hardening"]["status"] == "pass"
+    assert checks["architecture_capacity_model_trust_boundary"]["status"] == "pass"
+
+
+def test_architecture_scorecard_cli_writes_json(tmp_path: Path, capsys) -> None:
+    module = _load_file_module("architecture_scorecard_cli_test_module", ARCHITECTURE_SCORECARD)
+    output = tmp_path / "architecture-scorecard.json"
+
+    assert module.main(["--compact", "--output", str(output)]) == 0
+
+    stdout_payload = json.loads(capsys.readouterr().out)
+    file_payload = json.loads(output.read_text(encoding="utf-8"))
+    assert stdout_payload["status"] == "pass"
+    assert file_payload["supported_score"] == "4.5 / 5"
+
+
+def test_remote_dask_worker_command_quotes_dynamic_fragments() -> None:
+    module = _load_cluster_module("runtime_distribution_support")
+
+    command = module._remote_dask_worker_command(
+        cmd_prefix="env AGILAB_REMOTE=1",
+        dask_env="DASK_DISTRIBUTED__LOGGING__distributed=info ",
+        uv_cmd="uv --preview-features extra-build-dependencies",
+        wenv_rel=Path("worker env/worker's env"),
+        scheduler="scheduler.example; touch /tmp/bad",
+        pid_file="worker pid.pid",
+    )
+
+    tokens = shlex.split(command, posix=True)
+    assert tokens[:2] == ["env", "AGILAB_REMOTE=1"]
+    assert "worker env/worker's env" in tokens
+    assert "tcp://scheduler.example; touch /tmp/bad" in tokens
+    assert "worker env/worker's env/worker pid.pid" in tokens
+    assert "; touch /tmp/bad --no-nanny" not in command
+
+
+def test_capacity_predictor_refuses_untrusted_pickle_path(tmp_path: Path) -> None:
+    module = _load_cluster_module("runtime_misc_support")
+    trusted_root = tmp_path / "trusted"
+    outside_root = tmp_path / "outside"
+    trusted_root.mkdir()
+    outside_root.mkdir()
+    model_path = outside_root / "balancer_model.pkl"
+    model_path.write_bytes(b"not-a-trusted-pickle")
+
+    retrained: list[bool] = []
+
+    def _load_should_not_run(_stream):
+        raise AssertionError("untrusted capacity model should not be deserialized")
+
+    predictor = module.load_capacity_predictor(
+        model_path,
+        trusted_root=trusted_root,
+        load_fn=_load_should_not_run,
+        retrain_fn=lambda: retrained.append(True),
+    )
+
+    assert predictor is None
+    assert retrained == [True]
+
+
+def test_capacity_predictor_refuses_world_writable_trusted_model(tmp_path: Path) -> None:
+    module = _load_cluster_module("runtime_misc_support")
+    model_path = tmp_path / "balancer_model.pkl"
+    model_path.write_bytes(b"world-writable-pickle")
+    model_path.chmod(model_path.stat().st_mode | stat.S_IWOTH)
+
+    retrained: list[bool] = []
+
+    def _load_should_not_run(_stream):
+        raise AssertionError("world-writable capacity model should not be deserialized")
+
+    try:
+        predictor = module.load_capacity_predictor(
+            model_path,
+            trusted_root=tmp_path,
+            load_fn=_load_should_not_run,
+            retrain_fn=lambda: retrained.append(True),
+        )
+    finally:
+        model_path.chmod(model_path.stat().st_mode & ~stat.S_IWOTH)
+
+    assert predictor is None
+    assert retrained == [True]

--- a/test/test_production_readiness_report.py
+++ b/test/test_production_readiness_report.py
@@ -34,6 +34,7 @@ def test_build_report_passes_static_production_readiness_contracts() -> None:
         "docs_mirror_stamp",
         "docs_workflow_parity_profile",
         "production_readiness_workflow_profile",
+        "architecture_scorecard",
         "compatibility_matrix_validated_paths",
         "service_health_json_prometheus",
         "controlled_pilot_readiness_gate",
@@ -59,6 +60,7 @@ def test_build_report_includes_shared_adoption_hardening_controls() -> None:
         "public_ui_bind_guard",
         "cluster_share_fail_fast",
         "controlled_pilot_readiness_gate",
+        "architecture_scorecard",
         "production_boundary_docs",
     }:
         check = checks[check_id]
@@ -85,6 +87,25 @@ def test_controlled_pilot_readiness_gate_supports_score_movement() -> None:
         "persisted_artifact_contract",
         "public_bind_and_secret_boundary",
         "compatibility_matrix_entry",
+    }
+
+
+def test_architecture_scorecard_is_scoped_and_evidence_backed() -> None:
+    module = _load_module()
+
+    report = module.build_report(run_docs_profile=False)
+    check = next(check for check in report["checks"] if check["id"] == "architecture_scorecard")
+
+    assert check["status"] == "pass"
+    assert check["details"]["supported_score"] == "4.5 / 5"
+    assert "multi-tenant production" in check["details"]["score_scope"]
+    assert set(check["details"]["check_ids"]) >= {
+        "architecture_plane_boundaries",
+        "architecture_runtime_guardrails",
+        "architecture_supply_chain_release_proof",
+        "architecture_remote_execution_hardening",
+        "architecture_capacity_model_trust_boundary",
+        "architecture_claim_boundary",
     }
 
 

--- a/test/test_view_maps_3d.py
+++ b/test/test_view_maps_3d.py
@@ -637,6 +637,46 @@ def test_view_maps_3d_page_bootstrap_reuses_active_app_argument(monkeypatch, tmp
     assert fake_state["GUI_SAMPLING"] == 4
 
 
+def test_view_maps_3d_resets_app_scoped_state_on_active_app_change(monkeypatch, tmp_path) -> None:
+    module = _load_view_maps_3d_module()
+    fake_st = _FakeStreamlit()
+    first_app = tmp_path / "first_app"
+    second_app = tmp_path / "second_app"
+    first_app.mkdir()
+    second_app.mkdir()
+    fake_st.session_state = _State(
+        {
+            module.APP_SCOPE_KEY: str(first_app.resolve()),
+            "env": object(),
+            "datadir": "/tmp/old-data",
+            "beamdir": "/tmp/old-beams",
+            "dataset_files": ["old.csv"],
+            "loaded_df": object(),
+            "view_maps_3d:df_files_selected": ["old.csv"],
+            "view_maps_3d:last_datadir": "/tmp/old-data",
+            "unrelated": "keep",
+        }
+    )
+    monkeypatch.setattr(module, "st", fake_st)
+
+    assert module._reset_app_scoped_session_state(first_app) is False
+    assert "datadir" in fake_st.session_state
+
+    assert module._reset_app_scoped_session_state(second_app) is True
+    assert fake_st.session_state[module.APP_SCOPE_KEY] == str(second_app.resolve())
+    assert fake_st.session_state["unrelated"] == "keep"
+    for key in (
+        "env",
+        "datadir",
+        "beamdir",
+        "dataset_files",
+        "loaded_df",
+        "view_maps_3d:df_files_selected",
+        "view_maps_3d:last_datadir",
+    ):
+        assert key not in fake_st.session_state
+
+
 def test_view_maps_3d_page_rejects_invalid_datadir(monkeypatch, tmp_path) -> None:
     module = _load_view_maps_3d_module()
     settings_file = tmp_path / "app_settings.toml"

--- a/tools/architecture_scorecard.py
+++ b/tools/architecture_scorecard.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""Emit executable evidence for AGILAB's architecture self-assessment."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = "agilab.architecture_scorecard.v1"
+SUPPORTED_SCORE = "4.5 / 5"
+SCORE_SCOPE = (
+    "Excellent evidence-first workbench architecture; conditional for shared "
+    "or multi-tenant production use."
+)
+
+
+def _read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _missing_required_tokens(
+    repo_root: Path,
+    required: Mapping[str, Sequence[str]],
+) -> dict[str, list[str]]:
+    missing: dict[str, list[str]] = {}
+    for relative_path, tokens in required.items():
+        path = repo_root / relative_path
+        try:
+            text = _read_text(path)
+        except Exception as exc:
+            missing[relative_path] = [f"<unable to read: {exc}>"]
+            continue
+        missing_tokens = [token for token in tokens if token not in text]
+        if missing_tokens:
+            missing[relative_path] = missing_tokens
+    return missing
+
+
+def _check_result(
+    check_id: str,
+    label: str,
+    passed: bool,
+    summary: str,
+    *,
+    evidence: Sequence[str],
+    details: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "id": check_id,
+        "label": label,
+        "status": "pass" if passed else "fail",
+        "summary": summary,
+        "evidence": list(evidence),
+        "details": details or {},
+    }
+
+
+def _token_check(
+    repo_root: Path,
+    *,
+    check_id: str,
+    label: str,
+    pass_summary: str,
+    fail_summary: str,
+    required: Mapping[str, Sequence[str]],
+) -> dict[str, Any]:
+    missing = _missing_required_tokens(repo_root, required)
+    return _check_result(
+        check_id,
+        label,
+        not missing,
+        pass_summary if not missing else fail_summary,
+        evidence=list(required),
+        details={"missing": missing},
+    )
+
+
+def _check_plane_boundaries(repo_root: Path) -> dict[str, Any]:
+    return _token_check(
+        repo_root,
+        check_id="architecture_plane_boundaries",
+        label="Control/payload/evidence plane boundaries",
+        pass_summary=(
+            "architecture docs describe the visible control path, manager/worker split, "
+            "and evidence handoff"
+        ),
+        fail_summary="architecture boundary documentation is incomplete",
+        required={
+            "docs/source/architecture-five-minutes.rst": [
+                "one public control path stays visible",
+                "manager prepares and dispatches work; workers",
+                "Artifacts, run manifests",
+            ],
+            "docs/source/architecture.rst": [
+                "Execution back-plane boundary",
+                "Global AGILAB architecture",
+            ],
+        },
+    )
+
+
+def _check_runtime_guardrails(repo_root: Path) -> dict[str, Any]:
+    return _token_check(
+        repo_root,
+        check_id="architecture_runtime_guardrails",
+        label="Runtime fail-closed guardrails",
+        pass_summary=(
+            "robustness matrix covers public UI bind, cluster share, evidence manifest, "
+            "notebook import, service, and route bad states"
+        ),
+        fail_summary="runtime robustness matrix does not cover the expected architecture guardrails",
+        required={
+            "tools/robustness_matrix.py": [
+                "public_streamlit_bind_without_controls_refused",
+                "cluster_share_same_as_local_fails_closed",
+                "missing_run_manifest_fails_verification",
+                "invalid_notebook_import_fails_preflight",
+                "service_unhealthy_workers_block_promotion",
+            ],
+            "test/test_robustness_matrix.py": [
+                "test_robustness_matrix_p0_passes_against_current_contracts",
+            ],
+        },
+    )
+
+
+def _check_supply_chain_and_release(repo_root: Path) -> dict[str, Any]:
+    return _token_check(
+        repo_root,
+        check_id="architecture_supply_chain_release_proof",
+        label="Supply-chain and release-proof architecture",
+        pass_summary=(
+            "release architecture is backed by package contracts, SBOM/audit planning, "
+            "provenance, and release-proof checks"
+        ),
+        fail_summary="release and supply-chain architecture evidence is incomplete",
+        required={
+            "tools/profile_supply_chain_scan.py": [
+                "pip-audit",
+                "cyclonedx-py",
+                "write_pip_audit_requirements",
+            ],
+            "tools/release_proof_report.py": [
+                "--check-github-runs",
+                "release_proof.toml",
+            ],
+            ".github/workflows/pypi-publish.yaml": [
+                "pypi-provenance-evidence",
+                "publish-release-assets",
+                "trusted publishing",
+            ],
+        },
+    )
+
+
+def _check_remote_execution_hardening(repo_root: Path) -> dict[str, Any]:
+    return _token_check(
+        repo_root,
+        check_id="architecture_remote_execution_hardening",
+        label="Remote execution command hardening",
+        pass_summary=(
+            "remote worker command construction quotes dynamic scheduler, environment, "
+            "and worker-path fragments"
+        ),
+        fail_summary="remote execution command construction is not fully evidenced as quoted",
+        required={
+            "src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime_distribution_support.py": [
+                "_remote_dask_worker_command",
+                "shlex.quote",
+                "tcp://{scheduler}",
+            ],
+            "src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_remote_support.py": [
+                "_remote_arg",
+                "_remote_command",
+                "_remote_share_mount_command",
+            ],
+            "test/test_architecture_scorecard.py": [
+                "test_remote_dask_worker_command_quotes_dynamic_fragments",
+            ],
+        },
+    )
+
+
+def _check_capacity_model_trust_boundary(repo_root: Path) -> dict[str, Any]:
+    return _token_check(
+        repo_root,
+        check_id="architecture_capacity_model_trust_boundary",
+        label="Capacity model trust boundary",
+        pass_summary=(
+            "capacity predictor pickle loading is constrained to a trusted resource root "
+            "and rejects world-writable model files"
+        ),
+        fail_summary="capacity predictor pickle trust boundary is incomplete",
+        required={
+            "src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime_misc_support.py": [
+                "_capacity_model_trust_error",
+                "trusted_root=env.resources_path",
+                "model file is world-writable",
+                "Refusing to load untrusted capacity model",
+            ],
+            "test/test_architecture_scorecard.py": [
+                "test_capacity_predictor_refuses_untrusted_pickle_path",
+            ],
+        },
+    )
+
+
+def _check_claim_boundary(repo_root: Path) -> dict[str, Any]:
+    return _token_check(
+        repo_root,
+        check_id="architecture_claim_boundary",
+        label="Architecture claim boundary",
+        pass_summary=(
+            "public docs keep the score scoped to an evidence-first workbench and avoid "
+            "multi-tenant production overclaiming"
+        ),
+        fail_summary="architecture score docs overclaim or omit the production boundary",
+        required={
+            "docs/source/architecture-scorecard.rst": [
+                "self-assessment",
+                "not a production MLOps certification",
+                "not a multi-tenant production platform score",
+                "conditional for shared or",
+                "multi-tenant production use",
+            ],
+            "docs/source/agilab-mlops-positioning.rst": [
+                "not as a production MLOps platform",
+            ],
+        },
+    )
+
+
+def build_report(*, repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    repo_root = repo_root.resolve()
+    checks = [
+        _check_plane_boundaries(repo_root),
+        _check_runtime_guardrails(repo_root),
+        _check_supply_chain_and_release(repo_root),
+        _check_remote_execution_hardening(repo_root),
+        _check_capacity_model_trust_boundary(repo_root),
+        _check_claim_boundary(repo_root),
+    ]
+    passed = sum(1 for check in checks if check["status"] == "pass")
+    failed = sum(1 for check in checks if check["status"] == "fail")
+    return {
+        "schema": SCHEMA,
+        "kpi": "Architecture scorecard",
+        "supported_score": SUPPORTED_SCORE,
+        "score_scope": SCORE_SCOPE,
+        "status": "pass" if failed == 0 else "fail",
+        "summary": {
+            "passed": passed,
+            "failed": failed,
+            "total": len(checks),
+            "score_boundary": (
+                "self-assessment from repository evidence; not external certification"
+            ),
+        },
+        "checks": checks,
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--compact", action="store_true", help="Emit compact JSON.")
+    parser.add_argument("--output", type=Path, help="Optional JSON output path.")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    report = build_report()
+    text = json.dumps(report, separators=(",", ":") if args.compact else None, indent=None if args.compact else 2, sort_keys=True)
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(text + "\n", encoding="utf-8")
+    print(text)
+    return 0 if report["status"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/production_readiness_report.py
+++ b/tools/production_readiness_report.py
@@ -246,6 +246,42 @@ def _run_docs_workflow_profile(repo_root: Path) -> dict[str, Any]:
     )
 
 
+def _check_architecture_scorecard(repo_root: Path) -> dict[str, Any]:
+    try:
+        architecture_scorecard = _load_tool_module("architecture_scorecard")
+        report = architecture_scorecard.build_report(repo_root=repo_root)
+        checks = report.get("checks", [])
+        score_scope = str(report.get("score_scope", ""))
+        ok = (
+            report.get("status") == "pass"
+            and report.get("supported_score") == architecture_scorecard.SUPPORTED_SCORE
+            and "multi-tenant production" in score_scope
+        )
+        summary = (
+            "architecture scorecard passes with an explicit multi-tenant production boundary"
+            if ok
+            else "architecture scorecard is missing, failing, or over-scoped"
+        )
+        details = {
+            "supported_score": report.get("supported_score"),
+            "score_scope": score_scope,
+            "check_ids": [check.get("id") for check in checks],
+            "failed": [check.get("id") for check in checks if check.get("status") != "pass"],
+        }
+    except Exception as exc:
+        ok = False
+        summary = str(exc)
+        details = {"error": str(exc)}
+    return _check_result(
+        "architecture_scorecard",
+        "Architecture scorecard",
+        ok,
+        summary,
+        evidence=["tools/architecture_scorecard.py", "docs/source/architecture-scorecard.rst"],
+        details=details,
+    )
+
+
 def _check_compatibility_matrix(repo_root: Path) -> dict[str, Any]:
     matrix_path = repo_root / "docs" / "source" / "data" / "compatibility_matrix.toml"
     required_validated_ids = {
@@ -748,6 +784,7 @@ def build_report(*, repo_root: Path = REPO_ROOT, run_docs_profile: bool = False)
         _check_docs_mirror_stamp(repo_root),
         _check_docs_workflow_profile(repo_root),
         _check_production_readiness_workflow_profile(repo_root),
+        _check_architecture_scorecard(repo_root),
         _check_compatibility_matrix(repo_root),
         _check_service_health_contract(repo_root),
         _check_controlled_pilot_readiness_gate(repo_root),


### PR DESCRIPTION
## Summary
- add an executable architecture scorecard with explicit evidence-first and multi-tenant production boundaries
- wire the scorecard into production-readiness reporting
- harden remote Dask worker command construction by quoting dynamic fragments
- add regression coverage and public docs for the architecture scorecard

## Notes
- staged only the architecture-scorecard scope; unrelated local dirty files were left unstaged