### PR TITLE
[codex] Allow latest Streamlit 1.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ agilab-mcp = "agilab_mcp.server:main"
 [project.optional-dependencies]
 ai = ["openai>=2.32.0,<3"]
 core = ["agi-core==2026.05.31.post1"]
-ui = ["agi-apps==2026.05.31.post1", "agi-pages==2026.05.31.post1", "agi-gui==2026.05.31.post1", "agi-web==2026.05.31.post1", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "streamlit>=1.56,<1.59", "tomli_w>=1.2.0,<2"]
+ui = ["agi-apps==2026.05.31.post1", "agi-pages==2026.05.31.post1", "agi-gui==2026.05.31.post1", "agi-web==2026.05.31.post1", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "streamlit>=1.58,<2", "tomli_w>=1.2.0,<2"]
 viz = ["matplotlib>=3.10.0,<4", "plotly>=6.7.0,<7"]
 mlflow = ["mlflow>=3.11.1,<4", "idna>=3.15,<4", "starlette>=1.0.1,<2"]
 bridges = ["duckdb>=1.4.0,<2"]

--- a/src/agilab/apps-pages/templates/analysis_page_template/pyproject.toml
+++ b/src/agilab/apps-pages/templates/analysis_page_template/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.11"
 dependencies = [
     "agi-env>=2026.05.18,<2027.0",
     "agi-node>=2026.05.18,<2027.0",
-    "streamlit>=1.56,<1.59",
+    "streamlit>=1.58,<2",
 ]
 
 [build-system]

--- a/src/agilab/apps/builtin/data_quality_gate_project/pyproject.toml
+++ b/src/agilab/apps/builtin/data_quality_gate_project/pyproject.toml
@@ -3,7 +3,7 @@ name = "data_quality_gate_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILAB data contract and drift gate app with promotion evidence"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "streamlit>=1.56,<1.59"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "streamlit>=1.58,<2"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/apps/builtin/execution_pandas_project/pyproject.toml
+++ b/src/agilab/apps/builtin/execution_pandas_project/pyproject.toml
@@ -3,7 +3,7 @@ name = "execution_pandas_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILab execution playground using PandasWorker"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "numpy>=2.2,<3", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "streamlit>=1.56,<1.59"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "numpy>=2.2,<3", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "streamlit>=1.58,<2"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/execution_polars_project/pyproject.toml
+++ b/src/agilab/apps/builtin/execution_polars_project/pyproject.toml
@@ -3,7 +3,7 @@ name = "execution_polars_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILab execution playground using PolarsWorker"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "polars>=1.35,<2", "pydantic>=2.11,<2.13", "streamlit>=1.56,<1.59"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "polars>=1.35,<2", "pydantic>=2.11,<2.13", "streamlit>=1.58,<2"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/flight_telemetry_project/pyproject.toml
+++ b/src/agilab/apps/builtin/flight_telemetry_project/pyproject.toml
@@ -3,7 +3,7 @@ name = "flight_telemetry_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILab example app (flight-telemetry preprocessing)"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "polars[rtcompat]>=1.35,<2", "pydantic>=2.11,<2.13", "py7zr>=1.1,<1.2", "streamlit>=1.56,<1.59"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "polars[rtcompat]>=1.35,<2", "pydantic>=2.11,<2.13", "py7zr>=1.1,<1.2", "streamlit>=1.58,<2"]
 
 [tool.agilab]
 runtime_target = "flight_telemetry"

--- a/src/agilab/apps/builtin/minimal_app_project/pyproject.toml
+++ b/src/agilab/apps/builtin/minimal_app_project/pyproject.toml
@@ -3,7 +3,7 @@ name = "minimal_app_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILab example app template (minimal manager + worker)"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "polars>=1.35,<2", "pydantic>=2.11,<2.13", "streamlit>=1.56,<1.59"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "polars>=1.35,<2", "pydantic>=2.11,<2.13", "streamlit>=1.58,<2"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/mission_decision_project/pyproject.toml
+++ b/src/agilab/apps/builtin/mission_decision_project/pyproject.toml
@@ -3,7 +3,7 @@ name = "mission_decision_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILAB Mission Decision autonomous demo"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "streamlit>=1.56,<1.59"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "streamlit>=1.58,<2"]
 
 [tool.agilab]
 runtime_target = "mission_decision"

