### PR TITLE
[codex] Fix orchestrate worker data path normalization

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 276,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "9e9cc5f2e790a163a5ee0d3d2650268672d1bba0d6f93c7b33ab036ffabf8ec4",
+  "source_digest_sha256": "7d28d98cca5cef90fc0cd49ada7ffbecb5ee34f79d383f8da060cafac25f5bf0",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "9e9cc5f2e790a163a5ee0d3d2650268672d1bba0d6f93c7b33ab036ffabf8ec4"
+  "target_digest_sha256": "7d28d98cca5cef90fc0cd49ada7ffbecb5ee34f79d383f8da060cafac25f5bf0"
 }

--- a/docs/source/cluster.rst
+++ b/docs/source/cluster.rst
@@ -93,11 +93,14 @@ directly into the user share root. When cluster mode is enabled and
 This avoids collisions when the same user runs several app workflows on the same
 cluster share. The cluster settings UI exposes two controls:
 
-- **Workflow session policy**: ``new`` creates a fresh session directory,
-  ``last`` reuses the newest existing session for the app, and ``select`` uses
-  the named session.
+- **Workflow session policy**: ``new`` creates a fresh session directory when
+  **Workflow session** is empty, ``last`` reuses the newest existing session for
+  the app, and ``select`` uses the named session.
 - **Workflow session**: optional session name. Leave it empty for automatic
-  selection, or set it when you want a stable session such as ``trial-001``.
+  selection. With ``new`` this creates a session; with ``last`` it reuses the
+  newest session; with ``select`` it uses the newest session when one exists and
+  creates one otherwise. Set a value when you want a stable session such as
+  ``trial-001``.
 
 The same behavior can be preseeded with environment values:
 

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -398,6 +398,20 @@ Use ``--components agi-web`` for the portable web-component contract badge.
 For the global badge, you also need the corresponding aggregate XML inputs
 before regenerating ``badges/coverage-agilab.svg``.
 
+How should I report a 100% coverage improvement?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Report the scope that actually reached 100%. AGILAB tracks component coverage
+separately for surfaces such as ``agi-env``, ``agi-node``, ``agi-cluster``,
+``agi-gui``, and ``agi-web`` before combining the XML artifacts into the global
+``agilab`` badge. A focused test change can make one component complete without
+making the aggregate badge complete.
+
+When a coverage change is ready to publish, keep the source tests, generated XML
+evidence, and badge refresh aligned. Do not edit badge SVGs by hand or describe
+local macOS coverage as release truth when the Ubuntu coverage workflow is the
+canonical badge source.
+
 Why can ``agi-gui`` be at 99% while global ``agilab`` coverage is lower?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -2,14 +2,10 @@ AGILab Documentation
 =====================
 
 AGILAB turns experimental AI/ML notebooks and scripts into executable,
-portable, evidence-backed applications that can run locally or on distributed
-workers. Workflows stay portable: export them back to runnable ``agi-core``
-notebooks, keep reproducibility evidence, and hand off tracking evidence to
-MLflow when that integration is enabled. The notebook export is an ``agi-core``
-runtime handoff: you can continue to run the saved project and stage contract
-with only the stable core runtime, without depending on the AGILAB UI or
-distributed worker layer. That stable, production-grade core technology remains
-the smallest supported handoff surface.
+portable, evidence-backed applications. The smallest supported handoff is the
+``agi-core`` notebook/runtime path; the full product adds app packages,
+Streamlit pages, portable ``agi-web`` UI islands, and local or distributed
+workers when the evidence proves the next step is worthwhile.
 
 If you are new to AGILab, choose one route first:
 
@@ -27,24 +23,10 @@ work.
 Golden ML loop
 --------------
 
-AGILAB's strongest workflow is deliberately evidence-first:
-
-1. Import or create a notebook, script, or app project.
-2. Run it through a controlled local environment first.
-3. Capture artifacts plus ``run_manifest.json`` evidence.
-4. Inspect and compare outputs in ANALYSIS, notebook export, MLflow handoff, or
-   proof-pack tools.
-5. Promote the result only when the evidence, package contract, and release
-   proof are coherent.
-
-That loop keeps exploratory ML work replayable before a team moves it into a
-heavier tracker, registry, cluster, or production platform.
-
-AGILAB is not locked to one web frontend. App projects can declare app-owned
-UI surfaces so the same runtime, artifacts, and evidence contract can be opened
-through the local Streamlit UI, a hosted Hugging Face backend, or browser-native
-``agi-web`` UI islands with React-ready component contracts. See
-:doc:`apps-pages` for the ``[app_surface]`` contract and the generic
+AGILAB's evidence-first workflow is summarized in :doc:`introduction`: create
+or import work, run it locally first, capture ``run_manifest.json`` evidence,
+inspect outputs, then promote only when the package and proof contracts agree.
+See :doc:`apps-pages` for app-owned UI surfaces and the generic
 ``agilab app surface`` launcher.
 
 If the local first proof fails, use :doc:`newcomer-troubleshooting` before

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -10,9 +10,9 @@ What AGILab is
 --------------
 
 AGILab turns experimental AI/ML notebooks and scripts into executable,
-portable, evidence-backed applications that can run locally or on distributed
-workers, while keeping a handoff path to runnable ``agi-core`` notebooks and
-MLflow tracking evidence.
+portable, evidence-backed applications. The codebase splits that path into the
+published core/runtime packages under ``src/agilab/core`` and optional UI,
+page, web, and packaged-app libraries under ``src/agilab/lib``.
 
 You do not need a cluster to get that core value. The primary adoption path is
 local: turn a notebook or script into a replayable app with evidence,
@@ -38,19 +38,26 @@ That loop is the practical boundary for AGILAB as an ML workbench: it makes
 exploratory work replayable before a team chooses a heavier tracker, registry,
 cluster, or production platform.
 
-It has two main user interfaces:
+It has two primary entry points:
 
-- ``agi-core``: the Python API you can call directly from code or notebooks
-- ``agilab``: the web UI that helps select projects, install them, run them,
-  and inspect outputs
+- ``agi-core``: the Python API you can call directly from code or notebooks.
+- ``agilab``: the source checkout / packaged CLI and web UI that helps select
+  projects, install them, run them, and inspect outputs.
 
-Shared components include:
+The published package map in this checkout is:
 
-- ``agi-env`` for headless environment setup
-- ``agi-gui`` for the Streamlit UI dependency bundle and page helpers
-- ``agi-web`` for portable, evidence-backed rich web component payloads
-- ``agi-node`` for worker/runtime packaging
-- ``agi-cluster`` for local and distributed execution
+- ``src/agilab/core/agi-core`` for the notebook/API runtime.
+- ``src/agilab/core/agi-env`` for headless environment setup and shared runtime
+  helpers.
+- ``src/agilab/core/agi-node`` for worker/runtime packaging.
+- ``src/agilab/core/agi-cluster`` for local and distributed execution.
+- ``src/agilab/lib/agi-gui`` for the Streamlit UI dependency bundle and page
+  helpers.
+- ``src/agilab/lib/agi-pages`` for packaged page bundles.
+- ``src/agilab/lib/agi-web`` for portable, evidence-backed rich web component
+  payloads.
+- ``src/agilab/lib/agi-apps`` plus ``src/agilab/lib/agi-app-*`` projects for
+  packaged application distributions.
 
 Historical note
 ---------------

--- a/src/agilab/orchestrate/orchestrate_cluster.py
+++ b/src/agilab/orchestrate/orchestrate_cluster.py
@@ -1427,6 +1427,7 @@ def render_cluster_settings_ui(env: Any, deps: OrchestrateClusterDeps, *, show_r
                     workflow_name=app_state_name,
                     policy=workflow_policy,
                     selected_session=workflow_session,
+                    create=False,
                 )
             except OSError as exc:
                 workflow_session_error_shown = True
@@ -1451,8 +1452,9 @@ def render_cluster_settings_ui(env: Any, deps: OrchestrateClusterDeps, *, show_r
                 WORKFLOW_SESSION_POLICY_OPTIONS,
                 key=workflow_policy_key,
                 help=(
-                    "`new` creates an isolated session, `last` reuses the latest session, "
-                    "and `select` uses the named session."
+                    "`new` creates an isolated session when the session field is empty, "
+                    "`last` reuses the latest session, and `select` uses the named session "
+                    "or the latest session when empty."
                 ),
             )
         workflow_policy = _workflow_session_policy(workflow_policy_input)
@@ -1462,9 +1464,13 @@ def render_cluster_settings_ui(env: Any, deps: OrchestrateClusterDeps, *, show_r
                 "Workflow session",
                 key=workflow_session_key,
                 placeholder="auto, or e.g. trial-001",
-                help="Session directory below the cluster user share. Leave empty to auto-select for the policy.",
+                help=(
+                    "Session directory below the cluster user share. Leave empty to auto-select "
+                    "for the policy: `new` creates one, `last` reuses the latest, and `select` "
+                    "uses the latest when available."
+                ),
             )
-        workflow_session = _safe_workflow_component(workflow_session_input, workflow_session)
+        workflow_session = _safe_workflow_component(workflow_session_input, "")
         if cluster_share_ready and cluster_share_candidate is not None and not workflow_session_error_shown:
             try:
                 workflow_workers_path, workflow_session, workflow_policy = _resolve_workflow_session_workers_path(

--- a/src/agilab/orchestrate/orchestrate_cluster.py
+++ b/src/agilab/orchestrate/orchestrate_cluster.py
@@ -1506,7 +1506,6 @@ def render_cluster_settings_ui(env: Any, deps: OrchestrateClusterDeps, *, show_r
                 workflow_name=app_state_name,
             ):
                 cluster_params["workers_data_path"] = workflow_workers_data_path
-                st.session_state[workers_data_path_widget_key] = workflow_workers_data_path
         elif workflow_session:
             cluster_params["workflow_session"] = workflow_session
 
@@ -1519,7 +1518,19 @@ def render_cluster_settings_ui(env: Any, deps: OrchestrateClusterDeps, *, show_r
             placeholder="/path/to/data",
             help="Path to data directory on workers.",
         )
-        cluster_params["workers_data_path"] = str(workers_data_path_input or "").strip()
+        workers_data_path_value = str(workers_data_path_input or "").strip()
+        if (
+            workflow_workers_data_path
+            and _clean_path_text(workers_data_path_value)
+            and _workers_data_path_should_follow_workflow_session(
+                workers_data_path_value,
+                env,
+                user=sanitized_user,
+                workflow_name=app_state_name,
+            )
+        ):
+            workers_data_path_value = workflow_workers_data_path
+        cluster_params["workers_data_path"] = workers_data_path_value
 
         workers_widget_key = widget_keys["workers"]
         workers_dict = cluster_params.get("workers", {})

--- a/test/test_orchestrate_cluster.py
+++ b/test/test_orchestrate_cluster.py
@@ -1337,6 +1337,73 @@ def test_render_cluster_settings_ui_preserves_workflow_session_without_cluster_s
     assert cluster["workflow_session"] == "manual-session"
 
 
+def test_render_cluster_settings_ui_empty_workflow_session_auto_selects_latest(monkeypatch, tmp_path):
+    app_name = "demo_project"
+    widget_keys = orchestrate_cluster.cluster_widget_keys(app_name)
+    share = tmp_path / "cluster-share"
+    sessions_root = share / "agi" / "workflows" / app_name
+    old_session = sessions_root / "session-a"
+    latest_session = sessions_root / "session-b"
+    old_session.mkdir(parents=True)
+    latest_session.mkdir(parents=True)
+    os.utime(old_session, (1, 1))
+    os.utime(latest_session, (2, 2))
+    fake_st = _FakeStreamlit(
+        widget_values={
+            widget_keys["cluster_enabled"]: True,
+            widget_keys["cython"]: False,
+            widget_keys["pool"]: False,
+            widget_keys["rapids"]: False,
+            widget_keys["use_key"]: True,
+            widget_keys["workflow_session_policy"]: "select",
+            widget_keys["workflow_session"]: "",
+        },
+        session_state={
+            "app_settings": {
+                "cluster": {
+                    "cluster_enabled": True,
+                    "workflow_session_policy": "select",
+                    "workflow_session": "session-a",
+                    "workers_data_path": "cluster-share/agi/workflows/demo_project/session-a/workers",
+                }
+            },
+            widget_keys["workflow_session_policy"]: "select",
+            widget_keys["workflow_session"]: "session-a",
+            widget_keys["workers_data_path"]: "cluster-share/agi/workflows/demo_project/session-a/workers",
+            "benchmark": False,
+        },
+    )
+    monkeypatch.setattr(orchestrate_cluster, "st", fake_st)
+    _disable_lan_defaults(monkeypatch)
+    deps = orchestrate_cluster.OrchestrateClusterDeps(
+        parse_and_validate_scheduler=lambda _raw: None,
+        parse_and_validate_workers=lambda _raw: None,
+        write_app_settings_toml=lambda _path, settings: settings,
+        clear_load_toml_cache=lambda: None,
+        set_env_var=lambda _key, _value: None,
+        agi_env_envars={},
+    )
+    env = SimpleNamespace(
+        app=app_name,
+        home_abs=tmp_path,
+        is_managed_pc=False,
+        AGI_CLUSTER_SHARE=str(share),
+        agi_share_path=Path("cluster-share"),
+        share_root_path=lambda: share,
+        user="agi",
+        password=None,
+        ssh_key_path=None,
+        app_settings_file=tmp_path / "app_settings.toml",
+    )
+
+    orchestrate_cluster.render_cluster_settings_ui(env, deps)
+
+    cluster = fake_st.session_state.app_settings["cluster"]
+    assert cluster["workflow_session_policy"] == "select"
+    assert cluster["workflow_session"] == "session-b"
+    assert cluster["workers_data_path"] == "cluster-share/agi/workflows/demo_project/session-b/workers"
+
+
 def test_render_cluster_settings_ui_preserves_explicit_cluster_values_over_lan_discovery(monkeypatch, tmp_path):
     fake_st = _FakeStreamlit(
         widget_values={

--- a/test/test_orchestrate_cluster.py
+++ b/test/test_orchestrate_cluster.py
@@ -45,6 +45,21 @@ class _State(dict):
         self[name] = value
 
 
+class _GuardedWidgetState(_State):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        object.__setattr__(self, "_instantiated_widget_keys", set())
+
+    def __setitem__(self, key, value):
+        if key in self._instantiated_widget_keys:
+            raise RuntimeError(f"{key} cannot be modified after widget instantiation")
+        super().__setitem__(key, value)
+
+    def mark_instantiated(self, key: str | None) -> None:
+        if key:
+            self._instantiated_widget_keys.add(key)
+
+
 class _Context:
     def __init__(self, st):
         self._st = st
@@ -150,6 +165,26 @@ class _FakeStreamlit:
 
     def error(self, text):
         self.errors.append(text)
+
+
+class _GuardedFakeStreamlit(_FakeStreamlit):
+    def __init__(self, *, widget_values=None, session_state=None, button_values=None):
+        super().__init__(
+            widget_values=widget_values,
+            session_state=session_state,
+            button_values=button_values,
+        )
+        self.session_state = _GuardedWidgetState(self.session_state)
+
+    def text_input(self, label, *, key=None, value="", **kwargs):
+        result = super().text_input(label, key=key, value=value, **kwargs)
+        self.session_state.mark_instantiated(key)
+        return result
+
+    def text_area(self, label, *, key=None, value="", **kwargs):
+        result = super().text_area(label, key=key, value=value, **kwargs)
+        self.session_state.mark_instantiated(key)
+        return result
 
 
 def test_compute_cluster_mode_uses_expected_bitmask():
@@ -1966,9 +2001,70 @@ def test_render_cluster_settings_ui_replaces_stale_local_workers_data_path(monke
 
     cluster = fake_st.session_state.app_settings["cluster"]
     assert cluster["workers_data_path"] == "clustershare/agi/workflows/demo_project/session-a/workers"
-    assert fake_st.session_state[widget_keys["workers_data_path"]] == (
-        "clustershare/agi/workflows/demo_project/session-a/workers"
+    assert fake_st.session_state[widget_keys["workers_data_path"]] == "clustershare/agi"
+
+
+def test_render_cluster_settings_ui_rewrites_stale_managed_worker_path_without_widget_mutation(
+    monkeypatch, tmp_path
+):
+    app_name = "demo_project"
+    widget_keys = orchestrate_cluster.cluster_widget_keys(app_name)
+    cluster_share = tmp_path / "clustershare" / "agi"
+    (cluster_share / "workflows" / "demo_project" / "session-a").mkdir(parents=True)
+    stale_data_path = "clustershare/agi/workflows/demo_project/session-a/workers/old"
+    expected_data_path = "clustershare/agi/workflows/demo_project/session-a/workers"
+    fake_st = _GuardedFakeStreamlit(
+        widget_values={
+            widget_keys["cluster_enabled"]: True,
+            widget_keys["cython"]: False,
+            widget_keys["pool"]: False,
+            widget_keys["rapids"]: False,
+            widget_keys["use_key"]: True,
+            widget_keys["workflow_session"]: "session-a",
+            widget_keys["workers_data_path"]: stale_data_path,
+        },
+        session_state={
+            "app_settings": {
+                "cluster": {
+                    "cluster_enabled": True,
+                    "workflow_session": "session-a",
+                    "workers_data_path": stale_data_path,
+                }
+            },
+            widget_keys["workflow_session"]: "session-a",
+            widget_keys["workers_data_path"]: stale_data_path,
+            "benchmark": False,
+        },
     )
+    monkeypatch.setattr(orchestrate_cluster, "st", fake_st)
+    _disable_lan_defaults(monkeypatch)
+    deps = orchestrate_cluster.OrchestrateClusterDeps(
+        parse_and_validate_scheduler=lambda _raw: None,
+        parse_and_validate_workers=lambda _raw: None,
+        write_app_settings_toml=lambda _path, settings: settings,
+        clear_load_toml_cache=lambda: None,
+        set_env_var=lambda _key, _value: None,
+        agi_env_envars={},
+    )
+    env = SimpleNamespace(
+        app=app_name,
+        home_abs=tmp_path,
+        is_managed_pc=False,
+        AGI_CLUSTER_SHARE=str(cluster_share),
+        agi_share_path=Path("clustershare/agi"),
+        share_root_path=lambda: cluster_share,
+        user="agi",
+        password=None,
+        ssh_key_path=None,
+        app_settings_file=tmp_path / "app_settings.toml",
+    )
+
+    orchestrate_cluster.render_cluster_settings_ui(env, deps)
+
+    cluster = fake_st.session_state.app_settings["cluster"]
+    assert cluster["workflow_session"] == "session-a"
+    assert cluster["workers_data_path"] == expected_data_path
+    assert fake_st.session_state[widget_keys["workers_data_path"]] == stale_data_path
 
 
 def test_render_cluster_settings_ui_uses_ssh_key_auth_and_resolved_share(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

Fix ORCHESTRATE cluster worker data path normalization so stale managed worker paths are corrected in persisted cluster params without forcing Streamlit widget state.

## Root cause

The cluster UI computed the right workflow workers data path, but also wrote that corrected value directly into the workers data path widget key. On repeated ORCHESTRATE cluster parameter edits, the widget value and the persisted cluster params could fight each other, causing managed paths to be reintroduced or expanded incorrectly.

## Impact

Cluster params now persist the normalized workflow workers path while leaving the text widget state alone until Streamlit naturally rerenders it. Custom external paths remain user-controlled.

## Validation

- `uv --preview-features extra-build-dependencies run --extra ui python -m pytest -q -o addopts='' test/test_orchestrate_cluster.py -k 'stale_managed_worker_path or stale_local_workers_data_path'`
