### PR TITLE
[codex] Fix Barycentric app-scoped state

### DIFF
--- a/src/agilab/apps-pages/view_barycentric/src/view_barycentric/view_barycentric.py
+++ b/src/agilab/apps-pages/view_barycentric/src/view_barycentric/view_barycentric.py
@@ -65,6 +65,50 @@ var_default = [0, None]
 st.title(":chart_with_upwards_trend: Barycentric Graph")
 
 
+PAGE_KEY_PREFIX = "view_barycentric"
+APP_SCOPE_KEY = f"{PAGE_KEY_PREFIX}:active_app_scope"
+APP_SCOPED_SESSION_KEY_PREFIXES = (f"{PAGE_KEY_PREFIX}:",)
+APP_SCOPED_SESSION_DEFAULT_KEYS = (
+    "env",
+    "IS_SOURCE_ENV",
+    "IS_WORKER_ENV",
+    "apps_path",
+    "app",
+    "project",
+    "projects",
+    "TABLE_MAX_ROWS",
+    "GUI_SAMPLING",
+    "datadir",
+    "input_datadir",
+    "csv_files",
+    "df_file",
+    "loaded_df",
+    "variables",
+    "df_cols",
+    "coltype",
+    "discrete",
+    "continuous",
+    "lat",
+    "long",
+)
+
+
+def _reset_app_scoped_session_state(active_app: Path) -> bool:
+    """Clear Barycentric page state that belongs to a specific active app."""
+
+    app_scope = str(active_app.resolve())
+    if st.session_state.get(APP_SCOPE_KEY) == app_scope:
+        return False
+    for key in list(st.session_state.keys()):
+        if key in APP_SCOPED_SESSION_DEFAULT_KEYS or any(
+            isinstance(key, str) and key.startswith(prefix)
+            for prefix in APP_SCOPED_SESSION_KEY_PREFIXES
+        ):
+            st.session_state.pop(key, None)
+    st.session_state[APP_SCOPE_KEY] = app_scope
+    return True
+
+
 class ModifiedScrawler(Scrawler):
     """
     A class representing a modified version of a scrawler.
@@ -651,6 +695,7 @@ def main():
             st.error(f"Error: provided --active-app path not found: {active_app}")
             sys.exit(1)
 
+        _reset_app_scoped_session_state(active_app)
         if "coltype" not in st.session_state:
             st.session_state["coltype"] = var[0]
 

--- a/test/test_view_barycentric.py
+++ b/test/test_view_barycentric.py
@@ -778,6 +778,45 @@ def test_view_barycentric_main_reports_missing_app_and_page_errors(monkeypatch, 
     assert any("page boom" in message for message in errors)
 
 
+def test_view_barycentric_resets_app_scoped_state_on_active_app_change(monkeypatch, tmp_path: Path) -> None:
+    module = _load_module()
+    first_app = tmp_path / "first_app"
+    second_app = tmp_path / "second_app"
+    first_app.mkdir()
+    second_app.mkdir()
+    session_state = _State(
+        {
+            module.APP_SCOPE_KEY: str(first_app.resolve()),
+            "env": object(),
+            "datadir": "/tmp/old-data",
+            "csv_files": ["old.csv"],
+            "df_file": "old.csv",
+            "loaded_df": object(),
+            "variables": ["old-x", "old-y", "old-color"],
+            "view_barycentric:future_widget": "old",
+            "unrelated": "keep",
+        }
+    )
+    monkeypatch.setattr(module, "st", SimpleNamespace(session_state=session_state))
+
+    assert module._reset_app_scoped_session_state(first_app) is False
+    assert "datadir" in session_state
+
+    assert module._reset_app_scoped_session_state(second_app) is True
+    assert session_state[module.APP_SCOPE_KEY] == str(second_app.resolve())
+    assert session_state["unrelated"] == "keep"
+    for key in (
+        "env",
+        "datadir",
+        "csv_files",
+        "df_file",
+        "loaded_df",
+        "variables",
+        "view_barycentric:future_widget",
+    ):
+        assert key not in session_state
+
+
 def test_view_barycentric_repo_path_and_visible_file_helpers(monkeypatch, tmp_path: Path) -> None:
     module = _load_module()
     repo_root = tmp_path / "repo"


### PR DESCRIPTION
## Summary
- add an active-app scope guard for the Barycentric page
- clear page-owned data, selected file, loaded dataframe, variable, and namespaced `view_barycentric:*` state when `--active-app` changes
- preserve same-app state and unrelated session keys
- add a focused regression for cross-app reset behavior

## Why
Barycentric rebuilds runtime env on launch, but warm Streamlit sessions could retain the previous app's data directory, selected dataframe, loaded data, and variable choices.

## Validation
- not run locally; pre-push classified docs mirror, release proof, and app-contract inputs as unchanged
