### PR TITLE
Harden UI robot coverage contracts

### DIFF
--- a/.github/workflows/ui-robot-matrix.yml
+++ b/.github/workflows/ui-robot-matrix.yml
@@ -44,6 +44,8 @@ jobs:
               isolated-project-import-sidebar
               isolated-project-rename-sidebar
               isolated-settings-page
+              isolated-all-builtins-orchestrate-smoke
+              isolated-all-builtins-core-render-smoke
           - shard: state
             scenarios: >-
               isolated-fresh-session-core-pages

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -334,6 +334,10 @@ Use this runbook whenever you:
 - **CLI agent helpers**: Repo-scoped wrappers and configs exist for Codex, Aider, and
   OpenCode under `tools/*_workflow.*`, `.aider.conf.yml`, `opencode.json`, and
   `.opencode/agents/`. Keep them aligned with repo guardrails when workflow policy changes.
+  When coding through a terminal agent, prefer launching it through Tokki when
+  available so AGILAB sessions get compact context, noisy-output digestion,
+  token-savings accounting, and consistent wrapper metadata. Tokki is an
+  agent-session efficiency layer, not a replacement for AGILAB validation gates.
 - **Agent instruction contract**: Keep `AGENTS.md`, `AGENT_CONVENTIONS.md`,
   `AGENT_LEARNINGS.md`, `tools/agent_workflows.md`, public agent docs, and
   `agilab-capabilities.json` aligned. Run

--- a/AGENT_CONVENTIONS.md
+++ b/AGENT_CONVENTIONS.md
@@ -10,6 +10,9 @@ publication, or other risky surfaces, read [AGENTS.md](AGENTS.md) too.
 
 - Use `uv --preview-features extra-build-dependencies run ...` for Python entrypoints.
 - Prefer `rg` for search and `rg --files` for file listing.
+- Prefer launching terminal coding agents through Tokki when it is available;
+  use it for compact context, noisy-output digestion, and session metadata, not
+  as a substitute for AGILAB validation gates.
 - Run `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --staged`
   before non-trivial edits.
 - Prefer app-local fixes over shared-core changes.

--- a/AGENT_LEARNINGS.md
+++ b/AGENT_LEARNINGS.md
@@ -50,3 +50,7 @@ is not a scratchpad or task log.
   step after its safety gate, report the result, and provide the next
   recommendation without requiring a second user round trip unless a real
   blocker needs input.
+- When asked for token-saving or workflow-saving tactics and a repo-local
+  default is clear, do not end with a broad clarification menu. State the
+  assumed target, choose the highest-leverage applicable mechanism, and either
+  implement it or name the exact blocker that prevents implementation.

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -1,9 +1,9 @@
 {
-  "file_count": 270,
+  "file_count": 276,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "9e67bb850d67d0aafff65585be8d71ea23f5ac0a5db86dd9fa8f52bd930dad6b",
+  "source_digest_sha256": "0d968fc57f27f25b7846b46a550acc770a4b69fee1b1c3cf6eb0e8a0d7ac9d8d",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "9e67bb850d67d0aafff65585be8d71ea23f5ac0a5db86dd9fa8f52bd930dad6b"
+  "target_digest_sha256": "0d968fc57f27f25b7846b46a550acc770a4b69fee1b1c3cf6eb0e8a0d7ac9d8d"
 }

--- a/docs/source/_static/page-shots/analysis-page.svg
+++ b/docs/source/_static/page-shots/analysis-page.svg
@@ -1,0 +1,56 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 850" role="img" aria-labelledby="title desc">
+<title id="title">AGILAB analysis page vector screenshot summary</title>
+<desc id="desc">Screenshot-derived SVG summary generated from analysis-page.png, sha256 69e971e72e855804. The PNG remains the canonical raster evidence.</desc>
+<defs><linearGradient id="panelGradient" x1="0" x2="1"><stop offset="0" stop-color="#1f2c2f"/><stop offset="0.55" stop-color="#0f3033"/><stop offset="1" stop-color="#243b24"/></linearGradient></defs>
+<rect x="0" y="0" width="1440" height="850" rx="0" fill="#07111f"/>
+<rect x="0" y="0" width="300" height="850" rx="0" fill="#10293b"/>
+<text x="20" y="46" font-size="26" font-weight="700" fill="#c9d3d7" text-anchor="start">AGI Lab</text>
+<text x="28" y="94" font-size="14" font-weight="500" fill="#d6dde0" text-anchor="start">PROJECT</text>
+<text x="28" y="128" font-size="14" font-weight="500" fill="#d6dde0" text-anchor="start">ORCHESTRATE</text>
+<text x="28" y="162" font-size="14" font-weight="500" fill="#d6dde0" text-anchor="start">WORKFLOW</text>
+<rect x="20" y="179" width="260" height="28" rx="6" fill="#38546c"/>
+<text x="28" y="196" font-size="14" font-weight="800" fill="#f7f7f2" text-anchor="start">ANALYSIS</text>
+<line x1="20" y1="230" x2="280" y2="230" stroke="#4e6572" stroke-width="1" opacity="0.75"/>
+<text x="20" y="273" font-size="16" font-weight="700" fill="#f7f7f2" text-anchor="start">Flight Telemetry Project</text>
+<rect x="20" y="318" width="260" height="40" rx="8" fill="#102b3d" stroke="#4f6471" stroke-width="1"/>
+<text x="56" y="344" font-size="14" font-weight="600" fill="#f7f7f2" text-anchor="start">Quick actions</text>
+<rect x="20" y="374" width="260" height="40" rx="8" fill="#102b3d" stroke="#4f6471" stroke-width="1"/>
+<text x="56" y="400" font-size="14" font-weight="600" fill="#f7f7f2" text-anchor="start">agi-app</text>
+<rect x="20" y="430" width="260" height="40" rx="8" fill="#102b3d" stroke="#4f6471" stroke-width="1"/>
+<text x="56" y="456" font-size="14" font-weight="600" fill="#f7f7f2" text-anchor="start">Reviewed</text>
+<text x="16" y="830" font-size="12" font-weight="400" fill="#b9c5ca" text-anchor="start">AGILAB v2026.06.02</text>
+<text x="1340" y="34" font-size="14" font-weight="700" fill="#f7f7f2" text-anchor="start">Deploy</text>
+<rect x="380" y="120" width="980" height="210" rx="20" fill="url(#panelGradient)" stroke="#4f6471" stroke-width="1"/>
+<line x1="400" y1="135" x2="1328" y2="135" stroke="#cda759" stroke-width="1" opacity="0.8"/>
+<rect x="410" y="150" width="216" height="104" rx="12" fill="#20363b" stroke="#4f6471" stroke-width="1" opacity="0.96"/>
+<rect x="420" y="162" width="4" height="80" rx="2" fill="#7ee6c6"/>
+<text x="428" y="174" font-size="11" font-weight="800" fill="#c7cdd0" text-anchor="start">OUTPUT FILES</text>
+<text x="428" y="206" font-size="22" font-weight="800" fill="#7ee6c6" text-anchor="start">31</text>
+<text x="428" y="236" font-size="12" font-weight="400" fill="#aeb9bd" text-anchor="start">latest output set</text>
+<rect x="645" y="150" width="216" height="104" rx="12" fill="#20363b" stroke="#4f6471" stroke-width="1" opacity="0.96"/>
+<rect x="655" y="162" width="4" height="80" rx="2" fill="#7ee6c6"/>
+<text x="663" y="174" font-size="11" font-weight="800" fill="#c7cdd0" text-anchor="start">LATEST OUTPUT</text>
+<text x="663" y="206" font-size="22" font-weight="800" fill="#7ee6c6" text-anchor="start">2026-05-30 20:44</text>
+<text x="663" y="236" font-size="12" font-weight="400" fill="#aeb9bd" text-anchor="start">timestamp</text>
+<rect x="880" y="150" width="216" height="104" rx="12" fill="#20363b" stroke="#4f6471" stroke-width="1" opacity="0.96"/>
+<rect x="890" y="162" width="4" height="80" rx="2" fill="#7ee6c6"/>
+<text x="898" y="174" font-size="11" font-weight="800" fill="#c7cdd0" text-anchor="start">VIEWS SELECTED</text>
+<text x="898" y="206" font-size="22" font-weight="800" fill="#7ee6c6" text-anchor="start">2/17</text>
+<text x="898" y="236" font-size="12" font-weight="400" fill="#aeb9bd" text-anchor="start">linked to project</text>
+<rect x="1115" y="150" width="216" height="104" rx="12" fill="#20363b" stroke="#4f6471" stroke-width="1" opacity="0.96"/>
+<rect x="1125" y="162" width="4" height="80" rx="2" fill="#7ee6c6"/>
+<text x="1133" y="174" font-size="11" font-weight="800" fill="#c7cdd0" text-anchor="start">NOTEBOOKS SELECTED</text>
+<text x="1133" y="206" font-size="22" font-weight="800" fill="#7ee6c6" text-anchor="start">0/0</text>
+<text x="1133" y="236" font-size="12" font-weight="400" fill="#aeb9bd" text-anchor="start">no notebooks found</text>
+<text x="410" y="288" font-size="14" font-weight="500" fill="#aeb9bd" text-anchor="start">Discovered evidence: dataframe, beams, satellites</text>
+<rect x="380" y="362" width="980" height="40" rx="8" fill="#0b1727" stroke="#4f6471" stroke-width="1"/>
+<text x="418" y="388" font-size="14" font-weight="700" fill="#f7f7f2" text-anchor="start">Evidence drawer</text>
+<rect x="380" y="418" width="980" height="40" rx="8" fill="#0b1727" stroke="#4f6471" stroke-width="1"/>
+<text x="418" y="444" font-size="14" font-weight="700" fill="#f7f7f2" text-anchor="start">Analysis context</text>
+<rect x="380" y="474" width="980" height="40" rx="8" fill="#0b1727" stroke="#4f6471" stroke-width="1"/>
+<text x="418" y="500" font-size="14" font-weight="700" fill="#f7f7f2" text-anchor="start">Choose analysis views</text>
+<rect x="380" y="530" width="980" height="40" rx="8" fill="#0b1727" stroke="#4f6471" stroke-width="1"/>
+<text x="418" y="556" font-size="14" font-weight="700" fill="#f7f7f2" text-anchor="start">How to choose pages and notebooks</text>
+<rect x="380" y="586" width="980" height="40" rx="8" fill="#0b1727" stroke="#4f6471" stroke-width="1"/>
+<text x="418" y="612" font-size="14" font-weight="700" fill="#f7f7f2" text-anchor="start">Create analysis view</text>
+</svg>

--- a/docs/source/_static/page-shots/core-pages-overview.svg
+++ b/docs/source/_static/page-shots/core-pages-overview.svg
@@ -1,0 +1,55 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 850" role="img" aria-labelledby="title desc">
+<title id="title">AGILAB core pages overview vector screenshot summary</title>
+<desc id="desc">Screenshot-derived SVG summary generated from core-pages-overview.png, sha256 c864b5b14e3bf92f. The PNG remains the canonical raster evidence.</desc>
+<defs><linearGradient id="panelGradient" x1="0" x2="1"><stop offset="0" stop-color="#1f2c2f"/><stop offset="0.55" stop-color="#0f3033"/><stop offset="1" stop-color="#243b24"/></linearGradient></defs>
+<rect x="0" y="0" width="1440" height="850" rx="0" fill="#07111f"/>
+<rect x="0" y="0" width="300" height="850" rx="0" fill="#10293b"/>
+<text x="20" y="46" font-size="26" font-weight="700" fill="#c9d3d7" text-anchor="start">AGI Lab</text>
+<text x="28" y="94" font-size="14" font-weight="500" fill="#d6dde0" text-anchor="start">PROJECT</text>
+<text x="28" y="128" font-size="14" font-weight="500" fill="#d6dde0" text-anchor="start">ORCHESTRATE</text>
+<text x="28" y="162" font-size="14" font-weight="500" fill="#d6dde0" text-anchor="start">WORKFLOW</text>
+<text x="28" y="196" font-size="14" font-weight="500" fill="#d6dde0" text-anchor="start">ANALYSIS</text>
+<line x1="20" y1="230" x2="280" y2="230" stroke="#4e6572" stroke-width="1" opacity="0.75"/>
+<rect x="20" y="318" width="260" height="40" rx="8" fill="#102b3d" stroke="#4f6471" stroke-width="1"/>
+<text x="56" y="344" font-size="14" font-weight="600" fill="#f7f7f2" text-anchor="start">Quick actions</text>
+<rect x="20" y="374" width="260" height="40" rx="8" fill="#102b3d" stroke="#4f6471" stroke-width="1"/>
+<text x="56" y="400" font-size="14" font-weight="600" fill="#f7f7f2" text-anchor="start">agi-app</text>
+<rect x="20" y="430" width="260" height="40" rx="8" fill="#102b3d" stroke="#4f6471" stroke-width="1"/>
+<text x="56" y="456" font-size="14" font-weight="600" fill="#f7f7f2" text-anchor="start">Reviewed</text>
+<text x="16" y="830" font-size="12" font-weight="400" fill="#b9c5ca" text-anchor="start">AGILAB v2026.06.02</text>
+<text x="1340" y="34" font-size="14" font-weight="700" fill="#f7f7f2" text-anchor="start">Deploy</text>
+<rect x="380" y="104" width="980" height="292" rx="20" fill="url(#panelGradient)" stroke="#4f6471" stroke-width="1"/>
+<line x1="400" y1="134" x2="1328" y2="134" stroke="#cda759" stroke-width="1" opacity="0.8"/>
+<text x="408" y="162" font-size="34" font-weight="800" fill="#f7f7f2"><tspan x="408" dy="0">Turn experiments into</tspan><tspan x="408" dy="40">evidence-backed apps.</tspan></text>
+<text x="408" y="258" font-size="18" font-weight="400" fill="#aeb9bd"><tspan x="408" dy="0">Import, execute, prove, export</tspan></text>
+<rect x="408" y="318" width="78" height="36" rx="18" fill="#12273a" stroke="#4f6471" stroke-width="1"/>
+<text x="447" y="341" font-size="13" font-weight="700" fill="#f7f7f2" text-anchor="middle">Import</text>
+<rect x="496" y="318" width="78" height="36" rx="18" fill="#12273a" stroke="#4f6471" stroke-width="1"/>
+<text x="535" y="341" font-size="13" font-weight="700" fill="#f7f7f2" text-anchor="middle">Execute</text>
+<rect x="584" y="318" width="78" height="36" rx="18" fill="#12273a" stroke="#4f6471" stroke-width="1"/>
+<text x="623" y="341" font-size="13" font-weight="700" fill="#f7f7f2" text-anchor="middle">Prove</text>
+<rect x="672" y="318" width="78" height="36" rx="18" fill="#12273a" stroke="#4f6471" stroke-width="1"/>
+<text x="711" y="341" font-size="13" font-weight="700" fill="#f7f7f2" text-anchor="middle">Export</text>
+<rect x="822" y="248" width="508" height="190" rx="18" fill="#2a3f40" stroke="#4f6471" stroke-width="1" opacity="0.92"/>
+<text x="1076" y="282" font-size="13" font-weight="800" fill="#f7f7f2" text-anchor="middle">DIGITAL TWIN MAP</text>
+<circle cx="934" cy="388" r="66" fill="#293b3d" stroke="#7f8b8e"/>
+<circle cx="934" cy="388" r="34" fill="none" stroke="#f45d52" stroke-dasharray="6 6"/>
+<circle cx="934" cy="388" r="16" fill="#4fbf9f" opacity="0.85"/>
+<line x1="952" y1="380" x2="1030" y2="326" stroke="#f4b44d" stroke-width="3"/>
+<line x1="950" y1="394" x2="1024" y2="372" stroke="#7ee6c6" stroke-width="3"/>
+<rect x="1156" y="332" width="140" height="36" rx="8" fill="#1b3030" stroke="#4f6471" stroke-width="1"/>
+<text x="1170" y="355" font-size="12" font-weight="800" fill="#f7f7f2" text-anchor="start">Controls</text>
+<rect x="1156" y="386" width="140" height="36" rx="8" fill="#1b3030" stroke="#4f6471" stroke-width="1"/>
+<text x="1170" y="409" font-size="12" font-weight="800" fill="#f7f7f2" text-anchor="start">Symptoms</text>
+<rect x="1156" y="440" width="140" height="36" rx="8" fill="#1b3030" stroke="#4f6471" stroke-width="1"/>
+<text x="1170" y="463" font-size="12" font-weight="800" fill="#f7f7f2" text-anchor="start">Diagnosis</text>
+<rect x="380" y="628" width="124" height="40" rx="8" fill="#0b1727" stroke="#4f6471" stroke-width="1"/>
+<text x="442" y="653" font-size="13" font-weight="700" fill="#f7f7f2" text-anchor="middle">1. INSTALL demo</text>
+<text x="380" y="718" font-size="13" font-weight="400" fill="#aeb9bd"><tspan x="380" dy="0">Runs ORCHESTRATE install</tspan></text>
+<rect x="712" y="628" width="124" height="40" rx="8" fill="#0b1727" stroke="#4f6471" stroke-width="1"/>
+<text x="774" y="653" font-size="13" font-weight="700" fill="#f7f7f2" text-anchor="middle">2. EXECUTE demo</text>
+<text x="712" y="718" font-size="13" font-weight="400" fill="#aeb9bd"><tspan x="712" dy="0">Runs ORCHESTRATE execute</tspan></text>
+<rect x="1044" y="628" width="124" height="40" rx="8" fill="#0b1727" stroke="#4f6471" stroke-width="1"/>
+<text x="1106" y="653" font-size="13" font-weight="700" fill="#f7f7f2" text-anchor="middle">3. OPEN ANALYSIS</text>
+<text x="1044" y="718" font-size="13" font-weight="400" fill="#aeb9bd"><tspan x="1044" dy="0">Opens ANALYSIS evidence</tspan></text>
+</svg>

--- a/docs/source/_static/page-shots/orchestrate-page.svg
+++ b/docs/source/_static/page-shots/orchestrate-page.svg
@@ -1,0 +1,59 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 850" role="img" aria-labelledby="title desc">
+<title id="title">AGILAB orchestrate page vector screenshot summary</title>
+<desc id="desc">Screenshot-derived SVG summary generated from orchestrate-page.png, sha256 840b4bd8f3f33cb7. The PNG remains the canonical raster evidence.</desc>
+<defs><linearGradient id="panelGradient" x1="0" x2="1"><stop offset="0" stop-color="#1f2c2f"/><stop offset="0.55" stop-color="#0f3033"/><stop offset="1" stop-color="#243b24"/></linearGradient></defs>
+<rect x="0" y="0" width="1440" height="850" rx="0" fill="#07111f"/>
+<rect x="0" y="0" width="300" height="850" rx="0" fill="#10293b"/>
+<text x="20" y="46" font-size="26" font-weight="700" fill="#c9d3d7" text-anchor="start">AGI Lab</text>
+<text x="28" y="94" font-size="14" font-weight="500" fill="#d6dde0" text-anchor="start">PROJECT</text>
+<rect x="20" y="111" width="260" height="28" rx="6" fill="#38546c"/>
+<text x="28" y="128" font-size="14" font-weight="800" fill="#f7f7f2" text-anchor="start">ORCHESTRATE</text>
+<text x="28" y="162" font-size="14" font-weight="500" fill="#d6dde0" text-anchor="start">WORKFLOW</text>
+<text x="28" y="196" font-size="14" font-weight="500" fill="#d6dde0" text-anchor="start">ANALYSIS</text>
+<line x1="20" y1="230" x2="280" y2="230" stroke="#4e6572" stroke-width="1" opacity="0.75"/>
+<text x="20" y="273" font-size="16" font-weight="700" fill="#f7f7f2" text-anchor="start">Flight Telemetry</text>
+<rect x="20" y="318" width="260" height="40" rx="8" fill="#102b3d" stroke="#4f6471" stroke-width="1"/>
+<text x="56" y="344" font-size="14" font-weight="600" fill="#f7f7f2" text-anchor="start">Quick actions</text>
+<rect x="20" y="374" width="260" height="40" rx="8" fill="#102b3d" stroke="#4f6471" stroke-width="1"/>
+<text x="56" y="400" font-size="14" font-weight="600" fill="#f7f7f2" text-anchor="start">agi-app</text>
+<rect x="20" y="430" width="260" height="40" rx="8" fill="#102b3d" stroke="#4f6471" stroke-width="1"/>
+<text x="56" y="456" font-size="14" font-weight="600" fill="#f7f7f2" text-anchor="start">Reviewed</text>
+<text x="16" y="830" font-size="12" font-weight="400" fill="#b9c5ca" text-anchor="start">AGILAB v2026.06.02</text>
+<text x="1340" y="34" font-size="14" font-weight="700" fill="#f7f7f2" text-anchor="start">Deploy</text>
+<rect x="380" y="120" width="980" height="590" rx="20" fill="url(#panelGradient)" stroke="#4f6471" stroke-width="1"/>
+<line x1="400" y1="135" x2="1328" y2="135" stroke="#cda759" stroke-width="1" opacity="0.8"/>
+<rect x="380" y="112" width="980" height="40" rx="8" fill="#0b1727" stroke="#4f6471" stroke-width="1"/>
+<text x="418" y="138" font-size="14" font-weight="700" fill="#f7f7f2" text-anchor="start">Environment Health</text>
+<rect x="380" y="168" width="980" height="40" rx="8" fill="#0b1727" stroke="#4f6471" stroke-width="1"/>
+<text x="418" y="194" font-size="14" font-weight="700" fill="#f7f7f2" text-anchor="start">Environment details</text>
+<rect x="380" y="224" width="980" height="92" rx="8" fill="#0b1727" stroke="#4f6471" stroke-width="1"/>
+<text x="418" y="250" font-size="14" font-weight="700" fill="#f7f7f2" text-anchor="start">1. Resources and install</text>
+<rect x="412" y="260" width="150" height="28" rx="6" fill="#101f2f" stroke="#4f6471" stroke-width="1"/>
+<text x="487" y="279" font-size="12" font-weight="600" fill="#f7f7f2" text-anchor="middle">Share: not used</text>
+<rect x="587" y="260" width="150" height="28" rx="6" fill="#101f2f" stroke="#4f6471" stroke-width="1"/>
+<text x="662" y="279" font-size="12" font-weight="600" fill="#f7f7f2" text-anchor="middle">CPU: 16 cores</text>
+<rect x="762" y="260" width="150" height="28" rx="6" fill="#101f2f" stroke="#4f6471" stroke-width="1"/>
+<text x="837" y="279" font-size="12" font-weight="600" fill="#f7f7f2" text-anchor="middle">RAM: 48 GB</text>
+<rect x="937" y="260" width="150" height="28" rx="6" fill="#101f2f" stroke="#4f6471" stroke-width="1"/>
+<text x="1012" y="279" font-size="12" font-weight="600" fill="#f7f7f2" text-anchor="middle">GPU: Apple M4 Max</text>
+<rect x="1112" y="260" width="150" height="28" rx="6" fill="#101f2f" stroke="#4f6471" stroke-width="1"/>
+<text x="1187" y="279" font-size="12" font-weight="600" fill="#f7f7f2" text-anchor="middle">NPU: Apple Neural Engine</text>
+<rect x="380" y="336" width="980" height="92" rx="8" fill="#0b1727" stroke="#4f6471" stroke-width="1"/>
+<text x="418" y="362" font-size="14" font-weight="700" fill="#f7f7f2" text-anchor="start">Worker options</text>
+<rect x="412" y="372" width="150" height="28" rx="6" fill="#101f2f" stroke="#4f6471" stroke-width="1"/>
+<text x="487" y="391" font-size="12" font-weight="600" fill="#f7f7f2" text-anchor="middle">Cython</text>
+<rect x="587" y="372" width="150" height="28" rx="6" fill="#101f2f" stroke="#4f6471" stroke-width="1"/>
+<text x="662" y="391" font-size="12" font-weight="600" fill="#f7f7f2" text-anchor="middle">Pool</text>
+<rect x="762" y="372" width="150" height="28" rx="6" fill="#101f2f" stroke="#4f6471" stroke-width="1"/>
+<text x="837" y="391" font-size="12" font-weight="600" fill="#f7f7f2" text-anchor="middle">Rapids</text>
+<rect x="937" y="372" width="150" height="28" rx="6" fill="#101f2f" stroke="#4f6471" stroke-width="1"/>
+<text x="1012" y="391" font-size="12" font-weight="600" fill="#f7f7f2" text-anchor="middle">Enable Cluster</text>
+<rect x="380" y="448" width="980" height="68" rx="8" fill="#0b1727" stroke="#4f6471" stroke-width="1"/>
+<text x="418" y="474" font-size="14" font-weight="700" fill="#f7f7f2" text-anchor="start">Generated INSTALL snippet</text>
+<rect x="412" y="484" width="150" height="28" rx="6" fill="#101f2f" stroke="#4f6471" stroke-width="1"/>
+<text x="487" y="503" font-size="12" font-weight="600" fill="#f7f7f2" text-anchor="middle">INSTALL</text>
+<rect x="380" y="560" width="980" height="68" rx="8" fill="#0b1727" stroke="#4f6471" stroke-width="1"/>
+<text x="418" y="586" font-size="14" font-weight="700" fill="#f7f7f2" text-anchor="start">2. Configure run arguments</text>
+<rect x="412" y="596" width="150" height="28" rx="6" fill="#101f2f" stroke="#4f6471" stroke-width="1"/>
+<text x="487" y="615" font-size="12" font-weight="600" fill="#f7f7f2" text-anchor="middle">Edit app parameters</text>
+</svg>

--- a/docs/source/_static/page-shots/project-create-page.svg
+++ b/docs/source/_static/page-shots/project-create-page.svg
@@ -1,0 +1,66 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 1000" role="img" aria-labelledby="title desc">
+<title id="title">AGILAB project create page vector screenshot summary</title>
+<desc id="desc">Screenshot-derived SVG summary generated from project-create-page.png, sha256 ea9dfc70552a9744. The PNG remains the canonical raster evidence.</desc>
+<defs><linearGradient id="panelGradient" x1="0" x2="1"><stop offset="0" stop-color="#1f2c2f"/><stop offset="0.55" stop-color="#0f3033"/><stop offset="1" stop-color="#243b24"/></linearGradient></defs>
+<rect x="0" y="0" width="1440" height="1000" rx="0" fill="#07111f"/>
+<rect x="0" y="0" width="300" height="1000" rx="0" fill="#10293b"/>
+<text x="20" y="46" font-size="26" font-weight="700" fill="#c9d3d7" text-anchor="start">AGI Lab</text>
+<rect x="20" y="77" width="260" height="28" rx="6" fill="#38546c"/>
+<text x="28" y="94" font-size="14" font-weight="800" fill="#f7f7f2" text-anchor="start">PROJECT</text>
+<text x="28" y="128" font-size="14" font-weight="500" fill="#d6dde0" text-anchor="start">ORCHESTRATE</text>
+<text x="28" y="162" font-size="14" font-weight="500" fill="#d6dde0" text-anchor="start">WORKFLOW</text>
+<text x="28" y="196" font-size="14" font-weight="500" fill="#d6dde0" text-anchor="start">ANALYSIS</text>
+<line x1="20" y1="230" x2="280" y2="230" stroke="#4e6572" stroke-width="1" opacity="0.75"/>
+<text x="20" y="273" font-size="16" font-weight="700" fill="#f7f7f2" text-anchor="start">Flight Telemetry</text>
+<rect x="20" y="318" width="260" height="74" rx="8" fill="#102b3d" stroke="#4f6471" stroke-width="1"/>
+<text x="38" y="346" font-size="14" font-weight="700" fill="#f7f7f2" text-anchor="start">Install PyPI app</text>
+<rect x="20" y="408" width="260" height="74" rx="8" fill="#102b3d" stroke="#4f6471" stroke-width="1"/>
+<text x="38" y="436" font-size="14" font-weight="700" fill="#f7f7f2" text-anchor="start">Export</text>
+<rect x="20" y="498" width="260" height="108" rx="8" fill="#102b3d" stroke="#4f6471" stroke-width="1"/>
+<text x="38" y="526" font-size="14" font-weight="700" fill="#f7f7f2" text-anchor="start">Create mode</text>
+<rect x="36" y="536" width="228" height="30" rx="8" fill="#071827" stroke="#58a6ff" stroke-width="1"/>
+<text x="150" y="556" font-size="13" font-weight="500" fill="#58a6ff" text-anchor="middle">Template clone</text>
+<rect x="36" y="570" width="228" height="30" rx="8" fill="#071827" stroke="#58a6ff" stroke-width="1"/>
+<text x="150" y="590" font-size="13" font-weight="500" fill="#58a6ff" text-anchor="middle">From notebook</text>
+<rect x="20" y="622" width="260" height="74" rx="8" fill="#102b3d" stroke="#4f6471" stroke-width="1"/>
+<text x="38" y="650" font-size="14" font-weight="700" fill="#f7f7f2" text-anchor="start">Starting point</text>
+<rect x="36" y="660" width="228" height="30" rx="8" fill="#071827" stroke="#58a6ff" stroke-width="1"/>
+<text x="150" y="680" font-size="13" font-weight="500" fill="#58a6ff" text-anchor="middle">flight_telemetry_project</text>
+<rect x="20" y="712" width="260" height="108" rx="8" fill="#102b3d" stroke="#4f6471" stroke-width="1"/>
+<text x="38" y="740" font-size="14" font-weight="700" fill="#f7f7f2" text-anchor="start">Environment strategy</text>
+<rect x="36" y="750" width="228" height="30" rx="8" fill="#071827" stroke="#58a6ff" stroke-width="1"/>
+<text x="150" y="770" font-size="13" font-weight="500" fill="#58a6ff" text-anchor="middle">Working clone</text>
+<rect x="36" y="784" width="228" height="30" rx="8" fill="#071827" stroke="#58a6ff" stroke-width="1"/>
+<text x="150" y="804" font-size="13" font-weight="500" fill="#58a6ff" text-anchor="middle">Temporary clone</text>
+<rect x="20" y="836" width="260" height="74" rx="8" fill="#102b3d" stroke="#4f6471" stroke-width="1"/>
+<text x="38" y="864" font-size="14" font-weight="700" fill="#f7f7f2" text-anchor="start">New project base name</text>
+<rect x="36" y="874" width="228" height="30" rx="8" fill="#071827" stroke="#58a6ff" stroke-width="1"/>
+<text x="150" y="894" font-size="13" font-weight="500" fill="#58a6ff" text-anchor="middle"></text>
+<rect x="20" y="926" width="260" height="74" rx="8" fill="#102b3d" stroke="#4f6471" stroke-width="1"/>
+<text x="38" y="954" font-size="14" font-weight="700" fill="#f7f7f2" text-anchor="start">Create</text>
+<text x="16" y="980" font-size="12" font-weight="400" fill="#b9c5ca" text-anchor="start">AGILAB v2026.06.02</text>
+<text x="1340" y="34" font-size="14" font-weight="700" fill="#f7f7f2" text-anchor="start">Deploy</text>
+<text x="380" y="162" font-size="34" font-weight="800" fill="#f7f7f2" text-anchor="start">Create project</text>
+<text x="380" y="202" font-size="14" font-weight="400" fill="#aeb9bd" text-anchor="start">Create a new project from an existing template.</text>
+<rect x="380" y="270" width="520" height="56" rx="12" fill="#172633" stroke="#4f6471" stroke-width="1"/>
+<text x="408" y="305" font-size="18" font-weight="700" fill="#f7f7f2" text-anchor="start">Choose source template</text>
+<line x1="640" y1="332" x2="640" y2="352" stroke="#58a6ff" stroke-width="3"/>
+<rect x="380" y="356" width="520" height="56" rx="12" fill="#172633" stroke="#4f6471" stroke-width="1"/>
+<text x="408" y="391" font-size="18" font-weight="700" fill="#f7f7f2" text-anchor="start">Choose environment strategy</text>
+<line x1="640" y1="418" x2="640" y2="438" stroke="#58a6ff" stroke-width="3"/>
+<rect x="380" y="442" width="520" height="56" rx="12" fill="#172633" stroke="#4f6471" stroke-width="1"/>
+<text x="408" y="477" font-size="18" font-weight="700" fill="#f7f7f2" text-anchor="start">Name project</text>
+<line x1="640" y1="504" x2="640" y2="524" stroke="#58a6ff" stroke-width="3"/>
+<rect x="380" y="528" width="520" height="56" rx="12" fill="#172633" stroke="#4f6471" stroke-width="1"/>
+<text x="408" y="563" font-size="18" font-weight="700" fill="#f7f7f2" text-anchor="start">Create workspace</text>
+<rect x="945" y="282" width="320" height="236" rx="14" fill="#10263a" stroke="#4f6471" stroke-width="1"/>
+<text x="970" y="320" font-size="20" font-weight="800" fill="#f7f7f2" text-anchor="start">Sidebar contract</text>
+<rect x="970" y="350" width="250" height="26" rx="7" fill="#071827" stroke="#58a6ff" stroke-width="1"/>
+<text x="984" y="368" font-size="12" font-weight="600" fill="#58a6ff" text-anchor="start">Create mode</text>
+<rect x="970" y="390" width="250" height="26" rx="7" fill="#071827" stroke="#58a6ff" stroke-width="1"/>
+<text x="984" y="408" font-size="12" font-weight="600" fill="#58a6ff" text-anchor="start">Starting point</text>
+<rect x="970" y="430" width="250" height="26" rx="7" fill="#071827" stroke="#58a6ff" stroke-width="1"/>
+<text x="984" y="448" font-size="12" font-weight="600" fill="#58a6ff" text-anchor="start">Environment strategy</text>
+<rect x="970" y="470" width="250" height="26" rx="7" fill="#071827" stroke="#58a6ff" stroke-width="1"/>
+<text x="984" y="488" font-size="12" font-weight="600" fill="#58a6ff" text-anchor="start">Project name</text>
+</svg>

