### PR TITLE
Clarify PyPI trusted publishing token provenance

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 276,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "7eb20ff9867ebb8ae8fb8625a14d4e37b1e537e85398e614086edede9d58319d",
+  "source_digest_sha256": "8b5da2e6b09418088085aeb746c514f953adbc292edec4ef52def465da50abf2",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "7eb20ff9867ebb8ae8fb8625a14d4e37b1e537e85398e614086edede9d58319d"
+  "target_digest_sha256": "8b5da2e6b09418088085aeb746c514f953adbc292edec4ef52def465da50abf2"
 }

--- a/docs/source/package-publishing-policy.rst
+++ b/docs/source/package-publishing-policy.rst
@@ -315,6 +315,11 @@ Real PyPI publication must use GitHub OIDC Trusted Publishing. Long-lived PyPI
 API tokens are not part of the normal release path. If a package or repository
 is not configured as a PyPI trusted publisher, the publish workflow should stop
 with an explicit configuration error instead of falling back to a stored token.
+PyPI may still describe an upload as using an API token because the Trusted
+Publishing flow exchanges the GitHub OIDC identity for a short-lived PyPI upload
+token. That upload token is minted by PyPI for the matched project and workflow;
+it is not a stored repository secret, not ``PYPI_API_TOKEN``, not
+``PYPI_TOKEN``, and not ``TWINE_PASSWORD``.
 
 Each PyPI project selected for upload must have a GitHub trusted publisher entry
 matching the release workflow claims exactly. The workflow renders the same contract with

--- a/test/test_pypi_trusted_publisher_contract.py
+++ b/test/test_pypi_trusted_publisher_contract.py
@@ -52,6 +52,8 @@ def test_markdown_report_explains_invalid_publisher_and_setup_path() -> None:
     assert "`pypi-agi-apps`" in markdown
     assert "`repo:ThalesGroup/agilab:environment:pypi-agi-apps`" in markdown
     assert "`invalid-publisher`" in markdown
+    assert "short-lived API token" in markdown
+    assert "not a stored `PYPI_API_TOKEN`, `PYPI_TOKEN`, or `TWINE_PASSWORD` secret" in markdown
     assert "Settings > Publishing > Trusted publishers" in markdown
 
 
@@ -86,6 +88,8 @@ def test_docs_list_every_required_trusted_publisher_environment() -> None:
     docs = (REPO_ROOT / "docs/source/package-publishing-policy.rst").read_text(encoding="utf-8")
 
     assert "invalid-publisher" in docs
+    assert "short-lived PyPI" in docs and "upload\ntoken" in docs
+    assert "not a stored repository secret" in docs
     assert "repo:ThalesGroup/agilab:environment:<environment>" in docs
     for claim in module.trusted_publisher_claims():
         assert f"``{claim.project}``" in docs

--- a/tools/pypi_trusted_publisher_contract.py
+++ b/tools/pypi_trusted_publisher_contract.py
@@ -34,6 +34,12 @@ PYPI_PUBLISH_PACKAGE_NAMES = tuple(
     for package in PACKAGE_CONTRACTS
     if package.role in PYPI_PUBLISH_ROLES or package.name in PROMOTED_APP_PROJECT_PACKAGE_NAMES
 )
+OIDC_AUTH_NOTE = (
+    "Upload authentication must come from GitHub OIDC Trusted Publishing. "
+    "PyPI and upload logs may refer to a short-lived API token because PyPI "
+    "exchanges the GitHub OIDC identity for a project-scoped upload token; "
+    "that is not a stored `PYPI_API_TOKEN`, `PYPI_TOKEN`, or `TWINE_PASSWORD` secret."
+)
 
 
 @dataclass(frozen=True)
@@ -133,6 +139,7 @@ def format_markdown(claims: Sequence[TrustedPublisherClaim]) -> str:
         "",
         "Configure every PyPI project below with these exact GitHub publisher values.",
         "A PyPI `invalid-publisher` error means the project is missing this entry or one field differs.",
+        OIDC_AUTH_NOTE,
         "",
         "| PyPI project | GitHub owner | GitHub repository | Workflow | Environment | OIDC subject |",
         "| --- | --- | --- | --- | --- | --- |",
@@ -157,6 +164,7 @@ def format_text(claims: Sequence[TrustedPublisherClaim]) -> str:
     lines = [
         "PyPI Trusted Publishing contract",
         "Configure these GitHub publisher values in each PyPI project:",
+        OIDC_AUTH_NOTE,
         "",
     ]
     for claim in claims:


### PR DESCRIPTION
## Summary
- add an OIDC/token-boundary note to the PyPI trusted publisher contract output
- document that PyPI may call the OIDC-minted short-lived upload credential an API token, but it is not a stored PYPI_API_TOKEN/PYPI_TOKEN/TWINE_PASSWORD secret
- sync the docs-source mirror stamp after updating the canonical docs source

## Validation
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_pypi_trusted_publisher_contract.py
- uv --preview-features extra-build-dependencies run python -m pytest test/test_pypi_trusted_publisher_contract.py test/test_pypi_publish_workflow.py -q
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs
- python3 tools/impact_validate.py --files tools/pypi_trusted_publisher_contract.py test/test_pypi_trusted_publisher_contract.py docs/source/package-publishing-policy.rst
- git diff --check