### PR TITLE
[codex] Add workflow automation evidence manifest

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 277,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "ad1b2cd152c88ff67cfb468fc38f045f7865b71d741f2aa5fef0fa2a7d5fd861",
+  "source_digest_sha256": "9f8241c8de456fe28f1b5fe48062d9d854f61e3a0488161496e656918fbdc6e5",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "ad1b2cd152c88ff67cfb468fc38f045f7865b71d741f2aa5fef0fa2a7d5fd861"
+  "target_digest_sha256": "9f8241c8de456fe28f1b5fe48062d9d854f61e3a0488161496e656918fbdc6e5"
 }

--- a/docs/source/agilab-mlops-positioning.rst
+++ b/docs/source/agilab-mlops-positioning.rst
@@ -481,11 +481,10 @@ renders cleanly on narrower viewports.
 - **Positioning note**: modern Airflow already supports dynamic task mapping
   and dynamic DAG generation, so it remains stronger when the core need is
   task-level orchestration semantics inside a scheduler-first platform.
-  AGILab can express dynamic behavior inside generated or custom Python stages,
-  but it does not yet expose the same kind of first-class runtime pipeline-stage
-  expansion in **WORKFLOW**. Its strength is elsewhere: experiment packaging,
-  managed execution environments, distributed research workloads, and
-  app-centric user workflows.
+  AGILab now supports dependency-aware WORKFLOW waves for saved lab stages, but
+  it remains scoped to experiment packaging, managed execution environments,
+  distributed research workloads, and app-centric user workflows rather than
+  replacing a scheduler-first orchestration platform.
 
 Selection guide
 ---------------

--- a/docs/source/experiment-help.rst
+++ b/docs/source/experiment-help.rst
@@ -83,6 +83,112 @@ must be refreshed deliberately.
 For example, if an app renames a runtime argument, older saved snippets that
 still pass the removed name must be regenerated or replaced before they can run.
 
+Pipeline profiles and stage dependencies
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``lab_stages.toml`` can remain a plain ordered stage list, but projects that
+need faster replay can opt into explicit single-project workflow automation.
+The contract is additive: older stage files without dependency fields still run
+in their saved sequence.
+
+The WORKFLOW execution controls expose:
+
+* ``Pipeline profile``: chooses the generic automation profile for this run.
+  Built-in profile names are ``balanced``, ``smoke``, ``fast``, ``evidence``,
+  and ``custom``. A stage may declare optional ``profiles.<name>`` overrides;
+  if it does not, AGILAB runs the saved stage exactly as written.
+* ``Parallel stage workers``: caps how many independent ``agi.*`` stages can
+  run at the same time. In-process ``runpy`` stages remain serialized because
+  they share the Streamlit session state.
+* ``Save automation settings``: persists the selected profile and worker cap in
+  the ``lab_stages.toml`` metadata. Opening WORKFLOW or changing the controls
+  does not rewrite the file until you press this button.
+* ``Stage dependencies``: lets you review or edit ``deps`` for the selected
+  stages. ``Suggest dependencies`` derives candidate edges from install/pipeline
+  naming and explicit path literals such as ``data_in`` and ``data_out``. Review
+  the suggestions before pressing ``Save dependencies``.
+* ``Show dependency graph``: previews the exact dependency graph used to compute
+  execution waves.
+
+A dependency-aware stage entry uses stable ids instead of fragile list indices:
+
+.. code-block:: toml
+
+   [[my_project]]
+   id = "prepare_data"
+   deps = []
+   D = "my_app/pipeline"
+   R = "agi.run"
+   C = "..."
+
+   [[my_project]]
+   id = "train_model"
+   deps = ["prepare_data"]
+   D = "my_model/pipeline"
+   R = "agi.run"
+   C = "..."
+
+The runner validates the graph before execution. Duplicate ids, unknown
+dependencies, cycles, or dependencies outside the selected execution sequence
+block the run instead of producing a partial or racy pipeline. When dependencies
+are valid, AGILAB computes topological waves: independent ``agi.*`` stages in
+the same wave may run concurrently, while dependent stages wait for their
+upstream wave.
+
+Stages can also declare an optional output-existence skip rule inside the same
+stage entry:
+
+.. code-block:: toml
+
+   [[my_project]]
+   id = "prepare_data"
+   deps = []
+   D = "my_app/pipeline"
+   R = "agi.run"
+   C = "..."
+   automation = { skip_if_outputs_exist = true, outputs = ["my_app/pipeline"] }
+
+This rule skips a stage only when every declared output exists. It is a
+convenience for fast local iteration, not a full freshness proof: AGILAB does
+not compare input mtimes, dependency hashes, or semantic content for this
+shortcut. Use ``reset_target`` or clear outputs when you need a clean rebuild.
+
+Each workflow run writes a local automation manifest beside the run logs. The
+current schema is ``agilab.pipeline.automation.v2``. The manifest also records
+``agilab.pipeline.automation.v1`` as a compatible schema for readers that only
+need the original profile, wave, stage status, and dependency fields. The
+manifest records the selected profile, worker cap, stage ids, dependencies,
+computed waves, per-stage status, declared output records, and a DOT dependency
+graph. Output records include resolved paths, existence, file or directory
+classification, size and mtime when available, and a SHA-256 for regular files
+up to the bounded manifest hashing limit. Larger files and directories are
+classified instead of hashed so workflow logging stays cheap. When MLflow
+tracking is available, the parent run also stores the automation metadata and
+dependency graph as text artifacts. The ``pipeline_metadata/automation.json``
+artifact records schema, compatible reader schemas, producer, producer version,
+local-only scope, workflow source, app, target, profile, run id, max workers,
+dependency waves, stage ids, and stage dependencies. For parallel waves, the
+automation manifest is the per-stage evidence source; nested MLflow stage runs
+remain a serial-stage evidence path. The ``Latest automation run`` expander
+summarizes the same manifest with a ``Schema`` KPI for reader compatibility
+status (``current``, ``compatible legacy``, ``unknown``, or ``unsupported``),
+the detailed schema caption, compatible reader schemas, producer, producer version, run id, automation profile, max workers,
+local-only scope, workflow source, app, target, lab directory, stages file,
+stages file SHA-256, start timestamp, finish timestamp, run duration, run
+error, stage counts, wave count, ``run_manifest_path`` for the immutable
+per-run manifest, ``manifest_path`` as the compatibility alias for that same
+per-run file, ``latest_manifest_path`` for the rolling latest-manifest alias,
+manifest SHA-256, declared output count, existing output count, hashed output
+count, and oversized-output count. Use
+``Show output evidence`` in that expander to inspect the manifest rows for each
+declared output: stage, status, specification, resolved path, existence, file
+kind, size, hash status, and SHA-256 when available.
+
+   The MLflow parent run also records ``pipeline_metadata/sequence.json`` with
+   schema ``agilab.pipeline.sequence.v2``. That artifact keeps the selected
+   sequence for legacy readers and adds the effective automation profile, run id,
+   max worker setting, dependency waves, stage ids, and stage dependencies so the
+   tracker evidence matches the actual waved execution plan.
+
 Workflow graph scopes
 ~~~~~~~~~~~~~~~~~~~~~
 The **Workflow graph** expander is the transition path from a single-project
@@ -269,14 +375,16 @@ MLflow tracking
 WORKFLOW execution and MLflow tracking now share the same runtime contract:
 
 .. figure:: diagrams/pipeline_mlflow_tracking.svg
-   :alt: Diagram showing one parent MLflow run for the whole workflow and one nested run per executed stage.
+   :alt: Diagram showing one parent MLflow run for the workflow and nested stage runs for serial stage execution.
    :align: center
    :class: diagram-panel diagram-standard
 
-   WORKFLOW creates one parent MLflow run per execution, then one nested run per stage, while both in-process and subprocess paths write to the same tracking store exposed by the MLflow UI.
+   WORKFLOW creates one parent MLflow run per execution. Serial stages create nested MLflow runs, while parallel waves record per-stage status in the automation manifest and attach workflow-level metadata to the parent run.
 
 * ``Run pipeline`` creates one parent MLflow run for the whole lab execution.
-* Every executed stage becomes a nested MLflow run with its own metadata.
+* Serial executed stages become nested MLflow runs with their own metadata.
+* Parallel ready waves intentionally use the automation manifest for per-stage
+  status, stdout, failure, and dependency evidence.
 * The tracked metadata comes from ``lab_stages.toml`` and includes the stage
   description, prompt/question, selected model, execution engine, and runtime.
 * Captured stdout, the executed snippet, the run log, and produced dataframe
@@ -304,8 +412,10 @@ domain metrics:
    tracker.log_artifact("reports/confusion_matrix.png")
 
 The tracking store is the directory configured by ``MLFLOW_TRACKING_DIR``.
-Subprocess-based stages receive the same ``MLFLOW_TRACKING_URI`` as in-process
-stages, so both execution paths are visible from the same MLflow UI.
+Serial subprocess-based stages receive the same ``MLFLOW_TRACKING_URI`` as
+in-process stages, so both serial execution paths are visible from the same
+MLflow UI. For parallel stage waves, use the latest automation manifest in
+WORKFLOW as the detailed per-stage execution view.
 
 HISTORY
 ~~~~~~~

--- a/src/agilab/pages/3_WORKFLOW.py
+++ b/src/agilab/pages/3_WORKFLOW.py
@@ -347,6 +347,9 @@ def run_all_stages(
     env: AgiEnv,
     log_placeholder: Optional[Any] = None,
     force_lock_clear: bool = False,
+    pipeline_profile: str = "balanced",
+    pipeline_max_workers: int = 1,
+    pipeline_stage_deps: Optional[Any] = None,
 ) -> None:
     """Execute all stages sequentially, honouring per-stage virtual environments."""
     _run_all_stages_impl(
@@ -365,6 +368,9 @@ def run_all_stages(
         ),
         log_placeholder=log_placeholder,
         force_lock_clear=force_lock_clear,
+        pipeline_profile=pipeline_profile,
+        pipeline_max_workers=pipeline_max_workers,
+        pipeline_stage_deps=pipeline_stage_deps,
     )
 
 

--- a/src/agilab/pipeline/pipeline_lab.py
+++ b/src/agilab/pipeline/pipeline_lab.py
@@ -54,11 +54,13 @@ get_available_virtualenvs = _pipeline_stages_module.get_available_virtualenvs
 _is_displayable_stage = _pipeline_stages_module.is_displayable_stage
 _is_orchestrate_locked_stage = _pipeline_stages_module.is_orchestrate_locked_stage
 _load_sequence_preferences = _pipeline_stages_module.load_sequence_preferences
+_load_automation_preferences = _pipeline_stages_module.load_automation_preferences
 _module_keys = _pipeline_stages_module.module_keys
 _normalize_imported_orchestrate_snippet = _pipeline_stages_module.normalize_imported_orchestrate_snippet
 normalize_runtime_path = _pipeline_stages_module.normalize_runtime_path
 _orchestrate_snippet_source = _pipeline_stages_module.orchestrate_snippet_source
 _persist_sequence_preferences = _pipeline_stages_module.persist_sequence_preferences
+_persist_automation_preferences = _pipeline_stages_module.persist_automation_preferences
 _snippet_source_guidance = _pipeline_stages_module.snippet_source_guidance
 _stage_label_for_multiselect = _pipeline_stages_module.stage_label_for_multiselect
 _stage_summary = _pipeline_stages_module.stage_summary
@@ -186,6 +188,153 @@ delete_pipeline_stage_command = _pipeline_page_state_module.delete_pipeline_stag
 finish_pipeline_run_command = _pipeline_page_state_module.finish_pipeline_run_command
 start_pipeline_run_command = _pipeline_page_state_module.start_pipeline_run_command
 undo_pipeline_delete_command = _pipeline_page_state_module.undo_pipeline_delete_command
