### PR TITLE
Document view page naming convention

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 276,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "8ac5b19e035966218382aba1837725e37ff7f438fabcffa51de5025a6306a493",
+  "source_digest_sha256": "dbde6434e1e17761a13861a0794d2dd2a060ef0ad81cf410292a60faaa225695",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "8ac5b19e035966218382aba1837725e37ff7f438fabcffa51de5025a6306a493"
+  "target_digest_sha256": "dbde6434e1e17761a13861a0794d2dd2a060ef0ad81cf410292a60faaa225695"
 }

--- a/docs/source/apps-pages-gallery.rst
+++ b/docs/source/apps-pages-gallery.rst
@@ -9,18 +9,18 @@ chrome.
 .. list-table::
    :widths: 34 66
 
-   * - .. image:: _static/apps-pages-gallery/view_app_ui.svg
-          :alt: view_app_ui preview
+   * - .. image:: _static/apps-pages-gallery/app_ui.svg
+          :alt: app_ui preview
           :width: 260px
-     - **view_app_ui**
+     - **app_ui**
 
        Launches app-owned interactive Streamlit surfaces from ANALYSIS.
 
        When to use: Use when the app owns live controls, training loops, or a custom UI that should stay outside generic page bundles.
-   * - .. image:: _static/apps-pages-gallery/view_autoencoder_latentspace.svg
-          :alt: view_autoencoder_latentspace preview
+   * - .. image:: _static/apps-pages-gallery/autoencoder_latentspace.svg
+          :alt: autoencoder_latentspace preview
           :width: 260px
-     - **view_autoencoder_latentspace**
+     - **autoencoder_latentspace**
 
        Opt-in playground exception for TensorFlow/Keras latent projections and
        reconstruction behavior.

--- a/docs/source/apps-pages.rst
+++ b/docs/source/apps-pages.rst
@@ -14,6 +14,11 @@ Page bundles are standalone dashboards that complement the built-in workflow
 pages. In the UI they appear alongside the main pages, but they run in their
 own sidecar web process.
 
+Naming convention:
+
+- ``view_*`` page bundles are the generic app-agnostic sidecars.
+- ``app_ui`` and ``autoencoder_latentspace`` are visible exceptions with their own names because they are not generic sidecars.
+
 Looking for the PyTorch playground, live play/pause training, or loss landscape?
 Use the built-in ``pytorch_playground_project`` app or launch it directly with
 ``agilab pytorch-playground``. It is a reproducible app project, not a generic
@@ -142,7 +147,7 @@ pulled by the umbrella dependency graph.
      - Package
      - Purpose
      - Packaging status
-   * - ``view_autoencoder_latentspace``
+   * - ``autoencoder_latentspace``
      - ``agi-page-latent-space``
      - Opt-in TensorFlow/Keras latent-space playground that trains a small
        autoencoder in-page.
@@ -169,7 +174,7 @@ pulled by the umbrella dependency graph.
      - ``agi-page-live-artifacts``
      - Dynamic artifact, manifest, evidence, and log monitor for active apps.
      - Included in ``agi-pages``.
-   * - ``view_app_ui``
+   * - ``app_ui``
      - ``agi-page-app-ui``
      - Bridge that displays an app-owned Streamlit UI from ANALYSIS.
      - Included in ``agi-pages``.

--- a/src/agilab/apps-pages/README.md
+++ b/src/agilab/apps-pages/README.md
@@ -5,9 +5,14 @@ active app and its exported datasets.
 
 Page projects depend on `agi-gui`, the shared UI package under `src/agilab/lib/agi-gui`.
 
+Naming convention:
+
+- `view_*` page bundles are the generic app-agnostic sidecars.
+- `app_ui` and `autoencoder_latentspace` are visible exceptions with their own names because they are not generic sidecars.
+
 Looking for the PyTorch playground or loss landscape? Use the built-in
 `pytorch_playground_project`. It is a reproducible app project, not a generic
-app-agnostic analysis page. The generic `view_app_ui` bridge lets ANALYSIS
+app-agnostic analysis page. The generic `app_ui` bridge lets ANALYSIS
 display the app-owned playground UI without moving training logic into
 apps-pages.
 
