### PR TITLE
[codex] Improve Streamlit evidence UX

### DIFF
--- a/src/agilab/about_page/onboarding.py
+++ b/src/agilab/about_page/onboarding.py
@@ -36,12 +36,15 @@ FIRST_PROOF_NOTEBOOK_BUTTON = "Create from built-in notebook"
 FIRST_PROOF_NOTEBOOK_HINT = (
     "No file to find or upload: AGILAB opens PROJECT with its bundled notebook already selected."
 )
-FIRST_PROOF_NOTEBOOK_LANE_LABEL = "Notebook import: included sample"
+FIRST_PROOF_NOTEBOOK_LANE_LABEL = "Create from included notebook"
 FIRST_PROOF_NOTEBOOK_PROJECT = "flight_telemetry_from_notebook_project"
 FIRST_PROOF_NOTEBOOK_AFTER_HINT = (
     f"Then click PROJECT `Create`; it builds `{FIRST_PROOF_NOTEBOOK_PROJECT}`."
 )
 FIRST_PROOF_NOTEBOOK_RUN_HINT = "After creation, run ORCHESTRATE `INSTALL` and `EXECUTE`."
+FIRST_PROOF_OWN_NOTEBOOK_HINT = (
+    "For your own notebook: open PROJECT -> Create -> From notebook -> Upload your own notebook."
+)
 FIRST_PROOF_NOTEBOOK_QUERY_PARAMS = {"start": "notebook-import"}
 FIRST_PROOF_NOTEBOOK_SAMPLE_QUERY_KEY = "sample"
 FIRST_PROOF_NOTEBOOK_SAMPLE_QUERY_VALUE = "agilab-first-proof"
@@ -326,6 +329,7 @@ def _first_proof_action_columns_layout(
             notebook_hint,
             FIRST_PROOF_NOTEBOOK_AFTER_HINT,
             FIRST_PROOF_NOTEBOOK_RUN_HINT,
+            FIRST_PROOF_OWN_NOTEBOOK_HINT,
         ]
     )
     spec = [proof_width, _FIRST_PROOF_ACTION_SEPARATOR_WIDTH_PX, notebook_width]
