### PR TITLE
Extract deploy stage plan support

### DIFF
--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_local_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_local_support.py
@@ -1,15 +1,11 @@
 import getpass
-import hashlib
-import json
 import logging
 import os
-import platform
 import re
 import shutil
 import stat
 import subprocess
 import time
-from dataclasses import dataclass
 from importlib.metadata import (
     PackageNotFoundError,
     distribution as pkg_distribution,
@@ -82,6 +78,12 @@ from agi_cluster.agi_distributor.deployment_stage_cache_support import (
     _write_deploy_copy_stamp as _write_deploy_copy_stamp,
     _write_deploy_stage_cache as _write_deploy_stage_cache,
     _write_deploy_timing_trace as _write_deploy_timing_trace,
+)
+from agi_cluster.agi_distributor.deployment_stage_plan_support import (
+    _DeployPlan as _DeployPlan,
+    _DeployPlanNode as _DeployPlanNode,
+    _deploy_stage_digest as _deploy_stage_digest,
+    _run_cached_deploy_stage as _run_cached_deploy_stage,
 )
 from agi_cluster.agi_distributor.deployment_venv_support import (
     project_site_packages_dir as _project_site_packages_dir,
@@ -183,140 +185,6 @@ def _remove_project_venv_if_mismatched(
         _force_remove(venv_root, env_logger=env_logger)
         return True
     return False
-
-
-def _deploy_stage_digest(
-    stage_name: str,
-    cmd: str,
-    cwd: Path,
-    *,
-    inputs: list[Path],
-) -> str:
-    unique_inputs = sorted(
-        {path.expanduser().resolve(strict=False).as_posix(): path for path in inputs}
-    )
-    payload = {
-        "schema": DEPLOY_STAGE_CACHE_SCHEMA,
-        "stage": stage_name,
-        "cmd": cmd,
-        "cwd": cwd.expanduser().resolve(strict=False).as_posix(),
-        "platform": platform.system(),
-        "machine": platform.machine(),
-        "os_name": os.name,
-        "inputs": [
-            _deploy_stage_file_fingerprint(Path(path)) for path in unique_inputs
-        ],
-    }
-    return hashlib.sha256(
-        json.dumps(payload, sort_keys=True).encode("utf-8")
-    ).hexdigest()
-
-
-async def _run_cached_deploy_stage(
-    *,
-    stage_name: str,
-    cmd: str,
-    cwd: Path,
-    run_fn: Callable[..., Any],
-    cache_enabled: bool,
-    cache_state: dict[str, Any],
-    cache_path: Path,
-    inputs: list[Path],
-    output_probe: Callable[[], bool],
-    log: logging.Logger | Any,
-) -> bool:
-    if not cache_enabled:
-        await run_fn(cmd, cwd)
-        return True
-
-    digest = _deploy_stage_digest(stage_name, cmd, cwd, inputs=inputs)
-    stages = cache_state.setdefault("stages", {})
-    cached = stages.get(stage_name) if isinstance(stages, dict) else None
-    if isinstance(cached, dict) and cached.get("digest") == digest and output_probe():
-        log.info("Skipping cached deploy stage: %s", stage_name)
-        return False
-
-    await run_fn(cmd, cwd)
-    if output_probe() and isinstance(stages, dict):
-        stages[stage_name] = {
-            "digest": _deploy_stage_digest(stage_name, cmd, cwd, inputs=inputs)
-        }
-        _write_deploy_stage_cache(cache_path, cache_state)
-    return True
-
-
-@dataclass(frozen=True)
-class _DeployPlanNode:
-    name: str
-    cmd: str
-    cwd: Path
-    inputs: list[Path]
-    output_probe: Callable[[], bool]
-    dependencies: tuple[str, ...] = ()
-
-
-class _DeployPlan:
-    def __init__(
-        self,
-        *,
-        run_fn: Callable[..., Any],
-        cache_enabled: bool,
-        cache_state: dict[str, Any],
-        cache_path: Path,
-        log: logging.Logger | Any,
-        time_fn: Callable[[], float] = time.perf_counter,
-    ) -> None:
-        self._run_fn = run_fn
-        self._cache_enabled = cache_enabled
-        self._cache_state = cache_state
-        self._cache_path = cache_path
-        self._log = log
-        self._time_fn = time_fn
-        self._completed: set[str] = set()
-        self.results: dict[str, str] = {}
-        self.timings: list[dict[str, Any]] = []
-
-    def record_timing(self, stage: str, result: str, seconds: float) -> None:
-        self.timings.append(
-            {
-                "stage": stage,
-                "result": result,
-                "seconds": round(float(seconds), 6),
-            }
-        )
-
-    async def run(self, node: _DeployPlanNode) -> str:
-        missing = [
-            dependency
-            for dependency in node.dependencies
-            if dependency not in self._completed
-        ]
-        if missing:
-            raise RuntimeError(
-                f"Deploy plan stage {node.name!r} is missing dependencies: {', '.join(missing)}"
-            )
-
-        result = "failed"
-        started_at = self._time_fn()
-        try:
-            ran = await _run_cached_deploy_stage(
-                stage_name=node.name,
-                cmd=node.cmd,
-                cwd=node.cwd,
-                run_fn=self._run_fn,
-                cache_enabled=self._cache_enabled,
-                cache_state=self._cache_state,
-                cache_path=self._cache_path,
-                inputs=node.inputs,
-                output_probe=node.output_probe,
-                log=self._log,
-            )
-            result = "ran" if ran else "skipped"
-            self.results[node.name] = result
-            self._completed.add(node.name)
-            return result
-        finally:
-            self.record_timing(node.name, result, self._time_fn() - started_at)
 
 
 async def _ensure_project_venv(

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_stage_plan_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_stage_plan_support.py
@@ -1,0 +1,151 @@
+import hashlib
+import json
+import logging
+import os
+import platform
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+from agi_cluster.agi_distributor.deployment_stage_cache_support import (
+    DEPLOY_STAGE_CACHE_SCHEMA,
+    _deploy_stage_file_fingerprint,
+    _write_deploy_stage_cache,
+)
+
+
+def _deploy_stage_digest(
+    stage_name: str,
+    cmd: str,
+    cwd: Path,
+    *,
+    inputs: list[Path],
+) -> str:
+    unique_inputs = sorted(
+        {path.expanduser().resolve(strict=False).as_posix(): path for path in inputs}
+    )
+    payload = {
+        "schema": DEPLOY_STAGE_CACHE_SCHEMA,
+        "stage": stage_name,
+        "cmd": cmd,
+        "cwd": cwd.expanduser().resolve(strict=False).as_posix(),
+        "platform": platform.system(),
+        "machine": platform.machine(),
+        "os_name": os.name,
+        "inputs": [
+            _deploy_stage_file_fingerprint(Path(path)) for path in unique_inputs
+        ],
+    }
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True).encode("utf-8")
+    ).hexdigest()
+
+
+async def _run_cached_deploy_stage(
+    *,
+    stage_name: str,
+    cmd: str,
+    cwd: Path,
+    run_fn: Callable[..., Any],
+    cache_enabled: bool,
+    cache_state: dict[str, Any],
+    cache_path: Path,
+    inputs: list[Path],
+    output_probe: Callable[[], bool],
+    log: logging.Logger | Any,
+) -> bool:
+    if not cache_enabled:
+        await run_fn(cmd, cwd)
+        return True
+
+    digest = _deploy_stage_digest(stage_name, cmd, cwd, inputs=inputs)
+    stages = cache_state.setdefault("stages", {})
+    cached = stages.get(stage_name) if isinstance(stages, dict) else None
+    if isinstance(cached, dict) and cached.get("digest") == digest and output_probe():
+        log.info("Skipping cached deploy stage: %s", stage_name)
+        return False
+
+    await run_fn(cmd, cwd)
+    if output_probe() and isinstance(stages, dict):
+        stages[stage_name] = {
+            "digest": _deploy_stage_digest(stage_name, cmd, cwd, inputs=inputs)
+        }
+        _write_deploy_stage_cache(cache_path, cache_state)
+    return True
+
+
+@dataclass(frozen=True)
+class _DeployPlanNode:
+    name: str
+    cmd: str
+    cwd: Path
+    inputs: list[Path]
+    output_probe: Callable[[], bool]
+    dependencies: tuple[str, ...] = ()
+
+
+class _DeployPlan:
+    def __init__(
+        self,
+        *,
+        run_fn: Callable[..., Any],
+        cache_enabled: bool,
+        cache_state: dict[str, Any],
+        cache_path: Path,
+        log: logging.Logger | Any,
+        time_fn: Callable[[], float] = time.perf_counter,
+    ) -> None:
+        self._run_fn = run_fn
+        self._cache_enabled = cache_enabled
+        self._cache_state = cache_state
+        self._cache_path = cache_path
+        self._log = log
+        self._time_fn = time_fn
+        self._completed: set[str] = set()
+        self.results: dict[str, str] = {}
+        self.timings: list[dict[str, Any]] = []
+
+    def record_timing(self, stage: str, result: str, seconds: float) -> None:
+        self.timings.append(
+            {
+                "stage": stage,
+                "result": result,
+                "seconds": round(float(seconds), 6),
+            }
+        )
+
+    async def run(self, node: _DeployPlanNode) -> str:
+        missing = [
+            dependency
+            for dependency in node.dependencies
+            if dependency not in self._completed
+        ]
+        if missing:
+            raise RuntimeError(
+                f"Deploy plan stage {node.name!r} is missing dependencies: {', '.join(missing)}"
+            )
+
+        result = "failed"
+        started_at = self._time_fn()
+        try:
+            ran = await _run_cached_deploy_stage(
+                stage_name=node.name,
+                cmd=node.cmd,
+                cwd=node.cwd,
+                run_fn=self._run_fn,
+                cache_enabled=self._cache_enabled,
+                cache_state=self._cache_state,
+                cache_path=self._cache_path,
+                inputs=node.inputs,
+                output_probe=node.output_probe,
+                log=self._log,
+            )
+            result = "ran" if ran else "skipped"
+            self.results[node.name] = result
+            self._completed.add(node.name)
+            return result
+        finally:
+            self.record_timing(node.name, result, self._time_fn() - started_at)
+
+


### PR DESCRIPTION
## Summary
- extract deploy-stage digest/cache runner and plan classes from `deployment_local_support.py` into `deployment_stage_plan_support.py`
- keep the previous `deployment_local_support._...` symbols as explicit compatibility re-exports
- continue the CODE_REVIEW architecture/module-topology decomposition of the remaining deployment-local monolith

## Validation
- `uv --preview-features extra-build-dependencies run --no-sync python -m py_compile src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_local_support.py src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_stage_plan_support.py`
- `uv --preview-features extra-build-dependencies run --no-sync pytest -q -o addopts='' src/agilab/core/test/test_agi_distributor_deployment_local_support.py -k 'run_cached_deploy_stage or deploy_plan'`
- `uv --preview-features extra-build-dependencies run --no-sync python tools/impact_validate.py --files src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_local_support.py src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_stage_plan_support.py`
- `uv --preview-features extra-build-dependencies run --no-sync pytest -q -o addopts='' src/agilab/core/test`
