### PR TITLE
Add apps-pages gallery quality bar

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -1,9 +1,9 @@
 {
-  "file_count": 252,
+  "file_count": 270,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "3de3748b65155152cb197b299ff0886431f30e563f907768a52a5012d5a3ecf2",
+  "source_digest_sha256": "9e67bb850d67d0aafff65585be8d71ea23f5ac0a5db86dd9fa8f52bd930dad6b",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "3de3748b65155152cb197b299ff0886431f30e563f907768a52a5012d5a3ecf2"
+  "target_digest_sha256": "9e67bb850d67d0aafff65585be8d71ea23f5ac0a5db86dd9fa8f52bd930dad6b"
 }

--- a/docs/source/_static/apps-pages-gallery/view_app_ui.svg
+++ b/docs/source/_static/apps-pages-gallery/view_app_ui.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="360" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
+  <title id="title">App UI Bridge preview</title>
+  <desc id="desc">Preview thumbnail for view_app_ui, package agi-page-app-ui.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#f8fafc"/>
+      <stop offset="1" stop-color="#e2e8f0"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="10" stdDeviation="12" flood-color="#0f172a" flood-opacity=".18"/>
+    </filter>
+  </defs>
+  <rect width="640" height="360" fill="url(#bg)"/>
+  <rect x="52" y="54" width="536" height="252" rx="18" fill="#ffffff" filter="url(#shadow)"/>
+  <rect x="52" y="54" width="536" height="58" rx="18" fill="#0f766e"/>
+  <text x="84" y="91" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="700" fill="#ffffff">App UI Bridge</text>
+  <text x="84" y="136" font-family="Inter, Arial, sans-serif" font-size="13" fill="#334155">Launches app-owned interactive Streamlit surfaces from ANALYSIS.</text>
+  <g fill="none" stroke="#0f766e" stroke-width="9" stroke-linecap="round" stroke-linejoin="round" opacity=".95">
+    <rect x="104" y="122" width="180" height="132"/><rect x="356" y="122" width="180" height="132"/><path d="M284 188 H356"/><path d="M336 170 L358 188 L336 206"/>
+  </g>
+  <g font-family="Inter, Arial, sans-serif" font-size="13" font-weight="700" fill="#0f172a">
+    <text x="132" y="314" class="pill">App-owned UI</text><text x="292" y="314" class="pill">Bridge</text><text x="452" y="314" class="pill">Sidecar</text>
+  </g>
+</svg>

--- a/docs/source/_static/apps-pages-gallery/view_autoencoder_latentspace.svg
+++ b/docs/source/_static/apps-pages-gallery/view_autoencoder_latentspace.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="360" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
+  <title id="title">Autoencoder Latent Space preview</title>
+  <desc id="desc">Preview thumbnail for view_autoencoder_latentspace, package agi-page-latent-space.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#f8fafc"/>
+      <stop offset="1" stop-color="#e2e8f0"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="10" stdDeviation="12" flood-color="#0f172a" flood-opacity=".18"/>
+    </filter>
+  </defs>
+  <rect width="640" height="360" fill="url(#bg)"/>
+  <rect x="52" y="54" width="536" height="252" rx="18" fill="#ffffff" filter="url(#shadow)"/>
+  <rect x="52" y="54" width="536" height="58" rx="18" fill="#7c3aed"/>
+  <text x="84" y="91" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="700" fill="#ffffff">Autoencoder Latent Space</text>
+  <text x="84" y="136" font-family="Inter, Arial, sans-serif" font-size="13" fill="#334155">Explores TensorFlow/Keras latent projections and reconstruction behavior.</text>
+  <g fill="none" stroke="#7c3aed" stroke-width="9" stroke-linecap="round" stroke-linejoin="round" opacity=".95">
+    <circle cx="198" cy="224" r="54" opacity=".22"/><circle cx="344" cy="176" r="68" opacity=".22"/><circle cx="456" cy="246" r="44" opacity=".22"/><circle cx="230" cy="206" r="7"/><circle cx="344" cy="188" r="7"/><circle cx="440" cy="242" r="7"/>
+  </g>
+  <g font-family="Inter, Arial, sans-serif" font-size="13" font-weight="700" fill="#0f172a">
+    <text x="132" y="314" class="pill">Latent map</text><text x="292" y="314" class="pill">Decoder</text><text x="452" y="314" class="pill">Projection</text>
+  </g>
+</svg>

--- a/docs/source/_static/apps-pages-gallery/view_barycentric.svg
+++ b/docs/source/_static/apps-pages-gallery/view_barycentric.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="360" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
+  <title id="title">Barycentric Simplex Map preview</title>
+  <desc id="desc">Preview thumbnail for view_barycentric, package agi-page-simplex-map.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#f8fafc"/>
+      <stop offset="1" stop-color="#e2e8f0"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="10" stdDeviation="12" flood-color="#0f172a" flood-opacity=".18"/>
+    </filter>
+  </defs>
+  <rect width="640" height="360" fill="url(#bg)"/>
+  <rect x="52" y="54" width="536" height="252" rx="18" fill="#ffffff" filter="url(#shadow)"/>
+  <rect x="52" y="54" width="536" height="58" rx="18" fill="#b45309"/>
+  <text x="84" y="91" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="700" fill="#ffffff">Barycentric Simplex Map</text>
+  <text x="84" y="136" font-family="Inter, Arial, sans-serif" font-size="13" fill="#334155">Plots proportion-style KPI features on a barycentric/simplex surface.</text>
+  <g fill="none" stroke="#b45309" stroke-width="9" stroke-linecap="round" stroke-linejoin="round" opacity=".95">
+    <path d="M320 95 L160 282 L500 282 Z"/><circle cx="284" cy="216" r="13"/><circle cx="364" cy="232" r="13"/>
+  </g>
+  <g font-family="Inter, Arial, sans-serif" font-size="13" font-weight="700" fill="#0f172a">
+    <text x="132" y="314" class="pill">Simplex</text><text x="292" y="314" class="pill">KPI mix</text><text x="452" y="314" class="pill">Clusters</text>
+  </g>
+</svg>

--- a/docs/source/_static/apps-pages-gallery/view_data_io_decision.svg
+++ b/docs/source/_static/apps-pages-gallery/view_data_io_decision.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="360" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
+  <title id="title">Decision Evidence preview</title>
+  <desc id="desc">Preview thumbnail for view_data_io_decision, package agi-page-decision-evidence.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#f8fafc"/>
+      <stop offset="1" stop-color="#e2e8f0"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="10" stdDeviation="12" flood-color="#0f172a" flood-opacity=".18"/>
+    </filter>
+  </defs>
+  <rect width="640" height="360" fill="url(#bg)"/>
+  <rect x="52" y="54" width="536" height="252" rx="18" fill="#ffffff" filter="url(#shadow)"/>
+  <rect x="52" y="54" width="536" height="58" rx="18" fill="#1d4ed8"/>
+  <text x="84" y="91" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="700" fill="#ffffff">Decision Evidence</text>
+  <text x="84" y="136" font-family="Inter, Arial, sans-serif" font-size="13" fill="#334155">Reviews data-ingestion and strategy-selection evidence.</text>
+  <g fill="none" stroke="#1d4ed8" stroke-width="9" stroke-linecap="round" stroke-linejoin="round" opacity=".95">
+    <path d="M138 116 H312 V176 H138 Z"/><path d="M138 226 H312 V286 H138 Z"/><path d="M365 116 H522 V286 H365 Z"/><path d="M312 146 H365 M312 256 H365"/>
+  </g>
+  <g font-family="Inter, Arial, sans-serif" font-size="13" font-weight="700" fill="#0f172a">
+    <text x="132" y="314" class="pill">Strategy</text><text x="292" y="314" class="pill">Evidence</text><text x="452" y="314" class="pill">Timeline</text>
+  </g>
+</svg>

--- a/docs/source/_static/apps-pages-gallery/view_forecast_analysis.svg
+++ b/docs/source/_static/apps-pages-gallery/view_forecast_analysis.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="360" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
+  <title id="title">Forecast Analysis preview</title>
+  <desc id="desc">Preview thumbnail for view_forecast_analysis, package agi-page-timeseries-forecast.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#f8fafc"/>
+      <stop offset="1" stop-color="#e2e8f0"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="10" stdDeviation="12" flood-color="#0f172a" flood-opacity=".18"/>
+    </filter>
+  </defs>
+  <rect width="640" height="360" fill="url(#bg)"/>
+  <rect x="52" y="54" width="536" height="252" rx="18" fill="#ffffff" filter="url(#shadow)"/>
+  <rect x="52" y="54" width="536" height="58" rx="18" fill="#2563eb"/>
+  <text x="84" y="91" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="700" fill="#ffffff">Forecast Analysis</text>
+  <text x="84" y="136" font-family="Inter, Arial, sans-serif" font-size="13" fill="#334155">Reviews forecast metrics and prediction tables for time-series workflows.</text>
+  <g fill="none" stroke="#2563eb" stroke-width="9" stroke-linecap="round" stroke-linejoin="round" opacity=".95">
+    <path d="M105 262 C170 205 220 230 278 178 S410 148 536 98"/><path d="M105 240 C180 222 252 246 330 210 S450 194 536 158" opacity=".45"/>
+  </g>
+  <g font-family="Inter, Arial, sans-serif" font-size="13" font-weight="700" fill="#0f172a">
+    <text x="132" y="314" class="pill">Forecast</text><text x="292" y="314" class="pill">Metrics</text><text x="452" y="314" class="pill">Residuals</text>
+  </g>
+</svg>

--- a/docs/source/_static/apps-pages-gallery/view_inference_analysis.svg
+++ b/docs/source/_static/apps-pages-gallery/view_inference_analysis.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="360" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
+  <title id="title">Inference Analysis preview</title>
+  <desc id="desc">Preview thumbnail for view_inference_analysis, package agi-page-inference-report.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#f8fafc"/>
+      <stop offset="1" stop-color="#e2e8f0"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="10" stdDeviation="12" flood-color="#0f172a" flood-opacity=".18"/>
+    </filter>
+  </defs>
+  <rect width="640" height="360" fill="url(#bg)"/>
+  <rect x="52" y="54" width="536" height="252" rx="18" fill="#ffffff" filter="url(#shadow)"/>
+  <rect x="52" y="54" width="536" height="58" rx="18" fill="#0891b2"/>
+  <text x="84" y="91" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="700" fill="#ffffff">Inference Analysis</text>
+  <text x="84" y="136" font-family="Inter, Arial, sans-serif" font-size="13" fill="#334155">Compares allocation and inference-result metrics across exported runs.</text>
+  <g fill="none" stroke="#0891b2" stroke-width="9" stroke-linecap="round" stroke-linejoin="round" opacity=".95">
+    <rect x="118" y="118" width="92" height="92"/><rect x="230" y="118" width="92" height="92"/><rect x="342" y="118" width="92" height="92"/><rect x="454" y="118" width="92" height="92"/><path d="M118 246 H546"/>
+  </g>
+  <g font-family="Inter, Arial, sans-serif" font-size="13" font-weight="700" fill="#0f172a">
+    <text x="132" y="314" class="pill">Runs</text><text x="292" y="314" class="pill">Heatmaps</text><text x="452" y="314" class="pill">Profiles</text>
+  </g>
+</svg>

--- a/docs/source/_static/apps-pages-gallery/view_live_artifacts.svg
+++ b/docs/source/_static/apps-pages-gallery/view_live_artifacts.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="360" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
+  <title id="title">Live Artifacts preview</title>
+  <desc id="desc">Preview thumbnail for view_live_artifacts, package agi-page-live-artifacts.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#f8fafc"/>
+      <stop offset="1" stop-color="#e2e8f0"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="10" stdDeviation="12" flood-color="#0f172a" flood-opacity=".18"/>
+    </filter>
+  </defs>
+  <rect width="640" height="360" fill="url(#bg)"/>
+  <rect x="52" y="54" width="536" height="252" rx="18" fill="#ffffff" filter="url(#shadow)"/>
+  <rect x="52" y="54" width="536" height="58" rx="18" fill="#16a34a"/>
+  <text x="84" y="91" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="700" fill="#ffffff">Live Artifacts</text>
+  <text x="84" y="136" font-family="Inter, Arial, sans-serif" font-size="13" fill="#334155">Watches exported evidence, manifests, logs, text, CSVs, and images while a run is active.</text>
+  <g fill="none" stroke="#16a34a" stroke-width="9" stroke-linecap="round" stroke-linejoin="round" opacity=".95">
+    <path d="M116 230 H214 L248 154 L302 284 L350 202 H548"/><circle cx="548" cy="202" r="12"/>
+  </g>
+  <g font-family="Inter, Arial, sans-serif" font-size="13" font-weight="700" fill="#0f172a">
+    <text x="132" y="314" class="pill">Refresh</text><text x="292" y="314" class="pill">Manifest</text><text x="452" y="314" class="pill">Preview</text>
+  </g>
+</svg>

--- a/docs/source/_static/apps-pages-gallery/view_maps.svg
+++ b/docs/source/_static/apps-pages-gallery/view_maps.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="360" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
+  <title id="title">2D Geospatial Map preview</title>
+  <desc id="desc">Preview thumbnail for view_maps, package agi-page-geospatial-map.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#f8fafc"/>
+      <stop offset="1" stop-color="#e2e8f0"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="10" stdDeviation="12" flood-color="#0f172a" flood-opacity=".18"/>
+    </filter>
+  </defs>
+  <rect width="640" height="360" fill="url(#bg)"/>
+  <rect x="52" y="54" width="536" height="252" rx="18" fill="#ffffff" filter="url(#shadow)"/>
+  <rect x="52" y="54" width="536" height="58" rx="18" fill="#047857"/>
+  <text x="84" y="91" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="700" fill="#ffffff">2D Geospatial Map</text>
+  <text x="84" y="136" font-family="Inter, Arial, sans-serif" font-size="13" fill="#334155">Explores geolocated datasets with map, sampling, palette, and basemap controls.</text>
+  <g fill="none" stroke="#047857" stroke-width="9" stroke-linecap="round" stroke-linejoin="round" opacity=".95">
+    <path d="M102 232 C170 156 258 270 334 185 S460 152 548 248"/><circle cx="210" cy="210" r="12"/><circle cx="386" cy="184" r="12"/>
+  </g>
+  <g font-family="Inter, Arial, sans-serif" font-size="13" font-weight="700" fill="#0f172a">
+    <text x="132" y="314" class="pill">Map</text><text x="292" y="314" class="pill">Sampling</text><text x="452" y="314" class="pill">Basemap</text>
+  </g>
+</svg>

--- a/docs/source/_static/apps-pages-gallery/view_maps_3d.svg
+++ b/docs/source/_static/apps-pages-gallery/view_maps_3d.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="360" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
+  <title id="title">3D Geospatial Map preview</title>
+  <desc id="desc">Preview thumbnail for view_maps_3d, package agi-page-geospatial-3d.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#f8fafc"/>
+      <stop offset="1" stop-color="#e2e8f0"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="10" stdDeviation="12" flood-color="#0f172a" flood-opacity=".18"/>
+    </filter>
+  </defs>
+  <rect width="640" height="360" fill="url(#bg)"/>
+  <rect x="52" y="54" width="536" height="252" rx="18" fill="#ffffff" filter="url(#shadow)"/>
+  <rect x="52" y="54" width="536" height="58" rx="18" fill="#4338ca"/>
+  <text x="84" y="91" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="700" fill="#ffffff">3D Geospatial Map</text>
+  <text x="84" y="136" font-family="Inter, Arial, sans-serif" font-size="13" fill="#334155">Shows geospatial data in Deck.gl with extrusion, color, and overlay controls.</text>
+  <g fill="none" stroke="#4338ca" stroke-width="9" stroke-linecap="round" stroke-linejoin="round" opacity=".95">
+    <path d="M130 238 L250 154 L485 220 L356 295 Z"/><path d="M250 154 L250 86 L485 152 L485 220" opacity=".65"/>
+  </g>
+  <g font-family="Inter, Arial, sans-serif" font-size="13" font-weight="700" fill="#0f172a">
+    <text x="132" y="314" class="pill">3D map</text><text x="292" y="314" class="pill">Extrusion</text><text x="452" y="314" class="pill">Overlay</text>
+  </g>
+</svg>

--- a/docs/source/_static/apps-pages-gallery/view_maps_network.svg
+++ b/docs/source/_static/apps-pages-gallery/view_maps_network.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="360" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
+  <title id="title">Network Map preview</title>
+  <desc id="desc">Preview thumbnail for view_maps_network, package agi-page-network-map.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#f8fafc"/>
+      <stop offset="1" stop-color="#e2e8f0"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="10" stdDeviation="12" flood-color="#0f172a" flood-opacity=".18"/>
+    </filter>
+  </defs>
+  <rect width="640" height="360" fill="url(#bg)"/>
+  <rect x="52" y="54" width="536" height="252" rx="18" fill="#ffffff" filter="url(#shadow)"/>
+  <rect x="52" y="54" width="536" height="58" rx="18" fill="#dc2626"/>
+  <text x="84" y="91" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="700" fill="#ffffff">Network Map</text>
+  <text x="84" y="136" font-family="Inter, Arial, sans-serif" font-size="13" fill="#334155">Synchronizes topology, routes, allocations, trajectories, and geographic views.</text>
+  <g fill="none" stroke="#dc2626" stroke-width="9" stroke-linecap="round" stroke-linejoin="round" opacity=".95">
+    <circle cx="170" cy="206" r="16"/><circle cx="270" cy="154" r="16"/><circle cx="370" cy="210" r="16"/><path d="M185 199 L255 162 L285 162 L356 203"/>
+  </g>
+  <g font-family="Inter, Arial, sans-serif" font-size="13" font-weight="700" fill="#0f172a">
+    <text x="132" y="314" class="pill">Topology</text><text x="292" y="314" class="pill">Routes</text><text x="452" y="314" class="pill">Timeline</text>
+  </g>
+</svg>

--- a/docs/source/_static/apps-pages-gallery/view_queue_resilience.svg
+++ b/docs/source/_static/apps-pages-gallery/view_queue_resilience.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="360" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
+  <title id="title">Queue Resilience preview</title>
+  <desc id="desc">Preview thumbnail for view_queue_resilience, package agi-page-queue-health.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#f8fafc"/>
+      <stop offset="1" stop-color="#e2e8f0"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="10" stdDeviation="12" flood-color="#0f172a" flood-opacity=".18"/>
+    </filter>
+  </defs>
+  <rect width="640" height="360" fill="url(#bg)"/>
+  <rect x="52" y="54" width="536" height="252" rx="18" fill="#ffffff" filter="url(#shadow)"/>
+  <rect x="52" y="54" width="536" height="58" rx="18" fill="#ca8a04"/>
+  <text x="84" y="91" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="700" fill="#ffffff">Queue Resilience</text>
+  <text x="84" y="136" font-family="Inter, Arial, sans-serif" font-size="13" fill="#334155">Reviews queue occupancy, packet events, routing summaries, and run metadata.</text>
+  <g fill="none" stroke="#ca8a04" stroke-width="9" stroke-linecap="round" stroke-linejoin="round" opacity=".95">
+    <rect x="130" y="214" width="90" height="48"/><rect x="236" y="184" width="90" height="78"/><rect x="342" y="134" width="90" height="128"/><rect x="448" y="96" width="90" height="166"/>
+  </g>
+  <g font-family="Inter, Arial, sans-serif" font-size="13" font-weight="700" fill="#0f172a">
+    <text x="132" y="314" class="pill">Queue</text><text x="292" y="314" class="pill">Delay</text><text x="452" y="314" class="pill">Drops</text>
+  </g>
+</svg>

--- a/docs/source/_static/apps-pages-gallery/view_relay_resilience.svg
+++ b/docs/source/_static/apps-pages-gallery/view_relay_resilience.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="360" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
+  <title id="title">Relay Resilience preview</title>
+  <desc id="desc">Preview thumbnail for view_relay_resilience, package agi-page-relay-health.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#f8fafc"/>
+      <stop offset="1" stop-color="#e2e8f0"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="10" stdDeviation="12" flood-color="#0f172a" flood-opacity=".18"/>
+    </filter>
+  </defs>
+  <rect width="640" height="360" fill="url(#bg)"/>
+  <rect x="52" y="54" width="536" height="252" rx="18" fill="#ffffff" filter="url(#shadow)"/>
+  <rect x="52" y="54" width="536" height="58" rx="18" fill="#ea580c"/>
+  <text x="84" y="91" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="700" fill="#ffffff">Relay Resilience</text>
+  <text x="84" y="136" font-family="Inter, Arial, sans-serif" font-size="13" fill="#334155">Compares relay queue health, route usage, and exported node motion traces.</text>
+  <g fill="none" stroke="#ea580c" stroke-width="9" stroke-linecap="round" stroke-linejoin="round" opacity=".95">
+    <circle cx="170" cy="232" r="15"/><circle cx="320" cy="146" r="18"/><circle cx="490" cy="226" r="15"/><path d="M185 224 L304 154 L337 154 L476 218"/>
+  </g>
+  <g font-family="Inter, Arial, sans-serif" font-size="13" font-weight="700" fill="#0f172a">
+    <text x="132" y="314" class="pill">Relay</text><text x="292" y="314" class="pill">Queue</text><text x="452" y="314" class="pill">Routes</text>
+  </g>
+</svg>

--- a/docs/source/_static/apps-pages-gallery/view_release_decision.svg
+++ b/docs/source/_static/apps-pages-gallery/view_release_decision.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="360" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
+  <title id="title">Release Decision preview</title>
+  <desc id="desc">Preview thumbnail for view_release_decision, package agi-page-promotion-gate.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#f8fafc"/>
+      <stop offset="1" stop-color="#e2e8f0"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="10" stdDeviation="12" flood-color="#0f172a" flood-opacity=".18"/>
+    </filter>
+  </defs>
+  <rect width="640" height="360" fill="url(#bg)"/>
+  <rect x="52" y="54" width="536" height="252" rx="18" fill="#ffffff" filter="url(#shadow)"/>
+  <rect x="52" y="54" width="536" height="58" rx="18" fill="#be123c"/>
+  <text x="84" y="91" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="700" fill="#ffffff">Release Decision</text>
+  <text x="84" y="136" font-family="Inter, Arial, sans-serif" font-size="13" fill="#334155">Builds an evidence cockpit for candidate/baseline review and promotion gates.</text>
+  <g fill="none" stroke="#be123c" stroke-width="9" stroke-linecap="round" stroke-linejoin="round" opacity=".95">
+    <path d="M154 104 H500 V272 H154 Z"/><path d="M194 152 H350 M194 198 H440 M194 244 H320"/><circle cx="472" cy="150" r="18"/><path d="M463 150 l8 8 l18 -22"/>
+  </g>
+  <g font-family="Inter, Arial, sans-serif" font-size="13" font-weight="700" fill="#0f172a">
+    <text x="132" y="314" class="pill">Gate</text><text x="292" y="314" class="pill">Baseline</text><text x="452" y="314" class="pill">Handoff</text>
+  </g>
+</svg>

--- a/docs/source/_static/apps-pages-gallery/view_routing_model_comparison.svg
+++ b/docs/source/_static/apps-pages-gallery/view_routing_model_comparison.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="360" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
+  <title id="title">Routing Model Comparison preview</title>
+  <desc id="desc">Preview thumbnail for view_routing_model_comparison, package agi-page-routing-model-comparison.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#f8fafc"/>
+      <stop offset="1" stop-color="#e2e8f0"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="10" stdDeviation="12" flood-color="#0f172a" flood-opacity=".18"/>
+    </filter>
+  </defs>
+  <rect width="640" height="360" fill="url(#bg)"/>
+  <rect x="52" y="54" width="536" height="252" rx="18" fill="#ffffff" filter="url(#shadow)"/>
+  <rect x="52" y="54" width="536" height="58" rx="18" fill="#0d9488"/>
+  <text x="84" y="91" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="700" fill="#ffffff">Routing Model Comparison</text>
+  <text x="84" y="136" font-family="Inter, Arial, sans-serif" font-size="13" fill="#334155">Compares baseline and candidate routing allocation decisions.</text>
+  <g fill="none" stroke="#0d9488" stroke-width="9" stroke-linecap="round" stroke-linejoin="round" opacity=".95">
+    <circle cx="150" cy="232" r="14"/><circle cx="310" cy="138" r="14"/><circle cx="500" cy="232" r="14"/><path d="M164 226 L296 146 L324 146 L486 226"/><path d="M164 244 C260 292 390 292 486 244" opacity=".45"/>
+  </g>
+  <g font-family="Inter, Arial, sans-serif" font-size="13" font-weight="700" fill="#0f172a">
+    <text x="132" y="314" class="pill">Baseline</text><text x="292" y="314" class="pill">Candidate</text><text x="452" y="314" class="pill">Delta</text>
+  </g>
+</svg>

--- a/docs/source/_static/apps-pages-gallery/view_scenario_cockpit.svg
+++ b/docs/source/_static/apps-pages-gallery/view_scenario_cockpit.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="360" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
+  <title id="title">Scenario Cockpit preview</title>
+  <desc id="desc">Preview thumbnail for view_scenario_cockpit, package agi-page-scenario-cockpit.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#f8fafc"/>
+      <stop offset="1" stop-color="#e2e8f0"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="10" stdDeviation="12" flood-color="#0f172a" flood-opacity=".18"/>
+    </filter>
+  </defs>
+  <rect width="640" height="360" fill="url(#bg)"/>
+  <rect x="52" y="54" width="536" height="252" rx="18" fill="#ffffff" filter="url(#shadow)"/>
+  <rect x="52" y="54" width="536" height="58" rx="18" fill="#9333ea"/>
+  <text x="84" y="91" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="700" fill="#ffffff">Scenario Cockpit</text>
+  <text x="84" y="136" font-family="Inter, Arial, sans-serif" font-size="13" fill="#334155">Packages baseline/candidate scenario evidence and promotion-gate deltas.</text>
+  <g fill="none" stroke="#9333ea" stroke-width="9" stroke-linecap="round" stroke-linejoin="round" opacity=".95">
+    <rect x="122" y="112" width="206" height="176"/><rect x="350" y="112" width="206" height="176"/><path d="M198 236 L254 172 L300 220 M424 236 L470 176 L528 204"/>
+  </g>
+  <g font-family="Inter, Arial, sans-serif" font-size="13" font-weight="700" fill="#0f172a">
+    <text x="132" y="314" class="pill">Scenario</text><text x="292" y="314" class="pill">Gate</text><text x="452" y="314" class="pill">Hashes</text>
+  </g>
+</svg>

--- a/docs/source/_static/apps-pages-gallery/view_shap_explanation.svg
+++ b/docs/source/_static/apps-pages-gallery/view_shap_explanation.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="360" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
+  <title id="title">SHAP Explanation preview</title>
+  <desc id="desc">Preview thumbnail for view_shap_explanation, package agi-page-feature-attribution.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#f8fafc"/>
+      <stop offset="1" stop-color="#e2e8f0"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="10" stdDeviation="12" flood-color="#0f172a" flood-opacity=".18"/>
+    </filter>
+  </defs>
+  <rect width="640" height="360" fill="url(#bg)"/>
+  <rect x="52" y="54" width="536" height="252" rx="18" fill="#ffffff" filter="url(#shadow)"/>
+  <rect x="52" y="54" width="536" height="58" rx="18" fill="#db2777"/>
+  <text x="84" y="91" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="700" fill="#ffffff">SHAP Explanation</text>
+  <text x="84" y="136" font-family="Inter, Arial, sans-serif" font-size="13" fill="#334155">Displays local feature-attribution evidence without depending on a specific explainer runtime.</text>
+  <g fill="none" stroke="#db2777" stroke-width="9" stroke-linecap="round" stroke-linejoin="round" opacity=".95">
+    <rect x="142" y="112" width="86" height="36"/><rect x="142" y="166" width="176" height="36"/><rect x="142" y="220" width="132" height="36"/><rect x="354" y="112" width="154" height="36"/><rect x="354" y="166" width="96" height="36"/><rect x="354" y="220" width="190" height="36"/>
+  </g>
+  <g font-family="Inter, Arial, sans-serif" font-size="13" font-weight="700" fill="#0f172a">
+    <text x="132" y="314" class="pill">Features</text><text x="292" y="314" class="pill">Attribution</text><text x="452" y="314" class="pill">Instance</text>
+  </g>
+</svg>

--- a/docs/source/_static/apps-pages-gallery/view_training_analysis.svg
+++ b/docs/source/_static/apps-pages-gallery/view_training_analysis.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="360" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
+  <title id="title">Training Analysis preview</title>
+  <desc id="desc">Preview thumbnail for view_training_analysis, package agi-page-training-report.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#f8fafc"/>
+      <stop offset="1" stop-color="#e2e8f0"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="10" stdDeviation="12" flood-color="#0f172a" flood-opacity=".18"/>
+    </filter>
+  </defs>
+  <rect width="640" height="360" fill="url(#bg)"/>
+  <rect x="52" y="54" width="536" height="252" rx="18" fill="#ffffff" filter="url(#shadow)"/>
+  <rect x="52" y="54" width="536" height="58" rx="18" fill="#4f46e5"/>
+  <text x="84" y="91" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="700" fill="#ffffff">Training Analysis</text>
+  <text x="84" y="136" font-family="Inter, Arial, sans-serif" font-size="13" fill="#334155">Browses scalar training runs from TensorBoard logs or AGILAB training-history CSVs.</text>
+  <g fill="none" stroke="#4f46e5" stroke-width="9" stroke-linecap="round" stroke-linejoin="round" opacity=".95">
+    <path d="M110 256 C182 202 240 208 292 170 S412 132 532 82"/><path d="M110 104 C196 150 270 165 352 212 S450 240 532 266" opacity=".45"/>
+  </g>
+  <g font-family="Inter, Arial, sans-serif" font-size="13" font-weight="700" fill="#0f172a">
+    <text x="132" y="314" class="pill">Training</text><text x="292" y="314" class="pill">Scalars</text><text x="452" y="314" class="pill">Runs</text>
+  </g>
+</svg>

--- a/docs/source/apps-pages-gallery.rst
+++ b/docs/source/apps-pages-gallery.rst
@@ -1,0 +1,147 @@
+Page Bundle Gallery
+===================
+
+This gallery is the visual front door for the reusable Streamlit page bundles
+that AGILAB can launch from ANALYSIS. Each bundle has a local README, a
+source-controlled preview asset, direct test coverage, and shared AGILAB page
+chrome.
+
+.. list-table::
+   :widths: 34 66
+
+   * - .. image:: _static/apps-pages-gallery/view_app_ui.svg
+          :alt: view_app_ui preview
+          :width: 260px
+     - **view_app_ui**
+
+       Launches app-owned interactive Streamlit surfaces from ANALYSIS.
+
+       When to use: Use when the app owns live controls, training loops, or a custom UI that should stay outside generic page bundles.
+   * - .. image:: _static/apps-pages-gallery/view_autoencoder_latentspace.svg
+          :alt: view_autoencoder_latentspace preview
+          :width: 260px
+     - **view_autoencoder_latentspace**
+
+       Explores TensorFlow/Keras latent projections and reconstruction behavior.
+
+       When to use: Use for heavier Python 3.12 teaching or exploration sessions where latent-space structure matters more than lightweight packaging.
+   * - .. image:: _static/apps-pages-gallery/view_barycentric.svg
+          :alt: view_barycentric preview
+          :width: 260px
+     - **view_barycentric**
+
+       Plots proportion-style KPI features on a barycentric/simplex surface.
+
+       When to use: Use when three or more normalized contributions need a visual balance map instead of a raw table.
+   * - .. image:: _static/apps-pages-gallery/view_data_io_decision.svg
+          :alt: view_data_io_decision preview
+          :width: 260px
+     - **view_data_io_decision**
+
+       Reviews data-ingestion and strategy-selection evidence.
+
+       When to use: Use after a decision producer exports strategy, route, latency, cost, and reliability artifacts.
+   * - .. image:: _static/apps-pages-gallery/view_forecast_analysis.svg
+          :alt: view_forecast_analysis preview
+          :width: 260px
+     - **view_forecast_analysis**
+
+       Reviews forecast metrics and prediction tables for time-series workflows.
+
+       When to use: Use for notebook-to-AGILAB migrations or apps exporting forecast_metrics.json and forecast_predictions.csv.
+   * - .. image:: _static/apps-pages-gallery/view_inference_analysis.svg
+          :alt: view_inference_analysis preview
+          :width: 260px
+     - **view_inference_analysis**
+
+       Compares allocation and inference-result metrics across exported runs.
+
+       When to use: Use when several allocation exports need side-by-side diagnostics for load, routing, latency, bearer mix, and flows.
+   * - .. image:: _static/apps-pages-gallery/view_live_artifacts.svg
+          :alt: view_live_artifacts preview
+          :width: 260px
+     - **view_live_artifacts**
+
+       Watches exported evidence, manifests, logs, text, CSVs, and images while a run is active.
+
+       When to use: Use when a producer is still writing files and the reviewer needs a safe live artifact monitor.
+   * - .. image:: _static/apps-pages-gallery/view_maps.svg
+          :alt: view_maps preview
+          :width: 260px
+     - **view_maps**
+
+       Explores geolocated datasets with map, sampling, palette, and basemap controls.
+
+       When to use: Use first when latitude/longitude data needs a quick spatial sanity check.
+   * - .. image:: _static/apps-pages-gallery/view_maps_3d.svg
+          :alt: view_maps_3d preview
+          :width: 260px
+     - **view_maps_3d**
+
+       Shows geospatial data in Deck.gl with extrusion, color, and overlay controls.
+
+       When to use: Use when altitude, density, or height-encoded metrics need a spatial 3D view.
+   * - .. image:: _static/apps-pages-gallery/view_maps_network.svg
+          :alt: view_maps_network preview
+          :width: 260px
+     - **view_maps_network**
+
+       Synchronizes topology, routes, allocations, trajectories, and geographic views.
+
+       When to use: Use for relay or satellite queue-analysis runs where route choice and link availability need visual inspection.
+   * - .. image:: _static/apps-pages-gallery/view_queue_resilience.svg
+          :alt: view_queue_resilience preview
+          :width: 260px
+     - **view_queue_resilience**
+
+       Reviews queue occupancy, packet events, routing summaries, and run metadata.
+
+       When to use: Use for compact queue-analysis artifacts from any producer writing the AGILAB queue contract.
+   * - .. image:: _static/apps-pages-gallery/view_relay_resilience.svg
+          :alt: view_relay_resilience preview
+          :width: 260px
+     - **view_relay_resilience**
+
+       Compares relay queue health, route usage, and exported node motion traces.
+
+       When to use: Use after relay-focused queue runs when packet delivery and relay behavior need side-by-side review.
+   * - .. image:: _static/apps-pages-gallery/view_release_decision.svg
+          :alt: view_release_decision preview
+          :width: 260px
+     - **view_release_decision**
+
+       Builds an evidence cockpit for candidate/baseline review and promotion gates.
+
+       When to use: Use before handoff when a run needs explicit gates, indexed evidence, and a promotion_decision.json export.
+   * - .. image:: _static/apps-pages-gallery/view_routing_model_comparison.svg
+          :alt: view_routing_model_comparison preview
+          :width: 260px
+     - **view_routing_model_comparison**
+
+       Compares baseline and candidate routing allocation decisions.
+
+       When to use: Use when routing models need allocation deltas, failure inspection, and side-by-side decision evidence.
+   * - .. image:: _static/apps-pages-gallery/view_scenario_cockpit.svg
+          :alt: view_scenario_cockpit preview
+          :width: 260px
+     - **view_scenario_cockpit**
+
+       Packages baseline/candidate scenario evidence and promotion-gate deltas.
+
+       When to use: Use before opening detailed queue or network maps when a compact scenario decision artifact is enough.
+   * - .. image:: _static/apps-pages-gallery/view_shap_explanation.svg
+          :alt: view_shap_explanation preview
+          :width: 260px
+     - **view_shap_explanation**
+
+       Displays local feature-attribution evidence without depending on a specific explainer runtime.
+
+       When to use: Use when producer workflows export SHAPKit, shap, or compatible attribution tables.
+   * - .. image:: _static/apps-pages-gallery/view_training_analysis.svg
+          :alt: view_training_analysis preview
+          :width: 260px
+     - **view_training_analysis**
+
+       Browses scalar training runs from TensorBoard logs or AGILAB training-history CSVs.
+
+       When to use: Use to compare trainers, tags, steps, and training curves before deeper model review.

--- a/docs/source/apps-pages.rst
+++ b/docs/source/apps-pages.rst
@@ -128,6 +128,8 @@ This section summarizes every page bundle shipped under
 ``src/agilab/apps-pages``. Use :doc:`explore-help` to discover, configure, and
 launch them from the UI.
 
+For a visual first pass, open the curated :doc:`apps-pages-gallery`.
+
 ``agi-pages`` is the provider/umbrella package for the default lightweight page
 set. Heavier teaching or framework-specific pages can still be shipped as
 standalone ``agi-page-*`` packages or source-checkout bundles without being

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -107,6 +107,7 @@ references, and example projects.
    WORKFLOW page <experiment-help>
    ANALYSIS page <explore-help>
    Page bundles <apps-pages>
+   Page bundle gallery <apps-pages-gallery>
    Portable web components <agi-web>
 
 .. toctree::

--- a/docs/source/roadmap/workflow-maintainability-patterns.md
+++ b/docs/source/roadmap/workflow-maintainability-patterns.md
@@ -62,11 +62,12 @@ The Pipeline-first slice is now the reference implementation:
 
 - Compatibility Shim Budget: tracked. The release tree currently carries a
   measured compatibility-shim baseline, enforced by
-  `tools/compat_shim_inventory.py` and the focused regression in
-  `test/test_compat_shim_inventory.py`. The rule is no silent growth: future
-  migration work should lower the cap as legacy imports are retired, while
-  release-safe changes must not delete public forwarding modules without a
-  dedicated deprecation plan.
+  `tools/compat_shim_inventory.py`, `python tools/local_quality.py --profile quick`,
+  and the focused regression in `apps/test/test_compat_shim_inventory.py`.
+  The current cap is explicit rather than aspirational: no silent growth.
+  Future migration work should lower the cap as legacy imports are retired,
+  while release-safe changes must not delete public forwarding modules without
+  a dedicated deprecation plan.
 - Page State / ViewModel: partially done. Pipeline has a typed
   `PipelinePageState` / ViewModel for visible stages, selected lab, stale
   snippets, lock/run status, logs, and available actions. Orchestrate service

--- a/src/agilab/apps-pages/README.md
+++ b/src/agilab/apps-pages/README.md
@@ -11,6 +11,22 @@ app-agnostic analysis page. The generic `view_app_ui` bridge lets ANALYSIS
 display the app-owned playground UI without moving training logic into
 apps-pages.
 
+## Gallery
+
+Every shipped view bundle has a local README, a source-controlled preview, direct tests, and shared AGILAB page chrome.
+
+| View | View |
+|---|---|
+| [![view_app_ui preview](../../../docs/source/_static/apps-pages-gallery/view_app_ui.svg)](view_app_ui)<br>**view_app_ui**<br>Launches app-owned interactive Streamlit surfaces from ANALYSIS. | [![view_autoencoder_latentspace preview](../../../docs/source/_static/apps-pages-gallery/view_autoencoder_latentspace.svg)](view_autoencoder_latentspace)<br>**view_autoencoder_latentspace**<br>Explores TensorFlow/Keras latent projections and reconstruction behavior. |
+| [![view_barycentric preview](../../../docs/source/_static/apps-pages-gallery/view_barycentric.svg)](view_barycentric)<br>**view_barycentric**<br>Plots proportion-style KPI features on a barycentric/simplex surface. | [![view_data_io_decision preview](../../../docs/source/_static/apps-pages-gallery/view_data_io_decision.svg)](view_data_io_decision)<br>**view_data_io_decision**<br>Reviews data-ingestion and strategy-selection evidence. |
+| [![view_forecast_analysis preview](../../../docs/source/_static/apps-pages-gallery/view_forecast_analysis.svg)](view_forecast_analysis)<br>**view_forecast_analysis**<br>Reviews forecast metrics and prediction tables for time-series workflows. | [![view_inference_analysis preview](../../../docs/source/_static/apps-pages-gallery/view_inference_analysis.svg)](view_inference_analysis)<br>**view_inference_analysis**<br>Compares allocation and inference-result metrics across exported runs. |
+| [![view_live_artifacts preview](../../../docs/source/_static/apps-pages-gallery/view_live_artifacts.svg)](view_live_artifacts)<br>**view_live_artifacts**<br>Watches exported evidence, manifests, logs, text, CSVs, and images while a run is active. | [![view_maps preview](../../../docs/source/_static/apps-pages-gallery/view_maps.svg)](view_maps)<br>**view_maps**<br>Explores geolocated datasets with map, sampling, palette, and basemap controls. |
+| [![view_maps_3d preview](../../../docs/source/_static/apps-pages-gallery/view_maps_3d.svg)](view_maps_3d)<br>**view_maps_3d**<br>Shows geospatial data in Deck.gl with extrusion, color, and overlay controls. | [![view_maps_network preview](../../../docs/source/_static/apps-pages-gallery/view_maps_network.svg)](view_maps_network)<br>**view_maps_network**<br>Synchronizes topology, routes, allocations, trajectories, and geographic views. |
+| [![view_queue_resilience preview](../../../docs/source/_static/apps-pages-gallery/view_queue_resilience.svg)](view_queue_resilience)<br>**view_queue_resilience**<br>Reviews queue occupancy, packet events, routing summaries, and run metadata. | [![view_relay_resilience preview](../../../docs/source/_static/apps-pages-gallery/view_relay_resilience.svg)](view_relay_resilience)<br>**view_relay_resilience**<br>Compares relay queue health, route usage, and exported node motion traces. |
+| [![view_release_decision preview](../../../docs/source/_static/apps-pages-gallery/view_release_decision.svg)](view_release_decision)<br>**view_release_decision**<br>Builds an evidence cockpit for candidate/baseline review and promotion gates. | [![view_routing_model_comparison preview](../../../docs/source/_static/apps-pages-gallery/view_routing_model_comparison.svg)](view_routing_model_comparison)<br>**view_routing_model_comparison**<br>Compares baseline and candidate routing allocation decisions. |
+| [![view_scenario_cockpit preview](../../../docs/source/_static/apps-pages-gallery/view_scenario_cockpit.svg)](view_scenario_cockpit)<br>**view_scenario_cockpit**<br>Packages baseline/candidate scenario evidence and promotion-gate deltas. | [![view_shap_explanation preview](../../../docs/source/_static/apps-pages-gallery/view_shap_explanation.svg)](view_shap_explanation)<br>**view_shap_explanation**<br>Displays local feature-attribution evidence without depending on a specific explainer runtime. |
+| [![view_training_analysis preview](../../../docs/source/_static/apps-pages-gallery/view_training_analysis.svg)](view_training_analysis)<br>**view_training_analysis**<br>Browses scalar training runs from TensorBoard logs or AGILAB training-history CSVs. |  |
+
 Quick start (dev checkout):
 
 - view_maps

--- a/src/agilab/apps-pages/view_app_ui/README.md
+++ b/src/agilab/apps-pages/view_app_ui/README.md
@@ -1,0 +1,26 @@
+# view_app_ui
+
+![view_app_ui preview](../../../../docs/source/_static/apps-pages-gallery/view_app_ui.svg)
+
+Package: `agi-page-app-ui`
+
+Launches app-owned interactive Streamlit surfaces from ANALYSIS.
+
+## When To Use It
+
+Use when the app owns live controls, training loops, or a custom UI that should stay outside generic page bundles.
+
+## Expected Inputs
+
+- An active app with a [pages.view_app_ui] or app_surface Streamlit entrypoint.
+- The app-owned UI source and its exported artifacts.
+
+Open it from `ANALYSIS` after selecting a project, or run it directly while developing:
+
+```bash
+uv --preview-features extra-build-dependencies run streamlit run src/agilab/apps-pages/view_app_ui/src/view_app_ui/view_app_ui.py -- --active-app src/agilab/apps/builtin/pytorch_playground_project
+```
+
+## Quality Contract
+
+This bundle has a local README, a source-controlled preview asset, direct test coverage, and uses the shared `agi_pages.runtime` page chrome.

--- a/src/agilab/apps-pages/view_autoencoder_latentspace/README.md
+++ b/src/agilab/apps-pages/view_autoencoder_latentspace/README.md
@@ -1,0 +1,26 @@
+# view_autoencoder_latentspace
+
+![view_autoencoder_latentspace preview](../../../../docs/source/_static/apps-pages-gallery/view_autoencoder_latentspace.svg)
+
+Package: `agi-page-latent-space`
+
+Explores TensorFlow/Keras latent projections and reconstruction behavior.
+
+## When To Use It
+
+Use for heavier Python 3.12 teaching or exploration sessions where latent-space structure matters more than lightweight packaging.
+
+## Expected Inputs
+
+- A dataframe with continuous/discrete columns.
+- Optional model or embedding outputs from the selected app.
+
+Open it from `ANALYSIS` after selecting a project, or run it directly while developing:
+
+```bash
+uv --preview-features extra-build-dependencies run streamlit run src/agilab/apps-pages/view_autoencoder_latentspace/src/view_autoencoder_latentspace/view_autoencoder_latentspace.py -- --active-app src/agilab/apps/builtin/flight_telemetry_project
+```
+
+## Quality Contract
+
+This bundle has a local README, a source-controlled preview asset, direct test coverage, and uses the shared `agi_pages.runtime` page chrome.

--- a/src/agilab/apps-pages/view_barycentric/README.md
+++ b/src/agilab/apps-pages/view_barycentric/README.md
@@ -1,0 +1,26 @@
+# view_barycentric
+
+![view_barycentric preview](../../../../docs/source/_static/apps-pages-gallery/view_barycentric.svg)
+
+Package: `agi-page-simplex-map`
+
+Plots proportion-style KPI features on a barycentric/simplex surface.
+
+## When To Use It
+
+Use when three or more normalized contributions need a visual balance map instead of a raw table.
+
+## Expected Inputs
+
+- A dataframe with proportion or KPI columns.
+- An active app export containing the selected table.
+
+Open it from `ANALYSIS` after selecting a project, or run it directly while developing:
+
+```bash
+uv --preview-features extra-build-dependencies run streamlit run src/agilab/apps-pages/view_barycentric/src/view_barycentric/view_barycentric.py -- --active-app src/agilab/apps/builtin/flight_telemetry_project
+```
+
+## Quality Contract
+
+This bundle has a local README, a source-controlled preview asset, direct test coverage, and uses the shared `agi_pages.runtime` page chrome.

--- a/src/agilab/apps-pages/view_data_io_decision/README.md
+++ b/src/agilab/apps-pages/view_data_io_decision/README.md
@@ -1,5 +1,10 @@
 # Decision Evidence View
 
+![view_data_io_decision preview](../../../../docs/source/_static/apps-pages-gallery/view_data_io_decision.svg)
+
+Package: `agi-page-decision-evidence`
+
+
 Streamlit analysis page for generic decision-evidence exports.
 
 Use this page after running a compatible producer such as `mission_decision_project` from AGILAB:

--- a/src/agilab/apps-pages/view_forecast_analysis/README.md
+++ b/src/agilab/apps-pages/view_forecast_analysis/README.md
@@ -1,5 +1,10 @@
 # view_forecast_analysis
 
+![view_forecast_analysis preview](../../../../docs/source/_static/apps-pages-gallery/view_forecast_analysis.svg)
+
+Package: `agi-page-timeseries-forecast`
+
+
 Reusable Streamlit analysis page for forecast-style artifacts.
 
 ## Expected Inputs

--- a/src/agilab/apps-pages/view_inference_analysis/README.md
+++ b/src/agilab/apps-pages/view_inference_analysis/README.md
@@ -1,5 +1,10 @@
 # view_inference_analysis
 
+![view_inference_analysis preview](../../../../docs/source/_static/apps-pages-gallery/view_inference_analysis.svg)
+
+Package: `agi-page-inference-report`
+
+
 Reusable AGILAB ANALYSIS page for comparing metrics exported in
 `allocations_steps` artifacts across multiple folders.
 

--- a/src/agilab/apps-pages/view_live_artifacts/README.md
+++ b/src/agilab/apps-pages/view_live_artifacts/README.md
@@ -1,5 +1,10 @@
 # view_live_artifacts
 
+![view_live_artifacts preview](../../../../docs/source/_static/apps-pages-gallery/view_live_artifacts.svg)
+
+Package: `agi-page-live-artifacts`
+
+
 `view_live_artifacts` is an app-agnostic AGILAB analysis page for watching an
 active app's exported evidence while a run is still producing files.
 

--- a/src/agilab/apps-pages/view_maps/README.md
+++ b/src/agilab/apps-pages/view_maps/README.md
@@ -1,0 +1,26 @@
+# view_maps
+
+![view_maps preview](../../../../docs/source/_static/apps-pages-gallery/view_maps.svg)
+
+Package: `agi-page-geospatial-map`
+
+Explores geolocated datasets with map, sampling, palette, and basemap controls.
+
+## When To Use It
+
+Use first when latitude/longitude data needs a quick spatial sanity check.
+
+## Expected Inputs
+
+- CSV or Parquet with latitude/longitude columns.
+- Optional app page defaults for data path and column names.
+
+Open it from `ANALYSIS` after selecting a project, or run it directly while developing:
+
+```bash
+uv --preview-features extra-build-dependencies run streamlit run src/agilab/apps-pages/view_maps/src/view_maps/view_maps.py -- --active-app src/agilab/apps/builtin/flight_telemetry_project
+```
+
+## Quality Contract
+
+This bundle has a local README, a source-controlled preview asset, direct test coverage, and uses the shared `agi_pages.runtime` page chrome.

--- a/src/agilab/apps-pages/view_maps_3d/README.md
+++ b/src/agilab/apps-pages/view_maps_3d/README.md
@@ -1,0 +1,26 @@
+# view_maps_3d
+
+![view_maps_3d preview](../../../../docs/source/_static/apps-pages-gallery/view_maps_3d.svg)
+
+Package: `agi-page-geospatial-3d`
+
+Shows geospatial data in Deck.gl with extrusion, color, and overlay controls.
+
+## When To Use It
+
+Use when altitude, density, or height-encoded metrics need a spatial 3D view.
+
+## Expected Inputs
+
+- One or more geolocated datasets.
+- Optional altitude or extrusion metric columns.
+
+Open it from `ANALYSIS` after selecting a project, or run it directly while developing:
+
+```bash
+uv --preview-features extra-build-dependencies run streamlit run src/agilab/apps-pages/view_maps_3d/src/view_maps_3d/view_maps_3d.py -- --active-app src/agilab/apps/builtin/flight_telemetry_project
+```
+
+## Quality Contract
+
+This bundle has a local README, a source-controlled preview asset, direct test coverage, and uses the shared `agi_pages.runtime` page chrome.

--- a/src/agilab/apps-pages/view_maps_network/README.md
+++ b/src/agilab/apps-pages/view_maps_network/README.md
@@ -1,0 +1,27 @@
+# view_maps_network
+
+![view_maps_network preview](../../../../docs/source/_static/apps-pages-gallery/view_maps_network.svg)
+
+Package: `agi-page-network-map`
+
+Synchronizes topology, routes, allocations, trajectories, and geographic views.
+
+## When To Use It
+
+Use for relay or satellite queue-analysis runs where route choice and link availability need visual inspection.
+
+## Expected Inputs
+
+- pipeline/topology.gml or routing edge exports.
+- pipeline/allocations_steps.csv or equivalent allocation exports.
+- Trajectory CSV/Parquet files.
+
+Open it from `ANALYSIS` after selecting a project, or run it directly while developing:
+
+```bash
+uv --preview-features extra-build-dependencies run streamlit run src/agilab/apps-pages/view_maps_network/src/view_maps_network/view_maps_network.py -- --active-app src/agilab/apps/builtin/uav_relay_queue_project
+```
+
+## Quality Contract
+
+This bundle has a local README, a source-controlled preview asset, direct test coverage, and uses the shared `agi_pages.runtime` page chrome.

