### PR TITLE
Increase UI robot analysis coverage

### DIFF
--- a/src/agilab/lib/agi-gui/src/agi_gui/file_picker.py
+++ b/src/agilab/lib/agi-gui/src/agi_gui/file_picker.py
@@ -259,7 +259,7 @@ def agi_file_picker(
     st.session_state[state_key] = current_selection
 
     button_label = _button_label(label, current_selection, selection_mode)
-    with target.popover(button_label, icon=":material/folder_open:", help=help, width="stretch"):
+    with target.popover(button_label, help=help, width="stretch"):
         if len(root_labels) > 1:
             selected_root = st.pills(
                 "Root",

--- a/src/agilab/lib/agi-gui/test/test_file_picker.py
+++ b/src/agilab/lib/agi-gui/test/test_file_picker.py
@@ -62,10 +62,15 @@ class _FakeStreamlit:
         self.dataframes: list[dict[str, object]] = []
         self.errors: list[str] = []
         self.popovers: list[str] = []
+        self.popover_kwargs: list[dict[str, object]] = []
         self.reruns = 0
 
-    def popover(self, label, **_kwargs):
+    def popover(self, label, **kwargs):
+        icon = kwargs.get("icon")
+        if isinstance(icon, str) and icon.startswith(":material/"):
+            raise ModuleNotFoundError("No module named 'streamlit.material_icon_names'")
         self.popovers.append(str(label))
+        self.popover_kwargs.append(dict(kwargs))
         return _Popover()
 
     def pills(self, _label, options, **_kwargs):
@@ -269,6 +274,7 @@ def test_agi_file_picker_selects_dataframe_row(tmp_path: Path, monkeypatch) -> N
 
     assert result == str(selected_file.resolve())
     assert fake_st.popovers == ["Browse"]
+    assert "icon" not in fake_st.popover_kwargs[0]
     assert fake_st.dataframes[0]["selection_mode"] == "single-row"
     assert fake_st.dataframes[0]["column_order"] == ("relative_path", "type", "size", "modified")
 

--- a/test/test_agilab_widget_robot.py
+++ b/test/test_agilab_widget_robot.py
@@ -133,6 +133,8 @@ def test_widget_robot_parser_exposes_resumable_run_controls() -> None:
     assert args.accessibility_check is False
     assert args.browser_error_check is False
     assert args.above_fold_check is False
+    assert args.required_text == ""
+    assert args.forbidden_text == ""
     assert args.required_action_labels == ""
     assert args.visual_mask_dynamic_regions is False
     assert args.success_screenshot is False
@@ -833,6 +835,73 @@ def test_required_text_probe_reports_missing_text() -> None:
 
     assert probe.status == "failed"
     assert "Run training" in probe.detail
+
+
+def test_forbidden_text_probe_reads_child_frames_and_passes_when_absent() -> None:
+    module = _load_module()
+
+    class _Locator:
+        def __init__(self, text: str):
+            self._text = text
+
+        def inner_text(self, **_kwargs) -> str:
+            return self._text
+
+    class _Frame:
+        def __init__(self, text: str):
+            self._text = text
+
+        def locator(self, _selector: str) -> _Locator:
+            return _Locator(self._text)
+
+    class _Page(_Frame):
+        url = "http://demo/ANALYSIS"
+
+        def __init__(self) -> None:
+            super().__init__("PyTorch Playground\nPage")
+            self.main_frame = object()
+            self.frames = [self.main_frame, _Frame("Refresh evidence")]
+
+    probe = module._forbidden_text_probe(
+        _Page(),
+        app_name="pytorch_playground_project",
+        display="ANALYSIS",
+        forbidden_text=("Project:",),
+        timeout_ms=100,
+    )
+
+    assert probe.status == "interacted"
+    assert probe.kind == "forbidden_text"
+    assert "forbidden text absent" in probe.detail
+
+
+def test_forbidden_text_probe_reports_visible_forbidden_text() -> None:
+    module = _load_module()
+
+    class _Locator:
+        def inner_text(self, **_kwargs) -> str:
+            return "Project: PyTorch Playground\nPage"
+
+    class _Page:
+        url = "http://demo/ANALYSIS"
+        frames: list[object] = []
+        main_frame = None
+
+        @staticmethod
+        def locator(_selector: str) -> _Locator:
+            return _Locator()
+
+    probe = module._forbidden_text_probe(
+        _Page(),
+        app_name="pytorch_playground_project",
+        display="ANALYSIS",
+        forbidden_text=("Project:",),
+        timeout_ms=100,
+    )
+
+    assert probe.status == "failed"
+    assert probe.kind == "forbidden_text"
+    assert "forbidden text present" in probe.detail
 
 
 def test_required_action_probe_trial_clicks_child_frame_button() -> None:

--- a/test/test_agilab_widget_robot_matrix.py
+++ b/test/test_agilab_widget_robot_matrix.py
@@ -210,7 +210,8 @@ def test_opt_in_mobile_and_release_evidence_scenarios_are_not_part_of_default_al
     assert all_builtin_orchestrate.page_timeout_seconds == 120.0
     assert pytorch_analysis.apps == "pytorch_playground_project"
     assert pytorch_analysis.pages == "ANALYSIS"
-    assert pytorch_analysis.required_text == "PyTorch Playground,Refresh evidence,Synced RUN snippet,Settings"
+    assert pytorch_analysis.required_text == "PyTorch Playground,Page,Refresh evidence,Synced RUN snippet,Settings"
+    assert pytorch_analysis.forbidden_text == "Project:"
     assert pytorch_analysis.required_action_labels == "Refresh evidence"
     assert pytorch_analysis.browser_error_check is True
     assert above_fold.above_fold_check is True
@@ -538,7 +539,8 @@ def test_build_robot_command_covers_pytorch_playground_analysis_text(tmp_path) -
     assert argv[argv.index("--apps") + 1] == "pytorch_playground_project"
     assert argv[argv.index("--pages") + 1] == "ANALYSIS"
     assert argv[argv.index("--apps-pages") + 1] == "none"
-    assert argv[argv.index("--required-text") + 1] == "PyTorch Playground,Refresh evidence,Synced RUN snippet,Settings"
+    assert argv[argv.index("--required-text") + 1] == "PyTorch Playground,Page,Refresh evidence,Synced RUN snippet,Settings"
+    assert argv[argv.index("--forbidden-text") + 1] == "Project:"
     assert argv[argv.index("--required-action-labels") + 1] == "Refresh evidence"
     assert "--browser-error-check" in argv
     assert summary_path == tmp_path / "isolated-pytorch-playground-analysis.json"

--- a/test/test_ui_robot_coverage_contract.py
+++ b/test/test_ui_robot_coverage_contract.py
@@ -95,10 +95,11 @@ def test_ui_robot_coverage_contract_passes_for_current_matrix() -> None:
     assert "isolated-pytorch-playground-analysis" in payload["coverage"]["ui_robot_matrix_profile_scenarios"]
     assert payload["coverage"]["pytorch_analysis_robot"] == {
         "apps": ["pytorch_playground_project"],
+        "forbidden_text": ["Project:"],
         "flags": ["browser_error_check"],
         "pages": ["ANALYSIS"],
         "required_actions": ["Refresh evidence"],
-        "required_text": ["PyTorch Playground", "Refresh evidence", "Settings", "Synced RUN snippet"],
+        "required_text": ["Page", "PyTorch Playground", "Refresh evidence", "Settings", "Synced RUN snippet"],
     }
     assert payload["coverage"]["hf_robot_scenarios"]["hf-first-proof-visual-smoke"] == {
         "actions": [],
@@ -143,6 +144,7 @@ def test_ui_robot_coverage_contract_accepts_explicit_full_app_profile(monkeypatc
         apps_pages: str = "none",
         click_action_labels: str = "",
         required_text: str = "",
+        forbidden_text: str = "",
         required_action_labels: str = "",
         success_screenshot: bool = False,
         above_fold_check: bool = False,
@@ -155,6 +157,7 @@ def test_ui_robot_coverage_contract_accepts_explicit_full_app_profile(monkeypatc
             apps_pages=apps_pages,
             click_action_labels=click_action_labels,
             required_text=required_text,
+            forbidden_text=forbidden_text,
             required_action_labels=required_action_labels,
             success_screenshot=success_screenshot,
             above_fold_check=above_fold_check,
@@ -191,6 +194,7 @@ def test_ui_robot_coverage_contract_accepts_explicit_full_app_profile(monkeypatc
         pages="ANALYSIS",
         apps=module.REQUIRED_PYTORCH_ANALYSIS_APP,
         required_text=",".join(module.REQUIRED_PYTORCH_ANALYSIS_TEXT),
+        forbidden_text=",".join(module.REQUIRED_PYTORCH_ANALYSIS_FORBIDDEN_TEXT),
         required_action_labels=",".join(module.REQUIRED_PYTORCH_ANALYSIS_ACTIONS),
         browser_error_check=True,
     )
@@ -482,6 +486,7 @@ def test_ui_robot_coverage_contract_reports_matrix_and_pytorch_gaps(monkeypatch,
         apps_pages="none",
         click_action_labels="",
         required_text="",
+        forbidden_text="",
         required_action_labels="",
         success_screenshot=False,
         above_fold_check=False,
@@ -494,6 +499,7 @@ def test_ui_robot_coverage_contract_reports_matrix_and_pytorch_gaps(monkeypatch,
         apps_pages="view_maps",
         click_action_labels="",
         required_text="",
+        forbidden_text="",
         required_action_labels="",
         success_screenshot=False,
         above_fold_check=False,
@@ -506,6 +512,7 @@ def test_ui_robot_coverage_contract_reports_matrix_and_pytorch_gaps(monkeypatch,
         apps_pages="none",
         click_action_labels="",
         required_text="",
+        forbidden_text="",
         required_action_labels="",
         success_screenshot=False,
         above_fold_check=False,
@@ -518,6 +525,7 @@ def test_ui_robot_coverage_contract_reports_matrix_and_pytorch_gaps(monkeypatch,
         apps_pages="none",
         click_action_labels="",
         required_text="PyTorch Playground",
+        forbidden_text="",
         required_action_labels="",
         success_screenshot=False,
         above_fold_check=False,
@@ -594,8 +602,9 @@ def test_ui_robot_coverage_contract_reports_matrix_and_pytorch_gaps(monkeypatch,
     assert "isolated-pytorch-playground-analysis does not target pytorch_playground_project" in details
     assert (
         "isolated-pytorch-playground-analysis is missing required text probes: "
-        "Refresh evidence, Settings, Synced RUN snippet"
+        "Page, Refresh evidence, Settings, Synced RUN snippet"
     ) in details
+    assert "isolated-pytorch-playground-analysis is missing forbidden text probes: Project:" in details
     assert "isolated-pytorch-playground-analysis is missing required action probes: Refresh evidence" in details
     assert "isolated-pytorch-playground-analysis does not enable browser_error_check" in details
     assert "ui-robot-matrix profile does not run isolated-pytorch-playground-analysis" in details

--- a/test/test_workflow_ui.py
+++ b/test/test_workflow_ui.py
@@ -189,6 +189,45 @@ def test_render_context_expander_links_back_to_project_page(tmp_path) -> None:
     assert not [event for event in fake_st.events if event[0] == "selectbox"]
 
 
+def test_render_context_expander_analysis_generic_and_noop_paths(tmp_path) -> None:
+    assert workflow_ui.render_context_expander(
+        _FakeStreamlit(), page_label="ANALYSIS", env=None
+    ) is None
+    assert workflow_ui.render_context_expander(
+        SimpleNamespace(expander=lambda *_args, **_kwargs: None),
+        page_label="ANALYSIS",
+        env=SimpleNamespace(app="demo_project"),
+    ) is None
+
+    app_root = tmp_path / "demo_project"
+    app_root.mkdir()
+    env = SimpleNamespace(app="demo_project", active_app=app_root)
+    analysis_st = _FakeStreamlit()
+    workflow_ui.render_context_expander(
+        analysis_st, page_label="ANALYSIS", env=env, expanded=True
+    )
+
+    assert ("expander", "Analysis context:True") in analysis_st.events
+    link_values = [value for kind, value in analysis_st.events if kind == "link_button"]
+    assert any(
+        value.startswith(
+            "Run again:/ORCHESTRATE?active_app=demo_project:context_expander:ANALYSIS:Run_again:"
+        )
+        for value in link_values
+    )
+    assert any(
+        value.startswith(
+            "Open workflow:/WORKFLOW?active_app=demo_project:context_expander:ANALYSIS:Open_workflow:"
+        )
+        for value in link_values
+    )
+
+    generic_st = _FakeStreamlit()
+    workflow_ui.render_context_expander(generic_st, page_label="OTHER", env=env)
+
+    assert ("expander", "Project context:False") in generic_st.events
+
+
 def test_workflow_link_buttons_do_not_require_key_support(monkeypatch) -> None:
     fake_st = _NoKeyLinkButtonStreamlit()
     monkeypatch.setattr(

--- a/tools/agilab_widget_robot.py
+++ b/tools/agilab_widget_robot.py
@@ -4582,6 +4582,7 @@ def sweep_page(  # pragma: no cover - live browser path
     browser_error_check: bool = False,
     above_fold_check: bool = False,
     required_text: Sequence[str] = (),
+    forbidden_text: Sequence[str] = (),
     required_action_labels: Sequence[str] = (),
     visual_mask_dynamic_regions: bool = False,
     success_screenshot: bool = False,
@@ -4704,6 +4705,16 @@ def sweep_page(  # pragma: no cover - live browser path
                         app_name=app_name,
                         display=display,
                         required_text=required_text,
+                        timeout_ms=widget_timeout_ms,
+                    )
+                )
+            if forbidden_text and not any(probe.status == "failed" for probe in probes):
+                probes.append(
+                    _forbidden_text_probe(
+                        page,
+                        app_name=app_name,
+                        display=display,
+                        forbidden_text=forbidden_text,
                         timeout_ms=widget_timeout_ms,
                     )
                 )
@@ -5556,6 +5567,41 @@ def _required_text_probe(  # pragma: no cover - live browser path
     )
 
 
+def _forbidden_text_probe(  # pragma: no cover - live browser path
+    page: Any,
+    *,
+    app_name: str,
+    display: str,
+    forbidden_text: Sequence[str],
+    timeout_ms: float,
+) -> WidgetProbe:
+    expected = tuple(str(label).strip() for label in forbidden_text if str(label).strip())
+    text = _page_and_frame_text(page, timeout_ms=timeout_ms)
+    normalized_text = text.lower()
+    present = [label for label in expected if label.lower() in normalized_text]
+    if present:
+        detail = f"forbidden text present: {present}; page/frame text sample={text[:500]!r}"
+        return WidgetProbe(
+            app_name,
+            display,
+            "forbidden_text",
+            "page_and_frames",
+            "failed",
+            _short_detail(detail),
+            getattr(page, "url", ""),
+        )
+    detail = f"forbidden text absent from page and child frames: {list(expected)}"
+    return WidgetProbe(
+        app_name,
+        display,
+        "forbidden_text",
+        "page_and_frames",
+        "interacted",
+        _short_detail(detail),
+        getattr(page, "url", ""),
+    )
+
+
 def _trial_click_required_button(  # pragma: no cover - live browser path
     owner: Any,
     label: str,
@@ -5677,6 +5723,7 @@ def sweep_direct_apps_page(  # pragma: no cover - live browser path
     browser_error_check: bool = False,
     above_fold_check: bool = False,
     required_text: Sequence[str] = (),
+    forbidden_text: Sequence[str] = (),
     required_action_labels: Sequence[str] = (),
     visual_mask_dynamic_regions: bool = False,
     failure_bundle_dir: Path | None = None,
@@ -5803,6 +5850,7 @@ def sweep_direct_apps_page(  # pragma: no cover - live browser path
                         browser_error_check=browser_error_check,
                         above_fold_check=above_fold_check,
                         required_text=required_text,
+                        forbidden_text=forbidden_text,
                         required_action_labels=required_action_labels,
                         visual_mask_dynamic_regions=visual_mask_dynamic_regions,
                         failure_bundle_dir=failure_bundle_dir,
@@ -5854,6 +5902,7 @@ def sweep_app(  # pragma: no cover - live browser path
     browser_error_check: bool = False,
     above_fold_check: bool = False,
     required_text: Sequence[str] = (),
+    forbidden_text: Sequence[str] = (),
     required_action_labels: Sequence[str] = (),
     visual_mask_dynamic_regions: bool = False,
     viewport_width: int = DEFAULT_VIEWPORT_WIDTH,
@@ -5958,6 +6007,7 @@ def sweep_app(  # pragma: no cover - live browser path
                                 browser_error_check=browser_error_check,
                                 above_fold_check=above_fold_check,
                                 required_text=required_text,
+                                forbidden_text=forbidden_text,
                                 required_action_labels=required_action_labels,
                                 visual_mask_dynamic_regions=visual_mask_dynamic_regions,
                                 success_screenshot=success_screenshot,
@@ -6072,6 +6122,7 @@ def sweep_app(  # pragma: no cover - live browser path
                     browser_error_check=browser_error_check,
                     above_fold_check=above_fold_check,
                     required_text=required_text,
+                    forbidden_text=forbidden_text,
                     required_action_labels=required_action_labels,
                     visual_mask_dynamic_regions=visual_mask_dynamic_regions,
                     failure_bundle_dir=failure_bundle_dir,
@@ -6125,6 +6176,7 @@ def sweep_remote_app(  # pragma: no cover - live browser path
     browser_error_check: bool = False,
     above_fold_check: bool = False,
     required_text: Sequence[str] = (),
+    forbidden_text: Sequence[str] = (),
     required_action_labels: Sequence[str] = (),
     visual_mask_dynamic_regions: bool = False,
     viewport_width: int = DEFAULT_VIEWPORT_WIDTH,
@@ -6208,6 +6260,7 @@ def sweep_remote_app(  # pragma: no cover - live browser path
                         browser_error_check=browser_error_check,
                         above_fold_check=above_fold_check,
                         required_text=required_text,
+                        forbidden_text=forbidden_text,
                         required_action_labels=required_action_labels,
                         visual_mask_dynamic_regions=visual_mask_dynamic_regions,
                         success_screenshot=success_screenshot,
@@ -6342,6 +6395,7 @@ def sweep_remote_app(  # pragma: no cover - live browser path
                             browser_error_check=browser_error_check,
                             above_fold_check=above_fold_check,
                             required_text=required_text,
+                            forbidden_text=forbidden_text,
                             required_action_labels=required_action_labels,
                             visual_mask_dynamic_regions=visual_mask_dynamic_regions,
                             failure_bundle_dir=failure_bundle_dir,
@@ -6472,6 +6526,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--browser-error-check", action="store_true", help="Record explicit pass/fail evidence for console, pageerror, requestfailed, and HTTP error capture.")
     parser.add_argument("--above-fold-check", action="store_true", help="Fail when expected page headings or primary controls are not visible above the initial viewport fold.")
     parser.add_argument("--required-text", default="", help="Comma-separated text that must be visible in the page or a child iframe after render.")
+    parser.add_argument("--forbidden-text", default="", help="Comma-separated text that must not be visible in the page or a child iframe after render.")
     parser.add_argument("--required-action-labels", default="", help="Comma-separated button labels that must be visible, enabled, and trial-clickable in the page or a child iframe.")
     parser.add_argument("--visual-mask-dynamic-regions", action="store_true", help="Mask volatile log/progress/code regions before success screenshots for visual baseline evidence.")
     parser.add_argument("--success-screenshot", action="store_true", help="Capture a screenshot for each passed page when --screenshot-dir is set.")
@@ -6542,6 +6597,7 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - live b
     click_action_labels = parse_csv(args.click_action_labels)
     preselect_labels = parse_csv(args.preselect_labels)
     required_text = parse_csv(args.required_text)
+    forbidden_text = parse_csv(args.forbidden_text)
     required_action_labels = parse_csv(args.required_action_labels)
     if args.action_button_policy == "click-selected" and not click_action_labels:
         parser.error("--click-action-labels is required with --action-button-policy click-selected")
@@ -6608,6 +6664,7 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - live b
                 browser_error_check=args.browser_error_check,
                 above_fold_check=args.above_fold_check,
                 required_text=required_text,
+                forbidden_text=forbidden_text,
                 required_action_labels=required_action_labels,
                 visual_mask_dynamic_regions=args.visual_mask_dynamic_regions,
                 viewport_width=args.viewport_width,
@@ -6661,6 +6718,7 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - live b
                 browser_error_check=args.browser_error_check,
                 above_fold_check=args.above_fold_check,
                 required_text=required_text,
+                forbidden_text=forbidden_text,
                 required_action_labels=required_action_labels,
                 visual_mask_dynamic_regions=args.visual_mask_dynamic_regions,
                 viewport_width=args.viewport_width,

--- a/tools/agilab_widget_robot_matrix.py
+++ b/tools/agilab_widget_robot_matrix.py
@@ -47,6 +47,7 @@ class RobotScenario:
     click_action_labels: str = ""
     preselect_labels: str = ""
     required_text: str = ""
+    forbidden_text: str = ""
     required_action_labels: str = ""
     route_query: str = ""
     missing_selected_action_policy: str = "fail"
@@ -493,7 +494,8 @@ OPT_IN_SCENARIOS: dict[str, RobotScenario] = {
         runtime_isolation="isolated",
         action_button_policy="trial",
         apps="pytorch_playground_project",
-        required_text="PyTorch Playground,Refresh evidence,Synced RUN snippet,Settings",
+        required_text="PyTorch Playground,Page,Refresh evidence,Synced RUN snippet,Settings",
+        forbidden_text="Project:",
         required_action_labels="Refresh evidence",
         action_timeout_seconds=30.0,
         page_timeout_seconds=420.0,
@@ -782,6 +784,8 @@ def build_robot_command(
         argv.extend(["--route-query", scenario.route_query])
     if scenario.required_text:
         argv.extend(["--required-text", scenario.required_text])
+    if scenario.forbidden_text:
+        argv.extend(["--forbidden-text", scenario.forbidden_text])
     if scenario.required_action_labels:
         argv.extend(["--required-action-labels", scenario.required_action_labels])
     if scenario.assert_orchestrate_artifacts:

--- a/tools/ui_robot_coverage_contract.py
+++ b/tools/ui_robot_coverage_contract.py
@@ -31,7 +31,8 @@ REQUIRED_HF_FIRST_PROOF_PAGES = ("view_forecast_analysis", "view_maps", "view_re
 FORBIDDEN_HF_FIRST_PROOF_APPS = ("flight_project", "weather_forecast_legacy_project")
 REQUIRED_PYTORCH_ANALYSIS_SCENARIO = "isolated-pytorch-playground-analysis"
 REQUIRED_PYTORCH_ANALYSIS_APP = "pytorch_playground_project"
-REQUIRED_PYTORCH_ANALYSIS_TEXT = ("PyTorch Playground", "Refresh evidence", "Synced RUN snippet", "Settings")
+REQUIRED_PYTORCH_ANALYSIS_TEXT = ("PyTorch Playground", "Page", "Refresh evidence", "Synced RUN snippet", "Settings")
+REQUIRED_PYTORCH_ANALYSIS_FORBIDDEN_TEXT = ("Project:",)
 REQUIRED_PYTORCH_ANALYSIS_ACTIONS = ("Refresh evidence",)
 REQUIRED_HF_ROBOT_SCENARIOS = {
     "hf-first-proof-visual-smoke": {
@@ -131,6 +132,10 @@ def _scenario_apps(widget_robot: Any, scenario: Any) -> set[str]:
 
 def _scenario_required_text(widget_robot: Any, scenario: Any) -> set[str]:
     return set(widget_robot.parse_csv(str(getattr(scenario, "required_text", ""))))
+
+
+def _scenario_forbidden_text(widget_robot: Any, scenario: Any) -> set[str]:
+    return set(widget_robot.parse_csv(str(getattr(scenario, "forbidden_text", ""))))
 
 
 def _scenario_required_actions(widget_robot: Any, scenario: Any) -> set[str]:
@@ -379,12 +384,14 @@ def evaluate_contract() -> dict[str, Any]:
         pages = sorted(_scenario_pages(widget_robot, pytorch_scenario))
         apps = sorted(_scenario_apps(widget_robot, pytorch_scenario))
         required_text = sorted(_scenario_required_text(widget_robot, pytorch_scenario))
+        forbidden_text = sorted(_scenario_forbidden_text(widget_robot, pytorch_scenario))
         required_actions = sorted(_scenario_required_actions(widget_robot, pytorch_scenario))
         flags = sorted(_scenario_flags(pytorch_scenario))
         pytorch_analysis = {
             "pages": pages,
             "apps": apps,
             "required_text": required_text,
+            "forbidden_text": forbidden_text,
             "required_actions": required_actions,
             "flags": flags,
         }
@@ -409,6 +416,17 @@ def evaluate_contract() -> dict[str, Any]:
                     "pytorch_analysis_robot",
                     f"{REQUIRED_PYTORCH_ANALYSIS_SCENARIO} is missing required text probes: "
                     + ", ".join(missing_text),
+                )
+            )
+        missing_forbidden_text = sorted(
+            set(REQUIRED_PYTORCH_ANALYSIS_FORBIDDEN_TEXT) - set(forbidden_text)
+        )
+        if missing_forbidden_text:
+            issues.append(
+                CoverageIssue(
+                    "pytorch_analysis_robot",
+                    f"{REQUIRED_PYTORCH_ANALYSIS_SCENARIO} is missing forbidden text probes: "
+                    + ", ".join(missing_forbidden_text),
                 )
             )
         missing_actions = sorted(set(REQUIRED_PYTORCH_ANALYSIS_ACTIONS) - set(required_actions))


### PR DESCRIPTION
## Summary
- add forbidden-text robot probes and matrix coverage for PyTorch ANALYSIS
- require the PyTorch ANALYSIS robot to confirm stale Project chrome is absent
- add focused file-picker and workflow context coverage regressions

## Validation
- PYTHONPATH=src:src/agilab/lib/agi-gui/src uv --preview-features extra-build-dependencies run --extra dev --extra ui pytest -q -o addopts='' --import-mode=importlib test/test_workflow_ui.py src/agilab/lib/agi-gui/test/test_file_picker.py --cov=agilab.workflow_ui --cov=agi_gui.file_picker --cov-report=term-missing