### PR TITLE
Fix docs autodoc source path pollution

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 252,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "051794699293f8919b9b6273d4a1036726bf7fb975253d3cc07d6f774e9079ad",
+  "source_digest_sha256": "28efe46a7d195354117148550c2099221c00f4d9572e40d6bc906677fd6e029a",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "051794699293f8919b9b6273d4a1036726bf7fb975253d3cc07d6f774e9079ad"
+  "target_digest_sha256": "28efe46a7d195354117148550c2099221c00f4d9572e40d6bc906677fd6e029a"
 }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -36,6 +36,16 @@ def _add_agilab_lib_paths(agilab_package_root: Path) -> None:
     _add_path(agilab_package_root / "lib/agi-gui/src")
 
 
+def _is_site_packages_path(path: Path) -> bool:
+    return "site-packages" in path.parts
+
+
+def _should_use_agilab_path_fallback(path: Path) -> bool:
+    """Avoid documenting stale installed wheels when a source checkout is built."""
+
+    return not _is_site_packages_path(path)
+
+
 # Prefer the pinned public framework submodule when present.
 if (repo_root / ".external/agilab/src").exists():
     _add_path(repo_root / ".external/agilab/src")
@@ -48,8 +58,16 @@ if (repo_root / ".external/agilab/src/agilab/core").exists():
 if (repo_root / "core").exists():
     _add_core_paths(repo_root / "core")
 
+# Current public source checkout. Prefer this over any persisted installed path
+# so autodoc does not import stale binary wheels from another Python version.
+if (repo_root / "src/agilab").exists():
+    _add_path(repo_root / "src")
+    _add_agilab_lib_paths(repo_root / "src/agilab")
+    if (repo_root / "src/agilab/core").exists():
+        _add_core_paths(repo_root / "src/agilab/core")
+
 # Fallback: use the upstream checkout recorded by `~/.local/share/agilab/.agilab-path`.
-if agi_path is not None:
+if agi_path is not None and _should_use_agilab_path_fallback(agi_path):
     # `.agilab-path` commonly points at `<repo>/src/agilab`. Add the parent so
     # `import agilab` works, while still supporting a repo-root path.
     if agi_path.name == "agilab" and (agi_path / "__init__.py").exists():
@@ -62,6 +80,11 @@ if agi_path is not None:
         _add_core_paths(agi_path / "src/agilab/core")
     elif (agi_path / "core").exists():
         _add_core_paths(agi_path / "core")
+elif agi_path is not None:
+    print(
+        "Info: ignoring installed AGILAB path for docs build "
+        f"because it points into site-packages: {agi_path}"
+    )
 
 try:
     from agi_env import AgiEnv  # noqa: F401  # Optional at build time

--- a/test/test_docs_version_label.py
+++ b/test/test_docs_version_label.py
@@ -51,3 +51,16 @@ def test_docs_conf_skips_generated_root_project_workspaces() -> None:
         )
         is False
     )
+
+
+def test_docs_conf_ignores_installed_agilab_path_fallback() -> None:
+    conf = _load_conf_module()
+
+    installed_agilab = (
+        Path("/tmp/uv-cache/archive/lib/python3.14/site-packages/agilab")
+    )
+    source_agilab = Path("/tmp/agilab/src/agilab")
+
+    assert conf._is_site_packages_path(installed_agilab) is True
+    assert conf._should_use_agilab_path_fallback(installed_agilab) is False
+    assert conf._should_use_agilab_path_fallback(source_agilab) is True


### PR DESCRIPTION
## Summary
- prefer the current source checkout in Sphinx docs path setup
- ignore persisted .agilab-path values that point into site-packages
- add a regression for polluted installed-package fallback paths

## Validation
- uv --preview-features extra-build-dependencies run pytest -q -o addopts= test/test_docs_version_label.py
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs
- ./dev scope