### PR TITLE
[codex] Align log window defaults to twenty lines

### DIFF
--- a/src/agilab/orchestrate/orchestrate_page_helpers.py
+++ b/src/agilab/orchestrate/orchestrate_page_helpers.py
@@ -7,11 +7,6 @@ from pathlib import Path
 from typing import Any, Callable, Mapping, MutableMapping, Optional
 
 LOG_DISPLAY_MAX_LINES = 250
-LOG_WINDOW_MIN_LINES = 20
-LOG_LINE_HEIGHT_PX = 20
-LOG_WINDOW_MIN_HEIGHT = LOG_WINDOW_MIN_LINES * LOG_LINE_HEIGHT_PX
-LIVE_LOG_MIN_HEIGHT = LOG_WINDOW_MIN_HEIGHT
-INSTALL_LOG_HEIGHT = LOG_WINDOW_MIN_HEIGHT
 _TRACEBACK_SKIP = {"active": False}
 
 _import_guard_path = Path(__file__).resolve().parents[1] / "security" / "import_guard.py"
@@ -28,6 +23,11 @@ _orchestrate_page_support = import_agilab_module(
     fallback_path=Path(__file__).resolve().parent / "orchestrate_page_support.py",
     fallback_name="agilab_orchestrate_page_support_fallback",
 )
+LOG_WINDOW_MIN_LINES = _orchestrate_page_support.LOG_WINDOW_DEFAULT_LINES
+LOG_LINE_HEIGHT_PX = _orchestrate_page_support.LOG_WINDOW_LINE_HEIGHT_PX
+LOG_WINDOW_MIN_HEIGHT = _orchestrate_page_support.LOG_WINDOW_DEFAULT_HEIGHT
+LIVE_LOG_MIN_HEIGHT = LOG_WINDOW_MIN_HEIGHT
+INSTALL_LOG_HEIGHT = LOG_WINDOW_MIN_HEIGHT
 _append_log_lines_impl = _orchestrate_page_support.append_log_lines
 _display_log_impl = _orchestrate_page_support.display_log
 _init_session_state_impl = _orchestrate_page_support.init_session_state

--- a/src/agilab/orchestrate/orchestrate_page_support.py
+++ b/src/agilab/orchestrate/orchestrate_page_support.py
@@ -11,6 +11,10 @@ from typing import Any
 from agi_env.snippet_contract import snippet_contract_block
 from agilab.environment.logging_utils import compact_log_view, render_compact_log_view
 
+LOG_WINDOW_DEFAULT_LINES = 20
+LOG_WINDOW_LINE_HEIGHT_PX = 20
+LOG_WINDOW_DEFAULT_HEIGHT = LOG_WINDOW_DEFAULT_LINES * LOG_WINDOW_LINE_HEIGHT_PX
+
 try:
     from packaging.markers import default_environment as _packaging_default_environment
     from packaging.requirements import InvalidRequirement as _PackagingInvalidRequirement
@@ -1202,7 +1206,7 @@ def update_log(
     display_lines = lines[-log_display_max_lines:]
     live_view = "\n".join(display_lines)
     line_count = max(len(display_lines), 1)
-    height_px = min(max(20 * line_count, live_log_min_height), max_log_height)
+    height_px = min(max(LOG_WINDOW_LINE_HEIGHT_PX * line_count, live_log_min_height), max_log_height)
     live_log_placeholder.code(live_view, language="python", height=height_px)
 
 
@@ -1218,7 +1222,7 @@ def display_log(
     error_fn: Callable[[str], Any] = lambda message: None,
     code_fn: Callable[..., Any] = lambda *args, **kwargs: None,
     log_display_max_lines: int = 250,
-    log_display_height: int = 400,
+    log_display_height: int = LOG_WINDOW_DEFAULT_HEIGHT,
 ) -> None:
     """Render combined stdout/stderr logs with warning and error normalization."""
     if not stdout.strip() and "log_text" in session_state:

--- a/test/test_orchestrate_page_helpers.py
+++ b/test/test_orchestrate_page_helpers.py
@@ -1097,6 +1097,16 @@ def test_orchestrate_page_support_log_filters_and_display_helpers():
     assert code_sink.calls[-1][1]["language"] == "text"
 
 
+def test_log_window_helper_constants_match_support_defaults():
+    module = _load_orchestrate_page_helpers_module()
+
+    assert orchestrate_page_support.LOG_WINDOW_DEFAULT_LINES == 20
+    assert module.LOG_WINDOW_MIN_LINES == orchestrate_page_support.LOG_WINDOW_DEFAULT_LINES
+    assert module.LOG_LINE_HEIGHT_PX == orchestrate_page_support.LOG_WINDOW_LINE_HEIGHT_PX
+    assert module.LIVE_LOG_MIN_HEIGHT == orchestrate_page_support.LOG_WINDOW_DEFAULT_HEIGHT
+    assert module.INSTALL_LOG_HEIGHT == orchestrate_page_support.LOG_WINDOW_DEFAULT_HEIGHT
+
+
 def test_orchestrate_page_support_dataframe_state_helpers():
     session_state: dict[str, object] = {
         "loaded_df": {"rows": 1},

--- a/test/test_orchestrate_page_support.py
+++ b/test/test_orchestrate_page_support.py
@@ -1623,6 +1623,26 @@ def test_update_log_helper_updates_session_state_and_trims_output():
     assert sink.calls[-1][1]["height"] == 160
 
 
+def test_log_window_defaults_render_twenty_lines():
+    code_sink = _CaptureCodeSink()
+
+    assert orchestrate_page_support.LOG_WINDOW_DEFAULT_LINES == 20
+    assert orchestrate_page_support.LOG_WINDOW_LINE_HEIGHT_PX == 20
+    assert orchestrate_page_support.LOG_WINDOW_DEFAULT_HEIGHT == 400
+
+    orchestrate_page_support.display_log(
+        stdout="ready",
+        stderr="",
+        session_state={},
+        strip_ansi_fn=orchestrate_page_support.strip_ansi,
+        filter_warning_messages_fn=lambda text: text,
+        format_log_block_fn=lambda text: text,
+        code_fn=code_sink,
+    )
+
+    assert code_sink.calls[-1][1]["height"] == orchestrate_page_support.LOG_WINDOW_DEFAULT_HEIGHT
+
+
 def test_update_log_helper_renders_empty_message_without_appending_log_text():
     sink = _CaptureCodeSink()
     session_state: dict[str, object] = {}


### PR DESCRIPTION
## Summary
- Centralize ORCHESTRATE log-window sizing around a 20-line default.
- Make helper constants derive from the shared support defaults to prevent drift.
- Add regressions proving the default display height is 20 lines / 400 px and helper constants remain aligned.

## Repro
- Some log rendering paths still encoded display heights as local literals, making the 20-line default contract easy to drift from future changes.

## Root Cause
- ORCHESTRATE helper constants and support defaults duplicated the same 20-line sizing contract instead of sharing one source of truth.

## Regression Test
- `uv --preview-features extra-build-dependencies run --extra ui pytest test/test_orchestrate_page_support.py test/test_orchestrate_page_helpers.py test/test_pipeline_run_controls.py`

## Validation
- Passed: `uv --preview-features extra-build-dependencies run --extra ui pytest test/test_orchestrate_page_support.py test/test_orchestrate_page_helpers.py test/test_pipeline_run_controls.py`
- Passed: local pre-push guard.
- GitHub: `GitGuardian Security Checks`, `local-only-policy`, and clean public install matrix passed; `public-demo-smoke` skipped.
- GitHub blocker: `windows-core-tests` failed in `src/agilab/core/agi-env/src/agi_env/runtime/agi_env.py:630` broad-exception hygiene, outside this PR diff. Not addressed here because shared core changes require explicit approval.
- Note: an initial no-extra test invocation failed because the fresh worktree environment lacked `streamlit`; the source UI extra command above was the valid rerun.

## Review Evidence
- Reviewer model: not used
- Result: not applicable
- Findings addressed: not applicable

## Agent Metadata
- Tokki version: tokki 1.0.17
- Agent/runtime: Codex CLI / GPT-5 coding agent
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used
