### PR TITLE
fix: use underscore hotfix release tags

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -16,7 +16,7 @@ on:
         description: "Optional git ref used to publish only changed packages plus exact-pin dependents. Ignored when packages or roles are set."
         required: false
       release_mode:
-        description: "Release intent: stable=YYYY.MM.DD, hotfix=YYYY.MM.DD.N, candidate=YYYY.MM.DDrcN, repair=no PyPI distributions."
+        description: "Release intent: stable=YYYY.MM.DD, hotfix=package YYYY.MM.DD.N with release tag vYYYY.MM.DD_N, candidate=YYYY.MM.DDrcN, repair=no PyPI distributions."
         required: false
         type: choice
         default: stable

--- a/test/test_audit_response_docs.py
+++ b/test/test_audit_response_docs.py
@@ -291,6 +291,7 @@ def test_package_publishing_policy_addresses_common_audit_misreads() -> None:
     assert "tools/pypi_release_version_policy.py" in policy
     assert "``release_mode=hotfix``" in policy
     assert "``YYYY.MM.DD.N``" in policy
+    assert "``vYYYY.MM.DD_N``" in policy
     assert "release-candidate versions such as ``YYYY.MM.DDrc1``" in policy
     assert "disallow_untyped_defs = true" in policy
     assert "runs mypy with ``--strict``" in policy

--- a/test/test_pypi_publish.py
+++ b/test/test_pypi_publish.py
@@ -435,6 +435,7 @@ def test_public_post_release_policy_rejects_post_release_even_with_legacy_env(mo
     message = str(excinfo.value)
     assert ".postN releases are forbidden" in message
     assert "YYYY.MM.DD.N" in message
+    assert "vYYYY.MM.DD_N" in message
 
 
 def test_public_post_release_policy_accepts_hotfix_and_rejects_dry_run_post_release() -> None:
@@ -757,6 +758,21 @@ def test_compute_date_tag_with_collisions(monkeypatch) -> None:
     monkeypatch.setattr(module, "_tag_exists", lambda tag, repo=None: tag in existing)
 
     assert module.compute_date_tag() == "2026.03.20-3"
+
+
+def test_compute_release_tag_for_hotfix_uses_underscore_suffix(monkeypatch) -> None:
+    module = _load_pypi_publish()
+    monkeypatch.setattr(module, "_tag_exists", lambda _tag, repo=None: False)
+
+    assert module.compute_release_tag_for_version("2026.03.20.1") == "2026.03.20_1"
+
+
+def test_compute_release_tag_for_hotfix_keeps_retry_collision_suffix(monkeypatch) -> None:
+    module = _load_pypi_publish()
+    existing = {"v2026.03.20_1", "v2026.03.20_1-2"}
+    monkeypatch.setattr(module, "_tag_exists", lambda tag, repo=None: tag in existing)
+
+    assert module.compute_release_tag_for_version("2026.03.20.1") == "2026.03.20_1-3"
 
 
 def test_github_release_notes_lists_published_packages() -> None:

--- a/test/test_pypi_release_version_policy.py
+++ b/test/test_pypi_release_version_policy.py
@@ -71,7 +71,8 @@ def test_release_version_policy_rejects_public_post_release_even_with_hotfix_mod
 
     message = str(excinfo.value)
     assert ".postN releases are forbidden" in message
-    assert "release_mode=hotfix with YYYY.MM.DD.N" in message
+    assert "release_mode=hotfix with package version YYYY.MM.DD.N" in message
+    assert "release tag vYYYY.MM.DD_N" in message
 
 
 def test_release_version_policy_rejects_stable_shape_in_hotfix_mode() -> None:

--- a/test/test_release_robustness_tools.py
+++ b/test/test_release_robustness_tools.py
@@ -137,6 +137,7 @@ def test_pypi_project_preflight_caches_project_version_until_manifest_changes(
 
 def test_release_status_derives_package_version_from_release_tag() -> None:
     assert release_status.package_version_from_tag("v2026.05.23-2") == "2026.05.23"
+    assert release_status.package_version_from_tag("v2026.05.23_1") == "2026.05.23.1"
     assert (
         release_status.package_version_from_tag("refs/tags/v2026.05.26") == "2026.05.26"
     )
@@ -216,19 +217,19 @@ def test_release_handoff_guard_requires_archiving_old_handoffs(tmp_path: Path) -
     )
 
 
-def test_release_handoff_guard_accepts_dot_hotfix_release_tags(tmp_path: Path) -> None:
+def test_release_handoff_guard_accepts_underscore_hotfix_release_tags(tmp_path: Path) -> None:
     manifest = tmp_path / "release_proof.toml"
     manifest.write_text(
-        '[release]\ngithub_release_tag = "v2026.06.04.1"\n',
+        '[release]\ngithub_release_tag = "v2026.06.04_1"\n',
         encoding="utf-8",
     )
     handoff = tmp_path / "v2026.06.04-handoff.md"
     handoff.write_text("# AGILAB release handoff for v2026.06.04\n", encoding="utf-8")
 
-    assert release_handoff_guard.latest_release_tag(manifest) == "v2026.06.04.1"
+    assert release_handoff_guard.latest_release_tag(manifest) == "v2026.06.04_1"
     assert release_handoff_guard.stale_handoffs(
         handoff_dir=tmp_path,
-        latest_tag="v2026.06.04.1",
+        latest_tag="v2026.06.04_1",
     ) == [handoff]
 
 

--- a/test/test_security_hygiene_report.py
+++ b/test/test_security_hygiene_report.py
@@ -92,6 +92,8 @@ def test_release_tag_alignment_accepts_same_version_retry_tags() -> None:
     assert not module._release_tag_matches_version("v2026.05.11", "")
     assert module._release_tag_matches_version("v2026.05.11", "2026.05.11")
     assert module._release_tag_matches_version("v2026.05.11-2", "2026.05.11")
+    assert module._release_tag_matches_version("v2026.05.11_1", "2026.05.11.1")
+    assert module._release_tag_matches_version("v2026.05.11_1-2", "2026.05.11.1")
     assert module._release_tag_matches_version("v2026.05.12.post1", "2026.05.12.post1")
     assert module._release_tag_matches_version("v2026.05.12.post1-2", "2026.05.12.post1")
     assert module._release_tag_matches_version("v2026.05.12-5", "2026.05.12.post1")

--- a/tools/pypi_publish.py
+++ b/tools/pypi_publish.py
@@ -8,9 +8,9 @@ Highlights
 - Builds with uv (wheels and/or sdists). No pep517 shim.
 - Per-package versions for published AGI components, bundles, and payload packages.
   Real PyPI never auto-bumps to .postN; choose an explicit new version instead.
-  Public .postN releases are reserved for documented critical hotfixes. Use
-  release-candidate versions or TestPyPI for release rehearsals; TestPyPI may
-  auto-bump .postN for retries.
+  Public package hotfixes use YYYY.MM.DD.N. GitHub release tags use
+  vYYYY.MM.DD_N for the same-day id. Use release-candidate versions or TestPyPI
+  for release rehearsals; TestPyPI may auto-bump .postN for retries.
 - Robust pyproject.toml editing with tomlkit (preserves formatting, trailing newline).
 - TestPyPI twine auth from ~/.pypirc; CLI --username/--password are ONLY for cleanup/purge.
 - Optional purge/cleanup (web login flow) before/after using pypi-cleanup.
@@ -142,7 +142,8 @@ def parse_args() -> argparse.Namespace:
         help=(
             "Explicit version 'X.Y.Z[.N][rcN][.postN]'. If omitted, base=UTC YYYY.MM.DD. "
             "Real PyPI refuses automatic .postN bumps when that version is already used; "
-            ".postN is forbidden on public PyPI. Use YYYY.MM.DD.N for same-day hotfixes."
+            ".postN is forbidden on public PyPI. Use package version YYYY.MM.DD.N "
+            "and release tag vYYYY.MM.DD_N for same-day hotfixes."
         ),
     )
 
@@ -609,8 +610,8 @@ def require_public_post_release_policy(cfg: Cfg, package_versions: Dict[str, str
     raise SystemExit(
         "ERROR: Public PyPI .postN releases are forbidden for new AGILAB publications. "
         f"Selected post-release versions: {formatted}. Use a release candidate or TestPyPI for "
-        "rehearsal, publish YYYY.MM.DD for a stable release, or publish YYYY.MM.DD.N "
-        "for a same-day hotfix."
+        "rehearsal, publish YYYY.MM.DD for a stable release, or publish package "
+        "version YYYY.MM.DD.N with release tag vYYYY.MM.DD_N for a same-day hotfix."
     )
 
 
@@ -1677,6 +1678,25 @@ def compute_date_tag() -> str:
     return tag
 
 
+def hotfix_release_tag_base(version: str) -> str | None:
+    match = re.fullmatch(r"(\d{4}\.\d{1,2}\.\d{1,2})\.(\d+)", version.strip())
+    if not match:
+        return None
+    return f"{match.group(1)}_{match.group(2)}"
+
+
+def compute_release_tag_for_version(version: str) -> str:
+    base = hotfix_release_tag_base(version)
+    if base is None:
+        return compute_date_tag()
+    tag = base
+    n = 2
+    while _tag_exists(f"v{tag}"):
+        tag = f"{base}-{n}"
+        n += 1
+    return tag
+
+
 def _is_git_repo(path: pathlib.Path) -> bool:
     try:
         subprocess.run(
@@ -2535,7 +2555,7 @@ def main():
             print(f"  - {name}: {package_versions[name]}")
         date_tag = normalize_base(chosen)  # primary date base (YYYY.MM.DD)
         print(f"[plan] Tag base (UTC): {date_tag}")
-        planned_tag = compute_date_tag() if cfg.repo == "pypi" and cfg.git_tag else None
+        planned_tag = compute_release_tag_for_version(chosen) if cfg.repo == "pypi" and cfg.git_tag else None
         if cfg.dry_run:
             print("[dry-run] Collisions per package:")
             for n in version_targets:

--- a/tools/pypi_release_version_policy.py
+++ b/tools/pypi_release_version_policy.py
@@ -87,7 +87,8 @@ def validate_public_release_versions(
         raise ReleaseVersionPolicyError(
             "Public PyPI .postN releases are forbidden for new AGILAB publications. "
             f"Selected post-release versions: {formatted}. Use release_mode=stable with "
-            "YYYY.MM.DD, release_mode=hotfix with YYYY.MM.DD.N for a same-day fix, or "
+            "YYYY.MM.DD, release_mode=hotfix with package version YYYY.MM.DD.N "
+            "and release tag vYYYY.MM.DD_N for a same-day fix, or "
             "release_mode=candidate with YYYY.MM.DDrcN for a public pre-release rehearsal."
         )
 
@@ -194,7 +195,8 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         choices=RELEASE_MODES,
         default="stable",
         help=(
-            "Public release intent: stable=YYYY.MM.DD, hotfix=YYYY.MM.DD.N, "
+            "Public release intent: stable=YYYY.MM.DD, hotfix=package YYYY.MM.DD.N "
+            "with release tag vYYYY.MM.DD_N, "
             "candidate=YYYY.MM.DDrcN, repair=no PyPI distributions."
         ),
     )

--- a/tools/release_handoff_guard.py
+++ b/tools/release_handoff_guard.py
@@ -13,15 +13,17 @@ from typing import Sequence
 ROOT = Path(__file__).resolve().parents[1]
 HANDOFF_DIR = ROOT / "tools" / "release_handoffs"
 PROOF_MANIFEST = ROOT / "docs" / "source" / "data" / "release_proof.toml"
-TAG_RE = re.compile(r"v\d{4}\.\d{2}\.\d{2}(?:(?:-|\.)\d+)?")
+TAG_RE = re.compile(r"v\d{4}\.\d{2}\.\d{2}(?:(?:-|\.|_)\d+)?")
 
 
 def _tag_key(tag: str) -> tuple[int, int, int, int]:
     body = tag.removeprefix("v")
     suffix = 0
-    if "-" in body:
-        body, raw_suffix = body.rsplit("-", 1)
-        suffix = int(raw_suffix) if raw_suffix.isdigit() else 0
+    for separator in ("-", "_"):
+        if separator in body:
+            body, raw_suffix = body.rsplit(separator, 1)
+            suffix = int(raw_suffix) if raw_suffix.isdigit() else 0
+            break
     parts = body.split(".")
     if len(parts) == 4:
         raw_suffix = parts.pop()

--- a/tools/release_status.py
+++ b/tools/release_status.py
@@ -29,7 +29,8 @@ def package_version_from_tag(tag: str) -> str:
     if value.startswith("refs/tags/"):
         value = value.removeprefix("refs/tags/")
     value = value.removeprefix("v")
-    return re.sub(r"-\d+$", "", value)
+    value = re.sub(r"-\d+$", "", value)
+    return re.sub(r"^(\d{4}\.\d{1,2}\.\d{1,2})_(\d+)$", r"\1.\2", value)
 
 
 def _run_json(command: list[str]) -> tuple[dict[str, Any] | None, str | None]:

--- a/tools/security_hygiene_report.py
+++ b/tools/security_hygiene_report.py
@@ -494,6 +494,9 @@ def _release_tag_matches_version(manifest_tag: str, project_version: str) -> boo
     if not manifest_tag or not project_version:
         return False
     accepted_bases = [project_version]
+    hotfix_tag = re.sub(r"^(\d{4}\.\d{1,2}\.\d{1,2})\.(\d+)$", r"\1_\2", project_version)
+    if hotfix_tag != project_version:
+        accepted_bases.append(hotfix_tag)
     post_base = re.sub(r"\.post\d+\Z", "", project_version)
     if post_base != project_version:
         accepted_bases.append(post_base)
@@ -507,6 +510,9 @@ def _accepted_release_tag_pattern(project_version: str) -> str:
     if not project_version:
         return ""
     patterns = [f"v{project_version}[-N]"]
+    hotfix_tag = re.sub(r"^(\d{4}\.\d{1,2}\.\d{1,2})\.(\d+)$", r"\1_\2", project_version)
+    if hotfix_tag != project_version:
+        patterns.insert(0, f"v{hotfix_tag}[-N]")
     post_base = re.sub(r"\.post\d+\Z", "", project_version)
     if post_base != project_version:
         patterns.append(f"v{post_base}[-N]")


### PR DESCRIPTION
## Summary
- derive hotfix GitHub release tags from package versions as vYYYY.MM.DD_N while keeping PyPI package versions PEP 440-valid as YYYY.MM.DD.N
- teach release status, handoff, and security hygiene checks to accept underscore hotfix release tags
- update release policy docs/workflow help and regression coverage
- sync docs-source mirror stamp and release-proof data from the canonical docs source

## Validation
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_pypi_publish.py test/test_pypi_release_version_policy.py test/test_release_robustness_tools.py test/test_security_hygiene_report.py test/test_audit_response_docs.py test/test_pypi_publish_workflow.py
- uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files .github/workflows/pypi-publish.yaml docs/source/package-publishing-policy.rst test/test_audit_response_docs.py test/test_pypi_publish.py test/test_pypi_release_version_policy.py test/test_release_robustness_tools.py test/test_security_hygiene_report.py tools/pypi_publish.py tools/pypi_release_version_policy.py tools/release_handoff_guard.py tools/release_status.py tools/security_hygiene_report.py
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs
- uv --preview-features extra-build-dependencies run python tools/release_proof_report.py --check --compact
- uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp
- git diff --check