### PR TITLE
[codex] Refresh page-shot SVG summaries

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 276,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "313d3162ab42022d7865f270c8f6a5c962968481a7ae5f4a7d5b558b304c1acd",
+  "source_digest_sha256": "94f6dc622257c818d4fbb66d09733ab27db8fce15b1e8d956671e2c99342aa53",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "313d3162ab42022d7865f270c8f6a5c962968481a7ae5f4a7d5b558b304c1acd"
+  "target_digest_sha256": "94f6dc622257c818d4fbb66d09733ab27db8fce15b1e8d956671e2c99342aa53"
 }

--- a/docs/source/_static/page-shots/analysis-page.svg
+++ b/docs/source/_static/page-shots/analysis-page.svg
@@ -12,13 +12,9 @@
 <text x="28" y="196" font-size="14" font-weight="800" fill="#f7f7f2" text-anchor="start">ANALYSIS</text>
 <line x1="20" y1="230" x2="280" y2="230" stroke="#4e6572" stroke-width="1" opacity="0.75"/>
 <text x="20" y="273" font-size="16" font-weight="700" fill="#f7f7f2" text-anchor="start">Flight Telemetry Project</text>
-<rect x="20" y="318" width="260" height="40" rx="8" fill="#102b3d" stroke="#4f6471" stroke-width="1"/>
-<text x="56" y="344" font-size="14" font-weight="600" fill="#f7f7f2" text-anchor="start">Quick actions</text>
-<rect x="20" y="374" width="260" height="40" rx="8" fill="#102b3d" stroke="#4f6471" stroke-width="1"/>
-<text x="56" y="400" font-size="14" font-weight="600" fill="#f7f7f2" text-anchor="start">agi-app</text>
-<rect x="20" y="430" width="260" height="40" rx="8" fill="#102b3d" stroke="#4f6471" stroke-width="1"/>
-<text x="56" y="456" font-size="14" font-weight="600" fill="#f7f7f2" text-anchor="start">Reviewed</text>
-<text x="16" y="830" font-size="12" font-weight="400" fill="#b9c5ca" text-anchor="start">AGILAB v2026.06.02</text>
+<text x="20" y="318" font-size="13" font-weight="700" fill="#c7cdd0" text-anchor="start">view_maps</text>
+<text x="20" y="348" font-size="13" font-weight="700" fill="#c7cdd0" text-anchor="start">view_maps_network</text>
+<text x="16" y="830" font-size="12" font-weight="400" fill="#b9c5ca" text-anchor="start">AGILAB v2026.06.02+dev.95dee1cf7</text>
 <text x="1340" y="34" font-size="14" font-weight="700" fill="#f7f7f2" text-anchor="start">Deploy</text>
 <rect x="380" y="120" width="980" height="210" rx="20" fill="url(#panelGradient)" stroke="#4f6471" stroke-width="1"/>
 <line x1="400" y1="135" x2="1328" y2="135" stroke="#cda759" stroke-width="1" opacity="0.8"/>

--- a/docs/source/_static/page-shots/orchestrate-page.svg
+++ b/docs/source/_static/page-shots/orchestrate-page.svg
@@ -12,13 +12,7 @@
 <text x="28" y="196" font-size="14" font-weight="500" fill="#d6dde0" text-anchor="start">ANALYSIS</text>
 <line x1="20" y1="230" x2="280" y2="230" stroke="#4e6572" stroke-width="1" opacity="0.75"/>
 <text x="20" y="273" font-size="16" font-weight="700" fill="#f7f7f2" text-anchor="start">Flight Telemetry</text>
