### PR TITLE
[codex] Fix training analysis active app state

### DIFF
--- a/src/agilab/apps-pages/view_training_analysis/src/view_training_analysis/view_training_analysis.py
+++ b/src/agilab/apps-pages/view_training_analysis/src/view_training_analysis/view_training_analysis.py
@@ -44,10 +44,22 @@ except ModuleNotFoundError:  # pragma: no cover
 
 
 PAGE_KEY = "view_training_analysis"
+APP_SCOPE_KEY = f"{PAGE_KEY}_active_app_path"
 RUN_ROOTS_KEY = f"{PAGE_KEY}_run_roots"
 TRAINERS_KEY = f"{PAGE_KEY}_trainers"
 TAGS_KEY = f"{PAGE_KEY}_tags"
 X_AXIS_KEY = f"{PAGE_KEY}_x_axis"
+APP_SCOPED_SESSION_KEYS = (
+    "env",
+    "app_settings",
+    "base_dir_choice",
+    "input_datadir",
+    "datadir_rel",
+    RUN_ROOTS_KEY,
+    TRAINERS_KEY,
+    TAGS_KEY,
+    X_AXIS_KEY,
+)
 TRAINING_HISTORY_REL = Path("data/training_history.csv")
 SCALAR_FRAME_COLUMNS = ["tag", "step", "wall_time", "value"]
 EMBED_QUERY_VALUES = {"1", "true", "yes", "on"}
@@ -65,6 +77,41 @@ from agi_gui.pagelib import render_logo
 
 def _resolve_active_app() -> Path:
     return resolve_active_app_path(error_fn=st.error, stop_fn=st.stop)
+
+
+def _env_app_scope_key(env: Any) -> str | None:
+    app_path = getattr(env, "app_path", None)
+    if app_path:
+        return str(Path(app_path).resolve())
+    apps_path = getattr(env, "apps_path", None)
+    app = getattr(env, "app", None)
+    if apps_path and app:
+        return str((Path(apps_path) / str(app)).resolve())
+    return None
+
+
+def _ensure_app_scoped_env() -> AgiEnv:
+    env = st.session_state.get("env")
+    scope_key = st.session_state.get(APP_SCOPE_KEY)
+    if env is not None and scope_key is None:
+        inferred_scope_key = _env_app_scope_key(env)
+        if inferred_scope_key is None:
+            return env
+        st.session_state[APP_SCOPE_KEY] = inferred_scope_key
+        scope_key = inferred_scope_key
+
+    active_app_path = _resolve_active_app()
+    active_app_key = str(active_app_path.resolve())
+    if scope_key != active_app_key:
+        for key in APP_SCOPED_SESSION_KEYS:
+            st.session_state.pop(key, None)
+        st.session_state[APP_SCOPE_KEY] = active_app_key
+
+    if "env" not in st.session_state:
+        env = AgiEnv(apps_path=active_app_path.parent, app=active_app_path.name, verbose=0)
+        env.init_done = True
+        st.session_state["env"] = env
+    return st.session_state["env"]
 
 
 def _ensure_app_settings_loaded(env: AgiEnv) -> None:
@@ -592,13 +639,7 @@ def main() -> None:
     if embed_mode:
         _render_embed_chrome()
 
-    if "env" not in st.session_state:
-        active_app_path = _resolve_active_app()
-        env = AgiEnv(apps_path=active_app_path.parent, app=active_app_path.name, verbose=0)
-        env.init_done = True
-        st.session_state["env"] = env
-    else:
-        env = st.session_state["env"]
+    env = _ensure_app_scoped_env()
 
     _ensure_app_settings_loaded(env)
 

