### PR TITLE
Add exact regression for stale worker data path

### DIFF
--- a/test/test_orchestrate_cluster.py
+++ b/test/test_orchestrate_cluster.py
@@ -611,6 +611,13 @@ def test_workers_data_path_regression_rewrites_misplaced_managed_share_values(tm
         workflow_name="workflows",
         project_name="flight_telemetry_project",
     )
+    assert orchestrate_cluster._workers_data_path_should_follow_workflow_session(
+        "clustershare/agi/workflows/flight_telemetry_project/20260618T093102Z-492de776/workers",
+        env,
+        user="agi",
+        workflow_name="workflows",
+        project_name="flight_telemetry_project",
+    )
     assert not orchestrate_cluster._workers_data_path_should_follow_workflow_session(
         "clustershare/agi/workflows/20260618T093102Z-492de776/flight_telemetry/custom-data",
         env,
@@ -1475,12 +1482,12 @@ def test_render_cluster_settings_ui_empty_workflow_session_auto_selects_latest(m
                     "cluster_enabled": True,
                     "workflow_session_policy": "select",
                     "workflow_session": "session-a",
-                    "workers_data_path": "cluster-share/agi/workflows/demo_project/session-a/stale",
+                    "workers_data_path": "cluster-share/agi/workflows/demo_project/session-a/workers",
                 }
             },
             widget_keys["workflow_session_policy"]: "select",
             widget_keys["workflow_session"]: "session-a",
-            widget_keys["workers_data_path"]: "cluster-share/agi/workflows/demo_project/session-a/stale",
+            widget_keys["workers_data_path"]: "cluster-share/agi/workflows/demo_project/session-a/workers",
             "benchmark": False,
         },
     )


### PR DESCRIPTION
## Summary
- adds exact regression coverage for the stale path shape still seen in the UI: clustershare/<user>/<workflow>/<project>/<session>/workers
- verifies ORCHESTRATE rewrites that state to clustershare/<user>/<workflow>/<session>/<module>

## Validation
- fresh clone: /Users/agi/PycharmProjects/agilab-validation-20260618-stale-worker-path
- uv --preview-features extra-build-dependencies run --extra ui pytest -q -o addopts='' test/test_orchestrate_cluster.py
- uv --preview-features extra-build-dependencies run --extra ui --extra dev python tools/bugfix_validate.py --base origin/main --run
- git diff --check origin/main...HEAD