### PR TITLE
Harden CI provider and MCP read boundaries

### DIFF
--- a/src/agilab/ci/ci_provider_artifacts.py
+++ b/src/agilab/ci/ci_provider_artifacts.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import hashlib
+import ipaddress
 import json
 import os
 from collections.abc import Callable, Mapping, Sequence
@@ -30,6 +31,9 @@ GENERIC_PROVIDER = "generic_download"
 GITLAB_CI_PROVIDER = "gitlab_ci"
 DEFAULT_SOURCE_MACHINE = "github-actions"
 DEFAULT_USER_AGENT = "agilab-ci-provider-artifacts/1"
+DEFAULT_GITLAB_URL = "https://gitlab.com"
+DEFAULT_GITLAB_HOST = "gitlab.com"
+GITLAB_URL_ALLOWLIST_ENV = "AGILAB_GITLAB_URL_ALLOWLIST"
 REQUIRED_PAYLOAD_PATHS = {
     "run_manifest": ("run_manifest.json",),
     "kpi_evidence_bundle": ("kpi_evidence_bundle.json",),
@@ -271,6 +275,89 @@ def _gitlab_headers(token: str | None) -> dict[str, str]:
     return headers
 
 
+def _normalize_gitlab_host(value: str) -> str:
+    raw = value.strip()
+    parsed = parse.urlparse(raw if "://" in raw else f"//{raw}")
+    host = parsed.hostname or raw
+    return host.strip().strip("[]").rstrip(".").lower()
+
+
+def _split_gitlab_hosts(value: str | None) -> tuple[str, ...]:
+    if not value:
+        return ()
+    hosts = []
+    for item in value.split(","):
+        normalized = _normalize_gitlab_host(item)
+        if normalized:
+            hosts.append(normalized)
+    return tuple(hosts)
+
+
+def _configured_gitlab_allowed_hosts(
+    allowed_hosts: Sequence[str] = (),
+) -> set[str]:
+    hosts: set[str] = set()
+    for value in allowed_hosts:
+        hosts.update(_split_gitlab_hosts(value))
+    hosts.update(_split_gitlab_hosts(os.getenv(GITLAB_URL_ALLOWLIST_ENV)))
+    return hosts
+
+
+def _gitlab_literal_ip_is_sensitive(host: str) -> bool:
+    try:
+        address = ipaddress.ip_address(host)
+    except ValueError:
+        return False
+    return (
+        address.is_loopback
+        or address.is_link_local
+        or address.is_private
+        or address.is_multicast
+        or address.is_reserved
+        or address.is_unspecified
+    )
+
+
+def _gitlab_host_is_sensitive(host: str) -> bool:
+    return (
+        host == "localhost"
+        or host.endswith(".localhost")
+        or _gitlab_literal_ip_is_sensitive(host)
+    )
+
+
+def validate_gitlab_base_url(
+    gitlab_url: str = DEFAULT_GITLAB_URL,
+    *,
+    allowed_hosts: Sequence[str] = (),
+) -> str:
+    """Return a validated GitLab base URL before attaching PRIVATE-TOKEN."""
+
+    base_url = (gitlab_url or DEFAULT_GITLAB_URL).strip().rstrip("/")
+    parsed = parse.urlparse(base_url)
+    if parsed.scheme != "https":
+        raise ValueError("GitLab URL must use https before a token can be sent")
+    if not parsed.netloc or not parsed.hostname:
+        raise ValueError("GitLab URL must include a host")
+    if parsed.username or parsed.password:
+        raise ValueError("GitLab URL must not contain credentials")
+
+    host = _normalize_gitlab_host(parsed.hostname)
+    allowed = _configured_gitlab_allowed_hosts(allowed_hosts)
+    if host != DEFAULT_GITLAB_HOST and host not in allowed:
+        raise ValueError(
+            f"GitLab host is not allowlisted for token use: {host}. "
+            f"Use --allow-gitlab-host or {GITLAB_URL_ALLOWLIST_ENV} for "
+            "self-managed GitLab hosts."
+        )
+    if _gitlab_host_is_sensitive(host) and host not in allowed:
+        raise ValueError(
+            f"GitLab host is local, private, or metadata-like and must be "
+            f"explicitly allowlisted before token use: {host}"
+        )
+    return base_url
+
+
 def _read_json_url(url: str, *, token: str | None, urlopen: UrlOpen) -> dict[str, Any]:
     req = request.Request(url, headers=_github_headers(token))
     with urlopen(req) as response:
@@ -323,7 +410,8 @@ def list_gitlab_ci_artifacts(
     *,
     project: str,
     pipeline_id: str,
-    gitlab_url: str = "https://gitlab.com",
+    gitlab_url: str = DEFAULT_GITLAB_URL,
+    allowed_gitlab_hosts: Sequence[str] = (),
     token: str | None = None,
     urlopen: UrlOpen = request.urlopen,
 ) -> tuple[list[dict[str, Any]], int]:
@@ -333,7 +421,10 @@ def list_gitlab_ci_artifacts(
     query_count = 0
     page = 1
     encoded_project = parse.quote(project, safe="")
-    base_url = gitlab_url.rstrip("/")
+    base_url = validate_gitlab_base_url(
+        gitlab_url,
+        allowed_hosts=allowed_gitlab_hosts,
+    )
     while True:
         url = (
             f"{base_url}/api/v4/projects/{encoded_project}/pipelines/"
@@ -386,7 +477,8 @@ def download_gitlab_ci_artifacts(
     *,
     destination: Path,
     project: str,
-    gitlab_url: str = "https://gitlab.com",
+    gitlab_url: str = DEFAULT_GITLAB_URL,
+    allowed_gitlab_hosts: Sequence[str] = (),
     token: str | None = None,
     urlopen: UrlOpen = request.urlopen,
 ) -> tuple[list[Path], int]:
@@ -397,7 +489,10 @@ def download_gitlab_ci_artifacts(
     paths: list[Path] = []
     download_count = 0
     encoded_project = parse.quote(project, safe="")
-    base_url = gitlab_url.rstrip("/")
+    base_url = validate_gitlab_base_url(
+        gitlab_url,
+        allowed_hosts=allowed_gitlab_hosts,
+    )
     for artifact in artifacts:
         job_id = str(artifact.get("id", "") or "")
         if not job_id:
@@ -483,7 +578,8 @@ def build_gitlab_ci_artifact_index(
     *,
     project: str,
     pipeline_id: str,
-    gitlab_url: str = "https://gitlab.com",
+    gitlab_url: str = DEFAULT_GITLAB_URL,
+    allowed_gitlab_hosts: Sequence[str] = (),
     download_dir: Path | None = None,
     token: str | None = None,
     workflow: str = "",
@@ -494,10 +590,15 @@ def build_gitlab_ci_artifact_index(
 ) -> dict[str, Any]:
     """Query GitLab CI, download job artifacts, and build a harvest index."""
 
+    base_url = validate_gitlab_base_url(
+        gitlab_url,
+        allowed_hosts=allowed_gitlab_hosts,
+    )
     provider_artifacts, provider_query_count = list_gitlab_ci_artifacts(
         project=project,
         pipeline_id=pipeline_id,
-        gitlab_url=gitlab_url,
+        gitlab_url=base_url,
+        allowed_gitlab_hosts=allowed_gitlab_hosts,
         token=token,
         urlopen=urlopen,
     )
@@ -507,7 +608,8 @@ def build_gitlab_ci_artifact_index(
                 provider_artifacts,
                 destination=Path(tmp),
                 project=project,
-                gitlab_url=gitlab_url,
+                gitlab_url=base_url,
+                allowed_gitlab_hosts=allowed_gitlab_hosts,
                 token=token,
                 urlopen=urlopen,
             )
@@ -528,7 +630,8 @@ def build_gitlab_ci_artifact_index(
         provider_artifacts,
         destination=download_dir,
         project=project,
-        gitlab_url=gitlab_url,
+        gitlab_url=base_url,
+        allowed_gitlab_hosts=allowed_gitlab_hosts,
         token=token,
         urlopen=urlopen,
     )

--- a/src/agilab_mcp/manifest_tools.py
+++ b/src/agilab_mcp/manifest_tools.py
@@ -12,6 +12,7 @@ from agilab.secret_uri import redact_mapping
 
 
 _ALLOWED_ROOTS_ENV = "AGILAB_MCP_ALLOWED_ROOTS"
+_ALLOW_CWD_ENV = "AGILAB_MCP_ALLOW_CWD"
 _CONFIGURED_ROOT_ENV_NAMES = (
     "AGILAB_APPS_ROOT",
     "AGILAB_LOG_ROOT",
@@ -40,10 +41,16 @@ def _unique_roots(paths: list[Path]) -> tuple[Path, ...]:
     return tuple(roots)
 
 
+def _env_truthy(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
 def _configured_read_roots() -> tuple[Path, ...]:
     roots: list[Path] = []
     configured = os.environ.get(_ALLOWED_ROOTS_ENV, "")
-    roots.extend(Path(item) for item in configured.split(os.pathsep) if item)
+    explicit_roots = [Path(item) for item in configured.split(os.pathsep) if item]
+    if explicit_roots:
+        return _unique_roots(explicit_roots)
     for env_name in _CONFIGURED_ROOT_ENV_NAMES:
         env_value = os.environ.get(env_name)
         if env_value:
@@ -51,7 +58,8 @@ def _configured_read_roots() -> tuple[Path, ...]:
     repo_root = _repo_root()
     if repo_root is not None:
         roots.append(repo_root)
-    roots.append(Path.cwd())
+    if _env_truthy(_ALLOW_CWD_ENV):
+        roots.append(Path.cwd())
     home = Path.home()
     roots.extend((home / "log" / "agents", home / "log" / "execute"))
     return _unique_roots(roots)

--- a/test/test_audience_bridges.py
+++ b/test/test_audience_bridges.py
@@ -1230,6 +1230,29 @@ def test_manifest_tools_reject_paths_outside_allowed_roots(
         manifest_tools.agent_quickstart(capabilities_path=outside_manifest)
 
 
+def test_manifest_tools_do_not_allow_launch_cwd_by_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cwd = tmp_path / "operator-cwd"
+    cwd.mkdir()
+    manifest = cwd / "run_manifest.json"
+    manifest.write_text('{"status": "pass"}', encoding="utf-8")
+
+    monkeypatch.delenv("AGILAB_MCP_ALLOWED_ROOTS", raising=False)
+    monkeypatch.delenv("AGILAB_MCP_ALLOW_CWD", raising=False)
+    monkeypatch.delenv("AGILAB_APPS_ROOT", raising=False)
+    monkeypatch.delenv("AGILAB_LOG_ROOT", raising=False)
+    monkeypatch.delenv("AGILAB_AGENT_LOG_ROOT", raising=False)
+    monkeypatch.chdir(cwd)
+
+    with pytest.raises(ValueError, match="outside configured read roots"):
+        manifest_tools.read_manifest(manifest)
+
+    monkeypatch.setenv("AGILAB_MCP_ALLOW_CWD", "1")
+    payload = manifest_tools.read_manifest(manifest)
+    assert payload["manifest"]["status"] == "pass"
+
+
 def test_agent_quickstart_discovers_manifest_from_env(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/test/test_ci_provider_artifacts.py
+++ b/test/test_ci_provider_artifacts.py
@@ -381,6 +381,99 @@ def test_live_gitlab_ci_artifact_index_uses_api_downloads(tmp_path: Path) -> Non
     assert index["summary"]["missing_required_count"] == 3
 
 
+@pytest.mark.parametrize(
+    "gitlab_url",
+    [
+        "http://gitlab.com",
+        "https://attacker.example",
+        "https://localhost",
+        "https://127.0.0.1",
+        "https://169.254.169.254",
+    ],
+)
+def test_live_gitlab_rejects_untrusted_base_urls_before_token_use(
+    tmp_path: Path, gitlab_url: str
+) -> None:
+    requests: list[object] = []
+
+    def fake_urlopen(req: object) -> object:
+        requests.append(req)
+        raise AssertionError("urlopen must not run for untrusted GitLab URLs")
+
+    with pytest.raises(ValueError, match="GitLab"):
+        build_gitlab_ci_artifact_index(
+            project="thales/agilab",
+            pipeline_id="987654321",
+            gitlab_url=gitlab_url,
+            download_dir=tmp_path / "downloads",
+            token="secret-token",
+            urlopen=fake_urlopen,
+        )
+
+    assert requests == []
+
+
+def test_live_gitlab_allows_explicit_enterprise_host(tmp_path: Path) -> None:
+    archive_bytes = io.BytesIO()
+    with ZipFile(archive_bytes, "w") as archive:
+        archive.writestr(
+            "ci/source-checkout-first-proof/run_manifest.json",
+            json.dumps(_sample_payload("run_manifest"), sort_keys=True),
+        )
+    archive_payload = archive_bytes.getvalue()
+    requested_urls: list[str] = []
+    token_headers: list[str | None] = []
+
+    class _Response:
+        def __init__(self, payload: bytes) -> None:
+            self.payload = payload
+
+        def __enter__(self) -> "_Response":
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return self.payload
+
+    def fake_urlopen(req: object) -> _Response:
+        headers = getattr(req, "headers", {})
+        token_headers.append(headers.get("Private-token") or headers.get("PRIVATE-TOKEN"))
+        url = str(getattr(req, "full_url"))
+        requested_urls.append(url)
+        if url.endswith("/pipelines/987654321/jobs?scope[]=success&per_page=100&page=1"):
+            return _Response(
+                json.dumps(
+                    [
+                        {
+                            "id": 42,
+                            "name": "public-evidence",
+                            "artifacts_file": {"filename": "public-evidence.zip"},
+                        }
+                    ]
+                ).encode("utf-8")
+            )
+        return _Response(archive_payload)
+
+    index = build_gitlab_ci_artifact_index(
+        project="thales/agilab",
+        pipeline_id="987654321",
+        gitlab_url="https://gitlab.enterprise.example",
+        allowed_gitlab_hosts=("gitlab.enterprise.example",),
+        download_dir=tmp_path / "downloads",
+        token="secret-token",
+        urlopen=fake_urlopen,
+    )
+
+    assert requested_urls == [
+        "https://gitlab.enterprise.example/api/v4/projects/thales%2Fagilab/pipelines/987654321/jobs?scope[]=success&per_page=100&page=1",
+        "https://gitlab.enterprise.example/api/v4/projects/thales%2Fagilab/jobs/42/artifacts",
+    ]
+    assert token_headers == ["secret-token", "secret-token"]
+    assert index["provider"] == "gitlab_ci"
+
+
 def test_provider_archive_edge_cases_cover_validation_and_duplicates(tmp_path: Path) -> None:
     bad_archive = tmp_path / "bad-json.zip"
     with ZipFile(bad_archive, "w") as archive:

--- a/tools/ci_provider_artifact_index.py
+++ b/tools/ci_provider_artifact_index.py
@@ -86,6 +86,17 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--pipeline-id", default="", help="GitLab CI pipeline id.")
     parser.add_argument("--gitlab-url", default="https://gitlab.com")
     parser.add_argument(
+        "--allow-gitlab-host",
+        action="append",
+        default=[],
+        metavar="HOST",
+        help=(
+            "Allow a self-managed GitLab host for token-bearing live queries. "
+            "Can be passed multiple times; AGILAB_GITLAB_URL_ALLOWLIST also "
+            "accepts comma-separated hosts."
+        ),
+    )
+    parser.add_argument(
         "--download-dir",
         type=Path,
         default=None,
@@ -137,6 +148,7 @@ def _build_index(args: argparse.Namespace) -> dict[str, object]:
             project=args.project,
             pipeline_id=args.pipeline_id,
             gitlab_url=args.gitlab_url,
+            allowed_gitlab_hosts=tuple(args.allow_gitlab_host or ()),
             download_dir=args.download_dir,
             token=token_from_env(args.token_env),
             workflow=args.workflow,


### PR DESCRIPTION
## Summary
- Validate live GitLab base URLs before any token-bearing request is created.
- Require `https://gitlab.com` by default, with explicit self-managed host allowlisting through `--allow-gitlab-host` or `AGILAB_GITLAB_URL_ALLOWLIST`.
- Stop treating MCP launch `cwd` as an implicit read root; `AGILAB_MCP_ALLOWED_ROOTS` is now an explicit override, and cwd access requires `AGILAB_MCP_ALLOW_CWD=1`.

## Repro
- Audit finding: `tools/ci_provider_artifact_index.py --live-gitlab --gitlab-url <operator-url>` could forward `GITLAB_TOKEN` to a non-GitLab or local URL.
- Audit finding: MCP read-only tools allowed JSON reads under the process launch cwd even when that cwd was unrelated to AGILAB evidence roots.

## Root Cause
- The GitLab live artifact path accepted arbitrary base URLs and attached `PRIVATE-TOKEN` headers without scheme/host containment.
- MCP read-root configuration always appended `Path.cwd()`, making launch location part of the trust boundary by default.

## Regression Test
- Added unsafe GitLab URL regressions for `http://gitlab.com`, attacker host, localhost, loopback, and metadata/link-local IP before token use.
- Added explicit enterprise GitLab allowlist coverage.
- Added MCP regression proving cwd reads fail by default and only work when `AGILAB_MCP_ALLOW_CWD=1` is set.

## Validation
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --staged`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_ci_provider_artifacts.py test/test_audience_bridges.py`
- `./dev scope --staged`
- `git diff --check --cached`
- Pre-push guard passed/skipped unrelated scopes as expected.

## Review Evidence
- Codex audit finding addressed: GitLab live provider token exfiltration risk.
- Codex audit finding addressed: MCP cwd-root overexposure risk.
- Local main checkout pollution was not deleted in this PR; this branch was built in a clean task worktree to keep the code fix isolated.

## Agent Metadata
- Tokki version: `tokki 1.0.10`
- Agent/runtime: Codex CLI, version unavailable
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used
