### PR TITLE
Refresh coverage badges

### DIFF
--- a/badges/coverage-agi-cluster.svg
+++ b/badges/coverage-agi-cluster.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="181" height="20" role="img" aria-label="agi-cluster coverage: 98%">
+<svg xmlns="http://www.w3.org/2000/svg" width="181" height="20" role="img" aria-label="agi-cluster coverage: 97%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="75.0" y="15" fill="#010101" fill-opacity=".3">agi-cluster coverage</text>
   <text x="75.0" y="14">agi-cluster coverage</text>
-  <text x="165.5" y="15" fill="#010101" fill-opacity=".3">98%</text>
-  <text x="165.5" y="14">98%</text>
+  <text x="165.5" y="15" fill="#010101" fill-opacity=".3">97%</text>
+  <text x="165.5" y="14">97%</text>
 </g>
 </svg>

--- a/badges/coverage-agi-core.svg
+++ b/badges/coverage-agi-core.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="160" height="20" role="img" aria-label="agi-core coverage: 98%">
+<svg xmlns="http://www.w3.org/2000/svg" width="160" height="20" role="img" aria-label="agi-core coverage: 97%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="64.5" y="15" fill="#010101" fill-opacity=".3">agi-core coverage</text>
   <text x="64.5" y="14">agi-core coverage</text>
-  <text x="144.5" y="15" fill="#010101" fill-opacity=".3">98%</text>
-  <text x="144.5" y="14">98%</text>
+  <text x="144.5" y="15" fill="#010101" fill-opacity=".3">97%</text>
+  <text x="144.5" y="14">97%</text>
 </g>
 </svg>

--- a/badges/coverage-agi-env.svg
+++ b/badges/coverage-agi-env.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="153" height="20" role="img" aria-label="agi-env coverage: 98%">
+<svg xmlns="http://www.w3.org/2000/svg" width="153" height="20" role="img" aria-label="agi-env coverage: 97%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="61.0" y="15" fill="#010101" fill-opacity=".3">agi-env coverage</text>
   <text x="61.0" y="14">agi-env coverage</text>
-  <text x="137.5" y="15" fill="#010101" fill-opacity=".3">98%</text>
-  <text x="137.5" y="14">98%</text>
+  <text x="137.5" y="15" fill="#010101" fill-opacity=".3">97%</text>
+  <text x="137.5" y="14">97%</text>
 </g>
 </svg>

--- a/badges/coverage-agilab.svg
+++ b/badges/coverage-agilab.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="146" height="20" role="img" aria-label="agilab coverage: 98%">
+<svg xmlns="http://www.w3.org/2000/svg" width="146" height="20" role="img" aria-label="agilab coverage: 97%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="57.5" y="15" fill="#010101" fill-opacity=".3">agilab coverage</text>
   <text x="57.5" y="14">agilab coverage</text>
-  <text x="130.5" y="15" fill="#010101" fill-opacity=".3">98%</text>
-  <text x="130.5" y="14">98%</text>
+  <text x="130.5" y="15" fill="#010101" fill-opacity=".3">97%</text>
+  <text x="130.5" y="14">97%</text>
 </g>
 </svg>


### PR DESCRIPTION
## Summary
- refresh static coverage badges from main coverage run 27069236659 artifacts
- align agi-env, agi-cluster, agi-core, and aggregate agilab badges with the current CI-generated values

## Source evidence
- coverage run: https://github.com/ThalesGroup/agilab/actions/runs/27069236659
- failed final job regenerated badges as agi-env 97%, agi-cluster 97%, agi-core 97%, agilab 97%

## Validation
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_generate_component_coverage_badges.py
- uv --preview-features extra-build-dependencies run python tools/generate_component_coverage_badges.py --components agi-cluster agi-env
- AGILAB_ALLOW_BADGE_ONLY_UPDATE=1 uv --preview-features extra-build-dependencies run python tools/coverage_badge_guard.py --components agi-cluster agi-env
- AGILAB_ALLOW_BADGE_ONLY_UPDATE=1 uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile badges
- git diff --check
- uv --preview-features extra-build-dependencies run python tools/impact_validate.py --staged