### PR TITLE
[codex] Add local artifact clean shortcut

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,8 @@ Use this runbook whenever you:
   state,
   `flow` for one or more workflow parity profiles,
   `release` for local pre-tag release guards, `badge` for the explicit release/pre-release
-  coverage-badge guard, and `docs` for docs mirror sync plus stamp verification. `impact` tells you what must be validated, `test` runs the
+  coverage-badge guard, `docs` for docs mirror sync plus stamp verification, and
+  `clean` for stale local build/lib duplicate-source cleanup. `impact` tells you what must be validated, `test` runs the
   narrow pytest slice, `lint` provisions Ruff through `uv --extra dev` so it does not depend
   on an already-synced local venv, `bugfix` is the default low-load pre-push loop for normal code fixes,
   `regress` optimizes a likely regression subset from changed files and optional JUnit timings,
@@ -46,8 +47,9 @@ Use this runbook whenever you:
   `audit` is the quick robustness check before handoff between machines,
   `flow` matches local GitHub workflow profiles, `release` checks impact, generated PyPI release
   plan, trusted-publisher contract, Ruff availability, dependency policy, strict typing, docs, and badges before a tag,
-  `badge` checks badge freshness when intentionally requested, and `docs` keeps the public mirror
-  aligned. Use `--print-only` to audit the expanded commands.
+  `badge` checks badge freshness when intentionally requested, `docs` keeps the public mirror
+  aligned, and `clean` dry-runs removal of ignored local build/lib duplicates unless `--apply`
+  is passed. Use `--print-only` to audit the expanded commands.
 - **Upgrade packaged tools first**: Before launching the published CLI with `uvx
   agilab`, run `uv --preview-features extra-build-dependencies tool install --upgrade agilab` to install or pick up the latest wheel.
 - **No repo uvx**: Reserve `uvx` for packaged installs outside this checkout. Launching

--- a/test/test_agilab_dev_shortcuts.py
+++ b/test/test_agilab_dev_shortcuts.py
@@ -468,6 +468,33 @@ def test_docs_shortcut_syncs_and_verifies_mirror():
     ]
 
 
+def test_clean_shortcut_runs_local_artifact_cleaner_dry_run_by_default():
+    assert agilab_dev.planned_commands(["clean"]) == [
+        [
+            "uv",
+            "--preview-features",
+            "extra-build-dependencies",
+            "run",
+            "python",
+            "tools/clean_local_artifacts.py",
+        ]
+    ]
+
+
+def test_clean_shortcut_keeps_apply_flag():
+    assert agilab_dev.planned_commands(["clean", "--apply"]) == [
+        [
+            "uv",
+            "--preview-features",
+            "extra-build-dependencies",
+            "run",
+            "python",
+            "tools/clean_local_artifacts.py",
+            "--apply",
+        ]
+    ]
+
+
 def test_skills_shortcut_syncs_then_validates_and_generates():
     assert agilab_dev.planned_commands(["skills", "agilab-runbook"]) == [
         ["python3", "tools/sync_agent_skills.py", "--skills", "agilab-runbook"],

--- a/test/test_clean_local_artifacts.py
+++ b/test/test_clean_local_artifacts.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "tools" / "clean_local_artifacts.py"
+
+spec = importlib.util.spec_from_file_location("clean_local_artifacts", MODULE_PATH)
+assert spec is not None and spec.loader is not None
+clean_local_artifacts = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(clean_local_artifacts)
+
+
+def _seed_stale_build_libs(root: Path) -> list[Path]:
+    targets = [
+        root / "src/agilab/core/agi-env/build/lib",
+        root / "src/agilab/core/agi-node/build/lib",
+    ]
+    for target in targets:
+        target.mkdir(parents=True)
+        (target / "stale.py").write_text("VALUE = 1\n", encoding="utf-8")
+    return targets
+
+
+def test_clean_stale_build_libs_dry_run_keeps_existing_trees(tmp_path: Path) -> None:
+    targets = _seed_stale_build_libs(tmp_path)
+
+    results = clean_local_artifacts.clean_stale_build_libs(tmp_path, apply=False)
+
+    assert [result.action for result in results] == ["would-remove", "would-remove"]
+    assert [result.path for result in results] == [
+        "src/agilab/core/agi-env/build/lib",
+        "src/agilab/core/agi-node/build/lib",
+    ]
+    assert all(target.exists() for target in targets)
+
+
+def test_clean_stale_build_libs_apply_removes_existing_trees(tmp_path: Path) -> None:
+    targets = _seed_stale_build_libs(tmp_path)
+
+    results = clean_local_artifacts.clean_stale_build_libs(tmp_path, apply=True)
+
+    assert [result.action for result in results] == ["removed", "removed"]
+    assert all(not target.exists() for target in targets)
+
+
+def test_clean_stale_build_libs_reports_missing_trees(tmp_path: Path) -> None:
+    results = clean_local_artifacts.clean_stale_build_libs(tmp_path, apply=True)
+
+    assert [result.action for result in results] == ["missing", "missing"]

--- a/tools/agilab_dev.py
+++ b/tools/agilab_dev.py
@@ -134,6 +134,9 @@ def planned_commands(argv: Sequence[str]) -> list[list[str]]:
             _uv_python("tools/sync_docs_source.py", "--verify-stamp"),
         ]
 
