### PR TITLE
Clarify read-only MCP docs

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 232,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "b7e65d6a4828dee9a1382da37cacb0ad2bd68002bb5367c80d716fdb4efde643",
+  "source_digest_sha256": "99e34f53da694b0e96fd4627b850652f9ed23e1dfdf4bb21ebbd119eafb50d02",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "b7e65d6a4828dee9a1382da37cacb0ad2bd68002bb5367c80d716fdb4efde643"
+  "target_digest_sha256": "99e34f53da694b0e96fd4627b850652f9ed23e1dfdf4bb21ebbd119eafb50d02"
 }

--- a/docs/source/roadmap/audience-bridges.md
+++ b/docs/source/roadmap/audience-bridges.md
@@ -199,7 +199,6 @@ agilab-mcp
     summarize_run
     summarize_agent_run
     compare_runs
-    export_quarto_report
     agent_handoff
     agent_next_actions
     agent_context
@@ -212,6 +211,9 @@ agilab-mcp
     install_app
     execute_stage
 ```
+
+Quarto export stays on the explicit `agilab export quarto` CLI/export bridge,
+not on the read-only MCP server, because it writes report files.
 
 Default policy:
 


### PR DESCRIPTION
## Summary
- sync the public docs mirror after removing write-capable Quarto export from the read-only MCP tool list
- clarify that Quarto report export remains an explicit CLI/export bridge
- refresh the docs source mirror stamp

## Validation
- uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp
- git diff --check
- targeted grep in canonical and mirrored audience-bridges docs