### PR TITLE
Harden cluster SSH transport security

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -130,6 +130,14 @@ organization's security requirements in mind. At minimum:
 - Treat AGILAB command execution as a trusted-operator boundary. Shared deployments should restrict
   project roots, environment variables, writable paths, and network access according to the team
   threat model.
+- Treat cluster worker SSH host identity as a deployment control. AGILAB's controller-to-worker
+  SSH and SCP paths verify host keys by default through a real ``known_hosts`` file. Seed
+  ``~/.ssh/known_hosts`` or set ``AGILAB_CLUSTER_SSH_KNOWN_HOSTS`` before cluster install/run.
+  ``AGILAB_CLUSTER_SSH_HOST_KEY_POLICY=accept-new`` is a lab-bootstrap TOFU mode, not a substitute
+  for out-of-band fingerprint verification. Prefer key-based SSH auth over passwords.
+- Treat worker app execution as trusted-code execution by design. A user who can submit or install
+  an AGILAB app can run code on the selected workers; use containers, VMs, dedicated OS users, or
+  scheduler-level isolation before accepting untrusted apps or multi-tenant submissions.
 - Run ``agilab security-check --profile shared --json`` before shared adoption reviews. The default
   ``local`` profile stays advisory for single-operator experiments; ``shared``, ``cluster``, and
   ``public-ui`` promote deployment-boundary issues to failures so ``--strict`` can be used as a real

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 252,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "7e870f0e74addb73a529a2328f8d9b7c25cd1d719940c06774498b318e6a733a",
+  "source_digest_sha256": "d8f54fc75a7d7f1a363e95f1ea1d39500239a29980bc47f612e67e8f8305a99d",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "7e870f0e74addb73a529a2328f8d9b7c25cd1d719940c06774498b318e6a733a"
+  "target_digest_sha256": "d8f54fc75a7d7f1a363e95f1ea1d39500239a29980bc47f612e67e8f8305a99d"
 }

--- a/docs/source/cluster.rst
+++ b/docs/source/cluster.rst
@@ -95,6 +95,17 @@ is classified by SSH BatchMode auth, operating system, ``python3``, ``uv``,
 ``sshfs``, and reverse SSH back to the scheduler when ``--scheduler`` is
 provided.
 
+Discovery is not a trust decision. Before running ``INSTALL`` or sending files
+to a remote worker, verify each worker host-key fingerprint out of band and pin
+it in the manager user's SSH ``known_hosts`` file. Controller-to-worker SSH and
+SCP default to strict host-key verification using ``~/.ssh/known_hosts``. To use
+a separate file, set ``AGILAB_CLUSTER_SSH_KNOWN_HOSTS=/path/to/known_hosts``.
+For controlled lab bootstrap only, ``AGILAB_CLUSTER_SSH_HOST_KEY_POLICY=accept-new``
+learns an unseen host key into that file on first use; use it only on a trusted
+network after confirming the machine identity. Prefer key-based auth. Password
+auth works, but a wrong or unpinned host-key setup can expose the password to an
+impersonating host.
+
 Windows managers can run discovery when the OpenSSH client is installed; AGILAB
 parses Windows ``ipconfig`` and ``arp -a`` output to find local LAN candidates.
 Windows remote workers are not covered by this cluster proof yet. Worker
@@ -291,6 +302,10 @@ worker:
    $workerHost = "<worker-host>"
    New-Item -ItemType Directory -Force "$HOME\.ssh" | Out-Null
    ssh-keyscan -H -t ed25519,rsa,ecdsa $workerHost | Out-File -Append -Encoding ascii "$HOME\.ssh\known_hosts"
+
+If you keep cluster host keys outside the default OpenSSH file, set
+``AGILAB_CLUSTER_SSH_KNOWN_HOSTS`` to that file before running AGILAB from
+PowerShell.
 
 Windows as a remote cluster worker is a separate support target and is not
 covered by the automatic SSHFS setup today. The generated remote setup commands

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/api/entrypoint_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/api/entrypoint_support.py
@@ -7,8 +7,9 @@ import time
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, TypeAlias, Union
 
-from agi_cluster.agi_distributor import runtime_misc_support
 from agi_cluster.agi_distributor import background_jobs_support
+from agi_cluster.agi_distributor import deployment_remote_support
+from agi_cluster.agi_distributor import runtime_misc_support
 from agi_cluster.agi_distributor.api.worker_cli_support import resolve_worker_cli_path
 from agi_cluster.agi_distributor.run_request_support import RunRequest
 
@@ -530,20 +531,43 @@ async def _launch_scheduler_process(
             log.info(result)
         return
 
-    remote_mkdir_cmd = (
-        f"{cmd_prefix}{env.uv} run --no-sync python -c "
-        f"\"import os; os.makedirs('{wenv_rel}', exist_ok=True)\""
+    remote_uv = deployment_remote_support._remote_tool(cmd_prefix, env.uv)
+    remote_mkdir_script = (
+        f"import os; os.makedirs({wenv_rel.as_posix()!r}, exist_ok=True)"
+    )
+    remote_mkdir_cmd = deployment_remote_support._remote_command(
+        remote_uv,
+        "run",
+        "--no-sync",
+        "python",
+        "-c",
+        remote_mkdir_script,
     )
     await agi_cls.exec_ssh(agi_cls._scheduler_ip, remote_mkdir_cmd)
 
     toml_wenv = wenv_rel / "pyproject.toml"
     await agi_cls.send_file(env, agi_cls._scheduler_ip, toml_local, toml_wenv)
 
-    remote_scheduler_cmd = (
-        f"{cmd_prefix}{dask_env}{env.uv} --project {wenv_rel} run --no-sync "
-        f"dask scheduler "
-        f"--port {agi_cls._scheduler_port} "
-        f"--host {agi_cls._scheduler_ip} --dashboard-address :0 --pid-file dask_scheduler.pid"
+    remote_scheduler_uv = deployment_remote_support._remote_tool(
+        f"{cmd_prefix}{dask_env}",
+        env.uv,
+    )
+    remote_scheduler_cmd = deployment_remote_support._remote_command(
+        remote_scheduler_uv,
+        "--project",
+        wenv_rel,
+        "run",
+        "--no-sync",
+        "dask",
+        "scheduler",
+        "--port",
+        agi_cls._scheduler_port,
+        "--host",
+        agi_cls._scheduler_ip,
+        "--dashboard-address",
+        ":0",
+        "--pid-file",
+        "dask_scheduler.pid",
     )
     create_task_fn(agi_cls.exec_ssh_async(agi_cls._scheduler_ip, remote_scheduler_cmd))
 

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_prepare_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_prepare_support.py
@@ -2,7 +2,6 @@ import logging
 import os
 import shlex
 import shutil
-import socket
 from ipaddress import ip_address as is_ip
 from pathlib import Path
 from tempfile import mkdtemp
@@ -54,7 +53,10 @@ async def _remote_uv_python_available(
     remote_command_failures: tuple[type[BaseException], ...],
 ) -> bool:
     try:
-        await run_exec_ssh_fn(ip, f"{uv} python find {pyvers}")
+        await run_exec_ssh_fn(
+            ip,
+            deployment_remote_support._remote_command(uv, "python", "find", pyvers),
+        )
     except remote_command_failures:
         return False
     return True
@@ -83,6 +85,12 @@ def _staged_uv_powershell_install_command() -> str:
         "Remove-Item -Force $p"
         '"'
     )
+
+
+def _remote_python_makedirs_command(uv: str, path: Path) -> str:
+    remote_path = path.as_posix()
+    script = f"import os; os.makedirs({remote_path!r}, exist_ok=True)"
+    return deployment_remote_support._remote_command(uv, "run", "python", "-c", script)
 
 
 async def uninstall_modules(agi_cls: Any, env: AgiEnv, *, run_fn: Callable[..., Any] = AgiEnv.run, log: Any = logger) -> None:
@@ -215,7 +223,6 @@ async def prepare_cluster_env(
     log: Any = logger,
 ) -> None:
     list_ip = set(list(agi_cls._workers) + [agi_cls._get_scheduler(scheduler_addr)[0]])
-    localhost_ip = socket.gethostbyname("localhost")
     env = agi_cls.env
     dist_rel = env.dist_rel
     wenv_rel = env.wenv_rel
@@ -275,15 +282,16 @@ async def prepare_cluster_env(
         if cmd_prefix is None:
             cmd_prefix = await detect_export_cmd_fn(ip)
             set_env_var_fn(f"{ip}_CMD_PREFIX", cmd_prefix)
-        uv_is_installed = True
-
         agi_internet_on = 1 if envar_truthy_fn(env.envars, "AGI_INTERNET_ON") else 0
+        uv_probe = deployment_remote_support._remote_tool(cmd_prefix, env.uv)
         try:
-            await run_exec_ssh_fn(ip, f"{cmd_prefix}{env.uv} --version")
+            await run_exec_ssh_fn(
+                ip,
+                deployment_remote_support._remote_command(uv_probe, "--version"),
+            )
         except ConnectionError:
             raise
         except remote_command_failures:
-            uv_is_installed = False
             if agi_internet_on == 0:
                 log.error("Uv binary is not installed, please install it manually on the workers.")
                 raise EnvironmentError("Uv binary is not installed, please install it manually on the workers.")
@@ -293,26 +301,26 @@ async def prepare_cluster_env(
                     ip,
                     _staged_uv_powershell_install_command(),
                 )
-                uv_is_installed = True
             except ConnectionError:
                 raise
             except remote_command_failures:
-                uv_is_installed = False
                 await run_exec_ssh_fn(ip, _staged_uv_install_command())
-                uv_is_installed = True
 
         if agi_internet_on == 1 and _uv_self_update_enabled(env.envars, envar_truthy_fn):
             try:
-                await run_exec_ssh_fn(ip, f"{cmd_prefix}{env.uv} self update")
+                await run_exec_ssh_fn(
+                    ip,
+                    deployment_remote_support._remote_command(uv_probe, "self", "update"),
+                )
             except remote_command_failures as exc:
                 log.warning("Failed to update uv on %s (skipping self update): %s", ip, exc)
         elif agi_internet_on != 1:
             log.warning("You appears to be on a local network. Please be sure to have uv latest release.")
 
         cmd_prefix = env.envars.get(f"{ip}_CMD_PREFIX", "")
-        uv = cmd_prefix + env.uv
+        uv = deployment_remote_support._remote_tool(cmd_prefix, env.uv)
 
-        cmd = f"{uv} run python -c \"import os; os.makedirs('{dist_rel.parents[1]}', exist_ok=True)\""
+        cmd = _remote_python_makedirs_command(uv, dist_rel.parents[1])
         await run_exec_ssh_fn(ip, cmd)
 
         if await _remote_uv_python_available(
@@ -325,7 +333,15 @@ async def prepare_cluster_env(
             log.info("[%s] Python interpreter '%s' is already available to uv; skipping install.", ip, pyvers_worker)
         else:
             try:
-                await run_exec_ssh_fn(ip, f"{uv} python install {pyvers_worker}")
+                await run_exec_ssh_fn(
+                    ip,
+                    deployment_remote_support._remote_command(
+                        uv,
+                        "python",
+                        "install",
+                        pyvers_worker,
+                    ),
+                )
             except process_error_type as exc:
                 if "No download found for request" in str(exc):
                     log.warning(
@@ -341,7 +357,7 @@ async def prepare_cluster_env(
         await kill_fn(ip, force=True)
         await clean_dirs_fn(ip)
 
-        cmd = f"{uv} run python -c \"import os; os.makedirs('{dist_rel}', exist_ok=True)\""
+        cmd = _remote_python_makedirs_command(uv, dist_rel)
         await run_exec_ssh_fn(ip, cmd)
 
         files_to_send: list[Path] = []

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime/runtime_misc_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime/runtime_misc_support.py
@@ -202,29 +202,38 @@ def load_capacity_predictor(
             retrain_fn()
         return None
 
-    if trusted_root is not None:
-        trust_error = _capacity_model_trust_error(path, trusted_root)
-        if trust_error is not None:
-            if log is not None:
-                log.warning(
-                    "Refusing to load untrusted capacity model from %s: %s",
-                    path,
-                    trust_error,
-                )
-            if retrain_fn is not None:
-                retrain_fn()
-            return None
-        manifest_error = _capacity_model_manifest_error(path)
-        if manifest_error is not None:
-            if log is not None:
-                log.warning(
-                    "Refusing to load unverified capacity model from %s: %s",
-                    path,
-                    manifest_error,
-                )
-            if retrain_fn is not None:
-                retrain_fn()
-            return None
+    if trusted_root is None:
+        if log is not None:
+            log.warning(
+                "Refusing to load capacity model from %s without a trusted resource root",
+                path,
+            )
+        if retrain_fn is not None:
+            retrain_fn()
+        return None
+
+    trust_error = _capacity_model_trust_error(path, trusted_root)
+    if trust_error is not None:
+        if log is not None:
+            log.warning(
+                "Refusing to load untrusted capacity model from %s: %s",
+                path,
+                trust_error,
+            )
+        if retrain_fn is not None:
+            retrain_fn()
+        return None
+    manifest_error = _capacity_model_manifest_error(path)
+    if manifest_error is not None:
+        if log is not None:
+            log.warning(
+                "Refusing to load unverified capacity model from %s: %s",
+                path,
+                manifest_error,
+            )
+        if retrain_fn is not None:
+            retrain_fn()
+        return None
 
     try:
         with open(path.resolve(strict=False), "rb") as stream:

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime/transport_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime/transport_support.py
@@ -4,6 +4,7 @@ import getpass
 import logging
 import os
 import shutil
+import subprocess
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any, AsyncIterator, Callable, Iterable, List, Optional, cast
@@ -16,10 +17,184 @@ from agi_env import AgiEnv
 
 logger = logging.getLogger(__name__)
 
+_KNOWN_HOSTS_ENV_NAMES = (
+    "AGILAB_CLUSTER_SSH_KNOWN_HOSTS",
+    "AGILAB_CLUSTER_KNOWN_HOSTS",
+    "AGI_CLUSTER_SSH_KNOWN_HOSTS",
+    "AGI_CLUSTER_KNOWN_HOSTS",
+    "cluster_ssh_known_hosts",
+    "cluster_known_hosts",
+)
+_HOST_KEY_POLICY_ENV_NAMES = (
+    "AGILAB_CLUSTER_SSH_HOST_KEY_POLICY",
+    "AGILAB_CLUSTER_HOST_KEY_POLICY",
+    "AGI_CLUSTER_SSH_HOST_KEY_POLICY",
+    "AGI_CLUSTER_HOST_KEY_POLICY",
+    "AGILAB_CLUSTER_SSH_STRICT_HOST_KEY_CHECKING",
+    "cluster_ssh_host_key_policy",
+    "cluster_host_key_policy",
+)
+_STRICT_HOST_KEY_VALUES = {"1", "on", "strict", "true", "yes"}
+_TOFU_HOST_KEY_VALUES = {
+    "0",
+    "accept-new",
+    "false",
+    "learn",
+    "learn-and-pin",
+    "off",
+    "tofu",
+}
+
 
 def _is_local_ip(ip: str) -> bool:
     is_local = cast(Callable[[str], bool], AgiEnv.is_local)
     return is_local(ip)
+
+
+def _env_lookup(env: Any, *names: str) -> str | None:
+    for name in names:
+        value = getattr(env, name, None)
+        if value not in (None, ""):
+            return str(value)
+    envars = getattr(env, "envars", None)
+    if isinstance(envars, dict):
+        for name in names:
+            value = envars.get(name)
+            if value not in (None, ""):
+                return str(value)
+    for name in names:
+        value = os.environ.get(name)
+        if value not in (None, ""):
+            return str(value)
+    return None
+
+
+def _cluster_ssh_known_hosts_path(env: Any) -> Path:
+    configured = _env_lookup(env, *_KNOWN_HOSTS_ENV_NAMES)
+    if configured:
+        return Path(configured).expanduser()
+    return Path("~/.ssh/known_hosts").expanduser()
+
+
+def _cluster_ssh_host_key_policy(env: Any) -> str:
+    configured = _env_lookup(env, *_HOST_KEY_POLICY_ENV_NAMES)
+    if configured in (None, ""):
+        return "strict"
+
+    normalized = str(configured).strip().lower()
+    if normalized in _STRICT_HOST_KEY_VALUES:
+        return "strict"
+    if normalized in _TOFU_HOST_KEY_VALUES:
+        return "accept-new"
+    raise ValueError(
+        "Invalid cluster SSH host-key policy. Use 'strict' or 'accept-new'."
+    )
+
+
+def _scp_host_key_options(env: Any) -> list[str]:
+    policy = _cluster_ssh_host_key_policy(env)
+    strict_check = "accept-new" if policy == "accept-new" else "yes"
+    known_hosts = _cluster_ssh_known_hosts_path(env)
+    return [
+        "-o",
+        f"StrictHostKeyChecking={strict_check}",
+        "-o",
+        f"UserKnownHostsFile={known_hosts}",
+    ]
+
+
+def _known_hosts_query_host(host: str, port: int) -> str:
+    return f"[{host}]:{port}" if port != 22 else host
+
+
+def _known_host_entry_exists(host: str, known_hosts_path: Path, *, port: int = 22) -> bool:
+    if not known_hosts_path.exists():
+        return False
+    try:
+        result = subprocess.run(
+            [
+                "ssh-keygen",
+                "-F",
+                _known_hosts_query_host(host, port),
+                "-f",
+                str(known_hosts_path),
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return result.returncode == 0 and bool(result.stdout.strip())
+
+
+def _append_known_host_from_scan(
+    host: str,
+    known_hosts_path: Path,
+    *,
+    port: int = 22,
+    log: Any = logger,
+) -> bool:
+    known_hosts_path.parent.mkdir(parents=True, exist_ok=True)
+    if os.name != "nt":
+        try:
+            known_hosts_path.parent.chmod(0o700)
+        except OSError:
+            pass
+    try:
+        result = subprocess.run(
+            [
+                "ssh-keyscan",
+                "-H",
+                "-T",
+                "5",
+                "-p",
+                str(port),
+                "-t",
+                "ed25519,rsa,ecdsa",
+                host,
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        log.warning("Could not learn SSH host key for %s: %s", host, exc)
+        return False
+
+    lines = [line for line in result.stdout.splitlines() if line.strip() and not line.startswith("#")]
+    if result.returncode != 0 or not lines:
+        detail = (result.stderr or "").strip() or "no host key returned"
+        log.warning("Could not learn SSH host key for %s: %s", host, detail)
+        return False
+
+    with known_hosts_path.open("a", encoding="utf-8") as stream:
+        for line in lines:
+            stream.write(f"{line}\n")
+    if os.name != "nt":
+        try:
+            known_hosts_path.chmod(0o600)
+        except OSError:
+            pass
+    return True
+
+
+def _prepare_known_hosts_for_policy(
+    host: str,
+    known_hosts_path: Path,
+    policy: str,
+    *,
+    log: Any = logger,
+) -> None:
+    if policy != "accept-new":
+        return
+    if _known_host_entry_exists(host, known_hosts_path):
+        return
+    learned = _append_known_host_from_scan(host, known_hosts_path, log=log)
+    if learned:
+        log.info("Pinned SSH host key for %s in %s", host, known_hosts_path)
 
 
 async def _run_scp_command(
@@ -138,13 +313,7 @@ async def send_file(
         auth_prefix = ["sshpass", "-e"]
         scp_env["SSHPASS"] = password
 
-    scp_cmd = [
-        "scp",
-        "-o",
-        "StrictHostKeyChecking=no",
-        "-o",
-        "UserKnownHostsFile=/dev/null",
-    ]
+    scp_cmd = ["scp", *_scp_host_key_options(env)]
     if local_path.is_dir():
         scp_cmd.append("-r")
     ssh_key_path = getattr(env, "ssh_key_path", None)
@@ -218,12 +387,21 @@ async def get_ssh_connection(
                 keys = discover_private_keys_fn(ssh_dir)
                 client_keys = keys if keys else None
 
+        host_key_policy = _cluster_ssh_host_key_policy(env)
+        known_hosts_path = _cluster_ssh_known_hosts_path(env)
+        _prepare_known_hosts_for_policy(
+            ip,
+            known_hosts_path,
+            host_key_policy,
+            log=log,
+        )
+
         conn = await asyncio.wait_for(
             asyncssh.connect(
                 ip,
                 username=env.user,
                 password=env.password,
-                known_hosts=None,
+                known_hosts=str(known_hosts_path),
                 client_keys=client_keys,
                 agent_path=agent_path,
             ),

--- a/src/agilab/core/test/test_agi_distributor_deployment_prepare_support.py
+++ b/src/agilab/core/test/test_agi_distributor_deployment_prepare_support.py
@@ -438,6 +438,52 @@ async def test_prepare_cluster_env_legacy_intel_macos_selects_python_311(tmp_pat
 
 
 @pytest.mark.asyncio
+async def test_prepare_cluster_env_quotes_remote_uv_setup_arguments(tmp_path):
+    env = _build_cluster_env(tmp_path)
+    env.dist_rel = Path("wenv/dist;touch pwn")
+    env.pyvers_worker = "3.13;touch pwn"
+    env.uv = "uv --quiet"
+    agi_cls = _build_agi(env)
+    sent = []
+    remote_cmds = []
+
+    async def _fake_detect(_ip):
+        return 'export PATH="$HOME/.local/bin:$PATH"; '
+
+    async def _fake_exec(ip, cmd):
+        remote_cmds.append((ip, cmd))
+        if "--version" in cmd:
+            return "uv 0.6.0"
+        if "python find" in cmd:
+            raise RuntimeError("not found")
+        return "ok"
+
+    async def _noop(*_args, **_kwargs):
+        return None
+
+    await deployment_prepare_support.prepare_cluster_env(
+        agi_cls,
+        "127.0.0.1",
+        envar_truthy_fn=_truthy,
+        detect_export_cmd_fn=_fake_detect,
+        ensure_optional_extras_fn=lambda *_a, **_k: None,
+        stage_uv_sources_fn=lambda **_kwargs: [],
+        run_exec_ssh_fn=_fake_exec,
+        send_files_fn=_recording_send(sent),
+        kill_fn=_noop,
+        clean_dirs_fn=_noop,
+        set_env_var_fn=lambda key, value=None: env.envars.__setitem__(key, value),
+        log=mock.Mock(),
+    )
+
+    joined = "\n".join(cmd for _, cmd in remote_cmds)
+    assert "python install '3.13;touch pwn'" in joined
+    assert "python install 3.13;touch pwn" not in joined
+    assert "wenv/dist;touch pwn" in joined
+    assert "'3.13;touch pwn'" in joined
+
+
+@pytest.mark.asyncio
 async def test_prepare_cluster_env_stages_uv_source_payload(tmp_path):
     cluster_pck = tmp_path / "cluster_pck"
     (cluster_pck / "agi_distributor").mkdir(parents=True, exist_ok=True)

--- a/src/agilab/core/test/test_agi_distributor_entrypoint_support.py
+++ b/src/agilab/core/test/test_agi_distributor_entrypoint_support.py
@@ -253,7 +253,10 @@ async def test_run_prepared_execution_calls_prepare_then_run_main(monkeypatch):
 
     process_error_type = RuntimeError
     format_exception_chain_fn = str
-    traceback_format_exc_fn = lambda: "tb"
+
+    def traceback_format_exc_fn():
+        return "tb"
+
     log = object()
 
     result = await entrypoint_support._run_prepared_execution(
@@ -353,7 +356,10 @@ async def test_dispatch_run_execution_switches_between_benchmark_and_prepared(
 
     process_error_type = RuntimeError
     format_exception_chain_fn = str
-    traceback_format_exc_fn = lambda: "tb"
+
+    def traceback_format_exc_fn():
+        return "tb"
+
     log = object()
 
     benchmark_result = await entrypoint_support._dispatch_run_execution(
@@ -1081,6 +1087,60 @@ async def test_launch_scheduler_process_remote_sends_pyproject_and_starts_async_
     assert calls["send"][0][1] == app_path / "pyproject.toml"
     assert calls["send"][0][2] == Path("worker") / "pyproject.toml"
     assert calls["tasks"][0][0] == "exec_ssh_async"
+
+
+@pytest.mark.asyncio
+async def test_launch_scheduler_process_remote_quotes_shell_arguments(monkeypatch, tmp_path):
+    app_path = tmp_path / "app"
+    app_path.mkdir()
+    (app_path / "pyproject.toml").write_text(
+        "[project]\nname='app'\n",
+        encoding="utf-8",
+    )
+
+    calls = {"exec": [], "send": [], "tasks": []}
+    AGI.env = SimpleNamespace(
+        active_app=app_path,
+        wenv_rel=Path("worker;touch pwn"),
+        wenv_abs=tmp_path / "worker",
+        uv="uv --quiet",
+        export_local_bin="",
+        app="demo",
+        is_local=lambda _ip: False,
+    )
+    AGI._scheduler_ip = "10.0.0.2"
+    AGI._scheduler_port = 8786
+
+    async def _fake_exec_ssh(ip, cmd):
+        calls["exec"].append((ip, cmd))
+
+    async def _fake_send(_env, ip, local_path, remote_path):
+        calls["send"].append((ip, local_path, remote_path))
+
+    monkeypatch.setattr(AGI, "_dask_env_prefix", staticmethod(lambda: "ENV=1 "))
+    monkeypatch.setattr(AGI, "exec_ssh", staticmethod(_fake_exec_ssh))
+    monkeypatch.setattr(AGI, "send_file", staticmethod(_fake_send))
+    monkeypatch.setattr(
+        AGI,
+        "exec_ssh_async",
+        staticmethod(lambda ip, cmd: ("exec_ssh_async", ip, cmd)),
+    )
+
+    async def _fake_sleep(_delay):
+        return None
+
+    await entrypoint_support._launch_scheduler_process(
+        AGI,
+        cmd_prefix='export PATH="$HOME/bin:$PATH"; ',
+        create_task_fn=lambda task: calls["tasks"].append(task),
+        sleep_fn=_fake_sleep,
+    )
+
+    mkdir_cmd = calls["exec"][0][1]
+    scheduler_cmd = calls["tasks"][0][2]
+    assert "worker;touch pwn" in mkdir_cmd
+    assert "--project 'worker;touch pwn'" in scheduler_cmd
+    assert "--project worker;touch pwn" not in scheduler_cmd
 
 
 @pytest.mark.asyncio

--- a/src/agilab/core/test/test_agi_distributor_runtime_misc_support.py
+++ b/src/agilab/core/test/test_agi_distributor_runtime_misc_support.py
@@ -256,16 +256,25 @@ def test_format_exception_chain_handles_context_normalization_edges(monkeypatch)
     assert "fresh detail" in text
 
 
-def test_load_capacity_predictor_returns_loaded_value(tmp_path):
+def test_load_capacity_predictor_rejects_missing_trusted_root_by_default(tmp_path):
     model_path = tmp_path / "balancer_model.pkl"
     model_path.write_bytes(b"pickle-bytes")
+    calls = {"load": 0, "retrain": 0, "warnings": []}
+    log = SimpleNamespace(
+        warning=lambda message, path: calls["warnings"].append((message, path))
+    )
 
     loaded = runtime_misc_support.load_capacity_predictor(
         model_path,
-        load_fn=lambda stream: {"size": len(stream.read())},
+        load_fn=lambda _stream: calls.__setitem__("load", calls["load"] + 1),
+        retrain_fn=lambda: calls.__setitem__("retrain", calls["retrain"] + 1),
+        log=log,
     )
 
-    assert loaded == {"size": len(b"pickle-bytes")}
+    assert loaded is None
+    assert calls["load"] == 0
+    assert calls["retrain"] == 1
+    assert "without a trusted resource root" in calls["warnings"][0][0]
 
 
 def test_load_capacity_predictor_returns_signed_trusted_value(tmp_path):
@@ -390,8 +399,10 @@ def test_load_capacity_predictor_retrains_when_missing(tmp_path):
 
 
 def test_load_capacity_predictor_handles_legacy_module_error(tmp_path):
-    model_path = tmp_path / "balancer_model.pkl"
+    model_path = tmp_path / "resources" / "balancer_model.pkl"
+    model_path.parent.mkdir()
     model_path.write_bytes(b"pickle-bytes")
+    runtime_misc_support.write_capacity_model_manifest(model_path)
     calls = {"retrain": 0, "warnings": []}
     log = SimpleNamespace(
         warning=lambda message, path, exc: calls["warnings"].append(
@@ -406,6 +417,7 @@ def test_load_capacity_predictor_handles_legacy_module_error(tmp_path):
         ),
         retrain_fn=lambda: calls.__setitem__("retrain", calls["retrain"] + 1),
         log=log,
+        trusted_root=model_path.parent,
     )
 
     assert loaded is None

--- a/src/agilab/core/test/test_agi_distributor_transport_support.py
+++ b/src/agilab/core/test/test_agi_distributor_transport_support.py
@@ -67,6 +67,7 @@ async def test_send_file_remote_success_and_command_construction(monkeypatch, tm
         user="alice",
         password="secret",
         ssh_key_path=str(tmp_path / "id_rsa"),
+        envars={"AGILAB_CLUSTER_SSH_KNOWN_HOSTS": str(tmp_path / "known_hosts")},
     )
     calls = []
 
@@ -96,16 +97,66 @@ async def test_send_file_remote_success_and_command_construction(monkeypatch, tm
     flat = list(calls[0])
     assert flat[0] == ("scp" if os.name == "nt" else "sshpass")
     assert "scp" in flat
+    assert "StrictHostKeyChecking=yes" in flat
+    assert f"UserKnownHostsFile={tmp_path / 'known_hosts'}" in flat
+    assert "StrictHostKeyChecking=no" not in flat
+    assert "UserKnownHostsFile=/dev/null" not in flat
     assert "-i" in flat
     assert str(local_file) in flat
     assert "alice@10.0.0.9:/tmp/remote.bin" in flat
 
 
 @pytest.mark.asyncio
+async def test_send_file_remote_accept_new_host_key_policy_is_explicit(monkeypatch, tmp_path):
+    local_file = tmp_path / "src.bin"
+    local_file.write_text("x", encoding="utf-8")
+    env = SimpleNamespace(
+        user="alice",
+        password=None,
+        ssh_key_path=None,
+        envars={
+            "AGILAB_CLUSTER_SSH_HOST_KEY_POLICY": "accept-new",
+            "AGILAB_CLUSTER_SSH_KNOWN_HOSTS": str(tmp_path / "known_hosts"),
+        },
+    )
+    calls = []
+
+    class _Proc:
+        returncode = 0
+
+        async def communicate(self):
+            return b"ok", b""
+
+    async def _fake_subproc(*cmd, **_kwargs):
+        calls.append(cmd)
+        return _Proc()
+
+    monkeypatch.setattr(transport_support.AgiEnv, "is_local", staticmethod(lambda _ip: False))
+    monkeypatch.setattr(transport_support.asyncio, "create_subprocess_exec", _fake_subproc)
+
+    await transport_support.send_file(
+        env=env,
+        ip="10.0.0.9",
+        local_path=local_file,
+        remote_path=Path("/tmp/remote.bin"),
+    )
+
+    flat = list(calls[0])
+    assert "StrictHostKeyChecking=accept-new" in flat
+    assert f"UserKnownHostsFile={tmp_path / 'known_hosts'}" in flat
+    assert "UserKnownHostsFile=/dev/null" not in flat
+
+
+@pytest.mark.asyncio
 async def test_send_file_remote_retries_with_password_auth_on_first_failure(monkeypatch, tmp_path):
     local_file = tmp_path / "src.bin"
     local_file.write_text("x", encoding="utf-8")
-    env = SimpleNamespace(user="alice", password="secret", ssh_key_path=None)
+    env = SimpleNamespace(
+        user="alice",
+        password="secret",
+        ssh_key_path=None,
+        envars={"AGILAB_CLUSTER_SSH_KNOWN_HOSTS": str(tmp_path / "known_hosts")},
+    )
     calls = []
     call_envs = []
     procs = [
@@ -136,6 +187,8 @@ async def test_send_file_remote_retries_with_password_auth_on_first_failure(monk
     assert ("-e" in calls[1]) is (os.name != "nt")
     assert "-p" not in calls[0]
     assert "-p" not in calls[1]
+    assert "StrictHostKeyChecking=yes" in calls[0]
+    assert f"UserKnownHostsFile={tmp_path / 'known_hosts'}" in calls[0]
     if os.name != "nt":
         assert call_envs[0]["SSHPASS"] == "secret"
         assert call_envs[1]["SSHPASS"] == "secret"
@@ -387,7 +440,12 @@ async def test_get_ssh_connection_sets_local_user_and_uses_key_override(monkeypa
     monkeypatch.setattr(transport_support.asyncssh, "connect", _fake_connect)
 
     agi_cls = SimpleNamespace(
-        env=SimpleNamespace(user=None, password=None, ssh_key_path=str(tmp_path / "id_ed25519")),
+        env=SimpleNamespace(
+            user=None,
+            password=None,
+            ssh_key_path=str(tmp_path / "id_ed25519"),
+            envars={"AGILAB_CLUSTER_SSH_KNOWN_HOSTS": str(tmp_path / "known_hosts")},
+        ),
         _ssh_connections={},
     )
 
@@ -396,23 +454,37 @@ async def test_get_ssh_connection_sets_local_user_and_uses_key_override(monkeypa
 
     assert agi_cls.env.user == "local-user"
     assert calls[0][1]["client_keys"] == [str((tmp_path / "id_ed25519").expanduser())]
+    assert calls[0][1]["known_hosts"] == str(tmp_path / "known_hosts")
+    assert calls[0][1]["known_hosts"] is not None
 
 
 @pytest.mark.asyncio
-async def test_get_ssh_connection_uses_password_auth_and_handles_generic_oserror(monkeypatch):
+async def test_get_ssh_connection_uses_password_auth_and_handles_generic_oserror(monkeypatch, tmp_path):
+    calls = []
+
     async def _fake_connect(*args, **kwargs):
+        calls.append((args, kwargs))
         return SimpleNamespace(is_closed=lambda: False)
 
     monkeypatch.setattr(transport_support.AgiEnv, "is_local", staticmethod(lambda _ip: False))
     monkeypatch.setattr(transport_support.asyncssh, "connect", _fake_connect)
 
     agi_cls = SimpleNamespace(
-        env=SimpleNamespace(user="alice", password="secret", ssh_key_path=None),
+        env=SimpleNamespace(
+            user="alice",
+            password="secret",
+            ssh_key_path=None,
+            envars={"AGILAB_CLUSTER_SSH_KNOWN_HOSTS": str(tmp_path / "known_hosts")},
+        ),
         _ssh_connections={},
     )
 
     async with transport_support.get_ssh_connection(agi_cls, "10.0.0.7") as conn:
         assert conn is agi_cls._ssh_connections["10.0.0.7"]
+
+    assert calls[0][1]["password"] == "secret"
+    assert calls[0][1]["client_keys"] == []
+    assert calls[0][1]["known_hosts"] == str(tmp_path / "known_hosts")
 
     async def _raise_generic_oserror(_awaitable, timeout):
         _awaitable.close()
@@ -423,6 +495,44 @@ async def test_get_ssh_connection_uses_password_auth_and_handles_generic_oserror
     with pytest.raises(ConnectionError, match="disk glitch"):
         async with transport_support.get_ssh_connection(agi_cls, "10.0.0.8", timeout_sec=1):
             pass
+
+
+@pytest.mark.asyncio
+async def test_get_ssh_connection_accept_new_policy_pins_known_host(monkeypatch, tmp_path):
+    calls = []
+    pinned = []
+
+    async def _fake_connect(*args, **kwargs):
+        calls.append((args, kwargs))
+        return SimpleNamespace(is_closed=lambda: False)
+
+    monkeypatch.setattr(transport_support.AgiEnv, "is_local", staticmethod(lambda _ip: False))
+    monkeypatch.setattr(transport_support.asyncssh, "connect", _fake_connect)
+    monkeypatch.setattr(transport_support, "_known_host_entry_exists", lambda *_a, **_k: False)
+    monkeypatch.setattr(
+        transport_support,
+        "_append_known_host_from_scan",
+        lambda host, path, **_kwargs: pinned.append((host, path)) or True,
+    )
+
+    agi_cls = SimpleNamespace(
+        env=SimpleNamespace(
+            user="alice",
+            password=None,
+            ssh_key_path=None,
+            envars={
+                "AGILAB_CLUSTER_SSH_HOST_KEY_POLICY": "tofu",
+                "AGILAB_CLUSTER_SSH_KNOWN_HOSTS": str(tmp_path / "known_hosts"),
+            },
+        ),
+        _ssh_connections={},
+    )
+
+    async with transport_support.get_ssh_connection(agi_cls, "10.0.0.9") as conn:
+        assert conn is agi_cls._ssh_connections["10.0.0.9"]
+
+    assert pinned == [("10.0.0.9", tmp_path / "known_hosts")]
+    assert calls[0][1]["known_hosts"] == str(tmp_path / "known_hosts")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- make controller-to-worker SSH/SCP host-key verification default-on through a real known_hosts file
- add explicit accept-new/TOFU bootstrap mode and remove known_hosts=None and /dev/null bypasses
- quote remote worker and scheduler setup commands built from uv, paths, and Python versions
- fail closed when loading capacity predictor pickle files without a trusted root
- document cluster host-key trust and trusted-code worker execution boundaries

## Validation
- uv --preview-features extra-build-dependencies run --extra dev ruff check <touched python files and tests>
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' --import-mode=importlib src/agilab/core/test/test_agi_distributor_transport_support.py src/agilab/core/test/test_agi_distributor_deployment_prepare_support.py src/agilab/core/test/test_agi_distributor_runtime_misc_support.py src/agilab/core/test/test_agi_distributor_entrypoint_support.py
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' --import-mode=importlib test/test_cluster_flight_validation.py test/test_cluster_lan_discovery.py src/agilab/core/test/test_agi_distributor_deployment_prepare_support.py src/agilab/core/test/test_agi_distributor_entrypoint_support.py src/agilab/core/test/test_agi_distributor_runtime_misc_support.py src/agilab/core/test/test_agi_distributor_transport_support.py
- uv --preview-features extra-build-dependencies run --no-sync pytest -q -o addopts='' --import-mode=importlib src/agilab/core/test
- uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --check
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs
