### PR TITLE
Centralize API key placeholder detection

### DIFF
--- a/src/agilab/about_page/layout.py
+++ b/src/agilab/about_page/layout.py
@@ -515,13 +515,11 @@ def display_landing_page(resources_path: Path) -> None:
 
 def clean_openai_key(key: str | None) -> str | None:
     """Return None for missing/placeholder keys to avoid confusing 401s."""
-    if not key:
+    from agilab.security.api_keys import looks_placeholder_secret
+
+    if looks_placeholder_secret(key):
         return None
-    trimmed = key.strip()
-    placeholders = {"your-key", "sk-your-key", "sk-XXXX"}
-    if trimmed in placeholders or len(trimmed) < 12:
-        return None
-    return trimmed
+    return key.strip()
 
 
 def openai_status_banner(env: Any, *, env_file_path: Path) -> None:

--- a/src/agilab/environment/environment_health.py
+++ b/src/agilab/environment/environment_health.py
@@ -278,21 +278,9 @@ def _mapping_value(envars: Mapping[str, Any], name: str) -> str:
 
 
 def _looks_placeholder_secret(value: str | None) -> bool:
-    if not value:
-        return True
-    cleaned = str(value).strip()
-    if not cleaned:
-        return True
-    upper_value = cleaned.upper()
-    if cleaned in {"EMPTY", "None", "none", "null", "NULL"}:
-        return True
-    if "***" in cleaned or "..." in cleaned:
-        return True
-    if "YOUR-API-KEY" in upper_value or "YOUR_API_KEY" in upper_value:
-        return True
-    if cleaned in {"your-key", "sk-your-key", "sk-XXXX"}:
-        return True
-    return len(cleaned) < 12
+    from agilab.security.api_keys import looks_placeholder_secret
+
+    return looks_placeholder_secret(value)
 
 
 def _api_key_card(env: Any) -> tuple[EnvironmentHealthCard, tuple[str, str]]:

--- a/src/agilab/pipeline/pipeline_openai.py
+++ b/src/agilab/pipeline/pipeline_openai.py
@@ -13,22 +13,9 @@ _ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 def is_placeholder_api_key(key: Optional[str]) -> bool:
     """True only when clearly missing or visibly redacted."""
-    if not key:
-        return True
-    value = str(key).strip()
-    if not value:
-        return True
+    from agilab.security.api_keys import looks_placeholder_secret
 
-    upper_value = value.upper()
-    if "***" in value or "…" in value:
-        return True
-    if "YOUR-API-KEY" in upper_value or "YOUR_API_KEY" in upper_value:
-        return True
-    if value in {"your-key", "sk-your-key", "sk-XXXX"}:
-        return True
-    if len(value) < 12:
-        return True
-    return False
+    return looks_placeholder_secret(key)
 
 
 def _dotenv_quote(value: str) -> str:

--- a/src/agilab/security/api_keys.py
+++ b/src/agilab/security/api_keys.py
@@ -1,0 +1,32 @@
+"""Helpers for classifying API-key placeholder values."""
+
+from __future__ import annotations
+
+
+_PLACEHOLDER_LITERALS = {
+    "EMPTY",
+    "None",
+    "none",
+    "null",
+    "NULL",
+    "your-key",
+    "sk-your-key",
+    "sk-XXXX",
+}
+
+
+def looks_placeholder_secret(value: object | None, *, min_length: int = 12) -> bool:
+    """Return true for missing, redacted, example, or visibly invalid secrets."""
+    if value is None:
+        return True
+    cleaned = str(value).strip()
+    if not cleaned:
+        return True
+    upper_value = cleaned.upper()
+    if cleaned in _PLACEHOLDER_LITERALS:
+        return True
+    if "***" in cleaned or "..." in cleaned or "…" in cleaned:
+        return True
+    if "YOUR-API-KEY" in upper_value or "YOUR_API_KEY" in upper_value:
+        return True
+    return len(cleaned) < min_length

--- a/test/test_about_agilab_helpers.py
+++ b/test/test_about_agilab_helpers.py
@@ -3565,6 +3565,8 @@ def test_about_layout_rejects_placeholder_openai_keys():
     assert layout.clean_openai_key("") is None
     assert layout.clean_openai_key(" your-key ") is None
     assert layout.clean_openai_key("sk-XXXX") is None
+    assert layout.clean_openai_key("***") is None
+    assert layout.clean_openai_key("YOUR_API_KEY") is None
     assert layout.clean_openai_key("short") is None
     assert layout.clean_openai_key(" sk-" + "a" * 16 + " ") == "sk-" + "a" * 16
 

--- a/test/test_environment_health.py
+++ b/test/test_environment_health.py
@@ -356,6 +356,7 @@ def test_environment_health_remaining_helper_edges(tmp_path, monkeypatch):
     assert environment_health._looks_placeholder_secret("***") is True
     assert environment_health._looks_placeholder_secret("YOUR_API_KEY") is True
     assert environment_health._looks_placeholder_secret("sk-XXXX") is True
+    assert environment_health._looks_placeholder_secret("…") is True
 
     card, detail = environment_health._api_key_card(
         SimpleNamespace(

--- a/test/test_pipeline_openai.py
+++ b/test/test_pipeline_openai.py
@@ -127,6 +127,8 @@ def test_make_openai_client_and_model_prefers_azure(monkeypatch):
 
 def test_is_placeholder_api_key_catches_redacted_forms():
     assert pipeline_openai.is_placeholder_api_key("***redacted***") is True
+    assert pipeline_openai.is_placeholder_api_key("None") is True
+    assert pipeline_openai.is_placeholder_api_key("...") is True
     assert pipeline_openai.is_placeholder_api_key("sk-realistic-key-123456") is False
 
 


### PR DESCRIPTION
## Summary
- add a shared `agilab.security.api_keys.looks_placeholder_secret` helper
- route pipeline OpenAI setup, environment health, and About-page key cleanup through the shared classifier
- extend focused regressions for placeholder/redacted key variants

## Validation
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files src/agilab/security/api_keys.py src/agilab/pipeline/pipeline_openai.py src/agilab/environment/environment_health.py src/agilab/about_page/layout.py test/test_pipeline_openai.py test/test_environment_health.py test/test_about_agilab_helpers.py`
- `uv --preview-features extra-build-dependencies run --extra ui pytest -q -o addopts='' test/test_environment_health.py test/test_pipeline_openai.py test/test_pipeline_openai_compatible.py test/test_about_agilab_helpers.py`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --staged`
- `./dev scope --staged`
- `git diff --cached --check`

## Security Notes
- This only broadens placeholder/redacted-secret rejection and does not log, persist, or expose secret values.
- The shared helper lives under `agilab.security` to avoid importing UI or pipeline modules across trust boundaries.

## Agent Metadata
- Tokki version: `tokki 1.0.9`
- Agent/runtime: Codex CLI / GPT-5 Codex
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used
