### PR TITLE
Hide internal AgiEnv switch errors

### DIFF
--- a/src/agilab/about_page/bootstrap.py
+++ b/src/agilab/about_page/bootstrap.py
@@ -140,8 +140,17 @@ def source_launch_env_updates(apps_path: Path | None) -> dict[str, str]:
     }
 
 
-def _is_already_initialised_env_error(exc: RuntimeError) -> bool:
+def _is_already_initialised_env_error(exc: BaseException) -> bool:
     return "AgiEnv is already initialised with a different configuration" in str(exc)
+
+
+def _project_switch_failure_message(target_name: str, exc: BaseException) -> str:
+    if _is_already_initialised_env_error(exc):
+        return (
+            f"Unable to switch to project '{target_name}'. Refresh the page or "
+            "restart AGILAB, then select the project again."
+        )
+    return f"Unable to switch to project '{target_name}': {exc}"
 
 
 def _normalize_path(value: Any) -> Path | None:
@@ -418,7 +427,7 @@ def _rebootstrap_same_named_active_app(env: Any, target_path: Path, target_name:
         if previous_init_done is not None:
             env.init_done = previous_init_done
     except (AttributeError, OSError, RuntimeError, TypeError, ValueError) as exc:
-        streamlit.warning(f"Unable to switch to project '{target_name}': {exc}")
+        streamlit.warning(_project_switch_failure_message(target_name, exc))
         return False
     return True
 
@@ -437,7 +446,7 @@ def apply_active_app_request(env: Any, request_value: Optional[str], *, streamli
     try:
         env.change_app(target_path)
     except (AttributeError, OSError, RuntimeError, TypeError, ValueError) as exc:
-        streamlit.warning(f"Unable to switch to project '{target_name}': {exc}")
+        streamlit.warning(_project_switch_failure_message(target_name, exc))
         return False
     return True
 

--- a/test/test_about_agilab_helpers.py
+++ b/test/test_about_agilab_helpers.py
@@ -2188,6 +2188,30 @@ def test_bootstrap_active_app_helpers_handle_empty_same_and_failed_switch(tmp_pa
     )
     assert any("cannot switch" in warning for warning in warnings)
 
+    class InternalBrokenEnv(FakeEnv):
+        def __init__(self):
+            super().__init__()
+            self.app = "default"
+
+        def change_app(self, _path: Path) -> None:
+            raise RuntimeError(
+                "AgiEnv is already initialised with a different configuration; "
+                "use AgiEnv.reset() for a fresh environment or change_app() to switch apps."
+            )
+
+    warnings.clear()
+    assert not bootstrap.apply_active_app_request(
+        InternalBrokenEnv(),
+        "known",
+        streamlit=SimpleNamespace(warning=warnings.append),
+    )
+    assert warnings == [
+        "Unable to switch to project 'known'. Refresh the page or restart AGILAB, "
+        "then select the project again."
+    ]
+    assert "AgiEnv.reset" not in warnings[0]
+    assert "change_app" not in warnings[0]
+
 
 def test_bootstrap_additional_active_app_and_source_path_edges(tmp_path, monkeypatch):
     bootstrap = about_agilab._about_bootstrap


### PR DESCRIPTION
## Summary
- sanitize internal AgiEnv singleton switch errors shown during active-project changes
- show end users a refresh/restart instruction instead of AgiEnv.reset/change_app internals
- add regression coverage that forbids leaking the internal message in project-switch warnings

## Tests
- uv --preview-features extra-build-dependencies run --extra ui pytest -q -o addopts='' test/test_about_agilab_helpers.py::test_bootstrap_active_app_helpers_handle_empty_same_and_failed_switch