### PR TITLE
[codex] Add root app installer wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -609,11 +609,19 @@ agilab first-proof --json --max-seconds 60
 ## App Repository Updates
 
 When `APPS_REPOSITORY` points at an external apps repository, rerun the
-installer after app changes:
+app-only installer after app changes:
 
 ```bash
-./install.sh --non-interactive --apps-repository /path/to/apps-repository --install-apps all
+./install_apps.sh --apps-repository /path/to/apps-repository --install-apps all
+./install_apps.sh --apps-repository /path/to/apps-repository --install-apps app_a_project,app_b_project
 ```
+
+`--install-apps all` installs all discoverable apps, `--install-apps builtin`
+limits the install to bundled public apps, and a comma-separated value installs
+only the named apps. The wrapper delegates to the active source checkout's
+existing `src/agilab/install_apps.sh` implementation, so use root
+`./install.sh` only when you also need root installer side effects such as
+environment setup, dataset seeding, or install-time root/core tests.
 
 During an update, the apps repository is treated as the source of truth. If the
 target app/page already exists as a real directory instead of a symlink, AGILAB

--- a/install_apps.sh
+++ b/install_apps.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: ./install_apps.sh [--apps-repository <path>] [--install-apps [app1,app2,...|all|builtin]] [--test-apps]
+
+Installs apps/pages by delegating to the active source checkout's existing
+src/agilab/install_apps.sh script.
+
+Options:
+  --apps-repository <path>   External apps repository root containing apps/ and/or apps-pages/.
+  --install-apps [value]     Same selection shape as install.sh:
+                               all      install all discoverable apps
+                               builtin  install only bundled public apps
+                               name,... install the named apps
+                             Omit the value to use the existing picker/default selection.
+  --test-apps, --apps-test   Run app tests after install.
+  --active-checkout <path>   Override the source path normally read from
+                             ~/.local/share/agilab/.agilab-path.
+  --help, -h                 Show this help.
+
+Examples:
+  ./install_apps.sh --apps-repository /path/to/apps-repo --install-apps all
+  ./install_apps.sh --apps-repository /path/to/apps-repo --install-apps app_a_project,app_b_project
+  ./install_apps.sh --install-apps builtin --test-apps
+EOF
+}
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+active_source="${AGILAB_SRC:-}"
+apps_repository="${APPS_REPOSITORY:-}"
+install_apps_value=""
+install_apps_value_set=0
+declare -a forwarded_args=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --apps-repository)
+      if [[ $# -lt 2 || "$2" == --* ]]; then
+        echo "Error: --apps-repository requires a path." >&2
+        usage >&2
+        exit 2
+      fi
+      apps_repository="$2"
+      shift 2
+      ;;
+    --apps-repository=*)
+      apps_repository="${1#--apps-repository=}"
+      shift
+      ;;
+    --install-apps)
+      install_apps_value_set=1
+      if [[ $# -ge 2 && "$2" != --* ]]; then
+        install_apps_value="$2"
+        shift 2
+      else
+        install_apps_value=""
+        shift
+      fi
+      ;;
+    --install-apps=*)
+      install_apps_value_set=1
+      install_apps_value="${1#--install-apps=}"
+      shift
+      ;;
+    --test-apps|--apps-test|--link-compatible-venvs|--no-link-compatible-venvs)
+      forwarded_args+=("$1")
+      shift
+      ;;
+    --active-checkout)
+      if [[ $# -lt 2 || "$2" == --* ]]; then
+        echo "Error: --active-checkout requires a path." >&2
+        usage >&2
+        exit 2
+      fi
+      active_source="$2"
+      shift 2
+      ;;
+    --active-checkout=*)
+      active_source="${1#--active-checkout=}"
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Error: unknown option '$1'." >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$active_source" ]]; then
+  active_path_file="$HOME/.local/share/agilab/.agilab-path"
+  if [[ -f "$active_path_file" ]]; then
+    active_source="$(cat "$active_path_file")"
+  elif [[ -x "$script_dir/src/agilab/install_apps.sh" ]]; then
+    active_source="$script_dir/src/agilab"
+  else
+    echo "Error: active AGILAB source path is unknown." >&2
+    echo "Run the root installer first or pass --active-checkout <path>." >&2
+    exit 1
+  fi
+fi
+
+active_source="${active_source%/}"
+installer="$active_source/install_apps.sh"
+if [[ ! -x "$installer" ]]; then
+  echo "Error: install_apps.sh not found or not executable at: $installer" >&2
+  exit 1
+fi
+
+if [[ -n "$apps_repository" ]]; then
+  if [[ ! -d "$apps_repository" ]]; then
+    echo "Error: --apps-repository is not a directory: $apps_repository" >&2
+    exit 1
+  fi
+  if [[ ! -d "$apps_repository/apps" && ! -d "$apps_repository/apps-pages" ]]; then
+    echo "Error: apps repository must contain apps/ and/or apps-pages/: $apps_repository" >&2
+    exit 1
+  fi
+fi
+
+case "$install_apps_value" in
+  all)
+    install_apps_value="__AGILAB_ALL_APPS__"
+    ;;
+  builtin)
+    install_apps_value="__AGILAB_BUILTIN_APPS__"
+    ;;
+esac
+
+echo "Active AGILAB source: $active_source"
+if [[ -n "$apps_repository" ]]; then
+  echo "Apps repository: $apps_repository"
+fi
+
+export APPS_REPOSITORY="$apps_repository"
+export AGILAB_DEV_APPS_REPOSITORY="${AGILAB_DEV_APPS_REPOSITORY:-1}"
+if (( install_apps_value_set )) && [[ -n "$install_apps_value" ]]; then
+  export BUILTIN_APPS="$install_apps_value"
+fi
+
+cd "$active_source"
+exec ./install_apps.sh "${forwarded_args[@]}"


### PR DESCRIPTION
## Summary
- Add a root `install_apps.sh` wrapper that delegates to the active source checkout's existing `src/agilab/install_apps.sh`.
- Document the app-only external repository update flow in `README.md`, including `all`, `builtin`, and comma-separated app selection.

## Repro
From a source checkout root, `./install_apps.sh --apps-repository /path/to/apps-repository --install-apps all` failed because no root-level app installer wrapper existed.

## Root Cause
The app-only installer UX lived under `src/agilab/install_apps.sh`, while the root checkout only documented rerunning `install.sh` for app repository updates.

## Regression Test
Not run: local test execution was not requested for this script/docs-only UX change. The app installer itself was also not run.

## Validation
- `python3 tools/agent_commit_provenance_guard.py --check-config`
- pre-push guard passed; scoped guards for docs mirror, agent instructions, and app contracts were skipped as unchanged

## Review Evidence
Not used.

## Agent Metadata
- Tokki version: not used
- Agent/runtime: Codex CLI, version unavailable
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: unknown
