### PR TITLE
Prepare 2026.06.04 release packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.02.post1"
+version = "2026.06.04"
 name = "agilab"
 description = "AGILAB is a reproducible AI/ML workbench for engineering teams."
 requires-python = ">=3.11,<3.14"
@@ -60,19 +60,21 @@ agilab-mcp = "agilab_mcp.server:main"
 
 [project.optional-dependencies]
 ai = ["openai>=2.32.0,<3"]
-core = ["agi-core==2026.06.02.post1"]
-ui = ["agi-apps==2026.06.02.post1", "agi-pages==2026.06.02.post1", "agi-gui==2026.06.02.post1", "agi-web==2026.06.01", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "streamlit>=1.58,<2", "starlette>=1.0.1,<2", "tomli_w>=1.2.0,<2"]
+core = ["agi-core==2026.06.04"]
+ui = ["agi-apps==2026.06.04", "agi-pages==2026.06.04", "agi-gui==2026.06.04", "agi-web==2026.06.01", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "streamlit>=1.58,<2", "starlette>=1.0.1,<2", "tomli_w>=1.2.0,<2"]
 viz = ["matplotlib>=3.10.0,<4", "plotly>=6.7.0,<7"]
 mlflow = ["mlflow>=3.11.1,<4", "idna>=3.15,<4", "starlette>=1.0.1,<2"]
 bridges = ["duckdb>=1.4.0,<2"]
 notebook = ["ipykernel>=6.29.0,<8", "nbclient>=0.10.0,<1", "nbformat>=5.10.0,<6"]
-examples = ["agi-apps==2026.06.02.post1", "jupyterlab>=4.4.0,<5", "matplotlib>=3.10.0,<4", "plotly>=6.7.0,<7", "starlette>=1.0.1,<2"]
-pages = ["agi-pages==2026.06.02.post1", "starlette>=1.0.1,<2"]
+examples = ["agi-apps==2026.06.04", "jupyterlab>=4.4.0,<5", "matplotlib>=3.10.0,<4", "plotly>=6.7.0,<7", "starlette>=1.0.1,<2"]
+pages = ["agi-pages==2026.06.04", "starlette>=1.0.1,<2"]
 proof = ["cryptography>=46.0.0,<49"]
 agents = ["openai>=2.32.0,<3"]
 local-llm = ["accelerate>=0.34.2,<2; python_version >= '3.12'", "fastapi>=0.124.4,!=0.136.3,<1; python_version >= '3.12'", "gpt-oss>=0.0.8,<0.1; python_version >= '3.12'", "langchain-core>=1.3.3,<2; python_version >= '3.12'", "langsmith>=0.8.0,<1; python_version >= '3.12'", "mlx>=0.31.2,<0.32; sys_platform == 'darwin' and platform_machine == 'arm64'", "mlx-lm>=0.31.3,<0.32; sys_platform == 'darwin' and platform_machine == 'arm64'", "mlx-vlm>=0.5.0,<0.6; sys_platform == 'darwin' and platform_machine == 'arm64'", "requests>=2.32.0,<3; python_version >= '3.12'", "starlette>=1.0.1,<2; python_version >= '3.12'", "torch>=2.8.0,<3; python_version >= '3.12'", "transformers>=4.57.0,<6; python_version >= '3.12'", "universal-offline-ai-chatbot>=0.1.0,<0.2; python_version >= '3.12'"]
 offline = ["accelerate>=0.34.2,<2; python_version >= '3.12'", "fastapi>=0.124.4,!=0.136.3,<1; python_version >= '3.12'", "gpt-oss>=0.0.8,<0.1; python_version >= '3.12'", "langchain-core>=1.3.3,<2; python_version >= '3.12'", "langsmith>=0.8.0,<1; python_version >= '3.12'", "mlx>=0.31.2,<0.32; sys_platform == 'darwin' and platform_machine == 'arm64'", "mlx-lm>=0.31.3,<0.32; sys_platform == 'darwin' and platform_machine == 'arm64'", "mlx-vlm>=0.5.0,<0.6; sys_platform == 'darwin' and platform_machine == 'arm64'", "requests>=2.32.0,<3; python_version >= '3.12'", "starlette>=1.0.1,<2; python_version >= '3.12'", "torch>=2.8.0,<3; python_version >= '3.12'", "transformers>=4.57.0,<6; python_version >= '3.12'", "universal-offline-ai-chatbot>=0.1.0,<0.2; python_version >= '3.12'"]
 dev = ["build>=1.3.0,<2", "cyclonedx-bom>=7.2.1,<8", "pip-audit>=2.9.0,<3", "pytest>=9.0.0,<10", "pytest-asyncio>=1.3.0,<2", "pytest-cov>=7.0.0,<8", "ruff>=0.15.14,<1", "tomlkit>=0.13.0,<1", "twine>=6.2.0,<7", "wheel>=0.45.0,<1"]
