### PR TITLE
[codex] Extract deployment virtualenv helpers

### DIFF
--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_local_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_local_support.py
@@ -25,15 +25,21 @@ import tomlkit
 from packaging.requirements import InvalidRequirement, Requirement
 
 from agi_cluster.agi_distributor import deployment_dask_support
+from agi_cluster.agi_distributor.deployment_venv_support import (
+    project_site_packages_dir as _project_site_packages_dir,
+    project_venv_cfg_version as _project_venv_cfg_version,
+    project_venv_matches as _project_venv_matches,
+    project_venv_python as _project_venv_python,
+    project_venv_root as _project_venv_root,
+    python_version_tuple as _python_version_tuple,
+)
 from agi_env import AgiEnv
-from agi_env.process_support import project_virtualenv_root, project_virtualenv_script_path
 
 
 logger = logging.getLogger(__name__)
 FORCE_REMOVE_EXCEPTIONS = (OSError, shutil.Error)
 DEPENDENCY_PARSE_EXCEPTIONS = (InvalidRequirement,)
 PYPROJECT_PARSE_EXCEPTIONS = (OSError, tomlkit.exceptions.ParseError)  # ty: ignore[possibly-missing-submodule]
-PYTHON_VERSION_RE = re.compile(r"(\d+)(?:\.(\d+))?(?:\.(\d+))?")
 SHARED_WORKER_VENV_ENV = "AGILAB_SHARED_WORKER_VENV"
 SHARED_WORKER_VENV_DIR_ENV = "AGILAB_SHARED_WORKER_VENV_DIR"
 REFRESH_LOCKS_ENV = "AGILAB_REFRESH_LOCKS"
@@ -263,61 +269,6 @@ def _build_worker_core_add_commands(
         )
 
     return commands
