### PR TITLE
[codex] refactor legacy analysis page chrome

### DIFF
--- a/src/agilab/apps-pages/templates/analysis_page_template/src/view_demo/view_demo.py
+++ b/src/agilab/apps-pages/templates/analysis_page_template/src/view_demo/view_demo.py
@@ -26,6 +26,8 @@ except (ImportError, ModuleNotFoundError, OSError):  # pragma: no cover - packag
 
 
 PAGE_TITLE = "view_demo"
+PAGE_LAYOUT = "wide"
+PAGE_HELP_HTML = "explore-help.html"
 
 
 def _query_param_value(value: object) -> str:
@@ -70,13 +72,17 @@ def _dataset_root(env: Any) -> Path | None:
     return None
 
 
-def main() -> None:
+def _render_page_chrome() -> None:
     st.set_page_config(
         page_title=PAGE_TITLE,
-        layout="wide",
-        menu_items=get_docs_menu_items(html_file="explore-help.html"),
+        layout=PAGE_LAYOUT,
+        menu_items=get_docs_menu_items(html_file=PAGE_HELP_HTML),
     )
     st.title(PAGE_TITLE)
+
+
+def main() -> None:
+    _render_page_chrome()
 
     active_app = _parse_active_app().strip()
     if not active_app:

--- a/src/agilab/apps-pages/view_autoencoder_latentspace/pyproject.toml
+++ b/src/agilab/apps-pages/view_autoencoder_latentspace/pyproject.toml
@@ -13,6 +13,7 @@ keywords = [
     "reproducibility",
 ]
 dependencies = [
+    "agi-pages>=2026.05.30,<2027.0",
     "agi-env>=2026.05.12.post3,<2027.0",
     "agi-node>=2026.05.12.post3,<2027.0",
     "agi-gui>=2026.05.12.post3,<2027.0",
@@ -36,6 +37,7 @@ Discussions = "https://github.com/ThalesGroup/agilab/discussions"
 Changelog = "https://github.com/ThalesGroup/agilab/releases"
 
 [tool.uv.sources]
+agi-pages = { path = "../../lib/agi-pages", editable = true }
 agi-gui = { path = "../../lib/agi-gui", editable = true }
 agi-env = { path = "../../core/agi-env", editable = true }
 agi-node = { path = "../../core/agi-node", editable = true }

--- a/src/agilab/apps-pages/view_autoencoder_latentspace/src/view_autoencoder_latentspace/autoencoder_latentspace.py
+++ b/src/agilab/apps-pages/view_autoencoder_latentspace/src/view_autoencoder_latentspace/autoencoder_latentspace.py
@@ -39,7 +39,7 @@ def _ensure_repo_on_path() -> None:
 
 _ensure_repo_on_path()
 
-from agi_pages.runtime import active_app_scope_value, reset_scoped_session_state
+from agi_pages.runtime import active_app_scope_value, render_streamlit_page_header, reset_scoped_session_state
 from agi_env import AgiEnv
 from agi_env.app_settings_support import prepare_app_settings_for_write
 from agi_gui.pagelib import load_df, sidebar_views, initialize_csv_files, _dump_toml_payload
@@ -70,7 +70,7 @@ APP_SCOPED_SESSION_KEYS = (
     "coltype",
 )
 
-st.title(":chart_with_downwards_trend: Dimension Reduction")
+render_streamlit_page_header(st, title=":chart_with_downwards_trend: Dimension Reduction", show_logo=False)
 
 os.environ["TF_ENABLE_ONEDNN_OPTS"] = "0"
 

--- a/src/agilab/apps-pages/view_barycentric/pyproject.toml
+++ b/src/agilab/apps-pages/view_barycentric/pyproject.toml
@@ -13,6 +13,7 @@ keywords = [
     "reproducibility",
 ]
 dependencies = [
+    "agi-pages>=2026.05.30,<2027.0",
     "agi-env>=2026.05.12.post3,<2027.0",
     "agi-node>=2026.05.12.post3,<2027.0",
     "agi-gui>=2026.05.12.post3,<2027.0",
@@ -46,6 +47,7 @@ Changelog = "https://github.com/ThalesGroup/agilab/releases"
 
 
 [tool.uv.sources]
+agi-pages = { path = "../../lib/agi-pages", editable = true }
 agi-gui = { path = "../../lib/agi-gui", editable = true }
 agi-env = { path = "../../core/agi-env", editable = true }
 agi-node = { path = "../../core/agi-node", editable = true }

--- a/src/agilab/apps-pages/view_barycentric/src/view_barycentric/view_barycentric.py
+++ b/src/agilab/apps-pages/view_barycentric/src/view_barycentric/view_barycentric.py
@@ -53,7 +53,7 @@ def _ensure_repo_on_path() -> None:
 
 _ensure_repo_on_path()
 
-from agi_pages.runtime import reset_scoped_session_state
+from agi_pages.runtime import render_streamlit_page_header, reset_scoped_session_state
 from agi_env import AgiEnv
 from agi_env.app_settings_support import prepare_app_settings_for_write
 from agi_gui.pagelib import find_files, load_df, JumpToMain, update_datadir, _dump_toml_payload
@@ -64,7 +64,7 @@ logger = logging.getLogger(__name__)
 var = ["discrete", "continuous", "lat", "long"]
 var_default = [0, None]
 
-st.title(":chart_with_upwards_trend: Barycentric Graph")
+render_streamlit_page_header(st, title=":chart_with_upwards_trend: Barycentric Graph", show_logo=False)
 
 
 PAGE_KEY_PREFIX = "view_barycentric"

--- a/src/agilab/apps-pages/view_maps/pyproject.toml
+++ b/src/agilab/apps-pages/view_maps/pyproject.toml
@@ -13,6 +13,7 @@ keywords = [
     "reproducibility",
 ]
 dependencies = [
+    "agi-pages>=2026.05.30,<2027.0",
     "agi-env>=2026.05.12.post3,<2027.0",
     "agi-gui>=2026.05.12.post3,<2027.0",
     "agi-node>=2026.05.12.post3,<2027.0",
@@ -43,6 +44,7 @@ Changelog = "https://github.com/ThalesGroup/agilab/releases"
 
 
 [tool.uv.sources]
+agi-pages = { path = "../../lib/agi-pages", editable = true }
 agi-gui = { path = "../../lib/agi-gui", editable = true }
 agi-env = { path = "../../core/agi-env", editable = true }
 agi-node = { path = "../../core/agi-node", editable = true }

--- a/src/agilab/apps-pages/view_maps/src/view_maps/view_maps.py
+++ b/src/agilab/apps-pages/view_maps/src/view_maps/view_maps.py
@@ -63,7 +63,7 @@ def _ensure_repo_on_path() -> None:
 
 _ensure_repo_on_path()
 
-from agi_pages.runtime import reset_scoped_session_state
+from agi_pages.runtime import render_streamlit_page_header, reset_scoped_session_state
 
 
 def _default_app() -> Path | None:
@@ -175,7 +175,7 @@ def _visible_dataset_files(datadir: Path, files: list[Path]) -> list[Path]:
         visible_files.append(file_path)
     return visible_files
 
-st.title(":world_map: Cartography Visualization")
+render_streamlit_page_header(st, title=":world_map: Cartography Visualization", show_logo=False)
 
 
 def continuous():

--- a/src/agilab/apps-pages/view_maps_3d/pyproject.toml
+++ b/src/agilab/apps-pages/view_maps_3d/pyproject.toml
@@ -13,6 +13,7 @@ keywords = [
     "reproducibility",
 ]
 dependencies = [
+    "agi-pages>=2026.05.30,<2027.0",
     "agi-env>=2026.05.12.post3,<2027.0",
     "agi-gui>=2026.05.12.post3,<2027.0",
     "agi-node>=2026.05.12.post3,<2027.0",
@@ -44,6 +45,7 @@ Changelog = "https://github.com/ThalesGroup/agilab/releases"
 
 
 [tool.uv.sources]
+agi-pages = { path = "../../lib/agi-pages", editable = true }
 agi-gui = { path = "../../lib/agi-gui", editable = true }
 agi-env = { path = "../../core/agi-env", editable = true }
 agi-node = { path = "../../core/agi-node", editable = true }

--- a/src/agilab/apps-pages/view_maps_3d/src/view_maps_3d/view_maps_3d.py
+++ b/src/agilab/apps-pages/view_maps_3d/src/view_maps_3d/view_maps_3d.py
@@ -43,7 +43,7 @@ def _ensure_repo_on_path() -> None:
 
 _ensure_repo_on_path()
 
-from agi_pages.runtime import reset_scoped_session_state
+from agi_pages.runtime import render_streamlit_page_header, reset_scoped_session_state
 
 
 def _default_app() -> Path | None:
@@ -62,7 +62,7 @@ def _default_app() -> Path | None:
 
 from agi_env import AgiEnv
 from agi_env.app_settings_support import prepare_app_settings_for_write
-from agi_gui.pagelib import find_files, load_df, render_dataframe_preview, render_logo, _dump_toml_payload
+from agi_gui.pagelib import find_files, load_df, render_dataframe_preview, _dump_toml_payload
 import tomllib as _toml
 
 
@@ -185,7 +185,7 @@ def _list_dataset_files(base_dir: Path, ext_choice: str = "all") -> list[Path]:
     return visible
 
 
-st.title(":world_map: Cartography-3D Visualization")
+render_streamlit_page_header(st, title=":world_map: Cartography-3D Visualization", show_logo=False)
 
 
 def _normalize_legacy_coltype(raw: str) -> str:
@@ -597,7 +597,12 @@ def page():
     Returns:
         None
     """
-    render_logo("3D Maps and Network Topology Visualization")
+    render_streamlit_page_header(
+        st,
+        title="3D Maps and Network Topology Visualization",
+        logo_title="3D Maps and Network Topology Visualization",
+        show_title=False,
+    )
 
     if 'env' not in st.session_state:
         restored = _bootstrap_env_from_active_app()

--- a/src/agilab/apps-pages/view_maps_network/pyproject.toml
+++ b/src/agilab/apps-pages/view_maps_network/pyproject.toml
@@ -13,6 +13,7 @@ keywords = [
     "reproducibility",
 ]
 dependencies = [
+    "agi-pages>=2026.05.30,<2027.0",
     "agi-env>=2026.05.12.post3,<2027.0",
     "agi-gui>=2026.05.12.post3,<2027.0",
     "agi-node>=2026.05.12.post3,<2027.0",
@@ -51,6 +52,7 @@ Changelog = "https://github.com/ThalesGroup/agilab/releases"
 
 
 [tool.uv.sources]
+agi-pages = { path = "../../lib/agi-pages", editable = true }
 agi-gui = { path = "../../lib/agi-gui", editable = true }
 agi-env = { path = "../../core/agi-env", editable = true }
 agi-node = { path = "../../core/agi-node", editable = true }

--- a/src/agilab/apps-pages/view_maps_network/src/view_maps_network/view_maps_network.py
+++ b/src/agilab/apps-pages/view_maps_network/src/view_maps_network/view_maps_network.py
@@ -125,10 +125,9 @@ def _ensure_repo_on_path() -> None:
 
 _ensure_repo_on_path()
 
-from agi_pages.runtime import reset_scoped_session_state
+from agi_pages.runtime import render_streamlit_page_header, reset_scoped_session_state
 from agi_env import AgiEnv
 import agi_gui.pagelib as pagelib
-from agi_gui.pagelib import render_logo
 
 
 def _resolve_active_app() -> Path:
@@ -353,7 +352,11 @@ def _list_subdirectories(base: Path) -> list[str]:
     return []
 
 
-st.title(":world_map: Maps Network Graph")
+render_streamlit_page_header(
+    st,
+    title=":world_map: Maps Network Graph",
+    logo_title="Cartography Visualization",
+)
 
 active_app_path = _resolve_active_app()
 app_scope_changed = _reset_app_scoped_session_state(active_app_path)
@@ -377,8 +380,6 @@ if "TABLE_MAX_ROWS" not in st.session_state:
     st.session_state["TABLE_MAX_ROWS"] = env.TABLE_MAX_ROWS
 if "GUI_SAMPLING" not in st.session_state:
     st.session_state["GUI_SAMPLING"] = env.GUI_SAMPLING
-render_logo("Cartography Visualization")
-
 # Map imagery token must come from runtime env/secrets, never from source code.
 _mapbox_secret = ""
 try:

--- a/src/agilab/lib/agi-pages/src/agi_pages/runtime.py
+++ b/src/agilab/lib/agi-pages/src/agi_pages/runtime.py
@@ -193,6 +193,7 @@ def render_streamlit_page_header(
     logo_title: str | None = None,
     caption: str | None = None,
     show_logo: bool = True,
+    show_title: bool = True,
     render_logo_fn: Callable[..., Any] | None = None,
 ) -> None:
     """Render the common AGILAB analysis-page logo, title, and optional caption."""
@@ -206,6 +207,7 @@ def render_streamlit_page_header(
             render_logo_fn()
         else:
             render_logo_fn(logo_title)
-    streamlit.title(title)
+    if show_title:
+        streamlit.title(title)
     if caption:
         streamlit.caption(caption)

--- a/test/test_agi_pages_runtime.py
+++ b/test/test_agi_pages_runtime.py
@@ -127,6 +127,24 @@ def test_agi_pages_runtime_header_can_skip_logo_and_caption() -> None:
     assert events == [("title", "Embedded training analysis")]
 
 
+def test_agi_pages_runtime_header_can_render_logo_without_title() -> None:
+    events: list[tuple[str, object]] = []
+    fake_st = SimpleNamespace(
+        title=lambda value: events.append(("title", value)),
+        caption=lambda value: events.append(("caption", value)),
+    )
+
+    runtime.render_streamlit_page_header(
+        fake_st,
+        title="3D maps",
+        logo_title="3D Maps",
+        show_title=False,
+        render_logo_fn=lambda *args: events.append(("logo", args)),
+    )
+
+    assert events == [("logo", ("3D Maps",))]
+
+
 def test_agi_pages_runtime_resets_app_scoped_session_state(tmp_path: Path) -> None:
     first_app = tmp_path / "first"
     second_app = tmp_path / "second"

--- a/test/test_view_maps_3d.py
+++ b/test/test_view_maps_3d.py
@@ -695,7 +695,7 @@ def test_view_maps_3d_page_rejects_invalid_datadir(monkeypatch, tmp_path) -> Non
     fake_st.session_state["beamdir"] = tmp_path / "beams"
 
     monkeypatch.setattr(module, "st", fake_st)
-    monkeypatch.setattr(module, "render_logo", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(module, "render_streamlit_page_header", lambda *_args, **_kwargs: None)
 
     module.page()
 
@@ -735,7 +735,7 @@ def test_view_maps_3d_page_handles_invalid_regex_and_empty_selection(monkeypatch
     outside_file = tmp_path / "outside.csv"
 
     monkeypatch.setattr(module, "st", fake_st)
-    monkeypatch.setattr(module, "render_logo", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(module, "render_streamlit_page_header", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(
         module,
         "_list_dataset_files",
@@ -837,7 +837,7 @@ def test_view_maps_3d_page_renders_loaded_datasets_and_geojson_controls(monkeypa
 
     monkeypatch.setattr(module, "st", fake_st)
     monkeypatch.setattr(module, "pdk", _FakePdk)
-    monkeypatch.setattr(module, "render_logo", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(module, "render_streamlit_page_header", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(
         module,
         "_list_dataset_files",
@@ -1020,7 +1020,7 @@ def test_view_maps_3d_page_missing_env_uses_info_fallback(monkeypatch) -> None:
 
     fake_st = _NoPageLinkStreamlit()
     monkeypatch.setattr(module, "st", fake_st)
-    monkeypatch.setattr(module, "render_logo", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(module, "render_streamlit_page_header", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(module, "_bootstrap_env_from_active_app", lambda: False)
 
     with pytest.raises(_StopExecution):


### PR DESCRIPTION
## Summary

Refactors the remaining legacy/special analysis page chrome to use the shared `agi_pages.runtime.render_streamlit_page_header` seam where those pages already depend on the page runtime. This covers the 2D map, 3D map, network map, barycentric, and autoencoder latent-space page bundles while preserving their existing import-time and page-time launch behavior.

The change also adds `show_title=False` support for logo-only legacy call sites, declares the missing `agi-pages>=2026.05.30,<2027.0` runtime dependency in those page bundles, and folds the analysis page template chrome into a local helper without adding a template dependency.

## Validation

- `uv --preview-features extra-build-dependencies run --python 3.13 --extra dev --extra ui --extra viz ruff check --extend-ignore E402,F821 $(git diff --name-only -- '*.py')`
- `uv --preview-features extra-build-dependencies run --python 3.13 --extra ui --extra viz python -m py_compile $(git diff --name-only -- '*.py')`
- `uv --preview-features extra-build-dependencies run --python 3.13 --extra dev --extra ui --extra viz pytest -q -o addopts='' test/test_agi_pages_runtime.py test/test_view_maps.py test/test_view_maps_3d.py test/test_view_maps_network.py test/test_view_maps_network_path_resolution.py test/test_view_barycentric.py test/test_view_autoencoder_latentspace.py test/test_page_bundle_registry.py`
- `uv lock --check`
- `git diff --check`