### PR TITLE
Populate Safe Action reuse list

### DIFF
--- a/src/agilab/generated_actions.py
+++ b/src/agilab/generated_actions.py
@@ -64,6 +64,63 @@ _ACTION_KEYS = {
     "rolling_mean": {"action", "input", "output", "window"},
     "clip": {"action", "input", "output", "lower", "upper"},
 }
+SAFE_ACTION_CATALOG = (
+    {
+        "action": "select_columns",
+        "label": "Select columns",
+        "prompt": "Select the dataframe columns needed for the next analysis step.",
+    },
+    {
+        "action": "drop_columns",
+        "label": "Drop columns",
+        "prompt": "Drop unnecessary dataframe columns while preserving the analysis target.",
+    },
+    {
+        "action": "rename_columns",
+        "label": "Rename columns",
+        "prompt": "Rename dataframe columns to clearer analysis-ready names.",
+    },
+    {
+        "action": "filter_rows",
+        "label": "Filter rows",
+        "prompt": "Filter rows using a column condition and keep only relevant observations.",
+    },
+    {
+        "action": "derive_column",
+        "label": "Derive column",
+        "prompt": "Create a derived dataframe column from an existing column.",
+    },
+    {
+        "action": "fill_missing",
+        "label": "Fill missing values",
+        "prompt": "Fill missing values in selected dataframe columns.",
+    },
+    {
+        "action": "drop_missing",
+        "label": "Drop missing rows",
+        "prompt": "Drop rows with missing values in the relevant dataframe columns.",
+    },
+    {
+        "action": "sort_rows",
+        "label": "Sort rows",
+        "prompt": "Sort dataframe rows by the columns that define the analysis order.",
+    },
+    {
+        "action": "groupby_aggregate",
+        "label": "Group and aggregate",
+        "prompt": "Group rows by one or more columns and compute aggregate metrics.",
+    },
+    {
+        "action": "rolling_mean",
+        "label": "Rolling mean",
+        "prompt": "Compute a rolling mean feature from an ordered numeric column.",
+    },
+    {
+        "action": "clip",
+        "label": "Clip values",
+        "prompt": "Clip numeric values to a safe lower and upper range.",
+    },
+)
 
 
 class GeneratedActionError(ValueError):
@@ -93,6 +150,10 @@ def dataframe_schema_for_prompt(df: pd.DataFrame | None, *, max_columns: int = 8
     for column in list(df.columns)[:max_columns]:
         rows.append({"name": str(column), "dtype": str(df[column].dtype)})
     return rows
+
+
+def safe_action_catalog_options() -> tuple[dict[str, str], ...]:
+    return tuple(dict(item) for item in SAFE_ACTION_CATALOG)
 
 
 def build_generated_actions_prompt(question: str, df: pd.DataFrame | None = None) -> str:

--- a/src/agilab/pipeline_lab.py
+++ b/src/agilab/pipeline_lab.py
@@ -80,6 +80,7 @@ GeneratedActionError = _generated_actions_module.GeneratedActionError
 pin_safe_action_extra_fields = _generated_actions_module.pin_safe_action_extra_fields
 safe_action_contract_sha256 = _generated_actions_module.safe_action_contract_sha256
 safe_action_contract_stage_code = _generated_actions_module.safe_action_contract_stage_code
+safe_action_catalog_options = _generated_actions_module.safe_action_catalog_options
 stage_generation_extra_fields = _generated_actions_module.stage_generation_extra_fields
 summarize_generated_actions = _generated_actions_module.summarize_generated_actions
 validate_generated_action_contract = _generated_actions_module.validate_generated_action_contract
@@ -90,6 +91,7 @@ GENERATION_MODE_LABELS = {
 }
 GENERATION_MODE_BY_LABEL = {label: mode for mode, label in GENERATION_MODE_LABELS.items()}
 PINNED_SAFE_ACTION_NEW = "Generate new Safe Action"
+SAFE_ACTION_TEMPLATE_PREFIX = "Template: "
 SNIPPET_EDITOR_HEIGHT = 420
 
 
@@ -113,14 +115,12 @@ def _safe_action_contract_payload(raw_contract: Any) -> dict[str, Any] | None:
         return None
 
 
-def _pinned_safe_actions_from_stages(stages: List[Mapping[str, Any]]) -> List[_PinnedSafeAction]:
-    pinned_actions: List[_PinnedSafeAction] = []
+def _existing_safe_actions_from_stages(stages: List[Mapping[str, Any]]) -> List[_PinnedSafeAction]:
+    existing_actions: List[_PinnedSafeAction] = []
     for stage_index, entry in enumerate(stages):
         if not isinstance(entry, Mapping):
             continue
         if entry.get(STAGE_GENERATION_MODE_FIELD) != GENERATION_MODE_SAFE_ACTIONS:
-            continue
-        if not bool(entry.get(STAGE_SAFE_ACTION_PINNED_FIELD)):
             continue
         contract = _safe_action_contract_payload(entry.get(STAGE_ACTION_CONTRACT_FIELD))
         if contract is None:
@@ -128,10 +128,11 @@ def _pinned_safe_actions_from_stages(stages: List[Mapping[str, Any]]) -> List[_P
         detail = summarize_generated_actions(contract)
         digest = str(entry.get(STAGE_ACTION_CONTRACT_SHA256_FIELD) or safe_action_contract_sha256(contract))
         suffix = f" ({digest[:8]})" if digest else ""
-        pinned_actions.append(
+        state = "pinned" if bool(entry.get(STAGE_SAFE_ACTION_PINNED_FIELD)) else "saved"
+        existing_actions.append(
             _PinnedSafeAction(
                 stage_index=stage_index,
-                label=f"Stage {stage_index + 1}: {detail}{suffix}",
+                label=f"Stage {stage_index + 1} [{state}]: {detail}{suffix}",
                 question=str(entry.get("Q") or detail),
                 detail=detail,
                 model=str(entry.get("M") or "pinned-safe-action"),
@@ -139,7 +140,7 @@ def _pinned_safe_actions_from_stages(stages: List[Mapping[str, Any]]) -> List[_P
                 code=safe_action_contract_stage_code(contract),
             )
         )
-    return pinned_actions
+    return existing_actions
 
 _pipeline_page_state_module = import_agilab_module(
     "agilab.pipeline_page_state",
@@ -3430,17 +3431,19 @@ def display_lab_tab(
         labels = list(GENERATION_MODE_LABELS.values())
         mode = existing_mode if existing_mode in GENERATION_MODE_LABELS else GENERATION_MODE_SAFE_ACTIONS
         default_label = GENERATION_MODE_LABELS[mode]
-        select_kwargs: Dict[str, Any] = {
-            "key": key,
-            "help": (
+        if st.session_state.get(key) not in labels:
+            st.session_state[key] = default_label
+        selected_label = compact_choice(
+            st,
+            "Generation mode",
+            labels,
+            key=key,
+            help=(
                 "Safe actions asks the model for a validated JSON action contract. "
                 "Python snippet is for advanced manual code generation."
             ),
-        }
-        if st.session_state.get(key) not in labels:
-            st.session_state.pop(key, None)
-            select_kwargs["index"] = labels.index(default_label)
-        selected_label = st.selectbox("Generation mode", labels, **select_kwargs)
+            inline_limit=4,
+        )
         selected_mode = GENERATION_MODE_BY_LABEL.get(str(selected_label), GENERATION_MODE_SAFE_ACTIONS)
         if selected_mode == GENERATION_MODE_SAFE_ACTIONS:
             st.caption("Safe actions: model JSON is validated, then AGILAB writes deterministic pandas code.")
@@ -3467,26 +3470,45 @@ def display_lab_tab(
         return loaded if isinstance(loaded, pd.DataFrame) else None
 
     def _render_pinned_safe_action_selectbox(key: str) -> _PinnedSafeAction | None:
-        if not pinned_safe_actions:
-            st.caption("No pinned Safe Actions yet. Pin a generated Safe Action stage to reuse it here.")
-            return None
-        options = [PINNED_SAFE_ACTION_NEW] + [action.label for action in pinned_safe_actions]
+        catalog_by_label = {
+            f"{SAFE_ACTION_TEMPLATE_PREFIX}{item['label']}": item
+            for item in safe_action_catalog_options()
+        }
+        options = [
+            PINNED_SAFE_ACTION_NEW,
+            *[action.label for action in existing_safe_actions],
+            *catalog_by_label,
+        ]
         select_kwargs: Dict[str, Any] = {
             "key": key,
             "help": (
-                "Reuse a pinned validated Safe Action contract from this workflow. "
-                "Raw Python snippets are not listed here."
+                "Reuse a saved validated Safe Action contract, or start from a built-in Safe Action template. "
+                "Raw Python snippets are excluded."
             ),
         }
         if st.session_state.get(key) not in options:
             st.session_state.pop(key, None)
             select_kwargs["index"] = 0
         selected = st.selectbox("Existing Safe Action", options, **select_kwargs)
-        for action in pinned_safe_actions:
+        for action in existing_safe_actions:
             if selected == action.label:
-                st.caption(f"Reusing pinned Safe Action from stage {action.stage_index + 1}.")
+                st.session_state.pop(f"{key}__template_prompt", None)
+                st.caption(f"Reusing existing Safe Action from stage {action.stage_index + 1}.")
                 return action
+        template = catalog_by_label.get(str(selected))
+        if template:
+            st.session_state[f"{key}__template_prompt"] = str(template.get("prompt") or "")
+            st.caption(f"{selected}. Edit the prompt below, then generate a validated Safe Action.")
+            return None
+        st.session_state.pop(f"{key}__template_prompt", None)
+        if not existing_safe_actions:
+            st.caption("No saved Safe Actions yet; choose a template or write a prompt.")
         return None
+
+    def _seed_safe_action_template_prompt(selection_key: str, prompt_key: str) -> None:
+        template_prompt = str(st.session_state.get(f"{selection_key}__template_prompt") or "").strip()
+        if template_prompt and not str(st.session_state.get(prompt_key) or "").strip():
+            st.session_state[prompt_key] = template_prompt
 
     def _answer_from_pinned_safe_action(action: _PinnedSafeAction, df_path: Path) -> List[Any]:
         return [
@@ -3552,7 +3574,7 @@ def display_lab_tab(
                 persisted_stages = [s for s in fallback_stages if _is_displayable_stage(s)]
         except (AttributeError, OSError, TypeError, tomllib.TOMLDecodeError):
             pass
-    pinned_safe_actions = _pinned_safe_actions_from_stages(persisted_stages)
+    existing_safe_actions = _existing_safe_actions_from_stages(persisted_stages)
     total_stages = len(persisted_stages)
     safe_prefix = index_page_str.replace("/", "_")
     total_stages_key = f"{safe_prefix}_total_stages"
@@ -3648,6 +3670,7 @@ def display_lab_tab(
                     if generation_mode == GENERATION_MODE_SAFE_ACTIONS
                     else None
                 )
+                _seed_safe_action_template_prompt(f"{safe_prefix}_safe_action_choice_first", new_q_key)
                 st.text_area(
                     "Ask code generator:",
                     key=new_q_key,
@@ -4017,6 +4040,7 @@ def display_lab_tab(
                 if generation_mode == GENERATION_MODE_SAFE_ACTIONS
                 else None
             )
+            _seed_safe_action_template_prompt(f"{safe_prefix}_safe_action_choice_{stage}", q_key)
             current_contract = _safe_action_contract_payload(entry.get(STAGE_ACTION_CONTRACT_FIELD))
             if current_contract is not None:
                 current_safe_action_pinned = bool(entry.get(STAGE_SAFE_ACTION_PINNED_FIELD))
@@ -4596,6 +4620,7 @@ def display_lab_tab(
                 if generation_mode == GENERATION_MODE_SAFE_ACTIONS
                 else None
             )
+            _seed_safe_action_template_prompt(f"{safe_prefix}_safe_action_choice_add", new_q_key)
             st.text_area(
                 "Ask code generator:",
                 key=new_q_key,

--- a/test/test_generated_actions.py
+++ b/test/test_generated_actions.py
@@ -36,6 +36,7 @@ dataframe_schema_for_prompt = generated_actions.dataframe_schema_for_prompt
 dataframe_schema_sha256 = generated_actions.dataframe_schema_sha256
 pin_safe_action_extra_fields = generated_actions.pin_safe_action_extra_fields
 safe_action_contract_sha256 = generated_actions.safe_action_contract_sha256
+safe_action_catalog_options = generated_actions.safe_action_catalog_options
 safe_action_contract_stage_code = generated_actions.safe_action_contract_stage_code
 stage_generation_extra_fields = generated_actions.stage_generation_extra_fields
 summarize_generated_actions = generated_actions.summarize_generated_actions
@@ -198,6 +199,25 @@ def test_dataframe_schema_for_prompt_returns_empty_for_invalid_payload() -> None
     assert dataframe_schema_for_prompt(None) == []
     df = pd.DataFrame({"a": [1], "b": ["x"]})
     assert dataframe_schema_for_prompt(df, max_columns=1) == [{"name": "a", "dtype": "int64"}]
+
+
+def test_safe_action_catalog_exposes_supported_templates() -> None:
+    options = safe_action_catalog_options()
+
+    assert {item["action"] for item in options} == {
+        "select_columns",
+        "drop_columns",
+        "rename_columns",
+        "filter_rows",
+        "derive_column",
+        "fill_missing",
+        "drop_missing",
+        "sort_rows",
+        "groupby_aggregate",
+        "rolling_mean",
+        "clip",
+    }
+    assert all(item["label"] and item["prompt"] for item in options)
 
 
 def test_parse_generated_action_contract_can_extract_json_codeblock() -> None:

--- a/test/test_pipeline_lab.py
+++ b/test/test_pipeline_lab.py
@@ -305,7 +305,8 @@ def _safe_action_stage(*, pinned: bool, question: str = "keep Paris rows") -> di
 
 def _safe_action_option_label(stage: dict[str, Any], *, stage_index: int = 0) -> str:
     digest = str(stage[pipeline_lab.STAGE_ACTION_CONTRACT_SHA256_FIELD])[:8]
-    return f"Stage {stage_index + 1}: Safe action contract: filter rows. ({digest})"
+    state = "pinned" if bool(stage[pipeline_lab.STAGE_SAFE_ACTION_PINNED_FIELD]) else "saved"
+    return f"Stage {stage_index + 1} [{state}]: Safe action contract: filter rows. ({digest})"
 
 
 def test_valid_runtime_path_rejects_non_runtime_roots(monkeypatch):
@@ -3419,6 +3420,25 @@ def test_display_lab_tab_empty_pipeline_renders_generator_form(monkeypatch, tmp_
     assert fake_st.session_state["demo_new_q"] == ""
 
 
+def test_display_lab_tab_empty_pipeline_populates_safe_action_templates(monkeypatch, tmp_path):
+    fake_st = _FakeStreamlit({"demo": [0, "", "", "", "", "", 0]})
+    monkeypatch.setattr(pipeline_lab, "st", fake_st)
+    monkeypatch.setattr(pipeline_lab, "get_available_virtualenvs", lambda _env: [])
+    monkeypatch.setattr(pipeline_lab, "normalize_runtime_path", lambda raw: str(raw) if raw else "")
+
+    env = SimpleNamespace(active_app=tmp_path / "flight_telemetry_project", envars={}, app="flight_telemetry_project")
+    deps = _make_lab_deps()
+
+    pipeline_lab.display_lab_tab(tmp_path, "demo", tmp_path / "lab_stages.toml", tmp_path / "flight_telemetry_project", env, deps)
+
+    safe_action_calls = [call for call in fake_st.selectbox_calls if call[0] == "Existing Safe Action"]
+    assert safe_action_calls
+    options = safe_action_calls[0][1]
+    assert pipeline_lab.PINNED_SAFE_ACTION_NEW in options
+    assert f"{pipeline_lab.SAFE_ACTION_TEMPLATE_PREFIX}Filter rows" in options
+    assert f"{pipeline_lab.SAFE_ACTION_TEMPLATE_PREFIX}Group and aggregate" in options
+
+
 def test_display_lab_tab_loads_selected_dataframe_without_index_inference(monkeypatch, tmp_path):
     calls: list[tuple[Path, bool | None]] = []
     df_path = tmp_path / "export.csv"
@@ -4525,8 +4545,8 @@ def test_display_lab_tab_existing_stages_warns_when_safe_action_generation_has_n
     assert ("warning", "The assistant did not return runnable stage code.") in fake_st.messages
 
 
-def test_display_lab_tab_lists_pinned_safe_actions_after_safe_mode(monkeypatch, tmp_path):
-    pinned_stage = _safe_action_stage(pinned=True)
+def test_display_lab_tab_lists_saved_safe_actions_after_safe_mode(monkeypatch, tmp_path):
+    safe_stage = _safe_action_stage(pinned=False)
     raw_stage = {
         "D": "",
         "Q": "raw python",
@@ -4534,7 +4554,7 @@ def test_display_lab_tab_lists_pinned_safe_actions_after_safe_mode(monkeypatch, 
         "C": "print('raw')",
         "E": "",
         pipeline_lab.STAGE_GENERATION_MODE_FIELD: pipeline_lab.GENERATION_MODE_PYTHON_SNIPPET,
-        pipeline_lab.STAGE_ACTION_CONTRACT_FIELD: pinned_stage[pipeline_lab.STAGE_ACTION_CONTRACT_FIELD],
+        pipeline_lab.STAGE_ACTION_CONTRACT_FIELD: safe_stage[pipeline_lab.STAGE_ACTION_CONTRACT_FIELD],
         pipeline_lab.STAGE_SAFE_ACTION_PINNED_FIELD: True,
     }
     fake_st = _FakeStreamlit(
@@ -4555,7 +4575,7 @@ def test_display_lab_tab_lists_pinned_safe_actions_after_safe_mode(monkeypatch, 
     monkeypatch.setattr(pipeline_lab, "get_css_text", lambda: {})
 
     deps = _make_lab_deps(
-        load_all_stages=lambda *_args, **_kwargs: [pinned_stage, raw_stage],
+        load_all_stages=lambda *_args, **_kwargs: [safe_stage, raw_stage],
         load_pipeline_conceptual_dot=lambda *_args, **_kwargs: (None, None),
         render_pipeline_view=lambda *_args, **_kwargs: None,
         inspect_pipeline_run_lock=lambda *_args, **_kwargs: None,
@@ -4568,7 +4588,7 @@ def test_display_lab_tab_lists_pinned_safe_actions_after_safe_mode(monkeypatch, 
     assert safe_action_calls
     options = safe_action_calls[0][1]
     assert options[0] == pipeline_lab.PINNED_SAFE_ACTION_NEW
-    assert _safe_action_option_label(pinned_stage) in options
+    assert _safe_action_option_label(safe_stage) in options
     assert all("raw python" not in str(option) for option in options)
 
 


### PR DESCRIPTION
## Summary
- list saved Safe Action contracts even when they are not pinned
- populate the Safe Action selector with built-in validated-action templates
- keep the generation-mode widget as the compact Safe actions / Python snippet control

## Validation
- uv --preview-features extra-build-dependencies run python -m pytest -q -o addopts='' test/test_generated_actions.py test/test_pipeline_lab.py::test_display_lab_tab_empty_pipeline_renders_generator_form test/test_pipeline_lab.py::test_display_lab_tab_empty_pipeline_populates_safe_action_templates test/test_pipeline_lab.py::test_display_lab_tab_existing_stages_generates_new_stage test/test_pipeline_lab.py::test_display_lab_tab_existing_stages_warns_when_safe_action_generation_has_no_code test/test_pipeline_lab.py::test_display_lab_tab_lists_saved_safe_actions_after_safe_mode test/test_pipeline_lab.py::test_display_lab_tab_add_stage_reuses_selected_pinned_safe_action test/test_pipeline_lab.py::test_display_lab_tab_pin_safe_action_persists_pinned_metadata test/test_pipeline_lab.py::test_display_lab_tab_existing_stage_run_button_generates_and_autofixes test/test_pipeline_lab.py::test_display_lab_tab_safe_generation_failure_keeps_existing_code