### PR TITLE
[codex] Fix release compact log test expectation

### DIFF
--- a/test/test_orchestrate_page_helpers.py
+++ b/test/test_orchestrate_page_helpers.py
@@ -1012,7 +1012,10 @@ def test_orchestrate_page_support_log_filters_and_display_helpers():
     )
     assert warnings == []
     assert errors == ["Errors occurred during cluster installation:"]
-    assert code_sink.calls[-1][0][0] == "something failed"
+    rendered_log = code_sink.calls[-1][0][0]
+    assert "AGILAB compact log" in rendered_log
+    assert "something failed" in rendered_log
+    assert code_sink.calls[-1][1]["language"] == "text"
 
 
 def test_orchestrate_page_support_dataframe_state_helpers():


### PR DESCRIPTION
## Summary

- update the stale `test_orchestrate_page_helpers.py` assertion to match AGILAB's compact signal-first log renderer
- preserve the product behavior: stderr still renders as a compact log block and keeps the failure signal visible

## Root Cause

The `pypi-publish` release workflow failed in the `agi-gui` coverage support chunk because this older helper regression still expected raw stderr (`something failed`). The runtime now intentionally renders install logs through `AGILAB compact log` to keep token-heavy cluster diagnostics bounded.

## Validation

- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' --import-mode=importlib test/test_orchestrate_page_helpers.py::test_orchestrate_page_support_log_filters_and_display_helpers`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' --import-mode=importlib test/test_orchestrate_page_helpers.py`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui`