### PR TITLE
Forbid public PyPI post releases

### DIFF
--- a/.claude/skills/agilab-runbook/SKILL.md
+++ b/.claude/skills/agilab-runbook/SKILL.md
@@ -238,9 +238,9 @@ Use this skill when you need repo-specific “how we do things” guidance in `a
   - Real PyPI publishes now require the GitHub CLI (`gh`) because `tools/pypi_publish.py` creates or updates the matching GitHub Release after pushing the tag.
   - Real PyPI does not auto-select `.postN` when the date version already
     exists. Normal public releases should move to a deliberate new date-based
-    version or a release candidate/TestPyPI rehearsal first. Use `.postN` only
-    for a documented critical hotfix and pass the workflow's explicit
-    `allow_post_release` / reason controls.
+    version or a release candidate/TestPyPI rehearsal first. Public `.postN`
+    releases are forbidden for new AGILAB publications; use `release_mode=hotfix`
+    with `YYYY.MM.DD.N` for a same-day public fix.
   - On publish retries, the top-level `agilab` artifact may already exist while split runtime/app/page packages still need publication. Let the preflight/release plan decide what remains instead of checking only the root package.
   - Add `--delete-former-github-release` only when the public release page should keep a single current GitHub Release. This deletes the previous GitHub Release entry after the new one is created, but keeps the previous git tag and PyPI files.
   - Add `--delete-pypi-release <version>` only when a specific old PyPI version must be removed from the selected packages. This uses an exact `pypi-cleanup --version-regex` match, requires real PyPI web-login credentials in `[pypi_cleanup]`, and cannot use API tokens or trusted publishing credentials.

--- a/.codex/skills/agilab-runbook/SKILL.md
+++ b/.codex/skills/agilab-runbook/SKILL.md
@@ -238,9 +238,9 @@ Use this skill when you need repo-specific “how we do things” guidance in `a
   - Real PyPI publishes now require the GitHub CLI (`gh`) because `tools/pypi_publish.py` creates or updates the matching GitHub Release after pushing the tag.
   - Real PyPI does not auto-select `.postN` when the date version already
     exists. Normal public releases should move to a deliberate new date-based
-    version or a release candidate/TestPyPI rehearsal first. Use `.postN` only
-    for a documented critical hotfix and pass the workflow's explicit
-    `allow_post_release` / reason controls.
+    version or a release candidate/TestPyPI rehearsal first. Public `.postN`
+    releases are forbidden for new AGILAB publications; use `release_mode=hotfix`
+    with `YYYY.MM.DD.N` for a same-day public fix.
   - On publish retries, the top-level `agilab` artifact may already exist while split runtime/app/page packages still need publication. Let the preflight/release plan decide what remains instead of checking only the root package.
   - Add `--delete-former-github-release` only when the public release page should keep a single current GitHub Release. This deletes the previous GitHub Release entry after the new one is created, but keeps the previous git tag and PyPI files.
   - Add `--delete-pypi-release <version>` only when a specific old PyPI version must be removed from the selected packages. This uses an exact `pypi-cleanup --version-regex` match, requires real PyPI web-login credentials in `[pypi_cleanup]`, and cannot use API tokens or trusted publishing credentials.

--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -15,14 +15,16 @@ on:
       impact_base_ref:
         description: "Optional git ref used to publish only changed packages plus exact-pin dependents. Ignored when packages or roles are set."
         required: false
-      allow_post_release:
-        description: "Allow committed .postN versions on public PyPI only for a critical hotfix. Prefer TestPyPI or rc versions before final release."
+      release_mode:
+        description: "Release intent: stable=YYYY.MM.DD, hotfix=YYYY.MM.DD.N, candidate=YYYY.MM.DDrcN, repair=no PyPI distributions."
         required: false
-        type: boolean
-        default: false
-      post_release_reason:
-        description: "Critical hotfix justification required when allow_post_release is true."
-        required: false
+        type: choice
+        default: stable
+        options:
+          - stable
+          - hotfix
+          - candidate
+          - repair
       include_existing_pypi:
         description: "Include package versions that already exist on PyPI to repair release assets. Default skips them."
         required: false
@@ -275,8 +277,7 @@ jobs:
           RELEASE_ROLES: ${{ github.event.inputs.roles || '' }}
           RELEASE_IMPACT_BASE_REF: ${{ github.event.inputs.impact_base_ref || '' }}
           INCLUDE_EXISTING_PYPI: ${{ github.event.inputs.include_existing_pypi || 'false' }}
-          ALLOW_POST_RELEASE: ${{ github.event.inputs.allow_post_release || 'false' }}
-          POST_RELEASE_REASON: ${{ github.event.inputs.post_release_reason || '' }}
+          RELEASE_MODE: ${{ github.event.inputs.release_mode || 'stable' }}
         run: |
           set -euxo pipefail
           args=(--repo-root . --github-step-summary "$GITHUB_STEP_SUMMARY")
@@ -292,9 +293,7 @@ jobs:
           if [ -n "${RELEASE_IMPACT_BASE_REF:-}" ] && [ -z "${RELEASE_PACKAGES:-}" ] && [ -z "${RELEASE_ROLES:-}" ]; then
             args+=(--impact-base-ref "$RELEASE_IMPACT_BASE_REF")
           fi
-          if [ "${ALLOW_POST_RELEASE:-false}" = "true" ]; then
-            args+=(--allow-post-release --post-release-reason "$POST_RELEASE_REASON")
-          fi
+          args+=(--release-mode "$RELEASE_MODE")
           python tools/pypi_release_version_policy.py "${args[@]}"
 
   publish-library-packages:

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 252,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "890c98318c4573eb6479567dde9a2f0709782aed2be47f26147e2aacf3b174a1",
+  "source_digest_sha256": "051794699293f8919b9b6273d4a1036726bf7fb975253d3cc07d6f774e9079ad",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "890c98318c4573eb6479567dde9a2f0709782aed2be47f26147e2aacf3b174a1"
+  "target_digest_sha256": "051794699293f8919b9b6273d4a1036726bf7fb975253d3cc07d6f774e9079ad"
 }

--- a/docs/source/package-publishing-policy.rst
+++ b/docs/source/package-publishing-policy.rst
@@ -612,20 +612,20 @@ to a deliberate new version. Real PyPI publication must not silently auto-create
 ``.postN`` releases when a version collision is detected; the release tool is
 expected to stop and require an explicit version choice instead.
 
-``.postN`` releases are reserved for critical hotfixes to bounded packaging,
-publication, provenance, or evidence refreshes on an already published
-date-based version. The ``pypi-publish`` workflow enforces this with
-``tools/pypi_release_version_policy.py``: a selected public package version that
-contains ``.postN`` fails unless the workflow dispatch explicitly sets
-``allow_post_release=true`` and provides ``post_release_reason``. Tag-triggered
-releases cannot bypass that gate.
+Public PyPI ``.postN`` releases are forbidden for new AGILAB
+publications. The ``pypi-publish`` workflow enforces this with
+``tools/pypi_release_version_policy.py`` and an explicit ``release_mode``:
+``stable`` accepts ``YYYY.MM.DD``, ``hotfix`` accepts ``YYYY.MM.DD.N`` for a
+same-day public fix, ``candidate`` accepts ``YYYY.MM.DDrcN``, and ``repair`` is
+reserved for release-evidence repair flows that must not publish PyPI
+distributions.
 
 The dense April-May 2026 ``.postN`` history records public-beta hardening of the
 split package release pipeline and is kept visible for auditability. It is not
 the target steady-state release rhythm: normal feature or behavior changes
-should advance to a deliberate new date-based release, and
-multiple same-day post releases should be treated as release
-process debt. TestPyPI rehearsals are the exception: retry-oriented ``.postN``
+should advance to a deliberate new date-based release, and same-day public
+hotfixes should use ``release_mode=hotfix`` with ``YYYY.MM.DD.N`` instead of a
+post-release suffix. TestPyPI rehearsals are the exception: retry-oriented ``.postN``
 bumps are allowed there because TestPyPI is often reused during dry runs.
 Release-candidate versions such as
 ``YYYY.MM.DDrc1`` are also acceptable for rehearsal when a public pre-release is

--- a/test/test_audit_response_docs.py
+++ b/test/test_audit_response_docs.py
@@ -287,10 +287,10 @@ def test_package_publishing_policy_addresses_common_audit_misreads() -> None:
     assert "must not rewrite versions or dependency metadata during the upload job" in normalized_policy
     assert "dependency-policy hygiene, docs mirror\nintegrity, installer behavior" in policy
     assert "Real PyPI publication must not silently auto-create\n``.postN`` releases" in policy
-    assert "multiple same-day post releases should be treated as release\nprocess debt" in policy
+    assert "Public PyPI ``.postN`` releases are forbidden for new AGILAB\npublications" in policy
     assert "tools/pypi_release_version_policy.py" in policy
-    assert "``allow_post_release=true``" in policy
-    assert "``post_release_reason``" in policy
+    assert "``release_mode=hotfix``" in policy
+    assert "``YYYY.MM.DD.N``" in policy
     assert "release-candidate versions such as ``YYYY.MM.DDrc1``" in policy
     assert "disallow_untyped_defs = true" in policy
     assert "runs mypy with ``--strict``" in policy

--- a/test/test_pypi_publish.py
+++ b/test/test_pypi_publish.py
@@ -420,10 +420,10 @@ def test_require_safe_pypi_release_rejects_skipping_release_preflight() -> None:
         raise AssertionError("require_safe_pypi_release() should reject skipping real release preflight")
 
 
-def test_public_post_release_policy_requires_documented_hotfix(monkeypatch) -> None:
+def test_public_post_release_policy_rejects_post_release_even_with_legacy_env(monkeypatch) -> None:
     module = _load_pypi_publish()
-    monkeypatch.delenv(module.ALLOW_PYPI_POST_RELEASE_ENV, raising=False)
-    monkeypatch.delenv(module.PYPI_POST_RELEASE_REASON_ENV, raising=False)
+    monkeypatch.setenv("AGILAB_ALLOW_PYPI_POST_RELEASE", "1")
+    monkeypatch.setenv("AGILAB_PYPI_POST_RELEASE_REASON", "critical provenance attestation repair")
 
     with pytest.raises(SystemExit) as excinfo:
         module.require_public_post_release_policy(
@@ -432,27 +432,16 @@ def test_public_post_release_policy_requires_documented_hotfix(monkeypatch) -> N
         )
 
     message = str(excinfo.value)
-    assert "critical hotfixes" in message
-    assert "release candidate or TestPyPI" in message
-    assert module.ALLOW_PYPI_POST_RELEASE_ENV in message
-    assert module.PYPI_POST_RELEASE_REASON_ENV in message
+    assert ".postN releases are forbidden" in message
+    assert "YYYY.MM.DD.N" in message
 
 
-def test_public_post_release_policy_allows_documented_hotfix(monkeypatch, capsys) -> None:
+def test_public_post_release_policy_accepts_same_day_hotfix_version() -> None:
     module = _load_pypi_publish()
-    monkeypatch.setenv(module.ALLOW_PYPI_POST_RELEASE_ENV, "1")
-    monkeypatch.setenv(module.PYPI_POST_RELEASE_REASON_ENV, "critical provenance attestation repair")
-
     module.require_public_post_release_policy(
         _base_cfg(module, repo="pypi", git_tag=True, git_commit_version=True, git_reset_on_failure=True),
-        {"agilab": "2026.05.18.post1"},
+        {"agilab": "2026.05.18.1"},
     )
-
-    assert "Allowing documented public PyPI post-release hotfix" in capsys.readouterr().out
-
-
-def test_public_post_release_policy_warns_only_for_dry_run(capsys) -> None:
-    module = _load_pypi_publish()
 
     module.require_public_post_release_policy(
         _base_cfg(module, repo="pypi", dry_run=True),

--- a/test/test_pypi_publish_workflow.py
+++ b/test/test_pypi_publish_workflow.py
@@ -120,8 +120,13 @@ def test_pypi_publish_skips_existing_artifacts_and_requires_trusted_auth() -> No
     assert "packages:" in text
     assert "roles:" in text
     assert "impact_base_ref:" in text
-    assert "allow_post_release:" in text
-    assert "post_release_reason:" in text
+    assert "release_mode:" in text
+    assert "stable" in text
+    assert "hotfix" in text
+    assert "candidate" in text
+    assert "repair" in text
+    assert "allow_post_release:" not in text
+    assert "post_release_reason:" not in text
     assert "include_existing_pypi:" in text
     assert "RELEASE_PACKAGES" in text
     assert "RELEASE_ROLES" in text
@@ -139,8 +144,9 @@ def test_pypi_publish_skips_existing_artifacts_and_requires_trusted_auth() -> No
     assert "tools/pypi_trusted_publisher_contract.py" in text
     assert "Validate public release cadence policy" in text
     assert "tools/pypi_release_version_policy.py" in text
-    assert "--allow-post-release" in text
-    assert "POST_RELEASE_REASON" in text
+    assert "--release-mode \"$RELEASE_MODE\"" in text
+    assert "--allow-post-release" not in text
+    assert "POST_RELEASE_REASON" not in text
     assert "--check-workflow .github/workflows/pypi-publish.yaml" in text
     assert "release-plan:" in text
     assert "Render release package plan" in text

--- a/test/test_pypi_release_version_policy.py
+++ b/test/test_pypi_release_version_policy.py
@@ -22,43 +22,80 @@ def _load_policy():
     return module
 
 
-def test_release_version_policy_accepts_final_and_release_candidate_versions() -> None:
+def test_release_version_policy_accepts_stable_versions() -> None:
     policy = _load_policy()
 
     result = policy.validate_public_release_versions(
         {
             "agilab": "2026.05.18",
-            "agi-core": "2026.05.18rc1",
+            "agi-core": "2026.05.18",
         }
     )
 
-    assert "No selected public PyPI package uses a .postN" in result
+    assert "release_mode=stable accepted" in result
 
 
-def test_release_version_policy_rejects_public_post_release_without_hotfix_reason() -> None:
-    policy = _load_policy()
-
-    with pytest.raises(policy.ReleaseVersionPolicyError) as excinfo:
-        policy.validate_public_release_versions({"agilab": "2026.05.18.post1"})
-
-    message = str(excinfo.value)
-    assert "critical hotfixes" in message
-    assert "release candidate or TestPyPI" in message
-    assert "allow_post_release=true" in message
-    assert "post_release_reason" in message
-
-
-def test_release_version_policy_allows_documented_public_post_release() -> None:
+def test_release_version_policy_accepts_hotfix_versions() -> None:
     policy = _load_policy()
 
     result = policy.validate_public_release_versions(
-        {"agilab": "2026.05.18.post1"},
-        allow_post_release=True,
-        post_release_reason="critical package metadata repair",
+        {
+            "agilab": "2026.05.18.1",
+            "agi-core": "2026.05.18.1",
+        },
+        release_mode="hotfix",
     )
 
-    assert "Allowed documented critical hotfix post-release" in result
-    assert "critical package metadata repair" in result
+    assert "release_mode=hotfix accepted" in result
+
+
+def test_release_version_policy_accepts_candidate_versions() -> None:
+    policy = _load_policy()
+
+    result = policy.validate_public_release_versions(
+        {"agilab": "2026.05.18rc1"},
+        release_mode="candidate",
+    )
+
+    assert "release_mode=candidate accepted" in result
+
+
+def test_release_version_policy_rejects_public_post_release_even_with_hotfix_mode() -> None:
+    policy = _load_policy()
+
+    with pytest.raises(policy.ReleaseVersionPolicyError) as excinfo:
+        policy.validate_public_release_versions(
+            {"agilab": "2026.05.18.post1"},
+            release_mode="hotfix",
+        )
+
+    message = str(excinfo.value)
+    assert ".postN releases are forbidden" in message
+    assert "release_mode=hotfix with YYYY.MM.DD.N" in message
+
+
+def test_release_version_policy_rejects_stable_shape_in_hotfix_mode() -> None:
+    policy = _load_policy()
+
+    with pytest.raises(policy.ReleaseVersionPolicyError) as excinfo:
+        policy.validate_public_release_versions(
+            {"agilab": "2026.05.18"},
+            release_mode="hotfix",
+        )
+
+    assert "release_mode=hotfix rejected version shape" in str(excinfo.value)
+
+
+def test_release_version_policy_repair_mode_rejects_pypi_publications() -> None:
+    policy = _load_policy()
+
+    with pytest.raises(policy.ReleaseVersionPolicyError) as excinfo:
+        policy.validate_public_release_versions(
+            {"agilab": "2026.05.18"},
+            release_mode="repair",
+        )
+
+    assert "release_mode=repair must not publish PyPI package distributions" in str(excinfo.value)
 
 
 def test_selected_public_versions_reads_filtered_package_versions(tmp_path, monkeypatch) -> None:

--- a/tools/pypi_publish.py
+++ b/tools/pypi_publish.py
@@ -105,9 +105,7 @@ UPLOAD_COLLISION_DETECTED: bool = False
 UPLOAD_SUCCESS_COUNT: int = 0
 UPLOAD_SKIPPED_EXISTING_COUNT: int = 0
 ALLOW_LOCAL_PYPI_TWINE_ENV = "AGILAB_ALLOW_LOCAL_PYPI_TWINE"
-ALLOW_PYPI_POST_RELEASE_ENV = "AGILAB_ALLOW_PYPI_POST_RELEASE"
-PYPI_POST_RELEASE_REASON_ENV = "AGILAB_PYPI_POST_RELEASE_REASON"
-VERSION_PATTERN = r"\d+\.\d+\.\d+(?:(?:a|b|rc)\d+)?(?:\.post\d+)?"
+VERSION_PATTERN = r"\d+\.\d+\.\d+(?:\.\d+)?(?:(?:a|b|rc)\d+)?(?:\.post\d+)?"
 VERSION_RE = re.compile(rf"^{VERSION_PATTERN}$", re.IGNORECASE)
 
 
@@ -144,9 +142,9 @@ def parse_args() -> argparse.Namespace:
     ap.add_argument(
         "--version",
         help=(
-            "Explicit version 'X.Y.Z[rcN][.postN]'. If omitted, base=UTC YYYY.MM.DD. "
+            "Explicit version 'X.Y.Z[.N][rcN][.postN]'. If omitted, base=UTC YYYY.MM.DD. "
             "Real PyPI refuses automatic .postN bumps when that version is already used; "
-            ".postN is reserved for documented critical hotfixes."
+            ".postN is forbidden on public PyPI. Use YYYY.MM.DD.N for same-day hotfixes."
         ),
     )
 
@@ -602,12 +600,8 @@ def is_post_release_version(version: str) -> bool:
         return bool(re.search(r"(?:^|[._-])post\d+\Z", version, flags=re.IGNORECASE))
 
 
-def _env_flag(name: str) -> bool:
-    return str(os.environ.get(name, "")).strip().lower() in {"1", "true", "yes", "on"}
-
-
 def require_public_post_release_policy(cfg: Cfg, package_versions: Dict[str, str]) -> None:
-    """Require an explicit critical-hotfix decision for public PyPI .postN releases."""
+    """Reject public PyPI .postN releases; use YYYY.MM.DD.N hotfix versions instead."""
 
     if cfg.repo != "pypi" or cfg.cleanup_only:
         return
@@ -620,23 +614,11 @@ def require_public_post_release_policy(cfg: Cfg, package_versions: Dict[str, str
         return
 
     formatted = ", ".join(f"{package}={version}" for package, version in post_versions.items())
-    reason = os.environ.get(PYPI_POST_RELEASE_REASON_ENV, "").strip()
-    if cfg.dry_run:
-        print(
-            "[policy] Public PyPI .postN release detected in dry-run. "
-            f"Publication would require {ALLOW_PYPI_POST_RELEASE_ENV}=1 and "
-            f"{PYPI_POST_RELEASE_REASON_ENV}: {formatted}"
-        )
-        return
-    if _env_flag(ALLOW_PYPI_POST_RELEASE_ENV) and reason:
-        print(f"[policy] Allowing documented public PyPI post-release hotfix: {reason}")
-        return
     raise SystemExit(
-        "ERROR: Public PyPI .postN releases are reserved for documented critical hotfixes. "
+        "ERROR: Public PyPI .postN releases are forbidden for new AGILAB publications. "
         f"Selected post-release versions: {formatted}. Use a release candidate or TestPyPI for "
-        "rehearsal, then publish a deliberate new date-based final release. "
-        f"Break-glass post-release publication requires {ALLOW_PYPI_POST_RELEASE_ENV}=1 and "
-        f"{PYPI_POST_RELEASE_REASON_ENV} with the hotfix justification."
+        "rehearsal, publish YYYY.MM.DD for a stable release, or publish YYYY.MM.DD.N "
+        "for a same-day hotfix."
     )
 
 

--- a/tools/pypi_release_version_policy.py
+++ b/tools/pypi_release_version_policy.py
@@ -17,6 +17,10 @@ except ModuleNotFoundError:  # pragma: no cover - used when imported as tools.*
 
 
 POST_RELEASE_RE = re.compile(r"(?:[._-]?post\d+)\Z", re.IGNORECASE)
+STABLE_RELEASE_RE = re.compile(r"^\d{4}\.\d{1,2}\.\d{1,2}$")
+HOTFIX_RELEASE_RE = re.compile(r"^\d{4}\.\d{1,2}\.\d{1,2}\.\d+$")
+CANDIDATE_RELEASE_RE = re.compile(r"^\d{4}\.\d{1,2}\.\d{1,2}rc\d+$", re.IGNORECASE)
+RELEASE_MODES = ("stable", "hotfix", "candidate", "repair")
 
 
 class ReleaseVersionPolicyError(ValueError):
@@ -42,28 +46,61 @@ def post_release_versions(package_versions: Mapping[str, str]) -> dict[str, str]
     }
 
 
+def _version_shape_errors(package_versions: Mapping[str, str], release_mode: str) -> list[str]:
+    if release_mode == "repair":
+        if package_versions:
+            formatted = ", ".join(
+                f"{package}={version}" for package, version in sorted(package_versions.items())
+            )
+            return [
+                "release_mode=repair must not publish PyPI package distributions. "
+                f"Selected package versions: {formatted}."
+            ]
+        return []
+
+    pattern_by_mode = {
+        "stable": STABLE_RELEASE_RE,
+        "hotfix": HOTFIX_RELEASE_RE,
+        "candidate": CANDIDATE_RELEASE_RE,
+    }
+    pattern = pattern_by_mode[release_mode]
+    return [
+        f"{package}={version}"
+        for package, version in sorted(package_versions.items())
+        if not pattern.fullmatch(version)
+    ]
+
+
 def validate_public_release_versions(
     package_versions: Mapping[str, str],
     *,
-    allow_post_release: bool = False,
-    post_release_reason: str = "",
+    release_mode: str = "stable",
 ) -> str:
+    if release_mode not in RELEASE_MODES:
+        raise ReleaseVersionPolicyError(
+            f"Unknown release_mode={release_mode!r}. Expected one of: {', '.join(RELEASE_MODES)}."
+        )
+
     post_versions = post_release_versions(package_versions)
-    if not post_versions:
-        return "No selected public PyPI package uses a .postN release version."
+    if post_versions:
+        formatted = ", ".join(f"{package}={version}" for package, version in post_versions.items())
+        raise ReleaseVersionPolicyError(
+            "Public PyPI .postN releases are forbidden for new AGILAB publications. "
+            f"Selected post-release versions: {formatted}. Use release_mode=stable with "
+            "YYYY.MM.DD, release_mode=hotfix with YYYY.MM.DD.N for a same-day fix, or "
+            "release_mode=candidate with YYYY.MM.DDrcN for a public pre-release rehearsal."
+        )
 
-    formatted = ", ".join(f"{package}={version}" for package, version in post_versions.items())
-    reason = post_release_reason.strip()
-    if allow_post_release and reason:
-        return f"Allowed documented critical hotfix post-release: {formatted}. Reason: {reason}"
+    shape_errors = _version_shape_errors(package_versions, release_mode)
+    if shape_errors:
+        raise ReleaseVersionPolicyError(
+            f"Public PyPI release_mode={release_mode} rejected version shape(s): "
+            + ", ".join(shape_errors)
+        )
 
-    raise ReleaseVersionPolicyError(
-        "Public PyPI .postN releases are reserved for documented critical hotfixes. "
-        f"Selected post-release versions: {formatted}. Use a release candidate or TestPyPI "
-        "for rehearsal, then publish a deliberate new date-based final release. "
-        "To publish a critical hotfix, set allow_post_release=true and provide "
-        "post_release_reason in the workflow dispatch inputs."
-    )
+    if release_mode == "repair":
+        return "release_mode=repair selected no public PyPI package distributions."
+    return f"release_mode={release_mode} accepted {len(package_versions)} public PyPI package version(s)."
 
 
 def public_package_entries(
@@ -153,14 +190,13 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         help="Limit policy validation to comma- or space-separated package roles.",
     )
     parser.add_argument(
-        "--allow-post-release",
-        action="store_true",
-        help="Allow committed .postN public PyPI versions for a documented critical hotfix.",
-    )
-    parser.add_argument(
-        "--post-release-reason",
-        default="",
-        help="Critical hotfix justification required when --allow-post-release is set.",
+        "--release-mode",
+        choices=RELEASE_MODES,
+        default="stable",
+        help=(
+            "Public release intent: stable=YYYY.MM.DD, hotfix=YYYY.MM.DD.N, "
+            "candidate=YYYY.MM.DDrcN, repair=no PyPI distributions."
+        ),
     )
     parser.add_argument(
         "--skip-existing-pypi",
@@ -200,8 +236,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         result = validate_public_release_versions(
             package_versions,
-            allow_post_release=args.allow_post_release,
-            post_release_reason=args.post_release_reason,
+            release_mode=args.release_mode,
         )
     except (OSError, tomllib.TOMLDecodeError, ValueError) as exc:
         print(f"ERROR: {exc}", file=sys.stderr)

--- a/tools/release_plan.py
+++ b/tools/release_plan.py
@@ -614,13 +614,11 @@ def validate_workflow_contract(workflow_path: Path) -> list[str]:
         "gh release create \"$DATASET_RELEASE_TAG\" dataset-release-assets/*": (
             "dataset release job must upload dataset assets to the dataset release"
         ),
-        "allow_post_release:": "workflow must require an explicit public .postN hotfix override",
-        "post_release_reason:": "workflow must capture the public .postN hotfix justification",
+        "release_mode:": "workflow must require explicit stable/hotfix/candidate/repair release intent",
         "tools/pypi_release_version_policy.py": (
             "workflow must validate public release cadence before publishing"
         ),
-        "--allow-post-release": "workflow must pass the explicit .postN override to the policy gate",
-        "POST_RELEASE_REASON": "workflow must pass the .postN hotfix justification to the policy gate",
+        "--release-mode": "workflow must pass explicit release intent to the policy gate",
         "pypi-release-retention:": "workflow must prune old PyPI releases after provenance passes",
         "tools/pypi_release_retention.py": "workflow must use the PyPI release retention tool",
         "--protect-versions-from-projects": (


### PR DESCRIPTION
## Summary
- replace the public PyPI .postN break-glass switch with explicit release_mode intent
- reject .postN unconditionally for public AGILAB PyPI publications
- allow same-day public hotfixes via YYYY.MM.DD.N and release_mode=hotfix
- update release policy docs, runbook guidance, and focused regressions

## Validation
- python3 tools/sync_agent_skills.py --skills agilab-runbook
- uv --preview-features extra-build-dependencies run python -m pytest -q -o addopts='' test/test_pypi_release_version_policy.py test/test_pypi_publish_workflow.py test/test_pypi_publish.py -k 'post_release_policy or release_version_policy or pypi_publish_skips_existing_artifacts' test/test_audit_response_docs.py -k 'package_publishing_policy or audit'
- uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp

## PyPI retention
- Dry-run checked 35 packages and found 14 older releases to remove while protecting each current project version.
- Destructive delete was attempted but blocked locally because PyPI deletion requires PYPI_RELEASE_PRUNE_USERNAME and PYPI_RELEASE_PRUNE_PASSWORD; Trusted Publishing only covers upload.