### PR TITLE
[codex] Fix PyCharm core test run configs

### DIFF
--- a/.idea/runConfigurations/test_base_worker.xml
+++ b/.idea/runConfigurations/test_base_worker.xml
@@ -6,7 +6,7 @@
     <option name="PARENT_ENVS" value="true" />
     <option name="SDK_HOME" value="" />
     <option name="SDK_NAME" value="uv (agi-cluster)" />
-    <option name="WORKING_DIRECTORY" value="" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/src/agilab/core/agi-cluster" />
     <option name="IS_MODULE_SDK" value="false" />
     <option name="ADD_CONTENT_ROOTS" value="true" />
     <option name="ADD_SOURCE_ROOTS" value="true" />

--- a/.idea/runConfigurations/test_dag_worker.xml
+++ b/.idea/runConfigurations/test_dag_worker.xml
@@ -6,7 +6,7 @@
     <option name="PARENT_ENVS" value="true" />
     <option name="SDK_HOME" value="" />
     <option name="SDK_NAME" value="uv (agi-cluster)" />
-    <option name="WORKING_DIRECTORY" value="" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/src/agilab/core/agi-cluster" />
     <option name="IS_MODULE_SDK" value="false" />
     <option name="ADD_CONTENT_ROOTS" value="true" />
     <option name="ADD_SOURCE_ROOTS" value="true" />

--- a/.idea/runConfigurations/test_work_dispatcher.xml
+++ b/.idea/runConfigurations/test_work_dispatcher.xml
@@ -6,7 +6,7 @@
     <option name="PARENT_ENVS" value="true" />
     <option name="SDK_HOME" value="" />
     <option name="SDK_NAME" value="uv (agi-cluster)" />
-    <option name="WORKING_DIRECTORY" value="" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/src/agilab/core/agi-cluster" />
     <option name="IS_MODULE_SDK" value="false" />
     <option name="ADD_CONTENT_ROOTS" value="true" />
     <option name="ADD_SOURCE_ROOTS" value="true" />

--- a/test/test_setup_pycharm.py
+++ b/test/test_setup_pycharm.py
@@ -690,6 +690,13 @@ def test_tracked_run_configs_use_valid_uv_sdk_bindings() -> None:
             problems.append(f"{path.name}: IS_MODULE_SDK={options.get('IS_MODULE_SDK')!r}")
         if config.get("type") == "PythonConfigurationType" and envs.get("VIRTUAL_ENV") != "":
             problems.append(f"{path.name}: VIRTUAL_ENV must be cleared for uv run")
+        if (
+            config.get("type") == "tests"
+            and options.get("SDK_NAME") == "uv (agi-cluster)"
+            and "$PROJECT_DIR$/src/agilab/core/test/" in options.get("_new_target", "")
+            and options.get("WORKING_DIRECTORY") != "$PROJECT_DIR$/src/agilab/core/agi-cluster"
+        ):
+            problems.append(f"{path.name}: core agi-cluster pytest config has wrong working directory")
         if "wenv/builtin" in option_values:
             problems.append(f"{path.name}: stale builtin worker path")
 

--- a/tools/run_configs/agilab/test-work-dispatcher.sh
+++ b/tools/run_configs/agilab/test-work-dispatcher.sh
@@ -5,6 +5,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 
 # Generated from PyCharm run configuration: test work_dispatcher
+cd "$REPO_ROOT/src/agilab/core/agi-cluster"
 # Let uv select the run-config project .venv instead of a stale activated shell.
 unset VIRTUAL_ENV
 uv run python

--- a/tools/run_configs/components/test-base-worker.sh
+++ b/tools/run_configs/components/test-base-worker.sh
@@ -5,6 +5,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 
 # Generated from PyCharm run configuration: test base_worker
+cd "$REPO_ROOT/src/agilab/core/agi-cluster"
 # Let uv select the run-config project .venv instead of a stale activated shell.
 unset VIRTUAL_ENV
 uv run python

--- a/tools/run_configs/components/test-dag-worker.sh
+++ b/tools/run_configs/components/test-dag-worker.sh
@@ -5,6 +5,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 
 # Generated from PyCharm run configuration: test dag_worker
+cd "$REPO_ROOT/src/agilab/core/agi-cluster"
 # Let uv select the run-config project .venv instead of a stale activated shell.
 unset VIRTUAL_ENV
 uv run python


### PR DESCRIPTION
## Summary

Fix three tracked PyCharm core pytest run configurations that were bound to the `uv (agi-cluster)` SDK but had an empty working directory. The generated CLI wrappers were regenerated so the shell launchers now run from the same `src/agilab/core/agi-cluster` directory.

## Repro

PyCharm `test base_worker`, `test dag_worker`, and `test work_dispatcher` launched with an empty `WORKING_DIRECTORY`, unlike the sibling core pytest configs for pandas, polars, and distributor tests.

## Root Cause

The affected tracked run configurations did not set the agi-cluster project working directory, so PyCharm could resolve the test target with the right SDK but run from the wrong/default directory.

## Regression Test

`test/test_setup_pycharm.py::test_tracked_run_configs_use_valid_uv_sdk_bindings` now rejects agi-cluster pytest configs targeting `src/agilab/core/test/` unless their working directory is `$PROJECT_DIR$/src/agilab/core/agi-cluster`.

## Validation

- `uv --preview-features extra-build-dependencies run python tools/generate_runconfig_scripts.py`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_setup_pycharm.py::test_tracked_run_configs_use_valid_uv_sdk_bindings`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --staged`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_setup_pycharm.py`
- pre-push guard passed

## Review Evidence

Not used.

## Agent Metadata

- Tokki version: `tokki 1.0.19`
- Agent/runtime: Codex CLI, version unavailable
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: no