### PR TITLE
[codex] Sync analysis notebooks with project files

### DIFF
--- a/maintenance/memory/by-path/src%2Fagilab%2Fpages%2F4_ANALYSIS.py.md
+++ b/maintenance/memory/by-path/src%2Fagilab%2Fpages%2F4_ANALYSIS.py.md
@@ -1,7 +1,7 @@
 ---
 schema: agilab.maintenance_memory.v1
 source: src/agilab/pages/4_ANALYSIS.py
-source_sha256: a2b5de47cf1d87db01413b108e818e486395cccef3165c27b2c342a181ab1a01
+source_sha256: 64a7b2c42dfefad164f2f9eeccc5d4c71b3f0af66ef941ed5609a56b2f09f874
 title: ANALYSIS page AgiEnv singleton contract
 verified_commit: b58bcbf66ebfa8d41da46f98c0a2882c433144a4
 ---

--- a/src/agilab/notebooks/notebook_export_support.py
+++ b/src/agilab/notebooks/notebook_export_support.py
@@ -24,6 +24,7 @@ NOTEBOOK_EXPORT_SCHEMA_VERSION = 1
 NOTEBOOK_EXPORT_STAGE_CELL_SCHEMA = "agilab.notebook_export.stage_cell.v1"
 NOTEBOOK_EXPORT_MANIFEST_SCHEMA = "agilab.notebook_export_manifest.v1"
 NOTEBOOK_EXPORT_HANDOFF_SCHEMA = "agilab.notebook_export_handoff.v1"
+NOTEBOOK_VIEW_SYNC_STATUS_SCHEMA = "agilab.notebook_view_sync_status.v1"
 PYCHARM_NOTEBOOK_MIRROR_ROOT = "exported_notebooks"
 PROJECT_NOTEBOOK_MIRROR_DIR = "notebooks"
 ALLOW_WORKSPACE_SIBLING_APPS_ENV = "AGILAB_NOTEBOOK_EXPORT_ALLOW_WORKSPACE_SIBLINGS"
@@ -137,6 +138,8 @@ class RelatedPageExport:
     launch_note: str = ""
     script_path: str = ""
     inline_renderer: str = ""
+    script_sha256: str = ""
+    inline_renderer_sha256: str = ""
 
 
 @dataclass(frozen=True)
@@ -151,6 +154,7 @@ class NotebookExportContext:
     export_mode: str = DEFAULT_NOTEBOOK_EXPORT_MODE
     allow_workspace_sibling_apps: bool = False
     related_pages: tuple[RelatedPageExport, ...] = ()
+    view_sync: Mapping[str, Any] | None = None
 
 
 def _normalize_path(value: Any) -> str:
@@ -496,6 +500,102 @@ def _load_related_page_manifest(
     return {}, ()
 
 
+def _file_sha256(path: str | Path | None) -> str:
+    if not path:
+        return ""
+    try:
+        candidate = Path(path).expanduser()
+        if not candidate.is_file():
+            return ""
+        return hashlib.sha256(candidate.read_bytes()).hexdigest()
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return ""
+
+
+def _inline_renderer_module_path(target: str | None) -> str:
+    target_text = str(target or "").strip()
+    if not target_text:
+        return ""
+    module_target, _, _attr = target_text.partition(":")
+    module_target = module_target.strip()
+    if not module_target:
+        return ""
+    try:
+        candidate = Path(module_target).expanduser()
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return ""
+    if candidate.suffix == ".py" or "/" in module_target or "\\" in module_target:
+        return str(candidate)
+    return ""
+
+
+def _sync_source_record(kind: str, path: str | Path | None, *, module: str = "") -> dict[str, Any]:
+    path_text = _normalize_path(path)
+    return {
+        "kind": kind,
+        "module": str(module or ""),
+        "path": path_text,
+        "sha256": _file_sha256(path_text),
+    }
+
+
+def _dedupe_sync_sources(sources: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    normalized: list[dict[str, Any]] = []
+    seen: set[tuple[str, str, str]] = set()
+    for source in sources:
+        path = str(source.get("path", "") or "").strip()
+        sha256 = str(source.get("sha256", "") or "").strip()
+        if not path or not sha256:
+            continue
+        record = {
+            "kind": str(source.get("kind", "") or ""),
+            "module": str(source.get("module", "") or ""),
+            "path": path,
+            "sha256": sha256,
+        }
+        key = (record["kind"], record["module"], record["path"])
+        if key in seen:
+            continue
+        seen.add(key)
+        normalized.append(record)
+    normalized.sort(key=lambda item: (item["kind"], item["module"], item["path"]))
+    return normalized
+
+
+def _build_view_sync_snapshot(
+    *,
+    settings_file: Path | None,
+    source_settings: Path | None,
+    active_app: str,
+    related_pages: Sequence[RelatedPageExport],
+) -> dict[str, Any]:
+    sources: list[dict[str, Any]] = []
+    for path, kind in (
+        (settings_file, "workspace_app_settings"),
+        (source_settings, "source_app_settings"),
+    ):
+        if path is not None:
+            sources.append(_sync_source_record(kind, path))
+    for path in _candidate_notebook_manifest_paths(active_app):
+        sources.append(_sync_source_record("notebook_export_manifest", path))
+    for page in related_pages:
+        sources.append(_sync_source_record("analysis_page_script", page.script_path, module=page.module))
+        inline_path = _inline_renderer_module_path(page.inline_renderer)
+        if inline_path:
+            sources.append(_sync_source_record("analysis_page_inline_renderer", inline_path, module=page.module))
+
+    normalized_sources = _dedupe_sync_sources(sources)
+    modules = [page.module for page in related_pages if page.module]
+    payload = {
+        "schema": "agilab.notebook_view_sync.v1",
+        "source": "app_settings_and_page_bundles",
+        "related_page_modules": modules,
+        "sources": normalized_sources,
+    }
+    payload["sha256"] = notebook_export_sha256(payload)
+    return payload
+
+
 def _bundle_record_from_provider(bundle: Any) -> dict[str, str]:
     if bundle is None:
         return {}
@@ -675,18 +775,29 @@ def build_notebook_export_context(
     page_manifest, manifest_order = _load_related_page_manifest(active_app)
     related_pages = _load_related_pages_from_settings(settings_file) or _load_related_pages_from_settings(source_settings) or manifest_order
     pages_root = _normalize_path(getattr(env, "AGILAB_PAGES_ABS", ""))
-    related_page_records = tuple(
-        RelatedPageExport(
-            module=page,
-            label=str(page_manifest.get(page, {}).get("label", "") or ""),
-            description=str(page_manifest.get(page, {}).get("description", "") or ""),
-            artifacts=tuple(str(item) for item in page_manifest.get(page, {}).get("artifacts", ())),
-            launch_note=str(page_manifest.get(page, {}).get("launch_note", "") or ""),
-            script_path=script_path,
-            inline_renderer=_discover_page_inline_renderer(page_manifest, page, script_path=script_path),
+    related_page_records_list: list[RelatedPageExport] = []
+    for page in related_pages:
+        script_path = _discover_page_script(pages_root, page)
+        inline_renderer = _discover_page_inline_renderer(page_manifest, page, script_path=script_path)
+        related_page_records_list.append(
+            RelatedPageExport(
+                module=page,
+                label=str(page_manifest.get(page, {}).get("label", "") or ""),
+                description=str(page_manifest.get(page, {}).get("description", "") or ""),
+                artifacts=tuple(str(item) for item in page_manifest.get(page, {}).get("artifacts", ())),
+                launch_note=str(page_manifest.get(page, {}).get("launch_note", "") or ""),
+                script_path=script_path,
+                inline_renderer=inline_renderer,
+                script_sha256=_file_sha256(script_path),
+                inline_renderer_sha256=_file_sha256(_inline_renderer_module_path(inline_renderer)),
+            )
         )
-        for page in related_pages
-        for script_path in (_discover_page_script(pages_root, page),)
+    related_page_records = tuple(related_page_records_list)
+    view_sync = _build_view_sync_snapshot(
+        settings_file=settings_file,
+        source_settings=source_settings,
+        active_app=active_app,
+        related_pages=related_page_records,
     )
 
     return NotebookExportContext(
@@ -699,6 +810,7 @@ def build_notebook_export_context(
         repo_root=repo_root,
         allow_workspace_sibling_apps=allow_workspace_sibling_apps,
         related_pages=related_page_records,
+        view_sync=view_sync,
     )
 
 
@@ -1046,6 +1158,8 @@ def _related_page_manifest_records(metadata: Mapping[str, Any]) -> list[dict[str
                 "launch_note": str(page.get("launch_note", "") or ""),
                 "script_path": str(page.get("script_path", "") or ""),
                 "inline_renderer": str(page.get("inline_renderer", "") or ""),
+                "script_sha256": str(page.get("script_sha256", "") or ""),
+                "inline_renderer_sha256": str(page.get("inline_renderer_sha256", "") or ""),
             }
         )
     return records
@@ -1156,6 +1270,7 @@ def build_notebook_export_manifest(
         "notebook_sha256": notebook_export_sha256(notebook_data),
         "stages": _stage_manifest_records(metadata),
         "related_pages": _related_page_manifest_records(metadata),
+        "view_sync": dict(metadata.get("view_sync", {})) if isinstance(metadata.get("view_sync", {}), Mapping) else {},
         "stage_source_hashes": _stage_source_hashes(metadata),
         "stage_cells": _stage_cell_manifest_records(notebook_data),
     }
@@ -1300,6 +1415,41 @@ def _verification_check(checks: list[dict[str, Any]], check_id: str, ok: bool, s
     return ok
 
 
+def _view_sync_source_drift(manifest: Mapping[str, Any]) -> tuple[int, list[dict[str, Any]], list[dict[str, Any]], int]:
+    view_sync = manifest.get("view_sync", {})
+    if not isinstance(view_sync, Mapping):
+        return 0, [], [], 0
+    raw_sources = view_sync.get("sources", [])
+    if not isinstance(raw_sources, list):
+        return 0, [], [], 0
+
+    checked = 0
+    changed: list[dict[str, Any]] = []
+    unavailable: list[dict[str, Any]] = []
+    for raw_source in raw_sources:
+        if not isinstance(raw_source, Mapping):
+            continue
+        path = str(raw_source.get("path", "") or "").strip()
+        expected_sha256 = str(raw_source.get("sha256", "") or "").strip()
+        if not path or not expected_sha256:
+            continue
+        actual_sha256 = _file_sha256(path)
+        record = {
+            "kind": str(raw_source.get("kind", "") or ""),
+            "module": str(raw_source.get("module", "") or ""),
+            "path": path,
+            "expected_sha256": expected_sha256,
+            "actual_sha256": actual_sha256,
+        }
+        if not actual_sha256:
+            unavailable.append(record)
+            continue
+        checked += 1
+        if actual_sha256 != expected_sha256:
+            changed.append(record)
+    return checked, changed, unavailable, len(raw_sources)
+
+
 def verify_notebook_export_manifest(
     notebook_path: str | Path,
     manifest_path: str | Path | None = None,
@@ -1415,11 +1565,93 @@ def verify_notebook_export_manifest(
             actual_sha256=actual_source_hash,
         )
 
+    checked_sources, changed_sources, unavailable_sources, total_sources = _view_sync_source_drift(manifest)
+    if total_sources:
+        _verification_check(
+            checks,
+            "view_sync_sources",
+            not changed_sources,
+            "Reachable app settings, page manifests, and analysis page sources match the notebook export snapshot.",
+            source_count=total_sources,
+            checked_count=checked_sources,
+            changed_sources=changed_sources,
+            unavailable_sources=unavailable_sources,
+        )
+
     return {
         "ok": all(check["status"] == "pass" for check in checks),
         "notebook_path": str(notebook_file),
         "manifest_path": str(manifest_file),
         "checks": checks,
+    }
+
+
+def notebook_view_sync_status(
+    notebook_path: str | Path,
+    manifest_path: str | Path | None = None,
+) -> dict[str, Any]:
+    """Summarize both drift directions between an exported notebook and AGILAB views."""
+    verification = verify_notebook_export_manifest(notebook_path, manifest_path=manifest_path)
+    checks = verification.get("checks", [])
+    check_records = [check for check in checks if isinstance(check, Mapping)]
+    failed_checks = [check for check in check_records if check.get("status") != "pass"]
+    failed_ids = {str(check.get("id", "") or "") for check in failed_checks}
+
+    source_check = next((check for check in check_records if check.get("id") == "view_sync_sources"), {})
+    source_details = source_check.get("details", {}) if isinstance(source_check, Mapping) else {}
+    if not isinstance(source_details, Mapping):
+        source_details = {}
+    changed_sources = source_details.get("changed_sources", [])
+    unavailable_sources = source_details.get("unavailable_sources", [])
+    changed_source_count = len(changed_sources) if isinstance(changed_sources, list) else 0
+    unavailable_source_count = len(unavailable_sources) if isinstance(unavailable_sources, list) else 0
+    source_changed = str(source_check.get("status", "") or "") == "fail" and changed_source_count > 0
+
+    notebook_content_check_ids = {"notebook_sha256", "cell_ids"}
+    notebook_changed = any(check_id in failed_ids for check_id in notebook_content_check_ids) or any(
+        check_id.startswith("stage_source_") for check_id in failed_ids
+    )
+    manifest_problem = any(check_id in failed_ids for check_id in {"notebook_exists", "manifest_exists", "manifest_schema"})
+    handoff_changed = any(check_id in failed_ids for check_id in {"handoff_exists", "handoff_sha256"})
+
+    if manifest_problem:
+        state = "unverified"
+        summary = "Notebook sync could not be verified because the export notebook or manifest is missing or unsupported."
+    elif source_changed and notebook_changed:
+        state = "both_changed"
+        summary = "Both the notebook and linked AGILAB view/app sources changed since export."
+    elif source_changed:
+        state = "source_changed"
+        summary = "Linked AGILAB view/app sources changed since this notebook was exported."
+    elif notebook_changed:
+        state = "notebook_changed"
+        summary = "The notebook changed since export; re-import edited stage cells before treating AGILAB sources as current."
+    elif failed_checks:
+        state = "support_changed"
+        summary = "Notebook export support files changed or are unavailable."
+    else:
+        state = "synced"
+        summary = "Notebook, export manifest, and linked AGILAB view/app sources are synchronized."
+
+    fallback_manifest_path = (
+        str(Path(manifest_path))
+        if manifest_path is not None
+        else str(notebook_export_manifest_path(notebook_path))
+    )
+    return {
+        "schema": NOTEBOOK_VIEW_SYNC_STATUS_SCHEMA,
+        "ok": bool(verification.get("ok")),
+        "state": state,
+        "summary": summary,
+        "notebook_changed": notebook_changed,
+        "source_changed": source_changed,
+        "handoff_changed": handoff_changed,
+        "changed_source_count": changed_source_count,
+        "unavailable_source_count": unavailable_source_count,
+        "failed_check_ids": sorted(failed_ids),
+        "notebook_path": verification.get("notebook_path", str(Path(notebook_path))),
+        "manifest_path": verification.get("manifest_path", fallback_manifest_path),
+        "verification": verification,
     }
 
 
@@ -1811,6 +2043,55 @@ def _helper_cell(payload: dict[str, Any]) -> str:
                 return Path(path_value).expanduser().exists()
             except Exception:
                 return False
+
+
+        def _file_sha256(path_value):
+            if not path_value:
+                return ""
+            try:
+                path = Path(path_value).expanduser()
+                if not path.is_file():
+                    return ""
+                import hashlib
+
+                return hashlib.sha256(path.read_bytes()).hexdigest()
+            except Exception:
+                return ""
+
+
+        def _view_sync_source_drift():
+            view_sync = AGILAB_NOTEBOOK_EXPORT.get("view_sync", {{}})
+            if not isinstance(view_sync, dict):
+                return 0, [], [], 0
+            raw_sources = view_sync.get("sources", [])
+            if not isinstance(raw_sources, list):
+                return 0, [], [], 0
+
+            checked = 0
+            changed = []
+            unavailable = []
+            for source in raw_sources:
+                if not isinstance(source, dict):
+                    continue
+                path = str(source.get("path") or "").strip()
+                expected = str(source.get("sha256") or "").strip()
+                if not path or not expected:
+                    continue
+                actual = _file_sha256(path)
+                record = {{
+                    "kind": str(source.get("kind") or ""),
+                    "module": str(source.get("module") or ""),
+                    "path": path,
+                    "expected_sha256": expected,
+                    "actual_sha256": actual,
+                }}
+                if not actual:
+                    unavailable.append(record)
+                    continue
+                checked += 1
+                if actual != expected:
+                    changed.append(record)
+            return checked, changed, unavailable, len(raw_sources)
 
 
         def _command_or_path_exists(value):
@@ -2279,6 +2560,19 @@ def _helper_cell(payload: dict[str, Any]) -> str:
                     inline_renderer_exists=inline_ok,
                 ) and ok
 
+            checked_sources, changed_sources, unavailable_sources, total_sources = _view_sync_source_drift()
+            if total_sources:
+                ok = _validation_check(
+                    checks,
+                    "view_sync_sources",
+                    not changed_sources,
+                    "Reachable app settings, page manifests, and analysis page sources match the notebook export snapshot.",
+                    source_count=total_sources,
+                    checked_count=checked_sources,
+                    changed_sources=changed_sources,
+                    unavailable_sources=unavailable_sources,
+                ) and ok
+
             report = {{
                 "ok": ok,
                 "project_name": AGILAB_NOTEBOOK_EXPORT.get("project_name"),
@@ -2660,6 +2954,7 @@ def build_notebook_document(
         "export_mode": export_context.export_mode,
         "allow_workspace_sibling_apps": export_context.allow_workspace_sibling_apps,
         "related_pages": [asdict(page) for page in export_context.related_pages],
+        "view_sync": dict(export_context.view_sync or {}),
         "stages": stage_records,
         "stages_file": str(Path(toml_path)),
     }

--- a/src/agilab/pages/4_ANALYSIS.py
+++ b/src/agilab/pages/4_ANALYSIS.py
@@ -116,6 +116,17 @@ import_agilab_symbols(
 )
 import_agilab_symbols(
     globals(),
+    "agilab.notebook_export_support",
+    {
+        "notebook_view_sync_status": "notebook_view_sync_status",
+    },
+    current_file=__file__,
+    fallback_path=Path(__file__).resolve().parents[1] / "notebooks/notebook_export_support.py",
+    fallback_name="agilab_notebook_export_support_fallback",
+)
+_notebook_view_sync_status = globals()["notebook_view_sync_status"]
+import_agilab_symbols(
+    globals(),
     "agilab.app_surface",
     {
         "app_surface_config": "app_surface_config",
@@ -3183,6 +3194,25 @@ async def main():
     )
 
 
+def _render_notebook_view_sync_status(notebook_path: Path) -> None:
+    try:
+        status = _notebook_view_sync_status(notebook_path)
+    except Exception as exc:
+        st.caption(f"Notebook sync: unavailable ({exc})")
+        return
+
+    state = str(status.get("state", "") or "")
+    summary = str(status.get("summary", "") or "Notebook sync status unavailable.")
+    if state == "synced":
+        st.caption(f"Notebook sync: {summary}")
+    elif state in {"source_changed", "notebook_changed", "support_changed"}:
+        st.warning(f"Notebook sync: {summary}")
+    elif state == "both_changed":
+        st.error(f"Notebook sync: {summary}")
+    else:
+        st.caption(f"Notebook sync: {summary}")
+
+
 async def render_notebook_page(notebook_path: Path):
     """Render a project notebook by launching JupyterLab as a project-rooted sidecar."""
     env = st.session_state["env"]
@@ -3211,6 +3241,8 @@ async def render_notebook_page(notebook_path: Path):
             st.rerun()
     with title_col:
         st.subheader(f"Notebook: `{notebook_label}`")
+
+    _render_notebook_view_sync_status(resolved_notebook)
 
     if _is_hosted_analysis_runtime(env):
         st.warning("Notebook sidecars are available in local AGILAB runtimes only.")

--- a/test/test_analysis_page_helpers.py
+++ b/test/test_analysis_page_helpers.py
@@ -632,6 +632,8 @@ def test_render_notebook_page_embeds_project_jupyter_sidecar(tmp_path: Path, mon
     notebook_path.parent.mkdir(parents=True)
     notebook_path.write_text("{}", encoding="utf-8")
     calls: list[tuple[str, dict[str, object]]] = []
+    status_events: list[tuple[str, str]] = []
+    sync_status_paths: list[Path] = []
     sidebar_hides: list[str] = []
 
     class _Column:
@@ -656,10 +658,21 @@ def test_render_notebook_page_embeds_project_jupyter_sidecar(tmp_path: Path, mon
         columns=lambda _spec: [_Column(), _Column(), _Column()],
         button=lambda *_args, **_kwargs: False,
         subheader=lambda *_args, **_kwargs: None,
+        caption=lambda value: status_events.append(("caption", str(value))),
+        warning=lambda value: status_events.append(("warning", str(value))),
+        error=lambda value: status_events.append(("error", str(value))),
         iframe=lambda src, **kwargs: calls.append((src, kwargs)),
     )
 
     monkeypatch.setattr(module, "st", fake_st)
+    monkeypatch.setattr(
+        module,
+        "_notebook_view_sync_status",
+        lambda path: sync_status_paths.append(Path(path)) or {
+            "state": "notebook_changed",
+            "summary": "The notebook changed since export.",
+        },
+    )
     monkeypatch.setattr(module, "_hide_parent_sidebar", lambda: sidebar_hides.append("hide"))
     monkeypatch.setattr(module, "_is_hosted_analysis_runtime", lambda _env: False)
     monkeypatch.setattr(module, "_ensure_notebook_sidecar", lambda *_args, **_kwargs: True)
@@ -673,6 +686,8 @@ def test_render_notebook_page_embeds_project_jupyter_sidecar(tmp_path: Path, mon
             {"height": 900},
         )
     ]
+    assert sync_status_paths == [notebook_path.resolve()]
+    assert status_events == [("warning", "Notebook sync: The notebook changed since export.")]
     assert sidebar_hides == []
 
 

--- a/test/test_pipeline_editor.py
+++ b/test/test_pipeline_editor.py
@@ -3500,6 +3500,89 @@ launch_note = "Open this after the run."
     assert context.related_pages[0].launch_note == "Open this after the run."
     assert context.related_pages[0].script_path == str(page_script.resolve())
     assert context.related_pages[0].inline_renderer.endswith("notebook_inline.py:render_inline")
+    assert context.related_pages[0].script_sha256
+    assert context.related_pages[0].inline_renderer_sha256
+    assert context.view_sync
+    assert context.view_sync["schema"] == "agilab.notebook_view_sync.v1"
+    assert context.view_sync["related_page_modules"] == ["view_demo"]
+    sync_kinds = {source["kind"] for source in context.view_sync["sources"]}
+    assert {
+        "workspace_app_settings",
+        "source_app_settings",
+        "notebook_export_manifest",
+        "analysis_page_script",
+        "analysis_page_inline_renderer",
+    } <= sync_kinds
+
+
+def test_notebook_export_view_sync_detects_changed_analysis_page_source(tmp_path):
+    pages_root = tmp_path / "apps-pages"
+    page_script = pages_root / "view_demo" / "src" / "view_demo" / "view_demo.py"
+    page_script.parent.mkdir(parents=True, exist_ok=True)
+    page_script.write_text("print('page v1')\n", encoding="utf-8")
+    page_script.with_name("notebook_inline.py").write_text(
+        "def render_inline(*, page, record, export_payload):\n    return f'inline:{page}'\n",
+        encoding="utf-8",
+    )
+
+    source_app = tmp_path / "apps" / "demo_project"
+    source_settings = source_app / "src" / "app_settings.toml"
+    source_settings.parent.mkdir(parents=True, exist_ok=True)
+    source_settings.write_text("[pages]\nview_module=['view_demo']\n", encoding="utf-8")
+    (source_app / "notebook_export.toml").write_text(
+        """
+[notebook_export]
+
+[[notebook_export.related_pages]]
+module = "view_demo"
+label = "Demo Analysis"
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    workspace_settings = tmp_path / ".agilab" / "apps" / "demo_project" / "app_settings.toml"
+    workspace_settings.parent.mkdir(parents=True, exist_ok=True)
+    workspace_settings.write_text("[pages]\nview_module=['view_demo']\n", encoding="utf-8")
+
+    env = SimpleNamespace(
+        AGILAB_PAGES_ABS=pages_root,
+        active_app=source_app,
+        app_settings_file=workspace_settings,
+        resolve_user_app_settings_file=lambda app_name, ensure_exists=False: workspace_settings,
+        find_source_app_settings_file=lambda app_name: source_settings,
+        read_agilab_path=lambda: tmp_path,
+    )
+    export_dir = tmp_path / "export" / "demo_project"
+    export_dir.mkdir(parents=True, exist_ok=True)
+    toml_path = export_dir / "lab_stages.toml"
+    context = pipeline_editor.build_notebook_export_context(
+        env,
+        Path("demo_project"),
+        toml_path,
+        project_name="demo_project",
+    )
+    pipeline_editor.toml_to_notebook({"demo_project": [{"C": "print('stage')\n"}]}, toml_path, export_context=context)
+
+    notebook_path = toml_path.with_suffix(".ipynb")
+    manifest = json.loads(notebook_export_support.notebook_export_manifest_path(notebook_path).read_text(encoding="utf-8"))
+    assert manifest["view_sync"]["schema"] == "agilab.notebook_view_sync.v1"
+    assert manifest["related_pages"][0]["script_sha256"]
+    assert manifest["related_pages"][0]["inline_renderer_sha256"]
+    assert notebook_export_support.verify_notebook_export_manifest(notebook_path)["ok"] is True
+
+    page_script.write_text("print('page v2')\n", encoding="utf-8")
+    verification = notebook_export_support.verify_notebook_export_manifest(notebook_path)
+
+    assert verification["ok"] is False
+    sync_check = next(check for check in verification["checks"] if check["id"] == "view_sync_sources")
+    assert sync_check["status"] == "fail"
+    changed_sources = sync_check["details"]["changed_sources"]
+    assert any(source["kind"] == "analysis_page_script" and source["module"] == "view_demo" for source in changed_sources)
+    sync_status = notebook_export_support.notebook_view_sync_status(notebook_path)
+    assert sync_status["state"] == "source_changed"
+    assert sync_status["source_changed"] is True
+    assert sync_status["notebook_changed"] is False
 
 
 @pytest.mark.parametrize(
@@ -4080,6 +4163,10 @@ def test_verify_notebook_export_manifest_detects_tampered_stage_source(tmp_path)
     checks = {check["id"]: check for check in verification["checks"]}
     assert checks["notebook_sha256"]["status"] == "pass"
     assert checks["stage_source_0"]["status"] == "fail"
+    sync_status = notebook_export_support.notebook_view_sync_status(notebook_path)
+    assert sync_status["state"] == "notebook_changed"
+    assert sync_status["notebook_changed"] is True
+    assert sync_status["source_changed"] is False
 
 
 def test_notebook_helper_re_resolves_stale_analysis_page_paths_with_agi_env_and_agi_pages(


### PR DESCRIPTION
## Summary
- synchronize ANALYSIS page project-notebook state with notebook export support
- add regression coverage for project notebook modification tracking
- refresh the ANALYSIS page maintenance memory note for the touched contract

## Validation
- `./dev scope --staged`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --staged`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_ui_pages.py test/test_analysis_page_helpers.py test/test_pipeline_editor.py`
- `uv --preview-features extra-build-dependencies run python tools/maintenance_memory.py check --files src/agilab/pages/4_ANALYSIS.py`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui`
