### PR TITLE
Defer ANALYSIS reuse catalog loading

### DIFF
--- a/maintenance/memory/by-path/src%2Fagilab%2Fpages%2F4_ANALYSIS.py.md
+++ b/maintenance/memory/by-path/src%2Fagilab%2Fpages%2F4_ANALYSIS.py.md
@@ -1,9 +1,9 @@
 ---
 schema: agilab.maintenance_memory.v1
 source: src/agilab/pages/4_ANALYSIS.py
-source_sha256: 7ff5680f3f0c4a4c49e421d1d5133c7dd5b23a26cd78d8a58f4801485854f065
+source_sha256: 9696bfb7ab36f8511d9077ab760c0f78ae981aac4559c6b153223d569de6dfd1
 title: ANALYSIS page AgiEnv singleton contract
-verified_commit: c722f7a9603487715f8d13b6a1ce63d743cde3b9
+verified_commit: f2787236033ea8b0f0b70cc2ba61371c01928331
 ---
 
 # ANALYSIS page AgiEnv singleton contract

--- a/src/agilab/pages/4_ANALYSIS.py
+++ b/src/agilab/pages/4_ANALYSIS.py
@@ -116,13 +116,6 @@ import_agilab_symbols(
     fallback_path=Path(__file__).resolve().parents[1] / "ui_performance.py",
     fallback_name="agilab_ui_performance_fallback",
 )
-_reuse_catalog_module = import_agilab_module(
-    "agilab.reuse_catalog",
-    current_file=__file__,
-    fallback_path=Path(__file__).resolve().parents[1] / "reuse_catalog.py",
-    fallback_name="agilab_reuse_catalog_analysis_fallback",
-)
-_build_reuse_suggestion_report = _reuse_catalog_module.build_suggestion_report
 import_agilab_symbols(
     globals(),
     "agilab.notebook_export_support",
@@ -166,6 +159,13 @@ def _lazy_import_attr(module_name: str, attr_name: str) -> Any:
             importlib.import_module(module_name), attr_name
         )
     return _LAZY_IMPORT_ATTR_CACHE[cache_key]
+
+
+def _build_reuse_suggestion_report(*args: Any, **kwargs: Any) -> Any:
+    """Load reuse-catalog suggestions only when the ANALYSIS page needs them."""
+    return _lazy_import_attr("agilab.reuse_catalog", "build_suggestion_report")(
+        *args, **kwargs
+    )
 
 
 class _LazyAgiEnv:

--- a/test/test_ui_pages.py
+++ b/test/test_ui_pages.py
@@ -99,6 +99,32 @@ def _assert_sidebar_link_absent(markdown: str, label: str) -> None:
         )
 
 
+def test_analysis_page_defers_reuse_catalog_import_until_suggestion_report() -> None:
+    analysis_source = Path("src/agilab/pages/4_ANALYSIS.py").read_text(
+        encoding="utf-8"
+    )
+    analysis_tree = ast.parse(analysis_source)
+    eager_reuse_imports = []
+    for node in analysis_tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        value = node.value
+        if not (
+            isinstance(value, ast.Call)
+            and isinstance(value.func, ast.Name)
+            and value.func.id == "import_agilab_module"
+            and value.args
+            and isinstance(value.args[0], ast.Constant)
+            and value.args[0].value == "agilab.reuse_catalog"
+        ):
+            continue
+        eager_reuse_imports.append(node)
+
+    assert eager_reuse_imports == []
+    assert 'def _build_reuse_suggestion_report(*args: Any, **kwargs: Any) -> Any:' in analysis_source
+    assert '_lazy_import_attr("agilab.reuse_catalog", "build_suggestion_report")' in analysis_source
+
+
 def test_primary_pages_keep_homogeneous_support_field_order() -> None:
     """Support fields should not jump above the page's primary content."""
     analysis_source = Path("src/agilab/pages/4_ANALYSIS.py").read_text(


### PR DESCRIPTION
## Summary
- defer ANALYSIS `agilab.reuse_catalog` loading until `_build_reuse_suggestion_report(...)` is actually called
- keep the existing helper surface available for tests and monkeypatches
- add a page-level regression assertion that ANALYSIS no longer eagerly imports `agilab.reuse_catalog`
- refresh the ANALYSIS path-scoped maintenance note after validating the AgiEnv singleton invariant still applies

## Validation
- `uv --preview-features extra-build-dependencies run python -m py_compile src/agilab/pages/4_ANALYSIS.py`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' --import-mode=importlib test/test_analysis_page_helpers.py` (`71 passed`)
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files src/agilab/pages/4_ANALYSIS.py`
- `uv --preview-features extra-build-dependencies run python tools/perf_smoke.py --scenario ui-analysis-page-import --repeats 1 --warmups 0 --json`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_ui_pages.py` (`77 passed`)
- `uv --preview-features extra-build-dependencies run python tools/maintenance_memory.py check --files src/agilab/pages/4_ANALYSIS.py`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui`
- `uv --preview-features extra-build-dependencies run --with playwright python tools/agilab_web_robot.py --page-load-smoke-only --timeout 30 --target-seconds 120 --json-output test-results/agilab-browser-page-load-reuse-lazy-smoke.json --json`
- `uv --preview-features extra-build-dependencies run python tools/browser_page_load_trend.py --allow-empty`
- `./dev scope`
- `git diff --check`

## Performance Evidence
- ANALYSIS import smoke: `0.7316s`
- Browser page-load sample after change:
  - ABOUT: `0.9067s`
  - PROJECT: `0.2910s`
  - WORKFLOW: `0.5195s`
  - ANALYSIS: `0.7068s`
  - TOTAL: `2.9370s`
- Trend versus previous local sample:
  - ANALYSIS: `0.7605s -> 0.7068s` (`-0.0538s`)
  - TOTAL: `3.2182s -> 2.9370s` (`-0.2812s`)

## Agent Metadata
- Tokki version: `tokki 1.0.10`
- Agent/runtime: Codex API session, runtime version unavailable
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used
