### PR TITLE
package: promote data quality gate app package

### DIFF
--- a/agilab-capabilities.json
+++ b/agilab-capabilities.json
@@ -594,7 +594,7 @@
     {
       "name": "agi-app-data-quality-gate",
       "role": "app-project",
-      "status": "Release artifact",
+      "status": "PyPI app package",
       "version": "2026.06.23",
       "description": "AGILAB deterministic data contract, drift, leakage, and promotion gate",
       "project": "src/agilab/lib/agi-app-data-quality-gate",
@@ -673,7 +673,7 @@
     {
       "project": "data_quality_gate_project",
       "package": "agi-app-data-quality-gate",
-      "status": "Release artifact",
+      "status": "PyPI app package",
       "source": "src/agilab/lib/agi-app-data-quality-gate",
       "version": "2026.06.23",
       "description": "AGILAB deterministic data contract, drift, leakage, and promotion gate"

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 277,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "30231369d8ba61fded89b6adef794ff685640be055eb66b75ed426caa874e773",
+  "source_digest_sha256": "ad1b2cd152c88ff67cfb468fc38f045f7865b71d741f2aa5fef0fa2a7d5fd861",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "30231369d8ba61fded89b6adef794ff685640be055eb66b75ed426caa874e773"
+  "target_digest_sha256": "ad1b2cd152c88ff67cfb468fc38f045f7865b71d741f2aa5fef0fa2a7d5fd861"
 }

--- a/docs/source/minimal-app-project.rst
+++ b/docs/source/minimal-app-project.rst
@@ -7,8 +7,9 @@ Overview
 - Demonstrates the project layout expected by the platform (manager package,
   worker package, ``app_args`` definitions, Analysis configuration) with minimal
   business logic so you can focus on custom code.
-- Ships with blank web forms and prompt files to illustrate where to plug
-  in UI customisation and WORKFLOW prompts.
+- Ships with a small custom Streamlit argument form and an empty
+  ``pre_prompt.json`` prompt seed so copied projects have explicit places for
+  UI customisation and WORKFLOW prompts.
 
 Scientific placeholders
 -----------------------
@@ -25,29 +26,38 @@ data loading, feature extraction, and artifact export around this core loop.
 
 Manager (`minimal_app.minimal_app`)
 -----------------------------------
-- Lightweight subclass of ``BaseWorker`` that shows how to wire argument
-  handling, logging and dataframe export without heavy dependencies.
-- Provides the same ``from_toml`` / ``to_toml`` helpers as production projects so
-  you can reuse the Orchestrate page snippets verbatim.
+- Lightweight ``BaseWorker`` subclass that prepares app-owned shared input and
+  output directories through ``env.resolve_share_path``.
+- Accepts validated ``MinimalAppArgs`` values, supports ``reset_target`` cleanup
+  of the output directory, and keeps ``from_toml`` / ``to_toml`` helpers for the
+  same settings round-trip used by richer apps.
+- Leaves work distribution as a template hook: ``build_distribution`` currently
+  returns empty placeholder structures until a copied project adds real stages.
 
 Args (`minimal_app.app_args`)
 -----------------------------
-- Simple Pydantic model that mirrors the keys present in ``app_settings.toml``.
-- Ideal starting point for capturing new configuration options; extend the model
-  and the web form generated on the Orchestrate page will pick them up.
+- Simple Pydantic model with defaults for ``data_in``, ``data_out``, ``files``,
+  ``nfile``, ``nskip``, ``nread``, and ``reset_target``.
+- ``src/app_settings.toml`` intentionally seeds an empty ``[args]`` table; the
+  runtime loads model defaults, then persists concrete values only after the
+  custom ``src/app_args_form.py`` edits them.
+- The model still migrates legacy ``data_uri`` input into ``data_in`` so older
+  snippets can be adapted without changing the scaffold shape first.
 
 Worker (`minimal_app_worker.minimal_app_worker`)
 ------------------------------------------------
-- Skeleton worker that demonstrates the lifecycle hooks (``start``,
-  ``work_init``, ``run``) required by the distributor.
-- Includes placeholder logic for dataset loading and result persistence—replace
-  with your domain-specific processing stages.
+- Concrete ``MinimalAppWorker`` subclass of ``agi_node.polars_worker.PolarsWorker``.
+- It intentionally adds no domain logic; the class exists so installers and
+  worker deployment can discover a real worker package while copied projects
+  replace the inherited placeholder behavior with domain-specific processing.
 
 Reducer contract status
 -----------------------
-``minimal_app_project`` is template-only. It intentionally does not ship a reducer
-contract because the manager and worker contain placeholders and no concrete
-merge output.
+``minimal_app_project`` is template-only. It intentionally does not ship a
+reducer contract because the manager distribution hook and worker behavior are
+scaffold placeholders and no concrete merge output exists yet. This is an
+explicit reducer exemption for the starter template, not a gap in a promoted
+domain app.
 
 When a cloned project starts producing durable worker summaries, add a
 ``reduction.py`` module, emit ``reduce_summary_worker_<id>.json`` artifacts, and
@@ -57,12 +67,17 @@ starter template as an unfinished built-in app.
 
 Assets & Tests
 --------------
-- ``app_test.py`` ensures the installer and worker skeleton keep working as the
-  template evolves.
-- ``test/_test_*`` modules show how to unit-test managers and workers in
-  isolation.
-- ``app_args_form.py`` provides the optional web form that mirrors the
-  generated UI; tailor it when you need additional validation or widgets.
+- ``README.md`` and ``pyproject.toml`` describe the installable project package
+  and its runtime dependencies.
+- ``src/app_settings.toml`` carries cluster defaults plus the intentionally
+  empty ``[args]`` seed.
+- ``src/app_args_form.py`` is the current custom ORCHESTRATE form for path and
+  small run-control arguments; tailor it when you need additional validation or
+  widgets.
+- ``src/pre_prompt.json`` is currently an empty prompt list.
+- Repo-level tests exercise the installer, clone path, runtime bootstrap, and
+  minimal app environment behavior rather than project-local ``test/_test_*``
+  files.
 
 API Reference
 -------------

--- a/docs/source/package-publishing-policy.rst
+++ b/docs/source/package-publishing-policy.rst
@@ -110,15 +110,15 @@ recommended use cases, see :doc:`public-app-catalog`.
 - ``agi-app-uav-queue``
 - ``agi-app-uav-relay-queue``
 
-Ten app payload packages are promoted to PyPI in the current release plan:
+Eleven app payload packages are promoted to PyPI in the current release plan:
 ``agi-app-mission-decision``, ``agi-app-pandas-execution``,
 ``agi-app-polars-execution``, ``agi-app-flight-telemetry``,
 ``agi-app-multi-dag``, ``agi-app-weather-forecast``,
-``agi-app-sklearn-pipeline``, ``agi-app-pytorch-playground``,
-``agi-app-tescia-diagnostic``, and ``agi-app-uav-relay-queue``. The
-remaining app project payloads, ``agi-app-data-quality-gate`` and
-``agi-app-uav-queue``, are also built as wheel and source-distribution
-artifacts and kept in the GitHub Release distribution archive until they are
+``agi-app-sklearn-pipeline``, ``agi-app-data-quality-gate``,
+``agi-app-pytorch-playground``, ``agi-app-tescia-diagnostic``, and
+``agi-app-uav-relay-queue``. The remaining app project payload,
+``agi-app-uav-queue``, is also built as a wheel and source-distribution
+artifact and kept in the GitHub Release distribution archive until it is
 explicitly promoted. Each payload is staged during package build, with local
 virtual environments, compiled artifacts, locks, and generated build outputs
 excluded.

--- a/docs/source/public-app-catalog.rst
+++ b/docs/source/public-app-catalog.rst
@@ -53,7 +53,7 @@ Status legend:
        hashes.
    * - ``data_quality_gate_project``
      - ``agi-app-data-quality-gate``
-     - Release artifact
+     - PyPI app package
      - Production-adjacent data gate for contract, drift, leakage, and
        promotion-decision evidence before training.
    * - ``mission_decision_project``

--- a/src/agilab/app_management/pypi_app_packages.py
+++ b/src/agilab/app_management/pypi_app_packages.py
@@ -48,6 +48,7 @@ PROMOTED_PYPI_APP_PACKAGES: tuple[str, ...] = (
     "agi-app-polars-execution",
     "agi-app-pytorch-playground",
     "agi-app-sklearn-pipeline",
+    "agi-app-data-quality-gate",
     "agi-app-tescia-diagnostic",
     "agi-app-uav-relay-queue",
     "agi-app-weather-forecast",

--- a/src/agilab/lib/agi-apps/README.md
+++ b/src/agilab/lib/agi-apps/README.md
@@ -9,12 +9,12 @@ distributions. Promoted app payloads now live in focused PyPI packages:
 `agi-app-mission-decision`, `agi-app-pandas-execution`,
 `agi-app-polars-execution`, `agi-app-flight-telemetry`, `agi-app-multi-dag`,
 `agi-app-weather-forecast`, `agi-app-sklearn-pipeline`,
-`agi-app-pytorch-playground`, `agi-app-tescia-diagnostic`, and
-`agi-app-uav-relay-queue`.
+`agi-app-data-quality-gate`, `agi-app-pytorch-playground`,
+`agi-app-tescia-diagnostic`, and `agi-app-uav-relay-queue`.
 
-Release-artifact app payloads such as `agi-app-data-quality-gate` remain
-installable from GitHub Release archives until they are explicitly promoted to
-PyPI and pulled by this umbrella.
+Release-artifact app payloads such as `agi-app-uav-queue` remain installable
+from GitHub Release archives until they are explicitly promoted to PyPI and
+pulled by this umbrella.
 
 The umbrella keeps the lightweight `agilab.apps.install` helper and
 `agilab.examples` learning assets. It also bundles `minimal_app_project` as the

--- a/src/agilab/lib/agi-apps/pyproject.toml
+++ b/src/agilab/lib/agi-apps/pyproject.toml
@@ -31,7 +31,7 @@ keywords = [
     "workflow-orchestration",
 ]
 
-dependencies = ["agi-core==2026.06.24", "agi-app-mission-decision==2026.06.24", "agi-app-pandas-execution==2026.06.23", "agi-app-polars-execution==2026.06.23", "agi-app-flight-telemetry==2026.06.24", "agi-app-multi-dag==2026.06.23", "agi-app-weather-forecast==2026.06.24", "agi-app-sklearn-pipeline==2026.06.23", "agi-app-pytorch-playground==2026.06.24; python_version >= '3.12'", "agi-app-tescia-diagnostic==2026.06.23; python_version >= '3.13'", "agi-app-uav-relay-queue==2026.06.24; python_version >= '3.13'"]
+dependencies = ["agi-core==2026.06.24", "agi-app-mission-decision==2026.06.24", "agi-app-pandas-execution==2026.06.23", "agi-app-polars-execution==2026.06.23", "agi-app-flight-telemetry==2026.06.24", "agi-app-multi-dag==2026.06.23", "agi-app-weather-forecast==2026.06.24", "agi-app-sklearn-pipeline==2026.06.23", "agi-app-data-quality-gate==2026.06.23", "agi-app-pytorch-playground==2026.06.24; python_version >= '3.12'", "agi-app-tescia-diagnostic==2026.06.23; python_version >= '3.13'", "agi-app-uav-relay-queue==2026.06.24; python_version >= '3.13'"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/tools/package_split_contract.py
+++ b/tools/package_split_contract.py
@@ -46,6 +46,7 @@ PROMOTED_APP_PROJECT_PACKAGE_NAMES: tuple[str, ...] = (
     "agi-app-multi-dag",
     "agi-app-weather-forecast",
     "agi-app-sklearn-pipeline",
+    "agi-app-data-quality-gate",
     "agi-app-pytorch-playground",
     "agi-app-tescia-diagnostic",
     "agi-app-uav-relay-queue",


### PR DESCRIPTION
## Summary

- Promotes `agi-app-data-quality-gate` into the PyPI app package contract and generated promoted-package registry.
- Adds `agi-app-data-quality-gate==2026.06.23` to the `agi-apps` umbrella dependency list.
- Updates AGILAB docs mirror, package catalog text, capabilities metadata, and docs mirror stamp.
- Keeps the canonical docs source paired with jpmorard/thales_agilab#118.

## Validation

- `./dev scope --staged`
- `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --staged`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_pypi_app_packages.py test/test_pyproject_dependency_hygiene.py test/test_package_split_contract.py`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_public_app_catalog.py test/test_release_plan.py test/test_pypi_trusted_publisher_contract.py test/test_agilab_capabilities_lint.py test/test_app_installer_packaging.py`
- `uv --preview-features extra-build-dependencies run python tools/app_contract_matrix.py --quiet`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile docs`
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui`
- `uv --preview-features extra-build-dependencies run python tools/release_plan.py --packages agi-app-data-quality-gate --skip-existing-pypi`
- `uv --preview-features extra-build-dependencies run python tools/pypi_publish.py --repo pypi --packages agi-app-data-quality-gate --dry-run --skip-cleanup`

## PyPI publication state

- PyPI JSON/simple endpoints currently return 404 for `agi-app-data-quality-gate`, so there is no existing project/version collision.
- Local dry-run selects `agi-app-data-quality-gate 2026.06.23` and would build/upload both artifacts.
- Live PyPI publication was not dispatched in this PR.

## Review Evidence

- Model/sub-agent review: not used.

## Agent Metadata

- Tokki version: tokki 1.0.16
- Agent/runtime: codex-cli 0.142.4
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used


## GitHub Checks

- GitGuardian Security Checks: passed
- docs-source-guard / verify: passed
- repo-guardrails / local-only-policy: passed
- repo-guardrails / clean-public-install (ubuntu-latest): passed
- repo-guardrails / clean-public-install (macos-latest): passed
- repo-guardrails / clean-public-install (windows-latest): passed
- repo-guardrails / public-demo-smoke: skipped by workflow policy