+
+
 
 
 

--- a/src/agilab/apps-pages/view_release_decision/pyproject.toml
+++ b/src/agilab/apps-pages/view_release_decision/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-promotion-gate"
-version = "2026.06.02.post1"
+version = "2026.06.04"
 description = "AGILAB page bundle for evidence-cockpit run review and promotion gates."
 readme = { text = "AGILAB page bundle for evidence-cockpit run review and promotion gates.", content-type = "text/markdown" }
 requires-python = ">=3.11"
@@ -35,6 +35,7 @@ Homepage = "https://github.com/ThalesGroup/agilab"
 Repository = "https://github.com/ThalesGroup/agilab"
 Discussions = "https://github.com/ThalesGroup/agilab/discussions"
 Changelog = "https://github.com/ThalesGroup/agilab/releases"
+
 
 
 

--- a/src/agilab/core/agi-cluster/pyproject.toml
+++ b/src/agilab/core/agi-cluster/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.02.post1"
+version = "2026.06.04"
 name = "agi-cluster"
 description = "Distributed cluster orchestration layer for AGILAB workers over local and SSH backends"
 requires-python = ">=3.11"
@@ -35,7 +35,7 @@ keywords = [
     "job-scheduling",
     "mlops",
 ]
-dependencies = ["agi-env==2026.06.02.post1", "agi-node==2026.06.02.post1", "asyncssh>=2.23,<3", "dask[distributed]>=2026.3,<2027.0", "humanize>=4.10,<5", "numpy>=2.2,<3", "packaging>=25,<27", "polars>=1.35,<2", "psutil>=7,<8", "scikit-learn>=1.7.2,<2", "tomlkit>=0.13,<1"]
+dependencies = ["agi-env==2026.06.04", "agi-node==2026.06.04", "asyncssh>=2.23,<3", "dask[distributed]>=2026.3,<2027.0", "humanize>=4.10,<5", "numpy>=2.2,<3", "packaging>=25,<27", "polars>=1.35,<2", "psutil>=7,<8", "scikit-learn>=1.7.2,<2", "tomlkit>=0.13,<1"]
 
 [project.entry-points."agi_env.runtime_packages"]
 agi-cluster = "agi_cluster.agi_env_runtime:RUNTIME_PACKAGE_SPEC"
@@ -48,6 +48,8 @@ Homepage = "https://github.com/ThalesGroup/agilab"
 Repository = "https://github.com/ThalesGroup/agilab"
 Discussions = "https://github.com/ThalesGroup/agilab/discussions"
 Changelog = "https://github.com/ThalesGroup/agilab/releases"
+
+
 
 
 

--- a/src/agilab/core/agi-core/pyproject.toml
+++ b/src/agilab/core/agi-core/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.02.post1"
+version = "2026.06.04"
 name = "agi-core"
 description = "Meta-package that installs and wires agi-env, agi-node, and agi-cluster together"
 readme = "README.md"
@@ -30,7 +30,7 @@ keywords = [
   "distributed-computing",
   "distributed-execution",
 ]
-dependencies = ["agi-env==2026.06.02.post1", "agi-node==2026.06.02.post1", "agi-cluster==2026.06.02.post1"]
+dependencies = ["agi-env==2026.06.04", "agi-node==2026.06.04", "agi-cluster==2026.06.04"]
 
 [project.entry-points."agi_env.runtime_packages"]
 agi-core = "agi_core.agi_env_runtime:RUNTIME_PACKAGE_SPEC"
@@ -42,6 +42,8 @@ Documentation = "https://thalesgroup.github.io/agilab"
 Repository = "https://github.com/ThalesGroup/agilab"
 Discussions = "https://github.com/ThalesGroup/agilab/discussions"
 Changelog = "https://github.com/ThalesGroup/agilab/releases"
+
+
 
 
 

