### PR TITLE
[codex] Fix worker share root normalization

### DIFF
--- a/.claude/skills/agilab-runbook/SKILL.md
+++ b/.claude/skills/agilab-runbook/SKILL.md
@@ -49,10 +49,11 @@ Use this skill when you need repo-specific “how we do things” guidance in `a
   fixing bootstrap code because `st.session_state["env"]` and `env.active_app` can retain
   stale paths across reruns.
 - **Worker data path resolution layer**: in cluster and workflow execution, UI pages may
-  choose and persist `workers_data_path`, but app `data_in` and `data_out` resolution belongs
-  to the shared worker runtime: `BaseWorker._resolve_data_dir` and
-  `agi_node.agi_dispatcher.base_worker_path_support`. The canonical workflow share root passed
-  as `workers_data_path` is `clustershare/<user>/<workflow-id>/<session>`. App module
+  choose and persist `workers_data_path`, but canonical share-root storage and app
+  `data_in` / `data_out` resolution belong to the shared worker runtime:
+  `runtime_misc_support.initialize_runtime_state`, `BaseWorker._resolve_data_dir`,
+  and `agi_node.agi_dispatcher.base_worker_path_support`. The canonical workflow share
+  root passed as `workers_data_path` is `clustershare/<user>/<workflow-id>/<session>`. App module
   subdirectories are appended by app arguments, where the module is the project name without
   the `_project` suffix, yielding `clustershare/<user>/<workflow-id>/<session>/<module>/...`
   for app data. Do not fix duplicated paths such as `<module>/<module>/dataset`, stale

--- a/.codex/skills/agilab-runbook/SKILL.md
+++ b/.codex/skills/agilab-runbook/SKILL.md
@@ -49,10 +49,11 @@ Use this skill when you need repo-specific “how we do things” guidance in `a
   fixing bootstrap code because `st.session_state["env"]` and `env.active_app` can retain
   stale paths across reruns.
 - **Worker data path resolution layer**: in cluster and workflow execution, UI pages may
-  choose and persist `workers_data_path`, but app `data_in` and `data_out` resolution belongs
-  to the shared worker runtime: `BaseWorker._resolve_data_dir` and
-  `agi_node.agi_dispatcher.base_worker_path_support`. The canonical workflow share root passed
-  as `workers_data_path` is `clustershare/<user>/<workflow-id>/<session>`. App module
+  choose and persist `workers_data_path`, but canonical share-root storage and app
+  `data_in` / `data_out` resolution belong to the shared worker runtime:
+  `runtime_misc_support.initialize_runtime_state`, `BaseWorker._resolve_data_dir`,
+  and `agi_node.agi_dispatcher.base_worker_path_support`. The canonical workflow share
+  root passed as `workers_data_path` is `clustershare/<user>/<workflow-id>/<session>`. App module
   subdirectories are appended by app arguments, where the module is the project name without
   the `_project` suffix, yielding `clustershare/<user>/<workflow-id>/<session>/<module>/...`
   for app data. Do not fix duplicated paths such as `<module>/<module>/dataset`, stale

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -387,11 +387,11 @@ Use this runbook whenever you:
   an explicit saved value with a recomputed default on render; if a field is intentionally derived,
   make that dependency explicit in the UI instead of presenting it as a normal independent input.
 - **Worker data path resolution layer**: In cluster and workflow execution,
-  UI pages may choose and persist `workers_data_path`, but app `data_in` and
-  `data_out` resolution belongs to the shared worker runtime:
-  `BaseWorker._resolve_data_dir` and
-  `agi_node.agi_dispatcher.base_worker_path_support`. The canonical workflow
-  share root passed as `workers_data_path` is
+  UI pages may choose and persist `workers_data_path`, but canonical share-root
+  storage and app `data_in` / `data_out` resolution belong to the shared worker
+  runtime: `runtime_misc_support.initialize_runtime_state`,
+  `BaseWorker._resolve_data_dir`, and `agi_node.agi_dispatcher.base_worker_path_support`.
+  The canonical workflow share root passed as `workers_data_path` is
   `clustershare/<user>/<workflow-id>/<session>`. App module subdirectories are
   appended by app arguments, where the module is the project name without the
   `_project` suffix, yielding

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime/runtime_misc_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime/runtime_misc_support.py
@@ -15,7 +15,7 @@ import traceback
 import urllib.error
 import urllib.request
 from datetime import timedelta
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Any, Callable, List, Optional, cast
 
 CAPACITY_MODEL_MANIFEST_SCHEMA = "agilab.capacity_model_manifest.v1"
@@ -357,6 +357,67 @@ def bootstrap_capacity_predictor(
     return predictor
 
 
+def _pure_path_from_text(value: str) -> PurePosixPath | PureWindowsPath:
+    if "\\" in value or re.match(r"^[A-Za-z]:[\\/]", value):
+        return PureWindowsPath(value)
+    return PurePosixPath(value)
+
+
+def _first_relative_data_path_segment(value: Any) -> str | None:
+    if not isinstance(value, (str, os.PathLike)):
+        return None
+    raw = os.fspath(value)
+    if not isinstance(raw, str):
+        return None
+    text = raw.strip()
+    if not text:
+        return None
+    path = _pure_path_from_text(text)
+    if path.is_absolute():
+        return None
+    parts = tuple(part for part in path.parts if part not in {"", "."})
+    if not parts or parts[0] == "..":
+        return None
+    return parts[0]
+
+
+def _worker_data_path_module_candidates(
+    *arg_maps: dict[str, Any] | None,
+) -> set[str]:
+    candidates: set[str] = set()
+    for arg_map in arg_maps:
+        if not isinstance(arg_map, dict):
+            continue
+        for key in ("data_in", "data_out"):
+            segment = _first_relative_data_path_segment(arg_map.get(key))
+            if segment:
+                candidates.add(segment)
+    return candidates
+
+
+def normalize_workers_data_path(
+    workers_data_path: str | None,
+    *,
+    args: dict[str, Any],
+    worker_args: dict[str, Any] | None = None,
+) -> str | None:
+    """Return the workflow session root for module-scoped worker data paths."""
+    if workers_data_path is None:
+        return None
+    text = str(workers_data_path).strip()
+    if not text:
+        return workers_data_path
+
+    path = _pure_path_from_text(text)
+    module_candidates = _worker_data_path_module_candidates(worker_args, args)
+    if path.name not in module_candidates:
+        return workers_data_path
+    parent = path.parent
+    if str(parent) in {"", "."}:
+        return workers_data_path
+    return str(parent)
+
+
 def initialize_runtime_state(
     agi_cls: Any,
     env: Any,
@@ -382,7 +443,11 @@ def initialize_runtime_state(
     agi_cls._worker_args = worker_args if worker_args is not None else agi_cls._args
     agi_cls.verbose = verbose
     agi_cls._workers = workers
-    agi_cls._workers_data_path = workers_data_path
+    agi_cls._workers_data_path = normalize_workers_data_path(
+        workers_data_path,
+        args=agi_cls._args,
+        worker_args=agi_cls._worker_args,
+    )
     agi_cls._run_time = {}
 
 

--- a/src/agilab/core/test/test_agi_distributor_runtime_misc_support.py
+++ b/src/agilab/core/test/test_agi_distributor_runtime_misc_support.py
@@ -539,6 +539,78 @@ def test_initialize_runtime_state_sets_common_runtime_fields():
     assert calls["info"] == [("runtime for %s v%s", "demo", 1)]
 
 
+def test_initialize_runtime_state_normalizes_workflow_module_workers_data_path():
+    agi_cls = SimpleNamespace()
+    env = SimpleNamespace(
+        manager_path=Path("/tmp/manager"),
+        target="flight_trajectory_project",
+        verbose=0,
+    )
+    session_root = Path("/Users/agi/clustershare/agi/workflows/20260618T093102Z-492de776")
+
+    runtime_misc_support.initialize_runtime_state(
+        agi_cls,
+        env,
+        workers={"127.0.0.1": 1},
+        verbose=0,
+        rapids_enabled=False,
+        args={"data_in": "flight_trajectory/dataset"},
+        worker_args={"data_in": "flight_trajectory/dataset"},
+        workers_data_path=str(session_root / "flight_trajectory"),
+    )
+
+    assert agi_cls._workers_data_path == str(session_root)
+
+
+def test_initialize_runtime_state_preserves_workflow_session_workers_data_path():
+    agi_cls = SimpleNamespace()
+    env = SimpleNamespace(
+        manager_path=Path("/tmp/manager"),
+        target="flight_trajectory_project",
+        verbose=0,
+    )
+    session_root = Path("/Users/agi/clustershare/agi/workflows/20260618T093102Z-492de776")
+
+    runtime_misc_support.initialize_runtime_state(
+        agi_cls,
+        env,
+        workers={"127.0.0.1": 1},
+        verbose=0,
+        rapids_enabled=False,
+        args={"data_in": "flight_trajectory/dataset"},
+        worker_args={"data_in": "flight_trajectory/dataset"},
+        workers_data_path=str(session_root),
+    )
+
+    assert agi_cls._workers_data_path == str(session_root)
+
+
+def test_initialize_runtime_state_normalizes_windows_module_workers_data_path():
+    agi_cls = SimpleNamespace()
+    env = SimpleNamespace(
+        manager_path=Path("/tmp/manager"),
+        target="flight_trajectory_project",
+        verbose=0,
+    )
+    session_root = (
+        r"C:\Users\agi\clustershare\agi\workflows"
+        r"\20260618T093102Z-492de776"
+    )
+
+    runtime_misc_support.initialize_runtime_state(
+        agi_cls,
+        env,
+        workers={"127.0.0.1": 1},
+        verbose=0,
+        rapids_enabled=False,
+        args={"data_in": "flight_trajectory/dataset"},
+        worker_args={"data_in": "flight_trajectory/dataset"},
+        workers_data_path=rf"{session_root}\flight_trajectory",
+    )
+
+    assert agi_cls._workers_data_path == session_root
+
+
 def test_configure_runtime_mode_supports_default_dask_mode():
     agi_cls = SimpleNamespace(_RUN_MASK=0b001111, RAPIDS_MODE=16, DASK_MODE=4)
     env = SimpleNamespace(mode2int=lambda value: {"d": 4}[value])


### PR DESCRIPTION
## Summary
- Normalize module-scoped `workers_data_path` in `runtime_misc_support.initialize_runtime_state` so the stored share root is the workflow session root.
- Add regressions for the reported `flight_trajectory` shape, already-canonical session roots, and Windows-style path strings.
- Tighten AGENTS/runbook skill guidance to name the runtime-state layer as part of the worker path contract.

## Root Cause
The previous fix corrected worker-side path resolution, but `AGI.run` could still store a stale module-scoped share root such as `.../<session>/flight_trajectory` in `_workers_data_path`. Deployment and remote-share revalidation then used that wrong root even though `data_in` resolved later.

## Validation
- Reproduced the failing runtime state before the implementation patch.
- `uv --preview-features extra-build-dependencies run --no-project --with-editable ./src/agilab/core/agi-env --with-editable ./src/agilab/core/agi-node --with-editable ./src/agilab/core/agi-cluster --with pytest --with pytest-asyncio --with sqlalchemy python -m pytest -q -o addopts='' src/agilab/core/test/test_agi_distributor_runtime_misc_support.py`
- `uv --preview-features extra-build-dependencies run --no-project --with-editable ./src/agilab/core/agi-env --with pytest python -m pytest -q -o addopts='' src/agilab/core/test/test_base_worker_path_support.py`
- `uv --preview-features extra-build-dependencies run --no-project --with-editable ./src/agilab/core/agi-env --with-editable ./src/agilab/core/agi-node --with-editable ./src/agilab/core/agi-cluster --with pytest --with pytest-asyncio --with sqlalchemy python -m pytest -q -o addopts='' src/agilab/core/test/test_agi_distributor_run_api.py src/agilab/core/test/test_agi_distributor_run_request_support.py`
- `./dev test src/agilab/core/test`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile skills`
- `python3 tools/agent_instruction_contract.py --check`
- `uv --preview-features extra-build-dependencies run --extra dev ruff check src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime/runtime_misc_support.py src/agilab/core/test/test_agi_distributor_runtime_misc_support.py`
- `./dev scope --staged`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --staged`