### PR TITLE
Add support edge coverage

### DIFF
--- a/test/test_agent_run.py
+++ b/test/test_agent_run.py
@@ -1264,12 +1264,84 @@ def test_agent_run_command_policy_and_read_edge_cases(tmp_path: Path, monkeypatc
 def test_agent_run_render_and_validation_remaining_edges(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     module = _load_module()
 
+    assert module._render_summary_table([]) == "No AGILAB agent runs found."
+    assert "pass" in module._render_summary_table(
+        [
+            module.AgentRunSummary(
+                run_id="summary",
+                agent="codex",
+                label="Summary",
+                status="pass",
+                returncode=0,
+                manifest_path=tmp_path / "manifest.json",
+                stdout_path=None,
+                stderr_path=None,
+                trace_events_path=None,
+                duration_seconds=1.0,
+                tags=(),
+                metadata={},
+            )
+        ]
+    )
+
+    invalid_root = tmp_path / "invalid-runs"
+    invalid_dir = invalid_root / "invalid"
+    invalid_dir.mkdir(parents=True)
+    (invalid_dir / module.MANIFEST_FILENAME).write_text("{bad-json", encoding="utf-8")
+    assert module.list_agent_runs(invalid_root) == []
+
+    handoff_from_dict = module.agent_handoff_payload(
+        {
+            "kind": module.TRACE_KIND,
+            "run_id": "dict-run",
+            "agent": "codex",
+            "status": "planned",
+            "command": {},
+            "permission": {},
+            "artifacts": {},
+        }
+    )
+    assert handoff_from_dict["run"]["run_id"] == "dict-run"
+
+    next_text = module.render_next_actions_markdown(
+        {
+            "run": {"run_id": "next", "agent": "codex", "status": "pass", "manifest": "m"},
+            "next_actions": ["skip", {"priority": "P2", "action": "Document", "reason": "done"}],
+        }
+    )
+    assert "Document" in next_text
+
     assert "No matching agent runs" in module.render_context_markdown(
         {"match_count": 0, "status_counts": {}, "runs": [], "latest": {}}
     )
+    context_with_non_dict_items = module.render_context_markdown(
+        {
+            "match_count": 0,
+            "status_counts": {},
+            "runs": ["skip"],
+            "latest": {
+                "next_actions": {
+                    "next_actions": [
+                        "skip",
+                        {"priority": "P1", "action": "Retry", "reason": "failed"},
+                    ]
+                }
+            },
+        }
+    )
+    assert "Retry" in context_with_non_dict_items
     assert "No linked agent runs" in module.render_lineage_markdown(
         {"query": {"run_id": "missing"}, "found": False, "chain": [], "edges": []}
     )
+    lineage_with_non_dict_items = module.render_lineage_markdown(
+        {
+            "query": {"run_id": "missing"},
+            "found": False,
+            "chain": ["skip"],
+            "edges": ["skip", {"from": "left", "to": "right"}],
+        }
+    )
+    assert "left -> right" in lineage_with_non_dict_items
     assert "Metadata delta" in module.render_compare_markdown(
         {
             "left": {"run_id": "left", "status": "fail"},
@@ -1306,6 +1378,35 @@ def test_agent_run_render_and_validation_remaining_edges(tmp_path: Path, monkeyp
     assert {"kind", "status", "manifest_path", "stdout_path", "stderr_path", "argv_sha256", "trace_events_exists"} <= codes
     assert "argv_redaction" in warning_codes
 
+    stdout_only = tmp_path / "stdout.txt"
+    stdout_only.write_text("ok\n", encoding="utf-8")
+    stderr_missing_manifest = {
+        "kind": module.TRACE_KIND,
+        "run_id": "stderr-missing",
+        "status": "pass",
+        "command": {"argv_sha256": "hash"},
+        "artifacts": {
+            "stdout": {"path": str(stdout_only)},
+            "stderr": {"path": str(tmp_path / "missing-stderr.txt")},
+        },
+    }
+    stderr_missing_validation = module.validate_agent_run(stderr_missing_manifest)
+    assert {item["code"] for item in stderr_missing_validation["issues"]} >= {"stderr_exists"}
+
+    trace_path = tmp_path / "agent_events.ndjson"
+    trace_path.write_text('{"event":"command_done","sequence":2}\n', encoding="utf-8")
+    monkeypatch.setattr(module, "validate_event_sequence", lambda _events: ["out of order"])
+    trace_validation = module.validate_agent_run(
+        {
+            "kind": module.TRACE_KIND,
+            "run_id": "trace-bad",
+            "status": "planned",
+            "command": {"argv_sha256": "hash"},
+            "artifacts": {"agent_trace": {"events": str(trace_path)}},
+        }
+    )
+    assert "trace_sequence" in {item["code"] for item in trace_validation["issues"]}
+
     no_trace_manifest = {
         "kind": module.TRACE_KIND,
         "run_id": "planned",
@@ -1318,6 +1419,42 @@ def test_agent_run_render_and_validation_remaining_edges(tmp_path: Path, monkeyp
 
     assert module.agent_next_actions_payload({"kind": module.TRACE_KIND, "status": "timeout"})["next_actions"][0]["priority"] == "P0"
     assert module.agent_next_actions_payload({"kind": module.TRACE_KIND, "status": "unknown"})["next_actions"][0]["priority"] == "P1"
+    assert module._trace_event_count(
+        module.AgentRunSummary(
+            run_id="no-trace",
+            agent="codex",
+            label="no trace",
+            status="planned",
+            returncode=None,
+            manifest_path=None,
+            stdout_path=None,
+            stderr_path=None,
+            trace_events_path=None,
+            duration_seconds=0.0,
+            tags=(),
+            metadata={},
+        )
+    ) == 0
+    monkeypatch.setattr(module, "load_trace_events", lambda _root: (_ for _ in ()).throw(OSError("bad trace")))
+    assert module._trace_event_count(
+        module.AgentRunSummary(
+            run_id="bad-trace",
+            agent="codex",
+            label="bad trace",
+            status="pass",
+            returncode=0,
+            manifest_path=None,
+            stdout_path=None,
+            stderr_path=None,
+            trace_events_path=tmp_path / "events.ndjson",
+            duration_seconds=0.0,
+            tags=(),
+            metadata={},
+        )
+    ) == 0
+
+    with pytest.raises(SystemExit):
+        module._main_list(["--root", str(tmp_path), "--limit", "-1"])
 
     monkeypatch.setattr(
         module,
@@ -1373,3 +1510,21 @@ def test_agent_run_render_and_validation_remaining_edges(tmp_path: Path, monkeyp
     lineage = module.agent_lineage_payload(tmp_path, run_id="child")
     assert lineage["found"] is True
     assert [item["run_id"] for item in lineage["ancestors"]] == ["parent"]
+
+    missing_parent = module.AgentRunSummary(
+        run_id="orphan",
+        agent="codex",
+        label="orphan",
+        status="pass",
+        returncode=0,
+        manifest_path=Path(""),
+        stdout_path=None,
+        stderr_path=None,
+        trace_events_path=None,
+        duration_seconds=0.0,
+        tags=(),
+        metadata={"followup_of": "missing-parent"},
+    )
+    monkeypatch.setattr(module, "list_agent_runs", lambda *_args, **_kwargs: [missing_parent])
+    orphan_lineage = module.agent_lineage_payload(tmp_path, run_id="orphan")
+    assert orphan_lineage["ancestors"] == []

--- a/test/test_audience_bridges.py
+++ b/test/test_audience_bridges.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import builtins
 import json
 from pathlib import Path
 import subprocess
@@ -187,6 +188,13 @@ def test_hf_space_export_edges_and_secret_scan(tmp_path: Path) -> None:
 
 def test_mlflow_vscode_and_workflow_handoff_exports(tmp_path: Path) -> None:
     manifest_path = _write_manifest(tmp_path)
+    manifest_payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest_payload["validations"][0]["details"] = {
+        "score": 1.25,
+        "accepted": True,
+        "attempts": 2,
+    }
+    manifest_path.write_text(json.dumps(manifest_payload), encoding="utf-8")
 
     mlflow_payload = bridge_cli.export_mlflow_handoff(
         manifest_path,
@@ -194,6 +202,8 @@ def test_mlflow_vscode_and_workflow_handoff_exports(tmp_path: Path) -> None:
     )
     assert mlflow_payload["params"]["agilab_app"] == "demo_project"
     assert mlflow_payload["metrics"]["duration_seconds"] == 1.25
+    assert mlflow_payload["metrics"]["schema_accepted"] == 1.0
+    assert mlflow_payload["metrics"]["schema_attempts"] == 2.0
 
     imported = bridge_cli.import_mlflow_handoff(
         "demo",
@@ -205,6 +215,8 @@ def test_mlflow_vscode_and_workflow_handoff_exports(tmp_path: Path) -> None:
     vscode = bridge_cli.init_vscode_bridge(tmp_path / "workspace", force=True)
     assert any(path.endswith(".vscode/tasks.json") for path in vscode["files"])
     assert (tmp_path / "workspace" / "AGILAB_QUICKSTART.md").is_file()
+    with pytest.raises(FileExistsError, match="already exists"):
+        bridge_cli.init_vscode_bridge(tmp_path / "workspace")
 
     airflow = bridge_cli.export_airflow_dag(
         manifest_path,
@@ -289,6 +301,8 @@ def test_bridge_cli_helper_edges_and_duckdb_inputs(tmp_path: Path, capsys) -> No
     assert bridge_cli._resolve_artifact_path(str(tmp_path / "absolute.txt"), tmp_path / "run.json") == (
         tmp_path / "absolute.txt"
     )
+    assert bridge_cli._resolve_artifact_path("relative.txt", tmp_path / "run.json") == tmp_path / "relative.txt"
+    assert bridge_cli._markdown_cell("a|b\nc") == "a\\|b<br>c"
 
     notebook = tmp_path / "bad.ipynb"
     notebook.write_text("[]\n", encoding="utf-8")
@@ -354,6 +368,69 @@ def test_bridge_cli_helper_edges_and_duckdb_inputs(tmp_path: Path, capsys) -> No
 
     with pytest.raises(RuntimeError, match="MLflow import MVP requires"):
         bridge_cli.import_mlflow_handoff("demo", tmp_path / "mlflow.json")
+
+
+def test_bridge_cli_remaining_failure_edges(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    notebook = tmp_path / "demo.ipynb"
+    _write_minimal_notebook(notebook)
+
+    original_import = builtins.__import__
+
+    def block_notebook_import(name, *args, **kwargs):
+        if name == "nbformat":
+            raise ModuleNotFoundError("nbformat")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", block_notebook_import)
+    with pytest.raises(RuntimeError, match="optional notebook dependencies"):
+        bridge_cli._execute_notebook_with_nbclient(
+            notebook,
+            tmp_path / "executed.ipynb",
+            tmp_path,
+            tmp_path,
+            {},
+            1,
+            None,
+            False,
+        )
+    monkeypatch.undo()
+
+    bridge_cli._redact_notebook_text_fields(tmp_path / "missing.ipynb")
+    invalid = tmp_path / "invalid-redact.ipynb"
+    invalid.write_text("[]\n", encoding="utf-8")
+    bridge_cli._redact_notebook_text_fields(invalid)
+
+    def status_fail_executor(prepared, executed, *_args):
+        executed.write_text(prepared.read_text(encoding="utf-8"), encoding="utf-8")
+        return {"status": "error", "stdout": "partial", "stderr": "failed"}
+
+    payload = bridge_cli.run_notebook_sandbox(
+        notebook,
+        tmp_path / "notebook-status-fail",
+        executor=status_fail_executor,
+    )
+    assert payload["status"] == "fail"
+    assert "failed" in Path(payload["stderr_log"]).read_text(encoding="utf-8")
+
+    def block_duckdb_import(name, *args, **kwargs):
+        if name == "duckdb":
+            raise ModuleNotFoundError("duckdb")
+        return original_import(name, *args, **kwargs)
+
+    query = tmp_path / "query.sql"
+    query.write_text("select 1", encoding="utf-8")
+    monkeypatch.setattr(builtins, "__import__", block_duckdb_import)
+    with pytest.raises(RuntimeError, match="DuckDB bridge requires"):
+        bridge_cli.run_duckdb_query(query, tmp_path / "duckdb-missing")
+    monkeypatch.undo()
+
+    calls: list[list[str]] = []
+    monkeypatch.setattr(mcp_server, "main", lambda argv: calls.append(list(argv)) or 17)
+    assert bridge_cli.main(["mcp", "--", "serve"]) == 17
+    assert calls == [["serve"]]
 
 
 def _write_minimal_notebook(path: Path, source: str = "print('hello')") -> Path:

--- a/test/test_environment_health.py
+++ b/test/test_environment_health.py
@@ -288,6 +288,10 @@ def test_environment_health_remaining_helper_edges(tmp_path, monkeypatch):
         def __str__(self):
             return "bad-path"
 
+    class BadNestedPath(BadPath):
+        def __str__(self):
+            return f"dir{environment_health.os.sep}bad-path"
+
     assert environment_health.render_environment_details(SimpleNamespace(), []) is None
     assert environment_health.data_share_content_summary(None) == (
         "not configured",
@@ -299,6 +303,7 @@ def test_environment_health_remaining_helper_edges(tmp_path, monkeypatch):
     )
     assert environment_health.path_status(BadPath()) == ("not configured", "bad-path")
     assert environment_health.compact_path_caption("/") == "/"
+    assert environment_health.compact_path_caption(BadNestedPath()) == "bad-path in dir"
 
     fifo_path = tmp_path / "fifo"
     if hasattr(environment_health.os, "mkfifo"):
@@ -311,18 +316,36 @@ def test_environment_health_remaining_helper_edges(tmp_path, monkeypatch):
     def raise_walk(_path):
         raise OSError("walk unavailable")
 
-    monkeypatch.setattr(environment_health.os, "walk", raise_walk)
-    assert environment_health.data_share_content_summary(data_dir)[0] == "unknown"
-    monkeypatch.undo()
+    with monkeypatch.context() as scoped:
+        scoped.setattr(environment_health.os, "walk", raise_walk)
+        assert environment_health.data_share_content_summary(data_dir)[0] == "unknown"
+
+    stat_error_dir = tmp_path / "stat-error"
+    stat_error_dir.mkdir()
+    stat_error_file = stat_error_dir / "item.txt"
+    stat_error_file.write_text("x", encoding="utf-8")
+    original_stat = environment_health.Path.stat
+
+    def stat_raises_for_item(self, *args, **kwargs):
+        if self == stat_error_file:
+            raise OSError("stat denied")
+        return original_stat(self, *args, **kwargs)
+
+    with monkeypatch.context() as scoped:
+        scoped.setattr(environment_health.Path, "stat", stat_raises_for_item)
+        assert environment_health.data_share_content_summary(stat_error_dir) == (
+            "unknown",
+            str(stat_error_dir),
+        )
 
     project = tmp_path / "project"
     project.mkdir()
     (project / "code.py").write_text("print('ok')\n", encoding="utf-8")
     assert environment_health.latest_project_mtime(project) != "unknown"
 
-    monkeypatch.setattr(environment_health.os, "walk", raise_walk)
-    assert environment_health.latest_project_mtime(project) == "unknown"
-    monkeypatch.undo()
+    with monkeypatch.context() as scoped:
+        scoped.setattr(environment_health.os, "walk", raise_walk)
+        assert environment_health.latest_project_mtime(project) == "unknown"
 
     assert environment_health._environment_mapping(SimpleNamespace(envars=["not", "mapping"])) == {}
     assert environment_health._looks_placeholder_secret("   ") is True
@@ -358,4 +381,49 @@ def test_environment_health_remaining_helper_edges(tmp_path, monkeypatch):
     assert environment_health._is_local_worker_host("[::1]:8786") is True
     assert environment_health._cluster_has_nonlocal_workers({"workers": "[]"}) is False
     assert environment_health._cluster_has_nonlocal_workers({"workers": "worker-a"}) is True
+
+    runenv = tmp_path / "runenv"
+    runenv.mkdir()
+    original_glob = environment_health.Path.glob
+
+    def glob_raises(self, pattern):
+        if self == runenv and pattern == "run_*.log":
+            raise OSError("glob denied")
+        return original_glob(self, pattern)
+
+    with monkeypatch.context() as scoped:
+        scoped.setattr(environment_health.Path, "glob", glob_raises)
+        assert environment_health.run_history_summary(SimpleNamespace(runenv=runenv)) == (
+            "0",
+            "run log directory unavailable",
+        )
+
+    (runenv / "run_bad.log").write_text("bad\n", encoding="utf-8")
+
+    def stat_always_raises(self, *args, **kwargs):
+        if self.name == "run_bad.log":
+            raise OSError("stat denied")
+        return original_stat(self, *args, **kwargs)
+
+    original_is_file = environment_health.Path.is_file
+
+    def is_file_for_bad_log(self, *args, **kwargs):
+        if self.name == "run_bad.log":
+            return True
+        return original_is_file(self, *args, **kwargs)
+
+    with monkeypatch.context() as scoped:
+        scoped.setattr(environment_health.Path, "stat", stat_always_raises)
+        scoped.setattr(environment_health.Path, "is_file", is_file_for_bad_log)
+        scoped.setattr(
+            environment_health.Path,
+            "glob",
+            lambda self, pattern: [runenv / "run_bad.log"]
+            if self == runenv and pattern == "run_*.log"
+            else original_glob(self, pattern),
+        )
+        assert environment_health.run_history_summary(SimpleNamespace(runenv=runenv)) == (
+            "1",
+            "latest run log unavailable",
+        )
     assert environment_health._resolve_share_path(SimpleNamespace(), "relative") == Path("relative")

--- a/test/test_kubernetes_job.py
+++ b/test/test_kubernetes_job.py
@@ -83,6 +83,11 @@ def test_kubernetes_job_renderers_are_deterministic() -> None:
     assert '- name: "AGILAB_ACTIVE_APP"' in yaml_text
     assert json.loads(json_text)["metadata"]["name"] == "agilab-demo-project"
     assert kubernetes_job.kubectl_apply_command("/tmp/job.yaml") == "kubectl apply -f /tmp/job.yaml"
+    with pytest.raises(ValueError, match="unsupported manifest format"):
+        kubernetes_job.render_manifest(manifest, output_format="toml")
+    assert "empty:\n  []" in "\n".join(kubernetes_job._yaml_lines({"empty": []}))
+    assert "- {}" in "\n".join(kubernetes_job._yaml_lines([{}]))
+    assert "-\n  - 1" in "\n".join(kubernetes_job._yaml_lines([[1]]))
 
 
 def test_kubernetes_job_cli_writes_manifest_and_accepts_command_after_separator(
@@ -126,6 +131,23 @@ def test_kubernetes_job_cli_reports_bad_environment_assignment() -> None:
 
     assert exc_info.value.code == 2
 
+    with pytest.raises(ValueError, match="invalid Kubernetes"):
+        kubernetes_job.parse_env_assignments(["1_BAD=value"])
+
+    with pytest.raises(ValueError, match="app is required"):
+        kubernetes_job.build_kubernetes_job_manifest(
+            kubernetes_job.KubernetesJobConfig(app="", image="agilab:local")
+        )
+    with pytest.raises(ValueError, match="image is required"):
+        kubernetes_job.build_kubernetes_job_manifest(
+            kubernetes_job.KubernetesJobConfig(app="demo", image="")
+        )
+
+    manifest = kubernetes_job.build_kubernetes_job_manifest(
+        kubernetes_job.KubernetesJobConfig(app="demo", image="agilab:local", command=("",))
+    )
+    assert manifest["spec"]["template"]["spec"]["containers"][0]["command"] == ["python"]
+
 
 def test_kubernetes_job_module_entrypoint_reads_process_argv(monkeypatch, capsys) -> None:
     monkeypatch.setattr(
@@ -146,3 +168,21 @@ def test_kubernetes_job_module_entrypoint_reads_process_argv(monkeypatch, capsys
 
     manifest = json.loads(capsys.readouterr().out)
     assert manifest["metadata"]["name"] == "agilab-demo-project"
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "python -m agilab.kubernetes_job",
+            "manifest",
+            "--app",
+            "demo_project",
+            "--image",
+            "agilab:local",
+            "--format",
+            "json",
+        ],
+    )
+
+    assert kubernetes_job.main() == 0
+    assert json.loads(capsys.readouterr().out)["metadata"]["name"] == "agilab-demo-project"

--- a/test/test_notebook_demo.py
+++ b/test/test_notebook_demo.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import builtins
 import json
 from pathlib import Path
 import sys
@@ -62,6 +63,7 @@ def test_resolve_notebook_apps_path_reports_install_hint(monkeypatch, tmp_path: 
 
 def test_notebook_demo_package_and_installed_app_resolution_edges(monkeypatch, tmp_path: Path) -> None:
     assert notebook_demo._normalise_project_app("") == "minimal_app_project"
+    assert notebook_demo._normalise_project_app("   ") == "minimal_app_project"
     assert notebook_demo._normalise_project_app("weather-forecast") == "weather_forecast_project"
     assert notebook_demo._app_aliases("weather_forecast_project") == (
         "weather_forecast_project",
@@ -98,9 +100,26 @@ def test_notebook_demo_package_and_installed_app_resolution_edges(monkeypatch, t
     monkeypatch.setattr(
         notebook_demo.importlib.util,
         "find_spec",
+        lambda _package: SimpleNamespace(submodule_search_locations=[], origin=None),
+    )
+    assert notebook_demo._package_dir("demo") is None
+    monkeypatch.setattr(
+        notebook_demo.importlib.util,
+        "find_spec",
         lambda _package: (_ for _ in ()).throw(ValueError("bad spec")),
     )
     assert notebook_demo._package_dir("demo") is None
+
+    original_import = builtins.__import__
+
+    def block_registry_import(name, *args, **kwargs):
+        if name == "agi_env.app_provider_registry":
+            raise ImportError("missing registry")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", block_registry_import)
+    assert notebook_demo._installed_app_project_root("weather_forecast_project") is None
+    monkeypatch.undo()
 
     provider = ModuleType("agi_env.app_provider_registry")
     provider.resolve_installed_app_project = lambda _app: app_root
@@ -114,11 +133,27 @@ def test_notebook_demo_package_and_installed_app_resolution_edges(monkeypatch, t
     monkeypatch.setattr(notebook_demo, "_installed_app_project_root", lambda _app: None)
     assert notebook_demo.resolve_notebook_apps_path("weather_forecast", start=tmp_path / "missing") == builtin_root
 
+    apps_package_root = tmp_path / "apps_package"
+    _make_app(apps_package_root, "weather_forecast_project")
+    monkeypatch.setattr(
+        notebook_demo,
+        "_package_dir",
+        lambda package: apps_package_root if package == "agilab.apps" else None,
+    )
+    assert notebook_demo.resolve_notebook_apps_path("weather_forecast", start=tmp_path / "missing") == apps_package_root
+
     installed_root = tmp_path / "installed" / "standalone_project"
     _make_app(installed_root.parent, "standalone_project")
     monkeypatch.setattr(notebook_demo, "_package_dir", lambda _package: None)
     monkeypatch.setattr(notebook_demo, "_installed_app_project_root", lambda _app: installed_root)
     assert notebook_demo.resolve_notebook_apps_path("standalone_project", start=tmp_path / "missing") == installed_root.parent
+    detached_project = tmp_path / "installed" / "detached_project"
+    monkeypatch.setattr(notebook_demo, "_installed_app_project_root", lambda _app: detached_project)
+    assert notebook_demo.resolve_notebook_apps_path("detached_project", start=tmp_path / "missing") == detached_project.parent
+
+    request = SimpleNamespace(workers={"remote": 2}, mode="local")
+    assert notebook_demo._workers_from_request(request, None) == {"remote": 2}
+    assert notebook_demo._modes_from_request(request, None) == notebook_demo.DEFAULT_LOCAL_MODE
 
 
 def test_notebook_local_request_uses_visible_local_defaults(monkeypatch) -> None:


### PR DESCRIPTION
Add low-risk test coverage for agent-run rendering, bridge failure paths, environment health edge cases, Kubernetes manifest helpers, evidence proof-capsule helpers, and notebook demo app resolution.\n\nValidation:\n- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_evidence_contract.py test/test_workflow_ui.py test/test_ui_pages.py\n- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_agent_run.py test/test_audience_bridges.py test/test_environment_health.py test/test_kubernetes_job.py\n- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_notebook_demo.py\n- uv --preview-features extra-build-dependencies run python tools/impact_validate.py --staged