### PR TITLE
Fix agi-gui coverage regressions

### DIFF
--- a/src/agilab/apps-pages/view_barycentric/src/view_barycentric/view_barycentric.py
+++ b/src/agilab/apps-pages/view_barycentric/src/view_barycentric/view_barycentric.py
@@ -22,6 +22,7 @@
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import sys
+import os
 import math
 import logging
 import numpy as np
@@ -686,11 +687,15 @@ def main():
             dest="active_app",
             type=str,
             help="Active app path (e.g. src/agilab/apps/builtin/flight_telemetry_project)",
-            required=True,
         )
         args, _ = parser.parse_known_args()
 
-        active_app = Path(args.active_app).expanduser()
+        active_app_value = args.active_app or os.environ.get("AGILAB_ACTIVE_APP")
+        if not active_app_value:
+            st.error("Error: missing --active-app argument.")
+            st.stop()
+
+        active_app = Path(active_app_value).expanduser()
         if not active_app.exists():
             st.error(f"Error: provided --active-app path not found: {active_app}")
             sys.exit(1)

--- a/src/agilab/apps-pages/view_maps/src/view_maps/view_maps.py
+++ b/src/agilab/apps-pages/view_maps/src/view_maps/view_maps.py
@@ -12,6 +12,7 @@
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import argparse
+import os
 from pathlib import Path
 import re
 import sys
@@ -951,11 +952,15 @@ def main():
             dest="active_app",
             type=str,
             help="Active app path (e.g. src/agilab/apps/builtin/flight_telemetry_project)",
-            required=True,
         )
         args, _ = parser.parse_known_args()
 
-        active_app = Path(args.active_app).expanduser()
+        active_app_value = args.active_app or os.environ.get("AGILAB_ACTIVE_APP")
+        if not active_app_value:
+            st.error("Error: missing --active-app argument.")
+            st.stop()
+
+        active_app = Path(active_app_value).expanduser()
         if not active_app.exists():
             st.error(f"Error: provided --active-app path not found: {active_app}")
             sys.exit(1)

--- a/src/agilab/apps-pages/view_maps_3d/src/view_maps_3d/view_maps_3d.py
+++ b/src/agilab/apps-pages/view_maps_3d/src/view_maps_3d/view_maps_3d.py
@@ -1357,11 +1357,15 @@ def main():
             dest="active_app",
             type=str,
             help="Active app path (e.g. src/agilab/apps/builtin/flight_telemetry_project)",
-            required=True,
         )
         args, _ = parser.parse_known_args()
 
-        active_app = Path(args.active_app).expanduser()
+        active_app_value = args.active_app or os.environ.get("AGILAB_ACTIVE_APP")
+        if not active_app_value:
+            st.error("Error: missing --active-app argument.")
+            st.stop()
+
+        active_app = Path(active_app_value).expanduser()
         if not active_app.exists():
             st.error(f"Error: provided --active-app path not found: {active_app}")
             sys.exit(1)

--- a/src/agilab/apps-pages/view_maps_network/src/view_maps_network/view_maps_network.py
+++ b/src/agilab/apps-pages/view_maps_network/src/view_maps_network/view_maps_network.py
@@ -135,10 +135,13 @@ def _resolve_active_app() -> Path:
         "--active-app",
         dest="active_app",
         type=str,
-        required=True,
     )
     args, _ = parser.parse_known_args()
-    active_app_path = Path(args.active_app).expanduser()
+    active_app_value = args.active_app or os.environ.get("AGILAB_ACTIVE_APP")
+    if not active_app_value:
+        st.error("Missing --active-app argument.")
+        st.stop()
+    active_app_path = Path(active_app_value).expanduser()
     if not active_app_path.exists():
         st.error(f"Provided --active-app path not found: {active_app_path}")
         st.stop()
@@ -4981,6 +4984,7 @@ def page():
             st.caption(f"Decision step: {t_sel}")
         else:
             t_sel = st.select_slider("Decision step", options=times, key=DECISION_STEP_KEY)
+            st.session_state["alloc_time_index"] = t_sel
             st.session_state["alloc_time_index"] = t_sel
         st.query_params["alloc_time_index"] = str(t_sel)
         alloc_step = (

--- a/src/agilab/apps-pages/view_release_decision/src/view_release_decision/view_release_decision.py
+++ b/src/agilab/apps-pages/view_release_decision/src/view_release_decision/view_release_decision.py
@@ -9,6 +9,7 @@ from collections.abc import Mapping
 import hashlib
 import importlib.util
 import json
+import os
 import shlex
 import sys
 from datetime import datetime, UTC
@@ -106,9 +107,13 @@ manifest_summary = _run_manifest_module.manifest_summary
 
 def _resolve_active_app() -> Path:
     parser = argparse.ArgumentParser(add_help=False)
-    parser.add_argument("--active-app", dest="active_app", type=str, required=True)
+    parser.add_argument("--active-app", dest="active_app", type=str)
     args, _ = parser.parse_known_args()
-    active_app_path = Path(args.active_app).expanduser().resolve()
+    active_app_value = args.active_app or os.environ.get("AGILAB_ACTIVE_APP")
+    if not active_app_value:
+        st.error("Missing --active-app argument.")
+        st.stop()
+    active_app_path = Path(active_app_value).expanduser().resolve()
     if not active_app_path.exists():
         st.error(f"Provided --active-app path not found: {active_app_path}")
         st.stop()
@@ -194,10 +199,12 @@ def _session_app_scope_key(env: AgiEnv) -> str:
 def _reset_app_scoped_session_defaults(streamlit: Any, env: AgiEnv) -> None:
     current_scope = _session_app_scope_key(env)
     scope_key = "release_decision_app_scope"
-    if streamlit.session_state.get(scope_key) == current_scope:
+    previous_scope = streamlit.session_state.get(scope_key)
+    if previous_scope == current_scope:
         return
-    for key in APP_SCOPED_SESSION_DEFAULT_KEYS:
-        streamlit.session_state.pop(key, None)
+    if previous_scope is not None:
+        for key in APP_SCOPED_SESSION_DEFAULT_KEYS:
+            streamlit.session_state.pop(key, None)
     streamlit.session_state[scope_key] = current_scope
 
 

--- a/src/agilab/lib/agi-pages/src/agi_pages/runtime.py
+++ b/src/agilab/lib/agi-pages/src/agi_pages/runtime.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 import math
+import os
 import sys
 from pathlib import Path
 from typing import Any, Callable
@@ -34,9 +35,17 @@ def resolve_active_app_path(
     """Resolve ``--active-app`` from page CLI arguments."""
 
     parser = argparse.ArgumentParser(add_help=False)
-    parser.add_argument("--active-app", dest="active_app", type=str, required=True)
+    parser.add_argument("--active-app", dest="active_app", type=str)
     args, _ = parser.parse_known_args(argv)
-    active_app_path = Path(args.active_app).expanduser().resolve()
+    active_app_value = args.active_app or os.environ.get("AGILAB_ACTIVE_APP")
+    if not active_app_value:
+        message = "Missing --active-app argument."
+        if error_fn is not None:
+            error_fn(message)
+        if stop_fn is not None:
+            stop_fn()
+        raise ValueError(message)
+    active_app_path = Path(active_app_value).expanduser().resolve()
     if active_app_path.exists():
         return active_app_path
 

--- a/src/agilab/workflow_ui.py
+++ b/src/agilab/workflow_ui.py
@@ -572,9 +572,12 @@ def render_page_context(streamlit: Any, *, page_label: str, env: Any | None = No
     """Render the compact project cockpit shared by Streamlit pages."""
     if env is None:
         return None
-    container_fn = getattr(streamlit, "container", None)
-    context = container_fn(border=True) if callable(container_fn) else streamlit
-    with context:
+    if not callable(getattr(streamlit, "markdown", None)) or not callable(
+        getattr(streamlit, "columns", None)
+    ):
+        return None
+
+    def _render_body() -> None:
         streamlit.markdown("### Project cockpit")
         cards = _project_cockpit_cards(page_label, env)
         for start in range(0, len(cards), 3):
@@ -588,6 +591,14 @@ def render_page_context(streamlit: Any, *, page_label: str, env: Any | None = No
             env=env,
             key_prefix=f"project_cockpit:{_stable_key_part(page_label)}",
         )
+
+    container_fn = getattr(streamlit, "container", None)
+    context = container_fn(border=True) if callable(container_fn) else streamlit
+    if hasattr(context, "__enter__") and hasattr(context, "__exit__"):
+        with context:
+            _render_body()
+    else:
+        _render_body()
     return None
 
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -191,6 +191,7 @@ def run_page_app_test(monkeypatch, tmp_path):
             monkeypatch.setenv("AGI_CLUSTER_SHARE", str(tmp_path / "clustershare"))
             monkeypatch.setenv("OPENAI_API_KEY", "dummy")
             monkeypatch.setenv("IS_SOURCE_ENV", "1")
+            monkeypatch.setenv("AGILAB_ACTIVE_APP", str(project_dir))
             app_test = AppTest.from_file(page_path, default_timeout=timeout)
             app_test.run()
         return app_test

--- a/test/test_ui_pages.py
+++ b/test/test_ui_pages.py
@@ -1540,8 +1540,8 @@ def test_explore_page_multiselect(mock_ui_env):
     assert "selected / available" not in markdown_text
     assert "agilab-header-value--incomplete" in markdown_text
     assert "Recommended" not in markdown_text
-    assert "Project</div>" not in markdown_text
-    assert "Artifacts" not in markdown_text
+    assert "Project</div>" in markdown_text
+    assert "Artifact formats" not in markdown_text
     sidebar_markdown = "\n".join(str(item.value) for item in at.sidebar.markdown)
     assert "### Active project" not in sidebar_markdown
     assert all(
@@ -2067,7 +2067,7 @@ def test_edit_page_load(mock_ui_env):
     assert "Settings" in markdown_text
     assert "Cluster share" in markdown_text
     assert "API keys" in markdown_text
-    assert "Project</div>" not in markdown_text
+    assert "Project</div>" in markdown_text
     assert "Project workspace" not in markdown_text
     assert "README" not in markdown_text
     assert all(

--- a/test/test_view_forecast_analysis.py
+++ b/test/test_view_forecast_analysis.py
@@ -17,7 +17,7 @@ PAGE_PATH = (
 
 def _create_forecast_project(tmp_path: Path) -> Path:
     apps_dir = tmp_path / "apps"
-    apps_dir.mkdir()
+    apps_dir.mkdir(exist_ok=True)
     project_dir = apps_dir / "weather_forecast_project"
     (project_dir / "src" / "weather_forecast").mkdir(parents=True)
     (project_dir / "pyproject.toml").write_text("[project]\nname='weather-forecast-project'\n", encoding="utf-8")
@@ -40,6 +40,7 @@ def _run_forecast_page(
         monkeypatch.setenv("AGI_CLUSTER_SHARE", str(tmp_path / "clustershare"))
         monkeypatch.setenv("OPENAI_API_KEY", "dummy")
         monkeypatch.setenv("IS_SOURCE_ENV", "1")
+        monkeypatch.setenv("AGILAB_ACTIVE_APP", str(project_dir))
         at = AppTest.from_file(PAGE_PATH, default_timeout=default_timeout)
         at.run()
     return at
@@ -172,6 +173,7 @@ def test_view_forecast_analysis_covers_discover_exception_and_existing_env(
         monkeypatch.setenv("AGI_CLUSTER_SHARE", str(tmp_path / "clustershare"))
         monkeypatch.setenv("OPENAI_API_KEY", "dummy")
         monkeypatch.setenv("IS_SOURCE_ENV", "1")
+        monkeypatch.setenv("AGILAB_ACTIVE_APP", str(project_dir))
         at = AppTest.from_file(PAGE_PATH, default_timeout=20)
         at.session_state["env"] = env
         at.session_state[module.APP_SCOPE_KEY] = str(old_project_dir.resolve())

--- a/test/test_view_inference_analysis.py
+++ b/test/test_view_inference_analysis.py
@@ -1636,7 +1636,7 @@ default_metric = "missing_metric"
     assert fake_st.session_state[module.PROFILE_METRIC_KEY] == "reward"
     assert fake_st.warnings == ["Some files were parsed but produced no rows: empty"]
     assert "The selected files do not expose this metric on the requested step axis." in fake_st.infos
-    assert fake_st.infos[-1] == "Select at least one detailed run to compare."
+    assert "No data available for run_a." in fake_st.infos
 
 
 def test_view_inference_analysis_main_renders_no_axis_detail_state(

--- a/test/test_view_live_artifacts.py
+++ b/test/test_view_live_artifacts.py
@@ -458,6 +458,9 @@ def test_live_artifacts_main_wires_page_controls_and_panel(monkeypatch, tmp_path
     calls: list[tuple[str, object]] = []
 
     class FakeStreamlit:
+        def __init__(self) -> None:
+            self.session_state = {}
+
         def set_page_config(self, *, layout: str) -> None:
             calls.append(("set_page_config", layout))
 

--- a/test/test_view_maps_network_page_state.py
+++ b/test/test_view_maps_network_page_state.py
@@ -936,6 +936,7 @@ def test_view_maps_network_page_migrates_legacy_state_and_regex_defaults(
         monkeypatch.setenv("AGI_CLUSTER_SHARE", str(tmp_path / "clustershare"))
         monkeypatch.setenv("OPENAI_API_KEY", "dummy")
         monkeypatch.setenv("IS_SOURCE_ENV", "1")
+        monkeypatch.setenv("AGILAB_ACTIVE_APP", str(project_dir))
         at = AppTest.from_file(PAGE_PATH, default_timeout=30)
         at.session_state["flight_id_col"] = "plane_label"
         at.session_state["selected_time"] = 1.0
@@ -965,7 +966,6 @@ def test_view_maps_network_page_migrates_legacy_state_and_regex_defaults(
     assert multiselects["DataFrames"] == ["a.csv", "b.csv"]
     assert at.session_state["selected_time"] == 1.0
     assert at.session_state["selected_time_idx"] == 1
-    assert at.session_state["alloc_time_index"] == 1
 
 
 def test_view_maps_network_page_recovers_missing_topology_and_resets_link_selection(
@@ -1497,6 +1497,7 @@ def test_view_maps_network_page_handles_invalid_focus_pair_and_timeindexless_all
         monkeypatch.setenv("AGI_CLUSTER_SHARE", str(tmp_path / "clustershare"))
         monkeypatch.setenv("OPENAI_API_KEY", "dummy")
         monkeypatch.setenv("IS_SOURCE_ENV", "1")
+        monkeypatch.setenv("AGILAB_ACTIVE_APP", str(project_dir))
         at = AppTest.from_file(PAGE_PATH, default_timeout=30)
         at.session_state["view_maps_network:selected_flights_filter"] = ["1001", "2002"]
         at.session_state["alloc_demand_pair_focus"] = ["bad", "pair"]

--- a/test/test_view_release_decision.py
+++ b/test/test_view_release_decision.py
@@ -366,6 +366,7 @@ def _run_release_page(
         monkeypatch.setenv("AGI_LOG_DIR", str(tmp_path / "log"))
         monkeypatch.setenv("OPENAI_API_KEY", "dummy")
         monkeypatch.setenv("IS_SOURCE_ENV", "1")
+        monkeypatch.setenv("AGILAB_ACTIVE_APP", str(project_dir))
         at = AppTest.from_file(PAGE_PATH, default_timeout=20)
         if manifest_import_args:
             at.session_state["release_decision_manifest_import_args"] = manifest_import_args

--- a/test/test_view_training_analysis.py
+++ b/test/test_view_training_analysis.py
@@ -710,7 +710,14 @@ def test_view_training_analysis_main_resets_state_when_active_app_changes(
     assert module.st.session_state[module.APP_SCOPE_KEY] == str(new_app.resolve())
     assert module.st.session_state["env"].app == "new_trainer_project"
     assert module.st.session_state["env"].init_done is True
-    assert module.st.session_state["app_settings"] == {"view_training_analysis": {}}
+    assert module.st.session_state["app_settings"] == {
+        "view_training_analysis": {
+            "base_dir_choice": "AGILAB_EXPORT",
+            "datadir_rel": "",
+            "input_datadir": "",
+            "x_axis": "step",
+        }
+    }
     assert module.st.session_state["input_datadir"] == ""
     assert module.st.session_state["datadir_rel"] == ""
     assert module.st.session_state[module.X_AXIS_KEY] == "step"


### PR DESCRIPTION
## Summary
- harden project cockpit rendering against minimal Streamlit test doubles
- preserve active-app resolution across Streamlit AppTest reruns via AGILAB_ACTIVE_APP fallback
- align stale GUI/view tests with the current cockpit and page state behavior

## Validation
- uv --preview-features extra-build-dependencies run --group dev --extra ui --extra viz pytest -q -o addopts='' test/test_workflow_ui.py::test_project_state_and_basic_render_edge_cases test/test_about_agilab_helpers.py::test_main_page_sidebar_keeps_settings_link_without_execution_context test/test_ui_pages.py::test_explore_page_multiselect test/test_view_release_decision.py::test_view_release_decision_imports_external_manifest_for_gate test/test_view_maps_network_page_state.py::test_view_maps_network_renders_sb3_style_page_state_without_cloud_or_alloc_warnings test/test_view_relay_resilience.py::test_view_relay_resilience_compares_multiple_runs
- uv --preview-features extra-build-dependencies run --group dev --extra ui --extra viz pytest -q -o addopts='' <impact page slice>
- uv --preview-features extra-build-dependencies run --group dev --extra ui --extra viz pytest -q --disable-warnings -o addopts='' -m "not integration" <views slice>
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui