### PR TITLE
Fix coverage shard for proof handoff tests

### DIFF
--- a/test/test_coverage_shard_plan.py
+++ b/test/test_coverage_shard_plan.py
@@ -66,6 +66,8 @@ def test_static_plan_preserves_fallback_chunks_when_timings_are_missing(tmp_path
     ]
     assert "test/test_notebook_demo.py" in chunks["pipeline"]
     assert "test/test_notebook_import_sample.py" in chunks["pipeline"]
+    assert "test/test_promotion_dossier.py" in chunks["pipeline"]
+    assert "test/test_run_storyboard.py" in chunks["pipeline"]
     assert "test/test_pypi_app_packages.py" in chunks["pages-rest"]
     assert "test/test_agi_pages_chart_spec.py" in chunks["pages-rest"]
     assert "test/test_*_report.py" not in chunks["reports"]

--- a/tools/coverage_shard_plan.py
+++ b/tools/coverage_shard_plan.py
@@ -96,6 +96,8 @@ STATIC_AGI_GUI_CHUNKS: tuple[tuple[str, tuple[str, ...]], ...] = (
             "test/test_first_proof_cli.py",
             "test/test_first_proof_wizard.py",
             "test/test_generated_actions.py",
+            "test/test_promotion_dossier.py",
+            "test/test_run_storyboard.py",
             "test/test_notebook_colab_support.py",
             "test/test_notebook_demo.py",
             "test/test_notebook_import_sample.py",


### PR DESCRIPTION
## Summary
- include promotion dossier and run storyboard tests in the AGI-GUI coverage pipeline shard
- assert the static shard plan keeps those tests scheduled

## Validation
- uv --preview-features extra-build-dependencies run --python 3.13 pytest -q -o addopts='' test/test_coverage_shard_plan.py test/test_coverage_workflow.py test/test_promotion_dossier.py test/test_run_storyboard.py
- uv --preview-features extra-build-dependencies run --python 3.13 --extra dev ruff check tools/coverage_shard_plan.py test/test_coverage_shard_plan.py
- git diff --check