+    if command == "clean":
+        return [_uv_python("tools/clean_local_artifacts.py", *args)]
+
     if command == "skills":
         skills, extras = _split_leading_values(args, command_name=command)
         return [
@@ -164,6 +167,7 @@ def _usage() -> str:
   ./dev [--print-only] release [impact_validate args]
   ./dev [--print-only] badge|guard [coverage_badge_guard args]
   ./dev [--print-only] docs
+  ./dev [--print-only] clean [--apply]
   ./dev [--print-only] skills <skill> [skill...]
 
 High-frequency mappings:
@@ -181,6 +185,7 @@ High-frequency mappings:
   release   -> Run local release guards: impact, generated PyPI plan, release cadence, PyPI project preflight, trusted publisher contract, Ruff availability, docs, dependency policy, typing, and badge freshness.
   badge     -> Run the explicit release/pre-release coverage badge freshness guard.
   docs      -> Sync docs from the canonical docs checkout and verify the mirror stamp.
+  clean     -> Dry-run cleanup of ignored local build/lib duplicate-source trees; pass --apply to remove them.
   skills    -> Sync repo skills from Claude to Codex, validate, regenerate indexes/catalog/badges, and scan skill risk.
 """
 

--- a/tools/clean_local_artifacts.py
+++ b/tools/clean_local_artifacts.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Remove ignored local artifacts that commonly pollute AGILAB checkouts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import NamedTuple, Sequence
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+STALE_BUILD_LIB_DIRS = (
+    Path("src/agilab/core/agi-env/build/lib"),
+    Path("src/agilab/core/agi-node/build/lib"),
+)
+
+
+class CleanResult(NamedTuple):
+    path: str
+    action: str
+    exists: bool
+
+
+def repo_root(repo: str | Path) -> Path:
+    """Return the Git repository root for ``repo``."""
+
+    completed = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        cwd=Path(repo),
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return Path(completed.stdout.strip()).resolve()
+
+
+def stale_build_lib_paths(root: Path) -> list[Path]:
+    """Return known stale setuptools ``build/lib`` duplicate-source trees."""
+
+    return [root / rel for rel in STALE_BUILD_LIB_DIRS]
+
+
+def _is_safe_clean_target(root: Path, target: Path) -> bool:
+    resolved_root = root.resolve()
+    resolved_target = target.resolve(strict=False)
+    try:
+        resolved_target.relative_to(resolved_root)
+    except ValueError:
+        return False
+    return resolved_target.name == "lib" and resolved_target.parent.name == "build"
+
+
+def clean_stale_build_libs(root: Path, *, apply: bool = False) -> list[CleanResult]:
+    """Dry-run or remove known stale ``build/lib`` duplicate-source trees."""
+
+    results: list[CleanResult] = []
+    for target in stale_build_lib_paths(root):
+        rel = target.relative_to(root).as_posix()
+        exists = target.exists()
+        if not exists:
+            results.append(CleanResult(path=rel, action="missing", exists=False))
+            continue
+        if not _is_safe_clean_target(root, target):
+            raise RuntimeError(f"Refusing unsafe clean target: {target}")
+        if apply:
+            shutil.rmtree(target)
+            results.append(CleanResult(path=rel, action="removed", exists=True))
+        else:
+            results.append(CleanResult(path=rel, action="would-remove", exists=True))
+    return results
+
+
+def _print_human(results: Sequence[CleanResult], *, apply: bool) -> None:
+    actionable = [result for result in results if result.action != "missing"]
+    if not actionable:
+        print("No stale local build/lib artifacts found.")
+        return
+
+    verb = "Removed" if apply else "Would remove"
+    for result in actionable:
+        print(f"{verb}: {result.path}")
+    if not apply:
+        print("Dry run only. Re-run with --apply to remove these ignored local artifacts.")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Clean ignored AGILAB local artifacts that duplicate source trees."
+    )
+    parser.add_argument("--repo", default=str(REPO_ROOT), help="Repository checkout to clean.")
+    parser.add_argument("--apply", action="store_true", help="Actually remove stale artifacts.")
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    root = repo_root(args.repo)
+    results = clean_stale_build_libs(root, apply=bool(args.apply))
+
+    if args.json:
+        payload = {
+            "schema": "agilab.clean_local_artifacts.v1",
+            "repo": str(root),
+            "apply": bool(args.apply),
+            "results": [result._asdict() for result in results],
+        }
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        _print_human(results, apply=bool(args.apply))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Add `tools/clean_local_artifacts.py` to dry-run or remove ignored stale `build/lib` duplicate-source trees.
- Wire the cleaner into `./dev clean`, with `--apply` required for deletion.
- Document the shortcut in `AGENTS.md` and add focused shortcut/cleaner tests.
- Ran the cleaner locally with `--apply`; the stale `src/agilab/core/agi-env/build/lib` and `src/agilab/core/agi-node/build/lib` directories are now removed from this checkout.

## Validation

- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files tools/clean_local_artifacts.py tools/agilab_dev.py test/test_clean_local_artifacts.py test/test_agilab_dev_shortcuts.py AGENTS.md`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_clean_local_artifacts.py test/test_agilab_dev_shortcuts.py`
- `uv --preview-features extra-build-dependencies run python tools/clean_local_artifacts.py --json`
- `git diff --check`