@@ -604,7 +608,8 @@ def _render_first_proof_wizard_actions(
     st.markdown("**First proof: built-in demo**")
     st.caption(
         "Recommended path: run the built-in flight telemetry demo, then inspect the generated "
-        "evidence."
+        "evidence. Notebook-first paths are below: use AGILAB's included notebook first; upload "
+        "your own notebook from PROJECT Create when you are ready."
     )
     proof_actions = [
         {
@@ -626,7 +631,7 @@ def _render_first_proof_wizard_actions(
             )
             st.caption(action["hint"])
 
-    with st.expander("Notebook-first option", expanded=False):
+    with st.expander("Create from included notebook", expanded=False):
         st.caption(FIRST_PROOF_NOTEBOOK_LANE_LABEL)
         _first_proof_link_button(
             FIRST_PROOF_NOTEBOOK_BUTTON,
@@ -637,6 +642,7 @@ def _render_first_proof_wizard_actions(
         st.caption(FIRST_PROOF_NOTEBOOK_HINT)
         st.caption(FIRST_PROOF_NOTEBOOK_AFTER_HINT)
         st.caption(FIRST_PROOF_NOTEBOOK_RUN_HINT)
+        st.caption(FIRST_PROOF_OWN_NOTEBOOK_HINT)
 
     with st.expander("Notebook to validated app: full proof", expanded=False):
         st.caption(

--- a/src/agilab/pages/2_ORCHESTRATE.py
+++ b/src/agilab/pages/2_ORCHESTRATE.py
@@ -134,6 +134,7 @@ import_agilab_symbols(
     {
         "is_dag_worker_base": "is_dag_worker_base",
         "render_page_context": "render_page_context",
+        "render_workflow_timeline": "render_workflow_timeline",
     },
     current_file=__file__,
     fallback_path=Path(__file__).resolve().parents[1] / "workflow_ui.py",
@@ -1648,6 +1649,55 @@ def _render_orchestrate_readiness_panel(
     )
 
 
+def _render_orchestrate_action_rail(
+    env: Any,
+    *,
+    install_status: dict[str, Any],
+    installed: bool,
+    install_block_reason: str,
+) -> None:
+    """Show the concrete ORCHESTRATE path before detailed controls."""
+    run_count, run_caption = _run_history_summary(env)
+    has_run = str(run_count).strip() not in {"", "0"}
+    project_name = str(getattr(env, "app", "") or getattr(env, "target", "") or "").strip()
+    install_exists = bool(
+        install_status.get("manager_exists") or install_status.get("worker_exists")
+    )
+    install_state = "done" if installed else "warning" if install_exists else "waiting"
+    install_detail = (
+        "environment ready"
+        if installed
+        else install_block_reason or "run INSTALL before EXECUTE"
+    )
+    render_workflow_timeline(
+        st,
+        title="Path: Prepare -> Install -> Execute -> Review evidence",
+        expanded=True,
+        items=(
+            {
+                "label": "Prepare",
+                "state": "ready" if project_name else "blocked",
+                "detail": f"`{project_name}` selected" if project_name else "select a project first",
+            },
+            {
+                "label": "Install",
+                "state": install_state,
+                "detail": install_detail,
+            },
+            {
+                "label": "Execute",
+                "state": "ready" if installed else "waiting",
+                "detail": "run the project" if installed else "disabled until INSTALL is ready",
+            },
+            {
+                "label": "Review evidence",
+                "state": "ready" if has_run else "waiting",
+                "detail": run_caption if has_run else "open ANALYSIS after EXECUTE writes outputs",
+            },
+        ),
+    )
+
+
 _ORCHESTRATE_RESOURCE_SUMMARY_LABELS = ("Share", "CPU", "RAM", "GPU", "NPU")
 
 
@@ -2451,6 +2501,12 @@ async def page() -> None:
     install_block_reason = (
         _install_status_warning_message(install_status)
         or _runtime_status_label(install_status)[1]
+    )
+    _render_orchestrate_action_rail(
+        env,
+        install_status=install_status,
+        installed=installed,
+        install_block_reason=install_block_reason,
     )
 
     # Sidebar toggles for each page section

--- a/src/agilab/pages/4_ANALYSIS.py
+++ b/src/agilab/pages/4_ANALYSIS.py
@@ -2228,6 +2228,10 @@ def _render_analysis_workspace_overview(
     )
 
     with st.container(border=True):
+        st.markdown("### Evidence first")
+        st.caption(
+            "Start from discovered project outputs, then choose the page or notebook that best reviews them."
+        )
         cols = st.columns(4)
         with cols[0]:
             suffix = "+" if artifact_summary["truncated"] else ""
@@ -2249,10 +2253,19 @@ def _render_analysis_workspace_overview(
                 notebooks_caption,
             )
 
+        if artifact_summary["examples"]:
+            st.caption(
+                "Discovered evidence: "
+                + ", ".join(str(item) for item in artifact_summary["examples"])
+            )
         if not artifact_summary["exists"]:
-            st.info("Run ORCHESTRATE or WORKFLOW to create analysis outputs.")
+            st.info(
+                "No analysis workspace found. Run ORCHESTRATE -> EXECUTE, then return here to review manifests, tables, figures, logs, and notebooks."
+            )
         elif not artifact_summary["examples"]:
-            st.info("No output files detected yet.")
+            st.info(
+                "No evidence files detected yet. Run ORCHESTRATE -> EXECUTE or WORKFLOW, then use ANALYSIS to inspect the generated outputs."
+            )
 
 
 def _render_analysis_surface_guide(*, expanded: bool = False) -> None:

--- a/src/agilab/workflow_ui.py
+++ b/src/agilab/workflow_ui.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import html
 import json
+import os
 import re
 from datetime import datetime
 from pathlib import Path
@@ -29,6 +31,22 @@ _TEXT_PREVIEW_SUFFIXES = {
     ".yml",
 }
 _IMAGE_PREVIEW_SUFFIXES = {".gif", ".jpeg", ".jpg", ".png", ".webp"}
+_COCKPIT_ARTIFACT_SUFFIXES = {
+    ".csv",
+    ".html",
+    ".ipynb",
+    ".json",
+    ".jsonl",
+    ".log",
+    ".md",
+    ".npz",
+    ".parquet",
+    ".png",
+    ".svg",
+    ".toml",
+    ".txt",
+}
+_COCKPIT_SCAN_LIMIT = 200
 
 
 def _as_text(value: Any) -> str:
@@ -57,6 +75,11 @@ def workflow_state_scope(page_label: str, env: Any | None = None) -> str:
     if target_name and target_name != app_name:
         parts.append(target_name)
     return "::".join(parts)
+
+
+def project_widget_key(page_label: str, env: Any | None, key: Any) -> str:
+    """Return a widget key scoped to one page and one active project."""
+    return f"{workflow_state_scope(page_label, env)}::{_stable_key_part(key)}"
 
 
 def _identity_tokens(value: Any) -> set[str]:
@@ -127,8 +150,254 @@ def restore_project_ui_state(
     return dict(bucket) if isinstance(bucket, dict) else {}
 
 
+def _project_display_name(env: Any | None) -> str:
+    if env is None:
+        return "No project"
+    for attr in ("app", "target", "active_app"):
+        value = _as_text(getattr(env, attr, ""))
+        if value:
+            return Path(value).name
+    return "No project"
+
+
+def _project_path(env: Any | None) -> Path | None:
+    if env is None:
+        return None
+    for attr in ("active_app", "app_path"):
+        path = _path_from(getattr(env, attr, None))
+        if path is not None:
+            return path
+    apps_path = _path_from(getattr(env, "apps_path", None))
+    app_name = _as_text(getattr(env, "app", ""))
+    if apps_path is not None and app_name:
+        return apps_path / app_name
+    return None
+
+
+def _runtime_roots(env: Any | None) -> list[Path]:
+    if env is None:
+        return []
+    roots: list[Path] = []
+    seen: set[str] = set()
+
+    def append(path: Any) -> None:
+        candidate = _path_from(path)
+        if candidate is None:
+            return
+        key = candidate.expanduser().as_posix()
+        if key not in seen:
+            seen.add(key)
+            roots.append(candidate)
+
+    append(getattr(env, "runenv", None))
+    append(getattr(env, "app_data_rel", None))
+    export_root = _path_from(getattr(env, "AGILAB_EXPORT_ABS", None))
+    if export_root is not None:
+        append(export_root)
+        target_name = _as_text(getattr(env, "target", ""))
+        if target_name:
+            append(export_root / target_name)
+    project_root = _project_path(env)
+    if project_root is not None:
+        append(project_root / "notebooks")
+        append(project_root / "artifacts")
+    return roots
+
+
+def _latest_timestamp_label(timestamp: float | None) -> str:
+    if timestamp is None:
+        return "no file timestamp"
+    return datetime.fromtimestamp(timestamp).strftime("%Y-%m-%d %H:%M")
+
+
+def _scan_project_evidence(env: Any | None) -> dict[str, Any]:
+    count = 0
+    latest: float | None = None
+    manifest: Path | None = None
+    examples: list[str] = []
+    truncated = False
+    ignored_dirs = {
+        ".git",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".venv",
+        "__pycache__",
+        "build",
+        "dist",
+        "venv",
+    }
+    for root in _runtime_roots(env):
+        try:
+            if not root.exists():
+                continue
+            if root.is_file():
+                paths = [root]
+            else:
+                paths = []
+                for current_root, dirs, files in os.walk(root):
+                    dirs[:] = sorted(
+                        dirname
+                        for dirname in dirs
+                        if dirname not in ignored_dirs and not dirname.startswith(".")
+                    )
+                    for filename in sorted(files):
+                        paths.append(Path(current_root) / filename)
+                    if count + len(paths) >= _COCKPIT_SCAN_LIMIT:
+                        truncated = True
+                        break
+            for path in paths:
+                suffix = path.suffix.lower()
+                if path.name == "run_manifest.json" and manifest is None:
+                    manifest = path
+                if suffix not in _COCKPIT_ARTIFACT_SUFFIXES and path.name != "run_manifest.json":
+                    continue
+                count += 1
+                if len(examples) < 3:
+                    examples.append(path.name)
+                try:
+                    latest = max(latest or path.stat().st_mtime, path.stat().st_mtime)
+                except OSError:
+                    pass
+                if count >= _COCKPIT_SCAN_LIMIT:
+                    truncated = True
+                    break
+            if count >= _COCKPIT_SCAN_LIMIT:
+                break
+        except OSError:
+            continue
+    return {
+        "count": count,
+        "latest": latest,
+        "manifest": manifest,
+        "examples": examples,
+        "truncated": truncated,
+    }
+
+
+def _project_install_status(env: Any | None) -> tuple[str, str, str]:
+    if env is None:
+        return "Unknown", "environment not loaded", "incomplete"
+    try:
+        from agilab.environment_health import _default_install_status
+
+        status = _default_install_status(env)
+    except Exception:
+        return "Check", "install status unavailable", "incomplete"
+    workerless = bool(status.get("workerless"))
+    manager_ready = bool(status.get("manager_ready"))
+    worker_ready = bool(status.get("worker_ready"))
+    manager_exists = bool(status.get("manager_exists"))
+    worker_exists = bool(status.get("worker_exists"))
+    if manager_ready and (workerless or worker_ready):
+        return "Ready", "manager and worker ready" if not workerless else "manager ready", "ready"
+    if manager_exists or worker_exists:
+        return "Incomplete", "rerun INSTALL before EXECUTE", "incomplete"
+    return "Not installed", "run ORCHESTRATE -> INSTALL", "incomplete"
+
+
+def _run_history(env: Any | None) -> tuple[str, str, str]:
+    if env is None:
+        return "0", "environment not loaded", "incomplete"
+    try:
+        from agilab.environment_health import run_history_summary
+
+        count, caption = run_history_summary(env)
+    except Exception:
+        count, caption = "0", "run log status unavailable"
+    state = "ready" if count not in {"", "0"} else "incomplete"
+    return count, caption, state
+
+
+def _render_cockpit_card(streamlit: Any, *, label: str, value: str, caption: str, state: str) -> None:
+    streamlit.markdown(
+        (
+            f"<div class='agilab-header-card agilab-header-card--{html.escape(state)}'>"
+            f"<div class='agilab-header-label'>{html.escape(label)}</div>"
+            f"<div class='agilab-header-value agilab-header-value--{html.escape(state)}'>{html.escape(value)}</div>"
+            f"<div class='agilab-header-caption'>{html.escape(caption)}</div>"
+            "</div>"
+        ),
+        unsafe_allow_html=True,
+    )
+
+
+def _project_cockpit_cards(page_label: str, env: Any | None) -> list[dict[str, str]]:
+    project_name = _project_display_name(env)
+    project_root = _project_path(env)
+    project_ready = bool(project_root and (project_root.exists() or project_root.is_symlink()))
+    install_value, install_caption, install_state = _project_install_status(env)
+    run_value, run_caption, run_state = _run_history(env)
+    evidence = _scan_project_evidence(env)
+    artifact_count = int(evidence["count"])
+    artifact_suffix = "+" if evidence["truncated"] else ""
+    if evidence["manifest"] is not None:
+        evidence_value = "Manifest"
+        evidence_caption = Path(evidence["manifest"]).name
+        evidence_state = "ready"
+    elif artifact_count:
+        evidence_value = "Outputs"
+        evidence_caption = ", ".join(evidence["examples"]) or "artifact files detected"
+        evidence_state = "ready"
+    else:
+        evidence_value = "No evidence"
+        evidence_caption = "run ORCHESTRATE -> EXECUTE"
+        evidence_state = "incomplete"
+    return [
+        {
+            "label": "Page",
+            "value": _as_text(page_label) or "AGILAB",
+            "caption": "current workspace",
+            "state": "neutral",
+        },
+        {
+            "label": "Project",
+            "value": project_name,
+            "caption": "selected" if project_ready else "select or create a project",
+            "state": "ready" if project_ready else "incomplete",
+        },
+        {
+            "label": "Install",
+            "value": install_value,
+            "caption": install_caption,
+            "state": install_state,
+        },
+        {
+            "label": "Last run",
+            "value": run_value,
+            "caption": run_caption,
+            "state": run_state,
+        },
+        {
+            "label": "Evidence",
+            "value": evidence_value,
+            "caption": evidence_caption,
+            "state": evidence_state,
+        },
+        {
+            "label": "Artifacts",
+            "value": f"{artifact_count}{artifact_suffix}",
+            "caption": _latest_timestamp_label(evidence["latest"]),
+            "state": "ready" if artifact_count else "incomplete",
+        },
+    ]
+
+
 def render_page_context(streamlit: Any, *, page_label: str, env: Any | None = None) -> None:
-    """Compatibility hook; page context is intentionally not rendered."""
+    """Render the compact project cockpit shared by Streamlit pages."""
+    if env is None:
+        return None
+    container_fn = getattr(streamlit, "container", None)
+    context = container_fn(border=True) if callable(container_fn) else streamlit
+    with context:
+        streamlit.markdown("### Project cockpit")
+        cards = _project_cockpit_cards(page_label, env)
+        for start in range(0, len(cards), 3):
+            row = cards[start : start + 3]
+            columns = streamlit.columns(len(row))
+            for column, card in zip(columns, row):
+                with column:
+                    _render_cockpit_card(streamlit, **card)
     return None
 
 

--- a/test/test_about_agilab_helpers.py
+++ b/test/test_about_agilab_helpers.py
@@ -4925,7 +4925,7 @@ def test_render_newcomer_first_proof_places_wizard_before_diagnostics(
         and "Opens ANALYSIS on `view_maps`" in fake_st.events[index][1]
     )
     notebook_option = _event_index(
-        fake_st.events, "expander", "Notebook-first option:False"
+        fake_st.events, "expander", "Create from included notebook:False"
     )
     notebook_start = _event_index(
         fake_st.events, "link_button", "Create from built-in notebook"
@@ -4949,7 +4949,7 @@ def test_render_newcomer_first_proof_places_wizard_before_diagnostics(
     validated_path = _event_index(fake_st.events, "caption", "Validated path:")
 
     assert [body for kind, body in fake_st.events if kind == "expander"] == [
-        "Notebook-first option:False",
+        "Create from included notebook:False",
         "Notebook to validated app: full proof:False",
         "If it fails / proof details:False",
     ]
@@ -4969,9 +4969,9 @@ def test_render_newcomer_first_proof_places_wizard_before_diagnostics(
     second_action_column = _event_index(fake_st.events, "enter_column", "1")
     third_action_column = _event_index(fake_st.events, "enter_column", "2")
     caption_bodies = [body for kind, body in pre_details if kind == "caption"]
-    assert len(caption_bodies) == 11
+    assert len(caption_bodies) == 12
     assert caption_bodies[0] == (
-        "Recommended path: run the built-in flight telemetry demo, then inspect the generated evidence."
+        "Recommended path: run the built-in flight telemetry demo, then inspect the generated evidence. Notebook-first paths are below: use AGILAB's included notebook first; upload your own notebook from PROJECT Create when you are ready."
     )
     assert (
         caption_bodies[1]
@@ -4981,7 +4981,7 @@ def test_render_newcomer_first_proof_places_wizard_before_diagnostics(
     assert (
         caption_bodies[3] == "Opens ANALYSIS on `view_maps` for the generated evidence."
     )
-    assert caption_bodies[4] == "Notebook import: included sample"
+    assert caption_bodies[4] == "Create from included notebook"
     assert caption_bodies[5] == (
         "No file to find or upload: AGILAB opens PROJECT with its bundled notebook already selected."
     )
@@ -4992,12 +4992,15 @@ def test_render_newcomer_first_proof_places_wizard_before_diagnostics(
         caption_bodies[7] == "After creation, run ORCHESTRATE `INSTALL` and `EXECUTE`."
     )
     assert caption_bodies[8] == (
+        "For your own notebook: open PROJECT -> Create -> From notebook -> Upload your own notebook."
+    )
+    assert caption_bodies[9] == (
         "Use this lane when the starting asset is a notebook and the target is a reusable app with a no-lock-in handoff."
     )
-    assert caption_bodies[9].startswith("Adoption gate: Not ready yet.")
-    assert "Run one local proof first" in caption_bodies[9]
-    assert caption_bodies[10].startswith("Handoff bundle:")
-    assert "strict security-check output" in caption_bodies[10]
+    assert caption_bodies[10].startswith("Adoption gate: Not ready yet.")
+    assert "Run one local proof first" in caption_bodies[10]
+    assert caption_bodies[11].startswith("Handoff bundle:")
+    assert "strict security-check output" in caption_bodies[11]
     assert link_types == {
         "1. INSTALL demo": "secondary",
         "2. EXECUTE demo": "secondary",

--- a/test/test_workflow_ui.py
+++ b/test/test_workflow_ui.py
@@ -49,6 +49,9 @@ class _FakeContainer:
     def image(self, body: object, **kwargs):
         self._streamlit.events.append(("image", str(body)))
 
+    def markdown(self, body: object, **kwargs):
+        self._streamlit.events.append(("markdown", str(body)))
+
 
 class _FakeSidebar:
     def __init__(self, streamlit):
@@ -69,9 +72,16 @@ class _FakeStreamlit:
         self.events.append(("expander", f"{title}:{expanded}"))
         return _FakeContainer(self)
 
+    def container(self, **kwargs):
+        self.events.append(("container", str(bool(kwargs.get("border", False)))))
+        return _FakeContainer(self)
+
     def columns(self, specs):
         count = len(specs) if isinstance(specs, (list, tuple)) else int(specs)
         return [_FakeContainer(self) for _ in range(count)]
+
+    def markdown(self, body: object, **kwargs):
+        self.events.append(("markdown", str(body)))
 
     def caption(self, body: object):
         self.events.append(("caption", str(body)))
@@ -116,14 +126,36 @@ def test_fake_streamlit_and_sidebar_helpers_are_exercised() -> None:
     assert graph().number_of_edges() == 1
 
 
-def test_render_page_context_is_silent() -> None:
+def test_render_page_context_renders_project_cockpit(tmp_path) -> None:
     fake_st = _FakeStreamlit()
-    env = SimpleNamespace(app="flight_telemetry_project", target="flight_telemetry_worker", mode="Run now")
+    runenv = tmp_path / "run"
+    runenv.mkdir()
+    (runenv / "run_001.log").write_text("ok\n", encoding="utf-8")
+    (runenv / "run_manifest.json").write_text("{}", encoding="utf-8")
+    env = SimpleNamespace(
+        app="flight_telemetry_project",
+        target="flight_telemetry_worker",
+        active_app=tmp_path,
+        runenv=runenv,
+        app_data_rel=tmp_path / "data",
+    )
 
     workflow_ui.render_page_context(fake_st, page_label="ORCHESTRATE", env=env)
 
-    assert ("sidebar.expander", "Context:False") not in fake_st.events
-    assert fake_st.events == []
+    markdown = "\n".join(body for kind, body in fake_st.events if kind == "markdown")
+    assert "Project cockpit" in markdown
+    assert "flight_telemetry_project" in markdown
+    assert "run_manifest.json" in markdown
+    assert "agilab-header-card" in markdown
+
+
+def test_project_widget_key_is_scoped_by_page_and_project() -> None:
+    env = SimpleNamespace(app="flight_telemetry_project", target="flight_telemetry_worker")
+
+    assert (
+        workflow_ui.project_widget_key("ORCHESTRATE", env, "cluster enabled")
+        == "ORCHESTRATE::flight_telemetry_project::flight_telemetry_worker::cluster_enabled"
+    )
 
 
 def test_is_dag_based_app_uses_env_worker_base_and_identity_fallback() -> None:


### PR DESCRIPTION
## Summary
- Add a shared Streamlit Project cockpit with project, install, run, evidence, and artifact cards.
- Add an ORCHESTRATE action rail for Prepare -> Install -> Execute -> Review evidence.
- Make ANALYSIS start from discovered evidence and clarify empty states.
- Clarify first-proof notebook lanes and own-notebook guidance.

## Validation
- `./dev test test/test_workflow_ui.py::test_render_page_context_renders_project_cockpit test/test_workflow_ui.py::test_project_widget_key_is_scoped_by_page_and_project test/test_about_agilab_helpers.py::test_render_newcomer_first_proof_places_wizard_before_diagnostics`
