### PR TITLE
[codex] Fix worker build argv path serialization

### DIFF
--- a/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/build.py
+++ b/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/build.py
@@ -15,6 +15,7 @@ from zipfile import ZipFile
 import argparse
 import logging
 import subprocess
+import warnings
 from collections.abc import Mapping
 
 try:
@@ -24,8 +25,8 @@ except ImportError:  # pragma: no cover - script execution fallback
 
 bootstrap_core_source_paths(source_file=__file__)
 
-from setuptools import setup, find_packages, Extension, SetuptoolsDeprecationWarning
-from Cython.Build import cythonize
+from setuptools import setup, find_packages, Extension, SetuptoolsDeprecationWarning  # noqa: E402
+from Cython.Build import cythonize  # noqa: E402
 
 
 def _inject_shared_site_packages(*, source_file: str | Path = __file__) -> None:
@@ -34,11 +35,11 @@ def _inject_shared_site_packages(*, source_file: str | Path = __file__) -> None:
 
 _inject_shared_site_packages()
 
-from agi_env import AgiEnv
-import warnings
+from agi_env import AgiEnv  # noqa: E402
+
 warnings.filterwarnings("ignore", category=SetuptoolsDeprecationWarning)
 
-from agi_env.agi_logger import AgiLogger
+from agi_env.agi_logger import AgiLogger  # noqa: E402
 
 logger = AgiLogger.get_logger(__name__)
 
@@ -581,9 +582,10 @@ def _build_setuptools_argv(
     command: str,
     home_abs: str | Path,
     out_arg: str,
-) -> list[object]:
+) -> list[str]:
     flag = "-b" if command == "build_ext" else "-d"
-    return [prog_name, command, flag, Path(home_abs) / out_arg / "dist"]
+    output_dir = Path(home_abs) / out_arg / "dist"
+    return [prog_name, command, flag, str(output_dir)]
 
 
 def _ensure_build_readme(readme_path: Path | str = "README.md") -> Path:
@@ -906,6 +908,9 @@ def _prepare_main_execution(
     prepare_setup_artifacts_fn=None,
     set_argv_fn=None,
 ) -> tuple[object, str, str, list, list[Path]]:
+    def _set_sys_argv(argv: list[str]) -> None:
+        sys.argv = argv
+
     if build_env_cls is None:
         build_env_cls = AgiEnv
     if resolve_build_output_fn is None:
@@ -917,7 +922,7 @@ def _prepare_main_execution(
     if prepare_setup_artifacts_fn is None:
         prepare_setup_artifacts_fn = _prepare_setup_artifacts
     if set_argv_fn is None:
-        set_argv_fn = lambda argv: setattr(sys, "argv", argv)
+        set_argv_fn = _set_sys_argv
 
     verbose = 0 if quiet else 2
     env = build_env_cls(
@@ -933,14 +938,13 @@ def _prepare_main_execution(
     if cmd == "build_ext":
         prepare_build_ext_command_fn(env=env, build_dir=build_dir)
 
-    set_argv_fn(
-        build_setuptools_argv_fn(
-            prog_name=prog_name,
-            command=cmd,
-            home_abs=env.home_abs,
-            out_arg=out_arg,
-        )
+    setup_argv = build_setuptools_argv_fn(
+        prog_name=prog_name,
+        command=cmd,
+        home_abs=env.home_abs,
+        out_arg=out_arg,
     )
+    set_argv_fn([str(value) for value in setup_argv])
 
     worker_module = target_module + "_worker"
     ext_modules, links_created = prepare_setup_artifacts_fn(

--- a/src/agilab/core/test/test_agi_dispatcher_build_main_support.py
+++ b/src/agilab/core/test/test_agi_dispatcher_build_main_support.py
@@ -304,16 +304,36 @@ def test_prepare_main_execution_orchestrates_build_ext_runtime(tmp_path):
         remaining_args=["--quiet"],
         packages=["pkg_a"],
         build_env_cls=DummyEnv,
-        resolve_build_output_fn=lambda outdir, home_abs: (Path(outdir), "exports/demo_worker", "demo_worker"),
+        resolve_build_output_fn=lambda outdir, home_abs: (
+            Path(outdir),
+            "exports/demo_worker",
+            "demo_worker",
+        ),
         prepare_build_ext_command_fn=lambda **kwargs: preflight_calls.append(kwargs),
-        build_setuptools_argv_fn=lambda **kwargs: ["build.py", "build_ext", "-b", Path(kwargs["home_abs"]) / "exports/demo_worker" / "dist"],
-        prepare_setup_artifacts_fn=lambda **kwargs: (artifact_calls.append(kwargs) or (["ext_mod"], [tmp_path / "pkg_a"])),
+        build_setuptools_argv_fn=lambda **kwargs: [
+            "build.py",
+            "build_ext",
+            "-b",
+            Path(kwargs["home_abs"]) / "exports/demo_worker" / "dist",
+        ],
+        prepare_setup_artifacts_fn=lambda **kwargs: (
+            artifact_calls.append(kwargs) or (["ext_mod"], [tmp_path / "pkg_a"])
+        ),
         set_argv_fn=lambda argv: argv_calls.append(argv),
     )
 
     assert build_env_inits == [(active_app, 2)]
-    assert preflight_calls == [{"env": env, "build_dir": str(tmp_path / "exports" / "demo_worker")}]
-    assert argv_calls == [["build.py", "build_ext", "-b", tmp_path / "home" / "exports/demo_worker" / "dist"]]
+    assert preflight_calls == [
+        {"env": env, "build_dir": str(tmp_path / "exports" / "demo_worker")}
+    ]
+    assert argv_calls == [
+        [
+            "build.py",
+            "build_ext",
+            "-b",
+            str(tmp_path / "home" / "exports/demo_worker" / "dist"),
+        ]
+    ]
     assert out_arg == "exports/demo_worker"
     assert worker_module == "demo_worker_worker"
     assert ext_modules == ["ext_mod"]
@@ -356,13 +376,25 @@ def test_prepare_main_execution_skips_build_ext_preflight_for_bdist_egg(tmp_path
         build_env_cls=DummyEnv,
         resolve_build_output_fn=lambda outdir, home_abs: (Path(outdir), "dist-out", "demo"),
         prepare_build_ext_command_fn=lambda **kwargs: preflight_calls.append(kwargs),
-        build_setuptools_argv_fn=lambda **kwargs: ["build.py", "bdist_egg", "-d", Path(kwargs["home_abs"]) / "dist-out" / "dist"],
+        build_setuptools_argv_fn=lambda **kwargs: [
+            "build.py",
+            "bdist_egg",
+            "-d",
+            Path(kwargs["home_abs"]) / "dist-out" / "dist",
+        ],
         prepare_setup_artifacts_fn=lambda **kwargs: ([], [tmp_path / "pkg_link"]),
         set_argv_fn=lambda argv: argv_calls.append(argv),
     )
 
     assert preflight_calls == []
-    assert argv_calls == [["build.py", "bdist_egg", "-d", tmp_path / "home" / "dist-out" / "dist"]]
+    assert argv_calls == [
+        [
+            "build.py",
+            "bdist_egg",
+            "-d",
+            str(tmp_path / "home" / "dist-out" / "dist"),
+        ]
+    ]
     assert out_arg == "dist-out"
     assert worker_module == "demo_worker"
     assert ext_modules == []

--- a/src/agilab/core/test/test_agi_dispatcher_scripts.py
+++ b/src/agilab/core/test/test_agi_dispatcher_scripts.py
@@ -2111,12 +2111,18 @@ def test_build_setuptools_argv_handles_relative_and_absolute_out_arg(tmp_path):
         out_arg=str(tmp_path / "external" / "demo_worker"),
     )
 
-    assert relative_argv == ["build.py", "build_ext", "-b", tmp_path / "home" / "exports" / "dist"]
+    assert all(isinstance(arg, str) for arg in relative_argv + absolute_argv)
+    assert relative_argv == [
+        "build.py",
+        "build_ext",
+        "-b",
+        str(tmp_path / "home" / "exports" / "dist"),
+    ]
     assert absolute_argv == [
         "build.py",
         "bdist_egg",
         "-d",
-        tmp_path / "external" / "demo_worker" / "dist",
+        str(tmp_path / "external" / "demo_worker" / "dist"),
     ]
 
 


### PR DESCRIPTION
## Summary
- Normalize worker build setuptools argv entries to strings before assigning `sys.argv`.
- Keep delayed bootstrap imports lint-clean with explicit `E402` annotations.
- Add regressions proving helper and orchestration paths do not leak `Path` objects into argv.

## Root cause
The release-proof workflow failed on Linux with `expected string or bytes-like object, got 'PosixPath'` because the worker build helper could place a `Path` object in `sys.argv` for setuptools execution.

## Validation
- Focused argv regression tests passed.
- `./dev lint` passed for touched files.
- `./dev scope --staged` passed.
- `./dev impact` reviewed staged shared-core risk.
- Core dispatcher test slice passed.
- Inferred narrow core test slice passed with the repo import-mode-safe invocation.
- Shared-core strict typing passed.
- Fresh-source release-proof regression passed locally.