### PR TITLE
Classify core broad exception boundaries

### DIFF
--- a/src/agilab/core/agi-env/src/agi_env/app_provider_registry.py
+++ b/src/agilab/core/agi-env/src/agi_env/app_provider_registry.py
@@ -142,12 +142,16 @@ def is_app_project_root(path: Path) -> bool:
 def _entry_points(entry_points_fn: Callable[[], Any]) -> Iterable[Any]:
     try:
         entry_points = entry_points_fn()
+    # Best-effort provider discovery boundary: broken entry-point backends must
+    # not prevent AGILAB from using source checkout app discovery.
     except Exception:
         return ()
     select = getattr(entry_points, "select", None)
     if callable(select):
         try:
             return tuple(select(group=APP_PROVIDER_ENTRYPOINT_GROUP))
+        # Best-effort provider discovery boundary: ignore malformed third-party
+        # entry-point selectors and fall back to source checkout app discovery.
         except Exception:
             return ()
     if isinstance(entry_points, Mapping):
@@ -163,6 +167,8 @@ def _coerce_project_root(value: Any) -> Path | None:
     if callable(value):
         try:
             value = value()
+        # Best-effort provider discovery boundary: provider callbacks execute
+        # third-party package code, so broken providers are ignored.
         except Exception:
             return None
     try:
@@ -183,6 +189,8 @@ def discover_installed_app_projects(
     for entry_point in sorted(_entry_points(entry_points_fn), key=lambda item: str(getattr(item, "name", ""))):
         try:
             loaded = entry_point.load()
+        # Best-effort provider discovery boundary: one broken installed
+        # provider must not hide the rest of the installed app catalog.
         except Exception:
             continue
         root = _coerce_project_root(loaded)

--- a/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/worker_tracking_support.py
+++ b/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/worker_tracking_support.py
@@ -124,6 +124,8 @@ def worker_tracking_run(
         _log_tracking_metadata(mlflow, tags=tags, params=params, logger_obj=logger_obj)
         try:
             yield worker_run
+        # Worker code boundary: record failure metadata, then re-raise the
+        # original worker exception without converting it into tracking success.
         except Exception as exc:
             exit_exc_info = sys.exc_info()
             _log_tracking_metadata(
@@ -144,6 +146,8 @@ def worker_tracking_run(
                 metrics={"agilab.worker.runtime_seconds": max(time_fn() - started_at, 0.0)},
                 logger_obj=logger_obj,
             )
+    # Defensive tracking boundary: MLflow startup is optional; if no worker run
+    # was entered yet, disable tracking and let the worker continue.
     except Exception as exc:
         if worker_run is None:
             _log_debug(logger_obj, "worker tracking disabled: failed to start MLflow run: %s", exc)

--- a/src/agilab/core/agi-node/src/agi_node/dag_worker/dag_worker.py
+++ b/src/agilab/core/agi-node/src/agi_node/dag_worker/dag_worker.py
@@ -230,6 +230,8 @@ class DagWorker(BaseWorker):
             try:
                 results[fn] = future.result()
                 logging.info(f"Method {fn} for partition {pname} completed.")
+            # Worker code boundary: DAG partitions execute app methods; log each
+            # failed partition and continue collecting sibling partition results.
             except Exception as exc:
                 logging.error(f"Method {fn} for partition {pname} generated an exception: {exc}")
 

--- a/src/agilab/core/test/test_broad_exception_hygiene.py
+++ b/src/agilab/core/test/test_broad_exception_hygiene.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[4]
+CORE_SOURCE_ROOTS = (
+    ROOT / "src/agilab/core/agi-env/src",
+    ROOT / "src/agilab/core/agi-node/src",
+    ROOT / "src/agilab/core/agi-cluster/src",
+)
+BROAD_EXCEPT_MARKER = "except Exception"
+CLASSIFICATION_TOKENS = (
+    "boundary",
+    "defensive",
+    "intentional",
+    "worker code",
+    "third-party",
+    "best-effort",
+    "log and re-raise",
+    "persist the failure",
+    "keep the queue alive",
+)
+
+
+def _nearby_classification(lines: list[str], line_index: int) -> str:
+    start = max(0, line_index - 3)
+    end = min(len(lines), line_index + 2)
+    return " ".join(lines[start:end]).lower()
+
+
+def test_core_broad_exception_handlers_are_classified() -> None:
+    unclassified: list[str] = []
+    for source_root in CORE_SOURCE_ROOTS:
+        for path in sorted(source_root.rglob("*.py")):
+            rel = path.relative_to(ROOT).as_posix()
+            lines = path.read_text(encoding="utf-8").splitlines()
+            for index, line in enumerate(lines):
+                if BROAD_EXCEPT_MARKER not in line:
+                    continue
+                nearby = _nearby_classification(lines, index)
+                if not any(token in nearby for token in CLASSIFICATION_TOKENS):
+                    unclassified.append(f"{rel}:{index + 1}: {line.strip()}")
+
+    assert unclassified == []


### PR DESCRIPTION
## Summary
- classify remaining broad  handlers in core provider discovery, worker tracking, and DAG worker partition execution
- add a core hygiene regression that fails on unclassified broad exception handlers in runtime source files
- keep existing boundary behavior: provider discovery and MLflow tracking remain best-effort, worker execution failures still re-raise where required, and DAG partition failures stay logged per partition

## Blast radius
- shared agi-env installed app provider discovery
- shared agi-node worker tracking and DAG partition execution
- new static hygiene test over core runtime source files

## Validation
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' src/agilab/core/test/test_broad_exception_hygiene.py src/agilab/core/test/test_worker_tracking_support.py src/agilab/core/test/test_dag_worker.py
- direct provider-registry boundary check via 
- uv --preview-features extra-build-dependencies run python tools/impact_validate.py --staged
- git diff --cached --check
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' src/agilab/core/agi-env/test/test_app_provider_registry.py src/agilab/core/test/test_worker_tracking_support.py src/agilab/core/test/test_dag_worker.py src/agilab/core/test/test_broad_exception_hygiene.py
- uv --preview-features extra-build-dependencies run --no-sync pytest -q -o addopts='' src/agilab/core/agi-env/test
- uv --preview-features extra-build-dependencies run --no-sync pytest -q -o addopts='' src/agilab/core/test