### PR TITLE
Fix WORKFLOW reload run reattachment

### DIFF
--- a/src/agilab/pipeline/pipeline_lab.py
+++ b/src/agilab/pipeline/pipeline_lab.py
@@ -2036,6 +2036,129 @@ def _latest_run_log_file(run_log_dir: Path) -> Path | None:
     return sorted(candidates, key=_sort_key)[-1]
 
 
+def _latest_pipeline_page_log_file(run_log_dir: Path | None) -> Path | None:
+    if run_log_dir is None:
+        return None
+    candidates: list[Path] = []
+    try:
+        expanded = run_log_dir.expanduser()
+        for pattern in ("pipeline_*.log", "stage_*.log", "run_*.log"):
+            candidates.extend(path for path in expanded.glob(pattern) if path.is_file())
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return None
+    if not candidates:
+        return None
+
+    def _sort_key(path: Path) -> tuple[float, str]:
+        try:
+            return path.stat().st_mtime, path.name
+        except OSError:
+            return 0.0, path.name
+
+    return sorted(candidates, key=_sort_key)[-1]
+
+
+def _read_pipeline_page_log_tail(log_file: Path, *, max_lines: int = 200) -> list[str]:
+    try:
+        lines = log_file.expanduser().read_text(
+            encoding="utf-8",
+            errors="replace",
+        ).splitlines()
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return []
+    return lines[-max_lines:]
+
+
+def _pipeline_page_log_from_lock(lock_state: Mapping[str, Any] | None) -> Path | None:
+    if not isinstance(lock_state, Mapping):
+        return None
+    payload = lock_state.get("payload")
+    if not isinstance(payload, Mapping):
+        return None
+    raw_path = str(payload.get("log_file_path") or "").strip()
+    if not raw_path:
+        return None
+    try:
+        candidate = Path(raw_path).expanduser()
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return None
+    return candidate if candidate.is_file() else None
+
+
+def _infer_pipeline_page_log_status(
+    lines: list[str],
+    lock_state: Mapping[str, Any] | None,
+) -> str:
+    if isinstance(lock_state, Mapping) and not lock_state.get("is_stale"):
+        return "running"
+    tail = "\n".join(lines[-25:]).lower()
+    if not tail:
+        return ""
+    if "traceback" in tail or "run workflow failed" in tail or "command failed" in tail:
+        return "failed"
+    if "run workflow completed" in tail:
+        return "complete"
+    return ""
+
+
+def _hydrate_pipeline_page_run_state_from_disk(
+    index_page: str,
+    env: Any,
+    session_state: Any,
+    inspect_pipeline_run_lock: Callable[..., Any] | None,
+) -> dict[str, Any]:
+    run_logs_key = f"{index_page}__run_logs"
+    last_log_key = f"{index_page}__last_run_log_file"
+    last_status_key = f"{index_page}__last_run_status"
+
+    fresh_run_logs = run_logs_key not in session_state
+    lock_state = inspect_pipeline_run_lock(env) if callable(inspect_pipeline_run_lock) else None
+    lock_state = dict(lock_state) if isinstance(lock_state, Mapping) else None
+    log_file = _pipeline_page_log_from_lock(lock_state)
+    if log_file is None:
+        existing_log = str(session_state.get(last_log_key) or "").strip()
+        if existing_log:
+            try:
+                existing_path = Path(existing_log).expanduser()
+            except (OSError, RuntimeError, TypeError, ValueError):
+                existing_path = None
+            if existing_path is not None and existing_path.is_file():
+                log_file = existing_path
+    if log_file is None:
+        log_file = _latest_pipeline_page_log_file(_workflow_run_log_dir(env))
+
+    loaded_lines: list[str] = []
+    if log_file is not None:
+        session_state.setdefault(last_log_key, str(log_file))
+        if fresh_run_logs:
+            loaded_lines = _read_pipeline_page_log_tail(log_file)
+            if loaded_lines:
+                session_state[run_logs_key] = loaded_lines
+
+    lines_for_status = loaded_lines
+    if not lines_for_status:
+        raw_logs = session_state.get(run_logs_key, [])
+        if isinstance(raw_logs, list):
+            lines_for_status = [str(line) for line in raw_logs]
+        elif isinstance(raw_logs, tuple):
+            lines_for_status = [str(line) for line in raw_logs]
+    inferred_status = _infer_pipeline_page_log_status(lines_for_status, lock_state)
+    if inferred_status == "running" or (inferred_status and not session_state.get(last_status_key)):
+        session_state[last_status_key] = inferred_status
+
+    active_lock = bool(lock_state and not lock_state.get("is_stale"))
+    if active_lock and fresh_run_logs and (loaded_lines or log_file is not None):
+        session_state[f"{index_page}__run_state_hydrated_notice"] = (
+            "Reconnected to an in-progress workflow run from the saved lock and log file."
+        )
+    return {
+        "lock_state": lock_state,
+        "log_file": str(log_file) if log_file is not None else "",
+        "loaded_lines": len(loaded_lines),
+        "status": session_state.get(last_status_key, ""),
+    }
+
+
 def _format_duration_seconds(value: Any) -> str:
     try:
         seconds = float(value)
@@ -4383,6 +4506,12 @@ def display_lab_tab(
     run_logs_key = f"{index_page_str}__run_logs"
     run_placeholder_key = f"{index_page_str}__run_placeholder"
     delete_undo_key = f"{index_page_str}__undo_delete_snapshot"
+    _hydrate_pipeline_page_run_state_from_disk(
+        index_page_str,
+        env,
+        st.session_state,
+        _inspect_pipeline_run_lock,
+    )
     st.session_state.setdefault(run_logs_key, [])
     expander_state_key = f"{safe_prefix}_expander_open"
     expander_state: Dict[int, bool] = st.session_state.setdefault(expander_state_key, {})
@@ -5408,6 +5537,12 @@ def display_lab_tab(
             _persist_sequence_preferences(module_path, stages_file, final_sequence)
 
     page_state = _build_page_state(include_lock=True)
+    hydrated_notice = st.session_state.pop(
+        f"{index_page_str}__run_state_hydrated_notice",
+        "",
+    )
+    if hydrated_notice:
+        st.info(hydrated_notice)
     if page_state.stale_stage_refs and page_state.run_disabled_reason:
         st.warning(page_state.run_disabled_reason)
 

--- a/src/agilab/pipeline/pipeline_run_controls.py
+++ b/src/agilab/pipeline/pipeline_run_controls.py
@@ -1482,6 +1482,9 @@ def _acquire_pipeline_run_lock(
         "created_at": now,
         "heartbeat_at": now,
     }
+    log_file_path = str(st.session_state.get(f"{index_page}__run_log_file") or "")
+    if log_file_path:
+        payload["log_file_path"] = log_file_path
 
     if force and not _clear_pipeline_run_lock(
         env,

--- a/test/test_pipeline_lab.py
+++ b/test/test_pipeline_lab.py
@@ -4229,6 +4229,54 @@ def test_display_lab_tab_revert_restores_previous_snapshot(monkeypatch, tmp_path
     assert reruns == ["fragment"]
 
 
+def test_hydrate_pipeline_page_run_state_recovers_reload_from_lock_log(tmp_path):
+    log_file = tmp_path / "pipeline_20260706_120000_000001.log"
+    log_file.write_text(
+        "Run workflow started... logs will be saved to pipeline.log\n"
+        "Running stage 1...\n"
+        "Running stage 2...\n",
+        encoding="utf-8",
+    )
+    session_state: dict[str, Any] = {}
+    lock_state = {
+        "is_stale": False,
+        "owner_text": "pid 123",
+        "payload": {"log_file_path": str(log_file)},
+    }
+
+    result = pipeline_lab._hydrate_pipeline_page_run_state_from_disk(
+        "demo",
+        SimpleNamespace(runenv=tmp_path, app="demo_project", target="demo_project"),
+        session_state,
+        lambda _env: lock_state,
+    )
+
+    assert result["status"] == "running"
+    assert result["loaded_lines"] == 3
+    assert result["log_file"] == str(log_file)
+    assert session_state["demo__last_run_status"] == "running"
+    assert session_state["demo__last_run_log_file"] == str(log_file)
+    assert session_state["demo__run_logs"][-1] == "Running stage 2..."
+    assert "Reconnected" in session_state["demo__run_state_hydrated_notice"]
+
+
+def test_hydrate_pipeline_page_run_state_respects_cleared_page_logs(tmp_path):
+    log_file = tmp_path / "pipeline_20260706_120000_000001.log"
+    log_file.write_text("Running stage 1...\n", encoding="utf-8")
+    session_state: dict[str, Any] = {"demo__run_logs": []}
+
+    result = pipeline_lab._hydrate_pipeline_page_run_state_from_disk(
+        "demo",
+        SimpleNamespace(runenv=tmp_path, app="demo_project", target="demo_project"),
+        session_state,
+        lambda _env: None,
+    )
+
+    assert result["loaded_lines"] == 0
+    assert session_state["demo__run_logs"] == []
+    assert session_state["demo__last_run_log_file"] == str(log_file)
+
+
 def test_display_lab_tab_run_pipeline_and_delete_all(monkeypatch, tmp_path):
     run_calls = []
     remove_calls = []


### PR DESCRIPTION
## Summary
- persist the active WORKFLOW run log path into the cross-process pipeline lock
- hydrate a fresh Streamlit WORKFLOW session from the saved lock/log after page reload
- restore the log tail and running status so duplicate runs stay blocked while the original workflow is active

## Repro
- Start a WORKFLOW run.
- Reload the browser page while the workflow is still running.
- The new Streamlit session loses page-local run logs/status and can look detached from the active backend run.

## Root Cause
- The workflow lock and run log were file-backed, but the page view model only hydrated logs/status from `st.session_state`.
- A browser reload creates a fresh Streamlit session state, so the UI could see an active lock but not reattach the saved log/status context.

## Regression Test
- Added helper coverage for reload hydration from an active lock with `log_file_path`.
- Added helper coverage that respects intentionally cleared page logs while still keeping the saved log file reference.

## Validation
- Local non-test guards passed: `python3 tools/agent_commit_provenance_guard.py --check-config`, `git diff --cached --check`, `./dev scope --staged`.
- Focused tests were not run in this turn per operator preference unless explicitly requested.

## Review Evidence
- Model/sub-agent review: not used

## Agent Metadata
- Tokki version: tokki 1.0.19
- Agent/runtime: Codex coding agent, version unknown
- Model: GPT-5
- Reasoning effort: unknown
- /fast mode: not used
