### PR TITLE
[codex] Offload real PyPI uploads to trusted workflow

### DIFF
--- a/docs/source/package-publishing-policy.rst
+++ b/docs/source/package-publishing-policy.rst
@@ -540,11 +540,9 @@ future promotion but are skipped by the real PyPI publish step; their artifacts
 remain GitHub Release archive payloads until promotion.
 
 The local ``tools/pypi_publish.py`` helper may still build packages and publish
-to TestPyPI for rehearsals, but local twine upload to real PyPI is disabled by
-default. Real PyPI files should come from ``.github/workflows/pypi-publish.yaml``
-so PyPI metadata shows Trusted Publishing/OIDC provenance. Any break-glass local
-twine upload requires ``AGILAB_ALLOW_LOCAL_PYPI_TWINE=1`` and a documented
-release exception.
+to TestPyPI for rehearsals, but real PyPI upload is offloaded to
+``.github/workflows/pypi-publish.yaml``. PyPI metadata should therefore show
+Trusted Publishing/OIDC provenance for all public files.
 
 Release managers can run the same provenance gate locally after a publish run::
 

--- a/docs/source/package-publishing-policy.rst
+++ b/docs/source/package-publishing-policy.rst
@@ -540,9 +540,11 @@ future promotion but are skipped by the real PyPI publish step; their artifacts
 remain GitHub Release archive payloads until promotion.
 
 The local ``tools/pypi_publish.py`` helper may still build packages and publish
-to TestPyPI for rehearsals, but real PyPI upload is offloaded to
-``.github/workflows/pypi-publish.yaml``. PyPI metadata should therefore show
-Trusted Publishing/OIDC provenance for all public files.
+to TestPyPI for rehearsals, but local twine upload to real PyPI is disabled by
+default. Real PyPI files should come from ``.github/workflows/pypi-publish.yaml``
+so PyPI metadata shows Trusted Publishing/OIDC provenance. Any break-glass local
+twine upload requires ``AGILAB_ALLOW_LOCAL_PYPI_TWINE=1`` and a documented
+release exception.
 
 Release managers can run the same provenance gate locally after a publish run::
 

--- a/test/test_pypi_publish.py
+++ b/test/test_pypi_publish.py
@@ -29,12 +29,6 @@ def _load_pypi_publish():
     return module
 
 
-@pytest.fixture(autouse=True)
-def _allow_break_glass_pypi_for_release_flow_unit_tests(monkeypatch):
-    """Most tests exercise release ordering internals, not the outer OIDC gate."""
-    monkeypatch.setenv("AGILAB_ALLOW_LOCAL_PYPI_TWINE", "1")
-
-
 def _base_cfg(module, **overrides):
     values = {
         "repo": "pypi",
@@ -348,9 +342,9 @@ def test_require_safe_pypi_release_rejects_missing_repo_sync_flags() -> None:
         raise AssertionError("require_safe_pypi_release() should reject unsafe real PyPI publish settings")
 
 
-def test_require_safe_pypi_release_rejects_local_twine_without_break_glass(monkeypatch) -> None:
+def test_require_safe_pypi_release_accepts_valid_real_pypi_settings(monkeypatch) -> None:
     module = _load_pypi_publish()
-    monkeypatch.delenv(module.ALLOW_LOCAL_PYPI_TWINE_ENV, raising=False)
+    monkeypatch.setenv("AGILAB_ALLOW_LOCAL_PYPI_TWINE", "1")
 
     cfg = module.Cfg(
         repo="pypi",
@@ -378,8 +372,15 @@ def test_require_safe_pypi_release_rejects_local_twine_without_break_glass(monke
         gen_docs=False,
     )
 
-    with pytest.raises(SystemExit, match="Trusted Publishing/OIDC"):
-        module.require_safe_pypi_release(cfg)
+    module.require_safe_pypi_release(cfg)
+
+
+def test_twine_upload_rejects_real_pypi_uploads(monkeypatch) -> None:
+    module = _load_pypi_publish()
+    monkeypatch.setenv("AGILAB_ALLOW_LOCAL_PYPI_TWINE", "1")
+
+    with pytest.raises(SystemExit, match="offloaded to the GitHub pypi-publish workflow"):
+        module.twine_upload(["dist/agilab-2026.06.13.whl"], "pypi", True, 1)
 
 
 def test_require_safe_pypi_release_rejects_skipping_release_preflight() -> None:
@@ -1830,12 +1831,12 @@ def test_twine_upload_reports_summary_and_skip_existing(monkeypatch, capsys) -> 
 
     monkeypatch.setattr(module.subprocess, "run", _fake_run)
 
-    module.twine_upload(files, "pypi", True, 1)
+    module.twine_upload(files, "testpypi", True, 1)
 
     out = capsys.readouterr().out
     assert "[upload] uploaded: first.whl" in out
     assert "[upload] skipped existing (already on server): second.whl" in out
-    assert "[upload] summary: uploaded=1 skipped_existing=1 total=2 repo=pypi" in out
+    assert "[upload] summary: uploaded=1 skipped_existing=1 total=2 repo=testpypi" in out
     assert module.UPLOAD_SUCCESS_COUNT == 1
     assert module.UPLOAD_SKIPPED_EXISTING_COUNT == 1
 

--- a/tools/pypi_publish.py
+++ b/tools/pypi_publish.py
@@ -24,9 +24,8 @@ Typical:
   # with PyPI Trusted Publishing / OIDC.
 
 Notes
-- Local twine upload to real PyPI is disabled by default so published files show
-  Trusted Publishing / OIDC provenance. Set AGILAB_ALLOW_LOCAL_PYPI_TWINE=1 only
-  for documented break-glass maintenance.
+- Real PyPI uploads are offloaded to the GitHub pypi-publish workflow only so
+  published files show Trusted Publishing / OIDC provenance.
 - Cleanup/purge uses PyPI web login and needs real account USER/PASS (not token).
 """
 
@@ -104,7 +103,6 @@ except ModuleNotFoundError:  # pragma: no cover - used when imported as tools.py
 UPLOAD_COLLISION_DETECTED: bool = False
 UPLOAD_SUCCESS_COUNT: int = 0
 UPLOAD_SKIPPED_EXISTING_COUNT: int = 0
-ALLOW_LOCAL_PYPI_TWINE_ENV = "AGILAB_ALLOW_LOCAL_PYPI_TWINE"
 VERSION_PATTERN = r"\d+\.\d+\.\d+(?:\.\d+)?(?:(?:a|b|rc)\d+)?(?:\.post\d+)?"
 VERSION_RE = re.compile(rf"^{VERSION_PATTERN}$", re.IGNORECASE)
 
@@ -567,12 +565,6 @@ def require_safe_pypi_release(cfg: Cfg) -> None:
         )
     if cfg.repo != "pypi" or cfg.dry_run or cfg.cleanup_only:
         return
-    if str(os.environ.get(ALLOW_LOCAL_PYPI_TWINE_ENV, "")).strip().lower() not in {"1", "true", "yes", "on"}:
-        raise SystemExit(
-            "ERROR: Local twine upload to real PyPI is disabled. "
-            "Run the GitHub pypi-publish workflow so PyPI files are uploaded via Trusted Publishing/OIDC. "
-            f"Break-glass local upload requires {ALLOW_LOCAL_PYPI_TWINE_ENV}=1 and must be documented."
-        )
     missing: list[str] = []
     if not cfg.git_commit_version:
         missing.append("--git-commit-version")
@@ -1466,6 +1458,11 @@ def twine_upload(files: List[str], repo: str, skip_existing: bool, retries: int)
     global UPLOAD_COLLISION_DETECTED, UPLOAD_SUCCESS_COUNT, UPLOAD_SKIPPED_EXISTING_COUNT
     if not files:
         raise SystemExit("No artifacts to upload")
+    if repo == "pypi":
+        raise SystemExit(
+            "ERROR: Real PyPI uploads are offloaded to the GitHub pypi-publish workflow. "
+            "Use the workflow so PyPI files are uploaded via Trusted Publishing/OIDC."
+        )
     UPLOAD_COLLISION_DETECTED = False
     UPLOAD_SUCCESS_COUNT = 0
     UPLOAD_SKIPPED_EXISTING_COUNT = 0


### PR DESCRIPTION
## Summary
- block direct local twine uploads to real PyPI inside the upload path
- require the GitHub pypi-publish workflow for real PyPI files so artifacts use Trusted Publishing/OIDC provenance
- keep TestPyPI/local upload behavior covered for rehearsal paths

## Validation
- ./dev test test/test_pypi_publish.py