### PR TITLE
[codex] Fix installer connectivity probe

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -52,14 +52,31 @@ Set-UvLinkMode
 
 function Check-Internet {
     Write-Info "Checking internet connectivity..."
-    try {
-        $null = Invoke-WebRequest -Uri "https://www.google.com" -TimeoutSec 3 -UseBasicParsing
-        Write-Success "Internet connection is OK."
-        $global:AGI_INTERNET_ON = 1
-    } catch {
-        Write-Warn "No internet connection detected."
-        $global:AGI_INTERNET_ON = 0
+    $probeUrls = @(
+        "https://pypi.org/simple/pip/",
+        "https://files.pythonhosted.org/",
+        "https://api.github.com/zen",
+        "https://www.google.com"
+    )
+    foreach ($probeUrl in $probeUrls) {
+        try {
+            $null = Invoke-WebRequest -Method Head -Uri $probeUrl -TimeoutSec 8 -UseBasicParsing -ErrorAction Stop
+            Write-Success "Internet connection is OK."
+            $global:AGI_INTERNET_ON = 1
+            return
+        } catch {
+            try {
+                $null = Invoke-WebRequest -Uri $probeUrl -Headers @{ Range = "bytes=0-0" } -TimeoutSec 8 -UseBasicParsing -ErrorAction Stop
+                Write-Success "Internet connection is OK."
+                $global:AGI_INTERNET_ON = 1
+                return
+            } catch {
+                continue
+            }
+        }
     }
+    Write-Warn "No internet connection detected."
+    $global:AGI_INTERNET_ON = 0
 }
 
 function Prompt-YesNo {

--- a/install.sh
+++ b/install.sh
@@ -780,13 +780,27 @@ restore_deleted_runconfig_assets() {
 
 check_internet() {
     echo -e "${BLUE}Checking internet connectivity...${NC}"
-    if curl -Is --connect-timeout 3 https://www.google.com &>/dev/null; then
-        echo -e "${GREEN}Internet connection is OK.${NC}"
-        AGI_INTERNET_ON=1
-    else
-        echo -e "${RED}No internet connection detected. Going into network restricted mode.${NC}"
-        AGI_INTERNET_ON=0
-    fi
+    local -a probe_urls=(
+        "https://pypi.org/simple/pip/"
+        "https://files.pythonhosted.org/"
+        "https://api.github.com/zen"
+        "https://www.google.com"
+    )
+    local probe_url
+    for probe_url in "${probe_urls[@]}"; do
+        if curl -fsSI --connect-timeout 3 --max-time 8 "$probe_url" &>/dev/null; then
+            echo -e "${GREEN}Internet connection is OK.${NC}"
+            AGI_INTERNET_ON=1
+            return 0
+        fi
+        if curl -fsSL --connect-timeout 3 --max-time 8 --range 0-0 -o /dev/null "$probe_url" &>/dev/null; then
+            echo -e "${GREEN}Internet connection is OK.${NC}"
+            AGI_INTERNET_ON=1
+            return 0
+        fi
+    done
+    echo -e "${RED}No internet connection detected. Going into network restricted mode.${NC}"
+    AGI_INTERNET_ON=0
 }
 
 set_locale() {

--- a/test/test_install_local_models.py
+++ b/test/test_install_local_models.py
@@ -108,6 +108,75 @@ def test_root_installer_propagates_env_before_core_and_app_installs() -> None:
     assert update_pos < write_pos < install_core_pos < core_tests_pos < app_install_pos
 
 
+def test_root_installer_internet_check_does_not_depend_on_single_endpoint() -> None:
+    script_text = INSTALL_SH.read_text(encoding="utf-8")
+    function_body = _extract_function(script_text, "check_internet")
+    bash_script = f"""#!/usr/bin/env bash
+set -euo pipefail
+BLUE=''
+GREEN=''
+RED=''
+NC=''
+declare -a curl_calls=()
+curl() {{
+  curl_calls+=("$*")
+  case "$*" in
+    *"https://files.pythonhosted.org/"*) return 0 ;;
+    *) return 22 ;;
+  esac
+}}
+{function_body}
+check_internet
+printf 'AGI_INTERNET_ON=%s\\n' "$AGI_INTERNET_ON"
+printf 'curl_calls=%s\\n' "${{#curl_calls[@]}}"
+printf '%s\\n' "${{curl_calls[@]}}"
+"""
+    completed = subprocess.run(
+        ["bash", "-c", bash_script],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "AGI_INTERNET_ON=1" in completed.stdout
+    assert "https://pypi.org/simple/pip/" in completed.stdout
+    assert "https://files.pythonhosted.org/" in completed.stdout
+
+
+def test_root_installer_internet_check_preserves_restricted_mode() -> None:
+    script_text = INSTALL_SH.read_text(encoding="utf-8")
+    function_body = _extract_function(script_text, "check_internet")
+    bash_script = f"""#!/usr/bin/env bash
+set -euo pipefail
+BLUE=''
+GREEN=''
+RED=''
+NC=''
+curl() {{
+  return 22
+}}
+{function_body}
+check_internet
+printf 'AGI_INTERNET_ON=%s\\n' "$AGI_INTERNET_ON"
+"""
+    completed = subprocess.run(
+        ["bash", "-c", bash_script],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "AGI_INTERNET_ON=0" in completed.stdout
+
+
+def test_windows_installer_internet_check_uses_packaging_endpoints() -> None:
+    ps1_text = INSTALL_PS1.read_text(encoding="utf-8")
+
+    assert "https://pypi.org/simple/pip/" in ps1_text
+    assert "https://files.pythonhosted.org/" in ps1_text
+    assert "https://api.github.com/zen" in ps1_text
+
+
 def test_root_installer_default_share_dir_is_user_scoped() -> None:
     script_text = INSTALL_SH.read_text(encoding="utf-8")
     function_body = "\n".join(


### PR DESCRIPTION
## Summary
- Make the Unix installer probe PyPI/PythonHosted/GitHub before falling back to Google for online detection.
- Apply the same packaging-relevant connectivity probe to the Windows installer.
- Add regression coverage so a single endpoint failure does not force offline/cache-only mode while explicit restricted mode remains honored.

## Root cause
The installer used one Google HEAD request to decide whether fresh installs were online. A transient or environment-specific Google probe failure could incorrectly set `AGI_INTERNET_ON=0`, forcing app deployment into `uv --offline` on a fresh cache.

## Validation
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files install.sh install.ps1 test/test_install_local_models.py`
- `bash -n install.sh src/agilab/install_apps.sh src/agilab/core/install.sh`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_install_apps_discovery.py test/test_install_contract_check.py test/test_install_local_models.py test/test_install_release_proof_package.py` (`48 passed`)
- Full clean install from cloned checkout with all built-in apps, root/core tests, app tests, and end-user install completed successfully in `12m 5s`.

Evidence log: `/Users/agi/.cache/agilab/source_validate/agilab_full_app_install_fixed_20260529_180040/sandbox_home/log/install_logs/install_20260529_180042.log`