### PR TITLE
Add browser UI load smoke timing

### DIFF
--- a/test/test_agilab_web_robot.py
+++ b/test/test_agilab_web_robot.py
@@ -259,6 +259,65 @@ def test_build_page_url_targets_streamlit_page_route() -> None:
     assert url == "http://127.0.0.1:8501/ANALYSIS?active_app=flight_telemetry_project"
 
 
+def test_page_load_smoke_pages_default_to_core_ui_pages() -> None:
+    module = _load_module()
+
+    assert module.resolve_page_load_pages(None) == (
+        "ABOUT",
+        "PROJECT",
+        "WORKFLOW",
+        "ANALYSIS",
+    )
+    assert module.resolve_page_load_pages(["WORKFLOW"]) == ("WORKFLOW",)
+
+
+def test_page_load_smoke_print_only_json_reports_route(capsys) -> None:
+    module = _load_module()
+
+    code = module.main(
+        [
+            "--print-only",
+            "--json",
+            "--page-load-smoke-only",
+            "--page-load-page",
+            "WORKFLOW",
+            "--port",
+            "9999",
+        ]
+    )
+
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["page_load_pages"] == ["WORKFLOW"]
+    assert payload["route"] == ["WORKFLOW first visible render"]
+
+
+def test_page_load_smoke_print_only_writes_json_output(tmp_path: Path) -> None:
+    module = _load_module()
+    output_path = tmp_path / "page-load.json"
+
+    code = module.main(
+        [
+            "--print-only",
+            "--page-load-smoke-only",
+            "--json-output",
+            str(output_path),
+            "--port",
+            "9999",
+        ]
+    )
+
+    assert code == 0
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert payload["page_load_pages"] == ["ABOUT", "PROJECT", "WORKFLOW", "ANALYSIS"]
+    assert payload["route"] == [
+        "ABOUT first visible render",
+        "PROJECT first visible render",
+        "WORKFLOW first visible render",
+        "ANALYSIS first visible render",
+    ]
+
+
 def test_resolve_local_active_app_accepts_builtin_project_name() -> None:
     module = _load_module()
 

--- a/test/test_perf_smoke.py
+++ b/test/test_perf_smoke.py
@@ -34,10 +34,18 @@ def test_scenario_catalog_contains_expected_builtins() -> None:
     assert "ui-orchestrate-page-import" in scenarios
     assert "ui-workflow-page-import" in scenarios
     assert "ui-analysis-page-import" in scenarios
+    assert "ui-browser-core-page-load" in scenarios
     assert scenarios["base-worker-import"].command[0] == sys.executable
     assert "1_PROJECT_STATUS.py" in " ".join(
         scenarios["ui-project-status-page-import"].command
     )
+    browser_command = scenarios["ui-browser-core-page-load"].command
+    assert browser_command[0] == sys.executable
+    assert "agilab_web_robot.py" in browser_command[1]
+    assert "--page-load-smoke-only" in browser_command
+    assert "--json-output" in browser_command
+    for page_name in ("ABOUT", "PROJECT", "WORKFLOW", "ANALYSIS"):
+        assert page_name in browser_command
 
 
 def test_repo_python_paths_deduplicates_extra_paths() -> None:

--- a/tools/agilab_web_robot.py
+++ b/tools/agilab_web_robot.py
@@ -239,6 +239,39 @@ class StreamlitServer:
         return output[-limit:]
 
 
+PAGE_LOAD_SMOKE_PAGES = {
+    "ABOUT": {
+        "route": None,
+        "expect_any": ("First proof", "Explore more proof routes"),
+    },
+    "PROJECT": {
+        "route": "PROJECT",
+        "expect_any": ("PROJECT", "Create project", "Notebook"),
+    },
+    "WORKFLOW": {
+        "route": "WORKFLOW",
+        "expect_any": ("WORKFLOW", "Pipeline", "Stages"),
+    },
+    "ANALYSIS": {
+        "route": "ANALYSIS",
+        "expect_any": ("ANALYSIS", "Choose pages", "View:"),
+    },
+}
+DEFAULT_PAGE_LOAD_SMOKE_PAGES = ("ABOUT", "PROJECT", "WORKFLOW", "ANALYSIS")
+
+
+def resolve_page_load_pages(page_names: Sequence[str] | None) -> tuple[str, ...]:
+    selected = tuple(page_names or DEFAULT_PAGE_LOAD_SMOKE_PAGES)
+    unknown = [name for name in selected if name not in PAGE_LOAD_SMOKE_PAGES]
+    if unknown:
+        raise ValueError(f"unknown page-load smoke page(s): {', '.join(unknown)}")
+    return selected
+
+
+def _page_load_smoke_route(page_names: Sequence[str]) -> list[str]:
+    return [f"{name} first visible render" for name in page_names]
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description=(
@@ -308,6 +341,23 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--page-load-smoke-only",
+        action="store_true",
+        help=(
+            "Open selected core Streamlit pages in a real browser and record first "
+            "visible render timings without running the full workflow robot."
+        ),
+    )
+    parser.add_argument(
+        "--page-load-page",
+        action="append",
+        choices=sorted(PAGE_LOAD_SMOKE_PAGES),
+        help=(
+            "Core page to include with --page-load-smoke-only. May be repeated. "
+            "Defaults to ABOUT, PROJECT, WORKFLOW, and ANALYSIS."
+        ),
+    )
+    parser.add_argument(
         "--dev-scope-before-smoke",
         action="store_true",
         help=(
@@ -318,6 +368,10 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+    parser.add_argument(
+        "--json-output",
+        help="Optional path where the machine-readable JSON payload is written.",
+    )
     parser.add_argument(
         "--print-only",
         action="store_true",
@@ -954,6 +1008,94 @@ def run_browser_robot(
     return steps
 
 
+def run_page_load_smoke(
+    *,
+    base_url: str,
+    active_app_query: str,
+    browser_name: str,
+    headless: bool,
+    timeout: float,
+    page_names: Sequence[str],
+    screenshot_dir: Path | None = None,
+) -> list[RobotStep]:
+    Error, TimeoutError, sync_playwright = _load_playwright()
+    timeout_ms = timeout * 1000.0
+    steps: list[RobotStep] = []
+    selected_pages = resolve_page_load_pages(page_names)
+
+    try:
+        with sync_playwright() as playwright:
+            browser_type = getattr(playwright, browser_name)
+            browser = browser_type.launch(headless=headless)
+            context = browser.new_context(viewport={"width": 1440, "height": 1000})
+            try:
+                page = context.new_page()
+                for page_name in selected_pages:
+                    page_config = PAGE_LOAD_SMOKE_PAGES[page_name]
+                    route = page_config["route"]
+                    target_url = (
+                        build_url(base_url, active_app=active_app_query)
+                        if route is None
+                        else build_page_url(base_url, str(route), active_app=active_app_query)
+                    )
+                    label = f"{page_name} first visible render"
+                    start = time.perf_counter()
+                    try:
+                        page.goto(target_url, wait_until="domcontentloaded", timeout=timeout_ms)
+                        health = assert_page_healthy(
+                            page,
+                            label=label,
+                            expect_any=tuple(page_config["expect_any"]),
+                            timeout_ms=timeout_ms,
+                            screenshot_dir=screenshot_dir,
+                        )
+                        duration = time.perf_counter() - start
+                        if health.success:
+                            steps.append(
+                                RobotStep(
+                                    label,
+                                    True,
+                                    duration,
+                                    "page reached first visible marker",
+                                    page.url,
+                                )
+                            )
+                            continue
+                        steps.append(
+                            RobotStep(
+                                label,
+                                False,
+                                duration,
+                                health.detail,
+                                health.url,
+                            )
+                        )
+                        return steps
+                    except (Error, TimeoutError) as exc:
+                        screenshot = _screenshot(page, screenshot_dir, label)
+                        detail = f"page did not reach first visible marker: {exc}"
+                        if screenshot:
+                            detail += f"; screenshot={screenshot}"
+                        steps.append(
+                            RobotStep(
+                                label,
+                                False,
+                                time.perf_counter() - start,
+                                detail,
+                                getattr(page, "url", target_url),
+                            )
+                        )
+                        return steps
+            finally:
+                context.close()
+                browser.close()
+    except RuntimeError:
+        raise
+    except (Error, TimeoutError) as exc:
+        steps.append(RobotStep("page-load browser", False, 0.0, f"playwright failed: {exc}", base_url))
+    return steps
+
+
 def run_frontend_smoke(
     *,
     base_url: str,
@@ -1058,6 +1200,12 @@ def _print_json(payload: object) -> None:
     print(json.dumps(payload, indent=2))
 
 
+def _write_json_output(payload: object, path: str) -> None:
+    output_path = Path(path).expanduser()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
 def _frontend_smoke_route(*, dev_scope_before_smoke: bool = False) -> list[str]:
     route = ["frontend static assets", "frontend landing hydration"]
     if dev_scope_before_smoke:
@@ -1082,6 +1230,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         parser.error("--timeout must be greater than 0")
     if args.target_seconds <= 0:
         parser.error("--target-seconds must be greater than 0")
+    if args.frontend_smoke_only and args.page_load_smoke_only:
+        parser.error("--frontend-smoke-only and --page-load-smoke-only are mutually exclusive")
+    if args.page_load_page and not args.page_load_smoke_only:
+        parser.error("--page-load-page requires --page-load-smoke-only")
     if args.dev_scope_before_smoke and not args.frontend_smoke_only:
         parser.error("--dev-scope-before-smoke requires --frontend-smoke-only")
     if args.dev_scope_before_smoke and args.url:
@@ -1101,17 +1253,23 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
 
     if args.print_only:
+        page_load_pages = resolve_page_load_pages(args.page_load_page)
         route = (
+            _page_load_smoke_route(page_load_pages)
+            if args.page_load_smoke_only
+            else (
             _frontend_smoke_route(
                 dev_scope_before_smoke=args.dev_scope_before_smoke
             )
             if args.frontend_smoke_only
             else _full_robot_route()
+            )
         )
         payload = {
             "base_url": base_url,
             "launch_command": launch_command,
             "route": route,
+            "page_load_pages": list(page_load_pages) if args.page_load_smoke_only else None,
             "analysis_view": args.analysis_view,
             "analysis_view_path": (
                 resolve_analysis_view_path(
@@ -1123,6 +1281,8 @@ def main(argv: Sequence[str] | None = None) -> int:
                 else None
             ),
         }
+        if args.json_output:
+            _write_json_output(payload, args.json_output)
         if args.json:
             _print_json(payload)
         else:
@@ -1172,6 +1332,18 @@ def main(argv: Sequence[str] | None = None) -> int:
                                     screenshot_dir=screenshot_dir,
                                 )
                             )
+                    elif args.page_load_smoke_only:
+                        steps.extend(
+                            run_page_load_smoke(
+                                base_url=base_url,
+                                active_app_query=active_app_query,
+                                browser_name=args.browser,
+                                headless=not args.headful,
+                                timeout=args.timeout,
+                                page_names=resolve_page_load_pages(args.page_load_page),
+                                screenshot_dir=screenshot_dir,
+                            )
+                        )
                     else:
                         steps.extend(
                             run_browser_robot(
@@ -1207,6 +1379,18 @@ def main(argv: Sequence[str] | None = None) -> int:
                         screenshot_dir=screenshot_dir,
                     )
                 )
+            elif args.page_load_smoke_only:
+                steps.extend(
+                    run_page_load_smoke(
+                        base_url=base_url,
+                        active_app_query=active_app_query,
+                        browser_name=args.browser,
+                        headless=not args.headful,
+                        timeout=args.timeout,
+                        page_names=resolve_page_load_pages(args.page_load_page),
+                        screenshot_dir=screenshot_dir,
+                    )
+                )
             else:
                 steps.extend(
                     run_browser_robot(
@@ -1224,8 +1408,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         steps.append(RobotStep("browser setup", False, 0.0, str(exc), base_url))
 
     summary = summarize_steps(steps, target_seconds=args.target_seconds)
+    payload = asdict(summary)
+    if args.json_output:
+        _write_json_output(payload, args.json_output)
     if args.json:
-        _print_json(asdict(summary))
+        _print_json(payload)
     else:
         print(render_human(summary=summary, launch_command=launch_command, base_url=base_url))
     return 0 if summary.success else 1

--- a/tools/perf_smoke.py
+++ b/tools/perf_smoke.py
@@ -99,6 +99,26 @@ def _file_import_command(
     return (sys.executable, "-c", code)
 
 
+def _browser_core_page_load_command() -> tuple[str, ...]:
+    output_path = REPO_ROOT / "test-results/perf-smoke-ui-browser-core-page-load.json"
+    return (
+        sys.executable,
+        str(REPO_ROOT / "tools/agilab_web_robot.py"),
+        "--page-load-smoke-only",
+        "--page-load-page",
+        "ABOUT",
+        "--page-load-page",
+        "PROJECT",
+        "--page-load-page",
+        "WORKFLOW",
+        "--page-load-page",
+        "ANALYSIS",
+        "--json",
+        "--json-output",
+        str(output_path),
+    )
+
+
 def scenario_catalog() -> dict[str, PerfScenario]:
     maps_network_src = REPO_ROOT / "src/agilab/apps-pages/view_maps_network/src"
     maps_3d_src = REPO_ROOT / "src/agilab/apps-pages/view_maps_3d/src"
@@ -181,6 +201,14 @@ def scenario_catalog() -> dict[str, PerfScenario]:
                 streamlit_pages_root / "4_ANALYSIS.py",
                 "agilab_perf_ui_analysis_page",
             ),
+        ),
+        "ui-browser-core-page-load": PerfScenario(
+            name="ui-browser-core-page-load",
+            description=(
+                "Real-browser first-visible render smoke for ABOUT, PROJECT, "
+                "WORKFLOW, and ANALYSIS."
+            ),
+            command=_browser_core_page_load_command(),
         ),
     }
 


### PR DESCRIPTION
## Summary
- add a page-load smoke mode to `tools/agilab_web_robot.py` that records first-visible render timing for ABOUT, PROJECT, WORKFLOW, and ANALYSIS in a real browser
- add optional JSON artifact output for robot payloads
- expose the browser load pass as `tools/perf_smoke.py --scenario ui-browser-core-page-load`
- cover page selection, print-only routing, artifact output, and perf-smoke command wiring

## Validation
- `uv --preview-features extra-build-dependencies run python -m py_compile tools/agilab_web_robot.py tools/perf_smoke.py`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' --import-mode=importlib test/test_perf_smoke.py test/test_agilab_web_robot.py -k 'perf_smoke or page_load_smoke or web_robot_entrypoint_help'` (`16 passed`)
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files tools/agilab_web_robot.py tools/perf_smoke.py test/test_agilab_web_robot.py test/test_perf_smoke.py`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_agilab_web_robot.py test/test_perf_smoke.py` (`95 passed`)
- `uv --preview-features extra-build-dependencies run --with playwright python tools/agilab_web_robot.py --page-load-smoke-only --timeout 30 --target-seconds 120 --json-output test-results/agilab-browser-page-load-smoke.json --json`
- `./dev scope`
- `git diff --check`

## Browser Timing Sample
- Streamlit health: `0.5145s`
- ABOUT first visible render: `0.9263s`
- PROJECT first visible render: `0.2953s`
- WORKFLOW first visible render: `0.5456s`
- ANALYSIS first visible render: `0.7472s`
- Total measured robot duration: `3.0289s`

## Agent Metadata
- Tokki version: `tokki 1.0.10`
- Agent/runtime: Codex API session, runtime version unavailable
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used
