### PR TITLE
Enable clean-only Tokki launch updates

### DIFF
--- a/.tokki/profile
+++ b/.tokki/profile
@@ -1,5 +1,6 @@
 agilab
 agilab-clean-worktree
+repo-update-on-launch-clean-only
 agilab-validation-shortcuts
 agilab-builtin-apps
 agilab-docs-mirror


### PR DESCRIPTION
## Summary

- Enable AGILAB repo-local Tokki launch updates with `repo-update-on-launch-clean-only`.
- Preserve AGILAB clean-worktree semantics: dirty tracked changes skip the pull and record `repo_update_status=skipped_dirty` instead of autostashing.

## Validation

- `./dev scope --staged`
- `tokki doctor --strict`
- Launch smoke with temporary runtime/log paths: `repo_update_status=skipped_dirty`, `repo_update_exit_code=0`, `codex-cli 0.142.4`

## Review Evidence

- Reviewer model: unspecified in review handoff
- Result: no actionable correctness issues found; clean-only launch profile behavior has focused coverage and existing repo-update paths compile
- Findings addressed: not applicable

## Agent Metadata

- Tokki version: `tokki 1.0.16`
- Agent/runtime: Codex CLI `0.142.4` via Tokki wrapper
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used
