### PR TITLE
Align localshare default with per-user share policy

### DIFF
--- a/src/agilab/core/agi-env/src/agi_env/resources/.agilab/.env
+++ b/src/agilab/core/agi-env/src/agi_env/resources/.agilab/.env
@@ -12,8 +12,8 @@
 # ALL AGI_xxx DIRs have to be relative path to user home
 #
 # MLFLOW_TRACKING_DIR=".mlfow"
-# AGI_CLUSTER_SHARE=clustershare
-# AGI_LOCAL_SHARE=localshare
+# AGI_CLUSTER_SHARE=clustershare/<user>
+# AGI_LOCAL_SHARE=localshare/<user>
 # AGI_LOG_DIR="log"
 # AGI_EXPORT_DIR="export"
 

--- a/src/agilab/core/agi-env/src/agi_env/runtime/runtime_bootstrap_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/runtime/runtime_bootstrap_support.py
@@ -27,6 +27,11 @@ def default_share_user(*, environ) -> str:
     return safe_user or "user"
 
 
+def default_local_share(*, environ) -> str:
+    """Return the per-user fallback local share root."""
+    return f"localshare/{default_share_user(environ=environ)}"
+
+
 def default_cluster_share(*, environ) -> str:
     """Return the per-user fallback cluster share root."""
     return f"clustershare/{default_share_user(environ=environ)}"
@@ -110,7 +115,11 @@ def resolve_share_runtime_config(
     home_path,
 ) -> ShareRuntimeConfig:
     """Resolve local/cluster share settings and the effective runtime share path."""
-    local_share = envars.get("AGI_LOCAL_SHARE") or environ.get("AGI_LOCAL_SHARE") or "localshare"
+    local_share = (
+        envars.get("AGI_LOCAL_SHARE")
+        or environ.get("AGI_LOCAL_SHARE")
+        or default_local_share(environ=environ)
+    )
     cluster_share = (
         envars.get("AGI_CLUSTER_SHARE")
         or environ.get("AGI_CLUSTER_SHARE")

--- a/src/agilab/core/agi-env/test/test_agi_env_remaining_coverage.py
+++ b/src/agilab/core/agi-env/test/test_agi_env_remaining_coverage.py
@@ -602,7 +602,7 @@ def test_init_preserves_existing_dataset_without_stamp_and_uses_windows_export_b
     worker_dir = app_root / "src" / "demo_worker"
     dataset_archive = worker_dir / "dataset.7z"
     dataset_archive.write_text("archive", encoding="utf-8")
-    dataset_root = fake_home / "localshare" / "demo" / "dataset"
+    dataset_root = fake_home / "localshare" / "agi" / "demo" / "dataset"
     dataset_root.mkdir(parents=True)
     (dataset_root / "existing.csv").write_text("value\n", encoding="utf-8")
     mock_logger = mock.Mock()
@@ -644,7 +644,7 @@ def test_init_dataset_stamp_probe_failure_appends_sys_path_and_sets_windows_expo
     worker_dir = app_root / "src" / "demo_worker"
     dataset_archive = worker_dir / "dataset.7z"
     dataset_archive.write_text("archive", encoding="utf-8")
-    dataset_root = fake_home / "localshare" / "demo" / "dataset"
+    dataset_root = fake_home / "localshare" / "agi" / "demo" / "dataset"
     dataset_root.mkdir(parents=True)
     (dataset_root / "existing.csv").write_text("value\n", encoding="utf-8")
     stamp_path = dataset_root / ".agilab_dataset_stamp"

--- a/src/agilab/core/agi-env/test/test_agi_env_remaining_coverage.py
+++ b/src/agilab/core/agi-env/test/test_agi_env_remaining_coverage.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import builtins
 import importlib.util
+import os
 import sys
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
@@ -11,6 +12,7 @@ import agi_env.agi_env as agi_env_module
 import pytest
 from agi_env import AgiEnv, project_initialization_support
 from agi_env.agi_logger import AgiLogger
+from agi_env.runtime.runtime_bootstrap_support import default_local_share
 
 
 MODULE_PATH = Path("src/agilab/core/agi-env/src/agi_env/agi_env.py").resolve()
@@ -330,6 +332,10 @@ def _prepare_fake_home(tmp_path: Path, monkeypatch, *, env_text: str) -> Path:
     return fake_home
 
 
+def _default_dataset_root(fake_home: Path) -> Path:
+    return fake_home / default_local_share(environ=os.environ) / "demo" / "dataset"
+
+
 def _configure_fake_installed_specs(monkeypatch, site_root: Path):
     agilab_pkg = site_root / "agilab"
     agi_env_pkg = site_root / "agi_env"
@@ -602,7 +608,7 @@ def test_init_preserves_existing_dataset_without_stamp_and_uses_windows_export_b
     worker_dir = app_root / "src" / "demo_worker"
     dataset_archive = worker_dir / "dataset.7z"
     dataset_archive.write_text("archive", encoding="utf-8")
-    dataset_root = fake_home / "localshare" / "agi" / "demo" / "dataset"
+    dataset_root = _default_dataset_root(fake_home)
     dataset_root.mkdir(parents=True)
     (dataset_root / "existing.csv").write_text("value\n", encoding="utf-8")
     mock_logger = mock.Mock()
@@ -644,7 +650,7 @@ def test_init_dataset_stamp_probe_failure_appends_sys_path_and_sets_windows_expo
     worker_dir = app_root / "src" / "demo_worker"
     dataset_archive = worker_dir / "dataset.7z"
     dataset_archive.write_text("archive", encoding="utf-8")
-    dataset_root = fake_home / "localshare" / "agi" / "demo" / "dataset"
+    dataset_root = _default_dataset_root(fake_home)
     dataset_root.mkdir(parents=True)
     (dataset_root / "existing.csv").write_text("value\n", encoding="utf-8")
     stamp_path = dataset_root / ".agilab_dataset_stamp"

--- a/src/agilab/core/agi-env/test/test_runtime_bootstrap_support.py
+++ b/src/agilab/core/agi-env/test/test_runtime_bootstrap_support.py
@@ -6,6 +6,7 @@ import pytest
 
 from agi_env.runtime_bootstrap_support import (
     default_cluster_share,
+    default_local_share,
     default_share_user,
     parse_int_env_value,
     resolve_share_runtime_config,
@@ -19,15 +20,17 @@ def test_parse_int_env_value_falls_back_for_blank_and_invalid():
     assert parse_int_env_value({"TABLE_MAX_ROWS": "42"}, "TABLE_MAX_ROWS", 100) == 42
 
 
-def test_default_cluster_share_is_user_scoped_and_filesystem_safe():
+def test_default_share_roots_are_user_scoped_and_filesystem_safe():
     environ = {"USER": "alice@example.com"}
 
     assert default_share_user(environ=environ) == "alice_example.com"
+    assert default_local_share(environ=environ) == "localshare/alice_example.com"
     assert default_cluster_share(environ=environ) == "clustershare/alice_example.com"
+    assert default_local_share(environ={}) == "localshare/user"
     assert default_cluster_share(environ={}) == "clustershare/user"
 
 
-def test_resolve_share_runtime_config_defaults_cluster_share_per_user(tmp_path):
+def test_resolve_share_runtime_config_defaults_share_roots_per_user(tmp_path):
     result = resolve_share_runtime_config(
         envars={},
         environ={"USER": "demo-user"},
@@ -41,6 +44,7 @@ def test_resolve_share_runtime_config_defaults_cluster_share_per_user(tmp_path):
         home_path=tmp_path,
     )
 
+    assert result.local_share == "localshare/demo-user"
     assert result.cluster_share == "clustershare/demo-user"
     assert result.agi_share_path == "clustershare/demo-user"
 
@@ -297,7 +301,7 @@ def test_resolve_share_runtime_config_applies_share_dir_override(tmp_path):
         home_path=tmp_path,
     )
 
-    assert result.local_share == "localshare"
+    assert result.local_share == "localshare/user"
     assert result.cluster_share == "cluster_mount"
     assert result.agi_share_path == "cluster_mount"
     assert envars["AGI_CLUSTER_SHARE"] == "cluster_mount"


### PR DESCRIPTION
## Summary
- add a per-user default for AGI_LOCAL_SHARE matching the clustershare fallback policy
- update the bundled .env template to show per-user localshare and clustershare examples
- adjust agi-env regressions to cover the new default path

## Validation
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' src/agilab/core/agi-env/test/test_runtime_bootstrap_support.py
- uv --preview-features extra-build-dependencies run --no-sync pytest src/agilab/core/agi-env/test -q -o addopts=''
- git diff --check
- ./dev scope --staged --summary-lines 80