### PR TITLE
[codex] Harden PyPI first-publish release flow

### DIFF
--- a/.github/workflows/pypi-pending-trusted-publisher.yaml
+++ b/.github/workflows/pypi-pending-trusted-publisher.yaml
@@ -28,7 +28,7 @@ on:
 
 permissions:
   contents: read
-  actions: read
+  actions: write
 
 jobs:
   register:
@@ -66,5 +66,7 @@ jobs:
             --github-confirm-login-variable "PYPI_CONFIRM_LOGIN_URL" \
             --github-confirm-login-timeout 900 \
             --github-token "${PYPI_CONFIRM_READER_TOKEN:-$GITHUB_TOKEN}" \
+            --github-confirm-login-cleanup-token "$GITHUB_TOKEN" \
+            --delete-github-confirm-login-variable-after-use \
             --json \
             --github-step-summary "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -9,6 +9,9 @@ on:
       packages:
         description: "Optional comma- or space-separated package names to publish. Default: all."
         required: false
+      first_publish_packages:
+        description: "Optional package/PyPI names whose missing projects are expected after pending trusted publisher registration."
+        required: false
       roles:
         description: "Optional comma- or space-separated package roles to publish. Default: all."
         required: false
@@ -65,13 +68,16 @@ jobs:
       - name: Run strict AGILAB audit review
         env:
           RELEASE_PACKAGES: ${{ github.event.inputs.packages || '' }}
+          FIRST_PUBLISH_PACKAGES: ${{ github.event.inputs.first_publish_packages || '' }}
           RELEASE_ROLES: ${{ github.event.inputs.roles || '' }}
         run: |
           set -euxo pipefail
           audit_args=(--strict)
           if [ -n "${RELEASE_PACKAGES:-}" ]; then
             audit_args+=(--pypi-package "$RELEASE_PACKAGES")
-            audit_args+=(--allow-missing-pypi-project "$RELEASE_PACKAGES")
+          fi
+          if [ -n "${FIRST_PUBLISH_PACKAGES:-}" ]; then
+            audit_args+=(--allow-missing-pypi-project "$FIRST_PUBLISH_PACKAGES")
           fi
           if [ -n "${RELEASE_ROLES:-}" ]; then
             audit_args+=(--pypi-role "$RELEASE_ROLES")

--- a/test/test_pypi_pending_trusted_publisher.py
+++ b/test/test_pypi_pending_trusted_publisher.py
@@ -395,6 +395,90 @@ def test_existing_public_project_does_not_require_credentials(monkeypatch, capsy
     assert "PYPI_RELEASE_PRUNE_USERNAME" not in captured.err
 
 
+def test_cleanup_github_confirm_login_variable_uses_delete_helper(
+    monkeypatch,
+    capsys,
+) -> None:
+    module = _load_module()
+    calls: list[dict[str, str]] = []
+
+    def fake_delete(**kwargs):
+        calls.append(kwargs)
+        return True
+
+    monkeypatch.setattr(module, "_delete_github_actions_variable", fake_delete)
+
+    module._cleanup_github_confirm_login_variable(
+        repository="ThalesGroup/agilab",
+        variable="PYPI_CONFIRM_LOGIN_URL",
+        token="secret-token",
+    )
+
+    captured = capsys.readouterr()
+    assert calls == [
+        {
+            "repository": "ThalesGroup/agilab",
+            "variable": "PYPI_CONFIRM_LOGIN_URL",
+            "token": "secret-token",
+        }
+    ]
+    assert "Cleared temporary GitHub Actions variable" in captured.err
+    assert "PYPI_CONFIRM_LOGIN_URL" in captured.err
+    assert "secret-token" not in captured.err
+
+
+def test_main_cleans_confirmation_variable_after_registration(monkeypatch) -> None:
+    module = _load_module()
+    cleanup_calls: list[dict[str, str]] = []
+
+    monkeypatch.setattr(module, "_public_project_exists", lambda _project, _repo: False)
+    monkeypatch.setattr(module, "require_credentials", lambda _user, _password: ("u", "p"))
+    monkeypatch.setattr(module, "resolve_auth_code", lambda _otp, _totp: None)
+    monkeypatch.setattr(
+        module,
+        "_cleanup_github_confirm_login_variable",
+        lambda **kwargs: cleanup_calls.append(kwargs),
+    )
+
+    def fake_register(**kwargs):
+        return module.RegistrationResult(
+            publisher=kwargs["publisher"],
+            registered=True,
+            already_registered=False,
+        )
+
+    monkeypatch.setattr(module, "register_pending_github_publisher", fake_register)
+
+    assert (
+        module.main(
+            [
+                "--project-name",
+                "agi-page-scenario-cockpit",
+                "--environment",
+                "pypi-agi-page-scenario-cockpit",
+                "--github-confirm-login-repository",
+                "ThalesGroup/agilab",
+                "--github-confirm-login-variable",
+                "PYPI_CONFIRM_LOGIN_URL",
+                "--github-token",
+                "reader-token",
+                "--github-confirm-login-cleanup-token",
+                "writer-token",
+                "--delete-github-confirm-login-variable-after-use",
+            ]
+        )
+        == 0
+    )
+
+    assert cleanup_calls == [
+        {
+            "repository": "ThalesGroup/agilab",
+            "variable": "PYPI_CONFIRM_LOGIN_URL",
+            "token": "writer-token",
+        }
+    ]
+
+
 def test_register_rejects_pending_publisher_for_different_project() -> None:
     module = _load_module()
     publisher = module.PendingGitHubPublisher(
@@ -417,6 +501,7 @@ def test_pending_trusted_publisher_workflow_uses_release_web_credentials() -> No
     text = WORKFLOW_PATH.read_text(encoding="utf-8")
 
     assert "workflow_dispatch:" in text
+    assert "permissions:\n  contents: read\n  actions: write" in text
     assert "tools/pypi_pending_trusted_publisher.py" in text
     assert "PYPI_RELEASE_PRUNE_USERNAME: ${{ secrets.PYPI_RELEASE_PRUNE_USERNAME }}" in text
     assert "PYPI_RELEASE_PRUNE_PASSWORD: ${{ secrets.PYPI_RELEASE_PRUNE_PASSWORD }}" in text
@@ -427,3 +512,5 @@ def test_pending_trusted_publisher_workflow_uses_release_web_credentials() -> No
     assert "--environment \"${{ inputs.pypi_environment }}\"" in text
     assert "--github-confirm-login-variable \"PYPI_CONFIRM_LOGIN_URL\"" in text
     assert "--github-token \"${PYPI_CONFIRM_READER_TOKEN:-$GITHUB_TOKEN}\"" in text
+    assert "--github-confirm-login-cleanup-token \"$GITHUB_TOKEN\"" in text
+    assert "--delete-github-confirm-login-variable-after-use" in text

--- a/test/test_pypi_publish_workflow.py
+++ b/test/test_pypi_publish_workflow.py
@@ -121,7 +121,13 @@ def test_pypi_publish_release_tests_use_local_parity_profiles() -> None:
     assert 'python-version: ["3.13", "3.14"]' not in text
     assert "Run strict AGILAB audit review" in text
     assert "audit_args=(--strict)" in text
-    assert "--allow-missing-pypi-project" in text
+    assert "first_publish_packages:" in text
+    assert (
+        "FIRST_PUBLISH_PACKAGES: ${{ github.event.inputs.first_publish_packages || '' }}"
+        in text
+    )
+    assert 'audit_args+=(--allow-missing-pypi-project "$FIRST_PUBLISH_PACKAGES")' in text
+    assert 'audit_args+=(--allow-missing-pypi-project "$RELEASE_PACKAGES")' not in text
     assert "tools/agilab_audit.py" in text
     assert text.index("tools/agilab_audit.py") < text.index(
         "Install Playwright browser for frontend smoke"

--- a/test/test_release_robustness_tools.py
+++ b/test/test_release_robustness_tools.py
@@ -20,6 +20,7 @@ def _load_tool(name: str):
 
 pending_publisher = _load_tool("pypi_pending_trusted_publisher")
 pypi_project_preflight = _load_tool("pypi_project_preflight")
+release_handoff = _load_tool("release_handoff")
 release_handoff_guard = _load_tool("release_handoff_guard")
 release_status = _load_tool("release_status")
 
@@ -98,6 +99,37 @@ def test_pypi_project_preflight_allows_explicit_missing_project_for_first_publis
         == "agi-page-live-artifacts"
     )
     assert report["blockers"] == []
+
+
+def test_release_handoff_dispatch_allowlist_matches_missing_first_publish_projects(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(release_handoff, "_run_text", lambda _command: "")
+
+    text = release_handoff.render_handoff(
+        "v2026.05.26",
+        {
+            "status": "fail",
+            "summary": {"checked": 1, "blockers": 1},
+            "blockers": [
+                {
+                    "status": "missing-project",
+                    "pypi_project": "agi-page-live-artifacts",
+                    "pypi_environment": "pypi-agi-page-live-artifacts",
+                    "version": "2026.05.26",
+                    "pending_publisher_command": (
+                        "gh workflow run pypi-pending-trusted-publisher.yaml "
+                        "-R ThalesGroup/agilab --ref main "
+                        "-f project_name=agi-page-live-artifacts "
+                        "-f pypi_environment=pypi-agi-page-live-artifacts"
+                    ),
+                }
+            ],
+        },
+    )
+
+    assert "pypi-pending-trusted-publisher.yaml" in text
+    assert "-f 'first_publish_packages=agi-page-live-artifacts'" in text
 
 
 def test_pypi_project_preflight_caches_project_version_until_manifest_changes(

--- a/tools/pypi_pending_trusted_publisher.py
+++ b/tools/pypi_pending_trusted_publisher.py
@@ -26,6 +26,7 @@ try:
     from pypi_release_retention import (
         PYPI_HOSTS,
         PYPI_JSON_URLS,
+        _delete_github_actions_variable,
         _find_form,
         _fresh_totp_code,
         _submit_reauthentication_if_needed,
@@ -41,6 +42,7 @@ except ModuleNotFoundError:  # pragma: no cover - used when imported as tools.*
     from tools.pypi_release_retention import (
         PYPI_HOSTS,
         PYPI_JSON_URLS,
+        _delete_github_actions_variable,
         _find_form,
         _fresh_totp_code,
         _submit_reauthentication_if_needed,
@@ -295,6 +297,32 @@ def _fetch_github_actions_variable(
         token=token,
     )
     return payload.value if payload else None
+
+
+def _cleanup_github_confirm_login_variable(
+    *,
+    repository: str,
+    variable: str,
+    token: str,
+) -> None:
+    try:
+        deleted = _delete_github_actions_variable(
+            repository=repository,
+            variable=variable,
+            token=token,
+        )
+    except RuntimeError as exc:
+        print(
+            "::warning title=PyPI pending trusted publisher::"
+            f"Unable to clear temporary GitHub Actions variable {variable!r}: {exc}",
+            file=sys.stderr,
+        )
+        return
+    if deleted:
+        print(
+            f"Cleared temporary GitHub Actions variable {variable!r}.",
+            file=sys.stderr,
+        )
 
 
 def _github_variable_is_fresh(
@@ -587,6 +615,22 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         ),
     )
     parser.add_argument("--github-token", default=os.environ.get("GITHUB_TOKEN"))
+    parser.add_argument(
+        "--github-confirm-login-cleanup-token",
+        default=os.environ.get("GITHUB_TOKEN"),
+        help=(
+            "GitHub token used to delete the temporary confirmation URL variable "
+            "after the registration attempt. Defaults to GITHUB_TOKEN."
+        ),
+    )
+    parser.add_argument(
+        "--delete-github-confirm-login-variable-after-use",
+        action="store_true",
+        help=(
+            "Delete the temporary GitHub Actions confirmation URL variable after "
+            "the registration attempt succeeds or fails."
+        ),
+    )
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument("--json", action="store_true")
     parser.add_argument(
@@ -607,49 +651,77 @@ def main(argv: Sequence[str] | None = None) -> int:
         environment=args.environment,
     )
 
-    if args.dry_run:
-        result = RegistrationResult(
-            publisher=publisher,
-            registered=False,
-            already_registered=False,
-            dry_run=True,
-        )
-    elif _public_project_exists(publisher.project_name, args.repo):
-        result = _existing_project_result(publisher)
-    else:
-        username, password = require_credentials(args.username, args.password)
-        confirm_provider = None
-        if args.github_confirm_login_variable and args.github_confirm_login_timeout > 0:
-            if not args.github_confirm_login_repository or not args.github_token:
-                raise SystemExit(
-                    "ERROR: GitHub confirmation polling needs GITHUB_REPOSITORY "
-                    "and GITHUB_TOKEN."
-                )
+    cleanup_confirm_variable = False
+    if args.delete_github_confirm_login_variable_after_use:
+        if not args.github_confirm_login_variable:
+            raise SystemExit(
+                "ERROR: GitHub confirmation cleanup needs "
+                "--github-confirm-login-variable."
+            )
+        if (
+            not args.github_confirm_login_repository
+            or not args.github_confirm_login_cleanup_token
+        ):
+            raise SystemExit(
+                "ERROR: GitHub confirmation cleanup needs GITHUB_REPOSITORY "
+                "and GITHUB_TOKEN."
+            )
+        cleanup_confirm_variable = True
 
-            def confirm_provider() -> str | None:
-                print(
-                    "Waiting for PyPI login confirmation URL in GitHub Actions "
-                    f"variable {args.github_confirm_login_variable!r}...",
-                    file=sys.stderr,
-                )
-                return _wait_for_github_confirm_login_url(
-                    repository=args.github_confirm_login_repository,
-                    variable=args.github_confirm_login_variable,
-                    token=args.github_token,
-                    timeout=args.github_confirm_login_timeout,
-                    poll_delay=args.github_confirm_login_poll_delay,
-                    allow_existing=args.allow_existing_github_confirm_login_url,
-                )
+    try:
+        if args.dry_run:
+            result = RegistrationResult(
+                publisher=publisher,
+                registered=False,
+                already_registered=False,
+                dry_run=True,
+            )
+        elif _public_project_exists(publisher.project_name, args.repo):
+            result = _existing_project_result(publisher)
+        else:
+            username, password = require_credentials(args.username, args.password)
+            confirm_provider = None
+            if (
+                args.github_confirm_login_variable
+                and args.github_confirm_login_timeout > 0
+            ):
+                if not args.github_confirm_login_repository or not args.github_token:
+                    raise SystemExit(
+                        "ERROR: GitHub confirmation polling needs GITHUB_REPOSITORY "
+                        "and GITHUB_TOKEN."
+                    )
 
-        result = register_pending_github_publisher(
-            publisher=publisher,
-            repo=args.repo,
-            username=username,
-            password=password,
-            auth_code=resolve_auth_code(args.otp_code, args.totp_secret),
-            confirm_login_url_provider=confirm_provider,
-            project_exists_checker=lambda _project, _repo: False,
-        )
+                def confirm_provider() -> str | None:
+                    print(
+                        "Waiting for PyPI login confirmation URL in GitHub Actions "
+                        f"variable {args.github_confirm_login_variable!r}...",
+                        file=sys.stderr,
+                    )
+                    return _wait_for_github_confirm_login_url(
+                        repository=args.github_confirm_login_repository,
+                        variable=args.github_confirm_login_variable,
+                        token=args.github_token,
+                        timeout=args.github_confirm_login_timeout,
+                        poll_delay=args.github_confirm_login_poll_delay,
+                        allow_existing=args.allow_existing_github_confirm_login_url,
+                    )
+
+            result = register_pending_github_publisher(
+                publisher=publisher,
+                repo=args.repo,
+                username=username,
+                password=password,
+                auth_code=resolve_auth_code(args.otp_code, args.totp_secret),
+                confirm_login_url_provider=confirm_provider,
+                project_exists_checker=lambda _project, _repo: False,
+            )
+    finally:
+        if cleanup_confirm_variable:
+            _cleanup_github_confirm_login_variable(
+                repository=args.github_confirm_login_repository,
+                variable=args.github_confirm_login_variable,
+                token=args.github_confirm_login_cleanup_token,
+            )
 
     summary = render_summary(result)
     if args.json:

--- a/tools/release_handoff.py
+++ b/tools/release_handoff.py
@@ -77,6 +77,11 @@ def render_handoff(tag: str, preflight: dict[str, Any]) -> str:
     if guardrails:
         lines.extend(["- Latest main guardrail run JSON:", "", "```json", guardrails, "```"])
     lines.extend(["", "## Pending trusted publishers", ""])
+    first_publish_packages = " ".join(
+        str(blocker["pypi_project"])
+        for blocker in blockers
+        if blocker.get("pypi_project")
+    )
     if not blockers:
         lines.append("No missing PyPI projects were detected. Dispatch the release workflow directly.")
     else:
@@ -101,15 +106,23 @@ def render_handoff(tag: str, preflight: dict[str, Any]) -> str:
                     "",
                 ]
             )
+    release_dispatch = [
+        "gh workflow run pypi-publish.yaml \\",
+        "  -R ThalesGroup/agilab \\",
+        "  --ref main \\",
+        f"  -f release_tag={tag}",
+    ]
+    if first_publish_packages:
+        release_dispatch[-1] = f"  -f release_tag={tag} \\"
+        release_dispatch.append(
+            f"  -f 'first_publish_packages={first_publish_packages}'"
+        )
     lines.extend(
         [
             "## Release dispatch",
             "",
             "```bash",
-            "gh workflow run pypi-publish.yaml \\",
-            "  -R ThalesGroup/agilab \\",
-            "  --ref main \\",
-            f"  -f release_tag={tag}",
+            *release_dispatch,
             "```",
             "",
             "## Release watch",


### PR DESCRIPTION
## Summary
- Require an explicit `first_publish_packages` workflow input before release audit allows missing PyPI projects.
- Delete the temporary `PYPI_CONFIRM_LOGIN_URL` repository variable after the pending trusted-publisher attempt succeeds or fails.
- Carry missing first-publish projects into generated release handoff dispatch commands.

## Repro
A selected first-publish package could make `pypi-publish.yaml` pass release audit with `--allow-missing-pypi-project "$RELEASE_PACKAGES"` before the pending trusted publisher was actually registered. The pending publisher flow also consumed a temporary PyPI login confirmation URL without automatically deleting the repository variable afterward.

## Root Cause
The release audit workflow used package selection as the same signal as first-publish readiness, and the pending-publisher workflow had read access to the confirmation variable but no cleanup step after use.

## Regression Test
- `test/test_pypi_publish_workflow.py` asserts missing PyPI projects are allowlisted only through `FIRST_PUBLISH_PACKAGES`, not `RELEASE_PACKAGES`.
- `test/test_pypi_pending_trusted_publisher.py` covers confirmation-variable cleanup and the workflow permission/flag contract.
- `test/test_release_robustness_tools.py` covers release handoff dispatch including detected first-publish packages.

## Validation
- Targeted pytest: passed.
- Impact validation for touched files: low risk; required pytest slice passed.
- Python compile smoke for changed tools: passed.
- Staged whitespace check: passed.
- GitHub checks: passed (`repo-guardrails` local-only-policy and clean-public-install matrix, `windows-core-tests`, GitGuardian). `public-demo-smoke` was skipped by workflow policy.

## Review Evidence
- Model or sub-agent review: not used.

## Agent Metadata
- Tokki version: `tokki 1.0.17`
- Agent/runtime: `Codex CLI / unavailable`
- Model: `GPT-5`
- Reasoning effort: `unknown`
- `/fast` mode: `not used`
