### PR TITLE
perf(worker): reduce pandas typed-kernel allocations

### DIFF
--- a/src/agilab/apps/builtin/execution_pandas_project/src/execution_pandas_worker/execution_pandas_worker.py
+++ b/src/agilab/apps/builtin/execution_pandas_project/src/execution_pandas_worker/execution_pandas_worker.py
@@ -91,6 +91,22 @@ def _as_contiguous_float64(series: pd.Series) -> np.ndarray:
     return np.ascontiguousarray(series.to_numpy(dtype=np.float64, copy=False))
 
 
+def _fill_vectorized_score_array(
+    x_values: np.ndarray,
+    y_values: np.ndarray,
+    weighted_signal: np.ndarray,
+    *,
+    x_scale: float,
+    y_scale: float,
+    out: np.ndarray,
+) -> None:
+    """Fill one score output array with a low-allocation NumPy expression."""
+    np.multiply(x_values, x_scale, out=out)
+    out -= y_values * y_scale
+    out += weighted_signal
+    np.abs(out, out=out)
+
+
 def _tail_checksum_from_arrays(
     x_values: np.ndarray,
     y_values: np.ndarray,
@@ -180,14 +196,23 @@ class ExecutionPandasWorker(PandasWorker):
         score_0 = np.empty(len(df), dtype=np.float64)
         score_last = np.empty(len(df), dtype=np.float64)
         if not cython.compiled:
-            score_0[:] = np.abs(
-                (x_values * 1.3) - (y_values * 0.35) + (signal_values * weight_values)
+            weighted_signal = np.multiply(signal_values, weight_values)
+            _fill_vectorized_score_array(
+                x_values,
+                y_values,
+                weighted_signal,
+                x_scale=1.3,
+                y_scale=0.35,
+                out=score_0,
             )
             last_idx = passes - 1
-            score_last[:] = np.abs(
-                (x_values * (last_idx + 1.3))
-                - (y_values * (0.35 + last_idx * 0.05))
-                + (signal_values * weight_values)
+            _fill_vectorized_score_array(
+                x_values,
+                y_values,
+                weighted_signal,
+                x_scale=last_idx + 1.3,
+                y_scale=0.35 + last_idx * 0.05,
+                out=score_last,
             )
             checksum = _tail_checksum_from_arrays(
                 x_values,

--- a/src/agilab/apps/builtin/execution_pandas_project/test/test_execution_pandas_project.py
+++ b/src/agilab/apps/builtin/execution_pandas_project/test/test_execution_pandas_project.py
@@ -30,6 +30,7 @@ from execution_pandas.reduction import (
 )
 from execution_pandas_worker.execution_pandas_worker import (
     ExecutionPandasWorker,
+    _fill_vectorized_score_array,
     _tail_checksum_from_arrays,
 )
 
@@ -155,6 +156,27 @@ def test_execution_pandas_vectorized_tail_checksum_matches_scalar_reference() ->
     )
 
     assert actual == expected
+
+
+def test_execution_pandas_vectorized_score_fill_matches_reference() -> None:
+    x_values = np.asarray([1.5, -2.0, 3.5, 5.0], dtype=np.float64)
+    y_values = np.asarray([0.2, 0.4, -0.6, 0.8], dtype=np.float64)
+    signal_values = np.asarray([0.1, -0.2, 0.3, -0.4], dtype=np.float64)
+    weight_values = np.asarray([1.0, 1.1, 1.2, 1.3], dtype=np.float64)
+    weighted_signal = signal_values * weight_values
+    out = np.empty_like(x_values)
+
+    _fill_vectorized_score_array(
+        x_values,
+        y_values,
+        weighted_signal,
+        x_scale=2.3,
+        y_scale=0.45,
+        out=out,
+    )
+
+    expected = np.abs((x_values * 2.3) - (y_values * 0.45) + weighted_signal)
+    np.testing.assert_allclose(out, expected, rtol=0.0, atol=0.0)
 
 
 def test_execution_pandas_typed_kernel_matches_dataframe_scores(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary\n- factor the execution_pandas typed-numeric source fallback into a reusable low-allocation NumPy score fill helper\n- reuse precomputed weighted signal values for score_0 and score_last fills\n- add focused parity coverage for the vectorized score fill helper\n\n## Validation\n- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' src/agilab/apps/builtin/execution_pandas_project/test/test_execution_pandas_project.py::test_execution_pandas_vectorized_score_fill_matches_reference src/agilab/apps/builtin/execution_pandas_project/test/test_execution_pandas_project.py::test_execution_pandas_typed_kernel_matches_dataframe_scores src/agilab/apps/builtin/execution_pandas_project/test/test_execution_pandas_project.py::test_execution_pandas_worker_processes_a_file test/test_benchmark_execution_tools.py::test_cython_kernel_benchmark_uses_execution_pandas_worker_source test/test_benchmark_execution_tools.py::test_cython_kernel_benchmark_csv_rows_report_speedup test/test_benchmark_execution_tools.py::test_cython_kernel_benchmark_writes_lf_csv\n- uv --preview-features extra-build-dependencies run python tools/benchmark_execution_pandas_cython_kernel.py --rows 2000 --compute-passes 4 --repeats 1 --warmups 0