### PR TITLE
Fix remote cluster share mode propagation

### DIFF
--- a/src/agilab/cluster/cluster_flight_validation.py
+++ b/src/agilab/cluster/cluster_flight_validation.py
@@ -567,6 +567,26 @@ def _validate_distinct_cluster_share(plan: ValidationPlan, *, home: Path | None 
         )
 
 
+def _reverse_sshfs_mount_problem(local_share: Path, worker_ip: str) -> str | None:
+    from agi_cluster.agi_distributor.deployment.deployment_remote_support import (
+        _reverse_sshfs_mount_problem as detect_reverse_sshfs_mount,
+    )
+
+    return detect_reverse_sshfs_mount(local_share, worker_ip)
+
+
+def _validate_scheduler_cluster_share_not_reverse_mounted(
+    plan: ValidationPlan,
+    *,
+    home: Path | None = None,
+) -> None:
+    cluster_root = local_cluster_share_root(plan, home=home)
+    for spec in remote_worker_specs(plan):
+        problem = _reverse_sshfs_mount_problem(cluster_root, spec.host)
+        if problem:
+            raise RuntimeError(problem)
+
+
 def write_cluster_share_sentinel(
     plan: ValidationPlan,
     *,
@@ -574,6 +594,7 @@ def write_cluster_share_sentinel(
     token: str | None = None,
 ) -> tuple[Path, str]:
     _validate_distinct_cluster_share(plan, home=home)
+    _validate_scheduler_cluster_share_not_reverse_mounted(plan, home=home)
     cluster_root = local_cluster_share_root(plan, home=home)
     marker_dir = cluster_root / SHARE_SENTINEL_DIR
     marker_dir.mkdir(parents=True, exist_ok=True)
@@ -738,16 +759,23 @@ def _remote_env_update_script(plan: ValidationPlan) -> str:
     return "\n".join(
         [
             "from pathlib import Path",
-            "key = 'AGI_CLUSTER_SHARE'",
-            f"value = {json.dumps(plan.remote_cluster_share_setting)}",
+            "updates = (",
+            "    ('IS_SOURCE_ENV', '0'),",
+            "    ('IS_WORKER_ENV', '1'),",
+            "    ('AGI_CLUSTER_ENABLED', '1'),",
+            f"    ('AGI_CLUSTER_SHARE', {json.dumps(plan.remote_cluster_share_setting)}),",
+            ")",
+            "update_keys = {key for key, _value in updates}",
             "env_path = Path.home() / '.agilab' / '.env'",
             "env_path.parent.mkdir(parents=True, exist_ok=True)",
             "lines = []",
             "if env_path.exists():",
             "    for raw_line in env_path.read_text(encoding='utf-8').splitlines():",
-            "        if not raw_line.strip().startswith(key + '='):",
+            "        key = raw_line.split('=', 1)[0].strip()",
+            "        if key not in update_keys:",
             "            lines.append(raw_line)",
-            "lines.append(f'{key}={value!r}')",
+            "for key, value in updates:",
+            "    lines.append(f'{key}={value!r}')",
             "env_path.write_text('\\n'.join(lines) + '\\n', encoding='utf-8')",
             "print(str(env_path))",
         ]
@@ -903,6 +931,7 @@ def apply_share_setup(
         raise ValueError(f"unsupported share setup backend: {backend}")
 
     _validate_distinct_cluster_share(plan)
+    _validate_scheduler_cluster_share_not_reverse_mounted(plan)
     local_root = local_cluster_share_root(plan)
     local_root.mkdir(parents=True, exist_ok=True)
     summaries = [
@@ -1025,6 +1054,7 @@ def local_output_candidates(plan: ValidationPlan, *, home: Path | None = None) -
 
 
 def collect_local_outputs(plan: ValidationPlan, *, home: Path | None = None) -> tuple[OutputSummary, ...]:
+    _validate_scheduler_cluster_share_not_reverse_mounted(plan, home=home)
     return tuple(
         _summarize_output_dir(candidate, location="local")
         for candidate in local_output_candidates(plan, home=home)
@@ -1032,6 +1062,7 @@ def collect_local_outputs(plan: ValidationPlan, *, home: Path | None = None) -> 
 
 
 def clean_local_outputs(plan: ValidationPlan, *, home: Path | None = None) -> None:
+    _validate_scheduler_cluster_share_not_reverse_mounted(plan, home=home)
     for candidate in local_output_candidates(plan, home=home):
         shutil.rmtree(candidate, ignore_errors=True)
 
@@ -1191,6 +1222,22 @@ def _configure_process_env(plan: ValidationPlan) -> None:
         os.environ.pop("AGILAB_REMOTE_CLUSTER_SHARE_PREMOUNTED", None)
 
 
+def _configure_agi_env_for_cluster_validation(env: Any, plan: ValidationPlan) -> None:
+    if not isinstance(getattr(env, "envars", None), dict):
+        env.envars = {}
+    env.AGI_LOCAL_SHARE = plan.local_share_setting
+    env.AGI_CLUSTER_SHARE = plan.local_cluster_share_setting
+    env.agi_share_path = plan.local_cluster_share_setting
+    env.envars["AGI_CLUSTER_ENABLED"] = "1"
+    env.envars["AGI_LOCAL_SHARE"] = plan.local_share_setting
+    env.envars["AGI_CLUSTER_SHARE"] = plan.local_cluster_share_setting
+    try:
+        env._share_root_cache = None
+        env.agi_share_path_abs = env.share_root_path()
+    except AttributeError:
+        pass
+
+
 def _reset_agi_state(agi_cls: Any) -> None:
     for name, value in (
         ("_ssh_connections", {}),
@@ -1231,11 +1278,12 @@ async def run_cluster_validation(args: argparse.Namespace) -> dict[str, Any]:
     env.password = None
     env.scheduler_ssh_port = plan.scheduler_ssh_port
     env.remote_cluster_share_premounted = plan.remote_cluster_share_premounted
-    if not isinstance(getattr(env, "envars", None), dict):
-        env.envars = {}
+    _configure_agi_env_for_cluster_validation(env, plan)
     env.envars["AGILAB_SCHEDULER_SSH_PORT"] = str(plan.scheduler_ssh_port)
     if plan.remote_cluster_share_premounted:
         env.envars["AGILAB_REMOTE_CLUSTER_SHARE_PREMOUNTED"] = "1"
+    else:
+        env.envars.pop("AGILAB_REMOTE_CLUSTER_SHARE_PREMOUNTED", None)
     if args.ssh_key:
         env.ssh_key_path = str(Path(args.ssh_key).expanduser())
 

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_remote_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_remote_support.py
@@ -360,14 +360,23 @@ def _scheduler_ssh_target(agi_cls: Any, env: Any) -> str:
 
 
 def _remote_env_update_command(remote_share: str) -> str:
-    # Update only the AGI_CLUSTER_SHARE line: the remote ~/.agilab/.env holds
-    # other operator-managed settings that must be preserved (merge semantics,
-    # matching install.sh/write_env_updates).
-    line = f"AGI_CLUSTER_SHARE={remote_share!r}"
+    # Update only worker cluster-mode lines: the remote ~/.agilab/.env holds other
+    # operator-managed settings that must be preserved (merge semantics,
+    # matching install.sh/write_env_updates).  Remote workers resolve relative
+    # app outputs through the active share mode, so the share path and cluster
+    # flag must be written together; Dask workers also need worker layout flags
+    # because AgiEnv reads those from the persisted .env file during startup.
+    source_line = "IS_SOURCE_ENV='0'"
+    worker_line = "IS_WORKER_ENV='1'"
+    enabled_line = "AGI_CLUSTER_ENABLED='1'"
+    share_line = f"AGI_CLUSTER_SHARE={remote_share!r}"
     return (
         'mkdir -p "$HOME/.agilab" && touch "$HOME/.agilab/.env" && '
-        "{ grep -v '^AGI_CLUSTER_SHARE=' \"$HOME/.agilab/.env\" || true; "
-        f"printf '%s\\n' {quote(line)}; }} > \"$HOME/.agilab/.env.tmp\" && "
+        "{ grep -Ev '^(IS_SOURCE_ENV|IS_WORKER_ENV|AGI_CLUSTER_ENABLED|AGI_CLUSTER_SHARE)=' "
+        "\"$HOME/.agilab/.env\" || true; "
+        f"printf '%s\\n' {quote(source_line)} {quote(worker_line)} "
+        f"{quote(enabled_line)} {quote(share_line)}; }} "
+        "> \"$HOME/.agilab/.env.tmp\" && "
         'mv "$HOME/.agilab/.env.tmp" "$HOME/.agilab/.env"'
     )
 

--- a/src/agilab/core/test/test_agi_distributor_deployment_remote_support.py
+++ b/src/agilab/core/test/test_agi_distributor_deployment_remote_support.py
@@ -1449,12 +1449,19 @@ async def test_deploy_remote_worker_rapids_runtime_error_is_logged(tmp_path):
 def test_remote_env_update_command_preserves_other_env_keys():
     # Regression: the command previously truncated the whole remote
     # ~/.agilab/.env with '>' redirection; it must merge instead, replacing
-    # only the AGI_CLUSTER_SHARE line.
+    # only the worker cluster-mode lines.
     cmd = deployment_remote_support._remote_env_update_command("clustershare")
 
-    assert "grep -v '^AGI_CLUSTER_SHARE='" in cmd
+    assert (
+        "grep -Ev '^(IS_SOURCE_ENV|IS_WORKER_ENV|AGI_CLUSTER_ENABLED|AGI_CLUSTER_SHARE)='"
+        in cmd
+    )
     assert 'mv "$HOME/.agilab/.env.tmp" "$HOME/.agilab/.env"' in cmd
+    assert "IS_SOURCE_ENV=" in cmd
+    assert "IS_WORKER_ENV=" in cmd
+    assert "AGI_CLUSTER_ENABLED=" in cmd
     assert "AGI_CLUSTER_SHARE=" in cmd
+    assert "AGI_LOCAL_SHARE" not in cmd
     # No direct truncating redirection of the env file itself.
     assert '> "$HOME/.agilab/.env"' not in cmd.replace(
         '> "$HOME/.agilab/.env.tmp"', ""

--- a/test/test_cluster_flight_validation.py
+++ b/test/test_cluster_flight_validation.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import subprocess
 import sys
 import types
@@ -21,7 +22,7 @@ loaded_path = str(getattr(loaded_agilab, "__file__", ""))
 if loaded_agilab is not None and not loaded_path.startswith(str(SRC_ROOT)):
     sys.modules.pop("agilab", None)
 
-from agilab import cluster_flight_validation as cfv
+from agilab import cluster_flight_validation as cfv  # noqa: E402
 
 
 def _args(**overrides):
@@ -270,6 +271,45 @@ def test_build_validation_plan_reads_env_files_and_serializes_paths(tmp_path: Pa
     assert plan.to_dict()["local_dataset_dir"].endswith("share-in-env/flight_cluster_validation/dataset/csv")
 
 
+def test_remote_env_update_script_enables_cluster_mode_without_clobbering_env(tmp_path: Path):
+    env_path = tmp_path / ".agilab" / ".env"
+    env_path.parent.mkdir()
+    env_path.write_text(
+        "KEEP_ME=1\n"
+        "IS_SOURCE_ENV=1\n"
+        "IS_WORKER_ENV=0\n"
+        "AGI_CLUSTER_ENABLED=0\n"
+        "AGI_LOCAL_SHARE=localshare\n"
+        "AGI_CLUSTER_SHARE='oldshare'\n",
+        encoding="utf-8",
+    )
+    plan = cfv.build_validation_plan(
+        _args(workers="jpm@192.168.3.35", remote_cluster_share="clustershare/worker"),
+        home=tmp_path,
+        environ={"USER": "agi"},
+    )
+
+    subprocess.run(
+        [sys.executable, "-c", cfv._remote_env_update_script(plan)],
+        check=True,
+        env={**os.environ, "HOME": str(tmp_path)},
+        text=True,
+        capture_output=True,
+    )
+
+    lines = env_path.read_text(encoding="utf-8").splitlines()
+    assert "KEEP_ME=1" in lines
+    assert "AGI_LOCAL_SHARE=localshare" in lines
+    assert "IS_SOURCE_ENV='0'" in lines
+    assert "IS_WORKER_ENV='1'" in lines
+    assert "AGI_CLUSTER_ENABLED='1'" in lines
+    assert "AGI_CLUSTER_SHARE='clustershare/worker'" in lines
+    assert "IS_SOURCE_ENV=1" not in lines
+    assert "IS_WORKER_ENV=0" not in lines
+    assert "AGI_CLUSTER_ENABLED=0" not in lines
+    assert "AGI_CLUSTER_SHARE='oldshare'" not in lines
+
+
 def test_build_validation_plan_rejects_absolute_relative_arguments(tmp_path: Path):
     with pytest.raises(ValueError, match="--dataset-rel must be relative"):
         cfv.build_validation_plan(
@@ -498,6 +538,36 @@ def test_cluster_share_sentinel_rejects_local_share_alias(tmp_path: Path):
 
     with pytest.raises(ValueError, match="must be distinct"):
         cfv.write_cluster_share_sentinel(plan, home=tmp_path, token="fixed")
+
+
+def test_scheduler_cluster_share_rejects_reverse_worker_mount_before_io(
+    tmp_path: Path,
+    monkeypatch,
+):
+    cluster_share = tmp_path / "shared"
+    plan = cfv.build_validation_plan(
+        _args(cluster_share=str(cluster_share), workers="jpm@192.168.3.35"),
+        home=tmp_path,
+        environ={"USER": "agi"},
+    )
+    checked: list[tuple[Path, str]] = []
+
+    def fake_reverse_mount_problem(local_share: Path, worker_ip: str) -> str:
+        checked.append((local_share, worker_ip))
+        return "SSHFS loop detected"
+
+    monkeypatch.setattr(cfv, "_reverse_sshfs_mount_problem", fake_reverse_mount_problem)
+
+    with pytest.raises(RuntimeError, match="SSHFS loop"):
+        cfv.write_cluster_share_sentinel(plan, home=tmp_path, token="fixed")
+    with pytest.raises(RuntimeError, match="SSHFS loop"):
+        cfv.apply_share_setup(plan, "sshfs", timeout=1)
+
+    assert checked == [
+        (cluster_share, "192.168.3.35"),
+        (cluster_share, "192.168.3.35"),
+    ]
+    assert not cluster_share.exists()
 
 
 def test_validate_shared_cluster_share_probes_remote_sentinel(tmp_path: Path, monkeypatch):
@@ -1226,6 +1296,7 @@ def test_run_cluster_validation_with_mocked_agi_success(tmp_path: Path, monkeypa
             _args(
                 scheduler="127.0.0.1",
                 workers="127.0.0.1",
+                cluster_share="cluster-root",
                 aircraft="60",
                 timeout=5,
                 verbose=2,
@@ -1240,5 +1311,11 @@ def test_run_cluster_validation_with_mocked_agi_success(tmp_path: Path, monkeypa
     assert FakeAgiEnv.reset_called is True
     assert FakeAGI._TIMEOUT == 5
     assert install_calls[0]["workers"] == {"127.0.0.1": 1}
+    install_env = install_calls[0]["env"]
+    assert install_env.AGI_LOCAL_SHARE == "localshare"
+    assert install_env.AGI_CLUSTER_SHARE == "cluster-root"
+    assert install_env.agi_share_path == "cluster-root"
+    assert install_env.envars["AGI_CLUSTER_ENABLED"] == "1"
+    assert install_env.envars["AGI_CLUSTER_SHARE"] == "cluster-root"
     assert run_requests[0].kwargs["mode"] == 4
     assert run_requests[0].kwargs["data_out"] == "flight_cluster_validation/dataframe_cluster_validation"


### PR DESCRIPTION
## Summary
- Propagate remote worker cluster-share mode as a complete worker runtime contract: `IS_SOURCE_ENV=0`, `IS_WORKER_ENV=1`, `AGI_CLUSTER_ENABLED=1`, and `AGI_CLUSTER_SHARE=<remote-share>`.
- Make the cluster flight validation doctor stamp the live `AgiEnv` object with the selected cluster share so `AGI.install()` and the doctor preflight use the same scheduler share.
- Add a fail-fast doctor guard for reverse SSHFS scheduler-share mounts before local share I/O.

## Validation
- `uv --preview-features extra-build-dependencies run ruff check ...`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_cluster_flight_validation.py src/agilab/core/test/test_agi_distributor_deployment_remote_support.py src/agilab/core/agi-env/test/test_agi_env.py src/agilab/core/agi-env/test/test_share_mount_support.py`
- `uv --preview-features extra-build-dependencies run --no-sync pytest -q -o addopts='' src/agilab/core/test`
- Fresh Linux clone on `192.168.20.15` at `388b4f1`: targeted regression slice passed.
- Live cluster validation from that clone with scheduler `192.168.20.15` and worker `192.168.20.141`: `success=True`, local and remote outputs both reported 16 parquet files and 1 reduce artifact.
