### PR TITLE
Refresh core coverage badges

### DIFF
--- a/badges/coverage-agi-cluster.svg
+++ b/badges/coverage-agi-cluster.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="181" height="20" role="img" aria-label="agi-cluster coverage: 99%">
+<svg xmlns="http://www.w3.org/2000/svg" width="181" height="20" role="img" aria-label="agi-cluster coverage: 98%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="75.0" y="15" fill="#010101" fill-opacity=".3">agi-cluster coverage</text>
   <text x="75.0" y="14">agi-cluster coverage</text>
-  <text x="165.5" y="15" fill="#010101" fill-opacity=".3">99%</text>
-  <text x="165.5" y="14">99%</text>
+  <text x="165.5" y="15" fill="#010101" fill-opacity=".3">98%</text>
+  <text x="165.5" y="14">98%</text>
 </g>
 </svg>

--- a/badges/coverage-agi-core.svg
+++ b/badges/coverage-agi-core.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="160" height="20" role="img" aria-label="agi-core coverage: 99%">
+<svg xmlns="http://www.w3.org/2000/svg" width="160" height="20" role="img" aria-label="agi-core coverage: 98%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="64.5" y="15" fill="#010101" fill-opacity=".3">agi-core coverage</text>
   <text x="64.5" y="14">agi-core coverage</text>
-  <text x="144.5" y="15" fill="#010101" fill-opacity=".3">99%</text>
-  <text x="144.5" y="14">99%</text>
+  <text x="144.5" y="15" fill="#010101" fill-opacity=".3">98%</text>
+  <text x="144.5" y="14">98%</text>
 </g>
 </svg>

--- a/badges/coverage-agi-env.svg
+++ b/badges/coverage-agi-env.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="153" height="20" role="img" aria-label="agi-env coverage: 99%">
+<svg xmlns="http://www.w3.org/2000/svg" width="153" height="20" role="img" aria-label="agi-env coverage: 98%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="61.0" y="15" fill="#010101" fill-opacity=".3">agi-env coverage</text>
   <text x="61.0" y="14">agi-env coverage</text>
-  <text x="137.5" y="15" fill="#010101" fill-opacity=".3">99%</text>
-  <text x="137.5" y="14">99%</text>
+  <text x="137.5" y="15" fill="#010101" fill-opacity=".3">98%</text>
+  <text x="137.5" y="14">98%</text>
 </g>
 </svg>


### PR DESCRIPTION
## Summary
- Refresh core coverage badges from CI coverage XML artifacts generated by failed coverage run `26833390012`.
- Align `agi-env`, `agi-cluster`, and aggregate `agi-core` badges from `99%` to `98%`.

## Root cause
The coverage workflow passed test execution on merge commit `3ba0f9d9`, then failed its final committed-badge freshness check because the shared-core compatibility changes shifted component coverage below the previous truncated 99% badge value.

## Validation
- Downloaded coverage XML artifacts from GitHub Actions run `26833390012`.
- `uv --preview-features extra-build-dependencies run python tools/generate_component_coverage_badges.py`
- `AGILAB_ALLOW_BADGE_ONLY_UPDATE=1 uv --preview-features extra-build-dependencies run python tools/coverage_badge_guard.py --allow-badge-only`
