### PR TITLE
Fix worker runtime resolution of share-prefixed data paths

### DIFF
--- a/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/base_worker_path_support.py
+++ b/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/base_worker_path_support.py
@@ -100,6 +100,80 @@ def share_root_path(
     return path_cls(env.home_abs).expanduser()
 
 
+def _relative_share_prefixes(
+    env: Any | None,
+    share_base: Path,
+    *,
+    path_cls: type[Path] = Path,
+    home_factory: Callable[[], Path] = Path.home,
+) -> list[Path]:
+    prefixes: list[Path] = []
+
+    def add_prefix(value: Any) -> None:
+        if not value:
+            return
+        try:
+            prefix = path_cls(value).expanduser()
+        except PATH_FALLBACK_EXCEPTIONS:
+            return
+        if prefix.is_absolute():
+            return
+        if prefix not in {path_cls(), path_cls(".")}:
+            prefixes.append(prefix)
+
+    if env is not None:
+        for attr in ("agi_share_path", "AGILAB_SHARE_REL"):
+            add_prefix(getattr(env, attr, None))
+
+        share_abs = getattr(env, "agi_share_path_abs", None)
+        home_abs = getattr(env, "home_abs", None)
+        if share_abs and home_abs:
+            try:
+                add_prefix(path_cls(share_abs).expanduser().relative_to(path_cls(home_abs).expanduser()))
+            except PATH_FALLBACK_EXCEPTIONS:
+                pass
+
+    try:
+        home = path_cls(home_factory()).expanduser()
+        add_prefix(path_cls(share_base).expanduser().relative_to(home))
+    except PATH_FALLBACK_EXCEPTIONS:
+        pass
+
+    unique: list[Path] = []
+    seen: set[tuple[str, ...]] = set()
+    for prefix in sorted(prefixes, key=lambda value: len(value.parts), reverse=True):
+        parts = tuple(part for part in prefix.parts if part not in {"", "."})
+        if not parts or parts in seen:
+            continue
+        seen.add(parts)
+        unique.append(path_cls(*parts))
+    return unique
+
+
+def _resolve_relative_data_path(
+    raw: Path,
+    share_base: Path,
+    env: Any | None,
+    *,
+    path_cls: type[Path] = Path,
+    home_factory: Callable[[], Path] = Path.home,
+) -> Path:
+    raw_parts = tuple(part for part in raw.parts if part not in {"", "."})
+    for prefix in _relative_share_prefixes(
+        env,
+        share_base,
+        path_cls=path_cls,
+        home_factory=home_factory,
+    ):
+        prefix_parts = prefix.parts
+        if raw_parts[: len(prefix_parts)] != prefix_parts:
+            continue
+        remainder_parts = raw_parts[len(prefix_parts) :]
+        remainder = path_cls(*remainder_parts) if remainder_parts else path_cls()
+        return path_cls(share_base).expanduser() / remainder
+    return path_cls(share_base).expanduser() / raw
+
+
 def resolve_data_dir(
     env: Any | None,
     data_path: Path | str | None,
@@ -116,7 +190,13 @@ def resolve_data_dir(
     raw = path_cls(str(data_path)).expanduser()
     if not raw.is_absolute():
         base = share_root_path_fn(env) or home_factory()
-        raw = path_cls(base).expanduser() / raw
+        raw = _resolve_relative_data_path(
+            raw,
+            path_cls(base).expanduser(),
+            env,
+            path_cls=path_cls,
+            home_factory=home_factory,
+        )
 
     remapped = remap_managed_pc_path_fn(raw)
     try:

--- a/src/agilab/core/test/test_base_worker.py
+++ b/src/agilab/core/test/test_base_worker.py
@@ -228,6 +228,31 @@ def test_baseworker_share_root_path_none_absolute_and_home_fallback(tmp_path):
     assert BaseWorker._share_root_path(env_home) == (tmp_path / "home")
 
 
+def test_baseworker_resolves_share_prefixed_relative_worker_path_once(monkeypatch, tmp_path):
+    worker_home = tmp_path / "worker-home"
+    manager_home = tmp_path / "manager-home"
+    worker_home.mkdir()
+    manager_home.mkdir()
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: worker_home))
+
+    env = SimpleNamespace(
+        is_worker_env=True,
+        share_root_path=lambda: (_ for _ in ()).throw(OSError("share unavailable")),
+        agi_share_path_abs=manager_home / "clustershare" / "agi",
+        agi_share_path=Path("clustershare") / "agi",
+        home_abs=manager_home,
+        _is_managed_pc=False,
+    )
+
+    resolved = BaseWorker._resolve_data_dir(
+        env,
+        Path("clustershare") / "agi" / "demo_project" / "session-a" / "workers",
+    )
+    assert resolved == (
+        worker_home / "clustershare" / "agi" / "demo_project" / "session-a" / "workers"
+    ).resolve(strict=False)
+
+
 def test_baseworker_collect_share_aliases_and_data_dir_fallbacks(monkeypatch, tmp_path):
     class _BrokenPath:
         def __fspath__(self):
@@ -1391,7 +1416,6 @@ def test_baseworker_setup_data_directories_without_env_falls_back_to_home(
     requested_output = fake_home / "reports" / "out"
     fallback_output = fake_home / "out" / "output"
 
-    original_home = Path.home
     original_mkdir = Path.mkdir
 
     def _patched_home():

--- a/src/agilab/core/test/test_base_worker_path_support.py
+++ b/src/agilab/core/test/test_base_worker_path_support.py
@@ -52,6 +52,34 @@ def test_worker_share_fallback_uses_runtime_home_for_relative_share(monkeypatch,
     assert resolved == (expected_share / "demo" / "data").resolve(strict=False)
 
 
+def test_worker_data_dir_resolves_share_prefixed_relative_path_once(monkeypatch, tmp_path):
+    worker_home = tmp_path / "worker-home"
+    manager_home = tmp_path / "manager-home"
+    worker_home.mkdir()
+    manager_home.mkdir()
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: worker_home))
+
+    env = SimpleNamespace(
+        is_worker_env=True,
+        share_root_path=lambda: (_ for _ in ()).throw(OSError("share unavailable")),
+        agi_share_path_abs=manager_home / "clustershare" / "agi",
+        agi_share_path=Path("clustershare") / "agi",
+        home_abs=manager_home,
+        _is_managed_pc=False,
+    )
+
+    resolved = path_support.resolve_data_dir(
+        env,
+        Path("clustershare") / "agi" / "demo_project" / "session-a" / "workers",
+        share_root_path_fn=lambda current_env: path_support.share_root_path(current_env),
+        remap_managed_pc_path_fn=lambda value: Path(value),
+        normalized_path_fn=lambda value: Path(value),
+    )
+    assert resolved == (
+        worker_home / "clustershare" / "agi" / "demo_project" / "session-a" / "workers"
+    ).resolve(strict=False)
+
+
 def test_base_worker_path_support_data_dir_aliases_and_home_remap(monkeypatch, tmp_path):
     class _BrokenPath:
         def __fspath__(self):


### PR DESCRIPTION
## Summary
- fix worker runtime `data_path` resolution for values that already include the configured share prefix, such as `clustershare/agi/demo_project/session-a/workers`
- prevent doubled worker paths like `~/clustershare/agi/clustershare/agi/...`
- add helper and public `BaseWorker` regressions for separate manager/worker homes

## Root cause
PR #633 corrected the ORCHESTRATE-generated path shape, but the runtime worker resolver still treated every relative `data_path` as relative to the share root. A share-prefixed relative value was therefore prefixed by the share root a second time on the worker.

## Validation
- `uv --preview-features extra-build-dependencies run --no-sync pytest -q -o addopts='' src/agilab/core/test/test_base_worker_path_support.py::test_worker_data_dir_resolves_share_prefixed_relative_path_once src/agilab/core/test/test_base_worker.py::test_baseworker_resolves_share_prefixed_relative_worker_path_once`
- `uv --preview-features extra-build-dependencies run --extra dev ruff check src/agilab/core/agi-node/src/agi_node/agi_dispatcher/base_worker_path_support.py src/agilab/core/test/test_base_worker_path_support.py src/agilab/core/test/test_base_worker.py`
- `uv --preview-features extra-build-dependencies run --no-sync pytest -q -o addopts='' src/agilab/core/test/test_base_worker_path_support.py src/agilab/core/test/test_base_worker.py`
- `./dev impact --files src/agilab/core/agi-node/src/agi_node/agi_dispatcher/base_worker_path_support.py src/agilab/core/test/test_base_worker_path_support.py src/agilab/core/test/test_base_worker.py`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' src/agilab/core/test/test_base_worker_path_support.py src/agilab/core/test/test_base_worker.py`
- `uv --preview-features extra-build-dependencies run --no-sync pytest src/agilab/core/test`
- `uv --preview-features extra-build-dependencies run --with mypy python tools/shared_core_strict_typing.py`
- `git diff --check`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --staged`
- `./dev scope --staged`