### PR TITLE
Harden AGILAB audit skill quality gates

### DIFF
--- a/.claude/skills/agilab-deep-audit/SKILL.md
+++ b/.claude/skills/agilab-deep-audit/SKILL.md
@@ -191,6 +191,10 @@ evaluator before handoff unless the user explicitly asks not to validate:
 uv --preview-features extra-build-dependencies run python tools/audit_quality_evaluator.py <audit.md> --min-score 80
 ```
 
+Use `./dev audit-preflight` before writing a long audit when the architecture
+context is not fresh. Use `./dev audit-quality <audit.md>` as the short local
+gate after writing the audit.
+
 Use `--json --output <report.json>` when the score should become evidence. A
 score below 80 means the artifact is not yet comparison-quality; improve the
 missing rubric areas before presenting it as a final audit.

--- a/.claude/skills/agilab-intent-router/SKILL.md
+++ b/.claude/skills/agilab-intent-router/SKILL.md
@@ -53,7 +53,7 @@ Route these patterns before choosing tools:
 
 | User phrase family | Intent | Mode | Skills |
 |---|---|---|---|
-| `review AGILAB`, `audit AGILAB`, `deep review`, `address this audit` | deep audit | report-first unless `fix it` follows | `agilab-deep-audit`, then `agilab-testing` if patching |
+| `review AGILAB`, `audit AGILAB`, `deep review`, `address this audit` | deep audit | report-first; architecture-readiness gate before final audit; patch only if `fix it` follows | `agilab-deep-audit`, then `agilab-testing` if patching |
 | `do it`, `go on`, `fix it`, `next move` | continue current objective | inherit previous scope | previous active skill plus `plan-before-code` for code changes |
 | `update repos`, `sync repos` | safe repo sync | show command plan first | `agilab-runbook` |
 | `update skill`, `sync skills`, `make future agents do X` | repo skill update | edit `.claude`, sync `.codex`, regenerate index | `skill-creator`, `repo-skill-maintenance` |
@@ -65,7 +65,9 @@ Route these patterns before choosing tools:
 ## Behavior Contract
 
 - For `review AGILAB`, always load `agilab-deep-audit` and define a review
-  scope before reading code.
+  scope before reading code. If architecture context is not crystal clear, load
+  `ARCHITECTURE_FOUNDATIONS.md` and run the deep-audit preflight before writing
+  final findings.
 - For `fix it` after an audit, convert prioritized findings into a patch plan;
   do not silently patch unrelated findings.
 - For `update repos`, never touch repos outside the current allowlist unless

--- a/.codex/skills/agilab-deep-audit/SKILL.md
+++ b/.codex/skills/agilab-deep-audit/SKILL.md
@@ -191,6 +191,10 @@ evaluator before handoff unless the user explicitly asks not to validate:
 uv --preview-features extra-build-dependencies run python tools/audit_quality_evaluator.py <audit.md> --min-score 80
 ```
 
+Use `./dev audit-preflight` before writing a long audit when the architecture
+context is not fresh. Use `./dev audit-quality <audit.md>` as the short local
+gate after writing the audit.
+
 Use `--json --output <report.json>` when the score should become evidence. A
 score below 80 means the artifact is not yet comparison-quality; improve the
 missing rubric areas before presenting it as a final audit.

--- a/.codex/skills/agilab-intent-router/SKILL.md
+++ b/.codex/skills/agilab-intent-router/SKILL.md
@@ -53,7 +53,7 @@ Route these patterns before choosing tools:
 
 | User phrase family | Intent | Mode | Skills |
 |---|---|---|---|
-| `review AGILAB`, `audit AGILAB`, `deep review`, `address this audit` | deep audit | report-first unless `fix it` follows | `agilab-deep-audit`, then `agilab-testing` if patching |
+| `review AGILAB`, `audit AGILAB`, `deep review`, `address this audit` | deep audit | report-first; architecture-readiness gate before final audit; patch only if `fix it` follows | `agilab-deep-audit`, then `agilab-testing` if patching |
 | `do it`, `go on`, `fix it`, `next move` | continue current objective | inherit previous scope | previous active skill plus `plan-before-code` for code changes |
 | `update repos`, `sync repos` | safe repo sync | show command plan first | `agilab-runbook` |
 | `update skill`, `sync skills`, `make future agents do X` | repo skill update | edit `.claude`, sync `.codex`, regenerate index | `skill-creator`, `repo-skill-maintenance` |
