### PR TITLE
Refine teaser headless core messaging

### DIFF
--- a/artifacts/demo_media/flight/agilab_flight_youtube_pack.md
+++ b/artifacts/demo_media/flight/agilab_flight_youtube_pack.md
@@ -5,7 +5,7 @@
 - Latest public video: https://youtu.be/BsBjRSAXJZA
 - YouTube Studio URL: https://studio.youtube.com/video/BsBjRSAXJZA
 - Repository policy: keep only this lightweight upload pack in Git. Generated MP4, GIF, and poster outputs under `artifacts/demo_media/flight/` are local artifacts and are not stored in Git.
-- Duration: 15.47 seconds
+- Duration: 18.80 seconds
 - Format: 1920x1080, 30 fps, premium H.264 video plus stereo AAC audio MP4
 - Video master: regenerated from source frames at CRF 12
 - Audio: low-volume stereo synthetic sound bed, encoded as AAC with safe peak headroom
@@ -16,7 +16,7 @@ AGILAB turns one AI/ML app run into replayable evidence: project context, run co
 
 ## Suggested title
 
-AGILAB teaser: replayable AI/ML evidence in 15 seconds
+AGILAB teaser: replayable AI/ML evidence in 19 seconds
 
 ## Suggested description
 
@@ -27,19 +27,22 @@ PROJECT -> ORCHESTRATE -> WORKFLOW -> ANALYSIS.
 
 The point is not a feature tour. It is one claim: keep project context, the run contract, the replay step, and reviewer-facing analysis aligned in one workspace.
 
+The headless `agi-core` line is intentional: AGILAB can hand a runnable contract back to notebooks or automation, so teams can benefit from the core runtime without locking every review or replay step into the UI.
+
 Repo: https://github.com/ThalesGroup/agilab
 
 ## Chapters
 
 00:00 AGILAB: replayable evidence, not notebook drift
 00:02 PROJECT: pin the project context
-00:05 ORCHESTRATE: generate the run contract
-00:08 WORKFLOW: capture the replay step
-00:12 ANALYSIS: evidence reviewers can inspect
+00:04 ORCHESTRATE: optimize, map, and reduce
+00:07 WORKFLOW: export notebooks or run headless
+00:10 ANALYSIS: evidence reviewers can inspect
+00:13 PORTABLE CORE: replay without UI lock-in
 
 ## Pinned comment
 
-AGILAB is built for evidence-first AI/ML workflows: pin the project context, generate the run contract, preserve the replay step, and finish with analysis a reviewer can inspect.
+AGILAB is built for evidence-first AI/ML workflows: pin the project context, generate the run contract, preserve the replay step, and finish with analysis a reviewer can inspect. Use the UI when it helps; keep notebooks and headless `agi-core` when automation or portability matters.
 
 ## Thumbnail text
 
@@ -47,4 +50,4 @@ Replayable evidence
 
 ## Short social caption
 
-A 15-second look at AGILAB: one workspace for project context, run orchestration, replay, and analysis evidence.
+A 19-second look at AGILAB: one workspace for project context, run orchestration, replay, portable notebook handoff, and analysis evidence.

--- a/tools/build_product_demo_reel.py
+++ b/tools/build_product_demo_reel.py
@@ -109,7 +109,7 @@ FLIGHT_SCENES: tuple[Scene, ...] = (
         image=PAGE_SHOTS / "orchestrate-page.png",
         stage="ORCHESTRATE",
         title="Fan out the work. Reduce to proof.",
-        body="The run-mode optimizer chooses the fast path, then map/reduce turns outputs into evidence.",
+        body="The optimizer selects the fast path; map/reduce turns outputs into evidence.",
         seconds=3.0,
         active_step=1,
         focus=(0.60, 0.44),
@@ -123,8 +123,8 @@ FLIGHT_SCENES: tuple[Scene, ...] = (
         name="pipeline",
         image=PAGE_SHOTS / "workflow-page.png",
         stage="WORKFLOW",
-        title="Keep notebooks in the loop.",
-        body="Export project context back to notebooks, or run headless agi-core without UI lock-in.",
+        title="Keep notebooks portable.",
+        body="Export the run contract to notebooks, or execute it with headless agi-core.",
         seconds=2.8,
         active_step=2,
         focus=(0.60, 0.48),
@@ -154,7 +154,7 @@ FLIGHT_SCENES: tuple[Scene, ...] = (
         image=PAGE_SHOTS / "core-pages-overview.png",
         stage="AGILAB",
         title="Replayable AI/ML evidence.",
-        body="Use the UI when it helps. Keep the headless core and notebooks when they fit better.",
+        body="Use the UI for review. Keep notebooks and headless agi-core for automation.",
         seconds=2.1,
         active_step=-1,
         focus=(0.56, 0.52),
@@ -519,7 +519,7 @@ NARRATION_CUES: dict[str, tuple[NarrationCue, ...]] = {
         NarrationCue(0.0, 2.0, "AGILAB turns runs into proof capsules."),
         NarrationCue(2.0, 4.4, "Lock inputs, runtime, and artifacts."),
         NarrationCue(4.4, 7.4, "Optimizer: up to a thousand times faster."),
-        NarrationCue(7.4, 10.2, "Export notebooks, or run headless agi-core."),
+        NarrationCue(7.4, 10.2, "Export notebooks, or execute with headless agi-core."),
         NarrationCue(10.2, 12.9, "Verify maps, hashes, and metadata."),
         NarrationCue(12.9, 15.0, "Replayable AI and ML evidence."),
     ),
@@ -1030,7 +1030,7 @@ def draw_flight_hero_outro_overlay(canvas: Image.Image, scene: Scene, slide_x: i
     hero_font = load_font(54, bold=True)
     sub_font = load_font(29, bold=True)
     draw.text((36, 112), "Replayable AI/ML evidence", font=hero_font, fill=INK)
-    draw.text((38, 178), "from notebook, agent, or headless agi-core run", font=FONT_BODY, fill=MUTED)
+    draw.text((38, 178), "from notebook, agent, or headless agi-core runtime", font=FONT_BODY, fill=MUTED)
 
     flow_y = 250
     nodes = [
@@ -1202,7 +1202,7 @@ def draw_pipeline_snippet_overlay(canvas: Image.Image, scene: Scene, slide_x: in
         "request = RunRequest(mode=15, data_in=\"flight_batches\")",
         "result = await AGI.run(env, request=request)",
         "# export: notebooks/lab_stages.ipynb",
-        "# same contract runs through headless agi-core",
+        "# same contract executes via headless agi-core",
     ]
     line_y = 92
     code_font = load_font(22)


### PR DESCRIPTION
## Summary
- tighten teaser wording so headless agi-core is framed as portable runtime handoff
- update the YouTube upload pack to match the regenerated 18.8s artifact
- keep generated MP4/GIF/poster/audio ignored and out of Git

## Validation
- uv run python -m py_compile tools/build_product_demo_reel.py
- uv run python tools/build_product_demo_reel.py --variant flight --voice Alex --voice-rate 176
- ffprobe confirmed 18.80s, 1920x1080, 30 fps MP4 with audio duration 18.80s