### PR TITLE
Increase MLflow subproc wrapper coverage

### DIFF
--- a/src/agilab/core/agi-env/test/test_pagelib.py
+++ b/src/agilab/core/agi-env/test/test_pagelib.py
@@ -2719,3 +2719,53 @@ def test_activate_gpt_oss_transformers_backend_retries_busy_port_and_keeps_activ
 
 def test_scan_dir_returns_empty_list_for_missing_path(tmp_path):
     assert pagelib.scan_dir(tmp_path / "missing") == []
+
+
+def test_activate_mlflow_public_wrapper_does_not_strip_launch_options(tmp_path, monkeypatch):
+    errors: list[str] = []
+    launched: list[dict[str, object]] = []
+    _patch_mlflow_cli(monkeypatch)
+
+    class FakeSessionState(dict):
+        def __getattr__(self, name):
+            try:
+                return self[name]
+            except KeyError as exc:
+                raise AttributeError(name) from exc
+
+        def __setattr__(self, name, value):
+            self[name] = value
+
+    def _strict_subproc(command, cwd, *, env, stdout, stderr, start_new_session):
+        launched.append(
+            {
+                "command": command,
+                "cwd": cwd,
+                "env": env,
+                "stdout": stdout,
+                "stderr": stderr,
+                "start_new_session": start_new_session,
+            }
+        )
+        return SimpleNamespace(pid=999999999, poll=lambda: None, terminate=lambda: None)
+
+    fake_st = SimpleNamespace(session_state=FakeSessionState(), error=lambda message: errors.append(str(message)))
+    monkeypatch.setattr(pagelib, "st", fake_st)
+    monkeypatch.setattr(pagelib, "_ensure_default_mlflow_experiment", lambda _tracking_dir: "sqlite:///tmp/mlflow.db")
+    monkeypatch.setattr(pagelib, "_resolve_mlflow_artifact_dir", lambda _tracking_dir: tmp_path / "artifacts")
+    monkeypatch.setattr(pagelib, "get_random_port", lambda: 50123)
+    monkeypatch.setattr(pagelib, "is_port_in_use", lambda _port: False)
+    monkeypatch.setattr(pagelib, "_wait_for_listen_port", lambda _port: False)
+    monkeypatch.setattr(pagelib, "subproc", _strict_subproc)
+
+    started = pagelib.activate_mlflow(SimpleNamespace(MLFLOW_TRACKING_DIR="", home_abs=tmp_path))
+
+    assert started is False
+    assert len(launched) == 1
+    assert launched[0]["command"][:2] == ["mlflow", "server"]
+    assert launched[0]["env"]["PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION"] == "python"
+    assert launched[0]["stdout"].name == str(tmp_path / ".mlflow" / "mlflow-server.log")
+    assert launched[0]["stderr"] == pagelib.subprocess.STDOUT
+    assert launched[0]["start_new_session"] is True
+    assert fake_st.session_state["mlflow_autostart_disabled"] is True
+    assert "mlflow-server.log" in fake_st.session_state["mlflow_status_message"]

--- a/src/agilab/core/agi-env/test/test_pagelib.py
+++ b/src/agilab/core/agi-env/test/test_pagelib.py
@@ -1615,7 +1615,7 @@ def test_subproc_uses_absolute_cwd_and_returns_stdout(monkeypatch, tmp_path):
         def __init__(self, stdout_value):
             self.stdout = stdout_value
 
-    def fake_popen(command, shell, cwd, stdout, stderr, text, env):
+    def fake_popen(command, shell, cwd, stdout, stderr, text, env, **kwargs):
         calls["command"] = command
         calls["shell"] = shell
         calls["cwd"] = cwd
@@ -1623,6 +1623,7 @@ def test_subproc_uses_absolute_cwd_and_returns_stdout(monkeypatch, tmp_path):
         calls["stderr"] = stderr
         calls["text"] = text
         calls["env"] = env
+        calls["kwargs"] = kwargs
         return FakeProcess("stream-output")
 
     monkeypatch.setattr(pagelib.subprocess, "Popen", fake_popen)
@@ -1637,6 +1638,25 @@ def test_subproc_uses_absolute_cwd_and_returns_stdout(monkeypatch, tmp_path):
     assert calls["stderr"] == subprocess.STDOUT
     assert isinstance(calls["env"], dict)
     assert calls["text"] is True
+    assert calls["kwargs"] == {}
+
+    explicit_stdout = object()
+    explicit_env = {"AGILAB_TEST": "1"}
+    process_value = pagelib.subproc(
+        ["python", "-m", "mlflow"],
+        tmp_path,
+        env=explicit_env,
+        stdout=explicit_stdout,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+
+    assert isinstance(process_value, FakeProcess)
+    assert calls["command"] == ["python", "-m", "mlflow"]
+    assert calls["stdout"] is explicit_stdout
+    assert calls["stderr"] == subprocess.DEVNULL
+    assert calls["env"] == explicit_env
+    assert calls["kwargs"] == {"start_new_session": True}
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Summary
- extend the `pagelib.subproc` regression to cover explicit MLflow launch options
- prove explicit `env`, `stdout`, `stderr`, and `start_new_session` return a process handle instead of the legacy stdout pipe

## Validation
- Not run locally.
