### PR TITLE
fix: expose orchestrate pool parameters

### DIFF
--- a/src/agilab/orchestrate/orchestrate_cluster.py
+++ b/src/agilab/orchestrate/orchestrate_cluster.py
@@ -41,6 +41,10 @@ LAN_UI_PROBE_WORKERS = 32
 CLUSTER_ADVISOR_SCHEMA = "agilab.cluster_advisor.v1"
 CLUSTER_PLAN_FILE = Path(".agilab") / "cluster_plan.json"
 MAX_ADVISED_WORKERS_PER_HOST = 4
+POOL_MAX_WORKERS_ENV = "AGILAB_POOL_MAX_WORKERS"
+POOL_ITEM_TIMEOUT_ENV = "AGILAB_POOL_ITEM_TIMEOUT"
+POOL_EXECUTOR_ENV = "AGILAB_POOL_EXECUTOR"
+POOL_EXECUTOR_OPTIONS = ("auto", "process", "thread")
 
 
 @dataclass(frozen=True)
@@ -68,6 +72,9 @@ def cluster_widget_keys(app_state_name: str) -> dict[str, str]:
         "pool": f"cluster_pool__{app_state_name}",
         "rapids": f"cluster_rapids__{app_state_name}",
         "cluster_enabled": f"cluster_enabled__{app_state_name}",
+        "pool_max_workers": f"cluster_pool_max_workers__{app_state_name}",
+        "pool_item_timeout": f"cluster_pool_item_timeout__{app_state_name}",
+        "pool_executor": f"cluster_pool_executor__{app_state_name}",
         "scheduler": f"cluster_scheduler__{app_state_name}",
         "user": f"cluster_user__{app_state_name}",
         "use_key": f"cluster_use_key__{app_state_name}",
@@ -94,6 +101,18 @@ def hydrate_cluster_widget_state(
     session_state.setdefault(widget_keys["cluster_enabled"], bool(cluster_params.get("cluster_enabled", False)))
     session_state.setdefault(widget_keys["cython"], bool(cluster_params.get("cython", False)))
     session_state.setdefault(widget_keys["pool"], bool(cluster_params.get("pool", False)))
+    session_state.setdefault(
+        widget_keys["pool_max_workers"],
+        _optional_positive_int(cluster_params.get("pool_max_workers")) or 0,
+    )
+    session_state.setdefault(
+        widget_keys["pool_item_timeout"],
+        _optional_positive_float(cluster_params.get("pool_item_timeout")) or 0.0,
+    )
+    session_state.setdefault(
+        widget_keys["pool_executor"],
+        _pool_executor_value(cluster_params.get("pool_executor")),
+    )
     if is_managed_pc:
         session_state[widget_keys["rapids"]] = False
     else:
@@ -135,6 +154,64 @@ def persist_env_var_if_changed(
         current = str(agi_env_envars.get(key, "") or "")
     if normalized != current:
         set_env_var(key, normalized)
+
+
+def _optional_positive_int(value: Any) -> int | None:
+    if value in (None, ""):
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _optional_positive_float(value: Any) -> float | None:
+    if value in (None, ""):
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _pool_executor_value(value: Any) -> str:
+    normalized = str(value or "auto").strip().lower()
+    if normalized not in POOL_EXECUTOR_OPTIONS:
+        return "auto"
+    return normalized
+
+
+def _persist_pool_runtime_env(
+    *,
+    cluster_params: dict[str, Any],
+    pool_enabled: bool,
+    set_env_var: Callable[[str, str], None],
+    agi_env_envars: dict[str, Any] | None,
+) -> None:
+    if pool_enabled:
+        max_workers = _optional_positive_int(cluster_params.get("pool_max_workers"))
+        item_timeout = _optional_positive_float(cluster_params.get("pool_item_timeout"))
+        executor = _pool_executor_value(cluster_params.get("pool_executor"))
+        values = {
+            POOL_MAX_WORKERS_ENV: "" if max_workers is None else str(max_workers),
+            POOL_ITEM_TIMEOUT_ENV: "" if item_timeout is None else str(item_timeout),
+            POOL_EXECUTOR_ENV: "" if executor == "auto" else executor,
+        }
+    else:
+        values = {
+            POOL_MAX_WORKERS_ENV: "",
+            POOL_ITEM_TIMEOUT_ENV: "",
+            POOL_EXECUTOR_ENV: "",
+        }
+    for key, value in values.items():
+        persist_env_var_if_changed(
+            key=key,
+            value=value,
+            set_env_var=set_env_var,
+            agi_env_envars=agi_env_envars,
+        )
 
 
 def _describe_share_path(env: Any) -> str:
@@ -814,6 +891,73 @@ def render_cluster_settings_ui(env: Any, deps: OrchestrateClusterDeps, *, show_r
             help=f"Enable or disable {param}.",
         )
         cluster_params[param] = updated_value
+
+    pool_enabled = bool(cluster_params.get("pool", False))
+    if pool_enabled:
+        with st.container():
+            st.markdown("**Pool parameters**")
+            pool_cols = st.columns(3)
+            max_workers_key = widget_keys["pool_max_workers"]
+            if max_workers_key not in st.session_state:
+                st.session_state[max_workers_key] = _optional_positive_int(
+                    cluster_params.get("pool_max_workers")
+                ) or 0
+            max_workers = pool_cols[0].number_input(
+                "Max workers",
+                key=max_workers_key,
+                min_value=0,
+                step=1,
+                help="Optional cap for in-worker pool width. Use 0 for the automatic CPU/chunk limit.",
+            )
+            max_workers_value = _optional_positive_int(max_workers)
+            if max_workers_value is None:
+                cluster_params.pop("pool_max_workers", None)
+            else:
+                cluster_params["pool_max_workers"] = max_workers_value
+
+            item_timeout_key = widget_keys["pool_item_timeout"]
+            if item_timeout_key not in st.session_state:
+                st.session_state[item_timeout_key] = _optional_positive_float(
+                    cluster_params.get("pool_item_timeout")
+                ) or 0.0
+            item_timeout = pool_cols[1].number_input(
+                "Item timeout seconds",
+                key=item_timeout_key,
+                min_value=0.0,
+                step=0.5,
+                help="Optional per-work-item timeout. Use 0 for no timeout.",
+            )
+            item_timeout_value = _optional_positive_float(item_timeout)
+            if item_timeout_value is None:
+                cluster_params.pop("pool_item_timeout", None)
+            else:
+                cluster_params["pool_item_timeout"] = item_timeout_value
+
+            executor_key = widget_keys["pool_executor"]
+            executor_value = _pool_executor_value(cluster_params.get("pool_executor"))
+            if executor_key not in st.session_state:
+                st.session_state[executor_key] = executor_value
+            selected_executor = pool_cols[2].selectbox(
+                "Pool executor",
+                POOL_EXECUTOR_OPTIONS,
+                key=executor_key,
+                help="Choose auto unless you need to force process or thread execution.",
+            )
+            executor_value = _pool_executor_value(selected_executor)
+            if executor_value == "auto":
+                cluster_params.pop("pool_executor", None)
+            else:
+                cluster_params["pool_executor"] = executor_value
+    else:
+        for key in ("pool_max_workers", "pool_item_timeout", "pool_executor"):
+            cluster_params.pop(key, None)
+
+    _persist_pool_runtime_env(
+        cluster_params=cluster_params,
+        pool_enabled=pool_enabled,
+        set_env_var=deps.set_env_var,
+        agi_env_envars=deps.agi_env_envars,
+    )
 
     cluster_enabled_key = widget_keys["cluster_enabled"]
     cluster_share_problem = _cluster_share_problem(env)

--- a/test/test_orchestrate_cluster.py
+++ b/test/test_orchestrate_cluster.py
@@ -63,6 +63,12 @@ class _Context:
     def columns(self, spec, **kwargs):
         return self._st.columns(spec, **kwargs)
 
+    def number_input(self, *args, **kwargs):
+        return self._st.number_input(*args, **kwargs)
+
+    def selectbox(self, *args, **kwargs):
+        return self._st.selectbox(*args, **kwargs)
+
 
 class _FakeStreamlit:
     def __init__(self, *, widget_values=None, session_state=None, button_values=None):
@@ -73,6 +79,8 @@ class _FakeStreamlit:
         self.infos: list[str] = []
         self.errors: list[str] = []
         self.buttons: list[str] = []
+        self.number_inputs: list[str] = []
+        self.selectboxes: list[str] = []
 
     def _value(self, key, default=""):
         if key in self.widget_values:
@@ -106,6 +114,23 @@ class _FakeStreamlit:
 
     def text_area(self, _label, *, key=None, value="", **_kwargs):
         result = self._value(key, value)
+        if key is not None:
+            self.session_state[key] = result
+        return result
+
+    def number_input(self, label, *, key=None, value=0, **_kwargs):
+        self.number_inputs.append(label)
+        result = self._value(key, value)
+        if key is not None:
+            self.session_state[key] = result
+        return result
+
+    def selectbox(self, label, options, *, key=None, index=0, **_kwargs):
+        self.selectboxes.append(label)
+        default = options[index]
+        result = self._value(key, default)
+        if result not in options:
+            result = default
         if key is not None:
             self.session_state[key] = result
         return result
@@ -974,6 +999,9 @@ def test_render_cluster_settings_ui_initializes_state_and_persists_cluster_mode(
             "cluster_cython__demo_project": True,
             "cluster_pool__demo_project": True,
             "cluster_rapids__demo_project": True,
+            "cluster_pool_max_workers__demo_project": 3,
+            "cluster_pool_item_timeout__demo_project": 2.5,
+            "cluster_pool_executor__demo_project": "thread",
             "cluster_enabled__demo_project": False,
         },
         session_state={"benchmark": False},
@@ -1006,12 +1034,80 @@ def test_render_cluster_settings_ui_initializes_state_and_persists_cluster_mode(
     assert cluster["cython"] is True
     assert cluster["pool"] is True
     assert cluster["rapids"] is True
+    assert cluster["pool_max_workers"] == 3
+    assert cluster["pool_item_timeout"] == 2.5
+    assert cluster["pool_executor"] == "thread"
     assert cluster["cluster_enabled"] is False
+    assert "**Pool parameters**" in fake_st.markdowns
+    assert fake_st.number_inputs == ["Max workers", "Item timeout seconds"]
+    assert fake_st.selectboxes == ["Pool executor"]
     assert fake_st.session_state.dask is False
     assert fake_st.session_state["mode"] == 11
     assert fake_st.infos[-1] == "Run mode 11: rapids and pool and cython"
+    assert ("AGILAB_POOL_MAX_WORKERS", "3") in writes["env_calls"]
+    assert ("AGILAB_POOL_ITEM_TIMEOUT", "2.5") in writes["env_calls"]
+    assert ("AGILAB_POOL_EXECUTOR", "thread") in writes["env_calls"]
     assert writes["cleared"] is True
     assert writes["write"][0] == env.app_settings_file
+
+
+def test_render_cluster_settings_ui_clears_pool_parameters_when_pool_disabled(monkeypatch, tmp_path):
+    fake_st = _FakeStreamlit(
+        widget_values={
+            "cluster_cython__demo_project": False,
+            "cluster_pool__demo_project": False,
+            "cluster_rapids__demo_project": False,
+            "cluster_enabled__demo_project": False,
+        },
+        session_state={
+            "app_settings": {
+                "cluster": {
+                    "pool": True,
+                    "pool_max_workers": 4,
+                    "pool_item_timeout": 1.0,
+                    "pool_executor": "process",
+                }
+            },
+            "benchmark": False,
+        },
+    )
+    monkeypatch.setattr(orchestrate_cluster, "st", fake_st)
+
+    writes: dict[str, object] = {}
+    deps = orchestrate_cluster.OrchestrateClusterDeps(
+        parse_and_validate_scheduler=lambda raw: raw,
+        parse_and_validate_workers=lambda raw: {"parsed": raw},
+        write_app_settings_toml=lambda path, settings: writes.setdefault("write", (path, settings)) and settings,
+        clear_load_toml_cache=lambda: writes.setdefault("cleared", True),
+        set_env_var=lambda key, value: writes.setdefault("env_calls", []).append((key, value)),
+        agi_env_envars={
+            "AGILAB_POOL_MAX_WORKERS": "4",
+            "AGILAB_POOL_ITEM_TIMEOUT": "1.0",
+            "AGILAB_POOL_EXECUTOR": "process",
+        },
+    )
+    env = SimpleNamespace(
+        app="demo_project",
+        is_managed_pc=False,
+        agi_share_path=None,
+        share_root_path=lambda: tmp_path / "share",
+        user="",
+        password=None,
+        ssh_key_path=None,
+        app_settings_file=tmp_path / "app_settings.toml",
+    )
+
+    orchestrate_cluster.render_cluster_settings_ui(env, deps)
+
+    cluster = fake_st.session_state.app_settings["cluster"]
+    assert cluster["pool"] is False
+    assert "pool_max_workers" not in cluster
+    assert "pool_item_timeout" not in cluster
+    assert "pool_executor" not in cluster
+    assert "Pool parameters" not in fake_st.markdowns
+    assert ("AGILAB_POOL_MAX_WORKERS", "") in writes["env_calls"]
+    assert ("AGILAB_POOL_ITEM_TIMEOUT", "") in writes["env_calls"]
+    assert ("AGILAB_POOL_EXECUTOR", "") in writes["env_calls"]
 
 
 def test_render_cluster_settings_ui_can_hide_run_mode_info(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- show pool tuning controls in ORCHESTRATE Resources and deployment when Pool is enabled
- persist max workers, item timeout, and executor under cluster settings and export the existing worker-pool env vars
- clear stale pool runtime overrides when Pool is disabled

## Validation
- uv --preview-features extra-build-dependencies run python tools/impact_validate.py --staged
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_orchestrate_cluster.py -q