### PR TITLE
[codex] Enforce agent prevention rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -350,8 +350,10 @@ Use this runbook whenever you:
   `.opencode/agents/`. Keep them aligned with repo guardrails when workflow policy changes.
   When coding through a terminal agent, prefer launching it through Tokki when
   available so AGILAB sessions get compact context, noisy-output digestion,
-  token-savings accounting, and consistent wrapper metadata. Tokki is an
-  agent-session efficiency layer, not a replacement for AGILAB validation gates.
+  token-savings accounting, and consistent wrapper metadata. For ad-hoc
+  terminal checks inside a session, prefer `tokki run -- <command>` when it can
+  execute the command faithfully. Tokki is an agent-session efficiency layer,
+  not a replacement for AGILAB validation gates.
 - **Agent instruction contract**: Keep `AGENTS.md`, `AGENT_CONVENTIONS.md`,
   `AGENT_LEARNINGS.md`, `tools/agent_workflows.md`, public agent docs, and
   `agilab-capabilities.json` aligned. Run

--- a/test/test_agent_instruction_contract.py
+++ b/test/test_agent_instruction_contract.py
@@ -96,6 +96,50 @@ def test_contract_detects_missing_compact_validation_marker(tmp_path: Path) -> N
     assert "compact-validation" in evidence_by_path["tools/agent_workflows.md"]["required_terms_missing"]
 
 
+def test_contract_detects_missing_fix_prevention_marker(tmp_path: Path) -> None:
+    module = _load_module()
+    _write_minimal_contract_tree(module, tmp_path)
+    agents = tmp_path / "AGENTS.md"
+    agents.write_text(
+        agents.read_text(encoding="utf-8").replace("Fix prevention close-out", ""),
+        encoding="utf-8",
+    )
+
+    report = module.build_report(tmp_path)
+
+    assert report["status"] == "fail"
+    assert any(
+        issue["rule"] == "agent-instruction-required-term"
+        and issue["path"] == "AGENTS.md"
+        and "fix-prevention" in issue["message"]
+        for issue in report["issues"]
+    )
+    evidence_by_path = {row["path"]: row for row in report["file_evidence"]}
+    assert "fix-prevention" in evidence_by_path["AGENTS.md"]["required_terms_missing"]
+
+
+def test_contract_detects_missing_shell_url_quoting_marker(tmp_path: Path) -> None:
+    module = _load_module()
+    _write_minimal_contract_tree(module, tmp_path)
+    learnings = tmp_path / "AGENT_LEARNINGS.md"
+    learnings.write_text(
+        learnings.read_text(encoding="utf-8").replace("gh api repos/.../file?ref=main", ""),
+        encoding="utf-8",
+    )
+
+    report = module.build_report(tmp_path)
+
+    assert report["status"] == "fail"
+    assert any(
+        issue["rule"] == "agent-instruction-required-term"
+        and issue["path"] == "AGENT_LEARNINGS.md"
+        and "shell-url-quoting" in issue["message"]
+        for issue in report["issues"]
+    )
+    evidence_by_path = {row["path"]: row for row in report["file_evidence"]}
+    assert "shell-url-quoting" in evidence_by_path["AGENT_LEARNINGS.md"]["required_terms_missing"]
+
+
 def test_contract_detects_missing_capability_command(tmp_path: Path) -> None:
     module = _load_module()
     _write_minimal_contract_tree(module, tmp_path)

--- a/tools/agent_instruction_contract.py
+++ b/tools/agent_instruction_contract.py
@@ -93,6 +93,8 @@ CONTRACTS: tuple[FileContract, ...] = (
             RequiredTerm("docs-source", "Docs source of truth"),
             RequiredTerm("agent-contract", "Agent instruction contract"),
             RequiredTerm("agent-learnings", "Agent correction ledger"),
+            RequiredTerm("fix-prevention", "Fix prevention close-out"),
+            RequiredTerm("tokki-routing", "tokki run --"),
         ),
     ),
     FileContract(
@@ -122,6 +124,8 @@ CONTRACTS: tuple[FileContract, ...] = (
             RequiredTerm("concrete-rule", "one concrete rule"),
             RequiredTerm("prune", "Prune entries"),
             RequiredTerm("contract-command", "python3 tools/agent_instruction_contract.py --check"),
+            RequiredTerm("shell-url-quoting", "gh api repos/.../file?ref=main"),
+            RequiredTerm("tokki-routing", "tokki run --"),
         ),
     ),
     FileContract(


### PR DESCRIPTION
## Summary

- Strengthen today's agent-runbook change by making the new prevention guidance executable through `tools/agent_instruction_contract.py`.
- Add required markers for the fix-prevention close-out and shell URL quoting/Tokki routing guidance.
- Add regression tests proving the contract fails if either rule is removed.
- Clarify `AGENTS.md` so ad-hoc terminal checks explicitly prefer `tokki run -- <command>` when faithful execution is possible.

## Review note

The prior change captured the right behavior in prose, but it was still policy-only. This follow-up moves the high-value parts into the existing agent-instruction contract so they cannot silently drift.

## Validation

Validation passed.