### PR TITLE
Polish app surface docs and core parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Start with the route that matches the proof you want to show:
 | Gate candidate data | [Data Quality Gate](src/agilab/apps/builtin/data_quality_gate_project) | Contract, drift, leakage, and promotion decision evidence before training. |
 | Show performance engineering | [Cython worker speedup demo](https://thalesgroup.github.io/agilab/execution-playground.html) | Worker execution model plus checksum-matched typed-kernel speedup evidence. |
 | Show a native extension boundary | [Rust/PyO3 native worker preview](https://thalesgroup.github.io/agilab/execution-playground.html#optional-rust-pyo3-worker-preview) | Generated PyO3/maturin worker skeleton with explicit evidence handoff. |
-| Explore an opt-in app | [PyTorch Playground](src/agilab/apps/builtin/pytorch_playground_project) | Reproducible classifier playground with live play/pause training and loss-landscape analysis. |
+| Explore an opt-in app | [PyTorch Playground](src/agilab/apps/builtin/pytorch_playground_project) | Reproducible classifier playground with live play/pause training, multi-UI surface declarations, generic `agilab app surface ...` launch, and loss-landscape analysis. |
 | Go deeper after first proof | [Advanced Proof Pack](https://thalesgroup.github.io/agilab/advanced-proof-pack.html) | Mission decision, execution playground, UAV queue, service, MLflow, and release-proof routes. |
 
 Use the [local quick start](#quick-start) when you want to run the product
@@ -130,13 +130,14 @@ install.
 - [PyTorch Playground](src/agilab/apps/builtin/pytorch_playground_project)
   is the opt-in classifier playground app for
   synthetic datasets, real play/pause training, hidden-layer activation maps,
-  network diagnostics, and the **Loss landscape** view. Launch it directly with
-  `agilab pytorch-playground` or open the hosted backend with
-  `agilab pytorch-playground --backend hf`. The generic surface launcher also
-  works: `agilab app surface pytorch_playground_project --ui streamlit` or
-  `agilab app surface pytorch_playground_project --ui hf`. It is a reproducible
-  app project, not a generic app-agnostic analysis page, and loss landscape is
-  part of that project.
+  network diagnostics, and the **Loss landscape** view. It demonstrates the
+  reusable app-surface contract: inspect backends with
+  `agilab app surface pytorch_playground_project --list`, open the local UI with
+  `agilab app surface pytorch_playground_project --ui streamlit`, or open the
+  hosted backend with `agilab app surface pytorch_playground_project --ui hf`.
+  The shortcut `agilab pytorch-playground` remains for convenience. It is a
+  reproducible app project, not a generic app-agnostic analysis page, and loss
+  landscape is part of that project.
 
 ## Featured Performance Demo
 

--- a/README.pypi.md
+++ b/README.pypi.md
@@ -77,7 +77,7 @@ Start with the route that matches the proof you want to show:
 | Gate candidate data | [Data Quality Gate](https://github.com/ThalesGroup/agilab/tree/main/src/agilab/apps/builtin/data_quality_gate_project) | Contract, drift, leakage, and promotion decision evidence before training. |
 | Show performance engineering | [Cython worker speedup demo](https://thalesgroup.github.io/agilab/execution-playground.html) | Worker execution model plus checksum-matched typed-kernel speedup evidence. |
 | Show a native extension boundary | [Rust/PyO3 native worker preview](https://thalesgroup.github.io/agilab/execution-playground.html#optional-rust-pyo3-worker-preview) | Generated PyO3/maturin worker skeleton with explicit evidence handoff. |
-| Explore an opt-in app | [PyTorch Playground](https://github.com/ThalesGroup/agilab/tree/main/src/agilab/apps/builtin/pytorch_playground_project) | Reproducible classifier playground with live play/pause training, multi-UI surface declarations, and loss-landscape analysis. |
+| Explore an opt-in app | [PyTorch Playground](https://github.com/ThalesGroup/agilab/tree/main/src/agilab/apps/builtin/pytorch_playground_project) | Reproducible classifier playground with live play/pause training, multi-UI surface declarations, generic `agilab app surface ...` launch, and loss-landscape analysis. |
 | Go deeper after first proof | [Advanced Proof Pack](https://thalesgroup.github.io/agilab/advanced-proof-pack.html) | Mission decision, execution playground, UAV queue, service, MLflow, and release-proof routes. |
 
 Use the [local quick start](https://thalesgroup.github.io/agilab/quick-start.html)

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 244,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "5b1c78acf1a6d6ef99d357e4249c399b9f72406d87db1977a1f1243c7aaffba2",
+  "source_digest_sha256": "34be456d767241b9105ae77b75dc67c65d065f7fab6563f019d4214cbc82d1fe",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "5b1c78acf1a6d6ef99d357e4249c399b9f72406d87db1977a1f1243c7aaffba2"
+  "target_digest_sha256": "34be456d767241b9105ae77b75dc67c65d065f7fab6563f019d4214cbc82d1fe"
 }

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -114,6 +114,14 @@ agilab
   - Renders reviewable ``agi-core`` calls and snippets from UI state so users can
     understand the runtime path and reuse it outside the Streamlit session.
 
+- **App-owned multi-UI surfaces:**
+
+  - Apps can declare named UI surfaces in ``app_settings.toml`` while keeping
+    the runtime, artifacts, and evidence contract inside the app package. Use
+    ``agilab app surface <project> --list`` to inspect the available backends
+    and ``agilab app surface <project> --ui <backend>`` to open one. This keeps
+    Streamlit useful without making the app contract depend on Streamlit.
+
 - **Multi-provider coding assistant:**
 
   - Integrates with OpenAI, Mistral, and OpenAI-compatible endpoints such as vLLM to offer real-time code suggestions across preferred providers.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -24,6 +24,12 @@ The fastest adoption ladder is browser preview, one local first-proof lane,
 evidence manifest, then expansion into package mode, external apps, or cluster
 work.
 
+AGILAB is not locked to one web frontend. App projects can declare app-owned
+UI surfaces so the same runtime, artifacts, and evidence contract can be opened
+through the local Streamlit UI, a hosted Hugging Face backend, or future
+adapters. See :doc:`apps-pages` for the ``[app_surface]`` contract and the
+generic ``agilab app surface`` launcher.
+
 If the local first proof fails, use :doc:`newcomer-troubleshooting` before
 branching into cluster mode, external app repositories, or broader workflows.
 

--- a/docs/source/quick-start.rst
+++ b/docs/source/quick-start.rst
@@ -101,6 +101,17 @@ before changing install route. ``agilab adoption-report`` reads that manifest
 and turns the checkpoint into a short report with missing handoff evidence and
 the exact next command.
 
+After that first proof passes, use an app-owned UI surface when you want a
+richer interactive app without changing the evidence contract. The PyTorch
+Playground is the public example::
+
+   agilab app surface pytorch_playground_project --list
+   agilab app surface pytorch_playground_project --ui streamlit
+   agilab app surface pytorch_playground_project --ui hf --no-browser
+
+The generic launcher is the pattern to reuse for future Streamlit, hosted, or
+alternate UI adapters; the app still owns the runtime and evidence files.
+
 Recommended first proof path
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/agilab/apps/builtin/pytorch_playground_project/README.md
+++ b/src/agilab/apps/builtin/pytorch_playground_project/README.md
@@ -14,6 +14,9 @@ without leaving the AGILAB app model.
 - How Streamlit controls map to persisted ORCHESTRATE arguments.
 - How an app-owned ANALYSIS surface can show training curves, learning snapshots,
   neuron views, regularization effects, and loss landscape evidence.
+- How the `[app_surface]` contract separates the app runtime/evidence files
+  from the UI backend, so the same project can open locally or through a hosted
+  surface.
 - How live play/pause training differs from a deterministic full evidence run:
   live mode mutates one in-session model, while `Train / refresh` rebuilds the
   full reproducible artifact.
@@ -28,17 +31,21 @@ Use the app-managed environment so PyTorch, Plotly, and Streamlit are installed
 in the right place:
 
 ```bash
-agilab pytorch-playground
+agilab app surface pytorch_playground_project --list
+agilab app surface pytorch_playground_project --ui streamlit
 ```
 
 To open the hosted backend instead of a local app venv:
 
 ```bash
-agilab pytorch-playground --backend hf
+agilab app surface pytorch_playground_project --ui hf
 ```
 
-Set `AGILAB_PYTORCH_PLAYGROUND_HF_URL` or pass `--hf-space owner/agilab` when
-you maintain a different Hugging Face Space.
+`agilab pytorch-playground` and `agilab pytorch-playground --backend hf` are
+convenience shortcuts for the same app. The generic `agilab app surface ...`
+command is the reusable pattern for any app that declares `[app_surface]`. Set
+`AGILAB_PYTORCH_PLAYGROUND_HF_URL` or pass `--hf-space owner/agilab` when you
+maintain a different Hugging Face Space.
 
 ## Run In AGILAB
 

--- a/src/agilab/examples/README.md
+++ b/src/agilab/examples/README.md
@@ -31,6 +31,7 @@ the command shape stable.
 | 16 | `resilience_failure_injection` | UAV relay scenario contract | Read-only resilience preview: inject a relay failure, compare fixed/replanned/search/policy responses. |
 | 17 | `train_then_serve` | trained policy handoff contract | Read-only service handoff preview: model artifact, IO contract, prediction sample, and health gate. |
 | 18 | `native_rust_worker` | optional native worker preview | Read-only Rust/PyO3 skeleton: keep AGILAB orchestration in Python while moving only a typed hot kernel to Rust. |
+| 19 | `pytorch_playground_project` app surface | `pytorch_playground_project` | App-owned UI surface example: one runtime/evidence contract, selectable local Streamlit or hosted Hugging Face backend. |
 
 ## Execution Map
 
@@ -44,6 +45,7 @@ app execution from read-only contract previews.
 | Source/package read-only previews | `notebook_to_dask`, `parallel_stage`, `excel_workbook_proof`, `sqlite_connector_proof`, `voila_notebook_proof`, `inter_project_dag`, `service_mode`, `mlflow_auto_tracking`, `resilience_failure_injection`, `train_then_serve`, `native_rust_worker` | Deterministic Python preview scripts. They write local evidence and do not launch long-lived workers or hidden multi-app runs. | Preview JSON, CSV, workbook, SQLite database, notebook, dashboard-plan, or generated skeleton artifacts under `~/log/execute/<example>/` or the configured output path. |
 | Notebook migration assets | `notebook_migrations/skforecast_meteo_fr` | Packaged notebooks, artifacts, `lab_stages.toml`, and pipeline view used as migration source material. | Files to inspect or import; no service or cluster run is started by reading them. |
 | Built-in app-owned demo templates | `multi_app_dag_project` | Select the built-in project in WORKFLOW or let `inter_project_dag` read its DAG template. | App-owned contract files under `src/agilab/apps/builtin/multi_app_dag_project/`; no `src/agilab/examples/multi_app_dag_project` directory is expected. |
+| App-owned UI surface demo | `pytorch_playground_project` | `agilab app surface pytorch_playground_project --list`, then `--ui streamlit` or `--ui hf`. | The same app runtime, artifacts, and evidence contract opened through selectable UI backends. |
 
 Source-checkout commands use `uv --preview-features extra-build-dependencies run python ...`
 so dependencies resolve through the checkout environment. Commands under
@@ -125,6 +127,10 @@ From an installed package, locate one with
   AGILAB boundary explicit: orchestration and artifacts stay in Python, the
   measured CPU-bound kernel can move to Rust when the packaging cost is worth
   it.
+- `pytorch_playground_project` demonstrates the reusable app-surface contract:
+  `app_settings.toml` declares the local Streamlit surface and hosted Hugging
+  Face surface, while the app package still owns the runtime, artifacts, and
+  evidence files.
 - `data_in` and `data_out` are share-root relative paths, so examples stay
   portable across machines.
 - Run modes use named AGI constants instead of magic numbers, and keep Cython
@@ -178,6 +184,9 @@ competing experiment system. Use `resilience_failure_injection` when you want to
 explain fixed versus adaptive behavior on the same degraded scenario before
 training or serving a policy. Use `native_rust_worker` when you want to explain
 the advanced native-worker lane without adding Rust to the base install. Use
+`agilab app surface pytorch_playground_project --list` when you want to see how
+an app can expose more than one UI backend without changing its evidence
+contract. Use
 `excel_workbook_proof` when the stakeholder lives in
 Excel and needs to see workbook output plus refreshable CSV and evidence before
 they care about notebooks, DAGs, or clusters. Use `sqlite_connector_proof` when

--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/README.md
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/README.md
@@ -14,6 +14,9 @@ without leaving the AGILAB app model.
 - How Streamlit controls map to persisted ORCHESTRATE arguments.
 - How an app-owned ANALYSIS surface can show training curves, learning snapshots,
   neuron views, regularization effects, and loss landscape evidence.
+- How the `[app_surface]` contract separates the app runtime/evidence files
+  from the UI backend, so the same project can open locally or through a hosted
+  surface.
 - How live play/pause training differs from a deterministic full evidence run:
   live mode mutates one in-session model, while `Train / refresh` rebuilds the
   full reproducible artifact.
@@ -28,17 +31,21 @@ Use the app-managed environment so PyTorch, Plotly, and Streamlit are installed
 in the right place:
 
 ```bash
-agilab pytorch-playground
+agilab app surface pytorch_playground_project --list
+agilab app surface pytorch_playground_project --ui streamlit
 ```
 
 To open the hosted backend instead of a local app venv:
 
 ```bash
-agilab pytorch-playground --backend hf
+agilab app surface pytorch_playground_project --ui hf
 ```
 
-Set `AGILAB_PYTORCH_PLAYGROUND_HF_URL` or pass `--hf-space owner/agilab` when
-you maintain a different Hugging Face Space.
+`agilab pytorch-playground` and `agilab pytorch-playground --backend hf` are
+convenience shortcuts for the same app. The generic `agilab app surface ...`
+command is the reusable pattern for any app that declares `[app_surface]`. Set
+`AGILAB_PYTORCH_PLAYGROUND_HF_URL` or pass `--hf-space owner/agilab` when you
+maintain a different Hugging Face Space.
 
 ## Run In AGILAB
 

--- a/test/test_workflow_parity.py
+++ b/test/test_workflow_parity.py
@@ -201,6 +201,7 @@ def test_profile_commands_cover_expected_coverage_and_docs_contracts() -> None:
     combined_cluster_xml = agi_core_combined[2]
     assert combined_run.timeout_seconds == 20 * 60
     assert combined_run.argv[-1] == "src/agilab/core/test"
+    assert "--import-mode=importlib" in combined_run.argv
     assert "--data-file=.coverage.agi-core-combined" in combined_run.argv
     assert "--source=agi_node,agi_cluster" in combined_run.argv
     assert _has_with_dependency(combined_run.argv, "fastparquet")

--- a/tools/workflow_parity.py
+++ b/tools/workflow_parity.py
@@ -960,6 +960,7 @@ def _agi_core_combined_profile() -> list[CommandSpec]:
                 "--disable-warnings",
                 "-o",
                 "addopts=",
+                "--import-mode=importlib",
                 "src/agilab/core/test",
             ],
             timeout_seconds=20 * 60,


### PR DESCRIPTION
## Summary
- make the new app-surface launcher clearer in README, PyPI README, docs, examples, and PyTorch playground READMEs
- add the feature/index/quick-start docs callouts for app-owned multi-UI surfaces
- run agi-core combined parity with pytest importlib mode to avoid local import shadowing

## Validation
- `ruff check tools/workflow_parity.py test/test_workflow_parity.py`
- `pytest -q -o addopts='' test/test_workflow_parity.py`
- `python tools/sync_docs_source.py --verify-stamp`
- `python tools/workflow_parity.py --profile docs`
- `python tools/workflow_parity.py --profile agi-core-combined`