### PR TITLE
Refresh ANALYSIS maintenance memory hash

### DIFF
--- a/maintenance/memory/by-path/src%2Fagilab%2Fpages%2F4_ANALYSIS.py.md
+++ b/maintenance/memory/by-path/src%2Fagilab%2Fpages%2F4_ANALYSIS.py.md
@@ -1,9 +1,9 @@
 ---
 schema: agilab.maintenance_memory.v1
 source: src/agilab/pages/4_ANALYSIS.py
-source_sha256: 9696bfb7ab36f8511d9077ab760c0f78ae981aac4559c6b153223d569de6dfd1
+source_sha256: d1a02cffb27bfa0c6c9653a5a4338204bbd1c5c857279bbcda409f1832414d1b
 title: ANALYSIS page AgiEnv singleton contract
-verified_commit: f2787236033ea8b0f0b70cc2ba61371c01928331
+verified_commit: d26e4466dbb6400a8fc976acf9f58e753aa93361
 ---
 
 # ANALYSIS page AgiEnv singleton contract


### PR DESCRIPTION
## Summary
- Refresh the path-scoped maintenance-memory metadata for `src/agilab/pages/4_ANALYSIS.py`.
- Keep the ANALYSIS AgiEnv singleton contract note aligned with the current source hash after the reuse-catalog lazy-load change.
- Merge the latest `main` into the branch without changing the PR diff scope.

## Validation
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files maintenance/memory/by-path/src%2Fagilab%2Fpages%2F4_ANALYSIS.py.md`
- `uv --preview-features extra-build-dependencies run python tools/maintenance_memory.py check --all`
- `git diff --check`
- `./dev scope`

## Remote Checks
- GitGuardian Security Checks: pass
- `clean-public-install` on macOS, Ubuntu, and Windows: pass
- `local-only-policy`: pass
- `public-demo-smoke`: skipped by workflow

## Agent Metadata
- Tokki version: `tokki 1.0.10`
- Agent/runtime: Codex CLI / GPT-5 coding agent, runtime version unavailable
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used
