### PR TITLE
Make GitHub roadmap issues canonical

### DIFF
--- a/.github/ISSUE_TEMPLATE/roadmap-vote.yml
+++ b/.github/ISSUE_TEMPLATE/roadmap-vote.yml
@@ -1,37 +1,45 @@
-name: Roadmap vote
-description: Submit one roadmap preference for AGILab future work.
-title: "[Roadmap vote] "
+name: Roadmap proposal
+description: Propose one roadmap item or add rationale for an existing AGILAB priority.
+title: "[Roadmap] "
 labels:
   - roadmap
 body:
   - type: markdown
     attributes:
       value: |
-        Use this form to record one roadmap preference.
-        Votes are tracked as GitHub issues in this repository.
+        Roadmap voting uses roadmap-labeled GitHub issues.
+        Before opening a new proposal, browse existing roadmap issues and add a thumbs-up reaction when one already matches your priority:
+        https://github.com/ThalesGroup/agilab/issues?q=is%3Aissue+label%3Aroadmap
+
+        Use this form only when your requested roadmap item is missing or needs a distinct engineering discussion.
 
   - type: dropdown
     id: investment
     attributes:
-      label: Preferred next AGILab investment
-      description: Select the single item that should be prioritized next.
+      label: Roadmap lane
+      description: Select the closest current roadmap lane. Use "Other / write-in" only when none match.
       options:
-        - Experiment Cockpit
-        - Evidence / Release View
-        - Scenario Playback View
-        - Elastic/OpenSearch + Grafana
-        - OpenSearch + OpenSearch Dashboards
-        - Postgres + Superset
-        - Connector framework hardening and external integrations
+        - P0 release and runtime integrity
+        - P1 first-run product experience
+        - P2 notebook interop and no-lock-in
+        - P3 security and supply-chain posture
+        - P4 team and cluster operation
+        - P5 pinned private-app validation for non-public app CI and release checks
+        - Multi-app DAG orchestration productization
+        - Intent-first operator workbench
+        - Data connector facility and connector-aware views
+        - Other / write-in
     validations:
       required: true
 
   - type: textarea
-    id: rationale
+    id: proposal
     attributes:
-      label: Why this should be next
-      description: State the operational, product, or engineering reason.
-      placeholder: This should be next because...
+      label: Proposal and rationale
+      description: State the specific request and why this should be next.
+      placeholder: |
+        Proposal: ...
+        Why this matters now: ...
     validations:
       required: true
 
@@ -41,11 +49,12 @@ body:
       label: Expected value
       description: Select the main value drivers.
       options:
-        - label: Better daily usability
-        - label: Better evidence and release readiness
-        - label: Better observability and operations
-        - label: Better audit and traceability
-        - label: Better executive analytics
+        - label: Better release or runtime integrity
+        - label: Better first-run usability
+        - label: Better notebook interoperability
+        - label: Better security, supply-chain, or audit traceability
+        - label: Better team, cluster, or private-app reproducibility
+        - label: Better connector, data-system, or app-integration coverage
 
   - type: textarea
     id: constraints

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 276,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "94f6dc622257c818d4fbb66d09733ab27db8fce15b1e8d956671e2c99342aa53",
+  "source_digest_sha256": "c1616535cd9462ad411dcf14c77d0e2e99ae7cf8bff5840cdb1eabeff236e405",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "94f6dc622257c818d4fbb66d09733ab27db8fce15b1e8d956671e2c99342aa53"
+  "target_digest_sha256": "c1616535cd9462ad411dcf14c77d0e2e99ae7cf8bff5840cdb1eabeff236e405"
 }

--- a/docs/source/roadmap/agilab-future-work.md
+++ b/docs/source/roadmap/agilab-future-work.md
@@ -1722,30 +1722,33 @@ Use this rule of thumb:
   faster codebase onboarding, architecture discovery, and repository Q&A without
   turning generated content into official docs
 
-## Final consolidated poll
+## GitHub roadmap voting
 
-Use both paths, because they serve different purposes:
+Use one public GitHub path: roadmap-labeled issues. Add a thumbs-up reaction to
+an existing roadmap issue when it matches your priority; open a new roadmap
+proposal only when the existing list is missing the work you want to sponsor.
 
-1. Quick popularity signal in GitHub Discussions
-   - Create or answer a poll: <https://github.com/ThalesGroup/agilab/discussions/new?category=polls>
-   - Browse existing poll discussions: <https://github.com/ThalesGroup/agilab/discussions/categories/polls>
-2. Structured roadmap vote in GitHub Issues
-   - Submit a vote: <https://github.com/ThalesGroup/agilab/issues/new?template=roadmap-vote.yml>
-   - Browse submitted votes: <https://github.com/ThalesGroup/agilab/issues?q=is%3Aissue+in%3Atitle+%22%5BRoadmap+vote%5D%22>
-3. Open roadmap discussion in Issues
-   - Central roadmap thread: <https://github.com/ThalesGroup/agilab/issues/2>
-   - Use this thread if you want visible engineering discussion in the normal issue workflow.
+1. Browse and upvote roadmap issues:
+   <https://github.com/ThalesGroup/agilab/issues?q=is%3Aissue+label%3Aroadmap>
+2. Submit a missing proposal:
+   <https://github.com/ThalesGroup/agilab/issues/new?template=roadmap-vote.yml>
+3. Use the central roadmap index and discussion hub:
+   <https://github.com/ThalesGroup/agilab/issues/2>
 
-### Comment template for `issues/2`
+GitHub Discussions polls are no longer the roadmap intake path. Keeping the
+signal on roadmap issues avoids splitting votes across polls, form submissions,
+and central-thread comments.
+
+### Roadmap proposal template
 
 ```text
-Vote: <one option>
+Proposal: <one roadmap item>
 Why: <why this matters now>
 Expected value: <product / engineering / user impact>
 Constraints or dependencies: <blocking items, staffing, sequencing>
 ```
 
-### Current candidate priorities
+### Current GitHub roadmap candidates
 
 - P0 release and runtime integrity
 - P1 first-run product experience
@@ -1753,12 +1756,9 @@ Constraints or dependencies: <blocking items, staffing, sequencing>
 - P3 security and supply-chain posture
 - P4 team and cluster operation
 - P5 pinned private-app validation for non-public app CI and release checks
-- Multi-app DAG orchestration productization, once the professional baseline is
-  stable
-- Intent-first operator workbench, once profiles, command actions, compact logs,
-  and evidence surfaces are stable enough to share one operator shell
-- Data connector facility and connector-aware views, once first-run and
-  evidence paths are predictable
+- Multi-app DAG orchestration productization
+- Intent-first operator workbench
+- Data connector facility and connector-aware views
 
 If the `roadmap` label is not visible yet in GitHub, the issue form still
 works. The repository workflow will create or update that label on the next

--- a/test/test_roadmap_github_intake.py
+++ b/test/test_roadmap_github_intake.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ROADMAP_DOC = REPO_ROOT / "docs" / "source" / "roadmap" / "agilab-future-work.md"
+ROADMAP_ISSUE_TEMPLATE = REPO_ROOT / ".github" / "ISSUE_TEMPLATE" / "roadmap-vote.yml"
+
+
+def _current_github_roadmap_candidates(roadmap_text: str) -> list[str]:
+    candidates: list[str] = []
+    in_section = False
+    for line in roadmap_text.splitlines():
+        if line == "### Current GitHub roadmap candidates":
+            in_section = True
+            continue
+        if not in_section:
+            continue
+        if line.startswith("### ") or line.startswith("## "):
+            break
+        if line.startswith("- "):
+            candidates.append(line.removeprefix("- ").strip())
+    return candidates
+
+
+def _roadmap_lane_options(template: dict) -> list[str]:
+    lane_field = next(
+        item
+        for item in template["body"]
+        if item.get("type") == "dropdown" and item.get("id") == "investment"
+    )
+    return list(lane_field["attributes"]["options"])
+
+
+def test_github_roadmap_intake_uses_one_issue_based_voting_path() -> None:
+    roadmap_text = ROADMAP_DOC.read_text(encoding="utf-8")
+    issue_template_text = ROADMAP_ISSUE_TEMPLATE.read_text(encoding="utf-8")
+
+    assert "## GitHub roadmap voting" in roadmap_text
+    assert "Final consolidated poll" not in roadmap_text
+    assert "discussions/new?category=polls" not in roadmap_text
+    assert "discussions/categories/polls" not in roadmap_text
+    assert "label%3Aroadmap" in roadmap_text
+    assert "label%3Aroadmap" in issue_template_text
+
+
+def test_roadmap_issue_template_tracks_current_github_candidates() -> None:
+    roadmap_text = ROADMAP_DOC.read_text(encoding="utf-8")
+    template = yaml.safe_load(ROADMAP_ISSUE_TEMPLATE.read_text(encoding="utf-8"))
+
+    candidates = _current_github_roadmap_candidates(roadmap_text)
+    options = _roadmap_lane_options(template)
+
+    assert template["name"] == "Roadmap proposal"
+    assert template["title"] == "[Roadmap] "
+    assert options[:-1] == candidates
+    assert options[-1] == "Other / write-in"


### PR DESCRIPTION
## Summary
- make roadmap-labeled GitHub issues the canonical public voting path
- update the roadmap issue template to match the current future-work candidates and allow write-ins
- sync the canonical docs wording into the public mirror
- add a regression preventing poll links and template/doc candidate drift

## Live GitHub cleanup already applied
- seeded roadmap issues #560-#568 for the current Now/Next/Later candidates
- updated issue #2 as the central roadmap index and discussion hub
- retitled Discussions #3 and #4 as historical pointers to issue-based voting

## Validation
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_roadmap_github_intake.py
- uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs
- git diff --check
- uv --preview-features extra-build-dependencies run python tools/impact_validate.py --staged