### PR TITLE
Fix app installer selection and worker dependency sync

### DIFF
--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_local_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_local_support.py
@@ -144,6 +144,36 @@ def _compose_worker_post_install_tool(local_env_prefix: str, uv_worker: Any) -> 
     return " ".join(part for part in (local_prefix, uv_fragment) if part)
 
 
+def _worker_post_install_run_overlay_args(env: Any) -> str:
+    if not getattr(env, "is_source_env", False):
+        return ""
+    args: list[str] = []
+    for source_path in (
+        getattr(env, "agi_env", None),
+        getattr(env, "agi_node", None),
+    ):
+        if source_path:
+            args.append(f"--with-editable {_shell_arg(source_path)}")
+    return " ".join(args)
+
+
+def _worker_post_install_run_sync_args(
+    worker_venv_project: Path,
+    modules: tuple[str, ...],
+    *,
+    python_version: str | None = None,
+) -> str:
+    if _project_venv_matches(worker_venv_project, python_version=python_version) and (
+        _project_venv_has_modules(
+            worker_venv_project,
+            modules,
+            python_version=python_version,
+        )
+    ):
+        return "--no-sync"
+    return ""
+
+
 def _force_remove(
     path: Path, *, env_logger: Any | None = None, os_name: str = os.name
 ) -> None:
@@ -1652,10 +1682,30 @@ async def deploy_local_worker(
         _local_worker_post_install_env_prefix(agi_cls),
         uv_worker,
     )
