### PR TITLE
[codex] Suppress bundled capacity model version warning

### DIFF
--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime/runtime_misc_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime/runtime_misc_support.py
@@ -14,6 +14,7 @@ import sys
 import traceback
 import urllib.error
 import urllib.request
+import warnings
 from datetime import timedelta
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Any, Callable, List, Optional, cast
@@ -42,6 +43,14 @@ _WORKER_RESOLUTION_EXCEPTIONS = (
     ImportError,
     ModuleNotFoundError,
 )
+
+
+def _sklearn_inconsistent_version_warning() -> type[Warning] | None:
+    try:
+        from sklearn.exceptions import InconsistentVersionWarning
+    except Exception:
+        return None
+    return InconsistentVersionWarning
 _RUN_TYPES = ["run --no-sync", "sync --dev", "sync --upgrade --dev", "simulate"]
 
 
@@ -237,7 +246,14 @@ def load_capacity_predictor(
 
     try:
         with open(path.resolve(strict=False), "rb") as stream:
-            return load_fn(stream)
+            inconsistent_version_warning = _sklearn_inconsistent_version_warning()
+            with warnings.catch_warnings():
+                if inconsistent_version_warning is not None:
+                    warnings.filterwarnings(
+                        "ignore",
+                        category=inconsistent_version_warning,
+                    )
+                return load_fn(stream)
     except _CAPACITY_LOAD_EXCEPTIONS as exc:
         if log is not None:
             log.warning("Failed to load capacity model from %s: %s", path, exc)

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime/runtime_misc_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime/runtime_misc_support.py
@@ -49,6 +49,7 @@ def _sklearn_inconsistent_version_warning() -> type[Warning] | None:
     try:
         from sklearn.exceptions import InconsistentVersionWarning
     except Exception:
+        # third-party optional dependency probe; absence keeps normal load behavior.
         return None
     return InconsistentVersionWarning
 _RUN_TYPES = ["run --no-sync", "sync --dev", "sync --upgrade --dev", "simulate"]

--- a/src/agilab/core/agi-env/src/agi_env/runtime/agi_env.py
+++ b/src/agilab/core/agi-env/src/agi_env/runtime/agi_env.py
@@ -357,7 +357,7 @@ class AgiEnv(metaclass=_AgiEnvMeta):
     _share_mount_warning_keys: set[tuple[str, str]] = set()
     INDEX_URL="https://test.pypi.org/simple"
     EXTRA_INDEX_URL="https://pypi.org/simple"
-    snippet_tail = "asyncio.get_event_loop().run_until_complete(main())"
+    snippet_tail = "asyncio.run(main())"
     _pythonpath_entries: list[str] = []
 
     def __init__(self,

--- a/src/agilab/core/test/test_agi_distributor_runtime_misc_support.py
+++ b/src/agilab/core/test/test_agi_distributor_runtime_misc_support.py
@@ -4,6 +4,7 @@ import asyncio
 import io
 import json
 import urllib.error
+import warnings
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -290,6 +291,50 @@ def test_load_capacity_predictor_returns_signed_trusted_value(tmp_path):
     )
 
     assert loaded == {"size": len(b"pickle-bytes")}
+
+
+def test_load_capacity_predictor_suppresses_only_sklearn_version_warning(
+    monkeypatch, tmp_path
+):
+    class FakeInconsistentVersionWarning(Warning):
+        pass
+
+    model_path = tmp_path / "resources" / "balancer_model.pkl"
+    model_path.parent.mkdir()
+    model_path.write_bytes(b"pickle-bytes")
+    runtime_misc_support.write_capacity_model_manifest(model_path)
+    monkeypatch.setattr(
+        runtime_misc_support,
+        "_sklearn_inconsistent_version_warning",
+        lambda: FakeInconsistentVersionWarning,
+    )
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        loaded = runtime_misc_support.load_capacity_predictor(
+            model_path,
+            load_fn=lambda _stream: warnings.warn(
+                "version drift",
+                FakeInconsistentVersionWarning,
+            )
+            or {"ok": True},
+            trusted_root=model_path.parent,
+        )
+
+    assert loaded == {"ok": True}
+    assert caught == []
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        loaded = runtime_misc_support.load_capacity_predictor(
+            model_path,
+            load_fn=lambda _stream: warnings.warn("other warning", UserWarning)
+            or {"ok": True},
+            trusted_root=model_path.parent,
+        )
+
+    assert loaded == {"ok": True}
+    assert [item.category for item in caught] == [UserWarning]
 
 
 def test_load_capacity_predictor_rejects_missing_signature_manifest(tmp_path):


### PR DESCRIPTION
## Summary

Suppress noisy runtime warnings seen from ORCHESTRATE execution logs:

- sklearn `InconsistentVersionWarning` from AGILAB's trusted bundled capacity balancer model load.
- Python 3.13 `asyncio.get_event_loop()` deprecation from generated AGI launcher helpers.

## Repro

Opening ORCHESTRATE for `network_sim_project` after a successful run showed compact log tails containing sklearn version warnings from unpickling the bundled `balancer_model.pkl`. A later run still showed `/Users/agi/log/execute/network_sim/AGI_run_network_sim.py` emitting `DeprecationWarning: There is no current event loop` from `asyncio.get_event_loop().run_until_complete(main())`.

## Root Cause

The internal capacity model was saved with a previous sklearn version. Loading it under a newer sklearn version emits `InconsistentVersionWarning`, even though this path is an AGILAB-owned resource load guarded by trusted-root and manifest checks.

Generated ORCHESTRATE helpers also still used the legacy event-loop tail even though AGILAB already provides `ensure_asyncio_run_signature()` for pydevd compatibility around `asyncio.run`.

## Change

- Keep the existing trusted-root and manifest checks before pickle loading.
- Suppress only sklearn `InconsistentVersionWarning` around the verified capacity-model load.
- Add a regression that confirms this warning category is suppressed while unrelated warnings still surface.
- Change generated AGI launcher helper tails to `asyncio.run(main())`.
- Add the required broad-exception classification comment for the optional sklearn import probe.

## Regression Test

Added `test_load_capacity_predictor_suppresses_only_sklearn_version_warning`.

## Validation

- Local pre-push guards passed.
- GitHub checks passed after the CI hygiene fix: `windows-core-tests`, `local-only-policy`, clean public install on macOS, Ubuntu, and Windows, and GitGuardian.
- `public-demo-smoke` was skipped by workflow policy.

## Agent Metadata

- Tokki version: not used for initial PR creation; `tokki run` used for the follow-up commit/push, version unavailable
- Agent/runtime: Codex, version unknown
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used
