### PR TITLE
Add generic app surface launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ no longer the right interface. Those apps can run locally or on distributed
 workers, and the workflow stays portable: export it back to an `agi-core`
 notebook, inspect or adapt the Python stages, and hand off tracking evidence to
 MLflow when that integration is enabled.
+Apps can also declare multiple UI surfaces, so an app can keep the same runtime
+and evidence contract while exposing Streamlit, hosted Hugging Face, or future
+NiceGUI/Gradio/FastAPI adapters.
 
 You do not need a cluster to get AGILAB's core value. The primary adoption path
 is local: turn a notebook or script into a replayable app with evidence,
@@ -129,9 +132,11 @@ install.
   synthetic datasets, real play/pause training, hidden-layer activation maps,
   network diagnostics, and the **Loss landscape** view. Launch it directly with
   `agilab pytorch-playground` or open the hosted backend with
-  `agilab pytorch-playground --backend hf`. It is a reproducible app project,
-  not a generic app-agnostic analysis page, and loss landscape is part of that
-  project.
+  `agilab pytorch-playground --backend hf`. The generic surface launcher also
+  works: `agilab app surface pytorch_playground_project --ui streamlit` or
+  `agilab app surface pytorch_playground_project --ui hf`. It is a reproducible
+  app project, not a generic app-agnostic analysis page, and loss landscape is
+  part of that project.
 
 ## Featured Performance Demo
 
@@ -396,7 +401,7 @@ the same releaseable tree.
 | Area | Role | Stability contract |
 |---|---|---|
 | `src/agilab/core/agi-env`, `agi-node`, `agi-cluster`, `agi-core` | Runtime packages for environment setup, worker packaging, distributed execution, and the compact API. | Stable where documented; changes require focused regression evidence. |
-| `src/agilab/lib/agi-gui`, `src/agilab/pages` | Streamlit UI and page helpers. | Beta product surface; useful for operators, still evolving. |
+| `src/agilab/lib/agi-gui`, `src/agilab/pages` | Main web UI, Streamlit page helpers, and app-surface launch adapters. | Beta product surface; useful for operators, still evolving. App runtime contracts should not depend on one UI backend. |
 | `src/agilab/lib/agi-apps` | PyPI umbrella that carries app catalog/example assets and exact-pins the app payload packages already promoted to PyPI. | Packaged asset surface for the `ui` and `examples` extras. |
 | `src/agilab/lib/agi-pages` | PyPI provider package for public analysis page discovery. Published `agi-page-*` payload packages are distributed independently; `agi-pages` supplies the discovery/provider surface. | Packaged page-provider surface for the `ui` and `pages` extras. |
 | `src/agilab/apps/builtin` | Public built-in apps used for first proof, demos, workflow examples, and regression coverage. | Packaged examples, not enterprise deployment templates. |

--- a/README.pypi.md
+++ b/README.pypi.md
@@ -57,6 +57,9 @@ export the saved pipeline as a runnable `agi-core` supervisor notebook, so the
 code, stage order, runtime hints, and review context remain usable through the
 stable, production-grade core technology if the AGILAB UI or distributed
 runtime is no longer the right interface for that work.
+Apps can also declare multiple UI surfaces, so the same runtime and evidence
+contract can be exposed through Streamlit, hosted Hugging Face, or future
+NiceGUI/Gradio/FastAPI adapters.
 
 ## Demo Routes
 
