### PR TITLE
Restore Streamlit cap for UI installs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,14 @@ updates:
       python-runtime:
         patterns:
           - "*"
+    ignore:
+      # Streamlit >=1.57 is blocked by test_pyproject_dependency_hygiene.py
+      # until the uv archive install blank-frontend failure is resolved.
+      - dependency-name: "streamlit"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
 
   - package-ecosystem: "pip"
     directory: "/src/agilab/core/agi-env"
@@ -80,6 +88,13 @@ updates:
     labels:
       - "dependencies"
       - "python"
+    ignore:
+      # Keep agi-gui aligned with the root UI extra Streamlit cap.
+      - dependency-name: "streamlit"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
 
   - package-ecosystem: "pip"
     directory: "/src/agilab/lib/agi-apps"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ agilab-mcp = "agilab_mcp.server:main"
 
 [project.optional-dependencies]
 ai = ["openai>=2.32.0,<3"]
-ui = ["agi-apps==2026.05.30", "agi-pages==2026.05.30", "agi-gui==2026.05.30", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "streamlit>=1.56,<1.59", "tomli_w>=1.2.0,<2"]
+ui = ["agi-apps==2026.05.30", "agi-pages==2026.05.30", "agi-gui==2026.05.30", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "streamlit>=1.56,<1.57", "tomli_w>=1.2.0,<2"]
 viz = ["matplotlib>=3.10.0,<4", "plotly>=6.7.0,<7"]
 mlflow = ["mlflow>=3.11.1,<4", "idna>=3.15,<4", "starlette>=1.0.1,<2"]
 bridges = ["duckdb>=1.4.0,<2"]

--- a/src/agilab/lib/agi-gui/pyproject.toml
+++ b/src/agilab/lib/agi-gui/pyproject.toml
@@ -32,7 +32,7 @@ keywords = [
     "python",
 ]
 
-dependencies = ["agi-env==2026.05.30", "streamlit>=1.56,<1.59", "streamlit_code_editor>=0.1.22,<0.2", "watchdog>=6,<7"]
+dependencies = ["agi-env==2026.05.30", "streamlit>=1.56,<1.57", "streamlit_code_editor>=0.1.22,<0.2", "watchdog>=6,<7"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/test/test_governance_supply_chain_contract.py
+++ b/test/test_governance_supply_chain_contract.py
@@ -43,6 +43,19 @@ def test_dependabot_visibility_covers_python_and_github_actions() -> None:
     assert 'interval: "weekly"' in text
 
 
+def test_dependabot_does_not_reopen_unsupported_streamlit_bumps() -> None:
+    text = DEPENDABOT.read_text(encoding="utf-8")
+
+    for directory in ('directory: "/"', 'directory: "/src/agilab/lib/agi-gui"'):
+        start = text.index(f'package-ecosystem: "pip"\n    {directory}')
+        next_entry = text.find("\n  - package-ecosystem:", start + 1)
+        section = text[start:] if next_entry == -1 else text[start:next_entry]
+        assert 'dependency-name: "streamlit"' in section
+        assert 'version-update:semver-major' in section
+        assert 'version-update:semver-minor' in section
+        assert 'version-update:semver-patch' in section
+
+
 def test_contributing_documents_enterprise_governance_boundaries() -> None:
     contributing = CONTRIBUTING.read_text(encoding="utf-8")
     template = PR_TEMPLATE.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- restore the supported Streamlit range to >=1.56,<1.57 in the root UI extra and agi-gui package
- add Dependabot ignore rules so unsupported Streamlit bumps are not reopened automatically
- add a governance regression test for those ignore rules

## Validation
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile dependency-policy
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_pyproject_dependency_hygiene.py test/test_governance_supply_chain_contract.py
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui
- git diff --check