### PR TITLE
Add built-in app test runner shortcut

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ Use this runbook whenever you:
   creating or checking a function + split rule + reducer contract before scaling code,
   `app-contracts` for
   built-in app/package/catalog/docs alignment, `audit` for local worktree/docs/release/PyPI
-  state,
+  state, `builtin-app-tests` for app-local built-in test execution,
   `flow` for one or more workflow parity profiles,
   `release` for local pre-tag release guards, `badge` for the explicit release/pre-release
   coverage-badge guard, `maintenance` for long-term extension/evidence/docs/package
@@ -48,6 +48,9 @@ Use this runbook whenever you:
   `app-contracts` checks built-in app structure, worker manifests, reducer contracts,
   promoted PyPI package metadata, app catalog entries, and public docs rows; it is also
   part of the release shortcut and targeted pre-push guards,
+  `builtin-app-tests` runs built-in app tests inside each app's own `uv --project .`
+  environment with pytest importlib mode, avoiding false root-environment dependency
+  failures for app-local packages,
   `audit` is the quick robustness check before handoff between machines,
   `flow` matches local GitHub workflow profiles, `release` starts with the strict AGILAB audit/review,
   then checks impact, generated PyPI release plan, trusted-publisher contract, Ruff availability,

--- a/test/test_agilab_dev_shortcuts.py
+++ b/test/test_agilab_dev_shortcuts.py
@@ -231,6 +231,21 @@ def test_app_contracts_shortcut_keeps_matrix_arguments():
     ]
 
 
