### PR TITLE
[codex] expose execution pandas pool executor in ORCHESTRATE

### DIFF
--- a/.github/workflows/ui-robot-matrix.yml
+++ b/.github/workflows/ui-robot-matrix.yml
@@ -45,6 +45,7 @@ jobs:
               isolated-project-rename-sidebar
               isolated-settings-page
               isolated-all-builtins-orchestrate-smoke
+              isolated-execution-pandas-orchestrate-pool-executor
               isolated-all-builtins-core-render-smoke
           - shard: state
             scenarios: >-

--- a/src/agilab/apps/builtin/execution_pandas_project/README.md
+++ b/src/agilab/apps/builtin/execution_pandas_project/README.md
@@ -39,9 +39,11 @@ distance/checksum fields, and the execution engine label.
 
 ## Change One Thing
 
-After the default run works, change only the partition count or switch
-`kernel_mode` from `typed_numeric` to `dataframe`. The output row counts should
-stay stable while the runtime and kernel metadata change.
+After the default run works, change only the partition count, switch
+`kernel_mode` from `typed_numeric` to `dataframe`, or set the ORCHESTRATE pool
+executor to `thread` for a bounded pool-mode benchmark. The output row counts
+should stay stable while the runtime, kernel metadata, and execution-model label
+change.
 
 ## Troubleshooting
 

--- a/src/agilab/apps/builtin/execution_pandas_project/src/app_args_form.py
+++ b/src/agilab/apps/builtin/execution_pandas_project/src/app_args_form.py
@@ -11,7 +11,7 @@ _HERE = Path(__file__).resolve().parent
 if str(_HERE) not in sys.path:
     sys.path.insert(0, str(_HERE))
 
-from execution_pandas.app_args import ExecutionPandasArgs, dump_args, load_args
+from execution_pandas.app_args import ExecutionPandasArgs, dump_args, load_args  # noqa: E402
 
 
 PAGE_ID = "execution_pandas_project:app_args_form"
@@ -69,6 +69,7 @@ for key, default in (
     ("n_groups", int(current_payload.get("n_groups", 32) or 32)),
     ("compute_passes", int(current_payload.get("compute_passes", 32) or 32)),
     ("kernel_mode", str(current_payload.get("kernel_mode", "typed_numeric") or "typed_numeric")),
+    ("pool_executor", str(current_payload.get("pool_executor", "auto") or "auto")),
     ("output_format", str(current_payload.get("output_format", "csv") or "csv")),
     ("seed", int(current_payload.get("seed", 42) or 42)),
     ("reset_target", bool(current_payload.get("reset_target", False))),
@@ -113,11 +114,26 @@ with c10:
         key=_k("kernel_mode"),
     )
 with c11:
-    st.checkbox("Reset output", key=_k("reset_target"))
+    st.selectbox(
+        "Pool executor",
+        options=["auto", "process", "thread"],
+        format_func=lambda value: {
+            "auto": "Auto (ORCHESTRATE setting)",
+            "process": "Process",
+            "thread": "Thread",
+        }[value],
+        key=_k("pool_executor"),
+        help=(
+            "Only affects pool or Dask runs. Auto follows the ORCHESTRATE "
+            "Resources and deployment pool executor setting when it is set."
+        ),
+    )
 
-c12, _ = st.columns([1.2, 3.6])
+c12, c13, _ = st.columns([1.2, 1.2, 2.4])
 with c12:
     st.number_input("Seed", key=_k("seed"), min_value=0, step=1)
+with c13:
+    st.checkbox("Reset output", key=_k("reset_target"))
 
 candidate: dict[str, Any] = {
     "data_in": (st.session_state.get(_k("data_in")) or "").strip(),
@@ -129,6 +145,7 @@ candidate: dict[str, Any] = {
     "n_groups": st.session_state.get(_k("n_groups"), 32),
     "compute_passes": st.session_state.get(_k("compute_passes"), 32),
     "kernel_mode": st.session_state.get(_k("kernel_mode")) or "typed_numeric",
+    "pool_executor": st.session_state.get(_k("pool_executor")) or "auto",
     "output_format": st.session_state.get(_k("output_format")) or "csv",
     "seed": st.session_state.get(_k("seed"), 42),
     "reset_target": bool(st.session_state.get(_k("reset_target"), False)),
@@ -163,5 +180,5 @@ else:
     st.caption(
         f"Planned workload: `{validated.nfile}` files, about `{total_rows:,}` rows total, "
         f"`{validated.n_partitions}` partitions per file, about `{rows_per_partition:,}` rows per partition, "
-        f"`{validated.kernel_mode}` kernel."
+        f"`{validated.kernel_mode}` kernel, `{validated.pool_executor}` pool executor."
     )

--- a/src/agilab/apps/builtin/execution_pandas_project/src/app_settings.toml
+++ b/src/agilab/apps/builtin/execution_pandas_project/src/app_settings.toml
@@ -8,6 +8,7 @@ rows_per_file = 100000
 n_groups = 32
 compute_passes = 32
 kernel_mode = "typed_numeric"
+pool_executor = "auto"
 output_format = "csv"
 seed = 42
 reset_target = false

--- a/src/agilab/apps/builtin/execution_pandas_project/src/execution_pandas/app_args.py
+++ b/src/agilab/apps/builtin/execution_pandas_project/src/execution_pandas/app_args.py
@@ -24,6 +24,7 @@ class ExecutionPandasArgs(BaseModel):
     n_groups: int = 32
     compute_passes: int = 32
     kernel_mode: Literal["dataframe", "typed_numeric"] = "typed_numeric"
+    pool_executor: Literal["auto", "process", "thread"] = "auto"
     output_format: Literal["csv", "parquet"] = "csv"
     seed: int = 42
     reset_target: bool = False
@@ -39,6 +40,7 @@ class ExecutionPandasArgsTD(TypedDict, total=False):
     n_groups: int
     compute_passes: int
     kernel_mode: str
+    pool_executor: str
     output_format: str
     seed: int
     reset_target: bool

--- a/src/agilab/apps/builtin/execution_pandas_project/src/execution_pandas_worker/execution_pandas_worker.py
+++ b/src/agilab/apps/builtin/execution_pandas_project/src/execution_pandas_worker/execution_pandas_worker.py
@@ -3,14 +3,17 @@
 from __future__ import annotations
 
 import logging
+import os
 from pathlib import Path
 from types import SimpleNamespace
 import time
+from contextlib import contextmanager
 
 import cython
 import numpy as np
 import pandas as pd
 
+from agi_node.agi_dispatcher import worker_pool_support
 from agi_node.pandas_worker import PandasWorker
 from execution_pandas.reduction import write_reduce_artifact
 
@@ -85,6 +88,58 @@ def _typed_numeric_score_kernel(
 
 def _kernel_runtime_label() -> str:
     return "cython" if cython.compiled else "python"
+
+
+def _pool_executor_choice(args: SimpleNamespace | object) -> str:
+    raw = str(getattr(args, "pool_executor", "auto") or "auto").strip().lower()
+    return raw if raw in {"process", "thread"} else "auto"
+
+
+def _pool_execution_model_label(args: SimpleNamespace | object) -> str:
+    choice = _pool_executor_choice(args)
+    if choice == "auto":
+        choice = (
+            os.environ.get(worker_pool_support.POOL_EXECUTOR_ENV, "auto")
+            .strip()
+            .lower()
+        )
+        if choice not in {"auto", "process", "thread"}:
+            choice = "auto"
+    if choice == "thread":
+        return "threads"
+    if choice == "auto" and worker_pool_support._free_threading_active():
+        return "threads"
+    return "process"
+
+
+@contextmanager
+def _pool_executor_context(worker: object, args: SimpleNamespace | object):
+    choice = _pool_executor_choice(args)
+    previous = os.environ.get(worker_pool_support.POOL_EXECUTOR_ENV)
+    had_label = hasattr(worker, "_execution_model_label")
+    previous_label = getattr(worker, "_execution_model_label", None)
+    if choice != "auto":
+        os.environ[worker_pool_support.POOL_EXECUTOR_ENV] = choice
+    setattr(worker, "_execution_model_label", _pool_execution_model_label(args))
+    try:
+        yield
+    finally:
+        if choice != "auto":
+            if previous is None:
+                os.environ.pop(worker_pool_support.POOL_EXECUTOR_ENV, None)
+            else:
+                os.environ[worker_pool_support.POOL_EXECUTOR_ENV] = previous
+        if had_label:
+            setattr(worker, "_execution_model_label", previous_label)
+        else:
+            try:
+                delattr(worker, "_execution_model_label")
+            except AttributeError:
+                pass
+
+
+def _execution_model_label(worker: object) -> str:
+    return str(getattr(worker, "_execution_model_label", "process") or "process")
 
 
 def _as_contiguous_float64(series: pd.Series) -> np.ndarray:
@@ -256,7 +311,8 @@ class ExecutionPandasWorker(PandasWorker):
         """Treat pool and dask bits as parallel paths for this benchmark worker."""
         if workers_plan:
             if self._mode & 0b0101:
-                self._exec_multi_process(workers_plan, workers_plan_metadata)
+                with _pool_executor_context(self, self._current_args()):
+                    self._exec_multi_process(workers_plan, workers_plan_metadata)
             else:
                 self._exec_mono_process(workers_plan, workers_plan_metadata)
 
@@ -305,7 +361,7 @@ class ExecutionPandasWorker(PandasWorker):
         agg["dtype_contract"] = dtype_contract
         agg["source_file"] = source.name
         agg["engine"] = "pandas"
-        agg["execution_model"] = "process"
+        agg["execution_model"] = _execution_model_label(self)
         return agg
 
     def work_done(self, df: pd.DataFrame | None = None) -> None:

--- a/src/agilab/apps/builtin/execution_pandas_project/test/test_execution_pandas_project.py
+++ b/src/agilab/apps/builtin/execution_pandas_project/test/test_execution_pandas_project.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import os
+import pytest
 import sys
 import time
 import tomllib
@@ -11,7 +13,7 @@ import numpy as np
 import pandas as pd
 
 from agi_node.reduction import ReduceArtifact
-from agi_node.agi_dispatcher import BaseWorker
+from agi_node.agi_dispatcher import BaseWorker, worker_pool_support
 
 
 APP_ROOT = Path(__file__).resolve().parents[1]
@@ -19,20 +21,25 @@ SRC_ROOT = APP_ROOT / "src"
 if str(SRC_ROOT) not in sys.path:
     sys.path.insert(0, str(SRC_ROOT))
 
-from execution_pandas.execution_pandas import ExecutionPandas
-from execution_pandas.app_args import ExecutionPandasArgs
-from execution_pandas.reduction import (
+from execution_pandas.execution_pandas import ExecutionPandas  # noqa: E402
+from execution_pandas.app_args import ExecutionPandasArgs  # noqa: E402
+from execution_pandas.reduction import (  # noqa: E402
     REDUCE_ARTIFACT_NAME,
     REDUCER_NAME,
     build_reduce_artifact,
     partial_from_result_frame,
     reduce_artifact_path,
 )
-from execution_pandas_worker.execution_pandas_worker import (
+from execution_pandas_worker.execution_pandas_worker import (  # noqa: E402
     ExecutionPandasWorker,
     _fill_vectorized_score_array,
     _tail_checksum_from_arrays,
 )
+
+
+@pytest.fixture(autouse=True)
+def _clear_pool_executor_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(worker_pool_support.POOL_EXECUTOR_ENV, raising=False)
 
 
 def _load_toml(path: Path) -> dict:
@@ -57,6 +64,39 @@ def _make_env(tmp_path: Path) -> SimpleNamespace:
     )
 
 
+def _run_worker_plan(
+    tmp_path: Path,
+    args: ExecutionPandasArgs,
+    *,
+    mode: int,
+) -> ExecutionPandasWorker:
+    env = _make_env(tmp_path)
+    manager = ExecutionPandas(env, args=args)
+    workers = {"127.0.0.1": 1}
+    work_plan, metadata, *_ = manager.build_distribution(workers)
+
+    worker = ExecutionPandasWorker()
+    worker.env = env
+    worker.args = manager.args.model_dump(mode="json")
+    worker._worker_id = 0
+    worker.worker_id = 0
+    worker.verbose = 0
+    worker._mode = mode
+
+    BaseWorker._t0 = time.time()
+    worker.start()
+    seconds = worker.works(work_plan, metadata)
+
+    assert seconds >= 0.0
+    return worker
+
+
+def _read_first_output_csv(worker: ExecutionPandasWorker) -> pd.DataFrame:
+    output_files = sorted(Path(worker.data_out).glob("*.csv"))
+    assert output_files
+    return pd.read_csv(output_files[0])
+
+
 def test_execution_pandas_declares_cython_worker_reference_contract() -> None:
     settings = _load_toml(APP_ROOT / "src" / "app_settings.toml")
     worker_manifest = _load_toml(
@@ -69,6 +109,7 @@ def test_execution_pandas_declares_cython_worker_reference_contract() -> None:
     }
 
     assert settings["args"]["kernel_mode"] == "typed_numeric"
+    assert settings["args"]["pool_executor"] == "auto"
     assert settings["cluster"]["cython"] is True
     assert {"setuptools", "cython"} <= build_requires
 
@@ -127,6 +168,70 @@ def test_execution_pandas_worker_processes_a_file(tmp_path: Path) -> None:
     assert set(result["kernel_mode"]) == {"typed_numeric"}
     assert set(result["kernel_runtime"]) == {"python"}
     assert set(result["dtype_contract"]) == {"float64-contiguous"}
+
+
+def test_execution_pandas_worker_labels_forced_thread_executor(tmp_path: Path) -> None:
+    args = ExecutionPandasArgs(
+        n_partitions=1,
+        nfile=1,
+        rows_per_file=16,
+        n_groups=4,
+        pool_executor="thread",
+        reset_target=True,
+    )
+
+    worker = _run_worker_plan(tmp_path, args, mode=1)
+    result = _read_first_output_csv(worker)
+
+    assert set(result["execution_model"]) == {"threads"}
+
+
+def test_execution_pandas_worker_auto_labels_orchestrate_thread_executor(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv(worker_pool_support.POOL_EXECUTOR_ENV, "thread")
+    args = ExecutionPandasArgs(
+        n_partitions=1,
+        nfile=1,
+        rows_per_file=16,
+        n_groups=4,
+        pool_executor="auto",
+        reset_target=True,
+    )
+
+    worker = _run_worker_plan(tmp_path, args, mode=1)
+    result = _read_first_output_csv(worker)
+
+    assert set(result["execution_model"]) == {"threads"}
+
+
+def test_execution_pandas_worker_pool_selector_does_not_relabel_serial_work(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv(worker_pool_support.POOL_EXECUTOR_ENV, "thread")
+    env = _make_env(tmp_path)
+    args = ExecutionPandasArgs(
+        n_partitions=1,
+        nfile=1,
+        rows_per_file=16,
+        n_groups=4,
+        pool_executor="thread",
+    )
+    manager = ExecutionPandas(env, args=args)
+    source = sorted(manager.args.data_in.glob("*.csv"))[0]
+
+    worker = ExecutionPandasWorker()
+    worker.env = env
+    worker.args = manager.args.model_dump(mode="json")
+    worker._worker_id = 0
+    worker.verbose = 0
+    worker.start()
+
+    result = worker.work_pool(str(source))
+
+    assert set(result["execution_model"]) == {"process"}
 
 
 def test_execution_pandas_vectorized_tail_checksum_matches_scalar_reference() -> None:
@@ -322,3 +427,49 @@ def test_execution_pandas_worker_uses_parallel_path_for_pool_mode(tmp_path: Path
 
     assert seconds >= 0.0
     assert calls["parallel"] == 1
+
+
+def test_execution_pandas_pool_executor_arg_scopes_env_override(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv(worker_pool_support.POOL_EXECUTOR_ENV, "process")
+    env = _make_env(tmp_path)
+    args = ExecutionPandasArgs(
+        n_partitions=4,
+        nfile=4,
+        rows_per_file=24,
+        n_groups=6,
+        reset_target=True,
+        pool_executor="thread",
+    )
+    manager = ExecutionPandas(env, args=args)
+    workers = {"127.0.0.1": 1}
+    work_plan, metadata, *_ = manager.build_distribution(workers)
+
+    worker = ExecutionPandasWorker()
+    worker.env = env
+    worker.args = manager.args.model_dump(mode="json")
+    worker._worker_id = 0
+    worker.worker_id = 0
+    worker.verbose = 0
+    worker._mode = 1
+
+    observed: list[str | None] = []
+    observed_labels: list[str | None] = []
+
+    def _fake_multi(plan, meta):
+        observed.append(os.environ.get(worker_pool_support.POOL_EXECUTOR_ENV))
+        observed_labels.append(getattr(worker, "_execution_model_label", None))
+
+    worker._exec_multi_process = _fake_multi
+
+    BaseWorker._t0 = time.time()
+    worker.start()
+    seconds = worker.works(work_plan, metadata)
+
+    assert seconds >= 0.0
+    assert observed == ["thread"]
+    assert observed_labels == ["threads"]
+    assert os.environ.get(worker_pool_support.POOL_EXECUTOR_ENV) == "process"
+    assert not hasattr(worker, "_execution_model_label")

--- a/test/test_agilab_widget_robot_matrix.py
+++ b/test/test_agilab_widget_robot_matrix.py
@@ -37,6 +37,7 @@ def test_default_scenarios_cover_isolated_pages_and_current_home_actions() -> No
         "current-home-pytorch-direct-run-readiness",
         "current-home-orchestrate-journey",
         "isolated-orchestrate-pool-parameters",
+        "isolated-execution-pandas-orchestrate-pool-executor",
     ]
     (
         isolated,
@@ -51,6 +52,7 @@ def test_default_scenarios_cover_isolated_pages_and_current_home_actions() -> No
         pytorch_direct,
         journey,
         pool_parameters,
+        execution_pandas_pool,
     ) = scenarios
     assert isolated.pages == "ORCHESTRATE,WORKFLOW,ANALYSIS"
     assert isolated.runtime_isolation == "isolated"
@@ -123,6 +125,13 @@ def test_default_scenarios_cover_isolated_pages_and_current_home_actions() -> No
     assert pool_parameters.max_action_clicks_per_page == 0
     assert pool_parameters.required_text == "Pool parameters,Max workers,Item timeout seconds,Pool executor"
     assert pool_parameters.browser_error_check is True
+    assert execution_pandas_pool.pages == "ORCHESTRATE"
+    assert execution_pandas_pool.apps == "execution_pandas_project"
+    assert execution_pandas_pool.runtime_isolation == "isolated"
+    assert execution_pandas_pool.action_button_policy == "trial"
+    assert execution_pandas_pool.max_action_clicks_per_page == 0
+    assert execution_pandas_pool.required_text == "Pool executor,Auto (ORCHESTRATE setting)"
+    assert execution_pandas_pool.browser_error_check is True
     assert "isolated-browser-history" not in [scenario.name for scenario in scenarios]
     assert "isolated-mobile-core-pages" not in [scenario.name for scenario in scenarios]
     assert "isolated-fresh-session-core-pages" not in [scenario.name for scenario in scenarios]
@@ -1606,13 +1615,14 @@ def test_run_matrix_aggregates_json_summaries(tmp_path) -> None:
         "current-home-pytorch-direct-run-readiness",
         "current-home-orchestrate-journey",
         "isolated-orchestrate-pool-parameters",
+        "isolated-execution-pandas-orchestrate-pool-executor",
     ]
     assert summary["success"] is True
-    assert summary["scenario_count"] == 12
-    assert summary["page_count"] == 24
-    assert summary["widget_count"] == 60
-    assert summary["interacted_count"] == 36
-    assert summary["probed_count"] == 24
+    assert summary["scenario_count"] == 13
+    assert summary["page_count"] == 26
+    assert summary["widget_count"] == 65
+    assert summary["interacted_count"] == 39
+    assert summary["probed_count"] == 26
     assert summary["failed_scenarios"] == []
     assert summary["failure_samples"] == []
 

--- a/test/test_execution_playground_forms.py
+++ b/test/test_execution_playground_forms.py
@@ -21,6 +21,7 @@ def _make_env(tmp_path: Path, *, app_name: str, data_out: str) -> SimpleNamespac
         "n_groups = 32\n"
         "compute_passes = 32\n"
         "kernel_mode = \"typed_numeric\"\n"
+        "pool_executor = \"auto\"\n"
         "output_format = \"csv\"\n"
         "seed = 42\n"
         "reset_target = false\n",
@@ -44,10 +45,19 @@ def test_execution_pandas_form_renders_and_persists_args(tmp_path: Path) -> None
     assert at.text_input(key="execution_pandas_project:app_args_form:data_in").value == "execution_playground/dataset"
     assert at.text_input(key="execution_pandas_project:app_args_form:data_out").value == "execution_pandas/results"
     assert at.selectbox(key="execution_pandas_project:app_args_form:kernel_mode").value == "typed_numeric"
+    pool_executor = at.selectbox(key="execution_pandas_project:app_args_form:pool_executor")
+    assert pool_executor.label == "Pool executor"
+    assert pool_executor.options == [
+        "Auto (ORCHESTRATE setting)",
+        "Process",
+        "Thread",
+    ]
+    assert pool_executor.value == "auto"
 
     at.number_input(key="execution_pandas_project:app_args_form:nfile").set_value(8)
     at.number_input(key="execution_pandas_project:app_args_form:rows_per_file").set_value(50000)
     at.selectbox(key="execution_pandas_project:app_args_form:kernel_mode").set_value("dataframe")
+    at.selectbox(key="execution_pandas_project:app_args_form:pool_executor").set_value("thread")
     at.selectbox(key="execution_pandas_project:app_args_form:output_format").set_value("parquet")
     at.run()
 
@@ -56,6 +66,7 @@ def test_execution_pandas_form_renders_and_persists_args(tmp_path: Path) -> None
     assert at.session_state["app_settings"]["args"]["nfile"] == 8
     assert at.session_state["app_settings"]["args"]["rows_per_file"] == 50000
     assert at.session_state["app_settings"]["args"]["kernel_mode"] == "dataframe"
+    assert at.session_state["app_settings"]["args"]["pool_executor"] == "thread"
     assert at.session_state["app_settings"]["args"]["output_format"] == "parquet"
 
 

--- a/test/test_ui_robot_coverage_contract.py
+++ b/test/test_ui_robot_coverage_contract.py
@@ -107,10 +107,20 @@ def test_ui_robot_coverage_contract_passes_for_current_matrix() -> None:
     assert "isolated-project-editor-page" in payload["coverage"]["ui_robot_matrix_profile_scenarios"]
     assert "isolated-pytorch-playground-analysis" in payload["coverage"]["ui_robot_matrix_profile_scenarios"]
     assert "isolated-release-evidence" in payload["coverage"]["ui_robot_matrix_profile_scenarios"]
+    assert (
+        "isolated-execution-pandas-orchestrate-pool-executor"
+        in payload["coverage"]["ui_robot_matrix_profile_scenarios"]
+    )
     assert payload["coverage"]["orchestrate_pool_robot"] == {
         "flags": ["browser_error_check"],
         "pages": ["ORCHESTRATE"],
         "required_text": ["Item timeout seconds", "Max workers", "Pool executor", "Pool parameters"],
+    }
+    assert payload["coverage"]["execution_pandas_pool_robot"] == {
+        "apps": ["execution_pandas_project"],
+        "flags": ["browser_error_check"],
+        "pages": ["ORCHESTRATE"],
+        "required_text": ["Auto (ORCHESTRATE setting)", "Pool executor"],
     }
     assert payload["coverage"]["pytorch_analysis_robot"] == {
         "apps": ["pytorch_playground_project"],
@@ -237,6 +247,13 @@ def test_ui_robot_coverage_contract_accepts_explicit_full_app_profile(monkeypatc
         pages="ORCHESTRATE",
         required_text=",".join(module.REQUIRED_ORCHESTRATE_POOL_TEXT),
     )
+    execution_pandas_pool = scenario(
+        module.REQUIRED_EXECUTION_PANDAS_POOL_SCENARIO,
+        pages="ORCHESTRATE",
+        apps=module.REQUIRED_EXECUTION_PANDAS_POOL_APP,
+        required_text=",".join(module.REQUIRED_EXECUTION_PANDAS_POOL_TEXT),
+        browser_error_check=True,
+    )
     pytorch = scenario(
         "isolated-pytorch-playground-analysis",
         pages="ANALYSIS",
@@ -258,6 +275,7 @@ def test_ui_robot_coverage_contract_accepts_explicit_full_app_profile(monkeypatc
             hf_view_maps,
             hf_install,
             orchestrate_pool,
+            execution_pandas_pool,
             pytorch,
             release_evidence,
         )
@@ -321,6 +339,8 @@ def test_ui_robot_coverage_contract_accepts_explicit_full_app_profile(monkeypatc
                             "isolated-pytorch-playground-analysis",
                             "--scenario",
                             "isolated-release-evidence",
+                            "--scenario",
+                            module.REQUIRED_EXECUTION_PANDAS_POOL_SCENARIO,
                             "--apps",
                             ",".join(module.REQUIRED_DEMO_UI_APPS),
                         ]
@@ -720,6 +740,13 @@ def test_ui_robot_coverage_contract_reports_matrix_and_pytorch_gaps(monkeypatch,
     assert "isolated-pytorch-playground-analysis does not enable browser_error_check" in details
     assert "ui-robot-matrix profile does not run isolated-project-editor-page" in details
     assert "ui-robot-matrix profile does not run isolated-pytorch-playground-analysis" in details
+    assert (
+        "ui-robot-matrix profile does not run "
+        "isolated-execution-pandas-orchestrate-pool-executor"
+    ) in details
+    assert (
+        "isolated-execution-pandas-orchestrate-pool-executor is missing from the robot matrix"
+    ) in details
     assert any(
         detail.startswith("public proof scenarios are missing documented demo routes:")
         and "notebook-migration-proof" in detail

--- a/test/test_workflow_parity.py
+++ b/test/test_workflow_parity.py
@@ -507,6 +507,7 @@ def test_profile_commands_cover_expected_coverage_and_docs_contracts() -> None:
             "isolated-project-rename-sidebar",
             "isolated-settings-page",
             "isolated-all-builtins-orchestrate-smoke",
+            "isolated-execution-pandas-orchestrate-pool-executor",
             "isolated-all-builtins-core-render-smoke",
         },
         "state": {

--- a/tools/agilab_widget_robot_matrix.py
+++ b/tools/agilab_widget_robot_matrix.py
@@ -337,6 +337,21 @@ DEFAULT_SCENARIOS: dict[str, RobotScenario] = {
         required_text="Pool parameters,Max workers,Item timeout seconds,Pool executor",
         browser_error_check=True,
     ),
+    "isolated-execution-pandas-orchestrate-pool-executor": RobotScenario(
+        name="isolated-execution-pandas-orchestrate-pool-executor",
+        description=(
+            "Render execution_pandas_project in ORCHESTRATE and assert the "
+            "app-specific run-argument form exposes the pool executor selector."
+        ),
+        pages="ORCHESTRATE",
+        apps="execution_pandas_project",
+        apps_pages="none",
+        runtime_isolation="isolated",
+        action_button_policy="trial",
+        max_action_clicks_per_page=0,
+        required_text="Pool executor,Auto (ORCHESTRATE setting)",
+        browser_error_check=True,
+    ),
 }
 
 

--- a/tools/ui_robot_coverage_contract.py
+++ b/tools/ui_robot_coverage_contract.py
@@ -37,6 +37,9 @@ REQUIRED_PYTORCH_ANALYSIS_SCENARIO = "isolated-pytorch-playground-analysis"
 REQUIRED_RELEASE_EVIDENCE_SCENARIO = "isolated-release-evidence"
 REQUIRED_ORCHESTRATE_POOL_SCENARIO = "isolated-orchestrate-pool-parameters"
 REQUIRED_ORCHESTRATE_POOL_TEXT = ("Pool parameters", "Max workers", "Item timeout seconds", "Pool executor")
+REQUIRED_EXECUTION_PANDAS_POOL_SCENARIO = "isolated-execution-pandas-orchestrate-pool-executor"
+REQUIRED_EXECUTION_PANDAS_POOL_APP = "execution_pandas_project"
+REQUIRED_EXECUTION_PANDAS_POOL_TEXT = ("Pool executor", "Auto (ORCHESTRATE setting)")
 REQUIRED_PYTORCH_ANALYSIS_APP = "pytorch_playground_project"
 REQUIRED_PYTORCH_ANALYSIS_TEXT = ("PyTorch Playground", "Refresh evidence", "Synced RUN snippet", "Settings")
 REQUIRED_PYTORCH_ANALYSIS_FORBIDDEN_SIDEBAR_TEXT = ("Project:",)
@@ -647,6 +650,13 @@ def evaluate_contract() -> dict[str, Any]:
                 f"ui-robot-matrix profile does not run {REQUIRED_RELEASE_EVIDENCE_SCENARIO}",
             )
         )
+    if REQUIRED_EXECUTION_PANDAS_POOL_SCENARIO not in ui_robot_matrix_profile_scenarios:
+        issues.append(
+            CoverageIssue(
+                "execution_pandas_pool_robot",
+                f"ui-robot-matrix profile does not run {REQUIRED_EXECUTION_PANDAS_POOL_SCENARIO}",
+            )
+        )
 
     orchestrate_pool: dict[str, list[str]] = {}
     orchestrate_pool_scenario = scenario_by_name.get(REQUIRED_ORCHESTRATE_POOL_SCENARIO)
@@ -680,6 +690,58 @@ def evaluate_contract() -> dict[str, Any]:
                     "orchestrate_pool_robot",
                     f"{REQUIRED_ORCHESTRATE_POOL_SCENARIO} is missing required text probes: "
                     + ", ".join(missing_text),
+                )
+            )
+
+    execution_pandas_pool: dict[str, list[str]] = {}
+    execution_pandas_pool_scenario = scenario_by_name.get(REQUIRED_EXECUTION_PANDAS_POOL_SCENARIO)
+    if execution_pandas_pool_scenario is None:
+        issues.append(
+            CoverageIssue(
+                "execution_pandas_pool_robot",
+                f"{REQUIRED_EXECUTION_PANDAS_POOL_SCENARIO} is missing from the robot matrix",
+            )
+        )
+    else:
+        pages = sorted(_scenario_pages(widget_robot, execution_pandas_pool_scenario))
+        apps = sorted(_scenario_apps(widget_robot, execution_pandas_pool_scenario))
+        required_text = sorted(_scenario_required_text(widget_robot, execution_pandas_pool_scenario))
+        flags = sorted(_scenario_flags(execution_pandas_pool_scenario))
+        execution_pandas_pool = {
+            "apps": apps,
+            "pages": pages,
+            "required_text": required_text,
+            "flags": flags,
+        }
+        if REQUIRED_EXECUTION_PANDAS_POOL_APP not in apps:
+            issues.append(
+                CoverageIssue(
+                    "execution_pandas_pool_robot",
+                    f"{REQUIRED_EXECUTION_PANDAS_POOL_SCENARIO} does not target "
+                    f"{REQUIRED_EXECUTION_PANDAS_POOL_APP}",
+                )
+            )
+        if "ORCHESTRATE" not in pages:
+            issues.append(
+                CoverageIssue(
+                    "execution_pandas_pool_robot",
+                    f"{REQUIRED_EXECUTION_PANDAS_POOL_SCENARIO} does not cover ORCHESTRATE",
+                )
+            )
+        missing_text = sorted(set(REQUIRED_EXECUTION_PANDAS_POOL_TEXT) - set(required_text))
+        if missing_text:
+            issues.append(
+                CoverageIssue(
+                    "execution_pandas_pool_robot",
+                    f"{REQUIRED_EXECUTION_PANDAS_POOL_SCENARIO} is missing required text probes: "
+                    + ", ".join(missing_text),
+                )
+            )
+        if "browser_error_check" not in flags:
+            issues.append(
+                CoverageIssue(
+                    "execution_pandas_pool_robot",
+                    f"{REQUIRED_EXECUTION_PANDAS_POOL_SCENARIO} does not enable browser_error_check",
                 )
             )
 
@@ -756,6 +818,7 @@ def evaluate_contract() -> dict[str, Any]:
             "ui_robot_matrix_profile_scenarios": ui_robot_matrix_profile_scenarios,
             "hf_robot_scenarios": hf_robot_scenarios,
             "orchestrate_pool_robot": orchestrate_pool,
+            "execution_pandas_pool_robot": execution_pandas_pool,
             "pytorch_analysis_robot": pytorch_analysis,
             "public_demo_contract": {
                 "doc_snippets": list(REQUIRED_DEMO_DOC_SNIPPETS),

--- a/tools/workflow_parity.py
+++ b/tools/workflow_parity.py
@@ -67,6 +67,7 @@ UI_ROBOT_MATRIX_SHARDS = (
             "isolated-project-rename-sidebar",
             "isolated-settings-page",
             "isolated-all-builtins-orchestrate-smoke",
+            "isolated-execution-pandas-orchestrate-pool-executor",
             "isolated-all-builtins-core-render-smoke",
         ),
     ),


### PR DESCRIPTION
## Summary

- Add an execution-pandas `pool_executor` argument surfaced in the ORCHESTRATE run-arguments form.
- Apply the process/thread override only for the app-local pool/Dask execution path and keep serial metadata truthful.
- Add a dedicated UI robot scenario and coverage contract so the execution-pandas ORCHESTRATE pool executor UX is browser-validated.

## Validation

- App-local execution-pandas pytest suite passed.
- Required app-args / UI robot contract pytest slice passed.
- `tools/workflow_parity.py --profile ui-robot-contract` passed.
- Chromium widget robot scenario `isolated-execution-pandas-orchestrate-pool-executor` passed with browser-error checking enabled.
- `./dev app-contracts` passed.

Robot evidence was written under `/tmp/agilab-execution-pandas-pool-robot/` for local validation only.