### PR TITLE
Improve built-in app example quality plans

### DIFF
--- a/src/agilab/apps/builtin/data_quality_gate_project/README.md
+++ b/src/agilab/apps/builtin/data_quality_gate_project/README.md
@@ -80,6 +80,12 @@ After the default run works, change only one thing:
 Keep `seed=2026` for synthetic comparisons so artifact deltas remain easy to
 explain.
 
+## Example Quality Plan
+
+- Review artifact: Review `quality_gate_report.json` first; it is the teaching artifact that explains why a dataset is allowed, warned, or blocked before model work starts.
+- Practice change: Change one threshold or one missing-value count in the seeded input and confirm the gate moves from pass to warn or fail with an actionable reason.
+- Quality check: A mature run leaves a stable gate report, a concise summary, and no hidden dependency on private data or external services.
+
 ## Troubleshooting
 
 If custom CSV inputs fail, first run the defaults again to confirm the app and

--- a/src/agilab/apps/builtin/execution_pandas_project/README.md
+++ b/src/agilab/apps/builtin/execution_pandas_project/README.md
@@ -45,6 +45,12 @@ executor to `thread` for a bounded pool-mode benchmark. The output row counts
 should stay stable while the runtime, kernel metadata, and execution-model label
 change.
 
+## Example Quality Plan
+
+- Review artifact: Review the generated CSV partitions and reducer summary together so the input shape and aggregated pandas result are both visible.
+- Practice change: Change the row count or partition size, then confirm the reducer still reports deterministic totals and partition metadata.
+- Quality check: A mature run proves local-first tabular execution, deterministic artifacts, and a clear pandas baseline for comparison.
+
 ## Troubleshooting
 
 If `INSTALL` fails, rerun the app-local install from `ORCHESTRATE` before

--- a/src/agilab/apps/builtin/execution_polars_project/README.md
+++ b/src/agilab/apps/builtin/execution_polars_project/README.md
@@ -41,6 +41,12 @@ After the default run works, change only the partition count. The same logical
 workload should produce a different distribution shape while keeping reducer
 totals stable.
 
+## Example Quality Plan
+
+- Review artifact: Review the same partition and reducer artifacts used by the pandas example so the engine comparison stays fair.
+- Practice change: Change the workload size while keeping the schema fixed, then compare the polars output contract with the pandas project.
+- Quality check: A mature run proves the engine swap changes implementation, not the public artifact shape or learner instructions.
+
 ## Troubleshooting
 
 If polars cannot be imported, run `INSTALL` again for this app instead of using

--- a/src/agilab/apps/builtin/flight_telemetry_project/README.md
+++ b/src/agilab/apps/builtin/flight_telemetry_project/README.md
@@ -49,6 +49,12 @@ one route-centroid marker per aircraft on top of the trajectory points.
 After the default run works, change only the file glob or one input sample. The
 analysis views should update while the reducer contract remains the same.
 
+## Example Quality Plan
+
+- Review artifact: Review the flight trajectory outputs, map-ready artifacts, and notebook import views as one evidence chain.
+- Practice change: Change one vehicle, time window, or anomaly filter and confirm the trajectory and map views still line up.
+- Quality check: A mature run teaches data ingestion, geospatial review, and notebook handoff without requiring private telemetry feeds.
+
 ## Troubleshooting
 
 If `ANALYSIS` shows no map data, confirm that `EXECUTE` produced dataframe

--- a/src/agilab/apps/builtin/minimal_app_project/README.md
+++ b/src/agilab/apps/builtin/minimal_app_project/README.md
@@ -37,6 +37,12 @@ contract. It is intentionally small.
 Copy the project, rename the manager and worker modules, and add one real input
 field before changing the execution contract.
 
+## Example Quality Plan
+
+- Review artifact: Review the manager, worker, settings seed, and output artifact as the smallest complete AGILAB app contract.
+- Practice change: Change one argument default in the form or settings seed and confirm the worker output reflects only that change.
+- Quality check: A mature run remains the copy/paste reference for new app authors: small, deterministic, and easy to diff.
+
 ## Troubleshooting
 
 If a copied app does not appear in `PROJECT`, check the project suffix, root

--- a/src/agilab/apps/builtin/mission_decision_project/README.md
+++ b/src/agilab/apps/builtin/mission_decision_project/README.md
@@ -44,6 +44,12 @@ After the default run works, adjust one route constraint or event severity. The
 selected strategy and decision deltas should change without introducing
 nondeterministic inputs.
 
+## Example Quality Plan
+
+- Review artifact: Review the decision evidence, candidate route summary, and failure-event context before looking at UI charts.
+- Practice change: Change one constraint or failure event and confirm the recommended route and explanation move together.
+- Quality check: A mature run shows decision support as replayable evidence, not as an opaque score or dashboard-only result.
+
 ## Troubleshooting
 
 If the analysis page is empty, confirm the mirrored `data_io_decision` bundle

--- a/src/agilab/apps/builtin/multi_app_dag_project/README.md
+++ b/src/agilab/apps/builtin/multi_app_dag_project/README.md
@@ -40,6 +40,12 @@ After the default preview works, edit a copy of the DAG template and change one
 artifact handoff. The preview should make the affected downstream stage blocked
 or runnable based on that contract.
 
+## Example Quality Plan
+
+- Review artifact: Review `lab_stages.toml` and the DAG template before execution so the handoff contract is explicit.
+- Practice change: Change one upstream artifact name or stage edge and confirm validation catches the mismatch before runtime.
+- Quality check: A mature run teaches inter-app composition through declared artifacts, not through hidden path conventions.
+
 ## Troubleshooting
 
 If the preview cannot find built-in apps, run AGILAB once from the source or

--- a/src/agilab/apps/builtin/pytorch_playground_project/README.md
+++ b/src/agilab/apps/builtin/pytorch_playground_project/README.md
@@ -110,6 +110,12 @@ After the default run works, change only one learning control:
 The decision boundary and evidence manifest should update while the artifact
 names stay stable.
 
+## Example Quality Plan
+
+- Review artifact: Review the exported training metrics, decision-boundary snapshot, and replay metadata after using the controls.
+- Practice change: Change one model or dataset parameter and confirm the visible boundary and saved metrics explain the same run.
+- Quality check: A mature run keeps interactivity tied to reproducible artifacts so the playground remains inspectable after the session.
+
 ## Troubleshooting
 
 If PyTorch is unavailable, the app returns displayable `missing_torch` evidence

--- a/src/agilab/apps/builtin/r_runtime_bridge_project/README.md
+++ b/src/agilab/apps/builtin/r_runtime_bridge_project/README.md
@@ -40,6 +40,12 @@ After the default run works, change only the numeric vector in the input JSON.
 The output mean and standard deviation should change while the manifest schema
 stays stable.
 
+## Example Quality Plan
+
+- Review artifact: Review the R stage inputs, outputs, and AGILAB manifest together so the language boundary is explicit.
+- Practice change: Change one R-owned parameter while keeping the AGILAB stage contract fixed and confirm the artifacts still validate.
+- Quality check: A mature run proves existing R logic can stay app-owned while AGILAB owns orchestration and evidence.
+
 ## Troubleshooting
 
 If the run reports missing `Rscript`, install R or put `Rscript` on `PATH`. If

--- a/src/agilab/apps/builtin/sklearn_pipeline_project/README.md
+++ b/src/agilab/apps/builtin/sklearn_pipeline_project/README.md
@@ -40,6 +40,12 @@ The worker writes `metrics.json`, `predictions.csv`, `model.joblib`,
 After the default run works, change only `regularization_c` or `sample_count`.
 Keep `seed=2026` so differences remain easy to explain.
 
+## Example Quality Plan
+
+- Review artifact: Review the model metrics, feature summary, and pipeline view before treating the trained model as useful.
+- Practice change: Change one estimator parameter or split seed and confirm the metrics and saved model metadata change coherently.
+- Quality check: A mature run teaches a familiar scikit-learn workflow with persisted inputs, outputs, and reproducible review points.
+
 ## Troubleshooting
 
 If model artifacts are missing, confirm `RUN` completed after `INSTALL`. If

--- a/src/agilab/apps/builtin/tescia_diagnostic_project/README.md
+++ b/src/agilab/apps/builtin/tescia_diagnostic_project/README.md
@@ -57,6 +57,12 @@ change one `student_answer`, or add one diagnostic case with a weaker proposed
 fix. The feedback should identify missing evidence, wrong fix choice, or
 missing discriminator regression tests.
 
