### PR TITLE
Strengthen teaser hook and CTA

### DIFF
--- a/artifacts/demo_media/flight/agilab_flight_youtube_pack.md
+++ b/artifacts/demo_media/flight/agilab_flight_youtube_pack.md
@@ -5,7 +5,7 @@
 - Latest public video: https://youtu.be/BsBjRSAXJZA
 - YouTube Studio URL: https://studio.youtube.com/video/BsBjRSAXJZA
 - Repository policy: keep only this lightweight upload pack in Git. Generated MP4, GIF, and poster outputs under `artifacts/demo_media/flight/` are local artifacts and are not stored in Git.
-- Duration: 19.07 seconds
+- Duration: 19.87 seconds
 - Format: 1920x1080, 30 fps, premium H.264 video plus stereo AAC audio MP4
 - Video master: regenerated from source frames at CRF 12
 - Audio: low-volume stereo synthetic sound bed, encoded as AAC with safe peak headroom
@@ -16,7 +16,7 @@ AGILAB turns one AI/ML app run into replayable evidence: project context, run co
 
 ## Suggested title
 
-AGILAB teaser: replayable AI/ML evidence in 19 seconds
+AGILAB teaser: replay, verify, and share AI/ML evidence
 
 ## Suggested description
 
@@ -25,7 +25,7 @@ AGILAB is an open-source workbench for turning AI/ML experiments, notebooks, and
 This short teaser follows one flight-telemetry scenario through the core AGILAB loop:
 PROJECT -> ORCHESTRATE -> WORKFLOW -> ANALYSIS.
 
-The point is not a feature tour. It is one claim: keep project context, the run contract, the replay step, and reviewer-facing analysis aligned in one workspace.
+The point is not a feature tour. It is one claim: stop losing evidence in notebooks and logs by keeping project context, the run contract, the replay step, and reviewer-facing analysis aligned.
 
 The headless `agi-core` line is intentional: AGILAB can hand a runnable contract back to notebooks or automation, so teams can benefit from the core runtime without forcing every replay step through the UI.
 
@@ -33,21 +33,24 @@ Repo: https://github.com/ThalesGroup/agilab
 
 ## Chapters
 
-00:00 AGILAB: replayable evidence, not notebook drift
+00:00 Stop losing AI/ML evidence
 00:02 PROJECT: pin the project context
 00:04 ORCHESTRATE: optimize, map, and reduce
 00:07 WORKFLOW: export notebooks or run headless
 00:10 ANALYSIS: evidence reviewers can inspect
 00:13 PORTABLE CORE: replay without UI lock-in
+00:16 CTA: replay, verify, and share
 
 ## Pinned comment
 
 AGILAB is built for evidence-first AI/ML workflows: pin the project context, generate the run contract, preserve the replay step, and finish with analysis a reviewer can inspect. Use the UI for review; keep notebooks and headless `agi-core` for automation and portability.
 
+If your AI/ML run matters, make it replayable before it becomes another screenshot.
+
 ## Thumbnail text
 
-Replayable evidence
+Replay. Verify. Share.
 
 ## Short social caption
 
-A 19-second look at AGILAB: one workspace for project context, run orchestration, replay, portable notebook/headless handoff, and analysis evidence.
+A 20-second look at AGILAB: replay, verify, and share AI/ML evidence without trapping the run in a notebook.

--- a/tools/build_product_demo_reel.py
+++ b/tools/build_product_demo_reel.py
@@ -79,8 +79,8 @@ FLIGHT_SCENES: tuple[Scene, ...] = (
         name="intro",
         image=PAGE_SHOTS / "core-pages-overview.png",
         stage="AGILAB",
-        title="Turn agent runs into proof capsules.",
-        body="One path from experiment intent to replayable evidence.",
+        title="Stop losing AI/ML evidence.",
+        body="One run becomes a replayable proof capsule.",
         seconds=2.0,
         active_step=-1,
         focus=(0.56, 0.52),
@@ -153,8 +153,8 @@ FLIGHT_SCENES: tuple[Scene, ...] = (
         name="outro",
         image=PAGE_SHOTS / "core-pages-overview.png",
         stage="AGILAB",
-        title="Replayable AI/ML evidence.",
-        body="UI for review. Headless core for automation. Notebooks stay portable.",
+        title="Replay. Verify. Share.",
+        body="AGILAB keeps the UI, notebooks, and headless core aligned.",
         seconds=2.1,
         active_step=-1,
         focus=(0.56, 0.52),
@@ -516,12 +516,12 @@ VARIANTS: dict[str, Variant] = {
 
 NARRATION_CUES: dict[str, tuple[NarrationCue, ...]] = {
     "flight": (
-        NarrationCue(0.0, 2.0, "AGILAB turns runs into proof capsules."),
+        NarrationCue(0.0, 2.0, "Stop losing evidence in notebooks and logs."),
         NarrationCue(2.0, 4.4, "Lock inputs, runtime, and artifacts first."),
         NarrationCue(4.4, 7.4, "Optimizer: up to a thousand times faster."),
         NarrationCue(7.4, 10.2, "Export notebooks, or execute with headless agi-core."),
         NarrationCue(10.2, 12.9, "Verify maps, hashes, and metadata."),
-        NarrationCue(12.9, 15.0, "Replayable AI and ML evidence."),
+        NarrationCue(12.9, 15.0, "Replay, verify, and share the evidence."),
     ),
 }
 
@@ -1029,7 +1029,7 @@ def draw_flight_hero_outro_overlay(canvas: Image.Image, scene: Scene, slide_x: i
 
     hero_font = load_font(54, bold=True)
     sub_font = load_font(29, bold=True)
-    draw.text((36, 112), "Replayable AI/ML evidence", font=hero_font, fill=INK)
+    draw.text((36, 112), "Replay. Verify. Share.", font=hero_font, fill=INK)
     draw.text((38, 178), "portable from UI to notebooks to headless agi-core", font=FONT_BODY, fill=MUTED)
 
     flow_y = 250


### PR DESCRIPTION
## Summary
- strengthen the first two seconds with a direct evidence-loss hook
- make the finale a clearer Replay / Verify / Share CTA
- keep headless agi-core positioned as portable runtime alignment
- update the upload pack duration and YouTube copy for the regenerated 19.87s render

## Validation
- uv run python -m py_compile tools/build_product_demo_reel.py
- uv run python tools/build_product_demo_reel.py --variant flight --voice Alex --voice-rate 176
- ffprobe confirmed 19.87s, 1920x1080, 30 fps MP4 with full-duration audio
- inspected generated contact sheet at /tmp/agilab-teaser-cta-review/contact.jpg