### PR TITLE
[codex] Document compact validation close-outs

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 276,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "c1616535cd9462ad411dcf14c77d0e2e99ae7cf8bff5840cdb1eabeff236e405",
+  "source_digest_sha256": "cb93cc8efc0d927b9eaa6f2ac58b928dee320e2fadb327a13068bdcb8853c463",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "c1616535cd9462ad411dcf14c77d0e2e99ae7cf8bff5840cdb1eabeff236e405"
+  "target_digest_sha256": "cb93cc8efc0d927b9eaa6f2ac58b928dee320e2fadb327a13068bdcb8853c463"
 }

--- a/docs/source/agent-workflows.rst
+++ b/docs/source/agent-workflows.rst
@@ -87,6 +87,10 @@ the workflow-parity profiles.
 
 The main rule is simple: run the narrowest local proof first, then reproduce
 the real AGILAB path before broader validation.
+When all checks pass, keep final agent replies compact: write
+``Validation passed.`` without listing every command unless the details are
+needed for failures, skipped checks, release or audit evidence, PR proof, or an
+explicit user request.
 
 Use ``AGENT_LEARNINGS.md`` sparingly: add one concrete rule only when the
 correction is reusable and not already covered by the runbooks. Do not use it


### PR DESCRIPTION
## Summary
- Mirror the canonical docs update from jpmorard/thales_agilab#73.
- Document the compact final close-out rule: use `Validation passed.` without command details when all checks pass and no evidence exception applies.
- Refresh the docs source mirror stamp.

## Validation
- Mirror stamp check passed.
- Agent instruction contract passed.
- Targeted agent workflow docs tests passed.
- Docs workflow parity passed.
- Staged scope and whitespace checks passed.