+## Example Quality Plan
+
+- Review artifact: Review the structured diagnostic report first: symptoms, assumptions, root cause, fix, and regression evidence.
+- Practice change: Change one symptom or log fragment and confirm the diagnosis updates without losing the required evidence fields.
+- Quality check: A mature run turns support reasoning into auditable artifacts instead of a free-form chat transcript.
+
 ## Troubleshooting
 
 If generated cases fail validation, inspect the schema error and rerun with the

--- a/src/agilab/apps/builtin/uav_queue_project/README.md
+++ b/src/agilab/apps/builtin/uav_queue_project/README.md
@@ -40,6 +40,12 @@ After the default run works, change only `routing_policy` from `shortest_path`
 to `queue_aware`. Queue hotspots and drops should change while output schemas
 stay stable.
 
+## Example Quality Plan
+
+- Review artifact: Review queue-health, topology, routing, and trajectory artifacts as a single scenario evidence bundle.
+- Practice change: Change one seeded incident or queue pressure value and confirm the routing and health outputs explain the impact.
+- Quality check: A mature run teaches resilience analysis with deterministic scenario inputs and reviewable operational outputs.
+
 ## Troubleshooting
 
 If analysis pages are empty, confirm the queue analysis bundle exists under the

--- a/src/agilab/apps/builtin/uav_relay_queue_project/README.md
+++ b/src/agilab/apps/builtin/uav_relay_queue_project/README.md
@@ -40,6 +40,12 @@ After the default run works, adjust one relay capacity or routing policy. Delay,
 drops, or relay choice should change while the topology artifacts remain
 readable by `view_maps_network`.
 
+## Example Quality Plan
+
+- Review artifact: Review relay choice, congestion, delay, and drop metrics together before comparing policies.
+- Practice change: Change one relay capacity or packet rate and confirm the selected relay and queue metrics move together.
+- Quality check: A mature run makes policy tradeoffs visible through artifacts instead of only through final route labels.
+
 ## Troubleshooting
 
 If relay views show no data, confirm `EXECUTE` completed and exported queue

--- a/src/agilab/apps/builtin/weather_forecast_legacy_project/README.md
+++ b/src/agilab/apps/builtin/weather_forecast_legacy_project/README.md
@@ -41,6 +41,12 @@ After the default run works, replace only the weather CSV with a larger local
 snapshot that preserves the expected columns. Metrics and predictions should
 update while the analysis pages still load.
 
+## Example Quality Plan
+
+- Review artifact: Review the legacy notebook import views and forecast artifacts to see what was preserved during migration.
+- Practice change: Change one forecast horizon or input slice and confirm the legacy-shaped outputs still map to AGILAB evidence.
+- Quality check: A mature run teaches migration boundaries: preserve useful notebook behavior while making artifacts replayable.
+
 ## Troubleshooting
 
 If `skforecast` is missing, run the app in its own installed environment rather

--- a/src/agilab/apps/builtin/weather_forecast_project/README.md
+++ b/src/agilab/apps/builtin/weather_forecast_project/README.md
@@ -41,6 +41,12 @@ After the default run works, replace only the input weather CSV with a larger
 local snapshot that preserves the expected columns. Forecast metrics should
 change while artifact names remain stable.
 
+## Example Quality Plan
+
+- Review artifact: Review forecast artifacts, analysis views, and notebook import metadata as the main evidence chain.
+- Practice change: Change one city, horizon, or weather feature and confirm the forecast output and analysis view remain aligned.
+- Quality check: A mature run shows notebook-to-project packaging with deterministic public data, reviewable outputs, and safe adaptation.
+
 ## Troubleshooting
 
 If `skforecast` is missing, run `INSTALL` for this app and test from the app

--- a/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/README.md
+++ b/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/README.md
@@ -49,6 +49,12 @@ one route-centroid marker per aircraft on top of the trajectory points.
 After the default run works, change only the file glob or one input sample. The
 analysis views should update while the reducer contract remains the same.
 
