### PR TITLE
Fix cluster share SSHFS test portability

### DIFF
--- a/test/test_cluster_flight_validation.py
+++ b/test/test_cluster_flight_validation.py
@@ -556,7 +556,10 @@ def test_share_setup_script_lines_print_sshfs_commands(tmp_path: Path):
     assert 'ssh -p "$SCHEDULER_SSH_PORT" -o BatchMode=yes -o ConnectTimeout=5 "$SCHEDULER_SSH_TARGET" true' in script
     assert 'sshfs -p "$SCHEDULER_SSH_PORT" "$SCHEDULER_CLUSTER_SHARE"' in script
     assert "Scheduler SSH is not reachable from the worker" in script
-    assert "agi@192.168.3.103:/System/Volumes/Data/home/agilab/clustershare/agilab-two-node" in script
+    expected_scheduler_share = (
+        f"agi@192.168.3.103:{cfv.local_cluster_share_root(plan).as_posix()}"
+    )
+    assert expected_scheduler_share in script
     assert "jpm@192.168.3.35" in script
     assert "-o reconnect" in script
     assert "-o ServerAliveInterval=15" in script


### PR DESCRIPTION
## Summary
- derive the expected scheduler SSHFS source path from the validation plan instead of hardcoding a macOS canonical path

## Validation
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_cluster_flight_validation.py::test_share_setup_script_lines_print_sshfs_commands test/test_cluster_flight_validation.py::test_apply_share_setup_runs_idempotent_remote_commands
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui