### PR TITLE
Fix agi-env subprocess output capture

### DIFF
--- a/src/agilab/core/agi-env/src/agi_env/runtime/agi_env.py
+++ b/src/agilab/core/agi-env/src/agi_env/runtime/agi_env.py
@@ -142,10 +142,12 @@ try:
     import pwd
 except ImportError:  # Windows
     pwd = None  # type: ignore
-if FormattedTB is not None:
-    # Get constructor parameters of FormattedTB
-    _sig = inspect.signature(FormattedTB.__init__).parameters
 
+
+def _formatted_traceback_kwargs() -> dict[str, object] | None:
+    """Build IPython traceback options without mutating process-global state."""
+    if FormattedTB is None:
+        return None
     _call_pdb = bool(getattr(sys.stdin, "isatty", lambda: False)())
     if "AGILAB_CALL_PDB" in os.environ:
         _call_pdb = os.environ["AGILAB_CALL_PDB"].strip().lower() in {
@@ -155,13 +157,22 @@ if FormattedTB is not None:
             "on",
         }
 
-    _tb_kwargs = dict(mode='Verbose', call_pdb=_call_pdb)
+    _sig = inspect.signature(FormattedTB.__init__).parameters
+    _tb_kwargs: dict[str, object] = dict(mode="Verbose", call_pdb=_call_pdb)
     if 'color_scheme' in _sig:
         _tb_kwargs['color_scheme'] = 'NoColor'
     else:
         _tb_kwargs['theme_name'] = 'NoColor'
+    return _tb_kwargs
 
+
+def _install_formatted_traceback_excepthook():
+    """Install AGILAB's optional rich traceback hook during runtime setup."""
+    _tb_kwargs = _formatted_traceback_kwargs()
+    if _tb_kwargs is None:
+        return None
     sys.excepthook = FormattedTB(**_tb_kwargs)
+    return sys.excepthook
 
 from agi_env.runtime.agi_logger import AgiLogger
 
@@ -379,6 +390,7 @@ class AgiEnv(metaclass=_AgiEnvMeta):
                 "use AgiEnv.reset() for a fresh environment or change_app() to switch apps."
             )
 
+        _install_formatted_traceback_excepthook()
         initialize_agi_env_instance(
             self,
             apps_path=apps_path,

--- a/src/agilab/core/agi-env/src/agi_env/runtime/execution_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/runtime/execution_support.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import os
 import re
@@ -143,6 +144,15 @@ async def _stream_process_output(
     await asyncio.wait_for(asyncio.gather(*coroutines), timeout=timeout)
 
 
+async def _kill_and_wait(proc: asyncio.subprocess.Process) -> None:
+    """Terminate a timed-out subprocess and reap it when the platform permits."""
+
+    with contextlib.suppress(ProcessLookupError, OSError):
+        proc.kill()
+    with contextlib.suppress(asyncio.TimeoutError, ProcessLookupError, OSError):
+        await asyncio.wait_for(proc.wait(), timeout=5)
+
+
 def _raise_process_error(
     err: Exception,
     *,
@@ -263,7 +273,7 @@ async def run(
         return "\n".join(result)
     except asyncio.TimeoutError as err:
         if proc is not None:
-            proc.kill()
+            await _kill_and_wait(proc)
         raise RuntimeError(f"Command timed out after {timeout} seconds: {cmd}") from err
     except PROCESS_WRAP_EXCEPTIONS as err:
         _raise_process_error(
@@ -298,7 +308,8 @@ async def run_bg(
         process_env.update(env_override)
 
     cmd = inject_uv_preview_flag(cmd)  # ty: ignore[invalid-assignment]
-    result: list[str] = []
+    stdout_lines: list[str] = []
+    stderr_lines: list[str] = []
 
     proc = await _spawn_process(
         cmd=cmd,
@@ -309,18 +320,17 @@ async def run_bg(
 
     out_cb, err_cb = _resolve_stream_callbacks(log_callback=log_callback, logger=logger)
     try:
-        await _stream_process_output(
-            proc,
+        await asyncio.wait_for(
+            asyncio.gather(
+                _read_stream(proc.stdout, callback=out_cb, result=stdout_lines),
+                _read_stream(proc.stderr, callback=err_cb, result=stderr_lines),
+                proc.wait(),
+            ),
             timeout=timeout,
-            out_cb=out_cb,
-            err_cb=err_cb,
-            result=result,
-            wait_for_exit=True,
         )
     except asyncio.TimeoutError as err:
-        proc.kill()
+        await _kill_and_wait(proc)
         raise RuntimeError(f"Timeout expired for command: {cmd}") from err
-    stdout, stderr = await proc.communicate()
     returncode = proc.returncode
 
     if returncode != 0:
@@ -331,7 +341,7 @@ async def run_bg(
             simple_message=True,
         )
 
-    return stdout.decode(), stderr.decode()
+    return "\n".join(stdout_lines), "\n".join(stderr_lines)
 
 
 async def run_async(

--- a/src/agilab/core/agi-env/test/test_agi_env.py
+++ b/src/agilab/core/agi-env/test/test_agi_env.py
@@ -2425,6 +2425,8 @@ def test_run_async_and_run_bg_cover_success_and_nonzero_paths(tmp_path: Path, mo
     )
     assert "out" in streamed
     assert "err" in streamed
+    assert stdout == "out"
+    assert stderr == "err"
 
     with pytest.raises(RuntimeError, match="exit 4"):
         asyncio.run(AgiEnv._run_bg(fail_cmd, cwd=tmp_path, venv=tmp_path, timeout=10))
@@ -2477,7 +2479,7 @@ def test_run_bg_shell_fallback_handles_blank_lines_and_simple_callback(tmp_path:
     )
 
     assert stdout == ""
-    assert stderr == "stderr line\n"
+    assert stderr == "stderr line"
     assert streamed == ["stderr line"]
 
 

--- a/src/agilab/core/agi-env/test/test_agi_env_remaining_coverage.py
+++ b/src/agilab/core/agi-env/test/test_agi_env_remaining_coverage.py
@@ -64,6 +64,8 @@ def test_agi_env_import_honours_call_pdb_override_and_color_scheme(monkeypatch):
 
     monkeypatch.setenv("AGILAB_CALL_PDB", "yes")
     monkeypatch.setattr(sys, "stdin", SimpleNamespace(isatty=lambda: False), raising=False)
+    original_excepthook = object()
+    monkeypatch.setattr(sys, "excepthook", original_excepthook)
 
     module = _load_agi_env_variant(
         "agi_env.agi_env_formatted_tb_variant",
@@ -71,6 +73,9 @@ def test_agi_env_import_honours_call_pdb_override_and_color_scheme(monkeypatch):
         formatted_tb_type=_FakeFormattedTB,
     )
 
+    assert module.sys.excepthook is original_excepthook
+    assert captured == {}
+    module._install_formatted_traceback_excepthook()
     assert module.sys.excepthook is not None
     assert captured == {
         "mode": "Verbose",

--- a/src/agilab/core/agi-env/test/test_execution_support.py
+++ b/src/agilab/core/agi-env/test/test_execution_support.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
+import subprocess
+import sys
 from unittest import mock
 
 import pytest
@@ -354,15 +356,41 @@ def test_run_bg_uses_shell_for_shell_syntax(tmp_path: Path, monkeypatch):
         raise AssertionError("plain exec should not be used for shell syntax")
 
     async def _fake_shell(*_args, **_kwargs):
-        return _FakeProc(stderr_lines=[b"stderr line\n", b""])
+        return _FakeProc(stdout_lines=[b"stdout line\n", b""], stderr_lines=[b"stderr line\n", b""])
 
     monkeypatch.setattr(asyncio, "create_subprocess_exec", _unexpected_exec)
     monkeypatch.setattr(asyncio, "create_subprocess_shell", _fake_shell)
 
     stdout, stderr = asyncio.run(execution_support.run_bg("echo hi; echo bye", cwd=tmp_path, venv=tmp_path))
 
-    assert stdout == ""
-    assert stderr == ""
+    assert stdout == "stdout line"
+    assert stderr == "stderr line"
+
+
+def test_run_bg_returns_real_subprocess_output_after_streaming(tmp_path: Path):
+    streamed: list[str] = []
+    cmd = subprocess.list2cmdline(
+        [
+            sys.executable,
+            "-c",
+            "import sys; print('real out'); print('real err', file=sys.stderr)",
+        ]
+    )
+
+    stdout, stderr = asyncio.run(
+        execution_support.run_bg(
+            cmd,
+            cwd=tmp_path,
+            venv=None,
+            timeout=10,
+            log_callback=lambda message, **_kwargs: streamed.append(message),
+            build_env_fn=lambda _venv: {},
+        )
+    )
+
+    assert stdout == "real out"
+    assert stderr == "real err"
+    assert streamed == ["real out", "real err"]
 
 
 def test_run_bg_propagates_unexpected_exec_bug(tmp_path: Path, monkeypatch):


### PR DESCRIPTION
## Summary
- fix `agi_env.runtime.execution_support.run_bg()` so streamed subprocess stdout/stderr are also returned to callers
- reap timed-out subprocesses after killing them to reduce process cleanup races
- avoid mutating `sys.excepthook` at import time; install the optional formatted traceback hook during `AgiEnv` initialization instead

## Root Cause
`run_bg()` streamed stdout/stderr through `_read_stream()` and then called `communicate()` after the pipes were already exhausted, so callers such as ORCHESTRATE could receive empty stdout/stderr despite visible streamed logs.

## Validation
- `uv --preview-features extra-build-dependencies run --no-sync pytest -q -o addopts='' src/agilab/core/agi-env/test`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files src/agilab/core/agi-env/src/agi_env/runtime/agi_env.py src/agilab/core/agi-env/src/agi_env/runtime/execution_support.py src/agilab/core/agi-env/test/test_agi_env.py src/agilab/core/agi-env/test/test_agi_env_remaining_coverage.py src/agilab/core/agi-env/test/test_execution_support.py`
- `git diff --check`
