### PR TITLE
Improve data quality gate usability

### DIFF
--- a/src/agilab/apps/builtin/data_quality_gate_project/README.md
+++ b/src/agilab/apps/builtin/data_quality_gate_project/README.md
@@ -18,15 +18,26 @@ into a later CI/promotion step.
 Select `data_quality_gate_project`, then open `ORCHESTRATE`. Keep the default
 arguments for the first run, click `INSTALL`, then click `RUN`.
 
-The default configuration creates a deterministic candidate dataset with a small
-business distribution shift. The run should complete locally and write the data
-quality evidence under `data_quality_gate/evidence`.
+The default configuration creates a deterministic candidate dataset with a
+small business distribution shift. The run should complete locally and write
+the data quality evidence under `data_quality_gate/evidence`.
+
+To gate your own data, place two CSV files under the AGILAB share and set
+`baseline_csv` plus `candidate_csv` to their relative paths. Optional
+`contract_json` and `thresholds_json` files can override the default column
+contract and promotion thresholds without editing Python code.
 
 ## Expected Inputs
 
 No external data, API key, cloud service, notebook, model registry, or LLM is
-required. The app generates deterministic baseline and candidate datasets from
-the configured seed, row counts, and drift strength.
+required for the first run. The app can also read user-provided baseline and
+candidate CSV files from the AGILAB share. Contract JSON accepts:
+
+- `columns`: mapping from column name to `{kind, role, required, drift}`.
+- `allow_unexpected_columns`: whether extra candidate columns are accepted.
+- `target_column`, `identifier_columns`, and `leakage_name_patterns`.
+- `thresholds`: optional overrides for PSI, KS, null-rate, duplicate-rate, row
+  count, mean-shift, and category-delta thresholds.
 
 ## Expected Outputs
 
@@ -39,6 +50,9 @@ The worker writes:
 - `data_contract.json`
 - `drift_metrics.csv`
 - `gate_decision.json`
+- `decision_card.json`
+- `data_quality_dashboard.html`
+- `input_sources.json`
 - `data_quality_report.md`
 - `run_manifest.json`
 - `data_quality_gate_summary.json`
@@ -48,10 +62,14 @@ generic artifact readers can inspect it later.
 
 ## Change One Thing
 
-After the default run works, change only `drift_strength`. Lower values should
-move the gate toward `promote`; higher values should move it toward
-`manual-review` or `block`. Keep `seed=2026` so the artifact deltas remain easy
-to explain.
+After the default run works, change only one thing:
+
+- Raise or lower `drift_strength` to see the synthetic decision move.
+- Or set `baseline_csv` and `candidate_csv` to your own share-relative files.
+- Or set `thresholds_json` to tighten/relax the gate without code changes.
+
+Keep `seed=2026` for synthetic comparisons so artifact deltas remain easy to
+explain.
 
 ## Scope
 

--- a/src/agilab/apps/builtin/data_quality_gate_project/lab_stages.toml
+++ b/src/agilab/apps/builtin/data_quality_gate_project/lab_stages.toml
@@ -1,9 +1,9 @@
 [[stages]]
 id = "build_candidate_data"
-label = "Build baseline and candidate data"
+label = "Load or build baseline and candidate data"
 kind = "data"
-produces = ["baseline.csv", "candidate.csv"]
-M = "deterministic seeded tabular generator"
+produces = ["baseline.csv", "candidate.csv", "input_sources.json"]
+M = "user CSV inputs when provided, otherwise deterministic seeded tabular generator"
 
 [[stages]]
 id = "validate_contract"
@@ -11,7 +11,7 @@ label = "Validate data contract"
 kind = "validation"
 depends_on = ["build_candidate_data"]
 produces = ["data_contract.json", "baseline_profile.json", "candidate_profile.json"]
-M = "schema, null, duplicate, and leakage checks"
+M = "configurable schema, type, null, duplicate, and leakage checks"
 
 [[stages]]
 id = "measure_drift"
@@ -26,5 +26,5 @@ id = "write_gate_decision"
 label = "Write gate decision"
 kind = "decision"
 depends_on = ["measure_drift"]
-produces = ["gate_decision.json", "run_manifest.json", "data_quality_report.md"]
+produces = ["gate_decision.json", "decision_card.json", "data_quality_dashboard.html", "run_manifest.json", "data_quality_report.md"]
 M = "AGILAB data-quality evidence writer"

--- a/src/agilab/apps/builtin/data_quality_gate_project/pipeline_view.dot
+++ b/src/agilab/apps/builtin/data_quality_gate_project/pipeline_view.dot
@@ -2,10 +2,10 @@ digraph data_quality_gate_project {
   rankdir=LR;
   node [shape=box, style="rounded"];
 
-  build_candidate_data [label="Build baseline + candidate"];
+  build_candidate_data [label="Load/build baseline + candidate"];
   validate_contract [label="Validate contract"];
   measure_drift [label="Measure drift"];
-  write_gate_decision [label="Write gate decision"];
+  write_gate_decision [label="Write decision + dashboard"];
 
   build_candidate_data -> validate_contract;
   validate_contract -> measure_drift;

--- a/src/agilab/apps/builtin/data_quality_gate_project/src/app_args_form.py
+++ b/src/agilab/apps/builtin/data_quality_gate_project/src/app_args_form.py
@@ -44,12 +44,17 @@ current_payload = current_args.model_dump(mode="json")
 
 artifact_root = Path(getattr(env, "AGILAB_EXPORT_ABS", Path.home() / "export")) / env.target / "data_quality_gate"
 st.caption(
-    "Data Quality Gate validates a deterministic candidate dataset against a "
-    f"contract, drift thresholds, and promotion decision. Analysis artifacts are exported to `{artifact_root}`."
+    "Data Quality Gate validates a candidate dataset against a contract, drift thresholds, "
+    f"and a promotion decision. Leave CSV fields empty for the deterministic built-in sample. "
+    f"Analysis artifacts are exported to `{artifact_root}`."
 )
 
 for key, default in (
     ("data_out", str(current_payload.get("data_out", "data_quality_gate/evidence") or "data_quality_gate/evidence")),
+    ("baseline_csv", str(current_payload.get("baseline_csv") or "")),
+    ("candidate_csv", str(current_payload.get("candidate_csv") or "")),
+    ("contract_json", str(current_payload.get("contract_json") or "")),
+    ("thresholds_json", str(current_payload.get("thresholds_json") or "")),
     ("baseline_rows", int(current_payload.get("baseline_rows", 240) or 240)),
     ("candidate_rows", int(current_payload.get("candidate_rows", 220) or 220)),
     ("drift_strength", float(current_payload.get("drift_strength", 0.35) or 0.35)),
@@ -76,8 +81,25 @@ with c6:
     st.checkbox("Inject quality issues", key=_k("include_quality_issues"))
     st.checkbox("Reset output", key=_k("reset_target"))
 
+with st.expander("Use your own CSV data or gate policy", expanded=False):
+    st.caption(
+        "Paths are relative to the AGILAB share. Provide baseline and candidate CSV together; "
+        "contract/threshold JSON files are optional."
+    )
+    p1, p2 = st.columns(2)
+    with p1:
+        st.text_input("Baseline CSV", key=_k("baseline_csv"), placeholder="data_quality_gate/input/baseline.csv")
+        st.text_input("Contract JSON", key=_k("contract_json"), placeholder="data_quality_gate/input/contract.json")
+    with p2:
+        st.text_input("Candidate CSV", key=_k("candidate_csv"), placeholder="data_quality_gate/input/candidate.csv")
+        st.text_input("Thresholds JSON", key=_k("thresholds_json"), placeholder="data_quality_gate/input/thresholds.json")
+
 candidate: dict[str, Any] = {
     "data_out": (st.session_state.get(_k("data_out")) or "").strip(),
+    "baseline_csv": (st.session_state.get(_k("baseline_csv")) or "").strip(),
+    "candidate_csv": (st.session_state.get(_k("candidate_csv")) or "").strip(),
+    "contract_json": (st.session_state.get(_k("contract_json")) or "").strip(),
+    "thresholds_json": (st.session_state.get(_k("thresholds_json")) or "").strip(),
     "baseline_rows": st.session_state.get(_k("baseline_rows"), 240),
     "candidate_rows": st.session_state.get(_k("candidate_rows"), 220),
     "drift_strength": st.session_state.get(_k("drift_strength"), 0.35),
@@ -113,5 +135,6 @@ else:
     resolved_data_out = env.resolve_share_path(validated.data_out)
     st.caption(
         f"Resolved evidence directory: `{resolved_data_out}`  -  "
+        f"input mode: `{'csv' if validated.baseline_csv and validated.candidate_csv else 'synthetic'}`  -  "
         f"candidate/baseline rows: `{validated.candidate_rows}/{validated.baseline_rows}`."
     )

--- a/src/agilab/apps/builtin/data_quality_gate_project/src/app_settings.toml
+++ b/src/agilab/apps/builtin/data_quality_gate_project/src/app_settings.toml
@@ -1,5 +1,9 @@
 [args]
 data_out = "data_quality_gate/evidence"
+baseline_csv = ""
+candidate_csv = ""
+contract_json = ""
+thresholds_json = ""
 baseline_rows = 240
 candidate_rows = 220
 drift_strength = 0.35

--- a/src/agilab/apps/builtin/data_quality_gate_project/src/data_quality_gate/__init__.py
+++ b/src/agilab/apps/builtin/data_quality_gate_project/src/data_quality_gate/__init__.py
@@ -16,7 +16,15 @@ from .app_args import (
     share_root_from_env,
     validate_relative_data_out,
 )
-from .core import CONTRACT_COLUMNS, SCHEMA, THRESHOLDS, build_data_quality_gate_artifacts
+from .core import (
+    CONTRACT_COLUMNS,
+    CONTRACT_SCHEMA,
+    SCHEMA,
+    THRESHOLDS,
+    THRESHOLDS_SCHEMA,
+    build_data_quality_gate_artifacts,
+    default_contract,
+)
 from .data_quality_gate import DataQualityGate, DataQualityGateApp
 from .reduction import DATA_QUALITY_GATE_REDUCE_CONTRACT
 
@@ -24,6 +32,7 @@ __all__ = [
     "ArgsModel",
     "ArgsOverrides",
     "CONTRACT_COLUMNS",
+    "CONTRACT_SCHEMA",
     "DATA_QUALITY_GATE_REDUCE_CONTRACT",
     "DataQualityGate",
     "DataQualityGateApp",
@@ -31,7 +40,9 @@ __all__ = [
     "DataQualityGateArgsTD",
     "SCHEMA",
     "THRESHOLDS",
+    "THRESHOLDS_SCHEMA",
     "build_data_quality_gate_artifacts",
+    "default_contract",
     "dump_args",
     "ensure_defaults",
     "filter_arg_overrides",

--- a/src/agilab/apps/builtin/data_quality_gate_project/src/data_quality_gate/app_args.py
+++ b/src/agilab/apps/builtin/data_quality_gate_project/src/data_quality_gate/app_args.py
@@ -38,6 +38,10 @@ class DataQualityGateArgs(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     data_out: Path = Field(default_factory=lambda: Path("data_quality_gate/evidence"))
+    baseline_csv: Path | None = None
+    candidate_csv: Path | None = None
+    contract_json: Path | None = None
+    thresholds_json: Path | None = None
     baseline_rows: int = Field(default=240, ge=50, le=10000)
     candidate_rows: int = Field(default=220, ge=50, le=10000)
     drift_strength: float = Field(default=0.35, ge=0.0, le=1.0)
@@ -50,9 +54,20 @@ class DataQualityGateArgs(BaseModel):
     def _validate_data_out(cls, value: str | Path) -> Path:
         return validate_relative_data_out(value)
 
+    @field_validator("baseline_csv", "candidate_csv", "contract_json", "thresholds_json", mode="before")
+    @classmethod
+    def _validate_optional_input_path(cls, value: str | Path | None) -> Path | None:
+        if value is None or str(value).strip() == "":
+            return None
+        return validate_relative_data_out(value)
+
 
 class DataQualityGateArgsTD(TypedDict, total=False):
     data_out: str
+    baseline_csv: str | None
+    candidate_csv: str | None
+    contract_json: str | None
+    thresholds_json: str | None
     baseline_rows: int
     candidate_rows: int
     drift_strength: float

--- a/src/agilab/apps/builtin/data_quality_gate_project/src/data_quality_gate/core.py
+++ b/src/agilab/apps/builtin/data_quality_gate_project/src/data_quality_gate/core.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import csv
 import hashlib
+import html
 import json
 import math
 import random
@@ -14,6 +15,8 @@ import pandas as pd
 
 
 SCHEMA = "agilab.app.data_quality_gate.v1"
+CONTRACT_SCHEMA = "agilab.app.data_quality_gate.contract.v1"
+THRESHOLDS_SCHEMA = "agilab.app.data_quality_gate.thresholds.v1"
 
 CONTRACT_COLUMNS: dict[str, str] = {
     "customer_id": "integer identifier",
@@ -39,6 +42,40 @@ THRESHOLDS: dict[str, float | int] = {
     "category_delta_block": 0.25,
 }
 
+DEFAULT_TARGET_COLUMN = "target"
+DEFAULT_IDENTIFIER_COLUMNS = ("customer_id",)
+DEFAULT_LEAKAGE_NAME_PATTERNS = ("leak", "target_proxy")
+
+
+def default_contract() -> dict[str, Any]:
+    """Return the default data-quality contract used by the synthetic demo."""
+
+    columns: dict[str, dict[str, Any]] = {}
+    for name, description in CONTRACT_COLUMNS.items():
+        role = "feature"
+        kind = "categorical" if description == "categorical" else "numeric"
+        if name == DEFAULT_TARGET_COLUMN:
+            role = "target"
+            kind = "binary"
+        elif name in DEFAULT_IDENTIFIER_COLUMNS:
+            role = "identifier"
+            kind = "integer"
+        columns[name] = {
+            "description": description,
+            "drift": role == "feature",
+            "kind": kind,
+            "required": True,
+            "role": role,
+        }
+    return {
+        "schema": CONTRACT_SCHEMA,
+        "allow_unexpected_columns": False,
+        "columns": columns,
+        "identifier_columns": list(DEFAULT_IDENTIFIER_COLUMNS),
+        "leakage_name_patterns": list(DEFAULT_LEAKAGE_NAME_PATTERNS),
+        "target_column": DEFAULT_TARGET_COLUMN,
+    }
+
 
 def _sha256(path: Path) -> str:
     digest = hashlib.sha256()
@@ -55,6 +92,140 @@ def _artifact(path: Path, *, role: str, output_dir: Path) -> dict[str, Any]:
         "bytes": path.stat().st_size,
         "sha256": _sha256(path),
     }
+
+
+def _source_file(path: Path, *, role: str) -> dict[str, Any]:
+    resolved = path.expanduser().resolve(strict=False)
+    return {
+        "path": str(resolved),
+        "role": role,
+        "bytes": resolved.stat().st_size,
+        "sha256": _sha256(resolved),
+    }
+
+
+def _optional_path(value: str | Path | None) -> Path | None:
+    if value is None:
+        return None
+    raw = str(value).strip()
+    if not raw:
+        return None
+    return Path(raw).expanduser()
+
+
+def _read_json(path: Path, *, label: str) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid {label} JSON in {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError(f"{label} JSON in {path} must be an object")
+    return payload
+
+
+def _coerce_bool(value: Any, *, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
+def _normalize_column_spec(name: str, raw: Any) -> dict[str, Any]:
+    if isinstance(raw, str):
+        raw = {"kind": raw}
+    if not isinstance(raw, dict):
+        raw = {}
+    role = str(raw.get("role") or ("target" if name == DEFAULT_TARGET_COLUMN else "feature")).strip().lower()
+    if name in DEFAULT_IDENTIFIER_COLUMNS and "role" not in raw:
+        role = "identifier"
+    kind = str(raw.get("kind") or ("binary" if role == "target" else "numeric")).strip().lower()
+    required = _coerce_bool(raw.get("required"), default=True)
+    drift = _coerce_bool(raw.get("drift"), default=role == "feature")
+    return {
+        "description": str(raw.get("description") or kind),
+        "drift": drift,
+        "kind": kind,
+        "required": required,
+        "role": role,
+    }
+
+
+def _normalize_contract(payload: dict[str, Any] | None = None) -> dict[str, Any]:
+    base = default_contract()
+    if not payload:
+        return base
+
+    raw_columns = payload.get("columns") or payload.get("expected_columns")
+    if isinstance(raw_columns, list):
+        raw_columns = {str(name): {"kind": "numeric"} for name in raw_columns}
+    if isinstance(raw_columns, dict):
+        base["columns"] = {
+            str(name): _normalize_column_spec(str(name), raw)
+            for name, raw in sorted(raw_columns.items(), key=lambda item: str(item[0]))
+        }
+    base["allow_unexpected_columns"] = _coerce_bool(
+        payload.get("allow_unexpected_columns"),
+        default=bool(base["allow_unexpected_columns"]),
+    )
+    if isinstance(payload.get("target_column"), str) and payload["target_column"].strip():
+        base["target_column"] = payload["target_column"].strip()
+    raw_identifiers = payload.get("identifier_columns")
+    if isinstance(raw_identifiers, str):
+        raw_identifiers = [raw_identifiers]
+    if isinstance(raw_identifiers, list):
+        base["identifier_columns"] = [str(value).strip() for value in raw_identifiers if str(value).strip()]
+    raw_patterns = payload.get("leakage_name_patterns")
+    if isinstance(raw_patterns, str):
+        raw_patterns = [raw_patterns]
+    if isinstance(raw_patterns, list):
+        base["leakage_name_patterns"] = [str(value).strip() for value in raw_patterns if str(value).strip()]
+    return base
+
+
+def _normalize_thresholds(payload: dict[str, Any] | None = None) -> dict[str, float]:
+    thresholds = {key: float(value) for key, value in THRESHOLDS.items()}
+    thresholds.update(_threshold_updates(payload))
+    return thresholds
+
+
+def _threshold_updates(payload: dict[str, Any] | None = None) -> dict[str, float]:
+    updates: dict[str, float] = {}
+    if not payload:
+        return updates
+    raw_thresholds = payload.get("thresholds") if isinstance(payload.get("thresholds"), dict) else payload
+    for key, value in raw_thresholds.items():
+        if key not in THRESHOLDS:
+            continue
+        try:
+            updates[key] = float(value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"Threshold {key!r} must be numeric") from exc
+    return updates
+
+
+def _load_gate_configuration(
+    *,
+    contract_json: str | Path | None,
+    thresholds_json: str | Path | None,
+) -> tuple[dict[str, Any], dict[str, float], dict[str, dict[str, Any]]]:
+    contract_sources: dict[str, dict[str, Any]] = {}
+    raw_contract: dict[str, Any] | None = None
+    contract_path = _optional_path(contract_json)
+    if contract_path is not None:
+        raw_contract = _read_json(contract_path, label="contract")
+        contract_sources["contract_json"] = _source_file(contract_path, role="contract configuration")
+
+    contract = _normalize_contract(raw_contract)
+    thresholds = _normalize_thresholds(raw_contract.get("thresholds") if isinstance(raw_contract, dict) else None)
+    thresholds_path = _optional_path(thresholds_json)
+    if thresholds_path is not None:
+        raw_thresholds = _read_json(thresholds_path, label="thresholds")
+        thresholds.update(_threshold_updates(raw_thresholds))
+        contract_sources["thresholds_json"] = _source_file(thresholds_path, role="threshold configuration")
+    return contract, thresholds, contract_sources
 
 
 def _weighted_choice(rng: random.Random, choices: list[tuple[str, float]]) -> str:
@@ -262,30 +433,46 @@ def _severity(
     ks_statistic: float,
     mean_shift_std: float,
     max_category_delta: float,
+    thresholds: dict[str, float],
 ) -> tuple[str, str]:
     if (
-        psi >= float(THRESHOLDS["psi_block"])
-        or ks_statistic >= float(THRESHOLDS["ks_block"])
-        or mean_shift_std >= float(THRESHOLDS["mean_shift_block"])
-        or max_category_delta >= float(THRESHOLDS["category_delta_block"])
+        psi >= thresholds["psi_block"]
+        or ks_statistic >= thresholds["ks_block"]
+        or mean_shift_std >= thresholds["mean_shift_block"]
+        or max_category_delta >= thresholds["category_delta_block"]
     ):
         return "block", "drift exceeds block threshold"
     if (
-        psi >= float(THRESHOLDS["psi_warn"])
-        or ks_statistic >= float(THRESHOLDS["ks_warn"])
-        or mean_shift_std >= float(THRESHOLDS["mean_shift_warn"])
-        or max_category_delta >= float(THRESHOLDS["category_delta_warn"])
+        psi >= thresholds["psi_warn"]
+        or ks_statistic >= thresholds["ks_warn"]
+        or mean_shift_std >= thresholds["mean_shift_warn"]
+        or max_category_delta >= thresholds["category_delta_warn"]
     ):
         return "warn", "drift exceeds review threshold"
     return "pass", "within drift thresholds"
 
 
-def _drift_rows(baseline: pd.DataFrame, candidate: pd.DataFrame) -> list[dict[str, Any]]:
+def _drift_columns(contract: dict[str, Any]) -> list[str]:
+    columns = contract.get("columns", {})
+    if not isinstance(columns, dict):
+        return []
+    return [
+        str(name)
+        for name, spec in columns.items()
+        if isinstance(spec, dict) and spec.get("drift") is True and spec.get("role") not in {"identifier", "target"}
+    ]
+
+
+def _drift_rows(
+    baseline: pd.DataFrame,
+    candidate: pd.DataFrame,
+    *,
+    contract: dict[str, Any],
+    thresholds: dict[str, float],
+) -> list[dict[str, Any]]:
     rows: list[dict[str, Any]] = []
-    common_columns = [column for column in CONTRACT_COLUMNS if column in baseline.columns and column in candidate.columns]
+    common_columns = [column for column in _drift_columns(contract) if column in baseline.columns and column in candidate.columns]
     for column in common_columns:
-        if column in {"customer_id", "target"}:
-            continue
         base = baseline[column]
         current = candidate[column]
         kind = "numeric" if pd.api.types.is_numeric_dtype(base) and pd.api.types.is_numeric_dtype(current) else "categorical"
@@ -309,6 +496,7 @@ def _drift_rows(baseline: pd.DataFrame, candidate: pd.DataFrame) -> list[dict[st
             ks_statistic=ks_statistic,
             mean_shift_std=mean_shift_std,
             max_category_delta=max_category_delta,
+            thresholds=thresholds,
         )
         rows.append(
             {
@@ -326,13 +514,20 @@ def _drift_rows(baseline: pd.DataFrame, candidate: pd.DataFrame) -> list[dict[st
     return rows
 
 
-def _leakage_columns(candidate: pd.DataFrame) -> list[str]:
-    suspicious = [column for column in candidate.columns if "leak" in column.lower() or "target_proxy" in column.lower()]
-    if "target" not in candidate.columns:
+def _leakage_columns(candidate: pd.DataFrame, *, contract: dict[str, Any]) -> list[str]:
+    patterns = contract.get("leakage_name_patterns") or list(DEFAULT_LEAKAGE_NAME_PATTERNS)
+    target_column = str(contract.get("target_column") or DEFAULT_TARGET_COLUMN)
+    identifier_columns = {str(value) for value in contract.get("identifier_columns", [])}
+    suspicious = [
+        column
+        for column in candidate.columns
+        if any(pattern and pattern.lower() in column.lower() for pattern in patterns)
+    ]
+    if target_column not in candidate.columns:
         return sorted(suspicious)
-    target = candidate["target"]
+    target = candidate[target_column]
     for column in candidate.columns:
-        if column in {"target", "customer_id"} or not pd.api.types.is_numeric_dtype(candidate[column]):
+        if column == target_column or column in identifier_columns or not pd.api.types.is_numeric_dtype(candidate[column]):
             continue
         try:
             correlation = abs(float(candidate[column].corr(target)))
@@ -343,18 +538,47 @@ def _leakage_columns(candidate: pd.DataFrame) -> list[str]:
     return sorted(set(suspicious))
 
 
-def _contract_result(baseline: pd.DataFrame, candidate: pd.DataFrame) -> dict[str, Any]:
-    expected = set(CONTRACT_COLUMNS)
+def _type_issues(frame: pd.DataFrame, *, frame_name: str, contract: dict[str, Any]) -> list[str]:
+    issues: list[str] = []
+    columns = contract.get("columns", {})
+    if not isinstance(columns, dict):
+        return issues
+    for column, spec in sorted(columns.items()):
+        if column not in frame.columns or not isinstance(spec, dict):
+            continue
+        kind = str(spec.get("kind", "")).lower()
+        if kind in {"numeric", "integer", "float", "binary"} and not pd.api.types.is_numeric_dtype(frame[column]):
+            issues.append(f"{frame_name}.{column} expected numeric-compatible data, got {frame[column].dtype}")
+    return issues
+
+
+def _contract_result(
+    baseline: pd.DataFrame,
+    candidate: pd.DataFrame,
+    *,
+    contract: dict[str, Any],
+    thresholds: dict[str, float],
+) -> dict[str, Any]:
+    columns = contract.get("columns", {})
+    columns = columns if isinstance(columns, dict) else {}
+    expected = {name for name, spec in columns.items() if isinstance(spec, dict) and spec.get("required") is True}
+    defined = set(columns)
     candidate_columns = set(candidate.columns)
     missing = sorted(expected - candidate_columns)
-    unexpected = sorted(candidate_columns - expected)
+    unexpected = sorted(candidate_columns - defined)
     baseline_columns = set(baseline.columns)
     return {
-        "expected_columns": CONTRACT_COLUMNS,
+        "allow_unexpected_columns": bool(contract.get("allow_unexpected_columns")),
+        "expected_columns": columns,
         "missing_columns": missing,
-        "unexpected_columns": unexpected,
+        "unexpected_columns": [] if contract.get("allow_unexpected_columns") else unexpected,
+        "observed_unexpected_columns": unexpected,
         "baseline_missing_columns": sorted(expected - baseline_columns),
-        "thresholds": THRESHOLDS,
+        "type_issues": [
+            *_type_issues(baseline, frame_name="baseline", contract=contract),
+            *_type_issues(candidate, frame_name="candidate", contract=contract),
+        ],
+        "thresholds": thresholds,
     }
 
 
@@ -364,25 +588,30 @@ def _gate_decision(
     candidate: pd.DataFrame,
     contract: dict[str, Any],
     drift_rows: list[dict[str, Any]],
+    thresholds: dict[str, float],
 ) -> dict[str, Any]:
     blockers: list[str] = []
     warnings: list[str] = []
     if contract["missing_columns"]:
         blockers.append("missing required columns: " + ", ".join(contract["missing_columns"]))
+    if contract["baseline_missing_columns"]:
+        blockers.append("baseline missing required columns: " + ", ".join(contract["baseline_missing_columns"]))
     if contract["unexpected_columns"]:
         blockers.append("unexpected columns: " + ", ".join(contract["unexpected_columns"]))
+    if contract["type_issues"]:
+        blockers.extend(contract["type_issues"])
 
     null_rate = float(candidate.isna().mean().max()) if len(candidate.columns) else 0.0
     duplicate_rate = float(candidate.duplicated().mean()) if len(candidate) else 0.0
     row_count_delta = abs(len(candidate) - len(baseline)) / max(1, len(baseline))
-    if null_rate > float(THRESHOLDS["max_null_rate"]):
+    if null_rate > thresholds["max_null_rate"]:
         blockers.append(f"null rate {null_rate:.3f} exceeds threshold")
-    if duplicate_rate > float(THRESHOLDS["max_duplicate_rate"]):
+    if duplicate_rate > thresholds["max_duplicate_rate"]:
         blockers.append(f"duplicate rate {duplicate_rate:.3f} exceeds threshold")
-    if row_count_delta > float(THRESHOLDS["max_row_count_delta"]):
+    if row_count_delta > thresholds["max_row_count_delta"]:
         warnings.append(f"row count delta {row_count_delta:.3f} exceeds review threshold")
 
-    leakage_columns = _leakage_columns(candidate)
+    leakage_columns = _leakage_columns(candidate, contract=contract)
     if leakage_columns:
         blockers.append("potential leakage columns: " + ", ".join(leakage_columns))
 
@@ -431,16 +660,68 @@ def _write_csv(path: Path, rows: list[dict[str, Any]]) -> None:
         writer.writerows(rows)
 
 
-def _write_report(path: Path, *, decision: dict[str, Any], drift_rows: list[dict[str, Any]]) -> None:
+def _recommended_action(decision: str) -> str:
+    if decision == "promote":
+        return "Promote the candidate data to the next workflow step."
+    if decision == "manual-review":
+        return "Hold promotion until an owner reviews drift and row-count warnings."
+    return "Block promotion until blockers are fixed and the gate is rerun."
+
+
+def _risk_score(decision: dict[str, Any]) -> int:
+    base = len(decision["blockers"]) * 35 + len(decision["warnings"]) * 12
+    drift = decision["drift"]
+    base += int(float(drift["max_psi"]) * 100)
+    base += int(float(drift["max_ks_statistic"]) * 40)
+    return max(0, min(100, base))
+
+
+def _decision_card(decision: dict[str, Any], drift_rows: list[dict[str, Any]], *, input_mode: str) -> dict[str, Any]:
+    top_rows = sorted(drift_rows, key=lambda row: (row["severity"] == "pass", -float(row["psi"])))[:5]
+    return {
+        "schema": SCHEMA,
+        "decision": decision["decision"],
+        "input_mode": input_mode,
+        "recommended_action": _recommended_action(decision["decision"]),
+        "risk_score": _risk_score(decision),
+        "blocker_count": len(decision["blockers"]),
+        "warning_count": len(decision["warnings"]),
+        "quality": decision["quality"],
+        "drift": decision["drift"],
+        "top_drift_signals": top_rows,
+    }
+
+
+def _write_report(
+    path: Path,
+    *,
+    decision: dict[str, Any],
+    drift_rows: list[dict[str, Any]],
+    input_mode: str,
+    contract: dict[str, Any],
+) -> None:
     top_rows = sorted(drift_rows, key=lambda row: (row["severity"] != "block", -float(row["psi"])))[:5]
     lines = [
         "# Data Quality Gate Evidence",
         "",
+        f"- input mode: `{input_mode}`",
         f"- decision: `{decision['decision']}`",
+        f"- recommended action: {decision['recommended_action']}",
         f"- blockers: `{len(decision['blockers'])}`",
         f"- warnings: `{len(decision['warnings'])}`",
         f"- max PSI: `{decision['drift']['max_psi']}`",
         f"- max KS statistic: `{decision['drift']['max_ks_statistic']}`",
+        f"- contract columns: `{len(contract.get('expected_columns', {}))}`",
+        "",
+        "## Blockers",
+        "",
+        *(f"- {blocker}" for blocker in decision["blockers"]),
+        *([] if decision["blockers"] else ["- none"]),
+        "",
+        "## Warnings",
+        "",
+        *(f"- {warning}" for warning in decision["warnings"]),
+        *([] if decision["warnings"] else ["- none"]),
         "",
         "## Top drift signals",
         "",
@@ -460,9 +741,121 @@ def _write_report(path: Path, *, decision: dict[str, Any], drift_rows: list[dict
     path.write_text("\n".join(lines), encoding="utf-8")
 
 
+def _write_dashboard(
+    path: Path,
+    *,
+    decision_card: dict[str, Any],
+    drift_rows: list[dict[str, Any]],
+    contract: dict[str, Any],
+) -> None:
+    badge_color = {"promote": "#137333", "manual-review": "#b06000", "block": "#b42318"}.get(
+        str(decision_card["decision"]),
+        "#334155",
+    )
+    rows_html = "\n".join(
+        "<tr>"
+        f"<td>{html.escape(str(row['feature']))}</td>"
+        f"<td>{html.escape(str(row['kind']))}</td>"
+        f"<td>{html.escape(str(row['severity']))}</td>"
+        f"<td>{float(row['psi']):.4f}</td>"
+        f"<td>{float(row['ks_statistic']):.4f}</td>"
+        f"<td>{float(row['mean_shift_std']):.4f}</td>"
+        f"<td>{float(row['max_category_delta']):.4f}</td>"
+        "</tr>"
+        for row in sorted(drift_rows, key=lambda item: (item["severity"] == "pass", -float(item["psi"])))
+    )
+    blocker_items = "\n".join(
+        f"<li>{html.escape(str(value))}</li>" for value in decision_card.get("blockers", [])
+    ) or "<li>none</li>"
+    warning_items = "\n".join(
+        f"<li>{html.escape(str(value))}</li>" for value in decision_card.get("warnings", [])
+    ) or "<li>none</li>"
+    content = f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Data Quality Gate</title>
+  <style>
+    body {{ font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 2rem; color: #172033; }}
+    .hero {{ border: 1px solid #d7dee8; border-radius: 18px; padding: 1.4rem; background: #f8fafc; }}
+    .decision {{ display: inline-block; background: {badge_color}; color: white; border-radius: 999px; padding: .25rem .75rem; }}
+    .grid {{ display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: .8rem; margin: 1rem 0; }}
+    .card {{ border: 1px solid #d7dee8; border-radius: 14px; padding: .9rem; background: white; }}
+    table {{ width: 100%; border-collapse: collapse; margin-top: 1rem; }}
+    th, td {{ border-bottom: 1px solid #e5e9f0; padding: .45rem; text-align: left; }}
+    th {{ background: #eef3f8; }}
+  </style>
+</head>
+<body>
+  <section class="hero">
+    <h1>Data Quality Gate</h1>
+    <p class="decision">{html.escape(str(decision_card["decision"]))}</p>
+    <p>{html.escape(str(decision_card["recommended_action"]))}</p>
+  </section>
+  <section class="grid">
+    <div class="card"><strong>Input mode</strong><br>{html.escape(str(decision_card["input_mode"]))}</div>
+    <div class="card"><strong>Risk score</strong><br>{int(decision_card["risk_score"])}/100</div>
+    <div class="card"><strong>Max PSI</strong><br>{float(decision_card["drift"]["max_psi"]):.4f}</div>
+    <div class="card"><strong>Max KS</strong><br>{float(decision_card["drift"]["max_ks_statistic"]):.4f}</div>
+  </section>
+  <h2>Blockers</h2>
+  <ul>{blocker_items}</ul>
+  <h2>Warnings</h2>
+  <ul>{warning_items}</ul>
+  <h2>Drift signals</h2>
+  <table>
+    <thead><tr><th>Feature</th><th>Kind</th><th>Severity</th><th>PSI</th><th>KS</th><th>Mean shift</th><th>Category delta</th></tr></thead>
+    <tbody>{rows_html}</tbody>
+  </table>
+  <p>Contract columns: {len(contract.get("expected_columns", {}))}. This dashboard is a local evidence artifact, not a production certification.</p>
+</body>
+</html>
+"""
+    path.write_text(content, encoding="utf-8")
+
+
+def _load_or_generate_frames(
+    *,
+    baseline_csv: str | Path | None,
+    candidate_csv: str | Path | None,
+    baseline_rows: int,
+    candidate_rows: int,
+    drift_strength: float,
+    seed: int,
+    include_quality_issues: bool,
+) -> tuple[pd.DataFrame, pd.DataFrame, str, dict[str, dict[str, Any]]]:
+    baseline_path = _optional_path(baseline_csv)
+    candidate_path = _optional_path(candidate_csv)
+    if bool(baseline_path) != bool(candidate_path):
+        raise ValueError("baseline_csv and candidate_csv must be provided together")
+    if baseline_path and candidate_path:
+        if not baseline_path.is_file():
+            raise FileNotFoundError(f"baseline_csv not found: {baseline_path}")
+        if not candidate_path.is_file():
+            raise FileNotFoundError(f"candidate_csv not found: {candidate_path}")
+        sources = {
+            "baseline_csv": _source_file(baseline_path, role="baseline input CSV"),
+            "candidate_csv": _source_file(candidate_path, role="candidate input CSV"),
+        }
+        return pd.read_csv(baseline_path), pd.read_csv(candidate_path), "csv", sources
+
+    baseline, candidate = generate_reference_frames(
+        baseline_rows=baseline_rows,
+        candidate_rows=candidate_rows,
+        drift_strength=drift_strength,
+        seed=seed,
+        include_quality_issues=include_quality_issues,
+    )
+    return baseline, candidate, "synthetic", {}
+
+
 def build_data_quality_gate_artifacts(
     *,
     output_dir: Path,
+    baseline_csv: str | Path | None = None,
+    candidate_csv: str | Path | None = None,
+    contract_json: str | Path | None = None,
+    thresholds_json: str | Path | None = None,
     baseline_rows: int = 240,
     candidate_rows: int = 220,
     drift_strength: float = 0.35,
@@ -473,13 +866,20 @@ def build_data_quality_gate_artifacts(
 
     output_dir = output_dir.expanduser()
     output_dir.mkdir(parents=True, exist_ok=True)
-    baseline, candidate = generate_reference_frames(
+    baseline, candidate, input_mode, input_sources = _load_or_generate_frames(
+        baseline_csv=baseline_csv,
+        candidate_csv=candidate_csv,
         baseline_rows=baseline_rows,
         candidate_rows=candidate_rows,
         drift_strength=drift_strength,
         seed=seed,
         include_quality_issues=include_quality_issues,
     )
+    contract, thresholds, config_sources = _load_gate_configuration(
+        contract_json=contract_json,
+        thresholds_json=thresholds_json,
+    )
+    input_sources.update(config_sources)
 
     baseline_path = output_dir / "baseline.csv"
     candidate_path = output_dir / "candidate.csv"
@@ -497,24 +897,50 @@ def build_data_quality_gate_artifacts(
     )
 
     contract_path = output_dir / "data_contract.json"
-    contract = _contract_result(baseline, candidate)
-    contract_path.write_text(json.dumps(contract, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    contract_result = _contract_result(
+        baseline,
+        candidate,
+        contract=contract,
+        thresholds=thresholds,
+    )
+    contract_path.write_text(json.dumps(contract_result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
-    drift_rows = _drift_rows(baseline, candidate)
+    drift_rows = _drift_rows(baseline, candidate, contract=contract, thresholds=thresholds)
     drift_path = output_dir / "drift_metrics.csv"
     _write_csv(drift_path, drift_rows)
 
     decision = _gate_decision(
         baseline=baseline,
         candidate=candidate,
-        contract=contract,
+        contract=contract_result,
         drift_rows=drift_rows,
+        thresholds=thresholds,
     )
+    decision["recommended_action"] = _recommended_action(decision["decision"])
+    decision["risk_score"] = _risk_score(decision)
     decision_path = output_dir / "gate_decision.json"
     decision_path.write_text(json.dumps(decision, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
+    decision_card = _decision_card(decision, drift_rows, input_mode=input_mode)
+    decision_card["blockers"] = decision["blockers"]
+    decision_card["warnings"] = decision["warnings"]
+    decision_card_path = output_dir / "decision_card.json"
+    decision_card_path.write_text(json.dumps(decision_card, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
     report_path = output_dir / "data_quality_report.md"
-    _write_report(report_path, decision=decision, drift_rows=drift_rows)
+    _write_report(
+        report_path,
+        decision=decision,
+        drift_rows=drift_rows,
+        input_mode=input_mode,
+        contract=contract_result,
+    )
+
+    dashboard_path = output_dir / "data_quality_dashboard.html"
+    _write_dashboard(dashboard_path, decision_card=decision_card, drift_rows=drift_rows, contract=contract_result)
+
+    input_sources_path = output_dir / "input_sources.json"
+    input_sources_path.write_text(json.dumps(input_sources, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
     artifacts = {
         "baseline": _artifact(baseline_path, role="baseline dataset", output_dir=output_dir),
@@ -524,7 +950,10 @@ def build_data_quality_gate_artifacts(
         "contract": _artifact(contract_path, role="data contract", output_dir=output_dir),
         "drift_metrics": _artifact(drift_path, role="drift metrics", output_dir=output_dir),
         "gate_decision": _artifact(decision_path, role="gate decision", output_dir=output_dir),
+        "decision_card": _artifact(decision_card_path, role="operator decision card", output_dir=output_dir),
         "report": _artifact(report_path, role="human-readable evidence summary", output_dir=output_dir),
+        "dashboard": _artifact(dashboard_path, role="self-contained HTML dashboard", output_dir=output_dir),
+        "input_sources": _artifact(input_sources_path, role="input and configuration source hashes", output_dir=output_dir),
     }
     manifest_path = output_dir / "run_manifest.json"
     manifest = {
@@ -533,12 +962,18 @@ def build_data_quality_gate_artifacts(
         "deterministic": True,
         "runtime": "agi worker",
         "inputs": {
+            "baseline_csv": str(baseline_csv or ""),
             "baseline_rows": baseline_rows,
+            "candidate_csv": str(candidate_csv or ""),
             "candidate_rows": candidate_rows,
+            "contract_json": str(contract_json or ""),
             "drift_strength": drift_strength,
             "seed": seed,
             "include_quality_issues": include_quality_issues,
+            "input_mode": input_mode,
+            "thresholds_json": str(thresholds_json or ""),
         },
+        "input_sources": input_sources,
         "artifacts": artifacts,
         "decision": decision,
         "promotion_hint": decision["decision"],
@@ -554,9 +989,13 @@ def build_data_quality_gate_artifacts(
         "schema": SCHEMA,
         "output_dir": str(output_dir),
         "decision": decision["decision"],
+        "input_mode": input_mode,
+        "recommended_action": decision["recommended_action"],
+        "risk_score": decision["risk_score"],
         "quality": decision["quality"],
         "drift": decision["drift"],
         "artifacts": summary_artifacts,
+        "decision_card": str(decision_card_path),
         "manifest": str(manifest_path),
     }
     summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
@@ -565,8 +1004,11 @@ def build_data_quality_gate_artifacts(
 
 __all__ = [
     "CONTRACT_COLUMNS",
+    "CONTRACT_SCHEMA",
     "SCHEMA",
     "THRESHOLDS",
+    "THRESHOLDS_SCHEMA",
     "build_data_quality_gate_artifacts",
+    "default_contract",
     "generate_reference_frames",
 ]

--- a/src/agilab/apps/builtin/data_quality_gate_project/src/data_quality_gate_worker/data_quality_gate_worker.py
+++ b/src/agilab/apps/builtin/data_quality_gate_project/src/data_quality_gate_worker/data_quality_gate_worker.py
@@ -55,6 +55,15 @@ def _args_with_defaults(value: Any) -> DataQualityGateArgs:
     return DataQualityGateArgs(**{key: val for key, val in raw.items() if not key.startswith("_")})
 
 
+def _resolve_optional_share_path(env: object, value: Path | None) -> Path | None:
+    if value is None:
+        return None
+    path = Path(value).expanduser()
+    if not path.is_absolute() and callable(getattr(env, "resolve_share_path", None)):
+        path = Path(env.resolve_share_path(path))
+    return path
+
+
 def _copy_artifacts(source: Path, destination: Path) -> None:
     if source.resolve() == destination.resolve():
         return
@@ -77,6 +86,10 @@ class DataQualityGateWorker(PandasWorker):
         if not data_out.is_absolute() and callable(getattr(self.env, "resolve_share_path", None)):
             data_out = Path(self.env.resolve_share_path(data_out))
         self.args.data_out = data_out
+        self.args.baseline_csv = _resolve_optional_share_path(self.env, self.args.baseline_csv)
+        self.args.candidate_csv = _resolve_optional_share_path(self.env, self.args.candidate_csv)
+        self.args.contract_json = _resolve_optional_share_path(self.env, self.args.contract_json)
+        self.args.thresholds_json = _resolve_optional_share_path(self.env, self.args.thresholds_json)
         self.data_out = data_out
         if self.args.reset_target and self.data_out.exists():
             reset_path = safe_reset_path(self.data_out, share_root=share_root_from_env(self.env), label="data_out")
@@ -128,6 +141,10 @@ class DataQualityGateWorker(PandasWorker):
         args = self._current_args()
         summary = build_data_quality_gate_artifacts(
             output_dir=Path(self.data_out),
+            baseline_csv=args.baseline_csv,
+            candidate_csv=args.candidate_csv,
+            contract_json=args.contract_json,
+            thresholds_json=args.thresholds_json,
             baseline_rows=args.baseline_rows,
             candidate_rows=args.candidate_rows,
             drift_strength=args.drift_strength,
@@ -138,8 +155,11 @@ class DataQualityGateWorker(PandasWorker):
         _copy_artifacts(Path(self.data_out), Path(self.artifact_dir))
         metrics = {
             "decision": summary["decision"],
+            "input_mode": summary["input_mode"],
             "max_psi": summary["drift"]["max_psi"],
             "max_ks_statistic": summary["drift"]["max_ks_statistic"],
+            "recommended_action": summary["recommended_action"],
+            "risk_score": summary["risk_score"],
             "warn_feature_count": summary["drift"]["warn_feature_count"],
             "block_feature_count": summary["drift"]["block_feature_count"],
             "worker_id": int(getattr(self, "_worker_id", 0)),

--- a/test/test_data_quality_gate_project.py
+++ b/test/test_data_quality_gate_project.py
@@ -4,6 +4,7 @@ import csv
 import json
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -14,11 +15,46 @@ if str(APP_SRC) not in sys.path:
     sys.path.insert(0, str(APP_SRC))
 
 from data_quality_gate import (  # noqa: E402
+    CONTRACT_SCHEMA,
     DataQualityGateArgs,
+    THRESHOLDS_SCHEMA,
     build_data_quality_gate_artifacts,
+    default_contract,
     validate_relative_data_out,
 )
 from data_quality_gate.reduction import write_reduce_artifact  # noqa: E402
+from data_quality_gate_worker.data_quality_gate_worker import DataQualityGateWorker  # noqa: E402
+
+
+def _make_env(tmp_path: Path) -> SimpleNamespace:
+    share_root = tmp_path / "share"
+    export_root = tmp_path / "export"
+    share_root.mkdir(parents=True, exist_ok=True)
+    export_root.mkdir(parents=True, exist_ok=True)
+
+    def _resolve_share_path(path: str | Path) -> Path:
+        candidate = Path(path)
+        return candidate if candidate.is_absolute() else share_root / candidate
+
+    return SimpleNamespace(
+        AGILAB_EXPORT_ABS=export_root,
+        AGI_LOCAL_SHARE=str(share_root),
+        _is_managed_pc=False,
+        home_abs=tmp_path,
+        resolve_share_path=_resolve_share_path,
+        target="data_quality_gate_project",
+        verbose=0,
+    )
+
+
+def test_data_quality_gate_exports_policy_schema_helpers() -> None:
+    contract = default_contract()
+
+    assert CONTRACT_SCHEMA == "agilab.app.data_quality_gate.contract.v1"
+    assert THRESHOLDS_SCHEMA == "agilab.app.data_quality_gate.thresholds.v1"
+    assert contract["schema"] == CONTRACT_SCHEMA
+    assert contract["columns"]["age"]["kind"] == "numeric"
+    assert contract["columns"]["target"]["role"] == "target"
 
 
 def test_data_quality_gate_writes_replayable_evidence(tmp_path: Path) -> None:
@@ -42,8 +78,11 @@ def test_data_quality_gate_writes_replayable_evidence(tmp_path: Path) -> None:
         "baseline_profile.json",
         "candidate_profile.json",
         "data_contract.json",
+        "data_quality_dashboard.html",
         "drift_metrics.csv",
+        "decision_card.json",
         "gate_decision.json",
+        "input_sources.json",
         "data_quality_report.md",
         "run_manifest.json",
         "data_quality_gate_summary.json",
@@ -53,14 +92,28 @@ def test_data_quality_gate_writes_replayable_evidence(tmp_path: Path) -> None:
     manifest = json.loads((tmp_path / "run_manifest.json").read_text(encoding="utf-8"))
     assert manifest["app"] == "data_quality_gate_project"
     assert manifest["deterministic"] is True
+    assert manifest["inputs"]["input_mode"] == "synthetic"
     assert manifest["promotion_hint"] == "manual-review"
-    assert set(manifest["artifacts"]) >= {"baseline", "candidate", "drift_metrics", "gate_decision"}
+    assert set(manifest["artifacts"]) >= {
+        "baseline",
+        "candidate",
+        "dashboard",
+        "decision_card",
+        "drift_metrics",
+        "gate_decision",
+        "input_sources",
+    }
     assert all(len(artifact["sha256"]) == 64 for artifact in manifest["artifacts"].values())
 
     with (tmp_path / "drift_metrics.csv").open(encoding="utf-8", newline="") as stream:
         rows = list(csv.DictReader(stream))
     assert {row["feature"] for row in rows} == {"age", "income", "risk_score", "segment", "region"}
     assert any(row["severity"] == "warn" for row in rows)
+
+    decision_card = json.loads((tmp_path / "decision_card.json").read_text(encoding="utf-8"))
+    assert decision_card["recommended_action"].startswith("Hold promotion")
+    assert decision_card["risk_score"] > 0
+    assert "manual-review" in (tmp_path / "data_quality_dashboard.html").read_text(encoding="utf-8")
 
 
 def test_data_quality_gate_blocks_quality_and_leakage_issues(tmp_path: Path) -> None:
@@ -72,6 +125,135 @@ def test_data_quality_gate_blocks_quality_and_leakage_issues(tmp_path: Path) -> 
 
     decision = json.loads((tmp_path / "gate_decision.json").read_text(encoding="utf-8"))
     assert any("potential leakage columns" in blocker for blocker in decision["blockers"])
+
+
+def test_data_quality_gate_accepts_csv_contract_and_threshold_files(tmp_path: Path) -> None:
+    baseline_csv = tmp_path / "baseline_input.csv"
+    candidate_csv = tmp_path / "candidate_input.csv"
+    contract_json = tmp_path / "contract.json"
+    thresholds_json = tmp_path / "thresholds.json"
+    output_dir = tmp_path / "evidence"
+
+    baseline_csv.write_text(
+        "customer_id,age,segment,target\n"
+        + "\n".join(f"{idx},{20 + idx % 20},{'a' if idx % 2 else 'b'},{idx % 2}" for idx in range(1, 101))
+        + "\n",
+        encoding="utf-8",
+    )
+    candidate_csv.write_text(
+        "customer_id,age,segment,target\n"
+        + "\n".join(f"{idx},{60 + idx % 20},{'c' if idx % 3 else 'b'},{idx % 2}" for idx in range(1, 101))
+        + "\n",
+        encoding="utf-8",
+    )
+    contract_json.write_text(
+        json.dumps(
+            {
+                "schema": "agilab.app.data_quality_gate.contract.v1",
+                "allow_unexpected_columns": False,
+                "columns": {
+                    "customer_id": {"kind": "integer", "role": "identifier", "drift": False},
+                    "age": {"kind": "numeric", "role": "feature", "drift": True},
+                    "segment": {"kind": "categorical", "role": "feature", "drift": True},
+                    "target": {"kind": "binary", "role": "target", "drift": False},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    thresholds_json.write_text(
+        json.dumps({"schema": "agilab.app.data_quality_gate.thresholds.v1", "thresholds": {"psi_block": 0.01}}),
+        encoding="utf-8",
+    )
+
+    summary = build_data_quality_gate_artifacts(
+        output_dir=output_dir,
+        baseline_csv=baseline_csv,
+        candidate_csv=candidate_csv,
+        contract_json=contract_json,
+        thresholds_json=thresholds_json,
+    )
+
+    assert summary["input_mode"] == "csv"
+    assert summary["decision"] == "block"
+    manifest = json.loads((output_dir / "run_manifest.json").read_text(encoding="utf-8"))
+    assert set(manifest["input_sources"]) == {"baseline_csv", "candidate_csv", "contract_json", "thresholds_json"}
+    assert all(len(source["sha256"]) == 64 for source in manifest["input_sources"].values())
+    contract = json.loads((output_dir / "data_contract.json").read_text(encoding="utf-8"))
+    assert contract["thresholds"]["psi_block"] == 0.01
+    assert contract["expected_columns"]["age"]["kind"] == "numeric"
+
+
+def test_data_quality_gate_requires_csv_inputs_as_a_pair(tmp_path: Path) -> None:
+    baseline_csv = tmp_path / "baseline_input.csv"
+    baseline_csv.write_text("customer_id,age,target\n1,20,0\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="baseline_csv and candidate_csv"):
+        build_data_quality_gate_artifacts(output_dir=tmp_path / "evidence", baseline_csv=baseline_csv)
+
+
+def test_data_quality_gate_blocks_contract_type_issues(tmp_path: Path) -> None:
+    baseline_csv = tmp_path / "baseline_input.csv"
+    candidate_csv = tmp_path / "candidate_input.csv"
+    contract_json = tmp_path / "contract.json"
+    output_dir = tmp_path / "evidence"
+
+    baseline_csv.write_text("customer_id,age,target\n1,20,0\n2,21,1\n", encoding="utf-8")
+    candidate_csv.write_text("customer_id,age,target\n1,old,0\n2,older,1\n", encoding="utf-8")
+    contract_json.write_text(
+        json.dumps(
+            {
+                "columns": {
+                    "customer_id": {"kind": "integer", "role": "identifier", "drift": False},
+                    "age": {"kind": "numeric", "role": "feature", "drift": True},
+                    "target": {"kind": "binary", "role": "target", "drift": False},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    summary = build_data_quality_gate_artifacts(
+        output_dir=output_dir,
+        baseline_csv=baseline_csv,
+        candidate_csv=candidate_csv,
+        contract_json=contract_json,
+    )
+
+    assert summary["decision"] == "block"
+    decision = json.loads((output_dir / "gate_decision.json").read_text(encoding="utf-8"))
+    assert any("candidate.age expected numeric-compatible data" in blocker for blocker in decision["blockers"])
+
+
+def test_data_quality_gate_worker_runs_csv_gate_and_mirrors_analysis_artifacts(tmp_path: Path) -> None:
+    env = _make_env(tmp_path)
+    share_root = Path(env.AGI_LOCAL_SHARE)
+    input_root = share_root / "data_quality_gate/input"
+    input_root.mkdir(parents=True, exist_ok=True)
+    (input_root / "baseline.csv").write_text("customer_id,age,target\n1,20,0\n2,21,1\n3,22,0\n", encoding="utf-8")
+    (input_root / "candidate.csv").write_text("customer_id,age,target\n1,60,0\n2,61,1\n3,62,0\n", encoding="utf-8")
+
+    args = DataQualityGateArgs(
+        data_out="data_quality_gate/evidence",
+        baseline_csv="data_quality_gate/input/baseline.csv",
+        candidate_csv="data_quality_gate/input/candidate.csv",
+        reset_target=True,
+    )
+    worker = DataQualityGateWorker()
+    worker.env = env
+    worker.args = args.model_dump(mode="json")
+    worker._worker_id = 0
+    worker.verbose = 0
+
+    worker.start()
+    result = worker.work_pool("data_quality_gate")
+
+    assert set(result["input_mode"]) == {"csv"}
+    assert {"decision", "recommended_action", "risk_score"} <= set(result.columns)
+    evidence_root = share_root / "data_quality_gate/evidence"
+    assert (evidence_root / "run_manifest.json").is_file()
+    assert (evidence_root / "data_quality_dashboard.html").is_file()
+    assert (Path(env.AGILAB_EXPORT_ABS) / "data_quality_gate_project/data_quality_gate/run_manifest.json").is_file()
 
 
 def test_data_quality_gate_reduce_artifact_matches_public_contract(tmp_path: Path) -> None:
@@ -91,7 +273,11 @@ def test_data_quality_gate_reduce_artifact_matches_public_contract(tmp_path: Pat
 
 def test_data_quality_gate_args_reject_unsafe_output_paths() -> None:
     assert DataQualityGateArgs(data_out="safe/evidence").data_out == Path("safe/evidence")
+    assert DataQualityGateArgs(baseline_csv="safe/baseline.csv").baseline_csv == Path("safe/baseline.csv")
+    assert DataQualityGateArgs(baseline_csv="").baseline_csv is None
 
     for value in ("/tmp/out", "~/out", "../out", ".", "C:/temp/out"):
         with pytest.raises(ValueError):
             validate_relative_data_out(value)
+        with pytest.raises(ValueError):
+            DataQualityGateArgs(baseline_csv=value)


### PR DESCRIPTION
## Summary
- add CSV baseline/candidate mode with share-relative path validation
- add JSON contract and threshold policy inputs with source hashing
- write richer replayable evidence: decision card, dashboard, input source manifest, recommended action, risk score
- update app README, pipeline metadata, worker metrics, and regression coverage

## Validation
- UV_PYTHON=3.13 uv --preview-features extra-build-dependencies run --extra ui pytest -q -o addopts='' test/test_data_quality_gate_project.py
- UV_PYTHON=3.13 uv --preview-features extra-build-dependencies run --extra dev ruff check src/agilab/apps/builtin/data_quality_gate_project/src/data_quality_gate src/agilab/apps/builtin/data_quality_gate_project/src/data_quality_gate_worker src/agilab/apps/builtin/data_quality_gate_project/src/app_args_form.py test/test_data_quality_gate_project.py
- UV_PYTHON=3.13 uv --preview-features extra-build-dependencies run python tools/app_contract_matrix.py --quiet
- UV_PYTHON=3.13 uv --preview-features extra-build-dependencies run --extra ui pytest -q -o addopts='' test/test_app_installer_packaging.py test/test_default_app_cluster_settings.py test/test_package_split_contract.py test/test_package_wheel_sanitizer.py
- UV_PYTHON=3.13 uv --preview-features extra-build-dependencies run python -m build --wheel --sdist --outdir /tmp/agilab-dq-dist src/agilab/lib/agi-app-data-quality-gate
- CLI smoke: build_data_quality_gate_artifacts(output_dir=/tmp/agilab-dq-evidence)
- UV_PYTHON=3.13 uv --preview-features extra-build-dependencies run python tools/impact_validate.py --staged
- Split impact pytest slice: root 37 passed, core 29 passed