### PR TITLE
[codex] Add guarded release publish CLI shortcuts

### DIFF
--- a/src/agilab/lab_run.py
+++ b/src/agilab/lab_run.py
@@ -14,6 +14,7 @@
 import argparse
 import importlib.util
 import os
+import shlex
 import subprocess
 import sys
 import tomllib
@@ -44,6 +45,8 @@ packaged_streamlit_config_path = (
 UI_EXTRA_HINT = "Install the UI profile with `python -m pip install 'agilab[ui]'`."
 PYTORCH_PLAYGROUND_HF_SPACE = "jpmorard/agilab"
 PYTORCH_PLAYGROUND_APP_NAME = "pytorch_playground_project"
+AGILAB_GITHUB_REPO = "ThalesGroup/agilab"
+PYPI_PUBLISH_WORKFLOW = "pypi-publish.yaml"
 _PUBLIC_BIND_GUARD_MODULE = import_agilab_module(
     "agilab.ui_public_bind_guard",
     current_file=__file__,
@@ -198,6 +201,361 @@ def _run_workflow(argv: list[str]) -> int:
     return workflow_validation.main(argv)
 
 
+def _publish_repo_root() -> Path:
+    repo_root = _detect_repo_root(Path.cwd()) or _detect_repo_root(_PACKAGE_DIR)
+    if not repo_root:
+        raise SystemExit(
+            "agilab publish: run this maintainer command from the AGILAB source checkout."
+        )
+    workflow = repo_root / ".github" / "workflows" / PYPI_PUBLISH_WORKFLOW
+    release_plan = repo_root / "tools" / "release_plan.py"
+    if not workflow.is_file() or not release_plan.is_file():
+        raise SystemExit(
+            "agilab publish: the guarded release workflow was not found. "
+            "Real PyPI publication must use the AGILAB source checkout and "
+            ".github/workflows/pypi-publish.yaml."
+        )
+    return repo_root
+
+
+def _normalized_release_tag(value: str) -> str:
+    tag = value.strip()
+    return tag if tag.startswith("v") else f"v{tag}"
+
+
+def _shell_join(command: list[str]) -> str:
+    return " ".join(shlex.quote(part) for part in command)
+
+
+def _has_cli_option(argv: list[str], option: str) -> bool:
+    return any(arg == option or arg.startswith(f"{option}=") for arg in argv)
+
+
+def _pop_cli_flag(argv: list[str], option: str) -> bool:
+    if option not in argv:
+        return False
+    argv.remove(option)
+    return True
+
+
+def _uv_python_tool_command(
+    repo_root: Path, script_name: str, argv: list[str]
+) -> list[str]:
+    return [
+        "uv",
+        "--preview-features",
+        "extra-build-dependencies",
+        "run",
+        "python",
+        str(repo_root / "tools" / script_name),
+        *argv,
+    ]
+
+
+def _run_publish(argv: list[str], *, runner=subprocess.call) -> int:
+    parser = argparse.ArgumentParser(
+        prog="agilab publish",
+        description=(
+            "Dispatch the guarded AGILAB PyPI/GitHub release workflow. "
+            "Real PyPI publication stays workflow-owned through Trusted Publishing/OIDC."
+        ),
+    )
+    parser.add_argument(
+        "release_tag", nargs="?", help="Release tag, for example v2026.06.05."
+    )
+    parser.add_argument("--tag", dest="release_tag_option", help="Release tag alias.")
+    parser.add_argument(
+        "--packages", help="Optional package filter passed to the workflow."
+    )
+    parser.add_argument(
+        "--roles", help="Optional package-role filter passed to the workflow."
+    )
+    parser.add_argument(
+        "--impact-base-ref",
+        help="Publish only changed packages plus exact-pin dependents since this ref.",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=("stable", "hotfix", "candidate", "repair"),
+        default="stable",
+        help="Release intent passed as workflow release_mode.",
+    )
+    parser.add_argument(
+        "--include-existing-pypi",
+        action="store_true",
+        help="Include already-published PyPI artifacts for release-asset repair.",
+    )
+    parser.add_argument(
+        "--ref", default="main", help="Git ref used for workflow dispatch."
+    )
+    parser.add_argument("--repo", default=AGILAB_GITHUB_REPO, help="GitHub repository.")
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Print commands without dispatching."
+    )
+    parser.add_argument(
+        "--watch",
+        action="store_true",
+        help="Watch the latest workflow run after dispatch.",
+    )
+    parser.add_argument(
+        "--explain",
+        action="store_true",
+        help="Explain the guarded publication path and print the command without dispatching.",
+    )
+    args = parser.parse_args(argv)
+
+    requested_tag = args.release_tag_option or args.release_tag
+    if (
+        args.release_tag_option
+        and args.release_tag
+        and args.release_tag_option != args.release_tag
+    ):
+        parser.error("provide the release tag once, either positionally or with --tag")
+    if args.explain and not requested_tag:
+        print(
+            "AGILAB publication is workflow-owned: the GitHub workflow runs release "
+            "guards, release-plan selection, Trusted Publishing/OIDC, release assets, "
+            "and post-release evidence from one audited path."
+        )
+        print("example: agilab publish v2026.06.05 --dry-run")
+        print(
+            "workflow: gh workflow run "
+            f"{PYPI_PUBLISH_WORKFLOW} --repo {AGILAB_GITHUB_REPO} --ref main "
+            "-f release_tag=<tag> -f release_mode=stable"
+        )
+        return 0
+    if not requested_tag:
+        parser.error("release tag is required, for example: agilab publish v2026.06.05")
+
+    repo_root = _publish_repo_root()
+    command = [
+        "gh",
+        "workflow",
+        "run",
+        PYPI_PUBLISH_WORKFLOW,
+        "--repo",
+        args.repo,
+        "--ref",
+        args.ref,
+        "-f",
+        f"release_tag={_normalized_release_tag(requested_tag)}",
+        "-f",
+        f"release_mode={args.mode}",
+    ]
+    if args.packages:
+        command.extend(["-f", f"packages={args.packages}"])
+    if args.roles:
+        command.extend(["-f", f"roles={args.roles}"])
+    if args.impact_base_ref:
+        command.extend(["-f", f"impact_base_ref={args.impact_base_ref}"])
+    if args.include_existing_pypi:
+        command.extend(["-f", "include_existing_pypi=true"])
+
+    if args.explain:
+        print(
+            "AGILAB publication is workflow-owned: this command dispatches the "
+            "guarded PyPI/GitHub release workflow instead of uploading artifacts locally."
+        )
+    print(_shell_join(command))
+    if args.dry_run or args.explain:
+        if args.watch:
+            print(
+                "gh run list --repo "
+                f"{shlex.quote(args.repo)} --workflow {PYPI_PUBLISH_WORKFLOW} "
+                "--limit 1 --json databaseId --jq '.[0].databaseId'"
+            )
+            print(
+                f"gh run watch --repo {shlex.quote(args.repo)} <run-id> --exit-status"
+            )
+        return 0
+
+    rc = int(runner(command, cwd=repo_root))
+    if rc != 0:
+        return rc
+    print("agilab publish: dispatched GitHub release workflow.")
+
+    if not args.watch:
+        return 0
+
+    latest = subprocess.run(
+        [
+            "gh",
+            "run",
+            "list",
+            "--repo",
+            args.repo,
+            "--workflow",
+            PYPI_PUBLISH_WORKFLOW,
+            "--limit",
+            "1",
+            "--json",
+            "databaseId",
+            "--jq",
+            ".[0].databaseId",
+        ],
+        cwd=repo_root,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if latest.returncode != 0:
+        sys.stderr.write(latest.stderr)
+        return latest.returncode
+    run_id = latest.stdout.strip()
+    if not run_id:
+        print(
+            "agilab publish: workflow dispatched, but no run id was returned.",
+            file=sys.stderr,
+        )
+        return 1
+    return int(
+        runner(
+            ["gh", "run", "watch", "--repo", args.repo, run_id, "--exit-status"],
+            cwd=repo_root,
+        )
+    )
+
+
+def _run_release_plan(argv: list[str], *, runner=subprocess.call) -> int:
+    repo_root = _publish_repo_root()
+    forwarded = list(argv)
+    dry_run = _pop_cli_flag(forwarded, "--dry-run")
+    if not _has_cli_option(forwarded, "--repo-root"):
+        forwarded.extend(["--repo-root", str(repo_root)])
+    if not _has_cli_option(forwarded, "--check-workflow"):
+        forwarded.extend(
+            [
+                "--check-workflow",
+                str(repo_root / ".github" / "workflows" / PYPI_PUBLISH_WORKFLOW),
+            ]
+        )
+
+    command = _uv_python_tool_command(repo_root, "release_plan.py", forwarded)
+    if dry_run:
+        print(_shell_join(command))
+        return 0
+    return int(runner(command, cwd=repo_root))
+
+
+def _run_release_status(argv: list[str], *, runner=subprocess.call) -> int:
+    repo_root = _publish_repo_root()
+    forwarded = list(argv)
+    dry_run = _pop_cli_flag(forwarded, "--dry-run")
+    if forwarded and not forwarded[0].startswith("-"):
+        tag = forwarded.pop(0)
+        if _has_cli_option(forwarded, "--tag"):
+            raise SystemExit("agilab release status: provide the tag once.")
+        forwarded[:0] = ["--tag", _normalized_release_tag(tag)]
+    if not _has_cli_option(forwarded, "--tag"):
+        raise SystemExit(
+            "agilab release status: tag is required, for example: agilab release status v2026.06.05"
+        )
+    if not _has_cli_option(forwarded, "--repo-root"):
+        forwarded.extend(["--repo-root", str(repo_root)])
+
+    command = _uv_python_tool_command(repo_root, "release_status.py", forwarded)
+    if dry_run:
+        print(_shell_join(command))
+        return 0
+    return int(runner(command, cwd=repo_root))
+
+
+def _run_release_watch(argv: list[str], *, runner=subprocess.call) -> int:
+    parser = argparse.ArgumentParser(
+        prog="agilab release watch",
+        description="Watch the latest AGILAB PyPI publish workflow run.",
+    )
+    parser.add_argument("--repo", default=AGILAB_GITHUB_REPO, help="GitHub repository.")
+    parser.add_argument(
+        "--workflow", default=PYPI_PUBLISH_WORKFLOW, help="Workflow file name."
+    )
+    parser.add_argument("--run-id", help="Specific GitHub Actions run id to watch.")
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Print commands without watching."
+    )
+    args = parser.parse_args(argv)
+
+    repo_root = _publish_repo_root()
+    list_command = [
+        "gh",
+        "run",
+        "list",
+        "--repo",
+        args.repo,
+        "--workflow",
+        args.workflow,
+        "--limit",
+        "1",
+        "--json",
+        "databaseId",
+        "--jq",
+        ".[0].databaseId",
+    ]
+    watch_command = [
+        "gh",
+        "run",
+        "watch",
+        "--repo",
+        args.repo,
+        args.run_id or "<run-id>",
+        "--exit-status",
+    ]
+    if args.dry_run:
+        if not args.run_id:
+            print(_shell_join(list_command))
+        print(_shell_join(watch_command))
+        return 0
+
+    run_id = args.run_id
+    if not run_id:
+        latest = subprocess.run(
+            list_command,
+            cwd=repo_root,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        if latest.returncode != 0:
+            sys.stderr.write(latest.stderr)
+            return latest.returncode
+        run_id = latest.stdout.strip()
+        if not run_id:
+            print(
+                "agilab release watch: no workflow run id was returned.",
+                file=sys.stderr,
+            )
+            return 1
+    watch_command[5] = run_id
+    return int(runner(watch_command, cwd=repo_root))
+
+
+def _run_release(argv: list[str], *, runner=subprocess.call) -> int:
+    if not argv or argv[0] in {"-h", "--help", "help"}:
+        print(
+            "usage: agilab release <command> [args]\n\n"
+            "commands:\n"
+            "  publish   Dispatch the guarded PyPI/GitHub workflow\n"
+            "  plan      Run the local release package planner\n"
+            "  status    Check public release truth for a tag\n"
+            "  watch     Watch the latest publish workflow run"
+        )
+        return 0
+    command, rest = argv[0], argv[1:]
+    if command == "publish":
+        return _run_publish(rest, runner=runner)
+    if command == "plan":
+        return _run_release_plan(rest, runner=runner)
+    if command == "status":
+        return _run_release_status(rest, runner=runner)
+    if command == "watch":
+        return _run_release_watch(rest, runner=runner)
+    raise SystemExit(
+        "agilab release: supported commands are publish, plan, status, and watch"
+    )
+
+
 def _run_env(argv: list[str]) -> int:
     if argv[:1] == ["footprint"]:
         from agilab import env_footprint
@@ -253,7 +611,9 @@ def _pytorch_playground_project_root() -> Path:
 def _pytorch_playground_script_path(project_root: Path) -> Path:
     script = project_root / "src" / "pytorch_playground" / "playground_ui.py"
     if not script.is_file():
-        raise SystemExit(f"agilab pytorch-playground: Streamlit surface not found: {script}")
+        raise SystemExit(
+            f"agilab pytorch-playground: Streamlit surface not found: {script}"
+        )
     return script
 
 
@@ -408,9 +768,13 @@ def _run_app_surface(argv: list[str], *, runner=subprocess.call) -> int:
         help="Local UI host. Streamlit uses AGILAB's guarded localhost bind by default.",
     )
     parser.add_argument("--port", type=int, default=8501, help="Local UI port.")
-    parser.add_argument("--no-browser", action="store_true", help="Do not open external URLs.")
+    parser.add_argument(
+        "--no-browser", action="store_true", help="Do not open external URLs."
+    )
     parser.add_argument("--hf-url", default=None, help="Explicit hosted backend URL.")
-    parser.add_argument("--hf-space", default=None, help="Hosted Space ID, for example owner/agilab.")
+    parser.add_argument(
+        "--hf-space", default=None, help="Hosted Space ID, for example owner/agilab."
+    )
     args, extra_args = parser.parse_known_args(argv)
     if extra_args[:1] == ["--"]:
         extra_args = extra_args[1:]
@@ -422,14 +786,20 @@ def _run_app_surface(argv: list[str], *, runner=subprocess.call) -> int:
         if args.json:
             import json
 
-            print(json.dumps({"project": project_root.name, "surfaces": payload}, indent=2))
+            print(
+                json.dumps(
+                    {"project": project_root.name, "surfaces": payload}, indent=2
+                )
+            )
         else:
             for spec in payload:
                 default = " default" if spec.get("default") else ""
                 print(f"{spec['name']}\t{spec['backend']}{default}\t{spec['title']}")
         return 0
     if not specs:
-        raise SystemExit(f"agilab app surface: no app surface declared in {project_root}")
+        raise SystemExit(
+            f"agilab app surface: no app surface declared in {project_root}"
+        )
 
     selected = _APP_SURFACE_MODULE.select_app_surface_spec(project_root, name=args.ui)
     if selected is None:
@@ -445,7 +815,9 @@ def _run_app_surface(argv: list[str], *, runner=subprocess.call) -> int:
             or selected.url
         )
         if not url:
-            raise SystemExit(f"agilab app surface: surface {selected.name!r} has no URL.")
+            raise SystemExit(
+                f"agilab app surface: surface {selected.name!r} has no URL."
+            )
         url = _url_with_active_app_query(url, project_root.name)
         print(url)
         if not args.no_browser:
@@ -492,11 +864,25 @@ def _run_pytorch_playground(argv: list[str], *, runner=subprocess.call) -> int:
         default=os.environ.get("AGILAB_PYTORCH_PLAYGROUND_BACKEND", "local"),
         help="Launch locally through the app uv environment, or open the Hugging Face Space backend.",
     )
-    parser.add_argument("--host", default=None, help="Local Streamlit host. Defaults to AGILAB's guarded localhost bind.")
+    parser.add_argument(
+        "--host",
+        default=None,
+        help="Local Streamlit host. Defaults to AGILAB's guarded localhost bind.",
+    )
     parser.add_argument("--port", type=int, default=8501, help="Local Streamlit port.")
-    parser.add_argument("--no-browser", action="store_true", help="Do not open a browser for local or HF launch.")
-    parser.add_argument("--hf-url", default=None, help="Explicit Hugging Face runtime URL.")
-    parser.add_argument("--hf-space", default=None, help="Hugging Face Space ID, for example owner/agilab.")
+    parser.add_argument(
+        "--no-browser",
+        action="store_true",
+        help="Do not open a browser for local or HF launch.",
+    )
+    parser.add_argument(
+        "--hf-url", default=None, help="Explicit Hugging Face runtime URL."
+    )
+    parser.add_argument(
+        "--hf-space",
+        default=None,
+        help="Hugging Face Space ID, for example owner/agilab.",
+    )
     args, extra_args = parser.parse_known_args(argv)
     if extra_args[:1] == ["--"]:
         extra_args = extra_args[1:]
@@ -599,6 +985,10 @@ def main(argv: list[str] | None = None) -> int:
         return _run_evidence_contract([command, *raw_argv[1:]])
     if raw_argv[:1] == ["workflow"]:
         return _run_workflow(raw_argv[1:])
+    if raw_argv[:1] == ["publish"]:
+        return _run_publish(raw_argv[1:])
+    if raw_argv[:1] == ["release"]:
+        return _run_release(raw_argv[1:])
     if raw_argv[:1] == ["env"]:
         return _run_env(raw_argv[1:])
     if raw_argv[:1] == ["app"]:

--- a/test/test_lab_run.py
+++ b/test/test_lab_run.py
@@ -32,7 +32,9 @@ def test_main_prints_version_without_launching_streamlit(monkeypatch, capsys):
     monkeypatch.setattr(
         lab_run,
         "_load_streamlit_cli",
-        lambda: (_ for _ in ()).throw(AssertionError("streamlit should not be launched")),
+        lambda: (_ for _ in ()).throw(
+            AssertionError("streamlit should not be launched")
+        ),
     )
 
     rc = lab_run.main(["--version"])
@@ -43,7 +45,9 @@ def test_main_prints_version_without_launching_streamlit(monkeypatch, capsys):
 
 def test_main_keeps_streamlit_launch_path(monkeypatch, tmp_path: Path):
     monkeypatch.setattr(lab_run, "_guard_against_uvx_in_source_tree", lambda: None)
