### PR TITLE
[codex] restore routing docs

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 276,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "b569c1eab45212503f1740690556c8ff80ebed7967b07a40e5984a39c7b679d5",
+  "source_digest_sha256": "0b50c04c4adcdb2a78a1e1437369cc3e3148d91ebb6f0b2ef9af0b3d1f93e192",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "b569c1eab45212503f1740690556c8ff80ebed7967b07a40e5984a39c7b679d5"
+  "target_digest_sha256": "0b50c04c4adcdb2a78a1e1437369cc3e3148d91ebb6f0b2ef9af0b3d1f93e192"
 }

--- a/docs/source/agent-workflows.rst
+++ b/docs/source/agent-workflows.rst
@@ -117,8 +117,17 @@ baseline runbooks, matched rules, and recommended repo-managed skills from
 only: it does not execute agents, run tests, or replace
 ``tools/impact_validate.py``.
 
-For a local wrapper that expects AGILAB's bounded context profile, pass
-``--profile tokki``::
+For a scoped AGILAB context pack that starts from the current project and framework files,
+pass ``--profile agilab``::
+
+   python3 tools/agent_context_router.py \
+     --profile agilab \
+     --files docs/source/agent-workflows.rst src/agilab/agent_run.py \
+     --prompt "update agent evidence docs" \
+     --json
+
+For a smaller local wrapper that expects the bounded token-saving profile,
+pass ``--profile tokki``::
 
    python3 tools/agent_context_router.py \
      --profile tokki \


### PR DESCRIPTION
Restores the missing `--profile agilab` routing example in `docs/source/agent-workflows.rst` while keeping the Tokki example and the public disclosure boundary.

Why:
The docs edit had narrowed the section to Tokki only, but the existing contract and tests still expect both the scoped AGILAB route and the Tokki wrapper route.

Impact:
Keeps the public docs aligned with `test/test_agent_workflows.py` and preserves the limited Tokki disclosure wording.

Checks:
`uv run pytest -q test/test_agent_workflows.py`
