### PR TITLE
Harden AGILAB audit readiness surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,26 @@ cleanup, but retired GitHub release pages are not advertised as live evidence.
 
 ## Unreleased
 
+### Security
+
+- Hardened data-connector live endpoint smoke checks so bearer-token probes
+  refuse unsafe schemes, metadata/loopback/private targets, and cross-origin
+  redirects before credentials are attached.
+
+### Changed
+
+- Centralized built-in worker artifact directory resolution through the shared
+  `agi-node` worker path contract so evidence exports honor explicit export
+  roots, runtime share resolvers, and active workflow data roots before local
+  fallback paths.
+- Tightened public README production-boundary wording around the stable
+  `agi-core` handoff surface.
+
+### Fixed
+
+- Corrected the data-quality built-in example README so it points readers to
+  emitted artifacts instead of a nonexistent quality-gate report file.
+
 ## [2026.06.23] - 2026-06-23
 
 GitHub Release: https://github.com/ThalesGroup/agilab/releases/tag/v2026.06.23

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ moving it into a heavier tracker, registry, cluster, or production platform.
 That means you do not lose your work if the AGILAB UI or distributed runtime is
 no longer the right interface.
 The stable core runtime remains the smallest supported handoff surface and is
-production-grade core technology.
+release-gated core runtime handoff technology.
 
 ## Agent Entry Point
 

--- a/README.pypi.md
+++ b/README.pypi.md
@@ -84,8 +84,8 @@ notebook / MLflow / UI handoff
 The flow is reversible where it matters for long-term reuse: WORKFLOW can
 export the saved pipeline as a runnable `agi-core` supervisor notebook, so the
 code, stage order, runtime hints, and review context remain usable through the
-stable, production-grade core technology if the AGILAB UI or distributed
-runtime is no longer the right interface for that work.
+stable, release-gated core runtime handoff technology if the AGILAB UI or
+distributed runtime is no longer the right interface for that work.
 Apps can also declare multiple UI surfaces, so the same runtime and evidence
 contract can be exposed through Streamlit, hosted Hugging Face, or
 browser-native `agi-web` UI islands with React-ready component contracts.

--- a/src/agilab/apps/builtin/data_quality_gate_project/src/data_quality_gate_worker/data_quality_gate_worker.py
+++ b/src/agilab/apps/builtin/data_quality_gate_project/src/data_quality_gate_worker/data_quality_gate_worker.py
@@ -11,7 +11,7 @@ from typing import Any
 
 import pandas as pd
 
-from agi_node.agi_dispatcher import BaseWorker
+from agi_node.agi_dispatcher import BaseWorker, base_worker_path_support as path_support
 from agi_node.pandas_worker import PandasWorker
 from data_quality_gate import (
     DataQualityGateArgs,
@@ -26,21 +26,11 @@ _runtime: dict[str, object] = {}
 
 
 def _artifact_dir(env: object, leaf: str) -> Path:
-    export_root = getattr(env, "AGILAB_EXPORT_ABS", None)
-    target = str(getattr(env, "target", "") or "")
-    relative = Path(target) / leaf if target else Path(leaf)
-    if export_root is not None:
-        return Path(export_root) / relative
-    resolve_share_path = getattr(env, "resolve_share_path", None)
-    if callable(resolve_share_path):
-        return Path(resolve_share_path(relative))
-    return Path.home() / "export" / relative
+    return path_support.resolve_artifact_dir(env, leaf, path_cls=Path, home_factory=Path.home)
 
 
 def _artifact_reset_root(env: object) -> Path:
-    export_root = Path(getattr(env, "AGILAB_EXPORT_ABS", Path.home() / "export"))
-    target = str(getattr(env, "target", "") or "")
-    return export_root / target if target else export_root
+    return path_support.resolve_artifact_dir(env, ".", path_cls=Path, home_factory=Path.home)
 
 
 def _args_with_defaults(value: Any) -> DataQualityGateArgs:

--- a/src/agilab/apps/builtin/mission_decision_project/src/mission_decision_worker/mission_decision_worker.py
+++ b/src/agilab/apps/builtin/mission_decision_project/src/mission_decision_worker/mission_decision_worker.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
-from agi_node.agi_dispatcher import BaseWorker
+from agi_node.agi_dispatcher import BaseWorker, base_worker_path_support as path_support
 from agi_node.pandas_worker import PandasWorker
 from mission_decision import MissionDecisionArgs
 from mission_decision.artifacts import build_decision_artifacts
@@ -23,15 +23,7 @@ _runtime: dict[str, object] = {}
 
 
 def _artifact_dir(env: object, leaf: str) -> Path:
-    export_root = getattr(env, "AGILAB_EXPORT_ABS", None)
-    target = str(getattr(env, "target", "") or "")
-    relative = Path(target) / leaf if target else Path(leaf)
-    if export_root is not None:
-        return Path(export_root) / relative
-    resolve_share_path = getattr(env, "resolve_share_path", None)
-    if callable(resolve_share_path):
-        return Path(resolve_share_path(relative))
-    return Path.home() / "export" / relative
+    return path_support.resolve_artifact_dir(env, leaf, path_cls=Path, home_factory=Path.home)
 
 
 def _sanitize_slug(value: str) -> str:

--- a/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground_worker/pytorch_playground_worker.py
+++ b/src/agilab/apps/builtin/pytorch_playground_project/src/pytorch_playground_worker/pytorch_playground_worker.py
@@ -12,7 +12,7 @@ from typing import Any
 
 import pandas as pd
 
-from agi_node.agi_dispatcher import BaseWorker
+from agi_node.agi_dispatcher import BaseWorker, base_worker_path_support as path_support
 from agi_node.pandas_worker import PandasWorker
 from pytorch_playground import PytorchPlaygroundArgs, to_playground_config
 from pytorch_playground.core import (
@@ -42,15 +42,7 @@ def _args_model() -> type[Any]:
 
 
 def _artifact_dir(env: object, leaf: str) -> Path:
-    export_root = getattr(env, "AGILAB_EXPORT_ABS", None)
-    target = str(getattr(env, "target", "") or "")
-    relative = Path(target) / leaf if target else Path(leaf)
-    if export_root is not None:
-        return Path(export_root) / relative
-    resolve_share_path = getattr(env, "resolve_share_path", None)
-    if callable(resolve_share_path):
-        return Path(resolve_share_path(relative))
-    return Path.home() / "export" / relative
+    return path_support.resolve_artifact_dir(env, leaf, path_cls=Path, home_factory=Path.home)
 
 
 def _args_with_defaults(value: Any) -> PytorchPlaygroundArgs:

--- a/src/agilab/apps/builtin/r_runtime_bridge_project/src/r_runtime_bridge_worker/r_runtime_bridge_worker.py
+++ b/src/agilab/apps/builtin/r_runtime_bridge_project/src/r_runtime_bridge_worker/r_runtime_bridge_worker.py
@@ -11,7 +11,7 @@ from typing import Any
 
 import pandas as pd
 
-from agi_node.agi_dispatcher import BaseWorker
+from agi_node.agi_dispatcher import BaseWorker, base_worker_path_support as path_support
 from agi_node.pandas_worker import PandasWorker
 from r_runtime_bridge import RRuntimeBridgeArgs, build_r_runtime_bridge_artifacts
 from r_runtime_bridge.reduction import write_reduce_artifact
@@ -21,15 +21,7 @@ _runtime: dict[str, object] = {}
 
 
 def _artifact_dir(env: object, leaf: str) -> Path:
-    export_root = getattr(env, "AGILAB_EXPORT_ABS", None)
-    target = str(getattr(env, "target", "") or "")
-    relative = Path(target) / leaf if target else Path(leaf)
-    if export_root is not None:
-        return Path(export_root) / relative
-    resolve_share_path = getattr(env, "resolve_share_path", None)
-    if callable(resolve_share_path):
-        return Path(resolve_share_path(relative))
-    return Path.home() / "export" / relative
+    return path_support.resolve_artifact_dir(env, leaf, path_cls=Path, home_factory=Path.home)
 
 
 def _args_with_defaults(value: Any) -> RRuntimeBridgeArgs:

--- a/src/agilab/apps/builtin/sklearn_pipeline_project/src/sklearn_pipeline_worker/sklearn_pipeline_worker.py
+++ b/src/agilab/apps/builtin/sklearn_pipeline_project/src/sklearn_pipeline_worker/sklearn_pipeline_worker.py
@@ -11,7 +11,7 @@ from typing import Any
 
 import pandas as pd
 
-from agi_node.agi_dispatcher import BaseWorker
+from agi_node.agi_dispatcher import BaseWorker, base_worker_path_support as path_support
 from agi_node.pandas_worker import PandasWorker
 from sklearn_pipeline import (
     SklearnPipelineArgs,
@@ -26,21 +26,11 @@ _runtime: dict[str, object] = {}
 
 
 def _artifact_dir(env: object, leaf: str) -> Path:
-    export_root = getattr(env, "AGILAB_EXPORT_ABS", None)
-    target = str(getattr(env, "target", "") or "")
-    relative = Path(target) / leaf if target else Path(leaf)
-    if export_root is not None:
-        return Path(export_root) / relative
-    resolve_share_path = getattr(env, "resolve_share_path", None)
-    if callable(resolve_share_path):
-        return Path(resolve_share_path(relative))
-    return Path.home() / "export" / relative
+    return path_support.resolve_artifact_dir(env, leaf, path_cls=Path, home_factory=Path.home)
 
 
 def _artifact_reset_root(env: object) -> Path:
-    export_root = Path(getattr(env, "AGILAB_EXPORT_ABS", Path.home() / "export"))
-    target = str(getattr(env, "target", "") or "")
-    return export_root / target if target else export_root
+    return path_support.resolve_artifact_dir(env, ".", path_cls=Path, home_factory=Path.home)
 
 
 def _args_with_defaults(value: Any) -> SklearnPipelineArgs:

--- a/src/agilab/apps/builtin/tescia_diagnostic_project/src/tescia_diagnostic_worker/tescia_diagnostic_worker.py
+++ b/src/agilab/apps/builtin/tescia_diagnostic_project/src/tescia_diagnostic_worker/tescia_diagnostic_worker.py
@@ -12,6 +12,7 @@ from typing import Any
 
 import pandas as pd
 
+from agi_node.agi_dispatcher import base_worker_path_support as path_support
 from agi_node.pandas_worker import PandasWorker
 from tescia_diagnostic.classroom import (
     CLASSROOM_SCHEMA,
@@ -29,15 +30,7 @@ _runtime: dict[str, object] = {}
 
 
 def _artifact_dir(env: object, leaf: str) -> Path:
-    export_root = getattr(env, "AGILAB_EXPORT_ABS", None)
-    target = str(getattr(env, "target", "") or "")
-    relative = Path(target) / leaf if target else Path(leaf)
-    if export_root is not None:
-        return Path(export_root) / relative
-    resolve_share_path = getattr(env, "resolve_share_path", None)
-    if callable(resolve_share_path):
-        return Path(resolve_share_path(relative))
-    return Path.home() / "export" / relative
+    return path_support.resolve_artifact_dir(env, leaf, path_cls=Path, home_factory=Path.home)
 
 
 def _sanitize_slug(value: str) -> str:

--- a/src/agilab/apps/builtin/uav_queue_project/src/uav_queue_worker/uav_queue_worker.py
+++ b/src/agilab/apps/builtin/uav_queue_project/src/uav_queue_worker/uav_queue_worker.py
@@ -18,7 +18,7 @@ import networkx as nx
 import pandas as pd
 import simpy
 
-from agi_node.agi_dispatcher import BaseWorker
+from agi_node.agi_dispatcher import BaseWorker, base_worker_path_support as path_support
 from agi_node.pandas_worker import PandasWorker
 from uav_queue.reduction import write_reduce_artifact
 
@@ -27,15 +27,7 @@ _runtime: dict[str, object] = {}
 
 
 def _artifact_dir(env: object, leaf: str) -> Path:
-    export_root = getattr(env, "AGILAB_EXPORT_ABS", None)
-    target = str(getattr(env, "target", "") or "")
-    relative = Path(target) / leaf if target else Path(leaf)
-    if export_root is not None:
-        return Path(export_root) / relative
-    resolve_share_path = getattr(env, "resolve_share_path", None)
-    if callable(resolve_share_path):
-        return Path(resolve_share_path(relative))
-    return Path.home() / "export" / relative
+    return path_support.resolve_artifact_dir(env, leaf, path_cls=Path, home_factory=Path.home)
 
 
 @dataclass(frozen=True)

--- a/src/agilab/apps/builtin/uav_relay_queue_project/src/uav_relay_queue_worker/uav_relay_queue_worker.py
+++ b/src/agilab/apps/builtin/uav_relay_queue_project/src/uav_relay_queue_worker/uav_relay_queue_worker.py
@@ -18,7 +18,7 @@ import networkx as nx
 import pandas as pd
 import simpy
 
-from agi_node.agi_dispatcher import BaseWorker
+from agi_node.agi_dispatcher import BaseWorker, base_worker_path_support as path_support
 from agi_node.pandas_worker import PandasWorker
 from uav_relay_queue.reduction import write_reduce_artifact
 
@@ -27,15 +27,7 @@ _runtime: dict[str, object] = {}
 
 
 def _artifact_dir(env: object, leaf: str) -> Path:
-    export_root = getattr(env, "AGILAB_EXPORT_ABS", None)
-    target = str(getattr(env, "target", "") or "")
-    relative = Path(target) / leaf if target else Path(leaf)
-    if export_root is not None:
-        return Path(export_root) / relative
-    resolve_share_path = getattr(env, "resolve_share_path", None)
-    if callable(resolve_share_path):
-        return Path(resolve_share_path(relative))
-    return Path.home() / "export" / relative
+    return path_support.resolve_artifact_dir(env, leaf, path_cls=Path, home_factory=Path.home)
 
 
 @dataclass(frozen=True)

--- a/src/agilab/apps/builtin/weather_forecast_legacy_project/src/weather_forecast_legacy_worker/weather_forecast_legacy_worker.py
+++ b/src/agilab/apps/builtin/weather_forecast_legacy_project/src/weather_forecast_legacy_worker/weather_forecast_legacy_worker.py
@@ -13,6 +13,7 @@ from sklearn.ensemble import RandomForestRegressor
 from skforecast.model_selection import TimeSeriesFold, backtesting_forecaster
 from skforecast.recursive import ForecasterRecursive
 
+from agi_node.agi_dispatcher import base_worker_path_support as path_support
 from agi_node.pandas_worker import PandasWorker
 from weather_forecast_legacy.reduction import write_reduce_artifact
 
@@ -21,15 +22,7 @@ _runtime: dict[str, object] = {}
 
 
 def _artifact_dir(env: object, leaf: str) -> Path:
-    export_root = getattr(env, "AGILAB_EXPORT_ABS", None)
-    target = str(getattr(env, "target", "") or "")
-    relative = Path(target) / leaf if target else Path(leaf)
-    if export_root is not None:
-        return Path(export_root) / relative
-    resolve_share_path = getattr(env, "resolve_share_path", None)
-    if callable(resolve_share_path):
-        return Path(resolve_share_path(relative))
-    return Path.home() / "export" / relative
+    return path_support.resolve_artifact_dir(env, leaf, path_cls=Path, home_factory=Path.home)
 
 
 class WeatherForecastLegacyWorker(PandasWorker):

--- a/src/agilab/apps/builtin/weather_forecast_project/src/weather_forecast_worker/weather_forecast_worker.py
+++ b/src/agilab/apps/builtin/weather_forecast_project/src/weather_forecast_worker/weather_forecast_worker.py
@@ -13,6 +13,7 @@ from sklearn.ensemble import RandomForestRegressor
 from skforecast.model_selection import TimeSeriesFold, backtesting_forecaster
 from skforecast.recursive import ForecasterRecursive
 
+from agi_node.agi_dispatcher import base_worker_path_support as path_support
 from agi_node.pandas_worker import PandasWorker
 from weather_forecast.reduction import write_reduce_artifact
 
@@ -21,15 +22,7 @@ _runtime: dict[str, object] = {}
 
 
 def _artifact_dir(env: object, leaf: str) -> Path:
-    export_root = getattr(env, "AGILAB_EXPORT_ABS", None)
-    target = str(getattr(env, "target", "") or "")
-    relative = Path(target) / leaf if target else Path(leaf)
-    if export_root is not None:
-        return Path(export_root) / relative
-    resolve_share_path = getattr(env, "resolve_share_path", None)
-    if callable(resolve_share_path):
-        return Path(resolve_share_path(relative))
-    return Path.home() / "export" / relative
+    return path_support.resolve_artifact_dir(env, leaf, path_cls=Path, home_factory=Path.home)
 
 
 class WeatherForecastWorker(PandasWorker):

--- a/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/base_worker_path_support.py
+++ b/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/base_worker_path_support.py
@@ -231,6 +231,88 @@ def resolve_data_dir(
         return path_cls(os.path.normpath(str(resolved)))
 
 
+def _env_value(env: Any | None, name: str) -> Any:
+    if env is None:
+        return None
+    value = getattr(env, name, None)
+    if value:
+        return value
+    envars = getattr(env, "envars", None)
+    if isinstance(envars, dict):
+        return envars.get(name)
+    return None
+
+
+def _target_relative_path(
+    target: str,
+    leaf: Path | str,
+    *,
+    path_cls: type[Path] = Path,
+) -> Path:
+    leaf_path = path_cls(leaf)
+    if leaf_path == path_cls("."):
+        return path_cls(target) if target else path_cls()
+    return path_cls(target) / leaf_path if target else leaf_path
+
+
+def resolve_artifact_dir(
+    env: Any | None,
+    leaf: Path | str,
+    *,
+    target: str | None = None,
+    path_cls: type[Path] = Path,
+    home_factory: Callable[[], Path] = Path.home,
+) -> Path:
+    """Resolve app evidence artifacts through the shared worker path contract.
+
+    Precedence is explicit export root, runtime share resolver, active workflow
+    share root, then an operator-local ``export`` directory. The final fallback
+    uses ``env.home_abs`` when available so polluted process ``HOME`` values do
+    not silently move evidence.
+    """
+
+    target_text = str(target if target is not None else _env_value(env, "target") or "")
+    relative = _target_relative_path(target_text, leaf, path_cls=path_cls)
+
+    export_root = _env_value(env, "AGILAB_EXPORT_ABS")
+    if export_root:
+        root = path_cls(export_root).expanduser()
+        return root / relative if relative != path_cls() else root
+
+    resolve_share_path = getattr(env, "resolve_share_path", None) if env is not None else None
+    if callable(resolve_share_path):
+        resolved = path_cls(resolve_share_path(relative)).expanduser()
+        return resolved.resolve(strict=False)
+
+    share_root = None
+    has_share_hint = any(
+        _env_value(env, name)
+        for name in (
+            "AGILAB_WORKFLOW_DATA_ROOT",
+            "agi_workflow_data_root",
+            "workflow_data_root",
+            "agi_share_path_abs",
+            "agi_share_path",
+        )
+    )
+    if has_share_hint:
+        share_root = share_root_path(env, path_cls=path_cls)
+    else:
+        share_root_method = getattr(env, "share_root_path", None) if env is not None else None
+        if callable(share_root_method):
+            try:
+                share_root = path_cls(share_root_method()).expanduser().resolve(strict=False)
+            except SHARE_ROOT_FALLBACK_EXCEPTIONS:
+                share_root = None
+    if share_root is not None:
+        root = path_cls(share_root).expanduser()
+        return (root / relative).resolve(strict=False) if relative != path_cls() else root.resolve(strict=False)
+
+    home = _env_value(env, "home_abs") or home_factory()
+    root = path_cls(home).expanduser() / "export"
+    return root / relative if relative != path_cls() else root
+
+
 def relative_to_user_home(path: Path, *, path_cls: type[Path] = Path) -> Path | None:
     parts = path.parts
     if len(parts) >= 3 and parts[1].lower() in {"users", "home"}:

--- a/src/agilab/core/test/test_base_worker_path_support.py
+++ b/src/agilab/core/test/test_base_worker_path_support.py
@@ -136,6 +136,67 @@ def test_manager_data_dir_uses_active_workflow_data_root_not_cluster_share(tmp_p
     assert path_support.share_root_path(env) == session_root.resolve(strict=False)
 
 
+def test_artifact_dir_prefers_export_root_then_share_resolver(tmp_path):
+    export_root = tmp_path / "explicit-export"
+    env = SimpleNamespace(
+        AGILAB_EXPORT_ABS=export_root,
+        target="demo_project",
+        resolve_share_path=lambda relative: tmp_path / "share" / relative,
+        home_abs=tmp_path / "home",
+        _is_managed_pc=False,
+    )
+
+    assert path_support.resolve_artifact_dir(env, "analysis") == export_root / "demo_project" / "analysis"
+
+    env.AGILAB_EXPORT_ABS = None
+    assert path_support.resolve_artifact_dir(env, "analysis") == (
+        tmp_path / "share" / "demo_project" / "analysis"
+    ).resolve(strict=False)
+
+
+def test_artifact_dir_uses_workflow_root_before_process_home(monkeypatch, tmp_path):
+    process_home = tmp_path / "polluted-home"
+    process_home.mkdir()
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: process_home))
+
+    workflow_root = tmp_path / "clustershare" / "workflow-a"
+    env = SimpleNamespace(
+        AGILAB_WORKFLOW_DATA_ROOT=workflow_root,
+        target="demo_project",
+        share_root_path=lambda: tmp_path / "legacy-share",
+        agi_share_path_abs=None,
+        agi_share_path=None,
+        home_abs=tmp_path / "env-home",
+        _is_managed_pc=False,
+    )
+
+    assert path_support.resolve_artifact_dir(env, "analysis") == (
+        workflow_root / "demo_project" / "analysis"
+    ).resolve(strict=False)
+
+
+def test_artifact_dir_local_fallback_uses_env_home_abs(monkeypatch, tmp_path):
+    process_home = tmp_path / "polluted-home"
+    env_home = tmp_path / "env-home"
+    process_home.mkdir()
+    env_home.mkdir()
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: process_home))
+
+    env = SimpleNamespace(
+        target="demo_project",
+        share_root_path=lambda: (_ for _ in ()).throw(OSError("no share")),
+        agi_share_path_abs=None,
+        agi_share_path=None,
+        home_abs=env_home,
+        _is_managed_pc=False,
+    )
+
+    assert path_support.resolve_artifact_dir(env, "analysis") == (
+        env_home / "export" / "demo_project" / "analysis"
+    )
+    assert path_support.resolve_artifact_dir(env, ".") == env_home / "export" / "demo_project"
+
+
 def test_base_worker_path_support_data_dir_aliases_and_home_remap(monkeypatch, tmp_path):
     class _BrokenPath:
         def __fspath__(self):

--- a/src/agilab/data_connectors/data_connector_live_endpoint_smoke.py
+++ b/src/agilab/data_connectors/data_connector_live_endpoint_smoke.py
@@ -11,6 +11,8 @@ from pathlib import Path
 import sqlite3
 from typing import Any, Mapping, Sequence
 from urllib import request
+from urllib.parse import urlparse
+import ipaddress
 
 from agilab.data_connectors.data_connector_cloud import object_storage_target
 from agilab.data_connectors.data_connector_facility import (
@@ -26,6 +28,11 @@ SCHEMA = "agilab.data_connector_live_endpoint_smoke.v1"
 DEFAULT_RUN_ID = "data-connector-live-endpoint-smoke-proof"
 CREATED_AT = "2026-04-25T00:00:34Z"
 UPDATED_AT = "2026-04-25T00:00:34Z"
+LOCAL_HTTP_OPT_IN_ENV = "AGILAB_CONNECTOR_LIVE_SMOKE_ALLOW_LOCAL_HTTP"
+BLOCKED_LINK_LOCAL_METADATA_IPS = {
+    ipaddress.ip_address("169.254.169.254"),
+    ipaddress.ip_address("fd00:ec2::254"),
+}
 
 
 def _connector_target(connector: Mapping[str, Any]) -> str:
@@ -72,8 +79,76 @@ def _probe_sqlite(uri: str) -> tuple[str, str]:
     return "healthy", "sqlite connectivity check passed"
 
 
-def _probe_opensearch(connector: Mapping[str, Any], token: str) -> tuple[str, str]:
+def _origin(url: str) -> tuple[str, str, int | None]:
+    parsed = urlparse(url)
+    return parsed.scheme.lower(), (parsed.hostname or "").lower(), parsed.port
+
+
+def _local_http_allowed() -> bool:
+    return os.getenv(LOCAL_HTTP_OPT_IN_ENV, "").strip().lower() in {"1", "true", "yes"}
+
+
+def _host_is_blocked(host: str, *, allow_local_http: bool) -> str:
+    if not host:
+        return "missing host"
+    lowered = host.lower().strip("[]")
+    if lowered == "localhost" or lowered.endswith(".localhost"):
+        return "" if allow_local_http else "localhost targets require local emulator opt-in"
+    try:
+        address = ipaddress.ip_address(lowered)
+    except ValueError:
+        return ""
+    if address in BLOCKED_LINK_LOCAL_METADATA_IPS:
+        return "metadata-service target is blocked"
+    if address.is_loopback:
+        return "" if allow_local_http else "loopback targets require local emulator opt-in"
+    if address.is_private or address.is_link_local or address.is_unspecified or address.is_multicast:
+        return "non-public IP targets are blocked"
+    return ""
+
+
+def _validate_live_probe_url(url: str, *, allow_local_http: bool = False) -> tuple[bool, str]:
+    parsed = urlparse(url)
+    scheme = parsed.scheme.lower()
+    if scheme == "https":
+        pass
+    elif scheme == "http" and allow_local_http:
+        pass
+    else:
+        return False, "live endpoint smoke requires https unless local HTTP emulator mode is enabled"
+    blocked_reason = _host_is_blocked(parsed.hostname or "", allow_local_http=allow_local_http)
+    if blocked_reason:
+        return False, blocked_reason
+    return True, "live endpoint target passed URL safety policy"
+
+
+class _SameOriginRedirectHandler(request.HTTPRedirectHandler):
+    def __init__(self, *, allow_local_http: bool = False) -> None:
+        super().__init__()
+        self._allow_local_http = allow_local_http
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # type: ignore[override]
+        if _origin(req.full_url) != _origin(newurl):
+            raise RuntimeError("live endpoint smoke redirect changed origin")
+        ok, reason = _validate_live_probe_url(
+            newurl,
+            allow_local_http=self._allow_local_http,
+        )
+        if not ok:
+            raise RuntimeError(f"live endpoint smoke redirect target refused: {reason}")
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+
+def _live_probe_opener(*, allow_local_http: bool = False):
+    return request.build_opener(_SameOriginRedirectHandler(allow_local_http=allow_local_http))
+
+
+def _probe_opensearch(connector: Mapping[str, Any], token: str) -> tuple[str, str, bool]:
     url = _connector_target(connector)
+    allow_local_http = _local_http_allowed()
+    ok, reason = _validate_live_probe_url(url, allow_local_http=allow_local_http)
+    if not ok:
+        return "skipped", f"unsafe live endpoint target: {reason}", False
     provider = search_index_provider(str(connector.get("provider", "") or "opensearch"))
     label = provider.label if provider is not None else "Search index"
     req = request.Request(
@@ -81,13 +156,14 @@ def _probe_opensearch(connector: Mapping[str, Any], token: str) -> tuple[str, st
         method="HEAD",
         headers={"Authorization": f"Bearer {token}", "User-Agent": "agilab-live-smoke/1"},
     )
-    with request.urlopen(req, timeout=10) as response:
+    opener = _live_probe_opener(allow_local_http=allow_local_http)
+    with opener.open(req, timeout=10) as response:
         status = getattr(response, "status", 200)
     return (
         ("healthy", f"{label} HEAD returned {status}")
         if int(status) < 500
         else ("unhealthy", f"{label} HEAD returned {status}")
-    )
+    ) + (True,)
 
 
 def _smoke_row(
@@ -151,11 +227,10 @@ def _smoke_row(
             status, message = _probe_sqlite(str(connector.get("uri", "") or ""))
             network_probe = False
         elif kind == "opensearch" and credential_env_name:
-            status, message = _probe_opensearch(
+            status, message, network_probe = _probe_opensearch(
                 connector,
                 str(os.environ[credential_env_name]),
             )
-            network_probe = True
         else:
             status, message = "skipped", f"live smoke not implemented for {kind}"
             network_probe = False

--- a/src/agilab/lib/agi-app-mission-decision/src/agi_app_mission_decision/project/mission_decision_project/src/mission_decision_worker/mission_decision_worker.py
+++ b/src/agilab/lib/agi-app-mission-decision/src/agi_app_mission_decision/project/mission_decision_project/src/mission_decision_worker/mission_decision_worker.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
-from agi_node.agi_dispatcher import BaseWorker
+from agi_node.agi_dispatcher import BaseWorker, base_worker_path_support as path_support
 from agi_node.pandas_worker import PandasWorker
 from mission_decision import MissionDecisionArgs
 from mission_decision.artifacts import build_decision_artifacts
@@ -23,15 +23,7 @@ _runtime: dict[str, object] = {}
 
 
 def _artifact_dir(env: object, leaf: str) -> Path:
-    export_root = getattr(env, "AGILAB_EXPORT_ABS", None)
-    target = str(getattr(env, "target", "") or "")
-    relative = Path(target) / leaf if target else Path(leaf)
-    if export_root is not None:
-        return Path(export_root) / relative
-    resolve_share_path = getattr(env, "resolve_share_path", None)
-    if callable(resolve_share_path):
-        return Path(resolve_share_path(relative))
-    return Path.home() / "export" / relative
+    return path_support.resolve_artifact_dir(env, leaf, path_cls=Path, home_factory=Path.home)
 
 
 def _sanitize_slug(value: str) -> str:

--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground_worker/pytorch_playground_worker.py
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground_worker/pytorch_playground_worker.py
@@ -12,7 +12,7 @@ from typing import Any
 
 import pandas as pd
 
-from agi_node.agi_dispatcher import BaseWorker
+from agi_node.agi_dispatcher import BaseWorker, base_worker_path_support as path_support
 from agi_node.pandas_worker import PandasWorker
 from pytorch_playground import PytorchPlaygroundArgs, to_playground_config
 from pytorch_playground.core import (
@@ -42,15 +42,7 @@ def _args_model() -> type[Any]:
 
 
 def _artifact_dir(env: object, leaf: str) -> Path:
-    export_root = getattr(env, "AGILAB_EXPORT_ABS", None)
-    target = str(getattr(env, "target", "") or "")
-    relative = Path(target) / leaf if target else Path(leaf)
-    if export_root is not None:
-        return Path(export_root) / relative
-    resolve_share_path = getattr(env, "resolve_share_path", None)
-    if callable(resolve_share_path):
-        return Path(resolve_share_path(relative))
-    return Path.home() / "export" / relative
+    return path_support.resolve_artifact_dir(env, leaf, path_cls=Path, home_factory=Path.home)
 
 
 def _args_with_defaults(value: Any) -> PytorchPlaygroundArgs:

--- a/src/agilab/lib/agi-app-uav-relay-queue/src/agi_app_uav_relay_queue/project/uav_relay_queue_project/src/uav_relay_queue_worker/uav_relay_queue_worker.py
+++ b/src/agilab/lib/agi-app-uav-relay-queue/src/agi_app_uav_relay_queue/project/uav_relay_queue_project/src/uav_relay_queue_worker/uav_relay_queue_worker.py
@@ -18,7 +18,7 @@ import networkx as nx
 import pandas as pd
 import simpy
 
-from agi_node.agi_dispatcher import BaseWorker
+from agi_node.agi_dispatcher import BaseWorker, base_worker_path_support as path_support
 from agi_node.pandas_worker import PandasWorker
 from uav_relay_queue.reduction import write_reduce_artifact
 
@@ -27,15 +27,7 @@ _runtime: dict[str, object] = {}
 
 
 def _artifact_dir(env: object, leaf: str) -> Path:
-    export_root = getattr(env, "AGILAB_EXPORT_ABS", None)
-    target = str(getattr(env, "target", "") or "")
-    relative = Path(target) / leaf if target else Path(leaf)
-    if export_root is not None:
-        return Path(export_root) / relative
-    resolve_share_path = getattr(env, "resolve_share_path", None)
-    if callable(resolve_share_path):
-        return Path(resolve_share_path(relative))
-    return Path.home() / "export" / relative
+    return path_support.resolve_artifact_dir(env, leaf, path_cls=Path, home_factory=Path.home)
 
 
 @dataclass(frozen=True)

--- a/src/agilab/lib/agi-app-weather-forecast/src/agi_app_weather_forecast/project/weather_forecast_project/src/weather_forecast_worker/weather_forecast_worker.py
+++ b/src/agilab/lib/agi-app-weather-forecast/src/agi_app_weather_forecast/project/weather_forecast_project/src/weather_forecast_worker/weather_forecast_worker.py
@@ -13,6 +13,7 @@ from sklearn.ensemble import RandomForestRegressor
 from skforecast.model_selection import TimeSeriesFold, backtesting_forecaster
 from skforecast.recursive import ForecasterRecursive
 
+from agi_node.agi_dispatcher import base_worker_path_support as path_support
 from agi_node.pandas_worker import PandasWorker
 from weather_forecast.reduction import write_reduce_artifact
 
@@ -21,15 +22,7 @@ _runtime: dict[str, object] = {}
 
 
 def _artifact_dir(env: object, leaf: str) -> Path:
-    export_root = getattr(env, "AGILAB_EXPORT_ABS", None)
-    target = str(getattr(env, "target", "") or "")
-    relative = Path(target) / leaf if target else Path(leaf)
-    if export_root is not None:
-        return Path(export_root) / relative
-    resolve_share_path = getattr(env, "resolve_share_path", None)
-    if callable(resolve_share_path):
-        return Path(resolve_share_path(relative))
-    return Path.home() / "export" / relative
+    return path_support.resolve_artifact_dir(env, leaf, path_cls=Path, home_factory=Path.home)
 
 
 class WeatherForecastWorker(PandasWorker):

--- a/test/test_data_connector_live_endpoint_smoke_report.py
+++ b/test/test_data_connector_live_endpoint_smoke_report.py
@@ -4,6 +4,8 @@ import importlib.util
 import sys
 from pathlib import Path
 
+import pytest
+
 
 REPORT_PATH = Path("tools/data_connector_live_endpoint_smoke_report.py").resolve()
 CORE_PATH = Path("src/agilab/data_connector_live_endpoint_smoke.py").resolve()
@@ -178,7 +180,11 @@ def test_live_endpoint_smoke_opensearch_success_and_failure_paths(monkeypatch, t
         def __exit__(self, *_args):
             return False
 
-    monkeypatch.setattr(core.request, "urlopen", lambda *_args, **_kwargs: Response())
+    class Opener:
+        def open(self, *_args, **_kwargs):
+            return Response()
+
+    monkeypatch.setattr(core, "_live_probe_opener", lambda **_kwargs: Opener())
 
     healthy = core._smoke_row(
         connector,
@@ -191,10 +197,11 @@ def test_live_endpoint_smoke_opensearch_success_and_failure_paths(monkeypatch, t
     assert healthy["network_probe_executed"] is True
     assert "HEAD returned 204" in healthy["message"]
 
-    def fail_urlopen(*_args, **_kwargs):
-        raise OSError("network down")
+    class FailingOpener:
+        def open(self, *_args, **_kwargs):
+            raise OSError("network down")
 
-    monkeypatch.setattr(core.request, "urlopen", fail_urlopen)
+    monkeypatch.setattr(core, "_live_probe_opener", lambda **_kwargs: FailingOpener())
     unhealthy = core._smoke_row(
         connector,
         execute=True,
@@ -205,6 +212,68 @@ def test_live_endpoint_smoke_opensearch_success_and_failure_paths(monkeypatch, t
     assert unhealthy["execution_status"] == "executed"
     assert unhealthy["network_probe_executed"] is True
     assert unhealthy["message"] == "network down"
+
+
+def test_live_endpoint_smoke_blocks_unsafe_opensearch_targets_before_authorization(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    core = _load_module(CORE_PATH, "data_connector_live_smoke_unsafe_url_core")
+    monkeypatch.setenv("OPENSEARCH_TOKEN", "token-value")
+
+    def fail_if_opened(**_kwargs):
+        raise AssertionError("unsafe target should not build an opener")
+
+    monkeypatch.setattr(core, "_live_probe_opener", fail_if_opened)
+
+    for url in (
+        "file:///tmp/search",
+        "http://169.254.169.254/latest/meta-data",
+        "http://127.0.0.1:9200",
+    ):
+        row = core._smoke_row(
+            {
+                "id": "ops",
+                "kind": "opensearch",
+                "label": "Operations Search",
+                "provider": "opensearch",
+                "url": url,
+                "index": "runs-*",
+                "auth_ref": "env:OPENSEARCH_TOKEN",
+            },
+            execute=True,
+            allowed_connector_ids={"ops"},
+        )
+
+        assert row["status"] == "skipped"
+        assert row["execution_status"] == "skipped"
+        assert row["network_probe_executed"] is False
+        assert "unsafe live endpoint target" in row["message"]
+
+
+def test_live_endpoint_smoke_redirects_must_keep_same_safe_origin() -> None:
+    core = _load_module(CORE_PATH, "data_connector_live_smoke_redirect_policy_core")
+    handler = core._SameOriginRedirectHandler()
+    req = core.request.Request("https://opensearch.example.invalid/runs-*", method="HEAD")
+
+    assert handler.redirect_request(
+        req,
+        None,
+        302,
+        "found",
+        {},
+        "https://opensearch.example.invalid/health",
+    )
+
+    with pytest.raises(RuntimeError, match="redirect changed origin"):
+        handler.redirect_request(
+            req,
+            None,
+            302,
+            "found",
+            {},
+            "https://attacker.example.invalid/health",
+        )
 
 
 def test_live_endpoint_smoke_invalid_catalog_and_relative_persist_path(tmp_path: Path) -> None:

--- a/test/test_notebook_export_docs.py
+++ b/test/test_notebook_export_docs.py
@@ -30,10 +30,11 @@ def test_readme_leads_with_anti_lock_in_notebook_export_value() -> None:
 
     assert "anti-lock-in reproducibility workbench" in headline_window
     assert "executable, portable, evidence-backed apps" in headline_window
-    assert "export it back to an `agi-core` notebook" in compact_headline
+    assert "stable `agi-core` handoff" in headline_window
+    assert "portable handoff path" in headline_window
     assert "you do not lose your work" in headline_window
-    assert "stable, production-grade core technology" in compact_headline
-    assert "runnable outside the AGILAB UI as `agi-core` notebooks" in headline_window
+    assert "stable core runtime remains the smallest supported handoff surface" in compact_headline
+    assert "release-gated core runtime handoff technology" in compact_headline
     assert "reviewable run evidence" in headline_window
 
 

--- a/test/test_public_demo_links.py
+++ b/test/test_public_demo_links.py
@@ -158,7 +158,7 @@ def test_pypi_readme_tracks_public_readme_contract() -> None:
         "you do not lose your work if the AGILAB UI or distributed runtime is",
         "reviewable run evidence",
         "runnable outside the AGILAB UI as `agi-core` notebooks",
-        "production-grade core technology",
+        "release-gated core runtime handoff technology",
         "AGILAB complements MLflow and production MLOps platforms.",
         "## Core Flow",
         "### Local PyPI Proof",


### PR DESCRIPTION
## Summary

Generated and applied an AGILAB production/evidence-readiness audit prompt modeled on the Tokki version, then fixed the top actionable findings from an independent multi-axis review.

## AGILAB audit prompt generated

```text
Review current fetched origin/main for AGILAB as a trusted-operator reproducibility workbench, not a standalone production MLOps control plane or regulated serving platform.

Inspect current repository evidence before claims. Audit these lanes: pitfalls, speedup, correctness, known bugs, source-tree improvement, naming, deprecation, security, docs alignment, and repo status. Check control-plane, payload-plane, and evidence-plane contracts across runtime, workers, installer, app packages, notebooks, MCP tools, Streamlit pages, docs, release proof, PyPI, GitHub, and Hugging Face.

Return only concrete actionable findings that can fit coherent PRs. For each finding include severity, file/line evidence, mechanism, impact, smallest fix, and regression or validation. Mark lanes clear when no actionable issue is found. Keep AGILAB's claims bounded to replayable, attestable evidence for trusted operators.
```

## Findings fixed

### Security: connector live-smoke URL policy

- Added URL safety checks before bearer tokens are attached.
- Default policy now requires `https` unless local HTTP emulator mode is explicitly enabled.
- Blocks metadata, loopback, private, link-local, unspecified, and multicast IP targets by default.
- Adds same-origin redirect enforcement for live endpoint probes.
- Adds regressions proving unsafe targets are skipped before any opener can receive `Authorization`.

### Evidence path correctness: built-in worker artifact roots

- Added `resolve_artifact_dir` to the shared `agi-node` worker path support layer.
- Updated built-in app worker artifact helpers to use the shared resolver instead of duplicating `AGILAB_EXPORT_ABS` / `~/export` fallback logic.
- Preserves explicit export roots and runtime `resolve_share_path`, then uses active workflow/share root before local fallback.
- Adds polluted-environment regressions proving process `HOME` pollution does not silently move artifacts away from `env.home_abs` fallback.
- Synced checked-in package payload mirrors for promoted app packages.

### Release/docs alignment: changelog and public wording

- Added `Unreleased` entries for the data-quality README correction and this audit-readiness hardening batch.
- Tightened root README and PyPI README wording from broad production-grade phrasing to `release-gated core runtime handoff technology`.
- Updated public README/PyPI contract tests to enforce the bounded wording.

## Regression Test

- `test/test_data_connector_live_endpoint_smoke_report.py` covers unsafe URL refusal and same-origin redirect policy.
- `src/agilab/core/test/test_base_worker_path_support.py` covers shared artifact directory resolution precedence and polluted process-home fallback.
- Public README/PyPI tests cover the revised production-boundary language.

## Validation

Validation passed.

Local evidence:

- `./dev test test/test_data_connector_live_endpoint_smoke_report.py`
- `./dev test src/agilab/core/test/test_base_worker_path_support.py`
- `./dev test test/test_notebook_export_docs.py test/test_public_demo_links.py test/test_audit_response_docs.py`
- `git diff --check`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files $(git diff --name-only)`
- `./dev app-contracts`
- `uv --preview-features extra-build-dependencies run --no-sync pytest src/agilab/core/test`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui`
- `./dev robust`
- `uv --preview-features extra-build-dependencies run python tools/release_proof_report.py --render --check --compact`
- `python3 tools/agent_instruction_contract.py --check`
- `./dev scope --staged --max-scopes 40`
- `./dev impact --staged`

GitHub checks passed:

- GitGuardian Security Checks
- `clean-public-install` on macOS, Ubuntu, and Windows
- `local-only-policy`
- `windows-core-tests`

GitHub skipped by workflow policy:

- `public-demo-smoke`

Mixed-scope note: this intentionally spans security, shared worker path support, built-in app worker payloads, changelog, and public README wording because it is one AGILAB production/evidence audit-readiness batch.

## Review Evidence

Sub-agent reviewer used:

- Agent: `Beauvoir`
- Role: explorer, read-only
- Task: AGILAB multi-axis production/evidence-readiness audit
- Result: four actionable findings identified and addressed in this PR
- File edits by sub-agent: none

## Agent Metadata

- Tokki version: `tokki 1.0.10`
- Agent/runtime: `codex-cli 0.142.0`
- Model: `GPT-5 Codex`
- Reasoning effort: `unknown`
- `/fast` mode: `not used`
