### PR TITLE
Tighten analysis sidebar robot coverage

### DIFF
--- a/src/agilab/pages/4_ANALYSIS.py
+++ b/src/agilab/pages/4_ANALYSIS.py
@@ -2813,12 +2813,6 @@ async def _render_configured_app_surface(
             env=st.session_state.get("env"),
             container=st.sidebar,
         )
-        if active_app_path is not None:
-            project_label = _analysis_project_link_label(
-                active_app_path.name,
-                app_surface_cfg=surface_config,
-            )
-            st.markdown(f"**{html.escape(project_label)}**")
         st.subheader(app_surface_title(surface_config))
         render_app_surface(
             active_app_path,

--- a/test/test_agilab_widget_robot.py
+++ b/test/test_agilab_widget_robot.py
@@ -135,6 +135,8 @@ def test_widget_robot_parser_exposes_resumable_run_controls() -> None:
     assert args.above_fold_check is False
     assert args.required_text == ""
     assert args.forbidden_text == ""
+    assert args.forbidden_sidebar_text == ""
+    assert args.required_links == ""
     assert args.required_action_labels == ""
     assert args.visual_mask_dynamic_regions is False
     assert args.success_screenshot is False
@@ -902,6 +904,126 @@ def test_forbidden_text_probe_reports_visible_forbidden_text() -> None:
     assert probe.status == "failed"
     assert probe.kind == "forbidden_text"
     assert "forbidden text present" in probe.detail
+
+
+def test_forbidden_sidebar_text_probe_reports_visible_sidebar_text() -> None:
+    module = _load_module()
+
+    class _SidebarLocator:
+        def count(self) -> int:
+            return 1
+
+        def nth(self, index: int):
+            assert index == 0
+            return self
+
+        def inner_text(self, **_kwargs) -> str:
+            return "Project: PyTorch Playground\nPage"
+
+    class _Page:
+        url = "http://demo/ANALYSIS"
+        frames: list[object] = []
+        main_frame = None
+
+        @staticmethod
+        def locator(selector: str) -> _SidebarLocator:
+            assert selector == "[data-testid='stSidebar']"
+            return _SidebarLocator()
+
+    probe = module._forbidden_sidebar_text_probe(
+        _Page(),
+        app_name="pytorch_playground_project",
+        display="ANALYSIS",
+        forbidden_sidebar_text=("Project:",),
+        timeout_ms=100,
+    )
+
+    assert probe.status == "failed"
+    assert probe.kind == "forbidden_sidebar_text"
+    assert "forbidden sidebar text present" in probe.detail
+
+
+def test_required_link_probe_matches_label_and_href_fragments() -> None:
+    module = _load_module()
+
+    class _LinkLocator:
+        def count(self) -> int:
+            return 1
+
+        def nth(self, index: int):
+            assert index == 0
+            return self
+
+        def is_visible(self, **_kwargs) -> bool:
+            return True
+
+        def get_attribute(self, name: str, **_kwargs) -> str:
+            assert name == "href"
+            return "/ANALYSIS?current_page=view_app_ui&active_app=pytorch_playground_project"
+
+    class _Page:
+        url = "http://demo/ANALYSIS"
+        frames: list[object] = []
+        main_frame = None
+
+        @staticmethod
+        def get_by_role(role: str, name):
+            assert role == "link"
+            assert getattr(name, "pattern", "Page") == "Page"
+            return _LinkLocator()
+
+    probe = module._required_link_probe(
+        _Page(),
+        app_name="pytorch_playground_project",
+        display="ANALYSIS",
+        required_links=("Page=>current_page=view_app_ui;pytorch_playground_project",),
+        timeout_ms=100,
+    )
+
+    assert probe.status == "interacted"
+    assert probe.kind == "required_link"
+    assert "required links visible" in probe.detail
+
+
+def test_required_link_probe_reports_missing_href_fragment() -> None:
+    module = _load_module()
+
+    class _LinkLocator:
+        def count(self) -> int:
+            return 1
+
+        def nth(self, index: int):
+            assert index == 0
+            return self
+
+        def is_visible(self, **_kwargs) -> bool:
+            return True
+
+        def get_attribute(self, name: str, **_kwargs) -> str:
+            assert name == "href"
+            return "/ANALYSIS?current_page=view_maps"
+
+    class _Page:
+        url = "http://demo/ANALYSIS"
+        frames: list[object] = []
+        main_frame = None
+
+        @staticmethod
+        def get_by_role(role: str, name):
+            assert role == "link"
+            return _LinkLocator()
+
+    probe = module._required_link_probe(
+        _Page(),
+        app_name="pytorch_playground_project",
+        display="ANALYSIS",
+        required_links=("Page=>current_page=view_app_ui",),
+        timeout_ms=100,
+    )
+
+    assert probe.status == "failed"
+    assert probe.kind == "required_link"
+    assert "required links missing" in probe.detail
 
 
 def test_required_action_probe_trial_clicks_child_frame_button() -> None:

--- a/test/test_agilab_widget_robot_matrix.py
+++ b/test/test_agilab_widget_robot_matrix.py
@@ -210,8 +210,9 @@ def test_opt_in_mobile_and_release_evidence_scenarios_are_not_part_of_default_al
     assert all_builtin_orchestrate.page_timeout_seconds == 120.0
     assert pytorch_analysis.apps == "pytorch_playground_project"
     assert pytorch_analysis.pages == "ANALYSIS"
-    assert pytorch_analysis.required_text == "PyTorch Playground,Page,Refresh evidence,Synced RUN snippet,Settings"
-    assert pytorch_analysis.forbidden_text == "Project:"
+    assert pytorch_analysis.required_text == "PyTorch Playground,Refresh evidence,Synced RUN snippet,Settings"
+    assert pytorch_analysis.forbidden_sidebar_text == "Project:"
+    assert pytorch_analysis.required_links == "Page=>current_page=view_app_ui"
     assert pytorch_analysis.required_action_labels == "Refresh evidence"
     assert pytorch_analysis.browser_error_check is True
     assert above_fold.above_fold_check is True
@@ -539,8 +540,9 @@ def test_build_robot_command_covers_pytorch_playground_analysis_text(tmp_path) -
     assert argv[argv.index("--apps") + 1] == "pytorch_playground_project"
     assert argv[argv.index("--pages") + 1] == "ANALYSIS"
     assert argv[argv.index("--apps-pages") + 1] == "none"
-    assert argv[argv.index("--required-text") + 1] == "PyTorch Playground,Page,Refresh evidence,Synced RUN snippet,Settings"
-    assert argv[argv.index("--forbidden-text") + 1] == "Project:"
+    assert argv[argv.index("--required-text") + 1] == "PyTorch Playground,Refresh evidence,Synced RUN snippet,Settings"
+    assert argv[argv.index("--forbidden-sidebar-text") + 1] == "Project:"
+    assert argv[argv.index("--required-links") + 1] == "Page=>current_page=view_app_ui"
     assert argv[argv.index("--required-action-labels") + 1] == "Refresh evidence"
     assert "--browser-error-check" in argv
     assert summary_path == tmp_path / "isolated-pytorch-playground-analysis.json"

--- a/test/test_ui_robot_coverage_contract.py
+++ b/test/test_ui_robot_coverage_contract.py
@@ -95,11 +95,12 @@ def test_ui_robot_coverage_contract_passes_for_current_matrix() -> None:
     assert "isolated-pytorch-playground-analysis" in payload["coverage"]["ui_robot_matrix_profile_scenarios"]
     assert payload["coverage"]["pytorch_analysis_robot"] == {
         "apps": ["pytorch_playground_project"],
-        "forbidden_text": ["Project:"],
+        "forbidden_sidebar_text": ["Project:"],
         "flags": ["browser_error_check"],
         "pages": ["ANALYSIS"],
         "required_actions": ["Refresh evidence"],
-        "required_text": ["Page", "PyTorch Playground", "Refresh evidence", "Settings", "Synced RUN snippet"],
+        "required_links": ["Page=>current_page=view_app_ui"],
+        "required_text": ["PyTorch Playground", "Refresh evidence", "Settings", "Synced RUN snippet"],
     }
     assert payload["coverage"]["hf_robot_scenarios"]["hf-first-proof-visual-smoke"] == {
         "actions": [],
@@ -145,6 +146,8 @@ def test_ui_robot_coverage_contract_accepts_explicit_full_app_profile(monkeypatc
         click_action_labels: str = "",
         required_text: str = "",
         forbidden_text: str = "",
+        forbidden_sidebar_text: str = "",
+        required_links: str = "",
         required_action_labels: str = "",
         success_screenshot: bool = False,
         above_fold_check: bool = False,
@@ -158,6 +161,8 @@ def test_ui_robot_coverage_contract_accepts_explicit_full_app_profile(monkeypatc
             click_action_labels=click_action_labels,
             required_text=required_text,
             forbidden_text=forbidden_text,
+            forbidden_sidebar_text=forbidden_sidebar_text,
+            required_links=required_links,
             required_action_labels=required_action_labels,
             success_screenshot=success_screenshot,
             above_fold_check=above_fold_check,
@@ -194,7 +199,8 @@ def test_ui_robot_coverage_contract_accepts_explicit_full_app_profile(monkeypatc
         pages="ANALYSIS",
         apps=module.REQUIRED_PYTORCH_ANALYSIS_APP,
         required_text=",".join(module.REQUIRED_PYTORCH_ANALYSIS_TEXT),
-        forbidden_text=",".join(module.REQUIRED_PYTORCH_ANALYSIS_FORBIDDEN_TEXT),
+        forbidden_sidebar_text=",".join(module.REQUIRED_PYTORCH_ANALYSIS_FORBIDDEN_SIDEBAR_TEXT),
+        required_links=",".join(module.REQUIRED_PYTORCH_ANALYSIS_LINKS),
         required_action_labels=",".join(module.REQUIRED_PYTORCH_ANALYSIS_ACTIONS),
         browser_error_check=True,
     )
@@ -487,6 +493,8 @@ def test_ui_robot_coverage_contract_reports_matrix_and_pytorch_gaps(monkeypatch,
         click_action_labels="",
         required_text="",
         forbidden_text="",
+        forbidden_sidebar_text="",
+        required_links="",
         required_action_labels="",
         success_screenshot=False,
         above_fold_check=False,
@@ -500,6 +508,8 @@ def test_ui_robot_coverage_contract_reports_matrix_and_pytorch_gaps(monkeypatch,
         click_action_labels="",
         required_text="",
         forbidden_text="",
+        forbidden_sidebar_text="",
+        required_links="",
         required_action_labels="",
         success_screenshot=False,
         above_fold_check=False,
@@ -513,6 +523,8 @@ def test_ui_robot_coverage_contract_reports_matrix_and_pytorch_gaps(monkeypatch,
         click_action_labels="",
         required_text="",
         forbidden_text="",
+        forbidden_sidebar_text="",
+        required_links="",
         required_action_labels="",
         success_screenshot=False,
         above_fold_check=False,
@@ -526,6 +538,8 @@ def test_ui_robot_coverage_contract_reports_matrix_and_pytorch_gaps(monkeypatch,
         click_action_labels="",
         required_text="PyTorch Playground",
         forbidden_text="",
+        forbidden_sidebar_text="",
+        required_links="",
         required_action_labels="",
         success_screenshot=False,
         above_fold_check=False,
@@ -602,9 +616,13 @@ def test_ui_robot_coverage_contract_reports_matrix_and_pytorch_gaps(monkeypatch,
     assert "isolated-pytorch-playground-analysis does not target pytorch_playground_project" in details
     assert (
         "isolated-pytorch-playground-analysis is missing required text probes: "
-        "Page, Refresh evidence, Settings, Synced RUN snippet"
+        "Refresh evidence, Settings, Synced RUN snippet"
     ) in details
-    assert "isolated-pytorch-playground-analysis is missing forbidden text probes: Project:" in details
+    assert "isolated-pytorch-playground-analysis is missing forbidden sidebar text probes: Project:" in details
+    assert (
+        "isolated-pytorch-playground-analysis is missing required link probes: "
+        "Page=>current_page=view_app_ui"
+    ) in details
     assert "isolated-pytorch-playground-analysis is missing required action probes: Refresh evidence" in details
     assert "isolated-pytorch-playground-analysis does not enable browser_error_check" in details
     assert "ui-robot-matrix profile does not run isolated-pytorch-playground-analysis" in details

--- a/tools/agilab_widget_robot.py
+++ b/tools/agilab_widget_robot.py
@@ -4583,6 +4583,8 @@ def sweep_page(  # pragma: no cover - live browser path
     above_fold_check: bool = False,
     required_text: Sequence[str] = (),
     forbidden_text: Sequence[str] = (),
+    forbidden_sidebar_text: Sequence[str] = (),
+    required_links: Sequence[str] = (),
     required_action_labels: Sequence[str] = (),
     visual_mask_dynamic_regions: bool = False,
     success_screenshot: bool = False,
@@ -4715,6 +4717,26 @@ def sweep_page(  # pragma: no cover - live browser path
                         app_name=app_name,
                         display=display,
                         forbidden_text=forbidden_text,
+                        timeout_ms=widget_timeout_ms,
+                    )
+                )
+            if forbidden_sidebar_text and not any(probe.status == "failed" for probe in probes):
+                probes.append(
+                    _forbidden_sidebar_text_probe(
+                        page,
+                        app_name=app_name,
+                        display=display,
+                        forbidden_sidebar_text=forbidden_sidebar_text,
+                        timeout_ms=widget_timeout_ms,
+                    )
+                )
+            if required_links and not any(probe.status == "failed" for probe in probes):
+                probes.append(
+                    _required_link_probe(
+                        page,
+                        app_name=app_name,
+                        display=display,
+                        required_links=required_links,
                         timeout_ms=widget_timeout_ms,
                     )
                 )
@@ -5602,6 +5624,155 @@ def _forbidden_text_probe(  # pragma: no cover - live browser path
     )
 
 
+def _page_and_frame_sidebar_text(page: Any, *, timeout_ms: float = 1000.0) -> str:  # pragma: no cover - live browser path
+    texts: list[str] = []
+    for _owner_name, owner in _page_and_child_frame_owners(page):
+        try:
+            locator = owner.locator("[data-testid='stSidebar']")
+            count = int(locator.count())
+        except Exception:
+            continue
+        for index in range(min(count, 8)):
+            try:
+                text = locator.nth(index).inner_text(timeout=timeout_ms)
+            except Exception:
+                continue
+            if text:
+                texts.append(str(text))
+    return "\n".join(texts)
+
+
+def _forbidden_sidebar_text_probe(  # pragma: no cover - live browser path
+    page: Any,
+    *,
+    app_name: str,
+    display: str,
+    forbidden_sidebar_text: Sequence[str],
+    timeout_ms: float,
+) -> WidgetProbe:
+    expected = tuple(str(label).strip() for label in forbidden_sidebar_text if str(label).strip())
+    text = _page_and_frame_sidebar_text(page, timeout_ms=timeout_ms)
+    normalized_text = text.lower()
+    present = [label for label in expected if label.lower() in normalized_text]
+    if present:
+        detail = f"forbidden sidebar text present: {present}; sidebar text sample={text[:500]!r}"
+        return WidgetProbe(
+            app_name,
+            display,
+            "forbidden_sidebar_text",
+            "sidebars",
+            "failed",
+            _short_detail(detail),
+            getattr(page, "url", ""),
+        )
+    detail = f"forbidden sidebar text absent from page and child frame sidebars: {list(expected)}"
+    return WidgetProbe(
+        app_name,
+        display,
+        "forbidden_sidebar_text",
+        "sidebars",
+        "interacted",
+        _short_detail(detail),
+        getattr(page, "url", ""),
+    )
+
+
+def _required_link_spec_parts(spec: str) -> tuple[str, tuple[str, ...]]:
+    raw = str(spec).strip()
+    if "=>" in raw:
+        label, fragments = raw.split("=>", 1)
+    elif "|" in raw:
+        label, fragments = raw.split("|", 1)
+    else:
+        label, fragments = raw, ""
+    return label.strip(), tuple(part.strip() for part in fragments.split(";") if part.strip())
+
+
+def _visible_link_href(owner: Any, label: str, *, timeout_ms: float) -> tuple[str | None, str]:
+    if not hasattr(owner, "get_by_role"):
+        return None, "owner has no role locator"
+    try:
+        locator = owner.get_by_role("link", name=re.compile(re.escape(label), re.IGNORECASE))
+    except TypeError:
+        try:
+            locator = owner.get_by_role("link", name=label)
+        except Exception as exc:
+            return None, f"link role lookup failed: {exc}"
+    except Exception as exc:
+        return None, f"link role lookup failed: {exc}"
+    try:
+        count = int(locator.count())
+    except Exception as exc:
+        return None, f"link candidate count failed: {exc}"
+    if count <= 0:
+        return None, "no link candidates"
+    last_detail = "no visible link candidates"
+    for index in range(min(count, 20)):
+        try:
+            candidate = locator.nth(index)
+            if not candidate.is_visible(timeout=timeout_ms):
+                last_detail = "link candidate was not visible"
+                continue
+            href = candidate.get_attribute("href", timeout=timeout_ms) or ""
+            return str(href), "link is visible"
+        except Exception as exc:
+            last_detail = f"link candidate could not be inspected: {exc}"
+    return None, last_detail
+
+
+def _required_link_probe(  # pragma: no cover - live browser path
+    page: Any,
+    *,
+    app_name: str,
+    display: str,
+    required_links: Sequence[str],
+    timeout_ms: float,
+) -> WidgetProbe:
+    expected = tuple(_required_link_spec_parts(spec) for spec in required_links if str(spec).strip())
+    missing: list[str] = []
+    found: list[str] = []
+    details: list[str] = []
+    owners = _page_and_child_frame_owners(page)
+    for label, fragments in expected:
+        label_found = False
+        label_details: list[str] = []
+        for owner_name, owner in owners:
+            href, detail = _visible_link_href(owner, label, timeout_ms=timeout_ms)
+            if href is not None and all(fragment in href for fragment in fragments):
+                found.append(f"{label}@{owner_name}:{href}")
+                label_found = True
+                break
+            if href is not None:
+                missing_fragments = [fragment for fragment in fragments if fragment not in href]
+                detail = f"href={href!r} missing fragments={missing_fragments}"
+            label_details.append(f"{owner_name}: {detail}")
+        if not label_found:
+            spec = label if not fragments else f"{label}=>{';'.join(fragments)}"
+            missing.append(spec)
+            details.append(f"{spec}: {'; '.join(label_details)}")
+    if missing:
+        detail = f"required links missing: {missing}; " + " | ".join(details)
+        return WidgetProbe(
+            app_name,
+            display,
+            "required_link",
+            "page_and_frames",
+            "failed",
+            _short_detail(detail),
+            getattr(page, "url", ""),
+        )
+    detail = f"required links visible with expected href fragments: {found}"
+    return WidgetProbe(
+        app_name,
+        display,
+        "required_link",
+        "page_and_frames",
+        "interacted",
+        _short_detail(detail),
+        getattr(page, "url", ""),
+    )
+
+
 def _trial_click_required_button(  # pragma: no cover - live browser path
     owner: Any,
     label: str,
@@ -5724,6 +5895,8 @@ def sweep_direct_apps_page(  # pragma: no cover - live browser path
     above_fold_check: bool = False,
     required_text: Sequence[str] = (),
     forbidden_text: Sequence[str] = (),
+    forbidden_sidebar_text: Sequence[str] = (),
+    required_links: Sequence[str] = (),
     required_action_labels: Sequence[str] = (),
     visual_mask_dynamic_regions: bool = False,
     failure_bundle_dir: Path | None = None,
@@ -5851,6 +6024,8 @@ def sweep_direct_apps_page(  # pragma: no cover - live browser path
                         above_fold_check=above_fold_check,
                         required_text=required_text,
                         forbidden_text=forbidden_text,
+                        forbidden_sidebar_text=forbidden_sidebar_text,
+                        required_links=required_links,
                         required_action_labels=required_action_labels,
                         visual_mask_dynamic_regions=visual_mask_dynamic_regions,
                         failure_bundle_dir=failure_bundle_dir,
@@ -5903,6 +6078,8 @@ def sweep_app(  # pragma: no cover - live browser path
     above_fold_check: bool = False,
     required_text: Sequence[str] = (),
     forbidden_text: Sequence[str] = (),
+    forbidden_sidebar_text: Sequence[str] = (),
+    required_links: Sequence[str] = (),
     required_action_labels: Sequence[str] = (),
     visual_mask_dynamic_regions: bool = False,
     viewport_width: int = DEFAULT_VIEWPORT_WIDTH,
@@ -6008,6 +6185,8 @@ def sweep_app(  # pragma: no cover - live browser path
                                 above_fold_check=above_fold_check,
                                 required_text=required_text,
                                 forbidden_text=forbidden_text,
+                                forbidden_sidebar_text=forbidden_sidebar_text,
+                                required_links=required_links,
                                 required_action_labels=required_action_labels,
                                 visual_mask_dynamic_regions=visual_mask_dynamic_regions,
                                 success_screenshot=success_screenshot,
@@ -6123,6 +6302,8 @@ def sweep_app(  # pragma: no cover - live browser path
                     above_fold_check=above_fold_check,
                     required_text=required_text,
                     forbidden_text=forbidden_text,
+                    forbidden_sidebar_text=forbidden_sidebar_text,
+                    required_links=required_links,
                     required_action_labels=required_action_labels,
                     visual_mask_dynamic_regions=visual_mask_dynamic_regions,
                     failure_bundle_dir=failure_bundle_dir,
@@ -6177,6 +6358,8 @@ def sweep_remote_app(  # pragma: no cover - live browser path
     above_fold_check: bool = False,
     required_text: Sequence[str] = (),
     forbidden_text: Sequence[str] = (),
+    forbidden_sidebar_text: Sequence[str] = (),
+    required_links: Sequence[str] = (),
     required_action_labels: Sequence[str] = (),
     visual_mask_dynamic_regions: bool = False,
     viewport_width: int = DEFAULT_VIEWPORT_WIDTH,
@@ -6261,6 +6444,8 @@ def sweep_remote_app(  # pragma: no cover - live browser path
                         above_fold_check=above_fold_check,
                         required_text=required_text,
                         forbidden_text=forbidden_text,
+                        forbidden_sidebar_text=forbidden_sidebar_text,
+                        required_links=required_links,
                         required_action_labels=required_action_labels,
                         visual_mask_dynamic_regions=visual_mask_dynamic_regions,
                         success_screenshot=success_screenshot,
@@ -6396,6 +6581,8 @@ def sweep_remote_app(  # pragma: no cover - live browser path
                             above_fold_check=above_fold_check,
                             required_text=required_text,
                             forbidden_text=forbidden_text,
+                            forbidden_sidebar_text=forbidden_sidebar_text,
+                            required_links=required_links,
                             required_action_labels=required_action_labels,
                             visual_mask_dynamic_regions=visual_mask_dynamic_regions,
                             failure_bundle_dir=failure_bundle_dir,
@@ -6527,6 +6714,8 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--above-fold-check", action="store_true", help="Fail when expected page headings or primary controls are not visible above the initial viewport fold.")
     parser.add_argument("--required-text", default="", help="Comma-separated text that must be visible in the page or a child iframe after render.")
     parser.add_argument("--forbidden-text", default="", help="Comma-separated text that must not be visible in the page or a child iframe after render.")
+    parser.add_argument("--forbidden-sidebar-text", default="", help="Comma-separated text that must not be visible in Streamlit sidebars after render.")
+    parser.add_argument("--required-links", default="", help="Comma-separated link specs that must be visible, formatted as label=>href-fragment[;href-fragment].")
     parser.add_argument("--required-action-labels", default="", help="Comma-separated button labels that must be visible, enabled, and trial-clickable in the page or a child iframe.")
     parser.add_argument("--visual-mask-dynamic-regions", action="store_true", help="Mask volatile log/progress/code regions before success screenshots for visual baseline evidence.")
     parser.add_argument("--success-screenshot", action="store_true", help="Capture a screenshot for each passed page when --screenshot-dir is set.")
@@ -6598,6 +6787,8 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - live b
     preselect_labels = parse_csv(args.preselect_labels)
     required_text = parse_csv(args.required_text)
     forbidden_text = parse_csv(args.forbidden_text)
+    forbidden_sidebar_text = parse_csv(args.forbidden_sidebar_text)
+    required_links = parse_csv(args.required_links)
     required_action_labels = parse_csv(args.required_action_labels)
     if args.action_button_policy == "click-selected" and not click_action_labels:
         parser.error("--click-action-labels is required with --action-button-policy click-selected")
@@ -6665,6 +6856,8 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - live b
                 above_fold_check=args.above_fold_check,
                 required_text=required_text,
                 forbidden_text=forbidden_text,
+                forbidden_sidebar_text=forbidden_sidebar_text,
+                required_links=required_links,
                 required_action_labels=required_action_labels,
                 visual_mask_dynamic_regions=args.visual_mask_dynamic_regions,
                 viewport_width=args.viewport_width,
@@ -6719,6 +6912,8 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - live b
                 above_fold_check=args.above_fold_check,
                 required_text=required_text,
                 forbidden_text=forbidden_text,
+                forbidden_sidebar_text=forbidden_sidebar_text,
+                required_links=required_links,
                 required_action_labels=required_action_labels,
                 visual_mask_dynamic_regions=args.visual_mask_dynamic_regions,
                 viewport_width=args.viewport_width,

--- a/tools/agilab_widget_robot_matrix.py
+++ b/tools/agilab_widget_robot_matrix.py
@@ -48,6 +48,8 @@ class RobotScenario:
     preselect_labels: str = ""
     required_text: str = ""
     forbidden_text: str = ""
+    forbidden_sidebar_text: str = ""
+    required_links: str = ""
     required_action_labels: str = ""
     route_query: str = ""
     missing_selected_action_policy: str = "fail"
@@ -494,8 +496,9 @@ OPT_IN_SCENARIOS: dict[str, RobotScenario] = {
         runtime_isolation="isolated",
         action_button_policy="trial",
         apps="pytorch_playground_project",
-        required_text="PyTorch Playground,Page,Refresh evidence,Synced RUN snippet,Settings",
-        forbidden_text="Project:",
+        required_text="PyTorch Playground,Refresh evidence,Synced RUN snippet,Settings",
+        forbidden_sidebar_text="Project:",
+        required_links="Page=>current_page=view_app_ui",
         required_action_labels="Refresh evidence",
         action_timeout_seconds=30.0,
         page_timeout_seconds=420.0,
@@ -786,6 +789,10 @@ def build_robot_command(
         argv.extend(["--required-text", scenario.required_text])
     if scenario.forbidden_text:
         argv.extend(["--forbidden-text", scenario.forbidden_text])
+    if scenario.forbidden_sidebar_text:
+        argv.extend(["--forbidden-sidebar-text", scenario.forbidden_sidebar_text])
+    if scenario.required_links:
+        argv.extend(["--required-links", scenario.required_links])
     if scenario.required_action_labels:
         argv.extend(["--required-action-labels", scenario.required_action_labels])
     if scenario.assert_orchestrate_artifacts:

--- a/tools/ui_robot_coverage_contract.py
+++ b/tools/ui_robot_coverage_contract.py
@@ -31,8 +31,9 @@ REQUIRED_HF_FIRST_PROOF_PAGES = ("view_forecast_analysis", "view_maps", "view_re
 FORBIDDEN_HF_FIRST_PROOF_APPS = ("flight_project", "weather_forecast_legacy_project")
 REQUIRED_PYTORCH_ANALYSIS_SCENARIO = "isolated-pytorch-playground-analysis"
 REQUIRED_PYTORCH_ANALYSIS_APP = "pytorch_playground_project"
-REQUIRED_PYTORCH_ANALYSIS_TEXT = ("PyTorch Playground", "Page", "Refresh evidence", "Synced RUN snippet", "Settings")
-REQUIRED_PYTORCH_ANALYSIS_FORBIDDEN_TEXT = ("Project:",)
+REQUIRED_PYTORCH_ANALYSIS_TEXT = ("PyTorch Playground", "Refresh evidence", "Synced RUN snippet", "Settings")
+REQUIRED_PYTORCH_ANALYSIS_FORBIDDEN_SIDEBAR_TEXT = ("Project:",)
+REQUIRED_PYTORCH_ANALYSIS_LINKS = ("Page=>current_page=view_app_ui",)
 REQUIRED_PYTORCH_ANALYSIS_ACTIONS = ("Refresh evidence",)
 REQUIRED_HF_ROBOT_SCENARIOS = {
     "hf-first-proof-visual-smoke": {
@@ -136,6 +137,14 @@ def _scenario_required_text(widget_robot: Any, scenario: Any) -> set[str]:
 
 def _scenario_forbidden_text(widget_robot: Any, scenario: Any) -> set[str]:
     return set(widget_robot.parse_csv(str(getattr(scenario, "forbidden_text", ""))))
+
+
+def _scenario_forbidden_sidebar_text(widget_robot: Any, scenario: Any) -> set[str]:
+    return set(widget_robot.parse_csv(str(getattr(scenario, "forbidden_sidebar_text", ""))))
+
+
+def _scenario_required_links(widget_robot: Any, scenario: Any) -> set[str]:
+    return set(widget_robot.parse_csv(str(getattr(scenario, "required_links", ""))))
 
 
 def _scenario_required_actions(widget_robot: Any, scenario: Any) -> set[str]:
@@ -384,14 +393,16 @@ def evaluate_contract() -> dict[str, Any]:
         pages = sorted(_scenario_pages(widget_robot, pytorch_scenario))
         apps = sorted(_scenario_apps(widget_robot, pytorch_scenario))
         required_text = sorted(_scenario_required_text(widget_robot, pytorch_scenario))
-        forbidden_text = sorted(_scenario_forbidden_text(widget_robot, pytorch_scenario))
+        forbidden_sidebar_text = sorted(_scenario_forbidden_sidebar_text(widget_robot, pytorch_scenario))
+        required_links = sorted(_scenario_required_links(widget_robot, pytorch_scenario))
         required_actions = sorted(_scenario_required_actions(widget_robot, pytorch_scenario))
         flags = sorted(_scenario_flags(pytorch_scenario))
         pytorch_analysis = {
             "pages": pages,
             "apps": apps,
             "required_text": required_text,
-            "forbidden_text": forbidden_text,
+            "forbidden_sidebar_text": forbidden_sidebar_text,
+            "required_links": required_links,
             "required_actions": required_actions,
             "flags": flags,
         }
@@ -418,15 +429,24 @@ def evaluate_contract() -> dict[str, Any]:
                     + ", ".join(missing_text),
                 )
             )
-        missing_forbidden_text = sorted(
-            set(REQUIRED_PYTORCH_ANALYSIS_FORBIDDEN_TEXT) - set(forbidden_text)
+        missing_forbidden_sidebar_text = sorted(
+            set(REQUIRED_PYTORCH_ANALYSIS_FORBIDDEN_SIDEBAR_TEXT) - set(forbidden_sidebar_text)
         )
-        if missing_forbidden_text:
+        if missing_forbidden_sidebar_text:
             issues.append(
                 CoverageIssue(
                     "pytorch_analysis_robot",
-                    f"{REQUIRED_PYTORCH_ANALYSIS_SCENARIO} is missing forbidden text probes: "
-                    + ", ".join(missing_forbidden_text),
+                    f"{REQUIRED_PYTORCH_ANALYSIS_SCENARIO} is missing forbidden sidebar text probes: "
+                    + ", ".join(missing_forbidden_sidebar_text),
+                )
+            )
+        missing_links = sorted(set(REQUIRED_PYTORCH_ANALYSIS_LINKS) - set(required_links))
+        if missing_links:
+            issues.append(
+                CoverageIssue(
+                    "pytorch_analysis_robot",
+                    f"{REQUIRED_PYTORCH_ANALYSIS_SCENARIO} is missing required link probes: "
+                    + ", ".join(missing_links),
                 )
             )
         missing_actions = sorted(set(REQUIRED_PYTORCH_ANALYSIS_ACTIONS) - set(required_actions))


### PR DESCRIPTION
## Summary
- add robot probes for required link targets and forbidden sidebar text
- assert the PyTorch ANALYSIS sidebar exposes the Page link to view_app_ui without the Project: prefix
- remove duplicate app-surface title rendering from the ANALYSIS body

## Validation
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_agilab_widget_robot.py::test_widget_robot_parser_exposes_resumable_run_controls test/test_agilab_widget_robot.py::test_forbidden_text_probe_reads_child_frames_and_passes_when_absent test/test_agilab_widget_robot.py::test_forbidden_text_probe_reports_visible_forbidden_text test/test_agilab_widget_robot.py::test_forbidden_sidebar_text_probe_reports_visible_sidebar_text test/test_agilab_widget_robot.py::test_required_link_probe_matches_label_and_href_fragments test/test_agilab_widget_robot.py::test_required_link_probe_reports_missing_href_fragment test/test_agilab_widget_robot_matrix.py::test_opt_in_mobile_and_release_evidence_scenarios_are_not_part_of_default_all test/test_agilab_widget_robot_matrix.py::test_build_robot_command_covers_pytorch_playground_analysis_text test/test_ui_robot_coverage_contract.py::test_ui_robot_coverage_contract_json_cli test/test_ui_robot_coverage_contract.py::test_ui_robot_coverage_contract_accepts_explicit_full_app_profile test/test_ui_robot_coverage_contract.py::test_ui_robot_coverage_contract_reports_matrix_and_pytorch_gaps test/test_ui_pages.py::test_explore_page_app_surface_back_keeps_single_app_ui_sidebar_view test/test_ui_pages.py::test_explore_page_app_surface_uses_standard_view_selection