### PR TITLE
Fix worker post-install environment resolution

### DIFF
--- a/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/post_install.py
+++ b/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/post_install.py
@@ -37,16 +37,17 @@ def _packaged_apps_path() -> Path | None:
         import agilab
     except ImportError:
         return None
-    return Path(agilab.__file__).resolve().parent / "apps"
+    package_file = getattr(agilab, "__file__", None)
+    if package_file is None:
+        return None
+    return Path(package_file).resolve().parent / "apps"
 
 
 def _resolve_post_install_manager_app(app_arg: Path) -> tuple[Path | None, str]:
     if app_arg.name.endswith("_project"):
         return app_arg.parent, app_arg.name
     if app_arg.name.endswith("_worker"):
-        project_name = app_arg.name.removesuffix("_worker") + "_project"
-        apps_path = _packaged_apps_path()
-        return apps_path, project_name
+        return None, app_arg.name
     return app_arg.parent, app_arg.name
 
 

--- a/src/agilab/core/test/test_agi_dispatcher_scripts.py
+++ b/src/agilab/core/test/test_agi_dispatcher_scripts.py
@@ -584,9 +584,8 @@ def test_post_build_env_uses_parent_directory_and_name(monkeypatch, tmp_path):
     assert captured == {"apps_path": tmp_path, "app": "demo_project"}
 
 
-def test_post_build_env_worker_name_uses_packaged_apps_root(monkeypatch, tmp_path):
+def test_post_build_env_worker_name_uses_worker_environment(monkeypatch, tmp_path):
     captured = {}
-    packaged_apps = tmp_path / "site-packages" / "agilab" / "apps"
 
     class DummyEnv:
         def __init__(self, *, apps_path, app):
@@ -594,11 +593,17 @@ def test_post_build_env_worker_name_uses_packaged_apps_root(monkeypatch, tmp_pat
             captured["app"] = app
 
     monkeypatch.setattr(post_mod, "AgiEnv", DummyEnv)
-    monkeypatch.setattr(post_mod, "_packaged_apps_path", lambda: packaged_apps)
 
     post_mod._build_env(tmp_path / "wenv" / "demo_worker")
 
-    assert captured == {"apps_path": packaged_apps, "app": "demo_project"}
+    assert captured == {"apps_path": None, "app": "demo_worker"}
+
+
+def test_packaged_apps_path_tolerates_namespace_agilab_package(monkeypatch):
+    fake_agilab = SimpleNamespace(__file__=None)
+    monkeypatch.setitem(sys.modules, "agilab", fake_agilab)
+
+    assert post_mod._packaged_apps_path() is None
 
 
 def test_post_extract_archive_uses_py7zr_extractall(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- keep `_worker` post-install arguments in worker-env mode instead of forcing packaged manager app resolution
- tolerate namespace `agilab` packages with `__file__ = None`
- add regression coverage for the remote worker post-install path

## Validation
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' --import-mode=importlib src/agilab/core/test/test_agi_dispatcher_scripts.py`
- `uv --preview-features extra-build-dependencies run --no-sync pytest -q -o addopts='' --import-mode=importlib src/agilab/core/test`
