### PR TITLE
[codex] Harden src tree reorg contracts

### DIFF
--- a/.claude/skills/agilab-testing/SKILL.md
+++ b/.claude/skills/agilab-testing/SKILL.md
@@ -121,6 +121,21 @@ Use this skill when validating changes.
   - Treat compatibility fallbacks that strip unsupported arguments as suspect:
     add one regression proving the fallback is not hiding a product-path
     downgrade.
+- Source-tree reorganization regressions:
+  - When moving modules into classified packages, test both static shim targets
+    and runtime legacy identity (`__name__`, `__package__`) for representative
+    import-safe shims. A shim that imports the right target but exposes the
+    target module name is still broken for callers, monkeypatching, and
+    diagnostics.
+  - For `agi-app-*` package payloads, treat the built-in app project as the
+    canonical source and `src/agilab/lib/app_project_build_support.py` as the
+    generator. Do not hand-edit embedded package payload copies without
+    regenerating or validating them against the generated payload contract.
+  - After app/package/page tree changes, run
+    `uv --preview-features extra-build-dependencies run python tools/app_contract_matrix.py --quiet`
+    or `./dev app-contracts` so stale embedded app payloads, package-data drift,
+    page-bundle contract drift, and local artifact leakage are caught before
+    release.
 - Cluster/share regressions:
   - For live cluster validation, never assume a worker IP from memory or a prior
     run. Run the official no-cache LAN discovery first and use only a fresh

--- a/.codex/skills/agilab-testing/SKILL.md
+++ b/.codex/skills/agilab-testing/SKILL.md
@@ -121,6 +121,21 @@ Use this skill when validating changes.
   - Treat compatibility fallbacks that strip unsupported arguments as suspect:
     add one regression proving the fallback is not hiding a product-path
     downgrade.
+- Source-tree reorganization regressions:
+  - When moving modules into classified packages, test both static shim targets
+    and runtime legacy identity (`__name__`, `__package__`) for representative
+    import-safe shims. A shim that imports the right target but exposes the
+    target module name is still broken for callers, monkeypatching, and
+    diagnostics.
+  - For `agi-app-*` package payloads, treat the built-in app project as the
+    canonical source and `src/agilab/lib/app_project_build_support.py` as the
+    generator. Do not hand-edit embedded package payload copies without
+    regenerating or validating them against the generated payload contract.
+  - After app/package/page tree changes, run
+    `uv --preview-features extra-build-dependencies run python tools/app_contract_matrix.py --quiet`
+    or `./dev app-contracts` so stale embedded app payloads, package-data drift,
+    page-bundle contract drift, and local artifact leakage are caught before
+    release.
 - Cluster/share regressions:
   - For live cluster validation, never assume a worker IP from memory or a prior
     run. Run the official no-cache LAN discovery first and use only a fresh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,8 @@ Use this runbook whenever you:
   `memory` checks path-scoped maintenance notes for source drift,
   `docs` keeps the public mirror aligned, `scope` fails fast when unrelated dirty
   scopes are mixed, `task-worktree` creates a sibling checkout for one isolated
-  branch, and `clean` dry-runs removal of ignored local build/lib duplicates unless `--apply`
+  branch, and `clean` dry-runs removal of ignored local build/lib duplicates
+  plus ignored local artifact directories under `src/agilab` unless `--apply`
   is passed. Use `--print-only` to audit the expanded commands.
 - **Upgrade packaged tools first**: Before launching the published CLI with `uvx
   agilab`, run `uv --preview-features extra-build-dependencies tool install --upgrade agilab` to install or pick up the latest wheel.

--- a/agilab-capabilities.json
+++ b/agilab-capabilities.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-06-02T17:18:09Z",
+  "generated_at_utc": "2026-06-02T20:08:55Z",
   "schema": "agilab.capabilities.v1",
   "schema_version": 1,
   "generated_by": {
@@ -1751,18 +1751,24 @@
     {
       "schema": "agilab.notebook_export_handoff.v1",
       "sources": [
+        "src/agilab/apps/builtin/flight_telemetry_project/notebooks/lab_stages.notebook_export.md",
+        "src/agilab/apps/builtin/multi_app_dag_project/notebooks/lab_stages.notebook_export.md",
         "src/agilab/notebooks/notebook_export_support.py"
       ]
     },
     {
       "schema": "agilab.notebook_export_manifest.v1",
       "sources": [
+        "src/agilab/apps/builtin/flight_telemetry_project/notebooks/lab_stages.notebook_export.json",
+        "src/agilab/apps/builtin/multi_app_dag_project/notebooks/lab_stages.notebook_export.json",
         "src/agilab/notebooks/notebook_export_support.py"
       ]
     },
     {
       "schema": "agilab.notebook_export_portability.v1",
       "sources": [
+        "src/agilab/apps/builtin/flight_telemetry_project/notebooks/lab_stages.notebook_export.json",
+        "src/agilab/apps/builtin/multi_app_dag_project/notebooks/lab_stages.notebook_export.json",
         "src/agilab/notebooks/notebook_export_support.py"
       ]
     },

--- a/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/compat/module_shim.py
+++ b/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/compat/module_shim.py
@@ -83,7 +83,18 @@ def activate_compat_module(current_name: str, target_name: str) -> ModuleType | 
     current_module = sys.modules.get(current_name)
     if current_module is None:
         return module
+    legacy_metadata = {
+        "__name__": current_module.__dict__.get("__name__"),
+        "__package__": current_module.__dict__.get("__package__"),
+        "__loader__": current_module.__dict__.get("__loader__"),
+        "__spec__": current_module.__dict__.get("__spec__"),
+        "__file__": current_module.__dict__.get("__file__"),
+        "__cached__": current_module.__dict__.get("__cached__"),
+    }
     current_module.__dict__.update(module.__dict__)
+    for key, value in legacy_metadata.items():
+        if value is not None:
+            current_module.__dict__[key] = value
     current_module.__dict__["_COMPAT_TARGET_MODULE"] = module
     current_module.__class__ = _CompatModule
     return None

--- a/src/agilab/apps/builtin/tescia_diagnostic_project/src/tescia_diagnostic/compat/module_shim.py
+++ b/src/agilab/apps/builtin/tescia_diagnostic_project/src/tescia_diagnostic/compat/module_shim.py
@@ -83,7 +83,18 @@ def activate_compat_module(current_name: str, target_name: str) -> ModuleType | 
     current_module = sys.modules.get(current_name)
     if current_module is None:
         return module
+    legacy_metadata = {
+        "__name__": current_module.__dict__.get("__name__"),
+        "__package__": current_module.__dict__.get("__package__"),
+        "__loader__": current_module.__dict__.get("__loader__"),
+        "__spec__": current_module.__dict__.get("__spec__"),
+        "__file__": current_module.__dict__.get("__file__"),
+        "__cached__": current_module.__dict__.get("__cached__"),
+    }
     current_module.__dict__.update(module.__dict__)
+    for key, value in legacy_metadata.items():
+        if value is not None:
+            current_module.__dict__[key] = value
     current_module.__dict__["_COMPAT_TARGET_MODULE"] = module
     current_module.__class__ = _CompatModule
     return None

--- a/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/pyproject.toml
+++ b/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "flight_telemetry_project"
-version = "0.1.0"
+version = "2026.05.30.post1"
 description = "Built-in AGILab example app (flight-telemetry preprocessing)"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.13.post3,<2027.0", "agi-node>=2026.05.13.post3,<2027.0", "agi-cluster>=2026.05.13.post3,<2027.0", "polars[rtcompat]>=1.35,<2", "pydantic>=2.11,<2.13", "py7zr>=1.1,<1.2", "streamlit>=1.58,<2"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "polars[rtcompat]>=1.35,<2", "pydantic>=2.11,<2.13", "py7zr>=1.1,<1.2", "streamlit>=1.58,<2"]
 
 [tool.agilab]
 runtime_target = "flight_telemetry"

--- a/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/src/flight_telemetry_worker/pyproject.toml
+++ b/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/src/flight_telemetry_worker/pyproject.toml
@@ -1,15 +1,10 @@
 [project]
 name = "flight_telemetry_project"
-version = "0.1.0"
+version = "2026.05.30.post1"
 description = ""
 requires-python = ">=3.11,<3.14"
 readme = "README.md"
-dependencies = [
-    "agi-env>=2026.05.13.post3,<2027.0",
-    "agi-node>=2026.05.13.post3,<2027.0",
-    "polars>=1.35,<2",
-    "pydantic>=2.11,<2.13",
-]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "polars>=1.35,<2", "pydantic>=2.11,<2.13"]
 
 [[project.authors]]
 name = "Jean-Pierre Morard"
@@ -23,9 +18,21 @@ text = "Thales SIX GTS France SAS"
 dag-worker = []
 polars-worker = []
 
-[tool.uv.sources]
-agi-env = { path = "../../../../../../../../core/agi-env", editable = true }
-agi-node = { path = "../../../../../../../../core/agi-node", editable = true }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 [build-system]
 requires = ["setuptools", "cython"]

--- a/src/agilab/lib/agi-app-mission-decision/src/agi_app_mission_decision/project/mission_decision_project/pyproject.toml
+++ b/src/agilab/lib/agi-app-mission-decision/src/agi_app_mission_decision/project/mission_decision_project/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "mission_decision_project"
-version = "0.1.0"
+version = "2026.05.30.post1"
 description = "Built-in AGILAB Mission Decision autonomous demo"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.13.post3,<2027.0", "agi-node>=2026.05.13.post3,<2027.0", "agi-cluster>=2026.05.13.post3,<2027.0", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "streamlit>=1.58,<2"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "streamlit>=1.58,<2"]
 
 [tool.agilab]
 runtime_target = "mission_decision"

--- a/src/agilab/lib/agi-app-mission-decision/src/agi_app_mission_decision/project/mission_decision_project/src/mission_decision_worker/pyproject.toml
+++ b/src/agilab/lib/agi-app-mission-decision/src/agi_app_mission_decision/project/mission_decision_project/src/mission_decision_worker/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "mission_decision_project"
-version = "0.1.0"
+version = "2026.05.30.post1"
 description = "Built-in AGILAB Mission Decision autonomous demo"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.13.post3,<2027.0", "agi-node>=2026.05.13.post3,<2027.0", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13"]
 
 [tool.setuptools.package-data]
 mission_decision = ["sample_data/*.json"]

--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/pyproject.toml
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/pyproject.toml
@@ -5,10 +5,10 @@ description = "Built-in AGILab app for reproducible PyTorch classifier playgroun
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "agi-env>=2026.05.30.post1",
-    "agi-node>=2026.05.30.post1",
-    "agi-cluster>=2026.05.30.post1",
-    "agi-gui>=2026.05.30.post1",
+    "agi-env>=2026.05.31",
+    "agi-node>=2026.05.31",
+    "agi-cluster>=2026.05.31",
+    "agi-gui>=2026.05.31",
     "agi-web>=2026.05.31",
     "numpy>=2.2,<3",
     "pandas>=2.3.0,<4",
@@ -26,6 +26,7 @@ Homepage = "https://github.com/ThalesGroup/agilab"
 Repository = "https://github.com/ThalesGroup/agilab"
 Discussions = "https://github.com/ThalesGroup/agilab/discussions"
 Changelog = "https://github.com/ThalesGroup/agilab/releases"
+
 [tool.agilab.app]
 distribution_preview = false
 service_mode = false

--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground/compat/module_shim.py
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground/compat/module_shim.py
@@ -83,7 +83,18 @@ def activate_compat_module(current_name: str, target_name: str) -> ModuleType | 
     current_module = sys.modules.get(current_name)
     if current_module is None:
         return module
+    legacy_metadata = {
+        "__name__": current_module.__dict__.get("__name__"),
+        "__package__": current_module.__dict__.get("__package__"),
+        "__loader__": current_module.__dict__.get("__loader__"),
+        "__spec__": current_module.__dict__.get("__spec__"),
+        "__file__": current_module.__dict__.get("__file__"),
+        "__cached__": current_module.__dict__.get("__cached__"),
+    }
     current_module.__dict__.update(module.__dict__)
+    for key, value in legacy_metadata.items():
+        if value is not None:
+            current_module.__dict__[key] = value
     current_module.__dict__["_COMPAT_TARGET_MODULE"] = module
     current_module.__class__ = _CompatModule
     return None

--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground_worker/pyproject.toml
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground_worker/pyproject.toml
@@ -4,8 +4,8 @@ version = "2026.05.30.post1"
 description = "Worker package for the AGILAB PyTorch playground app"
 requires-python = ">=3.12"
 dependencies = [
-    "agi-env>=2026.05.30.post1",
-    "agi-node>=2026.05.30.post1",
+    "agi-env>=2026.05.31",
+    "agi-node>=2026.05.31",
     "numpy>=2.2,<3",
     "pandas>=2.3.0,<4",
     "pydantic>=2.11,<2.13",

--- a/src/agilab/lib/agi-app-uav-relay-queue/src/agi_app_uav_relay_queue/project/uav_relay_queue_project/notebook_export.toml
+++ b/src/agilab/lib/agi-app-uav-relay-queue/src/agi_app_uav_relay_queue/project/uav_relay_queue_project/notebook_export.toml
@@ -1,9 +1,9 @@
 [notebook_export]
 
 [[notebook_export.related_pages]]
-module = "view_relay_resilience"
-label = "UAV Relay Queue Analysis"
-description = "Inspect queue depth, packet delivery, relay routing summary, and node positions for the relay-queue demo."
+module = "view_scenario_cockpit"
+label = "Scenario Cockpit"
+description = "Inspect scenario setup, queue depth, packet delivery, relay routing summary, and node positions for the relay-queue demo."
 artifacts = [
   "*_summary_metrics.json",
   "*_queue_timeseries.csv",
@@ -11,7 +11,19 @@ artifacts = [
   "*_node_positions.csv",
   "*_routing_summary.csv",
 ]
-launch_note = "Open this first for the dedicated relay queue analysis view over the exported run artifacts."
+launch_note = "Open this first for the scenario-level view over the exported run artifacts."
+
+[[notebook_export.related_pages]]
+module = "view_relay_resilience"
+label = "Relay Resilience"
+description = "Inspect relay queue health, congestion pressure, and packet delivery evidence for the same run."
+artifacts = [
+  "*_summary_metrics.json",
+  "*_queue_timeseries.csv",
+  "*_packet_events.csv",
+  "*_routing_summary.csv",
+]
+launch_note = "Use this to focus on relay resilience metrics."
 
 [[notebook_export.related_pages]]
 module = "view_maps_network"

--- a/src/agilab/lib/agi-app-uav-relay-queue/src/agi_app_uav_relay_queue/project/uav_relay_queue_project/pipeline_view.dot
+++ b/src/agilab/lib/agi-app-uav-relay-queue/src/agi_app_uav_relay_queue/project/uav_relay_queue_project/pipeline_view.dot
@@ -6,7 +6,7 @@ digraph uav_relay_queue_pipeline {
 
   scenario [label="Scenario JSON\nsource + relays + sink"];
   simulate [label="UAV relay queue simulation\nshortest_path | queue_aware"];
-  analysis [label="AGILAB ANALYSIS\nview_relay_resilience\nview_maps_network"];
+  analysis [label="AGILAB ANALYSIS\nview_scenario_cockpit\nview_relay_resilience\nview_maps_network"];
 
   scenario -> simulate;
   simulate -> analysis;

--- a/src/agilab/lib/agi-app-uav-relay-queue/src/agi_app_uav_relay_queue/project/uav_relay_queue_project/pyproject.toml
+++ b/src/agilab/lib/agi-app-uav-relay-queue/src/agi_app_uav_relay_queue/project/uav_relay_queue_project/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "uav_relay_queue_project"
-version = "0.1.0"
+version = "2026.05.30.post1"
 description = "Built-in AGILAB lightweight UAV relay queue example"
-requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.13.post3,<2027.0", "agi-node>=2026.05.13.post3,<2027.0", "agi-cluster>=2026.05.13.post3,<2027.0", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "simpy>=4.1,<5", "streamlit>=1.58,<2"]
+requires-python = ">=3.13"
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "simpy>=4.1,<5", "streamlit>=1.58,<2"]
 
 [tool.setuptools.package-data]
 uav_relay_queue = ["sample_data/*.json"]

--- a/src/agilab/lib/agi-app-uav-relay-queue/src/agi_app_uav_relay_queue/project/uav_relay_queue_project/src/app_settings.toml
+++ b/src/agilab/lib/agi-app-uav-relay-queue/src/agi_app_uav_relay_queue/project/uav_relay_queue_project/src/app_settings.toml
@@ -36,9 +36,12 @@ scenario_sql = "uav_relay_queue_scenarios_sql"
 operator_events = "uav_relay_queue_ops_opensearch"
 artifact_store = "uav_relay_queue_artifact_store"
 
-[page_connector_refs.view_relay_resilience]
+[page_connector_refs.view_scenario_cockpit]
 relay_metrics = "uav_relay_queue_artifact_store"
 operator_events = "uav_relay_queue_ops_opensearch"
+
+[page_connector_refs.view_relay_resilience]
+relay_metrics = "uav_relay_queue_artifact_store"
 
 [page_connector_refs.view_maps_network]
 network_evidence = "uav_relay_queue_ops_opensearch"
@@ -49,6 +52,7 @@ data_out = "uav_relay_queue/results"
 
 [pages]
 view_module = [
+    "view_scenario_cockpit",
     "view_relay_resilience",
     "view_maps_network",
 ]

--- a/src/agilab/lib/agi-app-uav-relay-queue/src/agi_app_uav_relay_queue/project/uav_relay_queue_project/src/uav_relay_queue_worker/pyproject.toml
+++ b/src/agilab/lib/agi-app-uav-relay-queue/src/agi_app_uav_relay_queue/project/uav_relay_queue_project/src/uav_relay_queue_worker/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "uav_relay_queue_project"
-version = "0.1.0"
+version = "2026.05.30.post1"
 description = "Built-in AGILAB lightweight UAV relay queue example"
-requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.13.post3,<2027.0", "agi-node>=2026.05.13.post3,<2027.0", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "simpy>=4.1,<5"]
+requires-python = ">=3.13"
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "simpy>=4.1,<5"]
 
 [tool.setuptools.package-data]
 uav_relay_queue = ["sample_data/*.json"]

--- a/src/agilab/lib/agi-app-weather-forecast/src/agi_app_weather_forecast/project/weather_forecast_project/pyproject.toml
+++ b/src/agilab/lib/agi-app-weather-forecast/src/agi_app_weather_forecast/project/weather_forecast_project/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "weather_forecast_project"
-version = "0.1.0"
+version = "2026.05.30.post1"
 description = "Built-in AGILab weather forecasting example migrated from notebooks"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.17,<2027.0", "agi-node>=2026.05.17,<2027.0", "agi-cluster>=2026.05.17,<2027.0", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "scikit-learn>=1.7.2,<2", "skforecast>=0.19,<0.20", "streamlit>=1.58,<2"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "scikit-learn>=1.7.2,<2", "skforecast>=0.19,<0.20", "streamlit>=1.58,<2"]
 
 [tool.agilab]
 runtime_target = "weather_forecast"

--- a/src/agilab/lib/agi-app-weather-forecast/src/agi_app_weather_forecast/project/weather_forecast_project/src/weather_forecast_worker/pyproject.toml
+++ b/src/agilab/lib/agi-app-weather-forecast/src/agi_app_weather_forecast/project/weather_forecast_project/src/weather_forecast_worker/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "weather_forecast_project"
-version = "0.1.0"
+version = "2026.05.30.post1"
 description = "Built-in AGILab weather forecasting example migrated from notebooks"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.17,<2027.0", "agi-node>=2026.05.17,<2027.0", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "scikit-learn>=1.7.2,<2", "skforecast>=0.19,<0.20"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "scikit-learn>=1.7.2,<2", "skforecast>=0.19,<0.20"]
 
 [tool.setuptools.package-data]
 weather_forecast = ["sample_data/*.csv"]

--- a/src/agilab/lib/app_project_build_support.py
+++ b/src/agilab/lib/app_project_build_support.py
@@ -99,7 +99,7 @@ _EXCLUDED_PAYLOAD_DIRS = {
     "test",
 }
 _EXCLUDED_PAYLOAD_FILES = {".DS_Store", ".gitignore", ".lock", "uv.lock"}
-_EXCLUDED_PAYLOAD_SUFFIXES = {".c", ".pyc", ".pyo", ".pyx", ".so"}
+_EXCLUDED_PAYLOAD_SUFFIXES = {".c", ".pid", ".pyc", ".pyo", ".pyx", ".so"}
 
 
 def repo_root() -> Path:

--- a/src/agilab/pipeline/pipeline_lab.py
+++ b/src/agilab/pipeline/pipeline_lab.py
@@ -424,14 +424,20 @@ def _valid_runtime_choices(raw_paths: List[Any]) -> List[str]:
 
 
 def _repo_root_for_multi_app_dag() -> Path:
+    module_path = Path(__file__).resolve()
+    fallback_root = module_path.parents[2]
+    for parent in module_path.parents:
+        if (parent / "pyproject.toml").is_file() and (parent / "src" / "agilab").is_dir():
+            fallback_root = parent
+            break
     candidates = [
         Path.cwd(),
-        Path(__file__).resolve().parents[2],
+        fallback_root,
     ]
     for candidate in candidates:
         if (candidate / "docs" / "source" / "data").is_dir():
             return candidate.resolve()
-    return Path(__file__).resolve().parents[2]
+    return fallback_root.resolve()
 
 
 def _global_runner_dag_path(env: AgiEnv, repo_root: Path) -> Path | None:

--- a/test/test_agilab_module_layout.py
+++ b/test/test_agilab_module_layout.py
@@ -2,11 +2,17 @@ from __future__ import annotations
 
 import ast
 import importlib
+import os
 from pathlib import Path
+import subprocess
+import sys
 
 
 ENTRYPOINT_FILES = {"__init__.py", "bridge_cli.py", "lab_run.py", "main_page.py"}
 CORE_PACKAGE_ENTRYPOINT_FILES = {"__init__.py"}
+TOP_LEVEL_COMPAT_IMPORT_EXEMPTIONS = {
+    "agilab.agi_codex",  # Streamlit page module with session-state side effects on plain import.
+}
 
 
 def _target_module_from_shim(path: Path) -> str:
@@ -22,6 +28,23 @@ def _target_module_from_shim(path: Path) -> str:
         ):
             return node.value.value
     raise AssertionError(f"{path} does not declare _TARGET_MODULE")
+
+
+def _legacy_name_from_shim(path: Path) -> str:
+    module = ast.parse(path.read_text(encoding="utf-8"))
+    for node in ast.walk(module):
+        if not isinstance(node, ast.Call):
+            continue
+        if not isinstance(node.func, ast.Name) or node.func.id != "_activate_compat_module":
+            continue
+        for keyword in node.keywords:
+            if (
+                keyword.arg == "legacy_name"
+                and isinstance(keyword.value, ast.Constant)
+                and isinstance(keyword.value.value, str)
+            ):
+                return keyword.value.value
+    raise AssertionError(f"{path} does not declare legacy_name")
 
 
 def test_top_level_agilab_modules_are_classified_or_entrypoints():
@@ -41,6 +64,52 @@ def test_top_level_agilab_modules_are_classified_or_entrypoints():
         assert "activate_compat_module" in text
         assert "classified" in text
         assert "package layout" in text
+
+
+def test_top_level_agilab_shims_declare_exact_legacy_names() -> None:
+    root = Path(__file__).resolve().parents[1] / "src" / "agilab"
+
+    for path in sorted(root.glob("*.py")):
+        if path.name in ENTRYPOINT_FILES:
+            continue
+        assert _legacy_name_from_shim(path) == f"agilab.{path.stem}"
+
+
+def test_top_level_agilab_compat_modules_preserve_legacy_identity_for_import_safe_shims() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    root = repo_root / "src" / "agilab"
+    modules = [
+        f"agilab.{path.stem}"
+        for path in sorted(root.glob("*.py"))
+        if path.name not in ENTRYPOINT_FILES
+        and f"agilab.{path.stem}" not in TOP_LEVEL_COMPAT_IMPORT_EXEMPTIONS
+    ]
+    script = f"""
+import importlib
+
+modules = {modules!r}
+for name in modules:
+    module = importlib.import_module(name)
+    expected_package = name.rpartition(".")[0]
+    if module.__name__ != name or module.__package__ != expected_package:
+        raise AssertionError(
+            f"{{name}} exposed {{module.__name__}} / {{module.__package__}}"
+        )
+"""
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str((repo_root / "src").resolve())
+
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=repo_root,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
 
 
 def _assert_package_modules_are_classified(root: Path, package: str) -> None:

--- a/test/test_app_contract_matrix.py
+++ b/test/test_app_contract_matrix.py
@@ -32,6 +32,9 @@ def test_app_contract_matrix_passes_current_repo():
     assert "pytorch_playground_project:worker_pyproject" in check_ids
     assert "page_bundle_specs_point_to_source_bundles" in check_ids
     assert "page_bundle_pyprojects_match_package_contract" in check_ids
+    assert "app_packages_use_generated_payload_contract" in check_ids
+    assert "checked_in_app_payloads_match_generated_payloads" in check_ids
+    assert "apps_pages_root_keeps_asset_bundle_shape" in check_ids
     assert "apps_pages_catalog_matches_page_contract" in check_ids
     assert "agi_pages_provider_matches_page_bundle_contract" in check_ids
     assert "promoted_pypi_app_catalog_matches_package_split" in check_ids
@@ -153,6 +156,67 @@ def test_app_contract_matrix_detects_page_bundle_pyproject_drift():
     assert failed["page_bundle_pyprojects_match_package_contract"]["details"]["errors"][
         "agi-page-renamed-map"
     ]["name"] == "agi-page-geospatial-map"
+
+
+def test_app_contract_matrix_detects_checked_in_payload_drift(tmp_path: Path, monkeypatch):
+    module = _load_module()
+    package_root = tmp_path / "src/agilab/lib/agi-app-demo"
+    package_import_root = package_root / "src/agi_app_demo"
+    embedded_project = package_import_root / "project/demo_project"
+    embedded_project.mkdir(parents=True)
+    (embedded_project / "value.txt").write_text("old\n", encoding="utf-8")
+    (package_root / "setup.py").write_text(
+        "APP_PROJECT = 'demo_project'\nPACKAGE_IMPORT = 'agi_app_demo'\n",
+        encoding="utf-8",
+    )
+    (package_root / "pyproject.toml").write_text(
+        "\n".join(
+            [
+                "[project]",
+                'name = "agi-app-demo"',
+                'version = "1.0"',
+                "",
+                "[tool.setuptools.package-data]",
+                '"agi_app_demo" = ["project/**/*"]',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    class FakeBuildSupport:
+        @staticmethod
+        def app_project_specs():
+            return (
+                {
+                    "project": "demo_project",
+                    "distribution": "agi-app-demo",
+                    "package": "agi_app_demo",
+                },
+            )
+
+        @staticmethod
+        def copy_app_project_payload(project_name: str, target_root: Path):
+            generated_project = target_root / project_name
+            generated_project.mkdir(parents=True)
+            (generated_project / "value.txt").write_text("new\n", encoding="utf-8")
+            return []
+
+    def _fake_load_module(_repo_root: Path, relative_path: Path, _module_name: str):
+        if relative_path == module.APP_PROJECT_BUILD_SUPPORT_REL:
+            return FakeBuildSupport
+        raise AssertionError(relative_path)
+
+    monkeypatch.setattr(module, "_load_module", _fake_load_module)
+
+    contract_errors, drift_errors = module._app_payload_contract_errors(
+        tmp_path,
+        {"agi-app-demo": "src/agilab/lib/agi-app-demo"},
+        {"agi-app-demo": "demo_project"},
+    )
+
+    assert contract_errors == {}
+    assert drift_errors["agi-app-demo"]["changed"] == ["value.txt"]
 
 
 def test_app_contract_matrix_cli_writes_json_output(tmp_path: Path, capsys):

--- a/test/test_clean_local_artifacts.py
+++ b/test/test_clean_local_artifacts.py
@@ -50,3 +50,49 @@ def test_clean_stale_build_libs_reports_missing_trees(tmp_path: Path) -> None:
     results = clean_local_artifacts.clean_stale_build_libs(tmp_path, apply=True)
 
     assert [result.action for result in results] == ["missing", "missing"]
+
+
+def test_ignored_local_artifact_paths_stay_under_src_agilab(tmp_path: Path) -> None:
+    ignored_targets = [
+        tmp_path / "src/agilab/apps/builtin/demo_project/.venv",
+        tmp_path / "src/agilab/apps-pages/view_demo/__pycache__",
+        tmp_path / "src/agilab/lib/agi-demo/build",
+    ]
+    unsafe_target = tmp_path / "scratch/.venv"
+    for target in [*ignored_targets, unsafe_target]:
+        target.mkdir(parents=True)
+        (target / "artifact.txt").write_text("local\n", encoding="utf-8")
+
+    results = clean_local_artifacts.clean_ignored_local_artifacts(
+        tmp_path,
+        apply=False,
+        ignored_fn=lambda _root, _target: True,
+    )
+
+    assert [result.action for result in results] == ["would-remove"] * 3
+    assert [result.path for result in results] == [
+        "src/agilab/apps/builtin/demo_project/.venv",
+        "src/agilab/apps-pages/view_demo/__pycache__",
+        "src/agilab/lib/agi-demo/build",
+    ]
+    assert unsafe_target.exists()
+
+
+def test_clean_ignored_local_artifacts_apply_removes_only_safe_targets(tmp_path: Path) -> None:
+    target = tmp_path / "src/agilab/apps/builtin/demo_project/.pytest_cache"
+    target.mkdir(parents=True)
+    (target / "artifact.txt").write_text("local\n", encoding="utf-8")
+    outside = tmp_path / ".pytest_cache"
+    outside.mkdir()
+
+    results = clean_local_artifacts.clean_ignored_local_artifacts(
+        tmp_path,
+        apply=True,
+        ignored_fn=lambda _root, _target: True,
+    )
+
+    assert [result.path for result in results] == [
+        "src/agilab/apps/builtin/demo_project/.pytest_cache"
+    ]
+    assert not target.exists()
+    assert outside.exists()

--- a/test/test_pytorch_playground_app.py
+++ b/test/test_pytorch_playground_app.py
@@ -6,6 +6,7 @@ import hashlib
 import importlib
 import importlib.util
 import json
+import os
 from pathlib import Path
 import subprocess
 import sys
@@ -79,6 +80,33 @@ def _target_module_from_pytorch_shim(path: Path) -> str:
     raise AssertionError(f"{path} is missing _TARGET_MODULE")
 
 
+def _assert_pytorch_legacy_module_identity(package_src: Path, modules: list[str]) -> None:
+    script = f"""
+import importlib
+
+modules = {modules!r}
+for name in modules:
+    module = importlib.import_module(name)
+    expected_package = name.rpartition(".")[0]
+    if module.__name__ != name or module.__package__ != expected_package:
+        raise AssertionError(
+            f"{{name}} exposed {{module.__name__}} / {{module.__package__}}"
+        )
+"""
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(package_src.resolve())
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=Path.cwd(),
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
 def test_pytorch_playground_modules_are_classified_or_entrypoints():
     for package_root in (
         PROJECT_SRC / "pytorch_playground",
@@ -98,6 +126,13 @@ def test_pytorch_playground_modules_are_classified_or_entrypoints():
             assert "activate_compat_module" in source
             assert "classified" in source
             assert "package layout" in source
+
+        legacy_modules = [
+            f"pytorch_playground.{path.stem}"
+            for path in sorted(package_root.glob("*.py"))
+            if path.name != "__init__.py"
+        ]
+        _assert_pytorch_legacy_module_identity(package_root.parent, legacy_modules)
 
 
 def test_playground_ui_import_prefers_package_when_streamlit_puts_script_dir_first(monkeypatch):
@@ -129,7 +164,11 @@ def test_playground_ui_import_prefers_package_when_streamlit_puts_script_dir_fir
     try:
         spec.loader.exec_module(module)
         assert sys.path[0] == str(project_src)
-        assert module._playground_core.__name__ == "pytorch_playground.domain.core"
+        assert module._playground_core.__name__ == "pytorch_playground.core"
+        assert (
+            module._playground_core._COMPAT_TARGET_MODULE.__name__
+            == "pytorch_playground.domain.core"
+        )
     finally:
         sys.modules.pop(spec.name, None)
         for name in list(sys.modules):

--- a/test/test_tescia_diagnostic_project.py
+++ b/test/test_tescia_diagnostic_project.py
@@ -4,7 +4,9 @@ import ast
 import builtins
 import importlib
 import json
+import os
 import runpy
+import subprocess
 import sys
 from pathlib import Path
 import tomllib
@@ -187,6 +189,33 @@ def _target_module_from_tescia_shim(path: Path) -> str:
     raise AssertionError(f"{path} does not declare _TARGET_MODULE")
 
 
+def _assert_tescia_legacy_module_identity(package_src: Path, modules: list[str]) -> None:
+    script = f"""
+import importlib
+
+modules = {modules!r}
+for name in modules:
+    module = importlib.import_module(name)
+    expected_package = name.rpartition(".")[0]
+    if module.__name__ != name or module.__package__ != expected_package:
+        raise AssertionError(
+            f"{{name}} exposed {{module.__name__}} / {{module.__package__}}"
+        )
+"""
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(package_src.resolve())
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=Path.cwd(),
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
 def test_tescia_diagnostic_modules_are_classified_or_entrypoints() -> None:
     package_root = APP_SRC / "tescia_diagnostic"
     direct_modules = sorted(package_root.glob("*.py"))
@@ -204,6 +233,13 @@ def test_tescia_diagnostic_modules_are_classified_or_entrypoints() -> None:
         assert "activate_compat_module" in text
         assert "classified" in text
         assert "package layout" in text
+
+    legacy_modules = [
+        f"tescia_diagnostic.{path.stem}"
+        for path in direct_modules
+        if path.name != "__init__.py"
+    ]
+    _assert_tescia_legacy_module_identity(package_root.parent, legacy_modules)
 
 
 def test_tescia_classified_modules_keep_bundled_resource_paths(monkeypatch) -> None:

--- a/tools/app_contract_matrix.py
+++ b/tools/app_contract_matrix.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import re
 import subprocess
 import sys
+import tempfile
 import tomllib
 from typing import Any, Mapping, Sequence
 
@@ -25,6 +26,7 @@ PUBLIC_APP_CATALOG_REL = Path("docs/source/public-app-catalog.rst")
 APPS_PAGES_CATALOG_REL = Path("docs/source/apps-pages.rst")
 AGI_APPS_CATALOG_REL = Path("src/agilab/lib/agi-apps/src/agi_apps/catalog.json")
 AGI_PAGES_PROVIDER_REL = Path("src/agilab/lib/agi-pages/src/agi_pages/__init__.py")
+APP_PROJECT_BUILD_SUPPORT_REL = Path("src/agilab/lib/app_project_build_support.py")
 REDUCER_EXEMPT_PROJECTS = frozenset({"minimal_app_project", "multi_app_dag_project"})
 OPTIONAL_LAB_STAGES_EXEMPT_PROJECTS = frozenset(
     {
@@ -35,6 +37,23 @@ OPTIONAL_LAB_STAGES_EXEMPT_PROJECTS = frozenset(
         "pytorch_playground_project",
     }
 )
+PAYLOAD_EXCLUDED_DIRS = frozenset(
+    {
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".venv",
+        "__pycache__",
+        "Modules",
+        "agilab",
+        "build",
+        "dist",
+        "notebooks",
+        "test",
+    }
+)
+PAYLOAD_EXCLUDED_FILES = frozenset({".DS_Store", ".gitignore", ".lock", "uv.lock"})
+PAYLOAD_EXCLUDED_SUFFIXES = frozenset({".c", ".pid", ".pyc", ".pyo", ".pyx", ".so"})
 
 
 @dataclass(frozen=True)
@@ -125,6 +144,180 @@ def _has_dependency(dependencies: Sequence[str], package: str) -> bool:
     return any(pattern.match(item.strip()) for item in dependencies)
 
 
+def _literal_string_assignments(path: Path, names: set[str]) -> dict[str, str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    values: dict[str, str] = {}
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not isinstance(node.value, ast.Constant) or not isinstance(node.value.value, str):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id in names:
+                values[target.id] = node.value.value
+    return values
+
+
+def _payload_package_data(pyproject: Mapping[str, Any], package_import: str) -> tuple[str, ...]:
+    tool = pyproject.get("tool", {})
+    setuptools = tool.get("setuptools", {}) if isinstance(tool, dict) else {}
+    package_data = (
+        setuptools.get("package-data", {})
+        if isinstance(setuptools, dict)
+        else {}
+    )
+    raw = package_data.get(package_import, ()) if isinstance(package_data, dict) else ()
+    if not isinstance(raw, list):
+        return ()
+    return tuple(str(item) for item in raw)
+
+
+def _payload_file_index(root: Path) -> dict[str, bytes]:
+    """Return comparable generated-payload files below ``root``."""
+
+    if not root.is_dir():
+        return {}
+
+    files: dict[str, bytes] = {}
+    for path in sorted(root.rglob("*")):
+        relative = path.relative_to(root)
+        if any(part in PAYLOAD_EXCLUDED_DIRS or part.endswith(".egg-info") for part in relative.parts):
+            continue
+        if not path.is_file():
+            continue
+        if path.name in PAYLOAD_EXCLUDED_FILES or path.suffix in PAYLOAD_EXCLUDED_SUFFIXES:
+            continue
+        files[relative.as_posix()] = path.read_bytes()
+    return files
+
+
+def _generated_app_payload_index(build_support: Any, project_name: str) -> dict[str, bytes]:
+    with tempfile.TemporaryDirectory(prefix="agilab-app-payload-") as tmp_dir:
+        target_root = Path(tmp_dir) / "project"
+        build_support.copy_app_project_payload(project_name, target_root)
+        return _payload_file_index(target_root / project_name)
+
+
+def _app_payload_contract_errors(
+    repo_root: Path,
+    package_specs: Mapping[str, str],
+    package_to_project: Mapping[str, str],
+) -> tuple[dict[str, dict[str, Any]], dict[str, dict[str, Any]]]:
+    """Return generated-payload hook errors and checked-in payload drift."""
+
+    try:
+        build_support = _load_module(
+            repo_root,
+            APP_PROJECT_BUILD_SUPPORT_REL,
+            "agilab_app_contract_build_support",
+        )
+        raw_specs = build_support.app_project_specs()
+        build_support_error = ""
+    except Exception as exc:
+        build_support = None
+        raw_specs = ()
+        build_support_error = str(exc)
+
+    build_specs = {
+        str(spec.get("distribution")): {
+            "project": str(spec.get("project")),
+            "package": str(spec.get("package")),
+        }
+        for spec in raw_specs
+        if isinstance(spec, dict)
+    }
+    contract_errors: dict[str, dict[str, Any]] = {}
+    drift_errors: dict[str, dict[str, Any]] = {}
+
+    if build_support_error:
+        return (
+            {
+                "*": {
+                    "build_support": str(APP_PROJECT_BUILD_SUPPORT_REL),
+                    "error": build_support_error,
+                }
+            },
+            {},
+        )
+
+    for package, package_path in sorted(package_specs.items()):
+        expected_project = package_to_project.get(package, "")
+        build_spec = build_specs.get(package)
+        package_root = repo_root / package_path
+        setup_py = package_root / "setup.py"
+        pyproject_path = package_root / "pyproject.toml"
+        package_import = build_spec.get("package", "") if build_spec else ""
+        errors: dict[str, Any] = {}
+
+        if build_spec is None:
+            errors["missing_build_support_spec"] = True
+        elif build_spec.get("project") != expected_project:
+            errors["build_support_project"] = build_spec.get("project")
+            errors["expected_project"] = expected_project
+
+        try:
+            setup_values = _literal_string_assignments(setup_py, {"APP_PROJECT", "PACKAGE_IMPORT"})
+        except Exception as exc:
+            setup_values = {}
+            errors["setup_py_error"] = str(exc)
+        if setup_values.get("APP_PROJECT") != expected_project:
+            errors["setup_app_project"] = setup_values.get("APP_PROJECT")
+        if package_import and setup_values.get("PACKAGE_IMPORT") != package_import:
+            errors["setup_package_import"] = setup_values.get("PACKAGE_IMPORT")
+            errors["expected_package_import"] = package_import
+
+        try:
+            pyproject = _read_toml(pyproject_path)
+            package_data = _payload_package_data(pyproject, package_import)
+        except Exception as exc:
+            package_data = ()
+            errors["pyproject_error"] = str(exc)
+        if "project/**/*" not in package_data:
+            errors["package_data"] = list(package_data)
+            errors["expected_package_data"] = "project/**/*"
+
+        if errors:
+            contract_errors[package] = {
+                "package_path": package_path,
+                "project": expected_project,
+                **errors,
+            }
+
+        if not build_support or not package_import or not expected_project:
+            continue
+        embedded_payload = package_root / "src" / package_import / "project" / expected_project
+        if not embedded_payload.exists():
+            continue
+        generated_files = _generated_app_payload_index(build_support, expected_project)
+        embedded_files = _payload_file_index(embedded_payload)
+        missing = sorted(set(generated_files) - set(embedded_files))
+        extra = sorted(set(embedded_files) - set(generated_files))
+        changed = sorted(
+            path
+            for path in set(generated_files) & set(embedded_files)
+            if generated_files[path] != embedded_files[path]
+        )
+        if missing or extra or changed:
+            drift_errors[package] = {
+                "embedded_payload": _relative(repo_root, embedded_payload),
+                "missing_from_embedded": missing,
+                "extra_in_embedded": extra,
+                "changed": changed,
+            }
+
+    missing_build_specs = sorted(set(package_specs) - set(build_specs))
+    extra_build_specs = sorted(set(build_specs) - set(package_specs))
+    if missing_build_specs or extra_build_specs:
+        contract_errors.setdefault(
+            "*",
+            {
+                "missing_build_support_distributions": missing_build_specs,
+                "extra_build_support_distributions": extra_build_specs,
+            },
+        )
+    return contract_errors, drift_errors
+
+
 def _tracked_builtin_project_names(repo_root: Path) -> set[str] | None:
     """Return tracked built-in project directory names for git checkouts."""
     try:
@@ -165,6 +358,45 @@ def _tracked_builtin_project_names(repo_root: Path) -> set[str] | None:
         if project_name.endswith("_project"):
             names.add(project_name)
     return names
+
+
+def _tracked_children(repo_root: Path, root_rel: Path) -> set[str] | None:
+    """Return tracked direct children below ``root_rel`` for git checkouts."""
+
+    try:
+        result = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(repo_root),
+                "ls-files",
+                "-z",
+                "--",
+                str(root_rel),
+            ],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+    except (OSError, ValueError):
+        return None
+    if result.returncode != 0:
+        return None
+
+    children: set[str] = set()
+    prefix = root_rel.as_posix()
+    for item in result.stdout.split("\0"):
+        if not item:
+            continue
+        path = Path(item)
+        try:
+            rel = path.relative_to(prefix)
+        except ValueError:
+            continue
+        if rel.parts:
+            children.add(rel.parts[0])
+    return children
 
 
 def discover_builtin_projects(repo_root: Path) -> tuple[Path, ...]:
@@ -614,10 +846,71 @@ def _global_checks(
             details={"errors": package_mapping_errors, "package_to_project": package_to_project},
         )
     ]
+    payload_contract_errors, payload_drift_errors = _app_payload_contract_errors(
+        repo_root,
+        package_specs,
+        package_to_project,
+    )
+    checks.append(
+        _check(
+            "app_packages_use_generated_payload_contract",
+            "App packages use generated built-in payload contract",
+            not payload_contract_errors,
+            "app package setup hooks and package-data declarations generate payloads from built-in app sources",
+            evidence=(
+                str(APP_PROJECT_BUILD_SUPPORT_REL),
+                "tools/package_split_contract.py",
+                "src/agilab/lib/agi-app-*/setup.py",
+            ),
+            details={"errors": payload_contract_errors},
+        )
+    )
+    checks.append(
+        _check(
+            "checked_in_app_payloads_match_generated_payloads",
+            "Checked-in app payloads match generated payloads",
+            not payload_drift_errors,
+            "any checked-in embedded app payloads match the generated built-in source payload",
+            evidence=(str(APP_PROJECT_BUILD_SUPPORT_REL), "src/agilab/lib/agi-app-*"),
+            details={"errors": payload_drift_errors},
+        )
+    )
 
     page_package_to_module = {
         package: Path(page_path).name for package, page_path in sorted(page_package_specs.items())
     }
+    tracked_page_children = _tracked_children(repo_root, APPS_PAGES_REL)
+    if tracked_page_children is None:
+        tracked_page_children = {
+            path.name
+            for path in (repo_root / APPS_PAGES_REL).iterdir()
+            if path.is_file() or path.is_dir()
+        }
+    allowed_page_root_files = {"README.md", ".gitignore", "__init__.py"}
+    allowed_page_root_dirs = {"templates"}
+    invalid_page_children = sorted(
+        child
+        for child in tracked_page_children
+        if child not in allowed_page_root_files
+        and child not in allowed_page_root_dirs
+        and not child.startswith("view_")
+    )
+    unexpected_root_python = sorted(
+        child for child in tracked_page_children if child.endswith(".py") and child != "__init__.py"
+    )
+    checks.append(
+        _check(
+            "apps_pages_root_keeps_asset_bundle_shape",
+            "Apps-pages root keeps asset-bundle shape",
+            not invalid_page_children and not unexpected_root_python,
+            "apps-pages root only carries the provider, docs, templates, and view_* bundle projects",
+            evidence=(str(APPS_PAGES_REL), "tools/package_split_contract.py"),
+            details={
+                "invalid_children": invalid_page_children,
+                "unexpected_root_python": unexpected_root_python,
+            },
+        )
+    )
     page_mapping_errors = {
         package: {
             "package_path": page_package_specs[package],

--- a/tools/clean_local_artifacts.py
+++ b/tools/clean_local_artifacts.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import shutil
 import subprocess
-import sys
 from pathlib import Path
 from typing import NamedTuple, Sequence
 
@@ -16,6 +16,17 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 STALE_BUILD_LIB_DIRS = (
     Path("src/agilab/core/agi-env/build/lib"),
     Path("src/agilab/core/agi-node/build/lib"),
+)
+LOCAL_ARTIFACT_DIR_NAMES = frozenset(
+    {
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".venv",
+        "__pycache__",
+        "build",
+        "dist",
+    }
 )
 
 
@@ -44,7 +55,7 @@ def stale_build_lib_paths(root: Path) -> list[Path]:
     return [root / rel for rel in STALE_BUILD_LIB_DIRS]
 
 
-def _is_safe_clean_target(root: Path, target: Path) -> bool:
+def _is_safe_build_lib_target(root: Path, target: Path) -> bool:
     resolved_root = root.resolve()
     resolved_target = target.resolve(strict=False)
     try:
@@ -52,6 +63,46 @@ def _is_safe_clean_target(root: Path, target: Path) -> bool:
     except ValueError:
         return False
     return resolved_target.name == "lib" and resolved_target.parent.name == "build"
+
+
+def _is_safe_local_artifact_target(root: Path, target: Path) -> bool:
+    resolved_root = root.resolve()
+    resolved_target = target.resolve(strict=False)
+    try:
+        relative = resolved_target.relative_to(resolved_root)
+    except ValueError:
+        return False
+    return len(relative.parts) >= 3 and relative.parts[:2] == ("src", "agilab") and target.name in LOCAL_ARTIFACT_DIR_NAMES
+
+
+def _is_git_ignored(root: Path, target: Path) -> bool:
+    completed = subprocess.run(
+        ["git", "-C", str(root), "check-ignore", "-q", "--", str(target)],
+        check=False,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    return completed.returncode == 0
+
+
+def ignored_local_artifact_paths(root: Path, *, ignored_fn=_is_git_ignored) -> list[Path]:
+    """Return ignored local artifact directories below ``src/agilab``."""
+
+    source_root = root / "src" / "agilab"
+    if not source_root.is_dir():
+        return []
+
+    targets: list[Path] = []
+    for current, dirnames, _filenames in os.walk(source_root):
+        current_path = Path(current)
+        for dirname in list(dirnames):
+            candidate = current_path / dirname
+            if dirname not in LOCAL_ARTIFACT_DIR_NAMES:
+                continue
+            dirnames.remove(dirname)
+            if _is_safe_local_artifact_target(root, candidate) and ignored_fn(root, candidate):
+                targets.append(candidate)
+    return sorted(targets)
 
 
 def clean_stale_build_libs(root: Path, *, apply: bool = False) -> list[CleanResult]:
@@ -64,7 +115,7 @@ def clean_stale_build_libs(root: Path, *, apply: bool = False) -> list[CleanResu
         if not exists:
             results.append(CleanResult(path=rel, action="missing", exists=False))
             continue
-        if not _is_safe_clean_target(root, target):
+        if not _is_safe_build_lib_target(root, target):
             raise RuntimeError(f"Refusing unsafe clean target: {target}")
         if apply:
             shutil.rmtree(target)
@@ -72,6 +123,34 @@ def clean_stale_build_libs(root: Path, *, apply: bool = False) -> list[CleanResu
         else:
             results.append(CleanResult(path=rel, action="would-remove", exists=True))
     return results
+
+
+def clean_ignored_local_artifacts(root: Path, *, apply: bool = False, ignored_fn=_is_git_ignored) -> list[CleanResult]:
+    """Dry-run or remove ignored local artifact directories below ``src/agilab``."""
+
+    results: list[CleanResult] = []
+    for target in ignored_local_artifact_paths(root, ignored_fn=ignored_fn):
+        rel = target.relative_to(root).as_posix()
+        if not _is_safe_local_artifact_target(root, target):
+            raise RuntimeError(f"Refusing unsafe clean target: {target}")
+        if apply:
+            shutil.rmtree(target)
+            results.append(CleanResult(path=rel, action="removed", exists=True))
+        else:
+            results.append(CleanResult(path=rel, action="would-remove", exists=True))
+    return results
+
+
+def clean_local_artifacts(root: Path, *, apply: bool = False) -> list[CleanResult]:
+    """Dry-run or remove known ignored local artifacts."""
+
+    by_path: dict[str, CleanResult] = {}
+    for result in [*clean_stale_build_libs(root, apply=apply), *clean_ignored_local_artifacts(root, apply=apply)]:
+        if result.action == "missing":
+            by_path.setdefault(result.path, result)
+            continue
+        by_path[result.path] = result
+    return [by_path[path] for path in sorted(by_path)]
 
 
 def _print_human(results: Sequence[CleanResult], *, apply: bool) -> None:
@@ -100,7 +179,7 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     root = repo_root(args.repo)
-    results = clean_stale_build_libs(root, apply=bool(args.apply))
+    results = clean_local_artifacts(root, apply=bool(args.apply))
 
     if args.json:
         payload = {


### PR DESCRIPTION
## Summary
- Preserve legacy module identity in app compatibility shims and add runtime/static shim regressions.
- Add generated app payload contract checks and sync checked-in embedded payloads from built-in app sources.
- Extend local artifact cleaning, update AGENTS/runbook wording, and add testing-skill guidance so source-tree reorg drift is caught before release.

## Validation
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' --import-mode=importlib test/test_pyproject_dependency_hygiene.py test/test_notebook_export_docs.py src/agilab/core/agi-env/test/test_app_settings_support.py test/test_pipeline_lab.py test/test_agilab_module_layout.py test/test_app_contract_matrix.py test/test_clean_local_artifacts.py test/test_pytorch_playground_app.py test/test_tescia_diagnostic_project.py
- uv --preview-features extra-build-dependencies run --extra dev ruff check ...
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile skills
- uv --preview-features extra-build-dependencies run python tools/app_contract_matrix.py --compact
- python3 tools/agent_instruction_contract.py --check
- explicit staged scope allow-list passed for this cross-cutting guardrail change