### PR TITLE
Fix data quality README artifact reference

### DIFF
--- a/src/agilab/apps/builtin/data_quality_gate_project/README.md
+++ b/src/agilab/apps/builtin/data_quality_gate_project/README.md
@@ -82,7 +82,7 @@ explain.
 
 ## Example Quality Plan
 
-- Review artifact: Review `quality_gate_report.json` first; it is the teaching artifact that explains why a dataset is allowed, warned, or blocked before model work starts.
+- Review artifact: Review `data_quality_report.md` and `gate_decision.json` first; they explain why a dataset is allowed, warned, or blocked before model work starts.
 - Practice change: Change one threshold or one missing-value count in the seeded input and confirm the gate moves from pass to warn or fail with an actionable reason.
 - Quality check: A mature run leaves a stable gate report, a concise summary, and no hidden dependency on private data or external services.
 

--- a/test/test_app_installer_packaging.py
+++ b/test/test_app_installer_packaging.py
@@ -2010,3 +2010,13 @@ def test_builtin_app_readmes_include_example_quality_plan() -> None:
         assert "- Review artifact:" in text, readme
         assert "- Practice change:" in text, readme
         assert "- Quality check:" in text, readme
+
+
+def test_data_quality_gate_readme_points_to_existing_quality_artifacts() -> None:
+    readme = BUILTIN_APPS_ROOT / "data_quality_gate_project" / "README.md"
+    text = readme.read_text(encoding="utf-8")
+
+    assert "quality_gate_report.json" not in text
+    assert "data_quality_report.md" in text
+    assert "gate_decision.json" in text
+    assert "decision_card.json" in text


### PR DESCRIPTION
## Summary

Fixes the data-quality built-in app README quality plan so it points to artifacts the app actually emits.

- Replaces the nonexistent `quality_gate_report.json` reference with `data_quality_report.md` and `gate_decision.json`.
- Adds a packaging regression that prevents `quality_gate_report.json` from returning to the data-quality README while requiring the real artifacts to stay documented.

## Repro

The review finding was reproduced by comparing the README with the app contract:

- `README.md` listed `quality_gate_report.json` in the new `Example Quality Plan`.
- The app writes and documents `data_quality_report.md`, `gate_decision.json`, and `decision_card.json`.
- `rg` found `quality_gate_report.json` only in the README sentence added by PR #685.

## Root Cause

The previous example-quality pass used a plausible artifact name that was not checked against the app's actual output contract.

## Regression Test

Adds `test_data_quality_gate_readme_points_to_existing_quality_artifacts` in `test/test_app_installer_packaging.py`.

The test asserts:

- `quality_gate_report.json` is absent from the README.
- `data_quality_report.md`, `gate_decision.json`, and `decision_card.json` remain documented.

## Validation

Validation passed.

Local evidence:

- `./dev test test/test_app_installer_packaging.py`
- `git diff --check`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files $(git diff --name-only)`
- `./dev scope --staged`

GitHub checks passed:

- GitGuardian Security Checks
- `clean-public-install` on macOS, Ubuntu, and Windows
- `local-only-policy`
- `windows-core-tests`

GitHub skipped by workflow policy:

- `public-demo-smoke`

## Review Evidence

Addresses reviewer finding:

- `[P2] Point data-quality readers to an existing artifact`

No sub-agent or separate reviewer model was used for this fix.

## Agent Metadata

- Tokki version: `tokki 1.0.10`
- Agent/runtime: `codex-cli 0.142.0`
- Model: `GPT-5 Codex`
- Reasoning effort: `unknown`
- `/fast` mode: `not used`
