### PR TITLE
Fix Codecov uploader key import

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -77,6 +77,14 @@ jobs:
           kill "$HEARTBEAT_PID" 2>/dev/null || true
           trap - EXIT
 
+      - name: Import Codecov uploader key for agi-env
+        if: always() && hashFiles('coverage-agi-env.xml') != ''
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -fsSL https://uploader.codecov.io/verification.gpg | gpg --batch --import
+          gpg --batch --list-keys 27034E7FDB850E0BBC2C62FF806BB28AED779869 >/dev/null
+
       - name: Upload agi-env coverage to Codecov
         if: always() && hashFiles('coverage-agi-env.xml') != ''
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
@@ -175,6 +183,14 @@ jobs:
           kill "$HEARTBEAT_PID" 2>/dev/null || true
           trap - EXIT
 
+      - name: Import Codecov uploader key for agi-node
+        if: always() && hashFiles('coverage-agi-node.xml') != ''
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -fsSL https://uploader.codecov.io/verification.gpg | gpg --batch --import
+          gpg --batch --list-keys 27034E7FDB850E0BBC2C62FF806BB28AED779869 >/dev/null
+
       - name: Upload agi-node coverage to Codecov
         if: always() && hashFiles('coverage-agi-node.xml') != ''
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
@@ -184,6 +200,14 @@ jobs:
           use_oidc: true
           verbose: true
           fail_ci_if_error: true
+
+      - name: Import Codecov uploader key for agi-cluster
+        if: always() && hashFiles('coverage-agi-cluster.xml') != ''
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -fsSL https://uploader.codecov.io/verification.gpg | gpg --batch --import
+          gpg --batch --list-keys 27034E7FDB850E0BBC2C62FF806BB28AED779869 >/dev/null
 
       - name: Upload agi-cluster coverage to Codecov
         if: always() && hashFiles('coverage-agi-cluster.xml') != ''
@@ -356,6 +380,14 @@ jobs:
             --cov=agi_web --cov-report=xml:coverage-agi-web.xml \
             src/agilab/lib/agi-web/test
 
+      - name: Import Codecov uploader key for agi-web
+        if: always() && hashFiles('coverage-agi-web.xml') != ''
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -fsSL https://uploader.codecov.io/verification.gpg | gpg --batch --import
+          gpg --batch --list-keys 27034E7FDB850E0BBC2C62FF806BB28AED779869 >/dev/null
+
       - name: Upload agi-web coverage to Codecov
         if: always() && hashFiles('coverage-agi-web.xml') != ''
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
@@ -490,6 +522,14 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
+      - name: Import Codecov uploader key for agi-gui
+        if: always() && hashFiles('coverage-agi-gui.xml') != ''
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -fsSL https://uploader.codecov.io/verification.gpg | gpg --batch --import
+          gpg --batch --list-keys 27034E7FDB850E0BBC2C62FF806BB28AED779869 >/dev/null
+
       - name: Upload agi-gui coverage to Codecov
         if: always() && hashFiles('coverage-agi-gui.xml') != ''
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
@@ -538,6 +578,13 @@ jobs:
 
       - name: Verify committed badges are up to date
         run: git diff --exit-code -- badges/
+
+      - name: Import Codecov uploader key for repo-wide upload
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -fsSL https://uploader.codecov.io/verification.gpg | gpg --batch --import
+          gpg --batch --list-keys 27034E7FDB850E0BBC2C62FF806BB28AED779869 >/dev/null
 
       - name: Upload repo-wide agilab coverage to Codecov
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6

--- a/test/test_coverage_workflow.py
+++ b/test/test_coverage_workflow.py
@@ -10,6 +10,7 @@ WORKFLOW_PATH = Path(".github/workflows/coverage.yml")
 CODECOV_CONFIG_PATH = Path("codecov.yml")
 AGI_ENV_COVERAGE_CONFIG = Path(".coveragerc.agi-env")
 SHARD_PLAN_PATH = Path("tools/coverage_shard_plan.py")
+CODECOV_UPLOADER_KEY_FINGERPRINT = "27034E7FDB850E0BBC2C62FF806BB28AED779869"
 
 
 def _workflow_text() -> str:
@@ -421,6 +422,35 @@ def test_codecov_uploads_are_blocking_coverage_publication_gates() -> None:
         assert "# v6" in block
         assert "continue-on-error: true" not in block
         assert "fail_ci_if_error: true" in block
+
+
+def test_codecov_uploads_import_verification_key_before_blocking_upload() -> None:
+    workflow_text = _workflow_text()
+    upload_steps = [
+        ("Import Codecov uploader key for agi-env", "Upload agi-env coverage to Codecov"),
+        ("Import Codecov uploader key for agi-node", "Upload agi-node coverage to Codecov"),
+        ("Import Codecov uploader key for agi-cluster", "Upload agi-cluster coverage to Codecov"),
+        ("Import Codecov uploader key for agi-gui", "Upload agi-gui coverage to Codecov"),
+        ("Import Codecov uploader key for agi-web", "Upload agi-web coverage to Codecov"),
+        ("Import Codecov uploader key for repo-wide upload", "Upload repo-wide agilab coverage to Codecov"),
+    ]
+
+    for import_step_name, upload_step_name in upload_steps:
+        import_marker = f"      - name: {import_step_name}"
+        upload_marker = f"      - name: {upload_step_name}"
+        assert workflow_text.index(import_marker) < workflow_text.index(upload_marker)
+
+        import_block = _step_block(import_step_name)
+        upload_block = _step_block(upload_step_name)
+        import_if_lines = [line.strip() for line in import_block.splitlines() if line.strip().startswith("if:")]
+        upload_if_lines = [line.strip() for line in upload_block.splitlines() if line.strip().startswith("if:")]
+
+        assert import_if_lines == upload_if_lines
+        assert "shell: bash" in import_block
+        assert "set -euo pipefail" in import_block
+        assert "https://uploader.codecov.io/verification.gpg" in import_block
+        assert "gpg --batch --import" in import_block
+        assert f"gpg --batch --list-keys {CODECOV_UPLOADER_KEY_FINGERPRINT}" in import_block
 
 
 def test_codecov_config_enforces_project_and_patch_coverage_floor() -> None:


### PR DESCRIPTION
## Summary
- import Codecov's uploader verification key before each blocking Codecov upload in the coverage workflow
- keep Codecov validation and fail_ci_if_error enabled
- add a regression ensuring every Codecov upload has the matching key import step before it

## Validation
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_coverage_workflow.py
- git diff --check
- uv --preview-features extra-build-dependencies run python tools/impact_validate.py --staged