### PR TITLE
[codex] Guard AgiEnv singleton reinitialization

### DIFF
--- a/src/agilab/core/agi-env/src/agi_env/agi_env.py
+++ b/src/agilab/core/agi-env/src/agi_env/agi_env.py
@@ -353,7 +353,26 @@ class AgiEnv(metaclass=_AgiEnvMeta):
                  python_variante: str = '',
                  **kwargs):
 
+        allow_reinitialize = bool(kwargs.pop("_agilab_reinitialize", False))
         app, active_app_override = coerce_active_app_request(app, kwargs, path_cls=Path)
+        init_signature = self._init_signature(
+            apps_path=apps_path,
+            app=app,
+            active_app_override=active_app_override,
+            verbose=0 if verbose is None else verbose,
+            debug=debug,
+            python_variante=python_variante,
+            kwargs=kwargs,
+        )
+
+        if getattr(self, "_agilab_initialized", False) and not allow_reinitialize:
+            current_signature = getattr(self, "_agilab_init_signature", None)
+            if current_signature == init_signature:
+                return
+            raise RuntimeError(
+                "AgiEnv is already initialised with a different configuration; "
+                "use AgiEnv.reset() for a fresh environment or change_app() to switch apps."
+            )
 
         self.skip_repo_links = False
         self.AGILAB_SHARE_HINT = None
@@ -697,6 +716,40 @@ class AgiEnv(metaclass=_AgiEnvMeta):
             self.export_local_bin = 'export PATH="~/.local/bin:$PATH";'
         # export_local_bin available via singleton delegation if accessed as AgiEnv.export_local_bin
 
+        self._agilab_init_signature = init_signature
+        self._agilab_initialized = True
+
+    @staticmethod
+    def _init_signature(
+        *,
+        apps_path: Path | None,
+        app: str | None,
+        active_app_override,
+        verbose: int,
+        debug: bool,
+        python_variante: str,
+        kwargs: dict,
+    ) -> tuple:
+        return (
+            AgiEnv._signature_value(apps_path),
+            AgiEnv._signature_value(app),
+            AgiEnv._signature_value(active_app_override),
+            int(verbose),
+            bool(debug),
+            str(python_variante),
+            tuple(sorted((str(key), AgiEnv._signature_value(value)) for key, value in kwargs.items())),
+        )
+
+    @staticmethod
+    def _signature_value(value):
+        if isinstance(value, Path):
+            try:
+                return ("path", str(value.expanduser().resolve(strict=False)))
+            except (OSError, RuntimeError):
+                return ("path", str(value))
+        if isinstance(value, (str, int, float, bool, type(None))):
+            return value
+        return repr(value)
 
     @staticmethod
     def _resolve_package(root: Path) -> Path:
@@ -1411,6 +1464,7 @@ class AgiEnv(metaclass=_AgiEnvMeta):
                 apps_path=active_app.parent,
                 app=requested_name,
                 verbose=AgiEnv.verbose,
+                _agilab_reinitialize=True,
             )
         finally:
             if sys.exc_info()[0] is not None and active_app.exists():

--- a/src/agilab/core/agi-env/src/agi_env/bootstrap_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/bootstrap_support.py
@@ -123,7 +123,7 @@ def resolve_requested_apps_path(
         apps_path = path_cls(explicit_apps_path).expanduser()
         try:
             apps_path = apps_path.resolve()
-        except FileNotFoundError:
+        except (FileNotFoundError, OSError, RuntimeError):
             pass
         return apps_path, None
 

--- a/src/agilab/core/agi-env/test/test_agi_env.py
+++ b/src/agilab/core/agi-env/test/test_agi_env.py
@@ -903,6 +903,37 @@ def test_agienv_meta_handles_missing_instance_slot_and_current_returns_cached_in
         AgiEnv.reset()
 
 
+def test_agienv_constructor_is_idempotent_for_same_configuration(env, monkeypatch):
+    def _fail_load(*_args, **_kwargs):  # pragma: no cover - must not run
+        raise AssertionError("AgiEnv reloaded dotenv on an idempotent construction")
+
+    monkeypatch.setattr(agi_env_module, "_load_dotenv_values", _fail_load)
+
+    same_env = AgiEnv(apps_path=env.apps_path, app=env.app, verbose=env.verbose)
+
+    assert same_env is env
+    assert same_env.active_app == env.active_app
+
+
+def test_agienv_constructor_rejects_conflicting_reinitialization(env):
+    with pytest.raises(RuntimeError, match="already initialised with a different configuration"):
+        AgiEnv(apps_path=env.apps_path, app="other_project", verbose=env.verbose)
+
+
+def test_change_app_marks_reinitialization_as_intentional(monkeypatch, env):
+    called = {"kwargs": None}
+
+    def fake_init(self, *a, **k):
+        called["kwargs"] = k
+
+    apps_path = AgiEnv.locate_agilab_installation(verbose=False) / "apps"
+    env.app = apps_path / "mycode_project"
+    with mock.patch.object(AgiEnv, "__init__", fake_init, create=True):
+        env.change_app("mycode_path")
+
+    assert called["kwargs"]["_agilab_reinitialize"] is True
+
+
 def test_init_worker_env_flag_requires_app_and_sets_skip_repo_links(tmp_path: Path, monkeypatch):
     fake_home = tmp_path / "worker-home"
     fake_home.mkdir()


### PR DESCRIPTION
## What changed

- Added an `AgiEnv` initialization signature so repeated construction with the same configuration is idempotent.
- Refused conflicting `AgiEnv(...)` construction once the process-wide singleton is initialized, with guidance to use `AgiEnv.reset()` or `change_app()`.
- Marked `change_app()` as the explicit, intentional reinitialization path.
- Hardened explicit `apps_path` resolution fallback when `Path.resolve()` raises runtime/OS failures, preserving the existing install-type fallback behavior.
- Added regressions for idempotent construction, conflicting construction refusal, and intentional `change_app()` reinitialization.

## Why

This addresses the high-priority review finding that `AgiEnv.__new__` caches a singleton while `__init__` re-runs on every construction, letting GUI pages and tests silently mutate the shared process environment.

## Validation

- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' src/agilab/core/agi-env/test/test_agi_env.py`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files src/agilab/core/agi-env/src/agi_env/agi_env.py src/agilab/core/agi-env/src/agi_env/bootstrap_support.py src/agilab/core/agi-env/test/test_agi_env.py`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile shared-core-typing`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_agi_env.py src/agilab/core/agi-env/test/test_agi_env.py src/agilab/core/agi-env/test/test_agi_env_helper_branch_sweep.py src/agilab/core/agi-env/test/test_agi_env_remaining_coverage.py src/agilab/core/agi-env/test/test_bootstrap_support.py`
- `uv --preview-features extra-build-dependencies run --no-sync pytest -q -o addopts='' src/agilab/core/agi-env/test`
- `git diff --check`

## Separate follow-up

A pre-existing `tools/build_product_demo_reel.py` change was intentionally kept out of this PR and will be handled separately.
