### PR TITLE
[codex] Add AGILAB performance validation accelerators

### DIFF
--- a/test/test_agilab_dev_shortcuts.py
+++ b/test/test_agilab_dev_shortcuts.py
@@ -43,7 +43,9 @@ def test_bugfix_shortcut_runs_impact_then_fast_regression_by_default():
 
 
 def test_bugfix_shortcut_keeps_changed_file_arguments():
-    assert agilab_dev.planned_commands(["bugfix", "--files", "src/agilab/main_page.py"]) == [
+    assert agilab_dev.planned_commands(
+        ["bugfix", "--files", "src/agilab/main_page.py"]
+    ) == [
         [
             "uv",
             "--preview-features",
@@ -59,7 +61,9 @@ def test_bugfix_shortcut_keeps_changed_file_arguments():
 
 
 def test_test_shortcut_keeps_pytest_arguments():
-    assert agilab_dev.planned_commands(["test", "test/test_cluster_lan_discovery.py", "-k", "windows"]) == [
+    assert agilab_dev.planned_commands(
+        ["test", "test/test_cluster_lan_discovery.py", "-k", "windows"]
+    ) == [
         [
             "uv",
             "--preview-features",
@@ -153,7 +157,9 @@ def test_regress_shortcut_defaults_to_staged_ga_run():
 
 
 def test_regress_shortcut_keeps_selector_arguments():
-    assert agilab_dev.planned_commands(["regress", "--files", "src/agilab/pipeline_ai.py", "--json"]) == [
+    assert agilab_dev.planned_commands(
+        ["regress", "--files", "src/agilab/pipeline_ai.py", "--json"]
+    ) == [
         [
             "uv",
             "--preview-features",
@@ -205,7 +211,9 @@ def test_robust_shortcut_keeps_matrix_arguments():
 
 
 def test_parallel_stage_shortcut_runs_parallel_stage_tool():
-    assert agilab_dev.planned_commands(["parallel-stage", "--check", "parallel_stage.toml"]) == [
+    assert agilab_dev.planned_commands(
+        ["parallel-stage", "--check", "parallel_stage.toml"]
+    ) == [
         [
             "uv",
             "--preview-features",
@@ -262,7 +270,9 @@ def test_app_contracts_shortcut_keeps_matrix_arguments():
 
 
 def test_builtin_app_tests_shortcut_runs_app_local_runner():
-    assert agilab_dev.planned_commands(["builtin-app-tests", "--app", "weather_forecast_project"]) == [
+    assert agilab_dev.planned_commands(
+        ["builtin-app-tests", "--app", "weather_forecast_project"]
+    ) == [
         [
             "uv",
             "--preview-features",
@@ -334,7 +344,9 @@ def test_audit_shortcut_runs_agilab_audit():
 
 
 def test_audit_quality_shortcut_scores_markdown_audit():
-    assert agilab_dev.planned_commands(["audit-quality", "CODE_REVIEW.md", "--min-score", "90"]) == [
+    assert agilab_dev.planned_commands(
+        ["audit-quality", "CODE_REVIEW.md", "--min-score", "90"]
+    ) == [
         [
             "uv",
             "--preview-features",
@@ -377,7 +389,9 @@ def test_audit_preflight_shortcut_prints_architecture_preflight():
     ]
 
 
-def test_main_keeps_machine_readable_shortcut_stdout_clean(capsys, monkeypatch, tmp_path):
+def test_main_keeps_machine_readable_shortcut_stdout_clean(
+    capsys, monkeypatch, tmp_path
+):
     calls = []
 
     class Completed:
@@ -395,13 +409,16 @@ def test_main_keeps_machine_readable_shortcut_stdout_clean(capsys, monkeypatch, 
     monkeypatch.setattr(agilab_dev.subprocess, "run", fake_run)
     monkeypatch.setattr(agilab_dev, "DEV_LOG_DIR", tmp_path)
 
-    exit_code = agilab_dev.main(["regress", "--files", "src/agilab/pipeline_ai.py", "--json"])
+    exit_code = agilab_dev.main(
+        ["regress", "--files", "src/agilab/pipeline_ai.py", "--json"]
+    )
 
     captured = capsys.readouterr()
     assert exit_code == 0
     assert captured.out == ""
     assert "tools/ga_regression_selector.py" in captured.err
     assert "./dev compact-output: ok exit=0" in captured.err
+    assert "ok\n" not in captured.err
     assert f"log={tmp_path}" in captured.err
     assert calls == [
         (
@@ -421,7 +438,9 @@ def test_main_keeps_machine_readable_shortcut_stdout_clean(capsys, monkeypatch, 
     ]
 
 
-def test_main_compact_output_prints_signal_summary_and_writes_full_log(capsys, monkeypatch, tmp_path):
+def test_main_compact_output_prints_signal_summary_and_writes_full_log(
+    capsys, monkeypatch, tmp_path
+):
     class Completed:
         returncode = 1
         stdout = "\n".join(
@@ -451,7 +470,9 @@ def test_main_compact_output_prints_signal_summary_and_writes_full_log(capsys, m
     assert "omitted" in captured.err
     logs = list(tmp_path.glob("*.log"))
     assert len(logs) == 1
-    assert "line that should stay only in the artifact" in logs[0].read_text(encoding="utf-8")
+    assert "line that should stay only in the artifact" in logs[0].read_text(
+        encoding="utf-8"
+    )
 
 
 def test_main_raw_output_keeps_streaming_subprocess_call(capsys, monkeypatch):
@@ -513,6 +534,65 @@ def test_workflow_profile_shortcut_repeats_profile_flags_and_keeps_options():
             "--profile",
             "docs",
             "--keep-going",
+        ]
+    ]
+
+
+def test_ui_flow_shortcut_selects_ui_robot_profiles_from_changed_files():
+    assert agilab_dev.planned_commands(
+        ["ui-flow", "--changed-file", "src/agilab/pages/project.py"]
+    ) == [
+        [
+            "uv",
+            "--preview-features",
+            "extra-build-dependencies",
+            "run",
+            "python",
+            "tools/workflow_parity.py",
+            "--select-ui-robot-profiles",
+            "--changed-file",
+            "src/agilab/pages/project.py",
+        ]
+    ]
+
+
+def test_perf_startup_shortcut_uses_quick_startup_import_scenarios():
+    command = agilab_dev.planned_commands(["perf-startup"])[0]
+
+    assert command[:6] == [
+        "uv",
+        "--preview-features",
+        "extra-build-dependencies",
+        "run",
+        "python",
+        "tools/perf_smoke.py",
+    ]
+    assert command.count("--scenario") == 4
+    assert "orchestrate-execute-import" in command
+    assert command[-4:] == ["--repeats", "1", "--warmups", "0"]
+
+
+def test_worker_reuse_shortcut_runs_worker_env_reuse_tool():
+    assert agilab_dev.planned_commands(
+        [
+            "worker-reuse",
+            "--worker-pyproject",
+            "worker/pyproject.toml",
+            "--worker-copy",
+            "~/wenv/app_worker",
+        ]
+    ) == [
+        [
+            "uv",
+            "--preview-features",
+            "extra-build-dependencies",
+            "run",
+            "python",
+            "tools/worker_env_reuse.py",
+            "--worker-pyproject",
+            "worker/pyproject.toml",
+            "--worker-copy",
+            "~/wenv/app_worker",
         ]
     ]
 
@@ -816,7 +896,14 @@ def test_task_worktree_shortcut_requires_branch_and_keeps_arguments():
 def test_skills_shortcut_syncs_then_validates_and_generates():
     assert agilab_dev.planned_commands(["skills", "agilab-runbook"]) == [
         ["python3", "tools/sync_agent_skills.py", "--skills", "agilab-runbook"],
-        ["python3", "tools/codex_skills.py", "--root", ".codex/skills", "validate", "--strict"],
+        [
+            "python3",
+            "tools/codex_skills.py",
+            "--root",
+            ".codex/skills",
+            "validate",
+            "--strict",
+        ],
         ["python3", "tools/codex_skills.py", "--root", ".codex/skills", "generate"],
         ["python3", "tools/agent_skill_catalog.py", "--apply"],
         ["python3", "tools/generate_skill_badges.py"],

--- a/test/test_performance_cache.py
+++ b/test/test_performance_cache.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "tools" / "performance_cache.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location(
+        "performance_cache_test_module", MODULE_PATH
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_cached_file_sha256_reuses_signature_and_invalidates_on_change(
+    tmp_path: Path,
+) -> None:
+    module = _load_module()
+    cache_path = tmp_path / "cache.json"
+    payload = tmp_path / "payload.txt"
+    payload.write_text("alpha", encoding="utf-8")
+
+    first = module.cached_file_sha256(payload, cache_path=cache_path)
+    second = module.cached_file_sha256(payload, cache_path=cache_path)
+
+    assert first == second
+    cache = json.loads(cache_path.read_text(encoding="utf-8"))
+    assert len(cache["entries"]) == 1
+
+    payload.write_text("beta", encoding="utf-8")
+    changed = module.cached_file_sha256(payload, cache_path=cache_path)
+
+    assert changed != first
+
+
+def test_manifest_digest_is_order_stable_and_records_missing_files(
+    tmp_path: Path,
+) -> None:
+    module = _load_module()
+    left = tmp_path / "left.txt"
+    right = tmp_path / "right.txt"
+    missing = tmp_path / "missing.txt"
+    left.write_text("left", encoding="utf-8")
+    right.write_text("right", encoding="utf-8")
+
+    first = module.manifest_digest(
+        [right, missing, left], cache_path=tmp_path / "cache.json"
+    )
+    second = module.manifest_digest(
+        [left, right, missing], cache_path=tmp_path / "cache.json"
+    )
+
+    assert first["digest"] == second["digest"]
+    states = {
+        Path(str(entry["path"])).name: entry["signature"]["state"]
+        for entry in first["files"]
+    }
+    assert states == {"left.txt": "file", "right.txt": "file", "missing.txt": "missing"}

--- a/test/test_release_robustness_tools.py
+++ b/test/test_release_robustness_tools.py
@@ -24,7 +24,9 @@ release_handoff_guard = _load_tool("release_handoff_guard")
 release_status = _load_tool("release_status")
 
 
-def _planned_project(version: str = "2026.05.26") -> pypi_project_preflight.PlannedPyPIProject:
+def _planned_project(
+    version: str = "2026.05.26",
+) -> pypi_project_preflight.PlannedPyPIProject:
     return pypi_project_preflight.PlannedPyPIProject(
         package="agi-page-live-artifacts",
         project="src/agilab/apps-pages/view_live_artifacts",
@@ -45,7 +47,10 @@ def test_pypi_project_preflight_reports_missing_project_with_pending_command() -
     assert status.pending_publisher_command is not None
     assert "pypi-pending-trusted-publisher.yaml" in status.pending_publisher_command
     assert "project_name=agi-page-live-artifacts" in status.pending_publisher_command
-    assert "pypi_environment=pypi-agi-page-live-artifacts" in status.pending_publisher_command
+    assert (
+        "pypi_environment=pypi-agi-page-live-artifacts"
+        in status.pending_publisher_command
+    )
 
 
 def test_pypi_project_preflight_treats_pep440_normalized_version_as_current() -> None:
@@ -61,7 +66,9 @@ def test_pypi_project_preflight_treats_pep440_normalized_version_as_current() ->
     assert status.latest == "2026.5.26"
 
 
-def test_pypi_project_preflight_allows_existing_project_with_unpublished_version() -> None:
+def test_pypi_project_preflight_allows_existing_project_with_unpublished_version() -> (
+    None
+):
     report = pypi_project_preflight.build_report(
         fetch_json=lambda _name: {
             "info": {"version": "2026.5.25"},
@@ -75,7 +82,9 @@ def test_pypi_project_preflight_allows_existing_project_with_unpublished_version
     assert report["blockers"] == []
 
 
-def test_pypi_project_preflight_allows_explicit_missing_project_for_first_publish() -> None:
+def test_pypi_project_preflight_allows_explicit_missing_project_for_first_publish() -> (
+    None
+):
     report = pypi_project_preflight.build_report(
         fetch_json=lambda _name: None,
         package_names=["agi-page-live-artifacts"],
@@ -84,13 +93,53 @@ def test_pypi_project_preflight_allows_explicit_missing_project_for_first_publis
 
     assert report["status"] == "pass"
     assert report["summary"]["allowed_missing_projects"] == 1
-    assert report["allowed_missing_projects"][0]["pypi_project"] == "agi-page-live-artifacts"
+    assert (
+        report["allowed_missing_projects"][0]["pypi_project"]
+        == "agi-page-live-artifacts"
+    )
     assert report["blockers"] == []
+
+
+def test_pypi_project_preflight_caches_project_version_until_manifest_changes(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    project = tmp_path / "pkg"
+    project.mkdir()
+    pyproject = project / "pyproject.toml"
+    pyproject.write_text("[project]\nname='demo'\nversion='1'\n", encoding="utf-8")
+    calls: list[Path] = []
+
+    def fake_read_project_metadata(path: Path):
+        calls.append(path)
+        version = (
+            pyproject.read_text(encoding="utf-8")
+            .split("version='", 1)[1]
+            .split("'", 1)[0]
+        )
+        return "demo", version
+
+    pypi_project_preflight.clear_project_version_cache()
+    monkeypatch.setattr(
+        pypi_project_preflight, "read_project_metadata", fake_read_project_metadata
+    )
+
+    assert pypi_project_preflight._project_version(tmp_path, "pkg") == "1"
+    assert pypi_project_preflight._project_version(tmp_path, "pkg") == "1"
+    assert calls == [project]
+
+    pyproject.write_text(
+        "[project]\nname='demo'\nversion='2'\n# changed\n", encoding="utf-8"
+    )
+    assert pypi_project_preflight._project_version(tmp_path, "pkg") == "2"
+    assert calls == [project, project]
 
 
 def test_release_status_derives_package_version_from_release_tag() -> None:
     assert release_status.package_version_from_tag("v2026.05.23-2") == "2026.05.23"
-    assert release_status.package_version_from_tag("refs/tags/v2026.05.26") == "2026.05.26"
+    assert (
+        release_status.package_version_from_tag("refs/tags/v2026.05.26") == "2026.05.26"
+    )
 
 
 def test_release_status_can_check_partial_release_packages(monkeypatch) -> None:
@@ -120,9 +169,15 @@ def test_release_status_can_check_partial_release_packages(monkeypatch) -> None:
         release_status,
         "fetch_pypi_json",
         lambda name: {
-            "info": {"version": "2026.5.31.post1" if name == "agi-page-live-artifacts" else "2026.5.31"},
+            "info": {
+                "version": "2026.5.31.post1"
+                if name == "agi-page-live-artifacts"
+                else "2026.5.31"
+            },
             "releases": {
-                "2026.5.31.post1" if name == "agi-page-live-artifacts" else "2026.5.31": []
+                "2026.5.31.post1"
+                if name == "agi-page-live-artifacts"
+                else "2026.5.31": []
             },
         },
     )
@@ -152,17 +207,19 @@ def test_release_handoff_guard_requires_archiving_old_handoffs(tmp_path: Path) -
         encoding="utf-8",
     )
 
-    assert release_handoff_guard.stale_handoffs(
-        handoff_dir=tmp_path,
-        latest_tag="v2026.05.26",
-    ) == []
+    assert (
+        release_handoff_guard.stale_handoffs(
+            handoff_dir=tmp_path,
+            latest_tag="v2026.05.26",
+        )
+        == []
+    )
 
 
 def test_release_handoff_guard_accepts_dot_hotfix_release_tags(tmp_path: Path) -> None:
     manifest = tmp_path / "release_proof.toml"
     manifest.write_text(
-        "[release]\n"
-        'github_release_tag = "v2026.06.04.1"\n',
+        '[release]\ngithub_release_tag = "v2026.06.04.1"\n',
         encoding="utf-8",
     )
     handoff = tmp_path / "v2026.06.04-handoff.md"

--- a/test/test_worker_env_reuse.py
+++ b/test/test_worker_env_reuse.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "tools" / "worker_env_reuse.py"
+
+
+def _load_module():
+    sys.path.insert(0, str(ROOT / "tools"))
+    spec = importlib.util.spec_from_file_location(
+        "worker_env_reuse_test_module", MODULE_PATH
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_worker_env_reuse_reports_marker_missing_then_reuse(tmp_path: Path) -> None:
+    module = _load_module()
+    worker_pyproject = tmp_path / "worker" / "pyproject.toml"
+    worker_copy = tmp_path / "wenv" / "demo_worker"
+    worker_pyproject.parent.mkdir()
+    worker_pyproject.write_text(
+        "[project]\nname='demo-worker'\nversion='1'\n", encoding="utf-8"
+    )
+
+    missing = module.worker_env_reuse_report(
+        worker_pyproject=worker_pyproject,
+        worker_copy=worker_copy,
+    )
+    assert missing["status"] == "rebuild"
+    assert missing["reason"] == "marker-missing"
+
+    marker = module.write_marker(missing)
+    assert marker.is_file()
+
+    reuse = module.worker_env_reuse_report(
+        worker_pyproject=worker_pyproject,
+        worker_copy=worker_copy,
+    )
+    assert reuse["status"] == "reuse"
+    assert reuse["reason"] == "manifest-unchanged"
+
+
+def test_worker_env_reuse_detects_manifest_change_and_json_cli(
+    tmp_path: Path, capsys
+) -> None:
+    module = _load_module()
+    worker_pyproject = tmp_path / "worker" / "pyproject.toml"
+    worker_copy = tmp_path / "wenv" / "demo_worker"
+    worker_pyproject.parent.mkdir()
+    worker_pyproject.write_text(
+        "[project]\nname='demo-worker'\nversion='1'\n", encoding="utf-8"
+    )
+    module.write_marker(
+        module.worker_env_reuse_report(
+            worker_pyproject=worker_pyproject,
+            worker_copy=worker_copy,
+        )
+    )
+
+    worker_pyproject.write_text(
+        "[project]\nname='demo-worker'\nversion='2'\n", encoding="utf-8"
+    )
+    changed = module.worker_env_reuse_report(
+        worker_pyproject=worker_pyproject,
+        worker_copy=worker_copy,
+    )
+    assert changed["status"] == "rebuild"
+    assert changed["reason"] == "manifest-changed"
+
+    assert (
+        module.main(
+            [
+                "--worker-pyproject",
+                str(worker_pyproject),
+                "--worker-copy",
+                str(worker_copy),
+                "--json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["schema"] == module.SCHEMA_VERSION

--- a/test/test_workflow_parity.py
+++ b/test/test_workflow_parity.py
@@ -34,7 +34,9 @@ def _option_values(argv: list[str], option: str) -> list[str]:
 
 
 def _load_module():
-    spec = importlib.util.spec_from_file_location("workflow_parity_test_module", MODULE_PATH)
+    spec = importlib.util.spec_from_file_location(
+        "workflow_parity_test_module", MODULE_PATH
+    )
     assert spec and spec.loader
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
@@ -60,7 +62,9 @@ def _cache_args(cache_path: Path, *, no_result_cache: bool = False) -> SimpleNam
 
 
 def _coverage_workflow_agi_gui_targets() -> dict[str, list[str]]:
-    spec = importlib.util.spec_from_file_location("coverage_shard_plan_workflow_parity_test_module", SHARD_PLAN_PATH)
+    spec = importlib.util.spec_from_file_location(
+        "coverage_shard_plan_workflow_parity_test_module", SHARD_PLAN_PATH
+    )
     assert spec and spec.loader
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
@@ -69,27 +73,39 @@ def _coverage_workflow_agi_gui_targets() -> dict[str, list[str]]:
 
 
 def _parity_agi_gui_targets(module) -> dict[str, list[str]]:
-    args = SimpleNamespace(components=None, skills=None, app_path=None, worker_copy=None)
-    commands = module._profile_commands(args)["agi-gui"][: len(module.AGI_GUI_COVERAGE_CHUNKS)]
+    args = SimpleNamespace(
+        components=None, skills=None, app_path=None, worker_copy=None
+    )
+    commands = module._profile_commands(args)["agi-gui"][
+        : len(module.AGI_GUI_COVERAGE_CHUNKS)
+    ]
     targets_by_chunk: dict[str, list[str]] = {}
     for command in commands:
         match = re.fullmatch(r"agi-gui coverage \(([a-z-]+)\)", command.label)
         assert match is not None
-        ignore_index = command.argv.index("--ignore=src/agilab/test/test_model_returns_code.py")
+        ignore_index = command.argv.index(
+            "--ignore=src/agilab/test/test_model_returns_code.py"
+        )
         targets_by_chunk[match.group(1)] = command.argv[ignore_index + 1 :]
     return targets_by_chunk
 
 
-def test_coverage_shard_plan_module_fails_closed_when_loader_is_missing(monkeypatch) -> None:
+def test_coverage_shard_plan_module_fails_closed_when_loader_is_missing(
+    monkeypatch,
+) -> None:
     module = _load_module()
-    monkeypatch.setattr(module.importlib.util, "spec_from_file_location", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        module.importlib.util, "spec_from_file_location", lambda *_args, **_kwargs: None
+    )
 
     try:
         module._coverage_shard_plan_module()
     except RuntimeError as exc:
         assert "cannot load coverage shard planner" in str(exc)
     else:
-        raise AssertionError("_coverage_shard_plan_module should fail when the module spec is missing")
+        raise AssertionError(
+            "_coverage_shard_plan_module should fail when the module spec is missing"
+        )
 
 
 def test_agi_gui_workflow_parity_matches_coverage_workflow_targets() -> None:
@@ -113,13 +129,17 @@ def test_agi_gui_workflow_parity_matches_coverage_workflow_targets() -> None:
 def test_expand_repo_globs_preserves_unmatched_patterns() -> None:
     module = _load_module()
 
-    expanded = module._expand_repo_globs(["test/test_workflow_parity.py", "missing-ui-robot-*.py"])
+    expanded = module._expand_repo_globs(
+        ["test/test_workflow_parity.py", "missing-ui-robot-*.py"]
+    )
 
     assert "test/test_workflow_parity.py" in expanded
     assert "missing-ui-robot-*.py" in expanded
 
 
-def test_ty_typing_profile_omits_missing_optional_stubs(monkeypatch, tmp_path: Path) -> None:
+def test_ty_typing_profile_omits_missing_optional_stubs(
+    monkeypatch, tmp_path: Path
+) -> None:
     module = _load_module()
     monkeypatch.setattr(module, "REPO_ROOT", tmp_path)
 
@@ -134,7 +154,9 @@ def test_ty_typing_profile_omits_missing_optional_stubs(monkeypatch, tmp_path: P
 
 def test_profile_commands_cover_expected_coverage_and_docs_contracts() -> None:
     module = _load_module()
-    args = SimpleNamespace(components=None, skills=None, app_path=None, worker_copy=None)
+    args = SimpleNamespace(
+        components=None, skills=None, app_path=None, worker_copy=None
+    )
 
     profiles = module._profile_commands(args)
     agi_env = profiles["agi-env"][0]
@@ -251,20 +273,42 @@ def test_profile_commands_cover_expected_coverage_and_docs_contracts() -> None:
         "agi-gui coverage xml",
     ]
     assert all(command.timeout_seconds == 8 * 60 for command in agi_gui_chunks)
-    assert all(command.env["AGILAB_DISABLE_BACKGROUND_SERVICES"] == "1" for command in agi_gui_commands)
+    assert all(
+        command.env["AGILAB_DISABLE_BACKGROUND_SERVICES"] == "1"
+        for command in agi_gui_commands
+    )
     assert all(_has_extra(command.argv, "ui") for command in agi_gui_commands)
     assert all(_has_extra(command.argv, "viz") for command in agi_gui_commands)
-    assert agi_gui_commands[0].remove_paths[:2] == [".coverage.agi-gui", "coverage-agi-gui.xml"]
+    assert agi_gui_commands[0].remove_paths[:2] == [
+        ".coverage.agi-gui",
+        "coverage-agi-gui.xml",
+    ]
     assert all("coverage" in command.argv for command in agi_gui_chunks)
     assert all("--append" not in command.argv for command in agi_gui_chunks)
     assert all("--parallel-mode" in command.argv for command in agi_gui_chunks)
-    assert "test-results/coverage-agi-gui-support.db.*" in agi_gui_commands[0].remove_paths
-    assert "test-results/coverage-agi-gui-support.manifest.json" in agi_gui_commands[0].remove_paths
-    assert "test-results/coverage-agi-gui-pipeline.db.*" in agi_gui_commands[1].remove_paths
-    assert "test-results/coverage-agi-gui-pipeline.manifest.json" in agi_gui_commands[1].remove_paths
-    assert "--data-file=test-results/coverage-agi-gui-support.db" in agi_gui_commands[0].argv
+    assert (
+        "test-results/coverage-agi-gui-support.db.*" in agi_gui_commands[0].remove_paths
+    )
+    assert (
+        "test-results/coverage-agi-gui-support.manifest.json"
+        in agi_gui_commands[0].remove_paths
+    )
+    assert (
+        "test-results/coverage-agi-gui-pipeline.db.*"
+        in agi_gui_commands[1].remove_paths
+    )
+    assert (
+        "test-results/coverage-agi-gui-pipeline.manifest.json"
+        in agi_gui_commands[1].remove_paths
+    )
+    assert (
+        "--data-file=test-results/coverage-agi-gui-support.db"
+        in agi_gui_commands[0].argv
+    )
     assert "coverage_db_paths" in " ".join(agi_gui_commands[0].argv)
-    assert "test-results/coverage-agi-gui-support.manifest.json" in " ".join(agi_gui_commands[0].argv)
+    assert "test-results/coverage-agi-gui-support.manifest.json" in " ".join(
+        agi_gui_commands[0].argv
+    )
     agi_gui_combine_argv = " ".join(agi_gui_combine.argv)
     assert "'coverage', 'combine'" in agi_gui_combine_argv
     assert "--data-file=.coverage.agi-gui" in agi_gui_combine_argv
@@ -275,7 +319,9 @@ def test_profile_commands_cover_expected_coverage_and_docs_contracts() -> None:
     assert "coverage_db_paths" in agi_gui_combine_argv
     assert "range(120)" not in agi_gui_combine_argv
     assert "stat().st_size > 0" in agi_gui_combine_argv
-    assert "test-results/coverage-agi-gui-pipeline.manifest.json" in agi_gui_combine_argv
+    assert (
+        "test-results/coverage-agi-gui-pipeline.manifest.json" in agi_gui_combine_argv
+    )
     assert agi_gui_timing.timeout_seconds == 60
     assert "tools/coverage_timing_report.py" in agi_gui_timing.argv
     assert "test-results/junit-agi-gui-*.xml" in agi_gui_timing.argv
@@ -311,8 +357,14 @@ def test_profile_commands_cover_expected_coverage_and_docs_contracts() -> None:
     assert "test/test_ui_pages.py" in agi_gui_argv
     assert "--data-file=test-results/coverage-agi-gui-pages-flow.db" in agi_gui_argv
     assert "--data-file=test-results/coverage-agi-gui-pages-rest.db" in agi_gui_argv
-    assert "execute_page or experiment_page or pipeline_page_project_selectbox" in agi_gui_argv
-    assert "not (execute_page or experiment_page or pipeline_page_project_selectbox)" in agi_gui_argv
+    assert (
+        "execute_page or experiment_page or pipeline_page_project_selectbox"
+        in agi_gui_argv
+    )
+    assert (
+        "not (execute_page or experiment_page or pipeline_page_project_selectbox)"
+        in agi_gui_argv
+    )
     assert "test/test_view*.py" not in agi_gui_argv
     assert "test/test_view_maps.py" in agi_gui_argv
     assert "test/test_ci_provider_artifacts.py" in agi_gui_argv
@@ -330,12 +382,17 @@ def test_profile_commands_cover_expected_coverage_and_docs_contracts() -> None:
     assert dependency_policy.label == "dependency policy"
     assert dependency_policy.argv[-1] == "test/test_pyproject_dependency_hygiene.py"
     assert "addopts=" in dependency_policy.argv
-    assert release_proof.label == "fresh source clone first-proof plus notebook import/export proof"
+    assert (
+        release_proof.label
+        == "fresh source clone first-proof plus notebook import/export proof"
+    )
     assert release_proof.env["AGILAB_RUN_RELEASE_PROOF_SLOW"] == "1"
     assert release_proof.timeout_seconds == 15 * 60
     assert "-m" in release_proof.argv
     assert "release_proof" in release_proof.argv
-    assert release_proof.argv[-1].endswith("test_newcomer_first_proof_passes_from_fresh_source_clone")
+    assert release_proof.argv[-1].endswith(
+        "test_newcomer_first_proof_passes_from_fresh_source_clone"
+    )
     assert [command.label for command in security_adoption_commands] == [
         "base supply-chain scan for shared go gate",
         "security adoption check",
@@ -385,7 +442,9 @@ def test_profile_commands_cover_expected_coverage_and_docs_contracts() -> None:
     ]
     assert production_readiness.timeout_seconds == 5 * 60
     assert production_readiness.ensure_dirs == ["test-results"]
-    assert production_readiness.remove_paths == ["test-results/production-readiness.json"]
+    assert production_readiness.remove_paths == [
+        "test-results/production-readiness.json"
+    ]
     assert [command.label for command in cloud_emulators] == [
         "cloud emulator connector evidence",
         "cloud emulator connector tests",
@@ -394,15 +453,24 @@ def test_profile_commands_cover_expected_coverage_and_docs_contracts() -> None:
         "tools/data_connector_cloud_emulator_report.py",
         "--compact",
     ]
-    assert cloud_emulators[1].argv[-1] == "test/test_data_connector_cloud_emulator_report.py"
+    assert (
+        cloud_emulators[1].argv[-1]
+        == "test/test_data_connector_cloud_emulator_report.py"
+    )
     assert [command.label for command in ui_robot_contract] == [
         "ui robot coverage contract",
         "ui robot action contract",
     ]
     assert ui_robot_coverage_contract.timeout_seconds == 2 * 60
-    assert ui_robot_coverage_contract.argv[-2:] == ["tools/ui_robot_coverage_contract.py", "--json"]
+    assert ui_robot_coverage_contract.argv[-2:] == [
+        "tools/ui_robot_coverage_contract.py",
+        "--json",
+    ]
     assert ui_robot_action_contract.timeout_seconds == 2 * 60
-    assert ui_robot_action_contract.argv[-2:] == ["tools/ui_robot_action_contract.py", "--json"]
+    assert ui_robot_action_contract.argv[-2:] == [
+        "tools/ui_robot_action_contract.py",
+        "--json",
+    ]
     assert ui_robot_canary.label == "ui robot fault-injection canary"
     assert ui_robot_canary.timeout_seconds == 5 * 60
     assert "tools/ui_robot_canary.py" in ui_robot_canary.argv
@@ -457,7 +525,9 @@ def test_profile_commands_cover_expected_coverage_and_docs_contracts() -> None:
             f"screenshots/ui-robot-matrix/{shard}",
         ]
         assert "tools/agilab_widget_robot_matrix.py" in command.argv
-        assert expected_matrix_scenarios[shard] == set(_option_values(command.argv, "--scenario"))
+        assert expected_matrix_scenarios[shard] == set(
+            _option_values(command.argv, "--scenario")
+        )
         assert "--quiet-progress" in command.argv
         assert "--json" in command.argv
         assert "--no-result-cache" in command.argv
@@ -465,9 +535,18 @@ def test_profile_commands_cover_expected_coverage_and_docs_contracts() -> None:
         assert f"screenshots/ui-robot-matrix/{shard}" in command.argv
         assert f"test-results/ui-robot-matrix/{shard}/failure-bundles" in command.argv
         assert "--retry-failed-with-artifacts" in command.argv
-        assert f"test-results/ui-robot-matrix/{shard}/failure-artifacts/traces" in command.argv
-        assert f"test-results/ui-robot-matrix/{shard}/failure-artifacts/har" in command.argv
-        assert f"test-results/ui-robot-matrix/{shard}/failure-artifacts/video" in command.argv
+        assert (
+            f"test-results/ui-robot-matrix/{shard}/failure-artifacts/traces"
+            in command.argv
+        )
+        assert (
+            f"test-results/ui-robot-matrix/{shard}/failure-artifacts/har"
+            in command.argv
+        )
+        assert (
+            f"test-results/ui-robot-matrix/{shard}/failure-artifacts/video"
+            in command.argv
+        )
         assert _has_with_dependency(command.argv, "playwright")
         assert _has_extra(command.argv, "ai")
     assert ui_artifact_capture_robot.label == "ui artifact capture robot"
@@ -475,11 +554,18 @@ def test_profile_commands_cover_expected_coverage_and_docs_contracts() -> None:
     assert "isolated-project-page" in ui_artifact_capture_robot.argv
     assert "flight_telemetry_project" in ui_artifact_capture_robot.argv
     assert "--trace-dir" in ui_artifact_capture_robot.argv
-    assert "test-results/ui-artifact-capture-robot/traces" in ui_artifact_capture_robot.argv
+    assert (
+        "test-results/ui-artifact-capture-robot/traces"
+        in ui_artifact_capture_robot.argv
+    )
     assert "--har-dir" in ui_artifact_capture_robot.argv
-    assert "test-results/ui-artifact-capture-robot/har" in ui_artifact_capture_robot.argv
+    assert (
+        "test-results/ui-artifact-capture-robot/har" in ui_artifact_capture_robot.argv
+    )
     assert "--video-dir" in ui_artifact_capture_robot.argv
-    assert "test-results/ui-artifact-capture-robot/video" in ui_artifact_capture_robot.argv
+    assert (
+        "test-results/ui-artifact-capture-robot/video" in ui_artifact_capture_robot.argv
+    )
     assert ui_artifact_capture_robot.remove_paths == [
         "test-results/ui-artifact-capture-robot",
         "screenshots/ui-artifact-capture-robot",
@@ -487,7 +573,10 @@ def test_profile_commands_cover_expected_coverage_and_docs_contracts() -> None:
     assert _has_with_dependency(ui_artifact_capture_robot.argv, "playwright")
     assert ui_history_robot.label == "ui browser history robot"
     assert ui_history_robot.timeout_seconds == 30 * 60
-    assert ui_history_robot.remove_paths == ["test-results/ui-history-robot", "screenshots/ui-history-robot"]
+    assert ui_history_robot.remove_paths == [
+        "test-results/ui-history-robot",
+        "screenshots/ui-history-robot",
+    ]
     assert "tools/agilab_widget_robot_matrix.py" in ui_history_robot.argv
     assert "isolated-browser-history" in ui_history_robot.argv
     assert "screenshots/ui-history-robot" in ui_history_robot.argv
@@ -495,7 +584,10 @@ def test_profile_commands_cover_expected_coverage_and_docs_contracts() -> None:
     assert _has_with_dependency(ui_history_robot.argv, "playwright")
     assert ui_mobile_robot.label == "ui mobile viewport robot"
     assert ui_mobile_robot.timeout_seconds == 30 * 60
-    assert ui_mobile_robot.remove_paths == ["test-results/ui-mobile-robot", "screenshots/ui-mobile-robot"]
+    assert ui_mobile_robot.remove_paths == [
+        "test-results/ui-mobile-robot",
+        "screenshots/ui-mobile-robot",
+    ]
     assert "isolated-mobile-core-pages" in ui_mobile_robot.argv
     assert "screenshots/ui-mobile-robot" in ui_mobile_robot.argv
     assert "test-results/ui-mobile-robot/failure-bundles" in ui_mobile_robot.argv
@@ -510,7 +602,10 @@ def test_profile_commands_cover_expected_coverage_and_docs_contracts() -> None:
     assert "isolated-fresh-session-core-pages" in ui_release_evidence_robot.argv
     assert "--no-result-cache" in ui_release_evidence_robot.argv
     assert "screenshots/ui-release-evidence-robot" in ui_release_evidence_robot.argv
-    assert "test-results/ui-release-evidence-robot/failure-bundles" in ui_release_evidence_robot.argv
+    assert (
+        "test-results/ui-release-evidence-robot/failure-bundles"
+        in ui_release_evidence_robot.argv
+    )
     assert _has_with_dependency(ui_release_evidence_robot.argv, "playwright")
     assert ui_first_proof_robot.label == "ui first-proof golden path robot"
     assert ui_first_proof_robot.timeout_seconds == 45 * 60
@@ -521,38 +616,63 @@ def test_profile_commands_cover_expected_coverage_and_docs_contracts() -> None:
     assert "current-home-first-proof-golden-path" in ui_first_proof_robot.argv
     assert "flight_telemetry_project" in ui_first_proof_robot.argv
     assert "screenshots/ui-first-proof-robot" in ui_first_proof_robot.argv
-    assert "test-results/ui-first-proof-robot/failure-bundles" in ui_first_proof_robot.argv
+    assert (
+        "test-results/ui-first-proof-robot/failure-bundles" in ui_first_proof_robot.argv
+    )
     assert _has_with_dependency(ui_first_proof_robot.argv, "playwright")
     assert ui_keyboard_robot.label == "ui keyboard focus robot"
     assert ui_keyboard_robot.timeout_seconds == 30 * 60
-    assert ui_keyboard_robot.remove_paths == ["test-results/ui-keyboard-robot", "screenshots/ui-keyboard-robot"]
+    assert ui_keyboard_robot.remove_paths == [
+        "test-results/ui-keyboard-robot",
+        "screenshots/ui-keyboard-robot",
+    ]
     assert "isolated-keyboard-focus-core-pages" in ui_keyboard_robot.argv
     assert "test-results/ui-keyboard-robot/failure-bundles" in ui_keyboard_robot.argv
     assert _has_with_dependency(ui_keyboard_robot.argv, "playwright")
     assert ui_layout_robot.label == "ui layout integrity robot"
     assert ui_layout_robot.timeout_seconds == 45 * 60
-    assert ui_layout_robot.remove_paths == ["test-results/ui-layout-robot", "screenshots/ui-layout-robot"]
+    assert ui_layout_robot.remove_paths == [
+        "test-results/ui-layout-robot",
+        "screenshots/ui-layout-robot",
+    ]
     assert "isolated-layout-integrity-desktop" in ui_layout_robot.argv
     assert "isolated-layout-integrity-mobile" in ui_layout_robot.argv
     assert "test-results/ui-layout-robot/failure-bundles" in ui_layout_robot.argv
     assert _has_with_dependency(ui_layout_robot.argv, "playwright")
     assert ui_accessibility_robot.label == "ui accessibility semantics robot"
     assert ui_accessibility_robot.timeout_seconds == 30 * 60
-    assert ui_accessibility_robot.remove_paths == ["test-results/ui-accessibility-robot", "screenshots/ui-accessibility-robot"]
+    assert ui_accessibility_robot.remove_paths == [
+        "test-results/ui-accessibility-robot",
+        "screenshots/ui-accessibility-robot",
+    ]
     assert "isolated-accessibility-core-pages" in ui_accessibility_robot.argv
-    assert "test-results/ui-accessibility-robot/failure-bundles" in ui_accessibility_robot.argv
+    assert (
+        "test-results/ui-accessibility-robot/failure-bundles"
+        in ui_accessibility_robot.argv
+    )
     assert _has_with_dependency(ui_accessibility_robot.argv, "playwright")
     assert ui_browser_error_robot.label == "ui browser error robot"
     assert ui_browser_error_robot.timeout_seconds == 30 * 60
-    assert ui_browser_error_robot.remove_paths == ["test-results/ui-browser-error-robot", "screenshots/ui-browser-error-robot"]
+    assert ui_browser_error_robot.remove_paths == [
+        "test-results/ui-browser-error-robot",
+        "screenshots/ui-browser-error-robot",
+    ]
     assert "isolated-browser-error-core-pages" in ui_browser_error_robot.argv
-    assert "test-results/ui-browser-error-robot/failure-bundles" in ui_browser_error_robot.argv
+    assert (
+        "test-results/ui-browser-error-robot/failure-bundles"
+        in ui_browser_error_robot.argv
+    )
     assert _has_with_dependency(ui_browser_error_robot.argv, "playwright")
     assert ui_above_fold_robot.label == "ui above-fold primary targets robot"
     assert ui_above_fold_robot.timeout_seconds == 30 * 60
-    assert ui_above_fold_robot.remove_paths == ["test-results/ui-above-fold-robot", "screenshots/ui-above-fold-robot"]
+    assert ui_above_fold_robot.remove_paths == [
+        "test-results/ui-above-fold-robot",
+        "screenshots/ui-above-fold-robot",
+    ]
     assert "isolated-above-fold-core-pages" in ui_above_fold_robot.argv
-    assert "test-results/ui-above-fold-robot/failure-bundles" in ui_above_fold_robot.argv
+    assert (
+        "test-results/ui-above-fold-robot/failure-bundles" in ui_above_fold_robot.argv
+    )
     assert _has_with_dependency(ui_above_fold_robot.argv, "playwright")
     assert [command.label for command in ui_visual_baseline_robot] == [
         "ui visual baseline screenshot capture",
@@ -564,7 +684,10 @@ def test_profile_commands_cover_expected_coverage_and_docs_contracts() -> None:
     ]
     assert "isolated-visual-baseline-core-pages" in ui_visual_baseline_robot[0].argv
     assert "flight_telemetry_project" in ui_visual_baseline_robot[0].argv
-    assert "screenshots/ui-visual-baseline-robot/current" in ui_visual_baseline_robot[0].argv
+    assert (
+        "screenshots/ui-visual-baseline-robot/current"
+        in ui_visual_baseline_robot[0].argv
+    )
     assert "tools/ui_visual_baseline_report.py" in ui_visual_baseline_robot[1].argv
     assert "--advisory" in ui_visual_baseline_robot[1].argv
     assert _has_with_dependency(ui_visual_baseline_robot[0].argv, "playwright")
@@ -574,8 +697,12 @@ def test_profile_commands_cover_expected_coverage_and_docs_contracts() -> None:
     assert agi_web_visual.argv[agi_web_visual.argv.index("--browser") + 1] == "chromium"
     assert "screenshots/agi-web-visual-regression" in agi_web_visual.argv
     assert "docs/source/_static/agi-web-visual-baseline" in agi_web_visual.argv
-    assert agi_web_visual.argv[agi_web_visual.argv.index("--max-render-ms") + 1] == "2500"
-    assert agi_web_visual.argv[agi_web_visual.argv.index("--max-diff-ratio") + 1] == "0.08"
+    assert (
+        agi_web_visual.argv[agi_web_visual.argv.index("--max-render-ms") + 1] == "2500"
+    )
+    assert (
+        agi_web_visual.argv[agi_web_visual.argv.index("--max-diff-ratio") + 1] == "0.08"
+    )
     assert _has_with_dependency(agi_web_visual.argv, "playwright")
     assert _has_with_dependency(agi_web_visual.argv, "pillow")
     assert [command.label for command in agi_web_cross_browser] == [
@@ -586,11 +713,29 @@ def test_profile_commands_cover_expected_coverage_and_docs_contracts() -> None:
         "test-results/agi-web-cross-browser",
         "screenshots/agi-web-cross-browser",
     ]
-    assert agi_web_cross_browser[0].argv[-4:] == ["install", "chromium", "firefox", "webkit"]
-    assert agi_web_cross_browser[1].argv[agi_web_cross_browser[1].argv.index("--browser") + 1] == "all"
+    assert agi_web_cross_browser[0].argv[-4:] == [
+        "install",
+        "chromium",
+        "firefox",
+        "webkit",
+    ]
+    assert (
+        agi_web_cross_browser[1].argv[
+            agi_web_cross_browser[1].argv.index("--browser") + 1
+        ]
+        == "all"
+    )
     assert "--allow-canvas-fallback" in agi_web_cross_browser[1].argv
-    assert agi_web_cross_browser[1].argv[agi_web_cross_browser[1].argv.index("--max-render-ms") + 1] == "4000"
-    assert all(_has_with_dependency(command.argv, "playwright") for command in agi_web_cross_browser)
+    assert (
+        agi_web_cross_browser[1].argv[
+            agi_web_cross_browser[1].argv.index("--max-render-ms") + 1
+        ]
+        == "4000"
+    )
+    assert all(
+        _has_with_dependency(command.argv, "playwright")
+        for command in agi_web_cross_browser
+    )
     assert _has_with_dependency(agi_web_cross_browser[1].argv, "pillow")
     assert ui_trend_robot.label == "ui robot trend report"
     assert "tools/ui_robot_trend_report.py" in ui_trend_robot.argv
@@ -606,18 +751,42 @@ def test_profile_commands_cover_expected_coverage_and_docs_contracts() -> None:
         "test-results/ui-cross-browser-robot",
         "screenshots/ui-cross-browser-robot",
     ]
-    assert ui_cross_browser_robot[0].argv[-4:] == ["playwright", "install", "firefox", "webkit"]
+    assert ui_cross_browser_robot[0].argv[-4:] == [
+        "playwright",
+        "install",
+        "firefox",
+        "webkit",
+    ]
     assert "isolated-cross-browser-core-pages" in ui_cross_browser_robot[1].argv
-    assert ui_cross_browser_robot[1].argv[ui_cross_browser_robot[1].argv.index("--browser") + 1] == "firefox"
+    assert (
+        ui_cross_browser_robot[1].argv[
+            ui_cross_browser_robot[1].argv.index("--browser") + 1
+        ]
+        == "firefox"
+    )
     assert "isolated-cross-browser-core-pages" in ui_cross_browser_robot[2].argv
-    assert ui_cross_browser_robot[2].argv[ui_cross_browser_robot[2].argv.index("--browser") + 1] == "webkit"
-    assert all(_has_with_dependency(command.argv, "playwright") for command in ui_cross_browser_robot)
+    assert (
+        ui_cross_browser_robot[2].argv[
+            ui_cross_browser_robot[2].argv.index("--browser") + 1
+        ]
+        == "webkit"
+    )
+    assert all(
+        _has_with_dependency(command.argv, "playwright")
+        for command in ui_cross_browser_robot
+    )
     assert hf_install_robot.label == "hf first-proof install robot"
     assert hf_install_robot.timeout_seconds == 25 * 60
-    assert hf_install_robot.remove_paths == ["test-results/hf-install-robot", "screenshots/hf-install-robot"]
+    assert hf_install_robot.remove_paths == [
+        "test-results/hf-install-robot",
+        "screenshots/hf-install-robot",
+    ]
     assert "tools/agilab_widget_robot_matrix.py" in hf_install_robot.argv
     assert "hf-first-proof-install" in hf_install_robot.argv
-    assert "flight_telemetry_project,pytorch_playground_project,weather_forecast_project" in hf_install_robot.argv
+    assert (
+        "flight_telemetry_project,pytorch_playground_project,weather_forecast_project"
+        in hf_install_robot.argv
+    )
     assert "https://huggingface.co/spaces/jpmorard/agilab" in hf_install_robot.argv
     assert "--active-app" not in hf_install_robot.argv
     assert "screenshots/hf-install-robot" in hf_install_robot.argv
@@ -625,11 +794,17 @@ def test_profile_commands_cover_expected_coverage_and_docs_contracts() -> None:
     assert _has_with_dependency(hf_install_robot.argv, "playwright")
     assert hf_visual_smoke_robot.label == "hf first-proof visual smoke robot"
     assert hf_visual_smoke_robot.timeout_seconds == 25 * 60
-    assert hf_visual_smoke_robot.remove_paths == ["test-results/hf-visual-smoke-robot", "screenshots/hf-visual-smoke-robot"]
+    assert hf_visual_smoke_robot.remove_paths == [
+        "test-results/hf-visual-smoke-robot",
+        "screenshots/hf-visual-smoke-robot",
+    ]
     assert "hf-first-proof-visual-smoke" in hf_visual_smoke_robot.argv
     assert "hf-first-proof-app-pages-visual-smoke" in hf_visual_smoke_robot.argv
     assert hf_visual_smoke_robot.argv.count("--scenario") == 2
-    assert "flight_telemetry_project,pytorch_playground_project,weather_forecast_project" in hf_visual_smoke_robot.argv
+    assert (
+        "flight_telemetry_project,pytorch_playground_project,weather_forecast_project"
+        in hf_visual_smoke_robot.argv
+    )
     assert "https://huggingface.co/spaces/jpmorard/agilab" in hf_visual_smoke_robot.argv
     assert "--active-app" not in hf_visual_smoke_robot.argv
     assert "screenshots/hf-visual-smoke-robot" in hf_visual_smoke_robot.argv
@@ -670,7 +845,9 @@ def test_agi_gui_coverage_chunk_wrapper_writes_manifest(tmp_path) -> None:
     assert manifest["coverage_db_paths"] == [db_fragment.as_posix()]
 
 
-def test_agi_gui_coverage_combine_recovers_missing_success_manifest(tmp_path, monkeypatch) -> None:
+def test_agi_gui_coverage_combine_recovers_missing_success_manifest(
+    tmp_path, monkeypatch
+) -> None:
     module = _load_module()
     monkeypatch.setattr(module, "AGI_GUI_COVERAGE_MANIFEST_WAIT_SECONDS", 0.0)
     test_results = tmp_path / "test-results"
@@ -681,7 +858,9 @@ def test_agi_gui_coverage_combine_recovers_missing_success_manifest(tmp_path, mo
     for chunk in module.AGI_GUI_COVERAGE_CHUNKS:
         db_fragment = test_results / f"coverage-agi-gui-{chunk}.db.fragment"
         db_fragment.write_text("coverage-db\n", encoding="utf-8")
-        (test_results / f"junit-agi-gui-{chunk}.xml").write_text("<testsuite/>\n", encoding="utf-8")
+        (test_results / f"junit-agi-gui-{chunk}.xml").write_text(
+            "<testsuite/>\n", encoding="utf-8"
+        )
         if chunk == recovered_chunk:
             continue
         (test_results / f"coverage-agi-gui-{chunk}.manifest.json").write_text(
@@ -692,7 +871,9 @@ def test_agi_gui_coverage_combine_recovers_missing_success_manifest(tmp_path, mo
                     "returncode": 0,
                     "data_file": f"test-results/coverage-agi-gui-{chunk}.db",
                     "junit_path": f"test-results/junit-agi-gui-{chunk}.xml",
-                    "coverage_db_paths": [f"test-results/coverage-agi-gui-{chunk}.db.fragment"],
+                    "coverage_db_paths": [
+                        f"test-results/coverage-agi-gui-{chunk}.db.fragment"
+                    ],
                 }
             ),
             encoding="utf-8",
@@ -720,7 +901,9 @@ def test_agi_gui_coverage_combine_recovers_missing_success_manifest(tmp_path, mo
     )
 
 
-def test_agi_gui_coverage_combine_deduplicates_parallel_base_paths(tmp_path, monkeypatch) -> None:
+def test_agi_gui_coverage_combine_deduplicates_parallel_base_paths(
+    tmp_path, monkeypatch
+) -> None:
     module = _load_module()
     monkeypatch.setattr(module, "AGI_GUI_COVERAGE_MANIFEST_WAIT_SECONDS", 0.0)
     test_results = tmp_path / "test-results"
@@ -819,10 +1002,15 @@ def test_agi_gui_coverage_combine_rediscovers_current_db_when_manifest_is_stale(
         and "coverage-agi-gui-pages-rest.db.current" in arg
         for arg in combined_commands[0]
     )
-    assert all("coverage-agi-gui-pages-rest.db.stale" not in arg for arg in combined_commands[0])
+    assert all(
+        "coverage-agi-gui-pages-rest.db.stale" not in arg
+        for arg in combined_commands[0]
+    )
 
 
-def test_agi_gui_coverage_combine_does_not_recover_failing_junit(tmp_path, monkeypatch, capsys) -> None:
+def test_agi_gui_coverage_combine_does_not_recover_failing_junit(
+    tmp_path, monkeypatch, capsys
+) -> None:
     module = _load_module()
     monkeypatch.setattr(module, "AGI_GUI_COVERAGE_MANIFEST_WAIT_SECONDS", 0.0)
     test_results = tmp_path / "test-results"
@@ -847,7 +1035,9 @@ def test_agi_gui_coverage_combine_does_not_recover_failing_junit(tmp_path, monke
                     "returncode": 0,
                     "data_file": f"test-results/coverage-agi-gui-{chunk}.db",
                     "junit_path": f"test-results/junit-agi-gui-{chunk}.xml",
-                    "coverage_db_paths": [f"test-results/coverage-agi-gui-{chunk}.db.fragment"],
+                    "coverage_db_paths": [
+                        f"test-results/coverage-agi-gui-{chunk}.db.fragment"
+                    ],
                 }
             ),
             encoding="utf-8",
@@ -912,7 +1102,10 @@ def test_selected_profiles_can_select_ui_robot_profiles_from_changed_files() -> 
     args = SimpleNamespace(
         profile=None,
         select_ui_robot_profiles=True,
-        changed_file=["tools/agilab_widget_robot.py", "docs/source/_static/page-shots/home.png"],
+        changed_file=[
+            "tools/agilab_widget_robot.py",
+            "docs/source/_static/page-shots/home.png",
+        ],
         changed_base="",
     )
 
@@ -930,7 +1123,9 @@ def test_selected_profiles_can_select_ui_robot_profiles_from_changed_files() -> 
 def test_ui_robot_profile_selection_covers_change_classes() -> None:
     module = _load_module()
 
-    assert module.select_ui_robot_profiles_for_files([".github/workflows/coverage.yml"]) == [
+    assert module.select_ui_robot_profiles_for_files(
+        [".github/workflows/coverage.yml"]
+    ) == [
         "ui-robot-contract",
         "ui-robot-canary",
         "ui-trend-robot",
@@ -941,7 +1136,9 @@ def test_ui_robot_profile_selection_covers_change_classes() -> None:
         "ui-frontend-smoke",
         "ui-trend-robot",
     ]
-    assert module.select_ui_robot_profiles_for_files(["src/agilab/pages/project.py"]) == [
+    assert module.select_ui_robot_profiles_for_files(
+        ["src/agilab/pages/project.py"]
+    ) == [
         "ui-frontend-smoke",
         "ui-robot-matrix",
         "ui-history-robot",
@@ -953,7 +1150,9 @@ def test_ui_robot_profile_selection_covers_change_classes() -> None:
         "ui-above-fold-robot",
         "ui-trend-robot",
     ]
-    assert module.select_ui_robot_profiles_for_files([".github/workflows/huggingface.yml"]) == [
+    assert module.select_ui_robot_profiles_for_files(
+        [".github/workflows/huggingface.yml"]
+    ) == [
         "hf-install-robot",
         "hf-visual-smoke-robot",
     ]
@@ -961,7 +1160,9 @@ def test_ui_robot_profile_selection_covers_change_classes() -> None:
         "hf-install-robot",
         "hf-visual-smoke-robot",
     ]
-    assert module.select_ui_robot_profiles_for_files(["tools/hf_space_release_sync.py"]) == [
+    assert module.select_ui_robot_profiles_for_files(
+        ["tools/hf_space_release_sync.py"]
+    ) == [
         "hf-install-robot",
         "hf-visual-smoke-robot",
     ]
@@ -973,16 +1174,22 @@ def test_ui_robot_profile_selection_covers_change_classes() -> None:
     assert module.select_ui_robot_profiles_for_files(["tools/agilab_web_robot.py"]) == [
         "ui-frontend-smoke",
     ]
-    assert module.select_ui_robot_profiles_for_files(["src/agilab/lib/agi-web/src/agi_web/component.py"]) == [
+    assert module.select_ui_robot_profiles_for_files(
+        ["src/agilab/lib/agi-web/src/agi_web/component.py"]
+    ) == [
         "agi-web-visual",
     ]
-    assert module.select_ui_robot_profiles_for_files(["tools/agi_web_visual_regression.py"]) == [
+    assert module.select_ui_robot_profiles_for_files(
+        ["tools/agi_web_visual_regression.py"]
+    ) == [
         "agi-web-visual",
     ]
     assert module.select_ui_robot_profiles_for_files(["pyproject.toml"]) == [
         "ui-frontend-smoke",
     ]
-    assert module.select_ui_robot_profiles_for_files(["tools/run_configs/agilab/agilab-run-dev.sh"]) == [
+    assert module.select_ui_robot_profiles_for_files(
+        ["tools/run_configs/agilab/agilab-run-dev.sh"]
+    ) == [
         "ui-frontend-smoke",
     ]
     assert module.select_ui_robot_profiles_for_files(["README.md"]) == [
@@ -990,7 +1197,9 @@ def test_ui_robot_profile_selection_covers_change_classes() -> None:
     ]
 
 
-def test_selected_ui_robot_profiles_reads_dirty_tree_when_no_files_given(monkeypatch) -> None:
+def test_selected_ui_robot_profiles_reads_dirty_tree_when_no_files_given(
+    monkeypatch,
+) -> None:
     module = _load_module()
     monkeypatch.setattr(
         module,
@@ -1087,7 +1296,9 @@ def test_installer_profile_contract_check_allows_missing_worker_copy() -> None:
 
 def test_builtin_app_tests_profile_runs_app_local_runner() -> None:
     module = _load_module()
-    args = SimpleNamespace(components=None, skills=None, app_path=None, worker_copy=None)
+    args = SimpleNamespace(
+        components=None, skills=None, app_path=None, worker_copy=None
+    )
 
     command = module._profile_commands(args)["builtin-app-tests"][0]
 
@@ -1105,14 +1316,18 @@ def test_builtin_app_tests_profile_runs_app_local_runner() -> None:
 def test_builtin_app_tests_profile_is_accepted_by_parser(capsys) -> None:
     module = _load_module()
 
-    assert module.main(["--profile", "builtin-app-tests", "--print-only", "--json"]) == 0
+    assert (
+        module.main(["--profile", "builtin-app-tests", "--print-only", "--json"]) == 0
+    )
     payload = json.loads(capsys.readouterr().out)
 
     assert payload["profiles"] == ["builtin-app-tests"]
     assert payload["commands"]["builtin-app-tests"][0]["label"] == "built-in app tests"
 
 
-def test_prepare_command_removes_globbed_coverage_fragments(tmp_path, monkeypatch) -> None:
+def test_prepare_command_removes_globbed_coverage_fragments(
+    tmp_path, monkeypatch
+) -> None:
     module = _load_module()
     monkeypatch.setattr(module, "REPO_ROOT", tmp_path)
     results_dir = tmp_path / "test-results"
@@ -1172,7 +1387,9 @@ def test_run_command_executes_with_env_and_cwd(tmp_path, monkeypatch) -> None:
     assert (workdir / "out.txt").read_text(encoding="utf-8") == "ok"
 
 
-def test_run_profiles_reuses_cached_success_without_executing(tmp_path, monkeypatch) -> None:
+def test_run_profiles_reuses_cached_success_without_executing(
+    tmp_path, monkeypatch
+) -> None:
     module = _load_module()
     cache_path = tmp_path / "workflow-parity-cache.json"
     spec = module.CommandSpec(
@@ -1245,7 +1462,9 @@ def test_run_profiles_records_successful_result_cache(tmp_path, monkeypatch) -> 
         changed_files=[],
         cache_path=cache_path,
     )
-    cached = module._cached_run_results(module._load_result_cache(cache_path), cache_key, ["skills"])
+    cached = module._cached_run_results(
+        module._load_result_cache(cache_path), cache_key, ["skills"]
+    )
     assert cached is not None
     assert cached[0].commands[0].label == "quick success"
 
@@ -1273,11 +1492,15 @@ def test_run_profiles_does_not_cache_failures(tmp_path, monkeypatch) -> None:
         changed_files=[],
         cache_path=cache_path,
     )
-    cached = module._cached_run_results(module._load_result_cache(cache_path), cache_key, ["skills"])
+    cached = module._cached_run_results(
+        module._load_result_cache(cache_path), cache_key, ["skills"]
+    )
     assert cached is None
 
 
-def test_run_profiles_no_result_cache_bypasses_cached_success(tmp_path, monkeypatch) -> None:
+def test_run_profiles_no_result_cache_bypasses_cached_success(
+    tmp_path, monkeypatch
+) -> None:
     module = _load_module()
     cache_path = tmp_path / "workflow-parity-cache.json"
     spec = module.CommandSpec(
@@ -1320,7 +1543,9 @@ def test_run_profiles_no_result_cache_bypasses_cached_success(tmp_path, monkeypa
         ],
     )
 
-    results = module.run_profiles(["skills"], args=_cache_args(cache_path, no_result_cache=True))
+    results = module.run_profiles(
+        ["skills"], args=_cache_args(cache_path, no_result_cache=True)
+    )
 
     assert results[0].success is False
     assert results[0].commands[0].returncode == 5
@@ -1356,10 +1581,14 @@ def test_run_profiles_stops_on_first_failure_by_default() -> None:
     assert results[0].success is False
 
 
-def test_result_cache_helpers_round_trip_successful_profile(tmp_path, monkeypatch) -> None:
+def test_result_cache_helpers_round_trip_successful_profile(
+    tmp_path, monkeypatch
+) -> None:
     module = _load_module()
     monkeypatch.setattr(module, "REPO_ROOT", tmp_path)
-    monkeypatch.setattr(module, "RESULT_CACHE_INPUT_GLOBS", ("present.txt", "*.yml", "missing.txt"))
+    monkeypatch.setattr(
+        module, "RESULT_CACHE_INPUT_GLOBS", ("present.txt", "*.yml", "missing.txt")
+    )
     monkeypatch.setattr(module, "RESULT_CACHE_HASH_LIMIT_BYTES", 128)
     (tmp_path / "present.txt").write_text("present", encoding="utf-8")
     (tmp_path / "workflow.yml").write_text("workflow", encoding="utf-8")
@@ -1378,15 +1607,48 @@ def test_result_cache_helpers_round_trip_successful_profile(tmp_path, monkeypatc
     )
 
     assert module._result_cache_enabled(args, module._run_command) is True
-    assert module._result_cache_enabled(SimpleNamespace(result_cache=False, no_result_cache=False), module._run_command) is False
-    assert module._result_cache_enabled(SimpleNamespace(no_result_cache=True), module._run_command) is False
+    assert (
+        module._result_cache_enabled(
+            SimpleNamespace(result_cache=False, no_result_cache=False),
+            module._run_command,
+        )
+        is False
+    )
+    assert (
+        module._result_cache_enabled(
+            SimpleNamespace(
+                result_cache=False, no_result_cache=False, print_only=False
+            ),
+            module._run_command,
+            ["dependency-policy"],
+        )
+        is True
+    )
+    assert (
+        module._result_cache_enabled(
+            SimpleNamespace(
+                result_cache=False, no_result_cache=False, print_only=False
+            ),
+            module._run_command,
+            ["docs"],
+        )
+        is False
+    )
+    assert (
+        module._result_cache_enabled(
+            SimpleNamespace(no_result_cache=True), module._run_command
+        )
+        is False
+    )
     assert module._result_cache_enabled(args, lambda _spec: None) is False
     assert module._result_cache_path(args) == cache_path
     assert module._result_cache_changed_files(args) == [changed.as_posix()]
     assert module._repo_relative_or_absolute(tmp_path / "present.txt") == "present.txt"
     assert module._repo_relative_or_absolute(outside) == outside.as_posix()
 
-    input_paths = module._result_cache_input_paths([changed.as_posix(), cache_path.as_posix()], cache_path)
+    input_paths = module._result_cache_input_paths(
+        [changed.as_posix(), cache_path.as_posix()], cache_path
+    )
 
     assert input_paths == ["present.txt", "workflow.yml", "missing.txt", "changed.txt"]
     signatures = module._result_cache_fingerprints([changed.as_posix()], cache_path)
@@ -1394,9 +1656,14 @@ def test_result_cache_helpers_round_trip_successful_profile(tmp_path, monkeypatc
     assert signatures_by_path["present.txt"]["state"] == "file"
     assert "sha256" in signatures_by_path["present.txt"]
     assert signatures_by_path["missing.txt"]["state"] == "missing"
-    assert module._file_sha256(tmp_path / "present.txt") == signatures_by_path["present.txt"]["sha256"]
+    assert (
+        module._file_sha256(tmp_path / "present.txt")
+        == signatures_by_path["present.txt"]["sha256"]
+    )
 
-    command_spec = module.CommandSpec(label="cacheable", argv=["python", "-V"], env={"DEMO": "1"})
+    command_spec = module.CommandSpec(
+        label="cacheable", argv=["python", "-V"], env={"DEMO": "1"}
+    )
     commands_by_profile = {"skills": [command_spec]}
     descriptions = {"skills": "Validate skills"}
     monkeypatch.setattr(module, "_git_head", lambda: "abc123")
@@ -1440,7 +1707,9 @@ def test_result_cache_helpers_round_trip_successful_profile(tmp_path, monkeypatc
     assert cached[0].commands[0].env == {"DEMO": "1"}
 
 
-def test_result_cache_helpers_reject_invalid_payloads_and_prune(tmp_path, monkeypatch) -> None:
+def test_result_cache_helpers_reject_invalid_payloads_and_prune(
+    tmp_path, monkeypatch
+) -> None:
     module = _load_module()
     monkeypatch.setattr(module, "RESULT_CACHE_MAX_ENTRIES", 2)
     cache_path = tmp_path / "workflow_parity_results.json"
@@ -1448,24 +1717,81 @@ def test_result_cache_helpers_reject_invalid_payloads_and_prune(tmp_path, monkey
     assert module._load_result_cache(cache_path) == module._empty_result_cache()
     cache_path.write_text("{bad json", encoding="utf-8")
     assert module._load_result_cache(cache_path) == module._empty_result_cache()
-    cache_path.write_text(json.dumps({"schema": "wrong", "entries": {}}), encoding="utf-8")
+    cache_path.write_text(
+        json.dumps({"schema": "wrong", "entries": {}}), encoding="utf-8"
+    )
     assert module._load_result_cache(cache_path) == module._empty_result_cache()
-    cache_path.write_text(json.dumps({"schema": module.RESULT_CACHE_SCHEMA, "entries": []}), encoding="utf-8")
+    cache_path.write_text(
+        json.dumps({"schema": module.RESULT_CACHE_SCHEMA, "entries": []}),
+        encoding="utf-8",
+    )
     assert module._load_result_cache(cache_path) == module._empty_result_cache()
 
     assert module._command_result_from_cache(None) is None
-    assert module._command_result_from_cache({"label": "bad", "argv": [1], "env": {}, "returncode": 0, "cwd": "."}) is None
-    assert module._command_result_from_cache({"label": "bad", "argv": [], "env": [], "returncode": 0, "cwd": "."}) is None
-    assert module._command_result_from_cache({"label": "bad", "argv": [], "env": {}, "returncode": "0", "cwd": "."}) is None
+    assert (
+        module._command_result_from_cache(
+            {"label": "bad", "argv": [1], "env": {}, "returncode": 0, "cwd": "."}
+        )
+        is None
+    )
+    assert (
+        module._command_result_from_cache(
+            {"label": "bad", "argv": [], "env": [], "returncode": 0, "cwd": "."}
+        )
+        is None
+    )
+    assert (
+        module._command_result_from_cache(
+            {"label": "bad", "argv": [], "env": {}, "returncode": "0", "cwd": "."}
+        )
+        is None
+    )
     assert module._profile_result_from_cache(None) is None
-    assert module._profile_result_from_cache({"profile": 3, "description": "desc", "success": True, "commands": []}) is None
-    assert module._profile_result_from_cache({"profile": "skills", "description": "desc", "success": True, "commands": {}}) is None
-    assert module._profile_result_from_cache(
-        {"profile": "skills", "description": "desc", "success": True, "commands": [{"label": "bad"}]}
-    ) is None
+    assert (
+        module._profile_result_from_cache(
+            {"profile": 3, "description": "desc", "success": True, "commands": []}
+        )
+        is None
+    )
+    assert (
+        module._profile_result_from_cache(
+            {
+                "profile": "skills",
+                "description": "desc",
+                "success": True,
+                "commands": {},
+            }
+        )
+        is None
+    )
+    assert (
+        module._profile_result_from_cache(
+            {
+                "profile": "skills",
+                "description": "desc",
+                "success": True,
+                "commands": [{"label": "bad"}],
+            }
+        )
+        is None
+    )
     assert module._cached_run_results({"entries": []}, "key", ["skills"]) is None
-    assert module._cached_run_results({"entries": {"key": {"profiles": ["docs"], "results": []}}}, "key", ["skills"]) is None
-    assert module._cached_run_results({"entries": {"key": {"profiles": ["skills"], "results": {}}}}, "key", ["skills"]) is None
+    assert (
+        module._cached_run_results(
+            {"entries": {"key": {"profiles": ["docs"], "results": []}}},
+            "key",
+            ["skills"],
+        )
+        is None
+    )
+    assert (
+        module._cached_run_results(
+            {"entries": {"key": {"profiles": ["skills"], "results": {}}}},
+            "key",
+            ["skills"],
+        )
+        is None
+    )
     assert (
         module._cached_run_results(
             {"entries": {"key": {"profiles": ["skills"], "results": [{"profile": 3}]}}},
@@ -1499,7 +1825,9 @@ def test_result_cache_helpers_reject_invalid_payloads_and_prune(tmp_path, monkey
     assert not missing_entries_path.exists()
 
 
-def test_result_cache_helpers_cover_git_and_signature_failures(tmp_path, monkeypatch) -> None:
+def test_result_cache_helpers_cover_git_and_signature_failures(
+    tmp_path, monkeypatch
+) -> None:
     module = _load_module()
     monkeypatch.setattr(module, "REPO_ROOT", tmp_path)
 
@@ -1511,7 +1839,9 @@ def test_result_cache_helpers_cover_git_and_signature_failures(tmp_path, monkeyp
 
     target = tmp_path / "hash-error.txt"
     target.write_text("content", encoding="utf-8")
-    monkeypatch.setattr(module, "_file_sha256", lambda _path: (_ for _ in ()).throw(OSError("denied")))
+    monkeypatch.setattr(
+        module, "_file_sha256", lambda _path: (_ for _ in ()).throw(OSError("denied"))
+    )
 
     signature = module._file_signature("hash-error.txt")
 
@@ -1519,10 +1849,14 @@ def test_result_cache_helpers_cover_git_and_signature_failures(tmp_path, monkeyp
     assert signature["sha256_error"] == "OSError"
 
 
-def test_result_cache_input_paths_deduplicate_and_sign_directory_or_large_file(tmp_path, monkeypatch) -> None:
+def test_result_cache_input_paths_deduplicate_and_sign_directory_or_large_file(
+    tmp_path, monkeypatch
+) -> None:
     module = _load_module()
     monkeypatch.setattr(module, "REPO_ROOT", tmp_path)
-    monkeypatch.setattr(module, "RESULT_CACHE_INPUT_GLOBS", ("same.txt", "same.txt", "payload"))
+    monkeypatch.setattr(
+        module, "RESULT_CACHE_INPUT_GLOBS", ("same.txt", "same.txt", "payload")
+    )
     monkeypatch.setattr(module, "RESULT_CACHE_HASH_LIMIT_BYTES", 4)
     (tmp_path / "same.txt").write_text("same", encoding="utf-8")
     (tmp_path / "payload").write_text("too large", encoding="utf-8")
@@ -1546,7 +1880,16 @@ def test_result_cache_input_paths_deduplicate_and_sign_directory_or_large_file(t
 def test_main_print_only_json_lists_selected_profile_commands(capsys) -> None:
     module = _load_module()
 
-    exit_code = module.main(["--profile", "skills", "--skills", "agilab-installer", "--print-only", "--json"])
+    exit_code = module.main(
+        [
+            "--profile",
+            "skills",
+            "--skills",
+            "agilab-installer",
+            "--print-only",
+            "--json",
+        ]
+    )
 
     assert exit_code == 0
     payload = json.loads(capsys.readouterr().out)
@@ -1611,7 +1954,9 @@ def test_main_runs_profile_and_renders_results(capsys, monkeypatch) -> None:
 def test_main_accepts_production_readiness_profile(capsys) -> None:
     module = _load_module()
 
-    exit_code = module.main(["--profile", "production-readiness", "--print-only", "--json"])
+    exit_code = module.main(
+        ["--profile", "production-readiness", "--print-only", "--json"]
+    )
 
     assert exit_code == 0
     payload = json.loads(capsys.readouterr().out)
@@ -1628,14 +1973,18 @@ def test_main_accepts_production_readiness_profile(capsys) -> None:
 
 
 def test_workflow_parity_module_entrypoint_lists_profiles(monkeypatch, capsys) -> None:
-    monkeypatch.setattr(sys, "argv", ["workflow_parity.py", "--list-profiles", "--json"])
+    monkeypatch.setattr(
+        sys, "argv", ["workflow_parity.py", "--list-profiles", "--json"]
+    )
 
     try:
         runpy.run_path(MODULE_PATH.as_posix(), run_name="__main__")
     except SystemExit as exc:
         assert exc.code == 0
     else:
-        raise AssertionError("workflow_parity __main__ should terminate through SystemExit")
+        raise AssertionError(
+            "workflow_parity __main__ should terminate through SystemExit"
+        )
 
     listed = json.loads(capsys.readouterr().out)
     assert "skills" in listed

--- a/tools/agilab_dev.py
+++ b/tools/agilab_dev.py
@@ -59,7 +59,9 @@ def _uv_dev(*args: str) -> list[str]:
     return [*UV_RUN, "--extra", "dev", *args]
 
 
-def _split_leading_values(args: Sequence[str], *, command_name: str) -> tuple[list[str], list[str]]:
+def _split_leading_values(
+    args: Sequence[str], *, command_name: str
+) -> tuple[list[str], list[str]]:
     values: list[str] = []
     rest: list[str] = []
     for index, item in enumerate(args):
@@ -83,7 +85,9 @@ def _pop_option_value(args: Sequence[str], index: int, option: str) -> tuple[str
     return args[index + 1], index + 2
 
 
-def _split_release_args(args: Sequence[str]) -> tuple[list[str], list[str], list[str], list[str]]:
+def _split_release_args(
+    args: Sequence[str],
+) -> tuple[list[str], list[str], list[str], list[str]]:
     """Split local release shortcut options from impact-validation options."""
 
     impact_args: list[str] = []
@@ -99,7 +103,9 @@ def _split_release_args(args: Sequence[str]) -> tuple[list[str], list[str], list
             continue
         if item == "--impact-base-ref" or item.startswith("--impact-base-ref="):
             value, index = _pop_option_value(args, index, "--impact-base-ref")
-            release_plan_args.extend(["--skip-existing-pypi", "--impact-base-ref", value])
+            release_plan_args.extend(
+                ["--skip-existing-pypi", "--impact-base-ref", value]
+            )
             release_policy_args.extend(["--impact-base-ref", value])
             continue
         if item == "--packages" or item.startswith("--packages="):
@@ -168,7 +174,9 @@ def _compact_log_path(command: Sequence[str], output: str) -> Path:
     DEV_LOG_DIR.mkdir(parents=True, exist_ok=True)
     timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     family = Path(command[0]).name if command else "command"
-    digest = sha256(("\0".join(command) + "\n" + output).encode("utf-8", "replace")).hexdigest()[:12]
+    digest = sha256(
+        ("\0".join(command) + "\n" + output).encode("utf-8", "replace")
+    ).hexdigest()[:12]
     return DEV_LOG_DIR / f"{timestamp}-{family}-{digest}.log"
 
 
@@ -178,11 +186,15 @@ def _write_compact_log(command: Sequence[str], output: str) -> Path:
     return path
 
 
-def _summary_lines(output: str, *, max_lines: int, returncode: int) -> tuple[list[str], int, int]:
+def _summary_lines(
+    output: str, *, max_lines: int, returncode: int
+) -> tuple[list[str], int, int]:
     lines = output.splitlines()
     if not lines:
         return [], 0, 0
-    signals = [(index + 1, line) for index, line in enumerate(lines) if _is_signal_line(line)]
+    signals = [
+        (index + 1, line) for index, line in enumerate(lines) if _is_signal_line(line)
+    ]
     signal_budget = max(1, max_lines * 3 // 4)
     tail_budget = max(1, max_lines - min(len(signals), signal_budget))
 
@@ -194,7 +206,7 @@ def _summary_lines(output: str, *, max_lines: int, returncode: int) -> tuple[lis
     for line_number, line in signal_sample:
         selected.append(f"{line_number}: {line}")
 
-    if returncode != 0 or not selected:
+    if returncode != 0:
         tail = [line for line in lines[-tail_budget:] if line.strip()]
         if tail:
             if selected:
@@ -215,7 +227,9 @@ def _print_compact_result(
 ) -> None:
     log_path = _write_compact_log(command, output)
     lines = output.splitlines()
-    selected, signal_count, omitted = _summary_lines(output, max_lines=max_lines, returncode=returncode)
+    selected, signal_count, omitted = _summary_lines(
+        output, max_lines=max_lines, returncode=returncode
+    )
     rel_log = log_path.relative_to(ROOT) if log_path.is_relative_to(ROOT) else log_path
     status = "ok" if returncode == 0 else "failed"
     print(
@@ -226,8 +240,11 @@ def _print_compact_result(
     )
     for line in selected:
         print(line, file=sys.stderr)
-    if omitted > 0:
-        print(f"... omitted {omitted} line(s); inspect {rel_log} for full output", file=sys.stderr)
+    if omitted > 0 and selected:
+        print(
+            f"... omitted {omitted} line(s); inspect {rel_log} for full output",
+            file=sys.stderr,
+        )
 
 
 def _run_compact(command: Sequence[str], *, max_lines: int) -> int:
@@ -267,7 +284,17 @@ def planned_commands(argv: Sequence[str]) -> list[list[str]]:
         return [_uv_python("tools/bugfix_validate.py", *helper_args)]
 
     if command == "test":
-        return [[*UV_RUN, "pytest", "-q", "-o", "addopts=", "--import-mode=importlib", *args]]
+        return [
+            [
+                *UV_RUN,
+                "pytest",
+                "-q",
+                "-o",
+                "addopts=",
+                "--import-mode=importlib",
+                *args,
+            ]
+        ]
 
     if command == "lint":
         if args:
@@ -312,7 +339,9 @@ def planned_commands(argv: Sequence[str]) -> list[list[str]]:
         return [_uv_python("tools/agilab_audit.py", *args)]
 
     if command in {"audit-quality", "audit-preflight"}:
-        forwarded = ["--preflight"] if command == "audit-preflight" and not args else args
+        forwarded = (
+            ["--preflight"] if command == "audit-preflight" and not args else args
+        )
         if command == "audit-quality" and not forwarded:
             forwarded = ["--preflight"]
         return [_uv_python("tools/audit_quality_evaluator.py", *forwarded)]
@@ -324,11 +353,38 @@ def planned_commands(argv: Sequence[str]) -> list[list[str]]:
             profile_args.extend(["--profile", profile])
         return [_uv_python("tools/workflow_parity.py", *profile_args, *extras)]
 
+    if command in {"ui-flow", "ui-impact", "ui-robots"}:
+        return [
+            _uv_python("tools/workflow_parity.py", "--select-ui-robot-profiles", *args)
+        ]
+
+    if command in {"perf-startup", "startup-perf"}:
+        defaults = [
+            "--scenario",
+            "orchestrate-execute-import",
+            "--scenario",
+            "pipeline-ai-import",
+            "--scenario",
+            "runtime-distribution-import",
+            "--scenario",
+            "base-worker-import",
+            "--repeats",
+            "1",
+            "--warmups",
+            "0",
+        ]
+        return [_uv_python("tools/perf_smoke.py", *(args or defaults))]
+
+    if command in {"worker-reuse", "worker-env-reuse"}:
+        return [_uv_python("tools/worker_env_reuse.py", *args)]
+
     if command in {"typing", "ty"}:
         return [_uv_python("tools/workflow_parity.py", "--profile", "ty-typing", *args)]
 
     if command in {"release", "pre-release"}:
-        impact_args, release_plan_args, release_policy_args, preflight_args = _split_release_args(args)
+        impact_args, release_plan_args, release_policy_args, preflight_args = (
+            _split_release_args(args)
+        )
         return [
             _uv_python("tools/agilab_audit.py", "--strict"),
             _uv_python("tools/impact_validate.py", *impact_args),
@@ -338,7 +394,11 @@ def planned_commands(argv: Sequence[str]) -> list[list[str]]:
                 ".github/workflows/pypi-publish.yaml",
                 *release_plan_args,
             ),
-            _uv_python("tools/pypi_release_version_policy.py", "--skip-existing-pypi", *release_policy_args),
+            _uv_python(
+                "tools/pypi_release_version_policy.py",
+                "--skip-existing-pypi",
+                *release_policy_args,
+            ),
             _uv_python("tools/pypi_project_preflight.py", *preflight_args),
             _uv_python(
                 "tools/pypi_trusted_publisher_contract.py",
@@ -388,7 +448,14 @@ def planned_commands(argv: Sequence[str]) -> list[list[str]]:
         skills, extras = _split_leading_values(args, command_name=command)
         return [
             ["python3", "tools/sync_agent_skills.py", "--skills", *skills, *extras],
-            ["python3", "tools/codex_skills.py", "--root", ".codex/skills", "validate", "--strict"],
+            [
+                "python3",
+                "tools/codex_skills.py",
+                "--root",
+                ".codex/skills",
+                "validate",
+                "--strict",
+            ],
             ["python3", "tools/codex_skills.py", "--root", ".codex/skills", "generate"],
             ["python3", "tools/agent_skill_catalog.py", "--apply"],
             ["python3", "tools/generate_skill_badges.py"],
@@ -401,7 +468,15 @@ def planned_commands(argv: Sequence[str]) -> list[list[str]]:
                 "--fail-on",
                 "high",
             ],
-            ["python3", "tools/skill_security_scan.py", "--roots", ".claude/skills", ".codex/skills", "--fail-on", "critical"],
+            [
+                "python3",
+                "tools/skill_security_scan.py",
+                "--roots",
+                ".claude/skills",
+                ".codex/skills",
+                "--fail-on",
+                "critical",
+            ],
         ]
 
     raise SystemExit(f"unknown shortcut: {command}")
@@ -424,6 +499,9 @@ def _usage() -> str:
   ./dev [--print-only] [--raw-output|--compact-output] [--summary-lines N] audit-quality [audit_quality_evaluator args|audit.md]
   ./dev [--print-only] [--raw-output|--compact-output] [--summary-lines N] audit-preflight
   ./dev [--print-only] [--raw-output|--compact-output] [--summary-lines N] flow|profile <profile> [profile...] [workflow args]
+  ./dev [--print-only] [--raw-output|--compact-output] [--summary-lines N] ui-flow [workflow-parity changed-file args]
+  ./dev [--print-only] [--raw-output|--compact-output] [--summary-lines N] perf-startup [perf_smoke args]
+  ./dev [--print-only] [--raw-output|--compact-output] [--summary-lines N] worker-reuse [worker_env_reuse args]
   ./dev [--print-only] [--raw-output|--compact-output] [--summary-lines N] typing [workflow-parity options]
   ./dev [--print-only] [--raw-output|--compact-output] [--summary-lines N] release [--release-mode MODE] [--impact-base-ref REF] [impact_validate args]
   ./dev [--print-only] [--raw-output|--compact-output] [--summary-lines N] badge|guard [coverage_badge_guard args]
@@ -453,7 +531,10 @@ High-frequency mappings:
   audit     -> Audit local AGILAB worktrees, release proof, docs mirror, PyPI projects, and latest release truth.
   audit-quality -> Score a Markdown AGILAB audit, or print the deep-audit preflight when no file is provided.
   audit-preflight -> Print the mandatory architecture-foundation preflight for deep AGILAB audits.
-  flow      -> Run one or more workflow_parity profiles with repeated --profile flags.
+  flow      -> Run one or more workflow_parity profiles with repeated --profile flags. Cache-safe profiles reuse successful local results automatically.
+  ui-flow   -> Select the minimal UI robot workflow profiles from changed files.
+  perf-startup -> Measure startup-sensitive AGILAB import paths with perf_smoke.
+  worker-reuse -> Compare worker manifest fingerprints against a deployed-env reuse marker.
   typing    -> Run the forward shared-core ty typing profile. Mypy remains the curated temporary release guard under shared-core-typing.
   release   -> Run local release guards: AGILAB audit/review, impact, generated PyPI plan, release cadence, PyPI project preflight, trusted publisher contract, Ruff availability, docs, dependency policy, typing, and badge freshness. Pass --release-mode hotfix and --impact-base-ref <tag> for same-day hotfixes.
   badge     -> Run the explicit release/pre-release coverage badge freshness guard.
@@ -482,7 +563,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     if "--compact-output" in args:
         raw_output = False
         args = [item for item in args if item != "--compact-output"]
-    if "--summary-lines" in args or any(item.startswith("--summary-lines=") for item in args):
+    if "--summary-lines" in args or any(
+        item.startswith("--summary-lines=") for item in args
+    ):
         summary_lines = _parse_positive_int(
             _pop_global_option(args, "--summary-lines"),
             option="--summary-lines",

--- a/tools/performance_cache.py
+++ b/tools/performance_cache.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Small deterministic caches for local AGILAB performance helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Iterable
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_VERSION = "agilab.performance-cache.v1"
+DEFAULT_CACHE_PATH = REPO_ROOT / ".pytest_cache" / "agilab" / "performance_cache.json"
+
+
+def _empty_cache() -> dict[str, object]:
+    return {"schema": SCHEMA_VERSION, "entries": {}}
+
+
+def _load_cache(cache_path: Path = DEFAULT_CACHE_PATH) -> dict[str, object]:
+    try:
+        payload = json.loads(cache_path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return _empty_cache()
+    if not isinstance(payload, dict) or payload.get("schema") != SCHEMA_VERSION:
+        return _empty_cache()
+    if not isinstance(payload.get("entries"), dict):
+        return _empty_cache()
+    return payload
+
+
+def _write_cache(
+    cache: dict[str, object], cache_path: Path = DEFAULT_CACHE_PATH
+) -> None:
+    entries = cache.get("entries")
+    if not isinstance(entries, dict):
+        return
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = cache_path.with_name(f"{cache_path.name}.tmp")
+    tmp_path.write_text(
+        json.dumps(cache, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    tmp_path.replace(cache_path)
+
+
+def file_signature(path: Path) -> dict[str, object]:
+    try:
+        stat = path.stat()
+    except OSError as exc:
+        return {"state": "missing", "error": exc.__class__.__name__}
+    return {
+        "state": "file" if path.is_file() else "directory",
+        "size": stat.st_size,
+        "mtime_ns": stat.st_mtime_ns,
+        "inode": getattr(stat, "st_ino", 0),
+    }
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def cached_file_sha256(
+    path: Path,
+    *,
+    cache_path: Path = DEFAULT_CACHE_PATH,
+    namespace: str = "file-sha256",
+    use_cache: bool = True,
+) -> str:
+    resolved = path.expanduser().resolve()
+    signature = file_signature(resolved)
+    if signature.get("state") != "file":
+        raise FileNotFoundError(str(resolved))
+
+    cache = _load_cache(cache_path) if use_cache else _empty_cache()
+    entries = cache.setdefault("entries", {})
+    if not isinstance(entries, dict):
+        entries = {}
+        cache["entries"] = entries
+    key = f"{namespace}:{resolved}"
+    cached = entries.get(key)
+    if (
+        isinstance(cached, dict)
+        and cached.get("signature") == signature
+        and isinstance(cached.get("sha256"), str)
+    ):
+        return str(cached["sha256"])
+
+    digest = _sha256_file(resolved)
+    if use_cache:
+        entries[key] = {"signature": signature, "sha256": digest}
+        _write_cache(cache, cache_path)
+    return digest
+
+
+def manifest_digest(
+    paths: Iterable[Path],
+    *,
+    cache_path: Path = DEFAULT_CACHE_PATH,
+    namespace: str = "manifest",
+    use_cache: bool = True,
+) -> dict[str, object]:
+    files: list[dict[str, object]] = []
+    digest = hashlib.sha256()
+    for raw_path in sorted(
+        (path.expanduser() for path in paths), key=lambda item: item.as_posix()
+    ):
+        resolved = raw_path.resolve()
+        signature = file_signature(resolved)
+        entry: dict[str, object] = {
+            "path": resolved.as_posix(),
+            "signature": signature,
+        }
+        if signature.get("state") == "file":
+            entry["sha256"] = cached_file_sha256(
+                resolved,
+                cache_path=cache_path,
+                namespace=namespace,
+                use_cache=use_cache,
+            )
+        files.append(entry)
+        digest.update(
+            json.dumps(entry, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        )
+    return {"digest": digest.hexdigest(), "files": files}

--- a/tools/pypi_project_preflight.py
+++ b/tools/pypi_project_preflight.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 from dataclasses import asdict, dataclass
+from functools import lru_cache
 import json
 import os
 from pathlib import Path
@@ -19,7 +20,10 @@ try:
     from pypi_distribution_state import DistributionStateError, read_project_metadata
     from release_plan import release_plan
 except ModuleNotFoundError:  # pragma: no cover - used when imported as tools.*
-    from tools.pypi_distribution_state import DistributionStateError, read_project_metadata
+    from tools.pypi_distribution_state import (
+        DistributionStateError,
+        read_project_metadata,
+    )
     from tools.release_plan import release_plan
 
 
@@ -64,17 +68,40 @@ def fetch_pypi_json(project_name: str) -> dict[str, Any] | None:
     except urllib.error.HTTPError as exc:
         if exc.code == 404:
             return None
-        raise RuntimeError(f"could not fetch PyPI metadata for {project_name}: HTTP {exc.code}") from exc
+        raise RuntimeError(
+            f"could not fetch PyPI metadata for {project_name}: HTTP {exc.code}"
+        ) from exc
     except (OSError, json.JSONDecodeError) as exc:
-        raise RuntimeError(f"could not fetch PyPI metadata for {project_name}: {exc}") from exc
+        raise RuntimeError(
+            f"could not fetch PyPI metadata for {project_name}: {exc}"
+        ) from exc
 
 
 def _project_version(repo_root: Path, project: str) -> str:
+    pyproject_path = repo_root / project / "pyproject.toml"
     try:
-        _name, version = read_project_metadata(repo_root / project)
+        stat = pyproject_path.stat()
+    except OSError:
+        signature = ("missing", 0, 0)
+    else:
+        signature = ("file", stat.st_size, stat.st_mtime_ns)
+    return _project_version_cached(str(repo_root.resolve()), project, signature)
+
+
+@lru_cache(maxsize=512)
+def _project_version_cached(
+    repo_root: str, project: str, signature: tuple[str, int, int]
+) -> str:
+    _ = signature
+    try:
+        _name, version = read_project_metadata(Path(repo_root) / project)
     except DistributionStateError as exc:
         raise RuntimeError(str(exc)) from exc
     return str(version)
+
+
+def clear_project_version_cache() -> None:
+    _project_version_cached.cache_clear()
 
 
 def _split_values(values: Sequence[str] | None) -> list[str]:
@@ -101,7 +128,10 @@ def selected_pypi_projects(
         if entry.get("publish_to_pypi") == "true"
     ]
     umbrella = plan["umbrella_package"]
-    if plan.get("umbrella_selected") == "true" and umbrella.get("publish_to_pypi") == "true":
+    if (
+        plan.get("umbrella_selected") == "true"
+        and umbrella.get("publish_to_pypi") == "true"
+    ):
         entries.append(umbrella)
     projects: list[PlannedPyPIProject] = []
     for entry in entries:
@@ -216,7 +246,8 @@ def build_report(
     blockers = [
         status
         for status in statuses
-        if status.status in {"missing-project", "empty-project", "newer-on-pypi", "error"}
+        if status.status
+        in {"missing-project", "empty-project", "newer-on-pypi", "error"}
         and not (
             status.status == "missing-project"
             and (
@@ -230,8 +261,7 @@ def build_report(
         for status in statuses
         if status.status == "missing-project"
         and (
-            status.pypi_project in allowed_missing
-            or status.package in allowed_missing
+            status.pypi_project in allowed_missing or status.package in allowed_missing
         )
     ]
     return {
@@ -241,7 +271,9 @@ def build_report(
         "summary": {
             "checked": len(statuses),
             "current": sum(1 for status in statuses if status.status == "current"),
-            "to_publish": sum(1 for status in statuses if status.status == "missing-version"),
+            "to_publish": sum(
+                1 for status in statuses if status.status == "missing-version"
+            ),
             "allowed_missing_projects": len(allowed_missing_statuses),
             "blockers": len(blockers),
         },
@@ -280,7 +312,9 @@ def render_text(report: dict[str, Any]) -> str:
                 f"(expected {blocker['version']}, latest {blocker['latest'] or 'n/a'})"
             )
             if blocker.get("pending_publisher_command"):
-                lines.append(f"  pending publisher: {blocker['pending_publisher_command']}")
+                lines.append(
+                    f"  pending publisher: {blocker['pending_publisher_command']}"
+                )
     return "\n".join(lines)
 
 

--- a/tools/worker_env_reuse.py
+++ b/tools/worker_env_reuse.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Check whether a generated worker environment can be reused by manifest hash."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Sequence
+
+from performance_cache import manifest_digest
+
+
+SCHEMA_VERSION = "agilab.worker-env-reuse.v1"
+DEFAULT_MARKER_NAME = ".agilab-worker-env-fingerprint.json"
+
+
+def _marker_path(worker_copy: Path, marker_name: str = DEFAULT_MARKER_NAME) -> Path:
+    return worker_copy.expanduser() / marker_name
+
+
+def _read_marker(path: Path) -> dict[str, object] | None:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return None
+    if not isinstance(payload, dict) or payload.get("schema") != SCHEMA_VERSION:
+        return None
+    return payload
+
+
+def worker_env_reuse_report(
+    *,
+    worker_pyproject: Path,
+    worker_copy: Path,
+    manifest_files: Sequence[Path] = (),
+    marker_name: str = DEFAULT_MARKER_NAME,
+) -> dict[str, object]:
+    manifest_paths = [worker_pyproject, *manifest_files]
+    fingerprint = manifest_digest(manifest_paths, namespace="worker-env")
+    marker = _marker_path(worker_copy, marker_name)
+    existing = _read_marker(marker)
+    digest = str(fingerprint["digest"])
+    if existing is None:
+        status = "rebuild"
+        reason = "marker-missing"
+    elif existing.get("digest") == digest:
+        status = "reuse"
+        reason = "manifest-unchanged"
+    else:
+        status = "rebuild"
+        reason = "manifest-changed"
+    return {
+        "schema": SCHEMA_VERSION,
+        "status": status,
+        "reason": reason,
+        "digest": digest,
+        "marker": marker.as_posix(),
+        "manifest": fingerprint,
+    }
+
+
+def write_marker(report: dict[str, object]) -> Path:
+    marker = Path(str(report["marker"])).expanduser()
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return marker
+
+
+def _render_text(report: dict[str, object]) -> str:
+    return "\n".join(
+        [
+            "AGILAB worker env reuse",
+            f"status: {report['status']}",
+            f"reason: {report['reason']}",
+            f"digest: {report['digest']}",
+            f"marker: {report['marker']}",
+        ]
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--worker-pyproject", required=True, type=Path)
+    parser.add_argument("--worker-copy", required=True, type=Path)
+    parser.add_argument("--manifest-file", action="append", default=[], type=Path)
+    parser.add_argument("--marker-name", default=DEFAULT_MARKER_NAME)
+    parser.add_argument("--write-marker", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    report = worker_env_reuse_report(
+        worker_pyproject=args.worker_pyproject,
+        worker_copy=args.worker_copy,
+        manifest_files=args.manifest_file,
+        marker_name=args.marker_name,
+    )
+    if args.write_marker:
+        write_marker(report)
+        report = worker_env_reuse_report(
+            worker_pyproject=args.worker_pyproject,
+            worker_copy=args.worker_copy,
+            manifest_files=args.manifest_file,
+            marker_name=args.marker_name,
+        )
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(_render_text(report))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/workflow_parity.py
+++ b/tools/workflow_parity.py
@@ -19,7 +19,9 @@ from typing import Callable, Sequence
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 RESULT_CACHE_SCHEMA = "agilab-workflow-parity-result-cache-v1"
-DEFAULT_RESULT_CACHE_PATH = REPO_ROOT / ".pytest_cache" / "agilab" / "workflow_parity_results.json"
+DEFAULT_RESULT_CACHE_PATH = (
+    REPO_ROOT / ".pytest_cache" / "agilab" / "workflow_parity_results.json"
+)
 RESULT_CACHE_MAX_ENTRIES = 256
 RESULT_CACHE_HASH_LIMIT_BYTES = 10 * 1024 * 1024
 RESULT_CACHE_INPUT_GLOBS = (
@@ -96,7 +98,9 @@ UI_ROBOT_MATRIX_SHARDS = (
 
 def _coverage_shard_plan_module():
     module_path = REPO_ROOT / "tools" / "coverage_shard_plan.py"
-    spec = importlib.util.spec_from_file_location("agilab_coverage_shard_plan", module_path)
+    spec = importlib.util.spec_from_file_location(
+        "agilab_coverage_shard_plan", module_path
+    )
     if spec is None or spec.loader is None:
         raise RuntimeError(f"cannot load coverage shard planner from {module_path}")
     module = importlib.util.module_from_spec(spec)
@@ -144,7 +148,9 @@ def _expand_repo_globs(paths: Sequence[str]) -> list[str]:
         if any(token in path for token in "*?["):
             matches = sorted(REPO_ROOT.glob(path))
             if matches:
-                expanded.extend(match.relative_to(REPO_ROOT).as_posix() for match in matches)
+                expanded.extend(
+                    match.relative_to(REPO_ROOT).as_posix() for match in matches
+                )
                 continue
         expanded.append(path)
     return expanded
@@ -399,13 +405,40 @@ UI_ROBOT_PROFILE_ORDER = (
     "hf-visual-smoke-robot",
 )
 
+RESULT_CACHE_UNSAFE_PROFILES = {
+    # These profiles generate, mutate, or publish evidence/artifacts as part of
+    # their contract. A previous successful run is useful context, but should not
+    # stand in for a fresh artifact-producing validation.
+    "docs",
+    "badges",
+    "skills",
+    "release-proof",
+    "production-readiness",
+    "ui-robot-matrix",
+    "ui-artifact-capture-robot",
+    "ui-history-robot",
+    "ui-mobile-robot",
+    "ui-release-evidence-robot",
+    "ui-first-proof-robot",
+    "ui-keyboard-robot",
+    "ui-layout-robot",
+    "ui-accessibility-robot",
+    "ui-browser-error-robot",
+    "ui-above-fold-robot",
+    "ui-visual-baseline-robot",
+    "agi-web-visual",
+    "agi-web-cross-browser",
+    "ui-trend-robot",
+    "ui-cross-browser-robot",
+    "hf-install-robot",
+    "hf-visual-smoke-robot",
+}
+
 
 def select_ui_robot_profiles_for_files(paths: Sequence[str]) -> list[str]:
     profiles: set[str] = set()
     normalized = [
-        Path(path).as_posix().removeprefix("./")
-        for path in paths
-        if str(path).strip()
+        Path(path).as_posix().removeprefix("./") for path in paths if str(path).strip()
     ]
     for path in normalized:
         lower = path.lower()
@@ -425,20 +458,46 @@ def select_ui_robot_profiles_for_files(paths: Sequence[str]) -> list[str]:
                     "ui-trend-robot",
                 }
             )
-        if lower.startswith(("tools/agilab_web_robot.py", "test/test_agilab_web_robot.py")):
-            profiles.add("ui-frontend-smoke")
-        if (
-            lower.startswith(("tools/agi_web_visual_regression.py", "test/test_agi_web_visual_regression.py"))
-            or lower.startswith("src/agilab/lib/agi-web/")
+        if lower.startswith(
+            ("tools/agilab_web_robot.py", "test/test_agilab_web_robot.py")
         ):
+            profiles.add("ui-frontend-smoke")
+        if lower.startswith(
+            (
+                "tools/agi_web_visual_regression.py",
+                "test/test_agi_web_visual_regression.py",
+            )
+        ) or lower.startswith("src/agilab/lib/agi-web/"):
             profiles.add("agi-web-visual")
-        if lower.startswith(("tools/ui_visual_baseline", "test/test_ui_visual_baseline")) or "page-shots" in lower or "screenshot" in lower:
+        if (
+            lower.startswith(
+                ("tools/ui_visual_baseline", "test/test_ui_visual_baseline")
+            )
+            or "page-shots" in lower
+            or "screenshot" in lower
+        ):
             profiles.update({"ui-visual-baseline-robot", "ui-trend-robot"})
-        if lower.startswith((".github/workflows/ui-robot", ".github/workflows/coverage.yml")):
+        if lower.startswith(
+            (".github/workflows/ui-robot", ".github/workflows/coverage.yml")
+        ):
             profiles.update({"ui-robot-contract", "ui-robot-canary", "ui-trend-robot"})
         if lower.startswith(".github/workflows/ci.yml"):
-            profiles.update({"ui-frontend-smoke", "ui-robot-contract", "ui-robot-canary", "ui-trend-robot"})
-        if lower.startswith(("src/agilab/main_page.py", "src/agilab/pages/", "src/agilab/lib/agi-gui/", "src/agilab/apps-pages/")):
+            profiles.update(
+                {
+                    "ui-frontend-smoke",
+                    "ui-robot-contract",
+                    "ui-robot-canary",
+                    "ui-trend-robot",
+                }
+            )
+        if lower.startswith(
+            (
+                "src/agilab/main_page.py",
+                "src/agilab/pages/",
+                "src/agilab/lib/agi-gui/",
+                "src/agilab/apps-pages/",
+            )
+        ):
             profiles.update(
                 {
                     "ui-frontend-smoke",
@@ -467,11 +526,21 @@ def select_ui_robot_profiles_for_files(paths: Sequence[str]) -> list[str]:
         ):
             profiles.add("ui-frontend-smoke")
         if "huggingface" in lower or lower.startswith(
-            ("docker/", "spaces/", ".github/workflows/huggingface", "tools/hf_space_", "test/test_hf_space_")
+            (
+                "docker/",
+                "spaces/",
+                ".github/workflows/huggingface",
+                "tools/hf_space_",
+                "test/test_hf_space_",
+            )
         ):
             profiles.update({"hf-visual-smoke-robot", "hf-install-robot"})
-        if lower.startswith(("tools/workflow_parity.py", "test/test_workflow_parity.py")):
-            profiles.update({"ui-robot-contract", "ui-robot-canary", "ui-frontend-smoke"})
+        if lower.startswith(
+            ("tools/workflow_parity.py", "test/test_workflow_parity.py")
+        ):
+            profiles.update(
+                {"ui-robot-contract", "ui-robot-canary", "ui-frontend-smoke"}
+            )
     if not profiles:
         profiles.add("ui-robot-contract")
     return [profile for profile in UI_ROBOT_PROFILE_ORDER if profile in profiles]
@@ -492,7 +561,14 @@ def _git_changed_files(base: str = "") -> list[str]:
     paths: list[str] = []
     seen: set[str] = set()
     for argv in commands:
-        completed = subprocess.run(argv, cwd=REPO_ROOT, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)
+        completed = subprocess.run(
+            argv,
+            cwd=REPO_ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
         if completed.returncode != 0:
             continue
         for line in completed.stdout.splitlines():
@@ -519,32 +595,32 @@ def _agi_gui_profile() -> list[CommandSpec]:
         [
             _agi_gui_coverage_combine(),
             _agi_gui_timing_report(),
-        CommandSpec(
-            label="agi-gui coverage xml",
-            argv=[
-                "uv",
-                "--preview-features",
-                "extra-build-dependencies",
-                "run",
-                "--group",
-                "dev",
-                "--extra",
-                "ui",
-                "--extra",
-                "viz",
-                "python",
-                "-m",
-                "coverage",
-                "xml",
-                "--rcfile=.coveragerc.agi-gui",
-                "--data-file=.coverage.agi-gui",
-                "-o",
-                "coverage-agi-gui.xml",
-            ],
-            env={"AGILAB_DISABLE_BACKGROUND_SERVICES": "1"},
-            timeout_seconds=5 * 60,
-            ensure_dirs=["test-results"],
-        ),
+            CommandSpec(
+                label="agi-gui coverage xml",
+                argv=[
+                    "uv",
+                    "--preview-features",
+                    "extra-build-dependencies",
+                    "run",
+                    "--group",
+                    "dev",
+                    "--extra",
+                    "ui",
+                    "--extra",
+                    "viz",
+                    "python",
+                    "-m",
+                    "coverage",
+                    "xml",
+                    "--rcfile=.coveragerc.agi-gui",
+                    "--data-file=.coverage.agi-gui",
+                    "-o",
+                    "coverage-agi-gui.xml",
+                ],
+                env={"AGILAB_DISABLE_BACKGROUND_SERVICES": "1"},
+                timeout_seconds=5 * 60,
+                ensure_dirs=["test-results"],
+            ),
         ]
     )
     return commands
@@ -590,7 +666,9 @@ def _agi_gui_coverage_manifest_paths() -> list[str]:
     return [_agi_gui_coverage_manifest_path(chunk) for chunk in AGI_GUI_COVERAGE_CHUNKS]
 
 
-def _agi_gui_coverage_chunk_code(label: str, data_file: str, junit_path: str, manifest_path: str) -> str:
+def _agi_gui_coverage_chunk_code(
+    label: str, data_file: str, junit_path: str, manifest_path: str
+) -> str:
     return (
         "from pathlib import Path\n"
         "import json, shutil, subprocess, sys, time\n"
@@ -786,7 +864,9 @@ def _agi_gui_coverage_combine() -> CommandSpec:
     )
 
 
-def _agi_gui_coverage_chunk(label: str, targets: Sequence[str], *, clean: bool = False) -> CommandSpec:
+def _agi_gui_coverage_chunk(
+    label: str, targets: Sequence[str], *, clean: bool = False
+) -> CommandSpec:
     expanded_targets = _expand_repo_globs(targets)
     junit_path = f"test-results/junit-agi-gui-{label}.xml"
     data_file = f"test-results/coverage-agi-gui-{label}.db"
@@ -794,8 +874,14 @@ def _agi_gui_coverage_chunk(label: str, targets: Sequence[str], *, clean: bool =
     clean_paths = [
         ".coverage.agi-gui",
         "coverage-agi-gui.xml",
-        *(f"test-results/coverage-agi-gui-{chunk}.db" for chunk in AGI_GUI_COVERAGE_CHUNKS),
-        *(f"test-results/junit-agi-gui-{chunk}.xml" for chunk in AGI_GUI_COVERAGE_CHUNKS),
+        *(
+            f"test-results/coverage-agi-gui-{chunk}.db"
+            for chunk in AGI_GUI_COVERAGE_CHUNKS
+        ),
+        *(
+            f"test-results/junit-agi-gui-{chunk}.xml"
+            for chunk in AGI_GUI_COVERAGE_CHUNKS
+        ),
         *(_agi_gui_coverage_manifest_path(chunk) for chunk in AGI_GUI_COVERAGE_CHUNKS),
     ]
     return CommandSpec(
@@ -1119,7 +1205,7 @@ def _docs_profile() -> list[CommandSpec]:
                 "docs/html",
             ],
             remove_paths=["docs/html"],
-        )
+        ),
     ]
 
 
@@ -1167,11 +1253,24 @@ def _skills_profile(skills: Sequence[str] | None) -> list[CommandSpec]:
         [
             CommandSpec(
                 label="validate codex skills",
-                argv=["python3", "tools/codex_skills.py", "--root", ".codex/skills", "validate", "--strict"],
+                argv=[
+                    "python3",
+                    "tools/codex_skills.py",
+                    "--root",
+                    ".codex/skills",
+                    "validate",
+                    "--strict",
+                ],
             ),
             CommandSpec(
                 label="generate codex skills index",
-                argv=["python3", "tools/codex_skills.py", "--root", ".codex/skills", "generate"],
+                argv=[
+                    "python3",
+                    "tools/codex_skills.py",
+                    "--root",
+                    ".codex/skills",
+                    "generate",
+                ],
             ),
             CommandSpec(
                 label="generate public agent skill catalog",
@@ -1252,11 +1351,19 @@ def _skills_profile(skills: Sequence[str] | None) -> list[CommandSpec]:
     return commands
 
 
-def _installer_profile(app_path: str | None, worker_copy: str | None) -> list[CommandSpec]:
+def _installer_profile(
+    app_path: str | None, worker_copy: str | None
+) -> list[CommandSpec]:
     commands = [
         CommandSpec(
             label="installer shell syntax",
-            argv=["bash", "-n", "install.sh", "src/agilab/install_apps.sh", "src/agilab/core/install.sh"],
+            argv=[
+                "bash",
+                "-n",
+                "install.sh",
+                "src/agilab/install_apps.sh",
+                "src/agilab/core/install.sh",
+            ],
         ),
         CommandSpec(
             label="installer discovery tests",
@@ -1341,9 +1448,7 @@ def _shared_core_ty_target_paths() -> list[str]:
 def _shared_core_ty_typing_profile() -> list[CommandSpec]:
     target_paths = _shared_core_ty_target_paths()
     extra_search_path_args = [
-        item
-        for path in target_paths
-        for item in ("--extra-search-path", path)
+        item for path in target_paths for item in ("--extra-search-path", path)
     ]
     return [
         CommandSpec(
@@ -1733,7 +1838,10 @@ def _ui_artifact_capture_robot_profile() -> list[CommandSpec]:
                 "test-results/ui-artifact-capture-robot/video",
             ],
             timeout_seconds=15 * 60,
-            remove_paths=["test-results/ui-artifact-capture-robot", "screenshots/ui-artifact-capture-robot"],
+            remove_paths=[
+                "test-results/ui-artifact-capture-robot",
+                "screenshots/ui-artifact-capture-robot",
+            ],
         )
     ]
 
@@ -1767,7 +1875,10 @@ def _hf_install_robot_profile() -> list[CommandSpec]:
                 "test-results/hf-install-robot/failure-bundles",
             ],
             timeout_seconds=25 * 60,
-            remove_paths=["test-results/hf-install-robot", "screenshots/hf-install-robot"],
+            remove_paths=[
+                "test-results/hf-install-robot",
+                "screenshots/hf-install-robot",
+            ],
         )
     ]
 
@@ -1803,7 +1914,10 @@ def _hf_visual_smoke_robot_profile() -> list[CommandSpec]:
                 "test-results/hf-visual-smoke-robot/failure-bundles",
             ],
             timeout_seconds=25 * 60,
-            remove_paths=["test-results/hf-visual-smoke-robot", "screenshots/hf-visual-smoke-robot"],
+            remove_paths=[
+                "test-results/hf-visual-smoke-robot",
+                "screenshots/hf-visual-smoke-robot",
+            ],
         )
     ]
 
@@ -1833,7 +1947,10 @@ def _ui_keyboard_robot_profile() -> list[CommandSpec]:
                 "test-results/ui-keyboard-robot/failure-bundles",
             ],
             timeout_seconds=30 * 60,
-            remove_paths=["test-results/ui-keyboard-robot", "screenshots/ui-keyboard-robot"],
+            remove_paths=[
+                "test-results/ui-keyboard-robot",
+                "screenshots/ui-keyboard-robot",
+            ],
         )
     ]
 
@@ -1865,7 +1982,10 @@ def _ui_layout_robot_profile() -> list[CommandSpec]:
                 "test-results/ui-layout-robot/failure-bundles",
             ],
             timeout_seconds=45 * 60,
-            remove_paths=["test-results/ui-layout-robot", "screenshots/ui-layout-robot"],
+            remove_paths=[
+                "test-results/ui-layout-robot",
+                "screenshots/ui-layout-robot",
+            ],
         )
     ]
 
@@ -1895,7 +2015,10 @@ def _ui_accessibility_robot_profile() -> list[CommandSpec]:
                 "test-results/ui-accessibility-robot/failure-bundles",
             ],
             timeout_seconds=30 * 60,
-            remove_paths=["test-results/ui-accessibility-robot", "screenshots/ui-accessibility-robot"],
+            remove_paths=[
+                "test-results/ui-accessibility-robot",
+                "screenshots/ui-accessibility-robot",
+            ],
         )
     ]
 
@@ -1925,7 +2048,10 @@ def _ui_browser_error_robot_profile() -> list[CommandSpec]:
                 "test-results/ui-browser-error-robot/failure-bundles",
             ],
             timeout_seconds=30 * 60,
-            remove_paths=["test-results/ui-browser-error-robot", "screenshots/ui-browser-error-robot"],
+            remove_paths=[
+                "test-results/ui-browser-error-robot",
+                "screenshots/ui-browser-error-robot",
+            ],
         )
     ]
 
@@ -1955,7 +2081,10 @@ def _ui_above_fold_robot_profile() -> list[CommandSpec]:
                 "test-results/ui-above-fold-robot/failure-bundles",
             ],
             timeout_seconds=30 * 60,
-            remove_paths=["test-results/ui-above-fold-robot", "screenshots/ui-above-fold-robot"],
+            remove_paths=[
+                "test-results/ui-above-fold-robot",
+                "screenshots/ui-above-fold-robot",
+            ],
         )
     ]
 
@@ -1987,7 +2116,10 @@ def _ui_visual_baseline_robot_profile() -> list[CommandSpec]:
                 "test-results/ui-visual-baseline-robot/failure-bundles",
             ],
             timeout_seconds=30 * 60,
-            remove_paths=["test-results/ui-visual-baseline-robot", "screenshots/ui-visual-baseline-robot"],
+            remove_paths=[
+                "test-results/ui-visual-baseline-robot",
+                "screenshots/ui-visual-baseline-robot",
+            ],
         ),
         CommandSpec(
             label="ui visual baseline report",
@@ -2047,7 +2179,10 @@ def _agi_web_visual_profile() -> list[CommandSpec]:
                 "--json",
             ],
             timeout_seconds=5 * 60,
-            remove_paths=["test-results/agi-web-visual-regression", "screenshots/agi-web-visual-regression"],
+            remove_paths=[
+                "test-results/agi-web-visual-regression",
+                "screenshots/agi-web-visual-regression",
+            ],
         ),
     ]
 
@@ -2072,7 +2207,10 @@ def _agi_web_cross_browser_profile() -> list[CommandSpec]:
                 "webkit",
             ],
             timeout_seconds=10 * 60,
-            remove_paths=["test-results/agi-web-cross-browser", "screenshots/agi-web-cross-browser"],
+            remove_paths=[
+                "test-results/agi-web-cross-browser",
+                "screenshots/agi-web-cross-browser",
+            ],
         ),
         CommandSpec(
             label="agi-web cross-browser visual smoke",
@@ -2150,7 +2288,10 @@ def _ui_cross_browser_robot_profile() -> list[CommandSpec]:
                 "webkit",
             ],
             timeout_seconds=10 * 60,
-            remove_paths=["test-results/ui-cross-browser-robot", "screenshots/ui-cross-browser-robot"],
+            remove_paths=[
+                "test-results/ui-cross-browser-robot",
+                "screenshots/ui-cross-browser-robot",
+            ],
         ),
         CommandSpec(
             label="ui cross-browser robot (firefox)",
@@ -2232,7 +2373,10 @@ def _ui_history_robot_profile() -> list[CommandSpec]:
                 "test-results/ui-history-robot/failure-bundles",
             ],
             timeout_seconds=30 * 60,
-            remove_paths=["test-results/ui-history-robot", "screenshots/ui-history-robot"],
+            remove_paths=[
+                "test-results/ui-history-robot",
+                "screenshots/ui-history-robot",
+            ],
         )
     ]
 
@@ -2262,7 +2406,10 @@ def _ui_mobile_robot_profile() -> list[CommandSpec]:
                 "test-results/ui-mobile-robot/failure-bundles",
             ],
             timeout_seconds=30 * 60,
-            remove_paths=["test-results/ui-mobile-robot", "screenshots/ui-mobile-robot"],
+            remove_paths=[
+                "test-results/ui-mobile-robot",
+                "screenshots/ui-mobile-robot",
+            ],
         )
     ]
 
@@ -2295,7 +2442,10 @@ def _ui_release_evidence_robot_profile() -> list[CommandSpec]:
                 "test-results/ui-release-evidence-robot/failure-bundles",
             ],
             timeout_seconds=45 * 60,
-            remove_paths=["test-results/ui-release-evidence-robot", "screenshots/ui-release-evidence-robot"],
+            remove_paths=[
+                "test-results/ui-release-evidence-robot",
+                "screenshots/ui-release-evidence-robot",
+            ],
         )
     ]
 
@@ -2327,7 +2477,10 @@ def _ui_first_proof_robot_profile() -> list[CommandSpec]:
                 "test-results/ui-first-proof-robot/failure-bundles",
             ],
             timeout_seconds=45 * 60,
-            remove_paths=["test-results/ui-first-proof-robot", "screenshots/ui-first-proof-robot"],
+            remove_paths=[
+                "test-results/ui-first-proof-robot",
+                "screenshots/ui-first-proof-robot",
+            ],
         )
     ]
 
@@ -2412,10 +2565,26 @@ def _run_command(spec: CommandSpec) -> CommandResult:
     )
 
 
-def _result_cache_enabled(args: argparse.Namespace, runner: Callable[[CommandSpec], CommandResult]) -> bool:
+def _profiles_are_auto_cacheable(profile_names: Sequence[str]) -> bool:
+    return bool(profile_names) and not any(
+        profile in RESULT_CACHE_UNSAFE_PROFILES for profile in profile_names
+    )
+
+
+def _result_cache_enabled(
+    args: argparse.Namespace,
+    runner: Callable[[CommandSpec], CommandResult],
+    profile_names: Sequence[str] | None = None,
+) -> bool:
+    cache_requested = bool(getattr(args, "result_cache", False))
+    auto_cacheable = (
+        profile_names is not None
+        and _profiles_are_auto_cacheable(profile_names)
+        and not bool(getattr(args, "print_only", False))
+    )
     return (
         runner is _run_command
-        and bool(getattr(args, "result_cache", False))
+        and (cache_requested or auto_cacheable)
         and not bool(getattr(args, "no_result_cache", False))
     )
 
@@ -2443,7 +2612,11 @@ def _result_cache_changed_files(args: argparse.Namespace) -> list[str]:
     explicit = list(getattr(args, "changed_file", []) or [])
     if explicit:
         return explicit
-    base = str(getattr(args, "changed_base", "") or "") if getattr(args, "select_ui_robot_profiles", False) else ""
+    base = (
+        str(getattr(args, "changed_base", "") or "")
+        if getattr(args, "select_ui_robot_profiles", False)
+        else ""
+    )
     return _git_changed_files(base)
 
 
@@ -2454,13 +2627,18 @@ def _repo_relative_or_absolute(path: Path) -> str:
         return path.as_posix()
 
 
-def _result_cache_input_paths(changed_files: Sequence[str], cache_path: Path) -> list[str]:
+def _result_cache_input_paths(
+    changed_files: Sequence[str], cache_path: Path
+) -> list[str]:
     paths: list[str] = []
     seen: set[str] = set()
     cache_marker = _repo_relative_or_absolute(cache_path)
     for pattern in RESULT_CACHE_INPUT_GLOBS:
         if any(token in pattern for token in "*?["):
-            expanded = [path.relative_to(REPO_ROOT).as_posix() for path in sorted(REPO_ROOT.glob(pattern))]
+            expanded = [
+                path.relative_to(REPO_ROOT).as_posix()
+                for path in sorted(REPO_ROOT.glob(pattern))
+            ]
             candidates = expanded or [pattern]
         else:
             candidates = [pattern]
@@ -2470,7 +2648,9 @@ def _result_cache_input_paths(changed_files: Sequence[str], cache_path: Path) ->
                 seen.add(candidate)
     for changed_file in sorted(changed_files):
         path = Path(changed_file)
-        candidate = _repo_relative_or_absolute(path) if path.is_absolute() else path.as_posix()
+        candidate = (
+            _repo_relative_or_absolute(path) if path.is_absolute() else path.as_posix()
+        )
         if candidate == cache_marker or candidate in seen:
             continue
         paths.append(candidate)
@@ -2489,7 +2669,9 @@ def _file_sha256(path: Path) -> str:
 def _file_signature(path_name: str) -> dict[str, object]:
     path = Path(path_name)
     target = path if path.is_absolute() else REPO_ROOT / path
-    label = _repo_relative_or_absolute(target) if target.is_absolute() else path.as_posix()
+    label = (
+        _repo_relative_or_absolute(target) if target.is_absolute() else path.as_posix()
+    )
     try:
         stat = target.stat()
     except OSError as exc:
@@ -2508,8 +2690,13 @@ def _file_signature(path_name: str) -> dict[str, object]:
     return signature
 
 
-def _result_cache_fingerprints(changed_files: Sequence[str], cache_path: Path) -> list[dict[str, object]]:
-    return [_file_signature(path) for path in _result_cache_input_paths(changed_files, cache_path)]
+def _result_cache_fingerprints(
+    changed_files: Sequence[str], cache_path: Path
+) -> list[dict[str, object]]:
+    return [
+        _file_signature(path)
+        for path in _result_cache_input_paths(changed_files, cache_path)
+    ]
 
 
 def _run_result_cache_key(
@@ -2535,7 +2722,9 @@ def _run_result_cache_key(
             "executable": sys.executable,
             "version": sys.version,
         },
-        "env": {key: os.environ[key] for key in RESULT_CACHE_ENV_KEYS if key in os.environ},
+        "env": {
+            key: os.environ[key] for key in RESULT_CACHE_ENV_KEYS if key in os.environ
+        },
     }
     encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
     return hashlib.sha256(encoded).hexdigest()
@@ -2562,7 +2751,11 @@ def _command_result_from_cache(payload: object) -> CommandResult | None:
         return None
     argv = payload.get("argv")
     env = payload.get("env")
-    if not isinstance(payload.get("label"), str) or not isinstance(argv, list) or not isinstance(env, dict):
+    if (
+        not isinstance(payload.get("label"), str)
+        or not isinstance(argv, list)
+        or not isinstance(env, dict)
+    ):
         return None
     if not all(isinstance(arg, str) for arg in argv) or not all(
         isinstance(key, str) and isinstance(value, str) for key, value in env.items()
@@ -2589,7 +2782,11 @@ def _profile_result_from_cache(payload: object) -> ProfileResult | None:
     description = payload.get("description")
     success = payload.get("success")
     commands_payload = payload.get("commands")
-    if not isinstance(profile, str) or not isinstance(description, str) or not isinstance(success, bool):
+    if (
+        not isinstance(profile, str)
+        or not isinstance(description, str)
+        or not isinstance(success, bool)
+    ):
         return None
     if not isinstance(commands_payload, list):
         return None
@@ -2599,7 +2796,9 @@ def _profile_result_from_cache(payload: object) -> ProfileResult | None:
         if command is None:
             return None
         commands.append(command)
-    return ProfileResult(profile=profile, description=description, success=success, commands=commands)
+    return ProfileResult(
+        profile=profile, description=description, success=success, commands=commands
+    )
 
 
 def _cached_run_results(
@@ -2638,7 +2837,9 @@ def _prune_result_cache(entries: dict[str, object]) -> None:
 
     keep = {
         key
-        for key, _value in sorted(entries.items(), key=_stored_at, reverse=True)[:RESULT_CACHE_MAX_ENTRIES]
+        for key, _value in sorted(entries.items(), key=_stored_at, reverse=True)[
+            :RESULT_CACHE_MAX_ENTRIES
+        ]
     }
     for key in list(entries):
         if key not in keep:
@@ -2652,7 +2853,9 @@ def _write_result_cache(cache_path: Path, cache_state: dict[str, object]) -> Non
     _prune_result_cache(entries)
     cache_path.parent.mkdir(parents=True, exist_ok=True)
     temp_path = cache_path.with_name(f"{cache_path.name}.tmp")
-    temp_path.write_text(json.dumps(cache_state, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    temp_path.write_text(
+        json.dumps(cache_state, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
     temp_path.replace(cache_path)
 
 
@@ -2685,7 +2888,7 @@ def run_profiles(
     cache_path: Path | None = None
     cache_state: dict[str, object] | None = None
     cache_key = ""
-    cache_enabled = _result_cache_enabled(args, runner)
+    cache_enabled = _result_cache_enabled(args, runner, profile_names)
     if cache_enabled:
         cache_path = _result_cache_path(args)
         cache_state = _load_result_cache(cache_path)
@@ -2725,12 +2928,23 @@ def run_profiles(
         )
         if not success and not args.keep_going:
             break
-    if cache_enabled and cache_path is not None and cache_state is not None and all(result.success for result in results):
+    if (
+        cache_enabled
+        and cache_path is not None
+        and cache_state is not None
+        and all(result.success for result in results)
+    ):
         _store_run_results(cache_path, cache_state, cache_key, profile_names, results)
     return results
 
 
-def _render_human(profile_names: Sequence[str], results: Sequence[ProfileResult], *, print_only: bool, args: argparse.Namespace) -> str:
+def _render_human(
+    profile_names: Sequence[str],
+    results: Sequence[ProfileResult],
+    *,
+    print_only: bool,
+    args: argparse.Namespace,
+) -> str:
     descriptions = _profile_descriptions()
     commands_by_profile = _profile_commands(args)
     lines: list[str] = []


### PR DESCRIPTION
## Summary

- enable automatic workflow-parity result reuse for cache-safe profiles while keeping artifact-producing docs/UI/release profiles fresh
- add `./dev ui-flow`, `./dev perf-startup`, and `./dev worker-reuse` shortcuts
- tighten compact `./dev` output so clean successes with no signal lines print only the status/log pointer
- add deterministic file digest caching and a worker-env manifest reuse checker
- cache PyPI project version metadata by `pyproject.toml` signature during release preflight

## Notes

The worker-env reuse change is intentionally non-invasive: it adds a manifest-hash planner/checker and marker contract without modifying shared-core deployment behavior.

## Validation

- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_agilab_dev_shortcuts.py test/test_workflow_parity.py test/test_performance_cache.py test/test_worker_env_reuse.py test/test_release_robustness_tools.py`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files tools/agilab_dev.py tools/workflow_parity.py tools/performance_cache.py tools/worker_env_reuse.py tools/pypi_project_preflight.py test/test_agilab_dev_shortcuts.py test/test_workflow_parity.py test/test_performance_cache.py test/test_worker_env_reuse.py test/test_release_robustness_tools.py`
- `uv --preview-features extra-build-dependencies run --extra dev ruff check tools/agilab_dev.py tools/workflow_parity.py tools/performance_cache.py tools/worker_env_reuse.py tools/pypi_project_preflight.py test/test_agilab_dev_shortcuts.py test/test_workflow_parity.py test/test_performance_cache.py test/test_worker_env_reuse.py test/test_release_robustness_tools.py`
- `uv --preview-features extra-build-dependencies run --extra dev ruff format --check tools/agilab_dev.py tools/workflow_parity.py tools/performance_cache.py tools/worker_env_reuse.py tools/pypi_project_preflight.py test/test_agilab_dev_shortcuts.py test/test_workflow_parity.py test/test_performance_cache.py test/test_worker_env_reuse.py test/test_release_robustness_tools.py`
- `./dev --print-only ui-flow --changed-file src/agilab/pages/project.py`
- `./dev --print-only perf-startup`
- `./dev --print-only worker-reuse --worker-pyproject worker/pyproject.toml --worker-copy ~/wenv/app_worker`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile dependency-policy --print-only`
- `./dev --raw-output scope`
- `git diff --check`