### PR TITLE
[codex] Sync simplified baseline failure guidance

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 277,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "6b91659ff7956c77de820829d67117b16f782106314915e1fcad391f20fd08b4",
+  "source_digest_sha256": "973031cc3f3ee466d12431ea08df8fe94b7af3787d00f3460e8f6658c1d2b216",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "6b91659ff7956c77de820829d67117b16f782106314915e1fcad391f20fd08b4"
+  "target_digest_sha256": "973031cc3f3ee466d12431ea08df8fe94b7af3787d00f3460e8f6658c1d2b216"
 }

--- a/docs/source/contributor-guide.rst
+++ b/docs/source/contributor-guide.rst
@@ -26,10 +26,10 @@ Run this once from a clean source checkout:
    uv --preview-features extra-build-dependencies sync --group dev
    uv --preview-features extra-build-dependencies run python tools/newcomer_first_proof.py
 
-If the proof fails, do not branch into clusters, private app repositories, or
-large refactors yet. Use :doc:`newcomer-troubleshooting` first, or open a
-GitHub issue with ``[CONTRIBUTOR]`` in the title and include the command plus
-the first failing log lines.
+If the proof fails, stay on the newcomer path: use
+:doc:`newcomer-troubleshooting` or open a GitHub issue with ``[CONTRIBUTOR]``
+in the title, the command you ran, and the first failing log lines. Do not
+jump into clusters, private app repositories, or large refactors yet.
 
 Choose one lane
 ---------------


### PR DESCRIPTION
## Summary
- Syncs the canonical baseline failure guidance simplification from `jpmorard/thales_agilab#110`.
- Updates the public docs mirror stamp after syncing `docs/source`.

## Scope
Docs-only public mirror sync.

## Validation
- `git diff --check`
- `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --target docs/source --verify-stamp`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files docs/source/contributor-guide.rst docs/.docs_source_mirror_stamp.json`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs`
- Canonical docs: `uv run sphinx-build -n -q -b html docs/source docs/_build/html`

## Remote Checks
- docs-source-guard / verify: passed
- repo-guardrails / local-only-policy: passed
- repo-guardrails / clean-public-install (ubuntu-latest): passed
- repo-guardrails / clean-public-install (macos-latest): passed
- repo-guardrails / clean-public-install (windows-latest): passed
- GitGuardian Security Checks: passed
- repo-guardrails / public-demo-smoke: skipped by workflow

## Risk area
Docs.

## Generated artifacts updated
Yes: `docs/.docs_source_mirror_stamp.json`.

## Review Evidence
Not used.

## Agent Metadata
- Tokki version: 1.0.10
- Agent/runtime: Codex GPT-5
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used
