### PR TITLE
feat(agent): query agent-run evidence by context

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 231,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "310e4992b156e1d1a4804b5a0ce9496c647896a594ffcf3e3ef0befcc5683569",
+  "source_digest_sha256": "4443fdba619ecd39c3899ba26ce933f0500052f1b90a437a2708e77fcd600faa",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "310e4992b156e1d1a4804b5a0ce9496c647896a594ffcf3e3ef0befcc5683569"
+  "target_digest_sha256": "4443fdba619ecd39c3899ba26ce933f0500052f1b90a437a2708e77fcd600faa"
 }

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 231,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "a53b0dcaf0c96b316c041a621016c242897accf95601c8e62c2c7b4ef0045af8",
+  "source_digest_sha256": "310e4992b156e1d1a4804b5a0ce9496c647896a594ffcf3e3ef0befcc5683569",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "a53b0dcaf0c96b316c041a621016c242897accf95601c8e62c2c7b4ef0045af8"
+  "target_digest_sha256": "310e4992b156e1d1a4804b5a0ce9496c647896a594ffcf3e3ef0befcc5683569"
 }

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 231,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "c26fd7b657f77eeb5a82d2eb1a66be98435249fd91846ab89407149b6e054b40",
+  "source_digest_sha256": "a53b0dcaf0c96b316c041a621016c242897accf95601c8e62c2c7b4ef0045af8",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "c26fd7b657f77eeb5a82d2eb1a66be98435249fd91846ab89407149b6e054b40"
+  "target_digest_sha256": "a53b0dcaf0c96b316c041a621016c242897accf95601c8e62c2c7b4ef0045af8"
 }

--- a/docs/source/agent-workflows.rst
+++ b/docs/source/agent-workflows.rst
@@ -85,6 +85,7 @@ that other tools can query later. Read previous run evidence from the CLI::
    agilab agent-run context --tag review --metadata branch=main --limit 5 --json
    agilab agent-run lineage <run-id> --json
    agilab agent-run compare ~/log/agents/codex/<failed-run> ~/log/agents/codex/<follow-up-run> --json
+   agilab agent-run validate ~/log/agents/codex/<run-id> --json
 
 or from Python::
 
@@ -109,8 +110,10 @@ AGILAB keeps the agent evidence layer deliberately small and provider-neutral:
   should stay out of public JSON.
 - The read side can produce redacted continuation cards, deterministic
   next-action cards, filtered context packs, follow-up lineage graphs, and
-  pairwise run comparisons. These surfaces point to local artifacts but do not
-  embed stdout/stderr contents.
+  pairwise run comparisons. It can also validate manifest structure, trace
+  sequence, and referenced artifact presence before another agent trusts the
+  evidence. These surfaces point to local artifacts but do not embed
+  stdout/stderr contents.
 
 The base package records protocol bridges as evidence labels only. Add
 ``--protocol-adapter mcp`` or ``--capability app-as-tool`` when experimenting

--- a/docs/source/agent-workflows.rst
+++ b/docs/source/agent-workflows.rst
@@ -79,6 +79,11 @@ Use ``--tag`` and ``--metadata KEY=VALUE`` for structured, non-secret context
 that other tools can query later. Read previous run evidence from the CLI::
 
    agilab agent-run list --agent codex --json
+   agilab agent-run list --tag review --metadata branch=main --protocol-adapter mcp --capability evidence-review --json
+   agilab agent-run handoff ~/log/agents/codex/<run-id>
+   agilab agent-run next ~/log/agents/codex/<run-id> --json
+   agilab agent-run context --tag review --metadata branch=main --limit 5 --json
+   agilab agent-run lineage <run-id> --json
 
 or from Python::
 
@@ -101,6 +106,9 @@ AGILAB keeps the agent evidence layer deliberately small and provider-neutral:
   ``permission_resolved``, ``compact``, ``rewind``, and ``session_end``.
 - ``tool-output/`` is reserved for large or structured tool payloads that
   should stay out of public JSON.
+- The read side can produce redacted continuation cards, deterministic
+  next-action cards, filtered context packs, and follow-up lineage graphs. These
+  surfaces point to local artifacts but do not embed stdout/stderr contents.
 
 The base package records protocol bridges as evidence labels only. Add
 ``--protocol-adapter mcp`` or ``--capability app-as-tool`` when experimenting

--- a/docs/source/agent-workflows.rst
+++ b/docs/source/agent-workflows.rst
@@ -84,6 +84,7 @@ that other tools can query later. Read previous run evidence from the CLI::
    agilab agent-run next ~/log/agents/codex/<run-id> --json
    agilab agent-run context --tag review --metadata branch=main --limit 5 --json
    agilab agent-run lineage <run-id> --json
+   agilab agent-run compare ~/log/agents/codex/<failed-run> ~/log/agents/codex/<follow-up-run> --json
 
 or from Python::
 
@@ -107,8 +108,9 @@ AGILAB keeps the agent evidence layer deliberately small and provider-neutral:
 - ``tool-output/`` is reserved for large or structured tool payloads that
   should stay out of public JSON.
 - The read side can produce redacted continuation cards, deterministic
-  next-action cards, filtered context packs, and follow-up lineage graphs. These
-  surfaces point to local artifacts but do not embed stdout/stderr contents.
+  next-action cards, filtered context packs, follow-up lineage graphs, and
+  pairwise run comparisons. These surfaces point to local artifacts but do not
+  embed stdout/stderr contents.
 
 The base package records protocol bridges as evidence labels only. Add
 ``--protocol-adapter mcp`` or ``--capability app-as-tool`` when experimenting

--- a/docs/source/proof-capsule.rst
+++ b/docs/source/proof-capsule.rst
@@ -138,7 +138,7 @@ Keep using the existing first-proof and adoption commands as the entry evidence:
 
 .. code-block:: bash
 
-   agilab first-proof --json --with-ui
+   agilab first-proof --json
    agilab adoption-report
    agilab security-check --profile shared --json
 

--- a/docs/source/quick-start.rst
+++ b/docs/source/quick-start.rst
@@ -24,9 +24,9 @@ Fast adoption path:
      - ``PROJECT`` -> ``ORCHESTRATE`` -> ``WORKFLOW`` -> ``ANALYSIS`` works
        locally.
    * - 3. Record evidence
-     - Start the app with ``agilab`` and verify the built-in flow.
-       If startup fails, run ``agilab dry-run`` then
-       ``uv --preview-features extra-build-dependencies run agilab first-proof --json --with-ui``.
+     - Run ``agilab first-proof --json``, then ``agilab adoption-report``.
+       Add ``--with-ui`` only when you intentionally want the proof to boot the
+       local Streamlit pages too.
      - ``~/log/execute/flight_telemetry/run_manifest.json`` reports ``status: pass``.
    * - 4. Expand
      - Choose notebook, package, private app, or cluster routes only after the
@@ -42,9 +42,9 @@ Prerequisites
 - macOS or Linux shell for the source-checkout installer. On native Windows,
   use the published package route for the CI-covered CLI first proof, or use
   WSL2 for the source checkout path until native installer parity is published.
-- PyCharm is optional. The first proof below uses only a shell and the web UI;
-  IDE run configurations are contributor conveniences, not an installation
-  requirement.
+- PyCharm and the local web UI are optional. The first proof below uses only a
+  shell by default; IDE run configurations and Streamlit pages are contributor
+  conveniences, not installation requirements.
 - If you plan to explore remote workers later, keep SSH access for that later
   step; it is not needed for the first proof path.
 
@@ -65,7 +65,7 @@ If startup fails, run a local fallback first:
 .. code-block:: bash
 
    uv --preview-features extra-build-dependencies run agilab dry-run
-   uv --preview-features extra-build-dependencies run agilab first-proof --json --with-ui
+   uv --preview-features extra-build-dependencies run agilab first-proof --json
    uv --preview-features extra-build-dependencies run agilab adoption-report
 
 **Published package install or upgrade, CLI proof only**::
@@ -154,7 +154,7 @@ machine-readable proof record.
    .. code-block:: bash
 
       uv --preview-features extra-build-dependencies run agilab dry-run
-      uv --preview-features extra-build-dependencies run agilab first-proof --json --with-ui
+      uv --preview-features extra-build-dependencies run agilab first-proof --json
 
    Then rerun:
 
@@ -268,7 +268,7 @@ first-proof and compatibility-report commands to rerun.
 If you want the preflight to also check the built-in installer and seeded helper
 scripts::
 
-    uv --preview-features extra-build-dependencies run agilab first-proof --json --with-ui --with-install
+    uv --preview-features extra-build-dependencies run agilab first-proof --json --with-install
 
 ``agilab dry-run`` is the fast alias for ``agilab first-proof --dry-run`` and
 checks only CLI/core readiness.
@@ -308,7 +308,7 @@ The dedicated docs page for this route is :doc:`agilab-demo`.
 
 **Published package route** (fastest install, less representative of the full product path)::
 
-    uv --preview-features extra-build-dependencies tool install --upgrade agilab
+    uv --preview-features extra-build-dependencies tool install --upgrade "agilab[examples]"
     agilab first-proof --json --max-seconds 60
 
 The base package install is intentionally CLI/core only. Install the UI profile
@@ -323,7 +323,10 @@ profile, run:
 .. code-block:: bash
 
    agilab dry-run
-   agilab first-proof --json --with-ui
+   agilab first-proof --json
+
+Add ``--with-ui`` to the first-proof command only when the proof should also
+boot the packaged Streamlit pages.
 
 Optional feature stacks stay out of the base package install. Add
 ``agilab[ui]`` for the local Streamlit app, ``agilab[pages]`` for analysis

--- a/docs/source/roadmap/agilab-future-work.md
+++ b/docs/source/roadmap/agilab-future-work.md
@@ -1259,7 +1259,7 @@ The dependency-light bridge MVP baseline now exposes these commands:
    `agilab mcp serve --read-only`, `agilab agent-run list`,
    `agilab agent-run handoff`, `agilab agent-run next`,
    `agilab agent-run context`, `agilab agent-run lineage`, and
-   `agilab agent-run compare`
+   `agilab agent-run compare`, plus `agilab agent-run validate`
 3. Hugging Face Docker Space exporter: `agilab export hf-space`
 4. MLflow JSON handoff: `agilab export mlflow` and `agilab import mlflow`
 5. VS Code / devcontainer onboarding: `agilab init vscode`

--- a/docs/source/roadmap/agilab-future-work.md
+++ b/docs/source/roadmap/agilab-future-work.md
@@ -1258,7 +1258,8 @@ The dependency-light bridge MVP baseline now exposes these commands:
 2. read-only MCP evidence server and agent evidence cards:
    `agilab mcp serve --read-only`, `agilab agent-run list`,
    `agilab agent-run handoff`, `agilab agent-run next`,
-   `agilab agent-run context`, and `agilab agent-run lineage`
+   `agilab agent-run context`, `agilab agent-run lineage`, and
+   `agilab agent-run compare`
 3. Hugging Face Docker Space exporter: `agilab export hf-space`
 4. MLflow JSON handoff: `agilab export mlflow` and `agilab import mlflow`
 5. VS Code / devcontainer onboarding: `agilab init vscode`

--- a/docs/source/roadmap/agilab-future-work.md
+++ b/docs/source/roadmap/agilab-future-work.md
@@ -342,8 +342,9 @@ Remaining state-of-the-art scope:
   promotion gates, release gates, and sensitive-data gates
 - capability-based sandboxing for generated code, notebooks, and agent runs:
   explicit filesystem, network, secret, and subprocess scopes
-- first-class agent eval traces: prompt/tool/file/command timeline, permission
-  decisions, diff evidence, replay, scoring, and safety policy results
+- first-class agent eval traces beyond the shipped local agent-run cards:
+  prompt/tool/file timeline detail, diff evidence, replay, scoring, and safety
+  policy results
 - monitoring and drift handoff adapters for production systems without turning
   AGILab into the production control plane
 - enterprise controls for shared deployments: secrets backend integration,
@@ -390,9 +391,11 @@ Agent skills and resource evidence hardening:
 - feed resource snapshots and cluster inventory into scheduler recommendations
   and future autoscale decisions, while keeping autoscale behavior explicit and
   auditable rather than silently changing execution topology
-- extend `agilab agent-run` evidence so skill identity, skill version, resource
-  snapshot, permission decisions, changed files, command timeline, and resulting
-  proof artifacts can be replayed or reviewed together
+- build on the shipped `agilab agent-run` evidence commands (`list`,
+  `handoff`, `next`, `context`, and `lineage`) by adding skill identity, skill
+  version, resource snapshot, changed files, richer command timeline, and
+  resulting proof-artifact links so multi-agent work can be replayed or reviewed
+  together
 - publish agent-surface validation as release evidence: generated catalogs,
   badge freshness, changed-skill scan reports, and resource snapshot checks
   should be archived alongside SBOM, `pip-audit`, hashes, and provenance
@@ -1252,7 +1255,10 @@ normal workflow.
 The dependency-light bridge MVP baseline now exposes these commands:
 
 1. Quarto / R report bridge: `agilab export quarto` and `agilab run quarto`
-2. read-only MCP evidence server: `agilab mcp serve --read-only`
+2. read-only MCP evidence server and agent evidence cards:
+   `agilab mcp serve --read-only`, `agilab agent-run list`,
+   `agilab agent-run handoff`, `agilab agent-run next`,
+   `agilab agent-run context`, and `agilab agent-run lineage`
 3. Hugging Face Docker Space exporter: `agilab export hf-space`
 4. MLflow JSON handoff: `agilab export mlflow` and `agilab import mlflow`
 5. VS Code / devcontainer onboarding: `agilab init vscode`

--- a/docs/source/roadmap/audience-bridges.md
+++ b/docs/source/roadmap/audience-bridges.md
@@ -205,6 +205,7 @@ agilab-mcp
     agent_context
     agent_lineage
     compare_agent_runs
+    validate_agent_run
 
   dangerous tools, disabled by default:
     run_project
@@ -233,6 +234,7 @@ agilab agent-run next ~/log/agents/codex/<run-id> --json
 agilab agent-run context --tag review --limit 5 --json
 agilab agent-run lineage <run-id> --json
 agilab agent-run compare ~/log/agents/codex/<failed-run> ~/log/agents/codex/<follow-up-run> --json
