### PR TITLE
[codex] Guard pool executor options by platform

### DIFF
--- a/.claude/skills/agilab-testing/SKILL.md
+++ b/.claude/skills/agilab-testing/SKILL.md
@@ -183,6 +183,10 @@ Use this skill when validating changes.
   - When LAN discovery auto-populates scheduler/workers, test both the discovery
     result and the persisted form fields so the UI cannot show discovered nodes
     without saving executable cluster settings.
+  - When ORCHESTRATE or app forms expose cluster parameters that depend on worker
+    OS or platform capabilities, derive availability from fresh LAN discovery or
+    the local platform as appropriate, reset stale persisted widget values to a
+    safe default, and cover both the pure resolver and the rendered UI options.
 - App settings split:
   - Source `app_settings.toml` files are seeds; mutable settings live in the user workspace.
   - Tests should target the right layer and avoid asserting that runtime writes back into source files.

--- a/.codex/skills/agilab-testing/SKILL.md
+++ b/.codex/skills/agilab-testing/SKILL.md
@@ -183,6 +183,10 @@ Use this skill when validating changes.
   - When LAN discovery auto-populates scheduler/workers, test both the discovery
     result and the persisted form fields so the UI cannot show discovered nodes
     without saving executable cluster settings.
+  - When ORCHESTRATE or app forms expose cluster parameters that depend on worker
+    OS or platform capabilities, derive availability from fresh LAN discovery or
+    the local platform as appropriate, reset stale persisted widget values to a
+    safe default, and cover both the pure resolver and the rendered UI options.
 - App settings split:
   - Source `app_settings.toml` files are seeds; mutable settings live in the user workspace.
   - Tests should target the right layer and avoid asserting that runtime writes back into source files.

--- a/.coveragerc.agi-core
+++ b/.coveragerc.agi-core
@@ -1,0 +1,9 @@
+[run]
+branch = true
+source =
+    agi_node
+    agi_cluster
+
+[report]
+exclude_also =
+    if _module is not None:

--- a/.coveragerc.agi-env
+++ b/.coveragerc.agi-env
@@ -9,4 +9,5 @@ omit =
 omit =
     src/agilab/core/agi-env/src/agi_env/pagelib.py
 exclude_also =
+    if _module is not None:
     _tb_kwargs\['theme_name'\] = 'NoColor'

--- a/.coveragerc.agi-gui
+++ b/.coveragerc.agi-gui
@@ -23,3 +23,5 @@ omit =
     sitecustomize.py
     __init__.py
     src/__init__.py
+exclude_also =
+    if _module is not None:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -153,7 +153,8 @@ jobs:
             --with pytest \
             --with pytest-asyncio \
             --with coverage \
-            python -m coverage run --data-file=.coverage.agi-core-combined \
+            python -m coverage run --rcfile=.coveragerc.agi-core \
+            --data-file=.coverage.agi-core-combined \
             --source=agi_node,agi_cluster \
             -m pytest -q --maxfail=1 --disable-warnings -o addopts='' --import-mode=importlib \
             src/agilab/core/test src/agilab/core/agi-cluster/test
@@ -167,7 +168,8 @@ jobs:
             --with pytest \
             --with pytest-asyncio \
             --with coverage \
-            python -m coverage xml --data-file=.coverage.agi-core-combined \
+            python -m coverage xml --rcfile=.coveragerc.agi-core \
+            --data-file=.coverage.agi-core-combined \
             -o coverage-agi-node.xml --include='*/agi_node/*'
           uv run --no-project \
             --with-editable ./src/agilab/core/agi-env \
@@ -179,7 +181,8 @@ jobs:
             --with pytest \
             --with pytest-asyncio \
             --with coverage \
-            python -m coverage xml --data-file=.coverage.agi-core-combined \
+            python -m coverage xml --rcfile=.coveragerc.agi-core \
+            --data-file=.coverage.agi-core-combined \
             -o coverage-agi-cluster.xml --include='*/agi_cluster/*'
           kill "$HEARTBEAT_PID" 2>/dev/null || true
           trap - EXIT

--- a/agenticweb.md
+++ b/agenticweb.md
@@ -1,7 +1,7 @@
 ---
 agenticweb: "1"
 description: "AGILAB is an open-source AI/ML workbench for reproducible experiments, notebook-to-app workflows, run evidence, proof capsules, and local agent evidence review."
-updated: "2026-06-19"
+updated: "2026-06-20"
 organization:
   name: "AGILAB"
   website: "https://thalesgroup.github.io/agilab"

--- a/agilab-capabilities.json
+++ b/agilab-capabilities.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-06-19T17:00:03Z",
+  "generated_at_utc": "2026-06-20T17:30:17Z",
   "schema": "agilab.capabilities.v1",
   "schema_version": 1,
   "generated_by": {
@@ -1848,8 +1848,6 @@
     {
       "schema": "agilab.notebook_view_sync.v1",
       "sources": [
-        "src/agilab/apps/builtin/flight_telemetry_project/notebooks/lab_stages.notebook_export.json",
-        "src/agilab/apps/builtin/multi_app_dag_project/notebooks/lab_stages.notebook_export.json",
         "src/agilab/notebooks/notebook_export_support.py"
       ]
     },

--- a/badges/coverage-agi-cluster.svg
+++ b/badges/coverage-agi-cluster.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="181" height="20" role="img" aria-label="agi-cluster coverage: 96%">
+<svg xmlns="http://www.w3.org/2000/svg" width="181" height="20" role="img" aria-label="agi-cluster coverage: 97%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="75.0" y="15" fill="#010101" fill-opacity=".3">agi-cluster coverage</text>
   <text x="75.0" y="14">agi-cluster coverage</text>
-  <text x="165.5" y="15" fill="#010101" fill-opacity=".3">96%</text>
-  <text x="165.5" y="14">96%</text>
+  <text x="165.5" y="15" fill="#010101" fill-opacity=".3">97%</text>
+  <text x="165.5" y="14">97%</text>
 </g>
 </svg>

--- a/badges/coverage-agi-core.svg
+++ b/badges/coverage-agi-core.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="160" height="20" role="img" aria-label="agi-core coverage: 95%">
+<svg xmlns="http://www.w3.org/2000/svg" width="160" height="20" role="img" aria-label="agi-core coverage: 97%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="64.5" y="15" fill="#010101" fill-opacity=".3">agi-core coverage</text>
   <text x="64.5" y="14">agi-core coverage</text>
-  <text x="144.5" y="15" fill="#010101" fill-opacity=".3">95%</text>
-  <text x="144.5" y="14">95%</text>
+  <text x="144.5" y="15" fill="#010101" fill-opacity=".3">97%</text>
+  <text x="144.5" y="14">97%</text>
 </g>
 </svg>

--- a/badges/coverage-agi-env.svg
+++ b/badges/coverage-agi-env.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="153" height="20" role="img" aria-label="agi-env coverage: 95%">
+<svg xmlns="http://www.w3.org/2000/svg" width="153" height="20" role="img" aria-label="agi-env coverage: 98%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="61.0" y="15" fill="#010101" fill-opacity=".3">agi-env coverage</text>
   <text x="61.0" y="14">agi-env coverage</text>
-  <text x="137.5" y="15" fill="#010101" fill-opacity=".3">95%</text>
-  <text x="137.5" y="14">95%</text>
+  <text x="137.5" y="15" fill="#010101" fill-opacity=".3">98%</text>
+  <text x="137.5" y="14">98%</text>
 </g>
 </svg>

--- a/badges/coverage-agi-gui.svg
+++ b/badges/coverage-agi-gui.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="153" height="20" role="img" aria-label="agi-gui coverage: 97%">
+<svg xmlns="http://www.w3.org/2000/svg" width="153" height="20" role="img" aria-label="agi-gui coverage: 98%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="61.0" y="15" fill="#010101" fill-opacity=".3">agi-gui coverage</text>
   <text x="61.0" y="14">agi-gui coverage</text>
-  <text x="137.5" y="15" fill="#010101" fill-opacity=".3">97%</text>
-  <text x="137.5" y="14">97%</text>
+  <text x="137.5" y="15" fill="#010101" fill-opacity=".3">98%</text>
+  <text x="137.5" y="14">98%</text>
 </g>
 </svg>

--- a/badges/coverage-agi-node.svg
+++ b/badges/coverage-agi-node.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="160" height="20" role="img" aria-label="agi-node coverage: 96%">
+<svg xmlns="http://www.w3.org/2000/svg" width="160" height="20" role="img" aria-label="agi-node coverage: 97%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="64.5" y="15" fill="#010101" fill-opacity=".3">agi-node coverage</text>
   <text x="64.5" y="14">agi-node coverage</text>
-  <text x="144.5" y="15" fill="#010101" fill-opacity=".3">96%</text>
-  <text x="144.5" y="14">96%</text>
+  <text x="144.5" y="15" fill="#010101" fill-opacity=".3">97%</text>
+  <text x="144.5" y="14">97%</text>
 </g>
 </svg>

--- a/badges/coverage-agilab.svg
+++ b/badges/coverage-agilab.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="146" height="20" role="img" aria-label="agilab coverage: 97%">
+<svg xmlns="http://www.w3.org/2000/svg" width="146" height="20" role="img" aria-label="agilab coverage: 98%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="57.5" y="15" fill="#010101" fill-opacity=".3">agilab coverage</text>
   <text x="57.5" y="14">agilab coverage</text>
-  <text x="130.5" y="15" fill="#010101" fill-opacity=".3">97%</text>
-  <text x="130.5" y="14">97%</text>
+  <text x="130.5" y="15" fill="#010101" fill-opacity=".3">98%</text>
+  <text x="130.5" y="14">98%</text>
 </g>
 </svg>

--- a/src/agilab/apps/builtin/execution_pandas_project/src/app_args_form.py
+++ b/src/agilab/apps/builtin/execution_pandas_project/src/app_args_form.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import platform
 from pathlib import Path
 import sys
 from typing import Any
@@ -15,6 +16,13 @@ from execution_pandas.app_args import ExecutionPandasArgs, dump_args, load_args 
 
 
 PAGE_ID = "execution_pandas_project:app_args_form"
+POOL_EXECUTOR_OPTIONS = ("auto", "process", "thread")
+POOL_EXECUTOR_OS_SAFE_OPTIONS = ("auto", "thread")
+POOL_EXECUTOR_LABELS = {
+    "auto": "Auto (ORCHESTRATE setting)",
+    "process": "Process",
+    "thread": "Thread",
+}
 
 
 def _k(name: str) -> str:
@@ -42,6 +50,13 @@ def _safe_rows_per_partition(rows_per_file: int, n_partitions: int) -> int:
     if n_partitions <= 0:
         return 0
     return rows_per_file // n_partitions
+
+
+def _pool_executor_options_for_platform(system: str | None = None) -> tuple[str, ...]:
+    family = (platform.system() if system is None else system).strip().lower()
+    if family.startswith("windows"):
+        return POOL_EXECUTOR_OS_SAFE_OPTIONS
+    return POOL_EXECUTOR_OPTIONS
 
 
 env = _get_env()
@@ -114,15 +129,15 @@ with c10:
         key=_k("kernel_mode"),
     )
 with c11:
+    pool_executor_options = _pool_executor_options_for_platform()
+    pool_executor_key = _k("pool_executor")
+    if st.session_state.get(pool_executor_key) not in pool_executor_options:
+        st.session_state[pool_executor_key] = "auto"
     st.selectbox(
         "Pool executor",
-        options=["auto", "process", "thread"],
-        format_func=lambda value: {
-            "auto": "Auto (ORCHESTRATE setting)",
-            "process": "Process",
-            "thread": "Thread",
-        }[value],
-        key=_k("pool_executor"),
+        options=pool_executor_options,
+        format_func=lambda value: POOL_EXECUTOR_LABELS[value],
+        key=pool_executor_key,
         help=(
             "Only affects pool or Dask runs. Auto follows the ORCHESTRATE "
             "Resources and deployment pool executor setting when it is set."

--- a/src/agilab/core/agi-cluster/test/test_import_contract.py
+++ b/src/agilab/core/agi-cluster/test/test_import_contract.py
@@ -1,8 +1,43 @@
 from __future__ import annotations
 
+import importlib
 import subprocess
 import sys
 import textwrap
+
+import pytest
+
+
+SHIM_MODULES = (
+    "agi_cluster.agi_distributor.agi_distributor",
+    "agi_cluster.agi_distributor.background_jobs_support",
+    "agi_cluster.agi_distributor.capacity_support",
+    "agi_cluster.agi_distributor.cleanup_support",
+    "agi_cluster.agi_distributor.cli",
+    "agi_cluster.agi_distributor.deployment_build_support",
+    "agi_cluster.agi_distributor.deployment_dask_support",
+    "agi_cluster.agi_distributor.deployment_editable_install_support",
+    "agi_cluster.agi_distributor.deployment_install_spec_support",
+    "agi_cluster.agi_distributor.deployment_local_support",
+    "agi_cluster.agi_distributor.deployment_orchestration_support",
+    "agi_cluster.agi_distributor.deployment_prepare_support",
+    "agi_cluster.agi_distributor.deployment_remote_support",
+    "agi_cluster.agi_distributor.deployment_resolver_env_support",
+    "agi_cluster.agi_distributor.deployment_stage_cache_support",
+    "agi_cluster.agi_distributor.deployment_stage_plan_support",
+    "agi_cluster.agi_distributor.deployment_venv_support",
+    "agi_cluster.agi_distributor.deployment_worker_venv_cache_support",
+    "agi_cluster.agi_distributor.entrypoint_support",
+    "agi_cluster.agi_distributor.run_request_support",
+    "agi_cluster.agi_distributor.runtime_distribution_support",
+    "agi_cluster.agi_distributor.runtime_misc_support",
+    "agi_cluster.agi_distributor.scheduler_io_support",
+    "agi_cluster.agi_distributor.service_lifecycle_support",
+    "agi_cluster.agi_distributor.service_runtime_support",
+    "agi_cluster.agi_distributor.service_state_support",
+    "agi_cluster.agi_distributor.transport_support",
+    "agi_cluster.agi_distributor.uv_source_support",
+)
 
 
 def test_distributor_import_does_not_require_sklearn() -> None:
@@ -35,3 +70,11 @@ def test_distributor_import_does_not_require_sklearn() -> None:
 
     assert completed.returncode == 0, completed.stdout + completed.stderr
     assert completed.stdout.strip() == "ok"
+
+
+@pytest.mark.parametrize("module_name", SHIM_MODULES)
+def test_agi_cluster_legacy_shim_imports_target_module(module_name: str) -> None:
+    module = importlib.import_module(module_name)
+
+    assert module.__name__ == module_name
+    assert module.__dict__.get("_COMPAT_TARGET_MODULE") is not None or hasattr(module, "USAGE")

--- a/src/agilab/core/agi-env/test/test_compat_shim_imports.py
+++ b/src/agilab/core/agi-env/test/test_compat_shim_imports.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+SHIM_MODULES = (
+    "agi_env._optional_ui",
+    "agi_env.agi_env",
+    "agi_env.agi_env_app_switch_support",
+    "agi_env.agi_env_execution_methods",
+    "agi_env.agi_env_instance_initialization",
+    "agi_env.agi_env_meta_support",
+    "agi_env.agi_logger",
+    "agi_env.app_args",
+    "agi_env.app_provider_registry",
+    "agi_env.app_settings_support",
+    "agi_env.bootstrap_support",
+    "agi_env.connector_registry",
+    "agi_env.content_renamer_support",
+    "agi_env.credential_store_support",
+    "agi_env.data_archive_support",
+    "agi_env.defaults",
+    "agi_env.env_config_support",
+    "agi_env.env_runtime_initialization_support",
+    "agi_env.execution_support",
+    "agi_env.hook_support",
+    "agi_env.host_runtime_support",
+    "agi_env.installation_support",
+    "agi_env.mlflow_store",
+    "agi_env.package_layout_support",
+    "agi_env.pagelib",
+    "agi_env.pagelib_data_support",
+    "agi_env.pagelib_execution_support",
+    "agi_env.pagelib_navigation_support",
+    "agi_env.pagelib_preview_support",
+    "agi_env.pagelib_project_support",
+    "agi_env.pagelib_resource_support",
+    "agi_env.pagelib_runtime_support",
+    "agi_env.pagelib_selection_support",
+    "agi_env.pagelib_session_support",
+    "agi_env.process_support",
+    "agi_env.project_clone_support",
+    "agi_env.project_initialization_support",
+    "agi_env.rename_gitignore_support",
+    "agi_env.repository_support",
+    "agi_env.runtime_bootstrap_support",
+    "agi_env.share_mount_support",
+    "agi_env.share_runtime_support",
+    "agi_env.snippet_contract",
+    "agi_env.source_analysis_ast",
+    "agi_env.source_analysis_support",
+    "agi_env.streamlit_args",
+    "agi_env.ui_docs_support",
+    "agi_env.ui_state_support",
+    "agi_env.ui_support",
+    "agi_env.windows_link_support",
+    "agi_env.worker_runtime_support",
+    "agi_env.worker_source_support",
+)
+
+
+@pytest.mark.parametrize("module_name", SHIM_MODULES)
+def test_agi_env_legacy_shim_imports_target_module(module_name: str) -> None:
+    module = importlib.import_module(module_name)
+
+    assert module.__name__ == module_name
+    assert module.__dict__.get("_COMPAT_TARGET_MODULE") is not None

--- a/src/agilab/core/agi-env/test/test_cython_build_config.py
+++ b/src/agilab/core/agi-env/test/test_cython_build_config.py
@@ -1,0 +1,165 @@
+"""Component-local coverage for AGILAB Cython build configuration helpers."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from agi_env import cython_build_config as config
+
+
+def _write_pyproject(project_dir: Path, body: str) -> Path:
+    project_dir.mkdir(parents=True, exist_ok=True)
+    pyproject = project_dir / "pyproject.toml"
+    pyproject.write_text(body, encoding="utf-8")
+    return pyproject
+
+
+def test_parse_cython_directive_overrides_handles_bundles_and_booleans() -> None:
+    parsed = config.parse_cython_directive_overrides(
+        " unchecked, cdivision=true, profile, wraparound=no, =ignored, nonecheck=off "
+    )
+
+    assert parsed == {
+        "boundscheck": False,
+        "wraparound": False,
+        "initializedcheck": False,
+        "nonecheck": False,
+        "cdivision": True,
+        "profile": True,
+    }
+
+
+def test_parse_cython_directive_overrides_rejects_bad_names_and_values() -> None:
+    with pytest.raises(ValueError, match=r"boundschek.*demo/pyproject.toml"):
+        config.parse_cython_directive_overrides(
+            "boundschek=false", source="demo/pyproject.toml"
+        )
+
+    with pytest.raises(ValueError, match=r"Unsupported Cython directive boolean value"):
+        config.parse_cython_directive_overrides("boundscheck=maybe", source="env")
+
+
+def test_validate_cython_directives_accepts_opt_out_values() -> None:
+    for raw in config.CYTHON_FLAG_FALSE_VALUES:
+        config.validate_cython_directives_spec(raw, source="test")
+
+    config.validate_cython_directives_spec("boundscheck=false", source="test")
+    with pytest.raises(ValueError, match="Unknown Cython compiler directive"):
+        config.validate_cython_directives_spec("nochecks", source="test")
+
+
+def test_read_project_cython_config_edges(tmp_path: Path) -> None:
+    assert config.read_project_cython_config(None) == config.ProjectCythonConfig(
+        None, None, None
+    )
+    assert config.read_project_cython_config(tmp_path / "missing") == config.ProjectCythonConfig(
+        None, None, None
+    )
+
+    pyproject = _write_pyproject(tmp_path / "empty", "[project]\nname = 'demo'\n")
+    assert config.read_project_cython_config(tmp_path / "empty") == config.ProjectCythonConfig(
+        None, None, pyproject
+    )
+
+    pyproject = _write_pyproject(tmp_path / "not-table", "[tool.agilab]\ncython = 'bad'\n")
+    assert config.read_project_cython_config(
+        tmp_path / "not-table"
+    ) == config.ProjectCythonConfig(None, None, pyproject)
+
+    pyproject = _write_pyproject(
+        tmp_path / "configured",
+        "[tool.agilab.cython]\nenabled = false\ndirectives = 'unchecked'\n",
+    )
+    assert config.read_project_cython_config(
+        tmp_path / "configured"
+    ) == config.ProjectCythonConfig(False, "unchecked", pyproject)
+
+
+def test_read_project_cython_config_rejects_malformed_declarations(tmp_path: Path) -> None:
+    pyproject = _write_pyproject(tmp_path / "invalid", "not toml [\n")
+    with pytest.raises(ValueError, match="Invalid TOML") as excinfo:
+        config.read_project_cython_config(tmp_path / "invalid")
+    assert str(pyproject) in str(excinfo.value)
+
+    _write_pyproject(tmp_path / "bad-enabled", "[tool.agilab.cython]\nenabled = 'yes'\n")
+    with pytest.raises(ValueError, match="enabled must be a boolean"):
+        config.read_project_cython_config(tmp_path / "bad-enabled")
+
+    _write_pyproject(tmp_path / "bad-directives", "[tool.agilab.cython]\ndirectives = true\n")
+    with pytest.raises(ValueError, match="directives must be a string"):
+        config.read_project_cython_config(tmp_path / "bad-directives")
+
+    pyproject = _write_pyproject(tmp_path / "unknown", "[tool.agilab.cython]\nenable = true\n")
+    with pytest.raises(ValueError, match="Unknown .* keys") as excinfo:
+        config.read_project_cython_config(tmp_path / "unknown")
+    assert "enable" in str(excinfo.value)
+    assert str(pyproject) in str(excinfo.value)
+
+
+def test_resolve_cython_directives_spec_precedence(tmp_path: Path, monkeypatch) -> None:
+    project = tmp_path / "app"
+    _write_pyproject(project, "[tool.agilab.cython]\ndirectives = 'unchecked'\n")
+
+    assert config.resolve_cython_directives_spec(
+        environ={config.CYTHON_DIRECTIVES_ENV: "cdivision=true"},
+        project_dir=project,
+    ) == ("cdivision=true", config.CYTHON_DIRECTIVES_ENV)
+    assert config.resolve_cython_directives_spec(
+        env_value="boundscheck=true",
+        project_dir=project,
+    ) == ("boundscheck=true", config.CYTHON_DIRECTIVES_ENV)
+    assert config.resolve_cython_directives_spec(environ={}, project_dir=project) == (
+        "unchecked",
+        str(project / "pyproject.toml"),
+    )
+    assert config.resolve_cython_directives_spec(
+        environ={config.CYTHON_DIRECTIVES_ENV: "   "},
+        project_dir=tmp_path / "missing",
+    ) == (None, None)
+
+    monkeypatch.setenv(config.CYTHON_DIRECTIVES_ENV, "profile=true")
+    assert config.resolve_cython_directives_spec(project_dir=project) == (
+        "profile=true",
+        config.CYTHON_DIRECTIVES_ENV,
+    )
+
+
+def test_stamp_helpers_preserve_encoding_window_and_match_expected_source() -> None:
+    source = "# coding: utf-8\n# header\nprint('x')\n"
+    stamp = config.cython_pyx_stamp_line(source, type_preprocess=True)
+
+    assert stamp.startswith(config.CYTHON_PYX_STAMP_PREFIX)
+    assert f"src-sha256={config.cython_source_sha256(source)}" in stamp
+    assert "type-preprocess=1" in stamp
+
+    stamped = config.add_cython_pyx_stamp(source, stamp_line=stamp)
+    assert stamped.splitlines()[0:3] == ["# coding: utf-8", "# header", stamp]
+    assert config.cython_pyx_stamp_matches(stamped, source, type_preprocess=True)
+    assert not config.cython_pyx_stamp_matches(stamped, source, type_preprocess=False)
+    assert not config.cython_pyx_stamp_matches(
+        "\n".join(["# filler"] * 8 + [stamp]),
+        source,
+        type_preprocess=True,
+    )
+
+    assert config.add_cython_pyx_stamp("", stamp_line=f"{stamp}\n") == f"{stamp}\n"
+
+
+def test_overlay_specs_and_public_exports_are_consistent() -> None:
+    assert config.cython_build_overlay_specs() == ("setuptools", config.CYTHON_BUILD_REQUIREMENT)
+
+    exported = set(config.__all__)
+    for name in (
+        "CYTHON_DIRECTIVES_ENV",
+        "ProjectCythonConfig",
+        "parse_cython_directive_overrides",
+        "resolve_cython_directives_spec",
+        "cython_pyx_stamp_matches",
+    ):
+        assert name in exported
+        assert hasattr(config, name)
+
+    assert os.environ.get(config.CYTHON_DIRECTIVES_ENV) is None

--- a/src/agilab/core/test/test_agi_dispatcher_scripts.py
+++ b/src/agilab/core/test/test_agi_dispatcher_scripts.py
@@ -336,6 +336,123 @@ def run(values):
     assert type_preprocess_mod._call_name(type_preprocess_mod.ast.Constant(value=1)) is None
 
 
+def test_cython_type_preprocess_helper_edge_branches(tmp_path, capsys):
+    ast = type_preprocess_mod.ast
+
+    def expr(source: str):
+        return ast.parse(source, mode="eval").body
+
+    assert type_preprocess_mod._is_small_int_literal(expr("+42")) is True
+    assert type_preprocess_mod._static_int_value(expr("True")) is type_preprocess_mod._STATIC_INT_UNKNOWN
+    assert type_preprocess_mod._static_int_value(expr("+3")) == 3
+    assert type_preprocess_mod._static_int_value(expr("-4")) == -4
+    assert type_preprocess_mod._static_int_value(expr("2 + 3")) == 5
+    assert type_preprocess_mod._static_int_value(expr("8 - 3")) == 5
+    assert type_preprocess_mod._static_int_value(expr("2 * 3")) == 6
+    assert type_preprocess_mod._static_int_value(expr("8 // 3")) == 2
+    assert type_preprocess_mod._static_int_value(expr("8 % 3")) == 2
+    assert (
+        type_preprocess_mod._static_int_value(expr("2 ** 1000000"))
+        == type_preprocess_mod._PY_SSIZE_MAX + 1
+    )
+    assert type_preprocess_mod._static_int_value(expr("1 / 0")) is type_preprocess_mod._STATIC_INT_UNKNOWN
+
+    assert type_preprocess_mod._expr_type(expr("1 is 1")) == (
+        "bint",
+        "identity or membership comparison",
+    )
+    assert type_preprocess_mod._expr_type(expr("1 < 2 < 3")) == (
+        "bint",
+        "numeric comparison result",
+    )
+    assert type_preprocess_mod._expr_type(expr("2 ** 3")) == (
+        None,
+        "power expression type is not statically safe",
+    )
+    assert type_preprocess_mod._expr_type(
+        expr("left @ right"),
+        env={"left": "Py_ssize_t", "right": "Py_ssize_t"},
+    ) == (None, "operator is not statically safe")
+    assert type_preprocess_mod._expr_type(
+        expr("left * right"),
+        env={"left": "Py_ssize_t", "right": "Py_ssize_t"},
+    ) == (None, "multiplication requires a small literal operand")
+
+    assert type_preprocess_mod._range_loop_index_candidate(
+        expr("range(stop=5)"),
+        shadowed_builtins=set(),
+    ) == (False, "range() call uses keyword arguments")
+    assert type_preprocess_mod._range_loop_index_candidate(
+        expr("range()"),
+        shadowed_builtins=set(),
+    ) == (False, "range() argument count is invalid")
+
+    pattern_source = """
+match value:
+    case [first, *rest]:
+        pass
+    case {"x": mapped, **remaining}:
+        pass
+    case Point(px, y=py):
+        pass
+    case {"a": a} | {"b": b}:
+        pass
+"""
+    match_node = ast.parse(pattern_source).body[0]
+    bound_names = {
+        name
+        for case in match_node.cases
+        for name in type_preprocess_mod._pattern_bound_names(case.pattern)
+    }
+    assert {"first", "rest", "mapped", "remaining", "px", "py", "a", "b"} <= bound_names
+
+    for source in (
+        "def f(cython):\n    return cython\n",
+        "def cython():\n    return None\n",
+        "try:\n    pass\nexcept Exception as cython:\n    pass\n",
+        "def f():\n    global cython\n",
+        "import math as cython\n",
+        "from math import sin as cython\n",
+        "match value:\n    case cython:\n        pass\n",
+        "match value:\n    case {**cython}:\n        pass\n",
+    ):
+        assert type_preprocess_mod._cython_name_rebound(ast.parse(source)) is True
+
+    preview = type_preprocess_mod.analyze_source(
+        """
+def run(values):
+    holder.value += 1.0
+    from math import sin as sine
+    match values:
+        case [item] if bool(item):
+            result = True
+    return result
+"""
+    )
+    skipped = {item.name: item.reason for item in preview.skipped}
+    assert "value" not in skipped
+    assert skipped["sine"] == "import target is dynamic"
+    assert skipped["item"] == "match capture target is dynamic"
+
+    docstring_source = '"""doc."""\nfrom __future__ import annotations\n\ndef run():\n    total = 1.0\n    return total\n'
+    rendered, _ = type_preprocess_mod.preprocess_source(docstring_source, filename="worker.py")
+    assert rendered.splitlines()[2] == "import cython"
+
+    commented_source = "#!/usr/bin/env python\n# coding: utf-8\n\ndef run():\n    total = 1.0\n    return total\n"
+    rendered, _ = type_preprocess_mod.preprocess_source(commented_source, filename="worker.py")
+    assert rendered.splitlines()[3] == "import cython"
+
+    report = type_preprocess_mod.PreprocessPreview(declarations=(), skipped=()).to_report(
+        output_path="worker.pyx"
+    )
+    assert report["output"] == "worker.pyx"
+
+    plain_path = tmp_path / "plain.py"
+    plain_path.write_text("def run():\n    return object()\n", encoding="utf-8")
+    assert type_preprocess_mod.main([str(plain_path)]) == 0
+    assert "def run():" in capsys.readouterr().out
+
+
 def test_cython_type_preprocess_blocks_reproduced_unsound_bindings():
     source = """
 def run(arr, pair, value):

--- a/src/agilab/orchestrate/orchestrate_cluster.py
+++ b/src/agilab/orchestrate/orchestrate_cluster.py
@@ -1,6 +1,7 @@
 import ipaddress
 import json
 import os
+import platform
 import re
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -47,6 +48,7 @@ POOL_MAX_WORKERS_ENV = "AGILAB_POOL_MAX_WORKERS"
 POOL_ITEM_TIMEOUT_ENV = "AGILAB_POOL_ITEM_TIMEOUT"
 POOL_EXECUTOR_ENV = "AGILAB_POOL_EXECUTOR"
 POOL_EXECUTOR_OPTIONS = ("auto", "process", "thread")
+POOL_EXECUTOR_OS_SAFE_OPTIONS = ("auto", "thread")
 WORKFLOW_SESSION_POLICY_ENV = "AGI_WORKFLOW_SESSION_POLICY"
 WORKFLOW_SESSION_ENV = "AGI_WORKFLOW_SESSION"
 WORKFLOW_ID_ENV = "AGI_WORKFLOW_ID"
@@ -202,6 +204,55 @@ def _pool_executor_value(value: Any) -> str:
     if normalized not in POOL_EXECUTOR_OPTIONS:
         return "auto"
     return normalized
+
+
+def _pool_executor_platform_family(value: Any) -> str:
+    normalized = re.sub(r"[^a-z0-9]+", "", str(value or "").strip().lower())
+    if not normalized:
+        return ""
+    if normalized in {"nt", "win32"} or normalized.startswith("windows"):
+        return "windows"
+    if normalized.startswith("darwin") or normalized.startswith("macos"):
+        return "darwin"
+    if normalized.startswith("linux"):
+        return "linux"
+    return normalized
+
+
+def _lan_discovery_ready_worker_os_families(cache_path: Path | None) -> tuple[str, ...]:
+    payload = _load_lan_discovery_payload(cache_path)
+    nodes = payload.get("nodes")
+    if not isinstance(nodes, list):
+        return ()
+    families: list[str] = []
+    for node in nodes:
+        if not isinstance(node, dict):
+            continue
+        status = str(node.get("status") or "").strip()
+        if status and status not in LAN_READY_STATUSES:
+            continue
+        raw_os = node.get("os_name") or node.get("os") or node.get("platform") or node.get("system")
+        family = _pool_executor_platform_family(raw_os)
+        if family and family not in families:
+            families.append(family)
+    return tuple(families)
+
+
+def _pool_executor_options_for_cluster_os(
+    cache_path: Path | None,
+    *,
+    local_system: Any | None = None,
+) -> tuple[tuple[str, ...], str]:
+    local_family = _pool_executor_platform_family(platform.system() if local_system is None else local_system)
+    families = set(_lan_discovery_ready_worker_os_families(cache_path))
+    if local_family:
+        families.add(local_family)
+    if "windows" not in families:
+        return POOL_EXECUTOR_OPTIONS, ""
+    return (
+        POOL_EXECUTOR_OS_SAFE_OPTIONS,
+        "Process pool executor is unavailable for Windows cluster nodes; use Auto or Thread.",
+    )
 
 
 def _persist_pool_runtime_env(
@@ -1084,6 +1135,8 @@ def render_cluster_settings_ui(env: Any, deps: OrchestrateClusterDeps, *, show_r
     workflow_id = _orchestrate_workflow_id(cluster_params, env)
     cluster_params["workflow_id"] = workflow_id
     widget_keys = cluster_widget_keys(app_state_name)
+    env_home = _env_home_path(env)
+    lan_cache_path = _default_lan_discovery_cache_path(env_home)
 
     boolean_params = ["cython", "pool"]
     if env.is_managed_pc:
@@ -1145,20 +1198,30 @@ def render_cluster_settings_ui(env: Any, deps: OrchestrateClusterDeps, *, show_r
                 cluster_params["pool_item_timeout"] = item_timeout_value
 
             executor_key = widget_keys["pool_executor"]
+            executor_options, executor_notice = _pool_executor_options_for_cluster_os(lan_cache_path)
             executor_value = _pool_executor_value(cluster_params.get("pool_executor"))
+            if executor_value not in executor_options:
+                executor_value = "auto"
+                cluster_params.pop("pool_executor", None)
+            if st.session_state.get(executor_key) not in (None, *executor_options):
+                st.session_state[executor_key] = "auto"
             if executor_key not in st.session_state:
                 st.session_state[executor_key] = executor_value
             selected_executor = pool_cols[2].selectbox(
                 "Pool executor",
-                POOL_EXECUTOR_OPTIONS,
+                executor_options,
                 key=executor_key,
                 help="Choose auto unless you need to force process or thread execution.",
             )
             executor_value = _pool_executor_value(selected_executor)
+            if executor_value not in executor_options:
+                executor_value = "auto"
             if executor_value == "auto":
                 cluster_params.pop("pool_executor", None)
             else:
                 cluster_params["pool_executor"] = executor_value
+            if executor_notice:
+                st.info(executor_notice)
     else:
         for key in ("pool_max_workers", "pool_item_timeout", "pool_executor"):
             cluster_params.pop(key, None)
@@ -1232,8 +1295,6 @@ def render_cluster_settings_ui(env: Any, deps: OrchestrateClusterDeps, *, show_r
                 help="Build an advisory worker-count plan from LAN discovery without changing current settings.",
             )
         )
-        env_home = _env_home_path(env)
-        lan_cache_path = _default_lan_discovery_cache_path(env_home)
         lan_clear_clicked = bool(
             lan_action_cols[2].button(
                 "Clear LAN cache",

--- a/test/test_coverage_workflow.py
+++ b/test/test_coverage_workflow.py
@@ -9,6 +9,7 @@ import sys
 WORKFLOW_PATH = Path(".github/workflows/coverage.yml")
 CODECOV_CONFIG_PATH = Path("codecov.yml")
 AGI_ENV_COVERAGE_CONFIG = Path(".coveragerc.agi-env")
+AGI_CORE_COVERAGE_CONFIG = Path(".coveragerc.agi-core")
 SHARD_PLAN_PATH = Path("tools/coverage_shard_plan.py")
 CODECOV_UPLOADER_KEY_FINGERPRINT = "27034E7FDB850E0BBC2C62FF806BB28AED779869"
 
@@ -88,6 +89,7 @@ def test_core_coverage_uses_importlib_import_mode_for_src_layout() -> None:
     run_block = _agi_core_run_block()
 
     assert "--import-mode=importlib" in run_block
+    assert "--rcfile=.coveragerc.agi-core" in run_block
 
 
 def test_coverage_push_trigger_is_path_filtered_for_cost_control() -> None:
@@ -125,6 +127,13 @@ def test_agi_env_coverage_excludes_ipython_signature_compatibility_line() -> Non
     config_text = AGI_ENV_COVERAGE_CONFIG.read_text(encoding="utf-8")
 
     assert r"_tb_kwargs\['theme_name'\] = 'NoColor'" in config_text
+    assert "if _module is not None:" in config_text
+
+
+def test_agi_core_coverage_excludes_defensive_compat_shim_fallback() -> None:
+    config_text = AGI_CORE_COVERAGE_CONFIG.read_text(encoding="utf-8")
+
+    assert "if _module is not None:" in config_text
 
 
 def test_agi_core_coverage_installs_parquet_engine() -> None:
@@ -200,6 +209,12 @@ def test_agi_gui_coverage_includes_pytorch_playground_app_surface_regressions() 
     run_block = _agi_gui_run_block()
 
     assert "test/test_pytorch_playground_app.py" in run_block
+
+
+def test_agi_gui_coverage_includes_reuse_catalog_regressions() -> None:
+    run_block = _agi_gui_run_block()
+
+    assert "test/test_reuse_catalog.py" in run_block
 
 
 def test_agi_gui_coverage_uses_parallel_chunk_matrix_profile() -> None:

--- a/test/test_execution_playground_forms.py
+++ b/test/test_execution_playground_forms.py
@@ -6,7 +6,13 @@ from types import SimpleNamespace
 from streamlit.testing.v1 import AppTest
 
 
-def _make_env(tmp_path: Path, *, app_name: str, data_out: str) -> SimpleNamespace:
+def _make_env(
+    tmp_path: Path,
+    *,
+    app_name: str,
+    data_out: str,
+    pool_executor: str = "auto",
+) -> SimpleNamespace:
     settings_root = tmp_path / app_name
     settings_root.mkdir(parents=True, exist_ok=True)
     settings_file = settings_root / "app_settings.toml"
@@ -21,7 +27,7 @@ def _make_env(tmp_path: Path, *, app_name: str, data_out: str) -> SimpleNamespac
         "n_groups = 32\n"
         "compute_passes = 32\n"
         "kernel_mode = \"typed_numeric\"\n"
-        "pool_executor = \"auto\"\n"
+        f"pool_executor = \"{pool_executor}\"\n"
         "output_format = \"csv\"\n"
         "seed = 42\n"
         "reset_target = false\n",
@@ -68,6 +74,33 @@ def test_execution_pandas_form_renders_and_persists_args(tmp_path: Path) -> None
     assert at.session_state["app_settings"]["args"]["kernel_mode"] == "dataframe"
     assert at.session_state["app_settings"]["args"]["pool_executor"] == "thread"
     assert at.session_state["app_settings"]["args"]["output_format"] == "parquet"
+
+
+def test_execution_pandas_form_disables_process_executor_on_windows(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr("platform.system", lambda: "Windows")
+    env = _make_env(
+        tmp_path,
+        app_name="execution_pandas_project",
+        data_out="execution_pandas/results",
+        pool_executor="process",
+    )
+    at = AppTest.from_file("src/agilab/apps/builtin/execution_pandas_project/src/app_args_form.py", default_timeout=20)
+    at.session_state["env"] = env
+    at.session_state["app_settings"] = {"args": {}, "cluster": {}}
+
+    at.run()
+
+    assert not at.exception
+    pool_executor = at.selectbox(key="execution_pandas_project:app_args_form:pool_executor")
+    assert pool_executor.options == [
+        "Auto (ORCHESTRATE setting)",
+        "Thread",
+    ]
+    assert pool_executor.value == "auto"
+    assert at.session_state["app_settings"]["args"]["pool_executor"] == "auto"
 
 
 def test_execution_polars_form_renders_and_persists_args(tmp_path: Path) -> None:

--- a/test/test_orchestrate_cluster.py
+++ b/test/test_orchestrate_cluster.py
@@ -97,6 +97,7 @@ class _FakeStreamlit:
         self.buttons: list[str] = []
         self.number_inputs: list[str] = []
         self.selectboxes: list[str] = []
+        self.selectbox_options: dict[str, tuple[object, ...]] = {}
 
     def _value(self, key, default=""):
         if key in self.widget_values:
@@ -143,6 +144,8 @@ class _FakeStreamlit:
 
     def selectbox(self, label, options, *, key=None, index=0, **_kwargs):
         self.selectboxes.append(label)
+        if key is not None:
+            self.selectbox_options[key] = tuple(options)
         default = options[index]
         result = self._value(key, default)
         if result not in options:
@@ -1157,6 +1160,52 @@ def test_lan_discovery_cluster_defaults_uses_ready_cache_nodes(tmp_path):
     }
 
 
+def test_pool_executor_options_disable_process_for_windows_cluster_node(tmp_path):
+    cache_path = tmp_path / "lan_nodes.json"
+    cache_path.write_text(
+        json.dumps(
+            {
+                "nodes": [
+                    {"host": "192.168.20.15", "status": "ready", "os_name": "Windows"},
+                    {"host": "192.168.20.16", "status": "ready", "os_name": "Linux"},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    options, reason = orchestrate_cluster._pool_executor_options_for_cluster_os(
+        cache_path,
+        local_system="Darwin",
+    )
+
+    assert options == ("auto", "thread")
+    assert "Windows" in reason
+
+
+def test_pool_executor_options_keep_process_for_posix_multi_os_cluster(tmp_path):
+    cache_path = tmp_path / "lan_nodes.json"
+    cache_path.write_text(
+        json.dumps(
+            {
+                "nodes": [
+                    {"host": "192.168.20.15", "status": "ready", "os_name": "Linux"},
+                    {"host": "192.168.20.16", "status": "ready", "os_name": "Darwin"},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    options, reason = orchestrate_cluster._pool_executor_options_for_cluster_os(
+        cache_path,
+        local_system="Darwin",
+    )
+
+    assert options == orchestrate_cluster.POOL_EXECUTOR_OPTIONS
+    assert reason == ""
+
+
 def test_lan_discovery_cluster_defaults_accepts_explicit_non_private_lan_cache(tmp_path):
     cache_path = tmp_path / "lan_nodes.json"
     cache_path.write_text(
@@ -1438,6 +1487,73 @@ def test_render_cluster_settings_ui_initializes_state_and_persists_cluster_mode(
     assert ("AGILAB_POOL_EXECUTOR", "thread") in writes["env_calls"]
     assert writes["cleared"] is True
     assert writes["write"][0] == env.app_settings_file
+
+
+def test_render_cluster_settings_ui_disables_process_executor_for_windows_lan_node(monkeypatch, tmp_path):
+    cache_path = tmp_path / orchestrate_cluster.LAN_DISCOVERY_CACHE
+    cache_path.parent.mkdir(parents=True)
+    cache_path.write_text(
+        json.dumps(
+            {
+                "nodes": [
+                    {
+                        "host": "192.168.20.15",
+                        "status": "ready",
+                        "os_name": "Windows",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    fake_st = _FakeStreamlit(
+        widget_values={
+            "cluster_cython__demo_project": False,
+            "cluster_pool__demo_project": True,
+            "cluster_rapids__demo_project": False,
+            "cluster_pool_max_workers__demo_project": 0,
+            "cluster_pool_item_timeout__demo_project": 0.0,
+            "cluster_pool_executor__demo_project": "process",
+            "cluster_enabled__demo_project": False,
+        },
+        session_state={
+            "app_settings": {"cluster": {"pool": True, "pool_executor": "process"}},
+            "benchmark": False,
+        },
+    )
+    monkeypatch.setattr(orchestrate_cluster, "st", fake_st)
+    monkeypatch.setattr(orchestrate_cluster.platform, "system", lambda: "Darwin")
+
+    writes: dict[str, object] = {}
+    deps = orchestrate_cluster.OrchestrateClusterDeps(
+        parse_and_validate_scheduler=lambda raw: raw,
+        parse_and_validate_workers=lambda raw: {"parsed": raw},
+        write_app_settings_toml=lambda path, settings: writes.setdefault("write", (path, settings)) and settings,
+        clear_load_toml_cache=lambda: writes.setdefault("cleared", True),
+        set_env_var=lambda key, value: writes.setdefault("env_calls", []).append((key, value)),
+        agi_env_envars={"AGILAB_POOL_EXECUTOR": "process"},
+    )
+    env = SimpleNamespace(
+        app="demo_project",
+        is_managed_pc=False,
+        agi_share_path=None,
+        share_root_path=lambda: tmp_path / "share",
+        home_abs=tmp_path,
+        user="",
+        password=None,
+        ssh_key_path=None,
+        app_settings_file=tmp_path / "app_settings.toml",
+    )
+
+    orchestrate_cluster.render_cluster_settings_ui(env, deps)
+
+    cluster = fake_st.session_state.app_settings["cluster"]
+    executor_key = "cluster_pool_executor__demo_project"
+    assert fake_st.selectbox_options[executor_key] == ("auto", "thread")
+    assert fake_st.session_state[executor_key] == "auto"
+    assert "pool_executor" not in cluster
+    assert any("Windows cluster nodes" in info for info in fake_st.infos)
+    assert ("AGILAB_POOL_EXECUTOR", "") in writes["env_calls"]
 
 
 def test_render_cluster_settings_ui_clears_pool_parameters_when_pool_disabled(monkeypatch, tmp_path):

--- a/test/test_release_proof_report.py
+++ b/test/test_release_proof_report.py
@@ -71,6 +71,7 @@ def test_release_proof_refresh_from_local_updates_manifest_and_page(
         return original_text_contains(path, expected)
 
     monkeypatch.setattr(module, "_text_contains", _text_contains)
+    monkeypatch.setattr(module, "_local_tag_exists", lambda _repo_root, _tag: True)
     docs_source = tmp_path / "docs" / "source"
     data_dir = docs_source / "data"
     data_dir.mkdir(parents=True)

--- a/test/test_release_proof_report.py
+++ b/test/test_release_proof_report.py
@@ -98,8 +98,11 @@ def test_release_proof_refresh_from_local_updates_manifest_and_page(
     assert refreshed["release"]["package_version"] == module._load_project_version(Path.cwd())
     assert refreshed["release"]["github_release_tag"] == "v2026.05.01-2"
     assert refreshed["release"]["github_release_url"].endswith("/releases/tag/v2026.05.01-2")
-    assert refreshed["release"]["dataset_release_tag"].startswith("datasets-")
-    assert "dataset_release_url" not in refreshed["release"]
+    dataset_release_tag = refreshed["release"]["dataset_release_tag"]
+    assert dataset_release_tag.startswith("datasets-")
+    assert refreshed["release"]["dataset_release_url"].endswith(
+        f"/releases/tag/{dataset_release_tag}"
+    )
     assert refreshed["release"]["dataset_count"] > 0
     assert refreshed["release"]["hf_space_commit"] == "test-hf-commit"
     assert (docs_source / "release-proof.rst").read_text(encoding="utf-8") == module.render_release_proof(

--- a/test/test_workflow_parity.py
+++ b/test/test_workflow_parity.py
@@ -227,6 +227,7 @@ def test_profile_commands_cover_expected_coverage_and_docs_contracts() -> None:
     combined_node_xml = agi_core_combined[1]
     combined_cluster_xml = agi_core_combined[2]
     assert combined_run.timeout_seconds == 20 * 60
+    assert "--rcfile=.coveragerc.agi-core" in combined_run.argv
     assert combined_run.argv[-2:] == [
         "src/agilab/core/test",
         "src/agilab/core/agi-cluster/test",
@@ -239,11 +240,13 @@ def test_profile_commands_cover_expected_coverage_and_docs_contracts() -> None:
     assert _has_with_dependency(combined_cluster_xml.argv, "fastparquet")
     assert "pytest" in combined_run.argv
     assert combined_node_xml.timeout_seconds == 5 * 60
+    assert "--rcfile=.coveragerc.agi-core" in combined_node_xml.argv
     assert "--data-file=.coverage.agi-core-combined" in combined_node_xml.argv
     assert "-o" in combined_node_xml.argv
     assert "coverage-agi-node.xml" in combined_node_xml.argv
     assert "--include=*/agi_node/*" in combined_node_xml.argv
     assert combined_cluster_xml.timeout_seconds == 5 * 60
+    assert "--rcfile=.coveragerc.agi-core" in combined_cluster_xml.argv
     assert "--data-file=.coverage.agi-core-combined" in combined_cluster_xml.argv
     assert "-o" in combined_cluster_xml.argv
     assert "coverage-agi-cluster.xml" in combined_cluster_xml.argv

--- a/tools/coverage_shard_plan.py
+++ b/tools/coverage_shard_plan.py
@@ -75,6 +75,7 @@ STATIC_AGI_GUI_CHUNKS: tuple[tuple[str, tuple[str, ...]], ...] = (
             "test/test_page_bundle_registry.py",
             "test/test_python_versions.py",
             "test/test_pinned_expander.py",
+            "test/test_reuse_catalog.py",
             "test/test_security_check.py",
             "test/test_secret_uri.py",
             "test/test_snippet_registry.py",

--- a/tools/workflow_parity.py
+++ b/tools/workflow_parity.py
@@ -1060,6 +1060,7 @@ def _agi_core_combined_profile() -> list[CommandSpec]:
             argv=[
                 *base_argv,
                 "run",
+                "--rcfile=.coveragerc.agi-core",
                 "--data-file=.coverage.agi-core-combined",
                 "--source=agi_node,agi_cluster",
                 "-m",
@@ -1085,6 +1086,7 @@ def _agi_core_combined_profile() -> list[CommandSpec]:
             argv=[
                 *base_argv,
                 "xml",
+                "--rcfile=.coveragerc.agi-core",
                 "--data-file=.coverage.agi-core-combined",
                 "-o",
                 "coverage-agi-node.xml",
@@ -1097,6 +1099,7 @@ def _agi_core_combined_profile() -> list[CommandSpec]:
             argv=[
                 *base_argv,
                 "xml",
+                "--rcfile=.coveragerc.agi-core",
                 "--data-file=.coverage.agi-core-combined",
                 "-o",
                 "coverage-agi-cluster.xml",


### PR DESCRIPTION
## Summary

- Disable forced `process` pool executor options when ORCHESTRATE LAN discovery or the local app form platform indicates Windows.
- Reset stale persisted `process` widget values to `auto` when that option is unavailable.
- Add focused regressions and update the `agilab-testing` skill guidance for OS/platform-dependent cluster parameters.
- Raise component coverage signals with component-local Cython config tests, legacy shim import coverage, shared core coverage config parity, and regenerated coverage badges.

## Repro

A stale ORCHESTRATE or Execution Pandas setting could keep `pool_executor = "process"` even when the relevant platform did not support exposing that option safely. The UI also offered `process` unconditionally, so the failure class was not covered by a platform-aware regression.

For the coverage follow-up, the checked-in badges were not 100% and the local component XMLs showed real uncovered code rather than stale SVGs alone. `agi-gui` also could not refresh coverage until a release-proof test was aligned with the current dataset-release URL behavior.

## Root Cause

The pool executor selector used a static `("auto", "process", "thread")` option list. It did not consult LAN discovery `os_name` metadata for cluster workers, did not consult the local platform in the app form, and did not repair persisted widget state when the option set changed.

The coverage badges were below 100% because component coverage had genuine uncovered lines. Some missing lines were compatibility-shim fallback boilerplate or tests outside the component coverage shard plan; other remaining gaps are still real product code and are not hidden by this PR.

## Regression Test

- Added pure ORCHESTRATE resolver coverage for Windows and POSIX multi-OS LAN cache inputs.
- Added ORCHESTRATE render coverage proving stale `process` resets to `auto` and disappears from the selector.
- Added Execution Pandas AppTest coverage proving the Windows form exposes only Auto/Thread and persists `auto` from a stale `process` setting.
- Added agi-env component-local coverage for `cython_build_config.py` and legacy shim imports.
- Added agi-cluster legacy shim import coverage and agi-node Cython preprocessor edge coverage.
- Added workflow/coverage tests for the shared core coverage rcfile and agi-gui reuse catalog shard inclusion.

## Validation

- Component profiles passed locally: `agi-env`, `agi-core-combined`, `agi-gui`; `agi-web` remains 100% from the current XML.
- Current local component XML: agi-env 98.91%, agi-node 97.90%, agi-cluster 97.39%, agi-gui 98.28%, agi-web 100.00%.
- Regenerated coverage badges from the complete XML set: agi-env 98%, agi-node 97%, agi-cluster 97%, agi-gui 98%, agi-web 100%, agi-core 97%, agilab 98%.
- Focused tests passed for coverage workflow parity, release proof report, reuse catalog, agi-env shim/Cython config, agi-cluster import contract, and agi-node Cython preprocessor edge coverage.
- Ruff passed on touched Python files.
- `./dev badge` passed after commit.
- `./dev scope` passed from the clean tree; the push used the explicit mixed-scope override because this coverage update intentionally spans component tests, workflow config, and badges.

## Review Evidence

No sub-agent or model review was used.

## Agent Metadata

- Tokki version: `tokki 1.0.4`
- Agent/runtime: Codex, version unavailable
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used
