### PR TITLE
Fix analysis sidebar app surface labels

### DIFF
--- a/.claude/skills/agilab-streamlit-pages/SKILL.md
+++ b/.claude/skills/agilab-streamlit-pages/SKILL.md
@@ -59,6 +59,10 @@ Use this skill when editing:
 - Treat `view_app_ui` as an internal route key, not a user-facing label. Sidebar
   links for app surfaces should use `[app_surface].title`, route through the app
   surface renderer, and avoid exposing duplicate `view_app_ui` bridge links.
+- Keep the standard ANALYSIS view multiselect usable for app-surface projects:
+  `view_app_ui` may be the default selected sidebar launcher, but users must
+  still be able to add other installed analysis views through the same existing
+  selector instead of a custom "additional views" control.
 - Render an ANALYSIS sidebar launcher from one place per page route. If the main
   page persists selected views after rendering controls, do not also render the
   same project label or app-surface link before the main-page body; add a

--- a/.claude/skills/agilab-streamlit-pages/SKILL.md
+++ b/.claude/skills/agilab-streamlit-pages/SKILL.md
@@ -51,8 +51,19 @@ Use this skill when editing:
 - For an app-owned Streamlit surface that should appear as the app's primary
   ANALYSIS experience, declare `[app_surface]` in the app's `app_settings.toml`
   with a project-local entrypoint such as `pytorch_playground/app_surface.py`.
-  Keep `pages.view_module = []` when the app surface replaces generic page
-  launchers. Do not create a generic `apps-pages/view_<app>` bridge for this.
+  Use `[pages] restrict_to_view_module = true` for app-surface-first projects;
+  an empty or missing `pages.view_module` may be migrated to the virtual
+  `view_app_ui` launcher so the app surface is selected and visible in the
+  ANALYSIS sidebar. Do not create a generic `apps-pages/view_<app>` bridge for
+  this.
+- Treat `view_app_ui` as an internal route key, not a user-facing label. Sidebar
+  links for app surfaces should use `[app_surface].title`, route through the app
+  surface renderer, and avoid exposing duplicate `view_app_ui` bridge links.
+- Render an ANALYSIS sidebar launcher from one place per page route. If the main
+  page persists selected views after rendering controls, do not also render the
+  same project label or app-surface link before the main-page body; add a
+  regression assertion that the compact project caption and app-surface link
+  appear exactly once.
 
 ## Session State Rules (Avoid Common Crashes)
 

--- a/.codex/skills/agilab-streamlit-pages/SKILL.md
+++ b/.codex/skills/agilab-streamlit-pages/SKILL.md
@@ -59,6 +59,10 @@ Use this skill when editing:
 - Treat `view_app_ui` as an internal route key, not a user-facing label. Sidebar
   links for app surfaces should use `[app_surface].title`, route through the app
   surface renderer, and avoid exposing duplicate `view_app_ui` bridge links.
+- Keep the standard ANALYSIS view multiselect usable for app-surface projects:
+  `view_app_ui` may be the default selected sidebar launcher, but users must
+  still be able to add other installed analysis views through the same existing
+  selector instead of a custom "additional views" control.
 - Render an ANALYSIS sidebar launcher from one place per page route. If the main
   page persists selected views after rendering controls, do not also render the
   same project label or app-surface link before the main-page body; add a

--- a/.codex/skills/agilab-streamlit-pages/SKILL.md
+++ b/.codex/skills/agilab-streamlit-pages/SKILL.md
@@ -51,8 +51,19 @@ Use this skill when editing:
 - For an app-owned Streamlit surface that should appear as the app's primary
   ANALYSIS experience, declare `[app_surface]` in the app's `app_settings.toml`
   with a project-local entrypoint such as `pytorch_playground/app_surface.py`.
-  Keep `pages.view_module = []` when the app surface replaces generic page
-  launchers. Do not create a generic `apps-pages/view_<app>` bridge for this.
+  Use `[pages] restrict_to_view_module = true` for app-surface-first projects;
+  an empty or missing `pages.view_module` may be migrated to the virtual
+  `view_app_ui` launcher so the app surface is selected and visible in the
+  ANALYSIS sidebar. Do not create a generic `apps-pages/view_<app>` bridge for
+  this.
+- Treat `view_app_ui` as an internal route key, not a user-facing label. Sidebar
+  links for app surfaces should use `[app_surface].title`, route through the app
+  surface renderer, and avoid exposing duplicate `view_app_ui` bridge links.
+- Render an ANALYSIS sidebar launcher from one place per page route. If the main
+  page persists selected views after rendering controls, do not also render the
+  same project label or app-surface link before the main-page body; add a
+  regression assertion that the compact project caption and app-surface link
+  appear exactly once.
 
 ## Session State Rules (Avoid Common Crashes)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,6 +155,13 @@ Use this runbook whenever you:
   shared core, do not create import cycles, and do not move logic across package
   boundaries unless the dependency direction remains valid and the validation
   scope covers the affected callers.
+- **Existing mechanism first**: Before adding a new UI control, workflow path,
+  configuration key, launcher, persistence model, or helper abstraction, search
+  for the existing mechanism that already solves the same user intent. Reuse or
+  extend that mechanism when it is part of the established product contract.
+  Do not invent a parallel mechanism just because it is faster locally; only add
+  a new mechanism when the existing one is objectively insufficient, and state
+  why in the change summary and regression plan.
 - **Change-reporting accuracy rule**: When summarizing edits, make the coverage
   of the summary explicit enough that nearby preserved text is not mistaken for
   deleted text. If a change inserts rules around an existing rule, say whether

--- a/agilab-capabilities.json
+++ b/agilab-capabilities.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-06-01T13:02:51Z",
+  "generated_at_utc": "2026-06-01T16:04:54Z",
   "schema": "agilab.capabilities.v1",
   "schema_version": 1,
   "generated_by": {
@@ -22,7 +22,7 @@
     "package_count": 37,
     "public_app_count": 15,
     "agent_skill_count": 33,
-    "evidence_schema_count": 213,
+    "evidence_schema_count": 214,
     "catalog_file_count": 12
   },
   "cli_commands": [
@@ -1384,6 +1384,12 @@
         "src/agilab/data_connector_view_surface.py",
         "tools/data_connector_view_surface_report.py",
         "tools/kpi_evidence_bundle.py"
+      ]
+    },
+    {
+      "schema": "agilab.dataset_release_assets.v1",
+      "sources": [
+        "tools/dataset_release_assets.py"
       ]
     },
     {

--- a/src/agilab/apps-pages/templates/analysis_page_template/src/view_demo/view_demo.py
+++ b/src/agilab/apps-pages/templates/analysis_page_template/src/view_demo/view_demo.py
@@ -90,7 +90,7 @@ def main() -> None:
         return
 
     env = _load_project_env(active_app)
-    st.subheader(f"Project: {getattr(env, 'app', active_app)}")
+    st.subheader(str(getattr(env, "app", active_app)))
     st.caption(f"Project path: {getattr(env, 'active_app', active_app)}")
 
     dataset_root = _dataset_root(env)

--- a/src/agilab/apps-pages/view_maps/src/view_maps/view_maps.py
+++ b/src/agilab/apps-pages/view_maps/src/view_maps/view_maps.py
@@ -93,7 +93,7 @@ def _analysis_return_url(app: str) -> str:
 def _render_app_page_context(app: str, active_app: Path) -> None:
     columns = st.columns(2)
     with columns[0]:
-        st.caption(f"Project: `{app}`")
+        st.caption(f"`{app}`")
     with columns[1]:
         link_button = getattr(st, "link_button", None)
         url = _analysis_return_url(app)

--- a/src/agilab/apps-pages/view_maps_network/src/view_maps_network/view_maps_network.py
+++ b/src/agilab/apps-pages/view_maps_network/src/view_maps_network/view_maps_network.py
@@ -254,7 +254,7 @@ def _reset_app_scoped_session_state(active_app_path: Path) -> bool:
 def _render_app_page_context(app: str, active_app: Path) -> None:
     columns = st.columns(2)
     with columns[0]:
-        st.caption(f"Project: `{app}`")
+        st.caption(f"`{app}`")
     with columns[1]:
         link_button = getattr(st, "link_button", None)
         url = _analysis_return_url(app)

--- a/src/agilab/apps/builtin/pytorch_playground_project/src/app_settings.toml
+++ b/src/agilab/apps/builtin/pytorch_playground_project/src/app_settings.toml
@@ -45,6 +45,7 @@ view_module = []
 title = "PyTorch Playground"
 entrypoint = "pytorch_playground/app_surface.py"
 default = "streamlit"
+sidebar_controls = true
 
 [app_surface.backends.streamlit]
 title = "PyTorch Playground"

--- a/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/app_surface.py
+++ b/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/app_surface.py
@@ -106,13 +106,60 @@ def _resolve_active_app_path(active_app: Path | None = None) -> Path | None:
     return None
 
 
-def _load_orchestrate_args(active_app_path: Path):
-    from agi_env import AgiEnv
+def _env_matches_active_app(env: Any, active_app_path: Path) -> bool:
+    try:
+        resolved_active_app = active_app_path.expanduser().resolve(strict=False)
+    except (OSError, RuntimeError, TypeError, ValueError):
+        resolved_active_app = active_app_path.expanduser()
+
+    for value in (
+        getattr(env, "active_app", None),
+        getattr(env, "app_path", None),
+    ):
+        if not value:
+            continue
+        try:
+            if Path(str(value)).expanduser().resolve(strict=False) == resolved_active_app:
+                return True
+        except (OSError, RuntimeError, TypeError, ValueError):
+            continue
+
+    app_name = active_app_path.name
+    current_app = Path(str(getattr(env, "app", "") or "")).name
+    if current_app != app_name:
+        return False
+    apps_path = getattr(env, "apps_path", None)
+    if not apps_path:
+        return True
+    try:
+        root = Path(str(apps_path)).expanduser().resolve(strict=False)
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return True
+    return resolved_active_app in {
+        (root / app_name).resolve(strict=False),
+        (root / "builtin" / app_name).resolve(strict=False),
+    }
+
+
+def _load_orchestrate_args(active_app_path: Path, *, env: Any | None = None):
     from pytorch_playground import app_args
 
-    env = getattr(AgiEnv, "for_app", AgiEnv)(apps_path=active_app_path.parent, app=active_app_path.name, verbose=0)
+    if env is None:
+        from agi_env import AgiEnv
+
+        env = getattr(AgiEnv, "for_app", AgiEnv)(
+            apps_path=active_app_path.parent,
+            app=active_app_path.name,
+            verbose=0,
+        )
+        settings_path = env.app_settings_file
+    else:
+        settings_path = active_app_path / "src" / "app_settings.toml"
+        env_settings_file = getattr(env, "app_settings_file", None)
+        if env_settings_file and _env_matches_active_app(env, active_app_path):
+            settings_path = Path(env_settings_file)
     args_model = app_args.ensure_defaults(
-        app_args.load_args(env.app_settings_file), env=env
+        app_args.load_args(settings_path), env=env
     )
     return env, args_model
 
@@ -221,6 +268,7 @@ def _render_missing_evidence(paths: list[Path], *, configure_page: bool = True) 
 def _render_analysis_surface(
     active_app_path: Path | None,
     *,
+    env: Any | None = None,
     configure_page: bool = True,
     compact: bool = False,
 ) -> None:
@@ -233,7 +281,7 @@ def _render_analysis_surface(
         playground_ui.main(configure_page=configure_page, compact=compact)
         return
     try:
-        runtime_env, args_model = _load_orchestrate_args(active_app_path)
+        runtime_env, args_model = _load_orchestrate_args(active_app_path, env=env)
         evidence_dirs = _analysis_evidence_dirs(
             runtime_env, args_model, active_app_path
         )
@@ -294,7 +342,11 @@ def _run_playground_once(runtime_env: Any, args_model: Any):
 
 
 def _render_run_button(
-    active_app_path: Path, *, container: Any, app_args_form: Any | None = None
+    active_app_path: Path,
+    *,
+    container: Any,
+    env: Any | None = None,
+    app_args_form: Any | None = None,
 ) -> None:
     import streamlit as st
 
@@ -306,7 +358,7 @@ def _render_run_button(
     ):
         return
     try:
-        runtime_env, args_model = _load_orchestrate_args(active_app_path)
+        runtime_env, args_model = _load_orchestrate_args(active_app_path, env=env)
         persist_current_args = getattr(
             app_args_form or _load_app_args_form(), "persist_current_args", None
         )
@@ -346,6 +398,99 @@ def _render_surface_styles() -> None:
     )
 
 
+def _query_param_is_truthy(name: str) -> bool:
+    import streamlit as st
+
+    try:
+        value = st.query_params.get(name)
+    except Exception:
+        value = None
+    if isinstance(value, (list, tuple)):
+        value = value[-1] if value else ""
+    return str(value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _hide_embedded_streamlit_sidebar() -> None:
+    import streamlit as st
+
+    st.markdown(
+        """
+        <style>
+        html, body,
+        [data-testid="stApp"],
+        [data-testid="stAppViewContainer"],
+        [data-testid="stMain"],
+        .main {
+          margin-left: 0 !important;
+          padding-left: 0 !important;
+          width: 100% !important;
+          max-width: 100% !important;
+        }
+        section[data-testid="stSidebar"],
+        [data-testid="stSidebar"],
+        [data-testid="stSidebarContent"],
+        [data-testid="stSidebarHeader"],
+        [data-testid="stSidebarNav"],
+        [data-testid="stSidebarUserContent"],
+        [data-testid="stSidebarCollapsedControl"],
+        [data-testid="collapsedControl"],
+        [aria-label="Sidebar"],
+        [aria-label="sidebar"],
+        button[title="Open sidebar"],
+        button[title="Close sidebar"] {
+          display: none !important;
+          visibility: hidden !important;
+          width: 0 !important;
+          min-width: 0 !important;
+          max-width: 0 !important;
+        }
+        header[data-testid="stHeader"] {
+          left: 0 !important;
+        }
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )
+
+
+def _render_controls_surface(
+    active_app_path: Path,
+    *,
+    env: Any | None = None,
+    container: Any | None = None,
+) -> None:
+    import streamlit as st
+
+    controls_container = container or st.sidebar
+    try:
+        runtime_env, _args_model = _load_orchestrate_args(active_app_path, env=env)
+    except Exception as exc:
+        controls_container.error(f"Unable to load ORCHESTRATE app arguments: {exc}")
+        return
+
+    with controls_container:
+        controls_container.markdown("**Run**")
+        try:
+            app_args_form = _load_app_args_form()
+        except (ImportError, OSError, ValueError) as exc:
+            _render_dependency_import_error(
+                exc, configure_page=False, container=controls_container
+            )
+        else:
+            _render_run_button(
+                active_app_path,
+                container=controls_container,
+                env=env or runtime_env,
+                app_args_form=app_args_form,
+            )
+            app_args_form.render(
+                env=env or runtime_env,
+                container=controls_container,
+                wide=False,
+                compact=True,
+            )
+
+
 def _render_full_surface(
     active_app_path: Path | None,
     *,
@@ -368,10 +513,16 @@ def _render_full_surface(
         return
 
     if container is None:
+        embedded = _query_param_is_truthy("embed")
         st.set_page_config(
             page_title=getattr(playground_ui, "PAGE_TITLE", "PyTorch Playground"),
             layout="wide",
+            initial_sidebar_state="collapsed" if embedded else "auto",
         )
+        if embedded:
+            _hide_embedded_streamlit_sidebar()
+    else:
+        embedded = False
 
     try:
         runtime_env, _args_model = _load_orchestrate_args(active_app_path)
@@ -382,34 +533,28 @@ def _render_full_surface(
     root = container or st
     _render_surface_styles()
     if container is None:
-        analysis_container = None
-        controls_container = st.sidebar
+        if not embedded:
+            _render_controls_surface(active_app_path, env=env or runtime_env)
+        _render_analysis_surface(
+            active_app_path,
+            env=env or runtime_env,
+            configure_page=False,
+            compact=True,
+        )
+        return
     else:
         analysis_container, controls_container = root.columns([0.70, 0.30])
 
-    with controls_container:
-        controls_container.markdown("**Run**")
-        try:
-            app_args_form = _load_app_args_form()
-        except (ImportError, OSError, ValueError) as exc:
-            _render_dependency_import_error(
-                exc, configure_page=False, container=controls_container
-            )
-        else:
-            _render_run_button(
-                active_app_path, container=controls_container, app_args_form=app_args_form
-            )
-            app_args_form.render(
-                env=env or runtime_env,
-                container=controls_container,
-                wide=False,
-                compact=True,
-            )
-    if analysis_container is None:
-        _render_analysis_surface(active_app_path, configure_page=False, compact=True)
-    else:
-        with analysis_container:
-            _render_analysis_surface(active_app_path, configure_page=False, compact=True)
+    _render_controls_surface(
+        active_app_path, env=env or runtime_env, container=controls_container
+    )
+    with analysis_container:
+        _render_analysis_surface(
+            active_app_path,
+            env=env or runtime_env,
+            configure_page=False,
+            compact=True,
+        )
 
 
 def render(
@@ -425,9 +570,19 @@ def render(
         app_args_form = _load_app_args_form()
         app_args_form.render(env=env, container=container)
         return
+    if surface_mode == "controls":
+        active_app_path = _resolve_active_app_path(active_app)
+        if active_app_path is not None:
+            _render_controls_surface(active_app_path, env=env, container=container)
+        return
     if surface_mode == "analysis":
         active_app_path = _resolve_active_app_path(active_app)
-        _render_analysis_surface(active_app_path)
+        _render_analysis_surface(
+            active_app_path,
+            env=env,
+            configure_page=container is None,
+            compact=container is not None,
+        )
         return
     if surface_mode == "full":
         active_app_path = _resolve_active_app_path(active_app)

--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/app_settings.toml
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/app_settings.toml
@@ -45,6 +45,7 @@ view_module = []
 title = "PyTorch Playground"
 entrypoint = "pytorch_playground/app_surface.py"
 default = "streamlit"
+sidebar_controls = true
 
 [app_surface.backends.streamlit]
 title = "PyTorch Playground"

--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground/app_surface.py
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground/app_surface.py
@@ -106,13 +106,60 @@ def _resolve_active_app_path(active_app: Path | None = None) -> Path | None:
     return None
 
 
-def _load_orchestrate_args(active_app_path: Path):
-    from agi_env import AgiEnv
+def _env_matches_active_app(env: Any, active_app_path: Path) -> bool:
+    try:
+        resolved_active_app = active_app_path.expanduser().resolve(strict=False)
+    except (OSError, RuntimeError, TypeError, ValueError):
+        resolved_active_app = active_app_path.expanduser()
+
+    for value in (
+        getattr(env, "active_app", None),
+        getattr(env, "app_path", None),
+    ):
+        if not value:
+            continue
+        try:
+            if Path(str(value)).expanduser().resolve(strict=False) == resolved_active_app:
+                return True
+        except (OSError, RuntimeError, TypeError, ValueError):
+            continue
+
+    app_name = active_app_path.name
+    current_app = Path(str(getattr(env, "app", "") or "")).name
+    if current_app != app_name:
+        return False
+    apps_path = getattr(env, "apps_path", None)
+    if not apps_path:
+        return True
+    try:
+        root = Path(str(apps_path)).expanduser().resolve(strict=False)
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return True
+    return resolved_active_app in {
+        (root / app_name).resolve(strict=False),
+        (root / "builtin" / app_name).resolve(strict=False),
+    }
+
+
+def _load_orchestrate_args(active_app_path: Path, *, env: Any | None = None):
     from pytorch_playground import app_args
 
-    env = getattr(AgiEnv, "for_app", AgiEnv)(apps_path=active_app_path.parent, app=active_app_path.name, verbose=0)
+    if env is None:
+        from agi_env import AgiEnv
+
+        env = getattr(AgiEnv, "for_app", AgiEnv)(
+            apps_path=active_app_path.parent,
+            app=active_app_path.name,
+            verbose=0,
+        )
+        settings_path = env.app_settings_file
+    else:
+        settings_path = active_app_path / "src" / "app_settings.toml"
+        env_settings_file = getattr(env, "app_settings_file", None)
+        if env_settings_file and _env_matches_active_app(env, active_app_path):
+            settings_path = Path(env_settings_file)
     args_model = app_args.ensure_defaults(
-        app_args.load_args(env.app_settings_file), env=env
+        app_args.load_args(settings_path), env=env
     )
     return env, args_model
 
@@ -221,6 +268,7 @@ def _render_missing_evidence(paths: list[Path], *, configure_page: bool = True) 
 def _render_analysis_surface(
     active_app_path: Path | None,
     *,
+    env: Any | None = None,
     configure_page: bool = True,
     compact: bool = False,
 ) -> None:
@@ -233,7 +281,7 @@ def _render_analysis_surface(
         playground_ui.main(configure_page=configure_page, compact=compact)
         return
     try:
-        runtime_env, args_model = _load_orchestrate_args(active_app_path)
+        runtime_env, args_model = _load_orchestrate_args(active_app_path, env=env)
         evidence_dirs = _analysis_evidence_dirs(
             runtime_env, args_model, active_app_path
         )
@@ -294,7 +342,11 @@ def _run_playground_once(runtime_env: Any, args_model: Any):
 
 
 def _render_run_button(
-    active_app_path: Path, *, container: Any, app_args_form: Any | None = None
+    active_app_path: Path,
+    *,
+    container: Any,
+    env: Any | None = None,
+    app_args_form: Any | None = None,
 ) -> None:
     import streamlit as st
 
@@ -306,7 +358,7 @@ def _render_run_button(
     ):
         return
     try:
-        runtime_env, args_model = _load_orchestrate_args(active_app_path)
+        runtime_env, args_model = _load_orchestrate_args(active_app_path, env=env)
         persist_current_args = getattr(
             app_args_form or _load_app_args_form(), "persist_current_args", None
         )
@@ -346,6 +398,99 @@ def _render_surface_styles() -> None:
     )
 
 
+def _query_param_is_truthy(name: str) -> bool:
+    import streamlit as st
+
+    try:
+        value = st.query_params.get(name)
+    except Exception:
+        value = None
+    if isinstance(value, (list, tuple)):
+        value = value[-1] if value else ""
+    return str(value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _hide_embedded_streamlit_sidebar() -> None:
+    import streamlit as st
+
+    st.markdown(
+        """
+        <style>
+        html, body,
+        [data-testid="stApp"],
+        [data-testid="stAppViewContainer"],
+        [data-testid="stMain"],
+        .main {
+          margin-left: 0 !important;
+          padding-left: 0 !important;
+          width: 100% !important;
+          max-width: 100% !important;
+        }
+        section[data-testid="stSidebar"],
+        [data-testid="stSidebar"],
+        [data-testid="stSidebarContent"],
+        [data-testid="stSidebarHeader"],
+        [data-testid="stSidebarNav"],
+        [data-testid="stSidebarUserContent"],
+        [data-testid="stSidebarCollapsedControl"],
+        [data-testid="collapsedControl"],
+        [aria-label="Sidebar"],
+        [aria-label="sidebar"],
+        button[title="Open sidebar"],
+        button[title="Close sidebar"] {
+          display: none !important;
+          visibility: hidden !important;
+          width: 0 !important;
+          min-width: 0 !important;
+          max-width: 0 !important;
+        }
+        header[data-testid="stHeader"] {
+          left: 0 !important;
+        }
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )
+
+
+def _render_controls_surface(
+    active_app_path: Path,
+    *,
+    env: Any | None = None,
+    container: Any | None = None,
+) -> None:
+    import streamlit as st
+
+    controls_container = container or st.sidebar
+    try:
+        runtime_env, _args_model = _load_orchestrate_args(active_app_path, env=env)
+    except Exception as exc:
+        controls_container.error(f"Unable to load ORCHESTRATE app arguments: {exc}")
+        return
+
+    with controls_container:
+        controls_container.markdown("**Run**")
+        try:
+            app_args_form = _load_app_args_form()
+        except (ImportError, OSError, ValueError) as exc:
+            _render_dependency_import_error(
+                exc, configure_page=False, container=controls_container
+            )
+        else:
+            _render_run_button(
+                active_app_path,
+                container=controls_container,
+                env=env or runtime_env,
+                app_args_form=app_args_form,
+            )
+            app_args_form.render(
+                env=env or runtime_env,
+                container=controls_container,
+                wide=False,
+                compact=True,
+            )
+
+
 def _render_full_surface(
     active_app_path: Path | None,
     *,
@@ -368,10 +513,16 @@ def _render_full_surface(
         return
 
     if container is None:
+        embedded = _query_param_is_truthy("embed")
         st.set_page_config(
             page_title=getattr(playground_ui, "PAGE_TITLE", "PyTorch Playground"),
             layout="wide",
+            initial_sidebar_state="collapsed" if embedded else "auto",
         )
+        if embedded:
+            _hide_embedded_streamlit_sidebar()
+    else:
+        embedded = False
 
     try:
         runtime_env, _args_model = _load_orchestrate_args(active_app_path)
@@ -382,34 +533,28 @@ def _render_full_surface(
     root = container or st
     _render_surface_styles()
     if container is None:
-        analysis_container = None
-        controls_container = st.sidebar
+        if not embedded:
+            _render_controls_surface(active_app_path, env=env or runtime_env)
+        _render_analysis_surface(
+            active_app_path,
+            env=env or runtime_env,
+            configure_page=False,
+            compact=True,
+        )
+        return
     else:
         analysis_container, controls_container = root.columns([0.70, 0.30])
 
-    with controls_container:
-        controls_container.markdown("**Run**")
-        try:
-            app_args_form = _load_app_args_form()
-        except (ImportError, OSError, ValueError) as exc:
-            _render_dependency_import_error(
-                exc, configure_page=False, container=controls_container
-            )
-        else:
-            _render_run_button(
-                active_app_path, container=controls_container, app_args_form=app_args_form
-            )
-            app_args_form.render(
-                env=env or runtime_env,
-                container=controls_container,
-                wide=False,
-                compact=True,
-            )
-    if analysis_container is None:
-        _render_analysis_surface(active_app_path, configure_page=False, compact=True)
-    else:
-        with analysis_container:
-            _render_analysis_surface(active_app_path, configure_page=False, compact=True)
+    _render_controls_surface(
+        active_app_path, env=env or runtime_env, container=controls_container
+    )
+    with analysis_container:
+        _render_analysis_surface(
+            active_app_path,
+            env=env or runtime_env,
+            configure_page=False,
+            compact=True,
+        )
 
 
 def render(
@@ -425,9 +570,19 @@ def render(
         app_args_form = _load_app_args_form()
         app_args_form.render(env=env, container=container)
         return
+    if surface_mode == "controls":
+        active_app_path = _resolve_active_app_path(active_app)
+        if active_app_path is not None:
+            _render_controls_surface(active_app_path, env=env, container=container)
+        return
     if surface_mode == "analysis":
         active_app_path = _resolve_active_app_path(active_app)
-        _render_analysis_surface(active_app_path)
+        _render_analysis_surface(
+            active_app_path,
+            env=env,
+            configure_page=container is None,
+            compact=container is not None,
+        )
         return
     if surface_mode == "full":
         active_app_path = _resolve_active_app_path(active_app)

--- a/src/agilab/page_bootstrap.py
+++ b/src/agilab/page_bootstrap.py
@@ -241,6 +241,35 @@ def configure_page_chrome(
         inject_theme(resources_path)
 
 
+def _active_project_label(env: Any | None) -> str:
+    """Return the display label for the currently selected project."""
+    if env is None:
+        return ""
+    for attr_name in ("app", "target", "active_app"):
+        value = getattr(env, attr_name, None)
+        text = str(value or "").strip()
+        if not text:
+            continue
+        label = Path(text).name
+        if label.endswith("_project"):
+            label = label[: -len("_project")]
+        return label.replace("_", " ").title().replace("Pytorch", "PyTorch")
+    return ""
+
+
+def render_active_project_chip(streamlit: Any, *, env: Any | None = None) -> bool:
+    """Render a compact selected-project label using the historical page-chrome path."""
+    project_label = _active_project_label(env)
+    if not project_label:
+        return False
+    sidebar = getattr(streamlit, "sidebar", None)
+    markdown = getattr(sidebar, "markdown", None)
+    if not callable(markdown):
+        return False
+    markdown(f"**{project_label}**")
+    return True
+
+
 def render_page_header(
     streamlit: Any,
     *,
@@ -269,6 +298,7 @@ def render_page_header(
 
     render_logo()
     render_pinned_expanders(streamlit)
+    render_active_project_chip(streamlit, env=env)
     if show_project_context and render_page_context is not None:
         render_page_context(streamlit, page_label=page_label, env=env)
 

--- a/src/agilab/pages/4_ANALYSIS.py
+++ b/src/agilab/pages/4_ANALYSIS.py
@@ -120,6 +120,7 @@ import_agilab_symbols(
         "app_surface_config": "app_surface_config",
         "app_surface_title": "app_surface_title",
         "configured_app_surface_entrypoint": "configured_app_surface_entrypoint",
+        "render_app_surface": "render_app_surface",
     },
     current_file=__file__,
     fallback_path=Path(__file__).resolve().parents[1] / "app_surface.py",
@@ -1727,9 +1728,9 @@ def _migrate_declared_app_surface_config(
     )
     declared_app_ui_page = _declared_app_ui_page_config(active_app_path)
     if seed_restricts_views:
-        desired_modules = _dedupe_preserve_order(seed_modules)
-        if declared_app_ui_page is not None and not desired_modules:
-            desired_modules = [_APP_UI_PAGE_KEY]
+        desired_modules = _dedupe_preserve_order(seed_modules or [_APP_UI_PAGE_KEY])
+        if _APP_UI_PAGE_KEY not in desired_modules:
+            desired_modules.insert(0, _APP_UI_PAGE_KEY)
         if pages.get("restrict_to_view_module") is not True:
             pages["restrict_to_view_module"] = True
             changed = True
@@ -2018,7 +2019,14 @@ def _find_view_entry(
     return str(candidate), entry_point
 
 
-def _view_label(option_id: str, builtin_names: set[str]) -> str:
+def _view_label(
+    option_id: str,
+    builtin_names: set[str],
+    *,
+    app_surface_cfg: dict[str, Any] | None = None,
+) -> str:
+    if option_id == _APP_UI_PAGE_KEY and app_surface_cfg:
+        return app_surface_title(app_surface_cfg)
     if option_id in builtin_names:
         return option_id
     try:
@@ -2311,6 +2319,13 @@ def _analysis_sidebar_view_url(project: str | None, view_path: Path) -> str:
     return f"?{urlencode(params)}"
 
 
+def _analysis_sidebar_route_url(project: str | None, route: str) -> str:
+    params = {"current_page": route}
+    if project:
+        params["active_app"] = project
+    return f"?{urlencode(params)}"
+
+
 def _analysis_sidebar_notebook_url(project: str | None, notebook_path: Path) -> str:
     params = {"current_notebook": str(notebook_path.resolve())}
     if project:
@@ -2325,6 +2340,7 @@ def _render_analysis_sidebar_view_launcher(
     view_names: list[str],
     resolved_pages: dict[str, Path],
     custom_view_lookup: dict[str, Path],
+    app_surface_cfg: dict[str, Any] | None = None,
 ) -> None:
     launch_options = list(dict.fromkeys(selected_views))
     if not launch_options:
@@ -2340,13 +2356,20 @@ def _render_analysis_sidebar_view_launcher(
     missing_views: list[str] = []
     for view_name in launch_options:
         view_path = _resolve_view_path(view_name, resolved_pages, custom_view_lookup)
-        display_label = _view_label(view_name, builtin_names)
+        display_label = _view_label(
+            view_name,
+            builtin_names,
+            app_surface_cfg=app_surface_cfg,
+        )
         if view_path is None:
             missing_views.append(display_label)
             continue
-        link_href = html.escape(
-            _analysis_sidebar_view_url(project, view_path), quote=True
+        view_url = (
+            _analysis_sidebar_route_url(project, _APP_UI_PAGE_KEY)
+            if view_name == _APP_UI_PAGE_KEY and app_surface_cfg
+            else _analysis_sidebar_view_url(project, view_path)
         )
+        link_href = html.escape(view_url, quote=True)
         link_label = html.escape(display_label)
         link_weight = "650" if view_name in linked_views else "450"
         link_rows.append(
@@ -2746,11 +2769,30 @@ async def _render_configured_app_surface(
     entrypoint = configured_app_surface_entrypoint(active_app_path, cfg)
     if entrypoint is None:
         return False
+    if current_page in {None, "", "main"}:
+        return False
     if _is_app_surface_overview_requested(current_page):
         return False
     if _query_param_is_truthy(st.query_params.get(_APP_SURFACE_HIDE_QUERY_PARAM)):
         return False
     surface_config = app_surface_config(active_app_path, cfg)
+    if surface_config.get("sidebar_controls"):
+        render_app_surface(
+            active_app_path,
+            mode="controls",
+            config=cfg,
+            env=st.session_state.get("env"),
+            container=st.sidebar,
+        )
+        st.subheader(app_surface_title(surface_config))
+        render_app_surface(
+            active_app_path,
+            mode="analysis",
+            config=cfg,
+            env=st.session_state.get("env"),
+            container=st.container(),
+        )
+        return True
     await render_view_page(
         entrypoint,
         title=app_surface_title(surface_config),
@@ -2892,12 +2934,15 @@ async def main():
         sidebar_selected_views: list[str],
         sidebar_selected_notebooks: list[str],
     ) -> None:
+        if project:
+            st.sidebar.caption(f"Project: `{project}`")
         _render_analysis_sidebar_view_launcher(
             project=project,
             selected_views=sidebar_selected_views,
             view_names=all_available_views,
             resolved_pages=resolved_pages,
             custom_view_lookup=custom_view_lookup,
+            app_surface_cfg=app_surface_config(active_app_path, cfg),
         )
         _render_analysis_sidebar_notebook_launcher(
             project=project,
@@ -2913,6 +2958,7 @@ async def main():
     )
     app_surface_will_render = (
         configured_app_surface_entrypoint(active_app_path, cfg) is not None
+        and current_page not in {None, "", "main"}
         and not _is_app_surface_overview_requested(current_page)
         and not _query_param_is_truthy(st.query_params.get(_APP_SURFACE_HIDE_QUERY_PARAM))
     )
@@ -2929,6 +2975,10 @@ async def main():
     # Route: only render a child surface when the param is concrete, not "main"/empty.
     # The sidebar launchers above stay visible on child views/notebooks.
     if _consume_legacy_app_ui_route_for_app_surface(current_page, active_app_path):
+        if await _render_configured_app_surface(
+            active_app_path, cfg, current_page=_APP_UI_PAGE_KEY
+        ):
+            return
         current_page = None
     if await _render_selected_notebook_route(current_notebook):
         return
@@ -2963,7 +3013,11 @@ async def main():
             "Analysis views",
             view_names,
             key=selection_key,
-            format_func=lambda option: _view_label(option, set(resolved_pages.keys())),
+            format_func=lambda option: _view_label(
+                option,
+                set(resolved_pages.keys()),
+                app_surface_cfg=app_surface_config(active_app_path, cfg),
+            ),
             help="Selected views are persisted in the active project's app settings.",
         )
 
@@ -3171,7 +3225,11 @@ async def render_view_page(
         await _render_view_page_inline(view_path, active_app_arg)
         return
 
-    port = _port_for(f"{view_key}|{active_app_arg}")
+    try:
+        view_version_token = str(int(view_path.stat().st_mtime_ns))
+    except OSError:
+        view_version_token = "missing"
+    port = _port_for(f"{view_key}|{active_app_arg}|{view_version_token}")
     sidecar_ready = _ensure_sidecar(view_key, view_path, port, active_app_arg)
 
     # Regular iframe (child keeps its own sidebar if it has one), preserve extra query params (e.g., datadir_rel)

--- a/src/agilab/pages/4_ANALYSIS.py
+++ b/src/agilab/pages/4_ANALYSIS.py
@@ -2026,7 +2026,7 @@ def _view_label(
     app_surface_cfg: dict[str, Any] | None = None,
 ) -> str:
     if option_id == _APP_UI_PAGE_KEY and app_surface_cfg:
-        return app_surface_title(app_surface_cfg)
+        return "Page"
     if option_id in builtin_names:
         return option_id
     try:
@@ -2326,6 +2326,32 @@ def _analysis_sidebar_route_url(project: str | None, route: str) -> str:
     return f"?{urlencode(params)}"
 
 
+def _analysis_project_link_label(
+    project: str,
+    *,
+    app_surface_cfg: dict[str, Any] | None = None,
+) -> str:
+    if app_surface_cfg:
+        title = app_surface_title(app_surface_cfg).strip()
+        if title and title != "App Surface":
+            return title
+    return project.replace("_", " ").title()
+
+
+def _render_analysis_project_sidebar_label(
+    project: str | None,
+    active_app_path: Path | None,
+    cfg: dict[str, Any],
+) -> None:
+    if not project:
+        return
+    label = _analysis_project_link_label(
+        project,
+        app_surface_cfg=app_surface_config(active_app_path, cfg),
+    )
+    st.sidebar.markdown(f"**{html.escape(label)}**")
+
+
 def _analysis_sidebar_notebook_url(project: str | None, notebook_path: Path) -> str:
     params = {"current_notebook": str(notebook_path.resolve())}
     if project:
@@ -2384,8 +2410,9 @@ def _render_analysis_sidebar_view_launcher(
                 "<style>"
                 ".agilab-analysis-view-links{display:flex;flex-direction:column;"
                 "gap:.12rem;margin:.1rem 0 .45rem 0;}"
-                ".agilab-analysis-view-link a{font-size:.88rem;line-height:1.18;text-decoration:none;}"
-                ".agilab-analysis-view-link a:hover{text-decoration:underline;}"
+                ".agilab-analysis-view-link a{font-size:.88rem;line-height:1.18;"
+                "color:var(--primary-color);text-decoration:underline;}"
+                ".agilab-analysis-view-link a:hover{text-decoration-thickness:2px;}"
                 "</style>"
                 "<div class='agilab-analysis-view-links'>"
                 + "".join(link_rows)
@@ -2434,8 +2461,9 @@ def _render_analysis_sidebar_notebook_launcher(
                 "<style>"
                 ".agilab-analysis-notebook-links{display:flex;flex-direction:column;"
                 "gap:.12rem;margin:.1rem 0 .45rem 0;}"
-                ".agilab-analysis-notebook-link a{font-size:.88rem;line-height:1.18;text-decoration:none;}"
-                ".agilab-analysis-notebook-link a:hover{text-decoration:underline;}"
+                ".agilab-analysis-notebook-link a{font-size:.88rem;line-height:1.18;"
+                "color:var(--primary-color);text-decoration:underline;}"
+                ".agilab-analysis-notebook-link a:hover{text-decoration-thickness:2px;}"
                 "</style>"
                 "<div class='agilab-analysis-notebook-links'>"
                 + "".join(link_rows)
@@ -2784,6 +2812,12 @@ async def _render_configured_app_surface(
             env=st.session_state.get("env"),
             container=st.sidebar,
         )
+        if active_app_path is not None:
+            project_label = _analysis_project_link_label(
+                active_app_path.name,
+                app_surface_cfg=surface_config,
+            )
+            st.markdown(f"**{html.escape(project_label)}**")
         st.subheader(app_surface_title(surface_config))
         render_app_surface(
             active_app_path,
@@ -2817,7 +2851,7 @@ async def main():
         st.query_params["active_app"] = env.app
 
     # Sidebar header/logo
-    render_page_header(st, page_label="ANALYSIS", env=env)
+    render_page_header(st, page_label="ANALYSIS", env=None)
     from agilab.workflow_ui import render_context_expander
 
     render_context_expander(st, page_label="ANALYSIS", env=env)
@@ -2852,6 +2886,7 @@ async def main():
         migrated_cfg = True
     if migrated_cfg:
         _write_config(app_settings, cfg)
+    _render_analysis_project_sidebar_label(project, active_app_path, cfg)
     configured_views: list[str] = [
         str(v)
         for v in cfg.get("pages", {}).get("view_module", [])
@@ -2884,9 +2919,13 @@ async def main():
     selection_key = f"view_selection__{project or 'default'}"
     pages_cfg = cfg.get("pages", {})
     pages_cfg = pages_cfg if isinstance(pages_cfg, dict) else {}
+    surface_config = app_surface_config(active_app_path, cfg)
+    pages_cfg_for_selection = dict(pages_cfg)
+    if surface_config and _APP_UI_PAGE_KEY in configured_views:
+        pages_cfg_for_selection["restrict_to_view_module"] = False
     has_view_session_selection = selection_key in st.session_state
     selection_state = build_analysis_view_selection_state(
-        pages_cfg=pages_cfg,
+        pages_cfg=pages_cfg_for_selection,
         current_page=current_page,
         configured_views=configured_views,
         resolved_pages=resolved_pages,
@@ -2934,8 +2973,6 @@ async def main():
         sidebar_selected_views: list[str],
         sidebar_selected_notebooks: list[str],
     ) -> None:
-        if project:
-            st.sidebar.caption(f"Project: `{project}`")
         _render_analysis_sidebar_view_launcher(
             project=project,
             selected_views=sidebar_selected_views,
@@ -3034,7 +3071,7 @@ async def main():
         expanded=not selected_views and not selected_notebooks,
     )
 
-    pages_cfg_for_selection = dict(pages_cfg)
+    pages_cfg_for_persistence = dict(pages_cfg_for_selection)
     selected_view_set = set(selected_views)
     configured_default_views = [
         view_name
@@ -3042,15 +3079,15 @@ async def main():
         if view_name in selected_view_set
     ]
     if configured_default_views:
-        pages_cfg_for_selection["default_views"] = configured_default_views
-        pages_cfg_for_selection["default_view"] = configured_default_views[0]
+        pages_cfg_for_persistence["default_views"] = configured_default_views
+        pages_cfg_for_persistence["default_view"] = configured_default_views[0]
     else:
-        pages_cfg_for_selection.pop("default_views", None)
-        pages_cfg_for_selection.pop("default_view", None)
+        pages_cfg_for_persistence.pop("default_views", None)
+        pages_cfg_for_persistence.pop("default_view", None)
     selection_for_state = list(selected_views)
 
     selection_state = build_analysis_view_selection_state(
-        pages_cfg=pages_cfg_for_selection,
+        pages_cfg=pages_cfg_for_persistence,
         current_page=current_page,
         configured_views=configured_views,
         resolved_pages=resolved_pages,

--- a/src/agilab/workflow_ui.py
+++ b/src/agilab/workflow_ui.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import html
+import inspect
 import json
 import os
 import re
@@ -504,17 +505,13 @@ def render_next_best_action(
     """Render one navigation CTA derived from project readiness."""
     action = project_next_action(env)
     streamlit.caption(f"{title}: {action['detail']}")
-    link_button = getattr(streamlit, "link_button", None)
-    if callable(link_button):
-        link_button(
-            action["label"],
-            action["url"],
-            key=f"{key_prefix}:next:{_stable_key_part(action['id'])}",
-            type=action.get("type", "primary"),
-            width="content",
-        )
-    else:
-        streamlit.markdown(f"[{action['label']}]({action['url']})")
+    _render_link_button(
+        streamlit,
+        label=action["label"],
+        url=action["url"],
+        key=f"{key_prefix}:next:{_stable_key_part(action['id'])}",
+        type=action.get("type", "primary"),
+    )
     return action
 
 
@@ -595,9 +592,36 @@ def _render_context_link(
     key: str,
     type: str = "secondary",
 ) -> None:
+    _render_link_button(streamlit, label=label, url=url, key=key, type=type)
+
+
+def _callable_accepts_keyword(callable_obj: Any, keyword: str) -> bool:
+    try:
+        signature = inspect.signature(callable_obj)
+    except (TypeError, ValueError):
+        return True
+    if keyword in signature.parameters:
+        return True
+    return any(
+        parameter.kind is inspect.Parameter.VAR_KEYWORD
+        for parameter in signature.parameters.values()
+    )
+
+
+def _render_link_button(
+    streamlit: Any,
+    *,
+    label: str,
+    url: str,
+    key: str,
+    type: str = "secondary",
+) -> None:
     link_button = getattr(streamlit, "link_button", None)
     if callable(link_button):
-        link_button(label, url, key=key, type=type, width="content")
+        kwargs = {"type": type, "width": "content"}
+        if _callable_accepts_keyword(link_button, "key"):
+            kwargs["key"] = key
+        link_button(label, url, **kwargs)
         return
     streamlit.markdown(f"[{label}]({url})")
 

--- a/test/test_analysis_page_helpers.py
+++ b/test/test_analysis_page_helpers.py
@@ -1365,7 +1365,7 @@ def test_analysis_page_state_falls_back_to_all_views_when_restrict_config_is_emp
     assert state.widget_selection == ()
 
 
-def test_app_surface_migration_preserves_intentionally_empty_analysis_views(tmp_path: Path):
+def test_app_surface_migration_selects_app_ui_by_default(tmp_path: Path):
     module = _load_analysis_module()
     active_app_path = tmp_path / "app_surface_project"
     surface_module = active_app_path / "src" / "demo_surface"
@@ -1390,7 +1390,7 @@ default = "streamlit"
 
     assert changed is True
     assert cfg["pages"]["restrict_to_view_module"] is True
-    assert cfg["pages"]["view_module"] == []
+    assert cfg["pages"]["view_module"] == ["view_app_ui"]
     assert "view_app_ui" not in cfg["pages"]
     assert cfg["app_surface"]["entrypoint"] == "demo_surface/app.py"
 

--- a/test/test_pytorch_playground_app.py
+++ b/test/test_pytorch_playground_app.py
@@ -12,6 +12,7 @@ from types import ModuleType
 from types import SimpleNamespace
 import zipfile
 
+import agi_env as agi_env_package
 import numpy as np
 import pandas as pd
 import pytest
@@ -389,7 +390,7 @@ def test_app_surface_analysis_uses_orchestrate_args(monkeypatch):
 
     monkeypatch.setitem(sys.modules, "pytorch_playground", fake_package)
     monkeypatch.setattr(module, "_resolve_active_app_path", lambda _active_app=None: PROJECT_PATH.resolve())
-    monkeypatch.setattr(module, "_load_orchestrate_args", lambda _active_app_path: (SimpleNamespace(), fake_args))
+    monkeypatch.setattr(module, "_load_orchestrate_args", lambda _active_app_path, **_kwargs: (SimpleNamespace(), fake_args))
     monkeypatch.setattr(module, "_analysis_evidence_dirs", lambda _env, _args, _path: evidence_dirs)
     monkeypatch.setattr(module, "_has_evidence", lambda paths: paths == evidence_dirs)
 
@@ -443,7 +444,7 @@ def test_app_surface_analysis_uses_manifest_token_from_session(monkeypatch):
     monkeypatch.setitem(sys.modules, "pytorch_playground", fake_package)
     monkeypatch.setitem(sys.modules, "streamlit", fake_streamlit)
     monkeypatch.setattr(module, "_resolve_active_app_path", lambda _active_app=None: PROJECT_PATH.resolve())
-    monkeypatch.setattr(module, "_load_orchestrate_args", lambda _active_app_path: (SimpleNamespace(), fake_args))
+    monkeypatch.setattr(module, "_load_orchestrate_args", lambda _active_app_path, **_kwargs: (SimpleNamespace(), fake_args))
     monkeypatch.setattr(module, "_analysis_evidence_dirs", lambda _env, _args, _path: evidence_dirs)
     monkeypatch.setattr(module, "_has_evidence", lambda paths: paths == evidence_dirs)
 
@@ -490,7 +491,7 @@ def test_app_surface_analysis_no_evidence_avoids_playground_import(monkeypatch, 
     monkeypatch.setattr(
         module,
         "_load_orchestrate_args",
-        lambda _active_app_path: (
+        lambda _active_app_path, **_kwargs: (
             SimpleNamespace(AGILAB_EXPORT_ABS=tmp_path / "export", target="pytorch_playground_project"),
             SimpleNamespace(data_out=tmp_path / "evidence"),
         ),
@@ -632,7 +633,7 @@ def test_app_surface_run_button_persists_args_records_manifest_and_reruns(
     )
 
     monkeypatch.setitem(sys.modules, "streamlit", fake_streamlit)
-    monkeypatch.setattr(module, "_load_orchestrate_args", lambda _path: (runtime_env, initial_args))
+    monkeypatch.setattr(module, "_load_orchestrate_args", lambda _path, **_kwargs: (runtime_env, initial_args))
     monkeypatch.setattr(module, "_analysis_evidence_dirs", lambda _env, _args, _path: [evidence])
     monkeypatch.setattr(
         module,
@@ -749,7 +750,7 @@ def test_app_surface_full_renders_orchestrate_form_and_analysis_together(monkeyp
     monkeypatch.setitem(sys.modules, "streamlit", _FakeStreamlit())
     monkeypatch.setitem(sys.modules, "pytorch_playground", fake_package)
     monkeypatch.setattr(module, "_load_app_args_form", lambda: fake_app_args_form)
-    monkeypatch.setattr(module, "_load_orchestrate_args", lambda _active_app_path: (fake_runtime_env, fake_args))
+    monkeypatch.setattr(module, "_load_orchestrate_args", lambda _active_app_path, **_kwargs: (fake_runtime_env, fake_args))
     monkeypatch.setattr(module, "_analysis_evidence_dirs", lambda _env, _args, _path: evidence_dirs)
     monkeypatch.setattr(module, "_has_evidence", lambda paths: paths == evidence_dirs)
 
@@ -818,7 +819,7 @@ def test_app_surface_full_reports_app_args_form_dependency_error(monkeypatch):
 
     monkeypatch.setitem(sys.modules, "streamlit", _FakeStreamlit())
     monkeypatch.setattr(module, "_load_playground_ui_or_report", lambda **_kwargs: SimpleNamespace(PAGE_TITLE="PyTorch Playground"))
-    monkeypatch.setattr(module, "_load_orchestrate_args", lambda _path: (SimpleNamespace(), SimpleNamespace()))
+    monkeypatch.setattr(module, "_load_orchestrate_args", lambda _path, **_kwargs: (SimpleNamespace(), SimpleNamespace()))
     monkeypatch.setattr(module, "_load_app_args_form", lambda: (_ for _ in ()).throw(ImportError("broken app form dependency")))
     monkeypatch.setattr(
         module,
@@ -956,7 +957,7 @@ def test_app_surface_full_run_button_executes_before_analysis(monkeypatch):
 
     load_calls: list[Path] = []
 
-    def _load_args(path):
+    def _load_args(path, **_kwargs):
         load_calls.append(path)
         return runtime_env, args_model
 
@@ -1019,9 +1020,7 @@ def test_app_surface_additional_modes_and_error_paths(monkeypatch: pytest.Monkey
             instance.app_settings_file.write_text("[args]\nsample_count=96\n", encoding="utf-8")
             return instance
 
-    fake_agi_env_module = ModuleType("agi_env")
-    fake_agi_env_module.AgiEnv = FakeAgiEnv
-    monkeypatch.setitem(sys.modules, "agi_env", fake_agi_env_module)
+    monkeypatch.setattr(agi_env_package, "AgiEnv", FakeAgiEnv)
 
     env, args_model = module._load_orchestrate_args(PROJECT_PATH.resolve())
     assert args_model.sample_count == 96
@@ -1055,7 +1054,7 @@ def test_app_surface_additional_modes_and_error_paths(monkeypatch: pytest.Monkey
             events.append(("st-error", message))
 
     monkeypatch.setitem(sys.modules, "streamlit", FakeStreamlit())
-    monkeypatch.setattr(module, "_load_orchestrate_args", lambda _path: (_ for _ in ()).throw(RuntimeError("bad args")))
+    monkeypatch.setattr(module, "_load_orchestrate_args", lambda _path, **_kwargs: (_ for _ in ()).throw(RuntimeError("bad args")))
     module._render_analysis_surface(PROJECT_PATH.resolve())
     assert ("st-error", "Unable to load ORCHESTRATE app arguments: bad args") in events
     module._render_full_surface(PROJECT_PATH.resolve())
@@ -1077,7 +1076,7 @@ def test_app_surface_additional_modes_and_error_paths(monkeypatch: pytest.Monkey
     monkeypatch.setattr(
         module,
         "_render_analysis_surface",
-        lambda path: events.append(("render-analysis", path)),
+        lambda path, **kwargs: events.append(("render-analysis", (path, kwargs))),
     )
     monkeypatch.setattr(
         module,
@@ -1086,10 +1085,41 @@ def test_app_surface_additional_modes_and_error_paths(monkeypatch: pytest.Monkey
     )
     module.render(mode="analysis")
     module.render(mode="full", env="env", container="container")
-    assert ("render-analysis", None) in events
+    assert ("render-analysis", (None, {"env": None, "configure_page": True, "compact": False})) in events
     assert ("render-full", (None, {"env": "env", "container": "container"})) in events
     with pytest.raises(ValueError, match="Unsupported PyTorch Playground app surface mode"):
         module.render(mode="unknown")
+
+
+def test_app_surface_load_orchestrate_args_reuses_parent_env_without_for_app(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    module = _load_app_surface_module("pytorch_playground_app_surface_parent_env_test")
+    active_app = tmp_path / "apps" / "builtin" / "pytorch_playground_project"
+    active_app.mkdir(parents=True)
+    settings_file = tmp_path / "workspace" / "app_settings.toml"
+    settings_file.parent.mkdir(parents=True)
+    settings_file.write_text("[args]\nsample_count = 112\n", encoding="utf-8")
+
+    class ForbiddenAgiEnv:
+        @classmethod
+        def for_app(cls, **_kwargs):
+            raise AssertionError("inline app surface must reuse the parent env")
+
+    monkeypatch.setattr(agi_env_package, "AgiEnv", ForbiddenAgiEnv)
+
+    parent_env = SimpleNamespace(
+        active_app=active_app,
+        app="pytorch_playground_project",
+        apps_path=tmp_path / "apps",
+        app_settings_file=settings_file,
+    )
+
+    env, args_model = module._load_orchestrate_args(active_app, env=parent_env)
+
+    assert env is parent_env
+    assert args_model.sample_count == 112
 
 
 def test_app_surface_run_button_idle_and_failure_paths(monkeypatch: pytest.MonkeyPatch):
@@ -1124,7 +1154,7 @@ def test_app_surface_run_button_idle_and_failure_paths(monkeypatch: pytest.Monke
             events.append(("click", label))
             return True
 
-    monkeypatch.setattr(module, "_load_orchestrate_args", lambda _path: (_ for _ in ()).throw(RuntimeError("run failed")))
+    monkeypatch.setattr(module, "_load_orchestrate_args", lambda _path, **_kwargs: (_ for _ in ()).throw(RuntimeError("run failed")))
     module._render_run_button(PROJECT_PATH.resolve(), container=ClickContainer())
     assert ("error", "Run failed: run failed") in events
 

--- a/test/test_ui_pages.py
+++ b/test/test_ui_pages.py
@@ -1834,10 +1834,9 @@ def test_explore_page_app_surface_back_keeps_single_app_ui_sidebar_view(mock_ui_
 
     assert not at.exception
     sidebar_markdown = "\n".join(str(item.value) for item in at.sidebar.markdown)
-    sidebar_captions = "\n".join(str(item.value) for item in at.sidebar.caption)
-    assert "Project: `flight_telemetry_project`" in sidebar_captions
-    assert sidebar_captions.count("Project: `flight_telemetry_project`") == 1
-    assert ">Demo Surface</a>" in sidebar_markdown
+    sidebar_markdown = "\n".join(str(item.value) for item in at.sidebar.markdown)
+    assert "Project:" not in sidebar_markdown
+    assert ">Page</a>" in sidebar_markdown
     assert ">view_app_ui</a>" not in sidebar_markdown
     assert sidebar_markdown.count("current_page=view_app_ui") == 1
     assert "view_other" not in sidebar_markdown
@@ -1898,12 +1897,11 @@ def test_explore_page_app_surface_uses_standard_view_selection(mock_ui_env):
     assert not at.exception
     markdown_text = "\n".join(str(item.value) for item in at.markdown)
     sidebar_markdown = "\n".join(str(item.value) for item in at.sidebar.markdown)
-    sidebar_captions = "\n".join(str(item.value) for item in at.sidebar.caption)
-    assert "Project: `flight_telemetry_project`" in sidebar_captions
-    assert sidebar_captions.count("Project: `flight_telemetry_project`") == 1
+    sidebar_markdown = "\n".join(str(item.value) for item in at.sidebar.markdown)
+    assert "Project:" not in sidebar_markdown
     assert "surface:analysis" not in markdown_text
     assert "surface:controls" not in sidebar_markdown
-    assert ">Demo Surface</a>" in sidebar_markdown
+    assert ">Page</a>" in sidebar_markdown
     assert ">view_app_ui</a>" not in sidebar_markdown
     assert sidebar_markdown.count("current_page=view_app_ui") == 1
     assert "Choose analysis views" in [str(item.label) for item in at.expander]
@@ -1918,10 +1916,9 @@ def test_explore_page_app_surface_uses_standard_view_selection(mock_ui_env):
         persisted = tomllib.load(f)
     assert persisted["pages"]["view_module"] == ["view_app_ui", "view_extra"]
     sidebar_markdown = "\n".join(str(item.value) for item in at.sidebar.markdown)
-    sidebar_captions = "\n".join(str(item.value) for item in at.sidebar.caption)
-    assert "Project: `flight_telemetry_project`" in sidebar_captions
-    assert sidebar_captions.count("Project: `flight_telemetry_project`") == 1
-    assert ">Demo Surface</a>" in sidebar_markdown
+    sidebar_markdown = "\n".join(str(item.value) for item in at.sidebar.markdown)
+    assert "Project:" not in sidebar_markdown
+    assert ">Page</a>" in sidebar_markdown
     assert ">view_app_ui</a>" not in sidebar_markdown
     assert "view_extra" in sidebar_markdown
     assert "current_page=" in sidebar_markdown

--- a/test/test_ui_pages.py
+++ b/test/test_ui_pages.py
@@ -1834,7 +1834,12 @@ def test_explore_page_app_surface_back_keeps_single_app_ui_sidebar_view(mock_ui_
 
     assert not at.exception
     sidebar_markdown = "\n".join(str(item.value) for item in at.sidebar.markdown)
-    assert "view_app_ui" in sidebar_markdown
+    sidebar_captions = "\n".join(str(item.value) for item in at.sidebar.caption)
+    assert "Project: `flight_telemetry_project`" in sidebar_captions
+    assert sidebar_captions.count("Project: `flight_telemetry_project`") == 1
+    assert ">Demo Surface</a>" in sidebar_markdown
+    assert ">view_app_ui</a>" not in sidebar_markdown
+    assert sidebar_markdown.count("current_page=view_app_ui") == 1
     assert "view_other" not in sidebar_markdown
     assert "current_page=" in sidebar_markdown
     with env.resolve_user_app_settings_file("flight_telemetry_project").open("rb") as f:
@@ -1842,6 +1847,84 @@ def test_explore_page_app_surface_back_keeps_single_app_ui_sidebar_view(mock_ui_
     assert persisted["pages"]["restrict_to_view_module"] is True
     assert persisted["pages"]["view_module"] == ["view_app_ui"]
     assert "view_app_ui" not in persisted["pages"]
+
+
+def test_explore_page_app_surface_uses_standard_view_selection(mock_ui_env):
+    pages_dir = mock_ui_env["pages_dir"]
+    (pages_dir / "view_app_ui.py").write_text(
+        "import streamlit as st\n\ndef main():\n    st.write('app ui bridge')\n",
+        encoding="utf-8",
+    )
+    (pages_dir / "view_extra.py").write_text(
+        "import streamlit as st\n\ndef main():\n    st.write('extra view')\n",
+        encoding="utf-8",
+    )
+    app_surface = mock_ui_env["project_dir"] / "src" / "demo" / "app_surface.py"
+    app_surface.parent.mkdir(parents=True)
+    app_surface.write_text(
+        "def render(mode='analysis', container=None, **_kwargs):\n"
+        "    import streamlit as st\n"
+        "    target = container or st\n"
+        "    target.markdown(f'surface:{mode}')\n",
+        encoding="utf-8",
+    )
+    settings_payload = (
+        "[pages]\n"
+        "restrict_to_view_module = true\n"
+        "view_module = []\n"
+        "\n"
+        "[app_surface]\n"
+        "title = 'Demo Surface'\n"
+        "entrypoint = 'demo/app_surface.py'\n"
+        "sidebar_controls = true\n"
+    )
+    (mock_ui_env["project_dir"] / "src" / "app_settings.toml").write_text(
+        settings_payload,
+        encoding="utf-8",
+    )
+
+    at = _app_test("src/agilab/pages/4_ANALYSIS.py")
+    at.query_params["current_page"] = "main"
+    env = AgiEnv(
+        apps_path=mock_ui_env["apps_dir"], app="flight_telemetry_project", verbose=0
+    )
+    env.AGILAB_PAGES_ABS = str(pages_dir)
+    settings_file = env.resolve_user_app_settings_file("flight_telemetry_project")
+    settings_file.write_text(settings_payload, encoding="utf-8")
+    at.session_state["env"] = env
+
+    at.run()
+
+    assert not at.exception
+    markdown_text = "\n".join(str(item.value) for item in at.markdown)
+    sidebar_markdown = "\n".join(str(item.value) for item in at.sidebar.markdown)
+    sidebar_captions = "\n".join(str(item.value) for item in at.sidebar.caption)
+    assert "Project: `flight_telemetry_project`" in sidebar_captions
+    assert sidebar_captions.count("Project: `flight_telemetry_project`") == 1
+    assert "surface:analysis" not in markdown_text
+    assert "surface:controls" not in sidebar_markdown
+    assert ">Demo Surface</a>" in sidebar_markdown
+    assert ">view_app_ui</a>" not in sidebar_markdown
+    assert sidebar_markdown.count("current_page=view_app_ui") == 1
+    assert "Choose analysis views" in [str(item.label) for item in at.expander]
+    assert "Additional views" not in [
+        str(item.label) for item in at.sidebar.expander
+    ]
+    selection_key = "view_selection__flight_telemetry_project"
+    at.multiselect(key=selection_key).select("view_extra").run()
+
+    assert not at.exception
+    with settings_file.open("rb") as f:
+        persisted = tomllib.load(f)
+    assert persisted["pages"]["view_module"] == ["view_app_ui", "view_extra"]
+    sidebar_markdown = "\n".join(str(item.value) for item in at.sidebar.markdown)
+    sidebar_captions = "\n".join(str(item.value) for item in at.sidebar.caption)
+    assert "Project: `flight_telemetry_project`" in sidebar_captions
+    assert sidebar_captions.count("Project: `flight_telemetry_project`") == 1
+    assert ">Demo Surface</a>" in sidebar_markdown
+    assert ">view_app_ui</a>" not in sidebar_markdown
+    assert "view_extra" in sidebar_markdown
+    assert "current_page=" in sidebar_markdown
 
 
 def test_explore_page_sidebar_notebook_selection_persists(mock_ui_env):

--- a/test/test_view_maps.py
+++ b/test/test_view_maps.py
@@ -726,7 +726,7 @@ def test_view_maps_main_initializes_env_and_invokes_page(tmp_path, monkeypatch) 
     assert fake_st.session_state["TABLE_MAX_ROWS"] == 12
     assert fake_st.session_state["GUI_SAMPLING"] == 3
     assert fake_st.calls["info"] == []
-    assert f"Project: `{active_app.name}`" in fake_st.calls["caption"]
+    assert f"`{active_app.name}`" in fake_st.calls["caption"]
     assert any("Back to ANALYSIS" in caption for caption in fake_st.calls["caption"])
     assert str(active_app) in fake_st.calls["code"]
 
@@ -774,7 +774,7 @@ def test_view_maps_bootstrap_keeps_absolute_app_path_out_of_main_status() -> Non
 
     assert 'st.info(f"active_app:' not in source
     assert "_render_app_page_context(app, active_app)" in source
-    assert 'st.caption(f"Project: `{app}`")' in source
+    assert 'st.caption(f"`{app}`")' in source
     assert "Back to ANALYSIS" in source
     assert 'st.expander("Runtime context", expanded=False)' in source
     assert 'with st.sidebar.expander("Data source", expanded=False):' in source

--- a/test/test_workflow_ui.py
+++ b/test/test_workflow_ui.py
@@ -112,6 +112,11 @@ class _FakeStreamlit:
         self.events.append(("link_button", f"{label}:{url}:{key or ''}:{kwargs.get('type', '')}"))
 
 
+class _NoKeyLinkButtonStreamlit(_FakeStreamlit):
+    def link_button(self, label: str, url: str, *, type: str = "secondary", width: str = "content"):
+        self.events.append(("link_button", f"{label}:{url}:nokey:{type}:{width}"))
+
+
 def test_fake_streamlit_and_sidebar_helpers_are_exercised() -> None:
     streamlit = _FakeStreamlit()
     sidebar = _FakeSidebar(streamlit)
@@ -182,6 +187,42 @@ def test_render_context_expander_links_back_to_project_page(tmp_path) -> None:
         "Change project:/PROJECT_STATUS?active_app=flight_telemetry_project:context_expander:WORKFLOW:change_project:secondary",
     ) in fake_st.events
     assert not [event for event in fake_st.events if event[0] == "selectbox"]
+
+
+def test_workflow_link_buttons_do_not_require_key_support(monkeypatch) -> None:
+    fake_st = _NoKeyLinkButtonStreamlit()
+    monkeypatch.setattr(
+        workflow_ui,
+        "project_next_action",
+        lambda _env: {
+            "id": "analysis",
+            "label": "Review evidence",
+            "detail": "Open analysis.",
+            "url": "/ANALYSIS",
+            "type": "primary",
+        },
+    )
+
+    workflow_ui.render_next_best_action(
+        fake_st,
+        env=SimpleNamespace(app="demo_project"),
+        key_prefix="demo",
+    )
+    workflow_ui._render_context_link(
+        fake_st,
+        label="Change project",
+        url="/PROJECT_STATUS",
+        key="demo:change_project",
+    )
+
+    assert (
+        "link_button",
+        "Review evidence:/ANALYSIS:nokey:primary:content",
+    ) in fake_st.events
+    assert (
+        "link_button",
+        "Change project:/PROJECT_STATUS:nokey:secondary:content",
+    ) in fake_st.events
 
 
 def test_project_widget_key_is_scoped_by_page_and_project() -> None:


### PR DESCRIPTION
## Summary
- Fix ANALYSIS app-surface sidebar labels so the active project displays without the `Project:` prefix and the app-surface launcher displays as `Page`.
- Keep app-surface projects on the existing ANALYSIS view-selection mechanism while allowing additional views to be selected.
- Restore compatible project label rendering through the historical page-chrome path and avoid introducing a new `render_page_header` keyword.
- Remove stale `Project:` prefixes from app-page sidecar context labels and update focused regressions and skill guidance.
- Keep workflow link buttons compatible with Streamlit versions that do not accept `key` on `link_button`.

## Validation
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_analysis_page_helpers.py::test_app_surface_migration_selects_app_ui_by_default test/test_ui_pages.py::test_explore_page_app_surface_back_keeps_single_app_ui_sidebar_view test/test_ui_pages.py::test_explore_page_app_surface_uses_standard_view_selection test/test_pytorch_playground_app.py::test_app_surface_load_orchestrate_args_reuses_parent_env_without_for_app test/test_pytorch_playground_app.py::test_app_surface_additional_modes_and_error_paths test/test_workflow_ui.py::test_workflow_link_buttons_do_not_require_key_support test/test_view_maps.py::test_view_maps_main_initializes_env_and_invokes_page test/test_view_maps.py::test_view_maps_bootstrap_keeps_absolute_app_path_out_of_main_status`
- `git diff --cached --check`
- `python3 tools/codex_skills.py --root .codex/skills validate --strict`
