### PR TITLE
[codex] Harden Cython runtime load and range typing

### DIFF
--- a/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/base_worker_runtime_support.py
+++ b/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/base_worker_runtime_support.py
@@ -137,6 +137,30 @@ def load_manager(
     return load_module_fn(module_name, env.target_class)
 
 
+def _cython_worker_import_error_message(
+    env: Any,
+    module_name: str,
+    exc: BaseException,
+) -> str:
+    target_worker = getattr(env, "target_worker", module_name.removesuffix("_cy"))
+    parts = [
+        (
+            f"Cython mode requested for worker '{target_worker}', but compiled "
+            f"module '{module_name}' is not importable."
+        )
+    ]
+    wenv_abs = getattr(env, "wenv_abs", None)
+    if wenv_abs is not None:
+        parts.append(f"Expected compiled artifacts under '{Path(wenv_abs) / 'dist'}'.")
+    parts.append(
+        "Reinstall/build with Cython enabled (`install.py --with-cython` or "
+        "`[tool.agilab.cython].enabled = true`), or rerun without the Cython "
+        "mode bit (`--no-cython` or a mode without bit 2)."
+    )
+    parts.append(f"Original import error: {exc}")
+    return " ".join(parts)
+
+
 def load_worker(
     env: Any,
     mode: int,
@@ -146,12 +170,20 @@ def load_worker(
 ) -> Any:
     active_modules = sys_modules if sys_modules is not None else sys.modules
     module_name = env.target_worker
-    active_modules.pop(module_name, None)
     if mode & 2:
         module_name = f"{module_name}_cy"
     else:
         module_name = f"{module_name}.{module_name}"
-    return load_module_fn(module_name, env.target_worker_class)
+    active_modules.pop(module_name, None)
+    try:
+        return load_module_fn(module_name, env.target_worker_class)
+    except ModuleNotFoundError as exc:
+        if mode & 2:
+            raise ModuleNotFoundError(
+                _cython_worker_import_error_message(env, module_name, exc),
+                name=module_name,
+            ) from exc
+        raise
 
 
 def is_cython_installed(

--- a/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/cython_type_preprocess.py
+++ b/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/cython_type_preprocess.py
@@ -32,6 +32,7 @@ import ast
 import builtins
 import json
 import logging
+import sys
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Iterable, Sequence
@@ -42,11 +43,14 @@ logger = logging.getLogger(__name__)
 CYTHON_NUMERIC_TYPES = {"bint", "double", "Py_ssize_t"}
 _CALL_BUILTINS = {"bool", "enumerate", "float", "isinstance", "len", "range"}
 _SMALL_INT_LITERAL_ABS_LIMIT = 1_000_000
+_PY_SSIZE_MIN = -sys.maxsize - 1
+_PY_SSIZE_MAX = sys.maxsize
 _CYTHON_LOCALS_TYPE_MAP = {
     "Py_ssize_t": "cython.Py_ssize_t",
     "bint": "cython.bint",
     "double": "cython.double",
 }
+_STATIC_INT_UNKNOWN = object()
 
 
 @dataclass(frozen=True)
@@ -135,6 +139,47 @@ def _is_small_int_literal(node: ast.AST) -> bool:
     if isinstance(node, ast.UnaryOp) and isinstance(node.op, (ast.UAdd, ast.USub)):
         return _is_small_int_literal(node.operand)
     return False
+
+
+def _static_int_value(node: ast.AST) -> int | object:
+    if isinstance(node, ast.Constant):
+        if isinstance(node.value, int) and not isinstance(node.value, bool):
+            return node.value
+        return _STATIC_INT_UNKNOWN
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.UAdd):
+        return _static_int_value(node.operand)
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
+        value = _static_int_value(node.operand)
+        return -value if isinstance(value, int) else _STATIC_INT_UNKNOWN
+    if not isinstance(node, ast.BinOp):
+        return _STATIC_INT_UNKNOWN
+
+    left = _static_int_value(node.left)
+    right = _static_int_value(node.right)
+    if not isinstance(left, int) or not isinstance(right, int):
+        return _STATIC_INT_UNKNOWN
+    try:
+        if isinstance(node.op, ast.Add):
+            return left + right
+        if isinstance(node.op, ast.Sub):
+            return left - right
+        if isinstance(node.op, ast.Mult):
+            return left * right
+        if isinstance(node.op, ast.FloorDiv) and right != 0:
+            return left // right
+        if isinstance(node.op, ast.Mod) and right != 0:
+            return left % right
+        if isinstance(node.op, ast.Pow) and right >= 0:
+            if abs(left) > 1 and right > _PY_SSIZE_MAX.bit_length():
+                return _PY_SSIZE_MAX + 1
+            return left**right
+    except ArithmeticError:
+        return _STATIC_INT_UNKNOWN
+    return _STATIC_INT_UNKNOWN
+
+
+def _fits_py_ssize_t(value: int) -> bool:
+    return _PY_SSIZE_MIN <= value <= _PY_SSIZE_MAX
 
 
 def _numeric_operand_type(
@@ -305,6 +350,26 @@ def _is_range_call(node: ast.AST, *, shadowed_builtins: set[str]) -> bool:
         and _call_name(node.func) == "range"
         and "range" not in shadowed_builtins
     )
+
+
+def _range_loop_index_candidate(
+    node: ast.AST,
+    *,
+    shadowed_builtins: set[str],
+) -> tuple[bool, str] | None:
+    if not _is_range_call(node, shadowed_builtins=shadowed_builtins):
+        return None
+    if not isinstance(node, ast.Call):
+        return None
+    if node.keywords:
+        return (False, "range() call uses keyword arguments")
+    if len(node.args) not in {1, 2, 3}:
+        return (False, "range() argument count is invalid")
+    for argument in node.args:
+        value = _static_int_value(argument)
+        if isinstance(value, int) and not _fits_py_ssize_t(value):
+            return (False, "range() bound exceeds Py_ssize_t")
+    return (True, "range() loop index")
 
 
 def _is_safe_enumerate_call(node: ast.AST, *, shadowed_builtins: set[str]) -> bool:
@@ -580,14 +645,19 @@ class _FunctionCollector(ast.NodeVisitor):
 
     def visit_For(self, node: ast.For) -> None:
         names = _bound_names(node.target)
-        if isinstance(node.target, ast.Name) and _is_range_call(
+        range_candidate = _range_loop_index_candidate(
             node.iter,
             shadowed_builtins=self.shadowed_builtins,
-        ):
-            self._record(
-                node.target.id,
-                _Candidate("Py_ssize_t", node.lineno, "range() loop index"),
-            )
+        )
+        if isinstance(node.target, ast.Name) and range_candidate is not None:
+            is_safe_range_index, reason = range_candidate
+            if is_safe_range_index:
+                self._record(
+                    node.target.id,
+                    _Candidate("Py_ssize_t", node.lineno, reason),
+                )
+            else:
+                self._block(node.target.id, line=node.lineno, reason=reason)
         elif (
             isinstance(node.target, (ast.Tuple, ast.List))
             and len(node.target.elts) == 2

--- a/src/agilab/core/test/test_agi_dispatcher_scripts.py
+++ b/src/agilab/core/test/test_agi_dispatcher_scripts.py
@@ -365,6 +365,11 @@ def shadowed(values):
         pass
     return i
 
+def too_wide():
+    for i in range(10**20):
+        break
+    return i
+
 def numeric(values, other):
     offset = len(values) - 1
     scaled = len(values) * 8
@@ -384,6 +389,13 @@ def numeric(values, other):
 
     assert ("shadowed", "i", "Py_ssize_t") not in typed
     assert ("shadowed", "i") in skipped
+    assert ("too_wide", "i", "Py_ssize_t") not in typed
+    assert ("too_wide", "i") in skipped
+    assert {
+        item.reason
+        for item in preview.skipped
+        if item.function == "too_wide" and item.name == "i"
+    } == {"range() bound exceeds Py_ssize_t"}
     assert ("numeric", "offset", "Py_ssize_t") in typed
     assert ("numeric", "scaled", "Py_ssize_t") in typed
     assert ("numeric", "truth", "bint") in typed

--- a/src/agilab/core/test/test_base_worker_runtime_support.py
+++ b/src/agilab/core/test/test_base_worker_runtime_support.py
@@ -197,6 +197,70 @@ def test_baseworker_runtime_wrapper_loading_and_logging(monkeypatch):
     assert ("demo_worker_cy", "TargetWorker") in loaded_calls
 
 
+def test_load_worker_cython_failure_has_actionable_recovery(tmp_path):
+    env = SimpleNamespace(
+        target_worker="demo_worker",
+        target_worker_class="TargetWorker",
+        wenv_abs=tmp_path / "demo_worker",
+    )
+
+    def _missing_module(module_name, module_class):
+        assert (module_name, module_class) == ("demo_worker_cy", "TargetWorker")
+        raise ModuleNotFoundError("module demo_worker_cy is not installed")
+
+    with pytest.raises(ModuleNotFoundError) as exc_info:
+        runtime_support.load_worker(
+            env,
+            2,
+            load_module_fn=_missing_module,
+            sys_modules={},
+        )
+
+    message = str(exc_info.value)
+    assert "Cython mode requested for worker 'demo_worker'" in message
+    assert "compiled module 'demo_worker_cy' is not importable" in message
+    assert str(tmp_path / "demo_worker" / "dist") in message
+    assert "install.py --with-cython" in message
+    assert "[tool.agilab.cython].enabled = true" in message
+    assert "--no-cython" in message
+    assert "mode without bit 2" in message
+    assert exc_info.value.__cause__ is not None
+
+
+def test_load_worker_evicts_selected_worker_module_before_import():
+    env = SimpleNamespace(
+        target_worker="demo_worker",
+        target_worker_class="TargetWorker",
+    )
+    sys_modules = {
+        "demo_worker.demo_worker": object(),
+        "demo_worker_cy": object(),
+    }
+    loaded: list[str] = []
+
+    def _load(module_name, _module_class):
+        loaded.append(module_name)
+        return module_name
+
+    assert runtime_support.load_worker(
+        env,
+        0,
+        load_module_fn=_load,
+        sys_modules=sys_modules,
+    ) == "demo_worker.demo_worker"
+    assert "demo_worker.demo_worker" not in sys_modules
+    assert "demo_worker_cy" in sys_modules
+
+    assert runtime_support.load_worker(
+        env,
+        2,
+        load_module_fn=_load,
+        sys_modules=sys_modules,
+    ) == "demo_worker_cy"
+    assert "demo_worker_cy" not in sys_modules
+    assert loaded == ["demo_worker.demo_worker", "demo_worker_cy"]
+
+
 def test_baseworker_runtime_wrappers_delegate(monkeypatch, tmp_path):
     calls: dict[str, object] = {}
 

--- a/src/agilab/core/test/test_cython_type_preprocess_compile.py
+++ b/src/agilab/core/test/test_cython_type_preprocess_compile.py
@@ -192,10 +192,6 @@ CASES = (
             "    return i\n"
         ),
         entry="run",
-        pending=(
-            "plan item 14: range() bounds beyond Py_ssize_t must not type the "
-            "loop index"
-        ),
     ),
     Case(
         name="deleted_name",


### PR DESCRIPTION
## Summary

- add actionable Cython worker import errors in the real runtime load path
- evict the selected Python or `_cy` worker module before import so rebuilds do not reuse stale modules
- block preprocessor `range()` loop-index typing when a statically known bound exceeds `Py_ssize_t`
- promote the huge-int range compile-gate case from pending to enforced

## Validation

- `python3 -m py_compile src/agilab/core/agi-node/src/agi_node/agi_dispatcher/base_worker_runtime_support.py src/agilab/core/agi-node/src/agi_node/agi_dispatcher/cython_type_preprocess.py src/agilab/core/test/test_base_worker_runtime_support.py src/agilab/core/test/test_agi_dispatcher_scripts.py src/agilab/core/test/test_cython_type_preprocess_compile.py`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' --import-mode=importlib src/agilab/core/test/test_base_worker_runtime_support.py src/agilab/core/test/test_base_worker_execution_support.py src/agilab/core/test/test_agi_dispatcher_scripts.py -k 'cython_type_preprocess or pre_install_prepare_for_cython or baseworker_runtime or load_worker' test/test_cython_type_preprocess_preview.py src/agilab/core/test/test_cython_type_preprocess_compile.py`
- `git diff --check`
