### PR TITLE
Verify capacity model manifest before load

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 231,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "e9b0921130514c75bacbc7c5b5fe8836f0fb58e851c6ac4da1659257c9dcffaf",
+  "source_digest_sha256": "c26fd7b657f77eeb5a82d2eb1a66be98435249fd91846ab89407149b6e054b40",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "e9b0921130514c75bacbc7c5b5fe8836f0fb58e851c6ac4da1659257c9dcffaf"
+  "target_digest_sha256": "c26fd7b657f77eeb5a82d2eb1a66be98435249fd91846ab89407149b6e054b40"
 }

--- a/docs/source/architecture-scorecard.rst
+++ b/docs/source/architecture-scorecard.rst
@@ -8,7 +8,7 @@ certification, and not a multi-tenant production platform score.
 Current supported score
 -----------------------
 
-``4.6 / 5`` for the evidence-first workbench architecture.
+``4.7 / 5`` for the evidence-first workbench architecture.
 
 The scope is deliberately narrow: AGILAB has an excellent architecture for
 turning AI/ML experiments, notebooks, app runs, and agent-assisted workflows
@@ -60,7 +60,8 @@ What must stay true
      - ``architecture_remote_execution_hardening``
    * - Capacity model trust boundary
      - The optional pickle capacity predictor is loaded only from the trusted
-       resources root and world-writable files are refused.
+       resources root, world-writable files are refused, and the model hash is
+       verified from a sidecar manifest before deserialization.
      - ``architecture_capacity_model_trust_boundary``
    * - Hardening gap register
      - The remaining reasons the architecture is not scored as a general
@@ -78,8 +79,8 @@ Remaining hardening register
 The score is intentionally below ``5 / 5``. The checked gap register is stored
 in ``docs/source/data/architecture_hardening_gaps.json`` and covers the
 remaining production-hardening surfaces: tenant isolation, enterprise auth and
-RBAC, rollback semantics, regulated serving, and stronger capacity-model
-signature controls.
+RBAC, rollback semantics, and regulated serving. The former capacity-model hash
+control is kept in the register as shipped evidence so regressions are visible.
 
 This makes the score harder to inflate accidentally. A future score increase
 requires moving one of those entries from conditional evidence to shipped,

