### PR TITLE
[codex] Classify packaged example execution modes

### DIFF
--- a/src/agilab/examples/excel_workbook_proof/README.md
+++ b/src/agilab/examples/excel_workbook_proof/README.md
@@ -1,5 +1,10 @@
 # Excel Workbook Proof Example
 
+## Example Class
+
+**Read-only preview.** The preview writes deterministic local workbook, CSV, and evidence artifacts. It does not install or run an AGILAB app project.
+
+
 ## Purpose
 
 Shows the smallest Excel-shaped AGILAB adoption bridge:

--- a/src/agilab/examples/flight_telemetry/README.md
+++ b/src/agilab/examples/flight_telemetry/README.md
@@ -1,5 +1,10 @@
 # Flight Example
 
+## Example Class
+
+**Runnable app project.** Installed `AGI_install_*` and `AGI_run_*` helpers run `flight_telemetry_project` as a real AGILAB app project.
+
+
 ## Purpose
 
 Runs `flight_telemetry_project`, the default public AGILAB first-run app for file-based

--- a/src/agilab/examples/inter_project_dag/README.md
+++ b/src/agilab/examples/inter_project_dag/README.md
@@ -1,5 +1,10 @@
 # Inter-Project DAG Example
 
+## Example Class
+
+**Read-only preview.** The preview writes deterministic runner-state evidence for a cross-project DAG contract. It does not install or run either app project.
+
+
 ## Purpose
 
 Shows how two AGILAB projects can be connected by a DAG contract without

--- a/src/agilab/examples/mission_decision/README.md
+++ b/src/agilab/examples/mission_decision/README.md
@@ -1,5 +1,10 @@
 # Mission Decision Example
 
+## Example Class
+
+**Runnable app project.** Installed `AGI_install_*` and `AGI_run_*` helpers run `mission_decision_project` as a real AGILAB app project.
+
+
 ## Purpose
 
 Runs `mission_decision_project`, a deterministic public demo for autonomous

--- a/src/agilab/examples/mlflow_auto_tracking/README.md
+++ b/src/agilab/examples/mlflow_auto_tracking/README.md
@@ -1,5 +1,10 @@
 # MLflow Auto-Tracking Example
 
+## Example Class
+
+**Read-only preview.** The preview writes deterministic tracking evidence and optionally logs to MLflow when available. It does not install or run an AGILAB app project.
+
+
 ## Purpose
 
 Shows the intended AGILAB tracking posture:

--- a/src/agilab/examples/mycode/README.md
+++ b/src/agilab/examples/mycode/README.md
@@ -1,5 +1,10 @@
 # Mycode Example
 
+## Example Class
+
+**Runnable app project.** Installed `AGI_install_*` and `AGI_run_*` helpers run `mycode_project` as a real AGILAB app project.
+
+
 ## Purpose
 
 Runs `mycode_project`, the smallest built-in template for checking that AGILAB

--- a/src/agilab/examples/native_rust_worker/README.md
+++ b/src/agilab/examples/native_rust_worker/README.md
@@ -1,5 +1,10 @@
 # Native Rust Worker Example
 
+## Example Class
+
+**Read-only preview.** The preview writes a Rust/PyO3 worker skeleton and evidence. It does not compile Rust or install an AGILAB app project.
+
+
 ## Purpose
 
 Shows the optional Rust/PyO3 acceleration lane for an AGILAB worker:

--- a/src/agilab/examples/notebook_migrations/skforecast_meteo_fr/README.md
+++ b/src/agilab/examples/notebook_migrations/skforecast_meteo_fr/README.md
@@ -1,5 +1,10 @@
 # skforecast Meteo-France Migration Pilot
 
+## Example Class
+
+**Notebook import asset.** This folder contains notebooks, artifacts, `lab_stages.toml`, and a pipeline view for import or inspection. It is not an installed AGI project helper.
+
+
 This folder is a lightweight, local-first migration example for showing how a
 small notebook workflow can move into AGILAB without changing the core data
 science story.

--- a/src/agilab/examples/notebook_to_dask/README.md
+++ b/src/agilab/examples/notebook_to_dask/README.md
@@ -1,5 +1,10 @@
 # Notebook To Dask Migration Example
 
+## Example Class
+
+**Read-only preview.** The preview writes migration contracts and evidence for notebook-to-Dask planning. It does not install or run an AGILAB app project.
+
+
 ## Purpose
 
 Shows how a notebook-first data workflow can be imported into AGILAB as an

--- a/src/agilab/examples/parallel_stage/README.md
+++ b/src/agilab/examples/parallel_stage/README.md
@@ -1,5 +1,10 @@
 # Parallel Stage Example
 
+## Example Class
+
+**Read-only preview.** The preview validates a partition contract and writes planning evidence. It does not start workers or install an AGILAB app project.
+
+
 ## Purpose
 
 Shows the smallest AGILAB mental model for parallelizing code:

--- a/src/agilab/examples/resilience_failure_injection/README.md
+++ b/src/agilab/examples/resilience_failure_injection/README.md
@@ -1,5 +1,10 @@
 # Resilience Failure Injection Example
 
+## Example Class
+
+**Read-only preview.** The preview evaluates a deterministic failure scenario contract. It does not train, serve, or install an AGILAB app project.
+
+
 ## Purpose
 
 Shows how to compare routing strategies after a controlled degradation event.

--- a/src/agilab/examples/service_mode/README.md
+++ b/src/agilab/examples/service_mode/README.md
@@ -1,5 +1,10 @@
 # Service Mode Example
 
+## Example Class
+
+**Read-only preview.** The preview evaluates service lifecycle and health evidence. It does not start persistent workers or install an AGILAB app project.
+
+
 ## Purpose
 
 Shows how to reason about AGILAB service mode before starting persistent

--- a/src/agilab/examples/sklearn_pipeline/README.md
+++ b/src/agilab/examples/sklearn_pipeline/README.md
@@ -1,5 +1,10 @@
 # Scikit-Learn Pipeline Example
 
+## Example Class
+
+**Runnable app project.** Installed `AGI_install_*` and `AGI_run_*` helpers run `sklearn_pipeline_project` as a real AGILAB app project.
+
+
 ## Purpose
 
 Runs `sklearn_pipeline_project`, a compact app example that turns a normal

--- a/src/agilab/examples/sqlite_connector_proof/README.md
+++ b/src/agilab/examples/sqlite_connector_proof/README.md
@@ -1,5 +1,10 @@
 # SQLite Connector Proof Example
 
+## Example Class
+
+**Read-only preview.** The preview writes a deterministic SQLite database, CSV result, and evidence. It does not install or run an AGILAB app project.
+
+
 ## Purpose
 
 Shows the smallest database-shaped AGILAB adoption bridge:

--- a/src/agilab/examples/train_then_serve/README.md
+++ b/src/agilab/examples/train_then_serve/README.md
@@ -1,5 +1,10 @@
 # Train-Then-Serve Example
 
+## Example Class
+
+**Read-only preview.** The preview writes service-contract, prediction-sample, and health evidence. It does not train, serve, or install an AGILAB app project.
+
+
 ## Purpose
 
 Shows the product handoff after a policy has been trained: keep the training

--- a/src/agilab/examples/voila_notebook_proof/README.md
+++ b/src/agilab/examples/voila_notebook_proof/README.md
@@ -1,5 +1,10 @@
 # Voila Notebook Proof Preview
 
+## Example Class
+
+**Read-only preview.** The preview writes notebook-dashboard bridge artifacts and evidence. It does not start Voila or install an AGILAB app project.
+
+
 ## Purpose
 
 Show how a notebook dashboard can become an AGILAB app adoption bridge without

--- a/src/agilab/examples/weather_forecast/README.md
+++ b/src/agilab/examples/weather_forecast/README.md
@@ -1,5 +1,10 @@
 # Weather Forecast Example
 
+## Example Class
+
+**Runnable app project.** Installed `AGI_install_*` and `AGI_run_*` helpers run `weather_forecast_project` as a real AGILAB app project.
+
+
 ## Purpose
 
 Runs `weather_forecast_project`, a compact weather forecasting example migrated

--- a/test/test_app_installer_packaging.py
+++ b/test/test_app_installer_packaging.py
@@ -67,6 +67,14 @@ EXAMPLE_PREVIEWS = {
     "train_then_serve": ("preview_train_then_serve.py",),
     "voila_notebook_proof": ("preview_voila_notebook_proof.py",),
 }
+EXAMPLE_NOTEBOOK_ASSETS = {
+    "notebook_migrations/skforecast_meteo_fr": ("README.md",),
+}
+EXAMPLE_CLASS_LABELS = {
+    "Runnable app project",
+    "Read-only preview",
+    "Notebook import asset",
+}
 EXAMPLE_CATALOG_DOC = ROOT / "docs/source/packaged-examples.rst"
 DOCS_INDEX = ROOT / "docs/source/index.rst"
 DEPRECATED_EXAMPLE_DIR_NAMES = {
@@ -924,6 +932,7 @@ def test_packaged_example_catalog_is_documented() -> None:
             assert script_name in readme_text
         for heading in (
             "## Purpose",
+            "## Example Class",
             "## What You Learn",
             "## Install",
             "## Run",
@@ -951,6 +960,7 @@ def test_packaged_example_catalog_is_documented() -> None:
         )
         for heading in (
             "## Purpose",
+            "## Example Class",
             "## What You Learn",
             "## Install",
             "## Run",
@@ -961,6 +971,26 @@ def test_packaged_example_catalog_is_documented() -> None:
             "## Troubleshooting",
         ):
             assert heading in readme_text
+
+
+def test_packaged_example_readmes_have_explicit_execution_class() -> None:
+    expected_classes = {
+        **{example_name: "Runnable app project" for example_name in EXAMPLE_APPS},
+        **{example_name: "Read-only preview" for example_name in EXAMPLE_PREVIEWS},
+        **{example_name: "Notebook import asset" for example_name in EXAMPLE_NOTEBOOK_ASSETS},
+    }
+
+    for example_name in _packaged_example_dirs():
+        if example_name == "notebook_migrations":
+            continue
+        assert example_name in expected_classes
+
+    for example_name, expected_class in sorted(expected_classes.items()):
+        readme_text = (EXAMPLES_ROOT / example_name / "README.md").read_text(encoding="utf-8")
+        assert "## Example Class" in readme_text
+        assert f"**{expected_class}.**" in readme_text
+        for other_class in EXAMPLE_CLASS_LABELS - {expected_class}:
+            assert f"**{other_class}.**" not in readme_text
 
 
 def test_packaged_example_catalog_has_rendered_docs_page() -> None:


### PR DESCRIPTION
## Summary
- add an explicit `Example Class` section to every packaged example README
- distinguish runnable app projects, read-only previews, and notebook import assets
- add a packaging guard so future example READMEs must declare one allowed execution class

## Local validation
- not run directly; pre-push guard skipped unrelated docs/release/app-contract checks
