### PR TITLE
fix streamlit page hygiene

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 276,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "bc78c6564a1a09b5f5631a65994a6bd3cb1d12c396649c3d3b15bcb0529d47d9",
+  "source_digest_sha256": "7babdf4fd99070cda819e787040cda285b29c4f15b17df022d7ad0037700d44d",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "bc78c6564a1a09b5f5631a65994a6bd3cb1d12c396649c3d3b15bcb0529d47d9"
+  "target_digest_sha256": "7babdf4fd99070cda819e787040cda285b29c4f15b17df022d7ad0037700d44d"
 }

--- a/docs/source/apps-pages-gallery.rst
+++ b/docs/source/apps-pages-gallery.rst
@@ -22,9 +22,10 @@ chrome.
           :width: 260px
      - **view_autoencoder_latentspace**
 
-       Explores TensorFlow/Keras latent projections and reconstruction behavior.
+       Opt-in playground exception for TensorFlow/Keras latent projections and
+       reconstruction behavior.
 
-       When to use: Use for heavier Python 3.12 teaching or exploration sessions where latent-space structure matters more than lightweight packaging.
+       When to use: Use for heavier Python 3.12 teaching or exploration sessions where an in-page autoencoder training loop is intentional; keep reproducible training workflows in app projects.
    * - .. image:: _static/apps-pages-gallery/view_barycentric.svg
           :alt: view_barycentric preview
           :width: 260px

--- a/docs/source/apps-pages.rst
+++ b/docs/source/apps-pages.rst
@@ -144,9 +144,11 @@ pulled by the umbrella dependency graph.
      - Packaging status
    * - ``view_autoencoder_latentspace``
      - ``agi-page-latent-space``
-     - TensorFlow/Keras latent-space projection and autoencoder exploration.
+     - Opt-in TensorFlow/Keras latent-space playground that trains a small
+       autoencoder in-page.
      - Source-checkout opt-in; intentionally outside ``agi-pages`` because it
-       targets Python 3.12 and carries TensorFlow runtime constraints.
+       targets Python 3.12, carries TensorFlow runtime constraints, and is not
+       a generic app-agnostic sidecar.
    * - ``view_barycentric``
      - ``agi-page-simplex-map``
      - Barycentric/simplex visualisation for proportion-style KPI features.
@@ -383,14 +385,16 @@ Training evidence page for scalar logs and model-training runs.
 view_autoencoder_latentspace
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-TensorFlow/Keras latent-space exploration page for Python 3.12 source-checkout
-environments.
+Opt-in TensorFlow/Keras latent-space playground for Python 3.12 source-checkout
+environments. Unlike the default app-agnostic sidecars, this page trains a
+small autoencoder in-page for teaching and exploration.
 
 - Input: embeddings, labels, or autoencoder-ready tabular/image artifacts.
 - Output: latent-space projections, clustering diagnostics, and reconstruction
   exploration.
 - This page remains opt-in because TensorFlow constrains the supported Python
-  range and would make the default page bundle set heavier.
+  range, would make the default page bundle set heavier, and owns an in-page
+  training loop. Keep reproducible training workflows in app projects.
 
 Producer example for distributed runs
 -------------------------------------

--- a/maintenance/memory/by-path/src%2Fagilab%2Fpages%2F4_ANALYSIS.py.md
+++ b/maintenance/memory/by-path/src%2Fagilab%2Fpages%2F4_ANALYSIS.py.md
@@ -1,9 +1,9 @@
 ---
 schema: agilab.maintenance_memory.v1
 source: src/agilab/pages/4_ANALYSIS.py
-source_sha256: 64a7b2c42dfefad164f2f9eeccc5d4c71b3f0af66ef941ed5609a56b2f09f874
+source_sha256: 6336e8293d182b5767601e589f48e86e8d6a7714a330a809cebe201028ef7c21
 title: ANALYSIS page AgiEnv singleton contract
-verified_commit: b58bcbf66ebfa8d41da46f98c0a2882c433144a4
+verified_commit: ffdf636cf11d459aec7b713c9b5890acd4d9ea24
 ---
 
 # ANALYSIS page AgiEnv singleton contract

--- a/src/agilab/apps-pages/README.md
+++ b/src/agilab/apps-pages/README.md
@@ -17,7 +17,7 @@ Every shipped view bundle has a local README, a source-controlled preview, direc
 
 | View | View |
 |---|---|
-| [![view_app_ui preview](../../../docs/source/_static/apps-pages-gallery/view_app_ui.svg)](view_app_ui)<br>**view_app_ui**<br>Launches app-owned interactive Streamlit surfaces from ANALYSIS. | [![view_autoencoder_latentspace preview](../../../docs/source/_static/apps-pages-gallery/view_autoencoder_latentspace.svg)](view_autoencoder_latentspace)<br>**view_autoencoder_latentspace**<br>Explores TensorFlow/Keras latent projections and reconstruction behavior. |
+| [![view_app_ui preview](../../../docs/source/_static/apps-pages-gallery/view_app_ui.svg)](view_app_ui)<br>**view_app_ui**<br>Launches app-owned interactive Streamlit surfaces from ANALYSIS. | [![view_autoencoder_latentspace preview](../../../docs/source/_static/apps-pages-gallery/view_autoencoder_latentspace.svg)](view_autoencoder_latentspace)<br>**view_autoencoder_latentspace**<br>Opt-in playground exception for TensorFlow/Keras latent projections; it trains a small autoencoder in-page and is not a generic app-agnostic sidecar. |
 | [![view_barycentric preview](../../../docs/source/_static/apps-pages-gallery/view_barycentric.svg)](view_barycentric)<br>**view_barycentric**<br>Plots proportion-style KPI features on a barycentric/simplex surface. | [![view_data_io_decision preview](../../../docs/source/_static/apps-pages-gallery/view_data_io_decision.svg)](view_data_io_decision)<br>**view_data_io_decision**<br>Reviews data-ingestion and strategy-selection evidence. |
 | [![view_forecast_analysis preview](../../../docs/source/_static/apps-pages-gallery/view_forecast_analysis.svg)](view_forecast_analysis)<br>**view_forecast_analysis**<br>Reviews forecast metrics and prediction tables for time-series workflows. | [![view_inference_analysis preview](../../../docs/source/_static/apps-pages-gallery/view_inference_analysis.svg)](view_inference_analysis)<br>**view_inference_analysis**<br>Compares allocation and inference-result metrics across exported runs. |
 | [![view_live_artifacts preview](../../../docs/source/_static/apps-pages-gallery/view_live_artifacts.svg)](view_live_artifacts)<br>**view_live_artifacts**<br>Watches exported evidence, manifests, logs, text, CSVs, and images while a run is active. | [![view_maps preview](../../../docs/source/_static/apps-pages-gallery/view_maps.svg)](view_maps)<br>**view_maps**<br>Explores geolocated datasets with map, sampling, palette, and basemap controls. |
@@ -94,7 +94,7 @@ Experimental and opt-in views:
 
 - view_autoencoder_latentspace
   - uv run streamlit run src/agilab/apps-pages/view_autoencoder_latentspace/src/view_autoencoder_latentspace/view_autoencoder_latentspace.py -- --active-app src/agilab/apps/builtin/flight_telemetry_project
-  - TensorFlow-based latent-space exploration for Python 3.12 environments. It is intentionally not part of the public `agi-pages` umbrella because its runtime constraints are heavier than the generic page bundle set.
+  - Opt-in playground exception for Python 3.12 teaching sessions. It trains a small TensorFlow/Keras autoencoder in-page, so it is intentionally not part of the public `agi-pages` umbrella or the generic app-agnostic sidecar set.
 
 ## Repository Pages (optional)
 

--- a/src/agilab/apps-pages/view_autoencoder_latentspace/README.md
+++ b/src/agilab/apps-pages/view_autoencoder_latentspace/README.md
@@ -4,11 +4,15 @@
 
 Package: `agi-page-latent-space`
 
-Explores TensorFlow/Keras latent projections and reconstruction behavior.
+Opt-in playground exception for TensorFlow/Keras latent projections and reconstruction behavior.
 
 ## When To Use It
 
-Use for heavier Python 3.12 teaching or exploration sessions where latent-space structure matters more than lightweight packaging.
+Use for heavier Python 3.12 teaching or exploration sessions where latent-space structure matters more than lightweight packaging. This bundle trains a small autoencoder in-page, so treat it as an explicit playground exception rather than a generic app-agnostic analysis sidecar.
+
+## Opt-In Boundary
+
+Most apps-pages inspect artifacts produced by the active app. This page is different: it builds and fits a TensorFlow/Keras autoencoder from the selected dataframe to demonstrate latent projections. Keep reproducible training workflows in app projects; use this bundle only when the in-page teaching loop is intentional.
 
 ## Expected Inputs
 

--- a/src/agilab/apps-pages/view_autoencoder_latentspace/src/view_autoencoder_latentspace/autoencoder_latentspace.py
+++ b/src/agilab/apps-pages/view_autoencoder_latentspace/src/view_autoencoder_latentspace/autoencoder_latentspace.py
@@ -68,7 +68,18 @@ APP_SCOPED_SESSION_KEYS = (
     "data",
     "df_cols",
     "coltype",
+    f"{PAGE_KEY}:figure_format",
+    f"{PAGE_KEY}:figure_name",
+    f"{PAGE_KEY}:latent_dimension",
+    f"{PAGE_KEY}:row_index",
+    f"{PAGE_KEY}:row_limit",
+    f"{PAGE_KEY}:selected_color",
 )
+
+
+def _ae_key(name: str) -> str:
+    return f"{PAGE_KEY}:{name}"
+
 
 render_streamlit_page_header(st, title=":chart_with_downwards_trend: Dimension Reduction", show_logo=False)
 
