### PR TITLE
Add Tescia data scientist evaluation cases

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 252,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "d8f54fc75a7d7f1a363e95f1ea1d39500239a29980bc47f612e67e8f8305a99d",
+  "source_digest_sha256": "cc2b2457732281bb9454a773c985edc45a5a44f6316d52ce8b15469a74db9a18",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "d8f54fc75a7d7f1a363e95f1ea1d39500239a29980bc47f612e67e8f8305a99d"
+  "target_digest_sha256": "cc2b2457732281bb9454a773c985edc45a5a44f6316d52ce8b15469a74db9a18"
 }

--- a/docs/source/public-app-catalog.rst
+++ b/docs/source/public-app-catalog.rst
@@ -84,8 +84,9 @@ Status legend:
      - ``agi-app-tescia-diagnostic``
      - PyPI app package
      - Evidence-scored diagnostic and self-evaluation cases with 2026 math
-       coverage, classroom batch intake, live teacher dashboard artifacts,
-       better-fix selection, and regression-plan evidence.
+       coverage, 2026 data-scientist interview evaluation, classroom batch
+       intake, live teacher dashboard artifacts, better-fix selection, and
+       regression-plan evidence.
    * - ``uav_relay_queue_project``
      - ``agi-app-uav-relay-queue``
      - PyPI app package

--- a/src/agilab/apps/builtin/tescia_diagnostic_project/README.md
+++ b/src/agilab/apps/builtin/tescia_diagnostic_project/README.md
@@ -1,13 +1,17 @@
 # TeSciA Diagnostic Project
 
-`tescia_diagnostic_project` turns a TeSciA-style engineering diagnostic into a
-runnable AGILAB app and classroom-ready self-evaluation workflow.
+`tescia_diagnostic_project` turns TeSciA-style engineering and data-scientist
+diagnostics into a runnable AGILAB app and classroom-ready self-evaluation
+workflow.
 
 ## Purpose
 
 Use this app to convert support/debugging reasoning into structured evidence:
 symptoms, assumptions, root cause, stronger fix, regression plan, student score,
-and classroom intervention signals.
+and classroom intervention signals. The bundled catalog also includes a 2026
+data-scientist interview evaluation inspired by the legacy QCM format: modern
+Python/pandas practice, leakage-free model evaluation, scaling choices, RAG
+governance, and inference optimization.
 
 ## What You Learn
 
@@ -17,6 +21,8 @@ and classroom intervention signals.
 - How student answers produce `student_score`, feedback, and correction sheets.
 - How classroom batches can be split into worker-friendly independent rows.
 - How curriculum coverage is audited from explicit metadata.
+- How a data-scientist interview bank can be refreshed without relying on
+  outdated library APIs or unverified model claims.
 
 ## Run In AGILAB
 
@@ -43,9 +49,10 @@ student, curriculum, and intervention CSV files.
 
 ## Change One Thing
 
-After the default run works, change one `student_answer` or add one diagnostic
-case with a weaker proposed fix. The feedback should identify missing evidence,
-wrong fix choice, or missing discriminator regression tests.
+After the default run works, filter the catalog to `data-scientist candidate`,
+change one `student_answer`, or add one diagnostic case with a weaker proposed
+fix. The feedback should identify missing evidence, wrong fix choice, or
+missing discriminator regression tests.
 
 ## Troubleshooting
 

--- a/src/agilab/apps/builtin/tescia_diagnostic_project/src/tescia_diagnostic/sample_data/tescia_diagnostic_cases.json
+++ b/src/agilab/apps/builtin/tescia_diagnostic_project/src/tescia_diagnostic/sample_data/tescia_diagnostic_cases.json
@@ -1057,6 +1057,502 @@
         ],
         "confidence": 0.88
       }
+    },
+    {
+      "case_id": "data_scientist_2026_python_pandas_modernization",
+      "title": "Modernize a legacy Python and pandas interview answer",
+      "difficulty": "intro",
+      "topic_tags": [
+        "data-science-2026",
+        "python",
+        "pandas",
+        "notebook",
+        "interview"
+      ],
+      "estimated_minutes": 25,
+      "learner_level": "data-scientist candidate",
+      "student_prompt": "Review a legacy data-scientist QCM answer key. Identify the outdated Python and pandas claims, select the evidence-backed correction, and define regression checks for the refreshed interview bank.",
+      "symptom": "A candidate answer key still says venv is for sharing one environment across projects, pyenv is for one virtual environment per project, DataFrame.append is acceptable, and ordinary equality joins are enough for timestamp-aligned sensor data.",
+      "proposed_diagnosis": "The answer key only needs spelling cleanup because the Python fundamentals are still correct.",
+      "root_cause": "The legacy key mixes durable Python fundamentals with outdated tooling guidance; a 2026 data-scientist evaluation should require isolated virtual environments, separate Python-version management, pandas.concat instead of removed DataFrame.append, and merge_asof for nearest-key time joins on sorted data.",
+      "plain_repro": "Run the legacy pandas append snippet under pandas 2+ and review a time-series join where samples and labels have nearest timestamps instead of identical timestamps.",
+      "weak_assumptions": [
+        "Old pandas idioms remain acceptable if they were once common.",
+        "Environment isolation and Python-version selection are the same concept.",
+        "All tabular joins are equality joins even when the key is time."
+      ],
+      "evidence": [
+        {
+          "id": "pandas_append_removed",
+          "description": "pandas 2 removed Series.append and DataFrame.append; concat is the maintained replacement.",
+          "confidence": 0.96,
+          "relevance": 0.95
+        },
+        {
+          "id": "asof_time_join_required",
+          "description": "Timestamp-aligned telemetry and label data often need nearest-key joins with sorted inputs rather than exact equality joins.",
+          "confidence": 0.9,
+          "relevance": 0.88
+        },
+        {
+          "id": "environment_boundary_mislabeled",
+          "description": "venv isolates project dependencies while pyenv-style tooling selects Python interpreter versions.",
+          "confidence": 0.88,
+          "relevance": 0.82
+        },
+        {
+          "id": "reentrant_notebook_helper_risk",
+          "description": "Notebook helper functions that mutate module globals are not safe when reused in parallel scoring or worker execution.",
+          "confidence": 0.86,
+          "relevance": 0.8
+        }
+      ],
+      "candidate_fixes": [
+        {
+          "id": "replace_legacy_python_pandas_items",
+          "summary": "Refresh the answer key with current Python environment boundaries, pandas 2+ APIs, explicit time-join guidance, and reentrant helper expectations.",
+          "expected_impact": 0.91,
+          "blast_radius": 0.22,
+          "reversibility": 0.88
+        },
+        {
+          "id": "keep_legacy_items_with_notes",
+          "summary": "Keep the legacy answers and add a generic warning that some library APIs may have changed.",
+          "expected_impact": 0.39,
+          "blast_radius": 0.34,
+          "reversibility": 0.75
+        }
+      ],
+      "regression_tests": [
+        {
+          "id": "pandas_append_rejected",
+          "description": "Assert the refreshed bank no longer recommends DataFrame.append and names pandas.concat.",
+          "automated": true,
+          "discriminator": true
+        },
+        {
+          "id": "time_join_asof_case_present",
+          "description": "Assert timestamp-join prompts mention merge_asof or an equivalent nearest-key sorted join.",
+          "automated": true,
+          "discriminator": true
+        },
+        {
+          "id": "environment_terms_distinguished",
+          "description": "Assert the environment section separates virtual environments from Python-version management.",
+          "automated": true,
+          "discriminator": true
+        }
+      ],
+      "student_answer": {
+        "diagnosis": "The old QCM has valid Python fundamentals but the tooling guidance is now stale.",
+        "root_cause": "The legacy key mixes durable Python fundamentals with outdated tooling guidance; a 2026 data-scientist evaluation should require isolated virtual environments, separate Python-version management, pandas.concat instead of removed DataFrame.append, and merge_asof for nearest-key time joins on sorted data.",
+        "evidence_ids": [
+          "pandas_append_removed",
+          "asof_time_join_required"
+        ],
+        "selected_fix_id": "replace_legacy_python_pandas_items",
+        "regression_test_ids": [
+          "pandas_append_rejected",
+          "time_join_asof_case_present",
+          "environment_terms_distinguished"
+        ],
+        "confidence": 0.9
+      }
+    },
+    {
+      "case_id": "data_scientist_2026_model_evaluation_leakage",
+      "title": "Evaluate an imbalanced model without leakage",
+      "difficulty": "intermediate",
+      "topic_tags": [
+        "data-science-2026",
+        "machine-learning",
+        "model-evaluation",
+        "data-leakage",
+        "imbalanced-data"
+      ],
+      "estimated_minutes": 35,
+      "learner_level": "data-scientist candidate",
+      "student_prompt": "A fraud classifier reports 98 percent accuracy on a two percent positive class. Diagnose the weak evaluation, pick the safer fix, and choose regression checks.",
+      "symptom": "The notebook fits imputation, scaling, PCA, and synthetic oversampling before the train-test split, then selects the model by accuracy on a heavily imbalanced target.",
+      "proposed_diagnosis": "The score is high enough because accuracy is intuitive and easy to explain.",
+      "root_cause": "The evaluation leaks test-set information through preprocessing and resampling, and accuracy hides minority-class failure; the pipeline should fit every learned transform inside cross-validation and report task-aligned metrics such as precision, recall, F1, PR-AUC, ROC-AUC, calibration, and threshold tradeoffs.",
+      "plain_repro": "Run the notebook with a Pipeline that fits preprocessing only on training folds, compare accuracy with PR-AUC and recall at the required precision floor, and inspect whether test data is ever passed to fit.",
+      "weak_assumptions": [
+        "A high accuracy proves a classifier is useful on rare positives.",
+        "Preprocessing is harmless if labels are not passed explicitly.",
+        "The model threshold can be chosen after looking at test performance."
+      ],
+      "evidence": [
+        {
+          "id": "fit_before_split",
+          "description": "The scaler, PCA, and sampler are fit before train-test separation.",
+          "confidence": 0.94,
+          "relevance": 0.96
+        },
+        {
+          "id": "rare_positive_base_rate",
+          "description": "Only two percent of rows are positive, so a naive negative classifier can look accurate.",
+          "confidence": 0.92,
+          "relevance": 0.94
+        },
+        {
+          "id": "business_costs_asymmetric",
+          "description": "False negatives and false positives have different operational costs and require an explicit threshold policy.",
+          "confidence": 0.87,
+          "relevance": 0.86
+        }
+      ],
+      "candidate_fixes": [
+        {
+          "id": "pipeline_cv_metric_threshold_gate",
+          "summary": "Move learned preprocessing and resampling into a Pipeline, use stratified cross-validation, and gate the model on minority-class and calibrated-threshold metrics.",
+          "expected_impact": 0.93,
+          "blast_radius": 0.3,
+          "reversibility": 0.84
+        },
+        {
+          "id": "maximize_accuracy_only",
+          "summary": "Keep the preprocessing order and optimize accuracy because it is easy to communicate.",
+          "expected_impact": 0.28,
+          "blast_radius": 0.62,
+          "reversibility": 0.62
+        }
+      ],
+      "regression_tests": [
+        {
+          "id": "no_fit_on_test_data",
+          "description": "Static or notebook-level check that StandardScaler, imputers, PCA, and samplers are fit only inside training folds.",
+          "automated": true,
+          "discriminator": true
+        },
+        {
+          "id": "imbalanced_metric_suite",
+          "description": "Assert the model report includes PR-AUC or average precision, recall, precision, F1, ROC-AUC, and a confusion matrix.",
+          "automated": true,
+          "discriminator": true
+        },
+        {
+          "id": "threshold_policy_replay",
+          "description": "Replay the selected threshold on a holdout set and record the precision-recall tradeoff.",
+          "automated": true,
+          "discriminator": true
+        }
+      ],
+      "student_answer": {
+        "diagnosis": "The high accuracy is misleading because the workflow leaks information and ignores the rare positive class.",
+        "root_cause": "The evaluation leaks test-set information through preprocessing and resampling, and accuracy hides minority-class failure; the pipeline should fit every learned transform inside cross-validation and report task-aligned metrics such as precision, recall, F1, PR-AUC, ROC-AUC, calibration, and threshold tradeoffs.",
+        "evidence_ids": [
+          "fit_before_split",
+          "rare_positive_base_rate"
+        ],
+        "selected_fix_id": "pipeline_cv_metric_threshold_gate",
+        "regression_test_ids": [
+          "no_fit_on_test_data",
+          "imbalanced_metric_suite",
+          "threshold_policy_replay"
+        ],
+        "confidence": 0.91
+      }
+    },
+    {
+      "case_id": "data_scientist_2026_scaling_feature_pipeline",
+      "title": "Choose the right scaling path for a feature pipeline",
+      "difficulty": "intermediate",
+      "topic_tags": [
+        "data-science-2026",
+        "big-data",
+        "dask",
+        "ray",
+        "feature-engineering"
+      ],
+      "estimated_minutes": 30,
+      "learner_level": "data-scientist candidate",
+      "student_prompt": "A feature pipeline is slow and close to memory limits. Decide whether to optimize locally, use Dask, use Ray Data, or move to a heavier cluster path.",
+      "symptom": "A candidate proposes Spark immediately for a 60 GB CSV feature job without profiling, converting to Parquet, choosing partition sizes, or checking vectorized pandas and NumPy alternatives.",
+      "proposed_diagnosis": "Any dataset larger than memory should immediately move to a cluster framework.",
+      "root_cause": "The scaling diagnosis skips cheaper discriminators; the current pipeline needs profiling, columnar storage, partition and memory sizing, vectorized or compiled local baselines, then Dask for pandas-like out-of-core tabular work or Ray Data when the workload is an AI batch-inference or training ingest pipeline.",
+      "plain_repro": "Profile peak memory and wall time on one representative partition, convert the CSV sample to Parquet, and compare local vectorized pandas, Dask DataFrame, and Ray Data batch execution on the same feature contract.",
+      "weak_assumptions": [
+        "Big data is defined only by raw file size.",
+        "A cluster framework fixes inefficient algorithms and poor file formats.",
+        "Dask, Ray Data, and Spark have the same best use case."
+      ],
+      "evidence": [
+        {
+          "id": "no_profile_or_baseline",
+          "description": "No local baseline, memory profile, or algorithmic hotspot report is attached.",
+          "confidence": 0.9,
+          "relevance": 0.92
+        },
+        {
+          "id": "csv_io_bottleneck",
+          "description": "Most time is spent scanning wide CSV input that can be converted to columnar storage.",
+          "confidence": 0.86,
+          "relevance": 0.84
+        },
+        {
+          "id": "ai_batch_inference_stage",
+          "description": "The downstream stage performs GPU batch inference and needs streaming batches to keep accelerators busy.",
+          "confidence": 0.82,
+          "relevance": 0.8
+        }
+      ],
+      "candidate_fixes": [
+        {
+          "id": "profile_partition_then_select_engine",
+          "summary": "Create a measured baseline, convert to efficient columnar storage, size partitions, and choose Dask or Ray Data only when the measured workload matches their strengths.",
+          "expected_impact": 0.89,
+          "blast_radius": 0.28,
+          "reversibility": 0.86
+        },
+        {
+          "id": "rewrite_in_cluster_framework_first",
+          "summary": "Start by rewriting the pipeline in a cluster framework before profiling or changing storage format.",
+          "expected_impact": 0.42,
+          "blast_radius": 0.76,
+          "reversibility": 0.45
+        }
+      ],
+      "regression_tests": [
+        {
+          "id": "baseline_profile_artifact",
+          "description": "Require memory, I/O, and wall-time baseline artifacts before engine migration is accepted.",
+          "automated": true,
+          "discriminator": true
+        },
+        {
+          "id": "parquet_partition_smoke",
+          "description": "Verify the feature contract on a partitioned Parquet sample before distributed execution.",
+          "automated": true,
+          "discriminator": true
+        },
+        {
+          "id": "engine_choice_decision_record",
+          "description": "Require a decision row that states why local pandas, Dask, Ray Data, or Spark was selected.",
+          "automated": false,
+          "discriminator": true
+        }
+      ],
+      "student_answer": {
+        "diagnosis": "The framework choice is premature because the workload has not been profiled.",
+        "root_cause": "The scaling diagnosis skips cheaper discriminators; the current pipeline needs profiling, columnar storage, partition and memory sizing, vectorized or compiled local baselines, then Dask for pandas-like out-of-core tabular work or Ray Data when the workload is an AI batch-inference or training ingest pipeline.",
+        "evidence_ids": [
+          "no_profile_or_baseline",
+          "csv_io_bottleneck"
+        ],
+        "selected_fix_id": "profile_partition_then_select_engine",
+        "regression_test_ids": [
+          "baseline_profile_artifact",
+          "parquet_partition_smoke",
+          "engine_choice_decision_record"
+        ],
+        "confidence": 0.86
+      }
+    },
+    {
+      "case_id": "data_scientist_2026_genai_rag_governance",
+      "title": "Evaluate a RAG assistant with evidence and risk gates",
+      "difficulty": "advanced",
+      "topic_tags": [
+        "data-science-2026",
+        "genai",
+        "rag",
+        "evaluation",
+        "governance"
+      ],
+      "estimated_minutes": 40,
+      "learner_level": "data-scientist candidate",
+      "student_prompt": "A team wants to ship a RAG assistant after a good manual demo. Build the evidence-backed evaluation and risk plan expected from a current data-scientist interview.",
+      "symptom": "The proposed chatbot over internal documents has one happy-path demo, no retrieval goldens, no citation checks, no privacy tests, and no monitoring plan for groundedness or drift.",
+      "proposed_diagnosis": "The demo is convincing enough because the underlying foundation model is strong.",
+      "root_cause": "A 2026 data-scientist evaluation must treat GenAI as an evidence and risk-management workflow: retrieval quality, answer groundedness, citation coverage, refusal behavior, privacy redaction, prompt-injection resistance, and post-deployment drift need explicit tests before launch.",
+      "plain_repro": "Run a fixed RAG golden set with expected document ids, adversarial prompts, private-data probes, and stale-document cases; compare retrieved ids, cited spans, refusal decisions, and answer-groundedness scores.",
+      "weak_assumptions": [
+        "A strong base model removes the need for task-specific evaluation.",
+        "One demo can represent retrieval quality and safety behavior.",
+        "Privacy and prompt-injection failures are outside the data-scientist evaluation scope."
+      ],
+      "evidence": [
+        {
+          "id": "no_retrieval_goldens",
+          "description": "There is no dataset of questions mapped to expected documents or answer spans.",
+          "confidence": 0.93,
+          "relevance": 0.95
+        },
+        {
+          "id": "missing_groundedness_checks",
+          "description": "The report does not verify whether generated claims are supported by retrieved context.",
+          "confidence": 0.91,
+          "relevance": 0.94
+        },
+        {
+          "id": "privacy_prompt_injection_gap",
+          "description": "No tests cover private-data leakage, prompt injection, or unsafe refusal boundaries.",
+          "confidence": 0.89,
+          "relevance": 0.9
+        },
+        {
+          "id": "nist_genai_risk_profile",
+          "description": "Current AI risk guidance treats generative AI risks as requiring explicit governance actions.",
+          "confidence": 0.86,
+          "relevance": 0.84
+        }
+      ],
+      "candidate_fixes": [
+        {
+          "id": "add_rag_eval_and_risk_gates",
+          "summary": "Build a RAG evaluation set with retrieval, groundedness, citation, privacy, injection, refusal, and drift gates before release.",
+          "expected_impact": 0.94,
+          "blast_radius": 0.34,
+          "reversibility": 0.82
+        },
+        {
+          "id": "ship_demo_with_manual_review",
+          "summary": "Ship the assistant after a manual demo and rely on users to report poor answers.",
+          "expected_impact": 0.25,
+          "blast_radius": 0.7,
+          "reversibility": 0.5
+        }
+      ],
+      "regression_tests": [
+        {
+          "id": "rag_goldens_retrieval_recall",
+          "description": "Assert expected document ids appear in top-k retrieval for the golden set.",
+          "automated": true,
+          "discriminator": true
+        },
+        {
+          "id": "grounded_citation_check",
+          "description": "Assert answer claims cite retrieved spans and unsupported claims are rejected.",
+          "automated": true,
+          "discriminator": true
+        },
+        {
+          "id": "privacy_and_injection_suite",
+          "description": "Run private-data probes and prompt-injection cases against the assistant.",
+          "automated": true,
+          "discriminator": true
+        },
+        {
+          "id": "post_deploy_drift_monitor",
+          "description": "Record retrieval corpus version, model version, and live failure-rate drift thresholds.",
+          "automated": false,
+          "discriminator": true
+        }
+      ],
+      "student_answer": {
+        "diagnosis": "The demo is not enough because RAG quality and GenAI risk behavior are untested.",
+        "root_cause": "A 2026 data-scientist evaluation must treat GenAI as an evidence and risk-management workflow: retrieval quality, answer groundedness, citation coverage, refusal behavior, privacy redaction, prompt-injection resistance, and post-deployment drift need explicit tests before launch.",
+        "evidence_ids": [
+          "no_retrieval_goldens",
+          "missing_groundedness_checks",
+          "privacy_prompt_injection_gap"
+        ],
+        "selected_fix_id": "add_rag_eval_and_risk_gates",
+        "regression_test_ids": [
+          "rag_goldens_retrieval_recall",
+          "grounded_citation_check",
+          "privacy_and_injection_suite",
+          "post_deploy_drift_monitor"
+        ],
+        "confidence": 0.89
+      }
+    },
+    {
+      "case_id": "data_scientist_2026_inference_optimization",
+      "title": "Compress and deploy a neural model without losing the evidence trail",
+      "difficulty": "advanced",
+      "topic_tags": [
+        "data-science-2026",
+        "deep-learning",
+        "inference",
+        "quantization",
+        "deployment"
+      ],
+      "estimated_minutes": 35,
+      "learner_level": "data-scientist candidate",
+      "student_prompt": "A candidate suggests reducing neural-network size by changing float tensors to integers. Diagnose what is missing from the deployment-quality answer.",
+      "symptom": "The answer key lists dropout, pruning, quantification, and casting floats to integers as interchangeable ways to reduce inference cost, with no accuracy, latency, hardware, or calibration-data gates.",
+      "proposed_diagnosis": "The answer is acceptable because it names common compression techniques.",
+      "root_cause": "The answer confuses training regularization with deployment compression; a current answer should distinguish pruning, quantization-aware or post-training quantization, distillation, mixed precision, compilation, and runtime export, then prove accuracy and latency on the target hardware with representative calibration and holdout data.",
+      "plain_repro": "Benchmark the baseline model and each compressed candidate on the target runtime, recording model size, latency percentiles, throughput, memory, and accuracy deltas on calibration and holdout sets.",
+      "weak_assumptions": [
+        "Casting tensors to integers is equivalent to validated quantization.",
+        "Dropout is an inference-time compression method.",
+        "Model size reduction is safe without a target-runtime accuracy and latency gate."
+      ],
+      "evidence": [
+        {
+          "id": "compression_terms_mixed",
+          "description": "The answer key groups training regularization and deployment optimization as one technique family.",
+          "confidence": 0.91,
+          "relevance": 0.92
+        },
+        {
+          "id": "no_target_runtime_benchmark",
+          "description": "No CPU, GPU, or accelerator-specific latency and memory measurement is attached.",
+          "confidence": 0.9,
+          "relevance": 0.9
+        },
+        {
+          "id": "no_calibration_or_holdout_gate",
+          "description": "Quantization is proposed without representative calibration data or an accepted accuracy-delta threshold.",
+          "confidence": 0.88,
+          "relevance": 0.88
+        }
+      ],
+      "candidate_fixes": [
+        {
+          "id": "benchmark_compression_with_runtime_gates",
+          "summary": "Separate compression techniques, select the runtime path, and require calibration, holdout accuracy, latency, throughput, memory, and rollback gates.",
+          "expected_impact": 0.9,
+          "blast_radius": 0.31,
+          "reversibility": 0.83
+        },
+        {
+          "id": "cast_weights_to_int",
+          "summary": "Cast floating-point weights to integers and accept the smaller artifact if it loads.",
+          "expected_impact": 0.22,
+          "blast_radius": 0.72,
+          "reversibility": 0.38
+        }
+      ],
+      "regression_tests": [
+        {
+          "id": "accuracy_latency_gate",
+          "description": "Assert every compressed artifact meets an agreed accuracy delta and latency percentile gate.",
+          "automated": true,
+          "discriminator": true
+        },
+        {
+          "id": "calibration_dataset_recorded",
+          "description": "Assert the quantization report records calibration dataset identity and hash.",
+          "automated": true,
+          "discriminator": true
+        },
+        {
+          "id": "runtime_smoke_cpu_gpu",
+          "description": "Smoke-test the exported artifact on the declared CPU or GPU runtime before accepting it.",
+          "automated": true,
+          "discriminator": true
+        }
+      ],
+      "student_answer": {
+        "diagnosis": "The answer names real techniques but mixes them and lacks deployment evidence.",
+        "root_cause": "The answer confuses training regularization with deployment compression; a current answer should distinguish pruning, quantization-aware or post-training quantization, distillation, mixed precision, compilation, and runtime export, then prove accuracy and latency on the target hardware with representative calibration and holdout data.",
+        "evidence_ids": [
+          "compression_terms_mixed",
+          "no_target_runtime_benchmark",
+          "no_calibration_or_holdout_gate"
+        ],
+        "selected_fix_id": "benchmark_compression_with_runtime_gates",
+        "regression_test_ids": [
+          "accuracy_latency_gate",
+          "calibration_dataset_recorded",
+          "runtime_smoke_cpu_gpu"
+        ],
+        "confidence": 0.88
+      }
     }
   ]
 }

--- a/src/agilab/lib/agi-app-tescia-diagnostic/README.md
+++ b/src/agilab/lib/agi-app-tescia-diagnostic/README.md
@@ -23,6 +23,10 @@ learner response while `case_quality_score` keeps the reference exercise score.
 Bundled cases also carry a 2026 French mathematics-program coverage matrix at
 top-level domain granularity for the 2026-2027 rollout, with at least two
 exercises required per declared curriculum id.
+The bundled catalog now also includes a 2026 data-scientist interview
+evaluation inspired by a legacy QCM: modern Python/pandas practice,
+leakage-free model evaluation, scaling decisions, RAG governance, and
+inference optimization are scored with the same evidence-backed rubric.
 Classroom batches export anonymized teacher artifacts: progress, heatmap,
 needs-attention, per-student, curriculum-level, intervention-plan CSV files,
 and a printable teacher summary.
@@ -61,8 +65,10 @@ directory and set the file glob to that payload.
 The default input is a bundled JSON case file with exercise metadata. Optional
 local-AI generation requires a configured local endpoint and fails closed if the
 generated JSON does not match the expected schema. Student submissions can be
-added through a `student_answer` object in the case JSON. Mathematics cases can
-also include `curriculum_ids`; unknown ids are rejected by the coverage helper.
+added through a `student_answer` object in the case JSON. Data-scientist cases
+use topic tags such as `data-science-2026`, `pandas`, `model-evaluation`, `rag`,
+and `quantization`. Mathematics cases can also include `curriculum_ids`;
+unknown ids are rejected by the coverage helper.
 Classroom submission files contain `classroom` metadata plus a `submissions`
 list of `student_id`, `case_id`, and answer objects. Student ids are anonymized
 by default in teacher artifacts.
