### PR TITLE
[codex] Allow UV_INDEX_URL offline mirrors

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -982,6 +982,9 @@ update_environment() {
         echo "AGI_CLUSTER_SHARE=\"$AGI_CLUSTER_SHARE\""
         echo "AGI_LOCAL_SHARE=\"$AGI_LOCAL_SHARE\""
         echo "AGI_INTERNET_ON=\"$AGI_INTERNET_ON\""
+        if [[ -n "${UV_INDEX_URL:-}" ]]; then
+            echo "UV_INDEX_URL=\"$UV_INDEX_URL\""
+        fi
         echo "IS_SOURCE_ENV=\"1\""
     } > "$ENV_FILE"
     echo -e "${GREEN}Environment updated in $ENV_FILE${NC}"

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_build_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_build_support.py
@@ -59,15 +59,29 @@ def _python_site_version(pyvers_worker: str) -> str:
     return python_dirs[0] + "." + python_dirs[1]
 
 
-def _uv_offline_flag(env: Any) -> str:
-    envars = getattr(env, "envars", {})
-    raw = os.environ.get("AGI_INTERNET_ON")
+def _envar_value(envars: Any, key: str) -> Any:
+    raw = os.environ.get(key)
     if raw is None:
         try:
-            raw = envars.get("AGI_INTERNET_ON")
+            raw = envars.get(key)
         except (AttributeError, RuntimeError, TypeError):
             raw = None
+    return raw
+
+
+def _envar_nonempty(envars: Any, key: str) -> bool:
+    raw = _envar_value(envars, key)
     if raw is None:
+        return False
+    return bool(str(raw).strip().strip("\"'").strip())
+
+
+def _uv_offline_flag(env: Any) -> str:
+    envars = getattr(env, "envars", {})
+    raw = _envar_value(envars, "AGI_INTERNET_ON")
+    if raw is None:
+        return ""
+    if _envar_nonempty(envars, "UV_INDEX_URL"):
         return ""
     if isinstance(raw, bool):
         return "" if raw else "--offline "

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_local_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_local_support.py
@@ -1505,14 +1505,28 @@ def _shell_env_prefix(env_overrides: dict[str, str], *, os_name: str = os.name) 
     return "".join(f"{key}={quote(value)} " for key, value in env_overrides.items())
 
 
-def _uv_offline_flag(envars: Any) -> str:
-    raw = os.environ.get("AGI_INTERNET_ON")
+def _envar_value(envars: Any, key: str) -> Any:
+    raw = os.environ.get(key)
     if raw is None:
         try:
-            raw = envars.get("AGI_INTERNET_ON")
+            raw = envars.get(key)
         except (AttributeError, RuntimeError, TypeError):
             raw = None
+    return raw
+
+
+def _envar_nonempty(envars: Any, key: str) -> bool:
+    raw = _envar_value(envars, key)
     if raw is None:
+        return False
+    return bool(str(raw).strip().strip("\"'").strip())
+
+
+def _uv_offline_flag(envars: Any) -> str:
+    raw = _envar_value(envars, "AGI_INTERNET_ON")
+    if raw is None:
+        return ""
+    if _envar_nonempty(envars, "UV_INDEX_URL"):
         return ""
     if isinstance(raw, bool):
         return "" if raw else "--offline "