+
+_pipeline_run_controls_module = import_agilab_module(
+    "agilab.pipeline_run_controls",
+    current_file=__file__,
+    fallback_path=Path(__file__).resolve().parent / "pipeline_run_controls.py",
+    fallback_name="agilab_pipeline_run_controls_fallback",
+)
+PIPELINE_AUTOMATION_MANIFEST_FILENAME = _pipeline_run_controls_module.PIPELINE_AUTOMATION_MANIFEST_FILENAME
+PIPELINE_AUTOMATION_PROFILES = _pipeline_run_controls_module.PIPELINE_AUTOMATION_PROFILES
+PIPELINE_AUTOMATION_PROFILE_HELP = _pipeline_run_controls_module.PIPELINE_AUTOMATION_PROFILE_HELP
+PIPELINE_AUTOMATION_PROFILE_LABELS = _pipeline_run_controls_module.PIPELINE_AUTOMATION_PROFILE_LABELS
+build_stage_waves = _pipeline_run_controls_module._build_stage_waves
+infer_stage_dependency_suggestions = _pipeline_run_controls_module.infer_stage_dependency_suggestions
+stage_deps_for_dependency = _pipeline_run_controls_module._stage_deps
+stage_id_for_dependency = _pipeline_run_controls_module._stage_id
+_automation_manifest_output_rows = _pipeline_run_controls_module._automation_manifest_output_rows
+_automation_manifest_output_summary = _pipeline_run_controls_module._automation_manifest_output_summary
+_automation_manifest_stage_summary = _pipeline_run_controls_module._automation_manifest_stage_summary
+_automation_manifest_schema_caption = _pipeline_run_controls_module._automation_manifest_schema_caption
+_automation_manifest_schema_status = _pipeline_run_controls_module._automation_manifest_schema_status
+_automation_manifest_identity_captions = _pipeline_run_controls_module._automation_manifest_identity_captions
+_automation_manifest_duration_label = _pipeline_run_controls_module._automation_manifest_duration_label
+_automation_manifest_error_caption = _pipeline_run_controls_module._automation_manifest_error_caption
+
+
+def _dot_escape(value: object) -> str:
+    return str(value or "").replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+
+
+def _short_graph_label(value: object, *, limit: int = 72) -> str:
+    text = re.sub(r"\s+", " ", str(value or "")).strip()
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1].rstrip() + "..."
+
+
+def _workflow_dependency_dot(
+    *,
+    stage_ids_by_idx: Mapping[int, str],
+    deps_by_stage_id: Mapping[str, List[str]],
+    labels_by_stage_id: Mapping[str, str],
+    waves: List[List[int]],
+) -> str:
+    wave_by_idx: Dict[int, int] = {}
+    for wave_number, wave in enumerate(waves, start=1):
+        for idx in wave:
+            wave_by_idx[int(idx)] = wave_number
+    lines = [
+        "digraph workflow_dependencies {",
+        "  graph [rankdir=LR, bgcolor=\"transparent\", pad=\"0.2\", nodesep=\"0.45\", ranksep=\"0.75\"];",
+        "  node [shape=box, style=\"rounded,filled\", fillcolor=\"#F7FAFC\", color=\"#2D3748\", fontname=\"Helvetica\", fontsize=10];",
+        "  edge [color=\"#4A5568\", arrowsize=0.7];",
+    ]
+    for idx in sorted(stage_ids_by_idx):
+        stage_id = stage_ids_by_idx[idx]
+        label = _short_graph_label(labels_by_stage_id.get(stage_id, stage_id))
+        wave_label = f"wave {wave_by_idx.get(idx, '?')}"
+        lines.append(
+            f'  "{_dot_escape(stage_id)}" [label="{_dot_escape(idx + 1)}. {_dot_escape(label)}\\n{_dot_escape(stage_id)} · {_dot_escape(wave_label)}"];'
+        )
+    for stage_id, deps in deps_by_stage_id.items():
+        for dep_id in deps:
+            if dep_id in labels_by_stage_id and stage_id in labels_by_stage_id:
+                lines.append(f'  "{_dot_escape(dep_id)}" -> "{_dot_escape(stage_id)}";')
+    for wave in waves:
+        wave_stage_ids = [stage_ids_by_idx[idx] for idx in wave if idx in stage_ids_by_idx]
+        if len(wave_stage_ids) > 1:
+            same_rank = "; ".join(f'"{_dot_escape(stage_id)}"' for stage_id in wave_stage_ids)
+            lines.append(f"  {{ rank=same; {same_rank}; }}")
+    lines.append("}")
+    return "\n".join(lines)
+
+
+def _load_pipeline_automation_manifest(path: str) -> Dict[str, Any] | None:
+    if not path:
+        return None
+    try:
+        payload = json.loads(Path(path).expanduser().read_text(encoding="utf-8"))
+    except (OSError, RuntimeError, TypeError, ValueError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _render_pipeline_automation_manifest_summary(path: str, *, key_prefix: str) -> None:
+    manifest = _load_pipeline_automation_manifest(path)
+    if not manifest:
+        return
+    stage_summary = _automation_manifest_stage_summary(manifest)
+    with st.expander("Latest automation run", expanded=False):
+        status_col, schema_col, profile_col, worker_col, wave_col, duration_col = st.columns(6)
+        status_col.metric("Status", str(manifest.get("status", "") or "unknown"))
+        schema_col.metric("Schema", _automation_manifest_schema_status(manifest))
+        profile_col.metric("Profile", str(manifest.get("profile", "") or "balanced"))
+        worker_col.metric("Workers", int(manifest.get("max_workers", 1) or 1))
+        wave_col.metric("Waves", len(manifest.get("waves", []) if isinstance(manifest.get("waves"), list) else []))
+        duration_col.metric("Duration", _automation_manifest_duration_label(manifest))
+        st.caption(_automation_manifest_schema_caption(manifest))
+        for identity_caption in _automation_manifest_identity_captions(manifest, path=path):
+            st.caption(identity_caption)
+        error_caption = _automation_manifest_error_caption(manifest)
+        if error_caption:
+            st.error(error_caption)
+        stage_col, exec_col, skip_col, fail_col = st.columns(4)
+        stage_col.metric("Stages", stage_summary["stage_count"])
+        exec_col.metric("Executed", stage_summary["executed"])
+        skip_col.metric("Skipped", stage_summary["skipped"])
+        fail_col.metric("Failed", stage_summary["failed"])
+        output_rows = _automation_manifest_output_rows(manifest)
+        if output_rows:
+            output_summary = _automation_manifest_output_summary(manifest)
+            output_col, existing_col, hashed_col, large_col = st.columns(4)
+            output_col.metric("Outputs", output_summary["outputs"])
+            existing_col.metric("Existing", output_summary["existing"])
+            hashed_col.metric("Hashed", output_summary["hashed"])
+            large_col.metric("Too large", output_summary["too_large"])
+            missing_outputs = output_summary["missing"]
+            if missing_outputs:
+                st.caption(f"Declared outputs missing in latest manifest: {missing_outputs}")
+            if st.checkbox(
+                "Show output evidence",
+                key=f"{key_prefix}_automation_manifest_outputs",
+                help="Inspect declared output records stored in the latest automation manifest.",
+            ):
+                st.dataframe(
+                    pd.DataFrame(output_rows),
+                    hide_index=True,
+                    width="stretch",
+                )
+        waves = manifest.get("waves", [])
+        if isinstance(waves, list) and waves:
+            wave_labels = [
+                " + ".join(str(stage_number) for stage_number in wave)
+                for wave in waves
+                if isinstance(wave, list)
+            ]
+            if wave_labels:
+                st.caption(f"Waves: {' -> '.join(wave_labels)}")
+        if st.checkbox(
+            "Show recorded dependency graph",
+            key=f"{key_prefix}_automation_manifest_graph",
+            help="Render the DOT dependency graph stored in the latest automation manifest.",
+        ):
+            dot_text = str(manifest.get("dependency_graph_dot") or "").strip()
+            if dot_text:
+                st.graphviz_chart(dot_text, use_container_width=True)
+            else:
+                st.caption("No dependency graph was recorded in this manifest.")
 
 _pinned_expander_module = import_agilab_module(
     "agilab.pinned_expander",
@@ -4961,6 +5110,209 @@ def display_lab_tab(
     force_run_arm_clicked = False
     force_run_cancel_clicked = False
     force_run_confirm_key = f"{index_page_str}_confirm_force_run"
+    automation_preferences = _load_automation_preferences(module_path, stages_file, env=env)
+    profile_key = f"{index_page_str}__pipeline_profile"
+    profile_options = list(PIPELINE_AUTOMATION_PROFILES)
+    if profile_key not in st.session_state:
+        stored_profile = str(automation_preferences.get("profile", "") or "")
+        st.session_state[profile_key] = stored_profile if stored_profile in profile_options else "balanced"
+    elif st.session_state.get(profile_key) not in profile_options:
+        st.session_state[profile_key] = "balanced"
+    selected_pipeline_profile = st.selectbox(
+        "Pipeline profile",
+        options=profile_options,
+        key=profile_key,
+        format_func=lambda value: PIPELINE_AUTOMATION_PROFILE_LABELS.get(str(value), str(value).title()),
+        help=(
+            "Select a generic automation profile. Stages can opt in with `profiles.<name>` "
+            "overrides, `automation.skip_if_outputs_exist`, and declared `automation.outputs`."
+        ),
+    )
+    st.caption(PIPELINE_AUTOMATION_PROFILE_HELP.get(str(selected_pipeline_profile), "Use the saved workflow stage values."))
+    workers_key = f"{index_page_str}__pipeline_max_workers"
+    if workers_key not in st.session_state:
+        try:
+            stored_workers = int(automation_preferences.get("max_workers", 3) or 3)
+        except (TypeError, ValueError):
+            stored_workers = 3
+        st.session_state[workers_key] = min(max(stored_workers, 1), 8)
+    selected_pipeline_max_workers = int(
+        st.number_input(
+            "Parallel stage workers",
+            min_value=1,
+            max_value=8,
+            step=1,
+            key=workers_key,
+            help=(
+                "Maximum independent AGI stages to run at the same time. "
+                "Only stages with explicit dependencies and subprocess-backed `agi.*` engines are parallelized. "
+                "Parallel stage status is recorded in the automation manifest; nested per-stage MLflow runs "
+                "remain a serial-stage evidence path."
+            ),
+        )
+    )
+    save_automation_settings_clicked = action_button(
+        st,
+        "Save automation settings",
+        key=f"{index_page_str}_save_automation_settings",
+        kind="save",
+        help="Persist the selected pipeline profile and parallel worker cap into the active lab_stages.toml metadata.",
+    )
+    if save_automation_settings_clicked:
+        _persist_automation_preferences(
+            module_path,
+            stages_file,
+            {
+                "profile": str(selected_pipeline_profile),
+                "max_workers": selected_pipeline_max_workers,
+            },
+            env=env,
+        )
+        toast(st, "Automation settings saved.", state="success")
+        _rerun_fragment_or_app()
+        return
+    deps_state_key = f"{index_page_str}__pipeline_stage_deps"
+    deps_state = st.session_state.setdefault(deps_state_key, {})
+    if not isinstance(deps_state, dict):
+        deps_state = {}
+        st.session_state[deps_state_key] = deps_state
+    stage_ids_by_idx = {
+        idx: stage_id_for_dependency(persisted_stages[idx], idx)
+        for idx in final_sequence
+        if 0 <= idx < len(persisted_stages)
+    }
+    stage_labels_by_id = {
+        stage_id: _stage_label_for_multiselect(idx, persisted_stages[idx], env=env)
+        for idx, stage_id in stage_ids_by_idx.items()
+        if 0 <= idx < len(persisted_stages)
+    }
+    with st.expander("Stage dependencies", expanded=False):
+        st.caption(
+            "Declare which selected stages must complete before another stage can run. "
+            "If no dependencies are set, WORKFLOW keeps the legacy sequential order."
+        )
+        suggest_dependencies_clicked = action_button(
+            st,
+            "Suggest dependencies",
+            key=f"{index_page_str}_suggest_stage_dependencies",
+            kind="save",
+            help=(
+                "Infer candidate dependencies from install/pipeline naming and explicit "
+                "data_in/data_out/path literals. Review before saving."
+            ),
+        )
+        if suggest_dependencies_clicked:
+            suggested_deps = infer_stage_dependency_suggestions(
+                [
+                    dict(entry) if isinstance(entry, Mapping) else {}
+                    for entry in persisted_stages
+                ],
+                final_sequence,
+                str(selected_pipeline_profile),
+            )
+            for stage_id, deps in suggested_deps.items():
+                filtered_deps = [dep for dep in deps if dep in stage_labels_by_id and dep != stage_id]
+                deps_state[stage_id] = filtered_deps
+                st.session_state[f"{index_page_str}__pipeline_deps_{stage_id}"] = filtered_deps
+            toast(st, "Dependency suggestions applied. Review and save if correct.", state="success")
+            _rerun_fragment_or_app()
+            return
+        for idx, stage_id in stage_ids_by_idx.items():
+            options = [
+                candidate_id
+                for candidate_idx, candidate_id in stage_ids_by_idx.items()
+                if candidate_idx != idx
+            ]
+            widget_key = f"{index_page_str}__pipeline_deps_{stage_id}"
+            if widget_key not in st.session_state:
+                initial_deps = deps_state.get(stage_id, stage_deps_for_dependency(persisted_stages[idx]))
+                st.session_state[widget_key] = [
+                    str(dep)
+                    for dep in initial_deps
+                    if str(dep) in options
+                ]
+            selected_deps = st.multiselect(
+                f"Stage {idx + 1} depends on",
+                options=options,
+                key=widget_key,
+                format_func=lambda value, labels=stage_labels_by_id: labels.get(str(value), str(value)),
+            )
+            deps_state[stage_id] = [str(dep) for dep in selected_deps]
+        save_dependencies_clicked = action_button(
+            st,
+            "Save dependencies",
+            key=f"{index_page_str}_save_stage_dependencies",
+            kind="save",
+            help="Persist the edited stage ids and dependency lists into the active lab_stages.toml file.",
+        )
+        if save_dependencies_clicked:
+            for idx, stage_id in stage_ids_by_idx.items():
+                if not 0 <= idx < len(persisted_stages):
+                    continue
+                current_entry = persisted_stages[idx]
+                if not isinstance(current_entry, Mapping):
+                    continue
+                updated_entry = dict(current_entry)
+                updated_entry["id"] = stage_id
+                updated_entry["deps"] = list(deps_state.get(stage_id, []))
+                _force_persist_stage(module_path, stages_file, idx, updated_entry)
+            _bump_history_revision()
+            toast(st, "Stage dependencies saved.", state="success")
+            _rerun_fragment_or_app()
+            return
+    preview_stages = [
+        dict(entry) if isinstance(entry, Mapping) else {}
+        for entry in persisted_stages
+    ]
+    for idx, stage_id in stage_ids_by_idx.items():
+        if 0 <= idx < len(preview_stages):
+            preview_stages[idx]["deps"] = list(deps_state.get(stage_id, []))
+    preview_waves, dependency_error, _preview_ids, _preview_deps = build_stage_waves(
+        preview_stages,
+        final_sequence,
+        str(selected_pipeline_profile),
+        dependency_overrides=deps_state,
+    )
+    if dependency_error:
+        st.warning(dependency_error)
+    elif preview_waves:
+        wave_labels = [
+            " + ".join(str(stage_number + 1) for stage_number in wave)
+            for wave in preview_waves
+        ]
+        st.caption(f"Planned execution waves: {' -> '.join(wave_labels)}")
+        if st.checkbox(
+            "Show dependency graph",
+            key=f"{index_page_str}_show_dependency_graph",
+            help="Preview the exact stage dependency graph used to compute execution waves.",
+        ):
+            st.graphviz_chart(
+                _workflow_dependency_dot(
+                    stage_ids_by_idx=stage_ids_by_idx,
+                    deps_by_stage_id=deps_state,
+                    labels_by_stage_id=stage_labels_by_id,
+                    waves=preview_waves,
+                ),
+                use_container_width=True,
+            )
+    last_manifest_file = str(st.session_state.get(f"{index_page_str}__last_pipeline_manifest_file", "") or "")
+    if last_manifest_file:
+        st.caption(f"Last automation manifest: `{last_manifest_file}`")
+        _render_pipeline_automation_manifest_summary(
+            last_manifest_file,
+            key_prefix=index_page_str,
+        )
+    else:
+        st.caption(f"Automation manifests are written as `{PIPELINE_AUTOMATION_MANIFEST_FILENAME}` beside run logs.")
+    last_waves = st.session_state.get(f"{index_page_str}__last_pipeline_waves")
+    if isinstance(last_waves, list) and last_waves:
+        wave_labels = [
+            " + ".join(str(stage_number) for stage_number in wave)
+            for wave in last_waves
+            if isinstance(wave, list)
+        ]
+        if wave_labels:
+            st.caption(f"Last execution waves: {' -> '.join(wave_labels)}")
     run_col, force_col = st.columns(2)
     with run_col:
         run_blocked_reason = page_state.blocked_actions.get(
@@ -4972,8 +5324,8 @@ def display_lab_tab(
             "Run workflow",
             key=f"{index_page_str}_run_all",
             kind="run",
-            help=run_blocked_reason or "Execute every stage sequentially using its saved virtual environment.",
-            disabled=PipelineAction.RUN_PIPELINE not in page_state.available_actions,
+            help=run_blocked_reason or dependency_error or "Execute the selected workflow stages using the planned dependency waves.",
+            disabled=PipelineAction.RUN_PIPELINE not in page_state.available_actions or bool(dependency_error),
         )
     with force_col:
         if lock_state:
@@ -4988,7 +5340,7 @@ def display_lab_tab(
                     key=f"{index_page_str}_force_run_stale",
                     kind="run",
                     help=force_blocked_reason or "Remove the stale workflow lock and start a new run.",
-                    disabled=PipelineAction.FORCE_RUN not in page_state.available_actions,
+                    disabled=PipelineAction.FORCE_RUN not in page_state.available_actions or bool(dependency_error),
                 )
             elif st.session_state.get(force_run_confirm_key, False):
                 force_run_clicked = action_button(
@@ -4998,7 +5350,7 @@ def display_lab_tab(
                     kind="run",
                     help=force_blocked_reason
                     or "Remove the current lock and start a new run. Use this only if the previous run is gone.",
-                    disabled=PipelineAction.FORCE_RUN not in page_state.available_actions,
+                    disabled=PipelineAction.FORCE_RUN not in page_state.available_actions or bool(dependency_error),
                 )
             else:
                 force_run_arm_clicked = action_button(
@@ -5008,7 +5360,7 @@ def display_lab_tab(
                     kind="destructive",
                     help=force_blocked_reason
                     or "Use only when a previous workflow run was interrupted and left a lock behind.",
-                    disabled=PipelineAction.FORCE_RUN not in page_state.available_actions,
+                    disabled=PipelineAction.FORCE_RUN not in page_state.available_actions or bool(dependency_error),
                 )
 
     if run_all_clicked and PipelineAction.RUN_PIPELINE not in page_state.available_actions:
@@ -5019,6 +5371,10 @@ def display_lab_tab(
             )
         )
         run_all_clicked = False
+    if (run_all_clicked or force_run_clicked) and dependency_error:
+        st.warning(dependency_error)
+        run_all_clicked = False
+        force_run_clicked = False
     if force_run_clicked and PipelineAction.FORCE_RUN not in page_state.available_actions:
         st.warning(
             page_state.blocked_actions.get(
@@ -5141,6 +5497,9 @@ def display_lab_tab(
                         env,
                         log_placeholder=run_placeholder,
                         force_lock_clear=bool(start_result.details.get("force_lock_clear")),
+                        pipeline_profile=str(selected_pipeline_profile),
+                        pipeline_max_workers=selected_pipeline_max_workers,
+                        pipeline_stage_deps=deps_state,
                     )
                 except Exception:
                     finish_result = finish_pipeline_run_command(

--- a/src/agilab/pipeline/pipeline_run_controls.py
+++ b/src/agilab/pipeline/pipeline_run_controls.py
@@ -1,15 +1,19 @@
 from __future__ import annotations
 
 import importlib.util
+import hashlib
 import json
 import logging
 import os
 import socket
+import subprocess
 import time
 import uuid
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
+from importlib.metadata import PackageNotFoundError, version as package_version
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple
 
 import pandas as pd
 import re
@@ -55,6 +59,1021 @@ PIPELINE_LOCK_DEFAULT_TTL_SEC = 6 * 3600.0
 PIPELINE_RUN_LOG_MIN_LINES = 20
 PIPELINE_RUN_LOG_LINE_HEIGHT_PX = 20
 PIPELINE_RUN_LOG_HEIGHT = PIPELINE_RUN_LOG_MIN_LINES * PIPELINE_RUN_LOG_LINE_HEIGHT_PX
+PIPELINE_AUTOMATION_SCHEMA = "agilab.pipeline.automation.v2"
+PIPELINE_AUTOMATION_COMPATIBLE_SCHEMAS = ["agilab.pipeline.automation.v1"]
+PIPELINE_AUTOMATION_PRODUCER = "agilab.pipeline.run_all_stages"
+PIPELINE_SEQUENCE_METADATA_SCHEMA = "agilab.pipeline.sequence.v2"
+PIPELINE_SEQUENCE_METADATA_COMPATIBLE_SCHEMAS = ["agilab.pipeline.sequence.v1"]
+PIPELINE_AUTOMATION_MANIFEST_FILENAME = "pipeline_automation_manifest.json"
+PIPELINE_AUTOMATION_OUTPUT_HASH_MAX_BYTES = 16 * 1024 * 1024
+PIPELINE_AUTOMATION_PROFILES = ("balanced", "smoke", "fast", "evidence", "custom")
+PIPELINE_AUTOMATION_PROFILE_LABELS = {
+    "balanced": "Balanced",
+    "smoke": "Smoke",
+    "fast": "Fast",
+    "evidence": "Evidence",
+    "custom": "Custom",
+}
+PIPELINE_AUTOMATION_PROFILE_HELP = {
+    "balanced": "Use the stage values saved in the workflow.",
+    "smoke": "Use optional project-declared smoke overrides for the shortest validation run.",
+    "fast": "Use optional project-declared fast overrides for quick iteration.",
+    "evidence": "Use optional project-declared evidence overrides for fuller reproducible runs.",
+    "custom": "Use saved stage values plus any project-declared custom overrides.",
+}
+
+
+def _pipeline_automation_producer_version() -> str:
+    try:
+        return package_version("agilab")
+    except PackageNotFoundError:
+        return ""
+
+
+def _utc_timestamp() -> str:
+    return datetime.utcnow().isoformat(timespec="seconds") + "Z"
+
+
+def _safe_file_sha256(path: Path) -> str:
+    try:
+        if path.is_file():
+            return hashlib.sha256(path.read_bytes()).hexdigest()
+    except (OSError, RuntimeError, ValueError):
+        pass
+    return ""
+
+
+def _stable_json_sha256(payload: Any) -> str:
+    encoded = json.dumps(payload, sort_keys=True, default=str, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _normalize_pipeline_profile(profile: str | None) -> str:
+    normalized = str(profile or "balanced").strip().lower()
+    return normalized if normalized in PIPELINE_AUTOMATION_PROFILES else "balanced"
+
+
+def _mapping_payload(raw: Any) -> Dict[str, Any]:
+    return dict(raw) if isinstance(raw, Mapping) else {}
+
+
+def _deep_merge_mapping(base: Mapping[str, Any], override: Mapping[str, Any]) -> Dict[str, Any]:
+    merged: Dict[str, Any] = dict(base)
+    for key, value in override.items():
+        current = merged.get(key)
+        if isinstance(current, Mapping) and isinstance(value, Mapping):
+            merged[key] = _deep_merge_mapping(current, value)
+        else:
+            merged[key] = value
+    return merged
+
+
+def _stage_profile_override(entry: Mapping[str, Any], profile: str) -> Dict[str, Any]:
+    for key in ("profiles", "pipeline_profiles", "automation_profiles"):
+        profile_map = entry.get(key)
+        if not isinstance(profile_map, Mapping):
+            continue
+        override = profile_map.get(profile)
+        if isinstance(override, Mapping):
+            return dict(override)
+    return {}
+
+
+def _apply_stage_profile(entry: Mapping[str, Any], profile: str) -> tuple[Dict[str, Any], Dict[str, Any]]:
+    base = dict(entry)
+    override = _stage_profile_override(base, profile)
+    if not override:
+        return base, {}
+    merged = _deep_merge_mapping(base, override)
+    return merged, override
+
+
+def _stage_automation(entry: Mapping[str, Any]) -> Dict[str, Any]:
+    automation = _mapping_payload(entry.get("automation"))
+    for key in ("skip_if_outputs_exist", "skip_if_outputs_current", "outputs", "output_paths", "inputs", "input_paths"):
+        if key in entry and key not in automation:
+            automation[key] = entry[key]
+    return automation
+
+
+def _iter_path_specs(value: Any) -> List[str]:
+    if value is None or isinstance(value, bool):
+        return []
+    if isinstance(value, Path):
+        return [str(value)]
+    if isinstance(value, str):
+        return [value] if value.strip() else []
+    if isinstance(value, Mapping):
+        paths: List[str] = []
+        for key in sorted(value, key=str):
+            paths.extend(_iter_path_specs(value[key]))
+        return paths
+    if isinstance(value, (list, tuple)):
+        paths = []
+        for item in value:
+            paths.extend(_iter_path_specs(item))
+        return paths
+    if isinstance(value, set):
+        paths = []
+        for item in sorted(value, key=str):
+            paths.extend(_iter_path_specs(item))
+        return paths
+    return [str(value)] if str(value).strip() else []
+
+
+def _truthy_pipeline_flag(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "y", "on"}
+    return bool(value)
+
+
+def _workflow_data_root(env: AgiEnv, stages_file: Path) -> Path:
+    for method_name in ("workflow_data_root_path", "share_root_path"):
+        method = getattr(env, method_name, None)
+        if callable(method):
+            try:
+                return Path(method()).expanduser().resolve(strict=False)
+            except (OSError, RuntimeError, TypeError, ValueError):
+                pass
+    for attr_name in ("agi_share_path_abs", "share_root", "root", "data_root"):
+        raw = getattr(env, attr_name, None)
+        if raw:
+            try:
+                return Path(raw).expanduser().resolve(strict=False)
+            except (OSError, RuntimeError, TypeError, ValueError):
+                pass
+    return stages_file.parent.expanduser().resolve(strict=False)
+
+
+def _resolve_stage_output_path(spec: Any, *, env: AgiEnv, stages_file: Path) -> Optional[Path]:
+    normalized = _normalize_output_path_spec(spec)
+    if not normalized:
+        return None
+    candidate = Path(normalized).expanduser()
+    if candidate.is_absolute():
+        return candidate.resolve(strict=False)
+    return (_workflow_data_root(env, stages_file) / candidate).resolve(strict=False)
+
+
+def _stage_output_specs(entry: Mapping[str, Any]) -> List[str]:
+    automation = _stage_automation(entry)
+    specs: List[str] = []
+    for key in ("outputs", "output_paths"):
+        for item in _iter_path_specs(automation.get(key)):
+            normalized = _normalize_output_path_spec(item)
+            if normalized:
+                specs.append(normalized)
+    return sorted(set(specs))
+
+
+def _stage_output_skip_rule(entry: Mapping[str, Any]) -> Dict[str, Any]:
+    automation = _stage_automation(entry)
+    enabled = _truthy_pipeline_flag(
+        automation.get("skip_if_outputs_exist", automation.get("skip_if_outputs_current"))
+    )
+    return {
+        "enabled": enabled,
+        "outputs": _stage_output_specs(entry),
+    }
+
+
+def _stage_output_records(
+    entry: Mapping[str, Any],
+    *,
+    env: AgiEnv,
+    stages_file: Path,
+) -> List[Dict[str, Any]]:
+    records: List[Dict[str, Any]] = []
+    for spec in _stage_output_specs(entry):
+        path = _resolve_stage_output_path(spec, env=env, stages_file=stages_file)
+        if path is None:
+            continue
+        exists = path.exists()
+        is_dir = path.is_dir() if exists else False
+        is_file = path.is_file() if exists else False
+        size_bytes: Optional[int] = None
+        mtime: Optional[float] = None
+        sha256 = ""
+        sha256_status = "missing"
+        if exists:
+            try:
+                stat = path.stat()
+                size_bytes = int(stat.st_size)
+                mtime = float(stat.st_mtime)
+                if is_file and size_bytes <= PIPELINE_AUTOMATION_OUTPUT_HASH_MAX_BYTES:
+                    sha256 = _safe_file_sha256(path)
+                    sha256_status = "ok" if sha256 else "error"
+                elif is_file:
+                    sha256_status = "too_large"
+                elif is_dir:
+                    sha256_status = "directory"
+                else:
+                    sha256_status = "not_regular_file"
+            except OSError:
+                size_bytes = None
+                mtime = None
+                sha256_status = "stat_error"
+        records.append(
+            {
+                "spec": spec,
+                "path": str(path),
+                "exists": exists,
+                "is_dir": is_dir,
+                "is_file": is_file,
+                "size_bytes": size_bytes,
+                "mtime": mtime,
+                "sha256": sha256,
+                "sha256_status": sha256_status,
+            }
+        )
+    return records
+
+
+def _automation_manifest_output_rows(manifest: Mapping[str, Any]) -> List[Dict[str, Any]]:
+    output_rows: List[Dict[str, Any]] = []
+    for stage_record in manifest.get("stages", []):
+        if not isinstance(stage_record, Mapping):
+            continue
+        for output_record in stage_record.get("outputs", []):
+            if not isinstance(output_record, Mapping):
+                continue
+            output_rows.append(
+                {
+                    "stage": stage_record.get("stage_index", ""),
+                    "status": stage_record.get("status", ""),
+                    "spec": output_record.get("spec", ""),
+                    "exists": bool(output_record.get("exists")),
+                    "kind": (
+                        "file"
+                        if output_record.get("is_file")
+                        else "directory"
+                        if output_record.get("is_dir")
+                        else "other"
+                    ),
+                    "size_bytes": output_record.get("size_bytes"),
+                    "sha256_status": output_record.get("sha256_status", ""),
+                    "sha256": output_record.get("sha256", ""),
+                    "path": output_record.get("path", ""),
+                }
+            )
+    return output_rows
+
+
+def _automation_manifest_output_summary(manifest: Mapping[str, Any]) -> Dict[str, int]:
+    output_rows = _automation_manifest_output_rows(manifest)
+    return {
+        "outputs": len(output_rows),
+        "existing": sum(1 for record in output_rows if record.get("exists")),
+        "hashed": sum(1 for record in output_rows if record.get("sha256_status") == "ok"),
+        "too_large": sum(1 for record in output_rows if record.get("sha256_status") == "too_large"),
+        "missing": sum(1 for record in output_rows if not record.get("exists")),
+    }
+
+
+def _automation_manifest_stage_summary(manifest: Mapping[str, Any]) -> Dict[str, int]:
+    summary = manifest.get("summary", {})
+    if not isinstance(summary, Mapping):
+        summary = {}
+    return {
+        "stage_count": int(summary.get("stage_count", 0) or 0),
+        "executed": int(summary.get("executed", 0) or 0),
+        "skipped": int(summary.get("skipped", 0) or 0),
+        "failed": int(summary.get("failed", 0) or 0),
+    }
+
+
+def _automation_manifest_schema_caption(manifest: Mapping[str, Any]) -> str:
+    schema = str(manifest.get("schema", "") or "unknown")
+    compatible_schemas = manifest.get("compatible_schemas", [])
+    compatible_schema_text = ""
+    if isinstance(compatible_schemas, list):
+        compatible_schema_text = ", ".join(str(item) for item in compatible_schemas if item)
+    schema_status = _automation_manifest_schema_status(manifest)
+    if compatible_schema_text:
+        return (
+            f"Manifest schema: {schema} "
+            f"({schema_status}; compatible readers: {compatible_schema_text})"
+        )
+    return f"Manifest schema: {schema} ({schema_status})"
+
+
+def _automation_manifest_schema_status(manifest: Mapping[str, Any]) -> str:
+    schema = str(manifest.get("schema", "") or "").strip()
+    if schema == PIPELINE_AUTOMATION_SCHEMA:
+        return "current"
+    if schema in PIPELINE_AUTOMATION_COMPATIBLE_SCHEMAS:
+        return "compatible legacy"
+    if not schema:
+        return "unknown"
+    return "unsupported"
+
+
+def _automation_manifest_paths(
+    manifest: Mapping[str, Any],
+    *,
+    path: str = "",
+) -> tuple[str, str]:
+    run_manifest_path = str(
+        manifest.get("run_manifest_path", "") or manifest.get("manifest_path", "") or ""
+    ).strip()
+    latest_manifest_path = str(
+        manifest.get("latest_manifest_path", "") or path or ""
+    ).strip()
+    return run_manifest_path, latest_manifest_path
+
+
+def _automation_manifest_identity_captions(
+    manifest: Mapping[str, Any],
+    *,
+    path: str = "",
+) -> List[str]:
+    producer = str(manifest.get("producer", "") or "").strip()
+    run_id = str(manifest.get("run_id", "") or "").strip()
+    profile = str(manifest.get("profile", "") or "").strip()
+    max_workers = str(manifest.get("max_workers", "") or "").strip()
+    workflow_source = str(manifest.get("workflow_source", "") or "").strip()
+    app = str(manifest.get("app", "") or "").strip()
+    target = str(manifest.get("target", "") or "").strip()
+    lab_dir = str(manifest.get("lab_dir", "") or "").strip()
+    stages_file = str(manifest.get("stages_file", "") or "").strip()
+    stages_file_sha256 = str(manifest.get("stages_file_sha256", "") or "").strip()
+    started_at = str(manifest.get("started_at", "") or "").strip()
+    finished_at = str(manifest.get("finished_at", "") or "").strip()
+    run_manifest_path, latest_manifest_path = _automation_manifest_paths(
+        manifest,
+        path=path,
+    )
+    displayed_manifest_path = run_manifest_path or latest_manifest_path
+    manifest_sha256 = str(manifest.get("manifest_sha256", "") or "").strip()
+    captions: List[str] = []
+    if producer:
+        captions.append(f"Manifest producer: {producer}")
+    producer_version = str(manifest.get("producer_version", "") or "").strip()
+    if producer_version:
+        captions.append(f"Producer version: {producer_version}")
+    if run_id:
+        captions.append(f"Run ID: {run_id}")
+    if profile:
+        captions.append(f"Automation profile: {profile}")
+    if max_workers:
+        captions.append(f"Max workers: {max_workers}")
+    if "local_only" in manifest:
+        captions.append(f"Local-only evidence: {'yes' if manifest.get('local_only') else 'no'}")
+    if workflow_source:
+        captions.append(f"Workflow source: {workflow_source}")
+    if app:
+        captions.append(f"App: {app}")
+    if target:
+        captions.append(f"Target: {target}")
+    if lab_dir:
+        captions.append(f"Lab directory: {lab_dir}")
+    if stages_file:
+        captions.append(f"Stages file: {stages_file}")
+    if stages_file_sha256:
+        captions.append(f"Stages file SHA-256: {stages_file_sha256}")
+    if started_at:
+        captions.append(f"Started at: {started_at}")
+    if finished_at:
+        captions.append(f"Finished at: {finished_at}")
+    if run_manifest_path:
+        captions.append(f"Run manifest file: {run_manifest_path}")
+    elif displayed_manifest_path:
+        captions.append(f"Manifest file: {displayed_manifest_path}")
+    if (
+        latest_manifest_path
+        and run_manifest_path
+        and latest_manifest_path != run_manifest_path
+    ):
+        captions.append(f"Latest manifest file: {latest_manifest_path}")
+    if manifest_sha256:
+        captions.append(f"Manifest SHA-256: {manifest_sha256}")
+    return captions
+
+
+def _automation_manifest_duration_label(manifest: Mapping[str, Any]) -> str:
+    duration_value = manifest.get("duration_seconds")
+    try:
+        duration_seconds = float(duration_value)
+    except (TypeError, ValueError):
+        return "unknown"
+    if duration_seconds < 0:
+        return "unknown"
+    if duration_seconds < 60:
+        return f"{duration_seconds:.1f}s"
+    minutes, seconds = divmod(duration_seconds, 60)
+    if minutes < 60:
+        return f"{int(minutes)}m {seconds:.1f}s"
+    hours, minutes = divmod(int(minutes), 60)
+    return f"{hours}h {minutes}m {seconds:.1f}s"
+
+
+def _automation_manifest_error_caption(manifest: Mapping[str, Any]) -> str:
+    error = str(manifest.get("error", "") or "").strip()
+    if not error:
+        return ""
+    return f"Run error: {error}"
+
+
+def _should_skip_current_outputs(
+    entry: Mapping[str, Any],
+    *,
+    env: AgiEnv,
+    stages_file: Path,
+) -> tuple[bool, List[Dict[str, Any]]]:
+    rule = _stage_output_skip_rule(entry)
+    output_records = _stage_output_records(entry, env=env, stages_file=stages_file)
+    if not rule["enabled"] or not output_records:
+        return False, output_records
+    return all(record["exists"] for record in output_records), output_records
+
+
+def _stage_disabled(entry: Mapping[str, Any]) -> bool:
+    automation = _stage_automation(entry)
+    if entry.get("enabled") is False or automation.get("enabled") is False:
+        return True
+    return bool(entry.get("skip") is True or automation.get("skip") is True)
+
+
+def _stage_id(entry: Mapping[str, Any], idx: int) -> str:
+    raw = str(entry.get("id") or entry.get("stage_id") or "").strip()
+    if raw:
+        return raw
+    return f"stage_{idx + 1}"
+
+
+def _stage_deps(entry: Mapping[str, Any]) -> List[str]:
+    raw = entry.get("deps", entry.get("depends_on", entry.get("dependencies", [])))
+    if isinstance(raw, str):
+        return [raw] if raw.strip() else []
+    if isinstance(raw, (list, tuple)):
+        return [str(item).strip() for item in raw if str(item).strip()]
+    return []
+
+
+def _normalize_dependency_path(raw: Any) -> str:
+    text = str(raw or "").strip().strip("\"'")
+    if not text or "://" in text or text.startswith("$"):
+        return ""
+    text = text.replace("\\", "/")
+    for marker in (
+        "/localshare/agi/",
+        "/clustershare/",
+        "/share/agi/",
+    ):
+        if marker in text:
+            text = text.split(marker, 1)[1]
+            break
+    while text.startswith("./"):
+        text = text[2:]
+    return text.strip("/")
+
+
+def _normalize_output_path_spec(raw: Any) -> str:
+    text = str(raw or "").strip().strip("\"'")
+    if not text or "://" in text or text.startswith("$"):
+        return ""
+    text = text.replace("\\", "/")
+    candidate = Path(text).expanduser()
+    if candidate.is_absolute():
+        return str(candidate)
+    while text.startswith("./"):
+        text = text[2:]
+    return text.strip("/")
+
+
+def _literal_stage_paths(entry: Mapping[str, Any]) -> List[str]:
+    paths: List[str] = []
+    for key, value in entry.items():
+        key_text = str(key).lower()
+        if key_text in {"c", "q", "m", "r", "id", "deps", "depends_on", "dependencies"}:
+            continue
+        if any(token in key_text for token in ("path", "dir", "data", "glob", "input", "output", "file")):
+            for item in _iter_path_specs(value):
+                normalized = _normalize_dependency_path(item)
+                if normalized:
+                    paths.append(normalized)
+    code = str(entry.get("C", "") or "")
+    for _quote, literal in re.findall(r"(['\"])([^'\"]+/[^'\"]*)\1", code):
+        normalized = _normalize_dependency_path(literal)
+        if normalized:
+            paths.append(normalized)
+    return sorted(set(paths))
+
+
+def _stage_declared_outputs(entry: Mapping[str, Any]) -> List[str]:
+    outputs: List[str] = []
+    d_value = _normalize_dependency_path(entry.get("D", ""))
+    if d_value and not d_value.endswith("/install"):
+        outputs.append(d_value)
+    automation = _stage_automation(entry)
+    for item in _iter_path_specs(automation.get("outputs", automation.get("output_paths", []))):
+        normalized = _normalize_dependency_path(item)
+        if normalized:
+            outputs.append(normalized)
+    code = str(entry.get("C", "") or "")
+    for pattern in (
+        r"\bdata_out\s*=\s*(['\"])(?P<path>[^'\"]+)\1",
+        r"['\"]data_out['\"]\s*:\s*(['\"])(?P<path>[^'\"]+)\1",
+        r"\boutput_dir\s*=\s*(['\"])(?P<path>[^'\"]+)\1",
+        r"['\"]output_dir['\"]\s*:\s*(['\"])(?P<path>[^'\"]+)\1",
+    ):
+        for match in re.finditer(pattern, code):
+            normalized = _normalize_dependency_path(match.group("path"))
+            if normalized:
+                outputs.append(normalized)
+    return sorted(set(outputs))
+
+
+def _path_depends_on_output(path: str, output: str) -> bool:
+    if not path or not output or path == output:
+        return path == output
+    return path.startswith(output.rstrip("/") + "/") or path.startswith(output.rstrip("/") + "*")
+
+
+def infer_stage_dependency_suggestions(
+    stages: List[Dict[str, Any]],
+    sequence: List[int],
+    profile: str = "balanced",
+) -> Dict[str, List[str]]:
+    """Infer conservative stage dependency suggestions from explicit ids and path literals."""
+    entries: Dict[int, Dict[str, Any]] = {}
+    ids_by_idx: Dict[int, str] = {}
+    outputs_by_idx: Dict[int, List[str]] = {}
+    paths_by_idx: Dict[int, List[str]] = {}
+    for idx in sequence:
+        if not 0 <= idx < len(stages):
+            continue
+        entry, _override = _apply_stage_profile(stages[idx], profile)
+        entries[idx] = entry
+        ids_by_idx[idx] = _stage_id(entry, idx)
+        outputs_by_idx[idx] = _stage_declared_outputs(entry)
+        paths_by_idx[idx] = _literal_stage_paths(entry)
+
+    suggestions: Dict[str, List[str]] = {stage_id: [] for stage_id in ids_by_idx.values()}
+    for consumer_idx, consumer_entry in entries.items():
+        consumer_id = ids_by_idx[consumer_idx]
+        consumer_d = _normalize_dependency_path(consumer_entry.get("D", ""))
+        consumer_paths = paths_by_idx.get(consumer_idx, [])
+        deps: List[str] = []
+        for producer_idx, producer_entry in entries.items():
+            if producer_idx == consumer_idx:
+                continue
+            producer_id = ids_by_idx[producer_idx]
+            producer_d = _normalize_dependency_path(producer_entry.get("D", ""))
+            if producer_d.endswith("/install") and consumer_d.startswith(producer_d.removesuffix("/install") + "/"):
+                deps.append(producer_id)
+                continue
+            for output in outputs_by_idx.get(producer_idx, []):
+                if any(_path_depends_on_output(path, output) for path in consumer_paths):
+                    deps.append(producer_id)
+                    break
+        suggestions[consumer_id] = sorted(set(deps), key=deps.index)
+    return suggestions
+
+
+def _build_stage_waves(
+    stages: List[Dict[str, Any]],
+    sequence: List[int],
+    profile: str,
+    dependency_overrides: Mapping[str, List[str]] | None = None,
+) -> tuple[List[List[int]], Optional[str], Dict[int, str], Dict[int, List[str]]]:
+    dependency_overrides = dependency_overrides or {}
+    entries_by_idx: Dict[int, Dict[str, Any]] = {}
+    ids_by_idx: Dict[int, str] = {}
+    deps_by_idx: Dict[int, List[str]] = {}
+    explicit_deps = False
+    seen_ids: Dict[str, int] = {}
+    for idx in sequence:
+        if not 0 <= idx < len(stages):
+            continue
+        entry, _override = _apply_stage_profile(stages[idx], profile)
+        entries_by_idx[idx] = entry
+        stage_id = _stage_id(entry, idx)
+        if stage_id in seen_ids:
+            return [], f"Duplicate workflow stage id `{stage_id}` on stages {seen_ids[stage_id] + 1} and {idx + 1}.", ids_by_idx, deps_by_idx
+        seen_ids[stage_id] = idx
+        ids_by_idx[idx] = stage_id
+        deps = _stage_deps(entry)
+        if stage_id in dependency_overrides:
+            deps = [str(dep).strip() for dep in dependency_overrides.get(stage_id, []) if str(dep).strip()]
+        explicit_deps = explicit_deps or bool(deps)
+        deps_by_idx[idx] = deps
+    if not explicit_deps:
+        return [[idx] for idx in sequence], None, ids_by_idx, deps_by_idx
+
+    selected_ids = set(ids_by_idx.values())
+    for idx, deps in deps_by_idx.items():
+        for dep in deps:
+            if dep not in seen_ids:
+                return [], f"Stage {idx + 1} depends on unknown stage id `{dep}`.", ids_by_idx, deps_by_idx
+            if dep not in selected_ids:
+                return [], f"Stage {idx + 1} depends on `{dep}`, which is outside the selected execution sequence.", ids_by_idx, deps_by_idx
+
+    completed: set[str] = set()
+    remaining = list(sequence)
+    waves: List[List[int]] = []
+    while remaining:
+        ready = [
+            idx
+            for idx in remaining
+            if all(dep in completed for dep in deps_by_idx.get(idx, []))
+        ]
+        if not ready:
+            cycle_ids = ", ".join(ids_by_idx.get(idx, f"stage_{idx + 1}") for idx in remaining)
+            return [], f"Workflow stage dependencies contain a cycle or unresolved chain: {cycle_ids}.", ids_by_idx, deps_by_idx
+        waves.append(ready)
+        for idx in ready:
+            remaining.remove(idx)
+            completed.add(ids_by_idx[idx])
+    return waves, None, ids_by_idx, deps_by_idx
+
+
+def _dot_escape(value: object) -> str:
+    return str(value or "").replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+
+
+def _pipeline_dependency_dot(
+    *,
+    stage_ids: Mapping[int, str],
+    stage_deps: Mapping[int, List[str]],
+    waves: List[List[int]],
+) -> str:
+    wave_by_idx: Dict[int, int] = {}
+    for wave_number, wave in enumerate(waves, start=1):
+        for idx in wave:
+            wave_by_idx[int(idx)] = wave_number
+    labels = {stage_id: f"{idx + 1}. {stage_id}\\nwave {wave_by_idx.get(idx, '?')}" for idx, stage_id in stage_ids.items()}
+    lines = [
+        "digraph workflow_dependencies {",
+        "  graph [rankdir=LR, bgcolor=\"transparent\"];",
+        "  node [shape=box, style=\"rounded,filled\", fillcolor=\"#F7FAFC\", color=\"#2D3748\"];",
+        "  edge [color=\"#4A5568\"];",
+    ]
+    for stage_id, label in labels.items():
+        lines.append(f'  "{_dot_escape(stage_id)}" [label="{_dot_escape(label)}"];')
+    for idx, deps in stage_deps.items():
+        stage_id = stage_ids.get(idx, f"stage_{idx + 1}")
+        for dep_id in deps:
+            if dep_id in labels:
+                lines.append(f'  "{_dot_escape(dep_id)}" -> "{_dot_escape(stage_id)}";')
+    for wave in waves:
+        wave_stage_ids = [stage_ids[idx] for idx in wave if idx in stage_ids]
+        if len(wave_stage_ids) > 1:
+            same_rank = "; ".join(f'"{_dot_escape(stage_id)}"' for stage_id in wave_stage_ids)
+            lines.append(f"  {{ rank=same; {same_rank}; }}")
+    lines.append("}")
+    return "\n".join(lines)
+
+
+def _resolve_stage_engine_runtime(
+    entry: Mapping[str, Any],
+    *,
+    env: AgiEnv,
+    idx: int,
+    selected_map: Mapping[int, str],
+    engine_map: Mapping[int, str],
+    default_runtime: str,
+) -> tuple[str, str]:
+    raw_runtime = _pipeline_stages.normalize_runtime_path(entry.get("E", ""))
+    venv_path = raw_runtime if _pipeline_runtime.is_valid_runtime_root(raw_runtime) else ""
+    runtime_root = venv_path or selected_map.get(idx, "") or default_runtime
+    entry_engine = str(entry.get("R", "") or "")
+    ui_engine = str(engine_map.get(idx) or "")
+    if ui_engine and ui_engine != entry_engine:
+        if entry_engine.startswith("agi.") and ui_engine == "runpy":
+            engine = entry_engine
+        else:
+            engine = ui_engine
+    elif entry_engine:
+        engine = entry_engine
+    else:
+        engine = "agi.run" if runtime_root else "runpy"
+    if runtime_root and engine == "runpy":
+        engine = "agi.run"
+    if engine.startswith("agi.") and not runtime_root:
+        fallback_runtime = _pipeline_stages.normalize_runtime_path(
+            getattr(env, "active_app", "") or ""
+        )
+        if _pipeline_runtime.is_valid_runtime_root(fallback_runtime):
+            runtime_root = fallback_runtime
+    return engine, runtime_root
+
+
+def _stage_script_path(target_base: Path, idx: int) -> Path:
+    return (target_base / f"AGI_run_stage{idx + 1}.py").resolve()
+
+
+def _run_stage_subprocess(
+    command: List[str],
+    *,
+    cwd: Path,
+    extra_env: Mapping[str, str],
+) -> str:
+    env_vars = os.environ.copy()
+    env_vars.update({str(key): str(value) for key, value in extra_env.items()})
+    completed = subprocess.run(
+        command,
+        cwd=str(cwd),
+        env=env_vars,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    output = "\n".join(part for part in [completed.stdout, completed.stderr] if part)
+    if completed.returncode != 0:
+        raise RuntimeError(
+            f"Command exited with status {completed.returncode}: {' '.join(command)}\n{output.strip()}"
+        )
+    return output
+
+
+def _parallel_agi_wave_eligible(
+    stages: List[Dict[str, Any]],
+    wave: List[int],
+    *,
+    profile: str,
+    env: AgiEnv,
+    stages_file: Path,
+    selected_map: Mapping[int, str],
+    engine_map: Mapping[int, str],
+    default_runtime: str,
+) -> bool:
+    if len(wave) < 2:
+        return False
+    for idx in wave:
+        entry, _override = _apply_stage_profile(stages[idx], profile)
+        if _stage_disabled(entry):
+            return False
+        skip_current, _outputs = _should_skip_current_outputs(entry, env=env, stages_file=stages_file)
+        if skip_current:
+            return False
+        code, _normalized = _normalize_legacy_agi_run_request_code(str(entry.get("C", "") or ""))
+        candidate = {**entry, "C": code}
+        if not _pipeline_stages.is_runnable_stage(candidate):
+            return False
+        engine, runtime_root = _resolve_stage_engine_runtime(
+            candidate,
+            env=env,
+            idx=idx,
+            selected_map=selected_map,
+            engine_map=engine_map,
+            default_runtime=default_runtime,
+        )
+        if not engine.startswith("agi.") or not runtime_root:
+            return False
+    return True
+
+
+def _run_parallel_agi_wave(
+    *,
+    stages: List[Dict[str, Any]],
+    wave: List[int],
+    profile: str,
+    env: AgiEnv,
+    index_page: str,
+    stages_file: Path,
+    run_id: str,
+    selected_map: Mapping[int, str],
+    engine_map: Mapping[int, str],
+    default_runtime: str,
+    target_base: Path,
+    max_workers: int,
+    manifest_stage_records: List[Dict[str, Any]],
+    log_placeholder: Optional[Any],
+) -> int:
+    prepared: List[Dict[str, Any]] = []
+    base_stage_env: Dict[str, str] = {}
+    for idx in wave:
+        entry, profile_override = _apply_stage_profile(stages[idx], profile)
+        code, normalized_agi_code = _normalize_legacy_agi_run_request_code(str(entry.get("C", "") or ""))
+        if normalized_agi_code:
+            entry = {**entry, "C": code}
+            _push_run_log(
+                index_page,
+                (
+                    f"Stage {idx + 1}: normalized legacy AGI RunRequest snippet "
+                    "from StepRequest/steps to StageRequest/stages."
+                ),
+                log_placeholder,
+            )
+        engine, venv_root = _resolve_stage_engine_runtime(
+            entry,
+            env=env,
+            idx=idx,
+            selected_map=selected_map,
+            engine_map=engine_map,
+            default_runtime=default_runtime,
+        )
+        summary = _pipeline_stages.stage_summary({"Q": entry.get("Q", ""), "C": code})
+        env_label = _pipeline_runtime.label_for_stage_runtime(
+            venv_root,
+            engine=engine,
+            code=code,
+        )
+        script_path = _stage_script_path(target_base, idx)
+        script_path.write_text(_pipeline_runtime.wrap_code_with_mlflow_resume(code), encoding="utf-8")
+        python_cmd = _pipeline_runtime.python_for_stage(
+            venv_root,
+            engine=engine,
+            code=code,
+        )
+        stage_env = dict(base_stage_env)
+        stage_env.update(
+            {
+                "AGILAB_PIPELINE_PROFILE": profile,
+                "AGILAB_PIPELINE_RUN_ID": run_id,
+                "AGILAB_PIPELINE_STAGE_INDEX": str(idx + 1),
+                "AGILAB_PIPELINE_MANIFEST": str(_pipeline_manifest_paths(env, index_page, run_id)[0]),
+            }
+        )
+        stage_record: Dict[str, Any] = {
+            "stage_index": idx + 1,
+            "status": "running",
+            "profile": profile,
+            "profile_override_applied": bool(profile_override),
+            "profile_override_keys": sorted(str(key) for key in profile_override),
+            "output_skip_rule": _stage_output_skip_rule(entry),
+            "description": str(entry.get("D", "") or ""),
+            "summary": summary,
+            "engine": engine,
+            "runtime": venv_root or "",
+            "code_sha256": hashlib.sha256(str(code or "").encode("utf-8")).hexdigest(),
+            "started_at": _utc_timestamp(),
+            "finished_at": "",
+            "duration_seconds": None,
+            "outputs": [],
+            "error": "",
+            "script_path": str(script_path),
+            "parallel_wave": True,
+            "mlflow_stage_run": "disabled_for_parallel_wave",
+        }
+        manifest_stage_records.append(stage_record)
+        if profile_override:
+            _push_run_log(
+                index_page,
+                f"Stage {idx + 1}: applied `{profile}` profile override.",
+                log_placeholder,
+            )
+        _push_run_log(
+            index_page,
+            f"Stage {idx + 1}: parallel start engine={engine}, env={env_label}, summary='{summary}'",
+            log_placeholder,
+        )
+        prepared.append(
+            {
+                "idx": idx,
+                "record": stage_record,
+                "entry": entry,
+                "started": time.time(),
+                "command": [str(python_cmd), str(script_path)],
+                "stage_env": stage_env,
+                "script_path": script_path,
+            }
+        )
+
+    executed = 0
+    first_error: Optional[BaseException] = None
+    worker_count = max(1, min(int(max_workers or 1), len(prepared)))
+    with ThreadPoolExecutor(max_workers=worker_count) as executor:
+        futures = {
+            executor.submit(
+                _run_stage_subprocess,
+                item["command"],
+                cwd=target_base,
+                extra_env=item["stage_env"],
+            ): item
+            for item in prepared
+        }
+        for future in as_completed(futures):
+            item = futures[future]
+            idx = int(item["idx"])
+            record = item["record"]
+            try:
+                output = future.result()
+            except BaseException as exc:
+                record["status"] = "failed"
+                record["finished_at"] = _utc_timestamp()
+                record["duration_seconds"] = max(time.time() - float(item["started"]), 0.0)
+                record["error"] = str(exc)
+                _push_run_log(index_page, f"Stage {idx + 1}: failed in parallel wave: {exc}", log_placeholder)
+                if first_error is None:
+                    first_error = exc
+                continue
+            preview = (output or "").strip()
+            if preview:
+                _push_run_log(index_page, f"Output (stage {idx + 1}):\n{preview}", log_placeholder)
+            else:
+                _push_run_log(index_page, f"Output (stage {idx + 1}): parallel {record['engine']} executed (no captured stdout)", log_placeholder)
+            record["status"] = "completed"
+            record["finished_at"] = _utc_timestamp()
+            record["duration_seconds"] = max(time.time() - float(item["started"]), 0.0)
+            record["outputs"] = _stage_output_records(item["entry"], env=env, stages_file=stages_file)
+            executed += 1
+    if first_error is not None:
+        raise first_error
+    return executed
+
+
+def _pipeline_manifest_paths(
+    env: AgiEnv,
+    index_page: str,
+    run_id: str,
+) -> tuple[Path, Path]:
+    log_file_path = st.session_state.get(f"{index_page}__run_log_file")
+    if log_file_path:
+        latest_path = Path(log_file_path).expanduser().parent / PIPELINE_AUTOMATION_MANIFEST_FILENAME
+        run_path = Path(log_file_path).expanduser().with_suffix(".pipeline_manifest.json")
+        return run_path, latest_path
+    app_name = str(getattr(env, "app", "") or getattr(env, "target", "") or "agilab")
+    log_dir_candidate = env.runenv or (Path.home() / "log" / "execute" / app_name)
+    latest_path = Path(log_dir_candidate).expanduser() / PIPELINE_AUTOMATION_MANIFEST_FILENAME
+    return latest_path.with_name(f"pipeline_automation_{run_id}.json"), latest_path
+
+
+def _write_json_atomic(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_name(path.name + ".tmp")
+    tmp_path.write_text(json.dumps(payload, indent=2, sort_keys=True, default=str) + "\n", encoding="utf-8")
+    tmp_path.replace(path)
+
+
+def _write_pipeline_automation_manifest(
+    *,
+    env: AgiEnv,
+    index_page: str,
+    run_id: str,
+    profile: str,
+    status: str,
+    lab_dir: Path,
+    stages_file: Path,
+    sequence: List[int],
+    waves: List[List[int]],
+    max_workers: int,
+    stage_ids: Mapping[int, str],
+    stage_deps: Mapping[int, List[str]],
+    stages: List[Dict[str, Any]],
+    started_at: str,
+    finished_at: str,
+    executed: int,
+    skipped: int,
+    error: str,
+    duration_seconds: float | None = None,
+) -> Optional[Path]:
+    run_path, latest_path = _pipeline_manifest_paths(env, index_page, run_id)
+    payload: Dict[str, Any] = {
+        "schema": PIPELINE_AUTOMATION_SCHEMA,
+        "compatible_schemas": PIPELINE_AUTOMATION_COMPATIBLE_SCHEMAS,
+        "producer": PIPELINE_AUTOMATION_PRODUCER,
+        "producer_version": _pipeline_automation_producer_version(),
+        "local_only": True,
+        "run_id": run_id,
+        "workflow_source": index_page,
+        "profile": profile,
+        "status": status,
+        "app": str(getattr(env, "app", "") or ""),
+        "target": str(getattr(env, "target", "") or ""),
+        "lab_dir": str(lab_dir),
+        "stages_file": str(stages_file),
+        "stages_file_sha256": _safe_file_sha256(stages_file),
+        "started_at": started_at,
+        "finished_at": finished_at,
+        "duration_seconds": duration_seconds,
+        "sequence": [idx + 1 for idx in sequence],
+        "waves": [[idx + 1 for idx in wave] for wave in waves],
+        "max_workers": max_workers,
+        "stage_ids": {str(idx + 1): stage_ids.get(idx, "") for idx in sequence},
+        "stage_deps": {stage_ids.get(idx, str(idx + 1)): stage_deps.get(idx, []) for idx in sequence},
+        "dependency_graph_dot": _pipeline_dependency_dot(
+            stage_ids=stage_ids,
+            stage_deps=stage_deps,
+            waves=waves,
+        ),
+        "summary": {
+            "executed": executed,
+            "skipped": skipped,
+            "failed": 1 if status == "failed" else 0,
+            "stage_count": len(sequence),
+        },
+        "error": error,
+        "stages": stages,
+        "run_manifest_path": str(run_path),
+        "manifest_path": str(run_path),
+        "latest_manifest_path": str(latest_path),
+    }
+    payload["manifest_sha256"] = _stable_json_sha256({k: v for k, v in payload.items() if k != "manifest_sha256"})
+    try:
+        _write_json_atomic(run_path, payload)
+        if latest_path != run_path:
+            _write_json_atomic(latest_path, payload)
+        st.session_state[f"{index_page}__last_pipeline_manifest_file"] = str(run_path)
+        return run_path
+    except (OSError, RuntimeError, TypeError, ValueError) as exc:
+        logger.debug("Failed to write pipeline automation manifest: %s", exc)
+        return None
 
 
 def _is_missing_mlflow_cli_error(exc: BaseException) -> bool:
@@ -84,6 +1103,13 @@ def _mlflow_parent_payload(
     lab_dir: Path,
     stages_file: Path,
     sequence: List[int],
+    *,
+    profile: str = "",
+    run_id: str = "",
+    max_workers: int | None = None,
+    waves: List[List[int]] | None = None,
+    stage_ids: Mapping[int, str] | None = None,
+    stage_deps: Mapping[int, List[str]] | None = None,
 ) -> tuple[str, Dict[str, Any], Dict[str, Any], Dict[str, str]]:
     run_name = f"{env.app or 'agilab'}:{lab_dir.name}:pipeline"
     tags = {
@@ -99,16 +1125,93 @@ def _mlflow_parent_payload(
     }
     text_artifacts = {
         "pipeline_metadata/sequence.json": json.dumps(
-            {
-                "app": str(getattr(env, "app", "") or ""),
-                "lab_dir": str(lab_dir),
-                "stages_file": str(stages_file),
-                "sequence": [idx + 1 for idx in sequence],
-            },
+            _pipeline_sequence_metadata(
+                env=env,
+                lab_dir=lab_dir,
+                stages_file=stages_file,
+                sequence=sequence,
+                profile=profile,
+                run_id=run_id,
+                max_workers=max_workers,
+                waves=waves,
+                stage_ids=stage_ids,
+                stage_deps=stage_deps,
+            ),
             indent=2,
         )
     }
     return run_name, tags, params, text_artifacts
+
+
+def _pipeline_sequence_metadata(
+    *,
+    env: AgiEnv,
+    lab_dir: Path,
+    stages_file: Path,
+    sequence: List[int],
+    profile: str = "",
+    run_id: str = "",
+    max_workers: int | None = None,
+    waves: List[List[int]] | None = None,
+    stage_ids: Mapping[int, str] | None = None,
+    stage_deps: Mapping[int, List[str]] | None = None,
+) -> Dict[str, Any]:
+    payload: Dict[str, Any] = {
+        "schema": PIPELINE_SEQUENCE_METADATA_SCHEMA,
+        "compatible_schemas": PIPELINE_SEQUENCE_METADATA_COMPATIBLE_SCHEMAS,
+        "producer": PIPELINE_AUTOMATION_PRODUCER,
+        "producer_version": _pipeline_automation_producer_version(),
+        "local_only": True,
+        "app": str(getattr(env, "app", "") or ""),
+        "target": str(getattr(env, "target", "") or ""),
+        "lab_dir": str(lab_dir),
+        "stages_file": str(stages_file),
+        "sequence": [idx + 1 for idx in sequence],
+    }
+    if profile:
+        payload["profile"] = profile
+    if run_id:
+        payload["run_id"] = run_id
+    if max_workers is not None:
+        payload["max_workers"] = max_workers
+    if waves is not None:
+        payload["waves"] = [[idx + 1 for idx in wave] for wave in waves]
+    if stage_ids is not None:
+        payload["stage_ids"] = {str(idx + 1): stage_ids.get(idx, "") for idx in sequence}
+    if stage_deps is not None and stage_ids is not None:
+        payload["stage_deps"] = {stage_ids.get(idx, str(idx + 1)): stage_deps.get(idx, []) for idx in sequence}
+    return payload
+
+
+def _pipeline_automation_metadata(
+    *,
+    env: AgiEnv,
+    workflow_source: str,
+    profile: str,
+    run_id: str,
+    sequence: List[int],
+    max_workers: int,
+    waves: List[List[int]],
+    stage_ids: Mapping[int, str],
+    stage_deps: Mapping[int, List[str]],
+) -> Dict[str, Any]:
+    return {
+        "schema": PIPELINE_AUTOMATION_SCHEMA,
+        "compatible_schemas": PIPELINE_AUTOMATION_COMPATIBLE_SCHEMAS,
+        "producer": PIPELINE_AUTOMATION_PRODUCER,
+        "producer_version": _pipeline_automation_producer_version(),
+        "local_only": True,
+        "workflow_source": workflow_source,
+        "app": str(getattr(env, "app", "") or ""),
+        "target": str(getattr(env, "target", "") or ""),
+        "profile": profile,
+        "run_id": run_id,
+        "sequence": [idx + 1 for idx in sequence],
+        "max_workers": max_workers,
+        "waves": [[idx + 1 for idx in wave] for wave in waves],
+        "stage_ids": {str(idx + 1): stage_ids.get(idx, "") for idx in sequence},
+        "stage_deps": {stage_ids.get(idx, str(idx + 1)): stage_deps.get(idx, []) for idx in sequence},
+    }
 
 
 def _mlflow_stage_payload(
@@ -530,11 +1633,31 @@ def run_all_stages(
     stream_run_command_fn: Callable[..., str],
     log_placeholder: Optional[Any] = None,
     force_lock_clear: bool = False,
+    pipeline_profile: str = "balanced",
+    pipeline_max_workers: int = 1,
+    pipeline_stage_deps: Mapping[str, List[str]] | None = None,
 ) -> None:
     """Execute all stages sequentially, honouring per-stage virtual environments."""
     if log_placeholder is None:
         log_placeholder = _get_run_placeholder(index_page_str)
+    pipeline_profile = _normalize_pipeline_profile(pipeline_profile)
+    try:
+        pipeline_max_workers = max(1, int(pipeline_max_workers))
+    except (TypeError, ValueError):
+        pipeline_max_workers = 1
+    run_id = uuid.uuid4().hex
+    started_at = _utc_timestamp()
+    run_started = time.time()
+    manifest_stage_records: List[Dict[str, Any]] = []
+    skipped = 0
+    run_status = "running"
+    run_error = ""
     _push_run_log(index_page_str, "Run pipeline invoked.", log_placeholder)
+    _push_run_log(
+        index_page_str,
+        f"Pipeline automation profile: {PIPELINE_AUTOMATION_PROFILE_LABELS.get(pipeline_profile, pipeline_profile)}.",
+        log_placeholder,
+    )
     stages = load_all_stages_fn(module_path, stages_file, index_page_str) or []
     if not stages:
         st.info(f"No stages available to run from {stages_file}.")
@@ -564,6 +1687,27 @@ def run_all_stages(
     if _abort_if_legacy_agi_run_stages(index_page_str, stages_file, stages, sequence, log_placeholder):
         return
 
+    waves, dependency_error, stage_ids_by_idx, stage_deps_by_idx = _build_stage_waves(
+        stages,
+        sequence,
+        pipeline_profile,
+        dependency_overrides=pipeline_stage_deps,
+    )
+    if dependency_error:
+        st.error(dependency_error)
+        _push_run_log(index_page_str, f"Run workflow aborted: {dependency_error}", log_placeholder)
+        return
+    st.session_state[f"{index_page_str}__last_pipeline_waves"] = [
+        [stage_idx + 1 for stage_idx in wave]
+        for wave in waves
+    ]
+    if len(waves) != len(sequence):
+        _push_run_log(
+            index_page_str,
+            f"Workflow dependency planner built {len(waves)} execution wave(s) from {len(sequence)} selected stage(s).",
+            log_placeholder,
+        )
+
     lock_handle = _acquire_pipeline_run_lock(
         env,
         index_page_str,
@@ -580,6 +1724,34 @@ def run_all_stages(
             lab_dir,
             stages_file,
             sequence,
+            profile=pipeline_profile,
+            run_id=run_id,
+            max_workers=pipeline_max_workers,
+            waves=waves,
+            stage_ids=stage_ids_by_idx,
+            stage_deps=stage_deps_by_idx,
+        )
+        parent_tags["agilab.pipeline_profile"] = pipeline_profile
+        parent_params["pipeline_profile"] = pipeline_profile
+        parent_params["pipeline_max_workers"] = pipeline_max_workers
+        parent_text_artifacts["pipeline_metadata/automation.json"] = json.dumps(
+            _pipeline_automation_metadata(
+                env=env,
+                workflow_source=index_page_str,
+                profile=pipeline_profile,
+                run_id=run_id,
+                sequence=sequence,
+                max_workers=pipeline_max_workers,
+                waves=waves,
+                stage_ids=stage_ids_by_idx,
+                stage_deps=stage_deps_by_idx,
+            ),
+            indent=2,
+        )
+        parent_text_artifacts["pipeline_metadata/dependency_graph.dot"] = _pipeline_dependency_dot(
+            stage_ids=stage_ids_by_idx,
+            stage_deps=stage_deps_by_idx,
+            waves=waves,
         )
         pipeline_log_artifact = st.session_state.get(f"{index_page_str}__run_log_file")
         with _pipeline_runtime.start_tracker_run(
@@ -594,181 +1766,302 @@ def run_all_stages(
                     file_artifacts=[stages_file],
                 )
             with st.spinner("Running all stages…"):
-                for idx in sequence:
-                    _refresh_pipeline_run_lock(lock_handle)
-                    entry = stages[idx]
-                    code = entry.get("C", "")
-                    code, normalized_agi_code = _normalize_legacy_agi_run_request_code(str(code or ""))
-                    if normalized_agi_code:
-                        entry = {**entry, "C": code}
-                        _push_run_log(
-                            index_page_str,
-                            (
-                                f"Stage {idx + 1}: normalized legacy AGI RunRequest snippet "
-                                "from StepRequest/steps to StageRequest/stages."
-                            ),
-                            log_placeholder,
-                        )
-                    if not _pipeline_stages.is_runnable_stage(entry):
-                        continue
-                    _push_run_log(index_page_str, f"Running stage {idx + 1}…", log_placeholder)
-
-                    raw_runtime = _pipeline_stages.normalize_runtime_path(entry.get("E", ""))
-                    venv_path = (
-                        raw_runtime if _pipeline_runtime.is_valid_runtime_root(raw_runtime) else ""
-                    )
-                    if venv_path:
-                        selected_map[idx] = venv_path
-                        st.session_state["lab_selected_venv"] = venv_path
-                    else:
-                        selected_map.pop(idx, None)
-                    runtime_root = venv_path or st.session_state.get("lab_selected_venv", "")
-
-                    st.session_state[index_page_str][0] = idx
-                    st.session_state[index_page_str][1] = entry.get("D", "")
-                    st.session_state[index_page_str][2] = entry.get("Q", "")
-                    st.session_state[index_page_str][3] = entry.get("M", "")
-                    st.session_state[index_page_str][4] = code
-                    st.session_state[index_page_str][5] = details_store.get(idx, "")
-
-                    venv_root = runtime_root
-                    entry_engine = str(entry.get("R", "") or "")
-                    ui_engine = str(engine_map.get(idx) or "")
-                    if ui_engine and ui_engine != entry_engine:
-                        if entry_engine.startswith("agi.") and ui_engine == "runpy":
-                            engine = entry_engine
-                        else:
-                            engine = ui_engine
-                    elif entry_engine:
-                        engine = entry_engine
-                    else:
-                        engine = "agi.run" if venv_root else "runpy"
-                    if venv_root and engine == "runpy":
-                        engine = "agi.run"
-                    if engine.startswith("agi.") and not venv_root:
-                        fallback_runtime = _pipeline_stages.normalize_runtime_path(
-                            getattr(env, "active_app", "") or ""
-                        )
-                        if _pipeline_runtime.is_valid_runtime_root(fallback_runtime):
-                            venv_root = fallback_runtime
-                            st.session_state["lab_selected_venv"] = venv_root
-
-                    stage_run_name, stage_tags, stage_params, stage_text_artifacts = _mlflow_stage_payload(
-                        env,
-                        lab_dir,
-                        stages_file,
-                        stage_index=idx,
-                        entry=entry,
-                        engine=engine,
-                        runtime_root=venv_root,
+                for wave_number, wave in enumerate(waves, start=1):
+                    wave_label = ", ".join(str(stage_idx + 1) for stage_idx in wave)
+                    _push_run_log(
+                        index_page_str,
+                        f"Running workflow wave {wave_number}/{len(waves)}: stage(s) {wave_label}.",
+                        log_placeholder,
                     )
                     target_base = Path(stages_file).parent.resolve()
                     if target_base.name == target_base.parent.name:
                         target_base = target_base.parent
                     target_base.mkdir(parents=True, exist_ok=True)
-                    script_artifact: Optional[Path] = None
-                    export_target = st.session_state.get("df_file_out", "")
-                    with _pipeline_runtime.start_tracker_run(
-                        env,
-                        run_name=stage_run_name,
-                        tags=stage_tags,
-                        params=stage_params,
-                        nested=bool(pipeline_tracker),
-                    ) as stage_tracker:
-                        stage_env = (
-                            _pipeline_runtime.build_mlflow_process_env(
-                                env,
-                                run_id=stage_tracker.run_id,
-                            )
-                            if stage_tracker
-                            else {}
+                    default_runtime = st.session_state.get("lab_selected_venv", "")
+                    if (
+                        pipeline_max_workers > 1
+                        and _parallel_agi_wave_eligible(
+                            stages,
+                            wave,
+                            profile=pipeline_profile,
+                            env=env,
+                            stages_file=stages_file,
+                            selected_map=selected_map,
+                            engine_map=engine_map,
+                            default_runtime=default_runtime,
                         )
-                        if stage_tracker:
-                            stage_tracker.log_artifacts(
-                                text_artifacts=stage_text_artifacts,
+                    ):
+                        _push_run_log(
+                            index_page_str,
+                            f"Wave {wave_number}: running {len(wave)} AGI stage(s) in parallel with max_workers={pipeline_max_workers}.",
+                            log_placeholder,
+                        )
+                        executed += _run_parallel_agi_wave(
+                            stages=stages,
+                            wave=wave,
+                            profile=pipeline_profile,
+                            env=env,
+                            index_page=index_page_str,
+                            stages_file=stages_file,
+                            run_id=run_id,
+                            selected_map=selected_map,
+                            engine_map=engine_map,
+                            default_runtime=default_runtime,
+                            target_base=target_base,
+                            max_workers=pipeline_max_workers,
+                            manifest_stage_records=manifest_stage_records,
+                            log_placeholder=log_placeholder,
+                        )
+                        continue
+                    for idx in wave:
+                        _refresh_pipeline_run_lock(lock_handle)
+                        base_entry = stages[idx]
+                        entry, profile_override = _apply_stage_profile(base_entry, pipeline_profile)
+                        summary = _pipeline_stages.stage_summary(entry)
+                        stage_record: Dict[str, Any] = {
+                            "stage_index": idx + 1,
+                            "status": "pending",
+                        "profile": pipeline_profile,
+                        "profile_override_applied": bool(profile_override),
+                        "profile_override_keys": sorted(str(key) for key in profile_override),
+                        "output_skip_rule": _stage_output_skip_rule(entry),
+                        "description": str(entry.get("D", "") or ""),
+                        "summary": summary,
+                        "engine": "",
+                        "runtime": "",
+                            "code_sha256": hashlib.sha256(str(entry.get("C", "") or "").encode("utf-8")).hexdigest(),
+                            "started_at": "",
+                            "finished_at": "",
+                            "duration_seconds": None,
+                            "outputs": _stage_output_records(entry, env=env, stages_file=stages_file),
+                            "error": "",
+                        }
+                        manifest_stage_records.append(stage_record)
+                        if profile_override:
+                            _push_run_log(
+                                index_page_str,
+                                f"Stage {idx + 1}: applied `{pipeline_profile}` profile override.",
+                                log_placeholder,
                             )
-                        if engine == "runpy":
-                            output = run_lab(
-                                [entry.get("D", ""), entry.get("Q", ""), code],
-                                snippet_file,
-                                env.copilot_file,
-                                env_overrides=stage_env,
+                        if _stage_disabled(entry):
+                            stage_record["status"] = "skipped_disabled"
+                            stage_record["finished_at"] = _utc_timestamp()
+                            skipped += 1
+                            _push_run_log(index_page_str, f"Stage {idx + 1}: skipped by automation profile.", log_placeholder)
+                            continue
+                        skip_current, output_records = _should_skip_current_outputs(
+                            entry,
+                            env=env,
+                            stages_file=stages_file,
+                        )
+                        stage_record["outputs"] = output_records
+                        if skip_current:
+                            stage_record["status"] = "skipped_outputs_exist"
+                            stage_record["finished_at"] = _utc_timestamp()
+                            skipped += 1
+                            _push_run_log(
+                                index_page_str,
+                                f"Stage {idx + 1}: skipped because declared outputs already exist.",
+                                log_placeholder,
                             )
-                            script_artifact = Path(snippet_file)
+                            continue
+                        code = entry.get("C", "")
+                        code, normalized_agi_code = _normalize_legacy_agi_run_request_code(str(code or ""))
+                        if normalized_agi_code:
+                            entry = {**entry, "C": code}
+                            _push_run_log(
+                                index_page_str,
+                                (
+                                    f"Stage {idx + 1}: normalized legacy AGI RunRequest snippet "
+                                    "from StepRequest/steps to StageRequest/stages."
+                                ),
+                                log_placeholder,
+                            )
+                        if not _pipeline_stages.is_runnable_stage(entry):
+                            stage_record["status"] = "skipped_not_runnable"
+                            stage_record["finished_at"] = _utc_timestamp()
+                            skipped += 1
+                            continue
+                        _push_run_log(index_page_str, f"Running stage {idx + 1}…", log_placeholder)
+                        stage_started = time.time()
+                        stage_record["status"] = "running"
+                        stage_record["started_at"] = _utc_timestamp()
+
+                        raw_runtime = _pipeline_stages.normalize_runtime_path(entry.get("E", ""))
+                        venv_path = (
+                            raw_runtime if _pipeline_runtime.is_valid_runtime_root(raw_runtime) else ""
+                        )
+                        if venv_path:
+                            selected_map[idx] = venv_path
+                            st.session_state["lab_selected_venv"] = venv_path
                         else:
-                            script_path = (target_base / "AGI_run.py").resolve()
-                            script_path.write_text(_pipeline_runtime.wrap_code_with_mlflow_resume(code))
-                            script_artifact = script_path
-                            python_cmd = _pipeline_runtime.python_for_stage(
+                            selected_map.pop(idx, None)
+                        runtime_root = venv_path or st.session_state.get("lab_selected_venv", "")
+
+                        st.session_state[index_page_str][0] = idx
+                        st.session_state[index_page_str][1] = entry.get("D", "")
+                        st.session_state[index_page_str][2] = entry.get("Q", "")
+                        st.session_state[index_page_str][3] = entry.get("M", "")
+                        st.session_state[index_page_str][4] = code
+                        st.session_state[index_page_str][5] = details_store.get(idx, "")
+
+                        venv_root = runtime_root
+                        entry_engine = str(entry.get("R", "") or "")
+                        ui_engine = str(engine_map.get(idx) or "")
+                        if ui_engine and ui_engine != entry_engine:
+                            if entry_engine.startswith("agi.") and ui_engine == "runpy":
+                                engine = entry_engine
+                            else:
+                                engine = ui_engine
+                        elif entry_engine:
+                            engine = entry_engine
+                        else:
+                            engine = "agi.run" if venv_root else "runpy"
+                        if venv_root and engine == "runpy":
+                            engine = "agi.run"
+                        if engine.startswith("agi.") and not venv_root:
+                            fallback_runtime = _pipeline_stages.normalize_runtime_path(
+                                getattr(env, "active_app", "") or ""
+                            )
+                            if _pipeline_runtime.is_valid_runtime_root(fallback_runtime):
+                                venv_root = fallback_runtime
+                                st.session_state["lab_selected_venv"] = venv_root
+                        stage_record["engine"] = engine
+                        stage_record["runtime"] = venv_root or ""
+
+                        stage_run_name, stage_tags, stage_params, stage_text_artifacts = _mlflow_stage_payload(
+                            env,
+                            lab_dir,
+                            stages_file,
+                            stage_index=idx,
+                            entry=entry,
+                            engine=engine,
+                            runtime_root=venv_root,
+                        )
+                        target_base = Path(stages_file).parent.resolve()
+                        if target_base.name == target_base.parent.name:
+                            target_base = target_base.parent
+                        target_base.mkdir(parents=True, exist_ok=True)
+                        script_artifact: Optional[Path] = None
+                        export_target = st.session_state.get("df_file_out", "")
+                        with _pipeline_runtime.start_tracker_run(
+                            env,
+                            run_name=stage_run_name,
+                            tags=stage_tags,
+                            params=stage_params,
+                            nested=bool(pipeline_tracker),
+                        ) as stage_tracker:
+                            stage_env = (
+                                _pipeline_runtime.build_mlflow_process_env(
+                                    env,
+                                    run_id=stage_tracker.run_id,
+                                )
+                                if stage_tracker
+                                else {}
+                            )
+                            stage_env.update(
+                                {
+                                    "AGILAB_PIPELINE_PROFILE": pipeline_profile,
+                                    "AGILAB_PIPELINE_RUN_ID": run_id,
+                                    "AGILAB_PIPELINE_STAGE_INDEX": str(idx + 1),
+                                    "AGILAB_PIPELINE_MANIFEST": str(_pipeline_manifest_paths(env, index_page_str, run_id)[0]),
+                                }
+                            )
+                            if stage_tracker:
+                                stage_tracker.log_artifacts(
+                                    text_artifacts=stage_text_artifacts,
+                                )
+                            if engine == "runpy":
+                                output = run_lab(
+                                    [entry.get("D", ""), entry.get("Q", ""), code],
+                                    snippet_file,
+                                    env.copilot_file,
+                                    env_overrides=stage_env,
+                                )
+                                script_artifact = Path(snippet_file)
+                            else:
+                                script_path = _stage_script_path(target_base, idx)
+                                script_path.write_text(_pipeline_runtime.wrap_code_with_mlflow_resume(code))
+                                script_artifact = script_path
+                                python_cmd = _pipeline_runtime.python_for_stage(
+                                    venv_root,
+                                    engine=engine,
+                                    code=code,
+                                )
+                                output = stream_run_command_fn(
+                                    env,
+                                    index_page_str,
+                                    [str(python_cmd), str(script_path)],
+                                    cwd=target_base,
+                                    placeholder=log_placeholder,
+                                    extra_env=stage_env,
+                                )
+                            _refresh_pipeline_run_lock(lock_handle)
+
+                            preview = (output or "").strip()
+                            if preview:
+                                _push_run_log(
+                                    index_page_str,
+                                    f"Output (stage {idx + 1}):\n{preview}",
+                                    log_placeholder,
+                                )
+                                if "No such file or directory" in preview:
+                                    _push_run_log(
+                                        index_page_str,
+                                        "Hint: for AGI app stages, input/output data is normally resolved under "
+                                        "agi_env.AGI_CLUSTER_SHARE. Check whether the upstream stage created the "
+                                        "expected file there before this stage ran.",
+                                        log_placeholder,
+                                    )
+                            else:
+                                _push_run_log(
+                                    index_page_str,
+                                    f"Output (stage {idx + 1}): {engine} executed (no captured stdout)",
+                                    log_placeholder,
+                                )
+
+                            if isinstance(st.session_state.get("data"), pd.DataFrame) and not st.session_state["data"].empty:
+                                if save_csv(st.session_state["data"], export_target):
+                                    st.session_state["df_file_in"] = export_target
+                                    st.session_state["stage_checked"] = True
+                            summary = _pipeline_stages.stage_summary({"Q": entry.get("Q", ""), "C": code})
+                            env_label = _pipeline_runtime.label_for_stage_runtime(
                                 venv_root,
                                 engine=engine,
                                 code=code,
                             )
-                            output = stream_run_command_fn(
-                                env,
-                                index_page_str,
-                                [str(python_cmd), str(script_path)],
-                                cwd=target_base,
-                                placeholder=log_placeholder,
-                                extra_env=stage_env,
-                            )
-                        _refresh_pipeline_run_lock(lock_handle)
-
-                        preview = (output or "").strip()
-                        if preview:
                             _push_run_log(
                                 index_page_str,
-                                f"Output (stage {idx + 1}):\n{preview}",
+                                f"Stage {idx + 1}: engine={engine}, env={env_label}, summary=\"{summary}\"",
                                 log_placeholder,
                             )
-                            if "No such file or directory" in preview:
-                                _push_run_log(
-                                    index_page_str,
-                                    "Hint: for AGI app stages, input/output data is normally resolved under "
-                                    "agi_env.AGI_CLUSTER_SHARE. Check whether the upstream stage created the "
-                                    "expected file there before this stage ran.",
-                                    log_placeholder,
+                            if stage_tracker:
+                                stage_files = [script_artifact]
+                                if export_target:
+                                    stage_files.append(export_target)
+                                stage_tracker.log_artifacts(
+                                    text_artifacts={f"stage_{idx + 1}/stdout.txt": preview or ""},
+                                    file_artifacts=stage_files,
+                                    tags={
+                                        "agilab.status": "completed",
+                                        "agilab.output_present": bool(preview),
+                                    },
                                 )
-                        else:
-                            _push_run_log(
-                                index_page_str,
-                                f"Output (stage {idx + 1}): {engine} executed (no captured stdout)",
-                                log_placeholder,
+                            executed += 1
+                            stage_record["status"] = "completed"
+                            stage_record["finished_at"] = _utc_timestamp()
+                            stage_record["duration_seconds"] = max(time.time() - stage_started, 0.0)
+                            stage_record["outputs"] = _stage_output_records(
+                                entry,
+                                env=env,
+                                stages_file=stages_file,
                             )
-
-                        if isinstance(st.session_state.get("data"), pd.DataFrame) and not st.session_state["data"].empty:
-                            if save_csv(st.session_state["data"], export_target):
-                                st.session_state["df_file_in"] = export_target
-                                st.session_state["stage_checked"] = True
-                        summary = _pipeline_stages.stage_summary({"Q": entry.get("Q", ""), "C": code})
-                        env_label = _pipeline_runtime.label_for_stage_runtime(
-                            venv_root,
-                            engine=engine,
-                            code=code,
-                        )
-                        _push_run_log(
-                            index_page_str,
-                            f"Stage {idx + 1}: engine={engine}, env={env_label}, summary=\"{summary}\"",
-                            log_placeholder,
-                        )
-                        if stage_tracker:
-                            stage_files = [script_artifact]
-                            if export_target:
-                                stage_files.append(export_target)
-                            stage_tracker.log_artifacts(
-                                text_artifacts={f"stage_{idx + 1}/stdout.txt": preview or ""},
-                                file_artifacts=stage_files,
-                                tags={
-                                    "agilab.status": "completed",
-                                    "agilab.output_present": bool(preview),
-                                },
-                            )
-                        executed += 1
+            run_status = "completed"
             if pipeline_tracker:
                 pipeline_tracker.log_artifacts(
                     file_artifacts=[pipeline_log_artifact] if pipeline_log_artifact else [],
                     tags={"agilab.status": "completed"},
-                    metrics={"executed_stages": executed},
+                    metrics={"executed_stages": executed, "skipped_stages": skipped},
                 )
 
         if executed:
@@ -777,7 +2070,73 @@ def run_all_stages(
         else:
             st.info("No runnable code found in the stages.")
             _push_run_log(index_page_str, "Run workflow completed: no runnable code found.", log_placeholder)
+    except BaseException as exc:
+        run_status = "failed"
+        run_error = str(exc)
+        for stage_record in reversed(manifest_stage_records):
+            if stage_record.get("status") == "running":
+                stage_record["status"] = "failed"
+                stage_record["finished_at"] = _utc_timestamp()
+                stage_record["error"] = run_error
+                break
+        if "waves" in locals():
+            recorded = {
+                int(record.get("stage_index", 0)) - 1
+                for record in manifest_stage_records
+                if int(record.get("stage_index", 0) or 0) > 0
+            }
+            for wave in waves:
+                for pending_idx in wave:
+                    if pending_idx in recorded:
+                        continue
+                    pending_entry, _override = _apply_stage_profile(stages[pending_idx], pipeline_profile)
+                    manifest_stage_records.append(
+                        {
+                            "stage_index": pending_idx + 1,
+                            "status": "skipped_after_failure",
+                            "profile": pipeline_profile,
+                            "profile_override_applied": False,
+                            "profile_override_keys": [],
+                            "output_skip_rule": _stage_output_skip_rule(pending_entry),
+                            "description": str(pending_entry.get("D", "") or ""),
+                            "summary": _pipeline_stages.stage_summary(pending_entry),
+                            "engine": "",
+                            "runtime": "",
+                            "code_sha256": hashlib.sha256(str(pending_entry.get("C", "") or "").encode("utf-8")).hexdigest(),
+                            "started_at": "",
+                            "finished_at": _utc_timestamp(),
+                            "duration_seconds": None,
+                            "outputs": _stage_output_records(pending_entry, env=env, stages_file=stages_file),
+                            "error": "Skipped because an earlier workflow stage failed.",
+                        }
+                    )
+        raise
     finally:
+        manifest_path = _write_pipeline_automation_manifest(
+            env=env,
+            index_page=index_page_str,
+            run_id=run_id,
+            profile=pipeline_profile,
+            status=run_status,
+            lab_dir=lab_dir,
+            stages_file=stages_file,
+            sequence=sequence if "sequence" in locals() else [],
+            waves=waves if "waves" in locals() else [],
+            max_workers=pipeline_max_workers,
+            stage_ids=stage_ids_by_idx if "stage_ids_by_idx" in locals() else {},
+            stage_deps=stage_deps_by_idx if "stage_deps_by_idx" in locals() else {},
+            stages=manifest_stage_records,
+            started_at=started_at,
+            finished_at=_utc_timestamp(),
+            duration_seconds=max(time.time() - run_started, 0.0)
+            if "run_started" in locals()
+            else None,
+            executed=executed,
+            skipped=skipped,
+            error=run_error,
+        )
+        if manifest_path is not None:
+            _push_run_log(index_page_str, f"Pipeline automation manifest: {manifest_path}", log_placeholder)
         st.session_state[index_page_str][0] = original_stage
         st.session_state["lab_selected_venv"] = _pipeline_stages.normalize_runtime_path(
             original_selected

--- a/src/agilab/pipeline/pipeline_stages.py
+++ b/src/agilab/pipeline/pipeline_stages.py
@@ -622,6 +622,10 @@ def sequence_meta_key(module_key: str) -> str:
     return f"{module_key}__sequence"
 
 
+def automation_meta_key(module_key: str) -> str:
+    return f"{module_key}__automation"
+
+
 def load_sequence_preferences(module: Union[str, Path], stages_file: Path, env: Optional[AgiEnv] = None) -> List[int]:
     """Return the stored execution order for a module, if any."""
     module_key = module_keys(module, env=env)[0]
@@ -640,6 +644,28 @@ def load_sequence_preferences(module: Union[str, Path], stages_file: Path, env: 
     if not isinstance(raw_sequence, list):
         return []
     return [idx for idx in raw_sequence if isinstance(idx, int) and idx >= 0]
+
+
+def load_automation_preferences(
+    module: Union[str, Path],
+    stages_file: Path,
+    env: Optional[AgiEnv] = None,
+) -> Dict[str, Any]:
+    """Return stored WORKFLOW automation preferences for a module, if any."""
+    module_key = module_keys(module, env=env)[0]
+    try:
+        with stages_file.open("rb") as handle:
+            data = tomllib.load(handle)
+    except FileNotFoundError:
+        return {}
+    except tomllib.TOMLDecodeError as exc:
+        logger.warning("Failed to parse automation metadata from %s: %s", stages_file, exc)
+        return {}
+    meta = data.get(LAB_STAGES_META_KEY, {})
+    if not isinstance(meta, dict):
+        return {}
+    raw_preferences = meta.get(automation_meta_key(module_key), {})
+    return dict(raw_preferences) if isinstance(raw_preferences, dict) else {}
 
 
 def persist_sequence_preferences(
@@ -676,6 +702,54 @@ def persist_sequence_preferences(
             tomli_w.dump(_convert_paths_to_strings(prepare_lab_stages_for_write(data)), handle)
     except (OSError, TypeError, ValueError) as exc:
         logger.error("Failed to persist execution sequence to %s: %s", stages_file, exc)
+
+
+def persist_automation_preferences(
+    module: Union[str, Path],
+    stages_file: Path,
+    preferences: Dict[str, Any],
+    env: Optional[AgiEnv] = None,
+) -> None:
+    """Persist WORKFLOW automation preferences alongside the stage contract."""
+    module_key = module_keys(module, env=env)[0]
+    normalized: Dict[str, Any] = {}
+    profile = str(preferences.get("profile", "") or "").strip()
+    if profile:
+        normalized["profile"] = profile
+    try:
+        max_workers = int(preferences.get("max_workers", 0) or 0)
+    except (TypeError, ValueError):
+        max_workers = 0
+    if max_workers > 0:
+        normalized["max_workers"] = max_workers
+    try:
+        if stages_file.exists():
+            with stages_file.open("rb") as handle:
+                data = tomllib.load(handle)
+        else:
+            data = {}
+    except tomllib.TOMLDecodeError as exc:
+        logger.error("Failed to load stages while saving automation metadata: %s", exc)
+        return
+    try:
+        prepare_lab_stages_for_write(data)
+    except ValueError as exc:
+        logger.error("Refusing to persist automation metadata to %s: %s", stages_file, exc)
+        return
+    meta = data.setdefault(LAB_STAGES_META_KEY, {})
+    meta_key = automation_meta_key(module_key)
+    if meta.get(meta_key) == normalized:
+        return
+    if normalized:
+        meta[meta_key] = normalized
+    else:
+        meta.pop(meta_key, None)
+    try:
+        stages_file.parent.mkdir(parents=True, exist_ok=True)
+        with stages_file.open("wb") as handle:
+            tomli_w.dump(_convert_paths_to_strings(prepare_lab_stages_for_write(data)), handle)
+    except (OSError, TypeError, ValueError) as exc:
+        logger.error("Failed to persist automation metadata to %s: %s", stages_file, exc)
 
 
 def is_displayable_stage(entry: Dict[str, Any]) -> bool:

--- a/test/test_pipeline_automation.py
+++ b/test/test_pipeline_automation.py
@@ -1,0 +1,825 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+import tomllib
+from pathlib import Path
+from types import SimpleNamespace
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from agilab.pipeline import pipeline_run_controls as pipeline_automation  # noqa: E402
+from agilab.pipeline import pipeline_stages  # noqa: E402
+
+
+def test_automation_manifest_schema_contract_is_versioned() -> None:
+    assert (
+        pipeline_automation.PIPELINE_AUTOMATION_SCHEMA
+        == "agilab.pipeline.automation.v2"
+    )
+    assert pipeline_automation.PIPELINE_AUTOMATION_COMPATIBLE_SCHEMAS == [
+        "agilab.pipeline.automation.v1"
+    ]
+    assert (
+        pipeline_automation.PIPELINE_AUTOMATION_PRODUCER
+        == "agilab.pipeline.run_all_stages"
+    )
+    assert (
+        pipeline_automation.PIPELINE_SEQUENCE_METADATA_SCHEMA
+        == "agilab.pipeline.sequence.v2"
+    )
+    assert pipeline_automation.PIPELINE_SEQUENCE_METADATA_COMPATIBLE_SCHEMAS == [
+        "agilab.pipeline.sequence.v1"
+    ]
+
+
+def test_pipeline_sequence_metadata_records_dependency_waves(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        pipeline_automation,
+        "_pipeline_automation_producer_version",
+        lambda: "9.9.9",
+    )
+    env = SimpleNamespace(app="demo_app", target="demo_target")
+
+    payload = pipeline_automation._pipeline_sequence_metadata(
+        env=env,
+        lab_dir=tmp_path,
+        stages_file=tmp_path / "lab_stages.toml",
+        sequence=[0, 1, 2],
+        profile="fast",
+        run_id="run-123",
+        max_workers=3,
+        waves=[[0, 2], [1]],
+        stage_ids={0: "flight", 1: "link", 2: "sat"},
+        stage_deps={0: [], 1: ["flight", "sat"], 2: []},
+    )
+
+    assert payload["schema"] == "agilab.pipeline.sequence.v2"
+    assert payload["compatible_schemas"] == ["agilab.pipeline.sequence.v1"]
+    assert payload["producer"] == "agilab.pipeline.run_all_stages"
+    assert payload["producer_version"] == "9.9.9"
+    assert payload["local_only"] is True
+    assert payload["app"] == "demo_app"
+    assert payload["target"] == "demo_target"
+    assert payload["profile"] == "fast"
+    assert payload["run_id"] == "run-123"
+    assert payload["max_workers"] == 3
+    assert payload["sequence"] == [1, 2, 3]
+    assert payload["waves"] == [[1, 3], [2]]
+    assert payload["stage_ids"] == {"1": "flight", "2": "link", "3": "sat"}
+    assert payload["stage_deps"] == {
+        "flight": [],
+        "link": ["flight", "sat"],
+        "sat": [],
+    }
+
+
+def test_mlflow_parent_payload_records_waved_sequence_artifact(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        pipeline_automation,
+        "_pipeline_automation_producer_version",
+        lambda: "9.9.9",
+    )
+    monkeypatch.setattr(
+        pipeline_automation,
+        "_optional_mlflow_tracking_uri",
+        lambda env: "file:///tmp/mlruns",
+    )
+    env = SimpleNamespace(app="demo_app", target="demo_target")
+
+    _run_name, _tags, _params, text_artifacts = pipeline_automation._mlflow_parent_payload(
+        env,
+        tmp_path,
+        tmp_path / "lab_stages.toml",
+        [0, 1, 2],
+        profile="fast",
+        run_id="run-123",
+        max_workers=3,
+        waves=[[0, 2], [1]],
+        stage_ids={0: "flight", 1: "link", 2: "sat"},
+        stage_deps={0: [], 1: ["flight", "sat"], 2: []},
+    )
+
+    payload = json.loads(text_artifacts["pipeline_metadata/sequence.json"])
+
+    assert payload["schema"] == "agilab.pipeline.sequence.v2"
+    assert payload["producer_version"] == "9.9.9"
+    assert payload["profile"] == "fast"
+    assert payload["run_id"] == "run-123"
+    assert payload["max_workers"] == 3
+    assert payload["sequence"] == [1, 2, 3]
+    assert payload["waves"] == [[1, 3], [2]]
+    assert payload["stage_ids"] == {"1": "flight", "2": "link", "3": "sat"}
+    assert payload["stage_deps"] == {
+        "flight": [],
+        "link": ["flight", "sat"],
+        "sat": [],
+    }
+
+
+def test_pipeline_automation_metadata_records_identity_and_waves(monkeypatch) -> None:
+    monkeypatch.setattr(
+        pipeline_automation,
+        "_pipeline_automation_producer_version",
+        lambda: "9.9.9",
+    )
+    env = SimpleNamespace(app="demo_app", target="demo_target")
+
+    payload = pipeline_automation._pipeline_automation_metadata(
+        env=env,
+        workflow_source="demo/lab_stages.toml",
+        profile="fast",
+        run_id="run-123",
+        sequence=[0, 1, 2],
+        max_workers=3,
+        waves=[[0, 2], [1]],
+        stage_ids={0: "flight", 1: "link", 2: "sat"},
+        stage_deps={0: [], 1: ["flight", "sat"], 2: []},
+    )
+
+    assert payload["schema"] == "agilab.pipeline.automation.v2"
+    assert payload["compatible_schemas"] == ["agilab.pipeline.automation.v1"]
+    assert payload["producer"] == "agilab.pipeline.run_all_stages"
+    assert payload["producer_version"] == "9.9.9"
+    assert payload["local_only"] is True
+    assert payload["workflow_source"] == "demo/lab_stages.toml"
+    assert payload["app"] == "demo_app"
+    assert payload["target"] == "demo_target"
+    assert payload["profile"] == "fast"
+    assert payload["run_id"] == "run-123"
+    assert payload["max_workers"] == 3
+    assert payload["sequence"] == [1, 2, 3]
+    assert payload["waves"] == [[1, 3], [2]]
+    assert payload["stage_ids"] == {"1": "flight", "2": "link", "3": "sat"}
+    assert payload["stage_deps"] == {
+        "flight": [],
+        "link": ["flight", "sat"],
+        "sat": [],
+    }
+
+
+def test_automation_manifest_schema_caption_handles_compatible_readers() -> None:
+    assert pipeline_automation._automation_manifest_schema_caption(
+        {
+            "schema": "agilab.pipeline.automation.v2",
+            "compatible_schemas": ["agilab.pipeline.automation.v1"],
+        }
+    ) == (
+        "Manifest schema: agilab.pipeline.automation.v2 "
+        "(current; compatible readers: agilab.pipeline.automation.v1)"
+    )
+    assert pipeline_automation._automation_manifest_schema_caption({}) == (
+        "Manifest schema: unknown (unknown)"
+    )
+
+
+def test_automation_manifest_schema_status_flags_reader_compatibility() -> None:
+    assert pipeline_automation._automation_manifest_schema_status(
+        {"schema": "agilab.pipeline.automation.v2"}
+    ) == "current"
+    assert pipeline_automation._automation_manifest_schema_status(
+        {"schema": "agilab.pipeline.automation.v1"}
+    ) == "compatible legacy"
+    assert pipeline_automation._automation_manifest_schema_status({}) == "unknown"
+    assert pipeline_automation._automation_manifest_schema_status(
+        {"schema": "example.future"}
+    ) == "unsupported"
+    assert pipeline_automation._automation_manifest_schema_caption(
+        {"schema": "example.future"}
+    ) == "Manifest schema: example.future (unsupported)"
+
+
+def test_automation_manifest_identity_captions_expose_path_and_hash() -> None:
+    assert pipeline_automation._automation_manifest_identity_captions(
+        {
+            "producer": "agilab.pipeline.run_all_stages",
+            "producer_version": "9.9.9",
+            "run_id": "run-123",
+            "profile": "fast",
+            "max_workers": 3,
+            "local_only": True,
+            "workflow_source": "demo/lab_stages.toml",
+            "app": "demo_app",
+            "target": "demo_target",
+            "lab_dir": "/tmp/demo_lab",
+            "stages_file": "/tmp/lab_stages.toml",
+            "stages_file_sha256": "def456",
+            "started_at": "2026-07-03T00:00:00Z",
+            "finished_at": "2026-07-03T00:00:01Z",
+            "run_manifest_path": "/tmp/pipeline_automation_run-123.json",
+            "manifest_path": "/tmp/pipeline_automation_run-123.json",
+            "latest_manifest_path": "/tmp/pipeline_automation_manifest.json",
+            "manifest_sha256": "abc123",
+        },
+        path="/tmp/latest.json",
+    ) == [
+        "Manifest producer: agilab.pipeline.run_all_stages",
+        "Producer version: 9.9.9",
+        "Run ID: run-123",
+        "Automation profile: fast",
+        "Max workers: 3",
+        "Local-only evidence: yes",
+        "Workflow source: demo/lab_stages.toml",
+        "App: demo_app",
+        "Target: demo_target",
+        "Lab directory: /tmp/demo_lab",
+        "Stages file: /tmp/lab_stages.toml",
+        "Stages file SHA-256: def456",
+        "Started at: 2026-07-03T00:00:00Z",
+        "Finished at: 2026-07-03T00:00:01Z",
+        "Run manifest file: /tmp/pipeline_automation_run-123.json",
+        "Latest manifest file: /tmp/pipeline_automation_manifest.json",
+        "Manifest SHA-256: abc123",
+    ]
+    assert pipeline_automation._automation_manifest_identity_captions(
+        {},
+        path="/tmp/latest.json",
+    ) == ["Manifest file: /tmp/latest.json"]
+
+
+def test_automation_manifest_identity_captions_support_legacy_manifest_path() -> None:
+    assert pipeline_automation._automation_manifest_identity_captions(
+        {"manifest_path": "/tmp/pipeline_automation_run-123.json"},
+        path="/tmp/pipeline_automation_manifest.json",
+    ) == [
+        "Run manifest file: /tmp/pipeline_automation_run-123.json",
+        "Latest manifest file: /tmp/pipeline_automation_manifest.json",
+    ]
+    assert pipeline_automation._automation_manifest_paths(
+        {
+            "run_manifest_path": "/tmp/run.json",
+            "manifest_path": "/tmp/compat.json",
+            "latest_manifest_path": "/tmp/latest.json",
+        },
+        path="/tmp/fallback.json",
+    ) == ("/tmp/run.json", "/tmp/latest.json")
+
+
+def test_automation_manifest_duration_label_formats_seconds() -> None:
+    assert pipeline_automation._automation_manifest_duration_label(
+        {"duration_seconds": 1.25}
+    ) == "1.2s"
+    assert pipeline_automation._automation_manifest_duration_label(
+        {"duration_seconds": 65.5}
+    ) == "1m 5.5s"
+    assert pipeline_automation._automation_manifest_duration_label(
+        {"duration_seconds": 3665.25}
+    ) == "1h 1m 5.2s"
+    assert pipeline_automation._automation_manifest_duration_label({}) == "unknown"
+
+
+def test_automation_manifest_error_caption_shows_failed_run_error() -> None:
+    assert pipeline_automation._automation_manifest_error_caption(
+        {"error": "Stage 3 failed"}
+    ) == "Run error: Stage 3 failed"
+    assert pipeline_automation._automation_manifest_error_caption({}) == ""
+
+
+def test_automation_manifest_writer_emits_schema_contract(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(pipeline_automation.st, "session_state", {})
+    monkeypatch.setattr(
+        pipeline_automation,
+        "_pipeline_automation_producer_version",
+        lambda: "9.9.9",
+    )
+    stages_file = tmp_path / "lab_stages.toml"
+    stages_file.write_text(
+        """
+[[demo]]
+id = "stage_one"
+D = "demo/pipeline"
+C = "print('demo')"
+""".lstrip(),
+        encoding="utf-8",
+    )
+    env = SimpleNamespace(
+        runenv=tmp_path / "logs",
+        app="demo_app",
+        target="demo_target",
+    )
+
+    manifest_path = pipeline_automation._write_pipeline_automation_manifest(
+        env=env,
+        index_page="demo/lab_stages.toml",
+        run_id="run-123",
+        profile="balanced",
+        status="completed",
+        lab_dir=tmp_path,
+        stages_file=stages_file,
+        sequence=[0],
+        waves=[[0]],
+        max_workers=2,
+        stage_ids={0: "stage_one"},
+        stage_deps={0: []},
+        stages=[{"stage_index": 1, "status": "completed", "outputs": []}],
+        started_at="2026-07-03T00:00:00Z",
+        finished_at="2026-07-03T00:00:01Z",
+        duration_seconds=1.0,
+        executed=1,
+        skipped=0,
+        error="",
+    )
+
+    assert manifest_path is not None
+    latest_path = Path(env.runenv) / pipeline_automation.PIPELINE_AUTOMATION_MANIFEST_FILENAME
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    latest_payload = json.loads(latest_path.read_text(encoding="utf-8"))
+
+    for written_payload in (payload, latest_payload):
+        assert written_payload["schema"] == "agilab.pipeline.automation.v2"
+        assert written_payload["compatible_schemas"] == [
+            "agilab.pipeline.automation.v1"
+        ]
+        assert written_payload["producer"] == "agilab.pipeline.run_all_stages"
+        assert written_payload["producer_version"] == "9.9.9"
+        assert written_payload["local_only"] is True
+        assert written_payload["run_id"] == "run-123"
+        assert written_payload["workflow_source"] == "demo/lab_stages.toml"
+        assert written_payload["profile"] == "balanced"
+        assert written_payload["app"] == "demo_app"
+        assert written_payload["target"] == "demo_target"
+        assert written_payload["lab_dir"] == str(tmp_path)
+        assert written_payload["stages_file"] == str(stages_file)
+        assert written_payload["stages_file_sha256"] == hashlib.sha256(
+            stages_file.read_bytes()
+        ).hexdigest()
+        assert written_payload["started_at"] == "2026-07-03T00:00:00Z"
+        assert written_payload["finished_at"] == "2026-07-03T00:00:01Z"
+        assert written_payload["duration_seconds"] == 1.0
+        assert written_payload["sequence"] == [1]
+        assert written_payload["waves"] == [[1]]
+        assert written_payload["max_workers"] == 2
+        assert written_payload["run_manifest_path"] == str(manifest_path)
+        assert written_payload["manifest_path"] == str(manifest_path)
+        assert written_payload["latest_manifest_path"] == str(latest_path)
+        assert written_payload["summary"] == {
+            "executed": 1,
+            "skipped": 0,
+            "failed": 0,
+            "stage_count": 1,
+        }
+        assert written_payload["stage_ids"] == {"1": "stage_one"}
+        assert written_payload["stage_deps"] == {"stage_one": []}
+        assert written_payload["manifest_sha256"]
+
+
+def test_build_stage_waves_keeps_legacy_sequence_without_deps() -> None:
+    stages = [
+        {"id": "one", "C": "print('one')"},
+        {"id": "two", "C": "print('two')"},
+        {"id": "three", "C": "print('three')"},
+    ]
+
+    waves, error, ids, deps = pipeline_automation._build_stage_waves(
+        stages,
+        [0, 1, 2],
+        "balanced",
+    )
+
+    assert error is None
+    assert waves == [[0], [1], [2]]
+    assert ids == {0: "one", 1: "two", 2: "three"}
+    assert deps == {0: [], 1: [], 2: []}
+
+
+def test_build_stage_waves_groups_independent_ready_stages() -> None:
+    stages = [
+        {"id": "install_a", "deps": [], "C": "print('install a')"},
+        {"id": "run_a", "deps": ["install_a"], "C": "print('run a')"},
+        {"id": "install_b", "deps": [], "C": "print('install b')"},
+        {"id": "run_b", "deps": ["install_b"], "C": "print('run b')"},
+        {"id": "summary", "deps": ["run_a", "run_b"], "C": "print('summary')"},
+    ]
+
+    waves, error, _ids, deps = pipeline_automation._build_stage_waves(
+        stages,
+        [0, 1, 2, 3, 4],
+        "balanced",
+    )
+
+    assert error is None
+    assert waves == [[0, 2], [1, 3], [4]]
+    assert deps[4] == ["run_a", "run_b"]
+
+
+def test_build_stage_waves_rejects_unknown_duplicate_and_cycle() -> None:
+    unknown = [
+        {"id": "one", "deps": ["missing"], "C": "print('one')"},
+    ]
+    duplicate = [
+        {"id": "same", "deps": [], "C": "print('one')"},
+        {"id": "same", "deps": [], "C": "print('two')"},
+    ]
+    cycle = [
+        {"id": "one", "deps": ["two"], "C": "print('one')"},
+        {"id": "two", "deps": ["one"], "C": "print('two')"},
+    ]
+
+    assert "unknown stage id" in pipeline_automation._build_stage_waves(
+        unknown,
+        [0],
+        "balanced",
+    )[1]
+    assert "Duplicate workflow stage id" in pipeline_automation._build_stage_waves(
+        duplicate,
+        [0, 1],
+        "balanced",
+    )[1]
+    assert "cycle" in pipeline_automation._build_stage_waves(
+        cycle,
+        [0, 1],
+        "balanced",
+    )[1]
+
+
+def test_dependency_suggestions_use_install_and_data_paths() -> None:
+    stages = [
+        {
+            "id": "flight_install",
+            "D": "flight_trajectory/install",
+            "C": "print('install')",
+        },
+        {
+            "id": "flight_pipeline",
+            "D": "flight_trajectory/pipeline",
+            "C": "agi_run(data_out='flight_trajectory/pipeline')",
+        },
+        {
+            "id": "link_pipeline",
+            "D": "link_sim/pipeline",
+            "C": "agi_run(data_in='flight_trajectory/pipeline', data_out='link_sim/pipeline')",
+        },
+        {
+            "id": "network_pipeline",
+            "D": "network_sim/pipeline",
+            "C": "agi_run(data_in='link_sim/pipeline', data_out='network_sim/pipeline')",
+        },
+    ]
+
+    suggestions = pipeline_automation.infer_stage_dependency_suggestions(
+        stages,
+        [0, 1, 2, 3],
+    )
+
+    assert suggestions["flight_pipeline"] == ["flight_install"]
+    assert suggestions["link_pipeline"] == ["flight_pipeline"]
+    assert suggestions["network_pipeline"] == ["link_pipeline"]
+
+
+def test_profile_override_deep_merges_automation_settings() -> None:
+    entry = {
+        "id": "demo",
+        "automation": {
+            "skip_if_outputs_exist": False,
+            "outputs": ["demo/full"],
+        },
+        "profiles": {
+            "fast": {
+                "automation": {
+                    "skip_if_outputs_exist": True,
+                    "outputs": ["demo/fast"],
+                },
+            },
+        },
+    }
+
+    base_entry, base_override = pipeline_automation._apply_stage_profile(entry, "balanced")
+    fast_entry, fast_override = pipeline_automation._apply_stage_profile(entry, "fast")
+
+    assert base_override == {}
+    assert pipeline_automation._stage_output_skip_rule(base_entry) == {
+        "enabled": False,
+        "outputs": ["demo/full"],
+    }
+    assert fast_override == {
+        "automation": {
+            "skip_if_outputs_exist": True,
+            "outputs": ["demo/fast"],
+        }
+    }
+    assert pipeline_automation._stage_output_skip_rule(fast_entry) == {
+        "enabled": True,
+        "outputs": ["demo/fast"],
+    }
+
+
+def test_output_skip_rule_preserves_absolute_output_paths(tmp_path: Path) -> None:
+    absolute_output = tmp_path / "absolute" / "pipeline"
+    absolute_output.mkdir(parents=True)
+    env = SimpleNamespace(workflow_data_root_path=lambda: tmp_path / "share")
+    entry = {
+        "automation": {
+            "skip_if_outputs_exist": True,
+            "outputs": [str(absolute_output)],
+        },
+    }
+
+    skip_current, records = pipeline_automation._should_skip_current_outputs(
+        entry,
+        env=env,
+        stages_file=tmp_path / "lab_stages.toml",
+    )
+
+    assert skip_current is True
+    assert pipeline_automation._stage_output_skip_rule(entry) == {
+        "enabled": True,
+        "outputs": [str(absolute_output)],
+    }
+    assert records[0]["path"] == str(absolute_output)
+    assert records[0]["exists"] is True
+    assert records[0]["sha256"] == ""
+    assert records[0]["sha256_status"] == "directory"
+
+
+def test_output_records_hash_small_declared_files(tmp_path: Path) -> None:
+    share_root = tmp_path / "share"
+    output_file = share_root / "demo" / "result.txt"
+    output_file.parent.mkdir(parents=True)
+    output_file.write_text("workflow evidence\n", encoding="utf-8")
+    env = SimpleNamespace(workflow_data_root_path=lambda: share_root)
+
+    records = pipeline_automation._stage_output_records(
+        {
+            "automation": {
+                "outputs": ["demo/result.txt"],
+            },
+        },
+        env=env,
+        stages_file=tmp_path / "lab_stages.toml",
+    )
+
+    assert records[0]["exists"] is True
+    assert records[0]["is_file"] is True
+    assert records[0]["sha256"] == hashlib.sha256(b"workflow evidence\n").hexdigest()
+    assert records[0]["sha256_status"] == "ok"
+
+
+def test_output_records_skip_hash_for_large_declared_files(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(pipeline_automation, "PIPELINE_AUTOMATION_OUTPUT_HASH_MAX_BYTES", 4)
+    share_root = tmp_path / "share"
+    output_file = share_root / "demo" / "large.bin"
+    output_file.parent.mkdir(parents=True)
+    output_file.write_bytes(b"larger than cap")
+    env = SimpleNamespace(workflow_data_root_path=lambda: share_root)
+
+    records = pipeline_automation._stage_output_records(
+        {
+            "automation": {
+                "outputs": ["demo/large.bin"],
+            },
+        },
+        env=env,
+        stages_file=tmp_path / "lab_stages.toml",
+    )
+
+    assert records[0]["exists"] is True
+    assert records[0]["is_file"] is True
+    assert records[0]["size_bytes"] == len(b"larger than cap")
+    assert records[0]["sha256"] == ""
+    assert records[0]["sha256_status"] == "too_large"
+
+
+def test_automation_manifest_output_rows_are_ui_ready() -> None:
+    manifest = {
+        "stages": [
+            {
+                "stage_index": 1,
+                "status": "completed",
+                "outputs": [
+                    {
+                        "spec": "demo/result.txt",
+                        "exists": True,
+                        "is_file": True,
+                        "is_dir": False,
+                        "size_bytes": 42,
+                        "sha256_status": "ok",
+                        "sha256": "abc123",
+                        "path": "/tmp/demo/result.txt",
+                    },
+                    {
+                        "spec": "demo/folder",
+                        "exists": True,
+                        "is_file": False,
+                        "is_dir": True,
+                        "size_bytes": 128,
+                        "sha256_status": "directory",
+                        "sha256": "",
+                        "path": "/tmp/demo/folder",
+                    },
+                ],
+            },
+            {
+                "stage_index": 2,
+                "status": "skipped_after_failure",
+                "outputs": [
+                    {
+                        "spec": "demo/missing",
+                        "exists": False,
+                        "is_file": False,
+                        "is_dir": False,
+                        "sha256_status": "missing",
+                        "path": "/tmp/demo/missing",
+                    }
+                ],
+            },
+            {
+                "stage_index": 3,
+                "status": "completed",
+                "outputs": [
+                    {
+                        "spec": "demo/large.bin",
+                        "exists": True,
+                        "is_file": True,
+                        "is_dir": False,
+                        "size_bytes": 99,
+                        "sha256_status": "too_large",
+                        "sha256": "",
+                        "path": "/tmp/demo/large.bin",
+                    }
+                ],
+            },
+        ],
+    }
+
+    rows = pipeline_automation._automation_manifest_output_rows(manifest)
+
+    assert rows == [
+        {
+            "stage": 1,
+            "status": "completed",
+            "spec": "demo/result.txt",
+            "exists": True,
+            "kind": "file",
+            "size_bytes": 42,
+            "sha256_status": "ok",
+            "sha256": "abc123",
+            "path": "/tmp/demo/result.txt",
+        },
+        {
+            "stage": 1,
+            "status": "completed",
+            "spec": "demo/folder",
+            "exists": True,
+            "kind": "directory",
+            "size_bytes": 128,
+            "sha256_status": "directory",
+            "sha256": "",
+            "path": "/tmp/demo/folder",
+        },
+        {
+            "stage": 2,
+            "status": "skipped_after_failure",
+            "spec": "demo/missing",
+            "exists": False,
+            "kind": "other",
+            "size_bytes": None,
+            "sha256_status": "missing",
+            "sha256": "",
+            "path": "/tmp/demo/missing",
+        },
+        {
+            "stage": 3,
+            "status": "completed",
+            "spec": "demo/large.bin",
+            "exists": True,
+            "kind": "file",
+            "size_bytes": 99,
+            "sha256_status": "too_large",
+            "sha256": "",
+            "path": "/tmp/demo/large.bin",
+        },
+    ]
+    assert pipeline_automation._automation_manifest_output_summary(manifest) == {
+        "outputs": 4,
+        "existing": 3,
+        "hashed": 1,
+        "too_large": 1,
+        "missing": 1,
+    }
+
+
+def test_automation_manifest_stage_summary_counts_stage_statuses() -> None:
+    assert pipeline_automation._automation_manifest_stage_summary(
+        {
+            "summary": {
+                "stage_count": 4,
+                "executed": 2,
+                "skipped": 1,
+                "failed": 1,
+            }
+        }
+    ) == {
+        "stage_count": 4,
+        "executed": 2,
+        "skipped": 1,
+        "failed": 1,
+    }
+    assert pipeline_automation._automation_manifest_stage_summary(
+        {"summary": "invalid"}
+    ) == {
+        "stage_count": 0,
+        "executed": 0,
+        "skipped": 0,
+        "failed": 0,
+    }
+
+
+def test_output_skip_rule_requires_all_declared_outputs(tmp_path: Path) -> None:
+    share_root = tmp_path / "share"
+    existing_output = share_root / "demo" / "pipeline"
+    existing_output.mkdir(parents=True)
+    stages_file = tmp_path / "lab_stages.toml"
+    env = SimpleNamespace(workflow_data_root_path=lambda: share_root)
+    entry = {
+        "automation": {
+            "skip_if_outputs_exist": True,
+            "outputs": ["demo/pipeline", "demo/missing"],
+        },
+    }
+
+    skip_current, records = pipeline_automation._should_skip_current_outputs(
+        entry,
+        env=env,
+        stages_file=stages_file,
+    )
+
+    assert skip_current is False
+    assert [record["spec"] for record in records] == ["demo/missing", "demo/pipeline"]
+    assert [record["exists"] for record in records] == [False, True]
+
+    top_level_skip, top_level_records = pipeline_automation._should_skip_current_outputs(
+        {
+            "skip_if_outputs_exist": True,
+            "outputs": ["demo/pipeline"],
+        },
+        env=env,
+        stages_file=stages_file,
+    )
+
+    assert top_level_skip is True
+    assert [record["spec"] for record in top_level_records] == ["demo/pipeline"]
+
+    (share_root / "demo" / "missing").mkdir(parents=True)
+
+    skip_current, records = pipeline_automation._should_skip_current_outputs(
+        entry,
+        env=env,
+        stages_file=stages_file,
+    )
+
+    assert skip_current is True
+    assert [record["spec"] for record in records] == ["demo/missing", "demo/pipeline"]
+
+
+def test_automation_preferences_round_trip_through_lab_stages_meta(tmp_path: Path) -> None:
+    stages_file = tmp_path / "lab_stages.toml"
+    stages_file.write_text(
+        """
+[[demo]]
+D = "demo/pipeline"
+Q = "Run demo"
+C = "print('demo')"
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    pipeline_stages.persist_automation_preferences(
+        "demo",
+        stages_file,
+        {"profile": "fast", "max_workers": 4},
+    )
+
+    assert pipeline_stages.load_automation_preferences("demo", stages_file) == {
+        "profile": "fast",
+        "max_workers": 4,
+    }
+    payload = tomllib.loads(stages_file.read_text(encoding="utf-8"))
+    assert payload["__meta__"]["demo__automation"] == {
+        "profile": "fast",
+        "max_workers": 4,
+    }
+
+
+def test_automation_preferences_ignore_invalid_or_empty_values(tmp_path: Path) -> None:
+    stages_file = tmp_path / "lab_stages.toml"
+    stages_file.write_text(
+        """
+[[demo]]
+D = "demo/pipeline"
+C = "print('demo')"
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    pipeline_stages.persist_automation_preferences(
+        "demo",
+        stages_file,
+        {"profile": "", "max_workers": "bad"},
+    )
+
+    assert pipeline_stages.load_automation_preferences("demo", stages_file) == {}


### PR DESCRIPTION
## Summary

Adds project-agnostic WORKFLOW automation evidence and reader support for the latest automation manifest.

Changes include:
- workflow stage ids, dependency waves, automation profiles, and output skip metadata
- automation manifest schema `agilab.pipeline.automation.v2` with compatibility for v1 readers
- run/latest manifest path identity, schema status captions, and latest-run UI metrics
- focused tests for dependency planning, manifest writing, schema compatibility, and output evidence
- public docs mirror updates for WORKFLOW automation evidence

## Why

WORKFLOW parallel automation needs machine-readable evidence that explains what ran, what was skipped, which waves were computed, and where the immutable per-run manifest differs from the rolling latest alias.

## Repro

Before this change, the WORKFLOW page could not expose a complete automation manifest contract for project-agnostic stage waves, output evidence, schema compatibility status, and run/latest manifest identity.

## Root Cause

Workflow stage execution metadata existed across runtime logs, MLflow metadata, and UI state, but there was no consolidated manifest schema or compact reader surface for parallel automation evidence.

## Regression Test

Added `test/test_pipeline_automation.py` covering stage wave construction, manifest schema fields, schema compatibility, run/latest path handling, output summaries, and writer behavior.

## Validation

- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_pipeline_automation.py` passed: 24 tests.
- `uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py --verify-stamp` passed.
- `git diff --check` passed for AGILAB and `thales_agilab` before commit.
- AGILAB pre-push guard passed.

## Review Evidence

No sub-agent or model review was used beyond the coding agent implementation loop.

## Related private source update

Canonical private docs and `sb3_trainer_project` workflow metadata were pushed separately to `jpmorard/thales_agilab` on branch `codex/sb3-trainer-distributed-step10`, commit `aaceceb`.

## Agent Metadata

- Tokki version: 1.0.17, not used for command execution
- Agent/runtime: Codex coding agent, version unavailable
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used
