### PR TITLE
Add browser page-load trend report

### DIFF
--- a/test/test_browser_page_load_trend.py
+++ b/test/test_browser_page_load_trend.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+
+MODULE_PATH = Path("tools/browser_page_load_trend.py").resolve()
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("browser_page_load_trend_test_module", MODULE_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_artifact(path: Path, *, about: float, analysis: float, total: float) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "success": True,
+                "total_duration_seconds": total,
+                "steps": [
+                    {
+                        "label": "ABOUT first visible render",
+                        "success": True,
+                        "duration_seconds": about,
+                    },
+                    {
+                        "label": "ANALYSIS first visible render",
+                        "success": True,
+                        "duration_seconds": analysis,
+                    },
+                    {
+                        "label": "page-load advisory budget",
+                        "success": True,
+                        "duration_seconds": 0.0,
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_collect_trends_reports_latest_previous_delta_best_and_worst(tmp_path: Path) -> None:
+    module = _load_module()
+    first = tmp_path / "first-page-load.json"
+    second = tmp_path / "second-page-load.json"
+    _write_artifact(first, about=0.9, analysis=0.7, total=2.8)
+    _write_artifact(second, about=0.6, analysis=0.8, total=2.6)
+    os.utime(first, ns=(100, 100))
+    os.utime(second, ns=(200, 200))
+
+    trends = {trend.page: trend for trend in module.collect_trends([second, first])}
+
+    about = trends["ABOUT"]
+    assert about.latest_seconds == pytest.approx(0.6)
+    assert about.previous_seconds == pytest.approx(0.9)
+    assert about.delta_seconds == pytest.approx(-0.3)
+    assert about.best_seconds == pytest.approx(0.6)
+    assert about.worst_seconds == pytest.approx(0.9)
+    assert about.samples == 2
+    assert about.artifact == second.as_posix()
+
+    total = trends["TOTAL"]
+    assert total.latest_seconds == pytest.approx(2.6)
+    assert total.delta_seconds == pytest.approx(-0.2)
+
+
+def test_render_markdown_includes_core_page_rows(tmp_path: Path) -> None:
+    module = _load_module()
+    artifact = tmp_path / "sample-page-load.json"
+    _write_artifact(artifact, about=0.61, analysis=0.73, total=2.4)
+
+    trends = module.collect_trends([artifact])
+    markdown = module.render_markdown(trends, pattern="test-results/*page-load*.json")
+
+    assert "# Browser page-load trend" in markdown
+    assert "| ABOUT | 0.6100s | n/a | n/a | 0.6100s | 0.6100s | 1 |" in markdown
+    assert "| ANALYSIS | 0.7300s | n/a | n/a | 0.7300s | 0.7300s | 1 |" in markdown
+    assert "| TOTAL | 2.4000s | n/a | n/a | 2.4000s | 2.4000s | 1 |" in markdown
+
+
+def test_main_json_and_allow_empty(tmp_path: Path, monkeypatch, capsys) -> None:
+    module = _load_module()
+    monkeypatch.chdir(tmp_path)
+
+    assert module.main(["--pattern", "missing/*.json", "--allow-empty"]) == 0
+    assert "No browser page-load artifacts" in capsys.readouterr().out
+
+    artifact_dir = tmp_path / "test-results"
+    artifact_dir.mkdir()
+    _write_artifact(artifact_dir / "one-page-load.json", about=0.4, analysis=0.6, total=1.5)
+
+    assert module.main(["--pattern", "test-results/*page-load*.json", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["pattern"] == "test-results/*page-load*.json"
+    assert {trend["page"] for trend in payload["trends"]} == {"ABOUT", "ANALYSIS", "TOTAL"}
+
+
+def test_main_rejects_negative_limit() -> None:
+    module = _load_module()
+
+    with pytest.raises(SystemExit) as exc:
+        module.main(["--limit", "-1"])
+
+    assert exc.value.code == 2

--- a/tools/browser_page_load_trend.py
+++ b/tools/browser_page_load_trend.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Summarize AGILAB browser page-load timing artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+
+DEFAULT_PATTERN = "test-results/*page-load*.json"
+CORE_PAGE_ORDER = ("ABOUT", "PROJECT", "WORKFLOW", "ANALYSIS", "TOTAL")
+
+
+@dataclass(frozen=True)
+class PageLoadSample:
+    page: str
+    seconds: float
+    artifact: str
+    mtime_ns: int
+
+
+@dataclass(frozen=True)
+class PageLoadTrend:
+    page: str
+    latest_seconds: float
+    previous_seconds: float | None
+    delta_seconds: float | None
+    best_seconds: float
+    worst_seconds: float
+    samples: int
+    artifact: str
+
+
+def _load_json(path: Path) -> object | None:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _extract_samples(path: Path) -> list[PageLoadSample]:
+    payload = _load_json(path)
+    if not isinstance(payload, dict):
+        return []
+
+    stat = path.stat()
+    samples: list[PageLoadSample] = []
+    steps = payload.get("steps")
+    if isinstance(steps, list):
+        for step in steps:
+            if not isinstance(step, dict):
+                continue
+            label = step.get("label")
+            if not isinstance(label, str) or not label.endswith(" first visible render"):
+                continue
+            if step.get("success") is not True:
+                continue
+            duration = step.get("duration_seconds")
+            if not isinstance(duration, (float, int)):
+                continue
+            page = label.removesuffix(" first visible render")
+            samples.append(
+                PageLoadSample(
+                    page=page,
+                    seconds=float(duration),
+                    artifact=path.as_posix(),
+                    mtime_ns=stat.st_mtime_ns,
+                )
+            )
+
+    total = payload.get("total_duration_seconds")
+    if isinstance(total, (float, int)):
+        samples.append(
+            PageLoadSample(
+                page="TOTAL",
+                seconds=float(total),
+                artifact=path.as_posix(),
+                mtime_ns=stat.st_mtime_ns,
+            )
+        )
+    return samples
+
+
+def _sort_key(sample: PageLoadSample) -> tuple[int, str]:
+    return (sample.mtime_ns, sample.artifact)
+
+
+def collect_trends(paths: Iterable[Path]) -> list[PageLoadTrend]:
+    grouped: dict[str, list[PageLoadSample]] = {}
+    for path in paths:
+        if not path.is_file():
+            continue
+        for sample in _extract_samples(path):
+            grouped.setdefault(sample.page, []).append(sample)
+
+    trends: list[PageLoadTrend] = []
+    for page, samples in grouped.items():
+        ordered = sorted(samples, key=_sort_key)
+        latest = ordered[-1]
+        previous = ordered[-2] if len(ordered) >= 2 else None
+        best = min(ordered, key=lambda sample: sample.seconds)
+        worst = max(ordered, key=lambda sample: sample.seconds)
+        trends.append(
+            PageLoadTrend(
+                page=page,
+                latest_seconds=latest.seconds,
+                previous_seconds=previous.seconds if previous else None,
+                delta_seconds=(
+                    latest.seconds - previous.seconds
+                    if previous is not None
+                    else None
+                ),
+                best_seconds=best.seconds,
+                worst_seconds=worst.seconds,
+                samples=len(ordered),
+                artifact=latest.artifact,
+            )
+        )
+
+    page_rank = {page: index for index, page in enumerate(CORE_PAGE_ORDER)}
+    return sorted(
+        trends,
+        key=lambda trend: (page_rank.get(trend.page, len(page_rank)), trend.page),
+    )
+
+
+def discover_artifacts(pattern: str, *, limit: int | None = None) -> list[Path]:
+    paths = sorted(
+        Path().glob(pattern),
+        key=lambda path: (path.stat().st_mtime_ns if path.exists() else 0, path.as_posix()),
+    )
+    if limit is not None and limit > 0:
+        return paths[-limit:]
+    return paths
+
+
+def _fmt_seconds(value: float | None) -> str:
+    return "n/a" if value is None else f"{value:.4f}s"
+
+
+def _fmt_delta(value: float | None) -> str:
+    if value is None:
+        return "n/a"
+    sign = "+" if value >= 0 else ""
+    return f"{sign}{value:.4f}s"
+
+
+def render_markdown(trends: Sequence[PageLoadTrend], *, pattern: str) -> str:
+    if not trends:
+        return f"No browser page-load artifacts matched `{pattern}`."
+
+    lines = [
+        "# Browser page-load trend",
+        "",
+        f"Artifacts: `{pattern}`",
+        "",
+        "| Page | Latest | Previous | Delta | Best | Worst | Samples | Latest artifact |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |",
+    ]
+    for trend in trends:
+        lines.append(
+            "| "
+            f"{trend.page} | "
+            f"{_fmt_seconds(trend.latest_seconds)} | "
+            f"{_fmt_seconds(trend.previous_seconds)} | "
+            f"{_fmt_delta(trend.delta_seconds)} | "
+            f"{_fmt_seconds(trend.best_seconds)} | "
+            f"{_fmt_seconds(trend.worst_seconds)} | "
+            f"{trend.samples} | "
+            f"`{trend.artifact}` |"
+        )
+    return "\n".join(lines)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Summarize AGILAB browser page-load JSON artifacts and show latest, "
+            "previous, delta, best, and worst timings."
+        )
+    )
+    parser.add_argument(
+        "--pattern",
+        default=DEFAULT_PATTERN,
+        help=f"Glob pattern for page-load artifacts. Default: {DEFAULT_PATTERN}",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=20,
+        help="Maximum number of most-recent artifacts to include. Use 0 for all.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+    parser.add_argument(
+        "--allow-empty",
+        action="store_true",
+        help="Exit successfully even when no matching timing samples are found.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+    if args.limit < 0:
+        parser.error("--limit must be >= 0")
+
+    paths = discover_artifacts(args.pattern, limit=args.limit or None)
+    trends = collect_trends(paths)
+    if args.json:
+        print(json.dumps({"pattern": args.pattern, "trends": [asdict(trend) for trend in trends]}, indent=2))
+    else:
+        print(render_markdown(trends, pattern=args.pattern))
+
+    if not trends and not args.allow_empty:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `tools/browser_page_load_trend.py` to summarize recent browser page-load JSON artifacts
- report latest, previous, delta, best, worst, sample count, and latest artifact per page
- support Markdown and JSON output plus `--allow-empty` for first-run environments
- add focused tests for trend calculation, Markdown rendering, JSON output, empty handling, and invalid limits

## Validation
- `uv --preview-features extra-build-dependencies run python -m py_compile tools/browser_page_load_trend.py`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' --import-mode=importlib test/test_browser_page_load_trend.py` (`4 passed`)
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files tools/browser_page_load_trend.py test/test_browser_page_load_trend.py`
- `uv --preview-features extra-build-dependencies run python tools/browser_page_load_trend.py --allow-empty`
- `./dev scope`
- `git diff --check`

## Live Trend Sample
- ABOUT: latest `0.6200s`, previous `0.9263s`, delta `-0.3063s`
- PROJECT: latest `0.2908s`, previous `0.2953s`, delta `-0.0045s`
- WORKFLOW: latest `0.5304s`, previous `0.5456s`, delta `-0.0152s`
- ANALYSIS: latest `0.7605s`, previous `0.7472s`, delta `+0.0133s`
- TOTAL: latest `3.2182s`, previous `3.0289s`, delta `+0.1892s`

## Agent Metadata
- Tokki version: `tokki 1.0.10`
- Agent/runtime: Codex API session, runtime version unavailable
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used
