### PR TITLE
[codex] Fix invalid ANALYSIS app UI deep links

### DIFF
--- a/src/agilab/pages/4_ANALYSIS.py
+++ b/src/agilab/pages/4_ANALYSIS.py
@@ -1996,6 +1996,23 @@ def _consume_legacy_app_ui_route_for_app_surface(
     return True
 
 
+def _consume_invalid_app_ui_route(
+    current_page: str | None,
+    active_app_path: Path | None,
+) -> bool:
+    """Clear app UI deep links for projects that do not declare an app UI."""
+    if not _is_legacy_app_ui_route(current_page):
+        return False
+    if configured_app_surface_entrypoint(active_app_path) is not None:
+        return False
+    if _declared_app_ui_page_config(active_app_path) is not None:
+        return False
+    for key in ("current_page", _APP_SURFACE_HIDE_QUERY_PARAM):
+        if key in st.query_params:
+            del st.query_params[key]
+    return True
+
+
 async def _render_selected_notebook_route(current_notebook: str | None) -> bool:
     """Render a selected notebook route and surface one explicit user-facing failure."""
     if not current_notebook or current_notebook in ("", "main"):
@@ -3224,6 +3241,9 @@ async def main():
             notebook_names=notebook_names,
             notebook_lookup=notebook_lookup,
         )
+
+    if _consume_invalid_app_ui_route(current_page, active_app_path):
+        current_page = None
 
     route_view_path = (
         _resolve_view_path(current_page, resolved_pages, custom_view_lookup)

--- a/test/test_analysis_page_helpers.py
+++ b/test/test_analysis_page_helpers.py
@@ -752,6 +752,38 @@ def test_legacy_view_app_ui_route_opens_declared_app_surface(
     assert module._APP_SURFACE_HIDE_QUERY_PARAM not in fake_st.query_params
 
 
+def test_invalid_app_ui_route_without_declared_ui_is_cleared(
+    tmp_path: Path, monkeypatch
+):
+    module = _load_analysis_module()
+    app = tmp_path / "network_sim_project"
+    settings = app / "src" / "app_settings.toml"
+    settings.parent.mkdir(parents=True)
+    settings.write_text(
+        "\n".join(
+            [
+                "[pages]",
+                'view_module = ["tri_gtia_view"]',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    app_ui_route = tmp_path / "apps-pages" / "app_ui" / "src" / "app_ui" / "app_ui.py"
+    fake_st = SimpleNamespace(
+        query_params={
+            "current_page": str(app_ui_route),
+            module._APP_SURFACE_HIDE_QUERY_PARAM: "true",
+        },
+    )
+
+    monkeypatch.setattr(module, "st", fake_st)
+
+    assert module._consume_invalid_app_ui_route(str(app_ui_route), app) is True
+    assert "current_page" not in fake_st.query_params
+    assert module._APP_SURFACE_HIDE_QUERY_PARAM not in fake_st.query_params
+
+
 def test_render_notebook_page_embeds_project_jupyter_sidecar(tmp_path: Path, monkeypatch):
     module = _load_analysis_module()
     project_root = tmp_path / "apps" / "flight_telemetry_project"


### PR DESCRIPTION
## Summary

Fixes invalid ANALYSIS deep links that force the generic `app_ui` bridge for projects that do not declare an app-owned UI entrypoint.

## Repro

Open ANALYSIS with a URL like:

`/ANALYSIS?current_page=/path/to/src/agilab/apps-pages/app_ui/src/app_ui/app_ui.py&active_app=network_sim_project`

For `network_sim_project`, the app has a valid generic analysis view (`tri_gtia_view`) but no `[pages.app_ui].entrypoint`, so the forced bridge rendered the app UI entrypoint warning instead of falling back to the normal ANALYSIS page selection.

## Root Cause

ANALYSIS already consumed stale `app_ui` routes for apps that declare `[app_surface]`, but it did not clear forced `app_ui` routes for apps that declare neither `[app_surface]` nor `[pages.app_ui]`. An absolute `current_page` query could therefore bypass the corrected project settings.

## Change

- Clear invalid `app_ui`/`view_app_ui` deep links when the active app has no declared app-owned UI.
- Preserve the existing app-surface and declared `[pages.app_ui]` behavior.
- Add a focused regression for an invalid forced `app_ui.py` route.

## Regression Test

Added `test_invalid_app_ui_route_without_declared_ui_is_cleared` in `test/test_analysis_page_helpers.py`.

## Validation

- `uv --preview-features extra-build-dependencies run python -m pytest test/test_analysis_page_helpers.py -k "invalid_app_ui_route_without_declared_ui_is_cleared or legacy_app_ui_route_opens_declared_app_surface or legacy_view_app_ui_route_opens_declared_app_surface"`
- `git diff --check -- src/agilab/pages/4_ANALYSIS.py test/test_analysis_page_helpers.py`
- Local pre-push guards passed.

## Agent Metadata

- Tokki version: `tokki 1.0.17`
- Agent/runtime: Codex, version unknown
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used
