### PR TITLE
[codex] Fix SHAP explanation active app state

### DIFF
--- a/src/agilab/apps-pages/view_shap_explanation/src/view_shap_explanation/view_shap_explanation.py
+++ b/src/agilab/apps-pages/view_shap_explanation/src/view_shap_explanation/view_shap_explanation.py
@@ -42,8 +42,54 @@ from agi_env import AgiEnv
 from agi_gui.pagelib import render_logo
 
 
+PAGE_KEY = "view_shap_explanation"
+APP_SCOPE_KEY = f"{PAGE_KEY}_active_app_path"
+APP_SCOPED_SESSION_KEYS = (
+    "env",
+    "shap_explanation_datadir",
+    "shap_values_glob",
+    "shap_feature_values_glob",
+    "shap_metadata_glob",
+)
+
+
 def _resolve_active_app() -> Path:
     return resolve_active_app_path(error_fn=st.error, stop_fn=st.stop)
+
+
+def _env_app_scope_key(env: Any) -> str | None:
+    app_path = getattr(env, "app_path", None)
+    if app_path:
+        return str(Path(app_path).resolve())
+    apps_path = getattr(env, "apps_path", None)
+    app = getattr(env, "app", None)
+    if apps_path and app:
+        return str((Path(apps_path) / str(app)).resolve())
+    return None
+
+
+def _ensure_app_scoped_env() -> AgiEnv:
+    env = st.session_state.get("env")
+    scope_key = st.session_state.get(APP_SCOPE_KEY)
+    if env is not None and scope_key is None:
+        inferred_scope_key = _env_app_scope_key(env)
+        if inferred_scope_key is None:
+            return env
+        st.session_state[APP_SCOPE_KEY] = inferred_scope_key
+        scope_key = inferred_scope_key
+
+    active_app_path = _resolve_active_app()
+    active_app_key = str(active_app_path.resolve())
+    if scope_key != active_app_key:
+        for key in APP_SCOPED_SESSION_KEYS:
+            st.session_state.pop(key, None)
+        st.session_state[APP_SCOPE_KEY] = active_app_key
+
+    if "env" not in st.session_state:
+        env = AgiEnv(apps_path=active_app_path.parent, app=active_app_path.name, verbose=0)
+        env.init_done = True
+        st.session_state["env"] = env
+    return st.session_state["env"]
 
 
 def _default_artifact_root(env: AgiEnv) -> Path:
@@ -149,13 +195,7 @@ def _state_text_input(key: str, label: str, default_value: str) -> str:
 
 st.set_page_config(layout="wide")
 
-if "env" not in st.session_state:
-    active_app_path = _resolve_active_app()
-    env = AgiEnv(apps_path=active_app_path.parent, app=active_app_path.name, verbose=0)
-    env.init_done = True
-    st.session_state["env"] = env
-else:
-    env = st.session_state["env"]
+env = _ensure_app_scoped_env()
 
 render_logo("SHAP Explanation")
 st.title("SHAP explanation")

--- a/test/test_view_shap_explanation.py
+++ b/test/test_view_shap_explanation.py
@@ -104,6 +104,47 @@ def test_view_shap_explanation_warns_when_artifact_directory_is_missing(
     assert any("Artifact directory does not exist yet" in warning.value for warning in at.warning)
 
 
+def test_view_shap_explanation_resets_stale_app_scoped_state(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    module = _load_shap_helpers()
+    project_dir = _create_demo_project(tmp_path)
+    old_project = project_dir.parent / "old_mycode_project"
+    old_project.mkdir()
+    argv = [Path(PAGE_PATH).name, "--active-app", str(project_dir)]
+
+    with patch.object(sys, "argv", argv):
+        monkeypatch.setenv("AGI_EXPORT_DIR", str(tmp_path / "export"))
+        monkeypatch.setenv("AGI_LOCAL_SHARE", str(tmp_path / "localshare"))
+        monkeypatch.setenv("AGI_CLUSTER_SHARE", str(tmp_path / "clustershare"))
+        monkeypatch.setenv("OPENAI_API_KEY", "dummy")
+        monkeypatch.setenv("IS_SOURCE_ENV", "1")
+        at = AppTest.from_file(PAGE_PATH, default_timeout=20)
+        at.session_state[module.APP_SCOPE_KEY] = str(old_project.resolve())
+        at.session_state["env"] = SimpleNamespace(
+            apps_path=old_project.parent,
+            app=old_project.name,
+            AGILAB_EXPORT_ABS=str(tmp_path / "old-export"),
+            target="old_mycode",
+        )
+        at.session_state["shap_explanation_datadir"] = str(tmp_path / "old-export" / "old_mycode")
+        at.session_state["shap_values_glob"] = "old_values.csv"
+        at.session_state["shap_feature_values_glob"] = "old_features.csv"
+        at.session_state["shap_metadata_glob"] = "old_metadata.json"
+        at.run()
+
+    assert not at.exception
+    assert at.session_state[module.APP_SCOPE_KEY] == str(project_dir.resolve())
+    assert at.session_state["shap_explanation_datadir"] == str(
+        tmp_path / "export" / "mycode" / "shap_explanation"
+    )
+    assert at.session_state["shap_values_glob"] == "**/shap_values.*"
+    assert at.session_state["shap_feature_values_glob"] == "**/feature_values.*"
+    assert at.session_state["shap_metadata_glob"] == "**/explanation_summary.json"
+    assert any("Artifact directory does not exist yet" in warning.value for warning in at.warning)
+
+
 def test_view_shap_explanation_warns_when_shap_values_are_missing(
     tmp_path: Path,
     monkeypatch,


### PR DESCRIPTION
## Summary
- reset view_shap_explanation env and artifact glob state when --active-app changes
- rebuild the active-app env after stale app state is discarded
- add AppTest coverage for stale SHAP artifact roots crossing app boundaries

## Local validation
- not run; relying on PR checks for this app sweep
