### PR TITLE
Polish PROJECT agi-app controls and analysis labels

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 250,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "ed9acbe86aa8c5e29ce5e8fc028f680e52111bdac9bd10218f38986ba015e67f",
+  "source_digest_sha256": "7e67dd288d5e0de3abe9cbf012f6b6747b89cc97702a5f6c2923742bca806dee",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "ed9acbe86aa8c5e29ce5e8fc028f680e52111bdac9bd10218f38986ba015e67f"
+  "target_digest_sha256": "7e67dd288d5e0de3abe9cbf012f6b6747b89cc97702a5f6c2923742bca806dee"
 }

--- a/docs/source/package-publishing-policy.rst
+++ b/docs/source/package-publishing-policy.rst
@@ -124,7 +124,7 @@ virtual environments, compiled artifacts, locks, and generated build outputs
 excluded.
 
 End users can add a trusted promoted app package to an existing AGILAB
-environment from ``PROJECT`` through ``agi-app from PyPI`` or from the CLI with
+environment from ``PROJECT`` through ``agi-app`` or from the CLI with
 ``agilab app install``. Both routes accept one ``agi-app-*`` package
 requirement, use ``uv pip install --python`` against the current Python
 environment, and rely on the package's ``agilab.apps`` entry point for

--- a/maintenance/memory/by-path/src%2Fagilab%2Fpages%2F4_ANALYSIS.py.md
+++ b/maintenance/memory/by-path/src%2Fagilab%2Fpages%2F4_ANALYSIS.py.md
@@ -1,9 +1,9 @@
 ---
 schema: agilab.maintenance_memory.v1
 source: src/agilab/pages/4_ANALYSIS.py
-source_sha256: 44e82338f782784356051b0e50c7b1a24e2b86b4fba9db065d0ac565780ee0df
+source_sha256: 1ccdd3805f9dd0a6a06d074ed5895895eee10154ad5cfb89042ba6bfda8e453f
 title: ANALYSIS page AgiEnv singleton contract
-verified_commit: 14288641078471bf3f29b7cec8c67ede4939e539
+verified_commit: d954f4868bc69ebc957f2b3cd0f428c2fda6d16f
 ---
 
 # ANALYSIS page AgiEnv singleton contract

--- a/src/agilab/pages/1_PROJECT.py
+++ b/src/agilab/pages/1_PROJECT.py
@@ -1189,11 +1189,11 @@ def _render_installed_pypi_app_manager(env) -> None:
 
 
 def _render_pypi_app_install_action(env) -> None:
-    with st.sidebar.expander("agi-app from PyPI", expanded=False):
+    with st.sidebar.expander("agi-app", expanded=False):
         catalog = _search_promoted_pypi_app_catalog("")
         catalog_options = ["", *catalog]
         catalog_choice = st.selectbox(
-            "Catalog agi-app",
+            "Catalog pypi.org",
             options=catalog_options,
             key="project_pypi_app_catalog_choice",
         )
@@ -1215,17 +1215,26 @@ def _render_pypi_app_install_action(env) -> None:
                 st.warning(str(exc))
 
         preflight_key = "project_pypi_app_preflight_payload"
