### PR TITLE
Cover PROJECT_EDITOR in UI robot matrix

### DIFF
--- a/.github/workflows/ui-robot-matrix.yml
+++ b/.github/workflows/ui-robot-matrix.yml
@@ -39,6 +39,7 @@ jobs:
               isolated-core-pages
               isolated-entry-and-app-pages
               isolated-project-page
+              isolated-project-editor-page
               isolated-project-notebook-import
               isolated-project-import-sidebar
               isolated-project-rename-sidebar

--- a/test/test_agilab_widget_robot_matrix.py
+++ b/test/test_agilab_widget_robot_matrix.py
@@ -28,6 +28,7 @@ def test_default_scenarios_cover_isolated_pages_and_current_home_actions() -> No
         "isolated-core-pages",
         "isolated-entry-and-app-pages",
         "isolated-project-page",
+        "isolated-project-editor-page",
         "isolated-project-notebook-import",
         "isolated-project-import-sidebar",
         "isolated-project-rename-sidebar",
@@ -36,7 +37,7 @@ def test_default_scenarios_cover_isolated_pages_and_current_home_actions() -> No
         "current-home-pytorch-direct-run-readiness",
         "current-home-orchestrate-journey",
     ]
-    isolated, entry, project, project_notebook, project_import, project_rename, settings, current_home, pytorch_direct, journey = scenarios
+    isolated, entry, project, project_editor, project_notebook, project_import, project_rename, settings, current_home, pytorch_direct, journey = scenarios
     assert isolated.pages == "ORCHESTRATE,WORKFLOW,ANALYSIS"
     assert isolated.runtime_isolation == "isolated"
     assert isolated.action_button_policy == "trial"
@@ -52,6 +53,12 @@ def test_default_scenarios_cover_isolated_pages_and_current_home_actions() -> No
     assert project.runtime_isolation == "isolated"
     assert project.action_button_policy == "safe-click"
     assert project.action_timeout_seconds == 30.0
+    assert project_editor.pages == "PROJECT_EDITOR"
+    assert project_editor.apps_pages == "none"
+    assert project_editor.runtime_isolation == "isolated"
+    assert project_editor.action_button_policy == "safe-click"
+    assert project_editor.required_text == "Edit project files"
+    assert project_editor.forbidden_text == "Worker class,Source LOC,Environment Health"
     assert project_notebook.pages == "PROJECT"
     assert project_notebook.route_query == "start=notebook-import"
     assert project_notebook.apps_pages == "none"
@@ -982,6 +989,34 @@ def test_build_robot_command_covers_project_page(tmp_path) -> None:
     assert progress_path == tmp_path / "isolated-project-page.ndjson"
 
 
+def test_build_robot_command_covers_project_editor_page(tmp_path) -> None:
+    module = _load_module()
+    scenario = module.DEFAULT_SCENARIOS["isolated-project-editor-page"]
+    options = module.MatrixOptions(
+        apps="flight_telemetry_project",
+        output_dir=tmp_path,
+        screenshot_dir=tmp_path / "screenshots",
+        timeout_seconds=12.0,
+        widget_timeout_seconds=2.0,
+        quiet_progress=True,
+        no_seed_demo_artifacts=False,
+    )
+
+    argv, summary_path, progress_path = module.build_robot_command(scenario, options=options)
+
+    assert argv[argv.index("--pages") + 1] == "PROJECT_EDITOR"
+    assert argv[argv.index("--apps-pages") + 1] == "none"
+    assert argv[argv.index("--runtime-isolation") + 1] == "isolated"
+    assert argv[argv.index("--action-button-policy") + 1] == "safe-click"
+    assert argv[argv.index("--required-text") + 1] == "Edit project files"
+    assert argv[argv.index("--forbidden-text") + 1] == "Worker class,Source LOC,Environment Health"
+    assert argv[argv.index("--screenshot-dir") + 1] == str(
+        tmp_path / "screenshots" / "isolated-project-editor-page"
+    )
+    assert summary_path == tmp_path / "isolated-project-editor-page.json"
+    assert progress_path == tmp_path / "isolated-project-editor-page.ndjson"
+
+
 def test_build_robot_command_covers_project_notebook_import_deep_link(tmp_path) -> None:
     module = _load_module()
     scenario = module.DEFAULT_SCENARIOS["isolated-project-notebook-import"]
@@ -1493,6 +1528,7 @@ def test_run_matrix_aggregates_json_summaries(tmp_path) -> None:
         "isolated-core-pages",
         "isolated-entry-and-app-pages",
         "isolated-project-page",
+        "isolated-project-editor-page",
         "isolated-project-notebook-import",
         "isolated-project-import-sidebar",
         "isolated-project-rename-sidebar",
