### PR TITLE
[codex] Fix Live Artifacts app path-scoped state

### DIFF
--- a/src/agilab/apps-pages/view_live_artifacts/src/view_live_artifacts/view_live_artifacts.py
+++ b/src/agilab/apps-pages/view_live_artifacts/src/view_live_artifacts/view_live_artifacts.py
@@ -17,6 +17,12 @@ from agi_pages.runtime import relative_label, resolve_active_app_path
 
 
 PAGE_KEY = "view_live_artifacts"
+APP_SCOPE_KEY = f"{PAGE_KEY}__active_app_scope"
+APP_SCOPED_SESSION_KEY_PREFIXES = (f"{PAGE_KEY}__",)
+APP_SCOPED_SESSION_DEFAULT_KEYS = (
+    "env",
+    f"{PAGE_KEY}_preview_artifact",
+)
 DEFAULT_PATTERNS = (
     "**/live_state.json",
     "**/analysis_manifest.json",
@@ -261,6 +267,24 @@ def _resolve_active_app() -> Path:
     return resolve_active_app_path(error_fn=st.error, stop_fn=st.stop)
 
 
+def _reset_app_scoped_session_state(active_app_path: Path) -> bool:
+    """Clear Live Artifacts state that belongs to a specific active app path."""
+
+    app_scope = str(active_app_path.resolve())
+    if st.session_state.get(APP_SCOPE_KEY) == app_scope:
+        return False
+    for key in list(st.session_state.keys()):
+        if key == APP_SCOPE_KEY:
+            continue
+        if key in APP_SCOPED_SESSION_DEFAULT_KEYS or any(
+            isinstance(key, str) and key.startswith(prefix)
+            for prefix in APP_SCOPED_SESSION_KEY_PREFIXES
+        ):
+            st.session_state.pop(key, None)
+    st.session_state[APP_SCOPE_KEY] = app_scope
+    return True
+
+
 def _active_env(active_app_path: Path) -> AgiEnv:
     current = st.session_state.get("env")
     current_apps_path = getattr(current, "apps_path", None)
@@ -408,6 +432,7 @@ def _render_live_or_static_panel(root: Path, patterns: tuple[str, ...], max_file
 def main() -> None:
     st.set_page_config(layout="wide")
     active_app_path = _resolve_active_app()
+    _reset_app_scoped_session_state(active_app_path)
     env = _active_env(active_app_path)
 
     render_logo("Live Artifacts")

--- a/test/test_view_live_artifacts.py
+++ b/test/test_view_live_artifacts.py
@@ -184,6 +184,37 @@ def test_live_artifacts_resolve_active_app_delegates_to_runtime(monkeypatch, tmp
     assert module._resolve_active_app() == tmp_path / "apps" / "demo_project"
 
 
+def test_live_artifacts_resets_path_scoped_state_on_active_app_change(monkeypatch, tmp_path: Path) -> None:
+    module = _load_module()
+    first_app = tmp_path / "apps_a" / "demo_project"
+    second_app = tmp_path / "apps_b" / "demo_project"
+    first_app.mkdir(parents=True)
+    second_app.mkdir(parents=True)
+    state = {
+        module.APP_SCOPE_KEY: str(first_app.resolve()),
+        "env": object(),
+        module._state_key("demo_project", "root_choice"): "Custom path",
+        module._state_key("demo_project", "patterns"): "*.json",
+        f"{module.PAGE_KEY}_preview_artifact": "old.json",
+        "unrelated": "keep",
+    }
+    monkeypatch.setattr(module, "st", SimpleNamespace(session_state=state))
+
+    assert module._reset_app_scoped_session_state(first_app) is False
+    assert module._state_key("demo_project", "root_choice") in state
+
+    assert module._reset_app_scoped_session_state(second_app) is True
+    assert state[module.APP_SCOPE_KEY] == str(second_app.resolve())
+    assert state["unrelated"] == "keep"
+    for key in (
+        "env",
+        module._state_key("demo_project", "root_choice"),
+        module._state_key("demo_project", "patterns"),
+        f"{module.PAGE_KEY}_preview_artifact",
+    ):
+        assert key not in state
+
+
 def test_live_artifacts_rebuilds_env_when_session_env_points_to_another_apps_root(
     monkeypatch,
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- add an active-app path scope guard for Live Artifacts
- clear page-owned `view_live_artifacts__*` controls, preview selection, and env when the active-app path changes
- preserve same-path state and unrelated session keys
- add a focused regression for same app name from different app roots

## Why
Live Artifacts already scopes controls by app name and rebuilds env on app-root drift, but two projects with the same app name under different roots could reuse stale page controls and preview state in a warm Streamlit session.

## Validation
- not run locally; pre-push classified docs mirror, release proof, and app-contract inputs as unchanged
