### PR TITLE
Isolate service runtime shim regression cache

### DIFF
--- a/src/agilab/core/test/test_agi_distributor_service_runtime_support.py
+++ b/src/agilab/core/test/test_agi_distributor_service_runtime_support.py
@@ -71,6 +71,11 @@ def test_service_runtime_support_reexports_service_helpers(monkeypatch):
     monkeypatch.setitem(sys.modules, "agi_cluster.agi_distributor", distributor_pkg)
     monkeypatch.setitem(sys.modules, "agi_cluster.agi_distributor.service_lifecycle_support", lifecycle_module)
     monkeypatch.setitem(sys.modules, "agi_cluster.agi_distributor.service_state_support", state_module)
+    monkeypatch.delitem(
+        sys.modules,
+        "agi_cluster.agi_distributor.service.service_runtime_support",
+        raising=False,
+    )
 
     spec = importlib.util.spec_from_file_location(
         "agi_cluster.agi_distributor.service_runtime_support",


### PR DESCRIPTION
## Summary
- clear the classified service_runtime_support target module in the synthetic legacy-shim regression before loading the shim

## Root cause
The Windows full core suite can import the classified target earlier than this regression. The test then reused the cached real target instead of the fake sentinel modules it installs to verify legacy re-export behavior.

## Validation
- uv --preview-features extra-build-dependencies run --no-project --with-editable ./src/agilab/core/agi-env --with-editable ./src/agilab/core/agi-node --with-editable ./src/agilab/core/agi-cluster --with-editable ./src/agilab/core/agi-core --with pytest python -m pytest -q -o addopts='' --import-mode=importlib src/agilab/core/test/test_agi_distributor_service_runtime_support.py
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' src/agilab/core/test/test_agi_distributor_service_runtime_support.py
- ./dev impact --staged
- ./dev scope --staged
