### PR TITLE
Add large Kaggle launch badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ install.
 
 <p>
   <a href="https://huggingface.co/spaces/jpmorard/agilab"><img src="https://huggingface.co/datasets/huggingface/badges/resolve/main/open-in-hf-spaces-xl.svg" alt="Open in Hugging Face Spaces" height="56" /></a>
-  <a href="https://kaggle.com/kernels/welcome?src=https://github.com/ThalesGroup/agilab/blob/main/src/agilab/examples/notebook_quickstart/agi_core_kaggle_first_run.ipynb"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open In Kaggle" height="56" /></a>
+  <a href="https://kaggle.com/kernels/welcome?src=https://github.com/ThalesGroup/agilab/blob/main/src/agilab/examples/notebook_quickstart/agi_core_kaggle_first_run.ipynb"><img src="https://raw.githubusercontent.com/ThalesGroup/agilab/main/docs/source/_static/badges/open-in-kaggle-xl.svg" alt="Open In Kaggle" height="56" /></a>
 </p>
 
 ### Local PyPI Proof

--- a/README.pypi.md
+++ b/README.pypi.md
@@ -123,7 +123,7 @@ haversine distance kernel reports `speed_kernel_runtime`,
 ## Quick Start
 
 <a href="https://huggingface.co/spaces/jpmorard/agilab"><img src="https://huggingface.co/datasets/huggingface/badges/resolve/main/open-in-hf-spaces-xl.svg" alt="Open in Hugging Face Spaces" height="56" /></a>
-<a href="https://kaggle.com/kernels/welcome?src=https://github.com/ThalesGroup/agilab/blob/main/src/agilab/examples/notebook_quickstart/agi_core_kaggle_first_run.ipynb"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open In Kaggle" height="56" /></a>
+<a href="https://kaggle.com/kernels/welcome?src=https://github.com/ThalesGroup/agilab/blob/main/src/agilab/examples/notebook_quickstart/agi_core_kaggle_first_run.ipynb"><img src="https://raw.githubusercontent.com/ThalesGroup/agilab/main/docs/source/_static/badges/open-in-kaggle-xl.svg" alt="Open In Kaggle" height="56" /></a>
 
 ### Local PyPI Proof
 

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -1,9 +1,9 @@
 {
-  "file_count": 250,
+  "file_count": 251,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "59c2fa25b2006516c6ef55e54c1c0da5ec172968fbf09c57a211938a730d8fb0",
+  "source_digest_sha256": "6685852d9d342ed227bfa649506e18d9fc8a7e1f3aed566e71e933ddd7639000",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "59c2fa25b2006516c6ef55e54c1c0da5ec172968fbf09c57a211938a730d8fb0"
+  "target_digest_sha256": "6685852d9d342ed227bfa649506e18d9fc8a7e1f3aed566e71e933ddd7639000"
 }

--- a/docs/source/_static/badges/open-in-kaggle-xl.svg
+++ b/docs/source/_static/badges/open-in-kaggle-xl.svg
@@ -1,0 +1,22 @@
+<svg width="249" height="48" viewBox="0 0 249 48" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Open in Kaggle</title>
+  <desc id="desc">Large launch badge linking to a Kaggle notebook.</desc>
+  <defs>
+    <linearGradient id="badge-fill" x1="0" y1="0" x2="249" y2="48" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#F7FBFF"/>
+      <stop offset="1" stop-color="#EAF6FF"/>
+    </linearGradient>
+    <linearGradient id="icon-fill" x1="18" y1="12" x2="43" y2="37" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#20BEFF"/>
+      <stop offset="1" stop-color="#008ABC"/>
+    </linearGradient>
+  </defs>
+  <path d="M0.75 24C0.75 11.16 11.17 0.75 24.02 0.75H224.98C237.83 0.75 248.25 11.16 248.25 24C248.25 36.84 237.83 47.25 224.98 47.25H24.02C11.17 47.25 0.75 36.84 0.75 24Z" fill="url(#badge-fill)" stroke="#D7EAF7" stroke-width="1.5"/>
+  <path d="M31.1 12.25H35.72L28.94 20.82L36.36 35.75H31.92L26.04 24.02L23.42 27.24V35.75H19.36V12.25H23.42V22.02L31.1 12.25Z" fill="url(#icon-fill)"/>
+  <path d="M40.7 12.25H44.8V35.75H40.7V12.25Z" fill="url(#icon-fill)" opacity="0.24"/>
+  <text x="60" y="21" fill="#2C3236" font-family="Inter, Segoe UI, Helvetica, Arial, sans-serif" font-size="13" font-weight="600" letter-spacing="0.1">Open in</text>
+  <text x="60" y="35" fill="#2C3236" font-family="Inter, Segoe UI, Helvetica, Arial, sans-serif" font-size="17" font-weight="700" letter-spacing="0.1">Kaggle</text>
+  <path d="M205 17.5H221.5V34H205V17.5Z" fill="#20BEFF" opacity="0.1"/>
+  <path d="M210.5 15.5H224.5V29.5" stroke="#20BEFF" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M224.5 15.5L207.5 32.5" stroke="#20BEFF" stroke-width="2.4" stroke-linecap="round"/>
+</svg>

--- a/docs/source/quick-start.rst
+++ b/docs/source/quick-start.rst
@@ -323,7 +323,7 @@ The dedicated docs page for this route is :doc:`agilab-demo`.
 
 **agi-core Kaggle notebook**:
 
-.. image:: https://kaggle.com/static/images/open-in-kaggle.svg
+.. image:: _static/badges/open-in-kaggle-xl.svg
    :target: https://kaggle.com/kernels/welcome?src=https://github.com/ThalesGroup/agilab/blob/main/src/agilab/examples/notebook_quickstart/agi_core_kaggle_first_run.ipynb
    :alt: Open In Kaggle
    :height: 56px


### PR DESCRIPTION
## Summary\n- add a native 249x48 Kaggle launch badge so it visually matches the Hugging Face XL badge\n- point README and PyPI README at the deterministic badge asset instead of the small external Kaggle SVG\n- sync the canonical quick-start docs badge asset into the public docs mirror\n\n## Validation\n- XML parse confirmed open-in-kaggle-xl.svg width=249 height=48 viewBox=0 0 249 48\n- uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp