### PR TITLE
Harden playground args and docs redundancy checks

### DIFF
--- a/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground_worker/pytorch_playground_worker.py
+++ b/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground_worker/pytorch_playground_worker.py
@@ -45,7 +45,10 @@ def _artifact_dir(env: object, leaf: str) -> Path:
 def _args_with_defaults(value: Any) -> PytorchPlaygroundArgs:
     if isinstance(value, PytorchPlaygroundArgs):
         return value
-    if isinstance(value, dict):
+    model_dump = getattr(value, "model_dump", None)
+    if value.__class__.__name__ == "PytorchPlaygroundArgs" and callable(model_dump):
+        raw = model_dump(mode="json")
+    elif isinstance(value, dict):
         raw = dict(value)
     elif isinstance(value, SimpleNamespace):
         raw = vars(value).copy()

--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground_worker/pytorch_playground_worker.py
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground_worker/pytorch_playground_worker.py
@@ -45,7 +45,10 @@ def _artifact_dir(env: object, leaf: str) -> Path:
 def _args_with_defaults(value: Any) -> PytorchPlaygroundArgs:
     if isinstance(value, PytorchPlaygroundArgs):
         return value
-    if isinstance(value, dict):
+    model_dump = getattr(value, "model_dump", None)
+    if value.__class__.__name__ == "PytorchPlaygroundArgs" and callable(model_dump):
+        raw = model_dump(mode="json")
+    elif isinstance(value, dict):
         raw = dict(value)
     elif isinstance(value, SimpleNamespace):
         raw = vars(value).copy()

--- a/test/test_docs_redundancy.py
+++ b/test/test_docs_redundancy.py
@@ -46,3 +46,24 @@ def test_docs_redundancy_check_rejects_nearby_duplicate_prose(tmp_path: Path) ->
     assert len(violations) == 1
     assert violations[0].first_line == 5
     assert violations[0].second_line == 7
+
+
+def test_docs_redundancy_check_ignores_rst_code_blocks(tmp_path: Path) -> None:
+    module = _load_module()
+    page = tmp_path / "page.rst"
+    page.write_text(
+        "\n".join(
+            [
+                "Example",
+                "=======",
+                "",
+                ".. code-block:: toml",
+                "",
+                '   entrypoint = "pytorch_playground/app_surface.py"',
+                '   entrypoint = "pytorch_playground/app_surface.py"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    assert module.collect_violations(tmp_path) == []

--- a/test/test_pytorch_playground_app.py
+++ b/test/test_pytorch_playground_app.py
@@ -3131,6 +3131,16 @@ def test_pytorch_playground_worker_helper_and_dispatch_edges(
     assert worker_module._args_with_defaults(args.model_dump(mode="json")).sample_count == 96
     assert worker_module._args_with_defaults(SimpleNamespace(sample_count=128, _private="skip")).sample_count == 128
 
+    ForeignArgs = type(
+        "PytorchPlaygroundArgs",
+        (),
+        {"model_dump": lambda self, **_kwargs: {"sample_count": 144}},
+    )
+    foreign_args = ForeignArgs()
+    parsed_foreign_args = worker_module._args_with_defaults(foreign_args)
+    assert isinstance(parsed_foreign_args, args_module.PytorchPlaygroundArgs)
+    assert parsed_foreign_args.sample_count == 144
+
     class ArgsObject:
         def __init__(self):
             self.sample_count = 160

--- a/test/test_tools_surface_contract.py
+++ b/test/test_tools_surface_contract.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 from pathlib import Path
 
 
-# Current public release tooling keeps repository, release, HF sync, and
-# guardrail entrypoints top-level so workflows can call them directly.
-TOOLS_SURFACE_BUDGET = 163
+# Current public release tooling keeps repository, release, HF sync, shared
+# go/no-go gates, and guardrail entrypoints top-level so workflows can call them
+# directly.
+TOOLS_SURFACE_BUDGET = 164
 
 
 def test_top_level_tools_surface_stays_within_budget() -> None:

--- a/tools/docs_redundancy_check.py
+++ b/tools/docs_redundancy_check.py
@@ -94,6 +94,12 @@ def collect_violations(root: Path) -> list[RedundancyViolation]:
                 in_rst_literal = False
                 literal_indent = None
 
+            if stripped.startswith(".. code-block::") or stripped.startswith(".. sourcecode::"):
+                in_rst_literal = True
+                literal_indent = None
+                recent.clear()
+                continue
+
             if line.rstrip().endswith("::"):
                 in_rst_literal = True
                 literal_indent = None


### PR DESCRIPTION
## Summary
- Accept same-named PyTorch Playground args models from copied/package contexts when they expose `model_dump`
- Ignore explicit RST code-block/sourcecode blocks in the docs redundancy checker
- Adjust the tools surface budget for the added guardrail tool

## Validation
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_docs_redundancy.py test/test_tools_surface_contract.py test/test_pytorch_playground_app.py`
- `uv --preview-features extra-build-dependencies run --extra dev ruff check src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground_worker/pytorch_playground_worker.py src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground_worker/pytorch_playground_worker.py tools/docs_redundancy_check.py test/test_docs_redundancy.py test/test_tools_surface_contract.py test/test_pytorch_playground_app.py`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui`