### PR TITLE
Add run storyboard evidence command

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 233,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "9d3e5aaab0b2e73739403ca63fb79df1d4406c880749708128aed964bf0aff0d",
+  "source_digest_sha256": "3c9a31ef98cc1c94da26842af2ee0d9d1305dcac090371c89b9616e28d7ab184",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "9d3e5aaab0b2e73739403ca63fb79df1d4406c880749708128aed964bf0aff0d"
+  "target_digest_sha256": "3c9a31ef98cc1c94da26842af2ee0d9d1305dcac090371c89b9616e28d7ab184"
 }

--- a/docs/source/proof-capsule.rst
+++ b/docs/source/proof-capsule.rst
@@ -90,6 +90,7 @@ The shipped first layer operates on a run manifest:
    agilab verify proof.agipack --signature proof.agipack.sig.json --trust-policy policy.toml --strict
    agilab replay ~/log/execute/flight_telemetry/run_manifest.json
    agilab replay proof.agipack
+   agilab story ~/log/execute/flight_telemetry/run_manifest.json --output-dir proof-pack/story
    agilab export-lineage ~/log/execute/flight_telemetry/run_manifest.json --format all --output-dir proof-pack
    agilab export-traces proof.agipack --output-dir proof-pack
    agilab policy-check ~/log/execute/flight_telemetry/run_manifest.json --strict
@@ -103,6 +104,7 @@ The proof pack includes:
 * OpenLineage-shaped JSON
 * RO-Crate metadata
 * OpenTelemetry-shaped trace JSON
+* ``run_story.json`` and ``run_story.md`` for a shareable one-run summary
 * a local metadata-store entry
 * model, dataset, prompt, and evaluation cards generated from available
   manifest evidence
@@ -118,6 +120,20 @@ public-key hashes, signers, issuers, or expected capsule hashes. Replay is safe
 by default: ``agilab replay`` prints the recorded command from either
 ``run_manifest.json`` or ``proof.agipack`` and requires ``--execute`` before
 launching it.
+
+Run story
+---------
+
+``agilab story`` is the fast-adoption view of the same evidence. It reads a
+``run_manifest.json`` file, hashes present artifacts, summarizes validations,
+keeps only environment-variable names from command overrides, and writes:
+
+* ``run_story.md`` for a human-readable execution story.
+* ``run_story.json`` for CI, chat, ticket, or review-tool ingestion.
+
+The command is read-only: it does not replay the run, call network services, or
+execute recorded commands. Use it when a reviewer needs to understand what
+happened after one AGILAB run without opening logs or notebooks first.
 
 Minimal trust policy example:
 

--- a/src/agilab/lab_run.py
+++ b/src/agilab/lab_run.py
@@ -12,6 +12,7 @@
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import argparse
+import importlib.util
 import os
 import sys
 import tomllib
@@ -162,6 +163,12 @@ def _run_adoption_report(argv: list[str]) -> int:
     return adoption_report.main(argv)
 
 
+def _run_storyboard(argv: list[str]) -> int:
+    from agilab import run_storyboard
+
+    return run_storyboard.main(argv)
+
+
 def _run_evidence_contract(argv: list[str]) -> int:
     from agilab import evidence_contract
 
@@ -240,6 +247,8 @@ def main(argv: list[str] | None = None) -> int:
         return _run_security_check(raw_argv[1:])
     if raw_argv[:1] in (["adoption-report"], ["adoption_report"]):
         return _run_adoption_report(raw_argv[1:])
