### PR TITLE
Refresh coverage badges from current XML

### DIFF
--- a/badges/coverage-agi-cluster.svg
+++ b/badges/coverage-agi-cluster.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="188" height="20" role="img" aria-label="agi-cluster coverage: 100%">
+<svg xmlns="http://www.w3.org/2000/svg" width="181" height="20" role="img" aria-label="agi-cluster coverage: 97%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -6,17 +6,17 @@
   <stop offset="1" stop-opacity=".5"/>
 </linearGradient>
 <mask id="a">
-  <rect width="188" height="20" rx="3" fill="#fff"/>
+  <rect width="181" height="20" rx="3" fill="#fff"/>
 </mask>
 <g mask="url(#a)">
   <rect width="150" height="20" fill="#555"/>
-  <rect x="150" width="38" height="20" fill="#2ea44f"/>
-  <rect width="188" height="20" fill="url(#b)"/>
+  <rect x="150" width="31" height="20" fill="#2ea44f"/>
+  <rect width="181" height="20" fill="url(#b)"/>
 </g>
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="75.0" y="15" fill="#010101" fill-opacity=".3">agi-cluster coverage</text>
   <text x="75.0" y="14">agi-cluster coverage</text>
-  <text x="169.0" y="15" fill="#010101" fill-opacity=".3">100%</text>
-  <text x="169.0" y="14">100%</text>
+  <text x="165.5" y="15" fill="#010101" fill-opacity=".3">97%</text>
+  <text x="165.5" y="14">97%</text>
 </g>
 </svg>

--- a/badges/coverage-agi-core.svg
+++ b/badges/coverage-agi-core.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="167" height="20" role="img" aria-label="agi-core coverage: 100%">
+<svg xmlns="http://www.w3.org/2000/svg" width="160" height="20" role="img" aria-label="agi-core coverage: 95%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -6,17 +6,17 @@
   <stop offset="1" stop-opacity=".5"/>
 </linearGradient>
 <mask id="a">
-  <rect width="167" height="20" rx="3" fill="#fff"/>
+  <rect width="160" height="20" rx="3" fill="#fff"/>
 </mask>
 <g mask="url(#a)">
   <rect width="129" height="20" fill="#555"/>
-  <rect x="129" width="38" height="20" fill="#2ea44f"/>
-  <rect width="167" height="20" fill="url(#b)"/>
+  <rect x="129" width="31" height="20" fill="#2ea44f"/>
+  <rect width="160" height="20" fill="url(#b)"/>
 </g>
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="64.5" y="15" fill="#010101" fill-opacity=".3">agi-core coverage</text>
   <text x="64.5" y="14">agi-core coverage</text>
-  <text x="148.0" y="15" fill="#010101" fill-opacity=".3">100%</text>
-  <text x="148.0" y="14">100%</text>
+  <text x="144.5" y="15" fill="#010101" fill-opacity=".3">95%</text>
+  <text x="144.5" y="14">95%</text>
 </g>
 </svg>

--- a/badges/coverage-agi-env.svg
+++ b/badges/coverage-agi-env.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="160" height="20" role="img" aria-label="agi-env coverage: 100%">
+<svg xmlns="http://www.w3.org/2000/svg" width="153" height="20" role="img" aria-label="agi-env coverage: 95%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -6,17 +6,17 @@
   <stop offset="1" stop-opacity=".5"/>
 </linearGradient>
 <mask id="a">
-  <rect width="160" height="20" rx="3" fill="#fff"/>
+  <rect width="153" height="20" rx="3" fill="#fff"/>
 </mask>
 <g mask="url(#a)">
   <rect width="122" height="20" fill="#555"/>
-  <rect x="122" width="38" height="20" fill="#2ea44f"/>
-  <rect width="160" height="20" fill="url(#b)"/>
+  <rect x="122" width="31" height="20" fill="#2ea44f"/>
+  <rect width="153" height="20" fill="url(#b)"/>
 </g>
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="61.0" y="15" fill="#010101" fill-opacity=".3">agi-env coverage</text>
   <text x="61.0" y="14">agi-env coverage</text>
-  <text x="141.0" y="15" fill="#010101" fill-opacity=".3">100%</text>
-  <text x="141.0" y="14">100%</text>
+  <text x="137.5" y="15" fill="#010101" fill-opacity=".3">95%</text>
+  <text x="137.5" y="14">95%</text>
 </g>
 </svg>

--- a/badges/coverage-agi-node.svg
+++ b/badges/coverage-agi-node.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="167" height="20" role="img" aria-label="agi-node coverage: 100%">
+<svg xmlns="http://www.w3.org/2000/svg" width="160" height="20" role="img" aria-label="agi-node coverage: 96%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -6,17 +6,17 @@
   <stop offset="1" stop-opacity=".5"/>
 </linearGradient>
 <mask id="a">
-  <rect width="167" height="20" rx="3" fill="#fff"/>
+  <rect width="160" height="20" rx="3" fill="#fff"/>
 </mask>
 <g mask="url(#a)">
   <rect width="129" height="20" fill="#555"/>
-  <rect x="129" width="38" height="20" fill="#2ea44f"/>
-  <rect width="167" height="20" fill="url(#b)"/>
+  <rect x="129" width="31" height="20" fill="#2ea44f"/>
+  <rect width="160" height="20" fill="url(#b)"/>
 </g>
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="64.5" y="15" fill="#010101" fill-opacity=".3">agi-node coverage</text>
   <text x="64.5" y="14">agi-node coverage</text>
-  <text x="148.0" y="15" fill="#010101" fill-opacity=".3">100%</text>
-  <text x="148.0" y="14">100%</text>
+  <text x="144.5" y="15" fill="#010101" fill-opacity=".3">96%</text>
+  <text x="144.5" y="14">96%</text>
 </g>
 </svg>

--- a/badges/coverage-agilab.svg
+++ b/badges/coverage-agilab.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="146" height="20" role="img" aria-label="agilab coverage: 98%">
+<svg xmlns="http://www.w3.org/2000/svg" width="146" height="20" role="img" aria-label="agilab coverage: 97%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="57.5" y="15" fill="#010101" fill-opacity=".3">agilab coverage</text>
   <text x="57.5" y="14">agilab coverage</text>
-  <text x="130.5" y="15" fill="#010101" fill-opacity=".3">98%</text>
-  <text x="130.5" y="14">98%</text>
+  <text x="130.5" y="15" fill="#010101" fill-opacity=".3">97%</text>
+  <text x="130.5" y="14">97%</text>
 </g>
 </svg>


### PR DESCRIPTION
## Summary
- regenerate component coverage badges from fresh workflow XMLs
- correct stale agi-env, agi-node, agi-cluster, agi-core, and aggregate agilab badge values

## Validation
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-env --profile agi-core-combined --profile agi-gui
- uv --preview-features extra-build-dependencies run --no-project --with-editable ./src/agilab/lib/agi-web --with pytest --with pytest-cov python -m pytest -q --maxfail=1 --disable-warnings -o addopts='' --cov=agi_web --cov-report=xml:coverage-agi-web.xml src/agilab/lib/agi-web/test
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_generate_component_coverage_badges.py
- uv --preview-features extra-build-dependencies run python tools/coverage_badge_guard.py --components agi-cluster agi-env agi-node agi-core agilab --require-fresh-xml --allow-badge-only
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile badges