### PR TITLE
Sync docs autodoc Polars mock

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 276,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "7d5304938d47da49cc78410d76c48182b6b05ada3ed109d81d9c2a0f75bf4a6b",
+  "source_digest_sha256": "d92a7a9a35377ad36a8369d08d4cd261f1779adb5ad4bfa49f950be39a9317f0",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "7d5304938d47da49cc78410d76c48182b6b05ada3ed109d81d9c2a0f75bf4a6b"
+  "target_digest_sha256": "d92a7a9a35377ad36a8369d08d4cd261f1779adb5ad4bfa49f950be39a9317f0"
 }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -285,6 +285,7 @@ suppress_warnings = [
 ]
 
 autodoc_mock_imports = [
+    "polars",
     # Prevent heavy optional deps from breaking the build when absent
     "psutil",
     "asyncssh",


### PR DESCRIPTION
## Summary

- Sync canonical docs config from `jpmorard/thales_agilab` PR #96.
- Mock `polars` during Sphinx autodoc so docs builds do not import a broken or incomplete local Polars wheel just to render worker API pages.
- Refresh `docs/.docs_source_mirror_stamp.json`.

Canonical source PR: https://github.com/jpmorard/thales_agilab/pull/96

## Validation

Passed:

- `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --apply --delete`
- `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp`
- `./dev scope`
- `git diff --check`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs`

Docs profile result: Sphinx build succeeded with no warnings.

## Review Evidence

No sub-agent or separate model review was used.

## Agent Metadata

- Tokki version: `tokki 1.0.9`
- Agent/runtime: Codex, version unavailable
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used
