### PR TITLE
release: prepare 2026.06.13.1 hotfix

### DIFF
--- a/badges/coverage-agi-core.svg
+++ b/badges/coverage-agi-core.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="160" height="20" role="img" aria-label="agi-core coverage: 97%">
+<svg xmlns="http://www.w3.org/2000/svg" width="160" height="20" role="img" aria-label="agi-core coverage: 95%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="64.5" y="15" fill="#010101" fill-opacity=".3">agi-core coverage</text>
   <text x="64.5" y="14">agi-core coverage</text>
-  <text x="144.5" y="15" fill="#010101" fill-opacity=".3">97%</text>
-  <text x="144.5" y="14">97%</text>
+  <text x="144.5" y="15" fill="#010101" fill-opacity=".3">95%</text>
+  <text x="144.5" y="14">95%</text>
 </g>
 </svg>

--- a/badges/coverage-agi-env.svg
+++ b/badges/coverage-agi-env.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="153" height="20" role="img" aria-label="agi-env coverage: 97%">
+<svg xmlns="http://www.w3.org/2000/svg" width="153" height="20" role="img" aria-label="agi-env coverage: 95%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="61.0" y="15" fill="#010101" fill-opacity=".3">agi-env coverage</text>
   <text x="61.0" y="14">agi-env coverage</text>
-  <text x="137.5" y="15" fill="#010101" fill-opacity=".3">97%</text>
-  <text x="137.5" y="14">97%</text>
+  <text x="137.5" y="15" fill="#010101" fill-opacity=".3">95%</text>
+  <text x="137.5" y="14">95%</text>
 </g>
 </svg>

--- a/badges/coverage-agi-node.svg
+++ b/badges/coverage-agi-node.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="160" height="20" role="img" aria-label="agi-node coverage: 97%">
+<svg xmlns="http://www.w3.org/2000/svg" width="160" height="20" role="img" aria-label="agi-node coverage: 96%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="64.5" y="15" fill="#010101" fill-opacity=".3">agi-node coverage</text>
   <text x="64.5" y="14">agi-node coverage</text>
-  <text x="144.5" y="15" fill="#010101" fill-opacity=".3">97%</text>
-  <text x="144.5" y="14">97%</text>
+  <text x="144.5" y="15" fill="#010101" fill-opacity=".3">96%</text>
+  <text x="144.5" y="14">96%</text>
 </g>
 </svg>

--- a/badges/coverage-agi-node.svg
+++ b/badges/coverage-agi-node.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="160" height="20" role="img" aria-label="agi-node coverage: 99%">
+<svg xmlns="http://www.w3.org/2000/svg" width="160" height="20" role="img" aria-label="agi-node coverage: 97%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="64.5" y="15" fill="#010101" fill-opacity=".3">agi-node coverage</text>
   <text x="64.5" y="14">agi-node coverage</text>
-  <text x="144.5" y="15" fill="#010101" fill-opacity=".3">99%</text>
-  <text x="144.5" y="14">99%</text>
+  <text x="144.5" y="15" fill="#010101" fill-opacity=".3">97%</text>
+  <text x="144.5" y="14">97%</text>
 </g>
 </svg>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ agilab-mcp = "agilab_mcp.server:main"
 [project.optional-dependencies]
 ai = ["openai>=2.32.0,<3"]
 core = ["agi-core==2026.06.12"]