+agilab agent-run validate ~/log/agents/codex/<run-id> --json
 ```
 
 The value proposition is simple: ask an AI assistant why an experiment or agent

--- a/docs/source/roadmap/audience-bridges.md
+++ b/docs/source/roadmap/audience-bridges.md
@@ -56,7 +56,7 @@ Rscript tests are skipped when R is not installed.
 | Priority | Bridge | Audience gained | Why it fits AGILAB |
 |---:|---|---|---|
 | 1 | Quarto / R bridge | R users, academics, statisticians, pharma, reproducible-research users | Turns AGILAB evidence into publishable reports. |
-| 2 | MCP bridge | AI-agent users, Claude, ChatGPT, VS Code, Cursor users | Lets agents inspect and summarize AGILAB evidence workflows. |
+| 2 | MCP and agent evidence bridge | AI-agent users, Claude, ChatGPT, VS Code, Cursor users | Lets agents inspect, summarize, continue, and link AGILAB evidence workflows without executing projects. |
 | 3 | Hugging Face bridge | ML demo builders and the open-source ML community | Makes AGILAB apps easier to try publicly. |
 | 4 | Deeper MLflow bridge | MLOps engineers | Positions AGILAB as reproducible execution around MLflow tracking. |
 | 5 | VS Code / devcontainer bridge | Python developers, data scientists, students | Reduces install and first-run friction. |
@@ -178,10 +178,11 @@ The adapter contract must stay narrow:
 Shared core changes should wait until this payload-plane proof remains useful
 across real examples.
 
-## 3. MCP bridge, read-first
+## 3. MCP and agent evidence bridge, read-first
 
-The second strongest audience bridge is MCP because it plugs AGILAB into the
-AI-agent ecosystem.
+The second strongest audience bridge is MCP plus agent-run evidence because it
+plugs AGILAB into the AI-agent ecosystem without weakening the execution
+boundary.
 
 Do not start with "agents can execute everything." Start with a safe read-first
 server:
@@ -191,11 +192,18 @@ agilab-mcp
   tools:
     list_projects
     list_runs
+    list_agent_runs
     read_manifest
+    read_agent_run
     list_artifacts
     summarize_run
+    summarize_agent_run
     compare_runs
     export_quarto_report
+    agent_handoff
+    agent_next_actions
+    agent_context
+    agent_lineage
 
   dangerous tools, disabled by default:
     run_project
@@ -214,8 +222,20 @@ no shell commands
 no secret-bearing artifact output
 ```
 
-The value proposition is simple: ask an AI assistant why an experiment failed,
-and let it inspect AGILAB run evidence without weakening the execution boundary.
+The shipped agent-run read side adds the operational layer agents need to work
+across sessions:
+
+```bash
+agilab agent-run list --tag review --metadata branch=main --json
+agilab agent-run handoff ~/log/agents/codex/<run-id>
+agilab agent-run next ~/log/agents/codex/<run-id> --json
+agilab agent-run context --tag review --limit 5 --json
+agilab agent-run lineage <run-id> --json
+```
+
+The value proposition is simple: ask an AI assistant why an experiment or agent
+task failed, let it inspect AGILAB evidence, hand it a safe continuation card,
+and preserve the follow-up chain without granting execution authority.
 
 ## 4. Hugging Face bridge
 

--- a/docs/source/roadmap/audience-bridges.md
+++ b/docs/source/roadmap/audience-bridges.md
@@ -204,6 +204,7 @@ agilab-mcp
     agent_next_actions
     agent_context
     agent_lineage
+    compare_agent_runs
 
   dangerous tools, disabled by default:
     run_project
@@ -231,6 +232,7 @@ agilab agent-run handoff ~/log/agents/codex/<run-id>
 agilab agent-run next ~/log/agents/codex/<run-id> --json
 agilab agent-run context --tag review --limit 5 --json
 agilab agent-run lineage <run-id> --json
