### PR TITLE
Fix PyPI retention confirmation token path

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -695,7 +695,6 @@ jobs:
       PYPI_RELEASE_PRUNE_PASSWORD: ${{ secrets.PYPI_RELEASE_PRUNE_PASSWORD }}
       PYPI_RELEASE_PRUNE_TOTP_SECRET: ${{ secrets.PYPI_RELEASE_PRUNE_TOTP_SECRET }}
       PYPI_RELEASE_PRUNE_OTP: ${{ secrets.PYPI_RELEASE_PRUNE_OTP }}
-      PYPI_CONFIRM_READER_TOKEN: ${{ secrets.PYPI_CONFIRM_READER_TOKEN }}
       PYPI_RETENTION_PACKAGES: ${{ needs.release-plan.outputs.provenance_packages }}
     steps:
       - name: Checkout repository
@@ -726,7 +725,7 @@ jobs:
             --github-confirm-login-variable "PYPI_CONFIRM_LOGIN_URL"
             --github-confirm-login-timeout 1800
             --github-confirm-login-poll-delay 5
-            --github-token "${PYPI_CONFIRM_READER_TOKEN:-$GITHUB_TOKEN}"
+            --github-token "$GITHUB_TOKEN"
           )
           for package in ${PYPI_RETENTION_PACKAGES}; do
             args+=(--package "$package")

--- a/.github/workflows/pypi-release-retention.yaml
+++ b/.github/workflows/pypi-release-retention.yaml
@@ -12,7 +12,7 @@ on:
 
 permissions:
   contents: read
-  actions: read
+  actions: write
 
 jobs:
   retention:
@@ -22,7 +22,6 @@ jobs:
       PYPI_RELEASE_PRUNE_PASSWORD: ${{ secrets.PYPI_RELEASE_PRUNE_PASSWORD }}
       PYPI_RELEASE_PRUNE_TOTP_SECRET: ${{ secrets.PYPI_RELEASE_PRUNE_TOTP_SECRET }}
       PYPI_RELEASE_PRUNE_OTP: ${{ secrets.PYPI_RELEASE_PRUNE_OTP }}
-      PYPI_CONFIRM_READER_TOKEN: ${{ secrets.PYPI_CONFIRM_READER_TOKEN }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -61,4 +60,4 @@ jobs:
             --github-confirm-login-variable "PYPI_CONFIRM_LOGIN_URL" \
             --github-confirm-login-timeout 1800 \
             --github-confirm-login-poll-delay 5 \
-            --github-token "${PYPI_CONFIRM_READER_TOKEN:-$GITHUB_TOKEN}"
+            --github-token "$GITHUB_TOKEN"

--- a/test/test_pypi_publish_workflow.py
+++ b/test/test_pypi_publish_workflow.py
@@ -13,6 +13,7 @@ from package_split_contract import LIBRARY_PACKAGE_CONTRACTS, PACKAGE_NAMES, UMB
 
 WORKFLOW_PATH = REPO_ROOT / ".github/workflows/pypi-publish.yaml"
 TEST_PYPI_WORKFLOW_PATH = REPO_ROOT / ".github/workflows/test-pypi-publish.yaml"
+PYPI_RELEASE_RETENTION_WORKFLOW_PATH = REPO_ROOT / ".github/workflows/pypi-release-retention.yaml"
 
 
 def test_pypi_publish_runs_live_artifact_index_evidence_before_publish() -> None:
@@ -357,7 +358,6 @@ def test_pypi_publish_attempts_previous_pypi_release_pruning_before_release_asse
     assert "PYPI_RELEASE_PRUNE_PASSWORD: ${{ secrets.PYPI_RELEASE_PRUNE_PASSWORD }}" in text
     assert "PYPI_RELEASE_PRUNE_TOTP_SECRET: ${{ secrets.PYPI_RELEASE_PRUNE_TOTP_SECRET }}" in text
     assert "PYPI_RELEASE_PRUNE_OTP: ${{ secrets.PYPI_RELEASE_PRUNE_OTP }}" in text
-    assert "PYPI_CONFIRM_READER_TOKEN: ${{ secrets.PYPI_CONFIRM_READER_TOKEN }}" in text
     assert "PYPI_RETENTION_PACKAGES: ${{ needs.release-plan.outputs.provenance_packages }}" in text
     assert "python -m pip install --upgrade --no-cache-dir packaging pypi-cleanup requests" in text
     assert "tools/pypi_release_retention.py" in text
@@ -368,7 +368,8 @@ def test_pypi_publish_attempts_previous_pypi_release_pruning_before_release_asse
     assert "--github-confirm-login-variable \"PYPI_CONFIRM_LOGIN_URL\"" in text
     assert "--github-confirm-login-timeout 1800" in text
     assert "--github-confirm-login-poll-delay 5" in text
-    assert "--github-token \"${PYPI_CONFIRM_READER_TOKEN:-$GITHUB_TOKEN}\"" in text
+    assert "--github-token \"$GITHUB_TOKEN\"" in text
+    assert "PYPI_CONFIRM_READER_TOKEN" not in retention_block
     assert "Clear temporary PyPI confirmation variable" in retention_block
     assert "if: ${{ always() }}" in retention_block
     assert "_cleanup_github_confirm_login_variable" in retention_block
@@ -379,6 +380,15 @@ def test_pypi_publish_attempts_previous_pypi_release_pruning_before_release_asse
     assert "needs.pypi-release-retention.result == 'success'" in text
     assert "needs.pypi-release-retention.result == 'skipped'" in text
     assert "      - pypi-release-retention" in text
+
+
+def test_dedicated_pypi_retention_workflow_can_read_confirmation_variable() -> None:
+    text = PYPI_RELEASE_RETENTION_WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    assert "permissions:\n  contents: read\n  actions: write" in text
+    assert "PYPI_CONFIRM_READER_TOKEN" not in text
+    assert "--github-confirm-login-variable \"PYPI_CONFIRM_LOGIN_URL\"" in text
+    assert "--github-token \"$GITHUB_TOKEN\"" in text
 
 
 def test_pypi_publish_repair_mode_skips_retention_without_blocking_release_assets() -> None:

--- a/tools/release_plan.py
+++ b/tools/release_plan.py
@@ -633,8 +633,8 @@ def validate_workflow_contract(workflow_path: Path) -> list[str]:
         "PYPI_RELEASE_PRUNE_TOTP_SECRET": (
             "workflow must support non-interactive PyPI 2FA for release pruning"
         ),
-        "PYPI_CONFIRM_READER_TOKEN": (
-            "workflow must support PyPI unrecognized-login confirmation polling"
+        "--github-token \"$GITHUB_TOKEN\"": (
+            "workflow must use the scoped GitHub token for PyPI login confirmation polling"
         ),
         "--confirm-delete": "workflow must make destructive PyPI retention explicit",
         "--github-confirm-login-variable": (


### PR DESCRIPTION
Use the workflow-scoped GITHUB_TOKEN for PyPI login-confirmation variable polling instead of an optional reader PAT, and give the dedicated retention workflow the required Actions permission.\n\nValidation:\n- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_pypi_publish_workflow.py test/test_release_plan.py\n- uv --preview-features extra-build-dependencies run python tools/release_plan.py --check-workflow .github/workflows/pypi-publish.yaml --skip-existing-pypi --format json --compact\n- ./dev impact --staged