### PR TITLE
test: cover orchestrate pool controls in UI robots

### DIFF
--- a/test/test_agilab_widget_robot_matrix.py
+++ b/test/test_agilab_widget_robot_matrix.py
@@ -36,8 +36,22 @@ def test_default_scenarios_cover_isolated_pages_and_current_home_actions() -> No
         "current-home-actions",
         "current-home-pytorch-direct-run-readiness",
         "current-home-orchestrate-journey",
+        "isolated-orchestrate-pool-parameters",
     ]
-    isolated, entry, project, project_editor, project_notebook, project_import, project_rename, settings, current_home, pytorch_direct, journey = scenarios
+    (
+        isolated,
+        entry,
+        project,
+        project_editor,
+        project_notebook,
+        project_import,
+        project_rename,
+        settings,
+        current_home,
+        pytorch_direct,
+        journey,
+        pool_parameters,
+    ) = scenarios
     assert isolated.pages == "ORCHESTRATE,WORKFLOW,ANALYSIS"
     assert isolated.runtime_isolation == "isolated"
     assert isolated.action_button_policy == "trial"
@@ -102,6 +116,13 @@ def test_default_scenarios_cover_isolated_pages_and_current_home_actions() -> No
     assert "EXPORT dataframe" in journey.click_action_labels
     assert "Confirm delete" in journey.click_action_labels
     assert journey.assert_orchestrate_artifacts is True
+    assert pool_parameters.pages == "ORCHESTRATE"
+    assert pool_parameters.apps == "flight_telemetry_project"
+    assert pool_parameters.runtime_isolation == "isolated"
+    assert pool_parameters.action_button_policy == "trial"
+    assert pool_parameters.max_action_clicks_per_page == 0
+    assert pool_parameters.required_text == "Pool parameters,Max workers,Item timeout seconds,Pool executor"
+    assert pool_parameters.browser_error_check is True
     assert "isolated-browser-history" not in [scenario.name for scenario in scenarios]
     assert "isolated-mobile-core-pages" not in [scenario.name for scenario in scenarios]
     assert "isolated-fresh-session-core-pages" not in [scenario.name for scenario in scenarios]
@@ -1547,13 +1568,14 @@ def test_run_matrix_aggregates_json_summaries(tmp_path) -> None:
         "current-home-actions",
         "current-home-pytorch-direct-run-readiness",
         "current-home-orchestrate-journey",
+        "isolated-orchestrate-pool-parameters",
     ]
     assert summary["success"] is True
-    assert summary["scenario_count"] == 11
-    assert summary["page_count"] == 22
-    assert summary["widget_count"] == 55
-    assert summary["interacted_count"] == 33
-    assert summary["probed_count"] == 22
+    assert summary["scenario_count"] == 12
+    assert summary["page_count"] == 24
+    assert summary["widget_count"] == 60
+    assert summary["interacted_count"] == 36
+    assert summary["probed_count"] == 24
     assert summary["failed_scenarios"] == []
     assert summary["failure_samples"] == []
 

--- a/test/test_ui_pages.py
+++ b/test/test_ui_pages.py
@@ -1230,6 +1230,7 @@ def test_execute_page_cluster_settings(mock_ui_env):
     assert "Observe benchmark results" not in expander_labels
     assert all("Path: Prepare" not in label for label in expander_labels)
     assert "Resource summary" in markdown_text
+    assert "Pool parameters" in markdown_text
     assert "Share" in markdown_text
     assert "CPU" in markdown_text
     assert "RAM" in markdown_text
@@ -1275,6 +1276,12 @@ def test_execute_page_cluster_settings(mock_ui_env):
     pool_state = at.session_state[pool_key] if pool_key in at.session_state else None
     assert cluster_state.get("cluster_enabled", enabled_state) is True
     assert cluster_state.get("pool", pool_state) is True
+    assert at.number_input(key=f"cluster_pool_max_workers__{app_state_name}").label == "Max workers"
+    assert (
+        at.number_input(key=f"cluster_pool_item_timeout__{app_state_name}").label
+        == "Item timeout seconds"
+    )
+    assert at.selectbox(key=f"cluster_pool_executor__{app_state_name}").label == "Pool executor"
     assert at.session_state[scheduler_key] == "127.0.0.1:8786"
     assert "agi_share_path" not in markdown_text
 

--- a/test/test_ui_robot_coverage_contract.py
+++ b/test/test_ui_robot_coverage_contract.py
@@ -106,6 +106,11 @@ def test_ui_robot_coverage_contract_passes_for_current_matrix() -> None:
     assert "isolated-project-editor-page" in payload["coverage"]["ui_robot_matrix_profile_scenarios"]
     assert "isolated-pytorch-playground-analysis" in payload["coverage"]["ui_robot_matrix_profile_scenarios"]
     assert "isolated-release-evidence" in payload["coverage"]["ui_robot_matrix_profile_scenarios"]
+    assert payload["coverage"]["orchestrate_pool_robot"] == {
+        "flags": ["browser_error_check"],
+        "pages": ["ORCHESTRATE"],
+        "required_text": ["Item timeout seconds", "Max workers", "Pool executor", "Pool parameters"],
+    }
     assert payload["coverage"]["pytorch_analysis_robot"] == {
         "apps": ["pytorch_playground_project"],
         "forbidden_sidebar_text": ["Project:"],
@@ -213,6 +218,11 @@ def test_ui_robot_coverage_contract_accepts_explicit_full_app_profile(monkeypatc
         pages="ORCHESTRATE",
         click_action_labels="Deploy workers",
     )
+    orchestrate_pool = scenario(
+        module.REQUIRED_ORCHESTRATE_POOL_SCENARIO,
+        pages="ORCHESTRATE",
+        required_text=",".join(module.REQUIRED_ORCHESTRATE_POOL_TEXT),
+    )
     pytorch = scenario(
         "isolated-pytorch-playground-analysis",
         pages="ANALYSIS",
@@ -226,7 +236,16 @@ def test_ui_robot_coverage_contract_accepts_explicit_full_app_profile(monkeypatc
     release_evidence = scenario(module.REQUIRED_RELEASE_EVIDENCE_SCENARIO, pages="PROJECT,ORCHESTRATE,ANALYSIS")
     all_scenarios = {
         item.name: item
-        for item in (core_scenario, editor, hf_visual, hf_app_pages, hf_install, pytorch, release_evidence)
+        for item in (
+            core_scenario,
+            editor,
+            hf_visual,
+            hf_app_pages,
+            hf_install,
+            orchestrate_pool,
+            pytorch,
+            release_evidence,
+        )
     }
     widget_robot = SimpleNamespace(
         page_label=lambda page: str(page),
@@ -240,7 +259,11 @@ def test_ui_robot_coverage_contract_accepts_explicit_full_app_profile(monkeypatc
         ],
     )
     matrix = SimpleNamespace(
-        DEFAULT_SCENARIOS={"core-selected-actions": core_scenario, "isolated-project-editor-page": editor},
+        DEFAULT_SCENARIOS={
+            "core-selected-actions": core_scenario,
+            "isolated-project-editor-page": editor,
+            module.REQUIRED_ORCHESTRATE_POOL_SCENARIO: orchestrate_pool,
+        },
         ALL_SCENARIOS=all_scenarios,
         OPT_IN_SCENARIOS={"isolated-pytorch-playground-analysis": pytorch},
     )

--- a/tools/agilab_widget_robot_matrix.py
+++ b/tools/agilab_widget_robot_matrix.py
@@ -322,6 +322,21 @@ DEFAULT_SCENARIOS: dict[str, RobotScenario] = {
         target_seconds=2400.0,
         assert_orchestrate_artifacts=True,
     ),
+    "isolated-orchestrate-pool-parameters": RobotScenario(
+        name="isolated-orchestrate-pool-parameters",
+        description=(
+            "Render ORCHESTRATE in an isolated session for a pool-enabled app and assert "
+            "the Resources and deployment panel exposes the pool tuning controls."
+        ),
+        pages="ORCHESTRATE",
+        apps="flight_telemetry_project",
+        apps_pages="none",
+        runtime_isolation="isolated",
+        action_button_policy="trial",
+        max_action_clicks_per_page=0,
+        required_text="Pool parameters,Max workers,Item timeout seconds,Pool executor",
+        browser_error_check=True,
+    ),
 }
 
 

--- a/tools/ui_robot_coverage_contract.py
+++ b/tools/ui_robot_coverage_contract.py
@@ -35,6 +35,8 @@ REQUIRED_HF_FIRST_PROOF_PAGES = ("view_forecast_analysis", "view_maps", "view_re
 FORBIDDEN_HF_FIRST_PROOF_APPS = ("flight_project", "weather_forecast_legacy_project")
 REQUIRED_PYTORCH_ANALYSIS_SCENARIO = "isolated-pytorch-playground-analysis"
 REQUIRED_RELEASE_EVIDENCE_SCENARIO = "isolated-release-evidence"
+REQUIRED_ORCHESTRATE_POOL_SCENARIO = "isolated-orchestrate-pool-parameters"
+REQUIRED_ORCHESTRATE_POOL_TEXT = ("Pool parameters", "Max workers", "Item timeout seconds", "Pool executor")
 REQUIRED_PYTORCH_ANALYSIS_APP = "pytorch_playground_project"
 REQUIRED_PYTORCH_ANALYSIS_TEXT = ("PyTorch Playground", "Refresh evidence", "Synced RUN snippet", "Settings")
 REQUIRED_PYTORCH_ANALYSIS_FORBIDDEN_SIDEBAR_TEXT = ("Project:",)
@@ -646,6 +648,41 @@ def evaluate_contract() -> dict[str, Any]:
             )
         )
 
+    orchestrate_pool: dict[str, list[str]] = {}
+    orchestrate_pool_scenario = scenario_by_name.get(REQUIRED_ORCHESTRATE_POOL_SCENARIO)
+    if orchestrate_pool_scenario is None:
+        issues.append(
+            CoverageIssue(
+                "orchestrate_pool_robot",
+                f"{REQUIRED_ORCHESTRATE_POOL_SCENARIO} is missing from the robot matrix",
+            )
+        )
+    else:
+        pages = sorted(_scenario_pages(widget_robot, orchestrate_pool_scenario))
+        required_text = sorted(_scenario_required_text(widget_robot, orchestrate_pool_scenario))
+        flags = sorted(_scenario_flags(orchestrate_pool_scenario))
+        orchestrate_pool = {
+            "pages": pages,
+            "required_text": required_text,
+            "flags": flags,
+        }
+        if "ORCHESTRATE" not in pages:
+            issues.append(
+                CoverageIssue(
+                    "orchestrate_pool_robot",
+                    f"{REQUIRED_ORCHESTRATE_POOL_SCENARIO} does not cover ORCHESTRATE",
+                )
+            )
+        missing_text = sorted(set(REQUIRED_ORCHESTRATE_POOL_TEXT) - set(required_text))
+        if missing_text:
+            issues.append(
+                CoverageIssue(
+                    "orchestrate_pool_robot",
+                    f"{REQUIRED_ORCHESTRATE_POOL_SCENARIO} is missing required text probes: "
+                    + ", ".join(missing_text),
+                )
+            )
+
     demo_doc_text = DEMOS_DOC_PATH.read_text(encoding="utf-8") if DEMOS_DOC_PATH.is_file() else ""
     missing_demo_doc_snippets = [snippet for snippet in REQUIRED_DEMO_DOC_SNIPPETS if snippet not in demo_doc_text]
     if missing_demo_doc_snippets:
@@ -718,6 +755,7 @@ def evaluate_contract() -> dict[str, Any]:
             "hf_visual_smoke_profile_scenarios": hf_visual_smoke_profile_scenarios,
             "ui_robot_matrix_profile_scenarios": ui_robot_matrix_profile_scenarios,
             "hf_robot_scenarios": hf_robot_scenarios,
+            "orchestrate_pool_robot": orchestrate_pool,
             "pytorch_analysis_robot": pytorch_analysis,
             "public_demo_contract": {
                 "doc_snippets": list(REQUIRED_DEMO_DOC_SNIPPETS),


### PR DESCRIPTION
## Summary
- assert ORCHESTRATE pool parameter widgets in the Streamlit AppTest coverage
- add a focused isolated widget-robot scenario for pool-enabled ORCHESTRATE resources
- expose the pool-control robot probe in the UI robot coverage contract

## Validation
- uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files test/test_ui_pages.py tools/agilab_widget_robot_matrix.py test/test_agilab_widget_robot_matrix.py tools/ui_robot_coverage_contract.py test/test_ui_robot_coverage_contract.py
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_agilab_widget_robot_matrix.py test/test_ui_pages.py test/test_ui_robot_coverage_contract.py
- UV_PYTHON=3.13 uv --preview-features extra-build-dependencies run --with playwright python tools/agilab_widget_robot_matrix.py --scenario isolated-orchestrate-pool-parameters --json --quiet-progress --no-result-cache --output-dir /tmp/agilab-pool-ui-robot --screenshot-dir /tmp/agilab-pool-ui-robot-screenshots