### PR TITLE
[codex] Remove app cluster runtime dependency

### DIFF
--- a/src/agilab/apps/builtin/data_quality_gate_project/pyproject.toml
+++ b/src/agilab/apps/builtin/data_quality_gate_project/pyproject.toml
@@ -3,7 +3,7 @@ name = "data_quality_gate_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILAB data contract and drift gate app with promotion evidence"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "streamlit>=1.58,<2"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "streamlit>=1.58,<2"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"
@@ -17,7 +17,6 @@ Changelog = "https://github.com/ThalesGroup/agilab/releases"
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }
 agi-node = { path = "../../../core/agi-node", editable = true }
-agi-cluster = { path = "../../../core/agi-cluster", editable = true }
 
 [build-system]
 requires = ["setuptools"]

--- a/src/agilab/apps/builtin/data_quality_gate_project/src/data_quality_gate_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/data_quality_gate_project/src/data_quality_gate_worker/pyproject.toml
@@ -3,12 +3,11 @@ name = "data_quality_gate_project"
 version = "2026.05.30.post1"
 description = "Worker package for the AGILAB data quality gate app"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }
 agi-node = { path = "../../../../../core/agi-node", editable = true }
-agi-cluster = { path = "../../../../../core/agi-cluster", editable = true }
 
 [build-system]
 requires = ["setuptools"]

--- a/src/agilab/apps/builtin/execution_pandas_project/pyproject.toml
+++ b/src/agilab/apps/builtin/execution_pandas_project/pyproject.toml
@@ -3,12 +3,11 @@ name = "execution_pandas_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILab execution playground using PandasWorker"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "numpy>=2.2,<3", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "streamlit>=1.58,<2"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "numpy>=2.2,<3", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "streamlit>=1.58,<2"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }
 agi-node = { path = "../../../core/agi-node", editable = true }
-agi-cluster = { path = "../../../core/agi-cluster", editable = true }
 
 [build-system]
 requires = ["setuptools"]

--- a/src/agilab/apps/builtin/execution_pandas_project/src/execution_pandas_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/execution_pandas_project/src/execution_pandas_worker/pyproject.toml
@@ -3,12 +3,11 @@ name = "execution_pandas_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILab execution playground using PandasWorker"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "numpy>=2.2,<3", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "numpy>=2.2,<3", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }
 agi-node = { path = "../../../../../core/agi-node", editable = true }
-agi-cluster = { path = "../../../../../core/agi-cluster", editable = true }
 
 [build-system]
 requires = ["setuptools", "cython"]

--- a/src/agilab/apps/builtin/execution_polars_project/pyproject.toml
+++ b/src/agilab/apps/builtin/execution_polars_project/pyproject.toml
@@ -3,12 +3,11 @@ name = "execution_polars_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILab execution playground using PolarsWorker"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "polars>=1.35,<2", "pydantic>=2.11,<2.13", "streamlit>=1.58,<2"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "polars>=1.35,<2", "pydantic>=2.11,<2.13", "streamlit>=1.58,<2"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }
 agi-node = { path = "../../../core/agi-node", editable = true }
-agi-cluster = { path = "../../../core/agi-cluster", editable = true }
 
 [build-system]
 requires = ["setuptools"]

--- a/src/agilab/apps/builtin/execution_polars_project/src/execution_polars_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/execution_polars_project/src/execution_polars_worker/pyproject.toml
@@ -3,12 +3,11 @@ name = "execution_polars_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILab execution playground using PolarsWorker"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "polars>=1.35,<2", "pydantic>=2.11,<2.13"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "polars>=1.35,<2", "pydantic>=2.11,<2.13"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }
 agi-node = { path = "../../../../../core/agi-node", editable = true }
-agi-cluster = { path = "../../../../../core/agi-cluster", editable = true }
 
 [build-system]
 requires = ["setuptools"]

--- a/src/agilab/apps/builtin/flight_telemetry_project/pyproject.toml
+++ b/src/agilab/apps/builtin/flight_telemetry_project/pyproject.toml
@@ -3,7 +3,7 @@ name = "flight_telemetry_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILab example app (flight-telemetry preprocessing)"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "polars[rtcompat]>=1.35,<2", "pydantic>=2.11,<2.13", "py7zr>=1.1,<1.2", "streamlit>=1.58,<2"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "polars[rtcompat]>=1.35,<2", "pydantic>=2.11,<2.13", "py7zr>=1.1,<1.2", "streamlit>=1.58,<2"]
 
 [tool.agilab]
 runtime_target = "flight_telemetry"
@@ -11,7 +11,6 @@ runtime_target = "flight_telemetry"
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }
 agi-node = { path = "../../../core/agi-node", editable = true }
-agi-cluster = { path = "../../../core/agi-cluster", editable = true }
 
 [build-system]
 requires = ["setuptools"]

--- a/src/agilab/apps/builtin/flight_telemetry_project/src/flight_telemetry_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/flight_telemetry_project/src/flight_telemetry_worker/pyproject.toml
@@ -4,7 +4,7 @@ version = "2026.05.30.post1"
 description = ""
 requires-python = ">=3.11,<3.14"
 readme = "README.md"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "polars>=1.35,<2", "pydantic>=2.11,<2.13"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "polars>=1.35,<2", "pydantic>=2.11,<2.13"]
 
 [[project.authors]]
 name = "Jean-Pierre Morard"
@@ -37,7 +37,6 @@ polars-worker = []
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }
 agi-node = { path = "../../../../../core/agi-node", editable = true }
-agi-cluster = { path = "../../../../../core/agi-cluster", editable = true }
 
 [build-system]
 requires = ["setuptools", "cython"]

--- a/src/agilab/apps/builtin/minimal_app_project/pyproject.toml
+++ b/src/agilab/apps/builtin/minimal_app_project/pyproject.toml
@@ -3,12 +3,11 @@ name = "minimal_app_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILab example app template (minimal manager + worker)"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "polars>=1.35,<2", "pydantic>=2.11,<2.13", "streamlit>=1.58,<2"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "polars>=1.35,<2", "pydantic>=2.11,<2.13", "streamlit>=1.58,<2"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }
 agi-node = { path = "../../../core/agi-node", editable = true }
-agi-cluster = { path = "../../../core/agi-cluster", editable = true }
 
 [build-system]
 requires = ["setuptools"]

--- a/src/agilab/apps/builtin/minimal_app_project/src/minimal_app_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/minimal_app_project/src/minimal_app_worker/pyproject.toml
@@ -3,12 +3,11 @@ name = "minimal_app_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILab example app template (minimal manager + worker)"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "polars>=1.35,<2", "pydantic>=2.11,<2.13"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "polars>=1.35,<2", "pydantic>=2.11,<2.13"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }
 agi-node = { path = "../../../../../core/agi-node", editable = true }
-agi-cluster = { path = "../../../../../core/agi-cluster", editable = true }
 
 [build-system]
 requires = ["setuptools"]

--- a/src/agilab/apps/builtin/mission_decision_project/pyproject.toml
+++ b/src/agilab/apps/builtin/mission_decision_project/pyproject.toml
@@ -3,7 +3,7 @@ name = "mission_decision_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILAB Mission Decision autonomous demo"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "streamlit>=1.58,<2"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "streamlit>=1.58,<2"]
 
 [tool.agilab]
 runtime_target = "mission_decision"
@@ -11,7 +11,6 @@ runtime_target = "mission_decision"
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }
 agi-node = { path = "../../../core/agi-node", editable = true }
-agi-cluster = { path = "../../../core/agi-cluster", editable = true }
 
 [tool.setuptools.package-data]
 mission_decision = ["sample_data/*.json"]

--- a/src/agilab/apps/builtin/mission_decision_project/src/mission_decision_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/mission_decision_project/src/mission_decision_worker/pyproject.toml
@@ -3,12 +3,11 @@ name = "mission_decision_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILAB Mission Decision autonomous demo"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }
 agi-node = { path = "../../../../../core/agi-node", editable = true }
-agi-cluster = { path = "../../../../../core/agi-cluster", editable = true }
 
 [tool.setuptools.package-data]
 mission_decision = ["sample_data/*.json"]

--- a/src/agilab/apps/builtin/multi_app_dag_project/pyproject.toml
+++ b/src/agilab/apps/builtin/multi_app_dag_project/pyproject.toml
@@ -3,12 +3,11 @@ name = "multi_app_dag_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILAB multi-app DAG example project"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "polars>=1.35,<2", "pydantic>=2.11,<2.13", "streamlit>=1.58,<2"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "polars>=1.35,<2", "pydantic>=2.11,<2.13", "streamlit>=1.58,<2"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }
 agi-node = { path = "../../../core/agi-node", editable = true }
-agi-cluster = { path = "../../../core/agi-cluster", editable = true }
 
 [build-system]
 requires = ["setuptools"]

--- a/src/agilab/apps/builtin/multi_app_dag_project/src/multi_app_dag_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/multi_app_dag_project/src/multi_app_dag_worker/pyproject.toml
@@ -2,12 +2,11 @@
 name = "multi_app_dag_worker"
 version = "2026.05.30.post1"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "polars>=1.35,<2"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "polars>=1.35,<2"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }
 agi-node = { path = "../../../../../core/agi-node", editable = true }
-agi-cluster = { path = "../../../../../core/agi-cluster", editable = true }
 
 [build-system]
 requires = ["setuptools", "cython"]

--- a/src/agilab/apps/builtin/pytorch_playground_project/pyproject.toml
+++ b/src/agilab/apps/builtin/pytorch_playground_project/pyproject.toml
@@ -7,7 +7,6 @@ requires-python = ">=3.12"
 dependencies = [
     "agi-env>=2026.05.31",
     "agi-node>=2026.05.31",
-    "agi-cluster>=2026.05.31",
     "agi-gui>=2026.05.31",
     "agi-web>=2026.05.31",
     "numpy>=2.2,<3",
@@ -29,7 +28,6 @@ Changelog = "https://github.com/ThalesGroup/agilab/releases"
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }
 agi-node = { path = "../../../core/agi-node", editable = true }
-agi-cluster = { path = "../../../core/agi-cluster", editable = true }
 agi-gui = { path = "../../../lib/agi-gui", editable = true }
 agi-web = { path = "../../../lib/agi-web", editable = true }
 

--- a/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground_worker/pyproject.toml
@@ -6,7 +6,6 @@ requires-python = ">=3.12"
 dependencies = [
     "agi-env>=2026.05.31",
     "agi-node>=2026.05.31",
-    "agi-cluster>=2026.05.31",
     "numpy>=2.2,<3",
     "pandas>=2.3.0,<4",
     "pydantic>=2.11,<2.13",
@@ -16,7 +15,6 @@ dependencies = [
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }
 agi-node = { path = "../../../../../core/agi-node", editable = true }
-agi-cluster = { path = "../../../../../core/agi-cluster", editable = true }
 
 [build-system]
 requires = ["setuptools"]

--- a/src/agilab/apps/builtin/r_runtime_bridge_project/pyproject.toml
+++ b/src/agilab/apps/builtin/r_runtime_bridge_project/pyproject.toml
@@ -4,7 +4,7 @@ version = "2026.05.30.post1"
 description = "Built-in AGILAB smoke app for Rscript JSON/artifact stage execution"
 readme = "README.md"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "streamlit>=1.58,<2"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "streamlit>=1.58,<2"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"
@@ -24,7 +24,6 @@ Changelog = "https://github.com/ThalesGroup/agilab/releases"
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }
 agi-node = { path = "../../../core/agi-node", editable = true }
-agi-cluster = { path = "../../../core/agi-cluster", editable = true }
 
 [build-system]
 requires = ["setuptools"]

--- a/src/agilab/apps/builtin/r_runtime_bridge_project/src/r_runtime_bridge_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/r_runtime_bridge_project/src/r_runtime_bridge_worker/pyproject.toml
@@ -3,12 +3,11 @@ name = "r_runtime_bridge_project"
 version = "2026.05.30.post1"
 description = "Worker package for the AGILAB R runtime bridge app"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }
 agi-node = { path = "../../../../../core/agi-node", editable = true }
-agi-cluster = { path = "../../../../../core/agi-cluster", editable = true }
 
 [build-system]
 requires = ["setuptools"]

--- a/src/agilab/apps/builtin/sklearn_pipeline_project/pyproject.toml
+++ b/src/agilab/apps/builtin/sklearn_pipeline_project/pyproject.toml
@@ -3,7 +3,7 @@ name = "sklearn_pipeline_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILAB scikit-learn pipeline app with model, metrics, predictions, and evidence manifest"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "joblib>=1.5,<2", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "scikit-learn>=1.7.2,<2", "streamlit>=1.58,<2"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "joblib>=1.5,<2", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "scikit-learn>=1.7.2,<2", "streamlit>=1.58,<2"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"
@@ -23,7 +23,6 @@ Changelog = "https://github.com/ThalesGroup/agilab/releases"
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }
 agi-node = { path = "../../../core/agi-node", editable = true }
-agi-cluster = { path = "../../../core/agi-cluster", editable = true }
 
 [build-system]
 requires = ["setuptools"]

--- a/src/agilab/apps/builtin/sklearn_pipeline_project/src/sklearn_pipeline_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/sklearn_pipeline_project/src/sklearn_pipeline_worker/pyproject.toml
@@ -3,12 +3,11 @@ name = "sklearn_pipeline_worker"
 version = "2026.05.30.post1"
 description = "Worker package for the AGILAB scikit-learn pipeline app"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "joblib>=1.5,<2", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "scikit-learn>=1.7.2,<2"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "joblib>=1.5,<2", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "scikit-learn>=1.7.2,<2"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }
 agi-node = { path = "../../../../../core/agi-node", editable = true }
-agi-cluster = { path = "../../../../../core/agi-cluster", editable = true }
 
 [build-system]
 requires = ["setuptools"]

--- a/src/agilab/apps/builtin/tescia_diagnostic_project/pyproject.toml
+++ b/src/agilab/apps/builtin/tescia_diagnostic_project/pyproject.toml
@@ -3,12 +3,11 @@ name = "tescia_diagnostic_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILAB TeSciA-style diagnostic reasoning example"
 requires-python = ">=3.13"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "streamlit>=1.58,<2"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "streamlit>=1.58,<2"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }
 agi-node = { path = "../../../core/agi-node", editable = true }
-agi-cluster = { path = "../../../core/agi-cluster", editable = true }
 
 [tool.setuptools.package-data]
 tescia_diagnostic = ["curriculum/*.json", "sample_data/*.json"]

--- a/src/agilab/apps/builtin/tescia_diagnostic_project/src/tescia_diagnostic_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/tescia_diagnostic_project/src/tescia_diagnostic_worker/pyproject.toml
@@ -3,12 +3,11 @@ name = "tescia_diagnostic_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILAB TeSciA-style diagnostic reasoning example"
 requires-python = ">=3.13"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }
 agi-node = { path = "../../../../../core/agi-node", editable = true }
-agi-cluster = { path = "../../../../../core/agi-cluster", editable = true }
 
 [tool.setuptools.package-data]
 tescia_diagnostic = ["sample_data/*.json"]

--- a/src/agilab/apps/builtin/uav_queue_project/pyproject.toml
+++ b/src/agilab/apps/builtin/uav_queue_project/pyproject.toml
@@ -3,12 +3,11 @@ name = "uav_queue_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILAB lightweight UAV relay queue example"
 requires-python = ">=3.13"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "simpy>=4.1,<5", "streamlit>=1.58,<2"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "simpy>=4.1,<5", "streamlit>=1.58,<2"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }
 agi-node = { path = "../../../core/agi-node", editable = true }
-agi-cluster = { path = "../../../core/agi-cluster", editable = true }
 
 [tool.setuptools.package-data]
 uav_queue = ["sample_data/*.json"]

--- a/src/agilab/apps/builtin/uav_queue_project/src/uav_queue_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/uav_queue_project/src/uav_queue_worker/pyproject.toml
@@ -3,12 +3,11 @@ name = "uav_queue_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILAB lightweight UAV relay queue example"
 requires-python = ">=3.13"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "simpy>=4.1,<5"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "simpy>=4.1,<5"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }
 agi-node = { path = "../../../../../core/agi-node", editable = true }
-agi-cluster = { path = "../../../../../core/agi-cluster", editable = true }
 
 [tool.setuptools.package-data]
 uav_queue = ["sample_data/*.json"]

