### PR TITLE
Fix AGI-GUI coverage shard regressions

### DIFF
--- a/src/agilab/global_pipeline_app_dispatch_smoke.py
+++ b/src/agilab/global_pipeline_app_dispatch_smoke.py
@@ -171,9 +171,17 @@ def _relative(path: Path, root: Path) -> str:
 def _ensure_app_project_on_path(repo_root: Path, project_name: str) -> Path:
     src_root = repo_root / "src" / "agilab" / "apps" / "builtin" / project_name / "src"
     src_text = str(src_root)
-    if src_text not in sys.path:
-        sys.path.insert(0, src_text)
+    sys.path[:] = [entry for entry in sys.path if entry != src_text]
+    sys.path.insert(0, src_text)
     return src_root
+
+
+def _drop_app_module_cache(package_names: tuple[str, ...]) -> None:
+    prefixes = tuple(f"{name}." for name in package_names)
+    for module_name in list(sys.modules):
+        if module_name in package_names or module_name.startswith(prefixes):
+            del sys.modules[module_name]
+    importlib.invalidate_caches()
 
 
 def _make_env(run_root: Path, *, target: str) -> SimpleNamespace:
@@ -211,6 +219,7 @@ def _run_queue_family_app(
     app_entry: str,
 ) -> dict[str, Any]:
     _ensure_app_project_on_path(repo_root, project_name)
+    _drop_app_module_cache((manager_package, worker_package))
     manager_module = importlib.import_module(manager_package)
     worker_module = importlib.import_module(worker_package)
     args_class = getattr(manager_module, args_class_name)

--- a/test/test_analysis_page_helpers.py
+++ b/test/test_analysis_page_helpers.py
@@ -1280,8 +1280,9 @@ def test_create_analysis_page_bundle_writes_blank_template(tmp_path: Path, monke
     template_text = entrypoint.read_text(encoding="utf-8")
     assert "except (ImportError, ModuleNotFoundError, OSError) as exc" in template_text
     assert 'PAGE_TITLE = "demo_view"' in template_text
+    assert 'PAGE_HELP_HTML = "explore-help.html"' in template_text
     assert "src/view_demo/view_demo.py" not in template_text
-    assert 'get_docs_menu_items(html_file="explore-help.html")' in template_text
+    assert "get_docs_menu_items(html_file=PAGE_HELP_HTML)" in template_text
 
     fake_streamlit = _FakeAnalysisTemplateStreamlit()
     monkeypatch.setitem(sys.modules, "streamlit", fake_streamlit)

--- a/test/test_global_pipeline_app_dispatch_smoke_report.py
+++ b/test/test_global_pipeline_app_dispatch_smoke_report.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.util
 import sys
 from pathlib import Path
+from types import ModuleType
 
 import pytest
 
@@ -115,6 +116,50 @@ def test_app_dispatch_smoke_state_contains_real_artifacts(tmp_path: Path) -> Non
     assert (workspace / queue["real_execution"]["reduce_artifact_path"]).is_file()
     assert (workspace / relay["real_execution"]["summary_metrics_path"]).is_file()
     assert (workspace / relay["real_execution"]["reduce_artifact_path"]).is_file()
+
+
+def test_app_dispatch_smoke_ignores_stale_uav_modules(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    module = _load_core_module()
+    for package_name in (
+        "uav_queue",
+        "uav_queue_worker",
+        "uav_relay_queue",
+        "uav_relay_queue_worker",
+    ):
+        stale_package = ModuleType(package_name)
+        stale_package.__path__ = []
+        monkeypatch.setitem(sys.modules, package_name, stale_package)
+
+    proof = module.persist_app_dispatch_smoke(
+        repo_root=Path.cwd(),
+        output_path=tmp_path / "app_dispatch_smoke.json",
+        run_root=tmp_path / "workspace",
+    )
+
+    assert proof.ok is True
+    assert proof.completed_unit_ids == ("queue_baseline", "relay_followup")
+
+
+def test_app_dispatch_smoke_moves_target_project_first(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_core_module()
+    repo_root = Path.cwd()
+    src_root = repo_root / "src" / "agilab" / "apps" / "builtin" / "uav_relay_queue_project" / "src"
+    monkeypatch.setattr(
+        module.sys,
+        "path",
+        ["shadow-package-root", str(src_root), "other-package-root"],
+    )
+
+    result = module._ensure_app_project_on_path(repo_root, "uav_relay_queue_project")
+
+    assert result == src_root
+    assert module.sys.path[:3] == [str(src_root), "shadow-package-root", "other-package-root"]
+    assert module.sys.path.count(str(src_root)) == 1
 
 
 def test_app_dispatch_smoke_report_handles_load_failure(tmp_path: Path) -> None:

--- a/test/test_ui_robot_action_contract.py
+++ b/test/test_ui_robot_action_contract.py
@@ -72,6 +72,7 @@ def test_ui_robot_action_contract_passes_for_current_ui_surface() -> None:
     assert actions_by_label["Export"]["disposition"] == "trial-only"
     assert actions_by_label["Overwrite"]["disposition"] == "ignored"
     assert actions_by_label["Rebuild Universal Offline knowledge base"]["disposition"] == "ignored"
+    assert actions_by_label["Reset"]["disposition"] == "trial-only"
     assert actions_by_label["Train / refresh"]["disposition"] == "trial-only"
     assert payload["summary"]["unused_disposition_count"] == 0
 

--- a/tools/ui_robot_action_contract.py
+++ b/tools/ui_robot_action_contract.py
@@ -83,6 +83,10 @@ EXPLICIT_ACTION_DISPOSITIONS: Mapping[str, tuple[str, str]] = {
         "ignored",
         "requires a local knowledge-base rebuild outside the deterministic UI robot environment",
     ),
+    "Reset": (
+        "trial-only",
+        "clears the PyTorch playground local training state; focused playground tests cover state reset behavior",
+    ),
     "Rename": (
         "trial-only",
         "project rename is probed through PROJECT rename scenarios without mutating the project",


### PR DESCRIPTION
## Summary
- classify the PyTorch playground Reset action in the UI robot action contract
- align the analysis page template regression with the PAGE_HELP_HTML docs-menu constant
- make global pipeline app-dispatch smoke imports deterministic by moving the target built-in app src first and purging stale app modules

## Validation
- ruff check src/agilab/global_pipeline_app_dispatch_smoke.py tools/ui_robot_action_contract.py test/test_global_pipeline_app_dispatch_smoke_report.py test/test_ui_robot_action_contract.py test/test_analysis_page_helpers.py
- pytest -q -o addopts='' test/test_global_pipeline_app_dispatch_smoke_report.py test/test_global_pipeline_operator_ui_report.py test/test_global_pipeline_dependency_view_report.py test/test_ui_robot_action_contract.py test/test_analysis_page_helpers.py::test_create_analysis_page_bundle_writes_blank_template
- replayed failed CI shard file sets: pipeline 837 passed, robots 210 passed, views 596 passed, reports 563 passed