### PR TITLE
[codex] Update Streamlit widget state skill guidance

### DIFF
--- a/.claude/skills/agilab-streamlit-pages/SKILL.md
+++ b/.claude/skills/agilab-streamlit-pages/SKILL.md
@@ -74,6 +74,14 @@ Use this skill when editing:
 - Never assign `st.session_state["k"] = …` **after** a widget with `key="k"` was created.
   - Prefer `st.session_state.setdefault("k", default)` before the widget.
   - Or use widget return values and compute derived state separately.
+  - If a rendered widget value must be normalized into persisted settings such
+    as `app_settings["cluster"]` or `app_settings["args"]`, update only that
+    persisted payload after render. Do not write the normalized value back into
+    the widget key unless you do it before widget creation, behind a rerun, or
+    through a versioned replacement key.
+  - When fixing this class of bug, use a test fake or AppTest scenario that
+    raises on post-instantiation widget-key mutation; a permissive fake can hide
+    the real `StreamlitAPIException`.
 - Do not both pre-seed `st.session_state[key]` and pass a widget default/value/index for
   the same keyed widget. Pick one source of initialization:
   - use the widget default and leave `st.session_state` untouched before creation, or

--- a/.codex/skills/agilab-streamlit-pages/SKILL.md
+++ b/.codex/skills/agilab-streamlit-pages/SKILL.md
@@ -74,6 +74,14 @@ Use this skill when editing:
 - Never assign `st.session_state["k"] = …` **after** a widget with `key="k"` was created.
   - Prefer `st.session_state.setdefault("k", default)` before the widget.
   - Or use widget return values and compute derived state separately.
+  - If a rendered widget value must be normalized into persisted settings such
+    as `app_settings["cluster"]` or `app_settings["args"]`, update only that
+    persisted payload after render. Do not write the normalized value back into
+    the widget key unless you do it before widget creation, behind a rerun, or
+    through a versioned replacement key.
+  - When fixing this class of bug, use a test fake or AppTest scenario that
+    raises on post-instantiation widget-key mutation; a permissive fake can hide
+    the real `StreamlitAPIException`.
 - Do not both pre-seed `st.session_state[key]` and pass a widget default/value/index for
   the same keyed widget. Pick one source of initialization:
   - use the widget default and leave `st.session_state` untouched before creation, or


### PR DESCRIPTION
## Summary
- Record the Streamlit rule learned from the orchestrator regression: after a keyed widget is rendered, normalize values into persisted settings only, not back into the widget key.
- Require guarded fake/AppTest coverage that raises on post-instantiation widget-key mutation so this failure class cannot be hidden by permissive test fakes.
- Sync the canonical Claude skill into the Codex skill copy.

## Validation
- python3 tools/sync_agent_skills.py --skills agilab-streamlit-pages
- python3 tools/codex_skills.py --root .codex/skills validate --strict
- python3 tools/codex_skills.py --root .codex/skills generate
- python3 tools/agent_skill_catalog.py --apply
- python3 tools/generate_skill_badges.py
- python3 tools/agent_skill_quality_guard.py --roots .claude/skills .codex/skills --fail-on high
- python3 tools/skill_security_scan.py --roots .claude/skills .codex/skills --fail-on critical
- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile skills
- git diff --check
- ./dev scope
- ./dev scope --staged