### PR TITLE
Clarify macOS SSH benchmark boundary

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 277,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "8e9d282f47bc4ea81773906180404612b646dbeafe82f558aff32c37abc0f458",
+  "source_digest_sha256": "30231369d8ba61fded89b6adef794ff685640be055eb66b75ed426caa874e773",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "8e9d282f47bc4ea81773906180404612b646dbeafe82f558aff32c37abc0f458"
+  "target_digest_sha256": "30231369d8ba61fded89b6adef794ff685640be055eb66b75ed426caa874e773"
 }

--- a/docs/source/execution-playground.rst
+++ b/docs/source/execution-playground.rst
@@ -214,11 +214,13 @@ still the first AGILAB-native acceleration path for typed Python kernels. Use
 Rust/PyO3 when ownership, safety, an existing Rust crate, or a long-lived native
 library justifies the extra wheel and toolchain complexity.
 
-2-node 16-mode matrix
----------------------
+macOS SSH 2-node 16-mode matrix
+-------------------------------
 
-The repository also ships a second helper that benchmarks the full 16-mode
-matrix on 2 Macs over SSH:
+The repository also ships a second helper for one intentionally narrow evidence
+route: the full 16-mode matrix on 2 Macs over SSH. Treat this as
+``macos-ssh-2node`` benchmark evidence, not as portable Linux/macOS/Windows
+cluster validation:
 
 .. code-block:: bash
 
@@ -235,6 +237,9 @@ This run uses:
 - 1 local macOS ARM scheduler/worker
 - 1 remote macOS ARM worker over SSH
 - the same ``16`` partitions, ``100000`` rows per file, and ``32`` compute passes
+
+For portable cluster readiness, use the AGILAB cluster validation and robustness
+tools instead of this macOS-specific benchmark helper.
 
 Mode families
 ^^^^^^^^^^^^^

--- a/test/test_benchmark_execution_tools.py
+++ b/test/test_benchmark_execution_tools.py
@@ -419,6 +419,19 @@ def test_ssh_target_defaults_to_agi_and_preserves_explicit_user() -> None:
     assert matrix._ssh_target("bench@192.168.20.130") == "bench@192.168.20.130"
 
 
+def test_mode_matrix_declares_macos_ssh_topology() -> None:
+    assert matrix.TOPOLOGY_ID == "macos-ssh-2node"
+    assert "macOS" in matrix.TOPOLOGY_DESCRIPTION
+    assert "SSH" in matrix.TOPOLOGY_DESCRIPTION
+
+
+def test_mode_matrix_rejects_non_macos_scheduler(monkeypatch) -> None:
+    monkeypatch.setattr(matrix.platform, "system", lambda: "Linux")
+
+    with pytest.raises(RuntimeError, match="macOS SSH 2-node benchmark"):
+        matrix._require_macos_ssh_topology()
+
+
 def test_sync_dataset_to_remote_reuses_consistent_ssh_target(
     tmp_path, monkeypatch
 ) -> None:

--- a/tools/benchmark_execution_mode_matrix.py
+++ b/tools/benchmark_execution_mode_matrix.py
@@ -4,6 +4,7 @@ import argparse
 import asyncio
 import csv
 import json
+import platform
 import shlex
 import statistics
 import subprocess
@@ -43,6 +44,9 @@ MODE_NAMES = {
 }
 LOCAL_ONLY_MODES = tuple(range(0, 4)) + tuple(range(8, 12))
 CLUSTER_MODES = tuple(range(4, 8)) + tuple(range(12, 16))
+SUPPORTED_LOCAL_SYSTEM = "Darwin"
+TOPOLOGY_ID = "macos-ssh-2node"
+TOPOLOGY_DESCRIPTION = "1 local macOS scheduler/worker + 1 remote macOS worker over SSH"
 
 
 @dataclass(frozen=True)
@@ -55,6 +59,16 @@ class NodeInfo:
 
 def _ssh_target(host: str) -> str:
     return host if "@" in host else f"agi@{host}"
+
+
+def _require_macos_ssh_topology() -> None:
+    local_system = platform.system()
+    if local_system != SUPPORTED_LOCAL_SYSTEM:
+        raise RuntimeError(
+            "benchmark_execution_mode_matrix.py is scoped to the macOS SSH 2-node benchmark; "
+            f"local platform is {local_system or sys.platform!r}. Use AGILAB's cluster "
+            "validation tools for portable Linux/macOS/Windows cluster evidence."
+        )
 
 
 def _parse_runtime(run_output: Any) -> tuple[str, float]:
@@ -277,6 +291,7 @@ async def run_mode_matrix(
     n_partitions: int,
     repeats: int,
 ) -> dict[str, Any]:
+    _require_macos_ssh_topology()
     local_node = _probe_local_node()
     remote_node = _probe_remote_node(remote_host)
     cluster_workers = {"127.0.0.1": 1, remote_host: 1}
@@ -292,7 +307,8 @@ async def run_mode_matrix(
             "repeats": repeats,
             "scheduler_host": local_node.label,
             "remote_worker_host": remote_node.label,
-            "topology": "1 local macOS scheduler/worker + 1 remote macOS worker over SSH",
+            "topology_id": TOPOLOGY_ID,
+            "topology": TOPOLOGY_DESCRIPTION,
             "nodes": {
                 "local": {
                     "label": local_node.label,


### PR DESCRIPTION
## Summary
- Add explicit `macos-ssh-2node` topology metadata to the 16-mode benchmark helper.
- Fail fast on non-macOS schedulers so the helper cannot be mistaken for portable cluster evidence.
- Sync canonical docs wording that labels the helper as macOS/SSH benchmark evidence and points portable cluster readiness to validation/robustness tools.

## Validation
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files docs/source/execution-playground.rst test/test_benchmark_execution_tools.py tools/benchmark_execution_mode_matrix.py` (pass)
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_benchmark_execution_tools.py` (21 passed)
- `git diff --check` (pass)
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs` (pass)

## Review Evidence
- Source: AGILAB audit finding from Codex.
- Result: benchmark helper boundary was too easy to read as portable cluster evidence.
- Status: addressed in this PR.

## Agent Metadata
- Tokki version: not used
- Agent/runtime: Codex CLI
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used
