### PR TITLE
Fix PyTorch playground reuse script paths

### DIFF
--- a/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/core.py
+++ b/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/core.py
@@ -1149,8 +1149,7 @@ def _plain_pytorch_reuse_snippet(config: PlaygroundConfig) -> str:
     config_literal = _snippet_config_literal(config)
     return f'''# Reuse a PyTorch Playground evidence pack outside AGILAB.
 # 1. Download and unzip pytorch_playground_evidence.zip.
-# 2. Put this file next to the unzipped data/ directory.
-# 3. Run: python train_plain_pytorch.py
+# 2. Run from the unzip root: python reuse/train_plain_pytorch.py
 
 from pathlib import Path
 
@@ -1160,7 +1159,9 @@ import torch
 from torch import nn
 
 CONFIG = {config_literal}
-SAMPLES_CSV = Path("data/samples.csv")
+SCRIPT_DIR = Path(__file__).resolve().parent
+ROOT = SCRIPT_DIR.parent if SCRIPT_DIR.name == "reuse" else SCRIPT_DIR
+SAMPLES_CSV = ROOT / "data" / "samples.csv"
 
 
 def feature_matrix(samples: pd.DataFrame) -> np.ndarray:
@@ -1268,8 +1269,8 @@ def _pytorch_lightning_reuse_snippet(config: PlaygroundConfig) -> str:
     config_literal = _snippet_config_literal(config)
     return f'''# Reuse a PyTorch Playground evidence pack with PyTorch Lightning.
 # 1. Download and unzip pytorch_playground_evidence.zip.
-# 2. Put this file next to the unzipped data/ directory.
-# 3. Run: python -m pip install lightning && python train_pytorch_lightning.py
+# 2. Run from the unzip root:
+#    python -m pip install lightning && python reuse/train_pytorch_lightning.py
 
 from pathlib import Path
 
@@ -1281,7 +1282,9 @@ from torch import nn
 from torch.utils.data import DataLoader, TensorDataset
 
 CONFIG = {config_literal}
-SAMPLES_CSV = Path("data/samples.csv")
+SCRIPT_DIR = Path(__file__).resolve().parent
+ROOT = SCRIPT_DIR.parent if SCRIPT_DIR.name == "reuse" else SCRIPT_DIR
+SAMPLES_CSV = ROOT / "data" / "samples.csv"
 
 
 def feature_matrix(samples: pd.DataFrame) -> np.ndarray:

--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground/core.py
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground/core.py
@@ -1149,8 +1149,7 @@ def _plain_pytorch_reuse_snippet(config: PlaygroundConfig) -> str:
     config_literal = _snippet_config_literal(config)
     return f'''# Reuse a PyTorch Playground evidence pack outside AGILAB.
 # 1. Download and unzip pytorch_playground_evidence.zip.
-# 2. Put this file next to the unzipped data/ directory.
-# 3. Run: python train_plain_pytorch.py
+# 2. Run from the unzip root: python reuse/train_plain_pytorch.py
 
 from pathlib import Path
 
@@ -1160,7 +1159,9 @@ import torch
 from torch import nn
 
 CONFIG = {config_literal}
-SAMPLES_CSV = Path("data/samples.csv")
+SCRIPT_DIR = Path(__file__).resolve().parent
+ROOT = SCRIPT_DIR.parent if SCRIPT_DIR.name == "reuse" else SCRIPT_DIR
+SAMPLES_CSV = ROOT / "data" / "samples.csv"
 
 
 def feature_matrix(samples: pd.DataFrame) -> np.ndarray:
@@ -1268,8 +1269,8 @@ def _pytorch_lightning_reuse_snippet(config: PlaygroundConfig) -> str:
     config_literal = _snippet_config_literal(config)
     return f'''# Reuse a PyTorch Playground evidence pack with PyTorch Lightning.
 # 1. Download and unzip pytorch_playground_evidence.zip.
-# 2. Put this file next to the unzipped data/ directory.
-# 3. Run: python -m pip install lightning && python train_pytorch_lightning.py
+# 2. Run from the unzip root:
+#    python -m pip install lightning && python reuse/train_pytorch_lightning.py
 
 from pathlib import Path
 
@@ -1281,7 +1282,9 @@ from torch import nn
 from torch.utils.data import DataLoader, TensorDataset
 
 CONFIG = {config_literal}
-SAMPLES_CSV = Path("data/samples.csv")
+SCRIPT_DIR = Path(__file__).resolve().parent
+ROOT = SCRIPT_DIR.parent if SCRIPT_DIR.name == "reuse" else SCRIPT_DIR
+SAMPLES_CSV = ROOT / "data" / "samples.csv"
 
 
 def feature_matrix(samples: pd.DataFrame) -> np.ndarray:

--- a/test/test_pytorch_playground_app.py
+++ b/test/test_pytorch_playground_app.py
@@ -1359,6 +1359,10 @@ def test_pytorch_playground_evidence_pack_is_deterministic(
     assert manifest["row_counts"]["loss_landscape"] == 2
     assert manifest["landscape_summary"]["center_validation_loss"] == pytest.approx(0.6)
     assert manifest["artifacts"]["data/samples.csv"]["sha256"] == hashlib.sha256(sample_bytes).hexdigest()
+    assert b"python reuse/train_plain_pytorch.py" in plain_snippet_bytes
+    assert b'ROOT / "data" / "samples.csv"' in plain_snippet_bytes
+    assert b"python reuse/train_pytorch_lightning.py" in lightning_snippet_bytes
+    assert b'ROOT / "data" / "samples.csv"' in lightning_snippet_bytes
     assert (
         manifest["artifacts"]["reuse/train_plain_pytorch.py"]["sha256"]
         == hashlib.sha256(plain_snippet_bytes).hexdigest()
@@ -1402,10 +1406,14 @@ def test_pytorch_playground_reuse_snippets_are_config_driven() -> None:
     assert "'optimizer': 'SGD'" in plain
     assert "'regularization': 'L1'" in plain
     assert "torch.optim.SGD" in plain
+    assert 'ROOT / "data" / "samples.csv"' in plain
+    assert "python reuse/train_plain_pytorch.py" in plain
     assert "lightning.pytorch as L" not in plain
     assert "import lightning.pytorch as L" in lightning
     assert "class PlaygroundModule(L.LightningModule)" in lightning
     assert "'learning_rate': 0.025" in lightning
+    assert 'ROOT / "data" / "samples.csv"' in lightning
+    assert "python reuse/train_pytorch_lightning.py" in lightning
 
 
 def test_pytorch_playground_loads_latest_evidence_result(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- make generated reuse scripts resolve samples from the evidence ZIP root when stored under reuse/
- update generated run instructions to match the packaged ZIP layout
- add tests that lock the script path contract

## Validation
- UV_PYTHON=3.13 uv --preview-features extra-build-dependencies run ruff check src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/core.py src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground/core.py test/test_pytorch_playground_app.py
- UV_PYTHON=3.13 uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_pytorch_playground_app.py