### PR TITLE
Improve benchmark result summary UX

### DIFF
--- a/src/agilab/orchestrate/orchestrate_page_support.py
+++ b/src/agilab/orchestrate/orchestrate_page_support.py
@@ -665,6 +665,20 @@ def _benchmark_seconds(value: Any) -> float | None:
         return None
 
 
+def _benchmark_summary_mode_label(key: str, row: Mapping[str, Any]) -> str:
+    raw_mode = row.get("mode", key)
+    try:
+        return benchmark_mode_label(int(raw_mode))
+    except (TypeError, ValueError):
+        pass
+
+    key_mode, _, _ = key.partition(":")
+    try:
+        return benchmark_mode_label(int(key_mode))
+    except ValueError:
+        return str(raw_mode or key)
+
+
 def _best_node_rapids_counterpart_key(key: str) -> str | None:
     mode_text, separator, suffix = key.partition(":")
     if separator != ":" or suffix != "best-node":
@@ -734,6 +748,29 @@ def benchmark_rows_with_delta_percent(raw: Mapping[str, Any]) -> dict[str, Any]:
         else:
             row["delta (%)"] = 0.0 if seconds == best_seconds else None
     return rows
+
+
+def benchmark_results_caption(rows: Mapping[str, Any]) -> str:
+    """Return compact user-facing caption text for benchmark result rows."""
+    measured: list[tuple[float, str]] = []
+    for key, value in rows.items():
+        if not isinstance(value, Mapping):
+            continue
+        seconds = _benchmark_seconds(value.get("seconds"))
+        if seconds is None:
+            continue
+        measured.append((seconds, _benchmark_summary_mode_label(str(key), value)))
+
+    if not measured:
+        return "Benchmark results loaded, but no numeric timing rows were found."
+
+    best_seconds, best_mode = min(measured, key=lambda item: item[0])
+    plural = "mode" if len(measured) == 1 else "modes"
+    return (
+        f"Fastest mode: {best_mode} in {best_seconds:.3f}s across "
+        f"{len(measured)} measured {plural}. Lower is better; delta (%) compares "
+        "each row with this fastest run."
+    )
 
 
 def sanitize_benchmark_modes(

--- a/src/agilab/pages/2_ORCHESTRATE.py
+++ b/src/agilab/pages/2_ORCHESTRATE.py
@@ -59,6 +59,7 @@ import_agilab_symbols(
         "BENCHMARK_MODE_LEGEND_MARKDOWN": "BENCHMARK_MODE_LEGEND_MARKDOWN",
         "benchmark_dataframe_column_config": "benchmark_dataframe_column_config",
         "benchmark_mode_label": "benchmark_mode_label",
+        "benchmark_results_caption": "benchmark_results_caption",
         "benchmark_rows_with_delta_percent": "benchmark_rows_with_delta_percent",
         "benchmark_workers_data_path_issue": "benchmark_workers_data_path_issue",
         "compute_run_mode": "compute_run_mode",
@@ -2466,6 +2467,7 @@ async def _render_run_panels(
 
                                 if date_value:
                                     st.caption(f"Benchmark date: {date_value}")
+                                st.caption(benchmark_results_caption(raw))
                                 st.info(BENCHMARK_MODE_LEGEND_MARKDOWN)
 
                                 render_dataframe_preview(

--- a/test/test_orchestrate_page_support.py
+++ b/test/test_orchestrate_page_support.py
@@ -599,6 +599,43 @@ def test_benchmark_rows_with_delta_percent_handles_zero_and_invalid_seconds():
     assert rows["meta"] == "kept"
 
 
+def test_benchmark_results_caption_identifies_fastest_mode():
+    rows = orchestrate_page_support.benchmark_rows_with_delta_percent(
+        {
+            "0": {"mode": 0, "seconds": 10.0},
+            "2": {"mode": 2, "seconds": "5"},
+            "meta": "kept",
+        }
+    )
+
+    summary = orchestrate_page_support.benchmark_results_caption(rows)
+
+    assert "Fastest mode: 2: cython in 5.000s" in summary
+    assert "2 measured modes" in summary
+    assert "delta (%)" in summary
+
+
+def test_benchmark_results_caption_falls_back_to_key_mode_for_variants():
+    summary = orchestrate_page_support.benchmark_results_caption(
+        {"12:best-node": {"variant": "best-node", "seconds": 1.25}}
+    )
+
+    assert (
+        "Fastest mode: 12: rapids and dask (pools in-worker) in 1.250s"
+        in summary
+    )
+    assert "1 measured mode" in summary
+
+
+def test_benchmark_results_caption_reports_missing_numeric_rows():
+    assert (
+        orchestrate_page_support.benchmark_results_caption(
+            {"0": {"mode": 0, "seconds": "n/a"}, "meta": "kept"}
+        )
+        == "Benchmark results loaded, but no numeric timing rows were found."
+    )
+
+
 def test_benchmark_rows_hide_best_node_non_rapids_when_rapids_counterpart_exists():
     rows = orchestrate_page_support.benchmark_rows_with_delta_percent(
         {


### PR DESCRIPTION
## Summary
- add a compact benchmark result summary that identifies the fastest measured mode
- render the summary above the benchmark legend/table in ORCHESTRATE
- cover fastest-mode, variant-key fallback, and missing-numeric-row cases

## Validation
- uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files src/agilab/orchestrate/orchestrate_page_support.py src/agilab/pages/2_ORCHESTRATE.py test/test_orchestrate_page_support.py
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_orchestrate_page_support.py
- uv --preview-features extra-build-dependencies run pytest -q --maxfail=1 -o addopts='' test/test_orchestrate_page_support.py test/test_ui_pages.py
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui
- git diff --check