--- a/src/agilab/core/agi-env/pyproject.toml
+++ b/src/agilab/core/agi-env/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.02.post1"
+version = "2026.06.04"
 name = "agi-env"
 description = "Environment bootstrap package for AGILAB with virtualenv, path, and runtime helpers"
 requires-python = ">=3.11"
@@ -53,6 +53,7 @@ Homepage = "https://github.com/ThalesGroup/agilab"
 Repository = "https://github.com/ThalesGroup/agilab"
 Discussions = "https://github.com/ThalesGroup/agilab/discussions"
 Changelog = "https://github.com/ThalesGroup/agilab/releases"
+
 
 
 

--- a/src/agilab/core/agi-node/pyproject.toml
+++ b/src/agilab/core/agi-node/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.02.post1"
+version = "2026.06.04"
 name = "agi-node"
 description = "Distributed worker orchestration and execution support library for AGILAB"
 requires-python = ">=3.11"
@@ -35,7 +35,7 @@ keywords = [
     "pandas",
     "polars",
 ]
-dependencies = ["agi-env==2026.06.02.post1", "cython>=3.1,<4", "humanize>=4.10,<5", "numpy>=2.2,<3", "pandas>=2.3,<4", "parso>=0.8,<1", "polars>=1.35,<2", "psutil>=7,<8", "py7zr>=1.1,<1.2", "setuptools>=68,<83"]
+dependencies = ["agi-env==2026.06.04", "cython>=3.1,<4", "humanize>=4.10,<5", "numpy>=2.2,<3", "pandas>=2.3,<4", "parso>=0.8,<1", "polars>=1.35,<2", "psutil>=7,<8", "py7zr>=1.1,<1.2", "setuptools>=68,<83"]
 
 [project.entry-points."agi_env.runtime_packages"]
 agi-node = "agi_node.agi_env_runtime:RUNTIME_PACKAGE_SPEC"
@@ -48,6 +48,8 @@ Homepage = "https://github.com/ThalesGroup/agilab"
 Repository = "https://github.com/ThalesGroup/agilab"
 Discussions = "https://github.com/ThalesGroup/agilab/discussions"
 Changelog = "https://github.com/ThalesGroup/agilab/releases"
+
+
 
 
 

--- a/src/agilab/lib/agi-app-data-quality-gate/pyproject.toml
+++ b/src/agilab/lib/agi-app-data-quality-gate/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.31"
+version = "2026.06.04"
 name = "agi-app-data-quality-gate"
 description = "AGILAB deterministic data contract, drift, leakage, and promotion gate"
 requires-python = ">=3.11"
@@ -46,6 +46,7 @@ Changelog = "https://github.com/ThalesGroup/agilab/releases"
 [project.entry-points."agilab.apps"]
 data_quality_gate = "agi_app_data_quality_gate:project_root"
 data_quality_gate_project = "agi_app_data_quality_gate:project_root"
+
 
 
 [dependency-groups]

--- a/src/agilab/lib/agi-app-flight-telemetry/pyproject.toml
+++ b/src/agilab/lib/agi-app-flight-telemetry/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.02.post1"
+version = "2026.06.04"
 name = "agi-app-flight-telemetry"
 description = "AGILAB flight-telemetry ingestion demo with reusable dataframe and map-analysis outputs"
 requires-python = ">=3.11"
@@ -44,6 +44,7 @@ Changelog = "https://github.com/ThalesGroup/agilab/releases"
 [project.entry-points."agilab.apps"]
 flight_telemetry = "agi_app_flight_telemetry:project_root"
 flight_telemetry_project = "agi_app_flight_telemetry:project_root"
+
 
 
 

--- a/src/agilab/lib/agi-app-mission-decision/pyproject.toml
+++ b/src/agilab/lib/agi-app-mission-decision/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.02.post1"
+version = "2026.06.04"
 name = "agi-app-mission-decision"
 description = "Deterministic AGILAB mission-decision workflow with scenario scoring and evidence artifacts"
 requires-python = ">=3.11"
@@ -44,6 +44,7 @@ Changelog = "https://github.com/ThalesGroup/agilab/releases"
 [project.entry-points."agilab.apps"]
 mission_decision = "agi_app_mission_decision:project_root"
 mission_decision_project = "agi_app_mission_decision:project_root"
+
 
 
 

--- a/src/agilab/lib/agi-app-multi-dag/pyproject.toml
+++ b/src/agilab/lib/agi-app-multi-dag/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.31"
+version = "2026.06.04"
 name = "agi-app-multi-dag"
 description = "AGILAB cross-app DAG preview showing artifact handoffs between demo projects"
 requires-python = ">=3.11"
@@ -44,6 +44,7 @@ Changelog = "https://github.com/ThalesGroup/agilab/releases"
 [project.entry-points."agilab.apps"]
 multi_app_dag = "agi_app_multi_dag:project_root"
 multi_app_dag_project = "agi_app_multi_dag:project_root"
+
 
 
 

--- a/src/agilab/lib/agi-app-pandas-execution/pyproject.toml
+++ b/src/agilab/lib/agi-app-pandas-execution/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.31"
+version = "2026.06.04"
 name = "agi-app-pandas-execution"
 description = "AGILAB Pandas execution benchmark for deterministic worker and reducer validation"
 requires-python = ">=3.11"
@@ -44,6 +44,7 @@ Changelog = "https://github.com/ThalesGroup/agilab/releases"
 [project.entry-points."agilab.apps"]
 execution_pandas = "agi_app_pandas_execution:project_root"
 execution_pandas_project = "agi_app_pandas_execution:project_root"
+
 
 
 

--- a/src/agilab/lib/agi-app-polars-execution/pyproject.toml
+++ b/src/agilab/lib/agi-app-polars-execution/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.31"
+version = "2026.06.04"
 name = "agi-app-polars-execution"
 description = "AGILAB Polars execution benchmark for deterministic worker and reducer validation"
 requires-python = ">=3.11"
@@ -44,6 +44,7 @@ Changelog = "https://github.com/ThalesGroup/agilab/releases"
 [project.entry-points."agilab.apps"]
 execution_polars = "agi_app_polars_execution:project_root"
 execution_polars_project = "agi_app_polars_execution:project_root"
+
 
 
 

--- a/src/agilab/lib/agi-app-pytorch-playground/pyproject.toml
+++ b/src/agilab/lib/agi-app-pytorch-playground/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.02.post1"
+version = "2026.06.04"
 name = "agi-app-pytorch-playground"
 description = "AGILAB PyTorch playground app for reproducible neural-network experiments"
 requires-python = ">=3.12"
@@ -44,6 +44,7 @@ Changelog = "https://github.com/ThalesGroup/agilab/releases"
 [project.entry-points."agilab.apps"]
 pytorch_playground = "agi_app_pytorch_playground:project_root"
 pytorch_playground_project = "agi_app_pytorch_playground:project_root"
+
 
 
 

--- a/src/agilab/lib/agi-app-sklearn-pipeline/pyproject.toml
+++ b/src/agilab/lib/agi-app-sklearn-pipeline/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.31"
+version = "2026.06.04"
 name = "agi-app-sklearn-pipeline"
 description = "AGILAB scikit-learn pipeline app with model, metrics, predictions, and evidence manifest"
 requires-python = ">=3.11"
@@ -46,6 +46,7 @@ Changelog = "https://github.com/ThalesGroup/agilab/releases"
 [project.entry-points."agilab.apps"]
 sklearn_pipeline = "agi_app_sklearn_pipeline:project_root"
 sklearn_pipeline_project = "agi_app_sklearn_pipeline:project_root"
+
 
 
 

--- a/src/agilab/lib/agi-app-tescia-diagnostic/pyproject.toml
+++ b/src/agilab/lib/agi-app-tescia-diagnostic/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.31"
+version = "2026.06.04"
 name = "agi-app-tescia-diagnostic"
 description = "AGILAB TeSciA-style diagnostic workflow with evidence scoring and regression-plan artifacts"
 requires-python = ">=3.13"
@@ -42,6 +42,7 @@ Changelog = "https://github.com/ThalesGroup/agilab/releases"
 [project.entry-points."agilab.apps"]
 tescia_diagnostic = "agi_app_tescia_diagnostic:project_root"
 tescia_diagnostic_project = "agi_app_tescia_diagnostic:project_root"
+
 
 
 

--- a/src/agilab/lib/agi-app-uav-queue/pyproject.toml
+++ b/src/agilab/lib/agi-app-uav-queue/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.05.31"
+version = "2026.06.04"
 name = "agi-app-uav-queue"
 description = "AGILAB UAV queue simulation demo with scenario evidence and network-map artifacts"
 requires-python = ">=3.13"
