### PR TITLE
Improve Cython worker build efficiency

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 276,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "a6fce013df518d10dd4b59760ec23c599ffb10843c48609454c35c7ecb864464",
+  "source_digest_sha256": "8ac5b19e035966218382aba1837725e37ff7f438fabcffa51de5025a6306a493",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "a6fce013df518d10dd4b59760ec23c599ffb10843c48609454c35c7ecb864464"
+  "target_digest_sha256": "8ac5b19e035966218382aba1837725e37ff7f438fabcffa51de5025a6306a493"
 }

--- a/docs/source/environment.rst
+++ b/docs/source/environment.rst
@@ -149,6 +149,33 @@ rather than shown as one of the workflow pages.
    * - ``AGI_LOG_DIR``
      - ``~/log``
      - Parent directory for install logs (``install_logs``), worker logs, and general telemetry.
+   * - ``AGILAB_CYTHON_CACHE``
+     - ``~/.cache/agilab/cython``
+     - Cythonize cache directory for worker extension builds. Set to ``off`` to
+       disable Cython's conversion cache, or to a custom path for a shared local
+       cache.
+   * - ``AGILAB_CYTHON_TYPE_PREPROCESS``
+     - ``0``
+     - Opt-in conservative worker-source preprocessor that inserts local Cython
+       declarations only when the AST evidence is safe. When enabled,
+       ``pre_install`` also writes ``<worker>.cython-preview.json`` next to the
+       generated ``.pyx``.
+   * - ``AGILAB_CYTHON_DIRECTIVES``
+     - safe defaults
+     - Comma-separated Cython compiler directive overrides, for example
+       ``boundscheck=true`` or ``cdivision=true,infer_types=true``. Set to
+       ``off`` to restore legacy directives. ``cdivision`` and ``infer_types``
+       are opt-in because they can change results on arbitrary user workers.
+   * - ``AGILAB_CYTHON_ANNOTATE``
+     - ``0``
+     - Enables Cython ``annotate=True`` HTML diagnostics during worker extension
+       builds. This is for build investigation only and participates in worker
+       build-cache fingerprints.
+   * - ``AGILAB_DISABLE_WORKER_BUILD_CACHE``
+     - ``0``
+     - Disables AGILAB's worker build-output cache and Cython build stamps when
+       set to a truthy value. Use this when debugging cache invalidation or
+       forcing a clean worker rebuild.
    * - ``AGI_EXPORT_DIR``
      - ``~/export``
      - Target directory for exported artefacts.

--- a/docs/source/execution-playground.rst
+++ b/docs/source/execution-playground.rst
@@ -153,6 +153,11 @@ Python and Cython:
 
    uv --preview-features extra-build-dependencies run python tools/benchmark_execution_pandas_cython_kernel.py --rows 100000 --compute-passes 32 --repeats 3 --warmups 1
 
+To measure the optional type-preprocessor itself, add
+``--compare-preprocess``. That mode compiles the same worker as raw Cython and
+as ``remove_decorators + preprocess_source`` output, validates both against the
+Python implementation, and records typed/skipped counts in the JSON/CSV report.
+
 Latest local evidence on macOS / Python ``3.13.13``:
 
 .. csv-table:: Typed numeric kernel speedup for ``execution_pandas_project``

--- a/src/agilab/apps/builtin/flight_telemetry_project/src/flight_telemetry_worker/flight_telemetry_worker.py
+++ b/src/agilab/apps/builtin/flight_telemetry_project/src/flight_telemetry_worker/flight_telemetry_worker.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 # https://github.com/cython/cython/wiki/enhancements-compilerdirectives
-# cython:infer_types True
-# cython:boundscheck False
-# cython:cdivision True
+# cython: infer_types=True
+# cython: boundscheck=False
+# cython: cdivision=True
 
 import glob
 import logging

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_build_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_build_support.py
@@ -22,12 +22,19 @@ from agi_cluster.agi_distributor.deployment.deployment_venv_support import (
     project_site_packages_dir as _project_site_packages_dir,
 )
 from agi_env import AgiEnv
+from agi_env.cython_build_config import (
+    CYTHON_ANNOTATE_ENV,
+    CYTHON_DIRECTIVES_ENV,
+    CYTHON_DISABLE_BUILD_CACHE_ENV,
+    CYTHON_TYPE_PREPROCESS_ENV,
+    cython_build_overlay_specs,
+)
 from agi_env.share_runtime_support import python_supports_free_threading
 
 
 logger = logging.getLogger(__name__)
-BUILD_CACHE_SCHEMA = "agilab-worker-build-cache-v1"
-DISABLE_BUILD_CACHE_ENV = "AGILAB_DISABLE_WORKER_BUILD_CACHE"
+BUILD_CACHE_SCHEMA = "agilab-worker-build-cache-v2"
+DISABLE_BUILD_CACHE_ENV = CYTHON_DISABLE_BUILD_CACHE_ENV
 BUILD_CACHE_HASH_LIMIT = 8 * 1024 * 1024
 GIT_FINGERPRINT_TIMEOUT_SECONDS = 2.0
 
@@ -111,7 +118,6 @@ def _file_fingerprint(path: Path) -> dict[str, Any] | None:
     payload: dict[str, Any] = {
         "path": str(path.resolve(strict=False)),
         "size": stat_result.st_size,
-        "mtime_ns": stat_result.st_mtime_ns,
     }
     if stat_result.st_size <= BUILD_CACHE_HASH_LIMIT:
         digest = hashlib.sha256()
@@ -122,6 +128,8 @@ def _file_fingerprint(path: Path) -> dict[str, Any] | None:
             payload["sha256"] = digest.hexdigest()
         except OSError:
             pass
+    if "sha256" not in payload:
+        payload["mtime_ns"] = stat_result.st_mtime_ns
     return payload
 
 
@@ -260,8 +268,13 @@ def _worker_build_cache_payload(
 ) -> dict[str, Any]:
     app_path = Path(env.active_app)
     worker_pyproject_src = _worker_pyproject_source(env)
