### PR TITLE
[codex] Reduce GitHub workflow load

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: ["**"]
   workflow_dispatch:
   schedule:
-    - cron: "17 5 * * *"
+    - cron: "17 5 * * 1"
 
 permissions:
   contents: read
@@ -68,6 +68,23 @@ jobs:
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "0.10.7"
+
+      - name: Resolve Playwright version for browser cache key
+        id: playwright-version
+        run: |
+          set -euo pipefail
+          version="$(uv --preview-features extra-build-dependencies run --with playwright python -c 'from importlib.metadata import version; print(version("playwright"))')"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Restore Playwright browser cache
+        id: playwright-cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/ms-playwright
+          # Exact-key only: the key tracks the resolved Playwright version, so a
+          # version bump rolls to a fresh cache instead of restoring stale
+          # browser revisions and unioning them into ever-growing saves.
+          key: playwright-${{ runner.os }}-py3.13-${{ steps.playwright-version.outputs.version }}-chromium
 
       - name: Compile critical Python entrypoints
         run: |
@@ -152,7 +169,14 @@ jobs:
       - name: Install Playwright browser for frontend smoke
         run: |
           set -euo pipefail
-          uv --preview-features extra-build-dependencies run --with playwright python -m playwright install --with-deps chromium
+          uv --preview-features extra-build-dependencies run --with "playwright==${{ steps.playwright-version.outputs.version }}" python -m playwright install --with-deps chromium
+
+      - name: Save Playwright browser cache
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-py3.13-${{ steps.playwright-version.outputs.version }}-chromium
 
       - name: Validate Streamlit frontend smoke
         env:

--- a/.github/workflows/ui-robot-matrix.yml
+++ b/.github/workflows/ui-robot-matrix.yml
@@ -16,7 +16,7 @@ on:
         required: false
         default: "3"
   schedule:
-    - cron: "43 2 * * *"
+    - cron: "43 2 * * 3"
 
 permissions:
   contents: read
@@ -80,10 +80,34 @@ jobs:
         with:
           version: "0.10.7"
 
+      - name: Resolve Playwright version for browser cache key
+        id: playwright-version
+        run: |
+          set -euo pipefail
+          version="$(uv --preview-features extra-build-dependencies run --with playwright python -c 'from importlib.metadata import version; print(version("playwright"))')"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Restore Playwright browser cache
+        id: playwright-cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/ms-playwright
+          # Exact-key only: the key tracks the resolved Playwright version, so a
+          # version bump rolls to a fresh cache instead of restoring stale
+          # browser revisions and unioning them into ever-growing saves.
+          key: playwright-${{ runner.os }}-py3.13-${{ steps.playwright-version.outputs.version }}-chromium
+
       - name: Install Playwright browser
         run: |
           set -euo pipefail
-          uv --preview-features extra-build-dependencies run --with playwright python -m playwright install --with-deps chromium
+          uv --preview-features extra-build-dependencies run --with "playwright==${{ steps.playwright-version.outputs.version }}" python -m playwright install --with-deps chromium
+
+      - name: Save Playwright browser cache
+        if: steps.playwright-cache.outputs.cache-hit != 'true' && matrix.shard == 'core'
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-py3.13-${{ steps.playwright-version.outputs.version }}-chromium
 
       - name: Run UI robot matrix shard
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,8 @@ Use this runbook whenever you:
   `app-contracts` for
   built-in app/package/catalog/docs alignment, `audit` for local worktree/docs/release/PyPI
   state, `builtin-app-tests` for app-local built-in test execution,
-  `flow` for one or more workflow parity profiles,
+  `flow` for one or more workflow parity profiles, `ui-flow` for selecting the
+  minimal local UI robot profiles from changed files,
   `release` for local pre-tag release guards, `badge` for the explicit release/pre-release
   coverage-badge guard, `maintenance` for long-term extension/evidence/docs/package
   drift signals, `memory` for path-scoped maintenance-note drift checks,