--- a/docs/source/_static/page-shots/project-page.svg
+++ b/docs/source/_static/page-shots/project-page.svg
@@ -1,0 +1,77 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 850" role="img" aria-labelledby="title desc">
+<title id="title">AGILAB project page vector screenshot summary</title>
+<desc id="desc">Screenshot-derived SVG summary generated from project-page.png, sha256 7a2a872a12e0d35f. The PNG remains the canonical raster evidence.</desc>
+<defs><linearGradient id="panelGradient" x1="0" x2="1"><stop offset="0" stop-color="#1f2c2f"/><stop offset="0.55" stop-color="#0f3033"/><stop offset="1" stop-color="#243b24"/></linearGradient></defs>
+<rect x="0" y="0" width="1440" height="850" rx="0" fill="#07111f"/>
+<rect x="0" y="0" width="300" height="850" rx="0" fill="#10293b"/>
+<text x="20" y="46" font-size="26" font-weight="700" fill="#c9d3d7" text-anchor="start">AGI Lab</text>
+<rect x="20" y="77" width="260" height="28" rx="6" fill="#38546c"/>
+<text x="28" y="94" font-size="14" font-weight="800" fill="#f7f7f2" text-anchor="start">PROJECT</text>
+<text x="28" y="128" font-size="14" font-weight="500" fill="#d6dde0" text-anchor="start">ORCHESTRATE</text>
+<text x="28" y="162" font-size="14" font-weight="500" fill="#d6dde0" text-anchor="start">WORKFLOW</text>
+<text x="28" y="196" font-size="14" font-weight="500" fill="#d6dde0" text-anchor="start">ANALYSIS</text>
+<line x1="20" y1="230" x2="280" y2="230" stroke="#4e6572" stroke-width="1" opacity="0.75"/>
+<text x="20" y="273" font-size="16" font-weight="700" fill="#f7f7f2" text-anchor="start">Flight Telemetry</text>
+<rect x="20" y="318" width="260" height="40" rx="8" fill="#102b3d" stroke="#4f6471" stroke-width="1"/>
+<text x="56" y="344" font-size="14" font-weight="600" fill="#f7f7f2" text-anchor="start">Quick actions</text>
+<rect x="20" y="374" width="260" height="40" rx="8" fill="#102b3d" stroke="#4f6471" stroke-width="1"/>
+<text x="56" y="400" font-size="14" font-weight="600" fill="#f7f7f2" text-anchor="start">agi-app</text>
+<rect x="20" y="430" width="260" height="40" rx="8" fill="#102b3d" stroke="#4f6471" stroke-width="1"/>
+<text x="56" y="456" font-size="14" font-weight="600" fill="#f7f7f2" text-anchor="start">Reviewed</text>
+<text x="16" y="830" font-size="12" font-weight="400" fill="#b9c5ca" text-anchor="start">AGILAB v2026.06.02</text>
+<text x="1340" y="34" font-size="14" font-weight="700" fill="#f7f7f2" text-anchor="start">Deploy</text>
+<rect x="380" y="120" width="980" height="210" rx="20" fill="url(#panelGradient)" stroke="#4f6471" stroke-width="1"/>
+<line x1="400" y1="135" x2="1328" y2="135" stroke="#cda759" stroke-width="1" opacity="0.8"/>
+<rect x="410" y="210" width="216" height="105" rx="12" fill="#20363b" stroke="#4f6471" stroke-width="1" opacity="0.96"/>
+<rect x="420" y="222" width="4" height="81" rx="2" fill="#7ee6c6"/>
+<text x="428" y="234" font-size="11" font-weight="800" fill="#c7cdd0" text-anchor="start">PROJECT PATH</text>
+<text x="428" y="266" font-size="22" font-weight="800" fill="#7ee6c6" text-anchor="start">ready</text>
+<text x="428" y="297" font-size="12" font-weight="400" fill="#aeb9bd" text-anchor="start">flight_telemetry_project</text>
+<rect x="645" y="210" width="216" height="105" rx="12" fill="#20363b" stroke="#4f6471" stroke-width="1" opacity="0.96"/>
+<rect x="655" y="222" width="4" height="81" rx="2" fill="#7ee6c6"/>
+<text x="663" y="234" font-size="11" font-weight="800" fill="#c7cdd0" text-anchor="start">MANAGER ENV</text>
+<text x="663" y="266" font-size="22" font-weight="800" fill="#7ee6c6" text-anchor="start">ready</text>
+<text x="663" y="297" font-size="12" font-weight="400" fill="#aeb9bd" text-anchor="start">.venv in project</text>
+<rect x="880" y="210" width="216" height="105" rx="12" fill="#20363b" stroke="#4f6471" stroke-width="1" opacity="0.96"/>
+<rect x="890" y="222" width="4" height="81" rx="2" fill="#f4b44d"/>
+<text x="898" y="234" font-size="11" font-weight="800" fill="#c7cdd0" text-anchor="start">WORKER ENV</text>
+<text x="898" y="266" font-size="22" font-weight="800" fill="#f4b44d" text-anchor="start">missing</text>
+<text x="898" y="297" font-size="12" font-weight="400" fill="#aeb9bd" text-anchor="start">.venv in worker</text>
+<rect x="1115" y="210" width="216" height="105" rx="12" fill="#20363b" stroke="#4f6471" stroke-width="1" opacity="0.96"/>
+<rect x="1125" y="222" width="4" height="81" rx="2" fill="#7ee6c6"/>
+<text x="1133" y="234" font-size="11" font-weight="800" fill="#c7cdd0" text-anchor="start">SETTINGS</text>
+<text x="1133" y="266" font-size="22" font-weight="800" fill="#7ee6c6" text-anchor="start">Workspace</text>
+<text x="1133" y="297" font-size="12" font-weight="400" fill="#aeb9bd" text-anchor="start">app_settings.toml</text>
+<rect x="410" y="336" width="216" height="105" rx="12" fill="#20363b" stroke="#4f6471" stroke-width="1" opacity="0.96"/>
+<rect x="420" y="348" width="4" height="81" rx="2" fill="#7ee6c6"/>
+<text x="428" y="360" font-size="11" font-weight="800" fill="#c7cdd0" text-anchor="start">DATA SHARE</text>
+<text x="428" y="392" font-size="22" font-weight="800" fill="#7ee6c6" text-anchor="start">20 MB</text>
+<text x="428" y="423" font-size="12" font-weight="400" fill="#aeb9bd" text-anchor="start">33 files</text>
+<rect x="645" y="336" width="216" height="105" rx="12" fill="#20363b" stroke="#4f6471" stroke-width="1" opacity="0.96"/>
+<rect x="655" y="348" width="4" height="81" rx="2" fill="#7ee6c6"/>
+<text x="663" y="360" font-size="11" font-weight="800" fill="#c7cdd0" text-anchor="start">CLUSTER SHARE</text>
+<text x="663" y="392" font-size="22" font-weight="800" fill="#7ee6c6" text-anchor="start">Configured</text>
+<text x="663" y="423" font-size="12" font-weight="400" fill="#aeb9bd" text-anchor="start">runtime share path</text>
+<rect x="880" y="336" width="216" height="105" rx="12" fill="#20363b" stroke="#4f6471" stroke-width="1" opacity="0.96"/>
+<rect x="890" y="348" width="4" height="81" rx="2" fill="#7ee6c6"/>
+<text x="898" y="360" font-size="11" font-weight="800" fill="#c7cdd0" text-anchor="start">API KEYS</text>
+<text x="898" y="392" font-size="22" font-weight="800" fill="#7ee6c6" text-anchor="start">Configured</text>
+<text x="898" y="423" font-size="12" font-weight="400" fill="#aeb9bd" text-anchor="start">OpenAI</text>
+<rect x="1115" y="336" width="216" height="105" rx="12" fill="#20363b" stroke="#4f6471" stroke-width="1" opacity="0.96"/>
+<rect x="1125" y="348" width="4" height="81" rx="2" fill="#f4b44d"/>
+<text x="1133" y="360" font-size="11" font-weight="800" fill="#c7cdd0" text-anchor="start">RUNS</text>
+<text x="1133" y="392" font-size="22" font-weight="800" fill="#f4b44d" text-anchor="start">0</text>
+<text x="1133" y="423" font-size="12" font-weight="400" fill="#aeb9bd" text-anchor="start">no run logs yet</text>
+<rect x="380" y="462" width="980" height="260" rx="8" fill="#0b1727" stroke="#4f6471" stroke-width="1"/>
+<text x="418" y="488" font-size="14" font-weight="700" fill="#f7f7f2" text-anchor="start">Project metrics</text>
+<rect x="412" y="498" width="150" height="28" rx="6" fill="#101f2f" stroke="#4f6471" stroke-width="1"/>
+<text x="487" y="517" font-size="12" font-weight="600" fill="#f7f7f2" text-anchor="middle">masked metrics area</text>
+<rect x="380" y="742" width="980" height="260" rx="8" fill="#0b1727" stroke="#4f6471" stroke-width="1"/>
+<text x="418" y="768" font-size="14" font-weight="700" fill="#f7f7f2" text-anchor="start">Environment details</text>
+<rect x="412" y="778" width="150" height="28" rx="6" fill="#101f2f" stroke="#4f6471" stroke-width="1"/>
+<text x="487" y="797" font-size="12" font-weight="600" fill="#f7f7f2" text-anchor="middle">manager env</text>
+<rect x="587" y="778" width="150" height="28" rx="6" fill="#101f2f" stroke="#4f6471" stroke-width="1"/>
+<text x="662" y="797" font-size="12" font-weight="600" fill="#f7f7f2" text-anchor="middle">worker env</text>
+<rect x="762" y="778" width="150" height="28" rx="6" fill="#101f2f" stroke="#4f6471" stroke-width="1"/>
+<text x="837" y="797" font-size="12" font-weight="600" fill="#f7f7f2" text-anchor="middle">data share</text>
+</svg>

--- a/docs/source/_static/page-shots/screenshot_manifest.json
+++ b/docs/source/_static/page-shots/screenshot_manifest.json
@@ -18,6 +18,10 @@
       "source_command": [
         "targeted-playwright-doc-project-page-capture 1440x850-project-sidebar-minimalism"
       ],
+      "svg_summary_kind": "screenshot-derived-vector-summary",
+      "svg_summary_path": "analysis-page.svg",
+      "svg_summary_sha256": "42a9deca930a88457d6704861e647faad9667c6e55db020593373c06537e5ace",
+      "svg_summary_size_bytes": 5885,
       "url": "",
       "width_px": 1440
     },
@@ -34,6 +38,10 @@
       "source_command": [
         "targeted-playwright-doc-project-page-capture 1440x850-project-sidebar-minimalism"
       ],
+      "svg_summary_kind": "screenshot-derived-vector-summary",
+      "svg_summary_path": "core-pages-overview.svg",
+      "svg_summary_sha256": "4d0b7b7c7d0faebd2ce7978a16a18c7865f5dcf817e010a0c9dbc159e455e009",
+      "svg_summary_size_bytes": 5825,
       "url": "",
       "width_px": 1440
     },
@@ -50,6 +58,10 @@
       "source_command": [
         "targeted-playwright-doc-project-page-capture 1440x850-project-sidebar-minimalism"
       ],
+      "svg_summary_kind": "screenshot-derived-vector-summary",
+      "svg_summary_path": "orchestrate-page.svg",
+      "svg_summary_sha256": "990988c6fe4b10b197e8b988fc95ae6308ddef676c99fd565e3438675c5d24f8",
+      "svg_summary_size_bytes": 6251,
       "url": "",
       "width_px": 1440
     },
@@ -66,6 +78,10 @@
       "source_command": [
         "targeted-playwright-doc-project-page-capture 1440x850-project-sidebar-minimalism"
       ],
+      "svg_summary_kind": "screenshot-derived-vector-summary",
+      "svg_summary_path": "project-create-page.svg",
+      "svg_summary_sha256": "4ca9fe0d3421c9c57fbf523c977e5b3f32fdd3c6768e6797fc1f67a446d9c923",
+      "svg_summary_size_bytes": 6962,
       "url": "",
       "width_px": 1440
     },
@@ -82,6 +98,10 @@
       "source_command": [
         "targeted-playwright-doc-project-page-capture 1440x850-project-sidebar-minimalism"
       ],
+      "svg_summary_kind": "screenshot-derived-vector-summary",
+      "svg_summary_path": "project-page.svg",
+      "svg_summary_sha256": "ee9809d31071913774ae6258c628de14a966055a083a4d0d144bb4506936c960",
+      "svg_summary_size_bytes": 7955,
       "url": "",
       "width_px": 1440
     },
@@ -98,11 +118,16 @@
       "source_command": [
         "targeted-playwright-doc-project-page-capture 1440x850-project-sidebar-minimalism"
       ],
+      "svg_summary_kind": "screenshot-derived-vector-summary",
+      "svg_summary_path": "workflow-page.svg",
+      "svg_summary_sha256": "158f159d29a4d59b0d1bec69e778669f297d5ab3d64c67a859fe219f4e0ed679",
+      "svg_summary_size_bytes": 6424,
       "url": "",
       "width_px": 1440
     }
   ],
   "source_command": [
     "targeted-playwright-doc-project-page-capture 1440x850-project-sidebar-minimalism"
-  ]
+  ],
+  "svg_summary_note": "SVG summaries are token-light documentation views derived from the page-shot PNGs; PNG files remain canonical raster screenshot evidence."
 }

