### PR TITLE
[codex] Support offline install resolver modes

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -57,6 +57,47 @@ configure_uv_link_mode() {
 
 configure_uv_link_mode
 
+redact_url_value() {
+    local raw="$1"
+    if [[ "$raw" =~ ^([^:/]+://)[^/@]+@(.+)$ ]]; then
+        printf '%s***@%s' "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}"
+    else
+        printf '%s' "$raw"
+    fi
+}
+
+uv_resolver_mode() {
+    if [[ -n "${UV_INDEX_URL:-}" || -n "${UV_EXTRA_INDEX_URL:-}" ]]; then
+        echo "mirror"
+    elif [[ -n "${UV_FIND_LINKS:-}" ]]; then
+        echo "wheelhouse"
+    elif [[ "${AGI_INTERNET_ON:-1}" == "0" ]]; then
+        echo "cache-only"
+    else
+        echo "online"
+    fi
+}
+
+print_uv_resolver_mode() {
+    local mode offline
+    mode="$(uv_resolver_mode)"
+    case "$mode" in
+        cache-only|wheelhouse) offline="yes" ;;
+        *) offline="no" ;;
+    esac
+    echo -e "${BLUE}uv resolver mode: ${mode}${NC}"
+    echo -e "${BLUE}effective uv offline: ${offline}${NC}"
+    if [[ -n "${UV_INDEX_URL:-}" ]]; then
+        echo -e "${BLUE}UV_INDEX_URL: $(redact_url_value "$UV_INDEX_URL")${NC}"
+    fi
+    if [[ -n "${UV_EXTRA_INDEX_URL:-}" ]]; then
+        echo -e "${BLUE}UV_EXTRA_INDEX_URL: $(redact_url_value "$UV_EXTRA_INDEX_URL")${NC}"
+    fi
+    if [[ -n "${UV_FIND_LINKS:-}" ]]; then
+        echo -e "${BLUE}UV_FIND_LINKS: $UV_FIND_LINKS${NC}"
+    fi
+}
+
 run_remote_shell_installer() {
     local url="$1"
     local label="$2"
@@ -982,9 +1023,11 @@ update_environment() {
         echo "AGI_CLUSTER_SHARE=\"$AGI_CLUSTER_SHARE\""
         echo "AGI_LOCAL_SHARE=\"$AGI_LOCAL_SHARE\""
         echo "AGI_INTERNET_ON=\"$AGI_INTERNET_ON\""
-        if [[ -n "${UV_INDEX_URL:-}" ]]; then
-            echo "UV_INDEX_URL=\"$UV_INDEX_URL\""
-        fi
+        for key in UV_INDEX_URL UV_EXTRA_INDEX_URL UV_FIND_LINKS SSL_CERT_FILE REQUESTS_CA_BUNDLE UV_NATIVE_TLS; do
+            if [[ -n "${!key:-}" ]]; then
+                echo "$key=\"${!key}\""
+            fi
+        done
         echo "IS_SOURCE_ENV=\"1\""
     } > "$ENV_FILE"
     echo -e "${GREEN}Environment updated in $ENV_FILE${NC}"
@@ -1490,6 +1533,7 @@ else
 fi
 
 check_internet
+print_uv_resolver_mode
 guard_ephemeral_validation_env
 ensure_share_dir "$AGI_CLUSTER_SHARE" "$AGI_LOCAL_SHARE"
 set_locale

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_build_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_build_support.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import subprocess
 from pathlib import Path
+from shlex import quote
 from typing import Any, Callable, cast
 
 from agi_env import AgiEnv
@@ -16,6 +17,16 @@ BUILD_CACHE_SCHEMA = "agilab-worker-build-cache-v1"
 DISABLE_BUILD_CACHE_ENV = "AGILAB_DISABLE_WORKER_BUILD_CACHE"
 BUILD_CACHE_HASH_LIMIT = 8 * 1024 * 1024
 GIT_FINGERPRINT_TIMEOUT_SECONDS = 2.0
+UV_INDEX_RESOLVER_ENV_VARS = ("UV_INDEX_URL", "UV_EXTRA_INDEX_URL")
+UV_WHEELHOUSE_RESOLVER_ENV_VARS = ("UV_FIND_LINKS",)
+UV_RESOLVER_PROPAGATED_ENV_VARS = (
+    "UV_INDEX_URL",
+    "UV_EXTRA_INDEX_URL",
+    "UV_FIND_LINKS",
+    "SSL_CERT_FILE",
+    "REQUESTS_CA_BUNDLE",
+    "UV_NATIVE_TLS",
+)
 
 
 def _sorted_glob_matches(root: Path, pattern: str) -> list[Path]:
@@ -73,16 +84,45 @@ def _envar_nonempty(envars: Any, key: str) -> bool:
     raw = _envar_value(envars, key)
     if raw is None:
         return False
-    return bool(str(raw).strip().strip("\"'").strip())
+    normalized = str(raw).strip().strip("\"'").strip()
+    return bool(normalized) and normalized.casefold() not in {"none", "null"}
+
+
+def _uv_resolver_mode(envars: Any) -> str:
+    if any(_envar_nonempty(envars, key) for key in UV_INDEX_RESOLVER_ENV_VARS):
+        return "mirror"
+    if any(_envar_nonempty(envars, key) for key in UV_WHEELHOUSE_RESOLVER_ENV_VARS):
+        return "wheelhouse"
+    raw = _envar_value(envars, "AGI_INTERNET_ON")
+    if raw is None:
+        return "online"
+    if isinstance(raw, bool):
+        return "online" if raw else "cache-only"
+    if isinstance(raw, (int, float)):
+        try:
+            return "online" if int(raw) == 1 else "cache-only"
+        except (TypeError, ValueError):
+            return "cache-only"
+    normalized = str(raw).strip().strip("\"'").strip().lower()
+    return "online" if normalized in {"1", "true", "yes", "on"} else "cache-only"
+
+
+def _uv_resolver_env_prefix(envars: Any) -> str:
+    values: dict[str, str] = {}
+    for key in UV_RESOLVER_PROPAGATED_ENV_VARS:
+        if _envar_nonempty(envars, key):
+            values[key] = str(_envar_value(envars, key)).strip().strip("\"'").strip()
+    return "".join(f"{key}={quote(value)} " for key, value in values.items())
 
 
 def _uv_offline_flag(env: Any) -> str:
     envars = getattr(env, "envars", {})
+    mode = _uv_resolver_mode(envars)
+    if mode in {"online", "mirror"}:
+        return ""
+    if mode == "wheelhouse":
+        return "--offline "
     raw = _envar_value(envars, "AGI_INTERNET_ON")
-    if raw is None:
-        return ""
-    if _envar_nonempty(envars, "UV_INDEX_URL"):
-        return ""
     if isinstance(raw, bool):
         return "" if raw else "--offline "
     if isinstance(raw, (int, float)):
@@ -94,10 +134,11 @@ def _uv_offline_flag(env: Any) -> str:
 
 
 def _project_uv(env: Any) -> str:
+    resolver_prefix = _uv_resolver_env_prefix(getattr(env, "envars", {}))
     if not env.is_free_threading_available or not python_supports_free_threading():
-        return str(env.uv)
+        return f"{resolver_prefix}{env.uv}"
     cmd_prefix = str(env.envars.get("127.0.0.1_CMD_PREFIX", "")).strip()
-    return " ".join(part for part in (cmd_prefix, "PYTHON_GIL=0", env.uv) if part)
+    return " ".join(part for part in (resolver_prefix + cmd_prefix, "PYTHON_GIL=0", env.uv) if part)
 
 
 def _env_truthy(envars: Any, key: str) -> bool:

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_local_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_local_support.py
@@ -43,6 +43,16 @@ DEPLOY_TIMING_TRACE_SCHEMA = "agilab-deploy-timing-v1"
 DEPLOY_STAGE_CACHE_HASH_LIMIT = 8 * 1024 * 1024
 DEPLOY_COPY_STAMP_SCHEMA = "agilab-deploy-copy-stamp-v1"
 DEPLOY_COPY_STAMP_FILENAME = ".agilab-copy-stamp.json"
+UV_INDEX_RESOLVER_ENV_VARS = ("UV_INDEX_URL", "UV_EXTRA_INDEX_URL")
+UV_WHEELHOUSE_RESOLVER_ENV_VARS = ("UV_FIND_LINKS",)
+UV_RESOLVER_PROPAGATED_ENV_VARS = (
+    "UV_INDEX_URL",
+    "UV_EXTRA_INDEX_URL",
+    "UV_FIND_LINKS",
+    "SSL_CERT_FILE",
+    "REQUESTS_CA_BUNDLE",
+    "UV_NATIVE_TLS",
+)
 EDITABLE_INSTALL_CACHE_SCHEMA = "agilab-editable-install-cache-v1"
 EDITABLE_SHADOW_IMPORTS: dict[str, tuple[str, ...]] = {
     "agi-cluster": ("agi_cluster",),
@@ -1519,15 +1529,44 @@ def _envar_nonempty(envars: Any, key: str) -> bool:
     raw = _envar_value(envars, key)
     if raw is None:
         return False
-    return bool(str(raw).strip().strip("\"'").strip())
+    normalized = str(raw).strip().strip("\"'").strip()
+    return bool(normalized) and normalized.casefold() not in {"none", "null"}
+
+
+def _uv_resolver_mode(envars: Any) -> str:
+    if any(_envar_nonempty(envars, key) for key in UV_INDEX_RESOLVER_ENV_VARS):
+        return "mirror"
+    if any(_envar_nonempty(envars, key) for key in UV_WHEELHOUSE_RESOLVER_ENV_VARS):
+        return "wheelhouse"
+    raw = _envar_value(envars, "AGI_INTERNET_ON")
+    if raw is None:
+        return "online"
+    if isinstance(raw, bool):
+        return "online" if raw else "cache-only"
+    if isinstance(raw, (int, float)):
+        try:
+            return "online" if int(raw) == 1 else "cache-only"
+        except (TypeError, ValueError):
+            return "cache-only"
+    normalized = str(raw).strip().strip("\"'").strip().lower()
+    return "online" if normalized in {"1", "true", "yes", "on"} else "cache-only"
+
+
+def _uv_resolver_env_prefix(envars: Any, *, os_name: str = os.name) -> str:
+    values: dict[str, str] = {}
+    for key in UV_RESOLVER_PROPAGATED_ENV_VARS:
+        if _envar_nonempty(envars, key):
+            values[key] = str(_envar_value(envars, key)).strip().strip("\"'").strip()
+    return _shell_env_prefix(values, os_name=os_name)
 
 
 def _uv_offline_flag(envars: Any) -> str:
+    mode = _uv_resolver_mode(envars)
+    if mode in {"online", "mirror"}:
+        return ""
+    if mode == "wheelhouse":
+        return "--offline "
     raw = _envar_value(envars, "AGI_INTERNET_ON")
-    if raw is None:
-        return ""
-    if _envar_nonempty(envars, "UV_INDEX_URL"):
-        return ""
     if isinstance(raw, bool):
         return "" if raw else "--offline "
     if isinstance(raw, (int, float)):
@@ -1859,8 +1898,10 @@ async def deploy_local_worker(
 
     wenv_abs = env.wenv_abs
     cmd_prefix = env.envars.get(f"{ip}_CMD_PREFIX", "")
-    uv = cmd_prefix + env.uv
-    offline_flag = _uv_offline_flag(getattr(env, "envars", {}))
+    envars = getattr(env, "envars", {})
+    resolver_env_prefix = _uv_resolver_env_prefix(envars)
+    uv = resolver_env_prefix + cmd_prefix + env.uv
+    offline_flag = _uv_offline_flag(envars)
     pyvers = env.python_version
     stage_cache_enabled = _deploy_stage_cache_enabled(getattr(env, "envars", {}))
     stage_cache_path = _deploy_stage_cache_path(wenv_abs)
@@ -2095,7 +2136,7 @@ async def deploy_local_worker(
         time.perf_counter() - started_at,
     )
 
-    uv_worker = cmd_prefix + env.uv_worker
+    uv_worker = resolver_env_prefix + cmd_prefix + env.uv_worker
     pyvers_worker = env.pyvers_worker
 
     worker_extra_indexes = ""
@@ -2145,7 +2186,8 @@ async def deploy_local_worker(
         worker_venv_project.mkdir(parents=True, exist_ok=True)
         _force_remove(wenv_abs / ".venv", env_logger=getattr(env, "logger", None))
         uv_worker = (
-            cmd_prefix
+            resolver_env_prefix
+            + cmd_prefix
             + _shell_env_prefix(
                 {"UV_PROJECT_ENVIRONMENT": str(_project_venv_root(worker_venv_project))}
             )

--- a/src/agilab/core/test/test_agi_distributor_deployment_build_support.py
+++ b/src/agilab/core/test/test_agi_distributor_deployment_build_support.py
@@ -500,6 +500,44 @@ async def test_build_lib_local_uses_uv_index_url_mirror_when_internet_disabled(
     )
 
 
+def test_build_support_resolver_modes_for_offline_mirror_and_wheelhouse(monkeypatch):
+    monkeypatch.delenv("AGI_INTERNET_ON", raising=False)
+    monkeypatch.delenv("UV_INDEX_URL", raising=False)
+    monkeypatch.delenv("UV_EXTRA_INDEX_URL", raising=False)
+    monkeypatch.delenv("UV_FIND_LINKS", raising=False)
+
+    cache_only = SimpleNamespace(envars={"AGI_INTERNET_ON": "0"})
+    assert deployment_build_support._uv_resolver_mode(cache_only.envars) == "cache-only"
+    assert deployment_build_support._uv_offline_flag(cache_only) == "--offline "
+
+    mirror = SimpleNamespace(
+        envars={
+            "AGI_INTERNET_ON": "0",
+            "UV_EXTRA_INDEX_URL": "http://mirror.local/simple",
+        }
+    )
+    assert deployment_build_support._uv_resolver_mode(mirror.envars) == "mirror"
+    assert deployment_build_support._uv_offline_flag(mirror) == ""
+
+    wheelhouse = SimpleNamespace(
+        envars={
+            "AGI_INTERNET_ON": "0",
+            "UV_FIND_LINKS": "/mnt/wheelhouse",
+        }
+    )
+    assert deployment_build_support._uv_resolver_mode(wheelhouse.envars) == "wheelhouse"
+    assert deployment_build_support._uv_offline_flag(wheelhouse) == "--offline "
+
+    placeholder = SimpleNamespace(
+        envars={
+            "AGI_INTERNET_ON": "0",
+            "UV_INDEX_URL": "None",
+        }
+    )
+    assert deployment_build_support._uv_resolver_mode(placeholder.envars) == "cache-only"
+    assert deployment_build_support._uv_offline_flag(placeholder) == "--offline "
+
+
 @pytest.mark.asyncio
 async def test_build_lib_local_cython_copies_worker_lib(tmp_path):
     env = _build_env(tmp_path)

--- a/src/agilab/core/test/test_agi_distributor_deployment_local_support.py
+++ b/src/agilab/core/test/test_agi_distributor_deployment_local_support.py
@@ -1491,6 +1491,8 @@ def test_uv_offline_flag_keeps_quoted_false_values_offline(monkeypatch):
 def test_uv_offline_flag_uses_uv_index_url_mirror_when_internet_disabled(monkeypatch):
     monkeypatch.delenv("AGI_INTERNET_ON", raising=False)
     monkeypatch.delenv("UV_INDEX_URL", raising=False)
+    monkeypatch.delenv("UV_EXTRA_INDEX_URL", raising=False)
+    monkeypatch.delenv("UV_FIND_LINKS", raising=False)
 
     assert (
         deployment_local_support._uv_offline_flag(
@@ -1509,6 +1511,62 @@ def test_uv_offline_flag_uses_uv_index_url_mirror_when_internet_disabled(monkeyp
     assert (
         deployment_local_support._uv_offline_flag({"AGI_INTERNET_ON": "0"})
         == "--offline "
+    )
+
+
+def test_uv_resolver_mode_covers_extra_index_wheelhouse_and_placeholders(monkeypatch):
+    monkeypatch.delenv("AGI_INTERNET_ON", raising=False)
+    monkeypatch.delenv("UV_INDEX_URL", raising=False)
+    monkeypatch.delenv("UV_EXTRA_INDEX_URL", raising=False)
+    monkeypatch.delenv("UV_FIND_LINKS", raising=False)
+
+    assert (
+        deployment_local_support._uv_resolver_mode(
+            {
+                "AGI_INTERNET_ON": "0",
+                "UV_EXTRA_INDEX_URL": "http://mirror.local/simple",
+            }
+        )
+        == "mirror"
+    )
+    assert (
+        deployment_local_support._uv_offline_flag(
+            {
+                "AGI_INTERNET_ON": "0",
+                "UV_EXTRA_INDEX_URL": "http://mirror.local/simple",
+            }
+        )
+        == ""
+    )
+
+    assert (
+        deployment_local_support._uv_resolver_mode(
+            {
+                "AGI_INTERNET_ON": "0",
+                "UV_FIND_LINKS": "/mnt/wheelhouse",
+            }
+        )
+        == "wheelhouse"
+    )
+    assert (
+        deployment_local_support._uv_offline_flag(
+            {
+                "AGI_INTERNET_ON": "0",
+                "UV_FIND_LINKS": "/mnt/wheelhouse",
+            }
+        )
+        == "--offline "
+    )
+
+    assert (
+        deployment_local_support._uv_resolver_mode(
+            {
+                "AGI_INTERNET_ON": "0",
+                "UV_INDEX_URL": "None",
+                "UV_EXTRA_INDEX_URL": "null",
+            }
+        )
+        == "cache-only"
     )
 
 


### PR DESCRIPTION
## Summary
- distinguish cache-only, mirror, wheelhouse, and online uv resolver modes when public internet is unavailable
- propagate `UV_INDEX_URL`, `UV_EXTRA_INDEX_URL`, `UV_FIND_LINKS`, and TLS resolver environment into deployment commands
- persist resolver/TLS env from `install.sh` and print the effective resolver mode
- add focused regressions for extra-index mirror, wheelhouse, and placeholder resolver values

## Validation
- `bash -n install.sh src/agilab/install_apps.sh src/agilab/core/install.sh`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files install.sh src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_local_support.py src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_build_support.py src/agilab/core/test/test_agi_distributor_deployment_local_support.py src/agilab/core/test/test_agi_distributor_deployment_build_support.py`
- focused mirror tests: `7 passed`
- installer/deployment slice: `168 passed`
- full shared-core slice: `965 passed, 2 skipped`
