### PR TITLE
Add release evidence to UI robot matrix

### DIFF
--- a/.github/workflows/ui-robot-matrix.yml
+++ b/.github/workflows/ui-robot-matrix.yml
@@ -54,6 +54,7 @@ jobs:
             scenarios: >-
               isolated-browser-error-core-pages
               isolated-pytorch-playground-analysis
+              isolated-release-evidence
               isolated-above-fold-core-pages
               isolated-keyboard-focus-core-pages
               isolated-accessibility-core-pages

--- a/test/test_agilab_widget_robot_matrix.py
+++ b/test/test_agilab_widget_robot_matrix.py
@@ -104,7 +104,6 @@ def test_default_scenarios_cover_isolated_pages_and_current_home_actions() -> No
     assert journey.assert_orchestrate_artifacts is True
     assert "isolated-browser-history" not in [scenario.name for scenario in scenarios]
     assert "isolated-mobile-core-pages" not in [scenario.name for scenario in scenarios]
-    assert "isolated-release-evidence" not in [scenario.name for scenario in scenarios]
     assert "isolated-fresh-session-core-pages" not in [scenario.name for scenario in scenarios]
     assert "isolated-keyboard-focus-core-pages" not in [scenario.name for scenario in scenarios]
     assert "isolated-layout-integrity-desktop" not in [scenario.name for scenario in scenarios]

--- a/test/test_ui_robot_coverage_contract.py
+++ b/test/test_ui_robot_coverage_contract.py
@@ -105,6 +105,7 @@ def test_ui_robot_coverage_contract_passes_for_current_matrix() -> None:
     ]
     assert "isolated-project-editor-page" in payload["coverage"]["ui_robot_matrix_profile_scenarios"]
     assert "isolated-pytorch-playground-analysis" in payload["coverage"]["ui_robot_matrix_profile_scenarios"]
+    assert "isolated-release-evidence" in payload["coverage"]["ui_robot_matrix_profile_scenarios"]
     assert payload["coverage"]["pytorch_analysis_robot"] == {
         "apps": ["pytorch_playground_project"],
         "forbidden_sidebar_text": ["Project:"],
@@ -222,9 +223,10 @@ def test_ui_robot_coverage_contract_accepts_explicit_full_app_profile(monkeypatc
         required_action_labels=",".join(module.REQUIRED_PYTORCH_ANALYSIS_ACTIONS),
         browser_error_check=True,
     )
+    release_evidence = scenario(module.REQUIRED_RELEASE_EVIDENCE_SCENARIO, pages="PROJECT,ORCHESTRATE,ANALYSIS")
     all_scenarios = {
         item.name: item
-        for item in (core_scenario, editor, hf_visual, hf_app_pages, hf_install, pytorch)
+        for item in (core_scenario, editor, hf_visual, hf_app_pages, hf_install, pytorch, release_evidence)
     }
     widget_robot = SimpleNamespace(
         page_label=lambda page: str(page),
@@ -277,9 +279,11 @@ def test_ui_robot_coverage_contract_accepts_explicit_full_app_profile(monkeypatc
                             "isolated-project-editor-page",
                             "--scenario",
                             "isolated-pytorch-playground-analysis",
+                            "--scenario",
+                            "isolated-release-evidence",
                             "--apps",
                             ",".join(module.REQUIRED_DEMO_UI_APPS),
-                    ]
+                        ]
                 )
             ],
         }

--- a/test/test_workflow_parity.py
+++ b/test/test_workflow_parity.py
@@ -516,6 +516,7 @@ def test_profile_commands_cover_expected_coverage_and_docs_contracts() -> None:
         "quality": {
             "isolated-browser-error-core-pages",
             "isolated-pytorch-playground-analysis",
+            "isolated-release-evidence",
             "isolated-above-fold-core-pages",
             "isolated-keyboard-focus-core-pages",
             "isolated-accessibility-core-pages",

--- a/tools/ui_robot_coverage_contract.py
+++ b/tools/ui_robot_coverage_contract.py
@@ -34,6 +34,7 @@ REQUIRED_HF_FIRST_PROOF_APPS = (
 REQUIRED_HF_FIRST_PROOF_PAGES = ("view_forecast_analysis", "view_maps", "view_release_decision")
 FORBIDDEN_HF_FIRST_PROOF_APPS = ("flight_project", "weather_forecast_legacy_project")
 REQUIRED_PYTORCH_ANALYSIS_SCENARIO = "isolated-pytorch-playground-analysis"
+REQUIRED_RELEASE_EVIDENCE_SCENARIO = "isolated-release-evidence"
 REQUIRED_PYTORCH_ANALYSIS_APP = "pytorch_playground_project"
 REQUIRED_PYTORCH_ANALYSIS_TEXT = ("PyTorch Playground", "Refresh evidence", "Synced RUN snippet", "Settings")
 REQUIRED_PYTORCH_ANALYSIS_FORBIDDEN_SIDEBAR_TEXT = ("Project:",)
@@ -635,6 +636,13 @@ def evaluate_contract() -> dict[str, Any]:
             CoverageIssue(
                 "pytorch_analysis_robot",
                 f"ui-robot-matrix profile does not run {REQUIRED_PYTORCH_ANALYSIS_SCENARIO}",
+            )
+        )
+    if REQUIRED_RELEASE_EVIDENCE_SCENARIO not in ui_robot_matrix_profile_scenarios:
+        issues.append(
+            CoverageIssue(
+                "release_evidence_robot",
+                f"ui-robot-matrix profile does not run {REQUIRED_RELEASE_EVIDENCE_SCENARIO}",
             )
         )
 

--- a/tools/workflow_parity.py
+++ b/tools/workflow_parity.py
@@ -82,6 +82,7 @@ UI_ROBOT_MATRIX_SHARDS = (
         (
             "isolated-browser-error-core-pages",
             "isolated-pytorch-playground-analysis",
+            "isolated-release-evidence",
             "isolated-above-fold-core-pages",
             "isolated-keyboard-focus-core-pages",
             "isolated-accessibility-core-pages",


### PR DESCRIPTION
## Summary
- add isolated-release-evidence to the standard UI robot matrix quality shard
- require that scenario in the UI robot coverage contract
- update focused workflow/coverage tests

## Validation
- uv --preview-features extra-build-dependencies run pytest -q -o addopts= test/test_ci_workflow.py test/test_agilab_widget_robot_matrix.py test/test_ui_robot_coverage_contract.py test/test_workflow_parity.py
- uv --preview-features extra-build-dependencies run python tools/ui_robot_coverage_contract.py --json
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile ui-robot-matrix --print-only