### PR TITLE
[codex] Guard capacity CSV UTF-8 writes

### DIFF
--- a/WINDOWS_TEST_FAILURES.md
+++ b/WINDOWS_TEST_FAILURES.md
@@ -367,6 +367,11 @@ car ce fichier est utilisé par un autre processus:
 
 ### Category 7 — Polars CSV read fails: non-UTF-8 encoding (2 tests)
 
+**Current repo status:** fixed in code, pending a fresh Windows rerun to remove
+these failures from the verified count. `capacity_support.update_capacity` now
+opens the capacity CSV with `encoding="utf-8"` and `newline=""`, with regression
+coverage in `test_update_capacity_writes_utf8_capacity_csv_for_polars`.
+
 On Windows, the system default encoding for file writes can be CP1252 (French locale). When capacity data is written as CSV and read back by polars, the non-UTF-8 content triggers an error.
 
 **Fix in the CSV write path in `capacity_support.py`:** always write UTF-8:
@@ -453,11 +458,11 @@ On Windows, `sshpass` is unavailable; production code correctly falls back to `s
 | 4 | `cmd /c exit N` unreliable exit code | 4 | ❌ Open | Test fixtures — use `sys.executable -c sys.exit(N)` |
 | 5 | Linux-only (fstab, PosixPath, sshfs) | 6 | ❌ Open | Skip markers + production guards |
 | 6 | mlflow file locking | 1 | ❌ Open | `mlflow_store.py` copy+delete on Windows |
-| 7 | Polars CSV non-UTF-8 encoding | 2 | ❌ Open | `capacity_support.py` — write with `encoding="utf-8"` |
+| 7 | Polars CSV non-UTF-8 encoding | 2 | ✅ Fixed in current repo; rerun Windows to verify count | `capacity_support.py`, `test_agi_distributor_capacity_support.py` |
 | 8 | `prepare_local_env` self-update | 3 | ❌ Open (1 regression) | `deployment_prepare_support.py` |
 | 9 | `sshpass` not on Windows | 1 | ❌ Open | Skip marker |
 | — | Needs `pytest -vv` | 10 | ❓ Unknown | Run targeted to diagnose |
 
 **Recommended priority:** rerun the Windows command above to refresh the verified
-remaining count after the environment-isolation fixtures, then prioritize Cat 7
-(Polars encoding) and Cat 8 (prepare_local_env self-update regression).
+remaining count after the environment-isolation and capacity CSV encoding
+fixtures, then prioritize Cat 8 (prepare_local_env self-update regression).

--- a/src/agilab/core/test/test_agi_distributor_capacity_support.py
+++ b/src/agilab/core/test/test_agi_distributor_capacity_support.py
@@ -792,6 +792,47 @@ def test_update_capacity_adjusts_against_other_workers(tmp_path, monkeypatch):
     assert train_calls["count"] == 1
 
 
+def test_update_capacity_writes_utf8_capacity_csv_for_polars(tmp_path, monkeypatch):
+    AGI._workers = {"127.0.0.1": 1}
+    AGI.workers_info = {
+        "127.0.0.1:8787": {
+            "nb_workers": 1,
+            "ram_total": 10.0,
+            "ram_available": 5.0,
+            "cpu_count": 4.0,
+            "cpu_frequency": 2.5,
+            "network_speed": 1.0,
+            "label": 1.0,
+        }
+    }
+    AGI._run_time = [{"127.0.0.1:8787": 2.0}]
+    AGI._capacity_data_file = str(tmp_path / "capacity.csv")
+    AGI.env = SimpleNamespace(home_abs=str(tmp_path))
+    monkeypatch.setattr(AGI, "_train_capacity", staticmethod(lambda _path: None))
+    open_calls: list[dict[str, object]] = []
+    original_open = open
+
+    def _tracking_open(file, mode="r", *args, **kwargs):
+        if Path(file) == Path(AGI._capacity_data_file) and "a" in mode:
+            open_calls.append(
+                {
+                    "encoding": kwargs.get("encoding"),
+                    "newline": kwargs.get("newline"),
+                }
+            )
+        return original_open(file, mode, *args, **kwargs)
+
+    monkeypatch.setitem(
+        capacity_support.update_capacity.__globals__,
+        "open",
+        _tracking_open,
+    )
+
+    capacity_support.update_capacity(AGI)
+
+    assert open_calls == [{"encoding": "utf-8", "newline": ""}]
+
+
 def test_train_capacity_missing_and_success(tmp_path):
     AGI._capacity_data_file = "capacity_data.csv"
     AGI._capacity_model_file = "capacity_model.pkl"


### PR DESCRIPTION
## Summary
- Add a regression test proving `capacity_support.update_capacity` appends capacity CSV rows with `encoding="utf-8"` and `newline=""`.
- Mark the Windows Polars CSV encoding category as fixed in the current repo while preserving the last verified Windows count until a Windows rerun.
- Update the Windows tracker priority to focus next on the `prepare_local_env` self-update regression.

## Why
The Windows failure tracker still listed the Polars CSV encoding issue as open even though the code now uses an explicit UTF-8 writer. This PR makes that behavior test-covered and updates the tracker status.

## Validation
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' src/agilab/core/test/test_agi_distributor_capacity_support.py`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --staged`