-    monkeypatch.setattr(lab_run, "_resolve_apps_path", lambda _value: str(tmp_path / "apps"))
+    monkeypatch.setattr(
+        lab_run, "_resolve_apps_path", lambda _value: str(tmp_path / "apps")
+    )
     for env_key in [
         "STREAMLIT_CONFIG_FILE",
         "STREAMLIT_THEME_BASE",
@@ -60,23 +64,27 @@ def test_main_keeps_streamlit_launch_path(monkeypatch, tmp_path: Path):
         captured.append(list(lab_run.sys.argv))
         return 17
 
-    monkeypatch.setattr(lab_run, "_load_streamlit_cli", lambda: SimpleNamespace(main=fake_main))
+    monkeypatch.setattr(
+        lab_run, "_load_streamlit_cli", lambda: SimpleNamespace(main=fake_main)
+    )
 
     rc = lab_run.main(["--server.headless", "true"])
 
     assert rc == 17
-    assert captured == [[
-        "streamlit",
-        "run",
-        "--server.address",
-        "127.0.0.1",
-        str(Path(lab_run.__file__).resolve().parent / "main_page.py"),
-        "--",
-        "--apps-path",
-        str(tmp_path / "apps"),
-        "--server.headless",
-        "true",
-    ]]
+    assert captured == [
+        [
+            "streamlit",
+            "run",
+            "--server.address",
+            "127.0.0.1",
+            str(Path(lab_run.__file__).resolve().parent / "main_page.py"),
+            "--",
+            "--apps-path",
+            str(tmp_path / "apps"),
+            "--server.headless",
+            "true",
+        ]
+    ]
     assert lab_run.os.environ["STREAMLIT_CONFIG_FILE"] == str(
         Path(lab_run.__file__).resolve().parent / "resources" / "config.toml"
     )
@@ -99,7 +107,9 @@ def test_main_dispatches_pytorch_playground_without_generic_ui(monkeypatch):
     monkeypatch.setattr(
         lab_run,
         "_load_streamlit_cli",
-        lambda: (_ for _ in ()).throw(AssertionError("generic AGILAB UI should not be launched")),
+        lambda: (_ for _ in ()).throw(
+            AssertionError("generic AGILAB UI should not be launched")
+        ),
     )
 
     rc = lab_run.main(["pytorch-playground", "--backend", "hf", "--no-browser"])
@@ -108,14 +118,20 @@ def test_main_dispatches_pytorch_playground_without_generic_ui(monkeypatch):
     assert captured == [["--backend", "hf", "--no-browser"]]
 
 
-def test_pytorch_playground_local_launcher_uses_app_uv_project(monkeypatch, tmp_path: Path):
+def test_pytorch_playground_local_launcher_uses_app_uv_project(
+    monkeypatch, tmp_path: Path
+):
     project_root = tmp_path / "pytorch_playground_project"
     script_path = project_root / "src" / "pytorch_playground" / "playground_ui.py"
     script_path.parent.mkdir(parents=True)
-    script_path.write_text("from pytorch_playground.playground_ui import main\n", encoding="utf-8")
+    script_path.write_text(
+        "from pytorch_playground.playground_ui import main\n", encoding="utf-8"
+    )
     captured: list[list[str]] = []
 
-    monkeypatch.setattr(lab_run, "_pytorch_playground_project_root", lambda: project_root)
+    monkeypatch.setattr(
+        lab_run, "_pytorch_playground_project_root", lambda: project_root
+    )
     monkeypatch.setattr(lab_run, "_ensure_streamlit_config_file", lambda: None)
 
     rc = lab_run._run_pytorch_playground(
@@ -124,32 +140,38 @@ def test_pytorch_playground_local_launcher_uses_app_uv_project(monkeypatch, tmp_
     )
 
     assert rc == 23
-    assert captured == [[
-        "uv",
-        "--preview-features",
-        "extra-build-dependencies",
-        "run",
-        "--project",
-        str(project_root),
-        "streamlit",
-        "run",
-        "--server.address",
-        "127.0.0.1",
-        "--server.port",
-        "8765",
-        "--server.headless",
-        "true",
-        str(script_path),
-        "--",
-        "--demo-flag",
-    ]]
+    assert captured == [
+        [
+            "uv",
+            "--preview-features",
+            "extra-build-dependencies",
+            "run",
+            "--project",
+            str(project_root),
+            "streamlit",
+            "run",
+            "--server.address",
+            "127.0.0.1",
+            "--server.port",
+            "8765",
+            "--server.headless",
+            "true",
+            str(script_path),
+            "--",
+            "--demo-flag",
+        ]
+    ]
 
 
 def test_pytorch_playground_hf_backend_prints_runtime_url(monkeypatch, capsys):
     opened: list[str] = []
-    monkeypatch.setattr(lab_run.webbrowser, "open", lambda url: opened.append(url) or True)
+    monkeypatch.setattr(
+        lab_run.webbrowser, "open", lambda url: opened.append(url) or True
+    )
 
-    rc = lab_run._run_pytorch_playground(["--backend", "hf", "--hf-space", "Owner/agilab", "--no-browser"])
+    rc = lab_run._run_pytorch_playground(
+        ["--backend", "hf", "--hf-space", "Owner/agilab", "--no-browser"]
+    )
 
     assert rc == 0
     assert opened == []
@@ -170,7 +192,9 @@ def test_main_dispatches_doctor_without_launching_streamlit(monkeypatch):
     monkeypatch.setattr(
         lab_run,
         "_load_streamlit_cli",
-        lambda: (_ for _ in ()).throw(AssertionError("streamlit should not be launched")),
+        lambda: (_ for _ in ()).throw(
+            AssertionError("streamlit should not be launched")
+        ),
     )
 
     rc = lab_run.main(["doctor", "--cluster", "--scheduler", "127.0.0.1"])
@@ -191,7 +215,9 @@ def test_main_dispatches_first_proof_without_launching_streamlit(monkeypatch):
     monkeypatch.setattr(
         lab_run,
         "_load_streamlit_cli",
-        lambda: (_ for _ in ()).throw(AssertionError("streamlit should not be launched")),
+        lambda: (_ for _ in ()).throw(
+            AssertionError("streamlit should not be launched")
+        ),
     )
 
     rc = lab_run.main(["first-proof", "--json", "--with-ui"])
@@ -212,7 +238,9 @@ def test_main_dispatches_agent_run_without_launching_streamlit(monkeypatch):
     monkeypatch.setattr(
         lab_run,
         "_load_streamlit_cli",
-        lambda: (_ for _ in ()).throw(AssertionError("streamlit should not be launched")),
+        lambda: (_ for _ in ()).throw(
+            AssertionError("streamlit should not be launched")
+        ),
     )
 
     rc = lab_run.main(["agent-run", "--agent", "codex", "--", "codex", "review"])
@@ -233,7 +261,9 @@ def test_main_dispatches_dry_run_without_launching_streamlit(monkeypatch):
     monkeypatch.setattr(
         lab_run,
         "_load_streamlit_cli",
-        lambda: (_ for _ in ()).throw(AssertionError("streamlit should not be launched")),
+        lambda: (_ for _ in ()).throw(
+            AssertionError("streamlit should not be launched")
+        ),
     )
 
     rc = lab_run.main(["dry-run", "--json"])
@@ -254,7 +284,9 @@ def test_main_dispatches_dry_run_alias_as_first_proof(monkeypatch):
     monkeypatch.setattr(
         lab_run,
         "_load_streamlit_cli",
-        lambda: (_ for _ in ()).throw(AssertionError("streamlit should not be launched")),
+        lambda: (_ for _ in ()).throw(
+            AssertionError("streamlit should not be launched")
+        ),
     )
 
     rc = lab_run.main(["dry-run", "--max-seconds", "45"])
@@ -275,13 +307,219 @@ def test_main_dispatches_workflow_validation_without_launching_streamlit(monkeyp
     monkeypatch.setattr(
         lab_run,
         "_load_streamlit_cli",
-        lambda: (_ for _ in ()).throw(AssertionError("streamlit should not be launched")),
+        lambda: (_ for _ in ()).throw(
+            AssertionError("streamlit should not be launched")
+        ),
     )
 
     rc = lab_run.main(["workflow", "validate", "lab_stages.toml", "--dry-run"])
 
     assert rc == 45
     assert captured == [["validate", "lab_stages.toml", "--dry-run"]]
+
+
+def test_main_dispatches_publish_without_launching_streamlit(monkeypatch):
+    monkeypatch.setattr(lab_run, "_guard_against_uvx_in_source_tree", lambda: None)
+    captured: list[list[str]] = []
+
+    def fake_publish(argv: list[str]) -> int:
+        captured.append(argv)
+        return 47
+
+    monkeypatch.setattr(lab_run, "_run_publish", fake_publish)
+    monkeypatch.setattr(
+        lab_run,
+        "_load_streamlit_cli",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("streamlit should not be launched")
+        ),
+    )
+
+    rc = lab_run.main(["publish", "v2026.06.05", "--dry-run"])
+
+    assert rc == 47
+    assert captured == [["v2026.06.05", "--dry-run"]]
+
+
+def test_main_dispatches_release_without_launching_streamlit(monkeypatch):
+    monkeypatch.setattr(lab_run, "_guard_against_uvx_in_source_tree", lambda: None)
+    captured: list[list[str]] = []
+
+    def fake_release(argv: list[str]) -> int:
+        captured.append(argv)
+        return 48
+
+    monkeypatch.setattr(lab_run, "_run_release", fake_release)
+    monkeypatch.setattr(
+        lab_run,
+        "_load_streamlit_cli",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("streamlit should not be launched")
+        ),
+    )
+
+    rc = lab_run.main(["release", "publish", "v2026.06.05", "--watch"])
+
+    assert rc == 48
+    assert captured == [["publish", "v2026.06.05", "--watch"]]
+
+
+def test_release_publish_alias_routes_to_publish(monkeypatch):
+    captured: list[list[str]] = []
+
+    def fake_publish(argv: list[str], *, runner) -> int:
+        captured.append(argv)
+        return 49
+
+    monkeypatch.setattr(lab_run, "_run_publish", fake_publish)
+
+    rc = lab_run._run_release(["publish", "v2026.06.05", "--watch"])
+
+    assert rc == 49
+    assert captured == [["v2026.06.05", "--watch"]]
+
+
+def test_publish_dry_run_prints_guarded_workflow_command(monkeypatch, capsys):
+    monkeypatch.setattr(lab_run, "_publish_repo_root", lambda: ROOT)
+
+    rc = lab_run._run_publish(
+        [
+            "2026.06.05",
+            "--dry-run",
+            "--packages",
+            "agilab agi-core",
+            "--mode",
+            "repair",
+            "--include-existing-pypi",
+            "--impact-base-ref",
+            "v2026.06.04",
+        ],
+        runner=lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("dry-run must not dispatch")
+        ),
+    )
+
+    assert rc == 0
+    output = capsys.readouterr().out
+    assert "gh workflow run pypi-publish.yaml" in output
+    assert "--repo ThalesGroup/agilab" in output
+    assert "-f release_tag=v2026.06.05" in output
+    assert "-f release_mode=repair" in output
+    assert "-f 'packages=agilab agi-core'" in output
+    assert "-f include_existing_pypi=true" in output
+    assert "-f impact_base_ref=v2026.06.04" in output
+
+
+def test_publish_explain_does_not_require_release_tag(capsys):
+    rc = lab_run._run_publish(
+        ["--explain"],
+        runner=lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("explain must not dispatch")
+        ),
+    )
+
+    assert rc == 0
+    output = capsys.readouterr().out
+    assert "AGILAB publication is workflow-owned" in output
+    assert "agilab publish v2026.06.05 --dry-run" in output
+    assert "gh workflow run pypi-publish.yaml" in output
+
+
+def test_publish_dispatches_guarded_workflow_from_source_root(
+    monkeypatch, tmp_path: Path
+):
+    captured: list[tuple[list[str], Path]] = []
+    monkeypatch.setattr(lab_run, "_publish_repo_root", lambda: tmp_path)
+
+    def fake_runner(command: list[str], *, cwd: Path) -> int:
+        captured.append((command, cwd))
+        return 0
+
+    rc = lab_run._run_publish(["v2026.06.05", "--roles", "app"], runner=fake_runner)
+
+    assert rc == 0
+    assert captured == [
+        (
+            [
+                "gh",
+                "workflow",
+                "run",
+                "pypi-publish.yaml",
+                "--repo",
+                "ThalesGroup/agilab",
+                "--ref",
+                "main",
+                "-f",
+                "release_tag=v2026.06.05",
+                "-f",
+                "release_mode=stable",
+                "-f",
+                "roles=app",
+            ],
+            tmp_path,
+        )
+    ]
+
+
+def test_release_plan_dry_run_uses_guarded_local_planner(monkeypatch, capsys):
+    monkeypatch.setattr(lab_run, "_publish_repo_root", lambda: ROOT)
+
+    rc = lab_run._run_release_plan(
+        ["--dry-run", "--impact-base-ref", "v2026.06.04"],
+        runner=lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("dry-run must not run release_plan.py")
+        ),
+    )
+
+    assert rc == 0
+    output = capsys.readouterr().out
+    assert "uv --preview-features extra-build-dependencies run python" in output
+    assert "tools/release_plan.py" in output
+    assert "--impact-base-ref v2026.06.04" in output
+    assert "--check-workflow" in output
+    assert "pypi-publish.yaml" in output
+    assert "--repo-root" in output
+
+
+def test_release_status_accepts_positional_tag(monkeypatch):
+    captured: list[tuple[list[str], Path]] = []
+    monkeypatch.setattr(lab_run, "_publish_repo_root", lambda: ROOT)
+
+    def fake_runner(command: list[str], *, cwd: Path) -> int:
+        captured.append((command, cwd))
+        return 0
+
+    rc = lab_run._run_release_status(
+        ["2026.06.05", "--packages", "agilab"],
+        runner=fake_runner,
+    )
+
+    assert rc == 0
+    assert captured
+    command, cwd = captured[0]
+    assert cwd == ROOT
+    assert any("tools/release_status.py" in part for part in command)
+    assert "--tag" in command
+    assert "v2026.06.05" in command
+    assert "--packages" in command
+    assert "agilab" in command
+
+
+def test_release_watch_dry_run_prints_latest_run_commands(monkeypatch, capsys):
+    monkeypatch.setattr(lab_run, "_publish_repo_root", lambda: ROOT)
+
+    rc = lab_run._run_release_watch(
+        ["--dry-run"],
+        runner=lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("dry-run must not call gh")
+        ),
+    )
+
+    assert rc == 0
+    output = capsys.readouterr().out
+    assert "gh run list --repo ThalesGroup/agilab" in output
+    assert "--workflow pypi-publish.yaml" in output
+    assert "gh run watch --repo ThalesGroup/agilab '<run-id>' --exit-status" in output
 
 
 def test_main_dispatches_app_management_without_launching_streamlit(monkeypatch):
@@ -296,7 +534,9 @@ def test_main_dispatches_app_management_without_launching_streamlit(monkeypatch)
     monkeypatch.setattr(
         lab_run,
         "_load_streamlit_cli",
-        lambda: (_ for _ in ()).throw(AssertionError("streamlit should not be launched")),
+        lambda: (_ for _ in ()).throw(
+            AssertionError("streamlit should not be launched")
+        ),
     )
 
     rc = lab_run.main(["app", "list", "--json"])
@@ -317,7 +557,9 @@ def test_main_dispatches_app_surface_without_pypi_management(monkeypatch):
     monkeypatch.setattr(
         lab_run,
         "_load_streamlit_cli",
-        lambda: (_ for _ in ()).throw(AssertionError("streamlit should not be launched")),
+        lambda: (_ for _ in ()).throw(
+            AssertionError("streamlit should not be launched")
+        ),
     )
 
     rc = lab_run.main(["app", "surface", "demo_project", "--ui", "hf", "--no-browser"])
@@ -326,7 +568,9 @@ def test_main_dispatches_app_surface_without_pypi_management(monkeypatch):
     assert captured == [["demo_project", "--ui", "hf", "--no-browser"]]
 
 
-def test_app_surface_local_launcher_uses_declared_streamlit_surface(monkeypatch, tmp_path: Path):
+def test_app_surface_local_launcher_uses_declared_streamlit_surface(
+    monkeypatch, tmp_path: Path
+):
     project_root = tmp_path / "demo_project"
     script_path = project_root / "src" / "demo" / "app_surface.py"
     script_path.parent.mkdir(parents=True)
@@ -344,36 +588,49 @@ def test_app_surface_local_launcher_uses_declared_streamlit_surface(monkeypatch,
     )
     captured: list[list[str]] = []
 
-    monkeypatch.setattr(lab_run, "_resolve_app_surface_project_root", lambda _project: project_root)
+    monkeypatch.setattr(
+        lab_run, "_resolve_app_surface_project_root", lambda _project: project_root
+    )
     monkeypatch.setattr(lab_run, "_ensure_streamlit_config_file", lambda: None)
 
     rc = lab_run._run_app_surface(
-        ["demo_project", "--host", "127.0.0.1", "--port", "8765", "--no-browser", "--", "--flag"],
+        [
+            "demo_project",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            "8765",
+            "--no-browser",
+            "--",
+            "--flag",
+        ],
         runner=lambda command: captured.append(command) or 53,
     )
 
     assert rc == 53
-    assert captured == [[
-        "uv",
-        "--preview-features",
-        "extra-build-dependencies",
-        "run",
-        "--project",
-        str(project_root),
-        "streamlit",
-        "run",
-        "--server.address",
-        "127.0.0.1",
-        "--server.port",
-        "8765",
-        "--server.headless",
-        "true",
-        str(script_path),
-        "--",
-        "--active-app",
-        str(project_root),
-        "--flag",
-    ]]
+    assert captured == [
+        [
+            "uv",
+            "--preview-features",
+            "extra-build-dependencies",
+            "run",
+            "--project",
+            str(project_root),
+            "streamlit",
+            "run",
+            "--server.address",
+            "127.0.0.1",
+            "--server.port",
+            "8765",
+            "--server.headless",
+            "true",
+            str(script_path),
+            "--",
+            "--active-app",
+            str(project_root),
+            "--flag",
+        ]
+    ]
 
 
 def test_app_surface_hf_launcher_uses_declared_url(monkeypatch, tmp_path: Path, capsys):
@@ -396,8 +653,12 @@ def test_app_surface_hf_launcher_uses_declared_url(monkeypatch, tmp_path: Path, 
     )
     opened: list[str] = []
 
-    monkeypatch.setattr(lab_run, "_resolve_app_surface_project_root", lambda _project: project_root)
-    monkeypatch.setattr(lab_run.webbrowser, "open", lambda url: opened.append(url) or True)
+    monkeypatch.setattr(
+        lab_run, "_resolve_app_surface_project_root", lambda _project: project_root
+    )
+    monkeypatch.setattr(
+        lab_run.webbrowser, "open", lambda url: opened.append(url) or True
+    )
 
     rc = lab_run._run_app_surface(["demo_project", "--ui", "hf", "--no-browser"])
 
@@ -408,7 +669,9 @@ def test_app_surface_hf_launcher_uses_declared_url(monkeypatch, tmp_path: Path, 
     )
 
 
-def test_app_surface_hf_launcher_allows_space_override(monkeypatch, tmp_path: Path, capsys):
+def test_app_surface_hf_launcher_allows_space_override(
+    monkeypatch, tmp_path: Path, capsys
+):
     project_root = tmp_path / "demo_project"
     (project_root / "src").mkdir(parents=True)
     (project_root / "src" / "app_settings.toml").write_text(
@@ -427,11 +690,20 @@ def test_app_surface_hf_launcher_allows_space_override(monkeypatch, tmp_path: Pa
         encoding="utf-8",
     )
 
-    monkeypatch.setattr(lab_run, "_resolve_app_surface_project_root", lambda _project: project_root)
+    monkeypatch.setattr(
+        lab_run, "_resolve_app_surface_project_root", lambda _project: project_root
+    )
     monkeypatch.setattr(lab_run.webbrowser, "open", lambda _url: True)
 
     rc = lab_run._run_app_surface(
-        ["demo_project", "--ui", "hf", "--hf-space", "Owner/Other_Space", "--no-browser"]
+        [
+            "demo_project",
+            "--ui",
+            "hf",
+            "--hf-space",
+            "Owner/Other_Space",
+            "--no-browser",
+        ]
     )
 
     assert rc == 0
@@ -452,7 +724,9 @@ def test_main_dispatches_kubernetes_job_without_launching_streamlit(monkeypatch)
     monkeypatch.setattr(
         lab_run,
         "_load_streamlit_cli",
-        lambda: (_ for _ in ()).throw(AssertionError("streamlit should not be launched")),
+        lambda: (_ for _ in ()).throw(
+            AssertionError("streamlit should not be launched")
+        ),
     )
 
     rc = lab_run.main(["k8s-job", "--app", "demo_project", "--image", "agilab:local"])
@@ -473,7 +747,9 @@ def test_main_dispatches_security_check_without_launching_streamlit(monkeypatch)
     monkeypatch.setattr(
         lab_run,
         "_load_streamlit_cli",
-        lambda: (_ for _ in ()).throw(AssertionError("streamlit should not be launched")),
+        lambda: (_ for _ in ()).throw(
+            AssertionError("streamlit should not be launched")
+        ),
     )
 
     rc = lab_run.main(["security-check", "--json", "--strict"])
@@ -494,7 +770,9 @@ def test_main_dispatches_adoption_report_without_launching_streamlit(monkeypatch
     monkeypatch.setattr(
         lab_run,
         "_load_streamlit_cli",
-        lambda: (_ for _ in ()).throw(AssertionError("streamlit should not be launched")),
+        lambda: (_ for _ in ()).throw(
+            AssertionError("streamlit should not be launched")
+        ),
     )
 
     rc = lab_run.main(["adoption-report", "--json", "--strict"])
@@ -567,7 +845,9 @@ def test_public_headless_cli_imports_and_help_do_not_require_streamlit() -> None
     assert result.returncode == 0, result.stderr or result.stdout
 
 
-def test_main_dispatches_evidence_contract_commands_without_launching_streamlit(monkeypatch):
+def test_main_dispatches_evidence_contract_commands_without_launching_streamlit(
+    monkeypatch,
+):
     monkeypatch.setattr(lab_run, "_guard_against_uvx_in_source_tree", lambda: None)
     captured: list[list[str]] = []
 
@@ -579,18 +859,29 @@ def test_main_dispatches_evidence_contract_commands_without_launching_streamlit(
     monkeypatch.setattr(
         lab_run,
         "_load_streamlit_cli",
-        lambda: (_ for _ in ()).throw(AssertionError("streamlit should not be launched")),
+        lambda: (_ for _ in ()).throw(
+            AssertionError("streamlit should not be launched")
+        ),
     )
 
-    rc = lab_run.main(["export_lineage", "run_manifest.json", "--format", "openlineage"])
+    rc = lab_run.main(
+        ["export_lineage", "run_manifest.json", "--format", "openlineage"]
+    )
 
     assert rc == 45
-    assert captured == [["export-lineage", "run_manifest.json", "--format", "openlineage"]]
+    assert captured == [
+        ["export-lineage", "run_manifest.json", "--format", "openlineage"]
+    ]
 
     rc = lab_run.main(["export_traces", "run_manifest.json", "--output", "otel.json"])
 
     assert rc == 45
-    assert captured[-1] == ["export-traces", "run_manifest.json", "--output", "otel.json"]
+    assert captured[-1] == [
+        "export-traces",
+        "run_manifest.json",
+        "--output",
+        "otel.json",
+    ]
 
     rc = lab_run.main(["sign", "proof.agipack", "--key", "signer.pem"])
 
@@ -610,7 +901,9 @@ def test_main_dispatches_env_footprint_without_launching_streamlit(monkeypatch):
     monkeypatch.setattr(
         lab_run,
         "_load_streamlit_cli",
-        lambda: (_ for _ in ()).throw(AssertionError("streamlit should not be launched")),
+        lambda: (_ for _ in ()).throw(
+            AssertionError("streamlit should not be launched")
+        ),
     )
 
     rc = lab_run.main(["env", "footprint", "--json"])
@@ -622,7 +915,9 @@ def test_main_dispatches_env_footprint_without_launching_streamlit(monkeypatch):
 def test_main_reports_missing_ui_dependencies(monkeypatch):
     monkeypatch.setattr(lab_run, "_guard_against_uvx_in_source_tree", lambda: None)
     monkeypatch.setattr(lab_run, "_resolve_apps_path", lambda _value: None)
-    monkeypatch.setattr(lab_run, "_missing_ui_dependencies", lambda: ["streamlit", "agi-gui"])
+    monkeypatch.setattr(
+        lab_run, "_missing_ui_dependencies", lambda: ["streamlit", "agi-gui"]
+    )
 
     with pytest.raises(SystemExit, match=r"streamlit, agi-gui.*agilab\[ui\]"):
         lab_run.main([])
@@ -638,9 +933,13 @@ def test_main_refuses_public_bind_without_auth_or_tls(monkeypatch):
         lab_run.main([])
 
 
-def test_main_allows_explicit_public_bind_with_tls_indicator(monkeypatch, tmp_path: Path):
+def test_main_allows_explicit_public_bind_with_tls_indicator(
+    monkeypatch, tmp_path: Path
+):
     monkeypatch.setattr(lab_run, "_guard_against_uvx_in_source_tree", lambda: None)
-    monkeypatch.setattr(lab_run, "_resolve_apps_path", lambda _value: str(tmp_path / "apps"))
+    monkeypatch.setattr(
+        lab_run, "_resolve_apps_path", lambda _value: str(tmp_path / "apps")
+    )
     monkeypatch.setenv("STREAMLIT_SERVER_ADDRESS", "0.0.0.0")
     monkeypatch.setenv("AGILAB_PUBLIC_BIND_OK", "1")
     monkeypatch.setenv("AGILAB_TLS_TERMINATED", "1")
@@ -650,7 +949,9 @@ def test_main_allows_explicit_public_bind_with_tls_indicator(monkeypatch, tmp_pa
         captured.append(list(lab_run.sys.argv))
         return 0
 
-    monkeypatch.setattr(lab_run, "_load_streamlit_cli", lambda: SimpleNamespace(main=fake_main))
+    monkeypatch.setattr(
+        lab_run, "_load_streamlit_cli", lambda: SimpleNamespace(main=fake_main)
+    )
 
     assert lab_run.main([]) == 0
     assert captured[0][2:4] == ["--server.address", "0.0.0.0"]


### PR DESCRIPTION
## Summary

- add `agilab publish` as a short maintainer command for dispatching the guarded PyPI/GitHub release workflow
- add `agilab release publish`, `agilab release plan`, `agilab release status <tag>`, and `agilab release watch` shortcuts
- keep publication source-of-truth in `.github/workflows/pypi-publish.yaml`, `tools/release_plan.py`, and `tools/release_status.py`
- add tests for dispatch, dry-run/explain output, positional status tags, and workflow watch commands

## Validation

- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_lab_run.py`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files src/agilab/lab_run.py test/test_lab_run.py`
- `uv --preview-features extra-build-dependencies run --extra dev ruff check src/agilab/lab_run.py test/test_lab_run.py`
- `uv --preview-features extra-build-dependencies run --extra dev ruff format --check src/agilab/lab_run.py test/test_lab_run.py`
- `uv --preview-features extra-build-dependencies run agilab publish --explain`
- `uv --preview-features extra-build-dependencies run agilab release plan --dry-run --impact-base-ref v2026.06.04`
- `uv --preview-features extra-build-dependencies run agilab release status 2026.06.05 --dry-run --packages agilab`
- `uv --preview-features extra-build-dependencies run agilab release watch --dry-run`
- `./dev scope`
- `git diff --check`