### PR TITLE
Increase PROJECT sidebar coverage

### DIFF
--- a/src/agilab/about_page/onboarding.py
+++ b/src/agilab/about_page/onboarding.py
@@ -864,7 +864,7 @@ def _first_proof_handoff_bundle_caption(rows: List[Dict[str, str]]) -> str:
 
 
 def _first_proof_notebook_query_params(env: Any, state: Dict[str, Any]) -> Dict[str, str]:
-    """Return query params that open PROJECT on the notebook-import create path."""
+    """Return query params that open PROJECT_STATUS on the notebook-import create path."""
     query_params = dict(FIRST_PROOF_NOTEBOOK_QUERY_PARAMS)
     query_params[FIRST_PROOF_NOTEBOOK_SAMPLE_QUERY_KEY] = FIRST_PROOF_NOTEBOOK_SAMPLE_QUERY_VALUE
     active_app = str(state.get("active_app_name") or getattr(env, "app", "") or "").strip()

--- a/src/agilab/main_page.py
+++ b/src/agilab/main_page.py
@@ -582,7 +582,7 @@ def _active_app_readme_path(env: Any | None) -> Path | None:
 
 
 def _sidebar_readme_url(env: Any | None, readme_path: Path) -> str:
-    return f"/PROJECT?{urlencode(_sidebar_readme_query_params(env, readme_path))}"
+    return f"/PROJECT_EDIT?{urlencode(_sidebar_readme_query_params(env, readme_path))}"
 
 
 def _sidebar_readme_query_params(env: Any | None, readme_path: Path) -> dict[str, str]:
@@ -1122,15 +1122,21 @@ def _navigation_pages() -> list[Any]:
         visibility="hidden",
     )
     project_page = st.Page(
+        _page_file_runner(pages_root / "1_PROJECT_STATUS.py"),
+        title="PROJECT",
+        url_path="PROJECT",
+    )
+    project_edit_page = st.Page(
         _page_file_runner(pages_root / "1_PROJECT.py"),
         title="PROJECT EDIT",
-        url_path="PROJECT",
+        url_path="PROJECT_EDIT",
         visibility="hidden",
     )
