### PR TITLE
Use official demo badges in README and quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,8 +165,8 @@ install.
 ## [Quick Start](https://thalesgroup.github.io/agilab/quick-start.html)
 
 <p>
-  <a href="https://huggingface.co/spaces/jpmorard/agilab"><img src="https://img.shields.io/badge/AGILAB-Space-0F766E?style=for-the-badge" alt="AGILAB Space" /></a>
-  <a href="https://kaggle.com/kernels/welcome?src=https://github.com/ThalesGroup/agilab/blob/main/src/agilab/examples/notebook_quickstart/agi_core_kaggle_first_run.ipynb"><img src="https://img.shields.io/badge/agi--core-notebook-1D4ED8?style=for-the-badge" alt="agi-core notebook" /></a>
+  <a href="https://huggingface.co/spaces/jpmorard/agilab"><img src="https://huggingface.co/datasets/huggingface/badges/resolve/main/open-in-hf-spaces-md.svg" alt="Open in Hugging Face Spaces" /></a>
+  <a href="https://kaggle.com/kernels/welcome?src=https://github.com/ThalesGroup/agilab/blob/main/src/agilab/examples/notebook_quickstart/agi_core_kaggle_first_run.ipynb"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open In Kaggle" /></a>
 </p>
 
 ### Local PyPI Proof

--- a/README.pypi.md
+++ b/README.pypi.md
@@ -122,8 +122,8 @@ haversine distance kernel reports `speed_kernel_runtime`,
 
 ## Quick Start
 
-[![AGILAB Space](https://img.shields.io/badge/AGILAB-Space-0F766E?style=for-the-badge)](https://huggingface.co/spaces/jpmorard/agilab)
-[![agi-core notebook](https://img.shields.io/badge/agi--core-notebook-1D4ED8?style=for-the-badge)](https://kaggle.com/kernels/welcome?src=https://github.com/ThalesGroup/agilab/blob/main/src/agilab/examples/notebook_quickstart/agi_core_kaggle_first_run.ipynb)
+[![Open in Hugging Face Spaces](https://huggingface.co/datasets/huggingface/badges/resolve/main/open-in-hf-spaces-md.svg)](https://huggingface.co/spaces/jpmorard/agilab)
+[![Open In Kaggle](https://kaggle.com/static/images/open-in-kaggle.svg)](https://kaggle.com/kernels/welcome?src=https://github.com/ThalesGroup/agilab/blob/main/src/agilab/examples/notebook_quickstart/agi_core_kaggle_first_run.ipynb)
 
 ### Local PyPI Proof
 

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 250,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "984b2b93e2f507eb0e5f79d1b641c1e7a4a7ce8670f03826ba000b3b457d9037",
+  "source_digest_sha256": "2fbf7010fa379e5f8879b75d600a5805b6b640e460ea2973051a7863c6db9f83",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "984b2b93e2f507eb0e5f79d1b641c1e7a4a7ce8670f03826ba000b3b457d9037"
+  "target_digest_sha256": "2fbf7010fa379e5f8879b75d600a5805b6b640e460ea2973051a7863c6db9f83"
 }

--- a/docs/source/quick-start.rst
+++ b/docs/source/quick-start.rst
@@ -313,12 +313,21 @@ Use these only after the local ``flight_telemetry_project`` proof works once.
 
 **AGILAB demo**:
 
-.. image:: https://img.shields.io/badge/AGILAB-demo-0F766E?style=for-the-badge
+.. image:: https://huggingface.co/datasets/huggingface/badges/resolve/main/open-in-hf-spaces-md.svg
    :target: https://huggingface.co/spaces/jpmorard/agilab
-   :alt: AGILAB demo
+   :alt: Open in Hugging Face Spaces
 
 Self-serve public AGILAB demo hosted on Hugging Face Spaces.
 The dedicated docs page for this route is :doc:`agilab-demo`.
+
+**agi-core Kaggle notebook**:
+
+.. image:: https://kaggle.com/static/images/open-in-kaggle.svg
+   :target: https://kaggle.com/kernels/welcome?src=https://github.com/ThalesGroup/agilab/blob/main/src/agilab/examples/notebook_quickstart/agi_core_kaggle_first_run.ipynb
+   :alt: Open In Kaggle
+
+Notebook-first proof for users who want the headless ``agi-core`` route before
+installing or operating the full AGILAB UI.
 
 **Published package route** (fastest install, less representative of the full product path)::
 


### PR DESCRIPTION
## Summary
- Replace custom Shields.io demo badges in README and PyPI README with official Hugging Face Spaces and Kaggle badge SVGs.
- Update Quick Start docs to use the official Hugging Face Spaces badge and add the official Kaggle notebook badge.
- Sync canonical docs from `jpmorard/thales_agilab` into the public docs mirror.

## Validation
- `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --apply --delete`
- `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp`
- Targeted grep confirmed the README / Quick Start surfaces use `open-in-hf-spaces-md.svg` and `open-in-kaggle.svg`.