+agilab agent-run compare ~/log/agents/codex/<failed-run> ~/log/agents/codex/<follow-up-run> --json
 ```
 
 The value proposition is simple: ask an AI assistant why an experiment or agent

--- a/src/agilab/agent_run.py
+++ b/src/agilab/agent_run.py
@@ -1622,6 +1622,117 @@ def render_lineage_markdown(payload: dict[str, object]) -> str:
     return "\n".join(lines)
 
 
+def _string_set_delta(left: Sequence[object], right: Sequence[object]) -> dict[str, list[str]]:
+    left_set = {str(value) for value in left}
+    right_set = {str(value) for value in right}
+    return {
+        "added": sorted(right_set - left_set),
+        "removed": sorted(left_set - right_set),
+    }
+
+
+def _metadata_delta(
+    left: Mapping[str, object], right: Mapping[str, object]
+) -> dict[str, object]:
+    left_keys = set(left)
+    right_keys = set(right)
+    shared = left_keys & right_keys
+    return {
+        "added": {key: right[key] for key in sorted(right_keys - left_keys)},
+        "removed": {key: left[key] for key in sorted(left_keys - right_keys)},
+        "changed": {
+            key: {"left": left[key], "right": right[key]}
+            for key in sorted(shared)
+            if left[key] != right[key]
+        },
+    }
+
+
+def _trace_event_count(summary: AgentRunSummary) -> int:
+    if not summary.trace_events_path:
+        return 0
+    try:
+        return len(load_trace_events(summary.trace_events_path.parent))
+    except OSError:
+        return 0
+
+
+def compare_agent_runs(
+    left_manifest_or_path: dict[str, object] | Path | str,
+    right_manifest_or_path: dict[str, object] | Path | str,
+) -> dict[str, object]:
+    """Compare two agent-run manifests without embedding stdout/stderr contents."""
+
+    left_manifest = (
+        left_manifest_or_path
+        if isinstance(left_manifest_or_path, dict)
+        else load_agent_run_manifest(left_manifest_or_path)
+    )
+    right_manifest = (
+        right_manifest_or_path
+        if isinstance(right_manifest_or_path, dict)
+        else load_agent_run_manifest(right_manifest_or_path)
+    )
+    left = summarize_agent_run(left_manifest)
+    right = summarize_agent_run(right_manifest)
+    left_command = left_manifest.get("command", {})
+    right_command = right_manifest.get("command", {})
+    left_command_map = left_command if isinstance(left_command, dict) else {}
+    right_command_map = right_command if isinstance(right_command, dict) else {}
+    left_protocols = _protocol_summary(left_manifest)
+    right_protocols = _protocol_summary(right_manifest)
+    left_trace_count = _trace_event_count(left)
+    right_trace_count = _trace_event_count(right)
+    return {
+        "schema": "agilab.agent_compare.v1",
+        "left": _summary_payload(left),
+        "right": _summary_payload(right),
+        "status_changed": left.status != right.status,
+        "returncode_changed": left.returncode != right.returncode,
+        "duration_delta_seconds": right.duration_seconds - left.duration_seconds,
+        "command": {
+            "argv_sha256_changed": left_command_map.get("argv_sha256")
+            != right_command_map.get("argv_sha256"),
+            "argv_count_delta": int(right_command_map.get("argv_count") or 0)
+            - int(left_command_map.get("argv_count") or 0),
+            "cwd_changed": left_command_map.get("cwd") != right_command_map.get("cwd"),
+        },
+        "tags": _string_set_delta(left.tags, right.tags),
+        "metadata": _metadata_delta(left.metadata, right.metadata),
+        "protocol_adapters": _string_set_delta(
+            left_protocols["adapters"], right_protocols["adapters"]
+        ),
+        "capabilities": _string_set_delta(
+            left_protocols["capabilities"], right_protocols["capabilities"]
+        ),
+        "trace_event_count_delta": right_trace_count - left_trace_count,
+        "artifact_policy": "Manifest paths and counts only; stdout/stderr contents are not embedded.",
+    }
+
+
+def render_compare_markdown(payload: dict[str, object]) -> str:
+    """Render an agent-run comparison as compact Markdown."""
+
+    left = payload.get("left", {})
+    right = payload.get("right", {})
+    left_map = left if isinstance(left, dict) else {}
+    right_map = right if isinstance(right, dict) else {}
+    lines = [
+        "# AGILAB agent-run comparison",
+        "",
+        f"- left: {left_map.get('run_id', '')} ({left_map.get('status', '')})",
+        f"- right: {right_map.get('run_id', '')} ({right_map.get('status', '')})",
+        f"- status_changed: {payload.get('status_changed', False)}",
+        f"- returncode_changed: {payload.get('returncode_changed', False)}",
+        f"- duration_delta_seconds: {payload.get('duration_delta_seconds', 0.0)}",
+        f"- trace_event_count_delta: {payload.get('trace_event_count_delta', 0)}",
+    ]
+    metadata = payload.get("metadata", {})
+    if isinstance(metadata, dict) and any(metadata.get(key) for key in ("added", "removed", "changed")):
+        lines.extend(["", "## Metadata delta", "", json.dumps(metadata, sort_keys=True)])
+    return "\n".join(lines)
+
+
 def _build_handoff_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Render an AGILAB agent-run handoff card.")
     parser.add_argument("manifest_path", help="Agent-run manifest path or run directory.")
@@ -1665,6 +1776,14 @@ def _build_lineage_parser() -> argparse.ArgumentParser:
     parser.add_argument("run_id", help="Target agent-run id to explain.")
     parser.add_argument("--root", default="", help="Root directory to scan. Defaults to ~/log/agents.")
     parser.add_argument("--json", action="store_true", help="Print the lineage graph as JSON.")
+    return parser
+
+
+def _build_compare_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Compare two AGILAB agent-run manifests.")
+    parser.add_argument("left_manifest", help="Left agent-run manifest path or run directory.")
+    parser.add_argument("right_manifest", help="Right agent-run manifest path or run directory.")
+    parser.add_argument("--json", action="store_true", help="Print the comparison as JSON.")
     return parser
 
 
@@ -1723,6 +1842,20 @@ def _main_lineage(argv: Sequence[str]) -> int:
         print(json.dumps(payload, indent=2, sort_keys=True))
     else:
         print(render_lineage_markdown(payload))
+    return 0
+
+
+def _main_compare(argv: Sequence[str]) -> int:
+    parser = _build_compare_parser()
+    args = parser.parse_args(list(argv))
+    payload = compare_agent_runs(
+        Path(args.left_manifest).expanduser(),
+        Path(args.right_manifest).expanduser(),
+    )
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(render_compare_markdown(payload))
     return 0
 
 
@@ -1786,6 +1919,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         return _main_context(raw_argv[1:])
     if raw_argv[:1] == ["lineage"]:
         return _main_lineage(raw_argv[1:])
+    if raw_argv[:1] == ["compare"]:
+        return _main_compare(raw_argv[1:])
 
     config = parse_args(raw_argv)
     if config.print_only:

--- a/src/agilab/agent_run.py
+++ b/src/agilab/agent_run.py
@@ -19,7 +19,7 @@ from uuid import uuid4
 
 from agilab.agent_config import load_agent_config, resolve_agent_provider
 from agilab.agent_tool_safety import evaluate_tool_permission, normalize_permission_level
-from agilab.agent_trace import AgentTraceStore, trace_artifact_payload
+from agilab.agent_trace import AgentTraceStore, load_trace_events, trace_artifact_payload
 from agilab.secret_uri import redact_text
 
 
@@ -1182,6 +1182,133 @@ def _summary_payload(summary: AgentRunSummary) -> dict[str, object]:
     }
 
 
+def _protocol_summary(manifest: dict[str, object]) -> dict[str, object]:
+    protocols = manifest.get("protocols", {})
+    protocols_map = protocols if isinstance(protocols, dict) else {}
+    return {
+        "adapters": list(protocols_map.get("adapters", []))
+        if isinstance(protocols_map.get("adapters"), list)
+        else [],
+        "capabilities": list(protocols_map.get("capabilities", []))
+        if isinstance(protocols_map.get("capabilities"), list)
+        else [],
+        "mode": str(protocols_map.get("mode") or ""),
+    }
+
+
+def agent_handoff_payload(manifest_or_path: dict[str, object] | Path | str) -> dict[str, object]:
+    """Build a compact, redacted handoff card for a prior agent run."""
+
+    if isinstance(manifest_or_path, dict):
+        manifest = manifest_or_path
+    else:
+        manifest = load_agent_run_manifest(manifest_or_path)
+    summary = summarize_agent_run(manifest)
+    command = manifest.get("command", {})
+    command_map = command if isinstance(command, dict) else {}
+    permission = manifest.get("permission", {})
+    permission_map = permission if isinstance(permission, dict) else {}
+    trace_events: list[dict[str, object]] = []
+    if summary.trace_events_path:
+        for event in load_trace_events(summary.trace_events_path.parent):
+            trace_events.append(
+                {
+                    "sequence": event.sequence,
+                    "event": event.event,
+                    "status": event.status,
+                    "message": event.message,
+                }
+            )
+    manifest_path = str(summary.manifest_path)
+    continue_prompt = (
+        "Continue from AGILAB agent-run evidence "
+        f"{manifest_path}. Read the manifest first, inspect stdout/stderr only if needed, "
+        "and preserve the recorded tags, metadata, protocol adapters, and capabilities "
+        "when creating follow-up evidence."
+    )
+    return {
+        "schema": "agilab.agent_handoff.v1",
+        "run": _summary_payload(summary),
+        "command": {
+            "argv": command_map.get("argv", []),
+            "argv_redacted": bool(command_map.get("argv_redacted", False)),
+            "argv_count": command_map.get("argv_count"),
+            "argv_sha256": command_map.get("argv_sha256"),
+            "cwd": command_map.get("cwd"),
+        },
+        "protocols": _protocol_summary(manifest),
+        "permission": {
+            "allowed": bool(permission_map.get("allowed", False)),
+            "tier": permission_map.get("tier"),
+            "level": permission_map.get("level"),
+            "reason": permission_map.get("reason"),
+        },
+        "trace": {
+            "event_count": len(trace_events),
+            "events": trace_events,
+        },
+        "handoff": {
+            "continue_prompt": continue_prompt,
+            "artifact_policy": "Manifest paths and counts only; stdout/stderr contents are not embedded.",
+        },
+    }
+
+
+def render_handoff_markdown(payload: dict[str, object]) -> str:
+    """Render an agent handoff payload as compact Markdown."""
+
+    run = payload.get("run", {})
+    run_map = run if isinstance(run, dict) else {}
+    protocols = payload.get("protocols", {})
+    protocol_map = protocols if isinstance(protocols, dict) else {}
+    handoff = payload.get("handoff", {})
+    handoff_map = handoff if isinstance(handoff, dict) else {}
+    trace = payload.get("trace", {})
+    trace_map = trace if isinstance(trace, dict) else {}
+    tags = run_map.get("tags", [])
+    metadata = run_map.get("metadata", {})
+    lines = [
+        "# AGILAB agent handoff",
+        "",
+        f"- run_id: {run_map.get('run_id', '')}",
+        f"- agent: {run_map.get('agent', '')}",
+        f"- status: {run_map.get('status', '')}",
+        f"- label: {run_map.get('label', '')}",
+        f"- manifest: {run_map.get('manifest', '')}",
+        f"- stdout: {run_map.get('stdout', '')}",
+        f"- stderr: {run_map.get('stderr', '')}",
+        f"- trace_events: {run_map.get('trace_events', '')}",
+        f"- tags: {', '.join(str(tag) for tag in tags) if isinstance(tags, list) else ''}",
+        f"- metadata: {json.dumps(metadata, sort_keys=True) if isinstance(metadata, dict) else '{}'}",
+        f"- protocol_adapters: {', '.join(str(value) for value in protocol_map.get('adapters', []))}",
+        f"- capabilities: {', '.join(str(value) for value in protocol_map.get('capabilities', []))}",
+        f"- trace_event_count: {trace_map.get('event_count', 0)}",
+        "",
+        "## Continue prompt",
+        "",
+        str(handoff_map.get("continue_prompt", "")),
+    ]
+    return "\n".join(lines)
+
+
+def _build_handoff_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Render an AGILAB agent-run handoff card.")
+    parser.add_argument("manifest_path", help="Agent-run manifest path or run directory.")
+    parser.add_argument("--json", action="store_true", help="Print the handoff card as JSON.")
+    return parser
+
+
+def _main_handoff(argv: Sequence[str]) -> int:
+    parser = _build_handoff_parser()
+    args = parser.parse_args(list(argv))
+    payload = agent_handoff_payload(Path(args.manifest_path).expanduser())
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(render_handoff_markdown(payload))
+    return 0
+
+
 def _render_summary_table(summaries: Sequence[AgentRunSummary]) -> str:
     if not summaries:
         return "No AGILAB agent runs found."
@@ -1234,6 +1361,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     raw_argv = list(sys.argv[1:] if argv is None else argv)
     if raw_argv[:1] == ["list"]:
         return _main_list(raw_argv[1:])
+    if raw_argv[:1] == ["handoff"]:
+        return _main_handoff(raw_argv[1:])
 
     config = parse_args(raw_argv)
     if config.print_only:

--- a/src/agilab/agent_run.py
+++ b/src/agilab/agent_run.py
@@ -1521,6 +1521,107 @@ def render_context_markdown(payload: dict[str, object]) -> str:
     return "\n".join(lines)
 
 
+def agent_lineage_payload(
+    root: Path | str | None = None,
+    *,
+    run_id: str,
+) -> dict[str, object]:
+    """Build a follow-up lineage graph from agent-run metadata."""
+
+    summaries = list_agent_runs(root, limit=None)
+    by_run_id = {summary.run_id: summary for summary in summaries if summary.run_id}
+    children_by_parent: dict[str, list[AgentRunSummary]] = {}
+    parent_by_child: dict[str, str] = {}
+    for summary in summaries:
+        parent = summary.metadata.get("followup_of")
+        if not isinstance(parent, str) or not parent:
+            continue
+        parent_by_child[summary.run_id] = parent
+        children_by_parent.setdefault(parent, []).append(summary)
+
+    target = by_run_id.get(run_id)
+    ancestors: list[AgentRunSummary] = []
+    seen = {run_id}
+    cursor = run_id
+    while cursor in parent_by_child:
+        parent_id = parent_by_child[cursor]
+        if parent_id in seen:
+            break
+        seen.add(parent_id)
+        parent = by_run_id.get(parent_id)
+        if parent is None:
+            break
+        ancestors.append(parent)
+        cursor = parent_id
+    ancestors.reverse()
+
+    descendants: list[AgentRunSummary] = []
+
+    def visit(parent_id: str, seen_ids: set[str]) -> None:
+        for child in children_by_parent.get(parent_id, []):
+            if child.run_id in seen_ids:
+                continue
+            seen_ids.add(child.run_id)
+            descendants.append(child)
+            visit(child.run_id, seen_ids)
+
+    visit(run_id, {run_id})
+    chain = [*ancestors, *([target] if target is not None else []), *descendants]
+    edges = [
+        {"from": parent, "to": child}
+        for child, parent in sorted(parent_by_child.items())
+        if child in by_run_id and parent in by_run_id
+    ]
+    return {
+        "schema": "agilab.agent_lineage.v1",
+        "query": {
+            "root": str(Path(root).expanduser()) if root is not None else "~/log/agents",
+            "run_id": run_id,
+        },
+        "found": target is not None,
+        "target": _summary_payload(target) if target is not None else None,
+        "ancestors": [_summary_payload(summary) for summary in ancestors],
+        "descendants": [_summary_payload(summary) for summary in descendants],
+        "chain": [_summary_payload(summary) for summary in chain],
+        "edges": edges,
+        "artifact_policy": "Manifest paths and metadata links only; stdout/stderr contents are not embedded.",
+    }
+
+
+def render_lineage_markdown(payload: dict[str, object]) -> str:
+    """Render an agent lineage graph as compact Markdown."""
+
+    chain = payload.get("chain", [])
+    chain_list = chain if isinstance(chain, list) else []
+    edges = payload.get("edges", [])
+    edge_list = edges if isinstance(edges, list) else []
+    lines = [
+        "# AGILAB agent lineage",
+        "",
+        f"- run_id: {payload.get('query', {}).get('run_id', '') if isinstance(payload.get('query'), dict) else ''}",
+        f"- found: {payload.get('found', False)}",
+        "",
+        "## Chain",
+        "",
+    ]
+    if not chain_list:
+        lines.append("- No linked agent runs found.")
+    for item in chain_list:
+        if not isinstance(item, dict):
+            continue
+        lines.append(
+            f"- {item.get('status', '-')}: {item.get('run_id', '-')} "
+            f"({item.get('agent', '-')}) - {item.get('label', '')}"
+        )
+    if edge_list:
+        lines.extend(["", "## Links", ""])
+        for edge in edge_list:
+            if not isinstance(edge, dict):
+                continue
+            lines.append(f"- {edge.get('from', '')} -> {edge.get('to', '')}")
+    return "\n".join(lines)
+
+
 def _build_handoff_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Render an AGILAB agent-run handoff card.")
     parser.add_argument("manifest_path", help="Agent-run manifest path or run directory.")
@@ -1556,6 +1657,14 @@ def _build_context_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--limit", type=int, default=20, help="Maximum number of runs to include.")
     parser.add_argument("--json", action="store_true", help="Print the context pack as JSON.")
+    return parser
+
+
+def _build_lineage_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Render an AGILAB agent-run follow-up lineage.")
+    parser.add_argument("run_id", help="Target agent-run id to explain.")
+    parser.add_argument("--root", default="", help="Root directory to scan. Defaults to ~/log/agents.")
+    parser.add_argument("--json", action="store_true", help="Print the lineage graph as JSON.")
     return parser
 
 
@@ -1600,6 +1709,20 @@ def _main_context(argv: Sequence[str]) -> int:
         print(json.dumps(payload, indent=2, sort_keys=True))
     else:
         print(render_context_markdown(payload))
+    return 0
+
+
+def _main_lineage(argv: Sequence[str]) -> int:
+    parser = _build_lineage_parser()
+    args = parser.parse_args(list(argv))
+    payload = agent_lineage_payload(
+        Path(args.root).expanduser() if args.root else None,
+        run_id=args.run_id,
+    )
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(render_lineage_markdown(payload))
     return 0
 
 
@@ -1661,6 +1784,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         return _main_next(raw_argv[1:])
     if raw_argv[:1] == ["context"]:
         return _main_context(raw_argv[1:])
+    if raw_argv[:1] == ["lineage"]:
+        return _main_lineage(raw_argv[1:])
 
     config = parse_args(raw_argv)
     if config.print_only:

--- a/src/agilab/agent_run.py
+++ b/src/agilab/agent_run.py
@@ -929,6 +929,10 @@ def find_agent_run_manifests(
     *,
     agent: str | None = None,
     status: str | None = None,
+    tags: Sequence[str] = (),
+    metadata: Mapping[str, str] | None = None,
+    protocol_adapters: Sequence[str] = (),
+    capabilities: Sequence[str] = (),
     limit: int | None = None,
 ) -> list[Path]:
     """Find agent-run manifest files, newest first."""
@@ -937,6 +941,10 @@ def find_agent_run_manifests(
     search_root = Path(root).expanduser() if explicit_root else _default_log_root() / "agents"
     if agent and not explicit_root:
         search_root = search_root / _slug(agent, "agent")
+    required_tags = set(_normalize_tags(tags))
+    required_metadata = dict(metadata or {})
+    required_protocol_adapters = set(_normalize_slug_values(protocol_adapters))
+    required_capabilities = set(_normalize_slug_values(capabilities))
     if not search_root.exists():
         return []
     candidates = [
@@ -945,7 +953,14 @@ def find_agent_run_manifests(
         if path.is_file()
     ]
     candidates.sort(key=lambda path: path.stat().st_mtime_ns, reverse=True)
-    if agent or status:
+    if (
+        agent
+        or status
+        or required_tags
+        or required_metadata
+        or required_protocol_adapters
+        or required_capabilities
+    ):
         filtered: list[Path] = []
         for path in candidates:
             try:
@@ -955,9 +970,41 @@ def find_agent_run_manifests(
             if agent and manifest.get("agent") != agent:
                 continue
             if manifest.get("status") == status:
-                filtered.append(path)
-            elif not status:
-                filtered.append(path)
+                pass
+            elif status:
+                continue
+            context = manifest.get("context", {})
+            context_map = context if isinstance(context, dict) else {}
+            raw_tags = context_map.get("tags", [])
+            manifest_tags = set(str(tag) for tag in raw_tags) if isinstance(raw_tags, list) else set()
+            if required_tags and not required_tags.issubset(manifest_tags):
+                continue
+            raw_metadata = context_map.get("metadata", {})
+            manifest_metadata = raw_metadata if isinstance(raw_metadata, dict) else {}
+            if required_metadata and any(
+                str(manifest_metadata.get(key, "")) != value
+                for key, value in required_metadata.items()
+            ):
+                continue
+            protocols = manifest.get("protocols", {})
+            protocols_map = protocols if isinstance(protocols, dict) else {}
+            raw_adapters = protocols_map.get("adapters", [])
+            manifest_adapters = (
+                set(str(value) for value in raw_adapters)
+                if isinstance(raw_adapters, list)
+                else set()
+            )
+            if required_protocol_adapters and not required_protocol_adapters.issubset(manifest_adapters):
+                continue
+            raw_capabilities = protocols_map.get("capabilities", [])
+            manifest_capabilities = (
+                set(str(value) for value in raw_capabilities)
+                if isinstance(raw_capabilities, list)
+                else set()
+            )
+            if required_capabilities and not required_capabilities.issubset(manifest_capabilities):
+                continue
+            filtered.append(path)
         candidates = filtered
     return candidates[:limit] if limit is not None else candidates
 
@@ -967,12 +1014,25 @@ def list_agent_runs(
     *,
     agent: str | None = None,
     status: str | None = None,
+    tags: Sequence[str] = (),
+    metadata: Mapping[str, str] | None = None,
+    protocol_adapters: Sequence[str] = (),
+    capabilities: Sequence[str] = (),
     limit: int | None = None,
 ) -> list[AgentRunSummary]:
     """Return compact summaries for agent-run manifests, newest first."""
 
     summaries: list[AgentRunSummary] = []
-    for path in find_agent_run_manifests(root, agent=agent, status=status, limit=limit):
+    for path in find_agent_run_manifests(
+        root,
+        agent=agent,
+        status=status,
+        tags=tags,
+        metadata=metadata,
+        protocol_adapters=protocol_adapters,
+        capabilities=capabilities,
+        limit=limit,
+    ):
         try:
             summaries.append(summarize_agent_run(load_agent_run_manifest(path)))
         except (OSError, json.JSONDecodeError, ValueError):
@@ -1086,6 +1146,20 @@ def _build_list_parser() -> argparse.ArgumentParser:
     parser.add_argument("--root", default="", help="Root directory to scan. Defaults to ~/log/agents.")
     parser.add_argument("--agent", default="", help="Only list runs for this agent.")
     parser.add_argument("--status", default="", choices=["", "planned", "pass", "fail", "timeout", "denied"], help="Only list runs with this status.")
+    parser.add_argument("--tag", action="append", default=[], help="Only list runs containing this tag. May be repeated.")
+    parser.add_argument("--metadata", action="append", default=[], help="Only list runs with this metadata KEY=VALUE. May be repeated.")
+    parser.add_argument(
+        "--protocol-adapter",
+        action="append",
+        default=[],
+        help="Only list runs containing this protocol adapter label. May be repeated.",
+    )
+    parser.add_argument(
+        "--capability",
+        action="append",
+        default=[],
+        help="Only list runs containing this capability label. May be repeated.",
+    )
     parser.add_argument("--limit", type=int, default=20, help="Maximum number of runs to list.")
     parser.add_argument("--json", action="store_true", help="Print summaries as JSON.")
     return parser
@@ -1128,6 +1202,10 @@ def _main_list(argv: Sequence[str]) -> int:
         Path(args.root).expanduser() if args.root else None,
         agent=args.agent or None,
         status=args.status or None,
+        tags=args.tag,
+        metadata=_parse_metadata(args.metadata),
+        protocol_adapters=args.protocol_adapter,
+        capabilities=args.capability,
         limit=args.limit,
     )
     if args.json:

--- a/src/agilab/agent_run.py
+++ b/src/agilab/agent_run.py
@@ -1291,10 +1291,145 @@ def render_handoff_markdown(payload: dict[str, object]) -> str:
     return "\n".join(lines)
 
 
+def _next_action_items(summary: AgentRunSummary, permission: Mapping[str, object]) -> list[dict[str, str]]:
+    status = summary.status
+    if status == "pass":
+        return [
+            {
+                "priority": "P1",
+                "action": "Attach this manifest path to the proof, review, or release note that depends on it.",
+                "reason": "The agent run completed successfully and has reusable evidence artifacts.",
+            },
+            {
+                "priority": "P2",
+                "action": "Use matching tags, metadata, protocol adapters, and capabilities for follow-up runs.",
+                "reason": "Context-stable metadata keeps later agent evidence queryable.",
+            },
+        ]
+    if status == "denied":
+        return [
+            {
+                "priority": "P0",
+                "action": "Inspect the permission tier and stderr artifact before rerunning.",
+                "reason": str(permission.get("reason") or "The command was blocked by the permission policy."),
+            },
+            {
+                "priority": "P1",
+                "action": "Prefer a narrower non-destructive command; escalate permission only with explicit operator intent.",
+                "reason": "AGILAB records confirmation requirements but does not sandbox the process.",
+            },
+        ]
+    if status == "timeout":
+        return [
+            {
+                "priority": "P0",
+                "action": "Inspect stderr, stdout, and trace events to identify the slow phase before increasing timeout.",
+                "reason": "A timeout is ambiguous without artifact review.",
+            },
+            {
+                "priority": "P1",
+                "action": "Retry with the same tags and metadata after narrowing the command or extending timeout deliberately.",
+                "reason": "Stable context makes timeout regressions comparable.",
+            },
+        ]
+    if status == "fail":
+        return [
+            {
+                "priority": "P0",
+                "action": "Inspect stderr and trace events, fix the smallest reproducible cause, then rerun.",
+                "reason": "The command returned a non-zero exit status.",
+            },
+            {
+                "priority": "P1",
+                "action": "Record the follow-up run with metadata followup_of=<run_id>.",
+                "reason": "A linked follow-up preserves the debugging chain for another agent.",
+            },
+        ]
+    return [
+        {
+            "priority": "P1",
+            "action": "Read the manifest and trace events before deciding whether to rerun or archive this evidence.",
+            "reason": f"Status {status!r} does not have a specialized policy.",
+        }
+    ]
+
+
+def agent_next_actions_payload(manifest_or_path: dict[str, object] | Path | str) -> dict[str, object]:
+    """Build deterministic next-action guidance from one agent-run manifest."""
+
+    if isinstance(manifest_or_path, dict):
+        manifest = manifest_or_path
+    else:
+        manifest = load_agent_run_manifest(manifest_or_path)
+    summary = summarize_agent_run(manifest)
+    permission = manifest.get("permission", {})
+    permission_map = permission if isinstance(permission, dict) else {}
+    followup_metadata = dict(summary.metadata)
+    if summary.run_id:
+        followup_metadata["followup_of"] = summary.run_id
+    return {
+        "schema": "agilab.agent_next_actions.v1",
+        "run": _summary_payload(summary),
+        "protocols": _protocol_summary(manifest),
+        "permission": {
+            "allowed": bool(permission_map.get("allowed", False)),
+            "tier": permission_map.get("tier"),
+            "level": permission_map.get("level"),
+            "reason": permission_map.get("reason"),
+        },
+        "next_actions": _next_action_items(summary, permission_map),
+        "followup_context": {
+            "agent": summary.agent,
+            "tags": list(summary.tags),
+            "metadata": followup_metadata,
+            "protocol_adapters": _protocol_summary(manifest)["adapters"],
+            "capabilities": _protocol_summary(manifest)["capabilities"],
+            "command_policy": (
+                "Do not reconstruct redacted argv from the manifest. Rebuild the next command from current task context."
+            ),
+        },
+    }
+
+
+def render_next_actions_markdown(payload: dict[str, object]) -> str:
+    """Render next-action guidance as compact Markdown."""
+
+    run = payload.get("run", {})
+    run_map = run if isinstance(run, dict) else {}
+    actions = payload.get("next_actions", [])
+    action_list = actions if isinstance(actions, list) else []
+    lines = [
+        "# AGILAB agent next actions",
+        "",
+        f"- run_id: {run_map.get('run_id', '')}",
+        f"- agent: {run_map.get('agent', '')}",
+        f"- status: {run_map.get('status', '')}",
+        f"- manifest: {run_map.get('manifest', '')}",
+        "",
+        "## Recommended actions",
+        "",
+    ]
+    for item in action_list:
+        if not isinstance(item, dict):
+            continue
+        lines.append(
+            f"- {item.get('priority', 'P?')}: {item.get('action', '')} "
+            f"Reason: {item.get('reason', '')}"
+        )
+    return "\n".join(lines)
+
+
 def _build_handoff_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Render an AGILAB agent-run handoff card.")
     parser.add_argument("manifest_path", help="Agent-run manifest path or run directory.")
     parser.add_argument("--json", action="store_true", help="Print the handoff card as JSON.")
+    return parser
+
+
+def _build_next_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Render AGILAB agent-run next-action guidance.")
+    parser.add_argument("manifest_path", help="Agent-run manifest path or run directory.")
+    parser.add_argument("--json", action="store_true", help="Print next-action guidance as JSON.")
     return parser
 
 
@@ -1306,6 +1441,17 @@ def _main_handoff(argv: Sequence[str]) -> int:
         print(json.dumps(payload, indent=2, sort_keys=True))
     else:
         print(render_handoff_markdown(payload))
+    return 0
+
+
+def _main_next(argv: Sequence[str]) -> int:
+    parser = _build_next_parser()
+    args = parser.parse_args(list(argv))
+    payload = agent_next_actions_payload(Path(args.manifest_path).expanduser())
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(render_next_actions_markdown(payload))
     return 0
 
 
@@ -1363,6 +1509,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         return _main_list(raw_argv[1:])
     if raw_argv[:1] == ["handoff"]:
         return _main_handoff(raw_argv[1:])
+    if raw_argv[:1] in (["next"], ["next-actions"], ["next_actions"]):
+        return _main_next(raw_argv[1:])
 
     config = parse_args(raw_argv)
     if config.print_only:

--- a/src/agilab/agent_run.py
+++ b/src/agilab/agent_run.py
@@ -19,7 +19,12 @@ from uuid import uuid4
 
 from agilab.agent_config import load_agent_config, resolve_agent_provider
 from agilab.agent_tool_safety import evaluate_tool_permission, normalize_permission_level
-from agilab.agent_trace import AgentTraceStore, load_trace_events, trace_artifact_payload
+from agilab.agent_trace import (
+    AgentTraceStore,
+    load_trace_events,
+    trace_artifact_payload,
+    validate_event_sequence,
+)
 from agilab.secret_uri import redact_text
 
 
@@ -1733,6 +1738,99 @@ def render_compare_markdown(payload: dict[str, object]) -> str:
     return "\n".join(lines)
 
 
+def validate_agent_run(manifest_or_path: dict[str, object] | Path | str) -> dict[str, object]:
+    """Validate one agent-run manifest enough for safe read-side reuse."""
+
+    if isinstance(manifest_or_path, dict):
+        manifest = manifest_or_path
+    else:
+        manifest = load_agent_run_manifest(manifest_or_path)
+    summary = summarize_agent_run(manifest)
+    issues: list[dict[str, str]] = []
+    warnings: list[dict[str, str]] = []
+
+    def fail(code: str, message: str) -> None:
+        issues.append({"code": code, "message": message})
+
+    def warn(code: str, message: str) -> None:
+        warnings.append({"code": code, "message": message})
+
+    if manifest.get("kind") != TRACE_KIND:
+        fail("kind", f"unsupported manifest kind: {manifest.get('kind')!r}")
+    if summary.status not in {"planned", "pass", "fail", "timeout", "denied"}:
+        fail("status", f"unsupported status: {summary.status!r}")
+    if summary.manifest_path and not summary.manifest_path.exists():
+        fail("manifest_path", f"manifest artifact path is missing: {summary.manifest_path}")
+    if summary.status != "planned":
+        if not summary.stdout_path:
+            fail("stdout_path", "stdout artifact path is missing from manifest")
+        elif not summary.stdout_path.exists():
+            fail("stdout_exists", f"stdout artifact does not exist: {summary.stdout_path}")
+        if not summary.stderr_path:
+            fail("stderr_path", "stderr artifact path is missing from manifest")
+        elif not summary.stderr_path.exists():
+            fail("stderr_exists", f"stderr artifact does not exist: {summary.stderr_path}")
+
+    command = manifest.get("command", {})
+    command_map = command if isinstance(command, dict) else {}
+    if command_map.get("argv_redacted") is False:
+        warn("argv_redaction", "command arguments are stored in full; confirm they contain no prompt secrets")
+    if not command_map.get("argv_sha256"):
+        fail("argv_sha256", "command argv hash is missing")
+
+    if summary.trace_events_path:
+        if summary.trace_events_path.exists():
+            trace_events = load_trace_events(summary.trace_events_path.parent)
+            for issue in validate_event_sequence(trace_events):
+                fail("trace_sequence", issue)
+        else:
+            fail("trace_events_exists", f"trace events file does not exist: {summary.trace_events_path}")
+    else:
+        warn("trace_events_path", "trace events path is missing from manifest")
+
+    return {
+        "schema": "agilab.agent_run_validation.v1",
+        "run": _summary_payload(summary),
+        "ok": not issues,
+        "issue_count": len(issues),
+        "warning_count": len(warnings),
+        "issues": issues,
+        "warnings": warnings,
+        "artifact_policy": "Validation inspects manifest metadata and artifact presence; stdout/stderr contents are not embedded.",
+    }
+
+
+def render_validation_markdown(payload: dict[str, object]) -> str:
+    """Render agent-run validation as compact Markdown."""
+
+    run = payload.get("run", {})
+    run_map = run if isinstance(run, dict) else {}
+    issues = payload.get("issues", [])
+    warnings = payload.get("warnings", [])
+    issue_list = issues if isinstance(issues, list) else []
+    warning_list = warnings if isinstance(warnings, list) else []
+    lines = [
+        "# AGILAB agent-run validation",
+        "",
+        f"- run_id: {run_map.get('run_id', '')}",
+        f"- status: {run_map.get('status', '')}",
+        f"- ok: {payload.get('ok', False)}",
+        f"- issue_count: {payload.get('issue_count', 0)}",
+        f"- warning_count: {payload.get('warning_count', 0)}",
+    ]
+    if issue_list:
+        lines.extend(["", "## Issues", ""])
+        for issue in issue_list:
+            if isinstance(issue, dict):
+                lines.append(f"- {issue.get('code', '')}: {issue.get('message', '')}")
+    if warning_list:
+        lines.extend(["", "## Warnings", ""])
+        for warning in warning_list:
+            if isinstance(warning, dict):
+                lines.append(f"- {warning.get('code', '')}: {warning.get('message', '')}")
+    return "\n".join(lines)
+
+
 def _build_handoff_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Render an AGILAB agent-run handoff card.")
     parser.add_argument("manifest_path", help="Agent-run manifest path or run directory.")
@@ -1784,6 +1882,13 @@ def _build_compare_parser() -> argparse.ArgumentParser:
     parser.add_argument("left_manifest", help="Left agent-run manifest path or run directory.")
     parser.add_argument("right_manifest", help="Right agent-run manifest path or run directory.")
     parser.add_argument("--json", action="store_true", help="Print the comparison as JSON.")
+    return parser
+
+
+def _build_validate_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Validate one AGILAB agent-run manifest.")
+    parser.add_argument("manifest_path", help="Agent-run manifest path or run directory.")
+    parser.add_argument("--json", action="store_true", help="Print validation as JSON.")
     return parser
 
 
@@ -1859,6 +1964,17 @@ def _main_compare(argv: Sequence[str]) -> int:
     return 0
 
 
+def _main_validate(argv: Sequence[str]) -> int:
+    parser = _build_validate_parser()
+    args = parser.parse_args(list(argv))
+    payload = validate_agent_run(Path(args.manifest_path).expanduser())
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(render_validation_markdown(payload))
+    return 0 if payload["ok"] else 1
+
+
 def _render_summary_table(summaries: Sequence[AgentRunSummary]) -> str:
     if not summaries:
         return "No AGILAB agent runs found."
@@ -1921,6 +2037,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         return _main_lineage(raw_argv[1:])
     if raw_argv[:1] == ["compare"]:
         return _main_compare(raw_argv[1:])
+    if raw_argv[:1] in (["validate"], ["check"], ["audit"]):
+        return _main_validate(raw_argv[1:])
 
     config = parse_args(raw_argv)
     if config.print_only:

--- a/src/agilab/agent_run.py
+++ b/src/agilab/agent_run.py
@@ -1419,6 +1419,108 @@ def render_next_actions_markdown(payload: dict[str, object]) -> str:
     return "\n".join(lines)
 
 
+def agent_context_payload(
+    root: Path | str | None = None,
+    *,
+    agent: str | None = None,
+    status: str | None = None,
+    tags: Sequence[str] = (),
+    metadata: Mapping[str, str] | None = None,
+    protocol_adapters: Sequence[str] = (),
+    capabilities: Sequence[str] = (),
+    limit: int = 20,
+) -> dict[str, object]:
+    """Build a safe context pack from matching agent-run evidence."""
+
+    summaries = list_agent_runs(
+        root,
+        agent=agent,
+        status=status,
+        tags=tags,
+        metadata=metadata,
+        protocol_adapters=protocol_adapters,
+        capabilities=capabilities,
+        limit=limit,
+    )
+    status_counts: dict[str, int] = {}
+    for summary in summaries:
+        key = summary.status or "unknown"
+        status_counts[key] = status_counts.get(key, 0) + 1
+    latest_handoff: dict[str, object] | None = None
+    latest_next_actions: dict[str, object] | None = None
+    if summaries and str(summaries[0].manifest_path):
+        try:
+            latest_handoff = agent_handoff_payload(summaries[0].manifest_path)
+            latest_next_actions = agent_next_actions_payload(summaries[0].manifest_path)
+        except (OSError, json.JSONDecodeError, ValueError):
+            latest_handoff = None
+            latest_next_actions = None
+    return {
+        "schema": "agilab.agent_context.v1",
+        "query": {
+            "root": str(Path(root).expanduser()) if root is not None else "~/log/agents",
+            "agent": agent,
+            "status": status,
+            "tags": list(_normalize_tags(tags)),
+            "metadata": dict(metadata or {}),
+            "protocol_adapters": list(_normalize_slug_values(protocol_adapters)),
+            "capabilities": list(_normalize_slug_values(capabilities)),
+            "limit": limit,
+        },
+        "match_count": len(summaries),
+        "status_counts": status_counts,
+        "runs": [_summary_payload(summary) for summary in summaries],
+        "latest": {
+            "handoff": latest_handoff,
+            "next_actions": latest_next_actions,
+        },
+        "artifact_policy": "Manifest paths and counts only; stdout/stderr contents are not embedded.",
+    }
+
+
+def render_context_markdown(payload: dict[str, object]) -> str:
+    """Render an agent context pack as compact Markdown."""
+
+    runs = payload.get("runs", [])
+    run_list = runs if isinstance(runs, list) else []
+    status_counts = payload.get("status_counts", {})
+    status_map = status_counts if isinstance(status_counts, dict) else {}
+    latest = payload.get("latest", {})
+    latest_map = latest if isinstance(latest, dict) else {}
+    latest_next = latest_map.get("next_actions", {})
+    latest_next_map = latest_next if isinstance(latest_next, dict) else {}
+    actions = latest_next_map.get("next_actions", [])
+    action_list = actions if isinstance(actions, list) else []
+    lines = [
+        "# AGILAB agent context pack",
+        "",
+        f"- match_count: {payload.get('match_count', 0)}",
+        f"- status_counts: {json.dumps(status_map, sort_keys=True)}",
+        "",
+        "## Matching runs",
+        "",
+    ]
+    if not run_list:
+        lines.append("- No matching agent runs found.")
+    for item in run_list:
+        if not isinstance(item, dict):
+            continue
+        lines.append(
+            f"- {item.get('status', '-')}: {item.get('agent', '-')} "
+            f"{item.get('run_id', '-')} - {item.get('label', '')}"
+        )
+    if action_list:
+        lines.extend(["", "## Latest run next actions", ""])
+        for item in action_list:
+            if not isinstance(item, dict):
+                continue
+            lines.append(
+                f"- {item.get('priority', 'P?')}: {item.get('action', '')} "
+                f"Reason: {item.get('reason', '')}"
+            )
+    return "\n".join(lines)
+
+
 def _build_handoff_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Render an AGILAB agent-run handoff card.")
     parser.add_argument("manifest_path", help="Agent-run manifest path or run directory.")
@@ -1430,6 +1532,30 @@ def _build_next_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Render AGILAB agent-run next-action guidance.")
     parser.add_argument("manifest_path", help="Agent-run manifest path or run directory.")
     parser.add_argument("--json", action="store_true", help="Print next-action guidance as JSON.")
+    return parser
+
+
+def _build_context_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Render an AGILAB agent-run context pack.")
+    parser.add_argument("--root", default="", help="Root directory to scan. Defaults to ~/log/agents.")
+    parser.add_argument("--agent", default="", help="Only include runs for this agent.")
+    parser.add_argument("--status", default="", choices=["", "planned", "pass", "fail", "timeout", "denied"], help="Only include runs with this status.")
+    parser.add_argument("--tag", action="append", default=[], help="Only include runs containing this tag. May be repeated.")
+    parser.add_argument("--metadata", action="append", default=[], help="Only include runs with this metadata KEY=VALUE. May be repeated.")
+    parser.add_argument(
+        "--protocol-adapter",
+        action="append",
+        default=[],
+        help="Only include runs containing this protocol adapter label. May be repeated.",
+    )
+    parser.add_argument(
+        "--capability",
+        action="append",
+        default=[],
+        help="Only include runs containing this capability label. May be repeated.",
+    )
+    parser.add_argument("--limit", type=int, default=20, help="Maximum number of runs to include.")
+    parser.add_argument("--json", action="store_true", help="Print the context pack as JSON.")
     return parser
 
 
@@ -1452,6 +1578,28 @@ def _main_next(argv: Sequence[str]) -> int:
         print(json.dumps(payload, indent=2, sort_keys=True))
     else:
         print(render_next_actions_markdown(payload))
+    return 0
+
+
+def _main_context(argv: Sequence[str]) -> int:
+    parser = _build_context_parser()
+    args = parser.parse_args(list(argv))
+    if args.limit < 0:
+        parser.error("--limit must be >= 0")
+    payload = agent_context_payload(
+        Path(args.root).expanduser() if args.root else None,
+        agent=args.agent or None,
+        status=args.status or None,
+        tags=args.tag,
+        metadata=_parse_metadata(args.metadata),
+        protocol_adapters=args.protocol_adapter,
+        capabilities=args.capability,
+        limit=args.limit,
+    )
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(render_context_markdown(payload))
     return 0
 
 
@@ -1511,6 +1659,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         return _main_handoff(raw_argv[1:])
     if raw_argv[:1] in (["next"], ["next-actions"], ["next_actions"]):
         return _main_next(raw_argv[1:])
+    if raw_argv[:1] == ["context"]:
+        return _main_context(raw_argv[1:])
 
     config = parse_args(raw_argv)
     if config.print_only:

--- a/src/agilab_mcp/manifest_tools.py
+++ b/src/agilab_mcp/manifest_tools.py
@@ -69,6 +69,10 @@ def list_agent_runs(
     *,
     agent: str = "",
     status: str = "",
+    tag: str = "",
+    metadata: Mapping[str, str] | None = None,
+    protocol_adapter: str = "",
+    capability: str = "",
     limit: int = 20,
 ) -> dict[str, Any]:
     if limit < 0:
@@ -82,6 +86,10 @@ def list_agent_runs(
         root,
         agent=agent or None,
         status=status or None,
+        tags=(tag,) if tag else (),
+        metadata=metadata,
+        protocol_adapters=(protocol_adapter,) if protocol_adapter else (),
+        capabilities=(capability,) if capability else (),
         limit=limit,
     )
     return {
@@ -89,6 +97,10 @@ def list_agent_runs(
         "log_root": str(root) if root is not None else "~/log/agents",
         "agent": agent or None,
         "status": status or None,
+        "tag": tag or None,
+        "metadata": dict(metadata or {}),
+        "protocol_adapter": protocol_adapter or None,
+        "capability": capability or None,
         "runs": [_agent_run_summary_payload(summary) for summary in summaries],
     }
 

--- a/src/agilab_mcp/manifest_tools.py
+++ b/src/agilab_mcp/manifest_tools.py
@@ -136,6 +136,15 @@ def agent_handoff(manifest_path: str | Path) -> dict[str, Any]:
     }
 
 
+def agent_next_actions(manifest_path: str | Path) -> dict[str, Any]:
+    path = Path(manifest_path).expanduser().resolve(strict=False)
+    return {
+        "schema": "agilab.mcp.agent_next_actions.v1",
+        "manifest_path": str(path),
+        "next_actions": agent_run.agent_next_actions_payload(path),
+    }
+
+
 def read_manifest(manifest_path: str | Path) -> dict[str, Any]:
     path = Path(manifest_path).expanduser().resolve(strict=False)
     payload = json.loads(path.read_text(encoding="utf-8"))

--- a/src/agilab_mcp/manifest_tools.py
+++ b/src/agilab_mcp/manifest_tools.py
@@ -127,6 +127,15 @@ def summarize_agent_run(manifest_path: str | Path) -> dict[str, Any]:
     }
 
 
+def agent_handoff(manifest_path: str | Path) -> dict[str, Any]:
+    path = Path(manifest_path).expanduser().resolve(strict=False)
+    return {
+        "schema": "agilab.mcp.agent_handoff.v1",
+        "manifest_path": str(path),
+        "handoff": agent_run.agent_handoff_payload(path),
+    }
+
+
 def read_manifest(manifest_path: str | Path) -> dict[str, Any]:
     path = Path(manifest_path).expanduser().resolve(strict=False)
     payload = json.loads(path.read_text(encoding="utf-8"))

--- a/src/agilab_mcp/manifest_tools.py
+++ b/src/agilab_mcp/manifest_tools.py
@@ -179,6 +179,23 @@ def agent_context(
     }
 
 
+def agent_lineage(
+    log_root: str | Path | None = None,
+    *,
+    run_id: str,
+) -> dict[str, Any]:
+    root = (
+        Path(log_root).expanduser().resolve(strict=False)
+        if log_root not in (None, "")
+        else None
+    )
+    return {
+        "schema": "agilab.mcp.agent_lineage.v1",
+        "log_root": str(root) if root is not None else "~/log/agents",
+        "lineage": agent_run.agent_lineage_payload(root, run_id=run_id),
+    }
+
+
 def read_manifest(manifest_path: str | Path) -> dict[str, Any]:
     path = Path(manifest_path).expanduser().resolve(strict=False)
     payload = json.loads(path.read_text(encoding="utf-8"))

--- a/src/agilab_mcp/manifest_tools.py
+++ b/src/agilab_mcp/manifest_tools.py
@@ -209,6 +209,15 @@ def compare_agent_runs(
     }
 
 
+def validate_agent_run(manifest_path: str | Path) -> dict[str, Any]:
+    path = Path(manifest_path).expanduser().resolve(strict=False)
+    return {
+        "schema": "agilab.mcp.validate_agent_run.v1",
+        "manifest_path": str(path),
+        "validation": agent_run.validate_agent_run(path),
+    }
+
+
 def read_manifest(manifest_path: str | Path) -> dict[str, Any]:
     path = Path(manifest_path).expanduser().resolve(strict=False)
     payload = json.loads(path.read_text(encoding="utf-8"))

--- a/src/agilab_mcp/manifest_tools.py
+++ b/src/agilab_mcp/manifest_tools.py
@@ -145,6 +145,40 @@ def agent_next_actions(manifest_path: str | Path) -> dict[str, Any]:
     }
 
 
+def agent_context(
+    log_root: str | Path | None = None,
+    *,
+    agent: str = "",
+    status: str = "",
+    tag: str = "",
+    metadata: Mapping[str, str] | None = None,
+    protocol_adapter: str = "",
+    capability: str = "",
+    limit: int = 20,
+) -> dict[str, Any]:
+    if limit < 0:
+        raise ValueError("limit must be >= 0")
+    root = (
+        Path(log_root).expanduser().resolve(strict=False)
+        if log_root not in (None, "")
+        else None
+    )
+    return {
+        "schema": "agilab.mcp.agent_context.v1",
+        "log_root": str(root) if root is not None else "~/log/agents",
+        "context": agent_run.agent_context_payload(
+            root,
+            agent=agent or None,
+            status=status or None,
+            tags=(tag,) if tag else (),
+            metadata=metadata,
+            protocol_adapters=(protocol_adapter,) if protocol_adapter else (),
+            capabilities=(capability,) if capability else (),
+            limit=limit,
+        ),
+    }
+
+
 def read_manifest(manifest_path: str | Path) -> dict[str, Any]:
     path = Path(manifest_path).expanduser().resolve(strict=False)
     payload = json.loads(path.read_text(encoding="utf-8"))

--- a/src/agilab_mcp/manifest_tools.py
+++ b/src/agilab_mcp/manifest_tools.py
@@ -196,6 +196,19 @@ def agent_lineage(
     }
 
 
+def compare_agent_runs(
+    left_manifest: str | Path, right_manifest: str | Path
+) -> dict[str, Any]:
+    left = Path(left_manifest).expanduser().resolve(strict=False)
+    right = Path(right_manifest).expanduser().resolve(strict=False)
+    return {
+        "schema": "agilab.mcp.compare_agent_runs.v1",
+        "left_manifest": str(left),
+        "right_manifest": str(right),
+        "comparison": agent_run.compare_agent_runs(left, right),
+    }
+
+
 def read_manifest(manifest_path: str | Path) -> dict[str, Any]:
     path = Path(manifest_path).expanduser().resolve(strict=False)
     payload = json.loads(path.read_text(encoding="utf-8"))

--- a/src/agilab_mcp/server.py
+++ b/src/agilab_mcp/server.py
@@ -23,6 +23,7 @@ TOOLS: dict[str, ToolFn] = {
     "agent_context": manifest_tools.agent_context,
     "agent_lineage": manifest_tools.agent_lineage,
     "compare_agent_runs": manifest_tools.compare_agent_runs,
+    "validate_agent_run": manifest_tools.validate_agent_run,
     "read_manifest": manifest_tools.read_manifest,
     "summarize_run": manifest_tools.summarize_run,
     "list_artifacts": manifest_tools.list_artifacts,
@@ -155,6 +156,15 @@ def tool_descriptors() -> list[dict[str, Any]]:
                     "right_manifest": {"type": "string"},
                 },
                 "required": ["left_manifest", "right_manifest"],
+            },
+        },
+        {
+            "name": "validate_agent_run",
+            "description": "Validate an AGILAB agent-run manifest for safe read-side reuse.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {"manifest_path": {"type": "string"}},
+                "required": ["manifest_path"],
             },
         },
         {

--- a/src/agilab_mcp/server.py
+++ b/src/agilab_mcp/server.py
@@ -20,6 +20,7 @@ TOOLS: dict[str, ToolFn] = {
     "summarize_agent_run": manifest_tools.summarize_agent_run,
     "agent_handoff": manifest_tools.agent_handoff,
     "agent_next_actions": manifest_tools.agent_next_actions,
+    "agent_context": manifest_tools.agent_context,
     "read_manifest": manifest_tools.read_manifest,
     "summarize_run": manifest_tools.summarize_run,
     "list_artifacts": manifest_tools.list_artifacts,
@@ -105,6 +106,29 @@ def tool_descriptors() -> list[dict[str, Any]]:
                 "type": "object",
                 "properties": {"manifest_path": {"type": "string"}},
                 "required": ["manifest_path"],
+            },
+        },
+        {
+            "name": "agent_context",
+            "description": "Build a safe AGILAB agent context pack from matching agent-run evidence.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "log_root": {"type": "string"},
+                    "agent": {"type": "string"},
+                    "status": {
+                        "type": "string",
+                        "enum": ["", "planned", "pass", "fail", "timeout", "denied"],
+                    },
+                    "tag": {"type": "string"},
+                    "metadata": {
+                        "type": "object",
+                        "additionalProperties": {"type": "string"},
+                    },
+                    "protocol_adapter": {"type": "string"},
+                    "capability": {"type": "string"},
+                    "limit": {"type": "integer", "minimum": 0},
+                },
             },
         },
         {

--- a/src/agilab_mcp/server.py
+++ b/src/agilab_mcp/server.py
@@ -19,6 +19,7 @@ TOOLS: dict[str, ToolFn] = {
     "read_agent_run": manifest_tools.read_agent_run,
     "summarize_agent_run": manifest_tools.summarize_agent_run,
     "agent_handoff": manifest_tools.agent_handoff,
+    "agent_next_actions": manifest_tools.agent_next_actions,
     "read_manifest": manifest_tools.read_manifest,
     "summarize_run": manifest_tools.summarize_run,
     "list_artifacts": manifest_tools.list_artifacts,
@@ -91,6 +92,15 @@ def tool_descriptors() -> list[dict[str, Any]]:
         {
             "name": "agent_handoff",
             "description": "Render a compact AGILAB agent-run continuation card.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {"manifest_path": {"type": "string"}},
+                "required": ["manifest_path"],
+            },
+        },
+        {
+            "name": "agent_next_actions",
+            "description": "Render deterministic next-action guidance from AGILAB agent-run evidence.",
             "inputSchema": {
                 "type": "object",
                 "properties": {"manifest_path": {"type": "string"}},

--- a/src/agilab_mcp/server.py
+++ b/src/agilab_mcp/server.py
@@ -18,6 +18,7 @@ TOOLS: dict[str, ToolFn] = {
     "list_agent_runs": manifest_tools.list_agent_runs,
     "read_agent_run": manifest_tools.read_agent_run,
     "summarize_agent_run": manifest_tools.summarize_agent_run,
+    "agent_handoff": manifest_tools.agent_handoff,
     "read_manifest": manifest_tools.read_manifest,
     "summarize_run": manifest_tools.summarize_run,
     "list_artifacts": manifest_tools.list_artifacts,
@@ -81,6 +82,15 @@ def tool_descriptors() -> list[dict[str, Any]]:
         {
             "name": "summarize_agent_run",
             "description": "Summarize one AGILAB agent-run manifest.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {"manifest_path": {"type": "string"}},
+                "required": ["manifest_path"],
+            },
+        },
+        {
+            "name": "agent_handoff",
+            "description": "Render a compact AGILAB agent-run continuation card.",
             "inputSchema": {
                 "type": "object",
                 "properties": {"manifest_path": {"type": "string"}},

--- a/src/agilab_mcp/server.py
+++ b/src/agilab_mcp/server.py
@@ -58,6 +58,13 @@ def tool_descriptors() -> list[dict[str, Any]]:
                         "type": "string",
                         "enum": ["", "planned", "pass", "fail", "timeout", "denied"],
                     },
+                    "tag": {"type": "string"},
+                    "metadata": {
+                        "type": "object",
+                        "additionalProperties": {"type": "string"},
+                    },
+                    "protocol_adapter": {"type": "string"},
+                    "capability": {"type": "string"},
                     "limit": {"type": "integer", "minimum": 0},
                 },
             },

--- a/src/agilab_mcp/server.py
+++ b/src/agilab_mcp/server.py
@@ -22,6 +22,7 @@ TOOLS: dict[str, ToolFn] = {
     "agent_next_actions": manifest_tools.agent_next_actions,
     "agent_context": manifest_tools.agent_context,
     "agent_lineage": manifest_tools.agent_lineage,
+    "compare_agent_runs": manifest_tools.compare_agent_runs,
     "read_manifest": manifest_tools.read_manifest,
     "summarize_run": manifest_tools.summarize_run,
     "list_artifacts": manifest_tools.list_artifacts,
@@ -142,6 +143,18 @@ def tool_descriptors() -> list[dict[str, Any]]:
                     "run_id": {"type": "string"},
                 },
                 "required": ["run_id"],
+            },
+        },
+        {
+            "name": "compare_agent_runs",
+            "description": "Compare two AGILAB agent-run manifests without reading output contents.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "left_manifest": {"type": "string"},
+                    "right_manifest": {"type": "string"},
+                },
+                "required": ["left_manifest", "right_manifest"],
             },
         },
         {

--- a/src/agilab_mcp/server.py
+++ b/src/agilab_mcp/server.py
@@ -21,6 +21,7 @@ TOOLS: dict[str, ToolFn] = {
     "agent_handoff": manifest_tools.agent_handoff,
     "agent_next_actions": manifest_tools.agent_next_actions,
     "agent_context": manifest_tools.agent_context,
+    "agent_lineage": manifest_tools.agent_lineage,
     "read_manifest": manifest_tools.read_manifest,
     "summarize_run": manifest_tools.summarize_run,
     "list_artifacts": manifest_tools.list_artifacts,
@@ -129,6 +130,18 @@ def tool_descriptors() -> list[dict[str, Any]]:
                     "capability": {"type": "string"},
                     "limit": {"type": "integer", "minimum": 0},
                 },
+            },
+        },
+        {
+            "name": "agent_lineage",
+            "description": "Build a follow-up lineage graph from AGILAB agent-run evidence.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "log_root": {"type": "string"},
+                    "run_id": {"type": "string"},
+                },
+                "required": ["run_id"],
             },
         },
         {

--- a/test/test_agent_run.py
+++ b/test/test_agent_run.py
@@ -810,6 +810,111 @@ def test_agent_run_context_pack_summarizes_matching_runs(tmp_path: Path, capsys)
     assert "agent-context-fail" in markdown
 
 
+def test_agent_run_lineage_links_followups(tmp_path: Path, capsys) -> None:
+    module = _load_module()
+    run_root = tmp_path / "lineage"
+    root_dir = run_root / "root"
+    child_dir = run_root / "child"
+    grandchild_dir = run_root / "grandchild"
+
+    assert module.main(
+        [
+            "--agent",
+            "codex",
+            "--label",
+            "Root review",
+            "--run-id",
+            "agent-root",
+            "--output-dir",
+            str(root_dir),
+            "--tag",
+            "review",
+            "--permission-level",
+            "standard",
+            "--",
+            sys.executable,
+            "-c",
+            "print('lineage private root output')",
+        ]
+    ) == 0
+    assert module.main(
+        [
+            "--agent",
+            "codex",
+            "--label",
+            "Child fix",
+            "--run-id",
+            "agent-child",
+            "--output-dir",
+            str(child_dir),
+            "--metadata",
+            "followup_of=agent-root",
+            "--permission-level",
+            "standard",
+            "--",
+            sys.executable,
+            "-c",
+            "print('child')",
+        ]
+    ) == 0
+    assert module.main(
+        [
+            "--agent",
+            "codex",
+            "--label",
+            "Grandchild verify",
+            "--run-id",
+            "agent-grandchild",
+            "--output-dir",
+            str(grandchild_dir),
+            "--metadata",
+            "followup_of=agent-child",
+            "--permission-level",
+            "standard",
+            "--",
+            sys.executable,
+            "-c",
+            "print('grandchild')",
+        ]
+    ) == 0
+    capsys.readouterr()
+
+    root_payload = module.agent_lineage_payload(run_root, run_id="agent-root")
+    assert root_payload["schema"] == "agilab.agent_lineage.v1"
+    assert root_payload["found"] is True
+    assert [item["run_id"] for item in root_payload["descendants"]] == [
+        "agent-child",
+        "agent-grandchild",
+    ]
+    assert [item["run_id"] for item in root_payload["chain"]] == [
+        "agent-root",
+        "agent-child",
+        "agent-grandchild",
+    ]
+    assert {"from": "agent-root", "to": "agent-child"} in root_payload["edges"]
+    assert "lineage private root output" not in json.dumps(root_payload)
+
+    grandchild_payload = module.agent_lineage_payload(run_root, run_id="agent-grandchild")
+    assert [item["run_id"] for item in grandchild_payload["ancestors"]] == [
+        "agent-root",
+        "agent-child",
+    ]
+    assert [item["run_id"] for item in grandchild_payload["chain"]] == [
+        "agent-root",
+        "agent-child",
+        "agent-grandchild",
+    ]
+
+    assert module.main(["lineage", "agent-grandchild", "--root", str(run_root), "--json"]) == 0
+    cli_payload = json.loads(capsys.readouterr().out)
+    assert cli_payload["target"]["run_id"] == "agent-grandchild"
+
+    assert module.main(["lineage", "agent-root", "--root", str(run_root)]) == 0
+    markdown = capsys.readouterr().out
+    assert "# AGILAB agent lineage" in markdown
+    assert "agent-root -> agent-child" in markdown
+
+
 def test_agent_run_timeout_records_timeout_status(tmp_path: Path) -> None:
     module = _load_module()
     config = module.AgentRunConfig(

--- a/test/test_agent_run.py
+++ b/test/test_agent_run.py
@@ -995,6 +995,50 @@ def test_agent_run_compare_highlights_followup_changes(tmp_path: Path, capsys) -
     assert "status_changed: True" in markdown
 
 
+def test_agent_run_validate_checks_artifact_presence_and_trace(tmp_path: Path, capsys) -> None:
+    module = _load_module()
+
+    assert module.main(
+        [
+            "--agent",
+            "codex",
+            "--label",
+            "Validation smoke",
+            "--run-id",
+            "agent-validate",
+            "--output-dir",
+            str(tmp_path),
+            "--permission-level",
+            "standard",
+            "--",
+            sys.executable,
+            "-c",
+            "print('validation private output')",
+        ]
+    ) == 0
+    capsys.readouterr()
+
+    payload = module.validate_agent_run(tmp_path)
+    assert payload["schema"] == "agilab.agent_run_validation.v1"
+    assert payload["ok"] is True
+    assert payload["issue_count"] == 0
+    assert payload["run"]["run_id"] == "agent-validate"
+    assert "validation private output" not in json.dumps(payload)
+
+    assert module.main(["validate", str(tmp_path), "--json"]) == 0
+    cli_payload = json.loads(capsys.readouterr().out)
+    assert cli_payload["ok"] is True
+
+    (tmp_path / module.STDOUT_FILENAME).unlink()
+    broken = module.validate_agent_run(tmp_path)
+    assert broken["ok"] is False
+    assert broken["issues"][0]["code"] == "stdout_exists"
+    assert module.main(["validate", str(tmp_path)]) == 1
+    markdown = capsys.readouterr().out
+    assert "# AGILAB agent-run validation" in markdown
+    assert "stdout artifact does not exist" in markdown
+
+
 def test_agent_run_timeout_records_timeout_status(tmp_path: Path) -> None:
     module = _load_module()
     config = module.AgentRunConfig(

--- a/test/test_agent_run.py
+++ b/test/test_agent_run.py
@@ -915,6 +915,86 @@ def test_agent_run_lineage_links_followups(tmp_path: Path, capsys) -> None:
     assert "agent-root -> agent-child" in markdown
 
 
+def test_agent_run_compare_highlights_followup_changes(tmp_path: Path, capsys) -> None:
+    module = _load_module()
+    left_dir = tmp_path / "left"
+    right_dir = tmp_path / "right"
+
+    assert module.main(
+        [
+            "--agent",
+            "codex",
+            "--label",
+            "Failed review",
+            "--run-id",
+            "agent-compare-fail",
+            "--output-dir",
+            str(left_dir),
+            "--tag",
+            "review",
+            "--metadata",
+            "branch=main",
+            "--allow-failure",
+            "--permission-level",
+            "standard",
+            "--",
+            sys.executable,
+            "-c",
+            "print('private failed output'); raise SystemExit(5)",
+        ]
+    ) == 0
+    assert module.main(
+        [
+            "--agent",
+            "codex",
+            "--label",
+            "Fixed review",
+            "--run-id",
+            "agent-compare-pass",
+            "--output-dir",
+            str(right_dir),
+            "--tag",
+            "review",
+            "--metadata",
+            "branch=main",
+            "--metadata",
+            "followup_of=agent-compare-fail",
+            "--protocol-adapter",
+            "mcp",
+            "--capability",
+            "evidence-review",
+            "--permission-level",
+            "standard",
+            "--",
+            sys.executable,
+            "-c",
+            "print('private fixed output')",
+        ]
+    ) == 0
+    capsys.readouterr()
+
+    payload = module.compare_agent_runs(left_dir, right_dir)
+    assert payload["schema"] == "agilab.agent_compare.v1"
+    assert payload["left"]["run_id"] == "agent-compare-fail"
+    assert payload["right"]["run_id"] == "agent-compare-pass"
+    assert payload["status_changed"] is True
+    assert payload["returncode_changed"] is True
+    assert payload["metadata"]["added"] == {"followup_of": "agent-compare-fail"}
+    assert payload["protocol_adapters"]["added"] == ["mcp"]
+    assert payload["capabilities"]["added"] == ["evidence-review"]
+    assert "private failed output" not in json.dumps(payload)
+    assert "private fixed output" not in json.dumps(payload)
+
+    assert module.main(["compare", str(left_dir), str(right_dir), "--json"]) == 0
+    cli_payload = json.loads(capsys.readouterr().out)
+    assert cli_payload["right"]["run_id"] == "agent-compare-pass"
+
+    assert module.main(["compare", str(left_dir), str(right_dir)]) == 0
+    markdown = capsys.readouterr().out
+    assert "# AGILAB agent-run comparison" in markdown
+    assert "status_changed: True" in markdown
+
+
 def test_agent_run_timeout_records_timeout_status(tmp_path: Path) -> None:
     module = _load_module()
     config = module.AgentRunConfig(

--- a/test/test_agent_run.py
+++ b/test/test_agent_run.py
@@ -468,6 +468,10 @@ def test_agent_run_read_side_helpers_and_list_command(tmp_path: Path, capsys) ->
             "review",
             "--metadata",
             "branch=main",
+            "--protocol-adapter",
+            "mcp",
+            "--capability",
+            "evidence review",
             "--permission-level",
             "standard",
             "--",
@@ -513,8 +517,36 @@ def test_agent_run_read_side_helpers_and_list_command(tmp_path: Path, capsys) ->
 
     assert [path.parent.name for path in module.find_agent_run_manifests(run_root, status="fail")] == ["aider-run"]
     assert [item.run_id for item in module.list_agent_runs(run_root, agent="codex")] == ["agent-codex"]
+    assert [
+        item.run_id
+        for item in module.list_agent_runs(
+            run_root,
+            tags=("review",),
+            metadata={"branch": "main"},
+            protocol_adapters=("MCP",),
+            capabilities=("evidence review",),
+        )
+    ] == ["agent-codex"]
+    assert module.list_agent_runs(run_root, metadata={"branch": "other"}) == []
 
-    assert module.main(["list", "--root", str(run_root), "--agent", "codex", "--json"]) == 0
+    assert module.main(
+        [
+            "list",
+            "--root",
+            str(run_root),
+            "--agent",
+            "codex",
+            "--tag",
+            "review",
+            "--metadata",
+            "branch=main",
+            "--protocol-adapter",
+            "mcp",
+            "--capability",
+            "evidence-review",
+            "--json",
+        ]
+    ) == 0
     listed = json.loads(capsys.readouterr().out)
     assert [item["run_id"] for item in listed] == ["agent-codex"]
     assert listed[0]["metadata"] == {"branch": "main"}

--- a/test/test_agent_run.py
+++ b/test/test_agent_run.py
@@ -634,6 +634,74 @@ def test_agent_run_handoff_card_does_not_embed_output(tmp_path: Path, capsys) ->
     assert "private output" not in markdown
 
 
+def test_agent_run_next_actions_are_status_aware(tmp_path: Path, capsys) -> None:
+    module = _load_module()
+    fail_dir = tmp_path / "fail"
+    denied_dir = tmp_path / "denied"
+
+    assert module.main(
+        [
+            "--agent",
+            "codex",
+            "--label",
+            "Failing smoke",
+            "--run-id",
+            "agent-fail-next",
+            "--output-dir",
+            str(fail_dir),
+            "--tag",
+            "debug",
+            "--metadata",
+            "branch=main",
+            "--allow-failure",
+            "--permission-level",
+            "standard",
+            "--",
+            sys.executable,
+            "-c",
+            "raise SystemExit(7)",
+        ]
+    ) == 0
+    assert module.main(
+        [
+            "--agent",
+            "codex",
+            "--label",
+            "Denied smoke",
+            "--run-id",
+            "agent-denied-next",
+            "--output-dir",
+            str(denied_dir),
+            "--",
+            sys.executable,
+            "-c",
+            "print('should not run')",
+        ]
+    ) == 126
+    capsys.readouterr()
+
+    fail_payload = module.agent_next_actions_payload(fail_dir)
+    assert fail_payload["schema"] == "agilab.agent_next_actions.v1"
+    assert fail_payload["run"]["status"] == "fail"
+    assert fail_payload["followup_context"]["metadata"]["followup_of"] == "agent-fail-next"
+    assert fail_payload["next_actions"][0]["priority"] == "P0"
+    assert "stderr" in fail_payload["next_actions"][0]["action"]
+
+    denied_payload = module.agent_next_actions_payload(denied_dir)
+    assert denied_payload["run"]["status"] == "denied"
+    assert denied_payload["permission"]["allowed"] is False
+    assert "permission" in denied_payload["next_actions"][0]["action"]
+
+    assert module.main(["next", str(fail_dir), "--json"]) == 0
+    cli_payload = json.loads(capsys.readouterr().out)
+    assert cli_payload["run"]["run_id"] == "agent-fail-next"
+
+    assert module.main(["next-actions", str(denied_dir)]) == 0
+    markdown = capsys.readouterr().out
+    assert "# AGILAB agent next actions" in markdown
+    assert "agent-denied-next" in markdown
+
+
 def test_agent_run_timeout_records_timeout_status(tmp_path: Path) -> None:
     module = _load_module()
     config = module.AgentRunConfig(

--- a/test/test_agent_run.py
+++ b/test/test_agent_run.py
@@ -581,6 +581,59 @@ def test_agent_run_failure_returns_command_status_and_manifest(tmp_path: Path, c
     assert (tmp_path / "stderr.txt").read_text(encoding="utf-8").strip() == "bad"
 
 
+def test_agent_run_handoff_card_does_not_embed_output(tmp_path: Path, capsys) -> None:
+    module = _load_module()
+
+    assert module.main(
+        [
+            "--agent",
+            "codex",
+            "--label",
+            "Handoff smoke",
+            "--run-id",
+            "agent-handoff",
+            "--output-dir",
+            str(tmp_path),
+            "--tag",
+            "review",
+            "--metadata",
+            "branch=main",
+            "--protocol-adapter",
+            "mcp",
+            "--capability",
+            "evidence-review",
+            "--permission-level",
+            "standard",
+            "--",
+            sys.executable,
+            "-c",
+            "print('private output should stay in stdout artifact')",
+        ]
+    ) == 0
+    capsys.readouterr()
+
+    payload = module.agent_handoff_payload(tmp_path)
+    assert payload["schema"] == "agilab.agent_handoff.v1"
+    assert payload["run"]["run_id"] == "agent-handoff"
+    assert payload["run"]["tags"] == ["review"]
+    assert payload["protocols"]["adapters"] == ["mcp"]
+    assert payload["protocols"]["capabilities"] == ["evidence-review"]
+    assert payload["trace"]["event_count"] == 6
+    assert "private output" not in json.dumps(payload)
+    assert "Continue from AGILAB agent-run evidence" in payload["handoff"]["continue_prompt"]
+
+    assert module.main(["handoff", str(tmp_path), "--json"]) == 0
+    cli_payload = json.loads(capsys.readouterr().out)
+    assert cli_payload["run"]["run_id"] == "agent-handoff"
+    assert "private output" not in json.dumps(cli_payload)
+
+    assert module.main(["handoff", str(tmp_path)]) == 0
+    markdown = capsys.readouterr().out
+    assert "# AGILAB agent handoff" in markdown
+    assert "agent-handoff" in markdown
+    assert "private output" not in markdown
+
+
 def test_agent_run_timeout_records_timeout_status(tmp_path: Path) -> None:
     module = _load_module()
     config = module.AgentRunConfig(

--- a/test/test_agent_run.py
+++ b/test/test_agent_run.py
@@ -702,6 +702,114 @@ def test_agent_run_next_actions_are_status_aware(tmp_path: Path, capsys) -> None
     assert "agent-denied-next" in markdown
 
 
+def test_agent_run_context_pack_summarizes_matching_runs(tmp_path: Path, capsys) -> None:
+    module = _load_module()
+    run_root = tmp_path / "runs"
+    first_dir = run_root / "first"
+    second_dir = run_root / "second"
+
+    assert module.main(
+        [
+            "--agent",
+            "codex",
+            "--label",
+            "First pass",
+            "--run-id",
+            "agent-context-pass",
+            "--output-dir",
+            str(first_dir),
+            "--tag",
+            "review",
+            "--metadata",
+            "branch=main",
+            "--protocol-adapter",
+            "mcp",
+            "--capability",
+            "evidence-review",
+            "--permission-level",
+            "standard",
+            "--",
+            sys.executable,
+            "-c",
+            "print('context private output')",
+        ]
+    ) == 0
+    assert module.main(
+        [
+            "--agent",
+            "codex",
+            "--label",
+            "Second fail",
+            "--run-id",
+            "agent-context-fail",
+            "--output-dir",
+            str(second_dir),
+            "--tag",
+            "review",
+            "--metadata",
+            "branch=main",
+            "--protocol-adapter",
+            "mcp",
+            "--capability",
+            "evidence-review",
+            "--allow-failure",
+            "--permission-level",
+            "standard",
+            "--",
+            sys.executable,
+            "-c",
+            "raise SystemExit(3)",
+        ]
+    ) == 0
+    capsys.readouterr()
+
+    payload = module.agent_context_payload(
+        run_root,
+        agent="codex",
+        tags=("review",),
+        metadata={"branch": "main"},
+        protocol_adapters=("mcp",),
+        capabilities=("evidence-review",),
+    )
+    assert payload["schema"] == "agilab.agent_context.v1"
+    assert payload["match_count"] == 2
+    assert payload["status_counts"] == {"fail": 1, "pass": 1}
+    assert [item["run_id"] for item in payload["runs"]] == [
+        "agent-context-fail",
+        "agent-context-pass",
+    ]
+    assert payload["latest"]["handoff"]["run"]["run_id"] == "agent-context-fail"
+    assert payload["latest"]["next_actions"]["run"]["status"] == "fail"
+    assert "context private output" not in json.dumps(payload)
+
+    assert module.main(
+        [
+            "context",
+            "--root",
+            str(run_root),
+            "--agent",
+            "codex",
+            "--tag",
+            "review",
+            "--metadata",
+            "branch=main",
+            "--protocol-adapter",
+            "mcp",
+            "--capability",
+            "evidence-review",
+            "--json",
+        ]
+    ) == 0
+    cli_payload = json.loads(capsys.readouterr().out)
+    assert cli_payload["match_count"] == 2
+    assert "context private output" not in json.dumps(cli_payload)
+
+    assert module.main(["context", "--root", str(run_root)]) == 0
+    markdown = capsys.readouterr().out
+    assert "# AGILAB agent context pack" in markdown
+    assert "agent-context-fail" in markdown
+
+
 def test_agent_run_timeout_records_timeout_status(tmp_path: Path) -> None:
     module = _load_module()
     config = module.AgentRunConfig(

--- a/test/test_audience_bridges.py
+++ b/test/test_audience_bridges.py
@@ -644,6 +644,9 @@ def test_mcp_tools_and_jsonrpc(tmp_path: Path) -> None:
     agent_comparison = manifest_tools.compare_agent_runs(agent_dir, agent_dir)
     assert agent_comparison["comparison"]["status_changed"] is False
     assert agent_comparison["comparison"]["left"]["run_id"] == "agent-codex"
+    agent_validation = manifest_tools.validate_agent_run(agent_dir)
+    assert agent_validation["validation"]["ok"] is True
+    assert "agent ok" not in json.dumps(agent_validation)
     assert manifest_tools.summarize_run(manifest_path)["summary"]["status"] == "pass"
     assert (
         manifest_tools.list_artifacts(manifest_path)["artifacts"][0]["exists"] is True
@@ -787,6 +790,22 @@ def test_mcp_tools_and_jsonrpc(tmp_path: Path) -> None:
     assert (
         "agilab.agent_compare.v1"
         in compare_agent_call_response["result"]["content"][0]["text"]
+    )
+    validate_agent_call_response = mcp_server.handle_jsonrpc(
+        {
+            "jsonrpc": "2.0",
+            "id": 9,
+            "method": "tools/call",
+            "params": {
+                "name": "validate_agent_run",
+                "arguments": {"manifest_path": str(agent_dir)},
+            },
+        }
+    )
+    assert validate_agent_call_response
+    assert (
+        "agilab.agent_run_validation.v1"
+        in validate_agent_call_response["result"]["content"][0]["text"]
     )
     assert mcp_server.server_manifest()["policy"]["read_only"] is True
 

--- a/test/test_audience_bridges.py
+++ b/test/test_audience_bridges.py
@@ -623,6 +623,10 @@ def test_mcp_tools_and_jsonrpc(tmp_path: Path) -> None:
     handoff_payload = manifest_tools.agent_handoff(agent_dir)
     assert handoff_payload["handoff"]["run"]["run_id"] == "agent-codex"
     assert "agent ok" not in json.dumps(handoff_payload)
+    next_payload = manifest_tools.agent_next_actions(agent_dir)
+    assert next_payload["next_actions"]["run"]["run_id"] == "agent-codex"
+    assert next_payload["next_actions"]["next_actions"][0]["priority"] == "P1"
+    assert "agent ok" not in json.dumps(next_payload)
     assert manifest_tools.summarize_run(manifest_path)["summary"]["status"] == "pass"
     assert (
         manifest_tools.list_artifacts(manifest_path)["artifacts"][0]["exists"] is True
@@ -692,6 +696,22 @@ def test_mcp_tools_and_jsonrpc(tmp_path: Path) -> None:
     assert (
         "Continue from AGILAB agent-run evidence"
         in handoff_call_response["result"]["content"][0]["text"]
+    )
+    next_call_response = mcp_server.handle_jsonrpc(
+        {
+            "jsonrpc": "2.0",
+            "id": 5,
+            "method": "tools/call",
+            "params": {
+                "name": "agent_next_actions",
+                "arguments": {"manifest_path": str(agent_dir)},
+            },
+        }
+    )
+    assert next_call_response
+    assert (
+        "agilab.agent_next_actions.v1"
+        in next_call_response["result"]["content"][0]["text"]
     )
     assert mcp_server.server_manifest()["policy"]["read_only"] is True
 

--- a/test/test_audience_bridges.py
+++ b/test/test_audience_bridges.py
@@ -620,6 +620,9 @@ def test_mcp_tools_and_jsonrpc(tmp_path: Path) -> None:
     read_agent_payload = manifest_tools.read_agent_run(agent_dir)
     assert read_agent_payload["manifest"]["kind"] == agent_run.TRACE_KIND
     assert "agent ok" not in json.dumps(read_agent_payload)
+    handoff_payload = manifest_tools.agent_handoff(agent_dir)
+    assert handoff_payload["handoff"]["run"]["run_id"] == "agent-codex"
+    assert "agent ok" not in json.dumps(handoff_payload)
     assert manifest_tools.summarize_run(manifest_path)["summary"]["status"] == "pass"
     assert (
         manifest_tools.list_artifacts(manifest_path)["artifacts"][0]["exists"] is True
@@ -673,6 +676,22 @@ def test_mcp_tools_and_jsonrpc(tmp_path: Path) -> None:
     assert (
         "agent-codex"
         in agent_call_response["result"]["content"][0]["text"]
+    )
+    handoff_call_response = mcp_server.handle_jsonrpc(
+        {
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "tools/call",
+            "params": {
+                "name": "agent_handoff",
+                "arguments": {"manifest_path": str(agent_dir)},
+            },
+        }
+    )
+    assert handoff_call_response
+    assert (
+        "Continue from AGILAB agent-run evidence"
+        in handoff_call_response["result"]["content"][0]["text"]
     )
     assert mcp_server.server_manifest()["policy"]["read_only"] is True
 

--- a/test/test_audience_bridges.py
+++ b/test/test_audience_bridges.py
@@ -638,6 +638,9 @@ def test_mcp_tools_and_jsonrpc(tmp_path: Path) -> None:
     assert context_payload["context"]["match_count"] == 1
     assert context_payload["context"]["latest"]["handoff"]["run"]["run_id"] == "agent-codex"
     assert "agent ok" not in json.dumps(context_payload)
+    lineage_payload = manifest_tools.agent_lineage(agent_root, run_id="agent-codex")
+    assert lineage_payload["lineage"]["found"] is True
+    assert lineage_payload["lineage"]["target"]["run_id"] == "agent-codex"
     assert manifest_tools.summarize_run(manifest_path)["summary"]["status"] == "pass"
     assert (
         manifest_tools.list_artifacts(manifest_path)["artifacts"][0]["exists"] is True
@@ -743,6 +746,25 @@ def test_mcp_tools_and_jsonrpc(tmp_path: Path) -> None:
     assert (
         "agilab.agent_context.v1"
         in context_call_response["result"]["content"][0]["text"]
+    )
+    lineage_call_response = mcp_server.handle_jsonrpc(
+        {
+            "jsonrpc": "2.0",
+            "id": 7,
+            "method": "tools/call",
+            "params": {
+                "name": "agent_lineage",
+                "arguments": {
+                    "log_root": str(agent_root),
+                    "run_id": "agent-codex",
+                },
+            },
+        }
+    )
+    assert lineage_call_response
+    assert (
+        "agilab.agent_lineage.v1"
+        in lineage_call_response["result"]["content"][0]["text"]
     )
     assert mcp_server.server_manifest()["policy"]["read_only"] is True
 

--- a/test/test_audience_bridges.py
+++ b/test/test_audience_bridges.py
@@ -627,6 +627,17 @@ def test_mcp_tools_and_jsonrpc(tmp_path: Path) -> None:
     assert next_payload["next_actions"]["run"]["run_id"] == "agent-codex"
     assert next_payload["next_actions"]["next_actions"][0]["priority"] == "P1"
     assert "agent ok" not in json.dumps(next_payload)
+    context_payload = manifest_tools.agent_context(
+        agent_root,
+        agent="codex",
+        tag="review",
+        metadata={"branch": "main"},
+        protocol_adapter="mcp",
+        capability="evidence-review",
+    )
+    assert context_payload["context"]["match_count"] == 1
+    assert context_payload["context"]["latest"]["handoff"]["run"]["run_id"] == "agent-codex"
+    assert "agent ok" not in json.dumps(context_payload)
     assert manifest_tools.summarize_run(manifest_path)["summary"]["status"] == "pass"
     assert (
         manifest_tools.list_artifacts(manifest_path)["artifacts"][0]["exists"] is True
@@ -712,6 +723,26 @@ def test_mcp_tools_and_jsonrpc(tmp_path: Path) -> None:
     assert (
         "agilab.agent_next_actions.v1"
         in next_call_response["result"]["content"][0]["text"]
+    )
+    context_call_response = mcp_server.handle_jsonrpc(
+        {
+            "jsonrpc": "2.0",
+            "id": 6,
+            "method": "tools/call",
+            "params": {
+                "name": "agent_context",
+                "arguments": {
+                    "log_root": str(agent_root),
+                    "agent": "codex",
+                    "tag": "review",
+                },
+            },
+        }
+    )
+    assert context_call_response
+    assert (
+        "agilab.agent_context.v1"
+        in context_call_response["result"]["content"][0]["text"]
     )
     assert mcp_server.server_manifest()["policy"]["read_only"] is True
 

--- a/test/test_audience_bridges.py
+++ b/test/test_audience_bridges.py
@@ -593,6 +593,8 @@ def test_mcp_tools_and_jsonrpc(tmp_path: Path) -> None:
         permission_level="standard",
         tags=("review",),
         metadata={"branch": "main"},
+        protocol_adapters=("mcp",),
+        capabilities=("evidence-review",),
     )
 
     assert (
@@ -600,7 +602,14 @@ def test_mcp_tools_and_jsonrpc(tmp_path: Path) -> None:
         == "alpha_project"
     )
     assert manifest_tools.list_runs(tmp_path)["runs"]
-    agent_runs = manifest_tools.list_agent_runs(agent_root, agent="codex")["runs"]
+    agent_runs = manifest_tools.list_agent_runs(
+        agent_root,
+        agent="codex",
+        tag="review",
+        metadata={"branch": "main"},
+        protocol_adapter="mcp",
+        capability="evidence-review",
+    )["runs"]
     assert agent_runs[0]["run_id"] == "agent-codex"
     assert agent_runs[0]["tags"] == ["review"]
     assert agent_runs[0]["metadata"] == {"branch": "main"}
@@ -651,7 +660,12 @@ def test_mcp_tools_and_jsonrpc(tmp_path: Path) -> None:
             "method": "tools/call",
             "params": {
                 "name": "list_agent_runs",
-                "arguments": {"log_root": str(agent_root), "agent": "codex"},
+                "arguments": {
+                    "log_root": str(agent_root),
+                    "agent": "codex",
+                    "tag": "review",
+                    "metadata": {"branch": "main"},
+                },
             },
         }
     )

--- a/test/test_audience_bridges.py
+++ b/test/test_audience_bridges.py
@@ -641,6 +641,9 @@ def test_mcp_tools_and_jsonrpc(tmp_path: Path) -> None:
     lineage_payload = manifest_tools.agent_lineage(agent_root, run_id="agent-codex")
     assert lineage_payload["lineage"]["found"] is True
     assert lineage_payload["lineage"]["target"]["run_id"] == "agent-codex"
+    agent_comparison = manifest_tools.compare_agent_runs(agent_dir, agent_dir)
+    assert agent_comparison["comparison"]["status_changed"] is False
+    assert agent_comparison["comparison"]["left"]["run_id"] == "agent-codex"
     assert manifest_tools.summarize_run(manifest_path)["summary"]["status"] == "pass"
     assert (
         manifest_tools.list_artifacts(manifest_path)["artifacts"][0]["exists"] is True
@@ -765,6 +768,25 @@ def test_mcp_tools_and_jsonrpc(tmp_path: Path) -> None:
     assert (
         "agilab.agent_lineage.v1"
         in lineage_call_response["result"]["content"][0]["text"]
+    )
+    compare_agent_call_response = mcp_server.handle_jsonrpc(
+        {
+            "jsonrpc": "2.0",
+            "id": 8,
+            "method": "tools/call",
+            "params": {
+                "name": "compare_agent_runs",
+                "arguments": {
+                    "left_manifest": str(agent_dir),
+                    "right_manifest": str(agent_dir),
+                },
+            },
+        }
+    )
+    assert compare_agent_call_response
+    assert (
+        "agilab.agent_compare.v1"
+        in compare_agent_call_response["result"]["content"][0]["text"]
     )
     assert mcp_server.server_manifest()["policy"]["read_only"] is True
 

--- a/tools/agent_workflows.md
+++ b/tools/agent_workflows.md
@@ -94,6 +94,7 @@ agilab agent-run next ~/log/agents/codex/<run-id> --json
 agilab agent-run context --tag review --metadata branch=main --limit 5 --json
 agilab agent-run lineage <run-id> --json
 agilab agent-run compare ~/log/agents/codex/<failed-run> ~/log/agents/codex/<follow-up-run> --json
+agilab agent-run validate ~/log/agents/codex/<run-id> --json
 ```
 
 The read-only MCP bridge exposes the same agent-run evidence to external
