### PR TITLE
[codex] add changelog accuracy guardrail

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,15 @@ Use this runbook whenever you:
   run manifests, notebook export manifests, artifact hashes, UI robot evidence,
   SBOM / `pip-audit` / provenance, release proof, and verifier/replay contracts.
   Keep claims honest; do not present roadmap items as shipped features.
+- **Changelog accuracy**: Treat `CHANGELOG.md` as release evidence, not a
+  release-script dumping ground. Before a release or any changelog edit, compare
+  `## Unreleased`, the target release section, `git log <previous-tag>..HEAD`,
+  and the public evidence state for PyPI, GitHub Releases, docs, and Hugging Face.
+  Move only shipped, user-visible changes into the dated release section, keep
+  unfinished or unverified work under `Unreleased`, and do not claim publication
+  until the public evidence exists. If a release workflow fails and is recovered,
+  record the final successful workflow or repair evidence, not the failed attempt,
+  then rerun the release-proof check before closing the task.
 - **Current-code planning guardrail**: Before answering "next move", "ready for release",
   "release it", "sync HF", or any operational sequencing question, inspect the current
   repository state and the authoritative workflow/tooling files instead of relying on memory.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ publication, or evidence refreshes on an already published date version.
 
 ### Changed
 
+- Added a changelog accuracy guardrail so release notes are checked against Git
+  history, unreleased work, and public release evidence before claiming shipped
+  changes.
 - Added route-selection tables to the GitHub and PyPI READMEs so adopters can
   choose between hosted preview, source-checkout proof, package install,
   external app updates, and contribution paths.


### PR DESCRIPTION
## Summary

Adds a durable changelog accuracy rule to `AGENTS.md` so future release notes are checked against `Unreleased`, the target release section, git history, and public release evidence before claiming shipped changes.

Also records the process change in `CHANGELOG.md` under `Unreleased`.

## Validation

- `git diff --check`
- `git diff --check HEAD~1..HEAD`
- Local pre-push guard classified docs mirror, release-proof, and app-contract inputs as unchanged and skipped those unaffected guards.