### PR TITLE
Resolve PyTorch playground args model dynamically

### DIFF
--- a/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground_worker/pytorch_playground_worker.py
+++ b/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground_worker/pytorch_playground_worker.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import shutil
+import sys
 import time
 from pathlib import Path
 from types import SimpleNamespace
@@ -30,6 +31,14 @@ logger = logging.getLogger(__name__)
 _runtime: dict[str, object] = {}
 
 
+def _args_model() -> type[Any]:
+    module = sys.modules.get("pytorch_playground.app_args")
+    model = getattr(module, "PytorchPlaygroundArgs", None)
+    if isinstance(model, type) and model.__name__ == "PytorchPlaygroundArgs":
+        return model
+    return PytorchPlaygroundArgs
+
+
 def _artifact_dir(env: object, leaf: str) -> Path:
     export_root = getattr(env, "AGILAB_EXPORT_ABS", None)
     target = str(getattr(env, "target", "") or "")
@@ -43,11 +52,12 @@ def _artifact_dir(env: object, leaf: str) -> Path:
 
 
 def _args_with_defaults(value: Any) -> PytorchPlaygroundArgs:
-    if isinstance(value, PytorchPlaygroundArgs):
+    args_model = _args_model()
+    if isinstance(value, (PytorchPlaygroundArgs, args_model)):
         return value
     model_dump = getattr(value, "model_dump", None)
     if value.__class__.__name__ == "PytorchPlaygroundArgs" and callable(model_dump):
-        if value.__class__.__module__ == PytorchPlaygroundArgs.__module__:
+        if value.__class__.__module__ == args_model.__module__:
             return value
         raw = model_dump(mode="json")
     elif isinstance(value, dict):
@@ -56,7 +66,7 @@ def _args_with_defaults(value: Any) -> PytorchPlaygroundArgs:
         raw = vars(value).copy()
     else:
         raw = vars(value).copy()
-    return PytorchPlaygroundArgs(**{key: val for key, val in raw.items() if not key.startswith("_")})
+    return args_model(**{key: val for key, val in raw.items() if not key.startswith("_")})
 
 
 def _write_artifact_files(root: Path, files: dict[str, bytes]) -> None:

--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground_worker/pytorch_playground_worker.py
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground_worker/pytorch_playground_worker.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import shutil
+import sys
 import time
 from pathlib import Path
 from types import SimpleNamespace
@@ -30,6 +31,14 @@ logger = logging.getLogger(__name__)
 _runtime: dict[str, object] = {}
 
 
+def _args_model() -> type[Any]:
+    module = sys.modules.get("pytorch_playground.app_args")
+    model = getattr(module, "PytorchPlaygroundArgs", None)
+    if isinstance(model, type) and model.__name__ == "PytorchPlaygroundArgs":
+        return model
+    return PytorchPlaygroundArgs
+
+
 def _artifact_dir(env: object, leaf: str) -> Path:
     export_root = getattr(env, "AGILAB_EXPORT_ABS", None)
     target = str(getattr(env, "target", "") or "")
@@ -43,11 +52,12 @@ def _artifact_dir(env: object, leaf: str) -> Path:
 
 
 def _args_with_defaults(value: Any) -> PytorchPlaygroundArgs:
-    if isinstance(value, PytorchPlaygroundArgs):
+    args_model = _args_model()
+    if isinstance(value, (PytorchPlaygroundArgs, args_model)):
         return value
     model_dump = getattr(value, "model_dump", None)
     if value.__class__.__name__ == "PytorchPlaygroundArgs" and callable(model_dump):
-        if value.__class__.__module__ == PytorchPlaygroundArgs.__module__:
+        if value.__class__.__module__ == args_model.__module__:
             return value
         raw = model_dump(mode="json")
     elif isinstance(value, dict):
@@ -56,7 +66,7 @@ def _args_with_defaults(value: Any) -> PytorchPlaygroundArgs:
         raw = vars(value).copy()
     else:
         raw = vars(value).copy()
-    return PytorchPlaygroundArgs(**{key: val for key, val in raw.items() if not key.startswith("_")})
+    return args_model(**{key: val for key, val in raw.items() if not key.startswith("_")})
 
 
 def _write_artifact_files(root: Path, files: dict[str, bytes]) -> None:

--- a/test/test_pytorch_playground_app.py
+++ b/test/test_pytorch_playground_app.py
@@ -3152,6 +3152,24 @@ def test_pytorch_playground_worker_helper_and_dispatch_edges(
     same_module_args = SameModuleArgs()
     assert worker_module._args_with_defaults(same_module_args) is same_module_args
 
+    def _replacement_args_init(self, **kwargs):
+        self.sample_count = kwargs.get("sample_count", 0)
+
+    ReplacementArgs = type(
+        "PytorchPlaygroundArgs",
+        (),
+        {
+            "__module__": args_module.__name__,
+            "__init__": _replacement_args_init,
+        },
+    )
+    with monkeypatch.context() as module_patch:
+        module_patch.setattr(args_module, "PytorchPlaygroundArgs", ReplacementArgs)
+        replacement_args = worker_module._args_with_defaults({"sample_count": 168})
+        assert isinstance(replacement_args, ReplacementArgs)
+        assert replacement_args.sample_count == 168
+        assert worker_module._args_with_defaults(replacement_args) is replacement_args
+
     class ArgsObject:
         def __init__(self):
             self.sample_count = 160


### PR DESCRIPTION
## Summary
- Resolve the active PyTorch playground args model from sys.modules to handle import identity drift.
- Preserve active-model identity while keeping cross-module copies normalized.
- Add regression coverage for dynamic args model replacement.

## Validation
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_pytorch_playground_app.py
- uv --preview-features extra-build-dependencies run ruff check src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground_worker/pytorch_playground_worker.py src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground_worker/pytorch_playground_worker.py test/test_pytorch_playground_app.py
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui
- git diff --name-only origin/main..HEAD | xargs ./dev release --files