### PR TITLE
[codex] refactor first-party page chrome

### DIFF
--- a/src/agilab/apps-pages/view_app_ui/pyproject.toml
+++ b/src/agilab/apps-pages/view_app_ui/pyproject.toml
@@ -13,7 +13,7 @@ keywords = [
     "reproducibility",
 ]
 dependencies = [
-    "agi-pages>=2026.05.25,<2027.0",
+    "agi-pages>=2026.05.30,<2027.0",
     "agi-gui>=2026.05.21,<2027.0",
 ]
 

--- a/src/agilab/apps-pages/view_app_ui/src/view_app_ui/view_app_ui.py
+++ b/src/agilab/apps-pages/view_app_ui/src/view_app_ui/view_app_ui.py
@@ -13,6 +13,7 @@ from typing import Any
 
 import streamlit as st
 from agi_pages.runtime import (
+    configure_streamlit_page,
     ensure_repo_on_path as _page_ensure_repo_on_path,
     resolve_active_app_path,
 )
@@ -23,7 +24,7 @@ PAGE_KEY = "view_app_ui"
 
 def _safe_page_config() -> None:
     try:
-        st.set_page_config(page_title="App UI", layout="wide")
+        configure_streamlit_page(st, title="App UI")
     except Exception:
         pass
 