-        check_clicked = st.button(
-            "Check agi-app",
-            key="project_pypi_app_preflight",
-            disabled=not requirement,
-            width="stretch",
-        )
+        reviewed_key = "project_pypi_app_reviewed"
+        reviewed_requirement_key = "project_pypi_app_reviewed_requirement"
+        if st.session_state.get(reviewed_requirement_key) != requirement:
+            st.session_state[reviewed_requirement_key] = requirement
+            st.session_state[reviewed_key] = False
+            st.session_state.pop(preflight_key, None)
+
+        check_col, install_col = st.columns(2)
+        with check_col:
+            check_clicked = st.button(
+                "Check",
+                key="project_pypi_app_preflight",
+                disabled=not requirement,
+                width="stretch",
+            )
         if check_clicked and requirement:
             result = run_streamlit_action(
                 st,
                 ActionSpec(
-                    name="Check agi-app",
+                    name="Check",
                     start_message=f"Checking {requirement}...",
                     failure_title="agi-app preflight failed.",
                     failure_next_action="Check the agi-app name and PyPI availability.",
@@ -1235,31 +1244,37 @@ def _render_pypi_app_install_action(env) -> None:
             st.session_state[preflight_key] = result.data
 
         preflight_payload = st.session_state.get(preflight_key)
+        preflight_passed = False
         if isinstance(preflight_payload, dict):
             payload_requirement = str(preflight_payload.get("requirement") or "")
             if payload_requirement != requirement:
                 preflight_payload = None
+            else:
+                preflight_status = str(preflight_payload.get("status") or "").lower()
+                preflight_passed = preflight_status in {"pass", "success"}
         _render_pypi_metadata_summary(
             preflight_payload if isinstance(preflight_payload, dict) else None
         )
 
-        trusted = st.checkbox(
-            "Reviewed agi-app",
-            key="project_pypi_app_reviewed",
+        reviewed = bool(st.session_state.get(reviewed_key, False))
+        with install_col:
+            install_clicked = st.button(
+                "Install",
+                key="project_pypi_app_install",
+                type="primary",
+                disabled=not requirement or not preflight_passed or not reviewed,
+                width="stretch",
+            )
+        st.checkbox(
+            "Reviewed",
+            key=reviewed_key,
             help="Only install agi-apps you trust to run as local code.",
-        )
-        install_clicked = st.button(
-            "Install agi-app",
-            key="project_pypi_app_install",
-            type="primary",
-            disabled=not requirement or not trusted,
-            width="stretch",
         )
         if install_clicked:
             run_streamlit_action(
                 st,
                 ActionSpec(
-                    name="Install agi-app",
+                    name="Install",
                     start_message=f"Installing {requirement}...",
                     failure_title="agi-app install failed.",
                     failure_next_action="Check the agi-app name, Python version support, and PyPI availability.",

--- a/src/agilab/pages/4_ANALYSIS.py
+++ b/src/agilab/pages/4_ANALYSIS.py
@@ -2213,7 +2213,7 @@ def _render_analysis_workspace_overview(
 ) -> None:
     artifact_summary = _scan_analysis_artifacts(_active_analysis_data_root(env))
     artifact_count = int(artifact_summary["count"])
-    project_label = str(
+    project_label = _short_analysis_project_label(
         getattr(env, "app", "") or getattr(env, "target", "") or "project"
     )
     selected_views = tuple(getattr(selection_state, "selected_views", ()) or ())
@@ -2335,8 +2335,22 @@ def _analysis_project_link_label(
     if app_surface_cfg:
         title = app_surface_title(app_surface_cfg).strip()
         if title and title != "App Surface":
-            return title
-    return project.replace("_", " ").title()
+            return _strip_analysis_project_suffix(title)
+    return _short_analysis_project_label(project)
+
+
+def _strip_analysis_project_suffix(label: object) -> str:
+    text = str(label or "").strip()
+    lowered = text.lower()
+    for suffix in ("_project", " project"):
+        if lowered.endswith(suffix):
+            return text[: -len(suffix)].strip()
+    return text
+
+
+def _short_analysis_project_label(project: object) -> str:
+    label = Path(_strip_analysis_project_suffix(project)).name
+    return label.replace("_", " ").title().replace("Pytorch", "PyTorch")
 
 
 def _render_analysis_project_sidebar_label(

--- a/src/agilab/pipeline_editor.py
+++ b/src/agilab/pipeline_editor.py
@@ -839,6 +839,20 @@ def convert_paths_to_strings(obj: Any) -> Any:
         return str(obj)
     return obj
 
+
+def _drop_toml_none_values(obj: Any) -> Any:
+    """Recursively remove None values before writing TOML payloads."""
+    if isinstance(obj, dict):
+        return {
+            k: _drop_toml_none_values(v)
+            for k, v in obj.items()
+            if v is not None
+        }
+    if isinstance(obj, list):
+        return [_drop_toml_none_values(item) for item in obj if item is not None]
+    return obj
+
+
 def is_query_valid(query: Any) -> bool:
     """Check if a query is valid."""
     return isinstance(query, list) and bool(query[2])
@@ -1500,11 +1514,16 @@ def _force_persist_stage(
             stages[module_key].append({})
         current = stages[module_key][stage_idx]
         merged = dict(current) if isinstance(current, dict) else {}
-        merged.update(convert_paths_to_strings(entry))
-        stages[module_key][stage_idx] = merged
+        merged.update(_drop_toml_none_values(convert_paths_to_strings(entry)))
+        stages[module_key][stage_idx] = _drop_toml_none_values(merged)
         stages_file.parent.mkdir(parents=True, exist_ok=True)
         with open(stages_file, "wb") as f:
-            tomli_w.dump(convert_paths_to_strings(_prepare_lab_stages_for_write(stages)), f)
+            tomli_w.dump(
+                _drop_toml_none_values(
+                    convert_paths_to_strings(_prepare_lab_stages_for_write(stages))
+                ),
+                f,
+            )
     except (OSError, TypeError, ValueError, tomllib.TOMLDecodeError) as exc:
         logger.error(
             "Force persist failed for stage %s -> %s: %s",

--- a/test/test_about_agilab_helpers.py
+++ b/test/test_about_agilab_helpers.py
@@ -446,7 +446,7 @@ def test_page_bootstrap_keeps_session_env_when_recorded_root_differs(tmp_path):
 
 def test_page_bootstrap_handles_defensive_path_and_lookup_edges(tmp_path):
     apps_path = tmp_path / "repo" / "src" / "agilab" / "apps"
-    apps_path.mkdir()
+    apps_path.mkdir(parents=True)
     (apps_path / "demo_project").mkdir()
 
     assert page_bootstrap._page_apps_path(_BrokenPath()) is None

--- a/test/test_agilab_widget_robot.py
+++ b/test/test_agilab_widget_robot.py
@@ -73,7 +73,13 @@ def test_core_page_above_fold_expectations_track_current_layout() -> None:
     assert module.PAGE_ABOVE_FOLD_EXPECTED_LABELS["PROJECT"] == (
         "PROJECT",
         "Flight Telemetry",
-        "agi-app from PyPI",
+        "agi-app",
+        "Project path",
+    )
+    assert module.PAGE_EXPECTED_TEXT["PROJECT"] == (
+        "PROJECT",
+        "Flight Telemetry",
+        "agi-app",
         "Project path",
     )
     assert module.PAGE_ABOVE_FOLD_EXPECTED_LABELS["ORCHESTRATE"] == (
@@ -88,7 +94,12 @@ def test_core_page_above_fold_expectations_track_current_layout() -> None:
     )
     assert module.PAGE_ABOVE_FOLD_EXPECTED_LABELS["ANALYSIS"] == (
         "ANALYSIS",
-        "Flight Telemetry Project",
+        "Flight Telemetry",
+        "view_maps",
+    )
+    assert module.PAGE_EXPECTED_TEXT["ANALYSIS"] == (
+        "ANALYSIS",
+        "Flight Telemetry",
         "view_maps",
     )
 

--- a/test/test_pipeline_lab.py
+++ b/test/test_pipeline_lab.py
@@ -3775,10 +3775,12 @@ def test_display_lab_tab_empty_pipeline_generates_first_stage_with_runtime(monke
 
     assert saved["venv_map"] == {0: str(runtime_root)}
     assert saved["engine_map"] == {0: "agi.run"}
-    assert saved["extra_fields"] == {
-        pipeline_lab.STAGE_GENERATION_MODE_FIELD: pipeline_lab.GENERATION_MODE_SAFE_ACTIONS,
-        pipeline_lab.STAGE_ACTION_CONTRACT_FIELD: None,
-    }
+    extra_fields = saved["extra_fields"]
+    assert extra_fields[pipeline_lab.STAGE_GENERATION_MODE_FIELD] == pipeline_lab.GENERATION_MODE_SAFE_ACTIONS
+    assert extra_fields[pipeline_lab.STAGE_ACTION_CONTRACT_FIELD] is None
+    assert extra_fields[pipeline_lab.STAGE_ACTION_CONTRACT_SHA256_FIELD] == ""
+    assert extra_fields[pipeline_lab.STAGE_SAFE_ACTION_PINNED_FIELD] is False
+    assert extra_fields[pipeline_lab.STAGE_DATAFRAME_SCHEMA_SHA256_FIELD]
     assert saved["bumped"] is True
     assert ("rerun", "called") in fake_st.messages
 

--- a/test/test_ui_pages.py
+++ b/test/test_ui_pages.py
@@ -64,6 +64,73 @@ def _app_test(path: str, *, default_timeout: int = DEFAULT_APPTEST_TIMEOUT):
     return AppTest.from_file(path, default_timeout=default_timeout)
 
 
+def _assert_ordered_fragments(source: str, fragments: tuple[str, ...]) -> None:
+    positions = []
+    for fragment in fragments:
+        assert fragment in source, fragment
+        positions.append(source.index(fragment))
+    assert positions == sorted(positions), fragments
+
+
+def test_primary_pages_keep_homogeneous_support_field_order() -> None:
+    """Support fields should not jump above the page's primary content."""
+    analysis_source = Path("src/agilab/pages/4_ANALYSIS.py").read_text(
+        encoding="utf-8"
+    )
+    workflow_source = Path("src/agilab/pages/3_WORKFLOW.py").read_text(
+        encoding="utf-8"
+    )
+    project_source = Path("src/agilab/pages/1_PROJECT.py").read_text(
+        encoding="utf-8"
+    )
+    analysis_main = analysis_source[analysis_source.index("async def main():") :]
+    workflow_main_marker = (
+        "async def main" if "async def main" in workflow_source else "def main"
+    )
+    workflow_main = workflow_source[workflow_source.index(workflow_main_marker) :]
+    assert 'st.sidebar.expander("agi-app", expanded=False)' in project_source
+    assert '"Check",' in project_source
+    assert '"Install",' in project_source
+    assert '"Reviewed",' in project_source
+    assert "check_col, install_col = st.columns" in project_source
+    assert "review_col" not in project_source
+    assert "project_pypi_app_reviewed_requirement" in project_source
+    assert "preflight_passed = preflight_status in" in project_source
+    assert "disabled=not requirement or not preflight_passed or not reviewed" in project_source
+    assert "agi-app from PyPI" not in project_source
+    assert "Catalog pypi.org" in project_source
+    assert "Catalog agi-app" not in project_source
+    assert "Check agi-app" not in project_source
+    assert "Install agi-app" not in project_source
+    assert "Reviewed agi-app" not in project_source
+
+    _assert_ordered_fragments(
+        analysis_main,
+        (
+            "_render_analysis_workspace_overview(",
+            "render_project_evidence_drawer(",
+            'render_context_expander(st, page_label="ANALYSIS", env=env)',
+            'with st.expander("Choose analysis views", expanded=False):',
+            "_render_analysis_surface_guide(",
+        ),
+    )
+    _assert_ordered_fragments(
+        workflow_main,
+        (
+            "page()",
+            'render_context_expander(st, page_label="WORKFLOW", env=env)',
+        ),
+    )
+    project_sidebar = project_source[project_source.index("def render_project_sidebar(") :]
+    _assert_ordered_fragments(
+        project_sidebar,
+        (
+            "_render_active_project_sidebar(env)",
+            '"Project action"',
+        ),
+    )
+
+
 def _create_mock_project_root(apps_dir: Path, project_name: str) -> Path:
     project_dir = apps_dir / project_name
     (project_dir / "src").mkdir(parents=True, exist_ok=True)
@@ -1645,6 +1712,8 @@ def test_explore_page_multiselect(mock_ui_env):
     assert "Project</div>" not in markdown_text
     assert "Artifact formats" not in markdown_text
     sidebar_markdown = "\n".join(str(item.value) for item in at.sidebar.markdown)
+    assert "**Flight Telemetry**" in sidebar_markdown
+    assert "Flight Telemetry Project" not in sidebar_markdown
     assert "### Active project" not in sidebar_markdown
     assert all(
         text_input.key != "project_filter" for text_input in at.sidebar.text_input
@@ -1774,7 +1843,7 @@ def test_explore_page_sidebar_view_selection_persists(mock_ui_env):
     assert "default_view" not in pages_payload
     markdown_text = "\n".join(str(item.value) for item in at.markdown)
     assert "Views selected" in markdown_text
-    assert "2 linked to flight_telemetry_project" in markdown_text
+    assert "2 linked to Flight Telemetry" in markdown_text
     assert "agilab-header-value agilab-header-value--ready'>2/" in markdown_text
     assert "Available views" not in markdown_text
     assert "selected / available" not in markdown_text
@@ -1804,7 +1873,7 @@ def test_explore_page_sidebar_view_selection_persists(mock_ui_env):
     ]
     reloaded_markdown = "\n".join(str(item.value) for item in reloaded.markdown)
     assert "Views selected" in reloaded_markdown
-    assert "1 linked to flight_telemetry_project" in reloaded_markdown
+    assert "1 linked to Flight Telemetry" in reloaded_markdown
     assert "agilab-header-value agilab-header-value--ready'>1/" in reloaded_markdown
     assert "Available views" not in reloaded_markdown
     reloaded_sidebar_markdown = "\n".join(
@@ -1835,7 +1904,7 @@ def test_explore_page_app_surface_back_keeps_single_app_ui_sidebar_view(mock_ui_
         "view_module = []\n"
         "\n"
         "[app_surface]\n"
-        "title = 'Demo Surface'\n"
+        "title = 'Flight Telemetry Project'\n"
         "entrypoint = 'demo/app_surface.py'\n"
     )
     (mock_ui_env["project_dir"] / "src" / "app_settings.toml").write_text(
@@ -1861,6 +1930,8 @@ def test_explore_page_app_surface_back_keeps_single_app_ui_sidebar_view(mock_ui_
     assert not at.exception
     sidebar_markdown = "\n".join(str(item.value) for item in at.sidebar.markdown)
     sidebar_markdown = "\n".join(str(item.value) for item in at.sidebar.markdown)
+    assert "**Flight Telemetry**" in sidebar_markdown
+    assert "Flight Telemetry Project" not in sidebar_markdown
     assert "Project:" not in sidebar_markdown
     assert ">Page</a>" in sidebar_markdown
     assert ">view_app_ui</a>" not in sidebar_markdown
@@ -1924,6 +1995,8 @@ def test_explore_page_app_surface_uses_standard_view_selection(mock_ui_env):
     markdown_text = "\n".join(str(item.value) for item in at.markdown)
     sidebar_markdown = "\n".join(str(item.value) for item in at.sidebar.markdown)
     sidebar_markdown = "\n".join(str(item.value) for item in at.sidebar.markdown)
+    assert "**Demo Surface**" in sidebar_markdown
+    assert "Demo Surface Project" not in sidebar_markdown
     assert "Project:" not in sidebar_markdown
     assert "surface:analysis" not in markdown_text
     assert "surface:controls" not in sidebar_markdown
@@ -1981,7 +2054,7 @@ def test_explore_page_sidebar_notebook_selection_persists(mock_ui_env):
     assert settings_payload["notebooks"]["selected"] == ["extra/demo.ipynb"]
     markdown_text = "\n".join(str(item.value) for item in at.markdown)
     assert "Notebooks selected" in markdown_text
-    assert "1 linked to flight_telemetry_project" in markdown_text
+    assert "1 linked to Flight Telemetry" in markdown_text
     assert "agilab-header-value agilab-header-value--ready'>1/2</div>" in markdown_text
     sidebar_markdown = "\n".join(str(item.value) for item in at.sidebar.markdown)
     assert "### Notebooks" not in sidebar_markdown
@@ -1998,7 +2071,7 @@ def test_explore_page_sidebar_notebook_selection_persists(mock_ui_env):
     assert reloaded.session_state[selection_key] == ["extra/demo.ipynb"]
     reloaded_markdown = "\n".join(str(item.value) for item in reloaded.markdown)
     assert "Notebooks selected" in reloaded_markdown
-    assert "1 linked to flight_telemetry_project" in reloaded_markdown
+    assert "1 linked to Flight Telemetry" in reloaded_markdown
     assert (
         "agilab-header-value agilab-header-value--ready'>1/2</div>" in reloaded_markdown
     )
@@ -2994,6 +3067,9 @@ def test_project_status_page_owns_project_selectbox_edit_button_and_sidebar_acti
 
     main_selectboxes = list(at.selectbox)
     sidebar_selectboxes = list(at.sidebar.selectbox)
+    sidebar_selectbox_labels = [str(selectbox.label) for selectbox in sidebar_selectboxes]
+    assert "Catalog pypi.org" in sidebar_selectbox_labels
+    assert "Catalog agi-app" not in sidebar_selectbox_labels
     selectbox_keys = [sb.key for sb in main_selectboxes] + [
         sb.key for sb in sidebar_selectboxes
     ]
@@ -3010,6 +3086,17 @@ def test_project_status_page_owns_project_selectbox_edit_button_and_sidebar_acti
     assert "archives" in at.session_state
     assert "clone_env_strategy" not in at.session_state
     assert any(button.label == "Export" for button in at.sidebar.button)
+    sidebar_button_labels = [str(button.label) for button in at.sidebar.button]
+    assert "Check" in sidebar_button_labels
+    assert "Install" in sidebar_button_labels
+    assert "Check agi-app" not in sidebar_button_labels
+    assert "Install agi-app" not in sidebar_button_labels
+    sidebar_checkbox_labels = [str(checkbox.label) for checkbox in at.sidebar.checkbox]
+    assert "Reviewed" in sidebar_checkbox_labels
+    assert "Reviewed agi-app" not in sidebar_checkbox_labels
+    sidebar_expander_labels = [str(expander.label) for expander in at.sidebar.expander]
+    assert "agi-app" in sidebar_expander_labels
+    assert "agi-app from PyPI" not in sidebar_expander_labels
     markdown_text = "\n".join(str(item.value) for item in at.markdown)
     expander_labels = [str(item.label) for item in at.expander]
     assert "Project metrics" in expander_labels

--- a/tools/agilab_widget_robot.py
+++ b/tools/agilab_widget_robot.py
@@ -214,24 +214,24 @@ BROWSER_ISSUE_IGNORE_NEEDLES = (
 )
 PAGE_EXPECTED_TEXT = {
     "": ("Turn experiments", "First proof: built-in demo"),
-    "PROJECT": ("PROJECT", "Flight Telemetry", "agi-app from PyPI", "Project path"),
+    "PROJECT": ("PROJECT", "Flight Telemetry", "agi-app", "Project path"),
     "PROJECT_EDITOR": ("PROJECT", "Flight Telemetry", "Edit project files"),
     "PROJECT_EDIT": ("PROJECT", "Flight Telemetry", "Edit project files"),
     "SETTINGS": ("SETTINGS", "Settings", "README"),
     "ORCHESTRATE": ("ORCHESTRATE", "Flight Telemetry", "Deploy"),
     "WORKFLOW": ("WORKFLOW", "Flight Telemetry", "Data source"),
-    "ANALYSIS": ("ANALYSIS", "Flight Telemetry Project", "view_maps"),
+    "ANALYSIS": ("ANALYSIS", "Flight Telemetry", "view_maps"),
 }
 PAGE_MIN_WIDGETS = {"": 1, "PROJECT": 5, "PROJECT_EDITOR": 5, "PROJECT_EDIT": 5, "SETTINGS": 5, "ORCHESTRATE": 5, "WORKFLOW": 3, "ANALYSIS": 3}
 PAGE_ABOVE_FOLD_EXPECTED_LABELS = {
     "HOME": ("Turn experiments", "First proof: built-in demo"),
-    "PROJECT": ("PROJECT", "Flight Telemetry", "agi-app from PyPI", "Project path"),
+    "PROJECT": ("PROJECT", "Flight Telemetry", "agi-app", "Project path"),
     "PROJECT_EDITOR": ("PROJECT", "Flight Telemetry", "Edit project files"),
     "PROJECT_EDIT": ("PROJECT", "Flight Telemetry", "Edit project files"),
     "SETTINGS": ("SETTINGS", "README"),
     "ORCHESTRATE": ("ORCHESTRATE", "Flight Telemetry", "Deploy"),
     "WORKFLOW": ("WORKFLOW", "Flight Telemetry", "Data source"),
-    "ANALYSIS": ("ANALYSIS", "Flight Telemetry Project", "view_maps"),
+    "ANALYSIS": ("ANALYSIS", "Flight Telemetry", "view_maps"),
 }
 
 WIDGET_COLLECTOR_JS = r"""


### PR DESCRIPTION
## Summary
- shorten PROJECT agi-app labels and rename the catalog selector to Catalog pypi.org
- keep Check and Install on one row, with Reviewed on a separate acknowledgement line
- require a matching successful preflight plus Reviewed before install is enabled
- shorten ANALYSIS project labels and preserve TOML writes by dropping None values

## Validation
- ./dev test test/test_ui_pages.py::test_primary_pages_keep_homogeneous_support_field_order test/test_ui_pages.py::test_edit_page_load test/test_ui_pages.py::test_project_status_page_owns_project_selectbox_edit_button_and_sidebar_actions test/test_agilab_widget_robot.py::test_core_page_above_fold_expectations_track_current_layout test/test_pipeline_editor.py::test_force_persist_stage_merges_existing_content test/test_pipeline_editor.py::test_force_persist_stage_swallows_invalid_toml test/test_about_agilab_helpers.py::test_page_bootstrap_handles_defensive_path_and_lookup_edges
- uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp