### PR TITLE
Refine PyTorch Playground args identity handling

### DIFF
--- a/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground_worker/pytorch_playground_worker.py
+++ b/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground_worker/pytorch_playground_worker.py
@@ -47,6 +47,8 @@ def _args_with_defaults(value: Any) -> PytorchPlaygroundArgs:
         return value
     model_dump = getattr(value, "model_dump", None)
     if value.__class__.__name__ == "PytorchPlaygroundArgs" and callable(model_dump):
+        if value.__class__.__module__ == PytorchPlaygroundArgs.__module__:
+            return value
         raw = model_dump(mode="json")
     elif isinstance(value, dict):
         raw = dict(value)

--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground_worker/pytorch_playground_worker.py
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground_worker/pytorch_playground_worker.py
@@ -47,6 +47,8 @@ def _args_with_defaults(value: Any) -> PytorchPlaygroundArgs:
         return value
     model_dump = getattr(value, "model_dump", None)
     if value.__class__.__name__ == "PytorchPlaygroundArgs" and callable(model_dump):
+        if value.__class__.__module__ == PytorchPlaygroundArgs.__module__:
+            return value
         raw = model_dump(mode="json")
     elif isinstance(value, dict):
         raw = dict(value)

--- a/test/test_pytorch_playground_app.py
+++ b/test/test_pytorch_playground_app.py
@@ -3141,6 +3141,17 @@ def test_pytorch_playground_worker_helper_and_dispatch_edges(
     assert isinstance(parsed_foreign_args, args_module.PytorchPlaygroundArgs)
     assert parsed_foreign_args.sample_count == 144
 
+    SameModuleArgs = type(
+        "PytorchPlaygroundArgs",
+        (),
+        {
+            "__module__": args_module.PytorchPlaygroundArgs.__module__,
+            "model_dump": lambda self, **_kwargs: {"sample_count": 152},
+        },
+    )
+    same_module_args = SameModuleArgs()
+    assert worker_module._args_with_defaults(same_module_args) is same_module_args
+
     class ArgsObject:
         def __init__(self):
             self.sample_count = 160


### PR DESCRIPTION
## Summary
- Preserve local `PytorchPlaygroundArgs` objects when the class/module matches the worker runtime
- Convert same-named copied/package-context args through `model_dump` into the local model instead of returning a foreign object
- Mirror the worker fix into the packaged app payload

## Validation
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_pytorch_playground_app.py`
- `uv --preview-features extra-build-dependencies run --extra dev ruff check src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground_worker/pytorch_playground_worker.py src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground_worker/pytorch_playground_worker.py test/test_pytorch_playground_app.py`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui`