### PR TITLE
Compact cluster diagnostic logs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,16 @@ Use this runbook whenever you:
   improve the error message, log context, status report, or validation output
   as part of the fix when practical. A good fix should make the next failure in
   the same area faster to classify without requiring source-code archaeology.
+- **Token-budgeted logging rule**: Treat raw stdout/stderr and long tracebacks
+  as artifacts, not default prompt/UI payloads. Default visible and agent-facing
+  logs to compact signal-first summaries: counts, bounded high-value lines,
+  latest relevant tail, and explicit omitted-line counts. Escalate to
+  context-window details or full log artifacts only when the user, PyCharm
+  debugging flow, or Codex diagnosis needs that detail. Keep the runtime
+  diagnostics levels aligned with this contract: Quiet is essential status,
+  Standard is compact signal summary, Detailed adds nearby context windows, and
+  Debug may point to raw artifacts or include full text only when the log is
+  already small enough for prompt-safe use.
 - **Dependency-bound validation rule**: When changing dependency caps or
   compatibility shims, validate the meaningful boundary versions when practical:
   the currently installed version, the new lower or upper bound, and an import

--- a/src/agilab/diagnostics/runtime_diagnostics.py
+++ b/src/agilab/diagnostics/runtime_diagnostics.py
@@ -11,9 +11,9 @@ import tomllib
 GLOBAL_DIAGNOSTICS_ENV_KEY = "AGILAB_RUNTIME_DIAGNOSTICS_VERBOSE"
 DIAGNOSTICS_LEVELS: tuple[tuple[str, int, str], ...] = (
     ("Quiet", 0, "Show only essential progress and failures."),
-    ("Standard", 1, "Show normal progress, warnings, and concise failures."),
-    ("Detailed", 2, "Keep detailed runtime logs and filtered tracebacks."),
-    ("Debug", 3, "Keep full diagnostic output for troubleshooting."),
+    ("Standard", 1, "Show compact signal-first log summaries."),
+    ("Detailed", 2, "Add context windows around high-value log signals."),
+    ("Debug", 3, "Include full prompt-facing output only for small logs; otherwise point to raw artifacts."),
 )
 DIAGNOSTICS_OPTIONS: tuple[str, ...] = tuple(label for label, _verbose, _description in DIAGNOSTICS_LEVELS)
 DIAGNOSTICS_VERBOSE_BY_LABEL: dict[str, int] = {label: verbose for label, verbose, _description in DIAGNOSTICS_LEVELS}

--- a/src/agilab/environment/logging_utils.py
+++ b/src/agilab/environment/logging_utils.py
@@ -1,11 +1,49 @@
 from __future__ import annotations
 
+import re
 from typing import Any
 
 TERMINAL_LOG_WIDTH = 360
 LOG_PATH_LIMIT = 120
 LOG_DETAIL_LIMIT = 220
+COMPACT_LOG_SIGNAL_LIMIT = 8
+COMPACT_LOG_TAIL_LIMIT = 4
+COMPACT_LOG_CONTEXT_RADIUS = 1
+COMPACT_LOG_DEBUG_MAX_LINES = 120
 _ELLIPSIS = "..."
+_SECRET_REPLACEMENTS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (
+        re.compile(
+            r"(?i)\b(api[_-]?key|token|password|secret|authorization)\s*=\s*([^\s;]+)"
+        ),
+        r"\1=<redacted>",
+    ),
+    (re.compile(r"\bsk-(?:proj-)?[A-Za-z0-9_-]{16,}\b"), "<redacted-token>"),
+    (re.compile(r"\bgh[pousr]_[A-Za-z0-9_]{20,}\b"), "<redacted-token>"),
+    (re.compile(r"\bpypi-[A-Za-z0-9_-]{20,}\b"), "<redacted-token>"),
+)
+_HIGH_VALUE_LOG_PATTERNS: tuple[str, ...] = (
+    "traceback",
+    "error",
+    "exception",
+    "failed",
+    "failure",
+    "fatal",
+    "denied",
+    "missing",
+    "not found",
+    "no module named",
+    "modulenotfounderror",
+    "importerror",
+    "permission denied",
+    "connection refused",
+    "no route to host",
+    "timed out",
+    "timeout",
+    "unsatisfiable",
+    "non-zero exit status",
+    "exit code",
+)
 
 
 def bound_log_value(value: Any, limit: int = TERMINAL_LOG_WIDTH) -> str:
@@ -24,3 +62,156 @@ def bound_log_value(value: Any, limit: int = TERMINAL_LOG_WIDTH) -> str:
     if limit <= len(_ELLIPSIS):
         return _ELLIPSIS[:limit]
     return normalized[: limit - len(_ELLIPSIS)] + _ELLIPSIS
+
+
+def redact_log_value(value: Any) -> str:
+    """Redact common secret-like values before rendering prompt-facing logs."""
+    try:
+        text = str(value)
+    except Exception as exc:  # pragma: no cover - defensive formatting boundary
+        text = f"<unprintable {type(value).__name__}: {exc}>"
+    for pattern, replacement in _SECRET_REPLACEMENTS:
+        text = pattern.sub(replacement, text)
+    return text
+
+
+def is_high_value_log_line(line: str) -> bool:
+    """Return whether a line is likely worth surfacing in a compact diagnostic."""
+    normalized = str(line or "").strip().lower()
+    return bool(normalized) and any(pattern in normalized for pattern in _HIGH_VALUE_LOG_PATTERNS)
+
+
+def _bounded_render_line(line_number: int, line: str, *, max_line_chars: int) -> str:
+    return f"{line_number}: {bound_log_value(redact_log_value(line), max_line_chars)}"
+
+
+def _unique_ordered(values: list[int]) -> list[int]:
+    seen: set[int] = set()
+    ordered: list[int] = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        ordered.append(value)
+    return ordered
+
+
+def compact_log_view(
+    payload: Any,
+    *,
+    verbose: int = 1,
+    signal_limit: int = COMPACT_LOG_SIGNAL_LIMIT,
+    tail_limit: int = COMPACT_LOG_TAIL_LIMIT,
+    context_radius: int = COMPACT_LOG_CONTEXT_RADIUS,
+    max_line_chars: int = LOG_DETAIL_LIMIT,
+    debug_max_lines: int = COMPACT_LOG_DEBUG_MAX_LINES,
+) -> dict[str, Any]:
+    """Return a token-budgeted, signal-first view of a log payload.
+
+    Verbosity levels match AGILAB runtime diagnostics:
+    0 only reports counts and the newest signal, 1 adds bounded signal/tail
+    lines, 2 adds context windows around signals, and 3 includes the full log
+    only when it is already small enough for prompt-facing use.
+    """
+    text = "" if payload is None else str(payload)
+    lines = text.replace("\r\n", "\n").replace("\r", "\n").splitlines()
+    verbose = max(0, min(int(verbose or 0), 3))
+    signal_indexes = [index for index, line in enumerate(lines) if is_high_value_log_line(line)]
+
+    if verbose <= 0:
+        selected_signal_indexes = signal_indexes[-1:]
+        selected_tail_indexes: list[int] = []
+    else:
+        selected_signal_indexes = signal_indexes[: max(signal_limit, 0)]
+        selected_tail_indexes = list(range(max(len(lines) - max(tail_limit, 0), 0), len(lines)))
+
+    context_indexes: list[int] = []
+    if verbose >= 2:
+        for index in selected_signal_indexes:
+            start = max(index - max(context_radius, 0), 0)
+            stop = min(index + max(context_radius, 0) + 1, len(lines))
+            context_indexes.extend(range(start, stop))
+        context_indexes = _unique_ordered(context_indexes)
+
+    debug_indexes: list[int] = []
+    debug_note = ""
+    if verbose >= 3:
+        if len(lines) <= debug_max_lines:
+            debug_indexes = list(range(len(lines)))
+        else:
+            debug_note = (
+                f"debug log has {len(lines)} lines; full prompt-facing output is capped "
+                f"at {debug_max_lines} lines, so use the raw log artifact for exhaustive debugging"
+            )
+
+    included_indexes = set(selected_signal_indexes) | set(selected_tail_indexes) | set(context_indexes) | set(debug_indexes)
+    omitted_line_count = max(len(lines) - len(included_indexes), 0)
+    signals = [
+        {
+            "line": index + 1,
+            "text": bound_log_value(redact_log_value(lines[index]), max_line_chars),
+        }
+        for index in selected_signal_indexes
+    ]
+    tail = [_bounded_render_line(index + 1, lines[index], max_line_chars=max_line_chars) for index in selected_tail_indexes]
+    context = [
+        _bounded_render_line(index + 1, lines[index], max_line_chars=max_line_chars)
+        for index in context_indexes
+        if index not in selected_signal_indexes
+    ]
+    debug_lines = [
+        _bounded_render_line(index + 1, lines[index], max_line_chars=max_line_chars)
+        for index in debug_indexes
+    ]
+    note = (
+        debug_note
+        or "compact view keeps raw logs out of prompt context; increase diagnostics only when the signal is useful"
+    )
+    return {
+        "strategy": "signal-first-token-budget",
+        "verbose": verbose,
+        "line_count": len(lines),
+        "char_count": len(text),
+        "signal_count": len(signal_indexes),
+        "omitted_line_count": omitted_line_count,
+        "signals": signals,
+        "context": context,
+        "tail": tail,
+        "debug_lines": debug_lines,
+        "note": note,
+    }
+
+
+def render_compact_log_view(view: dict[str, Any]) -> str:
+    """Render ``compact_log_view`` output as compact text for Streamlit or Codex."""
+    lines = [
+        "AGILAB compact log",
+        f"strategy: {view.get('strategy', 'signal-first-token-budget')}",
+        (
+            f"lines: {view.get('line_count', 0)} "
+            f"signals: {view.get('signal_count', 0)} "
+            f"omitted: {view.get('omitted_line_count', 0)} "
+            f"verbose: {view.get('verbose', 1)}"
+        ),
+    ]
+    signals = view.get("signals") or []
+    if signals:
+        lines.append("signals:")
+        for signal in signals:
+            lines.append(f"- {signal.get('line')}: {signal.get('text')}")
+    context = view.get("context") or []
+    if context:
+        lines.append("context:")
+        lines.extend(f"- {item}" for item in context)
+    tail = view.get("tail") or []
+    if tail:
+        lines.append("tail:")
+        lines.extend(f"- {item}" for item in tail)
+    debug_lines = view.get("debug_lines") or []
+    if debug_lines:
+        lines.append("debug_lines:")
+        lines.extend(f"- {item}" for item in debug_lines)
+    note = str(view.get("note") or "").strip()
+    if note:
+        lines.append(f"note: {note}")
+    return "\n".join(lines)

