### PR TITLE
[codex] flight telemetry self-heal

### DIFF
--- a/src/agilab/apps/install.py
+++ b/src/agilab/apps/install.py
@@ -148,7 +148,7 @@ def _seed_example_scripts(app_slug: str) -> None:
 
     for source in sorted(examples_dir.glob("AGI_*.py")):
         destination = execute_dir / source.name
-        if destination.exists() and not _should_refresh_example_script(destination):
+        if destination.exists() and not _should_refresh_example_script(source, destination):
             continue
         try:
             shutil.copy2(source, destination)
@@ -157,14 +157,15 @@ def _seed_example_scripts(app_slug: str) -> None:
             print(f"[WARN] Unable to copy {source} to {destination}: {exc}")
 
 
-def _should_refresh_example_script(destination: Path) -> bool:
+def _should_refresh_example_script(source: Path, destination: Path) -> bool:
     """Return True when an existing seeded helper is known-stale."""
 
     try:
-        text = destination.read_text(encoding="utf-8")
+        source_text = source.read_text(encoding="utf-8")
+        destination_text = destination.read_text(encoding="utf-8")
     except OSError:
         return False
-    return _has_stale_builtin_apps_root(text)
+    return source_text != destination_text or _has_stale_builtin_apps_root(destination_text)
 
 
 def _has_stale_builtin_apps_root(text: str) -> bool:

--- a/src/agilab/examples/flight_telemetry/AGI_run_flight_telemetry.py
+++ b/src/agilab/examples/flight_telemetry/AGI_run_flight_telemetry.py
@@ -20,6 +20,12 @@ def agilab_apps_path() -> Path:
 
 async def main():
     app_env = AgiEnv(apps_path=agilab_apps_path(), app=APP, verbose=1)
+    await AGI.install(
+        app_env,
+        modes_enabled=LOCAL_RUN_MODES,
+        scheduler="127.0.0.1",
+        workers={"127.0.0.1": 1},
+    )
     request = RunRequest(
         params={
             "data_source": "file",

--- a/test/test_app_installer_packaging.py
+++ b/test/test_app_installer_packaging.py
@@ -1776,6 +1776,25 @@ def test_seed_example_scripts_refreshes_stale_builtin_helper(tmp_path: Path, mon
     assert text == (EXAMPLES_ROOT / "flight_telemetry" / "AGI_run_flight_telemetry.py").read_text(encoding="utf-8")
 
 
+def test_seed_example_scripts_refreshes_changed_helper_contents(tmp_path: Path, monkeypatch) -> None:
+    module = _load_installer(monkeypatch, tmp_path)
+    package_root = tmp_path / "site-packages" / "agilab"
+    examples_dir = package_root / "examples" / "flight_telemetry"
+    examples_dir.mkdir(parents=True)
+    source = examples_dir / "AGI_run_flight_telemetry.py"
+    source.write_text("# new run helper\n", encoding="utf-8")
+
+    monkeypatch.setattr(module, "_package_root", lambda: package_root)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    destination = tmp_path / "home" / "log" / "execute" / "flight_telemetry" / "AGI_run_flight_telemetry.py"
+    destination.parent.mkdir(parents=True)
+    destination.write_text("# old run helper\n", encoding="utf-8")
+
+    module._seed_example_scripts("flight_telemetry")
+
+    assert destination.read_text(encoding="utf-8") == "# new run helper\n"
+
+
 def test_packaged_run_and_install_examples_import_with_fake_home(tmp_path: Path, monkeypatch) -> None:
     agilab_path = tmp_path / ".local" / "share" / "agilab"
     agilab_path.mkdir(parents=True)
@@ -1798,6 +1817,17 @@ def test_packaged_run_and_install_examples_import_with_fake_home(tmp_path: Path,
         sys.modules[module_name] = module
         spec.loader.exec_module(module)
         assert callable(module.main)
+
+
+def test_flight_telemetry_run_example_provisions_install_before_run() -> None:
+    text = (EXAMPLES_ROOT / "flight_telemetry" / "AGI_run_flight_telemetry.py").read_text(
+        encoding="utf-8"
+    )
+
+    install_index = text.index("await AGI.install(")
+    run_index = text.index("res = await AGI.run(")
+
+    assert install_index < run_index
 
 
 def test_packaged_examples_fail_cleanly_without_agilab_marker(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## What changed

- The flight telemetry run helper now provisions the worker environment with `AGI.install(...)` before calling `AGI.run(...)`.
- Example seeding now refreshes copied `AGI_*.py` helpers whenever the packaged source changes, not only when a single stale marker pattern matches.
- Added packaging tests for both behaviors.

## Why

The HF Space was still executing an older copied helper that could hit `Worker installation (.venv) not found` on `EXECUTE`.

## Validation

- `uv run pytest -q test/test_app_installer_packaging.py -k "seed_example_scripts_refreshes or packaged_examples_use_public_api_and_modern_runner or flight_telemetry_run_example_provisions_install_before_run"`
- `uv run python -m py_compile src/agilab/examples/flight_telemetry/AGI_run_flight_telemetry.py src/agilab/apps/install.py test/test_app_installer_packaging.py`
