### PR TITLE
Polish project and analysis UI labels

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 250,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "7e67dd288d5e0de3abe9cbf012f6b6747b89cc97702a5f6c2923742bca806dee",
+  "source_digest_sha256": "4ecfd15e8f9bff201db25c088c10a98f18ba15569ba9a19d14ede36d89f2fb29",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "7e67dd288d5e0de3abe9cbf012f6b6747b89cc97702a5f6c2923742bca806dee"
+  "target_digest_sha256": "4ecfd15e8f9bff201db25c088c10a98f18ba15569ba9a19d14ede36d89f2fb29"
 }

--- a/docs/source/quick-start.rst
+++ b/docs/source/quick-start.rst
@@ -387,7 +387,7 @@ wheel/sdist availability, entry-point metadata, hashes, and advertised
 provenance/signature status, then confirm and click ``Install agi-app``.
 AGILAB installs the package into the current Python environment with
 ``uv pip install --python`` and discovers the project through the package's
-``agilab.apps`` entry point. The same expander includes an ``Installed agi-apps``
+``agilab.apps`` entry point. The same expander includes an ``Installed``
 maintenance drawer that can update or remove installed apps after explicit
 confirmation.
 

--- a/maintenance/memory/by-path/src%2Fagilab%2Fpages%2F4_ANALYSIS.py.md
+++ b/maintenance/memory/by-path/src%2Fagilab%2Fpages%2F4_ANALYSIS.py.md
@@ -1,9 +1,9 @@
 ---
 schema: agilab.maintenance_memory.v1
 source: src/agilab/pages/4_ANALYSIS.py
-source_sha256: 1ccdd3805f9dd0a6a06d074ed5895895eee10154ad5cfb89042ba6bfda8e453f
+source_sha256: a2b5de47cf1d87db01413b108e818e486395cccef3165c27b2c342a181ab1a01
 title: ANALYSIS page AgiEnv singleton contract
-verified_commit: d954f4868bc69ebc957f2b3cd0f428c2fda6d16f
+verified_commit: b58bcbf66ebfa8d41da46f98c0a2882c433144a4
 ---
 
 # ANALYSIS page AgiEnv singleton contract

--- a/src/agilab/pages/1_PROJECT.py
+++ b/src/agilab/pages/1_PROJECT.py
@@ -1119,15 +1119,19 @@ def _render_pypi_metadata_summary(preflight_payload: dict[str, object] | None) -
         st.dataframe(rows, hide_index=True, width="stretch")
 
 
+def _short_pypi_app_display_name(package: str) -> str:
+    return str(package).removeprefix("agi-app-")
+
+
 def _render_installed_pypi_app_manager(env) -> None:
     installed = _list_installed_pypi_apps()
-    st.caption("Installed agi-apps")
+    st.caption("Installed")
     if not installed:
         st.info("No installed agi-apps were discovered.")
         return
     rows = [
         {
-            "agi-app": app.package,
+            "Item": _short_pypi_app_display_name(app.package),
             "Version": app.version,
             "Provider": app.provider,
             "Entry point": app.entry_point,
@@ -1138,7 +1142,7 @@ def _render_installed_pypi_app_manager(env) -> None:
     st.dataframe(rows, hide_index=True, width="stretch")
     package_options = sorted({app.package for app in installed}, key=str.lower)
     selected_package = st.selectbox(
-        "Installed agi-app",
+        "Select one",
         options=package_options,
         key="project_pypi_app_installed_package",
     )
@@ -1265,11 +1269,13 @@ def _render_pypi_app_install_action(env) -> None:
                 disabled=not requirement or not preflight_passed or not reviewed,
                 width="stretch",
             )
-        st.checkbox(
-            "Reviewed",
-            key=reviewed_key,
-            help="Only install agi-apps you trust to run as local code.",
-        )
+        review_row = st.container()
+        with review_row:
+            st.checkbox(
+                "Reviewed",
+                key=reviewed_key,
+                help="Only install agi-apps you trust to run as local code.",
+            )
         if install_clicked:
             run_streamlit_action(
                 st,
@@ -1284,7 +1290,7 @@ def _render_pypi_app_install_action(env) -> None:
                     env
                 ),
             )
