### PR TITLE
[codex] Support generic page env realignment

### DIFF
--- a/src/agilab/page_bootstrap.py
+++ b/src/agilab/page_bootstrap.py
@@ -126,13 +126,19 @@ def realign_session_env_with_page_root(
             )
             session_state[env_key] = env
         else:
-            type(env).__init__(
-                env,
-                apps_path=expected_apps_path,
-                app=page_app.name,
-                verbose=getattr(env, "verbose", None),
-                _agilab_reinitialize=True,
-            )
+            init_kwargs = {
+                "apps_path": expected_apps_path,
+                "app": page_app.name,
+                "verbose": getattr(env, "verbose", None),
+            }
+            try:
+                type(env).__init__(
+                    env,
+                    **init_kwargs,
+                    _agilab_reinitialize=True,
+                )
+            except TypeError:
+                type(env).__init__(env, **init_kwargs)
         if previous_init_done is not None:
             env.init_done = previous_init_done
     except (AttributeError, OSError, RuntimeError, TypeError, ValueError):


### PR DESCRIPTION
## Summary

- Keep `AgiEnv.for_app(...)` as the preferred stale page-env repair path.
- Let the fallback constructor support lightweight env objects that do not accept AGILAB-specific `_agilab_reinitialize`.

## Root cause

The release preflight `agi-gui` support slice uses a lightweight fake env in `test_page_bootstrap_realigns_stale_session_env_to_page_root`. The bootstrap fallback always passed `_agilab_reinitialize=True`, which is valid for `AgiEnv` but invalid for that generic env object, causing realignment to return `False`.

## Validation

- `uv --preview-features extra-build-dependencies run --no-sync python -m py_compile src/agilab/page_bootstrap.py`
- `uv --preview-features extra-build-dependencies run --no-sync pytest -q -o addopts='' test/test_about_agilab_helpers.py::test_page_bootstrap_realigns_stale_session_env_to_page_root`
- `uv --preview-features extra-build-dependencies run --no-sync pytest -q -o addopts='' test/test_ui_pages.py::test_execute_page_realigns_stale_agi_space_session_env test/test_ui_pages.py::test_execute_page_realigns_stale_active_app_only_for_source_root`
