### PR TITLE
Fix app contract matrix plain Python module loading

### DIFF
--- a/test/test_app_contract_matrix.py
+++ b/test/test_app_contract_matrix.py
@@ -61,6 +61,24 @@ def test_discover_builtin_projects_ignores_untracked_workspace_dirs(tmp_path: Pa
     assert module.discover_builtin_projects(tmp_path) == (tracked_project,)
 
 
+def test_load_module_supports_package_imports_without_preexisting_src_path(monkeypatch):
+    module = _load_module()
+    src_path = str((ROOT / "src").resolve())
+    monkeypatch.setattr(module.sys, "path", [path for path in sys.path if path != src_path])
+    for name in list(sys.modules):
+        if name == "agilab" or name.startswith("agilab."):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+
+    loaded = module._load_module(
+        ROOT,
+        Path("src/agilab/pypi_app_packages.py"),
+        "agilab_app_contract_pypi_app_packages_plain_python_test",
+    )
+
+    assert loaded.PROMOTED_PYPI_APP_PACKAGES
+    assert src_path not in module.sys.path
+
+
 def test_app_contract_matrix_detects_promoted_catalog_drift():
     module = _load_module()
 

--- a/tools/app_contract_matrix.py
+++ b/tools/app_contract_matrix.py
@@ -78,12 +78,23 @@ def _check(
 
 def _load_module(repo_root: Path, relative_path: Path, module_name: str):
     module_path = repo_root / relative_path
+    src_path = str((repo_root / "src").resolve())
+    inserted_src_path = src_path not in sys.path
+    if inserted_src_path:
+        sys.path.insert(0, src_path)
     spec = importlib.util.spec_from_file_location(module_name, module_path)
     if spec is None or spec.loader is None:
         raise RuntimeError(f"Cannot load module: {module_path}")
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
-    spec.loader.exec_module(module)
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        if inserted_src_path:
+            try:
+                sys.path.remove(src_path)
+            except ValueError:
+                pass
     return module
 
 


### PR DESCRIPTION
## Summary
- Fix `tools/app_contract_matrix.py` plain-Python file loading after package-layout shims started importing `agilab.*` modules.
- Temporarily add `repo/src` to `sys.path` while loading file-based modules and restore it afterward.
- Add a regression for loading `src/agilab/pypi_app_packages.py` without a preexisting `src` path.

## Root cause
`repo-guardrails` runs `python tools/app_contract_matrix.py --output app-contract-matrix.json --quiet` directly. After module classification, `src/agilab/pypi_app_packages.py` is a compatibility shim importing `agilab.compat.module_shim`; direct Python execution did not expose `src`, so CI failed with `ModuleNotFoundError: No module named 'agilab'`.

## Validation
- `python3 tools/app_contract_matrix.py --output /tmp/app-contract-matrix.json --quiet` -> `129/129` passed
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_app_contract_matrix.py` -> `8 passed`
- `./dev scope --staged`
- `./dev impact --staged`