@@ -65,7 +65,9 @@ Route these patterns before choosing tools:
 ## Behavior Contract
 
 - For `review AGILAB`, always load `agilab-deep-audit` and define a review
-  scope before reading code.
+  scope before reading code. If architecture context is not crystal clear, load
+  `ARCHITECTURE_FOUNDATIONS.md` and run the deep-audit preflight before writing
+  final findings.
 - For `fix it` after an audit, convert prioritized findings into a patch plan;
   do not silently patch unrelated findings.
 - For `update repos`, never touch repos outside the current allowlist unless

--- a/test/fixtures/audit_quality/strong_agilab_audit.md
+++ b/test/fixtures/audit_quality/strong_agilab_audit.md
@@ -1,0 +1,70 @@
+# AGILAB - Detailed Code Review
+
+> Scope: fully inspected `tools/audit_quality_evaluator.py`, `src/agilab/main_page.py`, and sampled docs.
+> Limits: worker internals were sampled, not exhaustively inspected.
+
+## Executive summary
+
+Verdict: conditional go. The dominant thesis is that execution boundaries are
+good for local research but need stronger guardrails for shared cluster use.
+
+## Scope and method
+
+- Fully inspected: tools/audit_quality_evaluator.py, src/agilab/main_page.py:42,
+  src/agilab/ui_public_bind_guard.py:17, docs/source/apps-pages.rst:148
+- Sampled: src/agilab/core/agi-node/src/agi_node/agi_dispatcher/base_worker.py:88
+- Commands/evidence used: uv --preview-features extra-build-dependencies run pytest -q,
+  python tools/workflow_parity.py --profile skills, git status --short
+
+## Architecture and module topology
+
+The package topology separates control plane, payload plane, and evidence plane.
+The handoff runtime boundary is clear, but workflow ownership crosses modules.
+AGILAB is a trusted-operator reproducibility workbench, not a standalone
+production MLOps control plane. The `agi-pages` umbrella and apps-pages stay
+app-agnostic, so project-specific dependencies belong in app/page packages
+instead of generic providers. Linux, macOS, and Windows assumptions are part of
+the audit boundary. Release proof, package split, docs mirror, and public claims
+must agree before a feature is described as shipped.
+
+## Findings
+
+### Finding 1 - generated-code sandbox is policy based - **HIGH**
+
+- Evidence: src/agilab/lab_run.py:120 and tools/audit_quality_evaluator.py:10.
+- Mechanism: generated code can enter an execution path after an environment gate.
+- Impact: shared workspaces can run untrusted payloads.
+- Blast radius: UI, worker execution, cluster workflows, and tests.
+- Recommendation: require container or VM isolation for shared profiles.
+- Regression plan: add pytest coverage and workflow_parity.py shared profile checks.
+
+## Security posture
+
+Security review covered shell, subprocess, secrets, credentials, pickle, MCP,
+public bind, SBOM, provenance, and PyPI release evidence.
+
+## Testing and cross-platform posture
+
+Validation uses pytest and uv --preview-features extra-build-dependencies run
+commands. Missing test gap: Windows path quoting remains unverified.
+
+## Packaging, docs, and release posture
+
+Packaging and release posture cover wheel surface, docs mirror, changelog,
+PyPI provenance, GitHub release proof, and public documentation claims.
+
+## Prioritized recommendations
+
+| # | Severity | Issue | Action | Validation |
+|---|---|---|---|---|
+| 1 | **HIGH** | sandbox boundary | Add isolation gate | pytest and workflow profile |
+| 2 | **MED** | docs drift | Centralize mirror checks | ./dev docs |
+
+## Residual risks
+
+Some cluster behavior is unverified without a live remote worker.
+
+## Bottom line
+
+Bottom line: go for local research, conditional go for shared clusters, no-go
+for production multi-tenant serving without additional controls.

--- a/test/fixtures/audit_quality/weak_agilab_audit.md
+++ b/test/fixtures/audit_quality/weak_agilab_audit.md
@@ -1,0 +1,3 @@
+# Review
+
+Looks good overall. Some tests would help. I would improve security later.

--- a/test/test_agilab_dev_shortcuts.py
+++ b/test/test_agilab_dev_shortcuts.py
@@ -245,6 +245,50 @@ def test_audit_shortcut_runs_agilab_audit():
     ]
 
 
+def test_audit_quality_shortcut_scores_markdown_audit():
+    assert agilab_dev.planned_commands(["audit-quality", "CODE_REVIEW.md", "--min-score", "90"]) == [
+        [
+            "uv",
+            "--preview-features",
+            "extra-build-dependencies",
+            "run",
+            "python",
+            "tools/audit_quality_evaluator.py",
+            "CODE_REVIEW.md",
+            "--min-score",
+            "90",
+        ]
+    ]
+
+
+def test_audit_quality_shortcut_defaults_to_preflight_without_file():
+    assert agilab_dev.planned_commands(["audit-quality"]) == [
+        [
+            "uv",
+            "--preview-features",
+            "extra-build-dependencies",
+            "run",
+            "python",
+            "tools/audit_quality_evaluator.py",
+            "--preflight",
+        ]
+    ]
+
+
+def test_audit_preflight_shortcut_prints_architecture_preflight():
+    assert agilab_dev.planned_commands(["audit-preflight"]) == [
+        [
+            "uv",
+            "--preview-features",
+            "extra-build-dependencies",
+            "run",
+            "python",
+            "tools/audit_quality_evaluator.py",
+            "--preflight",
+        ]
+    ]
+
+
 def test_main_keeps_machine_readable_shortcut_stdout_clean(capsys, monkeypatch):
     calls = []
 

--- a/test/test_audit_quality_evaluator.py
+++ b/test/test_audit_quality_evaluator.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 MODULE_PATH = ROOT / "tools" / "audit_quality_evaluator.py"
+FIXTURES = ROOT / "test" / "fixtures" / "audit_quality"
 SPEC = importlib.util.spec_from_file_location("audit_quality_evaluator_test", MODULE_PATH)
 assert SPEC and SPEC.loader
 module = importlib.util.module_from_spec(SPEC)
@@ -15,108 +16,35 @@ sys.modules[SPEC.name] = module
 SPEC.loader.exec_module(module)
 
 
