### PR TITLE
docs: describe agi-web React-ready UI contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ workers, and the workflow stays portable: export it back to an `agi-core`
 notebook, inspect or adapt the Python stages, and hand off tracking evidence to
 MLflow when that integration is enabled.
 Apps can also declare multiple UI surfaces, so an app can keep the same runtime
-and evidence contract while exposing Streamlit, hosted Hugging Face, or future
-NiceGUI/Gradio/FastAPI adapters.
+and evidence contract while exposing Streamlit, hosted Hugging Face, or
+browser-native `agi-web` UI islands with React-ready component contracts.
 
 You do not need a cluster to get AGILAB's core value. The primary adoption path
 is local: turn a notebook or script into a replayable app with evidence,
@@ -273,7 +273,7 @@ what they need:
 |---|---|---|
 | Base package | Lightweight `agilab` command shell plus Python 3.13 stdlib shims. It does not install the core runtime, UI, apps, pages, notebooks, or model stacks by default. | Version/help checks, package/app management commands, and metadata/reporting helpers that do not execute AGILAB runtime code. |
 | `core` extra | `agi-core`, which wires `agi-env`, `agi-node`, and `agi-cluster` for compact local/distributed runtime smoke checks. | CLI proof, source-checkout validation, notebook/API runtime, and worker-runtime development without the UI or packaged examples. |
-| `ui` extra | Streamlit UI, page helpers, portable `agi-web` UI-island contracts, pandas/network graph utilities, `agi-apps`, and the `agi-pages` provider. Promoted app and page payload packages are on PyPI; unpromoted app payloads remain release artifacts until publication is enabled. | Running the local product UI with the packaged runtime and optional public demo assets. |
+| `ui` extra | Streamlit UI, page helpers, portable `agi-web` Canvas2D/WebGL and React-ready UI-island contracts, pandas/network graph utilities, `agi-apps`, and the `agi-pages` provider. Promoted app and page payload packages are on PyPI; unpromoted app payloads remain release artifacts until publication is enabled. | Running the local product UI with the packaged runtime and optional public demo assets. |
 | `examples` extra | `agi-apps` app catalog/examples plus notebook/demo helper dependencies such as JupyterLab and optional plotting packages. | Running packaged notebooks, demos, learning examples, and package first-proof routes. |
 | `notebook` extra | Notebook execution helpers such as `nbclient`, `nbformat`, and `ipykernel`. | Running `agilab run notebook` to execute a local notebook and write AGILAB evidence. |
 | `pages` extra | `agi-pages` page-provider helpers without the full UI profile. | Installing or validating sidecar page-bundle discovery separately from built-in app projects. |
@@ -404,7 +404,7 @@ the same releaseable tree.
 | Area | Role | Stability contract |
 |---|---|---|
 | `src/agilab/core/agi-env`, `agi-node`, `agi-cluster`, `agi-core` | Runtime packages for environment setup, worker packaging, distributed execution, and the compact API. | Stable where documented; changes require focused regression evidence. |
-| `src/agilab/lib/agi-gui`, `src/agilab/lib/agi-web`, `src/agilab/pages` | Main web UI, Streamlit page helpers, portable UI-island contracts, and app-surface launch adapters. | Beta product surface; useful for operators, still evolving. App runtime contracts should not depend on one UI backend. |
+| `src/agilab/lib/agi-gui`, `src/agilab/lib/agi-web`, `src/agilab/pages` | Main web UI, Streamlit page helpers, portable Canvas2D/WebGL and React-ready UI-island contracts, and app-surface launch adapters. | Beta product surface; useful for operators, still evolving. App runtime contracts should not depend on one UI backend. |
 | `src/agilab/lib/agi-apps` | PyPI umbrella that carries app catalog/example assets and exact-pins the app payload packages already promoted to PyPI. | Packaged asset surface for the `ui` and `examples` extras. |
 | `src/agilab/lib/agi-pages` | PyPI provider package for public analysis page discovery. Published `agi-page-*` payload packages are distributed independently; `agi-pages` supplies the discovery/provider surface. | Packaged page-provider surface for the `ui` and `pages` extras. |
 | `src/agilab/apps/builtin` | Public built-in apps used for first proof, demos, workflow examples, and regression coverage. | Packaged examples, not enterprise deployment templates. |
@@ -443,8 +443,8 @@ Current packaging policy is conservative:
   in by the `ui` and `pages` extras.
 - Rich app-owned browser views should use `agi-web` contracts when they need a
   stable payload that can render in Streamlit/static HTML now through bundled
-  Canvas2D/WebGL adapters and later move to another frontend without changing
-  the app evidence contract.
+  Canvas2D/WebGL adapters and keep a React-ready component boundary without
+  changing the app evidence contract.
 - The optional PyTorch playground lives in
   [`src/agilab/apps/builtin/pytorch_playground_project`](src/agilab/apps/builtin/pytorch_playground_project).
   It is a reproducible app project rather than a generic app-agnostic analysis

--- a/README.pypi.md
+++ b/README.pypi.md
@@ -57,8 +57,8 @@ code, stage order, runtime hints, and review context remain usable through the
 stable, production-grade core technology if the AGILAB UI or distributed
 runtime is no longer the right interface for that work.
 Apps can also declare multiple UI surfaces, so the same runtime and evidence
-contract can be exposed through Streamlit, hosted Hugging Face, or future
-NiceGUI/Gradio/FastAPI adapters.
+contract can be exposed through Streamlit, hosted Hugging Face, or
+browser-native `agi-web` UI islands with React-ready component contracts.
 
 ## Demo Routes
 
@@ -225,7 +225,7 @@ what they need:
 |---|---|---|
 | Base package | Lightweight `agilab` command shell plus Python 3.13 stdlib shims. It does not install the core runtime, UI, apps, pages, notebooks, or model stacks by default. | Version/help checks, package/app management commands, and metadata/reporting helpers that do not execute AGILAB runtime code. |
 | `core` extra | `agi-core`, which wires `agi-env`, `agi-node`, and `agi-cluster` for compact local/distributed runtime smoke checks. | CLI proof, source-checkout validation, notebook/API runtime, and worker-runtime development without the UI or packaged examples. |
-| `ui` extra | Streamlit UI, page helpers, portable `agi-web` UI-island contracts, pandas/network graph utilities, `agi-apps`, and the `agi-pages` provider. Promoted app and page payload packages are on PyPI; unpromoted app payloads remain release artifacts until publication is enabled. | Running the local product UI with the packaged runtime and optional public demo assets. |
+| `ui` extra | Streamlit UI, page helpers, portable `agi-web` Canvas2D/WebGL and React-ready UI-island contracts, pandas/network graph utilities, `agi-apps`, and the `agi-pages` provider. Promoted app and page payload packages are on PyPI; unpromoted app payloads remain release artifacts until publication is enabled. | Running the local product UI with the packaged runtime and optional public demo assets. |
 | `examples` extra | `agi-apps` app catalog/examples plus notebook/demo helper dependencies such as JupyterLab and optional plotting packages. | Running packaged notebooks, demos, learning examples, and package first-proof routes. |
 | `pages` extra | `agi-pages` page-provider helpers without the full UI profile. | Installing or validating sidecar page-bundle discovery separately from built-in app projects. |
 | `proof` extra | Optional `cryptography` dependency for detached Ed25519 proof-capsule signatures. | Signing `.agipack` archives and verifying them against local trust policies. |
@@ -328,7 +328,7 @@ Use three planes to read that tree:
 | Area | Role | Stability contract |
 |---|---|---|
 | `src/agilab/core/*` | Runtime packages and compact API. | Stable where documented. |
-| `src/agilab/lib/agi-gui`, `src/agilab/lib/agi-web`, `src/agilab/pages` | Main web UI, Streamlit page helpers, portable UI-island contracts, and app-surface launch adapters. | Beta product surface; app runtime contracts should not depend on one UI backend. |
+| `src/agilab/lib/agi-gui`, `src/agilab/lib/agi-web`, `src/agilab/pages` | Main web UI, Streamlit page helpers, portable Canvas2D/WebGL and React-ready UI-island contracts, and app-surface launch adapters. | Beta product surface; app runtime contracts should not depend on one UI backend. |
 | `src/agilab/lib/agi-apps` | PyPI umbrella carrying app catalog/example assets and exact-pinning the app payload packages already promoted to PyPI. Deferred app payloads remain release artifacts until publication is enabled. | Packaged asset surface for the `ui` and `examples` extras. |
 | `src/agilab/lib/agi-pages` | PyPI provider package for public analysis page discovery. Published `agi-page-*` payload packages are distributed independently; `agi-pages` supplies the discovery/provider surface. | Packaged page-provider surface for the `ui` and `pages` extras. |
 | `src/agilab/apps/builtin` | First-proof and demo apps. | Packaged examples, not deployment templates. |

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 250,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "3077937c03eabbde92d6d432ab514b92caedf4d4952b60add8e7246972c79e53",
+  "source_digest_sha256": "bdd8b4ba50e0baca6317d38bc713640639233dbe78619ad0ef9a8bc2cff1c5bb",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "3077937c03eabbde92d6d432ab514b92caedf4d4952b60add8e7246972c79e53"
+  "target_digest_sha256": "bdd8b4ba50e0baca6317d38bc713640639233dbe78619ad0ef9a8bc2cff1c5bb"
 }

