### PR TITLE
[codex] Record shell URL quoting rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,14 @@ Use this runbook whenever you:
   silently return. If an automated regression is genuinely not practical,
   document the reason, the closest manual/robot validation, and the remaining
   risk before closing the fix.
+- **Fix prevention close-out**: Every issue fix must include a prevention
+  step before handoff. For product or code defects, add or tighten the
+  smallest regression, guard, or validation that would have caught the failure.
+  For agent-process defects, such as a missed command-routing rule or a
+  preventable shell-construction mistake, add or tighten the narrowest durable
+  rule in `AGENT_LEARNINGS.md`, `AGENTS.md`, a repo skill, or tooling. If no
+  durable prevention is practical, state why and name the nearest validation
+  that now covers the risk.
 - **Streamlit duplicate-widget triage**: For duplicate element ID errors, first
   check whether the page, app surface, or entrypoint is being executed twice.
   Add stable widget keys for repeated controls, but do not mask duplicate

--- a/AGENT_LEARNINGS.md
+++ b/AGENT_LEARNINGS.md
@@ -58,3 +58,10 @@ is not a scratchpad or task log.
   Do not expand it into a command-by-command list unless failures, skipped
   checks, release/audit evidence, PR proof, or an explicit user request make the
   details useful.
+- When passing URLs, GitHub API paths, or query strings through the shell,
+  quote the entire argument or use stdin/structured flags. In zsh, unquoted
+  `?`, `&`, `[]`, or other glob-sensitive characters can change or reject the
+  command, so an unquoted `gh api repos/.../file?ref=main` style check is a
+  preventable command-construction error. When Tokki is available, run ad-hoc
+  verification commands through `tokki run -- ...`; Tokki reduces output noise
+  but does not replace correct shell quoting.


### PR DESCRIPTION
## Summary
- add a general fix-prevention close-out rule for every issue fix
- add an agent-learning rule for quoting URLs, GitHub API paths, and query strings in shell commands
- require explicit `tokki run -- ...` for ad-hoc verification commands when Tokki is available, while still keeping shell quoting correct

## Validation
- tokki run -- python3 tools/agent_instruction_contract.py --check
- tokki run -- ./dev scope
- tokki run -- uv --preview-features extra-build-dependencies run python tools/impact_validate.py --staged
- git diff --cached --check