--- a/src/agilab/orchestrate/orchestrate_page_support.py
+++ b/src/agilab/orchestrate/orchestrate_page_support.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from agi_env.snippet_contract import snippet_contract_block
+from agilab.environment.logging_utils import compact_log_view, render_compact_log_view
 
 try:
     from packaging.markers import default_environment as _packaging_default_environment
@@ -1087,25 +1088,41 @@ def display_log(
     clean_stderr = "\n".join(line for line in clean_stderr.splitlines() if line.strip())
 
     combined = "\n".join([clean_stdout, clean_stderr]).strip()
+    log_verbose = 1
+    try:
+        log_verbose = int(session_state.get("cluster_verbose", 1))
+    except (AttributeError, TypeError, ValueError):
+        log_verbose = 1
+
+    def _compact(text: str) -> str:
+        if not text.strip():
+            return "No logs available"
+        return render_compact_log_view(
+            compact_log_view(
+                text,
+                verbose=log_verbose,
+                debug_max_lines=log_display_max_lines,
+            )
+        )
 
     if "warning:" in combined.lower():
         warning_fn("Warnings occurred during cluster installation:")
         code_fn(
-            format_log_block_fn(combined),
-            language="python",
+            _compact(combined),
+            language="text",
             height=log_display_height,
         )
     elif clean_stderr:
         error_fn("Errors occurred during cluster installation:")
         code_fn(
-            format_log_block_fn(clean_stderr),
-            language="python",
+            _compact(clean_stderr),
+            language="text",
             height=log_display_height,
         )
     else:
         code_fn(
-            format_log_block_fn(clean_stdout) or "No logs available",
-            language="python",
+            _compact(clean_stdout),
+            language="text",
             height=log_display_height,
         )
 

--- a/test/test_logging_utils.py
+++ b/test/test_logging_utils.py
@@ -32,3 +32,134 @@ def test_bound_log_value_handles_nonpositive_and_tiny_limits() -> None:
     assert logging_utils.bound_log_value("payload", 1) == "."
     assert logging_utils.bound_log_value("payload", 2) == ".."
     assert logging_utils.bound_log_value("payload", 3) == "..."
+
+
+def test_compact_log_view_keeps_signal_lines_and_omits_benign_bulk() -> None:
+    text = "\n".join(
+        [
+            *[f"progress {index}" for index in range(20)],
+            "ModuleNotFoundError: No module named 'demo_worker'",
+            "continuing cleanup",
+            "tail marker",
+        ]
+    )
+
+    view = logging_utils.compact_log_view(text, verbose=1, tail_limit=1)
+
+    assert view["strategy"] == "signal-first-token-budget"
+    assert view["line_count"] == 23
+    assert view["signal_count"] == 1
+    assert view["signals"] == [
+        {"line": 21, "text": "ModuleNotFoundError: No module named 'demo_worker'"}
+    ]
+    assert view["tail"] == ["23: tail marker"]
+    assert view["omitted_line_count"] == 21
+    rendered = logging_utils.render_compact_log_view(view)
+    assert "signals: 1" in rendered
+    assert "progress 1" not in rendered
+
+
+def test_compact_log_view_expands_context_only_when_verbose_is_detailed() -> None:
+    text = "\n".join(["setup", "before", "ERROR: failed to connect", "after", "done"])
+
+    standard = logging_utils.compact_log_view(text, verbose=1, tail_limit=0)
+    detailed = logging_utils.compact_log_view(text, verbose=2, tail_limit=0, context_radius=1)
+
+    assert standard["context"] == []
+    assert detailed["context"] == ["2: before", "4: after"]
+
+
+def test_compact_log_view_debug_includes_small_logs_but_caps_large_logs() -> None:
+    small = logging_utils.compact_log_view("a\nb", verbose=3)
+    large = logging_utils.compact_log_view("\n".join(f"line {i}" for i in range(5)), verbose=3, debug_max_lines=2)
+
+    assert small["debug_lines"] == ["1: a", "2: b"]
+    assert large["debug_lines"] == []
+    assert "full prompt-facing output is capped" in large["note"]
+
+
+def test_compact_log_view_redacts_secret_like_values() -> None:
+    view = logging_utils.compact_log_view(
+        "ERROR api_key=sk-proj-abcdefghijklmnopqrstuvwxyz123456 token=ghp_abcdefghijklmnopqrstuvwxyz123456",
+        verbose=1,
+    )
+
+    rendered = logging_utils.render_compact_log_view(view)
+    assert "sk-proj" not in rendered
+    assert "ghp_" not in rendered
+    assert "api_key=<redacted>" in rendered
+    assert "token=<redacted>" in rendered
+
+
+def test_compact_log_view_has_budget_ceiling_for_large_stdout_artifacts() -> None:
+    noisy_lines = [
+        f"stdout progress NOISY_FILLER_{index:03d} " + ("x" * 120)
+        for index in range(300)
+    ]
+    noisy_lines.insert(
+        150,
+        "ERROR worker failed api_key=sk-proj-abcdefghijklmnopqrstuvwxyz123456",
+    )
+    noisy_lines.extend(["tail compact one", "tail compact two"])
+    raw_log = "\n".join(noisy_lines)
+
+    view = logging_utils.compact_log_view(
+        raw_log,
+        verbose=1,
+        signal_limit=2,
+        tail_limit=2,
+        max_line_chars=120,
+    )
+    rendered = logging_utils.render_compact_log_view(view)
+
+    assert view["line_count"] == 303
+    assert view["signal_count"] == 1
+    assert view["omitted_line_count"] >= 299
+    assert len(rendered) < 1_200
+    assert "ERROR worker failed" in rendered
+    assert "api_key=<redacted>" in rendered
+    assert "sk-proj" not in rendered
+    assert "NOISY_FILLER_000" not in rendered
+    assert "tail compact two" in rendered
+
+
+def test_compact_log_view_quiet_mode_keeps_only_newest_signal_counts() -> None:
+    raw_log = "\n".join(
+        [
+            "ERROR first failure should be skipped in quiet mode",
+            *[f"progress {index}" for index in range(80)],
+            "ModuleNotFoundError: No module named 'critical_worker'",
+            "final benign line",
+        ]
+    )
+
+    view = logging_utils.compact_log_view(raw_log, verbose=0)
+    rendered = logging_utils.render_compact_log_view(view)
+
+    assert view["verbose"] == 0
+    assert view["signal_count"] == 2
+    assert view["signals"] == [
+        {"line": 82, "text": "ModuleNotFoundError: No module named 'critical_worker'"}
+    ]
+    assert view["tail"] == []
+    assert "first failure should be skipped" not in rendered
+    assert "progress 0" not in rendered
+    assert "omitted:" in rendered
+
+
+def test_compact_log_view_debug_mode_points_to_artifact_for_large_logs() -> None:
+    raw_log = "\n".join(f"raw stdout line {index}" for index in range(200))
+
+    view = logging_utils.compact_log_view(
+        raw_log,
+        verbose=3,
+        tail_limit=0,
+        debug_max_lines=20,
+    )
+    rendered = logging_utils.render_compact_log_view(view)
+
+    assert view["debug_lines"] == []
+    assert view["omitted_line_count"] == 200
+    assert "full prompt-facing output is capped" in view["note"]
+    assert "raw stdout line 0" not in rendered
+    assert "raw log artifact" in rendered

--- a/test/test_orchestrate_page_support.py
+++ b/test/test_orchestrate_page_support.py
@@ -1644,7 +1644,9 @@ def test_display_log_helper_warns_on_warning_stderr_and_uses_stderr_path():
 
     assert warnings == ["Warnings occurred during cluster installation:"]
     assert errors == []
-    assert code_sink.calls[-1][0][0] == "normal output\nwarning: deprecated option"
+    assert "AGILAB compact log" in code_sink.calls[-1][0][0]
+    assert "warning: deprecated option" in code_sink.calls[-1][0][0]
+    assert code_sink.calls[-1][1]["language"] == "text"
 
 
 def test_display_log_helper_uses_cached_stdout_when_missing_and_shows_stderr_errors():
@@ -1668,7 +1670,54 @@ def test_display_log_helper_uses_cached_stdout_when_missing_and_shows_stderr_err
 
     assert warning_messages == []
     assert errors == ["Errors occurred during cluster installation:"]
-    assert code_sink.calls[-1][0][0] == "something failed"
+    assert "AGILAB compact log" in code_sink.calls[-1][0][0]
+    assert "something failed" in code_sink.calls[-1][0][0]
+    assert code_sink.calls[-1][1]["language"] == "text"
+
+
+def test_display_log_helper_keeps_large_stdout_stderr_as_compact_view():
+    errors: list[str] = []
+    warning_messages: list[str] = []
+    code_sink = _CaptureCodeSink()
+    stdout = "\n".join(
+        f"stdout progress DISPLAY_NOISE_{index:03d} " + ("x" * 80)
+        for index in range(180)
+    )
+    stderr = "\n".join(
+        [
+            "stderr progress before failure",
+            "Traceback (most recent call last):",
+            "ModuleNotFoundError: No module named 'cluster_worker'",
+            "stderr token=ghp_abcdefghijklmnopqrstuvwxyz123456",
+        ]
+    )
+
+    orchestrate_page_support.display_log(
+        stdout=stdout,
+        stderr=stderr,
+        session_state={"cluster_verbose": 1},
+        strip_ansi_fn=orchestrate_page_support.strip_ansi,
+        filter_warning_messages_fn=lambda text: text,
+        format_log_block_fn=lambda text: text,
+        warning_fn=lambda message: warning_messages.append(message),
+        error_fn=lambda message: errors.append(message),
+        code_fn=code_sink,
+        log_display_max_lines=250,
+        log_display_height=300,
+    )
+
+    rendered = code_sink.calls[-1][0][0]
+    assert errors == ["Errors occurred during cluster installation:"]
+    assert warning_messages == []
+    assert code_sink.calls[-1][1]["language"] == "text"
+    assert "AGILAB compact log" in rendered
+    assert "Traceback (most recent call last):" in rendered
+    assert "ModuleNotFoundError: No module named 'cluster_worker'" in rendered
+    assert "token=<redacted>" in rendered
+    assert "ghp_" not in rendered
+    assert "DISPLAY_NOISE_000" not in rendered
+    assert "omitted:" in rendered
+    assert len(rendered) < 2_000
 
 
 def test_capture_and_restore_dataframe_preview_state_round_trip():

--- a/test/test_runtime_diagnostics.py
+++ b/test/test_runtime_diagnostics.py
@@ -40,6 +40,19 @@ def test_diagnostics_verbose_mapping_is_user_facing_and_bounded() -> None:
     assert runtime_diagnostics.diagnostics_widget_key("   ") == "runtime_diagnostics_level__default"
 
 
+def test_diagnostics_level_descriptions_preserve_token_budget_contract() -> None:
+    descriptions = {
+        label: description
+        for label, _verbose, description in runtime_diagnostics.DIAGNOSTICS_LEVELS
+    }
+
+    assert "essential" in descriptions["Quiet"].lower()
+    assert "compact signal-first" in descriptions["Standard"]
+    assert "context windows" in descriptions["Detailed"]
+    assert "small logs" in descriptions["Debug"]
+    assert "raw artifacts" in descriptions["Debug"]
+
+
 def test_global_diagnostics_verbose_prefers_project_agnostic_env() -> None:
     assert runtime_diagnostics.global_diagnostics_verbose(
         session_state={runtime_diagnostics.GLOBAL_DIAGNOSTICS_ENV_KEY: "3"},


### PR DESCRIPTION
## Summary
- Add token-budgeted compact log views with signal/tail/context/debug levels and common secret redaction.
- Render ORCHESTRATE cluster install logs through the compact view instead of raw stdout/stderr blocks.
- Align runtime diagnostics copy and AGENTS guidance with the compact log contract.

## Validation
- uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files AGENTS.md src/agilab/diagnostics/runtime_diagnostics.py src/agilab/environment/logging_utils.py src/agilab/orchestrate/orchestrate_page_support.py test/test_logging_utils.py test/test_orchestrate_page_support.py test/test_runtime_diagnostics.py
- uv --preview-features extra-build-dependencies run --extra ui pytest -q -o addopts='' test/test_logging_utils.py test/test_orchestrate_page_support.py test/test_runtime_diagnostics.py
- uv --preview-features extra-build-dependencies run --extra dev ruff check src/agilab/diagnostics/runtime_diagnostics.py src/agilab/environment/logging_utils.py src/agilab/orchestrate/orchestrate_page_support.py test/test_logging_utils.py test/test_orchestrate_page_support.py test/test_runtime_diagnostics.py