### PR TITLE
Fix notebook import transactional failures

### DIFF
--- a/src/agilab/pages/1_PROJECT.py
+++ b/src/agilab/pages/1_PROJECT.py
@@ -3846,6 +3846,21 @@ def _notebook_project_detail(clone_detail, preflight, cell_count: int) -> str:
     return " ".join(parts)
 
 
+def _cleanup_failed_notebook_project(dest_root: Path) -> tuple[bool, str]:
+    try:
+        if not dest_root.exists():
+            return True, ""
+        import shutil
+
+        shutil.rmtree(dest_root)
+    except (OSError, RuntimeError, TypeError, ValueError) as exc:
+        return (
+            False,
+            f"Incomplete project clone remains at {dest_root}: {exc}",
+        )
+    return True, f"Removed incomplete project clone at {dest_root}."
+
+
 def _create_project_from_notebook_action(
     env: AgiEnv,
     *,
@@ -3942,10 +3957,18 @@ def _create_project_from_notebook_action(
             preview, dest_root, stages_file
         )
     except (OSError, RuntimeError, TypeError, ValueError) as exc:
+        cleanup_ok, cleanup_detail = _cleanup_failed_notebook_project(dest_root)
+        detail = str(exc)
+        if cleanup_detail:
+            detail = f"{detail}\n\n{cleanup_detail}"
         return ActionResult.error(
             f"Project '{new_name}' was created, but notebook import failed.",
-            detail=str(exc),
-            next_action="Open WORKFLOW for the project and retry notebook import.",
+            detail=detail,
+            next_action=(
+                "Fix the notebook import error, then retry project creation."
+                if cleanup_ok
+                else "Remove the incomplete project directory, then retry project creation."
+            ),
             data={
                 **dict(clone_result.data),
                 "new_name": new_name,
@@ -3954,6 +3977,7 @@ def _create_project_from_notebook_action(
                 "notebook_path": notebook_path,
                 "stages_file": stages_file,
                 "preflight": preflight,
+                "cleanup_ok": cleanup_ok,
             },
         )
 

--- a/src/agilab/pipeline_editor.py
+++ b/src/agilab/pipeline_editor.py
@@ -647,6 +647,48 @@ def _render_notebook_import_write_preview(
         caption(preview_text)
 
 
+def _backup_notebook_import_targets(paths: Iterable[Path]) -> Dict[Path, bytes | None]:
+    backups: Dict[Path, bytes | None] = {}
+    for path in paths:
+        try:
+            backups[path] = path.read_bytes()
+        except FileNotFoundError:
+            backups[path] = None
+    return backups
+
+
+def _restore_notebook_import_targets(backups: Mapping[Path, bytes | None]) -> None:
+    for path, payload in backups.items():
+        try:
+            if payload is None:
+                path.unlink()
+            else:
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_bytes(payload)
+        except FileNotFoundError:
+            pass
+        except OSError as exc:
+            logger.error(
+                "Unable to restore notebook import target %s after failed import commit: %s",
+                bound_log_value(path, LOG_PATH_LIMIT),
+                bound_log_value(exc, LOG_DETAIL_LIMIT),
+            )
+
+
+def _cleanup_notebook_import_temp_files(paths: Iterable[Path]) -> None:
+    for path in paths:
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            pass
+        except OSError as exc:
+            logger.warning(
+                "Unable to remove notebook import temporary file %s: %s",
+                bound_log_value(path, LOG_PATH_LIMIT),
+                bound_log_value(exc, LOG_DETAIL_LIMIT),
+            )
+
+
 def _notebook_import_blocking_detail(preflight: Any) -> str:
     if not isinstance(preflight, dict):
         return "Notebook preflight did not produce a valid report."
@@ -730,42 +772,59 @@ def write_notebook_import_preview(
     module = str(preview.get("module", "") or _notebook_import_module_name(module_dir))
     cell_count = int(preview.get("cell_count", 0) or 0)
 
+    module_dir.mkdir(parents=True, exist_ok=True)
     stages_file.parent.mkdir(parents=True, exist_ok=True)
-    temp_stages_file = stages_file.with_name(f".{stages_file.name}.{os.getpid()}.tmp")
-    try:
-        with open(temp_stages_file, "wb") as toml_file:
-            tomli_w.dump(convert_paths_to_strings(_prepare_lab_stages_for_write(toml_content)), toml_file)
-        temp_stages_file.replace(stages_file)
-    except (OSError, TypeError, ValueError):
-        try:
-            temp_stages_file.unlink()
-        except OSError:
-            pass
-        raise
-
     contract_path = module_dir / "notebook_import_contract.json"
     pipeline_view_path = module_dir / "notebook_import_pipeline_view.json"
     view_plan_path = module_dir / "notebook_import_view_plan.json"
     view_manifest_path = discover_notebook_import_view_manifest(view_manifest_dir or module_dir)
-    write_notebook_import_contract(
-        contract_path,
-        notebook_import,
-        preflight=preflight,
-        module_name=module,
+    temp_stages_file = stages_file.with_name(f".{stages_file.name}.{os.getpid()}.tmp")
+    temp_contract_path = contract_path.with_name(f".{contract_path.name}.{os.getpid()}.tmp")
+    temp_pipeline_view_path = pipeline_view_path.with_name(
+        f".{pipeline_view_path.name}.{os.getpid()}.tmp"
     )
-    write_notebook_import_pipeline_view(
-        pipeline_view_path,
-        notebook_import,
-        preflight=preflight,
-        module_name=module,
-    )
-    write_notebook_import_view_plan(
-        view_plan_path,
-        notebook_import,
-        preflight=preflight,
-        module_name=module,
-        manifest_path=view_manifest_path,
-    )
+    temp_view_plan_path = view_plan_path.with_name(f".{view_plan_path.name}.{os.getpid()}.tmp")
+    temp_targets = [
+        (temp_contract_path, contract_path),
+        (temp_pipeline_view_path, pipeline_view_path),
+        (temp_view_plan_path, view_plan_path),
+        (temp_stages_file, stages_file),
+    ]
+    backups: Dict[Path, bytes | None] | None = None
+    replaced_any = False
+    try:
+        with open(temp_stages_file, "wb") as toml_file:
+            tomli_w.dump(convert_paths_to_strings(_prepare_lab_stages_for_write(toml_content)), toml_file)
+        write_notebook_import_contract(
+            temp_contract_path,
+            notebook_import,
+            preflight=preflight,
+            module_name=module,
+        )
+        write_notebook_import_pipeline_view(
+            temp_pipeline_view_path,
+            notebook_import,
+            preflight=preflight,
+            module_name=module,
+        )
+        write_notebook_import_view_plan(
+            temp_view_plan_path,
+            notebook_import,
+            preflight=preflight,
+            module_name=module,
+            manifest_path=view_manifest_path,
+        )
+        backups = _backup_notebook_import_targets(target for _temp, target in temp_targets)
+        for temp_path, target_path in temp_targets:
+            temp_path.replace(target_path)
+            replaced_any = True
+    except (OSError, TypeError, ValueError):
+        if backups is not None and replaced_any:
+            _restore_notebook_import_targets(backups)
+        raise
+    finally:
+        _cleanup_notebook_import_temp_files(temp for temp, _target in temp_targets)
+
     _emit_notebook_preflight_result(preflight, contract_path, view_plan_path=view_plan_path)
     return cell_count
 
@@ -1717,8 +1776,9 @@ def on_import_notebook(
     module_dir: Path,
     stages_file: Path,
     index_page: str,
+    view_manifest_dir: Path | None = None,
 ) -> None:
-    """Handle notebook file import via sidebar uploader."""
+    """Compatibility handler for notebook imports via sidebar uploader."""
     uploaded_file = st.session_state.get(key)
     if not uploaded_file:
         _emit_streamlit_message("error", "No notebook file was uploaded.")
@@ -1726,21 +1786,16 @@ def on_import_notebook(
     if not _is_uploaded_notebook(uploaded_file):
         return
 
-    cell_count = notebook_to_toml(
-        uploaded_file,
-        stages_file.name,
-        module_dir,
-    )
-    if cell_count is None:
+    preview = build_notebook_import_preview(uploaded_file, module_dir)
+    if preview is None:
         return
-    if cell_count > 0:
-        _emit_streamlit_message("success", f"Imported {cell_count} notebook code cell(s).")
-    else:
-        _emit_streamlit_message("warning", "Notebook imported, but no code cells were found.")
-
-    if index_page in st.session_state and isinstance(st.session_state[index_page], list):
-        st.session_state[index_page][-1] = cell_count
-    st.session_state.page_broken = True
+    st.session_state[_notebook_import_preview_key(index_page)] = preview
+    confirm_notebook_import_preview(
+        module_dir,
+        stages_file,
+        index_page,
+        view_manifest_dir=view_manifest_dir,
+    )
 
 def display_history_tab(stages_file: Path, module_path: Path) -> None:
     """Display the HISTORY tab with code editor for the stage contract."""

--- a/test/test_pipeline_editor.py
+++ b/test/test_pipeline_editor.py
@@ -1097,17 +1097,86 @@ def test_on_import_notebook_imports_ipynb_and_marks_page_broken(monkeypatch, tmp
     fake_st = SimpleNamespace(session_state=_State({"upload": uploaded, "idx": [0, "", "", "", "", "", 0]}))
     calls: dict[str, object] = {}
     monkeypatch.setattr(pipeline_editor, "st", fake_st)
-    def _fake_notebook_to_toml(uploaded_file, toml_name, module_dir):
-        calls["args"] = (uploaded_file, toml_name, module_dir)
+
+    def _fake_build_notebook_import_preview(uploaded_file, module_dir):
+        calls["build_args"] = (uploaded_file, module_dir)
+        return {"preflight": {"safe_to_import": True}}
+
+    def _fake_confirm_notebook_import_preview(module_dir, stages_file, index_page, *, view_manifest_dir=None):
+        calls["confirm_args"] = (module_dir, stages_file, index_page, view_manifest_dir)
+        fake_st.session_state["idx"][-1] = 3
+        fake_st.session_state["page_broken"] = True
         return 3
 
-    monkeypatch.setattr(pipeline_editor, "notebook_to_toml", _fake_notebook_to_toml)
+    monkeypatch.setattr(
+        pipeline_editor,
+        "build_notebook_import_preview",
+        _fake_build_notebook_import_preview,
+    )
+    monkeypatch.setattr(
+        pipeline_editor,
+        "confirm_notebook_import_preview",
+        _fake_confirm_notebook_import_preview,
+    )
 
-    pipeline_editor.on_import_notebook("upload", tmp_path, tmp_path / "lab_stages.toml", "idx")
+    view_manifest_dir = tmp_path / "app"
+    pipeline_editor.on_import_notebook(
+        "upload",
+        tmp_path,
+        tmp_path / "lab_stages.toml",
+        "idx",
+        view_manifest_dir=view_manifest_dir,
+    )
 
-    assert calls["args"][0] is uploaded
+    assert calls["build_args"] == (uploaded, tmp_path)
+    assert calls["confirm_args"] == (
+        tmp_path,
+        tmp_path / "lab_stages.toml",
+        "idx",
+        view_manifest_dir,
+    )
     assert fake_st.session_state["idx"][-1] == 3
     assert fake_st.session_state["page_broken"] is True
+
+
+def test_write_notebook_import_preview_keeps_existing_stages_when_sidecar_write_fails(
+    monkeypatch, tmp_path
+):
+    uploaded = SimpleNamespace(
+        name="demo.ipynb",
+        type="application/x-ipynb+json",
+        read=lambda: json.dumps(
+            {
+                "cells": [
+                    {
+                        "cell_type": "code",
+                        "metadata": {"agilab": {"runtime_role": "manager"}},
+                        "source": ["print(1)\n"],
+                    }
+                ]
+            }
+        ).encode("utf-8"),
+    )
+    module_dir = tmp_path / "demo_project"
+    module_dir.mkdir()
+    stages_file = module_dir / "lab_stages.toml"
+    original_stages = "[[demo_project]]\nQ = 'old'\nC = 'print(0)'\n"
+    stages_file.write_text(original_stages, encoding="utf-8")
+    preview = pipeline_editor.build_notebook_import_preview(uploaded, module_dir)
+
+    def _raise_contract_write(*_args, **_kwargs):
+        raise ValueError("contract boom")
+
+    monkeypatch.setattr(pipeline_editor, "write_notebook_import_contract", _raise_contract_write)
+
+    with pytest.raises(ValueError, match="contract boom"):
+        pipeline_editor.write_notebook_import_preview(preview, module_dir, stages_file)
+
+    assert stages_file.read_text(encoding="utf-8") == original_stages
+    assert not (module_dir / "notebook_import_contract.json").exists()
+    assert not (module_dir / "notebook_import_pipeline_view.json").exists()
+    assert not (module_dir / "notebook_import_view_plan.json").exists()
+    assert list(module_dir.glob(".*.tmp")) == []
 
 
 def test_on_preview_notebook_import_stores_preview_without_writing(monkeypatch, tmp_path):
@@ -2710,7 +2779,11 @@ def test_on_import_notebook_does_not_mark_page_broken_when_import_fails(monkeypa
     pipeline_editor.on_import_notebook("upload", tmp_path, tmp_path / "lab_stages.toml", "idx")
 
     fake_st.session_state["upload"] = SimpleNamespace(type="application/x-ipynb+json")
-    monkeypatch.setattr(pipeline_editor, "notebook_to_toml", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        pipeline_editor,
+        "build_notebook_import_preview",
+        lambda *_args, **_kwargs: None,
+    )
     pipeline_editor.on_import_notebook("upload", tmp_path, tmp_path / "lab_stages.toml", "idx")
 
     assert messages == [
@@ -2737,7 +2810,23 @@ def test_on_import_notebook_warns_when_successful_import_has_no_code_cells(monke
         success=lambda message, *args, **kwargs: messages.append(("success", message)),
     )
     monkeypatch.setattr(pipeline_editor, "st", fake_st)
-    monkeypatch.setattr(pipeline_editor, "notebook_to_toml", lambda *_args, **_kwargs: 0)
+    monkeypatch.setattr(
+        pipeline_editor,
+        "build_notebook_import_preview",
+        lambda *_args, **_kwargs: {"preflight": {"safe_to_import": True}},
+    )
+
+    def _confirm_zero_cell_import(*_args, **_kwargs):
+        messages.append(("warning", "Notebook imported, but no code cells were found."))
+        fake_st.session_state["page_broken"] = True
+        fake_st.session_state["idx"][-1] = 0
+        return 0
+
+    monkeypatch.setattr(
+        pipeline_editor,
+        "confirm_notebook_import_preview",
+        _confirm_zero_cell_import,
+    )
 
     pipeline_editor.on_import_notebook("upload", tmp_path, tmp_path / "lab_stages.toml", "idx")
 
@@ -2752,13 +2841,21 @@ def test_on_import_notebook_does_not_report_success_after_write_failure(monkeypa
         session_state=_State(
             {
                 "upload": SimpleNamespace(
-                    name="demo.ipynb",
-                    type="application/x-ipynb+json",
-                    read=lambda: json.dumps(
-                        {"cells": [{"cell_type": "code", "source": ["print(1)\n"]}]}
-                    ).encode("utf-8"),
-                ),
-                "idx": [0, "", "", "", "", "", 0],
+                        name="demo.ipynb",
+                        type="application/x-ipynb+json",
+                        read=lambda: json.dumps(
+                            {
+                                "cells": [
+                                    {
+                                        "cell_type": "code",
+                                        "metadata": {"agilab": {"runtime_role": "manager"}},
+                                        "source": ["print(1)\n"],
+                                    }
+                                ]
+                            }
+                        ).encode("utf-8"),
+                    ),
+                    "idx": [0, "", "", "", "", "", 0],
             }
         ),
         error=lambda message, *args, **kwargs: messages.append(("error", message)),
@@ -2779,7 +2876,7 @@ def test_on_import_notebook_does_not_report_success_after_write_failure(monkeypa
         "idx",
     )
 
-    assert messages == [("error", "Failed to save TOML file: toml boom")]
+    assert messages == [("error", "Failed to save notebook import preview: toml boom")]
     assert "page_broken" not in fake_st.session_state
     assert fake_st.session_state["idx"][-1] == 0
     assert not (tmp_path / "demo_project" / "lab_stages.toml").exists()

--- a/test/test_project_clone_policy.py
+++ b/test/test_project_clone_policy.py
@@ -935,6 +935,58 @@ def test_create_project_from_notebook_blocks_unreviewed_runtime_roles(tmp_path: 
     assert not (tmp_path / "needs_role_project").exists()
 
 
+def test_create_project_from_notebook_removes_clone_when_import_write_fails(
+    monkeypatch, tmp_path: Path
+):
+    module = _load_project_module()
+    clone_calls: list[tuple[Path, Path]] = []
+
+    def _clone_project(source: Path, target: Path) -> None:
+        clone_calls.append((source, target))
+        dest_root = tmp_path / target
+        dest_root.mkdir()
+        (dest_root / "clone-marker.txt").write_text("created", encoding="utf-8")
+
+    def _raise_import_write(*_args, **_kwargs):
+        raise ValueError("import write boom")
+
+    monkeypatch.setattr(module, "_write_project_notebook_import_preview", _raise_import_write)
+    notebook = {
+        "nbformat": 4,
+        "nbformat_minor": 5,
+        "cells": [
+            {
+                "cell_type": "code",
+                "metadata": {"agilab": {"runtime_role": "manager"}},
+                "source": ["print('ready')\n"],
+            }
+        ],
+    }
+    uploaded = SimpleNamespace(
+        name="cleanup.ipynb",
+        type="application/x-ipynb+json",
+        read=lambda: json.dumps(notebook).encode("utf-8"),
+    )
+    env = SimpleNamespace(apps_path=tmp_path, clone_project=_clone_project)
+
+    result = module._create_project_from_notebook_action(
+        env,
+        template_source="pandas_app_template",
+        raw_project_name="Cleanup Demo",
+        uploaded_notebook=uploaded,
+        clone_env_strategy="detach_venv",
+    )
+
+    dest_root = tmp_path / "cleanup_demo_project"
+    assert result.status == "error"
+    assert result.title == "Project 'cleanup_demo_project' was created, but notebook import failed."
+    assert "import write boom" in str(result.detail)
+    assert "Removed incomplete project clone" in str(result.detail)
+    assert result.data["cleanup_ok"] is True
+    assert clone_calls == [(Path("pandas_app_template"), Path("cleanup_demo_project"))]
+    assert not dest_root.exists()
+
+
 def test_project_notebook_runtime_role_review_shows_cell_context() -> None:
     module = _load_project_module()
     messages: list[tuple] = []


### PR DESCRIPTION
## Summary
- make notebook import persistence transactional across lab_stages.toml and sidecars
- clean up a just-created notebook project clone when notebook import persistence fails
- route the legacy direct notebook import handler through preview/confirm so runtime-role and manifest guards stay consistent

## Tests
- Not run locally (not requested).
