### PR TITLE
[codex] Prepare AGILAB 2026.06.05 release readiness

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 252,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "ccdf2f3949d8ab05f56c577d03e997c61d6673baa13e52168058dd703c86970d",
+  "source_digest_sha256": "ff76eedbd5c1a49b4213ec0abb7a5f5313f0e787a1685b4c39218bb93419732c",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "ccdf2f3949d8ab05f56c577d03e997c61d6673baa13e52168058dd703c86970d"
+  "target_digest_sha256": "ff76eedbd5c1a49b4213ec0abb7a5f5313f0e787a1685b4c39218bb93419732c"
 }

--- a/docs/source/agent-workflows.rst
+++ b/docs/source/agent-workflows.rst
@@ -110,6 +110,33 @@ Validate the rules with::
 
    python3 tools/agent_context_router.py --check
 
+Demo an agentic workflow
+------------------------
+
+For a live demo, run the provider-neutral helper from the repository root::
+
+   tools/demo_agentic_agilab_workflow.sh --agent codex
+
+The demo is local-first. It does not need to call a hosted LLM to prove the
+workflow. It shows an agentic coding use case where an agent captures the repo
+scope, routes the task through AGILAB's context router, computes the
+impact-validation plan, records the validation as an ``agilab.agent_run.v1``
+evidence manifest, then renders handoff, next-action, validation, and context
+cards that another agent can consume.
+
+Use a custom prompt or another agent label when presenting another path::
+
+   tools/demo_agentic_agilab_workflow.sh \
+      --agent claude \
+      --prompt "review the current app changes and route the proof"
+
+Generated evidence is written under
+``artifacts/demo_media/agentic-workflow/evidence/``, which is ignored by Git.
+The command uses staged, unstaged, and untracked working-tree changes when
+there are local changes; if the tree is clean, it falls back to the diff
+against ``origin/main`` for impact validation and uses the agent workflow docs
+as the context-routing example.
+
 Agent run evidence
 ------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.04.2"
+version = "2026.06.05"
 name = "agilab"
 description = "AGILAB is a reproducible AI/ML workbench for engineering teams."
 requires-python = ">=3.11,<3.14"
@@ -60,13 +60,13 @@ agilab-mcp = "agilab_mcp.server:main"
 
 [project.optional-dependencies]
 ai = ["openai>=2.32.0,<3"]
-core = ["agi-core==2026.06.04"]
-ui = ["agi-apps==2026.06.04", "agi-pages==2026.06.04", "agi-gui==2026.06.04", "agi-web==2026.06.01", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "streamlit>=1.58,<2", "starlette>=1.0.1,<2", "tomli_w>=1.2.0,<2"]
+core = ["agi-core==2026.06.05"]
+ui = ["agi-apps==2026.06.05", "agi-pages==2026.06.04", "agi-gui==2026.06.04", "agi-web==2026.06.01", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "streamlit>=1.58,<2", "starlette>=1.0.1,<2", "tomli_w>=1.2.0,<2"]
 viz = ["matplotlib>=3.10.0,<4", "plotly>=6.7.0,<7"]
 mlflow = ["mlflow>=3.11.1,<4", "idna>=3.15,<4", "starlette>=1.0.1,<2"]
 bridges = ["duckdb>=1.4.0,<2"]
 notebook = ["ipykernel>=6.29.0,<8", "nbclient>=0.10.0,<1", "nbformat>=5.10.0,<6"]
-examples = ["agi-apps==2026.06.04", "jupyterlab>=4.4.0,<5", "matplotlib>=3.10.0,<4", "plotly>=6.7.0,<7", "starlette>=1.0.1,<2"]
+examples = ["agi-apps==2026.06.05", "jupyterlab>=4.4.0,<5", "matplotlib>=3.10.0,<4", "plotly>=6.7.0,<7", "starlette>=1.0.1,<2"]
 pages = ["agi-pages==2026.06.04", "starlette>=1.0.1,<2"]
 proof = ["cryptography>=46.0.0,<49"]
 agents = ["openai>=2.32.0,<3"]

--- a/src/agilab/core/agi-cluster/pyproject.toml
+++ b/src/agilab/core/agi-cluster/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.04"
+version = "2026.06.05"
 name = "agi-cluster"
 description = "Distributed cluster orchestration layer for AGILAB workers over local and SSH backends"
 requires-python = ">=3.11"

--- a/src/agilab/core/agi-core/pyproject.toml
+++ b/src/agilab/core/agi-core/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.04"
+version = "2026.06.05"
 name = "agi-core"
 description = "Meta-package that installs and wires agi-env, agi-node, and agi-cluster together"
 readme = "README.md"
@@ -30,7 +30,7 @@ keywords = [
   "distributed-computing",
   "distributed-execution",
 ]
