### PR TITLE
Accept hotfix release tags in handoff guard

### DIFF
--- a/test/test_release_robustness_tools.py
+++ b/test/test_release_robustness_tools.py
@@ -158,6 +158,23 @@ def test_release_handoff_guard_requires_archiving_old_handoffs(tmp_path: Path) -
     ) == []
 
 
+def test_release_handoff_guard_accepts_dot_hotfix_release_tags(tmp_path: Path) -> None:
+    manifest = tmp_path / "release_proof.toml"
+    manifest.write_text(
+        "[release]\n"
+        'github_release_tag = "v2026.06.04.1"\n',
+        encoding="utf-8",
+    )
+    handoff = tmp_path / "v2026.06.04-handoff.md"
+    handoff.write_text("# AGILAB release handoff for v2026.06.04\n", encoding="utf-8")
+
+    assert release_handoff_guard.latest_release_tag(manifest) == "v2026.06.04.1"
+    assert release_handoff_guard.stale_handoffs(
+        handoff_dir=tmp_path,
+        latest_tag="v2026.06.04.1",
+    ) == [handoff]
+
+
 def test_pending_publisher_confirm_url_freshness_blocks_stale_variable() -> None:
     payload = pending_publisher.GitHubActionsVariable(
         value="https://pypi.org/account/confirm-login/?token=fresh",

--- a/tools/release_handoff_guard.py
+++ b/tools/release_handoff_guard.py
@@ -13,7 +13,7 @@ from typing import Sequence
 ROOT = Path(__file__).resolve().parents[1]
 HANDOFF_DIR = ROOT / "tools" / "release_handoffs"
 PROOF_MANIFEST = ROOT / "docs" / "source" / "data" / "release_proof.toml"
-TAG_RE = re.compile(r"v\d{4}\.\d{2}\.\d{2}(?:-\d+)?")
+TAG_RE = re.compile(r"v\d{4}\.\d{2}\.\d{2}(?:(?:-|\.)\d+)?")
 
 
 def _tag_key(tag: str) -> tuple[int, int, int, int]:
@@ -22,7 +22,11 @@ def _tag_key(tag: str) -> tuple[int, int, int, int]:
     if "-" in body:
         body, raw_suffix = body.rsplit("-", 1)
         suffix = int(raw_suffix) if raw_suffix.isdigit() else 0
-    year, month, day = (int(part) for part in body.split("."))
+    parts = body.split(".")
+    if len(parts) == 4:
+        raw_suffix = parts.pop()
+        suffix = int(raw_suffix) if raw_suffix.isdigit() else 0
+    year, month, day = (int(part) for part in parts)
     return year, month, day, suffix
 
 


### PR DESCRIPTION
Allow the release handoff guard to parse current dot-hotfix tags such as v2026.06.04.1, while preserving historical -N suffix support.\n\nValidation:\n- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_release_robustness_tools.py\n- uv --preview-features extra-build-dependencies run python tools/release_handoff_guard.py --compact\n- ./dev impact --staged