### PR TITLE
[codex] Fix app consistency audit findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ into executable, portable, evidence-backed AI applications.
 
 ## Core Flow
 
-Notebook/script → AGILAB app → controlled execution → artifacts + evidence →
+Notebook/script -> AGILAB app -> controlled execution -> artifacts + evidence ->
 notebook / MLflow / UI handoff
 
 The flow is reversible where it matters for long-term reuse: WORKFLOW can export

--- a/README.pypi.md
+++ b/README.pypi.md
@@ -183,7 +183,7 @@ agilab adoption-report
 ```
 
 `agilab dry-run` is the fast alias for `agilab first-proof --dry-run`; it
-checks only CLI/core readiness.
+verifies CLI/core readiness only.
 `agilab first-proof --json` runs the onboarding contract and writes
 `run_manifest.json` without requiring Streamlit. Add `--with-ui` only when you
 intentionally want the proof to boot the packaged Streamlit pages too.
@@ -257,6 +257,7 @@ what they need:
 | `core` extra | `agi-core`, which wires `agi-env`, `agi-node`, and `agi-cluster` for compact local/distributed runtime smoke checks. | CLI proof, source-checkout validation, notebook/API runtime, and worker-runtime development without the UI or packaged examples. |
 | `ui` extra | Streamlit UI, page helpers, portable `agi-web` Canvas2D/WebGL and React-ready UI-island contracts, pandas/network graph utilities, `agi-apps`, and the `agi-pages` provider. Promoted app and page payload packages are on PyPI; unpromoted app payloads remain release artifacts until publication is enabled. | Running the local product UI with the packaged runtime and optional public demo assets. |
 | `examples` extra | `agi-apps` app catalog/examples plus notebook/demo helper dependencies such as JupyterLab and optional plotting packages. | Running packaged notebooks, demos, learning examples, and package first-proof routes. |
+| `notebook` extra | Notebook execution helpers such as `nbclient`, `nbformat`, and `ipykernel`. | Running `agilab run notebook` to execute a local notebook and write AGILAB evidence. |
 | `pages` extra | `agi-pages` page-provider helpers without the full UI profile. | Installing or validating sidecar page-bundle discovery separately from built-in app projects. |
 | `proof` extra | Optional `cryptography` dependency for detached Ed25519 proof-capsule signatures. | Signing `.agipack` archives and verifying them against local trust policies. |
 | `agents` extra | API client dependency boundary for packaged agent workflow helpers. | Reproducible coding-agent and assistant-backed workflows. |
@@ -482,11 +483,11 @@ compatibility status, and roadmap scope live in:
 Current public evaluation summary, refreshed from the public KPI bundle:
 
 - `4.0 / 5` for ease of adoption, research experimentation, and engineering prototyping.
-- `3.0 / 5` for production readiness.
+- `3.2 / 5` for production readiness.
 - `4.2 / 5` for strategic potential.
 - Overall public evaluation, rounded category average: `3.8 / 5`.
 
-These are AI/ML workbench scores, not production MLOps claims.
+These are public experimentation-workbench scores, not production MLOps claims.
 They cover project setup, environment management, execution, and result analysis.
 The overall score is the rounded category average, not a strategic score.
 

--- a/src/agilab/apps/builtin/data_quality_gate_project/pyproject.toml
+++ b/src/agilab/apps/builtin/data_quality_gate_project/pyproject.toml
@@ -2,7 +2,11 @@
 name = "data_quality_gate_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILAB data contract and drift gate app with promotion evidence"
+readme = "README.md"
 requires-python = ">=3.11"
+authors = [
+    { name = "Jean-Pierre Morard" }
+]
 dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "streamlit>=1.58,<2"]
 
 [project.urls]

--- a/src/agilab/apps/builtin/execution_pandas_project/pyproject.toml
+++ b/src/agilab/apps/builtin/execution_pandas_project/pyproject.toml
@@ -2,8 +2,21 @@
 name = "execution_pandas_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILab execution playground using PandasWorker"
+readme = "README.md"
 requires-python = ">=3.11"
+authors = [
+    { name = "Jean-Pierre Morard" }
+]
 dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "numpy>=2.2,<3", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "streamlit>=1.58,<2"]
+
+[project.urls]
+Documentation = "https://thalesgroup.github.io/agilab"
+Source = "https://github.com/ThalesGroup/agilab/tree/main/src/agilab/apps/builtin/execution_pandas_project"
+Issues = "https://github.com/ThalesGroup/agilab/issues"
+Homepage = "https://github.com/ThalesGroup/agilab"
+Repository = "https://github.com/ThalesGroup/agilab"
+Discussions = "https://github.com/ThalesGroup/agilab/discussions"
+Changelog = "https://github.com/ThalesGroup/agilab/releases"
 
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/execution_polars_project/pyproject.toml
+++ b/src/agilab/apps/builtin/execution_polars_project/pyproject.toml
@@ -2,8 +2,21 @@
 name = "execution_polars_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILab execution playground using PolarsWorker"
+readme = "README.md"
 requires-python = ">=3.11"
+authors = [
+    { name = "Jean-Pierre Morard" }
+]
 dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "polars>=1.35,<2", "pydantic>=2.11,<2.13", "streamlit>=1.58,<2"]
+
+[project.urls]
+Documentation = "https://thalesgroup.github.io/agilab"
+Source = "https://github.com/ThalesGroup/agilab/tree/main/src/agilab/apps/builtin/execution_polars_project"
+Issues = "https://github.com/ThalesGroup/agilab/issues"
+Homepage = "https://github.com/ThalesGroup/agilab"
+Repository = "https://github.com/ThalesGroup/agilab"
+Discussions = "https://github.com/ThalesGroup/agilab/discussions"
+Changelog = "https://github.com/ThalesGroup/agilab/releases"
 
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/flight_telemetry_project/pyproject.toml
+++ b/src/agilab/apps/builtin/flight_telemetry_project/pyproject.toml
@@ -2,8 +2,21 @@
 name = "flight_telemetry_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILab example app (flight-telemetry preprocessing)"
+readme = "README.md"
 requires-python = ">=3.11"
+authors = [
+    { name = "Jean-Pierre Morard" }
+]
 dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "polars[rtcompat]>=1.35,<2", "pydantic>=2.11,<2.13", "py7zr>=1.1,<1.2", "streamlit>=1.58,<2"]
+
+[project.urls]
+Documentation = "https://thalesgroup.github.io/agilab"
+Source = "https://github.com/ThalesGroup/agilab/tree/main/src/agilab/apps/builtin/flight_telemetry_project"
+Issues = "https://github.com/ThalesGroup/agilab/issues"
+Homepage = "https://github.com/ThalesGroup/agilab"
+Repository = "https://github.com/ThalesGroup/agilab"
+Discussions = "https://github.com/ThalesGroup/agilab/discussions"
+Changelog = "https://github.com/ThalesGroup/agilab/releases"
 
 [tool.agilab]
 runtime_target = "flight_telemetry"

--- a/src/agilab/apps/builtin/minimal_app_project/pyproject.toml
+++ b/src/agilab/apps/builtin/minimal_app_project/pyproject.toml
@@ -2,8 +2,21 @@
 name = "minimal_app_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILab example app template (minimal manager + worker)"
+readme = "README.md"
 requires-python = ">=3.11"
+authors = [
+    { name = "Jean-Pierre Morard" }
+]
 dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "polars>=1.35,<2", "pydantic>=2.11,<2.13", "streamlit>=1.58,<2"]
+
+[project.urls]
+Documentation = "https://thalesgroup.github.io/agilab"
+Source = "https://github.com/ThalesGroup/agilab/tree/main/src/agilab/apps/builtin/minimal_app_project"
+Issues = "https://github.com/ThalesGroup/agilab/issues"
+Homepage = "https://github.com/ThalesGroup/agilab"
+Repository = "https://github.com/ThalesGroup/agilab"
+Discussions = "https://github.com/ThalesGroup/agilab/discussions"
+Changelog = "https://github.com/ThalesGroup/agilab/releases"
 
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/mission_decision_project/pyproject.toml
+++ b/src/agilab/apps/builtin/mission_decision_project/pyproject.toml
@@ -2,8 +2,21 @@
 name = "mission_decision_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILAB Mission Decision autonomous demo"
+readme = "README.md"
 requires-python = ">=3.11"
+authors = [
+    { name = "Jean-Pierre Morard" }
+]
 dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "streamlit>=1.58,<2"]
+
+[project.urls]
+Documentation = "https://thalesgroup.github.io/agilab"
+Source = "https://github.com/ThalesGroup/agilab/tree/main/src/agilab/apps/builtin/mission_decision_project"
+Issues = "https://github.com/ThalesGroup/agilab/issues"
+Homepage = "https://github.com/ThalesGroup/agilab"
+Repository = "https://github.com/ThalesGroup/agilab"
+Discussions = "https://github.com/ThalesGroup/agilab/discussions"
+Changelog = "https://github.com/ThalesGroup/agilab/releases"
 
 [tool.agilab]
 runtime_target = "mission_decision"

--- a/src/agilab/apps/builtin/multi_app_dag_project/pyproject.toml
+++ b/src/agilab/apps/builtin/multi_app_dag_project/pyproject.toml
@@ -2,8 +2,21 @@
 name = "multi_app_dag_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILAB multi-app DAG example project"
+readme = "README.md"
 requires-python = ">=3.11"
+authors = [
+    { name = "Jean-Pierre Morard" }
+]
 dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "polars>=1.35,<2", "pydantic>=2.11,<2.13", "streamlit>=1.58,<2"]
+
+[project.urls]
+Documentation = "https://thalesgroup.github.io/agilab"
+Source = "https://github.com/ThalesGroup/agilab/tree/main/src/agilab/apps/builtin/multi_app_dag_project"
+Issues = "https://github.com/ThalesGroup/agilab/issues"
+Homepage = "https://github.com/ThalesGroup/agilab"
+Repository = "https://github.com/ThalesGroup/agilab"
+Discussions = "https://github.com/ThalesGroup/agilab/discussions"
+Changelog = "https://github.com/ThalesGroup/agilab/releases"
 
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/pytorch_playground_project/pyproject.toml
+++ b/src/agilab/apps/builtin/pytorch_playground_project/pyproject.toml
@@ -4,6 +4,9 @@ version = "2026.05.30.post1"
 description = "Built-in AGILab app for reproducible PyTorch classifier playground experiments."
 readme = "README.md"
 requires-python = ">=3.12"
+authors = [
+    { name = "Jean-Pierre Morard" }
+]
 dependencies = [
     "agi-env>=2026.05.31",
     "agi-node>=2026.05.31",

--- a/src/agilab/apps/builtin/r_runtime_bridge_project/pyproject.toml
+++ b/src/agilab/apps/builtin/r_runtime_bridge_project/pyproject.toml
@@ -4,6 +4,9 @@ version = "2026.05.30.post1"
 description = "Built-in AGILAB smoke app for Rscript JSON/artifact stage execution"
 readme = "README.md"
 requires-python = ">=3.11"
+authors = [
+    { name = "Jean-Pierre Morard" }
+]
 dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "streamlit>=1.58,<2"]
 
 [project.urls]
@@ -14,12 +17,6 @@ Homepage = "https://github.com/ThalesGroup/agilab"
 Repository = "https://github.com/ThalesGroup/agilab"
 Discussions = "https://github.com/ThalesGroup/agilab/discussions"
 Changelog = "https://github.com/ThalesGroup/agilab/releases"
-
-
-
-
-
-
 
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/sklearn_pipeline_project/pyproject.toml
+++ b/src/agilab/apps/builtin/sklearn_pipeline_project/pyproject.toml
@@ -2,7 +2,11 @@
 name = "sklearn_pipeline_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILAB scikit-learn pipeline app with model, metrics, predictions, and evidence manifest"
+readme = "README.md"
 requires-python = ">=3.11"
+authors = [
+    { name = "Jean-Pierre Morard" }
+]
 dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "joblib>=1.5,<2", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "scikit-learn>=1.7.2,<2", "streamlit>=1.58,<2"]
 
 [project.urls]
@@ -13,12 +17,6 @@ Homepage = "https://github.com/ThalesGroup/agilab"
 Repository = "https://github.com/ThalesGroup/agilab"
 Discussions = "https://github.com/ThalesGroup/agilab/discussions"
 Changelog = "https://github.com/ThalesGroup/agilab/releases"
-
-
-
-
-
-
 
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/tescia_diagnostic_project/pyproject.toml
+++ b/src/agilab/apps/builtin/tescia_diagnostic_project/pyproject.toml
@@ -2,8 +2,21 @@
 name = "tescia_diagnostic_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILAB TeSciA-style diagnostic reasoning example"
+readme = "README.md"
 requires-python = ">=3.13"
+authors = [
+    { name = "Jean-Pierre Morard" }
+]
 dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "streamlit>=1.58,<2"]
+
+[project.urls]
+Documentation = "https://thalesgroup.github.io/agilab"
+Source = "https://github.com/ThalesGroup/agilab/tree/main/src/agilab/apps/builtin/tescia_diagnostic_project"
+Issues = "https://github.com/ThalesGroup/agilab/issues"
+Homepage = "https://github.com/ThalesGroup/agilab"
+Repository = "https://github.com/ThalesGroup/agilab"
+Discussions = "https://github.com/ThalesGroup/agilab/discussions"
+Changelog = "https://github.com/ThalesGroup/agilab/releases"
 
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/uav_queue_project/pyproject.toml
+++ b/src/agilab/apps/builtin/uav_queue_project/pyproject.toml
@@ -1,9 +1,22 @@
 [project]
 name = "uav_queue_project"
 version = "2026.05.30.post1"
-description = "Built-in AGILAB lightweight UAV relay queue example"
+description = "Built-in AGILAB UAV queue resilience simulation app"
+readme = "README.md"
 requires-python = ">=3.13"
+authors = [
+    { name = "Jean-Pierre Morard" }
+]
 dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "simpy>=4.1,<5", "streamlit>=1.58,<2"]
+
+[project.urls]
+Documentation = "https://thalesgroup.github.io/agilab"
+Source = "https://github.com/ThalesGroup/agilab/tree/main/src/agilab/apps/builtin/uav_queue_project"
+Issues = "https://github.com/ThalesGroup/agilab/issues"
+Homepage = "https://github.com/ThalesGroup/agilab"
+Repository = "https://github.com/ThalesGroup/agilab"
+Discussions = "https://github.com/ThalesGroup/agilab/discussions"
+Changelog = "https://github.com/ThalesGroup/agilab/releases"
 
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/uav_relay_queue_project/pyproject.toml
+++ b/src/agilab/apps/builtin/uav_relay_queue_project/pyproject.toml
@@ -1,9 +1,22 @@
 [project]
 name = "uav_relay_queue_project"
 version = "2026.05.30.post1"
-description = "Built-in AGILAB lightweight UAV relay queue example"
+description = "Built-in AGILAB UAV relay service training and queue policy app"
+readme = "README.md"
 requires-python = ">=3.13"
+authors = [
+    { name = "Jean-Pierre Morard" }
+]
 dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "simpy>=4.1,<5", "streamlit>=1.58,<2"]
+
+[project.urls]
+Documentation = "https://thalesgroup.github.io/agilab"
+Source = "https://github.com/ThalesGroup/agilab/tree/main/src/agilab/apps/builtin/uav_relay_queue_project"
+Issues = "https://github.com/ThalesGroup/agilab/issues"
+Homepage = "https://github.com/ThalesGroup/agilab"
+Repository = "https://github.com/ThalesGroup/agilab"
+Discussions = "https://github.com/ThalesGroup/agilab/discussions"
+Changelog = "https://github.com/ThalesGroup/agilab/releases"
 
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/weather_forecast_legacy_project/pyproject.toml
+++ b/src/agilab/apps/builtin/weather_forecast_legacy_project/pyproject.toml
@@ -1,9 +1,22 @@
 [project]
 name = "weather_forecast_legacy_project"
 version = "2026.05.30.post1"
-description = "Built-in AGILab weather forecasting example migrated from notebooks"
+description = "Built-in AGILAB legacy weather forecasting app for migration comparison"
+readme = "README.md"
 requires-python = ">=3.13"
+authors = [
+    { name = "Jean-Pierre Morard" }
+]
 dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "scikit-learn>=1.7.2,<2", "skforecast>=0.19,<0.20", "streamlit>=1.58,<2"]
+
+[project.urls]
+Documentation = "https://thalesgroup.github.io/agilab"
+Source = "https://github.com/ThalesGroup/agilab/tree/main/src/agilab/apps/builtin/weather_forecast_legacy_project"
+Issues = "https://github.com/ThalesGroup/agilab/issues"
+Homepage = "https://github.com/ThalesGroup/agilab"
+Repository = "https://github.com/ThalesGroup/agilab"
+Discussions = "https://github.com/ThalesGroup/agilab/discussions"
+Changelog = "https://github.com/ThalesGroup/agilab/releases"
 
 [tool.uv.sources]
 agi-env = { path = "../../../core/agi-env", editable = true }

--- a/src/agilab/apps/builtin/weather_forecast_project/pyproject.toml
+++ b/src/agilab/apps/builtin/weather_forecast_project/pyproject.toml
@@ -1,9 +1,22 @@
 [project]
 name = "weather_forecast_project"
 version = "2026.05.30.post1"
-description = "Built-in AGILab weather forecasting example migrated from notebooks"
+description = "Built-in AGILAB current weather forecasting app with notebook-import evidence"
+readme = "README.md"
 requires-python = ">=3.11"
+authors = [
+    { name = "Jean-Pierre Morard" }
+]
 dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "scikit-learn>=1.7.2,<2", "skforecast>=0.19,<0.20", "streamlit>=1.58,<2"]
+
+[project.urls]
+Documentation = "https://thalesgroup.github.io/agilab"
+Source = "https://github.com/ThalesGroup/agilab/tree/main/src/agilab/apps/builtin/weather_forecast_project"
+Issues = "https://github.com/ThalesGroup/agilab/issues"
+Homepage = "https://github.com/ThalesGroup/agilab"
+Repository = "https://github.com/ThalesGroup/agilab"
+Discussions = "https://github.com/ThalesGroup/agilab/discussions"
+Changelog = "https://github.com/ThalesGroup/agilab/releases"
 
 [tool.agilab]
 runtime_target = "weather_forecast"

--- a/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/pyproject.toml
+++ b/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/pyproject.toml
@@ -2,8 +2,21 @@
 name = "flight_telemetry_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILab example app (flight-telemetry preprocessing)"
+readme = "README.md"
 requires-python = ">=3.11"
+authors = [
+    { name = "Jean-Pierre Morard" }
+]
 dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "polars[rtcompat]>=1.35,<2", "pydantic>=2.11,<2.13", "py7zr>=1.1,<1.2", "streamlit>=1.58,<2"]
+
+[project.urls]
+Documentation = "https://thalesgroup.github.io/agilab"
+Source = "https://github.com/ThalesGroup/agilab/tree/main/src/agilab/apps/builtin/flight_telemetry_project"
+Issues = "https://github.com/ThalesGroup/agilab/issues"
+Homepage = "https://github.com/ThalesGroup/agilab"
+Repository = "https://github.com/ThalesGroup/agilab"
+Discussions = "https://github.com/ThalesGroup/agilab/discussions"
+Changelog = "https://github.com/ThalesGroup/agilab/releases"
 
 [tool.agilab]
 runtime_target = "flight_telemetry"

--- a/src/agilab/lib/agi-app-mission-decision/src/agi_app_mission_decision/project/mission_decision_project/pyproject.toml
+++ b/src/agilab/lib/agi-app-mission-decision/src/agi_app_mission_decision/project/mission_decision_project/pyproject.toml
@@ -2,8 +2,21 @@
 name = "mission_decision_project"
 version = "2026.05.30.post1"
 description = "Built-in AGILAB Mission Decision autonomous demo"
+readme = "README.md"
 requires-python = ">=3.11"
+authors = [
+    { name = "Jean-Pierre Morard" }
+]
 dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "streamlit>=1.58,<2"]
+
+[project.urls]
+Documentation = "https://thalesgroup.github.io/agilab"
+Source = "https://github.com/ThalesGroup/agilab/tree/main/src/agilab/apps/builtin/mission_decision_project"
+Issues = "https://github.com/ThalesGroup/agilab/issues"
+Homepage = "https://github.com/ThalesGroup/agilab"
+Repository = "https://github.com/ThalesGroup/agilab"
+Discussions = "https://github.com/ThalesGroup/agilab/discussions"
+Changelog = "https://github.com/ThalesGroup/agilab/releases"
 
 [tool.agilab]
 runtime_target = "mission_decision"

--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/pyproject.toml
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/pyproject.toml
@@ -4,6 +4,9 @@ version = "2026.05.30.post1"
 description = "Built-in AGILab app for reproducible PyTorch classifier playground experiments."
 readme = "README.md"
 requires-python = ">=3.12"
+authors = [
+    { name = "Jean-Pierre Morard" }
+]
 dependencies = [
     "agi-env>=2026.05.31",
     "agi-node>=2026.05.31",

--- a/src/agilab/lib/agi-app-uav-relay-queue/src/agi_app_uav_relay_queue/project/uav_relay_queue_project/pyproject.toml
+++ b/src/agilab/lib/agi-app-uav-relay-queue/src/agi_app_uav_relay_queue/project/uav_relay_queue_project/pyproject.toml
@@ -1,9 +1,22 @@
 [project]
 name = "uav_relay_queue_project"
 version = "2026.05.30.post1"
-description = "Built-in AGILAB lightweight UAV relay queue example"
+description = "Built-in AGILAB UAV relay service training and queue policy app"
+readme = "README.md"
 requires-python = ">=3.13"
+authors = [
+    { name = "Jean-Pierre Morard" }
+]
 dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "simpy>=4.1,<5", "streamlit>=1.58,<2"]
+
+[project.urls]
+Documentation = "https://thalesgroup.github.io/agilab"
+Source = "https://github.com/ThalesGroup/agilab/tree/main/src/agilab/apps/builtin/uav_relay_queue_project"
+Issues = "https://github.com/ThalesGroup/agilab/issues"
+Homepage = "https://github.com/ThalesGroup/agilab"
+Repository = "https://github.com/ThalesGroup/agilab"
+Discussions = "https://github.com/ThalesGroup/agilab/discussions"
+Changelog = "https://github.com/ThalesGroup/agilab/releases"
 
 [tool.setuptools.package-data]
 uav_relay_queue = ["sample_data/*.json"]

--- a/src/agilab/lib/agi-app-weather-forecast/src/agi_app_weather_forecast/project/weather_forecast_project/pyproject.toml
+++ b/src/agilab/lib/agi-app-weather-forecast/src/agi_app_weather_forecast/project/weather_forecast_project/pyproject.toml
@@ -1,9 +1,22 @@
 [project]
 name = "weather_forecast_project"
 version = "2026.05.30.post1"
-description = "Built-in AGILab weather forecasting example migrated from notebooks"
+description = "Built-in AGILAB current weather forecasting app with notebook-import evidence"
+readme = "README.md"
 requires-python = ">=3.11"
+authors = [
+    { name = "Jean-Pierre Morard" }
+]
 dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "scikit-learn>=1.7.2,<2", "skforecast>=0.19,<0.20", "streamlit>=1.58,<2"]
+
+[project.urls]
+Documentation = "https://thalesgroup.github.io/agilab"
+Source = "https://github.com/ThalesGroup/agilab/tree/main/src/agilab/apps/builtin/weather_forecast_project"
+Issues = "https://github.com/ThalesGroup/agilab/issues"
+Homepage = "https://github.com/ThalesGroup/agilab"
+Repository = "https://github.com/ThalesGroup/agilab"
+Discussions = "https://github.com/ThalesGroup/agilab/discussions"
+Changelog = "https://github.com/ThalesGroup/agilab/releases"
 
 [tool.agilab]
 runtime_target = "weather_forecast"

--- a/test/test_app_contract_matrix.py
+++ b/test/test_app_contract_matrix.py
@@ -20,6 +20,97 @@ def _load_module():
     return module
 
 
+def _seed_builtin_project(
+    tmp_path: Path,
+    name: str,
+    *,
+    description: str = "Built-in AGILAB demo app",
+    include_metadata: bool = True,
+) -> Path:
+    module_name = name.removesuffix("_project")
+    project = tmp_path / "src" / "agilab" / "apps" / "builtin" / name
+    manager = project / "src" / module_name
+    worker = project / "src" / f"{module_name}_worker"
+    manager.mkdir(parents=True)
+    worker.mkdir(parents=True)
+    (project / "src" / "app_settings.toml").write_text("", encoding="utf-8")
+    (project / "src" / "app_args_form.py").write_text("", encoding="utf-8")
+    (manager / "__init__.py").write_text("", encoding="utf-8")
+    (manager / "reduction.py").write_text("", encoding="utf-8")
+    (worker / "__init__.py").write_text("", encoding="utf-8")
+    (project / "lab_stages.toml").write_text("[stage.demo]\nname = \"Demo\"\n", encoding="utf-8")
+    (project / "README.md").write_text(
+        f"{name}\n\n"
+        + " ".join(
+            [
+                "This",
+                "built-in",
+                "project",
+                "documents",
+                "the",
+                "demo",
+                "contract",
+                "with",
+                "enough",
+                "context",
+            ]
+            * 5
+        ),
+        encoding="utf-8",
+    )
+    metadata_lines = []
+    if include_metadata:
+        metadata_lines = [
+            'readme = "README.md"',
+            'authors = [{ name = "Jean-Pierre Morard" }]',
+            "",
+            "[project.urls]",
+            'Documentation = "https://thalesgroup.github.io/agilab"',
+            f'Source = "https://github.com/ThalesGroup/agilab/tree/main/src/agilab/apps/builtin/{name}"',
+            'Issues = "https://github.com/ThalesGroup/agilab/issues"',
+            'Homepage = "https://github.com/ThalesGroup/agilab"',
+            'Repository = "https://github.com/ThalesGroup/agilab"',
+            'Discussions = "https://github.com/ThalesGroup/agilab/discussions"',
+            'Changelog = "https://github.com/ThalesGroup/agilab/releases"',
+        ]
+    (project / "pyproject.toml").write_text(
+        "\n".join(
+            [
+                "[project]",
+                f'name = "{name}"',
+                'version = "1.0.0"',
+                f'description = "{description}"',
+                'requires-python = ">=3.11"',
+                'dependencies = ["agi-env>=1", "agi-node>=1"]',
+                *metadata_lines,
+                "",
+                "[build-system]",
+                'requires = ["setuptools"]',
+                'build-backend = "setuptools.build_meta"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (worker / "pyproject.toml").write_text(
+        "\n".join(
+            [
+                "[project]",
+                f'name = "{module_name}_worker"',
+                'version = "1.0.0"',
+                'dependencies = ["agi-env>=1", "agi-node>=1"]',
+                "",
+                "[tool.uv.sources]",
+                'agi-env = { path = "../../../../../core/agi-env", editable = true }',
+                'agi-node = { path = "../../../../../core/agi-node", editable = true }',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return project
+
+
 def test_app_contract_matrix_passes_current_repo():
     module = _load_module()
 
@@ -41,6 +132,8 @@ def test_app_contract_matrix_passes_current_repo():
     assert "agi_pages_provider_matches_page_bundle_contract" in check_ids
     assert "promoted_pypi_app_catalog_matches_package_split" in check_ids
     assert "public_app_catalog_matches_package_contract" in check_ids
+    assert "flight_telemetry_project:metadata" in check_ids
+    assert "builtin_project_description_uniqueness" in check_ids
 
 
 def test_discover_builtin_projects_ignores_untracked_workspace_dirs(tmp_path: Path, monkeypatch):
@@ -82,6 +175,34 @@ def test_load_module_supports_package_imports_without_preexisting_src_path(monke
 
     assert loaded.PROMOTED_PYPI_APP_PACKAGES
     assert src_path not in module.sys.path
+
+
+def test_app_contract_matrix_detects_missing_builtin_public_metadata(tmp_path: Path):
+    module = _load_module()
+    project = _seed_builtin_project(tmp_path, "demo_project", include_metadata=False)
+
+    checks = {check.id: check for check in module._project_checks(tmp_path, project)}
+    metadata = checks["demo_project:metadata"]
+
+    assert metadata.status == "fail"
+    assert metadata.details["errors"]["authors"] == "missing"
+    assert metadata.details["errors"]["readme"] is None
+    assert metadata.details["errors"]["missing_url_keys"] == sorted(module.REQUIRED_PROJECT_URL_KEYS)
+
+
+def test_app_contract_matrix_detects_duplicate_builtin_descriptions(tmp_path: Path):
+    module = _load_module()
+    projects = [
+        _seed_builtin_project(tmp_path, "alpha_project", description="Duplicate description"),
+        _seed_builtin_project(tmp_path, "beta_project", description="Duplicate description"),
+    ]
+
+    check = module._builtin_project_description_uniqueness_check(tmp_path, projects)
+
+    assert check.status == "fail"
+    assert check.details["duplicates"] == {
+        "Duplicate description": ["alpha_project", "beta_project"]
+    }
 
 
 def test_app_contract_matrix_detects_promoted_catalog_drift():

--- a/test/test_clean_local_artifacts.py
+++ b/test/test_clean_local_artifacts.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 
+import pytest
+
 
 ROOT = Path(__file__).resolve().parents[1]
 MODULE_PATH = ROOT / "tools" / "clean_local_artifacts.py"
@@ -96,3 +98,26 @@ def test_clean_ignored_local_artifacts_apply_removes_only_safe_targets(tmp_path:
     ]
     assert not target.exists()
     assert outside.exists()
+
+
+def test_clean_ignored_local_artifacts_apply_unlinks_safe_symlink_target(tmp_path: Path) -> None:
+    external_venv = tmp_path / "external-venv"
+    external_venv.mkdir()
+    target = tmp_path / "src/agilab/apps/builtin/demo_project/.venv"
+    target.parent.mkdir(parents=True)
+    try:
+        target.symlink_to(external_venv, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"symlink unavailable: {exc}")
+
+    results = clean_local_artifacts.clean_ignored_local_artifacts(
+        tmp_path,
+        apply=True,
+        ignored_fn=lambda _root, _target: True,
+    )
+
+    assert [result.path for result in results] == [
+        "src/agilab/apps/builtin/demo_project/.venv"
+    ]
+    assert not target.exists()
+    assert external_venv.exists()

--- a/tools/app_contract_matrix.py
+++ b/tools/app_contract_matrix.py
@@ -57,6 +57,25 @@ PAYLOAD_EXCLUDED_DIRS = frozenset(
 PAYLOAD_EXCLUDED_FILES = frozenset({".DS_Store", ".gitignore", ".lock", "uv.lock"})
 PAYLOAD_EXCLUDED_FILE_PREFIXES = (".coverage",)
 PAYLOAD_EXCLUDED_SUFFIXES = frozenset({".c", ".pid", ".pyc", ".pyo", ".pyx", ".so"})
+REQUIRED_PROJECT_URL_KEYS = frozenset(
+    {
+        "Documentation",
+        "Source",
+        "Issues",
+        "Homepage",
+        "Repository",
+        "Discussions",
+        "Changelog",
+    }
+)
+PROJECT_URL_EXPECTED_VALUES = {
+    "Documentation": "https://thalesgroup.github.io/agilab",
+    "Issues": "https://github.com/ThalesGroup/agilab/issues",
+    "Homepage": "https://github.com/ThalesGroup/agilab",
+    "Repository": "https://github.com/ThalesGroup/agilab",
+    "Discussions": "https://github.com/ThalesGroup/agilab/discussions",
+    "Changelog": "https://github.com/ThalesGroup/agilab/releases",
+}
 
 
 @dataclass(frozen=True)
@@ -145,6 +164,53 @@ def _has_dependency(dependencies: Sequence[str], package: str) -> bool:
         re.IGNORECASE,
     )
     return any(pattern.match(item.strip()) for item in dependencies)
+
+
+def _builtin_project_metadata_errors(
+    *,
+    repo_root: Path,
+    project_path: Path,
+    project_data: Mapping[str, Any],
+) -> dict[str, Any]:
+    errors: dict[str, Any] = {}
+    authors = project_data.get("authors", [])
+    if not isinstance(authors, list) or not authors:
+        errors["authors"] = "missing"
+    else:
+        placeholder_authors = [
+            author
+            for author in authors
+            if isinstance(author, dict)
+            and "your" in " ".join(str(value).lower() for value in author.values())
+        ]
+        if placeholder_authors:
+            errors["authors"] = "placeholder"
+
+    if project_data.get("readme") != "README.md":
+        errors["readme"] = project_data.get("readme")
+
+    urls = project_data.get("urls", {})
+    if not isinstance(urls, dict):
+        errors["urls"] = "invalid"
+        return errors
+
+    missing_url_keys = sorted(REQUIRED_PROJECT_URL_KEYS.difference(urls))
+    wrong_url_values = {
+        key: urls.get(key)
+        for key, expected in PROJECT_URL_EXPECTED_VALUES.items()
+        if urls.get(key) != expected
+    }
+    expected_source = (
+        "https://github.com/ThalesGroup/agilab/tree/main/"
+        f"{_relative(repo_root, project_path)}"
+    )
+    if urls.get("Source") != expected_source:
+        wrong_url_values["Source"] = urls.get("Source")
+    if missing_url_keys:
+        errors["missing_url_keys"] = missing_url_keys
+    if wrong_url_values:
+        errors["wrong_url_values"] = wrong_url_values
+    return errors
 
 
 def _literal_string_assignments(path: Path, names: set[str]) -> dict[str, str]:
@@ -495,6 +561,21 @@ def _project_checks(repo_root: Path, project_path: Path) -> list[Check]:
                 },
             )
         )
+        metadata_errors = _builtin_project_metadata_errors(
+            repo_root=repo_root,
+            project_path=project_path,
+            project_data=project_data,
+        )
+        checks.append(
+            _check(
+                f"{project_name}:metadata",
+                f"{project_name} public metadata",
+                not metadata_errors,
+                "manager pyproject declares public readme, author, and project URL metadata",
+                evidence=(_relative(repo_root, pyproject_path),),
+                details={"errors": metadata_errors},
+            )
+        )
     except Exception as exc:
         checks.append(
             _check(
@@ -648,6 +729,37 @@ def _project_checks(repo_root: Path, project_path: Path) -> list[Check]:
         )
     )
     return checks
+
+
+def _builtin_project_description_uniqueness_check(
+    repo_root: Path,
+    project_paths: Sequence[Path],
+) -> Check:
+    by_description: dict[str, list[str]] = {}
+    unreadable: dict[str, str] = {}
+    for project_path in project_paths:
+        pyproject_path = project_path / "pyproject.toml"
+        try:
+            project_data = _read_toml(pyproject_path).get("project", {})
+            description = str(project_data.get("description", "")).strip()
+        except Exception as exc:
+            unreadable[_relative(repo_root, pyproject_path)] = str(exc)
+            continue
+        if description:
+            by_description.setdefault(description, []).append(project_path.name)
+    duplicates = {
+        description: projects
+        for description, projects in sorted(by_description.items())
+        if len(projects) > 1
+    }
+    return _check(
+        "builtin_project_description_uniqueness",
+        "Built-in project description uniqueness",
+        not duplicates and not unreadable,
+        "built-in app pyproject descriptions are unique and parseable",
+        evidence=tuple(_relative(repo_root, path / "pyproject.toml") for path in project_paths),
+        details={"duplicates": duplicates, "unreadable": unreadable},
+    )
 
 
 def _project_name_for_package(repo_root: Path, package_path: str) -> str:
@@ -1188,6 +1300,7 @@ def build_report(
     )
     for project_path in project_paths:
         checks.extend(_project_checks(repo_root, project_path))
+    checks.append(_builtin_project_description_uniqueness_check(repo_root, project_paths))
     checks.extend(
         _global_checks(
             repo_root,

--- a/tools/clean_local_artifacts.py
+++ b/tools/clean_local_artifacts.py
@@ -57,7 +57,7 @@ def stale_build_lib_paths(root: Path) -> list[Path]:
 
 def _is_safe_build_lib_target(root: Path, target: Path) -> bool:
     resolved_root = root.resolve()
-    resolved_target = target.resolve(strict=False)
+    resolved_target = _resolve_clean_target_path(target)
     try:
         resolved_target.relative_to(resolved_root)
     except ValueError:
@@ -67,12 +67,29 @@ def _is_safe_build_lib_target(root: Path, target: Path) -> bool:
 
 def _is_safe_local_artifact_target(root: Path, target: Path) -> bool:
     resolved_root = root.resolve()
-    resolved_target = target.resolve(strict=False)
+    resolved_target = _resolve_clean_target_path(target)
     try:
         relative = resolved_target.relative_to(resolved_root)
     except ValueError:
         return False
     return len(relative.parts) >= 3 and relative.parts[:2] == ("src", "agilab") and target.name in LOCAL_ARTIFACT_DIR_NAMES
+
+
+def _resolve_clean_target_path(target: Path) -> Path:
+    """Resolve parent directories without following the final artifact symlink."""
+
+    if target.is_symlink():
+        return target.parent.resolve(strict=False) / target.name
+    return target.resolve(strict=False)
+
+
+def _remove_clean_target(target: Path) -> None:
+    """Remove an ignored artifact path without following final symlinks."""
+
+    if target.is_symlink() or target.is_file():
+        target.unlink()
+        return
+    shutil.rmtree(target)
 
 
 def _is_git_ignored(root: Path, target: Path) -> bool:
@@ -118,7 +135,7 @@ def clean_stale_build_libs(root: Path, *, apply: bool = False) -> list[CleanResu
         if not _is_safe_build_lib_target(root, target):
             raise RuntimeError(f"Refusing unsafe clean target: {target}")
         if apply:
-            shutil.rmtree(target)
+            _remove_clean_target(target)
             results.append(CleanResult(path=rel, action="removed", exists=True))
         else:
             results.append(CleanResult(path=rel, action="would-remove", exists=True))
@@ -134,7 +151,7 @@ def clean_ignored_local_artifacts(root: Path, *, apply: bool = False, ignored_fn
         if not _is_safe_local_artifact_target(root, target):
             raise RuntimeError(f"Refusing unsafe clean target: {target}")
         if apply:
-            shutil.rmtree(target)
+            _remove_clean_target(target)
             results.append(CleanResult(path=rel, action="removed", exists=True))
         else:
             results.append(CleanResult(path=rel, action="would-remove", exists=True))


### PR DESCRIPTION
## Summary

Fixes the confirmed current consistency-audit findings across public README surfaces, built-in app metadata, app-contract enforcement, and local artifact cleanup.

- Align `README.md` and `README.pypi.md`: production readiness `3.2 / 5`, notebook extra row, ASCII core-flow arrow, and matching dry-run/evaluation wording.
- Add public metadata (`readme`, `authors`, `[project.urls]`) to tracked built-in app pyprojects and synchronized checked-in promoted app payload pyprojects.
- Make duplicated app descriptions unique for UAV queue and weather forecast variants.
- Extend `tools/app_contract_matrix.py` to fail future missing public metadata or duplicate built-in descriptions.
- Fix `./dev clean --apply` so ignored symlinked artifact directories are unlinked without following their targets.

## Validation

- `tokki run -- ./dev lint tools/clean_local_artifacts.py tools/app_contract_matrix.py test/test_clean_local_artifacts.py test/test_app_contract_matrix.py`
- `tokki run -- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_pyproject_dependency_hygiene.py test/test_app_contract_matrix.py test/test_clean_local_artifacts.py`
- `tokki run -- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui`
- `tokki run -- ./dev app-contracts`
- `tokki run -- ./dev clean --apply`
- `git diff --cached --check`

## Scope note

The local scope guard intentionally reports `MIXED` because this PR fixes a cross-app consistency audit spanning many built-in app manifests plus README/tooling contract drift. The push used `AGILAB_ALLOW_MIXED_SCOPE_PUSH=1`; normal protected-path, docs, and app-contract pre-push guards remained active.