### PR TITLE
[codex] Centralize dispatcher bootstrap paths

### DIFF
--- a/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/bootstrap_source_paths.py
+++ b/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/bootstrap_source_paths.py
@@ -6,14 +6,21 @@ from pathlib import Path
 import sys
 
 
-def bootstrap_core_source_paths(*, source_file: str | Path | None = None) -> tuple[Path, ...]:
-    """Insert repo-local AGI core source roots into ``sys.path`` when available."""
-    source_path = Path(source_file or __file__).resolve()
-    core_root = None
+def resolve_core_source_root(*, source_file: str | Path | None = None) -> Path | None:
+    """Return the repository ``src/agilab/core`` root for a dispatcher source file."""
+    try:
+        source_path = Path(source_file or __file__).resolve()
+    except (OSError, RuntimeError):
+        return None
     for parent in source_path.parents:
         if parent.name == "core" and parent.parent.name == "agilab":
-            core_root = parent
-            break
+            return parent
+    return None
+
+
+def bootstrap_core_source_paths(*, source_file: str | Path | None = None) -> tuple[Path, ...]:
+    """Insert repo-local AGI core source roots into ``sys.path`` when available."""
+    core_root = resolve_core_source_root(source_file=source_file)
     if core_root is None:
         return ()
 
@@ -31,3 +38,72 @@ def bootstrap_core_source_paths(*, source_file: str | Path | None = None) -> tup
             sys.path.insert(0, candidate_str)
             added.append(candidate)
     return tuple(reversed(added))
+
+
+def resolve_source_checkout_root(source_file: str | Path) -> Path | None:
+    """Return the AGILAB source checkout root that owns ``source_file``."""
+    try:
+        source_path = Path(source_file).resolve()
+    except (OSError, RuntimeError):
+        return None
+    for parent in (source_path.parent, *source_path.parents):
+        if (parent / "src" / "agilab" / "main_page.py").exists():
+            return parent
+    return None
+
+
+def resolve_checkout_root_for_site_packages(candidate: Path) -> Path | None:
+    """Return the checkout root that owns a managed ``site-packages`` path."""
+    try:
+        candidate_path = candidate.resolve()
+    except (OSError, RuntimeError):
+        candidate_path = candidate
+    for parent in candidate_path.parents:
+        if parent.name != ".venv":
+            continue
+        checkout_root = parent.parent
+        if (checkout_root / "src" / "agilab" / "main_page.py").exists():
+            return checkout_root.resolve()
+        return None
+    return None
+
+
+def shared_site_package_candidates(
+    *,
+    home: str | Path | None = None,
+    version_info=None,
+) -> tuple[Path, ...]:
+    """Return legacy shared AGILAB virtualenv site-packages candidates."""
+    selected_home = Path.home() if home is None else Path(home).expanduser()
+    selected_version = sys.version_info if version_info is None else version_info
+    version = f"python{selected_version.major}.{selected_version.minor}"
+    return (
+        selected_home / "agilab/.venv/lib" / version / "site-packages",
+        selected_home / ".agilab/.venv/lib" / version / "site-packages",
+    )
+
+
+def append_shared_site_packages(
+    *,
+    source_file: str | Path = __file__,
+    sys_path: list[str] | None = None,
+    home: str | Path | None = None,
+    version_info=None,
+) -> tuple[Path, ...]:
+    """Append compatible shared AGILAB site-packages candidates to ``sys.path``."""
+    target_sys_path = sys.path if sys_path is None else sys_path
+    current_checkout_root = resolve_source_checkout_root(source_file)
+    added: list[Path] = []
+    for candidate in shared_site_package_candidates(home=home, version_info=version_info):
+        candidate_checkout_root = resolve_checkout_root_for_site_packages(candidate)
+        if (
+            current_checkout_root is not None
+            and candidate_checkout_root is not None
+            and candidate_checkout_root != current_checkout_root
+        ):
+            continue
+        path_str = str(candidate)
+        if path_str not in target_sys_path:
+            target_sys_path.append(path_str)
+            added.append(candidate)
+    return tuple(added)

--- a/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/build.py
+++ b/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/build.py
@@ -16,59 +16,18 @@ import subprocess
 from collections.abc import Mapping
 
 try:
-    from .bootstrap_source_paths import bootstrap_core_source_paths
+    from .bootstrap_source_paths import append_shared_site_packages, bootstrap_core_source_paths
 except ImportError:  # pragma: no cover - script execution fallback
-    from bootstrap_source_paths import bootstrap_core_source_paths  # ty: ignore[unresolved-import]
+    from bootstrap_source_paths import append_shared_site_packages, bootstrap_core_source_paths  # ty: ignore[unresolved-import]
 
 bootstrap_core_source_paths(source_file=__file__)
 
 from setuptools import setup, find_packages, Extension, SetuptoolsDeprecationWarning
 from Cython.Build import cythonize
 
