### PR TITLE
[codex] Ignore generated venv symlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,7 +143,9 @@ src/agilab/apps/builtin/*/src/**/*.pyx
 !src/agilab/apps/builtin/data_io_2026_project/**
 # Generated local app/page environments should never appear as source changes,
 # including when an external app checkout is copied without its nested .gitignore.
+src/agilab/apps-pages/*/.venv
 src/agilab/apps-pages/*/.venv/
+src/agilab/apps/builtin/*/.venv
 src/agilab/apps/builtin/*/.venv/
 _fcas_work
 .vscode/


### PR DESCRIPTION
## Summary

Extend the generated app/page virtual environment ignore rules to cover both `.venv/` directories and `.venv` symlinks.

## Repro

In `/Users/agi/agilab-src`, app-page `.venv` directories were ignored after PR #768, but `src/agilab/apps/builtin/uav_queue_project/.venv` still appeared as untracked because it is a symlink.

## Root Cause

The previous ignore rule used trailing-slash directory patterns only. Git does not match those patterns for symlink paths.

## Regression Test

Manual Git ignore/status checks were used because this is a Git ignore-policy update.

## Validation

- `git status --ignored -s src/agilab/apps-pages/app_ui/.venv src/agilab/apps/builtin/uav_queue_project/.venv`
- `python3 tools/agent_commit_provenance_guard.py --check-config`
- pre-push guard passed

## Review Evidence

Not used.

## Agent Metadata

- Tokki version: `tokki 1.0.19`
- Agent/runtime: Codex CLI, version unavailable
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: no