### PR TITLE
Avoid PyPI login for existing pending publisher projects

### DIFF
--- a/test/test_pypi_pending_trusted_publisher.py
+++ b/test/test_pypi_pending_trusted_publisher.py
@@ -155,6 +155,7 @@ def test_register_submits_github_pending_publisher_form_after_login_and_reauth()
         username="maintainer",
         password="secret",
         session_factory=lambda: session,
+        project_exists_checker=lambda _project, _repo: False,
     )
 
     assert result.registered is True
@@ -213,6 +214,7 @@ def test_register_handles_totp_when_login_requires_two_factor() -> None:
         password="secret",
         auth_code="123456",
         session_factory=lambda: session,
+        project_exists_checker=lambda _project, _repo: False,
     )
 
     assert result.registered is True
@@ -266,6 +268,7 @@ def test_register_consumes_same_runner_confirmation_url_before_retrying() -> Non
         password="secret",
         confirm_login_url_provider=lambda: confirm_url,
         session_factory=lambda: session,
+        project_exists_checker=lambda _project, _repo: False,
     )
 
     assert result.registered is True
@@ -339,6 +342,57 @@ def test_register_treats_existing_project_as_successful_noop() -> None:
     assert result.project_exists is True
     assert summary["success"] is True
     assert summary["project_exists"] is True
+
+
+def test_register_existing_public_project_skips_authenticated_web_flow() -> None:
+    module = _load_module()
+    publisher = module.PendingGitHubPublisher(
+        project_name="agi-app-multi-dag",
+        owner="ThalesGroup",
+        repository="agilab",
+        workflow_filename="pypi-publish.yaml",
+        environment="pypi-agi-app-multi-dag",
+    )
+
+    def fail_session():
+        raise AssertionError("PyPI web session should not be opened")
+
+    result = module.register_pending_github_publisher(
+        publisher=publisher,
+        repo="pypi",
+        username="maintainer",
+        password="secret",
+        session_factory=fail_session,
+        project_exists_checker=(
+            lambda project, repo: project == "agi-app-multi-dag" and repo == "pypi"
+        ),
+    )
+
+    assert result.registered is False
+    assert result.already_registered is False
+    assert result.project_exists is True
+
+
+def test_existing_public_project_does_not_require_credentials(monkeypatch, capsys) -> None:
+    module = _load_module()
+    monkeypatch.delenv("PYPI_RELEASE_PRUNE_USERNAME", raising=False)
+    monkeypatch.delenv("PYPI_RELEASE_PRUNE_PASSWORD", raising=False)
+    monkeypatch.setattr(module, "_public_project_exists", lambda _project, _repo: True)
+
+    status = module.main(
+        [
+            "--project-name",
+            "agi-app-multi-dag",
+            "--environment",
+            "pypi-agi-app-multi-dag",
+            "--json",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert status == 0
+    assert '"project_exists": true' in captured.out
+    assert "PYPI_RELEASE_PRUNE_USERNAME" not in captured.err
 
 
 def test_register_rejects_pending_publisher_for_different_project() -> None:

--- a/tools/pypi_pending_trusted_publisher.py
+++ b/tools/pypi_pending_trusted_publisher.py
@@ -25,6 +25,7 @@ if str(TOOLS_DIR) not in sys.path:
 try:
     from pypi_release_retention import (
         PYPI_HOSTS,
+        PYPI_JSON_URLS,
         _find_form,
         _fresh_totp_code,
         _submit_reauthentication_if_needed,
@@ -39,6 +40,7 @@ try:
 except ModuleNotFoundError:  # pragma: no cover - used when imported as tools.*
     from tools.pypi_release_retention import (
         PYPI_HOSTS,
+        PYPI_JSON_URLS,
         _find_form,
         _fresh_totp_code,
         _submit_reauthentication_if_needed,
@@ -154,6 +156,33 @@ def _publisher_form_data(
         }
     )
     return data
+
+
+def _existing_project_result(publisher: PendingGitHubPublisher) -> RegistrationResult:
+    return RegistrationResult(
+        publisher=publisher,
+        registered=False,
+        already_registered=False,
+        project_exists=True,
+    )
+
+
+def _public_project_exists(project_name: str, repo: str, *, timeout: int = 15) -> bool:
+    url = PYPI_JSON_URLS[repo].format(package=project_name)
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/json",
+            "User-Agent": "agilab-pypi-pending-trusted-publisher/1",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout):
+            return True
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return False
+        raise RuntimeError(f"{url}: HTTP {exc.code}") from exc
 
 
 def _confirm_login_url_is_safe(url: str) -> bool:
@@ -401,12 +430,7 @@ def _interpret_registration_response(
             "PyPI account publishing settings, then rerun this workflow."
         )
     if PROJECT_EXISTS_FRAGMENT in text:
-        return RegistrationResult(
-            publisher=publisher,
-            registered=False,
-            already_registered=False,
-            project_exists=True,
-        )
+        return _existing_project_result(publisher)
     if GENERIC_FAILURE_FRAGMENT in text or DIFFERENT_PROJECT_FRAGMENT in text:
         raise RuntimeError(
             "PyPI rejected the pending trusted publisher registration; check the "
@@ -428,8 +452,13 @@ def register_pending_github_publisher(
     auth_code: str | None = None,
     confirm_login_url_provider: Callable[[], str | None] | None = None,
     session_factory: Callable[[], Any] | None = None,
+    project_exists_checker: Callable[[str, str], bool] | None = None,
 ) -> RegistrationResult:
     import requests
+
+    exists = project_exists_checker or _public_project_exists
+    if exists(publisher.project_name, repo):
+        return _existing_project_result(publisher)
 
     base_url = PYPI_HOSTS[repo].rstrip("/")
     session_factory = session_factory or requests.Session
@@ -585,6 +614,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             already_registered=False,
             dry_run=True,
         )
+    elif _public_project_exists(publisher.project_name, args.repo):
+        result = _existing_project_result(publisher)
     else:
         username, password = require_credentials(args.username, args.password)
         confirm_provider = None
@@ -617,6 +648,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             password=password,
             auth_code=resolve_auth_code(args.otp_code, args.totp_secret),
             confirm_login_url_provider=confirm_provider,
+            project_exists_checker=lambda _project, _repo: False,
         )
 
     summary = render_summary(result)


### PR DESCRIPTION
## Summary
- Short-circuit pending trusted publisher registration when the PyPI project already exists according to the public PyPI JSON API.
- Avoid requiring PyPI web credentials, TOTP, or same-runner login confirmation for existing projects.
- Keep the authenticated form-response fallback for races where the project appears after the public preflight.

## Validation
- `uv --preview-features extra-build-dependencies run --python 3.13 pytest -q -o addopts='' test/test_pypi_pending_trusted_publisher.py test/test_release_robustness_tools.py`
- `env -u PYPI_RELEASE_PRUNE_USERNAME -u PYPI_RELEASE_PRUNE_PASSWORD uv --preview-features extra-build-dependencies run --python 3.13 python tools/pypi_pending_trusted_publisher.py --project-name agi-app-multi-dag --environment pypi-agi-app-multi-dag --json`
- `git diff --check`
