### PR TITLE
[codex] support root beams in view_maps_3d

### DIFF
--- a/src/agilab/apps-pages/view_maps_3d/src/view_maps_3d/view_maps_3d.py
+++ b/src/agilab/apps-pages/view_maps_3d/src/view_maps_3d/view_maps_3d.py
@@ -847,15 +847,32 @@ def page():
         args=("beamdir", beamdir_widget_key),
     )
 
-    # Initialize session state for beam_files if it doesn't exist
-    default_beam_files = ["dataset/beams.csv"]  # Define your default file here
+    configured_beam_files = view_settings.get("beam_files")
+    if isinstance(configured_beam_files, list):
+        default_beam_files = [str(item) for item in configured_beam_files]
+    elif isinstance(configured_beam_files, str) and configured_beam_files.strip():
+        default_beam_files = [configured_beam_files.strip()]
+    else:
+        default_beam_files = ["beams.csv", "dataset/beams.csv"]
     if "beam_files" not in st.session_state:
         st.session_state["beam_files"] = default_beam_files
 
     if st.session_state.beamdir:
         beamdir = Path(st.session_state.beamdir)
         if beamdir.exists() and beamdir.is_dir():
-            files = find_files(st.session_state["beamdir"], recursive=False)
+            direct_files = sorted(beamdir.glob("*.csv"))
+            nested_files = find_files(st.session_state["beamdir"], recursive=False)
+            def _beam_path_sort_key(path):
+                path = Path(path)
+                try:
+                    return path.relative_to(beamdir).as_posix()
+                except ValueError:
+                    return path.as_posix()
+
+            files = sorted(
+                {*direct_files, *nested_files},
+                key=_beam_path_sort_key,
+            )
             visible = []
             for f in files:
                 try:

--- a/test/test_view_maps_3d.py
+++ b/test/test_view_maps_3d.py
@@ -1198,6 +1198,52 @@ def test_view_maps_3d_page_handles_regex_and_beam_seed_fallbacks(monkeypatch, tm
     assert fake_st.session_state["beam_files"] == ["beam.csv"]
 
 
+def test_view_maps_3d_uses_configured_root_beams_file(monkeypatch, tmp_path) -> None:
+    module = _load_view_maps_3d_module()
+    datadir = tmp_path / "sat_trajectory" / "pipeline"
+    datadir.mkdir(parents=True)
+    dataset_path = datadir / "Trajectory" / "SAT-Z.csv"
+    dataset_path.parent.mkdir()
+    dataset_path.write_text("metric,lat,long,alt\n1,43.0,1.0,1000\n", encoding="utf-8")
+    beams_path = datadir / "beams.csv"
+    beams_path.write_text("beam,long,lat\n1,1.0,43.0\n", encoding="utf-8")
+
+    settings_path = tmp_path / "app_settings.toml"
+    settings_path.write_text(
+        "[view_maps_3d]\n"
+        f'datadir = "{datadir.as_posix()}"\n'
+        f'beamdir = "{datadir.as_posix()}"\n'
+        'file_ext_choice = "csv"\n'
+        'beam_files = ["beams.csv"]\n',
+        encoding="utf-8",
+    )
+    env = SimpleNamespace(
+        app_settings_file=settings_path,
+        target="sat_trajectory_project",
+        projects=["sat_trajectory_project"],
+        AGILAB_EXPORT_ABS=tmp_path / "export",
+        share_root_path=lambda: tmp_path,
+    )
+    fake_st = _FakeStreamlit()
+    fake_st.session_state["env"] = env
+
+    monkeypatch.setattr(module, "st", fake_st)
+    monkeypatch.setattr(module, "_list_dataset_files", lambda *_args, **_kwargs: [dataset_path])
+    monkeypatch.setattr(
+        module,
+        "load_df",
+        lambda path, *args, **kwargs: pd.DataFrame({"beam": [1], "long": [1.0], "lat": [43.0]})
+        if Path(path) == beams_path
+        else pd.DataFrame({"metric": [1], "lat": [43.0], "long": [1.0], "alt": [1000.0]}),
+    )
+
+    module.page()
+
+    assert fake_st.session_state[module._vm3d_key("beam_files")] == ["beams.csv"]
+    assert fake_st.session_state["beam_files"] == ["beams.csv"]
+    assert "beams.csv" in fake_st.session_state["dfs_beams"]
+
+
 def test_view_maps_3d_page_reclassifies_continuous_and_date_like_columns(monkeypatch, tmp_path) -> None:
     module = _load_view_maps_3d_module()
     export_root = tmp_path / "export"


### PR DESCRIPTION
## Summary

- allow `view_maps_3d` app settings to configure default beam files
- discover root-level `beams.csv` files in the configured beam directory
- keep legacy nested `dataset/beams.csv` discovery working
- add regression coverage for satellite trajectory root-level beam output

## Why

`sat_trajectory_project` writes `beams.csv` directly under its pipeline directory. The 3D map page previously only discovered nested beam files, so the app settings could not reliably seed the satellite beam export.

## Validation

Validation passed.
