### PR TITLE
Repair apps-pages docs contract tests

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 276,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "b621157f587d6c0ba45930f96810875a913fe0b9e621a8b260382a4302e68a61",
+  "source_digest_sha256": "18ca320627e8d9a1b218aefe2a63c0be0f238b36a1e633293696084fd6c3df1f",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "b621157f587d6c0ba45930f96810875a913fe0b9e621a8b260382a4302e68a61"
+  "target_digest_sha256": "18ca320627e8d9a1b218aefe2a63c0be0f238b36a1e633293696084fd6c3df1f"
 }

--- a/docs/source/apps-pages-gallery.rst
+++ b/docs/source/apps-pages-gallery.rst
@@ -9,6 +9,9 @@ Apps-pages gallery
 **autoencoder_latentspace**
 | _static/apps-pages-gallery/autoencoder_latentspace.svg
 
+Opt-in playground exception for TensorFlow/Keras latent projections; it trains
+a small autoencoder in-page and is not a generic app-agnostic sidecar.
+
 
 **view_barycentric**
 | _static/apps-pages-gallery/view_barycentric.svg

--- a/test/test_apps_pages_docs.py
+++ b/test/test_apps_pages_docs.py
@@ -119,7 +119,9 @@ def test_barycentric_dataframe_selector_avoids_session_state_double_init() -> No
 
     assert len(dataframe_selectboxes) == 1
     keywords = {keyword.arg: keyword for keyword in dataframe_selectboxes[0].keywords}
-    assert isinstance(keywords["key"].value, ast.Constant)
-    assert keywords["key"].value.value == "df_file"
+    key_value = keywords["key"].value
+    assert isinstance(key_value, ast.Name)
+    assert key_value.id == "DF_FILE_KEY"
+    assert 'DF_FILE_KEY = _vb_key("df_file")' in source
     assert "index" not in keywords
     assert "args" not in keywords


### PR DESCRIPTION
## Summary
- sync the apps-pages gallery opt-in boundary note from canonical docs
- repair stale apps-pages docs assertions for the autoencoder gallery and Barycentric `DF_FILE_KEY` widget key

## Validation
- `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --apply --delete`
- `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp`
- `./dev test test/test_apps_pages_docs.py`
- `git diff --check`
- `git -C /Users/agi/PycharmProjects/thales_agilab diff --check`
- `./dev scope`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs`

## Agent Metadata
- Tokki version: tokki 1.0.9
- Agent/runtime: Codex CLI 0.142.0
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used
