### PR TITLE
[codex] Compact successful validation close-outs

### DIFF
--- a/.claude/skills/agilab-testing/SKILL.md
+++ b/.claude/skills/agilab-testing/SKILL.md
@@ -37,6 +37,11 @@ Use this skill when validating changes.
   validation. It writes the full stdout/stderr stream to ignored
   `reports/dev-logs/` artifacts and prints only a bounded signal summary, which
   keeps prompt context focused without losing evidence.
+- In final user-facing close-outs, summarize successful validation as
+  `Validation passed.` without listing every command. Include the exact command
+  list only when a check failed or was skipped, the message is release/audit
+  evidence, a PR/commit body needs reproducible proof, or the user explicitly
+  asks for validation details.
 - Use `--raw-output` or `AGILAB_DEV_OUTPUT=raw` only when a human debugging
   session, wrapper, or downstream tool must consume the live raw stream or raw
   JSON. For normal diagnosis, inspect the cited `reports/dev-logs/...` artifact

--- a/.codex/skills/agilab-testing/SKILL.md
+++ b/.codex/skills/agilab-testing/SKILL.md
@@ -37,6 +37,11 @@ Use this skill when validating changes.
   validation. It writes the full stdout/stderr stream to ignored
   `reports/dev-logs/` artifacts and prints only a bounded signal summary, which
   keeps prompt context focused without losing evidence.
+- In final user-facing close-outs, summarize successful validation as
+  `Validation passed.` without listing every command. Include the exact command
+  list only when a check failed or was skipped, the message is release/audit
+  evidence, a PR/commit body needs reproducible proof, or the user explicitly
+  asks for validation details.
 - Use `--raw-output` or `AGILAB_DEV_OUTPUT=raw` only when a human debugging
   session, wrapper, or downstream tool must consume the live raw stream or raw
   JSON. For normal diagnosis, inspect the cited `reports/dev-logs/...` artifact

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,6 +167,12 @@ Use this runbook whenever you:
   Standard is compact signal summary, Detailed adds nearby context windows, and
   Debug may point to raw artifacts or include full text only when the log is
   already small enough for prompt-safe use.
+- **Compact validation close-out rule**: In final user-facing replies, write
+  `Validation passed.` without listing every command when all checks are green
+  and the command details are not needed for the next action. Include validation
+  detail only for failures, skipped checks, release or audit evidence,
+  PR/commit messages that need reproducible proof, or when the user explicitly
+  asks for the command list.
 - **Dependency-bound validation rule**: When changing dependency caps or
   compatibility shims, validate the meaningful boundary versions when practical:
   the currently installed version, the new lower or upper bound, and an import

--- a/AGENT_LEARNINGS.md
+++ b/AGENT_LEARNINGS.md
@@ -54,3 +54,7 @@ is not a scratchpad or task log.
   default is clear, do not end with a broad clarification menu. State the
   assumed target, choose the highest-leverage applicable mechanism, and either
   implement it or name the exact blocker that prevents implementation.
+- When validation succeeds, keep the final close-out terse: `Validation passed.`
+  Do not expand it into a command-by-command list unless failures, skipped
+  checks, release/audit evidence, PR proof, or an explicit user request make the
+  details useful.

--- a/agenticweb.md
+++ b/agenticweb.md
@@ -1,7 +1,7 @@
 ---
 agenticweb: "1"
 description: "AGILAB is an open-source AI/ML workbench for reproducible experiments, notebook-to-app workflows, run evidence, proof capsules, and local agent evidence review."
-updated: "2026-06-05"
+updated: "2026-06-06"
 organization:
   name: "AGILAB"
   website: "https://thalesgroup.github.io/agilab"

--- a/agilab-capabilities.json
+++ b/agilab-capabilities.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-06-05T22:41:43Z",
+  "generated_at_utc": "2026-06-06T18:06:57Z",
   "schema": "agilab.capabilities.v1",
   "schema_version": 1,
   "generated_by": {
@@ -22,7 +22,7 @@
     "package_count": 37,
     "public_app_count": 15,
     "agent_skill_count": 33,
-    "evidence_schema_count": 218,
+    "evidence_schema_count": 220,
     "catalog_file_count": 12
   },
   "cli_commands": [
@@ -767,7 +767,7 @@
       "status": "Source built-in",
       "source": "src/agilab/apps/builtin/weather_forecast_legacy_project",
       "version": "2026.05.30.post1",
-      "description": "Built-in AGILab weather forecasting example migrated from notebooks"
+      "description": "Built-in AGILAB legacy weather forecasting app for migration comparison"
     },
     {
       "project": "weather_forecast_project",
@@ -1757,18 +1757,39 @@
     {
       "schema": "agilab.notebook_export_handoff.v1",
       "sources": [
+        "src/agilab/apps/builtin/flight_telemetry_project/notebooks/lab_stages.notebook_export.md",
+        "src/agilab/apps/builtin/global_dag_project/notebooks/lab_stages.notebook_export.md",
+        "src/agilab/apps/builtin/meteo_forecast_project/notebooks/lab_stages.notebook_export.md",
+        "src/agilab/apps/builtin/mission_decision_project/notebooks/lab_stages.notebook_export.md",
+        "src/agilab/apps/builtin/multi_app_dag_project/notebooks/lab_stages.notebook_export.md",
+        "src/agilab/apps/builtin/tescia_diagnostic_project/notebooks/lab_stages.notebook_export.md",
+        "src/agilab/apps/builtin/weather_forecast_project/notebooks/lab_stages.notebook_export.md",
         "src/agilab/notebooks/notebook_export_support.py"
       ]
     },
     {
       "schema": "agilab.notebook_export_manifest.v1",
       "sources": [
+        "src/agilab/apps/builtin/flight_telemetry_project/notebooks/lab_stages.notebook_export.json",
+        "src/agilab/apps/builtin/global_dag_project/notebooks/lab_stages.notebook_export.json",
+        "src/agilab/apps/builtin/meteo_forecast_project/notebooks/lab_stages.notebook_export.json",
+        "src/agilab/apps/builtin/mission_decision_project/notebooks/lab_stages.notebook_export.json",
+        "src/agilab/apps/builtin/multi_app_dag_project/notebooks/lab_stages.notebook_export.json",
+        "src/agilab/apps/builtin/tescia_diagnostic_project/notebooks/lab_stages.notebook_export.json",
+        "src/agilab/apps/builtin/weather_forecast_project/notebooks/lab_stages.notebook_export.json",
         "src/agilab/notebooks/notebook_export_support.py"
       ]
     },
     {
       "schema": "agilab.notebook_export_portability.v1",
       "sources": [
+        "src/agilab/apps/builtin/flight_telemetry_project/notebooks/lab_stages.notebook_export.json",
+        "src/agilab/apps/builtin/global_dag_project/notebooks/lab_stages.notebook_export.json",
+        "src/agilab/apps/builtin/meteo_forecast_project/notebooks/lab_stages.notebook_export.json",
+        "src/agilab/apps/builtin/mission_decision_project/notebooks/lab_stages.notebook_export.json",
+        "src/agilab/apps/builtin/multi_app_dag_project/notebooks/lab_stages.notebook_export.json",
+        "src/agilab/apps/builtin/tescia_diagnostic_project/notebooks/lab_stages.notebook_export.json",
+        "src/agilab/apps/builtin/weather_forecast_project/notebooks/lab_stages.notebook_export.json",
         "src/agilab/notebooks/notebook_export_support.py"
       ]
     },
@@ -1842,6 +1863,8 @@
     {
       "schema": "agilab.notebook_view_sync.v1",
       "sources": [
+        "src/agilab/apps/builtin/flight_telemetry_project/notebooks/lab_stages.notebook_export.json",
+        "src/agilab/apps/builtin/multi_app_dag_project/notebooks/lab_stages.notebook_export.json",
         "src/agilab/notebooks/notebook_export_support.py"
       ]
     },
@@ -1888,6 +1911,12 @@
         "src/agilab/examples/parallel_stage/parallel_stage.toml",
         "src/agilab/examples/parallel_stage/preview_parallel_stage.py",
         "tools/parallel_stage.py"
+      ]
+    },
+    {
+      "schema": "agilab.performance-cache.v1",
+      "sources": [
+        "tools/performance_cache.py"
       ]
     },
     {
@@ -2410,6 +2439,12 @@
       "schema": "agilab.widget_robot_matrix_result_cache.v1",
       "sources": [
         "tools/agilab_widget_robot_matrix.py"
+      ]
+    },
+    {
+      "schema": "agilab.worker-env-reuse.v1",
+      "sources": [
+        "tools/worker_env_reuse.py"
       ]
     },
     {

--- a/test/test_worktree_scope_guard.py
+++ b/test/test_worktree_scope_guard.py
@@ -40,6 +40,16 @@ def test_scope_for_path_groups_git_hooks_as_infrastructure():
     assert scope_guard.scope_for_path(".githooks/pre-push") == "git-hooks"
 
 
+def test_scope_for_path_groups_agent_instruction_and_discovery_files():
+    assert scope_guard.scope_for_path("AGENTS.md") == "agent-runbook"
+    assert scope_guard.scope_for_path("AGENT_LEARNINGS.md") == "agent-runbook"
+    assert scope_guard.scope_for_path("AGENT_CONVENTIONS.md") == "agent-runbook"
+    assert scope_guard.scope_for_path("tools/agent_workflows.md") == "agent-runbook"
+    assert scope_guard.scope_for_path("agenticweb.md") == "agent-discovery"
+    assert scope_guard.scope_for_path("agilab-capabilities.json") == "agent-discovery"
+    assert scope_guard.scope_for_path("llms-full.txt") == "agent-discovery"
+
+
 def test_scope_guard_flags_mixed_unrelated_worktree():
     report = scope_guard.analyze_scope(
         [
@@ -134,6 +144,12 @@ def test_main_allows_infrastructure_scopes_by_default(capsys):
             [
                 "--changed-file",
                 "AGENTS.md",
+                "--changed-file",
+                "AGENT_LEARNINGS.md",
+                "--changed-file",
+                "agenticweb.md",
+                "--changed-file",
+                "agilab-capabilities.json",
                 "--changed-file",
                 ".githooks/pre-push",
                 "--changed-file",

--- a/tools/worktree_scope_guard.py
+++ b/tools/worktree_scope_guard.py
@@ -16,6 +16,7 @@ from typing import Callable, Sequence
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_MAX_SCOPES = 2
 DEFAULT_ALLOWED_SCOPES = (
+    "agent-discovery",
     "agent-runbook",
     "agent-skills",
     "badges",
@@ -25,6 +26,24 @@ DEFAULT_ALLOWED_SCOPES = (
     "repo-tools",
     "tests",
 )
+
+AGENT_RUNBOOK_FILES = {
+    "AGENTS.md",
+    "AGENT_CONVENTIONS.md",
+    "AGENT_LEARNINGS.md",
+    "tools/agent_workflows.md",
+    "docs/source/agent-workflows.rst",
+}
+
+AGENT_DISCOVERY_FILES = {
+    "AGENT_SKILLS.md",
+    "agenticweb.md",
+    "agilab-capabilities.json",
+    "agilab-capabilities.schema.json",
+    "agilab-capability-rules.yml",
+    "llms.txt",
+    "llms-full.txt",
+}
 
 APP_HINTS = {
     "flight_telemetry": "flight_telemetry_project",
@@ -122,8 +141,10 @@ def scope_for_path(path: str) -> str:
         return f"lib:{package}"
     if len(parts) >= 4 and parts[:3] == ("src", "agilab", "core"):
         return f"core:{parts[3]}"
-    if path == "AGENTS.md":
+    if path in AGENT_RUNBOOK_FILES:
         return "agent-runbook"
+    if path in AGENT_DISCOVERY_FILES:
+        return "agent-discovery"
     if path.startswith("docs/") or path in {"README.md", "CHANGELOG.md"}:
         return "docs"
     if path.startswith(".claude/skills/") or path.startswith(".codex/skills/"):


### PR DESCRIPTION
## Summary

- Add an explicit compact validation close-out rule to `AGENTS.md`, `AGENT_LEARNINGS.md`, and the shared `agilab-testing` skill.
- Sync the rule into the repo Codex skill mirror.
- Refresh agent discovery metadata generated by the skills profile.
- Teach the scope guard that agent instruction and discovery files belong to allowed agent scopes.

## Why

Successful close-outs were still expanding `Validation passed` into command-level detail, which wastes agent context when the details are not needed for the next action.

## Validation

- `python3 tools/sync_agent_skills.py --skills agilab-testing`
- `python3 tools/codex_skills.py --root .codex/skills validate --strict`
- `python3 tools/codex_skills.py --root .codex/skills generate`
- `python3 tools/agent_instruction_contract.py --check`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --staged`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_agenticweb_manifest.py test/test_worktree_scope_guard.py`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile skills`
- `git diff --check --cached`
- `./dev scope --staged`