### PR TITLE
[codex] Prepare AGILAB 2026.06.02.post1 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.02"
+version = "2026.06.02.post1"
 name = "agilab"
 description = "AGILAB is a reproducible AI/ML workbench for engineering teams."
 requires-python = ">=3.11,<3.14"
@@ -60,14 +60,14 @@ agilab-mcp = "agilab_mcp.server:main"
 
 [project.optional-dependencies]
 ai = ["openai>=2.32.0,<3"]
-core = ["agi-core==2026.06.02"]
-ui = ["agi-apps==2026.06.02", "agi-pages==2026.06.02", "agi-gui==2026.06.02", "agi-web==2026.06.01", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "streamlit>=1.58,<2", "tomli_w>=1.2.0,<2"]
+core = ["agi-core==2026.06.02.post1"]
+ui = ["agi-apps==2026.06.02.post1", "agi-pages==2026.06.02.post1", "agi-gui==2026.06.02.post1", "agi-web==2026.06.01", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "streamlit>=1.58,<2", "tomli_w>=1.2.0,<2"]
 viz = ["matplotlib>=3.10.0,<4", "plotly>=6.7.0,<7"]
 mlflow = ["mlflow>=3.11.1,<4", "idna>=3.15,<4", "starlette>=0.40.0,<0.51.0"]
 bridges = ["duckdb>=1.4.0,<2"]
 notebook = ["ipykernel>=6.29.0,<8", "nbclient>=0.10.0,<1", "nbformat>=5.10.0,<6"]
-examples = ["agi-apps==2026.06.02", "jupyterlab>=4.4.0,<5", "matplotlib>=3.10.0,<4", "plotly>=6.7.0,<7"]
-pages = ["agi-pages==2026.06.02"]
+examples = ["agi-apps==2026.06.02.post1", "jupyterlab>=4.4.0,<5", "matplotlib>=3.10.0,<4", "plotly>=6.7.0,<7"]
+pages = ["agi-pages==2026.06.02.post1"]
 proof = ["cryptography>=46.0.0,<49"]
 agents = ["openai>=2.32.0,<3"]
 local-llm = ["accelerate>=0.34.2,<2; python_version >= '3.12'", "fastapi>=0.124.4,!=0.136.3,<1; python_version >= '3.12'", "gpt-oss>=0.0.8,<0.1; python_version >= '3.12'", "langchain-core>=1.3.3,<2; python_version >= '3.12'", "langsmith>=0.8.0,<1; python_version >= '3.12'", "mlx>=0.31.2,<0.32; sys_platform == 'darwin' and platform_machine == 'arm64'", "mlx-lm>=0.31.3,<0.32; sys_platform == 'darwin' and platform_machine == 'arm64'", "mlx-vlm>=0.5.0,<0.6; sys_platform == 'darwin' and platform_machine == 'arm64'", "requests>=2.32.0,<3; python_version >= '3.12'", "torch>=2.8.0,<3; python_version >= '3.12'", "transformers>=4.57.0,<6; python_version >= '3.12'", "universal-offline-ai-chatbot>=0.1.0,<0.2; python_version >= '3.12'"]

--- a/src/agilab/apps-pages/view_release_decision/pyproject.toml
+++ b/src/agilab/apps-pages/view_release_decision/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-promotion-gate"
-version = "2026.05.31"
+version = "2026.06.02.post1"
 description = "AGILAB page bundle for evidence-cockpit run review and promotion gates."
 readme = { text = "AGILAB page bundle for evidence-cockpit run review and promotion gates.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/core/agi-cluster/pyproject.toml
+++ b/src/agilab/core/agi-cluster/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.02"
+version = "2026.06.02.post1"
 name = "agi-cluster"
 description = "Distributed cluster orchestration layer for AGILAB workers over local and SSH backends"
 requires-python = ">=3.11"
@@ -35,7 +35,7 @@ keywords = [
     "job-scheduling",
     "mlops",
 ]
-dependencies = ["agi-env==2026.06.02", "agi-node==2026.06.02", "asyncssh>=2.23,<3", "dask[distributed]>=2026.3,<2027.0", "humanize>=4.10,<5", "numpy>=2.2,<3", "packaging>=25,<27", "polars>=1.35,<2", "psutil>=7,<8", "scikit-learn>=1.7.2,<2", "tomlkit>=0.13,<1"]
+dependencies = ["agi-env==2026.06.02.post1", "agi-node==2026.06.02.post1", "asyncssh>=2.23,<3", "dask[distributed]>=2026.3,<2027.0", "humanize>=4.10,<5", "numpy>=2.2,<3", "packaging>=25,<27", "polars>=1.35,<2", "psutil>=7,<8", "scikit-learn>=1.7.2,<2", "tomlkit>=0.13,<1"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/core/agi-core/pyproject.toml
+++ b/src/agilab/core/agi-core/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.02"
+version = "2026.06.02.post1"
 name = "agi-core"
 description = "Meta-package that installs and wires agi-env, agi-node, and agi-cluster together"
 readme = "README.md"
@@ -30,7 +30,7 @@ keywords = [
   "distributed-computing",
   "distributed-execution",
 ]
-dependencies = ["agi-env==2026.06.02", "agi-node==2026.06.02", "agi-cluster==2026.06.02"]
+dependencies = ["agi-env==2026.06.02.post1", "agi-node==2026.06.02.post1", "agi-cluster==2026.06.02.post1"]
 
 [project.urls]
 Homepage = "https://github.com/ThalesGroup/agilab"

--- a/src/agilab/core/agi-env/pyproject.toml
+++ b/src/agilab/core/agi-env/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.02"
+version = "2026.06.02.post1"
 name = "agi-env"
 description = "Environment bootstrap package for AGILAB with virtualenv, path, and runtime helpers"
 requires-python = ">=3.11"

--- a/src/agilab/core/agi-node/pyproject.toml
+++ b/src/agilab/core/agi-node/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.02"
+version = "2026.06.02.post1"
 name = "agi-node"
 description = "Distributed worker orchestration and execution support library for AGILAB"
 requires-python = ">=3.11"
@@ -35,7 +35,7 @@ keywords = [
     "pandas",
     "polars",
 ]
-dependencies = ["agi-env==2026.06.02", "cython>=3.1,<4", "humanize>=4.10,<5", "numpy>=2.2,<3", "pandas>=2.3,<4", "parso>=0.8,<1", "polars>=1.35,<2", "psutil>=7,<8", "py7zr>=1.1,<1.2", "setuptools>=68,<83"]
+dependencies = ["agi-env==2026.06.02.post1", "cython>=3.1,<4", "humanize>=4.10,<5", "numpy>=2.2,<3", "pandas>=2.3,<4", "parso>=0.8,<1", "polars>=1.35,<2", "psutil>=7,<8", "py7zr>=1.1,<1.2", "setuptools>=68,<83"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/lib/agi-app-flight-telemetry/pyproject.toml
+++ b/src/agilab/lib/agi-app-flight-telemetry/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.01"
+version = "2026.06.02.post1"
 name = "agi-app-flight-telemetry"
 description = "AGILAB flight-telemetry ingestion demo with reusable dataframe and map-analysis outputs"
 requires-python = ">=3.11"

--- a/src/agilab/lib/agi-app-mission-decision/pyproject.toml
+++ b/src/agilab/lib/agi-app-mission-decision/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.01"
+version = "2026.06.02.post1"
 name = "agi-app-mission-decision"
 description = "Deterministic AGILAB mission-decision workflow with scenario scoring and evidence artifacts"
 requires-python = ">=3.11"

--- a/src/agilab/lib/agi-app-pytorch-playground/pyproject.toml
+++ b/src/agilab/lib/agi-app-pytorch-playground/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.01"
+version = "2026.06.02.post1"
 name = "agi-app-pytorch-playground"
 description = "AGILAB PyTorch playground app for reproducible neural-network experiments"
 requires-python = ">=3.12"

--- a/src/agilab/lib/agi-app-uav-relay-queue/pyproject.toml
+++ b/src/agilab/lib/agi-app-uav-relay-queue/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.01"
+version = "2026.06.02.post1"
 name = "agi-app-uav-relay-queue"
 description = "AGILAB UAV relay queue simulation demo with routing, delay, and resilience artifacts"
 requires-python = ">=3.13"

--- a/src/agilab/lib/agi-app-weather-forecast/pyproject.toml
+++ b/src/agilab/lib/agi-app-weather-forecast/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.01"
+version = "2026.06.02.post1"
 name = "agi-app-weather-forecast"
 description = "AGILAB weather-forecast notebook-migration demo with forecast analysis artifacts"
 requires-python = ">=3.11"

--- a/src/agilab/lib/agi-apps/pyproject.toml
+++ b/src/agilab/lib/agi-apps/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.02"
+version = "2026.06.02.post1"
 name = "agi-apps"
 description = "AGILAB public app package umbrella and example assets"
 requires-python = ">=3.11"
@@ -31,7 +31,7 @@ keywords = [
     "workflow-orchestration",
 ]
 
-dependencies = ["agi-core==2026.06.02", "agi-app-mission-decision==2026.06.01", "agi-app-pandas-execution==2026.05.31", "agi-app-polars-execution==2026.05.31", "agi-app-flight-telemetry==2026.06.01", "agi-app-multi-dag==2026.05.31", "agi-app-weather-forecast==2026.06.01", "agi-app-sklearn-pipeline==2026.05.31", "agi-app-pytorch-playground==2026.06.01; python_version >= '3.12'", "agi-app-tescia-diagnostic==2026.05.31; python_version >= '3.13'", "agi-app-uav-relay-queue==2026.06.01; python_version >= '3.13'"]
+dependencies = ["agi-core==2026.06.02.post1", "agi-app-mission-decision==2026.06.02.post1", "agi-app-pandas-execution==2026.05.31", "agi-app-polars-execution==2026.05.31", "agi-app-flight-telemetry==2026.06.02.post1", "agi-app-multi-dag==2026.05.31", "agi-app-weather-forecast==2026.06.02.post1", "agi-app-sklearn-pipeline==2026.05.31", "agi-app-pytorch-playground==2026.06.02.post1; python_version >= '3.12'", "agi-app-tescia-diagnostic==2026.05.31; python_version >= '3.13'", "agi-app-uav-relay-queue==2026.06.02.post1; python_version >= '3.13'"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/lib/agi-gui/pyproject.toml
+++ b/src/agilab/lib/agi-gui/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.02"
+version = "2026.06.02.post1"
 name = "agi-gui"
 description = "AGILAB Streamlit UI dependency bundle and compatibility imports"
 requires-python = ">=3.11"
@@ -32,7 +32,7 @@ keywords = [
     "python",
 ]
 
-dependencies = ["agi-env==2026.06.02", "streamlit>=1.58,<2", "streamlit_code_editor>=0.1.22,<0.2", "watchdog>=6,<7"]
+dependencies = ["agi-env==2026.06.02.post1", "streamlit>=1.58,<2", "streamlit_code_editor>=0.1.22,<0.2", "watchdog>=6,<7"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/lib/agi-pages/pyproject.toml
+++ b/src/agilab/lib/agi-pages/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.02"
+version = "2026.06.02.post1"
 name = "agi-pages"
 description = "AGILAB public analysis page umbrella and provider package"
 requires-python = ">=3.11"
@@ -34,7 +34,7 @@ keywords = [
     "page-bundles",
 ]
 
-dependencies = ["agi-gui==2026.06.02"]
+dependencies = ["agi-gui==2026.06.02.post1"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"


### PR DESCRIPTION
## Summary
- Bump only the optimized impact closure for the v2026.06.02 delta to 2026.06.02.post1.
- Update exact internal pins for impacted packages and exact-pin dependents.
- Leave unchanged public packages at their existing versions so the release workflow publishes only the needed package set.

## Release plan
- Dispatch pypi-publish.yaml manually after merge.
- Inputs: release_tag=v2026.06.02-2, impact_base_ref=v2026.06.02, allow_post_release=true.
- Reason: critical same-day release hardening for install/runtime guardrail fixes and package payload drift after v2026.06.02.

## Validation
- release plan with --impact-base-ref v2026.06.02 --skip-existing-pypi selects 14 packages.
- post-release cadence policy passed with explicit allow-post-release reason.
- PyPI project preflight passed: 14 to publish, 0 blockers.
- agi-env tests passed: 723 passed.
- shared-core tests passed with importlib mode: 1023 passed, 2 skipped.
- dependency/page tests passed: 31 passed.
- agi-gui parity passed: 3382 tests across chunks.
- dependency-policy, shared-core-typing, and docs parity passed.
- top-level wheel build/metadata check confirmed .post1 internal pins.
