### PR TITLE
Hydrate Safe Action editor templates

### DIFF
--- a/src/agilab/generated_actions.py
+++ b/src/agilab/generated_actions.py
@@ -156,6 +156,111 @@ def safe_action_catalog_options() -> tuple[dict[str, str], ...]:
     return tuple(dict(item) for item in SAFE_ACTION_CATALOG)
 
 
+def safe_action_template_code(action_name: str) -> str:
+    action = str(action_name or "").strip()
+    labels = {str(item["action"]): str(item["label"]) for item in SAFE_ACTION_CATALOG}
+    label = labels.get(action)
+    if label is None:
+        raise GeneratedActionError(f"unsupported safe action template: {action!r}")
+    template_body = {
+        "select_columns": (
+            'columns = ["column_a", "column_b"]\n'
+            "missing = [column for column in columns if column not in df.columns]\n"
+            "if missing:\n"
+            '    raise KeyError(f"Unknown dataframe column(s): {missing}")\n'
+            "df = df[columns].copy()\n"
+        ),
+        "drop_columns": (
+            'columns = ["column_to_drop"]\n'
+            "missing = [column for column in columns if column not in df.columns]\n"
+            "if missing:\n"
+            '    raise KeyError(f"Unknown dataframe column(s): {missing}")\n'
+            "df = df.drop(columns=columns).copy()\n"
+        ),
+        "rename_columns": (
+            'mapping = {"old_column": "new_column"}\n'
+            "missing = [column for column in mapping if column not in df.columns]\n"
+            "if missing:\n"
+            '    raise KeyError(f"Unknown dataframe column(s): {missing}")\n'
+            "df = df.rename(columns=mapping).copy()\n"
+        ),
+        "filter_rows": (
+            'column = "column_name"\n'
+            'value = "value"\n'
+            "if column not in df.columns:\n"
+            '    raise KeyError(f"Unknown dataframe column: {column}")\n'
+            "df = df[df[column] == value].copy()\n"
+        ),
+        "derive_column": (
+            'input_column = "source_column"\n'
+            'output_column = "derived_column"\n'
+            "scale = 1.0\n"
+            "if input_column not in df.columns:\n"
+            '    raise KeyError(f"Unknown dataframe column: {input_column}")\n'
+            "df = df.copy()\n"
+            "df[output_column] = df[input_column] * scale\n"
+        ),
+        "fill_missing": (
+            'columns = ["column_name"]\n'
+            "fill_value = 0\n"
+            "missing = [column for column in columns if column not in df.columns]\n"
+            "if missing:\n"
+            '    raise KeyError(f"Unknown dataframe column(s): {missing}")\n'
+            "df = df.copy()\n"
+            "df[columns] = df[columns].fillna(fill_value)\n"
+        ),
+        "drop_missing": (
+            'columns = ["column_name"]\n'
+            "missing = [column for column in columns if column not in df.columns]\n"
+            "if missing:\n"
+            '    raise KeyError(f"Unknown dataframe column(s): {missing}")\n'
+            "df = df.dropna(subset=columns).copy()\n"
+        ),
+        "sort_rows": (
+            'columns = ["column_name"]\n'
+            "ascending = True\n"
+            "missing = [column for column in columns if column not in df.columns]\n"
+            "if missing:\n"
+            '    raise KeyError(f"Unknown dataframe column(s): {missing}")\n'
+            "df = df.sort_values(by=columns, ascending=ascending).reset_index(drop=True)\n"
+        ),
+        "groupby_aggregate": (
+            'group_columns = ["group_column"]\n'
+            'aggregations = {"metric_column": "mean"}\n'
+            "required = [*group_columns, *aggregations.keys()]\n"
+            "missing = [column for column in required if column not in df.columns]\n"
+            "if missing:\n"
+            '    raise KeyError(f"Unknown dataframe column(s): {missing}")\n'
+            "df = df.groupby(group_columns, dropna=False).agg(aggregations).reset_index()\n"
+        ),
+        "rolling_mean": (
+            'input_column = "metric_column"\n'
+            'output_column = "metric_rolling_mean"\n'
+            "window = 3\n"
+            "if input_column not in df.columns:\n"
+            '    raise KeyError(f"Unknown dataframe column: {input_column}")\n'
+            "df = df.copy()\n"
+            "df[output_column] = df[input_column].rolling(window=window, min_periods=1).mean()\n"
+        ),
+        "clip": (
+            'input_column = "metric_column"\n'
+            "output_column = input_column\n"
+            "lower = 0\n"
+            "upper = 1\n"
+            "if input_column not in df.columns:\n"
+            '    raise KeyError(f"Unknown dataframe column: {input_column}")\n'
+            "df = df.copy()\n"
+            "df[output_column] = df[input_column].clip(lower=lower, upper=upper)\n"
+        ),
+    }[action]
+    return (
+        f"# AGILAB Safe Action template: {label}.\n"
+        "# Replace placeholder column/value names or click Gen code to create a validated Safe Action contract.\n"
+        "# The final saved Safe Action should come from AGILAB's validated JSON contract.\n"
+        f"{template_body}"
+    )
+
+
 def build_generated_actions_prompt(question: str, df: pd.DataFrame | None = None) -> str:
     schema = dataframe_schema_for_prompt(df)
     schema_text = json.dumps(schema, ensure_ascii=False, indent=2)

--- a/src/agilab/pipeline_lab.py
+++ b/src/agilab/pipeline_lab.py
@@ -81,6 +81,7 @@ pin_safe_action_extra_fields = _generated_actions_module.pin_safe_action_extra_f
 safe_action_contract_sha256 = _generated_actions_module.safe_action_contract_sha256
 safe_action_contract_stage_code = _generated_actions_module.safe_action_contract_stage_code
 safe_action_catalog_options = _generated_actions_module.safe_action_catalog_options
+safe_action_template_code = _generated_actions_module.safe_action_template_code
 stage_generation_extra_fields = _generated_actions_module.stage_generation_extra_fields
 summarize_generated_actions = _generated_actions_module.summarize_generated_actions
 validate_generated_action_contract = _generated_actions_module.validate_generated_action_contract
@@ -3490,14 +3491,32 @@ def display_lab_tab(
             st.session_state.pop(key, None)
             select_kwargs["index"] = 0
         selected = st.selectbox("Existing Safe Action", options, **select_kwargs)
+        selected_text = str(selected)
+        last_selected_key = f"{key}__last_selected"
+        selection_changed = st.session_state.get(last_selected_key) != selected_text
+        st.session_state[last_selected_key] = selected_text
         for action in existing_safe_actions:
-            if selected == action.label:
+            if selected_text == action.label:
                 st.session_state.pop(f"{key}__template_prompt", None)
+                st.session_state[f"{key}__safe_action_code"] = action.code
+                st.session_state[f"{key}__safe_action_question"] = action.question
+                st.session_state[f"{key}__safe_action_changed"] = selection_changed
                 st.caption(f"Reusing existing Safe Action from stage {action.stage_index + 1}.")
                 return action
-        template = catalog_by_label.get(str(selected))
+        st.session_state.pop(f"{key}__safe_action_code", None)
+        st.session_state.pop(f"{key}__safe_action_question", None)
+        st.session_state[f"{key}__safe_action_changed"] = False
+        template = catalog_by_label.get(selected_text)
         if template:
-            st.session_state[f"{key}__template_prompt"] = str(template.get("prompt") or "")
+            prompt = str(template.get("prompt") or "")
+            try:
+                template_code = safe_action_template_code(str(template.get("action") or ""))
+            except GeneratedActionError:
+                template_code = ""
+            st.session_state[f"{key}__template_prompt"] = prompt
+            st.session_state[f"{key}__safe_action_code"] = template_code
+            st.session_state[f"{key}__safe_action_question"] = prompt
+            st.session_state[f"{key}__safe_action_changed"] = selection_changed
             st.caption(f"{selected}. Edit the prompt below, then generate a validated Safe Action.")
             return None
         st.session_state.pop(f"{key}__template_prompt", None)
@@ -3509,6 +3528,25 @@ def display_lab_tab(
         template_prompt = str(st.session_state.get(f"{selection_key}__template_prompt") or "").strip()
         if template_prompt and not str(st.session_state.get(prompt_key) or "").strip():
             st.session_state[prompt_key] = template_prompt
+
+    def _hydrate_selected_safe_action_editor(
+        selection_key: str,
+        *,
+        q_key: str,
+        code_val_key: str,
+        rev_key: str,
+    ) -> None:
+        if not st.session_state.get(f"{selection_key}__safe_action_changed"):
+            return
+        code = str(st.session_state.get(f"{selection_key}__safe_action_code") or "")
+        if not code.strip():
+            return
+        question = str(st.session_state.get(f"{selection_key}__safe_action_question") or "").strip()
+        if question:
+            st.session_state[q_key] = question
+        st.session_state[code_val_key] = code
+        st.session_state[rev_key] = st.session_state.get(rev_key, 0) + 1
+        st.session_state[f"{selection_key}__safe_action_changed"] = False
 
     def _answer_from_pinned_safe_action(action: _PinnedSafeAction, df_path: Path) -> List[Any]:
         return [
@@ -4041,6 +4079,12 @@ def display_lab_tab(
                 else None
             )
             _seed_safe_action_template_prompt(f"{safe_prefix}_safe_action_choice_{stage}", q_key)
+            _hydrate_selected_safe_action_editor(
+                f"{safe_prefix}_safe_action_choice_{stage}",
+                q_key=q_key,
+                code_val_key=code_val_key,
+                rev_key=rev_key,
+            )
             current_contract = _safe_action_contract_payload(entry.get(STAGE_ACTION_CONTRACT_FIELD))
             if current_contract is not None:
                 current_safe_action_pinned = bool(entry.get(STAGE_SAFE_ACTION_PINNED_FIELD))

--- a/test/test_generated_actions.py
+++ b/test/test_generated_actions.py
@@ -38,6 +38,7 @@ pin_safe_action_extra_fields = generated_actions.pin_safe_action_extra_fields
 safe_action_contract_sha256 = generated_actions.safe_action_contract_sha256
 safe_action_catalog_options = generated_actions.safe_action_catalog_options
 safe_action_contract_stage_code = generated_actions.safe_action_contract_stage_code
+safe_action_template_code = generated_actions.safe_action_template_code
 stage_generation_extra_fields = generated_actions.stage_generation_extra_fields
 summarize_generated_actions = generated_actions.summarize_generated_actions
 validate_generated_action_contract = generated_actions.validate_generated_action_contract
@@ -218,6 +219,13 @@ def test_safe_action_catalog_exposes_supported_templates() -> None:
         "clip",
     }
     assert all(item["label"] and item["prompt"] for item in options)
+    filter_template = safe_action_template_code("filter_rows")
+    assert "AGILAB Safe Action template: Filter rows" in filter_template
+    assert 'column = "column_name"' in filter_template
+    assert "df = df[df[column] == value].copy()" in filter_template
+    assert "intentionally a no-op" not in filter_template
+    with pytest.raises(GeneratedActionError, match="unsupported safe action template"):
+        safe_action_template_code("raw_python")
 
 
 def test_parse_generated_action_contract_can_extract_json_codeblock() -> None:

--- a/test/test_pipeline_lab.py
+++ b/test/test_pipeline_lab.py
@@ -4592,6 +4592,102 @@ def test_display_lab_tab_lists_saved_safe_actions_after_safe_mode(monkeypatch, t
     assert all("raw python" not in str(option) for option in options)
 
 
+def test_display_lab_tab_selected_safe_action_populates_existing_code_editor(monkeypatch, tmp_path):
+    safe_stage = _safe_action_stage(pinned=True, question="keep Paris rows")
+    editable_stage = {
+        "D": "",
+        "Q": "old prompt",
+        "M": "model",
+        "C": "print('old')",
+        "E": "",
+        pipeline_lab.STAGE_GENERATION_MODE_FIELD: pipeline_lab.GENERATION_MODE_SAFE_ACTIONS,
+        pipeline_lab.STAGE_ACTION_CONTRACT_FIELD: None,
+        pipeline_lab.STAGE_SAFE_ACTION_PINNED_FIELD: False,
+    }
+    selected_label = _safe_action_option_label(safe_stage, stage_index=1)
+    editor_bodies = []
+    fake_st = _FakeStreamlit(
+        {
+            "demo": [0, "", "", "", "", "", 0],
+            "demo__run_sequence": [0, 1],
+        },
+        selectboxes={"demo_safe_action_choice_0": selected_label},
+        multiselects={"demo_run_sequence_widget": [0, 1]},
+    )
+    monkeypatch.setattr(pipeline_lab, "st", fake_st)
+    monkeypatch.setattr(pipeline_lab, "code_editor", lambda body, **_kwargs: editor_bodies.append(str(body)) or None)
+    monkeypatch.setattr(pipeline_lab, "get_available_virtualenvs", lambda _env: [])
+    monkeypatch.setattr(pipeline_lab, "normalize_runtime_path", lambda raw: str(raw) if raw else "")
+    monkeypatch.setattr(pipeline_lab, "_is_valid_runtime_root", lambda raw: bool(raw))
+    monkeypatch.setattr(pipeline_lab, "get_existing_snippets", lambda *_args, **_kwargs: {})
+    monkeypatch.setattr(pipeline_lab, "get_custom_buttons", lambda: [])
+    monkeypatch.setattr(pipeline_lab, "get_info_bar", lambda: {})
+    monkeypatch.setattr(pipeline_lab, "get_css_text", lambda: {})
+
+    deps = _make_lab_deps(
+        load_all_stages=lambda *_args, **_kwargs: [editable_stage, safe_stage],
+        load_pipeline_conceptual_dot=lambda *_args, **_kwargs: (None, None),
+        render_pipeline_view=lambda *_args, **_kwargs: None,
+        inspect_pipeline_run_lock=lambda *_args, **_kwargs: None,
+    )
+    env = SimpleNamespace(active_app=tmp_path / "flight_telemetry_project", envars={}, app="flight_telemetry_project")
+
+    pipeline_lab.display_lab_tab(tmp_path, "demo", tmp_path / "lab_stages.toml", tmp_path / "flight_telemetry_project", env, deps)
+
+    assert fake_st.session_state["demo_q_stage_0"] == "keep Paris rows"
+    assert fake_st.session_state["demo_code_stage_0"] == safe_stage["C"]
+    assert editor_bodies[0] == safe_stage["C"]
+
+
+def test_display_lab_tab_selected_safe_action_template_populates_existing_code_editor(monkeypatch, tmp_path):
+    editable_stage = {
+        "D": "",
+        "Q": "old prompt",
+        "M": "model",
+        "C": "print('old')",
+        "E": "",
+        pipeline_lab.STAGE_GENERATION_MODE_FIELD: pipeline_lab.GENERATION_MODE_SAFE_ACTIONS,
+        pipeline_lab.STAGE_ACTION_CONTRACT_FIELD: None,
+        pipeline_lab.STAGE_SAFE_ACTION_PINNED_FIELD: False,
+    }
+    selected_label = f"{pipeline_lab.SAFE_ACTION_TEMPLATE_PREFIX}Filter rows"
+    editor_bodies = []
+    fake_st = _FakeStreamlit(
+        {
+            "demo": [0, "", "", "", "", "", 0],
+            "demo__run_sequence": [0],
+        },
+        selectboxes={"demo_safe_action_choice_0": selected_label},
+        multiselects={"demo_run_sequence_widget": [0]},
+    )
+    monkeypatch.setattr(pipeline_lab, "st", fake_st)
+    monkeypatch.setattr(pipeline_lab, "code_editor", lambda body, **_kwargs: editor_bodies.append(str(body)) or None)
+    monkeypatch.setattr(pipeline_lab, "get_available_virtualenvs", lambda _env: [])
+    monkeypatch.setattr(pipeline_lab, "normalize_runtime_path", lambda raw: str(raw) if raw else "")
+    monkeypatch.setattr(pipeline_lab, "_is_valid_runtime_root", lambda raw: bool(raw))
+    monkeypatch.setattr(pipeline_lab, "get_existing_snippets", lambda *_args, **_kwargs: {})
+    monkeypatch.setattr(pipeline_lab, "get_custom_buttons", lambda: [])
+    monkeypatch.setattr(pipeline_lab, "get_info_bar", lambda: {})
+    monkeypatch.setattr(pipeline_lab, "get_css_text", lambda: {})
+
+    deps = _make_lab_deps(
+        load_all_stages=lambda *_args, **_kwargs: [editable_stage],
+        load_pipeline_conceptual_dot=lambda *_args, **_kwargs: (None, None),
+        render_pipeline_view=lambda *_args, **_kwargs: None,
+        inspect_pipeline_run_lock=lambda *_args, **_kwargs: None,
+    )
+    env = SimpleNamespace(active_app=tmp_path / "sb3_trainer_project", envars={}, app="sb3_trainer_project")
+
+    pipeline_lab.display_lab_tab(tmp_path, "demo", tmp_path / "lab_stages.toml", tmp_path / "sb3_trainer_project", env, deps)
+
+    assert fake_st.session_state["demo_q_stage_0"] == "Filter rows using a column condition and keep only relevant observations."
+    assert "AGILAB Safe Action template: Filter rows" in fake_st.session_state["demo_code_stage_0"]
+    assert 'column = "column_name"' in fake_st.session_state["demo_code_stage_0"]
+    assert "df = df[df[column] == value].copy()" in fake_st.session_state["demo_code_stage_0"]
+    assert "intentionally a no-op" not in fake_st.session_state["demo_code_stage_0"]
+    assert editor_bodies[0] == fake_st.session_state["demo_code_stage_0"]
+
+
 def test_display_lab_tab_add_stage_reuses_selected_pinned_safe_action(monkeypatch, tmp_path):
     pinned_stage = _safe_action_stage(pinned=True)
     selected_label = _safe_action_option_label(pinned_stage)


### PR DESCRIPTION
## Summary
- populate existing-stage prompt and code editor when a saved or pinned Safe Action is selected
- make built-in Safe Action templates populate action-specific editable skeleton code
- prevent the old no-op template preview from passing regressions

## Validation
- uv --preview-features extra-build-dependencies run python -m pytest -q -o addopts='' test/test_generated_actions.py test/test_pipeline_lab.py::test_display_lab_tab_empty_pipeline_populates_safe_action_templates test/test_pipeline_lab.py::test_display_lab_tab_lists_saved_safe_actions_after_safe_mode test/test_pipeline_lab.py::test_display_lab_tab_selected_safe_action_populates_existing_code_editor test/test_pipeline_lab.py::test_display_lab_tab_selected_safe_action_template_populates_existing_code_editor test/test_pipeline_lab.py::test_display_lab_tab_add_stage_reuses_selected_pinned_safe_action test/test_pipeline_lab.py::test_display_lab_tab_pin_safe_action_persists_pinned_metadata test/test_pipeline_lab.py::test_display_lab_tab_existing_stage_run_button_generates_and_autofixes test/test_pipeline_lab.py::test_display_lab_tab_safe_generation_failure_keeps_existing_code