### PR TITLE
[codex] Fix app installer wrapper empty args

### DIFF
--- a/install_apps.sh
+++ b/install_apps.sh
@@ -33,6 +33,7 @@ apps_repository="${APPS_REPOSITORY:-}"
 install_apps_value=""
 install_apps_value_set=0
 declare -a forwarded_args=()
+forwarded_args_count=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -65,7 +66,8 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --test-apps|--apps-test|--link-compatible-venvs|--no-link-compatible-venvs)
-      forwarded_args+=("$1")
+      forwarded_args[$forwarded_args_count]="$1"
+      forwarded_args_count=$((forwarded_args_count + 1))
       shift
       ;;
     --active-checkout)
@@ -145,4 +147,7 @@ if (( install_apps_value_set )) && [[ -n "$install_apps_value" ]]; then
 fi
 
 cd "$active_source"
-exec ./install_apps.sh "${forwarded_args[@]}"
+if [[ "$forwarded_args_count" -gt 0 ]]; then
+  exec ./install_apps.sh "${forwarded_args[@]}"
+fi
+exec ./install_apps.sh


### PR DESCRIPTION
## Summary
- Fix the root `install_apps.sh` wrapper when no flags need to be forwarded to `src/agilab/install_apps.sh`.
- Avoid expanding an empty Bash array under `set -u` by tracking the forwarded argument count explicitly.

## Repro
Running from a source checkout root:

```bash
./install_apps.sh --apps-repository /path/to/apps-repository --install-apps all
```

failed before reaching the underlying app installer with:

```text
forwarded_args[@]: unbound variable
```

## Root Cause
On the shell used by the wrapper, expanding an empty array with `set -u` can raise an unbound variable error. The wrapper always expanded `"${forwarded_args[@]}"` even when no forwarded flags were present.

## Regression Test
Not run: this is a narrow shell wrapper fix and the full installer command would install apps on the local machine. The repo pre-push guard completed successfully.

## Validation
- `python3 tools/agent_commit_provenance_guard.py --check-config`
- pre-push guard passed; scoped guards for docs mirror, release proof, agent instructions, and app contracts were skipped as unchanged

## Review Evidence
Not used.

## Agent Metadata
- Tokki version: not used
- Agent/runtime: Codex CLI, version unavailable
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: unknown
