### PR TITLE
[codex] Sync simplified PR evidence guidance

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 277,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "43885d2b9a60471bc1482eca6aa956b02eb8c51b9cd87d0e78f4bc4227bef261",
+  "source_digest_sha256": "9380d5a68db27a077a5330e05903a328ad0a56b3c6bcc849157ed24b795c6a6d",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "43885d2b9a60471bc1482eca6aa956b02eb8c51b9cd87d0e78f4bc4227bef261"
+  "target_digest_sha256": "9380d5a68db27a077a5330e05903a328ad0a56b3c6bcc849157ed24b795c6a6d"
 }

--- a/docs/source/contributor-guide.rst
+++ b/docs/source/contributor-guide.rst
@@ -122,18 +122,18 @@ check:
 Pull request evidence
 ---------------------
 
-Paste a short evidence block in every pull request:
+Use one short evidence block in every pull request:
 
 .. code-block:: text
 
    Scope:
    Validation:
    Risk area: docs | app | UI | workflow | shared core | security | dependency
+   Touched areas: public docs | dependencies | security | release tooling | generated files | shared core | none
    Generated artifacts updated: yes/no
 
-Also state whether the change touches public documentation, dependencies,
-security, release tooling, generated files, or shared core. These areas need
-more careful review than an app-local or docs-only change.
+If none of the touched areas apply, write ``none``. Those areas need more
+careful review than an app-local or docs-only change.
 
 Review expectations
 -------------------


### PR DESCRIPTION
## Summary
- Syncs the canonical PR evidence guidance simplification from `jpmorard/thales_agilab#108`.
- Updates the public docs mirror stamp after syncing `docs/source`.

## Scope
Docs-only public mirror sync.

## Validation
- `git diff --check`
- `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --target docs/source --verify-stamp`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files docs/source/contributor-guide.rst docs/.docs_source_mirror_stamp.json`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs`
- Canonical docs: `uv run sphinx-build -n -q -b html docs/source docs/_build/html`

## Remote Checks
- docs-source-guard / verify: passed
- repo-guardrails / local-only-policy: passed
- repo-guardrails / clean-public-install (ubuntu-latest): passed
- repo-guardrails / clean-public-install (macos-latest): passed
- repo-guardrails / clean-public-install (windows-latest): passed
- GitGuardian Security Checks: passed
- repo-guardrails / public-demo-smoke: skipped by workflow

## Risk area
Docs.

## Generated artifacts updated
Yes: `docs/.docs_source_mirror_stamp.json`.

## Review Evidence
Not used.

## Agent Metadata
- Tokki version: 1.0.10
- Agent/runtime: Codex GPT-5
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used
