### PR TITLE
Split dataset release assets from code release

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -730,6 +730,65 @@ jobs:
           done
           python tools/pypi_release_retention.py "${args[@]}"
 
+  publish-dataset-release-assets:
+    if: ${{ always() && needs.test.result == 'success' && needs.release-plan.result == 'success' }}
+    needs:
+      - test
+      - release-plan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+      actions: read
+    env:
+      RELEASE_TAG: ${{ github.event.inputs.release_tag || github.ref_name }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Build dataset release assets
+        id: dataset-assets
+        run: |
+          python tools/dataset_release_assets.py \
+            --repo-root . \
+            --output-dir dataset-release-assets \
+            --release-tag "$RELEASE_TAG" \
+            --github-output "$GITHUB_OUTPUT" \
+            --github-step-summary "$GITHUB_STEP_SUMMARY" \
+            --fail-on-lfs-pointer
+      - name: Check for existing dataset release
+        id: dataset-release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          dataset_release_tag="${{ steps.dataset-assets.outputs.dataset_release_tag }}"
+          if gh release view "$dataset_release_tag" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Dataset release $dataset_release_tag already exists; dataset payload is unchanged." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Attest dataset release assets
+        if: ${{ steps.dataset-assets.outputs.dataset_count != '0' && steps.dataset-release.outputs.exists != 'true' }}
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: dataset-release-assets/**
+      - name: Create dataset GitHub Release
+        if: ${{ steps.dataset-assets.outputs.dataset_count != '0' && steps.dataset-release.outputs.exists != 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DATASET_RELEASE_TAG: ${{ steps.dataset-assets.outputs.dataset_release_tag }}
+          DATASET_MANIFEST_SHA256: ${{ steps.dataset-assets.outputs.dataset_manifest_sha256 }}
+        run: |
+          gh release create "$DATASET_RELEASE_TAG" dataset-release-assets/* \
+            --title "AGILAB datasets ${DATASET_RELEASE_TAG#datasets-}" \
+            --notes "Complete AGILAB dataset assets for manifest $DATASET_MANIFEST_SHA256. PyPI packages keep their packaged datasets; this separate release is for source checkouts and Git LFS pointer replacement. Code release: $RELEASE_TAG."
+
   sync-hf-space:
     if: ${{ always() && needs.release-plan.outputs.umbrella_selected == 'true' && needs.publish-release-assets.result == 'success' }}
     needs:

--- a/test/test_dataset_release_assets.py
+++ b/test/test_dataset_release_assets.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tarfile
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "tools"))
+
+import dataset_release_assets  # noqa: E402
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(repo), *args], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+
+def test_dataset_release_assets_collects_all_tracked_datasets_and_pypi_datasets(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init")
+
+    packaged_dataset = repo / "src/agilab/apps/builtin/demo_project/src/demo_worker/dataset.7z"
+    sample_dataset = repo / "src/agilab/apps/builtin/demo_project/src/demo/sample_data/example.csv"
+    docs_dataset = repo / "docs/source/data/benchmark.csv"
+    non_dataset = repo / "README.csv"
+    packaged_dataset.parent.mkdir(parents=True)
+    sample_dataset.parent.mkdir(parents=True)
+    docs_dataset.parent.mkdir(parents=True)
+    packaged_dataset.write_bytes(b"binary dataset")
+    sample_dataset.write_text("x,y\n1,2\n", encoding="utf-8")
+    docs_dataset.write_text("case,value\nfast,1\n", encoding="utf-8")
+    non_dataset.write_text("not,a,dataset\n", encoding="utf-8")
+    _git(repo, "add", ".")
+
+    records = dataset_release_assets.discover_dataset_records(repo)
+
+    paths = [record["path"] for record in records]
+    assert paths == [
+        "docs/source/data/benchmark.csv",
+        "src/agilab/apps/builtin/demo_project/src/demo/sample_data/example.csv",
+        "src/agilab/apps/builtin/demo_project/src/demo_worker/dataset.7z",
+    ]
+    assert records[1]["pypi_packaged"] is True
+    assert records[2]["pypi_packaged"] is True
+    assert all(record["looks_like_lfs_pointer"] is False for record in records)
+
+
+def test_dataset_release_assets_writes_content_addressed_manifest_and_full_archive(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    out = tmp_path / "out"
+    repo.mkdir()
+    _git(repo, "init")
+
+    dataset = repo / "src/agilab/apps/builtin/demo_project/src/demo_worker/dataset.7z"
+    dataset.parent.mkdir(parents=True)
+    dataset.write_bytes(b"full dataset contents")
+    _git(repo, "add", ".")
+
+    records = dataset_release_assets.discover_dataset_records(repo)
+    manifest = dataset_release_assets.build_manifest(records, "v2026.6.1")
+    out.mkdir()
+    archive_path = out / f"agilab-datasets-{manifest['dataset_manifest_sha256'][:16]}.tar.gz"
+    manifest_path = out / "dataset-release-manifest.json"
+    dataset_release_assets.write_manifest(manifest, manifest_path)
+    dataset_release_assets.write_dataset_archive(repo, records, archive_path)
+
+    saved_manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert saved_manifest["dataset_release_tag"] == f"datasets-{saved_manifest['dataset_manifest_sha256'][:16]}"
+    assert saved_manifest["dataset_count"] == 1
+    assert saved_manifest["datasets"][0]["path"] == "src/agilab/apps/builtin/demo_project/src/demo_worker/dataset.7z"
+
+    with tarfile.open(archive_path, "r:gz") as tar:
+        member = tar.extractfile("src/agilab/apps/builtin/demo_project/src/demo_worker/dataset.7z")
+        assert member is not None
+        assert member.read() == b"full dataset contents"
+
+
+def test_dataset_release_assets_detects_lfs_pointer_files(tmp_path: Path) -> None:
+    pointer = tmp_path / "dataset.7z"
+    pointer.write_text(
+        "version https://git-lfs.github.com/spec/v1\n"
+        "oid sha256:593536ccdc000000000000000000000000000000000000000000000000000000\n"
+        "size 123\n",
+        encoding="utf-8",
+    )
+
+    assert dataset_release_assets.looks_like_lfs_pointer(pointer) is True

--- a/test/test_pypi_publish_workflow.py
+++ b/test/test_pypi_publish_workflow.py
@@ -291,6 +291,23 @@ def test_pypi_publish_attests_and_uploads_release_supply_chain_assets() -> None:
     assert "gh release create \"$release_tag\"" in text
 
 
+def test_pypi_publish_dataset_release_is_separate_from_code_release() -> None:
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    assert "publish-dataset-release-assets:" in text
+    assert "tools/dataset_release_assets.py" in text
+    assert "lfs: true" in text
+    assert "dataset-release-assets" in text
+    assert "DATASET_RELEASE_TAG" in text
+    assert "gh release view \"$dataset_release_tag\"" in text
+    assert "gh release create \"$DATASET_RELEASE_TAG\" dataset-release-assets/*" in text
+    assert "PyPI packages keep their packaged datasets" in text
+
+    dataset_job = text.split("publish-dataset-release-assets:", 1)[1].split("sync-hf-space:", 1)[0]
+    assert "github-release-assets" not in dataset_job
+    assert "needs.release-plan.outputs.pypi_publish_selected == 'true'" not in dataset_job
+
+
 def test_pypi_publish_syncs_hf_space_only_for_umbrella_release() -> None:
     text = WORKFLOW_PATH.read_text(encoding="utf-8")
 

--- a/tools/dataset_release_assets.py
+++ b/tools/dataset_release_assets.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import gzip
+import hashlib
+import io
+import json
+import os
+from pathlib import Path
+import subprocess
+import tarfile
+from typing import Any
+
+
+SCHEMA = "agilab.dataset_release_assets.v1"
+DATASET_SUFFIXES = {".7z", ".csv", ".npz", ".parquet"}
+DATASET_DIR_PARTS = {"analysis_artifacts", "data", "dataset", "datasets", "sample_data"}
+DATASET_FILENAMES = {"dataset.7z"}
+LFS_POINTER_PREFIX = b"version https://git-lfs.github.com/spec/v1\n"
+
+
+def _run_git(repo_root: Path, args: list[str]) -> str:
+    completed = subprocess.run(
+        ["git", "-C", str(repo_root), *args],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=False,
+    )
+    return completed.stdout.decode("utf-8", errors="replace")
+
+
+def _run_git_optional(repo_root: Path, args: list[str]) -> str:
+    try:
+        return _run_git(repo_root, args)
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return ""
+
+
+def _git_tracked_files(repo_root: Path) -> list[Path]:
+    output = _run_git(repo_root, ["ls-files", "-z"])
+    return [Path(part) for part in output.split("\0") if part]
+
+
+def _git_lfs_files(repo_root: Path) -> set[str]:
+    output = _run_git_optional(repo_root, ["lfs", "ls-files", "--name-only"])
+    return {line.strip() for line in output.splitlines() if line.strip()}
+
+
+def is_dataset_path(relative_path: Path) -> bool:
+    if relative_path.name in DATASET_FILENAMES:
+        return True
+    if relative_path.suffix.lower() not in DATASET_SUFFIXES:
+        return False
+    return any(part in DATASET_DIR_PARTS for part in relative_path.parts)
+
+
+def looks_like_lfs_pointer(path: Path) -> bool:
+    try:
+        with path.open("rb") as handle:
+            return handle.read(len(LFS_POINTER_PREFIX)) == LFS_POINTER_PREFIX
+    except OSError:
+        return False
+
+
+def _file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def discover_dataset_records(repo_root: Path) -> list[dict[str, Any]]:
+    lfs_paths = _git_lfs_files(repo_root)
+    records: list[dict[str, Any]] = []
+    for relative_path in sorted(_git_tracked_files(repo_root), key=lambda value: value.as_posix()):
+        if not is_dataset_path(relative_path):
+            continue
+        absolute_path = repo_root / relative_path
+        if not absolute_path.is_file():
+            continue
+        records.append(
+            {
+                "path": relative_path.as_posix(),
+                "sha256": _file_sha256(absolute_path),
+                "size_bytes": absolute_path.stat().st_size,
+                "lfs_tracked": relative_path.as_posix() in lfs_paths,
+                "looks_like_lfs_pointer": looks_like_lfs_pointer(absolute_path),
+                "pypi_packaged": relative_path.as_posix().startswith("src/agilab/"),
+            }
+        )
+    return records
+
+
+def manifest_content_hash(records: list[dict[str, Any]]) -> str:
+    stable_payload = {
+        "datasets": records,
+        "schema": SCHEMA,
+    }
+    encoded = json.dumps(stable_payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def build_manifest(records: list[dict[str, Any]], release_tag: str) -> dict[str, Any]:
+    content_hash = manifest_content_hash(records)
+    return {
+        "schema": SCHEMA,
+        "release_tag": release_tag,
+        "dataset_release_tag": f"datasets-{content_hash[:16]}",
+        "dataset_manifest_sha256": content_hash,
+        "generated_at_utc": dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat(),
+        "dataset_count": len(records),
+        "total_size_bytes": sum(int(record["size_bytes"]) for record in records),
+        "datasets": records,
+    }
+
+
+def write_manifest(manifest: dict[str, Any], path: Path) -> None:
+    path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_dataset_archive(repo_root: Path, records: list[dict[str, Any]], archive_path: Path) -> None:
+    tar_buffer = io.BytesIO()
+    with tarfile.open(fileobj=tar_buffer, mode="w") as tar:
+        for record in records:
+            relative_path = Path(record["path"])
+            absolute_path = repo_root / relative_path
+            tar_info = tar.gettarinfo(str(absolute_path), arcname=relative_path.as_posix())
+            tar_info.uid = 0
+            tar_info.gid = 0
+            tar_info.uname = ""
+            tar_info.gname = ""
+            tar_info.mtime = 0
+            tar_info.mode = 0o644
+            with absolute_path.open("rb") as handle:
+                tar.addfile(tar_info, handle)
+
+    with archive_path.open("wb") as output:
+        with gzip.GzipFile(filename="", mode="wb", fileobj=output, mtime=0) as gzip_file:
+            gzip_file.write(tar_buffer.getvalue())
+
+
+def write_sha256sums(output_dir: Path, checksum_path: Path) -> None:
+    lines: list[str] = []
+    for path in sorted(output_dir.iterdir(), key=lambda value: value.name):
+        if not path.is_file() or path == checksum_path:
+            continue
+        lines.append(f"{_file_sha256(path)}  {path.name}")
+    checksum_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _append_github_output(path: Path, values: dict[str, str]) -> None:
+    with path.open("a", encoding="utf-8") as handle:
+        for key, value in values.items():
+            handle.write(f"{key}={value}\n")
+
+
+def _append_step_summary(path: Path, manifest: dict[str, Any], archive_name: str) -> None:
+    lines = [
+        "## AGILAB dataset release assets",
+        "",
+        f"- Dataset release tag: `{manifest['dataset_release_tag']}`",
+        f"- Dataset manifest sha256: `{manifest['dataset_manifest_sha256']}`",
+        f"- Dataset files: `{manifest['dataset_count']}`",
+        f"- Archive: `{archive_name}`",
+        "",
+        "PyPI packages keep their packaged datasets. This separate GitHub release provides the full tracked dataset payload for source checkouts and LFS-pointer replacement.",
+        "",
+    ]
+    path.open("a", encoding="utf-8").write("\n".join(lines))
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Build AGILAB GitHub dataset release assets.")
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--release-tag", default=os.environ.get("RELEASE_TAG", "dev"))
+    parser.add_argument("--github-output", type=Path)
+    parser.add_argument("--github-step-summary", type=Path)
+    parser.add_argument("--fail-on-lfs-pointer", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = args.repo_root.resolve()
+    output_dir = args.output_dir.resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    records = discover_dataset_records(repo_root)
+    pointer_paths = [record["path"] for record in records if record["looks_like_lfs_pointer"]]
+    if args.fail_on_lfs_pointer and pointer_paths:
+        formatted_paths = "\n".join(f"- {path}" for path in pointer_paths)
+        raise SystemExit(
+            "Dataset release assets require materialized file contents, but Git LFS pointer files were found:\n"
+            f"{formatted_paths}\n"
+            "Run the workflow checkout with lfs: true or run git lfs pull before building dataset assets."
+        )
+
+    manifest = build_manifest(records, args.release_tag)
+    tag_suffix = manifest["dataset_manifest_sha256"][:16]
+    archive_name = f"agilab-datasets-{tag_suffix}.tar.gz"
+    manifest_path = output_dir / "dataset-release-manifest.json"
+    archive_path = output_dir / archive_name
+    checksum_path = output_dir / "dataset-SHA256SUMS.txt"
+
+    write_manifest(manifest, manifest_path)
+    write_dataset_archive(repo_root, records, archive_path)
+    write_sha256sums(output_dir, checksum_path)
+
+    outputs = {
+        "dataset_count": str(manifest["dataset_count"]),
+        "dataset_manifest_sha256": str(manifest["dataset_manifest_sha256"]),
+        "dataset_release_tag": str(manifest["dataset_release_tag"]),
+        "dataset_archive": archive_path.name,
+        "dataset_manifest": manifest_path.name,
+    }
+    if args.github_output:
+        _append_github_output(args.github_output, outputs)
+    if args.github_step_summary:
+        _append_step_summary(args.github_step_summary, manifest, archive_name)
+
+    print(json.dumps({**outputs, "output_dir": str(output_dir)}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/release_plan.py
+++ b/tools/release_plan.py
@@ -603,6 +603,17 @@ def validate_workflow_contract(workflow_path: Path) -> list[str]:
         "release-distribution-evidence.tar.gz": (
             "workflow must attach the complete release distribution evidence archive"
         ),
+        "publish-dataset-release-assets:": (
+            "workflow must publish datasets through a separate GitHub release job"
+        ),
+        "tools/dataset_release_assets.py": "workflow must build deterministic dataset release assets",
+        "DATASET_RELEASE_TAG": "dataset releases must use a dataset-specific tag namespace",
+        "gh release view \"$dataset_release_tag\"": (
+            "dataset release job must skip unchanged dataset payloads"
+        ),
+        "gh release create \"$DATASET_RELEASE_TAG\" dataset-release-assets/*": (
+            "dataset release job must upload dataset assets to the dataset release"
+        ),
         "allow_post_release:": "workflow must require an explicit public .postN hotfix override",
         "post_release_reason:": "workflow must capture the public .postN hotfix justification",
         "tools/pypi_release_version_policy.py": (


### PR DESCRIPTION
## Summary
- add deterministic dataset release asset builder and manifest
- publish datasets to a separate content-addressed GitHub release only when the dataset payload is new
- keep PyPI package datasets unchanged while giving source users a full dataset archive for LFS-pointer replacement

## Validation
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_dataset_release_assets.py test/test_pypi_publish_workflow.py
- uv --preview-features extra-build-dependencies run python tools/release_plan.py --check-workflow .github/workflows/pypi-publish.yaml
- ./dev scope