### PR TITLE
test: guard restricted analysis view selection

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 276,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "585e86e2e42e93c5797d8c50767d2887452ae619a18a410a1d958774c2aaf0c4",
+  "source_digest_sha256": "7eb20ff9867ebb8ae8fb8625a14d4e37b1e537e85398e614086edede9d58319d",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "585e86e2e42e93c5797d8c50767d2887452ae619a18a410a1d958774c2aaf0c4"
+  "target_digest_sha256": "7eb20ff9867ebb8ae8fb8625a14d4e37b1e537e85398e614086edede9d58319d"
 }

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -36,7 +36,7 @@ branching into cluster mode, external app repositories, or broader workflows.
 
 For release-level evidence, use :doc:`release-proof`; it points to the
 `latest public GitHub release
-<https://github.com/ThalesGroup/agilab/releases/tag/v2026.06.08>`__,
+<https://github.com/ThalesGroup/agilab/releases/tag/v2026.06.12>`__,
 package proof, CI guardrails, and hosted demo status.
 
 This documentation then expands into architecture, service mode, API

--- a/test/test_analysis_page_helpers.py
+++ b/test/test_analysis_page_helpers.py
@@ -1648,6 +1648,32 @@ def test_analysis_page_state_restricts_to_configured_normalized_views(tmp_path: 
     assert state.config_view_module == ("view_maps", "view_maps_network")
 
 
+def test_analysis_page_state_restricted_views_ignore_stale_session_selection(tmp_path: Path):
+    state_module = _load_analysis_state_module()
+    app_ui = tmp_path / "app_ui.py"
+    training = tmp_path / "view_training_analysis.py"
+
+    state = state_module.build_analysis_view_selection_state(
+        pages_cfg={
+            "restrict_to_view_module": True,
+            "default_view": "app_ui",
+        },
+        current_page=None,
+        configured_views=["app_ui"],
+        resolved_pages={
+            "app_ui": app_ui,
+            "view_training_analysis": training,
+        },
+        custom_view_lookup={},
+        session_selection=["view_training_analysis"],
+        has_session_selection=True,
+    )
+
+    assert state.view_names == ("app_ui",)
+    assert state.widget_selection == ("app_ui",)
+    assert state.config_view_module == ("app_ui",)
+
+
 def test_analysis_page_state_falls_back_to_all_views_when_restrict_config_is_empty(tmp_path: Path):
     state_module = _load_analysis_state_module()
     view_maps = tmp_path / "view_maps.py"


### PR DESCRIPTION
## Summary
- add a regression proving restricted ANALYSIS view configuration ignores stale session selections
- update the public docs index to point at the current live GitHub release `v2026.06.12`
- refresh the docs mirror stamp from the canonical docs source

## Root Cause
The restricted-view implementation is already fixed on `origin/main`, but the regression was missing. The public docs index still linked older release evidence and needed to align with the live release surface.

## Validation
- `./dev test test/test_analysis_page_helpers.py -k 'analysis_page_state_restricted_views_ignore_stale_session_selection or analysis_page_state_restricts_to_configured_normalized_views or analysis_page_state_sanitizes_stale_session_selection_before_widget'`
- `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp`
- `uv --preview-features extra-build-dependencies run python tools/release_proof_report.py --render --check --compact`
- `git diff --check`