--- a/src/agilab/apps/builtin/uav_relay_queue_project/pyproject.toml
+++ b/src/agilab/apps/builtin/uav_relay_queue_project/pyproject.toml
@@ -3,12 +3,11 @@ name = "uav_relay_queue_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILAB lightweight UAV relay queue example"
 requires-python = ">=3.13"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "simpy>=4.1,<5", "streamlit>=1.58,<2"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "simpy>=4.1,<5", "streamlit>=1.58,<2"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }
 agi-node = { path = "../../../core/agi-node", editable = true }
-agi-cluster = { path = "../../../core/agi-cluster", editable = true }
 
 [tool.setuptools.package-data]
 uav_relay_queue = ["sample_data/*.json"]

--- a/src/agilab/apps/builtin/uav_relay_queue_project/src/uav_relay_queue_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/uav_relay_queue_project/src/uav_relay_queue_worker/pyproject.toml
@@ -3,12 +3,11 @@ name = "uav_relay_queue_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILAB lightweight UAV relay queue example"
 requires-python = ">=3.13"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "simpy>=4.1,<5"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "simpy>=4.1,<5"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }
 agi-node = { path = "../../../../../core/agi-node", editable = true }
-agi-cluster = { path = "../../../../../core/agi-cluster", editable = true }
 
 [tool.setuptools.package-data]
 uav_relay_queue = ["sample_data/*.json"]

--- a/src/agilab/apps/builtin/weather_forecast_legacy_project/pyproject.toml
+++ b/src/agilab/apps/builtin/weather_forecast_legacy_project/pyproject.toml
@@ -3,12 +3,11 @@ name = "weather_forecast_legacy_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILab weather forecasting example migrated from notebooks"
 requires-python = ">=3.13"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "scikit-learn>=1.7.2,<2", "skforecast>=0.19,<0.20", "streamlit>=1.58,<2"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "scikit-learn>=1.7.2,<2", "skforecast>=0.19,<0.20", "streamlit>=1.58,<2"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }
 agi-node = { path = "../../../core/agi-node", editable = true }
-agi-cluster = { path = "../../../core/agi-cluster", editable = true }
 
 [tool.setuptools.package-data]
 weather_forecast_legacy = ["sample_data/*.csv"]

--- a/src/agilab/apps/builtin/weather_forecast_legacy_project/src/weather_forecast_legacy_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/weather_forecast_legacy_project/src/weather_forecast_legacy_worker/pyproject.toml
@@ -3,12 +3,11 @@ name = "weather_forecast_legacy_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILab weather forecasting example migrated from notebooks"
 requires-python = ">=3.13"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "scikit-learn>=1.7.2,<2", "skforecast>=0.19,<0.20"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "scikit-learn>=1.7.2,<2", "skforecast>=0.19,<0.20"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }
 agi-node = { path = "../../../../../core/agi-node", editable = true }
-agi-cluster = { path = "../../../../../core/agi-cluster", editable = true }
 
 [tool.setuptools.package-data]
 weather_forecast_legacy = ["sample_data/*.csv"]

--- a/src/agilab/apps/builtin/weather_forecast_project/pyproject.toml
+++ b/src/agilab/apps/builtin/weather_forecast_project/pyproject.toml
@@ -3,7 +3,7 @@ name = "weather_forecast_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILab weather forecasting example migrated from notebooks"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "scikit-learn>=1.7.2,<2", "skforecast>=0.19,<0.20", "streamlit>=1.58,<2"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "scikit-learn>=1.7.2,<2", "skforecast>=0.19,<0.20", "streamlit>=1.58,<2"]
 
 [tool.agilab]
 runtime_target = "weather_forecast"
@@ -11,7 +11,6 @@ runtime_target = "weather_forecast"
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }
 agi-node = { path = "../../../core/agi-node", editable = true }
-agi-cluster = { path = "../../../core/agi-cluster", editable = true }
 
 [tool.setuptools.package-data]
 weather_forecast = ["sample_data/*.csv"]

--- a/src/agilab/apps/builtin/weather_forecast_project/src/weather_forecast_worker/pyproject.toml
+++ b/src/agilab/apps/builtin/weather_forecast_project/src/weather_forecast_worker/pyproject.toml
@@ -3,12 +3,11 @@ name = "weather_forecast_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILab weather forecasting example migrated from notebooks"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "scikit-learn>=1.7.2,<2", "skforecast>=0.19,<0.20"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "scikit-learn>=1.7.2,<2", "skforecast>=0.19,<0.20"]
 
 [tool.uv.sources]
 agi-env = { path = "../../../../../core/agi-env", editable = true }
 agi-node = { path = "../../../../../core/agi-node", editable = true }
-agi-cluster = { path = "../../../../../core/agi-cluster", editable = true }
 
 [tool.setuptools.package-data]
 weather_forecast = ["sample_data/*.csv"]

--- a/src/agilab/apps/templates/dag_app_template/pyproject.toml
+++ b/src/agilab/apps/templates/dag_app_template/pyproject.toml
@@ -9,7 +9,6 @@ authors = [
 ]
 
 dependencies = [
-    "agi-cluster>=2026.05.25,<2027.0",
     "agi-env>=2026.05.25,<2027.0",
     "agi-node>=2026.05.25,<2027.0",
     "pydantic>=2.11,<2.13",

--- a/src/agilab/apps/templates/fireducks_app_template/pyproject.toml
+++ b/src/agilab/apps/templates/fireducks_app_template/pyproject.toml
@@ -9,7 +9,6 @@ authors = [
 ]
 
 dependencies = [
-    "agi-cluster>=2026.05.25,<2027.0",
     "agi-env>=2026.05.25,<2027.0",
     "agi-node>=2026.05.25,<2027.0",
     "fireducks>=1.4.4,<2",

--- a/src/agilab/apps/templates/pandas_app_template/pyproject.toml
+++ b/src/agilab/apps/templates/pandas_app_template/pyproject.toml
@@ -9,7 +9,6 @@ authors = [
 ]
 
 dependencies = [
-    "agi-cluster>=2026.05.25,<2027.0",
     "agi-env>=2026.05.25,<2027.0",
     "agi-node>=2026.05.25,<2027.0",
     "pandas>=2.3.0,<4",

--- a/src/agilab/apps/templates/polars_app_template/pyproject.toml
+++ b/src/agilab/apps/templates/polars_app_template/pyproject.toml
@@ -9,7 +9,6 @@ authors = [
 ]
 
 dependencies = [
-    "agi-cluster>=2026.05.25,<2027.0",
     "agi-env>=2026.05.25,<2027.0",
     "agi-node>=2026.05.25,<2027.0",
     "polars>=1.35,<2",

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_build_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_build_support.py
@@ -409,7 +409,6 @@ def _core_install_commands(*, env: Any, uv: str, app_path_arg: str) -> list[str]
     core_packages = (
         ("agi-env", getattr(env, "agi_env", None)),
         ("agi-node", getattr(env, "agi_node", None)),
-        ("agi-cluster", getattr(env, "agi_cluster", None)),
     )
     if getattr(env, "is_source_env", False):
         editable_specs = [

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_local_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_local_support.py
@@ -899,7 +899,6 @@ async def deploy_local_worker(
             env_project,
             node_project,
             core_project,
-            cluster_project,
         ]
         dependency_info, worker_pyprojects = _gather_dependency_specs(
             projects_for_specs
@@ -1089,7 +1088,6 @@ async def deploy_local_worker(
             (env_project, "agi-env"),
             (node_project, "agi-node"),
             (core_project, "agi-core"),
-            (cluster_project, "agi-cluster"),
         )
         for project_path, package_name in install_targets:
             if project_path and project_path.exists():
@@ -1105,7 +1103,7 @@ async def deploy_local_worker(
                     app_path,
                     install_spec,
                     run_fn=run_fn,
-                    no_deps=package_name not in {"agi-env", "agi-node", "agi-cluster"},
+                    no_deps=package_name not in {"agi-env", "agi-node"},
                     install_cache_enabled=stage_cache_enabled,
                 )
 
@@ -1189,7 +1187,6 @@ async def deploy_local_worker(
                 for package_name, project_path in (
                     ("agi-env", getattr(env, "agi_env", None)),
                     ("agi-node", getattr(env, "agi_node", None)),
-                    ("agi-cluster", getattr(env, "agi_cluster", None)),
                 )
                 if isinstance(project_path, Path) and project_path.exists()
             ],
@@ -1210,10 +1207,6 @@ async def deploy_local_worker(
                 for package_name, spec in (
                     ("agi-env", _resolve_install_spec(env_project, "agi-env")),
                     ("agi-node", _resolve_install_spec(node_project, "agi-node")),
-                    (
-                        "agi-cluster",
-                        _resolve_install_spec(cluster_project, "agi-cluster"),
-                    ),
                 )
                 if spec
             ],
@@ -1313,7 +1306,6 @@ async def deploy_local_worker(
         worker_dependency_names = [
             "worker-add-agi-env",
             "worker-add-agi-node",
-            "worker-add-agi-cluster",
         ]
         worker_stage_inputs = _deploy_stage_project_inputs(wenv_abs, app_path)
         cmd_worker = (
@@ -1348,23 +1340,6 @@ async def deploy_local_worker(
                 dependencies=("worker-add-agi-env",),
             )
         )
-        cmd_worker = (
-            f"{worker_extra_indexes}{uv_worker} --project {wenv_abs} add agi-cluster"
-        )
-        await deploy_plan.run(
-            _DeployPlanNode(
-                name="worker-add-agi-cluster",
-                cmd=cmd_worker,
-                cwd=wenv_abs,
-                inputs=worker_stage_inputs,
-                output_probe=lambda: _project_venv_matches(
-                    worker_venv_project,
-                    python_version=pyvers_worker,
-                ),
-                dependencies=("worker-add-agi-node",),
-            )
-        )
-
     if hw_rapids_capable:
         cmd_worker = (
             f"{worker_extra_indexes}{uv_worker} {offline_flag}{run_type} --python {pyvers_worker} "
@@ -1452,7 +1427,6 @@ async def deploy_local_worker(
             (env_project, "agi-env"),
             (node_project, "agi-node"),
             (core_project, "agi-core"),
-            (cluster_project, "agi-cluster"),
         )
         for project_path, package_name in install_targets:
             if project_path and project_path.exists():

--- a/src/agilab/core/test/test_agi_distributor_deployment_build_support.py
+++ b/src/agilab/core/test/test_agi_distributor_deployment_build_support.py
@@ -511,7 +511,8 @@ async def test_build_lib_local_non_cython_uploads_egg(tmp_path):
     )
 
     assert (env.wenv_abs / env.worker_pyproject.name).exists()
-    assert any("pip install agi-env agi-node agi-cluster" in cmd for cmd, _ in commands)
+    assert any("pip install agi-env agi-node" in cmd for cmd, _ in commands)
+    assert not any("pip install agi-env agi-node agi-cluster" in cmd for cmd, _ in commands)
     assert any("bdist_egg" in cmd for cmd, _ in commands)
     assert str(egg_path) in uploads
 
@@ -651,14 +652,17 @@ async def test_build_lib_local_uses_editable_core_installs_in_source_env(monkeyp
         run_fn=_fake_run,
     )
 
-    assert any(
-        (
-            f'--offline --project "{env.active_app}" pip install --upgrade --no-deps '
-            f"-e '{env.agi_env}' -e '{env.agi_node}' -e '{env.agi_cluster}'"
-        )
-        in cmd
+    core_runtime_installs = [
+        cmd
         for cmd, _ in commands
+        if f'--offline --project "{env.active_app}" pip install --upgrade --no-deps'
+        in cmd
+    ]
+    assert any(
+        f"-e '{env.agi_env}'" in cmd and f"-e '{env.agi_node}'" in cmd
+        for cmd in core_runtime_installs
     )
+    assert not any(f"-e '{env.agi_cluster}'" in cmd for cmd in core_runtime_installs)
     assert any(
         _editable_overlay_arg(env.agi_env) in cmd
         and _editable_overlay_arg(env.agi_node) in cmd
@@ -701,14 +705,16 @@ async def test_build_lib_local_uses_uv_index_url_mirror_when_internet_disabled(
 
     assert commands
     assert not any("--offline" in cmd for cmd, _ in commands)
-    assert any(
-        (
-            f'--project "{env.active_app}" pip install --upgrade --no-deps '
-            f"-e '{env.agi_env}' -e '{env.agi_node}' -e '{env.agi_cluster}'"
-        )
-        in cmd
+    core_runtime_installs = [
+        cmd
         for cmd, _ in commands
+        if f'--project "{env.active_app}" pip install --upgrade --no-deps' in cmd
+    ]
+    assert any(
+        f"-e '{env.agi_env}'" in cmd and f"-e '{env.agi_node}'" in cmd
+        for cmd in core_runtime_installs
     )
+    assert not any(f"-e '{env.agi_cluster}'" in cmd for cmd in core_runtime_installs)
     assert any(
         _editable_overlay_arg(env.agi_env) in cmd
         and _editable_overlay_arg(env.agi_node) in cmd

--- a/src/agilab/core/test/test_agi_distributor_deployment_local_support.py
+++ b/src/agilab/core/test/test_agi_distributor_deployment_local_support.py
@@ -2989,12 +2989,17 @@ async def test_deploy_local_worker_install_type_zero_non_source_covers_dependenc
     assert pth_content == expected_prefix
     assert agi_cls._install_done_local is True
     assert any(
+        f'add --editable "{env_project}" "{node_project}"' in cmd
+        and str(wenv_abs) in cmd
+        for cmd, _ in commands
+    )
+    assert not any(
         f'add --editable "{env_project}" "{node_project}" "{cluster_project}"' in cmd
         and str(wenv_abs) in cmd
         for cmd, _ in commands
     )
     manager_python = _venv_python(app_path)
-    assert any(
+    assert not any(
         f'pip install --python "{manager_python}" --upgrade "{cluster_project}"' in cmd
         for cmd, _ in commands
     )
@@ -3134,7 +3139,7 @@ async def test_deploy_local_worker_install_type_zero_non_source_uses_distributio
         in cmd
         for cmd, _ in commands
     )
-    assert any(
+    assert not any(
         "agi-cluster @ git+https://example.invalid/repo.git@main#subdirectory=agi-cluster"
         in cmd
         for cmd, _ in commands
@@ -3955,12 +3960,15 @@ path = "../sat_trajectory_project"
         f'pip install --python "{manager_python}" --upgrade "{env_project}"',
         f'pip install --python "{manager_python}" --upgrade "{node_project}"',
         f'pip install --python "{manager_python}" --upgrade --no-deps "{core_project}"',
-        f'pip install --python "{manager_python}" --upgrade "{cluster_project}"',
     ]
     for expected in expected_manager_installs:
         assert any(expected in cmd for cmd, _ in commands), "\n".join(
             cmd for cmd, _ in commands
         )
+    assert not any(
+        f'pip install --python "{manager_python}" --upgrade "{cluster_project}"' in cmd
+        for cmd, _ in commands
+    )
     assert any(
         f'add --editable "{env_project}" "{node_project}"' in cmd
         and str(wenv_abs) in cmd

--- a/src/agilab/lib/agi-app-data-quality-gate/pyproject.toml
+++ b/src/agilab/lib/agi-app-data-quality-gate/pyproject.toml
@@ -32,7 +32,7 @@ keywords = [
     "workflow-orchestration",
 ]
 
-dependencies = ["agi-core>=2026.05.13,<2027.0"]
+dependencies = ["agi-env>=2026.05.31,<2027.0", "agi-node>=2026.05.31,<2027.0"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"
@@ -53,8 +53,12 @@ dev = [
     "pytest",
 ]
 
-[tool.uv.sources.agi-core]
-    path = "../../core/agi-core"
+[tool.uv.sources.agi-env]
+    path = "../../core/agi-env"
+    editable = true
+
+[tool.uv.sources.agi-node]
+    path = "../../core/agi-node"
     editable = true
 
 [build-system]

--- a/src/agilab/lib/agi-app-flight-telemetry/pyproject.toml
+++ b/src/agilab/lib/agi-app-flight-telemetry/pyproject.toml
@@ -30,7 +30,7 @@ keywords = [
     "workflow-orchestration",
 ]
 
-dependencies = ["agi-core>=2026.05.13,<2027.0"]
+dependencies = ["agi-env>=2026.05.31,<2027.0", "agi-node>=2026.05.31,<2027.0"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"
@@ -62,8 +62,12 @@ dev = [
     "pytest",
 ]
 
-[tool.uv.sources.agi-core]
-    path = "../../core/agi-core"
+[tool.uv.sources.agi-env]
+    path = "../../core/agi-env"
+    editable = true
+
+[tool.uv.sources.agi-node]
+    path = "../../core/agi-node"
     editable = true
 
 [build-system]

--- a/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/pyproject.toml
+++ b/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/pyproject.toml
@@ -3,7 +3,7 @@ name = "flight_telemetry_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILab example app (flight-telemetry preprocessing)"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "polars[rtcompat]>=1.35,<2", "pydantic>=2.11,<2.13", "py7zr>=1.1,<1.2", "streamlit>=1.58,<2"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "polars[rtcompat]>=1.35,<2", "pydantic>=2.11,<2.13", "py7zr>=1.1,<1.2", "streamlit>=1.58,<2"]
 
 [tool.agilab]
 runtime_target = "flight_telemetry"

--- a/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/src/flight_telemetry_worker/pyproject.toml
+++ b/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/src/flight_telemetry_worker/pyproject.toml
@@ -4,7 +4,7 @@ version = "2026.05.30.post1"
 description = ""
 requires-python = ">=3.11,<3.14"
 readme = "README.md"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "polars>=1.35,<2", "pydantic>=2.11,<2.13"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "polars>=1.35,<2", "pydantic>=2.11,<2.13"]
 
 [[project.authors]]
 name = "Jean-Pierre Morard"

--- a/src/agilab/lib/agi-app-mission-decision/pyproject.toml
+++ b/src/agilab/lib/agi-app-mission-decision/pyproject.toml
@@ -30,7 +30,7 @@ keywords = [
     "workflow-orchestration",
 ]
 
-dependencies = ["agi-core>=2026.05.13,<2027.0"]
+dependencies = ["agi-env>=2026.05.31,<2027.0", "agi-node>=2026.05.31,<2027.0"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"
@@ -62,8 +62,12 @@ dev = [
     "pytest",
 ]
 
-[tool.uv.sources.agi-core]
-    path = "../../core/agi-core"
+[tool.uv.sources.agi-env]
+    path = "../../core/agi-env"
+    editable = true
+
+[tool.uv.sources.agi-node]
+    path = "../../core/agi-node"
     editable = true
 
 [build-system]

--- a/src/agilab/lib/agi-app-mission-decision/src/agi_app_mission_decision/project/mission_decision_project/pyproject.toml
+++ b/src/agilab/lib/agi-app-mission-decision/src/agi_app_mission_decision/project/mission_decision_project/pyproject.toml
@@ -3,7 +3,7 @@ name = "mission_decision_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILAB Mission Decision autonomous demo"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "streamlit>=1.58,<2"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "streamlit>=1.58,<2"]
 
 [tool.agilab]
 runtime_target = "mission_decision"

--- a/src/agilab/lib/agi-app-mission-decision/src/agi_app_mission_decision/project/mission_decision_project/src/mission_decision_worker/pyproject.toml
+++ b/src/agilab/lib/agi-app-mission-decision/src/agi_app_mission_decision/project/mission_decision_project/src/mission_decision_worker/pyproject.toml
@@ -3,7 +3,7 @@ name = "mission_decision_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILAB Mission Decision autonomous demo"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13"]
 
 [tool.setuptools.package-data]
 mission_decision = ["sample_data/*.json"]

--- a/src/agilab/lib/agi-app-multi-dag/pyproject.toml
+++ b/src/agilab/lib/agi-app-multi-dag/pyproject.toml
@@ -30,7 +30,7 @@ keywords = [
     "workflow-orchestration",
 ]
 
-dependencies = ["agi-core>=2026.05.13,<2027.0"]
+dependencies = ["agi-env>=2026.05.31,<2027.0", "agi-node>=2026.05.31,<2027.0"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"
@@ -61,8 +61,12 @@ dev = [
     "pytest",
 ]
 
-[tool.uv.sources.agi-core]
-    path = "../../core/agi-core"
+[tool.uv.sources.agi-env]
+    path = "../../core/agi-env"
+    editable = true
+
+[tool.uv.sources.agi-node]
+    path = "../../core/agi-node"
     editable = true
 
 [build-system]

--- a/src/agilab/lib/agi-app-pandas-execution/pyproject.toml
+++ b/src/agilab/lib/agi-app-pandas-execution/pyproject.toml
@@ -30,7 +30,7 @@ keywords = [
     "workflow-orchestration",
 ]
 
-dependencies = ["agi-core>=2026.05.13,<2027.0"]
+dependencies = ["agi-env>=2026.05.31,<2027.0", "agi-node>=2026.05.31,<2027.0"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"
@@ -61,8 +61,12 @@ dev = [
     "pytest",
 ]
 
-[tool.uv.sources.agi-core]
-    path = "../../core/agi-core"
+[tool.uv.sources.agi-env]
+    path = "../../core/agi-env"
+    editable = true
+
+[tool.uv.sources.agi-node]
+    path = "../../core/agi-node"
     editable = true
 
 [build-system]

--- a/src/agilab/lib/agi-app-polars-execution/pyproject.toml
+++ b/src/agilab/lib/agi-app-polars-execution/pyproject.toml
@@ -30,7 +30,7 @@ keywords = [
     "workflow-orchestration",
 ]
 
-dependencies = ["agi-core>=2026.05.13,<2027.0"]
+dependencies = ["agi-env>=2026.05.31,<2027.0", "agi-node>=2026.05.31,<2027.0"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"
@@ -61,8 +61,12 @@ dev = [
     "pytest",
 ]
 
-[tool.uv.sources.agi-core]
-    path = "../../core/agi-core"
+[tool.uv.sources.agi-env]
+    path = "../../core/agi-env"
+    editable = true
+
+[tool.uv.sources.agi-node]
+    path = "../../core/agi-node"
     editable = true
 
 [build-system]

--- a/src/agilab/lib/agi-app-pytorch-playground/pyproject.toml
+++ b/src/agilab/lib/agi-app-pytorch-playground/pyproject.toml
@@ -30,7 +30,7 @@ keywords = [
     "workflow-orchestration",
 ]
 
-dependencies = ["agi-core>=2026.05.13,<2027.0"]
+dependencies = ["agi-env>=2026.05.31,<2027.0", "agi-node>=2026.05.31,<2027.0"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"
@@ -59,8 +59,12 @@ dev = [
     "pytest",
 ]
 
-[tool.uv.sources.agi-core]
-    path = "../../core/agi-core"
+[tool.uv.sources.agi-env]
+    path = "../../core/agi-env"
+    editable = true
+
+[tool.uv.sources.agi-node]
+    path = "../../core/agi-node"
     editable = true
 
 [build-system]

--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/pyproject.toml
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/pyproject.toml
@@ -7,7 +7,6 @@ requires-python = ">=3.12"
 dependencies = [
     "agi-env>=2026.05.31",
     "agi-node>=2026.05.31",
-    "agi-cluster>=2026.05.31",
     "agi-gui>=2026.05.31",
     "agi-web>=2026.05.31",
     "numpy>=2.2,<3",

--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground_worker/pyproject.toml
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground_worker/pyproject.toml
@@ -6,7 +6,6 @@ requires-python = ">=3.12"
 dependencies = [
     "agi-env>=2026.05.31",
     "agi-node>=2026.05.31",
-    "agi-cluster>=2026.05.31",
     "numpy>=2.2,<3",
     "pandas>=2.3.0,<4",
     "pydantic>=2.11,<2.13",

--- a/src/agilab/lib/agi-app-sklearn-pipeline/pyproject.toml
+++ b/src/agilab/lib/agi-app-sklearn-pipeline/pyproject.toml
@@ -32,7 +32,7 @@ keywords = [
     "workflow-orchestration",
 ]
 
-dependencies = ["agi-core>=2026.05.13,<2027.0"]
+dependencies = ["agi-env>=2026.05.31,<2027.0", "agi-node>=2026.05.31,<2027.0"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"
@@ -56,8 +56,12 @@ dev = [
     "pytest",
 ]
 
-[tool.uv.sources.agi-core]
-    path = "../../core/agi-core"
+[tool.uv.sources.agi-env]
+    path = "../../core/agi-env"
+    editable = true
+
+[tool.uv.sources.agi-node]
+    path = "../../core/agi-node"
     editable = true
 
 [build-system]

--- a/src/agilab/lib/agi-app-tescia-diagnostic/pyproject.toml
+++ b/src/agilab/lib/agi-app-tescia-diagnostic/pyproject.toml
@@ -28,7 +28,7 @@ keywords = [
     "workflow-orchestration",
 ]
 
-dependencies = ["agi-core>=2026.05.13,<2027.0"]
+dependencies = ["agi-env>=2026.05.31,<2027.0", "agi-node>=2026.05.31,<2027.0"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"
@@ -59,8 +59,12 @@ dev = [
     "pytest",
 ]
 
-[tool.uv.sources.agi-core]
-    path = "../../core/agi-core"
+[tool.uv.sources.agi-env]
+    path = "../../core/agi-env"
+    editable = true
+
+[tool.uv.sources.agi-node]
+    path = "../../core/agi-node"
     editable = true
 
 [build-system]

--- a/src/agilab/lib/agi-app-uav-queue/pyproject.toml
+++ b/src/agilab/lib/agi-app-uav-queue/pyproject.toml
@@ -28,7 +28,7 @@ keywords = [
     "workflow-orchestration",
 ]
 
-dependencies = ["agi-core>=2026.05.13,<2027.0"]
+dependencies = ["agi-env>=2026.05.31,<2027.0", "agi-node>=2026.05.31,<2027.0"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"
@@ -59,8 +59,12 @@ dev = [
     "pytest",
 ]
 
-[tool.uv.sources.agi-core]
-    path = "../../core/agi-core"
+[tool.uv.sources.agi-env]
+    path = "../../core/agi-env"
+    editable = true
+
+[tool.uv.sources.agi-node]
+    path = "../../core/agi-node"
     editable = true
 
 [build-system]

--- a/src/agilab/lib/agi-app-uav-relay-queue/pyproject.toml
+++ b/src/agilab/lib/agi-app-uav-relay-queue/pyproject.toml
@@ -28,7 +28,7 @@ keywords = [
     "workflow-orchestration",
 ]
 
-dependencies = ["agi-core>=2026.05.13,<2027.0"]
+dependencies = ["agi-env>=2026.05.31,<2027.0", "agi-node>=2026.05.31,<2027.0"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"
@@ -60,8 +60,12 @@ dev = [
     "pytest",
 ]
 
-[tool.uv.sources.agi-core]
-    path = "../../core/agi-core"
+[tool.uv.sources.agi-env]
+    path = "../../core/agi-env"
+    editable = true
+
+[tool.uv.sources.agi-node]
+    path = "../../core/agi-node"
     editable = true
 
 [build-system]

--- a/src/agilab/lib/agi-app-uav-relay-queue/src/agi_app_uav_relay_queue/project/uav_relay_queue_project/pyproject.toml
+++ b/src/agilab/lib/agi-app-uav-relay-queue/src/agi_app_uav_relay_queue/project/uav_relay_queue_project/pyproject.toml
@@ -3,7 +3,7 @@ name = "uav_relay_queue_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILAB lightweight UAV relay queue example"
 requires-python = ">=3.13"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "simpy>=4.1,<5", "streamlit>=1.58,<2"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "simpy>=4.1,<5", "streamlit>=1.58,<2"]
 
 [tool.setuptools.package-data]
 uav_relay_queue = ["sample_data/*.json"]

--- a/src/agilab/lib/agi-app-uav-relay-queue/src/agi_app_uav_relay_queue/project/uav_relay_queue_project/src/uav_relay_queue_worker/pyproject.toml
+++ b/src/agilab/lib/agi-app-uav-relay-queue/src/agi_app_uav_relay_queue/project/uav_relay_queue_project/src/uav_relay_queue_worker/pyproject.toml
@@ -3,7 +3,7 @@ name = "uav_relay_queue_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILAB lightweight UAV relay queue example"
 requires-python = ">=3.13"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "simpy>=4.1,<5"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "simpy>=4.1,<5"]
 
 [tool.setuptools.package-data]
 uav_relay_queue = ["sample_data/*.json"]

--- a/src/agilab/lib/agi-app-weather-forecast/pyproject.toml
+++ b/src/agilab/lib/agi-app-weather-forecast/pyproject.toml
@@ -30,7 +30,7 @@ keywords = [
     "workflow-orchestration",
 ]
 
-dependencies = ["agi-core>=2026.05.13,<2027.0"]
+dependencies = ["agi-env>=2026.05.31,<2027.0", "agi-node>=2026.05.31,<2027.0"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"
@@ -62,8 +62,12 @@ dev = [
     "pytest",
 ]
 
-[tool.uv.sources.agi-core]
-    path = "../../core/agi-core"
+[tool.uv.sources.agi-env]
+    path = "../../core/agi-env"
+    editable = true
+
+[tool.uv.sources.agi-node]
+    path = "../../core/agi-node"
     editable = true
 
 [build-system]

--- a/src/agilab/lib/agi-app-weather-forecast/src/agi_app_weather_forecast/project/weather_forecast_project/pyproject.toml
+++ b/src/agilab/lib/agi-app-weather-forecast/src/agi_app_weather_forecast/project/weather_forecast_project/pyproject.toml
@@ -3,7 +3,7 @@ name = "weather_forecast_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILab weather forecasting example migrated from notebooks"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "scikit-learn>=1.7.2,<2", "skforecast>=0.19,<0.20", "streamlit>=1.58,<2"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "scikit-learn>=1.7.2,<2", "skforecast>=0.19,<0.20", "streamlit>=1.58,<2"]
 
 [tool.agilab]
 runtime_target = "weather_forecast"

--- a/src/agilab/lib/agi-app-weather-forecast/src/agi_app_weather_forecast/project/weather_forecast_project/src/weather_forecast_worker/pyproject.toml
+++ b/src/agilab/lib/agi-app-weather-forecast/src/agi_app_weather_forecast/project/weather_forecast_project/src/weather_forecast_worker/pyproject.toml
@@ -3,7 +3,7 @@ name = "weather_forecast_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILab weather forecasting example migrated from notebooks"
 requires-python = ">=3.11"
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "agi-cluster>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "scikit-learn>=1.7.2,<2", "skforecast>=0.19,<0.20"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "scikit-learn>=1.7.2,<2", "skforecast>=0.19,<0.20"]
 
 [tool.setuptools.package-data]
 weather_forecast = ["sample_data/*.csv"]

--- a/src/agilab/orchestrate/orchestrate_page_support.py
+++ b/src/agilab/orchestrate/orchestrate_page_support.py
@@ -99,11 +99,9 @@ _INSTALL_LOG_NON_FATAL_LINE_PATTERNS_LOWER: tuple[tuple[str, ...], ...] = tuple(
     if tokens
 )
 
-_MANAGER_REQUIRED_MODULES: tuple[str, ...] = ("agi_env", "agi_node", "agi_cluster")
+_MANAGER_REQUIRED_MODULES: tuple[str, ...] = ("agi_env", "agi_node")
 _WORKER_REQUIRED_MODULES: tuple[str, ...] = ("agi_env", "agi_node")
-_MANAGER_REQUIRED_SYMBOLS: tuple[tuple[str, str], ...] = (
-    ("agi_cluster.agi_distributor", "StageRequest"),
-)
+_MANAGER_REQUIRED_SYMBOLS: tuple[tuple[str, str], ...] = ()
 _DEPENDENCY_MODULE_ALIASES: dict[str, tuple[str, ...]] = {
     "legacy-cgi": ("cgi",),
     "pillow": ("PIL",),
@@ -1662,7 +1660,6 @@ def app_install_status(env: Any) -> dict[str, Any]:
         for name in (
             "agi-env",
             "agi-node",
-            "agi-cluster",
             active_app_distribution,
         )
         if name

--- a/test/test_app_contract_matrix.py
+++ b/test/test_app_contract_matrix.py
@@ -96,23 +96,25 @@ def test_app_contract_matrix_detects_promoted_catalog_drift():
     ]["details"]["missing_from_pypi_catalog"]
 
 
-def test_worker_projects_depend_on_cluster_cli_runtime() -> None:
+def test_worker_projects_depend_on_node_cli_runtime_without_cluster_stack() -> None:
     missing_dependency: list[str] = []
-    missing_source: list[str] = []
+    unexpected_cluster_dependency: list[str] = []
+    unexpected_cluster_source: list[str] = []
     for pyproject in sorted((ROOT / "src" / "agilab").rglob("*_worker/pyproject.toml")):
         metadata = tomllib.loads(pyproject.read_text(encoding="utf-8"))
         dependencies = tuple(metadata.get("project", {}).get("dependencies", ()))
         if not any(dependency.startswith("agi-node") for dependency in dependencies):
-            continue
-        if not any(dependency.startswith("agi-cluster") for dependency in dependencies):
             missing_dependency.append(pyproject.relative_to(ROOT).as_posix())
+        if any(dependency.startswith("agi-cluster") for dependency in dependencies):
+            unexpected_cluster_dependency.append(pyproject.relative_to(ROOT).as_posix())
         if pyproject.relative_to(ROOT).as_posix().startswith("src/agilab/apps/builtin/"):
             sources = metadata.get("tool", {}).get("uv", {}).get("sources", {})
-            if "agi-cluster" not in sources:
-                missing_source.append(pyproject.relative_to(ROOT).as_posix())
+            if "agi-cluster" in sources:
+                unexpected_cluster_source.append(pyproject.relative_to(ROOT).as_posix())
 
     assert missing_dependency == []
-    assert missing_source == []
+    assert unexpected_cluster_dependency == []
+    assert unexpected_cluster_source == []
 
 
 def test_app_contract_matrix_detects_page_bundle_provider_drift():
@@ -220,6 +222,8 @@ def test_app_contract_matrix_detects_checked_in_payload_drift(tmp_path: Path, mo
             generated_project = target_root / project_name
             generated_project.mkdir(parents=True)
             (generated_project / "value.txt").write_text("new\n", encoding="utf-8")
+            (generated_project / ".coverage").write_text("generated coverage\n", encoding="utf-8")
+            (generated_project / ".coverage.worker").write_text("generated coverage\n", encoding="utf-8")
             return []
 
     def _fake_load_module(_repo_root: Path, relative_path: Path, _module_name: str):
@@ -237,6 +241,8 @@ def test_app_contract_matrix_detects_checked_in_payload_drift(tmp_path: Path, mo
 
     assert contract_errors == {}
     assert drift_errors["agi-app-demo"]["changed"] == ["value.txt"]
+    assert ".coverage" not in drift_errors["agi-app-demo"]["missing_from_embedded"]
+    assert ".coverage.worker" not in drift_errors["agi-app-demo"]["missing_from_embedded"]
 
 
 def test_app_contract_matrix_cli_writes_json_output(tmp_path: Path, capsys):

--- a/test/test_app_installer_packaging.py
+++ b/test/test_app_installer_packaging.py
@@ -371,7 +371,8 @@ def test_app_templates_keep_runtime_contracts_explicit() -> None:
             assert {"agi-cluster", "agi-node"}.isdisjoint(dependencies), template.name
             assert not any(template.glob("src/*_worker")), template.name
         else:
-            assert {"agi-cluster", "agi-node"} <= dependencies, template.name
+            assert "agi-node" in dependencies, template.name
+            assert "agi-cluster" not in dependencies, template.name
         assert "filterwarnings" not in pyproject.get("tool", {}).get("mypy", {})
 
         cluster_settings = tomllib.loads((template / "src/app_settings.toml").read_text(encoding="utf-8"))["cluster"]

--- a/test/test_orchestrate_page_support.py
+++ b/test/test_orchestrate_page_support.py
@@ -1223,7 +1223,7 @@ def test_dataframe_preview_state_roundtrip_cleans_export_flags():
     assert restore_state["selected_cols"] == ["x"]
 
 
-def test_app_install_status_requires_manager_agi_cluster_import(tmp_path: Path) -> None:
+def test_app_install_status_does_not_require_manager_agi_cluster_import(tmp_path: Path) -> None:
     active_app = tmp_path / "mission_decision_project"
     worker_root = tmp_path / "wenv" / "mission_decision_worker"
     manager_venv = active_app / ".venv"
@@ -1234,10 +1234,10 @@ def test_app_install_status_requires_manager_agi_cluster_import(tmp_path: Path) 
 
     status = orchestrate_page_support.app_install_status(env)
 
-    assert status["manager_ready"] is False
+    assert status["manager_ready"] is True
     assert status["worker_ready"] is True
-    assert status["manager_missing_modules"] == ("agi_cluster",)
-    assert status["manager_problem"] == "missing modules: agi_cluster"
+    assert status["manager_missing_modules"] == ()
+    assert status["manager_problem"] == ""
 
 
 def test_app_install_status_rejects_manager_missing_core_dependency(tmp_path: Path) -> None:
@@ -1247,14 +1247,13 @@ def test_app_install_status_rejects_manager_missing_core_dependency(tmp_path: Pa
         active_app / ".venv",
         "agi_env",
         "agi_node",
-        "agi_cluster",
     )
     _seed_fake_venv_modules(worker_root / ".venv", "agi_env", "agi_node")
-    dist_info = manager_site / "agi_cluster-2026.5.25.dist-info"
+    dist_info = manager_site / "agi_node-2026.5.25.dist-info"
     dist_info.mkdir(parents=True, exist_ok=True)
     (dist_info / "METADATA").write_text(
         "Metadata-Version: 2.4\n"
-        "Name: agi-cluster\n"
+        "Name: agi-node\n"
         "Requires-Dist: humanize<5,>=4.10\n"
         "Requires-Dist: dask[distributed]<2027.0,>=2026.3\n",
         encoding="utf-8",
@@ -1290,7 +1289,6 @@ def test_app_install_status_uses_worker_project_dependencies(tmp_path: Path) -> 
         active_app / ".venv",
         "agi_env",
         "agi_node",
-        "agi_cluster",
         "dotenv",
         "streamlit",
     )
@@ -1333,7 +1331,6 @@ def test_app_install_status_uses_installed_top_level_metadata_for_dependency_imp
         active_app / ".venv",
         "agi_env",
         "agi_node",
-        "agi_cluster",
         "code_editor",
         "cgi",
         "imghdr",
@@ -1389,7 +1386,7 @@ def test_app_install_status_skips_marker_inactive_dependencies_for_target_venv(t
     )
     manager_venv = active_app / ".venv"
     worker_venv = worker_root / ".venv"
-    _seed_fake_venv_modules(manager_venv, "agi_env", "agi_node", "agi_cluster")
+    _seed_fake_venv_modules(manager_venv, "agi_env", "agi_node")
     _seed_fake_venv_modules(worker_venv, "agi_env", "agi_node")
     for venv in (manager_venv, worker_venv):
         (venv / "pyvenv.cfg").write_text("version = 3.12.11\n", encoding="utf-8")
@@ -1490,10 +1487,10 @@ def test_dependency_metadata_helpers_cover_error_edges(monkeypatch, tmp_path: Pa
     assert orchestrate_page_support._dependency_modules_from_metadata([site_packages], ["demo"]) == ()
 
 
-def test_app_install_status_rejects_stale_manager_missing_stage_request(tmp_path: Path) -> None:
+def test_app_install_status_ignores_absent_cluster_api_for_manager_runtime(tmp_path: Path) -> None:
     active_app = tmp_path / "weather_forecast_project"
     worker_root = tmp_path / "wenv" / "weather_forecast_worker"
-    manager_site = _seed_fake_venv_modules(active_app / ".venv", "agi_env", "agi_node", "agi_cluster")
+    manager_site = _seed_fake_venv_modules(active_app / ".venv", "agi_env", "agi_node")
     worker_site = _seed_fake_venv_modules(worker_root / ".venv", "agi_env", "agi_node")
     stale_distributor = manager_site / "agi_cluster" / "agi_distributor"
     stale_distributor.mkdir(parents=True, exist_ok=True)
@@ -1503,16 +1500,16 @@ def test_app_install_status_rejects_stale_manager_missing_stage_request(tmp_path
     status = orchestrate_page_support.app_install_status(env)
 
     assert worker_site.exists()
-    assert status["manager_ready"] is False
+    assert status["manager_ready"] is True
     assert status["worker_ready"] is True
-    assert status["manager_missing_symbols"] == ("agi_cluster.agi_distributor.StageRequest",)
-    assert status["manager_problem"] == "missing symbols: agi_cluster.agi_distributor.StageRequest"
+    assert status["manager_missing_symbols"] == ()
+    assert status["manager_problem"] == ""
 
 
 def test_app_install_status_detects_editable_pth_import_roots(tmp_path: Path) -> None:
     active_app = tmp_path / "mission_decision_project"
     worker_root = tmp_path / "wenv" / "mission_decision_worker"
-    manager_site = _seed_fake_venv_modules(active_app / ".venv", "agi_cluster")
+    manager_site = _seed_fake_venv_modules(active_app / ".venv")
     worker_site = _seed_fake_venv_modules(worker_root / ".venv")
     editable_core = tmp_path / "editable-core"
     for module in ("agi_env", "agi_node"):

--- a/test/test_pyproject_dependency_hygiene.py
+++ b/test/test_pyproject_dependency_hygiene.py
@@ -394,10 +394,12 @@ def test_builtin_app_manifests_depend_on_core_packages_not_core_internals() -> N
         deps = _dependency_names(pyproject)
 
         assert deps.isdisjoint(copied_core_internals), app_root.name
-        assert {"agi-env", "agi-node", "agi-cluster"} <= deps, app_root.name
+        assert {"agi-env", "agi-node"} <= deps, app_root.name
+        assert "agi-cluster" not in deps, app_root.name
 
         sources = data.get("tool", {}).get("uv", {}).get("sources", {})
-        for package in ("agi-env", "agi-node", "agi-cluster"):
+        assert "agi-cluster" not in sources, app_root.name
+        for package in ("agi-env", "agi-node"):
             raw_path = sources.get(package, {}).get("path")
             assert raw_path, f"{app_root.name}: missing local source for {package}"
             assert (app_root / raw_path).resolve(strict=False).exists()
@@ -415,8 +417,10 @@ def test_builtin_worker_manifests_have_resolvable_core_sources() -> None:
             continue
         core_worker_pyprojects.append(pyproject)
         assert {"agi-env", "agi-node"} <= deps, pyproject
+        assert "agi-cluster" not in deps, pyproject
 
         sources = data.get("tool", {}).get("uv", {}).get("sources", {})
+        assert "agi-cluster" not in sources, pyproject
         for package in ("agi-env", "agi-node"):
             raw_path = sources.get(package, {}).get("path")
             assert raw_path, f"{pyproject}: missing local source for {package}"
@@ -541,6 +545,21 @@ def test_shared_core_runtime_dependencies_are_not_copied_meta_stacks() -> None:
         "scikit-learn",
         "tomlkit",
     } <= _dependency_names(REPO_ROOT / "src/agilab/core/agi-cluster/pyproject.toml")
+
+
+def test_promoted_app_packages_depend_on_runtime_pair_not_core_bundle() -> None:
+    package_pyprojects = sorted((REPO_ROOT / "src/agilab/lib").glob("agi-app-*/pyproject.toml"))
+    assert package_pyprojects
+
+    for pyproject in package_pyprojects:
+        deps = _dependency_names(pyproject)
+        sources = _load_pyproject(pyproject).get("tool", {}).get("uv", {}).get("sources", {})
+        assert {"agi-env", "agi-node"} <= deps, pyproject
+        assert "agi-core" not in deps, pyproject
+        assert "agi-cluster" not in deps, pyproject
+        assert {"agi-env", "agi-node"} <= set(sources), pyproject
+        assert "agi-core" not in sources, pyproject
+        assert "agi-cluster" not in sources, pyproject
 
 
 def test_agi_env_does_not_hardcode_upper_core_package_names() -> None:

--- a/tools/app_contract_matrix.py
+++ b/tools/app_contract_matrix.py
@@ -53,6 +53,7 @@ PAYLOAD_EXCLUDED_DIRS = frozenset(
     }
 )
 PAYLOAD_EXCLUDED_FILES = frozenset({".DS_Store", ".gitignore", ".lock", "uv.lock"})
+PAYLOAD_EXCLUDED_FILE_PREFIXES = (".coverage",)
 PAYLOAD_EXCLUDED_SUFFIXES = frozenset({".c", ".pid", ".pyc", ".pyo", ".pyx", ".so"})
 
 
@@ -185,7 +186,11 @@ def _payload_file_index(root: Path) -> dict[str, bytes]:
             continue
         if not path.is_file():
             continue
-        if path.name in PAYLOAD_EXCLUDED_FILES or path.suffix in PAYLOAD_EXCLUDED_SUFFIXES:
+        if (
+            path.name in PAYLOAD_EXCLUDED_FILES
+            or path.name.startswith(PAYLOAD_EXCLUDED_FILE_PREFIXES)
+            or path.suffix in PAYLOAD_EXCLUDED_SUFFIXES
+        ):
             continue
         files[relative.as_posix()] = path.read_bytes()
     return files
@@ -469,7 +474,7 @@ def _project_checks(repo_root: Path, project_path: Path) -> list[Check]:
         project_data = pyproject.get("project", {})
         missing_core_deps = [
             package
-            for package in ("agi-env", "agi-node", "agi-cluster")
+            for package in ("agi-env", "agi-node")
             if not _has_dependency(manager_dependencies, package)
         ]
         checks.append(
@@ -479,7 +484,7 @@ def _project_checks(repo_root: Path, project_path: Path) -> list[Check]:
                 project_data.get("name") == project_name
                 and bool(project_data.get("version"))
                 and not missing_core_deps,
-                "manager pyproject declares the project name, version, and core dependencies",
+                "manager pyproject declares the project name, version, and app runtime dependencies",
                 evidence=(_relative(repo_root, pyproject_path),),
                 details={
                     "name": project_data.get("name"),


### PR DESCRIPTION
## Summary

Removes the remaining app-runtime dependency on `agi-cluster` now that `agi-node` is independent from the cluster stack.

## Root Cause

Built-in app manager/worker manifests, app templates, promoted app package metadata, deployment install plumbing, and ORCHESTRATE readiness checks still pulled in or required `agi-cluster`. That kept app installs coupled to the cluster package even when the runtime only needed `agi-env` and `agi-node`.

## Changes

- Removed `agi-cluster` from built-in app, worker, template, and promoted app manifests.
- Made promoted app packages depend directly on `agi-env` and `agi-node` instead of the broader core bundle.
- Removed forced `agi-cluster` injection from local worker/manager deployment setup and build install commands.
- Updated ORCHESTRATE install readiness and app contract checks to require app runtime dependencies only.
- Added/tightened regressions to prevent app manifests and install checks from reintroducing the cluster dependency.
- Updated Windows-covered core test expectations after CI showed stale `agi-cluster` assertions.

## Validation

- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_app_contract_matrix.py test/test_app_installer_packaging.py::test_app_templates_keep_runtime_contracts_explicit test/test_pyproject_dependency_hygiene.py test/test_orchestrate_page_support.py::test_app_install_status_does_not_require_manager_agi_cluster_import test/test_orchestrate_page_support.py::test_app_install_status_rejects_manager_missing_core_dependency test/test_orchestrate_page_support.py::test_app_install_status_uses_worker_project_dependencies test/test_orchestrate_page_support.py::test_app_install_status_uses_installed_top_level_metadata_for_dependency_imports test/test_orchestrate_page_support.py::test_app_install_status_skips_marker_inactive_dependencies_for_target_venv test/test_orchestrate_page_support.py::test_app_install_status_ignores_absent_cluster_api_for_manager_runtime test/test_orchestrate_page_support.py::test_app_install_status_detects_editable_pth_import_roots` -> 41 passed
- `uv --preview-features extra-build-dependencies run --no-project --with-editable ./src/agilab/core/agi-env --with-editable ./src/agilab/core/agi-node --with-editable ./src/agilab/core/agi-cluster --with-editable ./src/agilab/core/agi-core --with sqlalchemy --with streamlit --with fastparquet --with pytest --with pytest-asyncio --with pytest-cov python -m pytest -q --disable-warnings -o addopts='' --import-mode=importlib src/agilab/core/test/test_agi_distributor_deployment_build_support.py::test_build_lib_local_non_cython_uploads_egg src/agilab/core/test/test_agi_distributor_deployment_build_support.py::test_build_lib_local_uses_editable_core_installs_in_source_env src/agilab/core/test/test_agi_distributor_deployment_build_support.py::test_build_lib_local_uses_uv_index_url_mirror_when_internet_disabled src/agilab/core/test/test_agi_distributor_deployment_local_support.py::test_deploy_local_worker_install_type_zero_non_source_covers_dependency_flow src/agilab/core/test/test_agi_distributor_deployment_local_support.py::test_deploy_local_worker_install_type_zero_non_source_uses_distribution_specs_for_non_project_paths src/agilab/core/test/test_agi_distributor_deployment_local_support.py::test_deploy_local_worker_offline_manager_overlay_preserves_local_sources` -> 6 passed
- `./dev app-contracts` -> 132 checks, 0 failed
- `uv --preview-features extra-build-dependencies run python tools/install_contract_check.py --app-path src/agilab/apps/builtin/minimal_app_project --worker-copy src/agilab/apps/builtin/minimal_app_project/src/minimal_app_worker --worker-source src/agilab/apps/builtin/minimal_app_project/src/minimal_app_worker` -> Status: safe
- `git diff --check`