### PR TITLE
[codex] Sync simplified contributor guide reference

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 277,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "fa6e690e459823bda8bd3076b5a8d8bdf9429d9260c8e6781c7851aaf3603c27",
+  "source_digest_sha256": "1b12da880288b5ccf82115b889aa9c3dfc8bbb3aeade77343f8d1857146e2522",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "fa6e690e459823bda8bd3076b5a8d8bdf9429d9260c8e6781c7851aaf3603c27"
+  "target_digest_sha256": "1b12da880288b5ccf82115b889aa9c3dfc8bbb3aeade77343f8d1857146e2522"
 }

--- a/docs/source/contributor-guide.rst
+++ b/docs/source/contributor-guide.rst
@@ -150,5 +150,5 @@ Review expectations
 Reference
 ---------
 
-The complete repository policy is in the root ``CONTRIBUTING.md`` file. Agent
-and IDE runbooks live in ``AGENTS.md`` and :doc:`agent-workflows`.
+For the full policy, see the root ``CONTRIBUTING.md`` file. For agent and IDE
+workflows, see ``AGENTS.md`` and :doc:`agent-workflows`.


### PR DESCRIPTION
## Summary
- Syncs the canonical contributor guide reference simplification from `jpmorard/thales_agilab#112`.
- Updates the public docs mirror stamp after syncing `docs/source`.

## Scope
Docs-only public mirror sync.

## Validation
- `git diff --check`
- `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --target docs/source --verify-stamp`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files docs/source/contributor-guide.rst docs/.docs_source_mirror_stamp.json`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs`
- Canonical docs: `uv run sphinx-build -n -q -b html docs/source docs/_build/html`

## Remote Checks
- docs-source-guard / verify: passed
- repo-guardrails / local-only-policy: passed
- repo-guardrails / clean-public-install (ubuntu-latest): passed
- repo-guardrails / clean-public-install (macos-latest): passed
- repo-guardrails / clean-public-install (windows-latest): passed
- GitGuardian Security Checks: passed
- repo-guardrails / public-demo-smoke: skipped by workflow

## Risk area
Docs.

## Generated artifacts updated
Yes: `docs/.docs_source_mirror_stamp.json`.

## Review Evidence
Not used.

## Agent Metadata
- Tokki version: 1.0.10
- Agent/runtime: Codex GPT-5
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used