-STRONG_AUDIT = """
-# AGILAB - Detailed Code Review
-
-> Scope: fully inspected `tools/audit_quality_evaluator.py`, `src/agilab/main_page.py`, and sampled docs.
-> Limits: worker internals were sampled, not exhaustively inspected.
-
-## Executive summary
-
-Verdict: conditional go. The dominant thesis is that execution boundaries are
-good for local research but need stronger guardrails for shared cluster use.
-
-## Scope and method
-
-- Fully inspected: tools/audit_quality_evaluator.py, src/agilab/main_page.py:42,
-  src/agilab/ui_public_bind_guard.py:17, docs/source/apps-pages.rst:148
-- Sampled: src/agilab/core/agi-node/src/agi_node/agi_dispatcher/base_worker.py:88
-- Commands/evidence used: uv --preview-features extra-build-dependencies run pytest -q,
-  python tools/workflow_parity.py --profile skills, git status --short
-
-## Architecture and module topology
-
-The package topology separates control plane, payload plane, and evidence plane.
-The handoff runtime boundary is clear, but workflow ownership crosses modules.
-AGILAB is a trusted-operator reproducibility workbench. The `agi-pages`
-umbrella and apps-pages stay app-agnostic, so project-specific dependencies
-belong in app/page packages instead of generic providers. Linux, macOS, and
-Windows assumptions are part of the audit boundary.
-
-## Findings
-
-### Finding 1 - generated-code sandbox is policy based - **HIGH**
-
-- Evidence: src/agilab/lab_run.py:120 and tools/audit_quality_evaluator.py:10.
-- Mechanism: generated code can enter an execution path after an environment gate.
-- Impact: shared workspaces can run untrusted payloads.
-- Blast radius: UI, worker execution, cluster workflows, and tests.
-- Recommendation: require container or VM isolation for shared profiles.
-- Regression plan: add pytest coverage and workflow_parity.py shared profile checks.
-
-## Security posture
-
-Security review covered shell, subprocess, secrets, credentials, pickle, MCP,
-public bind, SBOM, provenance, and PyPI release evidence.
-
-## Testing and cross-platform posture
-
-Validation uses pytest and uv --preview-features extra-build-dependencies run
-commands. Missing test gap: Windows path quoting remains unverified.
-
-## Packaging, docs, and release posture
-
-Packaging and release posture cover wheel surface, docs mirror, changelog,
-PyPI provenance, GitHub release proof, and public documentation claims.
-
-## Prioritized recommendations
-
-| # | Severity | Issue | Action | Validation |
-|---|---|---|---|---|
-| 1 | **HIGH** | sandbox boundary | Add isolation gate | pytest and workflow profile |
-| 2 | **MED** | docs drift | Centralize mirror checks | ./dev docs |
-
-## Residual risks
-
-Some cluster behavior is unverified without a live remote worker.
-
-## Bottom line
-
-Bottom line: go for local research, conditional go for shared clusters, no-go
-for production multi-tenant serving without additional controls.
-"""
-
-
-WEAK_AUDIT = """
-# Review
-
-Looks good overall. Some tests would help. I would improve security later.
-"""
+def _fixture(name: str) -> str:
+    return (FIXTURES / name).read_text(encoding="utf-8")
 
 
 def test_audit_quality_evaluator_scores_strong_audit() -> None:
-    payload = module.evaluate_text(STRONG_AUDIT)
+    payload = module.evaluate_text(_fixture("strong_agilab_audit.md"))
 
     assert payload["score"] >= 85
     assert payload["grade"] in {"strong", "excellent"}
     by_id = {item["id"]: item for item in payload["rubric"]}
     assert by_id["evidence"]["score"] == by_id["evidence"]["weight"]
     assert by_id["security_release"]["score"] == by_id["security_release"]["weight"]
+    assert payload["architecture_evidence"]["status"] == "pass"
 
 
 def test_audit_quality_evaluator_flags_weak_audit() -> None:
-    payload = module.evaluate_text(WEAK_AUDIT)
+    payload = module.evaluate_text(_fixture("weak_agilab_audit.md"))
 
     assert payload["score"] < 50
     assert payload["grade"] == "poor"
     missing_ids = {item["id"] for item in payload["missing_or_partial"]}
     assert {"scope", "evidence", "severity", "validation"}.issubset(missing_ids)
+    assert payload["architecture_evidence"]["status"] == "fail"
 
 
 def test_audit_quality_evaluator_cli_writes_json_and_returns_failure(tmp_path: Path) -> None:
     audit = tmp_path / "audit.md"
     output = tmp_path / "report.json"
-    audit.write_text(WEAK_AUDIT, encoding="utf-8")
+    audit.write_text(_fixture("weak_agilab_audit.md"), encoding="utf-8")
 
     rc = module.main([str(audit), "--min-score", "80", "--output", str(output), "--json"])
 
