### PR TITLE
Extract editable cleanup support

### DIFF
--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_editable_install_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_editable_install_support.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import shutil
 from pathlib import Path
 from typing import Any
 from urllib.parse import unquote, urlparse
@@ -20,10 +21,79 @@ from agi_cluster.agi_distributor.deployment_venv_support import (
 )
 
 EDITABLE_INSTALL_CACHE_SCHEMA = "agilab-editable-install-cache-v1"
+EDITABLE_SHADOW_IMPORTS: dict[str, tuple[str, ...]] = {
+    "agi-cluster": ("agi_cluster",),
+    "agi-core": ("agi_core",),
+    "agi-env": ("agi_env",),
+    "agi-node": ("agi_node",),
+    "agilab": ("agilab",),
+}
 
 
 def _is_python_project(path: Path) -> bool:
     return (path / "pyproject.toml").exists() or (path / "setup.py").exists()
+
+
+def _cleanup_editable(site_packages: Path) -> None:
+    patterns = (
+        "__editable__.agi_env*.pth",
+        "__editable__.agi_node*.pth",
+        "__editable__.agi_core*.pth",
+        "__editable__.agi_cluster*.pth",
+        "__editable__.agilab*.pth",
+    )
+    for pattern in patterns:
+        for editable in site_packages.glob(pattern):
+            try:
+                editable.unlink()
+            except FileNotFoundError:
+                pass
+
+
+def _editable_shadow_import_names(package_project: Path) -> tuple[str, ...]:
+    distribution_name = package_project.name.replace("_", "-").lower()
+    return EDITABLE_SHADOW_IMPORTS.get(distribution_name, ())
+
+
+def _remove_site_package_shadow(path: Path) -> bool:
+    try:
+        if path.is_dir() and not path.is_symlink():
+            shutil.rmtree(path)
+            return True
+        if path.exists() or path.is_symlink():
+            path.unlink()
+            return True
+    except FileNotFoundError:
+        return False
+    return False
+
+
+def _cleanup_editable_shadow_packages(
+    venv_project: Path,
+    package_projects: list[Path],
+    *,
+    os_name: str = os.name,
+    python_version: str | None = None,
+) -> list[Path]:
+    """Remove stale package dirs that shadow editable source installs."""
+    site_packages = _project_site_packages_dir(
+        venv_project,
+        os_name=os_name,
+        python_version=python_version,
+    )
+    if not site_packages.exists():
+        return []
+
+    removed: list[Path] = []
+    for package_project in package_projects:
+        for import_name in _editable_shadow_import_names(package_project):
+            for candidate in (
+                site_packages / import_name,
+                site_packages / f"{import_name}.py",
+            ):
+                if _remove_site_package_shadow(candidate):
+                    removed.append(candidate)
+    return removed
 
 
 def _editable_install_cache_path(venv_project: Path) -> Path:

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_local_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_local_support.py
@@ -27,14 +27,19 @@ from packaging.requirements import InvalidRequirement, Requirement
 from agi_cluster.agi_distributor import deployment_dask_support
 from agi_cluster.agi_distributor.deployment_editable_install_support import (
     EDITABLE_INSTALL_CACHE_SCHEMA as EDITABLE_INSTALL_CACHE_SCHEMA,
+    EDITABLE_SHADOW_IMPORTS as EDITABLE_SHADOW_IMPORTS,
+    _cleanup_editable as _cleanup_editable,
+    _cleanup_editable_shadow_packages as _cleanup_editable_shadow_packages,
     _editable_install_cache_hit as _editable_install_cache_hit,
     _editable_install_cache_path as _editable_install_cache_path,
     _editable_install_digest as _editable_install_digest,
     _editable_install_metadata_inputs as _editable_install_metadata_inputs,
     _editable_install_project as _editable_install_project,
     _editable_install_proof_exists as _editable_install_proof_exists,
+    _editable_shadow_import_names as _editable_shadow_import_names,
     _load_editable_install_cache as _load_editable_install_cache,
     _record_editable_install_cache as _record_editable_install_cache,
+    _remove_site_package_shadow as _remove_site_package_shadow,
     _write_editable_install_cache as _write_editable_install_cache,
 )
 from agi_cluster.agi_distributor.deployment_stage_cache_support import (
@@ -94,13 +99,6 @@ UV_RESOLVER_PROPAGATED_ENV_VARS = (
     "REQUESTS_CA_BUNDLE",
     "UV_NATIVE_TLS",
 )
-EDITABLE_SHADOW_IMPORTS: dict[str, tuple[str, ...]] = {
-    "agi-cluster": ("agi_cluster",),
-    "agi-core": ("agi_core",),
-    "agi-env": ("agi_env",),
-    "agi-node": ("agi_node",),
-    "agilab": ("agilab",),
-}
 DEPENDENCY_MODULE_ALIASES: dict[str, tuple[str, ...]] = {
     "pillow": ("PIL",),
     "python-dotenv": ("dotenv",),
@@ -148,65 +146,6 @@ def _force_remove(path: Path, *, env_logger: Any | None = None) -> None:
                 "Path {} still exists, using subprocess cmd to delete it.".format(path)
             )
         subprocess.run(["cmd", "/c", "rmdir", "/s", "/q", str(path)], check=False)
-
-
-def _cleanup_editable(site_packages: Path) -> None:
-    patterns = (
-        "__editable__.agi_env*.pth",
-        "__editable__.agi_node*.pth",
-        "__editable__.agi_core*.pth",
-        "__editable__.agi_cluster*.pth",
-        "__editable__.agilab*.pth",
-    )
-    for pattern in patterns:
-        for editable in site_packages.glob(pattern):
-            try:
-                editable.unlink()
-            except FileNotFoundError:
-                pass
-
-
-def _editable_shadow_import_names(package_project: Path) -> tuple[str, ...]:
-    distribution_name = package_project.name.replace("_", "-").lower()
-    return EDITABLE_SHADOW_IMPORTS.get(distribution_name, ())
-
-
-def _remove_site_package_shadow(path: Path) -> bool:
-    try:
-        if path.is_dir() and not path.is_symlink():
-            shutil.rmtree(path)
-            return True
-        if path.exists() or path.is_symlink():
-            path.unlink()
-            return True
-    except FileNotFoundError:
-        return False
-    return False
-
-
-def _cleanup_editable_shadow_packages(
-    venv_project: Path,
-    package_projects: list[Path],
-    *,
-    os_name: str = os.name,
-    python_version: str | None = None,
-) -> list[Path]:
-    """Remove stale package dirs that shadow editable source installs."""
-    site_packages = _project_site_packages_dir(
-        venv_project,
-        os_name=os_name,
-        python_version=python_version,
-    )
-    if not site_packages.exists():
-        return []
-
-    removed: list[Path] = []
-    for package_project in package_projects:
-        for import_name in _editable_shadow_import_names(package_project):
-            for candidate in (site_packages / import_name, site_packages / f"{import_name}.py"):
-                if _remove_site_package_shadow(candidate):
-                    removed.append(candidate)
-    return removed
 
 
 def _is_python_project(path: Path) -> bool:

--- a/tools/build_product_demo_reel.py
+++ b/tools/build_product_demo_reel.py
@@ -516,12 +516,12 @@ VARIANTS: dict[str, Variant] = {
 
 NARRATION_CUES: dict[str, tuple[NarrationCue, ...]] = {
     "flight": (
-        NarrationCue(0.0, 2.0, "AGILAB turns runs into proof capsules."),
-        NarrationCue(2.0, 4.4, "Lock inputs, runtime, and artifacts."),
-        NarrationCue(4.4, 7.4, "Optimizer: up to a thousand times faster."),
-        NarrationCue(7.4, 10.2, "Export notebooks, or run headless agi-core."),
-        NarrationCue(10.2, 12.9, "Verify maps, hashes, and metadata."),
-        NarrationCue(12.9, 15.0, "Replayable AI and ML evidence."),
+        NarrationCue(0.0, 2.0, "AGILAB turns agent runs into proof capsules."),
+        NarrationCue(2.0, 4.4, "Lock inputs, runtime, and artifact intent before execution."),
+        NarrationCue(4.4, 7.4, "Run mode optimizer: up to a thousand times faster on suitable projects."),
+        NarrationCue(7.4, 10.2, "Export back to notebooks, or run headless agi-core with no UI lock-in."),
+        NarrationCue(10.2, 12.9, "Verify maps, hashes, artifacts, and run metadata."),
+        NarrationCue(12.9, 15.0, "AGILAB: replayable AI and ML evidence."),
     ),
 }
 
@@ -646,44 +646,6 @@ def synthesize_voiceover(script_path: Path, audio_path: Path, *, voice: str, rat
         if voice in names:
             cmd[1:1] = ["-v", voice]
     subprocess.run(cmd, check=True)
-
-
-def probe_media_duration(path: Path) -> float | None:
-    ffprobe = shutil.which("ffprobe") or "/opt/homebrew/bin/ffprobe"
-    try:
-        result = subprocess.run(
-            [
-                ffprobe,
-                "-v",
-                "error",
-                "-show_entries",
-                "format=duration",
-                "-of",
-                "default=noprint_wrappers=1:nokey=1",
-                str(path),
-            ],
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-    except (OSError, subprocess.CalledProcessError):
-        return None
-    try:
-        return float(result.stdout.strip())
-    except ValueError:
-        return None
-
-
-def extend_frames_to_duration(frames_dir: Path, frame_count: int, fps: int, target_duration: float) -> int:
-    target_count = max(frame_count, int(math.ceil(target_duration * fps)))
-    if target_count <= frame_count:
-        return frame_count
-    if frame_count <= 0:
-        raise ValueError("cannot extend an empty frame set")
-    last_frame = frames_dir / f"frame_{frame_count - 1:04d}.png"
-    for idx in range(frame_count, target_count):
-        shutil.copyfile(last_frame, frames_dir / f"frame_{idx:04d}.png")
-    return target_count
 
 
 def background() -> Image.Image:
@@ -2263,10 +2225,6 @@ def build(
             transcript_path, srt_path = write_narration_sidecars(out_mp4, cues)
             audio_path = out_mp4.with_name(f"{out_mp4.stem}_voiceover.aiff")
             synthesize_voiceover(transcript_path, audio_path, voice=voice, rate=voice_rate)
-            audio_duration = probe_media_duration(audio_path)
-            if audio_duration is not None and audio_duration > duration:
-                frame_no = extend_frames_to_duration(frames_dir, frame_no, FPS, audio_duration + 0.35)
-                duration = frame_no / FPS
 
         save_video_from_frames(frames_dir, out_mp4, out_gif, FPS, audio_path=audio_path, duration=duration)
     return transcript_path, srt_path, audio_path

--- a/tools/build_product_demo_reel.py
+++ b/tools/build_product_demo_reel.py
@@ -516,12 +516,12 @@ VARIANTS: dict[str, Variant] = {
 
 NARRATION_CUES: dict[str, tuple[NarrationCue, ...]] = {
     "flight": (
-        NarrationCue(0.0, 2.0, "AGILAB turns agent runs into proof capsules."),
-        NarrationCue(2.0, 4.4, "Lock inputs, runtime, and artifact intent before execution."),
-        NarrationCue(4.4, 7.4, "Run mode optimizer: up to a thousand times faster on suitable projects."),
-        NarrationCue(7.4, 10.2, "Export back to notebooks, or run headless agi-core with no UI lock-in."),
-        NarrationCue(10.2, 12.9, "Verify maps, hashes, artifacts, and run metadata."),
-        NarrationCue(12.9, 15.0, "AGILAB: replayable AI and ML evidence."),
+        NarrationCue(0.0, 2.0, "AGILAB turns runs into proof capsules."),
+        NarrationCue(2.0, 4.4, "Lock inputs, runtime, and artifacts."),
+        NarrationCue(4.4, 7.4, "Optimizer: up to a thousand times faster."),
+        NarrationCue(7.4, 10.2, "Export notebooks, or run headless agi-core."),
+        NarrationCue(10.2, 12.9, "Verify maps, hashes, and metadata."),
+        NarrationCue(12.9, 15.0, "Replayable AI and ML evidence."),
     ),
 }
 
@@ -646,6 +646,44 @@ def synthesize_voiceover(script_path: Path, audio_path: Path, *, voice: str, rat
         if voice in names:
             cmd[1:1] = ["-v", voice]
     subprocess.run(cmd, check=True)
+
+
+def probe_media_duration(path: Path) -> float | None:
+    ffprobe = shutil.which("ffprobe") or "/opt/homebrew/bin/ffprobe"
+    try:
+        result = subprocess.run(
+            [
+                ffprobe,
+                "-v",
+                "error",
+                "-show_entries",
+                "format=duration",
+                "-of",
+                "default=noprint_wrappers=1:nokey=1",
+                str(path),
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    try:
+        return float(result.stdout.strip())
+    except ValueError:
+        return None
+
+
+def extend_frames_to_duration(frames_dir: Path, frame_count: int, fps: int, target_duration: float) -> int:
+    target_count = max(frame_count, int(math.ceil(target_duration * fps)))
+    if target_count <= frame_count:
+        return frame_count
+    if frame_count <= 0:
+        raise ValueError("cannot extend an empty frame set")
+    last_frame = frames_dir / f"frame_{frame_count - 1:04d}.png"
+    for idx in range(frame_count, target_count):
+        shutil.copyfile(last_frame, frames_dir / f"frame_{idx:04d}.png")
+    return target_count
 
 
 def background() -> Image.Image:
@@ -2225,6 +2263,10 @@ def build(
             transcript_path, srt_path = write_narration_sidecars(out_mp4, cues)
             audio_path = out_mp4.with_name(f"{out_mp4.stem}_voiceover.aiff")
             synthesize_voiceover(transcript_path, audio_path, voice=voice, rate=voice_rate)
+            audio_duration = probe_media_duration(audio_path)
+            if audio_duration is not None and audio_duration > duration:
+                frame_no = extend_frames_to_duration(frames_dir, frame_no, FPS, audio_duration + 0.35)
+                duration = frame_no / FPS
 
         save_video_from_frames(frames_dir, out_mp4, out_gif, FPS, audio_path=audio_path, duration=duration)
     return transcript_path, srt_path, audio_path


### PR DESCRIPTION
## Summary
- Move editable install cleanup and shadow-package removal helpers into `deployment_editable_install_support.py`.
- Keep compatibility aliases in `deployment_local_support.py` for existing private callers and tests.
- Continue CODE_REVIEW §1 support-module decomposition without changing deployment behavior.

## Blast radius
Shared-core deployment support only: editable install cleanup, stale editable `.pth` cleanup, and stale site-package shadow removal before editable installs.

## Validation
- `uv --preview-features extra-build-dependencies run python -m py_compile src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_editable_install_support.py src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_local_support.py`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' src/agilab/core/test/test_agi_distributor_deployment_local_support.py::test_cleanup_editable_ignores_missing_entries src/agilab/core/test/test_agi_distributor_deployment_local_support.py::test_cleanup_editable_shadow_packages_removes_core_import_shadow src/agilab/core/test/test_agi_distributor_deployment_local_support.py::test_install_many_into_project_venv_cleans_cached_core_shadow src/agilab/core/test/test_agi_distributor_deployment_local_support.py::test_install_into_project_venv_skips_cached_editable_metadata`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_editable_install_support.py src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_local_support.py`
- `git diff --check`
- `uv --preview-features extra-build-dependencies run --no-sync pytest -q -o addopts='' src/agilab/core/test`
