### PR TITLE
[codex] Trigger coverage on coverage badge updates

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,6 +14,7 @@ on:
       - "tools/coverage_timing_report.py"
       - "tools/generate_component_coverage_badges.py"
       - "tools/workflow_parity.py"
+      - "badges/coverage-*.svg"
       - "uv.lock"
   workflow_dispatch:
 

--- a/test/test_coverage_workflow.py
+++ b/test/test_coverage_workflow.py
@@ -105,12 +105,14 @@ def test_coverage_push_trigger_is_path_filtered_for_cost_control() -> None:
         '"tools/coverage_timing_report.py"',
         '"tools/generate_component_coverage_badges.py"',
         '"tools/workflow_parity.py"',
+        '"badges/coverage-*.svg"',
         '"uv.lock"',
     ):
         assert path in trigger_block
     assert '"docs/**"' not in trigger_block
     assert '"README.md"' not in trigger_block
     assert '"badges/**"' not in trigger_block
+    assert '"badges/skills.svg"' not in trigger_block
 
 
 def test_agi_env_coverage_installs_streamlit_ui_dependency() -> None:


### PR DESCRIPTION
## Summary

- Trigger the coverage workflow when committed coverage badge SVGs change.
- Keep the trigger scoped to `badges/coverage-*.svg` instead of all badges.
- Add a regression test for the workflow trigger contract.

## Why

A badge-only refresh PR does not currently trigger `coverage.yml`, so the badge freshness check has to be run manually even though that workflow is the authority for static coverage badge freshness.

## Validation

- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_coverage_workflow.py`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --staged`
- `git diff --check --cached`
- `uv --preview-features extra-build-dependencies run --with pyyaml python -c "from pathlib import Path; import yaml; yaml.safe_load(Path('.github/workflows/coverage.yml').read_text())"`
- `./dev scope --staged`