### PR TITLE
[codex] Fix worker data path resolution

### DIFF
--- a/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/base_worker_path_support.py
+++ b/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/base_worker_path_support.py
@@ -82,11 +82,19 @@ def share_root_path(
     except SHARE_ROOT_FALLBACK_EXCEPTIONS:
         pass
 
-    for candidate in (env.agi_share_path_abs, env.agi_share_path):
+    is_worker_env = bool(getattr(env, "is_worker_env", False))
+    candidates = (
+        (env.agi_share_path, True),
+        (env.agi_share_path_abs, False),
+    ) if is_worker_env else (
+        (env.agi_share_path_abs, False),
+        (env.agi_share_path, False),
+    )
+    for candidate, use_runtime_home in candidates:
         if candidate:
             base = path_cls(candidate).expanduser()
             if not base.is_absolute():
-                home = path_cls(env.home_abs).expanduser()
+                home = path_cls.home() if use_runtime_home else path_cls(env.home_abs).expanduser()
                 base = (home / base).expanduser()
             return base
     return path_cls(env.home_abs).expanduser()

--- a/src/agilab/core/test/test_base_worker_path_support.py
+++ b/src/agilab/core/test/test_base_worker_path_support.py
@@ -23,6 +23,35 @@ def test_base_worker_path_support_normalized_and_share_root(monkeypatch, tmp_pat
     assert path_support.share_root_path(env) == tmp_path / "clustershare"
 
 
+def test_worker_share_fallback_uses_runtime_home_for_relative_share(monkeypatch, tmp_path):
+    worker_home = tmp_path / "worker-home"
+    manager_home = tmp_path / "manager-home"
+    worker_home.mkdir()
+    manager_home.mkdir()
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: worker_home))
+
+    env = SimpleNamespace(
+        is_worker_env=True,
+        share_root_path=lambda: (_ for _ in ()).throw(OSError("share unavailable")),
+        agi_share_path_abs=manager_home / "clustershare" / "agi",
+        agi_share_path=Path("clustershare") / "agi",
+        home_abs=manager_home,
+        _is_managed_pc=False,
+    )
+
+    expected_share = worker_home / "clustershare" / "agi"
+    assert path_support.share_root_path(env) == expected_share
+
+    resolved = path_support.resolve_data_dir(
+        env,
+        Path("demo") / "data",
+        share_root_path_fn=lambda current_env: path_support.share_root_path(current_env),
+        remap_managed_pc_path_fn=lambda value: Path(value),
+        normalized_path_fn=lambda value: Path(value),
+    )
+    assert resolved == (expected_share / "demo" / "data").resolve(strict=False)
+
+
 def test_base_worker_path_support_data_dir_aliases_and_home_remap(monkeypatch, tmp_path):
     class _BrokenPath:
         def __fspath__(self):


### PR DESCRIPTION
## Summary
- Fix worker fallback share-root resolution so worker environments prefer their runtime home for relative `agi_share_path` values when `env.share_root_path()` is unavailable.
- Add a regression for stale manager absolute share metadata resolving worker `data_in` under the wrong root.

## Root cause
A worker-like fallback env could carry both a stale manager absolute `agi_share_path_abs` and the correct relative `agi_share_path`. The fallback helper tried the absolute value first, so relative worker data paths could be anchored under the manager share instead of the worker-mounted share.

## Validation
- `./dev impact --files src/agilab/core/agi-node/src/agi_node/agi_dispatcher/base_worker_path_support.py src/agilab/core/test/test_base_worker_path_support.py`
- `./dev test src/agilab/core/test/test_base_worker_path_support.py src/agilab/core/test/test_base_worker.py::test_baseworker_share_root_path_none_absolute_and_home_fallback src/agilab/core/test/test_base_worker.py::test_baseworker_collect_share_aliases_and_data_dir_fallbacks src/agilab/core/test/test_base_worker.py::test_baseworker_setup_data_directories_and_info src/agilab/core/test/test_base_worker.py::test_baseworker_setup_data_directories_falls_back_when_output_unavailable`
- `uv --preview-features extra-build-dependencies run --no-sync pytest src/agilab/core/test`
- `uv --preview-features extra-build-dependencies run --with mypy python tools/shared_core_strict_typing.py`
- local pre-push guards