### PR TITLE
Fix newcomer release-proof install path handling

### DIFF
--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_local_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_local_support.py
@@ -127,6 +127,23 @@ def _shell_words(value: Any) -> str:
     return " ".join(shlex.quote(part) for part in shlex.split(str(value), posix=True))
 
 
+def _compose_worker_post_install_tool(local_env_prefix: str, uv_worker: Any) -> str:
+    uv_fragment = str(uv_worker or "").strip()
+    local_prefix = str(local_env_prefix or "").strip()
+    export_index = uv_fragment.find("export ")
+    semicolon_index = uv_fragment.find(";", export_index)
+    if export_index >= 0 and semicolon_index >= 0:
+        before_export = uv_fragment[:export_index].strip()
+        export_fragment = uv_fragment[export_index : semicolon_index + 1].strip()
+        after_export = uv_fragment[semicolon_index + 1 :].strip()
+        runnable_prefix = " ".join(
+            part for part in (local_prefix, before_export) if part
+        )
+        runnable = " ".join(part for part in (runnable_prefix, after_export) if part)
+        return " ".join(part for part in (export_fragment, runnable) if part)
+    return " ".join(part for part in (local_prefix, uv_fragment) if part)
+
+
 def _latest_glob_match(root: Path, pattern: str) -> Path | None:
     matches = sorted(root.glob(pattern), key=lambda candidate: candidate.name)
     if not matches:
@@ -1617,9 +1634,12 @@ async def deploy_local_worker(
                 exc,
             )
 
+    post_install_tool = _compose_worker_post_install_tool(
+        _local_worker_post_install_env_prefix(agi_cls),
+        uv_worker,
+    )
     post_install_cmd = (
-        f"{_local_worker_post_install_env_prefix(agi_cls)}"
-        f"{_shell_words(uv_worker)} run --no-sync --project {_shell_arg(wenv_abs)} "
+        f"{post_install_tool} run --no-sync --project {_shell_arg(wenv_abs)} "
         f"--python {_shell_arg(pyvers_worker)} python -m {_shell_arg(env.post_install_rel)} "
         f"{_shell_arg(env.active_app)}"
     )

--- a/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/build.py
+++ b/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/build.py
@@ -441,7 +441,7 @@ def _purge_top_level_ui_build_artifacts(app_root: Path, *, log: logging.Logger |
     return removed
 
 
-def _build_remove_decorators_command(worker_path: str) -> list[str]:
+def _build_remove_decorators_command(worker_path: str | Path) -> list[str]:
     return [
         "uv",
         "-q",
@@ -451,7 +451,7 @@ def _build_remove_decorators_command(worker_path: str) -> list[str]:
         "agi_node.agi_dispatcher.pre_install",
         "remove_decorators",
         "--worker_path",
-        worker_path,
+        str(worker_path),
         "--verbose",
     ]
 

--- a/src/agilab/core/test/test_agi_dispatcher_scripts.py
+++ b/src/agilab/core/test/test_agi_dispatcher_scripts.py
@@ -1883,6 +1883,13 @@ def test_build_remove_decorators_command_keeps_worker_path_as_argv():
     ]
 
 
+def test_build_remove_decorators_command_normalizes_path_arg():
+    command = build_mod._build_remove_decorators_command(Path("workers/demo_worker.py"))
+
+    assert Path(command[8]).parts == ("workers", "demo_worker.py")
+    assert all(isinstance(part, str) for part in command)
+
+
 def test_postprocess_bdist_egg_output_unpacks_and_cleans_links(tmp_path):
     out_dir = tmp_path / "worker_home" / "demo_project"
     dist_dir = out_dir / "dist"

--- a/src/agilab/core/test/test_agi_distributor_deployment_local_support.py
+++ b/src/agilab/core/test/test_agi_distributor_deployment_local_support.py
@@ -2067,6 +2067,19 @@ def test_local_worker_post_install_env_prefix_disables_cluster_only_for_non_dask
     )
 
 
+def test_compose_worker_post_install_tool_keeps_export_prefix_separate():
+    command = deployment_local_support._compose_worker_post_install_tool(
+        "AGI_CLUSTER_ENABLED=0 ",
+        'UV_INDEX_URL=https://mirror.example/simple export PATH="~/.local/bin:$PATH";uv --quiet',
+    )
+
+    assert command == (
+        'export PATH="~/.local/bin:$PATH"; '
+        "AGI_CLUSTER_ENABLED=0 UV_INDEX_URL=https://mirror.example/simple uv --quiet"
+    )
+    assert "export 'PATH=" not in command
+
+
 def test_infer_repo_root_from_runtime_returns_none_for_short_path():
     assert (
         deployment_local_support._infer_repo_root_from_runtime("too-short.py") is None

--- a/test/test_newcomer_first_proof.py
+++ b/test/test_newcomer_first_proof.py
@@ -52,6 +52,16 @@ def test_build_proof_commands_with_install_adds_install_and_seed_checks() -> Non
     assert "app_install_status" in commands[4].argv[-1]
 
 
+def test_install_readiness_code_passes_string_path_to_agienv() -> None:
+    module = _load_module()
+
+    code = module._install_readiness_code(module.DEFAULT_ACTIVE_APP)
+
+    assert "active_app = Path(" in code
+    assert "AgiEnv(active_app=str(active_app), verbose=1)" in code
+    assert "AgiEnv(active_app=active_app" not in code
+
+
 def test_build_proof_commands_with_run_adds_execute_probe() -> None:
     module = _load_module()
 

--- a/tools/newcomer_first_proof.py
+++ b/tools/newcomer_first_proof.py
@@ -302,7 +302,7 @@ def _install_readiness_code(active_app: Path) -> str:
         from agilab.orchestrate_page_support import app_install_status
 
         active_app = Path({str(active_app)!r})
-        env = AgiEnv(active_app=active_app, verbose=1)
+        env = AgiEnv(active_app=str(active_app), verbose=1)
         status = app_install_status(env)
 
         def encode(value):


### PR DESCRIPTION
## Summary
- pass string active-app paths into the newcomer proof readiness check
- normalize agi-node decorator-removal commands to string argv entries
- preserve PATH export shell fragments when composing local worker post-install commands

## Validation
Validation passed.