### PR TITLE
[codex] tokki repo-ready docs

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 276,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "0b50c04c4adcdb2a78a1e1437369cc3e3148d91ebb6f0b2ef9af0b3d1f93e192",
+  "source_digest_sha256": "84182d9d5b934fa2c1493515e36aeda4f6f7eccb88e821fd625be50b35a0e6e0",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "0b50c04c4adcdb2a78a1e1437369cc3e3148d91ebb6f0b2ef9af0b3d1f93e192"
+  "target_digest_sha256": "84182d9d5b934fa2c1493515e36aeda4f6f7eccb88e821fd625be50b35a0e6e0"
 }

--- a/docs/source/agent-workflows.rst
+++ b/docs/source/agent-workflows.rst
@@ -19,8 +19,9 @@ needed to work with these executable agent paths against the same repo contract:
 - Aider
 - OpenCode
 - Mistral Vibe
+- Tokki
 
-That does not mean the five tools behave identically. It means the repo now
+That does not mean the six tools behave identically. It means the repo now
 contains a prepared entry path for each of them instead of relying on ad hoc
 local setup.
 

--- a/test/test_agent_workflows.py
+++ b/test/test_agent_workflows.py
@@ -141,6 +141,8 @@ def test_agent_skill_badges_catalog_and_resource_preflight_are_documented() -> N
     assert "agilab.agent_instruction_contract.v1" in agent_workflows
     assert "--profile agilab" in public_docs
     assert "--profile tokki" in public_docs
+    assert "six tools behave identically" in public_docs
+    assert "- Tokki" in public_docs
     assert "current project and framework files" in public_docs
     assert "smaller local wrapper that expects the bounded token-saving profile" in public_docs
     assert "python tools/resource_snapshot.py --output resource_snapshot.json --json" in agent_workflows


### PR DESCRIPTION
## What changed

- Added Tokki to the repo-ready list in `docs/source/agent-workflows.rst`.
- Updated the mirrored docs stamp.
- Extended `test/test_agent_workflows.py` to assert the updated contract text.

## Why

The public docs contract now needs to mention Tokki explicitly, and the test should pin the exact wording so the page does not drift.

## Validation

- `uv run pytest -q test/test_agent_workflows.py`
