### PR TITLE
Guard page-shot manifest portability

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 276,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "d92a7a9a35377ad36a8369d08d4cd261f1779adb5ad4bfa49f950be39a9317f0",
+  "source_digest_sha256": "33670b9d1845d19d933e8fb31ecbab497664892952db3f2e925b22afaa5e5ac9",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "d92a7a9a35377ad36a8369d08d4cd261f1779adb5ad4bfa49f950be39a9317f0"
+  "target_digest_sha256": "33670b9d1845d19d933e8fb31ecbab497664892952db3f2e925b22afaa5e5ac9"
 }

--- a/docs/source/_static/page-shots/screenshot_manifest.json
+++ b/docs/source/_static/page-shots/screenshot_manifest.json
@@ -1,7 +1,7 @@
 {
   "created_at": "2026-06-02T14:01:51Z",
   "kind": "agilab.screenshot_manifest",
-  "root": "../thales_agilab/docs/source/_static/page-shots",
+  "root": "docs/source/_static/page-shots",
   "schema": "agilab.screenshot_manifest.v1",
   "schema_version": 1,
   "screenshots": [

--- a/test/test_screenshot_manifest.py
+++ b/test/test_screenshot_manifest.py
@@ -197,6 +197,8 @@ def test_screenshot_manifest_loader_reports_contract_errors(tmp_path: Path) -> N
 
 def test_docs_page_shot_svg_summaries_do_not_reintroduce_stale_sidebar_labels() -> None:
     manifest = json.loads((DOCS_PAGE_SHOTS / "screenshot_manifest.json").read_text(encoding="utf-8"))
+    assert manifest["root"] == "docs/source/_static/page-shots"
+    assert not manifest["root"].startswith("..")
     stale_sidebar_labels = ("Quick actions", "Reviewed")
 
     checked = []


### PR DESCRIPTION
## Summary
- sync the portable page-shot screenshot manifest from canonical docs
- add a regression guard so the tracked docs manifest cannot reintroduce a sibling checkout path

## Validation
- `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --apply --delete`
- `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp`
- `./dev test test/test_screenshot_manifest.py`
- `git diff --check`
- `git -C /Users/agi/PycharmProjects/thales_agilab diff --check`
- `./dev scope`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs`

## Agent Metadata
- Tokki version: tokki 1.0.9
- Agent/runtime: Codex CLI 0.142.0
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used
