### PR TITLE
Standardize log widget height

### DIFF
--- a/src/agilab/apps-pages/autoencoder_latentspace/src/autoencoder_latentspace/autoencoder_latentspace.py
+++ b/src/agilab/apps-pages/autoencoder_latentspace/src/autoencoder_latentspace/autoencoder_latentspace.py
@@ -734,7 +734,7 @@ def main():
         import traceback
 
         st.caption("Full traceback")
-        st.code(traceback.format_exc(), language="text")
+        st.code(traceback.format_exc(), language="text", height=400)
 
 
 # -------------------- Main Entry Point -------------------- #

--- a/src/agilab/apps-pages/view_barycentric/src/view_barycentric/view_barycentric.py
+++ b/src/agilab/apps-pages/view_barycentric/src/view_barycentric/view_barycentric.py
@@ -748,7 +748,7 @@ def main():
         import traceback
 
         st.caption("Full traceback")
-        st.code(traceback.format_exc(), language="text")
+        st.code(traceback.format_exc(), language="text", height=400)
 
 
 # -------------------- Main Entry Point -------------------- #

--- a/src/agilab/apps-pages/view_live_artifacts/src/view_live_artifacts/view_live_artifacts.py
+++ b/src/agilab/apps-pages/view_live_artifacts/src/view_live_artifacts/view_live_artifacts.py
@@ -376,13 +376,13 @@ def _render_preview(records: tuple[ArtifactRecord, ...]) -> None:
     st.caption(f"{selected.relative_path} · {format_bytes(selected.size)} · {selected.mtime_iso}")
     if preview.error:
         st.error("Preview unavailable.")
-        st.code(preview.error, language="text")
+        st.code(preview.error, language="text", height=400)
     elif preview.kind == "json":
         st.json(preview.value, expanded=False)
     elif preview.kind == "image":
         st.image(str(preview.value), caption=selected.relative_path)
     elif preview.kind == "text":
-        st.code(str(preview.value), language="text")
+        st.code(str(preview.value), language="text", height=400)
         if preview.truncated:
             st.caption("Showing the latest portion of this file.")
     else:

--- a/src/agilab/apps-pages/view_maps/src/view_maps/view_maps.py
+++ b/src/agilab/apps-pages/view_maps/src/view_maps/view_maps.py
@@ -1195,7 +1195,7 @@ def main():
         import traceback
 
         st.caption("Full traceback")
-        st.code(traceback.format_exc(), language="text")
+        st.code(traceback.format_exc(), language="text", height=400)
 
 
 # -------------------- Main Entry Point -------------------- #

--- a/src/agilab/apps-pages/view_maps_3d/src/view_maps_3d/view_maps_3d.py
+++ b/src/agilab/apps-pages/view_maps_3d/src/view_maps_3d/view_maps_3d.py
@@ -1431,7 +1431,7 @@ def main():
         import traceback
 
         st.caption("Full traceback")
-        st.code(traceback.format_exc(), language="text")
+        st.code(traceback.format_exc(), language="text", height=400)
 
 
 # -------------------- Main Entry Point -------------------- #

--- a/src/agilab/apps-pages/view_maps_network/src/view_maps_network/view_maps_network.py
+++ b/src/agilab/apps-pages/view_maps_network/src/view_maps_network/view_maps_network.py
@@ -4582,7 +4582,7 @@ def main():
         st.error(f"An error occurred: {e}")
         import traceback
         st.caption("Full traceback")
-        st.code(traceback.format_exc(), language="text")
+        st.code(traceback.format_exc(), language="text", height=400)
 
 def update_var(var_key, widget_key):
     st.session_state[var_key] = st.session_state[widget_key]

--- a/src/agilab/orchestrate/orchestrate_execute.py
+++ b/src/agilab/orchestrate/orchestrate_execute.py
@@ -556,6 +556,7 @@ async def render_execute_section(
             source=_run_log_source(),
             empty_message="No run logs yet.",
             info_name="Run logs",
+            height=deps.install_log_height,
             theme="dark",
         )
 
@@ -752,10 +753,10 @@ async def render_execute_section(
                     st.info(f"Next: {diagnostic.next_action}")
                 if log_body:
                     st.caption("Full run diagnostic")
-                    st.code(log_body, language="text")
+                    st.code(log_body, language="text", height=deps.install_log_height)
                 if str(stderr or "").strip() and str(stderr).strip() not in log_body:
                     st.caption("Execution error")
-                    st.code(str(stderr), language="text")
+                    st.code(str(stderr), language="text", height=deps.install_log_height)
             elif str(stderr or "").strip():
                 display_log(log_body, stderr)
             else:

--- a/src/agilab/orchestrate/orchestrate_page_helpers.py
+++ b/src/agilab/orchestrate/orchestrate_page_helpers.py
@@ -109,7 +109,7 @@ def update_log(
     is_dask_shutdown_noise_fn: Callable[[str], bool],
     log_display_max_lines: int,
     live_log_min_height: int,
-    max_log_height: int = 500,
+    max_log_height: int = LOG_WINDOW_MIN_HEIGHT,
 ) -> None:
     _update_log_impl(
         session_state,
@@ -320,7 +320,7 @@ def display_log(
     error_fn: Callable[[str], Any] = lambda message: None,
     code_fn: Callable[..., Any] = lambda *args, **kwargs: None,
     log_display_max_lines: int = LOG_DISPLAY_MAX_LINES,
-    log_display_height: int = 400,
+    log_display_height: int = LOG_WINDOW_MIN_HEIGHT,
 ) -> None:
     return _display_log_impl(
         stdout,

--- a/src/agilab/orchestrate/orchestrate_page_support.py
+++ b/src/agilab/orchestrate/orchestrate_page_support.py
@@ -1174,7 +1174,7 @@ def update_log(
     is_dask_shutdown_noise_fn: Callable[[str], bool],
     log_display_max_lines: int,
     live_log_min_height: int,
-    max_log_height: int = 500,
+    max_log_height: int = 400,
 ) -> None:
     """Append a cleaned message to accumulated log and refresh live display."""
     if "log_text" not in session_state:

--- a/src/agilab/pages/1_PROJECT.py
+++ b/src/agilab/pages/1_PROJECT.py
@@ -4921,7 +4921,7 @@ def main():
         import traceback
 
         st.caption("Full traceback")
-        st.code(traceback.format_exc(), language="text")
+        st.code(traceback.format_exc(), language="text", height=400)
 
 
 # -------------------- Main Entry Point -------------------- #

--- a/src/agilab/pages/2_ORCHESTRATE.py
+++ b/src/agilab/pages/2_ORCHESTRATE.py
@@ -455,7 +455,7 @@ def update_log(live_log_placeholder: Any, message: str, max_lines: int = 1000) -
         is_dask_shutdown_noise_fn=is_dask_shutdown_noise,
         log_display_max_lines=LOG_DISPLAY_MAX_LINES,
         live_log_min_height=LIVE_LOG_MIN_HEIGHT,
-        max_log_height=500,
+        max_log_height=LIVE_LOG_MIN_HEIGHT,
     )
     update_log._skip_traceback = bool(_TRACEBACK_SKIP["active"])
     return None
@@ -913,7 +913,7 @@ def display_log(stdout, stderr):
         warning_fn=lambda message: st.warning(message),
         error_fn=lambda message: st.error(message),
         code_fn=lambda *args, **kwargs: st.code(*args, **kwargs),
-        log_display_height=400,
+        log_display_height=INSTALL_LOG_HEIGHT,
     )
 
 
@@ -2931,7 +2931,7 @@ async def main():
         import traceback
 
         st.caption("Full traceback")
-        st.code(traceback.format_exc(), language="text")
+        st.code(traceback.format_exc(), language="text", height=400)
 
 
 if __name__ == "__main__":

--- a/src/agilab/pages/3_WORKFLOW.py
+++ b/src/agilab/pages/3_WORKFLOW.py
@@ -1851,7 +1851,7 @@ def main() -> None:
         import traceback
 
         st.caption("Full traceback")
-        st.code(traceback.format_exc(), language="text")
+        st.code(traceback.format_exc(), language="text", height=400)
 
 
 if __name__ == "__main__":

--- a/src/agilab/pages/4_ANALYSIS.py
+++ b/src/agilab/pages/4_ANALYSIS.py
@@ -2041,7 +2041,7 @@ async def _render_selected_view_route(current_page: str | None) -> bool:
     ) as exc:
         st.error(f"Failed to render view: {exc}")
         st.caption("Full traceback")
-        st.code(traceback.format_exc(), language="text")
+        st.code(traceback.format_exc(), language="text", height=400)
     return True
 
 
@@ -2110,7 +2110,7 @@ async def _render_selected_notebook_route(current_notebook: str | None) -> bool:
     ) as exc:
         st.error(f"Failed to render notebook: {exc}")
         st.caption("Full traceback")
-        st.code(traceback.format_exc(), language="text")
+        st.code(traceback.format_exc(), language="text", height=400)
     return True
 
 
@@ -3639,13 +3639,17 @@ async def render_notebook_page(notebook_path: Path):
         with st.expander("Notebook sidecar logs", expanded=True):
             if logs.exists():
                 st.code(
-                    logs.read_text(encoding="utf-8", errors="ignore"), language="bash"
+                    logs.read_text(encoding="utf-8", errors="ignore"),
+                    language="bash",
+                    height=400,
                 )
             else:
                 st.write("No log file found.")
             if errors.exists():
                 st.code(
-                    errors.read_text(encoding="utf-8", errors="ignore"), language="bash"
+                    errors.read_text(encoding="utf-8", errors="ignore"),
+                    language="bash",
+                    height=400,
                 )
             else:
                 st.write("No error log file found.")
@@ -3726,13 +3730,17 @@ async def render_view_page(
         with st.expander("Sidecar logs", expanded=True):
             if logs.exists():
                 st.code(
-                    logs.read_text(encoding="utf-8", errors="ignore"), language="bash"
+                    logs.read_text(encoding="utf-8", errors="ignore"),
+                    language="bash",
+                    height=400,
                 )
             else:
                 st.write("No log file found.")
             if errors.exists():
                 st.code(
-                    errors.read_text(encoding="utf-8", errors="ignore"), language="bash"
+                    errors.read_text(encoding="utf-8", errors="ignore"),
+                    language="bash",
+                    height=400,
                 )
             else:
                 st.write("No error log file found.")

--- a/src/agilab/pipeline/pipeline_lab.py
+++ b/src/agilab/pipeline/pipeline_lab.py
@@ -194,6 +194,7 @@ _pinned_expander_module = import_agilab_module(
     fallback_name="agilab_pinned_expander_fallback",
 )
 render_pinnable_code_editor = _pinned_expander_module.render_pinnable_code_editor
+WORKFLOW_RUN_LOG_HEIGHT = 20 * 20
 
 _workflow_ui_module = import_agilab_module(
     "agilab.workflow_ui",
@@ -2775,7 +2776,7 @@ def _render_global_runner_state_view(
             except Exception as exc:
                 st.error("Controlled workflow step execution failed.")
                 st.caption("Full diagnostic")
-                st.code(str(exc), language="text")
+                st.code(str(exc), language="text", height=400)
                 return
             if result.ok:
                 dag_engine.write_state(result.state)
@@ -2789,7 +2790,7 @@ def _render_global_runner_state_view(
             except Exception as exc:
                 st.error("Controlled DAG batch execution failed.")
                 st.caption("Full diagnostic")
-                st.code(str(exc), language="text")
+                st.code(str(exc), language="text", height=400)
                 return
             if result.executed_unit_ids or result.failed_unit_ids:
                 dag_engine.write_state(result.state)
@@ -2959,7 +2960,7 @@ def _render_global_runner_state_panel(
             except Exception as exc:
                 st.error("Project stages DAG preview is unavailable.")
                 st.caption("Full diagnostic")
-                st.code(str(exc), language="text")
+                st.code(str(exc), language="text", height=400)
                 return
             _render_global_runner_state_view(
                 state=state,
@@ -3055,7 +3056,7 @@ def _render_global_runner_state_panel(
             except Exception as exc:
                 st.error("Multi-app plan preview is unavailable.")
                 st.caption("Full diagnostic")
-                st.code(str(exc), language="text")
+                st.code(str(exc), language="text", height=400)
                 return
 
             _render_global_runner_state_view(
@@ -3332,7 +3333,7 @@ def _render_global_runner_state_panel(
         except Exception as exc:
             st.error("Multi-app DAG preview is unavailable.")
             st.caption("Full diagnostic")
-            st.code(str(exc), language="text")
+            st.code(str(exc), language="text", height=400)
             return
 
         _render_global_runner_state_view(
@@ -5314,5 +5315,6 @@ def display_lab_tab(
             source=source,
             empty_message="No runs recorded yet.",
             info_name="Run logs",
+            height=WORKFLOW_RUN_LOG_HEIGHT,
             theme="dark",
         )

--- a/test/test_orchestrate_execute.py
+++ b/test/test_orchestrate_execute.py
@@ -1275,6 +1275,7 @@ async def test_render_execute_section_can_pin_existing_run_logs(monkeypatch, tmp
     assert isinstance(buttons, list)
     assert [button["name"] for button in buttons[:2]] == ["Copy", "Pin"]
     assert editor_calls[-1]["theme"] == "dark"
+    assert editor_calls[-1]["height"] == deps.install_log_height
     assert panels["orchestrate_run_logs"]["title"] == "Run logs: flight_telemetry_project"
     assert panels["orchestrate_run_logs"]["body"] == "existing log"
     assert panels["orchestrate_run_logs"]["source"] == f"ORCHESTRATE {tmp_path / 'run.log'}"

--- a/test/test_orchestrate_execute.py
+++ b/test/test_orchestrate_execute.py
@@ -750,7 +750,7 @@ class _Placeholder:
     def caption(self, message):
         self._messages.append(("caption", str(message)))
 
-    def code(self, message, language=None):
+    def code(self, message, language=None, **_kwargs):
         self._messages.append(("code", str(message)))
 
 
@@ -829,7 +829,7 @@ class _FakeStreamlit:
     def error(self, message):
         self.messages.append(("error", str(message)))
 
-    def code(self, message, language=None):
+    def code(self, message, language=None, **_kwargs):
         self.messages.append(("code", str(message)))
 
 

--- a/test/test_pipeline_lab.py
+++ b/test/test_pipeline_lab.py
@@ -132,7 +132,7 @@ class _FakeStreamlit:
     def markdown(self, message, **_kwargs):
         self.messages.append(("markdown", str(message)))
 
-    def code(self, message, language=None):
+    def code(self, message, language=None, **_kwargs):
         self.messages.append(("code", str(message)))
 
     def error(self, message):

--- a/test/test_pipeline_lab.py
+++ b/test/test_pipeline_lab.py
@@ -5453,6 +5453,7 @@ def test_display_lab_tab_can_pin_run_logs(monkeypatch, tmp_path):
     assert isinstance(buttons, list)
     assert [button["name"] for button in buttons[:2]] == ["Copy", "Pin"]
     assert editor_calls[-1]["theme"] == "dark"
+    assert editor_calls[-1]["height"] == 400
     assert panels["pipeline_run_logs:demo"]["title"] == "Workflow logs: flight_telemetry_project"
     assert panels["pipeline_run_logs:demo"]["body"] == "line 1\nline 2"
     assert panels["pipeline_run_logs:demo"]["source"] == f"WORKFLOW {log_file}"


### PR DESCRIPTION
## Summary

Standardize AGILAB page and apps-page log/code diagnostic widgets to use a 20-line default height.

## Scope

- ORCHESTRATE live, deployment, service, and run diagnostic logs.
- WORKFLOW pinned run-log editor.
- ANALYSIS sidecar logs and page traceback diagnostics.
- apps-pages traceback diagnostics and Live Artifacts text previews.
- Focused assertions for ORCHESTRATE and WORKFLOW pinned log editor height.
- Test fakes now accept `st.code(..., height=...)` keyword arguments like Streamlit.

## Repro

User requested all page and apps-page log fields use a 20-line widget height. Existing log displays mixed implicit Streamlit defaults, 400 px windows, and one expandable live-log cap.

## Root Cause

The log rendering paths used separate defaults rather than one consistent 20-line display contract across page, app-page, ORCHESTRATE, and WORKFLOW surfaces. The first implementation exposed a test-fake mismatch: local fake `code()` methods did not accept Streamlit-compatible keyword arguments.

## Regression Test

Updated focused tests to assert the pinned ORCHESTRATE and WORKFLOW run-log editors receive the expected 20-line height. Updated local Streamlit test fakes to accept `code()` keyword arguments so `height=` is exercised through the same fake API shape.

## Validation

- `python3 tools/agent_commit_provenance_guard.py --check-config`: passed.
- Pre-push hook: passed.
- GitHub PR checks: pending after latest push.
- Targeted pytest command from the earlier failed run was not rerun locally in this turn.

## Review Evidence

No sub-agent or model review used.

## Agent Metadata

- Tokki version: `tokki 1.0.17`
- Agent/runtime: Codex CLI, version unavailable
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used