-
-
-def _project_venv_python(project: Path, *, os_name: str = os.name) -> Path:
-    return cast(Path, project_virtualenv_script_path(project, "python", os_name=os_name))
-
-
-def _project_venv_root(project: Path) -> Path:
-    return cast(Path, project_virtualenv_root(project))
-
-
-def _python_version_tuple(value: str | None) -> tuple[int, ...] | None:
-    if not value:
-        return None
-    match = PYTHON_VERSION_RE.search(value)
-    if not match:
-        return None
-    return tuple(int(part) for part in match.groups() if part is not None)
-
-
-def _project_venv_cfg_version(project: Path) -> tuple[int, ...] | None:
-    cfg = project / ".venv" / "pyvenv.cfg"
-    try:
-        lines = cfg.read_text(encoding="utf-8").splitlines()
-    except OSError:
-        return None
-
-    for line in lines:
-        key, separator, raw_value = line.partition("=")
-        if not separator:
-            continue
-        if key.strip().lower() not in {"version", "version_info"}:
-            continue
-        parsed = _python_version_tuple(raw_value.strip())
-        if parsed:
-            return parsed
-    return None
-
-
-def _project_venv_matches(
-    project: Path,
-    *,
-    os_name: str = os.name,
-    python_version: str | None = None,
-) -> bool:
-    if not _project_venv_python(project, os_name=os_name).exists():
-        return False
-
-    requested = _python_version_tuple(python_version)
-    if not requested:
-        return True
-
-    actual = _project_venv_cfg_version(project)
-    if not actual:
-        return False
-    return actual[: len(requested)] == requested
 
 
 def _remove_project_venv_if_mismatched(
@@ -801,39 +752,6 @@ def _editable_install_project(package_ref: str | Path) -> Path | None:
     except (OSError, TypeError, ValueError):
         return None
     return package_path if _is_python_project(package_path) else None
-
-
-def _project_site_packages_dir(
-    project: Path,
-    *,
-    os_name: str = os.name,
-    python_version: str | None = None,
-) -> Path:
-    venv_root = _project_venv_root(project)
-    if os_name == "nt":
-        return venv_root / "Lib" / "site-packages"
-
-    if python_version:
-        python_parts = str(python_version).split(".")
-        if len(python_parts) >= 2 and python_parts[-1].endswith("t"):
-            python_dir = f"{python_parts[0]}.{python_parts[1].removesuffix('t')}t"
-            return venv_root / "lib" / f"python{python_dir}" / "site-packages"
-
-    requested = _python_version_tuple(python_version)
-    version = requested or _project_venv_cfg_version(project)
-    if version and len(version) >= 2:
-        return venv_root / "lib" / f"python{version[0]}.{version[1]}" / "site-packages"
-
-    lib_root = venv_root / "lib"
-    try:
-        candidates = sorted(lib_root.glob("python*/site-packages"))
-    except OSError:
-        candidates = []
-    if candidates:
-        return candidates[0]
-
-    fallback = _python_version_tuple(platform.python_version()) or (3, 13)
-    return venv_root / "lib" / f"python{fallback[0]}.{fallback[1]}" / "site-packages"
 
 
 def _editable_install_proof_exists(

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_venv_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_venv_support.py
@@ -1,0 +1,114 @@
+"""Project virtualenv path helpers for local deployment flows."""
+
+from __future__ import annotations
+
+import os
+import platform
+import re
+from pathlib import Path
+from typing import cast
+
+from agi_env.process_support import project_virtualenv_root, project_virtualenv_script_path
+
+
+PYTHON_VERSION_RE = re.compile(r"(\d+)(?:\.(\d+))?(?:\.(\d+))?")
+
+
+def project_venv_python(project: Path, *, os_name: str = os.name) -> Path:
+    """Return the Python executable path for a project's managed virtualenv."""
+
+    return cast(Path, project_virtualenv_script_path(project, "python", os_name=os_name))
+
+
+def project_venv_root(project: Path) -> Path:
+    """Return the managed virtualenv root for a project."""
+
+    return cast(Path, project_virtualenv_root(project))
+
+
+def python_version_tuple(value: str | None) -> tuple[int, ...] | None:
+    """Parse a Python version-like string into an integer tuple."""
+
+    if not value:
+        return None
+    match = PYTHON_VERSION_RE.search(value)
+    if not match:
+        return None
+    return tuple(int(part) for part in match.groups() if part is not None)
+
+
+def project_venv_cfg_version(project: Path) -> tuple[int, ...] | None:
+    """Read the Python version recorded in a project's ``pyvenv.cfg``."""
+
+    cfg = project_venv_root(project) / "pyvenv.cfg"
+    try:
+        lines = cfg.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return None
+
+    for line in lines:
+        key, separator, raw_value = line.partition("=")
+        if not separator:
+            continue
+        if key.strip().lower() not in {"version", "version_info"}:
+            continue
+        parsed = python_version_tuple(raw_value.strip())
+        if parsed:
+            return parsed
+    return None
+
+
+def project_venv_matches(
+    project: Path,
+    *,
+    os_name: str = os.name,
+    python_version: str | None = None,
+) -> bool:
+    """Return whether the project virtualenv exists and matches a requested version."""
+
+    if not project_venv_python(project, os_name=os_name).exists():
+        return False
+
+    requested = python_version_tuple(python_version)
+    if not requested:
+        return True
+
+    actual = project_venv_cfg_version(project)
+    if not actual:
+        return False
+    return actual[: len(requested)] == requested
+
+
+def project_site_packages_dir(
+    project: Path,
+    *,
+    os_name: str = os.name,
+    python_version: str | None = None,
+) -> Path:
+    """Return the site-packages directory for a project's managed virtualenv."""
+
+    venv_root = project_venv_root(project)
+    if os_name == "nt":
+        return venv_root / "Lib" / "site-packages"
+
+    if python_version:
+        python_parts = str(python_version).split(".")
+        if len(python_parts) >= 2 and python_parts[-1].endswith("t"):
+            python_dir = f"{python_parts[0]}.{python_parts[1].removesuffix('t')}t"
+            return venv_root / "lib" / f"python{python_dir}" / "site-packages"
+
+    requested = python_version_tuple(python_version)
+    version = requested or project_venv_cfg_version(project)
+    if version and len(version) >= 2:
+        return venv_root / "lib" / f"python{version[0]}.{version[1]}" / "site-packages"
+
+    lib_root = venv_root / "lib"
+    try:
+        candidates = sorted(lib_root.glob("python*/site-packages"))
+    except OSError:
+        candidates = []
+    if candidates:
+        return candidates[0]
+
+    fallback = python_version_tuple(platform.python_version()) or (3, 13)
+    return venv_root / "lib" / f"python{fallback[0]}.{fallback[1]}" / "site-packages"

--- a/src/agilab/core/test/test_agi_distributor_deployment_venv_support.py
+++ b/src/agilab/core/test/test_agi_distributor_deployment_venv_support.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from agi_cluster.agi_distributor import deployment_venv_support
+
+
+def _write_venv_python(
+    project: Path,
+    *,
+    os_name: str = "posix",
+    python_version: str | None = None,
+) -> Path:
+    python_path = deployment_venv_support.project_venv_python(project, os_name=os_name)
+    python_path.parent.mkdir(parents=True, exist_ok=True)
+    python_path.write_text("", encoding="utf-8")
+    if python_version is not None:
+        (project / ".venv" / "pyvenv.cfg").write_text(
+            f"version = {python_version}\n",
+            encoding="utf-8",
+        )
+    return python_path
+
+
+def test_project_venv_python_uses_target_platform_layouts(tmp_path: Path) -> None:
+    assert deployment_venv_support.project_venv_python(tmp_path, os_name="posix") == (
+        tmp_path / ".venv" / "bin" / "python"
+    )
+    assert deployment_venv_support.project_venv_python(tmp_path, os_name="nt") == (
+        tmp_path / ".venv" / "Scripts" / "python.exe"
+    )
+
+
+def test_project_venv_matches_checks_executable_and_requested_version(tmp_path: Path) -> None:
+    assert deployment_venv_support.project_venv_matches(tmp_path, python_version="3.13") is False
+
+    _write_venv_python(tmp_path, python_version="3.13.2")
+
+    assert deployment_venv_support.project_venv_matches(tmp_path, python_version="3.13") is True
+    assert deployment_venv_support.project_venv_matches(tmp_path, python_version="3.12") is False
+
+
+def test_project_site_packages_dir_handles_windows_and_free_threaded_versions(tmp_path: Path) -> None:
+    assert deployment_venv_support.project_site_packages_dir(tmp_path, os_name="nt") == (
+        tmp_path / ".venv" / "Lib" / "site-packages"
+    )
+    assert deployment_venv_support.project_site_packages_dir(tmp_path, python_version="3.13t") == (
+        tmp_path / ".venv" / "lib" / "python3.13t" / "site-packages"
+    )
+
+
+def test_project_site_packages_dir_prefers_existing_python_site_packages(tmp_path: Path) -> None:
+    expected = tmp_path / ".venv" / "lib" / "python3.12" / "site-packages"
+    expected.mkdir(parents=True)
+
+    assert deployment_venv_support.project_site_packages_dir(tmp_path) == expected


### PR DESCRIPTION
## Summary

- Extract project virtualenv executable/version/site-packages helpers from `deployment_local_support.py` into `deployment_venv_support.py`.
- Keep backward-compatible private aliases in `deployment_local_support.py` so existing call sites and tests continue to work.
- Add focused tests for target-platform virtualenv layouts, version matching, and site-packages resolution.

## Validation

- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_venv_support.py src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_local_support.py src/agilab/core/test/test_agi_distributor_deployment_venv_support.py`
- `uv --preview-features extra-build-dependencies run --no-sync pytest -q -o addopts='' src/agilab/core/test/test_agi_distributor_deployment_venv_support.py src/agilab/core/test/test_agi_distributor_deployment_local_support.py`
- `uv --preview-features extra-build-dependencies run --with mypy python tools/shared_core_strict_typing.py`
- `uv --preview-features extra-build-dependencies run --no-sync pytest -q -o addopts='' src/agilab/core/test`
- `git diff --check -- src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_venv_support.py src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_local_support.py src/agilab/core/test/test_agi_distributor_deployment_venv_support.py`