### PR TITLE
Add promotion dossier handoff command

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 233,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "3c9a31ef98cc1c94da26842af2ee0d9d1305dcac090371c89b9616e28d7ab184",
+  "source_digest_sha256": "e405f561f95d1da2b6ae93db56d5802d920dcda27f522442a17a7c3f62fb370a",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "3c9a31ef98cc1c94da26842af2ee0d9d1305dcac090371c89b9616e28d7ab184"
+  "target_digest_sha256": "e405f561f95d1da2b6ae93db56d5802d920dcda27f522442a17a7c3f62fb370a"
 }

--- a/docs/source/proof-capsule.rst
+++ b/docs/source/proof-capsule.rst
@@ -91,6 +91,7 @@ The shipped first layer operates on a run manifest:
    agilab replay ~/log/execute/flight_telemetry/run_manifest.json
    agilab replay proof.agipack
    agilab story ~/log/execute/flight_telemetry/run_manifest.json --output-dir proof-pack/story
+   agilab promotion-dossier ~/log/execute/flight_telemetry/run_manifest.json --output-dir proof-pack/promotion
    agilab export-lineage ~/log/execute/flight_telemetry/run_manifest.json --format all --output-dir proof-pack
    agilab export-traces proof.agipack --output-dir proof-pack
    agilab policy-check ~/log/execute/flight_telemetry/run_manifest.json --strict
@@ -105,6 +106,7 @@ The proof pack includes:
 * RO-Crate metadata
 * OpenTelemetry-shaped trace JSON
 * ``run_story.json`` and ``run_story.md`` for a shareable one-run summary
+* ``promotion_dossier.md`` plus ``promotion_decision.json`` for handoff review
 * a local metadata-store entry
 * model, dataset, prompt, and evaluation cards generated from available
   manifest evidence
@@ -134,6 +136,23 @@ keeps only environment-variable names from command overrides, and writes:
 The command is read-only: it does not replay the run, call network services, or
 execute recorded commands. Use it when a reviewer needs to understand what
 happened after one AGILAB run without opening logs or notebooks first.
+
+Promotion dossier
+-----------------
+
+``agilab promotion-dossier`` is the production-handoff view of the same
+manifest. It does not deploy or serve a model. Instead it writes a deterministic
+review package:
+
+* ``promotion_decision.json`` with ``promote``, ``block``, or
+  ``manual-review``.
+* ``promotion_dossier.md`` for human reviewers.
+* ``evidence_manifest.json`` with dossier file hashes and source artifacts.
+* ``policy_results.json``, ``lineage.json``, ``mlflow_export.json``, and
+  ``replay.sh`` for downstream systems.
+
+Use it when a run needs a clear handoff package before MLflow, Kubeflow,
+SageMaker, a CI promotion gate, or another production stack takes ownership.
 
 Minimal trust policy example:
 

--- a/src/agilab/lab_run.py
+++ b/src/agilab/lab_run.py
@@ -169,6 +169,12 @@ def _run_storyboard(argv: list[str]) -> int:
     return run_storyboard.main(argv)
 
 
+def _run_promotion_dossier(argv: list[str]) -> int:
+    from agilab import promotion_dossier
+
+    return promotion_dossier.main(argv)
+
+
 def _run_evidence_contract(argv: list[str]) -> int:
     from agilab import evidence_contract
 
@@ -249,6 +255,12 @@ def main(argv: list[str] | None = None) -> int:
         return _run_adoption_report(raw_argv[1:])
     if raw_argv[:1] in (["story"], ["storyboard"], ["run-story"], ["run_story"]):
         return _run_storyboard(raw_argv[1:])
+    if raw_argv[:1] in (
+        ["dossier"],
+        ["promotion-dossier"],
+        ["promotion_dossier"],
+    ):
+        return _run_promotion_dossier(raw_argv[1:])
     if raw_argv[:1] in (
         ["prove"],
         ["verify"],

--- a/src/agilab/promotion_dossier.py
+++ b/src/agilab/promotion_dossier.py
@@ -1,0 +1,303 @@
+"""Generate a deterministic AGILAB promotion handoff dossier."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import shlex
+from typing import Any, Mapping, Sequence
+
+from agilab import bridge_cli, evidence_contract, run_manifest, run_storyboard
+
+
+SCHEMA = "agilab.promotion_dossier.v1"
+DECISION_SCHEMA = "agilab.promotion_decision.v1"
+EVIDENCE_MANIFEST_SCHEMA = "agilab.promotion_evidence_manifest.v1"
+PROMOTION_DECISION_JSON = "promotion_decision.json"
+PROMOTION_DOSSIER_MARKDOWN = "promotion_dossier.md"
+EVIDENCE_MANIFEST_JSON = "evidence_manifest.json"
+POLICY_RESULTS_JSON = "policy_results.json"
+LINEAGE_JSON = "lineage.json"
+MLFLOW_EXPORT_JSON = "mlflow_export.json"
+REPLAY_SCRIPT = "replay.sh"
+
+
+def _write_json(path: Path, payload: Mapping[str, Any]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def _write_text(path: Path, text: str, *, executable: bool = False) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    if executable:
+        path.chmod(path.stat().st_mode | 0o111)
+    return path
+
+
+def _file_row(path: Path, *, id_: str, kind: str) -> dict[str, Any]:
+    exists = path.exists()
+    row: dict[str, Any] = {
+        "id": id_,
+        "kind": kind,
+        "path": str(path),
+        "exists": exists,
+    }
+    if exists and path.is_file():
+        row["size_bytes"] = path.stat().st_size
+        row["sha256"] = evidence_contract.sha256_file(path)
+    return row
+
+
+def _failed_items(rows: Sequence[Mapping[str, Any]]) -> list[str]:
+    return [
+        str(row.get("id", row.get("label", "")))
+        for row in rows
+        if str(row.get("status", "unknown")) not in {"pass", "ok"}
+    ]
+
+
+def _decision(
+    manifest: run_manifest.RunManifest,
+    policy_results: Mapping[str, Any],
+    verification: Mapping[str, Any],
+) -> dict[str, Any]:
+    failed_policy_rules = _failed_items(
+        [row for row in policy_results.get("rules", []) if isinstance(row, Mapping)]
+    )
+    failed_verification_checks = _failed_items(
+        [row for row in verification.get("checks", []) if isinstance(row, Mapping)]
+    )
+    blockers = sorted(set(failed_policy_rules or failed_verification_checks))
+    if manifest.status == "pass" and policy_results.get("status") == "pass":
+        decision = "promote"
+        reason = "policy_passed"
+    elif manifest.status == "fail" or blockers:
+        decision = "block"
+        reason = "policy_failed" if blockers else "manifest_failed"
+    else:
+        decision = "manual-review"
+        reason = "insufficient_evidence"
+    return {
+        "schema": DECISION_SCHEMA,
+        "decision": decision,
+        "reason": reason,
+        "status": "pass" if decision == "promote" else "fail",
+        "run_id": manifest.run_id,
+        "path_id": manifest.path_id,
+        "label": manifest.label,
+        "app_name": manifest.environment.app_name,
+        "manifest_status": manifest.status,
+        "policy_status": str(policy_results.get("status", "unknown")),
+        "verification_status": str(verification.get("status", "unknown")),
+        "blockers": blockers,
+        "next_action": _next_action(decision, blockers),
+        "created_at": run_manifest.utc_now(),
+    }
+
+
+def _next_action(decision: str, blockers: Sequence[str]) -> str:
+    if decision == "promote":
+        return "Hand off the dossier with the candidate artifact to the target MLOps or review stack."
+    if blockers:
+        return "Fix the blocking evidence checks, rerun the AGILAB proof, then regenerate the dossier."
+    return "Ask an operator to review the dossier because the policy did not produce a clear pass/fail result."
+
+
+def _replay_script(manifest: run_manifest.RunManifest) -> str:
+    command = " ".join(shlex.quote(str(part)) for part in manifest.command.argv)
+    cwd = shlex.quote(manifest.command.cwd or ".")
+    return "\n".join(
+        [
+            "#!/usr/bin/env bash",
+            "set -euo pipefail",
+            f"cd {cwd}",
+            command,
+            "",
+        ]
+    )
+
+
+def _render_markdown(
+    *,
+    decision: Mapping[str, Any],
+    story: Mapping[str, Any],
+    policy_results: Mapping[str, Any],
+    files: Sequence[Mapping[str, Any]],
+) -> str:
+    story_summary = dict(story.get("story", {}))
+    lines = [
+        f"# Promotion dossier: {decision.get('label', 'AGILAB run')}",
+        "",
+        "## Decision",
+        "",
+        f"- Decision: `{decision.get('decision', 'manual-review')}`",
+        f"- Reason: `{decision.get('reason', '')}`",
+        f"- Next action: {decision.get('next_action', '')}",
+        "",
+        "## Run Summary",
+        "",
+        f"- App: `{decision.get('app_name', '')}`",
+        f"- Run ID: `{decision.get('run_id', '')}`",
+        f"- Path ID: `{decision.get('path_id', '')}`",
+        f"- Duration: `{story_summary.get('duration_seconds', 0.0)}` seconds",
+        f"- Artifact count: `{story_summary.get('artifact_count', 0)}`",
+        "",
+        "## Policy Results",
+        "",
+    ]
+    rules = [row for row in policy_results.get("rules", []) if isinstance(row, Mapping)]
+    if rules:
+        lines.extend(
+            f"- `{row.get('status', 'unknown')}` {row.get('id', '')}: {row.get('summary', '')}"
+            for row in rules
+        )
+    else:
+        lines.append("- No policy rules were recorded.")
+
+    lines.extend(["", "## Dossier Files", ""])
+    lines.extend(
+        f"- `{row.get('id', '')}`: `{row.get('path', '')}`"
+        for row in files
+        if row.get("exists")
+    )
+    lines.extend(
+        [
+            "",
+            "## Boundary",
+            "",
+            "This dossier is a deterministic handoff artifact. It does not deploy, serve, or certify a model by itself.",
+        ]
+    )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_promotion_dossier(
+    manifest_path: Path,
+    output_dir: Path | None = None,
+    *,
+    policy_path: Path | None = None,
+) -> dict[str, Any]:
+    """Build and write a promotion dossier for one AGILAB run manifest."""
+
+    resolved_manifest_path = manifest_path.expanduser().resolve(strict=False)
+    manifest = run_manifest.load_run_manifest(resolved_manifest_path)
+    target_dir = output_dir.expanduser() if output_dir else resolved_manifest_path.parent / "promotion_dossier"
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    verification = evidence_contract.verify_manifest(resolved_manifest_path)
+    policy_results = evidence_contract.evaluate_policy(
+        manifest,
+        resolved_manifest_path,
+        policy_path=policy_path,
+    )
+    story = run_storyboard.build_run_story(resolved_manifest_path)
+    decision = _decision(manifest, policy_results, verification)
+    lineage = evidence_contract.build_openlineage_event(manifest, resolved_manifest_path)
+
+    paths = {
+        "promotion_decision": target_dir / PROMOTION_DECISION_JSON,
+        "policy_results": target_dir / POLICY_RESULTS_JSON,
+        "lineage": target_dir / LINEAGE_JSON,
+        "mlflow_export": target_dir / MLFLOW_EXPORT_JSON,
+        "run_story_json": target_dir / run_storyboard.RUN_STORY_JSON,
+        "run_story_markdown": target_dir / run_storyboard.RUN_STORY_MARKDOWN,
+        "replay": target_dir / REPLAY_SCRIPT,
+        "promotion_dossier": target_dir / PROMOTION_DOSSIER_MARKDOWN,
+        "evidence_manifest": target_dir / EVIDENCE_MANIFEST_JSON,
+    }
+
+    _write_json(paths["promotion_decision"], decision)
+    _write_json(paths["policy_results"], policy_results)
+    _write_json(paths["lineage"], lineage)
+    bridge_cli.export_mlflow_handoff(resolved_manifest_path, paths["mlflow_export"])
+    _write_json(paths["run_story_json"], story)
+    _write_text(paths["run_story_markdown"], run_storyboard.render_markdown(story))
+    _write_text(paths["replay"], _replay_script(manifest), executable=True)
+
+    dossier_file_rows = [
+        _file_row(paths["promotion_decision"], id_="promotion_decision", kind="decision"),
+        _file_row(paths["policy_results"], id_="policy_results", kind="policy"),
+        _file_row(paths["lineage"], id_="lineage", kind="openlineage"),
+        _file_row(paths["mlflow_export"], id_="mlflow_export", kind="mlflow"),
+        _file_row(paths["run_story_json"], id_="run_story_json", kind="story-json"),
+        _file_row(paths["run_story_markdown"], id_="run_story_markdown", kind="story-markdown"),
+        _file_row(paths["replay"], id_="replay", kind="script"),
+    ]
+    _write_text(
+        paths["promotion_dossier"],
+        _render_markdown(
+            decision=decision,
+            story=story,
+            policy_results=policy_results,
+            files=dossier_file_rows,
+        ),
+    )
+    dossier_file_rows.append(
+        _file_row(paths["promotion_dossier"], id_="promotion_dossier", kind="markdown")
+    )
+    evidence_manifest = {
+        "schema": EVIDENCE_MANIFEST_SCHEMA,
+        "status": decision["status"],
+        "decision": decision["decision"],
+        "manifest_path": str(resolved_manifest_path),
+        "manifest_sha256": evidence_contract.sha256_file(resolved_manifest_path),
+        "policy_path": str(policy_path.expanduser()) if policy_path else "",
+        "source_artifacts": story["artifacts"],
+        "dossier_files": dossier_file_rows,
+    }
+    _write_json(paths["evidence_manifest"], evidence_manifest)
+    dossier_file_rows.append(
+        _file_row(paths["evidence_manifest"], id_="evidence_manifest", kind="manifest")
+    )
+
+    return {
+        "schema": SCHEMA,
+        "status": decision["status"],
+        "decision": decision["decision"],
+        "reason": decision["reason"],
+        "manifest_path": str(resolved_manifest_path),
+        "output_dir": str(target_dir),
+        "paths": {key: str(path) for key, path in sorted(paths.items())},
+        "blockers": decision["blockers"],
+        "next_action": decision["next_action"],
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Create a production-handoff promotion dossier from run_manifest.json."
+    )
+    parser.add_argument(
+        "manifest",
+        nargs="?",
+        help="Path to run_manifest.json. Defaults to the first-proof manifest location.",
+    )
+    parser.add_argument("--output-dir", help="Directory for the dossier files.")
+    parser.add_argument("--policy", help="Optional JSON/TOML policy file.")
+    parser.add_argument("--json", action="store_true", help="Print JSON output.")
+    parser.add_argument("--strict", action="store_true", help="Exit non-zero unless the decision is promote.")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    manifest_path = Path(args.manifest).expanduser() if args.manifest else run_storyboard.DEFAULT_MANIFEST_PATH.expanduser()
+    payload = build_promotion_dossier(
+        manifest_path,
+        Path(args.output_dir).expanduser() if args.output_dir else None,
+        policy_path=Path(args.policy).expanduser() if args.policy else None,
+    )
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(f"promotion dossier: {payload['decision']} ({payload['reason']})")
+        print(f"output_dir: {payload['output_dir']}")
+    return 1 if args.strict and payload["decision"] != "promote" else 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/test/test_promotion_dossier.py
+++ b/test/test_promotion_dossier.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+RUN_MANIFEST_PATH = Path("src/agilab/run_manifest.py").resolve()
+PROMOTION_DOSSIER_PATH = Path("src/agilab/promotion_dossier.py").resolve()
+LAB_RUN_PATH = Path("src/agilab/lab_run.py").resolve()
+
+
+def _load_module(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_manifest(tmp_path: Path, *, status: str = "pass") -> Path:
+    run_manifest = _load_module(RUN_MANIFEST_PATH, f"run_manifest_for_dossier_{status}")
+    active_app = tmp_path / "flight_telemetry_project"
+    active_app.mkdir()
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    artifact = tmp_path / "trajectory_summary.json"
+    artifact.write_text('{"rows": 3}\n', encoding="utf-8")
+    manifest = run_manifest.build_run_manifest(
+        path_id="source-checkout-first-proof",
+        label="Source checkout first proof",
+        status=status,
+        command=run_manifest.RunManifestCommand(
+            label="newcomer first proof",
+            argv=(sys.executable, "-c", "print('ok')"),
+            cwd=str(repo_root),
+            env_overrides={"OPENAI_API_KEY": "<redacted>"},
+        ),
+        environment=run_manifest.RunManifestEnvironment(
+            python_version="3.13.0",
+            python_executable=sys.executable,
+            platform="test-platform",
+            repo_root=str(repo_root),
+            active_app=str(active_app),
+            app_name=active_app.name,
+        ),
+        timing=run_manifest.RunManifestTiming(
+            started_at="2026-05-30T00:00:00Z",
+            finished_at="2026-05-30T00:00:05Z",
+            duration_seconds=5.0,
+            target_seconds=600.0,
+        ),
+        artifacts=[run_manifest.RunManifestArtifact.from_path(artifact)],
+        validations=[
+            run_manifest.RunManifestValidation(
+                label="proof_steps",
+                status=status,
+                summary="all proof steps passed" if status == "pass" else "proof failed",
+            )
+        ],
+        run_id=f"dossier-{status}",
+        created_at="2026-05-30T00:00:05Z",
+    )
+    return run_manifest.write_run_manifest(manifest, tmp_path / "run_manifest.json")
+
+
+def test_promotion_dossier_promotes_passing_manifest(tmp_path: Path) -> None:
+    module = _load_module(PROMOTION_DOSSIER_PATH, "promotion_dossier_test_module")
+    manifest_path = _write_manifest(tmp_path)
+
+    result = module.build_promotion_dossier(manifest_path, tmp_path / "dossier")
+
+    assert result["schema"] == "agilab.promotion_dossier.v1"
+    assert result["decision"] == "promote"
+    assert result["status"] == "pass"
+    expected_files = {
+        "promotion_decision",
+        "promotion_dossier",
+        "evidence_manifest",
+        "policy_results",
+        "lineage",
+        "mlflow_export",
+        "run_story_json",
+        "run_story_markdown",
+        "replay",
+    }
+    assert set(result["paths"]) == expected_files
+    for path in result["paths"].values():
+        assert Path(path).is_file()
+
+    decision = json.loads(Path(result["paths"]["promotion_decision"]).read_text(encoding="utf-8"))
+    assert decision["decision"] == "promote"
+    assert decision["policy_status"] == "pass"
+
+    evidence_manifest = json.loads(Path(result["paths"]["evidence_manifest"]).read_text(encoding="utf-8"))
+    assert evidence_manifest["schema"] == "agilab.promotion_evidence_manifest.v1"
+    assert {row["id"] for row in evidence_manifest["dossier_files"]} >= {
+        "promotion_decision",
+        "policy_results",
+        "run_story_json",
+    }
+    assert evidence_manifest["source_artifacts"][0]["sha256"]
+    assert "Decision: `promote`" in Path(result["paths"]["promotion_dossier"]).read_text(encoding="utf-8")
+
+
+def test_promotion_dossier_blocks_failed_manifest_and_strict_exits(tmp_path: Path) -> None:
+    module = _load_module(PROMOTION_DOSSIER_PATH, "promotion_dossier_block_test_module")
+    manifest_path = _write_manifest(tmp_path, status="fail")
+    output_dir = tmp_path / "dossier"
+
+    result = module.build_promotion_dossier(manifest_path, output_dir)
+
+    assert result["decision"] == "block"
+    assert "validations_pass" in result["blockers"]
+    assert module.main([str(manifest_path), "--output-dir", str(output_dir)]) == 0
+    assert module.main([str(manifest_path), "--output-dir", str(output_dir), "--strict"]) == 1
+
+
+def test_lab_run_routes_promotion_dossier(monkeypatch) -> None:
+    import agilab
+
+    lab_run = _load_module(LAB_RUN_PATH, "lab_run_promotion_dossier_route_test_module")
+    captured = {}
+
+    class _PromotionDossier:
+        @staticmethod
+        def main(argv):
+            captured["argv"] = argv
+            return 0
+
+    monkeypatch.setitem(sys.modules, "agilab.promotion_dossier", _PromotionDossier)
+    monkeypatch.setattr(agilab, "promotion_dossier", _PromotionDossier, raising=False)
+
+    assert lab_run.main(["promotion-dossier", "run_manifest.json", "--json"]) == 0
+    assert captured["argv"] == ["run_manifest.json", "--json"]

--- a/test/test_run_storyboard.py
+++ b/test/test_run_storyboard.py
@@ -117,6 +117,8 @@ def test_run_storyboard_strict_fails_on_failed_manifest(tmp_path: Path) -> None:
 
 
 def test_lab_run_routes_storyboard(monkeypatch) -> None:
+    import agilab
+
     lab_run = _load_module(LAB_RUN_PATH, "lab_run_storyboard_route_test_module")
     captured = {}
 
@@ -127,6 +129,7 @@ def test_lab_run_routes_storyboard(monkeypatch) -> None:
             return 0
 
     monkeypatch.setitem(sys.modules, "agilab.run_storyboard", _Storyboard)
+    monkeypatch.setattr(agilab, "run_storyboard", _Storyboard, raising=False)
 
     assert lab_run.main(["story", "run_manifest.json", "--json"]) == 0
     assert captured["argv"] == ["run_manifest.json", "--json"]


### PR DESCRIPTION
## Summary
- add `agilab dossier` / `promotion-dossier` CLI routes for read-only promotion handoff evidence
- generate deterministic promotion dossier artifacts: decision, evidence manifest, policy results, lineage, MLflow export, run story, and replay script
- document the handoff flow in proof-capsule docs and add regression coverage

## Validation
- `UV_PYTHON=3.13 uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_lab_run.py test/test_promotion_dossier.py test/test_run_storyboard.py`
- `UV_PYTHON=3.13 uv --preview-features extra-build-dependencies run --extra dev ruff check src/agilab/promotion_dossier.py src/agilab/lab_run.py test/test_promotion_dossier.py test/test_run_storyboard.py`
- `UV_PYTHON=3.13 uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp`
- `UV_PYTHON=3.13 uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files docs/.docs_source_mirror_stamp.json docs/source/proof-capsule.rst src/agilab/lab_run.py src/agilab/promotion_dossier.py test/test_promotion_dossier.py test/test_run_storyboard.py`
- `UV_PYTHON=3.13 uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs`
