### PR TITLE
feat(notebook): add agi-core context helper

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 231,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "4443fdba619ecd39c3899ba26ce933f0500052f1b90a437a2708e77fcd600faa",
+  "source_digest_sha256": "3da21917fbbae60ca331dbaddf908f5d092f67ca785ade932f8e65c53d3fba7a",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "4443fdba619ecd39c3899ba26ce933f0500052f1b90a437a2708e77fcd600faa"
+  "target_digest_sha256": "3da21917fbbae60ca331dbaddf908f5d092f67ca785ade932f8e65c53d3fba7a"
 }

--- a/docs/source/snippets/agi_core_mycode_minimal_app_env.py
+++ b/docs/source/snippets/agi_core_mycode_minimal_app_env.py
@@ -1,12 +1,9 @@
 from agi_cluster.agi_distributor import AGI
-from agilab.notebook_demo import (
-    notebook_app_env,
-    notebook_local_request,
-    notebook_log_root,
-)
+from agilab.notebook_demo import notebook_agi_core_context
 
 APP = "mycode_project"  # built-in MyCode example app
-app_env = notebook_app_env(APP, verbose=1)
-request = notebook_local_request()
-print("App:", app_env.app)
-print("Log root:", notebook_log_root(app_env))
+context = notebook_agi_core_context(APP, verbose=1)
+app_env = context.app_env
+request = context.request
+print("App:", context.app)
+print("Log root:", context.log_root)

--- a/src/agilab/notebook_demo.py
+++ b/src/agilab/notebook_demo.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import importlib.util
 from collections.abc import Mapping
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -22,6 +23,16 @@ DEFAULT_NOTEBOOK_APP = "mycode_project"
 DEFAULT_LOCAL_SCHEDULER = "127.0.0.1"
 DEFAULT_LOCAL_WORKERS = {DEFAULT_LOCAL_SCHEDULER: 1}
 DEFAULT_LOCAL_MODE = 0
+
+
+@dataclass(frozen=True)
+class NotebookAgiCoreContext:
+    """Visible notebook context for an ``AGI.run(...)`` core handoff."""
+
+    app: str
+    app_env: Any
+    request: Any
+    log_root: Path
 
 
 def _normalise_project_app(app: str | None) -> str:
@@ -214,6 +225,44 @@ def notebook_local_request(
     )
 
 
+def notebook_agi_core_context(
+    app: str | None = DEFAULT_NOTEBOOK_APP,
+    *,
+    apps_path: str | Path | None = None,
+    verbose: int = 0,
+    start: str | Path | None = None,
+    env_kwargs: Mapping[str, Any] | None = None,
+    scheduler: str = DEFAULT_LOCAL_SCHEDULER,
+    workers: Mapping[str, int] | None = None,
+    mode: int | list[int] | str | None = DEFAULT_LOCAL_MODE,
+    params: Mapping[str, Any] | None = None,
+    **app_params: Any,
+) -> NotebookAgiCoreContext:
+    """Create the compact notebook context while keeping ``AGI.run`` visible."""
+
+    project_app = _normalise_project_app(app)
+    app_env = notebook_app_env(
+        project_app,
+        apps_path=apps_path,
+        verbose=verbose,
+        start=start,
+        **dict(env_kwargs or {}),
+    )
+    request = notebook_local_request(
+        scheduler=scheduler,
+        workers=workers,
+        mode=mode,
+        params=params,
+        **app_params,
+    )
+    return NotebookAgiCoreContext(
+        app=project_app,
+        app_env=app_env,
+        request=request,
+        log_root=notebook_log_root(app_env),
+    )
+
+
 def _scheduler_from_request(request: Any | None, fallback: str | None) -> str:
     return str(fallback or getattr(request, "scheduler", None) or DEFAULT_LOCAL_SCHEDULER)
 
@@ -277,7 +326,9 @@ __all__ = [
     "DEFAULT_LOCAL_SCHEDULER",
     "DEFAULT_LOCAL_WORKERS",
     "DEFAULT_NOTEBOOK_APP",
+    "NotebookAgiCoreContext",
     "install_if_needed",
+    "notebook_agi_core_context",
     "notebook_app_env",
     "notebook_local_request",
     "notebook_log_root",

--- a/test/test_notebook_demo.py
+++ b/test/test_notebook_demo.py
@@ -164,6 +164,40 @@ def test_notebook_app_env_resolves_apps_path_and_returns_agi_env(monkeypatch, tm
     assert calls == [{"apps_path": builtin_root, "app": "mycode_project", "verbose": 1}]
 
 
+def test_notebook_agi_core_context_keeps_run_inputs_visible(monkeypatch, tmp_path: Path) -> None:
+    builtin_root = tmp_path / "apps" / "builtin"
+    _make_app(builtin_root)
+    monkeypatch.setattr(notebook_demo.Path, "home", staticmethod(lambda: tmp_path))
+
+    class FakeAgiEnv:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+            self.target = self.app.removesuffix("_project")
+
+    class FakeRunRequest:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    monkeypatch.setattr(notebook_demo, "_import_agi_env", lambda: FakeAgiEnv)
+    monkeypatch.setattr(notebook_demo, "_import_run_request", lambda: FakeRunRequest)
+
+    context = notebook_demo.notebook_agi_core_context(
+        "mycode",
+        apps_path=builtin_root,
+        verbose=1,
+        dataset="demo",
+    )
+
+    assert context.app == "mycode_project"
+    assert context.app_env.app == "mycode_project"
+    assert context.app_env.apps_path == builtin_root
+    assert context.request.scheduler == "127.0.0.1"
+    assert context.request.workers == {"127.0.0.1": 1}
+    assert context.request.mode == 0
+    assert context.request.params == {"dataset": "demo"}
+    assert context.log_root == tmp_path / "log" / "execute" / "mycode"
+
+
 @pytest.mark.asyncio
 async def test_install_if_needed_uses_request_defaults_without_hiding_agi_run(monkeypatch) -> None:
     calls = []


### PR DESCRIPTION
## Summary
- add NotebookAgiCoreContext and notebook_agi_core_context(...)
- keep install_if_needed(...) and AGI.run(...) visible in notebook snippets
- update the public docs mirror snippet and mirror stamp
- add focused helper coverage

## Validation
- pre-push guard classification ran during push
- no extra tests run