--- a/src/agilab/apps/builtin/multi_app_dag_project/pyproject.toml
+++ b/src/agilab/apps/builtin/multi_app_dag_project/pyproject.toml
@@ -3,7 +3,7 @@ name = "multi_app_dag_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILAB multi-app DAG example project"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "polars>=1.35,<2", "pydantic>=2.11,<2.13", "streamlit>=1.56,<1.59"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "polars>=1.35,<2", "pydantic>=2.11,<2.13", "streamlit>=1.58,<2"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/pytorch_playground_project/pyproject.toml
+++ b/src/agilab/apps/builtin/pytorch_playground_project/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "pandas>=2.3.0,<4",
     "plotly>=6.3.0,<7",
     "pydantic>=2.11,<2.13",
-    "streamlit>=1.56,<1.59",
+    "streamlit>=1.58,<2",
     "torch>=2.8.0,<3",
 ]
 

--- a/src/agilab/apps/builtin/r_runtime_bridge_project/pyproject.toml
+++ b/src/agilab/apps/builtin/r_runtime_bridge_project/pyproject.toml
@@ -4,7 +4,7 @@ version = "2026.05.30.post1"
 description = "Built-in AGILAB smoke app for Rscript JSON/artifact stage execution"
 readme = "README.md"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "streamlit>=1.56,<1.59"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "streamlit>=1.58,<2"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/apps/builtin/sklearn_pipeline_project/pyproject.toml
+++ b/src/agilab/apps/builtin/sklearn_pipeline_project/pyproject.toml
@@ -3,7 +3,7 @@ name = "sklearn_pipeline_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILAB scikit-learn pipeline app with model, metrics, predictions, and evidence manifest"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "joblib>=1.5,<2", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "scikit-learn>=1.7.2,<2", "streamlit>=1.56,<1.59"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "joblib>=1.5,<2", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "scikit-learn>=1.7.2,<2", "streamlit>=1.58,<2"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/apps/builtin/tescia_diagnostic_project/pyproject.toml
+++ b/src/agilab/apps/builtin/tescia_diagnostic_project/pyproject.toml
@@ -3,7 +3,7 @@ name = "tescia_diagnostic_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILAB TeSciA-style diagnostic reasoning example"
 requires-python = ">=3.13"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "streamlit>=1.56,<1.59"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "streamlit>=1.58,<2"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/uav_queue_project/pyproject.toml
+++ b/src/agilab/apps/builtin/uav_queue_project/pyproject.toml
@@ -3,7 +3,7 @@ name = "uav_queue_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILAB lightweight UAV relay queue example"
 requires-python = ">=3.13"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "simpy>=4.1,<5", "streamlit>=1.56,<1.59"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "simpy>=4.1,<5", "streamlit>=1.58,<2"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/uav_relay_queue_project/pyproject.toml
+++ b/src/agilab/apps/builtin/uav_relay_queue_project/pyproject.toml
@@ -3,7 +3,7 @@ name = "uav_relay_queue_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILAB lightweight UAV relay queue example"
 requires-python = ">=3.13"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "simpy>=4.1,<5", "streamlit>=1.56,<1.59"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "simpy>=4.1,<5", "streamlit>=1.58,<2"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/weather_forecast_legacy_project/pyproject.toml
+++ b/src/agilab/apps/builtin/weather_forecast_legacy_project/pyproject.toml
@@ -3,7 +3,7 @@ name = "weather_forecast_legacy_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILab weather forecasting example migrated from notebooks"
 requires-python = ">=3.13"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "scikit-learn>=1.7.2,<2", "skforecast>=0.19,<0.20", "streamlit>=1.56,<1.59"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "scikit-learn>=1.7.2,<2", "skforecast>=0.19,<0.20", "streamlit>=1.58,<2"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/weather_forecast_project/pyproject.toml
