### PR TITLE
docs: link dataset release evidence

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -675,7 +675,9 @@ jobs:
           if ! gh release view "$release_tag" >/dev/null 2>&1; then
             gh release create "$release_tag" \
               --title "AGILAB ${release_tag#v}" \
-              --notes "AGILAB release artifacts and supply-chain evidence."
+              --notes "AGILAB release artifacts and supply-chain evidence.
+
+Dataset payloads are published in separate datasets-* GitHub releases when present and linked from the release proof."
           fi
           gh release upload "$release_tag" github-release-assets/* --clobber
 

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 252,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "f7d7dbffadaeee63bf28ee0eb7b74cfbcf7adfe73dc2394642728a0539df15d8",
+  "source_digest_sha256": "d9f20076da326654fdccc8d5a8e49843c9eadeeee7fde957320ed3d16d894fa6",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "f7d7dbffadaeee63bf28ee0eb7b74cfbcf7adfe73dc2394642728a0539df15d8"
+  "target_digest_sha256": "d9f20076da326654fdccc8d5a8e49843c9eadeeee7fde957320ed3d16d894fa6"
 }

--- a/docs/source/data/release_proof.toml
+++ b/docs/source/data/release_proof.toml
@@ -30,6 +30,10 @@ github_release_url = "https://github.com/ThalesGroup/agilab/releases/tag/v2026.0
 hf_space_label = "jpmorard/agilab"
 hf_space_url = "https://huggingface.co/spaces/jpmorard/agilab"
 hf_space_commit = "e7e1456d3a6cafb50a623a87618b566c9afbf835"
+dataset_release_tag = "datasets-2f602a17b4745f05"
+dataset_release_url = "https://github.com/ThalesGroup/agilab/releases/tag/datasets-2f602a17b4745f05"
+dataset_manifest_sha256 = "2f602a17b4745f05cf3b2612d720675b7063cabf90164326a25bc080b2396a0f"
+dataset_count = 13
 
 [[ci_runs]]
 id = "release-guardrails"

--- a/docs/source/release-proof.rst
+++ b/docs/source/release-proof.rst
@@ -21,6 +21,8 @@ Current public release
      - ``agilab[examples]==2026.06.04.1`` on `PyPI <https://pypi.org/project/agilab/>`__
    * - GitHub release
      - `v2026.06.04.1 <https://github.com/ThalesGroup/agilab/releases/tag/v2026.06.04.1>`__
+   * - Dataset release
+     - `datasets-2f602a17b4745f05 <https://github.com/ThalesGroup/agilab/releases/tag/datasets-2f602a17b4745f05>`__ for ``13`` tracked dataset files; manifest ``2f602a17b4745f05cf3b2612d720675b7063cabf90164326a25bc080b2396a0f``
    * - Hosted demo
      - `jpmorard/agilab <https://huggingface.co/spaces/jpmorard/agilab>`__ at Space commit ``e7e1456d3a6cafb50a623a87618b566c9afbf835``
    * - Public guardrails

--- a/test/test_release_proof_report.py
+++ b/test/test_release_proof_report.py
@@ -37,6 +37,7 @@ def test_release_proof_manifest_renders_checked_in_page() -> None:
     assert {check["id"] for check in report["checks"]} >= {
         "pyproject_version",
         "pypi_badge_version",
+        "dataset_release_url",
         "changelog_release",
         "readme_release_proof_link",
         "ui_robot_evidence",
@@ -97,6 +98,9 @@ def test_release_proof_refresh_from_local_updates_manifest_and_page(
     assert refreshed["release"]["package_version"] == module._load_project_version(Path.cwd())
     assert refreshed["release"]["github_release_tag"] == "v2026.05.01-2"
     assert refreshed["release"]["github_release_url"].endswith("/releases/tag/v2026.05.01-2")
+    assert refreshed["release"]["dataset_release_tag"].startswith("datasets-")
+    assert refreshed["release"]["dataset_release_tag"] in refreshed["release"]["dataset_release_url"]
+    assert refreshed["release"]["dataset_count"] > 0
     assert refreshed["release"]["hf_space_commit"] == "test-hf-commit"
     assert (docs_source / "release-proof.rst").read_text(encoding="utf-8") == module.render_release_proof(
         refreshed

--- a/tools/release_proof_report.py
+++ b/tools/release_proof_report.py
@@ -271,6 +271,22 @@ def render_release_proof(manifest: Mapping[str, Any]) -> str:
                 f"     - `{release['github_release_tag']} "
                 f"<{release['github_release_url']}>`__"
             ),
+        ]
+    )
+    dataset_release_tag = str(release.get("dataset_release_tag", "") or "")
+    dataset_release_url = str(release.get("dataset_release_url", "") or "")
+    if dataset_release_tag and dataset_release_url:
+        dataset_details = f"`{dataset_release_tag} <{dataset_release_url}>`__"
+        dataset_count = release.get("dataset_count")
+        dataset_manifest_sha256 = str(release.get("dataset_manifest_sha256", "") or "")
+        if dataset_count is not None and dataset_manifest_sha256:
+            dataset_details += (
+                f" for ``{dataset_count}`` tracked dataset files; "
+                f"manifest ``{dataset_manifest_sha256}``"
+            )
+        lines.extend(["   * - Dataset release", f"     - {dataset_details}"])
+    lines.extend(
+        [
             "   * - Hosted demo",
             (
                 f"     - `{release['hf_space_label']} <{release['hf_space_url']}>`__ "
@@ -425,6 +441,31 @@ def _github_repo_name(repo_root: Path) -> str | None:
     if not base_url.startswith(prefix):
         return None
     return base_url.removeprefix(prefix)
+
+
+def _dataset_release_evidence(repo_root: Path, *, code_release_tag: str) -> dict[str, Any] | None:
+    module_path = repo_root / "tools" / "dataset_release_assets.py"
+    if not module_path.exists():
+        return None
+    spec = importlib.util.spec_from_file_location("agilab_dataset_release_assets", module_path)
+    if not spec or not spec.loader:
+        return None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    records = module.discover_dataset_records(repo_root)
+    if not records:
+        return None
+    manifest = module.build_manifest(records, code_release_tag)
+    base_url = _github_repo_base_url(repo_root)
+    dataset_release_tag = str(manifest["dataset_release_tag"])
+    return {
+        "dataset_release_tag": dataset_release_tag,
+        "dataset_release_url": (
+            f"{base_url}/releases/tag/{dataset_release_tag}" if base_url else ""
+        ),
+        "dataset_manifest_sha256": str(manifest["dataset_manifest_sha256"]),
+        "dataset_count": int(manifest["dataset_count"]),
+    }
 
 
 def _run_gh_json(args: Sequence[str]) -> Any:
@@ -619,6 +660,11 @@ def refresh_manifest_from_local(
 
     if hf_space_commit:
         release["hf_space_commit"] = hf_space_commit
+
+    code_release_tag = str(release.get("github_release_tag", "") or tag or "dev")
+    dataset_evidence = _dataset_release_evidence(repo_root, code_release_tag=code_release_tag)
+    if dataset_evidence:
+        release.update(dataset_evidence)
 
     return refreshed
 
@@ -863,6 +909,8 @@ def build_report(
     package_version = str(release["package_version"])
     github_release_url = str(release["github_release_url"])
     github_release_tag = str(release["github_release_tag"])
+    dataset_release_tag = str(release.get("dataset_release_tag", "") or "")
+    dataset_release_url = str(release.get("dataset_release_url", "") or "")
     checks: list[dict[str, Any]] = []
 
     project_version = _load_project_version(repo_root)
@@ -895,6 +943,18 @@ def build_report(
             details={"tag": github_release_tag, "url": github_release_url},
         )
     )
+    if dataset_release_tag or dataset_release_url:
+        checks.append(
+            _check_result(
+                "dataset_release_url",
+                bool(dataset_release_tag)
+                and bool(dataset_release_url)
+                and dataset_release_tag in dataset_release_url,
+                "manifest dataset release URL contains the dataset release tag",
+                evidence=[str(manifest_path)],
+                details={"tag": dataset_release_tag, "url": dataset_release_url},
+            )
+        )
     badge_path = repo_root / "badges" / "pypi-version-agilab.svg"
     badge_contains = _text_contains(badge_path, f"v{package_version}")
     checks.append(
@@ -981,6 +1041,8 @@ def build_report(
             "package_version": package_version,
             "github_release_tag": github_release_tag,
             "github_release_url": github_release_url,
+            "dataset_release_tag": dataset_release_tag,
+            "dataset_release_url": dataset_release_url,
             "hf_space_url": str(release["hf_space_url"]),
             "hf_space_commit": str(release["hf_space_commit"]),
         },


### PR DESCRIPTION
Links the deterministic datasets-* release from release proof, adds a release-proof guard for dataset release URLs, and makes future GitHub release notes point readers to separate dataset releases.