### PR TITLE
Clarify packaged demo catalog

### DIFF
--- a/src/agilab/examples/README.md
+++ b/src/agilab/examples/README.md
@@ -13,19 +13,19 @@ the command shape stable.
 
 | Order | Example | App | Main lesson |
 |---:|---|---|---|
-| 1 | `flight_telemetry` | `flight_telemetry_project` | First proof: install one app, run one file, inspect map-ready output. |
-| 2 | `mycode` | `mycode_project` | Smallest worker template and execution smoke. |
-| 3 | `weather_forecast` | `weather_forecast_project` | Turn a notebook-style forecast into a reproducible app run. |
-| 4 | `notebook_migrations/skforecast_meteo_fr` | `weather_forecast_project` | Packaged migration source: notebooks, artifacts, lab stages, and pipeline view. |
-| 5 | `notebook_to_dask` | notebook import -> Dask pipeline | Read-only migration preview: code cells, artifact contracts, and a Dask pipeline view. |
-| 6 | `parallel_stage` | function + split rule + reducer | Read-only parallelization preview: fewer files than cores, chunk partitions, worker capping, and reducer-first planning. |
-| 7 | `excel_workbook_proof` | spreadsheet bridge preview | Read-only Excel-shaped proof: workbook, Power Query-friendly CSVs, and evidence hashes. |
-| 8 | `sqlite_connector_proof` | database connector preview | Read-only SQLite proof: schema, parameterized query, CSV result, and evidence hashes. |
-| 9 | `voila_notebook_proof` | notebook dashboard bridge preview | Read-only notebook-dashboard proof: Voila-shaped notebook, widget-to-args hints, app-view plan, and evidence hashes. |
-| 10 | `sklearn_pipeline` | `sklearn_pipeline_project` | Classic ML app proof: deterministic dataset, fitted pipeline, predictions, model artifact, metrics, and hash manifest. |
-| 11 | `mission_decision` | `mission_decision_project` | Deterministic mission-data decision run with richer artifacts. |
-| 12 | `global_dag_project` | `flight_telemetry_project` -> `weather_forecast_project` | Built-in app-owned global DAG contract: app nodes, artifact handoff, and runner-state preview. |
-| 13 | `inter_project_dag` | `flight_telemetry_project` -> `weather_forecast_project` | Standalone compatibility preview for the same cross-project DAG concept. |
+| 1 | `notebook_quickstart` | `agi-core` notebook route | Notebook-first runtime proof for local, Colab, and Kaggle users. |
+| 2 | `flight_telemetry` | `flight_telemetry_project` | First proof: install one app, run one file, inspect map-ready output. |
+| 3 | `mycode` | `mycode_project` | Smallest worker template and execution smoke. |
+| 4 | `weather_forecast` | `weather_forecast_project` | Turn a notebook-style forecast into a reproducible app run. |
+| 5 | `notebook_migrations/skforecast_meteo_fr` | `weather_forecast_project` | Packaged migration source: notebooks, artifacts, lab stages, and pipeline view. |
+| 6 | `notebook_to_dask` | notebook import -> Dask pipeline | Read-only migration preview: code cells, artifact contracts, and a Dask pipeline view. |
+| 7 | `parallel_stage` | function + split rule + reducer | Read-only parallelization preview: fewer files than cores, chunk partitions, worker capping, and reducer-first planning. |
+| 8 | `excel_workbook_proof` | spreadsheet bridge preview | Read-only Excel-shaped proof: workbook, Power Query-friendly CSVs, and evidence hashes. |
+| 9 | `sqlite_connector_proof` | database connector preview | Read-only SQLite proof: schema, parameterized query, CSV result, and evidence hashes. |
+| 10 | `voila_notebook_proof` | notebook dashboard bridge preview | Read-only notebook-dashboard proof: Voila-shaped notebook, widget-to-args hints, app-view plan, and evidence hashes. |
+| 11 | `sklearn_pipeline` | `sklearn_pipeline_project` | Classic ML app proof: deterministic dataset, fitted pipeline, predictions, model artifact, metrics, and hash manifest. |
+| 12 | `mission_decision` | `mission_decision_project` | Deterministic mission-data decision run with richer artifacts. |
+| 13 | `inter_project_dag` | `flight_telemetry_project` -> `weather_forecast_project` | Standalone compatibility preview for the app-owned global DAG contract. |
 | 14 | `service_mode` | `mycode_project` | Read-only service lifecycle preview: start, status, health, stop. |
 | 15 | `mlflow_auto_tracking` | any pipeline app | Optional tracking preview: local evidence first, MLflow as the memory backend. |
 | 16 | `resilience_failure_injection` | UAV relay scenario contract | Read-only resilience preview: inject a relay failure, compare fixed/replanned/search/policy responses. |
@@ -39,9 +39,11 @@ app execution from read-only contract previews.
 
 | Class | Examples | What actually runs | Primary output |
 |---|---|---|---|
+| Notebook route assets | `notebook_quickstart` | Jupyter notebooks for local, Colab, Kaggle, source, and PyPI `agi-core` first runs. | Notebook-visible `AgiEnv` / `RunRequest` proof, without installing a full AGILAB app helper. |
 | Installed `AGI_*.py` helpers | `flight_telemetry`, `mycode`, `weather_forecast`, `sklearn_pipeline`, `mission_decision` | Real `AGI.install` / `AGI.run` calls from `~/log/execute/<app>/` after the app installer seeds the scripts. | App artifacts in AGILAB share/export paths plus execution logs. |
 | Source/package read-only previews | `notebook_to_dask`, `parallel_stage`, `excel_workbook_proof`, `sqlite_connector_proof`, `voila_notebook_proof`, `inter_project_dag`, `service_mode`, `mlflow_auto_tracking`, `resilience_failure_injection`, `train_then_serve`, `native_rust_worker` | Deterministic Python preview scripts. They write local evidence and do not launch long-lived workers or hidden multi-app runs. | Preview JSON, CSV, workbook, SQLite database, notebook, dashboard-plan, or generated skeleton artifacts under `~/log/execute/<example>/` or the configured output path. |
 | Notebook migration assets | `notebook_migrations/skforecast_meteo_fr` | Packaged notebooks, artifacts, `lab_stages.toml`, and pipeline view used as migration source material. | Files to inspect or import; no service or cluster run is started by reading them. |
+| Built-in app-owned demo templates | `global_dag_project` | Select the built-in project in WORKFLOW or let `inter_project_dag` read its DAG template. | App-owned contract files under `src/agilab/apps/builtin/global_dag_project/`; no `src/agilab/examples/global_dag_project` directory is expected. |
 
 Source-checkout commands use `uv --preview-features extra-build-dependencies run python ...`
 so dependencies resolve through the checkout environment. Commands under
@@ -72,6 +74,8 @@ From an installed package, locate one with
 
 - `AGI_install_*.py` prepares the app environment and worker runtime.
 - `AGI_run_*.py` builds a `RunRequest` and calls `AGI.run`.
+- `notebook_quickstart` contains the notebook-first route for users who want
+  the smaller `agi-core` surface before the web UI or installed app helpers.
 - `global_dag_project` owns the packaged global DAG template under
   `src/agilab/apps/builtin/global_dag_project/dag_templates/`.
 - `inter_project_dag/preview_inter_project_dag.py` remains as the standalone
@@ -153,11 +157,13 @@ uv --preview-features extra-build-dependencies run pytest -q test/test_app_insta
 ## When To Use These Scripts
 
 Run `agilab first-proof --json` when you want the shortest packaged product
-proof. Use these scripts when you want to inspect or adapt the generated
-programmatic calls. Select `global_dag_project` in WORKFLOW when you want to
-understand how project-level app runs can be connected by explicit artifact
-contracts, and use `inter_project_dag` only when you need the standalone
-compatibility preview path. Use
+proof. Use `notebook_quickstart` when you want the notebook-first `agi-core`
+route before any UI or app-helper run. Use the installed scripts when you want
+to inspect or adapt the generated programmatic calls. Select
+`global_dag_project` in WORKFLOW when you want to understand how project-level
+app runs can be connected by explicit artifact contracts, and use
+`inter_project_dag` only when you need the standalone compatibility preview
+path. Use
 `notebook_to_dask` when you want to evaluate a notebook migration before
 creating an app or running Dask. Use `sklearn_pipeline` when you want a minimal
 classic ML app proof that writes predictions, metrics, a serialized model, and

