### PR TITLE
Add advisory UI load budgets

### DIFF
--- a/test/test_agilab_web_robot.py
+++ b/test/test_agilab_web_robot.py
@@ -318,6 +318,77 @@ def test_page_load_smoke_print_only_writes_json_output(tmp_path: Path) -> None:
     ]
 
 
+def test_page_load_budget_warnings_are_advisory() -> None:
+    module = _load_module()
+
+    warnings = module._page_load_budget_warnings(
+        [
+            module.RobotStep(
+                "ABOUT first visible render",
+                True,
+                1.25,
+                "page reached first visible marker",
+                "http://demo/",
+            ),
+            module.RobotStep(
+                "PROJECT first visible render",
+                True,
+                0.25,
+                "page reached first visible marker",
+                "http://demo/PROJECT",
+            ),
+        ],
+        ["ABOUT", "PROJECT"],
+    )
+
+    assert warnings == [
+        "ABOUT first visible render 1.250s exceeds advisory budget 1.200s"
+    ]
+
+
+def test_page_load_budget_warnings_include_total_budget() -> None:
+    module = _load_module()
+
+    warnings = module._page_load_budget_warnings(
+        [
+            module.RobotStep(
+                "ABOUT first visible render",
+                True,
+                1.0,
+                "page reached first visible marker",
+                "http://demo/",
+            ),
+            module.RobotStep(
+                "PROJECT first visible render",
+                True,
+                0.7,
+                "page reached first visible marker",
+                "http://demo/PROJECT",
+            ),
+            module.RobotStep(
+                "WORKFLOW first visible render",
+                True,
+                0.7,
+                "page reached first visible marker",
+                "http://demo/WORKFLOW",
+            ),
+            module.RobotStep(
+                "ANALYSIS first visible render",
+                True,
+                2.7,
+                "page reached first visible marker",
+                "http://demo/ANALYSIS",
+            ),
+        ],
+        ["ABOUT", "PROJECT", "WORKFLOW", "ANALYSIS"],
+    )
+
+    assert warnings == [
+        "ANALYSIS first visible render 2.700s exceeds advisory budget 1.000s",
+        "page-load total 5.100s exceeds advisory budget 5.000s",
+    ]
+
+
 def test_resolve_local_active_app_accepts_builtin_project_name() -> None:
     module = _load_module()
 

--- a/tools/agilab_web_robot.py
+++ b/tools/agilab_web_robot.py
@@ -243,21 +243,26 @@ PAGE_LOAD_SMOKE_PAGES = {
     "ABOUT": {
         "route": None,
         "expect_any": ("First proof", "Explore more proof routes"),
+        "budget_seconds": 1.2,
     },
     "PROJECT": {
         "route": "PROJECT",
         "expect_any": ("PROJECT", "Create project", "Notebook"),
+        "budget_seconds": 0.8,
     },
     "WORKFLOW": {
         "route": "WORKFLOW",
         "expect_any": ("WORKFLOW", "Pipeline", "Stages"),
+        "budget_seconds": 0.8,
     },
     "ANALYSIS": {
         "route": "ANALYSIS",
         "expect_any": ("ANALYSIS", "Choose pages", "View:"),
+        "budget_seconds": 1.0,
     },
 }
 DEFAULT_PAGE_LOAD_SMOKE_PAGES = ("ABOUT", "PROJECT", "WORKFLOW", "ANALYSIS")
+PAGE_LOAD_TOTAL_BUDGET_SECONDS = 5.0
 
 
 def resolve_page_load_pages(page_names: Sequence[str] | None) -> tuple[str, ...]:
@@ -270,6 +275,29 @@ def resolve_page_load_pages(page_names: Sequence[str] | None) -> tuple[str, ...]
 
 def _page_load_smoke_route(page_names: Sequence[str]) -> list[str]:
     return [f"{name} first visible render" for name in page_names]
+
+
+def _page_load_budget_warnings(
+    page_steps: Sequence[RobotStep],
+    page_names: Sequence[str],
+) -> list[str]:
+    warnings: list[str] = []
+    total_seconds = sum(step.duration_seconds for step in page_steps if step.success)
+    for page_name, step in zip(page_names, page_steps):
+        if not step.success:
+            continue
+        budget = PAGE_LOAD_SMOKE_PAGES[page_name].get("budget_seconds")
+        if isinstance(budget, (float, int)) and step.duration_seconds > float(budget):
+            warnings.append(
+                f"{page_name} first visible render {step.duration_seconds:.3f}s "
+                f"exceeds advisory budget {float(budget):.3f}s"
+            )
+    if total_seconds > PAGE_LOAD_TOTAL_BUDGET_SECONDS:
+        warnings.append(
+            f"page-load total {total_seconds:.3f}s exceeds advisory budget "
+            f"{PAGE_LOAD_TOTAL_BUDGET_SECONDS:.3f}s"
+        )
+    return warnings
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -1030,6 +1058,7 @@ def run_page_load_smoke(
             context = browser.new_context(viewport={"width": 1440, "height": 1000})
             try:
                 page = context.new_page()
+                page_steps: list[RobotStep] = []
                 for page_name in selected_pages:
                     page_config = PAGE_LOAD_SMOKE_PAGES[page_name]
                     route = page_config["route"]
@@ -1051,15 +1080,15 @@ def run_page_load_smoke(
                         )
                         duration = time.perf_counter() - start
                         if health.success:
-                            steps.append(
-                                RobotStep(
-                                    label,
-                                    True,
-                                    duration,
-                                    "page reached first visible marker",
-                                    page.url,
-                                )
+                            step = RobotStep(
+                                label,
+                                True,
+                                duration,
+                                "page reached first visible marker",
+                                page.url,
                             )
+                            steps.append(step)
+                            page_steps.append(step)
                             continue
                         steps.append(
                             RobotStep(
@@ -1086,6 +1115,17 @@ def run_page_load_smoke(
                             )
                         )
                         return steps
+                budget_warnings = _page_load_budget_warnings(page_steps, selected_pages)
+                if budget_warnings:
+                    steps.append(
+                        RobotStep(
+                            "page-load advisory budget",
+                            True,
+                            0.0,
+                            "WARN: " + "; ".join(budget_warnings),
+                            page.url,
+                        )
+                    )
             finally:
                 context.close()
                 browser.close()


### PR DESCRIPTION
## Summary
- add advisory first-visible render budgets to the browser page-load smoke path
- emit non-failing `page-load advisory budget` warning steps when a page or total page-load budget is exceeded
- cover per-page and total-budget warning behavior in focused robot tests

## Validation
- `uv --preview-features extra-build-dependencies run python -m py_compile tools/agilab_web_robot.py`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' --import-mode=importlib test/test_agilab_web_robot.py -k 'page_load_budget or page_load_smoke'` (`5 passed`)
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files tools/agilab_web_robot.py test/test_agilab_web_robot.py`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_agilab_web_robot.py` (`85 passed`)
- `uv --preview-features extra-build-dependencies run --with playwright python tools/agilab_web_robot.py --page-load-smoke-only --timeout 30 --target-seconds 120 --json-output test-results/agilab-browser-page-load-budget-smoke.json --json`
- `./dev scope`
- `git diff --check`

## Browser Timing Sample
- Streamlit health: `1.0164s`
- ABOUT first visible render: `0.6200s` against advisory budget `1.200s`
- PROJECT first visible render: `0.2908s` against advisory budget `0.800s`
- WORKFLOW first visible render: `0.5304s` against advisory budget `0.800s`
- ANALYSIS first visible render: `0.7605s` against advisory budget `1.000s`
- Page-load total stayed below advisory budget `5.000s`; no warning step was emitted.

## Agent Metadata
- Tokki version: `tokki 1.0.10`
- Agent/runtime: Codex API session, runtime version unavailable
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used
