### PR TITLE
Fix classified core guardrail paths

### DIFF
--- a/src/agilab/core/test/test_agi_distributor_service_runtime_support.py
+++ b/src/agilab/core/test/test_agi_distributor_service_runtime_support.py
@@ -17,7 +17,7 @@ def test_service_runtime_support_reexports_service_helpers(monkeypatch):
     agi_cluster_pkg = ModuleType("agi_cluster")
     agi_cluster_pkg.__path__ = []  # type: ignore[attr-defined]
     distributor_pkg = ModuleType("agi_cluster.agi_distributor")
-    distributor_pkg.__path__ = []  # type: ignore[attr-defined]
+    distributor_pkg.__path__ = [str(source_path.parent)]  # type: ignore[attr-defined]
 
     lifecycle_module = ModuleType("agi_cluster.agi_distributor.service_lifecycle_support")
     state_module = ModuleType("agi_cluster.agi_distributor.service_state_support")

--- a/tools/security_hygiene_report.py
+++ b/tools/security_hygiene_report.py
@@ -20,8 +20,8 @@ PIP_AUDIT_COMMAND = "pip-audit --format json --output pip-audit.json"
 SBOM_COMMAND = "cyclonedx-py environment --output-format JSON --output-file sbom-cyclonedx.json"
 SERVICE_QUEUE_FILES = (
     "src/agilab/core/agi-node/src/agi_node/agi_dispatcher/base_worker_service_support.py",
-    "src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/service_lifecycle_support.py",
-    "src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/service_state_support.py",
+    "src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/service/service_lifecycle_support.py",
+    "src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/service/service_state_support.py",
 )
 SCAN_EXCLUDED_PARTS = {
     ".git",
@@ -619,7 +619,7 @@ def _remote_installer_staging_check(repo_root: Path) -> dict[str, Any]:
     files = [
         "install.sh",
         "tools/install_enduser.sh",
-        "src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment_prepare_support.py",
+        "src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_prepare_support.py",
     ]
     texts = {relative_path: _read_text(repo_root / relative_path) for relative_path in files}
     forbidden_tokens = [
@@ -677,7 +677,7 @@ def _installer_dry_run_profile_check(repo_root: Path) -> dict[str, Any]:
 
 
 def _central_command_runner_shell_gate_check(repo_root: Path) -> dict[str, Any]:
-    relative_path = "src/agilab/core/agi-env/src/agi_env/execution_support.py"
+    relative_path = "src/agilab/core/agi-env/src/agi_env/runtime/execution_support.py"
     text = _read_text(repo_root / relative_path)
     required_tokens = [
         "def _command_requires_shell",


### PR DESCRIPTION
## Summary
- update security hygiene static evidence paths after shared-core module classification
- keep the service-runtime support regression valid with the classified compat/service subpackages

## Root cause
The shared-core layout moved implementation files under classified subpackages, but the guardrail report and one synthetic import regression still targeted legacy shim paths.

## Validation
- python3 tools/security_hygiene_report.py --output /tmp/security-hygiene.json --compact
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' src/agilab/core/test/test_agi_distributor_service_runtime_support.py test/test_security_hygiene_report.py
- uv --preview-features extra-build-dependencies run --no-project --with-editable ./src/agilab/core/agi-env --with-editable ./src/agilab/core/agi-node --with-editable ./src/agilab/core/agi-cluster --with-editable ./src/agilab/core/agi-core --with pytest python -m pytest -q -o addopts='' --import-mode=importlib src/agilab/core/test/test_agi_distributor_service_runtime_support.py
- ./dev impact --staged
- ./dev scope --staged