-<rect x="20" y="318" width="260" height="40" rx="8" fill="#102b3d" stroke="#4f6471" stroke-width="1"/>
-<text x="56" y="344" font-size="14" font-weight="600" fill="#f7f7f2" text-anchor="start">Quick actions</text>
-<rect x="20" y="374" width="260" height="40" rx="8" fill="#102b3d" stroke="#4f6471" stroke-width="1"/>
-<text x="56" y="400" font-size="14" font-weight="600" fill="#f7f7f2" text-anchor="start">agi-app</text>
-<rect x="20" y="430" width="260" height="40" rx="8" fill="#102b3d" stroke="#4f6471" stroke-width="1"/>
-<text x="56" y="456" font-size="14" font-weight="600" fill="#f7f7f2" text-anchor="start">Reviewed</text>
-<text x="16" y="830" font-size="12" font-weight="400" fill="#b9c5ca" text-anchor="start">AGILAB v2026.06.02</text>
+<text x="16" y="830" font-size="12" font-weight="400" fill="#b9c5ca" text-anchor="start">AGILAB v2026.06.02+dev.95dee1cf7</text>
 <text x="1340" y="34" font-size="14" font-weight="700" fill="#f7f7f2" text-anchor="start">Deploy</text>
 <rect x="380" y="120" width="980" height="590" rx="20" fill="url(#panelGradient)" stroke="#4f6471" stroke-width="1"/>
 <line x1="400" y1="135" x2="1328" y2="135" stroke="#cda759" stroke-width="1" opacity="0.8"/>

--- a/docs/source/_static/page-shots/project-create-page.svg
+++ b/docs/source/_static/page-shots/project-create-page.svg
@@ -38,7 +38,7 @@
 <text x="150" y="894" font-size="13" font-weight="500" fill="#58a6ff" text-anchor="middle"></text>
 <rect x="20" y="926" width="260" height="74" rx="8" fill="#102b3d" stroke="#4f6471" stroke-width="1"/>
 <text x="38" y="954" font-size="14" font-weight="700" fill="#f7f7f2" text-anchor="start">Create</text>
-<text x="16" y="980" font-size="12" font-weight="400" fill="#b9c5ca" text-anchor="start">AGILAB v2026.06.02</text>
+<text x="16" y="980" font-size="12" font-weight="400" fill="#b9c5ca" text-anchor="start">AGILAB v2026.06.02+dev.95dee1cf7</text>
 <text x="1340" y="34" font-size="14" font-weight="700" fill="#f7f7f2" text-anchor="start">Deploy</text>
 <text x="380" y="162" font-size="34" font-weight="800" fill="#f7f7f2" text-anchor="start">Create project</text>
 <text x="380" y="202" font-size="14" font-weight="400" fill="#aeb9bd" text-anchor="start">Create a new project from an existing template.</text>

--- a/docs/source/_static/page-shots/project-page.svg
+++ b/docs/source/_static/page-shots/project-page.svg
@@ -12,13 +12,18 @@
 <text x="28" y="196" font-size="14" font-weight="500" fill="#d6dde0" text-anchor="start">ANALYSIS</text>
 <line x1="20" y1="230" x2="280" y2="230" stroke="#4e6572" stroke-width="1" opacity="0.75"/>
 <text x="20" y="273" font-size="16" font-weight="700" fill="#f7f7f2" text-anchor="start">Flight Telemetry</text>
-<rect x="20" y="318" width="260" height="40" rx="8" fill="#102b3d" stroke="#4f6471" stroke-width="1"/>
-<text x="56" y="344" font-size="14" font-weight="600" fill="#f7f7f2" text-anchor="start">Quick actions</text>
-<rect x="20" y="374" width="260" height="40" rx="8" fill="#102b3d" stroke="#4f6471" stroke-width="1"/>
-<text x="56" y="400" font-size="14" font-weight="600" fill="#f7f7f2" text-anchor="start">agi-app</text>
-<rect x="20" y="430" width="260" height="40" rx="8" fill="#102b3d" stroke="#4f6471" stroke-width="1"/>
-<text x="56" y="456" font-size="14" font-weight="600" fill="#f7f7f2" text-anchor="start">Reviewed</text>
-<text x="16" y="830" font-size="12" font-weight="400" fill="#b9c5ca" text-anchor="start">AGILAB v2026.06.02</text>
+<rect x="20" y="298" width="260" height="34" rx="8" fill="#0b1727" stroke="#4f6471" stroke-width="1"/>
+<text x="34" y="320" font-size="12" font-weight="600" fill="#f7f7f2" text-anchor="start">flight_telemetry_project</text>
+<rect x="224" y="298" width="56" height="34" rx="8" fill="#102b3d" stroke="#4f6471" stroke-width="1"/>
+<text x="252" y="320" font-size="12" font-weight="700" fill="#58a6ff" text-anchor="middle">Edit</text>
+<text x="20" y="358" font-size="13" font-weight="800" fill="#c7cdd0" text-anchor="start">Action</text>
+<rect x="20" y="370" width="260" height="34" rx="8" fill="#0b1727" stroke="#4f6471" stroke-width="1"/>
+<text x="34" y="392" font-size="12" font-weight="600" fill="#f7f7f2" text-anchor="start">None</text>
+<text x="20" y="436" font-size="13" font-weight="800" fill="#c7cdd0" text-anchor="start">agi-app</text>
+<text x="20" y="466" font-size="13" font-weight="800" fill="#c7cdd0" text-anchor="start">Catalog page</text>
+<text x="20" y="496" font-size="13" font-weight="800" fill="#c7cdd0" text-anchor="start">Manual requirement</text>
+<text x="20" y="526" font-size="13" font-weight="800" fill="#c7cdd0" text-anchor="start">Environment type</text>
+<text x="16" y="830" font-size="12" font-weight="400" fill="#b9c5ca" text-anchor="start">AGILAB v2026.06.02+dev.95dee1cf7</text>
 <text x="1340" y="34" font-size="14" font-weight="700" fill="#f7f7f2" text-anchor="start">Deploy</text>
 <rect x="380" y="120" width="980" height="210" rx="20" fill="url(#panelGradient)" stroke="#4f6471" stroke-width="1"/>
 <line x1="400" y1="135" x2="1328" y2="135" stroke="#cda759" stroke-width="1" opacity="0.8"/>

--- a/docs/source/_static/page-shots/screenshot_manifest.json
+++ b/docs/source/_static/page-shots/screenshot_manifest.json
@@ -20,8 +20,8 @@
       ],
       "svg_summary_kind": "screenshot-derived-vector-summary",
       "svg_summary_path": "analysis-page.svg",
-      "svg_summary_sha256": "42a9deca930a88457d6704861e647faad9667c6e55db020593373c06537e5ace",
-      "svg_summary_size_bytes": 5885,
+      "svg_summary_sha256": "d9dc8373933b3545ae8411e60096b7f806aa4744c90c1162300a1fddf19f0081",
+      "svg_summary_size_bytes": 5491,
       "url": "",
       "width_px": 1440
     },
@@ -60,8 +60,8 @@
       ],
       "svg_summary_kind": "screenshot-derived-vector-summary",
       "svg_summary_path": "orchestrate-page.svg",
-      "svg_summary_sha256": "990988c6fe4b10b197e8b988fc95ae6308ddef676c99fd565e3438675c5d24f8",
-      "svg_summary_size_bytes": 6251,
+      "svg_summary_sha256": "ae742b612cb359438734be4e21e2fd11bcaf7e2283f5c3473a4ea64f75ca7cdb",
+      "svg_summary_size_bytes": 5637,
       "url": "",
       "width_px": 1440
     },
@@ -80,8 +80,8 @@
       ],
       "svg_summary_kind": "screenshot-derived-vector-summary",
       "svg_summary_path": "project-create-page.svg",
-      "svg_summary_sha256": "4ca9fe0d3421c9c57fbf523c977e5b3f32fdd3c6768e6797fc1f67a446d9c923",
-      "svg_summary_size_bytes": 6962,
+      "svg_summary_sha256": "e3abe232bfc8fd8c0d1fdb8290010af2786bac0ad78536de7a6b0f4a592db916",
+      "svg_summary_size_bytes": 6976,
       "url": "",
       "width_px": 1440
     },
@@ -100,8 +100,8 @@
       ],
       "svg_summary_kind": "screenshot-derived-vector-summary",
       "svg_summary_path": "project-page.svg",
-      "svg_summary_sha256": "ee9809d31071913774ae6258c628de14a966055a083a4d0d144bb4506936c960",
-      "svg_summary_size_bytes": 7955,
+      "svg_summary_sha256": "77ad6c8bbdb1b2fa222c3d29a2e9f50230aded30f9cda44bae3d211c9862793f",
+      "svg_summary_size_bytes": 8519,
       "url": "",
       "width_px": 1440
     },
@@ -120,8 +120,8 @@
       ],
       "svg_summary_kind": "screenshot-derived-vector-summary",
       "svg_summary_path": "workflow-page.svg",
-      "svg_summary_sha256": "158f159d29a4d59b0d1bec69e778669f297d5ab3d64c67a859fe219f4e0ed679",
-      "svg_summary_size_bytes": 6424,
+      "svg_summary_sha256": "32ced868e57f15534e282833228267115d66740e68346feb6b5bfb7cfe13ba1d",
+      "svg_summary_size_bytes": 6270,
       "url": "",
       "width_px": 1440
     }

--- a/docs/source/_static/page-shots/workflow-page.svg
+++ b/docs/source/_static/page-shots/workflow-page.svg
@@ -12,13 +12,11 @@
 <text x="28" y="196" font-size="14" font-weight="500" fill="#d6dde0" text-anchor="start">ANALYSIS</text>
 <line x1="20" y1="230" x2="280" y2="230" stroke="#4e6572" stroke-width="1" opacity="0.75"/>
 <text x="20" y="273" font-size="16" font-weight="700" fill="#f7f7f2" text-anchor="start">Flight Telemetry</text>
-<rect x="20" y="318" width="260" height="40" rx="8" fill="#102b3d" stroke="#4f6471" stroke-width="1"/>
-<text x="56" y="344" font-size="14" font-weight="600" fill="#f7f7f2" text-anchor="start">Quick actions</text>
-<rect x="20" y="374" width="260" height="40" rx="8" fill="#102b3d" stroke="#4f6471" stroke-width="1"/>
-<text x="56" y="400" font-size="14" font-weight="600" fill="#f7f7f2" text-anchor="start">agi-app</text>
-<rect x="20" y="430" width="260" height="40" rx="8" fill="#102b3d" stroke="#4f6471" stroke-width="1"/>
-<text x="56" y="456" font-size="14" font-weight="600" fill="#f7f7f2" text-anchor="start">Reviewed</text>
-<text x="16" y="830" font-size="12" font-weight="400" fill="#b9c5ca" text-anchor="start">AGILAB v2026.06.02</text>
+<rect x="20" y="304" width="260" height="34" rx="8" fill="#0b1727" stroke="#4f6471" stroke-width="1"/>
+<text x="34" y="326" font-size="11" font-weight="700" fill="#f7f7f2" text-anchor="start">Run selected AGI.on_output...</text>
+<rect x="20" y="356" width="260" height="46" rx="8" fill="#0b1727" stroke="#4f6471" stroke-width="1"/>
+<text x="34" y="376" font-size="11" font-weight="700" fill="#f7f7f2" text-anchor="start">Notify generated pipeline stage</text>
+<text x="16" y="830" font-size="12" font-weight="400" fill="#b9c5ca" text-anchor="start">AGILAB v2026.06.02+dev.95dee1cf7</text>
 <text x="1340" y="34" font-size="14" font-weight="700" fill="#f7f7f2" text-anchor="start">Deploy</text>
 <rect x="380" y="120" width="980" height="210" rx="20" fill="url(#panelGradient)" stroke="#4f6471" stroke-width="1"/>
 <line x1="400" y1="135" x2="1328" y2="135" stroke="#cda759" stroke-width="1" opacity="0.8"/>


### PR DESCRIPTION
## Summary
- Refresh page-shot SVG summaries so their sidebars no longer show stale generic controls.
- Sync the docs mirror and update screenshot manifest plus mirror stamp.

## Validation
- XML parse for canonical and mirrored SVGs
- Manifest sha256 and size verification
- uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp
- uv --preview-features extra-build-dependencies run pytest -q -o addopts= test/test_screenshot_manifest.py
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs