### PR TITLE
[codex] Optimize Tokki profile for AGILAB

### DIFF
--- a/.tokki/model-free-commands
+++ b/.tokki/model-free-commands
@@ -9,6 +9,8 @@ exact ./dev docs
 exact ./dev --print-only docs
 exact ./dev release
 exact ./dev --print-only release
+exact ./dev badge
+exact ./dev --print-only badge
 exact ./dev parallel-stage
 exact ./dev app-contracts
 exact ./dev builtin-app-tests
@@ -16,16 +18,22 @@ exact ./dev maintenance
 exact ./dev memory
 exact ./dev warnings
 exact ./dev audit
+exact ./dev audit --strict
 exact ./dev ui-flow
 exact ./dev bugfix
 exact ./dev flow docs
+exact ./dev flow release-proof
 exact ./dev flow dependency-policy
 exact ./dev flow shared-core-typing
 exact ./dev flow builtin-app-tests
+exact uv --preview-features extra-build-dependencies run python tools/agent_context_router.py --check
+exact uv --preview-features extra-build-dependencies run python tools/release_proof_report.py --check --check-github-runs --compact
+exact uv --preview-features extra-build-dependencies run python tools/hf_space_smoke.py --json
 template ./dev impact --only <safe-component>
 template ./dev impact --files <safe-file>
 template ./dev test <safe-file>
 template ./dev flow <safe-component>
+template ./dev release --impact-base-ref <safe-ref>
 template ./dev task-worktree <safe-ref>
 template ./dev bugfix <safe-file>
 template ./dev regress <safe-selector>

--- a/.tokki/profile
+++ b/.tokki/profile
@@ -3,7 +3,14 @@ agilab-clean-worktree
 agilab-validation-shortcuts
 agilab-builtin-apps
 agilab-docs-mirror
+agilab-context-routing
+agilab-release-proof
+agilab-package-publishing
+agilab-huggingface-space
 agilab-pr-evidence
 model-free-agilab-validation
 model-free-dev-shortcuts
+model-free-release-proof
+model-free-workflow-parity
+model-free-hf-smoke
 model-free-git-push

--- a/.tokki/rules
+++ b/.tokki/rules
@@ -9,6 +9,9 @@
   run the exact focused tests it selects before broad profiles.
 - Prefer compact `./dev` output. Treat full logs as artifacts and summarize
   only signal: failing command, root cause, path, and next validation.
+- For ambiguous AGILAB work, ask `tools/agent_context_router.py --profile tokki`
+  for compact context before expanding to full repo reads. Impact validation
+  remains the source of truth for tests and artifact refreshes.
 
 ## Built-in apps and docs
 - Built-in app changes need app-local validation through
@@ -19,6 +22,25 @@
 - For docs, SVGs, and public mirror work, update canonical sources first,
   sync/verify the mirror, and compare references, captions, alt text, and
   rendered evidence before calling the docs aligned.
+
+## Release and public proof
+- For release planning, compute the impacted package graph first, then run the
+  same plan with `--skip-existing-pypi`. Do not equate "all artifacts already
+  exist" with "nothing should be released" when a version bump is intended.
+- Keep badges, release proof, docs, PyPI, GitHub Release, and Hugging Face
+  evidence tied to public truth. Do not pre-claim a new release in the badge or
+  proof page before the workflow publishes it and records the proof.
+- After release workflow success, verify the exact selected package set, the
+  GitHub Release assets, release-proof CI run IDs, docs Pages deployment, and
+  `tools/hf_space_smoke.py --json` before saying "all good".
+
+## Tokki model-free routing
+- Use model-free Tokki routes only for deterministic AGILAB checks that are
+  read-only or repo-local validation. Do not add mutating network operations
+  such as HF sync as generic model-free routes; require an explicit reviewed
+  capability for any such opt-in.
+- `tools/hf_space_smoke.py --json` is a read-only public smoke check and is safe
+  as a model-free validation route after releases or HF-alignment asks.
 
 ## Cluster, workers, and generated artifacts
 - If allocation artifacts show all `no_path` or `reject`, first compare them


### PR DESCRIPTION
## Summary

- Expand AGILAB's repo-local Tokki profile capabilities for release proof, package publishing, HF smoke, context routing, and workflow parity.
- Add compact profile rules for release/public-proof truth checks and safe model-free routing boundaries.
- Extend `.tokki/model-free-commands` with deterministic AGILAB validation routes such as badge guard, strict audit, release proof check, context-router check, and HF smoke.

## Validation

- `git diff --check`: passed.
- `tools/agent_context_router.py --check`: passed.
- `./dev --print-only badge`: passed.
- `TOKKI_REPO_TRUST=trusted tokki context --json --task 'release proof check'`: profile rules loaded.
- `tools/impact_validate.py --files .tokki/profile .tokki/rules .tokki/model-free-commands`: low risk; requested one narrow pytest slice.
- `pytest -q -o addopts='' test/test_profile_supply_chain_scan.py`: 4 passed.

## Review Evidence

No sub-agent review was used for this PR.

## Agent Metadata

- Tokki version: `1.0.10`
- Agent/runtime: Codex CLI, version unavailable
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used

## GitHub Checks

- GitGuardian Security Checks: passed.
- `clean-public-install` on macOS, Ubuntu, and Windows: passed.
- `local-only-policy`: passed.
- `public-demo-smoke`: skipped by workflow condition.