--- a/src/agilab/examples/notebook_quickstart/README.md
+++ b/src/agilab/examples/notebook_quickstart/README.md
@@ -1,0 +1,80 @@
+# Notebook Quickstart Examples
+
+## Example Class
+
+**Notebook import asset.** This folder contains notebook-first AGILAB runtime
+routes for local Jupyter, Colab, Kaggle, source-checkout, and PyPI-package
+users. It is not an installed `AGI_*.py` helper and it does not install an
+AGILAB app project by itself.
+
+## Purpose
+
+Shows the smallest notebook-first AGILAB proof:
+
+```text
+notebook -> AgiEnv -> RunRequest -> AGI.run -> run manifest
+```
+
+Use these notebooks when you want to stay in a notebook while still showing the
+same AGILAB concepts that the UI and app helpers use.
+
+## What You Learn
+
+- How to create an `AgiEnv` in a notebook.
+- How to build a `RunRequest` with explicit inputs, outputs, and run mode.
+- How to call `AGI.run(...)` without hiding the flow behind a one-line wrapper.
+- How local, Colab, Kaggle, source-checkout, and PyPI-package variants differ.
+
+## Install
+
+Choose the notebook variant that matches the environment:
+
+- `agi_core_first_run.ipynb` for a local source or installed environment.
+- `agi_core_colab_first_run.ipynb` for Google Colab.
+- `agi_core_kaggle_first_run.ipynb` for Kaggle.
+- `*_source.ipynb` variants when the notebook should point at a source checkout.
+- `*_pypi.ipynb` variants when the notebook should use the published package.
+
+## Run
+
+Open the notebook in the matching environment and run cells from top to bottom.
+The notebooks keep the important AGILAB steps visible: create `app_env`, create
+a `RunRequest`, optionally check worker readiness, then call `AGI.run(...)`.
+
+## Expected Input
+
+The first-run notebooks use deterministic public sample inputs or generate the
+smallest local files needed for the proof. They do not require private data,
+cluster credentials, or a hosted AGILAB UI.
+
+## Expected Output
+
+The notebook run should produce a local run manifest and visible output paths
+under the configured AGILAB log/share location. The exact output depends on the
+selected notebook route, but the proof should always make the run request,
+execution result, and artifact path visible in notebook cells.
+
+## Read The Notebook
+
+Start with `agi_core_first_run.ipynb` for the local path. Look for these cells:
+
+- environment setup and import checks
+- `AgiEnv` creation
+- `RunRequest` creation
+- optional install or worker-readiness check
+- `AGI.run(...)`
+- manifest or log-root inspection
+
+## Change One Thing
+
+After the default notebook runs once, change only the output directory or one
+small request parameter. Rerun the notebook and compare the new manifest path
+with the previous run.
+
+## Troubleshooting
+
+- If the notebook cannot import AGILAB, use the matching source or PyPI variant.
+- If a worker-readiness cell reports a missing environment, run the install cell
+  shown by the notebook before executing `AGI.run(...)`.
+- If a path is confusing, print the log root and share root cells before
+  changing the request.

--- a/test/test_app_installer_packaging.py
+++ b/test/test_app_installer_packaging.py
@@ -69,6 +69,7 @@ EXAMPLE_PREVIEWS = {
 }
 EXAMPLE_NOTEBOOK_ASSETS = {
     "notebook_migrations/skforecast_meteo_fr": ("README.md",),
+    "notebook_quickstart": ("README.md", "agi_core_first_run.ipynb"),
 }
 EXAMPLE_CLASS_LABELS = {
     "Runnable app project",
@@ -971,6 +972,32 @@ def test_packaged_example_catalog_is_documented() -> None:
             "## Troubleshooting",
         ):
             assert heading in readme_text
+
+    for example_name, file_names in EXAMPLE_NOTEBOOK_ASSETS.items():
+        example_dir = EXAMPLES_ROOT / example_name
+        readme = example_dir / "README.md"
+        assert readme.is_file()
+        readme_text = readme.read_text(encoding="utf-8")
+        assert example_name in catalog_text
+        for file_name in file_names:
+            assert (example_dir / file_name).is_file()
+        for heading in (
+            "## Purpose",
+            "## Example Class",
+            "## What You Learn",
+            "## Install",
+            "## Run",
+            "## Expected Input",
+            "## Expected Output",
+            "## Read The Notebook",
+            "## Change One Thing",
+            "## Troubleshooting",
+        ):
+            assert heading in readme_text
+
+    learning_path = catalog_text.split("## Learning Path", 1)[1].split("## Execution Map", 1)[0]
+    assert "`global_dag_project`" not in learning_path
+    assert "Built-in app-owned demo templates" in catalog_text
 
 
 def test_packaged_example_readmes_have_explicit_execution_class() -> None:


### PR DESCRIPTION
## Summary
- add an explicit README/classification for notebook_quickstart packaged notebooks
- clarify that global_dag_project is a built-in app-owned demo template, not a packaged examples folder
- extend the packaging guard so notebook route assets are documented and the learning path does not list app-owned templates as example directories

## Tests
- Not run (not requested).