### PR TITLE
ci: keep PyPI publish workflow YAML valid

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -673,11 +673,10 @@ jobs:
             release_tag="v${release_tag}"
           fi
           if ! gh release view "$release_tag" >/dev/null 2>&1; then
+            notes=$'AGILAB release artifacts and supply-chain evidence.\n\nDataset payloads are published in separate datasets-* GitHub releases when present and linked from the release proof.'
             gh release create "$release_tag" \
               --title "AGILAB ${release_tag#v}" \
-              --notes "AGILAB release artifacts and supply-chain evidence.
-
-Dataset payloads are published in separate datasets-* GitHub releases when present and linked from the release proof."
+              --notes "$notes"
           fi
           gh release upload "$release_tag" github-release-assets/* --clobber
 

--- a/test/test_pypi_publish_workflow.py
+++ b/test/test_pypi_publish_workflow.py
@@ -4,6 +4,8 @@ from pathlib import Path
 import re
 import sys
 
+import yaml
+
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT / "tools"))
@@ -14,6 +16,10 @@ from package_split_contract import LIBRARY_PACKAGE_CONTRACTS, PACKAGE_NAMES, UMB
 WORKFLOW_PATH = REPO_ROOT / ".github/workflows/pypi-publish.yaml"
 TEST_PYPI_WORKFLOW_PATH = REPO_ROOT / ".github/workflows/test-pypi-publish.yaml"
 PYPI_RELEASE_RETENTION_WORKFLOW_PATH = REPO_ROOT / ".github/workflows/pypi-release-retention.yaml"
+
+
+def test_pypi_publish_workflow_is_valid_yaml() -> None:
+    assert yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
 
 
 def test_pypi_publish_runs_live_artifact_index_evidence_before_publish() -> None:
@@ -206,6 +212,14 @@ def test_pypi_publish_skips_existing_artifacts_and_requires_trusted_auth() -> No
     assert "PYPI_TOKEN" not in text
     assert "TWINE_PASSWORD" not in text
     assert "twine upload" not in text
+
+
+def test_pypi_publish_release_notes_point_to_dataset_releases_without_breaking_yaml() -> None:
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    assert "notes=$'AGILAB release artifacts and supply-chain evidence.\\n\\n" in text
+    assert "Dataset payloads are published in separate datasets-* GitHub releases" in text
+    assert '--notes "$notes"' in text
 
 
 def test_pypi_publish_reuses_unchanged_artifacts_without_rebuilding_or_republishing() -> None:

--- a/test/test_release_proof_report.py
+++ b/test/test_release_proof_report.py
@@ -223,6 +223,40 @@ def test_release_proof_github_run_check_detects_failed_or_stale_runs(monkeypatch
     assert "stale" in " ".join(check["details"]["failures"])
 
 
+def test_release_proof_github_run_check_accepts_workflow_file_fallback_name(monkeypatch) -> None:
+    module = _load_module()
+
+    def fake_gh_json(args):
+        assert args[:2] == ["run", "view"]
+        return {
+            "databaseId": args[2],
+            "workflowName": ".github/workflows/pypi-publish.yaml",
+            "headSha": "abc123",
+            "status": "completed",
+            "conclusion": "success",
+            "url": f"https://github.com/ThalesGroup/agilab/actions/runs/{args[2]}",
+            "createdAt": "2026-06-04T00:00:00Z",
+            "event": "workflow_dispatch",
+        }
+
+    monkeypatch.setattr(module, "_run_gh_json", fake_gh_json)
+
+    check = module._github_ci_runs_check(
+        [
+            {
+                "workflow": "pypi-publish",
+                "run_id": "42",
+                "url": "https://github.com/ThalesGroup/agilab/actions/runs/42",
+            }
+        ],
+        repo_root=Path.cwd(),
+        github_repo="ThalesGroup/agilab",
+        max_age_days=45,
+    )
+
+    assert check["status"] == "pass"
+
+
 def test_release_proof_ui_robot_evidence_check_validates_github_run(
     tmp_path: Path,
     monkeypatch,

--- a/tools/release_proof_report.py
+++ b/tools/release_proof_report.py
@@ -507,6 +507,14 @@ def _github_run_is_success(row: Mapping[str, Any]) -> bool:
     )
 
 
+def _github_workflow_name_matches(expected: str, actual: str) -> bool:
+    return actual in {
+        expected,
+        f".github/workflows/{expected}.yaml",
+        f".github/workflows/{expected}.yml",
+    }
+
+
 def _github_created_at(value: str) -> datetime | None:
     if not value:
         return None
@@ -743,7 +751,7 @@ def _github_ci_runs_check(
         if created_at is not None:
             age_days = max((checked_at - created_at).total_seconds() / 86400, 0.0)
         run_failures: list[str] = []
-        if github_workflow != workflow:
+        if not _github_workflow_name_matches(workflow, github_workflow):
             run_failures.append(f"workflow mismatch: expected {workflow}, got {github_workflow}")
         if not _github_run_is_success(raw):
             run_failures.append(


### PR DESCRIPTION
Fixes the multiline release-note shell snippet so pypi-publish.yaml remains valid YAML, and adds a local YAML parse regression for the workflow.