### PR TITLE
[codex] Isolate root tests from real home

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 import importlib.util
 import shutil
@@ -27,9 +28,19 @@ if TYPE_CHECKING:
     from streamlit.testing.v1 import AppTest
 
 
+_ORIGINAL_PATH_HOME = Path.home
 REAL_HOME = Path.home().resolve()
 REPO_ROOT = Path(__file__).resolve().parents[1]
 AGILAB_PACKAGE_ROOT = REPO_ROOT / "src" / "agilab"
+
+
+def _home_from_env() -> Path:
+    """Resolve Path.home() from HOME inside tests, including on Windows."""
+
+    home = os.environ.get("HOME")
+    if home:
+        return Path(home)
+    return _ORIGINAL_PATH_HOME()
 
 
 def _ensure_agilab_package_spec() -> None:
@@ -68,11 +79,29 @@ def isolate_home_for_root_tests(tmp_path, monkeypatch):
     """Keep runner-local ~/.agilab state from leaking into root test imports."""
     fake_home = tmp_path / "fake_home"
     fake_home.mkdir()
+    fake_localappdata = fake_home / "AppData" / "Local"
+    fake_roaming_appdata = fake_home / "AppData" / "Roaming"
+    fake_agilab = fake_home / ".agilab"
+    fake_localappdata.mkdir(parents=True)
+    fake_roaming_appdata.mkdir(parents=True)
+    fake_agilab.mkdir(parents=True)
+    (fake_agilab / ".env").write_text(
+        "AGI_CLUSTER_SHARE=\nAGI_LOCAL_SHARE=\nAPPS_REPOSITORY=\nOPENAI_API_KEY=\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(Path, "home", staticmethod(_home_from_env))
     monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.setenv("USERPROFILE", str(fake_home))
+    monkeypatch.setenv("HOMEDRIVE", str(fake_home.drive) if fake_home.drive else "")
+    monkeypatch.setenv("HOMEPATH", str(fake_home)[len(fake_home.drive):] if fake_home.drive else str(fake_home))
+    monkeypatch.setenv("LOCALAPPDATA", str(fake_localappdata))
+    monkeypatch.setenv("APPDATA", str(fake_roaming_appdata))
     monkeypatch.delenv("AGI_CLUSTER_ENABLED", raising=False)
-    monkeypatch.delenv("AGI_CLUSTER_SHARE", raising=False)
+    monkeypatch.setenv("AGI_CLUSTER_SHARE", "")
+    monkeypatch.setenv("AGI_LOCAL_SHARE", "")
     monkeypatch.delenv("APPS_REPOSITORY", raising=False)
     monkeypatch.delenv("APP_DEFAULT", raising=False)
+    monkeypatch.delenv("AGILAB_LOG_ABS", raising=False)
     # Root tests must not inherit developer-shell secrets. Individual tests that
     # need these values should opt in explicitly with monkeypatch/setenv.
     monkeypatch.delenv("CLUSTER_CREDENTIALS", raising=False)
@@ -93,6 +122,9 @@ def isolate_home_for_root_tests(tmp_path, monkeypatch):
 
     repo_agilab_dir = (Path(__file__).resolve().parents[1] / "src" / "agilab").resolve()
     (share_dir / ".agilab-path").write_text(str(repo_agilab_dir) + "\n", encoding="utf-8")
+    localappdata_agilab = fake_localappdata / "agilab"
+    localappdata_agilab.mkdir(parents=True, exist_ok=True)
+    (localappdata_agilab / ".agilab-path").write_text(str(repo_agilab_dir) + "\n", encoding="utf-8")
 
 
 @pytest.fixture(autouse=True)

--- a/test/test_root_test_environment_isolation.py
+++ b/test/test_root_test_environment_isolation.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def test_root_tests_patch_path_home_to_isolated_home() -> None:
+    fake_home = Path(os.environ["HOME"])
+
+    assert Path.home() == fake_home
+    assert os.environ["USERPROFILE"] == str(fake_home)
+    assert os.environ["LOCALAPPDATA"] == str(fake_home / "AppData" / "Local")
+    assert os.environ["APPDATA"] == str(fake_home / "AppData" / "Roaming")
+    assert os.environ["AGI_CLUSTER_SHARE"] == ""
+    assert os.environ["AGI_LOCAL_SHARE"] == ""
+
+    env_file = fake_home / ".agilab" / ".env"
+    assert env_file.exists()
+    assert "AGI_CLUSTER_SHARE=" in env_file.read_text(encoding="utf-8")
+
+
+def test_root_tests_seed_isolated_agilab_path_markers() -> None:
+    fake_home = Path(os.environ["HOME"])
+    marker = fake_home / ".local" / "share" / "agilab" / ".agilab-path"
+    windows_marker = Path(os.environ["LOCALAPPDATA"]) / "agilab" / ".agilab-path"
+
+    assert marker.exists()
+    assert windows_marker.exists()
+    assert marker.read_text(encoding="utf-8") == windows_marker.read_text(encoding="utf-8")


### PR DESCRIPTION
## What changed

- Patched root-test `Path.home()` to resolve from the fixture-owned `HOME`, including on Windows where `USERPROFILE` normally wins.
- Seeded isolated Windows profile variables (`USERPROFILE`, `HOMEDRIVE`, `HOMEPATH`, `LOCALAPPDATA`, `APPDATA`) for root tests.
- Seeded fake `.agilab/.env` and both Unix-style and Windows-style `.agilab-path` markers under the fake home.
- Added root regression tests proving `Path.home()`, profile env vars, blank share env vars, and `.agilab-path` markers are isolated.

## Why

This addresses the next high-priority review issue: Windows/root tests can leak real `~/.agilab`, AppData `.agilab-path`, and profile paths unless `Path.home()` and Windows profile variables are isolated, not just `HOME`.

## Validation

- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_root_test_environment_isolation.py test/test_agi_env.py`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files test/conftest.py test/test_root_test_environment_isolation.py`
- `uv --preview-features extra-build-dependencies run --extra ui --extra viz pytest -q -o addopts='' test/test_ci_workflow.py test/test_view_maps_3d.py::test_view_maps_3d_warns_when_no_dataset_exists test/test_root_test_environment_isolation.py`
- `git diff --check`

Note: the same impact-suggested UI slice fails in the base environment because `streamlit`/`plotly` are optional extras; it passes with `ui+viz`.
