### PR TITLE
[codex] Fix hosted view maps dependencies and robot coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,13 +61,13 @@ agilab-mcp = "agilab_mcp.server:main"
 [project.optional-dependencies]
 ai = ["openai>=2.32.0,<3"]
 core = ["agi-core==2026.06.14.1"]
-ui = ["agi-apps==2026.06.14.1", "agi-pages==2026.06.14.1", "agi-gui==2026.06.14.1", "agi-web==2026.06.14.1", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "streamlit>=1.57,<1.58", "starlette>=1.0.1,<2", "tomli_w>=1.2.0,<2"]
+ui = ["agi-apps==2026.06.14.1", "agi-pages==2026.06.14.1", "agi-gui==2026.06.14.1", "agi-web==2026.06.14.1", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "plotly>=6.7.0,<7", "sqlalchemy>=2.0.43,<3", "streamlit>=1.57,<1.58", "starlette>=1.0.1,<2", "tomli_w>=1.2.0,<2"]
 viz = ["matplotlib>=3.10.0,<4", "plotly>=6.7.0,<7"]
 mlflow = ["mlflow>=3.11.1,<4", "idna>=3.15,<4", "starlette>=1.0.1,<2"]
 bridges = ["duckdb>=1.4.0,<2"]
 notebook = ["ipykernel>=6.29.0,<8", "nbclient>=0.10.0,<1", "nbformat>=5.10.0,<6"]
 examples = ["agi-apps==2026.06.14.1", "jupyterlab>=4.4.0,<5", "matplotlib>=3.10.0,<4", "plotly>=6.7.0,<7", "starlette>=1.0.1,<2"]
-pages = ["agi-pages==2026.06.14.1", "starlette>=1.0.1,<2"]
+pages = ["agi-pages==2026.06.14.1", "plotly>=6.7.0,<7", "sqlalchemy>=2.0.43,<3", "starlette>=1.0.1,<2"]
 proof = ["cryptography>=46.0.0,<49"]
 agents = ["openai>=2.32.0,<3"]
 local-llm = ["accelerate>=0.34.2,<2; python_version >= '3.12'", "fastapi>=0.124.4,!=0.136.3,<1; python_version >= '3.12'", "gpt-oss>=0.0.8,<0.1; python_version >= '3.12'", "langchain-core>=1.3.3,<2; python_version >= '3.12'", "langsmith>=0.8.0,<1; python_version >= '3.12'", "mlx>=0.31.2,<0.32; sys_platform == 'darwin' and platform_machine == 'arm64'", "mlx-lm>=0.31.3,<0.32; sys_platform == 'darwin' and platform_machine == 'arm64'", "mlx-vlm>=0.5.0,<0.6; sys_platform == 'darwin' and platform_machine == 'arm64'", "requests>=2.32.0,<3; python_version >= '3.12'", "starlette>=1.0.1,<2; python_version >= '3.12'", "torch>=2.8.0,<3; python_version >= '3.12'", "transformers>=4.57.0,<6; python_version >= '3.12'", "universal-offline-ai-chatbot>=0.1.0,<0.2; python_version >= '3.12'"]
@@ -387,7 +387,7 @@ ydata-profiling = ["standard-imghdr"]
     editable = true
 
 [tool.uv.sources.agi-page-app-ui]
-    path = "./src/agilab/apps-pages/view_app_ui"
+    path = "./src/agilab/apps-pages/app_ui"
     editable = true
 
 [tool.uv.sources.agi-page-training-report]

--- a/src/agilab/apps-pages/view_maps/src/view_maps/view_maps.py
+++ b/src/agilab/apps-pages/view_maps/src/view_maps/view_maps.py
@@ -274,7 +274,7 @@ def _safe_unique_count(series: pd.Series) -> int:
 
 
 def _contains_unhashable_values(series: pd.Series) -> bool:
-    for value in series.dropna().head(100):
+    for value in series.dropna():
         try:
             hash(value)
         except TypeError:

--- a/test/test_agilab_widget_robot_matrix.py
+++ b/test/test_agilab_widget_robot_matrix.py
@@ -140,6 +140,7 @@ def test_default_scenarios_cover_isolated_pages_and_current_home_actions() -> No
     assert "hf-first-proof-install" not in [scenario.name for scenario in scenarios]
     assert "hf-first-proof-visual-smoke" not in [scenario.name for scenario in scenarios]
     assert "hf-first-proof-app-pages-visual-smoke" not in [scenario.name for scenario in scenarios]
+    assert "hf-first-proof-view-maps-visual-smoke" not in [scenario.name for scenario in scenarios]
 
 
 def test_opt_in_browser_history_scenario_is_not_part_of_default_all() -> None:
@@ -195,6 +196,7 @@ def test_opt_in_mobile_and_release_evidence_scenarios_are_not_part_of_default_al
     visual_baseline = module.resolve_scenarios(["isolated-visual-baseline-core-pages"])[0]
     hf_visual_smoke = module.resolve_scenarios(["hf-first-proof-visual-smoke"])[0]
     hf_apps_pages_smoke = module.resolve_scenarios(["hf-first-proof-app-pages-visual-smoke"])[0]
+    hf_view_maps_smoke = module.resolve_scenarios(["hf-first-proof-view-maps-visual-smoke"])[0]
     cross_browser = module.resolve_scenarios(["isolated-cross-browser-core-pages"])[0]
 
     assert mobile.name not in default_names
@@ -213,6 +215,7 @@ def test_opt_in_mobile_and_release_evidence_scenarios_are_not_part_of_default_al
     assert visual_baseline.name not in default_names
     assert hf_visual_smoke.name not in default_names
     assert hf_apps_pages_smoke.name not in default_names
+    assert hf_view_maps_smoke.name not in default_names
     assert cross_browser.name not in default_names
     assert mobile.viewport_width == 390
     assert mobile.viewport_height == 844
@@ -261,6 +264,11 @@ def test_opt_in_mobile_and_release_evidence_scenarios_are_not_part_of_default_al
     assert hf_visual_smoke.visual_mask_dynamic_regions is True
     assert hf_visual_smoke.above_fold_check is True
     assert hf_visual_smoke.browser_error_check is True
+    assert hf_view_maps_smoke.apps_pages == "view_maps"
+    assert hf_view_maps_smoke.success_screenshot is True
+    assert hf_view_maps_smoke.visual_mask_dynamic_regions is True
+    assert hf_view_maps_smoke.above_fold_check is True
+    assert hf_view_maps_smoke.browser_error_check is True
     assert cross_browser.browser_error_check is True
 
 
@@ -689,6 +697,35 @@ def test_build_robot_command_enables_hf_app_pages_visual_smoke_controls(tmp_path
     assert "--browser-error-check" in argv
     assert summary_path == tmp_path / "hf-first-proof-app-pages-visual-smoke.json"
     assert progress_path == tmp_path / "hf-first-proof-app-pages-visual-smoke.ndjson"
+
+
+def test_build_robot_command_enables_hf_view_maps_visual_smoke_controls(tmp_path) -> None:
+    module = _load_module()
+    scenario = module.ALL_SCENARIOS["hf-first-proof-view-maps-visual-smoke"]
+    options = module.MatrixOptions(
+        apps="flight_telemetry_project,weather_forecast_project",
+        output_dir=tmp_path,
+        screenshot_dir=tmp_path / "screenshots",
+        timeout_seconds=12.0,
+        widget_timeout_seconds=2.0,
+        quiet_progress=True,
+        no_seed_demo_artifacts=False,
+        url="https://huggingface.co/spaces/jpmorard/agilab",
+    )
+
+    argv, summary_path, progress_path = module.build_robot_command(scenario, options=options)
+
+    assert argv[argv.index("--apps") + 1] == "flight_telemetry_project,weather_forecast_project"
+    assert argv[argv.index("--pages") + 1] == "none"
+    assert argv[argv.index("--apps-pages") + 1] == "view_maps"
+    assert argv[argv.index("--url") + 1] == "https://huggingface.co/spaces/jpmorard/agilab"
+    assert "--active-app" not in argv
+    assert "--success-screenshot" in argv
+    assert "--visual-mask-dynamic-regions" in argv
+    assert "--above-fold-check" in argv
+    assert "--browser-error-check" in argv
+    assert summary_path == tmp_path / "hf-first-proof-view-maps-visual-smoke.json"
+    assert progress_path == tmp_path / "hf-first-proof-view-maps-visual-smoke.ndjson"
 
 
 def test_build_robot_command_enables_artifact_assertions_for_stateful_journey(tmp_path) -> None:

--- a/test/test_package_split_contract.py
+++ b/test/test_package_split_contract.py
@@ -184,7 +184,12 @@ def test_root_extras_and_uv_sources_match_package_split_contract() -> None:
         requirement_names = _requirement_names(root_pyproject, extra)
         assert set(package_names) <= requirement_names, extra
 
-    assert _requirement_names(root_pyproject, "pages") == {"agi-pages", "starlette"}
+    assert _requirement_names(root_pyproject, "pages") == {
+        "agi-pages",
+        "plotly",
+        "sqlalchemy",
+        "starlette",
+    }
 
     sources = _load_toml(root_pyproject).get("tool", {}).get("uv", {}).get("sources", {})
     for package in LIBRARY_PACKAGE_CONTRACTS:
@@ -196,7 +201,6 @@ def test_root_extras_and_uv_sources_match_package_split_contract() -> None:
 
 def test_root_ui_extra_covers_default_source_analysis_view_dependencies() -> None:
     root_pyproject = REPO_ROOT / "pyproject.toml"
-    ui_names = _requirement_names(root_pyproject, "ui")
     default_analysis_bundle = REPO_ROOT / "src/agilab/apps-pages/view_maps/pyproject.toml"
     required_names = {
         requirement.name.lower()
@@ -204,7 +208,8 @@ def test_root_ui_extra_covers_default_source_analysis_view_dependencies() -> Non
         if not requirement.name.lower().startswith("agi-")
     }
 
-    assert required_names <= ui_names
+    assert required_names <= _requirement_names(root_pyproject, "ui")
+    assert required_names <= _requirement_names(root_pyproject, "pages")
 
 
 def test_publish_tool_uses_the_same_package_split_contract() -> None:

--- a/test/test_pyproject_dependency_hygiene.py
+++ b/test/test_pyproject_dependency_hygiene.py
@@ -309,9 +309,20 @@ def test_root_optional_extras_own_ai_and_visualization_stacks() -> None:
     assert _optional_dependency_names(pyproject, "agents") == {"openai"}
     assert _optional_dependency_names(pyproject, "core") == set(ROOT_EXTRA_INTERNAL_REQUIREMENTS["core"])
     assert set(ROOT_EXTRA_INTERNAL_REQUIREMENTS["examples"]) | {"jupyterlab", "matplotlib", "plotly"} <= _optional_dependency_names(pyproject, "examples")
-    assert _optional_dependency_names(pyproject, "pages") == set(ROOT_EXTRA_INTERNAL_REQUIREMENTS["pages"]) | {"starlette"}
+    assert _optional_dependency_names(pyproject, "pages") == set(ROOT_EXTRA_INTERNAL_REQUIREMENTS["pages"]) | {
+        "plotly",
+        "sqlalchemy",
+        "starlette",
+    }
     assert {"matplotlib", "plotly"} <= _optional_dependency_names(pyproject, "viz")
-    assert set(ROOT_EXTRA_INTERNAL_REQUIREMENTS["ui"]) | {"streamlit", "networkx", "pandas", "tomli_w"} <= _optional_dependency_names(pyproject, "ui")
+    assert set(ROOT_EXTRA_INTERNAL_REQUIREMENTS["ui"]) | {
+        "networkx",
+        "pandas",
+        "plotly",
+        "sqlalchemy",
+        "streamlit",
+        "tomli_w",
+    } <= _optional_dependency_names(pyproject, "ui")
     assert {"mlflow"} <= _optional_dependency_names(pyproject, "mlflow") <= {
         "mlflow",
         "idna",

--- a/test/test_ui_robot_coverage_contract.py
+++ b/test/test_ui_robot_coverage_contract.py
@@ -101,6 +101,7 @@ def test_ui_robot_coverage_contract_passes_for_current_matrix() -> None:
     assert payload["coverage"]["hf_install_profile_scenarios"] == ["hf-first-proof-install"]
     assert payload["coverage"]["hf_visual_smoke_profile_scenarios"] == [
         "hf-first-proof-app-pages-visual-smoke",
+        "hf-first-proof-view-maps-visual-smoke",
         "hf-first-proof-visual-smoke",
     ]
     assert "isolated-project-editor-page" in payload["coverage"]["ui_robot_matrix_profile_scenarios"]
@@ -129,6 +130,12 @@ def test_ui_robot_coverage_contract_passes_for_current_matrix() -> None:
     assert payload["coverage"]["hf_robot_scenarios"]["hf-first-proof-app-pages-visual-smoke"] == {
         "actions": [],
         "apps_pages": ["view_forecast_analysis", "view_maps", "view_release_decision"],
+        "flags": ["above_fold_check", "browser_error_check", "success_screenshot"],
+        "pages": [],
+    }
+    assert payload["coverage"]["hf_robot_scenarios"]["hf-first-proof-view-maps-visual-smoke"] == {
+        "actions": [],
+        "apps_pages": ["view_maps"],
         "flags": ["above_fold_check", "browser_error_check", "success_screenshot"],
         "pages": [],
     }
@@ -213,6 +220,13 @@ def test_ui_robot_coverage_contract_accepts_explicit_full_app_profile(monkeypatc
         above_fold_check=True,
         browser_error_check=True,
     )
+    hf_view_maps = scenario(
+        "hf-first-proof-view-maps-visual-smoke",
+        apps_pages="view_maps",
+        success_screenshot=True,
+        above_fold_check=True,
+        browser_error_check=True,
+    )
     hf_install = scenario(
         "hf-first-proof-install",
         pages="ORCHESTRATE",
@@ -241,6 +255,7 @@ def test_ui_robot_coverage_contract_accepts_explicit_full_app_profile(monkeypatc
             editor,
             hf_visual,
             hf_app_pages,
+            hf_view_maps,
             hf_install,
             orchestrate_pool,
             pytorch,
@@ -280,6 +295,8 @@ def test_ui_robot_coverage_contract_accepts_explicit_full_app_profile(monkeypatc
                         "hf-first-proof-visual-smoke",
                         "--scenario",
                         "hf-first-proof-app-pages-visual-smoke",
+                        "--scenario",
+                        "hf-first-proof-view-maps-visual-smoke",
                         "--apps",
                         ",".join(module.REQUIRED_HF_FIRST_PROOF_APPS),
                     ]
@@ -430,6 +447,7 @@ def test_ui_robot_coverage_contract_reports_hf_first_proof_gaps(monkeypatch) -> 
     ) in details
     assert "hf-visual-smoke-robot does not run hf-first-proof-visual-smoke" in details
     assert "hf-visual-smoke-robot does not run hf-first-proof-app-pages-visual-smoke" in details
+    assert "hf-visual-smoke-robot does not run hf-first-proof-view-maps-visual-smoke" in details
     assert "hf-visual-smoke-robot is missing first-proof apps: flight_project" in details
     assert "hf-install-robot does not run hf-first-proof-install" in details
     assert "hf-install-robot is missing first-proof apps: flight_project" in details
@@ -566,6 +584,21 @@ def test_ui_robot_coverage_contract_reports_matrix_and_pytorch_gaps(monkeypatch,
         above_fold_check=False,
         browser_error_check=False,
     )
+    broken_hf_view_maps = SimpleNamespace(
+        name="hf-first-proof-view-maps-visual-smoke",
+        pages="",
+        apps="",
+        apps_pages="none",
+        click_action_labels="",
+        required_text="",
+        forbidden_text="",
+        forbidden_sidebar_text="",
+        required_links="",
+        required_action_labels="",
+        success_screenshot=False,
+        above_fold_check=False,
+        browser_error_check=False,
+    )
     broken_hf_install = SimpleNamespace(
         name="hf-first-proof-install",
         pages="ORCHESTRATE",
@@ -609,7 +642,13 @@ def test_ui_robot_coverage_contract_reports_matrix_and_pytorch_gaps(monkeypatch,
         DEFAULT_SCENARIOS={},
         ALL_SCENARIOS={
             scenario.name: scenario
-            for scenario in (broken_hf_visual, broken_hf_app_pages, broken_hf_install, broken_pytorch)
+            for scenario in (
+                broken_hf_visual,
+                broken_hf_app_pages,
+                broken_hf_view_maps,
+                broken_hf_install,
+                broken_pytorch,
+            )
         },
         OPT_IN_SCENARIOS={"isolated-pytorch-playground-analysis": broken_pytorch},
     )
@@ -665,6 +704,7 @@ def test_ui_robot_coverage_contract_reports_matrix_and_pytorch_gaps(monkeypatch,
         "hf-first-proof-app-pages-visual-smoke is missing required apps-pages: "
         "view_forecast_analysis, view_release_decision"
     ) in details
+    assert "hf-first-proof-view-maps-visual-smoke is missing required apps-pages: view_maps" in details
     assert "isolated-pytorch-playground-analysis does not cover ANALYSIS" in details
     assert "isolated-pytorch-playground-analysis does not target pytorch_playground_project" in details
     assert (

--- a/test/test_view_maps.py
+++ b/test/test_view_maps.py
@@ -534,6 +534,13 @@ def test_view_maps_builds_generic_coordinate_overlay_points() -> None:
     assert module._coordinate_overlay_points(df, "missing", "node_lon").empty
 
 
+def test_view_maps_detects_late_unhashable_color_values() -> None:
+    module = _load_view_maps_module()
+    series = pd.Series(["normal"] * 150 + [{"beam": "late"}, ["payload"]])
+
+    assert module._contains_unhashable_values(series)
+
+
 @pytest.mark.parametrize(
     ("span", "expected"),
     [

--- a/test/test_workflow_parity.py
+++ b/test/test_workflow_parity.py
@@ -810,7 +810,8 @@ def test_profile_commands_cover_expected_coverage_and_docs_contracts() -> None:
     ]
     assert "hf-first-proof-visual-smoke" in hf_visual_smoke_robot.argv
     assert "hf-first-proof-app-pages-visual-smoke" in hf_visual_smoke_robot.argv
-    assert hf_visual_smoke_robot.argv.count("--scenario") == 2
+    assert "hf-first-proof-view-maps-visual-smoke" in hf_visual_smoke_robot.argv
+    assert hf_visual_smoke_robot.argv.count("--scenario") == 3
     assert (
         "flight_telemetry_project,pytorch_playground_project,weather_forecast_project"
         in hf_visual_smoke_robot.argv

--- a/tools/agilab_widget_robot_matrix.py
+++ b/tools/agilab_widget_robot_matrix.py
@@ -624,6 +624,24 @@ OPT_IN_SCENARIOS: dict[str, RobotScenario] = {
         above_fold_check=True,
         browser_error_check=True,
     ),
+    "hf-first-proof-view-maps-visual-smoke": RobotScenario(
+        name="hf-first-proof-view-maps-visual-smoke",
+        description=(
+            "Capture a focused hosted Hugging Face screenshot for the first-proof "
+            "view_maps app-page with browser-error and above-fold evidence."
+        ),
+        pages="none",
+        apps_pages="view_maps",
+        runtime_isolation="isolated",
+        action_button_policy="trial",
+        action_timeout_seconds=30.0,
+        page_timeout_seconds=420.0,
+        target_seconds=600.0,
+        success_screenshot=True,
+        visual_mask_dynamic_regions=True,
+        above_fold_check=True,
+        browser_error_check=True,
+    ),
     "current-home-first-proof-golden-path": RobotScenario(
         name="current-home-first-proof-golden-path",
         description=(

--- a/tools/ui_robot_coverage_contract.py
+++ b/tools/ui_robot_coverage_contract.py
@@ -51,11 +51,20 @@ REQUIRED_HF_ROBOT_SCENARIOS = {
         "apps_pages": REQUIRED_HF_FIRST_PROOF_PAGES,
         "flags": ("success_screenshot", "above_fold_check", "browser_error_check"),
     },
+    "hf-first-proof-view-maps-visual-smoke": {
+        "apps_pages": ("view_maps",),
+        "flags": ("success_screenshot", "above_fold_check", "browser_error_check"),
+    },
     "hf-first-proof-install": {
         "pages": ("ORCHESTRATE",),
         "actions": ("Deploy workers",),
     },
 }
+REQUIRED_HF_VISUAL_SMOKE_ROBOT_SCENARIOS = (
+    "hf-first-proof-visual-smoke",
+    "hf-first-proof-app-pages-visual-smoke",
+    "hf-first-proof-view-maps-visual-smoke",
+)
 REQUIRED_DEMO_DOC_SNIPPETS = (
     "Robot/proof coverage",
     "UI robot",
@@ -477,10 +486,7 @@ def evaluate_contract() -> dict[str, Any]:
     hf_install_profile_scenarios: list[str] = []
     ui_robot_matrix_profile_apps: list[str] = []
     ui_robot_matrix_profile_scenarios: list[str] = []
-    hf_visual_smoke_required_scenarios = {
-        "hf-first-proof-visual-smoke",
-        "hf-first-proof-app-pages-visual-smoke",
-    }
+    hf_visual_smoke_required_scenarios = set(REQUIRED_HF_VISUAL_SMOKE_ROBOT_SCENARIOS)
     hf_install_required_scenarios = {"hf-first-proof-install"}
     for command in parity_profiles.get("hf-visual-smoke-robot", []):
         scenarios = _argv_values(command.argv, "--scenario")
@@ -503,20 +509,14 @@ def evaluate_contract() -> dict[str, Any]:
     ui_robot_matrix_profile_scenarios = sorted(set(ui_robot_matrix_profile_scenarios))
     missing_profile_apps = sorted(set(hf_first_proof_apps) - set(hf_visual_smoke_profile_apps))
     missing_install_profile_apps = sorted(set(hf_first_proof_apps) - set(hf_install_profile_apps))
-    if "hf-first-proof-visual-smoke" not in hf_visual_smoke_profile_scenarios:
-        issues.append(
-            CoverageIssue(
-                "hf_robot_profile",
-                "hf-visual-smoke-robot does not run hf-first-proof-visual-smoke",
+    for scenario_name in REQUIRED_HF_VISUAL_SMOKE_ROBOT_SCENARIOS:
+        if scenario_name not in hf_visual_smoke_profile_scenarios:
+            issues.append(
+                CoverageIssue(
+                    "hf_robot_profile",
+                    f"hf-visual-smoke-robot does not run {scenario_name}",
+                )
             )
-        )
-    if "hf-first-proof-app-pages-visual-smoke" not in hf_visual_smoke_profile_scenarios:
-        issues.append(
-            CoverageIssue(
-                "hf_robot_profile",
-                "hf-visual-smoke-robot does not run hf-first-proof-app-pages-visual-smoke",
-            )
-        )
     if missing_profile_apps:
         issues.append(
             CoverageIssue(

--- a/tools/workflow_parity.py
+++ b/tools/workflow_parity.py
@@ -1907,6 +1907,8 @@ def _hf_visual_smoke_robot_profile() -> list[CommandSpec]:
                 "hf-first-proof-visual-smoke",
                 "--scenario",
                 "hf-first-proof-app-pages-visual-smoke",
+                "--scenario",
+                "hf-first-proof-view-maps-visual-smoke",
                 "--apps",
                 "flight_telemetry_project,pytorch_playground_project,weather_forecast_project",
                 "--url",


### PR DESCRIPTION
## Summary

Fixes the hosted `view_maps` failure path and strengthens robot coverage around the HF first-proof surface.

- Scans the full Plotly color column for unhashable nested values so late dict/list payloads are converted before rendering.
- Adds `plotly` and `sqlalchemy` to the root `agilab[ui]` / `agilab[pages]` extras so clean hosted UI installs include the dependencies used by `view_maps` and app-page launch flows.
- Corrects the root uv source path for `agi-page-app-ui`.
- Adds a focused HF `view_maps` visual-smoke robot scenario, wires it into `hf-visual-smoke-robot`, and tightens the UI robot coverage contract/tests.

## Root Cause

The first fix only sampled the first 100 non-null color values, so larger mixed object columns could still contain late unhashable dict/list values and crash Plotly. The hosted HF first-proof surface also exposed missing root UI dependencies for `plotly` and `sqlalchemy` in clean installs.

## Validation

- `./dev scope --staged`
- `uv --preview-features extra-build-dependencies run --extra ui --extra viz pytest -q -o addopts='' test/test_pyproject_dependency_hygiene.py test/test_package_split_contract.py test/test_view_maps.py test/test_view_maps_3d.py test/test_view_maps_network.py test/test_view_maps_network_edge_selection.py test/test_view_maps_network_notebook_inline.py test/test_view_maps_network_page_state.py test/test_view_maps_network_path_resolution.py test/test_view_maps_network_semantic_ids.py test/test_agilab_widget_robot_matrix.py test/test_ui_robot_coverage_contract.py test/test_workflow_parity.py` (`312 passed`)
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui`
- `git diff --check`
- `uv --preview-features extra-build-dependencies lock --check`
- `uv --preview-features extra-build-dependencies run python tools/ui_robot_coverage_contract.py --json`
- `uv --preview-features extra-build-dependencies run --extra ui --extra viz python -c 'import plotly, sqlalchemy'`
- `uv --preview-features extra-build-dependencies run python tools/hf_space_release_sync.py --dry-run --json`

Note: the live HF Space can remain on the old dependency set until this change is merged and released/synced.