### PR TITLE
docs: clarify coverage truth in FAQ

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 276,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "9e9cc5f2e790a163a5ee0d3d2650268672d1bba0d6f93c7b33ab036ffabf8ec4",
+  "source_digest_sha256": "b0785552b71d4a0541ac13f29496ead7d67605aea65d30f97ee74fefcf55e94b",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "108a3e604e7b3e58eade4c18cbd5bb7bea2791f9498f9fb6207df39c0ea6b349"
+  "target_digest_sha256": "b0785552b71d4a0541ac13f29496ead7d67605aea65d30f97ee74fefcf55e94b"
 }

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -398,6 +398,20 @@ Use ``--components agi-web`` for the portable web-component contract badge.
 For the global badge, you also need the corresponding aggregate XML inputs
 before regenerating ``badges/coverage-agilab.svg``.
 
+How should I report a 100% coverage improvement?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Report the scope that actually reached 100%. AGILAB tracks component coverage
+separately for surfaces such as ``agi-env``, ``agi-node``, ``agi-cluster``,
+``agi-gui``, and ``agi-web`` before combining the XML artifacts into the global
+``agilab`` badge. A focused test change can make one component complete without
+making the aggregate badge complete.
+
+When a coverage change is ready to publish, keep the source tests, generated XML
+evidence, and badge refresh aligned. Do not edit badge SVGs by hand or describe
+local macOS coverage as release truth when the Ubuntu coverage workflow is the
+canonical badge source.
+
 Why can ``agi-gui`` be at 99% while global ``agilab`` coverage is lower?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
## Summary
- clarify how to report 100% coverage improvements in the public FAQ
- explain component-scoped coverage versus the global aggregate badge
- refresh the docs mirror stamp for the FAQ change

## Validation
- `git diff --check`
- `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --staged`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs`
