### PR TITLE
Add reusable Safe Action selector

### DIFF
--- a/src/agilab/generated_actions.py
+++ b/src/agilab/generated_actions.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 from dataclasses import dataclass
 from typing import Any, Mapping, Sequence
@@ -14,6 +15,9 @@ GENERATION_MODE_PYTHON_SNIPPET = "python_snippet"
 
 STAGE_GENERATION_MODE_FIELD = "generation_mode"
 STAGE_ACTION_CONTRACT_FIELD = "action_contract"
+STAGE_ACTION_CONTRACT_SHA256_FIELD = "action_contract_sha256"
+STAGE_DATAFRAME_SCHEMA_SHA256_FIELD = "dataframe_schema_sha256"
+STAGE_SAFE_ACTION_PINNED_FIELD = "safe_action_pinned"
 
 GENERATED_ACTIONS_SYSTEM_INSTRUCTIONS = """
 Return ONLY a JSON object. Do not return Python code or Markdown.
@@ -175,6 +179,29 @@ def generated_action_contract_to_python(contract: GeneratedActionContract | Mapp
     return "\n".join(lines).strip() + "\n"
 
 
+def safe_action_contract_stage_code(contract: GeneratedActionContract | Mapping[str, Any]) -> str:
+    return generated_action_contract_to_python(contract)
+
+
+def safe_action_contract_sha256(contract: GeneratedActionContract | Mapping[str, Any]) -> str:
+    if isinstance(contract, GeneratedActionContract):
+        payload = contract.to_payload()
+    else:
+        payload = validate_generated_action_contract(contract).to_payload()
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def dataframe_schema_sha256(df: pd.DataFrame | None) -> str:
+    canonical = json.dumps(
+        dataframe_schema_for_prompt(df),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
 def summarize_generated_actions(contract: GeneratedActionContract | Mapping[str, Any]) -> str:
     if isinstance(contract, Mapping):
         contract = validate_generated_action_contract(contract)
@@ -193,16 +220,41 @@ def stage_generation_extra_fields(
     contract: GeneratedActionContract | Mapping[str, Any] | None,
     *,
     mode: str,
+    df: pd.DataFrame | None = None,
+    pinned: bool = False,
 ) -> dict[str, Any]:
-    fields: dict[str, Any] = {STAGE_GENERATION_MODE_FIELD: mode}
+    fields: dict[str, Any] = {
+        STAGE_GENERATION_MODE_FIELD: mode,
+        STAGE_ACTION_CONTRACT_SHA256_FIELD: "",
+        STAGE_DATAFRAME_SCHEMA_SHA256_FIELD: dataframe_schema_sha256(df),
+        STAGE_SAFE_ACTION_PINNED_FIELD: False,
+    }
     if contract is None:
         fields[STAGE_ACTION_CONTRACT_FIELD] = None
         return fields
     if isinstance(contract, GeneratedActionContract):
-        fields[STAGE_ACTION_CONTRACT_FIELD] = contract.to_payload()
+        payload = contract.to_payload()
     else:
-        fields[STAGE_ACTION_CONTRACT_FIELD] = validate_generated_action_contract(contract).to_payload()
+        payload = validate_generated_action_contract(contract).to_payload()
+    fields[STAGE_ACTION_CONTRACT_FIELD] = payload
+    fields[STAGE_ACTION_CONTRACT_SHA256_FIELD] = safe_action_contract_sha256(payload)
+    fields[STAGE_SAFE_ACTION_PINNED_FIELD] = bool(
+        pinned and mode == GENERATION_MODE_SAFE_ACTIONS
+    )
     return fields
+
+
+def pin_safe_action_extra_fields(
+    contract: GeneratedActionContract | Mapping[str, Any],
+    *,
+    df: pd.DataFrame | None = None,
+) -> dict[str, Any]:
+    return stage_generation_extra_fields(
+        contract,
+        mode=GENERATION_MODE_SAFE_ACTIONS,
+        df=df,
+        pinned=True,
+    )
 
 
 def _loads_json_contract(raw_text: str) -> Mapping[str, Any]:

--- a/src/agilab/pipeline_ai.py
+++ b/src/agilab/pipeline_ai.py
@@ -881,7 +881,7 @@ def ask_gpt(
                 model_label,
                 "",
                 "Safe action generation failed: model returned an empty response.",
-                stage_generation_extra_fields(None, mode=mode),
+                stage_generation_extra_fields(None, mode=mode, df=df),
             ]
         try:
             contract = parse_generated_action_contract(result)
@@ -895,7 +895,7 @@ def ask_gpt(
                 model_label,
                 code,
                 detail,
-                stage_generation_extra_fields(contract, mode=mode),
+                stage_generation_extra_fields(contract, mode=mode, df=df),
             ]
         except GeneratedActionError as exc:
             detail = f"Safe action generation failed: {exc}"
@@ -906,7 +906,7 @@ def ask_gpt(
                 model_label,
                 "",
                 detail,
-                stage_generation_extra_fields(None, mode=mode),
+                stage_generation_extra_fields(None, mode=mode, df=df),
             ]
 
     original_question = question

--- a/src/agilab/pipeline_lab.py
+++ b/src/agilab/pipeline_lab.py
@@ -72,13 +72,74 @@ _generated_actions_module = import_agilab_module(
 GENERATION_MODE_PYTHON_SNIPPET = _generated_actions_module.GENERATION_MODE_PYTHON_SNIPPET
 GENERATION_MODE_SAFE_ACTIONS = _generated_actions_module.GENERATION_MODE_SAFE_ACTIONS
 STAGE_ACTION_CONTRACT_FIELD = _generated_actions_module.STAGE_ACTION_CONTRACT_FIELD
+STAGE_ACTION_CONTRACT_SHA256_FIELD = _generated_actions_module.STAGE_ACTION_CONTRACT_SHA256_FIELD
+STAGE_DATAFRAME_SCHEMA_SHA256_FIELD = _generated_actions_module.STAGE_DATAFRAME_SCHEMA_SHA256_FIELD
 STAGE_GENERATION_MODE_FIELD = _generated_actions_module.STAGE_GENERATION_MODE_FIELD
+STAGE_SAFE_ACTION_PINNED_FIELD = _generated_actions_module.STAGE_SAFE_ACTION_PINNED_FIELD
+GeneratedActionError = _generated_actions_module.GeneratedActionError
+pin_safe_action_extra_fields = _generated_actions_module.pin_safe_action_extra_fields
+safe_action_contract_sha256 = _generated_actions_module.safe_action_contract_sha256
+safe_action_contract_stage_code = _generated_actions_module.safe_action_contract_stage_code
+stage_generation_extra_fields = _generated_actions_module.stage_generation_extra_fields
+summarize_generated_actions = _generated_actions_module.summarize_generated_actions
+validate_generated_action_contract = _generated_actions_module.validate_generated_action_contract
 
 GENERATION_MODE_LABELS = {
     GENERATION_MODE_SAFE_ACTIONS: "Safe actions",
     GENERATION_MODE_PYTHON_SNIPPET: "Python snippet (advanced)",
 }
 GENERATION_MODE_BY_LABEL = {label: mode for mode, label in GENERATION_MODE_LABELS.items()}
+PINNED_SAFE_ACTION_NEW = "Generate new Safe Action"
+SNIPPET_EDITOR_HEIGHT = 420
+
+
+@dataclass(frozen=True)
+class _PinnedSafeAction:
+    stage_index: int
+    label: str
+    question: str
+    detail: str
+    model: str
+    contract: Mapping[str, Any]
+    code: str
+
+
+def _safe_action_contract_payload(raw_contract: Any) -> dict[str, Any] | None:
+    if not isinstance(raw_contract, Mapping):
+        return None
+    try:
+        return validate_generated_action_contract(raw_contract).to_payload()
+    except GeneratedActionError:
+        return None
+
+
+def _pinned_safe_actions_from_stages(stages: List[Mapping[str, Any]]) -> List[_PinnedSafeAction]:
+    pinned_actions: List[_PinnedSafeAction] = []
+    for stage_index, entry in enumerate(stages):
+        if not isinstance(entry, Mapping):
+            continue
+        if entry.get(STAGE_GENERATION_MODE_FIELD) != GENERATION_MODE_SAFE_ACTIONS:
+            continue
+        if not bool(entry.get(STAGE_SAFE_ACTION_PINNED_FIELD)):
+            continue
+        contract = _safe_action_contract_payload(entry.get(STAGE_ACTION_CONTRACT_FIELD))
+        if contract is None:
+            continue
+        detail = summarize_generated_actions(contract)
+        digest = str(entry.get(STAGE_ACTION_CONTRACT_SHA256_FIELD) or safe_action_contract_sha256(contract))
+        suffix = f" ({digest[:8]})" if digest else ""
+        pinned_actions.append(
+            _PinnedSafeAction(
+                stage_index=stage_index,
+                label=f"Stage {stage_index + 1}: {detail}{suffix}",
+                question=str(entry.get("Q") or detail),
+                detail=detail,
+                model=str(entry.get("M") or "pinned-safe-action"),
+                contract=contract,
+                code=safe_action_contract_stage_code(contract),
+            )
+        )
+    return pinned_actions
 
 _pipeline_page_state_module = import_agilab_module(
     "agilab.pipeline_page_state",
@@ -3369,25 +3430,88 @@ def display_lab_tab(
         labels = list(GENERATION_MODE_LABELS.values())
         mode = existing_mode if existing_mode in GENERATION_MODE_LABELS else GENERATION_MODE_SAFE_ACTIONS
         default_label = GENERATION_MODE_LABELS[mode]
-        if st.session_state.get(key) not in labels:
-            st.session_state[key] = default_label
-        selected_label = compact_choice(
-            st,
-            "Generation mode",
-            labels,
-            key=key,
-            help=(
+        select_kwargs: Dict[str, Any] = {
+            "key": key,
+            "help": (
                 "Safe actions asks the model for a validated JSON action contract. "
                 "Python snippet is for advanced manual code generation."
             ),
-            inline_limit=4,
-        )
+        }
+        if st.session_state.get(key) not in labels:
+            st.session_state.pop(key, None)
+            select_kwargs["index"] = labels.index(default_label)
+        selected_label = st.selectbox("Generation mode", labels, **select_kwargs)
         selected_mode = GENERATION_MODE_BY_LABEL.get(str(selected_label), GENERATION_MODE_SAFE_ACTIONS)
         if selected_mode == GENERATION_MODE_SAFE_ACTIONS:
             st.caption("Safe actions: model JSON is validated, then AGILAB writes deterministic pandas code.")
         else:
             st.caption("Advanced: raw model Python is saved for review; auto-fix requires an explicit sandbox acknowledgement.")
         return selected_mode
+
+    def _current_safe_action_dataframe() -> pd.DataFrame | None:
+        df: Any = st.session_state.get("loaded_df")
+        if isinstance(df, pd.DataFrame):
+            return df
+        df_file = st.session_state.get("df_file")
+        if not df_file:
+            return None
+        try:
+            loaded = load_df_cached(Path(df_file), with_index=False)
+        except TypeError:
+            try:
+                loaded = load_df_cached(Path(df_file))
+            except (OSError, RuntimeError, TypeError, ValueError):
+                return None
+        except (OSError, RuntimeError, ValueError):
+            return None
+        return loaded if isinstance(loaded, pd.DataFrame) else None
+
+    def _render_pinned_safe_action_selectbox(key: str) -> _PinnedSafeAction | None:
+        if not pinned_safe_actions:
+            st.caption("No pinned Safe Actions yet. Pin a generated Safe Action stage to reuse it here.")
+            return None
+        options = [PINNED_SAFE_ACTION_NEW] + [action.label for action in pinned_safe_actions]
+        select_kwargs: Dict[str, Any] = {
+            "key": key,
+            "help": (
+                "Reuse a pinned validated Safe Action contract from this workflow. "
+                "Raw Python snippets are not listed here."
+            ),
+        }
+        if st.session_state.get(key) not in options:
+            st.session_state.pop(key, None)
+            select_kwargs["index"] = 0
+        selected = st.selectbox("Existing Safe Action", options, **select_kwargs)
+        for action in pinned_safe_actions:
+            if selected == action.label:
+                st.caption(f"Reusing pinned Safe Action from stage {action.stage_index + 1}.")
+                return action
+        return None
+
+    def _answer_from_pinned_safe_action(action: _PinnedSafeAction, df_path: Path) -> List[Any]:
+        return [
+            df_path,
+            action.question,
+            action.model or "pinned-safe-action",
+            action.code,
+            action.detail,
+            pin_safe_action_extra_fields(action.contract, df=_current_safe_action_dataframe()),
+        ]
+
+    def _extra_fields_for_manual_stage_save(entry: Mapping[str, Any], code_current: str) -> Dict[str, Any]:
+        contract = _safe_action_contract_payload(entry.get(STAGE_ACTION_CONTRACT_FIELD))
+        if contract is not None and code_current.strip() == safe_action_contract_stage_code(contract).strip():
+            return stage_generation_extra_fields(
+                contract,
+                mode=GENERATION_MODE_SAFE_ACTIONS,
+                df=_current_safe_action_dataframe(),
+                pinned=bool(entry.get(STAGE_SAFE_ACTION_PINNED_FIELD)),
+            )
+        return stage_generation_extra_fields(
+            None,
+            mode=GENERATION_MODE_PYTHON_SNIPPET,
+            df=_current_safe_action_dataframe(),
+        )
 
     def _ask_stage_generator(prompt_text: str, df_path: Path, generation_mode: str) -> List[Any]:
         return ask_gpt(
@@ -3402,10 +3526,11 @@ def display_lab_tab(
     def _generation_extra_fields(answer: List[Any], generation_mode: str) -> Dict[str, Any]:
         if len(answer) > 5 and isinstance(answer[5], dict):
             return dict(answer[5])
-        return {
-            STAGE_GENERATION_MODE_FIELD: generation_mode,
-            STAGE_ACTION_CONTRACT_FIELD: None,
-        }
+        return stage_generation_extra_fields(
+            None,
+            mode=generation_mode,
+            df=_current_safe_action_dataframe(),
+        )
 
     def _warn_generation_without_code(answer: List[Any]) -> None:
         detail = str(answer[4] if len(answer) > 4 else "").strip()
@@ -3427,6 +3552,7 @@ def display_lab_tab(
                 persisted_stages = [s for s in fallback_stages if _is_displayable_stage(s)]
         except (AttributeError, OSError, TypeError, tomllib.TOMLDecodeError):
             pass
+    pinned_safe_actions = _pinned_safe_actions_from_stages(persisted_stages)
     total_stages = len(persisted_stages)
     safe_prefix = index_page_str.replace("/", "_")
     total_stages_key = f"{safe_prefix}_total_stages"
@@ -3517,6 +3643,11 @@ def display_lab_tab(
             if stage_source == GENERATE_STAGE_SOURCE:
                 _render_assistant_engine_near_prompt()
                 generation_mode = _render_generation_mode_control(first_generation_mode_key)
+                selected_safe_action = (
+                    _render_pinned_safe_action_selectbox(f"{safe_prefix}_safe_action_choice_first")
+                    if generation_mode == GENERATION_MODE_SAFE_ACTIONS
+                    else None
+                )
                 st.text_area(
                     "Ask code generator:",
                     key=new_q_key,
@@ -3533,41 +3664,46 @@ def display_lab_tab(
                     inline_limit=4,
                 )
                 selected_path = "" if selected_new_venv == venv_labels[0] else _valid_runtime_path(selected_new_venv)
+                generate_label = "Use Safe Action" if selected_safe_action else "Generate code"
                 run_new = action_button(
                     st,
-                    "Generate code",
+                    generate_label,
                     key=f"{safe_prefix}_add_first_stage_btn",
-                    kind="generate",
+                    kind="add" if selected_safe_action else "generate",
                 )
                 if run_new:
                     prompt_text = st.session_state.get(new_q_key, "").strip()
-                    if not prompt_text:
+                    if selected_safe_action:
+                        df_path = Path(st.session_state.df_file) if st.session_state.get("df_file") else Path()
+                        answer = _answer_from_pinned_safe_action(selected_safe_action, df_path)
+                    elif not prompt_text:
                         st.warning("Enter a prompt before generating code.")
+                        return
                     else:
                         df_path = Path(st.session_state.df_file) if st.session_state.get("df_file") else Path()
                         answer = _ask_stage_generator(prompt_text, df_path, generation_mode)
-                        if not str(answer[3] if len(answer) > 3 else "").strip():
-                            _warn_generation_without_code(answer)
-                            return
-                        venv_map = {0: selected_path} if selected_path else {}
-                        eng_map = {0: "agi.run" if selected_path else "runpy"}
-                        extra_fields = _generation_extra_fields(answer, generation_mode)
-                        expander_state_key = f"{safe_prefix}_expander_open"
-                        expander_state = st.session_state.setdefault(expander_state_key, {})
-                        expander_state[0] = True
-                        st.session_state[expander_state_key] = expander_state
-                        save_stage(
-                            module_path,
-                            answer,
-                            0,
-                            1,
-                            stages_file,
-                            venv_map=venv_map,
-                            engine_map=eng_map,
-                            extra_fields=extra_fields,
-                        )
-                        _bump_history_revision()
-                        st.rerun()
+                    if not str(answer[3] if len(answer) > 3 else "").strip():
+                        _warn_generation_without_code(answer)
+                        return
+                    venv_map = {0: selected_path} if selected_path else {}
+                    eng_map = {0: "agi.run" if selected_path else "runpy"}
+                    extra_fields = _generation_extra_fields(answer, generation_mode)
+                    expander_state_key = f"{safe_prefix}_expander_open"
+                    expander_state = st.session_state.setdefault(expander_state_key, {})
+                    expander_state[0] = True
+                    st.session_state[expander_state_key] = expander_state
+                    save_stage(
+                        module_path,
+                        answer,
+                        0,
+                        1,
+                        stages_file,
+                        venv_map=venv_map,
+                        engine_map=eng_map,
+                        extra_fields=extra_fields,
+                    )
+                    _bump_history_revision()
+                    st.rerun()
             else:
                 snippet_path = snippet_option_map.get(stage_source)
                 snippet_code = ""
@@ -3876,6 +4012,59 @@ def display_lab_tab(
                 generation_mode_key,
                 existing_mode=str(entry.get(STAGE_GENERATION_MODE_FIELD) or ""),
             )
+            selected_safe_action = (
+                _render_pinned_safe_action_selectbox(f"{safe_prefix}_safe_action_choice_{stage}")
+                if generation_mode == GENERATION_MODE_SAFE_ACTIONS
+                else None
+            )
+            current_contract = _safe_action_contract_payload(entry.get(STAGE_ACTION_CONTRACT_FIELD))
+            if current_contract is not None:
+                current_safe_action_pinned = bool(entry.get(STAGE_SAFE_ACTION_PINNED_FIELD))
+                current_safe_action_state = "Pinned" if current_safe_action_pinned else "Reusable"
+                st.caption(f"{current_safe_action_state} Safe Action: {summarize_generated_actions(current_contract)}")
+                pin_label = "Unpin Safe Action" if current_safe_action_pinned else "Pin Safe Action"
+                pin_kind = "remove" if current_safe_action_pinned else "add"
+                if action_button(
+                    st,
+                    pin_label,
+                    key=f"{safe_prefix}_{'unpin' if current_safe_action_pinned else 'pin'}_safe_action_{stage}",
+                    kind=pin_kind,
+                ):
+                    df = _current_safe_action_dataframe()
+                    extra_fields = (
+                        stage_generation_extra_fields(
+                            current_contract,
+                            mode=GENERATION_MODE_SAFE_ACTIONS,
+                            df=df,
+                            pinned=False,
+                        )
+                        if current_safe_action_pinned
+                        else pin_safe_action_extra_fields(current_contract, df=df)
+                    )
+                    canonical_code = safe_action_contract_stage_code(current_contract)
+                    save_stage(
+                        module_path,
+                        [
+                            entry.get("D", ""),
+                            st.session_state.get(q_key, entry.get("Q", "")),
+                            entry.get("M", ""),
+                            canonical_code,
+                        ],
+                        stage,
+                        total_stages,
+                        stages_file,
+                        venv_map=selected_map,
+                        engine_map=engine_map,
+                        extra_fields=extra_fields,
+                    )
+                    st.session_state[pending_q_key] = st.session_state.get(q_key, entry.get("Q", ""))
+                    st.session_state[pending_c_key] = canonical_code
+                    st.session_state[rev_key] = st.session_state.get(rev_key, 0) + 1
+                    _bump_history_revision()
+                    _rerun_fragment_or_app()
+                    return
+            elif generation_mode == GENERATION_MODE_PYTHON_SNIPPET:
+                st.caption("Raw Python snippets are not listed as reusable Safe Actions.")
             st.text_area(
                 "Ask code generator:",
                 key=q_key,
@@ -3941,7 +4130,7 @@ def display_lab_tab(
             editor_key = f"{safe_prefix}a{stage}-{rev}"
             snippet_dict = code_editor(
                 code_text if code_text.endswith("\n") else code_text + "\n",
-                height=(min(30, len(code_text)) if code_text else 100),
+                height=SNIPPET_EDITOR_HEIGHT,
                 theme="contrast",
                 buttons=normalize_custom_buttons(get_custom_buttons()),
                 info=get_info_bar(),
@@ -3975,6 +4164,7 @@ def display_lab_tab(
                     stages_file,
                     venv_map=selected_map,
                     engine_map=engine_map,
+                    extra_fields=_extra_fields_for_manual_stage_save(entry, restored_c),
                 )
                 _bump_history_revision()
                 expander_state[stage] = True
@@ -3990,6 +4180,7 @@ def display_lab_tab(
                 st.session_state[rev_key] = st.session_state.get(rev_key, 0) + 1
                 expander_state[stage] = True
                 st.session_state[expander_state_key] = expander_state
+                manual_extra_fields = _extra_fields_for_manual_stage_save(entry, code_current)
                 save_stage(
                     module_path,
                     [entry.get("D", ""), st.session_state.get(q_key, ""), entry.get("M", ""), code_current],
@@ -3998,6 +4189,7 @@ def display_lab_tab(
                     stages_file,
                     venv_map=selected_map,
                     engine_map=engine_map,
+                    extra_fields=manual_extra_fields,
                 )
                 _force_persist_stage(
                     module_path,
@@ -4010,6 +4202,7 @@ def display_lab_tab(
                         "C": code_current,
                         "E": normalize_runtime_path(selected_map.get(stage, "")),
                         "R": engine_map.get(stage, "") or ("agi.run" if selected_map.get(stage) else "runpy"),
+                        **manual_extra_fields,
                     },
                 )
                 st.session_state[pending_q_key] = st.session_state.get(q_key, "")
@@ -4052,6 +4245,7 @@ def display_lab_tab(
                 st.session_state[rev_key] = st.session_state.get(rev_key, 0) + 1
                 expander_state[stage] = True
                 st.session_state[expander_state_key] = expander_state
+                manual_extra_fields = _extra_fields_for_manual_stage_save(entry, code_current)
                 save_stage(
                     module_path,
                     [entry.get("D", ""), st.session_state.get(q_key, ""), entry.get("M", ""), code_current],
@@ -4060,6 +4254,7 @@ def display_lab_tab(
                     stages_file,
                     venv_map=selected_map,
                     engine_map=engine_map,
+                    extra_fields=manual_extra_fields,
                 )
                 _force_persist_stage(
                     module_path,
@@ -4072,6 +4267,7 @@ def display_lab_tab(
                         "C": code_current,
                         "E": normalize_runtime_path(selected_map.get(stage, "")),
                         "R": engine_map.get(stage, "") or ("agi.run" if selected_map.get(stage) else "runpy"),
+                        **manual_extra_fields,
                     },
                 )
                 _bump_history_revision()
@@ -4253,13 +4449,20 @@ def display_lab_tab(
                     if st.session_state.get("df_file")
                     else Path()
                 )
-                answer = _ask_stage_generator(prompt_text, df_path, generation_mode)
+                answer = (
+                    _answer_from_pinned_safe_action(selected_safe_action, df_path)
+                    if selected_safe_action
+                    else _ask_stage_generator(prompt_text, df_path, generation_mode)
+                )
                 merged_code = None
                 code_txt = answer[3] if len(answer) > 3 else ""
                 detail_txt = (answer[4] or "").strip() if len(answer) > 4 else ""
                 if code_txt:
-                    summary_line = f"# {detail_txt}\n" if detail_txt else ""
-                    merged_code = f"{summary_line}{code_txt}"
+                    if generation_mode == GENERATION_MODE_SAFE_ACTIONS:
+                        merged_code = str(code_txt)
+                    else:
+                        summary_line = f"# {detail_txt}\n" if detail_txt else ""
+                        merged_code = f"{summary_line}{code_txt}"
                     if len(answer) > 3:
                         answer[3] = merged_code
                 elif generation_mode == GENERATION_MODE_SAFE_ACTIONS:
@@ -4388,6 +4591,11 @@ def display_lab_tab(
         if stage_source == GENERATE_STAGE_SOURCE:
             _render_assistant_engine_near_prompt()
             generation_mode = _render_generation_mode_control(add_generation_mode_key)
+            selected_safe_action = (
+                _render_pinned_safe_action_selectbox(f"{safe_prefix}_safe_action_choice_add")
+                if generation_mode == GENERATION_MODE_SAFE_ACTIONS
+                else None
+            )
             st.text_area(
                 "Ask code generator:",
                 key=new_q_key,
@@ -4404,71 +4612,84 @@ def display_lab_tab(
                 inline_limit=4,
             )
             selected_path = "" if selected_new_venv == venv_labels[0] else _valid_runtime_path(selected_new_venv)
-            run_new = action_button(st, "Generate code", key=f"{safe_prefix}_add_stage_btn", kind="generate")
+            generate_label = "Use Safe Action" if selected_safe_action else "Generate code"
+            run_new = action_button(
+                st,
+                generate_label,
+                key=f"{safe_prefix}_add_stage_btn",
+                kind="add" if selected_safe_action else "generate",
+            )
             if run_new:
                 prompt_text = st.session_state.get(new_q_key, "").strip()
-                if prompt_text:
+                if selected_safe_action:
+                    df_path = Path(st.session_state.df_file) if st.session_state.get("df_file") else Path()
+                    answer = _answer_from_pinned_safe_action(selected_safe_action, df_path)
+                elif prompt_text:
                     df_path = Path(st.session_state.df_file) if st.session_state.get("df_file") else Path()
                     answer = _ask_stage_generator(prompt_text, df_path, generation_mode)
-                    merged_code = None
-                    code_txt = answer[3] if len(answer) > 3 else ""
-                    detail_txt = (answer[4] or "").strip() if len(answer) > 4 else ""
-                    if code_txt:
-                        summary_line = f"# {detail_txt}\n" if detail_txt else ""
-                        merged_code = f"{summary_line}{code_txt}"
-                        if len(answer) > 3:
-                            answer[3] = merged_code
-                    elif generation_mode == GENERATION_MODE_SAFE_ACTIONS:
-                        _warn_generation_without_code(answer)
-                        return
-
-                    if merged_code and generation_mode != GENERATION_MODE_SAFE_ACTIONS:
-                        fixed_code, fixed_model, fixed_detail = _maybe_autofix_generated_code(
-                            original_request=prompt_text,
-                            df_path=df_path,
-                            index_page=index_page_str,
-                            env=env,
-                            merged_code=str(merged_code),
-                            model_label=str(answer[2] if len(answer) > 2 else ""),
-                            detail=str(answer[4] if len(answer) > 4 else ""),
-                            load_df_cached=load_df_cached,
-                            push_run_log=_push_run_log,
-                            get_run_placeholder=_get_run_placeholder,
-                        )
-                        merged_code = fixed_code
-                        if len(answer) > 3:
-                            answer[3] = fixed_code
-                        if len(answer) > 2:
-                            answer[2] = fixed_model
-                        if len(answer) > 4:
-                            answer[4] = fixed_detail
-                    new_idx = len(persisted_stages)
-                    venv_map = selected_map.copy()
-                    engine_map_local = engine_map.copy()
-                    if selected_path:
-                        venv_map[new_idx] = selected_path
-                        engine_map_local[new_idx] = "agi.run"
-                    else:
-                        engine_map_local[new_idx] = "runpy"
-                    extra_fields = _generation_extra_fields(answer, generation_mode)
-                    save_stage(
-                        module_path,
-                        answer,
-                        new_idx,
-                        new_idx + 1,
-                        stages_file,
-                        venv_map=venv_map,
-                        engine_map=engine_map_local,
-                        extra_fields=extra_fields,
-                    )
-                    detail_store = st.session_state.setdefault(f"{index_page_str}__details", {})
-                    detail = answer[4] if len(answer) > 4 else ""
-                    if detail:
-                        detail_store[new_idx] = detail
-                    _bump_history_revision()
-                    st.rerun()
                 else:
                     st.warning("Enter a prompt before generating code.")
+                    return
+                merged_code = None
+                code_txt = answer[3] if len(answer) > 3 else ""
+                detail_txt = (answer[4] or "").strip() if len(answer) > 4 else ""
+                if code_txt:
+                    if generation_mode == GENERATION_MODE_SAFE_ACTIONS:
+                        merged_code = str(code_txt)
+                    else:
+                        summary_line = f"# {detail_txt}\n" if detail_txt else ""
+                        merged_code = f"{summary_line}{code_txt}"
+                    if len(answer) > 3:
+                        answer[3] = merged_code
+                elif generation_mode == GENERATION_MODE_SAFE_ACTIONS:
+                    _warn_generation_without_code(answer)
+                    return
+
+                if merged_code and generation_mode != GENERATION_MODE_SAFE_ACTIONS:
+                    fixed_code, fixed_model, fixed_detail = _maybe_autofix_generated_code(
+                        original_request=prompt_text,
+                        df_path=df_path,
+                        index_page=index_page_str,
+                        env=env,
+                        merged_code=str(merged_code),
+                        model_label=str(answer[2] if len(answer) > 2 else ""),
+                        detail=str(answer[4] if len(answer) > 4 else ""),
+                        load_df_cached=load_df_cached,
+                        push_run_log=_push_run_log,
+                        get_run_placeholder=_get_run_placeholder,
+                    )
+                    merged_code = fixed_code
+                    if len(answer) > 3:
+                        answer[3] = fixed_code
+                    if len(answer) > 2:
+                        answer[2] = fixed_model
+                    if len(answer) > 4:
+                        answer[4] = fixed_detail
+                new_idx = len(persisted_stages)
+                venv_map = selected_map.copy()
+                engine_map_local = engine_map.copy()
+                if selected_path:
+                    venv_map[new_idx] = selected_path
+                    engine_map_local[new_idx] = "agi.run"
+                else:
+                    engine_map_local[new_idx] = "runpy"
+                extra_fields = _generation_extra_fields(answer, generation_mode)
+                save_stage(
+                    module_path,
+                    answer,
+                    new_idx,
+                    new_idx + 1,
+                    stages_file,
+                    venv_map=venv_map,
+                    engine_map=engine_map_local,
+                    extra_fields=extra_fields,
+                )
+                detail_store = st.session_state.setdefault(f"{index_page_str}__details", {})
+                detail = answer[4] if len(answer) > 4 else ""
+                if detail:
+                    detail_store[new_idx] = detail
+                _bump_history_revision()
+                st.rerun()
         else:
             snippet_path = snippet_option_map.get(stage_source)
             snippet_code = ""

--- a/test/test_generated_actions.py
+++ b/test/test_generated_actions.py
@@ -24,12 +24,19 @@ GENERATED_ACTIONS_SCHEMA_VERSION = generated_actions.GENERATED_ACTIONS_SCHEMA_VE
 GENERATION_MODE_SAFE_ACTIONS = generated_actions.GENERATION_MODE_SAFE_ACTIONS
 GENERATION_MODE_PYTHON_SNIPPET = generated_actions.GENERATION_MODE_PYTHON_SNIPPET
 STAGE_ACTION_CONTRACT_FIELD = generated_actions.STAGE_ACTION_CONTRACT_FIELD
+STAGE_ACTION_CONTRACT_SHA256_FIELD = generated_actions.STAGE_ACTION_CONTRACT_SHA256_FIELD
+STAGE_DATAFRAME_SCHEMA_SHA256_FIELD = generated_actions.STAGE_DATAFRAME_SCHEMA_SHA256_FIELD
 STAGE_GENERATION_MODE_FIELD = generated_actions.STAGE_GENERATION_MODE_FIELD
+STAGE_SAFE_ACTION_PINNED_FIELD = generated_actions.STAGE_SAFE_ACTION_PINNED_FIELD
 GeneratedActionError = generated_actions.GeneratedActionError
 build_generated_actions_prompt = generated_actions.build_generated_actions_prompt
 generated_action_contract_to_python = generated_actions.generated_action_contract_to_python
 parse_generated_action_contract = generated_actions.parse_generated_action_contract
 dataframe_schema_for_prompt = generated_actions.dataframe_schema_for_prompt
+dataframe_schema_sha256 = generated_actions.dataframe_schema_sha256
+pin_safe_action_extra_fields = generated_actions.pin_safe_action_extra_fields
+safe_action_contract_sha256 = generated_actions.safe_action_contract_sha256
+safe_action_contract_stage_code = generated_actions.safe_action_contract_stage_code
 stage_generation_extra_fields = generated_actions.stage_generation_extra_fields
 summarize_generated_actions = generated_actions.summarize_generated_actions
 validate_generated_action_contract = generated_actions.validate_generated_action_contract
@@ -132,12 +139,16 @@ def test_generated_action_prompt_and_stage_metadata_are_explicit() -> None:
     assert fields[STAGE_GENERATION_MODE_FIELD] == GENERATION_MODE_SAFE_ACTIONS
     assert fields[STAGE_ACTION_CONTRACT_FIELD]["schema_version"] == GENERATED_ACTIONS_SCHEMA_VERSION
     assert fields[STAGE_ACTION_CONTRACT_FIELD]["actions"][0]["action"] == "filter_rows"
+    assert fields[STAGE_ACTION_CONTRACT_SHA256_FIELD] == safe_action_contract_sha256(contract)
+    assert fields[STAGE_DATAFRAME_SCHEMA_SHA256_FIELD] == dataframe_schema_sha256(None)
+    assert fields[STAGE_SAFE_ACTION_PINNED_FIELD] is False
 
     empty_fields = stage_generation_extra_fields(None, mode=GENERATION_MODE_PYTHON_SNIPPET)
-    assert empty_fields == {
-        STAGE_GENERATION_MODE_FIELD: GENERATION_MODE_PYTHON_SNIPPET,
-        STAGE_ACTION_CONTRACT_FIELD: None,
-    }
+    assert empty_fields[STAGE_GENERATION_MODE_FIELD] == GENERATION_MODE_PYTHON_SNIPPET
+    assert empty_fields[STAGE_ACTION_CONTRACT_FIELD] is None
+    assert empty_fields[STAGE_ACTION_CONTRACT_SHA256_FIELD] == ""
+    assert empty_fields[STAGE_DATAFRAME_SCHEMA_SHA256_FIELD] == dataframe_schema_sha256(None)
+    assert empty_fields[STAGE_SAFE_ACTION_PINNED_FIELD] is False
 
     mapping_fields = stage_generation_extra_fields(
         {
@@ -149,6 +160,38 @@ def test_generated_action_prompt_and_stage_metadata_are_explicit() -> None:
         mode=GENERATION_MODE_SAFE_ACTIONS,
     )
     assert mapping_fields[STAGE_ACTION_CONTRACT_FIELD]["notes"] == "nothing to do"
+
+
+def test_safe_action_pin_metadata_hashes_contract_and_schema() -> None:
+    df = pd.DataFrame({"station": ["Paris"], "temperature": [21.5]})
+    contract = validate_generated_action_contract(
+        {
+            "schema_version": GENERATED_ACTIONS_SCHEMA_VERSION,
+            "kind": GENERATED_ACTIONS_KIND,
+            "actions": [{"action": "filter_rows", "column": "station", "operator": "eq", "value": "Paris"}],
+            "notes": "keep Paris rows",
+        },
+        df=df,
+    )
+
+    fields = pin_safe_action_extra_fields(contract, df=df)
+
+    assert fields[STAGE_GENERATION_MODE_FIELD] == GENERATION_MODE_SAFE_ACTIONS
+    assert fields[STAGE_SAFE_ACTION_PINNED_FIELD] is True
+    assert fields[STAGE_ACTION_CONTRACT_SHA256_FIELD] == safe_action_contract_sha256(contract)
+    assert fields[STAGE_DATAFRAME_SCHEMA_SHA256_FIELD] == dataframe_schema_sha256(df)
+    assert safe_action_contract_stage_code(contract) == generated_action_contract_to_python(contract)
+
+
+def test_python_snippet_metadata_cannot_be_marked_as_pinned_safe_action() -> None:
+    fields = stage_generation_extra_fields(
+        None,
+        mode=GENERATION_MODE_PYTHON_SNIPPET,
+        pinned=True,
+    )
+
+    assert fields[STAGE_ACTION_CONTRACT_FIELD] is None
+    assert fields[STAGE_SAFE_ACTION_PINNED_FIELD] is False
 
 
 def test_dataframe_schema_for_prompt_returns_empty_for_invalid_payload() -> None:

--- a/test/test_pipeline_lab.py
+++ b/test/test_pipeline_lab.py
@@ -281,6 +281,33 @@ def _make_lab_deps(**overrides):
     return SimpleNamespace(**defaults)
 
 
+def _safe_action_stage(*, pinned: bool, question: str = "keep Paris rows") -> dict[str, Any]:
+    contract = {
+        "schema_version": pipeline_lab._generated_actions_module.GENERATED_ACTIONS_SCHEMA_VERSION,
+        "kind": pipeline_lab._generated_actions_module.GENERATED_ACTIONS_KIND,
+        "actions": [{"action": "filter_rows", "column": "station", "operator": "eq", "value": "Paris"}],
+        "notes": question,
+    }
+    extra_fields = pipeline_lab.stage_generation_extra_fields(
+        contract,
+        mode=pipeline_lab.GENERATION_MODE_SAFE_ACTIONS,
+        pinned=pinned,
+    )
+    return {
+        "D": "",
+        "Q": question,
+        "M": "safe-model",
+        "C": pipeline_lab.safe_action_contract_stage_code(contract),
+        "E": "",
+        **extra_fields,
+    }
+
+
+def _safe_action_option_label(stage: dict[str, Any], *, stage_index: int = 0) -> str:
+    digest = str(stage[pipeline_lab.STAGE_ACTION_CONTRACT_SHA256_FIELD])[:8]
+    return f"Stage {stage_index + 1}: Safe action contract: filter rows. ({digest})"
+
+
 def test_valid_runtime_path_rejects_non_runtime_roots(monkeypatch):
     monkeypatch.setattr(pipeline_lab, "normalize_runtime_path", lambda raw: str(raw).strip() if raw else "")
     monkeypatch.setattr(pipeline_lab, "_is_valid_runtime_root", lambda raw: str(raw) == "/valid/runtime")
@@ -4496,6 +4523,140 @@ def test_display_lab_tab_existing_stages_warns_when_safe_action_generation_has_n
     pipeline_lab.display_lab_tab(tmp_path, "demo", tmp_path / "lab_stages.toml", tmp_path / "flight_telemetry_project", env, deps)
 
     assert ("warning", "The assistant did not return runnable stage code.") in fake_st.messages
+
+
+def test_display_lab_tab_lists_pinned_safe_actions_after_safe_mode(monkeypatch, tmp_path):
+    pinned_stage = _safe_action_stage(pinned=True)
+    raw_stage = {
+        "D": "",
+        "Q": "raw python",
+        "M": "model",
+        "C": "print('raw')",
+        "E": "",
+        pipeline_lab.STAGE_GENERATION_MODE_FIELD: pipeline_lab.GENERATION_MODE_PYTHON_SNIPPET,
+        pipeline_lab.STAGE_ACTION_CONTRACT_FIELD: pinned_stage[pipeline_lab.STAGE_ACTION_CONTRACT_FIELD],
+        pipeline_lab.STAGE_SAFE_ACTION_PINNED_FIELD: True,
+    }
+    fake_st = _FakeStreamlit(
+        {
+            "demo": [0, "", "", "", "", "", 0],
+            "demo__run_sequence": [0, 1],
+        },
+        multiselects={"demo_run_sequence_widget": [0, 1]},
+    )
+    monkeypatch.setattr(pipeline_lab, "st", fake_st)
+    monkeypatch.setattr(pipeline_lab, "code_editor", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(pipeline_lab, "get_available_virtualenvs", lambda _env: [])
+    monkeypatch.setattr(pipeline_lab, "normalize_runtime_path", lambda raw: str(raw) if raw else "")
+    monkeypatch.setattr(pipeline_lab, "_is_valid_runtime_root", lambda raw: bool(raw))
+    monkeypatch.setattr(pipeline_lab, "get_existing_snippets", lambda *_args, **_kwargs: {})
+    monkeypatch.setattr(pipeline_lab, "get_custom_buttons", lambda: [])
+    monkeypatch.setattr(pipeline_lab, "get_info_bar", lambda: {})
+    monkeypatch.setattr(pipeline_lab, "get_css_text", lambda: {})
+
+    deps = _make_lab_deps(
+        load_all_stages=lambda *_args, **_kwargs: [pinned_stage, raw_stage],
+        load_pipeline_conceptual_dot=lambda *_args, **_kwargs: (None, None),
+        render_pipeline_view=lambda *_args, **_kwargs: None,
+        inspect_pipeline_run_lock=lambda *_args, **_kwargs: None,
+    )
+    env = SimpleNamespace(active_app=tmp_path / "flight_telemetry_project", envars={}, app="flight_telemetry_project")
+
+    pipeline_lab.display_lab_tab(tmp_path, "demo", tmp_path / "lab_stages.toml", tmp_path / "flight_telemetry_project", env, deps)
+
+    safe_action_calls = [call for call in fake_st.selectbox_calls if call[0] == "Existing Safe Action"]
+    assert safe_action_calls
+    options = safe_action_calls[0][1]
+    assert options[0] == pipeline_lab.PINNED_SAFE_ACTION_NEW
+    assert _safe_action_option_label(pinned_stage) in options
+    assert all("raw python" not in str(option) for option in options)
+
+
+def test_display_lab_tab_add_stage_reuses_selected_pinned_safe_action(monkeypatch, tmp_path):
+    pinned_stage = _safe_action_stage(pinned=True)
+    selected_label = _safe_action_option_label(pinned_stage)
+    saved = []
+    fake_st = _FakeStreamlit(
+        {
+            "demo": [0, "", "", "", "", "", 0],
+            "demo__run_sequence": [0],
+            "demo_new_q": "",
+        },
+        buttons={"demo_add_stage_btn": True},
+        selectboxes={"demo_safe_action_choice_add": selected_label},
+        multiselects={"demo_run_sequence_widget": [0]},
+    )
+    monkeypatch.setattr(pipeline_lab, "st", fake_st)
+    monkeypatch.setattr(pipeline_lab, "code_editor", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(pipeline_lab, "get_available_virtualenvs", lambda _env: [])
+    monkeypatch.setattr(pipeline_lab, "normalize_runtime_path", lambda raw: str(raw) if raw else "")
+    monkeypatch.setattr(pipeline_lab, "_is_valid_runtime_root", lambda raw: bool(raw))
+    monkeypatch.setattr(pipeline_lab, "get_existing_snippets", lambda *_args, **_kwargs: {})
+    monkeypatch.setattr(pipeline_lab, "get_custom_buttons", lambda: [])
+    monkeypatch.setattr(pipeline_lab, "get_info_bar", lambda: {})
+    monkeypatch.setattr(pipeline_lab, "get_css_text", lambda: {})
+
+    deps = _make_lab_deps(
+        load_all_stages=lambda *_args, **_kwargs: [pinned_stage],
+        load_pipeline_conceptual_dot=lambda *_args, **_kwargs: (None, None),
+        render_pipeline_view=lambda *_args, **_kwargs: None,
+        inspect_pipeline_run_lock=lambda *_args, **_kwargs: None,
+        ask_gpt=lambda *_args, **_kwargs: pytest.fail("pinned Safe Action reuse must not call the assistant"),
+        save_stage=lambda *args, **kwargs: saved.append((args, kwargs)),
+    )
+    env = SimpleNamespace(active_app=tmp_path / "flight_telemetry_project", envars={}, app="flight_telemetry_project")
+
+    pipeline_lab.display_lab_tab(tmp_path, "demo", tmp_path / "lab_stages.toml", tmp_path / "flight_telemetry_project", env, deps)
+
+    assert saved
+    args, kwargs = saved[-1]
+    assert args[2] == 1
+    assert args[1][1] == "keep Paris rows"
+    assert args[1][3] == pinned_stage["C"]
+    assert kwargs["extra_fields"][pipeline_lab.STAGE_SAFE_ACTION_PINNED_FIELD] is True
+    assert kwargs["extra_fields"][pipeline_lab.STAGE_ACTION_CONTRACT_FIELD] == pinned_stage[pipeline_lab.STAGE_ACTION_CONTRACT_FIELD]
+
+
+def test_display_lab_tab_pin_safe_action_persists_pinned_metadata(monkeypatch, tmp_path):
+    safe_stage = _safe_action_stage(pinned=False)
+    saved = []
+    reruns = []
+    fake_st = _FakeStreamlit(
+        {
+            "demo": [0, "", "", "", "", "", 0],
+            "demo__run_sequence": [0],
+        },
+        buttons={"demo_pin_safe_action_0": True},
+        multiselects={"demo_run_sequence_widget": [0]},
+    )
+    monkeypatch.setattr(pipeline_lab, "st", fake_st)
+    monkeypatch.setattr(pipeline_lab, "code_editor", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(pipeline_lab, "get_available_virtualenvs", lambda _env: [])
+    monkeypatch.setattr(pipeline_lab, "normalize_runtime_path", lambda raw: str(raw) if raw else "")
+    monkeypatch.setattr(pipeline_lab, "_is_valid_runtime_root", lambda raw: bool(raw))
+    monkeypatch.setattr(pipeline_lab, "get_existing_snippets", lambda *_args, **_kwargs: {})
+    monkeypatch.setattr(pipeline_lab, "get_custom_buttons", lambda: [])
+    monkeypatch.setattr(pipeline_lab, "get_info_bar", lambda: {})
+    monkeypatch.setattr(pipeline_lab, "get_css_text", lambda: {})
+
+    deps = _make_lab_deps(
+        load_all_stages=lambda *_args, **_kwargs: [safe_stage],
+        load_pipeline_conceptual_dot=lambda *_args, **_kwargs: (None, None),
+        render_pipeline_view=lambda *_args, **_kwargs: None,
+        inspect_pipeline_run_lock=lambda *_args, **_kwargs: None,
+        save_stage=lambda *args, **kwargs: saved.append((args, kwargs)),
+        rerun_fragment_or_app=lambda: reruns.append("fragment"),
+    )
+    env = SimpleNamespace(active_app=tmp_path / "flight_telemetry_project", envars={}, app="flight_telemetry_project")
+
+    pipeline_lab.display_lab_tab(tmp_path, "demo", tmp_path / "lab_stages.toml", tmp_path / "flight_telemetry_project", env, deps)
+
+    assert saved
+    args, kwargs = saved[-1]
+    assert args[1][3] == safe_stage["C"]
+    assert kwargs["extra_fields"][pipeline_lab.STAGE_SAFE_ACTION_PINNED_FIELD] is True
+    assert kwargs["extra_fields"][pipeline_lab.STAGE_ACTION_CONTRACT_FIELD] == safe_stage[pipeline_lab.STAGE_ACTION_CONTRACT_FIELD]
+    assert reruns == ["fragment"]
 
 
 def test_display_lab_tab_overlay_save_persists_editor_payload(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- add pinned Safe Action metadata and contract/schema hashes
- show an Existing Safe Action selectbox after Safe actions mode
- allow pinned contracts to be reused without another assistant call

## Validation
- uv --preview-features extra-build-dependencies run python -m pytest -q -o addopts='' test/test_generated_actions.py test/test_pipeline_lab.py::test_display_lab_tab_existing_stages_generates_new_stage test/test_pipeline_lab.py::test_display_lab_tab_existing_stages_warns_when_safe_action_generation_has_no_code test/test_pipeline_lab.py::test_display_lab_tab_lists_pinned_safe_actions_after_safe_mode test/test_pipeline_lab.py::test_display_lab_tab_add_stage_reuses_selected_pinned_safe_action test/test_pipeline_lab.py::test_display_lab_tab_pin_safe_action_persists_pinned_metadata test/test_pipeline_lab.py::test_display_lab_tab_existing_stage_run_button_generates_and_autofixes test/test_pipeline_lab.py::test_display_lab_tab_safe_generation_failure_keeps_existing_code