### PR TITLE
feat(agent): expose agent-run evidence through MCP

### DIFF
--- a/src/agilab_mcp/manifest_tools.py
+++ b/src/agilab_mcp/manifest_tools.py
@@ -6,7 +6,7 @@ import json
 from pathlib import Path
 from typing import Any, Mapping
 
-from agilab import bridge_cli, run_manifest
+from agilab import agent_run, bridge_cli, run_manifest
 from agilab.secret_uri import redact_mapping
 
 
@@ -42,6 +42,76 @@ def list_runs(log_root: str | Path) -> dict[str, Any]:
         "schema": "agilab.mcp.list_runs.v1",
         "log_root": str(root),
         "runs": runs,
+    }
+
+
+def _agent_run_summary_payload(summary: agent_run.AgentRunSummary) -> dict[str, Any]:
+    return {
+        "run_id": summary.run_id,
+        "agent": summary.agent,
+        "label": summary.label,
+        "status": summary.status,
+        "returncode": summary.returncode,
+        "manifest": str(summary.manifest_path),
+        "stdout": str(summary.stdout_path) if summary.stdout_path else None,
+        "stderr": str(summary.stderr_path) if summary.stderr_path else None,
+        "trace_events": str(summary.trace_events_path)
+        if summary.trace_events_path
+        else None,
+        "duration_seconds": summary.duration_seconds,
+        "tags": list(summary.tags),
+        "metadata": summary.metadata,
+    }
+
+
+def list_agent_runs(
+    log_root: str | Path | None = None,
+    *,
+    agent: str = "",
+    status: str = "",
+    limit: int = 20,
+) -> dict[str, Any]:
+    if limit < 0:
+        raise ValueError("limit must be >= 0")
+    root = (
+        Path(log_root).expanduser().resolve(strict=False)
+        if log_root not in (None, "")
+        else None
+    )
+    summaries = agent_run.list_agent_runs(
+        root,
+        agent=agent or None,
+        status=status or None,
+        limit=limit,
+    )
+    return {
+        "schema": "agilab.mcp.list_agent_runs.v1",
+        "log_root": str(root) if root is not None else "~/log/agents",
+        "agent": agent or None,
+        "status": status or None,
+        "runs": [_agent_run_summary_payload(summary) for summary in summaries],
+    }
+
+
+def read_agent_run(manifest_path: str | Path) -> dict[str, Any]:
+    path = Path(manifest_path).expanduser().resolve(strict=False)
+    manifest = agent_run.load_agent_run_manifest(path)
+    summary = agent_run.summarize_agent_run(manifest)
+    resolved = summary.manifest_path if str(summary.manifest_path) else path
+    return {
+        "schema": "agilab.mcp.read_agent_run.v1",
+        "manifest_path": str(resolved),
+        "manifest": redact_mapping(manifest),
+    }
+
+
+def summarize_agent_run(manifest_path: str | Path) -> dict[str, Any]:
+    path = Path(manifest_path).expanduser().resolve(strict=False)
+    summary = agent_run.summarize_agent_run(path)
+    return {
+        "schema": "agilab.mcp.summarize_agent_run.v1",
+        "manifest_path": str(summary.manifest_path or path),
+        "summary": _agent_run_summary_payload(summary),
     }
 
 

