### PR TITLE
Use larger Hugging Face Spaces badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ install.
 ## [Quick Start](https://thalesgroup.github.io/agilab/quick-start.html)
 
 <p>
-  <a href="https://huggingface.co/spaces/jpmorard/agilab"><img src="https://huggingface.co/datasets/huggingface/badges/resolve/main/open-in-hf-spaces-md.svg" alt="Open in Hugging Face Spaces" /></a>
+  <a href="https://huggingface.co/spaces/jpmorard/agilab"><img src="https://huggingface.co/datasets/huggingface/badges/resolve/main/open-in-hf-spaces-xl.svg" alt="Open in Hugging Face Spaces" /></a>
   <a href="https://kaggle.com/kernels/welcome?src=https://github.com/ThalesGroup/agilab/blob/main/src/agilab/examples/notebook_quickstart/agi_core_kaggle_first_run.ipynb"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open In Kaggle" /></a>
 </p>
 

--- a/README.pypi.md
+++ b/README.pypi.md
@@ -122,7 +122,7 @@ haversine distance kernel reports `speed_kernel_runtime`,
 
 ## Quick Start
 
-[![Open in Hugging Face Spaces](https://huggingface.co/datasets/huggingface/badges/resolve/main/open-in-hf-spaces-md.svg)](https://huggingface.co/spaces/jpmorard/agilab)
+[![Open in Hugging Face Spaces](https://huggingface.co/datasets/huggingface/badges/resolve/main/open-in-hf-spaces-xl.svg)](https://huggingface.co/spaces/jpmorard/agilab)
 [![Open In Kaggle](https://kaggle.com/static/images/open-in-kaggle.svg)](https://kaggle.com/kernels/welcome?src=https://github.com/ThalesGroup/agilab/blob/main/src/agilab/examples/notebook_quickstart/agi_core_kaggle_first_run.ipynb)
 
 ### Local PyPI Proof

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 250,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "2fbf7010fa379e5f8879b75d600a5805b6b640e460ea2973051a7863c6db9f83",
+  "source_digest_sha256": "21eae68a1c7a8b46be584a18612f9c32e449c4a7ba286fb7cc1224b0b5e18b2f",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "2fbf7010fa379e5f8879b75d600a5805b6b640e460ea2973051a7863c6db9f83"
+  "target_digest_sha256": "21eae68a1c7a8b46be584a18612f9c32e449c4a7ba286fb7cc1224b0b5e18b2f"
 }

--- a/docs/source/quick-start.rst
+++ b/docs/source/quick-start.rst
@@ -313,7 +313,7 @@ Use these only after the local ``flight_telemetry_project`` proof works once.
 
 **AGILAB demo**:
 
-.. image:: https://huggingface.co/datasets/huggingface/badges/resolve/main/open-in-hf-spaces-md.svg
+.. image:: https://huggingface.co/datasets/huggingface/badges/resolve/main/open-in-hf-spaces-xl.svg
    :target: https://huggingface.co/spaces/jpmorard/agilab
    :alt: Open in Hugging Face Spaces
 


### PR DESCRIPTION
## Summary
- Switch the Hugging Face Spaces badge from the medium official variant to the larger official `open-in-hf-spaces-xl.svg` variant.
- Keep the official Kaggle badge unchanged.
- Sync the Quick Start docs mirror from canonical docs.

## Validation
- `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --apply --delete`
- `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp`
- Targeted grep confirmed README, PyPI README, canonical Quick Start, and mirrored Quick Start use `open-in-hf-spaces-xl.svg`.
