### PR TITLE
[codex] Fix warning allowlist source scoping

### DIFF
--- a/test/test_validation_warning_report.py
+++ b/test/test_validation_warning_report.py
@@ -114,6 +114,40 @@ reason = "Streamlit bare-mode validation emits this warning outside a script con
     assert report["warnings"][0]["allowlist_id"] == "streamlit-bare-mode"
 
 
+def test_warning_report_source_allowlist_does_not_approve_other_sources(tmp_path):
+    allowed_log = tmp_path / "allowed.log"
+    other_log = tmp_path / "other.log"
+    allowed_log.write_text("WARNING shared warning\n", encoding="utf-8")
+    other_log.write_text("WARNING shared warning\n", encoding="utf-8")
+    allowlist_path = tmp_path / "warning_allowlist.toml"
+    allowlist_path.write_text(
+        """
+[[warnings]]
+id = "approved-source"
+category = "log-warning"
+message = "shared warning"
+source = "allowed[.]log"
+expires = "2099-12-31"
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    report = validation_warning_report.build_report(
+        (tmp_path,), allowlist_path=allowlist_path
+    )
+
+    assert report["status"] == "warn"
+    assert report["summary"]["warning_count"] == 2
+    assert report["summary"]["approved_warning_count"] == 1
+    assert report["summary"]["unapproved_warning_count"] == 1
+    assert report["summary"]["unique_warning_count"] == 1
+    assert sorted(warning["approved"] for warning in report["warnings"]) == [
+        False,
+        True,
+    ]
+
+
 def test_warning_report_expired_allowlist_rule_does_not_approve(tmp_path):
     log_path = tmp_path / "validation.log"
     log_path.write_text("WARNING old warning\n", encoding="utf-8")

--- a/tools/validation_warning_report.py
+++ b/tools/validation_warning_report.py
@@ -389,15 +389,18 @@ def build_report(
     rules = load_allowlist(allowlist_path)
     occurrences = [warning for file in files for warning in _scan_file(file)]
 
-    grouped: dict[tuple[str, str], list[WarningOccurrence]] = {}
+    grouped: dict[tuple[str, str, str], list[WarningOccurrence]] = {}
     for occurrence in occurrences:
         warning_id = _warning_id(occurrence.category, occurrence.message)
-        grouped.setdefault((warning_id, occurrence.category), []).append(occurrence)
+        allowlist_id = _allowance_for(occurrence, warning_id, rules) or ""
+        grouped.setdefault((warning_id, occurrence.category, allowlist_id), []).append(
+            occurrence
+        )
 
     warning_groups: list[WarningGroup] = []
-    for (warning_id, category), group_occurrences in sorted(grouped.items()):
+    for (warning_id, category, allowlist_key), group_occurrences in sorted(grouped.items()):
         first = group_occurrences[0]
-        allowlist_id = _allowance_for(first, warning_id, rules)
+        allowlist_id = allowlist_key or None
         examples = tuple(
             {
                 "source": _display_path(item.source),
@@ -426,6 +429,9 @@ def build_report(
     total_count = sum(group.count for group in warning_groups)
     unapproved_count = total_count - approved_count
     expired_rules = [rule.rule_id for rule in rules if rule.expired]
+    unique_warning_count = len(
+        {(group.warning_id, group.category) for group in warning_groups}
+    )
 
     return {
         "schema": SCHEMA,
@@ -437,7 +443,7 @@ def build_report(
         "summary": {
             "file_count": len(files),
             "warning_count": total_count,
-            "unique_warning_count": len(warning_groups),
+            "unique_warning_count": unique_warning_count,
             "approved_warning_count": approved_count,
             "unapproved_warning_count": unapproved_count,
             "expired_allowlist_rule_count": len(expired_rules),


### PR DESCRIPTION
## Summary
- Fix validation warning allowlist handling so source-scoped rules are applied per occurrence, not once per grouped message.
- Preserve the unique-warning count as distinct warning identities while reporting approved and unapproved instances separately.
- Add a regression covering the same warning text emitted from an allowed source and an unrelated source.

## Root cause
The warning report grouped occurrences by warning id before evaluating allowlist rules. A source-scoped allowlist was evaluated only against the first occurrence in the group, so it could approve or reject unrelated occurrences with the same message.

## Validation
Validation passed.
