### PR TITLE
[codex] Fix PyTorch Playground sidebar rendering

### DIFF
--- a/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/app_surface.py
+++ b/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/app_surface.py
@@ -382,7 +382,7 @@ def _render_full_surface(
     root = container or st
     _render_surface_styles()
     if container is None:
-        analysis_container = root
+        analysis_container = None
         controls_container = st.sidebar
     else:
         analysis_container, controls_container = root.columns([0.70, 0.30])
@@ -405,8 +405,11 @@ def _render_full_surface(
                 wide=False,
                 compact=True,
             )
-    with analysis_container:
+    if analysis_container is None:
         _render_analysis_surface(active_app_path, configure_page=False, compact=True)
+    else:
+        with analysis_container:
+            _render_analysis_surface(active_app_path, configure_page=False, compact=True)
 
 
 def render(

--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground/app_surface.py
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground/app_surface.py
@@ -382,7 +382,7 @@ def _render_full_surface(
     root = container or st
     _render_surface_styles()
     if container is None:
-        analysis_container = root
+        analysis_container = None
         controls_container = st.sidebar
     else:
         analysis_container, controls_container = root.columns([0.70, 0.30])
@@ -405,8 +405,11 @@ def _render_full_surface(
                 wide=False,
                 compact=True,
             )
-    with analysis_container:
+    if analysis_container is None:
         _render_analysis_surface(active_app_path, configure_page=False, compact=True)
+    else:
+        with analysis_container:
+            _render_analysis_surface(active_app_path, configure_page=False, compact=True)
 
 
 def render(


### PR DESCRIPTION
## Summary

- Fix the PyTorch Playground sidebar-control change for direct/sidecar rendering.
- Render the analysis surface directly in standalone mode instead of entering `with st`.
- Keep sidebar controls for standalone mode and preserve the two-column fallback for explicit embedded containers.
- Keep source and packaged PyTorch Playground payload copies aligned.

## Validation

- `./dev scope`
- `git diff --check`