--- a/src/agilab/apps-pages/view_data_io_decision/pyproject.toml
+++ b/src/agilab/apps-pages/view_data_io_decision/pyproject.toml
@@ -13,7 +13,7 @@ keywords = [
     "reproducibility",
 ]
 dependencies = [
-    "agi-pages>=2026.05.25,<2027.0",
+    "agi-pages>=2026.05.30,<2027.0",
     "agi-env>=2026.05.12.post3,<2027.0",
     "agi-node>=2026.05.12.post3,<2027.0",
     "agi-gui>=2026.05.12.post3,<2027.0",

--- a/src/agilab/apps-pages/view_data_io_decision/src/view_data_io_decision/view_data_io_decision.py
+++ b/src/agilab/apps-pages/view_data_io_decision/src/view_data_io_decision/view_data_io_decision.py
@@ -12,9 +12,11 @@ import pandas as pd
 import streamlit as st
 from agi_pages.runtime import (
     artifact_root as _page_artifact_root,
+    configure_streamlit_page,
     discover_files as _page_discover_files,
     ensure_repo_on_path as _page_ensure_repo_on_path,
     relative_label as _page_relative_label,
+    render_streamlit_page_header,
     resolve_active_app_path,
     reset_scoped_session_state,
 )
@@ -27,7 +29,6 @@ def _ensure_repo_on_path() -> None:
 _ensure_repo_on_path()
 
 from agi_env import AgiEnv
-from agi_gui.pagelib import render_logo
 
 ARTIFACT_ROOT_KEY = "decision_evidence_artifact_root"
 RUN_SELECTION_KEY = "decision_evidence_selected_run"
@@ -94,7 +95,7 @@ def _read_csv_if_present(path: Path) -> pd.DataFrame:
         return pd.DataFrame()
 
 
-st.set_page_config(layout="wide")
+configure_streamlit_page(st, title="Decision evidence")
 
 active_app_path = _resolve_active_app()
 app_scope_changed = _reset_app_scoped_session_defaults(active_app_path)
@@ -105,11 +106,14 @@ if "env" not in st.session_state or app_scope_changed:
 else:
     env = st.session_state["env"]
 
-render_logo("Decision Evidence")
-st.title("Decision evidence")
-st.caption(
-    "Inspect exported decision artifacts: pipeline generation, failure injection, "
-    "re-planning, and final evidence."
+render_streamlit_page_header(
+    st,
+    title="Decision evidence",
+    logo_title="Decision Evidence",
+    caption=(
+        "Inspect exported decision artifacts: pipeline generation, failure injection, "
+        "re-planning, and final evidence."
+    ),
 )
 
 default_root = _default_artifact_root(env)

--- a/src/agilab/apps-pages/view_forecast_analysis/pyproject.toml
+++ b/src/agilab/apps-pages/view_forecast_analysis/pyproject.toml
@@ -13,7 +13,7 @@ keywords = [
     "reproducibility",
 ]
 dependencies = [
-    "agi-pages>=2026.05.25,<2027.0",
+    "agi-pages>=2026.05.30,<2027.0",
     "agi-env>=2026.05.12.post3,<2027.0",
     "agi-gui>=2026.05.12.post3,<2027.0",
     "agi-node>=2026.05.12.post3,<2027.0",

--- a/src/agilab/apps-pages/view_forecast_analysis/src/view_forecast_analysis/view_forecast_analysis.py
+++ b/src/agilab/apps-pages/view_forecast_analysis/src/view_forecast_analysis/view_forecast_analysis.py
@@ -13,9 +13,11 @@ import streamlit as st
 from agi_pages.runtime import (
     active_app_scope_value,
     artifact_root as _page_artifact_root,
+    configure_streamlit_page,
     discover_files as _page_discover_files,
     env_app_scope_value,
     ensure_repo_on_path as _page_ensure_repo_on_path,
+    render_streamlit_page_header,
     resolve_active_app_path,
     reset_scoped_session_state,
     safe_float,
@@ -29,7 +31,6 @@ def _ensure_repo_on_path() -> None:
 _ensure_repo_on_path()
 
 from agi_env import AgiEnv
-from agi_gui.pagelib import render_logo
 
 
 PAGE_KEY = "view_forecast_analysis"
@@ -97,14 +98,15 @@ def _load_predictions(path: Path) -> pd.DataFrame:
     return df
 
 
-st.set_page_config(layout="wide")
+configure_streamlit_page(st, title="Forecast analysis")
 
 env = _ensure_app_scoped_env()
 
-render_logo("Forecast Analysis")
-st.title("Forecast analysis")
-st.caption(
-    "Use exported metrics and prediction files to compare runs without reopening the notebooks."
+render_streamlit_page_header(
+    st,
+    title="Forecast analysis",
+    logo_title="Forecast Analysis",
+    caption="Use exported metrics and prediction files to compare runs without reopening the notebooks.",
 )
 
 default_root = _default_artifact_root(env)

--- a/src/agilab/apps-pages/view_inference_analysis/pyproject.toml
+++ b/src/agilab/apps-pages/view_inference_analysis/pyproject.toml
@@ -13,6 +13,7 @@ keywords = [
     "reproducibility",
 ]
 dependencies = [
+    "agi-pages>=2026.05.30,<2027.0",
     "agi-env>=2026.05.12.post3,<2027.0",
     "agi-node>=2026.05.12.post3,<2027.0",
     "agi-gui>=2026.05.12.post3,<2027.0",
@@ -43,6 +44,7 @@ Changelog = "https://github.com/ThalesGroup/agilab/releases"
 
 
 [tool.uv.sources]
+agi-pages = { path = "../../lib/agi-pages", editable = true }
 agi-gui = { path = "../../lib/agi-gui", editable = true }
 agi-env = { path = "../../core/agi-env", editable = true }
 agi-node = { path = "../../core/agi-node", editable = true }

--- a/src/agilab/apps-pages/view_inference_analysis/src/view_inference_analysis/view_inference_analysis.py
+++ b/src/agilab/apps-pages/view_inference_analysis/src/view_inference_analysis/view_inference_analysis.py
@@ -39,9 +39,14 @@ def _ensure_repo_on_path() -> None:
 
 _ensure_repo_on_path()
 
-from agi_pages.runtime import active_app_scope_value, env_app_scope_value, reset_scoped_session_state
+from agi_pages.runtime import (
+    active_app_scope_value,
+    configure_streamlit_page,
+    env_app_scope_value,
+    render_streamlit_page_header,
+    reset_scoped_session_state,
+)
 from agi_env import AgiEnv
-from agi_gui.pagelib import render_logo
 
 
 PAGE_KEY = "view_inference_analysis"
@@ -1384,7 +1389,7 @@ def _render_heatmap_section(
 
 
 def main() -> None:
-    st.set_page_config(page_title=PAGE_TITLE, layout="wide")
+    configure_streamlit_page(st, title=PAGE_TITLE)
 
     active_app_path = _resolve_active_app()
     _reset_state_for_active_app(active_app_path)
@@ -1424,11 +1429,14 @@ def main() -> None:
     st.session_state.setdefault(GLOBS_KEY, "\n".join(default_globs))
     st.session_state.setdefault(AGGREGATION_KEY, default_aggregation)
 
-    render_logo(PAGE_LOGO)
-    st.title(PAGE_TITLE)
-    st.caption(
-        "Inspect `allocations_steps` exports across several runs without hard-coding a specific project. "
-        "The page flattens nested step payloads and focuses on load, latency, bearer, and flow-level diagnostics."
+    render_streamlit_page_header(
+        st,
+        title=PAGE_TITLE,
+        logo_title=PAGE_LOGO,
+        caption=(
+            "Inspect `allocations_steps` exports across several runs without hard-coding a specific project. "
+            "The page flattens nested step payloads and focuses on load, latency, bearer, and flow-level diagnostics."
+        ),
     )
 
     with st.sidebar:

--- a/src/agilab/apps-pages/view_live_artifacts/pyproject.toml
+++ b/src/agilab/apps-pages/view_live_artifacts/pyproject.toml
@@ -14,7 +14,7 @@ keywords = [
     "evidence",
 ]
 dependencies = [
-    "agi-pages>=2026.05.25,<2027.0",
+    "agi-pages>=2026.05.30,<2027.0",
     "agi-env>=2026.05.12.post3,<2027.0",
     "agi-gui>=2026.05.12.post3,<2027.0",
     "agi-node>=2026.05.12.post3,<2027.0",

--- a/src/agilab/apps-pages/view_live_artifacts/src/view_live_artifacts/view_live_artifacts.py
+++ b/src/agilab/apps-pages/view_live_artifacts/src/view_live_artifacts/view_live_artifacts.py
@@ -12,8 +12,14 @@ from pathlib import Path
 from typing import Any, Iterable
 
 import streamlit as st
-from agi_pages.runtime import ensure_repo_on_path as _page_ensure_repo_on_path
-from agi_pages.runtime import relative_label, reset_scoped_session_state, resolve_active_app_path
+from agi_pages.runtime import (
+    configure_streamlit_page,
+    ensure_repo_on_path as _page_ensure_repo_on_path,
+    relative_label,
+    render_streamlit_page_header,
+    reset_scoped_session_state,
+    resolve_active_app_path,
+)
 
 
 PAGE_KEY = "view_live_artifacts"
@@ -90,7 +96,6 @@ def _ensure_repo_on_path() -> None:
 _ensure_repo_on_path()
 
 from agi_env import AgiEnv
-from agi_gui.pagelib import render_logo
 
 
 def parse_patterns(raw_value: str | Iterable[str] | None) -> tuple[str, ...]:
@@ -424,14 +429,17 @@ def _render_live_or_static_panel(root: Path, patterns: tuple[str, ...], max_file
 
 
 def main() -> None:
-    st.set_page_config(layout="wide")
+    configure_streamlit_page(st, title="Live artifacts")
     active_app_path = _resolve_active_app()
     _reset_app_scoped_session_state(active_app_path)
     env = _active_env(active_app_path)
 
-    render_logo("Live Artifacts")
-    st.title("Live artifacts")
-    st.caption("Monitor exported evidence, manifests, logs, and lightweight artifacts for the active app.")
+    render_streamlit_page_header(
+        st,
+        title="Live artifacts",
+        logo_title="Live Artifacts",
+        caption="Monitor exported evidence, manifests, logs, and lightweight artifacts for the active app.",
+    )
 
     root, patterns, max_files, live_refresh, interval_seconds = _render_controls(env, active_app_path)
     st.caption(f"Root: {root}")

--- a/src/agilab/apps-pages/view_queue_resilience/pyproject.toml
+++ b/src/agilab/apps-pages/view_queue_resilience/pyproject.toml
@@ -13,7 +13,7 @@ keywords = [
     "reproducibility",
 ]
 dependencies = [
-    "agi-pages>=2026.05.25,<2027.0",
+    "agi-pages>=2026.05.30,<2027.0",
     "agi-env>=2026.05.12.post3,<2027.0",
     "agi-gui>=2026.05.12.post3,<2027.0",
     "agi-node>=2026.05.12.post3,<2027.0",

--- a/src/agilab/apps-pages/view_queue_resilience/src/view_queue_resilience/view_queue_resilience.py
+++ b/src/agilab/apps-pages/view_queue_resilience/src/view_queue_resilience/view_queue_resilience.py
@@ -13,8 +13,10 @@ import pandas as pd
 import streamlit as st
 from agi_pages.runtime import (
     artifact_root as _page_artifact_root,
+    configure_streamlit_page,
     discover_files as _page_discover_files,
     ensure_repo_on_path as _page_ensure_repo_on_path,
+    render_streamlit_page_header,
     resolve_active_app_path,
     reset_scoped_session_state,
     safe_metric,
@@ -28,7 +30,6 @@ def _ensure_repo_on_path() -> None:
 _ensure_repo_on_path()
 
 from agi_env import AgiEnv
-from agi_gui.pagelib import render_logo
 
 
 DATA_DIR_KEY = "queue_resilience_datadir"
@@ -94,7 +95,7 @@ def _safe_metric(value: Any) -> str:
     return safe_metric(value)
 
 
-st.set_page_config(layout="wide")
+configure_streamlit_page(st, title=PAGE_TITLE)
 
 active_app_path = _resolve_active_app()
 app_scope_changed = _reset_app_scoped_session_defaults(active_app_path)
@@ -105,11 +106,14 @@ if "env" not in st.session_state or app_scope_changed:
 else:
     env = st.session_state["env"]
 
-render_logo(PAGE_LOGO)
-st.title(PAGE_TITLE)
-st.caption(
-    "Use exported queue telemetry to inspect backlog, routing pressure, and delivery outcomes "
-    "without reopening the producer code."
+render_streamlit_page_header(
+    st,
+    title=PAGE_TITLE,
+    logo_title=PAGE_LOGO,
+    caption=(
+        "Use exported queue telemetry to inspect backlog, routing pressure, and delivery outcomes "
+        "without reopening the producer code."
+    ),
 )
 st.info(
     "Each run also writes `pipeline/topology.gml`, `pipeline/allocations_steps.csv`, "

--- a/src/agilab/apps-pages/view_relay_resilience/pyproject.toml
+++ b/src/agilab/apps-pages/view_relay_resilience/pyproject.toml
@@ -13,7 +13,7 @@ keywords = [
     "reproducibility",
 ]
 dependencies = [
-    "agi-pages>=2026.05.25,<2027.0",
+    "agi-pages>=2026.05.30,<2027.0",
     "agi-env>=2026.05.12.post3,<2027.0",
     "agi-gui>=2026.05.12.post3,<2027.0",
     "agi-node>=2026.05.12.post3,<2027.0",

--- a/src/agilab/apps-pages/view_relay_resilience/src/view_relay_resilience/view_relay_resilience.py
+++ b/src/agilab/apps-pages/view_relay_resilience/src/view_relay_resilience/view_relay_resilience.py
@@ -12,9 +12,11 @@ import pandas as pd
 import streamlit as st
 from agi_pages.runtime import (
     artifact_root as _page_artifact_root,
+    configure_streamlit_page,
     discover_files as _page_discover_files,
     ensure_repo_on_path as _page_ensure_repo_on_path,
     relative_label as _page_relative_label,
+    render_streamlit_page_header,
     resolve_active_app_path,
     reset_scoped_session_state,
     safe_metric,
@@ -28,7 +30,6 @@ def _ensure_repo_on_path() -> None:
 _ensure_repo_on_path()
 
 from agi_env import AgiEnv
-from agi_gui.pagelib import render_logo
 
 RUN_SELECTION_KEY = "relay_resilience_selected_runs"
 DETAIL_RUN_KEY = "relay_resilience_detail_run"
@@ -182,7 +183,7 @@ def _build_max_queue_comparison_frame(selected_paths: dict[str, Path]) -> pd.Dat
     return pd.concat(queue_frames, axis=1).sort_index()
 
 
-st.set_page_config(layout="wide")
+configure_streamlit_page(st, title="Relay resilience analysis")
 
 active_app_path = _resolve_active_app()
 app_scope_changed = _reset_app_scoped_session_defaults(active_app_path)
@@ -193,11 +194,14 @@ if "env" not in st.session_state or app_scope_changed:
 else:
     env = st.session_state["env"]
 
-render_logo("Relay Resilience Analysis")
-st.title("Relay resilience analysis")
-st.caption(
-    "Use exported relay-queue telemetry to compare routing policies, queue hotspots, and delivery outcomes "
-    "without reopening the producer code."
+render_streamlit_page_header(
+    st,
+    title="Relay resilience analysis",
+    logo_title="Relay Resilience Analysis",
+    caption=(
+        "Use exported relay-queue telemetry to compare routing policies, queue hotspots, and delivery outcomes "
+        "without reopening the producer code."
+    ),
 )
 st.info(
     "Each run also writes `pipeline/topology.gml`, `pipeline/allocations_steps.csv`, "

--- a/src/agilab/apps-pages/view_release_decision/pyproject.toml
+++ b/src/agilab/apps-pages/view_release_decision/pyproject.toml
@@ -13,6 +13,7 @@ keywords = [
     "reproducibility",
 ]
 dependencies = [
+    "agi-pages>=2026.05.30,<2027.0",
     "agi-env>=2026.05.12.post3,<2027.0",
     "agi-gui>=2026.05.12.post3,<2027.0",
     "agi-node>=2026.05.12.post3,<2027.0",
@@ -42,6 +43,7 @@ Changelog = "https://github.com/ThalesGroup/agilab/releases"
 
 
 [tool.uv.sources]
+agi-pages = { path = "../../lib/agi-pages", editable = true }
 agi-gui = { path = "../../lib/agi-gui", editable = true }
 agi-env = { path = "../../core/agi-env", editable = true }
 agi-node = { path = "../../core/agi-node", editable = true }

--- a/src/agilab/apps-pages/view_release_decision/src/view_release_decision/view_release_decision.py
+++ b/src/agilab/apps-pages/view_release_decision/src/view_release_decision/view_release_decision.py
@@ -43,10 +43,13 @@ def _ensure_repo_on_path() -> None:
 
 _ensure_repo_on_path()
 
-from agi_pages.runtime import reset_scoped_session_state
+from agi_pages.runtime import (
+    configure_streamlit_page,
+    render_streamlit_page_header,
+    reset_scoped_session_state,
+)
 from agi_env import AgiEnv
 from agi_env.connector_registry import ConnectorPathRegistry, build_connector_path_registry
-from agi_gui.pagelib import render_logo
 from agilab.data_connector_facility import (
     DEFAULT_CONNECTORS_RELATIVE_PATH,
     load_connector_catalog,
@@ -2096,7 +2099,7 @@ def _render_release_decision_connector_live_ui(
     )
 
 
-st.set_page_config(layout="wide")
+configure_streamlit_page(st, title="Evidence cockpit")
 
 if "env" not in st.session_state:
     active_app_path = _resolve_active_app()
@@ -2107,10 +2110,14 @@ else:
     env = st.session_state["env"]
 _reset_app_scoped_session_defaults(st, env)
 
-render_logo("Evidence Cockpit")
-st.title("Evidence cockpit")
-st.caption(
-    "Review baseline versus candidate evidence, explain gate failures, and export a portable promotion decision."
+render_streamlit_page_header(
+    st,
+    title="Evidence cockpit",
+    logo_title="Evidence Cockpit",
+    caption=(
+        "Review baseline versus candidate evidence, explain gate failures, "
+        "and export a portable promotion decision."
+    ),
 )
 
 connector_registry = _connector_path_registry(env)

--- a/src/agilab/apps-pages/view_routing_model_comparison/pyproject.toml
+++ b/src/agilab/apps-pages/view_routing_model_comparison/pyproject.toml
@@ -14,7 +14,7 @@ keywords = [
     "reproducibility",
 ]
 dependencies = [
-    "agi-pages>=2026.05.25,<2027.0",
+    "agi-pages>=2026.05.30,<2027.0",
     "agi-env>=2026.05.12.post3,<2027.0",
     "agi-node>=2026.05.12.post3,<2027.0",
     "agi-gui>=2026.05.12.post3,<2027.0",

--- a/src/agilab/apps-pages/view_routing_model_comparison/src/view_routing_model_comparison/view_routing_model_comparison.py
+++ b/src/agilab/apps-pages/view_routing_model_comparison/src/view_routing_model_comparison/view_routing_model_comparison.py
@@ -17,7 +17,9 @@ from plotly.subplots import make_subplots
 import streamlit as st
 import tomllib
 from agi_pages.runtime import (
+    configure_streamlit_page,
     ensure_repo_on_path as _page_ensure_repo_on_path,
+    render_streamlit_page_header,
     resolve_active_app_path,
     reset_scoped_session_state,
 )
@@ -56,7 +58,6 @@ def _ensure_repo_on_path() -> None:
 _ensure_repo_on_path()
 
 from agi_env import AgiEnv  # noqa: E402
-from agi_gui.pagelib import render_logo  # noqa: E402
 
 
 def _resolve_active_app() -> Path:
@@ -692,15 +693,14 @@ def _format_summary(summary_df: pd.DataFrame) -> pd.DataFrame:
 
 
 def main() -> None:
-    st.set_page_config(page_title="Routing Model Comparison", layout="wide")
+    configure_streamlit_page(st, title="Routing Model Comparison")
     env = _ensure_app_scoped_env()
     active_app_path = _resolve_active_app()
     settings = _load_app_settings(active_app_path)
     defaults = _page_defaults(settings)
     default_root = _default_pipeline_root(env, defaults)
 
-    render_logo()
-    st.title("Routing Model Comparison")
+    render_streamlit_page_header(st, title="Routing Model Comparison")
 
     pipeline_dir_text = st.sidebar.text_input(
         "Pipeline directory",

--- a/src/agilab/apps-pages/view_scenario_cockpit/pyproject.toml
+++ b/src/agilab/apps-pages/view_scenario_cockpit/pyproject.toml
@@ -13,7 +13,7 @@ keywords = [
     "reproducibility",
 ]
 dependencies = [
-    "agi-pages>=2026.05.25,<2027.0",
+    "agi-pages>=2026.05.30,<2027.0",
     "agi-env>=2026.05.12.post3,<2027.0",
     "agi-gui>=2026.05.12.post3,<2027.0",
     "agi-node>=2026.05.12.post3,<2027.0",

--- a/src/agilab/apps-pages/view_scenario_cockpit/src/view_scenario_cockpit/view_scenario_cockpit.py
+++ b/src/agilab/apps-pages/view_scenario_cockpit/src/view_scenario_cockpit/view_scenario_cockpit.py
@@ -13,7 +13,9 @@ import pandas as pd
 import streamlit as st
 from agi_pages.runtime import (
     artifact_root as _page_artifact_root,
+    configure_streamlit_page,
     ensure_repo_on_path as _page_ensure_repo_on_path,
+    render_streamlit_page_header,
     resolve_active_app_path,
     reset_scoped_session_state,
 )
@@ -26,7 +28,6 @@ def _ensure_repo_on_path() -> None:
 _ensure_repo_on_path()
 
 from agi_env import AgiEnv
-from agi_gui.pagelib import render_logo
 
 
 RUN_SELECTION_KEY = "scenario_cockpit_selected_runs"
@@ -139,7 +140,7 @@ _candidate_gate = _evidence_helpers.candidate_gate
 _build_evidence_bundle = _evidence_helpers.build_evidence_bundle
 
 
-st.set_page_config(layout="wide")
+configure_streamlit_page(st, title=PAGE_TITLE)
 
 active_app_path = _resolve_active_app()
 app_scope_changed = _reset_app_scoped_session_defaults(active_app_path)
@@ -150,11 +151,14 @@ if "env" not in st.session_state or app_scope_changed:
 else:
     env = st.session_state["env"]
 
-render_logo(PAGE_LOGO)
-st.title(PAGE_TITLE)
-st.caption(
-    "Compare exported scenario runs, choose a baseline and candidate, then download a hashed evidence bundle "
-    "that explains the promotion decision."
+render_streamlit_page_header(
+    st,
+    title=PAGE_TITLE,
+    logo_title=PAGE_LOGO,
+    caption=(
+        "Compare exported scenario runs, choose a baseline and candidate, then download a hashed evidence bundle "
+        "that explains the promotion decision."
+    ),
 )
 st.info(
     "This page reuses the queue-analysis artifact contract exported by the UAV queue and relay demos. "

--- a/src/agilab/apps-pages/view_shap_explanation/pyproject.toml
+++ b/src/agilab/apps-pages/view_shap_explanation/pyproject.toml
@@ -13,7 +13,7 @@ keywords = [
     "reproducibility",
 ]
 dependencies = [
-    "agi-pages>=2026.05.25,<2027.0",
+    "agi-pages>=2026.05.30,<2027.0",
     "agi-env>=2026.05.13,<2027.0",
     "agi-gui>=2026.05.13,<2027.0",
     "agi-node>=2026.05.13,<2027.0",

--- a/src/agilab/apps-pages/view_shap_explanation/src/view_shap_explanation/view_shap_explanation.py
+++ b/src/agilab/apps-pages/view_shap_explanation/src/view_shap_explanation/view_shap_explanation.py
@@ -12,10 +12,12 @@ import streamlit as st
 from agi_pages.runtime import (
     active_app_scope_value,
     artifact_root as _page_artifact_root,
+    configure_streamlit_page,
     discover_files as _page_discover_files,
     env_app_scope_value,
     ensure_repo_on_path as _page_ensure_repo_on_path,
     load_json_object,
+    render_streamlit_page_header,
     resolve_active_app_path,
     reset_scoped_session_state,
     safe_float,
@@ -42,7 +44,6 @@ def _ensure_repo_on_path() -> None:
 _ensure_repo_on_path()
 
 from agi_env import AgiEnv
-from agi_gui.pagelib import render_logo
 
 
 PAGE_KEY = "view_shap_explanation"
@@ -187,14 +188,15 @@ def _state_text_input(key: str, label: str, default_value: str) -> str:
     return st.sidebar.text_input(label, key=key)
 
 
-st.set_page_config(layout="wide")
+configure_streamlit_page(st, title="SHAP explanation")
 
 env = _ensure_app_scoped_env()
 
-render_logo("SHAP Explanation")
-st.title("SHAP explanation")
-st.caption(
-    "Inspect local feature attributions exported by SHAPKit, shap, or any compatible explainer."
+render_streamlit_page_header(
+    st,
+    title="SHAP explanation",
+    logo_title="SHAP Explanation",
+    caption="Inspect local feature attributions exported by SHAPKit, shap, or any compatible explainer.",
 )
 
 default_root = _default_artifact_root(env)

--- a/src/agilab/apps-pages/view_training_analysis/pyproject.toml
+++ b/src/agilab/apps-pages/view_training_analysis/pyproject.toml
@@ -13,7 +13,7 @@ keywords = [
     "reproducibility",
 ]
 dependencies = [
-    "agi-pages>=2026.05.25,<2027.0",
+    "agi-pages>=2026.05.30,<2027.0",
     "agi-env>=2026.05.12.post3,<2027.0",
     "agi-node>=2026.05.12.post3,<2027.0",
     "agi-gui>=2026.05.12.post3,<2027.0",

--- a/src/agilab/apps-pages/view_training_analysis/src/view_training_analysis/view_training_analysis.py
+++ b/src/agilab/apps-pages/view_training_analysis/src/view_training_analysis/view_training_analysis.py
@@ -18,8 +18,10 @@ import tomllib
 from agi_env.app_settings_support import prepare_app_settings_for_write
 from agi_pages.runtime import (
     active_app_scope_value,
+    configure_streamlit_page,
     env_app_scope_value,
     ensure_repo_on_path as _page_ensure_repo_on_path,
+    render_streamlit_page_header,
     resolve_active_app_path,
     reset_scoped_session_state,
 )
@@ -76,7 +78,6 @@ def _ensure_repo_on_path() -> None:
 _ensure_repo_on_path()
 
 from agi_env import AgiEnv
-from agi_gui.pagelib import render_logo
 
 
 def _resolve_active_app() -> Path:
@@ -627,8 +628,9 @@ def _build_scalar_figure(
 
 def main() -> None:
     embed_mode = _is_embed_mode(getattr(st, "query_params", {}))
-    st.set_page_config(
-        layout="wide",
+    configure_streamlit_page(
+        st,
+        title="Training analysis",
         initial_sidebar_state="collapsed" if embed_mode else "auto",
     )
     if embed_mode:
@@ -641,10 +643,13 @@ def main() -> None:
     if embed_mode:
         st.caption("Training analysis")
     else:
-        render_logo("Training Analysis")
-        st.title("Training analysis")
-        st.caption(
-            "Browse TensorBoard scalar logs or AGILAB training-history artifacts and plot the metrics you need."
+        render_streamlit_page_header(
+            st,
+            title="Training analysis",
+            logo_title="Training Analysis",
+            caption=(
+                "Browse TensorBoard scalar logs or AGILAB training-history artifacts and plot the metrics you need."
+            ),
         )
 
     page_state = _get_page_state()

--- a/src/agilab/lib/agi-pages/src/agi_pages/__init__.py
+++ b/src/agilab/lib/agi-pages/src/agi_pages/__init__.py
@@ -23,13 +23,47 @@ from .chart_spec import (
 )
 from .runtime import (
     artifact_root,
+    configure_streamlit_page,
     discover_files,
     ensure_repo_on_path,
     load_json_object,
     relative_label,
+    render_streamlit_page_header,
     resolve_active_app_path,
     safe_float,
     safe_metric,
+)
+
+__all__ = (
+    "CHART_EVIDENCE_SCHEMA",
+    "CHART_SPEC_SCHEMA",
+    "DEFAULT_ECHARTS_SCRIPT_URL",
+    "PAGE_BUNDLE_ENTRYPOINT_GROUP",
+    "PAGE_BUNDLE_ENTRYPOINT_NAMES",
+    "PUBLIC_PAGE_MODULES",
+    "SUPPORTED_DATASET_CHART_TYPES",
+    "ChartData",
+    "ChartSpec",
+    "PageBundle",
+    "artifact_root",
+    "build_chart_spec",
+    "bundles_root",
+    "chart_spec_to_static_html",
+    "configure_streamlit_page",
+    "discover_files",
+    "ensure_repo_on_path",
+    "iter_bundles",
+    "load_json_object",
+    "normalize_chart_data",
+    "option_from_data",
+    "relative_label",
+    "render_notebook",
+    "render_streamlit",
+    "render_streamlit_page_header",
+    "resolve_active_app_path",
+    "resolve_bundle",
+    "safe_float",
+    "safe_metric",
 )
 
 PAGE_BUNDLE_ENTRYPOINT_NAMES = ("{module}.py", "main.py", "app.py")

--- a/src/agilab/lib/agi-pages/src/agi_pages/runtime.py
+++ b/src/agilab/lib/agi-pages/src/agi_pages/runtime.py
@@ -165,3 +165,47 @@ def safe_metric(value: Any, *, digits: int = 3) -> str:
     if numeric is None:
         return "n/a"
     return f"{numeric:.{digits}f}"
+
+
+def configure_streamlit_page(
+    streamlit: Any,
+    *,
+    title: str,
+    page_title: str | None = None,
+    layout: str = "wide",
+    initial_sidebar_state: str | None = None,
+) -> None:
+    """Configure a Streamlit analysis page with consistent defaults."""
+
+    config: dict[str, Any] = {
+        "page_title": page_title or title,
+        "layout": layout,
+    }
+    if initial_sidebar_state is not None:
+        config["initial_sidebar_state"] = initial_sidebar_state
+    streamlit.set_page_config(**config)
+
+
+def render_streamlit_page_header(
+    streamlit: Any,
+    *,
+    title: str,
+    logo_title: str | None = None,
+    caption: str | None = None,
+    show_logo: bool = True,
+    render_logo_fn: Callable[..., Any] | None = None,
+) -> None:
+    """Render the common AGILAB analysis-page logo, title, and optional caption."""
+
+    if show_logo:
+        if render_logo_fn is None:
+            from agi_gui.pagelib import render_logo as _render_logo
+
+            render_logo_fn = _render_logo
+        if logo_title is None:
+            render_logo_fn()
+        else:
+            render_logo_fn(logo_title)
+    streamlit.title(title)
+    if caption:
+        streamlit.caption(caption)

--- a/src/agilab/page_bootstrap.py
+++ b/src/agilab/page_bootstrap.py
@@ -10,6 +10,13 @@ from typing import Any, Callable
 PAGE_ENV_REALIGNED_STATE_KEY = "_agilab_page_env_realigned"
 
 
+def _default_page_title(page_label: str) -> str:
+    clean_label = str(page_label or "").strip()
+    if not clean_label:
+        return "AGILab"
+    return f"AGILab {clean_label}"
+
+
 def _safe_resolved_path(value: Any) -> Path | None:
     try:
         return Path(value).expanduser().resolve(strict=False)
@@ -202,3 +209,102 @@ def ensure_page_env(
     about_page.main()
     streamlit.rerun()
     return None
+
+
+def configure_page_chrome(
+    streamlit: Any,
+    *,
+    page_label: str,
+    docs_html_file: str,
+    resources_path: str | Path | None = None,
+    layout: str = "wide",
+    page_title: str | None = None,
+    get_docs_menu_items: Callable[..., dict[str, str]] | None = None,
+    inject_theme: Callable[[Any], Any] | None = None,
+) -> None:
+    """Apply the common AGILAB Streamlit page configuration and theme."""
+    if get_docs_menu_items is None:
+        from agilab.page_docs import get_docs_menu_items as _get_docs_menu_items
+
+        get_docs_menu_items = _get_docs_menu_items
+    if inject_theme is None:
+        from agi_gui.pagelib import inject_theme as _inject_theme
+
+        inject_theme = _inject_theme
+
+    streamlit.set_page_config(
+        page_title=page_title or _default_page_title(page_label),
+        layout=layout,
+        menu_items=get_docs_menu_items(html_file=docs_html_file),
+    )
+    if resources_path is not None:
+        inject_theme(resources_path)
+
+
+def render_page_header(
+    streamlit: Any,
+    *,
+    page_label: str,
+    env: Any | None = None,
+    render_logo: Callable[[], Any] | None = None,
+    render_pinned_expanders: Callable[[Any], Any] | None = None,
+    render_page_context: Callable[..., Any] | None = None,
+) -> None:
+    """Render the shared AGILAB sidebar/header affordances for first-party pages."""
+    if render_logo is None:
+        from agi_gui.pagelib import render_logo as _render_logo
+
+        render_logo = _render_logo
+    if render_pinned_expanders is None:
+        from agilab.pinned_expander import (
+            render_pinned_expanders as _render_pinned_expanders,
+        )
+
+        render_pinned_expanders = _render_pinned_expanders
+    if render_page_context is None:
+        from agilab.workflow_ui import render_page_context as _render_page_context
+
+        render_page_context = _render_page_context
+
+    render_logo()
+    render_pinned_expanders(streamlit)
+    render_page_context(streamlit, page_label=page_label, env=env)
+
+
+def render_page_chrome(
+    streamlit: Any,
+    *,
+    env: Any,
+    page_label: str,
+    docs_html_file: str,
+    resources_path: str | Path | None = None,
+    layout: str = "wide",
+    page_title: str | None = None,
+    get_docs_menu_items: Callable[..., dict[str, str]] | None = None,
+    inject_theme: Callable[[Any], Any] | None = None,
+    render_logo: Callable[[], Any] | None = None,
+    render_pinned_expanders: Callable[[Any], Any] | None = None,
+    render_page_context: Callable[..., Any] | None = None,
+) -> None:
+    """Configure and render common AGILAB Streamlit page chrome."""
+    resolved_resources_path = resources_path
+    if resolved_resources_path is None:
+        resolved_resources_path = getattr(env, "st_resources", None)
+    configure_page_chrome(
+        streamlit,
+        page_label=page_label,
+        docs_html_file=docs_html_file,
+        resources_path=resolved_resources_path,
+        layout=layout,
+        page_title=page_title,
+        get_docs_menu_items=get_docs_menu_items,
+        inject_theme=inject_theme,
+    )
+    render_page_header(
+        streamlit,
+        page_label=page_label,
+        env=env,
+        render_logo=render_logo,
+        render_pinned_expanders=render_pinned_expanders,
+        render_page_context=render_page_context,
+    )

--- a/src/agilab/pages/1_PROJECT.py
+++ b/src/agilab/pages/1_PROJECT.py
@@ -59,15 +59,6 @@ _public_bind_guard_module = import_agilab_module(
 )
 _public_bind_guard_module.enforce_public_bind_policy_or_stop(st)
 
-_page_docs_module = import_agilab_module(
-    "agilab.page_docs",
-    current_file=__file__,
-    fallback_path=Path(__file__).resolve().parents[1] / "page_docs.py",
-    fallback_name="agilab_page_docs_fallback",
-)
-get_docs_menu_items = _page_docs_module.get_docs_menu_items
-
-from agi_gui.pagelib import inject_theme
 from agi_gui.pagelib import (
     background_services_enabled,
     get_classes_name,
@@ -75,7 +66,6 @@ from agi_gui.pagelib import (
     get_templates,
     get_projects_zip,
     on_project_change,
-    render_logo,
     activate_mlflow,
 )
 from agi_gui.ux_widgets import compact_choice
@@ -100,6 +90,7 @@ _page_bootstrap_module = import_agilab_module(
     fallback_name="agilab_page_bootstrap_fallback",
 )
 ensure_page_env = _page_bootstrap_module.ensure_page_env
+render_page_chrome = _page_bootstrap_module.render_page_chrome
 
 _pinned_expander_module = import_agilab_module(
     "agilab.pinned_expander",
@@ -107,18 +98,9 @@ _pinned_expander_module = import_agilab_module(
     fallback_path=Path(__file__).resolve().parents[1] / "pinned_expander.py",
     fallback_name="agilab_pinned_expander_fallback",
 )
-render_pinned_expanders = _pinned_expander_module.render_pinned_expanders
 is_pinned_expander = _pinned_expander_module.is_pinned_expander
 remove_pinned_expander = _pinned_expander_module.remove_pinned_expander
 upsert_pinned_expander = _pinned_expander_module.upsert_pinned_expander
-
-_workflow_ui_module = import_agilab_module(
-    "agilab.workflow_ui",
-    current_file=__file__,
-    fallback_path=Path(__file__).resolve().parents[1] / "workflow_ui.py",
-    fallback_name="agilab_workflow_ui_fallback",
-)
-render_page_context = _workflow_ui_module.render_page_context
 
 _environment_health_module = import_agilab_module(
     "agilab.environment_health",
@@ -4655,16 +4637,12 @@ def page():
     st.session_state["_env"] = env
 
     env = st.session_state["_env"]
-    st.set_page_config(
-        page_title="AGILab PROJECT",
-        layout="wide",
-        menu_items=get_docs_menu_items(html_file="edit-help.html"),
+    render_page_chrome(
+        st,
+        env=env,
+        page_label="PROJECT",
+        docs_html_file="edit-help.html",
     )
-    inject_theme(env.st_resources)
-
-    render_logo()
-    render_pinned_expanders(st)
-    render_page_context(st, page_label="PROJECT", env=env)
 
     if background_services_enabled() and not st.session_state.get("server_started"):
         activate_mlflow(env)

--- a/src/agilab/pages/2_ORCHESTRATE.py
+++ b/src/agilab/pages/2_ORCHESTRATE.py
@@ -47,14 +47,6 @@ _public_bind_guard_module = import_agilab_module(
 )
 _public_bind_guard_module.enforce_public_bind_policy_or_stop(st)
 
-_page_docs_module = import_agilab_module(
-    "agilab.page_docs",
-    current_file=__file__,
-    fallback_path=Path(__file__).resolve().parents[1] / "page_docs.py",
-    fallback_name="agilab_page_docs_fallback",
-)
-get_docs_menu_items = _page_docs_module.get_docs_menu_items
-
 import_agilab_symbols(
     globals(),
     "agilab.orchestrate_page_support",
@@ -114,6 +106,7 @@ import_agilab_symbols(
         "PAGE_ENV_REALIGNED_STATE_KEY": "_PAGE_ENV_REALIGNED_STATE_KEY",
         "ensure_page_env": "_ensure_page_env",
         "realign_session_env_with_page_root": "_realign_session_env_with_page_root",
+        "render_page_chrome": "render_page_chrome",
     },
     current_file=__file__,
     fallback_path=Path(__file__).resolve().parents[1] / "page_bootstrap.py",
@@ -121,20 +114,9 @@ import_agilab_symbols(
 )
 import_agilab_symbols(
     globals(),
-    "agilab.pinned_expander",
-    {
-        "render_pinned_expanders": "render_pinned_expanders",
-    },
-    current_file=__file__,
-    fallback_path=Path(__file__).resolve().parents[1] / "pinned_expander.py",
-    fallback_name="agilab_pinned_expander_fallback",
-)
-import_agilab_symbols(
-    globals(),
     "agilab.workflow_ui",
     {
         "is_dag_worker_base": "is_dag_worker_base",
-        "render_page_context": "render_page_context",
         "render_project_evidence_drawer": "render_project_evidence_drawer",
         "render_workflow_timeline": "render_workflow_timeline",
     },
@@ -351,11 +333,9 @@ import_agilab_symbols(
 # Project Libraries:
 from agi_gui.pagelib import (
     background_services_enabled,
-    render_logo,
     activate_mlflow,
     init_custom_ui,
     on_project_change,
-    inject_theme,
     is_valid_ip,
     render_dataframe_preview,
     resolve_active_app,
@@ -2394,15 +2374,12 @@ async def page() -> None:
 
     st.session_state["_env"] = env
 
-    st.set_page_config(
-        page_title="AGILab ORCHESTRATE",
-        layout="wide",
-        menu_items=get_docs_menu_items(html_file="execute-help.html"),
+    render_page_chrome(
+        st,
+        env=env,
+        page_label="ORCHESTRATE",
+        docs_html_file="execute-help.html",
     )
-    inject_theme(env.st_resources)
-    render_logo()
-    render_pinned_expanders(st)
-    render_page_context(st, page_label="ORCHESTRATE", env=env)
 
     if background_services_enabled() and not st.session_state.get("server_started"):
         activate_mlflow(env)

--- a/src/agilab/pages/3_WORKFLOW.py
+++ b/src/agilab/pages/3_WORKFLOW.py
@@ -53,13 +53,6 @@ _page_project_selector_module = load_local_module(
     fallback_name="agilab_page_project_selector_fallback",
 )
 switch_to_project_page = _page_project_selector_module.switch_to_project_page
-_page_docs_module = load_local_module(
-    "agilab.page_docs",
-    current_file=__file__,
-    fallback_path=Path(__file__).resolve().parents[1] / "page_docs.py",
-    fallback_name="agilab_page_docs_fallback",
-)
-get_docs_menu_items = _page_docs_module.get_docs_menu_items
 
 from agi_gui.pagelib import (
     activate_mlflow,
@@ -68,8 +61,6 @@ from agi_gui.pagelib import (
     run_agi,
     load_df,
     resolve_selected_df_path,
-    render_logo,
-    inject_theme,
 )
 from agi_gui.file_picker import agi_file_picker
 from agi_env import AgiEnv
@@ -93,6 +84,7 @@ import_agilab_symbols(
     {
         "ensure_page_env": "_ensure_page_env",
         "load_about_page_module": "_load_about_page_module_impl",
+        "render_page_chrome": "render_page_chrome",
     },
     current_file=__file__,
     fallback_path=Path(__file__).resolve().parents[1] / "page_bootstrap.py",
@@ -100,20 +92,9 @@ import_agilab_symbols(
 )
 import_agilab_symbols(
     globals(),
-    "agilab.pinned_expander",
-    {
-        "render_pinned_expanders": "render_pinned_expanders",
-    },
-    current_file=__file__,
-    fallback_path=Path(__file__).resolve().parents[1] / "pinned_expander.py",
-    fallback_name="agilab_pinned_expander_fallback",
-)
-import_agilab_symbols(
-    globals(),
     "agilab.workflow_ui",
     {
         "is_dag_based_app": "is_dag_based_app",
-        "render_page_context": "render_page_context",
     },
     current_file=__file__,
     fallback_path=Path(__file__).resolve().parents[1] / "workflow_ui.py",
@@ -1659,12 +1640,12 @@ def main() -> None:
     env: AgiEnv = st.session_state["env"]
 
     try:
-        st.set_page_config(
-            page_title="AGILab WORKFLOW",
-            layout="wide",
-            menu_items=get_docs_menu_items(html_file="experiment-help.html"),
+        render_page_chrome(
+            st,
+            env=env,
+            page_label="WORKFLOW",
+            docs_html_file="experiment-help.html",
         )
-        inject_theme(env.st_resources)
 
         st.session_state.setdefault("stages_file_name", STAGES_FILE_NAME)
         st.session_state.setdefault("help_path", Path(env.agilab_pck) / "gui/help")
@@ -1682,16 +1663,6 @@ def main() -> None:
         )
         st.session_state.setdefault("df_file_out", str(df_dir_def / DEFAULT_DF))
         st.session_state.setdefault("df_file", str(df_dir_def / DEFAULT_DF))
-
-        df_file = (
-            Path(st.session_state["df_file"]) if st.session_state["df_file"] else None
-        )
-        if df_file:
-            render_logo()
-        else:
-            render_logo()
-        render_pinned_expanders(st)
-        render_page_context(st, page_label="WORKFLOW", env=env)
 
         if background_services_enabled() and not st.session_state.get(
             "server_started", False

--- a/src/agilab/pages/4_ANALYSIS.py
+++ b/src/agilab/pages/4_ANALYSIS.py
@@ -61,13 +61,6 @@ _public_bind_guard_module = import_agilab_module(
 )
 _public_bind_guard_module.enforce_public_bind_policy_or_stop(st)
 
-_page_docs_module = import_agilab_module(
-    "agilab.page_docs",
-    current_file=__file__,
-    fallback_path=Path(__file__).resolve().parents[1] / "page_docs.py",
-    fallback_name="agilab_page_docs_fallback",
-)
-get_docs_menu_items = _page_docs_module.get_docs_menu_items
 import_agilab_symbols(
     globals(),
     "agilab.analysis_page_state",
@@ -81,20 +74,20 @@ import_agilab_symbols(
 )
 import_agilab_symbols(
     globals(),
-    "agilab.pinned_expander",
+    "agilab.page_bootstrap",
     {
-        "render_pinned_expanders": "render_pinned_expanders",
+        "configure_page_chrome": "configure_page_chrome",
+        "render_page_header": "render_page_header",
     },
     current_file=__file__,
-    fallback_path=Path(__file__).resolve().parents[1] / "pinned_expander.py",
-    fallback_name="agilab_pinned_expander_fallback",
+    fallback_path=Path(__file__).resolve().parents[1] / "page_bootstrap.py",
+    fallback_name="agilab_page_bootstrap_fallback",
 )
 import_agilab_symbols(
     globals(),
     "agilab.workflow_ui",
     {
         "render_project_evidence_drawer": "render_project_evidence_drawer",
-        "render_page_context": "render_page_context",
     },
     current_file=__file__,
     fallback_path=Path(__file__).resolve().parents[1] / "workflow_ui.py",
@@ -139,9 +132,7 @@ import tomli_w  # For writing TOML files (write as binary)
 
 # Project utilities (unchanged)
 from agi_gui.pagelib import (
-    render_logo,
     on_project_change,
-    inject_theme,
 )
 from agi_gui.ux_widgets import compact_choice
 from agi_env import AgiEnv
@@ -393,12 +384,13 @@ def _write_minimal_view_template(
 
 
 # =============== Streamlit page config ==================
-st.set_page_config(
-    layout="wide",
-    menu_items=get_docs_menu_items(html_file="explore-help.html"),
-)
 resources_path = Path(__file__).resolve().parents[1] / "resources"
-inject_theme(resources_path)
+configure_page_chrome(
+    st,
+    page_label="ANALYSIS",
+    docs_html_file="explore-help.html",
+    resources_path=resources_path,
+)
 
 # =============== Helpers: per-view venv sidecar ==================
 
@@ -2781,9 +2773,7 @@ async def main():
         st.query_params["active_app"] = env.app
 
     # Sidebar header/logo
-    render_logo()
-    render_pinned_expanders(st)
-    render_page_context(st, page_label="ANALYSIS", env=env)
+    render_page_header(st, page_label="ANALYSIS", env=env)
 
     # Sidebar: project selection
     projects = env.projects

--- a/test/test_about_agilab_helpers.py
+++ b/test/test_about_agilab_helpers.py
@@ -732,6 +732,106 @@ def test_page_bootstrap_ensure_page_env_delegates_cold_start(tmp_path):
     assert events == ["main", "rerun"]
 
 
+def test_page_bootstrap_configure_page_chrome_sets_docs_title_and_theme(tmp_path):
+    events: list[tuple[str, object]] = []
+    fake_st = SimpleNamespace(
+        set_page_config=lambda **kwargs: events.append(("config", kwargs))
+    )
+
+    def fake_docs_menu_items(*, html_file: str):
+        events.append(("docs", html_file))
+        return {"Get help": html_file}
+
+    def fake_inject_theme(resources_path):
+        events.append(("theme", resources_path))
+
+    page_bootstrap.configure_page_chrome(
+        fake_st,
+        page_label="ANALYSIS",
+        docs_html_file="explore-help.html",
+        resources_path=tmp_path,
+        get_docs_menu_items=fake_docs_menu_items,
+        inject_theme=fake_inject_theme,
+    )
+
+    assert events == [
+        ("docs", "explore-help.html"),
+        (
+            "config",
+            {
+                "page_title": "AGILab ANALYSIS",
+                "layout": "wide",
+                "menu_items": {"Get help": "explore-help.html"},
+            },
+        ),
+        ("theme", tmp_path),
+    ]
+
+
+def test_page_bootstrap_render_page_header_orders_shared_sidebar_context():
+    events: list[tuple[str, object]] = []
+    fake_st = SimpleNamespace()
+    env = SimpleNamespace(app="demo")
+
+    page_bootstrap.render_page_header(
+        fake_st,
+        page_label="PROJECT",
+        env=env,
+        render_logo=lambda: events.append(("logo", None)),
+        render_pinned_expanders=lambda streamlit: events.append(
+            ("pinned", streamlit is fake_st)
+        ),
+        render_page_context=lambda streamlit, **kwargs: events.append(
+            ("context", (streamlit is fake_st, kwargs))
+        ),
+    )
+
+    assert events == [
+        ("logo", None),
+        ("pinned", True),
+        ("context", (True, {"page_label": "PROJECT", "env": env})),
+    ]
+
+
+def test_page_bootstrap_render_page_chrome_uses_env_resources():
+    events: list[tuple[str, object]] = []
+    fake_st = SimpleNamespace(
+        set_page_config=lambda **kwargs: events.append(("config", kwargs))
+    )
+    env = SimpleNamespace(st_resources="/resources")
+
+    page_bootstrap.render_page_chrome(
+        fake_st,
+        env=env,
+        page_label="WORKFLOW",
+        docs_html_file="experiment-help.html",
+        get_docs_menu_items=lambda *, html_file: {"Get help": html_file},
+        inject_theme=lambda resources_path: events.append(("theme", resources_path)),
+        render_logo=lambda: events.append(("logo", None)),
+        render_pinned_expanders=lambda streamlit: events.append(
+            ("pinned", streamlit is fake_st)
+        ),
+        render_page_context=lambda streamlit, **kwargs: events.append(
+            ("context", (streamlit is fake_st, kwargs))
+        ),
+    )
+
+    assert events == [
+        (
+            "config",
+            {
+                "page_title": "AGILab WORKFLOW",
+                "layout": "wide",
+                "menu_items": {"Get help": "experiment-help.html"},
+            },
+        ),
+        ("theme", "/resources"),
+        ("logo", None),
+        ("pinned", True),
+        ("context", (True, {"page_label": "WORKFLOW", "env": env})),
+    ]
+
+
 def test_ensure_env_file_falls_back_to_touch_when_template_read_fails(
     tmp_path, monkeypatch
 ):

--- a/test/test_agi_pages_runtime.py
+++ b/test/test_agi_pages_runtime.py
@@ -75,6 +75,58 @@ def test_agi_pages_runtime_file_helpers_are_deterministic(tmp_path: Path) -> Non
     assert runtime.safe_metric(1.23456, digits=2) == "1.23"
 
 
+def test_agi_pages_runtime_configures_and_renders_streamlit_page_header() -> None:
+    events: list[tuple[str, object]] = []
+    fake_st = SimpleNamespace(
+        set_page_config=lambda **kwargs: events.append(("config", kwargs)),
+        title=lambda value: events.append(("title", value)),
+        caption=lambda value: events.append(("caption", value)),
+    )
+
+    runtime.configure_streamlit_page(
+        fake_st,
+        title="Evidence cockpit",
+        initial_sidebar_state="collapsed",
+    )
+    runtime.render_streamlit_page_header(
+        fake_st,
+        title="Evidence cockpit",
+        logo_title="Evidence Cockpit",
+        caption="Review baseline versus candidate evidence.",
+        render_logo_fn=lambda *args: events.append(("logo", args)),
+    )
+
+    assert events == [
+        (
+            "config",
+            {
+                "page_title": "Evidence cockpit",
+                "layout": "wide",
+                "initial_sidebar_state": "collapsed",
+            },
+        ),
+        ("logo", ("Evidence Cockpit",)),
+        ("title", "Evidence cockpit"),
+        ("caption", "Review baseline versus candidate evidence."),
+    ]
+
+
+def test_agi_pages_runtime_header_can_skip_logo_and_caption() -> None:
+    events: list[tuple[str, object]] = []
+    fake_st = SimpleNamespace(
+        title=lambda value: events.append(("title", value)),
+        caption=lambda value: events.append(("caption", value)),
+    )
+
+    runtime.render_streamlit_page_header(
+        fake_st,
+        title="Embedded training analysis",
+        show_logo=False,
+    )
+
+    assert events == [("title", "Embedded training analysis")]
+
+
 def test_agi_pages_runtime_resets_app_scoped_session_state(tmp_path: Path) -> None:
     first_app = tmp_path / "first"
     second_app = tmp_path / "second"

--- a/test/test_ui_pages.py
+++ b/test/test_ui_pages.py
@@ -421,15 +421,30 @@ def _write_minimal_run_manifest(
 
 def test_first_party_pages_configure_docs_menu_items() -> None:
     expected = {
-        "src/agilab/main_page.py": "get_about_content()",
-        "src/agilab/pages/1_PROJECT.py": 'get_docs_menu_items(html_file="edit-help.html")',
-        "src/agilab/pages/2_ORCHESTRATE.py": 'get_docs_menu_items(html_file="execute-help.html")',
-        "src/agilab/pages/3_WORKFLOW.py": 'get_docs_menu_items(html_file="experiment-help.html")',
-        "src/agilab/pages/4_ANALYSIS.py": 'get_docs_menu_items(html_file="explore-help.html")',
+        "src/agilab/main_page.py": ("get_about_content()",),
+        "src/agilab/pages/1_PROJECT.py": (
+            "render_page_chrome(",
+            'docs_html_file="edit-help.html"',
+        ),
+        "src/agilab/pages/2_ORCHESTRATE.py": (
+            "render_page_chrome(",
+            'docs_html_file="execute-help.html"',
+        ),
+        "src/agilab/pages/3_WORKFLOW.py": (
+            "render_page_chrome(",
+            'docs_html_file="experiment-help.html"',
+        ),
+        "src/agilab/pages/4_ANALYSIS.py": (
+            "configure_page_chrome(",
+            "render_page_header(",
+            'docs_html_file="explore-help.html"',
+        ),
     }
 
-    for page_path, marker in expected.items():
-        assert marker in Path(page_path).read_text(encoding="utf-8")
+    for page_path, markers in expected.items():
+        source = Path(page_path).read_text(encoding="utf-8")
+        for marker in markers:
+            assert marker in source
 
 
 @pytest.fixture
@@ -2109,8 +2124,9 @@ def test_project_sidebar_orders_active_project_before_actions():
     assert "Export creates a portable archive" not in source
     assert "Project workspace" not in source
     assert "Identity, editable files" not in source
-    assert 'page_title="AGILab PROJECT"' in source
-    assert 'layout="wide"' in source
+    assert "render_page_chrome(" in source
+    assert 'page_label="PROJECT"' in source
+    assert 'docs_html_file="edit-help.html"' in source
     assert '["Edit", "Create", "Import", "Rename", "Delete"]' in source
     assert '["Edit", "Clone", "Import", "Rename", "Delete"]' not in source
     assert "_render_project_workspace_overview" not in source

--- a/test/test_view_data_io_decision.py
+++ b/test/test_view_data_io_decision.py
@@ -12,7 +12,7 @@ PAGE_PATH = (
 
 def _load_helpers() -> ModuleType:
     source = Path(PAGE_PATH).read_text(encoding="utf-8")
-    prefix = source.split('\nst.set_page_config(layout="wide")\n', 1)[0]
+    prefix = source.split("\nconfigure_streamlit_page(st,", 1)[0]
     module = ModuleType("view_data_io_decision_test_module")
     module.__file__ = str(Path(PAGE_PATH).resolve())
     module.__package__ = None

--- a/test/test_view_forecast_analysis.py
+++ b/test/test_view_forecast_analysis.py
@@ -48,7 +48,7 @@ def _run_forecast_page(
 
 def _load_forecast_helpers() -> ModuleType:
     source = Path(PAGE_PATH).read_text(encoding="utf-8")
-    prefix = source.split('\nst.set_page_config(layout="wide")\n', 1)[0]
+    prefix = source.split("\nconfigure_streamlit_page(st,", 1)[0]
     module = ModuleType("view_forecast_analysis_test_module")
     module.__file__ = str(Path(PAGE_PATH).resolve())
     module.__package__ = None

--- a/test/test_view_inference_analysis.py
+++ b/test/test_view_inference_analysis.py
@@ -109,6 +109,15 @@ class _FakeStreamlit:
         return [_FakeContext() for _ in range(count)]
 
 
+def _patch_page_header(monkeypatch, module) -> None:
+    def _render_header(streamlit, *, title: str, caption: str | None = None, **_kwargs) -> None:
+        streamlit.title(title)
+        if caption:
+            streamlit.caption(caption)
+
+    monkeypatch.setattr(module, "render_streamlit_page_header", _render_header)
+
+
 def test_view_inference_analysis_builds_routed_latency_percentiles() -> None:
     module = _load_module()
 
@@ -1442,7 +1451,7 @@ def test_view_inference_analysis_main_stops_when_dataset_root_is_missing(monkeyp
     monkeypatch.setattr(module, "st", fake_st)
     monkeypatch.setattr(module, "_resolve_active_app", lambda: active_app)
     monkeypatch.setattr(module, "AgiEnv", _FakeEnv)
-    monkeypatch.setattr(module, "render_logo", lambda *_args, **_kwargs: None)
+    _patch_page_header(monkeypatch, module)
     monkeypatch.setattr(module, "_resolve_base_path", lambda *_args, **_kwargs: tmp_path / "base")
     monkeypatch.setattr(module, "_resolve_dataset_root", lambda *_args, **_kwargs: tmp_path / "missing-root")
 
@@ -1486,7 +1495,7 @@ def test_view_inference_analysis_main_stops_when_dataset_root_is_unresolved(monk
     monkeypatch.setattr(module, "st", fake_st)
     monkeypatch.setattr(module, "_resolve_active_app", lambda: active_app)
     monkeypatch.setattr(module, "AgiEnv", _FakeEnv)
-    monkeypatch.setattr(module, "render_logo", lambda *_args, **_kwargs: None)
+    _patch_page_header(monkeypatch, module)
     monkeypatch.setattr(module, "_resolve_base_path", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(module, "_resolve_dataset_root", lambda *_args, **_kwargs: None)
 
@@ -1521,7 +1530,7 @@ def test_view_inference_analysis_main_stops_when_no_allocation_files_match(
     monkeypatch.setattr(module, "st", fake_st)
     monkeypatch.setattr(module, "_resolve_active_app", lambda: active_app)
     monkeypatch.setattr(module, "AgiEnv", _FakeEnv)
-    monkeypatch.setattr(module, "render_logo", lambda *_args, **_kwargs: None)
+    _patch_page_header(monkeypatch, module)
     monkeypatch.setattr(module, "_resolve_base_path", lambda *_args, **_kwargs: tmp_path / "base")
     monkeypatch.setattr(module, "_resolve_dataset_root", lambda *_args, **_kwargs: dataset_root)
     monkeypatch.setattr(module, "_discover_allocation_files", lambda *_args, **_kwargs: [])
@@ -1562,7 +1571,7 @@ def test_view_inference_analysis_main_handles_no_selection_before_loading_frames
     monkeypatch.setattr(module, "st", fake_st)
     monkeypatch.setattr(module, "_resolve_active_app", lambda: active_app)
     monkeypatch.setattr(module, "AgiEnv", _FakeEnv)
-    monkeypatch.setattr(module, "render_logo", lambda *_args, **_kwargs: None)
+    _patch_page_header(monkeypatch, module)
     monkeypatch.setattr(module, "_resolve_base_path", lambda *_args, **_kwargs: tmp_path / "base")
     monkeypatch.setattr(module, "_resolve_dataset_root", lambda *_args, **_kwargs: dataset_root)
     monkeypatch.setattr(module, "_discover_allocation_files", lambda *_args, **_kwargs: [allocations])
@@ -1620,7 +1629,7 @@ default_metric = "missing_metric"
     monkeypatch.setattr(module, "st", fake_st)
     monkeypatch.setattr(module, "_resolve_active_app", lambda: active_app)
     monkeypatch.setattr(module, "AgiEnv", _FakeEnv)
-    monkeypatch.setattr(module, "render_logo", lambda *_args, **_kwargs: None)
+    _patch_page_header(monkeypatch, module)
     monkeypatch.setattr(module, "_resolve_base_path", lambda *_args, **_kwargs: tmp_path / "base")
     monkeypatch.setattr(module, "_resolve_dataset_root", lambda *_args, **_kwargs: dataset_root)
     monkeypatch.setattr(module, "_discover_allocation_files", lambda *_args, **_kwargs: [empty_path, run_path])
@@ -1666,7 +1675,7 @@ def test_view_inference_analysis_main_renders_no_axis_detail_state(
     monkeypatch.setattr(module, "st", fake_st)
     monkeypatch.setattr(module, "_resolve_active_app", lambda: active_app)
     monkeypatch.setattr(module, "AgiEnv", _FakeEnv)
-    monkeypatch.setattr(module, "render_logo", lambda *_args, **_kwargs: None)
+    _patch_page_header(monkeypatch, module)
     monkeypatch.setattr(module, "_resolve_base_path", lambda *_args, **_kwargs: tmp_path / "base")
     monkeypatch.setattr(module, "_resolve_dataset_root", lambda *_args, **_kwargs: dataset_root)
     monkeypatch.setattr(module, "_discover_allocation_files", lambda *_args, **_kwargs: [run_path])
@@ -1710,7 +1719,7 @@ def test_view_inference_analysis_main_stops_when_selected_files_have_no_numeric_
     monkeypatch.setattr(module, "st", fake_st)
     monkeypatch.setattr(module, "_resolve_active_app", lambda: active_app)
     monkeypatch.setattr(module, "AgiEnv", _FakeEnv)
-    monkeypatch.setattr(module, "render_logo", lambda *_args, **_kwargs: None)
+    _patch_page_header(monkeypatch, module)
     monkeypatch.setattr(module, "_resolve_base_path", lambda *_args, **_kwargs: tmp_path / "base")
     monkeypatch.setattr(module, "_resolve_dataset_root", lambda *_args, **_kwargs: dataset_root)
     monkeypatch.setattr(module, "_discover_allocation_files", lambda *_args, **_kwargs: [allocations])
@@ -1780,7 +1789,7 @@ def test_view_inference_analysis_main_renders_time_series_requested_reference(
     monkeypatch.setattr(module, "st", fake_st)
     monkeypatch.setattr(module, "_resolve_active_app", lambda: active_app)
     monkeypatch.setattr(module, "AgiEnv", _FakeEnv)
-    monkeypatch.setattr(module, "render_logo", lambda *_args, **_kwargs: None)
+    _patch_page_header(monkeypatch, module)
     monkeypatch.setattr(module, "_resolve_base_path", lambda *_args, **_kwargs: tmp_path / "base")
     monkeypatch.setattr(module, "_resolve_dataset_root", lambda *_args, **_kwargs: dataset_root)
     monkeypatch.setattr(module, "_discover_allocation_files", lambda *_args, **_kwargs: [run_a_path, run_b_path])
@@ -1879,7 +1888,7 @@ default_profile_axis = "missing_axis"
     monkeypatch.setattr(module, "st", fake_st)
     monkeypatch.setattr(module, "_resolve_active_app", lambda: active_app)
     monkeypatch.setattr(module, "AgiEnv", _FakeEnv)
-    monkeypatch.setattr(module, "render_logo", lambda *_args, **_kwargs: None)
+    _patch_page_header(monkeypatch, module)
     monkeypatch.setattr(module, "_resolve_base_path", lambda *_args, **_kwargs: tmp_path / "base")
     monkeypatch.setattr(module, "_resolve_dataset_root", lambda *_args, **_kwargs: dataset_root)
     monkeypatch.setattr(module, "_discover_allocation_files", lambda *_args, **_kwargs: [run_a_path, run_b_path])

--- a/test/test_view_live_artifacts.py
+++ b/test/test_view_live_artifacts.py
@@ -461,8 +461,8 @@ def test_live_artifacts_main_wires_page_controls_and_panel(monkeypatch, tmp_path
         def __init__(self) -> None:
             self.session_state = {}
 
-        def set_page_config(self, *, layout: str) -> None:
-            calls.append(("set_page_config", layout))
+        def set_page_config(self, **kwargs: object) -> None:
+            calls.append(("set_page_config", kwargs))
 
         def title(self, value: str) -> None:
             calls.append(("title", value))
@@ -473,7 +473,11 @@ def test_live_artifacts_main_wires_page_controls_and_panel(monkeypatch, tmp_path
     monkeypatch.setattr(module, "st", FakeStreamlit())
     monkeypatch.setattr(module, "_resolve_active_app", lambda: app_path)
     monkeypatch.setattr(module, "_active_env", lambda active_app_path: env)
-    monkeypatch.setattr(module, "render_logo", lambda title: calls.append(("logo", title)))
+    monkeypatch.setattr(
+        module,
+        "render_streamlit_page_header",
+        lambda streamlit, **kwargs: calls.append(("header", kwargs)),
+    )
     monkeypatch.setattr(
         module,
         "_render_controls",
@@ -490,10 +494,15 @@ def test_live_artifacts_main_wires_page_controls_and_panel(monkeypatch, tmp_path
     module.main()
 
     assert calls == [
-        ("set_page_config", "wide"),
-        ("logo", "Live Artifacts"),
-        ("title", "Live artifacts"),
-        ("caption", "Monitor exported evidence, manifests, logs, and lightweight artifacts for the active app."),
+        ("set_page_config", {"page_title": "Live artifacts", "layout": "wide"}),
+        (
+            "header",
+            {
+                "title": "Live artifacts",
+                "logo_title": "Live Artifacts",
+                "caption": "Monitor exported evidence, manifests, logs, and lightweight artifacts for the active app.",
+            },
+        ),
         ("caption", f"Root: {tmp_path / 'artifacts'}"),
         ("panel", (tmp_path / "artifacts", ("**/*.json",), 5, False, 10)),
     ]

--- a/test/test_view_queue_resilience.py
+++ b/test/test_view_queue_resilience.py
@@ -27,7 +27,7 @@ def _page_title() -> str:
 
 def _load_queue_helpers() -> ModuleType:
     source = Path(PAGE_PATH).read_text(encoding="utf-8")
-    prefix = source.split('\nst.set_page_config(layout="wide")\n', 1)[0]
+    prefix = source.split("\nconfigure_streamlit_page(st,", 1)[0]
     module = ModuleType("view_queue_resilience_test_module")
     module.__file__ = str(Path(PAGE_PATH).resolve())
     module.__package__ = None

--- a/test/test_view_relay_resilience.py
+++ b/test/test_view_relay_resilience.py
@@ -78,7 +78,7 @@ def _write_relay_run(
 
 def _load_relay_helpers() -> ModuleType:
     source = Path(PAGE_PATH).read_text(encoding="utf-8")
-    prefix = source.split('\nst.set_page_config(layout="wide")\n', 1)[0]
+    prefix = source.split("\nconfigure_streamlit_page(st,", 1)[0]
     module = ModuleType("view_relay_resilience_test_module")
     module.__file__ = str(Path(PAGE_PATH).resolve())
     module.__package__ = None

--- a/test/test_view_release_decision.py
+++ b/test/test_view_release_decision.py
@@ -378,7 +378,7 @@ def _run_release_page(
 
 def _load_release_helpers() -> ModuleType:
     source = Path(PAGE_PATH).read_text(encoding="utf-8")
-    prefix = source.split('\nst.set_page_config(layout="wide")\n', 1)[0]
+    prefix = source.split("\nconfigure_streamlit_page(st,", 1)[0]
     module = ModuleType("view_release_decision_test_module")
     module.__file__ = str(Path(PAGE_PATH).resolve())
     module.__package__ = None

--- a/test/test_view_scenario_cockpit.py
+++ b/test/test_view_scenario_cockpit.py
@@ -71,7 +71,7 @@ def _write_run(
 
 def _load_helpers() -> ModuleType:
     source = Path(PAGE_PATH).read_text(encoding="utf-8")
-    prefix = source.split('\nst.set_page_config(layout="wide")\n', 1)[0]
+    prefix = source.split("\nconfigure_streamlit_page(st,", 1)[0]
     module = ModuleType("view_scenario_cockpit_test_module")
     module.__file__ = str(Path(PAGE_PATH).resolve())
     module.__package__ = None

--- a/test/test_view_shap_explanation.py
+++ b/test/test_view_shap_explanation.py
@@ -49,7 +49,7 @@ def _run_shap_page(
 
 def _load_shap_helpers() -> ModuleType:
     source = Path(PAGE_PATH).read_text(encoding="utf-8")
-    prefix = source.split('\nst.set_page_config(layout="wide")\n', 1)[0]
+    prefix = source.split("\nconfigure_streamlit_page(st,", 1)[0]
     module = ModuleType("view_shap_explanation_test_module")
     module.__file__ = str(Path(PAGE_PATH).resolve())
     module.__package__ = None

--- a/test/test_view_training_analysis.py
+++ b/test/test_view_training_analysis.py
@@ -34,6 +34,10 @@ def _stop() -> None:
     raise _StopCalled()
 
 
+def _patch_page_header(monkeypatch, module) -> None:
+    monkeypatch.setattr(module, "render_streamlit_page_header", lambda *_args, **_kwargs: None)
+
+
 def test_view_training_analysis_discovers_trainers_and_runs(tmp_path: Path) -> None:
     module = _load_module()
 
@@ -570,7 +574,7 @@ def test_view_training_analysis_main_warns_when_data_root_missing(monkeypatch, t
         warning=warnings_seen.append,
         stop=_stop,
     )
-    monkeypatch.setattr(module, "render_logo", lambda *args, **kwargs: None)
+    _patch_page_header(monkeypatch, module)
 
     with pytest.raises(_StopCalled):
         module.main()
@@ -619,7 +623,7 @@ def test_view_training_analysis_main_bootstraps_env_when_missing(monkeypatch, tm
         plotly_chart=lambda *args, **kwargs: None,
         stop=_stop,
     )
-    monkeypatch.setattr(module, "render_logo", lambda *args, **kwargs: None)
+    _patch_page_header(monkeypatch, module)
     monkeypatch.setattr(module, "_resolve_active_app", lambda: active_app)
     monkeypatch.setattr(module, "AgiEnv", FakeEnv)
     monkeypatch.setattr(module, "_discover_training_roots", lambda root: [])
@@ -699,7 +703,7 @@ def test_view_training_analysis_main_resets_state_when_active_app_changes(
         plotly_chart=lambda *args, **kwargs: None,
         stop=_stop,
     )
-    monkeypatch.setattr(module, "render_logo", lambda *args, **kwargs: None)
+    _patch_page_header(monkeypatch, module)
     monkeypatch.setattr(module, "_resolve_active_app", lambda: new_app)
     monkeypatch.setattr(module, "AgiEnv", FakeEnv)
     monkeypatch.setattr(module, "_discover_training_roots", lambda root: [])
@@ -783,7 +787,7 @@ def test_view_training_analysis_main_plots_selected_metrics(monkeypatch, tmp_pat
         plotly_chart=lambda fig, width=None: plotted.append((fig, width)),
         stop=_stop,
     )
-    monkeypatch.setattr(module, "render_logo", lambda *args, **kwargs: None)
+    _patch_page_header(monkeypatch, module)
     monkeypatch.setattr(module, "_discover_training_roots", lambda root: [trainer_dir])
     monkeypatch.setattr(module, "_discover_run_directories", lambda root: [run_a, run_b])
 
@@ -877,8 +881,8 @@ def test_view_training_analysis_embedded_mode_autoscales_export_target(monkeypat
     )
     monkeypatch.setattr(
         module,
-        "render_logo",
-        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("logo is hidden in embed mode")),
+        "render_streamlit_page_header",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("header is hidden in embed mode")),
     )
 
     def fake_discover_training_roots(data_root: Path) -> list[Path]:
@@ -914,7 +918,9 @@ def test_view_training_analysis_embedded_mode_autoscales_export_target(monkeypat
 
     module.main()
 
-    assert page_configs == [{"layout": "wide", "initial_sidebar_state": "collapsed"}]
+    assert page_configs == [
+        {"page_title": "Training analysis", "layout": "wide", "initial_sidebar_state": "collapsed"}
+    ]
     assert markdown_calls and markdown_calls[0][1] is True
     assert captions == ["Training analysis"]
     assert discovered_roots == [target_root.resolve()]
@@ -1043,7 +1049,7 @@ def test_view_training_analysis_main_warns_when_no_trainers_or_runs(monkeypatch,
             stop=_stop,
         )
 
-    monkeypatch.setattr(module, "render_logo", lambda *args, **kwargs: None)
+    _patch_page_header(monkeypatch, module)
 
     module.st = _base_st()
     monkeypatch.setattr(module, "_discover_training_roots", lambda root: [])
@@ -1101,7 +1107,7 @@ def test_view_training_analysis_main_warns_when_no_trainer_output_selected(monke
         plotly_chart=lambda *args, **kwargs: None,
         stop=_stop,
     )
-    monkeypatch.setattr(module, "render_logo", lambda *args, **kwargs: None)
+    _patch_page_header(monkeypatch, module)
     monkeypatch.setattr(module, "_discover_training_roots", lambda root: [trainer_dir])
 
     with pytest.raises(_StopCalled):
@@ -1169,7 +1175,7 @@ def test_view_training_analysis_main_handles_selection_and_metric_edge_cases(mon
             stop=_stop,
         )
 
-    monkeypatch.setattr(module, "render_logo", lambda *args, **kwargs: None)
+    _patch_page_header(monkeypatch, module)
     monkeypatch.setattr(module, "_discover_training_roots", lambda root: [trainer_dir])
     monkeypatch.setattr(module, "_discover_run_directories", lambda root: [run_a, run_b])
 


### PR DESCRIPTION
## Summary

Refactors repeated first-party Streamlit page chrome into shared helpers in `page_bootstrap.py`, then uses those helpers from Project, Orchestrate, Workflow, and Analysis. This keeps page config, docs menu wiring, theme injection, logo rendering, pinned expanders, and page context consistent across views.

The change also removes a redundant Workflow logo branch and gives Analysis the same explicit browser page title behavior as the other first-party pages.

## Validation

- `uv --preview-features extra-build-dependencies run --python 3.13 --extra dev --extra ui ruff check --extend-ignore E402,F821 src/agilab/page_bootstrap.py src/agilab/pages/1_PROJECT.py src/agilab/pages/2_ORCHESTRATE.py src/agilab/pages/3_WORKFLOW.py src/agilab/pages/4_ANALYSIS.py test/test_about_agilab_helpers.py test/test_ui_pages.py`
- `uv --preview-features extra-build-dependencies run --python 3.13 --extra ui python -m py_compile src/agilab/page_bootstrap.py src/agilab/pages/1_PROJECT.py src/agilab/pages/2_ORCHESTRATE.py src/agilab/pages/3_WORKFLOW.py src/agilab/pages/4_ANALYSIS.py`
- `uv --preview-features extra-build-dependencies run --python 3.13 --extra dev --extra ui pytest -q -o addopts='' test/test_about_agilab_helpers.py test/test_ui_pages.py`
- `uv --preview-features extra-build-dependencies run --python 3.13 --extra dev --extra ui pytest -q -o addopts='' test/test_analysis_page_helpers.py`
- `git diff --check`