--- a/docs/source/_static/page-shots/workflow-page.svg
+++ b/docs/source/_static/page-shots/workflow-page.svg
@@ -1,0 +1,62 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 850" role="img" aria-labelledby="title desc">
+<title id="title">AGILAB workflow page vector screenshot summary</title>
+<desc id="desc">Screenshot-derived SVG summary generated from workflow-page.png, sha256 0a32f81d0b9d8f1f. The PNG remains the canonical raster evidence.</desc>
+<defs><linearGradient id="panelGradient" x1="0" x2="1"><stop offset="0" stop-color="#1f2c2f"/><stop offset="0.55" stop-color="#0f3033"/><stop offset="1" stop-color="#243b24"/></linearGradient></defs>
+<rect x="0" y="0" width="1440" height="850" rx="0" fill="#07111f"/>
+<rect x="0" y="0" width="300" height="850" rx="0" fill="#10293b"/>
+<text x="20" y="46" font-size="26" font-weight="700" fill="#c9d3d7" text-anchor="start">AGI Lab</text>
+<text x="28" y="94" font-size="14" font-weight="500" fill="#d6dde0" text-anchor="start">PROJECT</text>
+<text x="28" y="128" font-size="14" font-weight="500" fill="#d6dde0" text-anchor="start">ORCHESTRATE</text>
+<rect x="20" y="145" width="260" height="28" rx="6" fill="#38546c"/>
+<text x="28" y="162" font-size="14" font-weight="800" fill="#f7f7f2" text-anchor="start">WORKFLOW</text>
+<text x="28" y="196" font-size="14" font-weight="500" fill="#d6dde0" text-anchor="start">ANALYSIS</text>
+<line x1="20" y1="230" x2="280" y2="230" stroke="#4e6572" stroke-width="1" opacity="0.75"/>
+<text x="20" y="273" font-size="16" font-weight="700" fill="#f7f7f2" text-anchor="start">Flight Telemetry</text>
+<rect x="20" y="318" width="260" height="40" rx="8" fill="#102b3d" stroke="#4f6471" stroke-width="1"/>
+<text x="56" y="344" font-size="14" font-weight="600" fill="#f7f7f2" text-anchor="start">Quick actions</text>
+<rect x="20" y="374" width="260" height="40" rx="8" fill="#102b3d" stroke="#4f6471" stroke-width="1"/>
+<text x="56" y="400" font-size="14" font-weight="600" fill="#f7f7f2" text-anchor="start">agi-app</text>
+<rect x="20" y="430" width="260" height="40" rx="8" fill="#102b3d" stroke="#4f6471" stroke-width="1"/>
+<text x="56" y="456" font-size="14" font-weight="600" fill="#f7f7f2" text-anchor="start">Reviewed</text>
+<text x="16" y="830" font-size="12" font-weight="400" fill="#b9c5ca" text-anchor="start">AGILAB v2026.06.02</text>
+<text x="1340" y="34" font-size="14" font-weight="700" fill="#f7f7f2" text-anchor="start">Deploy</text>
+<rect x="380" y="120" width="980" height="210" rx="20" fill="url(#panelGradient)" stroke="#4f6471" stroke-width="1"/>
+<line x1="400" y1="135" x2="1328" y2="135" stroke="#cda759" stroke-width="1" opacity="0.8"/>
+<rect x="410" y="150" width="450" height="104" rx="12" fill="#20363b" stroke="#4f6471" stroke-width="1" opacity="0.96"/>
+<rect x="420" y="162" width="4" height="80" rx="2" fill="#f4b44d"/>
+<text x="428" y="174" font-size="11" font-weight="800" fill="#c7cdd0" text-anchor="start">RUNNABLE</text>
+<text x="428" y="206" font-size="22" font-weight="800" fill="#f4b44d" text-anchor="start">0</text>
+<text x="428" y="236" font-size="12" font-weight="400" fill="#aeb9bd" text-anchor="start">stages with executable code</text>
+<rect x="880" y="150" width="450" height="104" rx="12" fill="#20363b" stroke="#4f6471" stroke-width="1" opacity="0.96"/>
+<rect x="890" y="162" width="4" height="80" rx="2" fill="#7ee6c6"/>
+<text x="898" y="174" font-size="11" font-weight="800" fill="#c7cdd0" text-anchor="start">OUTPUT FILES</text>
+<text x="898" y="206" font-size="22" font-weight="800" fill="#7ee6c6" text-anchor="start">9</text>
+<text x="898" y="236" font-size="12" font-weight="400" fill="#aeb9bd" text-anchor="start">2026-06-02 03:55</text>
+<rect x="410" y="274" width="295" height="104" rx="12" fill="#20363b" stroke="#4f6471" stroke-width="1" opacity="0.96"/>
+<rect x="420" y="286" width="4" height="80" rx="2" fill="#7ee6c6"/>
+<text x="428" y="298" font-size="11" font-weight="800" fill="#c7cdd0" text-anchor="start">DATAFRAMES</text>
+<text x="428" y="330" font-size="22" font-weight="800" fill="#7ee6c6" text-anchor="start">7</text>
+<text x="428" y="360" font-size="12" font-weight="400" fill="#aeb9bd" text-anchor="start">previewable table files</text>
+<rect x="724" y="274" width="295" height="104" rx="12" fill="#20363b" stroke="#4f6471" stroke-width="1" opacity="0.96"/>
+<rect x="734" y="286" width="4" height="80" rx="2" fill="#7ee6c6"/>
+<text x="742" y="298" font-size="11" font-weight="800" fill="#c7cdd0" text-anchor="start">WORKFLOW GRAPH</text>
+<text x="742" y="330" font-size="22" font-weight="800" fill="#7ee6c6" text-anchor="start">6/1</text>
+<text x="742" y="360" font-size="12" font-weight="400" fill="#aeb9bd" text-anchor="start">pipeline_view.dot</text>
+<rect x="1036" y="274" width="292" height="104" rx="12" fill="#20363b" stroke="#4f6471" stroke-width="1" opacity="0.96"/>
+<rect x="1046" y="286" width="4" height="80" rx="2" fill="#aeb9bd"/>
+<text x="1054" y="298" font-size="11" font-weight="800" fill="#c7cdd0" text-anchor="start">UPDATED</text>
+<text x="1054" y="330" font-size="22" font-weight="800" fill="#aeb9bd" text-anchor="start">2026-06-02 03:55</text>
+<text x="1054" y="360" font-size="12" font-weight="400" fill="#aeb9bd" text-anchor="start">flight_telemetry</text>
+<rect x="380" y="444" width="980" height="40" rx="8" fill="#0b1727" stroke="#4f6471" stroke-width="1"/>
+<text x="418" y="470" font-size="14" font-weight="700" fill="#f7f7f2" text-anchor="start">Notebook</text>
+<rect x="380" y="500" width="980" height="330" rx="8" fill="#0b1727" stroke="#4f6471" stroke-width="1"/>
+<text x="418" y="526" font-size="14" font-weight="700" fill="#f7f7f2" text-anchor="start">Workflow graph</text>
+<rect x="412" y="536" width="150" height="28" rx="6" fill="#101f2f" stroke="#4f6471" stroke-width="1"/>
+<text x="487" y="555" font-size="12" font-weight="600" fill="#f7f7f2" text-anchor="middle">Project workflow</text>
+<rect x="587" y="536" width="150" height="28" rx="6" fill="#101f2f" stroke="#4f6471" stroke-width="1"/>
+<text x="662" y="555" font-size="12" font-weight="600" fill="#f7f7f2" text-anchor="middle">Multi-app DAG</text>
+<rect x="762" y="536" width="150" height="28" rx="6" fill="#101f2f" stroke="#4f6471" stroke-width="1"/>
+<text x="837" y="555" font-size="12" font-weight="600" fill="#f7f7f2" text-anchor="middle">Choose workplan</text>
+<rect x="937" y="536" width="150" height="28" rx="6" fill="#101f2f" stroke="#4f6471" stroke-width="1"/>
+<text x="1012" y="555" font-size="12" font-weight="600" fill="#f7f7f2" text-anchor="middle">App templates</text>
+</svg>

--- a/docs/source/agent-workflows.rst
+++ b/docs/source/agent-workflows.rst
@@ -78,6 +78,13 @@ Then follow the repo rules in:
   validation feedback
 - ``AGENTS.md`` for the full AGILAB runbook and validation rules
 
+When coding through a terminal agent, AGILAB recommends launching that agent
+through Tokki when it is available. Tokki keeps context compact, digests noisy
+terminal output, records session metadata, and exposes token-savings evidence.
+It is an efficiency and observability layer for agent sessions; the AGILAB
+validation source of truth remains ``tools/impact_validate.py``, ``./dev``, and
+the workflow-parity profiles.
+
 The main rule is simple: run the narrowest local proof first, then reproduce
 the real AGILAB path before broader validation.
 

--- a/docs/source/agilab-help.rst
+++ b/docs/source/agilab-help.rst
@@ -38,7 +38,7 @@ sidebar **Settings** link to edit persisted environment variables and runtime
 diagnostics. The general AGILAB documentation link remains available from
 Streamlit's system menu under **Get help**.
 
-.. figure:: _static/page-shots/core-pages-overview.png
+.. figure:: _static/page-shots/core-pages-overview.svg
    :alt: Overview screenshot montage of the PROJECT, ORCHESTRATE, WORKFLOW, and ANALYSIS Streamlit pages.
    :align: center
    :class: diagram-panel diagram-wide

--- a/docs/source/distributed-workers.rst
+++ b/docs/source/distributed-workers.rst
@@ -98,7 +98,7 @@ a per-user cluster-share path instead of a common writable directory shared by
 multiple operators. Generated snippets remain under the local ``AGI_LOG_DIR``
 workspace.
 
-.. figure:: _static/page-shots/orchestrate-page.png
+.. figure:: _static/page-shots/orchestrate-page.svg
    :alt: Screenshot of the ORCHESTRATE page showing deployment toggles and generated setup code.
    :align: center
    :class: diagram-panel diagram-wide
@@ -288,7 +288,7 @@ Important: imported snippets are snapshots. If you change worker hosts,
 execution flags, or app arguments in ORCHESTRATE, regenerate or re-import the
 snippet before running it again in WORKFLOW.
 
-.. figure:: _static/page-shots/workflow-page.png
+.. figure:: _static/page-shots/workflow-page.svg
    :alt: Screenshot of the WORKFLOW page showing the lab-stage workspace where generated snippets are imported and rerun.
    :align: center
    :class: diagram-panel diagram-wide

--- a/docs/source/edit-help.rst
+++ b/docs/source/edit-help.rst
@@ -7,14 +7,14 @@ PROJECT
 Page snapshot
 -------------
 
-.. figure:: _static/page-shots/project-page.png
+.. figure:: _static/page-shots/project-page.svg
    :alt: Screenshot of the PROJECT page with the project selector and source-file expanders.
    :align: center
    :class: diagram-panel diagram-wide
 
    The PROJECT page keeps project selection in the sidebar and exposes the editable source/config sections in the main panel.
 
-.. figure:: _static/page-shots/project-create-page.png
+.. figure:: _static/page-shots/project-create-page.svg
    :alt: Screenshot of the PROJECT Create action with starting point, environment strategy, and new project name controls.
    :align: center
    :class: diagram-panel diagram-wide

--- a/docs/source/execute-help.rst
+++ b/docs/source/execute-help.rst
@@ -16,7 +16,7 @@ versioned ``app_settings.toml`` source file on first use.
 Page snapshot
 -------------
 
-.. figure:: _static/page-shots/orchestrate-page.png
+.. figure:: _static/page-shots/orchestrate-page.svg
    :alt: Screenshot of the ORCHESTRATE page showing deployment toggles and the generated install snippet.
    :align: center
    :class: diagram-panel diagram-wide

--- a/docs/source/execution-playground.rst
+++ b/docs/source/execution-playground.rst
@@ -33,7 +33,7 @@ The two apps are run through the normal AGILAB pages. The benchmark value comes
 from the fact that the same UI flow can drive two different worker families
 without changing the orchestration path.
 
-.. figure:: _static/page-shots/orchestrate-page.png
+.. figure:: _static/page-shots/orchestrate-page.svg
    :alt: ORCHESTRATE page showing deployment toggles and generated execution setup
    :align: center
    :class: page-shot

--- a/docs/source/experiment-help.rst
+++ b/docs/source/experiment-help.rst
@@ -7,7 +7,7 @@ WORKFLOW
 Page snapshot
 -------------
 
-.. figure:: _static/page-shots/workflow-page.png
+.. figure:: _static/page-shots/workflow-page.svg
    :alt: Screenshot of the WORKFLOW page with assistant controls, lab directory selectors, and dataframe selection.
    :align: center
    :class: diagram-panel diagram-wide

--- a/docs/source/explore-help.rst
+++ b/docs/source/explore-help.rst
@@ -41,7 +41,7 @@ selections and notebook selections are stored separately.
 Page snapshot
 -------------
 
-.. figure:: _static/page-shots/analysis-page.png
+.. figure:: _static/page-shots/analysis-page.svg
    :alt: Screenshot of the ANALYSIS page showing discovered views and per-project selection.
    :align: center
    :class: diagram-panel diagram-wide

--- a/test/test_agilab_widget_robot_matrix.py
+++ b/test/test_agilab_widget_robot_matrix.py
@@ -112,6 +112,7 @@ def test_default_scenarios_cover_isolated_pages_and_current_home_actions() -> No
     assert "isolated-accessibility-core-pages" not in [scenario.name for scenario in scenarios]
     assert "isolated-browser-error-core-pages" not in [scenario.name for scenario in scenarios]
     assert "isolated-all-builtins-orchestrate-smoke" not in [scenario.name for scenario in scenarios]
+    assert "isolated-all-builtins-core-render-smoke" not in [scenario.name for scenario in scenarios]
     assert "isolated-pytorch-playground-analysis" not in [scenario.name for scenario in scenarios]
     assert "isolated-above-fold-core-pages" not in [scenario.name for scenario in scenarios]
     assert "isolated-visual-baseline-core-pages" not in [scenario.name for scenario in scenarios]
@@ -168,6 +169,7 @@ def test_opt_in_mobile_and_release_evidence_scenarios_are_not_part_of_default_al
     accessibility = module.resolve_scenarios(["isolated-accessibility-core-pages"])[0]
     browser_error = module.resolve_scenarios(["isolated-browser-error-core-pages"])[0]
     all_builtin_orchestrate = module.resolve_scenarios(["isolated-all-builtins-orchestrate-smoke"])[0]
+    all_builtin_core_render = module.resolve_scenarios(["isolated-all-builtins-core-render-smoke"])[0]
     pytorch_analysis = module.resolve_scenarios(["isolated-pytorch-playground-analysis"])[0]
     above_fold = module.resolve_scenarios(["isolated-above-fold-core-pages"])[0]
     visual_baseline = module.resolve_scenarios(["isolated-visual-baseline-core-pages"])[0]
@@ -185,6 +187,7 @@ def test_opt_in_mobile_and_release_evidence_scenarios_are_not_part_of_default_al
     assert accessibility.name not in default_names
     assert browser_error.name not in default_names
     assert all_builtin_orchestrate.name not in default_names
+    assert all_builtin_core_render.name not in default_names
     assert pytorch_analysis.name not in default_names
     assert above_fold.name not in default_names
     assert visual_baseline.name not in default_names
@@ -215,6 +218,13 @@ def test_opt_in_mobile_and_release_evidence_scenarios_are_not_part_of_default_al
     assert all_builtin_orchestrate.max_action_clicks_per_page == 0
     assert all_builtin_orchestrate.browser_error_check is True
     assert all_builtin_orchestrate.page_timeout_seconds == 120.0
+    assert all_builtin_core_render.pages == "WORKFLOW,ANALYSIS"
+    assert all_builtin_core_render.apps_pages == "none"
+    assert all_builtin_core_render.runtime_isolation == "isolated"
+    assert all_builtin_core_render.action_button_policy == "trial"
+    assert all_builtin_core_render.max_action_clicks_per_page == 0
+    assert all_builtin_core_render.browser_error_check is True
+    assert all_builtin_core_render.page_timeout_seconds == 120.0
     assert pytorch_analysis.apps == "pytorch_playground_project"
     assert pytorch_analysis.pages == "ANALYSIS"
     assert pytorch_analysis.required_text == "PyTorch Playground,Refresh evidence,Synced RUN snippet,Settings"

--- a/test/test_ui_robot_action_contract.py
+++ b/test/test_ui_robot_action_contract.py
@@ -77,6 +77,14 @@ def test_ui_robot_action_contract_passes_for_current_ui_surface() -> None:
     assert actions_by_label["Reset"]["disposition"] == "trial-only"
     assert actions_by_label["Train / refresh"]["disposition"] == "trial-only"
     assert payload["summary"]["unused_disposition_count"] == 0
+    # Every explicit (non selected-click) disposition must point at focused tests that exist on
+    # disk, so a deleted/renamed focused test breaks the contract instead of silently leaving a
+    # high-risk action uncovered.
+    for action in payload["actions"]:
+        if action["disposition"] in {"trial-only", "ignored"}:
+            assert action["focused_tests"], action["label"]
+            for rel_path in action["focused_tests"]:
+                assert (module.REPO_ROOT / rel_path).is_file(), rel_path
 
 
 def test_ui_robot_action_contract_load_module_rejects_missing_spec(monkeypatch) -> None:
@@ -165,7 +173,11 @@ st.button("Reset project")
 def test_ui_robot_action_contract_rejects_empty_explicit_reason(tmp_path: Path, monkeypatch) -> None:
     module = _load_module()
     _patch_fake_runtime(monkeypatch, module)
-    monkeypatch.setattr(module, "EXPLICIT_ACTION_DISPOSITIONS", {"Delete": ("trial-only", "")})
+    monkeypatch.setattr(
+        module,
+        "EXPLICIT_ACTION_DISPOSITIONS",
+        {"Delete": ("trial-only", "", ("test/test_project_sidebar_support.py",))},
+    )
     _write_page(
         tmp_path,
         """
@@ -183,6 +195,99 @@ st.button("Delete")
             "kind": "missing_action_reason",
             "label": "Delete",
             "detail": "trial-only action must include a non-empty reason",
+            "path": str(tmp_path / "page.py"),
+            "line": 4,
+        }
+    ]
+
+
+def test_ui_robot_action_contract_rejects_missing_focused_test(tmp_path: Path, monkeypatch) -> None:
+    module = _load_module()
+    _patch_fake_runtime(monkeypatch, module)
+    monkeypatch.setattr(
+        module,
+        "EXPLICIT_ACTION_DISPOSITIONS",
+        {"Delete": ("trial-only", "covered elsewhere", ("test/test_does_not_exist.py",))},
+    )
+    _write_page(
+        tmp_path,
+        """
+import streamlit as st
+
+st.button("Delete")
+""",
+    )
+
+    payload = module.evaluate_contract((tmp_path,))
+
+    assert payload["success"] is False
+    assert payload["issues"] == [
+        {
+            "kind": "missing_focused_test",
+            "label": "Delete",
+            "detail": (
+                "trial-only action references focused tests that do not exist: "
+                "test/test_does_not_exist.py"
+            ),
+            "path": str(tmp_path / "page.py"),
+            "line": 4,
+        }
+    ]
+
+
+def test_ui_robot_action_contract_accepts_absolute_focused_test(
+    tmp_path: Path, monkeypatch
+) -> None:
+    module = _load_module()
+    _patch_fake_runtime(monkeypatch, module)
+    focused = tmp_path / "test_delete_action.py"
+    focused.write_text("def test_delete_action():\n    assert True\n", encoding="utf-8")
+    monkeypatch.setattr(
+        module,
+        "EXPLICIT_ACTION_DISPOSITIONS",
+        {"Delete": ("trial-only", "covered by temp focused test", (str(focused),))},
+    )
+    _write_page(
+        tmp_path,
+        """
+import streamlit as st
+
+st.button("Delete")
+""",
+    )
+
+    payload = module.evaluate_contract((tmp_path,))
+
+    assert payload["success"] is True
+
+
+def test_ui_robot_action_contract_rejects_disposition_without_focused_test(
+    tmp_path: Path, monkeypatch
+) -> None:
+    module = _load_module()
+    _patch_fake_runtime(monkeypatch, module)
+    monkeypatch.setattr(
+        module,
+        "EXPLICIT_ACTION_DISPOSITIONS",
+        {"Delete": ("trial-only", "covered elsewhere", ())},
+    )
+    _write_page(
+        tmp_path,
+        """
+import streamlit as st
+
+st.button("Delete")
+""",
+    )
+
+    payload = module.evaluate_contract((tmp_path,))
+
+    assert payload["success"] is False
+    assert payload["issues"] == [
+        {
+            "kind": "missing_focused_test",
+            "label": "Delete",
+            "detail": "trial-only action must name at least one focused test that exercises its behavior",
             "path": str(tmp_path / "page.py"),
             "line": 4,
         }

--- a/test/test_ui_robot_coverage_contract.py
+++ b/test/test_ui_robot_coverage_contract.py
@@ -21,6 +21,10 @@ def _load_module():
     return module
 
 
+def _all_classified_apps_pages(module) -> list[str]:
+    return [*module.BROWSER_ASSERTED_APPS_PAGES, *module.APPS_PAGE_RENDER_ONLY_DISPOSITIONS]
+
+
 def test_ui_robot_coverage_contract_passes_for_current_matrix() -> None:
     module = _load_module()
 
@@ -228,6 +232,7 @@ def test_ui_robot_coverage_contract_accepts_explicit_full_app_profile(monkeypatc
         parse_csv=lambda value: [part.strip() for part in str(value).split(",") if part.strip()],
         _normalized_label=lambda value: str(value).strip().lower(),
         public_builtin_apps=lambda: [SimpleNamespace(name=name) for name in module.REQUIRED_DEMO_UI_APPS],
+        public_apps_pages=lambda: [SimpleNamespace(name=name) for name in _all_classified_apps_pages(module)],
         configured_apps_pages_for_app=lambda _app: [
             SimpleNamespace(name=name) for name in module.REQUIRED_DEMO_UI_PAGES
         ],
@@ -344,6 +349,7 @@ def test_ui_robot_coverage_contract_reports_hf_first_proof_gaps(monkeypatch) -> 
         parse_csv=lambda value: [part.strip() for part in str(value).split(",") if part.strip()],
         _normalized_label=lambda value: str(value).strip().lower(),
         public_builtin_apps=lambda: [SimpleNamespace(name="flight_telemetry_project")],
+        public_apps_pages=lambda: [SimpleNamespace(name=name) for name in _all_classified_apps_pages(module)],
         configured_apps_pages_for_app=lambda _app: [],
     )
     matrix = SimpleNamespace(
@@ -446,6 +452,7 @@ def test_ui_robot_coverage_contract_reports_empty_public_app_inventory(monkeypat
         parse_csv=lambda value: [],
         _normalized_label=lambda value: str(value).strip().lower(),
         public_builtin_apps=lambda: [],
+        public_apps_pages=lambda: [SimpleNamespace(name=name) for name in _all_classified_apps_pages(module)],
         configured_apps_pages_for_app=lambda _app: [],
     )
     matrix = SimpleNamespace(DEFAULT_SCENARIOS={}, ALL_SCENARIOS={}, OPT_IN_SCENARIOS={})
@@ -568,6 +575,7 @@ def test_ui_robot_coverage_contract_reports_matrix_and_pytorch_gaps(monkeypatch,
         parse_csv=lambda value: [part.strip() for part in str(value).split(",") if part.strip()],
         _normalized_label=lambda value: str(value).strip().lower(),
         public_builtin_apps=lambda: [app],
+        public_apps_pages=lambda: [SimpleNamespace(name=name) for name in _all_classified_apps_pages(module)],
         configured_apps_pages_for_app=lambda _app: [route],
     )
     matrix = SimpleNamespace(
@@ -648,5 +656,76 @@ def test_ui_robot_coverage_contract_reports_matrix_and_pytorch_gaps(monkeypatch,
     assert any(
         detail.startswith("public proof scenarios are missing documented demo routes:")
         and "notebook-migration-proof" in detail
+        for detail in details
+    )
+
+
+def test_apps_page_coverage_accepts_classified_inventory() -> None:
+    module = _load_module()
+
+    public_views = _all_classified_apps_pages(module)
+    assert module.apps_page_coverage_issues(public_views) == []
+
+
+def test_apps_page_coverage_render_only_focused_tests_exist() -> None:
+    module = _load_module()
+
+    for view, (reason, focused_test) in module.APPS_PAGE_RENDER_ONLY_DISPOSITIONS.items():
+        assert reason.strip(), view
+        assert (module.REPO_ROOT / focused_test).is_file(), focused_test
+
+
+def test_apps_page_coverage_flags_unclassified_view() -> None:
+    module = _load_module()
+
+    issues = module.apps_page_coverage_issues([*_all_classified_apps_pages(module), "view_brand_new"])
+    details = [issue.detail for issue in issues]
+
+    assert any("view_brand_new is neither browser-asserted" in detail for detail in details)
+
+
+def test_apps_page_coverage_flags_missing_focused_test(monkeypatch) -> None:
+    module = _load_module()
+    monkeypatch.setattr(
+        module,
+        "APPS_PAGE_RENDER_ONLY_DISPOSITIONS",
+        {"view_ghost": ("renders only with seeded data", "test/test_view_ghost_missing.py")},
+    )
+
+    issues = module.apps_page_coverage_issues([*module.BROWSER_ASSERTED_APPS_PAGES, "view_ghost"])
+    details = [issue.detail for issue in issues]
+
+    assert any(
+        "view_ghost render-only disposition references a focused test that does not exist" in detail
+        for detail in details
+    )
+
+
+def test_apps_page_coverage_accepts_absolute_focused_test(tmp_path: Path, monkeypatch) -> None:
+    module = _load_module()
+    focused = tmp_path / "test_view_absolute.py"
+    focused.write_text("def test_view_absolute():\n    assert True\n", encoding="utf-8")
+    monkeypatch.setattr(
+        module,
+        "APPS_PAGE_RENDER_ONLY_DISPOSITIONS",
+        {"view_absolute": ("renders only with seeded data", str(focused))},
+    )
+
+    issues = module.apps_page_coverage_issues([*module.BROWSER_ASSERTED_APPS_PAGES, "view_absolute"])
+
+    assert issues == []
+
+
+def test_apps_page_coverage_flags_stale_disposition() -> None:
+    module = _load_module()
+
+    # A classified view that is no longer part of the public inventory must be reported.
+    public_views = [v for v in _all_classified_apps_pages(module) if v != "view_maps_3d"]
+    issues = module.apps_page_coverage_issues(public_views)
+    details = [issue.detail for issue in issues]
+
+    assert any(
+        detail.startswith("apps-page dispositions reference views that no longer exist:")
+        and "view_maps_3d" in detail
         for detail in details
     )

--- a/test/test_workflow_parity.py
+++ b/test/test_workflow_parity.py
@@ -431,6 +431,8 @@ def test_profile_commands_cover_expected_coverage_and_docs_contracts() -> None:
             "isolated-project-import-sidebar",
             "isolated-project-rename-sidebar",
             "isolated-settings-page",
+            "isolated-all-builtins-orchestrate-smoke",
+            "isolated-all-builtins-core-render-smoke",
         },
         "state": {
             "isolated-fresh-session-core-pages",

--- a/tools/agent_workflows.md
+++ b/tools/agent_workflows.md
@@ -48,6 +48,13 @@ Use the short repo contract in [AGENT_CONVENTIONS.md](../AGENT_CONVENTIONS.md)
 for local coding agents with smaller context windows. Use [AGENTS.md](../AGENTS.md)
 for the full AGILAB runbook when the task touches risky surfaces.
 
+When coding through a terminal agent, AGILAB recommends launching that agent
+through Tokki when it is available. Tokki keeps context compact, digests noisy
+terminal output, records session metadata, and exposes token-savings evidence.
+It is an efficiency and observability layer for agent sessions; the AGILAB
+validation source of truth remains `tools/impact_validate.py`, `./dev`, and the
+workflow-parity profiles.
+
 Use [AGENT_LEARNINGS.md](../AGENT_LEARNINGS.md) only for reusable corrections:
 when a user, reviewer, or failed validation exposes a repeated agent behavior
 not already covered by the runbooks, add one concrete rule or tighten an

--- a/tools/agilab_widget_robot.py
+++ b/tools/agilab_widget_robot.py
@@ -59,6 +59,14 @@ PAGE_READY_POLL_MS = 150
 PAGE_READY_STABILIZE_MS = 100
 WIDGET_READY_POLL_MS = 150
 ACTION_OUTCOME_POLL_MS = 100
+# Short Playwright timeouts for "is it on screen right now?" probes that run inside polling
+# loops. They must stay small so a missing element does not stall the loop for seconds.
+LOCATOR_VISIBILITY_TIMEOUT_MS = 500
+BODY_TEXT_PROBE_TIMEOUT_MS = 1000
+# Substring (lower-cased) of the AGILAB boot spinner copy rendered by
+# ``st.spinner("Initializing environment...")`` in src/agilab/main_page.py. Readiness detection
+# keys off this text, so keep it in sync if that copy changes.
+INITIALIZING_ENV_TEXT = "initializing environment"
 ACTION_MIN_OBSERVATION_SECONDS = 1.0
 DEFAULT_TARGET_SECONDS = 1800.0
 DEFAULT_VIEWPORT_WIDTH = 1440
@@ -1815,23 +1823,38 @@ def _any_visible_locator(locator: Any, *, timeout_ms: float = 100.0, limit: int 
     try:
         count = locator.count()
     except Exception:
+        logger.debug("_any_visible_locator: count() failed; treating as not visible", exc_info=True)
         return False
     for index in range(min(count, limit)):
         try:
             if locator.nth(index).is_visible(timeout=timeout_ms):
                 return True
         except Exception:
+            logger.debug("_any_visible_locator: is_visible() failed at index %d", index, exc_info=True)
             continue
     return False
 
 
 def _initializing_environment_visible(page: Any) -> bool:
+    # The boot spinner renders inside the Streamlit stSpinner testid; scope the text match to it
+    # so the check stays tied to the real element rather than scanning arbitrary body copy.
     try:
-        locator = page.get_by_text(re.compile("initializing environment", re.IGNORECASE))
+        spinner = page.locator("[data-testid='stSpinner']").get_by_text(
+            re.compile(INITIALIZING_ENV_TEXT, re.IGNORECASE)
+        )
+        if _any_visible_locator(spinner):
+            return True
     except Exception:
+        logger.debug("_initializing_environment_visible: scoped spinner probe failed", exc_info=True)
+    try:
+        locator = page.get_by_text(re.compile(INITIALIZING_ENV_TEXT, re.IGNORECASE))
+    except Exception:
+        logger.debug("_initializing_environment_visible: get_by_text failed; falling back to body text", exc_info=True)
         try:
-            return "initializing environment" in page.locator("body").inner_text(timeout=1000).lower()
+            body_text = page.locator("body").inner_text(timeout=BODY_TEXT_PROBE_TIMEOUT_MS).lower()
+            return INITIALIZING_ENV_TEXT in body_text
         except Exception:
+            logger.debug("_initializing_environment_visible: body text probe failed", exc_info=True)
             return False
     return _any_visible_locator(locator)
 
@@ -1842,6 +1865,7 @@ def wait_for_page_ready(page: Any, *, timeout_ms: float) -> None:  # pragma: no 
         try:
             spinner_visible = _any_visible_locator(page.locator("[data-testid='stSpinner']"))
         except Exception:
+            logger.debug("wait_for_page_ready: spinner probe failed; assuming not visible", exc_info=True)
             spinner_visible = False
         if not spinner_visible and not _initializing_environment_visible(page):
             page.wait_for_timeout(PAGE_READY_STABILIZE_MS)
@@ -1859,6 +1883,9 @@ def wait_for_widgets_ready(page: Any, *, page_name: str, timeout_ms: float) -> i
             page.evaluate(OPEN_EXPANDERS_JS)
             count = len(page.evaluate(WIDGET_COLLECTOR_JS))
         except Exception:
+            # A persistent failure here (e.g. the widget collector JS throwing every poll) would
+            # otherwise surface downstream as a confusing "0 widgets" timeout; log the root cause.
+            logger.debug("wait_for_widgets_ready: widget collection failed for %s", page_name, exc_info=True)
             count = 0
         if count >= minimum and count == last_count:
             stable_seen += 1
@@ -2267,7 +2294,7 @@ def _capture_failure_bundle_screenshot(  # pragma: no cover - live browser path
 
 def _page_text_snapshot(page: Any) -> tuple[str, str | None]:  # pragma: no cover - live browser path
     try:
-        text = page.locator("body").inner_text(timeout=1000)
+        text = page.locator("body").inner_text(timeout=BODY_TEXT_PROBE_TIMEOUT_MS)
     except Exception as exc:
         return "", _short_detail(str(exc))
     return _limited_text(text), None
@@ -3390,7 +3417,7 @@ def _button_locator_by_label(page: Any, label: str) -> Any | None:  # pragma: no
     for index in range(min(count, 20)):
         try:
             candidate = locator.nth(index)
-            if candidate.is_visible(timeout=500):
+            if candidate.is_visible(timeout=LOCATOR_VISIBILITY_TIMEOUT_MS):
                 return candidate
         except Exception:
             logger.debug("Unable to inspect button candidate %s for label %r", index, label, exc_info=True)
@@ -3533,8 +3560,11 @@ def _visible_exception_detail(page: Any) -> str | None:  # pragma: no cover - li
     """Backward-compatible alias for older tests and call sites."""
     try:
         exceptions = page.locator("[data-testid='stException']")
-        if exceptions.count() > 0 and exceptions.first.is_visible(timeout=500):
-            return _short_detail(exceptions.first.inner_text(timeout=500) or "Streamlit exception rendered")
+        if exceptions.count() > 0 and exceptions.first.is_visible(timeout=LOCATOR_VISIBILITY_TIMEOUT_MS):
+            return _short_detail(
+                exceptions.first.inner_text(timeout=LOCATOR_VISIBILITY_TIMEOUT_MS)
+                or "Streamlit exception rendered"
+            )
     except Exception:
         logger.debug("Unable to inspect rendered Streamlit exception", exc_info=True)
     return _visible_streamlit_issue_detail(page)

--- a/tools/agilab_widget_robot_matrix.py
+++ b/tools/agilab_widget_robot_matrix.py
@@ -343,6 +343,25 @@ OPT_IN_SCENARIOS: dict[str, RobotScenario] = {
         max_action_clicks_per_page=0,
         browser_error_check=True,
     ),
+    "isolated-all-builtins-core-render-smoke": RobotScenario(
+        name="isolated-all-builtins-core-render-smoke",
+        description=(
+            "Fast all-builtins WORKFLOW + ANALYSIS render smoke: render the remaining "
+            "core workflow pages for every built-in app with an isolated runtime, no "
+            "action callbacks, and explicit browser error capture. Complements the "
+            "ORCHESTRATE smoke so a per-app regression on WORKFLOW or ANALYSIS is caught, "
+            "not just on the default app."
+        ),
+        pages="WORKFLOW,ANALYSIS",
+        apps_pages="none",
+        runtime_isolation="isolated",
+        action_button_policy="trial",
+        action_timeout_seconds=15.0,
+        page_timeout_seconds=120.0,
+        target_seconds=900.0,
+        max_action_clicks_per_page=0,
+        browser_error_check=True,
+    ),
     "isolated-browser-history": RobotScenario(
         name="isolated-browser-history",
         description=(

--- a/tools/ui_robot_action_contract.py
+++ b/tools/ui_robot_action_contract.py
@@ -8,7 +8,7 @@ import ast
 import importlib.util
 import json
 import sys
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
@@ -34,90 +34,118 @@ EXCLUDED_PATH_PARTS = {
 }
 
 
-EXPLICIT_ACTION_DISPOSITIONS: Mapping[str, tuple[str, str]] = {
+# Each disposition is (disposition, reason, focused_tests). ``focused_tests`` lists the
+# repo-relative pytest files that actually exercise the action's behavior. Generic robots
+# deliberately do not fire these actions (they mutate state, hit external services, or are
+# only reachable behind conditional flows), so the disposition is only honest if the focused
+# tests it points at still exist. ``evaluate_contract`` enforces that every listed path is
+# present on disk, closing the gap where a deleted/renamed focused test would silently leave
+# a high-risk action with zero coverage and a passing contract.
+EXPLICIT_ACTION_DISPOSITIONS: Mapping[str, tuple[str, str, tuple[str, ...]]] = {
     "Add argument": (
         "trial-only",
         "mutates the ORCHESTRATE argument editor; covered by focused page tests, not fired by generic robots",
+        ("test/test_orchestrate_page_support.py",),
     ),
     "Apply": (
         "trial-only",
         "applies page-local user choices; generic robots verify visibility without firing the callback",
+        ("test/test_ui_pages.py",),
     ),
     "Build cluster plan": (
         "trial-only",
         "writes advisory LAN discovery output; focused cluster tests cover the planning logic without mutating user settings",
+        ("test/test_orchestrate_cluster.py",),
     ),
     "Clear LAN cache": (
         "trial-only",
         "clears local discovery cache; safe to render, but not a selected release action",
+        ("test/test_orchestrate_cluster.py",),
     ),
     "Create": (
         "trial-only",
         "creates project or analysis objects; PROJECT/ANALYSIS robots probe the control without mutating state",
+        ("test/test_project_sidebar_support.py",),
     ),
     "Delete": (
         "trial-only",
         "destructive project-level delete action; focused tests cover confirmation behavior",
+        ("test/test_project_sidebar_support.py",),
     ),
     "Export promotion decision": (
         "trial-only",
         "apps-page export side effect is covered by page-specific tests and visual robots",
+        ("test/test_view_release_decision.py",),
     ),
     "Import": (
         "trial-only",
         "project import is probed through PROJECT import scenarios without firing archive import",
+        ("test/test_project_sidebar_support.py",),
     ),
     "Install agi-app": (
         "ignored",
         "installs user-selected PyPI code and requires explicit operator trust; package preflight tests cover validation",
+        ("test/test_ui_pages.py",),
     ),
     "Overwrite": (
         "ignored",
         "conditional conflict-resolution action that only appears after an import conflict",
+        ("test/test_project_clone_policy.py",),
     ),
     "Rebuild Universal Offline knowledge base": (
         "ignored",
         "requires a local knowledge-base rebuild outside the deterministic UI robot environment",
+        ("test/test_pipeline_ai.py",),
     ),
     "Reset": (
         "trial-only",
         "clears the PyTorch playground local training state; focused playground tests cover state reset behavior",
+        ("test/test_pytorch_playground_app.py",),
     ),
     "Rename": (
         "trial-only",
         "project rename is probed through PROJECT rename scenarios without mutating the project",
+        ("test/test_project_sidebar_support.py",),
     ),
     "Run instant demo": (
         "trial-only",
         "runs page-local PyTorch training; focused playground tests cover state and evidence without making generic robots train",
+        ("test/test_pytorch_playground_app.py",),
     ),
     "Save .env": (
         "ignored",
         "writes local environment configuration and is covered by env-editor helper tests",
+        ("test/test_about_agilab_helpers.py",),
     ),
     "Save and retry": (
         "ignored",
         "writes local environment configuration and depends on user-provided settings",
+        ("test/test_about_agilab_helpers.py",),
     ),
     "Save classroom uploads": (
         "trial-only",
         "writes classroom intake files; focused TeSciA tests cover upload handling without mutating generic robot state",
+        ("test/test_tescia_diagnostic_project.py",),
     ),
     "Start GPT-OSS server": (
         "ignored",
         "starts an external local service and is not deterministic in CI robots",
+        ("test/test_pipeline_ai.py",),
     ),
     "Train / refresh": (
         "trial-only",
         "runs page-local PyTorch training; focused playground tests cover state and evidence without making generic robots train",
+        ("test/test_pytorch_playground_app.py",),
     ),
     "Undo last delete": (
         "trial-only",
         "stateful recovery action that appears only after selected delete-output flows",
+        ("test/test_orchestrate_execute.py",),
     ),
     "Update key": (
         "ignored",
         "updates local secret configuration and is covered by provider-form tests",
+        ("test/test_pipeline_openai.py", "test/test_pipeline_mistral.py"),
     ),
 }
 
@@ -139,6 +167,7 @@ class ActionDisposition:
     reason: str
     selected_scenarios: list[str]
     occurrences: list[ActionOccurrence]
+    focused_tests: list[str] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
@@ -277,11 +306,24 @@ def _selected_action_scenarios(widget_robot: Any, matrix: Any) -> dict[str, list
     return scenarios
 
 
-def _explicit_dispositions(widget_robot: Any) -> dict[str, tuple[str, str, str]]:
+def _explicit_dispositions(
+    widget_robot: Any,
+) -> dict[str, tuple[str, str, str, tuple[str, ...]]]:
     return {
-        widget_robot._normalized_label(label): (label, disposition, reason)
-        for label, (disposition, reason) in EXPLICIT_ACTION_DISPOSITIONS.items()
+        widget_robot._normalized_label(label): (label, disposition, reason, tuple(focused_tests))
+        for label, (disposition, reason, focused_tests) in EXPLICIT_ACTION_DISPOSITIONS.items()
     }
+
+
+def _missing_focused_tests(focused_tests: Sequence[str]) -> list[str]:
+    missing: list[str] = []
+    for rel_path in focused_tests:
+        candidate = Path(rel_path)
+        if not candidate.is_absolute():
+            candidate = REPO_ROOT / candidate
+        if not candidate.is_file():
+            missing.append(rel_path)
+    return missing
 
 
 def _is_high_risk_action(widget_robot: Any, occurrence: ActionOccurrence) -> bool:
@@ -341,14 +383,40 @@ def evaluate_contract(source_roots: Sequence[Path] = DEFAULT_SOURCE_ROOTS) -> di
                 )
             )
             continue
-        _raw_label, disposition, reason = explicit_entry
+        _raw_label, disposition, reason, focused_tests = explicit_entry
+        first = label_occurrences[0]
         if not reason.strip():
-            first = label_occurrences[0]
             issues.append(
                 ActionIssue(
                     kind="missing_action_reason",
                     label=label,
                     detail=f"{disposition} action must include a non-empty reason",
+                    path=first.path,
+                    line=first.line,
+                )
+            )
+            continue
+        if not focused_tests:
+            issues.append(
+                ActionIssue(
+                    kind="missing_focused_test",
+                    label=label,
+                    detail=f"{disposition} action must name at least one focused test that exercises its behavior",
+                    path=first.path,
+                    line=first.line,
+                )
+            )
+            continue
+        missing_tests = _missing_focused_tests(focused_tests)
+        if missing_tests:
+            issues.append(
+                ActionIssue(
+                    kind="missing_focused_test",
+                    label=label,
+                    detail=(
+                        f"{disposition} action references focused tests that do not exist: "
+                        f"{', '.join(missing_tests)}"
+                    ),
                     path=first.path,
                     line=first.line,
                 )
@@ -362,12 +430,19 @@ def evaluate_contract(source_roots: Sequence[Path] = DEFAULT_SOURCE_ROOTS) -> di
                 reason=reason,
                 selected_scenarios=[],
                 occurrences=label_occurrences,
+                focused_tests=list(focused_tests),
             )
         )
 
     unused_dispositions = [
-        {"label": raw_label, "normalized_label": normalized_label, "disposition": disposition, "reason": reason}
-        for normalized_label, (raw_label, disposition, reason) in sorted(explicit.items())
+        {
+            "label": raw_label,
+            "normalized_label": normalized_label,
+            "disposition": disposition,
+            "reason": reason,
+            "focused_tests": list(focused_tests),
+        }
+        for normalized_label, (raw_label, disposition, reason, focused_tests) in sorted(explicit.items())
         if normalized_label not in by_label
     ]
     return {

--- a/tools/ui_robot_coverage_contract.py
+++ b/tools/ui_robot_coverage_contract.py
@@ -90,6 +90,72 @@ REQUIRED_DEMO_PROOF_SCENARIOS = (
     "service-mode-preview-proof",
 )
 
+# Apps-pages whose content is asserted in the browser by a robot scenario. ``view_app_ui`` is
+# reached through the PyTorch analysis required-links contract; the rest are the HF first-proof
+# pages swept with seeded demo artifacts.
+BROWSER_ASSERTED_APPS_PAGES = REQUIRED_HF_FIRST_PROOF_PAGES + ("view_app_ui",)
+
+# The remaining public apps-pages render their meaningful content only after data-dependent
+# ``st.stop()`` guards pass, so the generic widget robot (which does not seed every view's
+# artifacts) deliberately performs render + Streamlit-exception checks only. Each entry names the
+# focused test that asserts the view's content against seeded fixtures. ``evaluate_contract``
+# enforces that every public view is either browser-asserted or listed here with a test that
+# exists, so a new view cannot ship with zero coverage and a dropped focused test is caught.
+APPS_PAGE_RENDER_ONLY_DISPOSITIONS: dict[str, tuple[str, str]] = {
+    "view_autoencoder_latentspace": (
+        "latent-space plots render only with a trained autoencoder artifact",
+        "test/test_view_autoencoder_latentspace.py",
+    ),
+    "view_barycentric": (
+        "barycentric projection renders only with seeded routing artifacts",
+        "test/test_view_barycentric.py",
+    ),
+    "view_data_io_decision": (
+        "decision panels render only after the artifact directory and pipeline exist",
+        "test/test_view_data_io_decision.py",
+    ),
+    "view_inference_analysis": (
+        "diagnostics render only when an active project and inference runs are passed in",
+        "test/test_view_inference_analysis.py",
+    ),
+    "view_live_artifacts": (
+        "manifest candidates render only when live artifacts are present",
+        "test/test_view_live_artifacts.py",
+    ),
+    "view_maps_3d": (
+        "3D map renders only with seeded geospatial artifacts",
+        "test/test_view_maps_3d.py",
+    ),
+    "view_maps_network": (
+        "network topology renders only after seeded relay artifacts pass the data guards",
+        "test/test_view_maps_network.py",
+    ),
+    "view_queue_resilience": (
+        "queue occupancy plots render only after the artifact directory guards pass",
+        "test/test_view_queue_resilience.py",
+    ),
+    "view_relay_resilience": (
+        "run comparison renders only after seeded relay artifacts pass the data guards",
+        "test/test_view_relay_resilience.py",
+    ),
+    "view_routing_model_comparison": (
+        "model summary renders only with seeded routing comparison artifacts",
+        "test/test_view_routing_model_comparison.py",
+    ),
+    "view_scenario_cockpit": (
+        "scenario comparison renders only after the artifact directory guards pass",
+        "test/test_view_scenario_cockpit.py",
+    ),
+    "view_shap_explanation": (
+        "feature attributions render only with a seeded SHAP explanation artifact",
+        "test/test_view_shap_explanation.py",
+    ),
+    "view_training_analysis": (
+        "scalar/training plots render only with seeded training-run artifacts",
+        "test/test_view_training_analysis.py",
+    ),
+}
+
 
 @dataclass(frozen=True)
 class CoverageIssue:
@@ -172,6 +238,49 @@ def _argv_value(argv: Sequence[str], option: str) -> str:
 
 def _argv_values(argv: Sequence[str], option: str) -> list[str]:
     return [argv[index + 1] for index, value in enumerate(argv[:-1]) if value == option]
+
+
+def apps_page_coverage_issues(public_views: Sequence[str]) -> list[CoverageIssue]:
+    """Every public apps-page must be browser-asserted or carry a render-only disposition whose
+    focused test exists; stale dispositions for removed views are also flagged."""
+    issues: list[CoverageIssue] = []
+    classified = set(BROWSER_ASSERTED_APPS_PAGES) | set(APPS_PAGE_RENDER_ONLY_DISPOSITIONS)
+    for view in sorted(set(public_views)):
+        if view in BROWSER_ASSERTED_APPS_PAGES:
+            continue
+        disposition = APPS_PAGE_RENDER_ONLY_DISPOSITIONS.get(view)
+        if disposition is None:
+            issues.append(
+                CoverageIssue(
+                    "apps_page_coverage",
+                    f"{view} is neither browser-asserted nor given a render-only disposition with a focused test",
+                )
+            )
+            continue
+        reason, focused_test = disposition
+        if not reason.strip():
+            issues.append(
+                CoverageIssue("apps_page_coverage", f"{view} render-only disposition needs a non-empty reason")
+            )
+        focused_path = Path(focused_test)
+        if not focused_path.is_absolute():
+            focused_path = REPO_ROOT / focused_path
+        if not focused_path.is_file():
+            issues.append(
+                CoverageIssue(
+                    "apps_page_coverage",
+                    f"{view} render-only disposition references a focused test that does not exist: {focused_test}",
+                )
+            )
+    stale = sorted(classified - set(public_views))
+    if stale:
+        issues.append(
+            CoverageIssue(
+                "apps_page_coverage",
+                "apps-page dispositions reference views that no longer exist: " + ", ".join(stale),
+            )
+        )
+    return issues
 
 
 def evaluate_contract() -> dict[str, Any]:
@@ -296,6 +405,9 @@ def evaluate_contract() -> dict[str, Any]:
                 "first-proof HF profile is missing public demo pages: " + ", ".join(missing_hf_pages),
             )
         )
+
+    public_apps_pages = sorted({route.name for route in widget_robot.public_apps_pages()})
+    issues.extend(apps_page_coverage_issues(public_apps_pages))
 
     scenario_by_name = {scenario.name: scenario for scenario in all_scenarios}
     hf_robot_scenarios: dict[str, dict[str, list[str]]] = {}

--- a/tools/workflow_parity.py
+++ b/tools/workflow_parity.py
@@ -64,6 +64,8 @@ UI_ROBOT_MATRIX_SHARDS = (
             "isolated-project-import-sidebar",
             "isolated-project-rename-sidebar",
             "isolated-settings-page",
+            "isolated-all-builtins-orchestrate-smoke",
+            "isolated-all-builtins-core-render-smoke",
         ),
     ),
     (


### PR DESCRIPTION
## Summary
- enforce focused-test evidence for trial-only and ignored UI robot action dispositions
- require apps-page robot coverage to be either browser-asserted or explicitly render-only with a focused test
- add all-builtins WORKFLOW/ANALYSIS robot breadth to the local and GitHub robot matrix parity surfaces
- refresh token-light SVG page-shot docs from the canonical docs source and document Tokki terminal-agent guidance
- add an agent-learning rule to choose and act on clear token-saving defaults instead of ending with a broad clarification menu

## Validation
- ./dev scope
- sync_docs_source.py --verify-stamp
- agent_instruction_contract.py --check
- ui_robot_action_contract.py --json
- ui_robot_coverage_contract.py --json
- ruff on touched robot/parity files
- focused robot/parity pytest slice
- broad robot pytest suite
- workflow_parity.py --profile docs
- git diff --check origin/main...HEAD