### PR TITLE
[codex] clean validation warning signals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,7 +259,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip --no-cache-dir
           python tools/install_release_proof_package.py --retries 20 --delay-seconds 15
 
       - name: Validate clean package first proof

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -590,12 +590,7 @@ jobs:
       - name: Upload repo-wide agilab coverage to Codecov
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
         with:
-          files: >-
-            ./merged-coverage/coverage-agi-env.xml,
-            ./merged-coverage/coverage-agi-node.xml,
-            ./merged-coverage/coverage-agi-cluster.xml,
-            ./merged-coverage/coverage-agi-gui.xml,
-            ./merged-coverage/coverage-agi-web.xml
+          files: ./merged-coverage/coverage-agi-env.xml,./merged-coverage/coverage-agi-node.xml,./merged-coverage/coverage-agi-cluster.xml,./merged-coverage/coverage-agi-gui.xml,./merged-coverage/coverage-agi-web.xml
           use_oidc: true
           verbose: true
           fail_ci_if_error: true

--- a/.github/workflows/windows-core-tests.yml
+++ b/.github/workflows/windows-core-tests.yml
@@ -67,7 +67,7 @@ jobs:
             --with pytest `
             --with pytest-asyncio `
             --with pytest-cov `
-            python -m pytest -q --disable-warnings -o addopts='' --import-mode=importlib `
+            python -m pytest -q -o addopts='' --import-mode=importlib `
             --junitxml test-results/windows-core-tests.xml `
             src/agilab/core/test src/agilab/core/agi-env/test src/agilab/core/agi-cluster/test `
             2>&1 | Tee-Object -FilePath test-results/windows-core-tests.txt
@@ -75,6 +75,17 @@ jobs:
           if ($exitCode -ne 0) {
             exit $exitCode
           }
+
+      - name: Audit Windows warning output
+        if: always()
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          & uv --preview-features extra-build-dependencies run --no-project `
+            python tools/validation_warning_report.py `
+            test-results/windows-core-tests.txt `
+            --strict `
+            --output test-results/windows-core-warning-report.json
 
       - name: Upload Windows core test artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -84,4 +95,5 @@ jobs:
           path: |
             test-results/windows-core-tests.txt
             test-results/windows-core-tests.xml
+            test-results/windows-core-warning-report.json
           if-no-files-found: ignore

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,9 @@ Use this runbook whenever you:
   environment with pytest importlib mode, avoiding false root-environment dependency
   failures for app-local packages,
   `warnings` writes a structured validation-warning report and can fail on
-  unapproved warnings when `--strict` is used,
+  unapproved warnings when `--strict` is used; for multi-command validation batches,
+  create a marker file before the batch and pass `--newer-than <marker>` so stale
+  dev logs do not pollute the current warning audit,
   `audit` is the quick robustness check before handoff between machines,
   `flow` matches local GitHub workflow profiles, `ui-flow` is the local-first gate
   before relying on the scheduled full UI robot matrix for browser-heavy frontend changes,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@ Use this runbook whenever you:
   `app-contracts` for
   built-in app/package/catalog/docs alignment, `audit` for local worktree/docs/release/PyPI
   state, `builtin-app-tests` for app-local built-in test execution,
+  `warnings` for summarizing validation warning signals from local logs and robot artifacts,
   `flow` for one or more workflow parity profiles, `ui-flow` for selecting the
   minimal local UI robot profiles from changed files,
   `release` for local pre-tag release guards, `badge` for the explicit release/pre-release
@@ -56,6 +57,8 @@ Use this runbook whenever you:
   `builtin-app-tests` runs built-in app tests inside each app's own `uv --project .`
   environment with pytest importlib mode, avoiding false root-environment dependency
   failures for app-local packages,
+  `warnings` writes a structured validation-warning report and can fail on
+  unapproved warnings when `--strict` is used,
   `audit` is the quick robustness check before handoff between machines,
   `flow` matches local GitHub workflow profiles, `ui-flow` is the local-first gate
   before relying on the scheduled full UI robot matrix for browser-heavy frontend changes,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -553,6 +553,10 @@ filterwarnings = [
   "ignore:'parseString' deprecated - use 'parse_string':Warning:matplotlib\\._fontconfig_pattern",
   "ignore:'resetCache' deprecated - use 'reset_cache':Warning:matplotlib\\._fontconfig_pattern",
   "ignore:'enablePackrat' deprecated - use 'enable_packrat':Warning:matplotlib\\._mathtext",
+  "ignore:.*agi_node\\.agi_dispatcher\\.(pre_install|post_install|build).*found in sys\\.modules.*:RuntimeWarning",
+  "ignore:Trying to unpickle estimator .* from version 1\\.4\\.1\\.post1 when using version .*:Warning:sklearn\\.base",
+  "ignore:numpy\\.core\\.numeric is deprecated.*:DeprecationWarning:agi_cluster\\.agi_distributor\\.runtime\\.runtime_misc_support",
+  "ignore:__package__ != __spec__\\.parent:DeprecationWarning",
 ]
 
 addopts = [

--- a/test/test_agilab_dev_shortcuts.py
+++ b/test/test_agilab_dev_shortcuts.py
@@ -316,6 +316,20 @@ def test_maintenance_shortcut_has_maintain_alias():
     ]
 
 
+def test_warnings_shortcut_runs_validation_warning_report():
+    assert agilab_dev.planned_commands(["warnings", "--strict"]) == [
+        [
+            "uv",
+            "--preview-features",
+            "extra-build-dependencies",
+            "run",
+            "python",
+            "tools/validation_warning_report.py",
+            "--strict",
+        ]
+    ]
+
+
 def test_memory_shortcut_runs_maintenance_memory():
     assert agilab_dev.planned_commands(["memory", "check", "--all"]) == [
         [

--- a/test/test_builtin_app_tests.py
+++ b/test/test_builtin_app_tests.py
@@ -31,7 +31,7 @@ def test_discover_builtin_app_tests_returns_sorted_projects_with_tests(tmp_path)
 def test_build_pytest_command_uses_app_local_project_and_importlib_mode():
     command = builtin_app_tests.build_pytest_command()
 
-    assert command[:8] == [
+    assert command[:10] == [
         "uv",
         "--preview-features",
         "extra-build-dependencies",
@@ -40,6 +40,8 @@ def test_build_pytest_command_uses_app_local_project_and_importlib_mode():
         ".",
         "--with",
         "pytest",
+        "--with",
+        "pytest-asyncio",
     ]
     assert "--import-mode=importlib" in command
     assert command[-1] == "test"

--- a/test/test_ci_workflow.py
+++ b/test/test_ci_workflow.py
@@ -242,13 +242,24 @@ def test_windows_core_tests_workflow_matches_failure_tracker_command() -> None:
     assert 'branches: ["main"]' in text
     assert 'branches: ["**"]' in text
     assert "--import-mode=importlib" in text
+    assert "--disable-warnings" not in text
+    assert "Audit Windows warning output" in text
+    assert "tools/validation_warning_report.py" in text
+    assert "--strict" in text
     assert "src/agilab/core/test src/agilab/core/agi-env/test src/agilab/core/agi-cluster/test" in text
     assert "test-results/windows-core-tests.txt" in text
     assert "test-results/windows-core-tests.xml" in text
+    assert "test-results/windows-core-warning-report.json" in text
     assert "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2" in text
     assert "actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6" in text
     assert "astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0" in text
     assert "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7" in text
+
+
+def test_clean_public_install_avoids_stale_pip_cache_warnings() -> None:
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    assert "python -m pip install --upgrade pip --no-cache-dir" in text
 
 
 def test_docs_workflows_block_stale_release_proof_github_runs() -> None:

--- a/test/test_coverage_workflow.py
+++ b/test/test_coverage_workflow.py
@@ -426,6 +426,24 @@ def test_codecov_uploads_are_blocking_coverage_publication_gates() -> None:
         assert "fail_ci_if_error: true" in block
 
 
+def test_repo_wide_codecov_file_list_has_no_whitespace_tokens() -> None:
+    block = _step_block("Upload repo-wide agilab coverage to Codecov")
+    match = re.search(r"\n          files: (?P<files>\S+)\n", block)
+
+    assert match is not None
+    files = match.group("files")
+    expected_files = [
+        "./merged-coverage/coverage-agi-env.xml",
+        "./merged-coverage/coverage-agi-node.xml",
+        "./merged-coverage/coverage-agi-cluster.xml",
+        "./merged-coverage/coverage-agi-gui.xml",
+        "./merged-coverage/coverage-agi-web.xml",
+    ]
+
+    assert files.split(",") == expected_files
+    assert all(token == token.strip() for token in files.split(","))
+
+
 def test_codecov_uploads_import_verification_key_before_blocking_upload() -> None:
     workflow_text = _workflow_text()
     upload_steps = [

--- a/test/test_first_launch_robot.py
+++ b/test/test_first_launch_robot.py
@@ -113,6 +113,23 @@ def test_first_launch_robot_helpers_cover_empty_values_and_docs_import_failure(
     assert module.sys.path[0] == src_root
 
 
+def test_first_launch_robot_suppresses_streamlit_bare_mode_context_logger() -> None:
+    module = _load_module()
+    logger = module.logging.getLogger(module.STREAMLIT_BARE_MODE_LOGGER)
+    previous_level = logger.level
+    try:
+        logger.disabled = False
+        logger.setLevel(module.logging.NOTSET)
+
+        module._suppress_streamlit_bare_mode_log_warning()
+
+        assert logger.level == module.logging.ERROR
+        assert logger.disabled is True
+    finally:
+        logger.disabled = False
+        logger.setLevel(previous_level)
+
+
 def test_first_launch_robot_marks_env_missing_when_session_state_probe_fails(
     monkeypatch,
 ) -> None:

--- a/test/test_validation_warning_report.py
+++ b/test/test_validation_warning_report.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import importlib.util
+import os
 from pathlib import Path
 import sys
+from datetime import datetime, timedelta, timezone
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -44,6 +46,42 @@ def test_warning_report_summarizes_log_warning_and_pytest_warning_count(tmp_path
     assert not any(
         "--disable-warnings" in warning["message"] for warning in report["warnings"]
     )
+
+
+def test_warning_report_does_not_treat_warning_word_in_branch_name_as_warning(tmp_path):
+    log_path = tmp_path / "validation.log"
+    log_path.write_text(
+        "- /repo: codex/validation-warning-cleanup 3819307\n",
+        encoding="utf-8",
+    )
+
+    report = validation_warning_report.build_report((tmp_path,))
+
+    assert report["status"] == "pass"
+    assert report["summary"]["warning_count"] == 0
+
+
+def test_warning_report_can_scan_only_files_newer_than_marker(tmp_path):
+    old_log = tmp_path / "old.log"
+    marker = tmp_path / "start.marker"
+    new_log = tmp_path / "new.log"
+    old_log.write_text("WARNING stale warning\n", encoding="utf-8")
+    marker.write_text("start\n", encoding="utf-8")
+    new_log.write_text("all good\n", encoding="utf-8")
+    old_time = datetime.now(timezone.utc) - timedelta(hours=2)
+    marker_time = datetime.now(timezone.utc) - timedelta(hours=1)
+    new_time = datetime.now(timezone.utc)
+    os.utime(old_log, (old_time.timestamp(), old_time.timestamp()))
+    os.utime(marker, (marker_time.timestamp(), marker_time.timestamp()))
+    os.utime(new_log, (new_time.timestamp(), new_time.timestamp()))
+
+    report = validation_warning_report.build_report(
+        (tmp_path,), newer_than=validation_warning_report._parse_newer_than(str(marker))
+    )
+
+    assert report["status"] == "pass"
+    assert report["summary"]["file_count"] == 1
+    assert report["summary"]["warning_count"] == 0
 
 
 def test_warning_report_allowlist_approves_matching_warning(tmp_path):

--- a/test/test_validation_warning_report.py
+++ b/test/test_validation_warning_report.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "tools" / "validation_warning_report.py"
+
+spec = importlib.util.spec_from_file_location("validation_warning_report", MODULE_PATH)
+assert spec is not None and spec.loader is not None
+validation_warning_report = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = validation_warning_report
+spec.loader.exec_module(validation_warning_report)
+
+
+def test_warning_report_summarizes_log_warning_and_pytest_warning_count(tmp_path):
+    log_path = tmp_path / "validation.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                "python -m pytest --disable-warnings",
+                (
+                    "local-only-policy\tValidate first-launch robot\t"
+                    "2026-06-17T11:03:28Z WARNING streamlit.runtime: "
+                    "missing ScriptRunContext"
+                ),
+                "1904 passed, 9 skipped, 65 warnings in 167.51s (0:02:47)",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    report = validation_warning_report.build_report((tmp_path,))
+
+    assert report["status"] == "warn"
+    assert report["summary"]["warning_count"] == 66
+    assert report["summary"]["unique_warning_count"] == 2
+    assert {warning["category"] for warning in report["warnings"]} == {
+        "log-warning",
+        "pytest-warning-summary",
+    }
+    assert not any(
+        "--disable-warnings" in warning["message"] for warning in report["warnings"]
+    )
+
+
+def test_warning_report_allowlist_approves_matching_warning(tmp_path):
+    log_path = tmp_path / "validation.log"
+    log_path.write_text("WARNING streamlit.runtime: missing ScriptRunContext\n", encoding="utf-8")
+    allowlist_path = tmp_path / "warning_allowlist.toml"
+    allowlist_path.write_text(
+        """
+[[warnings]]
+id = "streamlit-bare-mode"
+category = "log-warning"
+message = "missing ScriptRunContext"
+source = "validation[.]log"
+owner = "agilab"
+expires = "2099-12-31"
+reason = "Streamlit bare-mode validation emits this warning outside a script context."
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    report = validation_warning_report.build_report(
+        (tmp_path,), allowlist_path=allowlist_path
+    )
+
+    assert report["status"] == "pass"
+    assert report["summary"]["warning_count"] == 1
+    assert report["summary"]["approved_warning_count"] == 1
+    assert report["summary"]["unapproved_warning_count"] == 0
+    assert report["warnings"][0]["allowlist_id"] == "streamlit-bare-mode"
+
+
+def test_warning_report_expired_allowlist_rule_does_not_approve(tmp_path):
+    log_path = tmp_path / "validation.log"
+    log_path.write_text("WARNING old warning\n", encoding="utf-8")
+    allowlist_path = tmp_path / "warning_allowlist.toml"
+    allowlist_path.write_text(
+        """
+[[warnings]]
+id = "expired-warning"
+category = "log-warning"
+message = "old warning"
+expires = "2000-01-01"
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    report = validation_warning_report.build_report(
+        (tmp_path,), allowlist_path=allowlist_path
+    )
+
+    assert report["status"] == "warn"
+    assert report["summary"]["unapproved_warning_count"] == 1
+    assert report["summary"]["expired_allowlist_rule_count"] == 1
+    assert report["expired_allowlist_rules"] == ["expired-warning"]
+
+
+def test_warning_report_extracts_browser_warning_artifacts(tmp_path):
+    artifact_path = tmp_path / "robot.json"
+    artifact_path.write_text(
+        """
+{
+  "success": true,
+  "pages": [
+    {
+      "page": "ORCHESTRATE",
+      "browser_issues": [
+        {
+          "kind": "console.warning",
+          "detail": "console.warn('slow paint')"
+        }
+      ]
+    }
+  ]
+}
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    report = validation_warning_report.build_report((artifact_path,))
+
+    assert report["summary"]["warning_count"] == 1
+    assert report["warnings"][0]["category"] == "browser-warning"
+    assert "slow paint" in report["warnings"][0]["message"]
+
+
+def test_warning_report_strict_mode_fails_on_unapproved_warning(tmp_path, capsys):
+    log_path = tmp_path / "validation.log"
+    log_path.write_text("WARNING unapproved\n", encoding="utf-8")
+
+    exit_code = validation_warning_report.main([str(log_path), "--strict"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "unapproved=1" in captured.out
+
+
+def test_warning_report_strict_mode_passes_without_warnings(tmp_path):
+    log_path = tmp_path / "validation.log"
+    log_path.write_text("all good\n", encoding="utf-8")
+
+    assert validation_warning_report.main([str(log_path), "--strict"]) == 0

--- a/tools/agilab_dev.py
+++ b/tools/agilab_dev.py
@@ -346,6 +346,9 @@ def planned_commands(argv: Sequence[str]) -> list[list[str]]:
     if command in {"maintenance", "maintain"}:
         return [_uv_python("tools/maintenance_dashboard.py", *args)]
 
+    if command in {"warnings", "warning-report"}:
+        return [_uv_python("tools/validation_warning_report.py", *args)]
+
     if command in {"memory", "maint-memory"}:
         return [_uv_python("tools/maintenance_memory.py", *args)]
 
@@ -528,6 +531,7 @@ def _usage() -> str:
   ./dev [--print-only] [--raw-output|--compact-output] [--summary-lines N] app-contracts [app_contract_matrix args]
   ./dev [--print-only] [--raw-output|--compact-output] [--summary-lines N] builtin-app-tests [builtin_app_tests args]
   ./dev [--print-only] [--raw-output|--compact-output] [--summary-lines N] maintenance [maintenance_dashboard args]
+  ./dev [--print-only] [--raw-output|--compact-output] [--summary-lines N] warnings [validation_warning_report args]
   ./dev [--print-only] [--raw-output|--compact-output] [--summary-lines N] memory [maintenance_memory args]
   ./dev [--print-only] [--raw-output|--compact-output] [--summary-lines N] audit [agilab_audit args]
   ./dev [--print-only] [--raw-output|--compact-output] [--summary-lines N] audit-quality [audit_quality_evaluator args|audit.md]
@@ -562,6 +566,7 @@ High-frequency mappings:
   app-contracts -> Check built-in app, PyPI package, app catalog, and public-doc alignment.
   builtin-app-tests -> Run built-in app tests inside each app's own uv project environment.
   maintenance -> Report extension contracts, ADRs, docs drift, app/package contracts, evidence docs, release friction, TODO hotspots, generated artifacts, and coverage signals.
+  warnings  -> Summarize warning signals from local validation logs and robot artifacts; pass --strict to fail on unapproved warnings.
   memory    -> Check path-scoped maintenance memory notes for source drift.
   audit     -> Audit local AGILAB worktrees, release proof, docs mirror, PyPI projects, and latest release truth.
   audit-quality -> Score a Markdown AGILAB audit, or print the deep-audit preflight when no file is provided.

--- a/tools/builtin_app_tests.py
+++ b/tools/builtin_app_tests.py
@@ -59,6 +59,8 @@ def build_pytest_command(pytest_args: Sequence[str] = ()) -> list[str]:
         ".",
         "--with",
         "pytest",
+        "--with",
+        "pytest-asyncio",
         "python",
         "-m",
         "pytest",

--- a/tools/first_launch_robot.py
+++ b/tools/first_launch_robot.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 from html import unescape
 import importlib.util
 import json
+import logging
 from pathlib import Path
 import platform
 import sys
@@ -24,6 +25,17 @@ DEFAULT_ACTIVE_APP = (
 DEFAULT_APPS_PATH = REPO_ROOT / "src" / "agilab" / "apps" / "builtin"
 SCHEMA = "agilab.first_launch_robot.v1"
 DEFAULT_TARGET_SECONDS = 45.0
+STREAMLIT_BARE_MODE_LOGGER = (
+    "streamlit.runtime.scriptrunner_utils.script_run_context"
+)
+
+
+def _suppress_streamlit_bare_mode_log_warning() -> None:
+    """Keep AppTest bare-mode context warnings out of validation logs."""
+
+    logger = logging.getLogger(STREAMLIT_BARE_MODE_LOGGER)
+    logger.setLevel(logging.ERROR)
+    logger.disabled = True
 
 
 def _check_result(
@@ -143,6 +155,7 @@ def build_report(
     timeout: float = DEFAULT_TARGET_SECONDS,
     target_seconds: float = DEFAULT_TARGET_SECONDS,
 ) -> dict[str, Any]:
+    _suppress_streamlit_bare_mode_log_warning()
     from streamlit.testing.v1 import AppTest
 
     start = time.perf_counter()

--- a/tools/validation_warning_report.py
+++ b/tools/validation_warning_report.py
@@ -1,0 +1,515 @@
+#!/usr/bin/env python3
+"""Summarize validation warnings from local AGILAB validation artifacts."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from hashlib import sha256
+import json
+from pathlib import Path
+import re
+import sys
+import tomllib
+from typing import Any, Iterable, Sequence
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_INPUTS = (REPO_ROOT / "reports" / "dev-logs",)
+SCHEMA = "agilab.validation_warning_report.v1"
+ANSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+TIMESTAMP_PREFIX_RE = re.compile(
+    r"\b\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z?\s+(?P<message>.*)"
+)
+PYTEST_WARNING_SUMMARY_RE = re.compile(r"\b(?P<count>\d+) warnings? in\b")
+WARNING_CLASS_RE = re.compile(
+    r"\b(?:PytestConfigWarning|PytestWarning|DeprecationWarning|"
+    r"FutureWarning|RuntimeWarning|ResourceWarning|UserWarning)\b"
+)
+WARNING_LINE_RE = re.compile(
+    r"(?i)(::warning|##\[warning\]|\bWARNING\b|\bwarning\s+-|\bwarning:)"
+)
+SUPPORTED_SUFFIXES = {".log", ".txt", ".out", ".err", ".json", ".ndjson"}
+
+
+@dataclass(frozen=True)
+class WarningOccurrence:
+    source: Path
+    line: int
+    category: str
+    message: str
+    raw: str
+    count: int = 1
+
+
+@dataclass(frozen=True)
+class WarningGroup:
+    warning_id: str
+    category: str
+    message: str
+    count: int
+    sources: tuple[str, ...]
+    examples: tuple[dict[str, Any], ...]
+    approved: bool
+    allowlist_id: str | None
+
+
+@dataclass(frozen=True)
+class AllowRule:
+    rule_id: str
+    fingerprint: str | None
+    category: str | None
+    message_pattern: re.Pattern[str] | None
+    source_pattern: re.Pattern[str] | None
+    owner: str | None
+    expires: date | None
+    reason: str | None
+
+    @property
+    def expired(self) -> bool:
+        return self.expires is not None and self.expires < date.today()
+
+    def matches(self, occurrence: WarningOccurrence, warning_id: str) -> bool:
+        if self.expired:
+            return False
+        if self.fingerprint and self.fingerprint != warning_id:
+            return False
+        if self.category and self.category != occurrence.category:
+            return False
+        if self.message_pattern and not self.message_pattern.search(
+            f"{occurrence.message}\n{occurrence.raw}"
+        ):
+            return False
+        if self.source_pattern and not self.source_pattern.search(
+            _display_path(occurrence.source)
+        ):
+            return False
+        return any(
+            (
+                self.fingerprint,
+                self.category,
+                self.message_pattern,
+                self.source_pattern,
+            )
+        )
+
+
+def _display_path(path: Path) -> str:
+    try:
+        return path.resolve().relative_to(REPO_ROOT).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _strip_ansi(text: str) -> str:
+    return ANSI_RE.sub("", text)
+
+
+def _extract_message(line: str) -> str:
+    message = _strip_ansi(line).strip()
+    if "\t" in message:
+        message = message.split("\t")[-1].strip()
+    timestamp_match = TIMESTAMP_PREFIX_RE.search(message)
+    if timestamp_match:
+        message = timestamp_match.group("message").strip()
+    return re.sub(r"\s+", " ", message)
+
+
+def _normalize_message(message: str) -> str:
+    normalized = re.sub(r"\s+", " ", message.strip())
+    normalized = re.sub(r"\b0x[0-9a-fA-F]+\b", "0x...", normalized)
+    normalized = re.sub(r"\b\d{4}-\d{2}-\d{2}T[^\s]+\b", "<timestamp>", normalized)
+    return normalized
+
+
+def _warning_id(category: str, message: str) -> str:
+    payload = f"{category}\0{_normalize_message(message)}"
+    return sha256(payload.encode("utf-8", "replace")).hexdigest()[:16]
+
+
+def _classify_line(path: Path, line_number: int, line: str) -> WarningOccurrence | None:
+    message = _extract_message(line)
+    if not message:
+        return None
+
+    pytest_summary = PYTEST_WARNING_SUMMARY_RE.search(message)
+    if pytest_summary:
+        count = int(pytest_summary.group("count"))
+        return WarningOccurrence(
+            source=path,
+            line=line_number,
+            category="pytest-warning-summary",
+            message=f"pytest reported {count} warnings",
+            raw=line.rstrip(),
+            count=count,
+        )
+
+    if WARNING_CLASS_RE.search(message):
+        return WarningOccurrence(
+            source=path,
+            line=line_number,
+            category="python-warning",
+            message=message,
+            raw=line.rstrip(),
+        )
+
+    if WARNING_LINE_RE.search(message):
+        return WarningOccurrence(
+            source=path,
+            line=line_number,
+            category="log-warning",
+            message=message,
+            raw=line.rstrip(),
+        )
+
+    return None
+
+
+def _browser_warning_from_issue(
+    path: Path, issue: Any, *, line_number: int
+) -> WarningOccurrence | None:
+    if not isinstance(issue, dict):
+        return None
+    kind = str(issue.get("kind") or issue.get("type") or "browser").strip()
+    detail = str(
+        issue.get("detail")
+        or issue.get("message")
+        or issue.get("text")
+        or issue.get("url")
+        or ""
+    ).strip()
+    payload = f"{kind}: {detail}".strip(": ")
+    lower = payload.lower()
+    if not payload or ("warn" not in lower and "warning" not in lower):
+        return None
+    return WarningOccurrence(
+        source=path,
+        line=line_number,
+        category="browser-warning",
+        message=payload,
+        raw=json.dumps(issue, sort_keys=True),
+    )
+
+
+def _walk_browser_issues(
+    path: Path, value: Any, *, line_number: int
+) -> Iterable[WarningOccurrence]:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if key in {"browser_issues", "browserIssues"} and isinstance(child, list):
+                for issue in child:
+                    warning = _browser_warning_from_issue(
+                        path, issue, line_number=line_number
+                    )
+                    if warning:
+                        yield warning
+            else:
+                yield from _walk_browser_issues(path, child, line_number=line_number)
+    elif isinstance(value, list):
+        for item in value:
+            yield from _walk_browser_issues(path, item, line_number=line_number)
+
+
+def _scan_text(path: Path) -> list[WarningOccurrence]:
+    warnings: list[WarningOccurrence] = []
+    for line_number, line in enumerate(
+        path.read_text(encoding="utf-8", errors="replace").splitlines(), start=1
+    ):
+        warning = _classify_line(path, line_number, line)
+        if warning:
+            warnings.append(warning)
+    return warnings
+
+
+def _scan_json(path: Path) -> list[WarningOccurrence]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8", errors="replace"))
+    except json.JSONDecodeError:
+        return _scan_text(path)
+    return list(_walk_browser_issues(path, payload, line_number=1))
+
+
+def _scan_ndjson(path: Path) -> list[WarningOccurrence]:
+    warnings: list[WarningOccurrence] = []
+    for line_number, line in enumerate(
+        path.read_text(encoding="utf-8", errors="replace").splitlines(), start=1
+    ):
+        if not line.strip():
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            warning = _classify_line(path, line_number, line)
+            if warning:
+                warnings.append(warning)
+            continue
+        warnings.extend(_walk_browser_issues(path, payload, line_number=line_number))
+    return warnings
+
+
+def _scan_file(path: Path) -> list[WarningOccurrence]:
+    if path.suffix == ".json":
+        return _scan_json(path)
+    if path.suffix == ".ndjson":
+        return _scan_ndjson(path)
+    return _scan_text(path)
+
+
+def _iter_input_files(paths: Sequence[Path]) -> list[Path]:
+    files: list[Path] = []
+    for path in paths:
+        if not path.exists():
+            continue
+        if path.is_file():
+            if path.suffix in SUPPORTED_SUFFIXES:
+                files.append(path)
+            continue
+        for candidate in sorted(path.rglob("*")):
+            if candidate.is_file() and candidate.suffix in SUPPORTED_SUFFIXES:
+                files.append(candidate)
+    return sorted(files)
+
+
+def _compile_regex(value: object, *, field: str, rule_id: str) -> re.Pattern[str] | None:
+    if value in (None, ""):
+        return None
+    if not isinstance(value, str):
+        raise ValueError(f"warning allowlist rule {rule_id}: {field} must be a string")
+    try:
+        return re.compile(value)
+    except re.error as exc:
+        raise ValueError(
+            f"warning allowlist rule {rule_id}: invalid {field} regex: {exc}"
+        ) from exc
+
+
+def _parse_expiry(value: object, *, rule_id: str) -> date | None:
+    if value in (None, ""):
+        return None
+    if isinstance(value, date) and not isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        try:
+            return date.fromisoformat(value)
+        except ValueError as exc:
+            raise ValueError(
+                f"warning allowlist rule {rule_id}: expires must be YYYY-MM-DD"
+            ) from exc
+    raise ValueError(f"warning allowlist rule {rule_id}: expires must be a date")
+
+
+def load_allowlist(path: Path | None) -> list[AllowRule]:
+    if path is None or not path.exists():
+        return []
+    payload = tomllib.loads(path.read_text(encoding="utf-8"))
+    raw_rules = payload.get("warnings") or payload.get("allow") or payload.get("rules") or []
+    if not isinstance(raw_rules, list):
+        raise ValueError("warning allowlist must contain a list named warnings, allow, or rules")
+
+    rules: list[AllowRule] = []
+    for index, item in enumerate(raw_rules, start=1):
+        if not isinstance(item, dict):
+            raise ValueError(f"warning allowlist rule {index}: rule must be a table")
+        rule_id = str(item.get("id") or f"rule-{index}")
+        owner = item.get("owner")
+        reason = item.get("reason")
+        rules.append(
+            AllowRule(
+                rule_id=rule_id,
+                fingerprint=str(item["fingerprint"])
+                if item.get("fingerprint") not in (None, "")
+                else None,
+                category=str(item["category"])
+                if item.get("category") not in (None, "")
+                else None,
+                message_pattern=_compile_regex(
+                    item.get("message"), field="message", rule_id=rule_id
+                ),
+                source_pattern=_compile_regex(
+                    item.get("source"), field="source", rule_id=rule_id
+                ),
+                owner=str(owner) if owner not in (None, "") else None,
+                expires=_parse_expiry(item.get("expires"), rule_id=rule_id),
+                reason=str(reason) if reason not in (None, "") else None,
+            )
+        )
+    return rules
+
+
+def _allowance_for(
+    occurrence: WarningOccurrence, warning_id: str, rules: Sequence[AllowRule]
+) -> str | None:
+    for rule in rules:
+        if rule.matches(occurrence, warning_id):
+            return rule.rule_id
+    return None
+
+
+def build_report(
+    paths: Sequence[Path],
+    *,
+    allowlist_path: Path | None = None,
+    max_examples: int = 3,
+) -> dict[str, Any]:
+    files = _iter_input_files(paths)
+    rules = load_allowlist(allowlist_path)
+    occurrences = [warning for file in files for warning in _scan_file(file)]
+
+    grouped: dict[tuple[str, str], list[WarningOccurrence]] = {}
+    for occurrence in occurrences:
+        warning_id = _warning_id(occurrence.category, occurrence.message)
+        grouped.setdefault((warning_id, occurrence.category), []).append(occurrence)
+
+    warning_groups: list[WarningGroup] = []
+    for (warning_id, category), group_occurrences in sorted(grouped.items()):
+        first = group_occurrences[0]
+        allowlist_id = _allowance_for(first, warning_id, rules)
+        examples = tuple(
+            {
+                "source": _display_path(item.source),
+                "line": item.line,
+                "message": item.message,
+                "raw": item.raw,
+            }
+            for item in group_occurrences[:max_examples]
+        )
+        warning_groups.append(
+            WarningGroup(
+                warning_id=warning_id,
+                category=category,
+                message=first.message,
+                count=sum(item.count for item in group_occurrences),
+                sources=tuple(
+                    sorted({_display_path(item.source) for item in group_occurrences})
+                ),
+                examples=examples,
+                approved=allowlist_id is not None,
+                allowlist_id=allowlist_id,
+            )
+        )
+
+    approved_count = sum(group.count for group in warning_groups if group.approved)
+    total_count = sum(group.count for group in warning_groups)
+    unapproved_count = total_count - approved_count
+    expired_rules = [rule.rule_id for rule in rules if rule.expired]
+
+    return {
+        "schema": SCHEMA,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "paths": [_display_path(path) for path in paths],
+        "allowlist": _display_path(allowlist_path) if allowlist_path else None,
+        "status": "pass" if unapproved_count == 0 else "warn",
+        "summary": {
+            "file_count": len(files),
+            "warning_count": total_count,
+            "unique_warning_count": len(warning_groups),
+            "approved_warning_count": approved_count,
+            "unapproved_warning_count": unapproved_count,
+            "expired_allowlist_rule_count": len(expired_rules),
+        },
+        "expired_allowlist_rules": expired_rules,
+        "warnings": [
+            {
+                "id": group.warning_id,
+                "category": group.category,
+                "message": group.message,
+                "count": group.count,
+                "sources": list(group.sources),
+                "approved": group.approved,
+                "allowlist_id": group.allowlist_id,
+                "examples": list(group.examples),
+            }
+            for group in warning_groups
+        ],
+    }
+
+
+def _render_text(report: dict[str, Any]) -> str:
+    summary = report["summary"]
+    lines = [
+        (
+            "validation warnings: "
+            f"status={report['status']} "
+            f"warnings={summary['warning_count']} "
+            f"unique={summary['unique_warning_count']} "
+            f"unapproved={summary['unapproved_warning_count']} "
+            f"files={summary['file_count']}"
+        )
+    ]
+    if report["expired_allowlist_rules"]:
+        lines.append(
+            "expired allowlist rules: " + ", ".join(report["expired_allowlist_rules"])
+        )
+    for warning in report["warnings"][:20]:
+        approval = (
+            f"approved:{warning['allowlist_id']}"
+            if warning["approved"]
+            else "unapproved"
+        )
+        lines.append(
+            f"- {warning['category']} {warning['id']} count={warning['count']} "
+            f"{approval}: {warning['message']}"
+        )
+        if warning["sources"]:
+            lines.append(f"  source: {warning['sources'][0]}")
+    return "\n".join(lines)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        help="Validation log or robot artifact files/directories to scan. Defaults to reports/dev-logs.",
+    )
+    parser.add_argument(
+        "--allowlist",
+        type=Path,
+        help="Optional TOML allowlist with [[warnings]] rules.",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit non-zero when unapproved warnings are present.",
+    )
+    parser.add_argument("--json", action="store_true", help="Print JSON report.")
+    parser.add_argument("--output", type=Path, help="Write the JSON report to a file.")
+    parser.add_argument(
+        "--max-examples",
+        type=int,
+        default=3,
+        help="Maximum examples retained per warning group.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    paths = tuple(Path(item) for item in args.paths) or DEFAULT_INPUTS
+    try:
+        report = build_report(
+            paths,
+            allowlist_path=args.allowlist,
+            max_examples=max(args.max_examples, 0),
+        )
+    except (OSError, ValueError) as exc:
+        print(f"validation warning report failed: {exc}", file=sys.stderr)
+        return 2
+
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        print(_render_text(report))
+
+    if args.strict and report["summary"]["unapproved_warning_count"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validation_warning_report.py
+++ b/tools/validation_warning_report.py
@@ -28,7 +28,7 @@ WARNING_CLASS_RE = re.compile(
     r"FutureWarning|RuntimeWarning|ResourceWarning|UserWarning)\b"
 )
 WARNING_LINE_RE = re.compile(
-    r"(?i)(::warning|##\[warning\]|\bWARNING\b|\bwarning\s+-|\bwarning:)"
+    r"(::warning|##\[warning\]|\bWARNING\b|(?i:\bwarning\s+-|\bwarning:))"
 )
 SUPPORTED_SUFFIXES = {".log", ".txt", ".out", ".err", ".json", ".ndjson"}
 
@@ -256,19 +256,51 @@ def _scan_file(path: Path) -> list[WarningOccurrence]:
     return _scan_text(path)
 
 
-def _iter_input_files(paths: Sequence[Path]) -> list[Path]:
+def _is_new_enough(path: Path, newer_than: datetime | None) -> bool:
+    if newer_than is None:
+        return True
+    mtime = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
+    return mtime >= newer_than
+
+
+def _iter_input_files(
+    paths: Sequence[Path], *, newer_than: datetime | None = None
+) -> list[Path]:
     files: list[Path] = []
     for path in paths:
         if not path.exists():
             continue
         if path.is_file():
-            if path.suffix in SUPPORTED_SUFFIXES:
+            if path.suffix in SUPPORTED_SUFFIXES and _is_new_enough(
+                path, newer_than
+            ):
                 files.append(path)
             continue
         for candidate in sorted(path.rglob("*")):
-            if candidate.is_file() and candidate.suffix in SUPPORTED_SUFFIXES:
+            if (
+                candidate.is_file()
+                and candidate.suffix in SUPPORTED_SUFFIXES
+                and _is_new_enough(candidate, newer_than)
+            ):
                 files.append(candidate)
     return sorted(files)
+
+
+def _parse_newer_than(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    marker = Path(value)
+    if marker.exists():
+        return datetime.fromtimestamp(marker.stat().st_mtime, tz=timezone.utc)
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(
+            "--newer-than must be an existing marker path or an ISO-8601 timestamp"
+        ) from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
 
 
 def _compile_regex(value: object, *, field: str, rule_id: str) -> re.Pattern[str] | None:
@@ -351,8 +383,9 @@ def build_report(
     *,
     allowlist_path: Path | None = None,
     max_examples: int = 3,
+    newer_than: datetime | None = None,
 ) -> dict[str, Any]:
-    files = _iter_input_files(paths)
+    files = _iter_input_files(paths, newer_than=newer_than)
     rules = load_allowlist(allowlist_path)
     occurrences = [warning for file in files for warning in _scan_file(file)]
 
@@ -399,6 +432,7 @@ def build_report(
         "generated_at": datetime.now(timezone.utc).isoformat(),
         "paths": [_display_path(path) for path in paths],
         "allowlist": _display_path(allowlist_path) if allowlist_path else None,
+        "newer_than": newer_than.isoformat() if newer_than else None,
         "status": "pass" if unapproved_count == 0 else "warn",
         "summary": {
             "file_count": len(files),
@@ -481,6 +515,13 @@ def _parser() -> argparse.ArgumentParser:
         default=3,
         help="Maximum examples retained per warning group.",
     )
+    parser.add_argument(
+        "--newer-than",
+        help=(
+            "Only scan files modified at or after this existing marker file's mtime "
+            "or ISO-8601 timestamp."
+        ),
+    )
     return parser
 
 
@@ -492,6 +533,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             paths,
             allowlist_path=args.allowlist,
             max_examples=max(args.max_examples, 0),
+            newer_than=_parse_newer_than(args.newer_than),
         )
     except (OSError, ValueError) as exc:
         print(f"validation warning report failed: {exc}", file=sys.stderr)


### PR DESCRIPTION
## Summary

- Normalize the repo-wide Codecov upload file list so Codecov does not treat folded YAML spaces as part of coverage XML filenames.
- Install `pytest-asyncio` in the built-in app test runner's app-local pytest command so root `asyncio_mode` config is recognized during isolated app validation.
- Add `tools/validation_warning_report.py` and `./dev warnings` to summarize warning signals from validation logs and browser robot artifacts, with optional TOML allowlist, `--strict` failure mode, and `--newer-than` marker scoping for current validation batches.
- Gate the Windows core workflow with an explicit warning-report audit, stop hiding Windows pytest warning details, and upload the warning report artifact.
- Clean known validation warning noise: target the reproduced legacy fixture/test-mechanics warnings, suppress Streamlit AppTest bare-mode logger noise in the first-launch robot, and avoid stale pip cache warning output during clean public install.
- Add focused regressions for Codecov file-list handling, built-in app test command construction, warning report behavior, Windows warning gating, first-launch logger suppression, and clean-install pip cache handling.

## Root Cause

The post-merge warning audit found one actionable workflow warning: the repo-wide Codecov upload reported missing coverage XML files because the folded comma list introduced whitespace after delimiters. The app-local execution pandas warning was a validation-environment issue: the runner installed `pytest` but not the plugin that owns `asyncio_mode`.

Follow-up validation showed the Windows core workflow was still reporting `65 warnings` while `--disable-warnings` hid the details. A local unsuppressed reproduction classified them as known test mechanics and legacy fixture-load warnings. The warning scanner also needed batch scoping and a tighter regex so stale dev logs and branch names containing `warning` do not pollute current warning evidence.

## Validation

- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_coverage_workflow.py test/test_builtin_app_tests.py`
- `UV_PROJECT_ENVIRONMENT=/tmp/agilab-built-in-app-warning-cleanup-venv uv --preview-features extra-build-dependencies run python tools/builtin_app_tests.py --app execution_pandas_project -- -q -o addopts='' -ra test`
- `uv --preview-features extra-build-dependencies run --with pytest python -m pytest -q -o addopts='' test/test_security_hygiene_report.py test/test_github_actions_node_runtime.py`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_ci_workflow.py test/test_coverage_workflow.py test/test_pyproject_dependency_hygiene.py test/test_agilab_dev_shortcuts.py test/test_builtin_app_tests.py test/test_first_launch_robot.py test/test_validation_warning_report.py`
- `uv --preview-features extra-build-dependencies run --no-project --with-editable ./src/agilab/core/agi-env --with-editable ./src/agilab/core/agi-node --with-editable ./src/agilab/core/agi-cluster --with-editable ./src/agilab/core/agi-core --with sqlalchemy --with streamlit --with fastparquet --with pytest --with pytest-asyncio --with pytest-cov python -m pytest -q -o addopts='' --import-mode=importlib --junitxml test-results/windows-core-tests-local.xml src/agilab/core/test src/agilab/core/agi-env/test src/agilab/core/agi-cluster/test`
- `uv --preview-features extra-build-dependencies run --no-project python tools/validation_warning_report.py test-results/windows-core-tests-local.txt --strict --output test-results/windows-core-warning-report-local.json`
- Docker/Linux parity on `ghcr.io/astral-sh/uv:python3.13-bookworm-slim`: focused pytest slice and Ruff passed.
- `./dev warnings --strict --newer-than test-results/final-warning-audit-start.marker --json --output test-results/final-current-warning-report.json`
- `uv --preview-features extra-build-dependencies run --extra dev ruff check tools/validation_warning_report.py tools/first_launch_robot.py tools/agilab_dev.py tools/builtin_app_tests.py test/test_validation_warning_report.py test/test_ci_workflow.py test/test_first_launch_robot.py test/test_coverage_workflow.py test/test_agilab_dev_shortcuts.py test/test_builtin_app_tests.py`
- `python3 tools/agent_instruction_contract.py --check`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files $(git diff --name-only origin/main...HEAD) $(git diff --name-only)`
- `./dev scope --staged`
- `git diff --check`
