### PR TITLE
Align local release cadence policy with workflow

### DIFF
--- a/test/test_agilab_dev_shortcuts.py
+++ b/test/test_agilab_dev_shortcuts.py
@@ -447,6 +447,7 @@ def test_release_shortcut_runs_local_release_guards():
             "run",
             "python",
             "tools/pypi_release_version_policy.py",
+            "--skip-existing-pypi",
         ],
         [
             "uv",

--- a/tools/agilab_dev.py
+++ b/tools/agilab_dev.py
@@ -112,7 +112,7 @@ def planned_commands(argv: Sequence[str]) -> list[list[str]]:
                 "--check-workflow",
                 ".github/workflows/pypi-publish.yaml",
             ),
-            _uv_python("tools/pypi_release_version_policy.py"),
+            _uv_python("tools/pypi_release_version_policy.py", "--skip-existing-pypi"),
             _uv_python("tools/pypi_project_preflight.py"),
             _uv_python(
                 "tools/pypi_trusted_publisher_contract.py",


### PR DESCRIPTION
## Summary\n- make ./dev release pass --skip-existing-pypi to the PyPI release cadence policy check\n- keep local release validation aligned with the GitHub workflow default that skips already-published packages\n\n## Validation\n- uv --preview-features extra-build-dependencies run python -m pytest -q -o addopts='' --import-mode=importlib test/test_agilab_dev_shortcuts.py::test_release_shortcut_runs_local_release_guards\n- ./dev --print-only release