### PR TITLE
[codex] Harden agi-env audit findings

### DIFF
--- a/src/agilab/core/agi-env/README.md
+++ b/src/agilab/core/agi-env/README.md
@@ -28,6 +28,14 @@ pip install agi-gui
 - Resolve workspace paths consistently across local and shared installs.
 - Centralize small utilities used by managers and worker packaging.
 
+## Compatibility modules
+
+Top-level modules such as `agi_env.agi_env`, `agi_env.pagelib`, and
+`agi_env.data_archive_support` are compatibility shims for existing external
+imports. New internal code should import the classified implementation modules
+under `agi_env.runtime`, `agi_env.project`, `agi_env.ui`, `agi_env.shares`,
+`agi_env.source`, or `agi_env.integrations`.
+
 ## Repository
 
 - Source: https://github.com/ThalesGroup/agilab/tree/main/src/agilab/core/agi-env

--- a/src/agilab/core/agi-env/src/agi_env/compat/module_shim.py
+++ b/src/agilab/core/agi-env/src/agi_env/compat/module_shim.py
@@ -6,6 +6,7 @@ import importlib
 import importlib.util
 import runpy
 import sys
+from pathlib import Path
 from types import ModuleType
 
 
@@ -59,7 +60,7 @@ def _execute_target_in_current_module(current_name: str, target_name: str) -> Mo
     current_module.__dict__["__file__"] = spec.origin
     current_module.__dict__["__package__"] = target_package
     source = compile(
-        open(spec.origin, encoding="utf-8").read(),
+        Path(spec.origin).read_text(encoding="utf-8"),
         spec.origin,
         "exec",
     )

--- a/src/agilab/core/agi-env/src/agi_env/project/app_args.py
+++ b/src/agilab/core/agi-env/src/agi_env/project/app_args.py
@@ -10,11 +10,10 @@ import tomllib
 
 from pydantic import BaseModel, ValidationError
 
-from agi_env.app_settings_support import prepare_app_settings_for_write
+from agi_env.project.app_settings_support import prepare_app_settings_for_write
+from agi_env.runtime.agi_logger import AgiLogger
 
 TModel = TypeVar("TModel", bound=BaseModel)
-
-from agi_env.agi_logger import AgiLogger
 
 logger = AgiLogger.get_logger(__name__)
 

--- a/src/agilab/core/agi-env/src/agi_env/project/app_settings_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/project/app_settings_support.py
@@ -6,7 +6,7 @@ import shutil
 from pathlib import Path
 from typing import Any, Callable
 
-from agi_env.env_config_support import clean_envar_value
+from agi_env.runtime.env_config_support import clean_envar_value
 
 APP_SETTINGS_META_KEY = "__meta__"
 APP_SETTINGS_SCHEMA = "agilab.app_settings.v1"

--- a/src/agilab/core/agi-env/src/agi_env/project/data_archive_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/project/data_archive_support.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import importlib
 import os
 import traceback
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Any, Callable
 
 import py7zr
@@ -150,6 +150,39 @@ def _archive_size_mb(archive_path: Path) -> float | None:
         return None
 
 
+def _archive_member_names(archive: Any) -> list[str] | None:
+    getnames = getattr(archive, "getnames", None)
+    if not callable(getnames):
+        return None
+    return [str(name) for name in getnames()]
+
+
+def _archive_member_target(dest: Path, member_name: str) -> Path:
+    normalized = member_name.replace("\\", "/")
+    member_path = PurePosixPath(normalized)
+    return (dest / Path(*member_path.parts)).resolve()
+
+
+def _validate_archive_members_stay_within_dest(archive: Any, dest: Path) -> None:
+    """Reject archive entries that would escape ``dest`` before extraction."""
+
+    member_names = _archive_member_names(archive)
+    if member_names is None:
+        # Production py7zr exposes getnames(); this compatibility branch keeps
+        # lightweight test doubles working while real archives are preflighted.
+        return
+
+    resolved_dest = dest.resolve()
+    for member_name in member_names:
+        posix_member = PurePosixPath(member_name.replace("\\", "/"))
+        windows_member = PureWindowsPath(member_name)
+        if posix_member.is_absolute() or windows_member.is_absolute() or windows_member.drive:
+            raise RuntimeError(f"Unsafe archive member path in '{member_name}'")
+        target = _archive_member_target(resolved_dest, member_name)
+        if not target.is_relative_to(resolved_dest):
+            raise RuntimeError(f"Unsafe archive member path in '{member_name}'")
+
+
 def _write_dataset_stamp(archive_path: Path, stamp_path: Path) -> None:
     try:
         stamp_path.write_text(str(archive_path), encoding="utf-8")
