### PR TITLE
Align PROJECT and ORCHESTRATE expander order

### DIFF
--- a/src/agilab/pages/1_PROJECT.py
+++ b/src/agilab/pages/1_PROJECT.py
@@ -1245,7 +1245,7 @@ def _render_installed_pypi_app_manager(env) -> None:
 
 
 def _render_pypi_app_install_action(env) -> None:
-    with st.sidebar.expander("Install from pypi.org", expanded=False):
+    with st.sidebar.expander("Install another version", expanded=False):
         catalog = _search_promoted_pypi_app_catalog("")
         catalog_options = ["", *catalog]
         catalog_choice = st.selectbox(
@@ -2598,7 +2598,8 @@ def handle_editing(path: Path, key_prefix: str, comp_props, ace_props):
 
 def render_project_dashboard(env) -> None:
     """Render PROJECT-owned dashboard panels for the active project."""
-    health = render_environment_health_panel(st, env, render_details=False)
+    with st.container(border=True):
+        health = render_environment_health_panel(st, env, render_details=False)
     with st.expander("Project metrics", expanded=False):
         _render_project_software_metrics(env)
     render_environment_details(st, health.details)

--- a/src/agilab/pages/1_PROJECT_STATUS.py
+++ b/src/agilab/pages/1_PROJECT_STATUS.py
@@ -18,14 +18,19 @@ _PROJECT_EDITOR_PAGE_MODULE = "agilab_project_edit_page_shared"
 
 def _load_project_editor_page_module() -> ModuleType:
     """Load the editor page so PROJECT can reuse project operation handlers."""
-    cached = sys.modules.get(_PROJECT_EDITOR_PAGE_MODULE)
-    if isinstance(cached, ModuleType):
-        return cached
     module_path = Path(__file__).with_name("1_PROJECT.py")
+    source_mtime_ns = module_path.stat().st_mtime_ns
+    cached = sys.modules.get(_PROJECT_EDITOR_PAGE_MODULE)
+    if (
+        isinstance(cached, ModuleType)
+        and getattr(cached, "__agilab_source_mtime_ns__", None) == source_mtime_ns
+    ):
+        return cached
     spec = importlib.util.spec_from_file_location(_PROJECT_EDITOR_PAGE_MODULE, module_path)
     if spec is None or spec.loader is None:
         raise ModuleNotFoundError(f"Unable to load PROJECT editor page from {module_path}")
     module = importlib.util.module_from_spec(spec)
+    module.__agilab_source_mtime_ns__ = source_mtime_ns
     sys.modules[_PROJECT_EDITOR_PAGE_MODULE] = module
     spec.loader.exec_module(module)
     return module

--- a/src/agilab/pages/2_ORCHESTRATE.py
+++ b/src/agilab/pages/2_ORCHESTRATE.py
@@ -2424,6 +2424,7 @@ async def page() -> None:
         docs_html_file="execute-help.html",
         render_page_context=_skip_orchestrate_project_cockpit,
     )
+    orchestrate_banner_slot = st.container()
 
     if background_services_enabled() and not st.session_state.get("server_started"):
         activate_mlflow(env)
@@ -2558,12 +2559,14 @@ async def page() -> None:
     )
     st.session_state["cluster_verbose"] = selected_verbose_int
 
-    environment_health = _render_orchestrate_readiness_panel(
-        env,
-        app_settings=app_settings,
-        install_status=install_status,
-        show_run=show_run,
-    )
+    with orchestrate_banner_slot:
+        environment_health = _render_orchestrate_readiness_panel(
+            env,
+            app_settings=app_settings,
+            install_status=install_status,
+            show_run=show_run,
+        )
+    _environment_render_environment_details(st, environment_health.details)
 
     verbose, install_status = await _render_deployment_panel(
         env,
@@ -2632,7 +2635,6 @@ async def page() -> None:
         install_disabled_reason=install_block_reason,
         worker_env_required=worker_required_for_run,
     )
-    _environment_render_environment_details(st, environment_health.details)
 
 
 # ===========================

--- a/test/test_ui_pages.py
+++ b/test/test_ui_pages.py
@@ -91,7 +91,7 @@ def test_primary_pages_keep_homogeneous_support_field_order() -> None:
         "async def main" if "async def main" in workflow_source else "def main"
     )
     workflow_main = workflow_source[workflow_source.index(workflow_main_marker) :]
-    assert 'st.sidebar.expander("Install from pypi.org", expanded=False)' in project_source
+    assert 'st.sidebar.expander("Install another version", expanded=False)' in project_source
     assert '"Check",' in project_source
     assert '"Install agi-app",' in project_source
     assert '"Reviewed",' in project_source
@@ -1175,7 +1175,9 @@ def test_execute_page_cluster_settings(mock_ui_env):
     assert str(data_share) not in markdown_text
     expander_labels = [str(item.label) for item in at.expander]
     assert "Environment details" in expander_labels
-    assert expander_labels[-1] == "Environment details"
+    assert expander_labels.index("Environment details") < expander_labels.index(
+        "1. Resources and deployment"
+    )
     assert "Evidence drawer" not in expander_labels
     assert "Deployment logs" not in expander_labels
     assert "Observe benchmark results" not in expander_labels
@@ -1250,6 +1252,23 @@ def test_orchestrate_resource_summary_uses_updated_cluster_widget_state():
     )
 
     assert placeholder_index < cluster_widget_index < summary_index
+
+
+def test_orchestrate_expanders_render_below_banner_slot():
+    source = Path("src/agilab/pages/2_ORCHESTRATE.py").read_text(encoding="utf-8")
+
+    chrome_index = source.index("render_page_chrome(")
+    banner_slot_index = source.index("orchestrate_banner_slot = st.container()")
+    banner_render_index = source.index("with orchestrate_banner_slot:")
+    details_index = source.index(
+        "_environment_render_environment_details(st, environment_health.details)"
+    )
+    deployment_index = source.index(
+        "verbose, install_status = await _render_deployment_panel"
+    )
+
+    assert chrome_index < banner_slot_index < banner_render_index
+    assert banner_render_index < details_index < deployment_index
 
 
 def test_orchestrate_rechecks_install_status_after_install_before_run_gate():
@@ -2444,8 +2463,15 @@ def test_project_sidebar_orders_active_project_before_actions():
     assert "def render_project_dashboard(env)" in source
     dashboard_body = source[source.index("def render_project_dashboard(env)") :]
     dashboard_body = dashboard_body.split("def handle_project_selection(", 1)[0]
+    assert "with st.container(border=True):" in dashboard_body
     assert 'st.expander("Project metrics", expanded=False)' in dashboard_body
     assert "_render_project_software_metrics(env)" in dashboard_body
+    assert dashboard_body.index("with st.container(border=True):") < dashboard_body.index(
+        'st.expander("Project metrics", expanded=False)'
+    )
+    assert dashboard_body.index(
+        'st.expander("Project metrics", expanded=False)'
+    ) < dashboard_body.index("render_environment_details(st, health.details)")
     assert "_render_edit_project_metric" not in source
     assert "Choose what to do with the active project" not in source
     assert "Actions below apply to this selected project" not in source
@@ -2462,6 +2488,29 @@ def test_project_sidebar_orders_active_project_before_actions():
     assert "Source KLOC" in source
     assert "Project Name (no suffix)" not in source
     assert "New Project Name (no suffix)" not in source
+    project_status_source = Path("src/agilab/pages/1_PROJECT_STATUS.py").read_text(
+        encoding="utf-8"
+    )
+    chrome_index = project_status_source.index("render_page_chrome(")
+    selector_index = project_status_source.index("render_project_selector(")
+    dashboard_index = project_status_source.index(
+        "project_editor_page.render_project_dashboard(env)"
+    )
+    sidebar_index = project_status_source.index(
+        "project_editor_page.render_project_sidebar("
+    )
+    assert chrome_index < selector_index < sidebar_index < dashboard_index
+
+
+def test_project_status_reloads_editor_helpers_when_source_changes():
+    source = Path("src/agilab/pages/1_PROJECT_STATUS.py").read_text(encoding="utf-8")
+    loader_body = source.split("def _load_project_editor_page_module", 1)[1].split(
+        "def _on_project_change", 1
+    )[0]
+
+    assert "source_mtime_ns = module_path.stat().st_mtime_ns" in loader_body
+    assert "__agilab_source_mtime_ns__" in loader_body
+    assert "spec.loader.exec_module(module)" in loader_body
 
 
 def test_execute_page_cython_setting_hydrates_from_app_settings(mock_ui_env):
@@ -3184,8 +3233,8 @@ def test_project_status_page_owns_project_selectbox_edit_button_and_sidebar_acti
     assert "Reviewed" in sidebar_checkbox_labels
     assert "Reviewed agi-app" not in sidebar_checkbox_labels
     sidebar_expander_labels = [str(expander.label) for expander in at.sidebar.expander]
-    assert "Install from pypi.org" in sidebar_expander_labels
-    assert sidebar_expander_labels.index("Install from pypi.org") < sidebar_expander_labels.index("Quick actions")
+    assert "Install another version" in sidebar_expander_labels
+    assert sidebar_expander_labels.index("Install another version") < sidebar_expander_labels.index("Quick actions")
     assert "agi-app from PyPI" not in sidebar_expander_labels
     markdown_text = "\n".join(str(item.value) for item in at.markdown)
     expander_labels = [str(item.label) for item in at.expander]


### PR DESCRIPTION
## Summary
- keep PROJECT metrics/details below the PROJECT banner area
- keep ORCHESTRATE environment/deployment expanders below the top banner slot
- add source-order regressions for the layout contract

## Validation
- Not run; UI ordering change only, local pre-push scope guards passed/skipped unrelated guards.