### PR TITLE
Fix ORCHESTRATE dependency import health checks

### DIFF
--- a/src/agilab/orchestrate/orchestrate_page_support.py
+++ b/src/agilab/orchestrate/orchestrate_page_support.py
@@ -10,6 +10,15 @@ from typing import Any
 
 from agi_env.snippet_contract import snippet_contract_block
 
+try:
+    from packaging.markers import default_environment as _packaging_default_environment
+    from packaging.requirements import InvalidRequirement as _PackagingInvalidRequirement
+    from packaging.requirements import Requirement as _PackagingRequirement
+except ModuleNotFoundError:  # pragma: no cover - packaging is supplied by AGILAB's core stack.
+    _packaging_default_environment = None
+    _PackagingInvalidRequirement = ValueError
+    _PackagingRequirement = None
+
 
 RUN_MODE_LABELS: tuple[str, ...] = (
     "0: python",
@@ -1307,9 +1316,44 @@ def _project_distribution_name(project_path: Path | None) -> str | None:
     return _normalized_distribution_name(name) if isinstance(name, str) and name.strip() else None
 
 
-def _requirement_name_and_extras(requirement: str) -> tuple[str, str, set[str]] | None:
+_PYTHON_VERSION_PREFIX_PATTERN = re.compile(r"^(\d+)\.(\d+)(?:\.(\d+))?")
+
+
+def _python_full_version_from_venv_cfg(venv: Path) -> str | None:
+    try:
+        lines = (venv / "pyvenv.cfg").read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return None
+    for line in lines:
+        key, separator, value = line.partition("=")
+        if not separator or key.strip().lower() != "version":
+            continue
+        match = _PYTHON_VERSION_PREFIX_PATTERN.match(value.strip())
+        if not match:
+            return None
+        major, minor, patch = match.groups()
+        return f"{major}.{minor}.{patch or '0'}"
+    return None
+
+
+def _marker_environment_for_venv(venv: Path | None) -> dict[str, str]:
+    if _packaging_default_environment is None:
+        return {}
+    environment = dict(_packaging_default_environment())
+    environment.setdefault("extra", "")
+    if venv is None:
+        return environment
+    full_version = _python_full_version_from_venv_cfg(venv)
+    if full_version:
+        version_parts = full_version.split(".")
+        environment["python_full_version"] = full_version
+        environment["python_version"] = ".".join(version_parts[:2])
+    return environment
+
+
+def _legacy_requirement_name_and_extras(requirement: str) -> tuple[str, str, set[str]] | None:
     requirement_part, _, marker = requirement.partition(";")
-    if "extra ==" in marker or "extra==" in marker:
+    if marker.strip():
         return None
     match = _REQUIREMENT_NAME_PATTERN.match(requirement_part)
     if not match:
@@ -1326,6 +1370,78 @@ def _requirement_name_and_extras(requirement: str) -> tuple[str, str, set[str]] 
     return raw_name, normalized, extras
 
 
+def _requirement_name_and_extras(
+    requirement: str,
+    *,
+    marker_environment: Mapping[str, str] | None = None,
+) -> tuple[str, str, set[str]] | None:
+    if _PackagingRequirement is None:
+        return _legacy_requirement_name_and_extras(requirement)
+    try:
+        parsed = _PackagingRequirement(requirement)
+    except _PackagingInvalidRequirement:
+        return None
+    if parsed.marker is not None:
+        environment = dict(marker_environment or _marker_environment_for_venv(None))
+        environment.setdefault("extra", "")
+        try:
+            if not parsed.marker.evaluate(environment=environment):
+                return None
+        except (KeyError, ValueError):
+            return None
+    normalized = _normalized_distribution_name(parsed.name)
+    if normalized.startswith("agi-") or normalized == "agilab":
+        return None
+    return parsed.name, normalized, {str(extra).lower() for extra in parsed.extras}
+
+
+def _module_name_from_record_path(path_text: str) -> str | None:
+    root = path_text.strip().split(",", 1)[0].replace("\\", "/").split("/", 1)[0]
+    if not root:
+        return None
+    if root.endswith((".dist-info", ".egg-info", ".data")):
+        return None
+    if root.endswith(".py"):
+        module = root[:-3]
+    elif root.endswith((".so", ".pyd", ".dylib")):
+        module = root.split(".", 1)[0]
+    elif "." in root:
+        return None
+    else:
+        module = root
+    return module if module.isidentifier() else None
+
+
+def _top_level_modules_from_metadata_dir(metadata_dir: Path) -> tuple[str, ...]:
+    modules: list[str] = []
+    try:
+        lines = (metadata_dir / "top_level.txt").read_text(
+            encoding="utf-8",
+            errors="replace",
+        ).splitlines()
+    except OSError:
+        lines = []
+    for line in lines:
+        module = line.strip()
+        if module and not module.startswith("#") and module.isidentifier():
+            modules.append(module)
+    if modules:
+        return tuple(dict.fromkeys(modules))
+
+    try:
+        record_lines = (metadata_dir / "RECORD").read_text(
+            encoding="utf-8",
+            errors="replace",
+        ).splitlines()
+    except OSError:
+        return ()
+    for line in record_lines:
+        module = _module_name_from_record_path(line)
+        if module:
+            modules.append(module)
+    return tuple(dict.fromkeys(modules))
+
+
 def _top_level_modules_from_distribution(
     site_packages: Sequence[Path],
     distribution_name: str,
@@ -1340,17 +1456,7 @@ def _top_level_modules_from_distribution(
         for metadata_file in metadata_files:
             if _metadata_distribution_name(metadata_file) != normalized:
                 continue
-            try:
-                lines = (metadata_file.parent / "top_level.txt").read_text(
-                    encoding="utf-8",
-                    errors="replace",
-                ).splitlines()
-            except OSError:
-                continue
-            for line in lines:
-                module = line.strip()
-                if module and not module.startswith("#"):
-                    modules.append(module)
+            modules.extend(_top_level_modules_from_metadata_dir(metadata_file.parent))
     return tuple(dict.fromkeys(modules))
 
 
@@ -1358,8 +1464,12 @@ def _dependency_modules_from_requirement(
     requirement: str,
     *,
     site_packages: Sequence[Path] = (),
+    marker_environment: Mapping[str, str] | None = None,
 ) -> tuple[str, ...]:
-    requirement_info = _requirement_name_and_extras(requirement)
+    requirement_info = _requirement_name_and_extras(
+        requirement,
+        marker_environment=marker_environment,
+    )
     if requirement_info is None:
         return ()
     raw_name, normalized, extras = requirement_info
@@ -1385,6 +1495,8 @@ def _metadata_distribution_name(metadata_file: Path) -> str | None:
 def _dependency_modules_from_metadata(
     site_packages: Sequence[Path],
     distribution_names: Sequence[str],
+    *,
+    marker_environment: Mapping[str, str] | None = None,
 ) -> tuple[str, ...]:
     wanted = {
         _normalized_distribution_name(name)
@@ -1418,6 +1530,7 @@ def _dependency_modules_from_metadata(
                     _dependency_modules_from_requirement(
                         line.partition(":")[2],
                         site_packages=site_packages,
+                        marker_environment=marker_environment,
                     )
                 )
     return tuple(dict.fromkeys(modules))
@@ -1427,6 +1540,7 @@ def _dependency_modules_from_pyproject(
     project_path: Path | None,
     *,
     site_packages: Sequence[Path] = (),
+    marker_environment: Mapping[str, str] | None = None,
 ) -> tuple[str, ...]:
     if project_path is None:
         return ()
@@ -1445,6 +1559,7 @@ def _dependency_modules_from_pyproject(
                 _dependency_modules_from_requirement(
                     dependency,
                     site_packages=site_packages,
+                    marker_environment=marker_environment,
                 )
             )
     return tuple(dict.fromkeys(modules))
@@ -1458,14 +1573,20 @@ def _required_modules_with_dependencies(
     dependency_projects: Sequence[Path] = (),
 ) -> tuple[str, ...]:
     site_packages = _venv_site_package_dirs(venv)
+    marker_environment = _marker_environment_for_venv(venv)
     dependency_modules: list[str] = list(
-        _dependency_modules_from_metadata(site_packages, distribution_names)
+        _dependency_modules_from_metadata(
+            site_packages,
+            distribution_names,
+            marker_environment=marker_environment,
+        )
     )
     for project_path in dependency_projects:
         dependency_modules.extend(
             _dependency_modules_from_pyproject(
                 project_path,
                 site_packages=site_packages,
+                marker_environment=marker_environment,
             )
         )
     return tuple(dict.fromkeys((*modules, *dependency_modules)))

--- a/src/agilab/orchestrate/orchestrate_page_support.py
+++ b/src/agilab/orchestrate/orchestrate_page_support.py
@@ -96,10 +96,12 @@ _MANAGER_REQUIRED_SYMBOLS: tuple[tuple[str, str], ...] = (
     ("agi_cluster.agi_distributor", "StageRequest"),
 )
 _DEPENDENCY_MODULE_ALIASES: dict[str, tuple[str, ...]] = {
+    "legacy-cgi": ("cgi",),
     "pillow": ("PIL",),
     "python-dotenv": ("dotenv",),
     "pyyaml": ("yaml",),
     "scikit-learn": ("sklearn",),
+    "standard-imghdr": ("imghdr",),
 }
 _REQUIREMENT_NAME_PATTERN = re.compile(
     r"^\s*([A-Za-z0-9_.-]+)(?:\s*\[([A-Za-z0-9_,.\s-]+)\])?"
@@ -1240,6 +1242,11 @@ def _module_available_on_root(root: Path, module: str) -> bool:
     for suffix in (".py", ".so", ".pyd", ".dylib"):
         if (root / f"{module}{suffix}").exists():
             return True
+    try:
+        if any(root.glob(f"{module}.*.so")) or any(root.glob(f"{module}.*.pyd")):
+            return True
+    except OSError:
+        return False
     return False
 
 
@@ -1300,24 +1307,66 @@ def _project_distribution_name(project_path: Path | None) -> str | None:
     return _normalized_distribution_name(name) if isinstance(name, str) and name.strip() else None
 
 
-def _dependency_modules_from_requirement(requirement: str) -> tuple[str, ...]:
+def _requirement_name_and_extras(requirement: str) -> tuple[str, str, set[str]] | None:
     requirement_part, _, marker = requirement.partition(";")
     if "extra ==" in marker or "extra==" in marker:
-        return ()
+        return None
     match = _REQUIREMENT_NAME_PATTERN.match(requirement_part)
     if not match:
-        return ()
+        return None
     raw_name = match.group(1)
     normalized = _normalized_distribution_name(raw_name)
     if normalized.startswith("agi-") or normalized == "agilab":
-        return ()
-
-    modules = list(_DEPENDENCY_MODULE_ALIASES.get(normalized, (raw_name.replace("-", "_"),)))
+        return None
     extras = {
         item.strip().lower()
         for item in (match.group(2) or "").split(",")
         if item.strip()
     }
+    return raw_name, normalized, extras
+
+
+def _top_level_modules_from_distribution(
+    site_packages: Sequence[Path],
+    distribution_name: str,
+) -> tuple[str, ...]:
+    normalized = _normalized_distribution_name(distribution_name)
+    modules: list[str] = []
+    for site_package in site_packages:
+        try:
+            metadata_files = sorted(site_package.glob("*.dist-info/METADATA"))
+        except OSError:
+            continue
+        for metadata_file in metadata_files:
+            if _metadata_distribution_name(metadata_file) != normalized:
+                continue
+            try:
+                lines = (metadata_file.parent / "top_level.txt").read_text(
+                    encoding="utf-8",
+                    errors="replace",
+                ).splitlines()
+            except OSError:
+                continue
+            for line in lines:
+                module = line.strip()
+                if module and not module.startswith("#"):
+                    modules.append(module)
+    return tuple(dict.fromkeys(modules))
+
+
+def _dependency_modules_from_requirement(
+    requirement: str,
+    *,
+    site_packages: Sequence[Path] = (),
+) -> tuple[str, ...]:
+    requirement_info = _requirement_name_and_extras(requirement)
+    if requirement_info is None:
+        return ()
+    raw_name, normalized, extras = requirement_info
+
+    modules = list(_top_level_modules_from_distribution(site_packages, normalized))
+    if not modules:
+        modules = list(_DEPENDENCY_MODULE_ALIASES.get(normalized, (raw_name.replace("-", "_"),)))
     if normalized == "dask" and "distributed" in extras:
         modules.append("distributed")
     return tuple(dict.fromkeys(modules))
@@ -1366,12 +1415,19 @@ def _dependency_modules_from_metadata(
                 if not line.startswith("Requires-Dist:"):
                     continue
                 modules.extend(
-                    _dependency_modules_from_requirement(line.partition(":")[2])
+                    _dependency_modules_from_requirement(
+                        line.partition(":")[2],
+                        site_packages=site_packages,
+                    )
                 )
     return tuple(dict.fromkeys(modules))
 
 
-def _dependency_modules_from_pyproject(project_path: Path | None) -> tuple[str, ...]:
+def _dependency_modules_from_pyproject(
+    project_path: Path | None,
+    *,
+    site_packages: Sequence[Path] = (),
+) -> tuple[str, ...]:
     if project_path is None:
         return ()
     try:
@@ -1385,7 +1441,12 @@ def _dependency_modules_from_pyproject(project_path: Path | None) -> tuple[str, 
     modules: list[str] = []
     for dependency in dependencies:
         if isinstance(dependency, str):
-            modules.extend(_dependency_modules_from_requirement(dependency))
+            modules.extend(
+                _dependency_modules_from_requirement(
+                    dependency,
+                    site_packages=site_packages,
+                )
+            )
     return tuple(dict.fromkeys(modules))
 
 
@@ -1401,7 +1462,12 @@ def _required_modules_with_dependencies(
         _dependency_modules_from_metadata(site_packages, distribution_names)
     )
     for project_path in dependency_projects:
-        dependency_modules.extend(_dependency_modules_from_pyproject(project_path))
+        dependency_modules.extend(
+            _dependency_modules_from_pyproject(
+                project_path,
+                site_packages=site_packages,
+            )
+        )
     return tuple(dict.fromkeys((*modules, *dependency_modules)))
 
 

--- a/test/test_orchestrate_page_support.py
+++ b/test/test_orchestrate_page_support.py
@@ -72,6 +72,17 @@ def _seed_fake_venv_modules(venv: Path, *modules: str) -> Path:
     return site_packages
 
 
+def _seed_dist_info(site_packages: Path, distribution: str, *, top_level: str = "") -> None:
+    dist_dir = site_packages / f"{distribution}-1.0.dist-info"
+    dist_dir.mkdir(parents=True, exist_ok=True)
+    (dist_dir / "METADATA").write_text(
+        f"Metadata-Version: 2.4\nName: {distribution}\n",
+        encoding="utf-8",
+    )
+    if top_level:
+        (dist_dir / "top_level.txt").write_text(top_level, encoding="utf-8")
+
+
 def test_build_install_and_run_snippets_embed_expected_values():
     env = SimpleNamespace(apps_path="/tmp/apps", app="demo_project", is_source_env=False)
 
@@ -1072,6 +1083,8 @@ def test_app_install_status_reports_missing_env_and_python(tmp_path: Path, monke
     (lib_root / "standalone.py").parent.mkdir(parents=True, exist_ok=True)
     (lib_root / "standalone.py").write_text("", encoding="utf-8")
     assert orchestrate_page_support._module_available_on_root(lib_root, "standalone") is True
+    (lib_root / "compiled.cpython-313-x86_64-linux-gnu.so").write_text("", encoding="utf-8")
+    assert orchestrate_page_support._module_available_on_root(lib_root, "compiled") is True
     assert orchestrate_page_support._drop_shadowed_best_node_non_rapids_rows(
         {
             "4:best-node": {"variant": "best-node", "node": "alpha"},
@@ -1283,6 +1296,69 @@ def test_app_install_status_uses_worker_project_dependencies(tmp_path: Path) -> 
     assert status["worker_ready"] is True
     assert "streamlit" not in status["worker_missing_modules"]
     assert "python_dotenv" not in status["worker_missing_modules"]
+
+
+def test_app_install_status_uses_installed_top_level_metadata_for_dependency_imports(tmp_path: Path) -> None:
+    active_app = tmp_path / "sb3_trainer_project"
+    worker_root = tmp_path / "wenv" / "sb3_trainer_worker"
+    active_app.mkdir(parents=True)
+    worker_root.mkdir(parents=True)
+    active_app_dependencies = [
+        "streamlit_code_editor>=0.1",
+        "legacy-cgi>=2",
+        "standard-imghdr>=3",
+        "sat_trajectory_project",
+    ]
+    (active_app / "pyproject.toml").write_text(
+        "[project]\n"
+        "name='sb3-trainer-project'\n"
+        f"dependencies={active_app_dependencies!r}\n",
+        encoding="utf-8",
+    )
+    (worker_root / "pyproject.toml").write_text(
+        "[project]\n"
+        "name='sb3-trainer-project'\n"
+        "dependencies=['sat_trajectory_project']\n",
+        encoding="utf-8",
+    )
+    manager_site = _seed_fake_venv_modules(
+        active_app / ".venv",
+        "agi_env",
+        "agi_node",
+        "agi_cluster",
+        "code_editor",
+        "cgi",
+        "imghdr",
+        "sat_trajectory",
+        "sat_trajectory_worker",
+    )
+    worker_site = _seed_fake_venv_modules(
+        worker_root / ".venv",
+        "agi_env",
+        "agi_node",
+        "sat_trajectory",
+        "sat_trajectory_worker",
+    )
+    for site in (manager_site, worker_site):
+        _seed_dist_info(
+            site,
+            "sat_trajectory_project",
+            top_level="sat_trajectory\nsat_trajectory_worker\n",
+        )
+    _seed_dist_info(manager_site, "streamlit_code_editor", top_level="code_editor\n")
+    _seed_dist_info(manager_site, "standard_imghdr", top_level="imghdr\n")
+    env = SimpleNamespace(active_app=active_app, wenv_abs=worker_root)
+
+    status = orchestrate_page_support.app_install_status(env)
+
+    assert orchestrate_page_support._dependency_modules_from_requirement("legacy-cgi>=2") == ("cgi",)
+    assert status["manager_ready"] is True
+    assert status["worker_ready"] is True
+    assert status["manager_missing_modules"] == ()
+    assert status["worker_missing_modules"] == ()
+    assert "streamlit_code_editor" not in status["manager_missing_modules"]
+    assert "standard_imghdr" not in status["manager_missing_modules"]
+    assert "sat_trajectory_project" not in status["worker_missing_modules"]
 
 
 def test_dependency_metadata_helpers_cover_error_edges(monkeypatch, tmp_path: Path) -> None:

--- a/test/test_orchestrate_page_support.py
+++ b/test/test_orchestrate_page_support.py
@@ -72,7 +72,13 @@ def _seed_fake_venv_modules(venv: Path, *modules: str) -> Path:
     return site_packages
 
 
-def _seed_dist_info(site_packages: Path, distribution: str, *, top_level: str = "") -> None:
+def _seed_dist_info(
+    site_packages: Path,
+    distribution: str,
+    *,
+    top_level: str = "",
+    record: str = "",
+) -> None:
     dist_dir = site_packages / f"{distribution}-1.0.dist-info"
     dist_dir.mkdir(parents=True, exist_ok=True)
     (dist_dir / "METADATA").write_text(
@@ -81,6 +87,8 @@ def _seed_dist_info(site_packages: Path, distribution: str, *, top_level: str = 
     )
     if top_level:
         (dist_dir / "top_level.txt").write_text(top_level, encoding="utf-8")
+    if record:
+        (dist_dir / "RECORD").write_text(record, encoding="utf-8")
 
 
 def test_build_install_and_run_snippets_embed_expected_values():
@@ -1361,6 +1369,40 @@ def test_app_install_status_uses_installed_top_level_metadata_for_dependency_imp
     assert "sat_trajectory_project" not in status["worker_missing_modules"]
 
 
+def test_app_install_status_skips_marker_inactive_dependencies_for_target_venv(tmp_path: Path) -> None:
+    active_app = tmp_path / "py312_project"
+    worker_root = tmp_path / "wenv" / "py312_worker"
+    active_app.mkdir(parents=True)
+    worker_root.mkdir(parents=True)
+    dependency = "standard-imghdr>=3.13; python_version >= '3.13'"
+    (active_app / "pyproject.toml").write_text(
+        "[project]\n"
+        "name='py312-project'\n"
+        f"dependencies={[dependency]!r}\n",
+        encoding="utf-8",
+    )
+    (worker_root / "pyproject.toml").write_text(
+        "[project]\n"
+        "name='py312-project'\n"
+        f"dependencies={[dependency]!r}\n",
+        encoding="utf-8",
+    )
+    manager_venv = active_app / ".venv"
+    worker_venv = worker_root / ".venv"
+    _seed_fake_venv_modules(manager_venv, "agi_env", "agi_node", "agi_cluster")
+    _seed_fake_venv_modules(worker_venv, "agi_env", "agi_node")
+    for venv in (manager_venv, worker_venv):
+        (venv / "pyvenv.cfg").write_text("version = 3.12.11\n", encoding="utf-8")
+    env = SimpleNamespace(active_app=active_app, wenv_abs=worker_root)
+
+    status = orchestrate_page_support.app_install_status(env)
+
+    assert status["manager_ready"] is True
+    assert status["worker_ready"] is True
+    assert "imghdr" not in status["manager_missing_modules"]
+    assert "imghdr" not in status["worker_missing_modules"]
+
+
 def test_dependency_metadata_helpers_cover_error_edges(monkeypatch, tmp_path: Path) -> None:
     assert orchestrate_page_support._project_distribution_name(None) is None
     assert orchestrate_page_support._project_distribution_name(tmp_path / "missing_project") is None
@@ -1382,6 +1424,22 @@ def test_dependency_metadata_helpers_cover_error_edges(monkeypatch, tmp_path: Pa
         "dask",
         "distributed",
     )
+    py312_venv = tmp_path / "py312-venv"
+    py312_venv.mkdir()
+    (py312_venv / "pyvenv.cfg").write_text("version = 3.12.9\n", encoding="utf-8")
+    py312_environment = orchestrate_page_support._marker_environment_for_venv(py312_venv)
+    assert py312_environment["python_version"] == "3.12"
+    assert (
+        orchestrate_page_support._dependency_modules_from_requirement(
+            "legacy-cgi>=2; python_version >= '3.13'",
+            marker_environment=py312_environment,
+        )
+        == ()
+    )
+    assert orchestrate_page_support._dependency_modules_from_requirement(
+        "python-dotenv>=1; python_version < '3.13'",
+        marker_environment=py312_environment,
+    ) == ("dotenv",)
 
     site_packages = tmp_path / "site-packages"
     site_packages.mkdir()
@@ -1394,6 +1452,15 @@ def test_dependency_metadata_helpers_cover_error_edges(monkeypatch, tmp_path: Pa
     )
     assert orchestrate_page_support._dependency_modules_from_metadata([site_packages], []) == ()
     assert orchestrate_page_support._dependency_modules_from_metadata([site_packages], ["demo"]) == ("dotenv",)
+    _seed_dist_info(
+        site_packages,
+        "dash-extensions",
+        record="dash_extensions/__init__.py,,\ndash_extensions/enrich.py,,\ndash_extensions-1.0.dist-info/METADATA,,\n",
+    )
+    assert orchestrate_page_support._dependency_modules_from_requirement(
+        "dash-extensions>=1",
+        site_packages=(site_packages,),
+    ) == ("dash_extensions",)
 
     nameless = site_packages / "nameless-1.0.dist-info" / "METADATA"
     nameless.parent.mkdir()


### PR DESCRIPTION
## Summary
- Resolve dependency health checks through installed top-level metadata before falling back to package-name guesses.
- Add aliases for legacy-cgi and standard-imghdr and recognize ABI-tagged compiled modules.
- Cover the sb3_trainer-style package/import mismatch regression.

## Validation
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_orchestrate_page_support.py
- git diff --check -- src/agilab/orchestrate/orchestrate_page_support.py test/test_orchestrate_page_support.py
- live sb3_trainer_project status check reports manager_ready=True and worker_ready=True