### PR TITLE
[codex] Avoid uv cache reuse in built-in app tests

### DIFF
--- a/test/test_builtin_app_tests.py
+++ b/test/test_builtin_app_tests.py
@@ -33,6 +33,7 @@ def test_build_pytest_command_uses_app_local_project_and_importlib_mode():
 
     assert command[:10] == [
         "uv",
+        "--no-cache",
         "--preview-features",
         "extra-build-dependencies",
         "run",
@@ -41,8 +42,8 @@ def test_build_pytest_command_uses_app_local_project_and_importlib_mode():
         "--with",
         "pytest",
         "--with",
-        "pytest-asyncio",
     ]
+    assert "pytest-asyncio" in command
     assert "--import-mode=importlib" in command
     assert command[-1] == "test"
 
@@ -68,3 +69,13 @@ def test_subprocess_env_uses_isolated_app_environment(monkeypatch, tmp_path):
     assert "VIRTUAL_ENV" not in env
     assert "UV_RUN_RECURSION_DEPTH" not in env
     assert env["UV_PROJECT_ENVIRONMENT"] == str(tmp_path / "app-envs" / target.name)
+
+
+def test_app_test_env_root_uses_temporary_directory_by_default(monkeypatch):
+    monkeypatch.delenv("AGILAB_BUILTIN_APP_TEST_ENV_ROOT", raising=False)
+
+    with builtin_app_tests.app_test_env_root() as env_root:
+        assert env_root.name.startswith("agilab-builtin-app-tests-")
+        assert env_root.exists()
+
+    assert not env_root.exists()

--- a/tools/builtin_app_tests.py
+++ b/tools/builtin_app_tests.py
@@ -4,10 +4,13 @@
 from __future__ import annotations
 
 import argparse
+import contextlib
 import os
 import shlex
 import subprocess
 import sys
+import tempfile
+from collections.abc import Iterator
 from pathlib import Path
 from typing import NamedTuple, Sequence
 
@@ -54,6 +57,7 @@ def build_pytest_command(pytest_args: Sequence[str] = ()) -> list[str]:
         forwarded = list(DEFAULT_PYTEST_ARGS)
     return [
         "uv",
+        "--no-cache",
         "--preview-features",
         "extra-build-dependencies",
         "run",
@@ -70,15 +74,30 @@ def build_pytest_command(pytest_args: Sequence[str] = ()) -> list[str]:
     ]
 
 
-def subprocess_env(target: BuiltinAppTestTarget) -> dict[str, str]:
+def subprocess_env(
+    target: BuiltinAppTestTarget, env_root: Path | None = None
+) -> dict[str, str]:
     """Return an isolated uv environment for one built-in app test target."""
 
     env = os.environ.copy()
     env.pop("VIRTUAL_ENV", None)
     env.pop("UV_RUN_RECURSION_DEPTH", None)
-    env_root = Path(env.get(APP_TEST_ENV_ROOT_ENV, str(DEFAULT_APP_TEST_ENVS_ROOT)))
+    if env_root is None:
+        env_root = Path(env.get(APP_TEST_ENV_ROOT_ENV, str(DEFAULT_APP_TEST_ENVS_ROOT)))
     env["UV_PROJECT_ENVIRONMENT"] = str(env_root / target.name)
     return env
+
+
+@contextlib.contextmanager
+def app_test_env_root() -> Iterator[Path]:
+    """Return the root directory used for this runner invocation's app envs."""
+
+    configured = os.environ.get(APP_TEST_ENV_ROOT_ENV)
+    if configured:
+        yield Path(configured)
+        return
+    with tempfile.TemporaryDirectory(prefix="agilab-builtin-app-tests-") as temp_dir:
+        yield Path(temp_dir)
 
 
 def _selected_targets(
@@ -136,18 +155,24 @@ def main(argv: Sequence[str] | None = None) -> int:
         print("No built-in app test targets found.", file=sys.stderr)
         return 1
 
-    command = build_pytest_command(args.pytest_args)
     failures: list[str] = []
-    for target in targets:
-        print(f"\n== {target.path.relative_to(REPO_ROOT)} ==", flush=True)
-        if args.dry_run:
-            print(shlex.join(command))
-            continue
-        result = subprocess.run(command, cwd=target.path, check=False, env=subprocess_env(target))
-        if result.returncode:
-            failures.append(target.name)
-            if not args.keep_going:
-                return result.returncode
+    command = build_pytest_command(args.pytest_args)
+    with app_test_env_root() as env_root:
+        for target in targets:
+            print(f"\n== {target.path.relative_to(REPO_ROOT)} ==", flush=True)
+            if args.dry_run:
+                print(shlex.join(command))
+                continue
+            result = subprocess.run(
+                command,
+                cwd=target.path,
+                check=False,
+                env=subprocess_env(target, env_root),
+            )
+            if result.returncode:
+                failures.append(target.name)
+                if not args.keep_going:
+                    return result.returncode
 
     if failures:
         print(f"Failed built-in app test target(s): {', '.join(failures)}", file=sys.stderr)


### PR DESCRIPTION
## Summary
- Run built-in app test subprocesses with `uv --no-cache` so release validation does not reuse polluted persistent uv package archives.
- Use a temporary app-test env root by default, while keeping `AGILAB_BUILTIN_APP_TEST_ENV_ROOT` as an explicit debugging override.
- Extend runner tests to cover no-cache command construction and temporary env cleanup.

## Repro
After PR #696 isolated app test envs, `./dev release` advanced past `execution_pandas_project` but failed on `execution_polars_project` with:

```text
AttributeError: module 'polars' has no attribute 'DataFrame'
```

A no-cache uv run with a fresh app-test env installed a valid `polars` package, proving the failure was persistent uv cache pollution rather than app code.

## Root Cause
The first isolation fix prevented `.venv-dev` reuse, but the runner still reused persistent uv package cache entries and stable app-test env paths. A corrupted cache payload could therefore poison fresh app test environments, and a stale isolated env could keep the bad package across runs.

## Regression Test
`test/test_builtin_app_tests.py` now asserts that built-in app test commands include `uv --no-cache`, that inherited uv state is stripped, and that the default env root is temporary and removed after the invocation.

## Validation
- `./dev impact --files tools/builtin_app_tests.py test/test_builtin_app_tests.py`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_builtin_app_tests.py`
- `./dev builtin-app-tests --app execution_pandas_project --app execution_polars_project`
- `./dev builtin-app-tests`
- `git diff --check`

## Review Evidence
No external model or sub-agent review was used for this PR.

## Agent Metadata
- Tokki version: `tokki 1.0.10`
- Agent/runtime: Codex CLI / GPT-5 Codex
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used
