### PR TITLE
Fix external app bootstrap roots

### DIFF
--- a/src/agilab/about_page/bootstrap.py
+++ b/src/agilab/about_page/bootstrap.py
@@ -286,6 +286,14 @@ def normalize_active_app_input(env: Any, raw_value: Optional[str]) -> Path | Non
     except (TypeError, RuntimeError, ValueError):
         return None
 
+    def is_plain_app_name() -> bool:
+        return (
+            not provided.is_absolute()
+            and provided.parent == Path(".")
+            and "/" not in str(raw_value)
+            and "\\" not in str(raw_value)
+        )
+
     def add_root_candidate(root: Any, app_name: str) -> None:
         if not root or not app_name:
             return
@@ -331,13 +339,16 @@ def normalize_active_app_input(env: Any, raw_value: Optional[str]) -> Path | Non
     if provided.is_absolute():
         candidates.append(provided)
     else:
-        candidates.append((Path.cwd() / provided).resolve())
+        if not is_plain_app_name():
+            candidates.append((Path.cwd() / provided).resolve())
         add_root_candidate(getattr(env, "apps_path", None), str(provided))
         add_root_candidate(getattr(env, "apps_path", None), provided.name)
         add_root_candidate(getattr(env, "builtin_apps_path", None), str(provided))
         add_root_candidate(getattr(env, "builtin_apps_path", None), provided.name)
         add_root_candidate(getattr(env, "apps_repository_root", None), str(provided))
         add_root_candidate(getattr(env, "apps_repository_root", None), provided.name)
+        if is_plain_app_name():
+            candidates.append((Path.cwd() / provided).resolve())
 
     projects = getattr(env, "projects", set()) or set()
     if not provided.is_absolute():
@@ -432,8 +443,8 @@ def _active_app_path_matches(env: Any, target_path: Path) -> bool:
     return normalized_current == normalized_target
 
 
-def _rebootstrap_same_named_active_app(env: Any, target_path: Path, target_name: str, *, streamlit: Any) -> bool:
-    """Switch to the same project name under another root without using name-only change_app."""
+def _rebootstrap_active_app_path(env: Any, target_path: Path, target_name: str, *, streamlit: Any) -> bool:
+    """Switch to a resolved project path without using name-only change_app."""
     previous_init_done = getattr(env, "init_done", None)
     try:
         type(env).__init__(
@@ -441,6 +452,7 @@ def _rebootstrap_same_named_active_app(env: Any, target_path: Path, target_name:
             apps_path=target_path.parent,
             app=target_name,
             verbose=getattr(env, "verbose", None),
+            _agilab_reinitialize=True,
         )
         if previous_init_done is not None:
             env.init_done = previous_init_done
@@ -448,6 +460,16 @@ def _rebootstrap_same_named_active_app(env: Any, target_path: Path, target_name:
         streamlit.warning(_project_switch_failure_message(target_name, exc))
         return False
     return True
+
+
+def _rebootstrap_same_named_active_app(env: Any, target_path: Path, target_name: str, *, streamlit: Any) -> bool:
+    """Switch to the same project name under another root without using name-only change_app."""
+    return _rebootstrap_active_app_path(
+        env,
+        target_path,
+        target_name,
+        streamlit=streamlit,
+    )
 
 
 def apply_active_app_request(env: Any, request_value: Optional[str], *, streamlit: Any) -> bool:
@@ -461,12 +483,7 @@ def apply_active_app_request(env: Any, request_value: Optional[str], *, streamli
         if _active_app_path_matches(env, target_path):
             return False
         return _rebootstrap_same_named_active_app(env, target_path, target_name, streamlit=streamlit)
-    try:
-        env.change_app(target_path)
-    except (AttributeError, OSError, RuntimeError, TypeError, ValueError) as exc:
-        streamlit.warning(_project_switch_failure_message(target_name, exc))
-        return False
-    return True
+    return _rebootstrap_active_app_path(env, target_path, target_name, streamlit=streamlit)
 
 
 def sync_active_app_from_query(
@@ -774,7 +791,7 @@ def bootstrap_page_environment(
         pass
 
     saved_env = load_env_file_map(env_file_path)
-    openai_missing = persist_bootstrap_env(
+    persist_bootstrap_env(
         env,
         apps_path=apps_path,
         explicit_apps_path=bool(args.apps_path) or bool(preinit_updates),

--- a/src/agilab/orchestrate/orchestrate_support.py
+++ b/src/agilab/orchestrate/orchestrate_support.py
@@ -10,7 +10,8 @@ from typing import Any, Callable, Optional
 
 import tomli_w
 from agi_env.app_settings_support import (
-    prepare_app_settings_for_write,
+    app_settings_contract_error,
+    ensure_app_settings_metadata,
     sanitize_app_settings_for_toml,
 )
 
@@ -23,7 +24,13 @@ def sanitize_for_toml(obj: Any) -> Any:
 
 def write_app_settings_toml(settings_path: Path, payload: dict) -> dict:
     """Persist ``payload`` after converting it to a TOML-serializable object."""
-    sanitized = prepare_app_settings_for_write(payload)
+    sanitized = sanitize_app_settings_for_toml(payload)
+    if not isinstance(sanitized, dict):
+        raise ValueError("app_settings.toml payload must be a TOML table.")
+    error = app_settings_contract_error(sanitized)
+    if error:
+        raise ValueError(error)
+    sanitized = ensure_app_settings_metadata(sanitized)
     with open(settings_path, "wb") as file:
         tomli_w.dump(sanitized, file)
     return sanitized

--- a/test/test_about_agilab_helpers.py
+++ b/test/test_about_agilab_helpers.py
@@ -1169,14 +1169,23 @@ def test_bootstrap_active_app_helpers_resolve_and_switch_project(tmp_path):
     warnings: list[str] = []
 
     class FakeEnv:
-        def __init__(self):
+        def __init__(
+            self,
+            *,
+            apps_path: Path = apps_path,
+            app: str = "default",
+            verbose: int | None = 1,
+            _agilab_reinitialize: bool = False,
+        ):
             self.apps_path = apps_path
-            self.app = "default"
+            self.app = app
+            self.verbose = verbose
+            self.active_app = apps_path / app
+            self.reinitialized = _agilab_reinitialize
             self.projects = {"flight_telemetry_project"}
 
         def change_app(self, path: Path) -> None:
-            assert path == project_path.resolve()
-            self.app = path.name
+            raise RuntimeError(f"path switch should not call change_app({path})")
 
     fake_st = SimpleNamespace(warning=warnings.append)
     env = FakeEnv()
@@ -1192,6 +1201,9 @@ def test_bootstrap_active_app_helpers_resolve_and_switch_project(tmp_path):
         is True
     )
     assert env.app == "flight_telemetry_project"
+    assert env.apps_path == apps_path
+    assert env.active_app == project_path
+    assert env.reinitialized is True
     assert warnings == []
 
 
@@ -1212,6 +1224,7 @@ def test_bootstrap_active_app_request_switches_same_name_when_root_changes(tmp_p
             apps_path: Path = old_root,
             app: str = "flight_telemetry_project",
             verbose: int | None = 1,
+            _agilab_reinitialize: bool = False,
         ):
             self.apps_path = apps_path
             self.app = app
@@ -1219,6 +1232,7 @@ def test_bootstrap_active_app_request_switches_same_name_when_root_changes(tmp_p
             self.active_app = apps_path / app
             self.projects = {"flight_telemetry_project"}
             self.init_done = True
+            self.reinitialized = _agilab_reinitialize
 
         def change_app(self, _path: Path) -> None:
             raise RuntimeError(
@@ -1235,6 +1249,54 @@ def test_bootstrap_active_app_request_switches_same_name_when_root_changes(tmp_p
     assert env.app == "flight_telemetry_project"
     assert env.apps_path == new_root
     assert env.active_app == new_project
+    assert env.init_done is True
+    assert env.reinitialized is True
+    assert warnings == []
+
+
+def test_bootstrap_active_app_request_preserves_absolute_external_root(tmp_path):
+    bootstrap = about_agilab._about_bootstrap
+    source_root = tmp_path / "agilab" / "src" / "agilab" / "apps" / "builtin"
+    external_root = tmp_path / "thales_agilab" / "apps"
+    external_project = external_root / "sb3_trainer_project"
+    source_root.mkdir(parents=True)
+    external_project.mkdir(parents=True)
+    warnings: list[str] = []
+
+    class FakeEnv:
+        def __init__(
+            self,
+            *,
+            apps_path: Path = source_root,
+            app: str = "flight_telemetry_project",
+            verbose: int | None = 1,
+            _agilab_reinitialize: bool = False,
+        ):
+            self.apps_path = apps_path
+            self.app = app
+            self.verbose = verbose
+            self.active_app = apps_path / app
+            self.projects = set()
+            self.init_done = True
+            self.reinitialized = _agilab_reinitialize
+
+        def change_app(self, path: Path) -> None:
+            raise RuntimeError(f"external path switch lost resolved root: {path}")
+
+    env = FakeEnv()
+
+    assert (
+        bootstrap.apply_active_app_request(
+            env,
+            str(external_project),
+            streamlit=SimpleNamespace(warning=warnings.append),
+        )
+        is True
+    )
+    assert env.app == "sb3_trainer_project"
+    assert env.apps_path == external_root
+    assert env.active_app == external_project
+    assert env.reinitialized is True
     assert env.init_done is True
     assert warnings == []
 
@@ -1266,6 +1328,32 @@ def test_bootstrap_normalize_active_app_input_finds_builtin_project_name(tmp_pat
     assert (
         bootstrap.normalize_active_app_input(env, "flight_telemetry_project")
         == active_app.resolve()
+    )
+
+
+def test_bootstrap_normalize_active_app_input_prefers_configured_root_over_polluted_cwd(
+    tmp_path,
+    monkeypatch,
+):
+    bootstrap = about_agilab._about_bootstrap
+    checkout = tmp_path / "agilab"
+    polluted_project = checkout / "sb3_trainer_project"
+    external_root = tmp_path / "thales_agilab" / "apps"
+    external_project = external_root / "sb3_trainer_project"
+    polluted_project.mkdir(parents=True)
+    external_project.mkdir(parents=True)
+    monkeypatch.chdir(checkout)
+
+    env = SimpleNamespace(
+        apps_path=external_root,
+        builtin_apps_path=None,
+        apps_repository_root=None,
+        projects=set(),
+    )
+
+    assert (
+        bootstrap.normalize_active_app_input(env, "sb3_trainer_project")
+        == external_project.resolve()
     )
 
 
@@ -2327,12 +2415,14 @@ def test_bootstrap_active_app_helpers_handle_empty_same_and_failed_switch(tmp_pa
     )
 
     class BrokenEnv(FakeEnv):
-        def __init__(self):
+        def __init__(self, *args, **kwargs):
+            if args or kwargs:
+                raise RuntimeError("cannot switch")
             super().__init__()
             self.app = "default"
 
         def change_app(self, _path: Path) -> None:
-            raise RuntimeError("cannot switch")
+            raise RuntimeError("should not switch with change_app")
 
     assert not bootstrap.apply_active_app_request(
         BrokenEnv(),
@@ -2342,15 +2432,17 @@ def test_bootstrap_active_app_helpers_handle_empty_same_and_failed_switch(tmp_pa
     assert any("cannot switch" in warning for warning in warnings)
 
     class InternalBrokenEnv(FakeEnv):
-        def __init__(self):
+        def __init__(self, *args, **kwargs):
+            if args or kwargs:
+                raise RuntimeError(
+                    "AgiEnv is already initialised with a different configuration; "
+                    "use AgiEnv.reset() for a fresh environment or change_app() to switch apps."
+                )
             super().__init__()
             self.app = "default"
 
         def change_app(self, _path: Path) -> None:
-            raise RuntimeError(
-                "AgiEnv is already initialised with a different configuration; "
-                "use AgiEnv.reset() for a fresh environment or change_app() to switch apps."
-            )
+            raise RuntimeError("should not switch with change_app")
 
     warnings.clear()
     assert not bootstrap.apply_active_app_request(

--- a/test/test_orchestrate_support.py
+++ b/test/test_orchestrate_support.py
@@ -58,7 +58,7 @@ def test_prepare_app_settings_for_write_preserves_existing_supported_metadata(tm
     assert written == sanitized
 
 
-def test_write_app_settings_toml_normalizes_legacy_run_args_key(tmp_path):
+def test_write_app_settings_toml_preserves_app_owned_nested_args_key(tmp_path):
     settings_file = tmp_path / "app_settings.toml"
     payload = {
         "args": {
@@ -71,8 +71,10 @@ def test_write_app_settings_toml_normalizes_legacy_run_args_key(tmp_path):
     sanitized = orchestrate_support.write_app_settings_toml(settings_file, payload)
     written = tomllib.loads(settings_file.read_text(encoding="utf-8"))
 
-    assert "args" not in sanitized["args"]
-    assert sanitized["args"]["stages"] == [{"name": "fcas_routing_ppo_gnn", "args": {"seed": 42}}]
+    assert sanitized["args"]["args"] == [
+        {"name": "fcas_routing_ppo_gnn", "args": {"seed": 42}}
+    ]
+    assert "stages" not in sanitized["args"]
     assert written == sanitized
 
 


### PR DESCRIPTION
## Summary
- Rebootstrap resolved active-app paths directly so external app roots stay intact instead of falling back through cwd-derived core change_app behavior.
- Prefer configured app roots over polluted cwd directories for bare app names.
- Preserve app-owned nested args.args in ORCHESTRATE settings writes while keeping metadata and TOML sanitization.

## Validation
- uv --preview-features extra-build-dependencies run --extra ui pytest -q -o addopts='' test/test_orchestrate_support.py test/test_about_agilab_helpers.py src/agilab/core/agi-env/test/test_bootstrap_support.py
- uv --preview-features extra-build-dependencies run --extra dev ruff check src/agilab/about_page/bootstrap.py src/agilab/orchestrate/orchestrate_support.py test/test_about_agilab_helpers.py test/test_orchestrate_support.py
- uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files src/agilab/about_page/bootstrap.py src/agilab/orchestrate/orchestrate_support.py test/test_about_agilab_helpers.py test/test_orchestrate_support.py
- tools/agilab_widget_robot.py on external thales_agilab/apps/sb3_trainer_project ORCHESTRATE: 51 widgets, 0 failed; required SB3 form text present; forbidden errors absent.