### PR TITLE
chore(release): bump packages to 2026.06.18

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.17"
+version = "2026.06.18"
 name = "agilab"
 description = "AGILAB is a reproducible AI/ML workbench for engineering teams."
 requires-python = ">=3.11,<3.14"
@@ -60,13 +60,13 @@ agilab-mcp = "agilab_mcp.server:main"
 
 [project.optional-dependencies]
 ai = ["openai>=2.32.0,<3"]
-core = ["agi-core==2026.06.17"]
-ui = ["agi-apps==2026.06.17", "agi-pages==2026.06.14.1", "agi-gui==2026.06.14.1", "agi-web==2026.06.14.1", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "plotly>=6.7.0,<7", "sqlalchemy>=2.0.43,<3", "streamlit>=1.57,<1.59", "starlette>=1.0.1,<2", "tomli_w>=1.2.0,<2", "cryptography>=48.0.1,<50"]
+core = ["agi-core==2026.06.18"]
+ui = ["agi-apps==2026.06.18", "agi-pages==2026.06.14.1", "agi-gui==2026.06.14.1", "agi-web==2026.06.14.1", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "plotly>=6.7.0,<7", "sqlalchemy>=2.0.43,<3", "streamlit>=1.57,<1.59", "starlette>=1.0.1,<2", "tomli_w>=1.2.0,<2", "cryptography>=48.0.1,<50"]
 viz = ["matplotlib>=3.10.0,<4", "plotly>=6.7.0,<7"]
 mlflow = ["mlflow>=3.11.1,<4", "idna>=3.15,<4", "starlette>=1.0.1,<2"]
 bridges = ["duckdb>=1.4.0,<2"]
 notebook = ["ipykernel>=6.29.0,<8", "nbclient>=0.10.0,<1", "nbformat>=5.10.0,<6"]
-examples = ["agi-apps==2026.06.17", "jupyterlab>=4.4.0,<5", "matplotlib>=3.10.0,<4", "plotly>=6.7.0,<7", "starlette>=1.0.1,<2", "bleach>=6.4.0,<7"]
+examples = ["agi-apps==2026.06.18", "jupyterlab>=4.4.0,<5", "matplotlib>=3.10.0,<4", "plotly>=6.7.0,<7", "starlette>=1.0.1,<2", "bleach>=6.4.0,<7"]
 pages = ["agi-pages==2026.06.14.1", "plotly>=6.7.0,<7", "sqlalchemy>=2.0.43,<3", "starlette>=1.0.1,<2"]
 proof = ["cryptography>=48.0.1,<50"]
 agents = ["openai>=2.32.0,<3"]

--- a/src/agilab/core/agi-cluster/pyproject.toml
+++ b/src/agilab/core/agi-cluster/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.17"
+version = "2026.06.18"
 name = "agi-cluster"
 description = "Distributed cluster orchestration layer for AGILAB workers over local and SSH backends"
 requires-python = ">=3.11"
@@ -35,7 +35,7 @@ keywords = [
     "job-scheduling",
     "mlops",
 ]
-dependencies = ["agi-env==2026.06.14.1", "agi-node==2026.06.14.1", "asyncssh>=2.23,<3", "dask[distributed]>=2026.3,<2027.0", "humanize>=4.10,<5", "numpy>=2.2,<3", "packaging>=25,<27", "polars>=1.35,<2", "psutil>=7,<8", "scikit-learn>=1.7.2,<2", "tomlkit>=0.13,<1"]
+dependencies = ["agi-env==2026.06.14.1", "agi-node==2026.06.18", "asyncssh>=2.23,<3", "dask[distributed]>=2026.3,<2027.0", "humanize>=4.10,<5", "numpy>=2.2,<3", "packaging>=25,<27", "polars>=1.35,<2", "psutil>=7,<8", "scikit-learn>=1.7.2,<2", "tomlkit>=0.13,<1"]
 
 [project.entry-points."agi_env.runtime_packages"]
 agi-cluster = "agi_cluster.agi_env_runtime:RUNTIME_PACKAGE_SPEC"

--- a/src/agilab/core/agi-core/pyproject.toml
+++ b/src/agilab/core/agi-core/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.17"
+version = "2026.06.18"
 name = "agi-core"
 description = "Meta-package that installs and wires agi-env, agi-node, and agi-cluster together"
 readme = "README.md"
@@ -30,7 +30,7 @@ keywords = [
   "distributed-computing",
   "distributed-execution",
 ]
-dependencies = ["agi-env==2026.06.14.1", "agi-node==2026.06.14.1", "agi-cluster==2026.06.17"]
+dependencies = ["agi-env==2026.06.14.1", "agi-node==2026.06.18", "agi-cluster==2026.06.18"]
 
 [project.entry-points."agi_env.runtime_packages"]
 agi-core = "agi_core.agi_env_runtime:RUNTIME_PACKAGE_SPEC"

--- a/src/agilab/core/agi-node/pyproject.toml
+++ b/src/agilab/core/agi-node/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.14.1"
+version = "2026.06.18"
 name = "agi-node"
 description = "Distributed worker orchestration and execution support library for AGILAB"
 requires-python = ">=3.11"

--- a/src/agilab/lib/agi-apps/pyproject.toml
+++ b/src/agilab/lib/agi-apps/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.17"
+version = "2026.06.18"
 name = "agi-apps"
 description = "AGILAB public app package umbrella and example assets"
 requires-python = ">=3.11"
@@ -31,7 +31,7 @@ keywords = [
     "workflow-orchestration",
 ]
 
-dependencies = ["agi-core==2026.06.17", "agi-app-mission-decision==2026.06.14.1", "agi-app-pandas-execution==2026.06.04", "agi-app-polars-execution==2026.06.04", "agi-app-flight-telemetry==2026.06.16", "agi-app-multi-dag==2026.06.04", "agi-app-weather-forecast==2026.06.14.1", "agi-app-sklearn-pipeline==2026.06.04", "agi-app-pytorch-playground==2026.06.14.1; python_version >= '3.12'", "agi-app-tescia-diagnostic==2026.06.05; python_version >= '3.13'", "agi-app-uav-relay-queue==2026.06.14.1; python_version >= '3.13'"]
+dependencies = ["agi-core==2026.06.18", "agi-app-mission-decision==2026.06.14.1", "agi-app-pandas-execution==2026.06.04", "agi-app-polars-execution==2026.06.04", "agi-app-flight-telemetry==2026.06.16", "agi-app-multi-dag==2026.06.04", "agi-app-weather-forecast==2026.06.14.1", "agi-app-sklearn-pipeline==2026.06.04", "agi-app-pytorch-playground==2026.06.14.1; python_version >= '3.12'", "agi-app-tescia-diagnostic==2026.06.05; python_version >= '3.13'", "agi-app-uav-relay-queue==2026.06.14.1; python_version >= '3.13'"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"


### PR DESCRIPTION
## Summary
- bump impacted publish closure to 2026.06.18: agi-node, agi-cluster, agi-core, agi-apps, agilab
- update internal package pins for the same closure
- leave release proof and badge at the last public release; the publish workflow updates them after PyPI/HF publication

## Validation
- release selector from v2026.06.17 selects agi-node, agi-cluster, agi-core, agi-apps, agilab for PyPI
- stable version policy accepts 5 public PyPI package versions
- umbrella wheel builds with 2026.6.18 metadata and 2026.06.18 internal pins
- test/test_orchestrate_cluster.py: 60 passed
- ./dev maintenance
- release-gate remainder: PyPI preflight, Trusted Publishing contract, Ruff availability, app contracts, dependency policy, shared-core typing, docs build, coverage badge guard