@@ -108,6 +109,7 @@ agilab-mcp call-tool agent_next_actions --arguments '{"manifest_path":"~/log/age
 agilab-mcp call-tool agent_context --arguments '{"agent":"codex","tag":"review","metadata":{"branch":"main"},"limit":5}' --json
 agilab-mcp call-tool agent_lineage --arguments '{"run_id":"<run-id>"}' --json
 agilab-mcp call-tool compare_agent_runs --arguments '{"left_manifest":"~/log/agents/codex/<failed-run>","right_manifest":"~/log/agents/codex/<follow-up-run>"}' --json
+agilab-mcp call-tool validate_agent_run --arguments '{"manifest_path":"~/log/agents/codex/<run-id>"}' --json
 ```
 
 or from Python:

--- a/tools/agent_workflows.md
+++ b/tools/agent_workflows.md
@@ -88,6 +88,7 @@ Read previous run evidence from the CLI:
 
 ```bash
 agilab agent-run list --agent codex --json
+agilab agent-run list --tag review --metadata branch=main --protocol-adapter mcp --capability evidence-review --json
 ```
 
 The read-only MCP bridge exposes the same agent-run evidence to external
@@ -95,7 +96,7 @@ coding agents without enabling shell execution:
 
 ```bash
 agilab-mcp list-tools --json
