### PR TITLE
Fix worker path widget state normalization

### DIFF
--- a/src/agilab/orchestrate/orchestrate_cluster.py
+++ b/src/agilab/orchestrate/orchestrate_cluster.py
@@ -1609,7 +1609,6 @@ def render_cluster_settings_ui(env: Any, deps: OrchestrateClusterDeps, *, show_r
             )
         ):
             workers_data_path_value = workflow_workers_data_path
-            st.session_state[workers_data_path_widget_key] = workflow_workers_data_path
         cluster_params["workers_data_path"] = workers_data_path_value
 
         workers_widget_key = widget_keys["workers"]

--- a/test/test_orchestrate_cluster.py
+++ b/test/test_orchestrate_cluster.py
@@ -45,6 +45,21 @@ class _State(dict):
         self[name] = value
 
 
+class _GuardedWidgetState(_State):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        object.__setattr__(self, "_instantiated_widget_keys", set())
+
+    def __setitem__(self, key, value):
+        if key in self._instantiated_widget_keys:
+            raise RuntimeError(f"{key} cannot be modified after widget instantiation")
+        super().__setitem__(key, value)
+
+    def mark_instantiated(self, key: str | None) -> None:
+        if key:
+            self._instantiated_widget_keys.add(key)
+
+
 class _Context:
     def __init__(self, st):
         self._st = st
@@ -150,6 +165,26 @@ class _FakeStreamlit:
 
     def error(self, text):
         self.errors.append(text)
+
+
+class _GuardedFakeStreamlit(_FakeStreamlit):
+    def __init__(self, *, widget_values=None, session_state=None, button_values=None):
+        super().__init__(
+            widget_values=widget_values,
+            session_state=session_state,
+            button_values=button_values,
+        )
+        self.session_state = _GuardedWidgetState(self.session_state)
+
+    def text_input(self, label, *, key=None, value="", **kwargs):
+        result = super().text_input(label, key=key, value=value, **kwargs)
+        self.session_state.mark_instantiated(key)
+        return result
+
+    def text_area(self, label, *, key=None, value="", **kwargs):
+        result = super().text_area(label, key=key, value=value, **kwargs)
+        self.session_state.mark_instantiated(key)
+        return result
 
 
 def test_compute_cluster_mode_uses_expected_bitmask():
@@ -1582,7 +1617,7 @@ def test_render_cluster_settings_ui_rewrites_stale_app_child_workers_data_path(m
     (share / "agi" / "workflows" / "session-a").mkdir(parents=True)
     stale_data_path = "cluster-share/agi/workflows/session-a/flight_trajectory/dataset"
     session_data_path = "cluster-share/agi/workflows/session-a"
-    fake_st = _FakeStreamlit(
+    fake_st = _GuardedFakeStreamlit(
         widget_values={
             widget_keys["cluster_enabled"]: True,
             widget_keys["cython"]: False,
@@ -1633,7 +1668,7 @@ def test_render_cluster_settings_ui_rewrites_stale_app_child_workers_data_path(m
     cluster = fake_st.session_state.app_settings["cluster"]
     assert cluster["workflow_session"] == "session-a"
     assert cluster["workers_data_path"] == session_data_path
-    assert fake_st.session_state[widget_keys["workers_data_path"]] == session_data_path
+    assert fake_st.session_state[widget_keys["workers_data_path"]] == stale_data_path
 
 
 def test_render_cluster_settings_ui_selects_existing_workflow_session_directory(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- Stop writing back to the Workers Data Path widget key after the Streamlit text input has been instantiated
- Keep normalized workflow-session root in persisted cluster settings so downstream app args still use clustershare/<user>/<workflow>/<session>
- Add a guarded Streamlit fake regression for the stale flight_trajectory worker data path case

## Validation
- Reproduced the logged failure with a guarded fake state: cluster_workers_data_path__flight_trajectory_project cannot be modified after widget instantiation
- uv --preview-features extra-build-dependencies run --extra ui pytest -q -o addopts='' test/test_orchestrate_cluster.py::test_render_cluster_settings_ui_rewrites_stale_app_child_workers_data_path
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_orchestrate_cluster.py
- uv --preview-features extra-build-dependencies run --extra ui pytest -q -o addopts='' test/test_orchestrate_cluster.py
- git diff --check
- ./dev scope
- uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files src/agilab/orchestrate/orchestrate_cluster.py test/test_orchestrate_cluster.py
