### PR TITLE
Add optional numba tail for polars worker

### DIFF
--- a/src/agilab/apps/builtin/execution_polars_project/src/execution_polars_worker/execution_polars_worker.py
+++ b/src/agilab/apps/builtin/execution_polars_project/src/execution_polars_worker/execution_polars_worker.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 import time
 
 import polars as pl
@@ -12,6 +13,116 @@ from agi_node.polars_worker import PolarsWorker
 from execution_polars.reduction import write_reduce_artifact
 
 _runtime: dict[str, object] = {}
+_TAIL_CHECKSUM_NUMBA_KERNEL: Any | None = None
+_TAIL_CHECKSUM_NUMBA_KERNEL_ATTEMPTED = False
+TAIL_KERNEL_RUNTIME_COLUMN = "tail_kernel_runtime"
+
+
+def _tail_checksum_scalar_py(
+    x_values,
+    y_values,
+    signal_values,
+    weight_values,
+    *,
+    pass_count: int,
+    sample_stride: int = 64,
+) -> float:
+    loop_passes = max(int(pass_count), 1) * 8
+    if sample_stride <= 0 or len(x_values) == 0:
+        return 0.0
+
+    checksum = 0.0
+    for idx in range(0, len(x_values), sample_stride):
+        value = float(x_values[idx]) + float(y_values[idx]) * 0.01
+        signal = float(signal_values[idx])
+        weight = float(weight_values[idx])
+        for _ in range(loop_passes):
+            value = abs((value * 1.0000007) + signal * 0.17 - weight * 0.03)
+        checksum += value
+    return checksum
+
+
+def _tail_checksum_numba_kernel_py(
+    x_values,
+    y_values,
+    signal_values,
+    weight_values,
+    pass_count: int,
+    sample_stride: int,
+) -> float:
+    loop_passes = max(int(pass_count), 1) * 8
+    if sample_stride <= 0 or x_values.shape[0] == 0:
+        return 0.0
+
+    checksum = 0.0
+    for idx in range(0, x_values.shape[0], sample_stride):
+        value = float(x_values[idx]) + float(y_values[idx]) * 0.01
+        signal = float(signal_values[idx])
+        weight = float(weight_values[idx])
+        for _ in range(loop_passes):
+            value = abs((value * 1.0000007) + signal * 0.17 - weight * 0.03)
+        checksum += value
+    return checksum
+
+
+def _get_tail_checksum_numba_kernel() -> Any | None:
+    global _TAIL_CHECKSUM_NUMBA_KERNEL, _TAIL_CHECKSUM_NUMBA_KERNEL_ATTEMPTED
+
+    if _TAIL_CHECKSUM_NUMBA_KERNEL_ATTEMPTED:
+        return _TAIL_CHECKSUM_NUMBA_KERNEL
+
+    _TAIL_CHECKSUM_NUMBA_KERNEL_ATTEMPTED = True
+    try:
+        from numba import njit  # type: ignore[import-not-found]
+    except Exception:
+        _TAIL_CHECKSUM_NUMBA_KERNEL = None
+        return None
+
+    try:
+        _TAIL_CHECKSUM_NUMBA_KERNEL = njit(cache=False)(_tail_checksum_numba_kernel_py)
+    except Exception:
+        _TAIL_CHECKSUM_NUMBA_KERNEL = None
+    return _TAIL_CHECKSUM_NUMBA_KERNEL
+
+
+def _series_to_float64_array(series: pl.Series) -> Any:
+    import numpy as np
+
+    return np.ascontiguousarray(series.to_numpy(), dtype=np.float64)
+
+
+def _tail_checksum_from_columns(
+    df: pl.DataFrame,
+    *,
+    pass_count: int,
+    sample_stride: int = 64,
+) -> tuple[float, str]:
+    global _TAIL_CHECKSUM_NUMBA_KERNEL
+
+    kernel = _get_tail_checksum_numba_kernel()
+    if kernel is not None:
+        try:
+            checksum = kernel(
+                _series_to_float64_array(df["x"]),
+                _series_to_float64_array(df["y"]),
+                _series_to_float64_array(df["signal"]),
+                _series_to_float64_array(df["weight"]),
+                max(int(pass_count), 1),
+                int(sample_stride),
+            )
+            return float(checksum), "numba"
+        except Exception:
+            _TAIL_CHECKSUM_NUMBA_KERNEL = None
+
+    checksum = _tail_checksum_scalar_py(
+        df["x"].to_list(),
+        df["y"].to_list(),
+        df["signal"].to_list(),
+        df["weight"].to_list(),
+        pass_count=pass_count,
+        sample_stride=sample_stride,
+    )
+    return checksum, "python"
 
 
 class ExecutionPolarsWorker(PolarsWorker):
@@ -55,20 +166,10 @@ class ExecutionPolarsWorker(PolarsWorker):
     def _python_tail_checksum(self, df: pl.DataFrame) -> float:
         """Add a small GIL-bound scalar tail so execution modes separate more clearly."""
         args = self._current_args()
-        loop_passes = max(int(getattr(args, "compute_passes", 1)), 1) * 8
-        sample_stride = 64
-        checksum = 0.0
-        x_values = df["x"].to_list()
-        y_values = df["y"].to_list()
-        signal_values = df["signal"].to_list()
-        weight_values = df["weight"].to_list()
-        for idx in range(0, len(x_values), sample_stride):
-            value = float(x_values[idx]) + float(y_values[idx]) * 0.01
-            signal = float(signal_values[idx])
-            weight = float(weight_values[idx])
-            for _ in range(loop_passes):
-                value = abs((value * 1.0000007) + signal * 0.17 - weight * 0.03)
-            checksum += value
+        checksum, _runtime_label = _tail_checksum_from_columns(
+            df,
+            pass_count=max(int(getattr(args, "compute_passes", 1)), 1),
+        )
         return checksum
 
     def works(self, workers_plan, workers_plan_metadata) -> float:
@@ -122,12 +223,16 @@ class ExecutionPolarsWorker(PolarsWorker):
                 "segment_weight": [1.00, 1.08, 1.14, 1.22],
             }
         )
