### PR TITLE
chore(release): prepare 2026.06.02

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,19 @@ publication, or evidence refreshes on an already published date version.
 
 No unreleased public changes.
 
+## [2026.06.02] - 2026-06-02
+
+GitHub Release: https://github.com/ThalesGroup/agilab/releases/tag/v2026.06.02
+
+### Changed
+
+- Published AGILAB `2026.06.02` to PyPI for `agi-env`, `agi-gui`, `agi-pages`, `agi-node`, `agi-cluster`, `agi-core`, `agi-apps`, and `agilab`.
+- Hardened PyPI release retention so the temporary confirmation URL Actions variable is cleared after cleanup.
+- Fixed `AgiEnv.reset()` so repeated source/UI sessions clear runtime class caches before reinitialization.
+- Grouped the README repo-guardrails and coverage badges, and restored the explicit wheel and agent API badge contracts.
+- Updated release metadata so public docs, changelog, PyPI, and GitHub Releases point to the same source tag.
+- Kept release automation active so future PyPI publishes create or update the matching GitHub Release after pushing the tag.
+
 ## [2026.06.01] - 2026-06-01
 
 GitHub Release: https://github.com/ThalesGroup/agilab/releases/tag/v2026.06.01
@@ -791,3 +804,4 @@ GitHub Release: https://github.com/ThalesGroup/agilab/releases/tag/v2026.04.25
 [2026.05.31]: https://github.com/ThalesGroup/agilab/releases/tag/v2026.05.31
 [2026.05.31.post1]: https://github.com/ThalesGroup/agilab/releases/tag/v2026.05.31-2
 [2026.06.01]: https://github.com/ThalesGroup/agilab/releases/tag/v2026.06.01
+[2026.06.02]: https://github.com/ThalesGroup/agilab/releases/tag/v2026.06.02

--- a/badges/pypi-version-agilab.svg
+++ b/badges/pypi-version-agilab.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="125" height="20" role="img" aria-label="pypi: v2026.06.01">
+<svg xmlns="http://www.w3.org/2000/svg" width="125" height="20" role="img" aria-label="pypi: v2026.06.02">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="19" y="15" fill="#010101" fill-opacity=".3">pypi</text>
   <text x="19" y="14">pypi</text>
-  <text x="81.5" y="15" fill="#010101" fill-opacity=".3">v2026.06.01</text>
-  <text x="81.5" y="14">v2026.06.01</text>
+  <text x="81.5" y="15" fill="#010101" fill-opacity=".3">v2026.06.02</text>
+  <text x="81.5" y="14">v2026.06.02</text>
 </g>
 </svg>

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 250,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "dd2bed9cc9cf3e1bd42975e67256f34476b245dac7bf28fff4da65eed5073c72",
+  "source_digest_sha256": "43357501d694d7c9aa8796ccf308d1249a5cb7ac5a601733f797033fea5ffefd",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "dd2bed9cc9cf3e1bd42975e67256f34476b245dac7bf28fff4da65eed5073c72"
+  "target_digest_sha256": "43357501d694d7c9aa8796ccf308d1249a5cb7ac5a601733f797033fea5ffefd"
 }

--- a/docs/source/data/release_proof.toml
+++ b/docs/source/data/release_proof.toml
@@ -20,13 +20,13 @@ related_pages = [
 
 [release]
 package_name = "agilab"
-package_version = "2026.06.01"
+package_version = "2026.06.02"
 package_extras = [
   "examples",
 ]
 pypi_url = "https://pypi.org/project/agilab/"
-github_release_tag = "v2026.06.01"
-github_release_url = "https://github.com/ThalesGroup/agilab/releases/tag/v2026.06.01"
+github_release_tag = "v2026.06.02"
+github_release_url = "https://github.com/ThalesGroup/agilab/releases/tag/v2026.06.02"
 hf_space_label = "jpmorard/agilab"
 hf_space_url = "https://huggingface.co/spaces/jpmorard/agilab"
 hf_space_commit = "30ae75b6007a41b6fc9a528851558622254a9c06"

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -36,7 +36,7 @@ branching into cluster mode, external app repositories, or broader workflows.
 
 For release-level evidence, use :doc:`release-proof`; it points to the
 `latest public GitHub release
-<https://github.com/ThalesGroup/agilab/releases/tag/v2026.06.01>`__,
+<https://github.com/ThalesGroup/agilab/releases/tag/v2026.06.02>`__,
 package proof, CI guardrails, and hosted demo status.
 
 This documentation then expands into architecture, service mode, API

--- a/docs/source/release-proof.rst
+++ b/docs/source/release-proof.rst
@@ -18,9 +18,9 @@ Current public release
    * - Item
      - Public evidence
    * - Package version
-     - ``agilab[examples]==2026.06.01`` on `PyPI <https://pypi.org/project/agilab/>`__
+     - ``agilab[examples]==2026.06.02`` on `PyPI <https://pypi.org/project/agilab/>`__
    * - GitHub release
-     - `v2026.06.01 <https://github.com/ThalesGroup/agilab/releases/tag/v2026.06.01>`__
+     - `v2026.06.02 <https://github.com/ThalesGroup/agilab/releases/tag/v2026.06.02>`__
    * - Hosted demo
      - `jpmorard/agilab <https://huggingface.co/spaces/jpmorard/agilab>`__ at Space commit ``30ae75b6007a41b6fc9a528851558622254a9c06``
    * - Public guardrails
@@ -41,7 +41,7 @@ What was proved
 
   .. code-block:: bash
 
-     python -m pip install "agilab[examples]==2026.06.01"
+     python -m pip install "agilab[examples]==2026.06.02"
      python -m agilab.lab_run first-proof --json --max-seconds 60
 
 - The public GitHub Actions matrix validated the packaged first proof on
@@ -72,7 +72,7 @@ the current source checkout:
    python -m venv .venv
    . .venv/bin/activate
    python -m pip install --upgrade pip
-   python -m pip install "agilab[examples]==2026.06.01"
+   python -m pip install "agilab[examples]==2026.06.02"
    python -m agilab.lab_run first-proof --json --max-seconds 60
 
 Use :doc:`quick-start` when you want the fuller source-checkout path with the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.01"
+version = "2026.06.02"
 name = "agilab"
 description = "AGILAB is a reproducible AI/ML workbench for engineering teams."
 requires-python = ">=3.11,<3.14"
@@ -60,19 +60,21 @@ agilab-mcp = "agilab_mcp.server:main"
 
 [project.optional-dependencies]
 ai = ["openai>=2.32.0,<3"]
-core = ["agi-core==2026.06.01"]
-ui = ["agi-apps==2026.06.01", "agi-pages==2026.06.01", "agi-gui==2026.06.01", "agi-web==2026.06.01", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "streamlit>=1.58,<2", "tomli_w>=1.2.0,<2"]
+core = ["agi-core==2026.06.02"]
+ui = ["agi-apps==2026.06.02", "agi-pages==2026.06.02", "agi-gui==2026.06.02", "agi-web==2026.06.01", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "streamlit>=1.58,<2", "tomli_w>=1.2.0,<2"]
 viz = ["matplotlib>=3.10.0,<4", "plotly>=6.7.0,<7"]
 mlflow = ["mlflow>=3.11.1,<4", "idna>=3.15,<4", "starlette>=1.0.1,<2"]
 bridges = ["duckdb>=1.4.0,<2"]
 notebook = ["ipykernel>=6.29.0,<8", "nbclient>=0.10.0,<1", "nbformat>=5.10.0,<6"]
-examples = ["agi-apps==2026.06.01", "jupyterlab>=4.4.0,<5", "matplotlib>=3.10.0,<4", "plotly>=6.7.0,<7"]
-pages = ["agi-pages==2026.06.01"]
+examples = ["agi-apps==2026.06.02", "jupyterlab>=4.4.0,<5", "matplotlib>=3.10.0,<4", "plotly>=6.7.0,<7"]
+pages = ["agi-pages==2026.06.02"]
 proof = ["cryptography>=46.0.0,<49"]
 agents = ["openai>=2.32.0,<3"]
 local-llm = ["accelerate>=0.34.2,<2; python_version >= '3.12'", "fastapi>=0.124.4,!=0.136.3,<1; python_version >= '3.12'", "gpt-oss>=0.0.8,<0.1; python_version >= '3.12'", "langchain-core>=1.3.3,<2; python_version >= '3.12'", "langsmith>=0.8.0,<1; python_version >= '3.12'", "mlx>=0.31.2,<0.32; sys_platform == 'darwin' and platform_machine == 'arm64'", "mlx-lm>=0.31.3,<0.32; sys_platform == 'darwin' and platform_machine == 'arm64'", "mlx-vlm>=0.5.0,<0.6; sys_platform == 'darwin' and platform_machine == 'arm64'", "requests>=2.32.0,<3; python_version >= '3.12'", "torch>=2.8.0,<3; python_version >= '3.12'", "transformers>=4.57.0,<6; python_version >= '3.12'", "universal-offline-ai-chatbot>=0.1.0,<0.2; python_version >= '3.12'"]
 offline = ["accelerate>=0.34.2,<2; python_version >= '3.12'", "fastapi>=0.124.4,!=0.136.3,<1; python_version >= '3.12'", "gpt-oss>=0.0.8,<0.1; python_version >= '3.12'", "langchain-core>=1.3.3,<2; python_version >= '3.12'", "langsmith>=0.8.0,<1; python_version >= '3.12'", "mlx>=0.31.2,<0.32; sys_platform == 'darwin' and platform_machine == 'arm64'", "mlx-lm>=0.31.3,<0.32; sys_platform == 'darwin' and platform_machine == 'arm64'", "mlx-vlm>=0.5.0,<0.6; sys_platform == 'darwin' and platform_machine == 'arm64'", "requests>=2.32.0,<3; python_version >= '3.12'", "torch>=2.8.0,<3; python_version >= '3.12'", "transformers>=4.57.0,<6; python_version >= '3.12'", "universal-offline-ai-chatbot>=0.1.0,<0.2; python_version >= '3.12'"]
 dev = ["build>=1.3.0,<2", "cyclonedx-bom>=7.2.1,<8", "pip-audit>=2.9.0,<3", "pytest>=9.0.0,<10", "pytest-asyncio>=1.3.0,<2", "pytest-cov>=7.0.0,<8", "ruff>=0.15.14,<1", "tomlkit>=0.13.0,<1", "twine>=6.2.0,<7", "wheel>=0.45.0,<1"]
+
+
 
 
 

--- a/src/agilab/core/agi-cluster/pyproject.toml
+++ b/src/agilab/core/agi-cluster/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.01"
+version = "2026.06.02"
 name = "agi-cluster"
 description = "Distributed cluster orchestration layer for AGILAB workers over local and SSH backends"
 requires-python = ">=3.11"
@@ -35,7 +35,7 @@ keywords = [
     "job-scheduling",
     "mlops",
 ]
-dependencies = ["agi-env==2026.06.01", "agi-node==2026.06.01", "asyncssh>=2.23,<3", "dask[distributed]>=2026.3,<2027.0", "humanize>=4.10,<5", "numpy>=2.2,<3", "packaging>=25,<27", "polars>=1.35,<2", "psutil>=7,<8", "scikit-learn>=1.7.2,<2", "tomlkit>=0.13,<1"]
+dependencies = ["agi-env==2026.06.02", "agi-node==2026.06.02", "asyncssh>=2.23,<3", "dask[distributed]>=2026.3,<2027.0", "humanize>=4.10,<5", "numpy>=2.2,<3", "packaging>=25,<27", "polars>=1.35,<2", "psutil>=7,<8", "scikit-learn>=1.7.2,<2", "tomlkit>=0.13,<1"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"
@@ -45,6 +45,8 @@ Homepage = "https://github.com/ThalesGroup/agilab"
 Repository = "https://github.com/ThalesGroup/agilab"
 Discussions = "https://github.com/ThalesGroup/agilab/discussions"
 Changelog = "https://github.com/ThalesGroup/agilab/releases"
+
+
 
 
 

--- a/src/agilab/core/agi-core/pyproject.toml
+++ b/src/agilab/core/agi-core/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.01"
+version = "2026.06.02"
 name = "agi-core"
 description = "Meta-package that installs and wires agi-env, agi-node, and agi-cluster together"
 readme = "README.md"
@@ -30,7 +30,7 @@ keywords = [
   "distributed-computing",
   "distributed-execution",
 ]
-dependencies = ["agi-env==2026.06.01", "agi-node==2026.06.01", "agi-cluster==2026.06.01"]
+dependencies = ["agi-env==2026.06.02", "agi-node==2026.06.02", "agi-cluster==2026.06.02"]
 
 [project.urls]
 Homepage = "https://github.com/ThalesGroup/agilab"
@@ -39,6 +39,8 @@ Documentation = "https://thalesgroup.github.io/agilab"
 Repository = "https://github.com/ThalesGroup/agilab"
 Discussions = "https://github.com/ThalesGroup/agilab/discussions"
 Changelog = "https://github.com/ThalesGroup/agilab/releases"
+
+
 
 
 

--- a/src/agilab/core/agi-env/pyproject.toml
+++ b/src/agilab/core/agi-env/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.01"
+version = "2026.06.02"
 name = "agi-env"
 description = "Environment bootstrap package for AGILAB with virtualenv, path, and runtime helpers"
 requires-python = ">=3.11"
@@ -53,6 +53,7 @@ Homepage = "https://github.com/ThalesGroup/agilab"
 Repository = "https://github.com/ThalesGroup/agilab"
 Discussions = "https://github.com/ThalesGroup/agilab/discussions"
 Changelog = "https://github.com/ThalesGroup/agilab/releases"
+
 
 
 

--- a/src/agilab/core/agi-node/pyproject.toml
+++ b/src/agilab/core/agi-node/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.01"
+version = "2026.06.02"
 name = "agi-node"
 description = "Distributed worker orchestration and execution support library for AGILAB"
 requires-python = ">=3.11"
@@ -35,7 +35,7 @@ keywords = [
     "pandas",
     "polars",
 ]
-dependencies = ["agi-env==2026.06.01", "cython>=3.1,<4", "humanize>=4.10,<5", "numpy>=2.2,<3", "pandas>=2.3,<4", "parso>=0.8,<1", "polars>=1.35,<2", "psutil>=7,<8", "py7zr>=1.1,<1.2", "setuptools>=68,<83"]
+dependencies = ["agi-env==2026.06.02", "cython>=3.1,<4", "humanize>=4.10,<5", "numpy>=2.2,<3", "pandas>=2.3,<4", "parso>=0.8,<1", "polars>=1.35,<2", "psutil>=7,<8", "py7zr>=1.1,<1.2", "setuptools>=68,<83"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"
@@ -45,6 +45,8 @@ Homepage = "https://github.com/ThalesGroup/agilab"
 Repository = "https://github.com/ThalesGroup/agilab"
 Discussions = "https://github.com/ThalesGroup/agilab/discussions"
 Changelog = "https://github.com/ThalesGroup/agilab/releases"
+
+
 
 
 

--- a/src/agilab/lib/agi-apps/pyproject.toml
+++ b/src/agilab/lib/agi-apps/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.01"
+version = "2026.06.02"
 name = "agi-apps"
 description = "AGILAB public app package umbrella and example assets"
 requires-python = ">=3.11"
@@ -31,7 +31,7 @@ keywords = [
     "workflow-orchestration",
 ]
 
-dependencies = ["agi-core==2026.06.01", "agi-app-mission-decision==2026.06.01", "agi-app-pandas-execution==2026.05.31", "agi-app-polars-execution==2026.05.31", "agi-app-flight-telemetry==2026.06.01", "agi-app-multi-dag==2026.05.31", "agi-app-weather-forecast==2026.06.01", "agi-app-sklearn-pipeline==2026.05.31", "agi-app-pytorch-playground==2026.06.01; python_version >= '3.12'", "agi-app-tescia-diagnostic==2026.05.31; python_version >= '3.13'", "agi-app-uav-relay-queue==2026.06.01; python_version >= '3.13'"]
+dependencies = ["agi-core==2026.06.02", "agi-app-mission-decision==2026.06.01", "agi-app-pandas-execution==2026.05.31", "agi-app-polars-execution==2026.05.31", "agi-app-flight-telemetry==2026.06.01", "agi-app-multi-dag==2026.05.31", "agi-app-weather-forecast==2026.06.01", "agi-app-sklearn-pipeline==2026.05.31", "agi-app-pytorch-playground==2026.06.01; python_version >= '3.12'", "agi-app-tescia-diagnostic==2026.05.31; python_version >= '3.13'", "agi-app-uav-relay-queue==2026.06.01; python_version >= '3.13'"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"
@@ -41,6 +41,8 @@ Homepage = "https://github.com/ThalesGroup/agilab"
 Repository = "https://github.com/ThalesGroup/agilab"
 Discussions = "https://github.com/ThalesGroup/agilab/discussions"
 Changelog = "https://github.com/ThalesGroup/agilab/releases"
+
+
 
 
 

--- a/src/agilab/lib/agi-gui/pyproject.toml
+++ b/src/agilab/lib/agi-gui/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.01"
+version = "2026.06.02"
 name = "agi-gui"
 description = "AGILAB Streamlit UI dependency bundle and compatibility imports"
 requires-python = ">=3.11"
@@ -32,7 +32,7 @@ keywords = [
     "python",
 ]
 
-dependencies = ["agi-env==2026.06.01", "streamlit>=1.58,<2", "streamlit_code_editor>=0.1.22,<0.2", "watchdog>=6,<7"]
+dependencies = ["agi-env==2026.06.02", "streamlit>=1.58,<2", "streamlit_code_editor>=0.1.22,<0.2", "watchdog>=6,<7"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"
@@ -42,6 +42,8 @@ Homepage = "https://github.com/ThalesGroup/agilab"
 Repository = "https://github.com/ThalesGroup/agilab"
 Discussions = "https://github.com/ThalesGroup/agilab/discussions"
 Changelog = "https://github.com/ThalesGroup/agilab/releases"
+
+
 
 
 

--- a/src/agilab/lib/agi-pages/pyproject.toml
+++ b/src/agilab/lib/agi-pages/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.01"
+version = "2026.06.02"
 name = "agi-pages"
 description = "AGILAB public analysis page umbrella and provider package"
 requires-python = ">=3.11"
@@ -34,7 +34,7 @@ keywords = [
     "page-bundles",
 ]
 
-dependencies = ["agi-gui==2026.06.01"]
+dependencies = ["agi-gui==2026.06.02"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"
@@ -44,6 +44,8 @@ Homepage = "https://github.com/ThalesGroup/agilab"
 Repository = "https://github.com/ThalesGroup/agilab"
 Discussions = "https://github.com/ThalesGroup/agilab/discussions"
 Changelog = "https://github.com/ThalesGroup/agilab/releases"
+
+
 
 
 


### PR DESCRIPTION
Prepare optimized 2026.06.02 release metadata for the impacted AGILAB package closure.\n\nValidation run locally:\n- release plan impact closure selects agi-env, agi-gui, agi-pages, agi-node, agi-cluster, agi-core, agi-apps, agilab\n- release-operation tests\n- trusted-publisher workflow contract\n- dependency-policy and shared-core-typing workflow parity\n- docs mirror stamp