### PR TITLE
Support pre-mounted cluster share backends

### DIFF
--- a/src/agilab/cluster/cluster_flight_validation.py
+++ b/src/agilab/cluster/cluster_flight_validation.py
@@ -48,6 +48,14 @@ SSHFS_OPTIONS = (
     "StrictHostKeyChecking=yes",
     "noexec",
 )
+SSHFS_SHARE_BACKEND = "sshfs"
+PREMOUNTED_SHARE_BACKENDS = ("nfs", "ntfs")
+SUPPORTED_SHARE_BACKENDS = (SSHFS_SHARE_BACKEND, *PREMOUNTED_SHARE_BACKENDS)
+SHARE_BACKEND_LABELS = {
+    SSHFS_SHARE_BACKEND: "SSHFS",
+    "nfs": "NFS",
+    "ntfs": "NTFS",
+}
 REMOTE_PATH_PREFIX = 'export PATH="$HOME/.local/bin:$HOME/bin:/usr/local/bin:/opt/homebrew/bin:$PATH"; '
 
 
@@ -71,6 +79,7 @@ class ValidationPlan:
     worker_specs: tuple[WorkerSpec, ...]
     remote_user: str
     scheduler_ssh_port: int
+    cluster_share_backend: str
     remote_cluster_share_premounted: bool
     local_share_setting: str
     local_cluster_share_setting: str
@@ -119,6 +128,33 @@ class ShareSetupSummary:
     location: str
     action: str
     path: str
+
+
+def _normalize_share_backend(value: object = "") -> str:
+    backend = str(value or "").strip().lower() or SSHFS_SHARE_BACKEND
+    if backend not in SUPPORTED_SHARE_BACKENDS:
+        raise ValueError(f"unsupported share setup backend: {backend}")
+    return backend
+
+
+def _share_backend_label(backend: str) -> str:
+    return SHARE_BACKEND_LABELS.get(_normalize_share_backend(backend), backend.upper())
+
+
+def _share_backend_implies_premounted(backend: str) -> bool:
+    return _normalize_share_backend(backend) in PREMOUNTED_SHARE_BACKENDS
+
+
+def _resolve_cluster_share_backend(args: argparse.Namespace) -> str:
+    explicit = str(getattr(args, "cluster_share_backend", "") or "")
+    setup = str(getattr(args, "setup_share", "") or getattr(args, "print_share_setup", "") or "")
+    if explicit and setup and _normalize_share_backend(explicit) != _normalize_share_backend(setup):
+        raise ValueError("--cluster-share-backend must match --setup-share/--print-share-setup")
+    return _normalize_share_backend(explicit or setup)
+
+
+def _share_setup_uses_premounted(plan: ValidationPlan, backend: str) -> bool:
+    return bool(plan.remote_cluster_share_premounted or _share_backend_implies_premounted(backend))
 
 
 def _default_apps_path() -> Path:
@@ -194,6 +230,16 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--cluster-share-backend",
+        choices=SUPPORTED_SHARE_BACKENDS,
+        default="",
+        help=(
+            "Cluster-share backend contract. 'sshfs' mounts the scheduler share on workers; "
+            "'nfs' and 'ntfs' require pre-mounted shared storage and run the sentinel check. "
+            "Defaults to sshfs or the selected --setup-share backend."
+        ),
+    )
+    parser.add_argument(
         "--dataset-rel",
         default=str(DEFAULT_DATASET_REL.relative_to("localshare")),
         help="Dataset path relative to --local-share. Default: flight_cluster_validation/dataset/csv.",
@@ -239,13 +285,13 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--print-share-setup",
-        choices=("sshfs",),
+        choices=SUPPORTED_SHARE_BACKENDS,
         default="",
         help="Print cluster-share setup commands for the selected mount backend and exit.",
     )
     parser.add_argument(
         "--setup-share",
-        choices=("sshfs",),
+        choices=SUPPORTED_SHARE_BACKENDS,
         default="",
         help="Set up the shared cluster path using the selected backend.",
     )
@@ -350,6 +396,10 @@ def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
         parser.error("--setup-share already runs the share check")
     if args.setup_share and args.print_share_setup:
         parser.error("--setup-share cannot be combined with --print-share-setup")
+    if args.cluster_share_backend and args.setup_share and args.cluster_share_backend != args.setup_share:
+        parser.error("--cluster-share-backend must match --setup-share")
+    if args.cluster_share_backend and args.print_share_setup and args.cluster_share_backend != args.print_share_setup:
+        parser.error("--cluster-share-backend must match --print-share-setup")
     return args
 
 
@@ -502,6 +552,7 @@ def build_validation_plan(
     output_rel = Path(args.output_rel)
     if output_rel.is_absolute():
         raise ValueError("--output-rel must be relative to the cluster share")
+    cluster_share_backend = _resolve_cluster_share_backend(args)
     return ValidationPlan(
         app=args.app,
         apps_path=Path(args.apps_path).expanduser().resolve(strict=False),
@@ -510,7 +561,11 @@ def build_validation_plan(
         worker_specs=tuple(specs),
         remote_user=remote_user,
         scheduler_ssh_port=int(args.scheduler_ssh_port),
-        remote_cluster_share_premounted=bool(args.remote_cluster_share_premounted),
+        cluster_share_backend=cluster_share_backend,
+        remote_cluster_share_premounted=bool(
+            args.remote_cluster_share_premounted
+            or _share_backend_implies_premounted(cluster_share_backend)
+        ),
         local_share_setting=local_share_setting,
         local_cluster_share_setting=local_cluster_share_setting,
         remote_cluster_share_setting=str(args.remote_cluster_share or "clustershare"),
@@ -580,6 +635,8 @@ def _validate_scheduler_cluster_share_not_reverse_mounted(
     *,
     home: Path | None = None,
 ) -> None:
+    if plan.remote_cluster_share_premounted:
+        return
     cluster_root = local_cluster_share_root(plan, home=home)
     for spec in remote_worker_specs(plan):
         problem = _reverse_sshfs_mount_problem(cluster_root, spec.host)
@@ -733,7 +790,8 @@ def _workers_cli_value(plan: ValidationPlan) -> str:
     return ",".join(values)
 
 
-def _share_check_command(plan: ValidationPlan) -> str:
+def _share_check_command(plan: ValidationPlan, *, backend: str | None = None) -> str:
+    selected_backend = _normalize_share_backend(backend or plan.cluster_share_backend)
     parts = [
         "agilab",
         "doctor",
@@ -748,9 +806,11 @@ def _share_check_command(plan: ValidationPlan) -> str:
         plan.remote_cluster_share_setting,
         "--share-check-only",
     ]
+    if selected_backend != SSHFS_SHARE_BACKEND:
+        parts.extend(["--cluster-share-backend", selected_backend])
     if plan.scheduler_ssh_port != 22:
         parts.extend(["--scheduler-ssh-port", str(plan.scheduler_ssh_port)])
-    if plan.remote_cluster_share_premounted:
+    if _share_setup_uses_premounted(plan, selected_backend):
         parts.append("--remote-cluster-share-premounted")
     return " ".join(shlex.quote(part) for part in parts)
 
@@ -865,20 +925,24 @@ def share_setup_script_lines(
     *,
     local_user: str | None = None,
 ) -> tuple[str, ...]:
-    if backend != "sshfs":
-        raise ValueError(f"unsupported share setup backend: {backend}")
+    backend = _normalize_share_backend(backend)
+    backend_label = _share_backend_label(backend)
+    uses_premounted = _share_setup_uses_premounted(plan, backend)
 
     local_root = local_cluster_share_root(plan)
     lines = [
-        "# AGILAB cluster-share setup using SSHFS",
+        f"# AGILAB cluster-share setup using {backend_label}",
         "# Run these from the scheduler/manager host, then run the share check.",
         "# macOS workers need macFUSE + sshfs; Debian/Ubuntu workers need package sshfs.",
         "set -euo pipefail",
         f"mkdir -p {shlex.quote(str(local_root))}",
     ]
-    if plan.remote_cluster_share_premounted:
-        lines[0] = "# AGILAB cluster-share verification using pre-mounted remote shares"
-        lines[2] = "# Remote workers must already expose the same shared storage at AGI_CLUSTER_SHARE."
+    if uses_premounted:
+        lines[0] = f"# AGILAB cluster-share verification using pre-mounted {backend_label} shares"
+        lines[2] = (
+            "# Remote workers must already expose the same shared storage at "
+            "AGI_CLUSTER_SHARE; AGILAB will verify it instead of mounting with SSHFS."
+        )
         for spec in remote_worker_specs(plan):
             target = _ssh_target(spec, plan)
             lines.extend(
@@ -891,7 +955,7 @@ def share_setup_script_lines(
         lines.extend(
             [
                 "# Validate without running Flight install/compute:",
-                _share_check_command(plan),
+                _share_check_command(plan, backend=backend),
             ]
         )
         return tuple(lines)
@@ -914,7 +978,7 @@ def share_setup_script_lines(
     lines.extend(
         [
             "# Validate without running Flight install/compute:",
-            _share_check_command(plan),
+            _share_check_command(plan, backend=backend),
         ]
     )
     return tuple(lines)
@@ -927,17 +991,18 @@ def apply_share_setup(
     timeout: int,
     local_user: str | None = None,
 ) -> tuple[ShareSetupSummary, ...]:
-    if backend != "sshfs":
-        raise ValueError(f"unsupported share setup backend: {backend}")
+    backend = _normalize_share_backend(backend)
+    uses_premounted = _share_setup_uses_premounted(plan, backend)
 
     _validate_distinct_cluster_share(plan)
-    _validate_scheduler_cluster_share_not_reverse_mounted(plan)
+    if not uses_premounted:
+        _validate_scheduler_cluster_share_not_reverse_mounted(plan)
     local_root = local_cluster_share_root(plan)
     local_root.mkdir(parents=True, exist_ok=True)
     summaries = [
         ShareSetupSummary(location="local", action="mkdir", path=str(local_root)),
     ]
-    if plan.remote_cluster_share_premounted:
+    if uses_premounted:
         for spec in remote_worker_specs(plan):
             target = _ssh_target(spec, plan)
             completed = _run_command(_ssh_argv(target, _remote_env_update_command(plan)), timeout=timeout)
@@ -1216,6 +1281,7 @@ def _configure_process_env(plan: ValidationPlan) -> None:
     os.environ["AGI_LOCAL_SHARE"] = plan.local_share_setting
     os.environ["AGI_CLUSTER_SHARE"] = plan.local_cluster_share_setting
     os.environ["AGILAB_SCHEDULER_SSH_PORT"] = str(plan.scheduler_ssh_port)
+    os.environ["AGILAB_CLUSTER_SHARE_BACKEND"] = plan.cluster_share_backend
     if plan.remote_cluster_share_premounted:
         os.environ["AGILAB_REMOTE_CLUSTER_SHARE_PREMOUNTED"] = "1"
     else:
@@ -1231,6 +1297,7 @@ def _configure_agi_env_for_cluster_validation(env: Any, plan: ValidationPlan) ->
     env.envars["AGI_CLUSTER_ENABLED"] = "1"
     env.envars["AGI_LOCAL_SHARE"] = plan.local_share_setting
     env.envars["AGI_CLUSTER_SHARE"] = plan.local_cluster_share_setting
+    env.envars["AGILAB_CLUSTER_SHARE_BACKEND"] = plan.cluster_share_backend
     try:
         env._share_root_cache = None
         env.agi_share_path_abs = env.share_root_path()
@@ -1331,6 +1398,7 @@ def _print_plan(plan: ValidationPlan, files: Sequence[Path]) -> None:
     print(f"  workers: {plan.workers}")
     print(f"  ssh user: {plan.remote_user}")
     print(f"  scheduler ssh port: {plan.scheduler_ssh_port}")
+    print(f"  cluster share backend: {plan.cluster_share_backend}")
     print(f"  local input: {plan.local_dataset_dir}")
     print(f"  remote input: $HOME/{plan.dataset_rel_to_home.as_posix()}")
     print(f"  local cluster share: {plan.local_cluster_share_setting}")
@@ -1371,6 +1439,7 @@ def _run_lan_discovery(args: argparse.Namespace) -> dict[str, Any]:
     options = DiscoveryOptions(
         cidrs=parse_cidr_values(args.cidr) if args.cidr else (),
         remote_user=args.remote_user,
+        cluster_share_backend=_resolve_cluster_share_backend(args),
         active=not args.passive_only,
         tcp_timeout=args.discovery_timeout,
         ssh_timeout=args.ssh_probe_timeout,

--- a/src/agilab/cluster/cluster_lan_discovery.py
+++ b/src/agilab/cluster/cluster_lan_discovery.py
@@ -39,6 +39,7 @@ class _InterfaceIPv4:
 class DiscoveryOptions:
     cidrs: tuple[str, ...] = ()
     remote_user: str = ""
+    cluster_share_backend: str = "sshfs"
     active: bool = True
     port: int = DEFAULT_DISCOVERY_PORT
     tcp_timeout: float = DEFAULT_TCP_TIMEOUT
@@ -326,7 +327,12 @@ def _probe_node(
 
     values = _parse_key_value_lines(completed.stdout)
     reverse = _parse_optional_bool(values.get("reverse_ssh", ""))
-    status, score, errors = _classify(values, tcp_open=tcp_open, reverse_ssh=reverse)
+    status, score, errors = _classify(
+        values,
+        tcp_open=tcp_open,
+        reverse_ssh=reverse,
+        cluster_share_backend=options.cluster_share_backend,
+    )
     return DiscoveryNode(
         host=host,
         ssh_target=ssh_target,
@@ -389,14 +395,16 @@ def _classify(
     *,
     tcp_open: bool | None,
     reverse_ssh: bool | None,
+    cluster_share_backend: str = "sshfs",
 ) -> tuple[str, int, tuple[str, ...]]:
     if not values.get("python3"):
         return "python-missing", 50, ("python3 not found",)
     if not values.get("uv"):
         return "uv-missing", 60, ("uv not found",)
-    if not values.get("sshfs"):
+    needs_sshfs = str(cluster_share_backend or "sshfs").strip().lower() == "sshfs"
+    if needs_sshfs and not values.get("sshfs"):
         return "sshfs-missing", 70, ("sshfs not found",)
-    if reverse_ssh is False:
+    if needs_sshfs and reverse_ssh is False:
         return "reverse-ssh-needed", 80, ("worker cannot ssh back to scheduler",)
     score = 100 if tcp_open is not False else 90
     return "ready", score, ()

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_remote_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_remote_support.py
@@ -46,6 +46,9 @@ _SSHFS_OPTIONS = (
     "StrictHostKeyChecking=yes",
     "noexec",
 )
+_SSHFS_SHARE_BACKEND = "sshfs"
+_PREMOUNTED_SHARE_BACKENDS = {"nfs", "ntfs"}
+_SUPPORTED_SHARE_BACKENDS = {_SSHFS_SHARE_BACKEND, *_PREMOUNTED_SHARE_BACKENDS}
 _REMOTE_PATH_PREFIX = (
     'export PATH="$HOME/.local/bin:$HOME/bin:/usr/local/bin:/opt/homebrew/bin:$PATH"; '
 )
@@ -119,7 +122,7 @@ def _scheduler_ssh_port(env: Any) -> int:
 
 
 def _remote_cluster_share_premounted(env: Any) -> bool:
-    return _truthy_env(
+    return _cluster_share_backend(env) in _PREMOUNTED_SHARE_BACKENDS or _truthy_env(
         _env_lookup(
             env,
             "AGILAB_REMOTE_CLUSTER_SHARE_PREMOUNTED",
@@ -128,6 +131,19 @@ def _remote_cluster_share_premounted(env: Any) -> bool:
             "remote_cluster_share_premounted",
         )
     )
+
+
+def _cluster_share_backend(env: Any) -> str:
+    raw = _env_lookup(
+        env,
+        "AGILAB_CLUSTER_SHARE_BACKEND",
+        "AGI_CLUSTER_SHARE_BACKEND",
+        "cluster_share_backend",
+    )
+    backend = str(raw or _SSHFS_SHARE_BACKEND).strip().lower() or _SSHFS_SHARE_BACKEND
+    if backend not in _SUPPORTED_SHARE_BACKENDS:
+        raise ValueError(f"Unsupported AGILAB cluster-share backend: {backend!r}")
+    return backend
 
 
 def _sshfs_options_args() -> str:
@@ -478,9 +494,12 @@ async def _prepare_remote_cluster_share(
         or remote_share
     )
     local_share = _resolve_local_share_path(local_share_raw, env)
-    reverse_mount_problem = _reverse_sshfs_mount_problem(local_share, ip)
-    if reverse_mount_problem:
-        raise RuntimeError(reverse_mount_problem)
+    share_backend = _cluster_share_backend(env)
+    share_is_premounted = _remote_cluster_share_premounted(env)
+    if not share_is_premounted:
+        reverse_mount_problem = _reverse_sshfs_mount_problem(local_share, ip)
+        if reverse_mount_problem:
+            raise RuntimeError(reverse_mount_problem)
     scheduler_share = _scheduler_share_source(
         local_share,
         local_share_setting=local_share_raw,
@@ -491,10 +510,11 @@ async def _prepare_remote_cluster_share(
 
     remote_share_setting = _home_relative_share_setting(remote_share, env)
     await agi_cls.exec_ssh(ip, _remote_env_update_command(remote_share_setting))
-    if _remote_cluster_share_premounted(env):
+    if share_is_premounted:
         if getattr(env, "verbose", 0) > 0:
             log.info(
-                "Using pre-mounted AGILAB cluster share on remote worker %s at %s",
+                "Using pre-mounted AGILAB cluster share (%s) on remote worker %s at %s",
+                share_backend,
                 ip,
                 remote_share_setting,
             )

--- a/src/agilab/core/test/test_agi_distributor_deployment_remote_support.py
+++ b/src/agilab/core/test/test_agi_distributor_deployment_remote_support.py
@@ -901,6 +901,51 @@ async def test_prepare_remote_cluster_share_accepts_premounted_remote_share_with
 
 
 @pytest.mark.asyncio
+async def test_prepare_remote_cluster_share_treats_nfs_and_ntfs_backends_as_premounted(
+    tmp_path,
+    monkeypatch,
+):
+    for backend in ("nfs", "ntfs"):
+        env = SimpleNamespace(
+            AGI_CLUSTER_SHARE=str(tmp_path / f"scheduler-share-{backend}"),
+            envars={"AGILAB_CLUSTER_SHARE_BACKEND": backend},
+            home_abs=tmp_path,
+            user="agi",
+            verbose=0,
+        )
+        ssh_calls: list[str] = []
+
+        class _AgiNoScheduler:
+            _scheduler_ip = ""
+
+            async def exec_ssh(self, _ip, cmd):
+                ssh_calls.append(cmd)
+                return "ok"
+
+        monkeypatch.setattr(
+            deployment_remote_support,
+            "_reverse_sshfs_mount_problem",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("no reverse guard")),
+        )
+
+        await deployment_remote_support._prepare_remote_cluster_share(
+            _AgiNoScheduler(), "192.168.20.15", env, "clustershare"
+        )
+
+        assert len(ssh_calls) == 2
+        assert "Pre-mounted AGILAB cluster share" in ssh_calls[1]
+        assert "SCHEDULER_SSH_TARGET" not in "\n".join(ssh_calls)
+        assert "sshfs" not in "\n".join(ssh_calls).lower()
+
+
+def test_cluster_share_backend_rejects_unknown_backend():
+    env = SimpleNamespace(envars={"AGILAB_CLUSTER_SHARE_BACKEND": "smb"})
+
+    with pytest.raises(ValueError, match="Unsupported AGILAB cluster-share backend"):
+        deployment_remote_support._remote_cluster_share_premounted(env)
+
+
+@pytest.mark.asyncio
 async def test_deploy_remote_worker_prepins_dependencies_for_legacy_intel_macos(
     tmp_path,
 ):

--- a/test/test_cluster_flight_validation.py
+++ b/test/test_cluster_flight_validation.py
@@ -33,6 +33,7 @@ def _args(**overrides):
         "workers": "jpm@192.168.3.35:2",
         "remote_user": "",
         "scheduler_ssh_port": 22,
+        "cluster_share_backend": "",
         "remote_cluster_share_premounted": False,
         "local_share": "localshare",
         "cluster_share": "",
@@ -232,6 +233,35 @@ def test_parse_args_requires_cluster_and_positive_rows():
             ]
         )
 
+    parsed = cfv._parse_args(
+        [
+            "--cluster",
+            "--scheduler",
+            "127.0.0.1",
+            "--workers",
+            "127.0.0.1",
+            "--cluster-share-backend",
+            "nfs",
+            "--share-check-only",
+        ]
+    )
+    assert parsed.cluster_share_backend == "nfs"
+
+    with pytest.raises(SystemExit):
+        cfv._parse_args(
+            [
+                "--cluster",
+                "--scheduler",
+                "127.0.0.1",
+                "--workers",
+                "127.0.0.1",
+                "--cluster-share-backend",
+                "nfs",
+                "--print-share-setup",
+                "sshfs",
+            ]
+        )
+
 
 def test_build_validation_plan_makes_flight_paths_home_relative(tmp_path: Path):
     plan = cfv.build_validation_plan(
@@ -242,6 +272,7 @@ def test_build_validation_plan_makes_flight_paths_home_relative(tmp_path: Path):
 
     assert plan.remote_user == "jpm"
     assert plan.scheduler_ssh_port == 22
+    assert plan.cluster_share_backend == "sshfs"
     assert plan.remote_cluster_share_premounted is False
     assert plan.workers == {"192.168.3.35": 2}
     assert plan.local_dataset_dir == tmp_path / "localshare/flight_cluster_validation/dataset/csv"
@@ -269,6 +300,18 @@ def test_build_validation_plan_reads_env_files_and_serializes_paths(tmp_path: Pa
     assert plan.local_share_setting == "share-in-env"
     assert plan.local_cluster_share_setting == "cluster-in-env"
     assert plan.to_dict()["local_dataset_dir"].endswith("share-in-env/flight_cluster_validation/dataset/csv")
+
+
+def test_build_validation_plan_treats_nfs_and_ntfs_as_premounted_share_backends(tmp_path: Path):
+    for backend in ("nfs", "ntfs"):
+        plan = cfv.build_validation_plan(
+            _args(cluster_share_backend=backend),
+            home=tmp_path,
+            environ={"USER": "agi"},
+        )
+
+        assert plan.cluster_share_backend == backend
+        assert plan.remote_cluster_share_premounted is True
 
 
 def test_remote_env_update_script_enables_cluster_mode_without_clobbering_env(tmp_path: Path):
@@ -659,9 +702,34 @@ def test_share_setup_helpers_cover_scheduler_and_path_variants(tmp_path: Path):
     assert cfv._remote_share_assignment("relative/path") == '"$HOME"/relative/path'
 
     with pytest.raises(ValueError, match="unsupported share setup backend"):
-        cfv.share_setup_script_lines(plan, "nfs")
+        cfv.share_setup_script_lines(plan, "smb")
     with pytest.raises(ValueError, match="unsupported share setup backend"):
-        cfv.apply_share_setup(plan, "nfs", timeout=1)
+        cfv.apply_share_setup(plan, "smb", timeout=1)
+
+
+def test_share_setup_script_lines_verify_premounted_nfs_and_ntfs(tmp_path: Path):
+    for backend, label in (("nfs", "NFS"), ("ntfs", "NTFS")):
+        plan = cfv.build_validation_plan(
+            _args(
+                cluster_share_backend=backend,
+                scheduler="192.168.3.103",
+                workers="jpm@192.168.3.35",
+                cluster_share="/mnt/agilab/scheduler",
+                remote_cluster_share="/mnt/agilab/worker",
+            ),
+            home=tmp_path,
+            environ={"USER": "agi"},
+        )
+
+        script = "\n".join(cfv.share_setup_script_lines(plan, backend, local_user="agi"))
+
+        assert f"pre-mounted {label} shares" in script
+        assert "AGILAB will verify it instead of mounting with SSHFS" in script
+        assert "Pre-mounted AGILAB cluster share" in script
+        assert "--cluster-share-backend " + backend in script
+        assert "--remote-cluster-share-premounted" in script
+        assert "command -v sshfs" not in script
+        assert 'sshfs -p "$SCHEDULER_SSH_PORT"' not in script
 
 
 def test_apply_share_setup_runs_idempotent_remote_commands(tmp_path: Path, monkeypatch):
@@ -782,10 +850,57 @@ def test_apply_share_setup_verifies_premounted_share_without_sshfs(
     assert summaries[-1].path == "/mnt/agilab/shared"
     assert all("sshfs" not in command[-1] for command in commands)
     assert "Pre-mounted AGILAB cluster share" in commands[1][-1]
-    assert "AGILAB cluster-share verification using pre-mounted remote shares" in script
+    assert "AGILAB cluster-share verification using pre-mounted SSHFS shares" in script
     assert "command -v sshfs" not in script
     assert "SCHEDULER_CLUSTER_SHARE" not in script
     assert "--remote-cluster-share-premounted" in script
+
+
+def test_apply_share_setup_verifies_nfs_without_sshfs_or_reverse_mount_guard(
+    tmp_path: Path,
+    monkeypatch,
+):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    plan = cfv.build_validation_plan(
+        _args(
+            cluster_share_backend="nfs",
+            scheduler="192.168.3.103",
+            workers="jpm@192.168.3.35",
+            cluster_share=str(tmp_path / "scheduler-share"),
+            remote_cluster_share="/mnt/agilab/worker",
+        ),
+        home=tmp_path,
+        environ={"USER": "agi"},
+    )
+    commands: list[list[str]] = []
+    responses = iter(
+        [
+            subprocess.CompletedProcess([], 0, stdout="/Users/jpm/.agilab/.env\n", stderr=""),
+            subprocess.CompletedProcess([], 0, stdout="/mnt/agilab/worker\n", stderr=""),
+        ]
+    )
+
+    def fake_run(argv, *, timeout=None):
+        commands.append(list(argv))
+        assert timeout == 17
+        return next(responses)
+
+    monkeypatch.setattr(cfv, "_run_command", fake_run)
+    monkeypatch.setattr(
+        cfv,
+        "_reverse_sshfs_mount_problem",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("no reverse guard")),
+    )
+
+    summaries = cfv.apply_share_setup(plan, "nfs", timeout=17, local_user="agi")
+
+    assert [summary.action for summary in summaries] == [
+        "mkdir",
+        "write-env",
+        "check-premounted",
+    ]
+    assert all("sshfs" not in command[-1].lower() for command in commands)
+    assert "Pre-mounted AGILAB cluster share" in commands[1][-1]
 
 
 def test_validation_success_requires_local_visibility_for_remote_runs():
@@ -1079,6 +1194,7 @@ def test_run_lan_discovery_prints_and_serializes(monkeypatch, capsys):
 
     assert payload == {"success": True, "lan_discovery": {"nodes": [{"host": "192.168.3.35"}]}}
     assert reports[0].remote_user == "jpm"
+    assert reports[0].cluster_share_backend == "sshfs"
     assert reports[0].active is False
     assert reports[0].cache_path is None
     assert printed

--- a/test/test_cluster_lan_discovery.py
+++ b/test/test_cluster_lan_discovery.py
@@ -20,8 +20,8 @@ loaded_path = str(getattr(loaded_agilab, "__file__", ""))
 if loaded_agilab is not None and not loaded_path.startswith(str(SRC_ROOT)):
     sys.modules.pop("agilab", None)
 
-from agilab import cluster_flight_validation as cfv
-from agilab import cluster_lan_discovery as discovery
+from agilab import cluster_flight_validation as cfv  # noqa: E402
+from agilab import cluster_lan_discovery as discovery  # noqa: E402
 
 
 def test_parse_cidr_values_rejects_invalid_network():
@@ -841,6 +841,12 @@ def test_probe_helpers_classify_missing_prerequisites_and_reverse_ssh():
         tcp_open=True,
         reverse_ssh=None,
     ) == ("sshfs-missing", 70, ("sshfs not found",))
+    assert discovery._classify(
+        {"python3": "/usr/bin/python3", "uv": "/usr/local/bin/uv"},
+        tcp_open=True,
+        reverse_ssh=False,
+        cluster_share_backend="nfs",
+    ) == ("ready", 100, ())
     assert discovery._classify(
         {"python3": "python3", "uv": "uv", "sshfs": "sshfs"},
         tcp_open=True,


### PR DESCRIPTION
## Summary
- add cluster share backend support for sshfs, nfs, and ntfs
- treat nfs/ntfs as pre-mounted shared storage and verify the sentinel contract instead of requiring SSHFS/reverse SSH
- honor AGILAB_CLUSTER_SHARE_BACKEND in remote deployment and LAN discovery classification
- add regressions for CLI planning, setup/apply behavior, discovery classification, and remote deployment

## Validation
- ./dev scope --staged --allow-scope shared-core --allow-scope src
- uv --preview-features extra-build-dependencies run python tools/impact_validate.py --staged
- uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_cluster_flight_validation.py test/test_cluster_lan_discovery.py src/agilab/core/test/test_agi_distributor_deployment_remote_support.py
- uv --preview-features extra-build-dependencies run --no-sync pytest -q -o addopts='' src/agilab/core/test
- git diff --cached --check

Note: pre-push mixed-scope override was used intentionally because this single coherent feature spans cluster src, shared-core deployment, and tests.