### PR TITLE
Optimize Tokki profile for AGILAB

### DIFF
--- a/.tokki/model-free-commands
+++ b/.tokki/model-free-commands
@@ -1,20 +1,39 @@
 # Repo-local commands that Tokki may execute through `tokki run -- ...`
 # without a model call under the default readonly shell policy.
 exact ./dev scope
+exact ./dev scope --staged
 exact ./dev impact
+exact ./dev --print-only impact
 exact ./dev test
 exact ./dev docs
+exact ./dev --print-only docs
 exact ./dev release
+exact ./dev --print-only release
 exact ./dev parallel-stage
+exact ./dev app-contracts
+exact ./dev builtin-app-tests
 exact ./dev maintenance
 exact ./dev memory
+exact ./dev warnings
+exact ./dev audit
+exact ./dev ui-flow
 exact ./dev bugfix
+exact ./dev flow docs
+exact ./dev flow dependency-policy
+exact ./dev flow shared-core-typing
+exact ./dev flow builtin-app-tests
 template ./dev impact --only <safe-component>
+template ./dev impact --files <safe-file>
+template ./dev test <safe-file>
 template ./dev flow <safe-component>
 template ./dev task-worktree <safe-ref>
 template ./dev bugfix <safe-file>
 template ./dev regress <safe-selector>
 template ./dev parallel-stage <safe-profile>
+template ./dev app-contracts <safe-scope>
+template ./dev builtin-app-tests --app <safe-component>
 template ./dev maintenance <safe-scope>
 template ./dev memory <safe-component>
 template ./dev docs <safe-target>
+template ./dev warnings --newer-than <safe-file>
+template ./dev ui-flow <safe-file>

--- a/.tokki/profile
+++ b/.tokki/profile
@@ -1,2 +1,9 @@
 agilab
+agilab-clean-worktree
+agilab-validation-shortcuts
+agilab-builtin-apps
+agilab-docs-mirror
+agilab-pr-evidence
+model-free-agilab-validation
+model-free-dev-shortcuts
 model-free-git-push

--- a/.tokki/rules
+++ b/.tokki/rules
@@ -1,41 +1,34 @@
-# AGILAB profile rules — reusable agent operating notes for this repo.
-# Surfaced by `tokki rules`; keep each rule short, imperative, and durable.
+# AGILAB profile rules - short repo-local guidance surfaced by Tokki.
 
-## Routing / allocation debugging
-- Before debugging routing model quality, compare generated allocation JSON
-  (allocations_steps.json) against current local AND remote TimeRoutingEnv
-  candidate-path smoke results. If the smoke test finds candidate paths but
-  the artifacts show all no_path/reject, treat it as stale runtime drift:
-  refresh/redeploy worker envs and regenerate artifacts BEFORE retraining or
-  patching model code.
-- If allocation output is all no_path/reject, first run a direct current-env
-  smoke test and verify the deployed worker source matches local source.
-- Useful allocation health counters: no_path, reject, valid_path_count,
-  delivered bandwidth sum, bearer counts, step count, edge count, and
-  candidate-path count from a direct env smoke test.
+## Worktree and validation routing
+- Before push, merge, release, or "next move", inspect current state first:
+  `./dev scope`, PR status, and the authoritative workflow/tooling surface.
+- If `./dev scope` reports mixed dirty scopes, do not keep editing that
+  checkout. Use `./dev task-worktree <branch>` and stage only the intended files.
+- Start non-trivial fixes with `./dev impact` or `./dev impact --files ...`;
+  run the exact focused tests it selects before broad profiles.
+- Prefer compact `./dev` output. Treat full logs as artifacts and summarize
+  only signal: failing command, root cause, path, and next validation.
 
-## Workers / environments
-- Verify the deployed worker file and venv when local fixes do not show up in
-  generated artifacts — runtime drift, not model logic, is the usual cause.
-- Use explicit Python interpreters for worker/debug commands: python3 or the
-  worker venv's python. Never assume `python` exists locally or remotely.
+## Built-in apps and docs
+- Built-in app changes need app-local validation through
+  `./dev builtin-app-tests --app <project>` or `./dev app-contracts`; root
+  pytest over app tests is suspect because app dependencies are isolated.
+- For app README or quality-plan edits, compare documented artifacts with
+  worker outputs. Do not mention files the app does not emit.
+- For docs, SVGs, and public mirror work, update canonical sources first,
+  sync/verify the mirror, and compare references, captions, alt text, and
+  rendered evidence before calling the docs aligned.
 
-## Token discipline
-- Codex/Claude rollout logs are huge but the durable signal is small: thread
-  metadata, plan, command failures, key counters, final diagnosis. Digest
-  session logs into metadata-only summaries instead of rereading transcripts.
+## Cluster, workers, and generated artifacts
+- If allocation artifacts show all `no_path` or `reject`, first compare them
+  with fresh local and remote worker smoke results. Runtime or deployed-worker
+  drift is more likely than model quality.
+- Verify deployed worker files and venvs when local fixes do not appear in
+  generated artifacts. Use explicit `python3` or the worker venv Python.
 
-## Review / publishing hygiene
-- If `gh pr merge --delete-branch` fails on local worktree ownership of `main`,
-  check remote PR state before retrying. Prefer `gh pr merge <n> --repo
-  ThalesGroup/agilab --merge --delete-branch` from `/tmp`; a remote merge may
-  already have succeeded and only branch cleanup may remain.
-- For commit-provenance questions, inspect author, committer, signature
-  identity, GitHub actor, PR metadata, and timestamps before attributing work.
-- For built-in app quality, verify first-run UX, deterministic sample data,
-  README artifact truth, app-local tests, installer/catalog contract, and clear
-  example value as one gate.
-- When docs name app artifacts, compare the README or quality plan with worker
-  outputs; do not leave users looking for a file the app does not emit.
-- For docs/SVG alignment, compare source SVG, references, captions/alt text,
-  mirror/public copy, and rendered page together before calling it aligned.
+## PR and provenance hygiene
+- For commit-provenance questions, inspect author, committer, signature,
+  GitHub actor, PR metadata, and timestamps before attributing work.
+- If a GitHub merge or branch-delete command fails, re-check remote PR state
+  before retrying; the merge may have succeeded and only cleanup may remain.


### PR DESCRIPTION
## Summary

- Expand the repo-local Tokki profile with AGILAB-specific validation, docs, app, clean-worktree, and PR-evidence capabilities.
- Add high-frequency AGILAB `./dev` validation shortcuts to `.tokki/model-free-commands` so Tokki can route more safe local checks without a model call.
- Compress and sharpen `.tokki/rules` around AGILAB scope triage, impact validation, built-in app validation, docs alignment, worker drift, and provenance hygiene.

## Why

The previous Tokki profile was minimal and did not expose enough AGILAB-specific capability metadata or common validation shortcuts. This made Tokki less useful for AGILAB maintenance, especially when deciding between scope checks, impact validation, app-local tests, docs mirror checks, and PR/provenance workflows.

## Validation

Validation passed.

## Remote Evidence

- PR checks passed: `local-only-policy`, `clean-public-install (macos-latest)`, `clean-public-install (ubuntu-latest)`, `clean-public-install (windows-latest)`, and `GitGuardian Security Checks`.
- `public-demo-smoke` was skipped by workflow.
- Main post-merge `repo-guardrails` passed on merge commit `6b80b8f`.
- Main post-merge lane from the preceding merge is also clean: `docs-source-guard`, `repo-guardrails`, `coverage`, `windows-core-tests`, and `docs-publish` passed.

## Review Evidence

No external model or sub-agent review was used for this PR.

## Agent Metadata

- Tokki version: `tokki 1.0.10`
- Agent/runtime: Codex CLI / GPT-5 Codex
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used
