### PR TITLE
Add audit quality evaluator

### DIFF
--- a/.claude/skills/agilab-deep-audit/SKILL.md
+++ b/.claude/skills/agilab-deep-audit/SKILL.md
@@ -101,7 +101,9 @@ design issue appears in several places.
 
 ## Output template
 
-For a review document, write this structure:
+For a review document, use
+`templates/CODE_REVIEW_TEMPLATE.md` as the canonical file structure. If the
+template file is unavailable, write this structure:
 
 ```markdown
 # AGILAB — Detailed Code Review
@@ -151,6 +153,19 @@ For a review document, write this structure:
 
 For a shorter audit response, keep the same logic but compress it:
 verdict, scope, top strengths, top findings, prioritized actions, bottom line.
+
+## Quality gate
+
+When the audit is written to a Markdown file, run the deterministic quality
+evaluator before handoff unless the user explicitly asks not to validate:
+
+```bash
+uv --preview-features extra-build-dependencies run python tools/audit_quality_evaluator.py <audit.md> --min-score 80
+```
+
+Use `--json --output <report.json>` when the score should become evidence. A
+score below 80 means the artifact is not yet comparison-quality; improve the
+missing rubric areas before presenting it as a final audit.
 
 ## Validation and follow-up
 

--- a/.claude/skills/agilab-deep-audit/templates/CODE_REVIEW_TEMPLATE.md
+++ b/.claude/skills/agilab-deep-audit/templates/CODE_REVIEW_TEMPLATE.md
@@ -1,0 +1,77 @@
+# AGILAB - Detailed Code Review
+
+> Reviewer: `<agent or reviewer>`  
+> Date: `YYYY-MM-DD`  
+> Branch/commit: `<branch>` / `<commit>`  
+> Scope: `<files, workflows, docs, public artifacts, and sampled periphery>`  
+> Limits: `<what was not inspected or remains inferred>`
+
+## Executive summary
+
+State the verdict first. Include the dominant thesis, strongest positives, top
+risks, and whether the reviewed surface is `go`, `conditional go`, or `no-go`
+for the intended use.
+
+## Scope and method
+
+- Fully inspected:
+- Sampled:
+- Out of scope:
+- Commands/evidence used:
+
+## Architecture and module topology
+
+Describe the package graph, control/data/evidence planes, boundary ownership,
+and the design pressure behind any recurring issues.
+
+## Findings
+
+### Finding 1 - `<title>` - **HIGH**
+
+- Evidence: `<file>:<line>` and concrete call sites or commands.
+- Mechanism: what the code actually does.
+- Impact: what can break, leak, become nondeterministic, or mislead users.
+- Blast radius: affected pages, apps, packages, workflows, docs, or tests.
+- Recommendation: smallest good fix plus stronger architectural option if any.
+- Regression plan: targeted tests or workflow profiles that prove the fix.
+
+### Finding 2 - `<title>` - **MED**
+
+- Evidence:
+- Mechanism:
+- Impact:
+- Blast radius:
+- Recommendation:
+- Regression plan:
+
+## Security posture
+
+Cover generated/raw code execution, shell/subprocess boundaries, credentials,
+pickle/executable payloads, public UI binding, external apps, MCP exposure, and
+supply-chain/provenance.
+
+## Testing and cross-platform posture
+
+Cover hermeticity, `HOME`/environment isolation, Windows/macOS/Linux behavior,
+cluster assumptions, CI workflow coverage, and missing regression tests.
+
+## Packaging, docs, and release posture
+
+Cover wheel surface, optional extras, generated artifacts, docs/public mirror,
+changelog/public claims, release proof, PyPI/GitHub/Hugging Face evidence, and
+version alignment.
+
+## Prioritized recommendations
+
+| # | Severity | Issue | Action | Validation |
+|---|---|---|---|---|
+| 1 | **HIGH** | `<issue>` | `<action>` | `<test/profile>` |
+
+## Residual risks
+
+List assumptions that remain unverified and any surfaces that need a separate
+audit pass.
+
+## Bottom line
+
+Give a short, honest final judgement with the adoption boundary.

--- a/.codex/skills/agilab-deep-audit/SKILL.md
+++ b/.codex/skills/agilab-deep-audit/SKILL.md
@@ -101,7 +101,9 @@ design issue appears in several places.
 
 ## Output template
 
-For a review document, write this structure:
+For a review document, use
+`templates/CODE_REVIEW_TEMPLATE.md` as the canonical file structure. If the
+template file is unavailable, write this structure:
 
 ```markdown
 # AGILAB — Detailed Code Review
