### PR TITLE
[codex] Add compact validation rule to conventions

### DIFF
--- a/AGENT_CONVENTIONS.md
+++ b/AGENT_CONVENTIONS.md
@@ -19,6 +19,9 @@ publication, or other risky surfaces, read [AGENTS.md](AGENTS.md) too.
 - Do not edit shared core (`agi-env`, `agi-node`, `agi-cluster`, `agi-core`,
   shared installer/build tooling) unless the user explicitly approves it.
 - Keep edits narrow and validate with the smallest relevant proof first.
+- For successful final close-outs, write `Validation passed.` without listing
+  every command unless failures, skipped checks, release/audit evidence, PR
+  proof, or an explicit user request make the details useful.
 - When corrected, update `AGENT_LEARNINGS.md` only if the correction is reusable
   and not already covered by an existing rule.
 - Do not edit `docs/html/**`.

--- a/tools/agent_instruction_contract.py
+++ b/tools/agent_instruction_contract.py
@@ -107,6 +107,7 @@ CONTRACTS: tuple[FileContract, ...] = (
             RequiredTerm("agent-learnings", "AGENT_LEARNINGS.md"),
             RequiredTerm("capability-manifest", "agilab-capabilities.json"),
             RequiredTerm("agenticweb", "agenticweb.md"),
+            RequiredTerm("compact-validation", "Validation passed."),
             RequiredTerm("contract-command", "python3 tools/agent_instruction_contract.py --check"),
         ),
     ),


### PR DESCRIPTION
## Summary

- Add the compact successful-validation close-out rule to `AGENT_CONVENTIONS.md`.
- Make `tools/agent_instruction_contract.py` require that marker in the short local-agent contract.

## Why

The full runbook and testing skill already carry the rule. The short conventions file is the lower-token surface many terminal agents read first, so it should carry the same behavior explicitly.

## Validation

- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_agent_instruction_contract.py`
- `python3 tools/agent_instruction_contract.py --check`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --staged`
- `git diff --check --cached`
- `./dev scope --staged`