### PR TITLE
[codex] Document agent review and PR metadata rules

### DIFF
--- a/.claude/skills/agilab-runbook/SKILL.md
+++ b/.claude/skills/agilab-runbook/SKILL.md
@@ -157,6 +157,11 @@ Use this skill when you need repo-specific “how we do things” guidance in `a
   `src/agilab/core/agi-core`, shared installer/build/deploy code, and generic helpers reused across apps/pages.
   Prefer app-local fixes first. If a core edit looks necessary, stop and explain the required files,
   blast radius, and validation plan before making the change.
+- **Higher-model fix review**: when a product or code fix was designed or implemented with model assistance,
+  request a review from a stronger model before closing, pushing, or merging when that is available. The review
+  should challenge root cause, regression chain, blast radius, security risk, and test coverage. If no stronger
+  model is available in the current environment, state that explicitly and still perform the normal local review
+  and validation path.
 - **Docs source of truth**: edit docs in the sibling repo
   `../thales_agilab/docs/source` relative to the active AGILAB checkout.
 - **Generated docs in this repo**: treat `docs/html` (including `docs/html/_sources`)
@@ -192,6 +197,11 @@ Use this skill when you need repo-specific “how we do things” guidance in `a
   merge it until the dirty paths are reported and the update plan is adjusted. If a dirty feature
   checkout blocks direct update of a repo's `main`, check whether a clean registered `main` worktree
   exists before omitting that repository from the update.
+- **PR agent metadata**: every AGILAB PR description must include an `Agent Metadata`
+  section with the Tokki version (`tokki --version`, or `not used`/`unavailable`),
+  agent/runtime name and version when exposed, model name, reasoning effort, and
+  whether `/fast` mode was used. Do not infer missing values; write `unknown`,
+  `unavailable`, or `not used` explicitly.
 - **External AGILAB core pointer merges**: when a private app or integration repository
   points `.external/agilab` at a stale AGILAB core branch and GitHub reports that
   the branch has no history in common with current `main`, do not force-merge or

--- a/.claude/skills/agilab-runbook/SKILL.md
+++ b/.claude/skills/agilab-runbook/SKILL.md
@@ -202,6 +202,15 @@ Use this skill when you need repo-specific “how we do things” guidance in `a
   agent/runtime name and version when exposed, model name, reasoning effort, and
   whether `/fast` mode was used. Do not infer missing values; write `unknown`,
   `unavailable`, or `not used` explicitly.
+- **PR evidence contract**: PR descriptions must stay current through merge.
+  Include `Review Evidence` when model or sub-agent review was used, naming the
+  reviewer model, result, and whether findings were addressed. If sub-agents were
+  used, state their role/model and whether they edited files or reviewed only.
+  Bugfix PRs must include `Repro`, `Root Cause`, and `Regression Test` sections;
+  if automation is impractical, say why and name the closest validation. Any
+  skipped check must include a reason such as `not applicable`, `GitHub skipped`,
+  or `manual validation only`. Before marking a PR ready or merging, update the
+  body if review, CI, validation, or skip status changed after PR creation.
 - **External AGILAB core pointer merges**: when a private app or integration repository
   points `.external/agilab` at a stale AGILAB core branch and GitHub reports that
   the branch has no history in common with current `main`, do not force-merge or

--- a/.codex/skills/agilab-runbook/SKILL.md
+++ b/.codex/skills/agilab-runbook/SKILL.md
@@ -157,6 +157,11 @@ Use this skill when you need repo-specific “how we do things” guidance in `a
   `src/agilab/core/agi-core`, shared installer/build/deploy code, and generic helpers reused across apps/pages.
   Prefer app-local fixes first. If a core edit looks necessary, stop and explain the required files,
   blast radius, and validation plan before making the change.
+- **Higher-model fix review**: when a product or code fix was designed or implemented with model assistance,
+  request a review from a stronger model before closing, pushing, or merging when that is available. The review
+  should challenge root cause, regression chain, blast radius, security risk, and test coverage. If no stronger
+  model is available in the current environment, state that explicitly and still perform the normal local review
+  and validation path.
 - **Docs source of truth**: edit docs in the sibling repo
   `../thales_agilab/docs/source` relative to the active AGILAB checkout.
 - **Generated docs in this repo**: treat `docs/html` (including `docs/html/_sources`)
@@ -192,6 +197,11 @@ Use this skill when you need repo-specific “how we do things” guidance in `a
   merge it until the dirty paths are reported and the update plan is adjusted. If a dirty feature
   checkout blocks direct update of a repo's `main`, check whether a clean registered `main` worktree
   exists before omitting that repository from the update.
+- **PR agent metadata**: every AGILAB PR description must include an `Agent Metadata`
+  section with the Tokki version (`tokki --version`, or `not used`/`unavailable`),
+  agent/runtime name and version when exposed, model name, reasoning effort, and
+  whether `/fast` mode was used. Do not infer missing values; write `unknown`,
+  `unavailable`, or `not used` explicitly.
 - **External AGILAB core pointer merges**: when a private app or integration repository
   points `.external/agilab` at a stale AGILAB core branch and GitHub reports that
   the branch has no history in common with current `main`, do not force-merge or

--- a/.codex/skills/agilab-runbook/SKILL.md
+++ b/.codex/skills/agilab-runbook/SKILL.md
@@ -202,6 +202,15 @@ Use this skill when you need repo-specific “how we do things” guidance in `a
   agent/runtime name and version when exposed, model name, reasoning effort, and
   whether `/fast` mode was used. Do not infer missing values; write `unknown`,
   `unavailable`, or `not used` explicitly.
+- **PR evidence contract**: PR descriptions must stay current through merge.
+  Include `Review Evidence` when model or sub-agent review was used, naming the
+  reviewer model, result, and whether findings were addressed. If sub-agents were
+  used, state their role/model and whether they edited files or reviewed only.
+  Bugfix PRs must include `Repro`, `Root Cause`, and `Regression Test` sections;
+  if automation is impractical, say why and name the closest validation. Any
+  skipped check must include a reason such as `not applicable`, `GitHub skipped`,
+  or `manual validation only`. Before marking a PR ready or merging, update the
+  body if review, CI, validation, or skip status changed after PR creation.
 - **External AGILAB core pointer merges**: when a private app or integration repository
   points `.external/agilab` at a stale AGILAB core branch and GitHub reports that
   the branch has no history in common with current `main`, do not force-merge or

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -255,6 +255,15 @@ Use this runbook whenever you:
   agent/runtime name and version when exposed, model name, reasoning effort, and
   whether `/fast` mode was used. Do not infer missing values; write `unknown`,
   `unavailable`, or `not used` explicitly.
+- **PR evidence contract**: PR descriptions must stay current through merge.
+  Include `Review Evidence` when model or sub-agent review was used, naming the
+  reviewer model, result, and whether findings were addressed. If sub-agents were
+  used, state their role/model and whether they edited files or reviewed only.
+  Bugfix PRs must include `Repro`, `Root Cause`, and `Regression Test` sections;
+  if automation is impractical, say why and name the closest validation. Any
+  skipped check must include a reason such as `not applicable`, `GitHub skipped`,
+  or `manual validation only`. Before marking a PR ready or merging, update the
+  body if review, CI, validation, or skip status changed after PR creation.
 - **Dirty-scope guardrail**: Before starting a new task in a dirty checkout, and
   before answering "push", "release", or "all clean", run `./dev scope`. It
   includes untracked non-ignored files by default. If it reports `MIXED`, stop

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -250,6 +250,11 @@ Use this runbook whenever you:
   that belong to that scope. Direct pushes to `main` are reserved for explicit
   emergency fixes or release-maintenance operations where the user asks for that
   exception.
+- **PR agent metadata**: Every AGILAB PR description must include an `Agent Metadata`
+  section with the Tokki version (`tokki --version`, or `not used`/`unavailable`),
+  agent/runtime name and version when exposed, model name, reasoning effort, and
+  whether `/fast` mode was used. Do not infer missing values; write `unknown`,
+  `unavailable`, or `not used` explicitly.
 - **Dirty-scope guardrail**: Before starting a new task in a dirty checkout, and
   before answering "push", "release", or "all clean", run `./dev scope`. It
   includes untracked non-ignored files by default. If it reports `MIXED`, stop
@@ -478,6 +483,7 @@ Use this runbook whenever you:
   a better fix than the obvious one. Keep the plain repro command as the first discriminator, compare app-local and
   shared-core fixes, and explain why the stronger fix is better. Good one-query wording:
   `Assess the diagnostic below and find the better fix. Keep the plain repro as the first discriminator. Identify the real root cause, regression chain, weak points in the current diagnosis, the better fix, why it is better than the obvious fix, and the regression plan.`
+- **Higher-model fix review**: When a product or code fix was designed or implemented with model assistance, request a review from a stronger model before closing, pushing, or merging when that is available. The review should challenge root cause, regression chain, blast radius, security risk, and test coverage. If no stronger model is available in the current environment, state that explicitly and still perform the normal local review and validation path.
 - **Dependency removal audit**: When removing a dependency from code, check the impact on the corresponding
   `pyproject.toml` files as part of the same change. Remove stale declarations when they are no longer needed,
   or keep them only when there is a clear runtime, packaging, or optional-feature reason.

--- a/AGENT_LEARNINGS.md
+++ b/AGENT_LEARNINGS.md
@@ -50,6 +50,10 @@ is not a scratchpad or task log.
   step after its safety gate, report the result, and provide the next
   recommendation without requiring a second user round trip unless a real
   blocker needs input.
+- Every AGILAB PR description must include `Agent Metadata`: Tokki version,
+  agent/runtime name and version when exposed, model name, reasoning effort, and
+  whether `/fast` mode was used. If a value is unavailable, write `unknown`,
+  `unavailable`, or `not used` instead of guessing.
 - When asked for token-saving or workflow-saving tactics and a repo-local
   default is clear, do not end with a broad clarification menu. State the
   assumed target, choose the highest-leverage applicable mechanism, and either
@@ -58,6 +62,10 @@ is not a scratchpad or task log.
   Do not expand it into a command-by-command list unless failures, skipped
   checks, release/audit evidence, PR proof, or an explicit user request make the
   details useful.
+- When a product or code fix was designed or implemented with model assistance,
+  request a review from a stronger model before closing, pushing, or merging
+  when that is available. If no stronger model is available, say so explicitly
+  and still run the normal local review and validation path.
 - When a source Streamlit UI is running, do not run plain repo-level `uv run`
   validation commands against the same `.venv`. Use `./dev`, which isolates uv
   subprocesses in `.venv-dev`, or pass an explicit ignored

--- a/AGENT_LEARNINGS.md
+++ b/AGENT_LEARNINGS.md
@@ -54,6 +54,10 @@ is not a scratchpad or task log.
   agent/runtime name and version when exposed, model name, reasoning effort, and
   whether `/fast` mode was used. If a value is unavailable, write `unknown`,
   `unavailable`, or `not used` instead of guessing.
+- Keep AGILAB PR descriptions evidence-complete through merge: add review
+  evidence and sub-agent disclosure when used, bugfix `Repro` / `Root Cause` /
+  `Regression Test` sections, explicit skipped-check reasons, and refresh the
+  body before ready/merge if review, CI, validation, or skip status changed.
 - When asked for token-saving or workflow-saving tactics and a repo-local
   default is clear, do not end with a broad clarification menu. State the
   assumed target, choose the highest-leverage applicable mechanism, and either


### PR DESCRIPTION
## Summary

- Add a durable rule requiring stronger-model review for model-assisted product/code fixes before closing, pushing, or merging when available.
- Require every AGILAB PR description to include an `Agent Metadata` section with Tokki version, agent/runtime version, model, effort, and `/fast` usage.
- Add a `PR evidence contract` for review evidence, sub-agent disclosure, bugfix repro/root-cause/regression sections, skipped-check reasons, and final-state PR body updates before ready/merge.
- Mirror the AGILAB runbook skill from `.claude/skills` into `.codex/skills`.

## Validation

- `./dev scope --staged --allow-scope agent-instructions`
- `git diff --cached --check`
- `python3 tools/agent_instruction_contract.py --check`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile skills`
- GitHub checks passed: GitGuardian, local-only-policy, clean-public-install on macOS, Ubuntu, and Windows.

## Review Evidence

- Higher-model review: `gpt-5.5`, review-only. First pass found wording consistency issues; findings were addressed.
- Higher-model final review: `gpt-5.5`, review-only. Final pass reported no issues.
- Additional higher-model review for `PR evidence contract`: `gpt-5.5`, review-only. Reported no issues.

## Bugfix Evidence

- Repro: `not applicable` - this is an agent-instruction/process PR, not a product bugfix.
- Root Cause: `not applicable`.
- Regression Test: `not applicable`; covered by agent instruction contract and skills workflow parity.

## Skipped Checks

- `public-demo-smoke`: GitHub skipped; not applicable to an instruction-only PR.

## Agent Metadata

- Tokki version: `tokki 1.0.3`
- Agent/runtime: `codex-cli 0.141.0`
- Model: `GPT-5` main agent; `gpt-5.5` higher-model review
- Reasoning effort: main agent `unknown`; higher-model review `medium`
- `/fast` used: `not used`
- Sub-agents: `gpt-5.5` reviewers only; no sub-agent edited files