### PR TITLE
[codex] Sync final contributor guide simplification

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 277,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "db1e777a0f9ea357a135970a37096c96aa98ce31589e6c98a9e8fc6994313424",
+  "source_digest_sha256": "81ec54eef35c12c9061a7200a37b20aac4f14221d0624689742912f389b17499",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "db1e777a0f9ea357a135970a37096c96aa98ce31589e6c98a9e8fc6994313424"
+  "target_digest_sha256": "81ec54eef35c12c9061a7200a37b20aac4f14221d0624689742912f389b17499"
 }

--- a/docs/source/contributor-guide.rst
+++ b/docs/source/contributor-guide.rst
@@ -75,7 +75,7 @@ Use the smallest command that proves your change:
    * - Root docs only
      - ``git diff --check``
    * - Sphinx docs source
-     - ``tools/sync_docs_source.py --verify-stamp`` in the public mirror, after maintainer sync
+     - ``uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp`` after maintainer sync
    * - Workflow parity
      - ``uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile <name>``
    * - Skill catalog
@@ -115,9 +115,9 @@ request, check the page against this quality bar:
 - **Screenshots and diagrams**: update source screenshots, SVG diagrams,
   captions, alt text, and references together. Inspect the rendered page so old
   UI labels or clipped diagram text cannot survive a source-only edit.
-- **Generated discovery surfaces**: if a docs change alters public commands,
-  pages, schemas, apps, or evidence artifacts, note it in the pull request so
-  maintainers can refresh generated discovery surfaces.
+- **Generated files**: if a docs change alters public commands, pages, schemas,
+  apps, or evidence artifacts, note it in the pull request so maintainers can
+  refresh generated files.
 
 Pull request evidence
 ---------------------


### PR DESCRIPTION
## Summary

- Sync the final contributor-guide simplification from canonical `thales_agilab` docs.
- Use the full `uv` mirror-stamp command in the Sphinx docs validation row.
- Rename the generated-discovery wording to simpler generated-file wording.
- Refresh the managed docs mirror stamp.

## Why

This closes the remaining simplification review findings after the documentation quality bar cleanup while keeping the public mirror aligned with canonical docs.

## Validation

Validation passed.

## Validation Detail

- `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --source /Users/agi/PycharmProjects/thales_agilab/docs/source --apply --delete`
- `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --target docs/source --verify-stamp`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files docs/source/contributor-guide.rst docs/.docs_source_mirror_stamp.json`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs`
- `git diff --check`

## Remote Evidence

- PR checks passed: `verify`, `local-only-policy`, `clean-public-install (macos-latest)`, `clean-public-install (ubuntu-latest)`, `clean-public-install (windows-latest)`, and `GitGuardian Security Checks`.
- `public-demo-smoke` was skipped by workflow.

## Notes

- The canonical docs source PR is `jpmorard/thales_agilab#106`, merged.
- This work was done from a clean AGILAB worktree to avoid mixing unrelated local `.tokki/*` changes in the main checkout.

## Review Evidence

No external model or sub-agent review was used for this PR.

## Agent Metadata

- Tokki version: `tokki 1.0.10`
- Agent/runtime: Codex CLI / GPT-5 Codex
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used
