### PR TITLE
Retry PyPI provenance checks after upload 404

### DIFF
--- a/test/test_pypi_provenance_check.py
+++ b/test/test_pypi_provenance_check.py
@@ -136,3 +136,40 @@ def test_check_target_with_retries_waits_for_pypi_release_visibility() -> None:
     assert check["previous_failures"] == [
         {"attempt": 1, "reason": "release_missing", "status": "fail"}
     ]
+
+
+def test_check_target_with_retries_waits_for_pypi_json_404_after_upload() -> None:
+    module = _load_module()
+    target = module.ReleaseTarget("agi-apps", "2026.05.15", "src/agilab/lib/agi-apps")
+    calls = {"json": 0}
+
+    def fake_urlopen(request, *, timeout):
+        url = request.full_url
+        if url.endswith("/pypi/agi-apps/json"):
+            calls["json"] += 1
+            if calls["json"] == 1:
+                raise HTTPError(url, 404, "not found", hdrs=None, fp=None)
+            return _json_response(
+                {
+                    "releases": {
+                        "2026.5.15": [
+                            {"filename": "agi_apps-2026.5.15-py3-none-any.whl"},
+                        ]
+                    }
+                }
+            )
+        return _json_response({"attestation_bundles": [{"attestations": [{}]}]})
+
+    check = module.check_target_with_retries(
+        target,
+        attempts=2,
+        retry_delay=0,
+        sleep=lambda _seconds: None,
+        urlopen=fake_urlopen,
+    )
+
+    assert check["status"] == "pass"
+    assert check["attempt"] == 2
+    assert check["previous_failures"] == [
+        {"attempt": 1, "reason": "pypi_json_http_404", "status": "fail"}
+    ]

--- a/tools/pypi_provenance_check.py
+++ b/tools/pypi_provenance_check.py
@@ -200,9 +200,16 @@ def check_target(
 
 def _is_transient_failure(check: dict[str, Any]) -> bool:
     reason = str(check.get("reason", ""))
+    transient_http_reasons = {
+        "pypi_json_http_404",
+        "pypi_json_http_408",
+        "pypi_json_http_409",
+        "pypi_json_http_425",
+        "pypi_json_http_429",
+    }
     return reason in {"release_missing", "missing_attestation"} or reason.startswith(
         "pypi_json_http_5"
-    )
+    ) or reason in transient_http_reasons
 
 
 def check_target_with_retries(


### PR DESCRIPTION
## Summary
- treat immediate post-upload PyPI JSON 404/selected retryable HTTP responses as transient in provenance verification
- add regression coverage for a fresh upload that becomes visible on the next attempt

## Validation
- uv --preview-features extra-build-dependencies run pytest -q -o addopts= test/test_pypi_provenance_check.py