### PR TITLE
[codex] Add worktree audit learning

### DIFF
--- a/AGENT_LEARNINGS.md
+++ b/AGENT_LEARNINGS.md
@@ -80,6 +80,9 @@ is not a scratchpad or task log.
   `agilab` plus sibling `thales_agilab` when present, print both in the command
   plan, and explicitly report any dirty, missing, or intentionally skipped
   checkout.
+- Before acting on a stale sibling worktree reported by `./dev audit`, verify
+  it still exists in `git worktree list --porcelain`. If it is missing, stop
+  and ask whether to recreate that branch or continue from the current checkout.
 - On agent-prefixed branches such as `codex/*`, `codex-*`, `claude/*`,
   `aider/*`, `opencode/*`, or `agent/*`, never commit with a human Git
   identity. Run `python3 tools/agent_commit_provenance_guard.py --check-config`


### PR DESCRIPTION
## Summary

- Add one durable correction rule to `AGENT_LEARNINGS.md` from this session.
- Require agents to verify audit-reported sibling worktrees still exist in `git worktree list --porcelain` before acting on them.
- Instruct agents to stop and ask whether to recreate the branch or continue from the current checkout when the worktree is missing.

## Why

A follow-up action attempted to continue from a stale audit-reported sibling worktree after the worktree had already disappeared. This rule prevents future agents from acting on stale audit output as if it were live workspace state.

## Validation

Validation passed.

## Validation Detail

- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files AGENT_LEARNINGS.md`
- `python3 tools/agent_instruction_contract.py --check`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_agent_instruction_contract.py`
- `git diff --check`
- `python3 tools/agent_commit_provenance_guard.py --check-config`
- `./dev scope`

## Remote Evidence

- PR checks passed: `local-only-policy`, `clean-public-install (macos-latest)`, `clean-public-install (ubuntu-latest)`, `clean-public-install (windows-latest)`, and `GitGuardian Security Checks`.
- `public-demo-smoke` was skipped by workflow.

## Review Evidence

No external model or sub-agent review was used for this PR.

## Agent Metadata

- Tokki version: `tokki 1.0.10`
- Agent/runtime: Codex CLI / GPT-5 Codex
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used
