### PR TITLE
[codex] Clarify AGILAB golden ML loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,21 @@ That loop is the product in miniature: controlled environment, reproducible
 execution, artifacts, run evidence, and a portable handoff path without needing
 the Streamlit UI or a cluster.
 
+## Golden ML Loop
+
+The strongest AGILAB path is intentionally small and evidence-first:
+
+1. **Import or create** a notebook, script, or app project.
+2. **Run** it through a controlled local environment first.
+3. **Capture** artifacts plus `run_manifest.json` evidence.
+4. **Inspect and compare** outputs in ANALYSIS, notebook export, MLflow handoff,
+   or proof-pack tools.
+5. **Promote** the result only when the evidence, package contract, and release
+   proof are coherent.
+
+That is the center of gravity: make exploratory ML work replayable before
+moving it into a heavier tracker, registry, cluster, or production platform.
+
 That means you do not lose your work if the AGILAB UI or distributed runtime is
 no longer the right interface.
 The stable core runtime remains the smallest supported handoff surface and is

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 276,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "1e78dcf6ab11527dbae885cc2cd3c5f2fd605c645ab2490a2ae871f1af34ad0c",
+  "source_digest_sha256": "4d3c3474bcf7d62c89fbf8a450a8dee75dd6c97e999278bcd2fd5bcdfbb4cf87",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "1e78dcf6ab11527dbae885cc2cd3c5f2fd605c645ab2490a2ae871f1af34ad0c"
+  "target_digest_sha256": "4d3c3474bcf7d62c89fbf8a450a8dee75dd6c97e999278bcd2fd5bcdfbb4cf87"
 }

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -24,6 +24,22 @@ The fastest adoption ladder is browser preview, one local first-proof lane,
 evidence manifest, then expansion into package mode, external apps, or cluster
 work.
 
+Golden ML loop
+--------------
+
+AGILAB's strongest workflow is deliberately evidence-first:
+
+1. Import or create a notebook, script, or app project.
+2. Run it through a controlled local environment first.
+3. Capture artifacts plus ``run_manifest.json`` evidence.
+4. Inspect and compare outputs in ANALYSIS, notebook export, MLflow handoff, or
+   proof-pack tools.
+5. Promote the result only when the evidence, package contract, and release
+   proof are coherent.
+
+That loop keeps exploratory ML work replayable before a team moves it into a
+heavier tracker, registry, cluster, or production platform.
+
 AGILAB is not locked to one web frontend. App projects can declare app-owned
 UI surfaces so the same runtime, artifacts, and evidence contract can be opened
 through the local Streamlit UI, a hosted Hugging Face backend, or browser-native

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -24,6 +24,20 @@ through one visible workflow: create the app, execute it under controlled
 runtime choices, inspect artifacts and evidence, then export the result to a
 notebook or MLflow handoff when needed.
 
+The flagship loop is:
+
+1. import or create a notebook, script, or app project;
+2. run it through a controlled local environment first;
+3. capture artifacts plus ``run_manifest.json`` evidence;
+4. inspect and compare outputs in ANALYSIS, notebook export, MLflow handoff, or
+   proof-pack tools;
+5. promote the result only when the evidence, package contract, and release
+   proof are coherent.
+
+That loop is the practical boundary for AGILAB as an ML workbench: it makes
+exploratory work replayable before a team chooses a heavier tracker, registry,
+cluster, or production platform.
+
 It has two main user interfaces:
 
 - ``agi-core``: the Python API you can call directly from code or notebooks


### PR DESCRIPTION
## Summary
- add a concise Golden ML Loop to the public README
- sync docs landing and product overview mirror from canonical docs
- keep AGILAB positioned as an evidence-first ML workbench, not a production MLOps replacement

## Validation
- uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs