### PR TITLE
[codex] fix PyTorch playground audit cleanups

### DIFF
--- a/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/__init__.py
+++ b/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/__init__.py
@@ -39,7 +39,6 @@ __all__ = [
     "PYTORCH_PLAYGROUND_REDUCE_CONTRACT",
     "PytorchPlaygroundArgs",
     "PytorchPlaygroundArgsTD",
-    "PYTORCH_PLAYGROUND_REDUCE_CONTRACT",
     "dump_args",
     "ensure_defaults",
     "load_args",

--- a/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/compat/module_shim.py
+++ b/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/compat/module_shim.py
@@ -6,6 +6,7 @@ import importlib
 import importlib.util
 import runpy
 import sys
+from pathlib import Path
 from types import ModuleType
 
 _CLASSIFICATION_SEGMENTS = {"domain", "runtime", "ui"}
@@ -60,8 +61,9 @@ def _execute_target_in_current_module(current_name: str, target_name: str) -> Mo
     target_package = target_name.rpartition(".")[0]
     current_module.__dict__["__file__"] = spec.origin
     current_module.__dict__["__package__"] = target_package
+    source_text = Path(spec.origin).read_text(encoding="utf-8")
     source = compile(
-        open(spec.origin, encoding="utf-8").read(),
+        source_text,
         spec.origin,
         "exec",
     )

--- a/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/domain/core.py
+++ b/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/domain/core.py
@@ -27,7 +27,7 @@ try:
         ACTIVATIONS,
         DATASETS,
         DEFAULT_FEATURES,
-        FEATURES,
+        FEATURES,  # noqa: F401 - re-exported through the legacy pytorch_playground.core shim.
         OPTIMIZERS,
         REGULARIZATIONS,
         coerce_feature_names as _coerce_feature_names,
@@ -37,7 +37,7 @@ except ImportError:  # pragma: no cover - direct script execution fallback
         ACTIVATIONS,
         DATASETS,
         DEFAULT_FEATURES,
-        FEATURES,
+        FEATURES,  # noqa: F401 - re-exported through the legacy pytorch_playground.core shim.
         OPTIMIZERS,
         REGULARIZATIONS,
         coerce_feature_names as _coerce_feature_names,
@@ -1086,6 +1086,8 @@ def _loss_landscape(config: PlaygroundConfig, *, resolution: int = 21, span: flo
 
     try:
         model.eval()
+        # The landscape is intentionally a cross-entropy surface around the trained weights.
+        # L2 effects are already in the optimizer path; L1 is not re-added here.
         with torch.no_grad():
             for alpha in axis:
                 for beta in axis:

--- a/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/ui/playground_ui.py
+++ b/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/ui/playground_ui.py
@@ -288,6 +288,7 @@ _DATAFRAME_IPC_TYPE = "agilab.pytorch_playground.dataframe.v1"
 
 
 def _ipc_encode(value):
+    # Keep this fresh-interpreter encoder aligned with the module-level encoder below.
     if isinstance(value, pd.DataFrame):
         return {
             "__type__": _DATAFRAME_IPC_TYPE,
@@ -451,8 +452,11 @@ def _training_error_result(config: PlaygroundConfig, detail: str) -> dict[str, A
         "samples": samples,
         "history": pd.DataFrame(columns=["epoch", "train_loss", "validation_loss", "train_accuracy", "validation_accuracy"]),
         "grid": pd.DataFrame(columns=["x1", "x2", "probability"]),
+        "boundary_snapshots": _empty_boundary_snapshots(),
         "network_layers": _empty_network_layers(),
         "activation_maps": _empty_activation_maps(),
+        "loss_landscape": _empty_loss_landscape(),
+        "landscape_summary": _loss_landscape_summary(_empty_loss_landscape()),
         "summary": {
             "backend": "error",
             "samples": int(len(samples)),

--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground/__init__.py
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground/__init__.py
@@ -39,7 +39,6 @@ __all__ = [
     "PYTORCH_PLAYGROUND_REDUCE_CONTRACT",
     "PytorchPlaygroundArgs",
     "PytorchPlaygroundArgsTD",
-    "PYTORCH_PLAYGROUND_REDUCE_CONTRACT",
     "dump_args",
     "ensure_defaults",
     "load_args",

--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground/compat/module_shim.py
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground/compat/module_shim.py
@@ -6,6 +6,7 @@ import importlib
 import importlib.util
 import runpy
 import sys
+from pathlib import Path
 from types import ModuleType
 
 _CLASSIFICATION_SEGMENTS = {"domain", "runtime", "ui"}
@@ -60,8 +61,9 @@ def _execute_target_in_current_module(current_name: str, target_name: str) -> Mo
     target_package = target_name.rpartition(".")[0]
     current_module.__dict__["__file__"] = spec.origin
     current_module.__dict__["__package__"] = target_package
+    source_text = Path(spec.origin).read_text(encoding="utf-8")
     source = compile(
-        open(spec.origin, encoding="utf-8").read(),
+        source_text,
         spec.origin,
         "exec",
     )

--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground/domain/core.py
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground/domain/core.py
@@ -27,7 +27,7 @@ try:
         ACTIVATIONS,
         DATASETS,
         DEFAULT_FEATURES,
-        FEATURES,
+        FEATURES,  # noqa: F401 - re-exported through the legacy pytorch_playground.core shim.
         OPTIMIZERS,
         REGULARIZATIONS,
         coerce_feature_names as _coerce_feature_names,
@@ -37,7 +37,7 @@ except ImportError:  # pragma: no cover - direct script execution fallback
         ACTIVATIONS,
         DATASETS,
         DEFAULT_FEATURES,
-        FEATURES,
+        FEATURES,  # noqa: F401 - re-exported through the legacy pytorch_playground.core shim.
         OPTIMIZERS,
         REGULARIZATIONS,
         coerce_feature_names as _coerce_feature_names,
@@ -1086,6 +1086,8 @@ def _loss_landscape(config: PlaygroundConfig, *, resolution: int = 21, span: flo
 
     try:
         model.eval()
+        # The landscape is intentionally a cross-entropy surface around the trained weights.
+        # L2 effects are already in the optimizer path; L1 is not re-added here.
         with torch.no_grad():
             for alpha in axis:
                 for beta in axis:

--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground/ui/playground_ui.py
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground/ui/playground_ui.py
@@ -288,6 +288,7 @@ _DATAFRAME_IPC_TYPE = "agilab.pytorch_playground.dataframe.v1"
 
 
 def _ipc_encode(value):
+    # Keep this fresh-interpreter encoder aligned with the module-level encoder below.
     if isinstance(value, pd.DataFrame):
         return {
             "__type__": _DATAFRAME_IPC_TYPE,
@@ -451,8 +452,11 @@ def _training_error_result(config: PlaygroundConfig, detail: str) -> dict[str, A
         "samples": samples,
         "history": pd.DataFrame(columns=["epoch", "train_loss", "validation_loss", "train_accuracy", "validation_accuracy"]),
         "grid": pd.DataFrame(columns=["x1", "x2", "probability"]),
+        "boundary_snapshots": _empty_boundary_snapshots(),
         "network_layers": _empty_network_layers(),
         "activation_maps": _empty_activation_maps(),
+        "loss_landscape": _empty_loss_landscape(),
+        "landscape_summary": _loss_landscape_summary(_empty_loss_landscape()),
         "summary": {
             "backend": "error",
             "samples": int(len(samples)),

--- a/test/test_pytorch_playground_app.py
+++ b/test/test_pytorch_playground_app.py
@@ -135,6 +135,36 @@ def test_pytorch_playground_modules_are_classified_or_entrypoints():
         _assert_pytorch_legacy_module_identity(package_root.parent, legacy_modules)
 
 
+def test_pytorch_playground_public_exports_are_unique() -> None:
+    for init_path in (
+        PROJECT_SRC / "pytorch_playground" / "__init__.py",
+        PACKAGE_PROJECT_PATH / "src" / "pytorch_playground" / "__init__.py",
+    ):
+        tree = ast.parse(init_path.read_text(encoding="utf-8"))
+        all_values = [
+            ast.literal_eval(node.value)
+            for node in tree.body
+            if (
+                isinstance(node, ast.Assign)
+                and any(isinstance(target, ast.Name) and target.id == "__all__" for target in node.targets)
+            )
+        ]
+        assert len(all_values) == 1
+        public_exports = all_values[0]
+        assert len(public_exports) == len(set(public_exports))
+        assert "PYTORCH_PLAYGROUND_REDUCE_CONTRACT" in public_exports
+
+
+def test_pytorch_playground_compat_shim_uses_explicit_source_read() -> None:
+    for shim_path in (
+        PROJECT_SRC / "pytorch_playground" / "compat" / "module_shim.py",
+        PACKAGE_PROJECT_PATH / "src" / "pytorch_playground" / "compat" / "module_shim.py",
+    ):
+        source = shim_path.read_text(encoding="utf-8")
+        assert "Path(spec.origin).read_text" in source
+        assert "open(spec.origin" not in source
+
+
 def test_playground_ui_import_prefers_package_when_streamlit_puts_script_dir_first(monkeypatch):
     script_dir = MODULE_PATH.resolve().parent
     project_src = PROJECT_SRC.resolve()
@@ -1384,6 +1414,24 @@ def test_isolated_runner_failure_paths_return_displayable_error_results(monkeypa
     invalid_json = module._run_core_in_subprocess("train", config)
     assert invalid_json["status"] == "error"
     assert "JSONDecodeError" in invalid_json["detail"]
+
+
+def test_training_error_result_matches_train_result_artifact_shape() -> None:
+    module = _load_module()
+    config = module.PlaygroundConfig(sample_count=18, epochs=1, grid_size=6)
+
+    result = module._training_error_result(config, "boom")
+
+    assert result["status"] == "error"
+    assert result["detail"] == "boom"
+    assert result["samples"].shape[0] == 18
+    assert result["history"].empty
+    assert result["grid"].empty
+    assert result["boundary_snapshots"].equals(module._empty_boundary_snapshots())
+    assert result["network_layers"].equals(module._empty_network_layers())
+    assert result["activation_maps"].equals(module._empty_activation_maps())
+    assert result["loss_landscape"].equals(module._empty_loss_landscape())
+    assert result["landscape_summary"] == module._loss_landscape_summary(module._empty_loss_landscape())
 
 
 def test_isolated_runner_ipc_uses_json_without_pickle() -> None:


### PR DESCRIPTION
## Summary
- Close the compat shim source-read path by using Path.read_text instead of a bare open().read()
- Keep PyTorch playground error results aligned with train/evidence result shape
- Remove the duplicate public export, document intentional IPC encoder duplication and CE-only loss-landscape behavior, and keep the packaged app payload synchronized
- Add regressions for shim source reads, unique public exports, and training-error artifact shape

## Validation
- uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files <changed files>
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_pytorch_playground_app.py
- uv --preview-features extra-build-dependencies run --extra dev ruff check <changed files>
- ./dev app-contracts
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui
- git diff --check
- ./dev scope