### PR TITLE
Refactor AgiEnv host helpers

### DIFF
--- a/src/agilab/core/agi-env/src/agi_env/agi_env.py
+++ b/src/agilab/core/agi-env/src/agi_env/agi_env.py
@@ -65,6 +65,11 @@ from agi_env.env_config_support import (
     write_env_updates,
 )
 from agi_env.hook_support import resolve_worker_hook, select_hook
+from agi_env.host_runtime_support import (
+    check_internet_connectivity,
+    create_symlink as _create_symlink,
+    is_local_ip,
+)
 from agi_env.installation_support import (
     installation_marker_path,
     locate_agilab_installation_path,
@@ -1440,31 +1445,13 @@ class AgiEnv(metaclass=_AgiEnvMeta):
 
     @staticmethod
     def create_symlink(src: Path, dest: Path) -> bool:
-        try:
-            if dest.exists() or dest.is_symlink():
-                if dest.is_symlink() and dest.resolve() == src.resolve():
-                    logger = AgiEnv.logger
-                    if logger:
-                        logger.info(f"Symlink already exists and is correct: {dest} -> {src}")
-                    return True
-                logger = AgiEnv.logger
-                if logger:
-                    logger.warning(f"Warning: Destination already exists and is not a symlink: {dest}")
-                if dest.is_dir():
-                    return False
-                dest.unlink()
-            dest.symlink_to(src, target_is_directory=src.is_dir())
-            logger = AgiEnv.logger
-            if logger:
-                logger.info(f"Symlink created: @{dest.name} -> {src}")
-            return True
-        except OSError as e:
-            if os.name == "nt" and src.is_dir() and AgiEnv.create_junction_windows(src, dest):
-                return True
-            logger = AgiEnv.logger
-            if logger:
-                logger.error(f"Failed to create symlink @{dest} -> {src}: {e}")
-            return False
+        return _create_symlink(
+            src,
+            dest,
+            logger=AgiEnv.logger,
+            os_name=os.name,
+            create_junction_windows_fn=AgiEnv.create_junction_windows,
+        )
 
     def change_app(self, app):
         # Normalize current and requested app identifiers to comparable names
@@ -1526,18 +1513,12 @@ class AgiEnv(metaclass=_AgiEnvMeta):
         Returns:
 
         """
-        if (
-                not ip or ip in AgiEnv._ip_local_cache
-        ):  # Check if IP is None, empty, or cached
-            return True
-
-        for _, addrs in psutil.net_if_addrs().items():
-            for addr in addrs:
-                if addr.family == socket.AF_INET and ip == addr.address:
-                    AgiEnv._ip_local_cache.add(ip)  # Cache the local IP found
-                    return True
-
-        return False
+        return is_local_ip(
+            ip,
+            cache=AgiEnv._ip_local_cache,
+            net_if_addrs_fn=psutil.net_if_addrs,
+            inet_family=socket.AF_INET,
+        )
 
     @staticmethod
     def has_admin_rights():
@@ -1659,17 +1640,11 @@ class AgiEnv(metaclass=_AgiEnvMeta):
 
     @staticmethod
     def check_internet():
-        AgiEnv.logger.info("Checking internet connectivity...")  # ty: ignore[unresolved-attribute]
-        try:
-            # HEAD request to Google
-            req = urllib.request.Request("https://www.google.com", method="HEAD")
-            with urllib.request.urlopen(req, timeout=3):
-                pass  # Success if no exception
-        except OSError:
-            AgiEnv.logger.error("No internet connection detected. Aborting.")  # ty: ignore[unresolved-attribute]
-            return False
-        AgiEnv.logger.info("Internet connection is OK.")  # ty: ignore[unresolved-attribute]
-        return True
+        return check_internet_connectivity(
+            logger=AgiEnv.logger,
+            request_factory=urllib.request.Request,
+            urlopen_fn=urllib.request.urlopen,
+        )
 
 
 

--- a/src/agilab/core/agi-env/src/agi_env/host_runtime_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/host_runtime_support.py
@@ -1,0 +1,82 @@
+"""Host-level network and link helpers used by ``AgiEnv`` wrappers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable
+
+
+def create_symlink(
+    src: Path,
+    dest: Path,
+    *,
+    logger=None,
+    os_name: str,
+    create_junction_windows_fn: Callable[[Path, Path], bool],
+) -> bool:
+    """Create a symlink, using a Windows junction fallback for directories."""
+
+    try:
+        if dest.exists() or dest.is_symlink():
+            if dest.is_symlink() and dest.resolve() == src.resolve():
+                if logger:
+                    logger.info(f"Symlink already exists and is correct: {dest} -> {src}")
+                return True
+            if logger:
+                logger.warning(f"Warning: Destination already exists and is not a symlink: {dest}")
+            if dest.is_dir():
+                return False
+            dest.unlink()
+        dest.symlink_to(src, target_is_directory=src.is_dir())
+        if logger:
+            logger.info(f"Symlink created: @{dest.name} -> {src}")
+        return True
+    except OSError as exc:
+        if os_name == "nt" and src.is_dir() and create_junction_windows_fn(src, dest):
+            return True
+        if logger:
+            logger.error(f"Failed to create symlink @{dest} -> {src}: {exc}")
+        return False
+
+
+def is_local_ip(
+    ip,
+    *,
+    cache: set,
+    net_if_addrs_fn: Callable[[], dict[str, Any]],
+    inet_family,
+) -> bool:
+    """Return whether ``ip`` matches a local interface address."""
+
+    if not ip or ip in cache:
+        return True
+
+    for _, addrs in net_if_addrs_fn().items():
+        for addr in addrs:
+            if addr.family == inet_family and ip == addr.address:
+                cache.add(ip)
+                return True
+
+    return False
+
+
+def check_internet_connectivity(
+    *,
+    logger,
+    request_factory,
+    urlopen_fn,
+    url: str = "https://www.google.com",
+    timeout: int = 3,
+) -> bool:
+    """Check basic outbound connectivity with a HEAD request."""
+
+    logger.info("Checking internet connectivity...")
+    try:
+        req = request_factory(url, method="HEAD")
+        with urlopen_fn(req, timeout=timeout):
+            pass
+    except OSError:
+        logger.error("No internet connection detected. Aborting.")
+        return False
+    logger.info("Internet connection is OK.")
+    return True

--- a/src/agilab/core/agi-env/test/test_host_runtime_support.py
+++ b/src/agilab/core/agi-env/test/test_host_runtime_support.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest import mock
+
+from agi_env.host_runtime_support import (
+    check_internet_connectivity,
+    create_symlink,
+    is_local_ip,
+)
+
+
+def test_create_symlink_uses_windows_junction_fallback(tmp_path, monkeypatch):
+    src = tmp_path / "src"
+    src.mkdir()
+    dest = tmp_path / "dest"
+    calls = []
+
+    monkeypatch.setattr(
+        type(dest),
+        "symlink_to",
+        lambda self, *_args, **_kwargs: (_ for _ in ()).throw(OSError("denied")),
+        raising=False,
+    )
+
+    assert create_symlink(
+        src,
+        dest,
+        logger=mock.Mock(),
+        os_name="nt",
+        create_junction_windows_fn=lambda source, target: calls.append((source, target)) or True,
+    )
+    assert calls == [(src, dest)]
+
+
+def test_is_local_ip_caches_matched_interface():
+    cache = set()
+    addrs = {"en0": [SimpleNamespace(family="inet", address="192.168.1.10")]}
+
+    assert is_local_ip(
+        "192.168.1.10",
+        cache=cache,
+        net_if_addrs_fn=lambda: addrs,
+        inet_family="inet",
+    )
+    assert "192.168.1.10" in cache
+    assert is_local_ip(
+        "",
+        cache=cache,
+        net_if_addrs_fn=lambda: {},
+        inet_family="inet",
+    )
+
+
+def test_check_internet_connectivity_reports_success_and_failure():
+    logger = mock.Mock()
+
+    class _Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    assert check_internet_connectivity(
+        logger=logger,
+        request_factory=lambda url, method: (url, method),
+        urlopen_fn=lambda *_args, **_kwargs: _Response(),
+    )
+
+    def _raise(*_args, **_kwargs):
+        raise OSError("offline")
+
+    assert not check_internet_connectivity(
+        logger=logger,
+        request_factory=lambda url, method: (url, method),
+        urlopen_fn=_raise,
+    )
+    assert logger.error.called

--- a/test/test_tools_surface_contract.py
+++ b/test/test_tools_surface_contract.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+TOOLS_SURFACE_BUDGET = 160
+
+
+def test_top_level_tools_surface_stays_within_budget() -> None:
+    tools_dir = Path("tools")
+    top_level_tools = sorted(path for path in tools_dir.iterdir() if path.is_file())
+
+    assert len(top_level_tools) <= TOOLS_SURFACE_BUDGET, (
+        f"tools/ has {len(top_level_tools)} top-level files; budget is "
+        f"{TOOLS_SURFACE_BUDGET}. Reuse an existing tool, move helpers under a "
+        "subdirectory, or raise this budget in the same change with rationale."
+    )


### PR DESCRIPTION
## Summary
- extract host-level symlink, local-IP, and connectivity helpers from agi_env
- keep AgiEnv public wrappers stable for existing callers
- add direct host helper tests
- add a top-level tools surface budget guard for the review hygiene item

## Validation
- uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files src/agilab/core/agi-env/src/agi_env/agi_env.py src/agilab/core/agi-env/src/agi_env/host_runtime_support.py src/agilab/core/agi-env/test/test_host_runtime_support.py test/test_tools_surface_contract.py
- uv --preview-features extra-build-dependencies run --no-sync pytest src/agilab/core/agi-env/test
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_agi_env.py src/agilab/core/agi-env/test/test_agi_env.py src/agilab/core/agi-env/test/test_agi_env_helper_branch_sweep.py src/agilab/core/agi-env/test/test_agi_env_remaining_coverage.py src/agilab/core/agi-env/test/test_host_runtime_support.py test/test_tools_surface_contract.py
- uv --preview-features extra-build-dependencies run ruff check src/agilab/core/agi-env/src/agi_env/agi_env.py src/agilab/core/agi-env/src/agi_env/host_runtime_support.py src/agilab/core/agi-env/test/test_host_runtime_support.py test/test_tools_surface_contract.py
- uv --preview-features extra-build-dependencies run --with mypy python tools/shared_core_strict_typing.py
