### PR TITLE
Fix release ty typing gate

### DIFF
--- a/src/agilab/core/agi-env/src/agi_env/agi_env.py
+++ b/src/agilab/core/agi-env/src/agi_env/agi_env.py
@@ -289,28 +289,49 @@ class AgiEnv(metaclass=_AgiEnvMeta):
 
         with cls._lock:
             cls._instance = None
-    install_type = None  # deprecated: derived from flags for backward compatibility
-    apps_path = None
-    app = None
-    target = None
-    TABLE_MAX_ROWS = None
-    GUI_SAMPLING = None
-    init_done = False
-    hw_rapids_capable = None
-    is_worker_env = False
-    _is_managed_pc = None
-    skip_repo_links = False
-    debug = False
-    uv = None
-    benchmark = None
-    verbose = None
-    pyvers_worker = None
-    logger = None
-    out_log = None
-    err_log = None
+    install_type: int | None = None  # deprecated: derived from flags for backward compatibility
+    apps_path: Path | None = None
+    app: str | None = None
+    target: str | None = None
+    TABLE_MAX_ROWS: int | None = None
+    GUI_SAMPLING: int | float | None = None
+    init_done: bool = False
+    hw_rapids_capable: bool | None = None
+    is_worker_env: bool = False
+    _is_managed_pc: bool | None = None
+    skip_repo_links: bool = False
+    debug: bool = False
+    uv: str | None = None
+    benchmark: object = None
+    verbose: int | None = None
+    pyvers_worker: str | None = None
+    logger: logging.Logger | None = None
+    out_log: object = None
+    err_log: object = None
     # Minimal class-level fallbacks to support limited static usage pre-init
-    resources_path: Path | None = Path.home() / ".agilab"
-    envars: dict | None = {}
+    resources_path: Path = Path.home() / ".agilab"
+    envars: dict[str, str] = {}
+    home_abs: Path
+    active_app: Path
+    app_src: Path
+    builtin_apps_path: Path | None
+    apps_repository_root: Path | None
+    installed_app_project_paths: tuple[Path, ...]
+    projects: list[str]
+    user: str
+    env_pck: Path
+    node_pck: Path
+    core_pck: Path
+    cluster_pck: Path
+    agilab_pck: Path
+    st_resources: Path
+    agi_share_path: str | Path | None
+    agi_share_path_abs: Path
+    app_data_rel: Path
+    share_target_name: str
+    AGI_LOCAL_SHARE: str | Path | None
+    dist_abs: Path
+    wenv_abs: Path
     # Simplified environment flags
     is_source_env: bool = False
     is_local_worker: bool = False
@@ -414,9 +435,9 @@ class AgiEnv(metaclass=_AgiEnvMeta):
             node_pck=self.node_pck,
             core_pck=self.core_pck,
             cluster_pck=self.cluster_pck,
-            dist_abs=self.dist_abs,  # ty: ignore[unresolved-attribute]
-            app_src=self.app_src,  # ty: ignore[unresolved-attribute]
-            wenv_abs=self.wenv_abs,  # ty: ignore[unresolved-attribute]
+            dist_abs=self.dist_abs,
+            app_src=self.app_src,
+            wenv_abs=self.wenv_abs,
             agilab_pck=self.agilab_pck,
             dedupe_paths_fn=self._dedupe_paths,
         )
@@ -490,7 +511,7 @@ class AgiEnv(metaclass=_AgiEnvMeta):
     def set_env_var(key: str, value: str):
         """Persist ``key``/``value`` in :attr:`envars`, ``os.environ`` and the ``.env`` file."""
         AgiEnv._ensure_defaults()
-        AgiEnv.envars[key] = value  # ty: ignore[invalid-assignment]
+        AgiEnv.envars[key] = value
         os.environ[key] = str(value)
         AgiEnv._update_env_file({key: value})
 
@@ -543,7 +564,7 @@ class AgiEnv(metaclass=_AgiEnvMeta):
                 cls.resources_path = Path(".agilab").resolve()
         if getattr(cls, "envars", None) is None or not isinstance(cls.envars, dict):
             try:
-                env_path = cls.resources_path / ".env"  # ty: ignore[unsupported-operator]
+                env_path = cls.resources_path / ".env"
                 cls.envars = _load_dotenv_values(env_path, verbose=False)
             except (OSError, RuntimeError, TypeError, ValueError):
                 cls.envars = {}
@@ -585,14 +606,14 @@ class AgiEnv(metaclass=_AgiEnvMeta):
 
     def _update_env_file(updates: dict):
         AgiEnv._ensure_defaults()
-        env_file = AgiEnv.resources_path / ".env"  # ty: ignore[unsupported-operator]
+        env_file = AgiEnv.resources_path / ".env"
         write_env_updates(env_file, updates)
 
     def _init_resources(self, resources_src):
         """Replicate ``resources_src`` into the managed ``.agilab`` tree."""
         initialize_resources(
             resources_src,
-            resources_path=self.resources_path,  # ty: ignore[arg-type]
+            resources_path=self.resources_path,
             st_resources=self.st_resources,
             is_source_env=self.is_source_env,
             ensure_dir_fn=_ensure_dir,
@@ -608,7 +629,6 @@ class AgiEnv(metaclass=_AgiEnvMeta):
         self.projects = self.get_projects(self.apps_path, self.builtin_apps_path, self.apps_repository_root)  # ty: ignore[invalid-argument-type]
         for idx, project in enumerate(self.projects):
             if self.target == project[:-8].replace("-", "_"):
-                self.app = self.apps_path / project
                 self.app = project
                 break
 
@@ -681,7 +701,7 @@ class AgiEnv(metaclass=_AgiEnvMeta):
         return app_settings_source_roots(
             target_app=app_name or self.app,
             current_app=self.app,
-            app_src=self.app_src,  # ty: ignore[unresolved-attribute]
+            app_src=self.app_src,
             active_app=self.active_app,
             apps_path=self.apps_path,
             builtin_apps_path=self.builtin_apps_path,
@@ -695,7 +715,7 @@ class AgiEnv(metaclass=_AgiEnvMeta):
         return find_source_app_settings_file(
             target_app=app_name or self.app,
             current_app=self.app,
-            app_src=self.app_src,  # ty: ignore[unresolved-attribute]
+            app_src=self.app_src,
             active_app=self.active_app,
             apps_path=self.apps_path,
             builtin_apps_path=self.builtin_apps_path,
@@ -717,7 +737,7 @@ class AgiEnv(metaclass=_AgiEnvMeta):
         """
         return resolve_user_app_settings_file(
             target_app=app_name or self.app or self.target,
-            resources_path=self.resources_path,  # ty: ignore[invalid-argument-type]
+            resources_path=self.resources_path,
             ensure_exists=ensure_exists,
             find_source_file=self.find_source_app_settings_file,
         )
@@ -748,7 +768,7 @@ class AgiEnv(metaclass=_AgiEnvMeta):
         initialize_app_runtime(
             self,
             envars,
-            environ=os.environ,  # ty: ignore[arg-type]
+            environ=os.environ,
             default_account=getpass.getuser(),
             read_agilab_path_fn=self.read_agilab_path,
             optional_agi_pages_bundles_root_fn=_optional_agi_pages_bundles_root,
@@ -764,9 +784,9 @@ class AgiEnv(metaclass=_AgiEnvMeta):
 
     def _init_apps(self):
         app_files = initialize_app_files(
-            app_src=self.app_src,  # ty: ignore[arg-type]
+            app_src=self.app_src,
             active_app=self.active_app,
-            resources_path=self.resources_path,  # ty: ignore[arg-type]
+            resources_path=self.resources_path,
             agilab_pck=self.agilab_pck,
             find_source_app_settings_file_fn=self.find_source_app_settings_file,
             resolve_user_app_settings_file_fn=self.resolve_user_app_settings_file,

--- a/src/agilab/core/agi-env/src/agi_env/env_config_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/env_config_support.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Mapping
 from pathlib import Path
 
 from dotenv import dotenv_values, set_key
@@ -18,7 +19,7 @@ def _normalize_env_value(value: object) -> str | None:
 
 
 def clean_envar_value(
-    envars: dict | None,
+    envars: Mapping[str, object] | None,
     key: str,
     *,
     fallback_to_process: bool = False,

--- a/src/agilab/core/agi-env/src/agi_env/windows_link_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/windows_link_support.py
@@ -6,9 +6,10 @@ import ctypes as _ctypes
 import subprocess
 from ctypes import wintypes as _wintypes
 from pathlib import Path
+from typing import Any
 
 
-def has_admin_rights(*, ctypes_module=_ctypes):
+def has_admin_rights(*, ctypes_module: Any = _ctypes):
     """Return whether the current Windows process has administrative rights."""
 
     try:
@@ -43,8 +44,8 @@ def create_symlink_windows(
     *,
     has_admin_rights_fn,
     logger=None,
-    ctypes_module=_ctypes,
-    wintypes_module=_wintypes,
+    ctypes_module: Any = _ctypes,
+    wintypes_module: Any = _wintypes,
 ) -> None:
     """Create a Windows directory symbolic link when privileges allow it."""
 

--- a/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/build.py
+++ b/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/build.py
@@ -12,6 +12,7 @@ import stat
 from pathlib import Path
 from zipfile import ZipFile
 import argparse
+import logging
 import subprocess
 from collections.abc import Mapping
 
@@ -40,6 +41,10 @@ warnings.filterwarnings("ignore", category=SetuptoolsDeprecationWarning)
 from agi_env.agi_logger import AgiLogger
 
 logger = AgiLogger.get_logger(__name__)
+
+
+def _runtime_logger(log: logging.Logger | None = None) -> logging.Logger:
+    return log or AgiEnv.logger or logger
 
 def _ensure_hacl_dir(log=logger, path_factory=Path) -> None:
     hacl_dir = path_factory("Modules/_hacl")
@@ -371,12 +376,11 @@ def _unpack_worker_eggs(
     dist_dir: Path,
     dest_src: Path,
     zip_cls=None,
-    log=None,
+    log: logging.Logger | None = None,
 ) -> None:
     if zip_cls is None:
         zip_cls = ZipFile
-    if log is None:
-        log = AgiEnv.logger or logger
+    log = _runtime_logger(log)
     log.info(f"mkdir {dest_src}")
     dest_src.mkdir(exist_ok=True, parents=True)
     for egg in dist_dir.glob("*.egg"):
@@ -386,10 +390,9 @@ def _unpack_worker_eggs(
     _remove_top_level_ui_modules(dest_src, log=log)
 
 
-def _remove_top_level_ui_modules(dest_src: Path, *, log=None) -> list[Path]:
+def _remove_top_level_ui_modules(dest_src: Path, *, log: logging.Logger | None = None) -> list[Path]:
     """Remove stale UI-only top-level modules from headless worker sources."""
-    if log is None:
-        log = AgiEnv.logger or logger
+    log = _runtime_logger(log)
     removed: list[Path] = []
 
     for pattern in _TOP_LEVEL_UI_MODULE_PATTERNS:
@@ -415,10 +418,9 @@ def _remove_top_level_ui_modules(dest_src: Path, *, log=None) -> list[Path]:
     return removed
 
 
-def _purge_top_level_ui_build_artifacts(app_root: Path, *, log=None) -> list[Path]:
+def _purge_top_level_ui_build_artifacts(app_root: Path, *, log: logging.Logger | None = None) -> list[Path]:
     """Drop stale top-level UI modules from setuptools build caches."""
-    if log is None:
-        log = AgiEnv.logger or logger
+    log = _runtime_logger(log)
     build_root = app_root / "build"
     if not build_root.exists():
         return []
@@ -453,7 +455,7 @@ def _postprocess_bdist_egg_output(
     cleanup_links_fn=None,
     os_system_fn=None,
     zip_cls=None,
-    log=None,
+    log: logging.Logger | None = None,
 ) -> None:
     if cleanup_links_fn is None:
         cleanup_links_fn = cleanup_links
@@ -461,8 +463,7 @@ def _postprocess_bdist_egg_output(
         os_system_fn = os.system  # ty: ignore[deprecated]
     if zip_cls is None:
         zip_cls = ZipFile
-    if log is None:
-        log = AgiEnv.logger or logger
+    log = _runtime_logger(log)
     dest_src = out_dir / "src"
     _unpack_worker_eggs(dist_dir=out_dir / "dist", dest_src=dest_src, zip_cls=zip_cls, log=log)
 
@@ -512,7 +513,7 @@ def _ensure_worker_cython_source(
     resolve_pre_install_script_fn=None,
     resolve_cython_type_preprocess_option_fn=None,
     subprocess_run=None,
-    log=None,
+    log: logging.Logger | None = None,
 ) -> None:
     if resolve_pre_install_script_fn is None:
         resolve_pre_install_script_fn = _resolve_pre_install_script
@@ -520,8 +521,7 @@ def _ensure_worker_cython_source(
         resolve_cython_type_preprocess_option_fn = _resolve_cython_type_preprocess_option
     if subprocess_run is None:
         subprocess_run = subprocess.run
-    if log is None:
-        log = AgiEnv.logger or logger
+    log = _runtime_logger(log)
 
     worker_py = _resolve_worker_python_path(env)
     worker_pyx = worker_py.with_suffix(".pyx")
@@ -543,10 +543,9 @@ def _resolve_build_output(
     outdir,
     *,
     home_abs: str | Path,
-    log=None,
+    log: logging.Logger | None = None,
 ) -> tuple[Path, str, str]:
-    if log is None:
-        log = AgiEnv.logger or logger
+    log = _runtime_logger(log)
     if not outdir:
         log.error("Cannot determine target package name.")
         raise RuntimeError("Cannot determine target package name")
@@ -622,7 +621,7 @@ def _configure_build_ext_modules(
     ensure_hacl_dir_fn=None,
     build_worker_extension_fn=None,
     cythonize_worker_extension_fn=None,
-    log=None,
+    log: logging.Logger | None = None,
 ) -> list:
     if find_sys_prefix_fn is None:
         find_sys_prefix_fn = find_sys_prefix
@@ -636,8 +635,7 @@ def _configure_build_ext_modules(
         build_worker_extension_fn = _build_worker_extension
     if cythonize_worker_extension_fn is None:
         cythonize_worker_extension_fn = _cythonize_worker_extension
-    if log is None:
-        log = AgiEnv.logger or logger
+    log = _runtime_logger(log)
 
     log.info(f"cwd: {active_app}")
     log.info(f"build_dir: {build_dir}")
@@ -692,14 +690,13 @@ def _prepare_build_ext_command(
     build_dir: str | None,
     truncate_path_at_segment_fn=None,
     ensure_worker_cython_source_fn=None,
-    log=None,
+    log: logging.Logger | None = None,
 ) -> None:
     if truncate_path_at_segment_fn is None:
         truncate_path_at_segment_fn = truncate_path_at_segment
     if ensure_worker_cython_source_fn is None:
         ensure_worker_cython_source_fn = _ensure_worker_cython_source
-    if log is None:
-        log = AgiEnv.logger or logger
+    log = _runtime_logger(log)
 
     if not build_dir:
         log.error("build_ext requires --build-dir/-b argument")
@@ -727,7 +724,7 @@ def _prepare_setup_artifacts(
     purge_top_level_ui_build_artifacts_fn=None,
     configure_build_ext_modules_fn=None,
     prepare_bdist_egg_sources_fn=None,
-    log=None,
+    log: logging.Logger | None = None,
 ) -> tuple[list, list[Path]]:
     if purge_worker_venv_artifacts_fn is None:
         purge_worker_venv_artifacts_fn = _purge_worker_venv_artifacts


### PR DESCRIPTION
## Summary
- declare runtime-populated agi-env attributes so the release ty gate can reason about them
- widen env config value cleanup typing for JSON-derived config maps
- normalize dispatcher build logging helpers without changing module logger behavior

## Validation
- `uv --preview-features extra-build-dependencies run --with ty python -m ty check --project . --error-on-warning --extra-search-path src/agilab/core/agi-core/src --extra-search-path src/agilab/core/agi-env/src --extra-search-path src/agilab/core/agi-node/src --extra-search-path src/agilab/core/agi-cluster/src src/agilab/core/agi-core/src src/agilab/core/agi-env/src src/agilab/core/agi-node/src src/agilab/core/agi-cluster/src`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' src/agilab/core/agi-env/test/test_agi_env.py src/agilab/core/agi-env/test/test_agi_env_remaining_coverage.py src/agilab/core/test/test_agi_dispatcher_scripts.py src/agilab/core/test/test_agi_dispatcher_post_install_support.py`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_release_plan.py test/test_pypi_publish_workflow.py test/test_pypi_release_retention.py test/test_sync_docs_source.py`
- `git diff --check`