### PR TITLE
Fix ORCHESTRATE workflows path root

### DIFF
--- a/src/agilab/orchestrate/orchestrate_cluster.py
+++ b/src/agilab/orchestrate/orchestrate_cluster.py
@@ -49,8 +49,10 @@ POOL_EXECUTOR_ENV = "AGILAB_POOL_EXECUTOR"
 POOL_EXECUTOR_OPTIONS = ("auto", "process", "thread")
 WORKFLOW_SESSION_POLICY_ENV = "AGI_WORKFLOW_SESSION_POLICY"
 WORKFLOW_SESSION_ENV = "AGI_WORKFLOW_SESSION"
+WORKFLOW_ID_ENV = "AGI_WORKFLOW_ID"
 WORKFLOW_SESSION_POLICY_OPTIONS = ("new", "last", "select")
 WORKFLOW_SESSION_DEFAULT_POLICY = "new"
+WORKFLOW_DEFAULT_ID = "workflows"
 WORKFLOW_SESSION_DIR = "workflows"
 WORKFLOW_SESSION_LEGACY_WORKERS_DIR = "workers"
 WORKFLOW_PROJECT_SUFFIXES = ("_project", "-project")
@@ -525,6 +527,7 @@ def _workers_data_path_should_follow_workflow_session(
     user: Any,
     workflow_name: Any,
     project_name: Any = None,
+    legacy_workflow_names: tuple[Any, ...] = (),
 ) -> bool:
     text = _clean_path_text(value)
     if not text:
@@ -538,17 +541,31 @@ def _workers_data_path_should_follow_workflow_session(
     if data_path == cluster_share:
         return True
     module_name = _workflow_module_component(workflow_name if project_name is None else project_name)
-    sessions_root = _workflow_sessions_root(cluster_share, user, workflow_name)
-    legacy_sessions_root = _legacy_workflow_sessions_root(cluster_share, user, workflow_name)
-    return (
-        _path_matches_workflow_session_leaf(data_path, sessions_root, module_name)
-        or _path_matches_workflow_session_leaf(data_path, sessions_root, WORKFLOW_SESSION_LEGACY_WORKERS_DIR)
-        or _path_matches_workflow_session_leaf(data_path, legacy_sessions_root, module_name)
-        or _path_matches_workflow_session_leaf(
-            data_path,
-            legacy_sessions_root,
-            WORKFLOW_SESSION_LEGACY_WORKERS_DIR,
-        )
+    candidate_roots = [
+        _workflow_sessions_root(cluster_share, user, workflow_name),
+        _legacy_workflow_sessions_root(cluster_share, user, workflow_name),
+    ]
+    seen_roots = {root.resolve(strict=False) for root in candidate_roots}
+    for legacy_workflow_name in legacy_workflow_names:
+        for candidate_root in (
+            _workflow_sessions_root(cluster_share, user, legacy_workflow_name),
+            _legacy_workflow_sessions_root(cluster_share, user, legacy_workflow_name),
+        ):
+            resolved_candidate_root = candidate_root.resolve(strict=False)
+            if resolved_candidate_root not in seen_roots:
+                candidate_roots.append(candidate_root)
+                seen_roots.add(resolved_candidate_root)
+    return any(
+        _path_matches_workflow_session_leaf(data_path, candidate_root, module_name)
+        or _path_matches_workflow_session_leaf(data_path, candidate_root, WORKFLOW_SESSION_LEGACY_WORKERS_DIR)
+        for candidate_root in candidate_roots
+    )
+
+
+def _orchestrate_workflow_id(cluster_params: dict[str, Any], env: Any) -> str:
+    return _safe_workflow_component(
+        cluster_params.get("workflow_id") or _env_value(env, WORKFLOW_ID_ENV),
+        WORKFLOW_DEFAULT_ID,
     )
 
 
@@ -1078,6 +1095,8 @@ def render_cluster_settings_ui(env: Any, deps: OrchestrateClusterDeps, *, show_r
 
     cluster_params = app_settings.setdefault("cluster", {})
     app_state_name = Path(str(env.app)).name if env.app else ""
+    workflow_id = _orchestrate_workflow_id(cluster_params, env)
+    cluster_params["workflow_id"] = workflow_id
     widget_keys = cluster_widget_keys(app_state_name)
 
     boolean_params = ["cython", "pool"]
@@ -1492,13 +1511,13 @@ def render_cluster_settings_ui(env: Any, deps: OrchestrateClusterDeps, *, show_r
         workflow_session_options: list[str] = []
         if cluster_share_ready and cluster_share_candidate is not None:
             workflow_session_options = _workflow_session_names(
-                _workflow_sessions_root(cluster_share_candidate, sanitized_user, app_state_name)
+                _workflow_sessions_root(cluster_share_candidate, sanitized_user, workflow_id)
             )
             try:
                 workflow_workers_path, workflow_session, workflow_policy = _resolve_workflow_session_module_path(
                     cluster_share_candidate,
                     user=sanitized_user,
-                    workflow_name=app_state_name,
+                    workflow_name=workflow_id,
                     project_name=app_state_name,
                     policy=workflow_policy,
                     selected_session=workflow_session,
@@ -1555,7 +1574,7 @@ def render_cluster_settings_ui(env: Any, deps: OrchestrateClusterDeps, *, show_r
                 st.session_state.pop(workflow_existing_session_key, None)
                 st.info(
                     "No existing workflow session directories found under "
-                    f"`{_workflow_sessions_root(cluster_share_candidate, sanitized_user, app_state_name)}`."
+                    f"`{_workflow_sessions_root(cluster_share_candidate, sanitized_user, workflow_id)}`."
                 )
         else:
             st.session_state.pop(workflow_existing_session_key, None)
@@ -1577,7 +1596,7 @@ def render_cluster_settings_ui(env: Any, deps: OrchestrateClusterDeps, *, show_r
                 workflow_workers_path, workflow_session, workflow_policy = _resolve_workflow_session_module_path(
                     cluster_share_candidate,
                     user=sanitized_user,
-                    workflow_name=app_state_name,
+                    workflow_name=workflow_id,
                     project_name=app_state_name,
                     policy=workflow_policy,
                     selected_session=workflow_session,
@@ -1605,8 +1624,9 @@ def render_cluster_settings_ui(env: Any, deps: OrchestrateClusterDeps, *, show_r
                 current_workers_data_path,
                 env,
                 user=sanitized_user,
-                workflow_name=app_state_name,
+                workflow_name=workflow_id,
                 project_name=app_state_name,
+                legacy_workflow_names=(app_state_name,),
             ):
                 cluster_params["workers_data_path"] = workflow_workers_data_path
                 st.session_state[workers_data_path_widget_key] = workflow_workers_data_path

--- a/test/test_orchestrate_cluster.py
+++ b/test/test_orchestrate_cluster.py
@@ -443,7 +443,7 @@ def test_orchestrate_cluster_helper_edge_branches(tmp_path, monkeypatch):
 
 def test_workflow_session_module_path_policies(tmp_path):
     share = tmp_path / "clustershare" / "agi"
-    sessions_root = share / "demo_project"
+    sessions_root = share / "workflows"
     old_session = sessions_root / "old-run"
     latest_session = sessions_root / "latest-run"
     old_session.mkdir(parents=True)
@@ -453,11 +453,27 @@ def test_workflow_session_module_path_policies(tmp_path):
 
     assert orchestrate_cluster._workflow_module_component("demo_project") == "demo"
     assert orchestrate_cluster._workflow_module_component("demo-app-project") == "demo-app"
+    assert orchestrate_cluster._workflow_module_component("flight_telemetry_project") == "flight_telemetry"
+    assert orchestrate_cluster._orchestrate_workflow_id({}, SimpleNamespace()) == "workflows"
+    assert (
+        orchestrate_cluster._orchestrate_workflow_id(
+            {},
+            SimpleNamespace(envars={"AGI_WORKFLOW_ID": "mission flow"}),
+        )
+        == "mission-flow"
+    )
+    assert (
+        orchestrate_cluster._orchestrate_workflow_id(
+            {"workflow_id": "stored flow"},
+            SimpleNamespace(envars={"AGI_WORKFLOW_ID": "env-flow"}),
+        )
+        == "stored-flow"
+    )
 
     path, session, policy = orchestrate_cluster._resolve_workflow_session_module_path(
         share,
         user="agi",
-        workflow_name="demo_project",
+        workflow_name="workflows",
         project_name="demo_project",
         policy="last",
         create=False,
@@ -470,7 +486,7 @@ def test_workflow_session_module_path_policies(tmp_path):
     path, session, policy = orchestrate_cluster._resolve_workflow_session_module_path(
         share,
         user="agi",
-        workflow_name="demo_project",
+        workflow_name="workflows",
         project_name="demo_project",
         policy="select",
         selected_session="manual/run 1",
@@ -484,7 +500,7 @@ def test_workflow_session_module_path_policies(tmp_path):
     path, session, policy = orchestrate_cluster._resolve_workflow_session_module_path(
         share.parent,
         user="agi",
-        workflow_name="demo_project",
+        workflow_name="workflows",
         project_name="demo_project",
         policy="unknown",
         create=False,
@@ -494,55 +510,75 @@ def test_workflow_session_module_path_policies(tmp_path):
     assert session == "fresh-run"
     assert path == sessions_root / "fresh-run" / "demo"
 
+    path, session, policy = orchestrate_cluster._resolve_workflow_session_module_path(
+        share,
+        user="agi",
+        workflow_name="workflows",
+        project_name="flight_telemetry_project",
+        policy="select",
+        selected_session="20260618T093102Z-492de776",
+        create=False,
+    )
+    assert policy == "select"
+    assert session == "20260618T093102Z-492de776"
+    assert path == share / "workflows" / "20260618T093102Z-492de776" / "flight_telemetry"
+
     env = SimpleNamespace(home_abs=tmp_path, AGI_CLUSTER_SHARE=str(share), AGI_LOCAL_SHARE=str(tmp_path / "localshare"))
     assert orchestrate_cluster._workers_data_path_should_follow_workflow_session(
         "clustershare/agi",
         env,
         user="agi",
-        workflow_name="demo_project",
+        workflow_name="workflows",
         project_name="demo_project",
+        legacy_workflow_names=("demo_project",),
     )
     assert orchestrate_cluster._workers_data_path_should_follow_workflow_session(
-        "clustershare/agi/demo_project/latest-run/demo",
+        "clustershare/agi/workflows/latest-run/demo",
         env,
         user="agi",
-        workflow_name="demo_project",
+        workflow_name="workflows",
         project_name="demo_project",
+        legacy_workflow_names=("demo_project",),
     )
     assert orchestrate_cluster._workers_data_path_should_follow_workflow_session(
         "clustershare/agi/demo_project/latest-run/workers",
         env,
         user="agi",
-        workflow_name="demo_project",
+        workflow_name="workflows",
         project_name="demo_project",
+        legacy_workflow_names=("demo_project",),
     )
     assert orchestrate_cluster._workers_data_path_should_follow_workflow_session(
         "clustershare/agi/workflows/demo_project/latest-run/workers",
         env,
         user="agi",
-        workflow_name="demo_project",
+        workflow_name="workflows",
         project_name="demo_project",
+        legacy_workflow_names=("demo_project",),
     )
     assert not orchestrate_cluster._workers_data_path_should_follow_workflow_session(
-        "clustershare/agi/demo_project/latest-run/custom-module",
+        "clustershare/agi/workflows/latest-run/custom-module",
         env,
         user="agi",
-        workflow_name="demo_project",
+        workflow_name="workflows",
         project_name="demo_project",
+        legacy_workflow_names=("demo_project",),
     )
     assert not orchestrate_cluster._workers_data_path_should_follow_workflow_session(
-        "clustershare/agi/demo_project/latest-run/demo/custom-data",
+        "clustershare/agi/workflows/latest-run/demo/custom-data",
         env,
         user="agi",
-        workflow_name="demo_project",
+        workflow_name="workflows",
         project_name="demo_project",
+        legacy_workflow_names=("demo_project",),
     )
     assert not orchestrate_cluster._workers_data_path_should_follow_workflow_session(
         "/external/data",
         env,
         user="agi",
-        workflow_name="demo_project",
+        workflow_name="workflows",
         project_name="demo_project",
+        legacy_workflow_names=("demo_project",),
     )
 
 
@@ -1316,11 +1352,11 @@ def test_render_cluster_settings_ui_populates_empty_cluster_from_lan_discovery(m
     cluster = fake_st.session_state.app_settings["cluster"]
     assert cluster["scheduler"] == "192.168.3.103:8786"
     assert cluster["workers"] == {"192.168.3.35": 1}
-    assert cluster["workers_data_path"] == "clustershare/agi/demo_project/session-a/demo"
+    assert cluster["workers_data_path"] == "clustershare/agi/workflows/session-a/demo"
     assert fake_st.session_state["cluster_scheduler__demo_project"] == "192.168.3.103:8786"
     assert fake_st.session_state["cluster_workers__demo_project"] == '{\n  "192.168.3.35": 1\n}'
     assert fake_st.session_state["cluster_workers_data_path__demo_project"] == (
-        "clustershare/agi/demo_project/session-a/demo"
+        "clustershare/agi/workflows/session-a/demo"
     )
 
 
@@ -1378,7 +1414,7 @@ def test_render_cluster_settings_ui_empty_workflow_session_auto_selects_latest(m
     app_name = "demo_project"
     widget_keys = orchestrate_cluster.cluster_widget_keys(app_name)
     share = tmp_path / "cluster-share"
-    sessions_root = share / "agi" / app_name
+    sessions_root = share / "agi" / "workflows"
     old_session = sessions_root / "session-a"
     latest_session = sessions_root / "session-b"
     old_session.mkdir(parents=True)
@@ -1438,15 +1474,15 @@ def test_render_cluster_settings_ui_empty_workflow_session_auto_selects_latest(m
     cluster = fake_st.session_state.app_settings["cluster"]
     assert cluster["workflow_session_policy"] == "select"
     assert cluster["workflow_session"] == "session-b"
-    assert cluster["workers_data_path"] == "cluster-share/agi/demo_project/session-b/demo"
+    assert cluster["workers_data_path"] == "cluster-share/agi/workflows/session-b/demo"
 
 
 def test_render_cluster_settings_ui_preserves_custom_workers_data_path_under_workflow_root(monkeypatch, tmp_path):
     app_name = "demo_project"
     widget_keys = orchestrate_cluster.cluster_widget_keys(app_name)
     share = tmp_path / "cluster-share"
-    (share / "agi" / app_name / "session-a").mkdir(parents=True)
-    custom_data_path = "cluster-share/agi/demo_project/session-a/demo/custom-data"
+    (share / "agi" / "workflows" / "session-a").mkdir(parents=True)
+    custom_data_path = "cluster-share/agi/workflows/session-a/demo/custom-data"
     fake_st = _FakeStreamlit(
         widget_values={
             widget_keys["cluster_enabled"]: True,
@@ -1505,7 +1541,7 @@ def test_render_cluster_settings_ui_selects_existing_workflow_session_directory(
     app_name = "demo_project"
     widget_keys = orchestrate_cluster.cluster_widget_keys(app_name)
     share = tmp_path / "cluster-share"
-    sessions_root = share / "agi" / app_name
+    sessions_root = share / "agi" / "workflows"
     old_session = sessions_root / "session-a"
     latest_session = sessions_root / "session-b"
     old_session.mkdir(parents=True)
@@ -1561,7 +1597,7 @@ def test_render_cluster_settings_ui_selects_existing_workflow_session_directory(
     assert "Existing session directory" in fake_st.selectboxes
     assert fake_st.session_state[widget_keys["workflow_session"]] == "session-a"
     assert cluster["workflow_session"] == "session-a"
-    assert cluster["workers_data_path"] == "cluster-share/agi/demo_project/session-a/demo"
+    assert cluster["workers_data_path"] == "cluster-share/agi/workflows/session-a/demo"
 
 
 def test_render_cluster_settings_ui_reports_missing_existing_session_directories(monkeypatch, tmp_path):
@@ -1618,7 +1654,7 @@ def test_render_cluster_settings_ui_reports_missing_existing_session_directories
     assert "Existing session directory" not in fake_st.selectboxes
     assert any("No existing workflow session directories found" in info for info in fake_st.infos)
     assert cluster["workflow_session"] == "manual-session"
-    assert cluster["workers_data_path"] == "cluster-share/agi/demo_project/manual-session/demo"
+    assert cluster["workers_data_path"] == "cluster-share/agi/workflows/manual-session/demo"
 
 
 def test_render_cluster_settings_ui_preserves_explicit_cluster_values_over_lan_discovery(monkeypatch, tmp_path):
@@ -1843,11 +1879,11 @@ def test_render_cluster_settings_ui_refresh_replaces_stale_lan_discovery_state(m
     cluster = fake_st.session_state.app_settings["cluster"]
     assert cluster["scheduler"] == "192.168.3.103:8786"
     assert cluster["workers"] == {"192.168.3.35": 1}
-    assert cluster["workers_data_path"] == "clustershare/agi/demo_project/session-a/demo"
+    assert cluster["workers_data_path"] == "clustershare/agi/workflows/session-a/demo"
     assert fake_st.session_state[widget_keys["scheduler"]] == "192.168.3.103:8786"
     assert fake_st.session_state[widget_keys["workers"]] == '{\n  "192.168.3.35": 1\n}'
     assert fake_st.session_state[widget_keys["workers_data_path"]] == (
-        "clustershare/agi/demo_project/session-a/demo"
+        "clustershare/agi/workflows/session-a/demo"
     )
     assert refresh_calls
     assert refresh_calls[0][1]["remote_user"] == "agi"
@@ -2123,7 +2159,7 @@ def test_render_cluster_settings_ui_creates_missing_cluster_share(monkeypatch, t
     cluster = fake_st.session_state.app_settings["cluster"]
     assert missing_share.is_dir()
     assert cluster["cluster_enabled"] is True
-    assert cluster["workers_data_path"] == str(missing_share / "demo_project" / "session-a" / "demo")
+    assert cluster["workers_data_path"] == str(missing_share / "workflows" / "session-a" / "demo")
     assert fake_st.errors == []
 
 
@@ -2182,9 +2218,9 @@ def test_render_cluster_settings_ui_replaces_stale_local_workers_data_path(monke
     orchestrate_cluster.render_cluster_settings_ui(env, deps)
 
     cluster = fake_st.session_state.app_settings["cluster"]
-    assert cluster["workers_data_path"] == "clustershare/agi/demo_project/session-a/demo"
+    assert cluster["workers_data_path"] == "clustershare/agi/workflows/session-a/demo"
     assert fake_st.session_state[widget_keys["workers_data_path"]] == (
-        "clustershare/agi/demo_project/session-a/demo"
+        "clustershare/agi/workflows/session-a/demo"
     )
 
 
@@ -2660,7 +2696,7 @@ def test_workflow_session_helper_remaining_edges(monkeypatch, tmp_path):
     workers_path, session, policy = orchestrate_cluster._resolve_workflow_session_module_path(
         share,
         user="agi",
-        workflow_name="demo_project",
+        workflow_name="workflows",
         project_name="demo_project",
         policy="select",
         create=False,
@@ -2668,7 +2704,7 @@ def test_workflow_session_helper_remaining_edges(monkeypatch, tmp_path):
     )
     assert policy == "select"
     assert session == "fresh-run"
-    assert workers_path == share / "agi" / "demo_project" / "fresh-run" / "demo"
+    assert workers_path == share / "agi" / "workflows" / "fresh-run" / "demo"
     assert not workers_path.exists()
 
     env_with_setting = SimpleNamespace(home_abs=tmp_path, AGI_CLUSTER_SHARE=str(share))
@@ -2688,16 +2724,17 @@ def test_workflow_session_helper_remaining_edges(monkeypatch, tmp_path):
     assert (
         orchestrate_cluster._workflow_workers_data_path_text(
             share,
-            share / "agi" / "demo_project" / "session-a" / "demo",
+            share / "agi" / "workflows" / "session-a" / "demo",
             env_without_setting,
         )
-        == "cluster-share/agi/demo_project/session-a/demo"
+        == "cluster-share/agi/workflows/session-a/demo"
     )
     assert not orchestrate_cluster._workers_data_path_should_follow_workflow_session(
         "/external/data",
         env_without_setting,
         user="agi",
-        workflow_name="demo_project",
+        workflow_name="workflows",
+        project_name="demo_project",
     )
 
 
@@ -2748,7 +2785,7 @@ def test_render_cluster_settings_ui_uses_workflow_session_env_defaults(monkeypat
     cluster = fake_st.session_state.app_settings["cluster"]
     assert cluster["workflow_session_policy"] == "select"
     assert cluster["workflow_session"] == "env-session"
-    assert cluster["workers_data_path"] == "cluster-share/agi/demo_project/env-session/demo"
+    assert cluster["workers_data_path"] == "cluster-share/agi/workflows/env-session/demo"
     assert fake_st.session_state[widget_keys["workflow_session_policy"]] == "select"
     assert fake_st.session_state[widget_keys["workflow_session"]] == "env-session"
 


### PR DESCRIPTION
## Summary
- generate ORCHESTRATE worker data paths as clustershare/<user>/<workflow id>/<session>/<module>
- resolve workflow id from cluster settings or AGI_WORKFLOW_ID, defaulting to workflows for the current UX
- derive module from the active project name without the _project suffix, e.g. flight_telemetry_project -> flight_telemetry
- keep migration for prior generated layouts such as .../<project>/<session>/workers and .../workflows/<project>/<session>/workers while preserving custom paths

## Validation
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_orchestrate_cluster.py
- uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files src/agilab/orchestrate/orchestrate_cluster.py test/test_orchestrate_cluster.py
- uv --preview-features extra-build-dependencies run ruff check src/agilab/orchestrate/orchestrate_cluster.py test/test_orchestrate_cluster.py
- git diff --check