### PR TITLE
Improve ORCHESTRATE workflow session directory selection

### DIFF
--- a/src/agilab/orchestrate/orchestrate_cluster.py
+++ b/src/agilab/orchestrate/orchestrate_cluster.py
@@ -89,6 +89,7 @@ def cluster_widget_keys(app_state_name: str) -> dict[str, str]:
         "ssh_key_path": f"cluster_ssh_key__{app_state_name}",
         "password": f"cluster_password__{app_state_name}",
         "workflow_session_policy": f"cluster_workflow_session_policy__{app_state_name}",
+        "workflow_existing_session": f"cluster_workflow_existing_session__{app_state_name}",
         "workflow_session": f"cluster_workflow_session__{app_state_name}",
         "workers_data_path": f"cluster_workers_data_path__{app_state_name}",
         "workers": f"cluster_workers__{app_state_name}",
@@ -426,6 +427,10 @@ def _list_workflow_sessions(sessions_root: Path) -> list[Path]:
             return (0, path.name)
 
     return sorted(entries, key=sort_key, reverse=True)
+
+
+def _workflow_session_names(sessions_root: Path) -> list[str]:
+    return [session.name for session in _list_workflow_sessions(sessions_root)]
 
 
 def _resolve_workflow_session_workers_path(
@@ -1412,6 +1417,7 @@ def render_cluster_settings_ui(env: Any, deps: OrchestrateClusterDeps, *, show_r
 
         workers_data_path_widget_key = widget_keys["workers_data_path"]
         workflow_policy_key = widget_keys["workflow_session_policy"]
+        workflow_existing_session_key = widget_keys["workflow_existing_session"]
         workflow_session_key = widget_keys["workflow_session"]
         workflow_policy = _workflow_session_policy(
             st.session_state.get(
@@ -1433,7 +1439,11 @@ def render_cluster_settings_ui(env: Any, deps: OrchestrateClusterDeps, *, show_r
             and cluster_share_candidate.is_dir()
             and os.access(cluster_share_candidate, os.W_OK)
         )
+        workflow_session_options: list[str] = []
         if cluster_share_ready and cluster_share_candidate is not None:
+            workflow_session_options = _workflow_session_names(
+                _workflow_sessions_root(cluster_share_candidate, sanitized_user, app_state_name)
+            )
             try:
                 workflow_workers_path, workflow_session, workflow_policy = _resolve_workflow_session_workers_path(
                     cluster_share_candidate,
@@ -1473,6 +1483,32 @@ def render_cluster_settings_ui(env: Any, deps: OrchestrateClusterDeps, *, show_r
             )
         workflow_policy = _workflow_session_policy(workflow_policy_input)
         cluster_params["workflow_session_policy"] = workflow_policy
+
+        if workflow_policy == "select":
+            if workflow_session_options:
+                manual_session_option = "Manual / latest"
+                existing_session_options = [manual_session_option, *workflow_session_options]
+                current_existing_session = st.session_state.get(workflow_existing_session_key)
+                if current_existing_session not in existing_session_options:
+                    st.session_state[workflow_existing_session_key] = manual_session_option
+                selected_existing_session = st.selectbox(
+                    "Existing session directory",
+                    existing_session_options,
+                    key=workflow_existing_session_key,
+                    help="Pick a session directory already present under the workflow cluster share.",
+                )
+                if selected_existing_session != manual_session_option:
+                    workflow_session = _safe_workflow_component(selected_existing_session, "")
+                    st.session_state[workflow_session_key] = workflow_session
+            elif cluster_share_ready:
+                st.session_state.pop(workflow_existing_session_key, None)
+                st.info(
+                    "No existing workflow session directories found under "
+                    f"`{_workflow_sessions_root(cluster_share_candidate, sanitized_user, app_state_name)}`."
+                )
+        else:
+            st.session_state.pop(workflow_existing_session_key, None)
+
         with workflow_cols[1]:
             workflow_session_input = st.text_input(
                 "Workflow session",

--- a/test/test_orchestrate_cluster.py
+++ b/test/test_orchestrate_cluster.py
@@ -1410,6 +1410,126 @@ def test_render_cluster_settings_ui_empty_workflow_session_auto_selects_latest(m
     assert cluster["workers_data_path"] == "cluster-share/agi/demo_project/session-b/workers"
 
 
+def test_render_cluster_settings_ui_selects_existing_workflow_session_directory(monkeypatch, tmp_path):
+    app_name = "demo_project"
+    widget_keys = orchestrate_cluster.cluster_widget_keys(app_name)
+    share = tmp_path / "cluster-share"
+    sessions_root = share / "agi" / app_name
+    old_session = sessions_root / "session-a"
+    latest_session = sessions_root / "session-b"
+    old_session.mkdir(parents=True)
+    latest_session.mkdir(parents=True)
+    os.utime(old_session, (1, 1))
+    os.utime(latest_session, (2, 2))
+    fake_st = _FakeStreamlit(
+        widget_values={
+            widget_keys["cluster_enabled"]: True,
+            widget_keys["cython"]: False,
+            widget_keys["pool"]: False,
+            widget_keys["rapids"]: False,
+            widget_keys["use_key"]: True,
+            widget_keys["workflow_session_policy"]: "select",
+            widget_keys["workflow_existing_session"]: "session-a",
+        },
+        session_state={
+            "app_settings": {
+                "cluster": {
+                    "cluster_enabled": True,
+                    "workflow_session_policy": "select",
+                }
+            },
+            "benchmark": False,
+        },
+    )
+    monkeypatch.setattr(orchestrate_cluster, "st", fake_st)
+    _disable_lan_defaults(monkeypatch)
+    deps = orchestrate_cluster.OrchestrateClusterDeps(
+        parse_and_validate_scheduler=lambda _raw: None,
+        parse_and_validate_workers=lambda _raw: None,
+        write_app_settings_toml=lambda _path, settings: settings,
+        clear_load_toml_cache=lambda: None,
+        set_env_var=lambda _key, _value: None,
+        agi_env_envars={},
+    )
+    env = SimpleNamespace(
+        app=app_name,
+        home_abs=tmp_path,
+        is_managed_pc=False,
+        AGI_CLUSTER_SHARE=str(share),
+        agi_share_path=Path("cluster-share"),
+        share_root_path=lambda: share,
+        user="agi",
+        password=None,
+        ssh_key_path=None,
+        app_settings_file=tmp_path / "app_settings.toml",
+    )
+
+    orchestrate_cluster.render_cluster_settings_ui(env, deps)
+
+    cluster = fake_st.session_state.app_settings["cluster"]
+    assert "Existing session directory" in fake_st.selectboxes
+    assert fake_st.session_state[widget_keys["workflow_session"]] == "session-a"
+    assert cluster["workflow_session"] == "session-a"
+    assert cluster["workers_data_path"] == "cluster-share/agi/demo_project/session-a/workers"
+
+
+def test_render_cluster_settings_ui_reports_missing_existing_session_directories(monkeypatch, tmp_path):
+    app_name = "demo_project"
+    widget_keys = orchestrate_cluster.cluster_widget_keys(app_name)
+    share = tmp_path / "cluster-share"
+    share.mkdir()
+    fake_st = _FakeStreamlit(
+        widget_values={
+            widget_keys["cluster_enabled"]: True,
+            widget_keys["cython"]: False,
+            widget_keys["pool"]: False,
+            widget_keys["rapids"]: False,
+            widget_keys["use_key"]: True,
+            widget_keys["workflow_session_policy"]: "select",
+            widget_keys["workflow_session"]: "manual-session",
+        },
+        session_state={
+            "app_settings": {
+                "cluster": {
+                    "cluster_enabled": True,
+                    "workflow_session_policy": "select",
+                }
+            },
+            "benchmark": False,
+        },
+    )
+    monkeypatch.setattr(orchestrate_cluster, "st", fake_st)
+    _disable_lan_defaults(monkeypatch)
+    deps = orchestrate_cluster.OrchestrateClusterDeps(
+        parse_and_validate_scheduler=lambda _raw: None,
+        parse_and_validate_workers=lambda _raw: None,
+        write_app_settings_toml=lambda _path, settings: settings,
+        clear_load_toml_cache=lambda: None,
+        set_env_var=lambda _key, _value: None,
+        agi_env_envars={},
+    )
+    env = SimpleNamespace(
+        app=app_name,
+        home_abs=tmp_path,
+        is_managed_pc=False,
+        AGI_CLUSTER_SHARE=str(share),
+        agi_share_path=Path("cluster-share"),
+        share_root_path=lambda: share,
+        user="agi",
+        password=None,
+        ssh_key_path=None,
+        app_settings_file=tmp_path / "app_settings.toml",
+    )
+
+    orchestrate_cluster.render_cluster_settings_ui(env, deps)
+
+    cluster = fake_st.session_state.app_settings["cluster"]
+    assert "Existing session directory" not in fake_st.selectboxes
+    assert any("No existing workflow session directories found" in info for info in fake_st.infos)
+    assert cluster["workflow_session"] == "manual-session"
+    assert cluster["workers_data_path"] == "cluster-share/agi/demo_project/manual-session/workers"
+
+
 def test_render_cluster_settings_ui_preserves_explicit_cluster_values_over_lan_discovery(monkeypatch, tmp_path):
     fake_st = _FakeStreamlit(
         widget_values={


### PR DESCRIPTION
## Summary
- add an ORCHESTRATE picker for existing workflow session directories when the session policy is `select`
- keep manual/latest behavior non-destructive with a `Manual / latest` option
- show a compact message when no existing workflow session directories are available to select

## Validation
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_orchestrate_cluster.py::test_render_cluster_settings_ui_empty_workflow_session_auto_selects_latest test/test_orchestrate_cluster.py::test_render_cluster_settings_ui_selects_existing_workflow_session_directory test/test_orchestrate_cluster.py::test_render_cluster_settings_ui_reports_missing_existing_session_directories`
- `uv --preview-features extra-build-dependencies run --extra dev ruff check src/agilab/orchestrate/orchestrate_cluster.py test/test_orchestrate_cluster.py`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_orchestrate_cluster.py`
- `./dev impact --files src/agilab/orchestrate/orchestrate_cluster.py test/test_orchestrate_cluster.py`
- `./dev scope`
- `UV_PYTHON=3.13 uv --preview-features extra-build-dependencies run --with playwright python tools/agilab_widget_robot.py --apps flight_telemetry_project --pages ORCHESTRATE --apps-pages none --json --json-output /tmp/agilab-orchestrate-dir-picker-robot.json --progress-log /tmp/agilab-orchestrate-dir-picker-robot.ndjson --interaction-mode actionability --action-button-policy trial --runtime-isolation isolated --combination-mode off --browser-error-check --failure-bundle-dir /tmp/agilab-orchestrate-dir-picker-failures --screenshot-dir /tmp/agilab-orchestrate-dir-picker-screenshots`
- `git diff --check`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --staged`
- `./dev scope --staged`