### PR TITLE
[codex] Preserve valid PyCharm sibling SDKs

### DIFF
--- a/pycharm/setup_pycharm.py
+++ b/pycharm/setup_pycharm.py
@@ -985,6 +985,15 @@ class JdkTable:
         elif not changed_any:
             logging.info("Associated project already up to date for SDK %s", name)
 
+    def __jdk_home_exists(self, jdk: ET.Element) -> bool:
+        home = self.__jdk_home(jdk).strip()
+        if not home:
+            return False
+        try:
+            return self.__expand_jetbrains_path(home).exists()
+        except OSError:
+            return False
+
     def prune_uv_names(self, keep_names: Iterable[str]) -> None:
         keep = set(keep_names)
 
@@ -1005,13 +1014,23 @@ class JdkTable:
                 name = self.__jdk_name(jdk)
                 sdk_type = self.__jdk_type(jdk)
 
-                if sdk_type == self.sdk_type and name.startswith("uv (") and name not in keep:
-                    comp.remove(jdk)
-                    removed += 1
+                if sdk_type != self.sdk_type or not name.startswith("uv (") or name in keep:
+                    continue
+
+                if self.__jdk_home_exists(jdk):
+                    continue
+
+                comp.remove(jdk)
+                removed += 1
 
             if removed:
                 write_xml(tree, table)
-                logging.info("Pruned %d SDK(s) in %s, kept: %s", removed, table, sorted(keep))
+                logging.info(
+                    "Pruned %d stale SDK(s) in %s, kept active or valid SDKs: %s",
+                    removed,
+                    table,
+                    sorted(keep),
+                )
 
 
 class Project:

--- a/test/test_setup_pycharm.py
+++ b/test/test_setup_pycharm.py
@@ -133,6 +133,55 @@ def test_jdk_table_rewrites_stale_uv_venv_path(tmp_path: Path) -> None:
     assert additional.get("UV_VENV_PATH") == str(current_root / ".venv")
 
 
+def test_prune_uv_names_keeps_valid_sibling_checkout_sdks_and_removes_stale(
+    tmp_path: Path,
+) -> None:
+    active_root = _make_agilab_source_root(tmp_path / "agilab")
+    sibling_root = _make_agilab_source_root(tmp_path / "agilab-src")
+    sibling_python = sibling_root / ".venv" / "bin" / "python"
+    sibling_python.parent.mkdir(parents=True)
+    sibling_python.write_text("", encoding="utf-8")
+    missing_python = tmp_path / "missing" / ".venv" / "bin" / "python"
+    jdk_table = tmp_path / "jdk.table.xml"
+    jdk_table.write_text(
+        f"""<?xml version="1.0" encoding="UTF-8"?>
+<application>
+    <component name="ProjectJdkTable">
+        <jdk version="2">
+            <name value="uv (agilab)" />
+            <type value="Python SDK" />
+            <homePath value="{active_root / ".venv" / "bin" / "python"}" />
+        </jdk>
+        <jdk version="2">
+            <name value="uv (agilab-src)" />
+            <type value="Python SDK" />
+            <homePath value="{sibling_python}" />
+        </jdk>
+        <jdk version="2">
+            <name value="uv (stale-checkout)" />
+            <type value="Python SDK" />
+            <homePath value="{missing_python}" />
+        </jdk>
+    </component>
+</application>
+""",
+        encoding="utf-8",
+    )
+
+    table = setup_pycharm.JdkTable.__new__(setup_pycharm.JdkTable)
+    table.sdk_type = "Python SDK"
+    table.jdk_tables = [jdk_table]
+
+    table.prune_uv_names(["uv (agilab)"])
+
+    root = ET.parse(jdk_table).getroot()
+    names = [
+        jdk.find("name").get("value")
+        for jdk in root.findall("./component[@name='ProjectJdkTable']/jdk")
+    ]
+    assert names == ["uv (agilab)", "uv (agilab-src)"]
+
+
 def test_ensure_agilab_path_marker_rewrites_stale_checkout_marker(
     tmp_path: Path,
     monkeypatch,


### PR DESCRIPTION
## Summary
- Preserve valid `uv (...)` PyCharm SDKs whose interpreter paths still exist, even when they are not part of the active checkout keep list.
- Continue pruning stale `uv (...)` SDK entries whose interpreter path is missing.
- Add a regression for two sibling AGILAB checkouts, keeping `uv (agilab-src)` while removing a stale checkout SDK.

## Repro
Run `pycharm/setup_pycharm.py` from one AGILAB checkout, then from a sibling checkout such as `/Users/agi/agilab-src`. The second run can remove the first checkout's valid SDK entry from JetBrains `jdk.table.xml`, leaving that project XML pointing at an SDK name PyCharm no longer knows.

## Root Cause
`JdkTable.prune_uv_names()` removed every `uv (...)` SDK not in the active checkout's generated keep list. That was too aggressive for machines with multiple valid AGILAB source checkouts.

## Regression Test
`test_prune_uv_names_keeps_valid_sibling_checkout_sdks_and_removes_stale` proves a valid sibling checkout SDK is retained while a missing-interpreter SDK is pruned.

## Validation
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files pycharm/setup_pycharm.py test/test_setup_pycharm.py`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_setup_pycharm.py`
- pre-push guard passed; scoped guards for docs mirror, release proof, agent instructions, and app contracts were skipped as unchanged

## Review Evidence
Not used.

## Agent Metadata
- Tokki version: not used
- Agent/runtime: Codex CLI, version unavailable
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: unknown
