### PR TITLE
[codex] use core PyTorch playground config validation

### DIFF
--- a/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/ui/playground_ui.py
+++ b/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground/ui/playground_ui.py
@@ -407,26 +407,6 @@ def _ipc_decode(value: Any) -> Any:
     return value
 
 
-def _config_from_cache_payload(payload: Mapping[str, Any]) -> PlaygroundConfig:
-    return PlaygroundConfig(
-        dataset=str(payload["dataset"]),
-        sample_count=int(payload["sample_count"]),
-        noise=float(payload["noise"]),
-        train_ratio=float(payload["train_ratio"]),
-        hidden_layers=tuple(int(value) for value in payload["hidden_layers"]),
-        activation=str(payload["activation"]),
-        optimizer=str(payload["optimizer"]),
-        regularization=str(payload.get("regularization", "None")),
-        regularization_rate=float(payload.get("regularization_rate", 0.0)),
-        learning_rate=float(payload["learning_rate"]),
-        epochs=int(payload["epochs"]),
-        batch_size=int(payload["batch_size"]),
-        seed=int(payload["seed"]),
-        feature_names=tuple(str(value) for value in payload["feature_names"]),
-        grid_size=int(payload["grid_size"]),
-    )
-
-
 def _streamlit_script_context_active() -> bool:
     try:
         from streamlit.runtime.scriptrunner import get_script_run_ctx
@@ -670,7 +650,7 @@ def _request_live_rerun(delay_seconds: float) -> None:
 
 @st.cache_data(show_spinner=False)
 def _cached_train(payload: dict[str, Any]) -> dict[str, Any]:
-    config = _config_from_cache_payload(payload)
+    config = _config_from_payload(payload)
     if _use_isolated_torch_training():
         return _run_core_in_subprocess("train", config)
     return _train_playground(config)
@@ -678,7 +658,7 @@ def _cached_train(payload: dict[str, Any]) -> dict[str, Any]:
 
 @st.cache_data(show_spinner=False)
 def _cached_loss_landscape(payload: dict[str, Any], resolution: int, span: float) -> dict[str, Any]:
-    config = _config_from_cache_payload(payload)
+    config = _config_from_payload(payload)
     if _use_isolated_torch_training():
         return _run_core_in_subprocess("loss_landscape", config, resolution=resolution, span=span)
     return _loss_landscape(config, resolution=resolution, span=span)

--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground/ui/playground_ui.py
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground/ui/playground_ui.py
@@ -407,26 +407,6 @@ def _ipc_decode(value: Any) -> Any:
     return value
 
 
-def _config_from_cache_payload(payload: Mapping[str, Any]) -> PlaygroundConfig:
-    return PlaygroundConfig(
-        dataset=str(payload["dataset"]),
-        sample_count=int(payload["sample_count"]),
-        noise=float(payload["noise"]),
-        train_ratio=float(payload["train_ratio"]),
-        hidden_layers=tuple(int(value) for value in payload["hidden_layers"]),
-        activation=str(payload["activation"]),
-        optimizer=str(payload["optimizer"]),
-        regularization=str(payload.get("regularization", "None")),
-        regularization_rate=float(payload.get("regularization_rate", 0.0)),
-        learning_rate=float(payload["learning_rate"]),
-        epochs=int(payload["epochs"]),
-        batch_size=int(payload["batch_size"]),
-        seed=int(payload["seed"]),
-        feature_names=tuple(str(value) for value in payload["feature_names"]),
-        grid_size=int(payload["grid_size"]),
-    )
-
-
 def _streamlit_script_context_active() -> bool:
     try:
         from streamlit.runtime.scriptrunner import get_script_run_ctx
@@ -670,7 +650,7 @@ def _request_live_rerun(delay_seconds: float) -> None:
 
 @st.cache_data(show_spinner=False)
 def _cached_train(payload: dict[str, Any]) -> dict[str, Any]:
-    config = _config_from_cache_payload(payload)
+    config = _config_from_payload(payload)
     if _use_isolated_torch_training():
         return _run_core_in_subprocess("train", config)
     return _train_playground(config)
@@ -678,7 +658,7 @@ def _cached_train(payload: dict[str, Any]) -> dict[str, Any]:
 
 @st.cache_data(show_spinner=False)
 def _cached_loss_landscape(payload: dict[str, Any], resolution: int, span: float) -> dict[str, Any]:
-    config = _config_from_cache_payload(payload)
+    config = _config_from_payload(payload)
     if _use_isolated_torch_training():
         return _run_core_in_subprocess("loss_landscape", config, resolution=resolution, span=span)
     return _loss_landscape(config, resolution=resolution, span=span)

