### PR TITLE
[codex] Make subprocess venv paths target-platform aware

### DIFF
--- a/src/agilab/core/agi-env/src/agi_env/process_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/process_support.py
@@ -39,6 +39,13 @@ UV_LINK_MODE_VALUES = {"clone", "copy", "hardlink", "symlink"}
 DEFAULT_UV_LINK_MODE = "hardlink"
 
 
+def virtualenv_bin_dir_name(*, os_name: str | None = None) -> str:
+    """Return the virtualenv executable directory name for ``os_name``."""
+
+    platform_name = os.name if os_name is None else os_name
+    return "Scripts" if platform_name == "nt" else "bin"
+
+
 def _is_virtualenv_path(path: Path) -> bool:
     # Accept the legacy ``bin`` directory in addition to the platform default so
     # tests and tools that stage cross-platform virtualenv shapes still work.
@@ -124,6 +131,7 @@ def build_subprocess_env(
     venv=None,
     pythonpath_entries: Sequence[str] | None = None,
     sys_prefix: str | Path | None = None,
+    os_name: str | None = None,
 ) -> dict[str, str]:
     """Build an isolated subprocess environment for a target virtualenv."""
 
@@ -134,7 +142,7 @@ def build_subprocess_env(
     venv_path = None
     if venv is not None:
         venv_path = Path(venv)
-        bin_dir = "Scripts" if os.name == "nt" else "bin"
+        bin_dir = virtualenv_bin_dir_name(os_name=os_name)
         if (
             not (venv_path / bin_dir).exists()
             and not (venv_path / "bin").exists()

--- a/src/agilab/core/agi-env/test/test_process_support.py
+++ b/src/agilab/core/agi-env/test/test_process_support.py
@@ -200,6 +200,23 @@ def test_build_subprocess_env_keeps_pythonpath_entries_for_current_venv(tmp_path
     assert "PYTHONHOME" not in env
 
 
+def test_build_subprocess_env_can_target_windows_venv_layout(tmp_path: Path):
+    base_env = {"PATH": "/usr/bin"}
+    project_dir = tmp_path / "project"
+    windows_venv = project_dir / ".venv"
+    (windows_venv / "Scripts").mkdir(parents=True)
+
+    env = process_support.build_subprocess_env(
+        base_env=base_env,
+        venv=project_dir,
+        os_name="nt",
+        sys_prefix=sys.prefix,
+    )
+
+    assert env["VIRTUAL_ENV"] == str(windows_venv)
+    assert env["PATH"].split(os.pathsep)[0] == str(windows_venv / "Scripts")
+
+
 def test_last_non_empty_output_line_skips_blank_entries():
     lines = [None, "   ", "\n", " useful detail  "]
 


### PR DESCRIPTION
## Summary

- Add a target-OS aware virtualenv executable-directory helper in `agi_env.process_support`.
- Let `build_subprocess_env` build Windows `.venv/Scripts` PATH entries from a non-Windows host.
- Add a regression test for Windows-target virtualenv layout construction.

## Validation

- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files src/agilab/core/agi-env/src/agi_env/process_support.py src/agilab/core/agi-env/test/test_process_support.py`
- `uv --preview-features extra-build-dependencies run --no-sync pytest -q -o addopts='' src/agilab/core/agi-env/test/test_process_support.py`
- `uv --preview-features extra-build-dependencies run --no-sync pytest -q -o addopts='' src/agilab/core/agi-env/test`
- `git diff --check`