### PR TITLE
Document agent quickstart MCP entrypoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,11 @@ scripts that let GPT-5 Codex and human operators work from the same playbook. Th
 document mirrors the Spec Kit style guide so every agent—manual or autonomous—follows
 consistent launch, validation, and troubleshooting steps.
 
+> **Agent MCP start here**: When using `agilab-mcp`, call the read-only
+> `agent_quickstart` tool first. It returns the safety boundary, recommended
+> workflow, live tool list, and a condensed capability overview without reading
+> the full capabilities manifest.
+
 Use this runbook whenever you:
 - Launch Streamlit or CLI flows from PyCharm run configurations.
 - Regenerate agent/CLI wrappers after editing `.idea/runConfigurations`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,10 +5,9 @@ scripts that let GPT-5 Codex and human operators work from the same playbook. Th
 document mirrors the Spec Kit style guide so every agent—manual or autonomous—follows
 consistent launch, validation, and troubleshooting steps.
 
-> **Agent MCP start here**: When using `agilab-mcp`, call the read-only
-> `agent_quickstart` tool first. It returns the safety boundary, recommended
-> workflow, live tool list, and a condensed capability overview without reading
-> the full capabilities manifest.
+> **Agent MCP start here**: When using `agilab-mcp`, call `agent_quickstart`
+> first. It is read-only and returns the safety boundary, recommended workflow,
+> live tool list, and compact capability overview.
 
 Use this runbook whenever you:
 - Launch Streamlit or CLI flows from PyCharm run configurations.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ That loop is the product in miniature: controlled environment, reproducible
 execution, artifacts, run evidence, and a portable handoff path without needing
 the Streamlit UI or a cluster.
 
+## Agent Entry Point
+
+For MCP clients, start `agilab-mcp` and call `agent_quickstart` first. It is
+read-only and returns the safety boundary, recommended workflow, live tool list,
+and compact capability overview. The same entry point is advertised by the MCP
+`initialize` response and `agenticweb.md`.
+
 <p>
   <a href="https://pypi.org/project/agilab/"><img src="https://raw.githubusercontent.com/ThalesGroup/agilab/main/badges/pypi-version-agilab.svg" alt="PyPI version" /></a>
   <a href="https://pypi.org/project/agilab/#files"><img src="https://img.shields.io/badge/wheel-yes-0F766E" alt="Wheel: yes" /></a>
@@ -74,14 +81,11 @@ the Streamlit UI or a cluster.
 
 AGILAB also preserves a notebook export path.
 That export is an `agi-core` runtime handoff: you can continue to run the saved
-project and stage contract with only the stable, production-grade core
-technology, without depending on the AGILAB UI or distributed worker layer.
-The stable core runtime remains the smallest supported handoff surface.
-That means you do not lose your work if the AGILAB UI or distributed runtime is
-no longer the right interface. Those apps can run locally or on distributed
-workers, and the workflow stays portable: export it back to an `agi-core`
-notebook, inspect or adapt the Python stages, and hand off tracking evidence to
-MLflow when that integration is enabled.
+project and stage contract through the stable core runtime, without depending on
+the AGILAB UI or distributed worker layer. Apps can run locally or on
+distributed workers, then export back to an `agi-core` notebook, inspect or
+adapt the Python stages, and hand off tracking evidence to MLflow when that
+integration is enabled.
 Apps can also declare multiple UI surfaces, so an app can keep the same runtime
 and evidence contract while exposing Streamlit, hosted Hugging Face, or
 browser-native `agi-web` UI islands with React-ready component contracts.
@@ -112,9 +116,8 @@ notebook / MLflow / UI handoff
 
 The flow is reversible where it matters for long-term reuse: WORKFLOW can export
 the saved pipeline as a runnable `agi-core` supervisor notebook, so the code,
-stage order, runtime hints, and review context remain usable through the stable,
-core runtime if the AGILAB UI or distributed runtime is no
-longer the right interface for that work.
+stage order, runtime hints, and review context remain usable outside the
+workbench.
 
 ## Demo Routes
 

--- a/agenticweb.md
+++ b/agenticweb.md
@@ -190,6 +190,8 @@ capabilities:
       cache: true
       execute: false
     transport: "stdio"
+    entrypoint: "agent_quickstart"
+    instructions: "Call agent_quickstart first to orient: it returns the read-only safety boundary, recommended workflow, live tool list, and a condensed capability overview."
   - kind: "api"
     id: "agent-run-evidence"
     description: "Wrap coding-agent actions with redacted manifests, traces, and local artifact pointers."

--- a/agenticweb.md
+++ b/agenticweb.md
@@ -191,7 +191,7 @@ capabilities:
       execute: false
     transport: "stdio"
     entrypoint: "agent_quickstart"
-    instructions: "Call agent_quickstart first to orient: it returns the read-only safety boundary, recommended workflow, live tool list, and a condensed capability overview."
+    instructions: "Call agent_quickstart first. It is read-only and returns the safety boundary, recommended workflow, live tool list, and compact capability overview."
   - kind: "api"
     id: "agent-run-evidence"
     description: "Wrap coding-agent actions with redacted manifests, traces, and local artifact pointers."

--- a/src/agilab_mcp/server.py
+++ b/src/agilab_mcp/server.py
@@ -289,10 +289,9 @@ def handle_jsonrpc(payload: Mapping[str, Any]) -> dict[str, Any] | None:
                     "capabilities": {"tools": {}},
                     "serverInfo": {"name": "agilab-mcp", "version": "0.1.0"},
                     "instructions": (
-                        "Call agent_quickstart first to orient (read-only): it returns "
-                        "the safety boundary, a recommended workflow, the live tool "
-                        "list, and a condensed capability overview without reading the "
-                        "full capabilities manifest."
+                        "Call agent_quickstart first. It is read-only and returns "
+                        "the safety boundary, recommended workflow, live tool list, "
+                        "and compact capability overview."
                     ),
                 },
             )

--- a/test/test_agenticweb_manifest.py
+++ b/test/test_agenticweb_manifest.py
@@ -57,6 +57,8 @@ def test_agenticweb_manifest_builds_compact_discovery_from_capabilities(tmp_path
     by_id = {item["id"]: item for item in payload["capabilities"]}
     assert by_id["capability-manifest"]["kind"] == "data"
     assert by_id["read-only-evidence"]["kind"] == "mcp"
+    assert by_id["read-only-evidence"]["entrypoint"] == "agent_quickstart"
+    assert "Call agent_quickstart first" in by_id["read-only-evidence"]["instructions"]
     assert by_id["streamlit-demo"]["kind"] == "ui"
     assert by_id["first-proof-cli"]["permissions"]["execute"] is True
     assert by_id["capability-map"]["permissions"]["train"] is False
@@ -75,6 +77,7 @@ def test_agenticweb_manifest_render_and_check(tmp_path: Path) -> None:
     assert module.check_output(output_path, manifest_path) is True
     text = output_path.read_text(encoding="utf-8")
     assert text.startswith("---\nagenticweb: \"1\"")
+    assert "agent_quickstart" in text
     assert "agilab-capabilities.json" in text
     assert "python3 tools/agenticweb_manifest.py --check" in text
 

--- a/test/test_agenticweb_manifest.py
+++ b/test/test_agenticweb_manifest.py
@@ -58,7 +58,9 @@ def test_agenticweb_manifest_builds_compact_discovery_from_capabilities(tmp_path
     assert by_id["capability-manifest"]["kind"] == "data"
     assert by_id["read-only-evidence"]["kind"] == "mcp"
     assert by_id["read-only-evidence"]["entrypoint"] == "agent_quickstart"
-    assert "Call agent_quickstart first" in by_id["read-only-evidence"]["instructions"]
+    assert by_id["read-only-evidence"]["instructions"].startswith(
+        "Call agent_quickstart first. It is read-only"
+    )
     assert by_id["streamlit-demo"]["kind"] == "ui"
     assert by_id["first-proof-cli"]["permissions"]["execute"] is True
     assert by_id["capability-map"]["permissions"]["train"] is False

--- a/test/test_audience_bridges.py
+++ b/test/test_audience_bridges.py
@@ -1103,6 +1103,21 @@ def test_mcp_jsonrpc_notifications_are_silent():
     ) is None
 
 
+def test_mcp_initialize_advertises_agent_quickstart_entrypoint() -> None:
+    response = mcp_server.handle_jsonrpc(
+        {"jsonrpc": "2.0", "id": 1, "method": "initialize"}
+    )
+
+    assert response is not None
+    result = response["result"]
+    assert result["capabilities"]["tools"] == {}
+    assert result["serverInfo"]["name"] == "agilab-mcp"
+    instructions = result["instructions"]
+    assert "Call agent_quickstart first" in instructions
+    assert "read-only" in instructions
+    assert "full capabilities manifest" in instructions
+
+
 def test_mcp_tool_registry_and_descriptors_stay_in_parity() -> None:
     """Every callable tool is advertised by tools/list, and vice versa.
 

--- a/test/test_audience_bridges.py
+++ b/test/test_audience_bridges.py
@@ -1113,9 +1113,9 @@ def test_mcp_initialize_advertises_agent_quickstart_entrypoint() -> None:
     assert result["capabilities"]["tools"] == {}
     assert result["serverInfo"]["name"] == "agilab-mcp"
     instructions = result["instructions"]
-    assert "Call agent_quickstart first" in instructions
-    assert "read-only" in instructions
-    assert "full capabilities manifest" in instructions
+    assert instructions.startswith("Call agent_quickstart first. It is read-only")
+    assert "recommended workflow" in instructions
+    assert "compact capability overview" in instructions
 
 
 def test_mcp_tool_registry_and_descriptors_stay_in_parity() -> None:

--- a/tools/agenticweb_manifest.py
+++ b/tools/agenticweb_manifest.py
@@ -284,9 +284,9 @@ def build_discovery(manifest_path: Path = DEFAULT_CAPABILITIES) -> dict[str, Any
                 transport="stdio",
                 entrypoint="agent_quickstart",
                 instructions=(
-                    "Call agent_quickstart first to orient: it returns the read-only "
-                    "safety boundary, recommended workflow, live tool list, and a "
-                    "condensed capability overview."
+                    "Call agent_quickstart first. It is read-only and returns the "
+                    "safety boundary, recommended workflow, live tool list, and "
+                    "compact capability overview."
                 ),
                 auth_required=False,
                 permissions=_permissions(executable=False),

--- a/tools/agenticweb_manifest.py
+++ b/tools/agenticweb_manifest.py
@@ -282,6 +282,12 @@ def build_discovery(manifest_path: Path = DEFAULT_CAPABILITIES) -> dict[str, Any
                 description="Read-only MCP bridge for AGILAB run and agent-run evidence.",
                 url="mcp://agilab/read-only-evidence",
                 transport="stdio",
+                entrypoint="agent_quickstart",
+                instructions=(
+                    "Call agent_quickstart first to orient: it returns the read-only "
+                    "safety boundary, recommended workflow, live tool list, and a "
+                    "condensed capability overview."
+                ),
                 auth_required=False,
                 permissions=_permissions(executable=False),
             ),


### PR DESCRIPTION
## Summary

- Document `agent_quickstart` as the first MCP call in the AGILAB agent runbook.
- Surface the same entrypoint and instructions in the generated AgenticWeb manifest.
- Add regression coverage for the manifest and MCP initialize instructions.

## Validation

- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_agenticweb_manifest.py test/test_audience_bridges.py`
- `uv --preview-features extra-build-dependencies run python -m py_compile tools/agenticweb_manifest.py`
- `git diff --check`
