### PR TITLE
docs: refresh release proof run evidence

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 276,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "9292dff31d46af0f8ada3fcb193205c4b1e8a0a02066633f313f153865f6e072",
+  "source_digest_sha256": "8dd710f147ddc9b04c22300de5f726797ac7b477ad545bd3ee0ad21c7f0586fa",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "9292dff31d46af0f8ada3fcb193205c4b1e8a0a02066633f313f153865f6e072"
+  "target_digest_sha256": "8dd710f147ddc9b04c22300de5f726797ac7b477ad545bd3ee0ad21c7f0586fa"
 }

--- a/docs/source/data/release_proof.toml
+++ b/docs/source/data/release_proof.toml
@@ -54,8 +54,8 @@ summary = "passed docs mirror and release-proof consistency checks"
 id = "docs-publish"
 label = "Docs publish"
 workflow = "docs-publish"
-run_id = "27405597054"
-url = "https://github.com/ThalesGroup/agilab/actions/runs/27405597054"
+run_id = "27788337446"
+url = "https://github.com/ThalesGroup/agilab/actions/runs/27788337446"
 summary = "built the public documentation from the managed docs mirror"
 
 [[ci_runs]]
@@ -70,8 +70,8 @@ summary = "passed component coverage and badge freshness checks"
 id = "pypi-publish"
 label = "PyPI publish"
 workflow = "pypi-publish"
-run_id = "27401833940"
-url = "https://github.com/ThalesGroup/agilab/actions/runs/27401833940"
+run_id = "27786476047"
+url = "https://github.com/ThalesGroup/agilab/actions/runs/27786476047"
 summary = "passed the public release proof workflow gate"
 
 [proof_command]

--- a/docs/source/release-proof.rst
+++ b/docs/source/release-proof.rst
@@ -30,11 +30,11 @@ Current public release
    * - Docs source guard
      - `docs-source-guard run 27405793185 <https://github.com/ThalesGroup/agilab/actions/runs/27405793185>`__ passed docs mirror and release-proof consistency checks
    * - Docs publish
-     - `docs-publish run 27405597054 <https://github.com/ThalesGroup/agilab/actions/runs/27405597054>`__ built the public documentation from the managed docs mirror
+     - `docs-publish run 27788337446 <https://github.com/ThalesGroup/agilab/actions/runs/27788337446>`__ built the public documentation from the managed docs mirror
    * - Coverage
      - `coverage run 27402705475 <https://github.com/ThalesGroup/agilab/actions/runs/27402705475>`__ passed component coverage and badge freshness checks
    * - PyPI publish
-     - `pypi-publish run 27401833940 <https://github.com/ThalesGroup/agilab/actions/runs/27401833940>`__ passed the public release proof workflow gate
+     - `pypi-publish run 27786476047 <https://github.com/ThalesGroup/agilab/actions/runs/27786476047>`__ passed the public release proof workflow gate
 
 What was proved
 ---------------


### PR DESCRIPTION
Refreshes the public AGILAB docs mirror after the 2026.06.18 release.\n\n- syncs the release-proof run evidence from canonical thales_agilab docs\n- pins the current docs-publish and pypi-publish run IDs\n- refreshes the docs mirror stamp\n\nValidation passed locally: release_proof_report, mirror stamp verification, PyPI release status, HF smoke, and packaged first-proof install smoke.