### PR TITLE
[codex] Fix inference analysis active app state

### DIFF
--- a/src/agilab/apps-pages/view_inference_analysis/src/view_inference_analysis/view_inference_analysis.py
+++ b/src/agilab/apps-pages/view_inference_analysis/src/view_inference_analysis/view_inference_analysis.py
@@ -57,6 +57,19 @@ PROFILE_METRIC_KEY = f"{PAGE_KEY}:profile_metric"
 PROFILE_AXIS_KEY = f"{PAGE_KEY}:profile_axis"
 DETAIL_RUNS_KEY = f"{PAGE_KEY}:detail_runs"
 ENV_KEY = f"{PAGE_KEY}:env"
+APP_SCOPE_KEY = f"{PAGE_KEY}:active_app_path"
+APP_SCOPED_SESSION_KEYS = (
+    ENV_KEY,
+    BASE_CHOICE_KEY,
+    CUSTOM_BASE_KEY,
+    SUBPATH_KEY,
+    GLOBS_KEY,
+    FILES_KEY,
+    AGGREGATION_KEY,
+    PROFILE_METRIC_KEY,
+    PROFILE_AXIS_KEY,
+    DETAIL_RUNS_KEY,
+)
 LOAD_CACHE_VERSION = 2
 HEATMAP_ANNOTATION_MAX_DIM = 12
 HEATMAP_MAX_COLUMNS = 2
@@ -142,6 +155,22 @@ def _resolve_active_app() -> Path:
         st.error(f"Provided --active-app path not found: {active_app_path}")
         st.stop()
     return active_app_path
+
+
+def _reset_state_for_active_app(active_app_path: Path) -> None:
+    active_app_key = str(active_app_path.resolve())
+    current_scope = st.session_state.get(APP_SCOPE_KEY)
+    if current_scope == active_app_key:
+        return
+    env = st.session_state.get(ENV_KEY)
+    if current_scope is None and isinstance(env, AgiEnv):
+        env_active_app = Path(getattr(env, "active_app", active_app_path)).resolve()
+        if str(env_active_app) == active_app_key:
+            st.session_state[APP_SCOPE_KEY] = active_app_key
+            return
+    for key in APP_SCOPED_SESSION_KEYS:
+        st.session_state.pop(key, None)
+    st.session_state[APP_SCOPE_KEY] = active_app_key
 
 
 def _load_app_settings(env: AgiEnv) -> dict[str, Any]:
@@ -1352,6 +1381,7 @@ def main() -> None:
     st.set_page_config(page_title=PAGE_TITLE, layout="wide")
 
     active_app_path = _resolve_active_app()
+    _reset_state_for_active_app(active_app_path)
     env = st.session_state.get(ENV_KEY)
     if not isinstance(env, AgiEnv) or Path(getattr(env, "active_app", active_app_path)).resolve() != active_app_path:
         env = AgiEnv(apps_path=active_app_path.parent, app=active_app_path.name, verbose=0)

--- a/test/test_view_inference_analysis.py
+++ b/test/test_view_inference_analysis.py
@@ -1414,7 +1414,19 @@ def test_view_inference_analysis_main_stops_when_dataset_root_is_missing(monkeyp
     module = _load_module()
     fake_st = _FakeStreamlit()
     active_app = tmp_path / "demo_project"
+    old_app = tmp_path / "old_demo_project"
     active_app.mkdir()
+    old_app.mkdir()
+    fake_st.session_state[module.APP_SCOPE_KEY] = str(old_app.resolve())
+    fake_st.session_state[module.BASE_CHOICE_KEY] = "Custom"
+    fake_st.session_state[module.CUSTOM_BASE_KEY] = str(tmp_path / "old-base")
+    fake_st.session_state[module.SUBPATH_KEY] = "old/pipeline"
+    fake_st.session_state[module.GLOBS_KEY] = "old.json"
+    fake_st.session_state[module.FILES_KEY] = ["old-run"]
+    fake_st.session_state[module.AGGREGATION_KEY] = "sum"
+    fake_st.session_state[module.PROFILE_METRIC_KEY] = "old_metric"
+    fake_st.session_state[module.PROFILE_AXIS_KEY] = "old_axis"
+    fake_st.session_state[module.DETAIL_RUNS_KEY] = ["old-run"]
 
     class _FakeEnv:
         def __init__(self, **_kwargs):
@@ -1441,7 +1453,17 @@ def test_view_inference_analysis_main_stops_when_dataset_root_is_missing(monkeyp
     assert fake_st.headers[0] == "Data source"
     assert fake_st.infos == [f"Resolved dataset root: `{tmp_path / 'missing-root'}`"]
     assert fake_st.warnings == [f"Dataset root does not exist yet: {tmp_path / 'missing-root'}"]
+    assert fake_st.session_state[module.APP_SCOPE_KEY] == str(active_app.resolve())
     assert module.ENV_KEY in fake_st.session_state
+    assert fake_st.session_state[module.BASE_CHOICE_KEY] == "AGI_CLUSTER_SHARE"
+    assert fake_st.session_state[module.CUSTOM_BASE_KEY] == ""
+    assert fake_st.session_state[module.SUBPATH_KEY] == "demo/pipeline"
+    assert fake_st.session_state[module.GLOBS_KEY] == "**/allocations_steps.json"
+    assert fake_st.session_state[module.AGGREGATION_KEY] == "mean"
+    assert module.FILES_KEY not in fake_st.session_state
+    assert module.PROFILE_METRIC_KEY not in fake_st.session_state
+    assert module.PROFILE_AXIS_KEY not in fake_st.session_state
+    assert module.DETAIL_RUNS_KEY not in fake_st.session_state
 
 
 def test_view_inference_analysis_main_stops_when_dataset_root_is_unresolved(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- clear view_inference_analysis page-owned selections when --active-app changes
- keep same-app env reuse while adding explicit active-app path scope
- extend main-state coverage for stale base/glob/file/profile/detail selections

## Local validation
- not run; relying on PR checks for this app sweep
