### PR TITLE
Fix source worker build overlays

### DIFF
--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_build_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_build_support.py
@@ -429,6 +429,15 @@ def _core_install_commands(*, env: Any, uv: str, app_path_arg: str) -> list[str]
     return commands
 
 
+def _build_run_overlay_args(env: Any) -> str:
+    args = ["--with setuptools", "--with cython"]
+    if getattr(env, "is_source_env", False):
+        for source_path in (getattr(env, "agi_env", None), getattr(env, "agi_node", None)):
+            if source_path:
+                args.append(f"--with-editable {quote(str(source_path))}")
+    return " ".join(args)
+
+
 def _build_module_command(env: Any) -> str:
     if getattr(env, "is_source_env", False):
         agi_node_root = getattr(env, "agi_node", None)
@@ -466,19 +475,36 @@ def _stage_worker_build_project(
     validate_worker_uv_sources_fn(worker_pyproject_dest)
 
 
-def _bdist_egg_command(*, uv: str, module_cmd: str, app_path_arg: str, packages: str, wenv_arg: str, verbose: int) -> str:
+def _bdist_egg_command(
+    *,
+    uv: str,
+    module_cmd: str,
+    app_path_arg: str,
+    packages: str,
+    wenv_arg: str,
+    verbose: int,
+    build_overlay_args: str = "--with setuptools --with cython",
+) -> str:
     quiet_flag = "" if verbose > 1 else "-q "
     return (
-        f"{uv} --project {app_path_arg} run --no-sync --with setuptools --with cython "
+        f"{uv} --project {app_path_arg} run --no-sync {build_overlay_args} "
         f"{module_cmd} --app-path {app_path_arg} {quiet_flag}"
         f"bdist_egg --packages \"{packages}\" -d {wenv_arg}"
     )
 
 
-def _build_ext_command(*, uv: str, module_cmd: str, app_path_arg: str, wenv_arg: str, verbose: int) -> str:
+def _build_ext_command(
+    *,
+    uv: str,
+    module_cmd: str,
+    app_path_arg: str,
+    wenv_arg: str,
+    verbose: int,
+    build_overlay_args: str = "--with setuptools --with cython",
+) -> str:
     quiet_flag = "" if verbose > 1 else "-q "
     return (
-        f"{uv} --project {app_path_arg} run --no-sync --with setuptools --with cython "
+        f"{uv} --project {app_path_arg} run --no-sync {build_overlay_args} "
         f"{module_cmd} --app-path {app_path_arg} {quiet_flag}build_ext -b {wenv_arg}"
     )
 
@@ -532,6 +558,7 @@ async def build_lib_local(
     app_path_arg = f"\"{app_path}\""
     wenv_arg = f"\"{wenv_abs}\""
     core_install_commands = _core_install_commands(env=env, uv=uv, app_path_arg=app_path_arg)
+    build_overlay_args = _build_run_overlay_args(env)
 
     _stage_worker_build_project(
         agi_cls,
@@ -575,6 +602,7 @@ async def build_lib_local(
         packages=packages,
         wenv_arg=wenv_arg,
         verbose=env.verbose,
+        build_overlay_args=build_overlay_args,
     )
     await run_fn(cmd, app_path)
 
@@ -587,6 +615,7 @@ async def build_lib_local(
             app_path_arg=app_path_arg,
             wenv_arg=wenv_arg,
             verbose=env.verbose,
+            build_overlay_args=build_overlay_args,
         )
         res = await run_fn(cmd, app_path)
         _copy_cython_worker_lib(

--- a/src/agilab/core/test/test_agi_distributor_deployment_build_support.py
+++ b/src/agilab/core/test/test_agi_distributor_deployment_build_support.py
@@ -158,6 +158,21 @@ def test_worker_build_commands_keep_overlay_without_quiet_flag_when_verbose():
     assert " -q " not in f" {build_ext_cmd} "
 
 
+def test_source_worker_build_overlay_includes_editable_core_projects(tmp_path):
+    env = SimpleNamespace(
+        is_source_env=True,
+        agi_env=tmp_path / "core" / "agi-env",
+        agi_node=tmp_path / "core" / "agi-node",
+    )
+
+    overlay = deployment_build_support._build_run_overlay_args(env)
+
+    assert "--with setuptools" in overlay
+    assert "--with cython" in overlay
+    assert f"--with-editable {env.agi_env}" in overlay
+    assert f"--with-editable {env.agi_node}" in overlay
+
+
 def test_worker_pyproject_source_missing_raises(tmp_path):
     env = SimpleNamespace(
         worker_pyproject=tmp_path / "missing_worker.toml",
@@ -500,6 +515,10 @@ async def test_build_lib_local_uses_editable_core_installs_in_source_env(monkeyp
         in cmd
         for cmd, _ in commands
     )
+    assert any(
+        f"--with-editable {env.agi_env}" in cmd and f"--with-editable {env.agi_node}" in cmd
+        for cmd, _ in commands
+    )
 
 
 @pytest.mark.asyncio
@@ -542,6 +561,10 @@ async def test_build_lib_local_uses_uv_index_url_mirror_when_internet_disabled(
             f"-e '{env.agi_env}' -e '{env.agi_node}'"
         )
         in cmd
+        for cmd, _ in commands
+    )
+    assert any(
+        f"--with-editable {env.agi_env}" in cmd and f"--with-editable {env.agi_node}" in cmd
         for cmd, _ in commands
     )
 


### PR DESCRIPTION
## Summary
- add a worker build run overlay helper for required build tools
- include editable local agi-env and agi-node overlays when building from a source checkout
- cover source-env worker build commands with regression assertions

## Validation
- uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_build_support.py
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' src/agilab/core/test/test_agi_distributor_deployment_build_support.py
- uv --preview-features extra-build-dependencies run --no-sync pytest -q -o addopts='' src/agilab/core/test