### PR TITLE
Harden MCP reads and notebook sidecar

### DIFF
--- a/src/agilab/pages/4_ANALYSIS.py
+++ b/src/agilab/pages/4_ANALYSIS.py
@@ -21,6 +21,7 @@ import hashlib
 import html
 import json
 import re
+import secrets
 import inspect
 from collections.abc import Sequence
 from typing import Any, Union
@@ -2814,11 +2815,31 @@ def _notebook_lab_tree_path(notebook_path: Path, project_root: Path) -> str:
     return quote(rel_path.as_posix(), safe="/")
 
 
+_NOTEBOOK_IFRAME_FRAME_ANCESTORS = (
+    "frame-ancestors http://127.0.0.1:* http://localhost:*;"
+)
+_NOTEBOOK_ALLOW_ORIGIN_PAT = r"^https?://(localhost|127\.0\.0\.1)(:[0-9]+)?$"
+
+
+def _notebook_sidecar_token_key(notebook_key: str) -> str:
+    digest = hashlib.sha256(notebook_key.encode("utf-8")).hexdigest()[:16]
+    return f"notebook_sidecar_token__{digest}"
+
+
+def _notebook_sidecar_token(notebook_key: str) -> str:
+    session_key = _notebook_sidecar_token_key(notebook_key)
+    token = st.session_state.get(session_key)
+    if not isinstance(token, str) or not token:
+        token = secrets.token_urlsafe(32)
+        st.session_state[session_key] = token
+    return token
+
+
 def _notebook_iframe_tornado_settings_arg() -> str:
     """Return Jupyter headers that allow the local Streamlit parent to embed Lab."""
     settings = {
         "headers": {
-            "Content-Security-Policy": "frame-ancestors *;",
+            "Content-Security-Policy": _NOTEBOOK_IFRAME_FRAME_ANCESTORS,
             "X-Frame-Options": "",
         }
     }
@@ -2830,6 +2851,7 @@ def _ensure_notebook_sidecar(
     notebook_path: Path,
     port: int,
     project_root: Path,
+    token: str | None = None,
 ) -> bool:
     """Start a local JupyterLab sidecar rooted at the active project."""
     if _is_port_open(port):