-agilab-mcp call-tool list_agent_runs --arguments '{"agent":"codex","limit":5}' --json
+agilab-mcp call-tool list_agent_runs --arguments '{"agent":"codex","tag":"review","metadata":{"branch":"main"},"limit":5}' --json
 agilab-mcp call-tool summarize_agent_run --arguments '{"manifest_path":"~/log/agents/codex/<run-id>/agent_run_manifest.json"}' --json
 ```
 

--- a/tools/agent_workflows.md
+++ b/tools/agent_workflows.md
@@ -90,6 +90,7 @@ Read previous run evidence from the CLI:
 agilab agent-run list --agent codex --json
 agilab agent-run list --tag review --metadata branch=main --protocol-adapter mcp --capability evidence-review --json
 agilab agent-run handoff ~/log/agents/codex/<run-id>
+agilab agent-run next ~/log/agents/codex/<run-id> --json
 ```
 
 The read-only MCP bridge exposes the same agent-run evidence to external
@@ -100,6 +101,7 @@ agilab-mcp list-tools --json
 agilab-mcp call-tool list_agent_runs --arguments '{"agent":"codex","tag":"review","metadata":{"branch":"main"},"limit":5}' --json
 agilab-mcp call-tool summarize_agent_run --arguments '{"manifest_path":"~/log/agents/codex/<run-id>/agent_run_manifest.json"}' --json
 agilab-mcp call-tool agent_handoff --arguments '{"manifest_path":"~/log/agents/codex/<run-id>"}' --json