-def _source_checkout_root(source_file: str | Path) -> Path | None:
-    try:
-        source_path = Path(source_file).resolve()
-    except OSError:
-        return None
-    for parent in (source_path.parent, *source_path.parents):
-        if (parent / "src" / "agilab" / "main_page.py").exists():
-            return parent
-    return None
-
-
-def _checkout_root_for_site_packages(candidate: Path) -> Path | None:
-    try:
-        candidate_path = candidate.resolve()
-    except OSError:
-        candidate_path = candidate
-    for parent in candidate_path.parents:
-        if parent.name != ".venv":
-            continue
-        checkout_root = parent.parent
-        if (checkout_root / "src" / "agilab" / "main_page.py").exists():
-            return checkout_root.resolve()
-        return None
-    return None
-
 
 def _inject_shared_site_packages(*, source_file: str | Path = __file__) -> None:
-    version = f"python{sys.version_info.major}.{sys.version_info.minor}"
-    current_checkout_root = _source_checkout_root(source_file)
-    candidates = [
-        Path.home() / "agilab/.venv/lib" / version / "site-packages",
-        Path.home() / ".agilab/.venv/lib" / version / "site-packages",
-    ]
-    for candidate in candidates:
-        candidate_checkout_root = _checkout_root_for_site_packages(candidate)
-        if (
-            current_checkout_root is not None
-            and candidate_checkout_root is not None
-            and candidate_checkout_root != current_checkout_root
-        ):
-            continue
-        path_str = str(candidate)
-        if path_str not in sys.path:
-            sys.path.append(path_str)
+    append_shared_site_packages(source_file=source_file)
 
 
 _inject_shared_site_packages()

--- a/src/agilab/core/test/test_agi_dispatcher_build_main_support.py
+++ b/src/agilab/core/test/test_agi_dispatcher_build_main_support.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 
 
 from agi_node.agi_dispatcher import build as build_mod
@@ -77,6 +78,55 @@ def test_bootstrap_core_source_paths_moves_existing_editable_sources_before_site
     assert bootstrap_mod.sys.path[:3] == [str(env_src), str(node_src), str(cluster_src)]
     assert bootstrap_mod.sys.path[3] == str(site_packages)
     assert bootstrap_mod.sys.path.count(str(env_src)) == 1
+
+
+def test_append_shared_site_packages_appends_legacy_candidates_once(tmp_path):
+    fake_home = tmp_path / "home"
+    sys_path: list[str] = []
+
+    bootstrap_mod.append_shared_site_packages(
+        source_file=tmp_path / "standalone" / "build.py",
+        sys_path=sys_path,
+        home=fake_home,
+        version_info=SimpleNamespace(major=3, minor=13),
+    )
+    bootstrap_mod.append_shared_site_packages(
+        source_file=tmp_path / "standalone" / "build.py",
+        sys_path=sys_path,
+        home=fake_home,
+        version_info=SimpleNamespace(major=3, minor=13),
+    )
+
+    assert sys_path == [
+        str(fake_home / "agilab/.venv/lib/python3.13/site-packages"),
+        str(fake_home / ".agilab/.venv/lib/python3.13/site-packages"),
+    ]
+
+
+def test_append_shared_site_packages_skips_foreign_home_checkout(tmp_path):
+    fake_home = tmp_path / "home"
+    foreign_checkout = fake_home / "agilab"
+    current_checkout = tmp_path / "current"
+    source_file = current_checkout / "src/agilab/core/agi-node/src/agi_node/agi_dispatcher/build.py"
+    (foreign_checkout / "src/agilab").mkdir(parents=True)
+    (foreign_checkout / "src/agilab/main_page.py").write_text("", encoding="utf-8")
+    (current_checkout / "src/agilab").mkdir(parents=True)
+    (current_checkout / "src/agilab/main_page.py").write_text("", encoding="utf-8")
+    source_file.parent.mkdir(parents=True)
+    source_file.write_text("", encoding="utf-8")
+    sys_path: list[str] = []
+
+    added = bootstrap_mod.append_shared_site_packages(
+        source_file=source_file,
+        sys_path=sys_path,
+        home=fake_home,
+        version_info=SimpleNamespace(major=3, minor=13),
+    )
+
+    assert added == (fake_home / ".agilab/.venv/lib/python3.13/site-packages",)
+    assert sys_path == [
+        str(fake_home / ".agilab/.venv/lib/python3.13/site-packages"),
+    ]
 
 
 def test_resolve_main_inputs_uses_explicit_app_path_and_normalizes_windows_style_outdirs(tmp_path):


### PR DESCRIPTION
## Summary
- Move dispatcher build source-checkout and shared site-packages path discovery into `bootstrap_source_paths.py`.
- Keep `build.py` as a thin compatibility caller for the legacy `_inject_shared_site_packages` hook.
- Add focused regression coverage for duplicate-safe legacy candidates and foreign-checkout filtering.

## Why
The code review flagged `build.py` as owning too much ad hoc path/root bootstrapping. Centralizing the path-resolution helpers reduces drift while preserving the existing build-script behavior.

## Validation
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' src/agilab/core/test/test_build_worker_venv_artifacts.py src/agilab/core/test/test_agi_dispatcher_build_main_support.py src/agilab/core/test/test_agi_dispatcher_scripts.py`
- `uv --preview-features extra-build-dependencies run --with mypy python tools/shared_core_strict_typing.py`
- `uv --preview-features extra-build-dependencies run --no-sync pytest -q -o addopts='' src/agilab/core/test`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --staged`