@@ -410,7 +421,7 @@ def __bary_visualisation(
     s.attrs.height = 700
     s.attrs.text_size = 12
     s.plot(c, format=selected_format)
-    row_index = st.selectbox("Choose a row:", df.index)
+    row_index = st.selectbox("Choose a row:", df.index, key=_ae_key("row_index"))
     if color_data is not None:
         st.markdown(f"**{selected_color}:** {color_data.iloc[row_index]}")
     data = {
@@ -545,11 +556,18 @@ def page(env):
         Sequential, EarlyStopping, Dense = lazy_import_keras()
         train_test_split, StandardScaler = lazy_import_sklearn()
         nrows = st.session_state.data.shape[0]
+        row_limit_key = _ae_key("row_limit")
+        default_lines = min(max(10, nrows // 10), nrows)
+        try:
+            current_lines = int(st.session_state.get(row_limit_key, default_lines))
+        except Exception:
+            current_lines = default_lines
+        st.session_state[row_limit_key] = min(max(10, current_lines), nrows)
         lines = st.slider(
             "Number of rows:",
             min_value=10,
             max_value=nrows,
-            value=nrows // 10,
+            key=row_limit_key,
             step=100,
         )
         if lines >= 0:
@@ -560,19 +578,41 @@ def page(env):
         ndim_inter = round(round(ndim ** 0.9))
         col1, col2, col3, col4 = st.columns(4)
         with col1:
+            latent_dim_key = _ae_key("latent_dimension")
+            max_latent_dim = max(2, ndim - 1)
+            try:
+                current_latent_dim = int(st.session_state.get(latent_dim_key, 3))
+            except Exception:
+                current_latent_dim = 3
+            st.session_state[latent_dim_key] = min(max(2, current_latent_dim), max_latent_dim)
             ndim_middle = st.number_input(
-                "Dimension", value=3, step=1, min_value=2, max_value=(ndim - 1)
+                "Dimension",
+                step=1,
+                min_value=2,
+                max_value=max_latent_dim,
+                key=latent_dim_key,
             )
         with col2:
+            color_key = _ae_key("selected_color")
+            if st.session_state.get(color_key) not in st.session_state.df_cols:
+                st.session_state[color_key] = st.session_state.df_cols[0]
             selected_color = st.selectbox(
                 "Color",
                 st.session_state.df_cols,
+                key=color_key,
             )
         with col3:
-            selected_name = st.text_input(label="File", value="myfigure")
+            figure_name_key = _ae_key("figure_name")
+            st.session_state.setdefault(figure_name_key, "myfigure")
+            selected_name = st.text_input(label="File", key=figure_name_key)
         with col4:
+            format_key = _ae_key("figure_format")
+            if st.session_state.get(format_key) not in ["png", "jpeg", "svg", "webp"]:
+                st.session_state[format_key] = "png"
             selected_format = st.selectbox(
-                label="Format", options=["png", "jpeg", "svg", "webp"]
+                label="Format",
+                options=["png", "jpeg", "svg", "webp"],
+                key=format_key,
             )
         norm_X = __normalize_data(X)
         y = st.session_state.data[f"{selected_color}"]

--- a/src/agilab/apps-pages/view_barycentric/src/view_barycentric/view_barycentric.py
+++ b/src/agilab/apps-pages/view_barycentric/src/view_barycentric/view_barycentric.py
@@ -95,6 +95,18 @@ APP_SCOPED_SESSION_DEFAULT_KEYS = (
 )
 
 
+def _vb_key(name: str) -> str:
+    return f"{PAGE_KEY_PREFIX}:{name}"
+
+
+def _ensure_choice_state(key: str, options: list, default):
+    if not options:
+        return None
+    if st.session_state.get(key) not in options:
+        st.session_state[key] = default if default in options else options[0]
+    return st.session_state[key]
+
+
 def _reset_app_scoped_session_state(active_app: Path) -> bool:
     """Clear Barycentric page state that belongs to a specific active app."""
 
@@ -396,7 +408,10 @@ def __bary_visualisation(df, selected_format, selected_name, selected_x1, select
 
     tables = [f"Normalized {selected_x1}", "Barycentric coordinates"]
     selected_table = st.selectbox(
-        label="Data", label_visibility="hidden", options=tables
+        label="Data",
+        label_visibility="hidden",
+        options=tables,
+        key=_vb_key("barycentric_table"),
     )
     if selected_table == tables[0]:
         st.write(normalized_data)
@@ -481,19 +496,14 @@ def page(env):
             continue
     csv_files_rel = sorted(csv_files_rel)
     settings_file = st.session_state.get("df_file")
-    if settings_file and settings_file in csv_files_rel:
-        default_idx = csv_files_rel.index(settings_file)
-    else:
-        default_idx = 0
+    if settings_file not in csv_files_rel:
+        st.session_state["df_file"] = csv_files_rel[0]
 
     # DataFrame selection
     st.sidebar.selectbox(
         label="DataFrame",
         options=csv_files_rel,
         key="df_file",
-        index=default_idx,
-        # on_change=update_var,
-        args=("df_file"),
     )
 
     # Check if a DataFrame has been selected
@@ -559,11 +569,18 @@ def page(env):
                 and not st.session_state.loaded_df.empty
         ):
             nrows = st.session_state.loaded_df.shape[0]
+            row_limit_key = _vb_key("row_limit")
+            default_lines = min(max(10, nrows // 10), nrows)
+            try:
+                current_lines = int(st.session_state.get(row_limit_key, default_lines))
+            except Exception:
+                current_lines = default_lines
+            st.session_state[row_limit_key] = min(max(10, current_lines), nrows)
             lines = st.slider(
                 "Number of rows:",
                 min_value=10,
                 max_value=nrows,
-                value=nrows // 10,
+                key=row_limit_key,
                 step=100,
             )
             if lines >= 0:
@@ -612,42 +629,40 @@ def page(env):
                 col1, col2, col3 = st.columns(3)
 
                 with col1:
+                    x1_key = _vb_key("selected_x1")
+                    _ensure_choice_state(x1_key, numeric_cols, default_x1)
                     selected_x1 = st.selectbox(
                         "Correlated variables pair",
                         numeric_cols,
-                        index=(
-                            st.session_state.df_cols.index(default_x1)
-                            if default_x1 in st.session_state.df_cols
-                            else 0
-                        ),
+                        key=x1_key,
                     )
+                    x2_key = _vb_key("selected_x2")
+                    _ensure_choice_state(x2_key, numeric_cols, default_x2)
                     selected_x2 = st.selectbox(
                         "Correlated variables",
                         numeric_cols,
                         label_visibility="collapsed",
-                        index=(
-                            st.session_state.df_cols.index(default_x2)
-                            if default_x2 in st.session_state.df_cols
-                            else 0
-                        ),
+                        key=x2_key,
                     )
                 with col2:
+                    color_key = _vb_key("selected_color")
+                    _ensure_choice_state(color_key, st.session_state.df_cols, default_color)
                     selected_color = st.selectbox(
                         "Color",
                         st.session_state.df_cols,
-                        index=(
-                            st.session_state.df_cols.index(default_color)
-                            if default_color in st.session_state.df_cols
-                            else 0
-                        ),
+                        key=color_key,
                     )
                 with col3:
-                    selected_name = st.text_input(label="File", value="myfigure")
+                    figure_name_key = _vb_key("figure_name")
+                    st.session_state.setdefault(figure_name_key, "myfigure")
+                    selected_name = st.text_input(label="File", key=figure_name_key)
+                    format_key = _vb_key("figure_format")
+                    _ensure_choice_state(format_key, ["jpeg", "png", "svg", "webp"], "jpeg")
                     selected_format = st.selectbox(
                         label="Format",
                         label_visibility="collapsed",
                         options=["jpeg", "png", "svg", "webp"],
-                        index=0
+                        key=format_key,
                     )
 
                 if selected_x1 and selected_x2 and selected_color:

--- a/src/agilab/apps-pages/view_maps/src/view_maps/view_maps.py
+++ b/src/agilab/apps-pages/view_maps/src/view_maps/view_maps.py
@@ -715,24 +715,36 @@ def page(env):
     # treat it as discrete. Adjust this value based on your needs.
     # Threshold to classify numeric columns as discrete vs continuous
     unique_default = int(view_settings.get("unique_threshold", 10))
+    unique_threshold_key = _vm_key("unique_threshold")
+    try:
+        unique_threshold_current = int(st.session_state.get(unique_threshold_key, unique_default))
+    except Exception:
+        unique_threshold_current = unique_default
+    st.session_state[unique_threshold_key] = min(max(2, unique_threshold_current), 100)
     unique_threshold = st.sidebar.number_input(
         "Discrete threshold (unique values <)",
         min_value=2,
         max_value=100,
-        value=unique_default,
         step=1,
+        key=unique_threshold_key,
     )
     if view_settings.get("unique_threshold", 10) != unique_threshold:
         view_settings["unique_threshold"] = int(unique_threshold)
         full_settings = _persist_view_maps_settings(env, full_settings, view_settings)
 
     range_default = int(view_settings.get("range_threshold", 200))
+    range_threshold_key = _vm_key("range_threshold")
+    try:
+        range_threshold_current = int(st.session_state.get(range_threshold_key, range_default))
+    except Exception:
+        range_threshold_current = range_default
+    st.session_state[range_threshold_key] = min(max(1, range_threshold_current), 10000)
     range_threshold = st.sidebar.number_input(
         "Integer discrete range (max-min <=)",
         min_value=1,
         max_value=10000,
-        value=range_default,
         step=1,
+        key=range_threshold_key,
     )
     if view_settings.get("range_threshold", 200) != range_threshold:
         view_settings["range_threshold"] = int(range_threshold)
@@ -824,10 +836,20 @@ def page(env):
                         "Pastel2",
                         "Set3",
                     ]
-                    discreteseq = st.selectbox("Color Sequence", discreteseqs, index=0)
+                    discreteseq = st.selectbox(
+                        "Color Sequence",
+                        discreteseqs,
+                        index=0,
+                        key=_vm_key("color_sequence"),
+                    )
                 elif var[i] == "continuous":
                     colorscales = px.colors.named_colorscales()
-                    colorscale = st.selectbox("Color Scale", colorscales, index=0)
+                    colorscale = st.selectbox(
+                        "Color Scale",
+                        colorscales,
+                        index=0,
+                        key=_vm_key("color_scale"),
+                    )
         else:
             with c[i]:
                 st.warning(f"No columns available for {var[i]}.")

--- a/src/agilab/apps-pages/view_release_decision/src/view_release_decision/view_release_decision.py
+++ b/src/agilab/apps-pages/view_release_decision/src/view_release_decision/view_release_decision.py
@@ -2446,7 +2446,12 @@ else:
     st.dataframe(metric_df, width="stretch", hide_index=True)
 
 decision_path = candidate_path.parent / "promotion_decision.json"
-if st.button("Export promotion decision", type="primary", width="stretch"):
+if st.button(
+    "Export promotion decision",
+    type="primary",
+    width="stretch",
+    key="view_release_decision:export_promotion_decision",
+):
     written = _write_decision(decision_path, payload)
     written_index = _write_manifest_index(manifest_index_path, manifest_index_payload)
     st.success(f"Promotion decision exported to {written}; manifest index exported to {written_index}")
@@ -2457,4 +2462,5 @@ st.download_button(
     file_name="promotion_decision.json",
     mime="application/json",
     width="stretch",
+    key="view_release_decision:download_decision_json",
 )

--- a/src/agilab/apps-pages/view_shap_explanation/src/view_shap_explanation/view_shap_explanation.py
+++ b/src/agilab/apps-pages/view_shap_explanation/src/view_shap_explanation/view_shap_explanation.py
@@ -54,6 +54,9 @@ APP_SCOPED_SESSION_KEYS = (
     "shap_values_glob",
     "shap_feature_values_glob",
     "shap_metadata_glob",
+    f"{PAGE_KEY}:feature_values_file",
+    f"{PAGE_KEY}:metadata_file",
+    f"{PAGE_KEY}:shap_values_file",
 )
 
 
@@ -239,16 +242,19 @@ shap_path = st.sidebar.selectbox(
     "SHAP values file",
     options=shap_files,
     format_func=lambda path: str(Path(path).relative_to(artifact_root)),
+    key=f"{PAGE_KEY}:shap_values_file",
 )
 feature_path = st.sidebar.selectbox(
     "Feature values file",
     options=[*feature_files, None] if feature_files else [None],
     format_func=lambda path: "none" if path is None else str(Path(path).relative_to(artifact_root)),
+    key=f"{PAGE_KEY}:feature_values_file",
 )
 metadata_path = st.sidebar.selectbox(
     "Metadata file",
     options=[*metadata_files, None] if metadata_files else [None],
     format_func=lambda path: "none" if path is None else str(Path(path).relative_to(artifact_root)),
+    key=f"{PAGE_KEY}:metadata_file",
 )
 
 metadata = _load_json(Path(metadata_path) if metadata_path else None)

--- a/src/agilab/orchestrate/orchestrate_cluster.py
+++ b/src/agilab/orchestrate/orchestrate_cluster.py
@@ -9,6 +9,7 @@ from typing import Any, Callable, Optional
 import streamlit as st
 
 from agilab.cluster.cluster_lan_discovery import DiscoveryOptions, discover_lan_nodes
+from agilab.orchestrate.orchestrate_page_support import ORCHESTRATE_ACTION_LABELS
 
 RUN_MODE_LABELS: tuple[str, ...] = (
     "0: python",
@@ -846,7 +847,7 @@ def render_cluster_settings_ui(env: Any, deps: OrchestrateClusterDeps, *, show_r
         lan_action_cols = st.columns(3)
         lan_refresh_clicked = bool(
             lan_action_cols[0].button(
-                "Refresh LAN discovery",
+                ORCHESTRATE_ACTION_LABELS["refresh_lan_discovery"],
                 key=_lan_discovery_refresh_key(app_state_name),
                 help=(
                     "Run LAN discovery, refresh "
@@ -856,7 +857,7 @@ def render_cluster_settings_ui(env: Any, deps: OrchestrateClusterDeps, *, show_r
         )
         lan_advisor_clicked = bool(
             lan_action_cols[1].button(
-                "Build cluster plan",
+                ORCHESTRATE_ACTION_LABELS["build_cluster_plan"],
                 key=_cluster_advisor_plan_key(app_state_name),
                 help="Build an advisory worker-count plan from LAN discovery without changing current settings.",
             )

--- a/src/agilab/orchestrate/orchestrate_execute.py
+++ b/src/agilab/orchestrate/orchestrate_execute.py
@@ -117,6 +117,17 @@ _orchestrate_page_support = import_agilab_module(
     fallback_name="agilab_orchestrate_page_support_fallback",
 )
 app_declares_workerless = _orchestrate_page_support.app_declares_workerless
+ORCHESTRATE_ACTION_LABELS = _orchestrate_page_support.ORCHESTRATE_ACTION_LABELS
+
+_orchestrate_page_helpers = import_agilab_module(
+    "agilab.orchestrate_page_helpers",
+    current_file=__file__,
+    fallback_path=Path(__file__).resolve().parent / "orchestrate_page_helpers.py",
+    fallback_name="agilab_orchestrate_page_helpers_fallback",
+)
+finish_action_elapsed = _orchestrate_page_helpers.finish_action_elapsed
+start_action_elapsed = _orchestrate_page_helpers.start_action_elapsed
+update_action_elapsed_status = _orchestrate_page_helpers.update_action_elapsed_status
 
 _pinned_expander = import_agilab_module(
     "agilab.pinned_expander",
@@ -563,6 +574,7 @@ async def render_execute_section(
         target_expander = current_expander or _ensure_run_log_expander(expanded=True)
         with target_expander:
             log_placeholder = st.empty()
+            elapsed_placeholder = st.empty()
         _reset_traceback_skip()
         log_dir = Path(env.runenv or (Path.home() / "log" / "execute" / env.app))
         log_dir.mkdir(parents=True, exist_ok=True)
@@ -636,6 +648,13 @@ async def render_execute_section(
                         log_file.write(clean + "\n")
                         log_file.flush()
                     update_log(log_placeholder, message)
+                    update_action_elapsed_status(
+                        elapsed_placeholder,
+                        st.session_state,
+                        "orchestrate_run",
+                        ORCHESTRATE_ACTION_LABELS["run"],
+                        started_monotonic=elapsed_started,
+                    )
 
                 _, stderr_text = await env.run_agi(
                     cmd.replace("asyncio.run(main())", env.snippet_tail),
@@ -646,6 +665,14 @@ async def render_execute_section(
 
         run_error: Exception | None = None
         stderr = ""
+        elapsed_started = start_action_elapsed(st.session_state, "orchestrate_run")
+        update_action_elapsed_status(
+            elapsed_placeholder,
+            st.session_state,
+            "orchestrate_run",
+            ORCHESTRATE_ACTION_LABELS["run"],
+            started_monotonic=elapsed_started,
+        )
         with st.spinner("Running AGI..."):
             try:
                 stderr = await _run_and_stream()
@@ -658,6 +685,14 @@ async def render_execute_section(
         if fatal_stderr:
             st.session_state["_last_execute_failed"] = True
         run_failed = run_error is not None or fatal_stderr
+        finish_action_elapsed(
+            elapsed_placeholder,
+            st.session_state,
+            "orchestrate_run",
+            ORCHESTRATE_ACTION_LABELS["run"],
+            status="failed" if run_failed else "completed",
+            started_monotonic=elapsed_started,
+        )
         run_finished_at = _run_markdown_evidence.utc_now_text()
         try:
             started_dt = datetime.fromisoformat(run_started_at.replace("Z", "+00:00"))
@@ -792,9 +827,13 @@ async def render_execute_section(
                 else ""
             )
             run_label = (
-                "Run workflow"
+                ORCHESTRATE_ACTION_LABELS["run_workflow"]
                 if dag_based_app
-                else ("RUN benchmark" if st.session_state.get("benchmark") else "RUN")
+                else (
+                    ORCHESTRATE_ACTION_LABELS["run_benchmark"]
+                    if st.session_state.get("benchmark")
+                    else ORCHESTRATE_ACTION_LABELS["run"]
+                )
             )
             readiness_actions = [
                 (
@@ -829,7 +868,7 @@ async def render_execute_section(
                 _queue_execute_action("run")
 
             if not dag_based_app and load_col is not None and load_col.button(
-                "Load output",
+                ORCHESTRATE_ACTION_LABELS["load_output"],
                 key="load_data_main",
                 type="primary",
                 disabled=not artifact_state.load_action.enabled,
@@ -844,7 +883,7 @@ async def render_execute_section(
                 st.session_state.pop(delete_confirm_key, None)
             elif st.session_state.get(delete_confirm_key, False):
                 if delete_col.button(
-                    "Confirm delete",
+                    ORCHESTRATE_ACTION_LABELS["confirm_delete"],
                     key="delete_data_main_confirm_btn",
                     type="primary",
                     width="stretch",
@@ -859,7 +898,7 @@ async def render_execute_section(
                 )
             elif delete_col is not None:
                 delete_armed_clicked = delete_col.button(
-                    "Delete output",
+                    ORCHESTRATE_ACTION_LABELS["delete_output"],
                     key="delete_data_main",
                     type="secondary",
                     disabled=not artifact_state.delete_action.enabled,
@@ -879,7 +918,7 @@ async def render_execute_section(
             undo_payload = st.session_state.get(delete_undo_key)
             if not dag_based_app and isinstance(undo_payload, dict):
                 undo_delete_clicked = st.button(
-                    "Undo last delete",
+                    ORCHESTRATE_ACTION_LABELS["undo_last_delete"],
                     key="delete_data_main_undo_btn",
                     type="secondary",
                     width="stretch",
@@ -922,7 +961,7 @@ async def render_execute_section(
                 _rerun_fragment_or_app()
 
             if not dag_based_app and st.button(
-                "Run -> Load -> Export",
+                ORCHESTRATE_ACTION_LABELS["run_load_export"],
                 key="combo_exec_load_export",
                 type="primary",
                 disabled=not (execute_state.combo_action.enabled and approval_ready),
@@ -1226,7 +1265,9 @@ async def render_execute_section(
             "detail": str(project_path),
         },
         {
-            "label": "Run workflow" if dag_based_app else "RUN",
+            "label": ORCHESTRATE_ACTION_LABELS["run_workflow"]
+            if dag_based_app
+            else ORCHESTRATE_ACTION_LABELS["run"],
             "state": "done" if latest_log_path or existing_run_log else (
                 "ready" if execute_state.run_action.enabled else "blocked"
             ),
@@ -1237,7 +1278,7 @@ async def render_execute_section(
         timeline_items.extend(
             [
                 {
-                    "label": "Load output",
+                    "label": ORCHESTRATE_ACTION_LABELS["load_output"],
                     "state": "done" if source_preview_path else (
                         "ready" if current_artifact_state.load_action.enabled else "waiting"
                     ),
@@ -1387,7 +1428,7 @@ async def render_execute_section(
             action_col_stats, action_col_export = st.columns([1, 1])
             with action_col_stats:
                 stats_clicked = st.button(
-                    "STATS report",
+                    ORCHESTRATE_ACTION_LABELS["stats_report"],
                     key="stats_report_main",
                     type="primary",
                     disabled=not artifact_state.stats_action.enabled,
@@ -1395,7 +1436,7 @@ async def render_execute_section(
                 )
             with action_col_export:
                 export_clicked_manual = st.button(
-                    "EXPORT dataframe",
+                    ORCHESTRATE_ACTION_LABELS["export_dataframe"],
                     key="export_df_main",
                     type="primary",
                     disabled=not artifact_state.export_action.enabled,
@@ -1410,8 +1451,38 @@ async def render_execute_section(
                 profile_file = st.session_state.profile_report_file
                 if not profile_file.exists():
                     profile = generate_profile_report(loaded_df)
-                    with st.spinner("Generating profile report..."):
-                        profile.to_file(profile_file, silent=False)
+                    elapsed_placeholder = st.empty()
+                    elapsed_started = start_action_elapsed(
+                        st.session_state,
+                        "orchestrate_stats_report",
+                    )
+                    update_action_elapsed_status(
+                        elapsed_placeholder,
+                        st.session_state,
+                        "orchestrate_stats_report",
+                        ORCHESTRATE_ACTION_LABELS["stats_report"],
+                        started_monotonic=elapsed_started,
+                    )
+                    try:
+                        with st.spinner("Generating profile report..."):
+                            profile.to_file(profile_file, silent=False)
+                    except (OSError, RuntimeError, TypeError, ValueError, AttributeError):
+                        finish_action_elapsed(
+                            elapsed_placeholder,
+                            st.session_state,
+                            "orchestrate_stats_report",
+                            ORCHESTRATE_ACTION_LABELS["stats_report"],
+                            status="failed",
+                            started_monotonic=elapsed_started,
+                        )
+                        raise
+                    finish_action_elapsed(
+                        elapsed_placeholder,
+                        st.session_state,
+                        "orchestrate_stats_report",
+                        ORCHESTRATE_ACTION_LABELS["stats_report"],
+                        started_monotonic=elapsed_started,
+                    )
                 open_new_tab(profile_file.as_uri())
 
             if export_clicked:

--- a/src/agilab/orchestrate/orchestrate_page_helpers.py
+++ b/src/agilab/orchestrate/orchestrate_page_helpers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import time
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable, Mapping, MutableMapping, Optional
@@ -207,6 +208,101 @@ def benchmark_display_date(
     except OSError:
         return ""
     return datetime_type.fromtimestamp(ts).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def format_elapsed_seconds(value: Any) -> str:
+    try:
+        seconds = max(0, int(float(value)))
+    except (TypeError, ValueError):
+        seconds = 0
+    minutes, seconds = divmod(seconds, 60)
+    if minutes == 0:
+        return f"{seconds}s"
+    hours, minutes = divmod(minutes, 60)
+    if hours == 0:
+        return f"{minutes}m {seconds}s"
+    return f"{hours}h {minutes}m {seconds}s"
+
+
+def _elapsed_started_key(action_key: str) -> str:
+    return f"{action_key}__elapsed_started_monotonic"
+
+
+def _elapsed_seconds_key(action_key: str) -> str:
+    return f"{action_key}__elapsed_seconds"
+
+
+def _caption_placeholder(placeholder: Any, message: str) -> None:
+    caption = getattr(placeholder, "caption", None)
+    if callable(caption):
+        caption(message)
+        return
+    markdown = getattr(placeholder, "markdown", None)
+    if callable(markdown):
+        markdown(message)
+
+
+def start_action_elapsed(
+    session_state: MutableMapping[str, Any],
+    action_key: str,
+    *,
+    monotonic_fn: Callable[[], float] = time.monotonic,
+) -> float:
+    started = float(monotonic_fn())
+    session_state[_elapsed_started_key(action_key)] = started
+    session_state[_elapsed_seconds_key(action_key)] = 0.0
+    return started
+
+
+def update_action_elapsed_status(
+    placeholder: Any,
+    session_state: MutableMapping[str, Any],
+    action_key: str,
+    label: str,
+    *,
+    started_monotonic: Any = None,
+    monotonic_fn: Callable[[], float] = time.monotonic,
+) -> float:
+    started = started_monotonic
+    if started is None:
+        started = session_state.get(_elapsed_started_key(action_key))
+    try:
+        started_value = float(started)
+    except (TypeError, ValueError):
+        started_value = float(monotonic_fn())
+    elapsed = max(0.0, float(monotonic_fn()) - started_value)
+    session_state[_elapsed_seconds_key(action_key)] = elapsed
+    _caption_placeholder(
+        placeholder,
+        f"{label}: running for {format_elapsed_seconds(elapsed)}",
+    )
+    return elapsed
+
+
+def finish_action_elapsed(
+    placeholder: Any,
+    session_state: MutableMapping[str, Any],
+    action_key: str,
+    label: str,
+    *,
+    status: str = "completed",
+    started_monotonic: Any = None,
+    monotonic_fn: Callable[[], float] = time.monotonic,
+) -> float:
+    started = started_monotonic
+    if started is None:
+        started = session_state.get(_elapsed_started_key(action_key))
+    try:
+        started_value = float(started)
+    except (TypeError, ValueError):
+        started_value = float(monotonic_fn())
+    elapsed = max(0.0, float(monotonic_fn()) - started_value)
+    session_state[_elapsed_seconds_key(action_key)] = elapsed
+    _caption_placeholder(
+        placeholder,
+        f"{label}: {status} in {format_elapsed_seconds(elapsed)}",
+    )
+    return elapsed
 
 
 def display_log(

--- a/src/agilab/orchestrate/orchestrate_page_support.py
+++ b/src/agilab/orchestrate/orchestrate_page_support.py
@@ -51,6 +51,28 @@ DEPLOY_WORKERS_AGI_INSTALL_RATIONALE = (
     "forcing a reinstall; the user-facing action is still deployment because "
     "runtime readiness and workers are the goal."
 )
+ORCHESTRATE_ACTION_LABELS: dict[str, str] = {
+    "deploy_workers": "Deploy workers",
+    "check_distribute": "CHECK distribute",
+    "run": "RUN",
+    "run_benchmark": "RUN benchmark",
+    "run_workflow": "RUN workflow",
+    "run_load_export": "Run -> Load -> Export",
+    "load_output": "Load output",
+    "delete_output": "Delete output",
+    "confirm_delete": "Confirm delete",
+    "undo_last_delete": "Undo last delete",
+    "stats_report": "STATS report",
+    "export_dataframe": "EXPORT dataframe",
+    "refresh_lan_discovery": "Refresh LAN discovery",
+    "build_cluster_plan": "Build cluster plan",
+    "start_service": "START service",
+    "submit_job": "SUBMIT job",
+    "status_service": "STATUS service",
+    "health_gate": "HEALTH gate",
+    "export_snapshot": "EXPORT snapshot",
+    "stop_service": "STOP service",
+}
 
 BENCHMARK_MODE_LEGEND_MARKDOWN = (
     "**Mode legend**  \n"

--- a/src/agilab/orchestrate/orchestrate_services.py
+++ b/src/agilab/orchestrate/orchestrate_services.py
@@ -12,6 +12,12 @@ import streamlit as st
 from agi_gui.ux_widgets import action_button
 
 from agilab.evidence import run_markdown_evidence
+from agilab.orchestrate.orchestrate_page_helpers import (
+    finish_action_elapsed,
+    start_action_elapsed,
+    update_action_elapsed_status,
+)
+from agilab.orchestrate.orchestrate_page_support import ORCHESTRATE_ACTION_LABELS
 from agilab.workflow.action_execution import ActionResult, render_action_result
 
 SERVICE_MODE_POOL = 1
@@ -747,48 +753,49 @@ async def render_service_panel(
         start_col, submit_col, status_col, health_col, export_col, stop_col = st.columns(6)
         start_service_clicked = action_button(
             start_col,
-            "START service",
+            ORCHESTRATE_ACTION_LABELS["start_service"],
             key="service_start_btn",
             kind="run",
             disabled=not service_state.can(OrchestrateServiceAction.START) or not service_approved,
         )
         submit_service_clicked = action_button(
             submit_col,
-            "SUBMIT job",
+            ORCHESTRATE_ACTION_LABELS["submit_job"],
             key="service_submit_btn",
             kind="run",
             disabled=not service_state.can(OrchestrateServiceAction.SUBMIT) or not service_approved,
         )
         status_service_clicked = action_button(
             status_col,
-            "STATUS service",
+            ORCHESTRATE_ACTION_LABELS["status_service"],
             key="service_status_btn",
             kind="refresh",
             disabled=not service_state.can(OrchestrateServiceAction.STATUS),
         )
         health_gate_clicked = action_button(
             health_col,
-            "HEALTH gate",
+            ORCHESTRATE_ACTION_LABELS["health_gate"],
             key="service_health_gate_btn",
             kind="check",
             disabled=not service_state.can(OrchestrateServiceAction.HEALTH_GATE),
         )
         export_snapshot_clicked = action_button(
             export_col,
-            "EXPORT snapshot",
+            ORCHESTRATE_ACTION_LABELS["export_snapshot"],
             key="service_export_btn",
             kind="download",
             disabled=not service_state.can(OrchestrateServiceAction.EXPORT_SNAPSHOT),
         )
         stop_service_clicked = action_button(
             stop_col,
-            "STOP service",
+            ORCHESTRATE_ACTION_LABELS["stop_service"],
             key="service_stop_btn",
             kind="stop",
             disabled=not service_state.can(OrchestrateServiceAction.STOP),
         )
 
         service_log_placeholder = st.empty()
+        service_elapsed_placeholder = st.empty()
         service_health_placeholder = st.empty()
         service_summary_placeholder = st.empty()
         service_snapshot_placeholder = st.empty()
@@ -1007,11 +1014,27 @@ async def render_service_panel(
             service_stdout = ""
             service_stderr = ""
             service_error: Exception | None = None
+            elapsed_key = f"orchestrate_service_{action.value}"
+            elapsed_started = start_action_elapsed(st.session_state, elapsed_key)
+            update_action_elapsed_status(
+                service_elapsed_placeholder,
+                st.session_state,
+                elapsed_key,
+                f"Service {action_name}",
+                started_monotonic=elapsed_started,
+            )
 
             with st.spinner(f"Service action '{action_name}' in progress..."):
                 def _service_log_callback(message: str) -> None:
                     deps.append_log_lines(local_log, message)
                     _render_logs()
+                    update_action_elapsed_status(
+                        service_elapsed_placeholder,
+                        st.session_state,
+                        elapsed_key,
+                        f"Service {action_name}",
+                        started_monotonic=elapsed_started,
+                    )
 
                 runtime_root = (
                     Path(getattr(env, "agi_cluster"))
@@ -1130,6 +1153,14 @@ async def render_service_panel(
             _render_logs()
 
             if service_error or service_stderr.strip():
+                finish_action_elapsed(
+                    service_elapsed_placeholder,
+                    st.session_state,
+                    elapsed_key,
+                    f"Service {action_name}",
+                    status="failed",
+                    started_monotonic=elapsed_started,
+                )
                 service_finished_at = run_markdown_evidence.utc_now_text()
                 try:
                     start_dt = datetime.fromisoformat(service_started_at.replace("Z", "+00:00"))
@@ -1184,6 +1215,13 @@ async def render_service_panel(
                         + ", ".join(str(worker) for worker in restarted_workers)
                     )
             service_finished_at = run_markdown_evidence.utc_now_text()
+            finish_action_elapsed(
+                service_elapsed_placeholder,
+                st.session_state,
+                elapsed_key,
+                f"Service {action_name}",
+                started_monotonic=elapsed_started,
+            )
             try:
                 start_dt = datetime.fromisoformat(service_started_at.replace("Z", "+00:00"))
                 end_dt = datetime.fromisoformat(service_finished_at.replace("Z", "+00:00"))

--- a/src/agilab/pages/1_PROJECT.py
+++ b/src/agilab/pages/1_PROJECT.py
@@ -4577,6 +4577,7 @@ def handle_project_creation():
 
     create_clicked = st.sidebar.button(
         "Create",
+        key="project_create_sidebar_btn",
         type="primary",
         width="stretch",
         disabled=create_mode == CREATE_MODE_NOTEBOOK
@@ -4696,7 +4697,12 @@ def handle_project_rename():
         help="Enter the destination project name. AGILAB appends '_project' if it is missing.",
     ).strip()
 
-    rename_clicked = st.sidebar.button("Rename", type="primary", width="stretch")
+    rename_clicked = st.sidebar.button(
+        "Rename",
+        key="project_rename_sidebar_btn",
+        type="primary",
+        width="stretch",
+    )
     if rename_clicked:
 
         def _activate_renamed_project(result):
@@ -4738,7 +4744,12 @@ def handle_project_delete():
     )
 
     # Delete button
-    delete_clicked = st.sidebar.button("Delete", type="primary", width="stretch")
+    delete_clicked = st.sidebar.button(
+        "Delete",
+        key="project_delete_sidebar_btn",
+        type="primary",
+        width="stretch",
+    )
     if delete_clicked:
 
         def _activate_after_delete(result):
@@ -4832,7 +4843,12 @@ def handle_project_import():
             if cols[1].button("Cancel", width="stretch"):
                 st.rerun()
 
-        import_clicked = st.sidebar.button("Import", type="primary", width="stretch")
+        import_clicked = st.sidebar.button(
+            "Import",
+            key="project_import_sidebar_btn",
+            type="primary",
+            width="stretch",
+        )
         if import_clicked:
             if not target_dir.exists():
                 _run_import_action(overwrite=False)

--- a/src/agilab/pages/2_ORCHESTRATE.py
+++ b/src/agilab/pages/2_ORCHESTRATE.py
@@ -11,7 +11,7 @@ import json
 import logging
 from pathlib import Path
 import importlib
-from typing import Any, Optional, Sequence
+from typing import Any, Callable, Optional, Sequence
 from datetime import datetime
 
 # Third-Party imports
@@ -64,6 +64,7 @@ import_agilab_symbols(
         "compute_run_mode": "compute_run_mode",
         "describe_run_mode": "describe_run_mode",
         "merge_app_settings_sources": "merge_app_settings_sources",
+        "ORCHESTRATE_ACTION_LABELS": "ORCHESTRATE_ACTION_LABELS",
         "optional_python_expr": "optional_python_expr",
         "optional_string_expr": "optional_string_expr",
         "order_benchmark_display_columns": "order_benchmark_display_columns",
@@ -238,7 +239,10 @@ import_agilab_symbols(
         "update_select_all": "_orchestrate_update_select_all",
         "capture_dataframe_preview_state": "_orchestrate_capture_dataframe_preview_state",
         "restore_dataframe_preview_state": "_orchestrate_restore_dataframe_preview_state",
+        "finish_action_elapsed": "_orchestrate_finish_action_elapsed",
         "is_app_installed": "_orchestrate_is_app_installed",
+        "start_action_elapsed": "_orchestrate_start_action_elapsed",
+        "update_action_elapsed_status": "_orchestrate_update_action_elapsed_status",
         "LOG_DISPLAY_MAX_LINES": "LOG_DISPLAY_MAX_LINES",
         "LIVE_LOG_MIN_HEIGHT": "LIVE_LOG_MIN_HEIGHT",
         "INSTALL_LOG_HEIGHT": "INSTALL_LOG_HEIGHT",
@@ -1025,6 +1029,7 @@ async def _check_distribution_action(
     *,
     cmd: str,
     project_path: Path,
+    on_log: Optional[Callable[[], None]] = None,
 ) -> ActionResult:
     dist_log: list[str] = []
     # Distribution snippets import agi_cluster and orchestrate worker-side probes.
@@ -1035,7 +1040,10 @@ async def _check_distribution_action(
     try:
         stdout, stderr = await env.run_agi(
             command,
-            log_callback=lambda message: _append_log_lines(dist_log, message),
+            log_callback=lambda message: (
+                _append_log_lines(dist_log, message),
+                on_log() if on_log is not None else None,
+            ),
             venv=runtime_root,
         )
     except (
@@ -1082,6 +1090,7 @@ async def _install_worker_action(
     install_command: str,
     venv: Any,
     local_log: list[str],
+    on_log: Optional[Callable[[], None]] = None,
 ) -> ActionResult:
     install_stdout = ""
     install_stderr = ""
@@ -1089,7 +1098,10 @@ async def _install_worker_action(
     try:
         install_stdout, install_stderr = await env.run_agi(
             install_command,
-            log_callback=lambda message: _append_log_lines(local_log, message),
+            log_callback=lambda message: (
+                _append_log_lines(local_log, message),
+                on_log() if on_log is not None else None,
+            ),
             venv=None,
         )
     except (
@@ -1576,9 +1588,9 @@ def _orchestrate_notebook_document(
 def _render_orchestrate_notebook_expander(env: Any) -> None:
     snippets: list[tuple[str, str]] = []
     for name, label in (
-        ("install", "Deploy workers"),
-        ("distribution", "CHECK distribute"),
-        ("run", "RUN"),
+        ("install", ORCHESTRATE_ACTION_LABELS["deploy_workers"]),
+        ("distribution", ORCHESTRATE_ACTION_LABELS["check_distribute"]),
+        ("run", ORCHESTRATE_ACTION_LABELS["run"]),
     ):
         snippet = st.session_state.get(_orchestrate_snippet_state_key(env, name))
         if isinstance(snippet, str) and snippet.strip():
@@ -1805,7 +1817,8 @@ async def _render_deployment_panel(
             raw_workers=raw_workers,
             timestamp=datetime.now().isoformat(timespec="seconds"),
         )
-        with st.expander("Generated Deploy workers snippet", expanded=False):
+        deploy_workers_label = ORCHESTRATE_ACTION_LABELS["deploy_workers"]
+        with st.expander(f"Generated {deploy_workers_label} snippet", expanded=False):
             st.code(cmd, language="python")
             st.caption(DEPLOY_WORKERS_AGI_INSTALL_RATIONALE)
         if not install_state.action.enabled:
@@ -1819,7 +1832,7 @@ async def _render_deployment_panel(
                 log_placeholder.code(existing_log, language="python")
         pending_install_requested = consume_pending_install_action(st.session_state)
         install_requested = st.button(
-            "Deploy workers",
+            ORCHESTRATE_ACTION_LABELS["deploy_workers"],
             key="install_btn",
             type="primary",
             disabled=not install_state.action.enabled,
@@ -1843,6 +1856,7 @@ async def _render_deployment_panel(
             log_expander = st.expander("Deployment logs", expanded=True)
             with log_expander:
                 log_placeholder = st.empty()
+                elapsed_placeholder = st.empty()
             with log_expander:
                 log_placeholder.empty()
                 for line in context_lines:
@@ -1852,6 +1866,27 @@ async def _render_deployment_panel(
                 language="python",
                 height=INSTALL_LOG_HEIGHT,
             )
+            elapsed_started = _orchestrate_start_action_elapsed(
+                st.session_state,
+                "orchestrate_deploy_workers",
+            )
+            _orchestrate_update_action_elapsed_status(
+                elapsed_placeholder,
+                st.session_state,
+                "orchestrate_deploy_workers",
+                deploy_workers_label,
+                started_monotonic=elapsed_started,
+            )
+
+            def _tick_deploy_elapsed() -> None:
+                _orchestrate_update_action_elapsed_status(
+                    elapsed_placeholder,
+                    st.session_state,
+                    "orchestrate_deploy_workers",
+                    deploy_workers_label,
+                    started_monotonic=elapsed_started,
+                )
+
             spinner_label = (
                 "Installing app..." if workerless else "Installing worker..."
             )
@@ -1861,6 +1896,15 @@ async def _render_deployment_panel(
                     install_command=install_command,
                     venv=venv,
                     local_log=local_log,
+                    on_log=_tick_deploy_elapsed,
+                )
+                _orchestrate_finish_action_elapsed(
+                    elapsed_placeholder,
+                    st.session_state,
+                    "orchestrate_deploy_workers",
+                    deploy_workers_label,
+                    status="completed" if result.status == "success" else "failed",
+                    started_monotonic=elapsed_started,
                 )
                 with log_expander:
                     log_placeholder.code(
@@ -2008,25 +2052,57 @@ async def _render_distribution_panel(
             cmd=cmd,
             worker_env_path=getattr(env, "wenv_abs", None),
         )
-        with st.expander("Generated CHECK distribute snippet", expanded=False):
+        check_distribute_label = ORCHESTRATE_ACTION_LABELS["check_distribute"]
+        with st.expander(f"Generated {check_distribute_label} snippet", expanded=False):
             st.code(cmd, language="python")
         if not distribution_state.action.enabled:
             st.caption(distribution_state.action.disabled_reason)
         if st.button(
-            "CHECK distribute",
+            ORCHESTRATE_ACTION_LABELS["check_distribute"],
             key="preview_btn",
             type="primary",
             disabled=not distribution_state.action.enabled,
         ):
             with st.expander("Orchestration log", expanded=True):
                 live_log_placeholder = st.empty()
+                elapsed_placeholder = st.empty()
                 _reset_traceback_skip()
+                elapsed_started = _orchestrate_start_action_elapsed(
+                    st.session_state,
+                    "orchestrate_check_distribute",
+                )
+                _orchestrate_update_action_elapsed_status(
+                    elapsed_placeholder,
+                    st.session_state,
+                    "orchestrate_check_distribute",
+                    check_distribute_label,
+                    started_monotonic=elapsed_started,
+                )
+
+                def _tick_distribution_elapsed() -> None:
+                    _orchestrate_update_action_elapsed_status(
+                        elapsed_placeholder,
+                        st.session_state,
+                        "orchestrate_check_distribute",
+                        check_distribute_label,
+                        started_monotonic=elapsed_started,
+                    )
+
                 with st.spinner("Building distribution..."):
                     result = await _check_distribution_action(
                         env,
                         cmd=cmd,
                         project_path=project_path,
+                        on_log=_tick_distribution_elapsed,
                     )
+                _orchestrate_finish_action_elapsed(
+                    elapsed_placeholder,
+                    st.session_state,
+                    "orchestrate_check_distribute",
+                    check_distribute_label,
+                    status="completed" if result.status == "success" else "failed",
+                    started_monotonic=elapsed_started,
+                )
                 dist_log = list(result.data.get("dist_log", ()))
                 live_log_placeholder.code(
                     "\n".join(dist_log[-LOG_DISPLAY_MAX_LINES:]),

--- a/src/agilab/pages/3_WORKFLOW.py
+++ b/src/agilab/pages/3_WORKFLOW.py
@@ -19,12 +19,6 @@ import streamlit as st
 from streamlit.errors import StreamlitAPIException
 import tomllib  # For reading TOML files
 
-PIPELINE_PROJECT_LABEL = "Project"
-PIPELINE_PROJECT_HELP = (
-    "Project workspace whose workflow stages and exported artifacts are shown below. "
-    "Type in the dropdown to search."
-)
-
 _import_guard_path = Path(__file__).resolve().parents[1] / "import_guard.py"
 _import_guard_spec = importlib.util.spec_from_file_location(
     "agilab_import_guard_local", _import_guard_path

--- a/src/agilab/pages/4_ANALYSIS.py
+++ b/src/agilab/pages/4_ANALYSIS.py
@@ -3016,12 +3016,17 @@ async def main():
     if st.session_state.get(notebook_selection_key) != notebook_widget_selection:
         st.session_state[notebook_selection_key] = notebook_widget_selection
     selected_notebooks = list(notebook_widget_selection)
+    sidebar_launchers_rendered = False
 
     def _render_sidebar_launchers(
         *,
         sidebar_selected_views: list[str],
         sidebar_selected_notebooks: list[str],
     ) -> None:
+        nonlocal sidebar_launchers_rendered
+        if sidebar_launchers_rendered:
+            return
+        sidebar_launchers_rendered = True
         _render_analysis_sidebar_view_launcher(
             project=project,
             selected_views=sidebar_selected_views,

--- a/test/test_analysis_page_helpers.py
+++ b/test/test_analysis_page_helpers.py
@@ -478,6 +478,92 @@ def test_main_does_not_hide_parent_sidebar_on_main_route(tmp_path: Path, monkeyp
     assert sidebar_hides == []
 
 
+def test_main_renders_sidebar_launchers_once_when_route_helper_falls_through(
+    tmp_path: Path,
+    monkeypatch,
+):
+    module = _load_analysis_module()
+    launcher_calls: list[tuple[str, tuple[str, ...]]] = []
+    view_path = tmp_path / "pages" / "view_demo.py"
+    view_path.parent.mkdir(parents=True)
+    view_path.write_text("def render(): pass\n", encoding="utf-8")
+
+    class _Context:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, traceback):
+            return False
+
+    fake_st = SimpleNamespace(
+        query_params={
+            "active_app": "flight_telemetry_project",
+            "current_page": "view_demo",
+        },
+        session_state={},
+    )
+    fake_st.info = lambda *_args, **_kwargs: None
+    fake_st.caption = lambda *_args, **_kwargs: None
+    fake_st.expander = lambda *_args, **_kwargs: _Context()
+    fake_st.multiselect = (
+        lambda _label, _options, *, key, **_kwargs: list(fake_st.session_state.get(key, []))
+    )
+    fake_env = SimpleNamespace(
+        app="flight_telemetry_project",
+        projects=["flight_telemetry_project"],
+        AGILAB_PAGES_ABS=str(view_path.parent),
+        resolve_user_app_settings_file=lambda _project: tmp_path / "app_settings.toml",
+    )
+
+    async def _false(*_args, **_kwargs):
+        return False
+
+    monkeypatch.setattr(module, "st", fake_st)
+    monkeypatch.setattr(module, "_initialize_analysis_env", lambda _request: fake_env)
+    monkeypatch.setattr(module, "_read_config", lambda _path: {"pages": {"view_module": ["view_demo"]}})
+    monkeypatch.setattr(module, "_write_config", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(module, "_migrate_declared_app_ui_page_config", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(module, "_migrate_declared_app_surface_config", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(module, "_migrate_legacy_analysis_page_config", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(module, "discover_views", lambda _path: [view_path])
+    monkeypatch.setattr(module, "_resolve_discovered_views", lambda _views: {"view_demo": view_path})
+    monkeypatch.setattr(module, "discover_project_notebooks", lambda _active_app_path: {})
+    monkeypatch.setattr(module, "_consume_legacy_app_ui_route_for_app_surface", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(module, "_render_selected_notebook_route", _false)
+    monkeypatch.setattr(module, "_render_selected_view_route", _false)
+    monkeypatch.setattr(module, "_render_configured_app_surface", _false)
+    monkeypatch.setattr(module, "_active_app_path_for_env", lambda _env: tmp_path / "app")
+    monkeypatch.setattr(module, "render_page_header", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(module, "_store_active_app", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(module, "_render_analysis_project_sidebar_label", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        module,
+        "_render_analysis_sidebar_view_launcher",
+        lambda **kwargs: launcher_calls.append(
+            ("views", tuple(kwargs.get("selected_views") or ()))
+        ),
+    )
+    monkeypatch.setattr(
+        module,
+        "_render_analysis_sidebar_notebook_launcher",
+        lambda **kwargs: launcher_calls.append(
+            ("notebooks", tuple(kwargs.get("selected_notebooks") or ()))
+        ),
+    )
+    monkeypatch.setattr(module, "_render_analysis_workspace_overview", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(module, "render_project_evidence_drawer", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(module, "render_context_expander", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(module, "_render_analysis_surface_guide", lambda **_kwargs: None)
+    monkeypatch.setattr(module, "_render_custom_analysis_page_authoring", lambda **_kwargs: None)
+
+    asyncio.run(module.main())
+
+    assert launcher_calls == [
+        ("views", ("view_demo",)),
+        ("notebooks", ()),
+    ]
+
+
 def test_main_renders_analysis_context_after_evidence_overview(tmp_path: Path, monkeypatch):
     module = _load_analysis_module()
     events: list[str] = []

--- a/test/test_apps_pages_docs.py
+++ b/test/test_apps_pages_docs.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ast
 from pathlib import Path
 
 
@@ -58,3 +59,56 @@ def test_apps_pages_quality_bar_is_documented_and_enforced() -> None:
             "agi_pages.runtime" in path.read_text(encoding="utf-8", errors="ignore")
             for path in source_files
         ), module_name
+
+
+def test_autoencoder_latentspace_is_marked_as_opt_in_playground_exception() -> None:
+    texts = [
+        (APPS_PAGES_ROOT / "README.md").read_text(encoding="utf-8"),
+        (APPS_PAGES_ROOT / "view_autoencoder_latentspace" / "README.md").read_text(encoding="utf-8"),
+        (DOCS_SOURCE / "apps-pages.rst").read_text(encoding="utf-8"),
+        APPS_PAGES_GALLERY.read_text(encoding="utf-8"),
+    ]
+
+    for text in texts:
+        assert "opt-in" in text.lower()
+        assert "autoencoder" in text.lower()
+        assert "in-page" in text.lower()
+
+
+def test_barycentric_dataframe_selector_avoids_session_state_double_init() -> None:
+    source = (
+        APPS_PAGES_ROOT
+        / "view_barycentric"
+        / "src"
+        / "view_barycentric"
+        / "view_barycentric.py"
+    ).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    dataframe_selectboxes = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if (
+            isinstance(func, ast.Attribute)
+            and func.attr == "selectbox"
+            and isinstance(func.value, ast.Attribute)
+            and func.value.attr == "sidebar"
+        ):
+            labels = [
+                keyword.value.value
+                for keyword in node.keywords
+                if keyword.arg == "label"
+                and isinstance(keyword.value, ast.Constant)
+                and isinstance(keyword.value.value, str)
+            ]
+            if labels == ["DataFrame"]:
+                dataframe_selectboxes.append(node)
+
+    assert len(dataframe_selectboxes) == 1
+    keywords = {keyword.arg: keyword for keyword in dataframe_selectboxes[0].keywords}
+    assert isinstance(keywords["key"].value, ast.Constant)
+    assert keywords["key"].value.value == "df_file"
+    assert "index" not in keywords
+    assert "args" not in keywords

--- a/test/test_orchestrate_page_helpers.py
+++ b/test/test_orchestrate_page_helpers.py
@@ -474,6 +474,72 @@ def test_page_helpers_delegate_state_log_and_install_wrappers(monkeypatch, tmp_p
     assert "display_log" in captured
 
 
+def test_orchestrate_action_elapsed_status_updates_non_widget_state():
+    module = _load_orchestrate_page_helpers_module()
+    ticks = iter([100.0, 103.4, 166.0])
+    captions: list[str] = []
+    placeholder = SimpleNamespace(caption=captions.append)
+    session_state: dict[str, object] = {}
+
+    started = module.start_action_elapsed(
+        session_state,
+        "demo_action",
+        monotonic_fn=lambda: next(ticks),
+    )
+    assert started == 100.0
+    assert session_state["demo_action__elapsed_seconds"] == 0.0
+
+    elapsed = module.update_action_elapsed_status(
+        placeholder,
+        session_state,
+        "demo_action",
+        "RUN",
+        started_monotonic=started,
+        monotonic_fn=lambda: next(ticks),
+    )
+    assert elapsed == pytest.approx(3.4)
+    assert captions[-1] == "RUN: running for 3s"
+
+    finished = module.finish_action_elapsed(
+        placeholder,
+        session_state,
+        "demo_action",
+        "RUN",
+        started_monotonic=started,
+        monotonic_fn=lambda: next(ticks),
+    )
+    assert finished == pytest.approx(66.0)
+    assert session_state["demo_action__elapsed_seconds"] == pytest.approx(66.0)
+    assert captions[-1] == "RUN: completed in 1m 6s"
+
+
+def test_orchestrate_action_label_case_policy_is_explicit():
+    support = _import_agilab_module("agilab.orchestrate_page_support")
+
+    assert support.ORCHESTRATE_ACTION_LABELS == {
+        "deploy_workers": "Deploy workers",
+        "check_distribute": "CHECK distribute",
+        "run": "RUN",
+        "run_benchmark": "RUN benchmark",
+        "run_workflow": "RUN workflow",
+        "run_load_export": "Run -> Load -> Export",
+        "load_output": "Load output",
+        "delete_output": "Delete output",
+        "confirm_delete": "Confirm delete",
+        "undo_last_delete": "Undo last delete",
+        "stats_report": "STATS report",
+        "export_dataframe": "EXPORT dataframe",
+        "refresh_lan_discovery": "Refresh LAN discovery",
+        "build_cluster_plan": "Build cluster plan",
+        "start_service": "START service",
+        "submit_job": "SUBMIT job",
+        "status_service": "STATUS service",
+        "health_gate": "HEALTH gate",
+        "export_snapshot": "EXPORT snapshot",
+        "stop_service": "STOP service",
+    }
+
+
 def test_page_helpers_looks_like_shared_path_delegates_project_root(
     monkeypatch, tmp_path
 ):

--- a/test/test_orchestrate_services.py
+++ b/test/test_orchestrate_services.py
@@ -543,6 +543,26 @@ def _service_st(session_state, *, clicked: str | None = None):
     return st
 
 
+def _placeholder_with_info(fake_st, text: str):
+    return next(
+        holder
+        for holder in fake_st._placeholders
+        if holder.last_info is not None and text in holder.last_info
+    )
+
+
+def _placeholder_with_caption(fake_st, text: str):
+    return next(
+        holder
+        for holder in fake_st._placeholders
+        if holder.last_caption is not None and text in holder.last_caption
+    )
+
+
+def _placeholder_with_dataframe(fake_st):
+    return next(holder for holder in fake_st._placeholders if holder.last_df is not None)
+
+
 def test_render_service_panel_renders_preview_without_actions(monkeypatch, tmp_path):
     session_state = _SessionState(
         {
@@ -571,8 +591,7 @@ def test_render_service_panel_renders_preview_without_actions(monkeypatch, tmp_p
     assert any("APP = \"demo\"" in block for block in fake_st._code_blocks)
     assert session_state["service_status_cache"] == "idle"
     assert session_state["service_health_allow_idle__demo"] is False
-    assert fake_st._placeholders[2].last_info is not None
-    assert "Tracked workers: `0`" in fake_st._placeholders[2].last_info
+    _placeholder_with_info(fake_st, "Tracked workers: `0`")
 
 
 def test_render_service_panel_health_gate_action(monkeypatch, tmp_path):
@@ -656,9 +675,8 @@ def test_render_service_panel_health_gate_action(monkeypatch, tmp_path):
     assert any("HEALTH gate passed." in msg for msg in fake_st._success_messages)
     assert any("restart_rate=0.500" in msg for msg in fake_st._caption_messages)
     assert fake_st._placeholders[0].last_code is not None
-    assert fake_st._placeholders[1].last_df is not None
-    assert fake_st._placeholders[2].last_info is not None
-    assert "Unhealthy workers: `1`" in fake_st._placeholders[2].last_info
+    _placeholder_with_dataframe(fake_st)
+    _placeholder_with_info(fake_st, "Unhealthy workers: `1`")
 
 
 def test_render_service_panel_submit_action_queues_work(monkeypatch, tmp_path):
@@ -964,7 +982,7 @@ def test_render_service_panel_health_gate_skips_non_mapping_worker_health_rows(m
     )
 
     assert session_state["service_health_cache"] == health_payload["worker_health"]
-    assert fake_st._placeholders[1].last_df is not None
+    _placeholder_with_dataframe(fake_st)
 
 
 def test_render_service_panel_handles_status_error_and_cached_health_failures(monkeypatch, tmp_path):
@@ -1217,8 +1235,7 @@ def test_render_service_panel_exports_operator_snapshot(monkeypatch, tmp_path):
     assert payload["status"] == "running"
     assert payload["summary"]["unhealthy_workers"] == 1
     assert session_state["service_snapshot_path_cache"] == str(expected_path)
-    assert fake_st._placeholders[3].last_caption is not None
-    assert str(expected_path) in fake_st._placeholders[3].last_caption
+    _placeholder_with_caption(fake_st, str(expected_path))
     assert any("Operator snapshot exported" in msg for msg in fake_st._success_messages)
 
 

--- a/test/test_ui_pages.py
+++ b/test/test_ui_pages.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ast
 import importlib.util
 import importlib
 import json
@@ -2469,6 +2470,7 @@ def test_project_sidebar_orders_active_project_before_actions():
     assert dashboard_body.index("with st.container(border=True):") < dashboard_body.index(
         'st.expander("Project metrics", expanded=False)'
     )
+
     assert dashboard_body.index(
         'st.expander("Project metrics", expanded=False)'
     ) < dashboard_body.index("render_environment_details(st, health.details)")
@@ -2500,6 +2502,46 @@ def test_project_sidebar_orders_active_project_before_actions():
         "project_editor_page.render_project_sidebar("
     )
     assert chrome_index < selector_index < sidebar_index < dashboard_index
+
+
+def test_project_sidebar_action_buttons_have_stable_keys():
+    source = Path("src/agilab/pages/1_PROJECT.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    expected = {
+        "Create": "project_create_sidebar_btn",
+        "Rename": "project_rename_sidebar_btn",
+        "Delete": "project_delete_sidebar_btn",
+        "Import": "project_import_sidebar_btn",
+    }
+    found: dict[str, str] = {}
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+            continue
+        if node.func.attr != "button":
+            continue
+        owner = node.func.value
+        if (
+            not isinstance(owner, ast.Attribute)
+            or owner.attr != "sidebar"
+            or not isinstance(owner.value, ast.Name)
+            or owner.value.id != "st"
+            or not node.args
+            or not isinstance(node.args[0], ast.Constant)
+            or not isinstance(node.args[0].value, str)
+        ):
+            continue
+        label = node.args[0].value
+        if label not in expected:
+            continue
+        key_node = next(
+            (keyword.value for keyword in node.keywords if keyword.arg == "key"),
+            None,
+        )
+        if isinstance(key_node, ast.Constant) and isinstance(key_node.value, str):
+            found[label] = key_node.value
+
+    assert found == expected
 
 
 def test_project_status_reloads_editor_helpers_when_source_changes():

--- a/test/test_ui_robot_action_contract.py
+++ b/test/test_ui_robot_action_contract.py
@@ -104,10 +104,12 @@ from streamlit import button
 
 ANNOTATED_LABEL: str = "Reset project"
 CONCAT_LABEL = "Delete " + "cache"
+ACTION_LABELS = {"reset": "Reset from map"}
 DYNAMIC_LABEL = f"Delete {object()}"
 
 button(ANNOTATED_LABEL)
 button(CONCAT_LABEL)
+button(ACTION_LABELS["reset"])
 button(DYNAMIC_LABEL)
 """,
     )
@@ -120,6 +122,7 @@ button(DYNAMIC_LABEL)
 
     assert [(item.label, item.kind) for item in occurrences] == [
         ("Delete cache", "button"),
+        ("Reset from map", "button"),
         ("Reset project", "button"),
     ]
 

--- a/test/test_view_autoencoder_latentspace.py
+++ b/test/test_view_autoencoder_latentspace.py
@@ -375,7 +375,7 @@ def test_bary_visualisation_supports_color_and_plain_modes(monkeypatch) -> None:
         module,
         "st",
         SimpleNamespace(
-            selectbox=lambda label, options: list(options)[0],
+            selectbox=lambda label, options, **kwargs: list(options)[0],
             markdown=markdowns.append,
             table=lambda data: tables.append(data),
             write=lambda value: writes.append(value),

--- a/test/test_view_barycentric.py
+++ b/test/test_view_barycentric.py
@@ -338,7 +338,7 @@ def test_bary_visualisation_supports_colored_and_plain_modes(monkeypatch) -> Non
             session_state=state,
             header=headers.append,
             write=lambda value: writes.append(value),
-            selectbox=lambda label, label_visibility=None, options=None: options[0],
+            selectbox=lambda label, label_visibility=None, options=None, **kwargs: options[0],
         ),
     )
 
@@ -366,7 +366,7 @@ def test_bary_visualisation_supports_colored_and_plain_modes(monkeypatch) -> Non
             session_state=state,
             header=headers.append,
             write=lambda value: writes.append(value),
-            selectbox=lambda label, label_visibility=None, options=None: options[1],
+            selectbox=lambda label, label_visibility=None, options=None, **kwargs: options[1],
         ),
     )
 
@@ -441,7 +441,7 @@ def test_bary_visualisation_handles_categorical_colors_and_jump(monkeypatch) -> 
             session_state=session_state,
             header=lambda *_args, **_kwargs: None,
             write=fail_write,
-            selectbox=lambda label, label_visibility=None, options=None: options[0],
+            selectbox=lambda label, label_visibility=None, options=None, **kwargs: options[0],
         ),
     )
 
@@ -577,7 +577,7 @@ def test_page_with_single_distinct_axis_shows_info(monkeypatch, tmp_path: Path) 
     assert any("only 1 distinct value" in message for message in infos)
 
 
-def test_page_warns_when_no_files_or_no_selection(monkeypatch, tmp_path: Path) -> None:
+def test_page_warns_when_no_files(monkeypatch, tmp_path: Path) -> None:
     module = _load_module()
     datadir = tmp_path / "data"
     datadir.mkdir()
@@ -588,9 +588,15 @@ def test_page_warns_when_no_files_or_no_selection(monkeypatch, tmp_path: Path) -
     class _StopCalled(RuntimeError):
         pass
 
+    df_select_calls = []
+
+    def sidebar_selectbox(*args, **kwargs):
+        df_select_calls.append((args, kwargs))
+        return None
+
     sidebar = SimpleNamespace(
         text_input=lambda *args, **kwargs: None,
-        selectbox=lambda *args, **kwargs: None,
+        selectbox=sidebar_selectbox,
         error=lambda *args, **kwargs: None,
     )
 
@@ -610,23 +616,6 @@ def test_page_warns_when_no_files_or_no_selection(monkeypatch, tmp_path: Path) -
     with pytest.raises(_StopCalled):
         module.page(env)
     assert any("dataset is required" in message.lower() for message in warnings)
-
-    warnings.clear()
-    data_file = datadir / "dataset.csv"
-    data_file.write_text("a,b\n1,2\n", encoding="utf-8")
-    monkeypatch.setattr(module, "find_files", lambda *_args, **_kwargs: [data_file])
-    monkeypatch.setattr(
-        module,
-        "st",
-        SimpleNamespace(
-            session_state=_State(datadir=str(datadir)),
-            sidebar=sidebar,
-            warning=warnings.append,
-            error=lambda *args, **kwargs: None,
-        ),
-    )
-    module.page(env)
-    assert any("Please select a dataset" in message for message in warnings)
 
 
 def test_page_warns_when_loaded_df_invalid(monkeypatch, tmp_path: Path) -> None:
@@ -691,9 +680,15 @@ def test_view_barycentric_page_seeds_df_file_from_persisted_settings(monkeypatch
             return False
 
     session_state = _State()
+    df_select_calls = []
+
+    def sidebar_selectbox(*args, **kwargs):
+        df_select_calls.append((args, kwargs))
+        return None
+
     sidebar = SimpleNamespace(
         text_input=lambda *args, **kwargs: None,
-        selectbox=lambda *args, **kwargs: None,
+        selectbox=sidebar_selectbox,
         error=lambda *args, **kwargs: None,
     )
     monkeypatch.setattr(module, "find_files", lambda *_args, **_kwargs: [data_file])
@@ -723,6 +718,12 @@ def test_view_barycentric_page_seeds_df_file_from_persisted_settings(monkeypatch
 
     env = SimpleNamespace(target="demo_bary", projects=["demo_bary"], app_settings_file=settings_path)
     module.page(env)
+    assert session_state["df_file"] == "dataset.csv"
+    assert df_select_calls
+    _, df_select_kwargs = df_select_calls[0]
+    assert df_select_kwargs["key"] == "df_file"
+    assert "index" not in df_select_kwargs
+    assert "args" not in df_select_kwargs
 
     assert session_state["datadir"] == str(datadir)
     assert session_state["df_file"] == "dataset.csv"

--- a/tools/ui_robot_action_contract.py
+++ b/tools/ui_robot_action_contract.py
@@ -18,6 +18,7 @@ WIDGET_ROBOT_PATH = REPO_ROOT / "tools" / "agilab_widget_robot.py"
 MATRIX_PATH = REPO_ROOT / "tools" / "agilab_widget_robot_matrix.py"
 SCHEMA = "agilab.ui_robot_action_contract.v1"
 DEFAULT_SOURCE_ROOTS = (REPO_ROOT / "src/agilab",)
+SHARED_ACTION_LABELS_SOURCE = REPO_ROOT / "src/agilab/orchestrate/orchestrate_page_support.py"
 ACTION_CALL_NAMES = {"button", "form_submit_button", "download_button"}
 EXCLUDED_PATH_PARTS = {
     ".git",
@@ -193,11 +194,24 @@ def _is_excluded(path: Path) -> bool:
     return any(part in EXCLUDED_PATH_PARTS for part in path.parts)
 
 
-def _literal_string(node: ast.AST, constants: Mapping[str, str]) -> str | None:
+def _literal_string(
+    node: ast.AST,
+    constants: Mapping[str, str],
+    string_maps: Mapping[str, Mapping[str, str]] | None = None,
+) -> str | None:
+    string_maps = string_maps or {}
     if isinstance(node, ast.Constant) and isinstance(node.value, str):
         return node.value
     if isinstance(node, ast.Name):
         return constants.get(node.id)
+    if isinstance(node, ast.Subscript) and isinstance(node.value, ast.Name):
+        source_map = string_maps.get(node.value.id)
+        if source_map is None:
+            return None
+        key = _literal_string(node.slice, constants, string_maps)
+        if key is None:
+            return None
+        return source_map.get(key)
     if isinstance(node, ast.JoinedStr):
         parts: list[str] = []
         for value in node.values:
@@ -207,25 +221,75 @@ def _literal_string(node: ast.AST, constants: Mapping[str, str]) -> str | None:
                 return None
         return "".join(parts)
     if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
-        left = _literal_string(node.left, constants)
-        right = _literal_string(node.right, constants)
+        left = _literal_string(node.left, constants, string_maps)
+        right = _literal_string(node.right, constants, string_maps)
         if left is not None and right is not None:
             return left + right
     return None
 
 
-def _module_string_constants(tree: ast.AST) -> dict[str, str]:
+def _literal_string_dict(
+    node: ast.AST,
+    constants: Mapping[str, str],
+    string_maps: Mapping[str, Mapping[str, str]] | None = None,
+) -> dict[str, str] | None:
+    if not isinstance(node, ast.Dict):
+        return None
+    result: dict[str, str] = {}
+    for key_node, value_node in zip(node.keys, node.values, strict=False):
+        if key_node is None:
+            return None
+        key = _literal_string(key_node, constants, string_maps)
+        value = _literal_string(value_node, constants, string_maps)
+        if key is None or value is None:
+            return None
+        result[key] = value
+    return result
+
+
+def _module_string_constants(
+    tree: ast.AST,
+    string_maps: Mapping[str, Mapping[str, str]] | None = None,
+) -> dict[str, str]:
     constants: dict[str, str] = {}
     for node in ast.iter_child_nodes(tree):
         if isinstance(node, ast.Assign) and len(node.targets) == 1 and isinstance(node.targets[0], ast.Name):
-            value = _literal_string(node.value, constants)
+            value = _literal_string(node.value, constants, string_maps)
             if value is not None:
                 constants[node.targets[0].id] = value
         elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
-            value = _literal_string(node.value, constants) if node.value is not None else None
+            value = _literal_string(node.value, constants, string_maps) if node.value is not None else None
             if value is not None:
                 constants[node.target.id] = value
     return constants
+
+
+def _module_string_maps(tree: ast.AST) -> dict[str, dict[str, str]]:
+    maps: dict[str, dict[str, str]] = {}
+    constants = _module_string_constants(tree)
+    for node in ast.iter_child_nodes(tree):
+        target_name: str | None = None
+        value_node: ast.AST | None = None
+        if isinstance(node, ast.Assign) and len(node.targets) == 1 and isinstance(node.targets[0], ast.Name):
+            target_name = node.targets[0].id
+            value_node = node.value
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            target_name = node.target.id
+            value_node = node.value
+        if target_name is None or value_node is None:
+            continue
+        value = _literal_string_dict(value_node, constants)
+        if value is not None:
+            maps[target_name] = value
+    return maps
+
+
+def _shared_string_maps() -> dict[str, dict[str, str]]:
+    try:
+        tree = ast.parse(SHARED_ACTION_LABELS_SOURCE.read_text(encoding="utf-8"))
+    except (OSError, SyntaxError, UnicodeDecodeError):
+        return {}
+    return _module_string_maps(tree)
 
 
 def _call_name(node: ast.Call) -> str:
@@ -236,14 +300,22 @@ def _call_name(node: ast.Call) -> str:
     return ""
 
 
-def _call_label(node: ast.Call, constants: Mapping[str, str]) -> str | None:
+def _call_label(
+    node: ast.Call,
+    constants: Mapping[str, str],
+    string_maps: Mapping[str, Mapping[str, str]] | None = None,
+) -> str | None:
     if node.args:
-        label = _literal_string(node.args[0], constants)
+        label = _literal_string(node.args[0], constants, string_maps)
         if label is not None:
             return label
+        if len(node.args) > 1:
+            label = _literal_string(node.args[1], constants, string_maps)
+            if label is not None:
+                return label
     for keyword in node.keywords:
         if keyword.arg == "label":
-            return _literal_string(keyword.value, constants)
+            return _literal_string(keyword.value, constants, string_maps)
     return None
 
 
@@ -253,6 +325,7 @@ def scan_action_occurrences(
     widget_robot: Any,
 ) -> list[ActionOccurrence]:
     occurrences: list[ActionOccurrence] = []
+    shared_string_maps = _shared_string_maps()
     for root in source_roots:
         resolved_root = root if root.is_absolute() else REPO_ROOT / root
         if not resolved_root.exists():
@@ -264,14 +337,15 @@ def scan_action_occurrences(
                 tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
             except (OSError, SyntaxError, UnicodeDecodeError):
                 continue
-            constants = _module_string_constants(tree)
+            string_maps = {**shared_string_maps, **_module_string_maps(tree)}
+            constants = _module_string_constants(tree, string_maps)
             for node in ast.walk(tree):
                 if not isinstance(node, ast.Call):
                     continue
                 name = _call_name(node)
                 if name not in ACTION_CALL_NAMES:
                     continue
-                label = _call_label(node, constants)
+                label = _call_label(node, constants, string_maps)
                 if not label:
                     continue
                 try:


### PR DESCRIPTION
## Summary
- add stable PROJECT/ANALYSIS/ORCHESTRATE page hygiene fixes
- add compact elapsed status for long ORCHESTRATE actions and centralize action labels
- tighten apps-pages key hygiene and document the autoencoder page as an opt-in playground exception
- refresh docs mirror and ANALYSIS maintenance-memory metadata

## Validation
- passed