### PR TITLE
[codex] fix audit guardrail regressions

### DIFF
--- a/src/agilab/compat/module_shim.py
+++ b/src/agilab/compat/module_shim.py
@@ -95,7 +95,18 @@ def activate_compat_module(
     current_module = sys.modules.get(current_name)
     if current_module is None:
         return module
+    legacy_metadata = {
+        "__name__": current_module.__dict__.get("__name__"),
+        "__package__": current_module.__dict__.get("__package__"),
+        "__loader__": current_module.__dict__.get("__loader__"),
+        "__spec__": current_module.__dict__.get("__spec__"),
+        "__file__": current_module.__dict__.get("__file__"),
+        "__cached__": current_module.__dict__.get("__cached__"),
+    }
     current_module.__dict__.update(module.__dict__)
+    for key, value in legacy_metadata.items():
+        if value is not None:
+            current_module.__dict__[key] = value
     current_module.__dict__["_AGILAB_COMPAT_TARGET_MODULE"] = module
     current_module.__class__ = _CompatModule
     return None

--- a/src/agilab/core/agi-env/src/agi_env/ui/pagelib.py
+++ b/src/agilab/core/agi-env/src/agi_env/ui/pagelib.py
@@ -1051,7 +1051,7 @@ def sidebar_views():
         find_files_fn=find_files,
         resolve_default_selection_fn=resolve_default_selection,
         build_sidebar_dataframe_selection_fn=build_sidebar_dataframe_selection,
-        on_lab_change_fn=on_lab_change,  # ty: ignore[unresolved-reference]
+        on_lab_change_fn=on_lab_change,
         on_df_change_fn=on_df_change,
         path_cls=Path,
     )
@@ -1060,6 +1060,45 @@ def sidebar_views():
 def load_last_stage(_module_dir, _stages_file, _index_page_str):
     """Optional hook used by legacy sidebar integrations after dataframe changes."""
     return None
+
+
+def on_lab_change(new_index_page):
+    """Reset stale page state when the sidebar switches to another project."""
+    session_state = st.session_state
+    session_state.pop("stages_file", None)
+    session_state.pop("df_file", None)
+    session_state.pop(str(session_state.get("index_page", "")) + "df", None)
+    session_state["_requested_lab_dir"] = new_index_page
+    session_state["lab_dir"] = new_index_page
+    session_state["project_changed"] = True
+    session_state["_experiment_reload_required"] = True
+    try:
+        session_state.page_broken = True
+    except AttributeError:
+        session_state["page_broken"] = True
+
+    env = session_state.get("env")
+    if env is None:
+        return
+    try:
+        apps_path = Path(env.apps_path)
+        preferred_base = getattr(env, "builtin_apps_path", None)
+        candidates = active_app_candidates(
+            new_index_page,
+            apps_path,
+            getattr(env, "projects", None) or [],
+            preferred_base=Path(preferred_base) if preferred_base else None,
+        )
+        for candidate in candidates:
+            if candidate.exists():
+                store_last_active_app(candidate)
+                break
+    except (AttributeError, OSError, RuntimeError, TypeError, ValueError):
+        logger.debug(
+            "Could not persist active app selection for %s",
+            new_index_page,
+            exc_info=True,
+        )
 
 
 def on_df_change(module_dir, index_page, df_file=None, stages_file=None):

--- a/src/agilab/core/agi-env/src/agi_env/ui/pagelib_selection_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/ui/pagelib_selection_support.py
@@ -110,7 +110,9 @@ def sidebar_views(
     """
     Create sidebar controls for lab and dataframe selection.
     """
-    env = session_state["env"]
+    env = session_state.get("env")
+    if env is None:
+        return
     export_root = path_cls(env.AGILAB_EXPORT_ABS)
     modules = session_state.get("modules", scan_dir_fn(export_root))
 

--- a/src/agilab/core/agi-env/test/test_pagelib.py
+++ b/src/agilab/core/agi-env/test/test_pagelib.py
@@ -2518,7 +2518,6 @@ def test_pagelib_wrapper_functions_delegate_selection_helpers(monkeypatch):
     monkeypatch.setattr(pagelib, "_resolve_active_app_impl", _capture_active)
     monkeypatch.setattr(pagelib, "_sidebar_views_impl", _capture_sidebar)
     monkeypatch.setattr(pagelib, "_on_df_change_impl", _capture_df)
-    monkeypatch.setattr(pagelib, "on_lab_change", lambda *_args, **_kwargs: None, raising=False)
     monkeypatch.setattr(pagelib, "load_last_stage", lambda *_args, **_kwargs: None, raising=False)
 
     assert pagelib.select_project(["demo_project"], "demo_project") == "selected"
@@ -2528,7 +2527,52 @@ def test_pagelib_wrapper_functions_delegate_selection_helpers(monkeypatch):
     assert captured["select"][1]["session_state"] is session_state
     assert captured["active"][1]["query_params"] == {"app": "demo"}
     assert captured["sidebar"][1]["session_state"] is session_state
+    assert captured["sidebar"][1]["on_lab_change_fn"] is pagelib.on_lab_change
     assert captured["df"][1]["session_state"] is session_state
+
+
+def test_on_lab_change_resets_project_state_and_persists_existing_app(tmp_path, monkeypatch):
+    class _SessionState(dict):
+        def __setattr__(self, name, value):
+            self[name] = value
+
+    apps_path = tmp_path / "apps"
+    builtin_apps_path = apps_path / "builtin"
+    project_path = builtin_apps_path / "demo_project"
+    project_path.mkdir(parents=True)
+    state = _SessionState(
+        {
+            "index_page": "demo_project",
+            "demo_projectdf": "old.csv",
+            "stages_file": "old-stages.toml",
+            "df_file": "old.csv",
+            "env": SimpleNamespace(
+                apps_path=apps_path,
+                builtin_apps_path=builtin_apps_path,
+                projects=["demo_project"],
+            ),
+        }
+    )
+    stored = {}
+
+    monkeypatch.setattr(pagelib, "st", SimpleNamespace(session_state=state))
+    monkeypatch.setattr(
+        pagelib,
+        "store_last_active_app",
+        lambda path: stored.setdefault("path", path),
+    )
+
+    pagelib.on_lab_change("demo_project")
+
+    assert "stages_file" not in state
+    assert "df_file" not in state
+    assert "demo_projectdf" not in state
+    assert state["_requested_lab_dir"] == "demo_project"
+    assert state["lab_dir"] == "demo_project"
+    assert state["project_changed"] is True
+    assert state["_experiment_reload_required"] is True
+    assert state["page_broken"] is True
+    assert stored["path"] == project_path
 
 
 def test_update_views_ignores_missing_page_between_listdir_and_stat(tmp_path, monkeypatch):

--- a/src/agilab/core/agi-env/test/test_pagelib_selection_support.py
+++ b/src/agilab/core/agi-env/test/test_pagelib_selection_support.py
@@ -197,6 +197,26 @@ def test_sidebar_views_support_and_on_df_change_manage_selection_state(tmp_path)
     assert stages_file.parent.is_dir()
 
 
+def test_sidebar_views_support_returns_when_environment_is_not_ready():
+    session_state = _State()
+    calls = []
+
+    sidebar_views(
+        session_state=session_state,
+        sidebar=_Sidebar(session_state),
+        scan_dir_fn=lambda path: calls.append(path),
+        find_files_fn=lambda _path: (_ for _ in ()).throw(AssertionError("no env")),
+        resolve_default_selection_fn=resolve_default_selection,
+        build_sidebar_dataframe_selection_fn=build_sidebar_dataframe_selection,
+        on_lab_change_fn=lambda *_args, **_kwargs: None,
+        on_df_change_fn=lambda *_args, **_kwargs: None,
+        path_cls=Path,
+    )
+
+    assert calls == []
+    assert session_state == {}
+
+
 def test_sidebar_views_support_handles_empty_dataframe_list(tmp_path):
     export_root = tmp_path / "export"
     (export_root / "lab_a").mkdir(parents=True)

--- a/test/test_agilab_audit.py
+++ b/test/test_agilab_audit.py
@@ -60,3 +60,13 @@ def test_strict_audit_still_warns_on_unexpected_detached_checkout(monkeypatch, t
     assert report["detached"] is True
     assert report["detached_expected"] is False
     assert "detached HEAD" in report["warnings"]
+
+
+def test_audit_worktree_reports_missing_path_without_running_git(tmp_path: Path) -> None:
+    missing = tmp_path / "stale-worktree"
+
+    report = agilab_audit._audit_worktree(missing, fetch=True)
+
+    assert report["status"] == "missing worktree path"
+    assert report["head"] is None
+    assert "missing worktree path; run git worktree prune" in report["warnings"]

--- a/test/test_agilab_dev_shortcuts.py
+++ b/test/test_agilab_dev_shortcuts.py
@@ -88,6 +88,36 @@ def test_lint_shortcut_provisions_ruff_from_dev_extra_by_default():
             "dev",
             "ruff",
             "check",
+            *agilab_dev.DEFAULT_LINT_TARGETS,
+        ],
+        [
+            "uv",
+            "--preview-features",
+            "extra-build-dependencies",
+            "run",
+            "--extra",
+            "dev",
+            "ruff",
+            "check",
+            "--select",
+            "F821,E9",
+            *agilab_dev.DEFAULT_UNDEFINED_NAME_LINT_TARGETS,
+        ],
+    ]
+
+
+def test_lint_shortcut_keeps_explicit_paths():
+    assert agilab_dev.planned_commands(["lint", "src/agilab/main_page.py"]) == [
+        [
+            "uv",
+            "--preview-features",
+            "extra-build-dependencies",
+            "run",
+            "--extra",
+            "dev",
+            "ruff",
+            "check",
+            "src/agilab/main_page.py",
         ]
     ]
 

--- a/test/test_agilab_module_layout.py
+++ b/test/test_agilab_module_layout.py
@@ -87,6 +87,14 @@ def test_shared_core_compat_modules_preserve_legacy_module_identity():
     )
 
 
+def test_top_level_agilab_compat_modules_preserve_legacy_module_identity():
+    assert importlib.import_module("agilab.agent_run").__name__ == "agilab.agent_run"
+    assert (
+        importlib.import_module("agilab.pipeline_runtime").__name__
+        == "agilab.pipeline_runtime"
+    )
+
+
 def test_data_quality_gate_modules_are_classified_or_entrypoints() -> None:
     root = (
         Path(__file__).resolve().parents[1]

--- a/tools/agilab_audit.py
+++ b/tools/agilab_audit.py
@@ -22,15 +22,18 @@ SCHEMA_VERSION = "agilab.audit.v1"
 
 
 def _run(command: list[str], *, cwd: Path = ROOT, timeout: int = 60) -> tuple[int, str, str]:
-    completed = subprocess.run(
-        command,
-        cwd=cwd,
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        timeout=timeout,
-        check=False,
-    )
+    try:
+        completed = subprocess.run(
+            command,
+            cwd=cwd,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=timeout,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        return 127, "", str(exc)
     return completed.returncode, completed.stdout.strip(), completed.stderr.strip()
 
 
@@ -70,6 +73,18 @@ def _worktrees() -> list[dict[str, str]]:
 
 
 def _audit_worktree(path: Path, *, fetch: bool) -> dict[str, Any]:
+    if not path.exists():
+        return {
+            "path": str(path),
+            "status": "missing worktree path",
+            "branch": None,
+            "detached": False,
+            "detached_expected": False,
+            "head": None,
+            "upstream": None,
+            "ahead_behind_origin_main": None,
+            "warnings": ["missing worktree path; run git worktree prune"],
+        }
     if fetch:
         _git(["fetch", "--prune", "origin"], cwd=path)
     rc, status, err = _git(["status", "--short", "--branch", "--untracked-files=no"], cwd=path)

--- a/tools/agilab_dev.py
+++ b/tools/agilab_dev.py
@@ -12,6 +12,23 @@ from typing import Sequence
 
 ROOT = Path(__file__).resolve().parents[1]
 UV_RUN = ("uv", "--preview-features", "extra-build-dependencies", "run")
+DEFAULT_LINT_TARGETS = (
+    "src/agilab/security",
+    "src/agilab/evidence",
+    "src/agilab/agent_runtime",
+    "src/agilab/compat",
+    "src/agilab/core/agi-env/src/agi_env/ui/pagelib_selection_support.py",
+    "tools/agilab_audit.py",
+    "tools/agilab_dev.py",
+    "src/agilab/core/agi-env/test/test_pagelib_selection_support.py",
+    "test/test_agilab_audit.py",
+    "test/test_agilab_dev_shortcuts.py",
+    "test/test_agilab_module_layout.py",
+)
+DEFAULT_UNDEFINED_NAME_LINT_TARGETS = (
+    "src/agilab/core/agi-env/src/agi_env/ui/pagelib.py",
+    "src/agilab/core/agi-env/test/test_pagelib.py",
+)
 
 
 def _uv_python(*args: str) -> list[str]:
@@ -59,7 +76,18 @@ def planned_commands(argv: Sequence[str]) -> list[list[str]]:
         return [[*UV_RUN, "pytest", "-q", "-o", "addopts=", "--import-mode=importlib", *args]]
 
     if command == "lint":
-        return [_uv_dev("ruff", "check", *args)]
+        if args:
+            return [_uv_dev("ruff", "check", *args)]
+        return [
+            _uv_dev("ruff", "check", *DEFAULT_LINT_TARGETS),
+            _uv_dev(
+                "ruff",
+                "check",
+                "--select",
+                "F821,E9",
+                *DEFAULT_UNDEFINED_NAME_LINT_TARGETS,
+            ),
+        ]
 
     if command == "ruff":
         return [_uv_dev("ruff", *(args or ["check"]))]
@@ -214,7 +242,7 @@ High-frequency mappings:
   impact    -> Analyze changed files and list the required local validations; defaults to --staged.
   bugfix    -> Run impact triage, then run the GA-selected fast regression subset; defaults to --staged.
   test      -> Run targeted pytest with -q and repo-wide coverage disabled, while keeping all extra pytest arguments.
-  lint      -> Run Ruff through the repo dev extra; defaults to `ruff check`.
+  lint      -> Run Ruff through the repo dev extra on the default clean guardrail slice; pass paths for custom scope.
   regress   -> Use the GA regression selector on staged files and run the selected pytest subset.
   robust    -> Run the P0 robustness matrix of fail-closed bad-state scenarios.
   parallel-stage -> Create or validate a function + split rule + reducer contract for parallel execution.


### PR DESCRIPTION
## Changes
- Fix agi-env sidebar project switching by defining the missing on_lab_change callback and making unbootstrapped sidebar state fail closed.
- Preserve legacy metadata for top-level AGILAB compatibility shims.
- Make the local audit tool report missing/stale worktrees instead of crashing.
- Make ./dev lint a usable guardrail slice plus targeted undefined-name checks.

## Root cause
The pagelib wrapper delegated an undefined callback, tests masked the missing symbol, and release/audit guardrails had stale-worktree and too-noisy-lint failure modes.

## Validation
- ./dev lint
- uv --preview-features extra-build-dependencies run --no-sync pytest -q -o addopts= --import-mode=importlib src/agilab/core/agi-env/test
- uv --preview-features extra-build-dependencies run pytest -q -o addopts= --import-mode=importlib test/test_agilab_audit.py test/test_agilab_dev_shortcuts.py test/test_agilab_module_layout.py
- ./dev audit
- ./dev scope
