### PR TITLE
Add browser page-load regression gate

### DIFF
--- a/test/test_browser_page_load_trend.py
+++ b/test/test_browser_page_load_trend.py
@@ -106,10 +106,80 @@ def test_main_json_and_allow_empty(tmp_path: Path, monkeypatch, capsys) -> None:
     assert {trend["page"] for trend in payload["trends"]} == {"ABOUT", "ANALYSIS", "TOTAL"}
 
 
+def test_main_fails_when_latest_regression_exceeds_threshold(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    module = _load_module()
+    monkeypatch.chdir(tmp_path)
+    artifact_dir = tmp_path / "test-results"
+    artifact_dir.mkdir()
+    first = artifact_dir / "first-page-load.json"
+    second = artifact_dir / "second-page-load.json"
+    _write_artifact(first, about=0.5, analysis=0.7, total=1.5)
+    _write_artifact(second, about=0.9, analysis=0.71, total=2.2)
+    os.utime(first, ns=(100, 100))
+    os.utime(second, ns=(200, 200))
+
+    result = module.main(
+        [
+            "--pattern",
+            "test-results/*page-load*.json",
+            "--max-regression-seconds",
+            "0.2",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert result == 2
+    assert "Browser page-load regression gate failed" in captured.err
+    assert "ABOUT +0.4000s" in captured.err
+    assert "TOTAL +0.7000s" in captured.err
+    assert "ANALYSIS" not in captured.err
+
+
+def test_main_json_reports_regression_gate_result(tmp_path: Path, monkeypatch, capsys) -> None:
+    module = _load_module()
+    monkeypatch.chdir(tmp_path)
+    artifact_dir = tmp_path / "test-results"
+    artifact_dir.mkdir()
+    first = artifact_dir / "first-page-load.json"
+    second = artifact_dir / "second-page-load.json"
+    _write_artifact(first, about=0.5, analysis=0.7, total=1.5)
+    _write_artifact(second, about=0.55, analysis=0.71, total=1.6)
+    os.utime(first, ns=(100, 100))
+    os.utime(second, ns=(200, 200))
+
+    assert (
+        module.main(
+            [
+                "--pattern",
+                "test-results/*page-load*.json",
+                "--json",
+                "--max-regression-seconds",
+                "0.2",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["max_regression_seconds"] == pytest.approx(0.2)
+    assert payload["regressions"] == []
+
+
 def test_main_rejects_negative_limit() -> None:
     module = _load_module()
 
     with pytest.raises(SystemExit) as exc:
         module.main(["--limit", "-1"])
+
+    assert exc.value.code == 2
+
+
+def test_main_rejects_negative_regression_threshold() -> None:
+    module = _load_module()
+
+    with pytest.raises(SystemExit) as exc:
+        module.main(["--max-regression-seconds", "-0.1"])
 
     assert exc.value.code == 2

--- a/tools/browser_page_load_trend.py
+++ b/tools/browser_page_load_trend.py
@@ -149,6 +149,19 @@ def _fmt_delta(value: float | None) -> str:
     return f"{sign}{value:.4f}s"
 
 
+def _find_regressions(
+    trends: Sequence[PageLoadTrend], max_regression_seconds: float | None
+) -> list[PageLoadTrend]:
+    if max_regression_seconds is None:
+        return []
+    return [
+        trend
+        for trend in trends
+        if trend.delta_seconds is not None
+        and trend.delta_seconds > max_regression_seconds
+    ]
+
+
 def render_markdown(trends: Sequence[PageLoadTrend], *, pattern: str) -> str:
     if not trends:
         return f"No browser page-load artifacts matched `{pattern}`."
@@ -200,6 +213,15 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Exit successfully even when no matching timing samples are found.",
     )
+    parser.add_argument(
+        "--max-regression-seconds",
+        type=float,
+        default=None,
+        help=(
+            "Fail when any latest page timing is slower than the previous sample "
+            "by more than this many seconds. Pages with only one sample are ignored."
+        ),
+    )
     return parser
 
 
@@ -208,14 +230,34 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(list(argv) if argv is not None else None)
     if args.limit < 0:
         parser.error("--limit must be >= 0")
+    if args.max_regression_seconds is not None and args.max_regression_seconds < 0:
+        parser.error("--max-regression-seconds must be >= 0")
 
     paths = discover_artifacts(args.pattern, limit=args.limit or None)
     trends = collect_trends(paths)
+    regressions = _find_regressions(trends, args.max_regression_seconds)
     if args.json:
-        print(json.dumps({"pattern": args.pattern, "trends": [asdict(trend) for trend in trends]}, indent=2))
+        payload = {
+            "pattern": args.pattern,
+            "trends": [asdict(trend) for trend in trends],
+        }
+        if args.max_regression_seconds is not None:
+            payload["max_regression_seconds"] = args.max_regression_seconds
+            payload["regressions"] = [asdict(trend) for trend in regressions]
+        print(json.dumps(payload, indent=2))
     else:
         print(render_markdown(trends, pattern=args.pattern))
 
+    if regressions:
+        details = ", ".join(
+            f"{trend.page} {_fmt_delta(trend.delta_seconds)}"
+            for trend in regressions
+        )
+        print(
+            f"Browser page-load regression gate failed: {details}",
+            file=sys.stderr,
+        )
+        return 2
     if not trends and not args.allow_empty:
         return 1
     return 0


### PR DESCRIPTION
## Summary
- Add an opt-in `--max-regression-seconds` gate to `tools/browser_page_load_trend.py`.
- Return exit code `2` and a compact stderr summary when latest page-load samples regress beyond the configured threshold.
- Include regression-gate details in JSON output only when the gate is requested.
- Cover failing, passing, JSON, and invalid-threshold cases in the focused test module.

## Validation
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files tools/browser_page_load_trend.py test/test_browser_page_load_trend.py`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_browser_page_load_trend.py`
- `git diff --check`
- `./dev scope --staged`
- `./dev scope`

## Remote Checks
- GitGuardian Security Checks: pass
- `clean-public-install` on macOS, Ubuntu, and Windows: pass
- `local-only-policy`: pass
- `windows-core-tests`: pass
- `public-demo-smoke`: skipped by workflow

## Agent Metadata
- Tokki version: `tokki 1.0.10`
- Agent/runtime: Codex CLI / GPT-5 coding agent, runtime version unavailable
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used