+    if raw_argv[:1] in (["story"], ["storyboard"], ["run-story"], ["run_story"]):
+        return _run_storyboard(raw_argv[1:])
     if raw_argv[:1] in (
         ["prove"],
         ["verify"],

--- a/src/agilab/run_storyboard.py
+++ b/src/agilab/run_storyboard.py
@@ -1,0 +1,290 @@
+"""Build a shareable one-run story from an AGILAB run manifest."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import shlex
+from typing import Any, Mapping, Sequence
+
+from agilab import run_manifest
+
+
+SCHEMA = "agilab.run_storyboard.v1"
+RUN_STORY_JSON = "run_story.json"
+RUN_STORY_MARKDOWN = "run_story.md"
+DEFAULT_MANIFEST_PATH = Path("~/log/execute/flight_telemetry/run_manifest.json")
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _resolve_artifact_path(path: str, manifest_path: Path) -> Path:
+    candidate = Path(path).expanduser()
+    if candidate.is_absolute():
+        return candidate
+    return (manifest_path.parent / candidate).resolve(strict=False)
+
+
+def _command_text(argv: Sequence[str]) -> str:
+    return " ".join(shlex.quote(str(part)) for part in argv)
+
+
+def _validation_rows(manifest: run_manifest.RunManifest) -> list[dict[str, Any]]:
+    return [
+        {
+            "label": validation.label,
+            "status": validation.status,
+            "summary": validation.summary,
+        }
+        for validation in manifest.validations
+    ]
+
+
+def _artifact_rows(
+    manifest: run_manifest.RunManifest,
+    manifest_path: Path,
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for artifact in manifest.artifacts:
+        path = _resolve_artifact_path(artifact.path, manifest_path)
+        exists = path.exists()
+        row: dict[str, Any] = {
+            "name": artifact.name,
+            "kind": artifact.kind,
+            "path": str(path),
+            "exists": exists,
+            "size_bytes": path.stat().st_size if exists and path.is_file() else artifact.size_bytes,
+        }
+        if exists and path.is_file():
+            row["sha256"] = _sha256(path)
+        rows.append(row)
+    return rows
+
+
+def _headline(manifest: run_manifest.RunManifest) -> str:
+    if run_manifest.manifest_passed(manifest):
+        return f"{manifest.label} passed for {manifest.environment.app_name}."
+    if manifest.status == "fail":
+        return f"{manifest.label} failed for {manifest.environment.app_name}."
+    return f"{manifest.label} finished with unknown status for {manifest.environment.app_name}."
+
+
+def _next_actions(
+    manifest: run_manifest.RunManifest,
+    artifact_rows: Sequence[Mapping[str, Any]],
+) -> list[str]:
+    missing_artifacts = [row["name"] for row in artifact_rows if not row.get("exists")]
+    failing_validations = [
+        validation.label
+        for validation in manifest.validations
+        if validation.status not in {"pass", "ok"}
+    ]
+    if missing_artifacts:
+        return [
+            "Regenerate missing artifacts before sharing the run.",
+            "Missing artifacts: " + ", ".join(sorted(str(item) for item in missing_artifacts)),
+        ]
+    if failing_validations:
+        return [
+            "Fix or rerun the failing validation step before promoting the evidence.",
+            "Failing validations: " + ", ".join(sorted(failing_validations)),
+        ]
+    if run_manifest.manifest_passed(manifest):
+        return [
+            "Share run_story.md with reviewers as the human-readable run summary.",
+            "Attach run_story.json when a downstream tool needs structured evidence.",
+            "Run `agilab prove <run_manifest.json>` when a portable proof pack is required.",
+        ]
+    return ["Rerun the manifest-producing command until the status is pass or fail."]
+
+
+def build_run_story(manifest_path: Path) -> dict[str, Any]:
+    """Return a deterministic story payload for ``manifest_path``."""
+
+    resolved_manifest_path = manifest_path.expanduser().resolve(strict=False)
+    manifest = run_manifest.load_run_manifest(resolved_manifest_path)
+    artifacts = _artifact_rows(manifest, resolved_manifest_path)
+    validations = _validation_rows(manifest)
+    summary = run_manifest.manifest_summary(manifest)
+    argv = list(manifest.command.argv)
+    return {
+        "schema": SCHEMA,
+        "status": manifest.status,
+        "manifest_path": str(resolved_manifest_path),
+        "story": {
+            "headline": _headline(manifest),
+            "run_id": manifest.run_id,
+            "path_id": manifest.path_id,
+            "label": manifest.label,
+            "app_name": manifest.environment.app_name,
+            "duration_seconds": manifest.timing.duration_seconds,
+            "target_seconds": manifest.timing.target_seconds,
+            "artifact_count": summary["artifact_count"],
+            "validation_count": len(validations),
+        },
+        "command": {
+            "label": manifest.command.label,
+            "argv": argv,
+            "text": _command_text(argv),
+            "cwd": manifest.command.cwd,
+            "env_override_keys": sorted(manifest.command.env_overrides),
+        },
+        "environment": {
+            "python_version": manifest.environment.python_version,
+            "platform": manifest.environment.platform,
+            "repo_root": manifest.environment.repo_root,
+            "active_app": manifest.environment.active_app,
+        },
+        "validations": validations,
+        "artifacts": artifacts,
+        "next_actions": _next_actions(manifest, artifacts),
+        "provenance": {
+            "source": "run_manifest",
+            "source_schema": run_manifest.MANIFEST_KIND,
+            "source_schema_version": run_manifest.SCHEMA_VERSION,
+            "executes_commands": False,
+            "executes_network_probe": False,
+            "safe_for_public_evidence": True,
+        },
+    }
+
+
+def render_markdown(story: Mapping[str, Any]) -> str:
+    """Render ``story`` as a compact Markdown run storyboard."""
+
+    story_summary = dict(story.get("story", {}))
+    command = dict(story.get("command", {}))
+    environment = dict(story.get("environment", {}))
+    validations = [row for row in story.get("validations", []) if isinstance(row, Mapping)]
+    artifacts = [row for row in story.get("artifacts", []) if isinstance(row, Mapping)]
+    next_actions = [str(action) for action in story.get("next_actions", [])]
+
+    lines = [
+        f"# {story_summary.get('headline', 'AGILAB run story')}",
+        "",
+        "## Run",
+        "",
+        f"- Status: `{story.get('status', 'unknown')}`",
+        f"- Run ID: `{story_summary.get('run_id', '')}`",
+        f"- Path: `{story_summary.get('path_id', '')}`",
+        f"- App: `{story_summary.get('app_name', '')}`",
+        f"- Duration: `{story_summary.get('duration_seconds', 0.0)}` seconds",
+        "",
+        "## Command",
+        "",
+        f"- Label: `{command.get('label', '')}`",
+        f"- CWD: `{command.get('cwd', '')}`",
+        "",
+        "```bash",
+        str(command.get("text", "")),
+        "```",
+        "",
+        "## Environment",
+        "",
+        f"- Python: `{environment.get('python_version', '')}`",
+        f"- Platform: `{environment.get('platform', '')}`",
+        f"- Active app: `{environment.get('active_app', '')}`",
+        "",
+        "## Validations",
+        "",
+    ]
+    if validations:
+        lines.extend(
+            f"- `{row.get('status', 'unknown')}` {row.get('label', '')}: {row.get('summary', '')}"
+            for row in validations
+        )
+    else:
+        lines.append("- No validation rows were recorded.")
+
+    lines.extend(["", "## Artifacts", ""])
+    if artifacts:
+        lines.extend(
+            (
+                f"- `{row.get('name', '')}`: "
+                f"{'present' if row.get('exists') else 'missing'} "
+                f"at `{row.get('path', '')}`"
+            )
+            for row in artifacts
+        )
+    else:
+        lines.append("- No artifacts were recorded.")
+
+    lines.extend(["", "## Next Actions", ""])
+    if next_actions:
+        lines.extend(f"- {action}" for action in next_actions)
+    else:
+        lines.append("- No next action was generated.")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def write_run_storyboard(
+    manifest_path: Path,
+    output_dir: Path | None = None,
+) -> dict[str, Any]:
+    """Write JSON and Markdown story files and return their paths."""
+
+    resolved_manifest_path = manifest_path.expanduser().resolve(strict=False)
+    story = build_run_story(resolved_manifest_path)
+    target_dir = output_dir.expanduser() if output_dir else resolved_manifest_path.parent / "run_story"
+    target_dir.mkdir(parents=True, exist_ok=True)
+    json_path = target_dir / RUN_STORY_JSON
+    markdown_path = target_dir / RUN_STORY_MARKDOWN
+    json_path.write_text(json.dumps(story, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    markdown_path.write_text(render_markdown(story), encoding="utf-8")
+    return {
+        "schema": "agilab.run_storyboard.paths.v1",
+        "status": story["status"],
+        "manifest_path": str(resolved_manifest_path),
+        "output_dir": str(target_dir),
+        "paths": {
+            "json": str(json_path),
+            "markdown": str(markdown_path),
+        },
+        "story": story["story"],
+        "next_actions": story["next_actions"],
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Create a shareable AGILAB run storyboard from run_manifest.json."
+    )
+    parser.add_argument(
+        "manifest",
+        nargs="?",
+        help="Path to run_manifest.json. Defaults to the first-proof manifest location.",
+    )
+    parser.add_argument("--output-dir", help="Directory for run_story.json and run_story.md.")
+    parser.add_argument("--json", action="store_true", help="Print JSON output.")
+    parser.add_argument("--strict", action="store_true", help="Exit non-zero when the run did not pass.")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    manifest_path = Path(args.manifest).expanduser() if args.manifest else DEFAULT_MANIFEST_PATH.expanduser()
+    payload = write_run_storyboard(
+        manifest_path,
+        Path(args.output_dir).expanduser() if args.output_dir else None,
+    )
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(f"run story: {payload['status']}")
+        print(f"markdown: {payload['paths']['markdown']}")
+        print(f"json: {payload['paths']['json']}")
+    return 1 if args.strict and payload["status"] != "pass" else 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/test/test_run_storyboard.py
+++ b/test/test_run_storyboard.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+RUN_MANIFEST_PATH = Path("src/agilab/run_manifest.py").resolve()
+STORYBOARD_PATH = Path("src/agilab/run_storyboard.py").resolve()
+LAB_RUN_PATH = Path("src/agilab/lab_run.py").resolve()
+
+
+def _load_module(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_manifest(tmp_path: Path, *, status: str = "pass") -> Path:
+    run_manifest = _load_module(RUN_MANIFEST_PATH, "run_manifest_for_storyboard_test")
+    active_app = tmp_path / "flight_telemetry_project"
+    active_app.mkdir()
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    artifact = tmp_path / "trajectory_summary.json"
+    artifact.write_text('{"rows": 3}\n', encoding="utf-8")
+    manifest = run_manifest.build_run_manifest(
+        path_id="source-checkout-first-proof",
+        label="Source checkout first proof",
+        status=status,
+        command=run_manifest.RunManifestCommand(
+            label="newcomer first proof",
+            argv=("agilab", "first-proof", "--json"),
+            cwd=str(repo_root),
+            env_overrides={"OPENAI_API_KEY": "redacted-by-caller"},
+        ),
+        environment=run_manifest.RunManifestEnvironment(
+            python_version="3.13.0",
+            python_executable="/venv/bin/python",
+            platform="test-platform",
+            repo_root=str(repo_root),
+            active_app=str(active_app),
+            app_name=active_app.name,
+        ),
+        timing=run_manifest.RunManifestTiming(
+            started_at="2026-05-30T00:00:00Z",
+            finished_at="2026-05-30T00:00:05Z",
+            duration_seconds=5.0,
+            target_seconds=600.0,
+        ),
+        artifacts=[run_manifest.RunManifestArtifact.from_path(artifact)],
+        validations=[
+            run_manifest.RunManifestValidation(
+                label="proof_steps",
+                status=status,
+                summary="all proof steps passed" if status == "pass" else "proof failed",
+            )
+        ],
+        run_id="story-demo",
+        created_at="2026-05-30T00:00:05Z",
+    )
+    return run_manifest.write_run_manifest(manifest, tmp_path / "run_manifest.json")
+
+
+def test_run_storyboard_builds_shareable_story(tmp_path: Path) -> None:
+    module = _load_module(STORYBOARD_PATH, "run_storyboard_test_module")
+    manifest_path = _write_manifest(tmp_path)
+
+    story = module.build_run_story(manifest_path)
+
+    assert story["schema"] == "agilab.run_storyboard.v1"
+    assert story["status"] == "pass"
+    assert story["story"]["headline"] == (
+        "Source checkout first proof passed for flight_telemetry_project."
+    )
+    assert story["command"]["text"] == "agilab first-proof --json"
+    assert story["command"]["env_override_keys"] == ["OPENAI_API_KEY"]
+    assert story["artifacts"][0]["exists"] is True
+    assert len(story["artifacts"][0]["sha256"]) == 64
+    assert story["provenance"] == {
+        "source": "run_manifest",
+        "source_schema": "agilab.run_manifest",
+        "source_schema_version": 1,
+        "executes_commands": False,
+        "executes_network_probe": False,
+        "safe_for_public_evidence": True,
+    }
+
+
+def test_run_storyboard_writes_json_and_markdown(tmp_path: Path) -> None:
+    module = _load_module(STORYBOARD_PATH, "run_storyboard_write_test_module")
+    manifest_path = _write_manifest(tmp_path)
+    output_dir = tmp_path / "story"
+
+    result = module.write_run_storyboard(manifest_path, output_dir)
+
+    markdown_path = Path(result["paths"]["markdown"])
+    json_path = Path(result["paths"]["json"])
+    assert markdown_path.read_text(encoding="utf-8").startswith(
+        "# Source checkout first proof passed"
+    )
+    assert json.loads(json_path.read_text(encoding="utf-8"))["schema"] == (
+        "agilab.run_storyboard.v1"
+    )
+
+
+def test_run_storyboard_strict_fails_on_failed_manifest(tmp_path: Path) -> None:
+    module = _load_module(STORYBOARD_PATH, "run_storyboard_cli_test_module")
+    manifest_path = _write_manifest(tmp_path, status="fail")
+
+    assert module.main([str(manifest_path), "--output-dir", str(tmp_path / "story")]) == 0
+    assert module.main([str(manifest_path), "--output-dir", str(tmp_path / "story"), "--strict"]) == 1
+
+
+def test_lab_run_routes_storyboard(monkeypatch) -> None:
+    lab_run = _load_module(LAB_RUN_PATH, "lab_run_storyboard_route_test_module")
+    captured = {}
+
+    class _Storyboard:
+        @staticmethod
+        def main(argv):
+            captured["argv"] = argv
+            return 0
+
+    monkeypatch.setitem(sys.modules, "agilab.run_storyboard", _Storyboard)
+
+    assert lab_run.main(["story", "run_manifest.json", "--json"]) == 0
+    assert captured["argv"] == ["run_manifest.json", "--json"]


### PR DESCRIPTION
## Summary

Adds a dependency-light `agilab story` command that turns a `run_manifest.json` into a shareable one-run storyboard:

- writes `run_story.md` for human review
- writes `run_story.json` for tools/CI/chat ingestion
- hashes present artifacts and summarizes validations
- keeps command override values out of the story, exposing only environment variable names
- records that the command is read-only and performs no replay or network probe

## Validation

- `UV_PYTHON=3.13 uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_lab_run.py test/test_run_storyboard.py`
- `UV_PYTHON=3.13 uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_run_storyboard.py test/test_run_manifest.py`
- `UV_PYTHON=3.13 uv --preview-features extra-build-dependencies run --extra dev ruff check src/agilab/run_storyboard.py src/agilab/lab_run.py test/test_run_storyboard.py`
- `UV_PYTHON=3.13 uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp`
- `UV_PYTHON=3.13 uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs`