@@ -100,6 +106,11 @@ otherwise, and includes manual plus optional live refresh.
 Add one diagnostic case with a deliberately weak proposed fix and two candidate
 regression tests. The app should keep the stronger fix only when the evidence
 and tests support it.
+
+For data-scientist evaluation, filter the catalog to `data-scientist candidate`
+and change one answer selection. The score should fall when the answer keeps a
+stale pandas API, leaks test data, ships a RAG demo without goldens, or accepts
+model compression without a target-runtime accuracy and latency gate.
 
 For mathematics-program coverage, add or remove a `curriculum_ids` entry and
 run the focused TeSciA tests. Missing required ids, undercovered ids, and

--- a/test/test_tescia_diagnostic_project.py
+++ b/test/test_tescia_diagnostic_project.py
@@ -611,6 +611,52 @@ def test_tescia_diagnostic_selects_evidence_backed_fix(monkeypatch) -> None:
     assert "SSH login success proves the shared data path is usable." in report["weak_assumptions"]
 
 
+def test_tescia_data_scientist_2026_cases_are_scored_and_current(monkeypatch) -> None:
+    monkeypatch.syspath_prepend(str(APP_SRC))
+
+    from tescia_diagnostic import diagnose_case
+
+    cases = {
+        str(case["case_id"]): case
+        for case in _load_cases()
+        if str(case["case_id"]).startswith("data_scientist_2026_")
+    }
+
+    assert set(cases) == {
+        "data_scientist_2026_python_pandas_modernization",
+        "data_scientist_2026_model_evaluation_leakage",
+        "data_scientist_2026_scaling_feature_pipeline",
+        "data_scientist_2026_genai_rag_governance",
+        "data_scientist_2026_inference_optimization",
+    }
+    assert {case["learner_level"] for case in cases.values()} == {"data-scientist candidate"}
+    assert all("data-science-2026" in case["topic_tags"] for case in cases.values())
+    assert "pandas.concat" in cases["data_scientist_2026_python_pandas_modernization"]["root_cause"]
+    assert "merge_asof" in cases["data_scientist_2026_python_pandas_modernization"]["root_cause"]
+    assert "PR-AUC" in cases["data_scientist_2026_model_evaluation_leakage"]["root_cause"]
+    assert "Ray Data" in cases["data_scientist_2026_scaling_feature_pipeline"]["root_cause"]
+    assert "prompt-injection" in cases["data_scientist_2026_genai_rag_governance"]["root_cause"]
+    assert "quantization" in cases["data_scientist_2026_inference_optimization"]["root_cause"]
+
+    reports = {case_id: diagnose_case(case) for case_id, case in cases.items()}
+    assert reports["data_scientist_2026_python_pandas_modernization"]["selected_fix"]["id"] == (
+        "replace_legacy_python_pandas_items"
+    )
+    assert reports["data_scientist_2026_model_evaluation_leakage"]["selected_fix"]["id"] == (
+        "pipeline_cv_metric_threshold_gate"
+    )
+    assert reports["data_scientist_2026_scaling_feature_pipeline"]["selected_fix"]["id"] == (
+        "profile_partition_then_select_engine"
+    )
+    assert reports["data_scientist_2026_genai_rag_governance"]["selected_fix"]["id"] == (
+        "add_rag_eval_and_risk_gates"
+    )
+    assert reports["data_scientist_2026_inference_optimization"]["selected_fix"]["id"] == (
+        "benchmark_compression_with_runtime_gates"
+    )
+    assert all(report["self_evaluation"]["score_band"] == "excellent" for report in reports.values())
+
+
 def test_tescia_classroom_metadata_anonymizes_student_ids(monkeypatch) -> None:
     monkeypatch.syspath_prepend(str(APP_SRC))
 
