### PR TITLE
Restore Streamlit runtime cap

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ agilab-mcp = "agilab_mcp.server:main"
 
 [project.optional-dependencies]
 ai = ["openai>=2.32.0,<3"]
-ui = ["agi-apps==2026.05.30", "agi-pages==2026.05.30", "agi-gui==2026.05.30", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "streamlit>=1.56,<1.59", "tomli_w>=1.2.0,<2"]
+ui = ["agi-apps==2026.05.30", "agi-pages==2026.05.30", "agi-gui==2026.05.30", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "streamlit>=1.56,<1.57", "tomli_w>=1.2.0,<2"]
 viz = ["matplotlib>=3.10.0,<4", "plotly>=6.7.0,<7"]
 mlflow = ["mlflow>=3.11.1,<4", "idna>=3.15,<4", "starlette>=1.0.1,<2"]
 bridges = ["duckdb>=1.4.0,<2"]

--- a/src/agilab/lib/agi-gui/pyproject.toml
+++ b/src/agilab/lib/agi-gui/pyproject.toml
@@ -32,7 +32,7 @@ keywords = [
     "python",
 ]
 
-dependencies = ["agi-env==2026.05.30", "streamlit>=1.56,<1.59", "streamlit_code_editor>=0.1.22,<0.2", "watchdog>=6,<7"]
+dependencies = ["agi-env==2026.05.30", "streamlit>=1.56,<1.57", "streamlit_code_editor>=0.1.22,<0.2", "watchdog>=6,<7"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"


### PR DESCRIPTION
## Summary
- restore the AGILAB UI Streamlit cap to >=1.56,<1.57 in the root UI extra
- restore the same cap in agi-gui so dependency-policy stays aligned with the documented Streamlit 1.57+ blank frontend guard

## Validation
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile dependency-policy
- uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files pyproject.toml src/agilab/lib/agi-gui/pyproject.toml
- git diff --check
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui