### PR TITLE
Add agent instruction pre-push hook

### DIFF
--- a/.claude/skills/agilab-runbook/SKILL.md
+++ b/.claude/skills/agilab-runbook/SKILL.md
@@ -118,9 +118,10 @@ Use this skill when you need repo-specific “how we do things” guidance in `a
   - whether installer repros are mandatory
   - whether generated artifacts must be refreshed
 - **Diff-aware pre-push guards**: keep `git config core.hooksPath .githooks` enabled. The hook
-  uses `tools/pre_push_changed_files.py` to run docs mirror checks only for docs mirror inputs and
-  release-proof checks only for release-proof inputs. If classification fails, it runs all local
-  guards. Coverage badge freshness remains an explicit `./dev badge` or release/pre-release check.
+  uses `tools/pre_push_changed_files.py` to run docs mirror checks only for docs mirror inputs,
+  release-proof checks only for release-proof inputs, and agent-instruction contract checks only
+  for AGENTS/runbook/skill/discovery inputs. If classification fails, it runs all local guards.
+  Coverage badge freshness remains an explicit `./dev badge` or release/pre-release check.
 - **Public style badge alignment**: keep the code-style/style-guard signal in
   `README.md` and `README.pypi.md` aligned with the actual repository guard. If
   the public badge moves to a Ruff changed-files guard or another style tool,

--- a/.codex/skills/agilab-runbook/SKILL.md
+++ b/.codex/skills/agilab-runbook/SKILL.md
@@ -118,9 +118,10 @@ Use this skill when you need repo-specific “how we do things” guidance in `a
   - whether installer repros are mandatory
   - whether generated artifacts must be refreshed
 - **Diff-aware pre-push guards**: keep `git config core.hooksPath .githooks` enabled. The hook
-  uses `tools/pre_push_changed_files.py` to run docs mirror checks only for docs mirror inputs and
-  release-proof checks only for release-proof inputs. If classification fails, it runs all local
-  guards. Coverage badge freshness remains an explicit `./dev badge` or release/pre-release check.
+  uses `tools/pre_push_changed_files.py` to run docs mirror checks only for docs mirror inputs,
+  release-proof checks only for release-proof inputs, and agent-instruction contract checks only
+  for AGENTS/runbook/skill/discovery inputs. If classification fails, it runs all local guards.
+  Coverage badge freshness remains an explicit `./dev badge` or release/pre-release check.
 - **Public style badge alignment**: keep the code-style/style-guard signal in
   `README.md` and `README.pypi.md` aligned with the actual repository guard. If
   the public badge moves to a Ruff changed-files guard or another style tool,

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -16,6 +16,7 @@ DOCS_CHANGED=1
 RELEASE_PROOF_CHANGED=1
 APP_CONTRACTS_CHANGED=1
 AGI_CORE_PROTECTED_CHANGED=1
+AGENT_INSTRUCTIONS_CHANGED=1
 MIXED_SCOPE=0
 SCOPE_COUNT=0
 SCOPE_LIMIT=2
@@ -28,6 +29,7 @@ while IFS='=' read -r key value; do
     RELEASE_PROOF_CHANGED) RELEASE_PROOF_CHANGED="$value" ;;
     APP_CONTRACTS_CHANGED) APP_CONTRACTS_CHANGED="$value" ;;
     AGI_CORE_PROTECTED_CHANGED) AGI_CORE_PROTECTED_CHANGED="$value" ;;
+    AGENT_INSTRUCTIONS_CHANGED) AGENT_INSTRUCTIONS_CHANGED="$value" ;;
     MIXED_SCOPE) MIXED_SCOPE="$value" ;;
     SCOPE_COUNT) SCOPE_COUNT="$value" ;;
     SCOPE_LIMIT) SCOPE_LIMIT="$value" ;;
@@ -78,6 +80,13 @@ if [[ "${RELEASE_PROOF_CHANGED:-1}" == "1" ]]; then
     --quiet
 else
   echo "[agilab pre-push] release-proof inputs unchanged; skipping release-proof guard." >&2
+fi
+
+if [[ "${AGENT_INSTRUCTIONS_CHANGED:-1}" == "1" ]]; then
+  uv --preview-features extra-build-dependencies run python tools/agent_instruction_contract.py \
+    --check
+else
+  echo "[agilab pre-push] agent instruction inputs unchanged; skipping agent instruction guard." >&2
 fi
 
 if [[ "${APP_CONTRACTS_CHANGED:-1}" == "1" ]]; then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -327,6 +327,7 @@ Use this runbook whenever you:
   non-infrastructure scopes before docs/release/app-contract checks run; split the work or use
   `AGILAB_ALLOW_MIXED_SCOPE_PUSH=1` only with an explicit reason. It runs docs mirror checks
   only when docs mirror inputs changed, release-proof checks only when release-proof inputs changed,
+  agent-instruction contract checks only when AGENTS/runbook/skill/discovery inputs changed,
   and app-contract checks only when built-in app/package/catalog/docs contract inputs changed.
   If classification fails, it fails safe by running all local guards. Coverage badge freshness is
   intentionally not part of the default bugfix pre-push path; run `./dev badge` or the `badges`

--- a/agenticweb.md
+++ b/agenticweb.md
@@ -1,7 +1,7 @@
 ---
 agenticweb: "1"
 description: "AGILAB is an open-source AI/ML workbench for reproducible experiments, notebook-to-app workflows, run evidence, proof capsules, and local agent evidence review."
-updated: "2026-06-18"
+updated: "2026-06-19"
 organization:
   name: "AGILAB"
   website: "https://thalesgroup.github.io/agilab"
@@ -243,7 +243,7 @@ x_generated_by:
   command: "python3 tools/agenticweb_manifest.py --apply"
   source_manifest: "agilab-capabilities.json"
   source_schema: "agilab.capabilities.v1"
-  source_version: "2026.06.17"
+  source_version: "2026.06.18"
   boundary: "Discovery only: this file does not prove runtime success, external service reachability, security certification, or production readiness."
 ---
 

--- a/agilab-capabilities.json
+++ b/agilab-capabilities.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-06-18T13:44:39Z",
+  "generated_at_utc": "2026-06-19T06:21:02Z",
   "schema": "agilab.capabilities.v1",
   "schema_version": 1,
   "generated_by": {
@@ -10,7 +10,7 @@
     "repository": "https://github.com/ThalesGroup/agilab",
     "documentation": "https://thalesgroup.github.io/agilab/",
     "project": "agilab",
-    "version": "2026.06.17"
+    "version": "2026.06.18"
   },
   "boundary": {
     "proves": "This manifest proves that public AGILAB surfaces are discoverable from checked-in contracts.",
@@ -472,7 +472,7 @@
       "name": "agi-node",
       "role": "runtime-component",
       "status": "PyPI package",
-      "version": "2026.06.14.1",
+      "version": "2026.06.18",
       "description": "Distributed worker orchestration and execution support library for AGILAB",
       "project": "src/agilab/core/agi-node",
       "pyproject": "src/agilab/core/agi-node/pyproject.toml",
@@ -483,7 +483,7 @@
       "name": "agi-cluster",
       "role": "runtime-component",
       "status": "PyPI package",
-      "version": "2026.06.17",
+      "version": "2026.06.18",
       "description": "Distributed cluster orchestration layer for AGILAB workers over local and SSH backends",
       "project": "src/agilab/core/agi-cluster",
       "pyproject": "src/agilab/core/agi-cluster/pyproject.toml",
@@ -494,7 +494,7 @@
       "name": "agi-core",
       "role": "runtime-bundle",
       "status": "PyPI package",
-      "version": "2026.06.17",
+      "version": "2026.06.18",
       "description": "Meta-package that installs and wires agi-env, agi-node, and agi-cluster together",
       "project": "src/agilab/core/agi-core",
       "pyproject": "src/agilab/core/agi-core/pyproject.toml",
@@ -637,7 +637,7 @@
       "name": "agi-apps",
       "role": "app-umbrella",
       "status": "PyPI package",
-      "version": "2026.06.17",
+      "version": "2026.06.18",
       "description": "AGILAB public app package umbrella and example assets",
       "project": "src/agilab/lib/agi-apps",
       "pyproject": "src/agilab/lib/agi-apps/pyproject.toml",
@@ -648,7 +648,7 @@
       "name": "agilab",
       "role": "top-level-bundle",
       "status": "PyPI package",
-      "version": "2026.06.17",
+      "version": "2026.06.18",
       "description": "AGILAB is a reproducible AI/ML workbench for engineering teams.",
       "project": ".",
       "pyproject": "pyproject.toml",

--- a/test/test_pre_push_changed_files.py
+++ b/test/test_pre_push_changed_files.py
@@ -22,6 +22,7 @@ def test_classify_source_only_change_skips_docs_and_release_proof_guards():
     assert not state.release_proof_changed
     assert not state.app_contracts_changed
     assert not state.agi_core_protected_changed
+    assert not state.agent_instructions_changed
 
 
 def test_classify_docs_source_change_runs_docs_guard_only():
@@ -90,6 +91,28 @@ def test_classify_infra_scopes_do_not_count_as_mixed_push_scope():
     assert state.scope_count == 0
 
 
+def test_classify_agent_instruction_change_runs_agent_instruction_guard_only():
+    state = pre_push_changed_files.classify_changed_files(["AGENTS.md"])
+
+    assert not state.docs_changed
+    assert not state.release_proof_changed
+    assert not state.app_contracts_changed
+    assert not state.agi_core_protected_changed
+    assert state.agent_instructions_changed
+
+
+def test_classify_agent_skill_change_runs_agent_instruction_guard_only():
+    state = pre_push_changed_files.classify_changed_files(
+        [".codex/skills/agilab-runbook/SKILL.md"]
+    )
+
+    assert not state.docs_changed
+    assert not state.release_proof_changed
+    assert not state.app_contracts_changed
+    assert not state.agi_core_protected_changed
+    assert state.agent_instructions_changed
+
+
 def test_classify_many_product_scopes_blocks_mixed_push_scope():
     state = pre_push_changed_files.classify_changed_files(
         [
@@ -126,6 +149,7 @@ def test_render_shell_is_eval_friendly():
         "RELEASE_PROOF_CHANGED=1",
         "APP_CONTRACTS_CHANGED=0",
         "AGI_CORE_PROTECTED_CHANGED=0",
+        "AGENT_INSTRUCTIONS_CHANGED=0",
         "MIXED_SCOPE=0",
         "SCOPE_COUNT=0",
         "SCOPE_LIMIT=2",

--- a/tools/pre_push_changed_files.py
+++ b/tools/pre_push_changed_files.py
@@ -52,6 +52,32 @@ APP_CONTRACT_GUARD_FILES = {
 }
 AGI_CORE_PROTECTED_PREFIXES = ("src/agilab/core/agi-core/",)
 AGI_CORE_PROTECTED_FILES = {"src/agilab/core/agi-core"}
+AGENT_INSTRUCTION_PREFIXES = (
+    ".claude/skills/",
+    ".codex/skills/",
+)
+AGENT_INSTRUCTION_FILES = {
+    "AGENTS.md",
+    "AGENT_CONVENTIONS.md",
+    "AGENT_LEARNINGS.md",
+    "AGENT_SKILLS.md",
+    "agenticweb.md",
+    "agilab-capabilities.json",
+    "agilab-capabilities.schema.json",
+    "agilab-capability-rules.yml",
+    "docs/source/agent-workflows.rst",
+    "llms-full.txt",
+    "llms.txt",
+    "tools/agent_instruction_contract.py",
+    "tools/agent_workflows.md",
+    "tools/agilab_capabilities_lint.py",
+    "tools/agilab_capabilities_manifest.py",
+    "tools/agent_skill_catalog.py",
+    "tools/agenticweb_manifest.py",
+    "tools/codex_skills.py",
+    "tools/generate_skill_badges.py",
+    "tools/sync_agent_skills.py",
+}
 DEFAULT_PUSH_MAX_SCOPES = worktree_scope_guard.DEFAULT_MAX_SCOPES
 PUSH_SCOPE_ALLOWED = worktree_scope_guard.DEFAULT_ALLOWED_SCOPES
 
@@ -66,6 +92,7 @@ class GuardState:
     release_proof_changed: bool
     app_contracts_changed: bool
     agi_core_protected_changed: bool
+    agent_instructions_changed: bool
     mixed_scope: bool = False
     scope_count: int = 0
     scope_limit: int = DEFAULT_PUSH_MAX_SCOPES
@@ -160,6 +187,10 @@ def classify_changed_files(
         _matches(path, prefixes=AGI_CORE_PROTECTED_PREFIXES, files=AGI_CORE_PROTECTED_FILES)
         for path in changed_files
     )
+    agent_instructions_changed = any(
+        _matches(path, prefixes=AGENT_INSTRUCTION_PREFIXES, files=AGENT_INSTRUCTION_FILES)
+        for path in changed_files
+    )
     scope_report = worktree_scope_guard.analyze_scope(
         changed_files,
         max_scopes=max_scopes,
@@ -171,6 +202,7 @@ def classify_changed_files(
         release_proof_changed=release_proof_changed,
         app_contracts_changed=app_contracts_changed,
         agi_core_protected_changed=agi_core_protected_changed,
+        agent_instructions_changed=agent_instructions_changed,
         mixed_scope=scope_report.mixed,
         scope_count=len(scope_report.counted_scopes),
         scope_limit=scope_report.max_scopes,
@@ -184,6 +216,7 @@ def failed_detection_state(error: Exception) -> GuardState:
         release_proof_changed=True,
         app_contracts_changed=True,
         agi_core_protected_changed=True,
+        agent_instructions_changed=True,
         mixed_scope=True,
         detection_failed=True,
         error=str(error),
@@ -200,6 +233,7 @@ def render_shell(state: GuardState) -> str:
         f"RELEASE_PROOF_CHANGED={_shell_bool(state.release_proof_changed)}",
         f"APP_CONTRACTS_CHANGED={_shell_bool(state.app_contracts_changed)}",
         f"AGI_CORE_PROTECTED_CHANGED={_shell_bool(state.agi_core_protected_changed)}",
+        f"AGENT_INSTRUCTIONS_CHANGED={_shell_bool(state.agent_instructions_changed)}",
         f"MIXED_SCOPE={_shell_bool(state.mixed_scope)}",
         f"SCOPE_COUNT={state.scope_count}",
         f"SCOPE_LIMIT={state.scope_limit}",


### PR DESCRIPTION
Adds a diff-aware agent instruction hook to the AGILAB pre-push guard.\n\nWhat changed:\n- classifies AGENTS/runbook/skill/discovery changes as agent-instruction inputs\n- runs tools/agent_instruction_contract.py --check from .githooks/pre-push when those inputs changed\n- documents the hook in AGENTS.md and the shared agilab-runbook skill\n- refreshes generated agent discovery metadata\n- adds focused classifier regressions for AGENTS.md and repo skill changes\n\nValidation:\n- ./dev test test/test_pre_push_changed_files.py\n- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_agenticweb_manifest.py test/test_pre_push_changed_files.py\n- uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile skills\n- .githooks/pre-push