+    envars = getattr(env, "envars", {})
     return {
         "schema": BUILD_CACHE_SCHEMA,
+        "cython_build_requirements": list(cython_build_overlay_specs()),
+        "cython_type_preprocess": _env_truthy(envars, CYTHON_TYPE_PREPROCESS_ENV),
+        "cython_directives": _envar_value(envars, CYTHON_DIRECTIVES_ENV),
+        "cython_annotate": _env_truthy(envars, CYTHON_ANNOTATE_ENV),
         "base_worker_cls": str(getattr(env, "base_worker_cls", "")),
         "worker_group": worker_group,
         "packages": packages,
@@ -367,7 +380,7 @@ def _core_install_commands(*, env: Any, uv: str, app_path_arg: str) -> list[str]
 
 
 def _build_run_overlay_args(env: Any) -> str:
-    args = ["--with setuptools", "--with cython"]
+    args = [f"--with {spec}" for spec in cython_build_overlay_specs()]
     if getattr(env, "is_source_env", False):
         for source_path in (
             getattr(env, "agi_env", None),
@@ -424,9 +437,11 @@ def _bdist_egg_command(
     packages: str,
     wenv_arg: str,
     verbose: int,
-    build_overlay_args: str = "--with setuptools --with cython",
+    build_overlay_args: str | None = None,
 ) -> str:
     quiet_flag = "" if verbose > 1 else "-q "
+    if build_overlay_args is None:
+        build_overlay_args = " ".join(f"--with {spec}" for spec in cython_build_overlay_specs())
     return (
         f"{uv} --project {app_path_arg} run --no-sync {build_overlay_args} "
         f"{module_cmd} --app-path {app_path_arg} {quiet_flag}"
@@ -441,9 +456,11 @@ def _build_ext_command(
     app_path_arg: str,
     wenv_arg: str,
     verbose: int,
-    build_overlay_args: str = "--with setuptools --with cython",
+    build_overlay_args: str | None = None,
 ) -> str:
     quiet_flag = "" if verbose > 1 else "-q "
+    if build_overlay_args is None:
+        build_overlay_args = " ".join(f"--with {spec}" for spec in cython_build_overlay_specs())
     return (
         f"{uv} --project {app_path_arg} run --no-sync {build_overlay_args} "
         f"{module_cmd} --app-path {app_path_arg} {quiet_flag}build_ext -b {wenv_arg}"

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_remote_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_remote_support.py
@@ -17,6 +17,7 @@ from agi_cluster.agi_distributor.deployment.deployment_build_support import (
     _latest_glob_match as _latest_artifact_match,
 )
 from agi_env import AgiEnv
+from agi_env.cython_build_config import cython_build_overlay_specs
 
 
 logger = logging.getLogger(__name__)
@@ -816,10 +817,11 @@ async def deploy_remote_worker(
         wenv_rel,
         "run",
         "--no-sync",
-        "--with",
-        "setuptools",
-        "--with",
-        "cython",
+        *(
+            item
+            for spec in cython_build_overlay_specs()
+            for item in ("--with", spec)
+        ),
         "-p",
         pyvers,
         "python",

--- a/src/agilab/core/agi-env/src/agi_env/cython_build_config.py
+++ b/src/agilab/core/agi-env/src/agi_env/cython_build_config.py
@@ -1,0 +1,63 @@
+"""Shared Cython build-tool configuration for AGILAB worker builds."""
+
+import hashlib
+
+CYTHON_BUILD_REQUIREMENT = "cython==3.2.4"
+CYTHON_CACHE_ENV = "AGILAB_CYTHON_CACHE"
+CYTHON_TYPE_PREPROCESS_ENV = "AGILAB_CYTHON_TYPE_PREPROCESS"
+CYTHON_DIRECTIVES_ENV = "AGILAB_CYTHON_DIRECTIVES"
+CYTHON_ANNOTATE_ENV = "AGILAB_CYTHON_ANNOTATE"
+CYTHON_DISABLE_BUILD_CACHE_ENV = "AGILAB_DISABLE_WORKER_BUILD_CACHE"
+CYTHON_PYX_STAMP_PREFIX = "# agilab-pyx:"
+CYTHON_PREVIEW_REPORT_SUFFIX = ".cython-preview.json"
+CYTHON_BUILD_STAMP_FILENAME = ".agilab-cython-build-stamp.json"
+
+
+def cython_build_overlay_specs() -> tuple[str, str]:
+    """Return uv ``--with`` specs needed by worker build subprocesses."""
+
+    return ("setuptools", CYTHON_BUILD_REQUIREMENT)
+
+
+def cython_source_sha256(source: str) -> str:
+    return hashlib.sha256(source.encode("utf-8")).hexdigest()
+
+
+def cython_pyx_stamp_line(source: str, *, type_preprocess: bool) -> str:
+    return (
+        f"{CYTHON_PYX_STAMP_PREFIX} "
+        f"src-sha256={cython_source_sha256(source)} "
+        f"type-preprocess={int(bool(type_preprocess))}"
+    )
+
+
+def add_cython_pyx_stamp(source: str, *, stamp_line: str) -> str:
+    """Insert a generated-source stamp outside the PEP 263 line-1/2 window."""
+
+    lines = source.splitlines(keepends=True)
+    insert_at = min(2, len(lines))
+    newline = "" if stamp_line.endswith("\n") else "\n"
+    return "".join([*lines[:insert_at], stamp_line, newline, *lines[insert_at:]])
+
+
+def cython_pyx_stamp_matches(pyx_source: str, source: str, *, type_preprocess: bool) -> bool:
+    expected = cython_pyx_stamp_line(source, type_preprocess=type_preprocess)
+    return any(line.rstrip("\r\n") == expected for line in pyx_source.splitlines()[:8])
+
+
+__all__ = [
+    "CYTHON_PYX_STAMP_PREFIX",
+    "CYTHON_BUILD_REQUIREMENT",
+    "CYTHON_CACHE_ENV",
+    "CYTHON_DIRECTIVES_ENV",
+    "CYTHON_ANNOTATE_ENV",
+    "CYTHON_DISABLE_BUILD_CACHE_ENV",
+    "CYTHON_PREVIEW_REPORT_SUFFIX",
+    "CYTHON_BUILD_STAMP_FILENAME",
+    "CYTHON_TYPE_PREPROCESS_ENV",
+    "add_cython_pyx_stamp",
+    "cython_build_overlay_specs",
+    "cython_pyx_stamp_line",
+    "cython_pyx_stamp_matches",
+    "cython_source_sha256",
+]

--- a/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/build.py
+++ b/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/build.py
@@ -8,6 +8,8 @@ import sys
 import os
 import shutil
 import re
+import json
+import hashlib
 import shlex
 import stat
 from pathlib import Path
@@ -17,6 +19,7 @@ import logging
 import subprocess
 import warnings
 from collections.abc import Mapping
+from time import perf_counter
 
 try:
     from .bootstrap_source_paths import append_shared_site_packages, bootstrap_core_source_paths
@@ -26,6 +29,7 @@ except ImportError:  # pragma: no cover - script execution fallback
 bootstrap_core_source_paths(source_file=__file__)
 
 from setuptools import setup, find_packages, Extension, SetuptoolsDeprecationWarning  # noqa: E402
+import Cython  # noqa: E402
 from Cython.Build import cythonize  # noqa: E402
 
 
@@ -36,6 +40,16 @@ def _inject_shared_site_packages(*, source_file: str | Path = __file__) -> None:
 _inject_shared_site_packages()
 
 from agi_env import AgiEnv  # noqa: E402
+from agi_env.cython_build_config import (  # noqa: E402
+    CYTHON_ANNOTATE_ENV,
+    CYTHON_BUILD_REQUIREMENT,
+    CYTHON_BUILD_STAMP_FILENAME,
+    CYTHON_CACHE_ENV,
+    CYTHON_DIRECTIVES_ENV,
+    CYTHON_DISABLE_BUILD_CACHE_ENV,
+    CYTHON_TYPE_PREPROCESS_ENV,
+    cython_pyx_stamp_matches,
+)
 
 warnings.filterwarnings("ignore", category=SetuptoolsDeprecationWarning)
 
@@ -268,6 +282,7 @@ def _build_ext_compile_config(
     *,
     sys_platform: str,
     pyvers_worker: str,
+    environ: Mapping[str, str] | None = None,
 ) -> tuple[list[str], list[tuple[str, str]], dict[str, bool]]:
     extra_compile_args: list[str] = []
     if sys_platform == "darwin":
@@ -279,11 +294,10 @@ def _build_ext_compile_config(
     if sys_platform.startswith("win") and pyvers_worker.endswith("t"):
         define_macros.append(("Py_GIL_DISABLED", "1"))
 
-    compiler_directives: dict[str, bool] = {}
-    if pyvers_worker.endswith("t"):
-        # free-threaded CPython compatibility
-        compiler_directives = {"freethreading_compatible": True}
-
+    compiler_directives = _resolve_cython_compiler_directives(
+        pyvers_worker=pyvers_worker,
+        environ=environ,
+    )
     return extra_compile_args, define_macros, compiler_directives
 
 
@@ -310,9 +324,115 @@ def _build_worker_extension(
 
 _CYTHON_CACHE_DISABLED_VALUES = {"0", "false", "no", "off", "disable", "disabled"}
 _CYTHON_CACHE_ENABLED_VALUES = {"1", "true", "yes", "on", "enable", "enabled"}
-_CYTHON_TYPE_PREPROCESS_ENV = "AGILAB_CYTHON_TYPE_PREPROCESS"
+_CYTHON_SAFE_COMPILER_DIRECTIVES: dict[str, bool] = {
+    "boundscheck": False,
+    "wraparound": False,
+    "initializedcheck": False,
+    "nonecheck": False,
+    "embedsignature": True,
+    "profile": False,
+    "linetrace": False,
+}
+# Worker code is arbitrary user-authored Python: cdivision and infer_types are
+# intentionally opt-in because they can change results on unaudited workers.
+_CYTHON_DIRECTIVE_ALLOWLIST = frozenset(
+    {
+        "boundscheck",
+        "wraparound",
+        "cdivision",
+        "initializedcheck",
+        "infer_types",
+        "overflowcheck",
+        "nonecheck",
+        "embedsignature",
+        "profile",
+        "linetrace",
+    }
+)
+# Named bundle removing index checks only; deliberately excludes cdivision,
+# which changes arithmetic results instead of just removing checks.
+_CYTHON_UNCHECKED_BUNDLE: dict[str, bool] = {
+    "boundscheck": False,
+    "wraparound": False,
+    "initializedcheck": False,
+    "nonecheck": False,
+}
 _TOP_LEVEL_UI_MODULE_PATTERNS = ("app_args_form.py", "*_args_form.py")
 _TOP_LEVEL_UI_BYTECODE_PATTERNS = ("app_args_form.*.pyc", "*_args_form.*.pyc")
+
+
+def _env_flag(value: str | None, *, default: bool = False) -> bool:
+    if value is None:
+        return default
+    normalized = value.strip().lower()
+    if not normalized:
+        return default
+    if normalized in _CYTHON_CACHE_ENABLED_VALUES:
+        return True
+    if normalized in _CYTHON_CACHE_DISABLED_VALUES:
+        return False
+    return default
+
+
+def _parse_cython_directive_overrides(raw_value: str) -> dict[str, bool]:
+    directives: dict[str, bool] = {}
+    for item in raw_value.split(","):
+        part = item.strip()
+        if not part:
+            continue
+        if part == "unchecked":
+            directives.update(_CYTHON_UNCHECKED_BUNDLE)
+            continue
+        if "=" not in part:
+            key, value = part, "true"
+        else:
+            key, value = part.split("=", 1)
+        key = key.strip()
+        value = value.strip().lower()
+        if not key:
+            continue
+        if key not in _CYTHON_DIRECTIVE_ALLOWLIST:
+            # A typo silently dropping a safety directive is worse than failing.
+            raise ValueError(
+                f"Unknown Cython compiler directive {key!r}; allowed: "
+                f"unchecked, {', '.join(sorted(_CYTHON_DIRECTIVE_ALLOWLIST))}"
+            )
+        if value in _CYTHON_CACHE_ENABLED_VALUES:
+            directives[key] = True
+        elif value in _CYTHON_CACHE_DISABLED_VALUES:
+            directives[key] = False
+        else:
+            raise ValueError(
+                f"Unsupported Cython directive boolean value for {key!r}: {value!r}"
+            )
+    return directives
+
+
+def _resolve_cython_compiler_directives(
+    *,
+    pyvers_worker: str,
+    environ: Mapping[str, str] | None = None,
+) -> dict[str, bool]:
+    if environ is None:
+        environ = os.environ
+
+    raw_value = environ.get(CYTHON_DIRECTIVES_ENV, "").strip()
+    legacy_only = raw_value.lower() in _CYTHON_CACHE_DISABLED_VALUES
+    compiler_directives: dict[str, bool] = {} if legacy_only else dict(_CYTHON_SAFE_COMPILER_DIRECTIVES)
+    if raw_value and not legacy_only:
+        compiler_directives.update(_parse_cython_directive_overrides(raw_value))
+    if pyvers_worker.endswith("t"):
+        compiler_directives["freethreading_compatible"] = True
+    return compiler_directives
+
+
+def _resolve_cython_annotate_option(
+    *,
+    environ: Mapping[str, str] | None = None,
+) -> bool:
+    if environ is None:
+        environ = os.environ
+    return _env_flag(environ.get(CYTHON_ANNOTATE_ENV), default=False)
 
 
 def _resolve_cython_cache_option(
@@ -324,7 +444,7 @@ def _resolve_cython_cache_option(
     if environ is None:
         environ = os.environ
 
-    raw_value = environ.get("AGILAB_CYTHON_CACHE", "").strip()
+    raw_value = environ.get(CYTHON_CACHE_ENV, "").strip()
     default_cache_dir = path_cls.home() / ".cache" / "agilab" / "cython"
     if not raw_value or raw_value.lower() in _CYTHON_CACHE_ENABLED_VALUES:
         return str(default_cache_dir)
@@ -341,12 +461,8 @@ def _resolve_cython_type_preprocess_option(
     if environ is None:
         environ = os.environ
 
-    raw_value = environ.get(_CYTHON_TYPE_PREPROCESS_ENV, "").strip().lower()
-    if raw_value in _CYTHON_CACHE_ENABLED_VALUES:
-        return True
-    if raw_value in _CYTHON_CACHE_DISABLED_VALUES:
-        return False
-    return False
+    raw_value = environ.get(CYTHON_TYPE_PREPROCESS_ENV, "").strip().lower()
+    return _env_flag(raw_value, default=False)
 
 
 def _cythonize_worker_extension(
@@ -354,20 +470,36 @@ def _cythonize_worker_extension(
     extension: Extension,
     compiler_directives: dict[str, bool],
     quiet: bool,
+    annotate: bool | None = None,
     cythonize_fn=None,
     resolve_cython_cache_option_fn=None,
+    log: logging.Logger | None = None,
 ) -> list[Extension]:
     if cythonize_fn is None:
         cythonize_fn = cythonize
     if resolve_cython_cache_option_fn is None:
         resolve_cython_cache_option_fn = _resolve_cython_cache_option
-    return cythonize_fn(
-        [extension],
-        language_level=3,
-        quiet=quiet,
-        compiler_directives=compiler_directives,
-        cache=resolve_cython_cache_option_fn(),
+    if annotate is None:
+        annotate = _resolve_cython_annotate_option()
+    cache_option = resolve_cython_cache_option_fn()
+    log = _runtime_logger(log)
+    log.info(
+        f"Cythonize options: cache={cache_option} "
+        f"annotate={annotate} directives={compiler_directives}"
     )
+    start = perf_counter()
+    try:
+        # nthreads is intentionally omitted: each worker build has one extension.
+        return cythonize_fn(
+            [extension],
+            language_level=3,
+            quiet=quiet,
+            compiler_directives=compiler_directives,
+            cache=cache_option,
+            annotate=annotate,
+        )
+    finally:
+        log.info(f"Cythonize stage completed in {perf_counter() - start:.3f}s")
 
 
 def _unpack_worker_eggs(
@@ -481,12 +613,28 @@ def _postprocess_bdist_egg_output(
     dest_src = out_dir / "src"
     _unpack_worker_eggs(dist_dir=out_dir / "dist", dest_src=dest_src, zip_cls=zip_cls, log=log)
 
+    type_preprocess = _resolve_cython_type_preprocess_option()
+    if _worker_cython_source_is_fresh(
+        _resolve_worker_python_path(env),
+        _resolve_worker_python_path(env).with_suffix(".pyx"),
+        type_preprocess=type_preprocess,
+    ):
+        log.info("Worker .pyx stamp is fresh; skipping pre_install regeneration.")
+        if links_created:
+            cleanup_links_fn(links_created)
+            log.info("Cleanup of created symlinks/files done.")
+        return
+
     cmd = _build_remove_decorators_command(
         env.worker_path,
-        type_preprocess=_resolve_cython_type_preprocess_option(),
+        type_preprocess=type_preprocess,
     )
     log.info(f"Generating worker .pyx via pre_install:\n  {shlex.join(cmd)}")
-    subprocess_run_fn(cmd, check=True)
+    start = perf_counter()
+    try:
+        subprocess_run_fn(cmd, check=True)
+    finally:
+        log.info(f"pre_install subprocess completed in {perf_counter() - start:.3f}s")
 
     if links_created:
         cleanup_links_fn(links_created)
@@ -524,6 +672,26 @@ def _build_pre_install_command(
     return cmd
 
 
+def _worker_cython_source_is_fresh(
+    worker_py: Path,
+    worker_pyx: Path,
+    *,
+    type_preprocess: bool,
+) -> bool:
+    if not worker_pyx.exists():
+        return False
+    try:
+        source = worker_py.read_text(encoding="utf-8")
+        pyx_source = worker_pyx.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    return cython_pyx_stamp_matches(
+        pyx_source,
+        source,
+        type_preprocess=type_preprocess,
+    )
+
+
 def _ensure_worker_cython_source(
     env,
     *,
@@ -543,17 +711,30 @@ def _ensure_worker_cython_source(
     worker_py = _resolve_worker_python_path(env)
     worker_pyx = worker_py.with_suffix(".pyx")
     pre_install_script = resolve_pre_install_script_fn(env)
-    if worker_pyx.exists() or not pre_install_script:
+    type_preprocess = resolve_cython_type_preprocess_option_fn()
+    is_fresh = _worker_cython_source_is_fresh(
+        worker_py,
+        worker_pyx,
+        type_preprocess=type_preprocess,
+    )
+    if is_fresh:
+        log.info("Worker .pyx stamp is fresh; pre_install stage skipped.")
+        return
+    if not pre_install_script:
         return
 
     pre_cmd = _build_pre_install_command(
         pre_install_script=pre_install_script,
         worker_py=worker_py,
         verbose=env.verbose,
-        type_preprocess=resolve_cython_type_preprocess_option_fn(),
+        type_preprocess=type_preprocess,
     )
-    log.info("Ensuring Cython source via pre_install: %s", " ".join(pre_cmd))
-    subprocess_run(pre_cmd, check=True)
+    log.info(f"Ensuring Cython source via pre_install: {' '.join(pre_cmd)}")
+    start = perf_counter()
+    try:
+        subprocess_run(pre_cmd, check=True)
+    finally:
+        log.info(f"pre_install subprocess completed in {perf_counter() - start:.3f}s")
 
 
 def _resolve_build_output(
@@ -592,8 +773,158 @@ def _build_setuptools_argv(
     out_arg: str,
 ) -> list[str]:
     flag = "-b" if command == "build_ext" else "-d"
-    output_dir = Path(home_abs) / out_arg / "dist"
+    output_dir = _build_dist_output_dir(home_abs=home_abs, out_arg=out_arg)
     return [prog_name, command, flag, str(output_dir)]
+
+
+def _build_dist_output_dir(*, home_abs: str | Path, out_arg: str) -> Path:
+    return Path(home_abs) / out_arg / "dist"
+
+
+def _cython_build_stamp_path(*, home_abs: str | Path, out_arg: str) -> Path:
+    return _build_dist_output_dir(home_abs=home_abs, out_arg=out_arg) / CYTHON_BUILD_STAMP_FILENAME
+
+
+def _file_sha256(path: Path) -> str | None:
+    try:
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+    except OSError:
+        return None
+
+
+def _compiled_worker_outputs_exist(*, home_abs: str | Path, out_arg: str, worker_module: str) -> bool:
+    output_dir = _build_dist_output_dir(home_abs=home_abs, out_arg=out_arg)
+    return any(output_dir.glob(f"{worker_module}_cy.*"))
+
+
+def _cython_build_cache_disabled(*, environ: Mapping[str, str] | None = None) -> bool:
+    if environ is None:
+        environ = os.environ
+    return _env_flag(environ.get(CYTHON_DISABLE_BUILD_CACHE_ENV), default=False)
+
+
+def _cython_build_stamp_payload(
+    *,
+    env,
+    out_arg: str,
+    worker_module: str,
+    environ: Mapping[str, str] | None = None,
+) -> dict[str, object] | None:
+    if environ is None:
+        environ = os.environ
+    try:
+        worker_py = _resolve_worker_python_path(env)
+    # Defensive: fingerprinting is best-effort — a resolution failure means
+    # "no stamp", never a failed build.
+    except Exception:
+        return None
+    worker_pyx = worker_py.with_suffix(".pyx")
+    worker_py_hash = _file_sha256(worker_py)
+    worker_pyx_hash = _file_sha256(worker_pyx)
+    if worker_py_hash is None or worker_pyx_hash is None:
+        return None
+
+    extra_compile_args, define_macros, compiler_directives = _build_ext_compile_config(
+        sys_platform=sys.platform,
+        pyvers_worker=str(getattr(env, "pyvers_worker", "")),
+        environ=environ,
+    )
+    # Normalized through JSON so the equality check against the stamp read
+    # back from disk compares like with like (tuples become lists).
+    return json.loads(json.dumps({
+        "schema": "agilab-cython-build-stamp-v1",
+        "annotate": _resolve_cython_annotate_option(environ=environ),
+        "compile_config": {
+            "define_macros": [[name, value] for name, value in define_macros],
+            "extra_compile_args": extra_compile_args,
+        },
+        "compiler_directives": compiler_directives,
+        "cython_build_requirement": CYTHON_BUILD_REQUIREMENT,
+        "cython_version": getattr(Cython, "__version__", ""),
+        "pyvers_worker": str(getattr(env, "pyvers_worker", "")),
+        "python_tag": sys.implementation.cache_tag,
+        "sys_platform": sys.platform,
+        "type_preprocess": _resolve_cython_type_preprocess_option(environ=environ),
+        "worker_module": worker_module,
+        "worker_py": {
+            "path": str(worker_py.resolve(strict=False)),
+            "sha256": worker_py_hash,
+        },
+        "worker_pyx": {
+            "path": str(worker_pyx.resolve(strict=False)),
+            "sha256": worker_pyx_hash,
+        },
+    }))
+
+
+def _cython_build_stamp_hit(
+    *,
+    env,
+    out_arg: str,
+    worker_module: str,
+    log: logging.Logger | None = None,
+) -> bool:
+    log = _runtime_logger(log)
+    if _cython_build_cache_disabled():
+        log.info(f"Cython build stamp disabled by {CYTHON_DISABLE_BUILD_CACHE_ENV}.")
+        return False
+    home_abs = getattr(env, "home_abs", None)
+    if home_abs is None:
+        log.info("Cython build stamp miss: build environment has no home_abs.")
+        return False
+    if not _compiled_worker_outputs_exist(
+        home_abs=home_abs,
+        out_arg=out_arg,
+        worker_module=worker_module,
+    ):
+        log.info("Cython build stamp miss: compiled worker output is absent.")
+        return False
+    payload = _cython_build_stamp_payload(env=env, out_arg=out_arg, worker_module=worker_module)
+    if payload is None:
+        log.info("Cython build stamp miss: unable to fingerprint current inputs.")
+        return False
+    stamp_path = _cython_build_stamp_path(home_abs=home_abs, out_arg=out_arg)
+    try:
+        cached = json.loads(stamp_path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        log.info(f"Cython build stamp miss: {stamp_path} is absent or invalid.")
+        return False
+    if cached == payload:
+        log.info(f"Cython build stamp hit: skipping setup for {worker_module}.")
+        return True
+    log.info(f"Cython build stamp miss: inputs changed for {worker_module}.")
+    return False
+
+
+def _record_cython_build_stamp(
+    *,
+    env,
+    out_arg: str,
+    worker_module: str,
+    log: logging.Logger | None = None,
+) -> None:
+    log = _runtime_logger(log)
+    if _cython_build_cache_disabled():
+        return
+    home_abs = getattr(env, "home_abs", None)
+    if home_abs is None:
+        log.info("Cython build stamp not written: build environment has no home_abs.")
+        return
+    if not _compiled_worker_outputs_exist(
+        home_abs=home_abs,
+        out_arg=out_arg,
+        worker_module=worker_module,
+    ):
+        log.info("Cython build stamp not written: compiled worker output is absent.")
+        return
+    payload = _cython_build_stamp_payload(env=env, out_arg=out_arg, worker_module=worker_module)
+    if payload is None:
+        log.info("Cython build stamp not written: unable to fingerprint current inputs.")
+        return
+    stamp_path = _cython_build_stamp_path(home_abs=home_abs, out_arg=out_arg)
+    stamp_path.parent.mkdir(parents=True, exist_ok=True)
+    stamp_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    log.info(f"Wrote Cython build stamp: {stamp_path}")
 
 
 def _ensure_build_readme(readme_path: Path | str = "README.md") -> Path:
@@ -678,6 +1009,8 @@ def _configure_build_ext_modules(
         extension=mod,
         compiler_directives=compil_directives,
         quiet=bool(remaining_args and ("-q" in remaining_args or "--quiet" in remaining_args)),
+        annotate=_resolve_cython_annotate_option(),
+        log=log,
     )
     log.info(f"Cython extension configured: {worker_module}_cy")
     return ext_modules
@@ -942,9 +1275,13 @@ def _prepare_main_execution(
         raw_outdir,
         home_abs=env.home_abs,
     )
+    worker_module = target_module + "_worker"
 
     if cmd == "build_ext":
         prepare_build_ext_command_fn(env=env, build_dir=build_dir)
+        if _cython_build_stamp_hit(env=env, out_arg=out_arg, worker_module=worker_module):
+            setattr(env, "_agilab_skip_setup", True)
+            return env, out_arg, worker_module, [], []
 
     setup_argv = build_setuptools_argv_fn(
         prog_name=prog_name,
@@ -954,7 +1291,6 @@ def _prepare_main_execution(
     )
     set_argv_fn([str(value) for value in setup_argv])
 
-    worker_module = target_module + "_worker"
     ext_modules, links_created = prepare_setup_artifacts_fn(
         env=env,
         cmd=cmd,
@@ -980,6 +1316,7 @@ def _execute_main_setup(
     build_setup_kwargs_fn=None,
     setup_fn=None,
     finalize_setup_artifacts_fn=None,
+    record_cython_build_stamp_fn=None,
 ) -> None:
     if ensure_build_readme_fn is None:
         ensure_build_readme_fn = _ensure_build_readme
@@ -989,15 +1326,32 @@ def _execute_main_setup(
         setup_fn = setup
     if finalize_setup_artifacts_fn is None:
         finalize_setup_artifacts_fn = _finalize_setup_artifacts
+    if record_cython_build_stamp_fn is None:
+        record_cython_build_stamp_fn = _record_cython_build_stamp
+
+    log = _runtime_logger()
+    if getattr(env, "_agilab_skip_setup", False):
+        log.info("Setup stage skipped by fresh Cython build stamp.")
+        return
 
     ensure_build_readme_fn()
-    setup_fn(**build_setup_kwargs_fn(worker_module=worker_module, ext_modules=ext_modules))
-    finalize_setup_artifacts_fn(
-        env=env,
-        cmd=cmd,
-        out_arg=out_arg,
-        links_created=links_created,
-    )
+    start = perf_counter()
+    try:
+        setup_fn(**build_setup_kwargs_fn(worker_module=worker_module, ext_modules=ext_modules))
+    finally:
+        log.info(f"Setup/C compile stage completed in {perf_counter() - start:.3f}s")
+    start = perf_counter()
+    try:
+        finalize_setup_artifacts_fn(
+            env=env,
+            cmd=cmd,
+            out_arg=out_arg,
+            links_created=links_created,
+        )
+    finally:
+        log.info(f"Setup finalize stage completed in {perf_counter() - start:.3f}s")
+    if cmd == "build_ext":
+        record_cython_build_stamp_fn(env=env, out_arg=out_arg, worker_module=worker_module)
 
 
 def main(argv: list[str] | None = None) -> None:

--- a/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/cython_type_preprocess.py
+++ b/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/cython_type_preprocess.py
@@ -1,9 +1,21 @@
-"""Conservative Cython local-variable preprocessing for worker sources."""
+"""Conservative Cython local-variable preprocessing for worker sources.
+
+Scope and non-goals:
+- This pass only emits local Cython declarations when a value is proven stable
+  from simple AST evidence inside one function body.
+- It never rewrites function signatures, parameters, return types, decorators,
+  or Python control flow. AGILAB dispatch inspects worker signatures at runtime.
+- Unknown binding syntax is default-deny: if a statement binds a name without a
+  positive handler, that name is skipped instead of guessed.
+- Bare integer assignments remain Python objects. C integer arithmetic is only
+  inferred inside guarded expressions where semantics stay narrow.
+"""
 
 from __future__ import annotations
 
 import argparse
 import ast
+import builtins
 import json
 from dataclasses import asdict, dataclass
 from pathlib import Path
@@ -11,6 +23,8 @@ from typing import Iterable, Sequence
 
 
 CYTHON_NUMERIC_TYPES = {"bint", "double", "Py_ssize_t"}
+_CALL_BUILTINS = {"bool", "enumerate", "float", "isinstance", "len", "range"}
+_SMALL_INT_LITERAL_ABS_LIMIT = 1_000_000
 
 
 @dataclass(frozen=True)
@@ -89,7 +103,40 @@ def _call_name(node: ast.AST) -> str | None:
     return None
 
 
-def _expr_type(node: ast.AST) -> tuple[str | None, str]:
+def _is_small_int_literal(node: ast.AST) -> bool:
+    if isinstance(node, ast.Constant):
+        return (
+            isinstance(node.value, int)
+            and not isinstance(node.value, bool)
+            and abs(node.value) <= _SMALL_INT_LITERAL_ABS_LIMIT
+        )
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, (ast.UAdd, ast.USub)):
+        return _is_small_int_literal(node.operand)
+    return False
+
+
+def _numeric_operand_type(
+    node: ast.AST,
+    *,
+    shadowed_builtins: set[str],
+    allow_int_literal: bool,
+) -> tuple[str | None, str]:
+    cython_type, reason = _expr_type(node, shadowed_builtins=shadowed_builtins)
+    if cython_type is not None:
+        return cython_type, reason
+    if allow_int_literal and _is_small_int_literal(node):
+        return "Py_ssize_t", "small int literal operand"
+    return None, reason
+
+
+def _expr_type(
+    node: ast.AST,
+    *,
+    shadowed_builtins: set[str] | None = None,
+) -> tuple[str | None, str]:
+    if shadowed_builtins is None:
+        shadowed_builtins = set()
+
     if isinstance(node, ast.Constant):
         if isinstance(node.value, bool):
             return "bint", "bool literal"
@@ -98,14 +145,41 @@ def _expr_type(node: ast.AST) -> tuple[str | None, str]:
         return None, "literal keeps Python object semantics"
 
     if isinstance(node, ast.UnaryOp) and isinstance(node.op, (ast.UAdd, ast.USub)):
-        return _expr_type(node.operand)
+        return _expr_type(node.operand, shadowed_builtins=shadowed_builtins)
+
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.Not):
+        return "bint", "not expression"
 
     if isinstance(node, ast.Compare):
-        return "bint", "comparison result"
+        boolean_ops = (ast.Is, ast.IsNot, ast.In, ast.NotIn)
+        numeric_ops = (ast.Eq, ast.NotEq, ast.Lt, ast.LtE, ast.Gt, ast.GtE)
+        if all(isinstance(op, boolean_ops) for op in node.ops):
+            return "bint", "identity or membership comparison"
+        if all(isinstance(op, numeric_ops) for op in node.ops):
+            operands = (node.left, *node.comparators)
+            operand_types = [
+                _numeric_operand_type(
+                    operand,
+                    shadowed_builtins=shadowed_builtins,
+                    allow_int_literal=True,
+                )[0]
+                for operand in operands
+            ]
+            if all(operand_type in CYTHON_NUMERIC_TYPES for operand_type in operand_types):
+                return "bint", "numeric comparison result"
+        return None, "comparison operands are not statically numeric"
 
     if isinstance(node, ast.BinOp):
-        left_type, _ = _expr_type(node.left)
-        right_type, _ = _expr_type(node.right)
+        left_type, _ = _numeric_operand_type(
+            node.left,
+            shadowed_builtins=shadowed_builtins,
+            allow_int_literal=True,
+        )
+        right_type, _ = _numeric_operand_type(
+            node.right,
+            shadowed_builtins=shadowed_builtins,
+            allow_int_literal=True,
+        )
         if left_type in CYTHON_NUMERIC_TYPES and right_type in CYTHON_NUMERIC_TYPES:
             if isinstance(node.op, ast.Div):
                 # Python 3 true division yields float even for integer operands.
@@ -113,6 +187,15 @@ def _expr_type(node: ast.AST) -> tuple[str | None, str]:
             if isinstance(node.op, ast.Pow):
                 # Power results (e.g. negative exponents) are not statically safe.
                 return None, "power expression type is not statically safe"
+            if isinstance(node.op, ast.Mult) and not (
+                _is_small_int_literal(node.left) or _is_small_int_literal(node.right)
+            ):
+                return None, "multiplication requires a small literal operand"
+            if not isinstance(
+                node.op,
+                (ast.Add, ast.Sub, ast.Mult, ast.FloorDiv, ast.Mod, ast.Div),
+            ):
+                return None, "operator is not statically safe"
             if "double" in {left_type, right_type}:
                 return "double", "numeric expression"
             return "Py_ssize_t", "integer-sized numeric expression"
@@ -120,30 +203,104 @@ def _expr_type(node: ast.AST) -> tuple[str | None, str]:
 
     if isinstance(node, ast.Call):
         name = _call_name(node.func)
-        if name == "len":
+        if name == "len" and name not in shadowed_builtins:
             return "Py_ssize_t", "len() result"
-        if name == "float":
+        if name == "float" and name not in shadowed_builtins:
             return "double", "float() result"
-        if name == "bool":
+        if name == "bool" and name not in shadowed_builtins:
             return "bint", "bool() result"
+        if name == "isinstance" and name not in shadowed_builtins:
+            return "bint", "isinstance() result"
         return None, "call result is dynamic"
 
     return None, "expression type is dynamic"
 
 
-def _target_names(target: ast.AST) -> tuple[str, ...]:
-    if isinstance(target, ast.Name):
+def _pattern_bound_names(pattern: ast.AST) -> tuple[str, ...]:
+    names: list[str] = []
+    if isinstance(pattern, ast.MatchAs):
+        if pattern.name:
+            names.append(pattern.name)
+        if pattern.pattern is not None:
+            names.extend(_pattern_bound_names(pattern.pattern))
+    elif isinstance(pattern, ast.MatchStar):
+        if pattern.name:
+            names.append(pattern.name)
+    elif isinstance(pattern, ast.MatchMapping):
+        if pattern.rest:
+            names.append(pattern.rest)
+        for child in pattern.patterns:
+            names.extend(_pattern_bound_names(child))
+    elif isinstance(pattern, ast.MatchClass):
+        for child in [*pattern.patterns, *pattern.kwd_patterns]:
+            names.extend(_pattern_bound_names(child))
+    elif isinstance(pattern, (ast.MatchSequence, ast.MatchOr)):
+        for child in pattern.patterns:
+            names.extend(_pattern_bound_names(child))
+    return tuple(names)
+
+
+def _bound_names(target: ast.AST) -> tuple[str, ...]:
+    if isinstance(target, ast.Name) and isinstance(target.ctx, (ast.Store, ast.Del)):
         return (target.id,)
+    if isinstance(target, ast.Starred):
+        return _bound_names(target.value)
     if isinstance(target, (ast.Tuple, ast.List)):
         names: list[str] = []
         for item in target.elts:
-            names.extend(_target_names(item))
+            names.extend(_bound_names(item))
         return tuple(names)
+    if isinstance(target, ast.ExceptHandler):
+        return (target.name,) if target.name else ()
+    if isinstance(target, ast.alias):
+        return (target.asname or target.name.split(".", 1)[0],)
+    if isinstance(target, (ast.MatchAs, ast.MatchStar, ast.MatchMapping, ast.MatchClass, ast.MatchSequence, ast.MatchOr)):
+        return _pattern_bound_names(target)
+    if isinstance(target, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+        return (target.name,)
     return ()
 
 
-def _is_range_call(node: ast.AST) -> bool:
-    return isinstance(node, ast.Call) and _call_name(node.func) == "range"
+def _is_range_call(node: ast.AST, *, shadowed_builtins: set[str]) -> bool:
+    return (
+        isinstance(node, ast.Call)
+        and _call_name(node.func) == "range"
+        and "range" not in shadowed_builtins
+    )
+
+
+def _is_safe_enumerate_call(node: ast.AST, *, shadowed_builtins: set[str]) -> bool:
+    return (
+        isinstance(node, ast.Call)
+        and _call_name(node.func) == "enumerate"
+        and "enumerate" not in shadowed_builtins
+        and len(node.args) == 1
+        and not node.keywords
+    )
+
+
+def _statement_bound_names(statement: ast.stmt) -> tuple[str, ...]:
+    names: list[str] = []
+    for child in ast.walk(statement):
+        if isinstance(child, ast.Name) and isinstance(child.ctx, (ast.Store, ast.Del)):
+            names.append(child.id)
+        elif isinstance(child, ast.alias):
+            names.extend(_bound_names(child))
+        elif isinstance(child, ast.ExceptHandler):
+            names.extend(_bound_names(child))
+        elif isinstance(child, (ast.MatchAs, ast.MatchStar, ast.MatchMapping, ast.MatchClass, ast.MatchSequence, ast.MatchOr)):
+            names.extend(_bound_names(child))
+        elif isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)) and child is statement:
+            names.extend(_bound_names(child))
+    return tuple(names)
+
+
+def _shadowed_builtins(node: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str]:
+    builtin_names = set(dir(builtins)) | _CALL_BUILTINS
+    bound: set[str] = set()
+    for statement in node.body:
+        bound.update(_statement_bound_names(statement))
+    return bound & builtin_names
 
 
 def _function_args(node: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str]:
@@ -160,6 +317,8 @@ def _insert_after_line(node: ast.FunctionDef | ast.AsyncFunctionDef) -> int:
     if node.body and isinstance(node.body[0], ast.Expr):
         value = node.body[0].value
         if isinstance(value, ast.Constant) and isinstance(value.value, str):
+            if node.body[0].lineno == node.lineno:
+                return -1
             return int(getattr(node.body[0], "end_lineno", node.body[0].lineno))
     if node.body and node.body[0].lineno > node.lineno:
         # Insert just before the first body statement so multi-line signatures
@@ -194,9 +353,10 @@ def _iter_functions(
 
 
 class _FunctionCollector(ast.NodeVisitor):
-    def __init__(self, *, function: str, parameters: set[str]) -> None:
+    def __init__(self, *, function: str, parameters: set[str], shadowed_builtins: set[str]) -> None:
         self.function = function
         self.parameters = parameters
+        self.shadowed_builtins = shadowed_builtins
         self.candidates: dict[str, list[_Candidate]] = {}
         self.blocked: dict[str, list[_Candidate]] = {}
         self.global_or_nonlocal: set[str] = set()
@@ -218,18 +378,21 @@ class _FunctionCollector(ast.NodeVisitor):
         self.global_or_nonlocal.update(node.names)
 
     def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._block(node.name, line=node.lineno, reason="nested function binding is dynamic")
         return
 
     def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._block(node.name, line=node.lineno, reason="nested async function binding is dynamic")
         return
 
     def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self._block(node.name, line=node.lineno, reason="nested class binding is dynamic")
         return
 
     def visit_Assign(self, node: ast.Assign) -> None:
-        cython_type, reason = _expr_type(node.value)
+        cython_type, reason = _expr_type(node.value, shadowed_builtins=self.shadowed_builtins)
         for target in node.targets:
-            names = _target_names(target)
+            names = _bound_names(target)
             if isinstance(target, ast.Name) and cython_type is not None:
                 self._record(target.id, _Candidate(cython_type, node.lineno, reason))
             else:
@@ -238,11 +401,11 @@ class _FunctionCollector(ast.NodeVisitor):
         self.generic_visit(node.value)
 
     def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
-        names = _target_names(node.target)
+        names = _bound_names(node.target)
         annotation_type = _annotation_type(node.annotation)
         value_reason = "annotated assignment without value"
         if node.value is not None:
-            _, value_reason = _expr_type(node.value)
+            _, value_reason = _expr_type(node.value, shadowed_builtins=self.shadowed_builtins)
 
         reason = (
             "source annotation already provides a type hint"
@@ -255,8 +418,8 @@ class _FunctionCollector(ast.NodeVisitor):
             self.generic_visit(node.value)
 
     def visit_AugAssign(self, node: ast.AugAssign) -> None:
-        names = _target_names(node.target)
-        cython_type, reason = _expr_type(node.value)
+        names = _bound_names(node.target)
+        cython_type, reason = _expr_type(node.value, shadowed_builtins=self.shadowed_builtins)
         if isinstance(node.target, ast.Name) and cython_type is not None:
             self._record(node.target.id, _Candidate(cython_type, node.lineno, reason))
         else:
@@ -265,12 +428,27 @@ class _FunctionCollector(ast.NodeVisitor):
         self.generic_visit(node.value)
 
     def visit_For(self, node: ast.For) -> None:
-        names = _target_names(node.target)
-        if isinstance(node.target, ast.Name) and _is_range_call(node.iter):
+        names = _bound_names(node.target)
+        if isinstance(node.target, ast.Name) and _is_range_call(
+            node.iter,
+            shadowed_builtins=self.shadowed_builtins,
+        ):
             self._record(
                 node.target.id,
                 _Candidate("Py_ssize_t", node.lineno, "range() loop index"),
             )
+        elif (
+            isinstance(node.target, (ast.Tuple, ast.List))
+            and len(node.target.elts) == 2
+            and isinstance(node.target.elts[0], ast.Name)
+            and _is_safe_enumerate_call(node.iter, shadowed_builtins=self.shadowed_builtins)
+        ):
+            self._record(
+                node.target.elts[0].id,
+                _Candidate("Py_ssize_t", node.lineno, "enumerate() loop index"),
+            )
+            for name in _bound_names(node.target.elts[1]):
+                self._block(name, line=node.lineno, reason="enumerate() value target is dynamic")
         else:
             for name in names:
                 self._block(name, line=node.lineno, reason="loop target is dynamic")
@@ -278,7 +456,7 @@ class _FunctionCollector(ast.NodeVisitor):
             self.visit(statement)
 
     def visit_AsyncFor(self, node: ast.AsyncFor) -> None:
-        for name in _target_names(node.target):
+        for name in _bound_names(node.target):
             self._block(name, line=node.lineno, reason="async loop target is dynamic")
         for statement in [*node.body, *node.orelse]:
             self.visit(statement)
@@ -286,7 +464,7 @@ class _FunctionCollector(ast.NodeVisitor):
     def visit_With(self, node: ast.With) -> None:
         for item in node.items:
             if item.optional_vars is not None:
-                for name in _target_names(item.optional_vars):
+                for name in _bound_names(item.optional_vars):
                     self._block(
                         name,
                         line=node.lineno,
@@ -298,7 +476,7 @@ class _FunctionCollector(ast.NodeVisitor):
     def visit_AsyncWith(self, node: ast.AsyncWith) -> None:
         for item in node.items:
             if item.optional_vars is not None:
-                for name in _target_names(item.optional_vars):
+                for name in _bound_names(item.optional_vars):
                     self._block(
                         name,
                         line=node.lineno,
@@ -316,17 +494,36 @@ class _FunctionCollector(ast.NodeVisitor):
     def visit_Delete(self, node: ast.Delete) -> None:
         # Cython forbids deleting C-typed locals; never give del'ed names a cdef.
         for target in node.targets:
-            for name in _target_names(target):
+            for name in _bound_names(target):
                 self._block(name, line=node.lineno, reason="variable is deleted")
 
     def visit_NamedExpr(self, node: ast.NamedExpr) -> None:
-        cython_type, reason = _expr_type(node.value)
-        for name in _target_names(node.target):
+        cython_type, reason = _expr_type(node.value, shadowed_builtins=self.shadowed_builtins)
+        for name in _bound_names(node.target):
             if cython_type is not None and isinstance(node.target, ast.Name):
                 self._record(name, _Candidate(cython_type, node.lineno, reason))
             else:
                 self._block(name, line=node.lineno, reason=reason)
         self.generic_visit(node.value)
+
+    def visit_Import(self, node: ast.Import) -> None:
+        for alias in node.names:
+            for name in _bound_names(alias):
+                self._block(name, line=node.lineno, reason="import target is dynamic")
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        for alias in node.names:
+            for name in _bound_names(alias):
+                self._block(name, line=node.lineno, reason="import target is dynamic")
+
+    def visit_Match(self, node: ast.Match) -> None:
+        for case in node.cases:
+            for name in _bound_names(case.pattern):
+                self._block(name, line=node.lineno, reason="match capture target is dynamic")
+            if case.guard is not None:
+                self.visit(case.guard)
+            for statement in case.body:
+                self.visit(statement)
 
     def resolve(self) -> tuple[tuple[TypedVariable, ...], tuple[SkippedVariable, ...]]:
         typed: list[TypedVariable] = []
@@ -385,6 +582,7 @@ def analyze_source(source: str, *, filename: str = "<source>") -> PreprocessPrev
         collector = _FunctionCollector(
             function=info.qualname,
             parameters=_function_args(info.node),
+            shadowed_builtins=_shadowed_builtins(info.node),
         )
         for statement in info.node.body:
             collector.visit(statement)

--- a/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/pre_install.py
+++ b/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/pre_install.py
@@ -13,6 +13,7 @@
 
 import sys
 import argparse
+import json
 from pathlib import Path
 import parso
 
@@ -55,6 +56,11 @@ def _ensure_agi_env() -> None:
 
 _ensure_agi_env()
 from agi_env import AgiEnv
+from agi_env.cython_build_config import (
+    CYTHON_PREVIEW_REPORT_SUFFIX,
+    add_cython_pyx_stamp,
+    cython_pyx_stamp_line,
+)
 
 try:
     from .cython_type_preprocess import preprocess_source
@@ -140,7 +146,10 @@ def prepare_for_cython(args):
     with open(cython_src, 'r') as file:
         source = file.read()
     modified_source = remove_decorators(source, verbose=args.verbose)
-    if getattr(args, "type_preprocess", False):
+    type_preprocess = bool(getattr(args, "type_preprocess", False))
+    cython_out = worker_path.with_suffix('.pyx')
+    report_out = worker_path.with_suffix(CYTHON_PREVIEW_REPORT_SUFFIX)
+    if type_preprocess:
         modified_source, preview = preprocess_source(
             modified_source,
             filename=str(cython_src),
@@ -150,7 +159,20 @@ def prepare_for_cython(args):
             f"{len(preview.typed_variables)} local declarations "
             f"and skipped {len(preview.skipped)} variables."
         )
-    cython_out = worker_path.with_suffix('.pyx')
+        report_out.write_text(
+            json.dumps(
+                preview.to_report(input_path=str(cython_src), output_path=str(cython_out)),
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        AgiEnv.log_info(f"Cython type preprocessing report written to {report_out}")
+    elif report_out.exists():
+        report_out.unlink()
+    stamp_line = cython_pyx_stamp_line(source, type_preprocess=type_preprocess)
+    modified_source = add_cython_pyx_stamp(modified_source, stamp_line=stamp_line)
     with open(cython_out, 'w') as file:
         file.write(modified_source)
     AgiEnv.log_info(f'Processed {cython_src} and generated {cython_out}')

--- a/src/agilab/core/test/test_agi_dispatcher_scripts.py
+++ b/src/agilab/core/test/test_agi_dispatcher_scripts.py
@@ -13,6 +13,12 @@ from zipfile import ZipFile
 import py7zr
 import pytest
 
+from agi_env.cython_build_config import (
+    CYTHON_BUILD_STAMP_FILENAME,
+    CYTHON_PREVIEW_REPORT_SUFFIX,
+    add_cython_pyx_stamp,
+    cython_pyx_stamp_line,
+)
 from agi_node.agi_dispatcher import build as build_mod
 from agi_node.agi_dispatcher import cython_type_preprocess as type_preprocess_mod
 from agi_node.agi_dispatcher import post_install as post_mod
@@ -62,6 +68,27 @@ def test_pre_install_remove_decorators_by_name():
     assert "@drop" not in out
     assert "@keep" in out
     assert "def func" in out
+
+
+def test_pre_install_prepare_for_cython_writes_freshness_stamp(tmp_path):
+    worker_path = tmp_path / "demo_worker.py"
+    worker_path.write_text("@decorator\ndef run():\n    return 1\n", encoding="utf-8")
+    report_path = worker_path.with_suffix(CYTHON_PREVIEW_REPORT_SUFFIX)
+    report_path.write_text("stale\n", encoding="utf-8")
+
+    pre_mod.prepare_for_cython(
+        Namespace(
+            worker_path=str(worker_path),
+            cython_target_src_ext=".py",
+            type_preprocess=False,
+            verbose=False,
+        )
+    )
+
+    pyx_text = worker_path.with_suffix(".pyx").read_text(encoding="utf-8")
+    assert "# agilab-pyx: src-sha256=" in pyx_text
+    assert "type-preprocess=0" in pyx_text
+    assert not report_path.exists()
 
 
 def test_pre_install_process_decorators_handles_missing_parent_entry(monkeypatch):
@@ -155,9 +182,14 @@ def test_pre_install_prepare_for_cython_can_type_preprocess(tmp_path, monkeypatc
     )
 
     pyx_text = worker_py.with_suffix(".pyx").read_text(encoding="utf-8")
+    report = json.loads(worker_py.with_suffix(CYTHON_PREVIEW_REPORT_SUFFIX).read_text(encoding="utf-8"))
     assert "cdef Py_ssize_t i" in pyx_text
     assert "cdef double total" in pyx_text
+    assert len(report["declarations"]) == 2
+    assert report["input"] == str(worker_py)
+    assert report["output"] == str(worker_py.with_suffix(".pyx"))
     assert any("Cython type preprocessing inserted 2" in line for line in logs)
+    assert any("Cython type preprocessing report written" in line for line in logs)
 
 
 def test_cython_type_preprocess_skips_dynamic_reassignments():
@@ -259,6 +291,102 @@ def run(values):
     assert "blocked" in skipped
     assert "pair" in skipped
     assert type_preprocess_mod._call_name(type_preprocess_mod.ast.Constant(value=1)) is None
+
+
+def test_cython_type_preprocess_blocks_reproduced_unsound_bindings():
+    source = """
+def run(arr, pair, value):
+    c, *rest = pair
+    mask = arr > 0
+    import math as m
+    match value:
+        case {"x": x, **remaining}:
+            pass
+    return c, rest, mask, m, x, remaining
+"""
+
+    preview = type_preprocess_mod.analyze_source(source)
+    typed_names = {item.name for item in preview.typed_variables}
+    skipped = {item.name: item.reason for item in preview.skipped}
+
+    assert not ({"c", "rest", "mask", "m", "x", "remaining"} & typed_names)
+    assert {"c", "rest", "mask", "m", "x", "remaining"} <= set(skipped)
+    assert skipped["mask"] == "comparison operands are not statically numeric"
+
+
+def test_cython_type_preprocess_blocks_shadowed_builtins_and_keeps_safe_reach():
+    source = """
+def shadowed(values):
+    range = lambda n: [0]
+    for i in range(len(values)):
+        pass
+    return i
+
+def numeric(values, other):
+    offset = len(values) - 1
+    scaled = len(values) * 8
+    product = len(values) * len(other)
+    truth = not values
+    check = isinstance(values, list)
+    for idx, item in enumerate(values):
+        pass
+    for started, value in enumerate(values, 1):
+        pass
+    return offset, scaled, product, truth, check, idx, started
+"""
+
+    preview = type_preprocess_mod.analyze_source(source)
+    typed = {(item.function, item.name, item.cython_type) for item in preview.typed_variables}
+    skipped = {(item.function, item.name) for item in preview.skipped}
+
+    assert ("shadowed", "i", "Py_ssize_t") not in typed
+    assert ("shadowed", "i") in skipped
+    assert ("numeric", "offset", "Py_ssize_t") in typed
+    assert ("numeric", "scaled", "Py_ssize_t") in typed
+    assert ("numeric", "truth", "bint") in typed
+    assert ("numeric", "check", "bint") in typed
+    assert ("numeric", "idx", "Py_ssize_t") in typed
+    assert ("numeric", "product") in skipped
+    assert ("numeric", "started") in skipped
+
+
+def test_cython_type_preprocess_preserves_signatures_and_blocks_inline_docstring_defs():
+    source = (
+        "def inline(): \"doc\"; total = 1.0; return total\n"
+        "\n"
+        "def normal(a: float, b=1):\n"
+        "    value = 1.0\n"
+        "    return value\n"
+    )
+
+    preview = type_preprocess_mod.analyze_source(source)
+    pyx_source = type_preprocess_mod.render_pyx(source, preview)
+    skipped = {(item.function, item.name): item.reason for item in preview.skipped}
+
+    assert "def normal(a: float, b=1):" in pyx_source
+    assert "cdef double a" not in pyx_source
+    assert "cdef double value" in pyx_source
+    assert "cdef double total" not in pyx_source
+    assert skipped[("inline", "total")] == "no safe insertion point for inline function body"
+
+
+def test_cython_type_preprocess_rendered_output_translates_with_real_cython(tmp_path):
+    cython_build = pytest.importorskip("Cython.Build")
+    source = (
+        "def run(values):\n"
+        "    total = 0.0\n"
+        "    for i in range(len(values)):\n"
+        "        total += 1.0\n"
+        "    return total\n"
+    )
+    pyx_source, preview = type_preprocess_mod.preprocess_source(source, filename="worker.py")
+    pyx_path = tmp_path / "worker.pyx"
+    pyx_path.write_text(pyx_source, encoding="utf-8")
+
+    cython_build.cythonize([str(pyx_path)], language_level=3, quiet=True, force=True)
+
+    assert preview.typed_variables
+    assert pyx_path.with_suffix(".c").exists()
 
 
 def test_cython_type_preprocess_respects_global_and_nonlocal_targets():
@@ -1772,22 +1900,71 @@ def test_build_ext_compile_config_covers_platform_and_free_threading():
     compile_args, define_macros, compiler_directives = build_mod._build_ext_compile_config(
         sys_platform="darwin",
         pyvers_worker="3.13",
+        environ={},
     )
     assert compile_args == [
         "-Wno-unknown-warning-option",
         "-Wno-unreachable-code-fallthrough",
     ]
     assert define_macros == [("CYTHON_FALLTHROUGH", "")]
-    assert compiler_directives == {}
+    assert compiler_directives["boundscheck"] is False
+    assert compiler_directives["wraparound"] is False
+    assert compiler_directives["initializedcheck"] is False
+    assert compiler_directives["nonecheck"] is False
+    assert compiler_directives["embedsignature"] is True
+    assert compiler_directives["profile"] is False
+    assert compiler_directives["linetrace"] is False
+    assert "freethreading_compatible" not in compiler_directives
 
     compile_args, define_macros, compiler_directives = build_mod._build_ext_compile_config(
         sys_platform="win32",
         pyvers_worker="3.13t",
+        environ={},
     )
     assert compile_args == []
     assert ("CYTHON_FALLTHROUGH", "") in define_macros
     assert ("Py_GIL_DISABLED", "1") in define_macros
-    assert compiler_directives == {"freethreading_compatible": True}
+    assert compiler_directives["freethreading_compatible"] is True
+    assert compiler_directives["boundscheck"] is False
+    assert compiler_directives["nonecheck"] is False
+
+
+def test_resolve_cython_compiler_directives_supports_off_and_overrides():
+    assert build_mod._resolve_cython_compiler_directives(
+        pyvers_worker="3.13",
+        environ={"AGILAB_CYTHON_DIRECTIVES": "off"},
+    ) == {}
+    assert build_mod._resolve_cython_compiler_directives(
+        pyvers_worker="3.13t",
+        environ={"AGILAB_CYTHON_DIRECTIVES": "off"},
+    ) == {"freethreading_compatible": True}
+
+    directives = build_mod._resolve_cython_compiler_directives(
+        pyvers_worker="3.13",
+        environ={"AGILAB_CYTHON_DIRECTIVES": "infer_types=true,cdivision=true,boundscheck=true"},
+    )
+    assert directives["infer_types"] is True
+    assert directives["cdivision"] is True
+    assert directives["boundscheck"] is True
+
+    # The named bundle removes index checks only — cdivision is excluded
+    # because it changes arithmetic results instead of removing checks.
+    directives = build_mod._resolve_cython_compiler_directives(
+        pyvers_worker="3.13",
+        environ={"AGILAB_CYTHON_DIRECTIVES": "unchecked"},
+    )
+    assert directives["boundscheck"] is False
+    assert directives["wraparound"] is False
+    assert directives["initializedcheck"] is False
+    assert directives["nonecheck"] is False
+    assert "cdivision" not in directives
+
+    # A typo silently dropping a safety directive is worse than failing.
+    with pytest.raises(ValueError, match="Unknown Cython compiler directive"):
+        build_mod._resolve_cython_compiler_directives(
+            pyvers_worker="3.13",
+            environ={"AGILAB_CYTHON_DIRECTIVES": "boundschek=false"},
+        )
 
 
 def test_build_worker_extension_uses_expected_fields(tmp_path):
@@ -1853,15 +2030,17 @@ def test_cythonize_worker_extension_passes_quiet_directives_and_cache(tmp_path):
         extension=extension,
         compiler_directives={"freethreading_compatible": True},
         quiet=True,
-        cythonize_fn=lambda modules, language_level=3, quiet=False, compiler_directives=None, cache=False: (
-            cythonize_calls.append((modules, language_level, quiet, compiler_directives, cache)) or ["ext_mod"]
+        annotate=True,
+        cythonize_fn=lambda modules, language_level=3, quiet=False, compiler_directives=None, cache=False, annotate=False: (
+            cythonize_calls.append((modules, language_level, quiet, compiler_directives, cache, annotate)) or ["ext_mod"]
         ),
         resolve_cython_cache_option_fn=lambda: str(tmp_path / "cython-cache"),
+        log=SimpleNamespace(info=lambda *args: None),
     )
 
     assert result == ["ext_mod"]
     assert cythonize_calls == [
-        ([extension], 3, True, {"freethreading_compatible": True}, str(tmp_path / "cython-cache"))
+        ([extension], 3, True, {"freethreading_compatible": True}, str(tmp_path / "cython-cache"), True)
     ]
 
 
@@ -1904,7 +2083,7 @@ def test_postprocess_bdist_egg_output_unpacks_and_cleans_links(tmp_path):
         zf.writestr("demo_args_form.py", "import streamlit\n")
         zf.writestr("__pycache__/app_args_form.cpython-313.pyc", b"")
 
-    env = SimpleNamespace(worker_path="workers/demo_worker.py")
+    env = SimpleNamespace(worker_path="workers/demo_worker.py", home_abs=str(tmp_path))
     links_created = [tmp_path / "src" / "demo_worker" / "module_link"]
     cleanup_calls = []
     subprocess_calls = []
@@ -2044,6 +2223,64 @@ def test_ensure_worker_cython_source_runs_pre_install_when_pyx_missing(tmp_path)
     assert log_lines and "Ensuring Cython source via pre_install" in str(log_lines[0][0])
 
 
+def test_ensure_worker_cython_source_skips_when_pyx_stamp_is_fresh(tmp_path):
+    worker_py = tmp_path / "workers" / "demo_worker.py"
+    worker_py.parent.mkdir(parents=True, exist_ok=True)
+    worker_py.write_text("value = 1\n", encoding="utf-8")
+    worker_pyx = worker_py.with_suffix(".pyx")
+    worker_pyx.write_text(
+        add_cython_pyx_stamp(
+            "value = 1\n",
+            stamp_line=cython_pyx_stamp_line(
+                "value = 1\n",
+                type_preprocess=False,
+            ),
+        ),
+        encoding="utf-8",
+    )
+    pre_script = tmp_path / "pre_install.py"
+    pre_script.write_text("print('ok')\n", encoding="utf-8")
+    run_calls = []
+
+    build_mod._ensure_worker_cython_source(
+        SimpleNamespace(worker_path=str(worker_py), home_abs=str(tmp_path), verbose=2),
+        resolve_pre_install_script_fn=lambda _env: pre_script,
+        subprocess_run=lambda cmd, check=True: run_calls.append((cmd, check)),
+        log=SimpleNamespace(info=lambda *args: None),
+    )
+
+    assert run_calls == []
+
+
+def test_ensure_worker_cython_source_regenerates_when_preprocess_flag_changes(tmp_path):
+    worker_py = tmp_path / "workers" / "demo_worker.py"
+    worker_py.parent.mkdir(parents=True, exist_ok=True)
+    worker_py.write_text("value = 1\n", encoding="utf-8")
+    worker_py.with_suffix(".pyx").write_text(
+        add_cython_pyx_stamp(
+            "value = 1\n",
+            stamp_line=cython_pyx_stamp_line(
+                "value = 1\n",
+                type_preprocess=False,
+            ),
+        ),
+        encoding="utf-8",
+    )
+    pre_script = tmp_path / "pre_install.py"
+    pre_script.write_text("print('ok')\n", encoding="utf-8")
+    run_calls = []
+
+    build_mod._ensure_worker_cython_source(
+        SimpleNamespace(worker_path=str(worker_py), home_abs=str(tmp_path), verbose=0),
+        resolve_pre_install_script_fn=lambda _env: pre_script,
+        resolve_cython_type_preprocess_option_fn=lambda: True,
+        subprocess_run=lambda cmd, check=True: run_calls.append((cmd, check)),
+        log=SimpleNamespace(info=lambda *args: None),
+    )
+
+    assert run_calls and "--type-preprocess" in run_calls[0][0]
+
+
 def test_resolve_cython_type_preprocess_option_from_environment():
     assert build_mod._resolve_cython_type_preprocess_option(environ={}) is False
     assert build_mod._resolve_cython_type_preprocess_option(
@@ -2135,6 +2372,83 @@ def test_build_setuptools_argv_handles_relative_and_absolute_out_arg(tmp_path):
     ]
 
 
+def test_cython_build_stamp_hit_and_record_track_codegen_inputs(tmp_path):
+    home = tmp_path / "home"
+    worker_py = home / "demo_project" / "src" / "demo_worker" / "demo_worker.py"
+    worker_py.parent.mkdir(parents=True, exist_ok=True)
+    worker_py.write_text("def run():\n    return 1\n", encoding="utf-8")
+    worker_py.with_suffix(".pyx").write_text("def run():\n    return 1\n", encoding="utf-8")
+    dist = home / "exports" / "dist"
+    dist.mkdir(parents=True, exist_ok=True)
+    (dist / "demo_worker_cy.cpython-test.so").write_text("binary", encoding="utf-8")
+    env = SimpleNamespace(
+        home_abs=str(home),
+        worker_path=str(worker_py),
+        pyvers_worker="3.13",
+    )
+
+    build_mod._record_cython_build_stamp(
+        env=env,
+        out_arg="exports",
+        worker_module="demo_worker",
+        log=SimpleNamespace(info=lambda *args: None),
+    )
+
+    stamp_path = dist / CYTHON_BUILD_STAMP_FILENAME
+    payload = json.loads(stamp_path.read_text(encoding="utf-8"))
+    assert payload["worker_pyx"]["sha256"]
+    assert build_mod._cython_build_stamp_hit(
+        env=env,
+        out_arg="exports",
+        worker_module="demo_worker",
+        log=SimpleNamespace(info=lambda *args: None),
+    ) is True
+
+    worker_py.with_suffix(".pyx").write_text("def run():\n    return 2\n", encoding="utf-8")
+    assert build_mod._cython_build_stamp_hit(
+        env=env,
+        out_arg="exports",
+        worker_module="demo_worker",
+        log=SimpleNamespace(info=lambda *args: None),
+    ) is False
+
+
+def test_execute_main_setup_skips_or_records_cython_stamp(tmp_path):
+    calls = []
+    skipped_env = SimpleNamespace(_agilab_skip_setup=True)
+
+    build_mod._execute_main_setup(
+        env=skipped_env,
+        cmd="build_ext",
+        out_arg="exports",
+        worker_module="demo_worker",
+        ext_modules=[],
+        links_created=[],
+        ensure_build_readme_fn=lambda: calls.append("readme"),
+        setup_fn=lambda **_kwargs: calls.append("setup"),
+        finalize_setup_artifacts_fn=lambda **_kwargs: calls.append("finalize"),
+    )
+
+    assert calls == []
+
+    env = SimpleNamespace()
+    build_mod._execute_main_setup(
+        env=env,
+        cmd="build_ext",
+        out_arg="exports",
+        worker_module="demo_worker",
+        ext_modules=["ext_mod"],
+        links_created=[],
+        ensure_build_readme_fn=lambda: calls.append("readme"),
+        build_setup_kwargs_fn=lambda **kwargs: calls.append(("kwargs", kwargs)) or {"ext_modules": ["ext_mod"]},
+        setup_fn=lambda **kwargs: calls.append(("setup", kwargs)),
+        finalize_setup_artifacts_fn=lambda **kwargs: calls.append(("finalize", kwargs)),
+        record_cython_build_stamp_fn=lambda **kwargs: calls.append(("stamp", kwargs)),
+    )
+
+    assert calls[-1][0] == "stamp"
+
+
 def test_ensure_build_readme_creates_placeholder_once(tmp_path):
     readme = tmp_path / "README.md"
 
@@ -2169,10 +2483,12 @@ def test_build_setup_kwargs_uses_find_packages_and_ext_modules():
     }
 
 
-def test_configure_build_ext_modules_orchestrates_helper_calls(tmp_path):
+def test_configure_build_ext_modules_orchestrates_helper_calls(tmp_path, monkeypatch):
     build_extension_calls = []
     cythonize_calls = []
     log_lines = []
+    log = SimpleNamespace(info=lambda *args: log_lines.append(args))
+    monkeypatch.delenv("AGILAB_CYTHON_ANNOTATE", raising=False)
 
     result = build_mod._configure_build_ext_modules(
         active_app=tmp_path / "demo_project",
@@ -2194,7 +2510,7 @@ def test_configure_build_ext_modules_orchestrates_helper_calls(tmp_path):
         cythonize_worker_extension_fn=lambda **kwargs: (
             cythonize_calls.append(kwargs) or ["ext_mod"]
         ),
-        log=SimpleNamespace(info=lambda *args: log_lines.append(args)),
+        log=log,
     )
 
     assert result == ["ext_mod"]
@@ -2214,6 +2530,8 @@ def test_configure_build_ext_modules_orchestrates_helper_calls(tmp_path):
             "extension": "ext_def",
             "compiler_directives": {"freethreading_compatible": True},
             "quiet": True,
+            "annotate": False,
+            "log": log,
         }
     ]
     assert any(args[0] == "cwd: " + str(tmp_path / "demo_project") for args in log_lines if args)
@@ -3276,7 +3594,7 @@ def test_build_main_build_ext_invokes_pre_install_and_setup(tmp_path, monkeypatc
     monkeypatch.setattr(
         build_mod,
         "cythonize",
-        lambda modules, language_level=3, quiet=False, compiler_directives=None, cache=False: (
+        lambda modules, language_level=3, quiet=False, compiler_directives=None, cache=False, annotate=False: (
             cythonize_calls.append((modules, quiet, compiler_directives)) or ["ext_mod"]
         ),
     )
@@ -3532,7 +3850,7 @@ def test_build_main_build_ext_free_threaded_nonquiet_uses_worker_resolve_fallbac
     monkeypatch.setattr(build_mod.subprocess, "run", lambda cmd, check=True: run_calls.append((cmd, check)))
     cythonize_calls = []
 
-    def _fake_cythonize(modules, language_level=3, quiet=False, compiler_directives=None, cache=False):
+    def _fake_cythonize(modules, language_level=3, quiet=False, compiler_directives=None, cache=False, annotate=False):
         cythonize_calls.append((modules, quiet, compiler_directives))
         return ["ext_mod"]
 
@@ -3557,7 +3875,9 @@ def test_build_main_build_ext_free_threaded_nonquiet_uses_worker_resolve_fallbac
     assert cythonize_calls and cythonize_calls[0][1] is False
     ext = cythonize_calls[0][0][0]
     assert ("Py_GIL_DISABLED", "1") in ext.define_macros
-    assert cythonize_calls[0][2] == {"freethreading_compatible": True}
+    assert cythonize_calls[0][2]["freethreading_compatible"] is True
+    assert cythonize_calls[0][2]["boundscheck"] is False
+    assert cythonize_calls[0][2]["nonecheck"] is False
     assert setup_calls and setup_calls[0]["name"] == "demo_worker"
 
 

--- a/src/agilab/core/test/test_agi_distributor_cli.py
+++ b/src/agilab/core/test/test_agi_distributor_cli.py
@@ -663,7 +663,19 @@ def test_kill_does_not_target_unrelated_dask_named_processes(monkeypatch):
     )
     monkeypatch.setattr(cli_mod.os, "name", "posix", raising=False)
     monkeypatch.setattr(cli_mod.subprocess, "check_output", lambda *args, **kwargs: output)
-    monkeypatch.setattr(cli_mod.Path, "glob", lambda self, _pattern: [])
+
+    class _NoPidPath:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        @property
+        def parent(self):
+            return self
+
+        def glob(self, _pattern):
+            return []
+
+    monkeypatch.setattr(cli_mod, "Path", _NoPidPath)
     monkeypatch.setattr(cli_mod.os, "getpid", lambda: 999)
     monkeypatch.setattr(cli_mod, "_poll_until_dead", lambda pids: set())
 

--- a/src/agilab/core/test/test_agi_distributor_deployment_build_support.py
+++ b/src/agilab/core/test/test_agi_distributor_deployment_build_support.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from agi_env.cython_build_config import CYTHON_BUILD_REQUIREMENT
 from agi_cluster.agi_distributor import AGI
 import agi_cluster.agi_distributor.deployment_build_support as deployment_build_support
 from agi_cluster.agi_distributor import uv_source_support
@@ -205,8 +206,8 @@ def test_worker_build_commands_request_build_tool_overlay():
         verbose=0,
     )
 
-    assert "run --no-sync --with setuptools --with cython" in bdist_cmd
-    assert "run --no-sync --with setuptools --with cython" in build_ext_cmd
+    assert f"run --no-sync --with setuptools --with {CYTHON_BUILD_REQUIREMENT}" in bdist_cmd
+    assert f"run --no-sync --with setuptools --with {CYTHON_BUILD_REQUIREMENT}" in build_ext_cmd
     assert " -q " in f" {bdist_cmd} "
     assert " -q " in f" {build_ext_cmd} "
 
@@ -228,8 +229,8 @@ def test_worker_build_commands_keep_overlay_without_quiet_flag_when_verbose():
         verbose=2,
     )
 
-    assert "run --no-sync --with setuptools --with cython" in bdist_cmd
-    assert "run --no-sync --with setuptools --with cython" in build_ext_cmd
+    assert f"run --no-sync --with setuptools --with {CYTHON_BUILD_REQUIREMENT}" in bdist_cmd
+    assert f"run --no-sync --with setuptools --with {CYTHON_BUILD_REQUIREMENT}" in build_ext_cmd
     assert " -q " not in f" {bdist_cmd} "
     assert " -q " not in f" {build_ext_cmd} "
 
@@ -245,7 +246,7 @@ def test_source_worker_build_overlay_includes_editable_core_projects(tmp_path):
     overlay = deployment_build_support._build_run_overlay_args(env)
 
     assert "--with setuptools" in overlay
-    assert "--with cython" in overlay
+    assert f"--with {CYTHON_BUILD_REQUIREMENT}" in overlay
     assert _editable_overlay_arg(env.agi_env) in overlay
     assert _editable_overlay_arg(env.agi_node) in overlay
     assert _editable_overlay_arg(env.agi_cluster) in overlay
@@ -367,6 +368,20 @@ def test_build_support_fingerprint_edge_cases(monkeypatch, tmp_path):
     assert deployment_build_support._git_directory_fingerprint(source) is None
 
 
+def test_file_fingerprint_uses_hash_not_mtime_for_small_files(tmp_path):
+    source = tmp_path / "module.py"
+    source.write_text("VALUE = 1\n", encoding="utf-8")
+
+    first = deployment_build_support._file_fingerprint(source)
+    os.utime(source, (100, 100))
+    second = deployment_build_support._file_fingerprint(source)
+
+    assert first is not None and second is not None
+    assert first["sha256"] == second["sha256"]
+    assert "mtime_ns" not in first
+    assert "mtime_ns" not in second
+
+
 def test_worker_build_cache_helpers_cover_disabled_and_missing_outputs(tmp_path):
     env = SimpleNamespace(
         wenv_abs=tmp_path / "wenv",
@@ -402,6 +417,30 @@ def test_worker_build_cache_helpers_cover_disabled_and_missing_outputs(tmp_path)
         core_install_commands=[],
     )
     assert not deployment_build_support._build_cache_path(env.wenv_abs).exists()
+
+
+def test_worker_build_cache_payload_records_cython_codegen_inputs(tmp_path):
+    env = _build_env(tmp_path)
+    env.envars = {
+        "AGILAB_CYTHON_ANNOTATE": "1",
+        "AGILAB_CYTHON_TYPE_PREPROCESS": "1",
+        "AGILAB_CYTHON_DIRECTIVES": "off",
+    }
+
+    payload = deployment_build_support._worker_build_cache_payload(
+        env=env,
+        packages="agi_dispatcher, pandas_worker",
+        worker_group="pandas-worker",
+        is_cy=True,
+        module_cmd="python -m build",
+        core_install_commands=[],
+    )
+
+    assert payload["schema"] == "agilab-worker-build-cache-v2"
+    assert payload["cython_build_requirements"] == ["setuptools", CYTHON_BUILD_REQUIREMENT]
+    assert payload["cython_type_preprocess"] is True
+    assert payload["cython_directives"] == "off"
+    assert payload["cython_annotate"] is True
 
 
 def test_copy_cython_worker_lib_raises_when_output_missing(tmp_path):

--- a/src/agilab/core/test/test_agi_distributor_deployment_build_support.py
+++ b/src/agilab/core/test/test_agi_distributor_deployment_build_support.py
@@ -135,7 +135,10 @@ def test_cython_lib_destination_handles_free_thread_suffix(
         failure_message="missing",
     )
 
-    expected_dir = tmp_path / ".venv" / "lib" / f"python{expected}" / "site-packages"
+    expected_dir = deployment_build_support._project_site_packages_dir(
+        tmp_path,
+        python_version=expected,
+    )
     assert (expected_dir / "demo_cy.so").exists()
 
 
@@ -492,7 +495,10 @@ def test_copy_cython_worker_lib_prefers_latest_output(tmp_path):
         failure_message="build_ext failed",
     )
 
-    destination = wenv_abs / ".venv" / "lib" / "python3.13" / "site-packages"
+    destination = deployment_build_support._project_site_packages_dir(
+        wenv_abs,
+        python_version="3.13",
+    )
     assert (destination / "worker_new_cy.so").exists()
     assert not (destination / "worker_old_cy.so").exists()
 
@@ -844,7 +850,13 @@ async def test_build_lib_local_cython_copies_worker_lib(tmp_path):
         run_fn=_fake_run,
     )
 
-    target = env.wenv_abs / ".venv/lib/python3.13/site-packages/demo_cy.so"
+    target = (
+        deployment_build_support._project_site_packages_dir(
+            env.wenv_abs,
+            python_version="3.13",
+        )
+        / "demo_cy.so"
+    )
     assert target.exists()
     assert any("build_ext" in cmd for cmd, _ in commands)
     assert any(

--- a/src/agilab/core/test/test_agi_distributor_deployment_remote_support.py
+++ b/src/agilab/core/test/test_agi_distributor_deployment_remote_support.py
@@ -1457,6 +1457,7 @@ def test_remote_env_update_command_preserves_other_env_keys():
     )
 
 
+@pytest.mark.skipif(os.name == "nt", reason="BSD/macOS mount output uses POSIX paths")
 def test_local_mount_record_for_path_falls_back_to_mount_on_missing_findmnt(
     monkeypatch, tmp_path
 ):

--- a/src/agilab/core/test/test_agi_distributor_deployment_remote_support.py
+++ b/src/agilab/core/test/test_agi_distributor_deployment_remote_support.py
@@ -7,6 +7,7 @@ from unittest import mock
 
 import pytest
 
+from agi_env.cython_build_config import CYTHON_BUILD_REQUIREMENT
 from agi_cluster.agi_distributor import deployment_remote_support, uv_source_support
 
 
@@ -365,7 +366,7 @@ async def test_deploy_remote_worker_non_source_flow(monkeypatch, tmp_path):
     assert any(
         "agi_node.agi_dispatcher.build" in cmd
         and "--with setuptools" in cmd
-        and "--with cython" in cmd
+        and f"--with {CYTHON_BUILD_REQUIREMENT}" in cmd
         for cmd in ssh_calls
     )
 
@@ -495,7 +496,7 @@ async def test_deploy_remote_worker_verbose_build_keeps_overlay_without_quiet_fl
     assert len(build_commands) == 1
     build_cmd = build_commands[0]
     assert "--with setuptools" in build_cmd
-    assert "--with cython" in build_cmd
+    assert f"--with {CYTHON_BUILD_REQUIREMENT}" in build_cmd
     assert " -q " not in f" {build_cmd} "
 
 

--- a/src/agilab/core/test/test_agi_distributor_runtime_distribution_support.py
+++ b/src/agilab/core/test/test_agi_distributor_runtime_distribution_support.py
@@ -682,7 +682,7 @@ async def test_run_local_covers_debug_and_script_execution_paths(tmp_path, monke
         "python-upgrade",
         "--no-sync",
     ]
-    assert argv[argv.index("--project") + 1] == str(wenv_abs)
+    assert Path(argv[argv.index("--project") + 1]) == wenv_abs
     assert argv[argv.index("--python") + 1] == "3.13"
     assert "from agi_env import AgiEnv" in script
     assert "AgiEnv(apps_path=Path('/tmp/apps'), app='demo_project', verbose=2)" in script

--- a/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/src/flight_telemetry_worker/flight_telemetry_worker.py
+++ b/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/src/flight_telemetry_worker/flight_telemetry_worker.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 # https://github.com/cython/cython/wiki/enhancements-compilerdirectives
-# cython:infer_types True
-# cython:boundscheck False
-# cython:cdivision True
+# cython: infer_types=True
+# cython: boundscheck=False
+# cython: cdivision=True
 
 import glob
 import logging

--- a/test/test_benchmark_execution_tools.py
+++ b/test/test_benchmark_execution_tools.py
@@ -84,6 +84,40 @@ def test_cython_kernel_benchmark_writes_lf_csv(tmp_path) -> None:
     assert b"\n" in data
 
 
+def test_cython_kernel_compare_preprocess_csv_reports_counts(tmp_path) -> None:
+    results = {
+        "environment": {"rows": 100, "compare_preprocess": True},
+        "preprocess": {"typed_count": 3, "skipped_count": 2},
+        "runtimes": {
+            "cython_raw": {
+                "median_seconds": 1.0,
+                "min_seconds": 1.0,
+                "max_seconds": 1.0,
+                "checksum": 1.0,
+            },
+            "cython_preprocessed": {
+                "median_seconds": 0.8,
+                "min_seconds": 0.8,
+                "max_seconds": 0.8,
+                "checksum": 1.0,
+            },
+        },
+        "speedup_preprocessed_vs_raw": 1.25,
+    }
+    csv_path = tmp_path / "compare.csv"
+
+    rows = cython_kernel._rows_for_preprocess_csv(results)
+    cython_kernel._write_csv(csv_path, results)
+
+    assert rows[0]["runtime"] == "cython_raw"
+    assert rows[0]["speedup_preprocessed_vs_raw"] == "1.00"
+    assert rows[1]["runtime"] == "cython_preprocessed"
+    assert rows[1]["speedup_preprocessed_vs_raw"] == "1.25"
+    assert rows[1]["typed_count"] == "3"
+    assert rows[1]["skipped_count"] == "2"
+    assert "speedup_preprocessed_vs_raw" in csv_path.read_text(encoding="utf-8")
+
+
 def test_ssh_target_defaults_to_agi_and_preserves_explicit_user() -> None:
     assert matrix._ssh_target("192.168.20.130") == "agi@192.168.20.130"
     assert matrix._ssh_target("bench@192.168.20.130") == "bench@192.168.20.130"

--- a/tools/benchmark_execution_pandas_cython_kernel.py
+++ b/tools/benchmark_execution_pandas_cython_kernel.py
@@ -20,6 +20,8 @@ import numpy as np
 
 ROOT = Path(__file__).resolve().parents[1]
 APP_SRC = ROOT / "src/agilab/apps/builtin/execution_pandas_project/src"
+AGI_ENV_SRC = ROOT / "src/agilab/core/agi-env/src"
+AGI_NODE_SRC = ROOT / "src/agilab/core/agi-node/src"
 WORKER_SOURCE = APP_SRC / "execution_pandas_worker/execution_pandas_worker.py"
 SOURCE_MODULE = "execution_pandas_worker.execution_pandas_worker"
 COMPILED_MODULE = "_execution_pandas_typed_kernel_cy"
@@ -34,23 +36,37 @@ def _ensure_app_path() -> None:
         sys.path.insert(0, path)
 
 
+def _ensure_core_paths() -> None:
+    for path in (AGI_ENV_SRC, AGI_NODE_SRC):
+        text = str(path)
+        if text not in sys.path:
+            sys.path.insert(0, text)
+
+
 def _load_source_worker() -> ModuleType:
     _ensure_app_path()
     return importlib.import_module(SOURCE_MODULE)
 
 
-def _build_compiled_worker(tmp_root: Path) -> ModuleType:
-    pyx_path = tmp_root / f"{COMPILED_MODULE}.pyx"
-    pyx_path.write_text(WORKER_SOURCE.read_text(encoding="utf-8"), encoding="utf-8")
+def _build_compiled_worker(
+    tmp_root: Path,
+    *,
+    module_name: str = COMPILED_MODULE,
+    source_text: str | None = None,
+) -> ModuleType:
+    pyx_path = tmp_root / f"{module_name}.pyx"
+    if source_text is None:
+        source_text = WORKER_SOURCE.read_text(encoding="utf-8")
+    pyx_path.write_text(source_text, encoding="utf-8")
     setup_path = tmp_root / "setup.py"
     setup_path.write_text(
         "\n".join(
             [
                 "from setuptools import Extension, setup",
                 "from Cython.Build import cythonize",
-                f"extension = Extension({COMPILED_MODULE!r}, [{pyx_path.name!r}])",
+                f"extension = Extension({module_name!r}, [{pyx_path.name!r}])",
                 "setup(",
-                f"    name={COMPILED_MODULE!r},",
+                f"    name={module_name!r},",
                 "    ext_modules=cythonize([extension], language_level=3, quiet=True),",
                 ")",
                 "",
@@ -66,23 +82,36 @@ def _build_compiled_worker(tmp_root: Path) -> ModuleType:
         text=True,
     )
     suffix = sysconfig.get_config_var("EXT_SUFFIX") or ".so"
-    extension_path = tmp_root / f"{COMPILED_MODULE}{suffix}"
+    extension_path = tmp_root / f"{module_name}{suffix}"
     if not extension_path.exists():
-        candidates = sorted(tmp_root.glob(f"{COMPILED_MODULE}*.so"))
+        candidates = sorted(tmp_root.glob(f"{module_name}*.so"))
         if not candidates:
-            candidates = sorted(tmp_root.glob(f"{COMPILED_MODULE}*.pyd"))
+            candidates = sorted(tmp_root.glob(f"{module_name}*.pyd"))
         if not candidates:
             raise FileNotFoundError(f"Compiled module not found under {tmp_root}")
         extension_path = candidates[0]
 
-    spec = importlib.util.spec_from_file_location(COMPILED_MODULE, extension_path)
+    spec = importlib.util.spec_from_file_location(module_name, extension_path)
     if spec is None or spec.loader is None:
         raise ImportError(f"Unable to import compiled module from {extension_path}")
     module = importlib.util.module_from_spec(spec)
-    sys.modules.pop(COMPILED_MODULE, None)
-    sys.modules[COMPILED_MODULE] = module
+    sys.modules.pop(module_name, None)
+    sys.modules[module_name] = module
     spec.loader.exec_module(module)
     return module
+
+
+def _preprocess_worker_source(source_text: str) -> tuple[str, dict[str, Any]]:
+    _ensure_core_paths()
+    from agi_node.agi_dispatcher.cython_type_preprocess import preprocess_source
+    from agi_node.agi_dispatcher.pre_install import remove_decorators
+
+    stripped = remove_decorators(source_text, verbose=False)
+    preprocessed, preview = preprocess_source(
+        stripped,
+        filename=str(WORKER_SOURCE),
+    )
+    return preprocessed, preview.to_report(input_path=str(WORKER_SOURCE))
 
 
 def _make_arrays(rows: int, seed: int) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
@@ -195,13 +224,51 @@ def _rows_for_csv(results: dict[str, Any]) -> list[dict[str, Any]]:
     return rows
 
 
+def _rows_for_preprocess_csv(results: dict[str, Any]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    row_count = int(results["environment"]["rows"])
+    speedup = float(results["speedup_preprocessed_vs_raw"])
+    typed_count = int(results["preprocess"]["typed_count"])
+    skipped_count = int(results["preprocess"]["skipped_count"])
+    for runtime, data in results["runtimes"].items():
+        median = float(data["median_seconds"])
+        rows.append(
+            {
+                "runtime": runtime,
+                "median_seconds": f"{median:.6f}",
+                "min_seconds": f"{float(data['min_seconds']):.6f}",
+                "max_seconds": f"{float(data['max_seconds']):.6f}",
+                "rows_per_second": f"{row_count / median:.0f}" if median else "",
+                "speedup_preprocessed_vs_raw": (
+                    f"{speedup:.2f}" if runtime == "cython_preprocessed" else "1.00"
+                ),
+                "checksum": f"{float(data['checksum']):.6f}",
+                "typed_count": str(typed_count),
+                "skipped_count": str(skipped_count),
+            }
+        )
+    return rows
+
+
 def _write_csv(path: Path, results: dict[str, Any]) -> None:
-    rows = _rows_for_csv(results)
+    compare_preprocess = bool(results["environment"].get("compare_preprocess"))
+    rows = _rows_for_preprocess_csv(results) if compare_preprocess else _rows_for_csv(results)
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("w", encoding="utf-8", newline="") as fh:
-        writer = csv.DictWriter(
-            fh,
-            fieldnames=[
+        fieldnames = (
+            [
+                "runtime",
+                "median_seconds",
+                "min_seconds",
+                "max_seconds",
+                "rows_per_second",
+                "speedup_preprocessed_vs_raw",
+                "checksum",
+                "typed_count",
+                "skipped_count",
+            ]
+            if compare_preprocess
+            else [
                 "runtime",
                 "median_seconds",
                 "min_seconds",
@@ -209,7 +276,11 @@ def _write_csv(path: Path, results: dict[str, Any]) -> None:
                 "rows_per_second",
                 "speedup_vs_python",
                 "checksum",
-            ],
+            ]
+        )
+        writer = csv.DictWriter(
+            fh,
+            fieldnames=fieldnames,
             lineterminator="\n",
         )
         writer.writeheader()
@@ -270,6 +341,84 @@ def run_benchmark(
     }
 
 
+def run_compare_preprocess_benchmark(
+    *,
+    rows: int,
+    compute_passes: int,
+    repeats: int,
+    warmups: int,
+    seed: int,
+) -> dict[str, Any]:
+    source_worker = _load_source_worker()
+    arrays = _make_arrays(rows, seed)
+    source_text = WORKER_SOURCE.read_text(encoding="utf-8")
+    preprocessed_source, preprocess_report = _preprocess_worker_source(source_text)
+    with tempfile.TemporaryDirectory(prefix="agilab-cython-preprocess-") as tmp_dir:
+        tmp_root = Path(tmp_dir)
+        raw_worker = _build_compiled_worker(
+            tmp_root,
+            module_name="_execution_pandas_typed_kernel_raw_cy",
+            source_text=source_text,
+        )
+        preprocessed_worker = _build_compiled_worker(
+            tmp_root,
+            module_name="_execution_pandas_typed_kernel_preprocessed_cy",
+            source_text=preprocessed_source,
+        )
+        _validate_kernel_equivalence(
+            source_worker,
+            raw_worker,
+            arrays,
+            compute_passes,
+        )
+        _validate_kernel_equivalence(
+            source_worker,
+            preprocessed_worker,
+            arrays,
+            compute_passes,
+        )
+        raw_result = _measure(
+            raw_worker,
+            arrays,
+            compute_passes=compute_passes,
+            repeats=repeats,
+            warmups=warmups,
+        )
+        preprocessed_result = _measure(
+            preprocessed_worker,
+            arrays,
+            compute_passes=compute_passes,
+            repeats=repeats,
+            warmups=warmups,
+        )
+
+    speedup = raw_result["median_seconds"] / preprocessed_result["median_seconds"]
+    return {
+        "environment": {
+            "python": sys.version.split()[0],
+            "platform": sys.platform,
+            "rows": rows,
+            "compute_passes": compute_passes,
+            "repeats": repeats,
+            "warmups": warmups,
+            "seed": seed,
+            "kernel": KERNEL_NAME,
+            "dtype_contract": "float64-contiguous",
+            "compare_preprocess": True,
+        },
+        "preprocess": {
+            "typed_count": len(preprocess_report["declarations"]),
+            "skipped_count": len(preprocess_report["skipped"]),
+            "report": preprocess_report,
+        },
+        "runtimes": {
+            "cython_raw": raw_result,
+            "cython_preprocessed": preprocessed_result,
+        },
+        "speedup_preprocessed_vs_raw": speedup,
+    }
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description="Benchmark the typed numeric kernel used by execution_pandas_project."
@@ -281,9 +430,15 @@ def main() -> int:
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument("--json-out", type=Path)
     parser.add_argument("--csv-out", type=Path)
+    parser.add_argument(
+        "--compare-preprocess",
+        action="store_true",
+        help="Compile raw and preprocessed worker sources and compare their kernel timing.",
+    )
     args = parser.parse_args()
 
-    results = run_benchmark(
+    runner = run_compare_preprocess_benchmark if args.compare_preprocess else run_benchmark
+    results = runner(
         rows=args.rows,
         compute_passes=args.compute_passes,
         repeats=args.repeats,


### PR DESCRIPTION
## Summary
- add shared Cython build config, pinned Cython overlay, cache payload fixes, and content-hash .pyx/build stamps
- add compare-preprocess benchmark mode, persisted preprocess reports, annotate/directive env controls, and build-stage timing logs
- harden conservative Cython preprocessing against unsafe bindings, shadowed builtins, match/import captures, and numpy-style comparisons
- sync docs and flight telemetry embedded package payload after fixing Cython directive comments

## Validation
- python3 -m py_compile on changed Python modules
- ./dev test src/agilab/core/test/test_agi_dispatcher_scripts.py src/agilab/core/test/test_agi_distributor_deployment_build_support.py src/agilab/core/test/test_agi_distributor_deployment_remote_support.py test/test_benchmark_execution_tools.py
- uv --preview-features extra-build-dependencies run python tools/benchmark_execution_pandas_cython_kernel.py --rows 10 --compute-passes 1 --repeats 1 --warmups 0 --compare-preprocess
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs
- uv --preview-features extra-build-dependencies run --no-sync pytest -q -o addopts='' --import-mode=importlib src/agilab/core/agi-env/test
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' --import-mode=importlib test/test_environment_health.py src/agilab/core/test/test_build_worker_venv_artifacts.py test/test_cython_type_preprocess_preview.py src/agilab/core/test/test_agi_dispatcher_scripts.py src/agilab/core/test/test_agi_distributor_deployment_build_support.py src/agilab/core/test/test_agi_distributor_deployment_remote_support.py test/test_benchmark_execution_tools.py
- uv --preview-features extra-build-dependencies run --no-sync pytest -q -o addopts='' --import-mode=importlib src/agilab/core/test
- uv --preview-features extra-build-dependencies run python tools/app_contract_matrix.py --output .pytest_cache/agilab/app-contract-matrix-pre-push.json --quiet