### PR TITLE
[codex] Optimize dispatcher optimal chunk search

### DIFF
--- a/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/agi_dispatcher.py
+++ b/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/agi_dispatcher.py
@@ -30,7 +30,6 @@ import numpy as np
 import datetime
 import logging
 import socket
-from copy import deepcopy
 
 from agi_env import AgiEnv
 
@@ -282,7 +281,12 @@ class WorkDispatcher:
     chunks: Optional[List[Any]] = None,
     chunks_sizes: Optional[Any] = None
 ) -> Any:
-        """Partitions subsets in nchk non-weighted chunks, in a slower but optimal recursive way
+        """Partitions subsets in nchk non-weighted chunks, in a slower but optimal recursive way.
+
+        The search is exponential, so callers should keep using ``make_chunks``'
+        threshold gate for larger work plans.  This implementation mutates one
+        working assignment in place and undoes each recursive branch instead of
+        deep-copying every candidate tree.
 
         Args:
           subsets: list of tuples ('label', size)
@@ -294,61 +298,75 @@ class WorkDispatcher:
           : list of chunks weighted
 
         """
-        racine = False
-        best_chunks = None
-
         nchk = len(chkweights)
-        if chunks is None:  # 1ere execution
-            chunks = [[] for _ in range(nchk)]
-            chunks_sizes = np.zeros(nchk, dtype=float)
-            subsets.sort(reverse=True, key=lambda i: i[1])
-            racine = True
+        capacities = np.array(chkweights, dtype=float)
+        root_call = chunks is None
+        working_chunks = [[] for _ in range(nchk)] if chunks is None else chunks
+        working_sizes = (
+            np.zeros(nchk, dtype=float)
+            if chunks_sizes is None
+            else np.array(chunks_sizes, dtype=float)
+        )
+        ordered_subsets = list(subsets)
+        if root_call:
+            ordered_subsets.sort(reverse=True, key=lambda i: i[1])
 
-        if not subsets:  # finished when all subsets are partitioned
-            return [chunks, max(chunks_sizes)]  # ty: ignore[invalid-argument-type]
+        def _snapshot() -> tuple[list[list[Any]], float]:
+            return [list(chunk) for chunk in working_chunks], float(max(working_sizes))
 
-        # Optimisation: We check if the weighted difference between the biggest and the smalest chunk
-        # is more than the weighted sum of the remaining subsets
-        if max(chunks_sizes) > min(  # ty: ignore[invalid-argument-type]
-                np.array(chunks_sizes + sum([i[1] for i in subsets])) / chkweights
-        ):
-            # If yes, we won't make the biggest chunk bigger by filling the smallest chunk
-            smallest_chunk_index = np.argmin(
-                chunks_sizes + sum([i[1] for i in subsets]) / chkweights
-            )
-            chunks[smallest_chunk_index] += subsets
-            chunks_sizes[smallest_chunk_index] += (
-                    sum([i[1] for i in subsets]) / chkweights[smallest_chunk_index]
-            )
-            return [chunks, max(chunks_sizes)]  # ty: ignore[invalid-argument-type]
+        def _search(start: int) -> tuple[list[list[Any]], float]:
+            if start >= len(ordered_subsets):
+                return _snapshot()
 
-        chunks_choices = []
-        chunks_choices_max_size = np.array([])
-        inserted_chunk_sizes = []
-        for i in range(nchk):
-            # We add the next subset to the ith chunk if we haven't already tried a similar chunk
-            if (chunks_sizes[i], chkweights[i]) not in inserted_chunk_sizes:  # ty: ignore[not-subscriptable]
-                inserted_chunk_sizes.append((chunks_sizes[i], chkweights[i]))  # ty: ignore[not-subscriptable]
-                subsets2 = deepcopy(subsets)[1:]
-                chunk_pool = deepcopy(chunks)
-                chunk_pool[i].append(subsets[0])
-                chunks_sizes2 = deepcopy(chunks_sizes)
-                chunks_sizes2[i] += subsets[0][1] / chkweights[i]
-                chunks_choices.append(
-                    WorkDispatcher._make_chunks_optimal(
-                        subsets2, chkweights, chunk_pool, chunks_sizes2
-                    )
+            remaining = ordered_subsets[start:]
+            remaining_weight = sum(item[1] for item in remaining)
+
+            # Optimisation: if even putting all remaining work on the least-loaded
+            # worker cannot improve the current maximum load, finish this branch.
+            if max(working_sizes) > min(np.array(working_sizes + remaining_weight) / capacities):
+                smallest_chunk_index = int(
+                    np.argmin(working_sizes + remaining_weight / capacities)
                 )
-                chunks_choices_max_size = np.append(
-                    chunks_choices_max_size, chunks_choices[-1][1]
+                previous_size = float(working_sizes[smallest_chunk_index])
+                previous_len = len(working_chunks[smallest_chunk_index])
+                working_chunks[smallest_chunk_index].extend(remaining)
+                working_sizes[smallest_chunk_index] = (
+                    previous_size + remaining_weight / capacities[smallest_chunk_index]
                 )
+                result = _snapshot()
+                del working_chunks[smallest_chunk_index][previous_len:]
+                working_sizes[smallest_chunk_index] = previous_size
+                return result
 
-        best_chunks = chunks_choices[np.argmin(chunks_choices_max_size)]
+            subset = ordered_subsets[start]
+            best: tuple[list[list[Any]], float] | None = None
+            inserted_chunk_sizes = set()
+            for i in range(nchk):
+                # Add the next subset to the ith chunk if we have not already
+                # tried an equivalent chunk/capacity state.
+                state_key = (float(working_sizes[i]), float(capacities[i]))
+                if state_key in inserted_chunk_sizes:
+                    continue
+                inserted_chunk_sizes.add(state_key)
 
-        if racine:
-            return best_chunks[0]
-        else:
+                normalized_weight = subset[1] / capacities[i]
+                working_chunks[i].append(subset)
+                working_sizes[i] += normalized_weight
+                candidate = _search(start + 1)
+                working_chunks[i].pop()
+                working_sizes[i] -= normalized_weight
+
+                if best is None or candidate[1] < best[1]:
+                    best = candidate
+
+            if best is None:  # pragma: no cover - defensive guard
+                return _snapshot()
+            return best
+
+        best_chunks, best_size = _search(0)
+        if root_call:
             return best_chunks
+        return [best_chunks, best_size]
 
     @staticmethod
     def _make_chunks_fastest(subsets: List[Any], chk_weights: List[Any]) -> List[List[Any]]:

--- a/src/agilab/core/test/test_work_dispatcher.py
+++ b/src/agilab/core/test/test_work_dispatcher.py
@@ -420,6 +420,18 @@ def test_make_chunks_optimal_and_fastest_real_paths():
     assert sum(len(chunk) for chunk in fastest) == 3
 
 
+def test_make_chunks_optimal_backtracks_without_deepcopy_or_input_mutation():
+    subsets = [("small", 1), ("large", 4), ("mid", 3), ("other", 2)]
+    original = list(subsets)
+
+    chunks = WorkDispatcher._make_chunks_optimal(subsets, np.array([1, 1]))
+
+    assert "deepcopy" not in WorkDispatcher._make_chunks_optimal.__code__.co_names
+    assert subsets == original
+    assert sorted(item for chunk in chunks for item in chunk) == sorted(original)
+    assert sorted(sum(weight for _name, weight in chunk) for chunk in chunks) == [5, 5]
+
+
 @pytest.mark.asyncio
 async def test_load_module_refuses_runtime_auto_install_by_default(monkeypatch, tmp_path):
     def fake_import(_name):


### PR DESCRIPTION
## Summary

- Replace recursive `deepcopy` branch expansion in `WorkDispatcher._make_chunks_optimal` with in-place branch/undo recursion.
- Keep the threshold-gated exact search behavior while reducing per-branch allocations.
- Add regression coverage that locks out `deepcopy`, preserves caller input order, and verifies an exactly balanced assignment.

## Validation

- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files src/agilab/core/agi-node/src/agi_node/agi_dispatcher/agi_dispatcher.py src/agilab/core/test/test_work_dispatcher.py`
- `uv --preview-features extra-build-dependencies run --no-sync pytest -q -o addopts='' src/agilab/core/test/test_work_dispatcher.py`
- `uv --preview-features extra-build-dependencies run --with mypy python tools/shared_core_strict_typing.py`
- `uv --preview-features extra-build-dependencies run --no-sync pytest -q -o addopts='' src/agilab/core/test/test_agi_dispatcher_build_main_support.py src/agilab/core/test/test_agi_dispatcher_post_install_support.py src/agilab/core/test/test_agi_dispatcher_scripts.py src/agilab/core/test/test_work_dispatcher.py`
- `uv --preview-features extra-build-dependencies run --no-sync pytest -q -o addopts='' src/agilab/core/test`
- `git diff --check -- src/agilab/core/agi-node/src/agi_node/agi_dispatcher/agi_dispatcher.py src/agilab/core/test/test_work_dispatcher.py`

Note: local `tools/build_product_demo_reel.py` remains modified in the checkout but is not part of this PR.