### PR TITLE
[codex] Harden cluster command execution cleanup

### DIFF
--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_local_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_local_support.py
@@ -1,6 +1,7 @@
 import getpass
 import logging
 import os
+import shlex
 import shutil
 import stat
 import subprocess
@@ -114,6 +115,16 @@ DEPENDENCY_MODULE_ALIASES: dict[str, tuple[str, ...]] = {
     "pyyaml": ("yaml",),
     "scikit-learn": ("sklearn",),
 }
+
+
+def _shell_arg(value: Any) -> str:
+    if isinstance(value, Path):
+        return shlex.quote(value.as_posix())
+    return shlex.quote(str(value))
+
+
+def _shell_words(value: Any) -> str:
+    return " ".join(shlex.quote(part) for part in shlex.split(str(value), posix=True))
 
 
 def _latest_glob_match(root: Path, pattern: str) -> Path | None:
@@ -1608,9 +1619,9 @@ async def deploy_local_worker(
 
     post_install_cmd = (
         f"{_local_worker_post_install_env_prefix(agi_cls)}"
-        f'{uv_worker} run --no-sync --project "{wenv_abs}" '
-        f"--python {pyvers_worker} python -m {env.post_install_rel} "
-        f'"{env.active_app}"'
+        f"{_shell_words(uv_worker)} run --no-sync --project {_shell_arg(wenv_abs)} "
+        f"--python {_shell_arg(pyvers_worker)} python -m {_shell_arg(env.post_install_rel)} "
+        f"{_shell_arg(env.active_app)}"
     )
 
     started_at = time.perf_counter()

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_prepare_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_prepare_support.py
@@ -38,7 +38,7 @@ async def _local_uv_python_available(
     run_fn: Callable[..., Any],
 ) -> bool:
     try:
-        await run_fn(f"{uv} python find {pyvers}", cwd)
+        await run_fn(f"{uv} python find {shlex.quote(str(pyvers))}", cwd)
     except RuntimeError:
         return False
     return True
@@ -95,7 +95,7 @@ def _remote_python_makedirs_command(uv: str, path: Path) -> str:
 
 async def uninstall_modules(agi_cls: Any, env: AgiEnv, *, run_fn: Callable[..., Any] = AgiEnv.run, log: Any = logger) -> None:
     for module in agi_cls._module_to_clean:
-        cmd = f"{env.uv} pip uninstall {module} -y"
+        cmd = f"{env.uv} pip uninstall {shlex.quote(str(module))} -y"
         log.info(f"Executing: {cmd}")
         await run_fn(cmd, agi_cls.env.agi_env)
     agi_cls._module_to_clean.clear()
@@ -184,7 +184,7 @@ async def prepare_local_env(
             log.info("Python interpreter '%s' is already available to uv; skipping install.", pyvers)
         else:
             try:
-                await run_fn(f"{uv} python install {pyvers}", wenv_abs.parent)
+                await run_fn(f"{uv} python install {shlex.quote(str(pyvers))}", wenv_abs.parent)
             except RuntimeError as exc:
                 if "No download found for request" in str(exc):
                     log.warning(

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_remote_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_remote_support.py
@@ -574,6 +574,7 @@ async def deploy_remote_worker(
     wenv_rel = env.wenv_rel
     dist_abs = env.dist_abs
     pyvers = env.pyvers_worker
+    # Operator-managed shell prefix; trusted input prepended verbatim.
     cmd_prefix = env.envars.get(f"{ip}_CMD_PREFIX", "")
     uv = _remote_tool(cmd_prefix, env.uv_worker)
 

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime/cleanup_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime/cleanup_support.py
@@ -3,6 +3,7 @@ import getpass
 import logging
 import os
 import runpy
+import shlex
 import shutil
 import socket
 import stat
@@ -21,6 +22,16 @@ from agi_env import AgiEnv
 logger = logging.getLogger(__name__)
 REMOVE_DIR_RETRY_EXCEPTIONS = (OSError, shutil.Error)
 CMD_PREFIX_LOOKUP_EXCEPTIONS = (ConnectionError, OSError, RuntimeError, TimeoutError)
+
+
+def _remote_arg(value: Any) -> str:
+    if isinstance(value, Path):
+        return shlex.quote(value.as_posix())
+    return shlex.quote(str(value))
+
+
+def _remote_words(value: Any) -> str:
+    return " ".join(shlex.quote(part) for part in shlex.split(str(value), posix=True))
 
 
 async def _remote_cmd_prefix(
@@ -112,22 +123,22 @@ async def kill_processes(
         ip,
         detect_export_cmd_fn=detect_export_cmd_fn,
     )
-    kill_prefix = f"{cmd_prefix}{uv} run --no-sync python"
+    kill_prefix = f"{cmd_prefix}{_remote_words(uv)} run --no-sync python"
     if env.is_local(ip):
         if not cli_abs.exists():
             copy_fn(resolve_worker_cli_path(env), cli_abs)
         if force:
-            exclude_arg = f" {current_pid}" if current_pid else ""
-            cmds.append(f"{kill_prefix} '{cli_abs}' kill{exclude_arg}")
+            exclude_arg = f" {_remote_arg(current_pid)}" if current_pid else ""
+            cmds.append(f"{kill_prefix} {_remote_arg(cli_abs)} kill{exclude_arg}")
     elif force:
-        cmds.append(f"{kill_prefix} '{cli_rel.as_posix()}' kill")
+        cmds.append(f"{kill_prefix} {_remote_arg(cli_rel)} kill")
 
     last_res = None
     for cmd in cmds:
         cwd = str(env.wenv_abs)
         if env.is_local(ip):
             if env.debug:
-                sys_module.argv = cmd.split("python ")[1].split(" ")
+                sys_module.argv = shlex.split(cmd.split("python ", 1)[1], posix=True)
                 run_path_fn(sys_module.argv[0], run_name="__main__")
             else:
                 await run_fn(cmd, cwd)
@@ -226,5 +237,9 @@ async def clean_dirs(
     cmd_prefix = env.envars.get(f"{ip}_CMD_PREFIX", "")
     wenv = env.wenv_rel
     cli = wenv.parent / "cli.py"
-    cmd = f"{cmd_prefix}{uv} run --no-sync -p {env.python_version} python {cli.as_posix()} clean {wenv}"
+    cmd = (
+        f"{cmd_prefix}{_remote_words(uv)} run --no-sync "
+        f"-p {_remote_arg(env.python_version)} python "
+        f"{_remote_arg(cli)} clean {_remote_arg(wenv)}"
+    )
     await agi_cls.exec_ssh(ip, cmd)

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime/runtime_distribution_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime/runtime_distribution_support.py
@@ -81,6 +81,10 @@ def _remote_path(value: Path | str) -> str:
     return shlex.quote(str(value))
 
 
+def _remote_words(value: Any) -> str:
+    return " ".join(shlex.quote(part) for part in shlex.split(str(value), posix=True))
+
+
 def _remote_dask_worker_command(
     *,
     cmd_prefix: str,
@@ -317,7 +321,7 @@ async def run_local(
     else:
         uv_worker = getattr(env, "uv_worker", env.uv)
         pyvers_worker = getattr(env, "pyvers_worker", None)
-        python_selector = f" --python {pyvers_worker}" if pyvers_worker else ""
+        python_selector = f" --python {_remote_path(str(pyvers_worker))}" if pyvers_worker else ""
         manager_apps_path = _manager_apps_path(env)
         manager_app = _manager_app_name(env)
         # Use POSIX-style separators so the embedded ``Path(...)`` literal stays
@@ -329,20 +333,25 @@ async def run_local(
         )
         manager_app_expr = repr(manager_app)
         worker_args = _worker_startup_args(agi_cls)
+        worker_script = "\n".join(
+            [
+                "from pathlib import Path",
+                "from agi_env import AgiEnv",
+                "from agi_node.agi_dispatcher import  BaseWorker",
+                "import asyncio",
+                "async def main():",
+                f"  env = AgiEnv(apps_path={manager_apps_expr}, app={manager_app_expr}, verbose={env.verbose})",
+                f"  BaseWorker._new(env=env, mode={agi_cls._mode}, verbose={env.verbose}, args={worker_args})",
+                f"  res = await BaseWorker._run(env=env, mode={agi_cls._mode}, workers={agi_cls._workers}, args={agi_cls._args})",
+                "  print(res)",
+                "if __name__ == '__main__':",
+                "  asyncio.run(main())",
+            ]
+        )
         cmd = (
-            f"{uv_worker} run --preview-features python-upgrade --no-sync --project {env.wenv_abs}"
-            f"{python_selector} python -c \""
-            f"from pathlib import Path\n"
-            f"from agi_env import AgiEnv\n"
-            f"from agi_node.agi_dispatcher import  BaseWorker\n"
-            f"import asyncio\n"
-            f"async def main():\n"
-            f"  env = AgiEnv(apps_path={manager_apps_expr}, app={manager_app_expr}, verbose={env.verbose})\n"
-            f"  BaseWorker._new(env=env, mode={agi_cls._mode}, verbose={env.verbose}, args={worker_args})\n"
-            f"  res = await BaseWorker._run(env=env, mode={agi_cls._mode}, workers={agi_cls._workers}, args={agi_cls._args})\n"
-            f"  print(res)\n"
-            f"if __name__ == '__main__':\n"
-            f"  asyncio.run(main())\""
+            f"{_remote_words(uv_worker)} run --preview-features python-upgrade --no-sync "
+            f"--project {_remote_path(env.wenv_abs)}"
+            f"{python_selector} python -c {shlex.quote(worker_script)}"
         )
         res = await run_async_fn(cmd, env.wenv_abs)
 

--- a/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/build.py
+++ b/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/build.py
@@ -8,6 +8,7 @@ import sys
 import os
 import shutil
 import re
+import shlex
 import stat
 from pathlib import Path
 from zipfile import ZipFile
@@ -34,7 +35,6 @@ def _inject_shared_site_packages(*, source_file: str | Path = __file__) -> None:
 _inject_shared_site_packages()
 
 from agi_env import AgiEnv
-from agi_env import AgiLogger
 import warnings
 warnings.filterwarnings("ignore", category=SetuptoolsDeprecationWarning)
 
@@ -440,11 +440,19 @@ def _purge_top_level_ui_build_artifacts(app_root: Path, *, log: logging.Logger |
     return removed
 
 
-def _build_remove_decorators_command(worker_path: str) -> str:
-    return (
-        "uv -q run python -m agi_node.agi_dispatcher.pre_install remove_decorators "
-        f'--worker_path "{worker_path}" --verbose'
-    )
+def _build_remove_decorators_command(worker_path: str) -> list[str]:
+    return [
+        "uv",
+        "-q",
+        "run",
+        "python",
+        "-m",
+        "agi_node.agi_dispatcher.pre_install",
+        "remove_decorators",
+        "--worker_path",
+        worker_path,
+        "--verbose",
+    ]
 
 
 def _postprocess_bdist_egg_output(
@@ -453,14 +461,14 @@ def _postprocess_bdist_egg_output(
     out_dir: Path,
     links_created: list[Path],
     cleanup_links_fn=None,
-    os_system_fn=None,
+    subprocess_run_fn=None,
     zip_cls=None,
     log: logging.Logger | None = None,
 ) -> None:
     if cleanup_links_fn is None:
         cleanup_links_fn = cleanup_links
-    if os_system_fn is None:
-        os_system_fn = os.system  # ty: ignore[deprecated]
+    if subprocess_run_fn is None:
+        subprocess_run_fn = subprocess.run
     if zip_cls is None:
         zip_cls = ZipFile
     log = _runtime_logger(log)
@@ -468,8 +476,8 @@ def _postprocess_bdist_egg_output(
     _unpack_worker_eggs(dist_dir=out_dir / "dist", dest_src=dest_src, zip_cls=zip_cls, log=log)
 
     cmd = _build_remove_decorators_command(env.worker_path)
-    log.info(f"Stripping decorators via:\n  {cmd}")
-    os_system_fn(cmd)
+    log.info(f"Stripping decorators via:\n  {shlex.join(cmd)}")
+    subprocess_run_fn(cmd, check=True)
 
     if links_created:
         cleanup_links_fn(links_created)

--- a/src/agilab/core/test/test_agi_dispatcher_scripts.py
+++ b/src/agilab/core/test/test_agi_dispatcher_scripts.py
@@ -1865,11 +1865,22 @@ def test_cythonize_worker_extension_passes_quiet_directives_and_cache(tmp_path):
     ]
 
 
-def test_build_remove_decorators_command_quotes_worker_path():
-    command = build_mod._build_remove_decorators_command("workers/demo worker.py")
+def test_build_remove_decorators_command_keeps_worker_path_as_argv():
+    command = build_mod._build_remove_decorators_command("workers/demo worker'$.py")
 
     assert "remove_decorators" in command
-    assert '--worker_path "workers/demo worker.py"' in command
+    assert command == [
+        "uv",
+        "-q",
+        "run",
+        "python",
+        "-m",
+        "agi_node.agi_dispatcher.pre_install",
+        "remove_decorators",
+        "--worker_path",
+        "workers/demo worker'$.py",
+        "--verbose",
+    ]
 
 
 def test_postprocess_bdist_egg_output_unpacks_and_cleans_links(tmp_path):
@@ -1887,7 +1898,7 @@ def test_postprocess_bdist_egg_output_unpacks_and_cleans_links(tmp_path):
     env = SimpleNamespace(worker_path="workers/demo_worker.py")
     links_created = [tmp_path / "src" / "demo_worker" / "module_link"]
     cleanup_calls = []
-    os_calls = []
+    subprocess_calls = []
     log_lines = []
 
     build_mod._postprocess_bdist_egg_output(
@@ -1895,13 +1906,16 @@ def test_postprocess_bdist_egg_output_unpacks_and_cleans_links(tmp_path):
         out_dir=out_dir,
         links_created=links_created,
         cleanup_links_fn=lambda links: cleanup_calls.append(list(links)),
-        os_system_fn=lambda cmd: os_calls.append(cmd) or 0,
+        subprocess_run_fn=lambda cmd, check=False: subprocess_calls.append((cmd, check)),
         log=SimpleNamespace(info=lambda message: log_lines.append(message)),
     )
 
     assert (out_dir / "src" / "demo_worker" / "__init__.py").exists()
     assert any("mkdir" in line for line in log_lines)
-    assert os_calls and "remove_decorators" in os_calls[0]
+    assert subprocess_calls
+    assert subprocess_calls[0][0][6] == "remove_decorators"
+    assert subprocess_calls[0][0][8] == "workers/demo_worker.py"
+    assert subprocess_calls[0][1] is True
     assert cleanup_calls == [links_created]
 
 
@@ -3643,8 +3657,12 @@ def test_build_main_bdist_egg_unpacks_and_cleans_links(tmp_path, monkeypatch):
 
     cleanup_calls = []
     monkeypatch.setattr(build_mod, "cleanup_links", lambda links: cleanup_calls.append(list(links)))
-    os_calls = []
-    monkeypatch.setattr(build_mod.os, "system", lambda cmd: os_calls.append(cmd) or 0)
+    subprocess_calls = []
+    monkeypatch.setattr(
+        build_mod.subprocess,
+        "run",
+        lambda cmd, check=False: subprocess_calls.append((cmd, check)),
+    )
 
     build_mod.main(
         [
@@ -3663,7 +3681,8 @@ def test_build_main_bdist_egg_unpacks_and_cleans_links(tmp_path, monkeypatch):
     assert Path(DummyAgiEnv.init_args["active_app"]) == app_dir
     extracted = out_dir / "src" / "demo_worker" / "__init__.py"
     assert extracted.exists()
-    assert os_calls and "remove_decorators" in os_calls[0]
+    assert subprocess_calls and subprocess_calls[0][0][6] == "remove_decorators"
+    assert subprocess_calls[0][1] is True
     assert cleanup_calls and cleanup_calls[0] == links_created
 
 

--- a/src/agilab/core/test/test_agi_distributor_cleanup_support.py
+++ b/src/agilab/core/test/test_agi_distributor_cleanup_support.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import shlex
 from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
@@ -220,7 +221,7 @@ async def test_kill_processes_cleans_pid_files_and_handles_local_and_remote_path
     env = SimpleNamespace(
         uv="uv",
         wenv_abs=wenv_abs,
-        wenv_rel=Path("wenv/demo_worker"),
+        wenv_rel=Path("w env's/demo worker"),
         envars={},
         cluster_pck=cluster_pck,
         agi_cluster=str(tmp_path / "cluster-runtime"),
@@ -281,14 +282,19 @@ async def test_kill_processes_cleans_pid_files_and_handles_local_and_remote_path
 
     assert copied
     assert local_runs
-    assert any("cli.py' kill 999" in cmd for cmd, _cwd in local_runs)
+    local_argv = shlex.split(local_runs[0][0].split("python ", 1)[1], posix=True)
+    assert local_argv == [(wenv_parent / "cli.py").as_posix(), "kill", "999"]
     assert all(cwd == str(wenv_abs) for _cmd, cwd in local_runs)
-    assert remote_runs == [
-        (
-            "10.0.0.2",
-            'export PATH="$HOME/.local/bin:$PATH";uv run --no-sync python '
-            "'wenv/cli.py' kill",
-        )
+    assert len(remote_runs) == 1
+    assert remote_runs[0][0] == "10.0.0.2"
+    remote_argv = shlex.split(remote_runs[0][1].split(";", 1)[1], posix=True)
+    assert remote_argv == [
+        "uv",
+        "run",
+        "--no-sync",
+        "python",
+        "w env's/cli.py",
+        "kill",
     ]
     assert detected == ["10.0.0.2"]
     assert env.envars["10.0.0.2_CMD_PREFIX"] == 'export PATH="$HOME/.local/bin:$PATH";'
@@ -300,7 +306,7 @@ async def test_kill_processes_cleans_pid_files_and_handles_local_and_remote_path
 
 @pytest.mark.asyncio
 async def test_kill_processes_local_debug_uses_run_path_and_skips_current_pid(tmp_path):
-    wenv_parent = tmp_path / "wenv"
+    wenv_parent = tmp_path / "w env's"
     wenv_abs = wenv_parent / "demo_worker"
     wenv_abs.mkdir(parents=True)
     cluster_pck = tmp_path / "cluster"
@@ -334,7 +340,7 @@ async def test_kill_processes_local_debug_uses_run_path_and_skips_current_pid(tm
     )
 
     assert current_pid_file.exists()
-    assert run_path_calls == [(f"'{wenv_parent / 'cli.py'}'", "__main__")]
+    assert run_path_calls == [((wenv_parent / "cli.py").as_posix(), "__main__")]
 
 
 def test_clean_dirs_local_kills_dask_processes_and_ignores_errors(tmp_path):
@@ -408,7 +414,7 @@ async def test_clean_dirs_removes_local_wenv_and_execs_remote(tmp_path):
     env = SimpleNamespace(
         uv="/usr/bin/uv",
         wenv_abs=wenv_abs,
-        wenv_rel=Path("wenv"),
+        wenv_rel=Path("w env's"),
         python_version="3.13",
         envars={"10.0.0.9_CMD_PREFIX": "source /env && "},
     )
@@ -433,4 +439,15 @@ async def test_clean_dirs_removes_local_wenv_and_execs_remote(tmp_path):
     assert removed == [str(wenv_abs)]
     assert made_dirs == [(wenv_abs / "src", True)]
     assert ssh_calls
-    assert "clean wenv" in ssh_calls[0][1]
+    argv = shlex.split(ssh_calls[0][1].split("&& ", 1)[1], posix=True)
+    assert argv == [
+        "/usr/bin/uv",
+        "run",
+        "--no-sync",
+        "-p",
+        "3.13",
+        "python",
+        "cli.py",
+        "clean",
+        "w env's",
+    ]

--- a/src/agilab/core/test/test_agi_distributor_deployment_local_support.py
+++ b/src/agilab/core/test/test_agi_distributor_deployment_local_support.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import getpass
 import json
 import os
+import shlex
 from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
@@ -2486,7 +2487,8 @@ async def test_deploy_local_worker_non_source_flow(tmp_path):
         for cmd, _ in commands
     )
     assert any(
-        f'"{app_path}"' in cmd and "demo.post_install" in cmd for cmd, _ in commands
+        shlex.quote(app_path.as_posix()) in cmd and "demo.post_install" in cmd
+        for cmd, _ in commands
     )
     assert any("threaded" in cmd for cmd, _ in commands)
 

--- a/src/agilab/core/test/test_agi_distributor_runtime_distribution_support.py
+++ b/src/agilab/core/test/test_agi_distributor_runtime_distribution_support.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import shlex
 from pathlib import Path
 from types import SimpleNamespace
 from zipfile import ZipFile
@@ -599,7 +600,7 @@ async def test_stop_propagates_unexpected_programmer_bug(monkeypatch, phase):
 
 @pytest.mark.asyncio
 async def test_run_local_covers_debug_and_script_execution_paths(tmp_path, monkeypatch):
-    wenv_abs = tmp_path / "worker_env"
+    wenv_abs = tmp_path / "worker env's"
     (wenv_abs / ".venv").mkdir(parents=True, exist_ok=True)
 
     AGI._mode = AGI.DASK_MODE
@@ -671,16 +672,25 @@ async def test_run_local_covers_debug_and_script_execution_paths(tmp_path, monke
     )
 
     assert script_result == "line-2"
-    assert "uv-worker run --preview-features python-upgrade --no-sync" in calls["run_async"][0][0]
-    assert "--python 3.13 python -c" in calls["run_async"][0][0]
-    assert "from agi_env import AgiEnv" in calls["run_async"][0][0]
-    assert "AgiEnv(apps_path=Path('/tmp/apps'), app='demo_project', verbose=2)" in calls["run_async"][0][0]
-    assert "BaseWorker._new(env=env" in calls["run_async"][0][0]
-    assert "args={'startup': 1}" in calls["run_async"][0][0]
-    assert "BaseWorker._run(env=env" in calls["run_async"][0][0]
-    assert "args={'sample': 1}" in calls["run_async"][0][0]
-    assert "import asyncio" in calls["run_async"][0][0]
-    assert "if __name__ == '__main__':" in calls["run_async"][0][0]
+    argv = shlex.split(calls["run_async"][0][0], posix=True)
+    script = argv[argv.index("-c") + 1]
+    assert argv[:5] == [
+        "uv-worker",
+        "run",
+        "--preview-features",
+        "python-upgrade",
+        "--no-sync",
+    ]
+    assert argv[argv.index("--project") + 1] == str(wenv_abs)
+    assert argv[argv.index("--python") + 1] == "3.13"
+    assert "from agi_env import AgiEnv" in script
+    assert "AgiEnv(apps_path=Path('/tmp/apps'), app='demo_project', verbose=2)" in script
+    assert "BaseWorker._new(env=env" in script
+    assert "args={'startup': 1}" in script
+    assert "BaseWorker._run(env=env" in script
+    assert "args={'sample': 1}" in script
+    assert "import asyncio" in script
+    assert "if __name__ == '__main__':" in script
 
     calls["run_async"].clear()
     builtin_apps = Path("/tmp/repo/src/agilab/apps/builtin")
@@ -705,10 +715,12 @@ async def test_run_local_covers_debug_and_script_execution_paths(tmp_path, monke
         run_async_fn=_fake_run_async,
     )
 
+    argv = shlex.split(calls["run_async"][0][0], posix=True)
+    script = argv[argv.index("-c") + 1]
     assert (
         "AgiEnv(apps_path=Path('/tmp/repo/src/agilab/apps/builtin'), "
         "app='flight_telemetry_project', verbose=2)"
-    ) in calls["run_async"][0][0]
+    ) in script
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Replace the agi-node build post-processing `os.system` path with argv-based `subprocess.run(..., check=True)`.
- Quote cluster worker cleanup, local deployment post-install, and local worker startup command fragments that interpolate paths, Python selectors, or module names.
- Keep operator-managed remote command prefixes verbatim and document that trust boundary.
- Add regressions using spaces, quotes, and shell metacharacter-shaped values so command construction stays parseable and bounded.

## Security Context

This addresses the audit follow-up around shell-string construction and the remaining `os.system` debt in the cluster/node shared-core surface. It does not claim remote shell execution is sandboxed; it narrows accidental injection through AGILAB-controlled interpolated arguments and removes one local shell execution helper.

## Validation

- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --staged`
- `uv --preview-features extra-build-dependencies run pytest -q src/agilab/core/test/test_build_worker_venv_artifacts.py src/agilab/core/test/test_agi_dispatcher_scripts.py src/agilab/core/test/test_agi_distributor_cleanup_support.py src/agilab/core/test/test_agi_distributor_deployment_local_support.py src/agilab/core/test/test_agi_distributor_runtime_distribution_support.py` -> 300 passed
- `uv --preview-features extra-build-dependencies run pytest -q src/agilab/core/test` -> 1031 passed, 2 skipped
- `uv --preview-features extra-build-dependencies run --extra dev ruff check --ignore E402,E731 $(git diff --name-only -- '*.py')`
- `uv --preview-features extra-build-dependencies run python -m compileall -q src/agilab/core/agi-cluster/src src/agilab/core/agi-node/src`
- `git diff --check origin/main..HEAD`
- staged scope guard with explicit allowed scopes: `core:agi-cluster`, `core:agi-node`, `core:test`