### PR TITLE
Add hardened shared-use gate evidence

### DIFF
--- a/ADOPTION.md
+++ b/ADOPTION.md
@@ -75,6 +75,17 @@ uv --preview-features extra-build-dependencies run agilab security-check --profi
 uv --preview-features extra-build-dependencies run python tools/profile_supply_chain_scan.py --profile all --run
 ```
 
+A clean strict security check plus profile-specific SBOM and vulnerability
+evidence is the documented go gate for hardened shared/team use. Persist the
+combined decision before handoff:
+
+```bash
+uv --preview-features extra-build-dependencies run python tools/shared_go_gate.py \
+  --security-check-json security-check.json \
+  --supply-chain-dir test-results/supply-chain \
+  --output shared_go_gate.json
+```
+
 Use strict mode only when missing controls must block the gate:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -216,8 +216,8 @@ Use this boundary before deploying it in sensitive environments:
 
 | Boundary | Status | Required controls |
 |---|---|---|
-| Safe for production-like use | Local research sandboxes, internal demos, notebook-to-app migration, reproducible validation with non-sensitive data. | Normal repository hygiene and local proof evidence. |
-| Conditional use only | Shared team workspaces, SSH/Dask clusters, external apps, LLM connectors, or sensitive datasets. | Per-user isolation, explicit secrets management, TLS/auth for exposed services, SBOM plus vulnerability scan evidence, and a deployment threat model. |
+| Go for controlled local use | Local research sandboxes, internal demos, notebook-to-app migration, reproducible validation with non-sensitive data. | Normal repository hygiene and local proof evidence. |
+| Go for hardened shared use | Shared team workspaces, SSH/Dask clusters, reviewed external apps, LLM connectors, local/offline LLMs, or sensitive internal datasets when the hardening gate passes. | Per-user isolation, strict `agilab security-check` gate, explicit secrets management, TLS/auth for exposed services, pinned/allowlisted external apps, SBOM plus vulnerability scan evidence for deployed install profiles, bounded resources, and a deployment threat model. |
 | Not safe as-is | Sole production MLOps control plane, public Streamlit exposure, regulated production model serving, enterprise governance, online monitoring, drift detection, or audit-trail ownership. | Pair AGILAB with a hardened production stack such as MLflow/Kubeflow/SageMaker/Dagster/Airflow or an internal platform. |
 
 For shared adoption, run `agilab security-check --profile shared --json` and
@@ -225,6 +225,16 @@ use `--strict` or `AGILAB_SECURITY_CHECK_STRICT=1` when missing controls should
 block the gate. The stricter profiles check app-repository allowlists, public UI
 bind controls, cluster-share isolation, generated-code execution boundaries,
 plaintext local secrets, and profile-specific SBOM / `pip-audit` evidence.
+Treat a clean strict report plus profile-specific SBOM / `pip-audit` evidence
+as the documented go gate for hardened shared/team use. To persist the combined
+decision, write the gate artifact:
+
+```bash
+uv --preview-features extra-build-dependencies run python tools/shared_go_gate.py \
+  --security-check-json test-results/security-check.json \
+  --supply-chain-dir test-results/supply-chain \
+  --output test-results/shared_go_gate.json
+```
 
 ## Security Reporting
 

--- a/README.pypi.md
+++ b/README.pypi.md
@@ -180,8 +180,8 @@ Use this boundary before deploying it in sensitive environments:
 
 | Boundary | Status | Required controls |
 |---|---|---|
-| Safe for production-like use | Local research sandboxes, internal demos, notebook-to-app migration, reproducible validation with non-sensitive data. | Normal repository hygiene and local proof evidence. |
-| Conditional use only | Shared team workspaces, SSH/Dask clusters, external apps, LLM connectors, or sensitive datasets. | Per-user isolation, explicit secrets management, TLS/auth for exposed services, SBOM plus vulnerability scan evidence, and a deployment threat model. |
+| Go for controlled local use | Local research sandboxes, internal demos, notebook-to-app migration, reproducible validation with non-sensitive data. | Normal repository hygiene and local proof evidence. |
+| Go for hardened shared use | Shared team workspaces, SSH/Dask clusters, reviewed external apps, LLM connectors, local/offline LLMs, or sensitive internal datasets when the hardening gate passes. | Per-user isolation, strict `agilab security-check` gate, explicit secrets management, TLS/auth for exposed services, pinned/allowlisted external apps, SBOM plus vulnerability scan evidence for deployed install profiles, bounded resources, and a deployment threat model. |
 | Not safe as-is | Sole production MLOps control plane, public Streamlit exposure, regulated production model serving, enterprise governance, online monitoring, drift detection, or audit-trail ownership. | Pair AGILAB with a hardened production stack such as MLflow/Kubeflow/SageMaker/Dagster/Airflow or an internal platform. |
 
 For shared adoption, run `agilab security-check --profile shared --json` and
@@ -189,6 +189,16 @@ use `--strict` or `AGILAB_SECURITY_CHECK_STRICT=1` when missing controls should
 block the gate. The stricter profiles check app-repository allowlists, public UI
 bind controls, cluster-share isolation, generated-code execution boundaries,
 plaintext local secrets, and profile-specific SBOM / `pip-audit` evidence.
+Treat a clean strict report plus profile-specific SBOM / `pip-audit` evidence
+as the documented go gate for hardened shared/team use. To persist the combined
+decision, write the gate artifact:
+
+```bash
+uv --preview-features extra-build-dependencies run python tools/shared_go_gate.py \
+  --security-check-json test-results/security-check.json \
+  --supply-chain-dir test-results/supply-chain \
+  --output test-results/shared_go_gate.json
+```
 
 ## Security Reporting
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -83,21 +83,24 @@ distributed runs, and optionally start UI, tracking, or local-model tooling. Tre
 notebook, generated snippet, and external apps repository as executable code until it has been
 reviewed.
 
-Recommended use without additional platform hardening:
+Go for controlled local use without additional platform hardening:
 
 - Local research sandbox, notebook-to-app migration, reproducible experiment replay, and internal
   demonstrations with non-sensitive data.
 - Single-operator or controlled lab environments where the operator owns the apps, dependencies,
   datasets, secrets, and worker machines.
 
-Conditional use only after hardening:
+Go for hardened shared/team use when the hardening gate passes:
 
 - Shared team deployments, internal clusters, local/remote LLM use, or external apps repositories.
-- Minimum controls: per-user isolation, a dedicated OS user or equivalent workspace boundary,
-  restricted outbound network access where appropriate, bounded CPU/RAM, reviewed app code,
-  scanned dependencies, controlled logs, and secrets supplied outside repository or command-line
-  arguments. Reserve container/VM boundaries for untrusted apps, shared sensitive deployments, or
-  advanced raw-Python execution paths that need stronger isolation.
+- Minimum controls: a clean strict ``agilab security-check`` report for the target profile,
+  profile-specific SBOM and ``pip-audit`` evidence, per-user isolation, a dedicated OS user
+  or equivalent workspace boundary, restricted outbound network access where appropriate,
+  bounded CPU/RAM, reviewed app code, pinned and allowlisted external apps, controlled logs,
+  and secrets supplied outside repository or command-line arguments. Reserve container/VM
+  boundaries for untrusted apps, shared sensitive deployments, or advanced raw-Python execution
+  paths that need stronger isolation. For public UI binds, archive a reviewed
+  ``AGILAB_PUBLIC_BIND_EVIDENCE`` artifact proving the external auth/TLS/network control.
 
 Not recommended as-is:
 
@@ -117,6 +120,8 @@ organization's security requirements in mind. At minimum:
   workspace, dedicated UID, no default access to personal secrets, CPU/RAM quotas, and restricted
   network egress.
 - Run behind HTTPS and limit inbound network access to trusted operators.
+- For public Streamlit binds, set ``AGILAB_PUBLIC_BIND_EVIDENCE`` to a non-empty reviewed
+  artifact that records the reverse proxy, SSO/auth, TLS termination, and network ACL evidence.
 - Store API keys, model weights, and datasets outside of the repository, using a dedicated secrets
   manager where possible.
 - Rotate credentials regularly and prefer short-lived access tokens to static passwords.

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -1,9 +1,9 @@
 {
-  "file_count": 231,
+  "file_count": 232,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "c6ae14ff059cd13773262dfe1fcb7167ba542690a2cc7f4925d0b497f7562ecf",
+  "source_digest_sha256": "576b734e2ced9424b5c9fccc8a3f614aa00ef71e9ef9a9dc39398117e9d1daa1",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "c6ae14ff059cd13773262dfe1fcb7167ba542690a2cc7f4925d0b497f7562ecf"
+  "target_digest_sha256": "576b734e2ced9424b5c9fccc8a3f614aa00ef71e9ef9a9dc39398117e9d1daa1"
 }

--- a/docs/source/architecture-scorecard.rst
+++ b/docs/source/architecture-scorecard.rst
@@ -12,8 +12,11 @@ Current supported score
 
 The scope is deliberately narrow: AGILAB has an excellent architecture for
 turning AI/ML experiments, notebooks, app runs, and agent-assisted workflows
-into replayable evidence. The same score is conditional for shared or
-multi-tenant production use because tenant isolation, enterprise auth, RBAC,
+into replayable evidence. For this score, hardened shared/team use is go when
+explicit gates pass: strict security-check evidence, per-profile SBOM and
+vulnerability scans, reviewed external apps, bounded resources, and
+deployment-specific secrets, network, and UI controls. Multi-tenant production
+use remains outside this score because tenant isolation, enterprise auth, RBAC,
 production rollback, and regulated serving remain deployment responsibilities
 outside the current AGILAB core.
 

--- a/docs/source/environment.rst
+++ b/docs/source/environment.rst
@@ -181,6 +181,12 @@ rather than shown as one of the workflow pages.
        ``AGILAB_AUTH_REQUIRED``, ``AGILAB_PUBLIC_AUTH``,
        ``AGILAB_TLS_TERMINATED``, or ``STREAMLIT_AUTH_REQUIRED`` so accidental
        public exposure fails closed.
+   * - ``AGILAB_PUBLIC_BIND_EVIDENCE``
+     - unset
+     - Optional path to a non-empty reviewed public-bind evidence artifact.
+       Shared/public security-check profiles require this when the UI binds to
+       ``0.0.0.0`` or ``::`` with public-bind controls declared. Record the
+       reverse proxy, SSO/auth, TLS termination, network ACL, reviewer, and date.
    * - ``AGILAB_GENERATED_CODE_SANDBOX``
      - unset
      - Required only for the advanced raw-Python WORKFLOW auto-fix path.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -101,6 +101,7 @@ references, and example projects.
    :caption: Operations
 
    Cluster setup <cluster>
+   Trusted shared deployment <trusted-shared-deployment>
    Kubernetes Job preview <kubernetes-job>
    Parallel stages <parallel-stages>
    Distributed workers <distributed-workers>

--- a/docs/source/roadmap/agilab-future-work.md
+++ b/docs/source/roadmap/agilab-future-work.md
@@ -553,8 +553,8 @@ Why now:
 
 ### Priority 5. Security and shared-use hardening
 
-Keep controlled local R&D easy, but make shared-team use conditional on explicit
-controls.
+Keep controlled local R&D easy, but make hardened shared-team use a clear go
+path when explicit controls pass.
 
 Acceptance gate:
 

--- a/docs/source/security-adoption.rst
+++ b/docs/source/security-adoption.rst
@@ -36,18 +36,20 @@ repositories as executable code until they have been reviewed.
    * - Decision
      - Fit
      - Minimum controls
-   * - Go for controlled evaluation
+   * - Go for controlled local use
      - Local research sandbox, internal demo, notebook-to-app migration, and
        reproducible validation with non-sensitive data.
      - Normal repository hygiene, one local first proof, and evidence under
        ``~/log/execute``.
-   * - Go conditionally for shared teams
+   * - Go for hardened shared/team use
      - Shared workstation, internal cluster, external apps repository, LLM
-       connector, or sensitive business data.
-     - Per-user isolation, explicit secrets management, TLS/auth for exposed
+       connector, local/offline LLM, or sensitive internal data when the
+       hardening gate passes.
+     - Clean strict ``agilab security-check`` report for the target profile,
+       per-user isolation, explicit secrets management, TLS/auth for exposed
        services, app-repository allowlist and immutable pinning, SBOM plus
-       vulnerability scan evidence, bounded resources, and a deployment threat
-       model.
+       vulnerability scan evidence for the deployed install profile, bounded
+       resources, and a deployment threat model.
    * - No-go as a standalone production platform
      - Public Streamlit exposure, open multi-tenant service, regulated
        production model serving, enterprise governance, online monitoring,
@@ -59,7 +61,9 @@ Operational checks
 ------------------
 
 Before moving beyond a single-user proof, archive the profile-specific security
-and supply-chain evidence for the environment you will actually deploy:
+and supply-chain evidence for the environment you will actually deploy. Treat a
+clean strict report plus profile-specific SBOM and vulnerability evidence as
+the documented go gate for hardened shared/team use:
 
 .. code-block:: bash
 

--- a/docs/source/trusted-shared-deployment.rst
+++ b/docs/source/trusted-shared-deployment.rst
@@ -1,0 +1,83 @@
+Trusted shared deployment
+=========================
+
+AGILAB is a trusted-operator workbench. Shared/team use is a go only when the
+operator records the hardening evidence for the actual deployment profile. This
+page is the handoff checklist for a shared workstation, SSH/Dask cluster,
+reviewed external apps repository, local/offline LLM profile, public UI behind
+a front end, or sensitive internal dataset.
+
+Go gate
+-------
+
+Archive these artifacts before treating a shared/team deployment as ready:
+
+.. code-block:: bash
+
+   uv --preview-features extra-build-dependencies run agilab security-check \
+     --profile shared --strict --json > test-results/security-check.json
+   uv --preview-features extra-build-dependencies run python tools/profile_supply_chain_scan.py \
+     --profile all --run
+   uv --preview-features extra-build-dependencies run python tools/shared_go_gate.py \
+     --security-check-json test-results/security-check.json \
+     --supply-chain-dir test-results/supply-chain \
+     --install-profile all \
+     --output test-results/shared_go_gate.json \
+     --strict
+
+The gate decision is ``go`` only when ``security-check`` passes and each
+deployed install profile has fresh JSON ``pip-audit`` and CycloneDX SBOM
+artifacts. Keep ``shared_go_gate.json`` with the deployment evidence.
+
+Public UI evidence
+------------------
+
+``AGILAB_PUBLIC_BIND_OK=1`` plus an auth/TLS indicator is a runtime policy
+acknowledgement, not proof that the front end is actually safe. For shared or
+public profiles, write a small reviewed artifact and set
+``AGILAB_PUBLIC_BIND_EVIDENCE`` to that file before running the gate. The file
+should record the reverse proxy, SSO/auth control, TLS termination, network ACL,
+reviewer, and date.
+
+Cluster evidence
+----------------
+
+Rediscover workers before using a remembered IP:
+
+The discovery command starts with ``tools/cluster_flight_validation.py --discover-lan``.
+
+.. code-block:: bash
+
+   uv --preview-features extra-build-dependencies run --no-sync python tools/cluster_flight_validation.py \
+     --discover-lan \
+     --remote-user "<worker-user>" \
+     --json \
+     --no-discovery-cache
+
+Then prove the shared mount before running compute:
+
+.. code-block:: bash
+
+   uv --preview-features extra-build-dependencies run --no-sync python tools/cluster_flight_validation.py \
+     --cluster \
+     --scheduler "<scheduler-ip>" \
+     --workers "<worker-user>@<worker-ip>" \
+     --setup-share sshfs \
+     --apply
+   uv --preview-features extra-build-dependencies run --no-sync python tools/cluster_flight_validation.py \
+     --cluster \
+     --scheduler "<scheduler-ip>" \
+     --workers "<worker-user>@<worker-ip>" \
+     --share-check-only
+
+If setup fails with scheduler SSH unreachable, enable SSH on the
+scheduler/manager, install the worker public key on the scheduler, and verify
+``ssh <scheduler>`` from the worker before retrying SSHFS.
+
+What remains no-go
+------------------
+
+This gate does not turn AGILAB into a multi-tenant production MLOps control
+plane. Public Streamlit without a hardened front end, regulated production
+serving, enterprise governance, online monitoring, drift detection, and
+audit-trail ownership remain outside the safe-as-is boundary.

--- a/src/agilab/cluster_flight_validation.py
+++ b/src/agilab/cluster_flight_validation.py
@@ -35,6 +35,11 @@ SSHFS_INSTALL_HINT = (
     "Install sshfs first: Debian/Ubuntu: sudo apt-get install -y sshfs; "
     "macOS: install macFUSE/FUSE-T SSHFS and ensure sshfs is visible to non-interactive SSH."
 )
+SCHEDULER_SSH_HINT = (
+    "Scheduler SSH is not reachable from the worker. Enable SSH on the scheduler/manager, "
+    "install the worker public key on the scheduler, and verify ssh <scheduler> from the worker "
+    "before mounting AGI_CLUSTER_SHARE with SSHFS."
+)
 SSHFS_OPTIONS = (
     "reconnect",
     "ServerAliveInterval=15",
@@ -43,7 +48,7 @@ SSHFS_OPTIONS = (
     "StrictHostKeyChecking=yes",
     "noexec",
 )
-REMOTE_PATH_PREFIX = 'export PATH="$HOME/.local/bin:/usr/local/bin:/opt/homebrew/bin:$PATH"; '
+REMOTE_PATH_PREFIX = 'export PATH="$HOME/.local/bin:$HOME/bin:/usr/local/bin:/opt/homebrew/bin:$PATH"; '
 
 
 @dataclass(frozen=True)
@@ -767,8 +772,11 @@ def _remote_share_setup_commands(
     )
     mount_command = (
         REMOTE_PATH_PREFIX
+        + f"SCHEDULER_SSH_TARGET={shlex.quote(scheduler_target)}; "
         + f"SCHEDULER_CLUSTER_SHARE={shlex.quote(source)}; REMOTE_CLUSTER_SHARE="
         + remote_assignment
+        + '; if ! ssh -o BatchMode=yes -o ConnectTimeout=5 "$SCHEDULER_SSH_TARGET" true; then '
+        + f"printf '%s\\n' {shlex.quote(SCHEDULER_SSH_HINT)} >&2; exit 71; fi"
         + '; MOUNT_LINE=$(mount | grep -F -- "$REMOTE_CLUSTER_SHARE" || true); '
         + 'if [ -n "$MOUNT_LINE" ]; then '
         + 'if printf \'%s\\n\' "$MOUNT_LINE" | grep -F -- "$SCHEDULER_CLUSTER_SHARE" >/dev/null 2>&1 '

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_remote_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_remote_support.py
@@ -23,6 +23,11 @@ _SSHFS_INSTALL_HINT = (
     "Install sshfs first: Debian/Ubuntu: sudo apt-get install -y sshfs; "
     "macOS: install macFUSE/FUSE-T SSHFS and ensure sshfs is visible to non-interactive SSH."
 )
+_SCHEDULER_SSH_HINT = (
+    "Scheduler SSH is not reachable from the worker. Enable SSH on the scheduler/manager, "
+    "install the worker public key on the scheduler, and verify ssh <scheduler> from the worker "
+    "before mounting AGI_CLUSTER_SHARE with SSHFS."
+)
 _SSHFS_OPTIONS = (
     "reconnect",
     "ServerAliveInterval=15",
@@ -32,7 +37,7 @@ _SSHFS_OPTIONS = (
     "noexec",
 )
 _REMOTE_PATH_PREFIX = (
-    'export PATH="$HOME/.local/bin:/usr/local/bin:/opt/homebrew/bin:$PATH"; '
+    'export PATH="$HOME/.local/bin:$HOME/bin:/usr/local/bin:/opt/homebrew/bin:$PATH"; '
 )
 
 
@@ -164,6 +169,10 @@ def _remote_share_mount_command(
         'mkdir -p "$HOME/.agilab"; '
         "if ! command -v sshfs >/dev/null 2>&1; then "
         f"printf '%s\\n' {quote(_SSHFS_INSTALL_HINT)} >&2; exit 70; "
+        "fi; "
+        f"SCHEDULER_SSH_TARGET={quote(scheduler_target)}; "
+        'if ! ssh -o BatchMode=yes -o ConnectTimeout=5 "$SCHEDULER_SSH_TARGET" true; then '
+        f"printf '%s\\n' {quote(_SCHEDULER_SSH_HINT)} >&2; exit 71; "
         "fi; "
         "REMOTE_CLUSTER_SHARE=" + _remote_share_assignment(remote_share) + "; "
         f"SCHEDULER_CLUSTER_SHARE={quote(source)}; "

--- a/src/agilab/core/test/test_agi_distributor_deployment_remote_support.py
+++ b/src/agilab/core/test/test_agi_distributor_deployment_remote_support.py
@@ -505,6 +505,12 @@ async def test_deploy_remote_worker_mounts_scheduler_cluster_share_with_sshfs(tm
         for cmd in ssh_calls
     )
     assert any("command -v sshfs" in cmd for cmd in ssh_calls)
+    mount_cmd = next(cmd for cmd in ssh_calls if "SCHEDULER_CLUSTER_SHARE" in cmd)
+    assert mount_cmd.startswith(
+        'export PATH="$HOME/.local/bin:$HOME/bin:/usr/local/bin:/opt/homebrew/bin:$PATH"; '
+    )
+    assert 'ssh -o BatchMode=yes -o ConnectTimeout=5 "$SCHEDULER_SSH_TARGET" true' in mount_cmd
+    assert "Scheduler SSH is not reachable from the worker" in mount_cmd
     assert any(
         'sshfs "$SCHEDULER_CLUSTER_SHARE" "$REMOTE_CLUSTER_SHARE"' in cmd
         for cmd in ssh_calls
@@ -513,7 +519,7 @@ async def test_deploy_remote_worker_mounts_scheduler_cluster_share_with_sshfs(tm
         cmd for cmd in ssh_calls if 'sshfs "$SCHEDULER_CLUSTER_SHARE"' in cmd
     )
     assert (
-        'export PATH="$HOME/.local/bin:/usr/local/bin:/opt/homebrew/bin:$PATH"; set -e;'
+        'export PATH="$HOME/.local/bin:$HOME/bin:/usr/local/bin:/opt/homebrew/bin:$PATH"; set -e;'
         in mount_cmd
     )
     assert "-o reconnect" in mount_cmd

--- a/src/agilab/security_check.py
+++ b/src/agilab/security_check.py
@@ -22,6 +22,7 @@ HEX_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 LOCAL_HOSTS = {"", "127.0.0.1", "localhost", "::1"}
 EXPOSED_HOSTS = {"0.0.0.0", "::"}
 PUBLIC_BIND_OK_ENV = "AGILAB_PUBLIC_BIND_OK"
+PUBLIC_BIND_EVIDENCE_ENV = "AGILAB_PUBLIC_BIND_EVIDENCE"
 APPS_ALLOWLIST_ENV = "AGILAB_APPS_REPOSITORY_ALLOWLIST"
 APPS_ALLOWLIST_FILE_ENV = "AGILAB_APPS_REPOSITORY_ALLOWLIST_FILE"
 PLACEHOLDER_SECRET_VALUES = {
@@ -431,7 +432,40 @@ def _streamlit_config_address(home: Path) -> str | None:
     return str(value).strip() if value is not None else None
 
 
-def _check_ui_exposure(config: Mapping[str, str], *, home: Path, profile: str = "local") -> Check:
+def _public_bind_evidence_state(
+    config: Mapping[str, str],
+    *,
+    cwd: Path,
+) -> dict[str, Any]:
+    raw_path = str(config.get(PUBLIC_BIND_EVIDENCE_ENV) or "").strip()
+    if not raw_path:
+        return {
+            "configured": False,
+            "path": None,
+            "exists": False,
+            "non_empty": False,
+            "valid": False,
+        }
+    path = _resolve_path(raw_path, cwd=cwd)
+    exists = bool(path and path.is_file())
+    size_bytes = path.stat().st_size if exists and path else 0
+    return {
+        "configured": True,
+        "path": str(path) if path else raw_path,
+        "exists": exists,
+        "non_empty": size_bytes > 0,
+        "valid": exists and size_bytes > 0,
+        "size_bytes": size_bytes if exists else None,
+    }
+
+
+def _check_ui_exposure(
+    config: Mapping[str, str],
+    *,
+    home: Path,
+    cwd: Path | None = None,
+    profile: str = "local",
+) -> Check:
     host = (
         config.get("STREAMLIT_SERVER_ADDRESS")
         or config.get("AGILAB_UI_HOST")
@@ -459,13 +493,33 @@ def _check_ui_exposure(config: Mapping[str, str], *, home: Path, profile: str = 
         )
     )
     if public_bind_ok and auth_or_tls:
+        evidence = _public_bind_evidence_state(config, cwd=cwd or home)
+        details = {
+            "host": host,
+            "public_bind_ok": True,
+            "auth_or_tls_indicator": True,
+            "public_bind_evidence": evidence,
+        }
+        if _is_hardening_profile(profile) and not evidence["valid"]:
+            return Check(
+                "ui_network_exposure",
+                "UI network exposure",
+                "fail",
+                "UI public-bind controls are declared without a reviewed evidence artifact.",
+                (
+                    "Keep public binds behind verified auth/TLS/network controls, then set "
+                    f"{PUBLIC_BIND_EVIDENCE_ENV} to a non-empty evidence file before passing "
+                    "the shared/public adoption gate."
+                ),
+                details,
+            )
         return Check(
             "ui_network_exposure",
             "UI network exposure",
             "pass",
             "UI binds publicly with explicit public-bind acknowledgement and auth/TLS indicator.",
-            "Verify the front-end control is actually enforced before exposing sensitive data.",
-            {"host": host, "public_bind_ok": True, "auth_or_tls_indicator": True},
+            "Keep the front-end control evidence current before exposing sensitive data.",
+            details,
         )
     return Check(
         "ui_network_exposure",
@@ -652,7 +706,7 @@ def build_report(
         _check_apps_repository(config, cwd=cwd, profile=profile),
         _check_persisted_secrets(env_file, env_file_values, profile=profile),
         _check_cluster_share(config, cwd=cwd, profile=profile),
-        _check_ui_exposure(config, home=home, profile=profile),
+        _check_ui_exposure(config, home=home, cwd=cwd, profile=profile),
         _check_generated_code_execution(config, profile=profile),
         _check_optional_profiles(config, profile=profile),
         _check_supply_chain_artifacts(

--- a/src/agilab/ui_public_bind_guard.py
+++ b/src/agilab/ui_public_bind_guard.py
@@ -9,6 +9,7 @@ from typing import Callable, Mapping
 EXPOSED_UI_HOSTS = {"0.0.0.0", "::"}
 DEFAULT_STREAMLIT_HOST = "127.0.0.1"
 PUBLIC_BIND_OK_ENV = "AGILAB_PUBLIC_BIND_OK"
+PUBLIC_BIND_EVIDENCE_ENV = "AGILAB_PUBLIC_BIND_EVIDENCE"
 PUBLIC_BIND_CONTROL_ENVS = (
     "AGILAB_AUTH_REQUIRED",
     "AGILAB_PUBLIC_AUTH",
@@ -59,7 +60,8 @@ def public_bind_error_message(host: str) -> str:
     return (
         f"AGILAB refuses to bind the Streamlit UI publicly on {host!r} without explicit protection. "
         "Use the default 127.0.0.1 bind, or set AGILAB_PUBLIC_BIND_OK=1 together with "
-        "an auth/TLS indicator such as AGILAB_TLS_TERMINATED=1."
+        "an auth/TLS indicator such as AGILAB_TLS_TERMINATED=1. For shared/public deployments, "
+        "also archive AGILAB_PUBLIC_BIND_EVIDENCE for the security-check gate."
     )
 
 

--- a/test/test_audit_response_docs.py
+++ b/test/test_audit_response_docs.py
@@ -119,8 +119,9 @@ def test_security_policy_addresses_public_audit_adoption_boundaries() -> None:
     security = Path("SECURITY.md").read_text(encoding="utf-8")
 
     assert "trusted-operator experimentation workbench" in security
-    assert "Recommended use without additional platform hardening" in security
-    assert "Conditional use only after hardening" in security
+    assert "Go for controlled local use without additional platform hardening" in security
+    assert "Go for hardened shared/team use when the hardening gate passes" in security
+    assert "clean strict ``agilab security-check`` report" in security
     assert "Not recommended as-is" in security
     assert "public exposure without authentication, TLS, and sandboxing" in security
     assert "Multi-tenant service use" in security
@@ -191,6 +192,18 @@ def test_quick_start_documents_security_adoption_checkpoint() -> None:
     assert "security-check.json" in security_adoption
     assert "security-check --profile shared" in security_adoption
     assert "AGILAB_SECURITY_CHECK_STRICT=1" in security_adoption
+
+
+def test_trusted_shared_deployment_page_documents_go_gate_artifacts() -> None:
+    page = (DOCS_SOURCE / "trusted-shared-deployment.rst").read_text(encoding="utf-8")
+    index = (DOCS_SOURCE / "index.rst").read_text(encoding="utf-8")
+
+    assert "Trusted shared deployment" in page
+    assert "shared_go_gate.json" in page
+    assert "tools/shared_go_gate.py" in page
+    assert "AGILAB_PUBLIC_BIND_EVIDENCE" in page
+    assert "cluster_flight_validation.py --discover-lan" in page
+    assert "trusted-shared-deployment" in index
 
 
 def test_readme_uses_recommended_workbench_positioning() -> None:

--- a/test/test_cluster_flight_validation.py
+++ b/test/test_cluster_flight_validation.py
@@ -534,8 +534,10 @@ def test_share_setup_script_lines_print_sshfs_commands(tmp_path: Path):
     script = "\n".join(cfv.share_setup_script_lines(plan, "sshfs", local_user="agi"))
 
     assert "sshfs" in script
-    assert 'export PATH="$HOME/.local/bin:/usr/local/bin:/opt/homebrew/bin:$PATH"; ' in script
+    assert 'export PATH="$HOME/.local/bin:$HOME/bin:/usr/local/bin:/opt/homebrew/bin:$PATH"; ' in script
     assert "command -v sshfs" in script
+    assert 'ssh -o BatchMode=yes -o ConnectTimeout=5 "$SCHEDULER_SSH_TARGET" true' in script
+    assert "Scheduler SSH is not reachable from the worker" in script
     assert "agi@192.168.3.103:/Users/agi/clustershare/agilab-two-node" in script
     assert "jpm@192.168.3.35" in script
     assert "-o reconnect" in script
@@ -612,12 +614,14 @@ def test_apply_share_setup_runs_idempotent_remote_commands(tmp_path: Path, monke
     ]
     assert summaries[2].path == "/Users/jpm/.agilab/.env"
     assert commands[0][:4] == ["ssh", "-o", "BatchMode=yes", "jpm@192.168.3.35"]
-    assert commands[0][-1].startswith('export PATH="$HOME/.local/bin:/usr/local/bin:/opt/homebrew/bin:$PATH"; ')
+    assert commands[0][-1].startswith('export PATH="$HOME/.local/bin:$HOME/bin:/usr/local/bin:/opt/homebrew/bin:$PATH"; ')
     assert "command -v sshfs" in commands[0][-1]
     assert "AGI_CLUSTER_SHARE" in commands[1][-1]
     assert "mkdir -p \"$REMOTE_CLUSTER_SHARE\"" in commands[2][-1]
     assert "SCHEDULER_CLUSTER_SHARE=agi@192.168.3.103:" in commands[3][-1]
-    assert commands[3][-1].startswith('export PATH="$HOME/.local/bin:/usr/local/bin:/opt/homebrew/bin:$PATH"; ')
+    assert commands[3][-1].startswith('export PATH="$HOME/.local/bin:$HOME/bin:/usr/local/bin:/opt/homebrew/bin:$PATH"; ')
+    assert 'ssh -o BatchMode=yes -o ConnectTimeout=5 "$SCHEDULER_SSH_TARGET" true' in commands[3][-1]
+    assert "Scheduler SSH is not reachable from the worker" in commands[3][-1]
     assert "sshfs \"$SCHEDULER_CLUSTER_SHARE\"" in commands[3][-1]
     assert "-o reconnect" in commands[3][-1]
     assert "-o ServerAliveInterval=15" in commands[3][-1]

--- a/test/test_governance_supply_chain_contract.py
+++ b/test/test_governance_supply_chain_contract.py
@@ -76,8 +76,9 @@ def test_readmes_explain_production_dependency_and_evidence_boundaries() -> None
         text = path.read_text(encoding="utf-8")
         for fragment in (
             "## Production Boundary",
-            "Safe for production-like use",
-            "Conditional use only",
+            "Go for controlled local use",
+            "Go for hardened shared use",
+            "documented go gate for hardened shared/team use",
             "Not safe as-is",
             "Sole production MLOps control plane",
             "## Security Reporting",

--- a/test/test_security_check.py
+++ b/test/test_security_check.py
@@ -233,6 +233,39 @@ def test_cluster_share_and_ui_exposure_pass_boundaries(tmp_path: Path):
     assert exposure_check.details["auth_or_tls_indicator"] is True
 
 
+def test_shared_public_bind_requires_reviewed_evidence_artifact(tmp_path: Path):
+    streamlit_config = tmp_path / ".streamlit" / "config.toml"
+    streamlit_config.parent.mkdir()
+    streamlit_config.write_text("[server]\naddress = '0.0.0.0'\n", encoding="utf-8")
+
+    missing_evidence = security_check._check_ui_exposure(
+        {"AGILAB_PUBLIC_BIND_OK": "1", "AGILAB_AUTH_REQUIRED": "yes"},
+        home=tmp_path,
+        cwd=tmp_path,
+        profile="shared",
+    )
+
+    assert missing_evidence.status == "fail"
+    assert "evidence artifact" in missing_evidence.summary
+    assert missing_evidence.details["public_bind_evidence"]["valid"] is False
+
+    evidence = tmp_path / "public-bind-evidence.json"
+    evidence.write_text('{"reverse_proxy": "reviewed"}\n', encoding="utf-8")
+    with_evidence = security_check._check_ui_exposure(
+        {
+            "AGILAB_PUBLIC_BIND_OK": "1",
+            "AGILAB_AUTH_REQUIRED": "yes",
+            "AGILAB_PUBLIC_BIND_EVIDENCE": str(evidence),
+        },
+        home=tmp_path,
+        cwd=tmp_path,
+        profile="shared",
+    )
+
+    assert with_evidence.status == "pass"
+    assert with_evidence.details["public_bind_evidence"]["valid"] is True
+
+
 def test_cluster_share_reports_missing_unusable_and_world_writable_paths(tmp_path: Path):
     missing = security_check._check_cluster_share(
         {"AGI_WORKERS": "worker1"},

--- a/test/test_shared_go_gate.py
+++ b/test/test_shared_go_gate.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TOOL_PATH = ROOT / "tools" / "shared_go_gate.py"
+SPEC = importlib.util.spec_from_file_location("agilab_shared_go_gate", TOOL_PATH)
+assert SPEC and SPEC.loader
+shared_go_gate = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = shared_go_gate
+SPEC.loader.exec_module(shared_go_gate)
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_shared_go_gate_passes_with_clean_security_and_fresh_profile_artifacts(tmp_path: Path):
+    security_check = tmp_path / "security-check.json"
+    supply_chain = tmp_path / "supply-chain"
+    _write_json(
+        security_check,
+        {
+            "schema": "agilab.security_check.v1",
+            "status": "pass",
+            "summary": {"profile": "shared", "warnings": 0, "failures": 0},
+        },
+    )
+    _write_json(supply_chain / "base" / "pip-audit.json", {"dependencies": []})
+    _write_json(supply_chain / "base" / "sbom-cyclonedx.json", {"components": []})
+
+    gate = shared_go_gate.build_gate(
+        security_check_json=security_check,
+        supply_chain_dir=supply_chain,
+        install_profiles=("base",),
+        now=datetime.now(timezone.utc),
+    )
+
+    assert gate["schema"] == shared_go_gate.SCHEMA
+    assert gate["decision"] == "go"
+    assert gate["checks"]["security_check"]["status"] == "pass"
+    assert gate["checks"]["supply_chain"]["profiles"]["base"]["status"] == "pass"
+
+
+def test_shared_go_gate_blocks_missing_supply_chain_and_strict_cli_returns_nonzero(tmp_path: Path):
+    security_check = tmp_path / "security-check.json"
+    output = tmp_path / "shared_go_gate.json"
+    _write_json(
+        security_check,
+        {
+            "schema": "agilab.security_check.v1",
+            "status": "pass",
+            "summary": {"profile": "shared", "warnings": 0, "failures": 0},
+        },
+    )
+
+    rc = shared_go_gate.main(
+        [
+            "--security-check-json",
+            str(security_check),
+            "--supply-chain-dir",
+            str(tmp_path / "missing-supply-chain"),
+            "--output",
+            str(output),
+            "--strict",
+        ]
+    )
+
+    assert rc == 1
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["decision"] == "blocked"
+    assert payload["summary"]["failed_checks"] == ["supply_chain"]

--- a/test/test_ui_public_bind_guard.py
+++ b/test/test_ui_public_bind_guard.py
@@ -116,6 +116,7 @@ def test_public_bind_guard_or_stop_reports_error_before_stopping():
 
     assert FakeStreamlit.errors
     assert "AGILAB refuses to bind" in FakeStreamlit.errors[0]
+    assert "AGILAB_PUBLIC_BIND_EVIDENCE" in FakeStreamlit.errors[0]
     assert FakeStreamlit.stopped is True
 
 

--- a/tools/architecture_scorecard.py
+++ b/tools/architecture_scorecard.py
@@ -14,8 +14,8 @@ SCHEMA = "agilab.architecture_scorecard.v1"
 HARDENING_GAPS_SCHEMA = "agilab.architecture_hardening_gaps.v1"
 SUPPORTED_SCORE = "4.7 / 5"
 SCORE_SCOPE = (
-    "Excellent evidence-first workbench architecture; conditional for shared "
-    "or multi-tenant production use."
+    "Excellent evidence-first workbench architecture; hardened shared/team use is go "
+    "when explicit gates pass; multi-tenant production use remains outside the current score."
 )
 
 
@@ -243,8 +243,8 @@ def _check_claim_boundary(repo_root: Path) -> dict[str, Any]:
                 "self-assessment",
                 "not a production MLOps certification",
                 "not a multi-tenant production platform score",
-                "conditional for shared or",
-                "multi-tenant production use",
+                "hardened shared/team use is go",
+                "use remains outside this score",
             ],
             "docs/source/agilab-mlops-positioning.rst": [
                 "not as a production MLOps platform",

--- a/tools/security_hygiene_report.py
+++ b/tools/security_hygiene_report.py
@@ -301,8 +301,9 @@ def _release_evidence_scope_check(repo_root: Path, security_text: str) -> dict[s
 def _adoption_profile_check(security_text: str) -> dict[str, Any]:
     required_tokens = [
         "trusted-operator experimentation workbench",
-        "Recommended use without additional platform hardening",
-        "Conditional use only after hardening",
+        "Go for controlled local use without additional platform hardening",
+        "Go for hardened shared/team use when the hardening gate passes",
+        "clean strict ``agilab security-check`` report",
         "Not recommended as-is",
         "public exposure without authentication, TLS, and sandboxing",
         "Multi-tenant service use",
@@ -313,7 +314,7 @@ def _adoption_profile_check(security_text: str) -> dict[str, Any]:
         "adoption_profile_go_no_go_documented",
         "Security adoption profile is documented",
         not missing,
-        "SECURITY.md separates recommended sandbox use, conditional shared use, and no-go production/multi-tenant use",
+        "SECURITY.md separates controlled local use, hardened shared/team go gates, and no-go production/multi-tenant use",
         evidence=["SECURITY.md"],
         details={"missing_tokens": missing},
     )

--- a/tools/shared_go_gate.py
+++ b/tools/shared_go_gate.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Write the hardened shared-use go/no-go artifact for AGILAB."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+
+SCHEMA = "agilab.shared_go_gate.v1"
+DEFAULT_SECURITY_CHECK = Path("test-results/security-check.json")
+DEFAULT_SUPPLY_CHAIN_DIR = Path("test-results/supply-chain")
+DEFAULT_OUTPUT = Path("test-results/shared_go_gate.json")
+DEFAULT_MAX_AGE_DAYS = 30
+INSTALL_PROFILES = (
+    "base",
+    "ui",
+    "pages",
+    "ai",
+    "agents",
+    "examples",
+    "mlflow",
+    "local-llm",
+    "offline",
+    "dev",
+)
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _read_json(path: Path) -> tuple[dict[str, Any] | list[Any] | None, str | None]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        return None, str(exc)
+    if isinstance(payload, (dict, list)):
+        return payload, None
+    return None, f"JSON root is {type(payload).__name__}, expected object or list"
+
+
+def _artifact_state(path: Path, *, now: datetime, max_age_days: int) -> dict[str, Any]:
+    if not path.is_file():
+        return {
+            "path": str(path),
+            "exists": False,
+            "fresh": False,
+            "valid_json": False,
+            "status": "fail",
+        }
+    mtime = datetime.fromtimestamp(path.stat().st_mtime, timezone.utc)
+    age_days = (now - mtime).total_seconds() / 86400
+    payload, error = _read_json(path)
+    valid_json = payload is not None and error is None
+    fresh = age_days <= max_age_days
+    return {
+        "path": str(path),
+        "exists": True,
+        "age_days": round(age_days, 3),
+        "fresh": fresh,
+        "valid_json": valid_json,
+        "status": "pass" if fresh and valid_json else "fail",
+        "error": error,
+    }
+
+
+def _expand_profiles(values: Sequence[str] | None) -> tuple[str, ...]:
+    if not values:
+        return ("base",)
+    expanded: list[str] = []
+    for value in values:
+        if value == "all":
+            expanded.extend(INSTALL_PROFILES)
+        else:
+            expanded.append(value)
+    return tuple(dict.fromkeys(expanded))
+
+
+def _security_check_state(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        return {
+            "path": str(path),
+            "exists": False,
+            "status": "fail",
+            "profile": None,
+            "check_status": None,
+            "error": "security-check artifact is missing",
+        }
+    payload, error = _read_json(path)
+    if not isinstance(payload, dict):
+        return {
+            "path": str(path),
+            "exists": True,
+            "status": "fail",
+            "profile": None,
+            "check_status": None,
+            "error": error or "security-check artifact is not a JSON object",
+        }
+    summary = payload.get("summary") if isinstance(payload.get("summary"), dict) else {}
+    check_status = str(payload.get("status") or "unknown")
+    return {
+        "path": str(path),
+        "exists": True,
+        "status": "pass" if check_status == "pass" else "fail",
+        "profile": summary.get("profile"),
+        "check_status": check_status,
+        "warnings": summary.get("warnings"),
+        "failures": summary.get("failures"),
+        "schema": payload.get("schema"),
+    }
+
+
+def _supply_chain_state(
+    output_root: Path,
+    *,
+    profiles: Sequence[str],
+    now: datetime,
+    max_age_days: int,
+) -> dict[str, Any]:
+    profile_states: dict[str, Any] = {}
+    for profile in profiles:
+        profile_dir = output_root / profile.replace("/", "-")
+        pip_state = _artifact_state(
+            profile_dir / "pip-audit.json",
+            now=now,
+            max_age_days=max_age_days,
+        )
+        sbom_state = _artifact_state(
+            profile_dir / "sbom-cyclonedx.json",
+            now=now,
+            max_age_days=max_age_days,
+        )
+        profile_states[profile] = {
+            "status": "pass" if pip_state["status"] == "pass" and sbom_state["status"] == "pass" else "fail",
+            "pip_audit": pip_state,
+            "sbom": sbom_state,
+        }
+    failures = [
+        profile
+        for profile, state in profile_states.items()
+        if isinstance(state, Mapping) and state.get("status") != "pass"
+    ]
+    return {
+        "status": "pass" if not failures else "fail",
+        "output_root": str(output_root),
+        "profiles": profile_states,
+        "failed_profiles": failures,
+        "max_age_days": max_age_days,
+    }
+
+
+def build_gate(
+    *,
+    security_check_json: Path,
+    supply_chain_dir: Path,
+    install_profiles: Sequence[str],
+    now: datetime | None = None,
+    max_age_days: int = DEFAULT_MAX_AGE_DAYS,
+) -> dict[str, Any]:
+    generated_at = now or _utc_now()
+    security = _security_check_state(security_check_json)
+    supply_chain = _supply_chain_state(
+        supply_chain_dir,
+        profiles=install_profiles,
+        now=generated_at,
+        max_age_days=max_age_days,
+    )
+    checks = {
+        "security_check": security,
+        "supply_chain": supply_chain,
+    }
+    failed = [
+        name
+        for name, state in checks.items()
+        if isinstance(state, Mapping) and state.get("status") != "pass"
+    ]
+    decision = "go" if not failed else "blocked"
+    return {
+        "schema": SCHEMA,
+        "generated_at": generated_at.isoformat(),
+        "kind": "agilab.shared_go_gate",
+        "decision": decision,
+        "summary": {
+            "failed_checks": failed,
+            "install_profiles": list(install_profiles),
+            "go_gate": "clean strict security-check plus fresh profile-specific SBOM and pip-audit evidence",
+        },
+        "checks": checks,
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Persist AGILAB's hardened shared/team use decision from security-check "
+            "and profile-specific supply-chain evidence."
+        )
+    )
+    parser.add_argument("--security-check-json", type=Path, default=DEFAULT_SECURITY_CHECK)
+    parser.add_argument("--supply-chain-dir", type=Path, default=DEFAULT_SUPPLY_CHAIN_DIR)
+    parser.add_argument(
+        "--install-profile",
+        action="append",
+        choices=[*INSTALL_PROFILES, "all"],
+        help="Deployed install profile to require. Repeatable. Defaults to base.",
+    )
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument("--artifact-max-age-days", type=int, default=DEFAULT_MAX_AGE_DAYS)
+    parser.add_argument("--strict", action="store_true", help="Exit non-zero when the gate is blocked.")
+    parser.add_argument("--json", action="store_true", help="Print the full gate artifact to stdout.")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(list(argv) if argv is not None else None)
+    install_profiles = _expand_profiles(args.install_profile)
+    gate = build_gate(
+        security_check_json=args.security_check_json,
+        supply_chain_dir=args.supply_chain_dir,
+        install_profiles=install_profiles,
+        max_age_days=args.artifact_max_age_days,
+    )
+    output = args.output.expanduser()
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(gate, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if args.json:
+        print(json.dumps(gate, indent=2, sort_keys=True))
+    else:
+        mode = "strict" if args.strict else "advisory"
+        failed = ",".join(gate["summary"]["failed_checks"]) or "none"
+        print(
+            f"shared go gate artifact: {output} decision={gate['decision']} "
+            f"profiles={','.join(install_profiles)} failed={failed} mode={mode}"
+        )
+    return 1 if args.strict and gate["decision"] != "go" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/workflow_parity.py
+++ b/tools/workflow_parity.py
@@ -1335,7 +1335,25 @@ def _security_adoption_profile() -> list[CommandSpec]:
             timeout_seconds=2 * 60,
             ensure_dirs=["test-results"],
             remove_paths=["test-results/security-check.json"],
-        )
+        ),
+        CommandSpec(
+            label="shared-use go gate artifact",
+            argv=[
+                "uv",
+                "--preview-features",
+                "extra-build-dependencies",
+                "run",
+                "python",
+                "tools/shared_go_gate.py",
+                "--security-check-json",
+                "test-results/security-check.json",
+                "--output",
+                "test-results/shared_go_gate.json",
+            ],
+            timeout_seconds=2 * 60,
+            ensure_dirs=["test-results"],
+            remove_paths=["test-results/shared_go_gate.json"],
+        ),
     ]
 
 


### PR DESCRIPTION
## Summary
- rename shared/team adoption from conditional wording to an explicit hardened go gate
- add tools/shared_go_gate.py and wire it into the security-adoption workflow profile
- require public-bind evidence for shared/public security-check profiles
- improve SSHFS cluster setup diagnostics for non-interactive PATH and scheduler SSH reachability
- add trusted shared deployment docs and sync the public docs mirror

## Validation
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_shared_go_gate.py test/test_security_check.py test/test_ui_public_bind_guard.py test/test_cluster_flight_validation.py src/agilab/core/test/test_agi_distributor_deployment_remote_support.py test/test_audit_response_docs.py test/test_governance_supply_chain_contract.py
- uv --preview-features extra-build-dependencies run python tools/security_hygiene_report.py --compact
- uv --preview-features extra-build-dependencies run python tools/architecture_scorecard.py --compact
- uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile security-adoption
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs

Note: security-adoption writes a blocked advisory shared_go_gate.json in this local developer checkout because strict shared controls and supply-chain artifacts are intentionally not present locally.