### PR TITLE
Require cluster worker discovery before recovery

### DIFF
--- a/.claude/skills/agilab-runbook/SKILL.md
+++ b/.claude/skills/agilab-runbook/SKILL.md
@@ -328,6 +328,10 @@ Use this skill when you need repo-specific “how we do things” guidance in `a
 - Missing import: check both manager and worker `pyproject.toml` scopes (`src/agilab/apps/<app>/pyproject.toml` and `src/agilab/apps/<app>/src/<app>_worker/pyproject.toml`).
 - Installer pip issue: run `uv --preview-features extra-build-dependencies run python -m ensurepip --upgrade` once in the target venv.
 - Cluster inventory/status mismatch:
+  - Start with fresh discovery, not remembered LAN addresses:
+    `uv --preview-features extra-build-dependencies run --no-sync python tools/cluster_flight_validation.py --discover-lan --remote-user <user> --json --no-discovery-cache`.
+    Treat nodes with `status="no-ssh-port"` or missing ARP as stale candidates;
+    do not use them for validation until a fresh SSH probe succeeds.
   - If the UI shows a worker as unreachable but `ssh <user>@<ip> 'echo ok'` works,
     reproduce the exact non-interactive probe path used by AGILAB before changing UI
     display code.
@@ -339,6 +343,8 @@ Use this skill when you need repo-specific “how we do things” guidance in `a
   - Treat a display of "+ 1 worker unreachable" as an inventory/probe failure until the
     exact probe command succeeds; a bare SSH success only proves authentication.
 - For a reinstalled cluster node, separate host-key repair from auth repair:
+  - rediscover the worker IP first; examples must use `<ip>` placeholders, not
+    LAN addresses remembered from an earlier session
   - host key changed:
     - `ssh-keygen -R <ip>`
     - `ssh-keyscan -H -t ed25519 <ip> >> ~/.ssh/known_hosts`

--- a/.claude/skills/agilab-testing/SKILL.md
+++ b/.claude/skills/agilab-testing/SKILL.md
@@ -76,6 +76,12 @@ Use this skill when validating changes.
     tests that stub `AgiEnv.logger` must not leak that stub into later tests that expect the full
     logger API.
 - Cluster/share regressions:
+  - For live cluster validation, never assume a worker IP from memory or a prior
+    run. Run the official no-cache LAN discovery first and use only a fresh
+    `ready`/SSH-open worker candidate:
+    `uv --preview-features extra-build-dependencies run --no-sync python tools/cluster_flight_validation.py --discover-lan --remote-user <user> --json --no-discovery-cache`.
+    If discovery reports a remembered host as `no-ssh-port`, treat that host as
+    stale and pick the current ready node instead.
   - Keep explicit regressions for “cluster share missing”, “cluster share equals local share”, and
     “no silent fallback to localshare”.
   - For scheduler/worker inventory UI, cover mixed-node summaries: local scheduler

--- a/.codex/skills/agilab-runbook/SKILL.md
+++ b/.codex/skills/agilab-runbook/SKILL.md
@@ -328,6 +328,10 @@ Use this skill when you need repo-specific “how we do things” guidance in `a
 - Missing import: check both manager and worker `pyproject.toml` scopes (`src/agilab/apps/<app>/pyproject.toml` and `src/agilab/apps/<app>/src/<app>_worker/pyproject.toml`).
 - Installer pip issue: run `uv --preview-features extra-build-dependencies run python -m ensurepip --upgrade` once in the target venv.
 - Cluster inventory/status mismatch:
+  - Start with fresh discovery, not remembered LAN addresses:
+    `uv --preview-features extra-build-dependencies run --no-sync python tools/cluster_flight_validation.py --discover-lan --remote-user <user> --json --no-discovery-cache`.
+    Treat nodes with `status="no-ssh-port"` or missing ARP as stale candidates;
+    do not use them for validation until a fresh SSH probe succeeds.
   - If the UI shows a worker as unreachable but `ssh <user>@<ip> 'echo ok'` works,
     reproduce the exact non-interactive probe path used by AGILAB before changing UI
     display code.
@@ -339,6 +343,8 @@ Use this skill when you need repo-specific “how we do things” guidance in `a
   - Treat a display of "+ 1 worker unreachable" as an inventory/probe failure until the
     exact probe command succeeds; a bare SSH success only proves authentication.
 - For a reinstalled cluster node, separate host-key repair from auth repair:
+  - rediscover the worker IP first; examples must use `<ip>` placeholders, not
+    LAN addresses remembered from an earlier session
   - host key changed:
     - `ssh-keygen -R <ip>`
     - `ssh-keyscan -H -t ed25519 <ip> >> ~/.ssh/known_hosts`

--- a/.codex/skills/agilab-testing/SKILL.md
+++ b/.codex/skills/agilab-testing/SKILL.md
@@ -76,6 +76,12 @@ Use this skill when validating changes.
     tests that stub `AgiEnv.logger` must not leak that stub into later tests that expect the full
     logger API.
 - Cluster/share regressions:
+  - For live cluster validation, never assume a worker IP from memory or a prior
+    run. Run the official no-cache LAN discovery first and use only a fresh
+    `ready`/SSH-open worker candidate:
+    `uv --preview-features extra-build-dependencies run --no-sync python tools/cluster_flight_validation.py --discover-lan --remote-user <user> --json --no-discovery-cache`.
+    If discovery reports a remembered host as `no-ssh-port`, treat that host as
+    stale and pick the current ready node instead.
   - Keep explicit regressions for “cluster share missing”, “cluster share equals local share”, and
     “no silent fallback to localshare”.
   - For scheduler/worker inventory UI, cover mixed-node summaries: local scheduler

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -383,20 +383,40 @@ Use this runbook whenever you:
 
 ### 4. Cluster SSH recovery after node reinstall or host-key rotation
 
-Use this when a cluster node such as `192.168.20.130` was reinstalled, got a new SSH host key,
-or lost its `~/.ssh` state.
+Use this when a cluster node was reinstalled, got a new SSH host key, or lost
+its `~/.ssh` state.
+
+Before touching SSH state, rediscover the worker. Do not reuse a remembered
+worker IP from a previous session:
+
+```bash
+uv --preview-features extra-build-dependencies run --no-sync python tools/cluster_flight_validation.py \
+  --discover-lan \
+  --remote-user "<worker-user>" \
+  --json \
+  --no-discovery-cache
+```
+
+Pick a node whose discovery status is `ready` or whose SSH port is open, then
+set the concrete values for the rest of the recovery:
+
+```bash
+worker_user="<worker-user>"
+worker_ip="<discovered-worker-ip>"
+manager_user="<manager-user>"
+manager_ip="<manager-ip>"
+```
 
 1. Verify the new host key fingerprint out of band before trusting it.
 2. Remove the stale host key locally, then register the new one:
    ```bash
-   ssh-keygen -R 192.168.20.130
-   ssh-keyscan -H -t ed25519 192.168.20.130 >> ~/.ssh/known_hosts
-   ssh-keygen -F 192.168.20.130 -f ~/.ssh/known_hosts
+   ssh-keygen -R "$worker_ip"
+   ssh-keyscan -H -t ed25519 "$worker_ip" >> ~/.ssh/known_hosts
+   ssh-keygen -F "$worker_ip" -f ~/.ssh/known_hosts
    ```
 3. Re-bootstrap user auth on the remote node. Preferred path: copy the manager public key:
    ```bash
-   worker_user="<worker-user>"
-   ssh-copy-id "$worker_user@192.168.20.130"
+   ssh-copy-id "$worker_user@$worker_ip"
    ```
    If `ssh-copy-id` is unavailable, append the public key manually on the remote:
    ```bash
@@ -412,12 +432,10 @@ or lost its `~/.ssh` state.
    Expected: `PubkeyAuthentication yes`. Password auth can stay enabled as a bootstrap fallback only.
 5. Verify access before rerunning AGILAB:
    ```bash
-   worker_user="<worker-user>"
-   ssh "$worker_user@192.168.20.130" 'echo ok'
+   ssh "$worker_user@$worker_ip" 'echo ok'
    ```
 6. Recreate cluster-share prerequisites on the reinstalled Linux node:
    ```bash
-   worker_user="<worker-user>"
    worker_home="/home/$worker_user"
    mkdir -p "$worker_home/.agilab" "$worker_home/clustershare" "$worker_home/localshare"
    cat > "$worker_home/.agilab/.env" <<EOF
@@ -425,22 +443,18 @@ or lost its `~/.ssh` state.
    AGI_LOCAL_SHARE=$worker_home/localshare
    EOF
    ```
-7. Remount shared cluster storage if this cluster uses SSHFS from `.111` to `.130`:
+7. Remount shared cluster storage if this cluster uses SSHFS from the manager to the worker:
    ```bash
-   worker_user="<worker-user>"
-   manager_user="<manager-user>"
    worker_home="/home/$worker_user"
    manager_share="/path/to/manager/clustershare"
    sudo apt-get update && sudo apt-get install -y sshfs
    mkdir -p "$worker_home/clustershare"
-   sshfs "$manager_user@192.168.20.111:$manager_share" "$worker_home/clustershare"
+   sshfs "$manager_user@$manager_ip:$manager_share" "$worker_home/clustershare"
    mount | grep clustershare
    ```
 8. Verify the node can still reach the scheduler/manager peer non-interactively:
    ```bash
-   worker_user="<worker-user>"
-   manager_user="<manager-user>"
-   ssh "$worker_user@192.168.20.130" "ssh -o BatchMode=yes $manager_user@192.168.20.111 hostname"
+   ssh "$worker_user@$worker_ip" "ssh -o BatchMode=yes $manager_user@$manager_ip hostname"
    ```
 9. Only after these SSH and share checks pass, rerun `AGI.install(...)` / cluster pipelines.
 

--- a/test/test_env_contract_aliases.py
+++ b/test/test_env_contract_aliases.py
@@ -65,3 +65,10 @@ def test_retired_environment_aliases_do_not_reappear() -> None:
                     findings.append(f"{path.relative_to(REPO_ROOT)}: contains {retired}")
 
     assert findings == []
+
+
+def test_agents_cluster_recovery_does_not_pin_lan_worker_ip() -> None:
+    agents_text = (REPO_ROOT / "AGENTS.md").read_text(encoding="utf-8")
+    assert "tools/cluster_flight_validation.py" in agents_text
+    assert "--discover-lan" in agents_text
+    assert re.search(r"\b192\.168\.20\.\d+\b", agents_text) is None


### PR DESCRIPTION
## Summary\n- replace fixed LAN worker IPs in AGENTS cluster recovery with discovery-first placeholders\n- teach repo skills to run no-cache LAN discovery before live cluster validation\n- add a guard test preventing AGENTS from pinning concrete 192.168.20.x worker IPs\n\n## Validation\n- uv --preview-features extra-build-dependencies run --no-sync pytest -q -o addopts='' test/test_env_contract_aliases.py\n- uv --preview-features extra-build-dependencies run --no-sync python tools/workflow_parity.py --profile skills