### PR TITLE
Fix agi-core coverage import mode

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -146,7 +146,7 @@ jobs:
             --with coverage \
             python -m coverage run --data-file=.coverage.agi-core-combined \
             --source=agi_node,agi_cluster \
-            -m pytest -q --maxfail=1 --disable-warnings -o addopts='' \
+            -m pytest -q --maxfail=1 --disable-warnings -o addopts='' --import-mode=importlib \
             src/agilab/core/test
           uv run --no-project \
             --with-editable ./src/agilab/core/agi-env \

--- a/test/test_coverage_workflow.py
+++ b/test/test_coverage_workflow.py
@@ -81,6 +81,12 @@ def test_core_coverage_runs_shared_core_suite_once_for_node_and_cluster() -> Non
     assert "      - agi-cluster" not in workflow_text
 
 
+def test_core_coverage_uses_importlib_import_mode_for_src_layout() -> None:
+    run_block = _agi_core_run_block()
+
+    assert "--import-mode=importlib" in run_block
+
+
 def test_coverage_push_trigger_is_path_filtered_for_cost_control() -> None:
     workflow_text = _workflow_text()
     trigger_block = workflow_text.split("workflow_dispatch:", 1)[0]


### PR DESCRIPTION
## Summary
- make the agi-core coverage job pass pytest with explicit importlib import mode after clearing addopts
- add a workflow contract test so the CI import mode cannot regress

## Validation
- uv --preview-features extra-build-dependencies run --python 3.13 pytest -q -o addopts='' test/test_coverage_workflow.py test/test_workflow_parity.py
- CI-shaped agi-core coverage command with --import-mode=importlib: 1020 passed, 2 skipped