@@ -1502,11 +1538,11 @@ def test_run_matrix_aggregates_json_summaries(tmp_path) -> None:
         "current-home-orchestrate-journey",
     ]
     assert summary["success"] is True
-    assert summary["scenario_count"] == 10
-    assert summary["page_count"] == 20
-    assert summary["widget_count"] == 50
-    assert summary["interacted_count"] == 30
-    assert summary["probed_count"] == 20
+    assert summary["scenario_count"] == 11
+    assert summary["page_count"] == 22
+    assert summary["widget_count"] == 55
+    assert summary["interacted_count"] == 33
+    assert summary["probed_count"] == 22
     assert summary["failed_scenarios"] == []
     assert summary["failure_samples"] == []
 

--- a/test/test_ui_robot_coverage_contract.py
+++ b/test/test_ui_robot_coverage_contract.py
@@ -34,6 +34,13 @@ def test_ui_robot_coverage_contract_passes_for_current_matrix() -> None:
     for action in module.REQUIRED_HIGH_RISK_ACTIONS:
         assert payload["coverage"]["high_risk_actions"][action]
     assert payload["coverage"]["configured_apps_pages_scenarios"] == ["isolated-entry-and-app-pages"]
+    assert payload["coverage"]["editor_routes"] == {
+        "PROJECT_EDITOR": {
+            "forbidden_text": ["Environment Health", "Source LOC", "Worker class"],
+            "required_text": ["Edit project files"],
+            "scenarios": ["isolated-project-editor-page"],
+        }
+    }
     assert payload["coverage"]["public_demo_contract"]["ui_apps"] == [
         "flight_telemetry_project",
         "weather_forecast_project",
@@ -92,6 +99,7 @@ def test_ui_robot_coverage_contract_passes_for_current_matrix() -> None:
         "hf-first-proof-app-pages-visual-smoke",
         "hf-first-proof-visual-smoke",
     ]
+    assert "isolated-project-editor-page" in payload["coverage"]["ui_robot_matrix_profile_scenarios"]
     assert "isolated-pytorch-playground-analysis" in payload["coverage"]["ui_robot_matrix_profile_scenarios"]
     assert payload["coverage"]["pytorch_analysis_robot"] == {
         "apps": ["pytorch_playground_project"],
@@ -175,6 +183,12 @@ def test_ui_robot_coverage_contract_accepts_explicit_full_app_profile(monkeypatc
         apps_pages="configured",
         click_action_labels=",".join(module.REQUIRED_HIGH_RISK_ACTIONS),
     )
+    editor = scenario(
+        "isolated-project-editor-page",
+        pages="PROJECT_EDITOR",
+        required_text="Edit project files",
+        forbidden_text="Environment Health,Source LOC,Worker class",
+    )
     hf_visual = scenario(
         "hf-first-proof-visual-smoke",
         pages="HOME,PROJECT,ORCHESTRATE,WORKFLOW,ANALYSIS",
@@ -206,7 +220,7 @@ def test_ui_robot_coverage_contract_accepts_explicit_full_app_profile(monkeypatc
     )
     all_scenarios = {
         item.name: item
-        for item in (core_scenario, hf_visual, hf_app_pages, hf_install, pytorch)
+        for item in (core_scenario, editor, hf_visual, hf_app_pages, hf_install, pytorch)
     }
     widget_robot = SimpleNamespace(
         page_label=lambda page: str(page),
@@ -219,7 +233,7 @@ def test_ui_robot_coverage_contract_accepts_explicit_full_app_profile(monkeypatc
         ],
     )
     matrix = SimpleNamespace(
-        DEFAULT_SCENARIOS={"core-selected-actions": core_scenario},
+        DEFAULT_SCENARIOS={"core-selected-actions": core_scenario, "isolated-project-editor-page": editor},
         ALL_SCENARIOS=all_scenarios,
         OPT_IN_SCENARIOS={"isolated-pytorch-playground-analysis": pytorch},
     )
@@ -254,10 +268,12 @@ def test_ui_robot_coverage_contract_accepts_explicit_full_app_profile(monkeypatc
             "ui-robot-matrix": [
                 SimpleNamespace(
                     argv=[
-                        "--scenario",
-                        "isolated-pytorch-playground-analysis",
-                        "--apps",
-                        ",".join(module.REQUIRED_DEMO_UI_APPS),
+                            "--scenario",
+                            "isolated-project-editor-page",
+                            "--scenario",
+                            "isolated-pytorch-playground-analysis",
+                            "--apps",
+                            ",".join(module.REQUIRED_DEMO_UI_APPS),
                     ]
                 )
             ],
@@ -400,6 +416,7 @@ def test_ui_robot_coverage_contract_reports_hf_first_proof_gaps(monkeypatch) -> 
     assert "hf-first-proof-app-pages-visual-smoke is missing from the robot matrix" in details
     assert "hf-first-proof-install is missing from the robot matrix" in details
     assert "isolated-pytorch-playground-analysis is missing from the robot matrix" in details
+    assert "ui-robot-matrix profile does not run isolated-project-editor-page" in details
     assert "ui-robot-matrix profile does not run isolated-pytorch-playground-analysis" in details
     assert any(
         detail.startswith("ui-robot-matrix profile is missing documented demo apps:")
@@ -606,6 +623,7 @@ def test_ui_robot_coverage_contract_reports_matrix_and_pytorch_gaps(monkeypatch,
     assert "- core_page:" in rendered
     assert any("apps declare configured apps-pages" in detail for detail in details)
     assert "default robot matrix has no scenarios for --apps all" in details
+    assert "PROJECT_EDITOR is not covered by any default robot scenario" in details
     assert "'INSTALL' is not covered by a selected-action scenario" in details
     assert "hf-first-proof-install is missing required actions: install" in details
     assert (
@@ -625,6 +643,7 @@ def test_ui_robot_coverage_contract_reports_matrix_and_pytorch_gaps(monkeypatch,
     ) in details
     assert "isolated-pytorch-playground-analysis is missing required action probes: Refresh evidence" in details
     assert "isolated-pytorch-playground-analysis does not enable browser_error_check" in details
+    assert "ui-robot-matrix profile does not run isolated-project-editor-page" in details
     assert "ui-robot-matrix profile does not run isolated-pytorch-playground-analysis" in details
     assert any(
         detail.startswith("public proof scenarios are missing documented demo routes:")

--- a/test/test_workflow_parity.py
+++ b/test/test_workflow_parity.py
@@ -425,6 +425,7 @@ def test_profile_commands_cover_expected_coverage_and_docs_contracts() -> None:
             "isolated-core-pages",
             "isolated-entry-and-app-pages",
             "isolated-project-page",
+            "isolated-project-editor-page",
             "isolated-project-notebook-import",
             "isolated-project-import-sidebar",
             "isolated-project-rename-sidebar",

--- a/tools/agilab_widget_robot_matrix.py
+++ b/tools/agilab_widget_robot_matrix.py
@@ -191,6 +191,21 @@ DEFAULT_SCENARIOS: dict[str, RobotScenario] = {
         action_timeout_seconds=30.0,
         page_timeout_seconds=300.0,
     ),
+    "isolated-project-editor-page": RobotScenario(
+        name="isolated-project-editor-page",
+        description=(
+            "Open the hidden PROJECT_EDITOR route for every built-in app and "
+            "assert the editor surface stays separate from PROJECT dashboard panels."
+        ),
+        pages="PROJECT_EDITOR",
+        apps_pages="none",
+        runtime_isolation="isolated",
+        action_button_policy="safe-click",
+        required_text="Edit project files",
+        forbidden_text="Worker class,Source LOC,Environment Health",
+        action_timeout_seconds=30.0,
+        page_timeout_seconds=300.0,
+    ),
     "isolated-project-notebook-import": RobotScenario(
         name="isolated-project-notebook-import",
         description=(

--- a/tools/ui_robot_coverage_contract.py
+++ b/tools/ui_robot_coverage_contract.py
@@ -21,6 +21,10 @@ PUBLIC_PROOF_SCENARIOS_PATH = REPO_ROOT / "tools" / "public_proof_scenarios.py"
 DEMOS_DOC_PATH = REPO_ROOT / "docs" / "source" / "demos.rst"
 SCHEMA = "agilab.ui_robot_coverage_contract.v1"
 REQUIRED_CORE_PAGES = ("HOME", "PROJECT", "ORCHESTRATE", "WORKFLOW", "ANALYSIS", "SETTINGS")
+REQUIRED_EDITOR_ROUTES = ("PROJECT_EDITOR",)
+REQUIRED_EDITOR_ROUTE_TEXT = {"PROJECT_EDITOR": ("Edit project files",)}
+REQUIRED_EDITOR_ROUTE_FORBIDDEN_TEXT = {"PROJECT_EDITOR": ("Environment Health", "Source LOC", "Worker class")}
+REQUIRED_EDITOR_ROUTE_PROFILE_SCENARIOS = ("isolated-project-editor-page",)
 REQUIRED_HIGH_RISK_ACTIONS = ("INSTALL", "CHECK distribute", "Run -> Load -> Export")
 REQUIRED_HF_FIRST_PROOF_APPS = (
     "flight_telemetry_project",
@@ -191,6 +195,46 @@ def evaluate_contract() -> dict[str, Any]:
     for page, scenarios in page_to_scenarios.items():
         if not scenarios:
             issues.append(CoverageIssue("core_page", f"{page} is not covered by any robot scenario"))
+
+    editor_route_to_scenarios: dict[str, list[str]] = {route: [] for route in REQUIRED_EDITOR_ROUTES}
+    editor_route_contract: dict[str, dict[str, list[str]]] = {}
+    for route in REQUIRED_EDITOR_ROUTES:
+        required_text: set[str] = set()
+        forbidden_text: set[str] = set()
+        for scenario in default_scenarios:
+            if route not in _scenario_pages(widget_robot, scenario):
+                continue
+            editor_route_to_scenarios[route].append(scenario.name)
+            required_text.update(_scenario_required_text(widget_robot, scenario))
+            forbidden_text.update(_scenario_forbidden_text(widget_robot, scenario))
+        editor_route_contract[route] = {
+            "scenarios": editor_route_to_scenarios[route],
+            "required_text": sorted(required_text),
+            "forbidden_text": sorted(forbidden_text),
+        }
+        if not editor_route_to_scenarios[route]:
+            issues.append(
+                CoverageIssue(
+                    "editor_route",
+                    f"{route} is not covered by any default robot scenario",
+                )
+            )
+        missing_required_text = sorted(set(REQUIRED_EDITOR_ROUTE_TEXT.get(route, ())) - required_text)
+        if missing_required_text:
+            issues.append(
+                CoverageIssue(
+                    "editor_route",
+                    f"{route} is missing required text probes: " + ", ".join(missing_required_text),
+                )
+            )
+        missing_forbidden_text = sorted(set(REQUIRED_EDITOR_ROUTE_FORBIDDEN_TEXT.get(route, ())) - forbidden_text)
+        if missing_forbidden_text:
+            issues.append(
+                CoverageIssue(
+                    "editor_route",
+                    f"{route} is missing forbidden dashboard text probes: " + ", ".join(missing_forbidden_text),
+                )
+            )
 
     configured_apps_pages: dict[str, list[str]] = {}
     for app in widget_robot.public_builtin_apps():
@@ -465,6 +509,15 @@ def evaluate_contract() -> dict[str, Any]:
                     f"{REQUIRED_PYTORCH_ANALYSIS_SCENARIO} does not enable browser_error_check",
                 )
             )
+    for editor_profile_scenario in REQUIRED_EDITOR_ROUTE_PROFILE_SCENARIOS:
+        if editor_profile_scenario not in ui_robot_matrix_profile_scenarios:
+            issues.append(
+                CoverageIssue(
+                    "editor_route",
+                    f"ui-robot-matrix profile does not run {editor_profile_scenario}",
+                )
+            )
+
     if REQUIRED_PYTORCH_ANALYSIS_SCENARIO not in ui_robot_matrix_profile_scenarios:
         issues.append(
             CoverageIssue(
@@ -532,6 +585,7 @@ def evaluate_contract() -> dict[str, Any]:
             "built_in_apps_covered_by": "ui-robot-matrix --apps all" if default_apps_all else "",
             "core_pages": page_to_scenarios,
             "configured_apps_pages": configured_apps_pages,
+            "editor_routes": editor_route_contract,
             "configured_apps_page_names": configured_apps_page_names,
             "configured_apps_pages_scenarios": configured_scenarios,
             "high_risk_actions": action_to_scenarios,

--- a/tools/workflow_parity.py
+++ b/tools/workflow_parity.py
@@ -59,6 +59,7 @@ UI_ROBOT_MATRIX_SHARDS = (
             "isolated-core-pages",
             "isolated-entry-and-app-pages",
             "isolated-project-page",
+            "isolated-project-editor-page",
             "isolated-project-notebook-import",
             "isolated-project-import-sidebar",
             "isolated-project-rename-sidebar",


### PR DESCRIPTION
## Summary
- add an isolated PROJECT_EDITOR robot scenario to the default matrix
- require PROJECT_EDITOR coverage in the UI robot coverage contract
- wire the scenario into workflow parity and the GitHub ui-robot-matrix core shard

## Validation
- python3 -m py_compile tools/agilab_widget_robot_matrix.py tools/ui_robot_coverage_contract.py tools/workflow_parity.py test/test_agilab_widget_robot_matrix.py test/test_ui_robot_coverage_contract.py test/test_workflow_parity.py test/test_ci_workflow.py
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_agilab_widget_robot_matrix.py test/test_ui_robot_coverage_contract.py test/test_workflow_parity.py::test_profile_commands_cover_expected_coverage_and_docs_contracts test/test_ci_workflow.py::test_ui_robot_matrix_workflow_command_matches_local_workflow_parity
- uv --preview-features extra-build-dependencies run python tools/ui_robot_coverage_contract.py --json
- ./dev scope --staged
- uv --preview-features extra-build-dependencies run python tools/impact_validate.py --staged
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_ci_workflow.py test/test_agilab_widget_robot_matrix.py test/test_ui_robot_coverage_contract.py test/test_workflow_parity.py