### PR TITLE
Require PyPI confirmation reader token

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -695,6 +695,7 @@ jobs:
       PYPI_RELEASE_PRUNE_PASSWORD: ${{ secrets.PYPI_RELEASE_PRUNE_PASSWORD }}
       PYPI_RELEASE_PRUNE_TOTP_SECRET: ${{ secrets.PYPI_RELEASE_PRUNE_TOTP_SECRET }}
       PYPI_RELEASE_PRUNE_OTP: ${{ secrets.PYPI_RELEASE_PRUNE_OTP }}
+      PYPI_CONFIRM_READER_TOKEN: ${{ secrets.PYPI_CONFIRM_READER_TOKEN }}
       PYPI_RETENTION_PACKAGES: ${{ needs.release-plan.outputs.provenance_packages }}
     steps:
       - name: Checkout repository
@@ -713,6 +714,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euxo pipefail
+          test -n "${PYPI_CONFIRM_READER_TOKEN:-}" || {
+            echo "PYPI_CONFIRM_READER_TOKEN secret is required to read the temporary PyPI confirmation variable." >&2
+            exit 2
+          }
           args=(
             --repo pypi
             --repo-root .
@@ -725,7 +730,7 @@ jobs:
             --github-confirm-login-variable "PYPI_CONFIRM_LOGIN_URL"
             --github-confirm-login-timeout 1800
             --github-confirm-login-poll-delay 5
-            --github-token "$GITHUB_TOKEN"
+            --github-token "$PYPI_CONFIRM_READER_TOKEN"
           )
           for package in ${PYPI_RETENTION_PACKAGES}; do
             args+=(--package "$package")

--- a/.github/workflows/pypi-release-retention.yaml
+++ b/.github/workflows/pypi-release-retention.yaml
@@ -12,7 +12,7 @@ on:
 
 permissions:
   contents: read
-  actions: write
+  actions: read
 
 jobs:
   retention:
@@ -22,6 +22,7 @@ jobs:
       PYPI_RELEASE_PRUNE_PASSWORD: ${{ secrets.PYPI_RELEASE_PRUNE_PASSWORD }}
       PYPI_RELEASE_PRUNE_TOTP_SECRET: ${{ secrets.PYPI_RELEASE_PRUNE_TOTP_SECRET }}
       PYPI_RELEASE_PRUNE_OTP: ${{ secrets.PYPI_RELEASE_PRUNE_OTP }}
+      PYPI_CONFIRM_READER_TOKEN: ${{ secrets.PYPI_CONFIRM_READER_TOKEN }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -39,6 +40,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euxo pipefail
+          test -n "${PYPI_CONFIRM_READER_TOKEN:-}" || {
+            echo "PYPI_CONFIRM_READER_TOKEN secret is required to read the temporary PyPI confirmation variable." >&2
+            exit 2
+          }
           packages="${{ inputs.packages }}"
           if [[ -z "$packages" ]]; then
             packages="$(python - <<'PY'
@@ -60,4 +65,4 @@ jobs:
             --github-confirm-login-variable "PYPI_CONFIRM_LOGIN_URL" \
             --github-confirm-login-timeout 1800 \
             --github-confirm-login-poll-delay 5 \
-            --github-token "$GITHUB_TOKEN"
+            --github-token "$PYPI_CONFIRM_READER_TOKEN"

--- a/test/test_pypi_publish_workflow.py
+++ b/test/test_pypi_publish_workflow.py
@@ -358,6 +358,7 @@ def test_pypi_publish_attempts_previous_pypi_release_pruning_before_release_asse
     assert "PYPI_RELEASE_PRUNE_PASSWORD: ${{ secrets.PYPI_RELEASE_PRUNE_PASSWORD }}" in text
     assert "PYPI_RELEASE_PRUNE_TOTP_SECRET: ${{ secrets.PYPI_RELEASE_PRUNE_TOTP_SECRET }}" in text
     assert "PYPI_RELEASE_PRUNE_OTP: ${{ secrets.PYPI_RELEASE_PRUNE_OTP }}" in text
+    assert "PYPI_CONFIRM_READER_TOKEN: ${{ secrets.PYPI_CONFIRM_READER_TOKEN }}" in text
     assert "PYPI_RETENTION_PACKAGES: ${{ needs.release-plan.outputs.provenance_packages }}" in text
     assert "python -m pip install --upgrade --no-cache-dir packaging pypi-cleanup requests" in text
     assert "tools/pypi_release_retention.py" in text
@@ -368,8 +369,9 @@ def test_pypi_publish_attempts_previous_pypi_release_pruning_before_release_asse
     assert "--github-confirm-login-variable \"PYPI_CONFIRM_LOGIN_URL\"" in text
     assert "--github-confirm-login-timeout 1800" in text
     assert "--github-confirm-login-poll-delay 5" in text
-    assert "--github-token \"$GITHUB_TOKEN\"" in text
-    assert "PYPI_CONFIRM_READER_TOKEN" not in retention_block
+    assert "PYPI_CONFIRM_READER_TOKEN secret is required" in text
+    assert "--github-token \"$PYPI_CONFIRM_READER_TOKEN\"" in text
+    assert "--github-token \"${PYPI_CONFIRM_READER_TOKEN:-$GITHUB_TOKEN}\"" not in text
     assert "Clear temporary PyPI confirmation variable" in retention_block
     assert "if: ${{ always() }}" in retention_block
     assert "_cleanup_github_confirm_login_variable" in retention_block
@@ -385,10 +387,12 @@ def test_pypi_publish_attempts_previous_pypi_release_pruning_before_release_asse
 def test_dedicated_pypi_retention_workflow_can_read_confirmation_variable() -> None:
     text = PYPI_RELEASE_RETENTION_WORKFLOW_PATH.read_text(encoding="utf-8")
 
-    assert "permissions:\n  contents: read\n  actions: write" in text
-    assert "PYPI_CONFIRM_READER_TOKEN" not in text
+    assert "permissions:\n  contents: read\n  actions: read" in text
+    assert "PYPI_CONFIRM_READER_TOKEN: ${{ secrets.PYPI_CONFIRM_READER_TOKEN }}" in text
+    assert "PYPI_CONFIRM_READER_TOKEN secret is required" in text
     assert "--github-confirm-login-variable \"PYPI_CONFIRM_LOGIN_URL\"" in text
-    assert "--github-token \"$GITHUB_TOKEN\"" in text
+    assert "--github-token \"$PYPI_CONFIRM_READER_TOKEN\"" in text
+    assert "--github-token \"${PYPI_CONFIRM_READER_TOKEN:-$GITHUB_TOKEN}\"" not in text
 
 
 def test_pypi_publish_repair_mode_skips_retention_without_blocking_release_assets() -> None:

--- a/tools/release_plan.py
+++ b/tools/release_plan.py
@@ -633,8 +633,11 @@ def validate_workflow_contract(workflow_path: Path) -> list[str]:
         "PYPI_RELEASE_PRUNE_TOTP_SECRET": (
             "workflow must support non-interactive PyPI 2FA for release pruning"
         ),
-        "--github-token \"$GITHUB_TOKEN\"": (
-            "workflow must use the scoped GitHub token for PyPI login confirmation polling"
+        "PYPI_CONFIRM_READER_TOKEN": (
+            "workflow must require a PyPI confirmation reader token"
+        ),
+        "--github-token \"$PYPI_CONFIRM_READER_TOKEN\"": (
+            "workflow must use the explicit reader token for PyPI login confirmation polling"
         ),
         "--confirm-delete": "workflow must make destructive PyPI retention explicit",
         "--github-confirm-login-variable": (


### PR DESCRIPTION
Restore the explicit PyPI confirmation reader-token path and fail fast when the secret is missing. GitHub's workflow GITHUB_TOKEN returns HTTP 403 for the repository-variable read used by the retention tool.\n\nValidation:\n- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_pypi_publish_workflow.py test/test_release_plan.py\n- uv --preview-features extra-build-dependencies run python tools/release_plan.py --check-workflow .github/workflows/pypi-publish.yaml --skip-existing-pypi --format json --compact\n- ./dev impact --staged