### PR TITLE
Improve ABOUT first-run showcase rendering

### DIFF
--- a/src/agilab/about_page/onboarding.py
+++ b/src/agilab/about_page/onboarding.py
@@ -49,6 +49,138 @@ FIRST_PROOF_NOTEBOOK_QUERY_PARAMS = {"start": "notebook-import"}
 FIRST_PROOF_NOTEBOOK_SAMPLE_QUERY_KEY = "sample"
 FIRST_PROOF_NOTEBOOK_SAMPLE_QUERY_VALUE = "agilab-first-proof"
 FIRST_PROOF_ACTION_QUERY_KEY = "first_proof_action"
+SHOWCASE_DOC_BASE_URL = "https://thalesgroup.github.io/agilab"
+FIRST_RUN_SHOWCASE_VISIBLE_LIMIT = 5
+FIRST_RUN_SHOWCASE_ITEMS = (
+    {
+        "route": "Flight telemetry first proof",
+        "evidence": "run manifest plus map and network evidence",
+        "preview_page": "flight-telemetry-project",
+        "run_page": "ORCHESTRATE",
+        "active_app": "flight_telemetry_project",
+        "run_label": "Run proof",
+    },
+    {
+        "route": "Weather notebook migration",
+        "evidence": "forecast artifacts from a migrated notebook workflow",
+        "preview_page": "notebook-migration-skforecast-meteo",
+        "run_page": "ORCHESTRATE",
+        "active_app": "weather_forecast_project",
+        "run_label": "Open run page",
+    },
+    {
+        "route": "Classic ML pipeline",
+        "evidence": "scikit-learn model, predictions, metrics, and hashes",
+        "preview_page": "public-app-catalog",
+        "run_page": "ORCHESTRATE",
+        "active_app": "sklearn_pipeline_project",
+        "run_label": "Open run page",
+    },
+    {
+        "route": "Mission decision",
+        "evidence": "scenario scoring, replanning, and decision artifacts",
+        "preview_page": "advanced-proof-pack",
+        "run_page": "ORCHESTRATE",
+        "active_app": "mission_decision_project",
+        "run_label": "Open run page",
+    },
+    {
+        "route": "Pandas execution speedup",
+        "evidence": "typed Cython worker runtime evidence",
+        "preview_page": "execution-playground",
+        "run_page": "ORCHESTRATE",
+        "active_app": "execution_pandas_project",
+        "run_label": "Open run page",
+    },
+    {
+        "route": "Polars execution",
+        "evidence": "Polars worker execution evidence for comparison",
+        "preview_page": "execution-playground",
+        "run_page": "ORCHESTRATE",
+        "active_app": "execution_polars_project",
+        "run_label": "Open run page",
+    },
+    {
+        "route": "PyTorch playground",
+        "evidence": "classifier controls, loss landscape, and artifacts",
+        "preview_page": "public-app-catalog",
+        "run_page": "ANALYSIS",
+        "active_app": "pytorch_playground_project",
+        "run_label": "Open playground",
+    },
+    {
+        "route": "UAV relay queue",
+        "evidence": "relay health, scenario cockpit, and network analysis",
+        "preview_page": "advanced-proof-pack",
+        "run_page": "ORCHESTRATE",
+        "active_app": "uav_relay_queue_project",
+        "run_label": "Open run page",
+    },
+    {
+        "route": "UAV queue policy",
+        "evidence": "queue-policy proof and scenario-cockpit artifacts",
+        "preview_page": "advanced-proof-pack",
+        "run_page": "ORCHESTRATE",
+        "active_app": "uav_queue_project",
+        "run_label": "Open run page",
+    },
+    {
+        "route": "Multi-app DAG",
+        "evidence": "cross-app artifact handoff and workflow contract",
+        "preview_page": "public-app-catalog",
+        "run_page": "WORKFLOW",
+        "active_app": "multi_app_dag_project",
+        "run_label": "Open workflow",
+    },
+    {
+        "route": "TeSciA diagnostic",
+        "evidence": "scored diagnostic cases and classroom batch artifacts",
+        "preview_page": "public-app-catalog",
+        "run_page": "ORCHESTRATE",
+        "active_app": "tescia_diagnostic_project",
+        "run_label": "Open run page",
+    },
+    {
+        "route": "R runtime bridge",
+        "evidence": "Rscript JSON input/output and manifest hashes",
+        "preview_page": "public-app-catalog",
+        "run_page": "ORCHESTRATE",
+        "active_app": "r_runtime_bridge_project",
+        "run_label": "Open run page",
+    },
+    {
+        "route": "Excel workbook proof",
+        "evidence": "workbook, CSV outputs, and JSON evidence",
+        "preview_page": "excel-users",
+        "run_label": "Preview script",
+    },
+    {
+        "route": "Voila dashboard proof",
+        "evidence": "hide-code dashboard bridge and app-view evidence",
+        "preview_page": "voila-users",
+        "run_label": "Preview script",
+    },
+    {
+        "route": "MLflow tracking",
+        "evidence": "AGILAB run evidence with optional MLflow handoff",
+        "preview_page": "agilab-mlops-positioning",
+        "run_label": "Preview route",
+    },
+    {
+        "route": "Service and cluster path",
+        "evidence": "service health gates and distributed worker controls",
+        "preview_page": "service-mode",
+        "run_page": "ORCHESTRATE",
+        "active_app": "flight_telemetry_project",
+        "run_label": "Open controls",
+    },
+    {
+        "route": "Local/offline LLM",
+        "evidence": "assistant-provider setup for local model experiments",
+        "preview_page": "quick-start",
+        "run_label": "Open setup",
+    },
+)
 FIRST_PROOF_VIEW_MAPS_PATH = (
     _AGILAB_ROOT
     / "apps-pages"
@@ -261,6 +393,75 @@ def _first_proof_page_url(page_name: str, query_params: Dict[str, str] | None = 
     query = urlencode(query_params or {})
     suffix = f"?{query}" if query else ""
     return f"/{page_name}{suffix}"
+
+
+def _showcase_docs_url(page_name: str) -> str:
+    """Return the public documentation URL for a first-run showcase route."""
+    return f"{SHOWCASE_DOC_BASE_URL}/{page_name}.html"
+
+
+def _first_run_showcase_items() -> List[Dict[str, str]]:
+    """Return visible first-run routes with preview and progressive run links."""
+    items: List[Dict[str, str]] = []
+    for item in FIRST_RUN_SHOWCASE_ITEMS:
+        route = str(item["route"])
+        preview_url = _showcase_docs_url(str(item["preview_page"]))
+        access_parts = [f"[Preview]({preview_url})"]
+        run_page = str(item.get("run_page") or "").strip()
+        active_app = str(item.get("active_app") or "").strip()
+        if run_page and active_app:
+            run_url = _first_proof_page_url(run_page, {"active_app": active_app})
+            access_parts.append(f"[{item['run_label']}]({run_url})")
+        else:
+            access_parts.append(f"[{item['run_label']}]({preview_url})")
+        items.append(
+            {
+                "route": route,
+                "evidence": str(item["evidence"]),
+                "access": " / ".join(access_parts),
+            }
+        )
+    return items
+
+
+def _first_run_showcase_markdown(items: List[Dict[str, str]]) -> str:
+    """Render the first-run showcase as a compact Markdown table."""
+    def _cell(value: str) -> str:
+        return value.replace("|", "\\|").replace("\n", " ")
+
+    table = ["| Route | Evidence signal | Access |", "| --- | --- | --- |"]
+    table.extend(
+        f"| {_cell(item['route'])} | {_cell(item['evidence'])} | {item['access']} |"
+        for item in items
+    )
+    return "\n".join(table)
+
+
+def _first_run_showcase_card_markdown(item: Dict[str, str]) -> str:
+    """Render one flagship route as a compact card body."""
+    return f"**{item['route']}**\n\n{item['evidence']}\n\n{item['access']}"
+
+
+def _render_first_run_showcase() -> None:
+    """Render flagship routes without overwhelming the first-proof path."""
+    items = _first_run_showcase_items()
+    visible_items = items[:FIRST_RUN_SHOWCASE_VISIBLE_LIMIT]
+    remaining_items = items[FIRST_RUN_SHOWCASE_VISIBLE_LIMIT:]
+
+    st.markdown("**Explore more proof routes**")
+    st.caption(
+        "Start with the built-in first proof. These routes stay available when you want "
+        "another demo, notebook migration, or integration proof."
+    )
+    for offset in range(0, len(visible_items), 3):
+        row = visible_items[offset : offset + 3]
+        for column, item in zip(st.columns(len(row)), row):
+            with column:
+                st.markdown(_first_run_showcase_card_markdown(item))
+
+    if remaining_items:
+        with st.expander(f"Show {len(remaining_items)} more routes", expanded=False):
+            st.markdown(_first_run_showcase_markdown(remaining_items))
 
 
 def _first_proof_analysis_view_maps_url() -> str:
@@ -652,6 +853,8 @@ def _render_first_proof_wizard_actions(
         st.markdown(_notebook_to_validated_app_markdown(_notebook_to_validated_app_rows(env)))
         st.caption(_first_proof_adoption_gate_caption(_first_proof_adoption_gate(env, state)))
         st.caption(_first_proof_handoff_bundle_caption(_first_proof_handoff_bundle_rows(env, state)))
+
+    _render_first_run_showcase()
 
 
 def _render_first_proof_next_action(

--- a/test/test_about_agilab_helpers.py
+++ b/test/test_about_agilab_helpers.py
@@ -5077,12 +5077,18 @@ def test_render_newcomer_first_proof_places_wizard_before_diagnostics(
         "expander",
         "If it fails / proof details:False",
     )
+    showcase = _event_index(
+        fake_st.events,
+        "markdown",
+        "**Explore more proof routes**",
+    )
     progress = _event_index(fake_st.events, "markdown", "**Progress**")
     validated_path = _event_index(fake_st.events, "caption", "Validated path:")
 
     assert [body for kind, body in fake_st.events if kind == "expander"] == [
         "Create from included notebook:False",
         "Notebook to validated app: full proof:False",
+        "Show 12 more routes:False",
         "If it fails / proof details:False",
     ]
     assert not any(
@@ -5096,12 +5102,25 @@ def test_render_newcomer_first_proof_places_wizard_before_diagnostics(
     assert "| Step | Status | Action | Evidence |" in pre_detail_markdown[1]
     assert "Download pipeline notebook" in pre_detail_markdown[1]
     assert "lab_stages.ipynb" in pre_detail_markdown[1]
-    assert [body for kind, body in pre_details if kind == "columns"] == ["3"]
+    assert pre_detail_markdown[2] == "**Explore more proof routes**"
+    assert "Flight telemetry first proof" in pre_detail_markdown[3]
+    assert "Weather notebook migration" in pre_detail_markdown[4]
+    assert "Classic ML pipeline" in pre_detail_markdown[5]
+    assert "Mission decision" in pre_detail_markdown[6]
+    assert "Pandas execution speedup" in pre_detail_markdown[7]
+    assert "| Route | Evidence signal | Access |" in pre_detail_markdown[8]
+    assert "Polars execution" in pre_detail_markdown[8]
+    assert "PyTorch playground" in pre_detail_markdown[8]
+    assert "TeSciA diagnostic" in pre_detail_markdown[8]
+    assert "MLflow tracking" in pre_detail_markdown[8]
+    assert "/ORCHESTRATE?active_app=mission_decision_project" in pre_detail_markdown[6]
+    assert "/ANALYSIS?active_app=pytorch_playground_project" in pre_detail_markdown[8]
+    assert [body for kind, body in pre_details if kind == "columns"] == ["3", "3", "2"]
     first_action_column = _event_index(fake_st.events, "enter_column", "0")
     second_action_column = _event_index(fake_st.events, "enter_column", "1")
     third_action_column = _event_index(fake_st.events, "enter_column", "2")
     caption_bodies = [body for kind, body in pre_details if kind == "caption"]
-    assert len(caption_bodies) == 12
+    assert len(caption_bodies) == 13
     assert caption_bodies[0] == (
         "Recommended path: run the built-in flight telemetry demo, then inspect the generated evidence. Notebook-first paths are below: use AGILAB's included notebook first; upload your own notebook from PROJECT Create when you are ready."
     )
@@ -5133,6 +5152,7 @@ def test_render_newcomer_first_proof_places_wizard_before_diagnostics(
     assert "Run one local proof first" in caption_bodies[10]
     assert caption_bodies[11].startswith("Handoff bundle:")
     assert "strict security-check output" in caption_bodies[11]
+    assert caption_bodies[12].startswith("Start with the built-in first proof.")
     assert link_types == {
         "1. INSTALL demo": "secondary",
         "2. EXECUTE demo": "secondary",
@@ -5153,7 +5173,7 @@ def test_render_newcomer_first_proof_places_wizard_before_diagnostics(
     assert (
         open_analysis < analysis_hint < notebook_option < notebook_start < notebook_hint
     )
-    assert notebook_hint < notebook_full_proof < proof_details
+    assert notebook_hint < notebook_full_proof < showcase < proof_details
     assert proof_details < progress < validated_path
 
 
@@ -5336,6 +5356,49 @@ def test_first_proof_page_urls_preserve_targeted_query_params():
     assert parsed_analysis_url.path == "/ANALYSIS"
     assert analysis_params["active_app"] == ["flight_telemetry_project"]
     assert analysis_params["current_page"][0].endswith("view_maps.py")
+
+
+def test_first_run_showcase_exposes_flagship_routes_and_progressive_links():
+    onboarding = about_agilab._about_onboarding
+
+    items = onboarding._first_run_showcase_items()
+    by_route = {item["route"]: item for item in items}
+
+    assert len(items) >= 16
+    for route in (
+        "Flight telemetry first proof",
+        "Weather notebook migration",
+        "Mission decision",
+        "Pandas execution speedup",
+        "Polars execution",
+        "PyTorch playground",
+        "UAV relay queue",
+        "UAV queue policy",
+        "TeSciA diagnostic",
+        "R runtime bridge",
+        "Excel workbook proof",
+        "Voila dashboard proof",
+        "MLflow tracking",
+        "Local/offline LLM",
+    ):
+        assert route in by_route
+        assert "[Preview](https://thalesgroup.github.io/agilab/" in by_route[route]["access"]
+
+    assert "/ORCHESTRATE?active_app=flight_telemetry_project" in by_route["Flight telemetry first proof"]["access"]
+    assert "/ORCHESTRATE?active_app=mission_decision_project" in by_route["Mission decision"]["access"]
+    assert "/ANALYSIS?active_app=pytorch_playground_project" in by_route["PyTorch playground"]["access"]
+    assert "/ORCHESTRATE?active_app=tescia_diagnostic_project" in by_route["TeSciA diagnostic"]["access"]
+    assert "excel-users.html" in by_route["Excel workbook proof"]["access"]
+    assert "voila-users.html" in by_route["Voila dashboard proof"]["access"]
+
+    markdown = onboarding._first_run_showcase_markdown(items)
+    assert "| Route | Evidence signal | Access |" in markdown
+    assert "Classic ML pipeline" in markdown
+    assert "Service and cluster path" in markdown
+    assert onboarding.FIRST_RUN_SHOWCASE_VISIBLE_LIMIT == 5
+    card = onboarding._first_run_showcase_card_markdown(by_route["Flight telemetry first proof"])
+    assert "**Flight telemetry first proof**" in card
+    assert "/ORCHESTRATE?active_app=flight_telemetry_project" in card
 
 
 def test_first_proof_text_column_width_has_stable_floor():

--- a/test/test_agilab_web_robot.py
+++ b/test/test_agilab_web_robot.py
@@ -465,8 +465,8 @@ def test_main_print_only_json_has_no_playwright_requirement(capsys) -> None:
     payload = json.loads(capsys.readouterr().out)
     assert payload["base_url"] == "http://127.0.0.1:9999"
     assert payload["route"] == [
-        "landing Upload chooser",
-        "PROJECT notebook handoff",
+        "landing built-in notebook link",
+        "PROJECT sample notebook handoff",
         "ORCHESTRATE",
         "ANALYSIS",
     ]
@@ -1255,42 +1255,41 @@ class _FakeLocator:
     def count(self) -> int:
         return self._count
 
+    @property
+    def first(self):
+        return self
+
     def inner_text(self, *, timeout: int) -> str:
         assert self.selector == "body"
         return self.page.body_text
 
     def click(self, *, timeout: float) -> None:
+        if self.page.link_error is not None and self.selector.startswith("text:Create from included notebook"):
+            raise self.page.link_error
         self.page.clicked_selectors.append((self.selector, timeout))
 
+    def wait_for(self, *, timeout: float) -> None:
+        if self.page.link_error is not None and self.selector == "a:Create from built-in notebook":
+            raise self.page.link_error
+        if (
+            self.page.selector_error is not None
+            and self.selector.startswith("text:AGILAB's included notebook is selected")
+        ):
+            raise self.page.selector_error
 
-class _FakeFileChooser:
-    def __init__(self, page) -> None:
-        self.page = page
-
-    def set_files(self, path: str) -> None:
-        self.page.selected_files.append(Path(path).name)
-
-
-class _FakeFileChooserContext:
-    def __init__(self, page, error: Exception | None = None) -> None:
-        self.value = _FakeFileChooser(page)
-        self.error = error
-
-    def __enter__(self):
-        if self.error is not None:
-            raise self.error
-        return self
-
-    def __exit__(self, *_exc):
-        return None
+    def get_attribute(self, name: str) -> str | None:
+        assert self.selector == "a:Create from built-in notebook"
+        assert name == "href"
+        return self.page.link_href
 
 
 class _FakeBrowserPage:
     def __init__(
         self,
         *,
-        chooser_error: Exception | None = None,
         goto_error: Exception | None = None,
+        link_error: Exception | None = None,
+        link_href: str | None = "/PROJECT?active_app=flight&start=notebook-import&sample=agilab-first-proof",
         selector_error: Exception | None = None,
         url_error: Exception | None = None,
     ) -> None:
@@ -1298,10 +1297,10 @@ class _FakeBrowserPage:
         self.body_text = ""
         self.launch_headless: bool | None = None
         self.clicked_selectors: list[tuple[str, float]] = []
-        self.selected_files: list[str] = []
         self.visited: list[str] = []
-        self.chooser_error = chooser_error
         self.goto_error = goto_error
+        self.link_error = link_error
+        self.link_href = link_href
         self.selector_error = selector_error
         self.url_error = url_error
 
@@ -1317,8 +1316,10 @@ class _FakeBrowserPage:
             self.body_text = "View: selected analysis view"
         elif "ANALYSIS" in url:
             self.body_text = "ANALYSIS Choose pages View:"
+        elif "PROJECT" in url:
+            self.body_text = "PROJECT AGILAB's included notebook is selected"
         else:
-            self.body_text = "First proof Upload"
+            self.body_text = "First proof Explore more proof routes Create from included notebook"
 
     def wait_for_selector(self, selector: str, *, timeout: float) -> None:
         if (
@@ -1335,16 +1336,18 @@ class _FakeBrowserPage:
         if self.url_error is not None:
             raise self.url_error
         self.url = "http://demo/PROJECT?active_app=flight"
-        self.body_text = "PROJECT notebook uploader"
+        self.body_text = "PROJECT AGILAB's included notebook is selected"
 
-    def expect_file_chooser(self, *, timeout: float):
-        return _FakeFileChooserContext(self, self.chooser_error)
+    def get_by_text(self, text: str, *, exact: bool = False):
+        return _FakeLocator(self, selector=f"text:{text}")
 
-    def locator(self, selector: str):
+    def locator(self, selector: str, **kwargs):
         if selector == "body":
             return _FakeLocator(self, selector=selector)
         if selector == "[data-testid='stException']":
             return _FakeLocator(self, selector=selector, count=0)
+        if selector == "a" and kwargs.get("has_text") == "Create from built-in notebook":
+            return _FakeLocator(self, selector="a:Create from built-in notebook", count=1)
         return _FakeLocator(self, selector=selector)
 
     def screenshot(self, *, path: str, full_page: bool) -> None:
@@ -1370,9 +1373,9 @@ def test_run_browser_robot_covers_full_happy_path_with_analysis_view(monkeypatch
     assert [step.label for step in steps] == [
         "landing navigation",
         "landing page",
-        "about upload button",
-        "notebook upload handoff",
-        "project notebook uploader",
+        "about built-in notebook link",
+        "built-in notebook handoff",
+        "project sample notebook import",
         "orchestrate navigation",
         "orchestrate page",
         "analysis navigation",
@@ -1382,8 +1385,7 @@ def test_run_browser_robot_covers_full_happy_path_with_analysis_view(monkeypatch
     ]
     assert all(step.success for step in steps)
     assert page.launch_headless is True
-    assert page.clicked_selectors == [("[data-testid='stFileUploaderDropzone'] button", 1000.0)]
-    assert page.selected_files == ["agilab-web-robot-upload.ipynb"]
+    assert page.clicked_selectors == [("text:Create from included notebook", 1000.0)]
     assert page.visited[-1].endswith("active_app=flight&current_page=%2Fapp%2Fview_maps.py")
 
 
@@ -1405,7 +1407,7 @@ def test_run_browser_robot_skips_analysis_sidecar_when_not_requested(monkeypatch
     assert not any("current_page=" in url for url in page.visited)
 
 
-def test_run_browser_robot_reports_upload_handoff_failure(monkeypatch, tmp_path: Path) -> None:
+def test_run_browser_robot_reports_notebook_handoff_failure(monkeypatch, tmp_path: Path) -> None:
     module = _load_module()
     page = _FakeBrowserPage()
     PlaywrightError, _TimeoutError = _install_fake_playwright(monkeypatch, module, page)
@@ -1420,13 +1422,13 @@ def test_run_browser_robot_reports_upload_handoff_failure(monkeypatch, tmp_path:
         screenshot_dir=tmp_path,
     )
 
-    assert steps[-1].label == "notebook upload handoff"
+    assert steps[-1].label == "built-in notebook handoff"
     assert steps[-1].success is False
-    assert "PROJECT did not open after notebook upload" in steps[-1].detail
+    assert "PROJECT did not open after built-in notebook handoff" in steps[-1].detail
     assert "screenshot=" in steps[-1].detail
 
 
-def test_run_browser_robot_reports_upload_handoff_failure_without_screenshot(monkeypatch) -> None:
+def test_run_browser_robot_reports_notebook_handoff_failure_without_screenshot(monkeypatch) -> None:
     module = _load_module()
     page = _FakeBrowserPage()
     PlaywrightError, _TimeoutError = _install_fake_playwright(monkeypatch, module, page)
@@ -1440,15 +1442,15 @@ def test_run_browser_robot_reports_upload_handoff_failure_without_screenshot(mon
         timeout=1.0,
     )
 
-    assert steps[-1].label == "notebook upload handoff"
-    assert steps[-1].detail == "PROJECT did not open after notebook upload: PROJECT did not load"
+    assert steps[-1].label == "built-in notebook handoff"
+    assert steps[-1].detail == "PROJECT did not open after built-in notebook handoff: PROJECT did not load"
 
 
-def test_run_browser_robot_reports_upload_button_failure(monkeypatch, tmp_path: Path) -> None:
+def test_run_browser_robot_reports_built_in_notebook_link_failure(monkeypatch, tmp_path: Path) -> None:
     module = _load_module()
     page = _FakeBrowserPage()
     PlaywrightError, _TimeoutError = _install_fake_playwright(monkeypatch, module, page)
-    page.chooser_error = PlaywrightError("chooser blocked")
+    page.link_error = PlaywrightError("link blocked")
 
     steps = module.run_browser_robot(
         base_url="http://demo",
@@ -1459,17 +1461,17 @@ def test_run_browser_robot_reports_upload_button_failure(monkeypatch, tmp_path: 
         screenshot_dir=tmp_path,
     )
 
-    assert steps[-1].label == "about upload button"
+    assert steps[-1].label == "about built-in notebook link"
     assert steps[-1].success is False
-    assert "could not open file chooser" in steps[-1].detail
+    assert "could not validate ABOUT built-in notebook link" in steps[-1].detail
     assert "screenshot=" in steps[-1].detail
 
 
-def test_run_browser_robot_reports_upload_button_failure_without_screenshot(monkeypatch) -> None:
+def test_run_browser_robot_reports_built_in_notebook_link_failure_without_screenshot(monkeypatch) -> None:
     module = _load_module()
     page = _FakeBrowserPage()
     PlaywrightError, _TimeoutError = _install_fake_playwright(monkeypatch, module, page)
-    page.chooser_error = PlaywrightError("chooser blocked")
+    page.link_error = PlaywrightError("link blocked")
 
     steps = module.run_browser_robot(
         base_url="http://demo",
@@ -1479,16 +1481,16 @@ def test_run_browser_robot_reports_upload_button_failure_without_screenshot(monk
         timeout=1.0,
     )
 
-    assert steps[-1].label == "about upload button"
+    assert steps[-1].label == "about built-in notebook link"
     assert steps[-1].success is False
-    assert steps[-1].detail == "could not open file chooser from ABOUT Upload button: chooser blocked"
+    assert steps[-1].detail == "could not validate ABOUT built-in notebook link: link blocked"
 
 
-def test_run_browser_robot_reports_project_uploader_failure(monkeypatch, tmp_path: Path) -> None:
+def test_run_browser_robot_reports_project_sample_import_failure(monkeypatch, tmp_path: Path) -> None:
     module = _load_module()
     page = _FakeBrowserPage()
     PlaywrightError, _TimeoutError = _install_fake_playwright(monkeypatch, module, page)
-    page.selector_error = PlaywrightError("uploader missing")
+    page.selector_error = PlaywrightError("sample import missing")
 
     steps = module.run_browser_robot(
         base_url="http://demo",
@@ -1499,17 +1501,17 @@ def test_run_browser_robot_reports_project_uploader_failure(monkeypatch, tmp_pat
         screenshot_dir=tmp_path,
     )
 
-    assert steps[-1].label == "project notebook uploader"
+    assert steps[-1].label == "project sample notebook import"
     assert steps[-1].success is False
-    assert "PROJECT notebook uploader not visible" in steps[-1].detail
+    assert "PROJECT sample notebook import not visible" in steps[-1].detail
     assert "screenshot=" in steps[-1].detail
 
 
-def test_run_browser_robot_reports_project_uploader_failure_without_screenshot(monkeypatch) -> None:
+def test_run_browser_robot_reports_project_sample_import_failure_without_screenshot(monkeypatch) -> None:
     module = _load_module()
     page = _FakeBrowserPage()
     PlaywrightError, _TimeoutError = _install_fake_playwright(monkeypatch, module, page)
-    page.selector_error = PlaywrightError("uploader missing")
+    page.selector_error = PlaywrightError("sample import missing")
 
     steps = module.run_browser_robot(
         base_url="http://demo",
@@ -1519,8 +1521,11 @@ def test_run_browser_robot_reports_project_uploader_failure_without_screenshot(m
         timeout=1.0,
     )
 
-    assert steps[-1].label == "project notebook uploader"
-    assert steps[-1].detail == "PROJECT notebook uploader not visible after upload handoff: uploader missing"
+    assert steps[-1].label == "project sample notebook import"
+    assert (
+        steps[-1].detail
+        == "PROJECT sample notebook import not visible after handoff: sample import missing"
+    )
 
 
 def test_run_browser_robot_can_stop_after_navigation_steps(monkeypatch) -> None:
@@ -1943,4 +1948,4 @@ def test_render_human_non_json_output_includes_route_and_step_details(capsys) ->
     assert module.main(["--print-only", "--port", "8765"]) == 0
     human = capsys.readouterr().out
     assert "mode: print-only" in human
-    assert "route: landing Upload chooser -> PROJECT notebook handoff -> ORCHESTRATE -> ANALYSIS" in human
+    assert "route: landing built-in notebook link -> PROJECT sample notebook handoff -> ORCHESTRATE -> ANALYSIS" in human

--- a/test/test_first_launch_robot.py
+++ b/test/test_first_launch_robot.py
@@ -32,7 +32,7 @@ def test_first_launch_robot_passes_static_first_surface(tmp_path: Path) -> None:
     assert report["status"] == "pass", json.dumps(report, indent=2, sort_keys=True)
     assert report["success"] is True
     assert report["within_target"] is True
-    assert report["summary"]["check_count"] == 8
+    assert report["summary"]["check_count"] == 9
     checks = {check["id"]: check for check in report["checks"]}
     assert checks["first_launch_no_exceptions"]["status"] == "pass"
     assert checks["first_launch_env_initialized"]["status"] == "pass"
@@ -214,7 +214,10 @@ def test_first_launch_robot_entrypoint_runs_with_fake_apptest(
         markdown = [
             Widget(
                 "AGILAB logo AI/ML reproducibility workbench "
-                f'DEMO / ORCHESTRATE / ANALYSIS <a href="{readme_route}">README</a>'
+                "DEMO / ORCHESTRATE / ANALYSIS "
+                "Explore more proof routes "
+                "Weather notebook migration Mission decision PyTorch playground MLflow tracking "
+                f'<a href="{readme_route}">README</a>'
             )
         ]
         caption: list[object] = []
@@ -253,4 +256,4 @@ def test_first_launch_robot_entrypoint_runs_with_fake_apptest(
 
     payload = json.loads(capsys.readouterr().out)
     assert payload["status"] == "pass"
-    assert payload["summary"]["check_count"] == 8
+    assert payload["summary"]["check_count"] == 9

--- a/tools/agilab_web_robot.py
+++ b/tools/agilab_web_robot.py
@@ -686,57 +686,56 @@ def run_browser_robot(
                     assert_page_healthy(
                         page,
                         label="landing page",
-                        expect_any=("First proof", "Upload"),
+                        expect_any=("First proof", "Explore more proof routes"),
                         timeout_ms=timeout_ms,
                         screenshot_dir=screenshot_dir,
                     ),
                 ):
                     return steps
 
-                robot_notebook_path = Path(tempfile.gettempdir()) / "agilab-web-robot-upload.ipynb"
-                robot_notebook_path.write_text(
-                    json.dumps(
-                        {
-                            "cells": [
-                                {
-                                    "cell_type": "code",
-                                    "execution_count": None,
-                                    "metadata": {},
-                                    "outputs": [],
-                                    "source": ["print('hello from AGILAB web robot')"],
-                                }
-                            ],
-                            "metadata": {},
-                            "nbformat": 4,
-                            "nbformat_minor": 5,
-                        }
-                    ),
-                    encoding="utf-8",
-                )
                 start = time.perf_counter()
                 try:
-                    with page.expect_file_chooser(timeout=timeout_ms) as file_chooser_info:
-                        page.locator("[data-testid='stFileUploaderDropzone'] button").click(
-                            timeout=timeout_ms
+                    page.get_by_text("Create from included notebook", exact=True).first.click(
+                        timeout=timeout_ms
+                    )
+                    link = page.locator("a", has_text="Create from built-in notebook").first
+                    link.wait_for(timeout=timeout_ms)
+                    notebook_href = link.get_attribute("href")
+                    if not notebook_href:
+                        raise RuntimeError("Create from built-in notebook link has no href")
+                    parsed_href = urllib.parse.urlparse(notebook_href)
+                    parsed_query = urllib.parse.parse_qs(parsed_href.query)
+                    expected_query = {
+                        "start": ["notebook-import"],
+                        "sample": ["agilab-first-proof"],
+                    }
+                    missing_query = {
+                        key: value
+                        for key, value in expected_query.items()
+                        if parsed_query.get(key) != value
+                    }
+                    if parsed_href.path != "/PROJECT" or missing_query:
+                        raise RuntimeError(
+                            "Create from built-in notebook link does not target PROJECT sample import: "
+                            f"href={notebook_href!r} missing={missing_query!r}"
                         )
-                    file_chooser_info.value.set_files(str(robot_notebook_path))
                     steps.append(
                         RobotStep(
-                            "about upload button",
+                            "about built-in notebook link",
                             True,
                             time.perf_counter() - start,
-                            "file chooser opened and notebook selected",
+                            "PROJECT sample-import link is visible and well-formed",
                             page.url,
                         )
                     )
-                except (Error, TimeoutError) as exc:
-                    screenshot = _screenshot(page, screenshot_dir, "about upload button")
-                    detail = f"could not open file chooser from ABOUT Upload button: {exc}"
+                except (Error, TimeoutError, RuntimeError) as exc:
+                    screenshot = _screenshot(page, screenshot_dir, "about built-in notebook link")
+                    detail = f"could not validate ABOUT built-in notebook link: {exc}"
                     if screenshot:
                         detail += f"; screenshot={screenshot}"
                     steps.append(
                         RobotStep(
-                            "about upload button",
+                            "about built-in notebook link",
                             False,
                             time.perf_counter() - start,
                             detail,
@@ -747,24 +746,26 @@ def run_browser_robot(
 
                 start = time.perf_counter()
                 try:
+                    project_url = urllib.parse.urljoin(page.url, notebook_href)
+                    page.goto(project_url, wait_until="domcontentloaded", timeout=timeout_ms)
                     page.wait_for_url(re.compile(r".*/PROJECT(?:\?.*)?$"), timeout=timeout_ms)
                     steps.append(
                         RobotStep(
-                            "notebook upload handoff",
+                            "built-in notebook handoff",
                             True,
                             time.perf_counter() - start,
-                            "PROJECT opened",
+                            "PROJECT opened for sample notebook import",
                             page.url,
                         )
                     )
                 except (Error, TimeoutError) as exc:
-                    screenshot = _screenshot(page, screenshot_dir, "notebook upload handoff")
-                    detail = f"PROJECT did not open after notebook upload: {exc}"
+                    screenshot = _screenshot(page, screenshot_dir, "built-in notebook handoff")
+                    detail = f"PROJECT did not open after built-in notebook handoff: {exc}"
                     if screenshot:
                         detail += f"; screenshot={screenshot}"
                     steps.append(
                         RobotStep(
-                            "notebook upload handoff",
+                            "built-in notebook handoff",
                             False,
                             time.perf_counter() - start,
                             detail,
@@ -775,27 +776,29 @@ def run_browser_robot(
 
                 start = time.perf_counter()
                 try:
-                    page.wait_for_selector(
-                        "[data-testid='stFileUploader'], [data-testid='stFileUploaderDropzone']",
+                    page.get_by_text(
+                        "AGILAB's included notebook is selected",
+                        exact=False,
+                    ).wait_for(
                         timeout=timeout_ms,
                     )
                     steps.append(
                         RobotStep(
-                            "project notebook uploader",
+                            "project sample notebook import",
                             True,
                             time.perf_counter() - start,
-                            "visible",
+                            "sample notebook import is visible without a local file chooser",
                             page.url,
                         )
                     )
                 except (Error, TimeoutError) as exc:
-                    screenshot = _screenshot(page, screenshot_dir, "project notebook uploader")
-                    detail = f"PROJECT notebook uploader not visible after upload handoff: {exc}"
+                    screenshot = _screenshot(page, screenshot_dir, "project sample notebook import")
+                    detail = f"PROJECT sample notebook import not visible after handoff: {exc}"
                     if screenshot:
                         detail += f"; screenshot={screenshot}"
                     steps.append(
                         RobotStep(
-                            "project notebook uploader",
+                            "project sample notebook import",
                             False,
                             time.perf_counter() - start,
                             detail,
@@ -931,7 +934,7 @@ def run_frontend_smoke(
                     assert_page_healthy(
                         page,
                         label="frontend landing hydration",
-                        expect_any=("First proof", "Upload"),
+                        expect_any=("First proof", "Explore more proof routes"),
                         timeout_ms=timeout_ms,
                         screenshot_dir=screenshot_dir,
                     ),
@@ -998,8 +1001,8 @@ def _frontend_smoke_route() -> list[str]:
 
 def _full_robot_route() -> list[str]:
     return [
-        "landing Upload chooser",
-        "PROJECT notebook handoff",
+        "landing built-in notebook link",
+        "PROJECT sample notebook handoff",
         "ORCHESTRATE",
         "ANALYSIS",
     ]

--- a/tools/first_launch_robot.py
+++ b/tools/first_launch_robot.py
@@ -231,6 +231,22 @@ def build_report(
             evidence=[str(about_page.relative_to(REPO_ROOT))],
         ),
         _check_result(
+            "first_launch_showcase_signal",
+            "First launch exposes flagship showcase",
+            all(
+                _contains_any([*markdown, *captions, *buttons], [token])
+                for token in (
+                    "Explore more proof routes",
+                    "Weather notebook migration",
+                    "Mission decision",
+                    "PyTorch playground",
+                    "MLflow tracking",
+                )
+            ),
+            "Landing page exposes the broader AGILAB app and proof-route showcase",
+            evidence=[str(about_page.relative_to(REPO_ROOT))],
+        ),
+        _check_result(
             "first_launch_workflow_signal",
             "First launch exposes workflow path",
             _contains_any(


### PR DESCRIPTION
## Summary
- replace the dense always-visible flagship-route table with compact first-run route cards and a collapsed full route list
- keep the first-proof path focused on the built-in demo and included notebook lane
- realign the browser robot to validate the built-in notebook handoff instead of a removed ABOUT file uploader

## Validation
- UV_PYTHON=3.13 uv --preview-features extra-build-dependencies run --extra dev ruff check src/agilab/about_page/onboarding.py tools/agilab_web_robot.py tools/first_launch_robot.py test/test_about_agilab_helpers.py test/test_first_launch_robot.py test/test_agilab_web_robot.py
- UV_PYTHON=3.13 uv --preview-features extra-build-dependencies run --extra ui pytest -q -o addopts='' test/test_about_agilab_helpers.py test/test_agilab_web_robot.py test/test_first_launch_robot.py
- UV_PYTHON=3.13 uv --preview-features extra-build-dependencies run --extra ui python tools/first_launch_robot.py --json --output /tmp/agilab-first-launch-robot.json
- UV_PYTHON=3.13 uv --preview-features extra-build-dependencies run --extra ui --with playwright python tools/agilab_web_robot.py --json --screenshot-dir /tmp/agilab-web-robot-screenshots > /tmp/agilab-web-robot.json
- git diff --check