### PR TITLE
docs(readme): group guardrail and coverage badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
 <p>
   <a href="https://pypi.org/project/agilab/"><img src="https://raw.githubusercontent.com/ThalesGroup/agilab/main/badges/pypi-version-agilab.svg" alt="PyPI version" /></a>
+  <a href="https://pypi.org/project/agilab/#files"><img src="https://img.shields.io/badge/wheel-yes-0F766E" alt="Wheel: yes" /></a>
   <a href="https://pypi.org/project/agilab/"><img src="https://img.shields.io/pypi/pyversions/agilab.svg" alt="Supported Python Versions" /></a>
   <a href="https://thalesgroup.github.io/agilab/release-proof.html"><img src="https://img.shields.io/badge/release%20proof-latest%20proven%20release-0F766E" alt="Latest proven release proof" /></a>
   <a href="https://thalesgroup.github.io/agilab/release-proof.html"><img src="https://img.shields.io/badge/supply%20chain-SBOM%20%2B%20audit%20%2B%20provenance-0F766E" alt="Supply chain: SBOM, audit, provenance" /></a>
   <a href="https://thalesgroup.github.io/agilab/release-proof.html"><img src="https://img.shields.io/badge/first%20proof-passing-0F766E" alt="First proof: passing" /></a>
   <a href="https://opensource.org/licenses/BSD-3-Clause"><img src="https://img.shields.io/badge/License-BSD%203--Clause-blue.svg" alt="License: BSD 3-Clause" /></a>
   <a href="https://thalesgroup.github.io/agilab"><img src="https://img.shields.io/badge/Docs-online-brightgreen.svg" alt="Docs" /></a>
-  <a href="https://github.com/ThalesGroup/agilab/actions/workflows/ci.yml"><img src="https://github.com/ThalesGroup/agilab/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI" /></a>
 </p>
 
 <p>
+  <a href="https://github.com/ThalesGroup/agilab/actions/workflows/ci.yml"><img src="https://github.com/ThalesGroup/agilab/actions/workflows/ci.yml/badge.svg?branch=main" alt="Repo guardrails" /></a>
   <a href="https://github.com/ThalesGroup/agilab/actions/workflows/coverage.yml"><img src="https://github.com/ThalesGroup/agilab/actions/workflows/coverage.yml/badge.svg?branch=main" alt="Coverage workflow" /></a>
   <a href="https://codecov.io/gh/ThalesGroup/agilab"><img src="https://raw.githubusercontent.com/ThalesGroup/agilab/main/badges/coverage-agilab.svg" alt="agilab coverage" /></a>
 </p>
@@ -26,7 +27,7 @@
   <a href="AGENT_SKILLS.md"><img src="https://raw.githubusercontent.com/ThalesGroup/agilab/main/badges/skills.svg" alt="Skills" /></a>
   <a href="https://agentskills.io/"><img src="https://raw.githubusercontent.com/ThalesGroup/agilab/main/badges/agent-standard.svg" alt="Standard: Agent Skills" /></a>
   <a href="tools/agent_workflows.md"><img src="https://raw.githubusercontent.com/ThalesGroup/agilab/main/badges/agent-works-with.svg" alt="Works with Codex Claude Aider and OpenCode" /></a>
-  <a href="badges/agent-api.svg"><img src="https://raw.githubusercontent.com/ThalesGroup/agilab/main/badges/agent-api.svg" alt="Agent API: CLI Python" /></a>
+  <a href="tools/agent_workflows.md"><img src="https://raw.githubusercontent.com/ThalesGroup/agilab/main/badges/agent-api.svg" alt="Agent API: CLI Python" /></a>
   <a href="docs/source/environment.rst"><img src="https://img.shields.io/badge/Language-python%20free--threaded%20%26%20cythonized-5B6CFF" alt="Language Python free-threaded and Cythonized" /></a>
   <a href="https://github.com/ThalesGroup/agilab/pulls"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs welcome" /></a>
   <a href="https://github.com/ThalesGroup/agilab"><img src="https://img.shields.io/github/repo-size/ThalesGroup/agilab" alt="Repo size" /></a>


### PR DESCRIPTION
Moves the repo guardrail workflow badge onto the same README row as the coverage badges. Also restores README badge contract drift caught by the public demo link regression: explicit wheel badge and Agent API raw badge link target.\n\nValidated locally:\n- uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files README.md\n- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_public_demo_links.py\n- ./dev scope