@@ -151,6 +153,19 @@ For a review document, write this structure:
 
 For a shorter audit response, keep the same logic but compress it:
 verdict, scope, top strengths, top findings, prioritized actions, bottom line.
+
+## Quality gate
+
+When the audit is written to a Markdown file, run the deterministic quality
+evaluator before handoff unless the user explicitly asks not to validate:
+
+```bash
+uv --preview-features extra-build-dependencies run python tools/audit_quality_evaluator.py <audit.md> --min-score 80
+```
+
+Use `--json --output <report.json>` when the score should become evidence. A
+score below 80 means the artifact is not yet comparison-quality; improve the
+missing rubric areas before presenting it as a final audit.
 
 ## Validation and follow-up
 

--- a/.codex/skills/agilab-deep-audit/templates/CODE_REVIEW_TEMPLATE.md
+++ b/.codex/skills/agilab-deep-audit/templates/CODE_REVIEW_TEMPLATE.md
@@ -1,0 +1,77 @@
+# AGILAB - Detailed Code Review
+
+> Reviewer: `<agent or reviewer>`  
+> Date: `YYYY-MM-DD`  
+> Branch/commit: `<branch>` / `<commit>`  
+> Scope: `<files, workflows, docs, public artifacts, and sampled periphery>`  
+> Limits: `<what was not inspected or remains inferred>`
+
+## Executive summary
+
+State the verdict first. Include the dominant thesis, strongest positives, top
+risks, and whether the reviewed surface is `go`, `conditional go`, or `no-go`
+for the intended use.
+
+## Scope and method
+
+- Fully inspected:
+- Sampled:
+- Out of scope:
+- Commands/evidence used:
+
+## Architecture and module topology
+
+Describe the package graph, control/data/evidence planes, boundary ownership,
+and the design pressure behind any recurring issues.
+
+## Findings
+
+### Finding 1 - `<title>` - **HIGH**
+
+- Evidence: `<file>:<line>` and concrete call sites or commands.
+- Mechanism: what the code actually does.
+- Impact: what can break, leak, become nondeterministic, or mislead users.
+- Blast radius: affected pages, apps, packages, workflows, docs, or tests.
+- Recommendation: smallest good fix plus stronger architectural option if any.
+- Regression plan: targeted tests or workflow profiles that prove the fix.
+
+### Finding 2 - `<title>` - **MED**
+
+- Evidence:
+- Mechanism:
+- Impact:
+- Blast radius:
+- Recommendation:
+- Regression plan:
+
+## Security posture
+
+Cover generated/raw code execution, shell/subprocess boundaries, credentials,
+pickle/executable payloads, public UI binding, external apps, MCP exposure, and
+supply-chain/provenance.
+
+## Testing and cross-platform posture
+
+Cover hermeticity, `HOME`/environment isolation, Windows/macOS/Linux behavior,
+cluster assumptions, CI workflow coverage, and missing regression tests.
+
+## Packaging, docs, and release posture
+
+Cover wheel surface, optional extras, generated artifacts, docs/public mirror,
+changelog/public claims, release proof, PyPI/GitHub/Hugging Face evidence, and
+version alignment.
+
+## Prioritized recommendations
+
+| # | Severity | Issue | Action | Validation |
+|---|---|---|---|---|
+| 1 | **HIGH** | `<issue>` | `<action>` | `<test/profile>` |
+
+## Residual risks
+
+List assumptions that remain unverified and any surfaces that need a separate
+audit pass.
+
+## Bottom line
+
+Give a short, honest final judgement with the adoption boundary.

--- a/test/test_audit_quality_evaluator.py
+++ b/test/test_audit_quality_evaluator.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "tools" / "audit_quality_evaluator.py"
+SPEC = importlib.util.spec_from_file_location("audit_quality_evaluator_test", MODULE_PATH)
+assert SPEC and SPEC.loader
+module = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = module
+SPEC.loader.exec_module(module)
+
+
+STRONG_AUDIT = """
+# AGILAB - Detailed Code Review
+
+> Scope: fully inspected `tools/audit_quality_evaluator.py`, `src/agilab/main_page.py`, and sampled docs.
+> Limits: worker internals were sampled, not exhaustively inspected.
+
+## Executive summary
+
+Verdict: conditional go. The dominant thesis is that execution boundaries are
+good for local research but need stronger guardrails for shared cluster use.
+
+## Scope and method
+
+- Fully inspected: tools/audit_quality_evaluator.py, src/agilab/main_page.py:42,
+  src/agilab/ui_public_bind_guard.py:17, docs/source/apps-pages.rst:148
+- Sampled: src/agilab/core/agi-node/src/agi_node/agi_dispatcher/base_worker.py:88
+- Commands/evidence used: uv --preview-features extra-build-dependencies run pytest -q,
+  python tools/workflow_parity.py --profile skills, git status --short
+
+## Architecture and module topology
+
+The package topology separates control plane, payload plane, and evidence plane.
+The handoff runtime boundary is clear, but workflow ownership crosses modules.
+
+## Findings
+
+### Finding 1 - generated-code sandbox is policy based - **HIGH**
+
+- Evidence: src/agilab/lab_run.py:120 and tools/audit_quality_evaluator.py:10.
+- Mechanism: generated code can enter an execution path after an environment gate.
+- Impact: shared workspaces can run untrusted payloads.
+- Blast radius: UI, worker execution, cluster workflows, and tests.
+- Recommendation: require container or VM isolation for shared profiles.
+- Regression plan: add pytest coverage and workflow_parity.py shared profile checks.
+
+## Security posture
+
+Security review covered shell, subprocess, secrets, credentials, pickle, MCP,
+public bind, SBOM, provenance, and PyPI release evidence.
+
+## Testing and cross-platform posture
+
+Validation uses pytest and uv --preview-features extra-build-dependencies run
+commands. Missing test gap: Windows path quoting remains unverified.
+
+## Packaging, docs, and release posture
+
+Packaging and release posture cover wheel surface, docs mirror, changelog,
+PyPI provenance, GitHub release proof, and public documentation claims.
+
+## Prioritized recommendations
+
+| # | Severity | Issue | Action | Validation |
+|---|---|---|---|---|
+| 1 | **HIGH** | sandbox boundary | Add isolation gate | pytest and workflow profile |
+| 2 | **MED** | docs drift | Centralize mirror checks | ./dev docs |
+
+## Residual risks
+
+Some cluster behavior is unverified without a live remote worker.
+
+## Bottom line
+
+Bottom line: go for local research, conditional go for shared clusters, no-go
+for production multi-tenant serving without additional controls.
+"""
+
+
+WEAK_AUDIT = """
+# Review
+
+Looks good overall. Some tests would help. I would improve security later.
+"""
+
+
+def test_audit_quality_evaluator_scores_strong_audit() -> None:
+    payload = module.evaluate_text(STRONG_AUDIT)
+
+    assert payload["score"] >= 85
+    assert payload["grade"] in {"strong", "excellent"}
+    by_id = {item["id"]: item for item in payload["rubric"]}
+    assert by_id["evidence"]["score"] == by_id["evidence"]["weight"]
+    assert by_id["security_release"]["score"] == by_id["security_release"]["weight"]
+
+
+def test_audit_quality_evaluator_flags_weak_audit() -> None:
+    payload = module.evaluate_text(WEAK_AUDIT)
+
+    assert payload["score"] < 50
+    assert payload["grade"] == "poor"
+    missing_ids = {item["id"] for item in payload["missing_or_partial"]}
+    assert {"scope", "evidence", "severity", "validation"}.issubset(missing_ids)
+
+
+def test_audit_quality_evaluator_cli_writes_json_and_returns_failure(tmp_path: Path) -> None:
+    audit = tmp_path / "audit.md"
+    output = tmp_path / "report.json"
+    audit.write_text(WEAK_AUDIT, encoding="utf-8")
+
+    rc = module.main([str(audit), "--min-score", "80", "--output", str(output), "--json"])
+
+    assert rc == 1
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["status"] == "fail"
+    assert payload["threshold"] == 80
+    assert payload["source"] == str(audit)