@@ -886,11 +932,20 @@ def test_tescia_app_surface_catalog_answer_and_authoring_helpers(monkeypatch) ->
 
     assert any(row["case_id"] == "math_2026_seconde_gt_coverage" for row in rows)
     assert "seconde student" in filters["learner_level"]
+    assert "data-scientist candidate" in filters["learner_level"]
     assert "seconde_gt_fonctions" in filters["curriculum_id"]
     filtered = module.filter_cases(cases, curriculum_id="seconde_gt_fonctions")
     assert {case["case_id"] for case in filtered} == {
         "math_2026_seconde_gt_coverage",
         "math_2026_seconde_gt_practice_round",
+    }
+    data_scientist_cases = module.filter_cases(cases, learner_level="data-scientist candidate")
+    assert {case["case_id"] for case in data_scientist_cases} == {
+        "data_scientist_2026_python_pandas_modernization",
+        "data_scientist_2026_model_evaluation_leakage",
+        "data_scientist_2026_scaling_feature_pipeline",
+        "data_scientist_2026_genai_rag_governance",
+        "data_scientist_2026_inference_optimization",
     }
 
     answer = module.build_student_answer(


### PR DESCRIPTION
## Summary
- add five bundled Tescia data-scientist 2026 evaluation cases inspired by the legacy QCM format
- cover current Python/pandas practice, leakage-free model evaluation, scaling choices, RAG governance, and inference optimization
- document the new catalog scope in the app README, packaged app README, and public app catalog mirror
- add regression coverage for data-scientist case discovery, scoring, selected fixes, and catalog filtering

## Validation
- python3 -m json.tool src/agilab/apps/builtin/tescia_diagnostic_project/src/tescia_diagnostic/sample_data/tescia_diagnostic_cases.json
- git diff --check
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_tescia_diagnostic_project.py
- ./dev docs
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui
- ./dev app-contracts
- ./dev scope

Related docs-source PR: https://github.com/jpmorard/thales_agilab/pull/62