### PR TITLE
[codex] Propagate Windows app test install flag

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1006,7 +1006,7 @@ function Install-Apps {
         if ($AppFilter -and $AppFilter.Count -gt 0) {
             $env:BUILTIN_APPS_OVERRIDE = ($AppFilter -join ',')
         }
-        & ".\install_apps.ps1"
+        & ".\install_apps.ps1" -TestApps:$RunPytest
         if ($LASTEXITCODE -ne 0) {
             Write-Warn "install_apps.ps1 exited with code $LASTEXITCODE"
             return $false

--- a/test/test_install_local_models.py
+++ b/test/test_install_local_models.py
@@ -178,6 +178,13 @@ def test_windows_installer_internet_check_uses_packaging_endpoints() -> None:
     assert "https://api.github.com/zen" in ps1_text
 
 
+def test_windows_root_installer_propagates_test_apps_to_app_installer() -> None:
+    ps1_text = INSTALL_PS1.read_text(encoding="utf-8")
+
+    assert '& ".\\install_apps.ps1" -TestApps:$RunPytest' in ps1_text
+    assert '& ".\\install_apps.ps1"\n' not in ps1_text
+
+
 def test_root_installer_default_share_dir_is_user_scoped() -> None:
     script_text = INSTALL_SH.read_text(encoding="utf-8")
     function_body = "\n".join(


### PR DESCRIPTION
## Summary
- propagate `-TestApps` from the Windows root installer to `install_apps.ps1`
- add a regression assertion so Windows app-test log coverage cannot silently disappear again

## Root cause
`install.ps1 -TestApps` enabled app installation, but the `Install-Apps` wrapper called `install_apps.ps1` without passing `-TestApps`. App installation logs were visible through the PowerShell transcript, but app test execution and its logs were skipped on the Windows root-installer path.

## Validation
- `./dev scope`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_install_local_models.py::test_windows_root_installer_propagates_test_apps_to_app_installer`
- `pwsh -NoProfile -Command '[System.Management.Automation.Language.Parser]::ParseFile("install.ps1",[ref]$null,[ref]$errors)'` parse check
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files install.ps1 test/test_install_local_models.py`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_install_apps_discovery.py test/test_install_contract_check.py test/test_install_local_models.py test/test_install_release_proof_package.py`