--- a/docs/source/agi-web.rst
+++ b/docs/source/agi-web.rst
@@ -4,8 +4,9 @@ agi-web API
 ``agi-web`` is the portable AGILAB web component contract. It is not a second
 application framework and it does not make AGILAB depend on a JavaScript build
 pipeline. It gives apps a stable, JSON-normalized payload and evidence hash so
-the same UI island can render in Streamlit/static HTML today and later move to
-other adapters without changing the app-side contract.
+the same UI island can render in Streamlit/static HTML today through bundled
+Canvas2D/WebGL adapters while keeping a React-ready component boundary without
+changing the app-side contract.
 
 Use ``agi-web`` when a view needs browser-level fluidity, for example a
 training playground, a simulation cockpit, or an interactive digital twin view.
@@ -62,13 +63,13 @@ Example
 Current boundary
 ----------------
 
-The shipped renderer is a build-free static/Streamlit adapter with a WebGL
-heatmap path and Canvas2D overlay/fallback: timeline chips, play/pause,
-arrow-key scrubbing, confidence HUD, uncertainty contour, and pointer
-inspection. React is supported as a contract technology but is not a bundled
-runtime adapter yet. That distinction is deliberate: AGILAB apps should first
-own a stable payload/evidence contract, then add heavier frontend adapters only
-where the UX requires them.
+The shipped renderer is a build-free static/Streamlit adapter with Canvas2D
+and WebGL paths: timeline chips, play/pause, arrow-key scrubbing, confidence
+HUD, uncertainty contour, and pointer inspection. React is supported as a
+first-class renderer technology in the payload contract and adapter boundary,
+but AGILAB does not yet ship a shared React application shell. That distinction
+is deliberate: AGILAB apps should first own a stable payload/evidence contract,
+then add heavier frontend adapters only where the UX requires them.
 
 Visual guard
 ------------

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -19,8 +19,8 @@ AGILab currently exposes 2 main user interfaces:
 
 Shared components include ``agi-env`` (headless environment setup),
 ``agi-gui`` (Streamlit UI dependency bundle and page helpers), ``agi-web``
-(portable rich web component contracts), ``agi-node`` (runtime orchestration),
-and ``agi-cluster`` (multi-node execution support).
+(portable Canvas2D/WebGL and React-ready web component contracts), ``agi-node``
+(runtime orchestration), and ``agi-cluster`` (multi-node execution support).
 
 agi-core
 --------

--- a/docs/source/framework-api.rst
+++ b/docs/source/framework-api.rst
@@ -16,8 +16,9 @@ Core and UI packages
   pages and page bundles.
 - ``agi_web`` is the portable web component contract under
   ``src/agilab/lib/agi-web``. Use it when an app needs one evidence-backed
-  payload that can render through Streamlit/static HTML now and through future
-  React, Canvas, or WebGL adapters later.
+  payload that can render through Streamlit/static HTML now through bundled
+  Canvas2D/WebGL adapters while keeping a React-ready component contract for
+  app-owned adapters.
 - ``agi_core`` keeps the shared framework contracts intentionally thin; for now,
   the architecture page is more useful than autodoc because the top-level Python
   package exports only a minimal public surface.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -26,9 +26,10 @@ work.
 
 AGILAB is not locked to one web frontend. App projects can declare app-owned
 UI surfaces so the same runtime, artifacts, and evidence contract can be opened
-through the local Streamlit UI, a hosted Hugging Face backend, or future
-adapters. See :doc:`apps-pages` for the ``[app_surface]`` contract and the
-generic ``agilab app surface`` launcher.
+through the local Streamlit UI, a hosted Hugging Face backend, or browser-native
+``agi-web`` UI islands with React-ready component contracts. See
+:doc:`apps-pages` for the ``[app_surface]`` contract and the generic
+``agilab app surface`` launcher.
 
 If the local first proof fails, use :doc:`newcomer-troubleshooting` before
 branching into cluster mode, external app repositories, or broader workflows.

--- a/docs/source/package-publishing-policy.rst
+++ b/docs/source/package-publishing-policy.rst
@@ -43,9 +43,9 @@ to render UI.
 
 ``agi-web`` is published to PyPI from ``src/agilab/lib/agi-web``. It defines
 portable, evidence-backed web component payloads for app-owned rich UI islands.
-The current package provides build-free Streamlit/static HTML rendering and a
-stable contract for future React, Canvas, or WebGL adapters; it should not be
-treated as a bundled JavaScript framework.
+The current package provides build-free Streamlit/static HTML rendering with
+Canvas2D/WebGL paths and a stable React-ready contract for app-owned adapters;
+it should not be treated as a bundled JavaScript framework.
 
 Published page-bundle packages
 ------------------------------


### PR DESCRIPTION
Updates README and mirrored public docs to describe agi-web as the browser-native UI-island layer, with bundled Canvas2D/WebGL rendering and React-ready component contracts without claiming a bundled React app shell.