### PR TITLE
Speed PyPI publish retention cleanup

### DIFF
--- a/.claude/skills/agilab-pypi-release-maintenance/SKILL.md
+++ b/.claude/skills/agilab-pypi-release-maintenance/SKILL.md
@@ -27,7 +27,10 @@ For publication-process optimization checks, inspect the current workflow first:
 `pypi-publish` now makes the release plan package-aware. By default it omits
 selected package versions whose expected PyPI artifacts already exist, so those
 packages do not enter build, upload, provenance, retention, or release-asset
-jobs.
+jobs. The release workflow also defers destructive PyPI retention until a
+selected package has more than ten visible releases; the manual retention tool
+keeps its strict single-current-release default unless an operator passes a
+threshold explicitly.
 
 ## Required Safety Rules
 
@@ -182,9 +185,15 @@ uv --preview-features extra-build-dependencies run python tools/pypi_release_ret
   --packages "agilab agi-core agi-env" \
   --repo-root . \
   --protect-versions-from-projects \
+  --min-published-releases 11 \
   --dry-run \
   --json
 ```
+
+`--min-published-releases 11` matches the public `pypi-publish` workflow: keep
+old releases during normal publication, then prune only when a selected package
+would expose an eleventh release. Omit the threshold for explicit manual cleanup
+when the operator wants strict single-current-release retention now.
 
 Use a single `--protect-version` only for legacy aligned-version cleanup.
 For same-version partial releases, do not hand-copy long package lists. Prefer
@@ -391,6 +400,10 @@ real issue is cleanup, release-plan selection, or package reuse. The public
   explicit package selection, and race conditions between planning and upload.
 - When any expected artifact is missing, the workflow builds, verifies,
   manifests, and publishes that package with Trusted Publishing.
+- Destructive retention is intentionally less frequent than publication: the
+  release workflow passes `--min-published-releases 11`, so PyPI web-login
+  deletion runs only after a selected package accumulates more than ten visible
+  releases.
 
 Do not use deletion/reupload churn to compensate for unchanged package
 publication. Prefer fixing the reuse gate, release-plan matrix, or artifact

--- a/.claude/skills/agilab-release-verification/SKILL.md
+++ b/.claude/skills/agilab-release-verification/SKILL.md
@@ -162,7 +162,7 @@ workflow dispatch:
 - `publish-library-packages`: publishes selected split packages with PyPI Trusted Publishing.
 - `publish-agilab`: publishes the top-level `agilab` package only when the umbrella package is still selected.
 - `pypi-provenance-evidence`: verifies PyPI attestations only for `provenance_packages` selected by the release plan.
-- `pypi-release-retention`: prunes older public PyPI releases only for selected provenance packages; missing current releases or failed cleanup are hard failures.
+- `pypi-release-retention`: prunes older public PyPI releases only for selected provenance packages after a selected package has more than ten visible releases; missing current releases or failed cleanup after the threshold is reached are hard failures.
 - `publish-release-assets`: uploads release artifacts and supply-chain evidence to GitHub Releases.
 - `publish-dataset-release-assets`: builds a complete tracked-dataset archive, manifest, and checksums from an LFS-materialized checkout, then creates a separate content-addressed `datasets-<manifest-hash>` GitHub Release only when that dataset payload has not already been published. This job is intentionally independent from PyPI package selection; PyPI packages keep their packaged datasets.
 - `sync-hf-space`: deploys the public Hugging Face Space after release assets only when the umbrella `agilab` release is selected.
@@ -305,9 +305,11 @@ PY
 ```
 
 After PyPI pruning, `missing_expected` must be empty. `stale_old_releases`
-should be empty when strict retention succeeds, but stale versions can remain as
-cleanup debt when PyPI web login, unrecognized-login confirmation, or
-reauthentication blocks deletion. Do not confuse that warning state with a
+can be non-empty when the package is still below the workflow's ten-release
+cleanup threshold. Once threshold-triggered or explicit strict retention runs,
+remaining stale versions are cleanup debt when PyPI web login,
+unrecognized-login confirmation, or reauthentication blocks deletion. Do not
+confuse a below-threshold retained history or an authentication warning with a
 failed publish or failed provenance check.
 
 ### Release Proof and Docs
@@ -421,9 +423,11 @@ after the badge/source change.
   `agilab` wheel metadata. If `Requires-Dist` pins internal packages to a
   deleted version, publish a new corrective `.postN` release for the whole
   package graph before deleting anything else.
-- PyPI retention reports success but old releases remain: confirm whether PyPI
-  required password/TOTP reauthentication or unrecognized-login confirmation.
-  OIDC Trusted Publishing cannot delete old releases.
+- PyPI retention reports success but old releases remain: first check whether
+  the package is below the workflow's ten-release cleanup threshold. If the
+  threshold was reached, confirm whether PyPI required password/TOTP
+  reauthentication or unrecognized-login confirmation. OIDC Trusted Publishing
+  cannot delete old releases.
 - GitHub Release exists but PyPI missing: inspect `publish-agilab` and split
   package jobs; do not assume release assets imply package upload.
 - PyPI published but `sync-hf-space` skipped: first check
@@ -460,8 +464,10 @@ after the badge/source change.
 - If old releases must be deleted manually, use PyPI's project release pages or
   a controlled browser session, then re-run the split-package release truth
   check above.
-- Keep a single-current-release policy as a post-publish cleanup step, not as a
-  precondition for publishing the replacement package graph.
+- Keep the workflow's ten-release cleanup threshold as a post-publish cleanup
+  policy, not as a precondition for publishing the replacement package graph.
+  Use explicit manual cleanup only when an operator wants stricter retention for
+  a known package set.
 
 ## Final Answer Contract
 

--- a/.codex/skills/agilab-pypi-release-maintenance/SKILL.md
+++ b/.codex/skills/agilab-pypi-release-maintenance/SKILL.md
@@ -27,7 +27,10 @@ For publication-process optimization checks, inspect the current workflow first:
 `pypi-publish` now makes the release plan package-aware. By default it omits
 selected package versions whose expected PyPI artifacts already exist, so those
 packages do not enter build, upload, provenance, retention, or release-asset
-jobs.
+jobs. The release workflow also defers destructive PyPI retention until a
+selected package has more than ten visible releases; the manual retention tool
+keeps its strict single-current-release default unless an operator passes a
+threshold explicitly.
 
 ## Required Safety Rules
 
@@ -182,9 +185,15 @@ uv --preview-features extra-build-dependencies run python tools/pypi_release_ret
   --packages "agilab agi-core agi-env" \
   --repo-root . \
   --protect-versions-from-projects \
+  --min-published-releases 11 \
   --dry-run \
   --json
 ```
+
+`--min-published-releases 11` matches the public `pypi-publish` workflow: keep
+old releases during normal publication, then prune only when a selected package
+would expose an eleventh release. Omit the threshold for explicit manual cleanup
+when the operator wants strict single-current-release retention now.
 
 Use a single `--protect-version` only for legacy aligned-version cleanup.
 For same-version partial releases, do not hand-copy long package lists. Prefer
@@ -391,6 +400,10 @@ real issue is cleanup, release-plan selection, or package reuse. The public
   explicit package selection, and race conditions between planning and upload.
 - When any expected artifact is missing, the workflow builds, verifies,
   manifests, and publishes that package with Trusted Publishing.
+- Destructive retention is intentionally less frequent than publication: the
+  release workflow passes `--min-published-releases 11`, so PyPI web-login
+  deletion runs only after a selected package accumulates more than ten visible
+  releases.
 
 Do not use deletion/reupload churn to compensate for unchanged package
 publication. Prefer fixing the reuse gate, release-plan matrix, or artifact

--- a/.codex/skills/agilab-release-verification/SKILL.md
+++ b/.codex/skills/agilab-release-verification/SKILL.md
@@ -162,7 +162,7 @@ workflow dispatch:
 - `publish-library-packages`: publishes selected split packages with PyPI Trusted Publishing.
 - `publish-agilab`: publishes the top-level `agilab` package only when the umbrella package is still selected.
 - `pypi-provenance-evidence`: verifies PyPI attestations only for `provenance_packages` selected by the release plan.
-- `pypi-release-retention`: prunes older public PyPI releases only for selected provenance packages; missing current releases or failed cleanup are hard failures.
+- `pypi-release-retention`: prunes older public PyPI releases only for selected provenance packages after a selected package has more than ten visible releases; missing current releases or failed cleanup after the threshold is reached are hard failures.
 - `publish-release-assets`: uploads release artifacts and supply-chain evidence to GitHub Releases.
 - `publish-dataset-release-assets`: builds a complete tracked-dataset archive, manifest, and checksums from an LFS-materialized checkout, then creates a separate content-addressed `datasets-<manifest-hash>` GitHub Release only when that dataset payload has not already been published. This job is intentionally independent from PyPI package selection; PyPI packages keep their packaged datasets.
 - `sync-hf-space`: deploys the public Hugging Face Space after release assets only when the umbrella `agilab` release is selected.
@@ -305,9 +305,11 @@ PY
 ```
 
 After PyPI pruning, `missing_expected` must be empty. `stale_old_releases`
-should be empty when strict retention succeeds, but stale versions can remain as
-cleanup debt when PyPI web login, unrecognized-login confirmation, or
-reauthentication blocks deletion. Do not confuse that warning state with a
+can be non-empty when the package is still below the workflow's ten-release
+cleanup threshold. Once threshold-triggered or explicit strict retention runs,
+remaining stale versions are cleanup debt when PyPI web login,
+unrecognized-login confirmation, or reauthentication blocks deletion. Do not
+confuse a below-threshold retained history or an authentication warning with a
 failed publish or failed provenance check.
 
 ### Release Proof and Docs
@@ -421,9 +423,11 @@ after the badge/source change.
   `agilab` wheel metadata. If `Requires-Dist` pins internal packages to a
   deleted version, publish a new corrective `.postN` release for the whole
   package graph before deleting anything else.
-- PyPI retention reports success but old releases remain: confirm whether PyPI
-  required password/TOTP reauthentication or unrecognized-login confirmation.
-  OIDC Trusted Publishing cannot delete old releases.
+- PyPI retention reports success but old releases remain: first check whether
+  the package is below the workflow's ten-release cleanup threshold. If the
+  threshold was reached, confirm whether PyPI required password/TOTP
+  reauthentication or unrecognized-login confirmation. OIDC Trusted Publishing
+  cannot delete old releases.
 - GitHub Release exists but PyPI missing: inspect `publish-agilab` and split
   package jobs; do not assume release assets imply package upload.
 - PyPI published but `sync-hf-space` skipped: first check
@@ -460,8 +464,10 @@ after the badge/source change.
 - If old releases must be deleted manually, use PyPI's project release pages or
   a controlled browser session, then re-run the split-package release truth
   check above.
-- Keep a single-current-release policy as a post-publish cleanup step, not as a
-  precondition for publishing the replacement package graph.
+- Keep the workflow's ten-release cleanup threshold as a post-publish cleanup
+  policy, not as a precondition for publishing the replacement package graph.
+  Use explicit manual cleanup only when an operator wants stricter retention for
+  a known package set.
 
 ## Final Answer Contract
 

--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -758,7 +758,7 @@ jobs:
       - name: Install PyPI retention dependencies
         run: python -m pip install --upgrade --no-cache-dir packaging pypi-cleanup requests
 
-      - name: Delete older PyPI releases and keep the current release only
+      - name: Delete older PyPI releases once package history exceeds ten releases
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -771,6 +771,7 @@ jobs:
             --repo pypi
             --repo-root .
             --protect-versions-from-projects
+            --min-published-releases 11
             --confirm-delete
             --direct-web-only
             --json

--- a/test/test_pypi_publish_workflow.py
+++ b/test/test_pypi_publish_workflow.py
@@ -421,10 +421,12 @@ def test_pypi_publish_attempts_previous_pypi_release_pruning_before_release_asse
     assert "PYPI_RELEASE_PRUNE_OTP: ${{ secrets.PYPI_RELEASE_PRUNE_OTP }}" in text
     assert "PYPI_CONFIRM_READER_TOKEN: ${{ secrets.PYPI_CONFIRM_READER_TOKEN }}" in text
     assert "PYPI_RETENTION_PACKAGES: ${{ needs.release-plan.outputs.provenance_packages }}" in text
+    assert "Delete older PyPI releases once package history exceeds ten releases" in text
     assert "python -m pip install --upgrade --no-cache-dir packaging pypi-cleanup requests" in text
     assert "tools/pypi_release_retention.py" in text
     assert "--confirm-delete" in text
     assert "--direct-web-only" in text
+    assert "--min-published-releases 11" in text
     assert "retention_log=\"$(mktemp)\"" in text
     assert "PyPI redirected back to login while opening the release delete page after password/TOTP authentication." in text
     assert "--github-confirm-login-repository \"$GITHUB_REPOSITORY\"" in text

--- a/test/test_pypi_release_retention.py
+++ b/test/test_pypi_release_retention.py
@@ -36,6 +36,49 @@ def test_retention_plan_keeps_only_protected_normalized_version(monkeypatch) -> 
     assert plan.missing_protected_version is False
 
 
+def test_retention_plan_retains_old_versions_below_publish_threshold(monkeypatch) -> None:
+    module = _load_module()
+
+    monkeypatch.setattr(
+        module,
+        "fetch_releases",
+        lambda package, repo: ["2026.04.16", "2026.04.17", "2026.05.17"],
+    )
+
+    plan = module.build_plan(
+        "agilab",
+        "pypi",
+        "v2026.05.17",
+        min_published_releases=11,
+    )
+
+    assert plan.delete_versions == []
+    assert plan.retained_versions == ["2026.04.16", "2026.04.17"]
+    assert plan.retention_skipped_reason == (
+        "published release count 3 is below cleanup threshold 11"
+    )
+    assert plan.missing_protected_version is False
+
+
+def test_retention_plan_deletes_old_versions_when_publish_threshold_is_reached(monkeypatch) -> None:
+    module = _load_module()
+    releases = [f"2026.05.{day:02d}" for day in range(1, 12)]
+
+    monkeypatch.setattr(module, "fetch_releases", lambda package, repo: releases)
+
+    plan = module.build_plan(
+        "agilab",
+        "pypi",
+        "2026.05.11",
+        min_published_releases=11,
+    )
+
+    assert plan.delete_versions == releases[:-1]
+    assert plan.retained_versions == []
+    assert plan.retention_skipped_reason is None
+    assert plan.missing_protected_version is False
+
+
 def test_resolve_protect_versions_accepts_disaligned_package_versions() -> None:
     module = _load_module()
 
@@ -232,6 +275,41 @@ def test_main_refuses_to_delete_without_confirmation(monkeypatch, capsys) -> Non
         module.main(["--package", "agilab", "--protect-version", "2026.05.17"])
 
     assert capsys.readouterr().out == ""
+
+
+def test_main_skips_credentials_below_min_published_release_threshold(monkeypatch, capsys) -> None:
+    module = _load_module()
+
+    monkeypatch.setattr(
+        module,
+        "fetch_releases",
+        lambda package, repo: ["2026.04.16", "2026.05.17"],
+    )
+
+    def fail_require_credentials(*args, **kwargs):  # pragma: no cover - must not be called
+        raise AssertionError("credentials should not be requested below threshold")
+
+    monkeypatch.setattr(module, "require_credentials", fail_require_credentials)
+
+    status = module.main(
+        [
+            "--package",
+            "agilab",
+            "--protect-version",
+            "2026.05.17",
+            "--min-published-releases",
+            "11",
+            "--json",
+            "--retry-delay",
+            "0",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert status == 0
+    assert '"success": true' in captured.out
+    assert '"retained_versions": [\n        "2026.04.16"\n      ]' in captured.out
+    assert "below cleanup threshold 11" in captured.out
 
 
 def test_main_retries_until_protected_release_is_visible(monkeypatch, capsys) -> None:

--- a/tools/pypi_release_retention.py
+++ b/tools/pypi_release_retention.py
@@ -85,7 +85,9 @@ class ReleasePlan:
     protect_version: str
     published_versions: list[str]
     delete_versions: list[str]
+    retained_versions: list[str]
     missing_protected_version: bool
+    retention_skipped_reason: str | None = None
 
 
 def normalize_version(version: str) -> str:
@@ -270,14 +272,33 @@ def fetch_releases(package: str, repo: str, *, timeout: int = 15) -> list[str]:
     return sorted(releases, key=lambda value: Version(value))
 
 
-def build_plan(package: str, repo: str, protect_version: str) -> ReleasePlan:
+def build_plan(
+    package: str,
+    repo: str,
+    protect_version: str,
+    *,
+    min_published_releases: int = 2,
+) -> ReleasePlan:
     protected = Version(normalize_version(protect_version))
     releases = fetch_releases(package, repo)
-    delete_versions = [
+    old_versions = [
         version
         for version in releases
         if Version(normalize_version(version)) != protected
     ]
+    if len(releases) < min_published_releases:
+        delete_versions: list[str] = []
+        retained_versions = old_versions
+        retention_skipped_reason = (
+            f"published release count {len(releases)} is below cleanup threshold "
+            f"{min_published_releases}"
+            if old_versions
+            else None
+        )
+    else:
+        delete_versions = old_versions
+        retained_versions = []
+        retention_skipped_reason = None
     missing_protected = all(
         Version(normalize_version(version)) != protected for version in releases
     )
@@ -286,7 +307,9 @@ def build_plan(package: str, repo: str, protect_version: str) -> ReleasePlan:
         protect_version=str(protected),
         published_versions=releases,
         delete_versions=delete_versions,
+        retained_versions=retained_versions,
         missing_protected_version=missing_protected,
+        retention_skipped_reason=retention_skipped_reason,
     )
 
 
@@ -297,10 +320,19 @@ def wait_for_protected_releases(
     protect_version: str,
     attempts: int,
     retry_delay: float,
+    min_published_releases: int = 2,
 ) -> list[ReleasePlan]:
     latest: list[ReleasePlan] = []
     for attempt in range(1, max(1, attempts) + 1):
-        latest = [build_plan(package, repo, protect_version) for package in packages]
+        latest = [
+            build_plan(
+                package,
+                repo,
+                protect_version,
+                min_published_releases=min_published_releases,
+            )
+            for package in packages
+        ]
         if all(not plan.missing_protected_version for plan in latest):
             return latest
         if attempt < attempts:
@@ -314,11 +346,17 @@ def wait_for_package_protected_releases(
     repo: str,
     attempts: int,
     retry_delay: float,
+    min_published_releases: int = 2,
 ) -> list[ReleasePlan]:
     latest: list[ReleasePlan] = []
     for attempt in range(1, max(1, attempts) + 1):
         latest = [
-            build_plan(package, repo, protect_version)
+            build_plan(
+                package,
+                repo,
+                protect_version,
+                min_published_releases=min_published_releases,
+            )
             for package, protect_version in package_versions.items()
         ]
         if all(not plan.missing_protected_version for plan in latest):
@@ -985,10 +1023,19 @@ def verify_retention(
     protect_version: str,
     attempts: int,
     retry_delay: float,
+    min_published_releases: int = 2,
 ) -> list[ReleasePlan]:
     latest: list[ReleasePlan] = []
     for attempt in range(1, max(1, attempts) + 1):
-        latest = [build_plan(package, repo, protect_version) for package in packages]
+        latest = [
+            build_plan(
+                package,
+                repo,
+                protect_version,
+                min_published_releases=min_published_releases,
+            )
+            for package in packages
+        ]
         failures = [
             plan
             for plan in latest
@@ -1007,11 +1054,17 @@ def verify_package_retention(
     repo: str,
     attempts: int,
     retry_delay: float,
+    min_published_releases: int = 2,
 ) -> list[ReleasePlan]:
     latest: list[ReleasePlan] = []
     for attempt in range(1, max(1, attempts) + 1):
         latest = [
-            build_plan(package, repo, protect_version)
+            build_plan(
+                package,
+                repo,
+                protect_version,
+                min_published_releases=min_published_releases,
+            )
             for package, protect_version in package_versions.items()
         ]
         failures = [
@@ -1040,7 +1093,9 @@ def render_summary(plans: Sequence[ReleasePlan], *, dry_run: bool) -> dict[str, 
                 "protect_version": plan.protect_version,
                 "published_versions": plan.published_versions,
                 "delete_versions": plan.delete_versions,
+                "retained_versions": plan.retained_versions,
                 "missing_protected_version": plan.missing_protected_version,
+                "retention_skipped_reason": plan.retention_skipped_reason,
             }
             for plan in plans
         ],
@@ -1058,7 +1113,11 @@ def append_step_summary(path: Path, summary: dict[str, Any]) -> None:
         "| --- | ---: | ---: | --- |",
     ]
     for package in summary["packages"]:
-        deleted = ", ".join(package["delete_versions"]) or "(none)"
+        if package.get("retention_skipped_reason"):
+            retained = ", ".join(package["retained_versions"]) or "(none)"
+            deleted = f"retained below threshold: {retained}"
+        else:
+            deleted = ", ".join(package["delete_versions"]) or "(none)"
         lines.append(
             "| `{package}` | `{protect}` | `{published}` | {deleted} |".format(
                 package=package["package"],
@@ -1138,6 +1197,16 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--json", action="store_true")
     parser.add_argument("--verbose", action="store_true")
     parser.add_argument(
+        "--min-published-releases",
+        type=int,
+        default=2,
+        help=(
+            "Only delete old releases after a package has at least this many "
+            "published releases. The default keeps the existing strict "
+            "single-current-release cleanup behavior."
+        ),
+    )
+    parser.add_argument(
         "--direct-web-only",
         action="store_true",
         help=(
@@ -1179,6 +1248,8 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = parse_args(argv)
+    if args.min_published_releases < 2:
+        raise SystemExit("ERROR: --min-published-releases must be at least 2")
     packages = resolve_package_selection(
         package_values=args.package,
         packages_values=args.packages,
@@ -1225,6 +1296,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         repo=args.repo,
         attempts=args.verify_attempts,
         retry_delay=args.retry_delay,
+        min_published_releases=args.min_published_releases,
     )
     missing = [
         f"{plan.package}={plan.protect_version}"
@@ -1330,6 +1402,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             repo=args.repo,
             attempts=args.verify_attempts,
             retry_delay=args.retry_delay,
+            min_published_releases=args.min_published_releases,
         )
     else:
         delete_blocked = False
@@ -1341,10 +1414,16 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(json.dumps(summary, indent=2, sort_keys=True))
     else:
         for package in summary["packages"]:
-            deleted = ", ".join(package["delete_versions"]) or "(none)"
+            old_versions = package["delete_versions"] or package["retained_versions"]
+            deleted = ", ".join(old_versions) or "(none)"
+            skipped = (
+                f" retention_skipped={package['retention_skipped_reason']}"
+                if package.get("retention_skipped_reason")
+                else ""
+            )
             print(
                 f"{package['package']}: keep={package['protect_version']} "
-                f"published={len(package['published_versions'])} old={deleted}"
+                f"published={len(package['published_versions'])} old={deleted}{skipped}"
             )
     return 0 if summary["success"] or args.dry_run or delete_blocked else 1
 

--- a/tools/release_plan.py
+++ b/tools/release_plan.py
@@ -756,6 +756,9 @@ def validate_workflow_contract(workflow_path: Path) -> list[str]:
         "--repo-root .": (
             "PyPI release retention must read selected project versions from the checked-out repo"
         ),
+        "--min-published-releases 11": (
+            "release workflow must defer destructive PyPI pruning until a selected package has more than ten visible releases"
+        ),
         "PYPI_RELEASE_PRUNE_PASSWORD": (
             "workflow must keep PyPI release pruning credentials separate from OIDC upload"
         ),


### PR DESCRIPTION
## Summary
- Add a `--min-published-releases` threshold to the PyPI retention tool.
- Configure `pypi-publish` retention to prune only once a selected package has more than ten visible releases.
- Update release workflow contract tests and AGILAB release/PyPI maintenance skills.

## Validation
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_pypi_publish_workflow.py test/test_pypi_release_retention.py test/test_release_plan.py`
- workflow YAML parse check
- `uv --preview-features extra-build-dependencies run python tools/release_plan.py --check-workflow .github/workflows/pypi-publish.yaml --format json --compact`
- `uv --preview-features extra-build-dependencies run --extra dev ruff check tools/pypi_release_retention.py tools/release_plan.py test/test_pypi_release_retention.py test/test_pypi_publish_workflow.py`
- repo skill sync, validate/generate, quality/security gates, and `workflow_parity.py --profile skills`
- `git diff --check`
- `./dev scope`