-        with st.expander("Installed agi-apps", expanded=False):
+        with st.expander("Installed", expanded=False):
             _render_installed_pypi_app_manager(env)
 
 
@@ -2605,18 +2611,6 @@ def _render_active_project_sidebar(env) -> None:
     st.session_state["_env"] = env
 
 
-def _render_sidebar_export_action(env) -> None:
-    if not getattr(env, "app", None):
-        return
-    if st.sidebar.button(
-        "Export",
-        type="secondary",
-        width="stretch",
-        help=f"Export to {(env.export_apps / env.app).with_suffix('.zip')}",
-    ):
-        handle_export_project()
-
-
 def render_project_sidebar(
     env,
     *,
@@ -2643,7 +2637,6 @@ def render_project_sidebar(
 
     _render_active_project_sidebar(env)
     env = st.session_state["env"]
-    _render_sidebar_export_action(env)
 
     sidebar_selection = compact_choice(
         st.sidebar,
@@ -2657,7 +2650,7 @@ def render_project_sidebar(
 
     if sidebar_selection == "Overview":
         st.sidebar.info(
-            "Choose Create, Import, Rename, or Delete when you need to manage projects."
+            "Choose Create, Import, Export, Rename, or Delete when you need to manage projects."
         )
     elif sidebar_selection == "Edit":
         if render_edit_body:
@@ -2666,6 +2659,8 @@ def render_project_sidebar(
             st.sidebar.info("Use Edit to open file, configuration, runtime, and code editors.")
     elif sidebar_selection == "Create":
         handle_project_creation()
+    elif sidebar_selection == "Export":
+        handle_export_project()
     elif sidebar_selection == "Rename":
         handle_project_rename()
     elif sidebar_selection == "Delete":

--- a/src/agilab/pages/4_ANALYSIS.py
+++ b/src/agilab/pages/4_ANALYSIS.py
@@ -2025,9 +2025,13 @@ def _view_label(
     builtin_names: set[str],
     *,
     app_surface_cfg: dict[str, Any] | None = None,
+    app_ui_page_cfg: dict[str, Any] | None = None,
 ) -> str:
-    if option_id == _APP_UI_PAGE_KEY and app_surface_cfg:
-        return "Page"
+    if option_id == _APP_UI_PAGE_KEY:
+        return _app_ui_view_label(
+            app_surface_cfg=app_surface_cfg,
+            app_ui_page_cfg=app_ui_page_cfg,
+        )
     if option_id in builtin_names:
         return option_id
     try:
@@ -2035,6 +2039,30 @@ def _view_label(
     except OSError:
         return option_id
     return f"{path.name} (custom)"
+
+
+def _app_ui_view_label(
+    *,
+    app_surface_cfg: dict[str, Any] | None = None,
+    app_ui_page_cfg: dict[str, Any] | None = None,
+) -> str:
+    surface_label = _analysis_app_surface_label(app_surface_cfg)
+    if surface_label:
+        return surface_label
+    if isinstance(app_ui_page_cfg, dict):
+        title = str(app_ui_page_cfg.get("title", "")).strip()
+        if title:
+            return _strip_analysis_project_suffix(title)
+    return "App UI"
+
+
+def _analysis_app_surface_label(app_surface_cfg: dict[str, Any] | None) -> str | None:
+    if not app_surface_cfg:
+        return None
+    title = app_surface_title(app_surface_cfg).strip()
+    if title and title != "App Surface":
+        return _strip_analysis_project_suffix(title)
+    return None
 
 
 def _resolve_view_path(
@@ -2332,10 +2360,9 @@ def _analysis_project_link_label(
     *,
     app_surface_cfg: dict[str, Any] | None = None,
 ) -> str:
-    if app_surface_cfg:
-        title = app_surface_title(app_surface_cfg).strip()
-        if title and title != "App Surface":
-            return _strip_analysis_project_suffix(title)
+    surface_label = _analysis_app_surface_label(app_surface_cfg)
+    if surface_label:
+        return surface_label
     return _short_analysis_project_label(project)
 
 
@@ -2385,6 +2412,7 @@ def _render_analysis_sidebar_view_launcher(
     resolved_pages: dict[str, Path],
     custom_view_lookup: dict[str, Path],
     app_surface_cfg: dict[str, Any] | None = None,
+    app_ui_page_cfg: dict[str, Any] | None = None,
 ) -> None:
     launch_options = list(dict.fromkeys(selected_views))
     if not launch_options:
@@ -2404,6 +2432,7 @@ def _render_analysis_sidebar_view_launcher(
             view_name,
             builtin_names,
             app_surface_cfg=app_surface_cfg,
+            app_ui_page_cfg=app_ui_page_cfg,
         )
         if view_path is None:
             missing_views.append(display_label)
@@ -2989,6 +3018,7 @@ async def main():
             resolved_pages=resolved_pages,
             custom_view_lookup=custom_view_lookup,
             app_surface_cfg=app_surface_config(active_app_path, cfg),
+            app_ui_page_cfg=pages_cfg.get(_APP_UI_PAGE_KEY),
         )
         _render_analysis_sidebar_notebook_launcher(
             project=project,
@@ -3064,6 +3094,7 @@ async def main():
                 option,
                 set(resolved_pages.keys()),
                 app_surface_cfg=app_surface_config(active_app_path, cfg),
+                app_ui_page_cfg=pages_cfg.get(_APP_UI_PAGE_KEY),
             ),
             help="Selected views are persisted in the active project's app settings.",
         )

--- a/src/agilab/project_sidebar_support.py
+++ b/src/agilab/project_sidebar_support.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from typing import Any, Callable, Iterable
 
-PROJECT_EDITOR_ACTIONS = ("Edit", "Create", "Import", "Rename", "Delete")
+PROJECT_EDITOR_ACTIONS = ("Edit", "Create", "Import", "Export", "Rename", "Delete")
 PROJECT_EDIT_ACTIONS = PROJECT_EDITOR_ACTIONS
-PROJECT_STATUS_ACTIONS = ("Overview", "Create", "Import", "Rename", "Delete")
+PROJECT_STATUS_ACTIONS = ("Overview", "Create", "Import", "Export", "Rename", "Delete")
 
 
 def normalize_project_sidebar_actions(actions: Iterable[Any]) -> tuple[str, ...]:

--- a/test/test_agilab_widget_robot.py
+++ b/test/test_agilab_widget_robot.py
@@ -1020,14 +1020,14 @@ def test_required_link_probe_matches_label_and_href_fragments() -> None:
         @staticmethod
         def get_by_role(role: str, name):
             assert role == "link"
-            assert getattr(name, "pattern", "Page") == "Page"
+            assert getattr(name, "pattern", "PyTorch Playground") == "PyTorch\\ Playground"
             return _LinkLocator()
 
     probe = module._required_link_probe(
         _Page(),
         app_name="pytorch_playground_project",
         display="ANALYSIS",
-        required_links=("Page=>current_page=view_app_ui;pytorch_playground_project",),
+        required_links=("PyTorch Playground=>current_page=view_app_ui;pytorch_playground_project",),
         timeout_ms=100,
     )
 
@@ -1068,7 +1068,7 @@ def test_required_link_probe_reports_missing_href_fragment() -> None:
         _Page(),
         app_name="pytorch_playground_project",
         display="ANALYSIS",
-        required_links=("Page=>current_page=view_app_ui",),
+        required_links=("PyTorch Playground=>current_page=view_app_ui",),
         timeout_ms=100,
     )
 

--- a/test/test_agilab_widget_robot_matrix.py
+++ b/test/test_agilab_widget_robot_matrix.py
@@ -219,7 +219,7 @@ def test_opt_in_mobile_and_release_evidence_scenarios_are_not_part_of_default_al
     assert pytorch_analysis.pages == "ANALYSIS"
     assert pytorch_analysis.required_text == "PyTorch Playground,Refresh evidence,Synced RUN snippet,Settings"
     assert pytorch_analysis.forbidden_sidebar_text == "Project:"
-    assert pytorch_analysis.required_links == "Page=>current_page=view_app_ui"
+    assert pytorch_analysis.required_links == "PyTorch Playground=>current_page=view_app_ui"
     assert pytorch_analysis.required_action_labels == "Refresh evidence"
     assert pytorch_analysis.browser_error_check is True
     assert above_fold.above_fold_check is True
@@ -551,7 +551,7 @@ def test_build_robot_command_covers_pytorch_playground_analysis_text(tmp_path) -
     assert argv[argv.index("--apps-pages") + 1] == "none"
     assert argv[argv.index("--required-text") + 1] == "PyTorch Playground,Refresh evidence,Synced RUN snippet,Settings"
     assert argv[argv.index("--forbidden-sidebar-text") + 1] == "Project:"
-    assert argv[argv.index("--required-links") + 1] == "Page=>current_page=view_app_ui"
+    assert argv[argv.index("--required-links") + 1] == "PyTorch Playground=>current_page=view_app_ui"
     assert argv[argv.index("--required-action-labels") + 1] == "Refresh evidence"
     assert "--browser-error-check" in argv
     assert summary_path == tmp_path / "isolated-pytorch-playground-analysis.json"
@@ -2184,7 +2184,7 @@ def test_build_robot_command_passes_analysis_contract_controls(tmp_path) -> None
     assert _value_after(argv, "--pages") == "ANALYSIS"
     assert _value_after(argv, "--required-text") == "PyTorch Playground,Refresh evidence,Synced RUN snippet,Settings"
     assert _value_after(argv, "--forbidden-sidebar-text") == "Project:"
-    assert _value_after(argv, "--required-links") == "Page=>current_page=view_app_ui"
+    assert _value_after(argv, "--required-links") == "PyTorch Playground=>current_page=view_app_ui"
     assert _value_after(argv, "--required-action-labels") == "Refresh evidence"
     assert "--browser-error-check" in argv
     assert summary_path == tmp_path / "isolated-pytorch-playground-analysis.json"

--- a/test/test_analysis_page_helpers.py
+++ b/test/test_analysis_page_helpers.py
@@ -1470,6 +1470,36 @@ default = "streamlit"
     assert cfg["app_surface"]["entrypoint"] == "demo_surface/app.py"
 
 
+def test_view_app_ui_label_uses_declared_title_not_internal_route() -> None:
+    module = _load_analysis_module()
+    builtin_names = {"view_app_ui", "view_maps"}
+
+    assert (
+        module._view_label(
+            "view_app_ui",
+            builtin_names,
+            app_surface_cfg={
+                "title": "PyTorch Playground",
+                "entrypoint": "pytorch_playground/app_surface.py",
+            },
+        )
+        == "PyTorch Playground"
+    )
+    assert (
+        module._view_label(
+            "view_app_ui",
+            builtin_names,
+            app_ui_page_cfg={
+                "title": "Flight Telemetry Project",
+                "entrypoint": "demo/ui.py",
+            },
+        )
+        == "Flight Telemetry"
+    )
+    assert module._view_label("view_app_ui", builtin_names) == "App UI"
+    assert module._view_label("view_maps", builtin_names) == "view_maps"
+
+
 def test_analysis_page_state_handles_invalid_and_unresolved_defaults(tmp_path: Path):
     state_module = _load_analysis_state_module()
 

--- a/test/test_page_project_selector.py
+++ b/test/test_page_project_selector.py
@@ -194,7 +194,7 @@ def test_project_selector_edit_button_prefers_registered_navigation_page(monkeyp
     monkeypatch.setitem(
         sys.modules,
         "agilab.main_page",
-        SimpleNamespace(_NAVIGATION_PAGE_ROUTES={"project": route}),
+        SimpleNamespace(_NAVIGATION_PAGE_ROUTES={module.PROJECT_ROUTE_ID: route}),
     )
     monkeypatch.delattr(sys.modules["__main__"], "_NAVIGATION_PAGE_ROUTES", raising=False)
 
@@ -228,29 +228,29 @@ def test_registered_navigation_page_prefers_main_module_route(monkeypatch) -> No
     monkeypatch.setattr(
         sys.modules["__main__"],
         "_NAVIGATION_PAGE_ROUTES",
-        {"project": main_route},
+        {module.PROJECT_ROUTE_ID: main_route},
         raising=False,
     )
     monkeypatch.setitem(
         sys.modules,
         "agilab.main_page",
-        SimpleNamespace(_NAVIGATION_PAGE_ROUTES={"project": fallback_route}),
+        SimpleNamespace(_NAVIGATION_PAGE_ROUTES={module.PROJECT_ROUTE_ID: fallback_route}),
     )
 
-    assert module._registered_navigation_page("project") is main_route
+    assert module._registered_navigation_page(module.PROJECT_ROUTE_ID) is main_route
 
 
 def test_registered_navigation_page_ignores_missing_or_invalid_routes(monkeypatch) -> None:
     module = _load_module()
 
-    monkeypatch.setattr(sys.modules["__main__"], "_NAVIGATION_PAGE_ROUTES", ["project"], raising=False)
+    monkeypatch.setattr(sys.modules["__main__"], "_NAVIGATION_PAGE_ROUTES", [module.PROJECT_ROUTE_ID], raising=False)
     monkeypatch.setitem(
         sys.modules,
         "agilab.main_page",
-        SimpleNamespace(_NAVIGATION_PAGE_ROUTES={"project": None, "analysis": object()}),
+        SimpleNamespace(_NAVIGATION_PAGE_ROUTES={module.PROJECT_ROUTE_ID: None, "analysis": object()}),
     )
 
-    assert module._registered_navigation_page("project") is None
+    assert module._registered_navigation_page(module.PROJECT_ROUTE_ID) is None
 
 
 def test_switch_to_project_page_handles_missing_switch_page_without_side_effects() -> None:

--- a/test/test_project_sidebar_support.py
+++ b/test/test_project_sidebar_support.py
@@ -14,14 +14,17 @@ from agilab.project_sidebar_support import (
 
 def test_normalize_project_sidebar_actions_aliases_clone_and_rejects_unknown() -> None:
     assert PROJECT_EDITOR_ACTIONS[0] == "Edit"
-    assert normalize_project_sidebar_actions(["Overview", "Clone", "Create", "Delete"]) == (
+    assert "Export" in PROJECT_EDITOR_ACTIONS
+    assert "Export" in PROJECT_STATUS_ACTIONS
+    assert normalize_project_sidebar_actions(["Overview", "Clone", "Export", "Delete"]) == (
         "Overview",
         "Create",
+        "Export",
         "Delete",
     )
 
     with pytest.raises(ValueError, match="Unsupported PROJECT sidebar action"):
-        normalize_project_sidebar_actions(["Overview", "Export"])
+        normalize_project_sidebar_actions(["Overview", "Launch"])
 
 
 def test_project_sidebar_session_defaults_cover_status_host_state() -> None:

--- a/test/test_ui_pages.py
+++ b/test/test_ui_pages.py
@@ -83,6 +83,9 @@ def test_primary_pages_keep_homogeneous_support_field_order() -> None:
     project_source = Path("src/agilab/pages/1_PROJECT.py").read_text(
         encoding="utf-8"
     )
+    project_sidebar_source = Path("src/agilab/project_sidebar_support.py").read_text(
+        encoding="utf-8"
+    )
     analysis_main = analysis_source[analysis_source.index("async def main():") :]
     workflow_main_marker = (
         "async def main" if "async def main" in workflow_source else "def main"
@@ -93,6 +96,7 @@ def test_primary_pages_keep_homogeneous_support_field_order() -> None:
     assert '"Install",' in project_source
     assert '"Reviewed",' in project_source
     assert "check_col, install_col = st.columns" in project_source
+    assert "review_row = st.container()" in project_source
     assert "review_col" not in project_source
     assert "project_pypi_app_reviewed_requirement" in project_source
     assert "preflight_passed = preflight_status in" in project_source
@@ -103,6 +107,36 @@ def test_primary_pages_keep_homogeneous_support_field_order() -> None:
     assert "Check agi-app" not in project_source
     assert "Install agi-app" not in project_source
     assert "Reviewed agi-app" not in project_source
+    assert 'st.expander("Installed", expanded=False)' in project_source
+    assert "Installed agi-apps" not in project_source
+    assert "Installed agi-app" not in project_source
+    assert '"Select one",' in project_source
+    assert "def _short_pypi_app_display_name(package: str) -> str:" in project_source
+    assert '"Item": _short_pypi_app_display_name(app.package)' in project_source
+    assert '"agi-app": app.package' not in project_source
+    _assert_ordered_fragments(
+        project_source,
+        (
+            "check_col, install_col = st.columns(2)",
+            "with install_col:",
+            "review_row = st.container()",
+            "with review_row:",
+            'st.checkbox(\n                "Reviewed",',
+        ),
+    )
+    assert "_render_sidebar_export_action" not in project_source
+    assert (
+        'PROJECT_EDITOR_ACTIONS = ("Edit", "Create", "Import", "Export", '
+        '"Rename", "Delete")'
+        in project_sidebar_source
+    )
+    assert (
+        'PROJECT_STATUS_ACTIONS = ("Overview", "Create", "Import", '
+        '"Export", "Rename", "Delete")'
+        in project_sidebar_source
+    )
+    assert 'elif sidebar_selection == "Export":' in project_source
+    assert "handle_export_project()" in project_source
 
     _assert_ordered_fragments(
         analysis_main,
@@ -1933,7 +1967,7 @@ def test_explore_page_app_surface_back_keeps_single_app_ui_sidebar_view(mock_ui_
     assert "**Flight Telemetry**" in sidebar_markdown
     assert "Flight Telemetry Project" not in sidebar_markdown
     assert "Project:" not in sidebar_markdown
-    assert ">Page</a>" in sidebar_markdown
+    assert ">Flight Telemetry</a>" in sidebar_markdown
     assert ">view_app_ui</a>" not in sidebar_markdown
     assert sidebar_markdown.count("current_page=view_app_ui") == 1
     assert "view_other" not in sidebar_markdown
@@ -2000,7 +2034,7 @@ def test_explore_page_app_surface_uses_standard_view_selection(mock_ui_env):
     assert "Project:" not in sidebar_markdown
     assert "surface:analysis" not in markdown_text
     assert "surface:controls" not in sidebar_markdown
-    assert ">Page</a>" in sidebar_markdown
+    assert ">Demo Surface</a>" in sidebar_markdown
     assert ">view_app_ui</a>" not in sidebar_markdown
     assert sidebar_markdown.count("current_page=view_app_ui") == 1
     assert "Choose analysis views" in [str(item.label) for item in at.expander]
@@ -2017,7 +2051,7 @@ def test_explore_page_app_surface_uses_standard_view_selection(mock_ui_env):
     sidebar_markdown = "\n".join(str(item.value) for item in at.sidebar.markdown)
     sidebar_markdown = "\n".join(str(item.value) for item in at.sidebar.markdown)
     assert "Project:" not in sidebar_markdown
-    assert ">Page</a>" in sidebar_markdown
+    assert ">Demo Surface</a>" in sidebar_markdown
     assert ">view_app_ui</a>" not in sidebar_markdown
     assert "view_extra" in sidebar_markdown
     assert "current_page=" in sidebar_markdown
@@ -2350,10 +2384,10 @@ def test_project_sidebar_orders_active_project_before_actions():
     sidebar_body = source[source.index("def render_project_sidebar(") :]
 
     active_project_index = sidebar_body.index("_render_active_project_sidebar(env)")
-    export_index = sidebar_body.index("_render_sidebar_export_action(env)")
     action_index = sidebar_body.index('"Project action"')
 
-    assert active_project_index < export_index < action_index
+    assert active_project_index < action_index
+    assert "_render_sidebar_export_action" not in sidebar_body
     assert "Project workflow" not in source
     assert "### Active project" not in source
     assert "_render_sidebar_project_metric" not in source
@@ -3085,8 +3119,8 @@ def test_project_status_page_owns_project_selectbox_edit_button_and_sidebar_acti
     assert "templates" in at.session_state
     assert "archives" in at.session_state
     assert "clone_env_strategy" not in at.session_state
-    assert any(button.label == "Export" for button in at.sidebar.button)
     sidebar_button_labels = [str(button.label) for button in at.sidebar.button]
+    assert "Export" not in sidebar_button_labels
     assert "Check" in sidebar_button_labels
     assert "Install" in sidebar_button_labels
     assert "Check agi-app" not in sidebar_button_labels

--- a/test/test_ui_robot_action_contract.py
+++ b/test/test_ui_robot_action_contract.py
@@ -66,10 +66,12 @@ def test_ui_robot_action_contract_passes_for_current_ui_surface() -> None:
     assert payload["schema"] == module.SCHEMA
     assert payload["success"] is True
     assert payload["issues"] == []
-    assert actions_by_label["INSTALL"]["disposition"] == "selected-click"
+    assert actions_by_label["Install"]["disposition"] == "selected-click"
     assert actions_by_label["Run -> Load -> Export"]["disposition"] == "selected-click"
     assert actions_by_label["Delete"]["disposition"] == "trial-only"
-    assert actions_by_label["Export"]["disposition"] == "trial-only"
+    assert "Export" not in actions_by_label
+    assert actions_by_label["Remove"]["disposition"] == "trial-only"
+    assert actions_by_label["Update"]["disposition"] == "trial-only"
     assert actions_by_label["Overwrite"]["disposition"] == "ignored"
     assert actions_by_label["Rebuild Universal Offline knowledge base"]["disposition"] == "ignored"
     assert actions_by_label["Reset"]["disposition"] == "trial-only"

--- a/test/test_ui_robot_coverage_contract.py
+++ b/test/test_ui_robot_coverage_contract.py
@@ -107,7 +107,7 @@ def test_ui_robot_coverage_contract_passes_for_current_matrix() -> None:
         "flags": ["browser_error_check"],
         "pages": ["ANALYSIS"],
         "required_actions": ["Refresh evidence"],
-        "required_links": ["Page=>current_page=view_app_ui"],
+        "required_links": ["PyTorch Playground=>current_page=view_app_ui"],
         "required_text": ["PyTorch Playground", "Refresh evidence", "Settings", "Synced RUN snippet"],
     }
     assert payload["coverage"]["hf_robot_scenarios"]["hf-first-proof-visual-smoke"] == {
@@ -639,7 +639,7 @@ def test_ui_robot_coverage_contract_reports_matrix_and_pytorch_gaps(monkeypatch,
     assert "isolated-pytorch-playground-analysis is missing forbidden sidebar text probes: Project:" in details
     assert (
         "isolated-pytorch-playground-analysis is missing required link probes: "
-        "Page=>current_page=view_app_ui"
+        "PyTorch Playground=>current_page=view_app_ui"
     ) in details
     assert "isolated-pytorch-playground-analysis is missing required action probes: Refresh evidence" in details
     assert "isolated-pytorch-playground-analysis does not enable browser_error_check" in details

--- a/tools/agilab_widget_robot_matrix.py
+++ b/tools/agilab_widget_robot_matrix.py
@@ -513,7 +513,7 @@ OPT_IN_SCENARIOS: dict[str, RobotScenario] = {
         apps="pytorch_playground_project",
         required_text="PyTorch Playground,Refresh evidence,Synced RUN snippet,Settings",
         forbidden_sidebar_text="Project:",
-        required_links="Page=>current_page=view_app_ui",
+        required_links="PyTorch Playground=>current_page=view_app_ui",
         required_action_labels="Refresh evidence",
         action_timeout_seconds=30.0,
         page_timeout_seconds=420.0,

--- a/tools/ui_robot_action_contract.py
+++ b/tools/ui_robot_action_contract.py
@@ -59,10 +59,6 @@ EXPLICIT_ACTION_DISPOSITIONS: Mapping[str, tuple[str, str]] = {
         "trial-only",
         "destructive project-level delete action; focused tests cover confirmation behavior",
     ),
-    "Export": (
-        "trial-only",
-        "project export is not part of the first-proof selected-click path",
-    ),
     "Export promotion decision": (
         "trial-only",
         "apps-page export side effect is covered by page-specific tests and visual robots",
@@ -70,10 +66,6 @@ EXPLICIT_ACTION_DISPOSITIONS: Mapping[str, tuple[str, str]] = {
     "Import": (
         "trial-only",
         "project import is probed through PROJECT import scenarios without firing archive import",
-    ),
-    "Install PyPI app": (
-        "trial-only",
-        "installs a reviewed external app package; helper tests cover command construction without mutating the environment",
     ),
     "Overwrite": (
         "ignored",
@@ -91,7 +83,7 @@ EXPLICIT_ACTION_DISPOSITIONS: Mapping[str, tuple[str, str]] = {
         "trial-only",
         "project rename is probed through PROJECT rename scenarios without mutating the project",
     ),
-    "Remove PyPI app": (
+    "Remove": (
         "trial-only",
         "removes an installed external app package only after explicit user confirmation",
     ),
@@ -123,7 +115,7 @@ EXPLICIT_ACTION_DISPOSITIONS: Mapping[str, tuple[str, str]] = {
         "trial-only",
         "stateful recovery action that appears only after selected delete-output flows",
     ),
-    "Update PyPI app": (
+    "Update": (
         "trial-only",
         "updates an installed external app package only after explicit user confirmation",
     ),

--- a/tools/ui_robot_coverage_contract.py
+++ b/tools/ui_robot_coverage_contract.py
@@ -37,7 +37,7 @@ REQUIRED_PYTORCH_ANALYSIS_SCENARIO = "isolated-pytorch-playground-analysis"
 REQUIRED_PYTORCH_ANALYSIS_APP = "pytorch_playground_project"
 REQUIRED_PYTORCH_ANALYSIS_TEXT = ("PyTorch Playground", "Refresh evidence", "Synced RUN snippet", "Settings")
 REQUIRED_PYTORCH_ANALYSIS_FORBIDDEN_SIDEBAR_TEXT = ("Project:",)
-REQUIRED_PYTORCH_ANALYSIS_LINKS = ("Page=>current_page=view_app_ui",)
+REQUIRED_PYTORCH_ANALYSIS_LINKS = ("PyTorch Playground=>current_page=view_app_ui",)
 REQUIRED_PYTORCH_ANALYSIS_ACTIONS = ("Refresh evidence",)
 REQUIRED_HF_ROBOT_SCENARIOS = {
     "hf-first-proof-visual-smoke": {


### PR DESCRIPTION
## Summary
- Shorten PROJECT agi-app sidebar labels and action names.
- Use product-facing ANALYSIS app UI link labels instead of the internal view_app_ui/Page label.
- Align robot/matrix contracts, docs quick-start wording, and maintenance memory.

## Validation
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_ui_pages.py test/test_project_sidebar_support.py test/test_agilab_widget_robot.py test/test_agilab_widget_robot_matrix.py test/test_analysis_page_helpers.py test/test_page_project_selector.py test/test_ui_robot_action_contract.py test/test_ui_robot_coverage_contract.py
- uv --preview-features extra-build-dependencies run python tools/maintenance_memory.py check --files src/agilab/pages/4_ANALYSIS.py
- uv --preview-features extra-build-dependencies run python tools/maintenance_memory.py check --all
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui
