### PR TITLE
Add generic coordinate overlay example

### DIFF
--- a/src/agilab/apps-pages/view_maps/src/view_maps/view_maps.py
+++ b/src/agilab/apps-pages/view_maps/src/view_maps/view_maps.py
@@ -109,6 +109,38 @@ DATASET_EXTENSIONS = (".csv", ".parquet", ".json")
 FILE_TYPE_OPTIONS = ("csv", "parquet", "json", "all")
 DF_SELECTION_MODES = ("Single file", "Multi-select", "Regex (multi)")
 PAGE_KEY_PREFIX = "view_maps"
+OVERLAY_NONE = "(none)"
+DEFAULT_OVERLAY_LAT_COLUMNS = (
+    "sat_track_lat",
+    "track_lat",
+    "overlay_lat",
+    "beam_lat",
+    "latitude",
+    "lat",
+)
+DEFAULT_OVERLAY_LON_COLUMNS = (
+    "sat_track_long",
+    "sat_track_lon",
+    "track_long",
+    "track_lon",
+    "overlay_long",
+    "overlay_lon",
+    "beam_long",
+    "beam_lon",
+    "longitude",
+    "long",
+    "lon",
+    "lng",
+)
+DEFAULT_OVERLAY_LABEL_COLUMNS = (
+    "sat",
+    "sat_name",
+    "label",
+    "name",
+    "beam",
+    "category",
+    "__dataset__",
+)
 
 
 def _vm_key(name: str) -> str:
@@ -292,6 +324,38 @@ def _compute_viewport(df: pd.DataFrame, lat_col: str, lon_col: str) -> dict[str,
     span = max(span_lat, span_lon)
     zoom = _compute_zoom_from_span(span if span > 0 else 0.01)
     return {"center_lat": center_lat, "center_lon": center_lon, "default_zoom": zoom}
+
+
+def _ordered_existing_columns(df: pd.DataFrame, preferred: tuple[str, ...]) -> list[str]:
+    columns = [str(column) for column in df.columns]
+    preferred_existing = [column for column in preferred if column in columns]
+    return preferred_existing + [column for column in columns if column not in preferred_existing]
+
+
+def _select_column_index(options: list[str], saved: object, fallback: object = None) -> int:
+    for candidate in (saved, fallback):
+        if candidate in options:
+            return options.index(candidate)
+    return 0
+
+
+def _coordinate_overlay_points(
+    df: pd.DataFrame,
+    lat_col: str | None,
+    lon_col: str | None,
+    label_col: str | None = None,
+) -> pd.DataFrame:
+    if not lat_col or not lon_col or lat_col not in df.columns or lon_col not in df.columns:
+        return pd.DataFrame()
+
+    columns = [lat_col, lon_col]
+    if label_col and label_col != OVERLAY_NONE and label_col in df.columns:
+        columns.append(label_col)
+
+    points = df[columns].copy()
+    points[lat_col] = pd.to_numeric(points[lat_col], errors="coerce")
+    points[lon_col] = pd.to_numeric(points[lon_col], errors="coerce")
+    return points.dropna(subset=[lat_col, lon_col]).drop_duplicates()
 
 
 def _load_map_defaults(env: AgiEnv) -> dict[str, float]:
@@ -741,15 +805,74 @@ def page(env):
     else:
         st.sidebar.write("")
 
-    sat_default = bool(view_settings.get("show_sat_overlay", True))
-    show_sat_overlay = st.sidebar.checkbox(
-        "Show satellite overlay",
-        value=sat_default,
-        key=f"view_maps_sat_overlay_{env.app}",
+    legacy_overlay_available = {"sat_track_lat", "sat_track_long"} <= set(df.columns)
+    overlay_default = bool(
+        view_settings.get(
+            "show_coordinate_overlay",
+            view_settings.get("show_sat_overlay", legacy_overlay_available),
+        )
     )
-    if view_settings.get("show_sat_overlay", True) != show_sat_overlay:
-        view_settings["show_sat_overlay"] = show_sat_overlay
+    show_coordinate_overlay = st.sidebar.checkbox(
+        "Show coordinate overlay",
+        value=overlay_default,
+        key=f"view_maps_coordinate_overlay_{env.app}",
+        help="Overlay a second set of points from latitude/longitude columns in the loaded dataframe.",
+    )
+    if overlay_default != show_coordinate_overlay:
+        view_settings["show_coordinate_overlay"] = show_coordinate_overlay
         full_settings = _persist_view_maps_settings(env, full_settings, view_settings)
+
+    overlay_lat_col = None
+    overlay_lon_col = None
+    overlay_label_col = None
+    if show_coordinate_overlay:
+        overlay_lat_options = _ordered_existing_columns(df, DEFAULT_OVERLAY_LAT_COLUMNS)
+        overlay_lon_options = _ordered_existing_columns(df, DEFAULT_OVERLAY_LON_COLUMNS)
+        overlay_label_options = [OVERLAY_NONE] + _ordered_existing_columns(df, DEFAULT_OVERLAY_LABEL_COLUMNS)
+        if overlay_lat_options and overlay_lon_options:
+            overlay_lat_key = _vm_key("overlay_lat")
+            overlay_lon_key = _vm_key("overlay_long")
+            overlay_label_key = _vm_key("overlay_label")
+            overlay_lat_col = st.sidebar.selectbox(
+                "Overlay latitude",
+                overlay_lat_options,
+                index=_select_column_index(
+                    overlay_lat_options,
+                    view_settings.get("overlay_lat"),
+                    "sat_track_lat",
+                ),
+                key=overlay_lat_key,
+            )
+            overlay_lon_col = st.sidebar.selectbox(
+                "Overlay longitude",
+                overlay_lon_options,
+                index=_select_column_index(
+                    overlay_lon_options,
+                    view_settings.get("overlay_long"),
+                    "sat_track_long",
+                ),
+                key=overlay_lon_key,
+            )
+            overlay_label_col = st.sidebar.selectbox(
+                "Overlay label",
+                overlay_label_options,
+                index=_select_column_index(
+                    overlay_label_options,
+                    view_settings.get("overlay_label"),
+                    "sat",
+                ),
+                key=overlay_label_key,
+            )
+            for setting_name, setting_value in {
+                "overlay_lat": overlay_lat_col,
+                "overlay_long": overlay_lon_col,
+                "overlay_label": overlay_label_col,
+            }.items():
+                if view_settings.get(setting_name) != setting_value:
+                    view_settings[setting_name] = setting_value
+                    full_settings = _persist_view_maps_settings(env, full_settings, view_settings)
+        else:
+            st.sidebar.caption("No coordinate columns available for overlay.")
 
     # Select numeric columns
     numeric_cols = st.session_state.loaded_df.select_dtypes(include=["number"]).columns.tolist()
@@ -957,24 +1080,27 @@ def page(env):
                 **color_kwargs,
             )
 
-            if (
-                show_sat_overlay
-                and {"sat_track_lat", "sat_track_long"} <= set(st.session_state.loaded_df.columns)
-            ):
-                sat_points = (
-                    st.session_state.loaded_df[["sat_track_lat", "sat_track_long", "sat"]]
-                    .dropna(subset=["sat_track_lat", "sat_track_long"])
-                    .drop_duplicates()
+            if show_coordinate_overlay and overlay_lat_col and overlay_lon_col:
+                overlay_points = _coordinate_overlay_points(
+                    st.session_state.loaded_df,
+                    overlay_lat_col,
+                    overlay_lon_col,
+                    overlay_label_col,
                 )
-                if not sat_points.empty:
+                if not overlay_points.empty:
+                    text = (
+                        overlay_points[overlay_label_col]
+                        if overlay_label_col and overlay_label_col != OVERLAY_NONE and overlay_label_col in overlay_points.columns
+                        else None
+                    )
                     fig.add_trace(
                         go.Scattermap(
-                            lat=sat_points["sat_track_lat"],
-                            lon=sat_points["sat_track_long"],
+                            lat=overlay_points[overlay_lat_col],
+                            lon=overlay_points[overlay_lon_col],
                             mode="markers",
-                            marker=dict(size=10, color="#ffa600", symbol="triangle"),
-                            name="Satellite track",
-                            text=sat_points.get("sat"),
+                            marker=dict(size=10, color="#ffa600", symbol="circle"),
+                            name="Coordinate overlay",
+                            text=text,
                         )
                     )
 

--- a/src/agilab/apps/builtin/flight_telemetry_project/README.md
+++ b/src/agilab/apps/builtin/flight_telemetry_project/README.md
@@ -15,6 +15,7 @@ analysis views over the produced flight dataframe.
 - How worker-only Cython acceleration can cover a real hot loop while the app
   remains readable Python.
 - How `view_maps` and `view_maps_network` reuse the same run artifacts.
+- How `view_maps` can draw a generic coordinate overlay from dataframe columns.
 - How reducer summaries record row counts, source files, distance metrics,
   kernel runtime, dtype contracts, and checksums.
 - How notebook-import view declarations point the generic importer at
@@ -38,6 +39,10 @@ can point the input glob at local flight CSV files under shared storage.
 The run writes a flight dataframe dataset and a `ReduceArtifact` summary with
 aircraft counts, source-file counts, trajectory distance/time-span fields,
 written output files, speed-kernel metadata, and checksum evidence.
+
+The dataframe also includes `overlay_lat`, `overlay_long`, and `overlay_label`
+columns. In `ANALYSIS` > `view_maps`, enable `Show coordinate overlay` to draw
+one route-centroid marker per aircraft on top of the trajectory points.
 
 ## Change One Thing
 

--- a/src/agilab/apps/builtin/flight_telemetry_project/src/app_settings.toml
+++ b/src/agilab/apps/builtin/flight_telemetry_project/src/app_settings.toml
@@ -59,6 +59,10 @@ discrete = "aircraft"
 lat = "lat"
 long = "long"
 coltype = "discrete"
+show_coordinate_overlay = true
+overlay_lat = "overlay_lat"
+overlay_long = "overlay_long"
+overlay_label = "overlay_label"
 
 [pages]
 default_view = "view_maps"

--- a/src/agilab/apps/builtin/flight_telemetry_project/src/flight_telemetry_worker/flight_telemetry_worker.py
+++ b/src/agilab/apps/builtin/flight_telemetry_project/src/flight_telemetry_worker/flight_telemetry_worker.py
@@ -30,6 +30,10 @@ SPEED_DTYPE_CONTRACT = "float64-contiguous"
 SPEED_KERNEL_COLUMN = "speed_kernel_runtime"
 SPEED_DTYPE_COLUMN = "speed_dtype_contract"
 SPEED_KERNEL_CHECKSUM_COLUMN = "speed_kernel_checksum_m"
+OVERLAY_LAT_COLUMN = "overlay_lat"
+OVERLAY_LONG_COLUMN = "overlay_long"
+OVERLAY_LABEL_COLUMN = "overlay_label"
+OVERLAY_KIND_COLUMN = "overlay_kind"
 
 
 def _kernel_runtime_label() -> str:
@@ -135,6 +139,31 @@ def _haversine_distance_series(df: pl.DataFrame) -> tuple[pl.Series, str, str, f
         _kernel_runtime_label(),
         SPEED_DTYPE_CONTRACT,
         float(checksum),
+    )
+
+
+def _add_coordinate_overlay_columns(df: pl.DataFrame) -> pl.DataFrame:
+    """Add generic map overlay coordinates for the View Maps coordinate layer."""
+    if not {"aircraft", "lat", "long"} <= set(df.columns):
+        return df
+
+    return df.with_columns(
+        [
+            pl.col("lat")
+            .cast(pl.Float64, strict=False)
+            .mean()
+            .over("aircraft")
+            .alias(OVERLAY_LAT_COLUMN),
+            pl.col("long")
+            .cast(pl.Float64, strict=False)
+            .mean()
+            .over("aircraft")
+            .alias(OVERLAY_LONG_COLUMN),
+            (pl.lit("route centroid: ") + pl.col("aircraft").cast(pl.String)).alias(
+                OVERLAY_LABEL_COLUMN
+            ),
+            pl.lit("route_centroid").alias(OVERLAY_KIND_COLUMN),
+        ]
     )
 
 
@@ -280,6 +309,7 @@ class FlightTelemetryWorker(PolarsWorker):
 
         # Preserve the historical output column name expected by downstream demos.
         df = self.calculate_speed("speed", df)
+        df = _add_coordinate_overlay_columns(df)
         return df.with_columns(pl.lit(Path(file).name).alias("source_file"))
 
     def work_done(self, worker_df):

--- a/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/README.md
+++ b/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/README.md
@@ -15,6 +15,7 @@ analysis views over the produced flight dataframe.
 - How worker-only Cython acceleration can cover a real hot loop while the app
   remains readable Python.
 - How `view_maps` and `view_maps_network` reuse the same run artifacts.
+- How `view_maps` can draw a generic coordinate overlay from dataframe columns.
 - How reducer summaries record row counts, source files, distance metrics,
   kernel runtime, dtype contracts, and checksums.
 - How notebook-import view declarations point the generic importer at
@@ -38,6 +39,10 @@ can point the input glob at local flight CSV files under shared storage.
 The run writes a flight dataframe dataset and a `ReduceArtifact` summary with
 aircraft counts, source-file counts, trajectory distance/time-span fields,
 written output files, speed-kernel metadata, and checksum evidence.
+
+The dataframe also includes `overlay_lat`, `overlay_long`, and `overlay_label`
+columns. In `ANALYSIS` > `view_maps`, enable `Show coordinate overlay` to draw
+one route-centroid marker per aircraft on top of the trajectory points.
 
 ## Change One Thing
 

--- a/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/src/app_settings.toml
+++ b/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/src/app_settings.toml
@@ -59,6 +59,10 @@ discrete = "aircraft"
 lat = "lat"
 long = "long"
 coltype = "discrete"
+show_coordinate_overlay = true
+overlay_lat = "overlay_lat"
+overlay_long = "overlay_long"
+overlay_label = "overlay_label"
 
 [pages]
 default_view = "view_maps"

--- a/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/src/flight_telemetry_worker/flight_telemetry_worker.py
+++ b/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/src/flight_telemetry_worker/flight_telemetry_worker.py
@@ -30,6 +30,10 @@ SPEED_DTYPE_CONTRACT = "float64-contiguous"
 SPEED_KERNEL_COLUMN = "speed_kernel_runtime"
 SPEED_DTYPE_COLUMN = "speed_dtype_contract"
 SPEED_KERNEL_CHECKSUM_COLUMN = "speed_kernel_checksum_m"
+OVERLAY_LAT_COLUMN = "overlay_lat"
+OVERLAY_LONG_COLUMN = "overlay_long"
+OVERLAY_LABEL_COLUMN = "overlay_label"
+OVERLAY_KIND_COLUMN = "overlay_kind"
 
 
 def _kernel_runtime_label() -> str:
@@ -135,6 +139,31 @@ def _haversine_distance_series(df: pl.DataFrame) -> tuple[pl.Series, str, str, f
         _kernel_runtime_label(),
         SPEED_DTYPE_CONTRACT,
         float(checksum),
+    )
+
+
+def _add_coordinate_overlay_columns(df: pl.DataFrame) -> pl.DataFrame:
+    """Add generic map overlay coordinates for the View Maps coordinate layer."""
+    if not {"aircraft", "lat", "long"} <= set(df.columns):
+        return df
+
+    return df.with_columns(
+        [
+            pl.col("lat")
+            .cast(pl.Float64, strict=False)
+            .mean()
+            .over("aircraft")
+            .alias(OVERLAY_LAT_COLUMN),
+            pl.col("long")
+            .cast(pl.Float64, strict=False)
+            .mean()
+            .over("aircraft")
+            .alias(OVERLAY_LONG_COLUMN),
+            (pl.lit("route centroid: ") + pl.col("aircraft").cast(pl.String)).alias(
+                OVERLAY_LABEL_COLUMN
+            ),
+            pl.lit("route_centroid").alias(OVERLAY_KIND_COLUMN),
+        ]
     )
 
 
@@ -280,6 +309,7 @@ class FlightTelemetryWorker(PolarsWorker):
 
         # Preserve the historical output column name expected by downstream demos.
         df = self.calculate_speed("speed", df)
+        df = _add_coordinate_overlay_columns(df)
         return df.with_columns(pl.lit(Path(file).name).alias("source_file"))
 
     def work_done(self, worker_df):

--- a/test/test_flight_telemetry_coordinate_overlay.py
+++ b/test/test_flight_telemetry_coordinate_overlay.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tomllib
+from pathlib import Path
+
+import polars as pl
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PROJECT_ROOT = ROOT / "src/agilab/apps/builtin/flight_telemetry_project"
+PROJECT_SRC = PROJECT_ROOT / "src"
+WORKER_PATH = PROJECT_SRC / "flight_telemetry_worker/flight_telemetry_worker.py"
+
+
+def _load_worker_module():
+    sys.path.insert(0, str(PROJECT_SRC))
+    module_name = "flight_telemetry_coordinate_overlay_worker_test"
+    sys.modules.pop(module_name, None)
+    spec = importlib.util.spec_from_file_location(module_name, WORKER_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_flight_telemetry_output_adds_generic_coordinate_overlay_columns() -> None:
+    module = _load_worker_module()
+    df = pl.DataFrame(
+        {
+            "aircraft": ["A001", "A001", "B002"],
+            "lat": [48.0, 50.0, 52.0],
+            "long": [2.0, 4.0, 6.0],
+        }
+    )
+
+    result = module._add_coordinate_overlay_columns(df)
+
+    assert {
+        "overlay_lat",
+        "overlay_long",
+        "overlay_label",
+        "overlay_kind",
+    } <= set(result.columns)
+
+    rows = (
+        result.select(
+            "aircraft",
+            "overlay_lat",
+            "overlay_long",
+            "overlay_label",
+            "overlay_kind",
+        )
+        .unique()
+        .sort("aircraft")
+        .to_dicts()
+    )
+    assert rows == [
+        {
+            "aircraft": "A001",
+            "overlay_lat": 49.0,
+            "overlay_long": 3.0,
+            "overlay_label": "route centroid: A001",
+            "overlay_kind": "route_centroid",
+        },
+        {
+            "aircraft": "B002",
+            "overlay_lat": 52.0,
+            "overlay_long": 6.0,
+            "overlay_label": "route centroid: B002",
+            "overlay_kind": "route_centroid",
+        },
+    ]
+
+
+def test_flight_telemetry_view_maps_defaults_select_coordinate_overlay_columns() -> None:
+    settings = tomllib.loads(
+        (PROJECT_ROOT / "src/app_settings.toml").read_text(encoding="utf-8")
+    )
+
+    view_maps = settings["view_maps"]
+    assert view_maps["show_coordinate_overlay"] is True
+    assert view_maps["overlay_lat"] == "overlay_lat"
+    assert view_maps["overlay_long"] == "overlay_long"
+    assert view_maps["overlay_label"] == "overlay_label"

--- a/test/test_view_maps.py
+++ b/test/test_view_maps.py
@@ -516,6 +516,24 @@ def test_view_maps_safe_unique_count_handles_nested_payloads() -> None:
     assert module._safe_unique_count(series) == 2
 
 
+def test_view_maps_builds_generic_coordinate_overlay_points() -> None:
+    module = _load_view_maps_module()
+    df = pd.DataFrame(
+        {
+            "node_lat": ["48.0", "bad", "48.0", "49.0"],
+            "node_lon": ["2.0", "3.0", "2.0", "4.0"],
+            "node_name": ["A", "B", "A", "C"],
+        }
+    )
+
+    points = module._coordinate_overlay_points(df, "node_lat", "node_lon", "node_name")
+
+    assert points["node_lat"].tolist() == [48.0, 49.0]
+    assert points["node_lon"].tolist() == [2.0, 4.0]
+    assert points["node_name"].tolist() == ["A", "C"]
+    assert module._coordinate_overlay_points(df, "missing", "node_lon").empty
+
+
 @pytest.mark.parametrize(
     ("span", "expected"),
     [
@@ -833,7 +851,7 @@ def test_view_maps_page_single_file_mode_renders_overlay_and_caption(
             ("sidebar.selectbox", "DataFrame"): "export.csv",
             ("column.number_input", "Sampling ratio"): 1,
             ("sidebar.multiselect", "Filter beams"): [],
-            ("sidebar.checkbox", "Show satellite overlay"): True,
+            ("sidebar.checkbox", "Show coordinate overlay"): True,
             ("sidebar.number_input", "Discrete threshold (unique values <)"): 3,
             ("sidebar.number_input", "Integer discrete range (max-min <=)"): 100,
             ("selectbox", "discrete"): "int_small",
@@ -865,6 +883,11 @@ def test_view_maps_page_single_file_mode_renders_overlay_and_caption(
         for message in fake_st.calls["caption"]
     )
     assert fake_st.calls["plotly_chart"]
+    fig = fake_st.calls["plotly_chart"][0][0][0]
+    overlay_trace = next(trace for trace in fig.data if trace.name == "Coordinate overlay")
+    assert list(overlay_trace.lat) == [48.857]
+    assert list(overlay_trace.lon) == [2.36]
+    assert list(overlay_trace.text) == ["SAT1"]
     assert fake_st.calls["dataframe"]
     assert fake_st.session_state["df_select_mode"] == "Single file"
     assert fake_st.session_state["df_file"] == "export.csv"
@@ -904,7 +927,7 @@ def test_view_maps_page_handles_dict_valued_columns(
             ("sidebar.radio", "Dataset selection"): "Single file",
             ("sidebar.selectbox", "DataFrame"): "export.json",
             ("column.number_input", "Sampling ratio"): 1,
-            ("sidebar.checkbox", "Show satellite overlay"): False,
+            ("sidebar.checkbox", "Show coordinate overlay"): False,
             ("sidebar.number_input", "Discrete threshold (unique values <)"): 3,
             ("sidebar.number_input", "Integer discrete range (max-min <=)"): 100,
             ("selectbox", "discrete"): "payload",
@@ -989,7 +1012,7 @@ def test_view_maps_page_regex_mode_reports_load_errors_and_uses_continuous_color
             ("sidebar.multiselect", "DataFrames"): ["export.csv", "other.csv"],
             ("column.number_input", "Sampling ratio"): 2,
             ("sidebar.multiselect", "Filter beams"): ["A"],
-            ("sidebar.checkbox", "Show satellite overlay"): False,
+            ("sidebar.checkbox", "Show coordinate overlay"): False,
             ("sidebar.number_input", "Discrete threshold (unique values <)"): 3,
             ("sidebar.number_input", "Integer discrete range (max-min <=)"): 100,
             ("selectbox", "discrete"): "beam",
@@ -1073,7 +1096,7 @@ def test_view_maps_page_recovers_legacy_selection_and_reclassifies_integer_range
             ("sidebar.text_input", "DataFrame filename regex"): "",
             ("sidebar.multiselect", "DataFrames"): ["export.csv"],
             ("column.number_input", "Sampling ratio"): 1,
-            ("sidebar.checkbox", "Show satellite overlay"): False,
+            ("sidebar.checkbox", "Show coordinate overlay"): False,
             ("sidebar.number_input", "Discrete threshold (unique values <)"): 2,
             ("sidebar.number_input", "Integer discrete range (max-min <=)"): 10,
             ("selectbox", "discrete"): "reclass_int",
@@ -1293,7 +1316,7 @@ def test_view_maps_page_persists_datadir_and_recovers_invalid_line_limits(
             ("sidebar.radio", "Dataset selection"): "Single file",
             ("sidebar.selectbox", "DataFrame"): "export.csv",
             ("column.number_input", "Sampling ratio"): 1,
-            ("sidebar.checkbox", "Show satellite overlay"): False,
+            ("sidebar.checkbox", "Show coordinate overlay"): False,
             ("sidebar.number_input", "Discrete threshold (unique values <)"): 2,
             ("sidebar.number_input", "Integer discrete range (max-min <=)"): 200,
             ("selectbox", "discrete"): "metric",
@@ -1361,7 +1384,7 @@ def test_view_maps_page_warns_without_color_column_and_can_render_plain_map(
             ("sidebar.radio", "Dataset selection"): "Single file",
             ("sidebar.selectbox", "DataFrame"): "export.csv",
             ("column.number_input", "Sampling ratio"): 1,
-            ("sidebar.checkbox", "Show satellite overlay"): False,
+            ("sidebar.checkbox", "Show coordinate overlay"): False,
             ("sidebar.number_input", "Discrete threshold (unique values <)"): 10,
             ("sidebar.number_input", "Integer discrete range (max-min <=)"): 200,
             ("selectbox", "lat"): "lat",
@@ -1395,7 +1418,7 @@ def test_view_maps_page_warns_without_color_column_and_can_render_plain_map(
             ("sidebar.radio", "Dataset selection"): "Single file",
             ("sidebar.selectbox", "DataFrame"): "export.csv",
             ("column.number_input", "Sampling ratio"): 1,
-            ("sidebar.checkbox", "Show satellite overlay"): False,
+            ("sidebar.checkbox", "Show coordinate overlay"): False,
             ("sidebar.number_input", "Discrete threshold (unique values <)"): 2,
             ("sidebar.number_input", "Integer discrete range (max-min <=)"): 200,
             ("selectbox", "discrete"): "metric",
@@ -1457,7 +1480,7 @@ def test_view_maps_page_covers_continuous_and_plain_color_rendering(
             ("sidebar.radio", "Dataset selection"): "Single file",
             ("sidebar.selectbox", "DataFrame"): "export.csv",
             ("column.number_input", "Sampling ratio"): 1,
-            ("sidebar.checkbox", "Show satellite overlay"): False,
+            ("sidebar.checkbox", "Show coordinate overlay"): False,
             ("sidebar.number_input", "Discrete threshold (unique values <)"): 2,
             ("sidebar.number_input", "Integer discrete range (max-min <=)"): 200,
             ("selectbox", "discrete"): "metric",
@@ -1489,7 +1512,7 @@ def test_view_maps_page_covers_continuous_and_plain_color_rendering(
             ("sidebar.radio", "Dataset selection"): "Single file",
             ("sidebar.selectbox", "DataFrame"): "export.csv",
             ("column.number_input", "Sampling ratio"): 1,
-            ("sidebar.checkbox", "Show satellite overlay"): False,
+            ("sidebar.checkbox", "Show coordinate overlay"): False,
             ("sidebar.number_input", "Discrete threshold (unique values <)"): 2,
             ("sidebar.number_input", "Integer discrete range (max-min <=)"): 200,
             ("selectbox", "discrete"): "metric",
@@ -1568,7 +1591,7 @@ def test_view_maps_uses_loaded_session_dataframe_when_files_are_missing(
         {
             ("sidebar.selectbox", "File type"): "all",
             ("column.number_input", "Sampling ratio"): 1,
-            ("sidebar.checkbox", "Show satellite overlay"): False,
+            ("sidebar.checkbox", "Show coordinate overlay"): False,
             ("sidebar.number_input", "Discrete threshold (unique values <)"): 2,
             ("sidebar.number_input", "Integer discrete range (max-min <=)"): 200,
             ("selectbox", "discrete"): "beam",
@@ -1633,7 +1656,7 @@ def test_view_maps_page_reports_invalid_regex_and_falls_back_to_default_selectio
             ("sidebar.multiselect", "DataFrames"): ["export.csv"],
             ("column.number_input", "Sampling ratio"): 1,
             ("sidebar.multiselect", "Filter beams"): [],
-            ("sidebar.checkbox", "Show satellite overlay"): False,
+            ("sidebar.checkbox", "Show coordinate overlay"): False,
             ("sidebar.number_input", "Discrete threshold (unique values <)"): 3,
             ("sidebar.number_input", "Integer discrete range (max-min <=)"): 100,
             ("selectbox", "discrete"): "beam",
@@ -1828,7 +1851,7 @@ def test_view_maps_page_warns_without_lat_lon_columns(tmp_path, monkeypatch) -> 
             ("sidebar.radio", "Dataset selection"): "Single file",
             ("sidebar.selectbox", "DataFrame"): "export.csv",
             ("column.number_input", "Sampling ratio"): 1,
-            ("sidebar.checkbox", "Show satellite overlay"): False,
+            ("sidebar.checkbox", "Show coordinate overlay"): False,
             ("sidebar.number_input", "Discrete threshold (unique values <)"): 3,
             ("sidebar.number_input", "Integer discrete range (max-min <=)"): 100,
         }


### PR DESCRIPTION
## Summary
- Generalize view_maps satellite overlay into a dataframe-driven coordinate overlay.
- Add flight_telemetry_project output columns for a route-centroid coordinate overlay example.
- Configure flight_telemetry_project view_maps defaults and document the example.

## Validation
- ./dev scope --staged
- uv --preview-features extra-build-dependencies run python tools/impact_validate.py --staged
- uv --preview-features extra-build-dependencies run --extra ui --extra viz --with pytest pytest -q -o addopts='' test/test_view_maps.py test/test_view_maps_3d.py test/test_view_maps_network.py test/test_view_maps_network_edge_selection.py test/test_view_maps_network_notebook_inline.py test/test_view_maps_network_page_state.py test/test_view_maps_network_path_resolution.py test/test_view_maps_network_semantic_ids.py src/agilab/core/agi-env/test/test_app_settings_support.py test/test_flight_telemetry_coordinate_overlay.py
- uv --preview-features extra-build-dependencies run --with ruff ruff check --ignore E402 src/agilab/apps-pages/view_maps/src/view_maps/view_maps.py src/agilab/apps/builtin/flight_telemetry_project/src/flight_telemetry_worker/flight_telemetry_worker.py test/test_view_maps.py test/test_flight_telemetry_coordinate_overlay.py
- git diff --check

Note: local agi-gui workflow parity was attempted, but the root validation environment has a corrupted streamlit install: streamlit imports from .venv but lacks __version__, title, secrets, and cache_data. The page-specific and impact-required pytest slice passed with the correct ui+viz dependency surface.