-        python_tail_checksum = self._python_tail_checksum(df)
+        python_tail_checksum, tail_kernel_runtime = _tail_checksum_from_columns(
+            df,
+            pass_count=passes,
+        )
         agg = (
             agg.join(segment_weights, on="segment", how="left")
             .with_columns(
                 (pl.col("score_mean") * pl.col("segment_weight") * pl.col("row_count")).alias("weighted_score"),
                 pl.lit(python_tail_checksum).alias("python_tail_checksum"),
+                pl.lit(tail_kernel_runtime).alias(TAIL_KERNEL_RUNTIME_COLUMN),
                 pl.lit(source.name).alias("source_file"),
                 pl.lit("polars").alias("engine"),
                 pl.lit("threads").alias("execution_model"),

--- a/src/agilab/apps/builtin/execution_polars_project/test/test_execution_polars_project.py
+++ b/src/agilab/apps/builtin/execution_polars_project/test/test_execution_polars_project.py
@@ -6,6 +6,7 @@ import time
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
 import polars as pl
 
 from agi_node.reduction import ReduceArtifact
@@ -26,7 +27,14 @@ from execution_polars.reduction import (
     partial_from_result_frame,
     reduce_artifact_path,
 )
-from execution_polars_worker.execution_polars_worker import ExecutionPolarsWorker
+from execution_polars_worker import execution_polars_worker as worker_module
+from execution_polars_worker.execution_polars_worker import (
+    TAIL_KERNEL_RUNTIME_COLUMN,
+    ExecutionPolarsWorker,
+    _tail_checksum_from_columns,
+    _tail_checksum_numba_kernel_py,
+    _tail_checksum_scalar_py,
+)
 
 
 def _make_env(tmp_path: Path) -> SimpleNamespace:
@@ -70,7 +78,11 @@ def test_execution_polars_generates_dataset_and_distribution(tmp_path: Path) -> 
     assert "dir_path" not in manager.as_dict()
 
 
-def test_execution_polars_worker_processes_a_file(tmp_path: Path) -> None:
+def test_execution_polars_worker_processes_a_file(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(worker_module, "_get_tail_checksum_numba_kernel", lambda: None)
     env = _make_env(tmp_path)
     args = ExecutionPolarsArgs(n_partitions=1, nfile=1, rows_per_file=16, n_groups=4)
     manager = ExecutionPolars(env, args=args)
@@ -89,6 +101,101 @@ def test_execution_polars_worker_processes_a_file(tmp_path: Path) -> None:
     assert {"engine", "execution_model", "weighted_score", "python_tail_checksum", "source_file"} <= set(result.columns)
     assert set(result["engine"].to_list()) == {"polars"}
     assert set(result["execution_model"].to_list()) == {"threads"}
+    assert set(result[TAIL_KERNEL_RUNTIME_COLUMN].to_list()) == {"python"}
+
+
+def test_execution_polars_tail_checksum_matches_scalar_reference() -> None:
+    x_values = [1.5, 2.0, 3.5, 5.0, 8.0]
+    y_values = [0.2, 0.4, 0.6, 0.8, 1.0]
+    signal_values = [0.1, -0.2, 0.3, -0.4, 0.5]
+    weight_values = [1.0, 1.1, 1.2, 1.3, 1.4]
+    pass_count = 3
+    sample_stride = 2
+
+    expected = 0.0
+    for idx in range(0, len(x_values), sample_stride):
+        value = float(x_values[idx]) + float(y_values[idx]) * 0.01
+        signal = float(signal_values[idx])
+        weight = float(weight_values[idx])
+        for _ in range(pass_count * 8):
+            value = abs((value * 1.0000007) + signal * 0.17 - weight * 0.03)
+        expected += value
+
+    actual = _tail_checksum_scalar_py(
+        x_values,
+        y_values,
+        signal_values,
+        weight_values,
+        pass_count=pass_count,
+        sample_stride=sample_stride,
+    )
+
+    assert actual == expected
+
+
+def test_execution_polars_tail_checksum_uses_optional_numba_kernel(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    df = pl.DataFrame(
+        {
+            "x": [1.5, 2.0, 3.5, 5.0, 8.0],
+            "y": [0.2, 0.4, 0.6, 0.8, 1.0],
+            "signal": [0.1, -0.2, 0.3, -0.4, 0.5],
+            "weight": [1.0, 1.1, 1.2, 1.3, 1.4],
+        }
+    )
+    calls = {"count": 0}
+
+    def fake_kernel(*args):
+        calls["count"] += 1
+        return _tail_checksum_numba_kernel_py(*args)
+
+    monkeypatch.setattr(worker_module, "_get_tail_checksum_numba_kernel", lambda: fake_kernel)
+
+    checksum, runtime_label = _tail_checksum_from_columns(df, pass_count=3, sample_stride=2)
+    expected = _tail_checksum_scalar_py(
+        df["x"].to_list(),
+        df["y"].to_list(),
+        df["signal"].to_list(),
+        df["weight"].to_list(),
+        pass_count=3,
+        sample_stride=2,
+    )
+
+    assert checksum == expected
+    assert runtime_label == "numba"
+    assert calls["count"] == 1
+
+
+def test_execution_polars_tail_checksum_falls_back_after_kernel_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    df = pl.DataFrame(
+        {
+            "x": [1.5, 2.0, 3.5],
+            "y": [0.2, 0.4, 0.6],
+            "signal": [0.1, -0.2, 0.3],
+            "weight": [1.0, 1.1, 1.2],
+        }
+    )
+
+    def broken_kernel(*_args):
+        raise RuntimeError("numba kernel failed")
+
+    monkeypatch.setattr(worker_module, "_get_tail_checksum_numba_kernel", lambda: broken_kernel)
+
+    checksum, runtime_label = _tail_checksum_from_columns(df, pass_count=2, sample_stride=1)
+    expected = _tail_checksum_scalar_py(
+        df["x"].to_list(),
+        df["y"].to_list(),
+        df["signal"].to_list(),
+        df["weight"].to_list(),
+        pass_count=2,
+        sample_stride=1,
+    )
+
+    assert checksum == expected
+    assert runtime_label == "python"
 
 
 def test_execution_polars_reduce_contract_merges_result_partials(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add an optional cached `numba.njit` path for the Polars execution worker tail checksum
- keep `numba` optional with a Python fallback and no dependency manifest change
- expose `tail_kernel_runtime` in worker output so evidence can distinguish `python` and `numba`
- add tests for scalar parity, fake-numba execution, fallback after kernel failure, and worker output metadata

## Validation
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' src/agilab/apps/builtin/execution_polars_project/test/test_execution_polars_project.py`
- `uv --preview-features extra-build-dependencies run python -m py_compile src/agilab/apps/builtin/execution_polars_project/src/execution_polars_worker/execution_polars_worker.py src/agilab/apps/builtin/execution_polars_project/test/test_execution_polars_project.py`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files src/agilab/apps/builtin/execution_polars_project/src/execution_polars_worker/execution_polars_worker.py src/agilab/apps/builtin/execution_polars_project/test/test_execution_polars_project.py`
- `git diff --check`