### PR TITLE
[codex] Tighten test suite enforcement

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -147,7 +147,7 @@ jobs:
             python -m coverage run --data-file=.coverage.agi-core-combined \
             --source=agi_node,agi_cluster \
             -m pytest -q --maxfail=1 --disable-warnings -o addopts='' --import-mode=importlib \
-            src/agilab/core/test
+            src/agilab/core/test src/agilab/core/agi-cluster/test
           uv run --no-project \
             --with-editable ./src/agilab/core/agi-env \
             --with-editable ./src/agilab/core/agi-node \

--- a/.github/workflows/windows-core-tests.yml
+++ b/.github/workflows/windows-core-tests.yml
@@ -69,7 +69,7 @@ jobs:
             --with pytest-cov `
             python -m pytest -q --disable-warnings -o addopts='' --import-mode=importlib `
             --junitxml test-results/windows-core-tests.xml `
-            src/agilab/core/test src/agilab/core/agi-env/test `
+            src/agilab/core/test src/agilab/core/agi-env/test src/agilab/core/agi-cluster/test `
             2>&1 | Tee-Object -FilePath test-results/windows-core-tests.txt
           $exitCode = $LASTEXITCODE
           if ($exitCode -ne 0) {

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,13 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 95%
+        threshold: 1%
+    patch:
+      default:
+        target: 75%
+        threshold: 5%
 flags:
   agi-gui:
     # App-layer surface only: Streamlit pages, apps-pages bundles, and orchestration/pipeline helpers.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -520,6 +520,7 @@ format = "google"
 testpaths = [
   "test",
   "src/agilab/core/test",
+  "src/agilab/core/agi-cluster/test",
   "src/agilab/core/agi-env/test",
   "src/agilab/lib/agi-gui/test",
   "src/agilab/lib/agi-web/test",

--- a/test/test_ci_workflow.py
+++ b/test/test_ci_workflow.py
@@ -15,6 +15,7 @@ UI_ROBOT_MATRIX_WORKFLOW_PATH = Path(".github/workflows/ui-robot-matrix.yml")
 WINDOWS_CORE_TESTS_WORKFLOW_PATH = Path(".github/workflows/windows-core-tests.yml")
 ROOT_CONFTEST_PATH = Path("test/conftest.py")
 WORKFLOW_PARITY_PATH = Path("tools/workflow_parity.py")
+PYPROJECT_PATH = Path("pyproject.toml")
 
 VALIDATION_WORKFLOW_PATHS = (
     WORKFLOW_PATH,
@@ -178,6 +179,20 @@ def test_ci_workflow_includes_minimal_first_proof_contract() -> None:
     assert "--head-ref \"$AGILAB_CORE_CHANGE_HEAD\"" in text
 
 
+def test_root_pytest_discovers_all_existing_core_package_tests() -> None:
+    config = tomllib.loads(PYPROJECT_PATH.read_text(encoding="utf-8"))
+    pytest_options = config["tool"]["pytest"]["ini_options"]
+    testpaths = set(pytest_options["testpaths"])
+    existing_core_test_dirs = {
+        path.as_posix()
+        for path in Path("src/agilab/core").glob("*/test")
+        if path.is_dir()
+    }
+    expected = {"src/agilab/core/test", *existing_core_test_dirs}
+
+    assert expected <= testpaths
+
+
 def test_validation_workflows_cancel_superseded_branch_runs() -> None:
     for path in VALIDATION_WORKFLOW_PATHS:
         text = path.read_text(encoding="utf-8")
@@ -201,7 +216,7 @@ def test_windows_core_tests_workflow_matches_failure_tracker_command() -> None:
     assert 'branches: ["main"]' in text
     assert 'branches: ["**"]' in text
     assert "--import-mode=importlib" in text
-    assert "src/agilab/core/test src/agilab/core/agi-env/test" in text
+    assert "src/agilab/core/test src/agilab/core/agi-env/test src/agilab/core/agi-cluster/test" in text
     assert "test-results/windows-core-tests.txt" in text
     assert "test-results/windows-core-tests.xml" in text
     assert "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2" in text

--- a/test/test_coverage_workflow.py
+++ b/test/test_coverage_workflow.py
@@ -7,6 +7,7 @@ import sys
 
 
 WORKFLOW_PATH = Path(".github/workflows/coverage.yml")
+CODECOV_CONFIG_PATH = Path("codecov.yml")
 AGI_ENV_COVERAGE_CONFIG = Path(".coveragerc.agi-env")
 SHARD_PLAN_PATH = Path("tools/coverage_shard_plan.py")
 
@@ -74,6 +75,7 @@ def test_core_coverage_runs_shared_core_suite_once_for_node_and_cluster() -> Non
     assert "Run agi-node + agi-cluster coverage" in workflow_text
     assert "--source=agi_node,agi_cluster" in workflow_text
     assert workflow_text.count("src/agilab/core/test") == 1
+    assert workflow_text.count("src/agilab/core/agi-cluster/test") == 1
     assert "coverage-agi-node.xml" in workflow_text
     assert "coverage-agi-cluster.xml" in workflow_text
     assert "      - agi-core" in workflow_text
@@ -419,6 +421,24 @@ def test_codecov_uploads_are_blocking_coverage_publication_gates() -> None:
         assert "# v6" in block
         assert "continue-on-error: true" not in block
         assert "fail_ci_if_error: true" in block
+
+
+def test_codecov_config_enforces_project_and_patch_coverage_floor() -> None:
+    config_text = CODECOV_CONFIG_PATH.read_text(encoding="utf-8")
+
+    assert re.search(
+        r"coverage:\n"
+        r"  status:\n"
+        r"    project:\n"
+        r"      default:\n"
+        r"        target: 95%\n"
+        r"        threshold: 1%\n"
+        r"    patch:\n"
+        r"      default:\n"
+        r"        target: 75%\n"
+        r"        threshold: 5%",
+        config_text,
+    )
 
 
 def test_coverage_artifacts_have_short_retention_for_cost_control() -> None:

--- a/test/test_workflow_parity.py
+++ b/test/test_workflow_parity.py
@@ -205,7 +205,10 @@ def test_profile_commands_cover_expected_coverage_and_docs_contracts() -> None:
     combined_node_xml = agi_core_combined[1]
     combined_cluster_xml = agi_core_combined[2]
     assert combined_run.timeout_seconds == 20 * 60
-    assert combined_run.argv[-1] == "src/agilab/core/test"
+    assert combined_run.argv[-2:] == [
+        "src/agilab/core/test",
+        "src/agilab/core/agi-cluster/test",
+    ]
     assert "--import-mode=importlib" in combined_run.argv
     assert "--data-file=.coverage.agi-core-combined" in combined_run.argv
     assert "--source=agi_node,agi_cluster" in combined_run.argv
@@ -236,7 +239,10 @@ def test_profile_commands_cover_expected_coverage_and_docs_contracts() -> None:
     assert "--cov=agi_cluster" in agi_cluster.argv
     assert "coverage-agi-cluster.xml" in " ".join(agi_cluster.argv)
     assert _has_with_dependency(agi_cluster.argv, "fastparquet")
-    assert agi_cluster.argv[-1] == "src/agilab/core/test"
+    assert agi_cluster.argv[-2:] == [
+        "src/agilab/core/test",
+        "src/agilab/core/agi-cluster/test",
+    ]
 
     assert [command.label for command in agi_gui_commands] == [
         "agi-gui coverage (support)",

--- a/tools/workflow_parity.py
+++ b/tools/workflow_parity.py
@@ -981,6 +981,7 @@ def _agi_core_combined_profile() -> list[CommandSpec]:
                 "addopts=",
                 "--import-mode=importlib",
                 "src/agilab/core/test",
+                "src/agilab/core/agi-cluster/test",
             ],
             timeout_seconds=20 * 60,
             remove_paths=[
@@ -1055,6 +1056,7 @@ def _agi_cluster_profile() -> list[CommandSpec]:
                 "--cov=agi_cluster",
                 "--cov-report=xml:coverage-agi-cluster.xml",
                 "src/agilab/core/test",
+                "src/agilab/core/agi-cluster/test",
             ],
             env={"COVERAGE_FILE": ".coverage.agi-cluster"},
             timeout_seconds=20 * 60,


### PR DESCRIPTION
## What changed

- Adds Codecov project and patch coverage status floors in `codecov.yml`.
- Adds the existing `src/agilab/core/agi-cluster/test` directory to root pytest discovery.
- Includes the cluster package test path in the coverage workflow, Windows core workflow, and local `workflow_parity.py` coverage profiles.
- Adds regressions so root pytest discovery and Codecov coverage-floor config cannot drift silently.

## Why

The test-suite audit found two enforcement/discovery gaps: coverage was measured but had no explicit threshold, and contributor/root test discovery skipped an existing core package test directory. CI already covered node/cluster through the shared core suite, but the package-level cluster test was not part of root discovery or the combined coverage profile.

## Validation

- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files codecov.yml pyproject.toml .github/workflows/coverage.yml .github/workflows/windows-core-tests.yml tools/workflow_parity.py test/test_ci_workflow.py test/test_coverage_workflow.py test/test_workflow_parity.py`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_coverage_workflow.py test/test_pyproject_dependency_hygiene.py test/test_ci_workflow.py test/test_workflow_parity.py`
- `uv --preview-features extra-build-dependencies run --extra dev ruff check tools/workflow_parity.py test/test_ci_workflow.py test/test_coverage_workflow.py test/test_workflow_parity.py`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-core-combined --print-only`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-cluster --print-only`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' src/agilab/core/agi-cluster/test`
- YAML parse check for `codecov.yml`
- `git diff --check`
- `./dev scope`
