### PR TITLE
Fix worker cluster share root mounting

### DIFF
--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_remote_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_remote_support.py
@@ -410,7 +410,7 @@ def _scheduler_ssh_target(agi_cls: Any, env: Any) -> str:
     return f"{user}@{host}" if user else host
 
 
-def _remote_env_update_command(remote_share: str) -> str:
+def _remote_env_update_command(remote_share: str, workflow_data_root: str | None = None) -> str:
     # Update only worker cluster-mode lines: the remote ~/.agilab/.env holds other
     # operator-managed settings that must be preserved (merge semantics,
     # matching install.sh/write_env_updates).  Remote workers resolve relative
@@ -421,12 +421,13 @@ def _remote_env_update_command(remote_share: str) -> str:
     worker_line = "IS_WORKER_ENV='1'"
     enabled_line = "AGI_CLUSTER_ENABLED='1'"
     share_line = f"AGI_CLUSTER_SHARE={remote_share!r}"
+    workflow_root_line = f"AGILAB_WORKFLOW_DATA_ROOT={(workflow_data_root or remote_share)!r}"
     return (
         'mkdir -p "$HOME/.agilab" && touch "$HOME/.agilab/.env" && '
-        "{ grep -Ev '^(IS_SOURCE_ENV|IS_WORKER_ENV|AGI_CLUSTER_ENABLED|AGI_CLUSTER_SHARE)=' "
+        "{ grep -Ev '^(IS_SOURCE_ENV|IS_WORKER_ENV|AGI_CLUSTER_ENABLED|AGI_CLUSTER_SHARE|AGILAB_WORKFLOW_DATA_ROOT)=' "
         "\"$HOME/.agilab/.env\" || true; "
         f"printf '%s\\n' {quote(source_line)} {quote(worker_line)} "
-        f"{quote(enabled_line)} {quote(share_line)}; }} "
+        f"{quote(enabled_line)} {quote(share_line)} {quote(workflow_root_line)}; }} "
         "> \"$HOME/.agilab/.env.tmp\" && "
         'mv "$HOME/.agilab/.env.tmp" "$HOME/.agilab/.env"'
     )
@@ -518,7 +519,11 @@ async def _prepare_remote_cluster_share(
             raise RuntimeError(reverse_mount_problem)
     local_share.mkdir(parents=True, exist_ok=True)
 
-    await agi_cls.exec_ssh(ip, _remote_env_update_command(remote_share_setting))
+    workflow_data_root_setting = _home_relative_share_setting(remote_share, env)
+    await agi_cls.exec_ssh(
+        ip,
+        _remote_env_update_command(remote_share_setting, workflow_data_root_setting),
+    )
     if share_is_premounted:
         if getattr(env, "verbose", 0) > 0:
             log.info(

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_remote_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_remote_support.py
@@ -349,35 +349,39 @@ def _home_relative_share_setting(value: str, env: Any) -> str:
     return cleaned
 
 
-def _scheduler_share_source(
-    local_share: Path,
+def _remote_cluster_share_root_setting(
+    remote_share: str,
     *,
     local_share_setting: str,
-    remote_share: str,
     env: Any,
-) -> Path:
-    configured = PurePosixPath(
-        _home_relative_share_setting(local_share_setting, env).replace("\\", "/")
-    )
-    requested = PurePosixPath(
-        _home_relative_share_setting(remote_share, env).replace("\\", "/")
-    )
-    try:
-        suffix = requested.relative_to(configured)
-    except ValueError:
-        return local_share
-    if str(suffix) in {"", "."}:
-        return local_share
-    if ".." in suffix.parts:
-        return local_share
-    share_root = local_share.expanduser().resolve(strict=False)
-    candidate = share_root.joinpath(*suffix.parts).resolve(strict=False)
-    if not candidate.is_relative_to(share_root):
-        raise RuntimeError(
-            "Refusing to derive scheduler AGI_CLUSTER_SHARE outside the configured "
-            f"share root: {candidate.as_posix()} is not under {share_root.as_posix()}."
-        )
-    return candidate
+) -> str:
+    """Return the worker-side AGI_CLUSTER_SHARE root, not a per-run subpath."""
+
+    remote_setting = _home_relative_share_setting(remote_share, env)
+    requested = PurePosixPath(remote_setting.replace("\\", "/"))
+    configured_text = _home_relative_share_setting(local_share_setting, env)
+    configured = PurePosixPath(configured_text.replace("\\", "/"))
+
+    if configured_text and not configured.is_absolute():
+        try:
+            requested.relative_to(configured)
+        except ValueError:
+            pass
+        else:
+            return configured.as_posix()
+
+    user = str(getattr(env, "user", "") or "").strip()
+    requested_parts = tuple(part for part in requested.parts if part not in {"", "."})
+    if (
+        user
+        and not requested.is_absolute()
+        and len(requested_parts) >= 4
+        and requested_parts[0] in {"clustershare", "datashare"}
+        and requested_parts[1] == user
+    ):
+        return PurePosixPath(*requested_parts[:2]).as_posix()
+
+    return remote_setting
 
 
 def _scheduler_host_from_state(agi_cls: Any) -> str:
@@ -503,20 +507,17 @@ async def _prepare_remote_cluster_share(
     local_share = _resolve_local_share_path(local_share_raw, env)
     share_backend = _cluster_share_backend(env)
     share_is_premounted = _remote_cluster_share_premounted(env)
-    scheduler_share = _scheduler_share_source(
-        local_share,
+    remote_share_setting = _remote_cluster_share_root_setting(
+        remote_share,
         local_share_setting=local_share_raw,
-        remote_share=remote_share,
         env=env,
     )
     if not share_is_premounted:
-        for share_source in dict.fromkeys((local_share, scheduler_share)):
-            reverse_mount_problem = _reverse_sshfs_mount_problem(share_source, ip)
-            if reverse_mount_problem:
-                raise RuntimeError(reverse_mount_problem)
-    scheduler_share.mkdir(parents=True, exist_ok=True)
+        reverse_mount_problem = _reverse_sshfs_mount_problem(local_share, ip)
+        if reverse_mount_problem:
+            raise RuntimeError(reverse_mount_problem)
+    local_share.mkdir(parents=True, exist_ok=True)
 
-    remote_share_setting = _home_relative_share_setting(remote_share, env)
     await agi_cls.exec_ssh(ip, _remote_env_update_command(remote_share_setting))
     if share_is_premounted:
         if getattr(env, "verbose", 0) > 0:
@@ -538,7 +539,7 @@ async def _prepare_remote_cluster_share(
     mount_cmd = _remote_share_mount_command(
         scheduler_target=scheduler_target,
         scheduler_ssh_port=_scheduler_ssh_port(env),
-        local_share=scheduler_share,
+        local_share=local_share,
         remote_share=remote_share_setting,
     )
     if getattr(env, "verbose", 0) > 0:

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime/runtime_misc_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime/runtime_misc_support.py
@@ -461,19 +461,18 @@ def _apply_workers_data_path_to_env(
     if not _workers_data_path_can_rebind_env_share(env, share_text):
         return
 
-    share_root_abs = _absolute_workers_data_share_root(env, share_text)
-    env.AGI_CLUSTER_SHARE = share_text
-    env.agi_share_path = share_text
-    env.agi_share_path_abs = share_root_abs
-    env._share_root_cache = share_root_abs
+    workflow_data_root_abs = _absolute_workers_data_share_root(env, share_text)
+    env.AGILAB_WORKFLOW_DATA_ROOT = share_text
+    env.agi_workflow_data_root = share_text
+    env.agi_workflow_data_root_abs = workflow_data_root_abs
     if isinstance(getattr(env, "envars", None), dict):
-        env.envars["AGI_CLUSTER_SHARE"] = share_text
+        env.envars["AGILAB_WORKFLOW_DATA_ROOT"] = share_text
 
     share_target_name_fn = getattr(env, "_share_target_name", None)
     if callable(share_target_name_fn):
         share_target_name = share_target_name_fn()
         env.share_target_name = share_target_name
-        env.app_data_rel = share_root_abs / share_target_name
+        env.app_data_rel = workflow_data_root_abs / share_target_name
         env.dataframe_path = env.app_data_rel / "dataframe"
 
 

--- a/src/agilab/core/agi-env/src/agi_env/runtime/agi_env.py
+++ b/src/agilab/core/agi-env/src/agi_env/runtime/agi_env.py
@@ -565,11 +565,35 @@ class AgiEnv(metaclass=_AgiEnvMeta):
 
     def resolve_share_path(self, path: str | Path | None) -> Path:
         """
-        Resolve ``path`` relative to the shared storage root.
+        Resolve ``path`` relative to the active shared data root.
 
-        ``None`` or ``"."`` returns the root itself; absolute inputs pass through unchanged.
+        ``None`` or ``"."`` returns the active data root itself; absolute inputs
+        pass through unchanged. When workflow/session scoping is active,
+        ``AGILAB_WORKFLOW_DATA_ROOT`` is the active data root while
+        ``AGI_CLUSTER_SHARE`` remains the physical cluster-share mount root.
         """
-        return resolve_relative_share_path(path, self.share_root_path())
+        return resolve_relative_share_path(path, self.workflow_data_root_path())
+
+    def workflow_data_root_path(self) -> Path:
+        """Return the active workflow/session data root when configured."""
+
+        raw_value = getattr(self, "AGILAB_WORKFLOW_DATA_ROOT", None) or getattr(
+            self, "agi_workflow_data_root", None
+        )
+        envars = getattr(self, "envars", None)
+        if not raw_value and isinstance(envars, dict):
+            raw_value = envars.get("AGILAB_WORKFLOW_DATA_ROOT")
+        if not raw_value:
+            return self.share_root_path()
+
+        data_root = Path(raw_value).expanduser()
+        if not data_root.is_absolute():
+            base = Path.home()
+            env_home = self.home_abs
+            if env_home and not self.is_worker_env:
+                base = Path(env_home)
+            data_root = Path(base).expanduser() / data_root
+        return data_root.resolve(strict=False)
 
     @classmethod
     def _ensure_defaults(cls):

--- a/src/agilab/core/agi-env/test/test_agi_env.py
+++ b/src/agilab/core/agi-env/test/test_agi_env.py
@@ -2732,6 +2732,13 @@ def test_share_root_resolution_and_mode_helpers(tmp_path: Path, monkeypatch):
     assert env.share_root_path() == fake_home / "clustershare"
     assert env.resolve_share_path(None) == fake_home / "clustershare"
     assert env.resolve_share_path("demo/data") == fake_home / "clustershare" / "demo" / "data"
+    env.AGILAB_WORKFLOW_DATA_ROOT = "clustershare/alice/workflow/session-1"
+    assert env.share_root_path() == fake_home / "clustershare"
+    assert env.workflow_data_root_path() == fake_home / "clustershare" / "alice" / "workflow" / "session-1"
+    assert (
+        env.resolve_share_path("demo/data")
+        == fake_home / "clustershare" / "alice" / "workflow" / "session-1" / "demo" / "data"
+    )
     absolute_share_path = env.resolve_share_path("/tmp/absolute")
     if os.name == "nt":
         assert absolute_share_path.is_absolute()

--- a/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/base_worker_path_support.py
+++ b/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/base_worker_path_support.py
@@ -75,6 +75,22 @@ def share_root_path(
     if env is None:
         return None
 
+    for name in ("AGILAB_WORKFLOW_DATA_ROOT", "agi_workflow_data_root", "workflow_data_root"):
+        active_root = getattr(env, name, None)
+        if not active_root and isinstance(getattr(env, "envars", None), dict):
+            active_root = env.envars.get(name)
+        if not active_root:
+            continue
+        try:
+            base = path_cls(active_root).expanduser()
+            if not base.is_absolute():
+                home = getattr(env, "home_abs", None)
+                base_home = path_cls(home).expanduser() if home else path_cls.home()
+                base = base_home / base
+            return base.resolve(strict=False)
+        except SHARE_ROOT_FALLBACK_EXCEPTIONS:
+            continue
+
     try:
         base = path_cls(env.share_root_path()).expanduser()
         if base:

--- a/src/agilab/core/test/test_agi_distributor_deployment_remote_support.py
+++ b/src/agilab/core/test/test_agi_distributor_deployment_remote_support.py
@@ -103,20 +103,18 @@ def test_remote_deployment_path_and_probe_helpers(tmp_path):
         == ""
     )
     local_share = tmp_path / "home" / "clustershare" / "agi"
-    assert deployment_remote_support._scheduler_share_source(
-        local_share,
+    assert deployment_remote_support._remote_cluster_share_root_setting(
+        "clustershare/agi/workflows/session-123",
         local_share_setting=str(local_share),
-        remote_share="clustershare/agi/workflows/session-123",
         env=env,
-    ) == (local_share / "workflows" / "session-123").resolve(strict=False)
+    ) == "clustershare/agi"
     assert (
-        deployment_remote_support._scheduler_share_source(
-            local_share,
+        deployment_remote_support._remote_cluster_share_root_setting(
+            "clustershare/agi/../outside",
             local_share_setting=str(local_share),
-            remote_share="clustershare/agi/../outside",
             env=env,
         )
-        == local_share
+        == "clustershare/agi"
     )
 
     assert deployment_remote_support._parse_version_prefix("10.15.7-extra") == (
@@ -133,24 +131,14 @@ def test_remote_deployment_path_and_probe_helpers(tmp_path):
     )
 
 
-def test_scheduler_share_source_rejects_symlink_escape(tmp_path):
-    env = SimpleNamespace(home_abs=tmp_path)
-    local_share = tmp_path / "clustershare" / "agi"
-    outside = tmp_path / "outside"
-    local_share.mkdir(parents=True)
-    outside.mkdir()
-    try:
-        (local_share / "workflows").symlink_to(outside, target_is_directory=True)
-    except (NotImplementedError, OSError) as exc:
-        pytest.skip(f"directory symlinks are not available: {exc}")
+def test_remote_cluster_share_root_setting_strips_default_user_workflow_suffix(tmp_path):
+    env = SimpleNamespace(home_abs=tmp_path, user="agi")
 
-    with pytest.raises(RuntimeError, match="outside the configured share root"):
-        deployment_remote_support._scheduler_share_source(
-            local_share,
-            local_share_setting=str(local_share),
-            remote_share="clustershare/agi/workflows/session-123",
-            env=env,
-        )
+    assert deployment_remote_support._remote_cluster_share_root_setting(
+        "clustershare/agi/workflow-123/session-456",
+        local_share_setting=str(tmp_path / "scheduler-share"),
+        env=env,
+    ) == "clustershare/agi"
 
 
 def test_remote_command_helpers_quote_dynamic_arguments():
@@ -785,7 +773,7 @@ async def test_prepare_remote_cluster_share_honors_custom_scheduler_ssh_port(tmp
 
 
 @pytest.mark.asyncio
-async def test_prepare_remote_cluster_share_mounts_matching_workflow_session(tmp_path):
+async def test_prepare_remote_cluster_share_mounts_cluster_share_root_for_workflow_session(tmp_path):
     scheduler_share = tmp_path / "clustershare" / "agi"
     workflow_share = "clustershare/agi/workflows/session-123"
     env = SimpleNamespace(
@@ -810,20 +798,23 @@ async def test_prepare_remote_cluster_share_mounts_matching_workflow_session(tmp
 
     mount_cmd = next(cmd for cmd in ssh_calls if "SCHEDULER_CLUSTER_SHARE" in cmd)
     scheduler_session = scheduler_share / "workflows" / "session-123"
-    assert scheduler_session.is_dir()
-    assert f"agi@192.168.20.111:{scheduler_session.as_posix()}" in mount_cmd
-    assert '"$HOME"/clustershare/agi/workflows/session-123' in mount_cmd
+    remote_env_cmd = next(cmd for cmd in ssh_calls if "AGI_CLUSTER_SHARE=" in cmd)
+    assert scheduler_share.is_dir()
+    assert not scheduler_session.exists()
+    assert "workflows/session-123" not in remote_env_cmd
+    assert "clustershare/agi" in remote_env_cmd
+    assert f"agi@192.168.20.111:{scheduler_share.as_posix()}" in mount_cmd
+    assert '"$HOME"/clustershare/agi' in mount_cmd
+    assert "workflows/session-123" not in mount_cmd
 
 
 @pytest.mark.asyncio
-async def test_prepare_remote_cluster_share_rejects_reverse_sshfs_loop_on_session_source(
+async def test_prepare_remote_cluster_share_rejects_reverse_sshfs_loop_on_share_root(
     tmp_path, monkeypatch
 ):
     scheduler_share = tmp_path / "clustershare" / "agi"
     workflow_share = "clustershare/agi/workflows/session-123"
-    scheduler_session = (scheduler_share / "workflows" / "session-123").resolve(
-        strict=False
-    )
+    scheduler_root = scheduler_share.resolve(strict=False)
     env = SimpleNamespace(
         AGI_CLUSTER_SHARE=str(scheduler_share),
         envars={},
@@ -841,14 +832,11 @@ async def test_prepare_remote_cluster_share_rejects_reverse_sshfs_loop_on_sessio
             return "ok"
 
     def _mount_record(path):
-        if Path(path) != scheduler_session:
+        if Path(path) != scheduler_root:
             return None
         return {
-            "TARGET": scheduler_session.as_posix(),
-            "SOURCE": (
-                "agi@192.168.20.15:/home/agi/clustershare/agi/"
-                "workflows/session-123"
-            ),
+            "TARGET": scheduler_root.as_posix(),
+            "SOURCE": "agi@192.168.20.15:/home/agi/clustershare/agi",
             "FSTYPE": "fuse.sshfs",
         }
 
@@ -864,7 +852,7 @@ async def test_prepare_remote_cluster_share_rejects_reverse_sshfs_loop_on_sessio
         )
 
     assert ssh_calls == []
-    assert not scheduler_session.exists()
+    assert not scheduler_share.exists()
 
 
 @pytest.mark.asyncio

--- a/src/agilab/core/test/test_agi_distributor_deployment_remote_support.py
+++ b/src/agilab/core/test/test_agi_distributor_deployment_remote_support.py
@@ -801,8 +801,9 @@ async def test_prepare_remote_cluster_share_mounts_cluster_share_root_for_workfl
     remote_env_cmd = next(cmd for cmd in ssh_calls if "AGI_CLUSTER_SHARE=" in cmd)
     assert scheduler_share.is_dir()
     assert not scheduler_session.exists()
-    assert "workflows/session-123" not in remote_env_cmd
     assert "clustershare/agi" in remote_env_cmd
+    assert "AGILAB_WORKFLOW_DATA_ROOT=" in remote_env_cmd
+    assert "workflows/session-123" in remote_env_cmd
     assert f"agi@192.168.20.111:{scheduler_share.as_posix()}" in mount_cmd
     assert '"$HOME"/clustershare/agi' in mount_cmd
     assert "workflows/session-123" not in mount_cmd
@@ -1602,10 +1603,13 @@ def test_remote_env_update_command_preserves_other_env_keys():
     # Regression: the command previously truncated the whole remote
     # ~/.agilab/.env with '>' redirection; it must merge instead, replacing
     # only the worker cluster-mode lines.
-    cmd = deployment_remote_support._remote_env_update_command("clustershare")
+    cmd = deployment_remote_support._remote_env_update_command(
+        "clustershare/agi",
+        "clustershare/agi/workflows/session-123",
+    )
 
     assert (
-        "grep -Ev '^(IS_SOURCE_ENV|IS_WORKER_ENV|AGI_CLUSTER_ENABLED|AGI_CLUSTER_SHARE)='"
+        "grep -Ev '^(IS_SOURCE_ENV|IS_WORKER_ENV|AGI_CLUSTER_ENABLED|AGI_CLUSTER_SHARE|AGILAB_WORKFLOW_DATA_ROOT)='"
         in cmd
     )
     assert 'mv "$HOME/.agilab/.env.tmp" "$HOME/.agilab/.env"' in cmd
@@ -1613,6 +1617,8 @@ def test_remote_env_update_command_preserves_other_env_keys():
     assert "IS_WORKER_ENV=" in cmd
     assert "AGI_CLUSTER_ENABLED=" in cmd
     assert "AGI_CLUSTER_SHARE=" in cmd
+    assert "AGILAB_WORKFLOW_DATA_ROOT=" in cmd
+    assert "clustershare/agi/workflows/session-123" in cmd
     assert "AGI_LOCAL_SHARE" not in cmd
     # No direct truncating redirection of the env file itself.
     assert '> "$HOME/.agilab/.env"' not in cmd.replace(

--- a/src/agilab/core/test/test_agi_distributor_runtime_misc_support.py
+++ b/src/agilab/core/test/test_agi_distributor_runtime_misc_support.py
@@ -585,7 +585,7 @@ def test_initialize_runtime_state_preserves_workflow_session_workers_data_path()
     assert agi_cls._workers_data_path == str(session_root)
 
 
-def test_initialize_runtime_state_rebinds_manager_share_root_to_workflow_session():
+def test_initialize_runtime_state_sets_workflow_data_root_without_rebinding_cluster_share():
     agi_cls = SimpleNamespace()
     env = SimpleNamespace(
         manager_path=Path("/tmp/manager"),
@@ -614,14 +614,18 @@ def test_initialize_runtime_state_rebinds_manager_share_root_to_workflow_session
 
     expected_root = (Path("/home/agi") / session_root).resolve(strict=False)
     assert agi_cls._workers_data_path == session_root
-    assert env.AGI_CLUSTER_SHARE == session_root
-    assert env.agi_share_path == session_root
-    assert env.agi_share_path_abs == expected_root
-    assert env._share_root_cache == expected_root
+    assert env.AGI_CLUSTER_SHARE == "clustershare/agi"
+    assert env.agi_share_path == "clustershare/agi"
+    assert env.agi_share_path_abs == Path("/home/agi/clustershare/agi")
+    assert env._share_root_cache == Path("/home/agi/clustershare/agi")
+    assert env.AGILAB_WORKFLOW_DATA_ROOT == session_root
+    assert env.agi_workflow_data_root == session_root
+    assert env.agi_workflow_data_root_abs == expected_root
     assert env.share_target_name == "flight_trajectory"
     assert env.app_data_rel == expected_root / "flight_trajectory"
     assert env.dataframe_path == expected_root / "flight_trajectory" / "dataframe"
-    assert env.envars["AGI_CLUSTER_SHARE"] == session_root
+    assert env.envars["AGILAB_WORKFLOW_DATA_ROOT"] == session_root
+    assert "AGI_CLUSTER_SHARE" not in env.envars
 
 
 def test_initialize_runtime_state_preserves_scheduler_share_for_remote_workers_path():

--- a/src/agilab/core/test/test_base_worker_path_support.py
+++ b/src/agilab/core/test/test_base_worker_path_support.py
@@ -109,13 +109,14 @@ def test_worker_data_dir_deduplicates_share_leaf_for_any_app_module(tmp_path):
     assert "any_module/any_module" not in resolved.as_posix()
 
 
-def test_manager_data_dir_uses_workflow_session_share_root_not_legacy_share(tmp_path):
+def test_manager_data_dir_uses_active_workflow_data_root_not_cluster_share(tmp_path):
     session_root = (
         tmp_path / "clustershare" / "agi" / "workflows" / "20260618T093102Z-492de776"
     )
     legacy_root = tmp_path / "clustershare" / "agi"
     env = SimpleNamespace(
-        share_root_path=lambda: session_root,
+        AGILAB_WORKFLOW_DATA_ROOT=session_root,
+        share_root_path=lambda: legacy_root,
         agi_share_path_abs=legacy_root,
         agi_share_path=Path("clustershare") / "agi",
         home_abs=tmp_path,
@@ -132,6 +133,7 @@ def test_manager_data_dir_uses_workflow_session_share_root_not_legacy_share(tmp_
 
     assert resolved == (session_root / "flight_trajectory" / "dataset").resolve(strict=False)
     assert "workflows/20260618T093102Z-492de776/flight_trajectory/dataset" in resolved.as_posix()
+    assert path_support.share_root_path(env) == session_root.resolve(strict=False)
 
 
 def test_base_worker_path_support_data_dir_aliases_and_home_remap(monkeypatch, tmp_path):

--- a/src/agilab/pages/2_ORCHESTRATE.py
+++ b/src/agilab/pages/2_ORCHESTRATE.py
@@ -674,46 +674,62 @@ def _cluster_args_share_root(env: Any, cluster_params: dict[str, Any]) -> Path |
 class _ShareRootOverrideEnv:
     def __init__(self, env: Any, share_root: Path) -> None:
         object.__setattr__(self, "_env", env)
-        object.__setattr__(self, "_share_root", Path(share_root).expanduser())
+        object.__setattr__(self, "_data_root", Path(share_root).expanduser())
 
     def __getattr__(self, name: str) -> Any:
         return getattr(self._env, name)
 
     def __setattr__(self, name: str, value: Any) -> None:
-        if name in {"_env", "_share_root"}:
+        if name in {"_env", "_data_root"}:
             object.__setattr__(self, name, value)
             return
         setattr(self._env, name, value)
 
     @property
     def agi_share_path(self) -> Path:
-        return self._share_root
+        return Path(self.AGI_CLUSTER_SHARE).expanduser()
 
     @property
     def agi_share_path_abs(self) -> Path:
-        return self._share_root
+        candidate = Path(self.AGI_CLUSTER_SHARE).expanduser()
+        if not candidate.is_absolute():
+            candidate = Path(getattr(self._env, "home_abs", Path.home())) / candidate
+        return candidate.resolve(strict=False)
 
     @property
     def AGI_CLUSTER_SHARE(self) -> str:
-        return str(self._share_root)
+        env_vars = getattr(self._env, "envars", None)
+        env_value = getattr(self._env, "AGI_CLUSTER_SHARE", None)
+        if not env_value and isinstance(env_vars, dict):
+            env_value = env_vars.get("AGI_CLUSTER_SHARE")
+        return str(env_value or self._data_root)
+
+    @property
+    def AGILAB_WORKFLOW_DATA_ROOT(self) -> str:
+        return str(self._data_root)
+
+    @property
+    def agi_workflow_data_root(self) -> str:
+        return str(self._data_root)
 
     @property
     def envars(self) -> dict[str, Any]:
         env_vars = getattr(self._env, "envars", None)
         payload = dict(env_vars) if isinstance(env_vars, dict) else {}
-        payload["AGI_CLUSTER_SHARE"] = str(self._share_root)
+        payload["AGI_CLUSTER_SHARE"] = self.AGI_CLUSTER_SHARE
+        payload["AGILAB_WORKFLOW_DATA_ROOT"] = str(self._data_root)
         return payload
 
     def share_root_path(self) -> Path:
-        return self._share_root
+        return self._data_root
 
     def resolve_share_path(self, path: Any = None) -> Path:
         if path in (None, ""):
-            return self._share_root
+            return self._data_root
         candidate = Path(str(path)).expanduser()
         if candidate.is_absolute():
             return candidate.resolve(strict=False)
-        return (self._share_root / candidate).resolve(strict=False)
+        return (self._data_root / candidate).resolve(strict=False)
 
 
 def _app_args_env_for_cluster(env: Any, cluster_params: dict[str, Any]) -> Any:


### PR DESCRIPTION
## Summary

- Mount remote worker `AGI_CLUSTER_SHARE` at the physical share root instead of the workflow/session subpath.
- Keep per-run workflow/session paths as active workflow data roots so relative app data still resolves under `<user>/<workflow>/<session>`.
- Keep `AGI_CLUSTER_SHARE` / `agi_share_path` as the physical cluster share while exposing `AGILAB_WORKFLOW_DATA_ROOT` for active data scoping.
- Route manager-side `AgiEnv.resolve_share_path()` and remote-worker bootstrap env persistence through `AGILAB_WORKFLOW_DATA_ROOT` for relative app data paths.
- Add regressions for remote mount root selection, remote env persistence, runtime env separation, and worker data path resolution.

## Repro

Cluster deployment with a worker data path like `clustershare/agi/workflows/session-123` could prepare SSHFS using that full path as both the scheduler source suffix and the worker mount target.

## Root Cause

`_prepare_remote_cluster_share` reused `_workers_data_path` as the worker-side `AGI_CLUSTER_SHARE` value and derived a scheduler subdirectory from it. Runtime state also rebound `env.AGI_CLUSTER_SHARE` to `workers_data_path`, making a workflow/session directory look like the physical cluster share root. The first separation pass exposed `AGILAB_WORKFLOW_DATA_ROOT` but did not yet route all manager and remote-worker relative data path consumers through it.

## Regression Test

- `test_prepare_remote_cluster_share_mounts_cluster_share_root_for_workflow_session` verifies the SSHFS source and target stay at `clustershare/<user>` and do not use the workflow/session suffix as the mount root while persisting the workflow data root separately.
- `test_prepare_remote_cluster_share_rejects_reverse_sshfs_loop_on_share_root` keeps the loop guard anchored on the share root.
- `test_initialize_runtime_state_sets_workflow_data_root_without_rebinding_cluster_share` verifies runtime state uses `AGILAB_WORKFLOW_DATA_ROOT` without changing `AGI_CLUSTER_SHARE`.
- `test_manager_data_dir_uses_active_workflow_data_root_not_cluster_share` verifies relative data paths still resolve under the workflow/session root.
- `test_share_root_resolution_and_mode_helpers` verifies `AgiEnv.resolve_share_path()` resolves relative paths under `AGILAB_WORKFLOW_DATA_ROOT` while preserving the physical `AGI_CLUSTER_SHARE`.
- `test_remote_env_update_command_preserves_other_env_keys` verifies remote bootstrap persists both `AGI_CLUSTER_SHARE` and `AGILAB_WORKFLOW_DATA_ROOT` without dropping unrelated env keys.

## Validation

Passed:

- `git diff --check`
- `uv --preview-features extra-build-dependencies run python -m py_compile src/agilab/pages/2_ORCHESTRATE.py`
- `uv --preview-features extra-build-dependencies run python -m py_compile src/agilab/core/agi-env/src/agi_env/runtime/agi_env.py src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_remote_support.py`
- `./dev test src/agilab/core/agi-env/test/test_agi_env.py src/agilab/core/test/test_agi_distributor_deployment_remote_support.py src/agilab/core/test/test_agi_distributor_runtime_misc_support.py src/agilab/core/test/test_base_worker_path_support.py`
- `./dev test src/agilab/core/test/test_agi_distributor_runtime_misc_support.py src/agilab/core/test/test_base_worker_path_support.py src/agilab/core/test/test_agi_distributor_deployment_remote_support.py`
- `./dev test src/agilab/core/test`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui` support chunk: `1422 passed, 3 skipped, 2 warnings`

Known local validation blockers not caused by this patch:

- `./dev test test/test_ui_pages.py` fails during collection because the default validation env lacks `streamlit`.
- `agi-gui` pipeline chunk fails on `test_flight_telemetry_project_runtime_args.py` because the installed local `polars` package is incomplete in this environment: `polars.DataFrame` is absent and `polars.__version__` is missing.

Raw pytest without the repo import wrapper also failed earlier with `ModuleNotFoundError: No module named 'agilab.core'`; rerunning through `./dev test` passed.

## Review Evidence

Reviewer P1 about manager and remote-worker workflow-root consumers was addressed in commit `49c4f85` by routing `AgiEnv.resolve_share_path()` through `AGILAB_WORKFLOW_DATA_ROOT` and persisting that env var in the remote bootstrap.

No sub-agent or separate model review was used.

## Agent Metadata

- Tokki version: `tokki 1.0.9`
- Agent/runtime: Codex, version unavailable
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used