@@ -74,7 +77,7 @@ Start with the route that matches the proof you want to show:
 | Gate candidate data | [Data Quality Gate](https://github.com/ThalesGroup/agilab/tree/main/src/agilab/apps/builtin/data_quality_gate_project) | Contract, drift, leakage, and promotion decision evidence before training. |
 | Show performance engineering | [Cython worker speedup demo](https://thalesgroup.github.io/agilab/execution-playground.html) | Worker execution model plus checksum-matched typed-kernel speedup evidence. |
 | Show a native extension boundary | [Rust/PyO3 native worker preview](https://thalesgroup.github.io/agilab/execution-playground.html#optional-rust-pyo3-worker-preview) | Generated PyO3/maturin worker skeleton with explicit evidence handoff. |
-| Explore an opt-in app | [PyTorch Playground](https://github.com/ThalesGroup/agilab/tree/main/src/agilab/apps/builtin/pytorch_playground_project) | Reproducible classifier playground with live play/pause training and loss-landscape analysis. |
+| Explore an opt-in app | [PyTorch Playground](https://github.com/ThalesGroup/agilab/tree/main/src/agilab/apps/builtin/pytorch_playground_project) | Reproducible classifier playground with live play/pause training, multi-UI surface declarations, and loss-landscape analysis. |
 | Go deeper after first proof | [Advanced Proof Pack](https://thalesgroup.github.io/agilab/advanced-proof-pack.html) | Mission decision, execution playground, UAV queue, service, MLflow, and release-proof routes. |
 
 Use the [local quick start](https://thalesgroup.github.io/agilab/quick-start.html)
@@ -325,7 +328,7 @@ Use three planes to read that tree:
 | Area | Role | Stability contract |
 |---|---|---|
 | `src/agilab/core/*` | Runtime packages and compact API. | Stable where documented. |
-| `src/agilab/lib/agi-gui`, `src/agilab/pages` | Streamlit UI. | Beta product surface. |
+| `src/agilab/lib/agi-gui`, `src/agilab/pages` | Main web UI, Streamlit page helpers, and app-surface launch adapters. | Beta product surface; app runtime contracts should not depend on one UI backend. |
 | `src/agilab/lib/agi-apps` | PyPI umbrella carrying app catalog/example assets and exact-pinning the app payload packages already promoted to PyPI. Deferred app payloads remain release artifacts until publication is enabled. | Packaged asset surface for the `ui` and `examples` extras. |
 | `src/agilab/lib/agi-pages` | PyPI provider package for public analysis page discovery. Published `agi-page-*` payload packages are distributed independently; `agi-pages` supplies the discovery/provider surface. | Packaged page-provider surface for the `ui` and `pages` extras. |
 | `src/agilab/apps/builtin` | First-proof and demo apps. | Packaged examples, not deployment templates. |

--- a/badges/coverage-agi-cluster.svg
+++ b/badges/coverage-agi-cluster.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="181" height="20" role="img" aria-label="agi-cluster coverage: 96%">
+<svg xmlns="http://www.w3.org/2000/svg" width="181" height="20" role="img" aria-label="agi-cluster coverage: 99%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="75.0" y="15" fill="#010101" fill-opacity=".3">agi-cluster coverage</text>
   <text x="75.0" y="14">agi-cluster coverage</text>
-  <text x="165.5" y="15" fill="#010101" fill-opacity=".3">96%</text>
-  <text x="165.5" y="14">96%</text>
+  <text x="165.5" y="15" fill="#010101" fill-opacity=".3">99%</text>
+  <text x="165.5" y="14">99%</text>
 </g>
 </svg>

--- a/badges/coverage-agi-core.svg
+++ b/badges/coverage-agi-core.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="160" height="20" role="img" aria-label="agi-core coverage: 96%">
+<svg xmlns="http://www.w3.org/2000/svg" width="160" height="20" role="img" aria-label="agi-core coverage: 98%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="64.5" y="15" fill="#010101" fill-opacity=".3">agi-core coverage</text>
   <text x="64.5" y="14">agi-core coverage</text>
-  <text x="144.5" y="15" fill="#010101" fill-opacity=".3">96%</text>
-  <text x="144.5" y="14">96%</text>
+  <text x="144.5" y="15" fill="#010101" fill-opacity=".3">98%</text>
+  <text x="144.5" y="14">98%</text>
 </g>
 </svg>

--- a/badges/coverage-agi-gui.svg
+++ b/badges/coverage-agi-gui.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="153" height="20" role="img" aria-label="agi-gui coverage: 97%">
+<svg xmlns="http://www.w3.org/2000/svg" width="153" height="20" role="img" aria-label="agi-gui coverage: 96%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="61.0" y="15" fill="#010101" fill-opacity=".3">agi-gui coverage</text>
   <text x="61.0" y="14">agi-gui coverage</text>
-  <text x="137.5" y="15" fill="#010101" fill-opacity=".3">97%</text>
-  <text x="137.5" y="14">97%</text>
+  <text x="137.5" y="15" fill="#010101" fill-opacity=".3">96%</text>
+  <text x="137.5" y="14">96%</text>
 </g>
 </svg>

--- a/badges/coverage-agi-node.svg
+++ b/badges/coverage-agi-node.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="160" height="20" role="img" aria-label="agi-node coverage: 98%">
+<svg xmlns="http://www.w3.org/2000/svg" width="160" height="20" role="img" aria-label="agi-node coverage: 99%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="64.5" y="15" fill="#010101" fill-opacity=".3">agi-node coverage</text>
   <text x="64.5" y="14">agi-node coverage</text>
-  <text x="144.5" y="15" fill="#010101" fill-opacity=".3">98%</text>
-  <text x="144.5" y="14">98%</text>
+  <text x="144.5" y="15" fill="#010101" fill-opacity=".3">99%</text>
+  <text x="144.5" y="14">99%</text>
 </g>
 </svg>

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 244,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "4e623ab7579892534078be12fbf4989fe54b91b973906e3d860602614f4ce863",
+  "source_digest_sha256": "5b1c78acf1a6d6ef99d357e4249c399b9f72406d87db1977a1f1243c7aaffba2",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "4e623ab7579892534078be12fbf4989fe54b91b973906e3d860602614f4ce863"
+  "target_digest_sha256": "5b1c78acf1a6d6ef99d357e4249c399b9f72406d87db1977a1f1243c7aaffba2"
 }

--- a/docs/source/apps-pages.rst
+++ b/docs/source/apps-pages.rst
@@ -20,6 +20,41 @@ Use the built-in ``pytorch_playground_project`` app or launch it directly with
 app-agnostic analysis page. The loss-landscape projection belongs to that app,
 not to a separate ``view_loss_landscape`` package.
 
+App-owned multi-UI surfaces
+---------------------------
+
+Page bundles stay app-agnostic. When an app needs an interactive UI that owns
+training, controls, live loops, or evidence refresh, declare an app-owned
+surface instead. The default Streamlit surface remains compatible with the
+ANALYSIS and ORCHESTRATE pages, while additional named backends can point to a
+hosted demo or future UI adapters.
+
+.. code-block:: toml
+
+   [app_surface]
+   title = "PyTorch Playground"
+   entrypoint = "pytorch_playground/app_surface.py"
+   default = "streamlit"
+
+   [app_surface.backends.streamlit]
+   backend = "streamlit"
+   entrypoint = "pytorch_playground/app_surface.py"
+   capabilities = ["local", "live-training", "play-pause"]
+
+   [app_surface.backends.hf]
+   backend = "hf"
+   url = "https://jpmorard-agilab.hf.space/?active_app=pytorch_playground_project"
+   capabilities = ["hosted-demo", "live-training"]
+
+The generic launcher is::
+
+   agilab app surface pytorch_playground_project --ui streamlit
+   agilab app surface pytorch_playground_project --ui hf
+
+The rule is strict: the app runtime, artifacts, and evidence contracts stay in
+the app package. UI surfaces are thin adapters, so a project can move from
+Streamlit to another frontend without losing its work.
+
 What is a page bundle?
 ----------------------
 
@@ -309,10 +344,10 @@ Live evidence monitor for app-agnostic exported artifacts.
 view_app_ui
 ^^^^^^^^^^^
 
-Generic bridge for app-owned interactive Streamlit UIs.
+Generic bridge for the default app-owned Streamlit UI.
 
-- Input: an active app with ``[pages.view_app_ui].entrypoint`` configured in
-  ``app_settings.toml``.
+- Input: an active app with ``[app_surface]`` or legacy
+  ``[pages.view_app_ui].entrypoint`` configured in ``app_settings.toml``.
 - Output: the app-owned UI rendered inside ANALYSIS while the app keeps
   control of training, execution semantics, and evidence artifacts.
 

--- a/docs/source/public-app-catalog.rst
+++ b/docs/source/public-app-catalog.rst
@@ -69,8 +69,10 @@ Status legend:
      - ``agi-app-pytorch-playground``
      - PyPI app package
      - Reproducible PyTorch classifier playground with live play/pause training,
-       persisted controls, and evidence artifacts. It can also be launched with
-       ``agilab pytorch-playground`` or ``agilab pytorch-playground --backend hf``.
+       persisted controls, multi-UI surface declarations, and evidence
+       artifacts. It can also be launched with ``agilab pytorch-playground``,
+       ``agilab pytorch-playground --backend hf``, or the generic
+       ``agilab app surface pytorch_playground_project --ui <backend>`` path.
    * - ``r_runtime_bridge_project``
      - None
      - Source built-in

--- a/src/agilab/app_surface.py
+++ b/src/agilab/app_surface.py
@@ -6,11 +6,46 @@ import sys
 import tomllib
 from collections.abc import Mapping
 from contextlib import contextmanager
+from dataclasses import dataclass
 from pathlib import Path
 from types import ModuleType
 from typing import Any
 
 APP_SURFACE_SECTION = "app_surface"
+APP_SURFACE_BACKENDS_KEY = "backends"
+DEFAULT_SURFACE_NAME = "streamlit"
+
+
+@dataclass(frozen=True, slots=True)
+class AppSurfaceSpec:
+    """One launchable app-owned UI surface.
+
+    The app runtime contract remains outside the UI.  A surface is only an
+    adapter that knows how a user can interact with the app.
+    """
+
+    name: str
+    backend: str
+    title: str
+    entrypoint: str = ""
+    url: str = ""
+    default: bool = False
+    capabilities: tuple[str, ...] = ()
+
+    def as_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "name": self.name,
+            "backend": self.backend,
+            "title": self.title,
+            "default": self.default,
+        }
+        if self.entrypoint:
+            payload["entrypoint"] = self.entrypoint
+        if self.url:
+            payload["url"] = self.url
+        if self.capabilities:
+            payload["capabilities"] = list(self.capabilities)
+        return payload
 
 
 def _read_app_settings(active_app: Path) -> dict[str, Any]:
@@ -29,14 +64,160 @@ def app_surface_config(
 ) -> dict[str, Any]:
     """Return the declared app-owned UI surface configuration, if present."""
     configured_surface = config.get(APP_SURFACE_SECTION) if isinstance(config, Mapping) else None
-    if isinstance(configured_surface, Mapping) and configured_surface.get("entrypoint"):
+    if isinstance(configured_surface, Mapping) and _has_surface_declaration(configured_surface):
         return dict(configured_surface)
     if active_app is None:
         return {}
     seed_surface = _read_app_settings(Path(active_app).expanduser()).get(APP_SURFACE_SECTION)
-    if isinstance(seed_surface, Mapping) and seed_surface.get("entrypoint"):
+    if isinstance(seed_surface, Mapping) and _has_surface_declaration(seed_surface):
         return dict(seed_surface)
     return {}
+
+
+def _has_surface_declaration(surface: Mapping[str, Any]) -> bool:
+    if surface.get("entrypoint") or surface.get("url"):
+        return True
+    backends = surface.get(APP_SURFACE_BACKENDS_KEY)
+    return isinstance(backends, Mapping) and any(
+        isinstance(value, Mapping) and (value.get("entrypoint") or value.get("url"))
+        for value in backends.values()
+    )
+
+
+def _string_tuple(value: object) -> tuple[str, ...]:
+    if isinstance(value, str):
+        cleaned = value.strip()
+        return (cleaned,) if cleaned else ()
+    if not isinstance(value, (list, tuple)):
+        return ()
+    return tuple(str(item).strip() for item in value if str(item).strip())
+
+
+def _surface_spec_from_mapping(
+    name: str,
+    payload: Mapping[str, Any],
+    *,
+    root: Mapping[str, Any],
+    root_default_name: str,
+    inherited_entrypoint: str = "",
+) -> AppSurfaceSpec | None:
+    backend = str(payload.get("backend") or name or DEFAULT_SURFACE_NAME).strip().lower()
+    title = str(payload.get("title") or root.get("title") or "App Surface").strip()
+    entrypoint = str(payload.get("entrypoint") or inherited_entrypoint or "").strip()
+    url = str(payload.get("url") or "").strip()
+    if not entrypoint and not url:
+        return None
+    default = bool(payload.get("default") is True or name == root_default_name)
+    return AppSurfaceSpec(
+        name=name,
+        backend=backend,
+        title=title or "App Surface",
+        entrypoint=entrypoint,
+        url=url,
+        default=default,
+        capabilities=_string_tuple(payload.get("capabilities")),
+    )
+
+
+def app_surface_specs(
+    active_app: str | Path | None,
+    config: Mapping[str, Any] | None = None,
+) -> dict[str, AppSurfaceSpec]:
+    """Return named UI surfaces declared by an app.
+
+    Backward compatibility:
+    - legacy ``[app_surface] entrypoint = ...`` is exposed as the default
+      ``streamlit`` surface.
+    - optional ``[app_surface.backends.<name>]`` entries add explicit named
+      surfaces without changing the existing ANALYSIS/ORCHESTRATE behavior.
+    """
+
+    root = app_surface_config(active_app, config)
+    if not root:
+        return {}
+
+    root_default_name = str(root.get("default") or DEFAULT_SURFACE_NAME).strip()
+    if not root_default_name:
+        root_default_name = DEFAULT_SURFACE_NAME
+
+    specs: dict[str, AppSurfaceSpec] = {}
+    root_entrypoint = str(root.get("entrypoint") or "").strip()
+    root_url = str(root.get("url") or "").strip()
+    if root_entrypoint or root_url:
+        legacy_spec = _surface_spec_from_mapping(
+            DEFAULT_SURFACE_NAME,
+            root,
+            root=root,
+            root_default_name=root_default_name,
+        )
+        if legacy_spec is not None:
+            specs[legacy_spec.name] = legacy_spec
+
+    backends = root.get(APP_SURFACE_BACKENDS_KEY)
+    if isinstance(backends, Mapping):
+        for name, payload in backends.items():
+            if not isinstance(payload, Mapping):
+                continue
+            surface_name = str(name).strip()
+            if not surface_name:
+                continue
+            inherited_entrypoint = (
+                root_entrypoint if surface_name == DEFAULT_SURFACE_NAME else ""
+            )
+            spec = _surface_spec_from_mapping(
+                surface_name,
+                payload,
+                root=root,
+                root_default_name=root_default_name,
+                inherited_entrypoint=inherited_entrypoint,
+            )
+            if spec is not None:
+                specs[surface_name] = spec
+
+    if specs and not any(spec.default for spec in specs.values()):
+        default_name = root_default_name if root_default_name in specs else sorted(specs)[0]
+        selected = specs[default_name]
+        specs[default_name] = AppSurfaceSpec(
+            name=selected.name,
+            backend=selected.backend,
+            title=selected.title,
+            entrypoint=selected.entrypoint,
+            url=selected.url,
+            default=True,
+            capabilities=selected.capabilities,
+        )
+    return specs
+
+
+def select_app_surface_spec(
+    active_app: str | Path | None,
+    *,
+    name: str | None = None,
+    backend: str | None = None,
+    config: Mapping[str, Any] | None = None,
+) -> AppSurfaceSpec | None:
+    specs = app_surface_specs(active_app, config)
+    if not specs:
+        return None
+    cleaned_name = str(name or "").strip()
+    if cleaned_name:
+        if cleaned_name in specs:
+            return specs[cleaned_name]
+        cleaned_name_backend = cleaned_name.lower()
+        for spec in specs.values():
+            if spec.backend == cleaned_name_backend:
+                return spec
+        return None
+    cleaned_backend = str(backend or "").strip().lower()
+    if cleaned_backend:
+        for spec in specs.values():
+            if spec.backend == cleaned_backend:
+                return spec
+        return None
+    for spec in specs.values():
+        if spec.default:
+            return spec
+    return specs[sorted(specs)[0]]
 
 
 def app_surface_title(config: Mapping[str, Any] | None) -> str:
@@ -81,9 +262,13 @@ def resolve_app_surface_entrypoint(
 def configured_app_surface_entrypoint(
     active_app: str | Path | None,
     config: Mapping[str, Any] | None = None,
+    *,
+    surface: str | None = None,
 ) -> Path | None:
-    surface_config = app_surface_config(active_app, config)
-    return resolve_app_surface_entrypoint(active_app, surface_config.get("entrypoint"))
+    spec = select_app_surface_spec(active_app, name=surface, config=config)
+    if spec is None:
+        return None
+    return resolve_app_surface_entrypoint(active_app, spec.entrypoint)
 
 
 @contextmanager
@@ -126,6 +311,7 @@ def render_app_surface(
     *,
     mode: str,
     config: Mapping[str, Any] | None = None,
+    surface: str | None = None,
     env: Any | None = None,
     container: Any | None = None,
     streamlit: Any | None = None,
@@ -134,8 +320,10 @@ def render_app_surface(
     if active_app is None:
         return False
     active_app_path = Path(active_app).expanduser().resolve()
-    surface_config = app_surface_config(active_app_path, config)
-    entrypoint = resolve_app_surface_entrypoint(active_app_path, surface_config.get("entrypoint"))
+    selected = select_app_surface_spec(active_app_path, name=surface, config=config)
+    if selected is None or selected.backend != "streamlit":
+        return False
+    entrypoint = resolve_app_surface_entrypoint(active_app_path, selected.entrypoint)
     if entrypoint is None:
         return False
     with _temporary_sys_path([active_app_path / "src", entrypoint.parent]), _temporary_argv(entrypoint, active_app_path):

--- a/src/agilab/apps/builtin/pytorch_playground_project/src/app_settings.toml
+++ b/src/agilab/apps/builtin/pytorch_playground_project/src/app_settings.toml
@@ -44,3 +44,17 @@ view_module = []
 [app_surface]
 title = "PyTorch Playground"
 entrypoint = "pytorch_playground/app_surface.py"
+default = "streamlit"
+
+[app_surface.backends.streamlit]
+title = "PyTorch Playground"
+backend = "streamlit"
+entrypoint = "pytorch_playground/app_surface.py"
+default = true
+capabilities = ["local", "live-training", "play-pause", "evidence-refresh"]
+
+[app_surface.backends.hf]
+title = "PyTorch Playground on Hugging Face"
+backend = "hf"
+url = "https://jpmorard-agilab.hf.space/?active_app=pytorch_playground_project"
+capabilities = ["hosted-demo", "live-training", "play-pause"]

--- a/src/agilab/lab_run.py
+++ b/src/agilab/lab_run.py
@@ -52,6 +52,12 @@ _PUBLIC_BIND_GUARD_MODULE = import_agilab_module(
 )
 PublicBindPolicyError = _PUBLIC_BIND_GUARD_MODULE.PublicBindPolicyError
 enforce_public_bind_policy = _PUBLIC_BIND_GUARD_MODULE.enforce_public_bind_policy
+_APP_SURFACE_MODULE = import_agilab_module(
+    "agilab.app_surface",
+    current_file=__file__,
+    fallback_path=_PACKAGE_DIR / "app_surface.py",
+    fallback_name="agilab_app_surface_local",
+)
 
 
 def _streamlit_config_path() -> Path:
@@ -196,6 +202,9 @@ def _run_env(argv: list[str]) -> int:
 
 
 def _run_app(argv: list[str]) -> int:
+    if argv[:1] == ["surface"]:
+        return _run_app_surface(argv[1:])
+
     from agilab import pypi_app_packages
 
     return pypi_app_packages.main(argv)
@@ -250,21 +259,30 @@ def _validate_streamlit_host(host: str | None) -> str:
     return enforce_public_bind_policy(env)
 
 
-def _url_with_pytorch_playground_query(url: str) -> str:
+def _url_with_active_app_query(url: str, app_name: str) -> str:
     parsed = urlparse(url)
     query = dict(parse_qsl(parsed.query, keep_blank_values=True))
-    query.setdefault("active_app", PYTORCH_PLAYGROUND_APP_NAME)
+    query.setdefault("active_app", app_name)
     return urlunparse(parsed._replace(query=urlencode(query)))
+
+
+def _url_with_pytorch_playground_query(url: str) -> str:
+    return _url_with_active_app_query(url, PYTORCH_PLAYGROUND_APP_NAME)
 
 
 def _hf_runtime_url(space_id: str) -> str:
     if space_id.startswith(("http://", "https://")):
         return _url_with_pytorch_playground_query(space_id)
+    return _url_with_pytorch_playground_query(_hf_space_runtime_url(space_id))
+
+
+def _hf_space_runtime_url(space_id: str) -> str:
+    if space_id.startswith(("http://", "https://")):
+        return space_id
     if "/" not in space_id:
-        raise SystemExit("agilab pytorch-playground: --hf-space must look like <owner>/<space>.")
+        raise SystemExit("--hf-space must look like <owner>/<space>.")
     owner, name = space_id.split("/", 1)
-    host = f"https://{owner.lower().replace('_', '-')}-{name.lower().replace('_', '-')}.hf.space/"
-    return _url_with_pytorch_playground_query(host)
+    return f"https://{owner.lower().replace('_', '-')}-{name.lower().replace('_', '-')}.hf.space/"
 
 
 def _pytorch_playground_hf_url(hf_url: str | None, hf_space: str | None) -> str:
@@ -305,6 +323,156 @@ def _pytorch_playground_streamlit_command(
         command.append("--")
         command.extend(extra_args)
     return command
+
+
+def _resolve_app_surface_project_root(project: str) -> Path:
+    candidate = Path(project).expanduser()
+    if candidate.exists():
+        return candidate.resolve()
+
+    repo_root = _detect_repo_root(_PACKAGE_DIR)
+    if repo_root is not None:
+        for root in (
+            repo_root / "src" / "agilab" / "apps" / "builtin",
+            repo_root / "src" / "agilab" / "apps",
+        ):
+            path = root / project
+            if path.exists():
+                return path.resolve()
+
+    try:
+        from agilab import pypi_app_packages
+    except Exception:
+        pypi_app_packages = None
+
+    if pypi_app_packages is not None:
+        for app in pypi_app_packages.list_installed_pypi_apps():
+            if app.provider == project or Path(app.project_root).name == project:
+                return Path(app.project_root).expanduser().resolve()
+
+    raise SystemExit(f"agilab app surface: project not found: {project}")
+
+
+def _app_surface_streamlit_command(
+    *,
+    project_root: Path,
+    entrypoint: Path,
+    host: str,
+    port: int,
+    headless: bool,
+    extra_args: list[str],
+) -> list[str]:
+    command = [
+        "uv",
+        "--preview-features",
+        "extra-build-dependencies",
+        "run",
+        "--project",
+        str(project_root),
+        "streamlit",
+        "run",
+        "--server.address",
+        host,
+        "--server.port",
+        str(port),
+    ]
+    if headless:
+        command.extend(["--server.headless", "true"])
+    command.extend([str(entrypoint), "--", "--active-app", str(project_root)])
+    command.extend(extra_args)
+    return command
+
+
+def _run_app_surface(argv: list[str], *, runner=subprocess.call) -> int:
+    parser = argparse.ArgumentParser(
+        prog="agilab app surface",
+        description="Launch an app-owned UI surface without coupling apps to one web framework.",
+    )
+    parser.add_argument("project", help="App project name or path.")
+    parser.add_argument(
+        "--ui",
+        default=None,
+        help="Surface name or backend. Examples: streamlit, hf, nicegui.",
+    )
+    parser.add_argument("--list", action="store_true", help="List declared surfaces.")
+    parser.add_argument("--json", action="store_true", help="Emit JSON for --list.")
+    parser.add_argument(
+        "--host",
+        default=None,
+        help="Local UI host. Streamlit uses AGILAB's guarded localhost bind by default.",
+    )
+    parser.add_argument("--port", type=int, default=8501, help="Local UI port.")
+    parser.add_argument("--no-browser", action="store_true", help="Do not open external URLs.")
+    parser.add_argument("--hf-url", default=None, help="Explicit hosted backend URL.")
+    parser.add_argument("--hf-space", default=None, help="Hosted Space ID, for example owner/agilab.")
+    args, extra_args = parser.parse_known_args(argv)
+    if extra_args[:1] == ["--"]:
+        extra_args = extra_args[1:]
+
+    project_root = _resolve_app_surface_project_root(args.project)
+    specs = _APP_SURFACE_MODULE.app_surface_specs(project_root)
+    if args.list:
+        payload = [spec.as_dict() for spec in specs.values()]
+        if args.json:
+            import json
+
+            print(json.dumps({"project": project_root.name, "surfaces": payload}, indent=2))
+        else:
+            for spec in payload:
+                default = " default" if spec.get("default") else ""
+                print(f"{spec['name']}\t{spec['backend']}{default}\t{spec['title']}")
+        return 0
+    if not specs:
+        raise SystemExit(f"agilab app surface: no app surface declared in {project_root}")
+
+    selected = _APP_SURFACE_MODULE.select_app_surface_spec(project_root, name=args.ui)
+    if selected is None:
+        available = ", ".join(sorted(specs)) or "<none>"
+        raise SystemExit(
+            f"agilab app surface: unknown --ui {args.ui!r}; available: {available}"
+        )
+
+    if selected.backend in {"hf", "url"}:
+        url = (
+            args.hf_url
+            or (_hf_space_runtime_url(args.hf_space) if args.hf_space else "")
+            or selected.url
+        )
+        if not url:
+            raise SystemExit(f"agilab app surface: surface {selected.name!r} has no URL.")
+        url = _url_with_active_app_query(url, project_root.name)
+        print(url)
+        if not args.no_browser:
+            webbrowser.open(url)
+        return 0
+
+    if selected.backend != "streamlit":
+        raise SystemExit(
+            f"agilab app surface: backend {selected.backend!r} is declared but "
+            "does not have a built-in launcher yet."
+        )
+
+    try:
+        host = _validate_streamlit_host(args.host)
+    except PublicBindPolicyError as exc:
+        raise SystemExit(f"agilab app surface: {exc}") from exc
+    entrypoint = _APP_SURFACE_MODULE.resolve_app_surface_entrypoint(
+        project_root, selected.entrypoint
+    )
+    if entrypoint is None:
+        raise SystemExit(
+            f"agilab app surface: Streamlit entrypoint not found for {selected.name!r}."
+        )
+    _ensure_streamlit_config_file()
+    command = _app_surface_streamlit_command(
+        project_root=project_root,
+        entrypoint=entrypoint,
+        host=host,
+        port=args.port,
+        headless=args.no_browser,
+        extra_args=extra_args,
+    )
+    return int(runner(command))
 
 
 def _run_pytorch_playground(argv: list[str], *, runner=subprocess.call) -> int:

--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/app_settings.toml
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/app_settings.toml
@@ -44,3 +44,17 @@ view_module = []
 [app_surface]
 title = "PyTorch Playground"
 entrypoint = "pytorch_playground/app_surface.py"
+default = "streamlit"
+
+[app_surface.backends.streamlit]
+title = "PyTorch Playground"
+backend = "streamlit"
+entrypoint = "pytorch_playground/app_surface.py"
+default = true
+capabilities = ["local", "live-training", "play-pause", "evidence-refresh"]
+
+[app_surface.backends.hf]
+title = "PyTorch Playground on Hugging Face"
+backend = "hf"
+url = "https://jpmorard-agilab.hf.space/?active_app=pytorch_playground_project"
+capabilities = ["hosted-demo", "live-training", "play-pause"]

--- a/test/test_app_surface.py
+++ b/test/test_app_surface.py
@@ -49,6 +49,39 @@ def _write_app_surface_project(tmp_path: Path) -> Path:
     return app
 
 
+def _write_multi_surface_project(tmp_path: Path) -> Path:
+    app = tmp_path / "multi_project"
+    surface = app / "src" / "demo" / "app_surface.py"
+    surface.parent.mkdir(parents=True)
+    (app / "src" / "app_settings.toml").write_text(
+        "\n".join(
+            [
+                "[app_surface]",
+                'title = "Demo Surface"',
+                'entrypoint = "demo/app_surface.py"',
+                'default = "streamlit"',
+                "",
+                "[app_surface.backends.streamlit]",
+                'title = "Demo Streamlit"',
+                'backend = "streamlit"',
+                'entrypoint = "demo/app_surface.py"',
+                "default = true",
+                'capabilities = ["local", "play-pause"]',
+                "",
+                "[app_surface.backends.hf]",
+                'title = "Demo HF"',
+                'backend = "hf"',
+                'url = "https://demo.hf.space/?active_app=multi_project"',
+                'capabilities = ["hosted-demo"]',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    surface.write_text("def render(**_kwargs): pass\n", encoding="utf-8")
+    return app
+
+
 def test_app_surface_resolves_project_local_entrypoint(tmp_path: Path) -> None:
     module = _load_app_surface_module()
     app = _write_app_surface_project(tmp_path)
@@ -58,6 +91,47 @@ def test_app_surface_resolves_project_local_entrypoint(tmp_path: Path) -> None:
         "entrypoint": "demo/app_surface.py",
     }
     assert module.configured_app_surface_entrypoint(app) == app / "src" / "demo" / "app_surface.py"
+
+
+def test_app_surface_specs_support_multiple_backends(tmp_path: Path) -> None:
+    module = _load_app_surface_module()
+    app = _write_multi_surface_project(tmp_path)
+
+    specs = module.app_surface_specs(app)
+
+    assert sorted(specs) == ["hf", "streamlit"]
+    assert specs["streamlit"].as_dict() == {
+        "name": "streamlit",
+        "backend": "streamlit",
+        "title": "Demo Streamlit",
+        "default": True,
+        "entrypoint": "demo/app_surface.py",
+        "capabilities": ["local", "play-pause"],
+    }
+    assert specs["hf"].as_dict() == {
+        "name": "hf",
+        "backend": "hf",
+        "title": "Demo HF",
+        "default": False,
+        "url": "https://demo.hf.space/?active_app=multi_project",
+        "capabilities": ["hosted-demo"],
+    }
+    assert module.select_app_surface_spec(app).name == "streamlit"
+    assert module.select_app_surface_spec(app, name="hf").url == (
+        "https://demo.hf.space/?active_app=multi_project"
+    )
+    assert module.select_app_surface_spec(app, name="streamlit").entrypoint == (
+        "demo/app_surface.py"
+    )
+    assert module.select_app_surface_spec(app, name="HF").name == "hf"
+
+
+def test_render_app_surface_only_embeds_streamlit_backend(tmp_path: Path) -> None:
+    module = _load_app_surface_module()
+    app = _write_multi_surface_project(tmp_path)
+
+    assert module.render_app_surface(app, mode="analysis", surface="hf") is False
+    assert module.configured_app_surface_entrypoint(app, surface="hf") is None
 
 
 def test_render_app_surface_calls_project_render_hook_and_restores_argv(tmp_path: Path) -> None:

--- a/test/test_lab_run.py
+++ b/test/test_lab_run.py
@@ -284,6 +284,141 @@ def test_main_dispatches_app_management_without_launching_streamlit(monkeypatch)
     assert captured == [["list", "--json"]]
 
 
+def test_main_dispatches_app_surface_without_pypi_management(monkeypatch):
+    monkeypatch.setattr(lab_run, "_guard_against_uvx_in_source_tree", lambda: None)
+    captured: list[list[str]] = []
+
+    def fake_app_surface(argv: list[str]) -> int:
+        captured.append(argv)
+        return 49
+
+    monkeypatch.setattr(lab_run, "_run_app_surface", fake_app_surface)
+    monkeypatch.setattr(
+        lab_run,
+        "_load_streamlit_cli",
+        lambda: (_ for _ in ()).throw(AssertionError("streamlit should not be launched")),
+    )
+
+    rc = lab_run.main(["app", "surface", "demo_project", "--ui", "hf", "--no-browser"])
+
+    assert rc == 49
+    assert captured == [["demo_project", "--ui", "hf", "--no-browser"]]
+
+
+def test_app_surface_local_launcher_uses_declared_streamlit_surface(monkeypatch, tmp_path: Path):
+    project_root = tmp_path / "demo_project"
+    script_path = project_root / "src" / "demo" / "app_surface.py"
+    script_path.parent.mkdir(parents=True)
+    script_path.write_text("def render(**_kwargs): pass\n", encoding="utf-8")
+    (project_root / "src" / "app_settings.toml").write_text(
+        "\n".join(
+            [
+                "[app_surface]",
+                'title = "Demo"',
+                'entrypoint = "demo/app_surface.py"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    captured: list[list[str]] = []
+
+    monkeypatch.setattr(lab_run, "_resolve_app_surface_project_root", lambda _project: project_root)
+    monkeypatch.setattr(lab_run, "_ensure_streamlit_config_file", lambda: None)
+
+    rc = lab_run._run_app_surface(
+        ["demo_project", "--host", "127.0.0.1", "--port", "8765", "--no-browser", "--", "--flag"],
+        runner=lambda command: captured.append(command) or 53,
+    )
+
+    assert rc == 53
+    assert captured == [[
+        "uv",
+        "--preview-features",
+        "extra-build-dependencies",
+        "run",
+        "--project",
+        str(project_root),
+        "streamlit",
+        "run",
+        "--server.address",
+        "127.0.0.1",
+        "--server.port",
+        "8765",
+        "--server.headless",
+        "true",
+        str(script_path),
+        "--",
+        "--active-app",
+        str(project_root),
+        "--flag",
+    ]]
+
+
+def test_app_surface_hf_launcher_uses_declared_url(monkeypatch, tmp_path: Path, capsys):
+    project_root = tmp_path / "demo_project"
+    (project_root / "src").mkdir(parents=True)
+    (project_root / "src" / "app_settings.toml").write_text(
+        "\n".join(
+            [
+                "[app_surface]",
+                'default = "hf"',
+                "",
+                "[app_surface.backends.hf]",
+                'backend = "hf"',
+                'title = "Demo HF"',
+                'url = "https://demo.hf.space/?active_app=demo_project"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    opened: list[str] = []
+
+    monkeypatch.setattr(lab_run, "_resolve_app_surface_project_root", lambda _project: project_root)
+    monkeypatch.setattr(lab_run.webbrowser, "open", lambda url: opened.append(url) or True)
+
+    rc = lab_run._run_app_surface(["demo_project", "--ui", "hf", "--no-browser"])
+
+    assert rc == 0
+    assert opened == []
+    assert capsys.readouterr().out.strip() == (
+        "https://demo.hf.space/?active_app=demo_project"
+    )
+
+
+def test_app_surface_hf_launcher_allows_space_override(monkeypatch, tmp_path: Path, capsys):
+    project_root = tmp_path / "demo_project"
+    (project_root / "src").mkdir(parents=True)
+    (project_root / "src" / "app_settings.toml").write_text(
+        "\n".join(
+            [
+                "[app_surface]",
+                'default = "hf"',
+                "",
+                "[app_surface.backends.hf]",
+                'backend = "hf"',
+                'title = "Demo HF"',
+                'url = "https://declared.hf.space/?active_app=demo_project"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(lab_run, "_resolve_app_surface_project_root", lambda _project: project_root)
+    monkeypatch.setattr(lab_run.webbrowser, "open", lambda _url: True)
+
+    rc = lab_run._run_app_surface(
+        ["demo_project", "--ui", "hf", "--hf-space", "Owner/Other_Space", "--no-browser"]
+    )
+
+    assert rc == 0
+    assert capsys.readouterr().out.strip() == (
+        "https://owner-other-space.hf.space/?active_app=demo_project"
+    )
+
+
 def test_main_dispatches_kubernetes_job_without_launching_streamlit(monkeypatch):
     monkeypatch.setattr(lab_run, "_guard_against_uvx_in_source_tree", lambda: None)
     captured: list[list[str]] = []

--- a/test/test_workflow_parity.py
+++ b/test/test_workflow_parity.py
@@ -649,7 +649,11 @@ def test_agi_gui_coverage_combine_recovers_missing_success_manifest(tmp_path, mo
         assert exc.code == 0
 
     assert combined_commands
-    assert "test-results/coverage-agi-gui-pipeline.db.fragment" in combined_commands[0]
+    assert any(
+        "coverage-agi-gui-combine-inputs" in arg
+        and "coverage-agi-gui-pipeline.db.fragment" in arg
+        for arg in combined_commands[0]
+    )
 
 
 def test_agi_gui_coverage_combine_deduplicates_parallel_base_paths(tmp_path, monkeypatch) -> None:
@@ -695,8 +699,63 @@ def test_agi_gui_coverage_combine_deduplicates_parallel_base_paths(tmp_path, mon
 
     assert combined_commands
     combine_args = combined_commands[0]
-    assert "test-results/coverage-agi-gui-support.db.worker" in combine_args
+    assert any(
+        "coverage-agi-gui-combine-inputs" in arg
+        and "coverage-agi-gui-support.db.worker" in arg
+        for arg in combine_args
+    )
     assert "test-results/coverage-agi-gui-support.db" not in combine_args
+
+
+def test_agi_gui_coverage_combine_rediscovers_current_db_when_manifest_is_stale(
+    tmp_path, monkeypatch
+) -> None:
+    module = _load_module()
+    monkeypatch.setattr(module, "AGI_GUI_COVERAGE_MANIFEST_WAIT_SECONDS", 0.0)
+    test_results = tmp_path / "test-results"
+    test_results.mkdir()
+    stale_chunk = "pages-rest"
+    combined_commands: list[list[str]] = []
+
+    for chunk in module.AGI_GUI_COVERAGE_CHUNKS:
+        current_db = test_results / f"coverage-agi-gui-{chunk}.db.current"
+        current_db.write_text("coverage-db\n", encoding="utf-8")
+        manifest_paths = [current_db.as_posix()]
+        if chunk == stale_chunk:
+            manifest_paths = [f"test-results/coverage-agi-gui-{chunk}.db.stale"]
+        (test_results / f"coverage-agi-gui-{chunk}.manifest.json").write_text(
+            json.dumps(
+                {
+                    "schema": module.AGI_GUI_COVERAGE_MANIFEST_SCHEMA,
+                    "chunk": chunk,
+                    "returncode": 0,
+                    "data_file": f"test-results/coverage-agi-gui-{chunk}.db",
+                    "junit_path": f"test-results/junit-agi-gui-{chunk}.xml",
+                    "coverage_db_paths": manifest_paths,
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    def fake_run(cmd, check=False):
+        combined_commands.append(list(cmd))
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setitem(sys.modules, "subprocess", SimpleNamespace(run=fake_run))
+
+    try:
+        exec(module._agi_gui_coverage_combine_code(), {})
+    except SystemExit as exc:
+        assert exc.code == 0
+
+    assert combined_commands
+    assert any(
+        "coverage-agi-gui-combine-inputs" in arg
+        and "coverage-agi-gui-pages-rest.db.current" in arg
+        for arg in combined_commands[0]
+    )
+    assert all("coverage-agi-gui-pages-rest.db.stale" not in arg for arg in combined_commands[0])
 
 
 def test_agi_gui_coverage_combine_does_not_recover_failing_junit(tmp_path, monkeypatch, capsys) -> None:

--- a/tools/workflow_parity.py
+++ b/tools/workflow_parity.py
@@ -576,7 +576,7 @@ def _agi_gui_coverage_manifest_paths() -> list[str]:
 def _agi_gui_coverage_chunk_code(label: str, data_file: str, junit_path: str, manifest_path: str) -> str:
     return (
         "from pathlib import Path\n"
-        "import json, subprocess, sys, time\n"
+        "import json, shutil, subprocess, sys, time\n"
         "import xml.etree.ElementTree as ET\n"
         f"schema = {AGI_GUI_COVERAGE_MANIFEST_SCHEMA!r}\n"
         f"label = {label!r}\n"
@@ -612,7 +612,7 @@ def _agi_gui_coverage_combine_code() -> str:
     manifest_paths = _agi_gui_coverage_manifest_paths()
     return (
         "from pathlib import Path\n"
-        "import json, subprocess, sys, time\n"
+        "import json, shutil, subprocess, sys, time\n"
         "import xml.etree.ElementTree as ET\n"
         f"schema = {AGI_GUI_COVERAGE_MANIFEST_SCHEMA!r}\n"
         f"manifest_paths = {manifest_paths!r}\n"
@@ -700,7 +700,11 @@ def _agi_gui_coverage_combine_code() -> str:
         "    raw_chunk_paths = raw_paths if isinstance(raw_paths, list) else []\n"
         "    data_file = manifest.get('data_file')\n"
         "    base_path = Path(str(data_file)) if data_file else Path(f'test-results/coverage-agi-gui-{chunk}.db')\n"
-        "    chunk_paths = _stable_coverage_db_paths(base_path, raw_chunk_paths)\n"
+        "    discovered_chunk_paths = _stable_coverage_db_paths(\n"
+        "        base_path,\n"
+        "        [path for path in base_path.parent.glob(base_path.name + '*') if path.is_file() and path.stat().st_size > 0],\n"
+        "    )\n"
+        "    chunk_paths = discovered_chunk_paths or _stable_coverage_db_paths(base_path, raw_chunk_paths)\n"
         "    valid_chunk_paths = []\n"
         "    for raw_path in chunk_paths:\n"
         "        path = Path(str(raw_path))\n"
@@ -723,7 +727,17 @@ def _agi_gui_coverage_combine_code() -> str:
         "if missing_dbs:\n"
         "    print('Missing agi-gui coverage DB files: ' + ', '.join(missing_dbs))\n"
         "    sys.exit(1)\n"
-        "cmd = [sys.executable, '-m', 'coverage', 'combine', '--keep', *coverage_paths]\n"
+        "combine_input_dir = Path('test-results/coverage-agi-gui-combine-inputs')\n"
+        "if combine_input_dir.exists():\n"
+        "    shutil.rmtree(combine_input_dir)\n"
+        "combine_input_dir.mkdir(parents=True, exist_ok=True)\n"
+        "combine_paths = []\n"
+        "for index, raw_path in enumerate(coverage_paths):\n"
+        "    source = Path(raw_path)\n"
+        "    target = combine_input_dir / f'{index:03d}-{source.name}'\n"
+        "    shutil.copy2(source, target)\n"
+        "    combine_paths.append(target.as_posix())\n"
+        "cmd = [sys.executable, '-m', 'coverage', 'combine', '--keep', *combine_paths]\n"
         "sys.exit(subprocess.run(cmd, check=False).returncode)\n"
     )
 


### PR DESCRIPTION
## Summary
- add named app-surface declarations and a generic `agilab app surface` launcher for local Streamlit and hosted URL/HF backends
- document the multi-UI surface contract and align the PyTorch playground metadata
- refresh coverage badges from the latest main coverage XML artifacts and harden AGI-GUI parity combine handling

## Validation
- `ruff check tools/workflow_parity.py test/test_workflow_parity.py src/agilab/app_surface.py src/agilab/lab_run.py test/test_app_surface.py test/test_lab_run.py`
- `pytest -q -o addopts='' test/test_workflow_parity.py test/test_app_surface.py test/test_lab_run.py src/agilab/core/agi-env/test/test_app_settings_support.py`
- `pytest -q -o addopts='' test/test_generate_component_coverage_badges.py test/test_coverage_badge_guard.py test/test_app_surface.py test/test_lab_run.py`
- `python tools/sync_docs_source.py --verify-stamp`
- `python tools/workflow_parity.py --profile docs`
- `python tools/workflow_parity.py --profile badges`
- `python tools/workflow_parity.py --profile agi-gui`