### PR TITLE
Reset polluted Flight args strictly

### DIFF
--- a/src/agilab/apps/builtin/flight_telemetry_project/src/app_args_form.py
+++ b/src/agilab/apps/builtin/flight_telemetry_project/src/app_args_form.py
@@ -77,15 +77,10 @@ def _try_repair_foreign_args_payload(settings_path: Path) -> FlightArgs | None:
     if not unknown_keys:
         return None
 
-    known_payload = {
-        key: value for key, value in raw_payload.items() if key in field_names
-    }
     try:
-        repaired = apply_source_defaults(FlightArgs(**known_payload))
-    except Exception:
-        if known_payload:
-            return None
         repaired = apply_source_defaults(FlightArgs())
+    except Exception:
+        return None
 
     try:
         dump_args_to_toml(repaired, settings_path)

--- a/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/src/app_args_form.py
+++ b/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/src/app_args_form.py
@@ -77,15 +77,10 @@ def _try_repair_foreign_args_payload(settings_path: Path) -> FlightArgs | None:
     if not unknown_keys:
         return None
 
-    known_payload = {
-        key: value for key, value in raw_payload.items() if key in field_names
-    }
     try:
-        repaired = apply_source_defaults(FlightArgs(**known_payload))
-    except Exception:
-        if known_payload:
-            return None
         repaired = apply_source_defaults(FlightArgs())
+    except Exception:
+        return None
 
     try:
         dump_args_to_toml(repaired, settings_path)

--- a/test/test_app_args_form_normalization.py
+++ b/test/test_app_args_form_normalization.py
@@ -189,6 +189,7 @@ def test_flight_app_args_form_repairs_foreign_workspace_args(tmp_path: Path) -> 
                 "cluster_enabled = true",
                 "",
                 "[args]",
+                'data_out = "pytorch_playground/evidence"',
                 'dataset = "circles"',
                 "sample_count = 320",
                 "noise = 0.08",
@@ -227,6 +228,7 @@ def test_flight_app_args_form_repairs_foreign_workspace_args(tmp_path: Path) -> 
     assert persisted["cluster"]["cluster_enabled"] is True
     assert persisted["args"]["data_source"] == "file"
     assert persisted["args"]["data_in"] == "flight_telemetry/dataset"
+    assert persisted["args"]["data_out"] == "flight_telemetry/dataframe"
     assert "dataset" not in persisted["args"]
     assert "hidden_layers" not in persisted["args"]
 


### PR DESCRIPTION
## Summary
- Make Flight args pollution repair discard the full foreign `[args]` payload when any non-Flight keys are present.
- Preserve the packaged agi-app Flight form mirror.
- Extend the regression to cover a mixed payload with a semantically foreign `data_out` value.

## Root cause
The first repair removed strict-validation failures from foreign keys, but a mixed polluted payload could still retain coincidentally valid Flight fields such as `data_out = "pytorch_playground/evidence"`. That left the workspace semantically polluted after the validation error disappeared.

## Validation
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_app_args_form_normalization.py`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui`
