### PR TITLE
[codex] Add agi-core owner guard

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -15,6 +15,7 @@ guard_state="$(
 DOCS_CHANGED=1
 RELEASE_PROOF_CHANGED=1
 APP_CONTRACTS_CHANGED=1
+AGI_CORE_PROTECTED_CHANGED=1
 MIXED_SCOPE=0
 SCOPE_COUNT=0
 SCOPE_LIMIT=2
@@ -26,6 +27,7 @@ while IFS='=' read -r key value; do
     DOCS_CHANGED) DOCS_CHANGED="$value" ;;
     RELEASE_PROOF_CHANGED) RELEASE_PROOF_CHANGED="$value" ;;
     APP_CONTRACTS_CHANGED) APP_CONTRACTS_CHANGED="$value" ;;
+    AGI_CORE_PROTECTED_CHANGED) AGI_CORE_PROTECTED_CHANGED="$value" ;;
     MIXED_SCOPE) MIXED_SCOPE="$value" ;;
     SCOPE_COUNT) SCOPE_COUNT="$value" ;;
     SCOPE_LIMIT) SCOPE_LIMIT="$value" ;;
@@ -43,6 +45,18 @@ if [[ "${MIXED_SCOPE:-0}" == "1" && "${AGILAB_ALLOW_MIXED_SCOPE_PUSH:-}" != "1" 
   echo "[agilab pre-push] pushed changes span ${SCOPE_COUNT} non-infrastructure scopes; limit is ${SCOPE_LIMIT}." >&2
   echo "[agilab pre-push] Split the work, use ./dev task-worktree <branch-name>, or set AGILAB_ALLOW_MIXED_SCOPE_PUSH=1 with an explicit reason." >&2
   exit 1
+fi
+
+if [[ "${AGI_CORE_PROTECTED_CHANGED:-1}" == "1" ]]; then
+  agi_core_actor="${AGILAB_CORE_CHANGE_ACTOR:-${GITHUB_ACTOR:-}}"
+  if [[ -z "$agi_core_actor" ]]; then
+    agi_core_actor="$(git config --get github.user || true)"
+  fi
+  uv --preview-features extra-build-dependencies run python tools/agi_core_change_guard.py \
+    --actor "$agi_core_actor" \
+    --protected-changed
+else
+  echo "[agilab pre-push] protected agi-core paths unchanged; skipping owner guard." >&2
 fi
 
 if [[ "${DOCS_CHANGED:-1}" == "1" ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
 
       - name: Guard against committed docs/html artifacts
         run: |
@@ -43,6 +45,19 @@ jobs:
             echo "Please remove these symlinks or replace with real files." >&2
             exit 1
           fi
+
+      - name: Guard agi-core owner
+        if: github.event_name == 'pull_request' || github.event_name == 'push'
+        env:
+          AGILAB_CORE_CHANGE_ACTOR: ${{ github.actor }}
+          AGILAB_CORE_CHANGE_BASE: ${{ github.event.pull_request.base.sha || github.event.before }}
+          AGILAB_CORE_CHANGE_HEAD: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          python tools/agi_core_change_guard.py \
+            --actor "$AGILAB_CORE_CHANGE_ACTOR" \
+            --base-ref "$AGILAB_CORE_CHANGE_BASE" \
+            --head-ref "$AGILAB_CORE_CHANGE_HEAD"
 
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
@@ -74,6 +89,7 @@ jobs:
             tools/release_status.py \
             tools/release_handoff.py \
             tools/release_handoff_guard.py \
+            tools/agi_core_change_guard.py \
             tools/app_contract_matrix.py \
             tools/ui_robot_evidence.py \
             tools/ui_robot_matrix_aggregate.py \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -349,6 +349,11 @@ Use this runbook whenever you:
   - which shared files/modules need to change
   - the expected blast radius across apps/workflows
   - the test or regression plan you will use after approval
+- **agi-core owner gate**: Treat `src/agilab/core/agi-core/**` as owner-protected even after
+  shared-core approval. Only GitHub actor `jpmorard` may change this path. The local pre-push
+  hook and repo-guardrails CI run `tools/agi_core_change_guard.py`; agents should not stage or
+  push `agi-core` changes for any other actor. Use `AGILAB_CORE_CHANGE_ACTOR=jpmorard` only when
+  the real approving/publishing actor is jpmorard.
 - **No silent fallbacks**: Do not introduce automatic API client fallbacks
   (`chat.completions` ↔ `responses`, runtime parameter rewrites, etc.). Detect missing
   capabilities up-front and fail with a clear, actionable error.

--- a/test/test_agi_core_change_guard.py
+++ b/test/test_agi_core_change_guard.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "tools" / "agi_core_change_guard.py"
+
+spec = importlib.util.spec_from_file_location("agi_core_change_guard", MODULE_PATH)
+assert spec is not None and spec.loader is not None
+guard = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = guard
+spec.loader.exec_module(guard)
+
+
+def test_protected_path_detection_is_limited_to_agi_core() -> None:
+    assert guard.protected_changed_files(
+        [
+            "src/agilab/core/agi-core/src/agi_core/runtime.py",
+            "src/agilab/core/agi-node/src/agi_node/runtime.py",
+            "test/test_agi_core_change_guard.py",
+        ]
+    ) == ("src/agilab/core/agi-core/src/agi_core/runtime.py",)
+
+
+def test_jpmorard_can_change_protected_agi_core_path() -> None:
+    result = guard.evaluate(
+        ["src/agilab/core/agi-core/pyproject.toml"],
+        actor="jpmorard",
+    )
+
+    assert result.passed
+    assert result.actor_allowed
+
+
+def test_other_actor_is_blocked_for_protected_agi_core_path() -> None:
+    result = guard.evaluate(
+        ["src/agilab/core/agi-core/pyproject.toml"],
+        actor="other-user",
+    )
+
+    assert not result.passed
+    assert not result.actor_allowed
+    assert "other-user" in guard.render_result(result)
+    assert "src/agilab/core/agi-core/pyproject.toml" in guard.render_result(result)
+
+
+def test_other_actor_can_change_unprotected_paths() -> None:
+    result = guard.evaluate(
+        ["src/agilab/core/agi-node/pyproject.toml"],
+        actor="other-user",
+    )
+
+    assert result.passed

--- a/test/test_ci_workflow.py
+++ b/test/test_ci_workflow.py
@@ -171,6 +171,11 @@ def test_ci_workflow_includes_minimal_first_proof_contract() -> None:
     assert "tools/app_contract_matrix.py --output app-contract-matrix.json --quiet" in text
     assert "app-contract-matrix.json" in text
     assert "tools/ui_robot_matrix_aggregate.py" in text
+    assert "Guard agi-core owner" in text
+    assert "tools/agi_core_change_guard.py" in text
+    assert "AGILAB_CORE_CHANGE_ACTOR: ${{ github.actor }}" in text
+    assert "--base-ref \"$AGILAB_CORE_CHANGE_BASE\"" in text
+    assert "--head-ref \"$AGILAB_CORE_CHANGE_HEAD\"" in text
 
 
 def test_validation_workflows_cancel_superseded_branch_runs() -> None:

--- a/test/test_pre_push_changed_files.py
+++ b/test/test_pre_push_changed_files.py
@@ -21,6 +21,7 @@ def test_classify_source_only_change_skips_docs_and_release_proof_guards():
     assert not state.docs_changed
     assert not state.release_proof_changed
     assert not state.app_contracts_changed
+    assert not state.agi_core_protected_changed
 
 
 def test_classify_docs_source_change_runs_docs_guard_only():
@@ -53,6 +54,18 @@ def test_classify_app_contract_change_runs_app_contract_guard_only():
     assert not state.docs_changed
     assert not state.release_proof_changed
     assert state.app_contracts_changed
+    assert not state.agi_core_protected_changed
+
+
+def test_classify_agi_core_change_runs_owner_guard_only():
+    state = pre_push_changed_files.classify_changed_files(
+        ["src/agilab/core/agi-core/src/agi_core/runtime.py"]
+    )
+
+    assert not state.docs_changed
+    assert not state.release_proof_changed
+    assert not state.app_contracts_changed
+    assert state.agi_core_protected_changed
 
 
 def test_classify_public_app_catalog_change_runs_docs_and_app_contract_guards():
@@ -112,6 +125,7 @@ def test_render_shell_is_eval_friendly():
         "DOCS_CHANGED=1",
         "RELEASE_PROOF_CHANGED=1",
         "APP_CONTRACTS_CHANGED=0",
+        "AGI_CORE_PROTECTED_CHANGED=0",
         "MIXED_SCOPE=0",
         "SCOPE_COUNT=0",
         "SCOPE_LIMIT=2",

--- a/tools/agi_core_change_guard.py
+++ b/tools/agi_core_change_guard.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Fail closed when protected agi-core paths are changed by other actors."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ZERO_SHA = "0" * 40
+EMPTY_TREE_SHA = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+DEFAULT_ALLOWED_ACTORS = ("jpmorard",)
+PROTECTED_PREFIXES = ("src/agilab/core/agi-core/",)
+PROTECTED_FILES = ("src/agilab/core/agi-core",)
+
+
+@dataclass(frozen=True)
+class GuardResult:
+    actor: str
+    allowed_actors: tuple[str, ...]
+    protected_files: tuple[str, ...]
+
+    @property
+    def actor_allowed(self) -> bool:
+        normalized_actor = normalize_actor(self.actor)
+        return bool(normalized_actor) and normalized_actor in {
+            normalize_actor(actor) for actor in self.allowed_actors
+        }
+
+    @property
+    def passed(self) -> bool:
+        return not self.protected_files or self.actor_allowed
+
+
+def normalize_actor(actor: str | None) -> str:
+    return (actor or "").strip().lower()
+
+
+def is_protected_path(path: str) -> bool:
+    normalized = path.strip().replace("\\", "/")
+    return normalized in PROTECTED_FILES or any(
+        normalized.startswith(prefix) for prefix in PROTECTED_PREFIXES
+    )
+
+
+def protected_changed_files(paths: Sequence[str]) -> tuple[str, ...]:
+    return tuple(sorted({path for path in paths if is_protected_path(path)}))
+
+
+def _run_git(args: Sequence[str], *, repo_root: Path = REPO_ROOT) -> str:
+    completed = subprocess.run(
+        ["git", *args],
+        cwd=repo_root,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    return completed.stdout.strip()
+
+
+def changed_files_between(base_ref: str, head_ref: str, *, repo_root: Path = REPO_ROOT) -> tuple[str, ...]:
+    base = EMPTY_TREE_SHA if normalize_actor(base_ref) == ZERO_SHA else base_ref
+    output = _run_git(
+        ["diff", "--name-only", "--diff-filter=ACMR", base, head_ref],
+        repo_root=repo_root,
+    )
+    return tuple(line.strip() for line in output.splitlines() if line.strip())
+
+
+def read_changed_files(path: Path) -> tuple[str, ...]:
+    return tuple(line.strip() for line in path.read_text(encoding="utf-8").splitlines() if line.strip())
+
+
+def evaluate(
+    changed_files: Sequence[str],
+    *,
+    actor: str,
+    allowed_actors: Sequence[str] = DEFAULT_ALLOWED_ACTORS,
+) -> GuardResult:
+    return GuardResult(
+        actor=actor,
+        allowed_actors=tuple(allowed_actors),
+        protected_files=protected_changed_files(changed_files),
+    )
+
+
+def render_result(result: GuardResult) -> str:
+    if result.passed:
+        if result.protected_files:
+            return f"agi-core owner guard: allowed actor {result.actor!r}"
+        return "agi-core owner guard: no protected agi-core changes"
+
+    actor = result.actor or "(missing)"
+    lines = [
+        "agi-core owner guard: blocked protected agi-core change",
+        f"actor: {actor}",
+        "allowed actors: " + ", ".join(result.allowed_actors),
+        "protected files:",
+    ]
+    lines.extend(f"- {path}" for path in result.protected_files)
+    return "\n".join(lines)
+
+
+def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--actor",
+        default=os.environ.get("AGILAB_CORE_CHANGE_ACTOR") or os.environ.get("GITHUB_ACTOR") or "",
+        help="Actor attempting the change. Defaults to AGILAB_CORE_CHANGE_ACTOR or GITHUB_ACTOR.",
+    )
+    parser.add_argument(
+        "--allowed-actor",
+        action="append",
+        default=None,
+        help="Actor allowed to change agi-core. May be repeated. Defaults to jpmorard.",
+    )
+    parser.add_argument("--changed-file", action="append", default=[])
+    parser.add_argument("--changed-files", type=Path)
+    parser.add_argument("--base-ref", help="Base ref for git diff detection.")
+    parser.add_argument("--head-ref", help="Head ref for git diff detection.")
+    parser.add_argument(
+        "--protected-changed",
+        action="store_true",
+        help="Evaluate as if at least one protected agi-core path changed.",
+    )
+    return parser.parse_args(argv)
+
+
+def _changed_files_from_args(args: argparse.Namespace) -> tuple[str, ...]:
+    paths: list[str] = list(args.changed_file or [])
+    if args.changed_files:
+        paths.extend(read_changed_files(args.changed_files))
+    if args.base_ref or args.head_ref:
+        if not args.base_ref or not args.head_ref:
+            raise SystemExit("--base-ref and --head-ref must be provided together")
+        paths.extend(changed_files_between(args.base_ref, args.head_ref))
+    if args.protected_changed:
+        paths.append(PROTECTED_PREFIXES[0] + "__guard_probe__")
+    return tuple(paths)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    allowed_actors = tuple(args.allowed_actor or DEFAULT_ALLOWED_ACTORS)
+    result = evaluate(
+        _changed_files_from_args(args),
+        actor=args.actor,
+        allowed_actors=allowed_actors,
+    )
+    output = render_result(result)
+    stream = sys.stdout if result.passed else sys.stderr
+    print(output, file=stream)
+    return 0 if result.passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/pre_push_changed_files.py
+++ b/tools/pre_push_changed_files.py
@@ -50,6 +50,8 @@ APP_CONTRACT_GUARD_FILES = {
     "tools/app_contract_matrix.py",
     "tools/package_split_contract.py",
 }
+AGI_CORE_PROTECTED_PREFIXES = ("src/agilab/core/agi-core/",)
+AGI_CORE_PROTECTED_FILES = {"src/agilab/core/agi-core"}
 DEFAULT_PUSH_MAX_SCOPES = worktree_scope_guard.DEFAULT_MAX_SCOPES
 PUSH_SCOPE_ALLOWED = worktree_scope_guard.DEFAULT_ALLOWED_SCOPES
 
@@ -63,6 +65,7 @@ class GuardState:
     docs_changed: bool
     release_proof_changed: bool
     app_contracts_changed: bool
+    agi_core_protected_changed: bool
     mixed_scope: bool = False
     scope_count: int = 0
     scope_limit: int = DEFAULT_PUSH_MAX_SCOPES
@@ -153,6 +156,10 @@ def classify_changed_files(
         _matches(path, prefixes=APP_CONTRACT_GUARD_PREFIXES, files=APP_CONTRACT_GUARD_FILES)
         for path in changed_files
     )
+    agi_core_protected_changed = any(
+        _matches(path, prefixes=AGI_CORE_PROTECTED_PREFIXES, files=AGI_CORE_PROTECTED_FILES)
+        for path in changed_files
+    )
     scope_report = worktree_scope_guard.analyze_scope(
         changed_files,
         max_scopes=max_scopes,
@@ -163,6 +170,7 @@ def classify_changed_files(
         docs_changed=docs_changed,
         release_proof_changed=release_proof_changed,
         app_contracts_changed=app_contracts_changed,
+        agi_core_protected_changed=agi_core_protected_changed,
         mixed_scope=scope_report.mixed,
         scope_count=len(scope_report.counted_scopes),
         scope_limit=scope_report.max_scopes,
@@ -175,6 +183,7 @@ def failed_detection_state(error: Exception) -> GuardState:
         docs_changed=True,
         release_proof_changed=True,
         app_contracts_changed=True,
+        agi_core_protected_changed=True,
         mixed_scope=True,
         detection_failed=True,
         error=str(error),
@@ -190,6 +199,7 @@ def render_shell(state: GuardState) -> str:
         f"DOCS_CHANGED={_shell_bool(state.docs_changed)}",
         f"RELEASE_PROOF_CHANGED={_shell_bool(state.release_proof_changed)}",
         f"APP_CONTRACTS_CHANGED={_shell_bool(state.app_contracts_changed)}",
+        f"AGI_CORE_PROTECTED_CHANGED={_shell_bool(state.agi_core_protected_changed)}",
         f"MIXED_SCOPE={_shell_bool(state.mixed_scope)}",
         f"SCOPE_COUNT={state.scope_count}",
         f"SCOPE_LIMIT={state.scope_limit}",


### PR DESCRIPTION
## Summary

- Add `tools/agi_core_change_guard.py` to fail closed when `src/agilab/core/agi-core/**` changes are attempted by any actor other than `jpmorard`.
- Wire the guard into the local pre-push path and `repo-guardrails` CI.
- Document the owner gate in `AGENTS.md` and add focused tests for allowed, blocked, and unprotected paths.

## Validation

- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_ci_workflow.py test/test_agi_core_change_guard.py test/test_pre_push_changed_files.py`
- `uv --preview-features extra-build-dependencies run ruff check tools/agi_core_change_guard.py tools/pre_push_changed_files.py test/test_agi_core_change_guard.py test/test_pre_push_changed_files.py test/test_ci_workflow.py`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --staged`
- `python3 tools/agent_instruction_contract.py --check`
- Manual guard checks for blocked `other-user` and allowed `jpmorard` paths