### PR TITLE
[codex] Fix remote cluster deploy command handling

### DIFF
--- a/src/agilab/cluster_flight_validation.py
+++ b/src/agilab/cluster_flight_validation.py
@@ -43,6 +43,7 @@ SSHFS_OPTIONS = (
     "StrictHostKeyChecking=yes",
     "noexec",
 )
+REMOTE_PATH_PREFIX = 'export PATH="$HOME/.local/bin:/usr/local/bin:/opt/homebrew/bin:$PATH"; '
 
 
 @dataclass(frozen=True)
@@ -753,7 +754,8 @@ def _remote_share_setup_commands(
     sshfs_options = _sshfs_options_args()
     unmount_snippet = _remote_share_unmount_snippet()
     sshfs_check_command = (
-        'mkdir -p "$HOME"/.agilab && '
+        REMOTE_PATH_PREFIX
+        + 'mkdir -p "$HOME"/.agilab && '
         "if ! command -v sshfs >/dev/null 2>&1; then "
         f"printf '%s\\n' {shlex.quote(SSHFS_INSTALL_HINT)} >&2; exit 70; "
         "fi"
@@ -764,7 +766,8 @@ def _remote_share_setup_commands(
         + '; mkdir -p "$REMOTE_CLUSTER_SHARE"'
     )
     mount_command = (
-        f"SCHEDULER_CLUSTER_SHARE={shlex.quote(source)}; REMOTE_CLUSTER_SHARE="
+        REMOTE_PATH_PREFIX
+        + f"SCHEDULER_CLUSTER_SHARE={shlex.quote(source)}; REMOTE_CLUSTER_SHARE="
         + remote_assignment
         + '; MOUNT_LINE=$(mount | grep -F -- "$REMOTE_CLUSTER_SHARE" || true); '
         + 'if [ -n "$MOUNT_LINE" ]; then '

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_remote_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_remote_support.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import re
+import shlex
 import uuid
 from pathlib import Path, PurePosixPath
 from shlex import quote
@@ -64,8 +65,15 @@ def _operator_command_prefix(value: Any) -> str:
     return f"{prefix} " if prefix else ""
 
 
+def _shell_words(value: Any) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    return " ".join(quote(part) for part in shlex.split(text, posix=True))
+
+
 def _remote_tool(prefix: Any, executable: Any) -> str:
-    return _operator_command_prefix(prefix) + quote(str(executable))
+    return _operator_command_prefix(prefix) + _shell_words(executable)
 
 
 def _remote_arg(value: Any) -> str:
@@ -356,7 +364,7 @@ async def _remote_project_has_pip(
         )
     except ConnectionError:
         raise
-    except _REMOTE_COMMAND_EXCEPTIONS:
+    except Exception:
         return False
     return True
 

--- a/src/agilab/core/test/test_agi_distributor_deployment_remote_support.py
+++ b/src/agilab/core/test/test_agi_distributor_deployment_remote_support.py
@@ -135,8 +135,9 @@ def test_remote_command_helpers_quote_dynamic_arguments():
     )
     assert (
         deployment_remote_support._remote_tool("source ~/.profile &&", "uv tool")
-        == "source ~/.profile && 'uv tool'"
+        == "source ~/.profile && uv tool"
     )
+    assert deployment_remote_support._remote_tool("", "uv --quiet") == "uv --quiet"
 
 
 @pytest.mark.asyncio
@@ -209,7 +210,7 @@ async def test_deploy_remote_worker_non_source_flow(monkeypatch, tmp_path):
         dist_abs=dist_abs,
         pyvers_worker="3.13",
         envars={},
-        uv_worker="uv",
+        uv_worker="uv --quiet",
         is_source_env=False,
         app="demo_app",
         target_worker="demo_worker",
@@ -255,6 +256,8 @@ async def test_deploy_remote_worker_non_source_flow(monkeypatch, tmp_path):
 
     assert any("demo_worker-0.0.1.egg" in names for _, names, _ in send_calls)
     assert any("python -c 'import pip'" in cmd for cmd in ssh_calls)
+    assert any("uv --quiet run -p 3.13" in cmd for cmd in ssh_calls)
+    assert not any("'uv --quiet'" in cmd for cmd in ssh_calls)
     assert not any("ensurepip" in cmd for cmd in ssh_calls)
     assert not any("dask[distributed]" in cmd for cmd in ssh_calls)
     assert not any("numba==0.62.1" in cmd for cmd in ssh_calls)

--- a/test/test_cluster_flight_validation.py
+++ b/test/test_cluster_flight_validation.py
@@ -534,6 +534,8 @@ def test_share_setup_script_lines_print_sshfs_commands(tmp_path: Path):
     script = "\n".join(cfv.share_setup_script_lines(plan, "sshfs", local_user="agi"))
 
     assert "sshfs" in script
+    assert 'export PATH="$HOME/.local/bin:/usr/local/bin:/opt/homebrew/bin:$PATH"; ' in script
+    assert "command -v sshfs" in script
     assert "agi@192.168.3.103:/Users/agi/clustershare/agilab-two-node" in script
     assert "jpm@192.168.3.35" in script
     assert "-o reconnect" in script
@@ -610,10 +612,12 @@ def test_apply_share_setup_runs_idempotent_remote_commands(tmp_path: Path, monke
     ]
     assert summaries[2].path == "/Users/jpm/.agilab/.env"
     assert commands[0][:4] == ["ssh", "-o", "BatchMode=yes", "jpm@192.168.3.35"]
+    assert commands[0][-1].startswith('export PATH="$HOME/.local/bin:/usr/local/bin:/opt/homebrew/bin:$PATH"; ')
     assert "command -v sshfs" in commands[0][-1]
     assert "AGI_CLUSTER_SHARE" in commands[1][-1]
     assert "mkdir -p \"$REMOTE_CLUSTER_SHARE\"" in commands[2][-1]
     assert "SCHEDULER_CLUSTER_SHARE=agi@192.168.3.103:" in commands[3][-1]
+    assert commands[3][-1].startswith('export PATH="$HOME/.local/bin:/usr/local/bin:/opt/homebrew/bin:$PATH"; ')
     assert "sshfs \"$SCHEDULER_CLUSTER_SHARE\"" in commands[3][-1]
     assert "-o reconnect" in commands[3][-1]
     assert "-o ServerAliveInterval=15" in commands[3][-1]


### PR DESCRIPTION
## What changed

- Tokenize remote executable commands such as `uv --quiet` before shell quoting, so remote deploy no longer tries to execute a literal `'uv --quiet'` binary.
- Treat remote `python -c 'import pip'` failures as a pip-missing probe result and run `ensurepip` instead of aborting deployment.
- Prepend common user-local binary paths when cluster share setup checks and runs `sshfs` on remote workers.
- Add regressions for remote command construction and SSHFS PATH handling.

## Why

Live cluster validation discovered that the current ready worker is `agi@192.168.20.15`, not stale remembered hosts. The deploy path reached the worker but failed on remote command construction and pip bootstrap. After fixing those issues, the cluster Flight proof and the two-stage distributed app DAG smoke pass.

## Validation

- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' src/agilab/core/test/test_agi_distributor_deployment_remote_support.py`
- `PYTHONPATH=src uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_cluster_flight_validation.py`
- `uv --preview-features extra-build-dependencies run --no-sync pytest -q -o addopts='' src/agilab/core/test`
- Fresh LAN discovery: ready worker `agi@192.168.20.15`; stale remembered `192.168.20.130` reported `no-ssh-port`.
- Live cluster Flight proof passed with local scheduler `192.168.20.111` and worker `192.168.20.15`.
- Distributed DAG smoke passed after seeding the worker's Flight dataset: `flight_context` and `weather_forecast_review` both completed with artifacts available.
