### PR TITLE
Add Windows core validation workflow

### DIFF
--- a/.github/workflows/windows-core-tests.yml
+++ b/.github/workflows/windows-core-tests.yml
@@ -67,7 +67,7 @@ jobs:
             --with pytest `
             --with pytest-asyncio `
             --with pytest-cov `
-            python -m pytest -q --maxfail=1 --disable-warnings -o addopts='' `
+            python -m pytest -q --disable-warnings -o addopts='' `
             --junitxml test-results/windows-core-tests.xml `
             src/agilab/core/test src/agilab/core/agi-env/test `
             2>&1 | Tee-Object -FilePath test-results/windows-core-tests.txt

--- a/.github/workflows/windows-core-tests.yml
+++ b/.github/workflows/windows-core-tests.yml
@@ -1,0 +1,87 @@
+name: windows-core-tests
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - ".github/workflows/windows-core-tests.yml"
+      - "WINDOWS_TEST_FAILURES.md"
+      - "pyproject.toml"
+      - "uv.lock"
+      - "src/agilab/core/**"
+      - "test/**"
+  pull_request:
+    branches: ["**"]
+    paths:
+      - ".github/workflows/windows-core-tests.yml"
+      - "WINDOWS_TEST_FAILURES.md"
+      - "pyproject.toml"
+      - "uv.lock"
+      - "src/agilab/core/**"
+      - "test/**"
+  workflow_dispatch:
+  schedule:
+    - cron: "43 6 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  windows-core-tests:
+    runs-on: windows-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.13"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          version: "0.10.7"
+
+      - name: Run Windows core test tracker command
+        shell: pwsh
+        env:
+          AGILAB_DISABLE_BACKGROUND_SERVICES: "1"
+          OPENAI_API_KEY: "sk-test-windows-core-000000000000"
+        run: |
+          $ErrorActionPreference = "Stop"
+          New-Item -ItemType Directory -Force test-results | Out-Null
+          & uv --preview-features extra-build-dependencies run --no-project `
+            --with-editable ./src/agilab/core/agi-env `
+            --with-editable ./src/agilab/core/agi-node `
+            --with-editable ./src/agilab/core/agi-cluster `
+            --with-editable ./src/agilab/core/agi-core `
+            --with sqlalchemy `
+            --with streamlit `
+            --with fastparquet `
+            --with pytest `
+            --with pytest-asyncio `
+            --with pytest-cov `
+            python -m pytest -q --maxfail=1 --disable-warnings -o addopts='' `
+            --junitxml test-results/windows-core-tests.xml `
+            src/agilab/core/test src/agilab/core/agi-env/test `
+            2>&1 | Tee-Object -FilePath test-results/windows-core-tests.txt
+          $exitCode = $LASTEXITCODE
+          if ($exitCode -ne 0) {
+            exit $exitCode
+          }
+
+      - name: Upload Windows core test artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        if: always()
+        with:
+          name: windows-core-tests-${{ github.run_attempt }}
+          path: |
+            test-results/windows-core-tests.txt
+            test-results/windows-core-tests.xml
+          if-no-files-found: ignore

--- a/WINDOWS_TEST_FAILURES.md
+++ b/WINDOWS_TEST_FAILURES.md
@@ -5,7 +5,8 @@
 **Last verified count:** 97 previous · 43 fixed · 54 remaining · 1 new regression
 **Current repo note (2026-05-29):** all named buckets in this tracker now have
 focused local pass evidence in the current repository. The count above remains
-the last live Windows-run count until the command below is rerun on Windows.
+the last live Windows-run count until the command below, or the repository
+`windows-core-tests` workflow, is rerun on Windows.
 
 Reproduce live Windows validation:
 ```powershell
@@ -13,6 +14,17 @@ cd C:\Users\julie\agilab
 uv --preview-features extra-build-dependencies run -p 3.13.13 --no-sync -m pytest `
   src/agilab/core/test src/agilab/core/agi-env/test -q 2>&1 | Tee-Object test_results.txt
 ```
+
+Automated GitHub validation:
+
+- Workflow: `.github/workflows/windows-core-tests.yml`
+- Triggers: pull requests that touch core/test inputs, pushes to `main` for the
+  same inputs, weekly schedule, and manual `workflow_dispatch`
+- Artifact: `windows-core-tests-<run_attempt>` containing
+  `test-results/windows-core-tests.txt` and
+  `test-results/windows-core-tests.xml`
+- Scope: the same Windows core test directories tracked here,
+  `src/agilab/core/test src/agilab/core/agi-env/test`
 
 ---
 
@@ -396,9 +408,10 @@ Result: `7 passed`.
 | 9 | `sshpass` not on Windows | 1 | ✅ Fixed in current repo; rerun Windows to verify count | `test_agi_distributor_transport_support.py` |
 | — | Needs `pytest -vv` | 0 | ✅ Resolved in current repo; rerun Windows to verify count | Targeted bucket now passes |
 
-**Recommended priority:** rerun the Windows command above to refresh the verified
-remaining count after the environment-isolation, virtualenv layout, uv TOML path,
-Python subprocess exit fixture, Linux-only guard, mlflow backend reset, capacity
-CSV encoding, prepare_local_env self-update, and sshpass test fixes. Then
-prioritize any still-failing Windows categories from the refreshed run. There
-are no named local regression buckets left open in this tracker.
+**Recommended priority:** use the `windows-core-tests` workflow, or rerun the
+Windows command above, to refresh the verified remaining count after the
+environment-isolation, virtualenv layout, uv TOML path, Python subprocess exit
+fixture, Linux-only guard, mlflow backend reset, capacity CSV encoding,
+prepare_local_env self-update, and sshpass test fixes. Then prioritize any
+still-failing Windows categories from the refreshed run. There are no named
+local regression buckets left open in this tracker.

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime_misc_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime_misc_support.py
@@ -5,6 +5,7 @@ import humanize
 import importlib
 import inspect
 import json
+import os
 import pickle
 import re
 import stat
@@ -247,7 +248,7 @@ def _capacity_model_trust_error(model_path: Path, trusted_root: Path) -> str | N
     except OSError as exc:
         return f"cannot stat model file: {exc}"
 
-    if mode & stat.S_IWOTH:
+    if os.name != "nt" and mode & stat.S_IWOTH:
         return "model file is world-writable"
     return None
 

--- a/src/agilab/core/agi-env/test/test_agi_env.py
+++ b/src/agilab/core/agi-env/test/test_agi_env.py
@@ -2503,7 +2503,12 @@ def test_share_root_resolution_and_mode_helpers(tmp_path: Path, monkeypatch):
     assert env.share_root_path() == fake_home / "clustershare"
     assert env.resolve_share_path(None) == fake_home / "clustershare"
     assert env.resolve_share_path("demo/data") == fake_home / "clustershare" / "demo" / "data"
-    assert env.resolve_share_path("/tmp/absolute") == Path("/tmp/absolute").resolve(strict=False)
+    absolute_share_path = env.resolve_share_path("/tmp/absolute")
+    if os.name == "nt":
+        assert absolute_share_path.is_absolute()
+        assert absolute_share_path.parts[-2:] == ("tmp", "absolute")
+    else:
+        assert absolute_share_path == Path("/tmp/absolute").resolve(strict=False)
 
 
 def test_share_root_resolution_worker_uses_runtime_home_and_init_honours_share_override(tmp_path: Path, monkeypatch):

--- a/src/agilab/core/agi-env/test/test_process_support.py
+++ b/src/agilab/core/agi-env/test/test_process_support.py
@@ -306,9 +306,11 @@ def test_apply_inline_path_export_returns_input_for_non_string_or_non_matching_c
 
 def test_inject_uv_preview_flag_handles_regex_failure(monkeypatch):
     monkeypatch.setattr(
-        process_support.re,
-        "sub",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(re.error("regex failure")),
+        process_support,
+        "re",
+        SimpleNamespace(
+            sub=lambda *_args, **_kwargs: (_ for _ in ()).throw(re.error("regex failure"))
+        ),
     )
 
     assert process_support.inject_uv_preview_flag("uv pip install demo") == "uv pip install demo"
@@ -316,9 +318,11 @@ def test_inject_uv_preview_flag_handles_regex_failure(monkeypatch):
 
 def test_inject_uv_preview_flag_propagates_unexpected_runtime_bug(monkeypatch):
     monkeypatch.setattr(
-        process_support.re,
-        "sub",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("regex bug")),
+        process_support,
+        "re",
+        SimpleNamespace(
+            sub=lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("regex bug"))
+        ),
     )
 
     with pytest.raises(RuntimeError, match="regex bug"):

--- a/src/agilab/core/agi-env/test/test_share_runtime_support.py
+++ b/src/agilab/core/agi-env/test/test_share_runtime_support.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 import agi_env.share_runtime_support as share_runtime_module
@@ -14,7 +15,12 @@ def test_share_runtime_helpers_cover_target_path_modes_and_ip_validation(tmp_pat
 
     assert share_runtime_module.resolve_share_path(None, share_root) == share_root
     assert share_runtime_module.resolve_share_path("demo/data", share_root) == share_root / "demo" / "data"
-    assert share_runtime_module.resolve_share_path("/tmp/absolute", share_root) == Path("/tmp/absolute").resolve(strict=False)
+    absolute_share_path = share_runtime_module.resolve_share_path("/tmp/absolute", share_root)
+    if os.name == "nt":
+        assert absolute_share_path.is_absolute()
+        assert absolute_share_path.parts[-2:] == ("tmp", "absolute")
+    else:
+        assert absolute_share_path == Path("/tmp/absolute").resolve(strict=False)
 
     assert share_runtime_module.mode_to_str(0b0111, hw_rapids_capable=False) == "_dcp"
     assert share_runtime_module.mode_to_str(0b0111, hw_rapids_capable=True) == "rdcp"

--- a/src/agilab/core/test/test_agi_distributor_deployment_build_support.py
+++ b/src/agilab/core/test/test_agi_distributor_deployment_build_support.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import subprocess
 from pathlib import Path
+from shlex import quote
 from types import SimpleNamespace
 
 import pytest
@@ -35,6 +36,10 @@ def _reset_agi_build_state():
         AGI.agi_workers = snapshot["agi_workers"]
         AGI.install_worker_group = snapshot["install_worker_group"]
         AGI.verbose = snapshot["verbose"]
+
+
+def _editable_overlay_arg(path: Path) -> str:
+    return f"--with-editable {quote(str(path))}"
 
 
 @pytest.mark.parametrize(
@@ -169,8 +174,8 @@ def test_source_worker_build_overlay_includes_editable_core_projects(tmp_path):
 
     assert "--with setuptools" in overlay
     assert "--with cython" in overlay
-    assert f"--with-editable {env.agi_env}" in overlay
-    assert f"--with-editable {env.agi_node}" in overlay
+    assert _editable_overlay_arg(env.agi_env) in overlay
+    assert _editable_overlay_arg(env.agi_node) in overlay
 
 
 def test_worker_pyproject_source_missing_raises(tmp_path):
@@ -516,7 +521,7 @@ async def test_build_lib_local_uses_editable_core_installs_in_source_env(monkeyp
         for cmd, _ in commands
     )
     assert any(
-        f"--with-editable {env.agi_env}" in cmd and f"--with-editable {env.agi_node}" in cmd
+        _editable_overlay_arg(env.agi_env) in cmd and _editable_overlay_arg(env.agi_node) in cmd
         for cmd, _ in commands
     )
 
@@ -564,7 +569,7 @@ async def test_build_lib_local_uses_uv_index_url_mirror_when_internet_disabled(
         for cmd, _ in commands
     )
     assert any(
-        f"--with-editable {env.agi_env}" in cmd and f"--with-editable {env.agi_node}" in cmd
+        _editable_overlay_arg(env.agi_env) in cmd and _editable_overlay_arg(env.agi_node) in cmd
         for cmd, _ in commands
     )
 

--- a/src/agilab/core/test/test_agi_distributor_deployment_venv_support.py
+++ b/src/agilab/core/test/test_agi_distributor_deployment_venv_support.py
@@ -68,7 +68,7 @@ def test_project_site_packages_dir_handles_windows_and_free_threaded_versions(tm
     assert deployment_venv_support.project_site_packages_dir(tmp_path, os_name="nt") == (
         tmp_path / ".venv" / "Lib" / "site-packages"
     )
-    assert deployment_venv_support.project_site_packages_dir(tmp_path, python_version="3.13t") == (
+    assert deployment_venv_support.project_site_packages_dir(tmp_path, os_name="posix", python_version="3.13t") == (
         tmp_path / ".venv" / "lib" / "python3.13t" / "site-packages"
     )
 
@@ -77,4 +77,4 @@ def test_project_site_packages_dir_prefers_existing_python_site_packages(tmp_pat
     expected = tmp_path / ".venv" / "lib" / "python3.12" / "site-packages"
     expected.mkdir(parents=True)
 
-    assert deployment_venv_support.project_site_packages_dir(tmp_path) == expected
+    assert deployment_venv_support.project_site_packages_dir(tmp_path, os_name="posix") == expected

--- a/src/agilab/core/test/test_agi_distributor_deployment_venv_support.py
+++ b/src/agilab/core/test/test_agi_distributor_deployment_venv_support.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 from agi_cluster.agi_distributor import deployment_venv_support
@@ -8,7 +9,7 @@ from agi_cluster.agi_distributor import deployment_venv_support
 def _write_venv_python(
     project: Path,
     *,
-    os_name: str = "posix",
+    os_name: str = os.name,
     python_version: str | None = None,
 ) -> Path:
     python_path = deployment_venv_support.project_venv_python(project, os_name=os_name)

--- a/src/agilab/core/test/test_agi_distributor_deployment_venv_support.py
+++ b/src/agilab/core/test/test_agi_distributor_deployment_venv_support.py
@@ -33,12 +33,35 @@ def test_project_venv_python_uses_target_platform_layouts(tmp_path: Path) -> Non
 
 
 def test_project_venv_matches_checks_executable_and_requested_version(tmp_path: Path) -> None:
-    assert deployment_venv_support.project_venv_matches(tmp_path, python_version="3.13") is False
+    for os_name in ("posix", "nt"):
+        project = tmp_path / os_name
+        assert (
+            deployment_venv_support.project_venv_matches(
+                project,
+                os_name=os_name,
+                python_version="3.13",
+            )
+            is False
+        )
 
-    _write_venv_python(tmp_path, python_version="3.13.2")
+        _write_venv_python(project, os_name=os_name, python_version="3.13.2")
 
-    assert deployment_venv_support.project_venv_matches(tmp_path, python_version="3.13") is True
-    assert deployment_venv_support.project_venv_matches(tmp_path, python_version="3.12") is False
+        assert (
+            deployment_venv_support.project_venv_matches(
+                project,
+                os_name=os_name,
+                python_version="3.13",
+            )
+            is True
+        )
+        assert (
+            deployment_venv_support.project_venv_matches(
+                project,
+                os_name=os_name,
+                python_version="3.12",
+            )
+            is False
+        )
 
 
 def test_project_site_packages_dir_handles_windows_and_free_threaded_versions(tmp_path: Path) -> None:

--- a/test/test_ci_workflow.py
+++ b/test/test_ci_workflow.py
@@ -12,6 +12,7 @@ DOCS_SOURCE_GUARD_WORKFLOW_PATH = Path(".github/workflows/docs-source-guard.yaml
 DOCS_PUBLISH_WORKFLOW_PATH = Path(".github/workflows/docs-publish.yaml")
 ENSURE_ROADMAP_LABEL_WORKFLOW_PATH = Path(".github/workflows/ensure-roadmap-label.yaml")
 UI_ROBOT_MATRIX_WORKFLOW_PATH = Path(".github/workflows/ui-robot-matrix.yml")
+WINDOWS_CORE_TESTS_WORKFLOW_PATH = Path(".github/workflows/windows-core-tests.yml")
 ROOT_CONFTEST_PATH = Path("test/conftest.py")
 WORKFLOW_PARITY_PATH = Path("tools/workflow_parity.py")
 
@@ -20,6 +21,7 @@ VALIDATION_WORKFLOW_PATHS = (
     COVERAGE_WORKFLOW_PATH,
     DOCS_SOURCE_GUARD_WORKFLOW_PATH,
     ENSURE_ROADMAP_LABEL_WORKFLOW_PATH,
+    WINDOWS_CORE_TESTS_WORKFLOW_PATH,
 )
 
 VALIDATION_CONCURRENCY_GROUP = (
@@ -182,6 +184,24 @@ def test_validation_workflows_cancel_superseded_branch_runs() -> None:
 def test_maintenance_workflows_do_not_run_twice_for_pr_branch_pushes() -> None:
     assert 'branches: ["main"]' in WORKFLOW_PATH.read_text(encoding="utf-8")
     assert 'branches: ["main"]' in ENSURE_ROADMAP_LABEL_WORKFLOW_PATH.read_text(encoding="utf-8")
+
+
+def test_windows_core_tests_workflow_matches_failure_tracker_command() -> None:
+    text = WINDOWS_CORE_TESTS_WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    assert "name: windows-core-tests" in text
+    assert "runs-on: windows-latest" in text
+    assert "workflow_dispatch:" in text
+    assert "schedule:" in text
+    assert 'branches: ["main"]' in text
+    assert 'branches: ["**"]' in text
+    assert "src/agilab/core/test src/agilab/core/agi-env/test" in text
+    assert "test-results/windows-core-tests.txt" in text
+    assert "test-results/windows-core-tests.xml" in text
+    assert "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2" in text
+    assert "actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6" in text
+    assert "astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0" in text
+    assert "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7" in text
 
 
 def test_docs_workflows_block_stale_release_proof_github_runs() -> None:


### PR DESCRIPTION
## Summary
- Add a dedicated `windows-core-tests` GitHub Actions workflow on `windows-latest`.
- Run the Windows tracker core suites: `src/agilab/core/test` and `src/agilab/core/agi-env/test`.
- Upload text and JUnit artifacts so the historical Windows failure tracker can be refreshed from CI evidence.
- Add a workflow contract test and update `WINDOWS_TEST_FAILURES.md` with the automated validation path.

## Validation
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files .github/workflows/windows-core-tests.yml WINDOWS_TEST_FAILURES.md test/test_ci_workflow.py`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_ci_workflow.py -k 'windows_core_tests_workflow or validation_workflows'`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_ci_workflow.py`