--- a/src/agilab/apps-pages/view_maps_network/src/view_maps_network/allocation_support.py
+++ b/src/agilab/apps-pages/view_maps_network/src/view_maps_network/allocation_support.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+from typing import Any, Optional
+
+import numpy as np
+import pandas as pd
+
+def safe_literal_eval(value):
+    try:
+        return ast.literal_eval(value)
+    except (ValueError, SyntaxError):
+        return value
+
+_ALLOC_STEP_CANDIDATES = ("time_index", "decision", "step", "time_idx")
+_ALLOC_TIME_CANDIDATES = ("time_s", "t_now_s", "time", "t")
+
+
+def _pick_ci_column(df: pd.DataFrame, candidates: tuple[str, ...]) -> Optional[str]:
+    if df.empty:
+        return None
+    lower_map = {str(c).lower(): str(c) for c in df.columns}
+    for key in candidates:
+        col = lower_map.get(key.lower())
+        if col is not None:
+            return col
+    return None
+
+
+def _parse_allocations_cell(value: Any) -> list[dict[str, Any]]:
+    if value is None or (isinstance(value, float) and np.isnan(value)):
+        return []
+    parsed: Any = value
+    if isinstance(parsed, str):
+        parsed = safe_literal_eval(parsed)
+    if isinstance(parsed, dict):
+        return [parsed]
+    if isinstance(parsed, tuple):
+        parsed = list(parsed)
+    if not isinstance(parsed, list):
+        return []
+    rows: list[dict[str, Any]] = []
+    for item in parsed:
+        obj = safe_literal_eval(item) if isinstance(item, str) else item
+        if isinstance(obj, dict):
+            rows.append(obj)
+    return rows
+
+
+def _coerce_alloc_time_index(df: pd.DataFrame) -> pd.DataFrame:
+    if df.empty:
+        return df
+    normalized = df.copy()
+    step_col = _pick_ci_column(normalized, _ALLOC_STEP_CANDIDATES)
+    if "time_index" not in normalized.columns and step_col is not None:
+        normalized["time_index"] = normalized[step_col]
+    if "time_index" not in normalized.columns:
+        normalized["time_index"] = 0
+
+    step_num = pd.to_numeric(normalized["time_index"], errors="coerce")
+    if step_num.notna().any():
+        if step_num.isna().any():
+            fallback = pd.Series(np.arange(len(normalized), dtype=float), index=normalized.index)
+            step_num = step_num.combine_first(fallback)
+        normalized["time_index"] = step_num.round().astype("Int64")
+    else:
+        normalized["time_index"] = pd.Series(np.arange(len(normalized)), index=normalized.index, dtype="Int64")
+    return normalized
+
+
+def _drop_index_levels_shadowing_columns(df: pd.DataFrame) -> pd.DataFrame:
+    """Drop named index levels that duplicate real column labels."""
+    if df.empty:
+        return df
+    index_names = [name for name in df.index.names if name is not None]
+    duplicated = [name for name in index_names if name in df.columns]
+    if not duplicated:
+        return df
+    return df.reset_index(level=duplicated, drop=True)
+
+
+def _normalize_allocations_frame(df_in: pd.DataFrame) -> pd.DataFrame:
+    if df_in.empty:
+        return df_in
+    df = df_in.copy()
+
+    src_col = _pick_ci_column(df, ("source", "src", "from"))
+    dst_col = _pick_ci_column(df, ("destination", "dst", "dest", "to", "target"))
+    if src_col is not None and src_col != "source":
+        df["source"] = df[src_col]
+    if dst_col is not None and dst_col != "destination":
+        df["destination"] = df[dst_col]
+
+    alloc_col = _pick_ci_column(df, ("allocations",))
+    if alloc_col is not None and ("source" not in df.columns or "destination" not in df.columns):
+        step_col = _pick_ci_column(df, _ALLOC_STEP_CANDIDATES)
+        t_col = _pick_ci_column(df, _ALLOC_TIME_CANDIDATES)
+        rows: list[dict[str, Any]] = []
+        for idx, row in df.iterrows():
+            step_value = row.get(step_col) if step_col is not None else idx
+            t_value = row.get(t_col) if t_col is not None else None
+            for alloc in _parse_allocations_cell(row.get(alloc_col)):
+                merged = dict(alloc)
+                merged.setdefault("time_index", step_value)
+                if t_value is not None:
+                    merged.setdefault("time_s", t_value)
+                    merged.setdefault("t_now_s", t_value)
+                rows.append(merged)
+        if rows:
+            df = pd.DataFrame(rows)
+
+    df = _coerce_alloc_time_index(df)
+
+    t_col = _pick_ci_column(df, _ALLOC_TIME_CANDIDATES)
+    if t_col is not None:
+        t_num = pd.to_numeric(df[t_col], errors="coerce")
+        if t_num.notna().any():
+            df["time_s"] = t_num
+            if "t_now_s" not in df.columns:
+                df["t_now_s"] = t_num
+    return df
+
+
+def load_allocations(path: Path) -> pd.DataFrame:
+    path = path.expanduser()
+    if not path.exists():
+        return pd.DataFrame()
+    if path.suffix.lower() == ".csv":
+        try:
+            return _normalize_allocations_frame(pd.read_csv(path))
+        except Exception:
+            return pd.DataFrame()
+    if path.suffix.lower() in {".parquet", ".pq", ".parq"}:
+        try:
+            return _normalize_allocations_frame(pd.read_parquet(path))
+        except Exception:
+            return pd.DataFrame()
+    try:
+        if path.suffix.lower() in {".jsonl", ".ndjson"}:
+            records: list[Any] = []
+            for line in path.read_text(encoding="utf-8").splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                records.append(json.loads(line))
+            data: Any = records
+        else:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(data, list):
+            return _normalize_allocations_frame(pd.DataFrame(data))
+        elif isinstance(data, dict):
+            return _normalize_allocations_frame(pd.DataFrame([data]))
+    except Exception:
+        return pd.DataFrame()
+    return pd.DataFrame()
+
+def _nearest_row(df: pd.DataFrame, t: float, time_col: str = "time_s") -> pd.DataFrame:
+    if df.empty or time_col not in df.columns:
+        return df
+    series = pd.to_numeric(df[time_col], errors="coerce")
+    if series.dropna().empty:
+        return df.iloc[0:0]
+    idx = (series - t).abs().idxmin()
+    return df.loc[[idx]]

--- a/src/agilab/apps-pages/view_maps_network/src/view_maps_network/node_support.py
+++ b/src/agilab/apps-pages/view_maps_network/src/view_maps_network/node_support.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+try:
+    from allocation_support import safe_literal_eval
+except ModuleNotFoundError:  # pragma: no cover - package import path
+    from .allocation_support import safe_literal_eval
+
+logger = logging.getLogger(__name__)
+_TRAILING_EXPORT_TIMESTAMP_RE = re.compile(r"[_-]\d{4}-\d{2}-\d{2}(?:[_-]\d{2}-\d{2}-\d{2})?$")
+
+def _normalize_node_id_series(series: pd.Series) -> pd.Series:
+    """Normalize node IDs for consistent matching and drop invalid placeholders."""
+    raw = series.copy()
+    num = pd.to_numeric(raw, errors="coerce")
+    out = raw.astype("string").fillna("").astype(str).str.strip()
+    mask_int = num.notna() & np.isclose(num % 1, 0.0)
+    if mask_int.any():
+        out.loc[mask_int] = num.loc[mask_int].round().astype(int).astype(str)
+    invalid = out.str.lower().isin({"", "nan", "none", "nat", "<na>"})
+    out.loc[invalid] = ""
+    return out
+
+
+def _normalize_node_id_value(value: Any) -> str:
+    if value is None or (isinstance(value, float) and np.isnan(value)):
+        return ""
+    s = str(value).strip()
+    if not s or s.lower() in {"nan", "none", "nat", "<na>"}:
+        return ""
+    try:
+        num = float(s)
+        if np.isfinite(num) and np.isclose(num % 1, 0.0):
+            return str(int(round(num)))
+    except (TypeError, ValueError, OverflowError):
+        logger.debug("Node id %r is not an integer-like value", value, exc_info=True)
+    return s
+
+
+def _strip_export_suffix(value: Any) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    text = _TRAILING_EXPORT_TIMESTAMP_RE.sub("", text)
+    return re.sub(r"[-_](trajectory|traj)$", "", text, flags=re.IGNORECASE)
+
+
+def _semantic_node_id_from_text(value: Any) -> str | None:
+    text = _strip_export_suffix(value)
+    if not text:
+        return None
+    digits = "".join(ch for ch in text if ch.isdigit())
+    if not digits:
+        return None
+    try:
+        return str(int(digits))
+    except ValueError:
+        return None
+
+
+def _preferred_node_id_from_row(row: pd.Series, *, source_path: str | None = None) -> str:
+    semantic_columns = (
+        "plane_label",
+        "sat_name",
+        "plane_type",
+        "name",
+        "callsign",
+        "call_sign",
+        "stable_flight_id",
+        "node_label",
+        "trajectory_label",
+    )
+    for col in semantic_columns:
+        if col not in row:
+            continue
+        semantic_id = _semantic_node_id_from_text(row.get(col))
+        if semantic_id:
+            return semantic_id
+
+    source_value = row.get("source_file") if "source_file" in row else source_path
+    if source_value not in (None, ""):
+        semantic_id = _semantic_node_id_from_text(Path(str(source_value)).stem)
+        if semantic_id:
+            return semantic_id
+
+    for col in ("plane_id", "trajectory_id", "node_id", "flight_id", "id_col", "id"):
+        if col not in row:
+            continue
+        normalized = _normalize_node_id_value(row.get(col))
+        if normalized:
+            return normalized
+    return ""
+
+
+def _candidate_node_ids(value: Any) -> list[str]:
+    base = _normalize_node_id_value(value)
+    if not base:
+        return []
+    candidates = [base]
+    semantic_id = _semantic_node_id_from_text(value)
+    if semantic_id:
+        candidates.append(semantic_id)
+    prefixes = ("plane_", "sat_", "uav_", "node_")
+    lowered = base.lower()
+    for prefix in prefixes:
+        if lowered.startswith(prefix):
+            stripped = _normalize_node_id_value(base[len(prefix) :])
+            if stripped:
+                candidates.append(stripped)
+            break
+    for prefix in prefixes:
+        candidates.append(prefix + base)
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for cand in candidates:
+        if cand and cand not in seen:
+            seen.add(cand)
+            deduped.append(cand)
+    return deduped
+
+
+def _resolve_node_id(value: Any, node_set: set[str]) -> str | None:
+    for cand in _candidate_node_ids(value):
+        if cand in node_set:
+            return cand
+    return None
+
+
+def _coerce_list_cell(value: Any) -> list[Any]:
+    if value is None or (isinstance(value, float) and np.isnan(value)):
+        return []
+    if isinstance(value, list):
+        return value
+    if isinstance(value, tuple):
+        return list(value)
+    if isinstance(value, str):
+        parsed = safe_literal_eval(value)
+        if isinstance(parsed, list):
+            return parsed
+        if isinstance(parsed, tuple):
+            return list(parsed)
+    return []
+
+
+def _allocation_visible_node_ids(*frames: pd.DataFrame) -> set[str]:
+    visible_nodes: set[str] = set()
+    for df_in in frames:
+        if df_in is None or df_in.empty:
+            continue
+        for col in ("source", "destination"):
+            if col in df_in.columns:
+                visible_nodes.update(node_id for node_id in _normalize_node_id_series(df_in[col]).tolist() if node_id)
+        if "path" not in df_in.columns:
+            continue
+        for raw_path in df_in["path"].tolist():
+            for hop in _coerce_list_cell(raw_path):
+                hop_items = _coerce_list_cell(hop)
+                node_values = hop_items[:2] if len(hop_items) >= 2 else [hop]
+                for node in node_values:
+                    node_id = _normalize_node_id_value(node)
+                    if node_id:
+                        visible_nodes.add(node_id)
+    return visible_nodes
+
+
+def _allocation_endpoint_roles(
+    *frames: pd.DataFrame,
+    focus_pair: tuple[int, int] | None = None,
+) -> dict[str, str]:
+    if focus_pair is not None:
+        src = _normalize_node_id_value(focus_pair[0])
+        dst = _normalize_node_id_value(focus_pair[1])
+        roles = {}
+        if src:
+            roles[src] = "src"
+        if dst:
+            roles[dst] = "dst"
+        return roles
+
+    pairs: set[tuple[str, str]] = set()
+    for df_in in frames:
+        if df_in is None or df_in.empty or not {"source", "destination"} <= set(df_in.columns):
+            continue
+        src_ids = _normalize_node_id_series(df_in["source"])
+        dst_ids = _normalize_node_id_series(df_in["destination"])
+        for src, dst in zip(src_ids.tolist(), dst_ids.tolist()):
+            if src and dst:
+                pairs.add((src, dst))
+    if len(pairs) != 1:
+        return {}
+    src, dst = next(iter(pairs))
+    roles = {src: "src"}
+    if dst != src:
+        roles[dst] = "dst"
+    return roles
+
+
+def _format_node_label(value: Any, node_roles: dict[str, str] | None = None) -> str:
+    node_id = _normalize_node_id_value(value)
+    if not node_id:
+        return ""
+    role = (node_roles or {}).get(node_id)
+    if role:
+        return f"{node_id} ({role})"
+    return node_id
+
+
+def _coerce_numeric_float(value: Any) -> float | None:
+    try:
+        num = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    if not np.isfinite(num):
+        return None
+    return float(num)
+
+
+def _coerce_numeric_int(value: Any) -> int | None:
+    num = _coerce_numeric_float(value)
+    if num is None:
+        return None
+    return int(round(num))
+
+
+def _filter_allocation_rows_for_selected_nodes(
+    df_in: pd.DataFrame,
+    selected_nodes: set[str],
+    *,
+    sample_time: Any = None,
+    step_hint: Any = None,
+) -> pd.DataFrame:
+    if df_in.empty or not selected_nodes or not {"source", "destination"} <= set(df_in.columns):
+        return pd.DataFrame()
+
+    src_ids = _normalize_node_id_series(df_in["source"])
+    dst_ids = _normalize_node_id_series(df_in["destination"])
+    filtered = df_in.loc[src_ids.isin(selected_nodes) & dst_ids.isin(selected_nodes)].copy()
+    if filtered.empty:
+        return filtered
+
+    sample_time_num = _coerce_numeric_float(sample_time)
+    time_col = "time_s" if "time_s" in filtered.columns else "t_now_s" if "t_now_s" in filtered.columns else None
+    if sample_time_num is not None and time_col is not None:
+        t_series = pd.to_numeric(filtered[time_col], errors="coerce")
+        valid_times = sorted({float(v) for v in t_series.dropna().tolist()})
+        if valid_times:
+            nearest_time = min(valid_times, key=lambda value: abs(value - sample_time_num))
+            filtered = filtered.loc[t_series == nearest_time].copy()
+            if not filtered.empty:
+                return filtered
+
+    step_num = _coerce_numeric_int(step_hint)
+    if step_num is not None and "time_index" in filtered.columns:
+        step_series = pd.to_numeric(filtered["time_index"], errors="coerce")
+        valid_steps = sorted({int(round(float(v))) for v in step_series.dropna().tolist()})
+        if valid_steps:
+            nearest_step = min(valid_steps, key=lambda value: abs(value - step_num))
+            filtered = filtered.loc[step_series.round() == nearest_step].copy()
+
+    return filtered
+
+
+def _canonical_edge_pair(source: Any, target: Any) -> tuple[str, str] | None:
+    source_id = _normalize_node_id_value(source)
+    target_id = _normalize_node_id_value(target)
+    if not source_id or not target_id or source_id == target_id:
+        return None
+    return tuple(sorted((source_id, target_id)))

