### PR TITLE
docs: record badge hiding guidance for agents

### DIFF
--- a/.claude/skills/agilab-docs/SKILL.md
+++ b/.claude/skills/agilab-docs/SKILL.md
@@ -90,6 +90,11 @@ If you accidentally edit `docs/html` directly, discard that manual edit and rege
 ## Public Docs Constraint
 
 - Public documentation must not mention non-public apps/repositories.
+- When the user asks to hide or de-emphasize public README/PyPI README badges,
+  preserve the badge sources and assets unless removal is explicitly requested.
+  Move non-primary badges into a rendered ``<details>`` expander such as
+  ``More project badges`` instead of deleting badge markdown, generated SVGs,
+  or agent/discovery badge assets.
 - Release-proof and install-proof docs that execute the packaged first proof
   should use `agilab[examples]`, not bare `agilab`, because the base package is
   intentionally lean while the demo proof depends on packaged example payloads.

--- a/.codex/skills/agilab-docs/SKILL.md
+++ b/.codex/skills/agilab-docs/SKILL.md
@@ -90,6 +90,11 @@ If you accidentally edit `docs/html` directly, discard that manual edit and rege
 ## Public Docs Constraint
 
 - Public documentation must not mention non-public apps/repositories.
+- When the user asks to hide or de-emphasize public README/PyPI README badges,
+  preserve the badge sources and assets unless removal is explicitly requested.
+  Move non-primary badges into a rendered ``<details>`` expander such as
+  ``More project badges`` instead of deleting badge markdown, generated SVGs,
+  or agent/discovery badge assets.
 - Release-proof and install-proof docs that execute the packaged first proof
   should use `agilab[examples]`, not bare `agilab`, because the base package is
   intentionally lean while the demo proof depends on packaged example payloads.

--- a/AGENT_LEARNINGS.md
+++ b/AGENT_LEARNINGS.md
@@ -27,6 +27,9 @@ is not a scratchpad or task log.
 
 ## Current rules
 
+- When asked to hide badges or public README metadata, do not interpret
+  "hide" as deletion. Keep badge source/assets available and move secondary
+  badges into a rendered expander unless the user explicitly asks for removal.
 - When external agent-instruction projects inspire AGILAB, extract the
   AGILAB-native operating primitive and reject generic boilerplate replacement.
 - When a pre-push guard fails, do not bypass it silently. Re-run the underlying


### PR DESCRIPTION
Adds a reusable agent rule for badge cleanup: hide secondary public README badges in a rendered expander instead of deleting badge sources/assets unless removal is explicitly requested. Syncs the repo-managed Codex docs skill mirror and updates the correction ledger.\n\nValidation run:\n- python3 tools/sync_agent_skills.py --skills agilab-docs\n- python3 tools/codex_skills.py --root .codex/skills validate --strict\n- python3 tools/codex_skills.py --root .codex/skills generate\n- python3 tools/agent_instruction_contract.py --check\n- ./dev scope