### PR TITLE
Sync public docs quality cleanup

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 276,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "52609faa4c13da8dd83400ceafdf9c1ba880b1b7de12045f2c459e1365130bde",
+  "source_digest_sha256": "7d5304938d47da49cc78410d76c48182b6b05ada3ed109d81d9c2a0f75bf4a6b",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "52609faa4c13da8dd83400ceafdf9c1ba880b1b7de12045f2c459e1365130bde"
+  "target_digest_sha256": "7d5304938d47da49cc78410d76c48182b6b05ada3ed109d81d9c2a0f75bf4a6b"
 }

--- a/docs/source/apps-pages-gallery.rst
+++ b/docs/source/apps-pages-gallery.rst
@@ -1,5 +1,5 @@
 Apps-pages gallery
-=================
+==================
 
 
 **app_ui**
@@ -68,4 +68,3 @@ Apps-pages gallery
 
 **view_training_analysis**
 | _static/apps-pages-gallery/view_training_analysis.svg
-

--- a/docs/source/compatibility-matrix.rst
+++ b/docs/source/compatibility-matrix.rst
@@ -158,7 +158,7 @@ README summary alone. For normal maintenance, use the compact checks first:
    uv --preview-features extra-build-dependencies run python tools/revision_traceability_report.py --compact
    uv --preview-features extra-build-dependencies run python tools/public_certification_profile_report.py --compact
    uv --preview-features extra-build-dependencies run python tools/hf_space_smoke.py --json
-   uv --preview-features extra-build-dependencies run python tools/agilab_web_robot.py --target-url https://jpmorard-agilab.hf.space
+   uv --preview-features extra-build-dependencies run python tools/agilab_web_robot.py --target-url https://huggingface.co/spaces/jpmorard/agilab
    uv --preview-features extra-build-dependencies run python tools/production_readiness_report.py --compact
    uv --preview-features extra-build-dependencies run python tools/supply_chain_attestation_report.py --compact
    uv --preview-features extra-build-dependencies run python tools/public_proof_scenarios.py --compact

--- a/docs/source/experiment-help.rst
+++ b/docs/source/experiment-help.rst
@@ -182,8 +182,8 @@ Use the smoke validator before a live two-node run:
 .. code-block:: bash
 
    uv --preview-features extra-build-dependencies run python tools/dag_distributed_stage_smoke.py \
-     --scheduler 192.168.20.111:8786 \
-     --workers '{"192.168.20.111": 1, "192.168.20.15": 1}' \
+     --scheduler <scheduler-host>:8786 \
+     --workers '{"<scheduler-host>": 1, "<worker-host>": 1}' \
      --workers-data-path clustershare/agi \
      --compact
 


### PR DESCRIPTION
## Summary

- Sync canonical docs cleanup from `jpmorard/thales_agilab` PR #94 into the public AGILAB docs mirror.
- Replace local LAN IPs in the distributed DAG smoke example with source-agnostic placeholders.
- Use the public Hugging Face Space page URL in the compatibility robot command instead of the runtime `hf.space` URL.
- Fix the Apps-pages gallery title underline and refresh `docs/.docs_source_mirror_stamp.json`.

Canonical source PR: https://github.com/jpmorard/thales_agilab/pull/94

## Validation

Passed:

- `git -C /Users/agi/PycharmProjects/thales_agilab diff --check`
- `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --apply --delete`
- `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp`
- `./dev scope`
- `git diff --check`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs`

Known local docs build warnings not caused by this docs cleanup:

- Sphinx autodoc warnings from the local incomplete `polars` environment where `polars.DataFrame` is unavailable.

## Review Evidence

No sub-agent or separate model review was used.

## Agent Metadata

- Tokki version: `tokki 1.0.9`
- Agent/runtime: Codex, version unavailable
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used