@@ -42,6 +42,7 @@ Changelog = "https://github.com/ThalesGroup/agilab/releases"
 [project.entry-points."agilab.apps"]
 uav_queue = "agi_app_uav_queue:project_root"
 uav_queue_project = "agi_app_uav_queue:project_root"
+
 
 
 

--- a/src/agilab/lib/agi-app-uav-relay-queue/pyproject.toml
+++ b/src/agilab/lib/agi-app-uav-relay-queue/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.02.post1"
+version = "2026.06.04"
 name = "agi-app-uav-relay-queue"
 description = "AGILAB UAV relay queue simulation demo with routing, delay, and resilience artifacts"
 requires-python = ">=3.13"
@@ -42,6 +42,7 @@ Changelog = "https://github.com/ThalesGroup/agilab/releases"
 [project.entry-points."agilab.apps"]
 uav_relay_queue = "agi_app_uav_relay_queue:project_root"
 uav_relay_queue_project = "agi_app_uav_relay_queue:project_root"
+
 
 
 

--- a/src/agilab/lib/agi-app-weather-forecast/pyproject.toml
+++ b/src/agilab/lib/agi-app-weather-forecast/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.02.post1"
+version = "2026.06.04"
 name = "agi-app-weather-forecast"
 description = "AGILAB weather-forecast notebook-migration demo with forecast analysis artifacts"
 requires-python = ">=3.11"
@@ -44,6 +44,7 @@ Changelog = "https://github.com/ThalesGroup/agilab/releases"
 [project.entry-points."agilab.apps"]
 weather_forecast = "agi_app_weather_forecast:project_root"
 weather_forecast_project = "agi_app_weather_forecast:project_root"
+
 
 
 

--- a/src/agilab/lib/agi-apps/pyproject.toml
+++ b/src/agilab/lib/agi-apps/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.02.post1"
+version = "2026.06.04"
 name = "agi-apps"
 description = "AGILAB public app package umbrella and example assets"
 requires-python = ">=3.11"
@@ -31,7 +31,7 @@ keywords = [
     "workflow-orchestration",
 ]
 