@@ -2845,6 +2867,7 @@ def _ensure_notebook_sidecar(
     env.err_log = err_file
 
     project_home = str(project_root.resolve())
+    sidecar_token = token or _notebook_sidecar_token(notebook_key)
     tornado_settings = _notebook_iframe_tornado_settings_arg()
     run_cmd = [
         *uv,
@@ -2863,10 +2886,9 @@ def _ensure_notebook_sidecar(
         "--ServerApp.ip=127.0.0.1",
         f"--ServerApp.port={port}",
         "--ServerApp.open_browser=False",
-        "--ServerApp.token=",
+        f"--ServerApp.token={sidecar_token}",
         "--ServerApp.password=",
-        "--ServerApp.allow_origin=*",
-        "--ServerApp.disable_check_xsrf=True",
+        f"--ServerApp.allow_origin_pat={_NOTEBOOK_ALLOW_ORIGIN_PAT}",
         f"--ServerApp.root_dir={project_home}",
         f"--ServerApp.tornado_settings={tornado_settings}",
     ]
@@ -3433,8 +3455,9 @@ async def render_notebook_page(notebook_path: Path):
 
     notebook_key = f"{notebook_label}|{project_root.as_posix()}"
     port = _port_for(f"notebook|{notebook_key}")
+    sidecar_token = _notebook_sidecar_token(notebook_key)
     sidecar_ready = _ensure_notebook_sidecar(
-        notebook_key, resolved_notebook, port, project_root
+        notebook_key, resolved_notebook, port, project_root, token=sidecar_token
     )
 
     qp = st.query_params
@@ -3444,6 +3467,7 @@ async def render_notebook_page(notebook_path: Path):
             continue
         extras[key] = value
     extras["embed"] = "true"
+    extras["token"] = sidecar_token
     query = urlencode(extras, doseq=True)
     notebook_url_path = _notebook_lab_tree_path(resolved_notebook, project_root)
     if not sidecar_ready:
@@ -3478,7 +3502,11 @@ async def render_notebook_page(notebook_path: Path):
                 st.code("\n".join(sidecar_attempts), language="bash")
         return
     url = f"http://127.0.0.1:{port}/lab/tree/{notebook_url_path}?{query}"
-    env.logger.info("notebook url: %s", url)
+    env.logger.info(
+        "notebook url: http://127.0.0.1:%s/lab/tree/%s?token=<redacted>",
+        port,
+        notebook_url_path,
+    )
     st.iframe(url, height=900)
 
 

--- a/src/agilab_mcp/manifest_tools.py
+++ b/src/agilab_mcp/manifest_tools.py
@@ -11,8 +11,70 @@ from agilab import agent_run, bridge_cli, run_manifest
 from agilab.secret_uri import redact_mapping
 
 
+_ALLOWED_ROOTS_ENV = "AGILAB_MCP_ALLOWED_ROOTS"
+_CONFIGURED_ROOT_ENV_NAMES = (
+    "AGILAB_APPS_ROOT",
+    "AGILAB_LOG_ROOT",
+    "AGILAB_AGENT_LOG_ROOT",
+)
+
+
+def _repo_root() -> Path | None:
+    for parent in Path(__file__).resolve().parents:
+        if (parent / "agilab-capabilities.json").is_file() or (
+            parent / ".git"
+        ).exists():
+            return parent
+    return None
+
+
+def _unique_roots(paths: list[Path]) -> tuple[Path, ...]:
+    roots: list[Path] = []
+    seen: set[str] = set()
+    for path in paths:
+        resolved = path.expanduser().resolve(strict=False)
+        key = str(resolved)
+        if key not in seen:
+            roots.append(resolved)
+            seen.add(key)
+    return tuple(roots)
+
+
+def _configured_read_roots() -> tuple[Path, ...]:
+    roots: list[Path] = []
+    configured = os.environ.get(_ALLOWED_ROOTS_ENV, "")
+    roots.extend(Path(item) for item in configured.split(os.pathsep) if item)
+    for env_name in _CONFIGURED_ROOT_ENV_NAMES:
+        env_value = os.environ.get(env_name)
+        if env_value:
+            roots.append(Path(env_value))
+    repo_root = _repo_root()
+    if repo_root is not None:
+        roots.append(repo_root)
+    roots.append(Path.cwd())
+    home = Path.home()
+    roots.extend((home / "log" / "agents", home / "log" / "execute"))
+    return _unique_roots(roots)
+
+
+def _is_under_root(path: Path, root: Path) -> bool:
+    return path == root or path.is_relative_to(root)
+
+
+def _mcp_read_path(path: str | Path, *, purpose: str) -> Path:
+    resolved = Path(path).expanduser().resolve(strict=False)
+    roots = _configured_read_roots()
+    if any(_is_under_root(resolved, root) for root in roots):
+        return resolved
+    allowed = ", ".join(str(root) for root in roots) or "<none>"
+    raise ValueError(
+        f"MCP path for {purpose} is outside configured read roots: "
+        f"{resolved} (allowed roots: {allowed})"
+    )
+
+
 def list_projects(apps_root: str | Path) -> dict[str, Any]:
-    root = Path(apps_root).expanduser().resolve(strict=False)
+    root = _mcp_read_path(apps_root, purpose="projects root")
     projects = (
         [
             {"name": path.name, "path": str(path)}
@@ -30,7 +92,7 @@ def list_projects(apps_root: str | Path) -> dict[str, Any]:
 
 
 def list_runs(log_root: str | Path) -> dict[str, Any]:
-    root = Path(log_root).expanduser().resolve(strict=False)
+    root = _mcp_read_path(log_root, purpose="run log root")
     runs = (
         [
             {"path": str(path), "parent": str(path.parent)}
@@ -79,7 +141,7 @@ def list_agent_runs(
     if limit < 0:
         raise ValueError("limit must be >= 0")
     root = (
-        Path(log_root).expanduser().resolve(strict=False)
+        _mcp_read_path(log_root, purpose="agent log root")
         if log_root not in (None, "")
         else None
     )
@@ -107,7 +169,7 @@ def list_agent_runs(
 
 
 def read_agent_run(manifest_path: str | Path) -> dict[str, Any]:
-    path = Path(manifest_path).expanduser().resolve(strict=False)
+    path = _mcp_read_path(manifest_path, purpose="agent run manifest")
     manifest = agent_run.load_agent_run_manifest(path)
     summary = agent_run.summarize_agent_run(manifest)
     resolved = summary.manifest_path if str(summary.manifest_path) else path
@@ -119,7 +181,7 @@ def read_agent_run(manifest_path: str | Path) -> dict[str, Any]:
 
 
 def summarize_agent_run(manifest_path: str | Path) -> dict[str, Any]:
-    path = Path(manifest_path).expanduser().resolve(strict=False)
+    path = _mcp_read_path(manifest_path, purpose="agent run manifest")
     summary = agent_run.summarize_agent_run(path)
     return {
         "schema": "agilab.mcp.summarize_agent_run.v1",
@@ -129,7 +191,7 @@ def summarize_agent_run(manifest_path: str | Path) -> dict[str, Any]:
 
 
 def agent_handoff(manifest_path: str | Path) -> dict[str, Any]:
-    path = Path(manifest_path).expanduser().resolve(strict=False)
+    path = _mcp_read_path(manifest_path, purpose="agent run manifest")
     return {
         "schema": "agilab.mcp.agent_handoff.v1",
         "manifest_path": str(path),
@@ -138,7 +200,7 @@ def agent_handoff(manifest_path: str | Path) -> dict[str, Any]:
 
 
 def agent_next_actions(manifest_path: str | Path) -> dict[str, Any]:
-    path = Path(manifest_path).expanduser().resolve(strict=False)
+    path = _mcp_read_path(manifest_path, purpose="agent run manifest")
     return {
         "schema": "agilab.mcp.agent_next_actions.v1",
         "manifest_path": str(path),
@@ -160,7 +222,7 @@ def agent_context(
     if limit < 0:
         raise ValueError("limit must be >= 0")
     root = (
-        Path(log_root).expanduser().resolve(strict=False)
+        _mcp_read_path(log_root, purpose="agent log root")
         if log_root not in (None, "")
         else None
     )
@@ -186,7 +248,7 @@ def agent_lineage(
     run_id: str,
 ) -> dict[str, Any]:
     root = (
-        Path(log_root).expanduser().resolve(strict=False)
+        _mcp_read_path(log_root, purpose="agent log root")
         if log_root not in (None, "")
         else None
     )
@@ -200,8 +262,8 @@ def agent_lineage(
 def compare_agent_runs(
     left_manifest: str | Path, right_manifest: str | Path
 ) -> dict[str, Any]:
-    left = Path(left_manifest).expanduser().resolve(strict=False)
-    right = Path(right_manifest).expanduser().resolve(strict=False)
+    left = _mcp_read_path(left_manifest, purpose="left agent run manifest")
+    right = _mcp_read_path(right_manifest, purpose="right agent run manifest")
     return {
         "schema": "agilab.mcp.compare_agent_runs.v1",
         "left_manifest": str(left),
@@ -211,7 +273,7 @@ def compare_agent_runs(
 
 
 def validate_agent_run(manifest_path: str | Path) -> dict[str, Any]:
-    path = Path(manifest_path).expanduser().resolve(strict=False)
+    path = _mcp_read_path(manifest_path, purpose="agent run manifest")
     return {
         "schema": "agilab.mcp.validate_agent_run.v1",
         "manifest_path": str(path),
@@ -220,7 +282,7 @@ def validate_agent_run(manifest_path: str | Path) -> dict[str, Any]:
 
 
 def read_manifest(manifest_path: str | Path) -> dict[str, Any]:
-    path = Path(manifest_path).expanduser().resolve(strict=False)
+    path = _mcp_read_path(manifest_path, purpose="manifest")
     payload = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(payload, Mapping):
         raise ValueError(f"Manifest must be a JSON object: {path}")
@@ -232,7 +294,8 @@ def read_manifest(manifest_path: str | Path) -> dict[str, Any]:
 
 
 def summarize_run(manifest_path: str | Path) -> dict[str, Any]:
-    manifest, _, resolved = bridge_cli._load_run_manifest(Path(manifest_path))
+    path = _mcp_read_path(manifest_path, purpose="run manifest")
+    manifest, _, resolved = bridge_cli._load_run_manifest(path)
     return {
         "schema": "agilab.mcp.summarize_run.v1",
         "manifest_path": str(resolved),
@@ -241,7 +304,8 @@ def summarize_run(manifest_path: str | Path) -> dict[str, Any]:
 
 
 def list_artifacts(manifest_path: str | Path) -> dict[str, Any]:
-    manifest, _, resolved = bridge_cli._load_run_manifest(Path(manifest_path))
+    path = _mcp_read_path(manifest_path, purpose="run manifest")
+    manifest, _, resolved = bridge_cli._load_run_manifest(path)
     return {
         "schema": "agilab.mcp.list_artifacts.v1",
         "manifest_path": str(resolved),
@@ -252,8 +316,10 @@ def list_artifacts(manifest_path: str | Path) -> dict[str, Any]:
 def compare_runs(
     left_manifest: str | Path, right_manifest: str | Path
 ) -> dict[str, Any]:
-    left, _, left_path = bridge_cli._load_run_manifest(Path(left_manifest))
-    right, _, right_path = bridge_cli._load_run_manifest(Path(right_manifest))
+    left_input = _mcp_read_path(left_manifest, purpose="left run manifest")
+    right_input = _mcp_read_path(right_manifest, purpose="right run manifest")
+    left, _, left_path = bridge_cli._load_run_manifest(left_input)
+    right, _, right_path = bridge_cli._load_run_manifest(right_input)
     left_summary = run_manifest.manifest_summary(left)
     right_summary = run_manifest.manifest_summary(right)
     return {
@@ -273,8 +339,10 @@ def compare_runs(
 def export_quarto_report(
     manifest_path: str | Path, output_path: str | Path
 ) -> dict[str, Any]:
+    manifest = _mcp_read_path(manifest_path, purpose="run manifest")
+    output = _mcp_read_path(output_path, purpose="report output")
     return bridge_cli.export_quarto_report(
-        Path(manifest_path), Path(output_path), render=False
+        manifest, output, render=False
     )
 
 
@@ -299,7 +367,11 @@ def _capabilities_manifest_path(explicit: str | Path | None = None) -> Path | No
     """
     if explicit is not None:
         candidate = Path(explicit).expanduser()
-        return candidate.resolve() if candidate.is_file() else None
+        return (
+            _mcp_read_path(candidate, purpose="capabilities manifest")
+            if candidate.is_file()
+            else None
+        )
     candidates: list[Path] = []
     env_value = os.environ.get("AGILAB_CAPABILITIES_MANIFEST")
     if env_value:

--- a/test/test_analysis_page_helpers.py
+++ b/test/test_analysis_page_helpers.py
@@ -809,13 +809,14 @@ def test_render_notebook_page_embeds_project_jupyter_sidecar(tmp_path: Path, mon
     monkeypatch.setattr(module, "_hide_parent_sidebar", lambda: sidebar_hides.append("hide"))
     monkeypatch.setattr(module, "_is_hosted_analysis_runtime", lambda _env: False)
     monkeypatch.setattr(module, "_ensure_notebook_sidecar", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(module, "_notebook_sidecar_token", lambda _key: "test-token")
     monkeypatch.setattr(module, "_port_for", lambda _key: 8766)
 
     asyncio.run(module.render_notebook_page(notebook_path))
 
     assert calls == [
         (
-            "http://127.0.0.1:8766/lab/tree/notebooks/lab_stages.ipynb?active_app=flight_telemetry_project&embed=true",
+            "http://127.0.0.1:8766/lab/tree/notebooks/lab_stages.ipynb?active_app=flight_telemetry_project&embed=true&token=test-token",
             {"height": 900},
         )
     ]
@@ -892,6 +893,7 @@ def test_ensure_notebook_sidecar_starts_lab_root_and_allows_iframe(tmp_path: Pat
 
     monkeypatch.setattr(module, "st", fake_st)
     monkeypatch.setattr(module, "_is_port_open", lambda _port: next(port_checks))
+    monkeypatch.setattr(module, "_notebook_sidecar_token", lambda _key: "sidecar-token")
 
     def _fake_exec_bg(_env, cmd, cwd: str, process_env=None):
         commands.append((cmd, cwd, process_env))
@@ -915,8 +917,17 @@ def test_ensure_notebook_sidecar_starts_lab_root_and_allows_iframe(tmp_path: Pat
     assert "lab" in command
     assert "--no-browser" in command
     assert str(notebook_path.resolve()) not in command
+    assert "--ServerApp.token=sidecar-token" in command
+    assert "--ServerApp.token=" not in command
+    assert "--ServerApp.allow_origin=*" not in command
+    assert "--ServerApp.disable_check_xsrf=True" not in command
+    assert any(part.startswith("--ServerApp.allow_origin_pat=") for part in command)
     assert any(part.startswith("--ServerApp.tornado_settings=") for part in command)
-    assert any("frame-ancestors *;" in part for part in command)
+    assert not any("frame-ancestors *;" in part for part in command)
+    assert any(
+        "frame-ancestors http://127.0.0.1:* http://localhost:*;" in part
+        for part in command
+    )
     assert not any("'" in part for part in command)
 
 

--- a/test/test_audience_bridges.py
+++ b/test/test_audience_bridges.py
@@ -810,7 +810,8 @@ def test_bridge_cli_routes_export_import_init_and_mcp(monkeypatch: pytest.Monkey
     assert "planned" in capsys.readouterr().out
 
 
-def test_mcp_tools_and_jsonrpc(tmp_path: Path) -> None:
+def test_mcp_tools_and_jsonrpc(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGILAB_MCP_ALLOWED_ROOTS", str(tmp_path))
     manifest_path = _write_manifest(tmp_path)
     apps_root = tmp_path / "apps"
     (apps_root / "alpha_project").mkdir(parents=True)
@@ -1147,9 +1148,12 @@ def test_agent_quickstart_returns_bounded_curated_front_door() -> None:
     assert mcp_server.tool_descriptors()[0]["name"] == "agent_quickstart"
 
 
-def test_agent_quickstart_bounds_manifest_lists(tmp_path) -> None:
+def test_agent_quickstart_bounds_manifest_lists(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """When the capabilities manifest is large, lists are capped and big sets
     are summarized as counts rather than inlined."""
+    monkeypatch.setenv("AGILAB_MCP_ALLOWED_ROOTS", str(tmp_path))
     manifest = {
         "boundary": {"proves": "discoverable surfaces"},
         "cli_commands": [
@@ -1184,7 +1188,10 @@ def test_agent_quickstart_degrades_without_manifest() -> None:
     assert "note" in payload
 
 
-def test_manifest_tools_reject_invalid_limits_and_manifest_shapes(tmp_path: Path) -> None:
+def test_manifest_tools_reject_invalid_limits_and_manifest_shapes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AGILAB_MCP_ALLOWED_ROOTS", str(tmp_path))
     with pytest.raises(ValueError, match="limit must be >= 0"):
         manifest_tools.list_agent_runs(log_root=tmp_path, limit=-1)
     with pytest.raises(ValueError, match="limit must be >= 0"):
@@ -1198,6 +1205,29 @@ def test_manifest_tools_reject_invalid_limits_and_manifest_shapes(tmp_path: Path
     manifest.write_text('{"status": "pass"}', encoding="utf-8")
     payload = manifest_tools.read_manifest(manifest)
     assert payload["manifest"]["status"] == "pass"
+
+
+def test_manifest_tools_reject_paths_outside_allowed_roots(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    allowed = tmp_path / "allowed"
+    outside = tmp_path / "outside"
+    allowed.mkdir()
+    outside.mkdir()
+    outside_manifest = outside / "run_manifest.json"
+    outside_manifest.write_text('{"status": "pass"}', encoding="utf-8")
+    monkeypatch.setenv("AGILAB_MCP_ALLOWED_ROOTS", str(allowed))
+
+    with pytest.raises(ValueError, match="outside configured read roots"):
+        manifest_tools.read_manifest(outside_manifest)
+    with pytest.raises(ValueError, match="outside configured read roots"):
+        manifest_tools.list_runs(outside)
+    with pytest.raises(ValueError, match="outside configured read roots"):
+        manifest_tools.list_projects(outside)
+    with pytest.raises(ValueError, match="outside configured read roots"):
+        manifest_tools.list_agent_runs(log_root=outside)
+    with pytest.raises(ValueError, match="outside configured read roots"):
+        manifest_tools.agent_quickstart(capabilities_path=outside_manifest)
 
 
 def test_agent_quickstart_discovers_manifest_from_env(
@@ -1219,6 +1249,7 @@ def test_agent_quickstart_discovers_manifest_from_env(
         encoding="utf-8",
     )
     monkeypatch.setenv("AGILAB_CAPABILITIES_MANIFEST", str(manifest))
+    monkeypatch.setenv("AGILAB_MCP_ALLOWED_ROOTS", str(tmp_path))
 
     payload = manifest_tools.agent_quickstart()
 
@@ -1244,7 +1275,10 @@ def test_agent_quickstart_degrades_when_auto_discovery_finds_no_manifest(
     assert "Capabilities manifest not found" in payload["note"]
 
 
-def test_agent_quickstart_reports_bad_manifest_content(tmp_path: Path) -> None:
+def test_agent_quickstart_reports_bad_manifest_content(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AGILAB_MCP_ALLOWED_ROOTS", str(tmp_path))
     bad_json = tmp_path / "bad.json"
     bad_json.write_text("{", encoding="utf-8")
     unreadable = manifest_tools.agent_quickstart(capabilities_path=bad_json)


### PR DESCRIPTION
## Summary
- Enforce configured MCP read roots before local manifest, project, agent-run, and report-helper paths are opened.
- Harden the ANALYSIS notebook sidecar by using a session token, localhost-only iframe/origin policy, and default XSRF protection.
- Add focused regressions for MCP outside-root rejection and notebook sidecar launch arguments.

## Repro
- The audit found MCP read helpers accepted caller-supplied local paths after only `Path.resolve()`, allowing reads outside any declared AGILAB root.
- The audit found the notebook sidecar launched JupyterLab with a blank token, wildcard origin/frame ancestors, and disabled XSRF checks.

## Root Cause
- MCP helper functions normalized caller paths but did not enforce containment against configured AGILAB read roots.
- The notebook sidecar optimized iframe embedding by disabling Jupyter protections instead of granting the minimum localhost parent access needed by the Streamlit page.

## Regression Test
- `test_manifest_tools_reject_paths_outside_allowed_roots` proves caller paths outside `AGILAB_MCP_ALLOWED_ROOTS` are rejected.
- `test_ensure_notebook_sidecar_starts_lab_root_and_allows_iframe` proves the sidecar keeps a token, rejects wildcard origin/XSRF disable flags, and uses localhost frame ancestors.

## Validation
- `pytest -q -o addopts='' test/test_audience_bridges.py test/test_analysis_page_helpers.py`: 103 passed.
- `git diff --check`: passed.
- `./dev scope --staged`: passed.
- `tools/impact_validate.py --staged`: passed.
- Pre-push hook: passed; unrelated docs/release/agent/app guards were skipped by path classification.
- GitHub checks: `local-only-policy`, `clean-public-install` on Ubuntu/macOS/Windows, `windows-core-tests`, and GitGuardian passed.
- GitHub skipped: `public-demo-smoke` skipped by workflow classification; not applicable to this backend/test hardening scope.

## Review Evidence
- No separate model or sub-agent review was used.

## Agent Metadata
- Tokki version: `tokki 1.0.8`
- Agent/runtime: `codex-cli 0.142.0`
- Model: `GPT-5`
- Reasoning effort: `unknown`
- `/fast` mode: `not used`
- Sub-agents: `not used`