--- a/src/agilab_mcp/server.py
+++ b/src/agilab_mcp/server.py
@@ -15,6 +15,9 @@ ToolFn = Callable[..., dict[str, Any]]
 TOOLS: dict[str, ToolFn] = {
     "list_projects": manifest_tools.list_projects,
     "list_runs": manifest_tools.list_runs,
+    "list_agent_runs": manifest_tools.list_agent_runs,
+    "read_agent_run": manifest_tools.read_agent_run,
+    "summarize_agent_run": manifest_tools.summarize_agent_run,
     "read_manifest": manifest_tools.read_manifest,
     "summarize_run": manifest_tools.summarize_run,
     "list_artifacts": manifest_tools.list_artifacts,
@@ -41,6 +44,40 @@ def tool_descriptors() -> list[dict[str, Any]]:
                 "type": "object",
                 "properties": {"log_root": {"type": "string"}},
                 "required": ["log_root"],
+            },
+        },
+        {
+            "name": "list_agent_runs",
+            "description": "List redacted AGILAB agent-run evidence manifests.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "log_root": {"type": "string"},
+                    "agent": {"type": "string"},
+                    "status": {
+                        "type": "string",
+                        "enum": ["", "planned", "pass", "fail", "timeout", "denied"],
+                    },
+                    "limit": {"type": "integer", "minimum": 0},
+                },
+            },
+        },
+        {
+            "name": "read_agent_run",
+            "description": "Read and redact one AGILAB agent-run manifest.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {"manifest_path": {"type": "string"}},
+                "required": ["manifest_path"],
+            },
+        },
+        {
+            "name": "summarize_agent_run",
+            "description": "Summarize one AGILAB agent-run manifest.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {"manifest_path": {"type": "string"}},
+                "required": ["manifest_path"],
             },
         },
         {

--- a/test/test_audience_bridges.py
+++ b/test/test_audience_bridges.py
@@ -14,7 +14,7 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from agilab import bridge_cli, run_manifest
+from agilab import agent_run, bridge_cli, run_manifest
 from agilab_mcp import manifest_tools, server as mcp_server
 
 
@@ -581,12 +581,36 @@ def test_mcp_tools_and_jsonrpc(tmp_path: Path) -> None:
     manifest_path = _write_manifest(tmp_path)
     apps_root = tmp_path / "apps"
     (apps_root / "alpha_project").mkdir(parents=True)
+    agent_root = tmp_path / "agents"
+    agent_dir = agent_root / "codex-run"
+    agent_run.trace_agent_run(
+        [sys.executable, "-c", "print('agent ok')"],
+        agent="codex",
+        label="Review current diff",
+        cwd=ROOT,
+        output_dir=agent_dir,
+        run_id="agent-codex",
+        permission_level="standard",
+        tags=("review",),
+        metadata={"branch": "main"},
+    )
 
     assert (
         manifest_tools.list_projects(apps_root)["projects"][0]["name"]
         == "alpha_project"
     )
     assert manifest_tools.list_runs(tmp_path)["runs"]
+    agent_runs = manifest_tools.list_agent_runs(agent_root, agent="codex")["runs"]
+    assert agent_runs[0]["run_id"] == "agent-codex"
+    assert agent_runs[0]["tags"] == ["review"]
+    assert agent_runs[0]["metadata"] == {"branch": "main"}
+    assert (
+        manifest_tools.summarize_agent_run(agent_dir)["summary"]["status"]
+        == "pass"
+    )
+    read_agent_payload = manifest_tools.read_agent_run(agent_dir)
+    assert read_agent_payload["manifest"]["kind"] == agent_run.TRACE_KIND
+    assert "agent ok" not in json.dumps(read_agent_payload)
     assert manifest_tools.summarize_run(manifest_path)["summary"]["status"] == "pass"
     assert (
         manifest_tools.list_artifacts(manifest_path)["artifacts"][0]["exists"] is True
@@ -620,6 +644,22 @@ def test_mcp_tools_and_jsonrpc(tmp_path: Path) -> None:
         }
     )
     assert call_response and call_response["result"]["content"][0]["type"] == "text"
+    agent_call_response = mcp_server.handle_jsonrpc(
+        {
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {
+                "name": "list_agent_runs",
+                "arguments": {"log_root": str(agent_root), "agent": "codex"},
+            },
+        }
+    )
+    assert agent_call_response
+    assert (
+        "agent-codex"
+        in agent_call_response["result"]["content"][0]["text"]
+    )
     assert mcp_server.server_manifest()["policy"]["read_only"] is True
 
 

--- a/tools/agent_workflows.md
+++ b/tools/agent_workflows.md
@@ -90,6 +90,15 @@ Read previous run evidence from the CLI:
 agilab agent-run list --agent codex --json
 ```
 
+The read-only MCP bridge exposes the same agent-run evidence to external
+coding agents without enabling shell execution:
+
+```bash
+agilab-mcp list-tools --json
+agilab-mcp call-tool list_agent_runs --arguments '{"agent":"codex","limit":5}' --json
+agilab-mcp call-tool summarize_agent_run --arguments '{"manifest_path":"~/log/agents/codex/<run-id>/agent_run_manifest.json"}' --json
+```
+
 or from Python:
 
 ```python


### PR DESCRIPTION
## Summary\n- add read-only MCP tools for AGILAB agent-run evidence\n- expose list/read/summarize operations without shell execution\n- document the MCP bridge commands for agent-run evidence\n\n## Validation\n- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_audience_bridges.py::test_mcp_tools_and_jsonrpc