### PR TITLE
fix(agent): harden MCP and read-side limits

### DIFF
--- a/src/agilab/agent_run.py
+++ b/src/agilab/agent_run.py
@@ -942,6 +942,9 @@ def find_agent_run_manifests(
 ) -> list[Path]:
     """Find agent-run manifest files, newest first."""
 
+    if limit is not None and limit < 0:
+        raise ValueError("limit must be non-negative")
+
     explicit_root = root is not None
     search_root = Path(root).expanduser() if explicit_root else _default_log_root() / "agents"
     if agent and not explicit_root:

--- a/src/agilab_mcp/server.py
+++ b/src/agilab_mcp/server.py
@@ -244,11 +244,11 @@ def call_tool(name: str, arguments: Mapping[str, Any]) -> dict[str, Any]:
 
 
 def _jsonrpc_response(
-    request_id: Any, result: Any = None, error: Any = None
+    request_id: Any, result: Any = None, error: Any = None, error_code: int = -32000
 ) -> dict[str, Any]:
     response = {"jsonrpc": "2.0", "id": request_id}
     if error is not None:
-        response["error"] = {"code": -32000, "message": str(error)}
+        response["error"] = {"code": error_code, "message": str(error)}
     else:
         response["result"] = result
     return response
@@ -256,6 +256,10 @@ def _jsonrpc_response(
 
 def handle_jsonrpc(payload: Mapping[str, Any]) -> dict[str, Any] | None:
     method = payload.get("method")
+    if "id" not in payload:
+        # JSON-RPC notifications never receive responses. The server currently
+        # has no notification side effects to perform.
+        return None
     request_id = payload.get("id")
     try:
         if method == "initialize":
@@ -295,7 +299,23 @@ def serve_stdio(stdin: Any = sys.stdin, stdout: Any = sys.stdout) -> int:
     for line in stdin:
         if not line.strip():
             continue
-        response = handle_jsonrpc(json.loads(line))
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError as exc:
+            response = _jsonrpc_response(
+                None,
+                error=f"Parse error: {exc.msg}",
+                error_code=-32700,
+            )
+        else:
+            if not isinstance(payload, Mapping):
+                response = _jsonrpc_response(
+                    None,
+                    error="Invalid request",
+                    error_code=-32600,
+                )
+            else:
+                response = handle_jsonrpc(payload)
         if response is not None:
             stdout.write(json.dumps(response, sort_keys=True) + "\n")
             stdout.flush()

--- a/test/test_agent_run.py
+++ b/test/test_agent_run.py
@@ -1148,3 +1148,20 @@ def test_agent_run_human_rendering_and_allow_failure(tmp_path: Path, capsys) -> 
     output = capsys.readouterr().out
     assert "status: fail" in output
     assert f"manifest: {tmp_path / 'agent_run_manifest.json'}" in output
+
+
+def test_agent_run_read_helpers_reject_negative_limit(tmp_path):
+    import pytest
+
+    from agilab.agent_run import (
+        agent_context_payload,
+        find_agent_run_manifests,
+        list_agent_runs,
+    )
+
+    with pytest.raises(ValueError, match="limit must be non-negative"):
+        find_agent_run_manifests(tmp_path, limit=-1)
+    with pytest.raises(ValueError, match="limit must be non-negative"):
+        list_agent_runs(tmp_path, limit=-1)
+    with pytest.raises(ValueError, match="limit must be non-negative"):
+        agent_context_payload(tmp_path, limit=-1)

--- a/test/test_audience_bridges.py
+++ b/test/test_audience_bridges.py
@@ -838,3 +838,24 @@ def test_tool_wrappers_forward_sys_argv(monkeypatch: pytest.MonkeyPatch) -> None
         ["export", "quarto", "--help"],
         ["export", "hf-space", "--project", "demo", "--output", "hf"],
     ]
+
+
+def test_mcp_stdio_reports_parse_errors_without_crashing():
+    import io
+    import json
+
+    from agilab_mcp.server import serve_stdio
+
+    stdout = io.StringIO()
+    assert serve_stdio(stdin=io.StringIO("{bad json}\n"), stdout=stdout) == 0
+    response = json.loads(stdout.getvalue())
+    assert response["id"] is None
+    assert response["error"]["code"] == -32700
+
+
+def test_mcp_jsonrpc_notifications_are_silent():
+    from agilab_mcp.server import handle_jsonrpc
+
+    assert handle_jsonrpc(
+        {"jsonrpc": "2.0", "method": "unsupported/notification"}
+    ) is None


### PR DESCRIPTION
## Summary
- return JSON-RPC parse/invalid-request errors instead of crashing MCP stdio
- silence JSON-RPC notifications without ids
- reject negative agent-run limits in the Python read-side API
- add focused regression coverage for these agent interface cases

## Validation
- local pre-push guard classification ran during push and skipped unrelated guards