### PR TITLE
Guard Hugging Face runtime URL docs

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 276,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "261c525c294e43cfbf6846b7f8f2165ee8fb3da7a82869087dc4e0d49266c2d5",
+  "source_digest_sha256": "b621157f587d6c0ba45930f96810875a913fe0b9e621a8b260382a4302e68a61",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "261c525c294e43cfbf6846b7f8f2165ee8fb3da7a82869087dc4e0d49266c2d5"
+  "target_digest_sha256": "b621157f587d6c0ba45930f96810875a913fe0b9e621a8b260382a4302e68a61"
 }

--- a/docs/source/apps-pages.rst
+++ b/docs/source/apps-pages.rst
@@ -85,6 +85,12 @@ hosted demo or future UI adapters.
    url = "https://jpmorard-agilab.hf.space/?active_app=pytorch_playground_project"
    capabilities = ["hosted-demo", "live-training"]
 
+Use the ``*.hf.space`` runtime URL for app-surface backends because it opens
+the running Space directly and preserves the ``active_app`` route. Use the
+Hugging Face project page, for example
+``https://huggingface.co/spaces/jpmorard/agilab``, for public badges,
+release-proof links, and documentation entry points.
+
 The generic launcher is::
 
    agilab app surface pytorch_playground_project --ui streamlit

--- a/test/test_audit_response_docs.py
+++ b/test/test_audit_response_docs.py
@@ -125,6 +125,15 @@ def test_faq_separates_public_and_maintainer_docs_paths() -> None:
     assert "../thales_agilab/docs/source" not in faq
 
 
+def test_apps_pages_explains_huggingface_runtime_url_role() -> None:
+    docs = (DOCS_SOURCE / "apps-pages.rst").read_text(encoding="utf-8")
+
+    assert "Use the ``*.hf.space`` runtime URL for app-surface backends" in docs
+    assert "preserves the ``active_app`` route" in docs
+    assert "https://huggingface.co/spaces/jpmorard/agilab" in docs
+    assert "release-proof links, and documentation entry points" in docs
+
+
 def test_security_policy_addresses_public_audit_adoption_boundaries() -> None:
     security = Path("SECURITY.md").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- sync the apps-pages explanation for Hugging Face runtime URLs
- add a regression guard that keeps runtime URL and project-page roles documented

## Validation
- `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --apply --delete`
- `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp`
- `./dev test test/test_audit_response_docs.py`
- `git diff --check`
- `git -C /Users/agi/PycharmProjects/thales_agilab diff --check`
- `./dev scope`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs`

## Notes
- `test/test_apps_pages_docs.py` currently has unrelated local failures, so the new docs guard was placed in the public-doc assertions file instead of broadening this PR into that stale test repair.

## Agent Metadata
- Tokki version: tokki 1.0.9
- Agent/runtime: Codex CLI 0.142.0
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used
