### PR TITLE
[codex] Prepare AGILAB 2026.06.04.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,26 @@ publication, or evidence refreshes on an already published date version.
 
 ## Unreleased
 
+## [2026.06.04.2] - 2026-06-04
+
+GitHub Release: https://github.com/ThalesGroup/agilab/releases/tag/v2026.06.04.2
+
+### Added
+
+- Added Devstral and Mistral Vibe workflow support across local assistant setup,
+  installer guidance, and coding-agent documentation.
+- Added the operator workbench roadmap item.
+
 ### Fixed
+
+- Compact cluster diagnostics now summarize token-heavy logs instead of forwarding
+  raw command output by default.
+- External app bootstrap roots are preserved during installation and worker setup.
+- Release workflow YAML validation now guards release handoff checks and accepts
+  hotfix release tags.
+- PyPI retention confirmation now uses the guarded confirmation-reader token path.
+- Release evidence now links the dataset release and records Hugging Face Space sync
+  state.
 
 - Prepared a root `agilab` packaging hotfix so the published console script includes
   CLI-required subpackages such as `agilab.security`, while keeping app, core,
@@ -832,3 +851,4 @@ GitHub Release: https://github.com/ThalesGroup/agilab/releases/tag/v2026.04.25
 [2026.06.02]: https://github.com/ThalesGroup/agilab/releases/tag/v2026.06.02
 [2026.06.04]: https://github.com/ThalesGroup/agilab/releases/tag/v2026.06.04
 [2026.06.04.1]: https://github.com/ThalesGroup/agilab/releases/tag/v2026.06.04.1
+[2026.06.04.2]: https://github.com/ThalesGroup/agilab/releases/tag/v2026.06.04.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.04.1"
+version = "2026.06.04.2"
 name = "agilab"
 description = "AGILAB is a reproducible AI/ML workbench for engineering teams."
 requires-python = ">=3.11,<3.14"


### PR DESCRIPTION
## Summary

- bump the root `agilab` package to `2026.06.04.2`
- move post-`2026.06.04.1` changes into the dated changelog release section
- keep split package pins unchanged because the impact release plan selects only `agilab`

## Validation

- `uv --preview-features extra-build-dependencies run python tools/release_plan.py --check-workflow .github/workflows/pypi-publish.yaml --impact-base-ref v2026.06.04.1 --skip-existing-pypi --format json --compact`
- `uv --preview-features extra-build-dependencies run python tools/pypi_release_version_policy.py --release-mode hotfix --skip-existing-pypi --impact-base-ref v2026.06.04.1`
- `uv --preview-features extra-build-dependencies run python tools/pypi_project_preflight.py`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files pyproject.toml CHANGELOG.md`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' --import-mode=importlib test/test_pyproject_dependency_hygiene.py`
- `uv lock --check`
- wheel metadata check: built `agilab-2026.6.4.2-py3-none-any.whl`
- `./dev maintenance`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile dependency-policy --profile shared-core-typing --profile docs`
- `uv --preview-features extra-build-dependencies run --extra dev ruff --version`
- `uv --preview-features extra-build-dependencies run python tools/coverage_badge_guard.py --changed-only --require-fresh-xml`

Note: `./dev release --release-mode hotfix --impact-base-ref v2026.06.04.1 --base v2026.06.04.1` was attempted on the release branch and stopped at the strict audit because the branch is intentionally ahead of `origin/main` before merge. It will be rerun from clean `main` before dispatching the release workflow.