### PR TITLE
Guard against recursive SSHFS cluster shares

### DIFF
--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_remote_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_remote_support.py
@@ -3,6 +3,7 @@ import logging
 import os
 import re
 import shlex
+import subprocess
 import uuid
 from pathlib import Path, PurePosixPath
 from shlex import quote
@@ -42,6 +43,10 @@ _SSHFS_OPTIONS = (
 )
 _REMOTE_PATH_PREFIX = (
     'export PATH="$HOME/.local/bin:$HOME/bin:/usr/local/bin:/opt/homebrew/bin:$PATH"; '
+)
+_REVERSE_SSHFS_LOOP_HINT = (
+    "Unmount the local reverse SSHFS viewer mount or use a non-overlapping viewer "
+    "path such as ~/worker_clustershare before running cluster INSTALL/RUN."
 )
 
 
@@ -149,6 +154,89 @@ def _remote_share_unmount_snippet() -> str:
         "elif command -v fusermount >/dev/null 2>&1; then "
         'fusermount -u "$REMOTE_CLUSTER_SHARE" || true; '
         'else umount "$REMOTE_CLUSTER_SHARE" || true; fi'
+    )
+
+
+def _sshfs_source_host(source: str) -> str:
+    cleaned = str(source or "").strip()
+    if cleaned.startswith("sshfs#"):
+        cleaned = cleaned.split("#", 1)[1]
+    if not cleaned:
+        return ""
+
+    if cleaned.startswith("[") or "@[" in cleaned:
+        prefix = cleaned.rsplit("]:", 1)[0] + "]" if "]:" in cleaned else cleaned
+    elif ":" in cleaned:
+        prefix = cleaned.split(":", 1)[0]
+    else:
+        prefix = cleaned
+
+    host = prefix.rsplit("@", 1)[-1]
+    if host.startswith("[") and host.endswith("]"):
+        return host[1:-1]
+    return host
+
+
+def _local_mount_record_for_path(path: Path) -> dict[str, str] | None:
+    try:
+        completed = subprocess.run(
+            [
+                "findmnt",
+                "-T",
+                path.as_posix(),
+                "-n",
+                "-P",
+                "-o",
+                "TARGET,SOURCE,FSTYPE",
+            ],
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if completed.returncode != 0:
+        return None
+
+    line = completed.stdout.strip().splitlines()[0] if completed.stdout.strip() else ""
+    if not line:
+        return None
+
+    record: dict[str, str] = {}
+    try:
+        fields = shlex.split(line, posix=True)
+    except ValueError:
+        return None
+    for field in fields:
+        if "=" not in field:
+            continue
+        key, value = field.split("=", 1)
+        record[key] = value
+    return record or None
+
+
+def _reverse_sshfs_mount_problem(local_share: Path, worker_ip: str) -> str | None:
+    record = _local_mount_record_for_path(local_share)
+    if not record:
+        return None
+
+    fstype = record.get("FSTYPE", "")
+    if "sshfs" not in fstype.lower():
+        return None
+
+    source = record.get("SOURCE", "")
+    source_host = _sshfs_source_host(source)
+    if source_host != str(worker_ip or "").strip():
+        return None
+
+    target = record.get("TARGET", "")
+    return (
+        f"Refusing to mount AGI_CLUSTER_SHARE on remote worker {worker_ip}: "
+        f"scheduler share {local_share.as_posix()} is already inside SSHFS mount "
+        f"{target or '<unknown target>'} from the same worker ({source}). "
+        "Mounting the scheduler share back onto that worker would create an SSHFS loop. "
+        f"{_REVERSE_SSHFS_LOOP_HINT}"
     )
 
 
@@ -279,6 +367,9 @@ async def _prepare_remote_cluster_share(
         or remote_share
     )
     local_share = _resolve_local_share_path(local_share_raw, env)
+    reverse_mount_problem = _reverse_sshfs_mount_problem(local_share, ip)
+    if reverse_mount_problem:
+        raise RuntimeError(reverse_mount_problem)
     local_share.mkdir(parents=True, exist_ok=True)
 
     remote_share_setting = _home_relative_share_setting(remote_share, env)

--- a/src/agilab/core/test/test_agi_distributor_deployment_remote_support.py
+++ b/src/agilab/core/test/test_agi_distributor_deployment_remote_support.py
@@ -140,6 +140,27 @@ def test_remote_command_helpers_quote_dynamic_arguments():
     assert deployment_remote_support._remote_tool("", "uv --quiet") == "uv --quiet"
 
 
+def test_sshfs_source_host_parses_common_sources():
+    assert (
+        deployment_remote_support._sshfs_source_host(
+            "agi@192.168.20.15:/home/agi/clustershare"
+        )
+        == "192.168.20.15"
+    )
+    assert (
+        deployment_remote_support._sshfs_source_host(
+            "sshfs#agi@worker.local:/home/agi/clustershare"
+        )
+        == "worker.local"
+    )
+    assert (
+        deployment_remote_support._sshfs_source_host(
+            "agi@[2001:db8::1]:/home/agi/clustershare"
+        )
+        == "2001:db8::1"
+    )
+
+
 def test_remote_environment_and_scheduler_port_edge_helpers(monkeypatch):
     assert deployment_remote_support._env_lookup(SimpleNamespace(FIRST="attr"), "FIRST") == "attr"
     assert (
@@ -653,6 +674,81 @@ async def test_prepare_remote_cluster_share_honors_custom_scheduler_ssh_port(tmp
     assert "SCHEDULER_SSH_PORT=2222" in mount_cmd
     assert 'ssh -p "$SCHEDULER_SSH_PORT"' in mount_cmd
     assert 'sshfs -p "$SCHEDULER_SSH_PORT"' in mount_cmd
+
+
+@pytest.mark.asyncio
+async def test_prepare_remote_cluster_share_rejects_reverse_sshfs_loop(tmp_path, monkeypatch):
+    scheduler_share = tmp_path / "clustershare" / "agi"
+    env = SimpleNamespace(
+        AGI_CLUSTER_SHARE=str(scheduler_share),
+        envars={},
+        home_abs=tmp_path,
+        user="agi",
+        verbose=0,
+    )
+    ssh_calls: list[str] = []
+
+    class _Agi:
+        _scheduler_ip = "192.168.20.141"
+
+        async def exec_ssh(self, _ip, cmd):
+            ssh_calls.append(cmd)
+            return "ok"
+
+    monkeypatch.setattr(
+        deployment_remote_support,
+        "_local_mount_record_for_path",
+        lambda _path: {
+            "TARGET": str(tmp_path / "clustershare"),
+            "SOURCE": "agi@192.168.20.15:/home/agi/clustershare",
+            "FSTYPE": "fuse.sshfs",
+        },
+    )
+
+    with pytest.raises(RuntimeError, match="SSHFS loop"):
+        await deployment_remote_support._prepare_remote_cluster_share(
+            _Agi(), "192.168.20.15", env, "clustershare/agi"
+        )
+
+    assert ssh_calls == []
+    assert not scheduler_share.exists()
+
+
+@pytest.mark.asyncio
+async def test_prepare_remote_cluster_share_allows_unrelated_sshfs_mount(tmp_path, monkeypatch):
+    scheduler_share = tmp_path / "clustershare" / "agi"
+    env = SimpleNamespace(
+        AGI_CLUSTER_SHARE=str(scheduler_share),
+        envars={},
+        home_abs=tmp_path,
+        user="agi",
+        verbose=0,
+    )
+    ssh_calls: list[str] = []
+
+    class _Agi:
+        _scheduler_ip = "192.168.20.141"
+
+        async def exec_ssh(self, _ip, cmd):
+            ssh_calls.append(cmd)
+            return "ok"
+
+    monkeypatch.setattr(
+        deployment_remote_support,
+        "_local_mount_record_for_path",
+        lambda _path: {
+            "TARGET": str(tmp_path / "clustershare"),
+            "SOURCE": "agi@192.168.20.99:/home/agi/clustershare",
+            "FSTYPE": "fuse.sshfs",
+        },
+    )
+
+    await deployment_remote_support._prepare_remote_cluster_share(
+        _Agi(), "192.168.20.15", env, "clustershare/agi"
+    )
+
+    assert scheduler_share.is_dir()
+    assert any("SCHEDULER_CLUSTER_SHARE" in cmd for cmd in ssh_calls)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- fail fast before preparing a remote cluster share when the scheduler share is already inside an SSHFS mount from the same worker
- add parsing and regression coverage for the reverse SSHFS loop guard

## Validation
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' --import-mode=importlib src/agilab/core/test/test_agi_distributor_deployment_remote_support.py
- uv --preview-features extra-build-dependencies run --no-sync pytest -q -o addopts='' --import-mode=importlib src/agilab/core/test
- git diff --check -- src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_remote_support.py src/agilab/core/test/test_agi_distributor_deployment_remote_support.py