### PR TITLE
[codex] Make Streamlit cockpit actionable

### DIFF
--- a/src/agilab/pages/2_ORCHESTRATE.py
+++ b/src/agilab/pages/2_ORCHESTRATE.py
@@ -134,6 +134,7 @@ import_agilab_symbols(
     {
         "is_dag_worker_base": "is_dag_worker_base",
         "render_page_context": "render_page_context",
+        "render_project_evidence_drawer": "render_project_evidence_drawer",
         "render_workflow_timeline": "render_workflow_timeline",
     },
     current_file=__file__,
@@ -1695,6 +1696,12 @@ def _render_orchestrate_action_rail(
                 "detail": run_caption if has_run else "open ANALYSIS after EXECUTE writes outputs",
             },
         ),
+    )
+    render_project_evidence_drawer(
+        st,
+        env=env,
+        key_prefix="orchestrate:evidence",
+        expanded=has_run,
     )
 
 

--- a/src/agilab/pages/4_ANALYSIS.py
+++ b/src/agilab/pages/4_ANALYSIS.py
@@ -93,6 +93,7 @@ import_agilab_symbols(
     globals(),
     "agilab.workflow_ui",
     {
+        "render_project_evidence_drawer": "render_project_evidence_drawer",
         "render_page_context": "render_page_context",
     },
     current_file=__file__,
@@ -2917,6 +2918,12 @@ async def main():
         available_view_count=len(view_names),
         selected_notebook_count=len(selected_notebooks),
         available_notebook_count=len(notebook_names),
+    )
+    render_project_evidence_drawer(
+        st,
+        env=env,
+        key_prefix="analysis:evidence",
+        expanded=not selected_views and not selected_notebooks,
     )
 
     with st.expander("Choose analysis views", expanded=False):

--- a/src/agilab/workflow_ui.py
+++ b/src/agilab/workflow_ui.py
@@ -9,6 +9,7 @@ import re
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Iterable, Mapping
+from urllib.parse import urlencode
 
 MAX_INLINE_DOWNLOAD_BYTES = 5 * 1024 * 1024
 MAX_INLINE_PREVIEW_BYTES = 256 * 1024
@@ -47,6 +48,7 @@ _COCKPIT_ARTIFACT_SUFFIXES = {
     ".txt",
 }
 _COCKPIT_SCAN_LIMIT = 200
+_COCKPIT_MAX_DRAWER_ARTIFACTS = 12
 
 
 def _as_text(value: Any) -> str:
@@ -80,6 +82,11 @@ def workflow_state_scope(page_label: str, env: Any | None = None) -> str:
 def project_widget_key(page_label: str, env: Any | None, key: Any) -> str:
     """Return a widget key scoped to one page and one active project."""
     return f"{workflow_state_scope(page_label, env)}::{_stable_key_part(key)}"
+
+
+def project_state_key(page_label: str, env: Any | None, key: Any) -> str:
+    """Return a non-widget session key scoped to one page and one active project."""
+    return f"{workflow_state_scope(page_label, env)}::state::{_stable_key_part(key)}"
 
 
 def _identity_tokens(value: Any) -> set[str]:
@@ -210,11 +217,42 @@ def _latest_timestamp_label(timestamp: float | None) -> str:
     return datetime.fromtimestamp(timestamp).strftime("%Y-%m-%d %H:%M")
 
 
+def _artifact_label(path: Path) -> str:
+    if path.name == "run_manifest.json":
+        return "Run manifest"
+    suffix = path.suffix.lower()
+    if suffix == ".log":
+        return "Runtime log"
+    if suffix in {".csv", ".parquet"}:
+        return "Table"
+    if suffix in {".png", ".svg"}:
+        return "Figure"
+    if suffix == ".ipynb":
+        return "Notebook"
+    if suffix == ".json":
+        return "JSON evidence"
+    return path.name
+
+
+def _artifact_kind_label(path: Path) -> str:
+    if path.name == "run_manifest.json":
+        return "manifest"
+    return path.suffix.lower().lstrip(".") or "file"
+
+
+def _artifact_description(path: Path, root: Path) -> str:
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return path.name
+
+
 def _scan_project_evidence(env: Any | None) -> dict[str, Any]:
     count = 0
     latest: float | None = None
     manifest: Path | None = None
     examples: list[str] = []
+    artifact_rows: list[tuple[float, Path, Path]] = []
     truncated = False
     ignored_dirs = {
         ".git",
@@ -256,7 +294,9 @@ def _scan_project_evidence(env: Any | None) -> dict[str, Any]:
                 if len(examples) < 3:
                     examples.append(path.name)
                 try:
-                    latest = max(latest or path.stat().st_mtime, path.stat().st_mtime)
+                    mtime = path.stat().st_mtime
+                    artifact_rows.append((mtime, path, root))
+                    latest = max(latest or mtime, mtime)
                 except OSError:
                     pass
                 if count >= _COCKPIT_SCAN_LIMIT:
@@ -271,6 +311,20 @@ def _scan_project_evidence(env: Any | None) -> dict[str, Any]:
         "latest": latest,
         "manifest": manifest,
         "examples": examples,
+        "artifacts": [
+            {
+                "label": _artifact_label(path),
+                "path": path,
+                "kind": _artifact_kind_label(path),
+                "description": _artifact_description(path, root),
+                "preview": path.suffix.lower()
+                in (_TEXT_PREVIEW_SUFFIXES | _IMAGE_PREVIEW_SUFFIXES),
+            }
+            for _mtime, path, root in sorted(
+                artifact_rows,
+                key=lambda row: (-row[0], row[1].as_posix()),
+            )[:_COCKPIT_MAX_DRAWER_ARTIFACTS]
+        ],
         "truncated": truncated,
     }
 
@@ -307,6 +361,64 @@ def _run_history(env: Any | None) -> tuple[str, str, str]:
         count, caption = "0", "run log status unavailable"
     state = "ready" if count not in {"", "0"} else "incomplete"
     return count, caption, state
+
+
+def _project_page_url(page_name: str, env: Any | None) -> str:
+    params: dict[str, str] = {}
+    active_app = _as_text(getattr(env, "app", "") if env is not None else "")
+    if active_app:
+        params["active_app"] = active_app
+    query = urlencode(params)
+    return f"/{page_name}?{query}" if query else f"/{page_name}"
+
+
+def _project_next_action(
+    env: Any | None,
+    *,
+    project_ready: bool,
+    install_value: str,
+    run_value: str,
+    artifact_count: int,
+) -> dict[str, str]:
+    if not project_ready:
+        return {
+            "id": "project",
+            "label": "Create or select project",
+            "detail": "Choose a project before installing, executing, or reviewing evidence.",
+            "url": _project_page_url("PROJECT", env),
+            "type": "primary",
+        }
+    if artifact_count:
+        return {
+            "id": "analysis",
+            "label": "Review evidence",
+            "detail": "Open ANALYSIS on the selected project outputs.",
+            "url": _project_page_url("ANALYSIS", env),
+            "type": "primary",
+        }
+    if install_value != "Ready":
+        return {
+            "id": "install",
+            "label": "Install project",
+            "detail": "Prepare the manager and worker environments before execution.",
+            "url": _project_page_url("ORCHESTRATE", env),
+            "type": "primary",
+        }
+    if run_value in {"", "0"}:
+        return {
+            "id": "execute",
+            "label": "Execute project",
+            "detail": "Run the project once to create logs, manifests, and artifacts.",
+            "url": _project_page_url("ORCHESTRATE", env),
+            "type": "primary",
+        }
+    return {
+        "id": "execute",
+        "label": "Create evidence",
+        "detail": "Run ORCHESTRATE -> EXECUTE so ANALYSIS has outputs to inspect.",
+        "url": _project_page_url("ORCHESTRATE", env),
+        "type": "primary",
+    }
 
 
 def _render_cockpit_card(streamlit: Any, *, label: str, value: str, caption: str, state: str) -> None:
@@ -383,6 +495,79 @@ def _project_cockpit_cards(page_label: str, env: Any | None) -> list[dict[str, s
     ]
 
 
+def project_next_action(env: Any | None) -> dict[str, str]:
+    """Return the next user-facing action implied by current project state."""
+    project_root = _project_path(env)
+    project_ready = bool(project_root and (project_root.exists() or project_root.is_symlink()))
+    install_value, _install_caption, _install_state = _project_install_status(env)
+    run_value, _run_caption, _run_state = _run_history(env)
+    evidence = _scan_project_evidence(env)
+    return _project_next_action(
+        env,
+        project_ready=project_ready,
+        install_value=install_value,
+        run_value=run_value,
+        artifact_count=int(evidence["count"]),
+    )
+
+
+def render_next_best_action(
+    streamlit: Any,
+    *,
+    env: Any | None,
+    key_prefix: str,
+    title: str = "Next best action",
+) -> dict[str, str]:
+    """Render one navigation CTA derived from project readiness."""
+    action = project_next_action(env)
+    streamlit.caption(f"{title}: {action['detail']}")
+    link_button = getattr(streamlit, "link_button", None)
+    if callable(link_button):
+        link_button(
+            action["label"],
+            action["url"],
+            key=f"{key_prefix}:next:{_stable_key_part(action['id'])}",
+            type=action.get("type", "primary"),
+            width="content",
+        )
+    else:
+        streamlit.markdown(f"[{action['label']}]({action['url']})")
+    return action
+
+
+def project_evidence_artifacts(env: Any | None) -> list[dict[str, Any]]:
+    """Return latest evidence artifacts for the selected project."""
+    return list(_scan_project_evidence(env).get("artifacts", []))
+
+
+def render_project_evidence_drawer(
+    streamlit: Any,
+    *,
+    env: Any | None,
+    key_prefix: str,
+    title: str = "Evidence drawer",
+    expanded: bool = False,
+) -> None:
+    """Render latest project evidence in one reusable drawer."""
+    artifacts = project_evidence_artifacts(env)
+    if not artifacts:
+        expander = streamlit.expander(title, expanded=expanded)
+        with expander:
+            _call_container_method(
+                expander,
+                "caption",
+                "No evidence files found yet. Run ORCHESTRATE -> EXECUTE first.",
+            )
+        return
+    render_artifact_drawer(
+        streamlit,
+        artifacts=artifacts,
+        key_prefix=key_prefix,
+        title=title,
+        expanded=expanded,
+    )
+
+
 def render_page_context(streamlit: Any, *, page_label: str, env: Any | None = None) -> None:
     """Render the compact project cockpit shared by Streamlit pages."""
     if env is None:
@@ -398,6 +583,11 @@ def render_page_context(streamlit: Any, *, page_label: str, env: Any | None = No
             for column, card in zip(columns, row):
                 with column:
                     _render_cockpit_card(streamlit, **card)
+        render_next_best_action(
+            streamlit,
+            env=env,
+            key_prefix=f"project_cockpit:{_stable_key_part(page_label)}",
+        )
     return None
 
 

--- a/test/test_workflow_ui.py
+++ b/test/test_workflow_ui.py
@@ -52,6 +52,9 @@ class _FakeContainer:
     def markdown(self, body: object, **kwargs):
         self._streamlit.events.append(("markdown", str(body)))
 
+    def link_button(self, label: str, url: str, key: str | None = None, **kwargs):
+        self._streamlit.link_button(label, url, key=key, **kwargs)
+
 
 class _FakeSidebar:
     def __init__(self, streamlit):
@@ -105,6 +108,9 @@ class _FakeStreamlit:
     def image(self, body: object, **kwargs):
         self.events.append(("image", str(body)))
 
+    def link_button(self, label: str, url: str, key: str | None = None, **kwargs):
+        self.events.append(("link_button", f"{label}:{url}:{key or ''}:{kwargs.get('type', '')}"))
+
 
 def test_fake_streamlit_and_sidebar_helpers_are_exercised() -> None:
     streamlit = _FakeStreamlit()
@@ -147,6 +153,10 @@ def test_render_page_context_renders_project_cockpit(tmp_path) -> None:
     assert "flight_telemetry_project" in markdown
     assert "run_manifest.json" in markdown
     assert "agilab-header-card" in markdown
+    assert (
+        "link_button",
+        "Review evidence:/ANALYSIS?active_app=flight_telemetry_project:project_cockpit:ORCHESTRATE:next:analysis:primary",
+    ) in fake_st.events
 
 
 def test_project_widget_key_is_scoped_by_page_and_project() -> None:
@@ -156,6 +166,58 @@ def test_project_widget_key_is_scoped_by_page_and_project() -> None:
         workflow_ui.project_widget_key("ORCHESTRATE", env, "cluster enabled")
         == "ORCHESTRATE::flight_telemetry_project::flight_telemetry_worker::cluster_enabled"
     )
+    assert (
+        workflow_ui.project_state_key("ORCHESTRATE", env, "drawer open")
+        == "ORCHESTRATE::flight_telemetry_project::flight_telemetry_worker::state::drawer_open"
+    )
+
+
+def test_next_best_action_guides_install_execute_and_analysis(tmp_path, monkeypatch) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    env = SimpleNamespace(app="demo_project", target="demo", active_app=project)
+
+    monkeypatch.setattr(
+        workflow_ui,
+        "_project_install_status",
+        lambda _env: ("Not installed", "run ORCHESTRATE -> INSTALL", "incomplete"),
+    )
+    assert workflow_ui.project_next_action(env)["id"] == "install"
+
+    monkeypatch.setattr(
+        workflow_ui,
+        "_project_install_status",
+        lambda _env: ("Ready", "manager and worker ready", "ready"),
+    )
+    assert workflow_ui.project_next_action(env)["id"] == "execute"
+
+    runenv = tmp_path / "run"
+    runenv.mkdir()
+    (runenv / "run_001.log").write_text("ok\n", encoding="utf-8")
+    (runenv / "run_manifest.json").write_text("{}", encoding="utf-8")
+    env.runenv = runenv
+
+    assert workflow_ui.project_next_action(env)["id"] == "analysis"
+
+
+def test_project_evidence_drawer_lists_latest_artifacts(tmp_path) -> None:
+    runenv = tmp_path / "run"
+    runenv.mkdir()
+    (runenv / "run_manifest.json").write_text("{}", encoding="utf-8")
+    (runenv / "metrics.csv").write_text("x\n1\n", encoding="utf-8")
+    env = SimpleNamespace(app="demo_project", target="demo", active_app=tmp_path, runenv=runenv)
+    fake_st = _FakeStreamlit()
+
+    workflow_ui.render_project_evidence_drawer(
+        fake_st,
+        env=env,
+        key_prefix="demo:evidence",
+        expanded=True,
+    )
+
+    assert ("expander", "Evidence drawer:True") in fake_st.events
+    assert ("caption", "Run manifest: Ready (manifest)") in fake_st.events
+    assert ("caption", "Table: Ready (csv)") in fake_st.events
 
 
 def test_is_dag_based_app_uses_env_worker_base_and_identity_fallback() -> None:


### PR DESCRIPTION
## Summary
- Add a next-best-action CTA to the shared Streamlit Project cockpit.
- Add a reusable latest-evidence drawer for run manifests, logs, tables, figures, notebooks, and JSON evidence.
- Surface the evidence drawer in ORCHESTRATE and ANALYSIS.
- Add project-scoped non-widget state keys alongside widget keys.

## Validation
- `./dev test test/test_workflow_ui.py::test_render_page_context_renders_project_cockpit test/test_workflow_ui.py::test_project_widget_key_is_scoped_by_page_and_project test/test_workflow_ui.py::test_next_best_action_guides_install_execute_and_analysis test/test_workflow_ui.py::test_project_evidence_drawer_lists_latest_artifacts`