--- a/test/test_view_training_analysis.py
+++ b/test/test_view_training_analysis.py
@@ -635,6 +635,91 @@ def test_view_training_analysis_main_bootstraps_env_when_missing(monkeypatch, tm
     assert any("No TensorBoard or training-history outputs found" in message for message in warnings_seen)
 
 
+def test_view_training_analysis_main_resets_state_when_active_app_changes(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    module = _load_module()
+    old_app = tmp_path / "apps" / "old_trainer_project"
+    new_app = tmp_path / "apps" / "new_trainer_project"
+    old_app.mkdir(parents=True)
+    new_app.mkdir(parents=True)
+    old_export = tmp_path / "old-export"
+    new_export = tmp_path / "new-export"
+    new_export.mkdir()
+    old_settings_path = tmp_path / "old_settings.toml"
+    new_settings_path = tmp_path / "new_settings.toml"
+    warnings_seen: list[str] = []
+
+    old_env = SimpleNamespace(
+        apps_path=old_app.parent,
+        app=old_app.name,
+        app_settings_file=old_settings_path,
+        share_root_path=lambda: str(tmp_path / "old-share"),
+        AGILAB_EXPORT_ABS=str(old_export),
+    )
+
+    class FakeEnv:
+        def __init__(self, apps_path, app, verbose):
+            self.apps_path = apps_path
+            self.app = app
+            self.verbose = verbose
+            self.app_settings_file = new_settings_path
+            self.share_root_path = lambda: str(tmp_path / "new-share")
+            self.AGILAB_EXPORT_ABS = str(new_export)
+            self.init_done = False
+
+    module.st = SimpleNamespace(
+        session_state={
+            "env": old_env,
+            module.APP_SCOPE_KEY: str(old_app.resolve()),
+            "app_settings": {"view_training_analysis": {"datadir_rel": "stale"}},
+            "base_dir_choice": "Custom",
+            "input_datadir": str(old_export),
+            "datadir_rel": "stale",
+            module.TRAINERS_KEY: ["old-trainer"],
+            module.RUN_ROOTS_KEY: ["old-run"],
+            module.TAGS_KEY: ["old-tag"],
+            module.X_AXIS_KEY: "timestamp",
+        },
+        sidebar=SimpleNamespace(
+            radio=lambda *args, **kwargs: "AGILAB_EXPORT",
+            text_input=lambda *args, **kwargs: None,
+            caption=lambda *args, **kwargs: None,
+            selectbox=lambda label, options, index=0, key=None, format_func=None: options[index],
+            multiselect=lambda *args, **kwargs: [],
+        ),
+        set_page_config=lambda **kwargs: None,
+        title=lambda *args, **kwargs: None,
+        caption=lambda *args, **kwargs: None,
+        warning=warnings_seen.append,
+        info=lambda *args, **kwargs: None,
+        error=lambda *args, **kwargs: None,
+        subheader=lambda *args, **kwargs: None,
+        plotly_chart=lambda *args, **kwargs: None,
+        stop=_stop,
+    )
+    monkeypatch.setattr(module, "render_logo", lambda *args, **kwargs: None)
+    monkeypatch.setattr(module, "_resolve_active_app", lambda: new_app)
+    monkeypatch.setattr(module, "AgiEnv", FakeEnv)
+    monkeypatch.setattr(module, "_discover_training_roots", lambda root: [])
+
+    with pytest.raises(_StopCalled):
+        module.main()
+
+    assert module.st.session_state[module.APP_SCOPE_KEY] == str(new_app.resolve())
+    assert module.st.session_state["env"].app == "new_trainer_project"
+    assert module.st.session_state["env"].init_done is True
+    assert module.st.session_state["app_settings"] == {"view_training_analysis": {}}
+    assert module.st.session_state["input_datadir"] == ""
+    assert module.st.session_state["datadir_rel"] == ""
+    assert module.st.session_state[module.X_AXIS_KEY] == "step"
+    assert module.TRAINERS_KEY not in module.st.session_state
+    assert module.RUN_ROOTS_KEY not in module.st.session_state
+    assert module.TAGS_KEY not in module.st.session_state
+    assert any("No TensorBoard or training-history outputs found" in message for message in warnings_seen)
+
+
 def test_view_training_analysis_main_plots_selected_metrics(monkeypatch, tmp_path: Path) -> None:
     module = _load_module()
     export_root = tmp_path / "export"


### PR DESCRIPTION
## Summary
- reset view_training_analysis page-owned env/settings/widget state when --active-app changes
- rebuild the app-scoped AgiEnv for the new active app path
- add a regression test for stale trainer/run/tag state crossing app boundaries

## Local validation
- not run; relying on PR checks for this app sweep
