### PR TITLE
Prompt PRs to auto-close linked issues

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,6 +3,13 @@
 - What changed?
 - Why was this change needed?
 
+## Linked Issue
+
+- Fixes #<!-- issue number; use N/A only when no GitHub issue exists -->
+
+Use GitHub closing keywords (`Fixes`, `Closes`, or `Resolves`) for bug-fix
+PRs so the linked issue auto-closes when the PR is merged.
+
 ## Scope
 
 - Affected repo areas:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,12 @@ updates:
       python-runtime:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "streamlit"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
 
   - package-ecosystem: "pip"
     directory: "/src/agilab/core/agi-env"
@@ -80,6 +86,12 @@ updates:
     labels:
       - "dependencies"
       - "python"
+    ignore:
+      - dependency-name: "streamlit"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
 
   - package-ecosystem: "pip"
     directory: "/src/agilab/lib/agi-web"

--- a/test/test_governance_supply_chain_contract.py
+++ b/test/test_governance_supply_chain_contract.py
@@ -75,6 +75,10 @@ def test_contributing_documents_enterprise_governance_boundaries() -> None:
         assert fragment in contributing
 
     for fragment in (
+        "## Linked Issue",
+        "Fixes #<!-- issue number; use N/A only when no GitHub issue exists -->",
+        "Use GitHub closing keywords (`Fixes`, `Closes`, or `Resolves`)",
+        "auto-closes when the PR is merged",
         "Stability boundary: runtime core / beta UI / built-in app / learning example / release tooling / agent or IDE automation",
         "DCO/CLA status",
         "Repository-scope changes stay within the stated stability boundary",


### PR DESCRIPTION
## Summary
- add a Linked Issue section to the PR template with GitHub closing-keyword syntax
- keep the governance regression covering the auto-close prompt
- restore the existing Dependabot Streamlit ignore policy expected by the governance contract

## Linked Issue

- N/A

## Validation

- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_governance_supply_chain_contract.py
- ./dev scope --staged
- uv --preview-features extra-build-dependencies run python tools/impact_validate.py --staged