--- a/tools/audit_quality_evaluator.py
+++ b/tools/audit_quality_evaluator.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+"""Score AGILAB audit/review Markdown artifacts against a quality rubric."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+import re
+from typing import Callable, Sequence
+
+
+SCHEMA = "agilab.audit_quality_evaluator.v1"
+DEFAULT_MIN_SCORE = 80
+
+
+@dataclass(frozen=True)
+class RubricResult:
+    id: str
+    label: str
+    weight: int
+    score: int
+    evidence: tuple[str, ...]
+    guidance: str
+
+
+@dataclass(frozen=True)
+class RubricItem:
+    id: str
+    label: str
+    weight: int
+    scorer: Callable[[str], tuple[float, tuple[str, ...]]]
+    guidance: str
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _headings(text: str) -> list[str]:
+    return [match.group(1).strip().lower() for match in re.finditer(r"(?m)^#{1,4}\s+(.+?)\s*$", text)]
+
+
+def _has_heading(text: str, *needles: str) -> bool:
+    headings = _headings(text)
+    return any(any(needle in heading for needle in needles) for heading in headings)
+
+
+def _count_patterns(text: str, patterns: Sequence[str], *, flags: int = re.IGNORECASE) -> int:
+    return sum(len(re.findall(pattern, text, flags)) for pattern in patterns)
+
+
+def _ratio(count: int, target: int) -> float:
+    if target <= 0:
+        return 1.0
+    return min(1.0, count / target)
+
+
+def _score_from_booleans(*values: bool) -> float:
+    if not values:
+        return 0.0
+    return sum(1 for value in values if value) / len(values)
+
+
+def _scope_score(text: str) -> tuple[float, tuple[str, ...]]:
+    evidence: list[str] = []
+    has_scope = _has_heading(text, "scope") or re.search(r"\bscope\b", text, re.IGNORECASE)
+    has_limits = re.search(r"\b(out of scope|limits?|sampled|not inspected|residual risk)", text, re.IGNORECASE)
+    has_method = re.search(r"\b(method|commands?|evidence used|inspected|read pass)", text, re.IGNORECASE)
+    if has_scope:
+        evidence.append("scope is stated")
+    if has_limits:
+        evidence.append("limits or sampling are stated")
+    if has_method:
+        evidence.append("method/evidence collection is stated")
+    return _score_from_booleans(bool(has_scope), bool(has_limits), bool(has_method)), tuple(evidence)
+
+
+def _executive_score(text: str) -> tuple[float, tuple[str, ...]]:
+    verdict_terms = _count_patterns(text, (r"\bverdict\b", r"\bgo\b", r"\bconditional go\b", r"\bno-go\b"))
+    summary = _has_heading(text, "executive summary", "summary", "verdict")
+    thesis = bool(re.search(r"\b(thesis|dominant|root cause|bottom line)\b", text, re.IGNORECASE))
+    evidence = []
+    if summary:
+        evidence.append("executive/verdict section found")
+    if verdict_terms:
+        evidence.append(f"{verdict_terms} verdict/go-no-go terms")
+    if thesis:
+        evidence.append("thesis/root-cause language found")
+    return _score_from_booleans(summary, verdict_terms > 0, thesis), tuple(evidence)
+
+
+def _evidence_score(text: str) -> tuple[float, tuple[str, ...]]:
+    file_refs = re.findall(
+        r"(?<![\w.-])(?:[A-Za-z0-9_.-]+/)+[A-Za-z0-9_.-]+(?:\:\d+(?::\d+)?)?",
+        text,
+    )
+    command_refs = re.findall(
+        r"\b(?:uv --preview-features|pytest|python tools/|./dev|workflow_parity\.py|git status|rg -n)\b",
+        text,
+    )
+    line_refs = [ref for ref in file_refs if re.search(r":\d+", ref)]
+    evidence = []
+    if file_refs:
+        evidence.append(f"{len(file_refs)} file references")
+    if line_refs:
+        evidence.append(f"{len(line_refs)} line references")
+    if command_refs:
+        evidence.append(f"{len(command_refs)} command references")
+    score = 0.5 * _ratio(len(file_refs), 6) + 0.3 * _ratio(len(line_refs), 3) + 0.2 * _ratio(len(command_refs), 2)
+    return score, tuple(evidence)
+
+
+def _severity_score(text: str) -> tuple[float, tuple[str, ...]]:
+    severities = re.findall(r"\b(CRITICAL|HIGH|MED-HIGH|MED|LOW|P0|P1|P2|P3)\b", text)
+    has_findings = _has_heading(text, "finding", "findings") or bool(re.search(r"\bfinding\s+\d+", text, re.IGNORECASE))
+    has_priority_table = bool(re.search(r"\|\s*#\s*\|\s*Severity\s*\|", text, re.IGNORECASE))
+    evidence = []
+    if severities:
+        evidence.append(f"{len(severities)} severity markers")
+    if has_findings:
+        evidence.append("findings section found")
+    if has_priority_table:
+        evidence.append("prioritized severity table found")
+    return _score_from_booleans(bool(severities), has_findings, has_priority_table), tuple(evidence)
+
+
+def _mechanism_score(text: str) -> tuple[float, tuple[str, ...]]:
+    terms = {
+        "mechanism": r"\bmechanism\b",
+        "impact": r"\bimpact\b",
+        "blast radius": r"\bblast radius\b",
+        "recommendation": r"\brecommendation\b",
+    }
+    present = {name: bool(re.search(pattern, text, re.IGNORECASE)) for name, pattern in terms.items()}
+    evidence = tuple(f"{name} covered" for name, value in present.items() if value)
+    return _score_from_booleans(*present.values()), evidence
+
+
+def _architecture_score(text: str) -> tuple[float, tuple[str, ...]]:
+    architecture = _has_heading(text, "architecture", "topology", "module")
+    package_terms = _count_patterns(text, (r"\bpackage\b", r"\bmodule\b", r"\bcontrol plane\b", r"\bevidence plane\b"))
+    boundary_terms = _count_patterns(text, (r"\bboundar", r"\bhandoff\b", r"\bruntime\b", r"\bworkflow\b"))
+    evidence = []
+    if architecture:
+        evidence.append("architecture/topology section found")
+    if package_terms:
+        evidence.append(f"{package_terms} package/module/plane terms")
+    if boundary_terms:
+        evidence.append(f"{boundary_terms} boundary/runtime terms")
+    return _score_from_booleans(architecture, package_terms >= 3, boundary_terms >= 3), tuple(evidence)
+
+
+def _security_release_score(text: str) -> tuple[float, tuple[str, ...]]:
+    security = _has_heading(text, "security")
+    release = _has_heading(text, "release", "packaging", "supply")
+    risk_terms = _count_patterns(
+        text,
+        (
+            r"\bsecret",
+            r"\bcredential",
+            r"\bshell",
+            r"\bsubprocess",
+            r"\bpickle",
+            r"\bpublic bind",
+            r"\bMCP\b",
+            r"\bprovenance",
+            r"\bSBOM\b",
+            r"\bPyPI\b",
+        ),
+    )
+    evidence = []
+    if security:
+        evidence.append("security section found")
+    if release:
+        evidence.append("release/packaging section found")
+    if risk_terms:
+        evidence.append(f"{risk_terms} security/release risk terms")
+    return _score_from_booleans(security, release, risk_terms >= 4), tuple(evidence)
+
+
+def _validation_score(text: str) -> tuple[float, tuple[str, ...]]:
+    validation = _has_heading(text, "testing", "validation", "regression")
+    commands = _count_patterns(text, (r"\bpytest\b", r"\bworkflow_parity\.py\b", r"\b./dev\b", r"\buv --preview-features\b"))
+    gaps = bool(re.search(r"\b(gap|missing test|residual risk|unverified|not run)\b", text, re.IGNORECASE))
+    evidence = []
+    if validation:
+        evidence.append("testing/validation section found")
+    if commands:
+        evidence.append(f"{commands} validation command references")
+    if gaps:
+        evidence.append("gaps/residual risk are stated")
+    return _score_from_booleans(validation, commands > 0, gaps), tuple(evidence)
+
+
+def _recommendation_score(text: str) -> tuple[float, tuple[str, ...]]:
+    recommendations = _has_heading(text, "prioritized recommendations", "recommendations", "next steps")
+    action_terms = _count_patterns(text, (r"\bfix\b", r"\badd\b", r"\bcentralize\b", r"\breplace\b", r"\brequire\b", r"\bvalidate\b"))
+    table = bool(re.search(r"\|\s*#\s*\|.*\|\s*Action\s*\|", text, re.IGNORECASE))
+    evidence = []
+    if recommendations:
+        evidence.append("recommendations section found")
+    if action_terms:
+        evidence.append(f"{action_terms} action verbs")
+    if table:
+        evidence.append("action table found")
+    return _score_from_booleans(recommendations, action_terms >= 4, table), tuple(evidence)
+
+
+def _bottom_line_score(text: str) -> tuple[float, tuple[str, ...]]:
+    bottom = _has_heading(text, "bottom line", "conclusion")
+    adoption = bool(re.search(r"\b(local|shared|cluster|production|multi-tenant|adoption boundary|go|no-go)\b", text, re.IGNORECASE))
+    evidence = []
+    if bottom:
+        evidence.append("bottom-line/conclusion section found")
+    if adoption:
+        evidence.append("adoption boundary language found")
+    return _score_from_booleans(bottom, adoption), tuple(evidence)
+
+
+RUBRIC: tuple[RubricItem, ...] = (
+    RubricItem("scope", "Scope, method, and limits", 10, _scope_score, "State what was inspected, sampled, and out of scope."),
+    RubricItem("executive", "Executive verdict and thesis", 10, _executive_score, "Start with a verdict, thesis, and go/no-go boundary."),
+    RubricItem("evidence", "Concrete evidence and references", 15, _evidence_score, "Cite files, lines, commands, logs, or public evidence."),
+    RubricItem("severity", "Severity and prioritization", 10, _severity_score, "Use severity labels and a prioritized finding/action structure."),
+    RubricItem("mechanism", "Mechanism, impact, and blast radius", 12, _mechanism_score, "Explain how the issue works, impact, affected surfaces, and fix."),
+    RubricItem("architecture", "Architecture and topology context", 10, _architecture_score, "Explain package/module topology and runtime boundaries."),
+    RubricItem("security_release", "Security, packaging, and release posture", 10, _security_release_score, "Cover security boundaries plus packaging/release evidence."),
+    RubricItem("validation", "Testing and regression posture", 10, _validation_score, "Name validation commands, missing tests, and residual risks."),
+    RubricItem("recommendations", "Prioritized recommendations", 9, _recommendation_score, "Provide concrete next actions and validation per action."),
+    RubricItem("bottom_line", "Bottom line", 4, _bottom_line_score, "Close with a concise adoption-boundary judgement."),
+)
+
+
+def evaluate_text(text: str) -> dict[str, object]:
+    results: list[RubricResult] = []
+    for item in RUBRIC:
+        ratio, evidence = item.scorer(text)
+        ratio = max(0.0, min(1.0, ratio))
+        results.append(
+            RubricResult(
+                id=item.id,
+                label=item.label,
+                weight=item.weight,
+                score=round(item.weight * ratio),
+                evidence=evidence,
+                guidance=item.guidance,
+            )
+        )
+    total = sum(result.score for result in results)
+    max_score = sum(item.weight for item in RUBRIC)
+    missing = [
+        {
+            "id": result.id,
+            "label": result.label,
+            "score": result.score,
+            "weight": result.weight,
+            "guidance": result.guidance,
+        }
+        for result in results
+        if result.score < result.weight
+    ]
+    return {
+        "schema": SCHEMA,
+        "generated_at": _utc_now(),
+        "score": total,
+        "max_score": max_score,
+        "grade": _grade(total),
+        "status": "pass" if total >= DEFAULT_MIN_SCORE else "review",
+        "rubric": [
+            {
+                "id": result.id,
+                "label": result.label,
+                "score": result.score,
+                "weight": result.weight,
+                "evidence": list(result.evidence),
+                "guidance": result.guidance,
+            }
+            for result in results
+        ],
+        "missing_or_partial": missing,
+    }
+
+
+def _grade(score: int) -> str:
+    if score >= 90:
+        return "excellent"
+    if score >= 80:
+        return "strong"
+    if score >= 65:
+        return "adequate"
+    if score >= 50:
+        return "weak"
+    return "poor"
+
+
+def _text_report(payload: dict[str, object], *, min_score: int) -> str:
+    lines = [
+        f"Audit quality score: {payload['score']}/{payload['max_score']} ({payload['grade']})",
+        f"Threshold: {min_score}",
+    ]
+    for item in payload["rubric"]:  # type: ignore[index]
+        row = item  # type: ignore[assignment]
+        lines.append(f"- {row['label']}: {row['score']}/{row['weight']}")
+        evidence = row.get("evidence", [])
+        if evidence:
+            lines.append(f"  evidence: {', '.join(evidence)}")
+        if row["score"] < row["weight"]:
+            lines.append(f"  improve: {row['guidance']}")
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("audit_markdown", type=Path, help="Markdown audit/review document to score.")
+    parser.add_argument("--min-score", type=int, default=DEFAULT_MIN_SCORE, help="Fail when score is below this value.")
+    parser.add_argument("--json", action="store_true", help="Print JSON instead of a text report.")
+    parser.add_argument("--output", type=Path, help="Optional path to write the JSON report.")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    text = args.audit_markdown.read_text(encoding="utf-8")
+    payload = evaluate_text(text)
+    payload["source"] = str(args.audit_markdown)
+    payload["threshold"] = args.min_score
+    payload["status"] = "pass" if int(payload["score"]) >= args.min_score else "fail"
+
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(_text_report(payload, min_score=args.min_score))
+
+    return 0 if int(payload["score"]) >= args.min_score else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `tools/audit_quality_evaluator.py` to score AGILAB audit/review Markdown artifacts against a 100-point rubric
- add `CODE_REVIEW_TEMPLATE.md` under the deep-audit skill resources
- update `agilab-deep-audit` to use the template and run the quality gate before handoff
- add focused evaluator tests for strong/weak audits and CLI JSON output

## Validation
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_audit_quality_evaluator.py`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile skills`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --staged`

## Notes
- the quality gate fails under score 80 by default
- skill security scan findings remain existing medium/low/info findings and the profile exits successfully with `--fail-on critical`
