### PR TITLE
Fix audit-readiness security edges

### DIFF
--- a/src/agilab/apps-pages/view_maps_3d/src/view_maps_3d/view_maps_3d.py
+++ b/src/agilab/apps-pages/view_maps_3d/src/view_maps_3d/view_maps_3d.py
@@ -376,6 +376,13 @@ def discrete():
     st.session_state["coltype"] = "discrete"
 
 
+_COLTYPE_CALLBACKS = {
+    "continuous": continuous,
+    "continious": continious,
+    "discrete": discrete,
+}
+
+
 def update_var(var_key, widget_key):
     """
 
@@ -1134,7 +1141,7 @@ def page():
                             colsn,
                             index=var_default[i],
                             key=var[i],
-                            on_change=eval(var[i]),
+                            on_change=_COLTYPE_CALLBACKS[var[i]],
                         )
                         if i == 0:
                             # Select color palette from the list
@@ -1157,7 +1164,7 @@ def page():
                             [],
                             index=var_default[i],
                             key=var[i],
-                            on_change=eval(var[i]),
+                            on_change=_COLTYPE_CALLBACKS[var[i]],
                         )
 
             for i in range(2, 5):

--- a/src/agilab/pipeline_ai.py
+++ b/src/agilab/pipeline_ai.py
@@ -116,6 +116,7 @@ import_agilab_symbols(
 )
 
 GENERATED_CODE_SANDBOX_ENV = "AGILAB_GENERATED_CODE_SANDBOX"
+GENERATED_CODE_PROCESS_LIMITS_ENV = "AGILAB_GENERATED_CODE_PROCESS_LIMITS"
 GENERATED_CODE_SANDBOX_MODES = frozenset({"process", "container", "vm"})
 
 import_agilab_symbols(
@@ -980,6 +981,24 @@ def _maybe_autofix_generated_code(
             get_run_placeholder(index_page),
         )
         return merged_code, model_label, detail
+    if sandbox == "process":
+        process_limits = (
+            str(
+                env.envars.get(GENERATED_CODE_PROCESS_LIMITS_ENV)
+                or os.getenv(GENERATED_CODE_PROCESS_LIMITS_ENV)
+                or ""
+            )
+            .strip()
+            .lower()
+        )
+        if process_limits not in {"1", "true", "yes", "on"}:
+            push_run_log(
+                index_page,
+                "Auto-fix skipped: process generated-code execution requires "
+                f"{GENERATED_CODE_PROCESS_LIMITS_ENV}=1.",
+                get_run_placeholder(index_page),
+            )
+            return merged_code, model_label, detail
 
     df: Any = st.session_state.get("loaded_df")
     if not isinstance(df, pd.DataFrame) or df.empty:

--- a/src/agilab_mcp/server.py
+++ b/src/agilab_mcp/server.py
@@ -28,7 +28,6 @@ TOOLS: dict[str, ToolFn] = {
     "summarize_run": manifest_tools.summarize_run,
     "list_artifacts": manifest_tools.list_artifacts,
     "compare_runs": manifest_tools.compare_runs,
-    "export_quarto_report": manifest_tools.export_quarto_report,
 }
 
 
@@ -204,18 +203,6 @@ def tool_descriptors() -> list[dict[str, Any]]:
                     "right_manifest": {"type": "string"},
                 },
                 "required": ["left_manifest", "right_manifest"],
-            },
-        },
-        {
-            "name": "export_quarto_report",
-            "description": "Export a Quarto report from one AGILAB run manifest.",
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "manifest_path": {"type": "string"},
-                    "output_path": {"type": "string"},
-                },
-                "required": ["manifest_path", "output_path"],
             },
         },
     ]

--- a/test/test_audience_bridges.py
+++ b/test/test_audience_bridges.py
@@ -807,7 +807,16 @@ def test_mcp_tools_and_jsonrpc(tmp_path: Path) -> None:
         "agilab.agent_run_validation.v1"
         in validate_agent_call_response["result"]["content"][0]["text"]
     )
-    assert mcp_server.server_manifest()["policy"]["read_only"] is True
+    server_manifest = mcp_server.server_manifest()
+    assert server_manifest["policy"]["read_only"] is True
+    assert server_manifest["dangerous_tools"] == []
+    tool_names = {tool["name"] for tool in server_manifest["tools"]}
+    assert "export_quarto_report" not in tool_names
+    with pytest.raises(ValueError, match="Unknown AGILAB MCP tool"):
+        mcp_server.call_tool(
+            "export_quarto_report",
+            {"manifest_path": str(manifest_path), "output_path": str(tmp_path / "mcp.qmd")},
+        )
 
 
 def test_lab_run_routes_bridge_commands(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/test/test_pipeline_ai.py
+++ b/test/test_pipeline_ai.py
@@ -2902,7 +2902,12 @@ def test_maybe_autofix_generated_code_paths(monkeypatch):
     monkeypatch.setattr(pipeline_ai, "st", fake_st)
     push_run_log = lambda *_args: logs.append(_args[1])
     get_run_placeholder = lambda _page: "placeholder"
-    env = SimpleNamespace(envars={pipeline_ai.GENERATED_CODE_SANDBOX_ENV: "process"})
+    env = SimpleNamespace(
+        envars={
+            pipeline_ai.GENERATED_CODE_SANDBOX_ENV: "process",
+            pipeline_ai.GENERATED_CODE_PROCESS_LIMITS_ENV: "1",
+        }
+    )
 
     code, model, detail = pipeline_ai._maybe_autofix_generated_code(
         original_request="q",
@@ -2977,6 +2982,7 @@ def test_maybe_autofix_promotes_validated_recipe_memory(monkeypatch, tmp_path):
         envars={
             pipeline_recipe_memory_direct.RECIPE_MEMORY_PATH_ENV: str(memory_path),
             pipeline_ai.GENERATED_CODE_SANDBOX_ENV: "process",
+            pipeline_ai.GENERATED_CODE_PROCESS_LIMITS_ENV: "1",
         }
     )
 
@@ -3012,7 +3018,12 @@ def test_maybe_autofix_generated_code_short_circuits_for_provider_attempts_and_d
         }
     )
     monkeypatch.setattr(pipeline_ai, "st", fake_st)
-    env = SimpleNamespace(envars={pipeline_ai.GENERATED_CODE_SANDBOX_ENV: "process"})
+    env = SimpleNamespace(
+        envars={
+            pipeline_ai.GENERATED_CODE_SANDBOX_ENV: "process",
+            pipeline_ai.GENERATED_CODE_PROCESS_LIMITS_ENV: "1",
+        }
+    )
 
     unchanged = pipeline_ai._maybe_autofix_generated_code(
         original_request="q",
@@ -3104,6 +3115,23 @@ def test_maybe_autofix_generated_code_requires_sandbox_boundary(monkeypatch):
 
     assert (code, model, detail) == ("df['y'] = df['x'] + 1", "m", "detail")
     assert any("generated-code execution requires" in entry for entry in logs)
+
+    logs.clear()
+    code, model, detail = pipeline_ai._maybe_autofix_generated_code(
+        original_request="q",
+        df_path=Path("df.csv"),
+        index_page="page",
+        env=SimpleNamespace(envars={pipeline_ai.GENERATED_CODE_SANDBOX_ENV: "process"}),
+        merged_code="df['y'] = df['x'] + 1",
+        model_label="m",
+        detail="detail",
+        load_df_cached=lambda path: pd.DataFrame({"x": [1]}),
+        push_run_log=lambda *_args: logs.append(_args[1]),
+        get_run_placeholder=lambda _page: "placeholder",
+    )
+
+    assert (code, model, detail) == ("df['y'] = df['x'] + 1", "m", "detail")
+    assert any("process generated-code execution requires" in entry for entry in logs)
 
 
 def test_chat_ollama_local_covers_missing_model_and_generation_failure(monkeypatch):
@@ -3591,6 +3619,7 @@ def test_ask_gpt_and_autofix_cover_empty_and_failed_repair_paths(monkeypatch):
     fake_st.session_state[pipeline_ai.UOAIC_AUTOFIX_STATE_KEY] = False
     env.envars[pipeline_ai.UOAIC_AUTOFIX_ENV] = "1"
     env.envars[pipeline_ai.GENERATED_CODE_SANDBOX_ENV] = "process"
+    env.envars[pipeline_ai.GENERATED_CODE_PROCESS_LIMITS_ENV] = "1"
     logs: list[str] = []
     monkeypatch.setattr(
         pipeline_ai,
@@ -3697,7 +3726,12 @@ def test_autofix_and_provider_switch_cover_remaining_error_paths(monkeypatch):
         original_request="q",
         df_path=Path("df.csv"),
         index_page="page",
-        env=SimpleNamespace(envars={pipeline_ai.GENERATED_CODE_SANDBOX_ENV: "process"}),
+        env=SimpleNamespace(
+            envars={
+                pipeline_ai.GENERATED_CODE_SANDBOX_ENV: "process",
+                pipeline_ai.GENERATED_CODE_PROCESS_LIMITS_ENV: "1",
+            }
+        ),
         merged_code="raise ValueError('boom')",
         model_label="model-a",
         detail="detail-a",


### PR DESCRIPTION
## Summary
- tighten audit-readiness security edge handling
- update pipeline/audience coverage for the changed behavior
- remove stale MCP surface exposure from the audit path

## Validation
- not run locally in this cleanup turn; relying on PR guardrails