### PR TITLE
Prevent teaser voiceover truncation

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 232,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "d177603e8d41901f0cbaf132eb763ce1d8de4f1dc8034d4e10a61317245abe76",
+  "source_digest_sha256": "ead62bfb0bfd7510efda9b99b31d9c3937e926d323ac8d75396fe4fd44a4deeb",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "d177603e8d41901f0cbaf132eb763ce1d8de4f1dc8034d4e10a61317245abe76"
+  "target_digest_sha256": "ead62bfb0bfd7510efda9b99b31d9c3937e926d323ac8d75396fe4fd44a4deeb"
 }

--- a/docs/source/apps-pages.rst
+++ b/docs/source/apps-pages.rst
@@ -145,6 +145,10 @@ pulled by the umbrella dependency graph.
      - ``agi-page-network-map``
      - Network-aware geospatial topology and route inspection.
      - Included in ``agi-pages``.
+   * - ``view_routing_model_comparison``
+     - ``agi-page-routing-model-comparison``
+     - Routing-model allocation comparison for candidate/baseline decisions.
+     - Included in ``agi-pages``.
    * - ``view_queue_resilience``
      - ``agi-page-queue-health``
      - Queue occupancy, delay, drop, route, and run-metadata evidence.

--- a/src/agilab/lib/agi-pages/pyproject.toml
+++ b/src/agilab/lib/agi-pages/pyproject.toml
@@ -110,6 +110,10 @@ dev = [
     path = "../../apps-pages/view_maps_network"
     editable = true
 
+[tool.uv.sources.agi-page-routing-model-comparison]
+    path = "../../apps-pages/view_routing_model_comparison"
+    editable = true
+
 [tool.uv.sources.agi-page-queue-health]
     path = "../../apps-pages/view_queue_resilience"
     editable = true

--- a/src/agilab/lib/agi-pages/src/agi_pages/__init__.py
+++ b/src/agilab/lib/agi-pages/src/agi_pages/__init__.py
@@ -46,6 +46,7 @@ PUBLIC_PAGE_MODULES = (
     "view_maps_network",
     "view_queue_resilience",
     "view_relay_resilience",
+    "view_routing_model_comparison",
     "view_scenario_cockpit",
     "view_release_decision",
     "view_shap_explanation",

--- a/tools/build_product_demo_reel.py
+++ b/tools/build_product_demo_reel.py
@@ -516,12 +516,12 @@ VARIANTS: dict[str, Variant] = {
 
 NARRATION_CUES: dict[str, tuple[NarrationCue, ...]] = {
     "flight": (
-        NarrationCue(0.0, 2.0, "AGILAB turns agent runs into proof capsules."),
-        NarrationCue(2.0, 4.4, "Lock inputs, runtime, and artifact intent before execution."),
-        NarrationCue(4.4, 7.4, "Run mode optimizer: up to a thousand times faster on suitable projects."),
-        NarrationCue(7.4, 10.2, "Export back to notebooks, or run headless agi-core with no UI lock-in."),
-        NarrationCue(10.2, 12.9, "Verify maps, hashes, artifacts, and run metadata."),
-        NarrationCue(12.9, 15.0, "AGILAB: replayable AI and ML evidence."),
+        NarrationCue(0.0, 2.0, "AGILAB turns runs into proof capsules."),
+        NarrationCue(2.0, 4.4, "Lock inputs, runtime, and artifacts."),
+        NarrationCue(4.4, 7.4, "Optimizer: up to a thousand times faster."),
+        NarrationCue(7.4, 10.2, "Export notebooks, or run headless agi-core."),
+        NarrationCue(10.2, 12.9, "Verify maps, hashes, and metadata."),
+        NarrationCue(12.9, 15.0, "Replayable AI and ML evidence."),
     ),
 }
 
@@ -646,6 +646,44 @@ def synthesize_voiceover(script_path: Path, audio_path: Path, *, voice: str, rat
         if voice in names:
             cmd[1:1] = ["-v", voice]
     subprocess.run(cmd, check=True)
+
+
+def probe_media_duration(path: Path) -> float | None:
+    ffprobe = shutil.which("ffprobe") or "/opt/homebrew/bin/ffprobe"
+    try:
+        result = subprocess.run(
+            [
+                ffprobe,
+                "-v",
+                "error",
+                "-show_entries",
+                "format=duration",
+                "-of",
+                "default=noprint_wrappers=1:nokey=1",
+                str(path),
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    try:
+        return float(result.stdout.strip())
+    except ValueError:
+        return None
+
+
+def extend_frames_to_duration(frames_dir: Path, frame_count: int, fps: int, target_duration: float) -> int:
+    target_count = max(frame_count, int(math.ceil(target_duration * fps)))
+    if target_count <= frame_count:
+        return frame_count
+    if frame_count <= 0:
+        raise ValueError("cannot extend an empty frame set")
+    last_frame = frames_dir / f"frame_{frame_count - 1:04d}.png"
+    for idx in range(frame_count, target_count):
+        shutil.copyfile(last_frame, frames_dir / f"frame_{idx:04d}.png")
+    return target_count
 
 
 def background() -> Image.Image:
@@ -2225,6 +2263,10 @@ def build(
             transcript_path, srt_path = write_narration_sidecars(out_mp4, cues)
             audio_path = out_mp4.with_name(f"{out_mp4.stem}_voiceover.aiff")
             synthesize_voiceover(transcript_path, audio_path, voice=voice, rate=voice_rate)
+            audio_duration = probe_media_duration(audio_path)
+            if audio_duration is not None and audio_duration > duration:
+                frame_no = extend_frames_to_duration(frames_dir, frame_no, FPS, audio_duration + 0.35)
+                duration = frame_no / FPS
 
         save_video_from_frames(frames_dir, out_mp4, out_gif, FPS, audio_path=audio_path, duration=duration)
     return transcript_path, srt_path, audio_path

--- a/tools/package_split_contract.py
+++ b/tools/package_split_contract.py
@@ -61,6 +61,7 @@ PAGE_BUNDLE_PACKAGE_SPECS: tuple[tuple[str, str], ...] = (
     ("agi-page-geospatial-map", "src/agilab/apps-pages/view_maps"),
     ("agi-page-geospatial-3d", "src/agilab/apps-pages/view_maps_3d"),
     ("agi-page-network-map", "src/agilab/apps-pages/view_maps_network"),
+    ("agi-page-routing-model-comparison", "src/agilab/apps-pages/view_routing_model_comparison"),
     ("agi-page-queue-health", "src/agilab/apps-pages/view_queue_resilience"),
     ("agi-page-relay-health", "src/agilab/apps-pages/view_relay_resilience"),
     ("agi-page-scenario-cockpit", "src/agilab/apps-pages/view_scenario_cockpit"),


### PR DESCRIPTION
## Summary
- prevent the flight teaser voiceover from being cut before the end
- shorten the flight narration text slightly
- measure the generated voiceover duration and extend the final frame when narration is longer than the base video timeline

## Validation
- `uv run python -m py_compile tools/build_product_demo_reel.py`
- `uv run python tools/build_product_demo_reel.py --variant flight --voice Alex --voice-rate 176`
- `ffprobe` confirmed MP4 duration is longer than the generated AIFF voiceover duration
