### PR TITLE
Fix page-load trend total semantics

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -16,7 +16,8 @@ uv --preview-features extra-build-dependencies run python tools/agent_commit_pro
   --pre-push-spec "$push_spec_file"
 
 guard_state="$(
-  uv --preview-features extra-build-dependencies run python tools/pre_push_changed_files.py
+  uv --preview-features extra-build-dependencies run python tools/pre_push_changed_files.py \
+    --pre-push-spec "$push_spec_file"
 )"
 DOCS_CHANGED=1
 RELEASE_PROOF_CHANGED=1

--- a/agilab-capabilities.json
+++ b/agilab-capabilities.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-06-24T15:40:03Z",
+  "generated_at_utc": "2026-06-24T21:14:10Z",
   "schema": "agilab.capabilities.v1",
   "schema_version": 1,
   "generated_by": {
@@ -10,7 +10,7 @@
     "repository": "https://github.com/ThalesGroup/agilab",
     "documentation": "https://thalesgroup.github.io/agilab/",
     "project": "agilab",
-    "version": "2026.06.23"
+    "version": "2026.06.24"
   },
   "boundary": {
     "proves": "This manifest proves that public AGILAB surfaces are discoverable from checked-in contracts.",
@@ -265,7 +265,7 @@
       "name": "agi-env",
       "role": "runtime-component",
       "status": "PyPI package",
-      "version": "2026.06.23",
+      "version": "2026.06.24",
       "description": "Environment bootstrap package for AGILAB with virtualenv, path, and runtime helpers",
       "project": "src/agilab/core/agi-env",
       "pyproject": "src/agilab/core/agi-env/pyproject.toml",
@@ -276,7 +276,7 @@
       "name": "agi-gui",
       "role": "ui-component",
       "status": "PyPI package",
-      "version": "2026.06.23",
+      "version": "2026.06.24",
       "description": "AGILAB Streamlit UI dependency bundle and compatibility imports",
       "project": "src/agilab/lib/agi-gui",
       "pyproject": "src/agilab/lib/agi-gui/pyproject.toml",
@@ -474,7 +474,7 @@
       "name": "agi-pages",
       "role": "page-umbrella",
       "status": "PyPI package",
-      "version": "2026.06.23",
+      "version": "2026.06.24",
       "description": "AGILAB public analysis page umbrella and provider package",
       "project": "src/agilab/lib/agi-pages",
       "pyproject": "src/agilab/lib/agi-pages/pyproject.toml",
@@ -485,7 +485,7 @@
       "name": "agi-node",
       "role": "runtime-component",
       "status": "PyPI package",
-      "version": "2026.06.23",
+      "version": "2026.06.24",
       "description": "Distributed worker orchestration and execution support library for AGILAB",
       "project": "src/agilab/core/agi-node",
       "pyproject": "src/agilab/core/agi-node/pyproject.toml",
@@ -496,7 +496,7 @@
       "name": "agi-cluster",
       "role": "runtime-component",
       "status": "PyPI package",
-      "version": "2026.06.23",
+      "version": "2026.06.24",
       "description": "Distributed cluster orchestration layer for AGILAB workers over local and SSH backends",
       "project": "src/agilab/core/agi-cluster",
       "pyproject": "src/agilab/core/agi-cluster/pyproject.toml",
@@ -507,7 +507,7 @@
       "name": "agi-core",
       "role": "runtime-bundle",
       "status": "PyPI package",
-      "version": "2026.06.23",
+      "version": "2026.06.24",
       "description": "Meta-package that installs and wires agi-env, agi-node, and agi-cluster together",
       "project": "src/agilab/core/agi-core",
       "pyproject": "src/agilab/core/agi-core/pyproject.toml",
@@ -518,7 +518,7 @@
       "name": "agi-app-mission-decision",
       "role": "app-project",
       "status": "PyPI app package",
-      "version": "2026.06.23",
+      "version": "2026.06.24",
       "description": "Deterministic AGILAB mission-decision workflow with scenario scoring and evidence artifacts",
       "project": "src/agilab/lib/agi-app-mission-decision",
       "pyproject": "src/agilab/lib/agi-app-mission-decision/pyproject.toml",
@@ -551,7 +551,7 @@
       "name": "agi-app-flight-telemetry",
       "role": "app-project",
       "status": "PyPI app package",
-      "version": "2026.06.23",
+      "version": "2026.06.24",
       "description": "AGILAB flight-telemetry ingestion demo with reusable dataframe and map-analysis outputs",
       "project": "src/agilab/lib/agi-app-flight-telemetry",
       "pyproject": "src/agilab/lib/agi-app-flight-telemetry/pyproject.toml",
@@ -573,7 +573,7 @@
       "name": "agi-app-weather-forecast",
       "role": "app-project",
       "status": "PyPI app package",
-      "version": "2026.06.23",
+      "version": "2026.06.24",
       "description": "AGILAB weather-forecast notebook-migration demo with forecast analysis artifacts",
       "project": "src/agilab/lib/agi-app-weather-forecast",
       "pyproject": "src/agilab/lib/agi-app-weather-forecast/pyproject.toml",
@@ -606,7 +606,7 @@
       "name": "agi-app-pytorch-playground",
       "role": "app-project",
       "status": "PyPI app package",
-      "version": "2026.06.23",
+      "version": "2026.06.24",
       "description": "AGILAB PyTorch playground app for reproducible neural-network experiments",
       "project": "src/agilab/lib/agi-app-pytorch-playground",
       "pyproject": "src/agilab/lib/agi-app-pytorch-playground/pyproject.toml",
@@ -639,7 +639,7 @@
       "name": "agi-app-uav-relay-queue",
       "role": "app-project",
       "status": "PyPI app package",
-      "version": "2026.06.23",
+      "version": "2026.06.24",
       "description": "AGILAB UAV relay queue simulation demo with routing, delay, and resilience artifacts",
       "project": "src/agilab/lib/agi-app-uav-relay-queue",
       "pyproject": "src/agilab/lib/agi-app-uav-relay-queue/pyproject.toml",
@@ -650,7 +650,7 @@
       "name": "agi-apps",
       "role": "app-umbrella",
       "status": "PyPI package",
-      "version": "2026.06.23",
+      "version": "2026.06.24",
       "description": "AGILAB public app package umbrella and example assets",
       "project": "src/agilab/lib/agi-apps",
       "pyproject": "src/agilab/lib/agi-apps/pyproject.toml",
@@ -661,7 +661,7 @@
       "name": "agilab",
       "role": "top-level-bundle",
       "status": "PyPI package",
-      "version": "2026.06.23",
+      "version": "2026.06.24",
       "description": "AGILAB is a reproducible AI/ML workbench for engineering teams.",
       "project": ".",
       "pyproject": "pyproject.toml",
@@ -699,7 +699,7 @@
       "package": "agi-app-flight-telemetry",
       "status": "PyPI app package",
       "source": "src/agilab/lib/agi-app-flight-telemetry",
-      "version": "2026.06.23",
+      "version": "2026.06.24",
       "description": "AGILAB flight-telemetry ingestion demo with reusable dataframe and map-analysis outputs"
     },
     {
@@ -715,7 +715,7 @@
       "package": "agi-app-mission-decision",
       "status": "PyPI app package",
       "source": "src/agilab/lib/agi-app-mission-decision",
-      "version": "2026.06.23",
+      "version": "2026.06.24",
       "description": "Deterministic AGILAB mission-decision workflow with scenario scoring and evidence artifacts"
     },
     {
@@ -731,7 +731,7 @@
       "package": "agi-app-pytorch-playground",
       "status": "PyPI app package",
       "source": "src/agilab/lib/agi-app-pytorch-playground",
-      "version": "2026.06.23",
+      "version": "2026.06.24",
       "description": "AGILAB PyTorch playground app for reproducible neural-network experiments"
     },
     {
@@ -771,7 +771,7 @@
       "package": "agi-app-uav-relay-queue",
       "status": "PyPI app package",
       "source": "src/agilab/lib/agi-app-uav-relay-queue",
-      "version": "2026.06.23",
+      "version": "2026.06.24",
       "description": "AGILAB UAV relay queue simulation demo with routing, delay, and resilience artifacts"
     },
     {
@@ -787,7 +787,7 @@
       "package": "agi-app-weather-forecast",
       "status": "PyPI app package",
       "source": "src/agilab/lib/agi-app-weather-forecast",
-      "version": "2026.06.23",
+      "version": "2026.06.24",
       "description": "AGILAB weather-forecast notebook-migration demo with forecast analysis artifacts"
     }
   ],
@@ -1780,18 +1780,36 @@
     {
       "schema": "agilab.notebook_export_handoff.v1",
       "sources": [
+        "src/agilab/apps/builtin/flight_telemetry_project/notebooks/lab_stages.notebook_export.md",
+        "src/agilab/apps/builtin/mission_decision_project/notebooks/lab_stages.notebook_export.md",
+        "src/agilab/apps/builtin/multi_app_dag_project/notebooks/lab_stages.notebook_export.md",
+        "src/agilab/apps/builtin/tescia_diagnostic_project/notebooks/lab_stages.notebook_export.md",
+        "src/agilab/apps/builtin/weather_forecast_legacy_project/notebooks/lab_stages.notebook_export.md",
+        "src/agilab/apps/builtin/weather_forecast_project/notebooks/lab_stages.notebook_export.md",
         "src/agilab/notebooks/notebook_export_support.py"
       ]
     },
     {
       "schema": "agilab.notebook_export_manifest.v1",
       "sources": [
+        "src/agilab/apps/builtin/flight_telemetry_project/notebooks/lab_stages.notebook_export.json",
+        "src/agilab/apps/builtin/mission_decision_project/notebooks/lab_stages.notebook_export.json",
+        "src/agilab/apps/builtin/multi_app_dag_project/notebooks/lab_stages.notebook_export.json",
+        "src/agilab/apps/builtin/tescia_diagnostic_project/notebooks/lab_stages.notebook_export.json",
+        "src/agilab/apps/builtin/weather_forecast_legacy_project/notebooks/lab_stages.notebook_export.json",
+        "src/agilab/apps/builtin/weather_forecast_project/notebooks/lab_stages.notebook_export.json",
         "src/agilab/notebooks/notebook_export_support.py"
       ]
     },
     {
       "schema": "agilab.notebook_export_portability.v1",
       "sources": [
+        "src/agilab/apps/builtin/flight_telemetry_project/notebooks/lab_stages.notebook_export.json",
+        "src/agilab/apps/builtin/mission_decision_project/notebooks/lab_stages.notebook_export.json",
+        "src/agilab/apps/builtin/multi_app_dag_project/notebooks/lab_stages.notebook_export.json",
+        "src/agilab/apps/builtin/tescia_diagnostic_project/notebooks/lab_stages.notebook_export.json",
+        "src/agilab/apps/builtin/weather_forecast_legacy_project/notebooks/lab_stages.notebook_export.json",
+        "src/agilab/apps/builtin/weather_forecast_project/notebooks/lab_stages.notebook_export.json",
         "src/agilab/notebooks/notebook_export_support.py"
       ]
     },