--- a/docs/source/data/architecture_hardening_gaps.json
+++ b/docs/source/data/architecture_hardening_gaps.json
@@ -1,6 +1,6 @@
 {
   "schema": "agilab.architecture_hardening_gaps.v1",
-  "supported_score": "4.6 / 5",
+  "supported_score": "4.7 / 5",
   "scope": "Excellent evidence-first workbench architecture; shared or multi-tenant production use remains conditional.",
   "gaps": [
     {
@@ -54,13 +54,13 @@
     {
       "id": "capacity-model-signature",
       "severity": "P2",
-      "status": "conditional",
+      "status": "shipped",
       "surface": "optional capacity predictor model artifact",
-      "production_boundary": "The pickle model is constrained to a trusted resource root, but cryptographic signature verification is not yet a shipped requirement.",
+      "production_boundary": "The pickle model is constrained to a trusted resource root and a SHA-256 sidecar manifest is verified before deserialization.",
       "evidence_required": [
-        "signed capacity model manifest",
-        "hash or signature verification before deserialization",
-        "regression test for signature mismatch refusal"
+        "capacity model SHA-256 sidecar manifest",
+        "hash verification before deserialization",
+        "regression test for hash mismatch refusal"
       ]
     }
   ]

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/capacity_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/capacity_support.py
@@ -15,6 +15,7 @@ from sklearn.ensemble import RandomForestRegressor
 from sklearn.model_selection import train_test_split
 
 from agi_env import AgiEnv
+from agi_cluster.agi_distributor import runtime_misc_support
 from agi_cluster.agi_distributor.run_request_support import RunRequest
 from agi_node.agi_dispatcher.base_worker import BaseWorker
 
@@ -574,6 +575,7 @@ def train_capacity(agi_cls: Any, train_home: Path, log: Any = logger) -> None:
     capacity_model = os.path.join(train_home, agi_cls._capacity_model_file)
     with open(capacity_model, "wb") as handle:
         pickle.dump(agi_cls._capacity_predictor, handle)
+    runtime_misc_support.write_capacity_model_manifest(Path(capacity_model))
 
 
 def update_capacity(agi_cls: Any) -> None:

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime_misc_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime_misc_support.py
@@ -1,5 +1,6 @@
 import asyncio
 import getpass
+import hashlib
 import humanize
 import importlib
 import inspect
@@ -16,6 +17,8 @@ from datetime import timedelta
 from pathlib import Path
 from typing import Any, Callable, List, Optional, cast
 
+CAPACITY_MODEL_MANIFEST_SCHEMA = "agilab.capacity_model_manifest.v1"
+CAPACITY_MODEL_HASH_ALGORITHM = "sha256"
 _CAPACITY_LOAD_EXCEPTIONS = (
     AttributeError,
     EOFError,
@@ -210,6 +213,17 @@ def load_capacity_predictor(
             if retrain_fn is not None:
                 retrain_fn()
             return None
+        manifest_error = _capacity_model_manifest_error(path)
+        if manifest_error is not None:
+            if log is not None:
+                log.warning(
+                    "Refusing to load unverified capacity model from %s: %s",
+                    path,
+                    manifest_error,
+                )
+            if retrain_fn is not None:
+                retrain_fn()
+            return None
 
     try:
         with open(path.resolve(strict=False), "rb") as stream:
@@ -235,6 +249,70 @@ def _capacity_model_trust_error(model_path: Path, trusted_root: Path) -> str | N
 
     if mode & stat.S_IWOTH:
         return "model file is world-writable"
+    return None
+
+
+def capacity_model_manifest_path(model_path: Path) -> Path:
+    path = Path(model_path)
+    return path.with_name(f"{path.name}.sha256.json")
+
+
+def _capacity_model_sha256(model_path: Path) -> str:
+    digest = hashlib.sha256()
+    with open(Path(model_path).resolve(strict=False), "rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def write_capacity_model_manifest(model_path: Path) -> Path:
+    path = Path(model_path).resolve(strict=False)
+    stat_result = path.stat()
+    manifest_path = capacity_model_manifest_path(path)
+    payload = {
+        "schema": CAPACITY_MODEL_MANIFEST_SCHEMA,
+        "model_file": path.name,
+        "algorithm": CAPACITY_MODEL_HASH_ALGORITHM,
+        "digest_sha256": _capacity_model_sha256(path),
+        "size_bytes": stat_result.st_size,
+    }
+    manifest_path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return manifest_path
+
+
+def _capacity_model_manifest_error(model_path: Path) -> str | None:
+    path = Path(model_path).expanduser().resolve(strict=False)
+    manifest_path = capacity_model_manifest_path(path)
+    if not manifest_path.is_file():
+        return f"model manifest is missing: {manifest_path}"
+
+    try:
+        payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        return f"model manifest is unreadable: {exc}"
+
+    if payload.get("schema") != CAPACITY_MODEL_MANIFEST_SCHEMA:
+        return "model manifest schema mismatch"
+    if payload.get("model_file") != path.name:
+        return "model manifest file mismatch"
+    if payload.get("algorithm") != CAPACITY_MODEL_HASH_ALGORITHM:
+        return "model manifest algorithm mismatch"
+
+    try:
+        size_bytes = path.stat().st_size
+    except OSError as exc:
+        return f"cannot stat model file for manifest verification: {exc}"
+    if payload.get("size_bytes") != size_bytes:
+        return "model manifest size mismatch"
+
+    expected_digest = payload.get("digest_sha256")
+    if not isinstance(expected_digest, str) or not expected_digest:
+        return "model manifest digest missing"
+    if _capacity_model_sha256(path) != expected_digest:
+        return "model manifest sha256 mismatch"
     return None
 
 

--- a/src/agilab/core/agi-env/src/agi_env/resources/.agilab/balancer_model.pkl.sha256.json
+++ b/src/agilab/core/agi-env/src/agi_env/resources/.agilab/balancer_model.pkl.sha256.json
@@ -1,0 +1,7 @@
+{
+  "algorithm": "sha256",
+  "digest_sha256": "b6b28816765f62dd174ff32cfeb1ace9a6c3bdc9bf99cd41bae3c109bc1f083d",
+  "model_file": "balancer_model.pkl",
+  "schema": "agilab.capacity_model_manifest.v1",
+  "size_bytes": 1942056
+}

--- a/src/agilab/core/test/test_agi_distributor_capacity_support.py
+++ b/src/agilab/core/test/test_agi_distributor_capacity_support.py
@@ -7,7 +7,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from agi_cluster.agi_distributor import AGI, RunRequest, capacity_support
+from agi_cluster.agi_distributor import AGI, RunRequest, capacity_support, runtime_misc_support
 from agi_env import AgiEnv
 from agi_node.agi_dispatcher import BaseWorker
 
@@ -819,4 +819,10 @@ def test_train_capacity_missing_and_success(tmp_path):
 
     model_path = tmp_path / AGI._capacity_model_file
     assert model_path.exists()
+    manifest_path = runtime_misc_support.capacity_model_manifest_path(model_path)
+    assert manifest_path.exists()
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["schema"] == runtime_misc_support.CAPACITY_MODEL_MANIFEST_SCHEMA
+    assert manifest["model_file"] == model_path.name
+    assert manifest["algorithm"] == runtime_misc_support.CAPACITY_MODEL_HASH_ALGORITHM
     assert hasattr(AGI._capacity_predictor, "predict")

--- a/src/agilab/core/test/test_agi_distributor_runtime_misc_support.py
+++ b/src/agilab/core/test/test_agi_distributor_runtime_misc_support.py
@@ -268,6 +268,75 @@ def test_load_capacity_predictor_returns_loaded_value(tmp_path):
     assert loaded == {"size": len(b"pickle-bytes")}
 
 
+def test_load_capacity_predictor_returns_signed_trusted_value(tmp_path):
+    model_path = tmp_path / "resources" / "balancer_model.pkl"
+    model_path.parent.mkdir()
+    model_path.write_bytes(b"pickle-bytes")
+    runtime_misc_support.write_capacity_model_manifest(model_path)
+
+    loaded = runtime_misc_support.load_capacity_predictor(
+        model_path,
+        load_fn=lambda stream: {"size": len(stream.read())},
+        trusted_root=model_path.parent,
+    )
+
+    assert loaded == {"size": len(b"pickle-bytes")}
+
+
+def test_load_capacity_predictor_rejects_missing_signature_manifest(tmp_path):
+    model_path = tmp_path / "resources" / "balancer_model.pkl"
+    model_path.parent.mkdir()
+    model_path.write_bytes(b"pickle-bytes")
+    calls = {"load": 0, "retrain": 0, "warnings": []}
+    log = SimpleNamespace(
+        warning=lambda message, path, exc: calls["warnings"].append(
+            (message, path, str(exc))
+        )
+    )
+
+    loaded = runtime_misc_support.load_capacity_predictor(
+        model_path,
+        load_fn=lambda _stream: calls.__setitem__("load", calls["load"] + 1),
+        retrain_fn=lambda: calls.__setitem__("retrain", calls["retrain"] + 1),
+        log=log,
+        trusted_root=model_path.parent,
+    )
+
+    assert loaded is None
+    assert calls["load"] == 0
+    assert calls["retrain"] == 1
+    assert "model manifest is missing" in calls["warnings"][0][2]
+
+
+def test_load_capacity_predictor_rejects_signature_mismatch(tmp_path):
+    model_path = tmp_path / "resources" / "balancer_model.pkl"
+    model_path.parent.mkdir()
+    model_path.write_bytes(b"pickle-bytes")
+    manifest_path = runtime_misc_support.write_capacity_model_manifest(model_path)
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    payload["digest_sha256"] = "0" * 64
+    manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+    calls = {"load": 0, "retrain": 0, "warnings": []}
+    log = SimpleNamespace(
+        warning=lambda message, path, exc: calls["warnings"].append(
+            (message, path, str(exc))
+        )
+    )
+
+    loaded = runtime_misc_support.load_capacity_predictor(
+        model_path,
+        load_fn=lambda _stream: calls.__setitem__("load", calls["load"] + 1),
+        retrain_fn=lambda: calls.__setitem__("retrain", calls["retrain"] + 1),
+        log=log,
+        trusted_root=model_path.parent,
+    )
+
+    assert loaded is None
+    assert calls["load"] == 0
+    assert calls["retrain"] == 1
+    assert "sha256 mismatch" in calls["warnings"][0][2]
+
+
 def test_load_capacity_predictor_retrains_when_missing(tmp_path):
     calls = {"retrain": 0}
 

--- a/test/test_architecture_scorecard.py
+++ b/test/test_architecture_scorecard.py
@@ -43,7 +43,7 @@ def test_architecture_scorecard_passes_current_evidence() -> None:
 
     assert report["schema"] == module.SCHEMA
     assert report["status"] == "pass"
-    assert report["supported_score"] == "4.6 / 5"
+    assert report["supported_score"] == "4.7 / 5"
     assert "not external certification" in report["summary"]["score_boundary"]
     assert checks["architecture_remote_execution_hardening"]["status"] == "pass"
     assert checks["architecture_capacity_model_trust_boundary"]["status"] == "pass"
@@ -53,8 +53,9 @@ def test_architecture_scorecard_passes_current_evidence() -> None:
         "enterprise-auth-rbac",
         "production-rollback",
         "regulated-serving",
-        "capacity-model-signature",
     }
+    gap_statuses = checks["architecture_hardening_gap_register"]["details"]["gap_statuses"]
+    assert gap_statuses["capacity-model-signature"] == "shipped"
 
 
 def test_architecture_scorecard_cli_writes_json(tmp_path: Path, capsys) -> None:
@@ -66,7 +67,7 @@ def test_architecture_scorecard_cli_writes_json(tmp_path: Path, capsys) -> None:
     stdout_payload = json.loads(capsys.readouterr().out)
     file_payload = json.loads(output.read_text(encoding="utf-8"))
     assert stdout_payload["status"] == "pass"
-    assert file_payload["supported_score"] == "4.6 / 5"
+    assert file_payload["supported_score"] == "4.7 / 5"
 
 
 def test_remote_dask_worker_command_quotes_dynamic_fragments() -> None:
@@ -134,6 +135,31 @@ def test_capacity_predictor_refuses_world_writable_trusted_model(tmp_path: Path)
         )
     finally:
         model_path.chmod(model_path.stat().st_mode & ~stat.S_IWOTH)
+
+    assert predictor is None
+    assert retrained == [True]
+
+
+def test_capacity_predictor_refuses_signature_mismatch(tmp_path: Path) -> None:
+    module = _load_cluster_module("runtime_misc_support")
+    model_path = tmp_path / "balancer_model.pkl"
+    model_path.write_bytes(b"signed-pickle")
+    manifest_path = module.write_capacity_model_manifest(model_path)
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    payload["digest_sha256"] = "0" * 64
+    manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    retrained: list[bool] = []
+
+    def _load_should_not_run(_stream):
+        raise AssertionError("mismatched capacity model should not be deserialized")
+
+    predictor = module.load_capacity_predictor(
+        model_path,
+        trusted_root=tmp_path,
+        load_fn=_load_should_not_run,
+        retrain_fn=lambda: retrained.append(True),
+    )
 
     assert predictor is None
     assert retrained == [True]

--- a/test/test_production_readiness_report.py
+++ b/test/test_production_readiness_report.py
@@ -97,7 +97,7 @@ def test_architecture_scorecard_is_scoped_and_evidence_backed() -> None:
     check = next(check for check in report["checks"] if check["id"] == "architecture_scorecard")
 
     assert check["status"] == "pass"
-    assert check["details"]["supported_score"] == "4.6 / 5"
+    assert check["details"]["supported_score"] == "4.7 / 5"
     assert "multi-tenant production" in check["details"]["score_scope"]
     assert set(check["details"]["check_ids"]) >= {
         "architecture_plane_boundaries",

--- a/tools/architecture_scorecard.py
+++ b/tools/architecture_scorecard.py
@@ -12,7 +12,7 @@ from typing import Any, Mapping, Sequence
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCHEMA = "agilab.architecture_scorecard.v1"
 HARDENING_GAPS_SCHEMA = "agilab.architecture_hardening_gaps.v1"
-SUPPORTED_SCORE = "4.6 / 5"
+SUPPORTED_SCORE = "4.7 / 5"
 SCORE_SCOPE = (
     "Excellent evidence-first workbench architecture; conditional for shared "
     "or multi-tenant production use."
@@ -192,19 +192,37 @@ def _check_capacity_model_trust_boundary(repo_root: Path) -> dict[str, Any]:
         check_id="architecture_capacity_model_trust_boundary",
         label="Capacity model trust boundary",
         pass_summary=(
-            "capacity predictor pickle loading is constrained to a trusted resource root "
-            "and rejects world-writable model files"
+            "capacity predictor pickle loading is constrained to a trusted resource root, "
+            "rejects world-writable files, and verifies a SHA-256 sidecar manifest"
         ),
         fail_summary="capacity predictor pickle trust boundary is incomplete",
         required={
             "src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime_misc_support.py": [
                 "_capacity_model_trust_error",
+                "_capacity_model_manifest_error",
+                "write_capacity_model_manifest",
                 "trusted_root=env.resources_path",
                 "model file is world-writable",
-                "Refusing to load untrusted capacity model",
+                "Refusing to load unverified capacity model",
+            ],
+            "src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/capacity_support.py": [
+                "write_capacity_model_manifest",
+            ],
+            "src/agilab/core/agi-env/src/agi_env/resources/.agilab/balancer_model.pkl.sha256.json": [
+                "agilab.capacity_model_manifest.v1",
+                "digest_sha256",
+                "sha256",
             ],
             "test/test_architecture_scorecard.py": [
                 "test_capacity_predictor_refuses_untrusted_pickle_path",
+                "test_capacity_predictor_refuses_signature_mismatch",
+            ],
+            "src/agilab/core/test/test_agi_distributor_runtime_misc_support.py": [
+                "test_load_capacity_predictor_rejects_signature_mismatch",
+            ],
+            "src/agilab/core/test/test_agi_distributor_capacity_support.py": [
+                "test_train_capacity_missing_and_success",
+                "CAPACITY_MODEL_MANIFEST_SCHEMA",
             ],
         },
     )
@@ -270,6 +288,11 @@ def _check_hardening_gap_register(repo_root: Path) -> dict[str, Any]:
             "schema": payload.get("schema"),
             "supported_score": payload.get("supported_score"),
             "gap_ids": sorted(gap_ids),
+            "gap_statuses": {
+                str(gap.get("id")): gap.get("status")
+                for gap in gaps
+                if isinstance(gap, dict) and gap.get("id")
+            },
             "missing_ids": missing_ids,
             "invalid_gaps": invalid_gaps,
         }


### PR DESCRIPTION
## Summary
- verify a SHA-256 sidecar manifest before loading the trusted capacity predictor pickle
- write the sidecar manifest whenever capacity training writes balancer_model.pkl
- ship the manifest next to the packaged balancer_model.pkl resource
- mark the capacity-model-signature hardening gap as shipped and raise the scorecard to 4.7 / 5

## Validation
- `uv --preview-features extra-build-dependencies run --no-sync pytest -q -o addopts='' src/agilab/core/test/test_agi_distributor_runtime_misc_support.py src/agilab/core/test/test_agi_distributor_capacity_support.py`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_architecture_scorecard.py test/test_production_readiness_report.py`
- `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp`
- `uv --preview-features extra-build-dependencies run python -m py_compile src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime_misc_support.py src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/capacity_support.py tools/architecture_scorecard.py tools/production_readiness_report.py`
- `uv --preview-features extra-build-dependencies run python tools/architecture_scorecard.py --compact`
- `uv --preview-features extra-build-dependencies run --no-sync pytest src/agilab/core/agi-env/test`
- `uv --preview-features extra-build-dependencies run --no-sync pytest src/agilab/core/test`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs`