### PR TITLE
Refresh agi-cluster coverage badge

### DIFF
--- a/badges/coverage-agi-cluster.svg
+++ b/badges/coverage-agi-cluster.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="181" height="20" role="img" aria-label="agi-cluster coverage: 97%">
+<svg xmlns="http://www.w3.org/2000/svg" width="181" height="20" role="img" aria-label="agi-cluster coverage: 96%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="75.0" y="15" fill="#010101" fill-opacity=".3">agi-cluster coverage</text>
   <text x="75.0" y="14">agi-cluster coverage</text>
-  <text x="165.5" y="15" fill="#010101" fill-opacity=".3">97%</text>
-  <text x="165.5" y="14">97%</text>
+  <text x="165.5" y="15" fill="#010101" fill-opacity=".3">96%</text>
+  <text x="165.5" y="14">96%</text>
 </g>
 </svg>


### PR DESCRIPTION
## Summary
- Refresh `badges/coverage-agi-cluster.svg` from the coverage artifacts produced by main run 27813542506 after PR #658 merged.

## Validation
- Downloaded `coverage-*-xml` artifacts from main coverage run 27813542506.
- `python3 tools/generate_component_coverage_badges.py --components agi-cluster`
- `AGILAB_ALLOW_BADGE_ONLY_UPDATE=1 uv --preview-features extra-build-dependencies run python tools/coverage_badge_guard.py --changed-only --require-fresh-xml`
- `git diff --check`
- `./dev scope`
