### PR TITLE
Extract resolver env deployment support

### DIFF
--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_local_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_local_support.py
@@ -10,7 +10,6 @@ import stat
 import subprocess
 import time
 from dataclasses import dataclass
-from shlex import quote
 from importlib.metadata import (
     PackageNotFoundError,
     distribution as pkg_distribution,
@@ -47,6 +46,18 @@ from agi_cluster.agi_distributor.deployment_install_spec_support import (
     _is_local_project_install_spec as _is_local_project_install_spec,
     _is_python_project as _is_python_project,
     _resolve_distribution_install_spec as _support_resolve_distribution_install_spec,
+)
+from agi_cluster.agi_distributor.deployment_resolver_env_support import (
+    UV_INDEX_RESOLVER_ENV_VARS as UV_INDEX_RESOLVER_ENV_VARS,
+    UV_RESOLVER_PROPAGATED_ENV_VARS as UV_RESOLVER_PROPAGATED_ENV_VARS,
+    UV_WHEELHOUSE_RESOLVER_ENV_VARS as UV_WHEELHOUSE_RESOLVER_ENV_VARS,
+    _envar_nonempty as _envar_nonempty,
+    _envar_value as _envar_value,
+    _local_worker_post_install_env_prefix as _local_worker_post_install_env_prefix,
+    _shell_env_prefix as _shell_env_prefix,
+    _uv_offline_flag as _uv_offline_flag,
+    _uv_resolver_env_prefix as _uv_resolver_env_prefix,
+    _uv_resolver_mode as _uv_resolver_mode,
 )
 from agi_cluster.agi_distributor.deployment_stage_cache_support import (
     DEPLOY_COPY_STAMP_FILENAME as DEPLOY_COPY_STAMP_FILENAME,
@@ -95,16 +106,6 @@ FORCE_REMOVE_EXCEPTIONS = (OSError, shutil.Error)
 DEPENDENCY_PARSE_EXCEPTIONS = (InvalidRequirement,)
 PYPROJECT_PARSE_EXCEPTIONS = (OSError, tomlkit.exceptions.ParseError)  # ty: ignore[possibly-missing-submodule]
 PERF_TRACE_ENV = "AGILAB_PERF_TRACE"
-UV_INDEX_RESOLVER_ENV_VARS = ("UV_INDEX_URL", "UV_EXTRA_INDEX_URL")
-UV_WHEELHOUSE_RESOLVER_ENV_VARS = ("UV_FIND_LINKS",)
-UV_RESOLVER_PROPAGATED_ENV_VARS = (
-    "UV_INDEX_URL",
-    "UV_EXTRA_INDEX_URL",
-    "UV_FIND_LINKS",
-    "SSL_CERT_FILE",
-    "REQUESTS_CA_BUNDLE",
-    "UV_NATIVE_TLS",
-)
 DEPENDENCY_MODULE_ALIASES: dict[str, tuple[str, ...]] = {
     "pillow": ("PIL",),
     "python-dotenv": ("dotenv",),
@@ -715,89 +716,6 @@ def _write_manager_sync_overlay(
     overlay_pyproject = overlay_dir / "pyproject.toml"
     overlay_pyproject.write_text(tomlkit.dumps(doc), encoding="utf-8")
     return overlay_dir
-
-
-def _shell_env_prefix(env_overrides: dict[str, str], *, os_name: str = os.name) -> str:
-    if not env_overrides:
-        return ""
-    if os_name == "nt":
-        return "".join(
-            f'set "{key}={value}" && ' for key, value in env_overrides.items()
-        )
-    return "".join(f"{key}={quote(value)} " for key, value in env_overrides.items())
-
-
-def _envar_value(envars: Any, key: str) -> Any:
-    raw = os.environ.get(key)
-    if raw is None:
-        try:
-            raw = envars.get(key)
-        except (AttributeError, RuntimeError, TypeError):
-            raw = None
-    return raw
-
-
-def _envar_nonempty(envars: Any, key: str) -> bool:
-    raw = _envar_value(envars, key)
-    if raw is None:
-        return False
-    normalized = str(raw).strip().strip("\"'").strip()
-    return bool(normalized) and normalized.casefold() not in {"none", "null"}
-
-
-def _uv_resolver_mode(envars: Any) -> str:
-    if any(_envar_nonempty(envars, key) for key in UV_INDEX_RESOLVER_ENV_VARS):
-        return "mirror"
-    if any(_envar_nonempty(envars, key) for key in UV_WHEELHOUSE_RESOLVER_ENV_VARS):
-        return "wheelhouse"
-    raw = _envar_value(envars, "AGI_INTERNET_ON")
-    if raw is None:
-        return "online"
-    if isinstance(raw, bool):
-        return "online" if raw else "cache-only"
-    if isinstance(raw, (int, float)):
-        try:
-            return "online" if int(raw) == 1 else "cache-only"
-        except (TypeError, ValueError):
-            return "cache-only"
-    normalized = str(raw).strip().strip("\"'").strip().lower()
-    return "online" if normalized in {"1", "true", "yes", "on"} else "cache-only"
-
-
-def _uv_resolver_env_prefix(envars: Any, *, os_name: str = os.name) -> str:
-    values: dict[str, str] = {}
-    for key in UV_RESOLVER_PROPAGATED_ENV_VARS:
-        if _envar_nonempty(envars, key):
-            values[key] = str(_envar_value(envars, key)).strip().strip("\"'").strip()
-    return _shell_env_prefix(values, os_name=os_name)
-
-
-def _uv_offline_flag(envars: Any) -> str:
-    mode = _uv_resolver_mode(envars)
-    if mode in {"online", "mirror"}:
-        return ""
-    if mode == "wheelhouse":
-        return "--offline "
-    raw = _envar_value(envars, "AGI_INTERNET_ON")
-    if isinstance(raw, bool):
-        return "" if raw else "--offline "
-    if isinstance(raw, (int, float)):
-        try:
-            return "" if int(raw) == 1 else "--offline "
-        except (TypeError, ValueError):
-            return "--offline "
-    normalized = str(raw).strip().strip("\"'").strip().lower()
-    return "" if normalized in {"1", "true", "yes", "on"} else "--offline "
-
-
-def _local_worker_post_install_env_prefix(
-    agi_cls: Any, *, os_name: str = os.name
-) -> str:
-    mode = int(getattr(agi_cls, "_mode", 0) or 0)
-    dask_mode = int(getattr(agi_cls, "DASK_MODE", 0) or 0)
-    if dask_mode and (mode & dask_mode):
-        return ""
-    return _shell_env_prefix({"AGI_CLUSTER_ENABLED": "0"}, os_name=os_name)
 
 
 def _update_pyproject_dependencies(

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_resolver_env_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_resolver_env_support.py
@@ -1,0 +1,99 @@
+import os
+from shlex import quote
+from typing import Any
+
+
+UV_INDEX_RESOLVER_ENV_VARS = ("UV_INDEX_URL", "UV_EXTRA_INDEX_URL")
+UV_WHEELHOUSE_RESOLVER_ENV_VARS = ("UV_FIND_LINKS",)
+UV_RESOLVER_PROPAGATED_ENV_VARS = (
+    "UV_INDEX_URL",
+    "UV_EXTRA_INDEX_URL",
+    "UV_FIND_LINKS",
+    "SSL_CERT_FILE",
+    "REQUESTS_CA_BUNDLE",
+    "UV_NATIVE_TLS",
+)
+
+
+def _shell_env_prefix(env_overrides: dict[str, str], *, os_name: str = os.name) -> str:
+    if not env_overrides:
+        return ""
+    if os_name == "nt":
+        return "".join(
+            f'set "{key}={value}" && ' for key, value in env_overrides.items()
+        )
+    return "".join(f"{key}={quote(value)} " for key, value in env_overrides.items())
+
+
+def _envar_value(envars: Any, key: str) -> Any:
+    raw = os.environ.get(key)
+    if raw is None:
+        try:
+            raw = envars.get(key)
+        except (AttributeError, RuntimeError, TypeError):
+            raw = None
+    return raw
+
+
+def _envar_nonempty(envars: Any, key: str) -> bool:
+    raw = _envar_value(envars, key)
+    if raw is None:
+        return False
+    normalized = str(raw).strip().strip("\"'").strip()
+    return bool(normalized) and normalized.casefold() not in {"none", "null"}
+
+
+def _uv_resolver_mode(envars: Any) -> str:
+    if any(_envar_nonempty(envars, key) for key in UV_INDEX_RESOLVER_ENV_VARS):
+        return "mirror"
+    if any(_envar_nonempty(envars, key) for key in UV_WHEELHOUSE_RESOLVER_ENV_VARS):
+        return "wheelhouse"
+    raw = _envar_value(envars, "AGI_INTERNET_ON")
+    if raw is None:
+        return "online"
+    if isinstance(raw, bool):
+        return "online" if raw else "cache-only"
+    if isinstance(raw, (int, float)):
+        try:
+            return "online" if int(raw) == 1 else "cache-only"
+        except (TypeError, ValueError):
+            return "cache-only"
+    normalized = str(raw).strip().strip("\"'").strip().lower()
+    return "online" if normalized in {"1", "true", "yes", "on"} else "cache-only"
+
+
+def _uv_resolver_env_prefix(envars: Any, *, os_name: str = os.name) -> str:
+    values: dict[str, str] = {}
+    for key in UV_RESOLVER_PROPAGATED_ENV_VARS:
+        if _envar_nonempty(envars, key):
+            values[key] = str(_envar_value(envars, key)).strip().strip("\"'").strip()
+    return _shell_env_prefix(values, os_name=os_name)
+
+
+def _uv_offline_flag(envars: Any) -> str:
+    mode = _uv_resolver_mode(envars)
+    if mode in {"online", "mirror"}:
+        return ""
+    if mode == "wheelhouse":
+        return "--offline "
+    raw = _envar_value(envars, "AGI_INTERNET_ON")
+    if isinstance(raw, bool):
+        return "" if raw else "--offline "
+    if isinstance(raw, (int, float)):
+        try:
+            return "" if int(raw) == 1 else "--offline "
+        except (TypeError, ValueError):
+            return "--offline "
+    normalized = str(raw).strip().strip("\"'").strip().lower()
+    return "" if normalized in {"1", "true", "yes", "on"} else "--offline "
+
+
+def _local_worker_post_install_env_prefix(
+    agi_cls: Any, *, os_name: str = os.name
+) -> str:
+    mode = int(getattr(agi_cls, "_mode", 0) or 0)
+    dask_mode = int(getattr(agi_cls, "DASK_MODE", 0) or 0)
+    if dask_mode and (mode & dask_mode):
+        return ""
+    return _shell_env_prefix({"AGI_CLUSTER_ENABLED": "0"}, os_name=os_name)
+


### PR DESCRIPTION
## Summary
- extract uv resolver environment helpers from `deployment_local_support.py` into `deployment_resolver_env_support.py`
- keep the previous `deployment_local_support._...` symbols as explicit compatibility re-exports
- reduce the remaining deployment-local monolith as part of the CODE_REVIEW architecture/module-topology follow-up

## Validation
- `uv --preview-features extra-build-dependencies run --no-sync python -m py_compile src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_local_support.py src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_resolver_env_support.py`
- `uv --preview-features extra-build-dependencies run --no-sync pytest -q -o addopts='' src/agilab/core/test/test_agi_distributor_deployment_local_support.py -k 'shell_env_prefix or uv_offline_flag or uv_resolver_mode or local_worker_post_install_env_prefix'`
- `uv --preview-features extra-build-dependencies run --no-sync python tools/impact_validate.py --files src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_local_support.py src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_resolver_env_support.py`
- `uv --preview-features extra-build-dependencies run --no-sync pytest -q -o addopts='' src/agilab/core/test`
