### PR TITLE
[codex] Generalize chained command rule for merge

### DIFF
--- a/.claude/skills/agilab-intent-router/SKILL.md
+++ b/.claude/skills/agilab-intent-router/SKILL.md
@@ -46,11 +46,12 @@ constraint   ::= "only agilab" | "no tests" | "from current repo" | "from anothe
 8. If the previous turn established scope, `do it`, `go on`, and `check again`
    inherit that scope; otherwise inspect current repo state and ask only if
    action would be risky.
-9. If one user message combines an execution command with a follow-up planning
-   request, for example `do it; then next move`, treat it as a single ordered
-   turn: execute, validate, report the result, then give the next recommendation.
-   This avoids an extra prompt round trip while preserving current-state
-   inspection before the recommendation.
+9. If one user message combines execution, validation, publish, merge, or
+   follow-up planning requests, for example `do it; validate; push if clean;
+   merge it; then next move`, treat it as a single ordered turn. Execute each
+   explicit step only after its safety gate is satisfied, report the result,
+   then give the next recommendation. This avoids extra prompt round trips while
+   preserving current-state inspection before merge or recommendation.
 
 ## Session-Derived Routes
 
@@ -80,10 +81,11 @@ Route these patterns before choosing tools:
   the user names them. Show concrete `git -C` commands before execution.
 - For `do it` after a proposal, execute the proposed action if repo state is
   safe. If state changed unexpectedly, report the changed branch/files first.
-- For combined commands such as `do it; validate; push if clean; then suggest
-  next move`, complete the ordered chain in one response when safe. Do not ask
-  for a second `next move` turn unless a blocker or risky ambiguity requires
-  user input.
+- For combined commands such as `do it; validate; push if clean; merge it; then
+  suggest next move`, complete the ordered chain in one response when safe. A
+  merge step still requires the current PR/branch to be clean, synchronized, and
+  passing required checks; stop and report the blocker instead of asking for a
+  second `merge it` or `next move` turn.
 - For `check again`, verify the authoritative source for the prior claim:
   current repo state, workflow status, docs mirror, PyPI/GitHub release, or
   cluster discovery as appropriate.

--- a/.codex/skills/agilab-intent-router/SKILL.md
+++ b/.codex/skills/agilab-intent-router/SKILL.md
@@ -46,11 +46,12 @@ constraint   ::= "only agilab" | "no tests" | "from current repo" | "from anothe
 8. If the previous turn established scope, `do it`, `go on`, and `check again`
    inherit that scope; otherwise inspect current repo state and ask only if
    action would be risky.
-9. If one user message combines an execution command with a follow-up planning
-   request, for example `do it; then next move`, treat it as a single ordered
-   turn: execute, validate, report the result, then give the next recommendation.
-   This avoids an extra prompt round trip while preserving current-state
-   inspection before the recommendation.
+9. If one user message combines execution, validation, publish, merge, or
+   follow-up planning requests, for example `do it; validate; push if clean;
+   merge it; then next move`, treat it as a single ordered turn. Execute each
+   explicit step only after its safety gate is satisfied, report the result,
+   then give the next recommendation. This avoids extra prompt round trips while
+   preserving current-state inspection before merge or recommendation.
 
 ## Session-Derived Routes
 
@@ -80,10 +81,11 @@ Route these patterns before choosing tools:
   the user names them. Show concrete `git -C` commands before execution.
 - For `do it` after a proposal, execute the proposed action if repo state is
   safe. If state changed unexpectedly, report the changed branch/files first.
-- For combined commands such as `do it; validate; push if clean; then suggest
-  next move`, complete the ordered chain in one response when safe. Do not ask
-  for a second `next move` turn unless a blocker or risky ambiguity requires
-  user input.
+- For combined commands such as `do it; validate; push if clean; merge it; then
+  suggest next move`, complete the ordered chain in one response when safe. A
+  merge step still requires the current PR/branch to be clean, synchronized, and
+  passing required checks; stop and report the blocker instead of asking for a
+  second `merge it` or `next move` turn.
 - For `check again`, verify the authoritative source for the prior claim:
   current repo state, workflow status, docs mirror, PyPI/GitHub release, or
   cluster discovery as appropriate.

--- a/AGENT_LEARNINGS.md
+++ b/AGENT_LEARNINGS.md
@@ -44,7 +44,9 @@ is not a scratchpad or task log.
   explain that `Deploy workers` still calls `AGI.install` because it prepares
   manager/worker runtime environments and reuses an already-ready local manager
   environment instead of forcing a reinstall.
-- When the user combines execution and follow-up planning in one message, such
-  as `do it; then next move`, treat it as an ordered single turn. Execute,
-  validate, report the result, and provide the next recommendation without
-  requiring a second user round trip unless a real blocker needs input.
+- When the user combines execution, validation, publish, merge, and follow-up
+  planning in one message, such as `do it; validate; push if clean; merge it;
+  then next move`, treat it as an ordered single turn. Execute each explicit
+  step after its safety gate, report the result, and provide the next
+  recommendation without requiring a second user round trip unless a real
+  blocker needs input.

