### PR TITLE
Guard public docs contribution path wording

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 276,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "33670b9d1845d19d933e8fb31ecbab497664892952db3f2e925b22afaa5e5ac9",
+  "source_digest_sha256": "261c525c294e43cfbf6846b7f8f2165ee8fb3da7a82869087dc4e0d49266c2d5",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "33670b9d1845d19d933e8fb31ecbab497664892952db3f2e925b22afaa5e5ac9"
+  "target_digest_sha256": "261c525c294e43cfbf6846b7f8f2165ee8fb3da7a82869087dc4e0d49266c2d5"
 }

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -470,13 +470,17 @@ or publication contract is part of the change.
 Which docs repo should I edit?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Edit the canonical documentation source in the sibling documentation checkout:
-``../thales_agilab/docs/source`` relative to the AGILAB source checkout. The
-public Pages workflow publishes from the mirrored ``agilab/docs/source`` tree,
-so public docs changes need two steps:
+Public contributors can edit ``docs/source`` in the AGILAB checkout they cloned
+from GitHub. Maintainers who work with a separate canonical documentation
+checkout should edit that canonical source first, then sync the public mirror in
+``agilab/docs/source`` before opening or updating the public PR.
 
-1. edit the canonical source in the sibling documentation checkout
-2. sync the public mirror with ``tools/sync_docs_source.py``
+For maintainer mirror syncs, run:
+
+.. code-block:: bash
+
+   uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --apply --delete
+   uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp
 
 Do not edit ``docs/html``. It is generated output only.
 

--- a/test/test_audit_response_docs.py
+++ b/test/test_audit_response_docs.py
@@ -115,6 +115,16 @@ def test_environment_docs_scope_local_secret_persistence() -> None:
     assert "AGILAB_APPS_REPOSITORY_ALLOWLIST" in environment
 
 
+def test_faq_separates_public_and_maintainer_docs_paths() -> None:
+    faq = (DOCS_SOURCE / "faq.rst").read_text(encoding="utf-8")
+
+    assert "Public contributors can edit ``docs/source``" in faq
+    assert "Maintainers who work with a separate canonical documentation" in faq
+    assert "tools/sync_docs_source.py --apply --delete" in faq
+    assert "tools/sync_docs_source.py --verify-stamp" in faq
+    assert "../thales_agilab/docs/source" not in faq
+
+
 def test_security_policy_addresses_public_audit_adoption_boundaries() -> None:
     security = Path("SECURITY.md").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- sync FAQ wording that separates public contributor docs edits from maintainer mirror syncs
- add a regression guard for the public FAQ wording
- keep the public docs free of the private/canonical sibling checkout path

## Validation
- `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --apply --delete`
- `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp`
- `./dev test test/test_audit_response_docs.py`
- `git diff --check`
- `git -C /Users/agi/PycharmProjects/thales_agilab diff --check`
- fail-on-match grep for local checkout paths in docs source
- `./dev scope`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs`

## Agent Metadata
- Tokki version: tokki 1.0.9
- Agent/runtime: Codex CLI 0.142.0
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used
