### PR TITLE
[codex] hf boot refresh

### DIFF
--- a/test/test_hf_space_release_sync.py
+++ b/test/test_hf_space_release_sync.py
@@ -128,6 +128,14 @@ def test_generated_space_readme_uses_valid_hf_emoji_metadata() -> None:
     assert "emoji: lab_coat" not in module.README_TEMPLATE
 
 
+def test_generated_dockerfile_refreshes_first_proof_helpers_on_boot() -> None:
+    module = _load_module()
+
+    assert "src/agilab/apps/install.py" in module.DOCKERFILE_TEMPLATE
+    assert "flight_telemetry_project --verbose 0" in module.DOCKERFILE_TEMPLATE
+    assert "streamlit run /app/src/agilab/main_page.py" in module.DOCKERFILE_TEMPLATE
+
+
 def test_first_proof_profile_uses_public_weather_demo() -> None:
     module = _load_module()
 

--- a/tools/hf_space_release_sync.py
+++ b/tools/hf_space_release_sync.py
@@ -217,7 +217,8 @@ RUN uv sync --project /app --extra ui && \\
 EXPOSE 7860
 
 CMD ["bash", "-c", \\
-    "AGILAB_PUBLIC_BIND_OK=1 AGILAB_TLS_TERMINATED=1 \\
+    "uv run --project /app --no-sync python /app/src/agilab/apps/install.py /app/src/agilab/apps/builtin/flight_telemetry_project --verbose 0 && \\
+     AGILAB_PUBLIC_BIND_OK=1 AGILAB_TLS_TERMINATED=1 \\
      uv run --project /app --extra ui --no-sync streamlit run /app/src/agilab/main_page.py \\
      --server.port 7860 \\
      --server.address 0.0.0.0 \\


### PR DESCRIPTION
## What changed

- Make the HF Space boot path refresh the first-proof helper before launching Streamlit.
- Add a regression test for the generated Dockerfile command.

## Why

The Space could keep a stale `~/log/execute/flight_telemetry/AGI_run_flight_telemetry.py` across restarts, which left the old event-loop helper in place even after the repo was updated.

## Validation

- `uv run pytest -q test/test_hf_space_release_sync.py`
- `uv run python -m py_compile tools/hf_space_release_sync.py test/test_hf_space_release_sync.py`
