### PR TITLE
[codex] Sync simplified documentation quality bar

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 277,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "ef046ca4832452d6b07ee28b5a12c22d18ea63f8e5b37c4ad99adf8b4379c18a",
+  "source_digest_sha256": "db1e777a0f9ea357a135970a37096c96aa98ce31589e6c98a9e8fc6994313424",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "ef046ca4832452d6b07ee28b5a12c22d18ea63f8e5b37c4ad99adf8b4379c18a"
+  "target_digest_sha256": "db1e777a0f9ea357a135970a37096c96aa98ce31589e6c98a9e8fc6994313424"
 }

--- a/docs/source/contributor-guide.rst
+++ b/docs/source/contributor-guide.rst
@@ -75,7 +75,7 @@ Use the smallest command that proves your change:
    * - Root docs only
      - ``git diff --check``
    * - Sphinx docs source
-     - mirror sync plus stamp verification
+     - ``tools/sync_docs_source.py --verify-stamp`` in the public mirror, after maintainer sync
    * - Workflow parity
      - ``uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile <name>``
    * - Skill catalog
@@ -107,17 +107,17 @@ request, check the page against this quality bar:
   competitive positioning, local-only paths, and unsupported production-safety
   claims. When AGILAB needs MLflow, Kubeflow, Airflow, SageMaker, or an internal
   platform for production responsibilities, say so directly.
-- **Source/mirror parity**: edit canonical docs in the sibling
+- **Source/mirror parity**: external contributors can edit the public docs
+  source in their pull request. Maintainers reconcile the canonical
   ``../thales_agilab/docs/source`` tree, sync this repository's ``docs/source``
   mirror, verify the mirror stamp, and build the rendered page when layout or
   links matter. Never hand-edit ``docs/html``.
 - **Screenshots and diagrams**: update source screenshots, SVG diagrams,
   captions, alt text, and references together. Inspect the rendered page so old
   UI labels or clipped diagram text cannot survive a source-only edit.
-- **Agent-readable surfaces**: when docs change a command, app, page, schema, or
-  evidence artifact that agents should discover, keep ``llms.txt``,
-  ``agenticweb.md``, and ``agilab-capabilities.json`` aligned through their
-  existing generators or checks.
+- **Generated discovery surfaces**: if a docs change alters public commands,
+  pages, schemas, apps, or evidence artifacts, note it in the pull request so
+  maintainers can refresh generated discovery surfaces.
 
 Pull request evidence
 ---------------------


### PR DESCRIPTION
## Summary

- Sync the simplified contributor documentation quality bar from canonical `thales_agilab` docs.
- Clarify public contributor versus maintainer docs-mirror responsibilities.
- Refresh the managed docs mirror stamp.

## Why

The public contributor guide should stay actionable for normal contributors while preserving the maintainer-only canonical docs and mirror workflow.

## Validation

Validation passed.

## Validation Detail

- `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --source /Users/agi/PycharmProjects/thales_agilab/docs/source --apply --delete`
- `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --target docs/source --verify-stamp`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files docs/source/contributor-guide.rst docs/.docs_source_mirror_stamp.json`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs`
- `git diff --check`

## Remote Evidence

- PR checks passed: `verify`, `local-only-policy`, `clean-public-install (macos-latest)`, `clean-public-install (ubuntu-latest)`, `clean-public-install (windows-latest)`, and `GitGuardian Security Checks`.
- `public-demo-smoke` was skipped by workflow.

## Notes

- The canonical docs source PR is `jpmorard/thales_agilab#105`, merged.
- This work was done from a clean AGILAB worktree to avoid mixing unrelated local `.tokki/*` changes in the main checkout.

## Review Evidence

No external model or sub-agent review was used for this PR.

## Agent Metadata

- Tokki version: `tokki 1.0.10`
- Agent/runtime: Codex CLI / GPT-5 Codex
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used
