### PR TITLE
Fix example packaging pollution guards

### DIFF
--- a/src/agilab/lib/app_project_build_support.py
+++ b/src/agilab/lib/app_project_build_support.py
@@ -98,7 +98,7 @@ _EXCLUDED_PAYLOAD_DIRS = {
     "notebooks",
     "test",
 }
-_EXCLUDED_PAYLOAD_FILES = {".DS_Store", ".gitignore", ".lock", "uv.lock"}
+_EXCLUDED_PAYLOAD_FILES = {".coverage", ".DS_Store", ".gitignore", ".lock", "uv.lock"}
 _EXCLUDED_PAYLOAD_SUFFIXES = {".c", ".pid", ".pyc", ".pyo", ".pyx", ".so"}
 
 
@@ -128,7 +128,11 @@ def _ignore_payload_artifacts(directory: str, names: list[str]) -> set[str]:
         if path.is_dir() and (name in _EXCLUDED_PAYLOAD_DIRS or name.endswith(".egg-info")):
             ignored.add(name)
             continue
-        if name in _EXCLUDED_PAYLOAD_FILES or path.suffix in _EXCLUDED_PAYLOAD_SUFFIXES:
+        if (
+            name in _EXCLUDED_PAYLOAD_FILES
+            or name.startswith(".coverage.")
+            or path.suffix in _EXCLUDED_PAYLOAD_SUFFIXES
+        ):
             ignored.add(name)
     return ignored
 

--- a/test/test_app_installer_packaging.py
+++ b/test/test_app_installer_packaging.py
@@ -235,10 +235,38 @@ def test_app_project_payload_build_helper_ignores_generated_app_dirs() -> None:
     support = _load_app_project_build_support()
 
     assert APP_GENERATED_DIRS <= support._EXCLUDED_PAYLOAD_DIRS
+    assert APP_GENERATED_NAMES <= support._EXCLUDED_PAYLOAD_FILES
+    assert ".coverage.worker.123" in support._ignore_payload_artifacts(
+        ".",
+        [".coverage.worker.123"],
+    )
 
 
 def _builtin_app_dirs() -> list[Path]:
-    return sorted(path for path in BUILTIN_APPS_ROOT.glob("*_project") if path.is_dir())
+    tracked_readmes = _git_paths("ls-files", "src/agilab/apps/builtin/*_project/README.md")
+    tracked_dirs = set()
+    for path in tracked_readmes:
+        if not path.startswith("src/agilab/apps/builtin/"):
+            continue
+        project_name = Path(path).parent.name
+        tracked_dirs.add(BUILTIN_APPS_ROOT / project_name)
+    return sorted(path for path in tracked_dirs if path.is_dir())
+
+
+def test_builtin_app_dirs_follow_tracked_readme_inventory(tmp_path: Path, monkeypatch) -> None:
+    tracked = tmp_path / "tracked_project"
+    polluted = tmp_path / "polluted_project"
+    tracked.mkdir()
+    polluted.mkdir()
+
+    def fake_git_paths(*args: str) -> set[str]:
+        assert args == ("ls-files", "src/agilab/apps/builtin/*_project/README.md")
+        return {"src/agilab/apps/builtin/tracked_project/README.md"}
+
+    monkeypatch.setattr(sys.modules[__name__], "BUILTIN_APPS_ROOT", tmp_path)
+    monkeypatch.setattr(sys.modules[__name__], "_git_paths", fake_git_paths)
+
+    assert _builtin_app_dirs() == [tracked]
 
 
 def _root_package_data() -> list[str]:
@@ -1227,6 +1255,21 @@ def test_app_project_payload_copy_produces_self_contained_project_dirs(tmp_path:
         assert changed, f"{distribution}: expected packaged pyproject source sanitization"
         for pyproject_path in payload_root.rglob("pyproject.toml"):
             assert "[tool.uv.sources]" not in pyproject_path.read_text(encoding="utf-8")
+
+
+def test_app_project_payload_copy_excludes_parallel_coverage_artifacts(tmp_path: Path) -> None:
+    support = _load_app_project_build_support()
+    source_artifact = BUILTIN_APPS_ROOT / "flight_telemetry_project" / ".coverage.worker.123"
+    source_artifact.write_text("generated coverage", encoding="utf-8")
+
+    try:
+        support.copy_app_project_payload("flight_telemetry_project", tmp_path)
+    finally:
+        source_artifact.unlink(missing_ok=True)
+
+    payload_root = tmp_path / "flight_telemetry_project"
+    assert payload_root.is_dir()
+    assert not (payload_root / ".coverage.worker.123").exists()
 
 
 def test_agi_apps_umbrella_bundles_only_the_base_minimal_app_template() -> None:


### PR DESCRIPTION
## Summary
- exclude local .coverage artifacts from copied app project payloads
- make built-in app maturity tests use tracked README-backed projects instead of polluted filesystem directories
- add regressions for generated-file exclusion and polluted app inventory

## Validation
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_app_installer_packaging.py
- uv --preview-features extra-build-dependencies run python -m py_compile src/agilab/examples/inter_project_dag/preview_inter_project_dag.py
src/agilab/examples/flight_telemetry/AGI_run_flight_telemetry.py
src/agilab/examples/flight_telemetry/AGI_install_flight_telemetry.py
src/agilab/examples/native_rust_worker/preview_native_rust_worker.py
src/agilab/examples/sqlite_connector_proof/preview_sqlite_connector_proof.py
src/agilab/examples/parallel_stage/preview_parallel_stage.py
src/agilab/examples/mission_decision/AGI_install_mission_decision.py
src/agilab/examples/mission_decision/AGI_run_mission_decision.py
src/agilab/examples/minimal_app/AGI_run_minimal_app.py
src/agilab/examples/minimal_app/AGI_install_minimal_app.py
src/agilab/examples/weather_forecast/AGI_run_weather_forecast.py
src/agilab/examples/weather_forecast/AGI_install_weather_forecast.py
src/agilab/examples/__init__.py
src/agilab/examples/voila_notebook_proof/preview_voila_notebook_proof.py
src/agilab/examples/sklearn_pipeline/AGI_run_sklearn_pipeline.py
src/agilab/examples/sklearn_pipeline/AGI_install_sklearn_pipeline.py
src/agilab/examples/excel_workbook_proof/preview_excel_workbook_proof.py
src/agilab/examples/train_then_serve/preview_train_then_serve.py
src/agilab/examples/mlflow_auto_tracking/preview_mlflow_auto_tracking.py
src/agilab/examples/service_mode/preview_service_mode.py
src/agilab/examples/resilience_failure_injection/preview_resilience_failure_injection.py
src/agilab/examples/notebook_to_dask/preview_notebook_to_dask.py
- uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files src/agilab/lib/app_project_build_support.py test/test_app_installer_packaging.py
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui
- git diff --check