### PR TITLE
[codex] Sync simplified contributor lane heading

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 277,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "617c04e51f4add1e78ef5b4d1ee9f61ec53b15e3010826ecbef4585fdf216166",
+  "source_digest_sha256": "5ed339e75787ee4a4f933713c953fa5350d73388def5530ceeea9cadbc10012e",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "617c04e51f4add1e78ef5b4d1ee9f61ec53b15e3010826ecbef4585fdf216166"
+  "target_digest_sha256": "5ed339e75787ee4a4f933713c953fa5350d73388def5530ceeea9cadbc10012e"
 }

--- a/docs/source/contributor-guide.rst
+++ b/docs/source/contributor-guide.rst
@@ -31,8 +31,8 @@ If the proof fails, stay on the newcomer path: use
 in the title, the command you ran, and the first failing log lines. Do not
 jump into clusters, private app repositories, or large refactors yet.
 
-Choose one lane
----------------
+Choose a lane
+-------------
 
 Before editing, pick the closest lane:
 


### PR DESCRIPTION
## Summary
- Syncs the canonical contributor lane heading simplification from `jpmorard/thales_agilab#114`.
- Updates the public docs mirror stamp after syncing `docs/source`.

## Scope
Docs-only public mirror sync.

## Validation
- `git diff --check`
- `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --target docs/source --verify-stamp`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files docs/source/contributor-guide.rst docs/.docs_source_mirror_stamp.json`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs`
- Canonical docs: `uv run sphinx-build -n -q -b html docs/source docs/_build/html`

## Remote Checks
- docs-source-guard / verify: passed
- repo-guardrails / local-only-policy: passed
- repo-guardrails / clean-public-install (ubuntu-latest): passed
- repo-guardrails / clean-public-install (macos-latest): passed
- repo-guardrails / clean-public-install (windows-latest): passed
- GitGuardian Security Checks: passed
- repo-guardrails / public-demo-smoke: skipped by workflow

## Risk area
Docs.

## Generated artifacts updated
Yes: `docs/.docs_source_mirror_stamp.json`.

## Review Evidence
Not used.

## Agent Metadata
- Tokki version: 1.0.10
- Agent/runtime: Codex GPT-5
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used
