### PR TITLE
[codex] Fix stale ORCHESTRATE env realignment

### DIFF
--- a/src/agilab/page_bootstrap.py
+++ b/src/agilab/page_bootstrap.py
@@ -7,6 +7,8 @@ import importlib.util
 from pathlib import Path
 from typing import Any, Callable
 
+PAGE_ENV_REALIGNED_STATE_KEY = "_agilab_page_env_realigned"
+
 
 def _safe_resolved_path(value: Any) -> Path | None:
     try:
@@ -120,6 +122,7 @@ def realign_session_env_with_page_root(
             apps_path=expected_apps_path,
             app=page_app.name,
             verbose=getattr(env, "verbose", None),
+            _agilab_reinitialize=True,
         )
         if previous_init_done is not None:
             env.init_done = previous_init_done
@@ -174,7 +177,10 @@ def ensure_page_env(
         streamlit.session_state,
         init_done_default=init_done_default,
     ):
-        realign_session_env_with_page_root(streamlit.session_state, current_file)
+        if realign_session_env_with_page_root(streamlit.session_state, current_file):
+            streamlit.session_state[PAGE_ENV_REALIGNED_STATE_KEY] = True
+        else:
+            streamlit.session_state.pop(PAGE_ENV_REALIGNED_STATE_KEY, None)
         return streamlit.session_state["env"]
 
     about_page = load_about_page_module(current_file, load_module=load_module)

--- a/src/agilab/pages/2_ORCHESTRATE.py
+++ b/src/agilab/pages/2_ORCHESTRATE.py
@@ -111,6 +111,7 @@ import_agilab_symbols(
     globals(),
     "agilab.page_bootstrap",
     {
+        "PAGE_ENV_REALIGNED_STATE_KEY": "_PAGE_ENV_REALIGNED_STATE_KEY",
         "ensure_page_env": "_ensure_page_env",
         "realign_session_env_with_page_root": "_realign_session_env_with_page_root",
     },
@@ -2382,10 +2383,12 @@ async def page() -> None:
     if env is None:
         return
 
+    realigned_with_page_root = bool(st.session_state.pop(_PAGE_ENV_REALIGNED_STATE_KEY, False))
     current_app, changed_from_query = resolve_active_app(env)
     if _realign_session_env_with_page_root(st.session_state, __file__):
+        realigned_with_page_root = True
+    if realigned_with_page_root:
         current_app = env.app
-        changed_from_query = True
     if changed_from_query:
         st.session_state["project_changed"] = True
 


### PR DESCRIPTION
## Summary

- Record when page bootstrap repairs a stale AGILAB env rooted in another launch tree.
- Let ORCHESTRATE consume that repair signal without treating it as a user-driven project switch.
- Reinitialize `AgiEnv` through its explicit reinitialization path so stale `apps_path` and `active_app` are corrected.

## Root cause

The ORCHESTRATE page bootstrap could repair stale session state but then handle the repair like a project-selection change. In addition, the singleton-style `AgiEnv` guard prevented the path repair from taking effect without the explicit reinitialize flag.

## Validation

- `uv --preview-features extra-build-dependencies run --no-sync python -m py_compile src/agilab/page_bootstrap.py src/agilab/pages/2_ORCHESTRATE.py`
- `uv --preview-features extra-build-dependencies run --no-sync pytest -q -o addopts='' test/test_ui_pages.py::test_execute_page_realigns_stale_agi_space_session_env test/test_ui_pages.py::test_execute_page_realigns_stale_active_app_only_for_source_root`
- `uv --preview-features extra-build-dependencies run --group dev --extra ui --extra viz -m pytest -q --maxfail=1 --disable-warnings -o addopts= -m 'not integration' --ignore=src/agilab/test/test_model_returns_code.py test/test_ui_pages.py -k 'execute_page or experiment_page or pipeline_page_project_selectbox'`
