### PR TITLE
[codex] fix workflow snippet and analysis contracts

### DIFF
--- a/src/agilab/apps-pages/view_inference_analysis/src/view_inference_analysis/view_inference_analysis.py
+++ b/src/agilab/apps-pages/view_inference_analysis/src/view_inference_analysis/view_inference_analysis.py
@@ -10,6 +10,7 @@ import fnmatch
 import html
 import json
 import logging
+import os
 import sys
 import tomllib
 from pathlib import Path
@@ -82,7 +83,7 @@ HEATMAP_MAX_COLUMNS = 2
 BEARER_MAX_COLUMNS = 3
 HEATMAP_GRID_COLOR = "rgba(217, 222, 231, 0.35)"
 
-BASE_CHOICES = ("AGI_CLUSTER_SHARE", "AGILAB_EXPORT", "Custom")
+BASE_CHOICES = ("AGI_LOCAL_SHARE", "AGI_CLUSTER_SHARE", "AGILAB_EXPORT", "Custom")
 AGGREGATIONS = ("mean", "sum", "median", "min", "max", "std", "count")
 STEP_AXIS_CANDIDATES = ("time_index", "decision", "step", "time_idx")
 TIME_AXIS_CANDIDATES = ("time_s", "t_now_s", "time", "t")
@@ -254,7 +255,49 @@ def _default_dataset_subpath(env: AgiEnv, active_app_path: Path) -> str:
     return "pipeline"
 
 
+def _configured_env_path(env: AgiEnv, attr_name: str) -> Path | None:
+    raw_value = getattr(env, attr_name, None)
+    if raw_value is None or not str(raw_value).strip():
+        envars = getattr(env, "envars", {})
+        if isinstance(envars, dict):
+            raw_value = envars.get(attr_name)
+    if raw_value is None or not str(raw_value).strip():
+        return None
+    path = Path(str(raw_value).strip()).expanduser()
+    if not path.is_absolute():
+        path = Path.home() / path
+    return path
+
+
+def _default_local_share_path() -> Path:
+    raw_user = os.environ.get("AGILAB_SHARE_USER") or os.environ.get("USER") or os.environ.get("USERNAME") or "user"
+    safe_user = "".join(ch if ch.isalnum() or ch in "_.-" else "_" for ch in str(raw_user)).strip("_") or "user"
+    return Path.home() / "localshare" / safe_user
+
+
+def _preview_base_path(env: AgiEnv, base_choice: str, custom_base: str = "") -> Path | None:
+    if base_choice == "AGI_LOCAL_SHARE":
+        return _configured_env_path(env, "AGI_LOCAL_SHARE") or _default_local_share_path()
+    if base_choice == "AGI_CLUSTER_SHARE":
+        return Path(env.share_root_path())
+    if base_choice == "AGILAB_EXPORT":
+        return Path(env.AGILAB_EXPORT_ABS)
+    cleaned = custom_base.strip()
+    if not cleaned:
+        return None
+    return Path(cleaned).expanduser()
+
+
+def _base_choice_label(env: AgiEnv, choice: str, custom_base: str = "") -> str:
+    path = _preview_base_path(env, choice, custom_base)
+    if path is None:
+        return choice
+    return f"{choice} ({path})"
+
+
 def _resolve_base_path(env: AgiEnv, base_choice: str, custom_base: str) -> Path | None:
+    if base_choice == "AGI_LOCAL_SHARE":
+        return _configured_env_path(env, "AGI_LOCAL_SHARE") or _default_local_share_path()
     if base_choice == "AGI_CLUSTER_SHARE":
         return Path(env.share_root_path())
     if base_choice == "AGILAB_EXPORT":
@@ -1400,7 +1443,7 @@ def main() -> None:
         st.session_state[ENV_KEY] = env
 
     page_defaults = _get_page_defaults(env)
-    default_base_choice = str(page_defaults.get("dataset_base_choice") or "AGI_CLUSTER_SHARE")
+    default_base_choice = str(page_defaults.get("dataset_base_choice") or page_defaults.get("base_choice") or "AGI_CLUSTER_SHARE")
     if default_base_choice not in BASE_CHOICES:
         default_base_choice = "AGI_CLUSTER_SHARE"
     default_custom_base = str(page_defaults.get("dataset_custom_base") or "")
@@ -1441,7 +1484,12 @@ def main() -> None:
 
     with st.sidebar:
         st.header("Data source")