@@ -56,7 +57,9 @@ Use this runbook whenever you:
   environment with pytest importlib mode, avoiding false root-environment dependency
   failures for app-local packages,
   `audit` is the quick robustness check before handoff between machines,
-  `flow` matches local GitHub workflow profiles, `release` starts with the strict AGILAB audit/review,
+  `flow` matches local GitHub workflow profiles, `ui-flow` is the local-first gate
+  before relying on the scheduled full UI robot matrix for browser-heavy frontend changes,
+  `release` starts with the strict AGILAB audit/review,
   then checks impact, generated PyPI release plan, trusted-publisher contract, Ruff availability,
   dependency policy, strict typing, docs, and badges before a tag,
   `badge` checks badge freshness when intentionally requested, `maintenance` reports the

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 276,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "a28d7591db7074d4ec48699f21834077f9debe91a71fdee1f397d4b984498a0d",
+  "source_digest_sha256": "a6fce013df518d10dd4b59760ec23c599ffb10843c48609454c35c7ecb864464",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "a28d7591db7074d4ec48699f21834077f9debe91a71fdee1f397d4b984498a0d"
+  "target_digest_sha256": "a6fce013df518d10dd4b59760ec23c599ffb10843c48609454c35c7ecb864464"
 }

--- a/docs/source/agent-workflows.rst
+++ b/docs/source/agent-workflows.rst
@@ -85,6 +85,8 @@ the wrapper boundary: request bounded context, keep terminal evidence concise,
 and do not document wrapper-specific behavior. The AGILAB validation source of
 truth remains ``tools/impact_validate.py``, ``./dev``, and the workflow-parity
 profiles.
+For ad-hoc terminal checks inside an already routed local wrapper session, use
+``tokki run -- <command>`` when it can execute the command faithfully.
 
 The main rule is simple: run the narrowest local proof first, then reproduce
 the real AGILAB path before broader validation.

--- a/test/test_ci_workflow.py
+++ b/test/test_ci_workflow.py
@@ -147,14 +147,40 @@ def test_ci_workflow_includes_minimal_first_proof_contract() -> None:
 
     assert 'branches: ["main"]' in push_block
     assert 'branches: ["**"]' not in push_block
+    assert 'cron: "17 5 * * 1"' in text
+    assert 'cron: "17 5 * * *"' not in text
     assert "Validate first-launch robot" in text
     assert (
         "uv --preview-features extra-build-dependencies run --extra ui python "
         "tools/first_launch_robot.py --json --output first-launch-robot.json"
     ) in text
+    assert "Resolve Playwright version for browser cache key" in text
+    assert "id: playwright-version" in text
+    assert "Restore Playwright browser cache" in text
+    assert "id: playwright-cache" in text
+    assert "actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae" in text
+    assert "path: ~/.cache/ms-playwright" in text
+    assert (
+        "key: playwright-${{ runner.os }}-py3.13-${{ steps.playwright-version.outputs.version }}-chromium"
+    ) in text
+    assert "restore-keys" not in text.split("Restore Playwright browser cache", 1)[1].split(
+        "Install Playwright browser for frontend smoke", 1
+    )[0]
     assert "Install Playwright browser for frontend smoke" in text
     assert "Validate Streamlit frontend smoke" in text
-    assert "python -m playwright install --with-deps chromium" in text
+    assert (
+        'uv --preview-features extra-build-dependencies run --with "playwright==${{ steps.playwright-version.outputs.version }}" '
+        "python -m playwright install --with-deps chromium"
+    ) in text
+    assert "Save Playwright browser cache" in text
+    assert "steps.playwright-cache.outputs.cache-hit != 'true'" in text
+    assert "actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae" in text
+    assert text.index("Restore Playwright browser cache") < text.index(
+        "Install Playwright browser for frontend smoke"
+    )
+    assert text.index("Install Playwright browser for frontend smoke") < text.index(
+        "Save Playwright browser cache"
+    )
     assert "tools/agilab_web_robot.py" in text
     assert "--frontend-smoke-only" in text
     assert "frontend-smoke-robot.json" in text
@@ -240,12 +266,14 @@ def test_docs_workflows_block_stale_release_proof_github_runs() -> None:
     assert "run --extra ui pytest -q -o addopts='' test/test_sync_docs_source.py" not in guard_text
 
 
-def test_ui_robot_matrix_workflow_is_opt_in_or_nightly_only() -> None:
+def test_ui_robot_matrix_workflow_is_opt_in_or_weekly_only() -> None:
     text = UI_ROBOT_MATRIX_WORKFLOW_PATH.read_text(encoding="utf-8")
 
     assert "name: ui-robot-matrix" in text
     assert "workflow_dispatch:" in text
     assert "schedule:" in text
+    assert 'cron: "43 2 * * 3"' in text
+    assert 'cron: "43 2 * * *"' not in text
     assert "pull_request:" not in text
     assert "\n  push:" not in text
     assert "ui-robot-matrix:" in text
@@ -256,6 +284,31 @@ def test_ui_robot_matrix_workflow_is_opt_in_or_nightly_only() -> None:
     assert "- shard: quality" in text
     assert "- shard: layout" in text
     assert "tools/agilab_widget_robot_matrix.py" in text
+    assert "Resolve Playwright version for browser cache key" in text
+    assert "id: playwright-version" in text
+    assert "Restore Playwright browser cache" in text
+    assert "id: playwright-cache" in text
+    assert "actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae" in text
+    assert "path: ~/.cache/ms-playwright" in text
+    assert (
+        "key: playwright-${{ runner.os }}-py3.13-${{ steps.playwright-version.outputs.version }}-chromium"
+    ) in text
+    assert "restore-keys" not in text.split("Restore Playwright browser cache", 1)[1].split(
+        "Install Playwright browser", 1
+    )[0]
+    assert (
+        'uv --preview-features extra-build-dependencies run --with "playwright==${{ steps.playwright-version.outputs.version }}" '
+        "python -m playwright install --with-deps chromium"
+    ) in text
+    assert "Save Playwright browser cache" in text
+    assert "steps.playwright-cache.outputs.cache-hit != 'true' && matrix.shard == 'core'" in text
+    assert "actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae" in text
+    assert text.index("Restore Playwright browser cache") < text.index(
+        "Install Playwright browser"
+    )
+    assert text.index("Install Playwright browser") < text.index(
+        "Save Playwright browser cache"
+    )
     assert "uv --preview-features extra-build-dependencies run --extra ai --with playwright python tools/agilab_widget_robot_matrix.py" in text
     for scenario in {
         scenario


### PR DESCRIPTION
## Summary

Reduce GitHub-hosted workflow load while preserving local parity and manual dispatch paths.

- Change `repo-guardrails` from daily to weekly scheduled execution.
- Change `ui-robot-matrix` from daily to weekly scheduled execution while keeping `workflow_dispatch` available.
- Add exact-key Playwright browser caching to `repo-guardrails` and `ui-robot-matrix`; the UI matrix saves only from the `core` shard to avoid parallel cache-save races.
- Document `./dev ui-flow` as the local-first UI robot gate and sync the public agent workflow docs marker required by the instruction contract.
- Extend `test/test_ci_workflow.py` to guard the new schedules and cache wiring.

## Validation

- `./dev impact --staged`
- `./dev scope --staged`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_ci_workflow.py test/test_agilab_dev_shortcuts.py test/test_workflow_parity.py test/test_sync_docs_source.py`
- `python3 tools/agent_instruction_contract.py --check`
- `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --check --delete --quiet`
- `git diff --cached --check`

## Notes

Final PyPI publishing remains on GitHub for trusted publishing/provenance. This PR reduces repeated browser setup and scheduled runner load rather than replacing publish identity-sensitive jobs with local execution.