### PR TITLE
[codex] Enforce Tokki routing contract

### DIFF
--- a/AGENT_CONVENTIONS.md
+++ b/AGENT_CONVENTIONS.md
@@ -13,6 +13,8 @@ publication, or other risky surfaces, read [AGENTS.md](AGENTS.md) too.
 - Prefer launching terminal coding agents through Tokki when it is available;
   use it for compact context, noisy-output digestion, and session metadata, not
   as a substitute for AGILAB validation gates.
+- For ad-hoc terminal checks inside an agent session, prefer
+  `tokki run -- <command>` when it can execute the command faithfully.
 - Run `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --staged`
   before non-trivial edits.
 - Prefer app-local fixes over shared-core changes.

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 276,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "a1e37051be7dc9a839c26ba6427c3e5161c6b51b89f4d152b6857485e6aeeab6",
+  "source_digest_sha256": "76a1f39ce3e0c6e64e2f922d8c8d0576df75f3bd7071c2de28c34ff9f90512c5",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "a1e37051be7dc9a839c26ba6427c3e5161c6b51b89f4d152b6857485e6aeeab6"
+  "target_digest_sha256": "76a1f39ce3e0c6e64e2f922d8c8d0576df75f3bd7071c2de28c34ff9f90512c5"
 }

--- a/docs/source/agent-workflows.rst
+++ b/docs/source/agent-workflows.rst
@@ -81,6 +81,8 @@ Then follow the repo rules in:
 When coding through a terminal agent, AGILAB recommends launching that agent
 through Tokki when it is available. Tokki keeps context compact, digests noisy
 terminal output, records session metadata, and exposes token-savings evidence.
+For ad-hoc terminal checks inside an agent session, prefer
+``tokki run -- <command>`` when it can execute the command faithfully.
 It is an efficiency and observability layer for agent sessions; the AGILAB
 validation source of truth remains ``tools/impact_validate.py``, ``./dev``, and
 the workflow-parity profiles.

--- a/test/test_agent_instruction_contract.py
+++ b/test/test_agent_instruction_contract.py
@@ -140,6 +140,28 @@ def test_contract_detects_missing_shell_url_quoting_marker(tmp_path: Path) -> No
     assert "shell-url-quoting" in evidence_by_path["AGENT_LEARNINGS.md"]["required_terms_missing"]
 
 
+def test_contract_detects_missing_tokki_routing_marker_in_short_contract(tmp_path: Path) -> None:
+    module = _load_module()
+    _write_minimal_contract_tree(module, tmp_path)
+    conventions = tmp_path / "AGENT_CONVENTIONS.md"
+    conventions.write_text(
+        conventions.read_text(encoding="utf-8").replace("tokki run --", ""),
+        encoding="utf-8",
+    )
+
+    report = module.build_report(tmp_path)
+
+    assert report["status"] == "fail"
+    assert any(
+        issue["rule"] == "agent-instruction-required-term"
+        and issue["path"] == "AGENT_CONVENTIONS.md"
+        and "tokki-routing" in issue["message"]
+        for issue in report["issues"]
+    )
+    evidence_by_path = {row["path"]: row for row in report["file_evidence"]}
+    assert "tokki-routing" in evidence_by_path["AGENT_CONVENTIONS.md"]["required_terms_missing"]
+
+
 def test_contract_detects_missing_capability_command(tmp_path: Path) -> None:
     module = _load_module()
     _write_minimal_contract_tree(module, tmp_path)

--- a/tools/agent_instruction_contract.py
+++ b/tools/agent_instruction_contract.py
@@ -110,6 +110,7 @@ CONTRACTS: tuple[FileContract, ...] = (
             RequiredTerm("capability-manifest", "agilab-capabilities.json"),
             RequiredTerm("agenticweb", "agenticweb.md"),
             RequiredTerm("compact-validation", "Validation passed."),
+            RequiredTerm("tokki-routing", "tokki run --"),
             RequiredTerm("contract-command", "python3 tools/agent_instruction_contract.py --check"),
         ),
     ),
@@ -140,6 +141,7 @@ CONTRACTS: tuple[FileContract, ...] = (
             RequiredTerm("capability-manifest", "agilab-capabilities.json"),
             RequiredTerm("agenticweb", "agenticweb.md"),
             RequiredTerm("compact-validation", "Validation passed."),
+            RequiredTerm("tokki-routing", "tokki run --"),
         ),
     ),
     FileContract(
@@ -154,6 +156,7 @@ CONTRACTS: tuple[FileContract, ...] = (
             RequiredTerm("capability-manifest", "agilab-capabilities.json"),
             RequiredTerm("agenticweb", "agenticweb.md"),
             RequiredTerm("compact-validation", "Validation passed."),
+            RequiredTerm("tokki-routing", "tokki run --"),
         ),
     ),
 )

--- a/tools/agent_workflows.md
+++ b/tools/agent_workflows.md
@@ -53,6 +53,8 @@ without listing every command unless the evidence details are explicitly needed.
 When coding through a terminal agent, AGILAB recommends launching that agent
 through Tokki when it is available. Tokki keeps context compact, digests noisy
 terminal output, records session metadata, and exposes token-savings evidence.
+For ad-hoc terminal checks inside an agent session, prefer
+`tokki run -- <command>` when it can execute the command faithfully.
 It is an efficiency and observability layer for agent sessions; the AGILAB
 validation source of truth remains `tools/impact_validate.py`, `./dev`, and the
 workflow-parity profiles.


### PR DESCRIPTION
## Summary

- add `tokki run -- <command>` guidance to short and public agent surfaces
- enforce the Tokki routing marker across the instruction contract
- add a regression for missing short-contract routing guidance
- refresh the docs mirror stamp from canonical source

Validation passed.
