### PR TITLE
[codex] Add agi-web coverage badge

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -327,6 +327,54 @@ jobs:
           if-no-files-found: ignore
           retention-days: 3
 
+  agi-web:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.13"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          version: "0.10.7"
+
+      - name: Run agi-web coverage
+        run: |
+          set -e
+          rm -f .coverage.agi-web coverage-agi-web.xml
+          COVERAGE_FILE=.coverage.agi-web uv run --no-project \
+            --with-editable ./src/agilab/lib/agi-web \
+            --with pytest \
+            --with pytest-cov \
+            python -m pytest -q --maxfail=1 --disable-warnings -o addopts='' \
+            --cov=agi_web --cov-report=xml:coverage-agi-web.xml \
+            src/agilab/lib/agi-web/test
+
+      - name: Upload agi-web coverage to Codecov
+        if: always() && hashFiles('coverage-agi-web.xml') != ''
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
+        with:
+          files: ./coverage-agi-web.xml
+          flags: agi-web
+          use_oidc: true
+          verbose: true
+          fail_ci_if_error: true
+
+      - name: Archive agi-web coverage XML
+        if: always() && hashFiles('coverage-agi-web.xml') != ''
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: coverage-agi-web-xml
+          path: coverage-agi-web.xml
+          if-no-files-found: error
+          retention-days: 3
+
   agi-gui-combine:
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -468,6 +516,7 @@ jobs:
       - agi-env
       - agi-core
       - agi-gui-combine
+      - agi-web
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -497,7 +546,8 @@ jobs:
             ./merged-coverage/coverage-agi-env.xml,
             ./merged-coverage/coverage-agi-node.xml,
             ./merged-coverage/coverage-agi-cluster.xml,
-            ./merged-coverage/coverage-agi-gui.xml
+            ./merged-coverage/coverage-agi-gui.xml,
+            ./merged-coverage/coverage-agi-web.xml
           use_oidc: true
           verbose: true
           fail_ci_if_error: true

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
   <a href="https://github.com/ThalesGroup/agilab/actions/workflows/coverage.yml"><img src="https://github.com/ThalesGroup/agilab/actions/workflows/coverage.yml/badge.svg?branch=main" alt="Coverage workflow" /></a>
   <a href="https://codecov.io/gh/ThalesGroup/agilab"><img src="https://raw.githubusercontent.com/ThalesGroup/agilab/main/badges/coverage-agilab.svg" alt="agilab coverage" /></a>
   <a href="https://codecov.io/gh/ThalesGroup/agilab?flags%5B0%5D=agi-gui"><img src="https://raw.githubusercontent.com/ThalesGroup/agilab/main/badges/coverage-agi-gui.svg" alt="agi-gui coverage" /></a>
+  <a href="https://codecov.io/gh/ThalesGroup/agilab?flags%5B0%5D=agi-web"><img src="https://raw.githubusercontent.com/ThalesGroup/agilab/main/badges/coverage-agi-web.svg" alt="agi-web coverage" /></a>
   <a href="https://codecov.io/gh/ThalesGroup/agilab?flags%5B0%5D=agi-env"><img src="https://raw.githubusercontent.com/ThalesGroup/agilab/main/badges/coverage-agi-env.svg" alt="agi-env coverage" /></a>
   <a href="https://codecov.io/gh/ThalesGroup/agilab?flags%5B0%5D=agi-node"><img src="https://raw.githubusercontent.com/ThalesGroup/agilab/main/badges/coverage-agi-node.svg" alt="agi-node coverage" /></a>
   <a href="https://codecov.io/gh/ThalesGroup/agilab?flags%5B0%5D=agi-cluster"><img src="https://raw.githubusercontent.com/ThalesGroup/agilab/main/badges/coverage-agi-cluster.svg" alt="agi-cluster coverage" /></a>

--- a/badges/coverage-agi-web.svg
+++ b/badges/coverage-agi-web.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="153" height="20" role="img" aria-label="agi-web coverage: 96%">
+<linearGradient id="b" x2="0" y2="100%">
+  <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
+  <stop offset=".1" stop-opacity=".1"/>
+  <stop offset=".9" stop-opacity=".3"/>
+  <stop offset="1" stop-opacity=".5"/>
+</linearGradient>
+<mask id="a">
+  <rect width="153" height="20" rx="3" fill="#fff"/>
+</mask>
+<g mask="url(#a)">
+  <rect width="122" height="20" fill="#555"/>
+  <rect x="122" width="31" height="20" fill="#2ea44f"/>
+  <rect width="153" height="20" fill="url(#b)"/>
+</g>
+<g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+  <text x="61.0" y="15" fill="#010101" fill-opacity=".3">agi-web coverage</text>
+  <text x="61.0" y="14">agi-web coverage</text>
+  <text x="137.5" y="15" fill="#010101" fill-opacity=".3">96%</text>
+  <text x="137.5" y="14">96%</text>
+</g>
+</svg>

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 250,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "7b9f5c2eb3ce1a9fe1e0ed50ba8c41fd18d3a2d9f490a50c93b1a025e8a40c9f",
+  "source_digest_sha256": "3077937c03eabbde92d6d432ab514b92caedf4d4952b60add8e7246972c79e53",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "7b9f5c2eb3ce1a9fe1e0ed50ba8c41fd18d3a2d9f490a50c93b1a025e8a40c9f"
+  "target_digest_sha256": "3077937c03eabbde92d6d432ab514b92caedf4d4952b60add8e7246972c79e53"
 }

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -394,6 +394,7 @@ Typical refresh path::
 
    uv --preview-features extra-build-dependencies run python tools/generate_component_coverage_badges.py --components agi-gui
 
+Use ``--components agi-web`` for the portable web-component contract badge.
 For the global badge, you also need the corresponding aggregate XML inputs
 before regenerating ``badges/coverage-agilab.svg``.
 

--- a/test/test_coverage_badge_guard.py
+++ b/test/test_coverage_badge_guard.py
@@ -38,6 +38,24 @@ def test_changed_coverage_components_maps_gui_and_root_tests() -> None:
     }
 
 
+def test_changed_coverage_components_maps_agi_web_without_gui_overlap() -> None:
+    module = _load_module()
+
+    changed = module.changed_coverage_components(
+        [
+            "src/agilab/lib/agi-web/src/agi_web/component.py",
+            "src/agilab/lib/agi-web/test/test_agi_web_component.py",
+        ]
+    )
+
+    assert changed == {
+        "agi-web": [
+            "src/agilab/lib/agi-web/src/agi_web/component.py",
+            "src/agilab/lib/agi-web/test/test_agi_web_component.py",
+        ]
+    }
+
+
 def test_changed_coverage_components_ignores_coverage_tooling_tests() -> None:
     module = _load_module()
 
@@ -118,6 +136,7 @@ def test_expand_with_aggregates_adds_core_and_global_badges() -> None:
 
     assert module.expand_with_aggregates(["agi-env"]) == ["agi-env", "agi-core", "agilab"]
     assert module.expand_with_aggregates(["agi-gui"]) == ["agi-gui", "agilab"]
+    assert module.expand_with_aggregates(["agi-web"]) == ["agi-web"]
 
 
 def test_expected_svg_uses_generator_aggregate_policy() -> None:

--- a/test/test_coverage_workflow.py
+++ b/test/test_coverage_workflow.py
@@ -174,6 +174,23 @@ def test_agi_gui_coverage_includes_pages_lib_package_tests() -> None:
     assert "src/agilab/lib/agi-gui/test" in run_block
 
 
+def test_agi_web_has_dedicated_coverage_job_and_badge_input() -> None:
+    workflow_text = _workflow_text()
+    run_block = _step_block("Run agi-web coverage")
+    upload_block = _step_block("Upload agi-web coverage to Codecov")
+    archive_block = _step_block("Archive agi-web coverage XML")
+
+    assert "  agi-web:" in workflow_text
+    assert "--with-editable ./src/agilab/lib/agi-web" in run_block
+    assert "--cov=agi_web" in run_block
+    assert "coverage-agi-web.xml" in run_block
+    assert "src/agilab/lib/agi-web/test" in run_block
+    assert "flags: agi-web" in upload_block
+    assert "coverage-agi-web-xml" in archive_block
+    assert "      - agi-web" in workflow_text
+    assert "./merged-coverage/coverage-agi-web.xml" in workflow_text
+
+
 def test_agi_gui_coverage_includes_pytorch_playground_app_surface_regressions() -> None:
     run_block = _agi_gui_run_block()
 
@@ -391,6 +408,7 @@ def test_codecov_uploads_are_blocking_coverage_publication_gates() -> None:
         "Upload agi-node coverage to Codecov",
         "Upload agi-cluster coverage to Codecov",
         "Upload agi-gui coverage to Codecov",
+        "Upload agi-web coverage to Codecov",
         "Upload repo-wide agilab coverage to Codecov",
     ]
 
@@ -412,6 +430,7 @@ def test_coverage_artifacts_have_short_retention_for_cost_control() -> None:
         "Upload agi-gui chunk JUnit",
         "Upload JUnit results",
         "Archive agi-gui coverage XML",
+        "Archive agi-web coverage XML",
     ):
         block = _step_block(step_name)
 

--- a/test/test_generate_component_coverage_badges.py
+++ b/test/test_generate_component_coverage_badges.py
@@ -49,6 +49,7 @@ def test_component_badges_use_component_name_in_label() -> None:
     assert module.COMPONENTS["agi-node"]["label"] == "agi-node coverage"
     assert module.COMPONENTS["agi-cluster"]["label"] == "agi-cluster coverage"
     assert module.COMPONENTS["agi-gui"]["label"] == "agi-gui coverage"
+    assert module.COMPONENTS["agi-web"]["label"] == "agi-web coverage"
     assert module.COMPONENTS["agi-core"]["label"] == "agi-core coverage"
 
 
@@ -194,6 +195,7 @@ def test_node_and_cluster_default_to_explicit_component_or_combined_reports_only
     assert module.COMPONENTS["agi-cluster"].get("allow_combined_fallback") is None
     assert module.COMPONENTS["agi-env"].get("allow_combined_fallback") is None
     assert module.COMPONENTS["agi-gui"].get("allow_combined_fallback") is None
+    assert module.COMPONENTS["agi-web"].get("allow_combined_fallback") is None
 
 
 def test_resolve_component_counts_does_not_use_combined_xml_without_opt_in(tmp_path: Path) -> None:

--- a/tools/coverage_badge_guard.py
+++ b/tools/coverage_badge_guard.py
@@ -22,16 +22,18 @@ from typing import Iterable, Sequence
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
-COVERAGE_COMPONENTS = ("agi-env", "agi-node", "agi-cluster", "agi-gui")
+COVERAGE_COMPONENTS = ("agi-env", "agi-node", "agi-cluster", "agi-gui", "agi-web")
 AGGREGATE_COMPONENTS = ("agi-core", "agilab")
 ALL_COMPONENTS = (*COVERAGE_COMPONENTS, *AGGREGATE_COMPONENTS)
 CORE_COMPONENTS = {"agi-env", "agi-node", "agi-cluster"}
+GLOBAL_COMPONENTS = {"agi-env", "agi-node", "agi-cluster", "agi-gui"}
 
 COMPONENT_XML = {
     "agi-env": "coverage-agi-env.xml",
     "agi-node": "coverage-agi-node.xml",
     "agi-cluster": "coverage-agi-cluster.xml",
     "agi-gui": "coverage-agi-gui.xml",
+    "agi-web": "coverage-agi-web.xml",
 }
 
 COVERAGE_TOOLING_TESTS = {
@@ -167,6 +169,8 @@ def _is_gui_coverage_path(path: str) -> bool:
         return False
     if path == "pyproject.toml" or path.endswith("/pyproject.toml"):
         return False
+    if path.startswith("src/agilab/lib/agi-web/"):
+        return False
     if path.startswith("src/agilab/core/"):
         return False
     if path.startswith("src/agilab/test/"):
@@ -192,6 +196,8 @@ def changed_coverage_components(paths: Sequence[str]) -> dict[str, list[str]]:
         if path.startswith("src/agilab/core/test/"):
             by_component["agi-node"].append(path)
             by_component["agi-cluster"].append(path)
+        if path.startswith("src/agilab/lib/agi-web/"):
+            by_component["agi-web"].append(path)
         if _is_gui_coverage_path(path):
             by_component["agi-gui"].append(path)
         if (
@@ -211,7 +217,7 @@ def expand_with_aggregates(components: Iterable[str]) -> list[str]:
     selected = set(components)
     if selected & CORE_COMPONENTS:
         selected.add("agi-core")
-    if selected & set(COVERAGE_COMPONENTS):
+    if selected & GLOBAL_COMPONENTS:
         selected.add("agilab")
     return [component for component in ALL_COMPONENTS if component in selected]
 
@@ -350,6 +356,13 @@ def _guard_commands(components: Sequence[str]) -> list[str]:
         )
     if "agi-gui" in components:
         commands.append("uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui")
+    if "agi-web" in components:
+        commands.append(
+            "uv --preview-features extra-build-dependencies run --no-project "
+            "--with-editable ./src/agilab/lib/agi-web --with pytest --with pytest-cov "
+            "python -m pytest -q --maxfail=1 --disable-warnings -o addopts='' "
+            "--cov=agi_web --cov-report=xml:coverage-agi-web.xml src/agilab/lib/agi-web/test"
+        )
     if components:
         commands.append(
             "uv --preview-features extra-build-dependencies run python "

--- a/tools/generate_component_coverage_badges.py
+++ b/tools/generate_component_coverage_badges.py
@@ -35,6 +35,12 @@ COMPONENTS = {
         "prefix": "src/agilab/",
         "badge": REPO_ROOT / "badges" / "coverage-agi-gui.svg",
     },
+    "agi-web": {
+        "label": "agi-web coverage",
+        "xml": REPO_ROOT / "coverage-agi-web.xml",
+        "prefix": "src/agilab/lib/agi-web/",
+        "badge": REPO_ROOT / "badges" / "coverage-agi-web.svg",
+    },
     "agi-core": {
         "label": "agi-core coverage",
         "aggregate": ("agi-env", "agi-node", "agi-cluster"),


### PR DESCRIPTION
## Summary
- add a dedicated `agi-web` coverage badge and generated SVG artifact
- add the `agi-web` Codecov workflow slice and aggregate upload input
- extend badge guard/generator tests and document the refresh command in the public FAQ mirror

## Validation
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' --import-mode=importlib test/test_generate_component_coverage_badges.py test/test_coverage_badge_guard.py test/test_coverage_workflow.py` (`59 passed`)
- `uv --preview-features extra-build-dependencies run python tools/coverage_badge_guard.py --components agi-web`
- `COVERAGE_FILE=.coverage.agi-web uv run --no-project --with-editable ./src/agilab/lib/agi-web --with pytest --with pytest-cov python -m pytest -q --maxfail=1 --disable-warnings -o addopts='' --cov=agi_web --cov-report=xml:coverage-agi-web.xml src/agilab/lib/agi-web/test` (`9 passed`)
- `git diff --check`
