### PR TITLE
[codex] Ignore generated app virtual environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,6 +141,10 @@ src/agilab/apps/builtin/*/src/**/*.pyx
 !src/agilab/apps/builtin/uav_relay_queue_project/**
 !src/agilab/apps/builtin/data_io_2026_project/
 !src/agilab/apps/builtin/data_io_2026_project/**
+# Generated local app/page environments should never appear as source changes,
+# including when an external app checkout is copied without its nested .gitignore.
+src/agilab/apps-pages/*/.venv/
+src/agilab/apps/builtin/*/.venv/
 _fcas_work
 .vscode/
 # Generated demo media: keep only lightweight upload metadata in Git.


### PR DESCRIPTION
## Summary

Add root ignore rules for generated app/page `.venv` directories so local installs and external app checkouts do not show virtual environments as source changes.

## Repro

After installing app/page environments in `/Users/agi/agilab-src`, Git status showed generated paths such as `src/agilab/apps-pages/*/.venv` and `src/agilab/apps/builtin/uav_queue_project/.venv` as untracked noise.

## Root Cause

Some app/page virtual environments rely on nested `.gitignore` files. External or generated app checkouts can be copied without those nested ignore files, and root unignore rules can expose the generated `.venv` directories.

## Regression Test

A manual ignore check was used because this is a Git ignore-policy update, not runtime behavior.

## Validation

- `git check-ignore -v src/agilab/apps-pages/app_ui/.venv src/agilab/apps/builtin/uav_queue_project/.venv || true`
- `python3 tools/agent_commit_provenance_guard.py --check-config`
- pre-push guard passed

## Review Evidence

Not used.

## Agent Metadata

- Tokki version: `tokki 1.0.19`
- Agent/runtime: Codex CLI, version unavailable
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: no