### PR TITLE
[codex] Harden headless CLI proof path

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,15 @@ install.
   <a href="https://kaggle.com/kernels/welcome?src=https://github.com/ThalesGroup/agilab/blob/main/src/agilab/examples/notebook_quickstart/agi_core_kaggle_first_run.ipynb"><img src="https://img.shields.io/badge/agi--core-notebook-1D4ED8?style=for-the-badge" alt="agi-core notebook" /></a>
 </p>
 
-### Local PyPI UI Proof
+### Local PyPI Proof
+
+```bash
+uv --preview-features extra-build-dependencies tool install --upgrade "agilab[examples]"
+agilab first-proof --json
+agilab adoption-report
+```
+
+Use the UI profile only when you also want the local Streamlit pages:
 
 ```bash
 uv --preview-features extra-build-dependencies tool install --upgrade "agilab[ui]"
@@ -171,14 +179,15 @@ If startup fails, run a progressive fallback:
 
 ```bash
 agilab dry-run
-agilab first-proof --json --with-ui
+agilab first-proof --json
 agilab adoption-report
 ```
 
 `agilab dry-run` is the fast alias for `agilab first-proof --dry-run`; it
 verifies CLI/core readiness only.
-`agilab first-proof --json --with-ui` does the local onboarding contract
-including manifest generation for the UI path.
+`agilab first-proof --json` does the local onboarding contract and writes the
+manifest without requiring Streamlit. Add `--with-ui` only when you intentionally
+want the proof to boot the packaged Streamlit pages too.
 `agilab adoption-report` reads the manifest and tells you whether the first
 proof is a safe baseline before trying notebooks, private apps, or cluster work.
 

--- a/README.pypi.md
+++ b/README.pypi.md
@@ -115,7 +115,15 @@ haversine distance kernel reports `speed_kernel_runtime`,
 [![AGILAB Space](https://img.shields.io/badge/AGILAB-Space-0F766E?style=for-the-badge)](https://huggingface.co/spaces/jpmorard/agilab)
 [![agi-core notebook](https://img.shields.io/badge/agi--core-notebook-1D4ED8?style=for-the-badge)](https://kaggle.com/kernels/welcome?src=https://github.com/ThalesGroup/agilab/blob/main/src/agilab/examples/notebook_quickstart/agi_core_kaggle_first_run.ipynb)
 
-### Local PyPI UI Proof
+### Local PyPI Proof
+
+```bash
+uv --preview-features extra-build-dependencies tool install --upgrade "agilab[examples]"
+agilab first-proof --json
+agilab adoption-report
+```
+
+Use the UI profile only when you also want the local Streamlit pages:
 
 ```bash
 uv --preview-features extra-build-dependencies tool install --upgrade "agilab[ui]"
@@ -137,13 +145,15 @@ If startup fails, run a progressive fallback:
 
 ```bash
 agilab dry-run
-agilab first-proof --json --with-ui
+agilab first-proof --json
+agilab adoption-report
 ```
 
 `agilab dry-run` is the fast alias for `agilab first-proof --dry-run`; it
 checks only CLI/core readiness.
-`agilab first-proof --json --with-ui` runs the full onboarding contract and
-writes `run_manifest.json` for the local UI path.
+`agilab first-proof --json` runs the onboarding contract and writes
+`run_manifest.json` without requiring Streamlit. Add `--with-ui` only when you
+intentionally want the proof to boot the packaged Streamlit pages too.
 
 ### Maturity snapshot
 

--- a/src/agilab/adoption_report.py
+++ b/src/agilab/adoption_report.py
@@ -23,6 +23,7 @@ FIRST_PROOF_REQUIRED_VALIDATIONS = (
 )
 TROUBLESHOOTING_URL = "https://thalesgroup.github.io/agilab/newcomer-troubleshooting.html"
 QUICK_START_URL = "https://thalesgroup.github.io/agilab/quick-start.html"
+HEADLESS_FIRST_PROOF_COMMAND = "agilab first-proof --json"
 
 
 def _log_root() -> Path:
@@ -244,7 +245,7 @@ def _next_actions(
     compatibility_status: str,
     security_status: str,
 ) -> list[dict[str, str]]:
-    first_proof_command = "agilab first-proof --json --with-ui"
+    first_proof_command = HEADLESS_FIRST_PROOF_COMMAND
     actions: list[dict[str, str]] = []
 
     if first_proof_status == "missing":

--- a/test/test_adoption_report.py
+++ b/test/test_adoption_report.py
@@ -119,7 +119,8 @@ def test_build_report_explains_missing_manifest(tmp_path: Path) -> None:
     assert report["summary"]["first_proof_status"] == "missing"
     assert report["summary"]["safe_to_expand"] is False
     assert report["evidence"][0]["status"] == "missing"
-    assert report["next_actions"][0]["command"] == "agilab first-proof --json --with-ui"
+    assert report["next_actions"][0]["command"] == adoption_report.HEADLESS_FIRST_PROOF_COMMAND
+    assert "--with-ui" not in report["next_actions"][0]["command"]
 
 
 def test_build_report_rejects_dry_run_as_expansion_baseline(tmp_path: Path) -> None:

--- a/test/test_audit_response_docs.py
+++ b/test/test_audit_response_docs.py
@@ -195,7 +195,7 @@ def test_quick_start_documents_security_adoption_checkpoint() -> None:
 
 def test_readme_uses_recommended_workbench_positioning() -> None:
     readme = Path("README.md").read_text(encoding="utf-8")
-    local_pypi_proof = readme.split("### Local PyPI UI Proof", 1)[1].split(
+    local_pypi_proof = readme.split("### Local PyPI Proof", 1)[1].split(
         "For a zero-install browser preview", 1
     )[0]
 
@@ -204,8 +204,8 @@ def test_readme_uses_recommended_workbench_positioning() -> None:
     assert "AGILAB complements MLflow and production MLOps platforms." in readme
     assert "MLflow tracks experiments; AGILAB transforms notebooks and scripts" in readme
     assert "reproducible execution and analysis layer" in readme
-    assert "agilab\n```" in local_pypi_proof
-    assert "first-proof" not in local_pypi_proof
+    assert "agilab first-proof --json" in local_pypi_proof
+    assert "--with-ui" not in local_pypi_proof
     assert "If startup fails, run a progressive fallback" in readme
     assert "| `examples` extra |" in readme
     assert "| `proof` extra |" in readme
@@ -257,7 +257,8 @@ def test_quick_start_documents_public_install_tiers() -> None:
     assert 'tool install --upgrade "agilab[ui]"\n    agilab' in ui_route
     assert "agilab first-proof --json --max-seconds 60" not in ui_route
     assert "agilab dry-run" in ui_route
-    assert "agilab first-proof --json --with-ui" in ui_route
+    assert "agilab first-proof --json --with-ui" not in ui_route
+    assert "Add ``--with-ui``" in ui_route
     assert "base, UI, pages, AI, agents, examples, MLflow, local-LLM, offline, and dev\ninstall profiles" in quick_start
 
 

--- a/test/test_headless_cli_smoke.py
+++ b/test/test_headless_cli_smoke.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "tools" / "headless_cli_smoke.py"
+SPEC = importlib.util.spec_from_file_location("headless_cli_smoke_test_module", MODULE_PATH)
+assert SPEC and SPEC.loader
+headless_cli_smoke = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = headless_cli_smoke
+SPEC.loader.exec_module(headless_cli_smoke)
+
+
+def test_streamlit_blocked_probe_covers_public_headless_modules() -> None:
+    script = headless_cli_smoke.streamlit_blocked_probe_script()
+
+    for module_name in (
+        "agilab.lab_run",
+        "agilab.first_proof_cli",
+        "agilab.adoption_report",
+        "agilab.bridge_cli",
+        "agilab_mcp.server",
+    ):
+        assert module_name in script
+    assert 'name == "streamlit" or name.startswith("streamlit.")' in script
+    assert '["first-proof", "--help"]' in script
+    assert '["adoption-report", "--help"]' in script
+
+
+def test_package_import_probe_requires_minimal_no_streamlit_environment() -> None:
+    script = headless_cli_smoke.package_import_probe_script()
+
+    assert 'find_spec("streamlit") is not None' in script
+    assert "streamlit should not be installed" in script
+    assert "agilab_mcp.server" in script
+
+
+def test_source_smoke_runs_blocked_streamlit_probe(monkeypatch) -> None:
+    calls: list[tuple[list[str], str]] = []
+
+    def fake_run(command, *, label, timeout, env=None):
+        calls.append((list(command), label))
+        return headless_cli_smoke.SmokeResult(
+            label=label,
+            command=list(command),
+            returncode=0,
+            stdout_tail="ok",
+            stderr_tail="",
+        )
+
+    monkeypatch.setattr(headless_cli_smoke, "_run", fake_run)
+
+    results = headless_cli_smoke.run_source_smoke(python="/tmp/python", timeout=12.0)
+
+    assert [result.label for result in results] == ["source blocked-streamlit import/help"]
+    assert calls[0][0][0:2] == ["/tmp/python", "-c"]
+    assert "blocked streamlit" in calls[0][0][2]
+
+
+def test_package_smoke_prefers_uv_venv_and_uv_pip(monkeypatch) -> None:
+    calls: list[tuple[list[str], str]] = []
+
+    def fake_run(command, *, label, timeout, env=None):
+        calls.append((list(command), label))
+        return headless_cli_smoke.SmokeResult(
+            label=label,
+            command=list(command),
+            returncode=0,
+            stdout_tail="ok",
+            stderr_tail="",
+        )
+
+    monkeypatch.setattr(
+        headless_cli_smoke.shutil,
+        "which",
+        lambda name: "/usr/bin/uv" if name == "uv" else None,
+    )
+    monkeypatch.setattr(headless_cli_smoke, "_run", fake_run)
+
+    results = headless_cli_smoke.run_package_smoke(package_spec=".", timeout=12.0)
+
+    labels = [result.label for result in results]
+    assert labels[:3] == ["create uv venv", "install .", "package no-streamlit import"]
+    assert calls[0][0][:3] == ["/usr/bin/uv", "venv", "--python"]
+    expected_python, _ = headless_cli_smoke._venv_paths(Path(calls[0][0][-1]))
+    assert calls[1][0][:5] == [
+        "/usr/bin/uv",
+        "pip",
+        "install",
+        "--python",
+        str(expected_python),
+    ]
+
+
+def test_emit_results_returns_failing_status(capsys) -> None:
+    result = headless_cli_smoke.SmokeResult(
+        label="bad",
+        command=["agilab", "--help"],
+        returncode=1,
+        stdout_tail="out",
+        stderr_tail="err",
+    )
+
+    headless_cli_smoke._emit_results([result], json_output=False)
+
+    captured = capsys.readouterr()
+    assert "FAIL bad" in captured.out
+    assert "out" in captured.out
+    assert "err" in captured.err

--- a/test/test_lab_run.py
+++ b/test/test_lab_run.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import importlib.util
+import os
+import subprocess
 import sys
+import textwrap
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -264,6 +267,70 @@ def test_main_dispatches_adoption_report_without_launching_streamlit(monkeypatch
 
     assert rc == 39
     assert captured == [["--json", "--strict"]]
+
+
+def test_public_headless_cli_imports_and_help_do_not_require_streamlit() -> None:
+    script = """
+        import builtins
+        import contextlib
+        import importlib
+        import io
+
+        real_import = builtins.__import__
+
+        def blocked_import(name, globals=None, locals=None, fromlist=(), level=0):
+            if name == "streamlit" or name.startswith("streamlit."):
+                raise ModuleNotFoundError("blocked streamlit", name="streamlit")
+            return real_import(name, globals, locals, fromlist, level)
+
+        builtins.__import__ = blocked_import
+
+        for module_name in (
+            "agilab",
+            "agilab.lab_run",
+            "agilab.first_proof_cli",
+            "agilab.adoption_report",
+            "agilab.bridge_cli",
+            "agilab_mcp.server",
+        ):
+            importlib.import_module(module_name)
+
+        from agilab import lab_run
+
+        lab_run._guard_against_uvx_in_source_tree = lambda: None
+
+        for argv in (
+            ["--help"],
+            ["first-proof", "--help"],
+            ["adoption-report", "--help"],
+        ):
+            stdout = io.StringIO()
+            with contextlib.redirect_stdout(stdout):
+                try:
+                    code = lab_run.main(list(argv))
+                except SystemExit as exc:
+                    code = exc.code
+            if code not in (0, None):
+                raise SystemExit(f"help path failed for {argv}: {code}")
+    """
+    env = os.environ.copy()
+    src_path = str(ROOT / "src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(script)],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
 
 
 def test_main_dispatches_evidence_contract_commands_without_launching_streamlit(monkeypatch):

--- a/test/test_public_demo_links.py
+++ b/test/test_public_demo_links.py
@@ -160,7 +160,8 @@ def test_pypi_readme_tracks_public_readme_contract() -> None:
         "production-grade core technology",
         "AGILAB complements MLflow and production MLOps platforms.",
         "## Core Flow",
-        "### Local PyPI UI Proof",
+        "### Local PyPI Proof",
+        'uv --preview-features extra-build-dependencies tool install --upgrade "agilab[examples]"',
         'uv --preview-features extra-build-dependencies tool install --upgrade "agilab[ui]"',
         "## Production Boundary",
         "## Security Reporting",
@@ -317,17 +318,18 @@ def test_readmes_expose_first_proof_evidence_badge() -> None:
 
 def test_readme_first_proof_snippet_uses_console_script_without_manual_venv() -> None:
     readme = README.read_text(encoding="utf-8")
-    local_proof = readme.split("### Local PyPI UI Proof", 1)[1].split(
+    local_proof = readme.split("### Local PyPI Proof", 1)[1].split(
         "For a zero-install browser preview",
         1,
     )[0]
 
     assert (
-        'uv --preview-features extra-build-dependencies tool install --upgrade "agilab[ui]"'
+        'uv --preview-features extra-build-dependencies tool install --upgrade "agilab[examples]"'
         in local_proof
     )
-    assert "agilab first-proof" not in local_proof
-    assert "agilab first-proof --json --with-ui" in readme
+    assert "agilab first-proof --json" in local_proof
+    assert "agilab first-proof --json --with-ui" not in readme
+    assert "Add `--with-ui` only when" in readme
     assert "If startup fails, run a progressive fallback" in readme
     assert "agilab\n" in local_proof
     assert "python3 -m venv" not in local_proof
@@ -351,7 +353,7 @@ def test_quick_start_package_route_uses_tool_console_script_without_activation()
     )[1].split("Optional feature stacks", 1)[0]
 
     assert (
-        "uv --preview-features extra-build-dependencies tool install --upgrade agilab"
+        'uv --preview-features extra-build-dependencies tool install --upgrade "agilab[examples]"'
         in quick_start
     )
     assert (
@@ -360,7 +362,8 @@ def test_quick_start_package_route_uses_tool_console_script_without_activation()
     )
     assert "agilab first-proof --json --max-seconds 60" in quick_start
     assert "agilab first-proof --json --max-seconds 60" not in ui_route
-    assert "agilab first-proof --json --with-ui" in quick_start
+    assert "Add ``--with-ui``" in quick_start
+    assert "agilab first-proof --json --with-ui" not in quick_start
     assert "source .venv/bin/activate" not in quick_start
     assert "python -m agilab.lab_run" not in quick_start
 

--- a/tools/headless_cli_smoke.py
+++ b/tools/headless_cli_smoke.py
@@ -1,0 +1,281 @@
+"""Headless AGILAB CLI smoke checks.
+
+The default source-mode check blocks Streamlit imports and verifies that the
+public headless command surface remains importable. Package mode creates an
+isolated virtual environment, installs a package spec or wheel, and checks the
+console scripts without installing UI extras.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import textwrap
+import venv
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Sequence
+
+
+HEADLESS_MODULES = (
+    "agilab",
+    "agilab.lab_run",
+    "agilab.first_proof_cli",
+    "agilab.adoption_report",
+    "agilab.bridge_cli",
+    "agilab_mcp.server",
+)
+HELP_COMMANDS = (
+    ("agilab", "--help"),
+    ("agilab", "first-proof", "--help"),
+    ("agilab", "adoption-report", "--help"),
+    ("agilab-mcp", "serve", "--once"),
+)
+
+
+@dataclass(frozen=True)
+class SmokeResult:
+    label: str
+    command: list[str]
+    returncode: int
+    stdout_tail: str
+    stderr_tail: str
+
+    @property
+    def passed(self) -> bool:
+        return self.returncode == 0
+
+
+def _tail(text: str, *, limit: int = 1200) -> str:
+    return text[-limit:]
+
+
+def _run(
+    command: Sequence[str],
+    *,
+    label: str,
+    timeout: float,
+    env: dict[str, str] | None = None,
+) -> SmokeResult:
+    completed = subprocess.run(
+        list(command),
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=timeout,
+        env=env,
+    )
+    return SmokeResult(
+        label=label,
+        command=list(command),
+        returncode=completed.returncode,
+        stdout_tail=_tail(completed.stdout),
+        stderr_tail=_tail(completed.stderr),
+    )
+
+
+def streamlit_blocked_probe_script() -> str:
+    modules = ", ".join(repr(module) for module in HEADLESS_MODULES)
+    return textwrap.dedent(
+        f"""
+        import builtins
+        import contextlib
+        import importlib
+        import io
+
+        real_import = builtins.__import__
+
+        def blocked_import(name, globals=None, locals=None, fromlist=(), level=0):
+            if name == "streamlit" or name.startswith("streamlit."):
+                raise ModuleNotFoundError("blocked streamlit", name="streamlit")
+            return real_import(name, globals, locals, fromlist, level)
+
+        builtins.__import__ = blocked_import
+
+        for module_name in ({modules},):
+            importlib.import_module(module_name)
+
+        from agilab import lab_run
+
+        lab_run._guard_against_uvx_in_source_tree = lambda: None
+
+        for argv in (
+            ["--help"],
+            ["first-proof", "--help"],
+            ["adoption-report", "--help"],
+        ):
+            stdout = io.StringIO()
+            with contextlib.redirect_stdout(stdout):
+                try:
+                    code = lab_run.main(list(argv))
+                except SystemExit as exc:
+                    code = exc.code
+            if code not in (0, None):
+                raise SystemExit(f"help path failed for {{argv}}: {{code}}")
+
+        print("headless source import/help smoke: ok")
+        """
+    ).strip()
+
+
+def package_import_probe_script() -> str:
+    modules = ", ".join(repr(module) for module in HEADLESS_MODULES)
+    return textwrap.dedent(
+        f"""
+        import importlib
+        import importlib.util
+
+        if importlib.util.find_spec("streamlit") is not None:
+            raise SystemExit("streamlit should not be installed in the minimal package smoke")
+
+        for module_name in ({modules},):
+            importlib.import_module(module_name)
+
+        print("headless package import smoke: ok")
+        """
+    ).strip()
+
+
+def run_source_smoke(*, python: str, timeout: float) -> list[SmokeResult]:
+    return [
+        _run(
+            [python, "-c", streamlit_blocked_probe_script()],
+            label="source blocked-streamlit import/help",
+            timeout=timeout,
+        )
+    ]
+
+
+def _venv_paths(venv_dir: Path) -> tuple[Path, Path]:
+    if os.name == "nt":
+        scripts_dir = venv_dir / "Scripts"
+        return scripts_dir / "python.exe", scripts_dir
+    scripts_dir = venv_dir / "bin"
+    return scripts_dir / "python", scripts_dir
+
+
+def _create_package_venv(
+    venv_dir: Path, *, timeout: float, env: dict[str, str]
+) -> tuple[Path, Path, list[SmokeResult], bool]:
+    uv = shutil.which("uv")
+    if uv:
+        create_result = _run(
+            [uv, "venv", "--python", sys.executable, str(venv_dir)],
+            label="create uv venv",
+            timeout=timeout,
+            env=env,
+        )
+        python, scripts_dir = _venv_paths(venv_dir)
+        return python, scripts_dir, [create_result], True
+
+    venv.EnvBuilder(with_pip=True).create(venv_dir)
+    python, scripts_dir = _venv_paths(venv_dir)
+    return python, scripts_dir, [], False
+
+
+def run_package_smoke(*, package_spec: str, timeout: float) -> list[SmokeResult]:
+    with tempfile.TemporaryDirectory(prefix="agilab-headless-smoke-") as tmp:
+        venv_dir = Path(tmp) / "venv"
+        env = os.environ.copy()
+        env.pop("PYTHONPATH", None)
+        env.pop("VIRTUAL_ENV", None)
+        python, scripts_dir, results, created_with_uv = _create_package_venv(
+            venv_dir, timeout=timeout, env=env
+        )
+        if created_with_uv:
+            uv = shutil.which("uv")
+            assert uv is not None
+            results.append(
+                _run(
+                    [uv, "pip", "install", "--python", str(python), package_spec],
+                    label=f"install {package_spec}",
+                    timeout=timeout,
+                    env=env,
+                )
+            )
+        else:
+            results.extend(
+                (
+                    _run(
+                        [str(python), "-m", "pip", "install", "--upgrade", "pip"],
+                        label="upgrade pip",
+                        timeout=timeout,
+                        env=env,
+                    ),
+                    _run(
+                        [str(python), "-m", "pip", "install", package_spec],
+                        label=f"install {package_spec}",
+                        timeout=timeout,
+                        env=env,
+                    ),
+                )
+            )
+        results.append(
+            _run(
+                [str(python), "-c", package_import_probe_script()],
+                label="package no-streamlit import",
+                timeout=timeout,
+                env=env,
+            )
+        )
+        results.extend(
+            _run(
+                [str(scripts_dir / command[0]), *command[1:]],
+                label=" ".join(command),
+                timeout=timeout,
+                env=env,
+            )
+            for command in HELP_COMMANDS
+        )
+        return results
+
+
+def _emit_results(results: Sequence[SmokeResult], *, json_output: bool) -> None:
+    payload = {
+        "status": "pass" if all(result.passed for result in results) else "fail",
+        "results": [asdict(result) | {"passed": result.passed} for result in results],
+    }
+    if json_output:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return
+    for result in results:
+        status = "PASS" if result.passed else "FAIL"
+        print(f"{status} {result.label}: {' '.join(result.command)}")
+        if not result.passed:
+            if result.stdout_tail:
+                print(result.stdout_tail)
+            if result.stderr_tail:
+                print(result.stderr_tail, file=sys.stderr)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Verify AGILAB headless CLI imports and command help paths."
+    )
+    parser.add_argument(
+        "--package-spec",
+        help="Install this package spec or wheel into a temporary venv before checking console scripts.",
+    )
+    parser.add_argument("--python", default=sys.executable)
+    parser.add_argument("--timeout", type=float, default=180.0)
+    parser.add_argument("--json", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    if args.package_spec:
+        results = run_package_smoke(package_spec=args.package_spec, timeout=args.timeout)
+    else:
+        results = run_source_smoke(python=args.python, timeout=args.timeout)
+    _emit_results(results, json_output=args.json)
+    return 0 if all(result.passed for result in results) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- make the adoption report recommend the headless first-proof command by default
- add a reusable headless CLI smoke tool for blocked-Streamlit source checks and minimal package installs
- align README and public docs so `--with-ui` is explicitly optional
- sync the public docs mirror to the canonical docs source

## Validation
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_adoption_report.py test/test_lab_run.py test/test_headless_cli_smoke.py test/test_public_demo_links.py test/test_audit_response_docs.py`
- `uv --preview-features extra-build-dependencies run python tools/headless_cli_smoke.py --package-spec . --timeout 300`
- `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp`
