### PR TITLE
[codex] Fix UI log windows and project selector state

### DIFF
--- a/src/agilab/orchestrate/orchestrate_page_helpers.py
+++ b/src/agilab/orchestrate/orchestrate_page_helpers.py
@@ -7,8 +7,11 @@ from pathlib import Path
 from typing import Any, Callable, Mapping, MutableMapping, Optional
 
 LOG_DISPLAY_MAX_LINES = 250
-LIVE_LOG_MIN_HEIGHT = 160
-INSTALL_LOG_HEIGHT = 320
+LOG_WINDOW_MIN_LINES = 20
+LOG_LINE_HEIGHT_PX = 20
+LOG_WINDOW_MIN_HEIGHT = LOG_WINDOW_MIN_LINES * LOG_LINE_HEIGHT_PX
+LIVE_LOG_MIN_HEIGHT = LOG_WINDOW_MIN_HEIGHT
+INSTALL_LOG_HEIGHT = LOG_WINDOW_MIN_HEIGHT
 _TRACEBACK_SKIP = {"active": False}
 
 _import_guard_path = Path(__file__).resolve().parents[1] / "security" / "import_guard.py"

--- a/src/agilab/pages/2_ORCHESTRATE.py
+++ b/src/agilab/pages/2_ORCHESTRATE.py
@@ -1922,7 +1922,11 @@ async def _render_deployment_panel(
             install_expanded = st.session_state.get("_install_logs_expanded", False)
             with st.expander("Deployment logs", expanded=install_expanded):
                 log_placeholder = st.empty()
-                log_placeholder.code(existing_log, language="python")
+                log_placeholder.code(
+                    existing_log,
+                    language="python",
+                    height=INSTALL_LOG_HEIGHT,
+                )
         pending_install_requested = consume_pending_install_action(st.session_state)
         install_requested = st.button(
             ORCHESTRATE_ACTION_LABELS["deploy_workers"],

--- a/src/agilab/pages/4_ANALYSIS.py
+++ b/src/agilab/pages/4_ANALYSIS.py
@@ -3194,10 +3194,13 @@ async def main():
     if "pages" not in cfg:
         cfg["pages"] = {}
     migrated_cfg = False
+    analysis_launcher_migrated = False
     if _migrate_declared_app_ui_page_config(active_app_path, cfg):
         migrated_cfg = True
+        analysis_launcher_migrated = True
     if _migrate_declared_app_surface_config(active_app_path, cfg):
         migrated_cfg = True
+        analysis_launcher_migrated = True
     if _remove_stale_app_ui_selection(active_app_path, cfg):
         migrated_cfg = True
     if _migrate_legacy_analysis_page_config(project, cfg):
@@ -3248,6 +3251,8 @@ async def main():
             clone_source_labels[path_str] = label
 
     selection_key = f"view_selection__{project or 'default'}"
+    if analysis_launcher_migrated:
+        st.session_state.pop(selection_key, None)
     pages_cfg = cfg.get("pages", {})
     pages_cfg = pages_cfg if isinstance(pages_cfg, dict) else {}
     surface_config = app_surface_config(active_app_path, cfg)

--- a/src/agilab/pipeline/pipeline_run_controls.py
+++ b/src/agilab/pipeline/pipeline_run_controls.py
@@ -52,6 +52,9 @@ logger = logging.getLogger(__name__)
 PIPELINE_LOCK_SCHEMA = "agilab.pipeline.lock.v1"
 PIPELINE_LOCK_FILENAME = "pipeline_run.lock"
 PIPELINE_LOCK_DEFAULT_TTL_SEC = 6 * 3600.0
+PIPELINE_RUN_LOG_MIN_LINES = 20
+PIPELINE_RUN_LOG_LINE_HEIGHT_PX = 20
+PIPELINE_RUN_LOG_HEIGHT = PIPELINE_RUN_LOG_MIN_LINES * PIPELINE_RUN_LOG_LINE_HEIGHT_PX
 
 
 def _is_missing_mlflow_cli_error(exc: BaseException) -> bool:
@@ -172,7 +175,7 @@ def _push_run_log(index_page: str, message: str, placeholder: Optional[Any] = No
     if placeholder is not None:
         logs = st.session_state.get(f"{index_page}__run_logs", [])
         if logs:
-            placeholder.code("\n".join(logs))
+            placeholder.code("\n".join(logs), height=PIPELINE_RUN_LOG_HEIGHT)
         else:
             placeholder.caption("No runs recorded yet.")
 

--- a/src/agilab/ui/page_project_selector.py
+++ b/src/agilab/ui/page_project_selector.py
@@ -149,12 +149,14 @@ def render_project_selector(
         target.info("No projects available.")
         return None
 
-    if streamlit.session_state.get(key) not in project_names:
+    selected_project = streamlit.session_state.get(key)
+    if selected_project not in project_names or (
+        current in project_names and selected_project != current
+    ):
+        # Drop stale widget state before render. The selectbox index below
+        # supplies the current project without also assigning this widget key
+        # through Session State, which Streamlit warns about.
         streamlit.session_state.pop(key, None)
-    if current in project_names and streamlit.session_state.get(key) != current:
-        # Sync the widget to the environment before render so stale session
-        # values cannot revert project changes made elsewhere.
-        streamlit.session_state[key] = current
 
     def _emit_change() -> None:
         chosen = streamlit.session_state.get(key)

--- a/test/test_page_project_selector.py
+++ b/test/test_page_project_selector.py
@@ -142,6 +142,7 @@ def test_project_selector_edit_button_is_disabled_without_registered_route(monke
     class SelectorHost:
         @staticmethod
         def selectbox(_label, options, *, index=0, **_kwargs):
+            assert "project:selectbox" not in streamlit.session_state
             assert options == ["alpha_project", "beta_project"]
             assert index == 0
             return options[index]
@@ -171,8 +172,9 @@ def test_project_selector_edit_button_is_disabled_without_registered_route(monke
         on_change=changed.append,
     )
 
-    # Stale session value is replaced by the real current project pre-widget.
-    assert streamlit.session_state["project:selectbox"] == "alpha_project"
+    # Stale session value is cleared before render; the widget index supplies
+    # the current project without triggering Streamlit's default/state warning.
+    assert "project:selectbox" not in streamlit.session_state
     assert selection == "alpha_project"
     assert button_kwargs.get("disabled") is True
     # Without a registered route the edit button must not hard-code a page path.

--- a/test/test_pipeline_run_controls.py
+++ b/test/test_pipeline_run_controls.py
@@ -33,10 +33,12 @@ def _import_pipeline_run_controls():
 class _FakePlaceholder:
     def __init__(self) -> None:
         self.codes: list[str] = []
+        self.code_kwargs: list[dict] = []
         self.captions: list[str] = []
 
-    def code(self, value: str) -> None:
+    def code(self, value: str, **kwargs) -> None:
         self.codes.append(value)
+        self.code_kwargs.append(kwargs)
 
     def caption(self, value: str) -> None:
         self.captions.append(value)
@@ -112,6 +114,7 @@ def test_pipeline_run_controls_payloads_logs_and_log_file_setup(tmp_path, monkey
 
     assert log_file.read_text(encoding="utf-8") == "line one\n"
     assert placeholder.codes[-1].endswith("line one\n")
+    assert placeholder.code_kwargs[-1]["height"] == module.PIPELINE_RUN_LOG_HEIGHT
 
     prepared, error = module._prepare_run_log_file("page", env, "bad prefix !")
     assert error is None


### PR DESCRIPTION
## Summary
- Set ORCHESTRATE and WORKFLOW run-log code blocks to a minimum 20-line height.
- Clear stale `project:selectbox` widget state before render so Streamlit does not warn about using both a default value and Session State assignment.
- Keep newly migrated app UI/app-surface launchers visible by clearing stale per-project ANALYSIS view-selection widget state once after migration.
- Update focused regression expectations for log height and project selector stale-state handling.

## Repro
- ORCHESTRATE/WORKFLOW log windows were shorter than the requested minimum 20 visible lines.
- Streamlit emitted: `The widget with key "project:selectbox" was created with a default value but also had its value set via the Session State API.`
- After adding an app-owned ANALYSIS UI declaration, an already-open ANALYSIS session could keep the old `view_selection__<project>` state and hide the newly configured `app_ui` launcher until manual reselection.

## Root Cause
- Log code blocks did not pass an explicit minimum height everywhere.
- The project selector assigned `st.session_state["project:selectbox"]` before creating a `selectbox` that also passed `index=...`, which Streamlit treats as conflicting default/state initialization.
- ANALYSIS trusted stale widget session selection even immediately after migrating a project-owned launcher into persisted settings.

## Regression Test
- `test/test_pipeline_run_controls.py` now asserts the run-log placeholder receives the configured log height.
- `test/test_page_project_selector.py` now asserts stale project selector state is cleared before widget render.

## Validation
- Local pre-push guard passed.
- Targeted pytest not run; not requested in this turn.

## Review Evidence
- No sub-agent or model review was used.

## Agent Metadata
- Tokki version: tokki 1.0.17
- Agent/runtime: Codex CLI, version unknown
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: no
