### PR TITLE
release: allow selected first PyPI publish audit

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -63,9 +63,20 @@ jobs:
         run: python -m pip install --upgrade --no-cache-dir uv
 
       - name: Run strict AGILAB audit review
+        env:
+          RELEASE_PACKAGES: ${{ github.event.inputs.packages || '' }}
+          RELEASE_ROLES: ${{ github.event.inputs.roles || '' }}
         run: |
           set -euxo pipefail
-          uv --preview-features extra-build-dependencies run python tools/agilab_audit.py --strict
+          audit_args=(--strict)
+          if [ -n "${RELEASE_PACKAGES:-}" ]; then
+            audit_args+=(--pypi-package "$RELEASE_PACKAGES")
+            audit_args+=(--allow-missing-pypi-project "$RELEASE_PACKAGES")
+          fi
+          if [ -n "${RELEASE_ROLES:-}" ]; then
+            audit_args+=(--pypi-role "$RELEASE_ROLES")
+          fi
+          uv --preview-features extra-build-dependencies run python tools/agilab_audit.py "${audit_args[@]}"
 
       - name: Fail on accidental O.* version typos in published packages
         run: |

--- a/test/test_agilab_audit.py
+++ b/test/test_agilab_audit.py
@@ -70,3 +70,55 @@ def test_audit_worktree_reports_missing_path_without_running_git(tmp_path: Path)
     assert report["status"] == "missing worktree path"
     assert report["head"] is None
     assert "missing worktree path; run git worktree prune" in report["warnings"]
+
+
+def test_audit_preflight_accepts_selected_first_publish_project(monkeypatch) -> None:
+    calls = []
+
+    monkeypatch.setattr(agilab_audit, "_worktrees", lambda: [])
+    monkeypatch.setattr(
+        agilab_audit,
+        "_command_check",
+        lambda name, command, timeout=120: {
+            "name": name,
+            "status": "pass",
+            "returncode": 0,
+            "summary": "ok",
+        },
+    )
+
+    def fake_preflight_report(**kwargs):
+        calls.append(kwargs)
+        return {
+            "status": "pass",
+            "summary": {
+                "checked": 1,
+                "current": 0,
+                "to_publish": 0,
+                "allowed_missing_projects": 1,
+                "blockers": 0,
+            },
+        }
+
+    monkeypatch.setattr(agilab_audit, "pypi_preflight_report", fake_preflight_report)
+    monkeypatch.setenv("AGILAB_ALLOW_MISSING_PYPI_PROJECTS", "agi-app-extra")
+
+    report = agilab_audit.build_report(
+        fetch=False,
+        network=True,
+        pypi_package_names=["agi-app-data-quality-gate"],
+        allowed_missing_pypi_projects=["agi-app-data-quality-gate"],
+    )
+
+    assert report["status"] == "pass"
+    assert calls == [
+        {
+            "repo_root": agilab_audit.ROOT,
+            "package_names": ["agi-app-data-quality-gate"],
+            "roles": [],
+            "allowed_missing_projects": [
+                "agi-app-data-quality-gate",
+                "agi-app-extra",
+            ],
+        }
+    ]

--- a/test/test_pypi_publish_workflow.py
+++ b/test/test_pypi_publish_workflow.py
@@ -120,8 +120,10 @@ def test_pypi_publish_release_tests_use_local_parity_profiles() -> None:
     assert 'python-version: ["3.13"]' in text
     assert 'python-version: ["3.13", "3.14"]' not in text
     assert "Run strict AGILAB audit review" in text