-    post_install_cmd = (
-        f"{post_install_tool} run --no-sync --project {_shell_arg(wenv_abs)} "
-        f"--python {_shell_arg(pyvers_worker)} python -m {_shell_arg(env.post_install_rel)} "
-        f"{_shell_arg(env.active_app)}"
+    post_install_sync_args = _worker_post_install_run_sync_args(
+        worker_venv_project,
+        worker_probe_modules(),
+        python_version=pyvers_worker,
+    )
+    if not post_install_sync_args and env.verbose > 0:
+        log.info(
+            "Worker post-install will allow uv sync because the worker venv "
+            "is missing required probe modules."
+        )
+    post_install_cmd = " ".join(
+        part
+        for part in (
+            f"{post_install_tool} run",
+            post_install_sync_args,
+            _worker_post_install_run_overlay_args(env),
+            f"--project {_shell_arg(wenv_abs)}",
+            f"--python {_shell_arg(pyvers_worker)}",
+            "python",
+            "-m",
+            _shell_arg(env.post_install_rel),
+            _shell_arg(env.active_app),
+        )
+        if part
     )
 
     started_at = time.perf_counter()

--- a/src/agilab/core/test/test_agi_distributor_deployment_local_support.py
+++ b/src/agilab/core/test/test_agi_distributor_deployment_local_support.py
@@ -1073,6 +1073,35 @@ def test_dependency_module_and_pth_import_roots_cover_edge_branches(monkeypatch,
     assert deployment_local_support._pth_import_roots(site_packages) == ()
 
 
+def test_worker_post_install_sync_args_only_skips_when_modules_are_ready(tmp_path):
+    worker_project = tmp_path / "worker"
+    _write_venv_python(worker_project, python_version="3.13.14")
+    site_packages = deployment_local_support._project_site_packages_dir(
+        worker_project,
+        python_version="3.13.14",
+    )
+    site_packages.mkdir(parents=True, exist_ok=True)
+
+    assert (
+        deployment_local_support._worker_post_install_run_sync_args(
+            worker_project,
+            ("geopy",),
+            python_version="3.13.14",
+        )
+        == ""
+    )
+
+    (site_packages / "geopy").mkdir()
+    assert (
+        deployment_local_support._worker_post_install_run_sync_args(
+            worker_project,
+            ("geopy",),
+            python_version="3.13.14",
+        )
+        == "--no-sync"
+    )
+
+
 def test_editable_install_support_edge_cases(tmp_path):
     cache_path = tmp_path / "editable-cache.json"
     assert deployment_editable_install_support._load_editable_install_cache(cache_path) == {
@@ -2125,6 +2154,28 @@ def test_compose_worker_post_install_tool_keeps_export_prefix_separate():
         "AGI_CLUSTER_ENABLED=0 UV_INDEX_URL=https://mirror.example/simple uv --quiet"
     )
     assert "export 'PATH=" not in command
+
+
+def test_worker_post_install_run_overlay_args_empty_for_packaged_install():
+    assert (
+        deployment_local_support._worker_post_install_run_overlay_args(
+            SimpleNamespace(is_source_env=False, agi_env="/src/agi-env", agi_node="/src/agi-node")
+        )
+        == ""
+    )
+
+
+def test_worker_post_install_run_overlay_args_adds_source_core_editables():
+    command = deployment_local_support._worker_post_install_run_overlay_args(
+        SimpleNamespace(
+            is_source_env=True,
+            agi_env=Path("/repo/src/agilab/core/agi-env"),
+            agi_node=Path("/repo/src/agilab/core/agi-node"),
+        )
+    )
+
+    assert "--with-editable /repo/src/agilab/core/agi-env" in command
+    assert "--with-editable /repo/src/agilab/core/agi-node" in command
 
 
 def test_infer_repo_root_from_runtime_returns_none_for_short_path():

--- a/src/agilab/install_apps.sh
+++ b/src/agilab/install_apps.sh
@@ -16,6 +16,12 @@ declare -a BUILTIN_APPS=(
 )
 declare -a REPOSITORY_APPS=()
 declare -a INVALID_REPOSITORY_APPS=()
+CALLER_APPS_REPOSITORY_SET=0
+CALLER_APPS_REPOSITORY=""
+if [[ "${APPS_REPOSITORY+x}" == x ]]; then
+  CALLER_APPS_REPOSITORY_SET=1
+  CALLER_APPS_REPOSITORY="$APPS_REPOSITORY"
+fi
 
 declare -a DEFAULT_APPS_ORDER=(
   flight_telemetry_project
@@ -99,6 +105,7 @@ declare -a SKIPPED_APP_TESTS=()
 DATA_CHECK_MESSAGE=""
 DATA_URI_PATH=""
 PROMPT_FOR_APPS=1
+NON_INTERACTIVE=0
 FORCE_APP_SELECTION=0
 FORCE_ALL_APPS=0
 ALL_APPS_SENTINEL="${INSTALL_ALL_SENTINEL:-__AGILAB_ALL_APPS__}"
@@ -113,6 +120,9 @@ INSTALLED_APPS_FILE="${INSTALLED_APPS_FILE:-$HOME/.local/share/agilab/installed_
 # Load env + normalize Python version
 # shellcheck source=/dev/null
 source "$HOME/.local/share/agilab/.env"
+if (( CALLER_APPS_REPOSITORY_SET )); then
+  APPS_REPOSITORY="$CALLER_APPS_REPOSITORY"
+fi
 
 # Colors for output
 RED='\033[1;31m'
@@ -241,6 +251,41 @@ discover_repo_dir() {
 
 resolve_physical_dir() {
   (cd "$1" >/dev/null 2>&1 && pwd -P)
+}
+
+resolve_cli_path_arg() {
+  local raw="$1"
+  case "$raw" in
+    "~") printf '%s\n' "$HOME" ;;
+    "~/"*) printf '%s/%s\n' "$HOME" "${raw#"~/"}" ;;
+    /*) printf '%s\n' "$raw" ;;
+    *) printf '%s/%s\n' "$(pwd -P)" "$raw" ;;
+  esac
+}
+
+set_install_apps_selection_from_cli() {
+  local raw="${1:-select}"
+  local lower_val
+
+  lower_val="$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]')"
+  case "$lower_val" in
+    ""|select|picker|prompt)
+      BUILTIN_APPS_FROM_ENV=""
+      PROMPT_FOR_APPS=1
+      ;;
+    all)
+      BUILTIN_APPS_FROM_ENV="$ALL_APPS_SENTINEL"
+      PROMPT_FOR_APPS=0
+      ;;
+    builtin|built-in)
+      BUILTIN_APPS_FROM_ENV="$BUILTIN_ONLY_SENTINEL"
+      PROMPT_FOR_APPS=0
+      ;;
+    *)
+      BUILTIN_APPS_FROM_ENV="$raw"
+      PROMPT_FOR_APPS=0
+      ;;
+  esac
 }
 
 is_truthy() {
@@ -509,12 +554,18 @@ PY
 
 usage() {
   cat <<'EOF'
-Usage: install_apps.sh [--test-apps]
+Usage: install_apps.sh [--apps-repository <path>] [--install-apps [app1,app2,...|all|builtin|select]] [--test-apps]
+  --apps-repository <path>
+                   Install apps/pages from a source app repository
+  --install-apps [selection]
+                   App selection: all, builtin, select, or a comma/space-separated app list
   --test-apps      Run pytest for each app after installation (implies --install-apps)
   --link-compatible-venvs
                    Link app/page/worker venvs to compatible larger envs after install (default)
   --no-link-compatible-venvs
                    Disable compatible venv linking
+  --non-interactive, --yes, -y
+                   Do not prompt; use defaults unless --install-apps supplies a selection
   --help           Show this message and exit
 EOF
 }
@@ -522,9 +573,42 @@ EOF
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --apps-repository)
+      if [[ -z "${2-}" || "${2}" == --* ]]; then
+        echo -e "${RED}Error:${NC} --apps-repository requires a path" >&2
+        usage
+        exit 1
+      fi
+      APPS_REPOSITORY="$(resolve_cli_path_arg "$2")"
+      if [[ -e "$APPS_REPOSITORY" ]]; then
+        APPS_REPOSITORY="$(resolve_physical_dir "$APPS_REPOSITORY")"
+      fi
+      shift 2
+      continue
+      ;;
+    --apps-repository=*)
+      APPS_REPOSITORY="$(resolve_cli_path_arg "${1#*=}")"
+      if [[ -e "$APPS_REPOSITORY" ]]; then
+        APPS_REPOSITORY="$(resolve_physical_dir "$APPS_REPOSITORY")"
+      fi
+      ;;
+    --install-apps)
+      if [[ -n "${2-}" && "${2}" != --* ]]; then
+        set_install_apps_selection_from_cli "$2"
+        shift 2
+      else
+        set_install_apps_selection_from_cli select
+        shift
+      fi
+      continue
+      ;;
+    --install-apps=*)
+      set_install_apps_selection_from_cli "${1#*=}"
+      ;;
     --test-apps) DO_TEST_APPS=1;;
     --link-compatible-venvs) LINK_COMPATIBLE_VENVS=1;;
     --no-link-compatible-venvs) LINK_COMPATIBLE_VENVS=0;;
+    --non-interactive|--yes|-y) NON_INTERACTIVE=1;;
     --help|-h) usage; exit 0;;
     *)
       echo -e "${RED}Error:${NC} Unknown option '$1'" >&2
@@ -969,7 +1053,9 @@ fi
 
 # Offer an interactive picker when we still need confirmation.
 if (( PROMPT_FOR_APPS )); then
-  if [[ -t 0 ]]; then
+  if (( NON_INTERACTIVE )); then
+    echo -e "${YELLOW}Non-interactive mode enabled; installing default apps: ${INCLUDED_APPS_UNIQ[*]}.${NC}"
+  elif [[ -t 0 ]]; then
     declare -a PROMPT_APPS=()
     if (( ${#ALL_APPS[@]} )); then
       PROMPT_APPS=("${ALL_APPS[@]}")
@@ -980,17 +1066,28 @@ if (( PROMPT_FOR_APPS )); then
     for idx in "${!PROMPT_APPS[@]}"; do
       app="${PROMPT_APPS[$idx]}"
       marker="[ ]"
+      source_label="builtin"
+      if in_list "$app" "${REPOSITORY_APPS[@]}" && ! in_list "$app" "${BUILTIN_APPS[@]}"; then
+        source_label="repository"
+      fi
       if [[ " ${INCLUDED_APPS_UNIQ[*]} " == *" ${app} "* ]]; then
         marker="[x]"
       fi
-      printf "  %2d) %s %s\n" $((idx + 1)) "$marker" "$app"
+      printf "  %2d) %s %-32s %s\n" $((idx + 1)) "$marker" "$app" "($source_label)"
     done
-    read -rp "Numbers/ranges (1 3-5, blank = defaults): " selection
+    read -rp "Numbers/ranges/names, all, none (blank = defaults): " selection
     if [[ -n "$selection" ]]; then
       selection="${selection//,/ }"
       declare -a picked=()
-      for token in $selection; do
-        if [[ "$token" =~ ^([0-9]+)-([0-9]+)$ ]]; then
+      selection_lower="$(printf '%s' "$selection" | tr '[:upper:]' '[:lower:]')"
+      if [[ "$selection_lower" == "all" ]]; then
+        picked=("${PROMPT_APPS[@]}")
+      elif [[ "$selection_lower" == "none" ]]; then
+        picked=()
+        INCLUDED_APPS_UNIQ=()
+      else
+        for token in $selection; do
+          if [[ "$token" =~ ^([0-9]+)-([0-9]+)$ ]]; then
           start=${BASH_REMATCH[1]}
           end=${BASH_REMATCH[2]}
           if (( end < start )); then
@@ -1012,10 +1109,13 @@ if (( PROMPT_FOR_APPS )); then
           else
             echo -e "${YELLOW}Ignoring out-of-range selection: $token${NC}"
           fi
+          elif in_list "$token" "${PROMPT_APPS[@]}"; then
+            picked+=("$token")
         else
           echo -e "${YELLOW}Ignoring invalid selection: $token${NC}"
         fi
-      done
+        done
+      fi
       if (( ${#picked[@]} )); then
         declare -a unique_picked=()
         for item in "${picked[@]}"; do

--- a/test/test_install_apps_discovery.py
+++ b/test/test_install_apps_discovery.py
@@ -189,6 +189,37 @@ validate_apps_repository_policy "$1"
     )
 
 
+def _run_install_apps_selection_from_cli(raw: str) -> dict[str, str]:
+    script_text = INSTALL_APPS_SH.read_text(encoding="utf-8")
+    function_body = _extract_function(
+        script_text,
+        "set_install_apps_selection_from_cli",
+        "is_truthy",
+    )
+    bash_script = f"""#!/usr/bin/env bash
+set -euo pipefail
+ALL_APPS_SENTINEL="__AGILAB_ALL_APPS__"
+BUILTIN_ONLY_SENTINEL="__AGILAB_BUILTIN_APPS__"
+BUILTIN_APPS_FROM_ENV="initial"
+PROMPT_FOR_APPS=1
+{function_body}
+set_install_apps_selection_from_cli "$1"
+printf 'BUILTIN_APPS_FROM_ENV=%s\n' "$BUILTIN_APPS_FROM_ENV"
+printf 'PROMPT_FOR_APPS=%s\n' "$PROMPT_FOR_APPS"
+"""
+    completed = subprocess.run(
+        ["bash", "-c", bash_script, "install_apps_selection_test", raw],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    result: dict[str, str] = {}
+    for line in completed.stdout.splitlines():
+        key, value = line.split("=", 1)
+        result[key] = value
+    return result
+
+
 def test_page_discovery_keeps_only_installable_entrypoint_projects(tmp_path: Path) -> None:
     pages_root = tmp_path / "apps-pages"
     _write_page_project(pages_root / "view_demo")
@@ -298,3 +329,33 @@ def test_validate_apps_repository_policy_requires_allowlist_in_strict_mode(tmp_p
 
     assert result.returncode == 1
     assert "AGILAB_APPS_REPOSITORY_ALLOWLIST" in result.stderr
+
+
+def test_install_apps_preserves_caller_apps_repository_over_env_file() -> None:
+    text = INSTALL_APPS_SH.read_text(encoding="utf-8")
+
+    snapshot = text.index("CALLER_APPS_REPOSITORY_SET=0")
+    source_env = text.index('source "$HOME/.local/share/agilab/.env"')
+    restore = text.index('APPS_REPOSITORY="$CALLER_APPS_REPOSITORY"')
+
+    assert snapshot < source_env < restore
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected_value", "expected_prompt"),
+    [
+        ("all", "__AGILAB_ALL_APPS__", "0"),
+        ("builtin", "__AGILAB_BUILTIN_APPS__", "0"),
+        ("select", "", "1"),
+        ("flight_trajectory_project,ilp_project", "flight_trajectory_project,ilp_project", "0"),
+    ],
+)
+def test_install_apps_cli_selection_normalization(
+    raw: str,
+    expected_value: str,
+    expected_prompt: str,
+) -> None:
+    result = _run_install_apps_selection_from_cli(raw)
+
+    assert result["BUILTIN_APPS_FROM_ENV"] == expected_value
+    assert result["PROMPT_FOR_APPS"] == expected_prompt


### PR DESCRIPTION
## Summary
- preserve caller-provided `APPS_REPOSITORY` when the sourced AGILAB env file contains an empty value
- add `install_apps.sh` CLI selection UX for `--apps-repository` and `--install-apps` values including `all`, explicit app lists, and interactive selection
- make worker post-install self-heal stale worker environments by allowing `uv run` to sync when required probe modules such as `psutil` or `geopy` are missing

## Repro
- Running private app installs through `install_apps.sh` could ignore the caller `APPS_REPOSITORY` after sourcing an env file with `APPS_REPOSITORY=""`.
- Source worker post-install commands used `uv run --no-sync`; stale shared worker envs then failed with `ModuleNotFoundError`, first for `psutil`, then for declared app dependencies such as `geopy`.

## Root Cause
- The app installer did not keep an explicit caller repository value ahead of the persisted env defaults.
- Worker post-install always used `--no-sync`, even when the actual worker venv did not contain every module declared by the worker/app dependency probes.

## Regression Test
- Added installer discovery/CLI tests for caller repository preservation and app selection normalization.
- Added deployer tests for source overlay arguments and conditional worker post-install `--no-sync` behavior.

## Validation
- `bash -n src/agilab/install_apps.sh install.sh src/agilab/core/install.sh`
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts="" test/test_install_apps_discovery.py src/agilab/core/test/test_agi_distributor_deployment_local_support.py -k "install_apps_cli_selection_normalization or install_apps_preserves_caller_apps_repository_over_env_file or worker_post_install_run_overlay_args or worker_post_install_sync_args or compose_worker_post_install_tool or dependency_module_and_pth_import_roots"`
- Result: 10 passed, 108 deselected

## Review Evidence
- Model/sub-agent review: not used

## Scope Note
- The local pre-push mixed-scope guard was intentionally overridden because this is one coherent installer/deployer regression fix spanning installer UX, worker deployer behavior, and tests.

## Agent Metadata
- Tokki version: tokki 1.0.19
- Agent/runtime: Codex coding agent, version unknown
- Model: GPT-5
- Reasoning effort: unknown
- /fast mode: not used
