### PR TITLE
Align Kaggle launch badge size

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,8 +165,8 @@ install.
 ## [Quick Start](https://thalesgroup.github.io/agilab/quick-start.html)
 
 <p>
-  <a href="https://huggingface.co/spaces/jpmorard/agilab"><img src="https://huggingface.co/datasets/huggingface/badges/resolve/main/open-in-hf-spaces-xl.svg" alt="Open in Hugging Face Spaces" /></a>
-  <a href="https://kaggle.com/kernels/welcome?src=https://github.com/ThalesGroup/agilab/blob/main/src/agilab/examples/notebook_quickstart/agi_core_kaggle_first_run.ipynb"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open In Kaggle" /></a>
+  <a href="https://huggingface.co/spaces/jpmorard/agilab"><img src="https://huggingface.co/datasets/huggingface/badges/resolve/main/open-in-hf-spaces-xl.svg" alt="Open in Hugging Face Spaces" height="56" /></a>
+  <a href="https://kaggle.com/kernels/welcome?src=https://github.com/ThalesGroup/agilab/blob/main/src/agilab/examples/notebook_quickstart/agi_core_kaggle_first_run.ipynb"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open In Kaggle" height="56" /></a>
 </p>
 
 ### Local PyPI Proof

--- a/README.pypi.md
+++ b/README.pypi.md
@@ -122,8 +122,8 @@ haversine distance kernel reports `speed_kernel_runtime`,
 
 ## Quick Start
 
-[![Open in Hugging Face Spaces](https://huggingface.co/datasets/huggingface/badges/resolve/main/open-in-hf-spaces-xl.svg)](https://huggingface.co/spaces/jpmorard/agilab)
-[![Open In Kaggle](https://kaggle.com/static/images/open-in-kaggle.svg)](https://kaggle.com/kernels/welcome?src=https://github.com/ThalesGroup/agilab/blob/main/src/agilab/examples/notebook_quickstart/agi_core_kaggle_first_run.ipynb)
+<a href="https://huggingface.co/spaces/jpmorard/agilab"><img src="https://huggingface.co/datasets/huggingface/badges/resolve/main/open-in-hf-spaces-xl.svg" alt="Open in Hugging Face Spaces" height="56" /></a>
+<a href="https://kaggle.com/kernels/welcome?src=https://github.com/ThalesGroup/agilab/blob/main/src/agilab/examples/notebook_quickstart/agi_core_kaggle_first_run.ipynb"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open In Kaggle" height="56" /></a>
 
 ### Local PyPI Proof
 

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 250,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "21eae68a1c7a8b46be584a18612f9c32e449c4a7ba286fb7cc1224b0b5e18b2f",
+  "source_digest_sha256": "59c2fa25b2006516c6ef55e54c1c0da5ec172968fbf09c57a211938a730d8fb0",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "21eae68a1c7a8b46be584a18612f9c32e449c4a7ba286fb7cc1224b0b5e18b2f"
+  "target_digest_sha256": "59c2fa25b2006516c6ef55e54c1c0da5ec172968fbf09c57a211938a730d8fb0"
 }

--- a/docs/source/quick-start.rst
+++ b/docs/source/quick-start.rst
@@ -316,6 +316,7 @@ Use these only after the local ``flight_telemetry_project`` proof works once.
 .. image:: https://huggingface.co/datasets/huggingface/badges/resolve/main/open-in-hf-spaces-xl.svg
    :target: https://huggingface.co/spaces/jpmorard/agilab
    :alt: Open in Hugging Face Spaces
+   :height: 56px
 
 Self-serve public AGILAB demo hosted on Hugging Face Spaces.
 The dedicated docs page for this route is :doc:`agilab-demo`.
@@ -325,6 +326,7 @@ The dedicated docs page for this route is :doc:`agilab-demo`.
 .. image:: https://kaggle.com/static/images/open-in-kaggle.svg
    :target: https://kaggle.com/kernels/welcome?src=https://github.com/ThalesGroup/agilab/blob/main/src/agilab/examples/notebook_quickstart/agi_core_kaggle_first_run.ipynb
    :alt: Open In Kaggle
+   :height: 56px
 
 Notebook-first proof for users who want the headless ``agi-core`` route before
 installing or operating the full AGILAB UI.


### PR DESCRIPTION
## Summary\n- render Hugging Face and Kaggle launch badges at the same explicit height\n- keep the official Kaggle SVG asset while avoiding its small intrinsic size\n- sync the canonical docs quick-start badge sizing into the public docs mirror\n\n## Validation\n- uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp