### PR TITLE
fix(release): harden retention cleanup and env reset

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -691,7 +691,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      actions: read
+      actions: write
     env:
       PYPI_RELEASE_PRUNE_USERNAME: ${{ secrets.PYPI_RELEASE_PRUNE_USERNAME }}
       PYPI_RELEASE_PRUNE_PASSWORD: ${{ secrets.PYPI_RELEASE_PRUNE_PASSWORD }}
@@ -734,6 +734,24 @@ jobs:
             args+=(--package "$package")
           done
           python tools/pypi_release_retention.py "${args[@]}"
+
+      - name: Clear temporary PyPI confirmation variable
+        if: ${{ always() }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import os
+
+          from tools.pypi_release_retention import _cleanup_github_confirm_login_variable
+
+          _cleanup_github_confirm_login_variable(
+              repository=os.environ["GITHUB_REPOSITORY"],
+              variable="PYPI_CONFIRM_LOGIN_URL",
+              token=os.environ["GITHUB_TOKEN"],
+          )
+          PY
 
   publish-dataset-release-assets:
     if: ${{ always() && needs.test.result == 'success' && needs.release-plan.result == 'success' }}

--- a/src/agilab/core/agi-env/src/agi_env/agi_env.py
+++ b/src/agilab/core/agi-env/src/agi_env/agi_env.py
@@ -289,6 +289,9 @@ class AgiEnv(metaclass=_AgiEnvMeta):
 
         with cls._lock:
             cls._instance = None
+            cls._ip_local_cache = {"127.0.0.1", "::1"}
+            cls._share_mount_warning_keys = set()
+            cls._pythonpath_entries = []
     install_type: int | None = None  # deprecated: derived from flags for backward compatibility
     apps_path: Path | None = None
     app: str | None = None

--- a/src/agilab/core/agi-env/test/test_agi_env.py
+++ b/src/agilab/core/agi-env/test/test_agi_env.py
@@ -3188,6 +3188,18 @@ def test_is_local_and_has_admin_rights_helpers(monkeypatch):
     assert AgiEnv.has_admin_rights() is False
 
 
+def test_reset_clears_runtime_class_caches():
+    AgiEnv._ip_local_cache = {"127.0.0.1", "::1", "192.168.10.10"}
+    AgiEnv._share_mount_warning_keys = {("/tmp/local", "/tmp/cluster")}
+    AgiEnv._pythonpath_entries = ["/tmp/project/src"]
+
+    AgiEnv.reset()
+
+    assert AgiEnv._ip_local_cache == {"127.0.0.1", "::1"}
+    assert AgiEnv._share_mount_warning_keys == set()
+    assert AgiEnv._pythonpath_entries == []
+
+
 def test_create_symlink_windows_hits_success_and_failure_branches(tmp_path: Path, monkeypatch):
     src_dir = tmp_path / "src"
     src_dir.mkdir()

--- a/test/test_pypi_publish_workflow.py
+++ b/test/test_pypi_publish_workflow.py
@@ -339,8 +339,12 @@ def test_pypi_publish_syncs_hf_space_only_for_umbrella_release() -> None:
 
 def test_pypi_publish_attempts_previous_pypi_release_pruning_before_release_assets() -> None:
     text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    retention_block = text[
+        text.index("  pypi-release-retention:") : text.index("  publish-dataset-release-assets:")
+    ]
 
     assert "pypi-release-retention:" in text
+    assert "actions: write" in retention_block
     assert "(github.event.inputs.include_existing_pypi || 'false') != 'true'" in text
     assert "needs.pypi-provenance-evidence.result == 'success'" in text
     assert "PYPI_RELEASE_PRUNE_USERNAME: ${{ secrets.PYPI_RELEASE_PRUNE_USERNAME }}" in text
@@ -359,6 +363,9 @@ def test_pypi_publish_attempts_previous_pypi_release_pruning_before_release_asse
     assert "--github-confirm-login-timeout 1800" in text
     assert "--github-confirm-login-poll-delay 5" in text
     assert "--github-token \"${PYPI_CONFIRM_READER_TOKEN:-$GITHUB_TOKEN}\"" in text
+    assert "Clear temporary PyPI confirmation variable" in retention_block
+    assert "if: ${{ always() }}" in retention_block
+    assert "_cleanup_github_confirm_login_variable" in retention_block
     assert "--protect-versions-from-projects" in text
     assert "--repo-root ." in text
     assert "--protect-version \"$current_version\"" not in text

--- a/test/test_pypi_release_retention.py
+++ b/test/test_pypi_release_retention.py
@@ -473,6 +473,14 @@ def test_direct_pypi_delete_submits_reauth_before_delete_form() -> None:
 def test_direct_pypi_delete_consumes_confirm_login_url_after_runner_login_redirect() -> None:
     module = _load_module()
     confirm_url = "https://pypi.org/account/confirm-login/?token=token"
+    cleanup_calls = []
+
+    class ConfirmProvider:
+        def __call__(self) -> str:
+            return confirm_url
+
+        def cleanup(self) -> None:
+            cleanup_calls.append("cleanup")
 
     class FakeResponse:
         def __init__(self, *, text: str, url: str) -> None:
@@ -544,16 +552,61 @@ def test_direct_pypi_delete_consumes_confirm_login_url_after_runner_login_redire
         repo="pypi",
         username="maintainer",
         password="secret",
-        confirm_login_url_provider=lambda: confirm_url,
+        confirm_login_url_provider=ConfirmProvider(),
         session_factory=lambda: session,
     )
 
     assert confirm_url in session.get_urls
+    assert cleanup_calls == ["cleanup"]
     assert session.delete_attempts == 2
     assert session.posts[-1][1]["data"] == {
         "csrf_token": "delete-csrf",
         "confirm_delete_version": "2026.5.17",
     }
+
+
+def test_delete_github_actions_variable_handles_success_and_missing(monkeypatch) -> None:
+    module = _load_module()
+    requests = []
+    responses = iter([object(), module.urllib.error.HTTPError("url", 404, "missing", {}, None)])
+
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def read(self):
+            return b""
+
+    def fake_urlopen(request, timeout):
+        requests.append((request, timeout))
+        response = next(responses)
+        if isinstance(response, Exception):
+            raise response
+        return Response()
+
+    monkeypatch.setattr(module.urllib.request, "urlopen", fake_urlopen)
+
+    assert (
+        module._delete_github_actions_variable(
+            repository="owner/repo",
+            variable="PYPI_CONFIRM_LOGIN_URL",
+            token="token",
+        )
+        is True
+    )
+    assert (
+        module._delete_github_actions_variable(
+            repository="owner/repo",
+            variable="PYPI_CONFIRM_LOGIN_URL",
+            token="token",
+        )
+        is False
+    )
+    assert requests[0][0].get_method() == "DELETE"
+    assert requests[0][1] == 15
 
 
 def test_fresh_totp_code_waits_until_reused_code_changes(monkeypatch) -> None:

--- a/tools/pypi_release_retention.py
+++ b/tools/pypi_release_retention.py
@@ -397,6 +397,12 @@ def _consume_confirm_login_url(session: Any, url: str) -> None:
     response.raise_for_status()
 
 
+def _cleanup_confirm_login_url_provider(provider: Callable[[], str | None] | None) -> None:
+    cleanup = getattr(provider, "cleanup", None)
+    if callable(cleanup):
+        cleanup()
+
+
 def _fetch_github_actions_variable(
     *,
     repository: str,
@@ -424,6 +430,61 @@ def _fetch_github_actions_variable(
         ) from exc
     value = str(payload.get("value") or "").strip()
     return value or None
+
+
+def _delete_github_actions_variable(
+    *,
+    repository: str,
+    variable: str,
+    token: str,
+) -> bool:
+    api_url = f"https://api.github.com/repos/{repository}/actions/variables/{variable}"
+    request = urllib.request.Request(
+        api_url,
+        method="DELETE",
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "agilab-pypi-release-retention/1",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=15) as response:
+            response.read()
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return False
+        raise RuntimeError(
+            f"GitHub Actions variable delete failed with HTTP {exc.code}"
+        ) from exc
+    return True
+
+
+def _cleanup_github_confirm_login_variable(
+    *,
+    repository: str,
+    variable: str,
+    token: str,
+) -> None:
+    try:
+        deleted = _delete_github_actions_variable(
+            repository=repository,
+            variable=variable,
+            token=token,
+        )
+    except RuntimeError as exc:
+        print(
+            "::warning title=PyPI release retention::"
+            f"Unable to clear temporary GitHub Actions variable {variable!r}: {exc}",
+            file=sys.stderr,
+        )
+        return
+    if deleted:
+        print(
+            f"[pypi-retention] cleared temporary GitHub Actions variable {variable!r}",
+            file=sys.stderr,
+        )
 
 
 def _wait_for_github_confirm_login_url(
@@ -632,6 +693,7 @@ def delete_release_via_pypi_web(
                 confirm_url = confirm_login_url_provider()
                 if confirm_url:
                     _consume_confirm_login_url(session, confirm_url)
+                    _cleanup_confirm_login_url_provider(confirm_login_url_provider)
                     response = open_delete_page()
                     if response is None:
                         return
@@ -1018,6 +1080,15 @@ def main(argv: Sequence[str] | None = None) -> int:
                     timeout=args.github_confirm_login_timeout,
                     poll_delay=args.github_confirm_login_poll_delay,
                 )
+
+            def cleanup_confirm_provider() -> None:
+                _cleanup_github_confirm_login_variable(
+                    repository=args.github_confirm_login_repository,
+                    variable=args.github_confirm_login_variable,
+                    token=args.github_token,
+                )
+
+            confirm_provider.cleanup = cleanup_confirm_provider  # type: ignore[attr-defined]
 
         delete_blocked = False
         rotating_totp_secret = _rotating_totp_secret(args.otp_code, args.totp_secret)


### PR DESCRIPTION
Fixes review findings by clearing the temporary PyPI confirmation Actions variable after retention, restoring reset-time AgiEnv runtime cache cleanup, and adding targeted regressions. Validated locally with impact analysis, release-plan workflow check, docs parity, maintenance, Ruff on touched Python files, full agi-env tests, and focused PyPI/release tests.