### PR TITLE
[codex] rename orchestrate workflow action

### DIFF
--- a/src/agilab/orchestrate/orchestrate_page_support.py
+++ b/src/agilab/orchestrate/orchestrate_page_support.py
@@ -63,7 +63,7 @@ ORCHESTRATE_ACTION_LABELS: dict[str, str] = {
     "check_distribute": "CHECK distribute",
     "run": "RUN",
     "run_benchmark": "RUN benchmark",
-    "run_workflow": "RUN workflow",
+    "run_workflow": "RUN orchestration",
     "run_load_export": "Run -> Load -> Export",
     "load_output": "Load output",
     "delete_output": "Delete output",

--- a/test/test_orchestrate_page_helpers.py
+++ b/test/test_orchestrate_page_helpers.py
@@ -521,7 +521,7 @@ def test_orchestrate_action_label_case_policy_is_explicit():
         "check_distribute": "CHECK distribute",
         "run": "RUN",
         "run_benchmark": "RUN benchmark",
-        "run_workflow": "RUN workflow",
+        "run_workflow": "RUN orchestration",
         "run_load_export": "Run -> Load -> Export",
         "load_output": "Load output",
         "delete_output": "Delete output",


### PR DESCRIPTION
## Summary
- Renames the ORCHESTRATE DAG action label from `RUN workflow` to `RUN orchestration`.
- Keeps the WORKFLOW page's `Run workflow` label unchanged so the two page contracts are visually distinct.
- Updates the focused ORCHESTRATE label-policy regression.

## Repro
- ORCHESTRATE exposed a `RUN workflow` action, which was easy to confuse with the dedicated WORKFLOW page action named `Run workflow`.

## Root Cause
- The ORCHESTRATE action copy reused workflow terminology for an orchestration/run action.

## Regression Test
- Updated `test_orchestrate_action_label_case_policy_is_explicit` to enforce the new ORCHESTRATE label.

## Validation
- `./dev scope` passed.
- AGILAB pre-push guard passed.
- Targeted pytest not run in this turn.

## Agent Metadata
- Tokki version: tokki 1.0.17.
- Agent/runtime: Codex CLI, version unknown.
- Model: GPT-5 Codex.
- Reasoning effort: unknown.
- /fast mode: unknown.
