### PR TITLE
[codex] Clean up AGILAB audit agent docs

### DIFF
--- a/.claude/skills/agilab-deep-audit/SKILL.md
+++ b/.claude/skills/agilab-deep-audit/SKILL.md
@@ -83,28 +83,28 @@ For a deep AGILAB audit, cover these surfaces unless the user narrows scope:
 - Periphery sampling: representative built-in apps, page bundles, and examples
   only after the central architecture is understood.
 
-## Production and evidence-readiness audit prompt
+## Production and evidence-readiness audit mode
 
-When the user asks for the highest added-value AGILAB prompt, a Tokki-style
-AGILAB production audit, or to send/fix findings from such an audit, use this
-contract instead of a generic bug hunt:
+Use this mode for high-value AGILAB production and evidence-readiness audits.
+It is a reusable review contract, not a copied chat prompt or a generic bug
+hunt.
 
 ```text
-Load the full AGILAB repo, docs, release proof, package split, built-in apps,
-notebooks, MCP and agent surfaces, Streamlit pages, tests, generated assets,
-Hugging Face/PyPI/GitHub publication state, current git/GitHub state, and
-commit provenance when authorship or attribution matters.
+Audit scope: full AGILAB repo, docs, release proof, package split, built-in
+apps, notebooks, MCP and agent surfaces, Streamlit pages, tests, generated
+assets, Hugging Face/PyPI/GitHub publication state, current git/GitHub state,
+and commit provenance when authorship or attribution matters.
 
-Act as a senior production engineer, open-source product strategist, security
-reviewer, and evidence/reproducibility-readiness reviewer.
+Reviewer stance: senior production engineering, open-source product strategy,
+security review, and evidence/reproducibility readiness.
 
-Goal: make AGILAB production-grade as a trusted-operator workbench for turning
-AI/ML experiments, notebooks, and agent runs into replayable, attestable
-evidence. Keep claims honest: do not position AGILAB as a fully managed
-production MLOps control plane or regulatory compliance product unless current
-public evidence proves it.
+Review goal: make AGILAB production-grade as a trusted-operator workbench for
+turning AI/ML experiments, notebooks, and agent runs into replayable,
+attestable evidence. Keep claims honest: do not position AGILAB as a fully
+managed production MLOps control plane or regulatory compliance product unless
+current public evidence proves it.
 
-Review for:
+Risk areas:
 - correctness bugs, performance hot paths, and validation cost
 - broken or misleading user workflows
 - public/private boundary leaks, unsafe executable-content handling, credential
@@ -121,7 +121,7 @@ Review for:
 - places where AGILAB's trusted-operator, replayable-evidence story is not
   clear enough
 
-Then:
+Follow-up workflow:
 1. List findings by impact.
 2. Fix the top actionable issues directly when the user asks for fixes.
 3. Add or strengthen regression coverage or durable guards.

--- a/.codex/skills/agilab-deep-audit/SKILL.md
+++ b/.codex/skills/agilab-deep-audit/SKILL.md
@@ -83,28 +83,28 @@ For a deep AGILAB audit, cover these surfaces unless the user narrows scope:
 - Periphery sampling: representative built-in apps, page bundles, and examples
   only after the central architecture is understood.
 
-## Production and evidence-readiness audit prompt
+## Production and evidence-readiness audit mode
 
-When the user asks for the highest added-value AGILAB prompt, a Tokki-style
-AGILAB production audit, or to send/fix findings from such an audit, use this
-contract instead of a generic bug hunt:
+Use this mode for high-value AGILAB production and evidence-readiness audits.
+It is a reusable review contract, not a copied chat prompt or a generic bug
+hunt.
 
 ```text
-Load the full AGILAB repo, docs, release proof, package split, built-in apps,
-notebooks, MCP and agent surfaces, Streamlit pages, tests, generated assets,
-Hugging Face/PyPI/GitHub publication state, current git/GitHub state, and
-commit provenance when authorship or attribution matters.
+Audit scope: full AGILAB repo, docs, release proof, package split, built-in
+apps, notebooks, MCP and agent surfaces, Streamlit pages, tests, generated
+assets, Hugging Face/PyPI/GitHub publication state, current git/GitHub state,
+and commit provenance when authorship or attribution matters.
 
-Act as a senior production engineer, open-source product strategist, security
-reviewer, and evidence/reproducibility-readiness reviewer.
+Reviewer stance: senior production engineering, open-source product strategy,
+security review, and evidence/reproducibility readiness.
 
-Goal: make AGILAB production-grade as a trusted-operator workbench for turning
-AI/ML experiments, notebooks, and agent runs into replayable, attestable
-evidence. Keep claims honest: do not position AGILAB as a fully managed
-production MLOps control plane or regulatory compliance product unless current
-public evidence proves it.
+Review goal: make AGILAB production-grade as a trusted-operator workbench for
+turning AI/ML experiments, notebooks, and agent runs into replayable,
+attestable evidence. Keep claims honest: do not position AGILAB as a fully
+managed production MLOps control plane or regulatory compliance product unless
+current public evidence proves it.
 
-Review for:
+Risk areas:
 - correctness bugs, performance hot paths, and validation cost
 - broken or misleading user workflows
 - public/private boundary leaks, unsafe executable-content handling, credential
@@ -121,7 +121,7 @@ Review for:
 - places where AGILAB's trusted-operator, replayable-evidence story is not
   clear enough
 
-Then:
+Follow-up workflow:
 1. List findings by impact.
 2. Fix the top actionable issues directly when the user asks for fixes.
 3. Add or strengthen regression coverage or durable guards.

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 276,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "f82356efd3450b0568a3dcfa476ab519f337ce683fc4382f0be49b452fffe61d",
+  "source_digest_sha256": "538e7eea70165ef20afc967b08f410977edff4e14c6d2e33bb0eec42d44fd9b6",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "f82356efd3450b0568a3dcfa476ab519f337ce683fc4382f0be49b452fffe61d"
+  "target_digest_sha256": "538e7eea70165ef20afc967b08f410977edff4e14c6d2e33bb0eec42d44fd9b6"
 }

--- a/docs/source/agent-workflows.rst
+++ b/docs/source/agent-workflows.rst
@@ -88,20 +88,11 @@ profiles.
 For ad-hoc terminal checks inside an already routed local wrapper session, use
 ``tokki run -- <command>`` when it can execute the command faithfully.
 
-The main rule is simple: run the narrowest local proof first, then reproduce
-the real AGILAB path before broader validation.
-When all checks pass, keep final agent replies compact: write
-``Validation passed.`` without listing every command unless the details are
-needed for failures, skipped checks, release or audit evidence, PR proof, or an
-explicit user request.
-
-When all checks pass, keep final agent replies compact: write
-``Validation passed.`` without listing every command unless the details are
-needed for failures, skipped checks, release or audit evidence, PR proof, or an
-explicit user request.
-
-For ad-hoc terminal checks inside an already routed local wrapper, use
-``tokki run -- <command>`` when it can execute the command faithfully.
+The main contributor rule is simple: run the narrowest local proof first, then
+reproduce the real AGILAB path before broader validation. Close-out summaries
+should stay compact when everything is green; reserve command-by-command detail
+for failures, skipped checks, release or audit evidence, PR proof, or explicit
+reviewer requests.
 
 Use ``AGENT_LEARNINGS.md`` sparingly: add one concrete rule only when the
 correction is reusable and not already covered by the runbooks. Do not use it


### PR DESCRIPTION
## Summary

- Reword the AGILAB deep-audit skill so the production/evidence-readiness section reads as a reusable audit mode instead of a pasted prompt.
- Keep the repo Codex skill mirror synchronized with the Claude skill source.
- Simplify the public agent workflow docs by collapsing duplicated validation close-out wording while preserving the required `Validation passed.` marker.
- Refresh the docs mirror stamp and capability manifest generated surfaces.

## Why

The audit guidance and public agent workflow docs had prompt-like and duplicated wording. This keeps the operational contract intact while making the docs more concise and easier for future agents to follow.

## Validation

Validation passed.

## Validation Detail

- `./dev scope`
- `python3 tools/sync_agent_skills.py --skills agilab-deep-audit`
- `python3 tools/codex_skills.py --root .codex/skills validate --strict`
- `python3 tools/codex_skills.py --root .codex/skills generate`
- `python3 tools/agent_skill_catalog.py --apply`
- `python3 tools/agilab_capabilities_manifest.py --apply`
- `python3 tools/agenticweb_manifest.py --apply`
- `python3 tools/agent_skill_catalog.py --check`
- `python3 tools/agilab_capabilities_manifest.py --check`
- `python3 tools/agenticweb_manifest.py --check`
- `python3 tools/agent_instruction_contract.py --check`
- `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --target docs/source --verify-stamp`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_agent_instruction_contract.py test/test_agent_workflows.py`
- `python3 tools/generate_skill_badges.py`
- `python3 tools/agent_skill_quality_guard.py --roots .claude/skills .codex/skills --fail-on high`
- `python3 tools/skill_security_scan.py --roots .claude/skills .codex/skills --fail-on critical`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile skills`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files .claude/skills/agilab-deep-audit/SKILL.md .codex/skills/agilab-deep-audit/SKILL.md agilab-capabilities.json docs/.docs_source_mirror_stamp.json docs/source/agent-workflows.rst`
- `git diff --cached --check`

## Remote Evidence

- PR checks passed: `verify`, `local-only-policy`, `clean-public-install (macos-latest)`, `clean-public-install (ubuntu-latest)`, `clean-public-install (windows-latest)`, and `GitGuardian Security Checks`.
- `public-demo-smoke` was skipped by workflow.

## Notes

- Skill quality/security scans report existing low/medium informational findings below the configured failure thresholds; no high or critical blocker was introduced.
- A staged impact run during merge resolution over-reported recently merged `main` files. The final impact run was scoped to the actual PR diff against `origin/main`.

## Review Evidence

No external model or sub-agent review was used for this PR.

## Agent Metadata

- Tokki version: `tokki 1.0.10`
- Agent/runtime: Codex CLI / GPT-5 Codex
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used
