### PR TITLE
[codex] Add base Python 3.14 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,6 +215,45 @@ jobs:
           echo "GitHub Actions CI runs repository guardrails plus a minimal first-proof command contract."
           echo "Run local workflow parity profiles before push for full test coverage."
 
+  base-python-compat:
+    name: base-python-compat (${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.13", "3.14"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          version: "0.10.7"
+
+      - name: Validate base package import
+        run: |
+          set -euo pipefail
+          uv --preview-features extra-build-dependencies run --no-project \
+            --python "${{ matrix.python-version }}" \
+            --with-editable . \
+            python - <<'PY'
+          import sys
+          import agilab.lab_run
+
+          expected = tuple(map(int, "${{ matrix.python-version }}".split(".")))
+          if sys.version_info[:2] != expected:
+              raise SystemExit(
+                  f"expected Python {expected}, got {sys.version_info[:2]}"
+              )
+          print(f"base package import ok on Python {sys.version.split()[0]}")
+          PY
+
   clean-public-install:
     name: clean-public-install (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ what they need:
 
 | Profile | Dependency scope | Use when |
 |---|---|---|
-| Base package | Lightweight `agilab` command shell plus Python 3.13 stdlib shims. It does not install the core runtime, UI, apps, pages, notebooks, or model stacks by default. | Version/help checks, package/app management commands, and metadata/reporting helpers that do not execute AGILAB runtime code. |
+| Base package | Lightweight `agilab` command shell plus Python 3.13+ stdlib shims. It does not install the core runtime, UI, apps, pages, notebooks, or model stacks by default. | Version/help checks, package/app management commands, and metadata/reporting helpers that do not execute AGILAB runtime code. |
 | `core` extra | `agi-core`, which wires `agi-env`, `agi-node`, and `agi-cluster` for compact local/distributed runtime smoke checks. | CLI proof, source-checkout validation, notebook/API runtime, and worker-runtime development without the UI or packaged examples. |
 | `ui` extra | Streamlit UI, page helpers, portable `agi-web` Canvas2D/WebGL and React-ready UI-island contracts, pandas/network graph utilities, `agi-apps`, and the `agi-pages` provider. Promoted app and page payload packages are on PyPI; unpromoted app payloads remain release artifacts until publication is enabled. | Running the local product UI with the packaged runtime and optional public demo assets. |
 | `examples` extra | `agi-apps` app catalog/examples plus notebook/demo helper dependencies such as JupyterLab and optional plotting packages. | Running packaged notebooks, demos, learning examples, and package first-proof routes. |

--- a/README.pypi.md
+++ b/README.pypi.md
@@ -253,7 +253,7 @@ what they need:
 
 | Profile | Dependency scope | Use when |
 |---|---|---|
-| Base package | Lightweight `agilab` command shell plus Python 3.13 stdlib shims. It does not install the core runtime, UI, apps, pages, notebooks, or model stacks by default. | Version/help checks, package/app management commands, and metadata/reporting helpers that do not execute AGILAB runtime code. |
+| Base package | Lightweight `agilab` command shell plus Python 3.13+ stdlib shims. It does not install the core runtime, UI, apps, pages, notebooks, or model stacks by default. | Version/help checks, package/app management commands, and metadata/reporting helpers that do not execute AGILAB runtime code. |
 | `core` extra | `agi-core`, which wires `agi-env`, `agi-node`, and `agi-cluster` for compact local/distributed runtime smoke checks. | CLI proof, source-checkout validation, notebook/API runtime, and worker-runtime development without the UI or packaged examples. |
 | `ui` extra | Streamlit UI, page helpers, portable `agi-web` Canvas2D/WebGL and React-ready UI-island contracts, pandas/network graph utilities, `agi-apps`, and the `agi-pages` provider. Promoted app and page payload packages are on PyPI; unpromoted app payloads remain release artifacts until publication is enabled. | Running the local product UI with the packaged runtime and optional public demo assets. |
 | `examples` extra | `agi-apps` app catalog/examples plus notebook/demo helper dependencies such as JupyterLab and optional plotting packages. | Running packaged notebooks, demos, learning examples, and package first-proof routes. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 version = "2026.07.04"
 name = "agilab"
 description = "AGILAB is a reproducible AI/ML workbench for engineering teams."
-requires-python = ">=3.11,<3.14"
+requires-python = ">=3.11,<3.15"
 readme = "README.pypi.md"
 authors = [
     { name = "Jean-Pierre Morard" }
@@ -18,6 +18,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Operating System :: MacOS",
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX :: Linux",

--- a/test/test_pyproject_dependency_hygiene.py
+++ b/test/test_pyproject_dependency_hygiene.py
@@ -144,8 +144,9 @@ def test_root_requires_python_matches_published_classifiers() -> None:
     requires_python = SpecifierSet(project["requires-python"])
 
     assert "3.13" in requires_python
-    assert "3.14" not in requires_python
-    assert "Programming Language :: Python :: 3.14" not in classifiers
+    assert "3.14" in requires_python
+    assert "3.15" not in requires_python
+    assert "Programming Language :: Python :: 3.14" in classifiers
 
 
 def test_root_base_dependencies_do_not_own_app_or_example_stacks() -> None:


### PR DESCRIPTION
## Summary
- Lift the top-level `agilab` base package Python requirement to `>=3.11,<3.15` and add the Python 3.14 classifier.
- Add a lightweight repo-guardrails CI job that imports the base package on Python 3.13 and 3.14.
- Update the base-package README wording and metadata contract test for Python 3.13+ stdlib shims.

## Repro
Before this change, `uv --preview-features extra-build-dependencies lock --check --python 3.14` failed because the root package required `>=3.11,<3.14`.

## Root Cause
The root package metadata capped Python below 3.14 even though the lightweight base package imports cleanly with Python 3.14 when installed in isolation.

## Regression Test
- Added `base-python-compat` CI smoke for Python 3.13 and 3.14.
- Updated `test_root_requires_python_matches_published_classifiers` to require the Python 3.14 classifier and keep Python 3.15 excluded.

## Validation
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files pyproject.toml .github/workflows/ci.yml test/test_pyproject_dependency_hygiene.py README.md README.pypi.md`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts= test/test_pyproject_dependency_hygiene.py::test_root_requires_python_matches_published_classifiers`
- `uv --preview-features extra-build-dependencies run --no-project --python 3.13 --with-editable . python -c 'import sys; import agilab.lab_run; print(sys.version.split()[0])'`
- `uv --preview-features extra-build-dependencies run --no-project --python 3.14 --with-editable . python -c 'import sys; import agilab.lab_run; print(sys.version.split()[0])'`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_ci_workflow.py test/test_pyproject_dependency_hygiene.py`
- pre-push guard passed; scoped guards for docs mirror, agent instructions, and app contracts were skipped as unchanged

## Scope Boundary
This PR enables Python 3.14 for the lightweight base package only. Release workflow parity, UI extras, core runtime extras, and app/page projects remain on their existing Python support contracts until separately validated.

## Review Evidence
Not used.

## Agent Metadata
- Tokki version: not used
- Agent/runtime: Codex CLI, version unavailable
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: unknown
