### PR TITLE
Fix workflow session auto-selection

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 276,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "b0785552b71d4a0541ac13f29496ead7d67605aea65d30f97ee74fefcf55e94b",
+  "source_digest_sha256": "451563e8f025c18af69924c9965a51039d3b974349d9cf7f04197528aed254d2",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "b0785552b71d4a0541ac13f29496ead7d67605aea65d30f97ee74fefcf55e94b"
+  "target_digest_sha256": "451563e8f025c18af69924c9965a51039d3b974349d9cf7f04197528aed254d2"
 }

--- a/docs/source/cluster.rst
+++ b/docs/source/cluster.rst
@@ -93,11 +93,14 @@ directly into the user share root. When cluster mode is enabled and
 This avoids collisions when the same user runs several app workflows on the same
 cluster share. The cluster settings UI exposes two controls:
 
-- **Workflow session policy**: ``new`` creates a fresh session directory,
-  ``last`` reuses the newest existing session for the app, and ``select`` uses
-  the named session.
+- **Workflow session policy**: ``new`` creates a fresh session directory when
+  **Workflow session** is empty, ``last`` reuses the newest existing session for
+  the app, and ``select`` uses the named session.
 - **Workflow session**: optional session name. Leave it empty for automatic
-  selection, or set it when you want a stable session such as ``trial-001``.
+  selection. With ``new`` this creates a session; with ``last`` it reuses the
+  newest session; with ``select`` it uses the newest session when one exists and
+  creates one otherwise. Set a value when you want a stable session such as
+  ``trial-001``.
 
 The same behavior can be preseeded with environment values:
 

--- a/src/agilab/orchestrate/orchestrate_cluster.py
+++ b/src/agilab/orchestrate/orchestrate_cluster.py
@@ -1427,6 +1427,7 @@ def render_cluster_settings_ui(env: Any, deps: OrchestrateClusterDeps, *, show_r
                     workflow_name=app_state_name,
                     policy=workflow_policy,
                     selected_session=workflow_session,
+                    create=False,
                 )
             except OSError as exc:
                 workflow_session_error_shown = True
@@ -1451,8 +1452,9 @@ def render_cluster_settings_ui(env: Any, deps: OrchestrateClusterDeps, *, show_r
                 WORKFLOW_SESSION_POLICY_OPTIONS,
                 key=workflow_policy_key,
                 help=(
-                    "`new` creates an isolated session, `last` reuses the latest session, "
-                    "and `select` uses the named session."
+                    "`new` creates an isolated session when the session field is empty, "
+                    "`last` reuses the latest session, and `select` uses the named session "
+                    "or the latest session when empty."
                 ),
             )
         workflow_policy = _workflow_session_policy(workflow_policy_input)
@@ -1462,9 +1464,13 @@ def render_cluster_settings_ui(env: Any, deps: OrchestrateClusterDeps, *, show_r
                 "Workflow session",
                 key=workflow_session_key,
                 placeholder="auto, or e.g. trial-001",
-                help="Session directory below the cluster user share. Leave empty to auto-select for the policy.",
+                help=(
+                    "Session directory below the cluster user share. Leave empty to auto-select "
+                    "for the policy: `new` creates one, `last` reuses the latest, and `select` "
+                    "uses the latest when available."
+                ),
             )
-        workflow_session = _safe_workflow_component(workflow_session_input, workflow_session)
+        workflow_session = _safe_workflow_component(workflow_session_input, "")
         if cluster_share_ready and cluster_share_candidate is not None and not workflow_session_error_shown:
             try:
                 workflow_workers_path, workflow_session, workflow_policy = _resolve_workflow_session_workers_path(

--- a/test/test_orchestrate_cluster.py
+++ b/test/test_orchestrate_cluster.py
@@ -1337,6 +1337,73 @@ def test_render_cluster_settings_ui_preserves_workflow_session_without_cluster_s
     assert cluster["workflow_session"] == "manual-session"
 
 
+def test_render_cluster_settings_ui_empty_workflow_session_auto_selects_latest(monkeypatch, tmp_path):
+    app_name = "demo_project"
+    widget_keys = orchestrate_cluster.cluster_widget_keys(app_name)
+    share = tmp_path / "cluster-share"
+    sessions_root = share / "agi" / "workflows" / app_name
+    old_session = sessions_root / "session-a"
+    latest_session = sessions_root / "session-b"
+    old_session.mkdir(parents=True)
+    latest_session.mkdir(parents=True)
+    os.utime(old_session, (1, 1))
+    os.utime(latest_session, (2, 2))
+    fake_st = _FakeStreamlit(
+        widget_values={
+            widget_keys["cluster_enabled"]: True,
+            widget_keys["cython"]: False,
+            widget_keys["pool"]: False,
+            widget_keys["rapids"]: False,
+            widget_keys["use_key"]: True,
+            widget_keys["workflow_session_policy"]: "select",
+            widget_keys["workflow_session"]: "",
+        },
+        session_state={
+            "app_settings": {
+                "cluster": {
+                    "cluster_enabled": True,
+                    "workflow_session_policy": "select",
+                    "workflow_session": "session-a",
+                    "workers_data_path": "cluster-share/agi/workflows/demo_project/session-a/workers",
+                }
+            },
+            widget_keys["workflow_session_policy"]: "select",
+            widget_keys["workflow_session"]: "session-a",
+            widget_keys["workers_data_path"]: "cluster-share/agi/workflows/demo_project/session-a/workers",
+            "benchmark": False,
+        },
+    )
+    monkeypatch.setattr(orchestrate_cluster, "st", fake_st)
+    _disable_lan_defaults(monkeypatch)
+    deps = orchestrate_cluster.OrchestrateClusterDeps(
+        parse_and_validate_scheduler=lambda _raw: None,
+        parse_and_validate_workers=lambda _raw: None,
+        write_app_settings_toml=lambda _path, settings: settings,
+        clear_load_toml_cache=lambda: None,
+        set_env_var=lambda _key, _value: None,
+        agi_env_envars={},
+    )
+    env = SimpleNamespace(
+        app=app_name,
+        home_abs=tmp_path,
+        is_managed_pc=False,
+        AGI_CLUSTER_SHARE=str(share),
+        agi_share_path=Path("cluster-share"),
+        share_root_path=lambda: share,
+        user="agi",
+        password=None,
+        ssh_key_path=None,
+        app_settings_file=tmp_path / "app_settings.toml",
+    )
+
+    orchestrate_cluster.render_cluster_settings_ui(env, deps)
+
+    cluster = fake_st.session_state.app_settings["cluster"]
+    assert cluster["workflow_session_policy"] == "select"
+    assert cluster["workflow_session"] == "session-b"
+    assert cluster["workers_data_path"] == "cluster-share/agi/workflows/demo_project/session-b/workers"
+
+
 def test_render_cluster_settings_ui_preserves_explicit_cluster_values_over_lan_discovery(monkeypatch, tmp_path):
     fake_st = _FakeStreamlit(
         widget_values={


### PR DESCRIPTION
## Summary
- fix workflow-session clearing so an empty field requests policy-based auto-selection instead of reusing the previous session
- avoid pre-widget session creation during initial UI hydration so `select` can pick the actual latest session after clearing the field
- align cluster workflow-session docs and sync the managed docs/source mirror stamp

## Validation
- `.venv/bin/pytest -q test/test_orchestrate_cluster.py` (`48 passed`)
- `python3 tools/sync_docs_source.py --verify-stamp`
- `git diff --check -- docs/source/cluster.rst src/agilab/orchestrate/orchestrate_cluster.py test/test_orchestrate_cluster.py`