+++ b/src/agilab/apps/builtin/weather_forecast_project/pyproject.toml
@@ -3,7 +3,7 @@ name = "weather_forecast_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILab weather forecasting example migrated from notebooks"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "scikit-learn>=1.7.2,<2", "skforecast>=0.19,<0.20", "streamlit>=1.56,<1.59"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "scikit-learn>=1.7.2,<2", "skforecast>=0.19,<0.20", "streamlit>=1.58,<2"]
 
 [tool.agilab]
 runtime_target = "weather_forecast"

--- a/src/agilab/apps/templates/dag_app_template/pyproject.toml
+++ b/src/agilab/apps/templates/dag_app_template/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "agi-env>=2026.05.25,<2027.0",
     "agi-node>=2026.05.25,<2027.0",
     "pydantic>=2.11,<2.13",
-    "streamlit>=1.56,<1.59",
+    "streamlit>=1.58,<2",
 ]
 
 [dependency-groups]

--- a/src/agilab/apps/templates/fireducks_app_template/pyproject.toml
+++ b/src/agilab/apps/templates/fireducks_app_template/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "fireducks>=1.4.4,<2",
     "pydantic>=2.11,<2.13",
     "py7zr>=1.1,<1.2",
-    "streamlit>=1.56,<1.59",
+    "streamlit>=1.58,<2",
 ]
 
 [dependency-groups]

--- a/src/agilab/apps/templates/pandas_app_template/pyproject.toml
+++ b/src/agilab/apps/templates/pandas_app_template/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "pandas>=2.3.0,<4",
     "pydantic>=2.11,<2.13",
     "py7zr>=1.1,<1.2",
-    "streamlit>=1.56,<1.59",
+    "streamlit>=1.58,<2",
 ]
 
 [dependency-groups]

--- a/src/agilab/apps/templates/polars_app_template/pyproject.toml
+++ b/src/agilab/apps/templates/polars_app_template/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "polars>=1.35,<2",
     "pydantic>=2.11,<2.13",
     "py7zr>=1.1,<1.2",
-    "streamlit>=1.56,<1.59",
+    "streamlit>=1.58,<2",
 ]
 
 [dependency-groups]

--- a/src/agilab/apps/templates/simple_app_template/pyproject.toml
+++ b/src/agilab/apps/templates/simple_app_template/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 dependencies = [
     "agi-env>=2026.05.25,<2027.0",
     "pydantic>=2.11,<2.13",
-    "streamlit>=1.56,<1.59",
+    "streamlit>=1.58,<2",
 ]
 
 [dependency-groups]

--- a/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/pyproject.toml
+++ b/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/pyproject.toml
@@ -3,7 +3,7 @@ name = "flight_telemetry_project"
 version = "0.1.0"
 description = "Built-in AGILab example app (flight-telemetry preprocessing)"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.13.post3,<2027.0", "agi-node>=2026.05.13.post3,<2027.0", "agi-cluster>=2026.05.13.post3,<2027.0", "polars[rtcompat]>=1.35,<2", "pydantic>=2.11,<2.13", "py7zr>=1.1,<1.2", "streamlit>=1.56,<1.59"]
+dependencies = ["agi-env>=2026.05.13.post3,<2027.0", "agi-node>=2026.05.13.post3,<2027.0", "agi-cluster>=2026.05.13.post3,<2027.0", "polars[rtcompat]>=1.35,<2", "pydantic>=2.11,<2.13", "py7zr>=1.1,<1.2", "streamlit>=1.58,<2"]
 
 [tool.agilab]
 runtime_target = "flight_telemetry"

--- a/src/agilab/lib/agi-app-mission-decision/src/agi_app_mission_decision/project/mission_decision_project/pyproject.toml
+++ b/src/agilab/lib/agi-app-mission-decision/src/agi_app_mission_decision/project/mission_decision_project/pyproject.toml
@@ -3,7 +3,7 @@ name = "mission_decision_project"
 version = "0.1.0"
 description = "Built-in AGILAB Mission Decision autonomous demo"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.13.post3,<2027.0", "agi-node>=2026.05.13.post3,<2027.0", "agi-cluster>=2026.05.13.post3,<2027.0", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "streamlit>=1.56,<1.59"]
+dependencies = ["agi-env>=2026.05.13.post3,<2027.0", "agi-node>=2026.05.13.post3,<2027.0", "agi-cluster>=2026.05.13.post3,<2027.0", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "streamlit>=1.58,<2"]
 
 [tool.agilab]
 runtime_target = "mission_decision"

--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/pyproject.toml
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "pandas>=2.3.0,<4",
     "plotly>=6.3.0,<7",
     "pydantic>=2.11,<2.13",
-    "streamlit>=1.56,<1.59",
+    "streamlit>=1.58,<2",
     "torch>=2.8.0,<3",
 ]
 

--- a/src/agilab/lib/agi-app-uav-relay-queue/src/agi_app_uav_relay_queue/project/uav_relay_queue_project/pyproject.toml
+++ b/src/agilab/lib/agi-app-uav-relay-queue/src/agi_app_uav_relay_queue/project/uav_relay_queue_project/pyproject.toml
@@ -3,7 +3,7 @@ name = "uav_relay_queue_project"
 version = "0.1.0"
 description = "Built-in AGILAB lightweight UAV relay queue example"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.13.post3,<2027.0", "agi-node>=2026.05.13.post3,<2027.0", "agi-cluster>=2026.05.13.post3,<2027.0", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "simpy>=4.1,<5", "streamlit>=1.56,<1.59"]
+dependencies = ["agi-env>=2026.05.13.post3,<2027.0", "agi-node>=2026.05.13.post3,<2027.0", "agi-cluster>=2026.05.13.post3,<2027.0", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "simpy>=4.1,<5", "streamlit>=1.58,<2"]
 
 [tool.setuptools.package-data]
 uav_relay_queue = ["sample_data/*.json"]

--- a/src/agilab/lib/agi-app-weather-forecast/src/agi_app_weather_forecast/project/weather_forecast_project/pyproject.toml
+++ b/src/agilab/lib/agi-app-weather-forecast/src/agi_app_weather_forecast/project/weather_forecast_project/pyproject.toml
@@ -3,7 +3,7 @@ name = "weather_forecast_project"
 version = "0.1.0"
 description = "Built-in AGILab weather forecasting example migrated from notebooks"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.17,<2027.0", "agi-node>=2026.05.17,<2027.0", "agi-cluster>=2026.05.17,<2027.0", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "scikit-learn>=1.7.2,<2", "skforecast>=0.19,<0.20", "streamlit>=1.56,<1.59"]
+dependencies = ["agi-env>=2026.05.17,<2027.0", "agi-node>=2026.05.17,<2027.0", "agi-cluster>=2026.05.17,<2027.0", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "scikit-learn>=1.7.2,<2", "skforecast>=0.19,<0.20", "streamlit>=1.58,<2"]
 
 [tool.agilab]
 runtime_target = "weather_forecast"

--- a/src/agilab/lib/agi-gui/pyproject.toml
+++ b/src/agilab/lib/agi-gui/pyproject.toml
@@ -32,7 +32,7 @@ keywords = [
     "python",
 ]
 
-dependencies = ["agi-env==2026.05.31.post1", "streamlit>=1.56,<1.59", "streamlit_code_editor>=0.1.22,<0.2", "watchdog>=6,<7"]
+dependencies = ["agi-env==2026.05.31.post1", "streamlit>=1.58,<2", "streamlit_code_editor>=0.1.22,<0.2", "watchdog>=6,<7"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"


### PR DESCRIPTION
## Summary

- Raise AGILAB-owned Streamlit dependency constraints from `>=1.56,<1.59` to `>=1.58,<2`.
- Keep constraints aligned across the root UI extra, built-in app manifests, packaged app manifests, templates, and `agi-gui`.
- Avoid referencing non-existent `streamlit==1.59.0`; the current published latest from the package index is `1.58.0`.

## Validation

- `uv --preview-features extra-build-dependencies run python -m pip index versions streamlit`
- `uv --preview-features extra-build-dependencies lock --upgrade-package streamlit`
- `rg -n "streamlit>=1\\.56,<1\\.59|streamlit>=1\\.58,<2" pyproject.toml src/agilab -g pyproject.toml`
- `git diff --cached --check`

## Scope note

The staged scope guard reports this as mixed because the same dependency policy is duplicated across many app package manifests. That is intentional for package/template consistency.
