### PR TITLE
[codex] Sync simplified review expectations

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 277,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "9380d5a68db27a077a5330e05903a328ad0a56b3c6bcc849157ed24b795c6a6d",
+  "source_digest_sha256": "6b91659ff7956c77de820829d67117b16f782106314915e1fcad391f20fd08b4",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "9380d5a68db27a077a5330e05903a328ad0a56b3c6bcc849157ed24b795c6a6d"
+  "target_digest_sha256": "6b91659ff7956c77de820829d67117b16f782106314915e1fcad391f20fd08b4"
 }

--- a/docs/source/contributor-guide.rst
+++ b/docs/source/contributor-guide.rst
@@ -139,8 +139,8 @@ Review expectations
 -------------------
 
 - Pull requests need maintainer review before merge.
-- Shared core, release tooling, security-sensitive, dependency, and packaging
-  changes require review from an owner of that area.
+- Higher-risk areas need owner review: shared core, release tooling, security,
+  dependencies, and packaging.
 - ``main``, release tags, and publication workflows are maintainer-owned.
 - By submitting a pull request, you certify the Developer Certificate of Origin
   1.1 for your contribution. A separate CLA is not required for normal


### PR DESCRIPTION
## Summary
- Syncs the canonical review expectations simplification from `jpmorard/thales_agilab#109`.
- Updates the public docs mirror stamp after syncing `docs/source`.

## Scope
Docs-only public mirror sync.

## Validation
- `git diff --check`
- `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --target docs/source --verify-stamp`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files docs/source/contributor-guide.rst docs/.docs_source_mirror_stamp.json`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs`
- Canonical docs: `uv run sphinx-build -n -q -b html docs/source docs/_build/html`

## Remote Checks
- docs-source-guard / verify: passed
- repo-guardrails / local-only-policy: passed
- repo-guardrails / clean-public-install (ubuntu-latest): passed
- repo-guardrails / clean-public-install (macos-latest): passed
- repo-guardrails / clean-public-install (windows-latest): passed
- GitGuardian Security Checks: passed
- repo-guardrails / public-demo-smoke: skipped by workflow

## Risk area
Docs.

## Generated artifacts updated
Yes: `docs/.docs_source_mirror_stamp.json`.

## Review Evidence
Not used.

## Agent Metadata
- Tokki version: 1.0.10
- Agent/runtime: Codex GPT-5
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used
