### PR TITLE
[codex] Label lab snippet execution boundary

### DIFF
--- a/src/agilab/agent_runtime/agi_codex.py
+++ b/src/agilab/agent_runtime/agi_codex.py
@@ -18,6 +18,12 @@ from pathlib import Path
 
 import streamlit as st
 
+SNIPPET_EXECUTION_BOUNDARY = "unrestricted_local_python_snippet"
+SNIPPET_EXECUTION_NOTICE = (
+    "Python snippets run as unrestricted local code in the selected manager environment. "
+    "Review and trust the snippet before running it."
+)
+
 # Ensure the agilab package is importable when running snippets from source checkouts.
 if importlib.util.find_spec("agilab") is None:
     repo_src = Path(__file__).resolve().parents[1]
@@ -26,10 +32,12 @@ if importlib.util.find_spec("agilab") is None:
 
 df = st.session_state.loaded_df
 snippet_file = st.session_state.snippet_file
+st.session_state["workflow_snippet_execution_boundary"] = SNIPPET_EXECUTION_BOUNDARY
+st.warning(SNIPPET_EXECUTION_NOTICE)
 
-with open(snippet_file, "r") as snippet:
+with open(snippet_file, "r", encoding="utf-8") as snippet:
     try:
-        exec(snippet.read())
+        exec(compile(snippet.read(), str(snippet_file), "exec"))
 
     except KeyError as err:
         raise KeyError(

--- a/test/test_pipeline_runtime.py
+++ b/test/test_pipeline_runtime.py
@@ -7,6 +7,7 @@ import importlib.util
 import math
 import os
 from pathlib import Path
+import runpy
 import sqlite3
 import sys
 from types import SimpleNamespace
@@ -1563,6 +1564,39 @@ def test_run_locked_stage_runpy_executes_and_logs(tmp_path, monkeypatch):
     assert any("Output (stage 1):\nrunpy output" in line for line in logs)
     assert "ARTIFACTS" in logs
     assert released == ["lock"]
+
+
+def test_lab_snippet_runner_labels_unrestricted_local_execution(tmp_path, monkeypatch):
+    class SessionState(dict):
+        def __getattr__(self, name):
+            try:
+                return self[name]
+            except KeyError as exc:
+                raise AttributeError(name) from exc
+
+        def __setattr__(self, name, value):
+            self[name] = value
+
+    warnings: list[str] = []
+    snippet_file = tmp_path / "snippet.py"
+    snippet_file.write_text("df = {'answer': 42}\n", encoding="utf-8")
+
+    fake_streamlit = types.ModuleType("streamlit")
+    fake_streamlit.session_state = SessionState(
+        loaded_df={"answer": 0},
+        snippet_file=str(snippet_file),
+    )
+    fake_streamlit.warning = lambda message: warnings.append(message)
+    monkeypatch.setitem(sys.modules, "streamlit", fake_streamlit)
+
+    runpy.run_path("src/agilab/agent_runtime/agi_codex.py")
+
+    assert fake_streamlit.session_state["workflow_snippet_execution_boundary"] == "unrestricted_local_python_snippet"
+    assert warnings == [
+        "Python snippets run as unrestricted local code in the selected manager environment. "
+        "Review and trust the snippet before running it."
+    ]
+    assert fake_streamlit.session_state.data == {"answer": 42}
 
 
 def test_run_locked_stage_handles_missing_snippet_and_lock_refusal(tmp_path, monkeypatch):


### PR DESCRIPTION
## What changed

- Labels the WORKFLOW lab-snippet runner as unrestricted local Python before snippet execution.
- Records `workflow_snippet_execution_boundary` in Streamlit session state for diagnostics.
- Compiles snippets with the actual snippet file path so traceback provenance is clearer.
- Adds a focused regression for the boundary notice and marker.

## Why

The WORKFLOW dataframe codegen path is restricted, while imported lab snippets intentionally execute as local trusted operator code. This PR makes that boundary explicit so users do not infer sandboxing where none exists.

## Validation

- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_pipeline_runtime.py -k 'lab_snippet_runner_labels_unrestricted_local_execution or load_capacity_predictor'`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files src/agilab/agent_runtime/agi_codex.py test/test_pipeline_runtime.py`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_pipeline_runtime.py`
- `uv --preview-features extra-build-dependencies run --extra dev ruff check src/agilab/agent_runtime/agi_codex.py test/test_pipeline_runtime.py`
- `git diff --check`
- `./dev scope`