-    project_status_page = st.Page(
+    project_status_legacy_page = st.Page(
         _page_file_runner(pages_root / "1_PROJECT_STATUS.py"),
         title="PROJECT",
         url_path="PROJECT_STATUS",
+        visibility="hidden",
     )
     orchestrate_page = st.Page(
         _page_file_runner(pages_root / "2_ORCHESTRATE.py"),
@@ -1152,7 +1158,8 @@ def _navigation_pages() -> list[Any]:
         {
             "settings": settings_nav_page,
             "project": project_page,
-            "project_status": project_status_page,
+            "project_status": project_page,
+            "project_edit": project_edit_page,
             "orchestrate": orchestrate_page,
             "workflow": workflow_page,
             "analysis": analysis_page,
@@ -1162,7 +1169,8 @@ def _navigation_pages() -> list[Any]:
         main_page,
         settings_nav_page,
         project_page,
-        project_status_page,
+        project_edit_page,
+        project_status_legacy_page,
         orchestrate_page,
         workflow_page,
         analysis_page,

--- a/src/agilab/page_project_selector.py
+++ b/src/agilab/page_project_selector.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any, Callable, Iterable
 
 NAVIGATION_PAGE_ROUTES_ATTR = "_NAVIGATION_PAGE_ROUTES"
-PROJECT_ROUTE_ID = "project"
+PROJECT_ROUTE_ID = "project_edit"
 PROJECT_PAGE_PATH = Path("pages/1_PROJECT.py")
 MAIN_NAVIGATION_MODULES = ("__main__", "agilab.main_page")
 
@@ -50,7 +50,7 @@ def _registered_navigation_page(route_id: str) -> Any | None:
 
 
 def switch_to_project_page(streamlit: Any, *, active_app: str | None = None) -> bool:
-    """Switch to PROJECT using the active ``st.navigation`` page when available."""
+    """Switch to PROJECT_EDIT using the active ``st.navigation`` page when available."""
     switch_page = getattr(streamlit, "switch_page", None)
     if not callable(switch_page):
         return False

--- a/src/agilab/pages/1_PROJECT.py
+++ b/src/agilab/pages/1_PROJECT.py
@@ -120,6 +120,21 @@ _page_project_selector_module = import_agilab_module(
 )
 render_project_selector = _page_project_selector_module.render_project_selector
 
+_project_sidebar_support_module = import_agilab_module(
+    "agilab.project_sidebar_support",
+    current_file=__file__,
+    fallback_path=Path(__file__).resolve().parents[1] / "project_sidebar_support.py",
+    fallback_name="agilab_project_sidebar_support_fallback",
+)
+PROJECT_EDIT_ACTIONS = _project_sidebar_support_module.PROJECT_EDIT_ACTIONS
+PROJECT_STATUS_ACTIONS = _project_sidebar_support_module.PROJECT_STATUS_ACTIONS
+_normalize_project_sidebar_actions = (
+    _project_sidebar_support_module.normalize_project_sidebar_actions
+)
+_ensure_project_sidebar_session_defaults = (
+    _project_sidebar_support_module.ensure_project_sidebar_session_defaults
+)
+
 _action_execution_module = import_agilab_module(
     "agilab.action_execution",
     current_file=__file__,
@@ -206,8 +221,6 @@ PROJECT_ROOT = Path(__file__).resolve().parents[3]
 
 CREATE_MODE_TEMPLATE = "Template clone"
 CREATE_MODE_NOTEBOOK = "From notebook"
-PROJECT_EDIT_ACTIONS = ("Edit", "Create", "Import", "Rename", "Delete")
-PROJECT_STATUS_ACTIONS = ("Create", "Import", "Rename", "Delete")
 PROJECT_NOTEBOOK_IMPORT_START = "notebook-import"
 PROJECT_NOTEBOOK_IMPORT_CONSUMED_KEY = "_project_notebook_import_query_seed_consumed"
 PROJECT_NOTEBOOK_IMPORT_DEFAULTS_KEY = "_project_notebook_import_defaults"
@@ -2586,19 +2599,6 @@ def _render_sidebar_export_action(env) -> None:
         handle_export_project()
 
 
-def _normalize_project_sidebar_actions(actions) -> tuple[str, ...]:
-    normalized: list[str] = []
-    aliases = {"Clone": "Create"}
-    allowed = set(PROJECT_EDIT_ACTIONS)
-    for raw_action in actions:
-        action = aliases.get(str(raw_action or "").strip(), str(raw_action or "").strip())
-        if action not in allowed:
-            raise ValueError(f"Unsupported PROJECT sidebar action: {raw_action!r}")
-        if action not in normalized:
-            normalized.append(action)
-    return tuple(normalized)
-
-
 def render_project_sidebar(
     env,
     *,
@@ -2609,6 +2609,14 @@ def render_project_sidebar(
     actions = _normalize_project_sidebar_actions(actions)
     if not actions:
         return None
+
+    _ensure_project_sidebar_session_defaults(
+        st,
+        env,
+        actions,
+        get_templates=get_templates,
+        get_projects_zip=get_projects_zip,
+    )
 
     if st.session_state.get("sidebar_selection") == "Clone":
         st.session_state["sidebar_selection"] = "Create"
@@ -2628,7 +2636,11 @@ def render_project_sidebar(
         fallback="radio",
     )
 
-    if sidebar_selection == "Edit":
+    if sidebar_selection == "Overview":
+        st.sidebar.info(
+            "Choose Create, Import, Rename, or Delete when you need to manage projects."
+        )
+    elif sidebar_selection == "Edit":
         if render_edit_body:
             handle_project_selection()
         else:
@@ -4792,12 +4804,10 @@ def page():
     for key, value in session_defaults.items():
         st.session_state.setdefault(key, value)
 
-    if st.session_state.get("sidebar_selection") == "Clone":
-        st.session_state["sidebar_selection"] = "Create"
-    if not _consume_notebook_import_query_seed(st.session_state, st.query_params):
-        _consume_project_section_query_seed(st.session_state, st.query_params)
+    st.session_state["sidebar_selection"] = "Edit"
+    _consume_project_section_query_seed(st.session_state, st.query_params)
 
-    render_project_sidebar(env)
+    handle_project_selection()
 
 
 # -------------------- Main Application Entry -------------------- #

--- a/src/agilab/pages/1_PROJECT_STATUS.py
+++ b/src/agilab/pages/1_PROJECT_STATUS.py
@@ -11,6 +11,7 @@ import streamlit as st
 
 from agilab.page_bootstrap import ensure_page_env, render_page_chrome
 from agilab.page_project_selector import render_project_selector
+from agilab.project_sidebar_support import PROJECT_STATUS_ACTIONS
 from agilab.workflow_ui import render_project_status_page
 
 _PROJECT_EDIT_PAGE_MODULE = "agilab_project_edit_page_shared"
@@ -63,9 +64,10 @@ def main() -> None:
         show_edit_button=True,
     )
     project_edit_page = _load_project_edit_page_module()
+    project_edit_page._consume_notebook_import_query_seed(st.session_state, st.query_params)
     project_edit_page.render_project_sidebar(
         env,
-        actions=project_edit_page.PROJECT_STATUS_ACTIONS,
+        actions=PROJECT_STATUS_ACTIONS,
         render_edit_body=False,
     )
     render_project_status_page(st, env=env)

--- a/src/agilab/project_sidebar_support.py
+++ b/src/agilab/project_sidebar_support.py
@@ -1,0 +1,46 @@
+"""Shared PROJECT sidebar action contracts and session defaults."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Iterable
+
+PROJECT_EDIT_ACTIONS = ("Edit", "Create", "Import", "Rename", "Delete")
+PROJECT_STATUS_ACTIONS = ("Overview", "Create", "Import", "Rename", "Delete")
+
+
+def normalize_project_sidebar_actions(actions: Iterable[Any]) -> tuple[str, ...]:
+    """Return canonical PROJECT sidebar action names without duplicates."""
+    normalized: list[str] = []
+    aliases = {"Clone": "Create"}
+    allowed = set(PROJECT_EDIT_ACTIONS) | {"Overview"}
+    for raw_action in actions:
+        action = aliases.get(str(raw_action or "").strip(), str(raw_action or "").strip())
+        if action not in allowed:
+            raise ValueError(f"Unsupported PROJECT sidebar action: {raw_action!r}")
+        if action not in normalized:
+            normalized.append(action)
+    return tuple(normalized)
+
+
+def ensure_project_sidebar_session_defaults(
+    streamlit: Any,
+    env: Any,
+    actions: tuple[str, ...],
+    *,
+    get_templates: Callable[[], list[str]],
+    get_projects_zip: Callable[[], list[str]],
+) -> None:
+    """Initialize state required by PROJECT sidebar handlers in any host page."""
+    streamlit.session_state.setdefault("env", env)
+    streamlit.session_state.setdefault("_env", env)
+    streamlit.session_state.setdefault("orchest_functions", ["build_distribution"])
+    streamlit.session_state.setdefault("templates", get_templates())
+    streamlit.session_state.setdefault("archives", ["-- Select a file --"] + get_projects_zip())
+    streamlit.session_state.setdefault("export_message", "")
+    streamlit.session_state.setdefault("project_imported", False)
+    streamlit.session_state.setdefault("project_created", False)
+    streamlit.session_state.setdefault("show_widgets", [True, False])
+    streamlit.session_state.setdefault("pages", [])
+    streamlit.session_state.setdefault("switch_to_edit", False)
+    if actions:
+        streamlit.session_state.setdefault("sidebar_selection", actions[0])

--- a/src/agilab/workflow_ui.py
+++ b/src/agilab/workflow_ui.py
@@ -659,7 +659,7 @@ def render_context_expander(
             _render_context_link(
                 streamlit,
                 label="Change project",
-                url=_project_page_url("PROJECT_STATUS", env),
+                url=_project_page_url("PROJECT", env),
                 key=f"{key_root}:change_project",
             )
         with link_columns[1]:

--- a/test/test_about_agilab_helpers.py
+++ b/test/test_about_agilab_helpers.py
@@ -4287,10 +4287,10 @@ def test_main_page_sidebar_links_active_app_readme(tmp_path, monkeypatch):
     assert readme.resolve().as_uri() not in readme_url
     assert (
         readme_url
-        == "/PROJECT?active_app=flight_telemetry_project&sidebar_selection=Edit&project_section=readme"
+        == "/PROJECT_EDIT?active_app=flight_telemetry_project&sidebar_selection=Edit&project_section=readme"
     )
     parsed = urlparse(readme_url)
-    assert parsed.path == "/PROJECT"
+    assert parsed.path == "/PROJECT_EDIT"
     assert parse_qs(parsed.query) == {
         "active_app": ["flight_telemetry_project"],
         "sidebar_selection": ["Edit"],

--- a/test/test_first_launch_robot.py
+++ b/test/test_first_launch_robot.py
@@ -192,7 +192,7 @@ def test_first_launch_robot_rejects_non_positive_timeouts() -> None:
 def test_first_launch_robot_entrypoint_runs_with_fake_apptest(
     monkeypatch, capsys
 ) -> None:
-    readme_route = "/PROJECT?active_app=flight_telemetry_project&sidebar_selection=Edit&project_section=readme"
+    readme_route = "/PROJECT_EDIT?active_app=flight_telemetry_project&sidebar_selection=Edit&project_section=readme"
     readme_path = (
         MODULE_PATH.parents[1]
         / "src"

--- a/test/test_project_sidebar_support.py
+++ b/test/test_project_sidebar_support.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from agilab.project_sidebar_support import (
+    PROJECT_STATUS_ACTIONS,
+    ensure_project_sidebar_session_defaults,
+    normalize_project_sidebar_actions,
+)
+
+
+def test_normalize_project_sidebar_actions_aliases_clone_and_rejects_unknown() -> None:
+    assert normalize_project_sidebar_actions(["Overview", "Clone", "Create", "Delete"]) == (
+        "Overview",
+        "Create",
+        "Delete",
+    )
+
+    with pytest.raises(ValueError, match="Unsupported PROJECT sidebar action"):
+        normalize_project_sidebar_actions(["Overview", "Export"])
+
+
+def test_project_sidebar_session_defaults_cover_status_host_state() -> None:
+    streamlit = SimpleNamespace(session_state={})
+    env = SimpleNamespace(app="flight_telemetry_project")
+
+    ensure_project_sidebar_session_defaults(
+        streamlit,
+        env,
+        PROJECT_STATUS_ACTIONS,
+        get_templates=lambda: ["template_project"],
+        get_projects_zip=lambda: ["archive.zip"],
+    )
+
+    assert streamlit.session_state["env"] is env
+    assert streamlit.session_state["_env"] is env
+    assert streamlit.session_state["templates"] == ["template_project"]
+    assert streamlit.session_state["archives"] == ["-- Select a file --", "archive.zip"]
+    assert streamlit.session_state["sidebar_selection"] == "Overview"
+    assert streamlit.session_state["show_widgets"] == [True, False]
+
+
+def test_project_sidebar_session_defaults_preserve_existing_selection() -> None:
+    streamlit = SimpleNamespace(session_state={"sidebar_selection": "Rename"})
+    env = SimpleNamespace(app="flight_telemetry_project")
+
+    ensure_project_sidebar_session_defaults(
+        streamlit,
+        env,
+        PROJECT_STATUS_ACTIONS,
+        get_templates=lambda: [],
+        get_projects_zip=lambda: [],
+    )
+
+    assert streamlit.session_state["sidebar_selection"] == "Rename"

--- a/test/test_ui_pages.py
+++ b/test/test_ui_pages.py
@@ -734,20 +734,29 @@ def test_agilab_navigation_hides_about_and_settings_from_visible_page_list():
     assert 'title="PROJECT"' in source
     assert 'url_path="PROJECT"' in source
     project_block = source.split("project_page = st.Page(", 1)[1].split(
-        "project_status_page", 1
+        "project_edit_page", 1
     )[0]
-    project_status_block = source.split("project_status_page = st.Page(", 1)[1].split(
+    project_edit_block = source.split("project_edit_page = st.Page(", 1)[1].split(
+        "project_status_legacy_page", 1
+    )[0]
+    project_status_legacy_block = source.split("project_status_legacy_page = st.Page(", 1)[1].split(
         "orchestrate_page", 1
     )[0]
-    assert '_page_file_runner(pages_root / "1_PROJECT.py")' in project_block
-    assert '_page_file_runner(pages_root / "1_PROJECT_STATUS.py")' in project_status_block
-    assert 'title="PROJECT"' in project_status_block
-    assert 'url_path="PROJECT_STATUS"' in project_status_block
+    assert '_page_file_runner(pages_root / "1_PROJECT_STATUS.py")' in project_block
+    assert 'title="PROJECT"' in project_block
+    assert 'url_path="PROJECT"' in project_block
+    assert '_page_file_runner(pages_root / "1_PROJECT.py")' in project_edit_block
+    assert 'url_path="PROJECT_EDIT"' in project_edit_block
+    assert 'visibility="hidden"' in project_edit_block
+    assert '_page_file_runner(pages_root / "1_PROJECT_STATUS.py")' in project_status_legacy_block
+    assert 'url_path="PROJECT_STATUS"' in project_status_legacy_block
+    assert 'visibility="hidden"' in project_status_legacy_block
     assert 'visibility="hidden"' in source
     assert 'title="ORCHESTRATE"' in source
     assert 'title="WORKFLOW"' in source
     assert 'title="ANALYSIS"' in source
     assert 'target.columns([0.76, 0.24], vertical_alignment="bottom")' in selector_source
+    assert 'PROJECT_ROUTE_ID = "project_edit"' in selector_source
     assert 'PROJECT_PAGE_PATH = Path("pages/1_PROJECT.py")' in selector_source
     assert "switch_to_project_page(streamlit, active_app=selection)" in selector_source
     assert "switch_to_project_page(st, active_app=selected_lab)" not in pipeline_source
@@ -2973,14 +2982,67 @@ def test_project_status_page_owns_project_selectbox_edit_button_and_sidebar_acti
     assert "project_selectbox" in selectbox_keys
     assert "project_selectbox__edit" in [button.key for button in at.button]
     assert "project_selectbox__edit" not in [button.key for button in at.sidebar.button]
-    assert at.session_state["sidebar_selection"] == "Create"
-    sidebar_labels = "\n".join(str(widget.label) for widget in at.sidebar)
+    assert at.session_state["sidebar_selection"] == "Overview"
+    assert "templates" in at.session_state
+    assert "archives" in at.session_state
+    assert "clone_env_strategy" not in at.session_state
+    assert any(button.label == "Export" for button in at.sidebar.button)
+    sidebar_labels = "\n".join(str(getattr(widget, "label", "")) for widget in at.sidebar)
     assert "Project action" in sidebar_labels
+    assert "clone_dest" not in [ti.key for ti in at.sidebar.text_input]
     assert "project_filter" not in [ti.key for ti in at.sidebar.text_input]
 
 
-def test_create_page_exposes_environment_strategy(mock_ui_env):
-    at = _app_test("src/agilab/pages/1_PROJECT.py")
+def test_project_sidebar_support_normalizes_actions_and_rejects_unknown():
+    support = _import_agilab_module("agilab.project_sidebar_support")
+
+    assert support.normalize_project_sidebar_actions(
+        ["Overview", "Clone", "Create", "Edit", "Clone"]
+    ) == ("Overview", "Create", "Edit")
+
+    with pytest.raises(ValueError, match="Unsupported PROJECT sidebar action"):
+        support.normalize_project_sidebar_actions(["Overview", "Archive"])
+
+
+def test_project_sidebar_support_initializes_shared_session_defaults(tmp_path):
+    support = _import_agilab_module("agilab.project_sidebar_support")
+    env = SimpleNamespace(app="flight_telemetry_project")
+    fake_st = SimpleNamespace(session_state={"sidebar_selection": "Create"})
+
+    support.ensure_project_sidebar_session_defaults(
+        fake_st,
+        env,
+        ("Overview", "Create"),
+        get_templates=lambda: ["minimal_app_project"],
+        get_projects_zip=lambda: ["demo.zip"],
+    )
+
+    assert fake_st.session_state["env"] is env
+    assert fake_st.session_state["_env"] is env
+    assert fake_st.session_state["orchest_functions"] == ["build_distribution"]
+    assert fake_st.session_state["templates"] == ["minimal_app_project"]
+    assert fake_st.session_state["archives"] == ["-- Select a file --", "demo.zip"]
+    assert fake_st.session_state["export_message"] == ""
+    assert fake_st.session_state["project_imported"] is False
+    assert fake_st.session_state["project_created"] is False
+    assert fake_st.session_state["show_widgets"] == [True, False]
+    assert fake_st.session_state["pages"] == []
+    assert fake_st.session_state["switch_to_edit"] is False
+    assert fake_st.session_state["sidebar_selection"] == "Create"
+
+    fresh_st = SimpleNamespace(session_state={})
+    support.ensure_project_sidebar_session_defaults(
+        fresh_st,
+        env,
+        ("Overview", "Create"),
+        get_templates=list,
+        get_projects_zip=list,
+    )
+    assert fresh_st.session_state["sidebar_selection"] == "Overview"
+
+
+def test_project_status_create_action_exposes_environment_strategy(mock_ui_env):
+    at = _app_test("src/agilab/pages/1_PROJECT_STATUS.py")
     env = AgiEnv(
         apps_path=mock_ui_env["apps_dir"], app="flight_telemetry_project", verbose=0
     )
@@ -3003,8 +3065,31 @@ def test_create_page_exposes_environment_strategy(mock_ui_env):
     assert "Safer for real development." not in sidebar_captions
 
 
-def test_project_page_notebook_import_query_opens_file_selector(mock_ui_env):
+def test_project_edit_page_is_edit_only(mock_ui_env):
     at = _app_test("src/agilab/pages/1_PROJECT.py")
+    env = AgiEnv(
+        apps_path=mock_ui_env["apps_dir"], app="flight_telemetry_project", verbose=0
+    )
+    env.init_done = True
+    env.st_resources = (
+        Path(__file__).resolve().parents[1] / "src/agilab/resources"
+    ).resolve()
+    env.projects = ["flight_telemetry_project"]
+    env.get_projects = MagicMock(return_value=["flight_telemetry_project"])
+    at.session_state["env"] = env
+    at.session_state["sidebar_selection"] = "Create"
+
+    at.run()
+    assert not at.exception
+
+    assert at.session_state["sidebar_selection"] == "Edit"
+    assert "clone_env_strategy" not in at.session_state
+    assert "clone_dest" not in [ti.key for ti in at.sidebar.text_input]
+    assert not any(button.label == "Export" for button in at.sidebar.button)
+
+
+def test_project_status_notebook_import_query_opens_file_selector(mock_ui_env):
+    at = _app_test("src/agilab/pages/1_PROJECT_STATUS.py")
     env = AgiEnv(
         apps_path=mock_ui_env["apps_dir"], app="flight_telemetry_project", verbose=0
     )

--- a/test/test_workflow_ui.py
+++ b/test/test_workflow_ui.py
@@ -184,7 +184,7 @@ def test_render_context_expander_links_back_to_project_page(tmp_path) -> None:
     assert ("expander", "Workflow context:False") in fake_st.events
     assert (
         "link_button",
-        "Change project:/PROJECT_STATUS?active_app=flight_telemetry_project:context_expander:WORKFLOW:change_project:secondary",
+        "Change project:/PROJECT?active_app=flight_telemetry_project:context_expander:WORKFLOW:change_project:secondary",
     ) in fake_st.events
     assert not [event for event in fake_st.events if event[0] == "selectbox"]
 
@@ -250,7 +250,7 @@ def test_workflow_link_buttons_do_not_require_key_support(monkeypatch) -> None:
     workflow_ui._render_context_link(
         fake_st,
         label="Change project",
-        url="/PROJECT_STATUS",
+        url="/PROJECT",
         key="demo:change_project",
     )
 
@@ -260,7 +260,7 @@ def test_workflow_link_buttons_do_not_require_key_support(monkeypatch) -> None:
     ) in fake_st.events
     assert (
         "link_button",
-        "Change project:/PROJECT_STATUS:nokey:secondary:content",
+        "Change project:/PROJECT:nokey:secondary:content",
     ) in fake_st.events
 
 

--- a/tools/agilab_widget_robot.py
+++ b/tools/agilab_widget_robot.py
@@ -215,15 +215,17 @@ BROWSER_ISSUE_IGNORE_NEEDLES = (
 PAGE_EXPECTED_TEXT = {
     "": ("Turn experiments", "First proof: built-in demo"),
     "PROJECT": ("PROJECT", "Flight Telemetry", "Install PyPI app"),
+    "PROJECT_EDIT": ("PROJECT", "Flight Telemetry", "Edit project files"),
     "SETTINGS": ("SETTINGS", "Settings", "README"),
     "ORCHESTRATE": ("ORCHESTRATE", "Flight Telemetry", "Deploy"),
     "WORKFLOW": ("WORKFLOW", "Flight Telemetry", "Data source"),
     "ANALYSIS": ("ANALYSIS", "Flight Telemetry Project", "view_maps"),
 }
-PAGE_MIN_WIDGETS = {"": 1, "PROJECT": 5, "SETTINGS": 5, "ORCHESTRATE": 5, "WORKFLOW": 3, "ANALYSIS": 3}
+PAGE_MIN_WIDGETS = {"": 1, "PROJECT": 5, "PROJECT_EDIT": 5, "SETTINGS": 5, "ORCHESTRATE": 5, "WORKFLOW": 3, "ANALYSIS": 3}
 PAGE_ABOVE_FOLD_EXPECTED_LABELS = {
     "HOME": ("Turn experiments", "First proof: built-in demo"),
     "PROJECT": ("PROJECT", "Flight Telemetry", "Install PyPI app"),
+    "PROJECT_EDIT": ("PROJECT", "Flight Telemetry", "Edit project files"),
     "SETTINGS": ("SETTINGS", "README"),
     "ORCHESTRATE": ("ORCHESTRATE", "Flight Telemetry", "Deploy"),
     "WORKFLOW": ("WORKFLOW", "Flight Telemetry", "Data source"),

--- a/tools/first_launch_robot.py
+++ b/tools/first_launch_robot.py
@@ -81,7 +81,7 @@ def _active_app_readme_path(active_app: Path, apps_path: Path) -> Path | None:
 
 
 def _readme_route(app_name: str) -> str:
-    return f"/PROJECT?{urlencode({'active_app': app_name, 'sidebar_selection': 'Edit', 'project_section': 'readme'})}"
+    return f"/PROJECT_EDIT?{urlencode({'active_app': app_name, 'sidebar_selection': 'Edit', 'project_section': 'readme'})}"
 
 
 def _readme_link_details(


### PR DESCRIPTION
## Summary
- extract shared PROJECT sidebar action/default contracts
- route visible PROJECT to status and hidden PROJECT_EDIT to edit-only page
- add helper and AppTest coverage for PROJECT sidebar behavior and route links

## Validation
- uv --preview-features extra-build-dependencies run python -m pytest -q -o addopts='' test/test_project_sidebar_support.py test/test_ui_pages.py::test_project_sidebar_support_normalizes_actions_and_rejects_unknown test/test_ui_pages.py::test_project_sidebar_support_initializes_shared_session_defaults test/test_ui_pages.py::test_project_status_page_owns_project_selectbox_edit_button_and_sidebar_actions test/test_ui_pages.py::test_project_status_create_action_exposes_environment_strategy test/test_ui_pages.py::test_project_edit_page_is_edit_only test/test_ui_pages.py::test_project_status_notebook_import_query_opens_file_selector test/test_about_agilab_helpers.py::test_main_page_sidebar_links_active_app_readme test/test_first_launch_robot.py::test_first_launch_robot_entrypoint_runs_with_fake_apptest test/test_workflow_ui.py::test_render_context_expander_links_back_to_project_page test/test_workflow_ui.py::test_workflow_link_buttons_do_not_require_key_support