### PR TITLE
Parameterize PyPI retention threshold

### DIFF
--- a/.claude/skills/agilab-pypi-release-maintenance/SKILL.md
+++ b/.claude/skills/agilab-pypi-release-maintenance/SKILL.md
@@ -28,9 +28,11 @@ For publication-process optimization checks, inspect the current workflow first:
 selected package versions whose expected PyPI artifacts already exist, so those
 packages do not enter build, upload, provenance, retention, or release-asset
 jobs. The release workflow also defers destructive PyPI retention until a
-selected package has more than ten visible releases; the manual retention tool
-keeps its strict single-current-release default unless an operator passes a
-threshold explicitly.
+selected package exceeds the configured threshold
+(`pypi_retention_min_published_releases`, default `11`, or the
+`PYPI_RETENTION_MIN_PUBLISHED_RELEASES` repository variable for tag runs); the
+manual retention tool keeps its strict single-current-release default unless an
+operator passes a threshold explicitly.
 
 ## Required Safety Rules
 
@@ -185,15 +187,16 @@ uv --preview-features extra-build-dependencies run python tools/pypi_release_ret
   --packages "agilab agi-core agi-env" \
   --repo-root . \
   --protect-versions-from-projects \
-  --min-published-releases 11 \
+  --min-published-releases "$PYPI_RETENTION_MIN_PUBLISHED_RELEASES" \
   --dry-run \
   --json
 ```
 
-`--min-published-releases 11` matches the public `pypi-publish` workflow: keep
-old releases during normal publication, then prune only when a selected package
-would expose an eleventh release. Omit the threshold for explicit manual cleanup
-when the operator wants strict single-current-release retention now.
+`PYPI_RETENTION_MIN_PUBLISHED_RELEASES` matches the public `pypi-publish`
+workflow policy: keep old releases during normal publication, then prune only
+when a selected package exceeds the configured visible-release threshold. Omit
+the threshold for explicit manual cleanup when the operator wants strict
+single-current-release retention now.
 
 Use a single `--protect-version` only for legacy aligned-version cleanup.
 For same-version partial releases, do not hand-copy long package lists. Prefer
@@ -401,9 +404,9 @@ real issue is cleanup, release-plan selection, or package reuse. The public
 - When any expected artifact is missing, the workflow builds, verifies,
   manifests, and publishes that package with Trusted Publishing.
 - Destructive retention is intentionally less frequent than publication: the
-  release workflow passes `--min-published-releases 11`, so PyPI web-login
-  deletion runs only after a selected package accumulates more than ten visible
-  releases.
+  release workflow passes the configured
+  `PYPI_RETENTION_MIN_PUBLISHED_RELEASES` value, so PyPI web-login deletion
+  runs only after a selected package exceeds that visible-release threshold.
 
 Do not use deletion/reupload churn to compensate for unchanged package
 publication. Prefer fixing the reuse gate, release-plan matrix, or artifact

--- a/.claude/skills/agilab-release-verification/SKILL.md
+++ b/.claude/skills/agilab-release-verification/SKILL.md
@@ -162,7 +162,7 @@ workflow dispatch:
 - `publish-library-packages`: publishes selected split packages with PyPI Trusted Publishing.
 - `publish-agilab`: publishes the top-level `agilab` package only when the umbrella package is still selected.
 - `pypi-provenance-evidence`: verifies PyPI attestations only for `provenance_packages` selected by the release plan.
-- `pypi-release-retention`: prunes older public PyPI releases only for selected provenance packages after a selected package has more than ten visible releases; missing current releases or failed cleanup after the threshold is reached are hard failures.
+- `pypi-release-retention`: prunes older public PyPI releases only for selected provenance packages after a selected package exceeds the configured visible-release threshold (`pypi_retention_min_published_releases`, default `11`, or the `PYPI_RETENTION_MIN_PUBLISHED_RELEASES` repository variable for tag runs); missing current releases or failed cleanup after the threshold is reached are hard failures.
 - `publish-release-assets`: uploads release artifacts and supply-chain evidence to GitHub Releases.
 - `publish-dataset-release-assets`: builds a complete tracked-dataset archive, manifest, and checksums from an LFS-materialized checkout, then creates a separate content-addressed `datasets-<manifest-hash>` GitHub Release only when that dataset payload has not already been published. This job is intentionally independent from PyPI package selection; PyPI packages keep their packaged datasets.
 - `sync-hf-space`: deploys the public Hugging Face Space after release assets only when the umbrella `agilab` release is selected.
@@ -305,7 +305,7 @@ PY
 ```
 
 After PyPI pruning, `missing_expected` must be empty. `stale_old_releases`
-can be non-empty when the package is still below the workflow's ten-release
+can be non-empty when the package is still below the workflow's configured
 cleanup threshold. Once threshold-triggered or explicit strict retention runs,
 remaining stale versions are cleanup debt when PyPI web login,
 unrecognized-login confirmation, or reauthentication blocks deletion. Do not
@@ -424,7 +424,7 @@ after the badge/source change.
   deleted version, publish a new corrective `.postN` release for the whole
   package graph before deleting anything else.
 - PyPI retention reports success but old releases remain: first check whether
-  the package is below the workflow's ten-release cleanup threshold. If the
+  the package is below the workflow's configured cleanup threshold. If the
   threshold was reached, confirm whether PyPI required password/TOTP
   reauthentication or unrecognized-login confirmation. OIDC Trusted Publishing
   cannot delete old releases.
@@ -464,7 +464,7 @@ after the badge/source change.
 - If old releases must be deleted manually, use PyPI's project release pages or
   a controlled browser session, then re-run the split-package release truth
   check above.
-- Keep the workflow's ten-release cleanup threshold as a post-publish cleanup
+- Keep the workflow's configured cleanup threshold as a post-publish cleanup
   policy, not as a precondition for publishing the replacement package graph.
   Use explicit manual cleanup only when an operator wants stricter retention for
   a known package set.

--- a/.codex/skills/agilab-pypi-release-maintenance/SKILL.md
+++ b/.codex/skills/agilab-pypi-release-maintenance/SKILL.md
@@ -28,9 +28,11 @@ For publication-process optimization checks, inspect the current workflow first:
 selected package versions whose expected PyPI artifacts already exist, so those
 packages do not enter build, upload, provenance, retention, or release-asset
 jobs. The release workflow also defers destructive PyPI retention until a
-selected package has more than ten visible releases; the manual retention tool
-keeps its strict single-current-release default unless an operator passes a
-threshold explicitly.
+selected package exceeds the configured threshold
+(`pypi_retention_min_published_releases`, default `11`, or the
+`PYPI_RETENTION_MIN_PUBLISHED_RELEASES` repository variable for tag runs); the
+manual retention tool keeps its strict single-current-release default unless an
+operator passes a threshold explicitly.
 
 ## Required Safety Rules
 
@@ -185,15 +187,16 @@ uv --preview-features extra-build-dependencies run python tools/pypi_release_ret
   --packages "agilab agi-core agi-env" \
   --repo-root . \
   --protect-versions-from-projects \
-  --min-published-releases 11 \
+  --min-published-releases "$PYPI_RETENTION_MIN_PUBLISHED_RELEASES" \
   --dry-run \
   --json
 ```
 
-`--min-published-releases 11` matches the public `pypi-publish` workflow: keep
-old releases during normal publication, then prune only when a selected package
-would expose an eleventh release. Omit the threshold for explicit manual cleanup
-when the operator wants strict single-current-release retention now.
+`PYPI_RETENTION_MIN_PUBLISHED_RELEASES` matches the public `pypi-publish`
+workflow policy: keep old releases during normal publication, then prune only
+when a selected package exceeds the configured visible-release threshold. Omit
+the threshold for explicit manual cleanup when the operator wants strict
+single-current-release retention now.
 
 Use a single `--protect-version` only for legacy aligned-version cleanup.
 For same-version partial releases, do not hand-copy long package lists. Prefer
@@ -401,9 +404,9 @@ real issue is cleanup, release-plan selection, or package reuse. The public
 - When any expected artifact is missing, the workflow builds, verifies,
   manifests, and publishes that package with Trusted Publishing.
 - Destructive retention is intentionally less frequent than publication: the
-  release workflow passes `--min-published-releases 11`, so PyPI web-login
-  deletion runs only after a selected package accumulates more than ten visible
-  releases.
+  release workflow passes the configured
+  `PYPI_RETENTION_MIN_PUBLISHED_RELEASES` value, so PyPI web-login deletion
+  runs only after a selected package exceeds that visible-release threshold.
 
 Do not use deletion/reupload churn to compensate for unchanged package
 publication. Prefer fixing the reuse gate, release-plan matrix, or artifact

--- a/.codex/skills/agilab-release-verification/SKILL.md
+++ b/.codex/skills/agilab-release-verification/SKILL.md
@@ -162,7 +162,7 @@ workflow dispatch:
 - `publish-library-packages`: publishes selected split packages with PyPI Trusted Publishing.
 - `publish-agilab`: publishes the top-level `agilab` package only when the umbrella package is still selected.
 - `pypi-provenance-evidence`: verifies PyPI attestations only for `provenance_packages` selected by the release plan.
-- `pypi-release-retention`: prunes older public PyPI releases only for selected provenance packages after a selected package has more than ten visible releases; missing current releases or failed cleanup after the threshold is reached are hard failures.
+- `pypi-release-retention`: prunes older public PyPI releases only for selected provenance packages after a selected package exceeds the configured visible-release threshold (`pypi_retention_min_published_releases`, default `11`, or the `PYPI_RETENTION_MIN_PUBLISHED_RELEASES` repository variable for tag runs); missing current releases or failed cleanup after the threshold is reached are hard failures.
 - `publish-release-assets`: uploads release artifacts and supply-chain evidence to GitHub Releases.
 - `publish-dataset-release-assets`: builds a complete tracked-dataset archive, manifest, and checksums from an LFS-materialized checkout, then creates a separate content-addressed `datasets-<manifest-hash>` GitHub Release only when that dataset payload has not already been published. This job is intentionally independent from PyPI package selection; PyPI packages keep their packaged datasets.
 - `sync-hf-space`: deploys the public Hugging Face Space after release assets only when the umbrella `agilab` release is selected.
@@ -305,7 +305,7 @@ PY
 ```
 
 After PyPI pruning, `missing_expected` must be empty. `stale_old_releases`
-can be non-empty when the package is still below the workflow's ten-release
+can be non-empty when the package is still below the workflow's configured
 cleanup threshold. Once threshold-triggered or explicit strict retention runs,
 remaining stale versions are cleanup debt when PyPI web login,
 unrecognized-login confirmation, or reauthentication blocks deletion. Do not
@@ -424,7 +424,7 @@ after the badge/source change.
   deleted version, publish a new corrective `.postN` release for the whole
   package graph before deleting anything else.
 - PyPI retention reports success but old releases remain: first check whether
-  the package is below the workflow's ten-release cleanup threshold. If the
+  the package is below the workflow's configured cleanup threshold. If the
   threshold was reached, confirm whether PyPI required password/TOTP
   reauthentication or unrecognized-login confirmation. OIDC Trusted Publishing
   cannot delete old releases.
@@ -464,7 +464,7 @@ after the badge/source change.
 - If old releases must be deleted manually, use PyPI's project release pages or
   a controlled browser session, then re-run the split-package release truth
   check above.
-- Keep the workflow's ten-release cleanup threshold as a post-publish cleanup
+- Keep the workflow's configured cleanup threshold as a post-publish cleanup
   policy, not as a precondition for publishing the replacement package graph.
   Use explicit manual cleanup only when an operator wants stricter retention for
   a known package set.

--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -30,6 +30,11 @@ on:
         required: false
         type: boolean
         default: false
+      pypi_retention_min_published_releases:
+        description: "Minimum visible PyPI releases before retention prunes older releases."
+        required: false
+        type: string
+        default: "11"
   push:
     tags:
       - "v*.*.*"
@@ -40,6 +45,7 @@ concurrency:
 
 env:
   PYTHON_VERSION: "3.13"
+  PYPI_RETENTION_MIN_PUBLISHED_RELEASES: ${{ github.event.inputs.pypi_retention_min_published_releases || vars.PYPI_RETENTION_MIN_PUBLISHED_RELEASES || '11' }}
 
 jobs:
   release-audit:
@@ -758,7 +764,7 @@ jobs:
       - name: Install PyPI retention dependencies
         run: python -m pip install --upgrade --no-cache-dir packaging pypi-cleanup requests
 
-      - name: Delete older PyPI releases once package history exceeds ten releases
+      - name: Delete older PyPI releases once package history exceeds configured threshold
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -767,11 +773,21 @@ jobs:
             echo "PYPI_CONFIRM_READER_TOKEN secret is required to read the temporary PyPI confirmation variable." >&2
             exit 2
           }
+          case "$PYPI_RETENTION_MIN_PUBLISHED_RELEASES" in
+            ''|*[!0-9]*)
+              echo "PYPI_RETENTION_MIN_PUBLISHED_RELEASES must be an integer >= 2." >&2
+              exit 2
+              ;;
+          esac
+          if [[ "$PYPI_RETENTION_MIN_PUBLISHED_RELEASES" -lt 2 ]]; then
+            echo "PYPI_RETENTION_MIN_PUBLISHED_RELEASES must be an integer >= 2." >&2
+            exit 2
+          fi
           args=(
             --repo pypi
             --repo-root .
             --protect-versions-from-projects
-            --min-published-releases 11
+            --min-published-releases "$PYPI_RETENTION_MIN_PUBLISHED_RELEASES"
             --confirm-delete
             --direct-web-only
             --json

--- a/test/test_pypi_publish_workflow.py
+++ b/test/test_pypi_publish_workflow.py
@@ -421,12 +421,23 @@ def test_pypi_publish_attempts_previous_pypi_release_pruning_before_release_asse
     assert "PYPI_RELEASE_PRUNE_OTP: ${{ secrets.PYPI_RELEASE_PRUNE_OTP }}" in text
     assert "PYPI_CONFIRM_READER_TOKEN: ${{ secrets.PYPI_CONFIRM_READER_TOKEN }}" in text
     assert "PYPI_RETENTION_PACKAGES: ${{ needs.release-plan.outputs.provenance_packages }}" in text
-    assert "Delete older PyPI releases once package history exceeds ten releases" in text
+    assert (
+        '      pypi_retention_min_published_releases:\n'
+        '        description: "Minimum visible PyPI releases before retention prunes older releases."\n'
+        "        required: false\n"
+        "        type: string\n"
+        '        default: "11"'
+    ) in text
+    assert "PYPI_RETENTION_MIN_PUBLISHED_RELEASES" in text
+    assert "vars.PYPI_RETENTION_MIN_PUBLISHED_RELEASES" in text
+    assert "must be an integer >= 2" in text
+    assert "Delete older PyPI releases once package history exceeds configured threshold" in text
     assert "python -m pip install --upgrade --no-cache-dir packaging pypi-cleanup requests" in text
     assert "tools/pypi_release_retention.py" in text
     assert "--confirm-delete" in text
     assert "--direct-web-only" in text
-    assert "--min-published-releases 11" in text
+    assert '--min-published-releases "$PYPI_RETENTION_MIN_PUBLISHED_RELEASES"' in text
+    assert "--min-published-releases 11" not in text
     assert "retention_log=\"$(mktemp)\"" in text
     assert "PyPI redirected back to login while opening the release delete page after password/TOTP authentication." in text
     assert "--github-confirm-login-repository \"$GITHUB_REPOSITORY\"" in text

--- a/tools/release_plan.py
+++ b/tools/release_plan.py
@@ -750,14 +750,26 @@ def validate_workflow_contract(workflow_path: Path) -> list[str]:
         "--release-mode": "workflow must pass explicit release intent to the policy gate",
         "pypi-release-retention:": "workflow must prune old PyPI releases after provenance passes",
         "tools/pypi_release_retention.py": "workflow must use the PyPI release retention tool",
+        "pypi_retention_min_published_releases:": (
+            "release workflow must expose the PyPI retention threshold as a dispatch input"
+        ),
+        "PYPI_RETENTION_MIN_PUBLISHED_RELEASES": (
+            "release workflow must pass the configured PyPI retention threshold through the job environment"
+        ),
+        "vars.PYPI_RETENTION_MIN_PUBLISHED_RELEASES": (
+            "release workflow must allow tag releases to override the PyPI retention threshold by repository variable"
+        ),
         "--protect-versions-from-projects": (
             "PyPI release retention must protect each selected package's own project version"
         ),
         "--repo-root .": (
             "PyPI release retention must read selected project versions from the checked-out repo"
         ),
-        "--min-published-releases 11": (
-            "release workflow must defer destructive PyPI pruning until a selected package has more than ten visible releases"
+        "--min-published-releases \"$PYPI_RETENTION_MIN_PUBLISHED_RELEASES\"": (
+            "release workflow must use the configured threshold instead of hard-coding PyPI pruning frequency"
+        ),
+        "must be an integer >= 2": (
+            "release workflow must validate the configured PyPI retention threshold before invoking cleanup"
         ),
         "PYPI_RELEASE_PRUNE_PASSWORD": (
             "workflow must keep PyPI release pruning credentials separate from OIDC upload"


### PR DESCRIPTION
## Summary
- add `pypi_retention_min_published_releases` workflow dispatch input and `PYPI_RETENTION_MIN_PUBLISHED_RELEASES` repository-variable fallback for tag releases
- pass the configured value to `tools/pypi_release_retention.py` instead of hard-coding `--min-published-releases 11`
- update workflow contract tests and release-maintenance skills so the threshold stays configurable

## Validation
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_pypi_publish_workflow.py test/test_release_plan.py`
- workflow YAML parse smoke
- `uv --preview-features extra-build-dependencies run python tools/release_plan.py --check-workflow .github/workflows/pypi-publish.yaml --format json --compact`
- `uv --preview-features extra-build-dependencies run --extra dev ruff check test/test_pypi_publish_workflow.py tools/release_plan.py`
- `python3 tools/codex_skills.py --root .codex/skills validate --strict`
- `python3 tools/codex_skills.py --root .codex/skills generate`
- `python3 tools/agent_skill_quality_guard.py --roots .claude/skills .codex/skills --fail-on high`
- `python3 tools/skill_security_scan.py --roots .claude/skills .codex/skills --fail-on critical`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile skills`
- `git diff --check`
- `./dev scope --staged`
- `./dev impact --staged`