-    assert "tools/agilab_audit.py --strict" in text
-    assert text.index("tools/agilab_audit.py --strict") < text.index(
+    assert "audit_args=(--strict)" in text
+    assert "--allow-missing-pypi-project" in text
+    assert "tools/agilab_audit.py" in text
+    assert text.index("tools/agilab_audit.py") < text.index(
         "Install Playwright browser for frontend smoke"
     )
     assert "Resolve Playwright version for browser cache key" in text

--- a/tools/agilab_audit.py
+++ b/tools/agilab_audit.py
@@ -21,6 +21,13 @@ ROOT = Path(__file__).resolve().parents[1]
 SCHEMA_VERSION = "agilab.audit.v1"
 
 
+def _split_values(values: Sequence[str] | None) -> list[str]:
+    tokens: list[str] = []
+    for value in values or ():
+        tokens.extend(token for token in value.replace(",", " ").split() if token)
+    return tokens
+
+
 def _run(command: list[str], *, cwd: Path = ROOT, timeout: int = 60) -> tuple[int, str, str]:
     try:
         completed = subprocess.run(
@@ -136,7 +143,14 @@ def _command_check(name: str, command: list[str], *, timeout: int = 120) -> dict
     }
 
 
-def build_report(*, fetch: bool = True, network: bool = True) -> dict[str, Any]:
+def build_report(
+    *,
+    fetch: bool = True,
+    network: bool = True,
+    pypi_package_names: Sequence[str] | None = None,
+    pypi_roles: Sequence[str] | None = None,
+    allowed_missing_pypi_projects: Sequence[str] | None = None,
+) -> dict[str, Any]:
     worktree_reports = [
         _audit_worktree(Path(entry["worktree"]), fetch=fetch)
         for entry in _worktrees()
@@ -158,7 +172,15 @@ def build_report(*, fetch: bool = True, network: bool = True) -> dict[str, Any]:
     ]
     pypi_report: dict[str, Any] | None = None
     if network:
-        pypi_report = pypi_preflight_report(repo_root=ROOT)
+        pypi_report = pypi_preflight_report(
+            repo_root=ROOT,
+            package_names=_split_values(pypi_package_names),
+            roles=_split_values(pypi_roles),
+            allowed_missing_projects=[
+                *_split_values(allowed_missing_pypi_projects),
+                *_split_values([os.environ.get("AGILAB_ALLOW_MISSING_PYPI_PROJECTS", "")]),
+            ],
+        )
     warnings = [
         f"{report['path']}: {warning}"
         for report in worktree_reports
@@ -195,10 +217,12 @@ def render_text(report: dict[str, Any]) -> str:
     if report.get("pypi_preflight"):
         summary = report["pypi_preflight"]["summary"]
         lines.append("")
+        allowed_missing = summary.get("allowed_missing_projects", 0)
         lines.append(
             "PyPI preflight: "
             f"{report['pypi_preflight']['status']} "
-            f"({summary['current']}/{summary['checked']} current, {summary['blockers']} blockers)"
+            f"({summary['current']}/{summary['checked']} current, "
+            f"{summary['blockers']} blockers, {allowed_missing} allowed missing)"
         )
     if report["warnings"]:
         lines.append("")
@@ -211,6 +235,17 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--no-fetch", action="store_true")
     parser.add_argument("--no-network", action="store_true")
+    parser.add_argument("--pypi-package", dest="pypi_packages", action="append")
+    parser.add_argument("--pypi-role", dest="pypi_roles", action="append")
+    parser.add_argument(
+        "--allow-missing-pypi-project",
+        dest="allowed_missing_pypi_projects",
+        action="append",
+        help=(
+            "Allow an explicitly selected missing PyPI project after its pending "
+            "trusted publisher was registered. Matches package or PyPI project name."
+        ),
+    )
     parser.add_argument("--json", action="store_true")
     parser.add_argument("--strict", action="store_true", help="Exit non-zero on warnings.")
     return parser.parse_args(argv)
@@ -218,7 +253,13 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = parse_args(argv)
-    report = build_report(fetch=not args.no_fetch, network=not args.no_network)
+    report = build_report(
+        fetch=not args.no_fetch,
+        network=not args.no_network,
+        pypi_package_names=args.pypi_packages,
+        pypi_roles=args.pypi_roles,
+        allowed_missing_pypi_projects=args.allowed_missing_pypi_projects,
+    )
     if args.json:
         print(json.dumps(report, indent=2, sort_keys=True))
     else:


### PR DESCRIPTION
## Summary

- Fixes the `pypi-publish` release-audit blocker for intentionally selected first-time PyPI package publishes.
- Adds `tools/agilab_audit.py` package/role filters plus `--allow-missing-pypi-project` for pending trusted-publisher projects.
- Updates `pypi-publish.yaml` so package-filtered manual dispatches audit the selected package and allow that selected package as a first trusted publish candidate.
- Adds focused regression coverage for the audit path and workflow contract.

## Repro

- Dispatching `pypi-publish.yaml` for `packages=agi-app-data-quality-gate` failed in `release-audit` before any publish job ran.
- Run: https://github.com/ThalesGroup/agilab/actions/runs/28373592422

## Root Cause

- The release audit always ran global PyPI project preflight.
- `agi-app-data-quality-gate` is a legitimate first trusted-publisher publish target, so PyPI currently returns a missing-project state.
- The selected release plan allowed publishing that package, but the earlier global audit treated the missing first-publish project as a blocker.

## Regression Test

- `test/test_agilab_audit.py` now proves the audit passes selected package names and allowed missing first-publish projects into PyPI preflight.
- `test/test_pypi_publish_workflow.py` now proves the workflow supplies the selected package and allow-missing flag to the audit step.

## Validation

- `./dev scope --staged`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_agilab_audit.py test/test_pypi_publish_workflow.py test/test_release_robustness_tools.py`
- `uv --preview-features extra-build-dependencies run python - <<'PY' ... yaml.safe_load(...) ... PY`
- `uv --preview-features extra-build-dependencies run python tools/release_plan.py --check-workflow .github/workflows/pypi-publish.yaml --packages agi-app-data-quality-gate --skip-existing-pypi`
- `uv --preview-features extra-build-dependencies run python tools/agilab_audit.py --strict --pypi-package agi-app-data-quality-gate --allow-missing-pypi-project agi-app-data-quality-gate` reached `PyPI preflight: pass`; the local command still exited non-zero because this workstation has dirty changes and a stale detached AGILAB worktree, which are not present on GitHub runners.

## Review Evidence

- Model/sub-agent review: not used.

## Agent Metadata

- Tokki version: tokki 1.0.16
- Agent/runtime: codex-cli 0.142.4
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used


## GitHub Checks

- GitGuardian Security Checks: passed
- repo-guardrails / local-only-policy: passed
- repo-guardrails / clean-public-install (ubuntu-latest): passed
- repo-guardrails / clean-public-install (macos-latest): passed
- repo-guardrails / clean-public-install (windows-latest): passed
- windows-core-tests: passed
- repo-guardrails / public-demo-smoke: skipped by workflow policy
