### PR TITLE
Harden sklearn pipeline example

### DIFF
--- a/src/agilab/apps/builtin/sklearn_pipeline_project/src/sklearn_pipeline/__init__.py
+++ b/src/agilab/apps/builtin/sklearn_pipeline_project/src/sklearn_pipeline/__init__.py
@@ -9,8 +9,12 @@ from .app_args import (
     SklearnPipelineArgsTD,
     dump_args,
     ensure_defaults,
+    filter_arg_overrides,
     load_args,
     merge_args,
+    safe_reset_path,
+    share_root_from_env,
+    validate_relative_data_out,
 )
 from .core import SCHEMA, build_sklearn_pipeline_artifacts
 from .reduction import SKLEARN_PIPELINE_REDUCE_CONTRACT
@@ -28,6 +32,10 @@ __all__ = [
     "build_sklearn_pipeline_artifacts",
     "dump_args",
     "ensure_defaults",
+    "filter_arg_overrides",
     "load_args",
     "merge_args",
+    "safe_reset_path",
+    "share_root_from_env",
+    "validate_relative_data_out",
 ]

--- a/src/agilab/apps/builtin/sklearn_pipeline_project/src/sklearn_pipeline/app_args.py
+++ b/src/agilab/apps/builtin/sklearn_pipeline_project/src/sklearn_pipeline/app_args.py
@@ -2,12 +2,77 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-from typing import Any, TypedDict
+from collections.abc import Mapping
+from pathlib import Path, PureWindowsPath
+from typing import Any, TypedDict, cast
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from agi_env.app_args import dump_model_to_toml, load_model_from_toml, merge_model_data
+
+
+def validate_relative_data_out(value: str | Path) -> Path:
+    """Return a safe relative evidence path or raise ``ValueError``."""
+
+    raw = str(value).strip()
+    if not raw:
+        raise ValueError("data_out must be a non-empty relative path")
+    if raw.startswith("~"):
+        raise ValueError("data_out must not use a home-directory shortcut")
+
+    windows_path = PureWindowsPath(raw)
+    if windows_path.is_absolute() or windows_path.drive:
+        raise ValueError("data_out must be relative to the AGILAB share")
+
+    candidate = Path(raw)
+    if candidate.is_absolute():
+        raise ValueError("data_out must be relative to the AGILAB share")
+    if candidate == Path(".") or any(part in {"", ".", ".."} for part in candidate.parts):
+        raise ValueError("data_out must not be empty, '.', or contain parent traversal")
+    return candidate
+
+
+def filter_arg_overrides(overrides: Mapping[str, Any]) -> SklearnPipelineArgsTD:
+    """Keep only public sklearn-pipeline args from a generic runtime kwargs mapping."""
+
+    return cast(
+        SklearnPipelineArgsTD,
+        {key: value for key, value in overrides.items() if key in SklearnPipelineArgs.model_fields},
+    )
+
+
+def share_root_from_env(env: object) -> Path | None:
+    """Resolve the active AGILAB share root when the runtime exposes it."""
+
+    resolve_share_path = getattr(env, "resolve_share_path", None)
+    if not callable(resolve_share_path):
+        return None
+    try:
+        return Path(resolve_share_path(Path("."))).expanduser().resolve(strict=False)
+    except (OSError, TypeError, ValueError):
+        return None
+
+
+def safe_reset_path(path: str | Path, *, share_root: str | Path | None, label: str = "path") -> Path:
+    """Resolve and validate a path before destructive reset operations."""
+
+    target = Path(path).expanduser().resolve(strict=False)
+    if target == Path(target.anchor):
+        raise ValueError(f"{label} reset target must not be the filesystem root")
+
+    if share_root is None:
+        if not target.is_absolute():
+            raise ValueError(f"{label} reset target must be absolute when no share root is known")
+        return target
+
+    root = Path(share_root).expanduser().resolve(strict=False)
+    if target == root:
+        raise ValueError(f"{label} reset target must not be the share root")
+    try:
+        target.relative_to(root)
+    except ValueError as exc:
+        raise ValueError(f"{label} reset target must stay under {root}") from exc
+    return target
 
 
 class SklearnPipelineArgs(BaseModel):
@@ -21,6 +86,11 @@ class SklearnPipelineArgs(BaseModel):
     regularization_c: float = Field(default=1.0, gt=0.0, le=100.0)
     seed: int = Field(default=2026, ge=0)
     reset_target: bool = False
+
+    @field_validator("data_out", mode="before")
+    @classmethod
+    def _validate_data_out(cls, value: str | Path) -> Path:
+        return validate_relative_data_out(value)
 
 
 class SklearnPipelineArgsTD(TypedDict, total=False):
@@ -68,6 +138,10 @@ __all__ = [
     "SklearnPipelineArgsTD",
     "dump_args",
     "ensure_defaults",
+    "filter_arg_overrides",
     "load_args",
     "merge_args",
+    "safe_reset_path",
+    "share_root_from_env",
+    "validate_relative_data_out",
 ]

--- a/src/agilab/apps/builtin/sklearn_pipeline_project/src/sklearn_pipeline/core.py
+++ b/src/agilab/apps/builtin/sklearn_pipeline_project/src/sklearn_pipeline/core.py
@@ -160,7 +160,10 @@ def build_sklearn_pipeline_artifacts(
         "promotion_hint": "candidate" if metrics["accuracy"] >= 0.85 and metrics["f1"] >= 0.85 else "review",
     }
     manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    artifacts["manifest"] = _artifact(manifest_path, role="artifact hash manifest", output_dir=output_dir)
+    summary_artifacts = {
+        **artifacts,
+        "manifest": _artifact(manifest_path, role="artifact hash manifest", output_dir=output_dir),
+    }
 
     summary_path = output_dir / "sklearn_pipeline_summary.json"
     summary = {
@@ -168,9 +171,8 @@ def build_sklearn_pipeline_artifacts(
         "output_dir": str(output_dir),
         "metrics": metrics,
         "promotion_hint": manifest["promotion_hint"],
-        "artifacts": artifacts,
+        "artifacts": summary_artifacts,
         "manifest": str(manifest_path),
     }
     summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    summary["artifacts"]["summary"] = _artifact(summary_path, role="worker summary", output_dir=output_dir)
     return summary

--- a/src/agilab/apps/builtin/sklearn_pipeline_project/src/sklearn_pipeline/sklearn_pipeline.py
+++ b/src/agilab/apps/builtin/sklearn_pipeline_project/src/sklearn_pipeline/sklearn_pipeline.py
@@ -16,8 +16,11 @@ from .app_args import (
     SklearnPipelineArgs,
     dump_args,
     ensure_defaults,
+    filter_arg_overrides,
     load_args,
     merge_args,
+    safe_reset_path,
+    share_root_from_env,
 )
 
 logger = logging.getLogger(__name__)
@@ -37,20 +40,23 @@ class SklearnPipeline(BaseWorker):
         self.env = env
         self._ensure_managed_pc_share_dir(env)
         self.verbose = int(kwargs.pop("verbose", getattr(env, "verbose", 0) or 0))
+        arg_overrides = filter_arg_overrides(kwargs)
 
         if args is None:
             try:
-                args = SklearnPipelineArgs(**kwargs)
+                args = SklearnPipelineArgs(**arg_overrides)
             except ValidationError as exc:
                 raise ValueError(f"Invalid SklearnPipeline arguments: {exc}") from exc
+        elif arg_overrides:
+            args = merge_args(args, arg_overrides)
 
         self.args = ensure_defaults(args, env=env)
         self.args = self._apply_managed_pc_paths(self.args)
-        self.args.data_out = env.resolve_share_path(self.args.data_out)
-        self.data_out = self.args.data_out
+        self.data_out = env.resolve_share_path(self.args.data_out)
 
         if self.args.reset_target and self.data_out.exists():
-            shutil.rmtree(self.data_out, ignore_errors=True, onerror=WorkDispatcher._onerror)
+            reset_path = safe_reset_path(self.data_out, share_root=share_root_from_env(env), label="data_out")
+            shutil.rmtree(reset_path, ignore_errors=True, onerror=WorkDispatcher._onerror)
         self.data_out.mkdir(parents=True, exist_ok=True)
         self.analysis_artifact_dir.mkdir(parents=True, exist_ok=True)
 

--- a/src/agilab/apps/builtin/sklearn_pipeline_project/src/sklearn_pipeline_worker/sklearn_pipeline_worker.py
+++ b/src/agilab/apps/builtin/sklearn_pipeline_project/src/sklearn_pipeline_worker/sklearn_pipeline_worker.py
@@ -13,7 +13,12 @@ import pandas as pd
 
 from agi_node.agi_dispatcher import BaseWorker
 from agi_node.pandas_worker import PandasWorker
-from sklearn_pipeline import SklearnPipelineArgs, build_sklearn_pipeline_artifacts
+from sklearn_pipeline import (
+    SklearnPipelineArgs,
+    build_sklearn_pipeline_artifacts,
+    safe_reset_path,
+    share_root_from_env,
+)
 from sklearn_pipeline.reduction import write_reduce_artifact
 
 logger = logging.getLogger(__name__)
@@ -30,6 +35,12 @@ def _artifact_dir(env: object, leaf: str) -> Path:
     if callable(resolve_share_path):
         return Path(resolve_share_path(relative))
     return Path.home() / "export" / relative
+
+
+def _artifact_reset_root(env: object) -> Path:
+    export_root = Path(getattr(env, "AGILAB_EXPORT_ABS", Path.home() / "export"))
+    target = str(getattr(env, "target", "") or "")
+    return export_root / target if target else export_root
 
 
 def _args_with_defaults(value: Any) -> SklearnPipelineArgs:
@@ -68,11 +79,17 @@ class SklearnPipelineWorker(PandasWorker):
         self.args.data_out = data_out
         self.data_out = data_out
         if self.args.reset_target and self.data_out.exists():
-            shutil.rmtree(self.data_out, ignore_errors=True)
+            reset_path = safe_reset_path(self.data_out, share_root=share_root_from_env(self.env), label="data_out")
+            shutil.rmtree(reset_path, ignore_errors=True)
         self.data_out.mkdir(parents=True, exist_ok=True)
         self.artifact_dir = _artifact_dir(self.env, "sklearn_pipeline")
         if self.args.reset_target and self.artifact_dir.exists():
-            shutil.rmtree(self.artifact_dir, ignore_errors=True)
+            reset_path = safe_reset_path(
+                self.artifact_dir,
+                share_root=_artifact_reset_root(self.env),
+                label="artifact_dir",
+            )
+            shutil.rmtree(reset_path, ignore_errors=True)
         self.artifact_dir.mkdir(parents=True, exist_ok=True)
         self.pool_vars = {"args": self.args}
         _runtime = self.pool_vars

--- a/src/agilab/examples/README.md
+++ b/src/agilab/examples/README.md
@@ -16,21 +16,22 @@ the command shape stable.
 | 1 | `flight_telemetry` | `flight_telemetry_project` | First proof: install one app, run one file, inspect map-ready output. |
 | 2 | `mycode` | `mycode_project` | Smallest worker template and execution smoke. |
 | 3 | `weather_forecast` | `weather_forecast_project` | Turn a notebook-style forecast into a reproducible app run. |
-| 4 | `notebook_migrations/skforecast_meteo_fr` | `weather_forecast_project` | Packaged migration source: notebooks, artifacts, lab stages, and pipeline view. |
-| 5 | `notebook_to_dask` | notebook import -> Dask pipeline | Read-only migration preview: code cells, artifact contracts, and a Dask pipeline view. |
-| 6 | `parallel_stage` | function + split rule + reducer | Read-only parallelization preview: fewer files than cores, chunk partitions, worker capping, and reducer-first planning. |
-| 7 | `excel_workbook_proof` | spreadsheet bridge preview | Read-only Excel-shaped proof: workbook, Power Query-friendly CSVs, and evidence hashes. |
-| 8 | `sqlite_connector_proof` | database connector preview | Read-only SQLite proof: schema, parameterized query, CSV result, and evidence hashes. |
-| 9 | `voila_notebook_proof` | notebook dashboard bridge preview | Read-only notebook-dashboard proof: Voila-shaped notebook, widget-to-args hints, app-view plan, and evidence hashes. |
-| 10 | `sklearn_pipeline` | `sklearn_pipeline_project` | Classic ML app proof: deterministic dataset, fitted pipeline, predictions, model artifact, metrics, and hash manifest. |
-| 11 | `mission_decision` | `mission_decision_project` | Deterministic mission-data decision run with richer artifacts. |
-| 12 | `global_dag_project` | `flight_telemetry_project` -> `weather_forecast_project` | Built-in app-owned global DAG contract: app nodes, artifact handoff, and runner-state preview. |
-| 13 | `inter_project_dag` | `flight_telemetry_project` -> `weather_forecast_project` | Standalone compatibility preview for the same cross-project DAG concept. |
-| 14 | `service_mode` | `mycode_project` | Read-only service lifecycle preview: start, status, health, stop. |
-| 15 | `mlflow_auto_tracking` | any pipeline app | Optional tracking preview: local evidence first, MLflow as the memory backend. |
-| 16 | `resilience_failure_injection` | UAV relay scenario contract | Read-only resilience preview: inject a relay failure, compare fixed/replanned/search/policy responses. |
-| 17 | `train_then_serve` | trained policy handoff contract | Read-only service handoff preview: model artifact, IO contract, prediction sample, and health gate. |
-| 18 | `native_rust_worker` | optional native worker preview | Read-only Rust/PyO3 skeleton: keep AGILAB orchestration in Python while moving only a typed hot kernel to Rust. |
+| 4 | `notebook_quickstart` | notebook-first proof assets | Packaged notebooks for first-run, Colab, Kaggle, worker-path, benchmark, and data-DAG onboarding. |
+| 5 | `notebook_migrations/skforecast_meteo_fr` | `weather_forecast_project` | Packaged migration source: notebooks, artifacts, lab stages, and pipeline view. |
+| 6 | `notebook_to_dask` | notebook import -> Dask pipeline | Read-only migration preview: code cells, artifact contracts, and a Dask pipeline view. |
+| 7 | `parallel_stage` | function + split rule + reducer | Read-only parallelization preview: fewer files than cores, chunk partitions, worker capping, and reducer-first planning. |
+| 8 | `excel_workbook_proof` | spreadsheet bridge preview | Read-only Excel-shaped proof: workbook, Power Query-friendly CSVs, and evidence hashes. |
+| 9 | `sqlite_connector_proof` | database connector preview | Read-only SQLite proof: schema, parameterized query, CSV result, and evidence hashes. |
+| 10 | `voila_notebook_proof` | notebook dashboard bridge preview | Read-only notebook-dashboard proof: Voila-shaped notebook, widget-to-args hints, app-view plan, and evidence hashes. |
+| 11 | `sklearn_pipeline` | `sklearn_pipeline_project` | Classic ML app proof: deterministic dataset, fitted pipeline, predictions, model artifact, metrics, and hash manifest. |
+| 12 | `mission_decision` | `mission_decision_project` | Deterministic mission-data decision run with richer artifacts. |
+| 13 | `global_dag_project` | `flight_telemetry_project` -> `weather_forecast_project` | Built-in app-owned global DAG contract: app nodes, artifact handoff, and runner-state preview. |
+| 14 | `inter_project_dag` | `flight_telemetry_project` -> `weather_forecast_project` | Standalone compatibility preview for the same cross-project DAG concept. |
+| 15 | `service_mode` | `mycode_project` | Read-only service lifecycle preview: start, status, health, stop. |
+| 16 | `mlflow_auto_tracking` | any pipeline app | Optional tracking preview: local evidence first, MLflow as the memory backend. |
+| 17 | `resilience_failure_injection` | UAV relay scenario contract | Read-only resilience preview: inject a relay failure, compare fixed/replanned/search/policy responses. |
+| 18 | `train_then_serve` | trained policy handoff contract | Read-only service handoff preview: model artifact, IO contract, prediction sample, and health gate. |
+| 19 | `native_rust_worker` | optional native worker preview | Read-only Rust/PyO3 skeleton: keep AGILAB orchestration in Python while moving only a typed hot kernel to Rust. |
 
 ## Execution Map
 
@@ -41,7 +42,7 @@ app execution from read-only contract previews.
 |---|---|---|---|
 | Installed `AGI_*.py` helpers | `flight_telemetry`, `mycode`, `weather_forecast`, `sklearn_pipeline`, `mission_decision` | Real `AGI.install` / `AGI.run` calls from `~/log/execute/<app>/` after the app installer seeds the scripts. | App artifacts in AGILAB share/export paths plus execution logs. |
 | Source/package read-only previews | `notebook_to_dask`, `parallel_stage`, `excel_workbook_proof`, `sqlite_connector_proof`, `voila_notebook_proof`, `inter_project_dag`, `service_mode`, `mlflow_auto_tracking`, `resilience_failure_injection`, `train_then_serve`, `native_rust_worker` | Deterministic Python preview scripts. They write local evidence and do not launch long-lived workers or hidden multi-app runs. | Preview JSON, CSV, workbook, SQLite database, notebook, dashboard-plan, or generated skeleton artifacts under `~/log/execute/<example>/` or the configured output path. |
-| Notebook migration assets | `notebook_migrations/skforecast_meteo_fr` | Packaged notebooks, artifacts, `lab_stages.toml`, and pipeline view used as migration source material. | Files to inspect or import; no service or cluster run is started by reading them. |
+| Notebook assets | `notebook_quickstart`, `notebook_migrations/skforecast_meteo_fr` | Packaged notebooks, artifacts, `lab_stages.toml`, and pipeline view used as notebook-first or migration source material. | Files to inspect or import; no service or cluster run is started by reading them. |
 
 Source-checkout commands use `uv --preview-features extra-build-dependencies run python ...`
 so dependencies resolve through the checkout environment. Commands under
@@ -98,6 +99,9 @@ From an installed package, locate one with
 - `notebook_migrations/skforecast_meteo_fr` keeps the weather-forecast source
   notebooks, exported artifacts, migrated `lab_stages.toml`, and conceptual
   pipeline view in the packaged examples tree.
+- `notebook_quickstart` keeps notebook-first first-run, Colab, Kaggle,
+  worker-path, benchmark, and data-DAG notebooks together as importable learning
+  assets rather than seeded executable scripts.
 - `sklearn_pipeline/AGI_run_sklearn_pipeline.py` runs the classic ML app proof:
   deterministic scikit-learn dataset, fitted pipeline, model artifact,
   predictions, metrics, report, and hash manifest.
@@ -158,7 +162,8 @@ programmatic calls. Select `global_dag_project` in WORKFLOW when you want to
 understand how project-level app runs can be connected by explicit artifact
 contracts, and use `inter_project_dag` only when you need the standalone
 compatibility preview path. Use
-`notebook_to_dask` when you want to evaluate a notebook migration before
+`notebook_quickstart` when you want notebook-first onboarding material before
+running a seeded app script. Use `notebook_to_dask` when you want to evaluate a notebook migration before
 creating an app or running Dask. Use `sklearn_pipeline` when you want a minimal
 classic ML app proof that writes predictions, metrics, a serialized model, and
 artifact hashes without any tracking backend. Use `parallel_stage` when you want

--- a/src/agilab/examples/notebook_quickstart/README.md
+++ b/src/agilab/examples/notebook_quickstart/README.md
@@ -1,0 +1,64 @@
+# Notebook Quickstart Assets
+
+## Example Class
+
+**Notebook import asset.** This directory packages notebook-first onboarding
+material. It is not seeded as an `AGI_*.py` execution helper.
+
+## Purpose
+
+Use these notebooks when a user wants to stay in a notebook while learning the
+first AGILAB proof, worker paths, simple data DAGs, Colab, Kaggle, and benchmark
+variants.
+
+## What You Learn
+
+- How the notebook-first path maps to AGILAB proof and evidence concepts.
+- How local, Colab, and Kaggle notebooks differ without changing the core app
+  boundary.
+- How worker paths and data DAG notebooks introduce execution structure before a
+  full app migration.
+
+## Install
+
+Install AGILAB normally, then open the notebook from the packaged examples tree
+or copy it into a working notebook environment. The notebooks are source assets,
+not installer-seeded run scripts.
+
+## Run
+
+Open one notebook and run its cells in order. Start with
+`agi_core_first_run.ipynb` for a local source checkout, or the matching Colab or
+Kaggle first-run notebook for hosted notebook environments.
+
+## Expected Input
+
+The notebooks use public, deterministic first-run inputs and AGILAB-managed
+paths. No private dataset, API key, or cluster credential is required for the
+first-run path.
+
+## Expected Output
+
+The first-run notebooks produce AGILAB proof/evidence artifacts in the configured
+notebook or AGILAB output path. Worker-path and data-DAG notebooks show the
+paths and execution contracts used by later app migration steps.
+
+## Read The Script
+
+Read the cells that create the app environment, construct the run request, and
+call AGILAB execution helpers. Those cells are the notebook equivalent of the
+seeded `AGI_run_*.py` examples.
+
+## Change One Thing
+
+After the default notebook works, change only the output label or one small
+sample parameter. Keep the runtime local and deterministic until you have
+compared the new evidence with the previous run.
+
+## Troubleshooting
+
+- If imports fail, confirm AGILAB is installed in the notebook kernel.
+- If output paths are confusing, run the worker-path notebook before changing
+  any directories.
+- If hosted notebooks cannot access local files, use the Colab or Kaggle
+  variant instead of a source-checkout notebook.

--- a/test/test_app_installer_packaging.py
+++ b/test/test_app_installer_packaging.py
@@ -68,6 +68,7 @@ EXAMPLE_PREVIEWS = {
     "voila_notebook_proof": ("preview_voila_notebook_proof.py",),
 }
 EXAMPLE_NOTEBOOK_ASSETS = {
+    "notebook_quickstart": ("README.md",),
     "notebook_migrations/skforecast_meteo_fr": ("README.md",),
 }
 EXAMPLE_CLASS_LABELS = {
@@ -1464,8 +1465,9 @@ def test_sklearn_pipeline_app_writes_model_metrics_and_manifest(tmp_path: Path) 
     assert manifest["promotion_hint"] in {"candidate", "review"}
     assert manifest["artifacts"]["model"]["path"] == "model.joblib"
     assert manifest["artifacts"]["predictions"]["sha256"] == summary["artifacts"]["predictions"]["sha256"]
+    assert summary_payload == summary
     assert summary_payload["artifacts"]["manifest"]["sha256"] == summary["artifacts"]["manifest"]["sha256"]
-    assert summary["artifacts"]["summary"]["path"] == "sklearn_pipeline_summary.json"
+    assert "summary" not in summary["artifacts"]
     assert (tmp_path / "model.joblib").is_file()
     assert (tmp_path / "sklearn_report.md").is_file()
     assert predictions[0] == "row_id,target,prediction,positive_probability"

--- a/test/test_sklearn_pipeline_project.py
+++ b/test/test_sklearn_pipeline_project.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+PROJECT_SRC = ROOT / "src/agilab/apps/builtin/sklearn_pipeline_project/src"
+sys.path.insert(0, str(PROJECT_SRC))
+
+from sklearn_pipeline import (  # noqa: E402
+    SklearnPipelineArgs,
+    SklearnPipeline,
+    build_sklearn_pipeline_artifacts,
+    filter_arg_overrides,
+    safe_reset_path,
+)
+from sklearn_pipeline.reduction import partial_from_sklearn_summary  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "",
+        ".",
+        "..",
+        "../outside",
+        "sklearn_pipeline/../outside",
+        "/tmp/sklearn_pipeline",
+        "~/sklearn_pipeline",
+        r"C:\tmp\sklearn_pipeline",
+        "C:tmp/sklearn_pipeline",
+    ],
+)
+def test_sklearn_pipeline_rejects_unsafe_data_out(value: str) -> None:
+    with pytest.raises(ValueError):
+        SklearnPipelineArgs(data_out=value)
+
+
+def test_sklearn_pipeline_filters_generic_runtime_kwargs() -> None:
+    filtered = filter_arg_overrides(
+        {
+            "data_out": "sklearn_pipeline/evidence",
+            "sample_count": 80,
+            "verbose": 2,
+            "scheduler": "127.0.0.1",
+            "workers": {"127.0.0.1": 1},
+        }
+    )
+
+    assert filtered == {
+        "data_out": "sklearn_pipeline/evidence",
+        "sample_count": 80,
+    }
+    assert SklearnPipelineArgs(**filtered).sample_count == 80
+
+
+def test_sklearn_pipeline_manager_keeps_dispatched_args_relative(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    class FakeEnv:
+        verbose = 0
+        target = "sklearn_pipeline_project"
+        app = "sklearn_pipeline_project"
+        active_app = "sklearn_pipeline_project"
+        AGILAB_EXPORT_ABS = tmp_path / "export"
+
+        def resolve_share_path(self, path: str | Path) -> Path:
+            return tmp_path / "share" / Path(path)
+
+    monkeypatch.setattr(SklearnPipeline, "_ensure_managed_pc_share_dir", lambda self, env: None)
+    monkeypatch.setattr(SklearnPipeline, "_apply_managed_pc_paths", lambda self, args: args)
+
+    app = SklearnPipeline(
+        FakeEnv(),
+        data_out="sklearn_pipeline/evidence",
+        scheduler="127.0.0.1",
+        workers={"127.0.0.1": 1},
+    )
+
+    assert app.args.data_out == Path("sklearn_pipeline/evidence")
+    assert app.data_out == (tmp_path / "share" / "sklearn_pipeline" / "evidence")
+
+
+def test_sklearn_pipeline_safe_reset_path_stays_under_share_root(tmp_path: Path) -> None:
+    share_root = tmp_path / "share"
+    target = share_root / "sklearn_pipeline" / "evidence"
+    target.mkdir(parents=True)
+
+    assert safe_reset_path(target, share_root=share_root, label="data_out") == target.resolve(strict=False)
+
+    with pytest.raises(ValueError, match="share root"):
+        safe_reset_path(share_root, share_root=share_root, label="data_out")
+    with pytest.raises(ValueError, match="under"):
+        safe_reset_path(tmp_path / "outside", share_root=share_root, label="data_out")
+
+
+def test_sklearn_pipeline_artifact_summary_matches_persisted_file(tmp_path: Path) -> None:
+    output_dir = tmp_path / "evidence"
+
+    summary = build_sklearn_pipeline_artifacts(
+        output_dir=output_dir,
+        seed=2026,
+        sample_count=80,
+        test_size=0.25,
+        regularization_c=1.0,
+    )
+
+    persisted_summary = json.loads((output_dir / "sklearn_pipeline_summary.json").read_text(encoding="utf-8"))
+    persisted_manifest = json.loads((output_dir / "run_manifest.json").read_text(encoding="utf-8"))
+
+    assert persisted_summary == summary
+    assert set(summary["artifacts"]) == {
+        "manifest",
+        "metrics",
+        "model",
+        "predictions",
+        "report",
+    }
+    assert "manifest" not in persisted_manifest["artifacts"]
+    assert summary["artifacts"]["manifest"]["path"] == "run_manifest.json"
+    assert (output_dir / "metrics.json").is_file()
+    assert (output_dir / "predictions.csv").is_file()
+    assert (output_dir / "model.joblib").is_file()
+
+    partial = partial_from_sklearn_summary(summary, partial_id="worker-0")
+    assert partial.payload["run_count"] == 1
+    assert partial.payload["test_rows"] == summary["metrics"]["test_rows"]
+    assert "run_manifest.json" in partial.payload["artifact_paths"]


### PR DESCRIPTION
## Summary
- reject unsafe sklearn `data_out` values before they can be resolved or reset
- guard destructive reset paths so manager and worker resets stay under the intended share/export roots
- filter generic runtime kwargs before constructing sklearn app args
- make the returned sklearn summary match the persisted `sklearn_pipeline_summary.json`
- add focused sklearn regression tests and classify `notebook_quickstart` as a documented notebook asset

## Validation
- `uv --preview-features extra-build-dependencies run --extra ui pytest -q -o addopts='' test/test_sklearn_pipeline_project.py test/test_app_args.py test/test_app_args_form_normalization.py test/test_app_installer_packaging.py`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' src/agilab/core/agi-env/test/test_app_args.py`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_app_contract_matrix.py test/test_package_split_contract.py`
- `uv --preview-features extra-build-dependencies run python -m py_compile src/agilab/apps/builtin/sklearn_pipeline_project/src/sklearn_pipeline/app_args.py src/agilab/apps/builtin/sklearn_pipeline_project/src/sklearn_pipeline/__init__.py src/agilab/apps/builtin/sklearn_pipeline_project/src/sklearn_pipeline/core.py src/agilab/apps/builtin/sklearn_pipeline_project/src/sklearn_pipeline/sklearn_pipeline.py src/agilab/apps/builtin/sklearn_pipeline_project/src/sklearn_pipeline_worker/sklearn_pipeline_worker.py test/test_sklearn_pipeline_project.py`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files src/agilab/apps/builtin/sklearn_pipeline_project/src/sklearn_pipeline/app_args.py src/agilab/apps/builtin/sklearn_pipeline_project/src/sklearn_pipeline/__init__.py src/agilab/apps/builtin/sklearn_pipeline_project/src/sklearn_pipeline/core.py src/agilab/apps/builtin/sklearn_pipeline_project/src/sklearn_pipeline/sklearn_pipeline.py src/agilab/apps/builtin/sklearn_pipeline_project/src/sklearn_pipeline_worker/sklearn_pipeline_worker.py test/test_sklearn_pipeline_project.py test/test_app_installer_packaging.py src/agilab/examples/README.md src/agilab/examples/notebook_quickstart/README.md`
- `git diff --check`