@@ -17,7 +22,7 @@ Every shipped view bundle has a local README, a source-controlled preview, direc
 
 | View | View |
 |---|---|
-| [![view_app_ui preview](../../../docs/source/_static/apps-pages-gallery/view_app_ui.svg)](view_app_ui)<br>**view_app_ui**<br>Launches app-owned interactive Streamlit surfaces from ANALYSIS. | [![view_autoencoder_latentspace preview](../../../docs/source/_static/apps-pages-gallery/view_autoencoder_latentspace.svg)](view_autoencoder_latentspace)<br>**view_autoencoder_latentspace**<br>Opt-in playground exception for TensorFlow/Keras latent projections; it trains a small autoencoder in-page and is not a generic app-agnostic sidecar. |
+| [![app_ui preview](../../../docs/source/_static/apps-pages-gallery/app_ui.svg)](app_ui)<br>**app_ui**<br>Launches app-owned interactive Streamlit surfaces from ANALYSIS. | [![autoencoder_latentspace preview](../../../docs/source/_static/apps-pages-gallery/autoencoder_latentspace.svg)](autoencoder_latentspace)<br>**autoencoder_latentspace**<br>Opt-in playground exception for TensorFlow/Keras latent projections; it trains a small autoencoder in-page and is not a generic app-agnostic sidecar. |
 | [![view_barycentric preview](../../../docs/source/_static/apps-pages-gallery/view_barycentric.svg)](view_barycentric)<br>**view_barycentric**<br>Plots proportion-style KPI features on a barycentric/simplex surface. | [![view_data_io_decision preview](../../../docs/source/_static/apps-pages-gallery/view_data_io_decision.svg)](view_data_io_decision)<br>**view_data_io_decision**<br>Reviews data-ingestion and strategy-selection evidence. |
 | [![view_forecast_analysis preview](../../../docs/source/_static/apps-pages-gallery/view_forecast_analysis.svg)](view_forecast_analysis)<br>**view_forecast_analysis**<br>Reviews forecast metrics and prediction tables for time-series workflows. | [![view_inference_analysis preview](../../../docs/source/_static/apps-pages-gallery/view_inference_analysis.svg)](view_inference_analysis)<br>**view_inference_analysis**<br>Compares allocation and inference-result metrics across exported runs. |
 | [![view_live_artifacts preview](../../../docs/source/_static/apps-pages-gallery/view_live_artifacts.svg)](view_live_artifacts)<br>**view_live_artifacts**<br>Watches exported evidence, manifests, logs, text, CSVs, and images while a run is active. | [![view_maps preview](../../../docs/source/_static/apps-pages-gallery/view_maps.svg)](view_maps)<br>**view_maps**<br>Explores geolocated datasets with map, sampling, palette, and basemap controls. |

--- a/test/test_apps_pages_docs.py
+++ b/test/test_apps_pages_docs.py
@@ -75,6 +75,17 @@ def test_autoencoder_latentspace_is_marked_as_opt_in_playground_exception() -> N
         assert "in-page" in text.lower()
 
 
+def test_view_prefix_remains_the_generic_page_family() -> None:
+    docs = (DOCS_SOURCE / "apps-pages.rst").read_text(encoding="utf-8")
+    readme = (APPS_PAGES_ROOT / "README.md").read_text(encoding="utf-8")
+
+    for text in (docs, readme):
+        assert "view_*" in text
+        assert "generic app-agnostic sidecars" in text
+        assert "app_ui" in text
+        assert "autoencoder_latentspace" in text
+
+
 def test_barycentric_dataframe_selector_avoids_session_state_double_init() -> None:
     source = (
         APPS_PAGES_ROOT


### PR DESCRIPTION
Docs-only update that states the AGILab page naming convention: `view_*` pages are the generic app-agnostic sidecars, while `app_ui` and `autoencoder_latentspace` are explicit exceptions. Includes a small regression in test/test_apps_pages_docs.py and a synced docs mirror stamp.