--- a/test/test_session_intent_synthesis.py
+++ b/test/test_session_intent_synthesis.py
@@ -127,7 +127,12 @@ def test_session_rule_proposals_detect_candidates_and_existing_rules(tmp_path: P
                 "payload": {
                     "type": "message",
                     "role": "user",
-                    "content": [{"type": "input_text", "text": "do it + next move is cheaper"}],
+                    "content": [
+                        {
+                            "type": "input_text",
+                            "text": "do it; validate; push if clean; merge it; then next move",
+                        }
+                    ],
                 },
             },
             {
@@ -135,7 +140,12 @@ def test_session_rule_proposals_detect_candidates_and_existing_rules(tmp_path: P
                 "payload": {
                     "type": "message",
                     "role": "user",
-                    "content": [{"type": "input_text", "text": "do it + next move is cheaper"}],
+                    "content": [
+                        {
+                            "type": "input_text",
+                            "text": "do it; validate; push if clean; merge it; then next move",
+                        }
+                    ],
                 },
             },
             {
@@ -154,8 +164,8 @@ def test_session_rule_proposals_detect_candidates_and_existing_rules(tmp_path: P
         memory_paths=[],
         rule_surface_texts={
             "AGENT_LEARNINGS.md": (
-                "When the user combines execution and follow-up planning in one message, "
-                "treat it as an ordered single turn."
+                "When the user combines execution, validation, publish, merge, and "
+                "follow-up planning in one message, treat it as an ordered single turn."
             )
         },
         min_observations=1,
@@ -164,7 +174,9 @@ def test_session_rule_proposals_detect_candidates_and_existing_rules(tmp_path: P
     by_id = {proposal["id"]: proposal for proposal in payload["proposals"]}
     assert by_id["combined_execution_followup"]["status"] == "already-covered"
     assert by_id["combined_execution_followup"]["observations"] == 2
-    assert by_id["combined_execution_followup"]["redacted_examples"] == ["do it + next move is cheaper"]
+    assert by_id["combined_execution_followup"]["redacted_examples"] == [
+        "do it; validate; push if clean; merge it; then next move"
+    ]
     assert by_id["combined_execution_followup"]["duplicate_paths"] == ["AGENT_LEARNINGS.md"]
     assert by_id["explicit_rule_request"]["status"] == "candidate"
     assert "<redacted>" in json.dumps(by_id["explicit_rule_request"])

--- a/tools/session_intent_synthesis.py
+++ b/tools/session_intent_synthesis.py
@@ -158,21 +158,25 @@ RULE_PROPOSAL_PATTERNS = (
             "do it + next move",
             "do it then next move",
             "do it; validate; push",
+            "do it; validate; push if clean; merge it",
+            "merge it; then next move",
+            "merge it then next move",
             "then suggest next move",
             "then next move",
         ),
         ".claude/skills/agilab-intent-router/SKILL.md",
         (
-            "When a user combines execution and follow-up planning in one message, "
-            "treat it as an ordered single turn: execute, validate, report the "
+            "When a user combines execution, validation, publish, merge, and "
+            "follow-up planning in one message, treat it as an ordered single "
+            "turn: execute each explicit step after its safety gate, report the "
             "result, then provide the next recommendation unless a blocker needs input."
         ),
-        "Combining execution and follow-up planning avoids an extra prompt round trip.",
+        "Combining explicit safe steps avoids extra prompt round trips.",
         (
-            "combines execution and follow-up planning",
+            "combines execution, validation, publish, merge",
             "single ordered turn",
-            "do it; then next move",
-            "second `next move` turn",
+            "do it; validate; push if clean; merge it",
+            "second `merge it` or `next move` turn",
         ),
     ),
     RuleProposalPattern(


### PR DESCRIPTION
## Summary
- generalize the combined-command rule so explicit execution, validation, publish, merge, and follow-up planning requests can be handled in one ordered turn
- keep merge behavior gated on a clean synchronized branch/PR and passing required checks
- sync the Codex skill mirror and update the session-history rule proposal regression

## Validation
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_session_intent_synthesis.py
- uv --preview-features extra-build-dependencies run --extra dev ruff check tools/session_intent_synthesis.py test/test_session_intent_synthesis.py
- python3 -m py_compile tools/session_intent_synthesis.py test/test_session_intent_synthesis.py
- uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files .claude/skills/agilab-intent-router/SKILL.md .codex/skills/agilab-intent-router/SKILL.md AGENT_LEARNINGS.md tools/session_intent_synthesis.py test/test_session_intent_synthesis.py
- python3 tools/agent_instruction_contract.py --check
- python3 tools/sync_agent_skills.py --skills agilab-intent-router
- python3 tools/codex_skills.py --root .codex/skills validate --strict
- python3 tools/codex_skills.py --root .codex/skills generate
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile skills
- git diff --check
- ./dev scope