### PR TITLE
Prepare AGILAB 2026.06.23 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,21 @@ cleanup, but retired GitHub release pages are not advertised as live evidence.
 
 ## Unreleased
 
+## [2026.06.23] - 2026-06-23
+
+### Changed
+
+- Prepared AGILAB `2026.06.23` package metadata and internal dependency pins
+  for the post-`2026.06.20` release queue.
+- Hardened worker cluster share-root handling so workflow data paths resolve
+  under the per-run session root instead of the parent cluster share.
+- Improved public documentation quality around generated docs, contribution
+  boundaries, Hugging Face runtime URLs, page-shot manifest portability, and
+  apps-pages gallery/test contracts.
+- Centralized API-key placeholder detection across OpenAI pipeline setup,
+  environment health, and About-page key cleanup so visibly redacted or example
+  secrets are rejected consistently.
+
 ## [2026.06.20] - 2026-06-20
 
 GitHub Release: https://github.com/ThalesGroup/agilab/releases/tag/v2026.06.20

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.20"
+version = "2026.06.23"
 name = "agilab"
 description = "AGILAB is a reproducible AI/ML workbench for engineering teams."
 requires-python = ">=3.11,<3.14"
@@ -60,14 +60,14 @@ agilab-mcp = "agilab_mcp.server:main"
 
 [project.optional-dependencies]
 ai = ["openai>=2.32.0,<3"]
-core = ["agi-core==2026.06.20"]
-ui = ["agi-apps==2026.06.20", "agi-pages==2026.06.20", "agi-gui==2026.06.20", "agi-web==2026.6.20", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "plotly>=6.7.0,<7", "sqlalchemy>=2.0.43,<3", "streamlit>=1.57,<1.59", "starlette>=1.0.1,<2", "tomli_w>=1.2.0,<2", "cryptography>=48.0.1,<50"]
+core = ["agi-core==2026.06.23"]
+ui = ["agi-apps==2026.06.23", "agi-pages==2026.06.23", "agi-gui==2026.06.23", "agi-web==2026.06.23", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "plotly>=6.7.0,<7", "sqlalchemy>=2.0.43,<3", "streamlit>=1.57,<1.59", "starlette>=1.0.1,<2", "tomli_w>=1.2.0,<2", "cryptography>=48.0.1,<50"]
 viz = ["matplotlib>=3.10.0,<4", "plotly>=6.7.0,<7"]
 mlflow = ["mlflow>=3.11.1,<4", "idna>=3.15,<4", "starlette>=1.0.1,<2"]
 bridges = ["duckdb>=1.4.0,<2"]
 notebook = ["ipykernel>=6.29.0,<8", "nbclient>=0.10.0,<1", "nbformat>=5.10.0,<6"]
-examples = ["agi-apps==2026.06.20", "jupyterlab>=4.4.0,<5", "matplotlib>=3.10.0,<4", "plotly>=6.7.0,<7", "starlette>=1.0.1,<2", "bleach>=6.4.0,<7"]
-pages = ["agi-pages==2026.06.20", "plotly>=6.7.0,<7", "sqlalchemy>=2.0.43,<3", "starlette>=1.0.1,<2"]
+examples = ["agi-apps==2026.06.23", "jupyterlab>=4.4.0,<5", "matplotlib>=3.10.0,<4", "plotly>=6.7.0,<7", "starlette>=1.0.1,<2", "bleach>=6.4.0,<7"]
+pages = ["agi-pages==2026.06.23", "plotly>=6.7.0,<7", "sqlalchemy>=2.0.43,<3", "starlette>=1.0.1,<2"]
 proof = ["cryptography>=48.0.1,<50"]
 agents = ["openai>=2.32.0,<3"]
 local-llm = ["accelerate>=0.34.2,<2; python_version >= '3.12'", "fastapi>=0.124.4,!=0.136.3,<1; python_version >= '3.12'", "gpt-oss>=0.0.8,<0.1; python_version >= '3.12'", "langchain-core>=1.3.3,<2; python_version >= '3.12'", "langsmith>=0.8.0,<1; python_version >= '3.12'", "mlx>=0.31.2,<0.32; sys_platform == 'darwin' and platform_machine == 'arm64'", "mlx-lm>=0.31.3,<0.32; sys_platform == 'darwin' and platform_machine == 'arm64'", "mlx-vlm>=0.5.0,<0.7; sys_platform == 'darwin' and platform_machine == 'arm64'", "requests>=2.32.0,<3; python_version >= '3.12'", "starlette>=1.3.1,<2; python_version >= '3.12'", "torch>=2.8.0,<3; python_version >= '3.12'", "transformers>=4.57.0,<6; python_version >= '3.12'", "universal-offline-ai-chatbot>=0.1.0,<0.2; python_version >= '3.12'", "langchain>=1.3.9,<2; python_version >= '3.12'", "pypdf>=6.13.0,<7; python_version >= '3.12'", "python-multipart>=0.0.31,<1; python_version >= '3.12'", "tornado>=6.5.7,<7; python_version >= '3.12'"]

--- a/src/agilab/apps-pages/app_ui/pyproject.toml
+++ b/src/agilab/apps-pages/app_ui/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-app-ui"
-version = "2026.06.20"
+version = "2026.06.23"
 description = "AGILAB page bundle for app-owned interactive Streamlit UIs."
 readme = { text = "AGILAB page bundle for app-owned interactive Streamlit UIs.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_barycentric/pyproject.toml
+++ b/src/agilab/apps-pages/view_barycentric/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-simplex-map"
-version = "2026.06.20"
+version = "2026.06.23"
 description = "AGILAB page bundle for simplex projection and barycentric analysis."
 readme = { text = "AGILAB page bundle for simplex projection and barycentric analysis.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_data_io_decision/pyproject.toml
+++ b/src/agilab/apps-pages/view_data_io_decision/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-decision-evidence"
-version = "2026.06.20"
+version = "2026.06.23"
 description = "AGILAB page bundle for decision evidence review."
 readme = { text = "AGILAB page bundle for decision evidence review.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_forecast_analysis/pyproject.toml
+++ b/src/agilab/apps-pages/view_forecast_analysis/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-timeseries-forecast"
-version = "2026.06.20"
+version = "2026.06.23"
 description = "AGILAB page bundle for time-series forecast review."
 readme = { text = "AGILAB page bundle for time-series forecast review.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_inference_analysis/pyproject.toml
+++ b/src/agilab/apps-pages/view_inference_analysis/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-inference-report"
-version = "2026.06.20"
+version = "2026.06.23"
 description = "AGILAB page bundle for inference result reporting."
 readme = { text = "AGILAB page bundle for inference result reporting.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_live_artifacts/pyproject.toml
+++ b/src/agilab/apps-pages/view_live_artifacts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-live-artifacts"
-version = "2026.06.20"
+version = "2026.06.23"
 description = "AGILAB page bundle for live artifact and evidence monitoring."
 readme = { text = "AGILAB page bundle for live artifact and evidence monitoring.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_maps/pyproject.toml
+++ b/src/agilab/apps-pages/view_maps/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-geospatial-map"
-version = "2026.06.20"
+version = "2026.06.23"
 description = "AGILAB page bundle for 2D geospatial map exploration."
 readme = { text = "AGILAB page bundle for 2D geospatial map exploration.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_maps_3d/pyproject.toml
+++ b/src/agilab/apps-pages/view_maps_3d/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-geospatial-3d"
-version = "2026.06.20"
+version = "2026.06.23"
 description = "AGILAB page bundle for 3D geospatial exploration."
 readme = { text = "AGILAB page bundle for 3D geospatial exploration.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_maps_network/pyproject.toml
+++ b/src/agilab/apps-pages/view_maps_network/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-network-map"
-version = "2026.06.20"
+version = "2026.06.23"
 description = "AGILAB page bundle for network-aware geospatial analysis."
 readme = { text = "AGILAB page bundle for network-aware geospatial analysis.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_queue_resilience/pyproject.toml
+++ b/src/agilab/apps-pages/view_queue_resilience/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-queue-health"
-version = "2026.06.20"
+version = "2026.06.23"
 description = "AGILAB page bundle for queue health and resilience evidence."
 readme = { text = "AGILAB page bundle for queue health and resilience evidence.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_relay_resilience/pyproject.toml
+++ b/src/agilab/apps-pages/view_relay_resilience/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-relay-health"
-version = "2026.06.20"
+version = "2026.06.23"
 description = "AGILAB page bundle for relay health and resilience evidence."
 readme = { text = "AGILAB page bundle for relay health and resilience evidence.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_release_decision/pyproject.toml
+++ b/src/agilab/apps-pages/view_release_decision/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-promotion-gate"
-version = "2026.06.20"
+version = "2026.06.23"
 description = "AGILAB page bundle for evidence-cockpit run review and promotion gates."
 readme = { text = "AGILAB page bundle for evidence-cockpit run review and promotion gates.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_routing_model_comparison/pyproject.toml
+++ b/src/agilab/apps-pages/view_routing_model_comparison/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-routing-model-comparison"
-version = "2026.06.20"
+version = "2026.06.23"
 description = "AGILAB page bundle for comparing routing model allocation decisions."
 readme = { text = "AGILAB page bundle for comparing routing model allocation decisions.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_scenario_cockpit/pyproject.toml
+++ b/src/agilab/apps-pages/view_scenario_cockpit/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-scenario-cockpit"
-version = "2026.06.20"
+version = "2026.06.23"
 description = "AGILAB page bundle for scenario evidence comparison."
 readme = { text = "AGILAB page bundle for scenario evidence comparison.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_shap_explanation/pyproject.toml
+++ b/src/agilab/apps-pages/view_shap_explanation/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-feature-attribution"
-version = "2026.06.20"
+version = "2026.06.23"
 description = "AGILAB page bundle for feature-attribution evidence."
 readme = { text = "AGILAB page bundle for feature-attribution evidence.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/apps-pages/view_training_analysis/pyproject.toml
+++ b/src/agilab/apps-pages/view_training_analysis/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-training-report"
-version = "2026.06.20"
+version = "2026.06.23"
 description = "AGILAB page bundle for training run reporting."
 readme = { text = "AGILAB page bundle for training run reporting.", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/agilab/core/agi-cluster/pyproject.toml
+++ b/src/agilab/core/agi-cluster/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.20"
+version = "2026.06.23"
 name = "agi-cluster"
 description = "Distributed cluster orchestration layer for AGILAB workers over local and SSH backends"
 requires-python = ">=3.11"
@@ -35,7 +35,7 @@ keywords = [
     "job-scheduling",
     "mlops",
 ]
-dependencies = ["agi-env==2026.06.20", "agi-node==2026.06.20", "asyncssh>=2.23,<3", "dask[distributed]>=2026.3,<2027.0", "humanize>=4.10,<5", "numpy>=2.2,<3", "packaging>=25,<27", "polars>=1.35,<2", "psutil>=7,<8", "scikit-learn>=1.7.2,<2", "tomlkit>=0.13,<1"]
+dependencies = ["agi-env==2026.06.23", "agi-node==2026.06.23", "asyncssh>=2.23,<3", "dask[distributed]>=2026.3,<2027.0", "humanize>=4.10,<5", "numpy>=2.2,<3", "packaging>=25,<27", "polars>=1.35,<2", "psutil>=7,<8", "scikit-learn>=1.7.2,<2", "tomlkit>=0.13,<1"]
 
 [project.entry-points."agi_env.runtime_packages"]
 agi-cluster = "agi_cluster.agi_env_runtime:RUNTIME_PACKAGE_SPEC"

--- a/src/agilab/core/agi-core/pyproject.toml
+++ b/src/agilab/core/agi-core/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.20"
+version = "2026.06.23"
 name = "agi-core"
 description = "Meta-package that installs and wires agi-env, agi-node, and agi-cluster together"
 readme = "README.md"
@@ -30,7 +30,7 @@ keywords = [
   "distributed-computing",
   "distributed-execution",
 ]
-dependencies = ["agi-env==2026.06.20", "agi-node==2026.06.20", "agi-cluster==2026.06.20"]
+dependencies = ["agi-env==2026.06.23", "agi-node==2026.06.23", "agi-cluster==2026.06.23"]
 
 [project.entry-points."agi_env.runtime_packages"]
 agi-core = "agi_core.agi_env_runtime:RUNTIME_PACKAGE_SPEC"

--- a/src/agilab/core/agi-env/pyproject.toml
+++ b/src/agilab/core/agi-env/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.20"
+version = "2026.06.23"
 name = "agi-env"
 description = "Environment bootstrap package for AGILAB with virtualenv, path, and runtime helpers"
 requires-python = ">=3.11"

--- a/src/agilab/core/agi-node/pyproject.toml
+++ b/src/agilab/core/agi-node/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.20"
+version = "2026.06.23"
 name = "agi-node"
 description = "Distributed worker orchestration and execution support library for AGILAB"
 requires-python = ">=3.11"
@@ -35,7 +35,7 @@ keywords = [
     "pandas",
     "polars",
 ]
-dependencies = ["agi-env==2026.06.20", "cython>=3.1,<4", "humanize>=4.10,<5", "numpy>=2.2,<3", "pandas>=2.3,<4", "parso>=0.8,<1", "polars>=1.35,<2", "psutil>=7,<8", "py7zr>=1.1,<1.2", "setuptools>=68,<83"]
+dependencies = ["agi-env==2026.06.23", "cython>=3.1,<4", "humanize>=4.10,<5", "numpy>=2.2,<3", "pandas>=2.3,<4", "parso>=0.8,<1", "polars>=1.35,<2", "psutil>=7,<8", "py7zr>=1.1,<1.2", "setuptools>=68,<83"]
 
 [project.entry-points."agi_env.runtime_packages"]
 agi-node = "agi_node.agi_env_runtime:RUNTIME_PACKAGE_SPEC"

--- a/src/agilab/lib/agi-app-data-quality-gate/pyproject.toml
+++ b/src/agilab/lib/agi-app-data-quality-gate/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.20"
+version = "2026.06.23"
 name = "agi-app-data-quality-gate"
 description = "AGILAB deterministic data contract, drift, leakage, and promotion gate"
 requires-python = ">=3.11"

--- a/src/agilab/lib/agi-app-flight-telemetry/pyproject.toml
+++ b/src/agilab/lib/agi-app-flight-telemetry/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.20"
+version = "2026.06.23"
 name = "agi-app-flight-telemetry"
 description = "AGILAB flight-telemetry ingestion demo with reusable dataframe and map-analysis outputs"
 requires-python = ">=3.11"

--- a/src/agilab/lib/agi-app-mission-decision/pyproject.toml
+++ b/src/agilab/lib/agi-app-mission-decision/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.20"
+version = "2026.06.23"
 name = "agi-app-mission-decision"
 description = "Deterministic AGILAB mission-decision workflow with scenario scoring and evidence artifacts"
 requires-python = ">=3.11"

--- a/src/agilab/lib/agi-app-multi-dag/pyproject.toml
+++ b/src/agilab/lib/agi-app-multi-dag/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.20"
+version = "2026.06.23"
 name = "agi-app-multi-dag"
 description = "AGILAB cross-app DAG preview showing artifact handoffs between demo projects"
 requires-python = ">=3.11"

--- a/src/agilab/lib/agi-app-pandas-execution/pyproject.toml
+++ b/src/agilab/lib/agi-app-pandas-execution/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.20"
+version = "2026.06.23"
 name = "agi-app-pandas-execution"
 description = "AGILAB Pandas execution benchmark for deterministic worker and reducer validation"
 requires-python = ">=3.11"

--- a/src/agilab/lib/agi-app-polars-execution/pyproject.toml
+++ b/src/agilab/lib/agi-app-polars-execution/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.20"
+version = "2026.06.23"
 name = "agi-app-polars-execution"
 description = "AGILAB Polars execution benchmark for deterministic worker and reducer validation"
 requires-python = ">=3.11"

--- a/src/agilab/lib/agi-app-pytorch-playground/pyproject.toml
+++ b/src/agilab/lib/agi-app-pytorch-playground/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.20"
+version = "2026.06.23"
 name = "agi-app-pytorch-playground"
 description = "AGILAB PyTorch playground app for reproducible neural-network experiments"
 requires-python = ">=3.12"

--- a/src/agilab/lib/agi-app-sklearn-pipeline/pyproject.toml
+++ b/src/agilab/lib/agi-app-sklearn-pipeline/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.20"
+version = "2026.06.23"
 name = "agi-app-sklearn-pipeline"
 description = "AGILAB scikit-learn pipeline app with model, metrics, predictions, and evidence manifest"
 requires-python = ">=3.11"

--- a/src/agilab/lib/agi-app-tescia-diagnostic/pyproject.toml
+++ b/src/agilab/lib/agi-app-tescia-diagnostic/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.20"
+version = "2026.06.23"
 name = "agi-app-tescia-diagnostic"
 description = "AGILAB TeSciA-style diagnostic workflow with evidence scoring and regression-plan artifacts"
 requires-python = ">=3.13"

--- a/src/agilab/lib/agi-app-uav-queue/pyproject.toml
+++ b/src/agilab/lib/agi-app-uav-queue/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.20"
+version = "2026.06.23"
 name = "agi-app-uav-queue"
 description = "AGILAB UAV queue simulation demo with scenario evidence and network-map artifacts"
 requires-python = ">=3.13"

--- a/src/agilab/lib/agi-app-uav-relay-queue/pyproject.toml
+++ b/src/agilab/lib/agi-app-uav-relay-queue/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.20"
+version = "2026.06.23"
 name = "agi-app-uav-relay-queue"
 description = "AGILAB UAV relay queue simulation demo with routing, delay, and resilience artifacts"
 requires-python = ">=3.13"

--- a/src/agilab/lib/agi-app-weather-forecast/pyproject.toml
+++ b/src/agilab/lib/agi-app-weather-forecast/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.20"
+version = "2026.06.23"
 name = "agi-app-weather-forecast"
 description = "AGILAB weather-forecast notebook-migration demo with forecast analysis artifacts"
 requires-python = ">=3.11"

--- a/src/agilab/lib/agi-apps/pyproject.toml
+++ b/src/agilab/lib/agi-apps/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.20"
+version = "2026.06.23"
 name = "agi-apps"
 description = "AGILAB public app package umbrella and example assets"
 requires-python = ">=3.11"
@@ -31,7 +31,7 @@ keywords = [
     "workflow-orchestration",
 ]
 
-dependencies = ["agi-core==2026.06.20", "agi-app-mission-decision==2026.06.20", "agi-app-pandas-execution==2026.06.20", "agi-app-polars-execution==2026.06.20", "agi-app-flight-telemetry==2026.06.20", "agi-app-multi-dag==2026.06.20", "agi-app-weather-forecast==2026.06.20", "agi-app-sklearn-pipeline==2026.06.20", "agi-app-pytorch-playground==2026.06.20; python_version >= '3.12'", "agi-app-tescia-diagnostic==2026.06.20; python_version >= '3.13'", "agi-app-uav-relay-queue==2026.06.20; python_version >= '3.13'"]
+dependencies = ["agi-core==2026.06.23", "agi-app-mission-decision==2026.06.23", "agi-app-pandas-execution==2026.06.23", "agi-app-polars-execution==2026.06.23", "agi-app-flight-telemetry==2026.06.23", "agi-app-multi-dag==2026.06.23", "agi-app-weather-forecast==2026.06.23", "agi-app-sklearn-pipeline==2026.06.23", "agi-app-pytorch-playground==2026.06.23; python_version >= '3.12'", "agi-app-tescia-diagnostic==2026.06.23; python_version >= '3.13'", "agi-app-uav-relay-queue==2026.06.23; python_version >= '3.13'"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/lib/agi-gui/pyproject.toml
+++ b/src/agilab/lib/agi-gui/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.20"
+version = "2026.06.23"
 name = "agi-gui"
 description = "AGILAB Streamlit UI dependency bundle and compatibility imports"
 requires-python = ">=3.11"
@@ -32,7 +32,7 @@ keywords = [
     "python",
 ]
 
-dependencies = ["agi-env==2026.06.20", "streamlit>=1.57,<1.58", "starlette>=1.0.1,<2", "streamlit_code_editor>=0.1.22,<0.2", "watchdog>=6,<7"]
+dependencies = ["agi-env==2026.06.23", "streamlit>=1.57,<1.58", "starlette>=1.0.1,<2", "streamlit_code_editor>=0.1.22,<0.2", "watchdog>=6,<7"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/lib/agi-pages/pyproject.toml
+++ b/src/agilab/lib/agi-pages/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.20"
+version = "2026.06.23"
 name = "agi-pages"
 description = "AGILAB public analysis page umbrella and provider package"
 requires-python = ">=3.11"
@@ -34,7 +34,7 @@ keywords = [
     "page-bundles",
 ]
 
-dependencies = ["agi-gui==2026.06.20"]
+dependencies = ["agi-gui==2026.06.23"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/lib/agi-web/pyproject.toml
+++ b/src/agilab/lib/agi-web/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.20"
+version = "2026.06.23"
 name = "agi-web"
 description = "AGILAB portable web component contract with static Canvas2D/WebGL adapters for Streamlit and HTML"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- bump AGILAB package metadata and internal exact pins from `2026.06.20` to `2026.06.23`
- add a pre-publication changelog section for the post-`2026.06.20` release queue without claiming PyPI/GitHub publication
- keep release-proof and public badge evidence on `2026.06.20` until the release workflow publishes and refreshes public evidence

## Release Scope
- Impact base: `v2026.06.20`
- Package seeds: `agi-env`, `agi-node`, `agi-cluster`, `agilab`
- Publish closure: `agi-env`, `agi-gui`, `agi-pages`, `agi-node`, `agi-cluster`, `agi-core`, `agi-apps`, `agilab`
- PyPI preflight: 35 projects checked, 35 to publish, 0 blockers

## Validation
- `uv lock --check`
- `git diff --check`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --staged`
- `uv --preview-features extra-build-dependencies run python tools/release_plan.py --check-workflow .github/workflows/pypi-publish.yaml --impact-base-ref v2026.06.20 --skip-existing-pypi --format json --compact`
- `uv --preview-features extra-build-dependencies run python tools/pypi_release_version_policy.py --skip-existing-pypi --impact-base-ref v2026.06.20`
- `uv --preview-features extra-build-dependencies run python tools/pypi_project_preflight.py`
- `uv --preview-features extra-build-dependencies run python tools/pypi_trusted_publisher_contract.py --check-workflow .github/workflows/pypi-publish.yaml`
- `uv --preview-features extra-build-dependencies run python tools/app_contract_matrix.py --quiet`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile dependency-policy --profile shared-core-typing --profile docs`

## Known Release-Gate Note
- `./dev release` currently stops at the strict audit stage because this PR branch is intentionally ahead of `origin/main` by one release-prep commit.
- Rerun `./dev release` after merge on updated `main`; that is the clean-checkout gate before dispatching the PyPI release workflow.
- No PyPI publication, GitHub release tag, Hugging Face sync, or release-proof refresh was performed in this PR.

## Agent Metadata
- Tokki version: `tokki 1.0.9`
- Agent/runtime: Codex CLI / GPT-5 Codex
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used
