### PR TITLE
Fix Windows core compatibility shim paths

### DIFF
--- a/src/agilab/core/agi-env/src/agi_env/runtime/agi_env.py
+++ b/src/agilab/core/agi-env/src/agi_env/runtime/agi_env.py
@@ -198,10 +198,17 @@ def _ensure_dir(path: str | Path) -> Path:
 
 def _resolve_worker_hook(filename: str) -> Path | None:
     """Return the path to the shared worker hook."""
-    return resolve_worker_hook(filename, module_file=__file__)
+    return resolve_worker_hook(filename, module_file=_public_agi_env_module_file())
 
 
 _resolve_worker_hook.cache_clear = resolve_worker_hook.cache_clear  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+
+
+def _public_agi_env_module_file() -> str:
+    """Return the public ``agi_env.agi_env`` module file when loaded via the shim."""
+    public_module = sys.modules.get("agi_env.agi_env")
+    public_module_file = getattr(public_module, "__file__", None)
+    return str(public_module_file or __file__)
 
 
 def _select_hook(local_candidate: Path, fallback_filename: str, hook_label: str) -> tuple[Path, bool]:
@@ -586,7 +593,7 @@ class AgiEnv(metaclass=_AgiEnvMeta):
     def locate_agilab_installation(verbose=False):
         """Attempt to locate the installed AGILab package path on disk."""
         return locate_agilab_installation_path(
-            module_file=__file__,
+            module_file=_public_agi_env_module_file(),
             find_spec=importlib.util.find_spec,
         )
 

--- a/src/agilab/core/test/test_agi_distributor_deployment_local_support.py
+++ b/src/agilab/core/test/test_agi_distributor_deployment_local_support.py
@@ -211,7 +211,9 @@ def test_force_remove_swallows_filesystem_error_and_uses_subprocess(
 
 
 def test_deploy_local_worker_venv_cleanup_is_conditional() -> None:
-    source = Path(deployment_local_support.__file__).read_text(encoding="utf-8")
+    source = Path(
+        deployment_local_support.deploy_local_worker.__globals__["__file__"]
+    ).read_text(encoding="utf-8")
 
     assert '_force_remove(app_path / ".venv"' not in source
     assert "_remove_project_venv_if_mismatched(\n        app_path," in source


### PR DESCRIPTION
## Summary
- Keep `agi_env.agi_env` wrapper helpers using the public compatibility module file path when loaded through the shim.
- Update the deployment-local static source regression to inspect the classified implementation behind the compatibility shim.

## Root cause
The shared-core module classification preserved import compatibility, but two wrapper helpers still used the implementation module `__file__` from `agi_env.runtime.agi_env`. Windows/core and coverage jobs also had a static test reading the legacy shim source instead of the implementation source.

## Validation
- `uv --preview-features extra-build-dependencies run --no-project --with-editable ./src/agilab/core/agi-env --with-editable ./src/agilab/core/agi-node --with-editable ./src/agilab/core/agi-cluster --with-editable ./src/agilab/core/agi-core --with sqlalchemy --with streamlit --with fastparquet --with pytest --with pytest-asyncio --with pytest-cov python -m pytest -q --disable-warnings -o addopts='' --import-mode=importlib src/agilab/core/test/test_agi_distributor_deployment_local_support.py::test_deploy_local_worker_venv_cleanup_is_conditional src/agilab/core/agi-env/test/test_agi_env.py::test_resolve_worker_hook_wrapper_uses_hook_support src/agilab/core/agi-env/test/test_agi_env.py::test_locate_agilab_installation_wrapper_uses_installation_support`
- `uv --preview-features extra-build-dependencies run --no-project --with-editable ./src/agilab/core/agi-env --with-editable ./src/agilab/core/agi-node --with-editable ./src/agilab/core/agi-cluster --with-editable ./src/agilab/core/agi-core --with sqlalchemy --with streamlit --with fastparquet --with pytest --with pytest-asyncio --with pytest-cov python -m pytest -q --disable-warnings -o addopts='' --import-mode=importlib src/agilab/core/test src/agilab/core/agi-env/test`
- agi-env coverage-equivalent slice: `721 passed`
- agi-node/agi-cluster coverage-equivalent slice: `1023 passed, 2 skipped`
