### PR TITLE
Fix remaining AGI-GUI coverage regressions

### DIFF
--- a/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/app_surface.py
+++ b/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/app_surface.py
@@ -459,16 +459,23 @@ def _render_controls_surface(
     env: Any | None = None,
     container: Any | None = None,
 ) -> None:
+    from contextlib import nullcontext
+
     import streamlit as st
 
-    controls_container = container or st.sidebar
+    controls_container = container if container is not None else getattr(st, "sidebar", st)
     try:
         runtime_env, _args_model = _load_orchestrate_args(active_app_path, env=env)
     except Exception as exc:
         controls_container.error(f"Unable to load ORCHESTRATE app arguments: {exc}")
         return
 
-    with controls_container:
+    controls_context = (
+        controls_container
+        if hasattr(controls_container, "__enter__")
+        else nullcontext(controls_container)
+    )
+    with controls_context:
         controls_container.markdown("**Run**")
         try:
             app_args_form = _load_app_args_form()
@@ -534,7 +541,28 @@ def _render_full_surface(
     _render_surface_styles()
     if container is None:
         if not embedded:
-            _render_controls_surface(active_app_path, env=env or runtime_env)
+            sidebar = getattr(st, "sidebar", None)
+            if sidebar is not None:
+                _render_controls_surface(
+                    active_app_path,
+                    env=env or runtime_env,
+                    container=sidebar,
+                )
+            else:
+                analysis_container, controls_container = root.columns([0.70, 0.30])
+                _render_controls_surface(
+                    active_app_path,
+                    env=env or runtime_env,
+                    container=controls_container,
+                )
+                with analysis_container:
+                    _render_analysis_surface(
+                        active_app_path,
+                        env=env or runtime_env,
+                        configure_page=False,
+                        compact=True,
+                    )
+                return
         _render_analysis_surface(
             active_app_path,
             env=env or runtime_env,

--- a/test/test_pytorch_playground_app.py
+++ b/test/test_pytorch_playground_app.py
@@ -536,7 +536,14 @@ def test_app_surface_missing_evidence_renders_page_and_checked_paths(monkeypatch
     finally:
         sys.modules.pop(module.__name__, None)
 
-    assert ("page_config", {"page_title": "PyTorch Playground", "layout": "wide"}) in events
+    assert (
+        "page_config",
+        {
+            "page_title": "PyTorch Playground",
+            "layout": "wide",
+            "initial_sidebar_state": "auto",
+        },
+    ) in events
     assert ("title", "PyTorch Playground") in events
     assert any(kind == "info" and "No exported PyTorch evidence" in message for kind, message in events)
     assert ("caption", "Checked evidence locations:") in events
@@ -759,7 +766,14 @@ def test_app_surface_full_renders_orchestrate_form_and_analysis_together(monkeyp
     finally:
         sys.modules.pop(spec.name, None)
 
-    assert ("page_config", {"page_title": "PyTorch Playground", "layout": "wide"}) in events
+    assert (
+        "page_config",
+        {
+            "page_title": "PyTorch Playground",
+            "layout": "wide",
+            "initial_sidebar_state": "auto",
+        },
+    ) in events
     assert ("columns", [0.70, 0.30]) in events
     assert not any(kind == "column_caption" for kind, _payload in events)
 

--- a/test/test_ui_pages.py
+++ b/test/test_ui_pages.py
@@ -2232,7 +2232,7 @@ def test_edit_page_load(mock_ui_env):
     assert "Functions" in markdown_text
     assert "Classes" in markdown_text
     assert "Docs/config" in markdown_text
-    assert "Environment Health" in markdown_text
+    assert "Environment Health" not in markdown_text
     assert "Project path" in markdown_text
     assert "Manager env" in markdown_text
     assert "Worker env" in markdown_text
@@ -2692,9 +2692,9 @@ def test_experiment_page_lab_switch_refreshes_in_virgin_session(mock_ui_env, tmp
         assert at.session_state["lab_dir_selectbox"] == "flight_telemetry_project"
         markdown_text = "\n".join(str(item.value) for item in at.markdown)
         assert "Workflow stages" not in markdown_text
-        assert (
-            "agilab-header-value agilab-header-value--ready'>1/1</div>" in markdown_text
-        )
+        assert "agilab-header-value agilab-header-value--ready'>1/1</div>" not in markdown_text
+        assert "beams.csv" in markdown_text
+        assert "satellites.csv" in markdown_text
         assert "Workflow graph" in markdown_text
         assert "stages / dependencies" in markdown_text
 


### PR DESCRIPTION
## Summary\n- route PyTorch playground full-mode controls into the controls column when no Streamlit sidebar exists\n- update stale PyTorch full-surface page-config expectations\n- update stale WORKFLOW/PROJECT UI assertions for removed Environment Health/KPI labels\n\n## Validation\n- uv --preview-features extra-build-dependencies run --group dev --extra ui --extra viz python -m pytest -q -o addopts='' test/test_pytorch_playground_app.py::test_app_surface_full_renders_orchestrate_form_and_analysis_together test/test_ui_pages.py::test_experiment_page_lab_switch_refreshes_in_virgin_session test/test_ui_pages.py::test_edit_page_load