### PR TITLE
[codex] Fix Data IO Decision app-scoped state

### DIFF
--- a/src/agilab/apps-pages/view_data_io_decision/src/view_data_io_decision/view_data_io_decision.py
+++ b/src/agilab/apps-pages/view_data_io_decision/src/view_data_io_decision/view_data_io_decision.py
@@ -31,6 +31,12 @@ from agi_gui.pagelib import render_logo
 ARTIFACT_ROOT_KEY = "decision_evidence_artifact_root"
 RUN_SELECTION_KEY = "decision_evidence_selected_run"
 SUMMARY_GLOB_KEY = "decision_evidence_summary_glob"
+APP_SCOPE_KEY = "decision_evidence_active_app_scope"
+APP_SCOPED_SESSION_DEFAULT_KEYS = (
+    ARTIFACT_ROOT_KEY,
+    RUN_SELECTION_KEY,
+    SUMMARY_GLOB_KEY,
+)
 
 
 def _resolve_active_app() -> Path:
@@ -39,6 +45,18 @@ def _resolve_active_app() -> Path:
 
 def _default_artifact_root(env: AgiEnv) -> Path:
     return _page_artifact_root(env, "data_io_decision")
+
+
+def _reset_app_scoped_session_defaults(active_app_path: Path) -> bool:
+    """Clear persisted Decision Evidence defaults when the active app changes."""
+
+    app_scope = str(active_app_path.resolve())
+    if st.session_state.get(APP_SCOPE_KEY) == app_scope:
+        return False
+    for key in APP_SCOPED_SESSION_DEFAULT_KEYS:
+        st.session_state.pop(key, None)
+    st.session_state[APP_SCOPE_KEY] = app_scope
+    return True
 
 
 def _discover_files(base: Path, pattern: str) -> list[Path]:
@@ -78,8 +96,9 @@ def _read_csv_if_present(path: Path) -> pd.DataFrame:
 
 st.set_page_config(layout="wide")
 
-if "env" not in st.session_state:
-    active_app_path = _resolve_active_app()
+active_app_path = _resolve_active_app()
+app_scope_changed = _reset_app_scoped_session_defaults(active_app_path)
+if "env" not in st.session_state or app_scope_changed:
     env = AgiEnv(apps_path=active_app_path.parent, app=active_app_path.name, verbose=0)
     env.init_done = True
     st.session_state["env"] = env
@@ -118,12 +137,11 @@ if not summary_files:
 
 summary_label_to_path = {_relative_summary_label(path, artifact_root): path for path in summary_files}
 summary_labels = list(summary_label_to_path.keys())
-saved_run = st.session_state.get(RUN_SELECTION_KEY)
-default_index = summary_labels.index(saved_run) if saved_run in summary_labels else len(summary_labels) - 1
+if st.session_state.get(RUN_SELECTION_KEY) not in summary_labels:
+    st.session_state[RUN_SELECTION_KEY] = summary_labels[-1]
 selected_label = st.sidebar.selectbox(
     "Run",
     options=summary_labels,
-    index=default_index,
     key=RUN_SELECTION_KEY,
 )
 summary_path = summary_label_to_path[selected_label]

--- a/test/test_view_data_io_decision.py
+++ b/test/test_view_data_io_decision.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+
+PAGE_PATH = (
+    "src/agilab/apps-pages/view_data_io_decision/"
+    "src/view_data_io_decision/view_data_io_decision.py"
+)
+
+
+def _load_helpers() -> ModuleType:
+    source = Path(PAGE_PATH).read_text(encoding="utf-8")
+    prefix = source.split('\nst.set_page_config(layout="wide")\n', 1)[0]
+    module = ModuleType("view_data_io_decision_test_module")
+    module.__file__ = str(Path(PAGE_PATH).resolve())
+    module.__package__ = None
+    exec(compile(prefix, str(Path(PAGE_PATH)), "exec"), module.__dict__)
+    return module
+
+
+def test_view_data_io_decision_resets_app_scoped_state_on_active_app_change(tmp_path) -> None:
+    module = _load_helpers()
+    first_app = tmp_path / "first_app"
+    second_app = tmp_path / "second_app"
+    first_app.mkdir()
+    second_app.mkdir()
+    module.st = SimpleNamespace(
+        session_state={
+            module.APP_SCOPE_KEY: str(first_app.resolve()),
+            module.ARTIFACT_ROOT_KEY: "/tmp/old-artifacts",
+            module.RUN_SELECTION_KEY: "old-run",
+            module.SUMMARY_GLOB_KEY: "*old.json",
+        }
+    )
+
+    assert module._reset_app_scoped_session_defaults(first_app) is False
+    assert module.ARTIFACT_ROOT_KEY in module.st.session_state
+
+    assert module._reset_app_scoped_session_defaults(second_app) is True
+    assert module.st.session_state[module.APP_SCOPE_KEY] == str(second_app.resolve())
+    for key in module.APP_SCOPED_SESSION_DEFAULT_KEYS:
+        assert key not in module.st.session_state
+
+
+def test_view_data_io_decision_helper_edge_cases(tmp_path) -> None:
+    module = _load_helpers()
+
+    assert module._format_delta(2.25) == "+2.2%"
+    assert module._format_delta(-1, suffix=" ms") == "-1.0 ms"
+    assert module._format_delta("bad") is None
+
+    missing = tmp_path / "missing.csv"
+    assert module._read_csv_if_present(missing).empty


### PR DESCRIPTION
## Summary
- add an active-app scope guard for the Data IO Decision page
- clear artifact root, summary glob, and selected run state when `--active-app` changes
- normalize the selected run before rendering the keyed selectbox instead of passing a duplicate widget index
- add focused helper regressions for app-scope reset and edge cases

## Why
Decision Evidence persisted app-specific Streamlit state under global keys. In a warm session, switching apps could keep the previous app's artifact path or selected run. The keyed selectbox also received an explicit index while session state owned the widget value.

## Validation
- not run locally; pre-push classified docs mirror, release proof, and app-contract inputs as unchanged
