### PR TITLE
[codex] Sync simplified contributor lane table

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 277,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "973031cc3f3ee466d12431ea08df8fe94b7af3787d00f3460e8f6658c1d2b216",
+  "source_digest_sha256": "fa6e690e459823bda8bd3076b5a8d8bdf9429d9260c8e6781c7851aaf3603c27",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "973031cc3f3ee466d12431ea08df8fe94b7af3787d00f3460e8f6658c1d2b216"
+  "target_digest_sha256": "fa6e690e459823bda8bd3076b5a8d8bdf9429d9260c8e6781c7851aaf3603c27"
 }

--- a/docs/source/contributor-guide.rst
+++ b/docs/source/contributor-guide.rst
@@ -40,8 +40,8 @@ Before editing, pick the closest lane:
    :header-rows: 1
 
    * - Lane
-     - Good first scope
-     - First validation
+     - Typical scope
+     - First check
    * - Docs only
      - README, CONTRIBUTING, docs text, screenshots, links
      - ``git diff --check`` plus docs mirror checks if ``docs/source`` changes
@@ -56,10 +56,10 @@ Before editing, pick the closest lane:
      - Matching ``tools/workflow_parity.py --profile <name>``
    * - Shared core
      - ``src/agilab/core/*``, installer/build/deploy, generic runtime helpers
-     - Ask for maintainer approval first, then run the focused core regression plan
+     - Discuss with a maintainer first, then run the focused core regression plan
 
-Prefer docs, app-local, or UI-helper changes for a first pull request. Shared
-core has the highest blast radius because it can affect installation, worker
+For a first pull request, prefer docs, app-local, or UI-helper work. Shared core
+has the highest blast radius because it can affect installation, worker
 packaging, cluster execution, and packaged public examples.
 
 Validation map


### PR DESCRIPTION
## Summary
- Syncs the canonical contributor lane table simplification from `jpmorard/thales_agilab#111`.
- Updates the public docs mirror stamp after syncing `docs/source`.

## Scope
Docs-only public mirror sync.

## Validation
- `git diff --check`
- `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --target docs/source --verify-stamp`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files docs/source/contributor-guide.rst docs/.docs_source_mirror_stamp.json`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs`
- Canonical docs: `uv run sphinx-build -n -q -b html docs/source docs/_build/html`

## Remote Checks
- docs-source-guard / verify: passed
- repo-guardrails / local-only-policy: passed
- repo-guardrails / clean-public-install (ubuntu-latest): passed
- repo-guardrails / clean-public-install (macos-latest): passed
- repo-guardrails / clean-public-install (windows-latest): passed
- GitGuardian Security Checks: passed
- repo-guardrails / public-demo-smoke: skipped by workflow

## Risk area
Docs.

## Generated artifacts updated
Yes: `docs/.docs_source_mirror_stamp.json`.

## Review Evidence
Not used.

## Agent Metadata
- Tokki version: 1.0.10
- Agent/runtime: Codex GPT-5
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used