-ui = ["agi-apps==2026.06.12", "agi-pages==2026.06.12", "agi-gui==2026.06.12", "agi-web==2026.06.12", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "streamlit>=1.58,<2", "starlette>=1.0.1,<2", "tomli_w>=1.2.0,<2"]
+ui = ["agi-apps==2026.06.12", "agi-pages==2026.06.12", "agi-gui==2026.06.12", "agi-web==2026.06.12", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "streamlit>=1.57,<1.58", "starlette>=1.0.1,<2", "tomli_w>=1.2.0,<2"]
 viz = ["matplotlib>=3.10.0,<4", "plotly>=6.7.0,<7"]
 mlflow = ["mlflow>=3.11.1,<4", "idna>=3.15,<4", "starlette>=1.0.1,<2"]
 bridges = ["duckdb>=1.4.0,<2"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.12"
+version = "2026.06.13.1"
 name = "agilab"
 description = "AGILAB is a reproducible AI/ML workbench for engineering teams."
 requires-python = ">=3.11,<3.14"
@@ -60,14 +60,14 @@ agilab-mcp = "agilab_mcp.server:main"
 
 [project.optional-dependencies]
 ai = ["openai>=2.32.0,<3"]
-core = ["agi-core==2026.06.12"]
-ui = ["agi-apps==2026.06.12", "agi-pages==2026.06.12", "agi-gui==2026.06.12", "agi-web==2026.06.12", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "streamlit>=1.57,<1.58", "starlette>=1.0.1,<2", "tomli_w>=1.2.0,<2"]
+core = ["agi-core==2026.06.13.1"]
+ui = ["agi-apps==2026.06.13.1", "agi-pages==2026.06.13.1", "agi-gui==2026.06.13.1", "agi-web==2026.06.13.1", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "streamlit>=1.57,<1.58", "starlette>=1.0.1,<2", "tomli_w>=1.2.0,<2"]
 viz = ["matplotlib>=3.10.0,<4", "plotly>=6.7.0,<7"]
 mlflow = ["mlflow>=3.11.1,<4", "idna>=3.15,<4", "starlette>=1.0.1,<2"]
 bridges = ["duckdb>=1.4.0,<2"]
 notebook = ["ipykernel>=6.29.0,<8", "nbclient>=0.10.0,<1", "nbformat>=5.10.0,<6"]
-examples = ["agi-apps==2026.06.12", "jupyterlab>=4.4.0,<5", "matplotlib>=3.10.0,<4", "plotly>=6.7.0,<7", "starlette>=1.0.1,<2"]
-pages = ["agi-pages==2026.06.12", "starlette>=1.0.1,<2"]
+examples = ["agi-apps==2026.06.13.1", "jupyterlab>=4.4.0,<5", "matplotlib>=3.10.0,<4", "plotly>=6.7.0,<7", "starlette>=1.0.1,<2"]
+pages = ["agi-pages==2026.06.13.1", "starlette>=1.0.1,<2"]
 proof = ["cryptography>=46.0.0,<49"]
 agents = ["openai>=2.32.0,<3"]
 local-llm = ["accelerate>=0.34.2,<2; python_version >= '3.12'", "fastapi>=0.124.4,!=0.136.3,<1; python_version >= '3.12'", "gpt-oss>=0.0.8,<0.1; python_version >= '3.12'", "langchain-core>=1.3.3,<2; python_version >= '3.12'", "langsmith>=0.8.0,<1; python_version >= '3.12'", "mlx>=0.31.2,<0.32; sys_platform == 'darwin' and platform_machine == 'arm64'", "mlx-lm>=0.31.3,<0.32; sys_platform == 'darwin' and platform_machine == 'arm64'", "mlx-vlm>=0.5.0,<0.6; sys_platform == 'darwin' and platform_machine == 'arm64'", "requests>=2.32.0,<3; python_version >= '3.12'", "starlette>=1.0.1,<2; python_version >= '3.12'", "torch>=2.8.0,<3; python_version >= '3.12'", "transformers>=4.57.0,<6; python_version >= '3.12'", "universal-offline-ai-chatbot>=0.1.0,<0.2; python_version >= '3.12'"]

--- a/src/agilab/apps-pages/templates/analysis_page_template/pyproject.toml
+++ b/src/agilab/apps-pages/templates/analysis_page_template/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.11"
 dependencies = [
     "agi-env>=2026.05.18,<2027.0",
     "agi-node>=2026.05.18,<2027.0",
-    "streamlit>=1.58,<2",
+    "streamlit>=1.57,<1.58",
 ]
 
 [build-system]

--- a/src/agilab/apps-pages/view_barycentric/pyproject.toml
+++ b/src/agilab/apps-pages/view_barycentric/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-simplex-map"
-version = "2026.06.12"
+version = "2026.06.13.1"
 description = "AGILAB page bundle for simplex projection and barycentric analysis."
 readme = { text = "AGILAB page bundle for simplex projection and barycentric analysis.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_live_artifacts/pyproject.toml
+++ b/src/agilab/apps-pages/view_live_artifacts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-live-artifacts"
-version = "2026.06.12"
+version = "2026.06.13.1"
 description = "AGILAB page bundle for live artifact and evidence monitoring."
 readme = { text = "AGILAB page bundle for live artifact and evidence monitoring.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_maps_3d/pyproject.toml
+++ b/src/agilab/apps-pages/view_maps_3d/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-geospatial-3d"
-version = "2026.06.12"
+version = "2026.06.13.1"
 description = "AGILAB page bundle for 3D geospatial exploration."
 readme = { text = "AGILAB page bundle for 3D geospatial exploration.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_maps_network/pyproject.toml
+++ b/src/agilab/apps-pages/view_maps_network/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-network-map"
-version = "2026.06.12"
+version = "2026.06.13.1"
 description = "AGILAB page bundle for network-aware geospatial analysis."
 readme = { text = "AGILAB page bundle for network-aware geospatial analysis.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_routing_model_comparison/pyproject.toml
+++ b/src/agilab/apps-pages/view_routing_model_comparison/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-routing-model-comparison"
-version = "2026.06.12"
+version = "2026.06.13.1"
 description = "AGILAB page bundle for comparing routing model allocation decisions."
 readme = { text = "AGILAB page bundle for comparing routing model allocation decisions.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_training_analysis/pyproject.toml
+++ b/src/agilab/apps-pages/view_training_analysis/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-training-report"
-version = "2026.06.12"
+version = "2026.06.13.1"
 description = "AGILAB page bundle for training run reporting."
 readme = { text = "AGILAB page bundle for training run reporting.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps/builtin/data_quality_gate_project/pyproject.toml
+++ b/src/agilab/apps/builtin/data_quality_gate_project/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.11"
 authors = [
     { name = "Jean-Pierre Morard" }
 ]
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "streamlit>=1.58,<2"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "streamlit>=1.57,<1.58"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/apps/builtin/execution_pandas_project/pyproject.toml
+++ b/src/agilab/apps/builtin/execution_pandas_project/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.11"
 authors = [
     { name = "Jean-Pierre Morard" }
 ]
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "numpy>=2.2,<3", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "streamlit>=1.58,<2"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "numpy>=2.2,<3", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "streamlit>=1.57,<1.58"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/apps/builtin/execution_polars_project/pyproject.toml
+++ b/src/agilab/apps/builtin/execution_polars_project/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.11"
 authors = [
     { name = "Jean-Pierre Morard" }
 ]
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "polars>=1.35,<2", "pydantic>=2.11,<2.13", "streamlit>=1.58,<2"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "polars>=1.35,<2", "pydantic>=2.11,<2.13", "streamlit>=1.57,<1.58"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/apps/builtin/flight_telemetry_project/pyproject.toml
+++ b/src/agilab/apps/builtin/flight_telemetry_project/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.11"
 authors = [
     { name = "Jean-Pierre Morard" }
 ]
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "polars[rtcompat]>=1.35,<2", "pydantic>=2.11,<2.13", "py7zr>=1.1,<1.2", "streamlit>=1.58,<2"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "polars[rtcompat]>=1.35,<2", "pydantic>=2.11,<2.13", "py7zr>=1.1,<1.2", "streamlit>=1.57,<1.58"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/apps/builtin/minimal_app_project/pyproject.toml
+++ b/src/agilab/apps/builtin/minimal_app_project/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.11"
 authors = [
     { name = "Jean-Pierre Morard" }
 ]
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "polars>=1.35,<2", "pydantic>=2.11,<2.13", "streamlit>=1.58,<2"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "polars>=1.35,<2", "pydantic>=2.11,<2.13", "streamlit>=1.57,<1.58"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/apps/builtin/mission_decision_project/pyproject.toml
+++ b/src/agilab/apps/builtin/mission_decision_project/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.11"
 authors = [
     { name = "Jean-Pierre Morard" }
 ]
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "streamlit>=1.58,<2"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "streamlit>=1.57,<1.58"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/apps/builtin/multi_app_dag_project/pyproject.toml
+++ b/src/agilab/apps/builtin/multi_app_dag_project/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.11"
 authors = [
     { name = "Jean-Pierre Morard" }
 ]
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "polars>=1.35,<2", "pydantic>=2.11,<2.13", "streamlit>=1.58,<2"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "polars>=1.35,<2", "pydantic>=2.11,<2.13", "streamlit>=1.57,<1.58"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/apps/builtin/pytorch_playground_project/pyproject.toml
+++ b/src/agilab/apps/builtin/pytorch_playground_project/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "pandas>=2.3.0,<4",
     "plotly>=6.3.0,<7",
     "pydantic>=2.11,<2.13",
-    "streamlit>=1.58,<2",
+    "streamlit>=1.57,<1.58",
     "torch>=2.8.0,<3",
 ]
 

--- a/src/agilab/apps/builtin/r_runtime_bridge_project/pyproject.toml
+++ b/src/agilab/apps/builtin/r_runtime_bridge_project/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.11"
 authors = [
     { name = "Jean-Pierre Morard" }
 ]
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "streamlit>=1.58,<2"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "streamlit>=1.57,<1.58"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/apps/builtin/sklearn_pipeline_project/pyproject.toml
+++ b/src/agilab/apps/builtin/sklearn_pipeline_project/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.11"
 authors = [
     { name = "Jean-Pierre Morard" }
 ]
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "joblib>=1.5,<2", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "scikit-learn>=1.7.2,<2", "streamlit>=1.58,<2"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "joblib>=1.5,<2", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "scikit-learn>=1.7.2,<2", "streamlit>=1.57,<1.58"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/apps/builtin/tescia_diagnostic_project/pyproject.toml
+++ b/src/agilab/apps/builtin/tescia_diagnostic_project/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.13"
 authors = [
     { name = "Jean-Pierre Morard" }
 ]
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "streamlit>=1.58,<2"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "streamlit>=1.57,<1.58"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/apps/builtin/uav_queue_project/pyproject.toml
+++ b/src/agilab/apps/builtin/uav_queue_project/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.13"
 authors = [
     { name = "Jean-Pierre Morard" }
 ]
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "simpy>=4.1,<5", "streamlit>=1.58,<2"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "simpy>=4.1,<5", "streamlit>=1.57,<1.58"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/apps/builtin/uav_relay_queue_project/pyproject.toml
+++ b/src/agilab/apps/builtin/uav_relay_queue_project/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.13"
 authors = [
     { name = "Jean-Pierre Morard" }
 ]
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "simpy>=4.1,<5", "streamlit>=1.58,<2"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "simpy>=4.1,<5", "streamlit>=1.57,<1.58"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/apps/builtin/weather_forecast_legacy_project/pyproject.toml
+++ b/src/agilab/apps/builtin/weather_forecast_legacy_project/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.13"
 authors = [
     { name = "Jean-Pierre Morard" }
 ]
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "scikit-learn>=1.7.2,<2", "skforecast>=0.19,<0.20", "streamlit>=1.58,<2"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "scikit-learn>=1.7.2,<2", "skforecast>=0.19,<0.20", "streamlit>=1.57,<1.58"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/apps/builtin/weather_forecast_project/pyproject.toml
+++ b/src/agilab/apps/builtin/weather_forecast_project/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.11"
 authors = [
     { name = "Jean-Pierre Morard" }
 ]
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "scikit-learn>=1.7.2,<2", "skforecast>=0.19,<0.20", "streamlit>=1.58,<2"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "scikit-learn>=1.7.2,<2", "skforecast>=0.19,<0.20", "streamlit>=1.57,<1.58"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/apps/templates/dag_app_template/pyproject.toml
+++ b/src/agilab/apps/templates/dag_app_template/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "agi-env>=2026.05.25,<2027.0",
     "agi-node>=2026.05.25,<2027.0",
     "pydantic>=2.11,<2.13",
-    "streamlit>=1.58,<2",
+    "streamlit>=1.57,<1.58",
 ]
 
 [dependency-groups]

--- a/src/agilab/apps/templates/fireducks_app_template/pyproject.toml
+++ b/src/agilab/apps/templates/fireducks_app_template/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "fireducks>=1.4.4,<2",
     "pydantic>=2.11,<2.13",
     "py7zr>=1.1,<1.2",
-    "streamlit>=1.58,<2",
+    "streamlit>=1.57,<1.58",
 ]
 
 [dependency-groups]

--- a/src/agilab/apps/templates/pandas_app_template/pyproject.toml
+++ b/src/agilab/apps/templates/pandas_app_template/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "pandas>=2.3.0,<4",
     "pydantic>=2.11,<2.13",
     "py7zr>=1.1,<1.2",
-    "streamlit>=1.58,<2",
+    "streamlit>=1.57,<1.58",
 ]
 
 [dependency-groups]

--- a/src/agilab/apps/templates/polars_app_template/pyproject.toml
+++ b/src/agilab/apps/templates/polars_app_template/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "polars>=1.35,<2",
     "pydantic>=2.11,<2.13",
     "py7zr>=1.1,<1.2",
-    "streamlit>=1.58,<2",
+    "streamlit>=1.57,<1.58",
 ]
 
 [dependency-groups]

--- a/src/agilab/apps/templates/simple_app_template/pyproject.toml
+++ b/src/agilab/apps/templates/simple_app_template/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 dependencies = [
     "agi-env>=2026.05.25,<2027.0",
     "pydantic>=2.11,<2.13",
-    "streamlit>=1.58,<2",
+    "streamlit>=1.57,<1.58",
 ]
 
 [dependency-groups]

--- a/src/agilab/core/agi-cluster/pyproject.toml
+++ b/src/agilab/core/agi-cluster/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.12"
+version = "2026.06.13.1"
 name = "agi-cluster"
 description = "Distributed cluster orchestration layer for AGILAB workers over local and SSH backends"
 requires-python = ">=3.11"
@@ -35,7 +35,7 @@ keywords = [
     "job-scheduling",
     "mlops",
 ]
-dependencies = ["agi-env==2026.06.12", "agi-node==2026.06.12", "asyncssh>=2.23,<3", "dask[distributed]>=2026.3,<2027.0", "humanize>=4.10,<5", "numpy>=2.2,<3", "packaging>=25,<27", "polars>=1.35,<2", "psutil>=7,<8", "scikit-learn>=1.7.2,<2", "tomlkit>=0.13,<1"]
+dependencies = ["agi-env==2026.06.13.1", "agi-node==2026.06.13.1", "asyncssh>=2.23,<3", "dask[distributed]>=2026.3,<2027.0", "humanize>=4.10,<5", "numpy>=2.2,<3", "packaging>=25,<27", "polars>=1.35,<2", "psutil>=7,<8", "scikit-learn>=1.7.2,<2", "tomlkit>=0.13,<1"]
 
 [project.entry-points."agi_env.runtime_packages"]
 agi-cluster = "agi_cluster.agi_env_runtime:RUNTIME_PACKAGE_SPEC"

--- a/src/agilab/core/agi-core/pyproject.toml
+++ b/src/agilab/core/agi-core/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.12"
+version = "2026.06.13.1"
 name = "agi-core"
 description = "Meta-package that installs and wires agi-env, agi-node, and agi-cluster together"
 readme = "README.md"
@@ -30,7 +30,7 @@ keywords = [
   "distributed-computing",
   "distributed-execution",
 ]
-dependencies = ["agi-env==2026.06.12", "agi-node==2026.06.12", "agi-cluster==2026.06.12"]
+dependencies = ["agi-env==2026.06.13.1", "agi-node==2026.06.13.1", "agi-cluster==2026.06.13.1"]
 
 [project.entry-points."agi_env.runtime_packages"]
 agi-core = "agi_core.agi_env_runtime:RUNTIME_PACKAGE_SPEC"

--- a/src/agilab/core/agi-env/pyproject.toml
+++ b/src/agilab/core/agi-env/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.12"
+version = "2026.06.13.1"
 name = "agi-env"
 description = "Environment bootstrap package for AGILAB with virtualenv, path, and runtime helpers"
 requires-python = ">=3.11"

--- a/src/agilab/core/agi-env/test/test_optional_ui_split.py
+++ b/src/agilab/core/agi-env/test/test_optional_ui_split.py
@@ -97,8 +97,8 @@ def test_agi_gui_declares_streamlit_ui_runtime() -> None:
         if _requirement_name(dependency) == "streamlit"
     ]
     assert len(streamlit_dependencies) == 1
-    assert _requirement_has_lower_bound_at_least(streamlit_dependencies[0], "1.58")
-    assert _requirement_has_upper_bound_below(streamlit_dependencies[0], "2")
+    assert _requirement_has_lower_bound_at_least(streamlit_dependencies[0], "1.57")
+    assert _requirement_has_upper_bound_below(streamlit_dependencies[0], "1.58")
     assert "watchdog" in {_requirement_name(dependency) for dependency in dependencies}
 
 

--- a/src/agilab/core/agi-node/pyproject.toml
+++ b/src/agilab/core/agi-node/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.12"
+version = "2026.06.13.1"
 name = "agi-node"
 description = "Distributed worker orchestration and execution support library for AGILAB"
 requires-python = ">=3.11"
@@ -35,7 +35,7 @@ keywords = [
     "pandas",
     "polars",
 ]
-dependencies = ["agi-env==2026.06.12", "cython>=3.1,<4", "humanize>=4.10,<5", "numpy>=2.2,<3", "pandas>=2.3,<4", "parso>=0.8,<1", "polars>=1.35,<2", "psutil>=7,<8", "py7zr>=1.1,<1.2", "setuptools>=68,<83"]
+dependencies = ["agi-env==2026.06.13.1", "cython>=3.1,<4", "humanize>=4.10,<5", "numpy>=2.2,<3", "pandas>=2.3,<4", "parso>=0.8,<1", "polars>=1.35,<2", "psutil>=7,<8", "py7zr>=1.1,<1.2", "setuptools>=68,<83"]
 
 [project.entry-points."agi_env.runtime_packages"]
 agi-node = "agi_node.agi_env_runtime:RUNTIME_PACKAGE_SPEC"

--- a/src/agilab/lib/agi-app-flight-telemetry/pyproject.toml
+++ b/src/agilab/lib/agi-app-flight-telemetry/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.12"
+version = "2026.06.13.1"
 name = "agi-app-flight-telemetry"
 description = "AGILAB flight-telemetry ingestion demo with reusable dataframe and map-analysis outputs"
 requires-python = ">=3.11"

--- a/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/pyproject.toml
+++ b/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.11"
 authors = [
     { name = "Jean-Pierre Morard" }
 ]
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "polars[rtcompat]>=1.35,<2", "pydantic>=2.11,<2.13", "py7zr>=1.1,<1.2", "streamlit>=1.58,<2"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "polars[rtcompat]>=1.35,<2", "pydantic>=2.11,<2.13", "py7zr>=1.1,<1.2", "streamlit>=1.57,<1.58"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/lib/agi-app-mission-decision/pyproject.toml
+++ b/src/agilab/lib/agi-app-mission-decision/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.12"
+version = "2026.06.13.1"
 name = "agi-app-mission-decision"
 description = "Deterministic AGILAB mission-decision workflow with scenario scoring and evidence artifacts"
 requires-python = ">=3.11"

--- a/src/agilab/lib/agi-app-mission-decision/src/agi_app_mission_decision/project/mission_decision_project/pyproject.toml
+++ b/src/agilab/lib/agi-app-mission-decision/src/agi_app_mission_decision/project/mission_decision_project/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.11"
 authors = [
     { name = "Jean-Pierre Morard" }
 ]
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "streamlit>=1.58,<2"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "streamlit>=1.57,<1.58"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/lib/agi-app-pytorch-playground/pyproject.toml
+++ b/src/agilab/lib/agi-app-pytorch-playground/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.12"
+version = "2026.06.13.1"
 name = "agi-app-pytorch-playground"
 description = "AGILAB PyTorch playground app for reproducible neural-network experiments"
 requires-python = ">=3.12"

--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/pyproject.toml
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "pandas>=2.3.0,<4",
     "plotly>=6.3.0,<7",
     "pydantic>=2.11,<2.13",
-    "streamlit>=1.58,<2",
+    "streamlit>=1.57,<1.58",
     "torch>=2.8.0,<3",
 ]
 

--- a/src/agilab/lib/agi-app-uav-relay-queue/pyproject.toml
+++ b/src/agilab/lib/agi-app-uav-relay-queue/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.12"
+version = "2026.06.13.1"
 name = "agi-app-uav-relay-queue"
 description = "AGILAB UAV relay queue simulation demo with routing, delay, and resilience artifacts"
 requires-python = ">=3.13"

--- a/src/agilab/lib/agi-app-uav-relay-queue/src/agi_app_uav_relay_queue/project/uav_relay_queue_project/pyproject.toml
+++ b/src/agilab/lib/agi-app-uav-relay-queue/src/agi_app_uav_relay_queue/project/uav_relay_queue_project/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.13"
 authors = [
     { name = "Jean-Pierre Morard" }
 ]
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "simpy>=4.1,<5", "streamlit>=1.58,<2"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "simpy>=4.1,<5", "streamlit>=1.57,<1.58"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/lib/agi-app-weather-forecast/pyproject.toml
+++ b/src/agilab/lib/agi-app-weather-forecast/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.12"
+version = "2026.06.13.1"
 name = "agi-app-weather-forecast"
 description = "AGILAB weather-forecast notebook-migration demo with forecast analysis artifacts"
 requires-python = ">=3.11"

--- a/src/agilab/lib/agi-app-weather-forecast/src/agi_app_weather_forecast/project/weather_forecast_project/pyproject.toml
+++ b/src/agilab/lib/agi-app-weather-forecast/src/agi_app_weather_forecast/project/weather_forecast_project/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.11"
 authors = [
     { name = "Jean-Pierre Morard" }
 ]
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "scikit-learn>=1.7.2,<2", "skforecast>=0.19,<0.20", "streamlit>=1.58,<2"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.11,<2.13", "scikit-learn>=1.7.2,<2", "skforecast>=0.19,<0.20", "streamlit>=1.57,<1.58"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/lib/agi-apps/pyproject.toml
+++ b/src/agilab/lib/agi-apps/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.12"
+version = "2026.06.13.1"
 name = "agi-apps"
 description = "AGILAB public app package umbrella and example assets"
 requires-python = ">=3.11"
@@ -31,7 +31,7 @@ keywords = [
     "workflow-orchestration",
 ]
 
-dependencies = ["agi-core==2026.06.12", "agi-app-mission-decision==2026.06.12", "agi-app-pandas-execution==2026.06.04", "agi-app-polars-execution==2026.06.04", "agi-app-flight-telemetry==2026.06.12", "agi-app-multi-dag==2026.06.04", "agi-app-weather-forecast==2026.06.12", "agi-app-sklearn-pipeline==2026.06.04", "agi-app-pytorch-playground==2026.06.12; python_version >= '3.12'", "agi-app-tescia-diagnostic==2026.06.05; python_version >= '3.13'", "agi-app-uav-relay-queue==2026.06.12; python_version >= '3.13'"]
+dependencies = ["agi-core==2026.06.13.1", "agi-app-mission-decision==2026.06.13.1", "agi-app-pandas-execution==2026.06.04", "agi-app-polars-execution==2026.06.04", "agi-app-flight-telemetry==2026.06.13.1", "agi-app-multi-dag==2026.06.04", "agi-app-weather-forecast==2026.06.13.1", "agi-app-sklearn-pipeline==2026.06.04", "agi-app-pytorch-playground==2026.06.13.1; python_version >= '3.12'", "agi-app-tescia-diagnostic==2026.06.05; python_version >= '3.13'", "agi-app-uav-relay-queue==2026.06.13.1; python_version >= '3.13'"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/lib/agi-gui/pyproject.toml
+++ b/src/agilab/lib/agi-gui/pyproject.toml
@@ -32,7 +32,7 @@ keywords = [
     "python",
 ]
 
-dependencies = ["agi-env==2026.06.12", "streamlit>=1.58,<2", "starlette>=1.0.1,<2", "streamlit_code_editor>=0.1.22,<0.2", "watchdog>=6,<7"]
+dependencies = ["agi-env==2026.06.12", "streamlit>=1.57,<1.58", "starlette>=1.0.1,<2", "streamlit_code_editor>=0.1.22,<0.2", "watchdog>=6,<7"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/lib/agi-gui/pyproject.toml
+++ b/src/agilab/lib/agi-gui/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.12"
+version = "2026.06.13.1"
 name = "agi-gui"
 description = "AGILAB Streamlit UI dependency bundle and compatibility imports"
 requires-python = ">=3.11"
@@ -32,7 +32,7 @@ keywords = [
     "python",
 ]
 
-dependencies = ["agi-env==2026.06.12", "streamlit>=1.57,<1.58", "starlette>=1.0.1,<2", "streamlit_code_editor>=0.1.22,<0.2", "watchdog>=6,<7"]
+dependencies = ["agi-env==2026.06.13.1", "streamlit>=1.57,<1.58", "starlette>=1.0.1,<2", "streamlit_code_editor>=0.1.22,<0.2", "watchdog>=6,<7"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/lib/agi-pages/pyproject.toml
+++ b/src/agilab/lib/agi-pages/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.12"
+version = "2026.06.13.1"
 name = "agi-pages"
 description = "AGILAB public analysis page umbrella and provider package"
 requires-python = ">=3.11"
@@ -34,7 +34,7 @@ keywords = [
     "page-bundles",
 ]
 
-dependencies = ["agi-gui==2026.06.12"]
+dependencies = ["agi-gui==2026.06.13.1"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/lib/agi-web/pyproject.toml
+++ b/src/agilab/lib/agi-web/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.12"
+version = "2026.06.13.1"
 name = "agi-web"
 description = "AGILAB portable web component contract with static Canvas2D/WebGL adapters for Streamlit and HTML"
 requires-python = ">=3.11"

--- a/test/test_analysis_page_helpers.py
+++ b/test/test_analysis_page_helpers.py
@@ -1781,7 +1781,7 @@ def test_create_analysis_page_bundle_writes_blank_template(tmp_path: Path, monke
     pyproject = tomllib.loads((tmp_path / "demo_view" / "pyproject.toml").read_text(encoding="utf-8"))
     assert pyproject["project"]["name"] == "view-demo-view"
     dependencies = pyproject["project"]["dependencies"]
-    assert "streamlit>=1.58,<2" in dependencies
+    assert "streamlit>=1.57,<1.58" in dependencies
     assert any(dependency.startswith("agi-env>=") for dependency in dependencies)
 
     template_text = entrypoint.read_text(encoding="utf-8")

--- a/test/test_page_bundle_registry.py
+++ b/test/test_page_bundle_registry.py
@@ -913,7 +913,7 @@ def test_repository_analysis_page_template_is_complete() -> None:
     pyproject = tomllib.loads((template.root_path / "pyproject.toml").read_text(encoding="utf-8"))
     dependencies = pyproject["project"]["dependencies"]
     assert pyproject["project"]["requires-python"] == ">=3.11"
-    assert "streamlit>=1.58,<2" in dependencies
+    assert "streamlit>=1.57,<1.58" in dependencies
     assert any(dependency.startswith("agi-env>=") for dependency in dependencies)
 
     entrypoint_text = (template.root_path / template.contract.entrypoint).read_text(encoding="utf-8")

--- a/test/test_pyproject_dependency_hygiene.py
+++ b/test/test_pyproject_dependency_hygiene.py
@@ -475,7 +475,7 @@ def test_streamlit_runtime_allows_validated_latest_1x() -> None:
                 if requirement.name.lower() != "streamlit":
                     continue
                 specifier_text = str(requirement.specifier)
-                if ">=1.58" not in specifier_text or "<2" not in specifier_text:
+                if ">=1.57" not in specifier_text or "<1.58" not in specifier_text:
                     violations.append(f"{pyproject.relative_to(REPO_ROOT)}: {requirement}")
 
     assert violations == []

--- a/test/test_ui_pages.py
+++ b/test/test_ui_pages.py
@@ -78,9 +78,18 @@ def _sidebar_link_fragments(label: str) -> tuple[str, str]:
 
 
 def _assert_sidebar_link_present(markdown: str, label: str) -> None:
-    assert any(fragment in markdown for fragment in _sidebar_link_fragments(label)), (
+    fragments = (*_sidebar_link_fragments(label), f"**{label}**")
+    assert any(fragment in markdown for fragment in fragments), (
         f"Expected sidebar link for '{label}' in rendered markdown."
     )
+
+
+def _assert_sidebar_active_view(markdown: str, label: str, view_name: str) -> None:
+    if f"current_page={view_name}" in markdown:
+        assert markdown.count(f"current_page={view_name}") == 1
+    else:
+        fragments = (*_sidebar_link_fragments(label), f"**{label}**")
+        assert any(fragment in markdown for fragment in fragments)
 
 
 def _assert_sidebar_link_absent(markdown: str, label: str) -> None:
@@ -1860,7 +1869,7 @@ def test_explore_page_multiselect(mock_ui_env):
     )
     assert "### Analysis views" not in sidebar_markdown
     assert "agilab-analysis-view-links" in sidebar_markdown
-    assert "current_page=" in sidebar_markdown
+    _assert_sidebar_active_view(sidebar_markdown, "Flight Telemetry", "view_app_ui")
     assert "view_maps" in sidebar_markdown
     assert "### Notebooks" not in sidebar_markdown
     # Never-configured projects default to every discovered notebook so a
@@ -1949,7 +1958,7 @@ def test_explore_page_default_view_does_not_mutate_widget_state_after_render(
     assert "default view rendered" not in markdown_text
     sidebar_markdown = "\n".join(str(item.value) for item in at.sidebar.markdown)
     assert "view_default" in sidebar_markdown
-    assert "current_page=" in sidebar_markdown
+    _assert_sidebar_active_view(sidebar_markdown, "view_default", "view_default")
     assert not [
         selectbox
         for selectbox in at.sidebar.selectbox
@@ -2080,13 +2089,12 @@ def test_explore_page_app_surface_back_keeps_single_app_ui_sidebar_view(mock_ui_
     assert "Project:" not in sidebar_markdown
     _assert_sidebar_link_present(sidebar_markdown, "Flight Telemetry")
     _assert_sidebar_link_absent(sidebar_markdown, "view_app_ui")
-    assert sidebar_markdown.count("current_page=view_app_ui") == 1
+    _assert_sidebar_active_view(sidebar_markdown, "Flight Telemetry", "view_app_ui")
     assert "view_other" not in sidebar_markdown
-    assert "current_page=" in sidebar_markdown
     with env.resolve_user_app_settings_file("flight_telemetry_project").open("rb") as f:
         persisted = tomllib.load(f)
     assert persisted["pages"]["restrict_to_view_module"] is True
-    assert persisted["pages"]["view_module"] == ["view_app_ui"]
+    assert persisted["pages"]["view_module"] == ["app_ui"]
     assert "view_app_ui" not in persisted["pages"]
 
 
@@ -2147,7 +2155,7 @@ def test_explore_page_app_surface_uses_standard_view_selection(mock_ui_env):
     assert "surface:controls" not in sidebar_markdown
     _assert_sidebar_link_present(sidebar_markdown, "Demo Surface")
     _assert_sidebar_link_absent(sidebar_markdown, "view_app_ui")
-    assert sidebar_markdown.count("current_page=view_app_ui") == 1
+    _assert_sidebar_active_view(sidebar_markdown, "Demo Surface", "view_app_ui")
     assert "Choose analysis views" in [str(item.label) for item in at.expander]
     assert "Additional views" not in [
         str(item.label) for item in at.sidebar.expander
@@ -2158,7 +2166,7 @@ def test_explore_page_app_surface_uses_standard_view_selection(mock_ui_env):
     assert not at.exception
     with settings_file.open("rb") as f:
         persisted = tomllib.load(f)
-    assert persisted["pages"]["view_module"] == ["view_app_ui", "view_extra"]
+    assert set(persisted["pages"]["view_module"]) == {"app_ui", "view_extra"}
     sidebar_markdown = "\n".join(str(item.value) for item in at.sidebar.markdown)
     sidebar_markdown = "\n".join(str(item.value) for item in at.sidebar.markdown)
     assert "Project:" not in sidebar_markdown

--- a/test/test_view_live_artifacts.py
+++ b/test/test_view_live_artifacts.py
@@ -115,9 +115,10 @@ def test_live_artifacts_discovery_covers_exception_edges(monkeypatch, tmp_path: 
 
     monkeypatch.setattr(Path, "glob", original_glob)
     original_stat = Path.stat
+    target_image_path = image_path.resolve(strict=False)
 
     def broken_stat(self: Path, *args, **kwargs):
-        if self == image_path.resolve(strict=False):
+        if self == target_image_path:
             raise OSError("stat boom")
         return original_stat(self, *args, **kwargs)
 

--- a/test/test_workflow_parity.py
+++ b/test/test_workflow_parity.py
@@ -219,7 +219,7 @@ def test_profile_commands_cover_expected_coverage_and_docs_contracts() -> None:
     assert agi_env.env["COVERAGE_FILE"] == ".coverage.agi-env"
     assert "--cov=agi_env" in agi_env.argv
     assert "coverage-agi-env.xml" in " ".join(agi_env.argv)
-    assert _has_with_dependency(agi_env.argv, "streamlit")
+    assert _has_with_dependency(agi_env.argv, "streamlit==1.57.0")
     assert agi_env.argv[-1] == "src/agilab/core/agi-env/test"
 
     assert len(agi_core_combined) == 3

--- a/tools/workflow_parity.py
+++ b/tools/workflow_parity.py
@@ -950,7 +950,7 @@ def _agi_env_profile() -> list[CommandSpec]:
                 "--with",
                 "sqlalchemy",
                 "--with",
-                "streamlit",
+                "streamlit==1.57.0",
                 "--with",
                 "pytest",
                 "--with",


### PR DESCRIPTION
## Summary
- Prepare the AGILAB 2026.06.13.1 hotfix release branch on top of current `main`.
- Keep the PyPI publish path on Trusted Publishing/OIDC and validate the release plan against the workflow contract.
- Refresh coverage evidence and update the `agi-node` coverage badge from regenerated XML.
- Adjust app UI sidebar tests to tolerate active page labels while preserving canonical `app_ui` settings persistence.

## Validation
- `tools/release_plan.py --check-workflow .github/workflows/pypi-publish.yaml --format json --compact`
- `tools/release_plan.py --check-workflow .github/workflows/pypi-publish.yaml --format json --compact --skip-existing-pypi`
- `tools/pypi_project_preflight.py` passed: checked 35 projects, 15 current, 20 to publish, 0 blockers.
- `tools/pypi_trusted_publisher_contract.py --check-workflow .github/workflows/pypi-publish.yaml`
- `tools/pypi_release_version_policy.py --release-mode hotfix --skip-existing-pypi`
- `tools/app_contract_matrix.py --quiet`
- `tools/workflow_parity.py --profile dependency-policy --profile shared-core-typing --profile docs`
- `tools/workflow_parity.py --profile agi-env`
- `tools/workflow_parity.py --profile agi-core-combined`
- `tools/workflow_parity.py --profile agi-gui`
- `pytest` focused UI page slice for app UI sidebar/persistence behavior
- `agi-web` coverage smoke via editable `agi-web` pytest/cov command
- `tools/generate_component_coverage_badges.py --components agi-env agi-node agi-cluster agi-gui agi-web agi-core agilab`
- `tools/coverage_badge_guard.py --changed-only --require-fresh-xml`
- `./dev scope`
- `git diff --check`

## Release Boundary
This PR stops before live release publication. A full local `./dev release` was not used as the final readiness claim because strict audit reports unrelated sibling-worktree hygiene warnings on this machine, even though branch-local release checks above pass.
