### PR TITLE
[codex] Fix dispatcher audit findings

### DIFF
--- a/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/agi_dispatcher.py
+++ b/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/agi_dispatcher.py
@@ -42,12 +42,11 @@ RUN_STAGES_KEY = "_agilab_run_stages"
 class WorkDispatcher:
     """Builds and runs distribution plans for target applications."""
 
-    args = {}
     verbose = None
 
     def __init__(self, args=None):
         """Store ``args`` for later use when evaluating distribution plans."""
-        WorkDispatcher.args = args  # ty: ignore[invalid-assignment]
+        self.args = args or {}
 
     @staticmethod
     def _split_dispatch_args(args):
@@ -75,9 +74,6 @@ class WorkDispatcher:
             setattr(args_obj, "args", run_stages)
         else:
             raise TypeError(f"{type(target_inst).__name__} does not accept RunRequest.stages")
-
-        if isinstance(WorkDispatcher.args, dict):
-            WorkDispatcher.args["args"] = run_stages
 
     @staticmethod
     def _convert_functions_to_names(workers_plan):
@@ -205,9 +201,13 @@ class WorkDispatcher:
             os.chmod(path, stat.S_IWUSR)
             # Try the operation again
             func(path)
-        # else:
-        # Reraise the error if it's not a permission issue
-        # raise
+            return
+
+        exc_value = exc_info[1] if len(exc_info) > 1 else None
+        if isinstance(exc_value, BaseException):
+            traceback_obj = exc_info[2] if len(exc_info) > 2 else None
+            raise exc_value.with_traceback(traceback_obj)
+        raise RuntimeError(f"failed to remove {path!r}")
 
     @staticmethod
     def make_chunks(
@@ -431,13 +431,23 @@ class WorkDispatcher:
                 return importlib.import_module(module)
 
         except ModuleNotFoundError as e:
-            module_to_install = (str(e).replace("No module named ", "").lower().replace("'", ""))
             # Only attempt install if an environment is provided
             if env is None or attempted_install:
                 raise
+            if not WorkDispatcher._runtime_auto_install_enabled(env):
+                logger.error(
+                    "runtime dependency auto-install refused for missing module %s; "
+                    "declare the dependency in the app or set AGILAB_RUNTIME_AUTO_INSTALL=1",
+                    getattr(e, "name", None) or str(e),
+                )
+                raise
+            module_to_install = WorkDispatcher._missing_module_name(e)
+            if not module_to_install:
+                raise
             app_path = env.active_app
             cmd = f"{env.uv} add --upgrade {module_to_install}"
-            logging.info(f"{cmd} from {app_path}")
+            await WorkDispatcher._record_runtime_auto_install_event(env, module_to_install, cmd, app_path)
+            logger.warning("runtime dependency auto-install: %s from %s", cmd, app_path)
             await AgiEnv.run(cmd, app_path)
             return await WorkDispatcher._load_module(
                 module,
@@ -446,3 +456,32 @@ class WorkDispatcher:
                 env=env,
                 attempted_install=True,
             )
+
+    @staticmethod
+    def _runtime_auto_install_enabled(env) -> bool:
+        value = getattr(env, "runtime_auto_install", None)
+        if value is None:
+            value = os.environ.get("AGILAB_RUNTIME_AUTO_INSTALL", "")
+        return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+    @staticmethod
+    def _missing_module_name(exc: ModuleNotFoundError) -> str:
+        name = getattr(exc, "name", None)
+        if name:
+            return str(name).strip().lower()
+        return str(exc).replace("No module named ", "").lower().replace("'", "").strip()
+
+    @staticmethod
+    async def _record_runtime_auto_install_event(env, module_name: str, cmd: str, app_path: Path) -> None:
+        event = {
+            "event": "runtime_dependency_auto_install",
+            "module": module_name,
+            "command": cmd,
+            "app_path": str(app_path),
+        }
+        recorder = getattr(env, "record_provenance_event", None)
+        if not callable(recorder):
+            return
+        result = recorder(event)
+        if hasattr(result, "__await__"):
+            await result

--- a/src/agilab/core/test/test_work_dispatcher.py
+++ b/src/agilab/core/test/test_work_dispatcher.py
@@ -31,10 +31,14 @@ def test_convert_functions_to_names_handles_nested_callables():
     assert converted["root"][1][1]["cb"] == "<lambda>"
 
 
-def test_dispatcher_init_sets_class_args():
+def test_dispatcher_init_sets_instance_args_without_class_state():
     payload = {"x": 1}
-    WorkDispatcher(payload)
-    assert WorkDispatcher.args == payload
+    first = WorkDispatcher(payload)
+    second = WorkDispatcher({"x": 2})
+
+    assert first.args == payload
+    assert second.args == {"x": 2}
+    assert "args" not in WorkDispatcher.__dict__
 
 
 @pytest.mark.asyncio
@@ -58,12 +62,10 @@ async def test_do_distrib_keeps_run_stages_out_of_constructor_and_injects_model_
         def __init__(self, env, **kwargs):
             constructor_args.append(kwargs)
             self.args = SimpleNamespace(data_in=kwargs["data_in"], args=[])
-            WorkDispatcher.args = {"data_in": kwargs["data_in"], "args": []}
 
         def build_distribution(self, assigned_workers):
             assert assigned_workers == {"127.0.0.1": 1}
             assert self.args.args == stage_payload
-            assert WorkDispatcher.args["args"] == stage_payload
             return [["chunk"]], [{"meta": 1}], "partition", 1, 1.0
 
     monkeypatch.setattr(
@@ -337,6 +339,16 @@ def test_onerror_handles_permission_issue(monkeypatch):
     assert captured["path"] == "dummy_path"
 
 
+def test_onerror_reraises_non_permission_issue(monkeypatch):
+    monkeypatch.setattr("os.access", lambda path, mode: True)
+    original = RuntimeError("remove failed")
+
+    with pytest.raises(RuntimeError, match="remove failed") as caught:
+        WorkDispatcher._onerror(lambda _: None, "dummy_path", (RuntimeError, original, None))
+
+    assert caught.value is original
+
+
 def test_make_chunks_selects_optimal_or_fastest(monkeypatch):
     monkeypatch.setattr(WorkDispatcher, "_make_chunks_optimal", lambda *_args, **_kwargs: [["optimal"]])
     monkeypatch.setattr(WorkDispatcher, "_make_chunks_fastest", lambda *_args, **_kwargs: [["fastest"]])
@@ -409,32 +421,64 @@ def test_make_chunks_optimal_and_fastest_real_paths():
 
 
 @pytest.mark.asyncio
-async def test_load_module_requests_install(monkeypatch, tmp_path):
-    import_calls = []
+async def test_load_module_refuses_runtime_auto_install_by_default(monkeypatch, tmp_path):
+    def fake_import(_name):
+        raise ModuleNotFoundError("No module named 'missing_pkg'", name="missing_pkg")
 
-    def fake_import(name):
-        import_calls.append(name)
-        if len(import_calls) == 1:
-            raise ModuleNotFoundError("No module named 'missing_pkg'")
-        return "module"
-
-    recorded: list[tuple[str, Path]] = []
-
-    async def fake_run(cmd, app_path):
-        recorded.append((cmd, app_path))
+    async def fake_run(_cmd, _app_path):  # pragma: no cover - must not run
+        raise AssertionError("runtime auto-install should be opt-in")
 
     monkeypatch.setattr(dispatcher_module.importlib, "import_module", fake_import)
     monkeypatch.setattr(dispatcher_module.AgiEnv, "run", fake_run)
+    monkeypatch.delenv("AGILAB_RUNTIME_AUTO_INSTALL", raising=False)
 
     env = SimpleNamespace(
         uv="uv",
         active_app=tmp_path,
     )
 
+    with pytest.raises(ModuleNotFoundError):
+        await WorkDispatcher._load_module("demo", env=env)
+
+
+@pytest.mark.asyncio
+async def test_load_module_requests_install_when_explicitly_enabled(monkeypatch, tmp_path):
+    import_calls = []
+
+    def fake_import(name):
+        import_calls.append(name)
+        if len(import_calls) == 1:
+            raise ModuleNotFoundError("No module named 'missing_pkg'", name="missing_pkg")
+        return "module"
+
+    recorded: list[tuple[str, Path]] = []
+    events: list[dict[str, str]] = []
+
+    async def fake_run(cmd, app_path):
+        recorded.append((cmd, app_path))
+
+    monkeypatch.setattr(dispatcher_module.importlib, "import_module", fake_import)
+    monkeypatch.setattr(dispatcher_module.AgiEnv, "run", fake_run)
+    monkeypatch.setenv("AGILAB_RUNTIME_AUTO_INSTALL", "1")
+
+    env = SimpleNamespace(
+        uv="uv",
+        active_app=tmp_path,
+        record_provenance_event=events.append,
+    )
+
     result = await WorkDispatcher._load_module("demo", env=env)
 
     assert result == "module"
     assert recorded == [("uv add --upgrade missing_pkg", tmp_path)]
+    assert events == [
+        {
+            "event": "runtime_dependency_auto_install",
+            "module": "missing_pkg",
+            "command": "uv add --upgrade missing_pkg",
+            "app_path": str(tmp_path),
+        }
+    ]
     assert len(import_calls) == 2
 
 


### PR DESCRIPTION
## What changed

- Moved `WorkDispatcher(args)` state from shared class mutation to per-instance state.
- Removed the `WorkDispatcher.args` run-stage mutation path so one dispatch cannot leak stage payloads into another dispatch in the same process.
- Made `WorkDispatcher._onerror()` fail closed for non-permission cleanup failures instead of silently swallowing them.
- Changed runtime missing-module handling to fail closed by default; implicit `uv add --upgrade ...` now requires explicit `AGILAB_RUNTIME_AUTO_INSTALL=1` or `env.runtime_auto_install`.
- Added a provenance hook for explicit runtime auto-installs via `env.record_provenance_event(...)` when available.
- Added targeted core regressions for instance isolation, cleanup re-raise behavior, default auto-install refusal, explicit opt-in install, and provenance recording.

## Why

This addresses the bounded dispatcher issues from the external review without taking on the larger `AgiEnv` singleton redesign in the same PR.

## Validation

- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' src/agilab/core/test/test_work_dispatcher.py`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files src/agilab/core/agi-node/src/agi_node/agi_dispatcher/agi_dispatcher.py src/agilab/core/test/test_work_dispatcher.py`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile shared-core-typing`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' src/agilab/core/test/test_agi_dispatcher_build_main_support.py src/agilab/core/test/test_agi_dispatcher_post_install_support.py src/agilab/core/test/test_agi_dispatcher_scripts.py src/agilab/core/test/test_work_dispatcher.py`
- `uv --preview-features extra-build-dependencies run --no-sync pytest -q -o addopts='' src/agilab/core/test`
- `git diff --check`
