### PR TITLE
[codex] fix AGILAB page cache regressions

### DIFF
--- a/test/test_ui_pages.py
+++ b/test/test_ui_pages.py
@@ -1160,13 +1160,20 @@ def test_page_module_name_is_deterministic_for_resolved_path(tmp_path):
     assert len(relative_name.rsplit("_", 1)[-1]) == 16
 
 
-def test_navigation_pages_reuses_cached_page_list_until_disabled(monkeypatch):
+def test_navigation_pages_reuses_cached_page_list_until_disabled(monkeypatch, request):
     main_page = _import_agilab_module("agilab.main_page")
     main_page._NAVIGATION_PAGE_ROUTES.clear()
     main_page._NAVIGATION_PAGE_CACHE.clear()
     main_page._PAGE_RUNNER_CACHE.clear()
     for key in main_page._PAGE_CACHE_STATS:
         main_page._PAGE_CACHE_STATS[key] = 0
+
+    def cleanup_navigation_cache() -> None:
+        main_page._NAVIGATION_PAGE_ROUTES.clear()
+        main_page._NAVIGATION_PAGE_CACHE.clear()
+        main_page._PAGE_RUNNER_CACHE.clear()
+
+    request.addfinalizer(cleanup_navigation_cache)
     created_pages = []
 
     def fake_page(*args, **kwargs):


### PR DESCRIPTION
## Summary

Fixes review findings in the AGILAB Streamlit page-cache speed work.

- Keeps `AGILAB_DISABLE_NAVIGATION_PAGE_CACHE` scoped to navigation cache state only.
- Makes disabled module/runner/all-cache modes avoid repopulating their caches.
- Makes navigation page signatures derive names from the passed paths instead of a global tuple.
- Adds regressions for cache disable semantics, deterministic module names, navigation cache reuse, and test cleanup isolation.

## Repro

A code review of the recent `src/agilab/main_page.py` cache changes found that disable flags could repopulate caches, navigation-only cache disable cleared unrelated caches, and the new navigation cache test could leak fake `st.Page` objects into later AppTest runs.

## Root Cause

The cache layers were introduced incrementally, so read bypasses and write paths were not using a single disable decision. The navigation signature helper also mixed a caller-provided path tuple with a global file-name tuple. The test that monkeypatched `st.Page` did not clear the global navigation route cache after execution.

## Regression Test

Added and updated focused tests in `test/test_ui_pages.py` for:

- module cache disable no-store behavior
- all-page-cache disable no-store behavior
- deterministic module names for resolved paths
- navigation cache reuse and navigation-only disable behavior
- custom navigation signatures using passed paths
- cleanup of monkeypatched navigation route state

## Validation

Passed:

- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files src/agilab/main_page.py test/test_ui_pages.py`
- `uv --preview-features extra-build-dependencies run pytest test/test_ui_pages.py -q -k "navigation_page or page_file_runner or page_module_name or page_module_cache or all_page_caches"`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_ui_pages.py`
- `uv --preview-features extra-build-dependencies run ruff check --ignore E402 src/agilab/main_page.py test/test_ui_pages.py`
- `./dev scope --staged`
- `python3 tools/agent_commit_provenance_guard.py --check-config`

Not treated as passing evidence:

- Direct `ruff check` without `--ignore E402` reports the pre-existing delayed `streamlit` import in `src/agilab/main_page.py`.
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui` failed in the reports slice at `test/test_production_readiness_report.py::test_build_report_passes_static_production_readiness_contracts` while unrelated local docs/package edits were present in the working tree. The branch diff is limited to `src/agilab/main_page.py` and `test/test_ui_pages.py`.

## Review Evidence

Codex GPT-5 reviewed the recent cache changes before this fix. Findings were addressed in this branch. No sub-agents edited or reviewed files.

## Agent Metadata

- Tokki version: `tokki 1.0.16`
- Agent/runtime: Codex GPT-5, version unknown
- Model: GPT-5
- Reasoning effort: unknown
- `/fast` mode: unknown


## GitHub Checks

Current PR checks passed: GitGuardian, repo-guardrails clean public installs on macOS/Ubuntu/Windows, local-only-policy, and windows-core-tests. public-demo-smoke was skipped by workflow policy.