--- a/src/agilab/core/test/test_agi_distributor_deployment_build_support.py
+++ b/src/agilab/core/test/test_agi_distributor_deployment_build_support.py
@@ -422,6 +422,7 @@ async def test_build_lib_local_uses_free_threading_uv_prefix(monkeypatch, tmp_pa
 @pytest.mark.asyncio
 async def test_build_lib_local_uses_editable_core_installs_in_source_env(monkeypatch, tmp_path):
     monkeypatch.delenv("AGI_INTERNET_ON", raising=False)
+    monkeypatch.delenv("UV_INDEX_URL", raising=False)
     env = _build_env(tmp_path)
     env.is_source_env = True
     env.envars = {"AGI_INTERNET_ON": "0"}
@@ -448,6 +449,50 @@ async def test_build_lib_local_uses_editable_core_installs_in_source_env(monkeyp
     assert any(
         (
             f'--offline --project "{env.active_app}" pip install --upgrade --no-deps '
+            f"-e '{env.agi_env}' -e '{env.agi_node}'"
+        )
+        in cmd
+        for cmd, _ in commands
+    )
+
+
+@pytest.mark.asyncio
+async def test_build_lib_local_uses_uv_index_url_mirror_when_internet_disabled(
+    monkeypatch, tmp_path
+):
+    monkeypatch.delenv("AGI_INTERNET_ON", raising=False)
+    monkeypatch.delenv("UV_INDEX_URL", raising=False)
+    env = _build_env(tmp_path)
+    env.is_source_env = True
+    env.envars = {
+        "AGI_INTERNET_ON": "0",
+        "UV_INDEX_URL": "http://mirror.local/simple",
+    }
+    (env.wenv_abs / "dist" / "demo.egg").write_text("egg", encoding="utf-8")
+    commands = []
+
+    async def _fake_run(cmd, cwd):
+        commands.append((cmd, str(cwd)))
+        return ""
+
+    AGI.env = env
+    AGI._mode = AGI.PYTHON_MODE
+    AGI._dask_client = None
+    AGI.agi_workers = {"pandas": "pandas-worker"}
+
+    await deployment_build_support.build_lib_local(
+        AGI,
+        ensure_optional_extras_fn=uv_source_support.ensure_optional_extras,
+        stage_uv_sources_fn=uv_source_support.stage_uv_sources_for_copied_pyproject,
+        validate_worker_uv_sources_fn=uv_source_support.validate_worker_uv_sources,
+        run_fn=_fake_run,
+    )
+
+    assert commands
+    assert not any("--offline" in cmd for cmd, _ in commands)
+    assert any(
+        (
+            f'--project "{env.active_app}" pip install --upgrade --no-deps '
             f"-e '{env.agi_env}' -e '{env.agi_node}'"
         )
         in cmd

--- a/src/agilab/core/test/test_agi_distributor_deployment_local_support.py
+++ b/src/agilab/core/test/test_agi_distributor_deployment_local_support.py
@@ -1441,6 +1441,7 @@ def test_shell_env_prefix_returns_empty_for_no_overrides():
 
 def test_uv_offline_flag_handles_failing_lookup_false_and_nan(monkeypatch):
     monkeypatch.delenv("AGI_INTERNET_ON", raising=False)
+    monkeypatch.delenv("UV_INDEX_URL", raising=False)
 
     class _BrokenEnvars:
         def get(self, _key):
@@ -1475,6 +1476,7 @@ def test_uv_offline_flag_accepts_quoted_truthy_envar_values(monkeypatch):
 
 def test_uv_offline_flag_keeps_quoted_false_values_offline(monkeypatch):
     monkeypatch.delenv("AGI_INTERNET_ON", raising=False)
+    monkeypatch.delenv("UV_INDEX_URL", raising=False)
 
     assert (
         deployment_local_support._uv_offline_flag({"AGI_INTERNET_ON": '"0"'})
@@ -1482,6 +1484,30 @@ def test_uv_offline_flag_keeps_quoted_false_values_offline(monkeypatch):
     )
     assert (
         deployment_local_support._uv_offline_flag({"AGI_INTERNET_ON": "'false'"})
+        == "--offline "
+    )
+
+
+def test_uv_offline_flag_uses_uv_index_url_mirror_when_internet_disabled(monkeypatch):
+    monkeypatch.delenv("AGI_INTERNET_ON", raising=False)
+    monkeypatch.delenv("UV_INDEX_URL", raising=False)
+
+    assert (
+        deployment_local_support._uv_offline_flag(
+            {
+                "AGI_INTERNET_ON": "0",
+                "UV_INDEX_URL": "http://mirror.local/simple",
+            }
+        )
+        == ""
+    )
+
+    monkeypatch.setenv("UV_INDEX_URL", "http://mirror.local/simple")
+    assert deployment_local_support._uv_offline_flag({"AGI_INTERNET_ON": "0"}) == ""
+
+    monkeypatch.setenv("UV_INDEX_URL", "")
+    assert (
+        deployment_local_support._uv_offline_flag({"AGI_INTERNET_ON": "0"})
         == "--offline "
     )
 


### PR DESCRIPTION
## Summary
- preserve `UV_INDEX_URL` from `install.sh` into the AGILAB environment
- avoid forcing `uv --offline` when public internet is unavailable but a local/internal `UV_INDEX_URL` mirror is configured
- add local deployment and build support regressions for mirror mode

## Validation
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files install.sh src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_local_support.py src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_build_support.py src/agilab/core/test/test_agi_distributor_deployment_local_support.py src/agilab/core/test/test_agi_distributor_deployment_build_support.py`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' src/agilab/core/test/test_agi_distributor_deployment_local_support.py::test_uv_offline_flag_handles_failing_lookup_false_and_nan src/agilab/core/test/test_agi_distributor_deployment_local_support.py::test_uv_offline_flag_keeps_quoted_false_values_offline src/agilab/core/test/test_agi_distributor_deployment_local_support.py::test_uv_offline_flag_uses_uv_index_url_mirror_when_internet_disabled src/agilab/core/test/test_agi_distributor_deployment_build_support.py::test_build_lib_local_uses_editable_core_installs_in_source_env src/agilab/core/test/test_agi_distributor_deployment_build_support.py::test_build_lib_local_uses_uv_index_url_mirror_when_internet_disabled`
- `bash -n install.sh src/agilab/install_apps.sh src/agilab/core/install.sh`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_install_apps_discovery.py test/test_install_contract_check.py test/test_install_local_models.py test/test_install_release_proof_package.py src/agilab/core/test/test_agi_distributor_deployment_build_support.py src/agilab/core/test/test_agi_distributor_deployment_local_support.py`
- `uv --preview-features extra-build-dependencies run --no-sync pytest -q -o addopts='' src/agilab/core/test`