@@ -125,3 +53,14 @@ def test_audit_quality_evaluator_cli_writes_json_and_returns_failure(tmp_path: P
     assert payload["status"] == "fail"
     assert payload["threshold"] == 80
     assert payload["source"] == str(audit)
+    assert payload["architecture_evidence"]["status"] == "fail"
+
+
+def test_audit_quality_evaluator_preflight_prints_architecture_checklist(capsys) -> None:
+    rc = module.main(["--preflight"])
+
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "AGILAB deep-audit preflight" in captured.out
+    assert "control plane, payload plane, evidence plane" in captured.out
+    assert "Linux, macOS, and Windows" in captured.out

--- a/tools/agilab_dev.py
+++ b/tools/agilab_dev.py
@@ -80,6 +80,12 @@ def planned_commands(argv: Sequence[str]) -> list[list[str]]:
     if command == "audit":
         return [_uv_python("tools/agilab_audit.py", *args)]
 
+    if command in {"audit-quality", "audit-preflight"}:
+        forwarded = ["--preflight"] if command == "audit-preflight" and not args else args
+        if command == "audit-quality" and not forwarded:
+            forwarded = ["--preflight"]
+        return [_uv_python("tools/audit_quality_evaluator.py", *forwarded)]
+
     if command in {"flow", "profile"}:
         profiles, extras = _split_leading_values(args, command_name=command)
         profile_args: list[str] = []
@@ -162,6 +168,8 @@ def _usage() -> str:
   ./dev [--print-only] parallel-stage [parallel_stage args]
   ./dev [--print-only] app-contracts [app_contract_matrix args]
   ./dev [--print-only] audit [agilab_audit args]
+  ./dev [--print-only] audit-quality [audit_quality_evaluator args|audit.md]
+  ./dev [--print-only] audit-preflight
   ./dev [--print-only] flow|profile <profile> [profile...] [workflow args]
   ./dev [--print-only] typing [workflow-parity options]
   ./dev [--print-only] release [impact_validate args]
@@ -180,6 +188,8 @@ High-frequency mappings:
   parallel-stage -> Create or validate a function + split rule + reducer contract for parallel execution.
   app-contracts -> Check built-in app, PyPI package, app catalog, and public-doc alignment.
   audit     -> Audit local AGILAB worktrees, release proof, docs mirror, PyPI projects, and latest release truth.
+  audit-quality -> Score a Markdown AGILAB audit, or print the deep-audit preflight when no file is provided.
+  audit-preflight -> Print the mandatory architecture-foundation preflight for deep AGILAB audits.
   flow      -> Run one or more workflow_parity profiles with repeated --profile flags.
   typing    -> Run the forward shared-core ty typing profile. Mypy remains the curated temporary release guard under shared-core-typing.
   release   -> Run local release guards: impact, generated PyPI plan, release cadence, PyPI project preflight, trusted publisher contract, Ruff availability, docs, dependency policy, typing, and badge freshness.

--- a/tools/audit_quality_evaluator.py
+++ b/tools/audit_quality_evaluator.py
@@ -35,6 +35,80 @@ class RubricItem:
     guidance: str
 
 
+@dataclass(frozen=True)
+class ArchitectureCheck:
+    id: str
+    label: str
+    patterns: tuple[str, ...]
+    guidance: str
+
+
+ARCHITECTURE_CHECKS: tuple[ArchitectureCheck, ...] = (
+    ArchitectureCheck(
+        "product_boundary",
+        "Product boundary",
+        (r"\btrusted-operator\b", r"\breproducibility workbench\b", r"\bproduction MLOps\b"),
+        "State AGILAB's trusted-operator workbench role and non-production-MLOps boundary.",
+    ),
+    ArchitectureCheck(
+        "architecture_planes",
+        "Architecture planes",
+        (r"\bcontrol plane\b", r"\bpayload plane\b", r"\bevidence plane\b"),
+        "Name the control, payload, and evidence planes involved.",
+    ),
+    ArchitectureCheck(
+        "app_page_dependency_boundary",
+        "App/page dependency boundary",
+        (r"\bapps-pages\b", r"\bagi-pages\b", r"\bapp-agnostic\b", r"\bproject-specific dependenc"),
+        "Explain that app-specific dependencies belong in app/page packages, not generic apps-pages or agi-pages.",
+    ),
+    ArchitectureCheck(
+        "cross_platform_boundary",
+        "Cross-platform boundary",
+        (r"\bLinux\b", r"\bmacOS\b", r"\bWindows\b"),
+        "State which Linux/macOS/Windows assumptions were checked or remain residual risk.",
+    ),
+    ArchitectureCheck(
+        "release_truth_boundary",
+        "Release truth boundary",
+        (r"\brelease proof\b", r"\bpackage split\b", r"\bdocs mirror\b", r"\bpublic claims?\b"),
+        "Tie shipped claims to release proof, package split, docs mirror, and public evidence.",
+    ),
+)
+
+
+PREFLIGHT_LINES = (
+    "AGILAB deep-audit preflight",
+    "",
+    "Before writing a final audit, inspect enough current evidence to explain:",
+    "- product boundary: trusted-operator reproducibility workbench, not standalone production MLOps",
+    "- architecture planes: control plane, payload plane, evidence plane",
+    "- package boundary: lean base, optional extras, split apps/pages",
+    "- app/page dependency boundary: project-specific dependencies stay out of generic apps-pages and agi-pages",
+    "- cross-platform boundary: Linux, macOS, and Windows assumptions",
+    "- execution trust boundary: generated code, notebooks, external apps, workers, page bundles, cluster execution",
+    "- release truth: docs mirror, package split, changelog, release proof, PyPI/GitHub/HF evidence",
+    "",
+    "Useful first-read anchors:",
+    "- pyproject.toml",
+    "- tools/package_split_contract.py",
+    "- src/agilab/lib/agi-pages/src/agi_pages/__init__.py",
+    "- src/agilab/apps-pages/README.md",
+    "- README.md",
+    "- SECURITY.md",
+    "- ADOPTION.md",
+    "- CHANGELOG.md",
+    "- docs/source/release-proof.rst",
+    "- .github/workflows/pypi-publish.yaml",
+    "",
+    "Useful commands:",
+    "- git status --short --branch --untracked-files=no",
+    "- git log --oneline -5",
+    "- find src/agilab/core -maxdepth 3 -name pyproject.toml -print",
+    "- rg -n \"AGILAB_PUBLIC_BIND|pickle\\\\.load|subprocess|create_subprocess|shell=True|apps-pages|agi-pages|release proof|package split|Windows|macOS|Linux\" src/agilab tools docs test",
+)
+
+
 def _utc_now() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
 
@@ -62,6 +136,29 @@ def _score_from_booleans(*values: bool) -> float:
     if not values:
         return 0.0
     return sum(1 for value in values if value) / len(values)
+
+
+def architecture_evidence(text: str) -> dict[str, object]:
+    checks: list[dict[str, object]] = []
+    for check in ARCHITECTURE_CHECKS:
+        matched = [pattern for pattern in check.patterns if re.search(pattern, text, re.IGNORECASE)]
+        checks.append(
+            {
+                "id": check.id,
+                "label": check.label,
+                "status": "pass" if len(matched) == len(check.patterns) else "fail",
+                "matched": len(matched),
+                "required": len(check.patterns),
+                "guidance": check.guidance,
+            }
+        )
+    passed = sum(1 for check in checks if check["status"] == "pass")
+    return {
+        "passed": passed,
+        "required": len(checks),
+        "status": "pass" if passed == len(checks) else "fail",
+        "checks": checks,
+    }
 
 
 def _scope_score(text: str) -> tuple[float, tuple[str, ...]]:
@@ -143,21 +240,7 @@ def _architecture_score(text: str) -> tuple[float, tuple[str, ...]]:
     architecture = _has_heading(text, "architecture", "topology", "module")
     package_terms = _count_patterns(text, (r"\bpackage\b", r"\bmodule\b", r"\bcontrol plane\b", r"\bpayload plane\b", r"\bevidence plane\b"))
     boundary_terms = _count_patterns(text, (r"\bboundar", r"\bhandoff\b", r"\bruntime\b", r"\bworkflow\b"))
-    founding_terms = _count_patterns(
-        text,
-        (
-            r"\bapps-pages\b",
-            r"\bagi-pages\b",
-            r"\bapp-agnostic\b",
-            r"\bproject-specific dependenc",
-            r"\bLinux\b",
-            r"\bmacOS\b",
-            r"\bWindows\b",
-            r"\btrusted-operator\b",
-            r"\breproducibility workbench\b",
-        ),
-        flags=0,
-    )
+    foundation = architecture_evidence(text)
     evidence = []
     if architecture:
         evidence.append("architecture/topology section found")
@@ -165,9 +248,13 @@ def _architecture_score(text: str) -> tuple[float, tuple[str, ...]]:
         evidence.append(f"{package_terms} package/module/plane terms")
     if boundary_terms:
         evidence.append(f"{boundary_terms} boundary/runtime terms")
-    if founding_terms:
-        evidence.append(f"{founding_terms} architecture-foundation terms")
-    return _score_from_booleans(architecture, package_terms >= 3, boundary_terms >= 3, founding_terms >= 4), tuple(evidence)
+    evidence.append(f"{foundation['passed']}/{foundation['required']} architecture-foundation checks")
+    return _score_from_booleans(
+        architecture,
+        package_terms >= 3,
+        boundary_terms >= 3,
+        foundation["status"] == "pass",
+    ), tuple(evidence)
 
 
 def _security_release_score(text: str) -> tuple[float, tuple[str, ...]]:
@@ -279,6 +366,7 @@ def evaluate_text(text: str) -> dict[str, object]:
         for result in results
         if result.score < result.weight
     ]
+    architecture = architecture_evidence(text)
     return {
         "schema": SCHEMA,
         "generated_at": _utc_now(),
@@ -298,6 +386,7 @@ def evaluate_text(text: str) -> dict[str, object]:
             for result in results
         ],
         "missing_or_partial": missing,
+        "architecture_evidence": architecture,
     }
 
 
@@ -326,20 +415,39 @@ def _text_report(payload: dict[str, object], *, min_score: int) -> str:
             lines.append(f"  evidence: {', '.join(evidence)}")
         if row["score"] < row["weight"]:
             lines.append(f"  improve: {row['guidance']}")
+    architecture = payload.get("architecture_evidence", {})
+    if isinstance(architecture, dict):
+        lines.append(
+            f"Architecture evidence: {architecture.get('passed')}/{architecture.get('required')} "
+            f"({architecture.get('status')})"
+        )
+        for check in architecture.get("checks", []):
+            if isinstance(check, dict) and check.get("status") != "pass":
+                lines.append(f"  missing: {check.get('label')} - {check.get('guidance')}")
     return "\n".join(lines)
+
+
+def _preflight_report() -> str:
+    return "\n".join(PREFLIGHT_LINES)
 
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("audit_markdown", type=Path, help="Markdown audit/review document to score.")
+    parser.add_argument("audit_markdown", type=Path, nargs="?", help="Markdown audit/review document to score.")
     parser.add_argument("--min-score", type=int, default=DEFAULT_MIN_SCORE, help="Fail when score is below this value.")
     parser.add_argument("--json", action="store_true", help="Print JSON instead of a text report.")
     parser.add_argument("--output", type=Path, help="Optional path to write the JSON report.")
+    parser.add_argument("--preflight", action="store_true", help="Print the AGILAB deep-audit architecture preflight checklist.")
     return parser
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
+    if args.preflight:
+        print(_preflight_report())
+        return 0
+    if args.audit_markdown is None:
+        raise SystemExit("audit_markdown is required unless --preflight is used")
     text = args.audit_markdown.read_text(encoding="utf-8")
     payload = evaluate_text(text)
     payload["source"] = str(args.audit_markdown)


### PR DESCRIPTION
## Summary
- add golden strong/weak audit fixtures for audit quality regression tests
- add top-level `architecture_evidence` to `tools/audit_quality_evaluator.py`
- add `--preflight` mode for mandatory AGILAB architecture-readiness checks
- add `./dev audit-quality` and `./dev audit-preflight` shortcuts
- update `agilab-intent-router` so `review AGILAB` explicitly routes through architecture readiness
- update `agilab-deep-audit` to advertise the preflight and quality shortcuts

## Validation
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_audit_quality_evaluator.py test/test_agilab_dev_shortcuts.py`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile skills`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --staged`

## Notes
- this is skill/tooling only; no runtime shared-core code was changed
- the skills profile still reports existing medium/low/info skill-security findings but exits successfully with `--fail-on critical`
