### PR TITLE
[codex] Narrow remote pip probe exceptions

### DIFF
--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_remote_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_remote_support.py
@@ -8,6 +8,8 @@ from shlex import quote
 from tempfile import gettempdir
 from typing import Any, Callable, Union
 
+from asyncssh.process import ProcessError
+
 from agi_cluster.agi_distributor import deployment_dask_support
 from agi_env import AgiEnv
 
@@ -17,6 +19,7 @@ logger = logging.getLogger(__name__)
 _REMOTE_RAPIDS_CHECK_EXCEPTIONS = (ConnectionError, OSError, RuntimeError)
 _REMOTE_PLATFORM_PROBE_EXCEPTIONS = (OSError, RuntimeError, ValueError)
 _REMOTE_COMMAND_EXCEPTIONS = (OSError, RuntimeError)
+_REMOTE_PIP_PROBE_EXCEPTIONS = _REMOTE_COMMAND_EXCEPTIONS + (ProcessError,)
 _LEGACY_INTEL_MACOS_DEPENDENCY_SPECS = ("numba==0.62.1", "pyarrow==17.0.0")
 _SSHFS_INSTALL_HINT = (
     "sshfs is required to mount AGI_CLUSTER_SHARE on this worker. "
@@ -373,7 +376,7 @@ async def _remote_project_has_pip(
         )
     except ConnectionError:
         raise
-    except Exception:
+    except _REMOTE_PIP_PROBE_EXCEPTIONS:
         return False
     return True
 

--- a/src/agilab/core/test/test_agi_distributor_deployment_remote_support.py
+++ b/src/agilab/core/test/test_agi_distributor_deployment_remote_support.py
@@ -364,6 +364,23 @@ async def test_remote_project_has_pip_reports_missing_when_probe_fails():
 
 
 @pytest.mark.asyncio
+async def test_remote_project_has_pip_propagates_unexpected_probe_bug():
+    async def _fake_exec_ssh(_ip, _cmd):
+        raise ValueError("broken probe wiring")
+
+    agi_cls = SimpleNamespace(exec_ssh=_fake_exec_ssh)
+
+    with pytest.raises(ValueError, match="broken probe wiring"):
+        await deployment_remote_support._remote_project_has_pip(
+            agi_cls,
+            "10.0.0.2",
+            uv="uv",
+            wenv_rel=Path("worker_env"),
+            pyvers="3.13",
+        )
+
+
+@pytest.mark.asyncio
 async def test_deploy_remote_worker_installs_dask_runtime_when_dask_mode_enabled(
     tmp_path,
 ):


### PR DESCRIPTION
## Summary
- Replace the broad `except Exception` in `_remote_project_has_pip` with explicit remote-command failure classes.
- Preserve expected behavior for missing pip probes, remote command runtime errors, OS errors, and AsyncSSH process failures.
- Add a regression test proving unexpected probe wiring bugs now propagate instead of being silently converted to `False`.

## Why
The CODE_REVIEW §6 audit called out broad exception handling in cleanup/deploy paths. This is a bounded cleanup/deploy fix: the pip probe is allowed to classify known remote command failures as "pip missing", but unexpected local probe bugs must fail visibly.

## Validation
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' src/agilab/core/test/test_agi_distributor_deployment_remote_support.py`
- `uv --preview-features extra-build-dependencies run --with mypy python tools/shared_core_strict_typing.py`
- `uv --preview-features extra-build-dependencies run --no-sync pytest -q -o addopts='' src/agilab/core/test`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --staged`