### PR TITLE
Restrict workflow share root stripping

### DIFF
--- a/src/agilab/orchestrate/orchestrate_cluster.py
+++ b/src/agilab/orchestrate/orchestrate_cluster.py
@@ -54,6 +54,7 @@ WORKFLOW_SESSION_POLICY_OPTIONS = ("new", "last", "select")
 WORKFLOW_SESSION_DEFAULT_POLICY = "new"
 WORKFLOW_DEFAULT_ID = "workflows"
 WORKFLOW_PROJECT_SUFFIXES = ("_project", "-project")
+GENERATED_WORKFLOW_SESSION_RE = re.compile(r"^\d{8}T\d{6}Z-[0-9a-fA-F]{8}$")
 
 
 @dataclass(frozen=True)
@@ -419,13 +420,26 @@ def _workflow_sessions_root(cluster_share: Path, user: Any, workflow_name: Any) 
     return _workflow_user_root(cluster_share, user) / safe_workflow
 
 
-def _workflow_cluster_share_root(cluster_share: Path, *, user: Any, workflow_name: Any) -> Path:
+def _workflow_cluster_share_root(
+    cluster_share: Path,
+    *,
+    user: Any,
+    workflow_name: Any,
+    selected_session: Any = "",
+) -> Path:
     safe_user = _safe_workflow_component(user, "local-user")
     safe_workflow = _safe_workflow_component(workflow_name, "default")
     parts = cluster_share.parts
-    for index in range(len(parts) - 3, -1, -1):
-        if parts[index] == safe_user and parts[index + 1] == safe_workflow:
-            return Path(*parts[: index + 1])
+    if len(parts) < 3:
+        return cluster_share
+    suffix_user, suffix_workflow, suffix_session = parts[-3:]
+    if suffix_user != safe_user or suffix_workflow != safe_workflow:
+        return cluster_share
+    safe_session = _safe_workflow_component(selected_session, "")
+    if safe_session and suffix_session == safe_session:
+        return Path(*parts[:-2])
+    if GENERATED_WORKFLOW_SESSION_RE.fullmatch(suffix_session):
+        return Path(*parts[:-2])
     return cluster_share
 
 
@@ -1485,6 +1499,7 @@ def render_cluster_settings_ui(env: Any, deps: OrchestrateClusterDeps, *, show_r
                 cluster_share_candidate,
                 user=sanitized_user,
                 workflow_name=workflow_id,
+                selected_session=workflow_session,
             )
             if cluster_share_candidate is not None
             else None

--- a/test/test_orchestrate_cluster.py
+++ b/test/test_orchestrate_cluster.py
@@ -648,6 +648,15 @@ def test_workflow_session_path_regression_uses_workflow_session_root_semantic(tm
         )
         == share / "workflows"
     )
+    configured_share = tmp_path / "mnt" / "agi" / "workflows" / "cluster-share"
+    assert (
+        orchestrate_cluster._workflow_cluster_share_root(
+            configured_share,
+            user="agi",
+            workflow_name="workflows",
+        )
+        == configured_share
+    )
 
 
 def test_workflow_workers_data_path_regression_does_not_duplicate_module_dataset(tmp_path):
@@ -2123,6 +2132,68 @@ def test_render_cluster_settings_ui_refresh_keeps_session_scoped_share_root(monk
     assert fake_st.session_state[widget_keys["workers_data_path"]] == expected
     assert duplicated not in cluster["workers_data_path"]
     assert refresh_calls
+
+
+def test_render_cluster_settings_ui_preserves_share_with_user_workflow_parent_names(
+    monkeypatch,
+    tmp_path,
+):
+    app_name = "flight_trajectory_project"
+    session_id = "session-a"
+    widget_keys = orchestrate_cluster.cluster_widget_keys(app_name)
+    configured_share = tmp_path / "mnt" / "agi" / "workflows" / "cluster-share"
+    configured_share.mkdir(parents=True)
+    fake_st = _FakeStreamlit(
+        widget_values={
+            widget_keys["cluster_enabled"]: True,
+            widget_keys["cython"]: False,
+            widget_keys["pool"]: False,
+            widget_keys["rapids"]: False,
+            widget_keys["use_key"]: True,
+            widget_keys["workflow_session"]: session_id,
+        },
+        session_state={
+            "app_settings": {
+                "cluster": {
+                    "cluster_enabled": True,
+                    "workflow_session": session_id,
+                }
+            },
+            widget_keys["workflow_session"]: session_id,
+            "benchmark": False,
+        },
+    )
+    monkeypatch.setattr(orchestrate_cluster, "st", fake_st)
+    _disable_lan_defaults(monkeypatch)
+    deps = orchestrate_cluster.OrchestrateClusterDeps(
+        parse_and_validate_scheduler=lambda _raw: None,
+        parse_and_validate_workers=lambda _raw: None,
+        write_app_settings_toml=lambda _path, settings: settings,
+        clear_load_toml_cache=lambda: None,
+        set_env_var=lambda _key, _value: None,
+        agi_env_envars={},
+    )
+    env = SimpleNamespace(
+        app=app_name,
+        home_abs=tmp_path,
+        is_managed_pc=False,
+        AGI_CLUSTER_SHARE=str(configured_share),
+        agi_share_path=Path("mnt/agi/workflows/cluster-share"),
+        share_root_path=lambda: configured_share,
+        user="agi",
+        password=None,
+        ssh_key_path=None,
+        app_settings_file=tmp_path / "app_settings.toml",
+    )
+
+    orchestrate_cluster.render_cluster_settings_ui(env, deps)
+
+    cluster = fake_st.session_state.app_settings["cluster"]
+    assert cluster["workers_data_path"] == (
+        "mnt/agi/workflows/cluster-share/agi/workflows/session-a"
+    )
+    assert (configured_share / "agi" / "workflows" / session_id).is_dir()
+    assert not (tmp_path / "mnt" / "agi" / "workflows" / session_id).exists()
 
 
 def test_render_cluster_settings_ui_builds_advisory_cluster_plan_without_applying(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- restrict workflow cluster-share root stripping to suffixes that are known session roots
- preserve valid configured shares whose parent directories happen to contain the current user/workflow names
- add direct and render-path regressions for the review case

## Validation
- uv --preview-features extra-build-dependencies run --extra ui pytest -q -o addopts='' --import-mode=importlib test/test_orchestrate_cluster.py
- uv --preview-features extra-build-dependencies run --extra ui pytest -q -o addopts='' --import-mode=importlib test/test_orchestrate_page_helpers.py -k 'cluster_args_share or app_args_env_uses_cluster_share'
- uv --preview-features extra-build-dependencies run --extra ui pytest -q -o addopts='' --import-mode=importlib test/test_ui_pages.py -k workers_data_path
- git diff --check
- ./dev scope --staged