### PR TITLE
Fix fresh-clone worker runtime release proof

### DIFF
--- a/src/agilab/apps/builtin/data_quality_gate_project/src/data_quality_gate_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/data_quality_gate_project/src/data_quality_gate_worker/pyproject.toml
@@ -3,11 +3,12 @@ name = "data_quality_gate_project"
 version = "2026.05.30.post1"
 description = "Worker package for the AGILAB data quality gate app"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }
 agi-node = { path = "../../../../../core/agi-node", editable = true }
+agi-cluster = { path = "../../../../../core/agi-cluster", editable = true }
 
 [build-system]
 requires = ["setuptools"]

--- a/src/agilab/apps/builtin/execution_pandas_project/src/execution_pandas_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/execution_pandas_project/src/execution_pandas_worker/pyproject.toml
@@ -3,11 +3,12 @@ name = "execution_pandas_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILab execution playground using PandasWorker"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "numpy>=2.2,<3", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "numpy>=2.2,<3", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }
 agi-node = { path = "../../../../../core/agi-node", editable = true }
+agi-cluster = { path = "../../../../../core/agi-cluster", editable = true }
 
 [build-system]
 requires = ["setuptools", "cython"]

--- a/src/agilab/apps/builtin/execution_polars_project/src/execution_polars_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/execution_polars_project/src/execution_polars_worker/pyproject.toml
@@ -3,11 +3,12 @@ name = "execution_polars_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILab execution playground using PolarsWorker"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "polars>=1.35,<2", "pydantic>=2.11,<2.13"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "polars>=1.35,<2", "pydantic>=2.11,<2.13"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }
 agi-node = { path = "../../../../../core/agi-node", editable = true }
+agi-cluster = { path = "../../../../../core/agi-cluster", editable = true }
 
 [build-system]
 requires = ["setuptools"]

--- a/src/agilab/apps/builtin/flight_telemetry_project/src/flight_telemetry_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/flight_telemetry_project/src/flight_telemetry_worker/pyproject.toml
@@ -4,7 +4,7 @@ version = "2026.05.30.post1"
 description = ""
 requires-python = ">=3.11,<3.14"
 readme = "README.md"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "polars>=1.35,<2", "pydantic>=2.11,<2.13"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "polars>=1.35,<2", "pydantic>=2.11,<2.13"]
 
 [[project.authors]]
 name = "Jean-Pierre Morard"
@@ -37,6 +37,7 @@ polars-worker = []
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }
 agi-node = { path = "../../../../../core/agi-node", editable = true }
+agi-cluster = { path = "../../../../../core/agi-cluster", editable = true }
 
 [build-system]
 requires = ["setuptools", "cython"]

--- a/src/agilab/apps/builtin/minimal_app_project/src/minimal_app_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/minimal_app_project/src/minimal_app_worker/pyproject.toml
@@ -3,11 +3,12 @@ name = "minimal_app_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILab example app template (minimal manager + worker)"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "polars>=1.35,<2", "pydantic>=2.11,<2.13"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "polars>=1.35,<2", "pydantic>=2.11,<2.13"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }
 agi-node = { path = "../../../../../core/agi-node", editable = true }
+agi-cluster = { path = "../../../../../core/agi-cluster", editable = true }
 
 [build-system]
 requires = ["setuptools"]

--- a/src/agilab/apps/builtin/mission_decision_project/src/mission_decision_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/mission_decision_project/src/mission_decision_worker/pyproject.toml
@@ -3,11 +3,12 @@ name = "mission_decision_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILAB Mission Decision autonomous demo"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }
 agi-node = { path = "../../../../../core/agi-node", editable = true }
+agi-cluster = { path = "../../../../../core/agi-cluster", editable = true }
 
 [tool.setuptools.package-data]
 mission_decision = ["sample_data/*.json"]

--- a/src/agilab/apps/builtin/multi_app_dag_project/src/multi_app_dag_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/multi_app_dag_project/src/multi_app_dag_worker/pyproject.toml
@@ -2,11 +2,12 @@
 name = "multi_app_dag_worker"
 version = "2026.05.30.post1"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "polars>=1.35,<2"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "polars>=1.35,<2"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }
 agi-node = { path = "../../../../../core/agi-node", editable = true }
+agi-cluster = { path = "../../../../../core/agi-cluster", editable = true }
 
 [build-system]
 requires = ["setuptools", "cython"]

--- a/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground_worker/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = ">=3.12"
 dependencies = [
     "agi-env>=2026.05.31",
     "agi-node>=2026.05.31",
+    "agi-cluster>=2026.05.31",
     "numpy>=2.2,<3",
     "pandas>=2.3.0,<4",
     "pydantic>=2.11,<2.13",
@@ -15,6 +16,7 @@ dependencies = [
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }
 agi-node = { path = "../../../../../core/agi-node", editable = true }
+agi-cluster = { path = "../../../../../core/agi-cluster", editable = true }
 
 [build-system]
 requires = ["setuptools"]

--- a/src/agilab/apps/builtin/r_runtime_bridge_project/src/r_runtime_bridge_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/r_runtime_bridge_project/src/r_runtime_bridge_worker/pyproject.toml
@@ -3,11 +3,12 @@ name = "r_runtime_bridge_project"
 version = "2026.05.30.post1"
 description = "Worker package for the AGILAB R runtime bridge app"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }
 agi-node = { path = "../../../../../core/agi-node", editable = true }
+agi-cluster = { path = "../../../../../core/agi-cluster", editable = true }
 
 [build-system]
 requires = ["setuptools"]

--- a/src/agilab/apps/builtin/sklearn_pipeline_project/src/sklearn_pipeline_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/sklearn_pipeline_project/src/sklearn_pipeline_worker/pyproject.toml
@@ -3,11 +3,12 @@ name = "sklearn_pipeline_worker"
 version = "2026.05.30.post1"
 description = "Worker package for the AGILAB scikit-learn pipeline app"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "joblib>=1.5,<2", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "scikit-learn>=1.7.2,<2"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "joblib>=1.5,<2", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "scikit-learn>=1.7.2,<2"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }
 agi-node = { path = "../../../../../core/agi-node", editable = true }
+agi-cluster = { path = "../../../../../core/agi-cluster", editable = true }
 
 [build-system]
 requires = ["setuptools"]

--- a/src/agilab/apps/builtin/tescia_diagnostic_project/src/tescia_diagnostic_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/tescia_diagnostic_project/src/tescia_diagnostic_worker/pyproject.toml
@@ -3,11 +3,12 @@ name = "tescia_diagnostic_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILAB TeSciA-style diagnostic reasoning example"
 requires-python = ">=3.13"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }
 agi-node = { path = "../../../../../core/agi-node", editable = true }
+agi-cluster = { path = "../../../../../core/agi-cluster", editable = true }
 
 [tool.setuptools.package-data]
 tescia_diagnostic = ["sample_data/*.json"]

--- a/src/agilab/apps/builtin/uav_queue_project/src/uav_queue_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/uav_queue_project/src/uav_queue_worker/pyproject.toml
@@ -3,11 +3,12 @@ name = "uav_queue_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILAB lightweight UAV relay queue example"
 requires-python = ">=3.13"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "simpy>=4.1,<5"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "simpy>=4.1,<5"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }
 agi-node = { path = "../../../../../core/agi-node", editable = true }
+agi-cluster = { path = "../../../../../core/agi-cluster", editable = true }
 
 [tool.setuptools.package-data]
 uav_queue = ["sample_data/*.json"]

--- a/src/agilab/apps/builtin/uav_relay_queue_project/src/uav_relay_queue_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/uav_relay_queue_project/src/uav_relay_queue_worker/pyproject.toml
@@ -3,11 +3,12 @@ name = "uav_relay_queue_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILAB lightweight UAV relay queue example"
 requires-python = ">=3.13"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "simpy>=4.1,<5"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "simpy>=4.1,<5"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }
 agi-node = { path = "../../../../../core/agi-node", editable = true }
+agi-cluster = { path = "../../../../../core/agi-cluster", editable = true }
 
 [tool.setuptools.package-data]
 uav_relay_queue = ["sample_data/*.json"]

--- a/src/agilab/apps/builtin/weather_forecast_legacy_project/src/weather_forecast_legacy_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/weather_forecast_legacy_project/src/weather_forecast_legacy_worker/pyproject.toml
@@ -3,11 +3,12 @@ name = "weather_forecast_legacy_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILab weather forecasting example migrated from notebooks"
 requires-python = ">=3.13"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "scikit-learn>=1.7.2,<2", "skforecast>=0.19,<0.20"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "scikit-learn>=1.7.2,<2", "skforecast>=0.19,<0.20"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }
 agi-node = { path = "../../../../../core/agi-node", editable = true }
+agi-cluster = { path = "../../../../../core/agi-cluster", editable = true }
 
 [tool.setuptools.package-data]
 weather_forecast_legacy = ["sample_data/*.csv"]

--- a/src/agilab/apps/builtin/weather_forecast_project/src/weather_forecast_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/weather_forecast_project/src/weather_forecast_worker/pyproject.toml
@@ -3,11 +3,12 @@ name = "weather_forecast_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILab weather forecasting example migrated from notebooks"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "scikit-learn>=1.7.2,<2", "skforecast>=0.19,<0.20"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "scikit-learn>=1.7.2,<2", "skforecast>=0.19,<0.20"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }
 agi-node = { path = "../../../../../core/agi-node", editable = true }
+agi-cluster = { path = "../../../../../core/agi-cluster", editable = true }
 
 [tool.setuptools.package-data]
 weather_forecast = ["sample_data/*.csv"]

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_build_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_build_support.py
@@ -409,6 +409,7 @@ def _core_install_commands(*, env: Any, uv: str, app_path_arg: str) -> list[str]
     core_packages = (
         ("agi-env", getattr(env, "agi_env", None)),
         ("agi-node", getattr(env, "agi_node", None)),
+        ("agi-cluster", getattr(env, "agi_cluster", None)),
     )
     if getattr(env, "is_source_env", False):
         editable_specs = [
@@ -432,7 +433,11 @@ def _core_install_commands(*, env: Any, uv: str, app_path_arg: str) -> list[str]
 def _build_run_overlay_args(env: Any) -> str:
     args = ["--with setuptools", "--with cython"]
     if getattr(env, "is_source_env", False):
-        for source_path in (getattr(env, "agi_env", None), getattr(env, "agi_node", None)):
+        for source_path in (
+            getattr(env, "agi_env", None),
+            getattr(env, "agi_node", None),
+            getattr(env, "agi_cluster", None),
+        ):
             if source_path:
                 args.append(f"--with-editable {quote(str(source_path))}")
     return " ".join(args)

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_local_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_local_support.py
@@ -1,7 +1,6 @@
 import getpass
 import logging
 import os
-import re
 import shutil
 import stat
 import subprocess
@@ -87,11 +86,11 @@ from agi_cluster.agi_distributor.deployment_stage_plan_support import (
 )
 from agi_cluster.agi_distributor.deployment_venv_support import (
     project_site_packages_dir as _project_site_packages_dir,
-    project_venv_cfg_version as _project_venv_cfg_version,
+    project_venv_cfg_version as _project_venv_cfg_version,  # noqa: F401
     project_venv_matches as _project_venv_matches,
     project_venv_python as _project_venv_python,
     project_venv_root as _project_venv_root,
-    python_version_tuple as _python_version_tuple,
+    python_version_tuple as _python_version_tuple,  # noqa: F401
 )
 from agi_cluster.agi_distributor.deployment_worker_venv_cache_support import (
     SHARED_WORKER_VENV_DIR_ENV as SHARED_WORKER_VENV_DIR_ENV,
@@ -489,6 +488,39 @@ def _manager_dependency_names(pyproject_file: Path) -> set[str]:
         return set()
     project = data.get("project", {})
     return _parse_dependency_names(project.get("dependencies"))
+
+
+def _local_uv_source_names(pyproject_file: Path) -> set[str]:
+    try:
+        data = tomlkit.parse(pyproject_file.read_text())
+    except PYPROJECT_PARSE_EXCEPTIONS:
+        return set()
+
+    sources = data.get("tool", {}).get("uv", {}).get("sources")
+    if not isinstance(sources, dict):
+        return set()
+
+    names: set[str] = set()
+    for name, meta in sources.items():
+        if not isinstance(meta, dict):
+            continue
+        path_value = meta.get("path")
+        if not isinstance(path_value, str) or not path_value.strip():
+            continue
+        source_path = Path(path_value).expanduser()
+        if not source_path.is_absolute():
+            source_path = pyproject_file.parent / source_path
+        if source_path.resolve(strict=False).exists():
+            names.add(str(name).lower())
+    return names
+
+
+def _filter_worker_core_add_specs(
+    pyproject_file: Path,
+    specs: list[tuple[str, str]],
+) -> list[str]:
+    local_source_names = _local_uv_source_names(pyproject_file)
+    return [spec for package_name, spec in specs if package_name not in local_source_names]
 
 
 def _manager_overlay_core_sources(
@@ -1146,8 +1178,21 @@ async def deploy_local_worker(
         )
 
     worker_core_add_specs: list[str] = []
+    worker_core_add_source_known = False
     if env.is_source_env:
-        worker_core_add_specs = [str(env.agi_env), str(env.agi_node)]
+        worker_core_add_source_known = True
+        worker_core_add_specs = _filter_worker_core_add_specs(
+            wenv_abs / "pyproject.toml",
+            [
+                (package_name, str(project_path))
+                for package_name, project_path in (
+                    ("agi-env", getattr(env, "agi_env", None)),
+                    ("agi-node", getattr(env, "agi_node", None)),
+                    ("agi-cluster", getattr(env, "agi_cluster", None)),
+                )
+                if isinstance(project_path, Path) and project_path.exists()
+            ],
+        )
     elif (
         (not env.is_worker_env)
         and env.install_type == 0
@@ -1156,14 +1201,22 @@ async def deploy_local_worker(
         and env_project.exists()
         and node_project.exists()
     ):
-        worker_core_add_specs = [
-            spec
-            for spec in (
-                _resolve_install_spec(env_project, "agi-env"),
-                _resolve_install_spec(node_project, "agi-node"),
-            )
-            if spec
-        ]
+        worker_core_add_source_known = True
+        worker_core_add_specs = _filter_worker_core_add_specs(
+            wenv_abs / "pyproject.toml",
+            [
+                (package_name, spec)
+                for package_name, spec in (
+                    ("agi-env", _resolve_install_spec(env_project, "agi-env")),
+                    ("agi-node", _resolve_install_spec(node_project, "agi-node")),
+                    (
+                        "agi-cluster",
+                        _resolve_install_spec(cluster_project, "agi-cluster"),
+                    ),
+                )
+                if spec
+            ],
+        )
 
     worker_venv_project = _shared_worker_venv_project(
         getattr(env, "envars", {}),
@@ -1253,8 +1306,14 @@ async def deploy_local_worker(
                 )
             )
             worker_dependency_names.append(stage_name)
+    elif worker_core_add_source_known:
+        worker_dependency_names = []
     else:
-        worker_dependency_names = ["worker-add-agi-env", "worker-add-agi-node"]
+        worker_dependency_names = [
+            "worker-add-agi-env",
+            "worker-add-agi-node",
+            "worker-add-agi-cluster",
+        ]
         worker_stage_inputs = _deploy_stage_project_inputs(wenv_abs, app_path)
         cmd_worker = (
             f"{worker_extra_indexes}{uv_worker} --project {wenv_abs} add agi-env"
@@ -1286,6 +1345,22 @@ async def deploy_local_worker(
                     python_version=pyvers_worker,
                 ),
                 dependencies=("worker-add-agi-env",),
+            )
+        )
+        cmd_worker = (
+            f"{worker_extra_indexes}{uv_worker} --project {wenv_abs} add agi-cluster"
+        )
+        await deploy_plan.run(
+            _DeployPlanNode(
+                name="worker-add-agi-cluster",
+                cmd=cmd_worker,
+                cwd=wenv_abs,
+                inputs=worker_stage_inputs,
+                output_probe=lambda: _project_venv_matches(
+                    worker_venv_project,
+                    python_version=pyvers_worker,
+                ),
+                dependencies=("worker-add-agi-node",),
             )
         )
 

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime/cleanup_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime/cleanup_support.py
@@ -123,7 +123,7 @@ async def kill_processes(
 
     last_res = None
     for cmd in cmds:
-        cwd = env.agi_cluster if ip == localhost else str(env.wenv_abs)
+        cwd = str(env.wenv_abs)
         if env.is_local(ip):
             if env.debug:
                 sys_module.argv = cmd.split("python ")[1].split(" ")

--- a/src/agilab/core/test/test_agi_distributor_cleanup_support.py
+++ b/src/agilab/core/test/test_agi_distributor_cleanup_support.py
@@ -282,6 +282,7 @@ async def test_kill_processes_cleans_pid_files_and_handles_local_and_remote_path
     assert copied
     assert local_runs
     assert any("cli.py' kill 999" in cmd for cmd, _cwd in local_runs)
+    assert all(cwd == str(wenv_abs) for _cmd, cwd in local_runs)
     assert remote_runs == [
         (
             "10.0.0.2",

--- a/src/agilab/core/test/test_agi_distributor_deployment_build_support.py
+++ b/src/agilab/core/test/test_agi_distributor_deployment_build_support.py
@@ -222,6 +222,7 @@ def test_source_worker_build_overlay_includes_editable_core_projects(tmp_path):
         is_source_env=True,
         agi_env=tmp_path / "core" / "agi-env",
         agi_node=tmp_path / "core" / "agi-node",
+        agi_cluster=tmp_path / "core" / "agi-cluster",
     )
 
     overlay = deployment_build_support._build_run_overlay_args(env)
@@ -230,6 +231,7 @@ def test_source_worker_build_overlay_includes_editable_core_projects(tmp_path):
     assert "--with cython" in overlay
     assert _editable_overlay_arg(env.agi_env) in overlay
     assert _editable_overlay_arg(env.agi_node) in overlay
+    assert _editable_overlay_arg(env.agi_cluster) in overlay
 
 
 def test_worker_pyproject_source_missing_raises(tmp_path):
@@ -456,6 +458,8 @@ def _build_env(tmp_path: Path, *, base_worker_cls: str = "PandasWorker", free_th
     agi_env_path.mkdir(parents=True, exist_ok=True)
     agi_node_path = tmp_path / "agi-node"
     agi_node_path.mkdir(parents=True, exist_ok=True)
+    agi_cluster_path = tmp_path / "agi-cluster"
+    agi_cluster_path.mkdir(parents=True, exist_ok=True)
     return SimpleNamespace(
         wenv_abs=wenv_abs,
         base_worker_cls=base_worker_cls,
@@ -469,6 +473,7 @@ def _build_env(tmp_path: Path, *, base_worker_cls: str = "PandasWorker", free_th
         uvproject=uvproject,
         agi_env=agi_env_path,
         agi_node=agi_node_path,
+        agi_cluster=agi_cluster_path,
         is_source_env=False,
         verbose=0,
         pyvers_worker="3.13",
@@ -506,7 +511,7 @@ async def test_build_lib_local_non_cython_uploads_egg(tmp_path):
     )
 
     assert (env.wenv_abs / env.worker_pyproject.name).exists()
-    assert any("pip install agi-env agi-node" in cmd for cmd, _ in commands)
+    assert any("pip install agi-env agi-node agi-cluster" in cmd for cmd, _ in commands)
     assert any("bdist_egg" in cmd for cmd, _ in commands)
     assert str(egg_path) in uploads
 
@@ -649,13 +654,15 @@ async def test_build_lib_local_uses_editable_core_installs_in_source_env(monkeyp
     assert any(
         (
             f'--offline --project "{env.active_app}" pip install --upgrade --no-deps '
-            f"-e '{env.agi_env}' -e '{env.agi_node}'"
+            f"-e '{env.agi_env}' -e '{env.agi_node}' -e '{env.agi_cluster}'"
         )
         in cmd
         for cmd, _ in commands
     )
     assert any(
-        _editable_overlay_arg(env.agi_env) in cmd and _editable_overlay_arg(env.agi_node) in cmd
+        _editable_overlay_arg(env.agi_env) in cmd
+        and _editable_overlay_arg(env.agi_node) in cmd
+        and _editable_overlay_arg(env.agi_cluster) in cmd
         for cmd, _ in commands
     )
 
@@ -697,13 +704,15 @@ async def test_build_lib_local_uses_uv_index_url_mirror_when_internet_disabled(
     assert any(
         (
             f'--project "{env.active_app}" pip install --upgrade --no-deps '
-            f"-e '{env.agi_env}' -e '{env.agi_node}'"
+            f"-e '{env.agi_env}' -e '{env.agi_node}' -e '{env.agi_cluster}'"
         )
         in cmd
         for cmd, _ in commands
     )
     assert any(
-        _editable_overlay_arg(env.agi_env) in cmd and _editable_overlay_arg(env.agi_node) in cmd
+        _editable_overlay_arg(env.agi_env) in cmd
+        and _editable_overlay_arg(env.agi_node) in cmd
+        and _editable_overlay_arg(env.agi_cluster) in cmd
         for cmd, _ in commands
     )
 

--- a/src/agilab/core/test/test_agi_distributor_deployment_local_support.py
+++ b/src/agilab/core/test/test_agi_distributor_deployment_local_support.py
@@ -1749,6 +1749,33 @@ def test_manager_dependency_names_returns_empty_for_missing_or_invalid_pyproject
     assert deployment_local_support._manager_dependency_names(invalid) == set()
 
 
+def test_filter_worker_core_add_specs_skips_existing_local_uv_sources(tmp_path):
+    pyproject = tmp_path / "pyproject.toml"
+    (tmp_path / "_uv_sources" / "agi-env").mkdir(parents=True)
+    (tmp_path / "_uv_sources" / "agi-cluster").mkdir(parents=True)
+    pyproject.write_text(
+        """
+[project]
+name = "worker"
+
+[tool.uv.sources]
+agi-env = { path = "_uv_sources/agi-env", editable = true }
+agi-node = { path = "_uv_sources/missing", editable = true }
+agi-cluster = { path = "_uv_sources/agi-cluster", editable = true }
+""".strip(),
+        encoding="utf-8",
+    )
+
+    assert deployment_local_support._filter_worker_core_add_specs(
+        pyproject,
+        [
+            ("agi-env", "/repo/core/agi-env"),
+            ("agi-node", "/repo/core/agi-node"),
+            ("agi-cluster", "/repo/core/agi-cluster"),
+        ],
+    ) == ["/repo/core/agi-node"]
+
+
 def test_manager_overlay_core_sources_recovers_when_second_parse_fails(
     tmp_path, monkeypatch
 ):
@@ -2962,7 +2989,7 @@ async def test_deploy_local_worker_install_type_zero_non_source_covers_dependenc
     assert pth_content == expected_prefix
     assert agi_cls._install_done_local is True
     assert any(
-        f'add --editable "{env_project}" "{node_project}"' in cmd
+        f'add --editable "{env_project}" "{node_project}" "{cluster_project}"' in cmd
         and str(wenv_abs) in cmd
         for cmd, _ in commands
     )
@@ -3104,6 +3131,11 @@ async def test_deploy_local_worker_install_type_zero_non_source_uses_distributio
     )
     assert any(
         "agi-node @ git+https://example.invalid/repo.git@main#subdirectory=agi-node"
+        in cmd
+        for cmd, _ in commands
+    )
+    assert any(
+        "agi-cluster @ git+https://example.invalid/repo.git@main#subdirectory=agi-cluster"
         in cmd
         for cmd, _ in commands
     )

--- a/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/src/flight_telemetry_worker/pyproject.toml
+++ b/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/src/flight_telemetry_worker/pyproject.toml
@@ -4,7 +4,7 @@ version = "2026.05.30.post1"
 description = ""
 requires-python = ">=3.11,<3.14"
 readme = "README.md"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "polars>=1.35,<2", "pydantic>=2.11,<2.13"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "polars>=1.35,<2", "pydantic>=2.11,<2.13"]
 
 [[project.authors]]
 name = "Jean-Pierre Morard"

--- a/src/agilab/lib/agi-app-mission-decision/src/agi_app_mission_decision/project/mission_decision_project/src/mission_decision_worker/pyproject.toml
+++ b/src/agilab/lib/agi-app-mission-decision/src/agi_app_mission_decision/project/mission_decision_project/src/mission_decision_worker/pyproject.toml
@@ -3,7 +3,7 @@ name = "mission_decision_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILAB Mission Decision autonomous demo"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13"]
 
 [tool.setuptools.package-data]
 mission_decision = ["sample_data/*.json"]

--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground_worker/pyproject.toml
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground_worker/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = ">=3.12"
 dependencies = [
     "agi-env>=2026.05.31",
     "agi-node>=2026.05.31",
+    "agi-cluster>=2026.05.31",
     "numpy>=2.2,<3",
     "pandas>=2.3.0,<4",
     "pydantic>=2.11,<2.13",

--- a/src/agilab/lib/agi-app-uav-relay-queue/src/agi_app_uav_relay_queue/project/uav_relay_queue_project/src/uav_relay_queue_worker/pyproject.toml
+++ b/src/agilab/lib/agi-app-uav-relay-queue/src/agi_app_uav_relay_queue/project/uav_relay_queue_project/src/uav_relay_queue_worker/pyproject.toml
@@ -3,7 +3,7 @@ name = "uav_relay_queue_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILAB lightweight UAV relay queue example"
 requires-python = ">=3.13"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "simpy>=4.1,<5"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "simpy>=4.1,<5"]
 
 [tool.setuptools.package-data]
 uav_relay_queue = ["sample_data/*.json"]

--- a/src/agilab/lib/agi-app-weather-forecast/src/agi_app_weather_forecast/project/weather_forecast_project/src/weather_forecast_worker/pyproject.toml
+++ b/src/agilab/lib/agi-app-weather-forecast/src/agi_app_weather_forecast/project/weather_forecast_project/src/weather_forecast_worker/pyproject.toml
@@ -3,7 +3,7 @@ name = "weather_forecast_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILab weather forecasting example migrated from notebooks"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "scikit-learn>=1.7.2,<2", "skforecast>=0.19,<0.20"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "scikit-learn>=1.7.2,<2", "skforecast>=0.19,<0.20"]
 
 [tool.setuptools.package-data]
 weather_forecast = ["sample_data/*.csv"]

--- a/test/test_app_contract_matrix.py
+++ b/test/test_app_contract_matrix.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import sys
+import tomllib
 from pathlib import Path
 
 
@@ -93,6 +94,25 @@ def test_app_contract_matrix_detects_promoted_catalog_drift():
     assert "agi-app-pytorch-playground" in failed[
         "promoted_pypi_app_catalog_matches_package_split"
     ]["details"]["missing_from_pypi_catalog"]
+
+
+def test_worker_projects_depend_on_cluster_cli_runtime() -> None:
+    missing_dependency: list[str] = []
+    missing_source: list[str] = []
+    for pyproject in sorted((ROOT / "src" / "agilab").rglob("*_worker/pyproject.toml")):
+        metadata = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+        dependencies = tuple(metadata.get("project", {}).get("dependencies", ()))
+        if not any(dependency.startswith("agi-node") for dependency in dependencies):
+            continue
+        if not any(dependency.startswith("agi-cluster") for dependency in dependencies):
+            missing_dependency.append(pyproject.relative_to(ROOT).as_posix())
+        if pyproject.relative_to(ROOT).as_posix().startswith("src/agilab/apps/builtin/"):
+            sources = metadata.get("tool", {}).get("uv", {}).get("sources", {})
+            if "agi-cluster" not in sources:
+                missing_source.append(pyproject.relative_to(ROOT).as_posix())
+
+    assert missing_dependency == []
+    assert missing_source == []
 
 
 def test_app_contract_matrix_detects_page_bundle_provider_drift():


### PR DESCRIPTION
## Summary
- add agi-cluster to worker runtime manifests where agi-node worker CLI is used
- skip duplicate uv add for core packages already staged through _uv_sources
- run local cleanup CLI from the worker environment instead of the agi-cluster source project

## Validation
- uv --preview-features extra-build-dependencies run --no-sync pytest -q -o addopts='' --import-mode=importlib src/agilab/core/test/test_agi_distributor_deployment_build_support.py src/agilab/core/test/test_agi_distributor_deployment_local_support.py test/test_app_contract_matrix.py
- uv --preview-features extra-build-dependencies run --no-sync pytest -q -o addopts='' --import-mode=importlib src/agilab/core/test/test_agi_distributor_cleanup_support.py::test_kill_processes_cleans_pid_files_and_handles_local_and_remote_paths src/agilab/core/test/test_agi_distributor_cleanup_support.py::test_kill_processes_local_debug_uses_run_path_and_skips_current_pid
- uv --preview-features extra-build-dependencies run --no-sync ruff check <touched files>
- AGILAB_RUN_RELEASE_PROOF_SLOW=1 uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_source_clone_regression.py::test_newcomer_first_proof_passes_from_fresh_source_clone -vv