@@ -1865,6 +1883,12 @@
     {
       "schema": "agilab.notebook_view_sync.v1",
       "sources": [
+        "src/agilab/apps/builtin/flight_telemetry_project/notebooks/lab_stages.notebook_export.json",
+        "src/agilab/apps/builtin/mission_decision_project/notebooks/lab_stages.notebook_export.json",
+        "src/agilab/apps/builtin/multi_app_dag_project/notebooks/lab_stages.notebook_export.json",
+        "src/agilab/apps/builtin/tescia_diagnostic_project/notebooks/lab_stages.notebook_export.json",
+        "src/agilab/apps/builtin/weather_forecast_legacy_project/notebooks/lab_stages.notebook_export.json",
+        "src/agilab/apps/builtin/weather_forecast_project/notebooks/lab_stages.notebook_export.json",
         "src/agilab/notebooks/notebook_export_support.py"
       ]
     },

--- a/test/test_browser_page_load_trend.py
+++ b/test/test_browser_page_load_trend.py
@@ -50,6 +50,39 @@ def _write_artifact(path: Path, *, about: float, analysis: float, total: float) 
     )
 
 
+def test_extract_samples_derive_total_from_page_render_steps(tmp_path: Path) -> None:
+    module = _load_module()
+    artifact = tmp_path / "mixed-page-load.json"
+    _write_artifact(artifact, about=0.4, analysis=0.6, total=10.0)
+
+    trends = {trend.page: trend for trend in module.collect_trends([artifact])}
+
+    assert trends["TOTAL"].latest_seconds == pytest.approx(1.0)
+
+
+def test_extract_samples_ignore_top_level_total_without_page_steps(tmp_path: Path) -> None:
+    module = _load_module()
+    artifact = tmp_path / "failed-page-load.json"
+    artifact.write_text(
+        json.dumps(
+            {
+                "success": False,
+                "total_duration_seconds": 9.5,
+                "steps": [
+                    {
+                        "label": "streamlit health",
+                        "success": True,
+                        "duration_seconds": 1.2,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert module.collect_trends([artifact]) == []
+
+
 def test_collect_trends_reports_latest_previous_delta_best_and_worst(tmp_path: Path) -> None:
     module = _load_module()
     first = tmp_path / "first-page-load.json"
@@ -71,7 +104,7 @@ def test_collect_trends_reports_latest_previous_delta_best_and_worst(tmp_path: P
     assert about.artifact == second.as_posix()
 
     total = trends["TOTAL"]
-    assert total.latest_seconds == pytest.approx(2.6)
+    assert total.latest_seconds == pytest.approx(1.4)
     assert total.delta_seconds == pytest.approx(-0.2)
 
 
@@ -86,7 +119,7 @@ def test_render_markdown_includes_core_page_rows(tmp_path: Path) -> None:
     assert "# Browser page-load trend" in markdown
     assert "| ABOUT | 0.6100s | n/a | n/a | 0.6100s | 0.6100s | 1 |" in markdown
     assert "| ANALYSIS | 0.7300s | n/a | n/a | 0.7300s | 0.7300s | 1 |" in markdown
-    assert "| TOTAL | 2.4000s | n/a | n/a | 2.4000s | 2.4000s | 1 |" in markdown
+    assert "| TOTAL | 1.3400s | n/a | n/a | 1.3400s | 1.3400s | 1 |" in markdown
 
 
 def test_main_json_and_allow_empty(tmp_path: Path, monkeypatch, capsys) -> None:
@@ -133,7 +166,7 @@ def test_main_fails_when_latest_regression_exceeds_threshold(
     assert result == 2
     assert "Browser page-load regression gate failed" in captured.err
     assert "ABOUT +0.4000s" in captured.err
-    assert "TOTAL +0.7000s" in captured.err
+    assert "TOTAL +0.4100s" in captured.err
     assert "ANALYSIS" not in captured.err
 
 

--- a/test/test_pre_push_changed_files.py
+++ b/test/test_pre_push_changed_files.py
@@ -141,6 +141,30 @@ def test_pre_push_records_use_remote_sha_as_diff_base():
     assert calls == [["diff", "--name-only", "--diff-filter=ACMR", "remotesha", "localsha"]]
 
 
+def test_main_reads_pre_push_spec_file_for_hook_guard_state(tmp_path, monkeypatch, capsys):
+    spec_file = tmp_path / "pre-push-spec.txt"
+    spec_text = "refs/heads/topic localsha refs/heads/topic remotesha\n"
+    spec_file.write_text(spec_text, encoding="utf-8")
+    seen = []
+
+    def fake_changed_files_from_pre_push(stdin_text):
+        seen.append(stdin_text)
+        return ("docs/source/getting-started.rst",)
+
+    monkeypatch.setattr(
+        pre_push_changed_files,
+        "changed_files_from_pre_push",
+        fake_changed_files_from_pre_push,
+    )
+
+    assert pre_push_changed_files.main(["--pre-push-spec", str(spec_file)]) == 0
+
+    assert seen == [spec_text]
+    output = capsys.readouterr().out
+    assert "DOCS_CHANGED=1" in output
+    assert "CHANGED_COUNT=1" in output
+
+
 def test_render_shell_is_eval_friendly():
     state = pre_push_changed_files.classify_changed_files(["docs/source/release-proof.rst"])
 

--- a/test/test_ui_pages.py
+++ b/test/test_ui_pages.py
@@ -99,30 +99,38 @@ def _assert_sidebar_link_absent(markdown: str, label: str) -> None:
         )
 
 
-def test_analysis_page_defers_reuse_catalog_import_until_suggestion_report() -> None:
-    analysis_source = Path("src/agilab/pages/4_ANALYSIS.py").read_text(
-        encoding="utf-8"
+def test_analysis_page_defers_reuse_catalog_import_until_suggestion_report(
+    monkeypatch,
+) -> None:
+    module_path = Path("src/agilab/pages/4_ANALYSIS.py").resolve()
+    module_name = "agilab_analysis_lazy_reuse_catalog_test_module"
+    imported: list[str] = []
+    fake_reuse_catalog = types.SimpleNamespace(
+        build_suggestion_report=lambda *args, **kwargs: {"matches": []}
     )
-    analysis_tree = ast.parse(analysis_source)
-    eager_reuse_imports = []
-    for node in analysis_tree.body:
-        if not isinstance(node, ast.Assign):
-            continue
-        value = node.value
-        if not (
-            isinstance(value, ast.Call)
-            and isinstance(value.func, ast.Name)
-            and value.func.id == "import_agilab_module"
-            and value.args
-            and isinstance(value.args[0], ast.Constant)
-            and value.args[0].value == "agilab.reuse_catalog"
-        ):
-            continue
-        eager_reuse_imports.append(node)
+    original_import_module = importlib.import_module
 
-    assert eager_reuse_imports == []
-    assert 'def _build_reuse_suggestion_report(*args: Any, **kwargs: Any) -> Any:' in analysis_source
-    assert '_lazy_import_attr("agilab.reuse_catalog", "build_suggestion_report")' in analysis_source
+    def _tracking_import_module(name: str, package: str | None = None):
+        if name == "agilab.reuse_catalog":
+            imported.append(name)
+            return fake_reuse_catalog
+        return original_import_module(name, package)
+
+    monkeypatch.setattr(importlib, "import_module", _tracking_import_module)
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+
+    try:
+        spec.loader.exec_module(module)
+        assert imported == []
+        assert module._build_reuse_suggestion_report("demo", kind="page") == {
+            "matches": []
+        }
+        assert imported == ["agilab.reuse_catalog"]
+    finally:
+        sys.modules.pop(module_name, None)
 
 
 def test_primary_pages_keep_homogeneous_support_field_order() -> None:

--- a/tools/browser_page_load_trend.py
+++ b/tools/browser_page_load_trend.py
@@ -72,12 +72,11 @@ def _extract_samples(path: Path) -> list[PageLoadSample]:
                 )
             )
 
-    total = payload.get("total_duration_seconds")
-    if isinstance(total, (float, int)):
+    if samples:
         samples.append(
             PageLoadSample(
                 page="TOTAL",
-                seconds=float(total),
+                seconds=sum(sample.seconds for sample in samples),
                 artifact=path.as_posix(),
                 mtime_ns=stat.st_mtime_ns,
             )

--- a/tools/pre_push_changed_files.py
+++ b/tools/pre_push_changed_files.py
@@ -265,6 +265,12 @@ def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
         default=None,
         help="Bypass git detection and classify this file. Useful for tests/debugging.",
     )
+    parser.add_argument(
+        "--pre-push-spec",
+        type=Path,
+        default=None,
+        help="Read git pre-push stdin records from this file.",
+    )
     return parser.parse_args(argv)
 
 
@@ -272,11 +278,15 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = _parse_args(sys.argv[1:] if argv is None else argv)
 
     try:
-        changed_files = (
-            tuple(args.changed_file)
-            if args.changed_file is not None
-            else changed_files_from_pre_push(sys.stdin.read())
-        )
+        if args.changed_file is not None:
+            changed_files = tuple(args.changed_file)
+        else:
+            pre_push_text = (
+                args.pre_push_spec.read_text(encoding="utf-8")
+                if args.pre_push_spec is not None
+                else sys.stdin.read()
+            )
+            changed_files = changed_files_from_pre_push(pre_push_text)
         state = classify_changed_files(changed_files)
     except Exception as exc:  # pragma: no cover - defensive hook fail-safe
         state = failed_detection_state(exc)


### PR DESCRIPTION
## Summary
- Fix browser page-load trend `TOTAL` so it is derived from successful page first-visible-render samples instead of top-level run duration.
- Add regressions for page-derived totals and failed artifacts that only contain setup timing.
- Replace the ANALYSIS reuse-catalog lazy-import source-shape assertion with a runtime import-behavior regression.

## Validation
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files tools/browser_page_load_trend.py test/test_browser_page_load_trend.py test/test_ui_pages.py` (pass)
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_browser_page_load_trend.py test/test_ui_pages.py::test_analysis_page_defers_reuse_catalog_import_until_suggestion_report` (10 passed)
- `git diff --check` (pass)
- `./dev scope --staged` (pass)

## Remote Checks
- `gh pr checks 721` (pass): `windows-core-tests`, `clean-public-install` on macOS/Ubuntu/Windows, `local-only-policy`, and GitGuardian passed.
- `public-demo-smoke` skipped by workflow.

## Review Evidence
- Reviewer model: Codex reviewer output from `/review`.
- Result: identified page-load `TOTAL` semantics and ANALYSIS lazy-import coverage gaps.
- Status: addressed in this PR.

## Agent Metadata
- Tokki version: tokki 1.0.10
- Agent/runtime: Codex CLI 0.142.0
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used
