### PR TITLE
Centralize node source path resolution

### DIFF
--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/agi_distributor.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/agi_distributor.py
@@ -68,33 +68,18 @@ import runpy
 
 # Project Libraries:
 from agi_env import AgiEnv
+from agi_node.agi_dispatcher.bootstrap_source_paths import resolve_node_source_path
 
 def _resolve_node_src(
     sys_prefix: str | os.PathLike[str] | None = None,
     source_file: str | os.PathLike[str] | None = None,
 ) -> str | None:
     """Return the best ``agi-node/src`` path for the current runtime layout."""
-
-    candidates: list[Path] = []
-    prefix_root = Path(sys_prefix or sys.prefix)
-    source_root = Path(source_file or __file__).resolve()
-    for root in (prefix_root, *prefix_root.parents, source_root, *source_root.parents):
-        candidates.extend(
-            [
-                root / "agi-node" / "src",
-                root / "src" / "agi-node" / "src",
-                root / "src" / "agilab" / "core" / "agi-node" / "src",
-            ]
-        )
-
-    seen: set[Path] = set()
-    for candidate in candidates:
-        if candidate in seen:
-            continue
-        seen.add(candidate)
-        if candidate.is_dir():
-            return str(candidate)
-    return None
+    node_src = resolve_node_source_path(
+        sys_prefix=sys_prefix,
+        source_file=source_file or __file__,
+    )
+    return str(node_src) if node_src is not None else None
 
 
 def _bootstrap_node_src(

--- a/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/bootstrap_source_paths.py
+++ b/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/bootstrap_source_paths.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 import sys
 
@@ -15,6 +16,46 @@ def resolve_core_source_root(*, source_file: str | Path | None = None) -> Path |
     for parent in source_path.parents:
         if parent.name == "core" and parent.parent.name == "agilab":
             return parent
+    return None
+
+
+def package_source_path_candidates(
+    package_dir_name: str,
+    *,
+    sys_prefix: str | os.PathLike[str] | None = None,
+    source_file: str | os.PathLike[str] | None = None,
+) -> tuple[Path, ...]:
+    """Return likely source roots for an AGILAB core package directory."""
+    prefix_root = Path(sys_prefix or sys.prefix)
+    try:
+        source_root = Path(source_file or __file__).resolve()
+    except (OSError, RuntimeError):
+        source_root = Path(source_file or __file__)
+    candidates: list[Path] = []
+    for root in (prefix_root, *prefix_root.parents, source_root, *source_root.parents):
+        candidates.extend(
+            [
+                root / package_dir_name / "src",
+                root / "src" / package_dir_name / "src",
+                root / "src" / "agilab" / "core" / package_dir_name / "src",
+            ]
+        )
+    return tuple(dict.fromkeys(candidates))
+
+
+def resolve_node_source_path(
+    *,
+    sys_prefix: str | os.PathLike[str] | None = None,
+    source_file: str | os.PathLike[str] | None = None,
+) -> Path | None:
+    """Return the best repo-local ``agi-node/src`` path for the runtime layout."""
+    for candidate in package_source_path_candidates(
+        "agi-node",
+        sys_prefix=sys_prefix,
+        source_file=source_file,
+    ):
+        if candidate.is_dir():
+            return candidate
     return None
 
 

--- a/src/agilab/core/test/test_agi_dispatcher_build_main_support.py
+++ b/src/agilab/core/test/test_agi_dispatcher_build_main_support.py
@@ -80,6 +80,40 @@ def test_bootstrap_core_source_paths_moves_existing_editable_sources_before_site
     assert bootstrap_mod.sys.path.count(str(env_src)) == 1
 
 
+def test_resolve_node_source_path_prefers_runtime_prefix_layout(tmp_path):
+    node_src = tmp_path / "env" / "agi-node" / "src"
+    node_src.mkdir(parents=True)
+
+    assert bootstrap_mod.resolve_node_source_path(
+        sys_prefix=tmp_path / "env",
+        source_file=tmp_path / "pkg" / "build.py",
+    ) == node_src
+
+
+def test_resolve_node_source_path_finds_source_checkout_layout(tmp_path):
+    node_src = tmp_path / "repo" / "src" / "agilab" / "core" / "agi-node" / "src"
+    source_file = (
+        tmp_path
+        / "repo"
+        / "src"
+        / "agilab"
+        / "core"
+        / "agi-cluster"
+        / "src"
+        / "agi_cluster"
+        / "agi_distributor"
+        / "agi_distributor.py"
+    )
+    node_src.mkdir(parents=True)
+    source_file.parent.mkdir(parents=True)
+    source_file.write_text("", encoding="utf-8")
+
+    assert bootstrap_mod.resolve_node_source_path(
+        sys_prefix=tmp_path / "venv",
+        source_file=source_file,
+    ) == node_src
+
+
 def test_append_shared_site_packages_appends_legacy_candidates_once(tmp_path):
     fake_home = tmp_path / "home"
     sys_path: list[str] = []


### PR DESCRIPTION
## Summary
- add canonical AGILAB core package source-path candidate resolution to `bootstrap_source_paths.py`
- route `agi_distributor._resolve_node_src` through the shared node-source resolver instead of duplicating path guessing
- add focused tests for runtime-prefix and source-checkout layouts

## Validation
- `uv --preview-features extra-build-dependencies run --extra dev python -m py_compile src/agilab/core/agi-node/src/agi_node/agi_dispatcher/bootstrap_source_paths.py src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/agi_distributor.py`
- `uv --preview-features extra-build-dependencies run --extra dev pytest -q -o addopts='' src/agilab/core/test/test_agi_dispatcher_build_main_support.py src/agilab/core/test/test_agi_distributor_wrapper_surface.py -k 'bootstrap_core_source_paths or append_shared_site_packages or resolve_node_src or bootstrap_node_src or resolve_node_source_path'`
- `uv --preview-features extra-build-dependencies run --extra dev python tools/impact_validate.py --files src/agilab/core/agi-node/src/agi_node/agi_dispatcher/bootstrap_source_paths.py src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/agi_distributor.py src/agilab/core/test/test_agi_dispatcher_build_main_support.py`
- `uv --preview-features extra-build-dependencies run --no-sync pytest -q -o addopts='' src/agilab/core/test`
