### PR TITLE
[codex] Bump selected packages to 2026.06.24

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.23"
+version = "2026.06.24"
 name = "agilab"
 description = "AGILAB is a reproducible AI/ML workbench for engineering teams."
 requires-python = ">=3.11,<3.14"
@@ -60,19 +60,21 @@ agilab-mcp = "agilab_mcp.server:main"
 
 [project.optional-dependencies]
 ai = ["openai>=2.32.0,<3"]
-core = ["agi-core==2026.06.23"]
-ui = ["agi-apps==2026.06.23", "agi-pages==2026.06.23", "agi-gui==2026.06.23", "agi-web==2026.06.23", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "plotly>=6.7.0,<7", "sqlalchemy>=2.0.43,<3", "streamlit>=1.57,<1.59", "starlette>=1.0.1,<2", "tomli_w>=1.2.0,<2", "cryptography>=48.0.1,<50"]
+core = ["agi-core==2026.06.24"]
+ui = ["agi-apps==2026.06.24", "agi-pages==2026.06.24", "agi-gui==2026.06.24", "agi-web==2026.06.23", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "plotly>=6.7.0,<7", "sqlalchemy>=2.0.43,<3", "streamlit>=1.57,<1.59", "starlette>=1.0.1,<2", "tomli_w>=1.2.0,<2", "cryptography>=48.0.1,<50"]
 viz = ["matplotlib>=3.10.0,<4", "plotly>=6.7.0,<7"]
 mlflow = ["mlflow>=3.11.1,<4", "idna>=3.15,<4", "starlette>=1.0.1,<2"]
 bridges = ["duckdb>=1.4.0,<2"]
 notebook = ["ipykernel>=6.29.0,<8", "nbclient>=0.10.0,<1", "nbformat>=5.10.0,<6"]
-examples = ["agi-apps==2026.06.23", "jupyterlab>=4.4.0,<5", "matplotlib>=3.10.0,<4", "plotly>=6.7.0,<7", "starlette>=1.0.1,<2", "bleach>=6.4.0,<7"]
-pages = ["agi-pages==2026.06.23", "plotly>=6.7.0,<7", "sqlalchemy>=2.0.43,<3", "starlette>=1.0.1,<2"]
+examples = ["agi-apps==2026.06.24", "jupyterlab>=4.4.0,<5", "matplotlib>=3.10.0,<4", "plotly>=6.7.0,<7", "starlette>=1.0.1,<2", "bleach>=6.4.0,<7"]
+pages = ["agi-pages==2026.06.24", "plotly>=6.7.0,<7", "sqlalchemy>=2.0.43,<3", "starlette>=1.0.1,<2"]
 proof = ["cryptography>=48.0.1,<50"]
 agents = ["openai>=2.32.0,<3"]
 local-llm = ["accelerate>=0.34.2,<2; python_version >= '3.12'", "fastapi>=0.124.4,!=0.136.3,<1; python_version >= '3.12'", "gpt-oss>=0.0.8,<0.1; python_version >= '3.12'", "langchain-core>=1.3.3,<2; python_version >= '3.12'", "langsmith>=0.8.0,<1; python_version >= '3.12'", "mlx>=0.31.2,<0.32; sys_platform == 'darwin' and platform_machine == 'arm64'", "mlx-lm>=0.31.3,<0.32; sys_platform == 'darwin' and platform_machine == 'arm64'", "mlx-vlm>=0.5.0,<0.7; sys_platform == 'darwin' and platform_machine == 'arm64'", "requests>=2.32.0,<3; python_version >= '3.12'", "starlette>=1.3.1,<2; python_version >= '3.12'", "torch>=2.8.0,<3; python_version >= '3.12'", "transformers>=4.57.0,<6; python_version >= '3.12'", "universal-offline-ai-chatbot>=0.1.0,<0.2; python_version >= '3.12'", "langchain>=1.3.9,<2; python_version >= '3.12'", "pypdf>=6.13.0,<7; python_version >= '3.12'", "python-multipart>=0.0.31,<1; python_version >= '3.12'", "tornado>=6.5.7,<7; python_version >= '3.12'"]
 offline = ["accelerate>=0.34.2,<2; python_version >= '3.12'", "fastapi>=0.124.4,!=0.136.3,<1; python_version >= '3.12'", "gpt-oss>=0.0.8,<0.1; python_version >= '3.12'", "langchain-core>=1.3.3,<2; python_version >= '3.12'", "langsmith>=0.8.0,<1; python_version >= '3.12'", "mlx>=0.31.2,<0.32; sys_platform == 'darwin' and platform_machine == 'arm64'", "mlx-lm>=0.31.3,<0.32; sys_platform == 'darwin' and platform_machine == 'arm64'", "mlx-vlm>=0.5.0,<0.7; sys_platform == 'darwin' and platform_machine == 'arm64'", "requests>=2.32.0,<3; python_version >= '3.12'", "starlette>=1.3.1,<2; python_version >= '3.12'", "torch>=2.8.0,<3; python_version >= '3.12'", "transformers>=4.57.0,<6; python_version >= '3.12'", "universal-offline-ai-chatbot>=0.1.0,<0.2; python_version >= '3.12'", "langchain>=1.3.9,<2; python_version >= '3.12'", "pypdf>=6.13.0,<7; python_version >= '3.12'", "python-multipart>=0.0.31,<1; python_version >= '3.12'", "tornado>=6.5.7,<7; python_version >= '3.12'"]
 dev = ["build>=1.3.0,<2", "cyclonedx-bom>=7.2.1,<8", "pip-audit>=2.9.0,<3", "pytest>=9.0.0,<10", "pytest-asyncio>=1.3.0,<2", "pytest-cov>=7.0.0,<8", "ruff>=0.15.14,<1", "tomlkit>=0.13.0,<1", "twine>=6.2.0,<7", "wheel>=0.45.0,<1"]
+
+
 
 
 

--- a/src/agilab/core/agi-cluster/pyproject.toml
+++ b/src/agilab/core/agi-cluster/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.23"
+version = "2026.06.24"
 name = "agi-cluster"
 description = "Distributed cluster orchestration layer for AGILAB workers over local and SSH backends"
 requires-python = ">=3.11"
@@ -35,7 +35,7 @@ keywords = [
     "job-scheduling",
     "mlops",
 ]
-dependencies = ["agi-env==2026.06.23", "agi-node==2026.06.23", "asyncssh>=2.23,<3", "dask[distributed]>=2026.3,<2027.0", "humanize>=4.10,<5", "numpy>=2.2,<3", "packaging>=25,<27", "polars>=1.35,<2", "psutil>=7,<8", "scikit-learn>=1.7.2,<2", "tomlkit>=0.13,<1"]
+dependencies = ["agi-env==2026.06.24", "agi-node==2026.06.24", "asyncssh>=2.23,<3", "dask[distributed]>=2026.3,<2027.0", "humanize>=4.10,<5", "numpy>=2.2,<3", "packaging>=25,<27", "polars>=1.35,<2", "psutil>=7,<8", "scikit-learn>=1.7.2,<2", "tomlkit>=0.13,<1"]
 
 [project.entry-points."agi_env.runtime_packages"]
 agi-cluster = "agi_cluster.agi_env_runtime:RUNTIME_PACKAGE_SPEC"
@@ -48,6 +48,8 @@ Homepage = "https://github.com/ThalesGroup/agilab"
 Repository = "https://github.com/ThalesGroup/agilab"
 Discussions = "https://github.com/ThalesGroup/agilab/discussions"
 Changelog = "https://github.com/ThalesGroup/agilab/releases"
+
+
 
 
 

--- a/src/agilab/core/agi-core/pyproject.toml
+++ b/src/agilab/core/agi-core/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.23"
+version = "2026.06.24"
 name = "agi-core"
 description = "Meta-package that installs and wires agi-env, agi-node, and agi-cluster together"
 readme = "README.md"
@@ -30,7 +30,7 @@ keywords = [
   "distributed-computing",
   "distributed-execution",
 ]
-dependencies = ["agi-env==2026.06.23", "agi-node==2026.06.23", "agi-cluster==2026.06.23"]
+dependencies = ["agi-env==2026.06.24", "agi-node==2026.06.24", "agi-cluster==2026.06.24"]
 
 [project.entry-points."agi_env.runtime_packages"]
 agi-core = "agi_core.agi_env_runtime:RUNTIME_PACKAGE_SPEC"
@@ -42,6 +42,8 @@ Documentation = "https://thalesgroup.github.io/agilab"
 Repository = "https://github.com/ThalesGroup/agilab"
 Discussions = "https://github.com/ThalesGroup/agilab/discussions"
 Changelog = "https://github.com/ThalesGroup/agilab/releases"
+
+
 
 
 

--- a/src/agilab/core/agi-env/pyproject.toml
+++ b/src/agilab/core/agi-env/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.23"
+version = "2026.06.24"
 name = "agi-env"
 description = "Environment bootstrap package for AGILAB with virtualenv, path, and runtime helpers"
 requires-python = ">=3.11"
@@ -53,6 +53,7 @@ Homepage = "https://github.com/ThalesGroup/agilab"
 Repository = "https://github.com/ThalesGroup/agilab"
 Discussions = "https://github.com/ThalesGroup/agilab/discussions"
 Changelog = "https://github.com/ThalesGroup/agilab/releases"
+
 
 
 

--- a/src/agilab/core/agi-node/pyproject.toml
+++ b/src/agilab/core/agi-node/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.23"
+version = "2026.06.24"
 name = "agi-node"
 description = "Distributed worker orchestration and execution support library for AGILAB"
 requires-python = ">=3.11"
@@ -35,7 +35,7 @@ keywords = [
     "pandas",
     "polars",
 ]
-dependencies = ["agi-env==2026.06.23", "cython>=3.1,<4", "humanize>=4.10,<5", "numpy>=2.2,<3", "pandas>=2.3,<4", "parso>=0.8,<1", "polars>=1.35,<2", "psutil>=7,<8", "py7zr>=1.1,<1.2", "setuptools>=68,<83"]
+dependencies = ["agi-env==2026.06.24", "cython>=3.1,<4", "humanize>=4.10,<5", "numpy>=2.2,<3", "pandas>=2.3,<4", "parso>=0.8,<1", "polars>=1.35,<2", "psutil>=7,<8", "py7zr>=1.1,<1.2", "setuptools>=68,<83"]
 
 [project.entry-points."agi_env.runtime_packages"]
 agi-node = "agi_node.agi_env_runtime:RUNTIME_PACKAGE_SPEC"
@@ -48,6 +48,8 @@ Homepage = "https://github.com/ThalesGroup/agilab"
 Repository = "https://github.com/ThalesGroup/agilab"
 Discussions = "https://github.com/ThalesGroup/agilab/discussions"
 Changelog = "https://github.com/ThalesGroup/agilab/releases"
+
+
 
 
 

--- a/src/agilab/lib/agi-app-flight-telemetry/pyproject.toml
+++ b/src/agilab/lib/agi-app-flight-telemetry/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.23"
+version = "2026.06.24"
 name = "agi-app-flight-telemetry"
 description = "AGILAB flight-telemetry ingestion demo with reusable dataframe and map-analysis outputs"
 requires-python = ">=3.11"
@@ -44,6 +44,7 @@ Changelog = "https://github.com/ThalesGroup/agilab/releases"
 [project.entry-points."agilab.apps"]
 flight_telemetry = "agi_app_flight_telemetry:project_root"
 flight_telemetry_project = "agi_app_flight_telemetry:project_root"
+
 
 
 

--- a/src/agilab/lib/agi-app-mission-decision/pyproject.toml
+++ b/src/agilab/lib/agi-app-mission-decision/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.23"
+version = "2026.06.24"
 name = "agi-app-mission-decision"
 description = "Deterministic AGILAB mission-decision workflow with scenario scoring and evidence artifacts"
 requires-python = ">=3.11"
@@ -44,6 +44,7 @@ Changelog = "https://github.com/ThalesGroup/agilab/releases"
 [project.entry-points."agilab.apps"]
 mission_decision = "agi_app_mission_decision:project_root"
 mission_decision_project = "agi_app_mission_decision:project_root"
+
 
 
 

--- a/src/agilab/lib/agi-app-pytorch-playground/pyproject.toml
+++ b/src/agilab/lib/agi-app-pytorch-playground/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.23"
+version = "2026.06.24"
 name = "agi-app-pytorch-playground"
 description = "AGILAB PyTorch playground app for reproducible neural-network experiments"
 requires-python = ">=3.12"
@@ -44,6 +44,7 @@ Changelog = "https://github.com/ThalesGroup/agilab/releases"
 [project.entry-points."agilab.apps"]
 pytorch_playground = "agi_app_pytorch_playground:project_root"
 pytorch_playground_project = "agi_app_pytorch_playground:project_root"
+
 
 
 

--- a/src/agilab/lib/agi-app-uav-relay-queue/pyproject.toml
+++ b/src/agilab/lib/agi-app-uav-relay-queue/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.23"
+version = "2026.06.24"
 name = "agi-app-uav-relay-queue"
 description = "AGILAB UAV relay queue simulation demo with routing, delay, and resilience artifacts"
 requires-python = ">=3.13"
@@ -42,6 +42,7 @@ Changelog = "https://github.com/ThalesGroup/agilab/releases"
 [project.entry-points."agilab.apps"]
 uav_relay_queue = "agi_app_uav_relay_queue:project_root"
 uav_relay_queue_project = "agi_app_uav_relay_queue:project_root"
+
 
 
 

--- a/src/agilab/lib/agi-app-weather-forecast/pyproject.toml
+++ b/src/agilab/lib/agi-app-weather-forecast/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.23"
+version = "2026.06.24"
 name = "agi-app-weather-forecast"
 description = "AGILAB weather-forecast notebook-migration demo with forecast analysis artifacts"
 requires-python = ">=3.11"
@@ -44,6 +44,7 @@ Changelog = "https://github.com/ThalesGroup/agilab/releases"
 [project.entry-points."agilab.apps"]
 weather_forecast = "agi_app_weather_forecast:project_root"
 weather_forecast_project = "agi_app_weather_forecast:project_root"
+
 
 
 

--- a/src/agilab/lib/agi-apps/pyproject.toml
+++ b/src/agilab/lib/agi-apps/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.23"
+version = "2026.06.24"
 name = "agi-apps"
 description = "AGILAB public app package umbrella and example assets"
 requires-python = ">=3.11"
@@ -31,7 +31,7 @@ keywords = [
     "workflow-orchestration",
 ]
 
-dependencies = ["agi-core==2026.06.23", "agi-app-mission-decision==2026.06.23", "agi-app-pandas-execution==2026.06.23", "agi-app-polars-execution==2026.06.23", "agi-app-flight-telemetry==2026.06.23", "agi-app-multi-dag==2026.06.23", "agi-app-weather-forecast==2026.06.23", "agi-app-sklearn-pipeline==2026.06.23", "agi-app-pytorch-playground==2026.06.23; python_version >= '3.12'", "agi-app-tescia-diagnostic==2026.06.23; python_version >= '3.13'", "agi-app-uav-relay-queue==2026.06.23; python_version >= '3.13'"]
+dependencies = ["agi-core==2026.06.24", "agi-app-mission-decision==2026.06.24", "agi-app-pandas-execution==2026.06.23", "agi-app-polars-execution==2026.06.23", "agi-app-flight-telemetry==2026.06.24", "agi-app-multi-dag==2026.06.23", "agi-app-weather-forecast==2026.06.24", "agi-app-sklearn-pipeline==2026.06.23", "agi-app-pytorch-playground==2026.06.24; python_version >= '3.12'", "agi-app-tescia-diagnostic==2026.06.23; python_version >= '3.13'", "agi-app-uav-relay-queue==2026.06.24; python_version >= '3.13'"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"
@@ -41,6 +41,8 @@ Homepage = "https://github.com/ThalesGroup/agilab"
 Repository = "https://github.com/ThalesGroup/agilab"
 Discussions = "https://github.com/ThalesGroup/agilab/discussions"
 Changelog = "https://github.com/ThalesGroup/agilab/releases"
+
+
 
 
 

--- a/src/agilab/lib/agi-gui/pyproject.toml
+++ b/src/agilab/lib/agi-gui/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.23"
+version = "2026.06.24"
 name = "agi-gui"
 description = "AGILAB Streamlit UI dependency bundle and compatibility imports"
 requires-python = ">=3.11"
@@ -32,7 +32,7 @@ keywords = [
     "python",
 ]
 
-dependencies = ["agi-env==2026.06.23", "streamlit>=1.57,<1.58", "starlette>=1.0.1,<2", "streamlit_code_editor>=0.1.22,<0.2", "watchdog>=6,<7"]
+dependencies = ["agi-env==2026.06.24", "streamlit>=1.57,<1.58", "starlette>=1.0.1,<2", "streamlit_code_editor>=0.1.22,<0.2", "watchdog>=6,<7"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"
@@ -42,6 +42,8 @@ Homepage = "https://github.com/ThalesGroup/agilab"
 Repository = "https://github.com/ThalesGroup/agilab"
 Discussions = "https://github.com/ThalesGroup/agilab/discussions"
 Changelog = "https://github.com/ThalesGroup/agilab/releases"
+
+
 
 
 

--- a/src/agilab/lib/agi-pages/pyproject.toml
+++ b/src/agilab/lib/agi-pages/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.23"
+version = "2026.06.24"
 name = "agi-pages"
 description = "AGILAB public analysis page umbrella and provider package"
 requires-python = ">=3.11"
@@ -34,7 +34,7 @@ keywords = [
     "page-bundles",
 ]
 
-dependencies = ["agi-gui==2026.06.23"]
+dependencies = ["agi-gui==2026.06.24"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"
@@ -44,6 +44,8 @@ Homepage = "https://github.com/ThalesGroup/agilab"
 Repository = "https://github.com/ThalesGroup/agilab"
 Discussions = "https://github.com/ThalesGroup/agilab/discussions"
 Changelog = "https://github.com/ThalesGroup/agilab/releases"
+
+
 
 
 


### PR DESCRIPTION
## Summary

- Bump the selected AGILAB public release package graph to `2026.06.24`.
- Update internal exact pins for the selected split packages and umbrella package.
- Keep the public PyPI badge and release proof at `2026.06.23` until the release workflow publishes and records the new public evidence.

## Release scope

Selected from `v2026.06.23` with `--impact-base-ref v2026.06.23`:

`agi-env`, `agi-gui`, `agi-pages`, `agi-node`, `agi-cluster`, `agi-core`, `agi-app-mission-decision`, `agi-app-flight-telemetry`, `agi-app-weather-forecast`, `agi-app-pytorch-playground`, `agi-app-uav-relay-queue`, `agi-apps`, `agilab`.

## Validation

- `git diff --cached --check`: passed.
- `uv lock --check`: passed.
- `tools/release_plan.py --check-workflow .github/workflows/pypi-publish.yaml --impact-base-ref v2026.06.23 --skip-existing-pypi --format json --compact`: `pypi_publish_selected=true`, 13 provenance packages selected.
- `tools/pypi_release_version_policy.py --skip-existing-pypi`: stable release mode accepted 13 public PyPI package versions.
- `tools/pypi_project_preflight.py`: passed, 35 checked, 22 current, 13 to publish, 0 blockers.
- `tools/release_proof_report.py --check --compact`: passed.
- `tools/impact_validate.py --staged`: high risk due shared-core and GUI package surfaces; required validations below were run.
- `pytest src/agilab/core/agi-env/test`: 795 passed.
- `pytest src/agilab/core/test`: 1194 passed, 3 skipped after refreshing a polluted local `polars==1.41.2` install.
- `pytest -q -o addopts='' test/test_pyproject_dependency_hygiene.py`: 27 passed.
- `tools/workflow_parity.py --profile agi-gui`: passed after keeping the PyPI badge on the last proven release.
- `./dev maintenance`: passed.
- `./dev release`: stopped at strict audit branch-state guard because this branch is intentionally ahead of `origin/main`; release-proof and handoff subchecks passed. Rerun from clean `main` after merge before dispatching the release workflow.

## Review Evidence

No sub-agent review was used for this PR.

## Agent Metadata

- Tokki version: `1.0.10`
- Agent/runtime: Codex CLI, version unavailable
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used

## GitHub Checks

- GitGuardian Security Checks: passed.
- `clean-public-install` on macOS, Ubuntu, and Windows: passed.
- `local-only-policy`: passed.
- `windows-core-tests`: passed.
- `public-demo-smoke`: skipped by workflow condition.