@@ -272,6 +305,7 @@ def unzip_data(
                     f"Starting dataset extraction: {archive_path}{size_hint} -> {dataset} "
                     "(this can take a moment; please wait)."
                 )
+            _validate_archive_members_stay_within_dest(archive, dest)
             archive.extractall(path=dest)
         if verbose > 1:
             logger.info(f"Extracted '{archive_path}' to '{dest}'.")

--- a/src/agilab/core/agi-env/src/agi_env/project/worker_source_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/project/worker_source_support.py
@@ -7,7 +7,7 @@ import logging
 from pathlib import Path
 from typing import Callable
 
-from agi_env.source_analysis_support import extract_base_info, get_import_mapping
+from agi_env.source.source_analysis_support import extract_base_info, get_import_mapping
 
 
 def get_base_classes(

--- a/src/agilab/core/agi-env/src/agi_env/runtime/agi_env.py
+++ b/src/agilab/core/agi-env/src/agi_env/runtime/agi_env.py
@@ -49,58 +49,58 @@ import ctypes
 from ctypes import wintypes
 import importlib.util
 from threading import RLock
-from agi_env.app_settings_support import (
+from agi_env.project.app_settings_support import (
     app_settings_aliases,
     app_settings_source_roots,
     candidate_app_settings_path,
     find_source_app_settings_file,
     resolve_user_app_settings_file,
 )
-from agi_env.env_config_support import (
+from agi_env.runtime.env_config_support import (
     load_dotenv_values as _load_dotenv_values,
     write_env_updates,
 )
-from agi_env.agi_env_app_switch_support import change_app as _agi_env_change_app
-from agi_env.agi_env_execution_methods import (
+from agi_env.runtime.agi_env_app_switch_support import change_app as _agi_env_change_app
+from agi_env.runtime.agi_env_execution_methods import (
     run as _agi_env_run,
     run_agi as _agi_env_run_agi,
     run_async as _agi_env_run_async,
     run_bg as _agi_env_run_bg,
 )
-from agi_env.agi_env_instance_initialization import initialize_agi_env_instance
-from agi_env.agi_env_meta_support import AgiEnvMeta as _AgiEnvMeta
-from agi_env.env_runtime_initialization_support import initialize_app_runtime
-from agi_env.hook_support import resolve_worker_hook, select_hook
-from agi_env.host_runtime_support import (
+from agi_env.runtime.agi_env_instance_initialization import initialize_agi_env_instance
+from agi_env.runtime.agi_env_meta_support import AgiEnvMeta as _AgiEnvMeta
+from agi_env.runtime.env_runtime_initialization_support import initialize_app_runtime
+from agi_env.runtime.hook_support import resolve_worker_hook, select_hook
+from agi_env.runtime.host_runtime_support import (
     check_internet_connectivity,
     create_symlink as _create_symlink,
     is_local_ip,
 )
-from agi_env.installation_support import (
+from agi_env.runtime.installation_support import (
     installation_marker_path,
     locate_agilab_installation_path,
     read_agilab_installation_marker,
 )
-from agi_env.runtime_bootstrap_support import parse_int_env_value
-from agi_env.worker_runtime_support import configure_worker_runtime
-from agi_env.windows_link_support import (
+from agi_env.runtime.runtime_bootstrap_support import parse_int_env_value
+from agi_env.runtime.worker_runtime_support import configure_worker_runtime
+from agi_env.runtime.windows_link_support import (
     create_junction_windows as _create_junction_windows,
     create_symlink_windows as _create_symlink_windows,
     has_admin_rights as _has_admin_rights,
 )
-from agi_env.process_support import (
+from agi_env.runtime.process_support import (
     build_subprocess_env,
     fix_windows_drive as _fix_windows_drive,
     normalize_path,
 )
-from agi_env.repository_support import (
+from agi_env.runtime.repository_support import (
     collect_pythonpath_entries as build_pythonpath_entries,
     configure_pythonpath as apply_pythonpath_entries,
     dedupe_existing_paths,
     get_apps_repository_root as resolve_apps_repository_root,
     resolve_package_root,
 )
-from agi_env.share_runtime_support import (
+from agi_env.shares.share_runtime_support import (
     is_valid_ip as is_valid_ipv4_address,
     mode_to_int,
     mode_to_str,
@@ -108,36 +108,36 @@ from agi_env.share_runtime_support import (
     share_target_name,
     python_supports_free_threading,
 )
-from agi_env.rename_gitignore_support import (
+from agi_env.project.rename_gitignore_support import (
     is_relative_to as is_path_relative_to,
     load_gitignore_spec,
     replace_text_content,
 )
-from agi_env.content_renamer_support import ContentRenamer as BaseContentRenamer
-from agi_env.bootstrap_support import coerce_active_app_request
-from agi_env.source_analysis_support import (
+from agi_env.project.content_renamer_support import ContentRenamer as BaseContentRenamer
+from agi_env.runtime.bootstrap_support import coerce_active_app_request
+from agi_env.source.source_analysis_support import (
     extract_base_info as extract_ast_base_info,
     get_full_attribute_name as build_full_attribute_name,
     get_import_mapping as build_import_mapping,
 )
-from agi_env.project_initialization_support import (
+from agi_env.project.project_initialization_support import (
     copy_file_if_missing,
     discover_projects,
     initialize_app_files,
     initialize_resources,
 )
-from agi_env.worker_source_support import (
+from agi_env.project.worker_source_support import (
     get_base_classes as discover_base_classes,
     get_base_worker_cls as discover_base_worker_cls,
 )
-from agi_env.project_clone_support import (
+from agi_env.project.project_clone_support import (
     cleanup_rename as cleanup_project_rename,
     clone_directory as clone_project_directory,
     clone_project as clone_app_project,
     copy_existing_projects as copy_missing_projects,
     create_rename_map as build_clone_rename_map,
 )
-from agi_env.data_archive_support import unzip_data as extract_dataset_archive
+from agi_env.project.data_archive_support import unzip_data as extract_dataset_archive
 try:
     import pwd
 except ImportError:  # Windows
@@ -163,7 +163,7 @@ if FormattedTB is not None:
 
     sys.excepthook = FormattedTB(**_tb_kwargs)
 
-from agi_env.agi_logger import AgiLogger
+from agi_env.runtime.agi_logger import AgiLogger
 
 logger = AgiLogger.get_logger(__name__)
 _LOGGING_MODULE = logging

--- a/src/agilab/core/agi-env/src/agi_env/runtime/agi_env_execution_methods.py
+++ b/src/agilab/core/agi-env/src/agi_env/runtime/agi_env_execution_methods.py
@@ -4,7 +4,7 @@ import importlib
 import sys
 from pathlib import Path
 
-from agi_env.execution_support import (
+from agi_env.runtime.execution_support import (
     run as run_command_in_env,
     run_agi as run_agi_snippet,
     run_async as run_command_async,

--- a/src/agilab/core/agi-env/src/agi_env/runtime/agi_env_instance_initialization.py
+++ b/src/agilab/core/agi-env/src/agi_env/runtime/agi_env_instance_initialization.py
@@ -10,9 +10,9 @@ import sys
 from pathlib import Path
 from typing import Callable
 
-from agi_env.agi_logger import AgiLogger
-from agi_env.app_provider_registry import installed_app_project_paths, resolve_app_runtime_target
-from agi_env.bootstrap_support import (
+from agi_env.runtime.agi_logger import AgiLogger
+from agi_env.project.app_provider_registry import installed_app_project_paths, resolve_app_runtime_target
+from agi_env.runtime.bootstrap_support import (
     can_link_repo_apps,
     resolve_active_app_selection,
     resolve_builtin_apps_path,
@@ -21,20 +21,20 @@ from agi_env.bootstrap_support import (
     resolve_package_dir,
     resolve_requested_apps_path,
 )
-from agi_env.env_config_support import clean_envar_value
-from agi_env.package_layout_support import (
+from agi_env.runtime.env_config_support import clean_envar_value
+from agi_env.runtime.package_layout_support import (
     resolve_agilab_package_context,
     resolve_agilab_source_root_from_module_file,
     resolve_package_dir_from_module_file,
     resolve_package_layout,
     resolve_resource_root,
 )
-from agi_env.runtime_bootstrap_support import (
+from agi_env.runtime.runtime_bootstrap_support import (
     parse_int_env_value,
     resolve_share_runtime_config,
     sync_repository_apps,
 )
-from agi_env.share_mount_support import (
+from agi_env.shares.share_mount_support import (
     cluster_enabled_from_settings as resolve_cluster_enabled_from_settings,
     resolve_share_path as resolve_runtime_share_path,
 )

--- a/src/agilab/core/agi-env/src/agi_env/runtime/bootstrap_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/runtime/bootstrap_support.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Sequence
 
-from agi_env.app_provider_registry import resolve_app_runtime_target, resolve_installed_app_project
+from agi_env.project.app_provider_registry import resolve_app_runtime_target, resolve_installed_app_project
 
 
 @dataclass(frozen=True)

--- a/src/agilab/core/agi-env/src/agi_env/runtime/env_runtime_initialization_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/runtime/env_runtime_initialization_support.py
@@ -3,10 +3,10 @@
 from pathlib import Path
 from typing import Callable, Mapping, MutableMapping
 
-from agi_env.connector_registry import resolve_connector_root
-from agi_env.credential_store_support import read_cluster_credentials
-from agi_env.defaults import get_default_openai_model
-from agi_env.env_config_support import clean_envar_value
+from agi_env.integrations.connector_registry import resolve_connector_root
+from agi_env.integrations.credential_store_support import read_cluster_credentials
+from agi_env.runtime.defaults import get_default_openai_model
+from agi_env.runtime.env_config_support import clean_envar_value
 
 
 def initialize_app_runtime(

--- a/src/agilab/core/agi-env/src/agi_env/runtime/execution_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/runtime/execution_support.py
@@ -13,8 +13,8 @@ import traceback
 from pathlib import Path
 from typing import Any, Awaitable, Callable
 
-from agi_env.agi_logger import AgiLogger
-from agi_env.process_support import (
+from agi_env.runtime.agi_logger import AgiLogger
+from agi_env.runtime.process_support import (
     apply_inline_path_export,
     build_subprocess_env,
     command_failure_hint,

--- a/src/agilab/core/agi-env/src/agi_env/runtime/hook_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/runtime/hook_support.py
@@ -10,7 +10,7 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Iterable
 
-from agi_env.package_layout_support import (
+from agi_env.runtime.package_layout_support import (
     RuntimePackageSpec,
     load_runtime_package_specs,
     resolve_agilab_source_root_from_module_file,

--- a/src/agilab/core/agi-env/src/agi_env/runtime/installation_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/runtime/installation_support.py
@@ -7,7 +7,7 @@ import os
 from pathlib import Path
 from typing import Callable
 
-from agi_env.package_layout_support import (
+from agi_env.runtime.package_layout_support import (
     resolve_agilab_source_root_from_module_file,
     resolve_package_dir_from_module_file,
 )

--- a/src/agilab/core/agi-env/src/agi_env/source/snippet_contract.py
+++ b/src/agilab/core/agi-env/src/agi_env/source/snippet_contract.py
@@ -52,7 +52,7 @@ def snippet_contract_lines(
         lines.append(f"# generator: {generator}")
     lines.extend(
         [
-            "from agi_env.snippet_contract import require_supported_snippet_api",
+            "from agi_env.source.snippet_contract import require_supported_snippet_api",
             "",
             f'{SNIPPET_API_NAME} = "{CURRENT_SNIPPET_API}"',
             f"require_supported_snippet_api({SNIPPET_API_NAME})",

--- a/src/agilab/core/agi-env/src/agi_env/ui/pagelib.py
+++ b/src/agilab/core/agi-env/src/agi_env/ui/pagelib.py
@@ -63,7 +63,7 @@ from .ui_support import (
     store_last_active_app,
     with_anchor as _with_anchor,
 )
-from agi_env.source_analysis_support import (
+from agi_env.source.source_analysis_support import (
     get_class_methods as extract_class_methods,
     get_classes_name as extract_class_names,
     get_functions_and_attributes,

--- a/src/agilab/core/agi-env/src/agi_env/ui/pagelib_navigation_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/ui/pagelib_navigation_support.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, MutableMapping, Sequence
 
-from agi_env.app_provider_registry import app_name_aliases
+from agi_env.project.app_provider_registry import app_name_aliases
 
 
 SessionStateLike = MutableMapping[str, Any]

--- a/src/agilab/core/agi-env/src/agi_env/ui/streamlit_args.py
+++ b/src/agilab/core/agi-env/src/agi_env/ui/streamlit_args.py
@@ -9,8 +9,8 @@ from typing import Any, Callable, Literal, get_args, get_origin
 from pydantic import BaseModel, ValidationError
 from annotated_types import Ge, Le, MultipleOf
 
-from agi_env._optional_ui import require_streamlit
-from agi_env.app_args import prefer_persisted_value
+from agi_env.ui._optional_ui import require_streamlit
+from agi_env.project.app_args import prefer_persisted_value
 
 st = require_streamlit()
 
@@ -54,7 +54,7 @@ def load_args_state(
 def diagnose_data_directory(directory: Path) -> str | None:
     """Proxy to the pagelib diagnosis helper without importing Streamlit UI code eagerly."""
 
-    from agi_env.pagelib import diagnose_data_directory as _diagnose_data_directory
+    from agi_env.ui.pagelib import diagnose_data_directory as _diagnose_data_directory
 
     return _diagnose_data_directory(directory)
 

--- a/src/agilab/core/agi-env/src/agi_env/ui/ui_docs_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/ui/ui_docs_support.py
@@ -7,7 +7,7 @@ import sys
 import tomllib
 from pathlib import Path
 
-from agi_env.package_layout_support import resolve_package_dir_from_module_file
+from agi_env.runtime.package_layout_support import resolve_package_dir_from_module_file
 
 
 ONLINE_DOCS_INDEX = "https://thalesgroup.github.io/agilab/index.html"

--- a/src/agilab/core/agi-env/test/test_agi_env_surface_contract.py
+++ b/src/agilab/core/agi-env/test/test_agi_env_surface_contract.py
@@ -7,6 +7,7 @@ from pathlib import Path
 AGI_ENV_MAX_LINES = 1000
 AGI_ENV_IMPORT_ALIAS_BUDGET = 30
 AGI_ENV_INIT_FUNCTION_BUDGET = 100
+AGI_ENV_PACKAGE_ROOT = Path(__file__).resolve().parents[1] / "src" / "agi_env"
 
 
 def test_agi_env_module_stays_below_review_surface_budget() -> None:
@@ -28,6 +29,25 @@ def test_agi_env_initialization_phases_stay_reviewable() -> None:
         init_module.read_text(encoding="utf-8"),
         max_lines=AGI_ENV_INIT_FUNCTION_BUDGET,
     )
+
+    assert offenders == {}
+
+
+def test_classified_agi_env_modules_do_not_import_legacy_shims() -> None:
+    legacy_modules = _legacy_shim_module_names()
+    offenders: dict[str, list[str]] = {}
+
+    for module_path in sorted(AGI_ENV_PACKAGE_ROOT.rglob("*.py")):
+        if module_path.parent == AGI_ENV_PACKAGE_ROOT or "compat" in module_path.parts:
+            continue
+        source = module_path.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(module_path))
+        for node in ast.walk(tree):
+            imported_module = _imported_legacy_module(node, legacy_modules)
+            if imported_module is None:
+                continue
+            relative_path = module_path.relative_to(AGI_ENV_PACKAGE_ROOT).as_posix()
+            offenders.setdefault(relative_path, []).append(f"{node.lineno}: {imported_module}")
 
     assert offenders == {}
 
@@ -54,3 +74,25 @@ def _function_lengths_over_budget(source: str, *, max_lines: int) -> dict[str, i
         if line_count > max_lines:
             offenders[node.name] = line_count
     return offenders
+
+
+def _legacy_shim_module_names() -> set[str]:
+    module_names: set[str] = set()
+    for module_path in sorted(AGI_ENV_PACKAGE_ROOT.glob("*.py")):
+        source = module_path.read_text(encoding="utf-8")
+        if "activate_compat_module" not in source or "_TARGET_MODULE" not in source:
+            continue
+        module_names.add(f"agi_env.{module_path.stem}")
+    return module_names
+
+
+def _imported_legacy_module(node: ast.AST, legacy_modules: set[str]) -> str | None:
+    if isinstance(node, ast.ImportFrom):
+        if node.module in legacy_modules:
+            return node.module
+        return None
+    if isinstance(node, ast.Import):
+        for alias in node.names:
+            if alias.name in legacy_modules:
+                return alias.name
+    return None

--- a/src/agilab/core/agi-env/test/test_data_archive_support.py
+++ b/src/agilab/core/agi-env/test/test_data_archive_support.py
@@ -65,6 +65,48 @@ def test_unzip_data_raises_runtime_error_on_extract_failure(tmp_path: Path):
         )
 
 
+def test_unzip_data_rejects_archive_member_path_traversal(tmp_path: Path):
+    archive = tmp_path / "demo.7z"
+    archive.write_bytes(b"7z")
+    logger = mock.Mock()
+    extracted = False
+
+    class _UnsafeSevenZip:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def getnames(self):
+            return ["dataset/good.csv", "../evil.txt"]
+
+        def extractall(self, path):
+            nonlocal extracted
+            extracted = True
+
+    with pytest.raises(RuntimeError, match="Unsafe archive member path"):
+        unzip_data(
+            archive,
+            extract_to="dataset/demo",
+            app_data_rel="demo",
+            agi_share_path_abs=tmp_path / "share",
+            user=Path.home().name,
+            home_abs=Path.home(),
+            verbose=0,
+            logger=logger,
+            force_extract=True,
+            ensure_dir_fn=lambda path: Path(path).mkdir(parents=True, exist_ok=True) or Path(path),
+            sevenzip_file_cls=_UnsafeSevenZip,
+            rmtree_fn=lambda *_a, **_k: None,
+        )
+
+    assert extracted is False
+
+
 def test_py7zr_archive_error_resolution_handles_missing_package_exceptions_attr():
     class _ArchiveError(Exception):
         pass

--- a/src/agilab/core/agi-env/test/test_streamlit_args.py
+++ b/src/agilab/core/agi-env/test/test_streamlit_args.py
@@ -158,7 +158,7 @@ def test_diagnose_data_directory_uses_lazy_pagelib_import(tmp_path, monkeypatch)
     fake_module = SimpleNamespace(
         diagnose_data_directory=lambda directory: f"diagnosed:{Path(directory).name}"
     )
-    monkeypatch.setitem(sys.modules, "agi_env.pagelib", fake_module)
+    monkeypatch.setitem(sys.modules, "agi_env.ui.pagelib", fake_module)
 
     assert streamlit_args.diagnose_data_directory(target) == "diagnosed:dataset"
 


### PR DESCRIPTION
## Summary

- Harden `agi-env` dataset archive extraction by preflighting 7z member paths before `extractall`.
- Move classified `agi-env` implementation imports away from legacy top-level compatibility shims.
- Keep top-level shims for external compatibility, document the internal import rule, and add a regression guard to prevent classified modules from importing those shims again.
- Replace the compat module loader's raw `open(...).read()` with `Path.read_text()`.

## Root Cause

The audit correctly identified that the package still carried many compatibility shims. Deleting all of them in one change would break existing external and repo compatibility imports, so this PR finishes the safe internal migration first and locks it with a test. The archive extraction path also relied on py7zr's current traversal protection; this PR adds an explicit AGILAB-side preflight guard.

## Validation

- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' src/agilab/core/agi-env/test/test_data_archive_support.py src/agilab/core/agi-env/test/test_agi_env_surface_contract.py`
- `uv --preview-features extra-build-dependencies run --no-sync pytest -q -o addopts='' src/agilab/core/agi-env/test`
- `uv --preview-features extra-build-dependencies run --extra ui pytest -q -o addopts='' test/test_app_args.py test/test_app_args_form_normalization.py src/agilab/core/agi-env/test/test_app_args.py src/agilab/core/agi-env/test/test_app_settings_support.py src/agilab/core/agi-env/test/test_data_archive_support.py src/agilab/core/agi-env/test/test_worker_source_support.py test/test_agi_env.py src/agilab/core/agi-env/test/test_agi_env.py`
- `uv --preview-features extra-build-dependencies run --extra dev ruff check --ignore F401 $(git diff --name-only -- '*.py')`
- `uv --preview-features extra-build-dependencies run python -m compileall -q src/agilab/core/agi-env/src/agi_env`
- `git diff --cached --check`
- `./dev scope --staged`