### PR TITLE
[codex] Sync simplified contributor guide copy

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 277,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "81ec54eef35c12c9061a7200a37b20aac4f14221d0624689742912f389b17499",
+  "source_digest_sha256": "43885d2b9a60471bc1482eca6aa956b02eb8c51b9cd87d0e78f4bc4227bef261",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "81ec54eef35c12c9061a7200a37b20aac4f14221d0624689742912f389b17499"
+  "target_digest_sha256": "43885d2b9a60471bc1482eca6aa956b02eb8c51b9cd87d0e78f4bc4227bef261"
 }

--- a/docs/source/contributor-guide.rst
+++ b/docs/source/contributor-guide.rst
@@ -4,10 +4,10 @@ Contributor Guide
 This page is for people changing AGILAB itself. If you only want to try the
 product, start with :doc:`quick-start` instead.
 
-Contributor target
-------------------
+Contributor goal
+----------------
 
-Your first contribution should prove three things:
+A good first pull request shows three things:
 
 1. You can reproduce the public first proof.
 2. Your pull request has one clear scope.
@@ -34,7 +34,7 @@ the first failing log lines.
 Choose one lane
 ---------------
 
-Pick the closest lane before editing:
+Before editing, pick the closest lane:
 
 .. list-table::
    :header-rows: 1
@@ -91,13 +91,13 @@ GitHub Actions when the same failure can be reproduced locally.
 Documentation quality bar
 -------------------------
 
-Treat public documentation as product surface. Before opening a docs pull
-request, check the page against this quality bar:
+Treat public docs as product surface. Before opening a docs pull request,
+check:
 
 - **One reader, one next action**: name the intended reader, then make the next
   command, page, or proof artifact obvious. Avoid pages that explain many
   routes without telling the reader which route to start with.
-- **Executable commands**: prefer copy-pasteable commands with the current
+- **Executable commands**: use copy-pasteable commands with the current
   ``uv --preview-features extra-build-dependencies`` entrypoints. If a command
   is source-checkout-only, packaged-only, or maintainer-only, label it that way.
 - **Evidence over claims**: link claims about readiness, release status, demos,
@@ -107,11 +107,11 @@ request, check the page against this quality bar:
   competitive positioning, local-only paths, and unsupported production-safety
   claims. When AGILAB needs MLflow, Kubeflow, Airflow, SageMaker, or an internal
   platform for production responsibilities, say so directly.
-- **Source/mirror parity**: external contributors can edit the public docs
-  source in their pull request. Maintainers reconcile the canonical
-  ``../thales_agilab/docs/source`` tree, sync this repository's ``docs/source``
-  mirror, verify the mirror stamp, and build the rendered page when layout or
-  links matter. Never hand-edit ``docs/html``.
+- **Source/mirror parity**: contributors can edit public docs in their pull
+  request. Maintainers keep the canonical ``../thales_agilab/docs/source`` tree
+  and this repository's ``docs/source`` mirror aligned, verify the mirror stamp,
+  and build the page when layout or links matter. Never hand-edit
+  ``docs/html``.
 - **Screenshots and diagrams**: update source screenshots, SVG diagrams,
   captions, alt text, and references together. Inspect the rendered page so old
   UI labels or clipped diagram text cannot survive a source-only edit.


### PR DESCRIPTION
## Summary
- Syncs the canonical contributor guide copy simplification from `jpmorard/thales_agilab#107`.
- Updates the public docs mirror stamp after syncing `docs/source`.

## Scope
Docs-only public mirror sync.

## Validation
- `git diff --check`
- `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --target docs/source --verify-stamp`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files docs/source/contributor-guide.rst docs/.docs_source_mirror_stamp.json`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs`
- Canonical docs: `uv run sphinx-build -n -q -b html docs/source docs/_build/html`

## Remote Checks
- docs-source-guard / verify: passed
- repo-guardrails / local-only-policy: passed
- repo-guardrails / clean-public-install (ubuntu-latest): passed
- repo-guardrails / clean-public-install (macos-latest): passed
- repo-guardrails / clean-public-install (windows-latest): passed
- GitGuardian Security Checks: passed
- repo-guardrails / public-demo-smoke: skipped by workflow

## Risk area
Docs.

## Generated artifacts updated
Yes: `docs/.docs_source_mirror_stamp.json`.

## Review Evidence
Not used.

## Agent Metadata
- Tokki version: 1.0.10
- Agent/runtime: Codex GPT-5
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used