-        st.selectbox("Base directory", BASE_CHOICES, key=BASE_CHOICE_KEY)
+        st.selectbox(
+            "Base directory",
+            BASE_CHOICES,
+            key=BASE_CHOICE_KEY,
+            format_func=lambda choice: _base_choice_label(env, choice, st.session_state.get(CUSTOM_BASE_KEY, "")),
+        )
         st.text_input("Custom base directory", key=CUSTOM_BASE_KEY)
         st.text_input("Dataset subpath", key=SUBPATH_KEY)
         st.text_area(
@@ -1455,7 +1503,7 @@ def main() -> None:
     glob_patterns = _coerce_str_list(st.session_state[GLOBS_KEY]) or ["**/allocations_steps.json"]
 
     if dataset_root is None:
-        st.warning("Provide a custom base directory or switch back to AGI_CLUSTER_SHARE / AGILAB_EXPORT.")
+        st.warning("Provide a custom base directory or switch back to AGI_LOCAL_SHARE / AGI_CLUSTER_SHARE / AGILAB_EXPORT.")
         st.stop()
 
     st.info(f"Resolved dataset root: `{dataset_root}`")

--- a/src/agilab/pipeline/pipeline_lab.py
+++ b/src/agilab/pipeline/pipeline_lab.py
@@ -3383,6 +3383,40 @@ class PipelineLabDeps:
     safe_service_template_marker: str
 
 
+def _stale_snippet_path_key(path: object) -> str:
+    try:
+        return str(Path(path).expanduser().resolve(strict=False))
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return str(path)
+
+
+def _stale_snippet_paths_resolved(stale_snippets: list[Path]) -> bool:
+    for path in stale_snippets:
+        try:
+            if Path(path).expanduser().exists():
+                return False
+        except (OSError, RuntimeError, TypeError, ValueError):
+            return False
+    return True
+
+
+def _clear_selected_stale_snippet(stale_snippets: list[Path]) -> None:
+    selected = st.session_state.get("snippet_file")
+    if not selected:
+        return
+    stale_keys = {_stale_snippet_path_key(path) for path in stale_snippets}
+    if _stale_snippet_path_key(selected) in stale_keys:
+        st.session_state.pop("snippet_file", None)
+
+
+def _rerun_after_stale_snippet_cleanup(deps: "PipelineLabDeps") -> None:
+    rerun_fn = getattr(deps, "rerun_fragment_or_app", None)
+    if not callable(rerun_fn):
+        rerun_fn = getattr(st, "rerun", None)
+    if callable(rerun_fn):
+        rerun_fn()
+
+
 def get_existing_snippets(env: AgiEnv, stages_file: Path, deps: "PipelineLabDeps") -> Dict[str, Path]:
     """Discover reusable snippet files and return a label->path mapping."""
     _ensure_safe_service_template = deps.ensure_safe_service_template
@@ -3426,6 +3460,9 @@ def get_existing_snippets(env: AgiEnv, stages_file: Path, deps: "PipelineLabDeps
                 if failed:
                     st.warning(f"Could not delete {len(failed)} stale generated snippet(s).")
                     toast(st, f"Could not delete {len(failed)} stale snippet(s).", state="warning")
+                if not failed and _stale_snippet_paths_resolved(stale_snippets):
+                    _clear_selected_stale_snippet(stale_snippets)
+                    _rerun_after_stale_snippet_cleanup(deps)
         except AttributeError:
             pass
 

--- a/src/agilab/pipeline/pipeline_run_controls.py
+++ b/src/agilab/pipeline/pipeline_run_controls.py
@@ -70,6 +70,15 @@ def _optional_mlflow_tracking_uri(env: AgiEnv) -> str:
         raise
 
 
+def _normalize_legacy_agi_run_request_code(code: str) -> tuple[str, bool]:
+    """Return code compatible with the current RunRequest/StageRequest API."""
+    if "StepRequest" not in code and not ("RunRequest" in code and re.search(r"\bsteps\b", code)):
+        return code, False
+    normalized = code.replace("StepRequest", "StageRequest")
+    normalized = re.sub(r"\bsteps\b", "stages", normalized)
+    return normalized, normalized != code
+
+
 def _mlflow_parent_payload(
     env: AgiEnv,
     lab_dir: Path,
@@ -589,6 +598,17 @@ def run_all_stages(
                     _refresh_pipeline_run_lock(lock_handle)
                     entry = stages[idx]
                     code = entry.get("C", "")
+                    code, normalized_agi_code = _normalize_legacy_agi_run_request_code(str(code or ""))
+                    if normalized_agi_code:
+                        entry = {**entry, "C": code}
+                        _push_run_log(
+                            index_page_str,
+                            (
+                                f"Stage {idx + 1}: normalized legacy AGI RunRequest snippet "
+                                "from StepRequest/steps to StageRequest/stages."
+                            ),
+                            log_placeholder,
+                        )
                     if not _pipeline_stages.is_runnable_stage(entry):
                         continue
                     _push_run_log(index_page_str, f"Running stage {idx + 1}…", log_placeholder)

--- a/src/agilab/pipeline/pipeline_runtime_mlflow_support.py
+++ b/src/agilab/pipeline/pipeline_runtime_mlflow_support.py
@@ -12,6 +12,7 @@ from typing import Any, Callable, Dict, List, Optional
 
 from agi_env import AgiEnv
 from agi_env import mlflow_store
+from agi_env.snippet_contract import CURRENT_SNIPPET_API, SNIPPET_API_NAME
 
 
 def build_mlflow_process_env(
@@ -453,6 +454,7 @@ def wrap_code_with_mlflow_resume(code: str, *, stage_run_id_env: str) -> str:
     body = code if code.endswith("\n") else code + "\n"
     indented = "".join(f"    {line}\n" for line in body.splitlines()) if body.strip() else "    pass\n"
     return (
+        f"{SNIPPET_API_NAME} = {CURRENT_SNIPPET_API!r}\n"
         "import os\n"
         "_agilab_mlflow = None\n"
         "_agilab_active_run = None\n"

--- a/test/test_pipeline_lab.py
+++ b/test/test_pipeline_lab.py
@@ -494,14 +494,19 @@ def test_get_existing_snippets_cleanup_button_deletes_stale_generated_snippets(m
     os.utime(app_settings, (settings_time, settings_time))
     os.utime(stale_snippet, (new_time, new_time))
 
+    reruns = []
     fake_st = _FakeStreamlit(
-        {"clean_stale_snippets_flight_telemetry_project__armed": True},
+        {
+            "snippet_file": str(stale_snippet),
+            "clean_stale_snippets_flight_telemetry_project__armed": True,
+        },
         buttons={"clean_stale_snippets_flight_telemetry_project__confirm": True},
     )
     monkeypatch.setattr(pipeline_lab, "st", fake_st)
     env = SimpleNamespace(runenv=runenv_dir, app_settings_file=app_settings, app="flight_telemetry_project")
     deps = SimpleNamespace(
         ensure_safe_service_template=lambda *_args, **_kwargs: None,
+        rerun_fragment_or_app=lambda: reruns.append("rerun"),
         safe_service_template_filename="unused.py",
         safe_service_template_marker="marker",
     )
@@ -510,6 +515,8 @@ def test_get_existing_snippets_cleanup_button_deletes_stale_generated_snippets(m
 
     assert option_map == {}
     assert not stale_snippet.exists()
+    assert "snippet_file" not in fake_st.session_state
+    assert reruns == ["rerun"]
     assert any(kind == "success" and "Deleted 1 stale" in message for kind, message in fake_st.messages)
 
 

--- a/test/test_pipeline_run_controls.py
+++ b/test/test_pipeline_run_controls.py
@@ -652,6 +652,27 @@ def test_pipeline_run_controls_blocks_legacy_agi_run_before_lock(tmp_path, monke
     assert not any("Running stage 1" in line for line in fake_st.session_state["page__run_logs"])
 
 
+def test_pipeline_run_controls_normalizes_legacy_step_request_snippet() -> None:
+    module = _import_pipeline_run_controls()
+    stale_code = (
+        "from agi_cluster.agi_distributor import AGI, RunRequest, StepRequest\n"
+        "steps = [StepRequest(name='demo', args={})]\n"
+        "request = RunRequest(mode=4, steps=steps)\n"
+    )
+
+    normalized, changed = module._normalize_legacy_agi_run_request_code(stale_code)
+
+    assert changed is True
+    assert "StepRequest" not in normalized
+    assert "StageRequest" in normalized
+    assert "stages = [StageRequest" in normalized
+    assert "RunRequest(mode=4, stages=stages)" in normalized
+
+    unchanged, changed = module._normalize_legacy_agi_run_request_code("steps = ['plain runpy loop']\n")
+    assert changed is False
+    assert unchanged == "steps = ['plain runpy loop']\n"
+
+
 def test_pipeline_run_controls_run_all_stages_without_mlflow_tracks_runpy_no_output(tmp_path, monkeypatch):
     module = _import_pipeline_run_controls()
     snippet_file = tmp_path / "snippet.py"

--- a/test/test_pipeline_runtime.py
+++ b/test/test_pipeline_runtime.py
@@ -514,6 +514,7 @@ def test_runtime_helper_edges_cover_run_id_cleanup_and_metric_failures(tmp_path,
 def test_wrap_code_with_mlflow_resume_uses_env_run_id():
     wrapped = pipeline_runtime.wrap_code_with_mlflow_resume("print('hello')")
 
+    assert 'AGILAB_SNIPPET_API = "agi.snippet.v1"' in wrapped
     assert pipeline_runtime.MLFLOW_STAGE_RUN_ID_ENV in wrapped
     assert "MLFLOW_TRACKING_URI" in wrapped
     assert "mlflow.start_run(run_id=_agilab_run_id)" in wrapped

--- a/test/test_view_inference_analysis.py
+++ b/test/test_view_inference_analysis.py
@@ -483,10 +483,12 @@ def test_view_inference_analysis_resolve_active_app_stops_for_missing_inputs(
 def test_view_inference_analysis_coerces_string_lists_and_resolves_dataset_paths(tmp_path: Path) -> None:
     module = _load_module()
     share_root = tmp_path / "share"
+    local_root = tmp_path / "local"
     export_root = tmp_path / "export"
     custom_root = tmp_path / "custom"
     env = SimpleNamespace(
         target="flight",
+        AGI_LOCAL_SHARE=str(local_root),
         AGILAB_EXPORT_ABS=str(export_root),
         share_root_path=lambda: str(share_root),
     )
@@ -498,6 +500,13 @@ def test_view_inference_analysis_coerces_string_lists_and_resolves_dataset_paths
 
     env.target = ""
     assert module._default_dataset_subpath(env, tmp_path / "demo_project") == "demo/pipeline"
+    assert "AGI_LOCAL_SHARE" in module.BASE_CHOICES
+    assert module._resolve_base_path(env, "AGI_LOCAL_SHARE", "") == local_root
+    env.AGI_LOCAL_SHARE = "relative-local-share"
+    assert module._resolve_base_path(env, "AGI_LOCAL_SHARE", "") == Path.home() / "relative-local-share"
+    env.AGI_LOCAL_SHARE = ""
+    env.envars = {"AGI_LOCAL_SHARE": str(local_root)}
+    assert module._resolve_base_path(env, "AGI_LOCAL_SHARE", "") == local_root
     assert module._resolve_base_path(env, "AGI_CLUSTER_SHARE", "") == share_root
     assert module._resolve_base_path(env, "AGILAB_EXPORT", "") == export_root
     assert export_root.exists()


### PR DESCRIPTION
## Summary
- Keeps generated WORKFLOW `AGI_run.py` artifacts compatible with the current snippet API marker.
- Clears stale selected snippet state after cleanup so stale warnings disappear after cleanup.
- Preserves local-share discovery in the inference analysis page and normalizes legacy AGI `StepRequest` snippets.

## Repro
- Stale snippet cleanup could delete `/Users/agi/export/sb3_trainer/AGI_run.py`, but the warning reappeared because new generated workflow snippets lacked the current snippet API marker.
- Workflow stage 17 could fail on legacy `StepRequest` imports after AGILAB core API changes.
- Inference analysis base-directory selection missed the local share value after SB3 workflow output generation.

## Root Cause
- Freshly generated MLflow-resume workflow snippets were not stamped with `AGILAB_SNIPPET_API`.
- Cleanup did not clear `st.session_state["snippet_file"]` or rerun after resolving stale snippets.
- Legacy generated snippets still used old AGI request naming.

## Regression Test
- Added focused unit coverage for snippet cleanup rerun/state clearing, snippet API stamping, legacy AGI request normalization, and local-share base discovery.

## Validation
- AGILAB pre-push guard passed.
- Targeted pytest not run in this turn.

## Agent Metadata
- Tokki version: tokki 1.0.17.
- Agent/runtime: Codex CLI, version unknown.
- Model: GPT-5 Codex.
- Reasoning effort: unknown.
- /fast mode: unknown.