--- a/src/agilab/apps-pages/view_maps_network/src/view_maps_network/path_support.py
+++ b/src/agilab/apps-pages/view_maps_network/src/view_maps_network/path_support.py
@@ -1,0 +1,365 @@
+from __future__ import annotations
+
+import glob
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+def _candidate_edges_paths(bases: list[Path]) -> list[Path]:
+    seen = set()
+    candidates: list[Path] = []
+    known_relative = (
+        Path("pipeline/flows/topology.json"),
+        Path("pipeline/topology.gml"),
+        Path("pipeline/ilp_topology.gml"),
+        Path("pipeline/routing_edges.jsonl"),
+    )
+    patterns = (
+        # Common routing exports
+        "routing_edges.jsonl",
+        "routing_edges.ndjson",
+        "routing_edges.json",
+        "routing_edges.parquet",
+        # Generic edge exports
+        "edges.parquet",
+        "edges.json",
+        "edges.jsonl",
+        "edges.ndjson",
+        "edges.*.parquet",
+        "edges.*.json",
+        "edges.*.jsonl",
+        "edges.*.ndjson",
+        # Common topology exports (GML-format files often named .json)
+        "topology.json",
+        "topology.gml",
+        "ilp_topology.gml",
+    )
+    for base in bases:
+        if not base or not base.exists():
+            continue
+        # Fast path: check known default locations (avoids expensive globbing on large shares).
+        for rel in known_relative:
+            p = (base / rel).expanduser()
+            if p.exists() and p.is_file() and p not in seen:
+                if not any(part.startswith(".") for part in p.parts):
+                    seen.add(p)
+                    candidates.append(p)
+        for pattern in patterns:
+            for p in base.glob(f"**/{pattern}"):
+                if p in seen:
+                    continue
+                if any(part.startswith(".") for part in p.parts):
+                    continue
+                seen.add(p)
+                candidates.append(p)
+    candidates.sort(key=lambda p: p.stat().st_mtime if p.exists() else 0.0, reverse=True)
+    return candidates
+
+def _quick_share_edges_paths(share_root: Path) -> list[Path]:
+    seen: set[Path] = set()
+    candidates: list[Path] = []
+    known_relative = (
+        Path("pipeline/flows/topology.json"),
+        Path("pipeline/topology.gml"),
+        Path("pipeline/ilp_topology.gml"),
+        Path("pipeline/routing_edges.jsonl"),
+        Path("pipeline/routing_edges.parquet"),
+        Path("pipeline/edges.parquet"),
+        Path("pipeline/edges.json"),
+        Path("pipeline/edges.jsonl"),
+        Path("pipeline/edges.ndjson"),
+        Path("pipeline/topology.json"),
+        Path("pipeline/ilp_topology.json"),
+    )
+    if not share_root.exists():
+        return []
+    roots = [share_root]
+    try:
+        roots.extend(
+            [
+                entry
+                for entry in sorted(share_root.iterdir())
+                if entry.is_dir() and not entry.name.startswith(".")
+            ]
+        )
+    except (OSError, RuntimeError):
+        logger.debug("Unable to enumerate edge candidate roots under %s", share_root, exc_info=True)
+        roots = [share_root]
+    for root in roots:
+        for rel in known_relative:
+            p = (root / rel).expanduser()
+            if p.exists() and p.is_file():
+                try:
+                    resolved = p.resolve(strict=False)
+                except (OSError, RuntimeError):
+                    logger.debug("Unable to resolve edge candidate %s", p, exc_info=True)
+                    resolved = p
+                if resolved in seen:
+                    continue
+                seen.add(resolved)
+                candidates.append(p)
+    candidates.sort(key=lambda p: p.stat().st_mtime if p.exists() else 0.0, reverse=True)
+    return candidates
+
+
+def _quick_share_traj_globs(share_root: Path) -> list[str]:
+    share_root = share_root.expanduser()
+    candidates = [
+        str(share_root / "*_trajectory" / "pipeline" / "*.parquet"),
+        str(share_root / "*_trajectory" / "pipeline" / "*.csv"),
+        str(share_root / "*trajectory*" / "pipeline" / "*.parquet"),
+        str(share_root / "*trajectory*" / "pipeline" / "*.csv"),
+    ]
+    return [c for c in candidates if glob.glob(str(Path(c).expanduser()))]
+
+
+def _candidate_files_from_globs(globs_list: list[str]) -> list[Path]:
+    seen: set[Path] = set()
+    candidates: list[Path] = []
+    for pattern in globs_list:
+        expanded = Path(pattern).expanduser()
+        for match in glob.glob(str(expanded), recursive=True):
+            path = Path(match).expanduser()
+            if not path.is_file():
+                continue
+            try:
+                resolved = path.resolve(strict=False)
+            except Exception:
+                resolved = path
+            if resolved in seen:
+                continue
+            seen.add(resolved)
+            candidates.append(path)
+    candidates.sort(key=lambda p: p.stat().st_mtime if p.exists() else 0.0, reverse=True)
+    return candidates
+
+
+def _expand_glob_patterns(patterns: list[str], base_dirs: list[Path]) -> list[str]:
+    expanded: list[str] = []
+    seen: set[str] = set()
+    bases = [base.expanduser() for base in base_dirs if base]
+    for pattern in patterns:
+        raw = pattern.strip()
+        if not raw:
+            continue
+        path = Path(raw).expanduser()
+        candidates = [str(path)] if path.is_absolute() else [str(base / raw) for base in bases]
+        for candidate in candidates:
+            if candidate in seen:
+                continue
+            seen.add(candidate)
+            expanded.append(candidate)
+    return expanded
+
+
+def _resolve_declared_path(value: str, base_dirs: list[Path]) -> str:
+    raw = (value or "").strip()
+    if not raw:
+        return ""
+    path = Path(raw).expanduser()
+    if path.is_absolute():
+        return str(path)
+    bases = [base.expanduser() for base in base_dirs if base]
+    for base in bases:
+        candidate = (base / raw).expanduser()
+        if candidate.exists():
+            return str(candidate)
+    return str((bases[0] / raw).expanduser()) if bases else raw
+
+
+def _choose_existing_declared_path(current_value: str, default_value: str, base_dirs: list[Path]) -> str:
+    for candidate in (current_value, default_value):
+        raw = (candidate or "").strip()
+        if not raw:
+            continue
+        resolved = _resolve_declared_path(raw, base_dirs)
+        try:
+            path = Path(resolved).expanduser()
+        except (OSError, RuntimeError, TypeError, ValueError):
+            continue
+        if path.exists():
+            return str(path)
+
+    raw_current = (current_value or "").strip()
+    if raw_current:
+        return _resolve_declared_path(raw_current, base_dirs)
+
+    raw_default = (default_value or "").strip()
+    if raw_default:
+        return _resolve_declared_path(raw_default, base_dirs)
+    return ""
+
+
+def _resolve_edges_file_path(value: str, base_dirs: list[Path]) -> Path | None:
+    raw = (value or "").strip()
+    if not raw:
+        return None
+    resolved = _resolve_declared_path(raw, base_dirs)
+    try:
+        return Path(resolved).expanduser()
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return None
+
+
+def _candidate_cloudmap_paths(bases: list[Path], names: tuple[str, ...]) -> list[Path]:
+    seen: set[Path] = set()
+    candidates: list[Path] = []
+    relative_paths = tuple(
+        Path(prefix) / name
+        for name in names
+        for prefix in ("", "dataset", "pipeline")
+    )
+    for base in bases:
+        base = base.expanduser()
+        if not base.exists():
+            continue
+        roots = [base]
+        try:
+            roots.extend(
+                entry
+                for entry in sorted(base.iterdir())
+                if entry.is_dir() and not entry.name.startswith(".")
+            )
+        except (OSError, RuntimeError):
+            logger.debug("Unable to enumerate cloud map candidates under %s", base, exc_info=True)
+        for root in roots:
+            for rel in relative_paths:
+                candidate = (root / rel).expanduser()
+                if not candidate.exists() or not candidate.is_file():
+                    continue
+                try:
+                    resolved = candidate.resolve(strict=False)
+                except (OSError, RuntimeError):
+                    logger.debug("Unable to resolve cloud map candidate %s", candidate, exc_info=True)
+                    resolved = candidate
+                if resolved in seen:
+                    continue
+                seen.add(resolved)
+                candidates.append(candidate)
+    candidates.sort(key=lambda p: p.stat().st_mtime if p.exists() else 0.0, reverse=True)
+    return candidates
+
+
+def _allocation_search_roots(
+    *,
+    base_path: Path,
+    datadir_path: Path,
+    export_base: Path,
+    local_share_root: Path,
+    target_name: str,
+) -> tuple[Path, list[Path]]:
+    local_target_root = (local_share_root / str(target_name)).expanduser()
+    selected_target_root = (base_path / str(target_name)).expanduser()
+    preferred_target_root = (
+        selected_target_root
+        if selected_target_root.exists() or selected_target_root != local_target_root
+        else local_target_root
+    )
+
+    roots: list[Path] = []
+    seen: set[Path] = set()
+    for root in (
+        preferred_target_root,
+        local_target_root,
+        datadir_path,
+        export_base,
+    ):
+        for candidate in (root, root / "pipeline", root / "dataframe"):
+            try:
+                resolved = candidate.expanduser().resolve(strict=False)
+            except Exception:
+                resolved = candidate.expanduser()
+            if resolved in seen:
+                continue
+            seen.add(resolved)
+            roots.append(candidate.expanduser())
+
+    return preferred_target_root, roots
+
+
+def _candidate_allocation_paths(bases: list[Path]) -> list[Path]:
+    seen = set()
+    candidates: list[Path] = []
+    known_relative = (
+        Path("pipeline/allocations_steps.parquet"),
+        Path("pipeline/allocations_steps.json"),
+        Path("pipeline/allocations_steps.jsonl"),
+        Path("pipeline/allocations_steps.csv"),
+        Path("dataframe/allocations_steps.parquet"),
+        Path("dataframe/allocations_steps.json"),
+        Path("dataframe/allocations_steps.jsonl"),
+        Path("dataframe/allocations_steps.csv"),
+    )
+    patterns = (
+        "allocations_steps.parquet",
+        "allocations_steps.json",
+        "allocations_steps.jsonl",
+        "allocations_steps.ndjson",
+        "allocations_steps.csv",
+        "allocations*.parquet",
+        "allocations*.json",
+        "allocations*.jsonl",
+        "allocations*.ndjson",
+        "allocations*.csv",
+        "*allocations*.parquet",
+        "*allocations*.json",
+        "*allocations*.jsonl",
+        "*allocations*.ndjson",
+        "*allocations*.csv",
+    )
+    for base in bases:
+        if not base or not base.exists():
+            continue
+        for rel in known_relative:
+            p = (base / rel).expanduser()
+            if p.exists() and p.is_file() and p not in seen:
+                if not any(part.startswith(".") for part in p.parts):
+                    seen.add(p)
+                    candidates.append(p)
+        for pattern in patterns:
+            for p in base.glob(f"**/{pattern}"):
+                if p in seen:
+                    continue
+                if any(part.startswith(".") for part in p.parts):
+                    continue
+                seen.add(p)
+                candidates.append(p)
+    candidates.sort(key=lambda p: p.stat().st_mtime if p.exists() else 0.0, reverse=True)
+    return candidates
+
+def _is_baseline_alloc_path(path: Path) -> bool:
+    lowered = str(path).lower()
+    return ("baseline" in lowered) or ("ilp" in lowered) or ("stepper" in lowered)
+
+
+def _find_latest_allocations(base: Path, include: tuple[str, ...] = ()) -> Path | None:
+    """Locate the most recent allocations file under a given base."""
+    candidates: list[Path] = []
+    for pattern in (
+        "allocations*.parquet",
+        "allocations*.json",
+        "allocations*.jsonl",
+        "allocations*.ndjson",
+        "allocations*.csv",
+        "*allocations*.parquet",
+        "*allocations*.json",
+        "*allocations*.jsonl",
+        "*allocations*.ndjson",
+        "*allocations*.csv",
+        "allocations_steps.parquet",
+        "allocations_steps.csv",
+    ):
+        candidates.extend(base.rglob(pattern))
+    if not candidates:
+        return None
+    candidates = [p for p in candidates if p.is_file()]
+    if include:
+        lowered = [token.lower() for token in include if token]
+        if lowered:
+            candidates = [p for p in candidates if all(token in str(p).lower() for token in lowered)]
+    if not candidates:
+        return None
+    return max(candidates, key=lambda p: p.stat().st_mtime)
+
+# ----------------------------

--- a/src/agilab/apps-pages/view_maps_network/src/view_maps_network/view_maps_network.py
+++ b/src/agilab/apps-pages/view_maps_network/src/view_maps_network/view_maps_network.py
@@ -84,6 +84,144 @@ except ModuleNotFoundError:
         setting_list as _get_setting_list,
     )
 
+try:
+    from allocation_support import (
+        _coerce_alloc_time_index,
+        _drop_index_levels_shadowing_columns,
+        _nearest_row,
+        _normalize_allocations_frame,
+        _parse_allocations_cell,
+        _pick_ci_column,
+        load_allocations,
+        safe_literal_eval,
+    )
+    from node_support import (
+        _allocation_endpoint_roles,
+        _allocation_visible_node_ids,
+        _candidate_node_ids,
+        _canonical_edge_pair,
+        _coerce_list_cell,
+        _coerce_numeric_float,
+        _coerce_numeric_int,
+        _filter_allocation_rows_for_selected_nodes,
+        _format_node_label,
+        _normalize_node_id_series,
+        _normalize_node_id_value,
+        _preferred_node_id_from_row,
+        _resolve_node_id,
+        _semantic_node_id_from_text,
+        _strip_export_suffix,
+    )
+    from path_support import (
+        _allocation_search_roots,
+        _candidate_allocation_paths,
+        _candidate_cloudmap_paths,
+        _candidate_edges_paths,
+        _candidate_files_from_globs,
+        _choose_existing_declared_path,
+        _expand_glob_patterns,
+        _find_latest_allocations,
+        _is_baseline_alloc_path,
+        _quick_share_edges_paths,
+        _quick_share_traj_globs,
+        _resolve_declared_path,
+        _resolve_edges_file_path,
+    )
+except ModuleNotFoundError:
+    page_dir = Path(__file__).resolve().parent
+    page_dir_str = str(page_dir)
+    if page_dir_str not in sys.path:
+        sys.path.insert(0, page_dir_str)
+    from allocation_support import (
+        _coerce_alloc_time_index,
+        _drop_index_levels_shadowing_columns,
+        _nearest_row,
+        _normalize_allocations_frame,
+        _parse_allocations_cell,
+        _pick_ci_column,
+        load_allocations,
+        safe_literal_eval,
+    )
+    from node_support import (
+        _allocation_endpoint_roles,
+        _allocation_visible_node_ids,
+        _candidate_node_ids,
+        _canonical_edge_pair,
+        _coerce_list_cell,
+        _coerce_numeric_float,
+        _coerce_numeric_int,
+        _filter_allocation_rows_for_selected_nodes,
+        _format_node_label,
+        _normalize_node_id_series,
+        _normalize_node_id_value,
+        _preferred_node_id_from_row,
+        _resolve_node_id,
+        _semantic_node_id_from_text,
+        _strip_export_suffix,
+    )
+    from path_support import (
+        _allocation_search_roots,
+        _candidate_allocation_paths,
+        _candidate_cloudmap_paths,
+        _candidate_edges_paths,
+        _candidate_files_from_globs,
+        _choose_existing_declared_path,
+        _expand_glob_patterns,
+        _find_latest_allocations,
+        _is_baseline_alloc_path,
+        _quick_share_edges_paths,
+        _quick_share_traj_globs,
+        _resolve_declared_path,
+        _resolve_edges_file_path,
+    )
+
+def _semantic_node_id_from_text(value: Any) -> str | None:
+    text = _strip_export_suffix(value)
+    if not text:
+        return None
+    digits = "".join(ch for ch in text if ch.isdigit())
+    if not digits:
+        return None
+    try:
+        return str(int(digits))
+    except ValueError:
+        return None
+
+
+def _choose_existing_declared_path(current_value: str, default_value: str, base_dirs: list[Path]) -> str:
+    for candidate in (current_value, default_value):
+        raw = (candidate or "").strip()
+        if not raw:
+            continue
+        resolved = _resolve_declared_path(raw, base_dirs)
+        try:
+            path = Path(resolved).expanduser()
+        except (OSError, RuntimeError, TypeError, ValueError):
+            continue
+        if path.exists():
+            return str(path)
+
+    raw_current = (current_value or "").strip()
+    if raw_current:
+        return _resolve_declared_path(raw_current, base_dirs)
+
+    raw_default = (default_value or "").strip()
+    if raw_default:
+        return _resolve_declared_path(raw_default, base_dirs)
+    return ""
+
+
+def _resolve_edges_file_path(value: str, base_dirs: list[Path]) -> Path | None:
+    raw = (value or "").strip()
+    if not raw:
+        return None
+    resolved = _resolve_declared_path(raw, base_dirs)
+    try:
+        return Path(resolved).expanduser()
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return None
+
+
 logger = AgiLogger.get_logger(__name__)
 _TRAILING_EXPORT_TIMESTAMP_RE = re.compile(r"[_-]\d{4}-\d{2}-\d{2}(?:[_-]\d{2}-\d{2}-\d{2})?$")
 _HEATMAP_NUMBA_KERNEL: Any | None = None
@@ -1159,474 +1297,6 @@ def _label_for_link(column: str) -> str:
         label = label[: -len("_link")]
     return label.replace("_", " ").upper()
 
-def _candidate_edges_paths(bases: list[Path]) -> list[Path]:
-    seen = set()
-    candidates: list[Path] = []
-    known_relative = (
-        Path("pipeline/flows/topology.json"),
-        Path("pipeline/topology.gml"),
-        Path("pipeline/ilp_topology.gml"),
-        Path("pipeline/routing_edges.jsonl"),
-    )
-    patterns = (
-        # Common routing exports
-        "routing_edges.jsonl",
-        "routing_edges.ndjson",
-        "routing_edges.json",
-        "routing_edges.parquet",
-        # Generic edge exports
-        "edges.parquet",
-        "edges.json",
-        "edges.jsonl",
-        "edges.ndjson",
-        "edges.*.parquet",
-        "edges.*.json",
-        "edges.*.jsonl",
-        "edges.*.ndjson",
-        # Common topology exports (GML-format files often named .json)
-        "topology.json",
-        "topology.gml",
-        "ilp_topology.gml",
-    )
-    for base in bases:
-        if not base or not base.exists():
-            continue
-        # Fast path: check known default locations (avoids expensive globbing on large shares).
-        for rel in known_relative:
-            p = (base / rel).expanduser()
-            if p.exists() and p.is_file() and p not in seen:
-                if not any(part.startswith(".") for part in p.parts):
-                    seen.add(p)
-                    candidates.append(p)
-        for pattern in patterns:
-            for p in base.glob(f"**/{pattern}"):
-                if p in seen:
-                    continue
-                if any(part.startswith(".") for part in p.parts):
-                    continue
-                seen.add(p)
-                candidates.append(p)
-    candidates.sort(key=lambda p: p.stat().st_mtime if p.exists() else 0.0, reverse=True)
-    return candidates
-
-def _quick_share_edges_paths(share_root: Path) -> list[Path]:
-    seen: set[Path] = set()
-    candidates: list[Path] = []
-    known_relative = (
-        Path("pipeline/flows/topology.json"),
-        Path("pipeline/topology.gml"),
-        Path("pipeline/ilp_topology.gml"),
-        Path("pipeline/routing_edges.jsonl"),
-        Path("pipeline/routing_edges.parquet"),
-        Path("pipeline/edges.parquet"),
-        Path("pipeline/edges.json"),
-        Path("pipeline/edges.jsonl"),
-        Path("pipeline/edges.ndjson"),
-        Path("pipeline/topology.json"),
-        Path("pipeline/ilp_topology.json"),
-    )
-    if not share_root.exists():
-        return []
-    roots = [share_root]
-    try:
-        roots.extend(
-            [
-                entry
-                for entry in sorted(share_root.iterdir())
-                if entry.is_dir() and not entry.name.startswith(".")
-            ]
-        )
-    except (OSError, RuntimeError):
-        logger.debug("Unable to enumerate edge candidate roots under %s", share_root, exc_info=True)
-        roots = [share_root]
-    for root in roots:
-        for rel in known_relative:
-            p = (root / rel).expanduser()
-            if p.exists() and p.is_file():
-                try:
-                    resolved = p.resolve(strict=False)
-                except (OSError, RuntimeError):
-                    logger.debug("Unable to resolve edge candidate %s", p, exc_info=True)
-                    resolved = p
-                if resolved in seen:
-                    continue
-                seen.add(resolved)
-                candidates.append(p)
-    candidates.sort(key=lambda p: p.stat().st_mtime if p.exists() else 0.0, reverse=True)
-    return candidates
-
-
-def _quick_share_traj_globs(share_root: Path) -> list[str]:
-    share_root = share_root.expanduser()
-    candidates = [
-        str(share_root / "*_trajectory" / "pipeline" / "*.parquet"),
-        str(share_root / "*_trajectory" / "pipeline" / "*.csv"),
-        str(share_root / "*trajectory*" / "pipeline" / "*.parquet"),
-        str(share_root / "*trajectory*" / "pipeline" / "*.csv"),
-    ]
-    return [c for c in candidates if glob.glob(str(Path(c).expanduser()))]
-
-
-def _candidate_files_from_globs(globs_list: list[str]) -> list[Path]:
-    seen: set[Path] = set()
-    candidates: list[Path] = []
-    for pattern in globs_list:
-        expanded = Path(pattern).expanduser()
-        for match in glob.glob(str(expanded), recursive=True):
-            path = Path(match).expanduser()
-            if not path.is_file():
-                continue
-            try:
-                resolved = path.resolve(strict=False)
-            except Exception:
-                resolved = path
-            if resolved in seen:
-                continue
-            seen.add(resolved)
-            candidates.append(path)
-    candidates.sort(key=lambda p: p.stat().st_mtime if p.exists() else 0.0, reverse=True)
-    return candidates
-
-
-def _expand_glob_patterns(patterns: list[str], base_dirs: list[Path]) -> list[str]:
-    expanded: list[str] = []
-    seen: set[str] = set()
-    bases = [base.expanduser() for base in base_dirs if base]
-    for pattern in patterns:
-        raw = pattern.strip()
-        if not raw:
-            continue
-        path = Path(raw).expanduser()
-        candidates = [str(path)] if path.is_absolute() else [str(base / raw) for base in bases]
-        for candidate in candidates:
-            if candidate in seen:
-                continue
-            seen.add(candidate)
-            expanded.append(candidate)
-    return expanded
-
-
-def _resolve_declared_path(value: str, base_dirs: list[Path]) -> str:
-    raw = (value or "").strip()
-    if not raw:
-        return ""
-    path = Path(raw).expanduser()
-    if path.is_absolute():
-        return str(path)
-    bases = [base.expanduser() for base in base_dirs if base]
-    for base in bases:
-        candidate = (base / raw).expanduser()
-        if candidate.exists():
-            return str(candidate)
-    return str((bases[0] / raw).expanduser()) if bases else raw
-
-
-def _choose_existing_declared_path(current_value: str, default_value: str, base_dirs: list[Path]) -> str:
-    for candidate in (current_value, default_value):
-        raw = (candidate or "").strip()
-        if not raw:
-            continue
-        resolved = _resolve_declared_path(raw, base_dirs)
-        try:
-            path = Path(resolved).expanduser()
-        except (OSError, RuntimeError, TypeError, ValueError):
-            continue
-        if path.exists():
-            return str(path)
-
-    raw_current = (current_value or "").strip()
-    if raw_current:
-        return _resolve_declared_path(raw_current, base_dirs)
-
-    raw_default = (default_value or "").strip()
-    if raw_default:
-        return _resolve_declared_path(raw_default, base_dirs)
-    return ""
-
-
-def _resolve_edges_file_path(value: str, base_dirs: list[Path]) -> Path | None:
-    raw = (value or "").strip()
-    if not raw:
-        return None
-    resolved = _resolve_declared_path(raw, base_dirs)
-    try:
-        return Path(resolved).expanduser()
-    except (OSError, RuntimeError, TypeError, ValueError):
-        return None
-
-
-def _candidate_cloudmap_paths(bases: list[Path], names: tuple[str, ...]) -> list[Path]:
-    seen: set[Path] = set()
-    candidates: list[Path] = []
-    relative_paths = tuple(
-        Path(prefix) / name
-        for name in names
-        for prefix in ("", "dataset", "pipeline")
-    )
-    for base in bases:
-        base = base.expanduser()
-        if not base.exists():
-            continue
-        roots = [base]
-        try:
-            roots.extend(
-                entry
-                for entry in sorted(base.iterdir())
-                if entry.is_dir() and not entry.name.startswith(".")
-            )
-        except (OSError, RuntimeError):
-            logger.debug("Unable to enumerate cloud map candidates under %s", base, exc_info=True)
-        for root in roots:
-            for rel in relative_paths:
-                candidate = (root / rel).expanduser()
-                if not candidate.exists() or not candidate.is_file():
-                    continue
-                try:
-                    resolved = candidate.resolve(strict=False)
-                except (OSError, RuntimeError):
-                    logger.debug("Unable to resolve cloud map candidate %s", candidate, exc_info=True)
-                    resolved = candidate
-                if resolved in seen:
-                    continue
-                seen.add(resolved)
-                candidates.append(candidate)
-    candidates.sort(key=lambda p: p.stat().st_mtime if p.exists() else 0.0, reverse=True)
-    return candidates
-
-
-def _allocation_search_roots(
-    *,
-    base_path: Path,
-    datadir_path: Path,
-    export_base: Path,
-    local_share_root: Path,
-    target_name: str,
-) -> tuple[Path, list[Path]]:
-    local_target_root = (local_share_root / str(target_name)).expanduser()
-    selected_target_root = (base_path / str(target_name)).expanduser()
-    preferred_target_root = (
-        selected_target_root
-        if selected_target_root.exists() or selected_target_root != local_target_root
-        else local_target_root
-    )
-
-    roots: list[Path] = []
-    seen: set[Path] = set()
-    for root in (
-        preferred_target_root,
-        local_target_root,
-        datadir_path,
-        export_base,
-    ):
-        for candidate in (root, root / "pipeline", root / "dataframe"):
-            try:
-                resolved = candidate.expanduser().resolve(strict=False)
-            except Exception:
-                resolved = candidate.expanduser()
-            if resolved in seen:
-                continue
-            seen.add(resolved)
-            roots.append(candidate.expanduser())
-
-    return preferred_target_root, roots
-
-
-def _normalize_node_id_series(series: pd.Series) -> pd.Series:
-    """Normalize node IDs for consistent matching and drop invalid placeholders."""
-    raw = series.copy()
-    num = pd.to_numeric(raw, errors="coerce")
-    out = raw.astype("string").fillna("").astype(str).str.strip()
-    mask_int = num.notna() & np.isclose(num % 1, 0.0)
-    if mask_int.any():
-        out.loc[mask_int] = num.loc[mask_int].round().astype(int).astype(str)
-    invalid = out.str.lower().isin({"", "nan", "none", "nat", "<na>"})
-    out.loc[invalid] = ""
-    return out
-
-
-def _normalize_node_id_value(value: Any) -> str:
-    if value is None or (isinstance(value, float) and np.isnan(value)):
-        return ""
-    s = str(value).strip()
-    if not s or s.lower() in {"nan", "none", "nat", "<na>"}:
-        return ""
-    try:
-        num = float(s)
-        if np.isfinite(num) and np.isclose(num % 1, 0.0):
-            return str(int(round(num)))
-    except (TypeError, ValueError, OverflowError):
-        logger.debug("Node id %r is not an integer-like value", value, exc_info=True)
-    return s
-
-
-def _strip_export_suffix(value: Any) -> str:
-    text = str(value or "").strip()
-    if not text:
-        return ""
-    text = _TRAILING_EXPORT_TIMESTAMP_RE.sub("", text)
-    return re.sub(r"[-_](trajectory|traj)$", "", text, flags=re.IGNORECASE)
-
-
-def _semantic_node_id_from_text(value: Any) -> str | None:
-    text = _strip_export_suffix(value)
-    if not text:
-        return None
-    digits = "".join(ch for ch in text if ch.isdigit())
-    if not digits:
-        return None
-    try:
-        return str(int(digits))
-    except ValueError:
-        return None
-
-
-def _preferred_node_id_from_row(row: pd.Series, *, source_path: str | None = None) -> str:
-    semantic_columns = (
-        "plane_label",
-        "sat_name",
-        "plane_type",
-        "name",
-        "callsign",
-        "call_sign",
-        "stable_flight_id",
-        "node_label",
-        "trajectory_label",
-    )
-    for col in semantic_columns:
-        if col not in row:
-            continue
-        semantic_id = _semantic_node_id_from_text(row.get(col))
-        if semantic_id:
-            return semantic_id
-
-    source_value = row.get("source_file") if "source_file" in row else source_path
-    if source_value not in (None, ""):
-        semantic_id = _semantic_node_id_from_text(Path(str(source_value)).stem)
-        if semantic_id:
-            return semantic_id
-
-    for col in ("plane_id", "trajectory_id", "node_id", "flight_id", "id_col", "id"):
-        if col not in row:
-            continue
-        normalized = _normalize_node_id_value(row.get(col))
-        if normalized:
-            return normalized
-    return ""
-
-
-def _candidate_node_ids(value: Any) -> list[str]:
-    base = _normalize_node_id_value(value)
-    if not base:
-        return []
-    candidates = [base]
-    semantic_id = _semantic_node_id_from_text(value)
-    if semantic_id:
-        candidates.append(semantic_id)
-    prefixes = ("plane_", "sat_", "uav_", "node_")
-    lowered = base.lower()
-    for prefix in prefixes:
-        if lowered.startswith(prefix):
-            stripped = _normalize_node_id_value(base[len(prefix) :])
-            if stripped:
-                candidates.append(stripped)
-            break
-    for prefix in prefixes:
-        candidates.append(prefix + base)
-    deduped: list[str] = []
-    seen: set[str] = set()
-    for cand in candidates:
-        if cand and cand not in seen:
-            seen.add(cand)
-            deduped.append(cand)
-    return deduped
-
-
-def _resolve_node_id(value: Any, node_set: set[str]) -> str | None:
-    for cand in _candidate_node_ids(value):
-        if cand in node_set:
-            return cand
-    return None
-
-
-def _coerce_list_cell(value: Any) -> list[Any]:
-    if value is None or (isinstance(value, float) and np.isnan(value)):
-        return []
-    if isinstance(value, list):
-        return value
-    if isinstance(value, tuple):
-        return list(value)
-    if isinstance(value, str):
-        parsed = safe_literal_eval(value)
-        if isinstance(parsed, list):
-            return parsed
-        if isinstance(parsed, tuple):
-            return list(parsed)
-    return []
-
-
-def _allocation_visible_node_ids(*frames: pd.DataFrame) -> set[str]:
-    visible_nodes: set[str] = set()
-    for df_in in frames:
-        if df_in is None or df_in.empty:
-            continue
-        for col in ("source", "destination"):
-            if col in df_in.columns:
-                visible_nodes.update(node_id for node_id in _normalize_node_id_series(df_in[col]).tolist() if node_id)
-        if "path" not in df_in.columns:
-            continue
-        for raw_path in df_in["path"].tolist():
-            for hop in _coerce_list_cell(raw_path):
-                hop_items = _coerce_list_cell(hop)
-                node_values = hop_items[:2] if len(hop_items) >= 2 else [hop]
-                for node in node_values:
-                    node_id = _normalize_node_id_value(node)
-                    if node_id:
-                        visible_nodes.add(node_id)
-    return visible_nodes
-
-
-def _allocation_endpoint_roles(
-    *frames: pd.DataFrame,
-    focus_pair: tuple[int, int] | None = None,
-) -> dict[str, str]:
-    if focus_pair is not None:
-        src = _normalize_node_id_value(focus_pair[0])
-        dst = _normalize_node_id_value(focus_pair[1])
-        roles = {}
-        if src:
-            roles[src] = "src"
-        if dst:
-            roles[dst] = "dst"
-        return roles
-
-    pairs: set[tuple[str, str]] = set()
-    for df_in in frames:
-        if df_in is None or df_in.empty or not {"source", "destination"} <= set(df_in.columns):
-            continue
-        src_ids = _normalize_node_id_series(df_in["source"])
-        dst_ids = _normalize_node_id_series(df_in["destination"])
-        for src, dst in zip(src_ids.tolist(), dst_ids.tolist()):
-            if src and dst:
-                pairs.add((src, dst))
-    if len(pairs) != 1:
-        return {}
-    src, dst = next(iter(pairs))
-    roles = {src: "src"}
-    if dst != src:
-        roles[dst] = "dst"
-    return roles
-
-
-def _format_node_label(value: Any, node_roles: dict[str, str] | None = None) -> str:
-    node_id = _normalize_node_id_value(value)
-    if not node_id:
-        return ""
-    role = (node_roles or {}).get(node_id)
-    if role:
-        return f"{node_id} ({role})"
-    return node_id
-
-
 def _build_map_label_layers(
     positions_df: pd.DataFrame,
     *,
@@ -1699,61 +1369,6 @@ def _build_map_label_layers(
     return text_layers
 
 
-def _coerce_numeric_float(value: Any) -> float | None:
-    try:
-        num = float(value)
-    except (TypeError, ValueError, OverflowError):
-        return None
-    if not np.isfinite(num):
-        return None
-    return float(num)
-
-
-def _coerce_numeric_int(value: Any) -> int | None:
-    num = _coerce_numeric_float(value)
-    if num is None:
-        return None
-    return int(round(num))
-
-
-def _filter_allocation_rows_for_selected_nodes(
-    df_in: pd.DataFrame,
-    selected_nodes: set[str],
-    *,
-    sample_time: Any = None,
-    step_hint: Any = None,
-) -> pd.DataFrame:
-    if df_in.empty or not selected_nodes or not {"source", "destination"} <= set(df_in.columns):
-        return pd.DataFrame()
-
-    src_ids = _normalize_node_id_series(df_in["source"])
-    dst_ids = _normalize_node_id_series(df_in["destination"])
-    filtered = df_in.loc[src_ids.isin(selected_nodes) & dst_ids.isin(selected_nodes)].copy()
-    if filtered.empty:
-        return filtered
-
-    sample_time_num = _coerce_numeric_float(sample_time)
-    time_col = "time_s" if "time_s" in filtered.columns else "t_now_s" if "t_now_s" in filtered.columns else None
-    if sample_time_num is not None and time_col is not None:
-        t_series = pd.to_numeric(filtered[time_col], errors="coerce")
-        valid_times = sorted({float(v) for v in t_series.dropna().tolist()})
-        if valid_times:
-            nearest_time = min(valid_times, key=lambda value: abs(value - sample_time_num))
-            filtered = filtered.loc[t_series == nearest_time].copy()
-            if not filtered.empty:
-                return filtered
-
-    step_num = _coerce_numeric_int(step_hint)
-    if step_num is not None and "time_index" in filtered.columns:
-        step_series = pd.to_numeric(filtered["time_index"], errors="coerce")
-        valid_steps = sorted({int(round(float(v))) for v in step_series.dropna().tolist()})
-        if valid_steps:
-            nearest_step = min(valid_steps, key=lambda value: abs(value - step_num))
-            filtered = filtered.loc[step_series.round() == nearest_step].copy()
-
-    return filtered
-
-
 def _expanded_node_ids_from_allocations(
     selected_nodes: set[str],
     *,
@@ -1802,14 +1417,6 @@ def _endpoint_roles_from_allocations(
         if not step_df.empty:
             frames.append(step_df)
     return _allocation_endpoint_roles(*frames, focus_pair=focus_pair)
-
-
-def _canonical_edge_pair(source: Any, target: Any) -> tuple[str, str] | None:
-    source_id = _normalize_node_id_value(source)
-    target_id = _normalize_node_id_value(target)
-    if not source_id or not target_id or source_id == target_id:
-        return None
-    return tuple(sorted((source_id, target_id)))
 
 
 def _allocation_routed_edge_pairs(
@@ -1891,61 +1498,6 @@ def _preview_edge_count(df: pd.DataFrame, col: str) -> int:
         return len(convert_to_tuples(sample))
     except Exception:
         return 0
-
-def _candidate_allocation_paths(bases: list[Path]) -> list[Path]:
-    seen = set()
-    candidates: list[Path] = []
-    known_relative = (
-        Path("pipeline/allocations_steps.parquet"),
-        Path("pipeline/allocations_steps.json"),
-        Path("pipeline/allocations_steps.jsonl"),
-        Path("pipeline/allocations_steps.csv"),
-        Path("dataframe/allocations_steps.parquet"),
-        Path("dataframe/allocations_steps.json"),
-        Path("dataframe/allocations_steps.jsonl"),
-        Path("dataframe/allocations_steps.csv"),
-    )
-    patterns = (
-        "allocations_steps.parquet",
-        "allocations_steps.json",
-        "allocations_steps.jsonl",
-        "allocations_steps.ndjson",
-        "allocations_steps.csv",
-        "allocations*.parquet",
-        "allocations*.json",
-        "allocations*.jsonl",
-        "allocations*.ndjson",
-        "allocations*.csv",
-        "*allocations*.parquet",
-        "*allocations*.json",
-        "*allocations*.jsonl",
-        "*allocations*.ndjson",
-        "*allocations*.csv",
-    )
-    for base in bases:
-        if not base or not base.exists():
-            continue
-        for rel in known_relative:
-            p = (base / rel).expanduser()
-            if p.exists() and p.is_file() and p not in seen:
-                if not any(part.startswith(".") for part in p.parts):
-                    seen.add(p)
-                    candidates.append(p)
-        for pattern in patterns:
-            for p in base.glob(f"**/{pattern}"):
-                if p in seen:
-                    continue
-                if any(part.startswith(".") for part in p.parts):
-                    continue
-                seen.add(p)
-                candidates.append(p)
-    candidates.sort(key=lambda p: p.stat().st_mtime if p.exists() else 0.0, reverse=True)
-    return candidates
-
-def _is_baseline_alloc_path(path: Path) -> bool:
-    lowered = str(path).lower()
-    return ("baseline" in lowered) or ("ilp" in lowered) or ("stepper" in lowered)
-
 
 _RGB_LIKE_RE = re.compile(
     r"^rgba?\(\s*(?P<r>[-+]?\d*\.?\d+)\s*,\s*(?P<g>[-+]?\d*\.?\d+)\s*,\s*(?P<b>[-+]?\d*\.?\d+)\s*(?:,\s*(?P<a>[-+]?\d*\.?\d+)\s*)?\)$",
@@ -2312,189 +1864,6 @@ def filter_edges(df, edge_columns, allowed_edge_pairs: set[tuple[str, str]] | No
 
 # ----------------------------
 # Live allocations helpers
-# ----------------------------
-_ALLOC_STEP_CANDIDATES = ("time_index", "decision", "step", "time_idx")
-_ALLOC_TIME_CANDIDATES = ("time_s", "t_now_s", "time", "t")
-
-
-def _pick_ci_column(df: pd.DataFrame, candidates: tuple[str, ...]) -> Optional[str]:
-    if df.empty:
-        return None
-    lower_map = {str(c).lower(): str(c) for c in df.columns}
-    for key in candidates:
-        col = lower_map.get(key.lower())
-        if col is not None:
-            return col
-    return None
-
-
-def _parse_allocations_cell(value: Any) -> list[dict[str, Any]]:
-    if value is None or (isinstance(value, float) and np.isnan(value)):
-        return []
-    parsed: Any = value
-    if isinstance(parsed, str):
-        parsed = safe_literal_eval(parsed)
-    if isinstance(parsed, dict):
-        return [parsed]
-    if isinstance(parsed, tuple):
-        parsed = list(parsed)
-    if not isinstance(parsed, list):
-        return []
-    rows: list[dict[str, Any]] = []
-    for item in parsed:
-        obj = safe_literal_eval(item) if isinstance(item, str) else item
-        if isinstance(obj, dict):
-            rows.append(obj)
-    return rows
-
-
-def _coerce_alloc_time_index(df: pd.DataFrame) -> pd.DataFrame:
-    if df.empty:
-        return df
-    normalized = df.copy()
-    step_col = _pick_ci_column(normalized, _ALLOC_STEP_CANDIDATES)
-    if "time_index" not in normalized.columns and step_col is not None:
-        normalized["time_index"] = normalized[step_col]
-    if "time_index" not in normalized.columns:
-        normalized["time_index"] = 0
-
-    step_num = pd.to_numeric(normalized["time_index"], errors="coerce")
-    if step_num.notna().any():
-        if step_num.isna().any():
-            fallback = pd.Series(np.arange(len(normalized), dtype=float), index=normalized.index)
-            step_num = step_num.combine_first(fallback)
-        normalized["time_index"] = step_num.round().astype("Int64")
-    else:
-        normalized["time_index"] = pd.Series(np.arange(len(normalized)), index=normalized.index, dtype="Int64")
-    return normalized
-
-
-def _drop_index_levels_shadowing_columns(df: pd.DataFrame) -> pd.DataFrame:
-    """Drop named index levels that duplicate real column labels."""
-    if df.empty:
-        return df
-    index_names = [name for name in df.index.names if name is not None]
-    duplicated = [name for name in index_names if name in df.columns]
-    if not duplicated:
-        return df
-    return df.reset_index(level=duplicated, drop=True)
-
-
-def _normalize_allocations_frame(df_in: pd.DataFrame) -> pd.DataFrame:
-    if df_in.empty:
-        return df_in
-    df = df_in.copy()
-
-    src_col = _pick_ci_column(df, ("source", "src", "from"))
-    dst_col = _pick_ci_column(df, ("destination", "dst", "dest", "to", "target"))
-    if src_col is not None and src_col != "source":
-        df["source"] = df[src_col]
-    if dst_col is not None and dst_col != "destination":
-        df["destination"] = df[dst_col]
-
-    alloc_col = _pick_ci_column(df, ("allocations",))
-    if alloc_col is not None and ("source" not in df.columns or "destination" not in df.columns):
-        step_col = _pick_ci_column(df, _ALLOC_STEP_CANDIDATES)
-        t_col = _pick_ci_column(df, _ALLOC_TIME_CANDIDATES)
-        rows: list[dict[str, Any]] = []
-        for idx, row in df.iterrows():
-            step_value = row.get(step_col) if step_col is not None else idx
-            t_value = row.get(t_col) if t_col is not None else None
-            for alloc in _parse_allocations_cell(row.get(alloc_col)):
-                merged = dict(alloc)
-                merged.setdefault("time_index", step_value)
-                if t_value is not None:
-                    merged.setdefault("time_s", t_value)
-                    merged.setdefault("t_now_s", t_value)
-                rows.append(merged)
-        if rows:
-            df = pd.DataFrame(rows)
-
-    df = _coerce_alloc_time_index(df)
-
-    t_col = _pick_ci_column(df, _ALLOC_TIME_CANDIDATES)
-    if t_col is not None:
-        t_num = pd.to_numeric(df[t_col], errors="coerce")
-        if t_num.notna().any():
-            df["time_s"] = t_num
-            if "t_now_s" not in df.columns:
-                df["t_now_s"] = t_num
-    return df
-
-
-def load_allocations(path: Path) -> pd.DataFrame:
-    path = path.expanduser()
-    if not path.exists():
-        return pd.DataFrame()
-    if path.suffix.lower() == ".csv":
-        try:
-            return _normalize_allocations_frame(pd.read_csv(path))
-        except Exception:
-            return pd.DataFrame()
-    if path.suffix.lower() in {".parquet", ".pq", ".parq"}:
-        try:
-            return _normalize_allocations_frame(pd.read_parquet(path))
-        except Exception:
-            return pd.DataFrame()
-    try:
-        if path.suffix.lower() in {".jsonl", ".ndjson"}:
-            records: list[Any] = []
-            for line in path.read_text(encoding="utf-8").splitlines():
-                line = line.strip()
-                if not line:
-                    continue
-                records.append(json.loads(line))
-            data: Any = records
-        else:
-            data = json.loads(path.read_text(encoding="utf-8"))
-        if isinstance(data, list):
-            return _normalize_allocations_frame(pd.DataFrame(data))
-        elif isinstance(data, dict):
-            return _normalize_allocations_frame(pd.DataFrame([data]))
-    except Exception:
-        return pd.DataFrame()
-    return pd.DataFrame()
-
-
-def _nearest_row(df: pd.DataFrame, t: float, time_col: str = "time_s") -> pd.DataFrame:
-    if df.empty or time_col not in df.columns:
-        return df
-    series = pd.to_numeric(df[time_col], errors="coerce")
-    if series.dropna().empty:
-        return df.iloc[0:0]
-    idx = (series - t).abs().idxmin()
-    return df.loc[[idx]]
-
-
-def _find_latest_allocations(base: Path, include: tuple[str, ...] = ()) -> Path | None:
-    """Locate the most recent allocations file under a given base."""
-    candidates: list[Path] = []
-    for pattern in (
-        "allocations*.parquet",
-        "allocations*.json",
-        "allocations*.jsonl",
-        "allocations*.ndjson",
-        "allocations*.csv",
-        "*allocations*.parquet",
-        "*allocations*.json",
-        "*allocations*.jsonl",
-        "*allocations*.ndjson",
-        "*allocations*.csv",
-        "allocations_steps.parquet",
-        "allocations_steps.csv",
-    ):
-        candidates.extend(base.rglob(pattern))
-    if not candidates:
-        return None
-    candidates = [p for p in candidates if p.is_file()]
-    if include:
-        lowered = [token.lower() for token in include if token]
-        if lowered:
-            candidates = [p for p in candidates if all(token in str(p).lower() for token in lowered)]
-    if not candidates:
-        return None
-    return max(candidates, key=lambda p: p.stat().st_mtime)
-
 # ----------------------------
 # Optional edges loader (from synthetic topology export)
 # ----------------------------
@@ -3366,12 +2735,6 @@ def increment_time() -> None:
 
 def decrement_time() -> None:
     _shift_selected_time(-1)
-
-def safe_literal_eval(value):
-    try:
-        return ast.literal_eval(value)
-    except (ValueError, SyntaxError):
-        return value
 
 def extract_metrics(df: pd.DataFrame, metric_column: str) -> dict[str, list[float]]:
     metrics: dict[str, list[float]] = {}

--- a/src/agilab/apps-pages/view_queue_resilience/README.md
+++ b/src/agilab/apps-pages/view_queue_resilience/README.md
@@ -1,5 +1,10 @@
 # view_queue_resilience
 
+![view_queue_resilience preview](../../../../docs/source/_static/apps-pages-gallery/view_queue_resilience.svg)
+
+Package: `agi-page-queue-health`
+
+
 Streamlit analysis page for queue telemetry exported by any app that writes the
 AGILAB queue-analysis artifact contract.
 

--- a/src/agilab/apps-pages/view_relay_resilience/README.md
+++ b/src/agilab/apps-pages/view_relay_resilience/README.md
@@ -1,5 +1,10 @@
 # view_relay_resilience
 
+![view_relay_resilience preview](../../../../docs/source/_static/apps-pages-gallery/view_relay_resilience.svg)
+
+Package: `agi-page-relay-health`
+
+
 Streamlit analysis page for relay queue telemetry exported by any app that
 writes the AGILAB relay-resilience artifact contract.
 

--- a/src/agilab/apps-pages/view_release_decision/README.md
+++ b/src/agilab/apps-pages/view_release_decision/README.md
@@ -1,5 +1,10 @@
 # view_release_decision
 
+![view_release_decision preview](../../../../docs/source/_static/apps-pages-gallery/view_release_decision.svg)
+
+Package: `agi-page-promotion-gate`
+
+
 Reusable Streamlit evidence cockpit for baseline-vs-candidate run review and
 promotion decisions.
 

--- a/src/agilab/apps-pages/view_routing_model_comparison/README.md
+++ b/src/agilab/apps-pages/view_routing_model_comparison/README.md
@@ -1,0 +1,26 @@
+# view_routing_model_comparison
+
+![view_routing_model_comparison preview](../../../../docs/source/_static/apps-pages-gallery/view_routing_model_comparison.svg)
+
+Package: `agi-page-routing-model-comparison`
+
+Compares baseline and candidate routing allocation decisions.
+
+## When To Use It
+
+Use when routing models need allocation deltas, failure inspection, and side-by-side decision evidence.
+
+## Expected Inputs
+
+- Baseline and candidate allocation exports.
+- Optional queue-analysis pipeline run folders.
+
+Open it from `ANALYSIS` after selecting a project, or run it directly while developing:
+
+```bash
+uv --preview-features extra-build-dependencies run streamlit run src/agilab/apps-pages/view_routing_model_comparison/src/view_routing_model_comparison/view_routing_model_comparison.py -- --active-app src/agilab/apps/builtin/uav_relay_queue_project
+```
+
+## Quality Contract
+
+This bundle has a local README, a source-controlled preview asset, direct test coverage, and uses the shared `agi_pages.runtime` page chrome.

--- a/src/agilab/apps-pages/view_scenario_cockpit/README.md
+++ b/src/agilab/apps-pages/view_scenario_cockpit/README.md
@@ -1,5 +1,10 @@
 # view_scenario_cockpit
 
+![view_scenario_cockpit preview](../../../../docs/source/_static/apps-pages-gallery/view_scenario_cockpit.svg)
+
+Package: `agi-page-scenario-cockpit`
+
+
 Streamlit evidence cockpit for comparing exported scenario runs and packaging the
 selected baseline/candidate decision as JSON.
 

--- a/src/agilab/apps-pages/view_shap_explanation/README.md
+++ b/src/agilab/apps-pages/view_shap_explanation/README.md
@@ -1,5 +1,10 @@
 # SHAP Explanation View
 
+![view_shap_explanation preview](../../../../docs/source/_static/apps-pages-gallery/view_shap_explanation.svg)
+
+Package: `agi-page-feature-attribution`
+
+
 `view_shap_explanation` displays local feature-attribution evidence exported by
 SHAPKit, `shap`, or another compatible explainer.
 

--- a/src/agilab/apps-pages/view_training_analysis/README.md
+++ b/src/agilab/apps-pages/view_training_analysis/README.md
@@ -1,0 +1,26 @@
+# view_training_analysis
+
+![view_training_analysis preview](../../../../docs/source/_static/apps-pages-gallery/view_training_analysis.svg)
+
+Package: `agi-page-training-report`
+
+Browses scalar training runs from TensorBoard logs or AGILAB training-history CSVs.
+
+## When To Use It
+
+Use to compare trainers, tags, steps, and training curves before deeper model review.
+
+## Expected Inputs
+
+- tensorboard/ event logs.
+- data/training_history.csv.
+
+Open it from `ANALYSIS` after selecting a project, or run it directly while developing:
+
+```bash
+uv --preview-features extra-build-dependencies run streamlit run src/agilab/apps-pages/view_training_analysis/src/view_training_analysis/view_training_analysis.py -- --active-app src/agilab/apps/builtin/flight_telemetry_project
+```
+
+## Quality Contract
+
+This bundle has a local README, a source-controlled preview asset, direct test coverage, and uses the shared `agi_pages.runtime` page chrome.

--- a/src/agilab_mcp/manifest_tools.py
+++ b/src/agilab_mcp/manifest_tools.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from typing import Any, Mapping
 
@@ -275,3 +276,132 @@ def export_quarto_report(
     return bridge_cli.export_quarto_report(
         Path(manifest_path), Path(output_path), render=False
     )
+
+
+_CAPABILITIES_FILENAME = "agilab-capabilities.json"
+
+# Deterministic "start here" workflow for a fresh agent. Ordered cheapest /
+# safest first so an agent orients before acting.
+_QUICKSTART_WORKFLOW = (
+    "agent_context — build a safe, redacted context pack from prior agent-run evidence before acting.",
+    "list_agent_runs — discover recent runs; read_agent_run / summarize_agent_run to inspect one.",
+    "agent_handoff — get a compact continuation card; agent_next_actions for deterministic next steps.",
+    "list_projects / list_runs — enumerate apps and run manifests on disk.",
+    "read_manifest / summarize_run / list_artifacts — inspect a specific run's evidence.",
+)
+
+
+def _capabilities_manifest_path(explicit: str | Path | None = None) -> Path | None:
+    """Resolve the capabilities manifest.
+
+    An explicit path wins or fails (no silent fallback to a different manifest).
+    Otherwise auto-discover via env var, repo root, then cwd.
+    """
+    if explicit is not None:
+        candidate = Path(explicit).expanduser()
+        return candidate.resolve() if candidate.is_file() else None
+    candidates: list[Path] = []
+    env_value = os.environ.get("AGILAB_CAPABILITIES_MANIFEST")
+    if env_value:
+        candidates.append(Path(env_value).expanduser())
+    for parent in Path(__file__).resolve().parents:
+        candidates.append(parent / _CAPABILITIES_FILENAME)
+    candidates.append(Path.cwd() / _CAPABILITIES_FILENAME)
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate.resolve()
+    return None
+
+
+def agent_quickstart(
+    capabilities_path: str | Path | None = None,
+    max_items: int = 20,
+) -> dict[str, Any]:
+    """Return a bounded 'start here' overview for a fresh agent.
+
+    Condenses the capabilities manifest (boundary, CLI commands, app/skill
+    names, counts) plus a recommended workflow so an agent can orient without
+    reading the full multi-thousand-line manifest. Degrades gracefully when the
+    manifest is absent — the safety boundary, workflow, and pointers always
+    return. (The server layer also injects the live MCP tool list.)
+    """
+    limit = max(1, int(max_items))
+    overview: dict[str, Any] = {
+        "tool": "agilab",
+        "read_only_boundary": {
+            "local_files_only": True,
+            "execution_tools_enabled": False,
+            "shell_enabled": False,
+        },
+        "recommended_workflow": list(_QUICKSTART_WORKFLOW),
+    }
+
+    path = _capabilities_manifest_path(capabilities_path)
+    if path is None:
+        overview["capabilities_manifest"] = None
+        overview["note"] = (
+            "Capabilities manifest not found; set AGILAB_CAPABILITIES_MANIFEST or "
+            "run from the repo root. Use tools/list for full MCP tool schemas."
+        )
+        return overview
+
+    try:
+        manifest = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        overview["capabilities_manifest"] = None
+        overview["note"] = f"Capabilities manifest unreadable: {exc}"
+        return overview
+    if not isinstance(manifest, Mapping):
+        overview["capabilities_manifest"] = None
+        overview["note"] = "Capabilities manifest is not a JSON object."
+        return overview
+
+    def _items(key: str) -> list[Any]:
+        value = manifest.get(key)
+        return value if isinstance(value, list) else []
+
+    boundary = manifest.get("boundary")
+    overview["capabilities_manifest"] = str(path)
+    overview["what_is_agilab"] = (
+        boundary.get("proves") if isinstance(boundary, Mapping) else None
+    )
+    overview["cli_commands"] = [
+        {
+            "command": item.get("command"),
+            "kind": item.get("kind"),
+            "maturity": item.get("maturity"),
+            "description": item.get("description"),
+        }
+        for item in _items("cli_commands")[:limit]
+        if isinstance(item, Mapping)
+    ]
+    overview["public_apps"] = [
+        item.get("project")
+        for item in _items("public_apps")[:limit]
+        if isinstance(item, Mapping) and item.get("project")
+    ]
+    overview["agent_skills"] = [
+        item.get("name")
+        for item in _items("agent_skills")[:limit]
+        if isinstance(item, Mapping) and item.get("name")
+    ]
+    overview["docs"] = [
+        {"title": item.get("title"), "path": item.get("path")}
+        for item in _items("docs")[:limit]
+        if isinstance(item, Mapping)
+    ]
+    overview["counts"] = {
+        key: len(_items(key))
+        for key in (
+            "cli_commands",
+            "streamlit_pages",
+            "packages",
+            "public_apps",
+            "agent_skills",
+            "evidence_schemas",
+        )
+    }
+    overview["full_manifest_hint"] = (
+        f"Read {path.name} for full detail (evidence_schemas, packages, schemas)."
+    )
+    return overview

--- a/src/agilab_mcp/server.py
+++ b/src/agilab_mcp/server.py
@@ -288,6 +288,12 @@ def handle_jsonrpc(payload: Mapping[str, Any]) -> dict[str, Any] | None:
                     "protocolVersion": "2024-11-05",
                     "capabilities": {"tools": {}},
                     "serverInfo": {"name": "agilab-mcp", "version": "0.1.0"},
+                    "instructions": (
+                        "Call agent_quickstart first to orient (read-only): it returns "
+                        "the safety boundary, a recommended workflow, the live tool "
+                        "list, and a condensed capability overview without reading the "
+                        "full capabilities manifest."
+                    ),
                 },
             )
         if method == "tools/list":

--- a/src/agilab_mcp/server.py
+++ b/src/agilab_mcp/server.py
@@ -12,7 +12,23 @@ from agilab_mcp import manifest_tools
 
 ToolFn = Callable[..., dict[str, Any]]
 
+
+def _agent_quickstart(**kwargs: Any) -> dict[str, Any]:
+    """Curated 'start here' front door for agents.
+
+    Combines the manifest-sourced overview with the live MCP tool list so a
+    fresh agent gets everything it needs to orient from a single call.
+    """
+    overview = manifest_tools.agent_quickstart(**kwargs)
+    overview["mcp_tools"] = [
+        {"name": descriptor["name"], "description": descriptor["description"]}
+        for descriptor in tool_descriptors()
+    ]
+    return overview
+
+
 TOOLS: dict[str, ToolFn] = {
+    "agent_quickstart": _agent_quickstart,
     "list_projects": manifest_tools.list_projects,
     "list_runs": manifest_tools.list_runs,
     "list_agent_runs": manifest_tools.list_agent_runs,
@@ -33,6 +49,22 @@ TOOLS: dict[str, ToolFn] = {
 
 def tool_descriptors() -> list[dict[str, Any]]:
     return [
+        {
+            "name": "agent_quickstart",
+            "description": (
+                "Curated 'start here' for agents: read-only boundary, recommended "
+                "workflow, the live MCP tool list, and a condensed CLI/apps/skills "
+                "overview with counts — without reading the full capabilities manifest."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "capabilities_path": {"type": "string"},
+                    "max_items": {"type": "integer"},
+                },
+                "required": [],
+            },
+        },
         {
             "name": "list_projects",
             "description": "List AGILAB project directories under an apps root.",

--- a/test/test_app_contract_matrix.py
+++ b/test/test_app_contract_matrix.py
@@ -37,6 +37,7 @@ def test_app_contract_matrix_passes_current_repo():
     assert "checked_in_app_payloads_match_generated_payloads" in check_ids
     assert "apps_pages_root_keeps_asset_bundle_shape" in check_ids
     assert "apps_pages_catalog_matches_page_contract" in check_ids
+    assert "apps_pages_quality_bar" in check_ids
     assert "agi_pages_provider_matches_page_bundle_contract" in check_ids
     assert "promoted_pypi_app_catalog_matches_package_split" in check_ids
     assert "public_app_catalog_matches_package_contract" in check_ids

--- a/test/test_apps_pages_docs.py
+++ b/test/test_apps_pages_docs.py
@@ -6,17 +6,55 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 APPS_PAGES_ROOT = REPO_ROOT / "src/agilab/apps-pages"
 DOCS_SOURCE = REPO_ROOT / "docs/source"
+APPS_PAGES_GALLERY = DOCS_SOURCE / "apps-pages-gallery.rst"
+APPS_PAGES_GALLERY_ASSETS = DOCS_SOURCE / "_static/apps-pages-gallery"
 
 
-def test_apps_pages_catalog_documents_every_source_bundle() -> None:
-    catalog = (DOCS_SOURCE / "apps-pages.rst").read_text(encoding="utf-8")
-    page_modules = sorted(
+def _page_modules() -> list[str]:
+    return sorted(
         path.name
         for path in APPS_PAGES_ROOT.iterdir()
         if path.is_dir() and (path / "pyproject.toml").is_file()
     )
 
+
+def test_apps_pages_catalog_documents_every_source_bundle() -> None:
+    catalog = (DOCS_SOURCE / "apps-pages.rst").read_text(encoding="utf-8")
+    page_modules = _page_modules()
+
     assert page_modules
     for module_name in page_modules:
         assert f"``{module_name}``" in catalog
         assert f"{module_name}\n" in catalog
+
+
+def test_apps_pages_quality_bar_is_documented_and_enforced() -> None:
+    page_modules = _page_modules()
+    gallery = APPS_PAGES_GALLERY.read_text(encoding="utf-8")
+    root_readme = (APPS_PAGES_ROOT / "README.md").read_text(encoding="utf-8")
+    test_files = sorted((REPO_ROOT / "test").glob("test*.py"))
+
+    assert page_modules
+    for module_name in page_modules:
+        page_root = APPS_PAGES_ROOT / module_name
+        readme = page_root / "README.md"
+        preview = APPS_PAGES_GALLERY_ASSETS / f"{module_name}.svg"
+        source_files = sorted((page_root / "src" / module_name).glob("*.py"))
+        direct_tests = [
+            path
+            for path in test_files
+            if module_name in path.read_text(encoding="utf-8", errors="ignore")
+        ]
+
+        assert readme.is_file(), module_name
+        readme_text = readme.read_text(encoding="utf-8")
+        assert f"apps-pages-gallery/{module_name}.svg" in readme_text, module_name
+        assert preview.is_file(), module_name
+        assert f"_static/apps-pages-gallery/{module_name}.svg" in gallery, module_name
+        assert f"**{module_name}**" in gallery, module_name
+        assert f"apps-pages-gallery/{module_name}.svg" in root_readme, module_name
+        assert direct_tests, module_name
+        assert any(
+            "agi_pages.runtime" in path.read_text(encoding="utf-8", errors="ignore")
+            for path in source_files
+        ), module_name

--- a/test/test_audience_bridges.py
+++ b/test/test_audience_bridges.py
@@ -1101,3 +1101,69 @@ def test_mcp_jsonrpc_notifications_are_silent():
     assert handle_jsonrpc(
         {"jsonrpc": "2.0", "method": "unsupported/notification"}
     ) is None
+
+
+def test_mcp_tool_registry_and_descriptors_stay_in_parity() -> None:
+    """Every callable tool is advertised by tools/list, and vice versa.
+
+    Guards the agentic interface against a tool being registered without a
+    descriptor (invisible to agents) or advertised without an implementation
+    (tools/call would fail).
+    """
+    registered = set(mcp_server.TOOLS)
+    descriptors = [d["name"] for d in mcp_server.tool_descriptors()]
+    assert len(descriptors) == len(set(descriptors)), "duplicate tool descriptors"
+    assert set(descriptors) == registered
+    for descriptor in mcp_server.tool_descriptors():
+        assert descriptor.get("description")
+        assert descriptor.get("inputSchema", {}).get("type") == "object"
+
+
+def test_agent_quickstart_returns_bounded_curated_front_door() -> None:
+    """agent_quickstart gives a fresh agent a bounded 'start here' in one call."""
+    payload = mcp_server.call_tool("agent_quickstart", {})
+    # Always present, even without the capabilities manifest.
+    assert payload["read_only_boundary"]["local_files_only"] is True
+    assert payload["recommended_workflow"], "workflow guidance must be non-empty"
+    # The live MCP tool list is injected so the agent needs no second call.
+    advertised = {d["name"] for d in mcp_server.tool_descriptors()}
+    assert {t["name"] for t in payload["mcp_tools"]} == advertised
+    # quickstart leads tools/list so it is the first thing an agent sees.
+    assert mcp_server.tool_descriptors()[0]["name"] == "agent_quickstart"
+
+
+def test_agent_quickstart_bounds_manifest_lists(tmp_path) -> None:
+    """When the capabilities manifest is large, lists are capped and big sets
+    are summarized as counts rather than inlined."""
+    manifest = {
+        "boundary": {"proves": "discoverable surfaces"},
+        "cli_commands": [
+            {"command": f"cmd{i}", "kind": "k", "maturity": "m", "description": "d"}
+            for i in range(50)
+        ],
+        "public_apps": [{"project": f"app{i}"} for i in range(50)],
+        "agent_skills": [{"name": f"skill{i}"} for i in range(50)],
+        "evidence_schemas": [{"id": i} for i in range(214)],
+        "packages": [],
+        "streamlit_pages": [],
+        "docs": [],
+    }
+    path = tmp_path / "agilab-capabilities.json"
+    path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    payload = manifest_tools.agent_quickstart(capabilities_path=str(path), max_items=5)
+    assert payload["capabilities_manifest"] == str(path)
+    assert len(payload["cli_commands"]) == 5
+    assert len(payload["public_apps"]) == 5
+    assert payload["counts"]["cli_commands"] == 50
+    assert payload["counts"]["evidence_schemas"] == 214  # count, never inlined
+    assert "evidence_schemas" not in payload  # the 214-item list is not returned
+
+
+def test_agent_quickstart_degrades_without_manifest() -> None:
+    """Missing manifest still yields a safe, useful front door."""
+    payload = manifest_tools.agent_quickstart(capabilities_path="/nonexistent/x.json")
+    assert payload["capabilities_manifest"] is None
+    assert payload["recommended_workflow"]
+    assert payload["read_only_boundary"]["shell_enabled"] is False
+    assert "note" in payload

--- a/test/test_view_routing_model_comparison.py
+++ b/test/test_view_routing_model_comparison.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import math
+
+import pandas as pd
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = (
+    ROOT
+    / "src/agilab/apps-pages/view_routing_model_comparison/src/view_routing_model_comparison/view_routing_model_comparison.py"
+)
+
+
+def _load_module():
+    src_path = str((ROOT / "src").resolve())
+    if src_path not in sys.path:
+        sys.path.insert(0, src_path)
+    spec = importlib.util.spec_from_file_location(
+        "view_routing_model_comparison_test_module",
+        MODULE_PATH,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_routing_model_comparison_parses_allocation_helpers() -> None:
+    module = _load_module()
+
+    assert module.safe_bool("yes") is True
+    assert module.safe_bool("0") is False
+    assert module.safe_bool(None) is None
+    assert math.isnan(module.safe_float(None))
+    assert module.parse_list_value("[(1, 2), (2, 3)]") == [(1, 2), (2, 3)]
+    assert module.parse_list_value("not a literal") == ["not a literal"]
+    assert module.is_edge_list_path([(1, 2), (2, 3)])
+
+    routed = {
+        "path": "[(1, 2)]",
+        "delivered_bandwidth": 5.0,
+        "bandwidth": 10.0,
+        "bearers": "['SATCOM', 'ivdl']",
+    }
+    assert module.has_path(routed)
+    assert module.is_routed(routed)
+    assert module.get_satisfaction(routed) == 0.5
+    assert module.hop_count(routed) == 1
+    assert module.normalize_bearer("satcom") == "SAT"
+    assert module.normalize_bearer("ivdl") == "IVDL"
+    assert module.demand_outcome(False, 1.0) == "unrouted"
+    assert module.demand_outcome(True, 1.0) == "fulfilled"
+    assert module.demand_outcome(True, 0.5) == "partial"
+
+
+def test_routing_model_comparison_loads_and_summarizes_allocations(tmp_path: Path) -> None:
+    module = _load_module()
+    base = tmp_path / "pipeline"
+    ilp_path = base / "trainer_fcas_routing_ilp" / "allocations_steps.json"
+    ppo_path = base / "trainer_fcas_routing_ppo_gnn" / "allocations_steps.json"
+    ilp_path.parent.mkdir(parents=True)
+    ppo_path.parent.mkdir(parents=True)
+    ilp_path.write_text(
+        json.dumps(
+            [
+                {
+                    "time_index": 0,
+                    "allocations": [
+                        {
+                            "source_label": "A",
+                            "destination_label": "B",
+                            "bandwidth": 10.0,
+                            "delivered_bandwidth": 10.0,
+                            "served_fraction": 1.0,
+                            "latency_ms": 20.0,
+                            "latency_target_ms": 30.0,
+                            "routed": True,
+                            "bearers": ["SAT", "IVDL"],
+                            "path": [[1, 2], [2, 3]],
+                        },
+                        {
+                            "source": "C",
+                            "destination": "D",
+                            "bandwidth": 4.0,
+                            "delivered_bandwidth": 0.0,
+                            "path_found": False,
+                        },
+                    ],
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    ppo_path.write_text(
+        json.dumps(
+            [
+                {
+                    "time_index": 0,
+                    "allocations": [
+                        {
+                            "source_label": "A",
+                            "destination_label": "B",
+                            "bandwidth": 10.0,
+                            "delivered_bandwidth": 5.0,
+                            "latency_ms": 45.0,
+                            "latency_target_ms": 30.0,
+                            "routed": True,
+                            "bearers": ["SAT"],
+                            "path_labels": ["A", "relay", "B"],
+                        }
+                    ],
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    signatures = module.available_file_signatures(base)
+    alloc_df = module.load_allocations(signatures)
+    alloc_df = module.add_latency_targets(alloc_df)
+    summary = module.build_summary(alloc_df)
+    failures = module.build_failure_table(alloc_df)
+
+    assert set(alloc_df["model"]) == {"ILP", "PPO-GNN"}
+    assert alloc_df["outcome"].tolist().count("fulfilled") == 1
+    assert alloc_df["outcome"].tolist().count("unrouted") == 1
+    assert alloc_df["outcome"].tolist().count("partial") == 1
+    assert summary.set_index("model").loc["ILP", "routed_count"] == 1
+    assert summary.set_index("model").loc["PPO-GNN", "latency_violation_rate"] == 1.0
+    assert len(failures) == 2
+    assert "latency_over_target_ms" in failures.columns
+
+
+def test_routing_model_comparison_figures_handle_empty_and_visible_models() -> None:
+    module = _load_module()
+    alloc_df = pd.DataFrame(
+        [
+            {
+                "model": "ILP",
+                "time_index": 0,
+                "satisfaction_ratio": 1.0,
+                "delivered_mbps": 10.0,
+                "latency_ms": 20.0,
+                "latency_violation": False,
+                "routed": True,
+                "outcome": "fulfilled",
+                "hop_count": 2,
+                "sat_edge_count": 1,
+                "ivdl_edge_count": 1,
+            },
+            {
+                "model": "PPO-GNN",
+                "time_index": 0,
+                "satisfaction_ratio": 0.5,
+                "delivered_mbps": 5.0,
+                "latency_ms": 45.0,
+                "latency_violation": True,
+                "routed": True,
+                "outcome": "partial",
+                "hop_count": 2,
+                "sat_edge_count": 1,
+                "ivdl_edge_count": 0,
+            },
+        ]
+    )
+    summary = pd.DataFrame(
+        [
+            {
+                "model": "ILP",
+                "served_bandwidth_ratio": 1.0,
+                "mean_latency_ms": 20.0,
+                "latency_violation_rate": 0.0,
+                "routed_count": 1,
+            },
+            {
+                "model": "PPO-GNN",
+                "served_bandwidth_ratio": 0.5,
+                "mean_latency_ms": 45.0,
+                "latency_violation_rate": 1.0,
+                "routed_count": 1,
+            },
+        ]
+    )
+    models = ["ILP", "PPO-GNN"]
+
+    assert len(module.build_overview_figure(alloc_df, summary, models).data) >= 4
+    assert len(module.build_time_figure(alloc_df, models).data) == 8
+    assert len(module.build_path_figure(alloc_df, models).data) >= 2
+    assert module._format_summary(summary).columns.tolist() == models

--- a/tools/app_contract_matrix.py
+++ b/tools/app_contract_matrix.py
@@ -24,6 +24,8 @@ BUILTIN_APPS_REL = Path("src/agilab/apps/builtin")
 APPS_PAGES_REL = Path("src/agilab/apps-pages")
 PUBLIC_APP_CATALOG_REL = Path("docs/source/public-app-catalog.rst")
 APPS_PAGES_CATALOG_REL = Path("docs/source/apps-pages.rst")
+APPS_PAGES_GALLERY_REL = Path("docs/source/apps-pages-gallery.rst")
+APPS_PAGES_GALLERY_ASSETS_REL = Path("docs/source/_static/apps-pages-gallery")
 AGI_APPS_CATALOG_REL = Path("src/agilab/lib/agi-apps/src/agi_apps/catalog.json")
 AGI_PAGES_PROVIDER_REL = Path("src/agilab/lib/agi-pages/src/agi_pages/__init__.py")
 APP_PROJECT_BUILD_SUPPORT_REL = Path("src/agilab/lib/app_project_build_support.py")
@@ -799,6 +801,52 @@ def _status_includes_agi_pages(status: str) -> bool:
     return "included in" in normalized and "agi-pages" in normalized
 
 
+def _page_quality_contract_errors(repo_root: Path, page_modules: set[str]) -> dict[str, dict[str, Any]]:
+    gallery_path = repo_root / APPS_PAGES_GALLERY_REL
+    gallery_text = gallery_path.read_text(encoding="utf-8") if gallery_path.is_file() else ""
+    root_readme_path = repo_root / APPS_PAGES_REL / "README.md"
+    root_readme = root_readme_path.read_text(encoding="utf-8") if root_readme_path.is_file() else ""
+    test_files = sorted((repo_root / "test").rglob("test*.py"))
+    test_texts = {
+        _relative(repo_root, path): path.read_text(encoding="utf-8", errors="ignore")
+        for path in test_files
+    }
+
+    errors: dict[str, dict[str, Any]] = {}
+    for module in sorted(page_modules):
+        page_root = repo_root / APPS_PAGES_REL / module
+        readme_path = page_root / "README.md"
+        preview_path = repo_root / APPS_PAGES_GALLERY_ASSETS_REL / f"{module}.svg"
+        source_root = page_root / "src" / module
+        source_files = sorted(source_root.glob("*.py")) if source_root.is_dir() else []
+        direct_tests = sorted(
+            rel_path for rel_path, text in test_texts.items() if module in text
+        )
+        readme_text = readme_path.read_text(encoding="utf-8") if readme_path.is_file() else ""
+        source_text = "\n".join(
+            path.read_text(encoding="utf-8", errors="ignore") for path in source_files
+        )
+        module_errors: dict[str, Any] = {}
+        if not readme_path.is_file():
+            module_errors["readme"] = _relative(repo_root, readme_path)
+        elif f"apps-pages-gallery/{module}.svg" not in readme_text:
+            module_errors["readme_preview_link"] = _relative(repo_root, readme_path)
+        if not preview_path.is_file():
+            module_errors["preview"] = _relative(repo_root, preview_path)
+        if f"_static/apps-pages-gallery/{module}.svg" not in gallery_text or f"**{module}**" not in gallery_text:
+            module_errors["gallery"] = _relative(repo_root, gallery_path)
+        if f"apps-pages-gallery/{module}.svg" not in root_readme:
+            module_errors["root_gallery"] = _relative(repo_root, root_readme_path)
+        if not direct_tests:
+            module_errors["tests"] = "no test file references this page module"
+        if "agi_pages.runtime" not in source_text:
+            module_errors["shared_page_chrome"] = _relative(repo_root, source_root)
+        if module_errors:
+            module_errors["direct_tests"] = direct_tests
+            errors[module] = module_errors
+    return errors
+
+
 def _global_checks(
     repo_root: Path,
     *,
@@ -1008,6 +1056,23 @@ def _global_checks(
                 "package_mismatches": page_package_mismatches,
                 "included_rows_without_package_contract": included_rows_without_contract,
             },
+        )
+    )
+
+    page_quality_errors = _page_quality_contract_errors(repo_root, source_page_modules)
+    checks.append(
+        _check(
+            "apps_pages_quality_bar",
+            "Apps-pages quality bar",
+            not page_quality_errors,
+            "every page bundle has a README, preview asset, gallery entry, direct tests, and shared page chrome",
+            evidence=(
+                str(APPS_PAGES_REL),
+                str(APPS_PAGES_GALLERY_REL),
+                str(APPS_PAGES_GALLERY_ASSETS_REL),
+                "test",
+            ),
+            details={"errors": page_quality_errors},
         )
     )
 


### PR DESCRIPTION
## Summary

- Add an MCP `agent_quickstart` front door for curated agent capability discovery.
- Add a visual apps-pages gallery, per-page preview assets, and local README coverage for all page bundles.
- Enforce the apps-pages quality bar in the app contract matrix and docs tests.
- Extract `view_maps_network` allocation/path/node helpers into support modules while preserving focused tests.
- Sync the public docs mirror stamp from the canonical `thales_agilab/docs/source` tree.

## Validation

- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_app_contract_matrix.py test/test_apps_pages_docs.py test/test_view_routing_model_comparison.py test/test_audience_bridges.py`
- `uv --preview-features extra-build-dependencies run python tools/app_contract_matrix.py --compact`
- `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp`
- `uv --preview-features extra-build-dependencies run python -m py_compile src/agilab/apps-pages/view_maps_network/src/view_maps_network/view_maps_network.py src/agilab/apps-pages/view_maps_network/src/view_maps_network/allocation_support.py src/agilab/apps-pages/view_maps_network/src/view_maps_network/node_support.py src/agilab/apps-pages/view_maps_network/src/view_maps_network/path_support.py src/agilab_mcp/manifest_tools.py src/agilab_mcp/server.py tools/app_contract_matrix.py`
- `git diff --check`
