### PR TITLE
[codex] Increase agi-web coverage

### DIFF
--- a/badges/coverage-agi-web.svg
+++ b/badges/coverage-agi-web.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="153" height="20" role="img" aria-label="agi-web coverage: 96%">
+<svg xmlns="http://www.w3.org/2000/svg" width="160" height="20" role="img" aria-label="agi-web coverage: 100%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -6,17 +6,17 @@
   <stop offset="1" stop-opacity=".5"/>
 </linearGradient>
 <mask id="a">
-  <rect width="153" height="20" rx="3" fill="#fff"/>
+  <rect width="160" height="20" rx="3" fill="#fff"/>
 </mask>
 <g mask="url(#a)">
   <rect width="122" height="20" fill="#555"/>
-  <rect x="122" width="31" height="20" fill="#2ea44f"/>
-  <rect width="153" height="20" fill="url(#b)"/>
+  <rect x="122" width="38" height="20" fill="#2ea44f"/>
+  <rect width="160" height="20" fill="url(#b)"/>
 </g>
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="61.0" y="15" fill="#010101" fill-opacity=".3">agi-web coverage</text>
   <text x="61.0" y="14">agi-web coverage</text>
-  <text x="137.5" y="15" fill="#010101" fill-opacity=".3">96%</text>
-  <text x="137.5" y="14">96%</text>
+  <text x="141.0" y="15" fill="#010101" fill-opacity=".3">100%</text>
+  <text x="141.0" y="14">100%</text>
 </g>
 </svg>

--- a/src/agilab/lib/agi-web/test/test_agi_web_component.py
+++ b/src/agilab/lib/agi-web/test/test_agi_web_component.py
@@ -48,6 +48,15 @@ def test_agi_web_exposes_version() -> None:
     assert agi_web.__version__ == installed_version
 
 
+def test_agi_web_version_falls_back_when_package_metadata_missing(monkeypatch) -> None:
+    def missing_version(name):
+        raise importlib.metadata.PackageNotFoundError(name)
+
+    monkeypatch.setattr(importlib.metadata, "version", missing_version)
+
+    assert _load_agi_web().__version__ == "0+unknown"
+
+
 def test_agi_web_component_evidence_is_deterministic_and_payload_sensitive() -> None:
     agi_web = _load_agi_web()
     renderer = agi_web.AgiWebRendererSpec(
@@ -142,6 +151,33 @@ def test_agi_web_render_streamlit_uses_components_html() -> None:
     assert calls[0][1:] == (400, False)
 
 
+def test_agi_web_render_streamlit_imports_default_streamlit(monkeypatch) -> None:
+    agi_web = _load_agi_web()
+    calls: list[tuple[str, int, bool]] = []
+
+    def html_renderer(fragment, *, height, scrolling):
+        calls.append((fragment, height, scrolling))
+        return "rendered"
+
+    fake_st = SimpleNamespace(components=SimpleNamespace(v1=SimpleNamespace(html=html_renderer)))
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "streamlit":
+            return fake_st
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    component = agi_web.AgiWebComponent(
+        component_id="demo",
+        title="Demo",
+        renderer=agi_web.AgiWebRendererSpec("demo"),
+    )
+
+    assert agi_web.render_streamlit(component, height=360) == "rendered"
+    assert calls[0][1:] == (360, False)
+
+
 def test_agi_web_records_from_data_covers_mapping_and_scalar_shapes() -> None:
     agi_web = _load_agi_web()
 
@@ -164,6 +200,10 @@ def test_agi_web_records_from_data_covers_mapping_and_scalar_shapes() -> None:
         {"x": 1, "y": 3},
         {"x": 2, "y": 4},
     ]
+    assert agi_web.records_from_data() == []
+    assert agi_web.records_from_data({}) == []
+    assert agi_web.records_from_data({"x": 1, "y": 2}) == [{"x": 1, "y": 2}]
+    assert agi_web.records_from_data({"x": [1], "y": [2, 3]}) == [{"x": [1], "y": [2, 3]}]
     assert agi_web.records_from_data([(1, 2), "plain"], max_rows=0) == []
     assert agi_web.records_from_data(7) == [{"value": 7}]
 
@@ -189,6 +229,12 @@ def test_agi_web_normalize_json_value_handles_portable_scalars() -> None:
 
         def __str__(self) -> str:
             return "broken"
+
+    class NonCallableItem:
+        item = "not-callable"
+
+        def __str__(self) -> str:
+            return "non-callable"
 
     payload_id = uuid.UUID("12345678-1234-5678-1234-567812345678")
     normalized = agi_web.normalize_json_value(
@@ -219,6 +265,7 @@ def test_agi_web_normalize_json_value_handles_portable_scalars() -> None:
     assert agi_web.normalize_json_value(decimal.Decimal("NaN")) is None
     assert agi_web.normalize_json_value(float("inf")) is None
     assert agi_web.normalize_json_value(BrokenScalar()) == "broken"
+    assert agi_web.normalize_json_value(NonCallableItem()) == "non-callable"
 
 
 def test_agi_web_component_variants_and_notebook_fallback(monkeypatch) -> None:
@@ -271,3 +318,30 @@ def test_agi_web_component_variants_and_notebook_fallback(monkeypatch) -> None:
     assert isinstance(fallback, str)
     assert "min-height:240px" in fallback
     assert "&lt;100%&gt;" in fallback
+
+
+def test_agi_web_render_notebook_returns_ipython_html(monkeypatch) -> None:
+    agi_web = _load_agi_web()
+    component = agi_web.AgiWebComponent(
+        component_id="demo",
+        title="Demo",
+        renderer=agi_web.AgiWebRendererSpec("demo"),
+    )
+
+    class FakeHTML:
+        def __init__(self, fragment):
+            self.fragment = fragment
+
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "IPython.display":
+            return SimpleNamespace(HTML=FakeHTML)
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    rendered = agi_web.render_notebook(component)
+
+    assert isinstance(rendered, FakeHTML)
+    assert 'class="agi-web-shell"' in rendered.fragment


### PR DESCRIPTION
## Summary
- add focused agi-web tests for metadata fallback, default Streamlit import, notebook HTML rendering, scalar normalization, and mapping-record edge cases
- increase the dedicated agi-web coverage badge from 95% to 100%

## Validation
- `COVERAGE_FILE=.coverage.agi-web uv run --no-project --with-editable ./src/agilab/lib/agi-web --with pytest --with pytest-cov python -m pytest -q --maxfail=1 --disable-warnings -o addopts='' --cov=agi_web --cov-report=term-missing --cov-report=xml:coverage-agi-web.xml src/agilab/lib/agi-web/test` (`12 passed`, `TOTAL 100%`)
- `uv --preview-features extra-build-dependencies run python tools/generate_component_coverage_badges.py --components agi-web`
- `uv --preview-features extra-build-dependencies run python tools/coverage_badge_guard.py --components agi-web`
- `git diff --check`
