### PR TITLE
docs: harden security review skill checks

### DIFF
--- a/.claude/skills/agilab-security-review-patterns/SKILL.md
+++ b/.claude/skills/agilab-security-review-patterns/SKILL.md
@@ -41,6 +41,21 @@ claim. Keep findings tied to concrete files, commands, and user impact.
   CLI examples, exception text, or persisted app settings.
 - **Serialization and tasks**: reject unsafe legacy formats instead of loading
   them. Prefer JSON schemas and explicit validation.
+- **Pickle/model loading**: require a trusted root plus manifest/hash
+  verification before loading pickle-backed models or caches. A production caller
+  being safe is not enough when the helper default can be reused unsafely; make
+  missing trust context fail closed and add a regression for that default.
+- **Cluster SSH identity**: flag `known_hosts=None`,
+  `StrictHostKeyChecking=no`, `UserKnownHostsFile=/dev/null`, and any equivalent
+  host-key bypass in SSH/SCP/SSHFS paths. Controller-to-worker and
+  worker-to-scheduler SSH must verify a real `known_hosts` file by default.
+  TOFU/`accept-new` is acceptable only as an explicit lab-bootstrap mode with
+  documentation that fingerprints still need out-of-band verification.
+- **Remote shell composition**: when `exec_ssh`, AsyncSSH, SCP, SSHFS, or worker
+  deployment commands use shell strings, review every interpolated value. Paths,
+  Python versions, uv commands, scheduler addresses, share paths, and probe
+  outputs need quoting helpers or argument-vector APIs. Add regressions with
+  shell metacharacters for fixed command builders.
 - **Cluster shares**: cluster mode must require a usable shared path distinct
   from local-only paths; do not silently degrade to local execution.
 - **Installer changes**: compare source manifests with copied worker manifests

--- a/.codex/skills/agilab-security-review-patterns/SKILL.md
+++ b/.codex/skills/agilab-security-review-patterns/SKILL.md
@@ -41,6 +41,21 @@ claim. Keep findings tied to concrete files, commands, and user impact.
   CLI examples, exception text, or persisted app settings.
 - **Serialization and tasks**: reject unsafe legacy formats instead of loading
   them. Prefer JSON schemas and explicit validation.
+- **Pickle/model loading**: require a trusted root plus manifest/hash
+  verification before loading pickle-backed models or caches. A production caller
+  being safe is not enough when the helper default can be reused unsafely; make
+  missing trust context fail closed and add a regression for that default.
+- **Cluster SSH identity**: flag `known_hosts=None`,
+  `StrictHostKeyChecking=no`, `UserKnownHostsFile=/dev/null`, and any equivalent
+  host-key bypass in SSH/SCP/SSHFS paths. Controller-to-worker and
+  worker-to-scheduler SSH must verify a real `known_hosts` file by default.
+  TOFU/`accept-new` is acceptable only as an explicit lab-bootstrap mode with
+  documentation that fingerprints still need out-of-band verification.
+- **Remote shell composition**: when `exec_ssh`, AsyncSSH, SCP, SSHFS, or worker
+  deployment commands use shell strings, review every interpolated value. Paths,
+  Python versions, uv commands, scheduler addresses, share paths, and probe
+  outputs need quoting helpers or argument-vector APIs. Add regressions with
+  shell metacharacters for fixed command builders.
 - **Cluster shares**: cluster mode must require a usable shared path distinct
   from local-only paths; do not silently degrade to local execution.
 - **Installer changes**: compare source manifests with copied worker manifests

--- a/agenticweb.md
+++ b/agenticweb.md
@@ -224,7 +224,7 @@ x_generated_by:
   command: "python3 tools/agenticweb_manifest.py --apply"
   source_manifest: "agilab-capabilities.json"
   source_schema: "agilab.capabilities.v1"
-  source_version: "2026.06.04.1"
+  source_version: "2026.06.04.2"
   boundary: "Discovery only: this file does not prove runtime success, external service reachability, security certification, or production readiness."
 ---
 

--- a/agilab-capabilities.json
+++ b/agilab-capabilities.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-06-04T16:19:03Z",
+  "generated_at_utc": "2026-06-04T17:45:37Z",
   "schema": "agilab.capabilities.v1",
   "schema_version": 1,
   "generated_by": {
@@ -10,7 +10,7 @@
     "repository": "https://github.com/ThalesGroup/agilab",
     "documentation": "https://thalesgroup.github.io/agilab/",
     "project": "agilab",
-    "version": "2026.06.04.1"
+    "version": "2026.06.04.2"
   },
   "boundary": {
     "proves": "This manifest proves that public AGILAB surfaces are discoverable from checked-in contracts.",
@@ -648,7 +648,7 @@
       "name": "agilab",
       "role": "top-level-bundle",
       "status": "PyPI package",
-      "version": "2026.06.04.1",
+      "version": "2026.06.04.2",
       "description": "AGILAB is a reproducible AI/ML workbench for engineering teams.",
       "project": ".",
       "pyproject": "pyproject.toml",


### PR DESCRIPTION
## Summary
- add concrete cluster SSH host-key review checks to agilab-security-review-patterns
- add remote shell composition and pickle/model loading review checks from the cluster security audit
- sync the Codex skill mirror and refresh public agent discovery metadata for 2026.06.04.2

## Validation
- python3 tools/sync_agent_skills.py --skills agilab-security-review-patterns
- python3 tools/codex_skills.py --root .codex/skills validate --strict
- python3 tools/codex_skills.py --root .codex/skills generate
- python3 tools/agent_instruction_contract.py --check
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile skills
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' --import-mode=importlib test/test_agenticweb_manifest.py
