### PR TITLE
[codex] Clarify dependency-aware workflow execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,39 @@ uv --preview-features extra-build-dependencies tool install --upgrade "agilab[ui
 agilab
 ```
 
+### Source Checkout With External Apps
+
+When running AGILAB from a source checkout, `--install-apps` installs the
+bundled public apps by default. To install apps from a separate private or
+external apps repository, pass that repository root explicitly. The repository
+root should contain `apps/` and/or `apps-pages/`.
+
+For a new source checkout:
+
+```bash
+CHECKOUT="${AGILAB_CHECKOUT:-$HOME/agilab-src}"
+APPS_REPO="/path/to/private-or-external-apps-repo"
+
+git clone https://github.com/ThalesGroup/agilab.git "$CHECKOUT"
+cd "$CHECKOUT"
+./install.sh --apps-repository "$APPS_REPO" --install-apps all
+uv --preview-features extra-build-dependencies run --extra ui streamlit run src/agilab/main_page.py
+```
+
+To add those apps after AGILAB is already installed, rerun only the app
+installer:
+
+```bash
+CHECKOUT="${AGILAB_CHECKOUT:-$HOME/agilab-src}"
+APPS_REPO="/path/to/private-or-external-apps-repo"
+
+cd "$CHECKOUT/src/agilab"
+APPS_REPOSITORY="$APPS_REPO" \
+AGILAB_DEV_APPS_REPOSITORY=1 \
+BUILTIN_APPS=__AGILAB_ALL_APPS__ \
+./install_apps.sh
+```
+
 For a zero-install browser preview, open the public
 [AGILAB Space](https://huggingface.co/spaces/jpmorard/agilab). It opens the
 lightweight `flight_telemetry_project` path by default and exposes the

--- a/src/agilab/pages/3_WORKFLOW.py
+++ b/src/agilab/pages/3_WORKFLOW.py
@@ -351,7 +351,7 @@ def run_all_stages(
     pipeline_max_workers: int = 1,
     pipeline_stage_deps: Optional[Any] = None,
 ) -> None:
-    """Execute all stages sequentially, honouring per-stage virtual environments."""
+    """Execute selected stages with dependency-aware waves and per-stage virtual environments."""
     _run_all_stages_impl(
         lab_dir,
         index_page_str,

--- a/src/agilab/pipeline/pipeline_run_controls.py
+++ b/src/agilab/pipeline/pipeline_run_controls.py
@@ -1643,7 +1643,7 @@ def run_all_stages(
     pipeline_max_workers: int = 1,
     pipeline_stage_deps: Mapping[str, List[str]] | None = None,
 ) -> None:
-    """Execute all stages sequentially, honouring per-stage virtual environments."""
+    """Execute selected stages with dependency-aware waves and per-stage virtual environments."""
     if log_placeholder is None:
         log_placeholder = _get_run_placeholder(index_page_str)
     pipeline_profile = _normalize_pipeline_profile(pipeline_profile)


### PR DESCRIPTION
## Summary

- Update WORKFLOW all-stage runner docstrings so they describe dependency-aware execution waves instead of the old strictly sequential behavior.
- Add a source-checkout README recipe for installing apps from an external or private apps repository.

## Context

The implementation already plans dependency-aware waves for saved lab stages. These docstrings were stale after the workflow dependency scheduler landed.

The README now documents the source-checkout installer path for external app repositories without naming private repositories or private app modules.

## Validation

Validation passed.

- Focused pytest slice: `test/test_ui_pages.py` and `test/test_pipeline_run_controls.py` passed for the workflow docstring change.
- `agi-gui` workflow parity profile passed and regenerated `coverage-agi-gui.xml` locally for the workflow branch.
- README follow-up: `./dev scope`, `python3 tools/agent_commit_provenance_guard.py --check-config`, and `git diff --check` passed.
- Related private app dependency migration was validated separately in the sibling private checkout and pushed to that private repository.

## CI Evidence

- GitHub `repo-guardrails`: `local-only-policy` passed.
- GitHub `repo-guardrails`: clean public install passed on ubuntu-latest, macos-latest, and windows-latest.
- GitGuardian Security Checks passed.
- `public-demo-smoke` was skipped by GitHub.

## Review Evidence

- Model or sub-agent review: not used.

## Agent Metadata

- Tokki version: `tokki 1.0.18`
- Agent/runtime: Codex CLI / GPT-5 Codex
- Agent/runtime version: unavailable
- Model name: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used
