### PR TITLE
[codex] Enforce compact validation runbook contract

### DIFF
--- a/test/test_agent_instruction_contract.py
+++ b/test/test_agent_instruction_contract.py
@@ -77,6 +77,25 @@ def test_contract_detects_missing_root_runbook_marker(tmp_path: Path) -> None:
     assert "no-fallbacks" in evidence_by_path["AGENTS.md"]["required_terms_missing"]
 
 
+def test_contract_detects_missing_compact_validation_marker(tmp_path: Path) -> None:
+    module = _load_module()
+    _write_minimal_contract_tree(module, tmp_path)
+    workflow = tmp_path / "tools" / "agent_workflows.md"
+    workflow.write_text(workflow.read_text(encoding="utf-8").replace("Validation passed.", ""), encoding="utf-8")
+
+    report = module.build_report(tmp_path)
+
+    assert report["status"] == "fail"
+    assert any(
+        issue["rule"] == "agent-instruction-required-term"
+        and issue["path"] == "tools/agent_workflows.md"
+        and "compact-validation" in issue["message"]
+        for issue in report["issues"]
+    )
+    evidence_by_path = {row["path"]: row for row in report["file_evidence"]}
+    assert "compact-validation" in evidence_by_path["tools/agent_workflows.md"]["required_terms_missing"]
+
+
 def test_contract_detects_missing_capability_command(tmp_path: Path) -> None:
     module = _load_module()
     _write_minimal_contract_tree(module, tmp_path)

--- a/tools/agent_instruction_contract.py
+++ b/tools/agent_instruction_contract.py
@@ -135,6 +135,7 @@ CONTRACTS: tuple[FileContract, ...] = (
             RequiredTerm("full-runbook", "AGENTS.md"),
             RequiredTerm("capability-manifest", "agilab-capabilities.json"),
             RequiredTerm("agenticweb", "agenticweb.md"),
+            RequiredTerm("compact-validation", "Validation passed."),
         ),
     ),
     FileContract(
@@ -148,6 +149,7 @@ CONTRACTS: tuple[FileContract, ...] = (
             RequiredTerm("full-runbook", "AGENTS.md"),
             RequiredTerm("capability-manifest", "agilab-capabilities.json"),
             RequiredTerm("agenticweb", "agenticweb.md"),
+            RequiredTerm("compact-validation", "Validation passed."),
         ),
     ),
 )

--- a/tools/agent_workflows.md
+++ b/tools/agent_workflows.md
@@ -47,6 +47,8 @@ The README badge contract is:
 Use the short repo contract in [AGENT_CONVENTIONS.md](../AGENT_CONVENTIONS.md)
 for local coding agents with smaller context windows. Use [AGENTS.md](../AGENTS.md)
 for the full AGILAB runbook when the task touches risky surfaces.
+When validation succeeds, keep close-outs compact: write `Validation passed.`
+without listing every command unless the evidence details are explicitly needed.
 
 When coding through a terminal agent, AGILAB recommends launching that agent
 through Tokki when it is available. Tokki keeps context compact, digests noisy


### PR DESCRIPTION
## Summary
- Add the compact `Validation passed.` close-out rule to the repo agent workflow reference.
- Extend the agent instruction contract so both the workflow reference and public agent docs must retain the compact-validation marker.
- Add a regression proving the contract fails when the workflow marker is removed.

## Validation
- Agent instruction contract passed.
- Targeted agent workflow tests passed.
- Staged impact validation passed.
- Staged scope and whitespace checks passed.