-dependencies = ["agi-env==2026.06.04", "agi-node==2026.06.04", "agi-cluster==2026.06.04"]
+dependencies = ["agi-env==2026.06.04", "agi-node==2026.06.04", "agi-cluster==2026.06.05"]
 
 [project.entry-points."agi_env.runtime_packages"]
 agi-core = "agi_core.agi_env_runtime:RUNTIME_PACKAGE_SPEC"

--- a/src/agilab/lib/agi-app-pytorch-playground/pyproject.toml
+++ b/src/agilab/lib/agi-app-pytorch-playground/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.04"
+version = "2026.06.05"
 name = "agi-app-pytorch-playground"
 description = "AGILAB PyTorch playground app for reproducible neural-network experiments"
 requires-python = ">=3.12"

--- a/src/agilab/lib/agi-app-tescia-diagnostic/pyproject.toml
+++ b/src/agilab/lib/agi-app-tescia-diagnostic/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.04"
+version = "2026.06.05"
 name = "agi-app-tescia-diagnostic"
 description = "AGILAB TeSciA-style diagnostic workflow with evidence scoring and regression-plan artifacts"
 requires-python = ">=3.13"

--- a/src/agilab/lib/agi-apps/pyproject.toml
+++ b/src/agilab/lib/agi-apps/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.04"
+version = "2026.06.05"
 name = "agi-apps"
 description = "AGILAB public app package umbrella and example assets"
 requires-python = ">=3.11"
@@ -31,7 +31,7 @@ keywords = [
     "workflow-orchestration",
 ]
 
-dependencies = ["agi-core==2026.06.04", "agi-app-mission-decision==2026.06.04", "agi-app-pandas-execution==2026.06.04", "agi-app-polars-execution==2026.06.04", "agi-app-flight-telemetry==2026.06.04", "agi-app-multi-dag==2026.06.04", "agi-app-weather-forecast==2026.06.04", "agi-app-sklearn-pipeline==2026.06.04", "agi-app-pytorch-playground==2026.06.04; python_version >= '3.12'", "agi-app-tescia-diagnostic==2026.06.04; python_version >= '3.13'", "agi-app-uav-relay-queue==2026.06.04; python_version >= '3.13'"]
+dependencies = ["agi-core==2026.06.05", "agi-app-mission-decision==2026.06.04", "agi-app-pandas-execution==2026.06.04", "agi-app-polars-execution==2026.06.04", "agi-app-flight-telemetry==2026.06.04", "agi-app-multi-dag==2026.06.04", "agi-app-weather-forecast==2026.06.04", "agi-app-sklearn-pipeline==2026.06.04", "agi-app-pytorch-playground==2026.06.05; python_version >= '3.12'", "agi-app-tescia-diagnostic==2026.06.05; python_version >= '3.13'", "agi-app-uav-relay-queue==2026.06.04; python_version >= '3.13'"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/test/test_agent_workflows.py
+++ b/test/test_agent_workflows.py
@@ -58,12 +58,14 @@ def test_agent_workflow_wrappers_are_shell_valid_and_reference_repo_defaults() -
     aider = REPO_ROOT / "tools" / "aider_workflow.sh"
     opencode = REPO_ROOT / "tools" / "opencode_workflow.sh"
     vibe = REPO_ROOT / "tools" / "vibe_workflow.sh"
+    demo = REPO_ROOT / "tools" / "demo_agentic_agilab_workflow.sh"
 
-    subprocess.run(["bash", "-n", str(aider), str(opencode), str(vibe)], check=True)
+    subprocess.run(["bash", "-n", str(aider), str(opencode), str(vibe), str(demo)], check=True)
 
     aider_text = aider.read_text(encoding="utf-8")
     opencode_text = opencode.read_text(encoding="utf-8")
     vibe_text = vibe.read_text(encoding="utf-8")
+    demo_text = demo.read_text(encoding="utf-8")
 
     assert ".aider.conf.yml" in aider_text
     assert "AGILAB_AIDER_MODEL" in aider_text
@@ -77,6 +79,11 @@ def test_agent_workflow_wrappers_are_shell_valid_and_reference_repo_defaults() -
     assert "AGILAB_VIBE_COMMAND" in vibe_text
     assert 'vibe "<prompt>"' in vibe_text
     assert "log/vibe" in vibe_text
+
+    assert "agent_context_router.py" in demo_text
+    assert "impact_validate.py" in demo_text
+    assert "agilab agent-run" in demo_text
+    assert "agentic-workflow" in demo_text
 
 
 def test_agent_run_evidence_command_is_documented() -> None:
@@ -99,6 +106,12 @@ def test_agent_run_evidence_command_is_documented() -> None:
     assert "agent_events.ndjson" in agent_workflows
     assert "permission tiers" in agent_workflows
     assert "agilab.agent_run.trace_agent_run()" in readme
+
+    for text in (agent_workflows, public_docs):
+        assert "tools/demo_agentic_agilab_workflow.sh --agent codex" in text
+        assert "artifacts/demo_media/agentic-workflow/evidence/" in text
+        normalized = re.sub(r"\s+", " ", text)
+        assert "handoff, next-action, validation, and context cards" in normalized
 
 
 def test_agent_skill_badges_catalog_and_resource_preflight_are_documented() -> None:

--- a/tools/agent_workflows.md
+++ b/tools/agent_workflows.md
@@ -90,6 +90,37 @@ Validate the rule file with:
 python tools/agent_context_router.py --check
 ```
 
+## Demo an agentic workflow
+
+For a live demo, run the provider-neutral AGILAB workflow helper from the
+repository root:
+
+```bash
+tools/demo_agentic_agilab_workflow.sh --agent codex
+```
+
+The demo is intentionally local-first. It does not need to call a hosted LLM to
+prove the workflow. It shows an agentic coding use case where an agent first
+captures the repo scope, routes the task through AGILAB's context router,
+computes the impact-validation plan, records the validation as an
+`agilab.agent_run.v1` evidence manifest, then renders handoff, next-action,
+validation, and context cards that another agent can consume.
+
+Use a custom prompt or agent label when presenting another path:
+
+```bash
+tools/demo_agentic_agilab_workflow.sh \
+  --agent claude \
+  --prompt "review the current app changes and route the proof"
+```
+
+Generated evidence is written under
+`artifacts/demo_media/agentic-workflow/evidence/`, which is ignored by Git.
+The command uses staged, unstaged, and untracked working-tree changes when
+there are local changes; if the tree is clean, it falls back to the diff
+against `origin/main` for impact validation and uses the agent workflow docs as
+the context-routing example.
+
 ## Skill quality and security scans
 
 Changed repo-managed skills are scanned locally. Run the local check before

--- a/tools/demo_agentic_agilab_workflow.sh
+++ b/tools/demo_agentic_agilab_workflow.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  cat <<'EOF'
+Usage:
+  tools/demo_agentic_agilab_workflow.sh [--agent codex] [--prompt TEXT] [--base origin/main]
+  tools/demo_agentic_agilab_workflow.sh [--output-root DIR] [--dry-run] [--include-command-args]
+
+What it demonstrates:
+  1. Tokki/repo session preflight.
+  2. AGILAB context routing for the task and changed files.
+  3. AGILAB impact validation for the same changed files.
+  4. A traced agilab agent-run evidence manifest.
+  5. Handoff, next-action, validation, and context cards for another agent.
+
+The generated evidence is written under artifacts/demo_media/agentic-workflow/evidence/
+by default, which is ignored by Git.
+EOF
+  exit 0
+fi
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+AGENT="codex"
+BASE="origin/main"
+PROMPT="demo an agentic AGILAB workflow for the current changed files"
+OUTPUT_ROOT="$ROOT/artifacts/demo_media/agentic-workflow/evidence"
+DRY_RUN="0"
+INCLUDE_COMMAND_ARGS="0"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --agent)
+      AGENT="$2"
+      shift 2
+      ;;
+    --prompt)
+      PROMPT="$2"
+      shift 2
+      ;;
+    --base)
+      BASE="$2"
+      shift 2
+      ;;
+    --output-root)
+      OUTPUT_ROOT="$2"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN="1"
+      shift
+      ;;
+    --include-command-args)
+      INCLUDE_COMMAND_ARGS="1"
+      shift
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+UV=(uv --preview-features extra-build-dependencies run)
+PY=("${UV[@]}" python)
+AGILAB=("${UV[@]}" agilab)
+
+CHANGED_FILES=()
+while IFS= read -r path; do
+  if [[ -n "$path" ]]; then
+    CHANGED_FILES+=("$path")
+  fi
+done < <(
+  {
+    git diff --name-only
+    git diff --cached --name-only
+    git ls-files --others --exclude-standard
+  } | sort -u
+)
+
+ROUTER_FILES=()
+IMPACT_ARGS=()
+if [[ ${#CHANGED_FILES[@]} -gt 0 ]]; then
+  ROUTER_FILES=("${CHANGED_FILES[@]}")
+  IMPACT_ARGS=(--files "${CHANGED_FILES[@]}")
+else
+  ROUTER_FILES=(tools/agent_workflows.md docs/source/agent-workflows.rst)
+  IMPACT_ARGS=(--base "$BASE")
+fi
+
+STAMP="$(date +%Y%m%d-%H%M%S)"
+BRANCH="$(git branch --show-current 2>/dev/null || true)"
+if [[ -z "$BRANCH" ]]; then
+  BRANCH="detached"
+fi
+RUN_ID="agentic-agilab-workflow-${STAMP}"
+RUN_DIR="$OUTPUT_ROOT/$RUN_ID"
+mkdir -p "$RUN_DIR"
+
+echo "== 1. Tokki session preflight =="
+if command -v tokki-gate >/dev/null 2>&1; then
+  tokki-gate session-start || true
+else
+  echo "tokki-gate not found; continuing with AGILAB-native routing."
+fi
+
+echo
+echo "== 2. AGILAB worktree scope =="
+if [[ -x ./dev ]]; then
+  ./dev scope || true
+else
+  git status --short --branch
+fi
+
+echo
+echo "== 3. Context router =="
+"${PY[@]}" tools/agent_context_router.py \
+  --files "${ROUTER_FILES[@]}" \
+  --prompt "$PROMPT" \
+  --json | tee "$RUN_DIR/context_router.json"
+
+echo
+echo "== 4. Impact validation =="
+"${PY[@]}" tools/impact_validate.py "${IMPACT_ARGS[@]}" | tee "$RUN_DIR/impact_validate.txt"
+
+AGENT_RUN_ARGS=(
+  --agent "$AGENT"
+  --label "AGILAB agentic workflow demo"
+  --run-id "$RUN_ID"
+  --output-dir "$RUN_DIR"
+  --cwd "$ROOT"
+  --permission-level standard
+  --allow-failure
+  --tag demo
+  --tag agentic-workflow
+  --metadata "repo=agilab"
+  --metadata "branch=$BRANCH"
+  --metadata "changed_files=${#CHANGED_FILES[@]}"
+  --protocol-adapter mcp
+  --capability evidence-review
+  --json
+)
+
+if [[ "$DRY_RUN" == "1" ]]; then
+  AGENT_RUN_ARGS+=(--print-only)
+fi
+
+if [[ "$INCLUDE_COMMAND_ARGS" == "1" ]]; then
+  AGENT_RUN_ARGS+=(--include-command-args)
+fi
+
+TRACE_COMMAND=("${UV[@]}" python tools/impact_validate.py "${IMPACT_ARGS[@]}" --json)
+
+echo
+echo "== 5. Agent-run evidence =="
+"${AGILAB[@]}" agent-run "${AGENT_RUN_ARGS[@]}" -- "${TRACE_COMMAND[@]}" \
+  | tee "$RUN_DIR/agent_run_manifest.printed.json"
+
+if [[ "$DRY_RUN" != "1" ]]; then
+  echo
+  echo "== 6. Read-side evidence cards =="
+  "${AGILAB[@]}" agent-run validate "$RUN_DIR" --json | tee "$RUN_DIR/agent_run_validation.json"
+  "${AGILAB[@]}" agent-run handoff "$RUN_DIR" | tee "$RUN_DIR/agent_handoff.md"
+  "${AGILAB[@]}" agent-run next "$RUN_DIR" --json | tee "$RUN_DIR/agent_next_actions.json"
+  "${AGILAB[@]}" agent-run context \
+    --root "$OUTPUT_ROOT" \
+    --agent "$AGENT" \
+    --tag agentic-workflow \
+    --limit 5 \
+    --json | tee "$RUN_DIR/agent_context.json"
+fi
+
+echo
+echo "Demo evidence directory: $RUN_DIR"


### PR DESCRIPTION
## Summary
- bump the impacted public release set to 2026.06.05: agilab, agi-core, agi-cluster, agi-apps, agi-app-pytorch-playground, and agi-app-tescia-diagnostic
- add a local-first agentic workflow demo helper with docs and regression assertions
- resync the public docs mirror stamp from the canonical thales docs source

## Why
The previous release plan selected packages whose current versions already existed on PyPI. This makes the next release publish a new impacted set instead of becoming a no-op.

## Validation
- uv lock --check
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_pyproject_dependency_hygiene.py test/test_agent_workflows.py
- tools/demo_agentic_agilab_workflow.sh --dry-run --output-root /tmp/agilab-agentic-demo-smoke
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-core-combined
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile shared-core-typing --profile dependency-policy
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui
- uv --preview-features extra-build-dependencies run python tools/pypi_release_version_policy.py --skip-existing-pypi
- uv --preview-features extra-build-dependencies run python tools/pypi_project_preflight.py
- uv --preview-features extra-build-dependencies run python tools/pypi_trusted_publisher_contract.py --check-workflow .github/workflows/pypi-publish.yaml
- uv --preview-features extra-build-dependencies run --extra dev ruff --version
- uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp
- uv --preview-features extra-build-dependencies run python tools/app_contract_matrix.py --quiet
- ./dev maintenance

## Push guard note
The local pre-push mixed-scope guard was overridden intentionally with AGILAB_ALLOW_MIXED_SCOPE_PUSH=1 because this is a release-prep version bump across the exact impacted package set. The agi-core owner guard passed with AGILAB_CORE_CHANGE_ACTOR=jpmorard.