### PR TITLE
Update deep audit benchmark boundary guidance

### DIFF
--- a/.claude/skills/agilab-deep-audit/SKILL.md
+++ b/.claude/skills/agilab-deep-audit/SKILL.md
@@ -78,6 +78,11 @@ For a deep AGILAB audit, cover these surfaces unless the user narrows scope:
 - Cross-platform and tests: Windows/macOS/Linux claims, hermetic `HOME`
   behavior, singleton resets, path separators, process/signal assumptions, and
   CI workflow coverage.
+- Benchmark and performance evidence helpers: verify that scripts and docs
+  declare their exact topology and platform boundary. A lab-specific helper
+  such as a macOS-over-SSH benchmark must not be treated as portable cluster,
+  release, or production evidence unless the code fails closed outside that
+  boundary and tests/docs name the limitation.
 - Packaging and docs: wheel surface, generated artifacts, docs/public mirror,
   release proof, and changelog/public claim alignment.
 - Periphery sampling: representative built-in apps, page bundles, and examples

--- a/.codex/skills/agilab-deep-audit/SKILL.md
+++ b/.codex/skills/agilab-deep-audit/SKILL.md
@@ -78,6 +78,11 @@ For a deep AGILAB audit, cover these surfaces unless the user narrows scope:
 - Cross-platform and tests: Windows/macOS/Linux claims, hermetic `HOME`
   behavior, singleton resets, path separators, process/signal assumptions, and
   CI workflow coverage.
+- Benchmark and performance evidence helpers: verify that scripts and docs
+  declare their exact topology and platform boundary. A lab-specific helper
+  such as a macOS-over-SSH benchmark must not be treated as portable cluster,
+  release, or production evidence unless the code fails closed outside that
+  boundary and tests/docs name the limitation.
 - Packaging and docs: wheel surface, generated artifacts, docs/public mirror,
   release proof, and changelog/public claim alignment.
 - Periphery sampling: representative built-in apps, page bundles, and examples

--- a/agenticweb.md
+++ b/agenticweb.md
@@ -243,7 +243,7 @@ x_generated_by:
   command: "python3 tools/agenticweb_manifest.py --apply"
   source_manifest: "agilab-capabilities.json"
   source_schema: "agilab.capabilities.v1"
-  source_version: "2026.06.23"
+  source_version: "2026.06.24"
   boundary: "Discovery only: this file does not prove runtime success, external service reachability, security certification, or production readiness."
 ---
 


### PR DESCRIPTION
## Summary
- Add AGILAB deep-audit guidance for benchmark/performance evidence helpers.
- Require audit passes to verify exact topology/platform boundaries and fail-closed behavior before lab-specific helpers are treated as portable cluster, release, or production evidence.
- Sync the Codex skill mirror and regenerate agent discovery metadata.

## Validation
- `python3 tools/sync_agent_skills.py --skills agilab-deep-audit` (pass)
- `python3 tools/codex_skills.py --root .codex/skills validate --strict` (pass)
- `python3 tools/codex_skills.py --root .codex/skills generate` (pass)
- `python3 tools/agent_skill_catalog.py --apply` (pass)
- `python3 tools/agilab_capabilities_manifest.py --apply` (pass)
- `python3 tools/agenticweb_manifest.py --apply` (pass)
- `python3 tools/agent_skill_catalog.py --check` (pass)
- `python3 tools/agilab_capabilities_manifest.py --check` (pass)
- `python3 tools/agenticweb_manifest.py --check` (pass)
- `python3 tools/agent_instruction_contract.py --check` (pass)
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files .claude/skills/agilab-deep-audit/SKILL.md .codex/skills/agilab-deep-audit/SKILL.md` (pass)
- `python3 tools/generate_skill_badges.py` (pass)
- `python3 tools/agent_skill_quality_guard.py --roots .claude/skills .codex/skills --fail-on high` (pass; existing low findings only)
- `python3 tools/skill_security_scan.py --roots .claude/skills .codex/skills --fail-on critical` (pass; existing medium/low findings only)
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile skills` (pass)
- `git diff --cached --check` (pass)

## Review Evidence
- Source: follow-up from AGILAB audit and PR #722.
- Result: future AGILAB audits should catch lab-specific benchmark helpers whose docs or outputs could be mistaken for portable evidence.
- Status: addressed in this PR.

## Agent Metadata
- Tokki version: not used
- Agent/runtime: Codex CLI
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used
