### PR TITLE
Handle missing Torch in playground edge coverage

### DIFF
--- a/test/test_pytorch_playground_app.py
+++ b/test/test_pytorch_playground_app.py
@@ -3572,6 +3572,12 @@ def test_pytorch_playground_core_remaining_training_edges() -> None:
         hidden_layers=(),
         epochs=2,
     )
+    if module.torch is None or module.nn is None:
+        missing_result = module._train_playground(no_hidden_config)
+        assert missing_result["status"] == "missing_torch"
+        assert module._new_live_training_state(no_hidden_config)["status"] == "missing_torch"
+        return
+
     training_data = module._prepare_training_data(no_hidden_config)
     model = module._build_model(len(no_hidden_config.feature_names), no_hidden_config)
     assert module._hidden_activation_maps(


### PR DESCRIPTION
## Summary
- Fix the new PyTorch Playground edge-coverage test for lightweight CI shards where Torch is not installed.
- Assert the existing `missing_torch` contract before returning from Torch-only training helpers.

## Validation
- `uv --preview-features extra-build-dependencies run --python 3.13 pytest -q -o addopts='' test/test_pytorch_playground_app.py::test_pytorch_playground_core_remaining_training_edges`
- `git diff --check`

Note: running the full local `test/test_pytorch_playground_app.py` in this minimal shell fails on unrelated missing `streamlit`; the failing CI coverage shard reproduced only the Torch-missing edge fixed here.
