### PR TITLE
Refresh AGILAB capability manifest

### DIFF
--- a/agilab-capabilities.json
+++ b/agilab-capabilities.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-06-02T17:14:12Z",
+  "generated_at_utc": "2026-06-02T17:18:09Z",
   "schema": "agilab.capabilities.v1",
   "schema_version": 1,
   "generated_by": {
@@ -1751,39 +1751,18 @@
     {
       "schema": "agilab.notebook_export_handoff.v1",
       "sources": [
-        "src/agilab/apps/builtin/flight_telemetry_project/notebooks/lab_stages.notebook_export.md",
-        "src/agilab/apps/builtin/global_dag_project/notebooks/lab_stages.notebook_export.md",
-        "src/agilab/apps/builtin/meteo_forecast_project/notebooks/lab_stages.notebook_export.md",
-        "src/agilab/apps/builtin/mission_decision_project/notebooks/lab_stages.notebook_export.md",
-        "src/agilab/apps/builtin/multi_app_dag_project/notebooks/lab_stages.notebook_export.md",
-        "src/agilab/apps/builtin/tescia_diagnostic_project/notebooks/lab_stages.notebook_export.md",
-        "src/agilab/apps/builtin/weather_forecast_project/notebooks/lab_stages.notebook_export.md",
         "src/agilab/notebooks/notebook_export_support.py"
       ]
     },
     {
       "schema": "agilab.notebook_export_manifest.v1",
       "sources": [
-        "src/agilab/apps/builtin/flight_telemetry_project/notebooks/lab_stages.notebook_export.json",
-        "src/agilab/apps/builtin/global_dag_project/notebooks/lab_stages.notebook_export.json",
-        "src/agilab/apps/builtin/meteo_forecast_project/notebooks/lab_stages.notebook_export.json",
-        "src/agilab/apps/builtin/mission_decision_project/notebooks/lab_stages.notebook_export.json",
-        "src/agilab/apps/builtin/multi_app_dag_project/notebooks/lab_stages.notebook_export.json",
-        "src/agilab/apps/builtin/tescia_diagnostic_project/notebooks/lab_stages.notebook_export.json",
-        "src/agilab/apps/builtin/weather_forecast_project/notebooks/lab_stages.notebook_export.json",
         "src/agilab/notebooks/notebook_export_support.py"
       ]
     },
     {
       "schema": "agilab.notebook_export_portability.v1",
       "sources": [
-        "src/agilab/apps/builtin/flight_telemetry_project/notebooks/lab_stages.notebook_export.json",
-        "src/agilab/apps/builtin/global_dag_project/notebooks/lab_stages.notebook_export.json",
-        "src/agilab/apps/builtin/meteo_forecast_project/notebooks/lab_stages.notebook_export.json",
-        "src/agilab/apps/builtin/mission_decision_project/notebooks/lab_stages.notebook_export.json",
-        "src/agilab/apps/builtin/multi_app_dag_project/notebooks/lab_stages.notebook_export.json",
-        "src/agilab/apps/builtin/tescia_diagnostic_project/notebooks/lab_stages.notebook_export.json",
-        "src/agilab/apps/builtin/weather_forecast_project/notebooks/lab_stages.notebook_export.json",
         "src/agilab/notebooks/notebook_export_support.py"
       ]
     },


### PR DESCRIPTION
## Summary
- refresh the generated AGILAB capability manifest after the agent skill/runbook updates already present on main
- remove stale notebook export source entries that the current generator no longer emits

## Validation
- python3 tools/sync_agent_skills.py --skills agilab-release-verification
- python3 tools/codex_skills.py --root .codex/skills validate --strict
- python3 tools/codex_skills.py --root .codex/skills generate
- python3 tools/agent_instruction_contract.py --check
- python3 tools/agilab_capabilities_lint.py --check
- ./dev impact --staged