+agilab-mcp call-tool agent_next_actions --arguments '{"manifest_path":"~/log/agents/codex/<run-id>"}' --json
 ```
 
 or from Python:

--- a/tools/agent_workflows.md
+++ b/tools/agent_workflows.md
@@ -89,6 +89,7 @@ Read previous run evidence from the CLI:
 ```bash
 agilab agent-run list --agent codex --json
 agilab agent-run list --tag review --metadata branch=main --protocol-adapter mcp --capability evidence-review --json
+agilab agent-run handoff ~/log/agents/codex/<run-id>
 ```
 
 The read-only MCP bridge exposes the same agent-run evidence to external
@@ -98,6 +99,7 @@ coding agents without enabling shell execution:
 agilab-mcp list-tools --json
 agilab-mcp call-tool list_agent_runs --arguments '{"agent":"codex","tag":"review","metadata":{"branch":"main"},"limit":5}' --json
 agilab-mcp call-tool summarize_agent_run --arguments '{"manifest_path":"~/log/agents/codex/<run-id>/agent_run_manifest.json"}' --json
+agilab-mcp call-tool agent_handoff --arguments '{"manifest_path":"~/log/agents/codex/<run-id>"}' --json
 ```
 
 or from Python:

--- a/tools/agent_workflows.md
+++ b/tools/agent_workflows.md
@@ -91,6 +91,7 @@ agilab agent-run list --agent codex --json
 agilab agent-run list --tag review --metadata branch=main --protocol-adapter mcp --capability evidence-review --json
 agilab agent-run handoff ~/log/agents/codex/<run-id>
 agilab agent-run next ~/log/agents/codex/<run-id> --json
+agilab agent-run context --tag review --metadata branch=main --limit 5 --json
 ```
 
 The read-only MCP bridge exposes the same agent-run evidence to external
@@ -102,6 +103,7 @@ agilab-mcp call-tool list_agent_runs --arguments '{"agent":"codex","tag":"review
 agilab-mcp call-tool summarize_agent_run --arguments '{"manifest_path":"~/log/agents/codex/<run-id>/agent_run_manifest.json"}' --json
 agilab-mcp call-tool agent_handoff --arguments '{"manifest_path":"~/log/agents/codex/<run-id>"}' --json
 agilab-mcp call-tool agent_next_actions --arguments '{"manifest_path":"~/log/agents/codex/<run-id>"}' --json
+agilab-mcp call-tool agent_context --arguments '{"agent":"codex","tag":"review","metadata":{"branch":"main"},"limit":5}' --json
 ```
 
 or from Python:

--- a/tools/agent_workflows.md
+++ b/tools/agent_workflows.md
@@ -93,6 +93,7 @@ agilab agent-run handoff ~/log/agents/codex/<run-id>
 agilab agent-run next ~/log/agents/codex/<run-id> --json
 agilab agent-run context --tag review --metadata branch=main --limit 5 --json
 agilab agent-run lineage <run-id> --json
+agilab agent-run compare ~/log/agents/codex/<failed-run> ~/log/agents/codex/<follow-up-run> --json
 ```
 
 The read-only MCP bridge exposes the same agent-run evidence to external
@@ -106,6 +107,7 @@ agilab-mcp call-tool agent_handoff --arguments '{"manifest_path":"~/log/agents/c
 agilab-mcp call-tool agent_next_actions --arguments '{"manifest_path":"~/log/agents/codex/<run-id>"}' --json
 agilab-mcp call-tool agent_context --arguments '{"agent":"codex","tag":"review","metadata":{"branch":"main"},"limit":5}' --json
 agilab-mcp call-tool agent_lineage --arguments '{"run_id":"<run-id>"}' --json
+agilab-mcp call-tool compare_agent_runs --arguments '{"left_manifest":"~/log/agents/codex/<failed-run>","right_manifest":"~/log/agents/codex/<follow-up-run>"}' --json
 ```
 
 or from Python:

--- a/tools/agent_workflows.md
+++ b/tools/agent_workflows.md
@@ -92,6 +92,7 @@ agilab agent-run list --tag review --metadata branch=main --protocol-adapter mcp
 agilab agent-run handoff ~/log/agents/codex/<run-id>
 agilab agent-run next ~/log/agents/codex/<run-id> --json
 agilab agent-run context --tag review --metadata branch=main --limit 5 --json
+agilab agent-run lineage <run-id> --json
 ```
 
 The read-only MCP bridge exposes the same agent-run evidence to external
@@ -104,6 +105,7 @@ agilab-mcp call-tool summarize_agent_run --arguments '{"manifest_path":"~/log/ag
 agilab-mcp call-tool agent_handoff --arguments '{"manifest_path":"~/log/agents/codex/<run-id>"}' --json
 agilab-mcp call-tool agent_next_actions --arguments '{"manifest_path":"~/log/agents/codex/<run-id>"}' --json
 agilab-mcp call-tool agent_context --arguments '{"agent":"codex","tag":"review","metadata":{"branch":"main"},"limit":5}' --json
+agilab-mcp call-tool agent_lineage --arguments '{"run_id":"<run-id>"}' --json
 ```
 
 or from Python:


### PR DESCRIPTION
## Summary\n- add tag, metadata, protocol-adapter, and capability filters to agent-run evidence listing\n- expose the same filters through read-only MCP list_agent_runs\n- add agent-run handoff cards for session continuation without embedding stdout/stderr contents\n- add deterministic next-action cards for pass/fail/timeout/denied agent runs\n- add agent context packs that summarize matching runs, status counts, latest handoff, and latest next actions\n- add agent-run lineage graphs using metadata.followup_of links for multi-step workflows\n- add agent-run comparison cards for failed/follow-up evidence without embedding stdout/stderr contents\n- add agent-run validation cards for manifest structure, trace sequence, and artifact presence\n- expose handoff, next-action, context-pack, lineage, comparison, and validation cards through CLI and read-only MCP\n- align roadmap, audience bridge docs, and agent workflow docs with the shipped agent evidence bridge\n\n## Validation\n- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_agent_run.py::test_agent_run_read_side_helpers_and_list_command test/test_agent_run.py::test_agent_run_handoff_card_does_not_embed_output test/test_agent_run.py::test_agent_run_next_actions_are_status_aware test/test_agent_run.py::test_agent_run_context_pack_summarizes_matching_runs test/test_agent_run.py::test_agent_run_lineage_links_followups test/test_agent_run.py::test_agent_run_compare_highlights_followup_changes test/test_agent_run.py::test_agent_run_validate_checks_artifact_presence_and_trace test/test_audience_bridges.py::test_mcp_tools_and_jsonrpc\n- uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --apply --delete\n- uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp