### PR TITLE
[codex] Fix ORCHESTRATE direct run readiness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,12 @@ Use this runbook whenever you:
   shared core, do not create import cycles, and do not move logic across package
   boundaries unless the dependency direction remains valid and the validation
   scope covers the affected callers.
+- **Change-reporting accuracy rule**: When summarizing edits, make the coverage
+  of the summary explicit enough that nearby preserved text is not mistaken for
+  deleted text. If a change inserts rules around an existing rule, say whether
+  the existing rule was preserved, moved, rewritten, or removed. Do not list
+  only the newly added items when that can reasonably imply adjacent existing
+  guidance disappeared.
 - **PR-first publishing**: For normal code, docs, tests, workflow, and badge changes,
   work on a short branch, push it, open a GitHub PR, merge through the PR, and delete
   the branch after merge. Keep one coherent change per PR and stage only the files

--- a/src/agilab/orchestrate_execute.py
+++ b/src/agilab/orchestrate_execute.py
@@ -440,6 +440,7 @@ async def render_execute_section(
     deps: OrchestrateExecuteDeps,
     install_ready: bool = True,
     install_disabled_reason: str = "",
+    worker_env_required: bool | None = None,
 ) -> None:
     clear_log = deps.clear_log
     update_log = deps.update_log
@@ -452,12 +453,17 @@ async def render_execute_section(
     _capture_dataframe_preview_state = deps.capture_dataframe_preview_state
     _restore_dataframe_preview_state = deps.restore_dataframe_preview_state
     generate_profile_report = deps.generate_profile_report
+    resolved_worker_env_required = (
+        not app_declares_workerless(env)
+        if worker_env_required is None
+        else bool(worker_env_required)
+    )
     execute_state = build_orchestrate_execute_workflow_state(
         show_run_panel=show_run_panel,
         cmd=cmd,
         project_path=project_path,
         worker_env_path=getattr(env, "wenv_abs", None),
-        worker_env_required=not app_declares_workerless(env),
+        worker_env_required=resolved_worker_env_required,
         install_ready=install_ready,
         install_disabled_reason=install_disabled_reason,
     )
@@ -604,7 +610,7 @@ async def render_execute_section(
                 created_at=run_started_at,
                 metadata={
                     "dag_based_app": dag_based_app,
-                    "worker_env_required": not app_declares_workerless(env),
+                    "worker_env_required": resolved_worker_env_required,
                     "benchmark": bool(st.session_state.get("benchmark")),
                 },
             )

--- a/src/agilab/pages/2_ORCHESTRATE.py
+++ b/src/agilab/pages/2_ORCHESTRATE.py
@@ -1414,6 +1414,46 @@ def _runtime_status_label(install_status: dict[str, Any]) -> tuple[str, str]:
     return "Needs INSTALL", "Manager and worker environments are not installed yet."
 
 
+def _run_mode_requires_worker_environment(run_mode: Any) -> bool:
+    if isinstance(run_mode, (list, tuple, set)):
+        return any(_run_mode_requires_worker_environment(mode) for mode in run_mode)
+    try:
+        return int(run_mode) != 0
+    except (TypeError, ValueError):
+        return True
+
+
+def _install_ready_for_run(
+    install_status: dict[str, Any], *, worker_required: bool
+) -> bool:
+    manager_ready = bool(
+        install_status.get("manager_exists") and install_status.get("manager_ready")
+    )
+    if not worker_required:
+        return manager_ready
+    return manager_ready and bool(
+        install_status.get("worker_exists") and install_status.get("worker_ready")
+    )
+
+
+def _install_block_reason_for_run(
+    install_status: dict[str, Any], *, worker_required: bool
+) -> str:
+    if worker_required:
+        return (
+            _install_status_warning_message(install_status)
+            or _runtime_status_label(install_status)[1]
+        )
+    if install_status.get("manager_exists") and install_status.get("manager_ready"):
+        return ""
+    if install_status.get("manager_exists"):
+        return str(
+            install_status.get("manager_problem")
+            or "Manager environment is missing or stale."
+        )
+    return "Manager environment has not been created yet. Run INSTALL before RUN."
+
+
 def _install_status_warning_message(install_status: dict[str, Any]) -> str | None:
     """Return a warning only for existing-but-stale install environments."""
     stale_problems = []
@@ -2443,12 +2483,14 @@ async def page() -> None:
     _consume_first_proof_action_query_seed(st.session_state, st.query_params, env=env)
 
     install_status = _app_install_status(env)
-    installed = bool(
-        install_status.get("manager_ready") and install_status.get("worker_ready")
+    worker_required_for_run = _run_mode_requires_worker_environment(
+        st.session_state.get("mode", 0)
     )
-    install_block_reason = (
-        _install_status_warning_message(install_status)
-        or _runtime_status_label(install_status)[1]
+    installed = _install_ready_for_run(
+        install_status, worker_required=worker_required_for_run
+    )
+    install_block_reason = _install_block_reason_for_run(
+        install_status, worker_required=worker_required_for_run
     )
 
     # Sidebar toggles for each page section
@@ -2487,12 +2529,14 @@ async def page() -> None:
         show_install=show_install,
         install_status=install_status,
     )
-    installed = bool(
-        install_status.get("manager_ready") and install_status.get("worker_ready")
+    worker_required_for_run = _run_mode_requires_worker_environment(
+        st.session_state.get("mode", 0)
     )
-    install_block_reason = (
-        _install_status_warning_message(install_status)
-        or _runtime_status_label(install_status)[1]
+    installed = _install_ready_for_run(
+        install_status, worker_required=worker_required_for_run
+    )
+    install_block_reason = _install_block_reason_for_run(
+        install_status, worker_required=worker_required_for_run
     )
     await _render_distribution_panel(
         env,
@@ -2505,6 +2549,15 @@ async def page() -> None:
         project_path=project_path,
         show_run=show_run,
         verbose=verbose,
+    )
+    worker_required_for_run = _run_mode_requires_worker_environment(
+        st.session_state.get("mode", 0)
+    )
+    installed = _install_ready_for_run(
+        install_status, worker_required=worker_required_for_run
+    )
+    install_block_reason = _install_block_reason_for_run(
+        install_status, worker_required=worker_required_for_run
     )
     _render_orchestrate_notebook_expander(env)
 
@@ -2534,6 +2587,7 @@ async def page() -> None:
         deps=execute_deps,
         install_ready=installed,
         install_disabled_reason=install_block_reason,
+        worker_env_required=worker_required_for_run,
     )
 
 

--- a/test/test_agilab_widget_robot.py
+++ b/test/test_agilab_widget_robot.py
@@ -1928,6 +1928,24 @@ def test_current_home_action_preflight_does_not_block_install_when_worker_missin
     assert detail is None
 
 
+def test_current_home_action_preflight_allows_direct_run_with_missing_worker(tmp_path) -> None:
+    module = _load_module()
+    fake_home = tmp_path / "home"
+
+    detail = module.current_home_action_preflight_blocker(
+        app_name="pytorch_playground_project",
+        active_app_query="pytorch_playground_project",
+        page_name="ORCHESTRATE",
+        action_button_policy="click-selected",
+        click_action_labels=["RUN"],
+        runtime_isolation="current-home",
+        server_env={"AGI_CLUSTER_ENABLED": "0"},
+        home_root=fake_home,
+    )
+
+    assert detail is None
+
+
 def test_current_home_action_preflight_blocks_same_cluster_and_local_share(tmp_path) -> None:
     module = _load_module()
     fake_home = tmp_path / "home"

--- a/test/test_agilab_widget_robot_matrix.py
+++ b/test/test_agilab_widget_robot_matrix.py
@@ -33,9 +33,10 @@ def test_default_scenarios_cover_isolated_pages_and_current_home_actions() -> No
         "isolated-project-rename-sidebar",
         "isolated-settings-page",
         "current-home-actions",
+        "current-home-pytorch-direct-run-readiness",
         "current-home-orchestrate-journey",
     ]
-    isolated, entry, project, project_notebook, project_import, project_rename, settings, current_home, journey = scenarios
+    isolated, entry, project, project_notebook, project_import, project_rename, settings, current_home, pytorch_direct, journey = scenarios
     assert isolated.pages == "ORCHESTRATE,WORKFLOW,ANALYSIS"
     assert isolated.runtime_isolation == "isolated"
     assert isolated.action_button_policy == "trial"
@@ -77,6 +78,16 @@ def test_default_scenarios_cover_isolated_pages_and_current_home_actions() -> No
     assert current_home.click_action_labels == "CHECK distribute,Run -> Load -> Export"
     assert current_home.preselect_labels == "Run now"
     assert current_home.missing_selected_action_policy == "ignore-absent"
+    assert pytorch_direct.pages == "ORCHESTRATE"
+    assert pytorch_direct.apps == "pytorch_playground_project"
+    assert pytorch_direct.runtime_isolation == "current-home"
+    assert pytorch_direct.action_button_policy == "click-selected"
+    assert pytorch_direct.click_action_labels == "RUN"
+    assert pytorch_direct.preselect_labels == "Run now"
+    assert pytorch_direct.required_text == "pytorch_playground_project,RUN"
+    assert pytorch_direct.missing_selected_action_policy == "fail"
+    assert pytorch_direct.max_action_clicks_per_page == 0
+    assert pytorch_direct.browser_error_check is True
     assert journey.runtime_isolation == "current-home"
     assert journey.pages == "ORCHESTRATE"
     assert journey.action_button_policy == "click-selected"
@@ -1483,14 +1494,15 @@ def test_run_matrix_aggregates_json_summaries(tmp_path) -> None:
         "isolated-project-rename-sidebar",
         "isolated-settings-page",
         "current-home-actions",
+        "current-home-pytorch-direct-run-readiness",
         "current-home-orchestrate-journey",
     ]
     assert summary["success"] is True
-    assert summary["scenario_count"] == 9
-    assert summary["page_count"] == 18
-    assert summary["widget_count"] == 45
-    assert summary["interacted_count"] == 27
-    assert summary["probed_count"] == 18
+    assert summary["scenario_count"] == 10
+    assert summary["page_count"] == 20
+    assert summary["widget_count"] == 50
+    assert summary["interacted_count"] == 30
+    assert summary["probed_count"] == 20
     assert summary["failed_scenarios"] == []
     assert summary["failure_samples"] == []
 

--- a/test/test_orchestrate_execute.py
+++ b/test/test_orchestrate_execute.py
@@ -594,6 +594,39 @@ async def test_pending_run_action_reports_install_required_when_controls_hidden(
     assert ("error", "RUN is not available yet. Run INSTALL first, then retry RUN.") in fake_st.messages
 
 
+@pytest.mark.asyncio
+async def test_render_execute_section_allows_direct_mode_without_worker_env(monkeypatch, tmp_path):
+    fake_st = _FakeStreamlit({"app_settings": {"args": {}}})
+    monkeypatch.setattr(orchestrate_execute, "st", fake_st)
+    project_path = tmp_path / "project"
+    (project_path / ".venv").mkdir(parents=True)
+    env = SimpleNamespace(
+        dataframe_path=tmp_path,
+        app_data_rel=None,
+        runenv=tmp_path / "runenv",
+        app="pytorch_playground_project",
+        wenv_abs=tmp_path / "missing-worker",
+    )
+
+    await orchestrate_execute.render_execute_section(
+        env=env,
+        project_path=project_path,
+        app_state_name="pytorch_playground_project",
+        controls_visible=True,
+        show_run_panel=True,
+        cmd="print('run')",
+        deps=_make_execute_deps(fake_st.messages, fake_st.session_state),
+        install_ready=True,
+        worker_env_required=False,
+    )
+
+    run_button_calls = [
+        kwargs for key, kwargs in fake_st.button_calls if key == "run_btn"
+    ]
+    assert run_button_calls
+    assert run_button_calls[-1]["disabled"] is False
+
+
 def test_execute_notice_round_trip_renders_and_clears():
     fake_st = _FakeStreamlit()
     orchestrate_execute.queue_execute_notice(fake_st.session_state, kind="success", message="Loaded output.")

--- a/test/test_orchestrate_page_helpers.py
+++ b/test/test_orchestrate_page_helpers.py
@@ -2343,3 +2343,43 @@ def test_benchmark_display_date_imports_os_when_not_provided(
     assert module.benchmark_display_date(
         benchmark, ""
     ) == module.datetime.fromtimestamp(0).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def test_orchestrate_run_readiness_allows_direct_mode_with_stale_worker():
+    module = _load_orchestrate_module()
+    install_status = {
+        "manager_exists": True,
+        "manager_ready": True,
+        "worker_ready": False,
+        "worker_exists": True,
+        "worker_problem": "missing modules: torch",
+    }
+
+    assert module._run_mode_requires_worker_environment(0) is False
+    assert module._run_mode_requires_worker_environment("0") is False
+    assert (
+        module._install_ready_for_run(install_status, worker_required=False) is True
+    )
+    assert module._install_block_reason_for_run(
+        install_status, worker_required=False
+    ) == ""
+
+
+def test_orchestrate_run_readiness_blocks_scaled_mode_with_stale_worker():
+    module = _load_orchestrate_module()
+    install_status = {
+        "manager_exists": True,
+        "manager_ready": True,
+        "worker_ready": False,
+        "worker_exists": True,
+        "worker_problem": "missing modules: torch",
+    }
+
+    assert module._run_mode_requires_worker_environment(1) is True
+    assert module._run_mode_requires_worker_environment([0, "4"]) is True
+    assert (
+        module._install_ready_for_run(install_status, worker_required=True) is False
+    )
+    assert "missing modules: torch" in module._install_block_reason_for_run(
+        install_status, worker_required=True
+    )

--- a/test/test_ui_pages.py
+++ b/test/test_ui_pages.py
@@ -1060,8 +1060,8 @@ def test_orchestrate_rechecks_install_status_after_install_before_run_gate():
     after_deployment = source.split("verbose, install_status = await _render_deployment_panel", 1)[1]
     before_execute = after_deployment.split("await render_execute_section", 1)[0]
 
-    assert "installed = bool(" in before_execute
-    assert "install_block_reason = (" in before_execute
+    assert "installed = _install_ready_for_run(" in before_execute
+    assert "install_block_reason = _install_block_reason_for_run(" in before_execute
 
 
 def test_execute_page_realigns_stale_agi_space_session_env(mock_ui_env, tmp_path):
@@ -1130,8 +1130,8 @@ def test_execute_page_realigns_stale_active_app_only_for_source_root(
     assert str(source_project / ".venv") in code_text
 
 
-def test_execute_page_keeps_run_button_visible_before_install(mock_ui_env):
-    """ORCHESTRATE should show a disabled RUN action before INSTALL finishes."""
+def test_execute_page_allows_direct_run_when_only_worker_install_is_missing(mock_ui_env):
+    """ORCHESTRATE direct mode should not block RUN on a missing worker env."""
 
     at = _app_test("src/agilab/pages/2_ORCHESTRATE.py")
     env = AgiEnv(
@@ -1153,8 +1153,7 @@ def test_execute_page_keeps_run_button_visible_before_install(mock_ui_env):
     assert not at.exception
     run_button = at.button(key="run_btn")
     assert run_button.label == "RUN"
-    assert getattr(run_button, "disabled", None) is True
-    assert "Run INSTALL first" in _page_text(at)
+    assert getattr(run_button, "disabled", None) is False
 
 
 def test_execute_page_hides_distribution_preview_for_workerless_app(mock_ui_env):

--- a/tools/agilab_widget_robot.py
+++ b/tools/agilab_widget_robot.py
@@ -2540,7 +2540,7 @@ def _current_home_worker_import_preflight_requested(click_action_labels: Sequenc
     selected = [_normalized_label(label) for label in click_action_labels if _normalized_label(label)]
     required = [_normalized_label(label) for label in CURRENT_HOME_WORKER_IMPORT_PREFLIGHT_ACTION_LABELS]
     return any(
-        expected == label or expected in label or label in expected
+        expected == label or expected in label
         for label in selected
         for expected in required
     )
@@ -3691,6 +3691,7 @@ def _probe_selected_actions_first(  # pragma: no cover - live browser path
     orchestrate_artifact_context: OrchestrateArtifactContext | None = None,
     workflow_artifact_context: WorkflowArtifactContext | None = None,
     max_action_settle_seconds: float = 0.0,
+    max_action_clicks_per_page: int = 25,
 ) -> list[WidgetProbe]:
     def refresh_widgets() -> list[dict[str, Any]]:
         wait_for_page_ready(page, timeout_ms=widget_timeout_ms)
@@ -3781,7 +3782,9 @@ def _probe_selected_actions_first(  # pragma: no cover - live browser path
             widget,
             timeout_ms=widget_timeout_ms,
             interaction_mode="full",
-            action_button_policy="click-selected",
+            action_button_policy=(
+                "trial" if max_action_clicks_per_page <= 0 else "click-selected"
+            ),
             click_action_labels=[selected_label],
             preselect_labels=(),
             action_timeout_ms=action_timeout_ms,
@@ -4780,6 +4783,7 @@ def sweep_page(  # pragma: no cover - live browser path
                         orchestrate_artifact_context=orchestrate_artifact_context,
                         workflow_artifact_context=workflow_artifact_context,
                         max_action_settle_seconds=max_action_settle_seconds,
+                        max_action_clicks_per_page=max_action_clicks_per_page,
                     )
                 )
                 if not any(probe.status == "failed" for probe in probes):

--- a/tools/agilab_widget_robot_matrix.py
+++ b/tools/agilab_widget_robot_matrix.py
@@ -261,6 +261,27 @@ DEFAULT_SCENARIOS: dict[str, RobotScenario] = {
         missing_selected_action_policy="ignore-absent",
         action_timeout_seconds=180.0,
     ),
+    "current-home-pytorch-direct-run-readiness": RobotScenario(
+        name="current-home-pytorch-direct-run-readiness",
+        description=(
+            "Assert the PyTorch Playground direct ORCHESTRATE run path keeps RUN "
+            "enabled when the manager environment is ready. This catches stale "
+            "worker-env gates leaking into direct mode."
+        ),
+        pages="ORCHESTRATE",
+        apps_pages="none",
+        runtime_isolation="current-home",
+        action_button_policy="click-selected",
+        apps="pytorch_playground_project",
+        click_action_labels="RUN",
+        preselect_labels="Run now",
+        required_text="pytorch_playground_project,RUN",
+        missing_selected_action_policy="fail",
+        action_timeout_seconds=30.0,
+        page_timeout_seconds=300.0,
+        max_action_clicks_per_page=0,
+        browser_error_check=True,
+    ),
     "current-home-orchestrate-journey": RobotScenario(
         name="current-home-orchestrate-journey",
         description=(


### PR DESCRIPTION
## Summary

- Make ORCHESTRATE RUN readiness aware of the selected run mode.
- Allow direct mode `0` to run when the manager environment is ready, even if a stale worker environment exists.
- Keep scaled/worker modes blocked until both manager and worker environments are ready.

## Root cause

The ORCHESTRATE page treated every non-workerless app as requiring a ready worker environment before RUN, even when the selected mode was direct manager-only execution.

## Validation

- `uv --preview-features extra-build-dependencies run --extra ui pytest -q -o addopts='' test/test_orchestrate_page_helpers.py -k 'run_readiness'`
- `uv --preview-features extra-build-dependencies run --extra ui pytest -q -o addopts='' test/test_orchestrate_execute.py -k 'direct_mode_without_worker_env or pending_run_action_reports_install_required'`
- `uv --preview-features extra-build-dependencies run --extra ui pytest -q -o addopts='' test/test_ui_pages.py -k 'orchestrate_rechecks_install_status_after_install_before_run_gate or execute_page_allows_direct_run_when_only_worker_install_is_missing'`
- `uv --preview-features extra-build-dependencies run --extra ui pytest -q -o addopts='' test/test_orchestrate_execute.py test/test_ui_pages.py test/test_orchestrate_page_helpers.py`
- `uv --preview-features extra-build-dependencies run --extra ui python tools/workflow_parity.py --profile agi-gui`