-dependencies = ["agi-core==2026.06.02.post1", "agi-app-mission-decision==2026.06.02.post1", "agi-app-pandas-execution==2026.05.31", "agi-app-polars-execution==2026.05.31", "agi-app-flight-telemetry==2026.06.02.post1", "agi-app-multi-dag==2026.05.31", "agi-app-weather-forecast==2026.06.02.post1", "agi-app-sklearn-pipeline==2026.05.31", "agi-app-pytorch-playground==2026.06.02.post1; python_version >= '3.12'", "agi-app-tescia-diagnostic==2026.05.31; python_version >= '3.13'", "agi-app-uav-relay-queue==2026.06.02.post1; python_version >= '3.13'"]
+dependencies = ["agi-core==2026.06.04", "agi-app-mission-decision==2026.06.04", "agi-app-pandas-execution==2026.06.04", "agi-app-polars-execution==2026.06.04", "agi-app-flight-telemetry==2026.06.04", "agi-app-multi-dag==2026.06.04", "agi-app-weather-forecast==2026.06.04", "agi-app-sklearn-pipeline==2026.06.04", "agi-app-pytorch-playground==2026.06.04; python_version >= '3.12'", "agi-app-tescia-diagnostic==2026.06.04; python_version >= '3.13'", "agi-app-uav-relay-queue==2026.06.04; python_version >= '3.13'"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"
@@ -41,6 +41,8 @@ Homepage = "https://github.com/ThalesGroup/agilab"
 Repository = "https://github.com/ThalesGroup/agilab"
 Discussions = "https://github.com/ThalesGroup/agilab/discussions"
 Changelog = "https://github.com/ThalesGroup/agilab/releases"
+
+
 
 
 

--- a/src/agilab/lib/agi-gui/pyproject.toml
+++ b/src/agilab/lib/agi-gui/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.02.post1"
+version = "2026.06.04"
 name = "agi-gui"
 description = "AGILAB Streamlit UI dependency bundle and compatibility imports"
 requires-python = ">=3.11"
@@ -32,7 +32,7 @@ keywords = [
     "python",
 ]
 
-dependencies = ["agi-env==2026.06.02.post1", "streamlit>=1.58,<2", "starlette>=1.0.1,<2", "streamlit_code_editor>=0.1.22,<0.2", "watchdog>=6,<7"]
+dependencies = ["agi-env==2026.06.04", "streamlit>=1.58,<2", "starlette>=1.0.1,<2", "streamlit_code_editor>=0.1.22,<0.2", "watchdog>=6,<7"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"
@@ -42,6 +42,8 @@ Homepage = "https://github.com/ThalesGroup/agilab"
 Repository = "https://github.com/ThalesGroup/agilab"
 Discussions = "https://github.com/ThalesGroup/agilab/discussions"
 Changelog = "https://github.com/ThalesGroup/agilab/releases"
+
+
 
 
 

--- a/src/agilab/lib/agi-pages/pyproject.toml
+++ b/src/agilab/lib/agi-pages/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.02.post1"
+version = "2026.06.04"
 name = "agi-pages"
 description = "AGILAB public analysis page umbrella and provider package"
 requires-python = ">=3.11"
@@ -34,7 +34,7 @@ keywords = [
     "page-bundles",
 ]
 
-dependencies = ["agi-gui==2026.06.02.post1"]
+dependencies = ["agi-gui==2026.06.04"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"
@@ -44,6 +44,8 @@ Homepage = "https://github.com/ThalesGroup/agilab"
 Repository = "https://github.com/ThalesGroup/agilab"
 Discussions = "https://github.com/ThalesGroup/agilab/discussions"
 Changelog = "https://github.com/ThalesGroup/agilab/releases"
+
+
 
 
 

--- a/test/test_pypi_publish.py
+++ b/test/test_pypi_publish.py
@@ -436,19 +436,20 @@ def test_public_post_release_policy_rejects_post_release_even_with_legacy_env(mo
     assert "YYYY.MM.DD.N" in message
 
 
-def test_public_post_release_policy_accepts_same_day_hotfix_version() -> None:
+def test_public_post_release_policy_accepts_hotfix_and_rejects_dry_run_post_release() -> None:
     module = _load_pypi_publish()
     module.require_public_post_release_policy(
         _base_cfg(module, repo="pypi", git_tag=True, git_commit_version=True, git_reset_on_failure=True),
         {"agilab": "2026.05.18.1"},
     )
 
-    module.require_public_post_release_policy(
-        _base_cfg(module, repo="pypi", dry_run=True),
-        {"agilab": "2026.05.18.post1"},
-    )
+    with pytest.raises(SystemExit) as excinfo:
+        module.require_public_post_release_policy(
+            _base_cfg(module, repo="pypi", dry_run=True),
+            {"agilab": "2026.05.18.post1"},
+        )
 
-    assert "Publication would require" in capsys.readouterr().out
+    assert ".postN releases are forbidden" in str(excinfo.value)
 
 
 def test_release_preflight_profiles_only_for_real_pypi() -> None:


### PR DESCRIPTION
## Summary
- Bump the impacted AGILAB split-package release closure to 2026.06.04.
- Update exact internal package pins for the top-level, core, UI, page, and app bundle packages.
- Align the PyPI release policy regression test with the stable-date release rule that forbids public .postN releases, including dry-run checks.

## Local validation
- `./dev maintenance`
- release proof check inside `./dev release` passed; full command stops on branch-ahead strict audit until merged to main
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_release_plan.py test/test_pypi_publish.py test/test_pypi_release_version_policy.py test/test_pypi_publish_workflow.py test/test_app_contract_matrix.py`
- `uv --preview-features extra-build-dependencies run python tools/release_plan.py --check-workflow .github/workflows/pypi-publish.yaml --impact-base-ref v2026.06.02 --skip-existing-pypi --format json --compact`
- `uv --preview-features extra-build-dependencies run python tools/pypi_release_version_policy.py --impact-base-ref v2026.06.02`
- `uv --preview-features extra-build-dependencies run python tools/pypi_project_preflight.py`
- `uv --preview-features extra-build-dependencies run python tools/pypi_trusted_publisher_contract.py --check-workflow .github/workflows/pypi-publish.yaml`
- `uv --preview-features extra-build-dependencies run python tools/app_contract_matrix.py --quiet`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile dependency-policy --profile shared-core-typing --profile docs`
- top-level wheel metadata check: `agilab==2026.6.4` and internal pins point to `2026.06.04` except unchanged `agi-web==2026.06.01`

## Release notes
- The checked-in release proof and PyPI badge intentionally remain on latest proven public release 2026.06.02 until the publishing workflow refreshes public evidence.