+def test_builtin_app_tests_shortcut_runs_app_local_runner():
+    assert agilab_dev.planned_commands(["builtin-app-tests", "--app", "weather_forecast_project"]) == [
+        [
+            "uv",
+            "--preview-features",
+            "extra-build-dependencies",
+            "run",
+            "python",
+            "tools/builtin_app_tests.py",
+            "--app",
+            "weather_forecast_project",
+        ]
+    ]
+
+
 def test_maintenance_shortcut_runs_dashboard():
     assert agilab_dev.planned_commands(["maintenance", "--json"]) == [
         [

--- a/test/test_builtin_app_tests.py
+++ b/test/test_builtin_app_tests.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "tools" / "builtin_app_tests.py"
+
+spec = importlib.util.spec_from_file_location("builtin_app_tests", MODULE_PATH)
+assert spec is not None and spec.loader is not None
+builtin_app_tests = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(builtin_app_tests)
+
+
+def test_discover_builtin_app_tests_returns_sorted_projects_with_tests(tmp_path):
+    root = tmp_path / "builtin"
+    (root / "z_project" / "test").mkdir(parents=True)
+    (root / "z_project" / "test" / "test_z.py").write_text("def test_z(): pass\n")
+    (root / "a_project" / "test").mkdir(parents=True)
+    (root / "a_project" / "test" / "test_a.py").write_text("def test_a(): pass\n")
+    (root / "empty_project" / "test").mkdir(parents=True)
+    (root / "not_a_builtin_app" / "test").mkdir(parents=True)
+    (root / "not_a_builtin_app" / "test" / "test_skip.py").write_text("def test_skip(): pass\n")
+
+    targets = builtin_app_tests.discover_builtin_app_tests(root)
+
+    assert [target.name for target in targets] == ["a_project", "z_project"]
+
+
+def test_build_pytest_command_uses_app_local_project_and_importlib_mode():
+    command = builtin_app_tests.build_pytest_command()
+
+    assert command[:8] == [
+        "uv",
+        "--preview-features",
+        "extra-build-dependencies",
+        "run",
+        "--project",
+        ".",
+        "--with",
+        "pytest",
+    ]
+    assert "--import-mode=importlib" in command
+    assert command[-1] == "test"
+
+
+def test_build_pytest_command_keeps_forwarded_args_after_separator():
+    command = builtin_app_tests.build_pytest_command(["--", "-k", "weather"])
+
+    assert command[-2:] == ["-k", "weather"]
+
+
+def test_subprocess_env_removes_active_root_virtualenv(monkeypatch):
+    monkeypatch.setenv("VIRTUAL_ENV", "/repo/.venv")
+
+    env = builtin_app_tests.subprocess_env()
+
+    assert "VIRTUAL_ENV" not in env

--- a/test/test_workflow_parity.py
+++ b/test/test_workflow_parity.py
@@ -1082,6 +1082,33 @@ def test_installer_profile_contract_check_allows_missing_worker_copy() -> None:
     assert "--worker-copy" not in contract.argv
 
 
+def test_builtin_app_tests_profile_runs_app_local_runner() -> None:
+    module = _load_module()
+    args = SimpleNamespace(components=None, skills=None, app_path=None, worker_copy=None)
+
+    command = module._profile_commands(args)["builtin-app-tests"][0]
+
+    assert command.label == "built-in app tests"
+    assert command.argv == [
+        "uv",
+        "--preview-features",
+        "extra-build-dependencies",
+        "run",
+        "python",
+        "tools/builtin_app_tests.py",
+    ]
+
+
+def test_builtin_app_tests_profile_is_accepted_by_parser(capsys) -> None:
+    module = _load_module()
+
+    assert module.main(["--profile", "builtin-app-tests", "--print-only", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["profiles"] == ["builtin-app-tests"]
+    assert payload["commands"]["builtin-app-tests"][0]["label"] == "built-in app tests"
+
+
 def test_prepare_command_removes_globbed_coverage_fragments(tmp_path, monkeypatch) -> None:
     module = _load_module()
     monkeypatch.setattr(module, "REPO_ROOT", tmp_path)

--- a/tools/agilab_dev.py
+++ b/tools/agilab_dev.py
@@ -77,6 +77,9 @@ def planned_commands(argv: Sequence[str]) -> list[list[str]]:
     if command in {"app-contracts", "apps-contracts"}:
         return [_uv_python("tools/app_contract_matrix.py", *args)]
 
+    if command in {"builtin-app-tests", "built-in-app-tests"}:
+        return [_uv_python("tools/builtin_app_tests.py", *args)]
+
     if command in {"maintenance", "maintain"}:
         return [_uv_python("tools/maintenance_dashboard.py", *args)]
 
@@ -191,6 +194,7 @@ def _usage() -> str:
   ./dev [--print-only] robust [robustness_matrix args]
   ./dev [--print-only] parallel-stage [parallel_stage args]
   ./dev [--print-only] app-contracts [app_contract_matrix args]
+  ./dev [--print-only] builtin-app-tests [builtin_app_tests args]
   ./dev [--print-only] maintenance [maintenance_dashboard args]
   ./dev [--print-only] memory [maintenance_memory args]
   ./dev [--print-only] audit [agilab_audit args]
@@ -215,6 +219,7 @@ High-frequency mappings:
   robust    -> Run the P0 robustness matrix of fail-closed bad-state scenarios.
   parallel-stage -> Create or validate a function + split rule + reducer contract for parallel execution.
   app-contracts -> Check built-in app, PyPI package, app catalog, and public-doc alignment.
+  builtin-app-tests -> Run built-in app tests inside each app's own uv project environment.
   maintenance -> Report extension contracts, ADRs, docs drift, app/package contracts, evidence docs, release friction, TODO hotspots, generated artifacts, and coverage signals.
   memory    -> Check path-scoped maintenance memory notes for source drift.
   audit     -> Audit local AGILAB worktrees, release proof, docs mirror, PyPI projects, and latest release truth.

--- a/tools/builtin_app_tests.py
+++ b/tools/builtin_app_tests.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Run built-in app tests in their own app project environments."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+from typing import NamedTuple, Sequence
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BUILTIN_APPS_ROOT = REPO_ROOT / "src" / "agilab" / "apps" / "builtin"
+DEFAULT_PYTEST_ARGS = (
+    "-q",
+    "--disable-warnings",
+    "-o",
+    "addopts=",
+    "--import-mode=importlib",
+    "test",
+)
+
+
+class BuiltinAppTestTarget(NamedTuple):
+    name: str
+    path: Path
+
+
+def discover_builtin_app_tests(root: Path = BUILTIN_APPS_ROOT) -> list[BuiltinAppTestTarget]:
+    """Return built-in app projects that own pytest tests."""
+
+    if not root.exists():
+        return []
+    targets: list[BuiltinAppTestTarget] = []
+    for app_dir in sorted(root.glob("*_project")):
+        test_dir = app_dir / "test"
+        if test_dir.is_dir() and any(test_dir.glob("test_*.py")):
+            targets.append(BuiltinAppTestTarget(name=app_dir.name, path=app_dir))
+    return targets
+
+
+def build_pytest_command(pytest_args: Sequence[str] = ()) -> list[str]:
+    """Build the app-local pytest command used for each built-in app."""
+
+    forwarded = list(pytest_args)
+    if forwarded and forwarded[0] == "--":
+        forwarded = forwarded[1:]
+    if not forwarded:
+        forwarded = list(DEFAULT_PYTEST_ARGS)
+    return [
+        "uv",
+        "--preview-features",
+        "extra-build-dependencies",
+        "run",
+        "--project",
+        ".",
+        "--with",
+        "pytest",
+        "python",
+        "-m",
+        "pytest",
+        *forwarded,
+    ]
+
+
+def subprocess_env() -> dict[str, str]:
+    """Return an environment that lets uv select each app's project environment."""
+
+    env = os.environ.copy()
+    env.pop("VIRTUAL_ENV", None)
+    return env
+
+
+def _selected_targets(
+    targets: Sequence[BuiltinAppTestTarget], app_names: Sequence[str]
+) -> list[BuiltinAppTestTarget]:
+    if not app_names:
+        return list(targets)
+    requested = set(app_names)
+    selected = [target for target in targets if target.name in requested]
+    missing = sorted(requested.difference(target.name for target in selected))
+    if missing:
+        raise SystemExit(f"unknown built-in app test target(s): {', '.join(missing)}")
+    return selected
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--app",
+        action="append",
+        default=[],
+        help="Built-in app project name to test. May be passed more than once.",
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="List built-in app projects with tests and exit.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print app-local pytest commands without executing them.",
+    )
+    parser.add_argument(
+        "--keep-going",
+        action="store_true",
+        help="Continue testing remaining apps after a failure.",
+    )
+    parser.add_argument(
+        "pytest_args",
+        nargs=argparse.REMAINDER,
+        help="Optional pytest arguments after '--'. Defaults to the app test directory.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    targets = _selected_targets(discover_builtin_app_tests(), args.app)
+    if args.list:
+        for target in targets:
+            print(target.name)
+        return 0
+    if not targets:
+        print("No built-in app test targets found.", file=sys.stderr)
+        return 1
+
+    command = build_pytest_command(args.pytest_args)
+    failures: list[str] = []
+    for target in targets:
+        print(f"\n== {target.path.relative_to(REPO_ROOT)} ==", flush=True)
+        if args.dry_run:
+            print(shlex.join(command))
+            continue
+        result = subprocess.run(command, cwd=target.path, check=False, env=subprocess_env())
+        if result.returncode:
+            failures.append(target.name)
+            if not args.keep_going:
+                return result.returncode
+
+    if failures:
+        print(f"Failed built-in app test target(s): {', '.join(failures)}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/workflow_parity.py
+++ b/tools/workflow_parity.py
@@ -170,6 +170,7 @@ def _build_parser() -> argparse.ArgumentParser:
             "badges",
             "skills",
             "installer",
+            "builtin-app-tests",
             "shared-core-typing",
             "ty-typing",
             "dependency-policy",
@@ -295,6 +296,7 @@ def _profile_descriptions() -> dict[str, str]:
         "badges": "Refresh component coverage badges from local coverage XML files.",
         "skills": "Validate and regenerate the repo Codex skill mirror outputs.",
         "installer": "Run local installer parity checks including shell syntax and contract checks.",
+        "builtin-app-tests": "Run built-in app tests inside each app's own uv project environment.",
         "shared-core-typing": "Run the curated temporary strict mypy release guard for shared core.",
         "ty-typing": "Run the forward shared-core strict ty type-check slice.",
         "dependency-policy": "Run dependency hygiene checks for runtime and release manifests.",
@@ -343,6 +345,7 @@ def _profile_commands(args: argparse.Namespace) -> dict[str, list[CommandSpec]]:
         "badges": _badges_profile(args.components),
         "skills": _skills_profile(args.skills),
         "installer": _installer_profile(args.app_path, args.worker_copy),
+        "builtin-app-tests": _builtin_app_tests_profile(),
         "shared-core-typing": _shared_core_typing_profile(),
         "ty-typing": _shared_core_ty_typing_profile(),
         "dependency-policy": _dependency_policy_profile(),
@@ -1287,6 +1290,22 @@ def _installer_profile(app_path: str | None, worker_copy: str | None) -> list[Co
             argv.extend(["--worker-copy", worker_copy])
         commands.append(CommandSpec(label="installer contract check", argv=argv))
     return commands
+
+
+def _builtin_app_tests_profile() -> list[CommandSpec]:
+    return [
+        CommandSpec(
+            label="built-in app tests",
+            argv=[
+                "uv",
+                "--preview-features",
+                "extra-build-dependencies",
+                "run",
+                "python",
+                "tools/builtin_app_tests.py",
+            ],
+        )
+    ]
 
 
 def _shared_core_typing_profile() -> list[CommandSpec]:
@@ -2321,6 +2340,7 @@ def _selected_profiles(args: argparse.Namespace) -> list[str]:
     opt_in_profiles = {
         "agi-node",
         "agi-cluster",
+        "builtin-app-tests",
         "release-proof",
         "security-adoption",
         "production-readiness",


### PR DESCRIPTION
## Summary\n- add tools/builtin_app_tests.py to run built-in app pytest suites inside each app-local uv project\n- expose the runner through ./dev builtin-app-tests and workflow_parity --profile builtin-app-tests\n- document the shortcut and add command-construction regression coverage\n\n## Validation\n- ./dev scope --staged