### PR TITLE
Fix analysis view selection sync

### DIFF
--- a/src/agilab/main_page.py
+++ b/src/agilab/main_page.py
@@ -346,12 +346,6 @@ def render_page_context(*args: Any, **kwargs: Any) -> Any:
     return _workflow_ui_module.render_page_context(*args, **kwargs)
 
 
-def render_active_project_chip(*args: Any, **kwargs: Any) -> bool:
-    return _lazy_import_attr("agilab.page_bootstrap", "render_active_project_chip")(
-        *args, **kwargs
-    )
-
-
 # --- minimal session-state safety (add this block) ---
 def _pre_render_reset() -> None:
     # If last run asked for a reset, clear BEFORE widgets are created this run
@@ -970,7 +964,6 @@ def _render_navigation_context(
         pass
     render_sidebar_settings_link(env)
     render_pinned_expanders(st)
-    render_active_project_chip(st, env=env)
     if show_project_context:
         render_page_context(st, page_label=page_label, env=env)
 

--- a/src/agilab/page_bootstrap.py
+++ b/src/agilab/page_bootstrap.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import html
 import importlib
 import importlib.util
 from pathlib import Path
@@ -242,42 +241,6 @@ def configure_page_chrome(
         inject_theme(resources_path)
 
 
-def _active_project_label(env: Any | None) -> str:
-    """Return the display label for the currently selected project."""
-    if env is None:
-        return ""
-    for attr_name in ("app", "target", "active_app"):
-        value = getattr(env, attr_name, None)
-        text = str(value or "").strip()
-        if not text:
-            continue
-        return Path(text).name
-    return ""
-
-
-def render_active_project_chip(streamlit: Any, *, env: Any | None = None) -> bool:
-    """Render a compact selected-project chip in shared page chrome."""
-    project_label = _active_project_label(env)
-    if not project_label:
-        return False
-    escaped_label = html.escape(project_label)
-    streamlit.markdown(
-        (
-            "<style>"
-            ".agilab-active-project-chip{display:inline-flex;align-items:center;"
-            "gap:.35rem;border:1px solid rgba(49,51,63,.18);border-radius:999px;"
-            "padding:.18rem .58rem;margin:.2rem 0 .45rem 0;font-size:.78rem;"
-            "line-height:1.2;background:rgba(250,250,250,.78);color:rgba(49,51,63,.78);}"
-            ".agilab-active-project-chip span{font-weight:650;color:rgba(49,51,63,.96);}"
-            "</style>"
-            "<div class='agilab-active-project-chip'>Project: "
-            f"<span>{escaped_label}</span></div>"
-        ),
-        unsafe_allow_html=True,
-    )
-    return True
-
-
 def render_page_header(
     streamlit: Any,
     *,
@@ -306,7 +269,6 @@ def render_page_header(
 
     render_logo()
     render_pinned_expanders(streamlit)
-    render_active_project_chip(streamlit, env=env)
     if show_project_context and render_page_context is not None:
         render_page_context(streamlit, page_label=page_label, env=env)
 

--- a/src/agilab/pages/4_ANALYSIS.py
+++ b/src/agilab/pages/4_ANALYSIS.py
@@ -851,8 +851,11 @@ def exec_bg(
     stderr = open(agi_env.err_log, "ab", buffering=0)
     env = dict(os.environ)
     env.pop("PYTHONPATH", None)
+    env.pop("VIRTUAL_ENV", None)
     if process_env:
         env.update(process_env)
+        if not env.get("VIRTUAL_ENV"):
+            env.pop("VIRTUAL_ENV", None)
     command: str | list[str]
     if isinstance(cmd, str):
         command = cmd
@@ -1722,8 +1725,11 @@ def _migrate_declared_app_surface_config(
         and isinstance(seed_pages.get("view_module"), list)
         else []
     )
+    declared_app_ui_page = _declared_app_ui_page_config(active_app_path)
     if seed_restricts_views:
-        desired_modules = _dedupe_preserve_order(seed_modules or [_APP_UI_PAGE_KEY])
+        desired_modules = _dedupe_preserve_order(seed_modules)
+        if declared_app_ui_page is not None and not desired_modules:
+            desired_modules = [_APP_UI_PAGE_KEY]
         if pages.get("restrict_to_view_module") is not True:
             pages["restrict_to_view_module"] = True
             changed = True
@@ -1731,7 +1737,7 @@ def _migrate_declared_app_surface_config(
             pages["view_module"] = desired_modules
             changed = True
 
-    if _declared_app_ui_page_config(active_app_path) is None:
+    if declared_app_ui_page is None:
         if _APP_UI_PAGE_KEY in pages:
             del pages[_APP_UI_PAGE_KEY]
             changed = True
@@ -2320,9 +2326,12 @@ def _render_analysis_sidebar_view_launcher(
     resolved_pages: dict[str, Path],
     custom_view_lookup: dict[str, Path],
 ) -> None:
-    launch_options = list(dict.fromkeys([*view_names, *selected_views]))
+    launch_options = list(dict.fromkeys(selected_views))
     if not launch_options:
-        st.sidebar.info("No analysis views available.")
+        if view_names:
+            st.sidebar.info("No analysis views selected.")
+        else:
+            st.sidebar.info("No analysis views available.")
         return
 
     builtin_names = set(resolved_pages.keys())
@@ -2878,19 +2887,44 @@ async def main():
         st.session_state[notebook_selection_key] = notebook_widget_selection
     selected_notebooks = list(notebook_widget_selection)
 
-    _render_analysis_sidebar_view_launcher(
-        project=project,
-        selected_views=selected_views,
-        view_names=all_available_views,
-        resolved_pages=resolved_pages,
-        custom_view_lookup=custom_view_lookup,
+    def _render_sidebar_launchers(
+        *,
+        sidebar_selected_views: list[str],
+        sidebar_selected_notebooks: list[str],
+    ) -> None:
+        _render_analysis_sidebar_view_launcher(
+            project=project,
+            selected_views=sidebar_selected_views,
+            view_names=all_available_views,
+            resolved_pages=resolved_pages,
+            custom_view_lookup=custom_view_lookup,
+        )
+        _render_analysis_sidebar_notebook_launcher(
+            project=project,
+            selected_notebooks=sidebar_selected_notebooks,
+            notebook_names=notebook_names,
+            notebook_lookup=notebook_lookup,
+        )
+
+    route_view_path = (
+        _resolve_view_path(current_page, resolved_pages, custom_view_lookup)
+        if current_page
+        else None
     )
-    _render_analysis_sidebar_notebook_launcher(
-        project=project,
-        selected_notebooks=selected_notebooks,
-        notebook_names=notebook_names,
-        notebook_lookup=notebook_lookup,
+    app_surface_will_render = (
+        configured_app_surface_entrypoint(active_app_path, cfg) is not None
+        and not _is_app_surface_overview_requested(current_page)
+        and not _query_param_is_truthy(st.query_params.get(_APP_SURFACE_HIDE_QUERY_PARAM))
     )
+    if (
+        current_notebook
+        or route_view_path is not None
+        or app_surface_will_render
+    ):
+        _render_sidebar_launchers(
+            sidebar_selected_views=selected_views,
+            sidebar_selected_notebooks=selected_notebooks,
+        )
 
     # Route: only render a child surface when the param is concrete, not "main"/empty.
     # The sidebar launchers above stay visible on child views/notebooks.
@@ -3001,6 +3035,11 @@ async def main():
             config_changed = True
     if config_changed:
         _write_config(app_settings, cfg)
+
+    _render_sidebar_launchers(
+        sidebar_selected_views=selected_views,
+        sidebar_selected_notebooks=selected_notebooks,
+    )
 
     _render_custom_analysis_page_authoring(
         project=project,

--- a/test/test_about_agilab_helpers.py
+++ b/test/test_about_agilab_helpers.py
@@ -770,11 +770,7 @@ def test_page_bootstrap_configure_page_chrome_sets_docs_title_and_theme(tmp_path
 
 def test_page_bootstrap_render_page_header_orders_shared_sidebar_context():
     events: list[tuple[str, object]] = []
-    fake_st = SimpleNamespace(
-        markdown=lambda body, **_kwargs: events.append(
-            ("chip", "agilab-active-project-chip" in str(body))
-        )
-    )
+    fake_st = SimpleNamespace()
     env = SimpleNamespace(app="demo")
 
     page_bootstrap.render_page_header(
@@ -794,18 +790,13 @@ def test_page_bootstrap_render_page_header_orders_shared_sidebar_context():
     assert events == [
         ("logo", None),
         ("pinned", True),
-        ("chip", True),
         ("context", (True, {"page_label": "PROJECT", "env": env})),
     ]
 
 
 def test_page_bootstrap_render_page_header_skips_project_context_by_default():
     events: list[tuple[str, object]] = []
-    fake_st = SimpleNamespace(
-        markdown=lambda body, **_kwargs: events.append(
-            ("chip", "agilab-active-project-chip" in str(body))
-        )
-    )
+    fake_st = SimpleNamespace()
 
     page_bootstrap.render_page_header(
         fake_st,
@@ -820,7 +811,7 @@ def test_page_bootstrap_render_page_header_skips_project_context_by_default():
         ),
     )
 
-    assert events == [("logo", None), ("pinned", True), ("chip", True)]
+    assert events == [("logo", None), ("pinned", True)]
 
 
 def test_page_bootstrap_render_page_chrome_uses_env_resources():
@@ -6265,14 +6256,10 @@ def test_render_newcomer_first_proof_uses_markdown(monkeypatch):
     assert "Success criteria" in body
 
 
-def test_main_navigation_context_imports_page_bootstrap_active_project_chip(monkeypatch):
-    """ABOUT navigation must not lazy-import a missing project chip helper."""
+def test_main_navigation_context_does_not_render_active_project_chip(monkeypatch):
+    """ABOUT navigation should not duplicate the selected project above page controls."""
     fake_st = _FakeStreamlit()
     env = SimpleNamespace(app="flight_telemetry_project", target="", active_app="")
-    about_agilab._LAZY_IMPORT_ATTR_CACHE.pop(
-        ("agilab.page_bootstrap", "render_active_project_chip"),
-        None,
-    )
 
     monkeypatch.setattr(about_agilab, "st", fake_st)
     monkeypatch.setattr(about_agilab, "detect_agilab_version", lambda _env: "0.test")
@@ -6290,5 +6277,5 @@ def test_main_navigation_context_imports_page_bootstrap_active_project_chip(monk
     markdown_text = "\n".join(
         value for event, value in fake_st.events if event == "markdown"
     )
-    assert "agilab-active-project-chip" in markdown_text
-    assert "flight_telemetry_project" in markdown_text
+    assert "agilab-active-project-chip" not in markdown_text
+    assert "Project: flight_telemetry_project" not in markdown_text

--- a/test/test_analysis_page_helpers.py
+++ b/test/test_analysis_page_helpers.py
@@ -655,6 +655,43 @@ def test_ensure_notebook_sidecar_starts_lab_root_and_allows_iframe(tmp_path: Pat
     assert not any("'" in part for part in command)
 
 
+def test_exec_bg_clears_parent_python_environment(tmp_path: Path, monkeypatch):
+    module = _load_analysis_module()
+    captured: dict[str, object] = {}
+
+    class _FakeProcess:
+        pass
+
+    def _fake_popen(command, **kwargs):
+        captured["command"] = command
+        captured["env"] = kwargs["env"]
+        captured["cwd"] = kwargs["cwd"]
+        return _FakeProcess()
+
+    monkeypatch.setenv("PYTHONPATH", "/bad/pythonpath")
+    monkeypatch.setenv("VIRTUAL_ENV", "/bad/manager-venv")
+    monkeypatch.setattr(module.subprocess, "Popen", _fake_popen)
+
+    fake_env = SimpleNamespace(
+        out_log=str(tmp_path / "sidecar.log"),
+        err_log=str(tmp_path / "sidecar.err"),
+    )
+    process = module.exec_bg(
+        fake_env,
+        ["uv", "run", "--project", str(tmp_path), "python", "-m", "streamlit"],
+        cwd=str(tmp_path),
+        process_env={"PATH": "/tool/bin"},
+    )
+
+    assert isinstance(process, _FakeProcess)
+    assert captured["cwd"] == str(tmp_path)
+    assert captured["command"][0] == "uv"
+    child_env = captured["env"]
+    assert child_env["PATH"] == "/tool/bin"
+    assert "PYTHONPATH" not in child_env
+    assert "VIRTUAL_ENV" not in child_env
+
+
 def test_source_bootstrap_stamp_invalidates_when_core_path_changes(tmp_path: Path):
     module = _load_analysis_module()
     project_root = tmp_path / "page_project"
@@ -1326,6 +1363,36 @@ def test_analysis_page_state_falls_back_to_all_views_when_restrict_config_is_emp
 
     assert state.view_names == (custom_key, "view_maps")
     assert state.widget_selection == ()
+
+
+def test_app_surface_migration_preserves_intentionally_empty_analysis_views(tmp_path: Path):
+    module = _load_analysis_module()
+    active_app_path = tmp_path / "app_surface_project"
+    surface_module = active_app_path / "src" / "demo_surface"
+    surface_module.mkdir(parents=True)
+    (surface_module / "app.py").write_text("def main():\n    pass\n", encoding="utf-8")
+    (active_app_path / "src" / "app_settings.toml").write_text(
+        """
+[pages]
+restrict_to_view_module = true
+view_module = []
+
+[app_surface]
+title = "Demo surface"
+entrypoint = "demo_surface/app.py"
+default = "streamlit"
+""".lstrip(),
+        encoding="utf-8",
+    )
+    cfg = {"pages": {"restrict_to_view_module": True, "view_module": []}}
+
+    changed = module._migrate_declared_app_surface_config(active_app_path, cfg)
+
+    assert changed is True
+    assert cfg["pages"]["restrict_to_view_module"] is True
+    assert cfg["pages"]["view_module"] == []
+    assert "view_app_ui" not in cfg["pages"]
+    assert cfg["app_surface"]["entrypoint"] == "demo_surface/app.py"
 
 
 def test_analysis_page_state_handles_invalid_and_unresolved_defaults(tmp_path: Path):

--- a/test/test_ui_pages.py
+++ b/test/test_ui_pages.py
@@ -2369,7 +2369,7 @@ def test_explore_page_deselect_view(mock_ui_env):
     assert "Open view_barycentric" not in btns
     assert not card_open_buttons
     sidebar_markdown = "\n".join(str(item.value) for item in at.sidebar.markdown)
-    assert "view_maps" in sidebar_markdown
+    assert "view_maps" not in sidebar_markdown
     assert "view_barycentric" in sidebar_markdown
 
 


### PR DESCRIPTION
## Summary
- keep app-surface-only ANALYSIS projects from migrating empty view selections to stale view_app_ui entries
- render sidebar analysis links from the finalized chooser selection
- remove deselected analysis views from the sidebar immediately

## Tests
- not run (not requested)