### PR TITLE
Improve UI maintenance coverage

### DIFF
--- a/badges/coverage-agi-gui.svg
+++ b/badges/coverage-agi-gui.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="153" height="20" role="img" aria-label="agi-gui coverage: 97%">
+<svg xmlns="http://www.w3.org/2000/svg" width="153" height="20" role="img" aria-label="agi-gui coverage: 98%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="61.0" y="15" fill="#010101" fill-opacity=".3">agi-gui coverage</text>
   <text x="61.0" y="14">agi-gui coverage</text>
-  <text x="137.5" y="15" fill="#010101" fill-opacity=".3">97%</text>
-  <text x="137.5" y="14">97%</text>
+  <text x="137.5" y="15" fill="#010101" fill-opacity=".3">98%</text>
+  <text x="137.5" y="14">98%</text>
 </g>
 </svg>

--- a/badges/coverage-agilab.svg
+++ b/badges/coverage-agilab.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="146" height="20" role="img" aria-label="agilab coverage: 97%">
+<svg xmlns="http://www.w3.org/2000/svg" width="146" height="20" role="img" aria-label="agilab coverage: 98%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="57.5" y="15" fill="#010101" fill-opacity=".3">agilab coverage</text>
   <text x="57.5" y="14">agilab coverage</text>
-  <text x="130.5" y="15" fill="#010101" fill-opacity=".3">97%</text>
-  <text x="130.5" y="14">97%</text>
+  <text x="130.5" y="15" fill="#010101" fill-opacity=".3">98%</text>
+  <text x="130.5" y="14">98%</text>
 </g>
 </svg>

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 244,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "2abe70adee80b18be3f5d7433d3aee842011b3a379d1357e5eb7c413a2d4c401",
+  "source_digest_sha256": "d9548790235ea6a81a2b7e455004e93ca3c4da76a5130c757ab791b7f4938f73",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "2abe70adee80b18be3f5d7433d3aee842011b3a379d1357e5eb7c413a2d4c401"
+  "target_digest_sha256": "d9548790235ea6a81a2b7e455004e93ca3c4da76a5130c757ab791b7f4938f73"
 }

--- a/docs/source/agi-app-data-quality-gate-licenses.md
+++ b/docs/source/agi-app-data-quality-gate-licenses.md
@@ -60,7 +60,6 @@ Audit notes:
 | python-dateutil | 2.9.0.post0 | APACHE SOFTWARE LICENSE;; BSD LICENSE |
 | python-dotenv | 1.2.2 | BSD-3-CLAUSE |
 | pyyaml | 6.0.3 | MIT LICENSE |
-| pyzstd | 0.19.1 | BSD LICENSE |
 | scikit-learn | 1.8.0 | BSD-3-CLAUSE |
 | scipy | 1.16.3 | BSD LICENSE |
 | setuptools | 81.0.0 | MIT |

--- a/docs/source/agi-app-mission-decision-licenses.md
+++ b/docs/source/agi-app-mission-decision-licenses.md
@@ -78,7 +78,6 @@ Audit notes:
 | python-dateutil | 2.9.0.post0 | APACHE SOFTWARE LICENSE;; BSD LICENSE |
 | python-dotenv | 1.2.2 | BSD-3-CLAUSE |
 | pyyaml | 6.0.3 | MIT LICENSE |
-| pyzstd | 0.19.1 | BSD LICENSE |
 | referencing | 0.37.0 | MIT |
 | requests | 2.33.1 | APACHE SOFTWARE LICENSE |
 | rpds-py | 0.30.0 | MIT |

--- a/docs/source/agi-app-multi-dag-licenses.md
+++ b/docs/source/agi-app-multi-dag-licenses.md
@@ -60,7 +60,6 @@ Audit notes:
 | python-dateutil | 2.9.0.post0 | APACHE SOFTWARE LICENSE;; BSD LICENSE |
 | python-dotenv | 1.2.2 | BSD-3-CLAUSE |
 | pyyaml | 6.0.3 | MIT LICENSE |
-| pyzstd | 0.19.1 | BSD LICENSE |
 | scikit-learn | 1.8.0 | BSD-3-CLAUSE |
 | scipy | 1.16.3 | BSD LICENSE |
 | setuptools | 81.0.0 | MIT |

--- a/docs/source/agi-app-pandas-execution-licenses.md
+++ b/docs/source/agi-app-pandas-execution-licenses.md
@@ -60,7 +60,6 @@ Audit notes:
 | python-dateutil | 2.9.0.post0 | APACHE SOFTWARE LICENSE;; BSD LICENSE |
 | python-dotenv | 1.2.2 | BSD-3-CLAUSE |
 | pyyaml | 6.0.3 | MIT LICENSE |
-| pyzstd | 0.19.1 | BSD LICENSE |
 | scikit-learn | 1.8.0 | BSD-3-CLAUSE |
 | scipy | 1.16.3 | BSD LICENSE |
 | setuptools | 81.0.0 | MIT |

--- a/docs/source/agi-app-polars-execution-licenses.md
+++ b/docs/source/agi-app-polars-execution-licenses.md
@@ -60,7 +60,6 @@ Audit notes:
 | python-dateutil | 2.9.0.post0 | APACHE SOFTWARE LICENSE;; BSD LICENSE |
 | python-dotenv | 1.2.2 | BSD-3-CLAUSE |
 | pyyaml | 6.0.3 | MIT LICENSE |
-| pyzstd | 0.19.1 | BSD LICENSE |
 | scikit-learn | 1.8.0 | BSD-3-CLAUSE |
 | scipy | 1.16.3 | BSD LICENSE |
 | setuptools | 81.0.0 | MIT |

--- a/docs/source/agi-app-pytorch-playground-licenses.md
+++ b/docs/source/agi-app-pytorch-playground-licenses.md
@@ -83,7 +83,6 @@ Audit notes:
 | python-dateutil | 2.9.0.post0 | APACHE SOFTWARE LICENSE;; BSD LICENSE |
 | python-dotenv | 1.2.2 | BSD-3-CLAUSE |
 | pyyaml | 6.0.3 | MIT LICENSE |
-| pyzstd | 0.19.1 | BSD LICENSE |
 | referencing | 0.37.0 | MIT |
 | requests | 2.33.1 | APACHE SOFTWARE LICENSE |
 | rpds-py | 0.30.0 | MIT |

--- a/docs/source/agi-app-sklearn-pipeline-licenses.md
+++ b/docs/source/agi-app-sklearn-pipeline-licenses.md
@@ -60,7 +60,6 @@ Audit notes:
 | python-dateutil | 2.9.0.post0 | APACHE SOFTWARE LICENSE;; BSD LICENSE |
 | python-dotenv | 1.2.2 | BSD-3-CLAUSE |
 | pyyaml | 6.0.3 | MIT LICENSE |
-| pyzstd | 0.19.1 | BSD LICENSE |
 | scikit-learn | 1.8.0 | BSD-3-CLAUSE |
 | scipy | 1.16.3 | BSD LICENSE |
 | setuptools | 81.0.0 | MIT |

--- a/docs/source/agi-app-tescia-diagnostic-licenses.md
+++ b/docs/source/agi-app-tescia-diagnostic-licenses.md
@@ -60,7 +60,6 @@ Audit notes:
 | python-dateutil | 2.9.0.post0 | APACHE SOFTWARE LICENSE;; BSD LICENSE |
 | python-dotenv | 1.2.2 | BSD-3-CLAUSE |
 | pyyaml | 6.0.3 | MIT LICENSE |
-| pyzstd | 0.19.1 | BSD LICENSE |
 | scikit-learn | 1.8.0 | BSD-3-CLAUSE |
 | scipy | 1.16.3 | BSD LICENSE |
 | setuptools | 81.0.0 | MIT |

--- a/docs/source/agi-app-uav-queue-licenses.md
+++ b/docs/source/agi-app-uav-queue-licenses.md
@@ -60,7 +60,6 @@ Audit notes:
 | python-dateutil | 2.9.0.post0 | APACHE SOFTWARE LICENSE;; BSD LICENSE |
 | python-dotenv | 1.2.2 | BSD-3-CLAUSE |
 | pyyaml | 6.0.3 | MIT LICENSE |
-| pyzstd | 0.19.1 | BSD LICENSE |
 | scikit-learn | 1.8.0 | BSD-3-CLAUSE |
 | scipy | 1.16.3 | BSD LICENSE |
 | setuptools | 81.0.0 | MIT |

--- a/docs/source/agi-app-uav-relay-queue-licenses.md
+++ b/docs/source/agi-app-uav-relay-queue-licenses.md
@@ -79,7 +79,6 @@ Audit notes:
 | python-dateutil | 2.9.0.post0 | APACHE SOFTWARE LICENSE;; BSD LICENSE |
 | python-dotenv | 1.2.2 | BSD-3-CLAUSE |
 | pyyaml | 6.0.3 | MIT LICENSE |
-| pyzstd | 0.19.1 | BSD LICENSE |
 | referencing | 0.37.0 | MIT |
 | requests | 2.33.1 | APACHE SOFTWARE LICENSE |
 | rpds-py | 0.30.0 | MIT |

--- a/docs/source/agi-app-weather-forecast-licenses.md
+++ b/docs/source/agi-app-weather-forecast-licenses.md
@@ -87,7 +87,6 @@ Audit notes:
 | python-dateutil | 2.9.0.post0 | APACHE SOFTWARE LICENSE;; BSD LICENSE |
 | python-dotenv | 1.2.2 | BSD-3-CLAUSE |
 | pyyaml | 6.0.3 | MIT LICENSE |
-| pyzstd | 0.19.1 | BSD LICENSE |
 | referencing | 0.37.0 | MIT |
 | requests | 2.33.1 | APACHE SOFTWARE LICENSE |
 | rich | 15.0.0 | MIT LICENSE |

--- a/docs/source/agi-apps-licenses.md
+++ b/docs/source/agi-apps-licenses.md
@@ -70,7 +70,6 @@ Audit notes:
 | python-dateutil | 2.9.0.post0 | APACHE SOFTWARE LICENSE;; BSD LICENSE |
 | python-dotenv | 1.2.2 | BSD-3-CLAUSE |
 | pyyaml | 6.0.3 | MIT LICENSE |
-| pyzstd | 0.19.1 | BSD LICENSE |
 | scikit-learn | 1.8.0 | BSD-3-CLAUSE |
 | scipy | 1.16.3 | BSD LICENSE |
 | setuptools | 81.0.0 | MIT |

--- a/docs/source/agi-cluster-licenses.md
+++ b/docs/source/agi-cluster-licenses.md
@@ -58,7 +58,6 @@ Audit notes:
 | python-dateutil | 2.9.0.post0 | APACHE SOFTWARE LICENSE;; BSD LICENSE |
 | python-dotenv | 1.2.2 | BSD-3-CLAUSE |
 | pyyaml | 6.0.3 | MIT LICENSE |
-| pyzstd | 0.19.1 | BSD LICENSE |
 | scikit-learn | 1.8.0 | BSD-3-CLAUSE |
 | scipy | 1.16.3 | BSD LICENSE |
 | setuptools | 81.0.0 | MIT |

--- a/docs/source/agi-core-licenses.md
+++ b/docs/source/agi-core-licenses.md
@@ -59,7 +59,6 @@ Audit notes:
 | python-dateutil | 2.9.0.post0 | APACHE SOFTWARE LICENSE;; BSD LICENSE |
 | python-dotenv | 1.2.2 | BSD-3-CLAUSE |
 | pyyaml | 6.0.3 | MIT LICENSE |
-| pyzstd | 0.19.1 | BSD LICENSE |
 | scikit-learn | 1.8.0 | BSD-3-CLAUSE |
 | scipy | 1.16.3 | BSD LICENSE |
 | setuptools | 81.0.0 | MIT |

--- a/docs/source/agi-env-licenses.md
+++ b/docs/source/agi-env-licenses.md
@@ -31,7 +31,6 @@ Audit notes:
 | pydantic-core | 2.41.5 | MIT |
 | pyppmd | 1.2.0 | LGPL-2.1-OR-LATER |
 | python-dotenv | 1.2.2 | BSD-3-CLAUSE |
-| pyzstd | 0.19.1 | BSD LICENSE |
 | texttable | 1.7.0 | MIT LICENSE |
 | tomlkit | 0.14.0 | MIT LICENSE |
 | typing-extensions | 4.15.0 | PSF-2.0 |

--- a/docs/source/agi-gui-licenses.md
+++ b/docs/source/agi-gui-licenses.md
@@ -55,7 +55,6 @@ Audit notes:
 | pyppmd | 1.2.0 | LGPL-2.1-OR-LATER |
 | python-dateutil | 2.9.0.post0 | APACHE SOFTWARE LICENSE;; BSD LICENSE |
 | python-dotenv | 1.2.2 | BSD-3-CLAUSE |
-| pyzstd | 0.19.1 | BSD LICENSE |
 | referencing | 0.37.0 | MIT |
 | requests | 2.33.1 | APACHE SOFTWARE LICENSE |
 | rpds-py | 0.30.0 | MIT |

--- a/docs/source/agi-node-licenses.md
+++ b/docs/source/agi-node-licenses.md
@@ -40,7 +40,6 @@ Audit notes:
 | pyppmd | 1.2.0 | LGPL-2.1-OR-LATER |
 | python-dateutil | 2.9.0.post0 | APACHE SOFTWARE LICENSE;; BSD LICENSE |
 | python-dotenv | 1.2.2 | BSD-3-CLAUSE |
-| pyzstd | 0.19.1 | BSD LICENSE |
 | setuptools | 81.0.0 | MIT |
 | six | 1.17.0 | MIT LICENSE |
 | texttable | 1.7.0 | MIT LICENSE |

--- a/docs/source/agi-page-app-ui-licenses.md
+++ b/docs/source/agi-page-app-ui-licenses.md
@@ -57,7 +57,6 @@ Audit notes:
 | pyppmd | 1.2.0 | LGPL-2.1-OR-LATER |
 | python-dateutil | 2.9.0.post0 | APACHE SOFTWARE LICENSE;; BSD LICENSE |
 | python-dotenv | 1.2.2 | BSD-3-CLAUSE |
-| pyzstd | 0.19.1 | BSD LICENSE |
 | referencing | 0.37.0 | MIT |
 | requests | 2.33.1 | APACHE SOFTWARE LICENSE |
 | rpds-py | 0.30.0 | MIT |

--- a/docs/source/agi-page-decision-evidence-licenses.md
+++ b/docs/source/agi-page-decision-evidence-licenses.md
@@ -63,7 +63,6 @@ Audit notes:
 | pyppmd | 1.2.0 | LGPL-2.1-OR-LATER |
 | python-dateutil | 2.9.0.post0 | APACHE SOFTWARE LICENSE;; BSD LICENSE |
 | python-dotenv | 1.2.2 | BSD-3-CLAUSE |
-| pyzstd | 0.19.1 | BSD LICENSE |
 | referencing | 0.37.0 | MIT |
 | requests | 2.33.1 | APACHE SOFTWARE LICENSE |
 | rpds-py | 0.30.0 | MIT |

--- a/docs/source/agi-page-feature-attribution-licenses.md
+++ b/docs/source/agi-page-feature-attribution-licenses.md
@@ -63,7 +63,6 @@ Audit notes:
 | pyppmd | 1.2.0 | LGPL-2.1-OR-LATER |
 | python-dateutil | 2.9.0.post0 | APACHE SOFTWARE LICENSE;; BSD LICENSE |
 | python-dotenv | 1.2.2 | BSD-3-CLAUSE |
-| pyzstd | 0.19.1 | BSD LICENSE |
 | referencing | 0.37.0 | MIT |
 | requests | 2.33.1 | APACHE SOFTWARE LICENSE |
 | rpds-py | 0.30.0 | MIT |

--- a/docs/source/agi-page-geospatial-3d-licenses.md
+++ b/docs/source/agi-page-geospatial-3d-licenses.md
@@ -65,7 +65,6 @@ Audit notes:
 | pyppmd | 1.2.0 | LGPL-2.1-OR-LATER |
 | python-dateutil | 2.9.0.post0 | APACHE SOFTWARE LICENSE;; BSD LICENSE |
 | python-dotenv | 1.2.2 | BSD-3-CLAUSE |
-| pyzstd | 0.19.1 | BSD LICENSE |
 | referencing | 0.37.0 | MIT |
 | requests | 2.33.1 | APACHE SOFTWARE LICENSE |
 | rpds-py | 0.30.0 | MIT |

--- a/docs/source/agi-page-geospatial-map-licenses.md
+++ b/docs/source/agi-page-geospatial-map-licenses.md
@@ -64,7 +64,6 @@ Audit notes:
 | pyppmd | 1.2.0 | LGPL-2.1-OR-LATER |
 | python-dateutil | 2.9.0.post0 | APACHE SOFTWARE LICENSE;; BSD LICENSE |
 | python-dotenv | 1.2.2 | BSD-3-CLAUSE |
-| pyzstd | 0.19.1 | BSD LICENSE |
 | referencing | 0.37.0 | MIT |
 | requests | 2.33.1 | APACHE SOFTWARE LICENSE |
 | rpds-py | 0.30.0 | MIT |

--- a/docs/source/agi-page-inference-report-licenses.md
+++ b/docs/source/agi-page-inference-report-licenses.md
@@ -64,7 +64,6 @@ Audit notes:
 | pyppmd | 1.2.0 | LGPL-2.1-OR-LATER |
 | python-dateutil | 2.9.0.post0 | APACHE SOFTWARE LICENSE;; BSD LICENSE |
 | python-dotenv | 1.2.2 | BSD-3-CLAUSE |
-| pyzstd | 0.19.1 | BSD LICENSE |
 | referencing | 0.37.0 | MIT |
 | requests | 2.33.1 | APACHE SOFTWARE LICENSE |
 | rpds-py | 0.30.0 | MIT |

--- a/docs/source/agi-page-live-artifacts-licenses.md
+++ b/docs/source/agi-page-live-artifacts-licenses.md
@@ -63,7 +63,6 @@ Audit notes:
 | pyppmd | 1.2.0 | LGPL-2.1-OR-LATER |
 | python-dateutil | 2.9.0.post0 | APACHE SOFTWARE LICENSE;; BSD LICENSE |
 | python-dotenv | 1.2.2 | BSD-3-CLAUSE |
-| pyzstd | 0.19.1 | BSD LICENSE |
 | referencing | 0.37.0 | MIT |
 | requests | 2.33.1 | APACHE SOFTWARE LICENSE |
 | rpds-py | 0.30.0 | MIT |

--- a/docs/source/agi-page-network-map-licenses.md
+++ b/docs/source/agi-page-network-map-licenses.md
@@ -83,7 +83,6 @@ Audit notes:
 | pyppmd | 1.2.0 | LGPL-2.1-OR-LATER |
 | python-dateutil | 2.9.0.post0 | APACHE SOFTWARE LICENSE;; BSD LICENSE |
 | python-dotenv | 1.2.2 | BSD-3-CLAUSE |
-| pyzstd | 0.19.1 | BSD LICENSE |
 | referencing | 0.37.0 | MIT |
 | requests | 2.33.1 | APACHE SOFTWARE LICENSE |
 | rpds-py | 0.30.0 | MIT |

--- a/docs/source/agi-page-promotion-gate-licenses.md
+++ b/docs/source/agi-page-promotion-gate-licenses.md
@@ -63,7 +63,6 @@ Audit notes:
 | pyppmd | 1.2.0 | LGPL-2.1-OR-LATER |
 | python-dateutil | 2.9.0.post0 | APACHE SOFTWARE LICENSE;; BSD LICENSE |
 | python-dotenv | 1.2.2 | BSD-3-CLAUSE |
-| pyzstd | 0.19.1 | BSD LICENSE |
 | referencing | 0.37.0 | MIT |
 | requests | 2.33.1 | APACHE SOFTWARE LICENSE |
 | rpds-py | 0.30.0 | MIT |

--- a/docs/source/agi-page-queue-health-licenses.md
+++ b/docs/source/agi-page-queue-health-licenses.md
@@ -63,7 +63,6 @@ Audit notes:
 | pyppmd | 1.2.0 | LGPL-2.1-OR-LATER |
 | python-dateutil | 2.9.0.post0 | APACHE SOFTWARE LICENSE;; BSD LICENSE |
 | python-dotenv | 1.2.2 | BSD-3-CLAUSE |
-| pyzstd | 0.19.1 | BSD LICENSE |
 | referencing | 0.37.0 | MIT |
 | requests | 2.33.1 | APACHE SOFTWARE LICENSE |
 | rpds-py | 0.30.0 | MIT |

--- a/docs/source/agi-page-relay-health-licenses.md
+++ b/docs/source/agi-page-relay-health-licenses.md
@@ -63,7 +63,6 @@ Audit notes:
 | pyppmd | 1.2.0 | LGPL-2.1-OR-LATER |
 | python-dateutil | 2.9.0.post0 | APACHE SOFTWARE LICENSE;; BSD LICENSE |
 | python-dotenv | 1.2.2 | BSD-3-CLAUSE |
-| pyzstd | 0.19.1 | BSD LICENSE |
 | referencing | 0.37.0 | MIT |
 | requests | 2.33.1 | APACHE SOFTWARE LICENSE |
 | rpds-py | 0.30.0 | MIT |

--- a/docs/source/agi-page-routing-model-comparison-licenses.md
+++ b/docs/source/agi-page-routing-model-comparison-licenses.md
@@ -64,7 +64,6 @@ Audit notes:
 | pyppmd | 1.2.0 | LGPL-2.1-OR-LATER |
 | python-dateutil | 2.9.0.post0 | APACHE SOFTWARE LICENSE;; BSD LICENSE |
 | python-dotenv | 1.2.2 | BSD-3-CLAUSE |
-| pyzstd | 0.19.1 | BSD LICENSE |
 | referencing | 0.37.0 | MIT |
 | requests | 2.33.1 | APACHE SOFTWARE LICENSE |
 | rpds-py | 0.30.0 | MIT |

--- a/docs/source/agi-page-scenario-cockpit-licenses.md
+++ b/docs/source/agi-page-scenario-cockpit-licenses.md
@@ -63,7 +63,6 @@ Audit notes:
 | pyppmd | 1.2.0 | LGPL-2.1-OR-LATER |
 | python-dateutil | 2.9.0.post0 | APACHE SOFTWARE LICENSE;; BSD LICENSE |
 | python-dotenv | 1.2.2 | BSD-3-CLAUSE |
-| pyzstd | 0.19.1 | BSD LICENSE |
 | referencing | 0.37.0 | MIT |
 | requests | 2.33.1 | APACHE SOFTWARE LICENSE |
 | rpds-py | 0.30.0 | MIT |

--- a/docs/source/agi-page-simplex-map-licenses.md
+++ b/docs/source/agi-page-simplex-map-licenses.md
@@ -71,7 +71,6 @@ Audit notes:
 | pyppmd | 1.2.0 | LGPL-2.1-OR-LATER |
 | python-dateutil | 2.9.0.post0 | APACHE SOFTWARE LICENSE;; BSD LICENSE |
 | python-dotenv | 1.2.2 | BSD-3-CLAUSE |
-| pyzstd | 0.19.1 | BSD LICENSE |
 | referencing | 0.37.0 | MIT |
 | requests | 2.33.1 | APACHE SOFTWARE LICENSE |
 | rpds-py | 0.30.0 | MIT |

--- a/docs/source/agi-page-timeseries-forecast-licenses.md
+++ b/docs/source/agi-page-timeseries-forecast-licenses.md
@@ -63,7 +63,6 @@ Audit notes:
 | pyppmd | 1.2.0 | LGPL-2.1-OR-LATER |
 | python-dateutil | 2.9.0.post0 | APACHE SOFTWARE LICENSE;; BSD LICENSE |
 | python-dotenv | 1.2.2 | BSD-3-CLAUSE |
-| pyzstd | 0.19.1 | BSD LICENSE |
 | referencing | 0.37.0 | MIT |
 | requests | 2.33.1 | APACHE SOFTWARE LICENSE |
 | rpds-py | 0.30.0 | MIT |

--- a/docs/source/agi-page-training-report-licenses.md
+++ b/docs/source/agi-page-training-report-licenses.md
@@ -67,7 +67,6 @@ Audit notes:
 | pyppmd | 1.2.0 | LGPL-2.1-OR-LATER |
 | python-dateutil | 2.9.0.post0 | APACHE SOFTWARE LICENSE;; BSD LICENSE |
 | python-dotenv | 1.2.2 | BSD-3-CLAUSE |
-| pyzstd | 0.19.1 | BSD LICENSE |
 | referencing | 0.37.0 | MIT |
 | requests | 2.33.1 | APACHE SOFTWARE LICENSE |
 | rpds-py | 0.30.0 | MIT |

--- a/docs/source/agi-pages-licenses.md
+++ b/docs/source/agi-pages-licenses.md
@@ -56,7 +56,6 @@ Audit notes:
 | pyppmd | 1.2.0 | LGPL-2.1-OR-LATER |
 | python-dateutil | 2.9.0.post0 | APACHE SOFTWARE LICENSE;; BSD LICENSE |
 | python-dotenv | 1.2.2 | BSD-3-CLAUSE |
-| pyzstd | 0.19.1 | BSD LICENSE |
 | referencing | 0.37.0 | MIT |
 | requests | 2.33.1 | APACHE SOFTWARE LICENSE |
 | rpds-py | 0.30.0 | MIT |

--- a/docs/source/agilab-licenses.md
+++ b/docs/source/agilab-licenses.md
@@ -260,7 +260,6 @@ Audit notes:
 | pytz | 2026.1.post1 | MIT LICENSE |
 | pyyaml | 6.0.3 | MIT LICENSE |
 | pyzmq | 27.1.0 | BSD LICENSE |
-| pyzstd | 0.19.1 | BSD LICENSE |
 | readme-renderer | 44.0 | APACHE SOFTWARE LICENSE |
 | referencing | 0.37.0 | MIT |
 | regex | 2026.4.4 | APACHE-2.0;; CNRI-PYTHON |

--- a/docs/source/data/release_proof.toml
+++ b/docs/source/data/release_proof.toml
@@ -29,7 +29,7 @@ github_release_tag = "v2026.05.30"
 github_release_url = "https://github.com/ThalesGroup/agilab/releases/tag/v2026.05.30"
 hf_space_label = "jpmorard/agilab"
 hf_space_url = "https://huggingface.co/spaces/jpmorard/agilab"
-hf_space_commit = "41871f32e629d29b2a90757ba657757be5559df1"
+hf_space_commit = "16b84cb01366e122e316b16c7ab5a0aedb1151a7"
 
 [[ci_runs]]
 id = "release-guardrails"

--- a/docs/source/release-proof.rst
+++ b/docs/source/release-proof.rst
@@ -22,7 +22,7 @@ Current public release
    * - GitHub release
      - `v2026.05.30 <https://github.com/ThalesGroup/agilab/releases/tag/v2026.05.30>`__
    * - Hosted demo
-     - `jpmorard/agilab <https://huggingface.co/spaces/jpmorard/agilab>`__ at Space commit ``41871f32e629d29b2a90757ba657757be5559df1``
+     - `jpmorard/agilab <https://huggingface.co/spaces/jpmorard/agilab>`__ at Space commit ``16b84cb01366e122e316b16c7ab5a0aedb1151a7``
    * - Public guardrails
      - `repo-guardrails run 26657909184 <https://github.com/ThalesGroup/agilab/actions/runs/26657909184>`__ passed repository guardrails and clean package first-proof jobs
    * - Docs source guard

--- a/src/agilab/apps/builtin/pytorch_playground_project/src/app_args_form.py
+++ b/src/agilab/apps/builtin/pytorch_playground_project/src/app_args_form.py
@@ -383,10 +383,13 @@ def _state_value(env: Any, name: str, fallback: Any) -> Any:
 def _current_form_values(
     model: app_args.PytorchPlaygroundArgs, *, env: Any
 ) -> dict[str, Any]:
-    return {
-        field.name: _state_value(env, field.name, getattr(model, field.name))
-        for field in FORM_FIELDS
-    }
+    values: dict[str, Any] = {}
+    for field in FORM_FIELDS:
+        value = _state_value(env, field.name, getattr(model, field.name))
+        if field.widget == "feature_names":
+            value = ",".join(_coerce_feature_names(value, default=DEFAULT_FEATURES))
+        values[field.name] = _coerce_field_value(field, value)
+    return values
 
 
 def persist_current_args(*, env: Any | None = None) -> app_args.PytorchPlaygroundArgs:

--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/app_args_form.py
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/app_args_form.py
@@ -383,10 +383,13 @@ def _state_value(env: Any, name: str, fallback: Any) -> Any:
 def _current_form_values(
     model: app_args.PytorchPlaygroundArgs, *, env: Any
 ) -> dict[str, Any]:
-    return {
-        field.name: _state_value(env, field.name, getattr(model, field.name))
-        for field in FORM_FIELDS
-    }
+    values: dict[str, Any] = {}
+    for field in FORM_FIELDS:
+        value = _state_value(env, field.name, getattr(model, field.name))
+        if field.widget == "feature_names":
+            value = ",".join(_coerce_feature_names(value, default=DEFAULT_FEATURES))
+        values[field.name] = _coerce_field_value(field, value)
+    return values
 
 
 def persist_current_args(*, env: Any | None = None) -> app_args.PytorchPlaygroundArgs:

--- a/src/agilab/main_page.py
+++ b/src/agilab/main_page.py
@@ -955,14 +955,17 @@ def _render_env_editor(env: Any, help_file: Path | None = None) -> None:
     _about_env_editor._render_env_editor(env, help_file)
 
 
-def _render_navigation_context(env: Any, *, page_label: str) -> None:
+def _render_navigation_context(
+    env: Any, *, page_label: str, show_project_context: bool = True
+) -> None:
     try:
         render_sidebar_version(detect_agilab_version(env))
     except (AttributeError, OSError, RuntimeError, TypeError, ValueError):
         pass
     render_sidebar_settings_link(env)
     render_pinned_expanders(st)
-    render_page_context(st, page_label=page_label, env=env)
+    if show_project_context:
+        render_page_context(st, page_label=page_label, env=env)
 
 
 def _seed_session_runtime_defaults(env: Any) -> None:
@@ -974,7 +977,7 @@ def _seed_session_runtime_defaults(env: Any) -> None:
 
 def page(env: Any) -> None:
     """Render the main landing page controls and footer for the lab."""
-    _render_navigation_context(env, page_label="MAIN_PAGE")
+    _render_navigation_context(env, page_label="MAIN_PAGE", show_project_context=False)
     _sync_layout_module()
     _about_layout.render_footer()
     _seed_session_runtime_defaults(env)

--- a/src/agilab/pages/2_ORCHESTRATE.py
+++ b/src/agilab/pages/2_ORCHESTRATE.py
@@ -2358,6 +2358,11 @@ async def _render_run_panels(
 # ===========================
 # Main Application UI
 # ===========================
+def _skip_orchestrate_project_cockpit(*_args: Any, **_kwargs: Any) -> None:
+    """ORCHESTRATE uses its action rail and Environment Health instead."""
+    return None
+
+
 async def page() -> None:
     env = _ensure_page_env(st, __file__)
     if env is None:
@@ -2379,6 +2384,7 @@ async def page() -> None:
         env=env,
         page_label="ORCHESTRATE",
         docs_html_file="execute-help.html",
+        render_page_context=_skip_orchestrate_project_cockpit,
     )
 
     if background_services_enabled() and not st.session_state.get("server_started"):

--- a/test/test_about_agilab_helpers.py
+++ b/test/test_about_agilab_helpers.py
@@ -2138,6 +2138,68 @@ def test_bootstrap_additional_active_app_and_source_path_edges(tmp_path, monkeyp
     assert any("cannot reinit" in warning for warning in warnings)
 
 
+def test_bootstrap_path_matching_and_payload_project_edges(tmp_path):
+    bootstrap = about_agilab._about_bootstrap
+    apps_path = tmp_path / "src" / "agilab" / "apps"
+    builtin_path = apps_path / "builtin"
+    project = builtin_path / "demo_project"
+    project.mkdir(parents=True)
+
+    assert bootstrap._normalize_path(_BrokenPath()) is None
+    assert bootstrap._existing_env_matches_apps_path(SimpleNamespace(), apps_path) is False
+    assert (
+        bootstrap._existing_env_matches_apps_path(
+            SimpleNamespace(active_app=project),
+            builtin_path,
+        )
+        is True
+    )
+    assert (
+        bootstrap._existing_env_matches_apps_path(
+            SimpleNamespace(app=project),
+            builtin_path,
+        )
+        is True
+    )
+    assert (
+        bootstrap._existing_env_matches_apps_path(
+            SimpleNamespace(app=_BrokenPath()),
+            builtin_path,
+        )
+        is False
+    )
+    assert bootstrap._recover_existing_env_for_apps_path(SimpleNamespace(current=None), apps_path) is None
+
+    class RaisingCurrent:
+        @staticmethod
+        def current():
+            raise RuntimeError("not initialised")
+
+    assert bootstrap._recover_existing_env_for_apps_path(RaisingCurrent, apps_path) is None
+
+    package_project = (
+        tmp_path
+        / "agi-app-demo"
+        / "src"
+        / "agi_app_demo"
+        / "project"
+        / "demo_project"
+    )
+    package_project.mkdir(parents=True)
+    env = SimpleNamespace(
+        apps_path=apps_path,
+        builtin_apps_path=builtin_path,
+        apps_repository_root=tmp_path / "repo",
+        projects={"demo_project"},
+    )
+
+    assert bootstrap.normalize_active_app_input(env, str(package_project)) == project.resolve()
+    assert bootstrap.persisted_active_app_request(env, project) == str(project)
+
+    stale = tmp_path / "other" / "demo_project"
+    assert bootstrap.persisted_active_app_request(env, stale) == "demo_project"
+
+
 def test_bootstrap_persist_env_handles_plain_and_empty_cluster_credentials(tmp_path):
     bootstrap = about_agilab._about_bootstrap
     calls: list[tuple[str, str]] = []
@@ -3908,11 +3970,16 @@ def test_main_page_sidebar_keeps_settings_link_without_execution_context(monkeyp
         body for kind, body in fake_st.events if kind == "sidebar.markdown"
     ]
     sidebar_markup = "\n".join(sidebar_markdowns)
+    page_markdown = "\n".join(
+        body for kind, body in fake_st.events if kind == "markdown"
+    )
     assert "[Settings](/SETTINGS)" in sidebar_markdowns
     assert "[Documentation](https://docs.example/agilab-help.html)" in sidebar_markdowns
     assert "[Settings](/SETTINGS)" in sidebar_markup
     assert "[Documentation](https://docs.example/agilab-help.html)" in sidebar_markup
     assert "[README]" not in sidebar_markup
+    assert "Project cockpit" not in page_markdown
+    assert "agilab-header-card" not in page_markdown
     assert "agilab-sidebar-system" not in sidebar_markup
     assert "Active project" not in sidebar_markup
     assert "Scheduler" not in sidebar_markup

--- a/test/test_adoption_report.py
+++ b/test/test_adoption_report.py
@@ -171,3 +171,55 @@ def test_main_writes_json_and_strict_fails_when_manifest_missing(tmp_path: Path)
         str(tmp_path / "missing-report.json"),
         "--strict",
     ]) == 1
+
+
+def test_adoption_report_edge_cases_and_stdout(tmp_path: Path, monkeypatch, capsys) -> None:
+    monkeypatch.setenv("AGILAB_LOG_ABS", str(tmp_path / "logs"))
+    default_path = adoption_report.default_manifest_path()
+    assert default_path == adoption_report.default_manifest_candidates()[0]
+
+    present = adoption_report.default_manifest_candidates()[1]
+    present.parent.mkdir(parents=True, exist_ok=True)
+    present.write_text("{}", encoding="utf-8")
+    assert adoption_report.default_manifest_path() == present
+
+    assert adoption_report._status_label(False, "parse-error") == "invalid"
+
+    invalid_manifest = tmp_path / "invalid.json"
+    invalid_manifest.write_text("{not-json", encoding="utf-8")
+    invalid_report = adoption_report.build_report(manifest_path=invalid_manifest)
+    assert invalid_report["summary"]["first_proof_status"] == "invalid"
+    assert "manifest parse error" in invalid_report["first_proof"]["issues"][0]
+
+    wrong_manifest = _write_manifest(
+        tmp_path / "wrong" / "run_manifest.json",
+        app_name="other_project",
+        status="fail",
+        validation_status="fail",
+    )
+    payload = json.loads(wrong_manifest.read_text(encoding="utf-8"))
+    payload["path_id"] = "other-path"
+    payload["timing"]["target_seconds"] = None
+    wrong_manifest.write_text(json.dumps(payload), encoding="utf-8")
+
+    report = adoption_report.build_report(manifest_path=wrong_manifest)
+    issues = report["first_proof"]["issues"]
+    assert any("path_id is" in issue for issue in issues)
+    assert any("manifest status is" in issue for issue in issues)
+    assert any("one or more manifest validations" in issue for issue in issues)
+    assert any("required validation issue" in issue for issue in issues)
+    assert any("active app is" in issue for issue in issues)
+    assert any("target_seconds is missing" in issue for issue in issues)
+    assert "## Blocking Issues" in adoption_report.render_markdown(report)
+
+    slow_manifest = _write_manifest(tmp_path / "slow" / "run_manifest.json")
+    slow_payload = json.loads(slow_manifest.read_text(encoding="utf-8"))
+    slow_payload["timing"]["duration_seconds"] = 99.0
+    slow_payload["timing"]["target_seconds"] = 1.0
+    slow_manifest.write_text(json.dumps(slow_payload), encoding="utf-8")
+    slow_report = adoption_report.build_report(manifest_path=slow_manifest)
+    assert any("exceeds target" in issue for issue in slow_report["first_proof"]["issues"])
+
+    assert adoption_report.main(["--manifest", str(slow_manifest)]) == 0
+    stdout = capsys.readouterr().out
+    assert "# AGILAB Adoption Report" in stdout

--- a/test/test_agent_run.py
+++ b/test/test_agent_run.py
@@ -1165,3 +1165,211 @@ def test_agent_run_read_helpers_reject_negative_limit(tmp_path):
         list_agent_runs(tmp_path, limit=-1)
     with pytest.raises(ValueError, match="limit must be non-negative"):
         agent_context_payload(tmp_path, limit=-1)
+
+
+def test_agent_run_command_policy_and_read_edge_cases(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_module()
+
+    assert module._is_destructive_git_args(()) is False
+    assert module._is_destructive_git_args(("clean", "-fdx")) is True
+    assert module._is_destructive_git_args(("branch", "-D", "old")) is True
+    assert module._is_destructive_git_args(("push", "--force-with-lease")) is True
+    assert module._is_destructive_git_args(("rm", "--force", "file")) is True
+    assert module._is_destructive_docker_args(()) is False
+    assert module._is_destructive_docker_args(("rm", "container")) is True
+    assert module._is_destructive_docker_args(("system", "prune")) is True
+    assert module._is_destructive_docker_args(("volume", "rm", "cache")) is True
+    assert module._is_destructive_uv_args(("pip", "uninstall", "pkg")) is True
+    assert module._is_destructive_uv_args(("cache", "clean")) is True
+    assert module._inline_python_snippets(("-c", "print(1)", "-cimport shutil; shutil.rmtree('x')")) == [
+        "print(1)",
+        "import shutil; shutil.rmtree('x')",
+    ]
+
+    commands = [
+        ("git", "clean", "-fdx"),
+        ("docker", "system", "prune"),
+        ("kubectl", "delete", "pod/demo"),
+        ("pip", "uninstall", "demo"),
+        ("uv", "cache", "clean"),
+        ("npm", "uninstall", "demo"),
+        ("bash", "-c", "rm -rf ./demo"),
+        (sys.executable, "-c", "import shutil; shutil.rmtree('demo')"),
+    ]
+    for command in commands:
+        assert module._command_content_requires_operator(command), command
+    assert module._command_content_requires_operator(()) is False
+    assert module._command_content_requires_operator(("python", "-c", "print('safe')")) is False
+
+    list_manifest = tmp_path / "list.json"
+    list_manifest.write_text("[]\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="must be a JSON object"):
+        module.load_agent_run_manifest(list_manifest)
+    wrong_kind = tmp_path / "wrong-kind.json"
+    wrong_kind.write_text('{"kind": "other"}\n', encoding="utf-8")
+    with pytest.raises(ValueError, match="Unsupported agent run manifest kind"):
+        module.load_agent_run_manifest(wrong_kind)
+
+    assert module._path_from_artifact({"path": ""}) is None
+    summary = module.summarize_agent_run(
+        {
+            "kind": module.TRACE_KIND,
+            "artifacts": "not-a-map",
+            "context": {"tags": "not-a-list", "metadata": "not-a-map"},
+            "timing": "not-a-map",
+            "returncode": "not-int",
+        }
+    )
+    assert summary.tags == ()
+    assert summary.metadata == {}
+    assert summary.returncode is None
+    assert summary.duration_seconds == 0.0
+
+    missing_root = tmp_path / "missing"
+    assert module.find_agent_run_manifests(missing_root) == []
+    monkeypatch.setenv("AGILAB_LOG_ABS", str(tmp_path / "logs"))
+    assert module.find_agent_run_manifests(agent="codex") == []
+
+    root = tmp_path / "runs"
+    valid_dir = root / "valid"
+    invalid_dir = root / "invalid"
+    valid_dir.mkdir(parents=True)
+    invalid_dir.mkdir()
+    valid_manifest = {
+        "kind": module.TRACE_KIND,
+        "run_id": "run-1",
+        "agent": "codex",
+        "status": "pass",
+        "context": {"tags": ["keep"], "metadata": {"branch": "main"}},
+        "protocols": {"adapters": "bad", "capabilities": "bad"},
+        "artifacts": {"manifest": {"path": str(valid_dir / module.MANIFEST_FILENAME)}},
+        "timing": {"duration_seconds": 1},
+    }
+    (valid_dir / module.MANIFEST_FILENAME).write_text(json.dumps(valid_manifest), encoding="utf-8")
+    (invalid_dir / module.MANIFEST_FILENAME).write_text("{bad-json", encoding="utf-8")
+
+    assert module.find_agent_run_manifests(root, protocol_adapters=("mcp",)) == []
+    assert module.find_agent_run_manifests(root, capabilities=("agent",)) == []
+    assert module.find_agent_run_manifests(root, tags=("keep",), metadata={"branch": "main"}) == [
+        valid_dir / module.MANIFEST_FILENAME
+    ]
+
+    assert module._protocol_summary({"protocols": {"adapters": "bad", "capabilities": "bad"}}) == {
+        "adapters": [],
+        "capabilities": [],
+        "mode": "",
+    }
+
+
+def test_agent_run_render_and_validation_remaining_edges(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_module()
+
+    assert "No matching agent runs" in module.render_context_markdown(
+        {"match_count": 0, "status_counts": {}, "runs": [], "latest": {}}
+    )
+    assert "No linked agent runs" in module.render_lineage_markdown(
+        {"query": {"run_id": "missing"}, "found": False, "chain": [], "edges": []}
+    )
+    assert "Metadata delta" in module.render_compare_markdown(
+        {
+            "left": {"run_id": "left", "status": "fail"},
+            "right": {"run_id": "right", "status": "pass"},
+            "metadata": {"added": {"followup_of": "left"}, "removed": {}, "changed": {}},
+        }
+    )
+    validation_text = module.render_validation_markdown(
+        {
+            "run": {"run_id": "bad", "status": "unknown"},
+            "ok": False,
+            "issue_count": 1,
+            "warning_count": 1,
+            "issues": [{"code": "kind", "message": "bad kind"}, "skip"],
+            "warnings": [{"code": "trace", "message": "missing trace"}, "skip"],
+        }
+    )
+    assert "## Issues" in validation_text
+    assert "## Warnings" in validation_text
+
+    bad_manifest = {
+        "kind": "other",
+        "run_id": "bad",
+        "status": "weird",
+        "command": {"argv_redacted": False},
+        "artifacts": {
+            "manifest": {"path": str(tmp_path / "missing-manifest.json")},
+            "agent_trace": {"events": str(tmp_path / "missing-events.ndjson")},
+        },
+    }
+    validation = module.validate_agent_run(bad_manifest)
+    codes = {item["code"] for item in validation["issues"]}
+    warning_codes = {item["code"] for item in validation["warnings"]}
+    assert {"kind", "status", "manifest_path", "stdout_path", "stderr_path", "argv_sha256", "trace_events_exists"} <= codes
+    assert "argv_redaction" in warning_codes
+
+    no_trace_manifest = {
+        "kind": module.TRACE_KIND,
+        "run_id": "planned",
+        "status": "planned",
+        "command": {"argv_sha256": "hash"},
+        "artifacts": {"manifest": {"path": ""}},
+    }
+    no_trace_validation = module.validate_agent_run(no_trace_manifest)
+    assert {item["code"] for item in no_trace_validation["warnings"]} == {"trace_events_path"}
+
+    assert module.agent_next_actions_payload({"kind": module.TRACE_KIND, "status": "timeout"})["next_actions"][0]["priority"] == "P0"
+    assert module.agent_next_actions_payload({"kind": module.TRACE_KIND, "status": "unknown"})["next_actions"][0]["priority"] == "P1"
+
+    monkeypatch.setattr(
+        module,
+        "list_agent_runs",
+        lambda *_args, **_kwargs: [
+            module.AgentRunSummary(
+                run_id="latest",
+                agent="codex",
+                label="bad latest",
+                status="pass",
+                returncode=0,
+                manifest_path=tmp_path / "bad.json",
+                stdout_path=None,
+                stderr_path=None,
+                trace_events_path=None,
+                duration_seconds=0.0,
+                tags=(),
+                metadata={},
+            )
+        ],
+    )
+    assert module.agent_context_payload(tmp_path)["latest"]["handoff"] is None
+
+    parent = module.AgentRunSummary(
+        run_id="parent",
+        agent="codex",
+        label="parent",
+        status="pass",
+        returncode=0,
+        manifest_path=Path(""),
+        stdout_path=None,
+        stderr_path=None,
+        trace_events_path=None,
+        duration_seconds=0.0,
+        tags=(),
+        metadata={"followup_of": "child"},
+    )
+    child = module.AgentRunSummary(
+        run_id="child",
+        agent="codex",
+        label="child",
+        status="pass",
+        returncode=0,
+        manifest_path=Path(""),
+        stdout_path=None,
+        stderr_path=None,
+        trace_events_path=None,
+        duration_seconds=0.0,
+        tags=(),
+        metadata={"followup_of": "parent"},
+    )
+    monkeypatch.setattr(module, "list_agent_runs", lambda *_args, **_kwargs: [parent, child])
+    lineage = module.agent_lineage_payload(tmp_path, run_id="child")
+    assert lineage["found"] is True
+    assert [item["run_id"] for item in lineage["ancestors"]] == ["parent"]

--- a/test/test_agent_trace.py
+++ b/test/test_agent_trace.py
@@ -7,6 +7,8 @@ import sys
 import types
 from pathlib import Path
 
+import pytest
+
 
 ROOT = Path(__file__).resolve().parents[1]
 SECRET_MODULE_PATH = ROOT / "src" / "agilab" / "secret_uri.py"
@@ -214,3 +216,97 @@ def test_agent_trace_summaries_tolerate_missing_or_invalid_files(tmp_path: Path)
     assert artifact["event_count"] == 0
     assert artifact["event_types"] == []
     assert artifact["exists"] is False
+
+
+def test_agent_trace_lock_and_sequence_edge_cases(tmp_path: Path, monkeypatch) -> None:
+    module = _load_module()
+    events_path = tmp_path / module.EVENTS_FILENAME
+    events_path.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "schema": module.TRACE_SCHEMA,
+                        "event": "session_start",
+                        "run_id": "run",
+                        "sequence": 4,
+                        "created_at": "now",
+                        "status": "running",
+                        "message": "",
+                        "metadata": {},
+                    }
+                ),
+                "{not-json",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    assert module._last_event_sequence(events_path) == 4
+
+    events_path.write_text(json.dumps({"sequence": "bad"}) + "\n", encoding="utf-8")
+    assert module._last_event_sequence(events_path) == 0
+    events_path.write_text(json.dumps(["not", "mapping"]) + "\n", encoding="utf-8")
+    assert module._last_event_sequence(events_path) == 0
+
+    same_host = {"host": module.socket.gethostname(), "pid": str(os.getpid())}
+    assert module._lock_owner_alive({"host": "other", "pid": os.getpid()}) is None
+    assert module._lock_owner_alive({"host": module.socket.gethostname(), "pid": "bad"}) is None
+    assert module._lock_owner_alive({"host": module.socket.gethostname(), "pid": 0}) is None
+    assert module._lock_owner_alive(same_host) is True
+
+    def process_missing(_pid, _signal):
+        raise ProcessLookupError
+
+    monkeypatch.setattr(module.os, "kill", process_missing)
+    assert module._lock_owner_alive(same_host) is False
+
+    def process_forbidden(_pid, _signal):
+        raise PermissionError
+
+    monkeypatch.setattr(module.os, "kill", process_forbidden)
+    assert module._lock_owner_alive(same_host) is True
+
+    def process_unknown(_pid, _signal):
+        raise OSError
+
+    monkeypatch.setattr(module.os, "kill", process_unknown)
+    assert module._lock_owner_alive(same_host) is None
+
+    lock_path = tmp_path / "events.lock"
+    lock_path.write_text("{not-json", encoding="utf-8")
+    assert module._read_lock_payload(lock_path) == {}
+    assert module._lock_is_stale(lock_path, now=lock_path.stat().st_mtime + module.LOCK_STALE_SECONDS) is True
+
+    monkeypatch.setattr(module, "_lock_owner_alive", lambda _payload: True)
+    assert module._lock_is_stale(lock_path, now=lock_path.stat().st_mtime + 999) is False
+    assert module._clear_stale_lock(lock_path) is False
+
+
+def test_agent_trace_event_lock_timeout_and_finally_edges(tmp_path: Path, monkeypatch) -> None:
+    module = _load_module()
+    events_path = tmp_path / module.EVENTS_FILENAME
+    events_path.touch()
+    lock_path = events_path.with_name(events_path.name + ".lock")
+    lock_path.write_text("{}", encoding="utf-8")
+
+    monotonic_values = iter([0.0, module.LOCK_TIMEOUT_SECONDS + 1.0])
+    monkeypatch.setattr(module.time, "monotonic", lambda: next(monotonic_values))
+    monkeypatch.setattr(module.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(module, "_clear_stale_lock", lambda _path: False)
+
+    with pytest.raises(TimeoutError, match="Timed out waiting"):
+        with module._event_file_lock(events_path):
+            pass
+
+    lock_path.unlink()
+    monkeypatch.setattr(module.time, "monotonic", lambda: 0.0)
+    original_unlink = module.Path.unlink
+
+    def unlink_missing(self):
+        if self == lock_path:
+            raise FileNotFoundError
+        return original_unlink(self)
+
+    monkeypatch.setattr(module.Path, "unlink", unlink_missing)
+    with module._event_file_lock(events_path):
+        assert lock_path.exists()

--- a/test/test_app_surface.py
+++ b/test/test_app_surface.py
@@ -156,3 +156,99 @@ def test_render_app_surface_calls_project_render_hook_and_restores_argv(tmp_path
         }
     ]
     assert sys.argv == before_argv
+
+
+def test_app_surface_config_and_selection_edge_cases(tmp_path: Path) -> None:
+    module = _load_app_surface_module()
+    bad_app = tmp_path / "bad_project"
+    (bad_app / "src").mkdir(parents=True)
+    (bad_app / "src" / "app_settings.toml").write_text("[app_surface\n", encoding="utf-8")
+
+    assert module._read_app_settings(bad_app) == {}
+    assert module.app_surface_config(None) == {}
+    assert module.app_surface_title(None) == "App Surface"
+    assert module.app_surface_title({"title": "   "}) == "App Surface"
+    assert module._string_tuple(" one ") == ("one",)
+    assert module._string_tuple(object()) == ()
+    assert module._surface_spec_from_mapping(
+        "empty",
+        {},
+        root={},
+        root_default_name="streamlit",
+    ) is None
+
+    config = {
+        "app_surface": {
+            "title": "Backend only",
+            "default": "",
+            "backends": {
+                "": {"entrypoint": "skip.py"},
+                "bad": "not-a-mapping",
+                "hf": {"backend": "hf", "url": "https://example.invalid"},
+            },
+        }
+    }
+    specs = module.app_surface_specs(None, config=config)
+    assert specs["hf"].default is True
+    assert module.select_app_surface_spec(None, name="missing", config=config) is None
+    assert module.select_app_surface_spec(None, backend="missing", config=config) is None
+    assert module.select_app_surface_spec(None, backend="hf", config=config).name == "hf"
+
+
+def test_app_surface_entrypoint_resolution_edges(tmp_path: Path) -> None:
+    module = _load_app_surface_module()
+    app = _write_app_surface_project(tmp_path)
+    outside = tmp_path / "outside.py"
+    outside.write_text("def render(**_kwargs): pass\n", encoding="utf-8")
+
+    assert module.resolve_app_surface_entrypoint(None, "demo/app_surface.py") is None
+    assert module.resolve_app_surface_entrypoint(app, object()) is None
+    assert module.resolve_app_surface_entrypoint(app, outside) is None
+    assert module.configured_app_surface_entrypoint(app, surface="missing") is None
+
+    no_render = app / "src" / "demo" / "no_render.py"
+    no_render.write_text("VALUE = 1\n", encoding="utf-8")
+    assert module.render_app_surface(
+        app,
+        mode="analysis",
+        config={"app_surface": {"entrypoint": "demo/no_render.py"}},
+    ) is False
+
+    missing = module.render_app_surface(
+        app,
+        mode="analysis",
+        config={"app_surface": {"entrypoint": "demo/missing.py"}},
+    )
+    assert missing is False
+
+
+def test_render_app_surface_forwards_optional_streamlit_argument(tmp_path: Path) -> None:
+    module = _load_app_surface_module()
+    app = tmp_path / "streamlit_project"
+    surface = app / "src" / "demo" / "app_surface.py"
+    surface.parent.mkdir(parents=True)
+    (app / "src" / "app_settings.toml").write_text(
+        "\n".join(
+            [
+                "[app_surface]",
+                'title = "Demo Surface"',
+                'entrypoint = "demo/app_surface.py"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    surface.write_text(
+        "def render(**kwargs):\n"
+        "    kwargs['container'].append(sorted(kwargs))\n",
+        encoding="utf-8",
+    )
+    events: list[list[str]] = []
+
+    assert module.render_app_surface(
+        app,
+        mode="analysis",
+        container=events,
+        streamlit=SimpleNamespace(name="fake-st"),
+    ) is True
+    assert events == [["active_app", "container", "mode", "streamlit"]]

--- a/test/test_audience_bridges.py
+++ b/test/test_audience_bridges.py
@@ -15,6 +15,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from agilab import agent_run, bridge_cli, run_manifest
+import agilab_mcp
 from agilab_mcp import manifest_tools, server as mcp_server
 
 
@@ -176,6 +177,13 @@ def test_hf_space_export_edges_and_secret_scan(tmp_path: Path) -> None:
     assert payload["status"] == "pass"
     assert (output / "evidence" / "evidence.txt").is_file()
 
+    evidence_dir = tmp_path / "evidence-dir"
+    evidence_dir.mkdir()
+    (evidence_dir / "nested.txt").write_text("evidence\n", encoding="utf-8")
+    payload = bridge_cli.export_hf_space(project, output, evidence_path=evidence_dir, force=True)
+    assert payload["status"] == "pass"
+    assert (output / "evidence" / "nested.txt").is_file()
+
 
 def test_mlflow_vscode_and_workflow_handoff_exports(tmp_path: Path) -> None:
     manifest_path = _write_manifest(tmp_path)
@@ -266,6 +274,86 @@ def test_duckdb_bridge_plan_and_optional_execution(tmp_path: Path) -> None:
             table_name="input;drop",
             plan_only=True,
         )
+
+
+def test_bridge_cli_helper_edges_and_duckdb_inputs(tmp_path: Path, capsys) -> None:
+    list_json = tmp_path / "list.json"
+    list_json.write_text("[]\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="Expected JSON object"):
+        bridge_cli._read_json(list_json)
+
+    repo = tmp_path / "repo"
+    (repo / "src" / "agilab").mkdir(parents=True)
+    (repo / "pyproject.toml").write_text("[project]\nname='demo'\n", encoding="utf-8")
+    assert bridge_cli._repo_root(repo / "src" / "agilab") == repo
+    assert bridge_cli._resolve_artifact_path(str(tmp_path / "absolute.txt"), tmp_path / "run.json") == (
+        tmp_path / "absolute.txt"
+    )
+
+    notebook = tmp_path / "bad.ipynb"
+    notebook.write_text("[]\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="Expected notebook JSON object"):
+        bridge_cli._load_notebook_json(notebook)
+    notebook.write_text('{"cells": {}}\n', encoding="utf-8")
+    with pytest.raises(ValueError, match="Expected notebook cells list"):
+        bridge_cli._load_notebook_json(notebook)
+
+    payload = {"cells": "not-a-list"}
+    bridge_cli._ensure_notebook_cell_ids(payload)
+    payload = {"cells": ["skip", {"id": "keep"}, {"cell_type": "code"}]}
+    bridge_cli._ensure_notebook_cell_ids(payload)
+    assert payload["cells"][2]["id"] == "agilab-cell-0001"
+
+    bridge_cli._emit({"schema": "demo", "status": "planned", "path": "out"}, json_output=False)
+    emitted = capsys.readouterr().out
+    assert "planned" in emitted
+    assert "path: out" in emitted
+
+    query = tmp_path / "query.sql"
+    query.write_text("select * from input_table", encoding="utf-8")
+
+    class FakeConnection:
+        description = [("value",)]
+
+        def __init__(self):
+            self.calls: list[tuple[str, object]] = []
+
+        def execute(self, query_text, params=None):
+            self.calls.append((query_text, params))
+            return self
+
+        def fetchall(self):
+            return [(1,)]
+
+    connection = FakeConnection()
+    fake_duckdb = SimpleNamespace(connect=lambda database: connection)
+    for suffix, expected_reader in (
+        (".csv", "read_csv_auto"),
+        (".parquet", "read_parquet"),
+        (".jsonl", "read_json_auto"),
+    ):
+        data = tmp_path / f"input{suffix}"
+        data.write_text("value\n1\n", encoding="utf-8")
+        bridge_cli.run_duckdb_query(
+            query,
+            tmp_path / f"duckdb-{suffix[1:]}",
+            input_path=data,
+            duckdb_module=fake_duckdb,
+        )
+        assert expected_reader in connection.calls[-2][0]
+
+    unsupported = tmp_path / "input.txt"
+    unsupported.write_text("value\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="Unsupported DuckDB input format"):
+        bridge_cli.run_duckdb_query(
+            query,
+            tmp_path / "duckdb-unsupported",
+            input_path=unsupported,
+            duckdb_module=fake_duckdb,
+        )
+
+    with pytest.raises(RuntimeError, match="MLflow import MVP requires"):
+        bridge_cli.import_mlflow_handoff("demo", tmp_path / "mlflow.json")
 
 
 def _write_minimal_notebook(path: Path, source: str = "print('hello')") -> Path:
@@ -575,6 +663,74 @@ def test_notebook_sandbox_cli_route(monkeypatch: pytest.MonkeyPatch, capsys) -> 
             "allow_errors": True,
         }
     ]
+
+
+def test_bridge_cli_routes_export_import_init_and_mcp(monkeypatch: pytest.MonkeyPatch, capsys) -> None:
+    calls: list[tuple[str, object]] = []
+
+    monkeypatch.setattr(
+        bridge_cli,
+        "export_hf_space",
+        lambda *args, **kwargs: calls.append(("hf", (args, kwargs))) or {"status": "pass", "schema": "hf"},
+    )
+    monkeypatch.setattr(
+        bridge_cli,
+        "export_mlflow_handoff",
+        lambda *args, **kwargs: calls.append(("mlflow", args)) or {"status": "pass", "schema": "mlflow"},
+    )
+    monkeypatch.setattr(
+        bridge_cli,
+        "export_airflow_dag",
+        lambda *args, **kwargs: calls.append(("airflow", (args, kwargs))) or {"status": "pass", "schema": "airflow"},
+    )
+    monkeypatch.setattr(
+        bridge_cli,
+        "export_dagster_job",
+        lambda *args, **kwargs: calls.append(("dagster", (args, kwargs))) or {"status": "pass", "schema": "dagster"},
+    )
+    monkeypatch.setattr(
+        bridge_cli,
+        "run_duckdb_query",
+        lambda *args, **kwargs: calls.append(("duckdb", (args, kwargs))) or {"status": "planned", "schema": "duckdb"},
+    )
+    monkeypatch.setattr(
+        bridge_cli,
+        "init_vscode_bridge",
+        lambda *args, **kwargs: calls.append(("vscode", (args, kwargs))) or {"status": "pass", "schema": "vscode"},
+    )
+    monkeypatch.setattr(
+        bridge_cli,
+        "import_mlflow_handoff",
+        lambda *args, **kwargs: calls.append(("import-mlflow", (args, kwargs))) or {"status": "pass", "schema": "import"},
+    )
+
+    fake_server = ModuleType("agilab_mcp.server")
+    fake_server.main = lambda args: calls.append(("mcp", args)) or 0
+    monkeypatch.setitem(sys.modules, "agilab_mcp.server", fake_server)
+    monkeypatch.setattr(agilab_mcp, "server", fake_server)
+
+    assert bridge_cli.main(["export", "hf-space", "--project", "p", "--output", "o", "--evidence", "e", "--force"]) == 0
+    assert bridge_cli.main(["export", "mlflow", "--run", "m.json", "--output", "o.json"]) == 0
+    assert bridge_cli.main(["export", "airflow-dag", "--run", "m.json", "--output", "dag.py", "--dag-id", "demo"]) == 0
+    assert bridge_cli.main(["export", "dagster-job", "--run", "m.json", "--output", "job.py", "--job-name", "demo_job"]) == 0
+    assert bridge_cli.main(["run", "duckdb", "--query", "q.sql", "--output", "out", "--input", "in.csv", "--params", "p.json", "--table-name", "input_table", "--plan-only"]) == 0
+    assert bridge_cli.main(["init", "vscode", "--root", "workspace", "--force"]) == 0
+    assert bridge_cli.main(["import", "mlflow", "--experiment", "exp", "--input", "in.json", "--output", "out.json"]) == 0
+    assert bridge_cli.main(["mcp", "--", "--help"]) == 0
+
+    assert [name for name, _payload in calls] == [
+        "hf",
+        "mlflow",
+        "airflow",
+        "dagster",
+        "duckdb",
+        "vscode",
+        "import-mlflow",
+        "mcp",
+    ]
+    assert calls[0][1][1]["force"] is True
+    assert calls[-1][1] == ["--help"]
+    assert "planned" in capsys.readouterr().out
 
 
 def test_mcp_tools_and_jsonrpc(tmp_path: Path) -> None:

--- a/test/test_environment_health.py
+++ b/test/test_environment_health.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 
 from agilab import environment_health
@@ -277,3 +278,84 @@ def test_environment_health_resolvers_and_cluster_edges(tmp_path, monkeypatch):
     monkeypatch.setattr(environment_health, "_default_install_status", lambda _env: {"workerless": True})
     health = environment_health.build_environment_health(TypeErrorResolver(), app_settings={})
     assert _card_map(health)["API keys"].value == "Configured"
+
+
+def test_environment_health_remaining_helper_edges(tmp_path, monkeypatch):
+    class BadPath:
+        def __fspath__(self):
+            raise TypeError("bad path")
+
+        def __str__(self):
+            return "bad-path"
+
+    assert environment_health.render_environment_details(SimpleNamespace(), []) is None
+    assert environment_health.data_share_content_summary(None) == (
+        "not configured",
+        "not configured",
+    )
+    assert environment_health.data_share_content_summary(BadPath()) == (
+        "not configured",
+        "bad-path",
+    )
+    assert environment_health.path_status(BadPath()) == ("not configured", "bad-path")
+    assert environment_health.compact_path_caption("/") == "/"
+
+    fifo_path = tmp_path / "fifo"
+    if hasattr(environment_health.os, "mkfifo"):
+        environment_health.os.mkfifo(fifo_path)
+        assert environment_health.data_share_content_summary(fifo_path)[0] == "unknown"
+
+    data_dir = tmp_path / "walk-error"
+    data_dir.mkdir()
+
+    def raise_walk(_path):
+        raise OSError("walk unavailable")
+
+    monkeypatch.setattr(environment_health.os, "walk", raise_walk)
+    assert environment_health.data_share_content_summary(data_dir)[0] == "unknown"
+    monkeypatch.undo()
+
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "code.py").write_text("print('ok')\n", encoding="utf-8")
+    assert environment_health.latest_project_mtime(project) != "unknown"
+
+    monkeypatch.setattr(environment_health.os, "walk", raise_walk)
+    assert environment_health.latest_project_mtime(project) == "unknown"
+    monkeypatch.undo()
+
+    assert environment_health._environment_mapping(SimpleNamespace(envars=["not", "mapping"])) == {}
+    assert environment_health._looks_placeholder_secret("   ") is True
+    assert environment_health._looks_placeholder_secret("None") is True
+    assert environment_health._looks_placeholder_secret("***") is True
+    assert environment_health._looks_placeholder_secret("YOUR_API_KEY") is True
+    assert environment_health._looks_placeholder_secret("sk-XXXX") is True
+
+    card, detail = environment_health._api_key_card(
+        SimpleNamespace(
+            envars={
+                "AZURE_OPENAI_API_KEY": "azure-real-key-12345",
+                "MISTRAL_API_KEY": "mistral-real-key-12345",
+            }
+        )
+    )
+    assert card.value == "Configured"
+    assert detail == ("API keys", "Azure OpenAI, Mistral")
+
+    class FailingLegacyResolver:
+        app_settings_file = None
+        app_settings_source_file = None
+
+        def resolve_user_app_settings_file(self, *args, **kwargs):
+            if kwargs:
+                raise TypeError("legacy")
+            raise RuntimeError("boom")
+
+    assert environment_health._app_settings_file(FailingLegacyResolver()) is None
+    assert environment_health._is_local_worker_host("") is False
+    assert environment_health._is_local_worker_host("tcp://127.0.0.1:8786") is True
+    assert environment_health._is_local_worker_host("user@localhost") is True
+    assert environment_health._is_local_worker_host("[::1]:8786") is True
+    assert environment_health._cluster_has_nonlocal_workers({"workers": "[]"}) is False
+    assert environment_health._cluster_has_nonlocal_workers({"workers": "worker-a"}) is True
+    assert environment_health._resolve_share_path(SimpleNamespace(), "relative") == Path("relative")

--- a/test/test_evidence_contract.py
+++ b/test/test_evidence_contract.py
@@ -722,3 +722,161 @@ def test_defensive_helper_branches_and_export_errors(tmp_path: Path, monkeypatch
     monkeypatch.setattr(module, "_build_parser", lambda: parser)
     assert module.main(["unsupported", str(manifest_path)]) == 2
     assert parser.message == "unsupported command: unsupported"
+
+
+def test_proof_capsule_invalid_archive_and_signature_edges(tmp_path: Path, monkeypatch) -> None:
+    module = _load_module()
+
+    missing_report = module.verify_proof_capsule(tmp_path / "missing.agipack")
+    assert missing_report["status"] == "fail"
+    assert missing_report["checks"][0]["id"] == "capsule_exists"
+
+    bad_zip = tmp_path / "bad.agipack"
+    bad_zip.write_text("not a zip", encoding="utf-8")
+    bad_zip_report = module.verify_proof_capsule(bad_zip)
+    assert any(check["id"] == "zip_readable" and check["status"] == "fail" for check in bad_zip_report["checks"])
+
+    no_manifest = tmp_path / "no-manifest.agipack"
+    with zipfile.ZipFile(no_manifest, "w") as archive:
+        archive.writestr("payload.txt", "payload")
+    no_manifest_report = module.verify_proof_capsule(no_manifest)
+    assert any(check["id"] == "capsule_manifest_present" and check["status"] == "fail" for check in no_manifest_report["checks"])
+
+    invalid_manifest = tmp_path / "invalid-manifest.agipack"
+    with zipfile.ZipFile(invalid_manifest, "w") as archive:
+        archive.writestr(module.PROOF_CAPSULE_MANIFEST_FILENAME, "{not-json")
+    invalid_manifest_report = module.verify_proof_capsule(invalid_manifest)
+    assert any(
+        check["id"] == "capsule_manifest_schema_supported" and check["status"] == "fail"
+        for check in invalid_manifest_report["checks"]
+    )
+
+    bad_schema = tmp_path / "bad-schema.agipack"
+    with zipfile.ZipFile(bad_schema, "w") as archive:
+        archive.writestr(module.PROOF_CAPSULE_MANIFEST_FILENAME, json.dumps({"schema": "other", "entries": []}))
+    bad_schema_report = module.verify_proof_capsule(bad_schema)
+    assert any(
+        check["id"] == "capsule_manifest_schema_supported" and check["status"] == "fail"
+        for check in bad_schema_report["checks"]
+    )
+
+    bad_entries = tmp_path / "bad-entries.agipack"
+    with zipfile.ZipFile(bad_entries, "w") as archive:
+        archive.writestr(
+            module.PROOF_CAPSULE_MANIFEST_FILENAME,
+            json.dumps({"schema": module.PROOF_CAPSULE_SCHEMA, "entries": "not-a-list"}),
+        )
+    bad_entries_report = module.verify_proof_capsule(bad_entries)
+    assert any(check["id"] == "capsule_entries_valid" and check["status"] == "fail" for check in bad_entries_report["checks"])
+
+    malformed_entries = tmp_path / "malformed-entries.agipack"
+    with zipfile.ZipFile(malformed_entries, "w") as archive:
+        archive.writestr("payload.txt", "payload")
+        archive.writestr("extra.txt", "extra")
+        archive.writestr(
+            module.PROOF_CAPSULE_MANIFEST_FILENAME,
+            json.dumps(
+                {
+                    "schema": module.PROOF_CAPSULE_SCHEMA,
+                    "entries": [
+                        {"path": "payload.txt", "sha256": "bad", "size_bytes": "bad"},
+                        {"path": "payload.txt", "sha256": "bad", "size_bytes": 999},
+                        {"path": "../unsafe", "sha256": "bad", "size_bytes": 1},
+                        "not-a-mapping",
+                    ],
+                }
+            ),
+        )
+    malformed_report = module.verify_proof_capsule(malformed_entries)
+    checks = {check["id"]: check for check in malformed_report["checks"]}
+    assert checks["capsule_entries_valid"]["status"] == "fail"
+    assert checks["capsule_entry_inventory_matches"]["status"] == "fail"
+    assert checks["capsule_entry_hashes_match"]["status"] == "fail"
+    assert checks["run_manifest_snapshot_valid"]["status"] == "fail"
+    assert checks["proof_pack_manifest_valid"]["status"] == "fail"
+
+    signature_checks = module._proof_capsule_signature_checks(malformed_entries, None)
+    assert signature_checks[0]["id"] == "capsule_signature_present"
+    missing_signature = module._proof_capsule_signature_checks(malformed_entries, tmp_path / "missing.sig.json")
+    assert missing_signature[0]["summary"].startswith("Missing detached")
+
+    invalid_signature = tmp_path / "invalid.sig.json"
+    invalid_signature.write_text("{not-json", encoding="utf-8")
+    invalid_signature_checks = module._proof_capsule_signature_checks(malformed_entries, invalid_signature)
+    assert invalid_signature_checks[1]["id"] == "capsule_signature_schema_supported"
+
+    list_signature = tmp_path / "list.sig.json"
+    list_signature.write_text("[]\n", encoding="utf-8")
+    list_signature_checks = module._proof_capsule_signature_checks(malformed_entries, list_signature)
+    assert list_signature_checks[1]["summary"] == "Signature file must contain a JSON object."
+
+    unsupported_signature = tmp_path / "unsupported.sig.json"
+    unsupported_signature.write_text(json.dumps({"schema": "other"}), encoding="utf-8")
+    unsupported_signature_checks = module._proof_capsule_signature_checks(malformed_entries, unsupported_signature)
+    assert unsupported_signature_checks[1]["status"] == "fail"
+
+    bad_key_signature = tmp_path / "bad-key.sig.json"
+    bad_key_signature.write_text(
+        json.dumps(
+            {
+                "schema": module.PROOF_CAPSULE_SIGNATURE_SCHEMA,
+                "subject": {"sha256": "wrong", "size_bytes": "bad"},
+                "key": {"algorithm": "rsa", "public_key_pem": "é", "public_key_sha256": "bad"},
+                "signature": {"algorithm": "rsa", "encoding": "hex", "value": ""},
+                "signer": "alice",
+                "issuer": "lab",
+            }
+        ),
+        encoding="utf-8",
+    )
+    bad_key_checks = module._proof_capsule_signature_checks(malformed_entries, bad_key_signature)
+    bad_key_by_id = {check["id"]: check for check in bad_key_checks}
+    assert bad_key_by_id["capsule_signature_subject_matches"]["status"] == "fail"
+    assert bad_key_by_id["capsule_signature_key_supported"]["status"] == "fail"
+
+    bad_policy = tmp_path / "bad-policy.txt"
+    bad_policy.write_text("not-json", encoding="utf-8")
+    trust_checks = module._trust_policy_checks(
+        bad_policy,
+        {"signer": "alice", "issuer": "lab"},
+        capsule_sha256="capsule",
+        public_key_sha256="key",
+    )
+    assert trust_checks[0]["id"] == "capsule_trust_policy_loaded"
+
+    no_anchor_policy = tmp_path / "no-anchor.json"
+    no_anchor_policy.write_text(json.dumps({"schema": module.TRUST_POLICY_SCHEMA}), encoding="utf-8")
+    no_anchor_checks = module._trust_policy_checks(
+        no_anchor_policy,
+        {"signer": "alice", "issuer": "lab"},
+        capsule_sha256="capsule",
+        public_key_sha256="key",
+    )
+    assert {check["id"]: check["status"] for check in no_anchor_checks}["capsule_trust_policy_has_anchor"] == "fail"
+
+    subject_policy = tmp_path / "subject-policy.json"
+    subject_policy.write_text(
+        json.dumps(
+            {
+                "schema": module.TRUST_POLICY_SCHEMA,
+                "allowed_issuers": ["lab"],
+                "expected_subject_sha256": ["capsule"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    subject_checks = module._trust_policy_checks(
+        subject_policy,
+        {"signer": "alice", "issuer": "lab"},
+        capsule_sha256="capsule",
+        public_key_sha256="key",
+    )
+    subject_status = {check["id"]: check["status"] for check in subject_checks}
+    assert subject_status["capsule_trust_policy_allows_issuer"] == "pass"
+    assert subject_status["capsule_trust_policy_allows_subject"] == "pass"
+
+    assert module._safe_archive_member_name("") is False
+    assert module._safe_archive_member_name("/absolute") is False
+    assert module._safe_archive_member_name("dir/") is False
+    assert module._safe_int("bad", default=-1) == -1
+    assert module._ascii_bytes("é") == b""

--- a/test/test_notebook_demo.py
+++ b/test/test_notebook_demo.py
@@ -63,11 +63,22 @@ def test_resolve_notebook_apps_path_reports_install_hint(monkeypatch, tmp_path: 
 def test_notebook_demo_package_and_installed_app_resolution_edges(monkeypatch, tmp_path: Path) -> None:
     assert notebook_demo._normalise_project_app("") == "minimal_app_project"
     assert notebook_demo._normalise_project_app("weather-forecast") == "weather_forecast_project"
+    assert notebook_demo._app_aliases("weather_forecast_project") == (
+        "weather_forecast_project",
+        "weather_forecast",
+    )
 
     builtin_root = tmp_path / "pkg" / "apps" / "builtin"
     app_root = _make_app(builtin_root, "weather_forecast_project")
     assert notebook_demo._root_for_app(builtin_root.parent, "weather_forecast") == builtin_root
     assert notebook_demo._root_for_app(app_root, "weather_forecast") == builtin_root
+    assert notebook_demo._root_for_app(tmp_path / "missing", "weather_forecast") is None
+
+    class OSErrorPath(type(Path())):
+        def is_dir(self):
+            raise OSError("unavailable")
+
+    assert notebook_demo._is_app_project(OSErrorPath(tmp_path / "unavailable")) is False
 
     class FakeSpec:
         submodule_search_locations = [str(tmp_path / "package")]
@@ -75,6 +86,8 @@ def test_notebook_demo_package_and_installed_app_resolution_edges(monkeypatch, t
 
     monkeypatch.setattr(notebook_demo.importlib.util, "find_spec", lambda _package: FakeSpec())
     assert notebook_demo._package_dir("demo") == tmp_path / "package"
+    monkeypatch.setattr(notebook_demo.importlib.util, "find_spec", lambda _package: None)
+    assert notebook_demo._package_dir("demo") is None
 
     class OriginSpec:
         submodule_search_locations = []
@@ -95,10 +108,17 @@ def test_notebook_demo_package_and_installed_app_resolution_edges(monkeypatch, t
     assert notebook_demo._installed_app_project_root("weather_forecast_project") == app_root
     provider.resolve_installed_app_project = lambda _app: (_ for _ in ()).throw(RuntimeError("boom"))
     assert notebook_demo._installed_app_project_root("weather_forecast_project") is None
+    monkeypatch.delitem(sys.modules, "agi_env.app_provider_registry", raising=False)
 
     monkeypatch.setattr(notebook_demo, "_package_dir", lambda package: tmp_path / "pkg" if package == "agilab" else None)
     monkeypatch.setattr(notebook_demo, "_installed_app_project_root", lambda _app: None)
     assert notebook_demo.resolve_notebook_apps_path("weather_forecast", start=tmp_path / "missing") == builtin_root
+
+    installed_root = tmp_path / "installed" / "standalone_project"
+    _make_app(installed_root.parent, "standalone_project")
+    monkeypatch.setattr(notebook_demo, "_package_dir", lambda _package: None)
+    monkeypatch.setattr(notebook_demo, "_installed_app_project_root", lambda _app: installed_root)
+    assert notebook_demo.resolve_notebook_apps_path("standalone_project", start=tmp_path / "missing") == installed_root.parent
 
 
 def test_notebook_local_request_uses_visible_local_defaults(monkeypatch) -> None:

--- a/test/test_orchestrate_cluster.py
+++ b/test/test_orchestrate_cluster.py
@@ -1894,3 +1894,172 @@ def test_render_cluster_settings_ui_ssh_key_mode_uses_env_default_key_when_input
     assert env.password is None
     assert env.ssh_key_path == "~/.ssh/id_demo"
     assert ("AGI_SSH_KEY_PATH", "~/.ssh/id_demo") in env_calls
+
+
+def test_orchestrate_cluster_remaining_helper_edges(monkeypatch, tmp_path):
+    share = tmp_path / "cluster-share"
+    share.mkdir()
+    env_from_envars = SimpleNamespace(
+        home_abs=tmp_path,
+        envars={"AGI_CLUSTER_SHARE": str(share)},
+    )
+    assert orchestrate_cluster._env_cluster_share_setting(env_from_envars) == "cluster-share"
+    assert orchestrate_cluster._cluster_share_problem(env_from_envars) is None
+
+    monkeypatch.setattr(orchestrate_cluster.os, "access", lambda *_args, **_kwargs: False)
+    assert "not writable" in orchestrate_cluster._cluster_share_problem(env_from_envars)
+
+    assert orchestrate_cluster._default_cluster_plan_path() == Path.home() / orchestrate_cluster.CLUSTER_PLAN_FILE
+    assert orchestrate_cluster._default_cluster_plan_path(object()) == Path.home() / orchestrate_cluster.CLUSTER_PLAN_FILE
+    assert orchestrate_cluster._load_lan_discovery_payload(None) == {}
+    assert orchestrate_cluster._parse_cpu_cores("16 cpu available") == 16
+    assert orchestrate_cluster._parse_ram_gb("not memory") is None
+    assert orchestrate_cluster._parse_ram_gb("1.5 TiB") == 1536.0
+    assert orchestrate_cluster._gpu_count("gpu0; gpu1, gpu2") == 3
+
+    assert orchestrate_cluster._recommended_workers_for_node({"host": "localhost"}) == (
+        0,
+        ["excluded: host is not a usable LAN worker address"],
+    )
+    count, reasons = orchestrate_cluster._recommended_workers_for_node(
+        {
+            "host": "192.168.10.22",
+            "status": "ready",
+            "cpu": "cores: 32",
+            "ram": "64 GB",
+            "gpu": "0,1",
+        },
+        scheduler_host="192.168.10.22",
+    )
+    assert count == 1
+    assert any("GPU budget" in reason for reason in reasons)
+    assert any("scheduler host kept" in reason for reason in reasons)
+
+    cache_path = tmp_path / "lan_nodes.json"
+    cache_path.write_text(
+        json.dumps(
+            {
+                "local_hosts": ["192.168.10.10"],
+                "nodes": [
+                    "bad",
+                    {"host": "192.168.10.10", "status": "ready"},
+                    {"host": "192.168.10.11", "status": "ready", "ram": "16 GB"},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    plan = orchestrate_cluster._cluster_advisor_plan(
+        cache_path,
+        {"scheduler": "192.168.10.10:8786", "workers": {"bad": "x", "192.168.10.11": "2"}},
+        env_from_envars,
+    )
+    assert plan["recommended_workers"]["192.168.10.10"] == 1
+    assert plan["recommended_workers"]["192.168.10.11"] >= 1
+    assert plan["summary"]["current_total_workers"] == 2
+
+    bad_parent = tmp_path / "not-a-dir"
+    bad_parent.write_text("blocked", encoding="utf-8")
+    written, message = orchestrate_cluster._write_cluster_advisor_plan(
+        bad_parent / "cluster_plan.json",
+        {"ok": True},
+    )
+    assert written is False
+    assert message
+
+
+def test_render_cluster_settings_ui_lan_button_error_edges(monkeypatch, tmp_path):
+    app_name = "demo_project"
+    widget_keys = orchestrate_cluster.cluster_widget_keys(app_name)
+    share = tmp_path / "cluster-share"
+    share.mkdir()
+
+    def _deps():
+        return orchestrate_cluster.OrchestrateClusterDeps(
+            parse_and_validate_scheduler=lambda raw: raw,
+            parse_and_validate_workers=lambda raw: json.loads(raw) if raw.strip().startswith("{") else None,
+            write_app_settings_toml=lambda _path, settings: settings,
+            clear_load_toml_cache=lambda: None,
+            set_env_var=lambda _key, _value: None,
+            agi_env_envars={},
+        )
+
+    def _env():
+        return SimpleNamespace(
+            app=app_name,
+            home_abs=tmp_path / "home",
+            is_managed_pc=False,
+            AGI_CLUSTER_SHARE=str(share),
+            agi_share_path=Path("clustershare"),
+            share_root_path=lambda: share,
+            user="agi",
+            password=None,
+            ssh_key_path=None,
+            app_settings_file=tmp_path / "app_settings.toml",
+        )
+
+    clear_st = _FakeStreamlit(
+        widget_values={
+            widget_keys["cluster_enabled"]: True,
+            widget_keys["cython"]: False,
+            widget_keys["pool"]: False,
+            widget_keys["rapids"]: False,
+            widget_keys["use_key"]: True,
+        },
+        button_values={orchestrate_cluster._lan_discovery_clear_key(app_name): True},
+        session_state={"app_settings": {"cluster": {"cluster_enabled": True}}, "benchmark": False},
+    )
+    monkeypatch.setattr(orchestrate_cluster, "st", clear_st)
+    monkeypatch.setattr(orchestrate_cluster, "_clear_lan_discovery_cache", lambda _path: (False, "missing"))
+    monkeypatch.setattr(orchestrate_cluster, "_lan_discovery_cluster_defaults", lambda *_, **__: {})
+    monkeypatch.setattr(orchestrate_cluster, "_lan_discovery_invalid_worker_hosts", lambda *_, **__: set())
+    orchestrate_cluster.render_cluster_settings_ui(_env(), _deps())
+    assert any("already clear" in info for info in clear_st.infos)
+
+    clear_error_st = _FakeStreamlit(
+        widget_values={
+            widget_keys["cluster_enabled"]: True,
+            widget_keys["cython"]: False,
+            widget_keys["pool"]: False,
+            widget_keys["rapids"]: False,
+            widget_keys["use_key"]: True,
+        },
+        button_values={orchestrate_cluster._lan_discovery_clear_key(app_name): True},
+        session_state={"app_settings": {"cluster": {"cluster_enabled": True}}, "benchmark": False},
+    )
+    monkeypatch.setattr(orchestrate_cluster, "st", clear_error_st)
+    monkeypatch.setattr(orchestrate_cluster, "_clear_lan_discovery_cache", lambda _path: (False, "denied"))
+    orchestrate_cluster.render_cluster_settings_ui(_env(), _deps())
+    assert any("Could not clear LAN discovery cache" in error for error in clear_error_st.errors)
+
+    refresh_st = _FakeStreamlit(
+        widget_values={
+            widget_keys["cluster_enabled"]: True,
+            widget_keys["cython"]: False,
+            widget_keys["pool"]: False,
+            widget_keys["rapids"]: False,
+            widget_keys["use_key"]: True,
+        },
+        button_values={orchestrate_cluster._lan_discovery_refresh_key(app_name): True},
+        session_state={"app_settings": {"cluster": {"cluster_enabled": True}}, "benchmark": False},
+    )
+    monkeypatch.setattr(orchestrate_cluster, "st", refresh_st)
+    monkeypatch.setattr(orchestrate_cluster, "_refresh_lan_discovery_cache", lambda *_args, **_kwargs: (False, "ssh failed"))
+    orchestrate_cluster.render_cluster_settings_ui(_env(), _deps())
+    assert any("LAN discovery refresh failed" in error for error in refresh_st.errors)
+
+    advisor_st = _FakeStreamlit(
+        widget_values={
+            widget_keys["cluster_enabled"]: True,
+            widget_keys["cython"]: False,
+            widget_keys["pool"]: False,
+            widget_keys["rapids"]: False,
+            widget_keys["use_key"]: True,
+        },
+        button_values={orchestrate_cluster._cluster_advisor_plan_key(app_name): True},
+        session_state={"app_settings": {"cluster": {"cluster_enabled": True}}, "benchmark": False},
+    )
+    monkeypatch.setattr(orchestrate_cluster, "st", advisor_st)
+    monkeypatch.setattr(orchestrate_cluster, "_write_cluster_advisor_plan", lambda *_args, **_kwargs: (False, "readonly"))
+    orchestrate_cluster.render_cluster_settings_ui(_env(), _deps())
+    assert any("Could not write cluster plan" in error for error in advisor_st.errors)

--- a/test/test_orchestrate_execute.py
+++ b/test/test_orchestrate_execute.py
@@ -2512,3 +2512,41 @@ async def test_render_execute_section_delete_reports_disk_failure(monkeypatch, t
     )
 
     assert any(kind == "error" and "Failed to delete" in msg for kind, msg in delete_st.messages)
+
+
+def test_orchestrate_execute_remaining_direct_helper_edges(monkeypatch, tmp_path):
+    fake_matplotlib = object()
+    monkeypatch.setattr(orchestrate_execute, "plt", fake_matplotlib)
+    assert orchestrate_execute._require_matplotlib() is fake_matplotlib
+
+    monkeypatch.setattr(orchestrate_execute, "plt", None)
+    monkeypatch.setattr(orchestrate_execute, "_MATPLOTLIB_IMPORT_ERROR", None)
+    imported = object()
+    assert orchestrate_execute._require_matplotlib(lambda _name: imported) is imported
+
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(orchestrate_execute.Path, "home", classmethod(lambda cls: home))
+
+    roots = orchestrate_execute.collect_candidate_roots(
+        SimpleNamespace(
+            dataframe_path=None,
+            app_data_rel=None,
+            resolve_share_path=lambda _path: (_ for _ in ()).throw(OSError("share failed")),
+        ),
+        {"data_out": "fallback/output", "data_in": "required/input"},
+    )
+    assert roots == [home / "fallback/output"]
+
+    direct_file = tmp_path / "result.csv"
+    direct_file.write_text("x\n1\n", encoding="utf-8")
+    target, files = orchestrate_execute.find_preview_target([direct_file])
+    assert target == direct_file
+    assert files == [direct_file]
+
+    notice_state = {}
+    orchestrate_execute.queue_execute_notice(notice_state, kind="fatal", message="fallback")
+    assert notice_state[orchestrate_execute.EXECUTE_NOTICE_KEY]["kind"] == "info"
+    body, omitted = orchestrate_execute.run_log_view_body("a\nb", max_lines=0)
+    assert body == "a\nb"
+    assert omitted == 0

--- a/test/test_pytorch_playground_app.py
+++ b/test/test_pytorch_playground_app.py
@@ -3559,6 +3559,91 @@ def test_pytorch_playground_main_live_mode_and_missing_evidence_branch(
     ]
 
 
+def test_pytorch_playground_core_remaining_training_edges() -> None:
+    module = _load_module()
+
+    fallback_fig = module._plotly_unavailable_figure("demo", trace_count=2)
+    assert len(fallback_fig.data) == 2
+    assert module._parse_hidden_layers("4,, 8") == (4, 8)
+
+    no_hidden_config = module.PlaygroundConfig(
+        sample_count=32,
+        grid_size=8,
+        hidden_layers=(),
+        epochs=2,
+    )
+    training_data = module._prepare_training_data(no_hidden_config)
+    model = module._build_model(len(no_hidden_config.feature_names), no_hidden_config)
+    assert module._hidden_activation_maps(
+        model,
+        no_hidden_config,
+        training_data["mean"],
+        training_data["std"],
+    ).empty
+
+    sgd_config = module.PlaygroundConfig(
+        sample_count=32,
+        grid_size=8,
+        hidden_layers=(4,),
+        optimizer="SGD",
+        regularization="L1",
+        regularization_rate=0.01,
+        epochs=2,
+    )
+    sgd_data = module._prepare_training_data(sgd_config)
+    sgd_model = module._build_model(len(sgd_config.feature_names), sgd_config)
+    loss_fn = module.nn.CrossEntropyLoss()
+    optimizer = module._playground_core._optimizer_for_config(sgd_model, sgd_config)
+    assert optimizer.__class__.__name__ == "SGD"
+    module._playground_core._train_one_epoch(
+        sgd_config,
+        sgd_model,
+        loss_fn,
+        optimizer,
+        sgd_data,
+    )
+
+    rows = [{"epoch": 3}]
+    module._playground_core._append_history_row_once(rows, sgd_model, loss_fn, sgd_data, 3)
+    assert rows == [{"epoch": 3}]
+
+    failed_state = module._advance_live_training({"status": "error", "playing": True})
+    assert failed_state["playing"] is False
+
+    bad_config_state = module._advance_live_training({"status": "ok", "config": "bad", "playing": True})
+    assert bad_config_state["status"] == "error"
+    assert bad_config_state["playing"] is False
+
+    bad_history_state = module._advance_live_training(
+        {
+            "status": "ok",
+            "config": sgd_config,
+            "history_rows": "bad",
+            "snapshot_states": [],
+            "playing": True,
+        }
+    )
+    assert bad_history_state["status"] == "error"
+    assert bad_history_state["playing"] is False
+
+    incomplete_result = module._live_training_result({})
+    assert incomplete_result["status"] == "error"
+    error_result = module._live_training_result(
+        {"status": "error", "detail": "boom", "config": sgd_config, "epoch": 1}
+    )
+    assert error_result["detail"] == "boom"
+    assert error_result["summary"]["backend"] == "error"
+
+    assert module._playground_core._boundary_snapshots(
+        sgd_model,
+        sgd_config,
+        sgd_data["mean"],
+        sgd_data["std"],
+        [],
+    ).empty
+    assert module._playground_core._normalized_landscape_resolution(10) == 11
+
+
 def test_pytorch_playground_app_provider_and_package_docs(tmp_path: Path) -> None:
     spec = importlib.util.spec_from_file_location("agi_app_pytorch_playground_init_test_module", INIT_PATH)
     assert spec is not None and spec.loader is not None

--- a/test/test_pytorch_playground_app.py
+++ b/test/test_pytorch_playground_app.py
@@ -5,6 +5,7 @@ import importlib
 import importlib.util
 import json
 from pathlib import Path
+import subprocess
 import sys
 from types import ModuleType
 from types import SimpleNamespace
@@ -643,6 +644,124 @@ def test_app_surface_full_run_button_executes_before_analysis(monkeypatch):
     assert ("column_success", "Run complete. Evidence refreshed (1 row).") in events
 
 
+def test_app_surface_additional_modes_and_error_paths(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    module = _load_app_surface_module("pytorch_playground_app_surface_extra_modes_test")
+    events: list[tuple[str, object]] = []
+
+    assert module._resolve_active_app_path(tmp_path / "missing") is None
+    monkeypatch.setattr(sys, "argv", ["app_surface.py"])
+    assert module._resolve_active_app_path() is None
+
+    class FakeAgiEnv:
+        def __init__(self, **kwargs):
+            events.append(("agi-env-init", kwargs))
+            self.app_settings_file = tmp_path / "settings.toml"
+
+        @classmethod
+        def for_app(cls, **kwargs):
+            events.append(("agi-env-for-app", kwargs))
+            instance = cls(**kwargs)
+            instance.app_settings_file.write_text("[args]\nsample_count=96\n", encoding="utf-8")
+            return instance
+
+    fake_agi_env_module = ModuleType("agi_env")
+    fake_agi_env_module.AgiEnv = FakeAgiEnv
+    monkeypatch.setitem(sys.modules, "agi_env", fake_agi_env_module)
+
+    env, args_model = module._load_orchestrate_args(PROJECT_PATH.resolve())
+    assert args_model.sample_count == 96
+    assert events[0][0] == "agi-env-for-app"
+
+    resolved_dirs = module._analysis_evidence_dirs(
+        SimpleNamespace(resolve_share_path=lambda value: tmp_path / "share" / value),
+        SimpleNamespace(data_out="relative-evidence"),
+        PROJECT_PATH.resolve(),
+    )
+    assert resolved_dirs[-1] == (tmp_path / "share" / "relative-evidence").resolve()
+
+    fake_package = ModuleType("pytorch_playground")
+    fake_playground_ui = SimpleNamespace(
+        PAGE_TITLE="PyTorch Playground",
+        main=lambda **kwargs: events.append(("playground-main", kwargs)),
+    )
+    fake_app_args_form = SimpleNamespace(render=lambda **kwargs: events.append(("configure-form", kwargs)))
+    fake_package.playground_ui = fake_playground_ui
+    monkeypatch.setitem(sys.modules, "pytorch_playground", fake_package)
+    monkeypatch.setattr(module, "_load_app_args_form", lambda: fake_app_args_form)
+
+    module._render_analysis_surface(None, configure_page=False, compact=True)
+    assert ("playground-main", {"configure_page": False, "compact": True}) in events
+
+    class FakeStreamlit:
+        def set_page_config(self, **kwargs):
+            events.append(("page-config", kwargs))
+
+        def error(self, message):
+            events.append(("st-error", message))
+
+    monkeypatch.setitem(sys.modules, "streamlit", FakeStreamlit())
+    monkeypatch.setattr(module, "_load_orchestrate_args", lambda _path: (_ for _ in ()).throw(RuntimeError("bad args")))
+    module._render_analysis_surface(PROJECT_PATH.resolve())
+    assert ("st-error", "Unable to load ORCHESTRATE app arguments: bad args") in events
+    module._render_full_surface(PROJECT_PATH.resolve())
+    assert events[-1] == ("st-error", "Unable to load ORCHESTRATE app arguments: bad args")
+
+    class NoMarkdownStreamlit:
+        pass
+
+    monkeypatch.setitem(sys.modules, "streamlit", NoMarkdownStreamlit())
+    assert module._render_surface_styles() is None
+
+    module._render_full_surface(None)
+    assert events[-1] == ("playground-main", {})
+
+    module.render(mode="configure", env="env", container="container")
+    assert events[-1] == ("configure-form", {"env": "env", "container": "container"})
+
+    monkeypatch.setattr(module, "_resolve_active_app_path", lambda _active_app=None: None)
+    monkeypatch.setattr(
+        module,
+        "_render_analysis_surface",
+        lambda path: events.append(("render-analysis", path)),
+    )
+    monkeypatch.setattr(
+        module,
+        "_render_full_surface",
+        lambda path, **kwargs: events.append(("render-full", (path, kwargs))),
+    )
+    module.render(mode="analysis")
+    module.render(mode="full", env="env", container="container")
+    assert ("render-analysis", None) in events
+    assert ("render-full", (None, {"env": "env", "container": "container"})) in events
+    with pytest.raises(ValueError, match="Unsupported PyTorch Playground app surface mode"):
+        module.render(mode="unknown")
+
+
+def test_app_surface_run_button_idle_and_failure_paths(monkeypatch: pytest.MonkeyPatch):
+    module = _load_app_surface_module("pytorch_playground_app_surface_run_edges_test")
+    events: list[tuple[str, object]] = []
+
+    class IdleContainer:
+        def button(self, label, **kwargs):
+            events.append(("button", (label, kwargs)))
+            return False
+
+        def error(self, message):
+            events.append(("error", message))
+
+    assert module._render_run_button(PROJECT_PATH.resolve(), container=IdleContainer()) is None
+    assert events == [("button", ("Refresh evidence", {"type": "primary", "width": "stretch"}))]
+
+    class ClickContainer(IdleContainer):
+        def button(self, label, **kwargs):
+            events.append(("click", label))
+            return True
+
+    monkeypatch.setattr(module, "_load_orchestrate_args", lambda _path: (_ for _ in ()).throw(RuntimeError("run failed")))
+    module._render_run_button(PROJECT_PATH.resolve(), container=ClickContainer())
+    assert ("error", "Run failed: run failed") in events
+
+
 def test_cached_train_uses_isolated_subprocess_in_streamlit_context() -> None:
     module = _load_module()
     if module.torch is None:
@@ -843,6 +962,135 @@ def test_playground_ui_helper_error_and_display_edges(monkeypatch: pytest.Monkey
     assert module._gap_band({"train_accuracy": 0.95, "validation_accuracy": 0.70})[0] == "Likely overfit"
     assert module._confidence_band(pd.DataFrame({"probability": [0.1, 0.9]}))[0] == "Decisive boundary"
     assert module._confidence_band(pd.DataFrame({"probability": [0.30, 0.70]}))[0] == "Boundary forming"
+
+
+def test_playground_ui_remaining_helper_and_subprocess_edges(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    module = _load_module()
+    config = module.PlaygroundConfig(sample_count=16, epochs=2, grid_size=5)
+
+    with pytest.raises(AttributeError, match="definitely_missing"):
+        getattr(module, "definitely_missing")
+    assert module._ipc_encode(np.array([[1, 2], [3, 4]])) == [[1, 2], [3, 4]]
+    with pytest.raises(ValueError, match="invalid dataframe columns"):
+        module._ipc_decode({"__type__": module._DATAFRAME_IPC_TYPE, "columns": [1], "records": []})
+    with pytest.raises(ValueError, match="invalid dataframe records"):
+        module._ipc_decode({"__type__": module._DATAFRAME_IPC_TYPE, "columns": ["x"], "records": {}})
+
+    class IndexOnlyState:
+        def __init__(self):
+            self.values = {"present": "value"}
+
+        def __getitem__(self, key):
+            return self.values[key]
+
+        def __setitem__(self, key, value):
+            self.values[key] = value
+
+    state = IndexOnlyState()
+    monkeypatch.setattr(module, "st", SimpleNamespace(session_state=state))
+    assert module._session_state_get("present", "fallback") == "value"
+    assert module._session_state_get("missing", "fallback") == "fallback"
+    module._session_state_set("new", "saved")
+    assert state.values["new"] == "saved"
+    assert module._progress_value(3, 0) == 0.0
+    assert module._progress_value(99, 10) == 1.0
+
+    events: list[tuple[str, object]] = []
+
+    class StatusStreamlit:
+        session_state = {}
+
+        def caption(self, body):
+            events.append(("caption", body))
+
+        def progress(self, value, **kwargs):
+            events.append(("progress", value))
+            events.append(("progress_text", kwargs.get("text")))
+
+        def rerun(self):
+            events.append(("rerun", ""))
+
+    monkeypatch.setattr(module, "st", StatusStreamlit())
+    monkeypatch.setattr(module.time, "sleep", lambda delay: events.append(("sleep", delay)))
+    module._render_live_training_status({"epoch": 1, "playing": True}, config)
+    module._request_live_rerun(0.01)
+    assert ("caption", "Live state: playing, epoch 1/2.") in events
+    assert ("progress", 0.5) in events
+    assert ("rerun", "") in events
+
+    bad_json = tmp_path / "bad.json"
+    bad_json.write_text("{not-json", encoding="utf-8")
+    list_json = tmp_path / "list.json"
+    list_json.write_text("[]\n", encoding="utf-8")
+    assert module._read_json_file(bad_json) == {}
+    assert module._read_json_file(list_json) == {}
+    empty_frame = pd.DataFrame({"x": []})
+    recovered_frame = module._read_evidence_frame(tmp_path / "missing.csv", empty_frame)
+    assert recovered_frame.empty
+    assert recovered_frame is not empty_frame
+    assert module._load_evidence_result(tmp_path / "missing-evidence") is None
+
+    evidence_root = tmp_path / "evidence"
+    (evidence_root / "config").mkdir(parents=True)
+    (evidence_root / "summary").mkdir(parents=True)
+    (evidence_root / "manifest.json").write_text(json.dumps({"schema": "demo"}), encoding="utf-8")
+    (evidence_root / "config" / "playground_config.json").write_text(
+        json.dumps({"config": {"dataset": "xor", "sample_count": 24}}),
+        encoding="utf-8",
+    )
+    (evidence_root / "summary" / "run_summary.json").write_text(
+        json.dumps({"summary": {"backend": "saved"}}),
+        encoding="utf-8",
+    )
+    loaded = module._load_latest_evidence_result([tmp_path / "missing", evidence_root])
+    assert loaded is not None
+    loaded_config, loaded_result, loaded_root = loaded
+    assert loaded_root == evidence_root
+    assert loaded_config.dataset == "xor"
+    assert loaded_result["summary"]["backend"] == "saved"
+
+    samples = pd.DataFrame({"x1": [0.0, 1.0], "x2": [0.0, 1.0], "target": [0, 1]})
+    grid = pd.DataFrame({"x1": [0.0], "x2": [0.0], "probability": [0.5]})
+    history = pd.DataFrame({"epoch": [1], "train_loss": [0.5], "validation_loss": [0.6]})
+    activation_maps = pd.DataFrame({"layer": [1], "neuron": [1], "x1": [0.0], "x2": [0.0], "activation": [0.3]})
+    layers = pd.DataFrame({"layer": [1], "kind": ["hidden"], "weight_max_abs": [0.1], "bias_max_abs": [0.2]})
+    landscape = pd.DataFrame({"alpha": [0.0], "beta": [0.0], "validation_loss": [0.4]})
+    monkeypatch.setattr(module, "go", None)
+    assert module._decision_figure(samples, grid, 5) is not None
+    assert module._history_figure(history) is not None
+    assert module._activation_figure(activation_maps, 1, 1) is not None
+    assert module._network_figure(layers) is not None
+    assert module._loss_landscape_figure(landscape) is not None
+
+    def timeout_run(*_args, **_kwargs):
+        raise subprocess.TimeoutExpired(cmd="python", timeout=1)
+
+    monkeypatch.setattr(module.subprocess, "run", timeout_run)
+    assert module._run_core_in_subprocess("train", config)["status"] == "error"
+    assert module._run_core_in_subprocess("loss_landscape", config)["status"] == "error"
+
+    def failed_run(*_args, **_kwargs):
+        return SimpleNamespace(returncode=2, stderr="boom\ntrace")
+
+    monkeypatch.setattr(module.subprocess, "run", failed_run)
+    assert "exit code 2" in module._run_core_in_subprocess("train", config)["detail"]
+
+    def malformed_run(args, **_kwargs):
+        Path(args[-1]).write_text("{bad-json", encoding="utf-8")
+        return SimpleNamespace(returncode=0, stderr="")
+
+    monkeypatch.setattr(module.subprocess, "run", malformed_run)
+    assert "JSONDecodeError" in module._run_core_in_subprocess("loss_landscape", config)["detail"]
+
+    def invalid_payload_run(args, **_kwargs):
+        Path(args[-1]).write_text(json.dumps({"ok": True, "result": []}), encoding="utf-8")
+        return SimpleNamespace(returncode=0, stderr="")
+
+    monkeypatch.setattr(module.subprocess, "run", invalid_payload_run)
+    assert "invalid payload" in module._run_core_in_subprocess("train", config)["detail"]
 
 
 def test_pytorch_playground_experiment_coach_returns_replayable_next_configs() -> None:
@@ -2047,10 +2295,74 @@ def test_pytorch_playground_distribution_marks_extra_workers_idle(monkeypatch: p
 
     manager = manager_module.PytorchPlayground.__new__(manager_module.PytorchPlayground)
     work_plan, metadata, id_name, count_name, label = manager.build_distribution(3)
+    fallback_plan, fallback_metadata, *_ = manager.build_distribution("bad")
 
     assert work_plan == [[["pytorch_playground"]], [], []]
     assert metadata == [[{"run": "pytorch_playground", "work_items": 1}], [], []]
+    assert fallback_plan == [[["pytorch_playground"]]]
+    assert fallback_metadata == [[{"run": "pytorch_playground", "work_items": 1}]]
     assert (id_name, count_name, label) == ("run", "work_items", "items")
+
+
+def test_pytorch_playground_manager_initialization_and_toml_edges(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.syspath_prepend(str(PROJECT_SRC.resolve()))
+    manager_module = importlib.import_module("pytorch_playground.pytorch_playground")
+    args_module = importlib.import_module("pytorch_playground.app_args")
+
+    def fake_share_dir(self, env):
+        self.share_checked = env
+
+    def fake_managed_paths(self, args):
+        return args
+
+    monkeypatch.setattr(manager_module.PytorchPlayground, "_ensure_managed_pc_share_dir", fake_share_dir)
+    monkeypatch.setattr(manager_module.PytorchPlayground, "_apply_managed_pc_paths", fake_managed_paths)
+
+    class FakeEnv:
+        verbose = 2
+        AGILAB_EXPORT_ABS = tmp_path / "export"
+        target = "custom_target"
+        app = ""
+        active_app = ""
+
+        def resolve_share_path(self, value):
+            return tmp_path / "share" / Path(value)
+
+    existing = tmp_path / "share" / "pytorch_playground" / "evidence"
+    existing.mkdir(parents=True)
+    (existing / "stale.txt").write_text("old", encoding="utf-8")
+
+    manager = manager_module.PytorchPlayground(
+        FakeEnv(),
+        data_out=Path("pytorch_playground/evidence"),
+        reset_target=True,
+        sample_count=96,
+    )
+
+    assert manager.verbose == 2
+    assert manager.data_out == existing
+    assert not (existing / "stale.txt").exists()
+    assert manager.analysis_artifact_dir == tmp_path / "export" / "custom_target" / "pytorch_playground"
+    assert manager.as_dict()["sample_count"] == 96
+
+    settings_path = tmp_path / "settings.toml"
+    manager.to_toml(settings_path)
+    loaded = manager_module.PytorchPlayground.from_toml(
+        FakeEnv(),
+        settings_path=settings_path,
+        sample_count=128,
+    )
+    assert loaded.as_dict()["sample_count"] == 128
+
+    with pytest.raises(ValueError, match="Invalid PyTorch playground arguments"):
+        manager_module.PytorchPlayground(FakeEnv(), sample_count=1)
+
+    app_suffix = manager_module.PytorchPlaygroundApp.__new__(manager_module.PytorchPlaygroundApp)
+    assert isinstance(app_suffix, manager_module.PytorchPlayground)
+    assert args_module.ensure_defaults(manager.args).model_dump(mode="json") == manager.args.model_dump(mode="json")
 
 
 def test_pytorch_playground_reduce_contract_merges_training_summaries(
@@ -2402,6 +2714,177 @@ def test_pytorch_playground_app_args_form_fallback_snippet_edges(
     assert "RUN_STAGES_PAYLOAD = json.loads('[]')" in snippet
 
 
+def test_pytorch_playground_app_args_form_remaining_edge_paths(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    import builtins
+
+    form_module = _load_app_args_form_module()
+
+    class StopRender(RuntimeError):
+        pass
+
+    class FakeContainer:
+        def __init__(self, label: str = "container"):
+            self.label = label
+            self.events: list[tuple[str, object]] = []
+
+        def __enter__(self):
+            self.events.append(("enter", self.label))
+            return self
+
+        def __exit__(self, *_args):
+            self.events.append(("exit", self.label))
+            return False
+
+        def markdown(self, body):
+            self.events.append(("markdown", body))
+
+        def caption(self, body):
+            self.events.append(("caption", body))
+
+        def error(self, body):
+            self.events.append(("error", body))
+
+        def code(self, body, **kwargs):
+            self.events.append(("code", (body, kwargs.get("language"))))
+
+        def expander(self, label, *, expanded=False):
+            self.events.append(("expander", (label, expanded)))
+            return self
+
+        def columns(self, spec):
+            self.events.append(("columns", tuple(spec) if isinstance(spec, list) else spec))
+            return [self for _ in range(len(spec) if isinstance(spec, list) else int(spec))]
+
+        def text_input(self, _label, *, key):
+            return form_module.st.session_state[key]
+
+        def checkbox(self, _label, *, key):
+            return form_module.st.session_state[key]
+
+        def number_input(self, _label, *, key, **_kwargs):
+            return form_module.st.session_state[key]
+
+        def slider(self, _label, *, key, **_kwargs):
+            return form_module.st.session_state[key]
+
+        def selectbox(self, _label, options=None, *, key):
+            return form_module.st.session_state[key]
+
+        def multiselect(self, _label, _options, *, key):
+            return form_module.st.session_state[key]
+
+    class FakeStreamlit:
+        def __init__(self):
+            self.session_state: dict[str, object] = {}
+            self.errors: list[str] = []
+            self.sidebar = FakeContainer("sidebar")
+
+        def error(self, message):
+            self.errors.append(str(message))
+
+        def stop(self):
+            raise StopRender()
+
+    fake_st = FakeStreamlit()
+    monkeypatch.setattr(form_module, "st", fake_st)
+    with pytest.raises(StopRender):
+        form_module._get_env()
+    assert fake_st.errors == [
+        "AGILAB environment is not initialised yet. Return to the main page and try again."
+    ]
+
+    env = SimpleNamespace(
+        app="",
+        active_app=tmp_path / "apps" / "pytorch_playground_project",
+        apps_path=tmp_path / "apps",
+        target="target",
+        AGILAB_EXPORT_ABS=tmp_path / "export",
+        humanize_validation_errors=lambda exc: [f"humanized: {type(exc).__name__}"],
+    )
+    fake_st.session_state["env"] = env
+    assert form_module._get_env() is env
+    assert form_module._active_app_name(env) == "pytorch_playground_project"
+    assert form_module._snippet_apps_path(env) == str(tmp_path / "apps")
+    assert form_module._cluster_settings() == {}
+    fake_st.session_state["app_settings"] = {"cluster": "bad"}
+    assert form_module._cluster_settings() == {}
+    fake_st.session_state["app_settings"] = {
+        "cluster": {
+            "cluster_enabled": True,
+            "scheduler": "host",
+            "workers": {"w": 1},
+            "workers_data_path": "/share",
+            "pool": True,
+            "cython": True,
+            "rapids": True,
+            "verbose": "bad",
+        }
+    }
+    assert form_module._coerce_verbose("bad") == 1
+    fake_st.session_state["mode"] = 7
+    assert form_module._run_mode(form_module._cluster_settings(), cluster_enabled=True) == 7
+    fake_st.session_state.pop("mode")
+    assert form_module._run_mode(form_module._cluster_settings(), cluster_enabled=True) == 15
+    assert form_module._optional_string_expr(False, "x") == "None"
+    assert form_module._optional_python_expr(True, {}) == "None"
+    payload, stages, data_in, data_out, reset_target = form_module._split_run_request_payload(
+        {"args": "not-list", "data_in": "in", "data_out": "out", "reset_target": True}
+    )
+    assert payload == {}
+    assert stages == []
+    assert (data_in, data_out, reset_target) == ("in", "out", True)
+
+    model = form_module.app_args.PytorchPlaygroundArgs(compute_loss_landscape=False)
+    values: dict[str, object] = {}
+    resolution_field = next(field for field in form_module.FORM_FIELDS if field.name == "landscape_resolution")
+    assert form_module._field_disabled(resolution_field, values, model, env=env) is True
+    assert (
+        form_module._feature_names(FakeContainer(), env, "feature_names", "Features", "")
+        == ",".join(form_module.DEFAULT_FEATURES)
+    )
+    sidebar_values = form_module._render_args_form(model, env=env, container=FakeContainer(), wide=False)
+    assert set(sidebar_values) == {field.name for field in form_module.FORM_FIELDS}
+
+    fake_st.session_state = {
+        "env": env,
+        "app_settings": fake_st.session_state["app_settings"],
+    }
+    persisted: list[object] = []
+    monkeypatch.setattr(
+        form_module,
+        "load_args_state",
+        lambda _env, *, args_module: (model, {"seed": "payload"}, tmp_path / "settings.toml"),
+    )
+    monkeypatch.setattr(form_module, "persist_args", lambda *args, **kwargs: persisted.append((args, kwargs)))
+    parsed = form_module.persist_current_args(env=env)
+    assert isinstance(parsed, form_module.app_args.PytorchPlaygroundArgs)
+    assert persisted
+
+    original_import = builtins.__import__
+
+    def fail_orchestrate_import(name, *args, **kwargs):
+        if name == "agilab.orchestrate_page_support":
+            raise ImportError("blocked")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fail_orchestrate_import)
+    snippet = form_module._build_synced_run_snippet(parsed, env=env)
+    assert "asyncio.run(main())" in snippet
+    assert "RunRequest" in snippet
+
+    monkeypatch.setattr(
+        form_module.app_args,
+        "to_playground_config",
+        lambda _parsed: (_ for _ in ()).throw(ValueError("bad config")),
+    )
+    output_container = FakeContainer("output")
+    form_module.render(env=env, container=output_container, compact=False)
+    assert ("error", "bad config") in output_container.events
+
+
 def test_pytorch_playground_source_and_packaged_payload_stay_aligned() -> None:
     source_root = PROJECT_PATH / "src"
     payload_root = PACKAGE_PROJECT_PATH / "src"
@@ -2453,6 +2936,74 @@ def test_pytorch_playground_worker_exports_evidence_without_torch(
     assert manifest["app"] == "pytorch_playground_project"
     assert (tmp_path / "out" / "pytorch_playground_evidence.zip").is_file()
     assert (tmp_path / "export" / "pytorch_playground_project" / "pytorch_playground" / "manifest.json").is_file()
+
+
+def test_pytorch_playground_worker_helper_and_dispatch_edges(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.syspath_prepend(str(PROJECT_SRC.resolve()))
+    worker_module = importlib.import_module("pytorch_playground_worker.pytorch_playground_worker")
+    args_module = importlib.import_module("pytorch_playground.app_args")
+
+    assert worker_module._artifact_dir(
+        SimpleNamespace(AGILAB_EXPORT_ABS=tmp_path / "export", target="target"),
+        "leaf",
+    ) == tmp_path / "export" / "target" / "leaf"
+    assert worker_module._artifact_dir(
+        SimpleNamespace(resolve_share_path=lambda value: tmp_path / "share" / value),
+        "leaf",
+    ) == tmp_path / "share" / "leaf"
+    monkeypatch.setattr(worker_module.Path, "home", staticmethod(lambda: tmp_path))
+    assert worker_module._artifact_dir(SimpleNamespace(), "leaf") == tmp_path / "export" / "leaf"
+
+    args = args_module.PytorchPlaygroundArgs(sample_count=96)
+    assert worker_module._args_with_defaults(args) is args
+    assert worker_module._args_with_defaults(args.model_dump(mode="json")).sample_count == 96
+    assert worker_module._args_with_defaults(SimpleNamespace(sample_count=128, _private="skip")).sample_count == 128
+
+    class ArgsObject:
+        def __init__(self):
+            self.sample_count = 160
+            self._private = "skip"
+
+    assert worker_module._args_with_defaults(ArgsObject()).sample_count == 160
+
+    existing_out = tmp_path / "resolved" / "evidence"
+    existing_out.mkdir(parents=True)
+    (existing_out / "stale.txt").write_text("old", encoding="utf-8")
+    worker = worker_module.PytorchPlaygroundWorker.__new__(worker_module.PytorchPlaygroundWorker)
+    worker.args = {"data_out": "evidence", "reset_target": True, "sample_count": 96}
+    worker.env = SimpleNamespace(resolve_share_path=lambda value: tmp_path / "resolved" / value, target="")
+    worker._worker_id = 0
+    worker.start()
+    assert worker.data_out == existing_out
+    assert not (existing_out / "stale.txt").exists()
+
+    events: list[tuple[str, object]] = []
+    dispatch_worker = worker_module.PytorchPlaygroundWorker.__new__(worker_module.PytorchPlaygroundWorker)
+    dispatch_worker._worker_id = 0
+    dispatch_worker.work_init = lambda: events.append(("init", None))
+    dispatch_worker.work_pool = lambda item: events.append(("pool", item)) or pd.DataFrame([{"item": item}])
+    dispatch_worker.work_done = lambda df: events.append(("done", df.iloc[0]["item"]))
+    dispatch_worker.stop = lambda: events.append(("stop", None))
+    worker_module.BaseWorker._t0 = None
+
+    elapsed = dispatch_worker.works([["a", ("b", "c")]], [])
+
+    assert elapsed >= 0
+    assert events == [
+        ("init", None),
+        ("pool", "a"),
+        ("done", "a"),
+        ("pool", "b"),
+        ("done", "b"),
+        ("pool", "c"),
+        ("done", "c"),
+        ("stop", None),
+    ]
+    bare_worker = worker_module.PytorchPlaygroundWorker.__new__(worker_module.PytorchPlaygroundWorker)
+    assert worker_module.PytorchPlaygroundWorker.work_done(bare_worker) is None
 
 
 def test_pytorch_playground_worker_exports_real_torch_evidence_when_available(
@@ -2832,6 +3383,180 @@ def test_pytorch_playground_main_renders_with_fake_streamlit(monkeypatch: pytest
     assert fake_st.downloads
     manifest = next(json.loads(body) for body, language in fake_st.code_payloads if language == "json")
     assert manifest["schema"] == module.EVIDENCE_SCHEMA
+
+
+def test_pytorch_playground_main_live_mode_and_missing_evidence_branch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    module = _load_module()
+
+    class FakeContext:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc):
+            return False
+
+        def metric(self, *_args, **_kwargs):
+            return None
+
+        def plotly_chart(self, *_args, **_kwargs):
+            return None
+
+        def dataframe(self, *_args, **_kwargs):
+            return None
+
+        def selectbox(self, _label, options, index=0, **_kwargs):
+            return list(options)[index]
+
+        def button(self, label, **_kwargs):
+            return label == "Play"
+
+        def caption(self, *_args, **_kwargs):
+            return None
+
+        def progress(self, *_args, **_kwargs):
+            return None
+
+    class FakeStreamlit:
+        def __init__(self):
+            self.query_params = {}
+            self.session_state: dict[str, object] = {}
+            self.sidebar = FakeContext()
+            self.infos: list[str] = []
+            self.errors: list[str] = []
+            self.warnings: list[str] = []
+            self.downloads: list[bytes] = []
+            self.code_payloads: list[tuple[str, str | None]] = []
+            self.rerun_count = 0
+
+        def set_page_config(self, **_kwargs):
+            return None
+
+        def title(self, *_args, **_kwargs):
+            return None
+
+        def caption(self, message="", **_kwargs):
+            return None
+
+        def markdown(self, *_args, **_kwargs):
+            return None
+
+        def error(self, message, **_kwargs):
+            self.errors.append(str(message))
+
+        def warning(self, message, **_kwargs):
+            self.warnings.append(str(message))
+
+        def columns(self, spec):
+            count = spec if isinstance(spec, int) else len(spec)
+            return [FakeContext() for _ in range(count)]
+
+        def tabs(self, labels):
+            return [FakeContext() for _label in labels]
+
+        def selectbox(self, label, options, index=0, **_kwargs):
+            if label == "Training mode":
+                return module.LIVE_TRAINING_MODE_LABEL
+            return list(options)[index]
+
+        def slider(self, _label, _min, _max, value, **_kwargs):
+            return value
+
+        def multiselect(self, _label, _options, default=None, **_kwargs):
+            return list(default or [])
+
+        def text_input(self, _label, value="", **_kwargs):
+            return value
+
+        def number_input(self, _label, value=0, **_kwargs):
+            return value
+
+        def checkbox(self, *_args, **_kwargs):
+            return False
+
+        def button(self, label, **_kwargs):
+            return label == "Play"
+
+        def plotly_chart(self, *_args, **_kwargs):
+            return None
+
+        def dataframe(self, *_args, **_kwargs):
+            return None
+
+        def info(self, message, **_kwargs):
+            self.infos.append(str(message))
+
+        def metric(self, *_args, **_kwargs):
+            return None
+
+        def progress(self, *_args, **_kwargs):
+            return None
+
+        def download_button(self, _label, data, **_kwargs):
+            self.downloads.append(data)
+            return False
+
+        def code(self, body, **kwargs):
+            self.code_payloads.append((str(body), kwargs.get("language")))
+
+        def rerun(self):
+            self.rerun_count += 1
+
+        def json(self, payload, **_kwargs):
+            raise AssertionError(f"st.json should not be used by PyTorch Playground: {payload!r}")
+
+    config = module.PlaygroundConfig(sample_count=64, grid_size=12, hidden_layers=(4,), epochs=8)
+    samples = module._make_dataset(config)
+    result = {
+        "status": "ok",
+        "detail": "",
+        "samples": samples,
+        "history": pd.DataFrame(
+            {
+                "epoch": [1],
+                "train_loss": [0.5],
+                "validation_loss": [0.6],
+                "train_accuracy": [0.7],
+                "validation_accuracy": [0.65],
+            }
+        ),
+        "grid": pd.DataFrame({"x1": [0.0], "x2": [0.0], "probability": [0.5]}),
+        "network_layers": module._empty_network_layers(),
+        "activation_maps": module._empty_activation_maps(),
+        "summary": {"backend": "live", "samples": len(samples), "features": 2},
+    }
+    fake_st = FakeStreamlit()
+    monkeypatch.setattr(module, "st", fake_st)
+    monkeypatch.setattr(module, "render_logo", lambda: None)
+    monkeypatch.setattr(module, "_resolve_active_app", lambda: tmp_path)
+    monkeypatch.setattr(module.time, "sleep", lambda _delay: None)
+    monkeypatch.setattr(
+        module,
+        "_run_live_training_controls",
+        lambda *_args, **_kwargs: (
+            {"epoch": 1, "playing": True, "signature": module._config_signature(config)},
+            result,
+            True,
+        ),
+    )
+
+    module.main()
+
+    assert fake_st.rerun_count == 1
+    assert fake_st.downloads
+
+    analysis_st = FakeStreamlit()
+    monkeypatch.setattr(module, "st", analysis_st)
+    module.main(
+        interactive_controls=False,
+        evidence_dirs=[tmp_path / "missing"],
+        configure_page=False,
+    )
+    assert analysis_st.infos == [
+        "No exported PyTorch evidence found yet. Run the app once from ORCHESTRATE, then return to ANALYSIS."
+    ]
 
 
 def test_pytorch_playground_app_provider_and_package_docs(tmp_path: Path) -> None:

--- a/test/test_ui_pages.py
+++ b/test/test_ui_pages.py
@@ -960,6 +960,7 @@ def test_execute_page_cluster_settings(mock_ui_env):
     markdown_text = "\n".join(str(item.value) for item in at.markdown)
     assert "Run readiness" not in markdown_text
     assert all("Check what will run" not in str(item.value) for item in at.caption)
+    assert "Project cockpit" not in markdown_text
     assert "Environment Health" in markdown_text
     assert "Project path" in markdown_text
     assert "Manager env" in markdown_text

--- a/test/test_view_maps_network.py
+++ b/test/test_view_maps_network.py
@@ -3195,3 +3195,181 @@ def test_view_maps_network_helper_covers_remaining_fallback_branches(
     assert positions["flight_id"].tolist() == ["2002"]
 
     assert module._canonical_bearer_state("   ", routed=True) == "Routed"
+
+
+def test_view_maps_network_direct_helper_remaining_edges(
+    monkeypatch, tmp_path: Path
+) -> None:
+    module = _load_view_maps_network_module(monkeypatch, tmp_path)
+
+    class _StopCalled(RuntimeError):
+        pass
+
+    class _NoLinkButtonColumn:
+        def __init__(self, events: list[tuple[str, str]]):
+            self.events = events
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc):
+            return False
+
+        def caption(self, message, **_kwargs):
+            self.events.append(("caption", str(message)))
+
+    class _ContextStreamlit:
+        def __init__(self):
+            self.events: list[tuple[str, str]] = []
+            self.session_state = {}
+
+        def error(self, message, **_kwargs):
+            self.events.append(("error", str(message)))
+
+        def stop(self):
+            raise _StopCalled
+
+        def columns(self, count):
+            return [_NoLinkButtonColumn(self.events) for _ in range(int(count))]
+
+        def caption(self, message, **_kwargs):
+            self.events.append(("caption", str(message)))
+
+        def expander(self, label, expanded=False):
+            self.events.append(("expander", f"{label}:{expanded}"))
+            return _NoLinkButtonColumn(self.events)
+
+        def code(self, message, **_kwargs):
+            self.events.append(("code", str(message)))
+
+        def warning(self, message, **_kwargs):
+            self.events.append(("warning", str(message)))
+
+    fake_st = _ContextStreamlit()
+    monkeypatch.setattr(module, "st", fake_st)
+    monkeypatch.delenv("AGILAB_ACTIVE_APP", raising=False)
+    with patch("sys.argv", ["view_maps_network.py"]), pytest.raises(_StopCalled):
+        module._resolve_active_app()
+    assert ("error", "Missing --active-app argument.") in fake_st.events
+
+    env_with_active = SimpleNamespace(app="demo", active_app=tmp_path / "active")
+    assert module._active_app_context_from_env(env_with_active) == (
+        "demo",
+        tmp_path / "active",
+    )
+    env_with_apps_path = SimpleNamespace(target="worker", apps_path=tmp_path / "apps")
+    assert module._active_app_context_from_env(env_with_apps_path) == (
+        "worker",
+        tmp_path / "apps" / "worker",
+    )
+    assert module._active_app_context_from_env(SimpleNamespace()) == (
+        "project",
+        Path("project"),
+    )
+
+    module._render_app_page_context("demo", tmp_path / "active")
+    assert ("caption", "Back to ANALYSIS: /ANALYSIS?active_app=demo") in fake_st.events
+
+    sanitized = module._sanitize_toml_payload(
+        {
+            None: "drop",
+            "path": tmp_path / "file.csv",
+            "set": {"b", "a"},
+            "scalar": np.int64(3),
+        }
+    )
+    assert sanitized["path"] == (tmp_path / "file.csv").as_posix()
+    assert sanitized["set"] == ["a", "b"]
+    assert sanitized["scalar"] == 3
+
+    zeros = module._cloud_heatmap_stats_kernel_py(
+        np.array([0.0]),
+        np.array([0.0]),
+        np.ones((1, 1), dtype=np.float32),
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        1,
+    )
+    assert all(np.isnan(values).all() for values in zeros)
+
+    nan_grid = module._cloud_heatmap_stats_kernel_py(
+        np.array([0.0]),
+        np.array([0.0]),
+        np.array([[np.nan, 2.0], [3.0, 4.0]], dtype=np.float32),
+        0.0,
+        0.0,
+        module.EARTH_RADIUS_M,
+        0.0,
+        0.0,
+        1,
+    )
+    assert np.isnan(nan_grid[0][0])
+    assert np.isfinite(nan_grid[2][0])
+
+    module._HEATMAP_NUMBA_KERNEL_ATTEMPTED = True
+    module._HEATMAP_NUMBA_KERNEL = "cached"
+    assert module._get_heatmap_numba_kernel() == "cached"
+
+    original_import = __import__
+
+    def _missing_numba(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "numba":
+            raise ImportError("no numba")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr("builtins.__import__", _missing_numba)
+    module._HEATMAP_NUMBA_KERNEL_ATTEMPTED = False
+    module._HEATMAP_NUMBA_KERNEL = None
+    assert module._get_heatmap_numba_kernel() is None
+
+    def _fake_numba(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "numba":
+            return SimpleNamespace(njit=lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("jit failed")))
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr("builtins.__import__", _fake_numba)
+    module._HEATMAP_NUMBA_KERNEL_ATTEMPTED = False
+    assert module._get_heatmap_numba_kernel() is None
+
+    with pytest.raises(ValueError, match="matching latitude and longitude"):
+        module._sample_cloud_heatmap_stats_batch("grid.npz", [0.0], [0.0, 1.0])
+    assert module._sample_cloud_heatmap_stats_batch("grid.npz", [], [])["raw_value"].size == 0
+
+    monkeypatch.setattr(
+        module,
+        "_load_cloud_heatmap_grid",
+        lambda _path: {
+            "heatmap": np.asarray([[1.0]], dtype=np.float32),
+            "x_min": 0.0,
+            "z_min": 0.0,
+            "step": module.EARTH_RADIUS_M,
+            "center_x": 0.0,
+            "center_z": 0.0,
+        },
+    )
+    module._HEATMAP_NUMBA_KERNEL_ATTEMPTED = True
+    module._HEATMAP_NUMBA_KERNEL = lambda *_args: (_ for _ in ()).throw(RuntimeError("kernel failed"))
+    sampled = module._sample_cloud_heatmap_stats_batch("grid.npz", [0.0], [0.0])
+    assert sampled["raw_value"].tolist() == [1.0]
+    assert module._HEATMAP_NUMBA_KERNEL is None
+
+    assert module._position_lookup(pd.DataFrame({"flight_id": [], "long": []})) == ({}, set())
+    lookup, node_set = module._position_lookup(
+        pd.DataFrame(
+            {
+                "flight_id": [float("nan"), "1001", "1001"],
+                "long": [1.0, 2.0, 3.0],
+                "lat": [4.0, 5.0, 6.0],
+                "alt": [7.0, 8.0, 9.0],
+            }
+        )
+    )
+    assert lookup == {"1001": (2.0, 5.0, 8.0)}
+    assert node_set == {"1001"}
+    assert module.build_allocation_layers(
+        pd.DataFrame({"source": ["1"], "destination": ["2"]}),
+        pd.DataFrame({"flight_id": ["1"], "long": [1.0]}),
+    ) == []

--- a/test/test_workflow_ui.py
+++ b/test/test_workflow_ui.py
@@ -531,6 +531,57 @@ def test_project_state_and_basic_render_edge_cases(monkeypatch, tmp_path) -> Non
     assert ("caption", "Output file is too large for inline download: large.csv") in fake_st.events
 
 
+def test_workflow_ui_project_context_remaining_edges(monkeypatch, tmp_path) -> None:
+    assert workflow_ui._project_display_name(None) == "No project"
+    assert workflow_ui._project_path(None) is None
+    assert workflow_ui._runtime_roots(None) == []
+    assert workflow_ui._artifact_label(tmp_path / "notebook.ipynb") == "Notebook"
+    assert workflow_ui._artifact_description(tmp_path / "outside.log", tmp_path / "root") == "outside.log"
+
+    app_root = tmp_path / "apps" / "demo_project"
+    app_root.mkdir(parents=True)
+    env = SimpleNamespace(app="demo_project", apps_path=tmp_path / "apps", runenv=tmp_path / "missing-run")
+    assert workflow_ui._project_path(env) == app_root
+
+    artifacts_root = app_root / "artifacts"
+    artifacts_root.mkdir()
+    manifest = artifacts_root / "run_manifest.json"
+    manifest.write_text("{}", encoding="utf-8")
+    table = artifacts_root / "metrics.csv"
+    table.write_text("x\n1\n", encoding="utf-8")
+    ignored = artifacts_root / ".git" / "ignored.csv"
+    ignored.parent.mkdir()
+    ignored.write_text("x\n", encoding="utf-8")
+    scanned = workflow_ui._scan_project_evidence(env)
+    assert scanned["count"] == 2
+    assert scanned["manifest"] == manifest
+    assert [artifact["label"] for artifact in scanned["artifacts"]][:2] == ["Table", "Run manifest"]
+
+    monkeypatch.setattr(workflow_ui.os, "walk", lambda _root: (_ for _ in ()).throw(OSError("walk failed")))
+    assert workflow_ui._scan_project_evidence(env)["count"] == 0
+
+    assert workflow_ui._project_install_status(None) == ("Unknown", "environment not loaded", "incomplete")
+    assert workflow_ui._run_history(None) == ("0", "environment not loaded", "incomplete")
+
+    fake_st = _FakeStreamlit()
+    workflow_ui.render_project_evidence_drawer(
+        fake_st,
+        env=SimpleNamespace(app="missing", active_app=tmp_path / "missing"),
+        key_prefix="missing",
+    )
+    assert (
+        "caption",
+        "No evidence files found yet. Run ORCHESTRATE -> EXECUTE first.",
+    ) in fake_st.events
+    assert workflow_ui._normalize_artifact({"description": "Description only"}) == {
+        "label": "Artifact",
+        "path": None,
+        "kind": "artifact",
+        "description": "Description only",
+        "preview": True,
+    }
+
+
 def test_artifact_drawer_covers_generic_preview_edges(monkeypatch, tmp_path) -> None:
     fake_st = _FakeStreamlit()
     folder = tmp_path / "folder"

--- a/test/test_workflow_ui.py
+++ b/test/test_workflow_ui.py
@@ -533,8 +533,11 @@ def test_project_state_and_basic_render_edge_cases(monkeypatch, tmp_path) -> Non
 
 def test_workflow_ui_project_context_remaining_edges(monkeypatch, tmp_path) -> None:
     assert workflow_ui._project_display_name(None) == "No project"
+    assert workflow_ui._project_display_name(SimpleNamespace()) == "No project"
     assert workflow_ui._project_path(None) is None
+    assert workflow_ui._project_path(SimpleNamespace(app="demo_project")) is None
     assert workflow_ui._runtime_roots(None) == []
+    assert workflow_ui._artifact_label(tmp_path / "figure.svg") == "Figure"
     assert workflow_ui._artifact_label(tmp_path / "notebook.ipynb") == "Notebook"
     assert workflow_ui._artifact_description(tmp_path / "outside.log", tmp_path / "root") == "outside.log"
 
@@ -557,11 +560,34 @@ def test_workflow_ui_project_context_remaining_edges(monkeypatch, tmp_path) -> N
     assert scanned["manifest"] == manifest
     assert [artifact["label"] for artifact in scanned["artifacts"]][:2] == ["Table", "Run manifest"]
 
-    monkeypatch.setattr(workflow_ui.os, "walk", lambda _root: (_ for _ in ()).throw(OSError("walk failed")))
-    assert workflow_ui._scan_project_evidence(env)["count"] == 0
+    with monkeypatch.context() as scoped_monkeypatch:
+        scoped_monkeypatch.setattr(
+            workflow_ui.os,
+            "walk",
+            lambda _root: (_ for _ in ()).throw(OSError("walk failed")),
+        )
+        assert workflow_ui._scan_project_evidence(env)["count"] == 0
 
     assert workflow_ui._project_install_status(None) == ("Unknown", "environment not loaded", "incomplete")
     assert workflow_ui._run_history(None) == ("0", "environment not loaded", "incomplete")
+
+    def _blocked_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "agilab.environment_health":
+            raise RuntimeError("blocked")
+        return original_import(name, globals, locals, fromlist, level)
+
+    original_import = __import__
+    monkeypatch.setattr("builtins.__import__", _blocked_import)
+    assert workflow_ui._project_install_status(SimpleNamespace()) == (
+        "Check",
+        "install status unavailable",
+        "incomplete",
+    )
+    assert workflow_ui._run_history(SimpleNamespace()) == (
+        "0",
+        "run log status unavailable",
+        "incomplete",
+    )
 
     fake_st = _FakeStreamlit()
     workflow_ui.render_project_evidence_drawer(
@@ -580,6 +606,46 @@ def test_workflow_ui_project_context_remaining_edges(monkeypatch, tmp_path) -> N
         "description": "Description only",
         "preview": True,
     }
+
+    file_root = tmp_path / "standalone.csv"
+    file_root.write_text("x\n1\n", encoding="utf-8")
+    file_scan = workflow_ui._scan_project_evidence(SimpleNamespace(app_data_rel=file_root))
+    assert file_scan["count"] == 1
+    assert file_scan["examples"] == ["standalone.csv"]
+
+    limited_root = tmp_path / "limited"
+    limited_root.mkdir()
+    for index in range(4):
+        (limited_root / f"artifact_{index}.csv").write_text("x\n1\n", encoding="utf-8")
+    monkeypatch.setattr(workflow_ui, "_COCKPIT_SCAN_LIMIT", 2)
+    limited_scan = workflow_ui._scan_project_evidence(SimpleNamespace(app_data_rel=limited_root))
+    assert limited_scan["truncated"] is True
+    assert limited_scan["count"] == 2
+
+    assert workflow_ui._project_next_action(
+        SimpleNamespace(app="demo_project"),
+        project_ready=True,
+        install_value="Ready",
+        run_value="3",
+        artifact_count=0,
+    )["label"] == "Create evidence"
+
+    class _NoLinkButtonStreamlit(_FakeStreamlit):
+        link_button = None
+
+    fallback_st = _NoLinkButtonStreamlit()
+    workflow_ui.render_next_action(
+        fallback_st,
+        env=SimpleNamespace(app="demo_project"),
+        key_prefix="demo",
+        action={
+            "id": "analysis",
+            "label": "Review evidence",
+            "url": "/ANALYSIS",
+            "type": "primary",
+        },
+    )
+    assert ("markdown", "[Review evidence](/ANALYSIS)") in fallback_st.events
 
 
 def test_artifact_drawer_covers_generic_preview_edges(monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
Normalize PyTorch Playground feature-name form state before persistence, keep the packaged PyPI payload aligned, hide redundant project cockpit context on MAIN and ORCHESTRATE, refresh mirrored license docs, and commit the coverage/badge maintenance tests.\n\nValidation:\n- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_evidence_contract.py test/test_pytorch_playground_app.py\n- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_generate_component_coverage_badges.py\n- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui\n- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs\n- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile badges\n- uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp\n- uv --preview-features extra-build-dependencies run python tools/coverage_badge_guard.py --changed-only --require-fresh-xml