### PR TITLE
Fix dataset release archive mtimes

### DIFF
--- a/test/test_dataset_release_assets.py
+++ b/test/test_dataset_release_assets.py
@@ -73,9 +73,39 @@ def test_dataset_release_assets_writes_content_addressed_manifest_and_full_archi
     assert saved_manifest["datasets"][0]["path"] == "src/agilab/apps/builtin/demo_project/src/demo_worker/dataset.7z"
 
     with tarfile.open(archive_path, "r:gz") as tar:
+        tar_member = tar.getmember("src/agilab/apps/builtin/demo_project/src/demo_worker/dataset.7z")
+        assert tar_member.mtime == dataset_release_assets.ZIP_SAFE_MINIMUM_MTIME
         member = tar.extractfile("src/agilab/apps/builtin/demo_project/src/demo_worker/dataset.7z")
         assert member is not None
         assert member.read() == b"full dataset contents"
+    assert int.from_bytes(archive_path.read_bytes()[4:8], byteorder="little") == (
+        dataset_release_assets.ZIP_SAFE_MINIMUM_MTIME
+    )
+
+
+def test_dataset_release_assets_clamps_source_date_epoch_to_zip_safe_floor(tmp_path: Path, monkeypatch) -> None:
+    repo = tmp_path / "repo"
+    out = tmp_path / "out"
+    repo.mkdir()
+    out.mkdir()
+    _git(repo, "init")
+
+    dataset = repo / "data" / "dataset.csv"
+    dataset.parent.mkdir(parents=True)
+    dataset.write_text("x\n1\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    records = dataset_release_assets.discover_dataset_records(repo)
+    archive_path = out / "datasets.tar.gz"
+
+    monkeypatch.setenv("SOURCE_DATE_EPOCH", "0")
+    dataset_release_assets.write_dataset_archive(repo, records, archive_path)
+
+    with tarfile.open(archive_path, "r:gz") as tar:
+        tar_member = tar.getmember("data/dataset.csv")
+        assert tar_member.mtime == dataset_release_assets.ZIP_SAFE_MINIMUM_MTIME
+    assert int.from_bytes(archive_path.read_bytes()[4:8], byteorder="little") == (
+        dataset_release_assets.ZIP_SAFE_MINIMUM_MTIME
+    )
 
 
 def test_dataset_release_assets_detects_lfs_pointer_files(tmp_path: Path) -> None:

--- a/tools/dataset_release_assets.py
+++ b/tools/dataset_release_assets.py
@@ -15,6 +15,7 @@ from typing import Any
 
 
 SCHEMA = "agilab.dataset_release_assets.v1"
+ZIP_SAFE_MINIMUM_MTIME = 315532800  # 1980-01-01T00:00:00Z, the ZIP timestamp floor.
 DATASET_SUFFIXES = {".7z", ".csv", ".npz", ".parquet"}
 DATASET_DIR_PARTS = {"analysis_artifacts", "data", "dataset", "datasets", "sample_data"}
 DATASET_FILENAMES = {"dataset.7z"}
@@ -122,7 +123,20 @@ def write_manifest(manifest: dict[str, Any], path: Path) -> None:
     path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
+def release_asset_mtime() -> int:
+    """Return a reproducible timestamp that remains valid for ZIP-based installers."""
+
+    raw_epoch = os.environ.get("SOURCE_DATE_EPOCH")
+    if raw_epoch:
+        try:
+            return max(int(raw_epoch), ZIP_SAFE_MINIMUM_MTIME)
+        except ValueError:
+            return ZIP_SAFE_MINIMUM_MTIME
+    return ZIP_SAFE_MINIMUM_MTIME
+
+
 def write_dataset_archive(repo_root: Path, records: list[dict[str, Any]], archive_path: Path) -> None:
+    archive_mtime = release_asset_mtime()
     tar_buffer = io.BytesIO()
     with tarfile.open(fileobj=tar_buffer, mode="w") as tar:
         for record in records:
@@ -133,13 +147,13 @@ def write_dataset_archive(repo_root: Path, records: list[dict[str, Any]], archiv
             tar_info.gid = 0
             tar_info.uname = ""
             tar_info.gname = ""
-            tar_info.mtime = 0
+            tar_info.mtime = archive_mtime
             tar_info.mode = 0o644
             with absolute_path.open("rb") as handle:
                 tar.addfile(tar_info, handle)
 
     with archive_path.open("wb") as output:
-        with gzip.GzipFile(filename="", mode="wb", fileobj=output, mtime=0) as gzip_file:
+        with gzip.GzipFile(filename="", mode="wb", fileobj=output, mtime=archive_mtime) as gzip_file:
             gzip_file.write(tar_buffer.getvalue())
 
 


### PR DESCRIPTION
## Summary
- keep dataset release assets deterministic while using a ZIP-safe timestamp floor
- clamp SOURCE_DATE_EPOCH below 1980-01-01 for tar members and gzip headers
- add regression coverage for archive member and gzip mtimes

## Validation
- uv --preview-features extra-build-dependencies run python -m pytest -q -o addopts='' test/test_dataset_release_assets.py