--- a/test/test_pytorch_playground_app.py
+++ b/test/test_pytorch_playground_app.py
@@ -1468,6 +1468,65 @@ def test_cached_train_and_loss_landscape_route_to_isolated_runner(monkeypatch: p
     assert calls == [("train", None, None), ("loss_landscape", 7, 0.3)]
 
 
+def test_cached_train_and_landscape_reuse_core_config_validation(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_module()
+    captured: list[tuple[str, object]] = []
+    polluted_payload = {
+        "dataset": "unknown",
+        "sample_count": 5000,
+        "noise": 9.0,
+        "train_ratio": 0.1,
+        "hidden_layers": ["not-an-int"],
+        "activation": "unknown",
+        "optimizer": "unknown",
+        "regularization": "unknown",
+        "regularization_rate": 9.0,
+        "learning_rate": 9.0,
+        "epochs": -1,
+        "batch_size": 9999,
+        "seed": 999999,
+        "feature_names": ["x1", "unknown"],
+        "grid_size": 1,
+    }
+
+    def fake_train(config):
+        captured.append(("train", config))
+        return {"status": "ok", "summary": {"backend": "fake"}}
+
+    def fake_landscape(config, *, resolution, span):
+        captured.append(("loss_landscape", config))
+        return {"status": "ok", "loss_landscape": pd.DataFrame(), "landscape_summary": {"points": 0}}
+
+    for cached_func in (module._cached_train, module._cached_loss_landscape):
+        clear = getattr(cached_func, "clear", None)
+        if callable(clear):
+            clear()
+    monkeypatch.setattr(module, "_use_isolated_torch_training", lambda: False)
+    monkeypatch.setattr(module, "_train_playground", fake_train)
+    monkeypatch.setattr(module, "_loss_landscape", fake_landscape)
+
+    assert module._cached_train(dict(polluted_payload))["status"] == "ok"
+    assert module._cached_loss_landscape(dict(polluted_payload), resolution=7, span=0.3)["status"] == "ok"
+
+    assert [action for action, _config in captured] == ["train", "loss_landscape"]
+    for _action, config in captured:
+        assert config.dataset == module.PlaygroundConfig().dataset
+        assert config.sample_count == 1000
+        assert config.noise == 0.5
+        assert config.train_ratio == 0.5
+        assert config.hidden_layers == module.PlaygroundConfig().hidden_layers
+        assert config.activation == module.PlaygroundConfig().activation
+        assert config.optimizer == module.PlaygroundConfig().optimizer
+        assert config.regularization == module.PlaygroundConfig().regularization
+        assert config.regularization_rate == 1.0
+        assert config.learning_rate == 0.2
+        assert config.epochs == 10
+        assert config.batch_size == 256
+        assert config.seed == 9999
+        assert config.feature_names == ("x1",)
+        assert config.grid_size == 12
+
+
 def test_playground_ui_helper_error_and_display_edges(monkeypatch: pytest.MonkeyPatch) -> None:
     module = _load_module()
     fake_st = SimpleNamespace(session_state={module.TRAINED_CONFIG_STATE_KEY: "bad payload"})

--- a/test/test_workflow_parity.py
+++ b/test/test_workflow_parity.py
@@ -267,6 +267,7 @@ def test_profile_commands_cover_expected_coverage_and_docs_contracts() -> None:
     assert "test-results/coverage-agi-gui-support.manifest.json" in " ".join(agi_gui_commands[0].argv)
     agi_gui_combine_argv = " ".join(agi_gui_combine.argv)
     assert "'coverage', 'combine'" in agi_gui_combine_argv
+    assert "--data-file=.coverage.agi-gui" in agi_gui_combine_argv
     assert "--keep" in agi_gui_combine_argv
     assert agi_gui_combine.env["COVERAGE_FILE"] == ".coverage.agi-gui"
     assert module.AGI_GUI_COVERAGE_MANIFEST_WAIT_SECONDS >= 90.0
@@ -710,10 +711,12 @@ def test_agi_gui_coverage_combine_recovers_missing_success_manifest(tmp_path, mo
         assert exc.code == 0
 
     assert combined_commands
+    combine_args = combined_commands[0]
+    assert "--data-file=.coverage.agi-gui" in combine_args
     assert any(
         "coverage-agi-gui-combine-inputs" in arg
         and "coverage-agi-gui-pipeline.db.fragment" in arg
-        for arg in combined_commands[0]
+        for arg in combine_args
     )
 
 

--- a/tools/workflow_parity.py
+++ b/tools/workflow_parity.py
@@ -754,7 +754,7 @@ def _agi_gui_coverage_combine_code() -> str:
         "    target = combine_input_dir / f'{index:03d}-{source.name}'\n"
         "    shutil.copy2(source, target)\n"
         "    combine_paths.append(target.as_posix())\n"
-        "cmd = [sys.executable, '-m', 'coverage', 'combine', '--keep', *combine_paths]\n"
+        "cmd = [sys.executable, '-m', 'coverage', 'combine', '--data-file=.coverage.agi-gui', '--keep', *combine_paths]\n"
         "sys.exit(subprocess.run(cmd, check=False).returncode)\n"
     )
 


### PR DESCRIPTION
## Summary
- route cached PyTorch playground train/landscape payloads through the core config validator
- add a polluted-cache regression for clamping/default behavior
- make agi-gui coverage combine write the same .coverage.agi-gui database consumed by XML generation

## Validation
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_pytorch_playground_app.py test/test_workflow_parity.py
- ./dev app-contracts
- uv --preview-features extra-build-dependencies run --extra dev ruff check tools/workflow_parity.py test/test_workflow_parity.py
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui