### PR TITLE
[codex] Refresh 2026.06.24 release proof evidence

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 277,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "ab44b58e9f8b579dfb7864f9ad29ec93b18e4bf98b673e1c64b5f8b61d500a48",
+  "source_digest_sha256": "ef046ca4832452d6b07ee28b5a12c22d18ea63f8e5b37c4ad99adf8b4379c18a",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "ab44b58e9f8b579dfb7864f9ad29ec93b18e4bf98b673e1c64b5f8b61d500a48"
+  "target_digest_sha256": "ef046ca4832452d6b07ee28b5a12c22d18ea63f8e5b37c4ad99adf8b4379c18a"
 }

--- a/docs/source/data/release_proof.toml
+++ b/docs/source/data/release_proof.toml
@@ -39,40 +39,40 @@ dataset_release_url = "https://github.com/ThalesGroup/agilab/releases/tag/datase
 id = "release-guardrails"
 label = "Public guardrails"
 workflow = "repo-guardrails"
-run_id = "27912098773"
-url = "https://github.com/ThalesGroup/agilab/actions/runs/27912098773"
+run_id = "28115253807"
+url = "https://github.com/ThalesGroup/agilab/actions/runs/28115253807"
 summary = "passed repository guardrails and clean package first-proof jobs"
 
 [[ci_runs]]
 id = "docs-source-guard"
 label = "Docs source guard"
 workflow = "docs-source-guard"
-run_id = "27912646471"
-url = "https://github.com/ThalesGroup/agilab/actions/runs/27912646471"
+run_id = "28115253719"
+url = "https://github.com/ThalesGroup/agilab/actions/runs/28115253719"
 summary = "passed docs mirror and release-proof consistency checks"
 
 [[ci_runs]]
 id = "docs-publish"
 label = "Docs publish"
 workflow = "docs-publish"
-run_id = "27912646482"
-url = "https://github.com/ThalesGroup/agilab/actions/runs/27912646482"
+run_id = "28115253710"
+url = "https://github.com/ThalesGroup/agilab/actions/runs/28115253710"
 summary = "built the public documentation from the managed docs mirror"
 
 [[ci_runs]]
 id = "coverage"
 label = "Coverage"
 workflow = "coverage"
-run_id = "27912098776"
-url = "https://github.com/ThalesGroup/agilab/actions/runs/27912098776"
+run_id = "28114104330"
+url = "https://github.com/ThalesGroup/agilab/actions/runs/28114104330"
 summary = "passed component coverage and badge freshness checks"
 
 [[ci_runs]]
 id = "pypi-publish"
 label = "PyPI publish"
 workflow = "pypi-publish"
-run_id = "27786476047"
-url = "https://github.com/ThalesGroup/agilab/actions/runs/27786476047"
+run_id = "28114310650"
+url = "https://github.com/ThalesGroup/agilab/actions/runs/28114310650"
 summary = "passed the public release proof workflow gate"
 
 [proof_command]

--- a/docs/source/release-proof.rst
+++ b/docs/source/release-proof.rst
@@ -26,15 +26,15 @@ Current public release
    * - Hosted demo
      - `jpmorard/agilab <https://huggingface.co/spaces/jpmorard/agilab>`__ at Space commit ``2eb4b21ac284d4fcc4ff65cb8efcd3a2b60d80de``
    * - Public guardrails
-     - `repo-guardrails run 27912098773 <https://github.com/ThalesGroup/agilab/actions/runs/27912098773>`__ passed repository guardrails and clean package first-proof jobs
+     - `repo-guardrails run 28115253807 <https://github.com/ThalesGroup/agilab/actions/runs/28115253807>`__ passed repository guardrails and clean package first-proof jobs
    * - Docs source guard
-     - `docs-source-guard run 27912646471 <https://github.com/ThalesGroup/agilab/actions/runs/27912646471>`__ passed docs mirror and release-proof consistency checks
+     - `docs-source-guard run 28115253719 <https://github.com/ThalesGroup/agilab/actions/runs/28115253719>`__ passed docs mirror and release-proof consistency checks
    * - Docs publish
-     - `docs-publish run 27912646482 <https://github.com/ThalesGroup/agilab/actions/runs/27912646482>`__ built the public documentation from the managed docs mirror
+     - `docs-publish run 28115253710 <https://github.com/ThalesGroup/agilab/actions/runs/28115253710>`__ built the public documentation from the managed docs mirror
    * - Coverage
-     - `coverage run 27912098776 <https://github.com/ThalesGroup/agilab/actions/runs/27912098776>`__ passed component coverage and badge freshness checks
+     - `coverage run 28114104330 <https://github.com/ThalesGroup/agilab/actions/runs/28114104330>`__ passed component coverage and badge freshness checks
    * - PyPI publish
-     - `pypi-publish run 27786476047 <https://github.com/ThalesGroup/agilab/actions/runs/27786476047>`__ passed the public release proof workflow gate
+     - `pypi-publish run 28114310650 <https://github.com/ThalesGroup/agilab/actions/runs/28114310650>`__ passed the public release proof workflow gate
 
 What was proved
 ---------------


### PR DESCRIPTION
## Summary

- Refresh AGILAB public release proof for `2026.06.24` after the release workflow completed.
- Record current CI evidence, including `pypi-publish` run `28114310650`.
- Sync the managed docs mirror stamp from canonical `thales_agilab` docs.

## Validation

- `tools/sync_docs_source.py --source ../thales_agilab/docs/source --target docs/source --verify-stamp`: passed.
- `tools/release_proof_report.py --check --check-github-runs --compact`: passed.
- `tools/workflow_parity.py --profile docs`: passed.
- Stale release/run grep for `v2026.06.23`, `2026.06.23`, and old CI run IDs in release-proof sources: no matches.

## Review Evidence

No sub-agent review was used for this PR.

## Agent Metadata

- Tokki version: `1.0.10`
- Agent/runtime: Codex CLI, version unavailable
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used

## GitHub Checks

- GitGuardian Security Checks: passed.
- `verify`: passed.
- `clean-public-install` on macOS, Ubuntu, and Windows: passed.
- `local-only-policy`: passed.
- `public-demo-smoke`: skipped by workflow condition.
