### PR TITLE
[codex] Add Tokki compact context profile

### DIFF
--- a/agent-context-rules.json
+++ b/agent-context-rules.json
@@ -21,6 +21,141 @@
       "agilab-intent-router"
     ]
   },
+  "context_profiles": {
+    "tokki": {
+      "label": "Tokki compact context profile",
+      "description": "Bounded context packs for Tokki and other token-saving agents. Use the baseline files first, then add only the packs for matched AGILAB task rules.",
+      "max_total_tokens": 9000,
+      "baseline_token_budget": 1200,
+      "max_rule_packs": 3,
+      "baseline_files": [
+        "AGENT_CONVENTIONS.md",
+        "agent-context-rules.json",
+        "tools/impact_validate.py"
+      ],
+      "commands": [
+        "python tools/agent_context_router.py --profile tokki --files <paths> --prompt <task> --json",
+        "uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files <paths>"
+      ],
+      "rule_packs": {
+        "docs-public-claims": {
+          "token_budget": 1800,
+          "files": [
+            ".claude/skills/agilab-docs/SKILL.md",
+            ".claude/skills/agilab-evidence-contracts/SKILL.md",
+            "tools/sync_docs_source.py"
+          ],
+          "commands": [
+            "uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --check"
+          ],
+          "why": "Route public wording through docs source discipline and evidence-boundary checks."
+        },
+        "release-publication": {
+          "token_budget": 2600,
+          "files": [
+            "AGENTS.md",
+            ".claude/skills/agilab-release-verification/SKILL.md",
+            "tools/release_plan.py",
+            ".github/workflows/pypi-publish.yaml"
+          ],
+          "commands": [
+            "./dev --print-only release",
+            "uv --preview-features extra-build-dependencies run python tools/release_plan.py"
+          ],
+          "why": "Release answers need current workflow truth, package impact, and public evidence sequencing."
+        },
+        "agent-skills": {
+          "token_budget": 2200,
+          "files": [
+            ".claude/skills/repo-skill-maintenance/SKILL.md",
+            "tools/sync_agent_skills.py",
+            "tools/agent_context_router.py",
+            "tools/agent_workflows.md"
+          ],
+          "commands": [
+            "python3 tools/sync_agent_skills.py --skills <skill>",
+            "python3 tools/agent_instruction_contract.py --check"
+          ],
+          "why": "Agent-facing changes need skill mirror, catalog, and instruction-contract alignment."
+        },
+        "streamlit-ui": {
+          "token_budget": 2200,
+          "files": [
+            ".claude/skills/agilab-streamlit-pages/SKILL.md",
+            ".claude/skills/agilab-ui-robot-validation/SKILL.md",
+            "tools/agilab_widget_robot.py"
+          ],
+          "commands": [
+            "uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui"
+          ],
+          "why": "Streamlit changes need session-state, route, browser-log, and robot-validation guardrails without loading the whole UI tree."
+        },
+        "evidence-proof": {
+          "token_budget": 1900,
+          "files": [
+            ".claude/skills/agilab-evidence-contracts/SKILL.md",
+            "src/agilab/evidence",
+            "tools/release_proof_report.py"
+          ],
+          "commands": [
+            "uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files <paths>"
+          ],
+          "why": "Evidence work needs schema, hash, replay, and proof semantics first."
+        },
+        "notebook-import-export": {
+          "token_budget": 2400,
+          "files": [
+            ".claude/skills/notebook-to-agilab-project/SKILL.md",
+            "src/agilab/notebooks/notebook_export_support.py",
+            "src/agilab/notebooks/notebook_pipeline_import.py",
+            "test/test_pipeline_editor.py"
+          ],
+          "commands": [
+            "uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_pipeline_editor.py"
+          ],
+          "why": "Notebook changes need cell-role metadata, import/export contracts, and focused round-trip tests."
+        },
+        "apps-examples": {
+          "token_budget": 1900,
+          "files": [
+            ".claude/skills/agilab-example-maturity/SKILL.md",
+            "tools/app_contract_matrix.py",
+            "src/agilab/examples"
+          ],
+          "commands": [
+            "./dev app-contracts"
+          ],
+          "why": "App/example changes need deterministic first-run behavior and app catalog/package alignment."
+        },
+        "installer-cluster": {
+          "token_budget": 2600,
+          "files": [
+            "AGENTS.md",
+            ".claude/skills/agilab-installer/SKILL.md",
+            ".claude/skills/agilab-security-review-patterns/SKILL.md",
+            "tools/install_contract_check.py",
+            "src/agilab/core/agi-cluster"
+          ],
+          "commands": [
+            "uv --preview-features extra-build-dependencies run python tools/install_contract_check.py --help"
+          ],
+          "why": "Installer and cluster changes need shared-core approval, manifest comparison, SSH/share safety, and polluted-environment regressions."
+        },
+        "frontend-visuals": {
+          "token_budget": 1800,
+          "files": [
+            ".claude/skills/scientific-svg-figures/SKILL.md",
+            ".claude/skills/svg-diagram-tuning/SKILL.md",
+            ".claude/skills/advanced-svg-system-design/SKILL.md"
+          ],
+          "commands": [
+            "git diff --check"
+          ],
+          "why": "Visual work needs figure/layout rules and export-safe source-of-truth assets."
+        }
+      }
+    }
+  },
   "rules": [
     {
       "id": "docs-public-claims",
@@ -94,8 +229,11 @@
         "agents.md",
         "codex",
         "claude",
+        "tokki",
         "opencode",
-        "aider"
+        "aider",
+        "context profile",
+        "token saving"
       ],
       "skills": [
         "repo-skill-maintenance",
@@ -164,6 +302,7 @@
       "label": "Notebook import and export",
       "paths": [
         "src/agilab/notebook_*.py",
+        "src/agilab/notebooks/**",
         "src/agilab/pages/3_WORKFLOW.py",
         "src/agilab/apps/builtin/**/notebooks/**",
         "test/test_*notebook*.py",

--- a/test/test_agent_context_router.py
+++ b/test/test_agent_context_router.py
@@ -73,6 +73,73 @@ def test_recommend_context_matches_release_prompt_without_files() -> None:
     assert "agilab-pypi-release-maintenance" in skill_names
 
 
+def test_recommend_context_can_emit_tokki_profile_packs() -> None:
+    payload = agent_context_router.recommend_context(
+        files=[
+            "src/agilab/pages/4_ANALYSIS.py",
+            "src/agilab/notebooks/notebook_export_support.py",
+        ],
+        prompt="fix notebook sync in the analysis page",
+        skills=_skill_index(),
+        profile="tokki",
+    )
+
+    profile = payload["context_profile"]
+
+    assert profile["id"] == "tokki"
+    assert profile["estimated_token_budget"] <= profile["max_total_tokens"]
+    assert profile["baseline_files"] == [
+        "AGENT_CONVENTIONS.md",
+        "agent-context-rules.json",
+        "tools/impact_validate.py",
+    ]
+    pack_ids = [pack["rule_id"] for pack in profile["matched_packs"]]
+    assert "streamlit-ui" in pack_ids
+    assert "notebook-import-export" in pack_ids
+    notebook_pack = next(pack for pack in profile["matched_packs"] if pack["rule_id"] == "notebook-import-export")
+    assert "test/test_pipeline_editor.py" in notebook_pack["files"]
+
+
+def test_recommend_context_routes_tokki_prompt_to_context_profile_pack() -> None:
+    payload = agent_context_router.recommend_context(
+        prompt="make AGILAB tokki friendly with token saving context packs",
+        skills=_skill_index(),
+        profile="tokki",
+    )
+
+    matched_ids = [rule["id"] for rule in payload["matched_rules"]]
+    profile_pack_ids = [pack["rule_id"] for pack in payload["context_profile"]["matched_packs"]]
+
+    assert "agent-skills" in matched_ids
+    assert "agent-skills" in profile_pack_ids
+
+
+def test_cli_text_output_reports_tokki_profile(capsys) -> None:
+    rc = agent_context_router.main(
+        [
+            "--files",
+            "src/agilab/pages/4_ANALYSIS.py",
+            "--prompt",
+            "fix Streamlit sidebar state",
+            "--profile",
+            "tokki",
+        ]
+    )
+
+    assert rc == 0
+    output = capsys.readouterr().out
+    assert "Context profile: tokki" in output
+    assert "streamlit-ui" in output
+
+
+def test_cli_reports_unknown_context_profile(capsys) -> None:
+    rc = agent_context_router.main(["--profile", "missing"])
+
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert "unknown context profile: missing" in captured.err
+
+
 def test_validate_rules_reports_unknown_skill() -> None:
     rules = {
         "schema": "agilab.agent_context_rules.v1",

--- a/tools/agent_context_router.py
+++ b/tools/agent_context_router.py
@@ -74,6 +74,19 @@ def _string_list(value: Any, *, path: str, issues: list[dict[str, str]]) -> list
     return result
 
 
+def _positive_int(value: Any, *, path: str, issues: list[dict[str, str]]) -> int:
+    if isinstance(value, int) and value > 0:
+        return value
+    issues.append(
+        {
+            "severity": "error",
+            "path": path,
+            "message": "expected a positive integer",
+        }
+    )
+    return 0
+
+
 def normalize_file(path: str | Path) -> str:
     raw = str(path).strip()
     if not raw:
@@ -232,6 +245,103 @@ def validate_rules(
                         "message": f"unknown skill: {name}",
                     }
                 )
+    profiles = rules_payload.get("context_profiles", {})
+    if profiles is not None:
+        profile_map = _expect_mapping(profiles, path="context_profiles", issues=issues)
+        for profile_id, raw_profile in profile_map.items():
+            profile_path = f"context_profiles.{profile_id}"
+            if not isinstance(profile_id, str) or not profile_id.strip():
+                issues.append(
+                    {
+                        "severity": "error",
+                        "path": profile_path,
+                        "message": "expected a non-empty profile id",
+                    }
+                )
+            profile = _expect_mapping(raw_profile, path=profile_path, issues=issues)
+            for field in ("label", "description"):
+                value = profile.get(field)
+                if not isinstance(value, str) or not value.strip():
+                    issues.append(
+                        {
+                            "severity": "error",
+                            "path": f"{profile_path}.{field}",
+                            "message": "expected a non-empty string",
+                        }
+                    )
+            max_total = _positive_int(
+                profile.get("max_total_tokens"),
+                path=f"{profile_path}.max_total_tokens",
+                issues=issues,
+            )
+            baseline_budget = _positive_int(
+                profile.get("baseline_token_budget"),
+                path=f"{profile_path}.baseline_token_budget",
+                issues=issues,
+            )
+            if max_total and baseline_budget and baseline_budget >= max_total:
+                issues.append(
+                    {
+                        "severity": "error",
+                        "path": f"{profile_path}.baseline_token_budget",
+                        "message": "baseline token budget must be smaller than max_total_tokens",
+                    }
+                )
+            _positive_int(
+                profile.get("max_rule_packs"),
+                path=f"{profile_path}.max_rule_packs",
+                issues=issues,
+            )
+            for field in ("baseline_files", "commands"):
+                for item in _string_list(profile.get(field), path=f"{profile_path}.{field}", issues=issues):
+                    if field == "baseline_files" and not (REPO_ROOT / item).exists():
+                        issues.append(
+                            {
+                                "severity": "error",
+                                "path": f"{profile_path}.{field}",
+                                "message": f"profile file does not exist: {item}",
+                            }
+                        )
+            rule_packs = _expect_mapping(
+                profile.get("rule_packs"),
+                path=f"{profile_path}.rule_packs",
+                issues=issues,
+            )
+            for rule_id, raw_pack in rule_packs.items():
+                pack_path = f"{profile_path}.rule_packs.{rule_id}"
+                if rule_id not in seen_ids:
+                    issues.append(
+                        {
+                            "severity": "error",
+                            "path": pack_path,
+                            "message": f"profile pack references unknown rule id: {rule_id}",
+                        }
+                    )
+                pack = _expect_mapping(raw_pack, path=pack_path, issues=issues)
+                _positive_int(
+                    pack.get("token_budget"),
+                    path=f"{pack_path}.token_budget",
+                    issues=issues,
+                )
+                for item in _string_list(pack.get("files"), path=f"{pack_path}.files", issues=issues):
+                    if not (REPO_ROOT / item).exists():
+                        issues.append(
+                            {
+                                "severity": "error",
+                                "path": f"{pack_path}.files",
+                                "message": f"profile file does not exist: {item}",
+                            }
+                        )
+                _string_list(pack.get("commands"), path=f"{pack_path}.commands", issues=issues)
+                why = pack.get("why")
+                if not isinstance(why, str) or not why.strip():
+                    issues.append(
+                        {
+                            "severity": "error",
+                            "path": f"{pack_path}.why",
+                            "message": "expected a non-empty string",
+                        }
+                    )
     errors = sum(1 for issue in issues if issue["severity"] == "error")
     return {
         "schema": VALIDATION_SCHEMA,
@@ -262,12 +372,74 @@ def _skill_payload(
     return payload
 
 
+def _context_profile_payload(
+    rules_payload: Mapping[str, Any],
+    *,
+    profile_id: str,
+    matched_rules: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    profiles = rules_payload.get("context_profiles", {})
+    if not isinstance(profiles, Mapping) or profile_id not in profiles:
+        raise ValueError(f"unknown context profile: {profile_id}")
+    profile = profiles[profile_id]
+    if not isinstance(profile, Mapping):
+        raise ValueError(f"context profile is not an object: {profile_id}")
+
+    max_total_tokens = int(profile.get("max_total_tokens", 0) or 0)
+    baseline_token_budget = int(profile.get("baseline_token_budget", 0) or 0)
+    max_rule_packs = int(profile.get("max_rule_packs", 0) or 0)
+    remaining_tokens = max(max_total_tokens - baseline_token_budget, 0)
+    rule_packs = profile.get("rule_packs", {})
+    rule_packs = rule_packs if isinstance(rule_packs, Mapping) else {}
+    selected_packs: list[dict[str, Any]] = []
+    dropped_rule_ids: list[str] = []
+    for matched_rule in matched_rules:
+        rule_id = str(matched_rule.get("id", "") or "")
+        raw_pack = rule_packs.get(rule_id)
+        if not isinstance(raw_pack, Mapping):
+            continue
+        if max_rule_packs and len(selected_packs) >= max_rule_packs:
+            dropped_rule_ids.append(rule_id)
+            continue
+        token_budget = int(raw_pack.get("token_budget", 0) or 0)
+        if token_budget > remaining_tokens:
+            dropped_rule_ids.append(rule_id)
+            continue
+        remaining_tokens -= token_budget
+        selected_packs.append(
+            {
+                "rule_id": rule_id,
+                "label": str(matched_rule.get("label", "") or ""),
+                "token_budget": token_budget,
+                "files": [item for item in raw_pack.get("files", []) if isinstance(item, str)],
+                "commands": [item for item in raw_pack.get("commands", []) if isinstance(item, str)],
+                "why": str(raw_pack.get("why", "") or ""),
+            }
+        )
+
+    return {
+        "id": profile_id,
+        "label": str(profile.get("label", "") or ""),
+        "description": str(profile.get("description", "") or ""),
+        "max_total_tokens": max_total_tokens,
+        "baseline_token_budget": baseline_token_budget,
+        "estimated_token_budget": baseline_token_budget
+        + sum(int(pack["token_budget"]) for pack in selected_packs),
+        "remaining_token_budget": remaining_tokens,
+        "baseline_files": [item for item in profile.get("baseline_files", []) if isinstance(item, str)],
+        "commands": [item for item in profile.get("commands", []) if isinstance(item, str)],
+        "matched_packs": selected_packs,
+        "dropped_rule_ids": dropped_rule_ids,
+    }
+
+
 def recommend_context(
     *,
     files: Sequence[str] = (),
     prompt: str = "",
     rules_path: Path = DEFAULT_RULES,
     skills: Mapping[str, Mapping[str, str]] | None = None,
+    profile: str = "",
 ) -> dict[str, Any]:
     rules_payload = _load_json(rules_path)
     if not isinstance(rules_payload, Mapping):
@@ -307,7 +479,7 @@ def recommend_context(
                 "matched_terms": matched_terms,
             }
         )
-    return {
+    result = {
         "schema": RECOMMENDATION_SCHEMA,
         "schema_version": 1,
         "status": "pass" if validation["status"] == "pass" else "rules-invalid",
@@ -325,6 +497,14 @@ def recommend_context(
         ],
         "validation": validation,
     }
+    profile_id = profile.strip()
+    if profile_id:
+        result["context_profile"] = _context_profile_payload(
+            rules_payload,
+            profile_id=profile_id,
+            matched_rules=matched_rules,
+        )
+    return result
 
 
 def render_text(payload: Mapping[str, Any]) -> str:
@@ -354,6 +534,19 @@ def render_text(payload: Mapping[str, Any]) -> str:
             lines.append(f"- {item.get('id')}: {item.get('label')}")
     else:
         lines.append("Matched rules: none; use the baseline runbooks and skills.")
+    profile = payload.get("context_profile", {})
+    if isinstance(profile, Mapping) and profile:
+        lines.append(
+            "Context profile: "
+            f"{profile.get('id')} "
+            f"({profile.get('estimated_token_budget')}/{profile.get('max_total_tokens')} tokens)"
+        )
+        packs = profile.get("matched_packs", [])
+        if isinstance(packs, list) and packs:
+            lines.append("Context packs:")
+            for pack in packs:
+                if isinstance(pack, Mapping):
+                    lines.append(f"- {pack.get('rule_id')}: {pack.get('token_budget')} tokens")
     return "\n".join(lines) + "\n"
 
 
@@ -362,6 +555,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--rules", type=Path, default=DEFAULT_RULES, help="Context routing rules JSON.")
     parser.add_argument("--files", nargs="*", default=(), help="Changed or target files to classify.")
     parser.add_argument("--prompt", default="", help="Natural-language task text to classify.")
+    parser.add_argument("--profile", default="", help="Optional compact context profile, for example 'tokki'.")
     parser.add_argument("--staged", action="store_true", help="Include staged git paths.")
     parser.add_argument("--changed", action="store_true", help="Include paths changed against HEAD.")
     parser.add_argument("--check", action="store_true", help="Validate the routing rules and exit.")
@@ -388,7 +582,11 @@ def main(argv: list[str] | None = None) -> int:
         return 0 if report["status"] == "pass" else 2
     files = list(args.files)
     files.extend(_git_changed_files(staged=args.staged, changed=args.changed))
-    payload = recommend_context(files=files, prompt=args.prompt, rules_path=rules_path)
+    try:
+        payload = recommend_context(files=files, prompt=args.prompt, rules_path=rules_path, profile=args.profile)
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
     if args.json:
         print(json.dumps(payload, indent=2, sort_keys=True))
     else:

--- a/tools/agent_workflows.md
+++ b/tools/agent_workflows.md
@@ -84,6 +84,21 @@ from the reviewed rules in `agent-context-rules.json`. It is a contract proof
 for agent context selection only: it does not execute agents, run tests, or
 override the validation gates reported by `tools/impact_validate.py`.
 
+For Tokki or another token-saving wrapper, request the compact profile:
+
+```bash
+python tools/agent_context_router.py \
+  --profile tokki \
+  --files src/agilab/pages/4_ANALYSIS.py src/agilab/notebooks/notebook_export_support.py \
+  --prompt "fix notebook sync in the analysis page" \
+  --json
+```
+
+The `context_profile` block returns the bounded baseline files, matched context
+packs, estimated token budget, and follow-up validation commands. The profile is
+advisory: it narrows context selection, while `tools/impact_validate.py` remains
+the validation source of truth.
+
 Validate the rule file with:
 
 ```bash


### PR DESCRIPTION
## Summary
- Add a Tokki compact context profile to AGILAB's agent context rules.
- Extend `tools/agent_context_router.py` with `--profile tokki` and validated context-profile output.
- Document the Tokki invocation in the agent workflow guide and add router regressions.

## Why
AGILAB already has strong agent routing and runbooks, but Tokki needs a bounded, machine-readable context pack so token-saving runs can select only the relevant AGILAB guidance, files, and validation commands.

## Validation
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_agent_context_router.py test/test_agent_workflows.py`
- `uv --preview-features extra-build-dependencies run python tools/agent_context_router.py --check`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files tools/agent_context_router.py agent-context-rules.json tools/agent_workflows.md test/test_agent_context_router.py`
- `python3 tools/agent_instruction_contract.py --check`
- `uv --preview-features extra-build-dependencies run --extra dev ruff check tools/agent_context_router.py test/test_agent_context_router.py`
- `python3 -m py_compile tools/agent_context_router.py`
- `git diff --check`
- `./dev scope`