+## Example Quality Plan
+
+- Review artifact: Review the flight trajectory outputs, map-ready artifacts, and notebook import views as one evidence chain.
+- Practice change: Change one vehicle, time window, or anomaly filter and confirm the trajectory and map views still line up.
+- Quality check: A mature run teaches data ingestion, geospatial review, and notebook handoff without requiring private telemetry feeds.
+
 ## Troubleshooting
 
 If `ANALYSIS` shows no map data, confirm that `EXECUTE` produced dataframe

--- a/src/agilab/lib/agi-app-mission-decision/src/agi_app_mission_decision/project/mission_decision_project/README.md
+++ b/src/agilab/lib/agi-app-mission-decision/src/agi_app_mission_decision/project/mission_decision_project/README.md
@@ -44,6 +44,12 @@ After the default run works, adjust one route constraint or event severity. The
 selected strategy and decision deltas should change without introducing
 nondeterministic inputs.
 
+## Example Quality Plan
+
+- Review artifact: Review the decision evidence, candidate route summary, and failure-event context before looking at UI charts.
+- Practice change: Change one constraint or failure event and confirm the recommended route and explanation move together.
+- Quality check: A mature run shows decision support as replayable evidence, not as an opaque score or dashboard-only result.
+
 ## Troubleshooting
 
 If the analysis page is empty, confirm the mirrored `data_io_decision` bundle

--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/README.md
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/README.md
@@ -110,6 +110,12 @@ After the default run works, change only one learning control:
 The decision boundary and evidence manifest should update while the artifact
 names stay stable.
 
+## Example Quality Plan
+
+- Review artifact: Review the exported training metrics, decision-boundary snapshot, and replay metadata after using the controls.
+- Practice change: Change one model or dataset parameter and confirm the visible boundary and saved metrics explain the same run.
+- Quality check: A mature run keeps interactivity tied to reproducible artifacts so the playground remains inspectable after the session.
+
 ## Troubleshooting
 
 If PyTorch is unavailable, the app returns displayable `missing_torch` evidence

--- a/src/agilab/lib/agi-app-uav-relay-queue/src/agi_app_uav_relay_queue/project/uav_relay_queue_project/README.md
+++ b/src/agilab/lib/agi-app-uav-relay-queue/src/agi_app_uav_relay_queue/project/uav_relay_queue_project/README.md
@@ -40,6 +40,12 @@ After the default run works, adjust one relay capacity or routing policy. Delay,
 drops, or relay choice should change while the topology artifacts remain
 readable by `view_maps_network`.
 
+## Example Quality Plan
+
+- Review artifact: Review relay choice, congestion, delay, and drop metrics together before comparing policies.
+- Practice change: Change one relay capacity or packet rate and confirm the selected relay and queue metrics move together.
+- Quality check: A mature run makes policy tradeoffs visible through artifacts instead of only through final route labels.
+
 ## Troubleshooting
 
 If relay views show no data, confirm `EXECUTE` completed and exported queue

--- a/src/agilab/lib/agi-app-weather-forecast/src/agi_app_weather_forecast/project/weather_forecast_project/README.md
+++ b/src/agilab/lib/agi-app-weather-forecast/src/agi_app_weather_forecast/project/weather_forecast_project/README.md
@@ -41,6 +41,12 @@ After the default run works, replace only the input weather CSV with a larger
 local snapshot that preserves the expected columns. Forecast metrics should
 change while artifact names remain stable.
 
+## Example Quality Plan
+
+- Review artifact: Review forecast artifacts, analysis views, and notebook import metadata as the main evidence chain.
+- Practice change: Change one city, horizon, or weather feature and confirm the forecast output and analysis view remain aligned.
+- Quality check: A mature run shows notebook-to-project packaging with deterministic public data, reviewable outputs, and safe adaptation.
+
 ## Troubleshooting
 
 If `skforecast` is missing, run `INSTALL` for this app and test from the app

--- a/test/test_app_installer_packaging.py
+++ b/test/test_app_installer_packaging.py
@@ -2001,3 +2001,12 @@ def test_example_notebooks_use_current_agi_run_request_api() -> None:
                     )
 
     assert not failures, "\n".join(failures)
+
+
+def test_builtin_app_readmes_include_example_quality_plan() -> None:
+    for readme in sorted(BUILTIN_APPS_ROOT.glob("*_project/README.md")):
+        text = readme.read_text(encoding="utf-8")
+        assert "## Example Quality Plan" in text, readme
+        assert "- Review artifact:" in text, readme
+        assert "- Practice change:" in text, readme
+        assert "- Quality check:" in text, readme


### PR DESCRIPTION
## Summary

Adds an `Example Quality Plan` section to every built-in app README so each packaged example now states:

- the review artifact a learner or maintainer should inspect
- one safe practice change to try
- the quality check that should move with that change

The change also syncs the existing checked-in package README payload mirrors for the promoted app packages and adds a packaging regression that requires all built-in app READMEs to keep the quality-plan markers.

## Per-app plan coverage

- `data_quality_gate_project`: review the quality-gate report, change threshold/missing-count settings, verify stable gate evidence.
- `execution_pandas_project`: review CSV partition/reducer artifacts, change row/partition size, verify deterministic pandas baseline output.
- `execution_polars_project`: review the matching Polars artifacts, change workload size, verify the same public artifact shape.
- `flight_telemetry_project`: review trajectory/map/notebook import artifacts, change vehicle/time/anomaly filters, verify aligned trajectory/map views.
- `minimal_app_project`: review manager/worker/settings/output, change one argument default, verify the minimal deterministic reference still works.
- `mission_decision_project`: review decision evidence/routes/failure context, change a constraint/failure event, verify recommendation and explanation move together.
- `multi_app_dag_project`: review `lab_stages.toml` and DAG templates, change one stage edge, verify validation catches mismatch.
- `pytorch_playground_project`: review training metrics/boundary/replay metadata, change model/dataset parameters, verify visible and saved evidence align.
- `r_runtime_bridge_project`: review R stage inputs/outputs/manifest, change one R parameter, verify the AGILAB stage contract stays fixed.
- `sklearn_pipeline_project`: review metrics/feature summary/pipeline view, change estimator or split seed, verify model metadata and metrics move coherently.
- `tescia_diagnostic_project`: review structured diagnostic reports, change symptom/log inputs, verify diagnosis updates while preserving schema fields.
- `uav_queue_project`: review queue/topology/routing/trajectory bundle, change incident or pressure settings, verify routing and health explain the impact.
- `uav_relay_queue_project`: review relay/congestion/delay/drop metrics, change relay capacity or packet rate, verify relay choice and metrics move together.
- `weather_forecast_legacy_project`: review legacy notebook import and forecast artifacts, change horizon/input slice, verify legacy-shaped outputs still map to evidence.
- `weather_forecast_project`: review forecast/analysis/notebook import metadata, change city/horizon/features, verify forecast and analysis remain aligned.

## Quality issue

The built-in app READMEs already had basic maturity sections, but they did not consistently tell maintainers and learners which artifact to inspect, what safe single change to try, and which quality signal should change as a result.

## Root cause

The example documentation contract checked for common README headings, but not for an explicit example-quality plan that ties evidence artifacts to safe adaptation and validation.

## Regression Test

Adds `test_builtin_app_readmes_include_example_quality_plan` in `test/test_app_installer_packaging.py` to require every built-in app README to include:

- `## Example Quality Plan`
- `- Review artifact:`
- `- Practice change:`
- `- Quality check:`

## Validation

Validation passed.

Local evidence:

- `./dev test test/test_app_installer_packaging.py`
- `./dev app-contracts`
- `git diff --check`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files $(git diff --name-only)`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui`
- `./dev scope --staged --max-scopes 30`

GitHub checks passed:

- GitGuardian Security Checks
- `clean-public-install` on macOS, Ubuntu, and Windows
- `local-only-policy`
- `windows-core-tests`

GitHub skipped by workflow policy:

- `public-demo-smoke`

Mixed-scope note: this intentionally spans all built-in app scopes because the requested change was a full built-in-app example-quality pass.

## Review Evidence

No sub-agent or separate reviewer model was used for this PR. The implementation was validated locally and by GitHub checks listed above.

## Agent Metadata

- Tokki version: `tokki 1.0.10`
- Agent/runtime: `codex-cli 0.142.0`
- Model: `GPT-5 Codex`
- Reasoning effort: `unknown`
- `/fast` mode: `not used`
