### PR TITLE
Refactor core review cleanup

### DIFF
--- a/WINDOWS_TEST_FAILURES.md
+++ b/WINDOWS_TEST_FAILURES.md
@@ -399,21 +399,19 @@ Result: `7 passed`.
 
 | # | Category | Count | Status | Primary fix location |
 |---|---|---|---|---|
-| 1 | Env isolation (`~/.agilab/.env` leaks) | 15 | ✅ Fixed in current repo; rerun Windows to verify count | `test/conftest.py`, `src/agilab/core/test/conftest.py`, `src/agilab/core/agi-env/test/conftest.py` |
-| 2 | `.venv/bin` vs `.venv/Scripts` | 7 | ✅ Fixed in current repo; rerun Windows to verify count | `deployment_local_support.py`, `process_support.py` |
-| 3 | uv TOML paths with `\` | 8 | ✅ Fixed in current repo; rerun Windows to verify count | `uv_source_support.py` |
-| 4 | `cmd /c exit N` unreliable exit code | 4 | ✅ Fixed in current repo; rerun Windows to verify count | `src/agilab/core/agi-env/test/test_agi_env.py` |
-| 5 | Linux-only (fstab, PosixPath, sshfs) | 6 | ✅ Fixed in current repo; rerun Windows to verify count | `share_mount_support.py`, `test_pagelib.py`, `test_agi_env.py`, `test_agi_distributor_deployment_remote_support.py` |
-| 6 | mlflow file locking | 1 | ✅ Fixed in current repo; rerun Windows to verify count | `mlflow_store.py`, `test_pagelib.py` |
-| 7 | Polars CSV non-UTF-8 encoding | 2 | ✅ Fixed in current repo; rerun Windows to verify count | `capacity_support.py`, `test_agi_distributor_capacity_support.py` |
-| 8 | `prepare_local_env` self-update | 3 | ✅ Fixed in current repo; rerun Windows to verify count | `deployment_prepare_support.py`, `test_agi_distributor_deployment_prepare_support.py` |
-| 9 | `sshpass` not on Windows | 1 | ✅ Fixed in current repo; rerun Windows to verify count | `test_agi_distributor_transport_support.py` |
-| — | Needs `pytest -vv` | 0 | ✅ Resolved in current repo; rerun Windows to verify count | Targeted bucket now passes |
+| 1 | Env isolation (`~/.agilab/.env` leaks) | 15 | ✅ Verified by Windows CI run 26650203561 | `test/conftest.py`, `src/agilab/core/test/conftest.py`, `src/agilab/core/agi-env/test/conftest.py` |
+| 2 | `.venv/bin` vs `.venv/Scripts` | 7 | ✅ Verified by Windows CI run 26650203561 | `deployment_local_support.py`, `process_support.py` |
+| 3 | uv TOML paths with `\` | 8 | ✅ Verified by Windows CI run 26650203561 | `uv_source_support.py` |
+| 4 | `cmd /c exit N` unreliable exit code | 4 | ✅ Verified by Windows CI run 26650203561 | `src/agilab/core/agi-env/test/test_agi_env.py` |
+| 5 | Linux-only (fstab, PosixPath, sshfs) | 6 | ✅ Verified by Windows CI run 26650203561 | `share_mount_support.py`, `test_pagelib.py`, `test_agi_env.py`, `test_agi_distributor_deployment_remote_support.py` |
+| 6 | mlflow file locking | 1 | ✅ Verified by Windows CI run 26650203561 | `mlflow_store.py`, `test_pagelib.py` |
+| 7 | Polars CSV non-UTF-8 encoding | 2 | ✅ Verified by Windows CI run 26650203561 | `capacity_support.py`, `test_agi_distributor_capacity_support.py` |
+| 8 | `prepare_local_env` self-update | 3 | ✅ Verified by Windows CI run 26650203561 | `deployment_prepare_support.py`, `test_agi_distributor_deployment_prepare_support.py` |
+| 9 | `sshpass` not on Windows | 1 | ✅ Verified by Windows CI run 26650203561 | `test_agi_distributor_transport_support.py` |
+| — | Needs `pytest -vv` | 0 | ✅ Verified by Windows CI run 26650203561 | Targeted bucket now passes |
 
-**Recommended priority:** use the `windows-core-tests` workflow, or rerun the
-Windows command above, to refresh the verified remaining count after the
-environment-isolation, virtualenv layout, uv TOML path, Python subprocess exit
-fixture, Linux-only guard, mlflow backend reset, capacity CSV encoding,
-prepare_local_env self-update, and sshpass test fixes. Then prioritize any
-still-failing Windows categories from the refreshed run. There are no named
-local regression buckets left open in this tracker.
+**Recommended priority:** keep this tracker as a historical regression index.
+Rerun the Windows command or the `windows-core-tests` workflow only after future
+Windows-sensitive core changes, then add any new failing category here with its
+fresh run evidence. There are no named Windows regression buckets left open in
+this tracker.

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/entrypoint_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/entrypoint_support.py
@@ -28,6 +28,7 @@ _EXPORT_CMD_LOOKUP_EXCEPTIONS = (
     OSError,
     RuntimeError,
 )
+_AGI_RUN_BOUNDARY_EXCEPTIONS: tuple[type[Exception], ...] = (Exception,)
 
 
 def _normalize_workers(
@@ -173,7 +174,7 @@ async def _run_main_with_handled_errors(
     except ModuleNotFoundError as exc:
         log.error("failed to load module \n%s", exc)
         return None
-    except Exception as exc:  # Intentional AGI.run boundary: log and re-raise.
+    except _AGI_RUN_BOUNDARY_EXCEPTIONS as exc:  # Intentional AGI.run boundary: log and re-raise.
         _log_unhandled_run_exception(
             exc,
             format_exception_chain_fn=format_exception_chain_fn,

--- a/src/agilab/core/agi-env/src/agi_env/agi_env.py
+++ b/src/agilab/core/agi-env/src/agi_env/agi_env.py
@@ -81,6 +81,11 @@ from agi_env.runtime_bootstrap_support import (
     sync_repository_apps,
 )
 from agi_env.worker_runtime_support import configure_worker_runtime
+from agi_env.windows_link_support import (
+    create_junction_windows as _create_junction_windows,
+    create_symlink_windows as _create_symlink_windows,
+    has_admin_rights as _has_admin_rights,
+)
 from agi_env.process_support import (
     build_subprocess_env,
     fix_windows_drive as _fix_windows_drive,
@@ -1542,10 +1547,7 @@ class AgiEnv(metaclass=_AgiEnvMeta):
         Returns:
             bool: True if admin, False otherwise.
         """
-        try:
-            return ctypes.windll.shell32.IsUserAnAdmin()  # ty: ignore[unresolved-attribute]
-        except (AttributeError, OSError, RuntimeError):
-            return False
+        return _has_admin_rights(ctypes_module=ctypes)
 
     @staticmethod
     def create_junction_windows(source: Path, dest: Path) -> bool:
@@ -1556,18 +1558,12 @@ class AgiEnv(metaclass=_AgiEnvMeta):
             source (Path): The target directory path.
             dest (Path): The destination junction path.
         """
-        try:
-            # Using the mklink command to create a junction (/J) which doesn't require admin rights.
-            subprocess.check_call(['cmd', '/c', 'mklink', '/J', str(dest), str(source)])
-            logger = AgiEnv.logger
-            if logger:
-                logger.info(f"Created junction: {dest} -> {source}")
-            return True
-        except (OSError, subprocess.CalledProcessError) as e:
-            logger = AgiEnv.logger
-            if logger:
-                logger.error(f"Failed to create junction. Error: {e}")
-            return False
+        return _create_junction_windows(
+            source,
+            dest,
+            logger=AgiEnv.logger,
+            check_call=subprocess.check_call,
+        )
 
     @staticmethod
     def create_symlink_windows(source: Path, dest: Path):
@@ -1578,36 +1574,14 @@ class AgiEnv(metaclass=_AgiEnvMeta):
             source (Path): Source directory path.
             dest (Path): Destination symlink path.
         """
-        # Define necessary Windows API functions and constants
-        CreateSymbolicLink = ctypes.windll.kernel32.CreateSymbolicLinkW  # ty: ignore[unresolved-attribute]
-        CreateSymbolicLink.restype = wintypes.BOOL
-        CreateSymbolicLink.argtypes = [wintypes.LPCWSTR, wintypes.LPCWSTR, wintypes.DWORD]
-
-        SYMBOLIC_LINK_FLAG_DIRECTORY = 0x1
-
-        # Check if Developer Mode is enabled or if the process has admin rights
-        if not AgiEnv.has_admin_rights():
-            logger = AgiEnv.logger
-            if logger:
-                logger.info(
-                    "Creating symbolic links on Windows requires administrative privileges or Developer Mode enabled."
-                )
-            return
-
-        flags = SYMBOLIC_LINK_FLAG_DIRECTORY
-
-        success = CreateSymbolicLink(str(dest), str(source), flags)
-        if success:
-            logger = AgiEnv.logger
-            if logger:
-                logger.info(f"Created symbolic link for .venv: {dest} -> {source}")
-        else:
-            error_code = ctypes.GetLastError()  # ty: ignore[unresolved-attribute]
-            logger = AgiEnv.logger
-            if logger:
-                logger.info(
-                    f"Failed to create symbolic link for .venv. Error code: {error_code}"
-                )
+        return _create_symlink_windows(
+            source,
+            dest,
+            has_admin_rights_fn=AgiEnv.has_admin_rights,
+            logger=AgiEnv.logger,
+            ctypes_module=ctypes,
+            wintypes_module=wintypes,
+        )
 
     def create_rename_map(self, target_project: Path, dest_project: Path) -> dict:
         """Create a mapping of old → new names for cloning."""
@@ -1689,7 +1663,7 @@ class AgiEnv(metaclass=_AgiEnvMeta):
         try:
             # HEAD request to Google
             req = urllib.request.Request("https://www.google.com", method="HEAD")
-            with urllib.request.urlopen(req, timeout=3) as resp:
+            with urllib.request.urlopen(req, timeout=3):
                 pass  # Success if no exception
         except OSError:
             AgiEnv.logger.error("No internet connection detected. Aborting.")  # ty: ignore[unresolved-attribute]

--- a/src/agilab/core/agi-env/src/agi_env/app_provider_registry.py
+++ b/src/agilab/core/agi-env/src/agi_env/app_provider_registry.py
@@ -14,6 +14,7 @@ APP_PROVIDER_ENTRYPOINT_GROUP = "agilab.apps"
 _RUNTIME_TARGET_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 PUBLIC_RUNTIME_TARGET_ALIASES: dict[str, str] = {}
 RUNTIME_TARGET_PROJECT_ALIAS_EXCEPTIONS: set[str] = set()
+APP_PROVIDER_DISCOVERY_EXCEPTIONS: tuple[type[Exception], ...] = (Exception,)
 
 
 @dataclass(frozen=True, slots=True)
@@ -144,7 +145,7 @@ def _entry_points(entry_points_fn: Callable[[], Any]) -> Iterable[Any]:
         entry_points = entry_points_fn()
     # Best-effort provider discovery boundary: broken entry-point backends must
     # not prevent AGILAB from using source checkout app discovery.
-    except Exception:
+    except APP_PROVIDER_DISCOVERY_EXCEPTIONS:
         return ()
     select = getattr(entry_points, "select", None)
     if callable(select):
@@ -152,7 +153,7 @@ def _entry_points(entry_points_fn: Callable[[], Any]) -> Iterable[Any]:
             return tuple(select(group=APP_PROVIDER_ENTRYPOINT_GROUP))
         # Best-effort provider discovery boundary: ignore malformed third-party
         # entry-point selectors and fall back to source checkout app discovery.
-        except Exception:
+        except APP_PROVIDER_DISCOVERY_EXCEPTIONS:
             return ()
     if isinstance(entry_points, Mapping):
         return tuple(entry_points.get(APP_PROVIDER_ENTRYPOINT_GROUP, ()))
@@ -169,7 +170,7 @@ def _coerce_project_root(value: Any) -> Path | None:
             value = value()
         # Best-effort provider discovery boundary: provider callbacks execute
         # third-party package code, so broken providers are ignored.
-        except Exception:
+        except APP_PROVIDER_DISCOVERY_EXCEPTIONS:
             return None
     try:
         path = Path(value).expanduser().resolve(strict=False)
@@ -191,7 +192,7 @@ def discover_installed_app_projects(
             loaded = entry_point.load()
         # Best-effort provider discovery boundary: one broken installed
         # provider must not hide the rest of the installed app catalog.
-        except Exception:
+        except APP_PROVIDER_DISCOVERY_EXCEPTIONS:
             continue
         root = _coerce_project_root(loaded)
         if root is None:

--- a/src/agilab/core/agi-env/src/agi_env/windows_link_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/windows_link_support.py
@@ -1,0 +1,77 @@
+"""Windows link and privilege helpers used by AGILAB environment setup."""
+
+from __future__ import annotations
+
+import ctypes as _ctypes
+import subprocess
+from ctypes import wintypes as _wintypes
+from pathlib import Path
+
+
+def has_admin_rights(*, ctypes_module=_ctypes):
+    """Return whether the current Windows process has administrative rights."""
+
+    try:
+        return ctypes_module.windll.shell32.IsUserAnAdmin()
+    except (AttributeError, OSError, RuntimeError):
+        return False
+
+
+def create_junction_windows(
+    source: Path,
+    dest: Path,
+    *,
+    logger=None,
+    check_call=subprocess.check_call,
+) -> bool:
+    """Create a directory junction on Windows without requiring admin rights."""
+
+    try:
+        check_call(["cmd", "/c", "mklink", "/J", str(dest), str(source)])
+        if logger:
+            logger.info(f"Created junction: {dest} -> {source}")
+        return True
+    except (OSError, subprocess.CalledProcessError) as exc:
+        if logger:
+            logger.error(f"Failed to create junction. Error: {exc}")
+        return False
+
+
+def create_symlink_windows(
+    source: Path,
+    dest: Path,
+    *,
+    has_admin_rights_fn,
+    logger=None,
+    ctypes_module=_ctypes,
+    wintypes_module=_wintypes,
+) -> None:
+    """Create a Windows directory symbolic link when privileges allow it."""
+
+    create_symbolic_link = ctypes_module.windll.kernel32.CreateSymbolicLinkW
+    create_symbolic_link.restype = wintypes_module.BOOL
+    create_symbolic_link.argtypes = [
+        wintypes_module.LPCWSTR,
+        wintypes_module.LPCWSTR,
+        wintypes_module.DWORD,
+    ]
+
+    symbolic_link_flag_directory = 0x1
+
+    if not has_admin_rights_fn():
+        if logger:
+            logger.info(
+                "Creating symbolic links on Windows requires administrative privileges or Developer Mode enabled."
+            )
+        return
+
+    success = create_symbolic_link(str(dest), str(source), symbolic_link_flag_directory)
+    if success:
+        if logger:
+            logger.info(f"Created symbolic link for .venv: {dest} -> {source}")
+    else:
+        error_code = ctypes_module.GetLastError()
+        if logger:
+            logger.info(
+                f"Failed to create symbolic link for .venv. Error code: {error_code}"
+            )

--- a/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/base_worker.py
+++ b/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/base_worker.py
@@ -56,6 +56,8 @@ from . import base_worker_runtime_support as runtime_support
 from . import base_worker_service_support as service_support
 
 logger = AgiLogger.get_logger(__name__)
+_WORKER_HOOK_BOUNDARY_EXCEPTIONS: tuple[type[Exception], ...] = (Exception,)
+_WORKER_SERVICE_BOUNDARY_EXCEPTIONS: tuple[type[Exception], ...] = (Exception,)
 
 
 class BaseWorker(ArtifactContract, abc.ABC):
@@ -418,7 +420,7 @@ class BaseWorker(ArtifactContract, abc.ABC):
             base_method = BaseWorker.start
             if method and method is not base_method:
                 method()
-        except Exception:  # pragma: no cover - intentional hook boundary
+        except _WORKER_HOOK_BOUNDARY_EXCEPTIONS:  # pragma: no cover - intentional hook boundary
             logger.error("Worker start hook failed:\n%s", traceback.format_exc())
             raise
 
@@ -570,7 +572,7 @@ class BaseWorker(ArtifactContract, abc.ABC):
             _write_heartbeat("stopped")
             return {"status": "stopped", "runtime": time.time() - start_time}
 
-        except Exception as exc:  # pragma: no cover - intentional hook boundary
+        except _WORKER_SERVICE_BOUNDARY_EXCEPTIONS as exc:  # pragma: no cover - intentional hook boundary
             primary_exc = exc
             logger.exception("Service loop failed: %s", exc)
             raise
@@ -585,7 +587,7 @@ class BaseWorker(ArtifactContract, abc.ABC):
             if callable(stop_hook):
                 try:
                     stop_hook()
-                except Exception:  # pragma: no cover - intentional hook boundary
+                except _WORKER_HOOK_BOUNDARY_EXCEPTIONS:  # pragma: no cover - intentional hook boundary
                     logger.exception(
                         "Worker stop hook raised inside service loop", exc_info=True
                     )

--- a/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/base_worker_execution_support.py
+++ b/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/base_worker_execution_support.py
@@ -25,6 +25,7 @@ DISTRIBUTION_PLAN_WRAP_EXCEPTIONS = (
     ImportError,
     ModuleNotFoundError,
 )
+WORKER_CODE_BOUNDARY_EXCEPTIONS: tuple[type[Exception], ...] = (Exception,)
 
 
 def _resolve_primary_cython_dist_path(
@@ -318,7 +319,7 @@ def initialize_worker(
             file_path=file_path,
             path_cls=path_cls,
         )
-    except Exception:
+    except WORKER_CODE_BOUNDARY_EXCEPTIONS:
         # Worker loading/constructor/startup executes app code; keep one logging boundary here.
         logger_obj.error(traceback_module.format_exc())
         raise
@@ -801,7 +802,7 @@ def execute_worker_plan(
         else:
             logger_obj.error("this worker is not initialized")
             raise RuntimeError("failed to do_works")
-    except Exception:
+    except WORKER_CODE_BOUNDARY_EXCEPTIONS:
         # ``works(...)`` executes arbitrary worker code; keep the runtime logging boundary here.
         logger_obj.error(traceback_module.format_exc())
         raise

--- a/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/base_worker_service_support.py
+++ b/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/base_worker_service_support.py
@@ -12,6 +12,7 @@ from typing import Any, Callable
 SERVICE_TASK_SCHEMA = "agi.service.task.v1"
 SERVICE_TASK_SUFFIX = ".task.json"
 LEGACY_SERVICE_TASK_SUFFIX = ".task.pkl"
+SERVICE_TASK_EXECUTION_EXCEPTIONS: tuple[type[Exception], ...] = (Exception,)
 
 
 def resolve_service_queue_root(
@@ -255,7 +256,7 @@ def run_service_queue(
                 )
                 processed += 1
             # Worker code can fail arbitrarily; persist the failure and keep the queue alive.
-            except Exception as exc:
+            except SERVICE_TASK_EXECUTION_EXCEPTIONS as exc:
                 payload["status"] = "failed"
                 payload["finished_at"] = time_module.time()
                 payload["runtime"] = time_module.time() - task_start

--- a/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/worker_tracking_support.py
+++ b/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/worker_tracking_support.py
@@ -17,6 +17,8 @@ MLFLOW_TRACKING_URI_ENV = "MLFLOW_TRACKING_URI"
 MLFLOW_PARENT_RUN_ID_TAG = "mlflow.parentRunId"
 DEFAULT_MLFLOW_DB_NAME = "mlflow.db"
 DEFAULT_MLFLOW_ARTIFACT_DIR = "artifacts"
+TRACKING_OPTIONAL_BOUNDARY_EXCEPTIONS: tuple[type[Exception], ...] = (Exception,)
+WORKER_RUN_BODY_EXCEPTIONS: tuple[type[Exception], ...] = (Exception,)
 
 
 def prepare_worker_tracking_environment(
@@ -53,7 +55,7 @@ def prepare_worker_tracking_environment(
             default_db_name=DEFAULT_MLFLOW_DB_NAME,
         )
         tracking_uri = mlflow_store.sqlite_uri_for_path(db_path, os_name=os.name, path_cls=path_cls)
-    except Exception as exc:  # pragma: no cover - defensive tracking boundary
+    except TRACKING_OPTIONAL_BOUNDARY_EXCEPTIONS as exc:  # pragma: no cover - defensive tracking boundary
         _log_debug(logger_obj, "worker tracking disabled: failed to resolve MLflow URI: %s", exc)
         return None
 
@@ -126,7 +128,7 @@ def worker_tracking_run(
             yield worker_run
         # Worker code boundary: record failure metadata, then re-raise the
         # original worker exception without converting it into tracking success.
-        except Exception as exc:
+        except WORKER_RUN_BODY_EXCEPTIONS as exc:
             exit_exc_info = sys.exc_info()
             _log_tracking_metadata(
                 mlflow,
@@ -148,7 +150,7 @@ def worker_tracking_run(
             )
     # Defensive tracking boundary: MLflow startup is optional; if no worker run
     # was entered yet, disable tracking and let the worker continue.
-    except Exception as exc:
+    except TRACKING_OPTIONAL_BOUNDARY_EXCEPTIONS as exc:
         if worker_run is None:
             _log_debug(logger_obj, "worker tracking disabled: failed to start MLflow run: %s", exc)
             yield None
@@ -160,7 +162,7 @@ def worker_tracking_run(
         for context in reversed(entered_contexts):
             try:
                 context.__exit__(*exit_exc_info)
-            except Exception as exc:  # pragma: no cover - defensive tracking boundary
+            except TRACKING_OPTIONAL_BOUNDARY_EXCEPTIONS as exc:  # pragma: no cover - defensive tracking boundary
                 _log_debug(logger_obj, "worker tracking cleanup failed: %s", exc)
 
 

--- a/src/agilab/core/agi-node/src/agi_node/dag_worker/dag_worker.py
+++ b/src/agilab/core/agi-node/src/agi_node/dag_worker/dag_worker.py
@@ -29,6 +29,9 @@ from typing import Any
 from agi_node.agi_dispatcher import BaseWorker
 
 
+_DAG_PARTITION_BOUNDARY_EXCEPTIONS: tuple[type[Exception], ...] = (Exception,)
+
+
 class DagWorker(BaseWorker):
     """
     Minimal-change DAG worker:
@@ -232,7 +235,7 @@ class DagWorker(BaseWorker):
                 logging.info(f"Method {fn} for partition {pname} completed.")
             # Worker code boundary: DAG partitions execute app methods; log each
             # failed partition and continue collecting sibling partition results.
-            except Exception as exc:
+            except _DAG_PARTITION_BOUNDARY_EXCEPTIONS as exc:
                 logging.error(f"Method {fn} for partition {pname} generated an exception: {exc}")
 
         # ._exec_multi_process doesn't need to return anything specific


### PR DESCRIPTION
## Summary
- refresh Windows failure tracker with verified passing CI evidence
- extract Windows link/admin helpers out of agi_env while preserving AgiEnv wrappers
- classify intentional broad exception boundaries in shared core
- remove stale untracked build/lib generated duplicate locally

## Validation
- uv --preview-features extra-build-dependencies run python tools/impact_validate.py --staged
- uv --preview-features extra-build-dependencies run --no-sync pytest src/agilab/core/agi-env/test
- uv --preview-features extra-build-dependencies run --no-sync pytest src/agilab/core/test
- uv --preview-features extra-build-dependencies run ruff check <changed core files>
- uv --preview-features extra-build-dependencies run --with mypy python tools/shared_core_strict_typing.py
