### PR TITLE
[codex] Isolate built-in app test environments

### DIFF
--- a/test/test_builtin_app_tests.py
+++ b/test/test_builtin_app_tests.py
@@ -53,9 +53,18 @@ def test_build_pytest_command_keeps_forwarded_args_after_separator():
     assert command[-2:] == ["-k", "weather"]
 
 
-def test_subprocess_env_removes_active_root_virtualenv(monkeypatch):
+def test_subprocess_env_uses_isolated_app_environment(monkeypatch, tmp_path):
     monkeypatch.setenv("VIRTUAL_ENV", "/repo/.venv")
+    monkeypatch.setenv("UV_PROJECT_ENVIRONMENT", "/repo/.venv-dev")
+    monkeypatch.setenv("UV_RUN_RECURSION_DEPTH", "1")
+    monkeypatch.setenv("AGILAB_BUILTIN_APP_TEST_ENV_ROOT", str(tmp_path / "app-envs"))
+    target = builtin_app_tests.BuiltinAppTestTarget(
+        name="execution_pandas_project",
+        path=tmp_path / "execution_pandas_project",
+    )
 
-    env = builtin_app_tests.subprocess_env()
+    env = builtin_app_tests.subprocess_env(target)
 
     assert "VIRTUAL_ENV" not in env
+    assert "UV_RUN_RECURSION_DEPTH" not in env
+    assert env["UV_PROJECT_ENVIRONMENT"] == str(tmp_path / "app-envs" / target.name)

--- a/tools/builtin_app_tests.py
+++ b/tools/builtin_app_tests.py
@@ -22,6 +22,8 @@ DEFAULT_PYTEST_ARGS = (
     "--import-mode=importlib",
     "test",
 )
+DEFAULT_APP_TEST_ENVS_ROOT = REPO_ROOT / ".venv-builtin-app-tests"
+APP_TEST_ENV_ROOT_ENV = "AGILAB_BUILTIN_APP_TEST_ENV_ROOT"
 
 
 class BuiltinAppTestTarget(NamedTuple):
@@ -68,11 +70,14 @@ def build_pytest_command(pytest_args: Sequence[str] = ()) -> list[str]:
     ]
 
 
-def subprocess_env() -> dict[str, str]:
-    """Return an environment that lets uv select each app's project environment."""
+def subprocess_env(target: BuiltinAppTestTarget) -> dict[str, str]:
+    """Return an isolated uv environment for one built-in app test target."""
 
     env = os.environ.copy()
     env.pop("VIRTUAL_ENV", None)
+    env.pop("UV_RUN_RECURSION_DEPTH", None)
+    env_root = Path(env.get(APP_TEST_ENV_ROOT_ENV, str(DEFAULT_APP_TEST_ENVS_ROOT)))
+    env["UV_PROJECT_ENVIRONMENT"] = str(env_root / target.name)
     return env
 
 
@@ -138,7 +143,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         if args.dry_run:
             print(shlex.join(command))
             continue
-        result = subprocess.run(command, cwd=target.path, check=False, env=subprocess_env())
+        result = subprocess.run(command, cwd=target.path, check=False, env=subprocess_env(target))
         if result.returncode:
             failures.append(target.name)
             if not args.keep_going:


### PR DESCRIPTION
## Summary
- Run each built-in app test target in its own root-owned uv environment under `.venv-builtin-app-tests/<app>`.
- Strip inherited `UV_PROJECT_ENVIRONMENT` and uv recursion state from nested app test subprocesses.
- Add a regression proving built-in app tests do not reuse root `.venv-dev` or app-local `.venv` state.

## Repro
`./dev release` failed in `tools/builtin_app_tests.py` while collecting `execution_pandas_project` because nested app-local uv runs inherited validation environment state and then resolved `pydantic` from a polluted local environment/cache. The visible failure was:

```text
ImportError: cannot import name 'BaseModel' from 'pydantic'
```

## Root Cause
`tools/builtin_app_tests.py` removed `VIRTUAL_ENV` but left `UV_PROJECT_ENVIRONMENT` and `UV_RUN_RECURSION_DEPTH` intact. When launched from `./dev release`, nested app test runs could reuse or mutate the root validation environment instead of a clean app-specific test environment. That made release validation sensitive to polluted local `.venv-dev` or app-local `.venv` state.

## Regression Test
`test/test_builtin_app_tests.py` now asserts that the runner removes inherited root uv state and assigns `UV_PROJECT_ENVIRONMENT` to `.venv-builtin-app-tests/<app>` for the target app.

## Validation
- `./dev impact --staged`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_builtin_app_tests.py`
- `./dev builtin-app-tests --app execution_pandas_project`
- `git diff --cached --check`

## Notes
- Local uv cache pollution for `pydantic` was repaired with `uv cache clean pydantic`; the downloaded PyPI wheel itself had a normal non-empty `pydantic/__init__.py`.
- Full `./dev release` was retried and correctly stopped at the strict audit because this PR branch has tracked changes. It should be rerun after merge on clean `main`.

## Review Evidence
No external model or sub-agent review was used for this PR.

## Agent Metadata
- Tokki version: `tokki 1.0.10`
- Agent/runtime: Codex CLI / GPT-5 Codex
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used
