### PR TITLE
[codex] Guard Python 3.14 install profiling path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ coverage-*.xml
 .DS_store
 
 # Python virtual environments and build artifacts
+.venv
 .venv/
 .venv*/
 dist/

--- a/README.md
+++ b/README.md
@@ -251,6 +251,14 @@ cd "$CHECKOUT"
 uv --preview-features extra-build-dependencies run --extra ui streamlit run src/agilab/main_page.py
 ```
 
+For repeat source-checkout installs, the repository also provides a wrapper that
+keeps the Python interpreter selection explicit, refreshes generated worker
+environments, installs the external apps repository, and then starts Streamlit:
+
+```bash
+APPS_REPO="/path/to/private-or-external-apps-repo" ./install_private_apps_and_run.sh
+```
+
 To add those apps after AGILAB is already installed, rerun only the app
 installer:
 
@@ -263,6 +271,15 @@ APPS_REPOSITORY="$APPS_REPO" \
 AGILAB_DEV_APPS_REPOSITORY=1 \
 BUILTIN_APPS=__AGILAB_ALL_APPS__ \
 ./install_apps.sh
+```
+
+Python 3.14 is supported for the main source install and worker runtime paths,
+but the ORCHESTRATE dataframe `STATS report` action is disabled on Python 3.14
+because the optional `ydata-profiling` stack currently depends on `numba`, which
+supports Python `<3.14`. Use Python 3.13 when that profiling report is required:
+
+```bash
+AGI_PYTHON_VERSION=3.13.14 APPS_REPO="/path/to/private-or-external-apps-repo" ./install_private_apps_and_run.sh
 ```
 
 For a zero-install browser preview, open the public

--- a/install.sh
+++ b/install.sh
@@ -42,6 +42,22 @@ export PATH="$HOME/.local/bin:$PATH"
 
 UV="uv --preview-features extra-build-dependencies"
 
+python_uv_spec_for_version() {
+    local version="${1:-}"
+    case "$version" in
+        3.14|3.14.*)
+            if [[ "$version" == *+* ]]; then
+                printf '%s\n' "$version"
+            else
+                printf '%s+gil\n' "$version"
+            fi
+            ;;
+        *)
+            printf '%s\n' "$version"
+            ;;
+    esac
+}
+
 configure_uv_link_mode() {
     local requested="${AGILAB_UV_LINK_MODE:-${UV_LINK_MODE:-hardlink}}"
     case "$requested" in
@@ -747,7 +763,7 @@ refresh_launch_matrix() {
     pushd "$AGI_INSTALL_PATH" > /dev/null || return 0
     if [[ -f "tools/refresh_launch_matrix.py" ]]; then
         # Best-effort; do not fail install if this step errors
-        $UV run -p "$AGI_PYTHON_VERSION" python tools/refresh_launch_matrix.py --inplace \
+        $UV run -p "${AGI_PYTHON_UV_SPEC:-$AGI_PYTHON_VERSION}" python tools/refresh_launch_matrix.py --inplace \
           && echo -e "${GREEN}Launch Matrix updated in AGENTS.md.${NC}" \
           || warn "Launch Matrix refresh skipped (tooling not available)."
     else
@@ -984,8 +1000,10 @@ choose_python_version() {
     AGI_PYTHON_FREE_THREADED=0
 
     AGI_PYTHON_VERSION="$chosen_python"
+    AGI_PYTHON_UV_SPEC="$(python_uv_spec_for_version "$AGI_PYTHON_VERSION")"
     export AGI_PYTHON_FREE_THREADED
     export AGI_PYTHON_VERSION
+    export AGI_PYTHON_UV_SPEC
 }
 
 remove_incompatible_project_venv() {
@@ -1068,6 +1086,7 @@ update_environment() {
         echo "CLUSTER_CREDENTIALS=\"$cluster_credentials\""
         echo "AGI_PYTHON_VERSION=\"$AGI_PYTHON_VERSION\""
         echo "AGI_PYTHON_FREE_THREADED=\"$AGI_PYTHON_FREE_THREADED\""
+        echo "AGI_PYTHON_UV_SPEC=\"${AGI_PYTHON_UV_SPEC:-$AGI_PYTHON_VERSION}\""
         echo "APPS_REPOSITORY=\"$APPS_REPOSITORY\""
         echo "AGI_CLUSTER_SHARE=\"$AGI_CLUSTER_SHARE\""
         echo "AGI_LOCAL_SHARE=\"$AGI_LOCAL_SHARE\""
@@ -1280,7 +1299,7 @@ install_core() {
 run_core_tests() {
     local repo_root="$AGI_INSTALL_PATH"
     local -a failures=()
-    local -a uv_run=(uv --preview-features extra-build-dependencies run -p "$AGI_PYTHON_VERSION" --no-sync --preview-features python-upgrade)
+    local -a uv_run=(uv --preview-features extra-build-dependencies run -p "${AGI_PYTHON_UV_SPEC:-$AGI_PYTHON_VERSION}" --no-sync --preview-features python-upgrade)
 
     echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
     echo -e "${BLUE}RUNNING CORE TEST SUITES${NC}"
@@ -1292,7 +1311,7 @@ run_core_tests() {
     # `uv run --no-sync` assumes dependencies are already installed.
     echo -e "${BLUE}Syncing repository environment for core tests...${NC}"
     remove_incompatible_project_venv "$repo_root" "repository root"
-    $UV sync -p "$AGI_PYTHON_VERSION" --preview-features python-upgrade
+    $UV sync -p "${AGI_PYTHON_UV_SPEC:-$AGI_PYTHON_VERSION}" --preview-features python-upgrade
 
     if ! "${uv_run[@]}" -m pytest src/agilab/core/agi-env/test --cov=src/agilab/core/agi-env/src/agi_env --cov-report=term-missing --cov-report=xml:coverage-agi-env.xml; then
         failures+=("agi-env tests")
@@ -1329,7 +1348,7 @@ run_root_tests() {
     echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
 
     pushd "$repo_root" > /dev/null
-    if ! $UV run -p "$AGI_PYTHON_VERSION" --no-sync --preview-features python-upgrade -m pytest src/agilab/test --cov=src/agilab --cov-report=term-missing --cov-report=xml:coverage-agilab.xml; then
+    if ! $UV run -p "${AGI_PYTHON_UV_SPEC:-$AGI_PYTHON_VERSION}" --no-sync --preview-features python-upgrade -m pytest src/agilab/test --cov=src/agilab --cov-report=term-missing --cov-report=xml:coverage-agilab.xml; then
         echo -e "${RED}Agilab unit tests failed. Aborting install.${NC}"
         popd > /dev/null
         exit 1
@@ -1366,7 +1385,7 @@ run_repository_tests_with_coverage() {
         has_app_filter=1
         echo -e "${BLUE}App coverage limited to installed set from ${installed_apps_file}.${NC}"
     fi
-    local -a uv_cmd=(uv --preview-features extra-build-dependencies run -p "$AGI_PYTHON_VERSION" --no-sync --preview-features python-upgrade)
+    local -a uv_cmd=(uv --preview-features extra-build-dependencies run -p "${AGI_PYTHON_UV_SPEC:-$AGI_PYTHON_VERSION}" --no-sync --preview-features python-upgrade)
     local extra_pythonpath="${repo_root}/src/agilab/core/agi-env/src:${repo_root}/src/agilab/core/agi-node/src:${repo_root}/src/agilab/core/agi-cluster/src"
     local repo_pythonpath="$repo_root"
     if [[ -n "$extra_pythonpath" ]]; then
@@ -1522,7 +1541,7 @@ install_enduser() {
 install_pycharm_script() {
     rm -f .idea/workspace.xml
     echo -e "${BLUE}Patching PyCharm workspace.xml interpreter settings...${NC}"
-    $UV run -p "$AGI_PYTHON_VERSION" python pycharm/setup_pycharm.py || warn "pycharm/install-apps-script.py failed or not found; continuing."
+    $UV run -p "${AGI_PYTHON_UV_SPEC:-$AGI_PYTHON_VERSION}" python pycharm/setup_pycharm.py || warn "pycharm/install-apps-script.py failed or not found; continuing."
 }
 
 resolve_cli_path_arg() {
@@ -1748,7 +1767,7 @@ maybe_run_core_tests
 echo -e "${BLUE}Installing agilab (repo root)...${NC}"
 pushd "$AGI_INSTALL_PATH" > /dev/null
 remove_incompatible_project_venv "$AGI_INSTALL_PATH" "repository root"
-$UV sync -p "$AGI_PYTHON_VERSION" --preview-features python-upgrade
+$UV sync -p "${AGI_PYTHON_UV_SPEC:-$AGI_PYTHON_VERSION}" --preview-features python-upgrade
 $UV pip install --upgrade --no-deps \
     -e src/agilab/core/agi-env \
     -e src/agilab/core/agi-node \

--- a/install.sh
+++ b/install.sh
@@ -922,12 +922,25 @@ choose_python_version() {
         fi
     fi
     PYTHON_VERSION=${PYTHON_VERSION:-3.14}
+    if [[ "$PYTHON_VERSION" == *freethreaded* \
+       || "$PYTHON_VERSION" =~ (^|[^[:alnum:]])python3\.[0-9]+t([^[:alnum:]]|$) \
+       || "$PYTHON_VERSION" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?t($|[^[:alnum:]]) ]]; then
+        echo -e "${RED}Unsupported Python selection '$PYTHON_VERSION'. AGILAB installs require a standard GIL Python interpreter; freethreaded Python can force native builds for binary packages such as Polars.${NC}"
+        echo -e "${YELLOW}Use AGI_PYTHON_VERSION=3.14.6 or AGI_PYTHON_VERSION=3.13.14.${NC}"
+        exit 1
+    fi
     echo "You selected Python version $PYTHON_VERSION"
     available_python_versions=$($UV python list | grep -F -- "$PYTHON_VERSION" | grep -v "freethreaded")
     python_array=()
     while IFS= read -r line; do
+        [[ -n "$line" ]] || continue
         python_array+=("$line")
     done <<< "$available_python_versions"
+    if (( ${#python_array[@]} == 0 )); then
+        echo -e "${RED}No standard CPython interpreter found for '$PYTHON_VERSION'. Freethreaded interpreters are intentionally excluded.${NC}"
+        echo -e "${YELLOW}Install a standard interpreter with: uv python install $PYTHON_VERSION${NC}"
+        exit 1
+    fi
 
     for idx in "${!python_array[@]}"; do
         if [[ "${python_array[$idx]}" == *"$PYTHON_VERSION"* ]]; then
@@ -968,22 +981,41 @@ choose_python_version() {
     fi
 
     chosen_python=$(echo "$chosen_python" | cut -d '-' -f2)
-    if $UV python list | grep "$chosen_python" | grep -q "freethreaded"; then
-        echo -e "${YELLOW}Freethreaded version available.${NC}"
-        chosen_python_free="${chosen_python}+freethreaded"
-        if ! echo "$installed_pythons" | grep -q "$chosen_python_free"; then
-            echo -e "${YELLOW}Installing $chosen_python_free...${NC}"
-            $UV python install "$chosen_python_free"
-            echo -e "${GREEN}Python version ($chosen_python_free) is now installed.${NC}"
-        else
-            echo -e "${GREEN}Python version ($chosen_python_free) is already installed.${NC}"
-        fi
-        AGI_PYTHON_FREE_THREADED=1
-    fi
+    AGI_PYTHON_FREE_THREADED=0
 
     AGI_PYTHON_VERSION="$chosen_python"
     export AGI_PYTHON_FREE_THREADED
     export AGI_PYTHON_VERSION
+}
+
+remove_incompatible_project_venv() {
+    local project_dir="$1"
+    local label="${2:-$1}"
+    local venv_dir="$project_dir/.venv"
+    local venv_python="$venv_dir/bin/python"
+    [[ -x "$venv_python" ]] || return 0
+
+    local status
+    status="$("$venv_python" - "$AGI_PYTHON_VERSION" <<'PY' 2>/dev/null || true
+import sys
+
+expected = sys.argv[1]
+expected_parts = expected.split(".")
+current_parts = [str(sys.version_info.major), str(sys.version_info.minor), str(sys.version_info.micro)]
+abi_flags = getattr(sys, "abiflags", "")
+gil_enabled = getattr(sys, "_is_gil_enabled", lambda: True)()
+if "t" in abi_flags or gil_enabled is False:
+    print("freethreaded")
+elif current_parts[: len(expected_parts)] != expected_parts:
+    print("version")
+else:
+    print("ok")
+PY
+)"
+    [[ "$status" == "ok" ]] && return 0
+
+    echo -e "${YELLOW}Removing incompatible virtual environment for ${label}: ${venv_dir} (${status:-unreadable}; expected Python ${AGI_PYTHON_VERSION}).${NC}"
+    rm -rf -- "$venv_dir"
 }
 
 
@@ -1259,6 +1291,7 @@ run_core_tests() {
     # Ensure the repo root virtual environment is populated before running pytest/coverage.
     # `uv run --no-sync` assumes dependencies are already installed.
     echo -e "${BLUE}Syncing repository environment for core tests...${NC}"
+    remove_incompatible_project_venv "$repo_root" "repository root"
     $UV sync -p "$AGI_PYTHON_VERSION" --preview-features python-upgrade
 
     if ! "${uv_run[@]}" -m pytest src/agilab/core/agi-env/test --cov=src/agilab/core/agi-env/src/agi_env --cov-report=term-missing --cov-report=xml:coverage-agi-env.xml; then
@@ -1714,6 +1747,7 @@ maybe_run_core_tests
 
 echo -e "${BLUE}Installing agilab (repo root)...${NC}"
 pushd "$AGI_INSTALL_PATH" > /dev/null
+remove_incompatible_project_venv "$AGI_INSTALL_PATH" "repository root"
 $UV sync -p "$AGI_PYTHON_VERSION" --preview-features python-upgrade
 $UV pip install --upgrade --no-deps \
     -e src/agilab/core/agi-env \

--- a/install_private_apps_and_run.sh
+++ b/install_private_apps_and_run.sh
@@ -6,7 +6,13 @@ APPS_REPO="${APPS_REPO:-}"
 
 export AGI_PYTHON_VERSION="${AGI_PYTHON_VERSION:-3.14.6}"
 export AGI_PYTHON_FREE_THREADED=0
-export UV_PYTHON_PREFERENCE="${UV_PYTHON_PREFERENCE:-only-system}"
+if [[ -z "${AGI_PYTHON_UV_SPEC:-}" ]]; then
+  case "$AGI_PYTHON_VERSION" in
+    3.14|3.14.*) AGI_PYTHON_UV_SPEC="${AGI_PYTHON_VERSION}+gil" ;;
+    *) AGI_PYTHON_UV_SPEC="$AGI_PYTHON_VERSION" ;;
+  esac
+fi
+export AGI_PYTHON_UV_SPEC
 export AGILAB_REFRESH_WORKER_ENVS="${AGILAB_REFRESH_WORKER_ENVS:-1}"
 
 if [[ ! -d "$CHECKOUT" ]]; then
@@ -21,7 +27,7 @@ fi
 
 cd "$CHECKOUT"
 
-uv --preview-features extra-build-dependencies run --no-project -p "$AGI_PYTHON_VERSION" python - <<'PY'
+uv --preview-features extra-build-dependencies run --no-project -p "$AGI_PYTHON_UV_SPEC" python - <<'PY'
 import sys
 
 print("Using Python:", sys.executable)

--- a/install_private_apps_and_run.sh
+++ b/install_private_apps_and_run.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CHECKOUT="${AGILAB_CHECKOUT:-$HOME/PycharmProjects/agilab}"
+APPS_REPO="${APPS_REPO:-}"
+
+export AGI_PYTHON_VERSION="${AGI_PYTHON_VERSION:-3.14.6}"
+export AGI_PYTHON_FREE_THREADED=0
+export UV_PYTHON_PREFERENCE="${UV_PYTHON_PREFERENCE:-only-system}"
+export AGILAB_REFRESH_WORKER_ENVS="${AGILAB_REFRESH_WORKER_ENVS:-1}"
+
+if [[ ! -d "$CHECKOUT" ]]; then
+  echo "AGILAB checkout not found: $CHECKOUT" >&2
+  exit 1
+fi
+
+if [[ ! -d "$APPS_REPO" ]]; then
+  echo "Apps repository not found. Set APPS_REPO=/path/to/private-or-external-apps-repo." >&2
+  exit 1
+fi
+
+cd "$CHECKOUT"
+
+uv --preview-features extra-build-dependencies run --no-project -p "$AGI_PYTHON_VERSION" python - <<'PY'
+import sys
+
+print("Using Python:", sys.executable)
+print("Version:", sys.version)
+
+if "t" in getattr(sys, "abiflags", "") or getattr(sys, "_is_gil_enabled", lambda: True)() is False:
+    raise SystemExit("ERROR: selected Python is freethreaded; aborting")
+PY
+
+uv cache clean polars polars-runtime-32 >/dev/null || true
+
+rm -rf \
+  .venv \
+  src/agilab/core/agi-env/.venv \
+  src/agilab/core/agi-node/.venv \
+  src/agilab/core/agi-cluster/.venv \
+  src/agilab/core/agi-core/.venv
+
+./install.sh \
+  --apps-repository "$APPS_REPO" \
+  --install-apps all
+
+uv --preview-features extra-build-dependencies run --extra ui \
+  streamlit run src/agilab/main_page.py "$@"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -317,7 +317,7 @@ dev = [
     "simpy>=4.1,<5",
     "twine",
     "wheel",
-    "ydata-profiling",
+    "ydata-profiling; python_version < '3.14'",
     "genbadge[coverage]",
     "pypi-cleanup",
 ]

--- a/src/agilab/apps/install.py
+++ b/src/agilab/apps/install.py
@@ -591,7 +591,12 @@ def _workerless_uv_sync_command(env: AgiEnv) -> list[str]:
         "--project",
         str(Path(getattr(env, "active_app", "")).expanduser()),
     ]
-    python_version = str(getattr(env, "python_version", "") or os.environ.get("AGI_PYTHON_VERSION", "")).strip()
+    python_version = str(
+        getattr(env, "python_uv_spec", "")
+        or os.environ.get("AGI_PYTHON_UV_SPEC", "")
+        or getattr(env, "python_version", "")
+        or os.environ.get("AGI_PYTHON_VERSION", "")
+    ).strip()
     if python_version:
         command.extend(["-p", python_version])
     return command

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_install_spec_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_install_spec_support.py
@@ -83,6 +83,7 @@ def _build_worker_core_add_commands(
     *,
     offline_flag: str = "",
     prefix: str = "",
+    python_spec: str | None = None,
 ) -> list[str]:
     editable_specs = []
     normal_specs = []
@@ -92,17 +93,18 @@ def _build_worker_core_add_commands(
         else:
             normal_specs.append(spec)
     commands = []
+    python_arg = f"--python {python_spec} " if python_spec else ""
 
     if editable_specs:
         quoted_specs = " ".join(f'"{spec}"' for spec in editable_specs)
         commands.append(
-            f"{prefix}{uv_worker} {offline_flag}--project {wenv_abs} add --editable {quoted_specs}"
+            f"{prefix}{uv_worker} {offline_flag}--project {wenv_abs} add {python_arg}--editable {quoted_specs}"
         )
 
     if normal_specs:
         quoted_specs = " ".join(f'"{spec}"' for spec in normal_specs)
         commands.append(
-            f"{prefix}{uv_worker} {offline_flag}--project {wenv_abs} add {quoted_specs}"
+            f"{prefix}{uv_worker} {offline_flag}--project {wenv_abs} add {python_arg}{quoted_specs}"
         )
 
     return commands

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_local_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_local_support.py
@@ -1391,6 +1391,7 @@ async def deploy_local_worker(
             worker_core_add_specs,
             offline_flag=offline_flag,
             prefix=worker_extra_indexes,
+            python_spec=pyvers_worker_uv_spec,
         )
         for index, cmd_worker in enumerate(worker_core_add_commands):
             stage_name = f"worker-core-add-{index}"

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_local_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_local_support.py
@@ -127,6 +127,14 @@ def _shell_arg(value: Any) -> str:
     return shlex.quote(str(value))
 
 
+def _worker_python_uv_spec(env: Any, fallback: str | None) -> str | None:
+    return (
+        getattr(env, "pyvers_worker_uv_spec", None)
+        or getattr(env, "python_uv_spec", None)
+        or fallback
+    )
+
+
 def _compose_worker_post_install_tool(local_env_prefix: str, uv_worker: Any) -> str:
     uv_fragment = str(uv_worker or "").strip()
     local_prefix = str(local_env_prefix or "").strip()
@@ -1265,6 +1273,7 @@ async def deploy_local_worker(
 
     uv_worker = resolver_env_prefix + cmd_prefix + env.uv_worker
     pyvers_worker = env.pyvers_worker
+    pyvers_worker_uv_spec = _worker_python_uv_spec(env, pyvers_worker)
 
     worker_extra_indexes = ""
     if (
@@ -1446,13 +1455,13 @@ async def deploy_local_worker(
         )
     if hw_rapids_capable:
         cmd_worker = (
-            f"{worker_extra_indexes}{uv_worker} {offline_flag}{run_type} --python {pyvers_worker} "
+            f"{worker_extra_indexes}{uv_worker} {offline_flag}{run_type} --python {pyvers_worker_uv_spec} "
             f'--config-file uv_config.toml --project "{wenv_abs}"'
         )
     else:
         cmd_worker = (
             f"{worker_extra_indexes}{uv_worker} {offline_flag}{run_type} {options_worker} "
-            f'--python {pyvers_worker} --project "{wenv_abs}"'
+            f'--python {pyvers_worker_uv_spec} --project "{wenv_abs}"'
         )
 
     if env.verbose > 0:
@@ -1699,7 +1708,7 @@ async def deploy_local_worker(
             post_install_sync_args,
             _worker_post_install_run_overlay_args(env),
             f"--project {_shell_arg(wenv_abs)}",
-            f"--python {_shell_arg(pyvers_worker)}",
+            f"--python {_shell_arg(pyvers_worker_uv_spec)}",
             "python",
             "-m",
             _shell_arg(env.post_install_rel),

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_prepare_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_prepare_support.py
@@ -123,6 +123,7 @@ async def prepare_local_env(
     env = agi_cls.env
     wenv_abs = env.wenv_abs
     pyvers = env.python_version
+    pyvers_uv_spec = getattr(env, "python_uv_spec", None) or pyvers
     ip = "127.0.0.1"
     hw_rapids_capable = agi_cls._hardware_supports_rapids() and agi_cls._rapids_enabled
     env.hw_rapids_capable = hw_rapids_capable
@@ -180,11 +181,11 @@ async def prepare_local_env(
             except RuntimeError as exc:
                 log.warning("Failed to update uv (skipping self update): %s", exc)
 
-        if await _local_uv_python_available(uv, pyvers, wenv_abs.parent, run_fn=run_fn):
+        if await _local_uv_python_available(uv, pyvers_uv_spec, wenv_abs.parent, run_fn=run_fn):
             log.info("Python interpreter '%s' is already available to uv; skipping install.", pyvers)
         else:
             try:
-                await run_fn(f"{uv} python install {shlex.quote(str(pyvers))}", wenv_abs.parent)
+                await run_fn(f"{uv} python install {shlex.quote(str(pyvers_uv_spec))}", wenv_abs.parent)
             except RuntimeError as exc:
                 if "No download found for request" in str(exc):
                     log.warning(

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime/runtime_distribution_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime/runtime_distribution_support.py
@@ -366,7 +366,12 @@ async def _run_local_worker(
     else:
         uv_worker = getattr(env, "uv_worker", env.uv)
         pyvers_worker = getattr(env, "pyvers_worker", None)
-        python_selector = f" --python {_remote_path(str(pyvers_worker))}" if pyvers_worker else ""
+        pyvers_worker_uv_spec = (
+            getattr(env, "pyvers_worker_uv_spec", None)
+            or getattr(env, "python_uv_spec", None)
+            or pyvers_worker
+        )
+        python_selector = f" --python {_remote_path(str(pyvers_worker_uv_spec))}" if pyvers_worker_uv_spec else ""
         manager_apps_path = _manager_apps_path(env)
         manager_app = _manager_app_name(env)
         # Use POSIX-style separators so the embedded ``Path(...)`` literal stays

--- a/src/agilab/core/agi-env/pyproject.toml
+++ b/src/agilab/core/agi-env/pyproject.toml
@@ -38,6 +38,7 @@ keywords = [
 
 dependencies = [
     "pathspec>=1.1,<2",
+    "charset-normalizer<3.4.8; python_version >= '3.14' and python_version < '3.15'",
     "psutil>=7,<8",
     "py7zr>=1.1,<1.2",
     "pydantic>=2.11,<2.14",

--- a/src/agilab/core/agi-env/src/agi_env/runtime/worker_runtime_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/runtime/worker_runtime_support.py
@@ -10,6 +10,13 @@ from typing import Any, Callable
 import tomlkit
 
 
+def _default_python_uv_spec(version: str) -> str:
+    version = str(version or "").strip()
+    if version.startswith("3.14") and "+" not in version:
+        return f"{version}+gil"
+    return version
+
+
 def _refresh_worker_paths(env_obj: Any, *, target: str, target_worker: str) -> None:
     env_obj.app_src = env_obj.active_app / "src"
     env_obj.manager_pyproject = env_obj.active_app / "pyproject.toml"
@@ -193,7 +200,11 @@ def _configure_worker_python_runtime(
     env_obj._configure_pythonpath(pythonpath_entries)
 
     env_obj.python_version = envars.get("AGI_PYTHON_VERSION", "3.14")
+    env_obj.python_uv_spec = envars.get("AGI_PYTHON_UV_SPEC") or _default_python_uv_spec(
+        env_obj.python_version
+    )
     env_obj.pyvers_worker = env_obj.python_version
+    env_obj.pyvers_worker_uv_spec = env_obj.python_uv_spec
     requested_free_threading = bool(parse_int_env_value_fn(envars, "AGI_PYTHON_FREE_THREADED", 0))
     env_obj.is_free_threading_available = (
         requested_free_threading and python_supports_free_threading_fn()

--- a/src/agilab/core/install.sh
+++ b/src/agilab/core/install.sh
@@ -12,8 +12,36 @@ CORE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 #source "$HOME/.local/bin/env"
 source "$HOME/.local/share/agilab/.env"
-AGI_PYTHON_VERSION=$(echo "$AGI_PYTHON_VERSION" | sed -E 's/^([0-9]+\.[0-9]+\.[0-9]+(\+freethreaded)?).*/\1/')
+normalize_agi_python_version() {
+    local raw="${1:-3.14}"
+    raw="$(printf '%s' "$raw" | sed -E 's/^[[:space:]]+//;s/[[:space:]]+$//')"
+    [[ -n "$raw" ]] || raw="3.14"
+
+    if [[ "$raw" == *freethreaded* \
+       || "$raw" =~ (^|[^[:alnum:]])python3\.[0-9]+t([^[:alnum:]]|$) \
+       || "$raw" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?t($|[^[:alnum:]]) ]]; then
+        echo "Unsupported AGI_PYTHON_VERSION '${raw}': AGILAB core installs require a standard GIL Python interpreter." >&2
+        return 1
+    fi
+
+    if [[ "$raw" =~ ^([0-9]+\.[0-9]+(\.[0-9]+)?)([^0-9].*)?$ ]]; then
+        printf '%s\n' "${BASH_REMATCH[1]}"
+    elif [[ "$raw" =~ cpython-([0-9]+\.[0-9]+(\.[0-9]+)?)([^0-9].*)?$ ]]; then
+        printf '%s\n' "${BASH_REMATCH[1]}"
+    elif [[ "$raw" =~ python([0-9]+\.[0-9]+(\.[0-9]+)?)([^0-9].*)?$ ]]; then
+        printf '%s\n' "${BASH_REMATCH[1]}"
+    else
+        echo "Invalid AGI_PYTHON_VERSION '${raw}'. Expected versions like 3.14, 3.14.6, or 3.13.14." >&2
+        return 1
+    fi
+}
+
+if ! AGI_PYTHON_VERSION="$(normalize_agi_python_version "$AGI_PYTHON_VERSION")"; then
+    exit 1
+fi
+AGI_PYTHON_FREE_THREADED=0
 export AGI_PYTHON_VERSION
+export AGI_PYTHON_FREE_THREADED
 
 BLUE='\033[1;34m'
 GREEN='\033[1;32m'
@@ -105,6 +133,36 @@ ensure_pip_if_missing() {
     ${UV_PREVIEW[@]} run -p "$AGI_PYTHON_VERSION" python -m ensurepip
 }
 
+remove_incompatible_project_venv() {
+    local project_dir="$1"
+    local label="${2:-$1}"
+    local venv_dir="$project_dir/.venv"
+    local venv_python="$venv_dir/bin/python"
+    [[ -x "$venv_python" ]] || return 0
+
+    local status
+    status="$("$venv_python" - "$AGI_PYTHON_VERSION" <<'PY' 2>/dev/null || true
+import sys
+
+expected = sys.argv[1]
+expected_parts = expected.split(".")
+current_parts = [str(sys.version_info.major), str(sys.version_info.minor), str(sys.version_info.micro)]
+abi_flags = getattr(sys, "abiflags", "")
+gil_enabled = getattr(sys, "_is_gil_enabled", lambda: True)()
+if "t" in abi_flags or gil_enabled is False:
+    print("freethreaded")
+elif current_parts[: len(expected_parts)] != expected_parts:
+    print("version")
+else:
+    print("ok")
+PY
+)"
+    [[ "$status" == "ok" ]] && return 0
+
+    echo -e "${YELLOW}Removing incompatible virtual environment for ${label}: ${venv_dir} (${status:-unreadable}; expected Python ${AGI_PYTHON_VERSION}).${NC}"
+    rm -rf -- "$venv_dir"
+}
+
 # Function to prompt user about test failures
 prompt_for_continuation() {
     if [ ${#FAILED_TEST_SUITES[@]} -eq 0 ]; then
@@ -150,6 +208,7 @@ prompt_for_continuation() {
 echo -e "${BLUE}Installing agi-env...${NC}"
 pushd "$CORE_DIR/agi-env" > /dev/null
 echo "${UV_PREVIEW[*]} sync -p $AGI_PYTHON_VERSION --dev"
+remove_incompatible_project_venv "$PWD" "agi-env"
 ${UV_PREVIEW[@]} sync -p "$AGI_PYTHON_VERSION" --dev
 ensure_pip_if_missing
 ${UV_PREVIEW[@]} pip install --upgrade --no-deps -e .
@@ -158,6 +217,7 @@ popd > /dev/null
 echo -e "${BLUE}Installing agi-node...${NC}"
 pushd "$CORE_DIR/agi-node" > /dev/null
 echo "${UV_PREVIEW[*]} sync -p $AGI_PYTHON_VERSION --dev"
+remove_incompatible_project_venv "$PWD" "agi-node"
 ${UV_PREVIEW[@]} sync -p "$AGI_PYTHON_VERSION" --dev
 ensure_pip_if_missing
 ${UV_PREVIEW[@]} pip install --upgrade --no-deps -e . -e ../agi-env
@@ -166,6 +226,7 @@ popd > /dev/null
 echo -e "${BLUE}Installing agi-cluster...${NC}"
 pushd "$CORE_DIR/agi-cluster" > /dev/null
 echo "${UV_PREVIEW[*]} sync -p $AGI_PYTHON_VERSION --dev"
+remove_incompatible_project_venv "$PWD" "agi-cluster"
 ${UV_PREVIEW[@]} sync -p "$AGI_PYTHON_VERSION" --dev
 ensure_pip_if_missing
 ${UV_PREVIEW[@]} pip install --upgrade --no-deps -e . -e ../agi-node -e ../agi-env
@@ -174,6 +235,7 @@ popd > /dev/null
 echo -e "${BLUE}Installing agi-core...${NC}"
 pushd "$CORE_DIR/agi-core" > /dev/null
 echo "${UV_PREVIEW[*]} sync -p $AGI_PYTHON_VERSION --dev"
+remove_incompatible_project_venv "$PWD" "agi-core"
 ${UV_PREVIEW[@]} sync -p "$AGI_PYTHON_VERSION" --dev
 ensure_pip_if_missing
 ${UV_PREVIEW[@]} pip install --upgrade --no-deps -e ../agi-env -e ../agi-node -e ../agi-cluster -e .

--- a/src/agilab/core/install.sh
+++ b/src/agilab/core/install.sh
@@ -10,6 +10,22 @@ set -o pipefail
 UV_PREVIEW=(uv --preview-features extra-build-dependencies)
 CORE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+python_uv_spec_for_version() {
+    local version="${1:-}"
+    case "$version" in
+        3.14|3.14.*)
+            if [[ "$version" == *+* ]]; then
+                printf '%s\n' "$version"
+            else
+                printf '%s+gil\n' "$version"
+            fi
+            ;;
+        *)
+            printf '%s\n' "$version"
+            ;;
+    esac
+}
+
 #source "$HOME/.local/bin/env"
 source "$HOME/.local/share/agilab/.env"
 normalize_agi_python_version() {
@@ -40,8 +56,10 @@ if ! AGI_PYTHON_VERSION="$(normalize_agi_python_version "$AGI_PYTHON_VERSION")";
     exit 1
 fi
 AGI_PYTHON_FREE_THREADED=0
+AGI_PYTHON_UV_SPEC="${AGI_PYTHON_UV_SPEC:-$(python_uv_spec_for_version "$AGI_PYTHON_VERSION")}"
 export AGI_PYTHON_VERSION
 export AGI_PYTHON_FREE_THREADED
+export AGI_PYTHON_UV_SPEC
 
 BLUE='\033[1;34m'
 GREEN='\033[1;32m'
@@ -83,7 +101,7 @@ link_compatible_core_venvs() {
 
     mkdir -p -- "$(dirname "$VENV_LINK_REPORT")"
     echo -e "${BLUE}Linking compatible core virtual environments...${NC}"
-    if "${UV_PREVIEW[@]}" run -p "$AGI_PYTHON_VERSION" --no-project --with packaging python "$linker" \
+    if "${UV_PREVIEW[@]}" run -p "${AGI_PYTHON_UV_SPEC:-$AGI_PYTHON_VERSION}" --no-project --with packaging python "$linker" \
         --apply \
         --report "$VENV_LINK_REPORT" \
         --root "$CORE_DIR"; then
@@ -125,12 +143,12 @@ run_pytest_tracked() {
 }
 
 ensure_pip_if_missing() {
-    if ${UV_PREVIEW[@]} run -p "$AGI_PYTHON_VERSION" python -c "import pip" >/dev/null 2>&1; then
+    if ${UV_PREVIEW[@]} run -p "${AGI_PYTHON_UV_SPEC:-$AGI_PYTHON_VERSION}" python -c "import pip" >/dev/null 2>&1; then
         echo -e "${GREEN}pip already available.${NC}"
         return
     fi
     echo -e "${YELLOW}pip missing; bootstrapping with ensurepip...${NC}"
-    ${UV_PREVIEW[@]} run -p "$AGI_PYTHON_VERSION" python -m ensurepip
+    ${UV_PREVIEW[@]} run -p "${AGI_PYTHON_UV_SPEC:-$AGI_PYTHON_VERSION}" python -m ensurepip
 }
 
 remove_incompatible_project_venv() {
@@ -207,36 +225,36 @@ prompt_for_continuation() {
 
 echo -e "${BLUE}Installing agi-env...${NC}"
 pushd "$CORE_DIR/agi-env" > /dev/null
-echo "${UV_PREVIEW[*]} sync -p $AGI_PYTHON_VERSION --dev"
+echo "${UV_PREVIEW[*]} sync -p ${AGI_PYTHON_UV_SPEC:-$AGI_PYTHON_VERSION} --dev"
 remove_incompatible_project_venv "$PWD" "agi-env"
-${UV_PREVIEW[@]} sync -p "$AGI_PYTHON_VERSION" --dev
+${UV_PREVIEW[@]} sync -p "${AGI_PYTHON_UV_SPEC:-$AGI_PYTHON_VERSION}" --dev
 ensure_pip_if_missing
 ${UV_PREVIEW[@]} pip install --upgrade --no-deps -e .
 popd > /dev/null
 
 echo -e "${BLUE}Installing agi-node...${NC}"
 pushd "$CORE_DIR/agi-node" > /dev/null
-echo "${UV_PREVIEW[*]} sync -p $AGI_PYTHON_VERSION --dev"
+echo "${UV_PREVIEW[*]} sync -p ${AGI_PYTHON_UV_SPEC:-$AGI_PYTHON_VERSION} --dev"
 remove_incompatible_project_venv "$PWD" "agi-node"
-${UV_PREVIEW[@]} sync -p "$AGI_PYTHON_VERSION" --dev
+${UV_PREVIEW[@]} sync -p "${AGI_PYTHON_UV_SPEC:-$AGI_PYTHON_VERSION}" --dev
 ensure_pip_if_missing
 ${UV_PREVIEW[@]} pip install --upgrade --no-deps -e . -e ../agi-env
 popd > /dev/null
 
 echo -e "${BLUE}Installing agi-cluster...${NC}"
 pushd "$CORE_DIR/agi-cluster" > /dev/null
-echo "${UV_PREVIEW[*]} sync -p $AGI_PYTHON_VERSION --dev"
+echo "${UV_PREVIEW[*]} sync -p ${AGI_PYTHON_UV_SPEC:-$AGI_PYTHON_VERSION} --dev"
 remove_incompatible_project_venv "$PWD" "agi-cluster"
-${UV_PREVIEW[@]} sync -p "$AGI_PYTHON_VERSION" --dev
+${UV_PREVIEW[@]} sync -p "${AGI_PYTHON_UV_SPEC:-$AGI_PYTHON_VERSION}" --dev
 ensure_pip_if_missing
 ${UV_PREVIEW[@]} pip install --upgrade --no-deps -e . -e ../agi-node -e ../agi-env
 popd > /dev/null
 
 echo -e "${BLUE}Installing agi-core...${NC}"
 pushd "$CORE_DIR/agi-core" > /dev/null
-echo "${UV_PREVIEW[*]} sync -p $AGI_PYTHON_VERSION --dev"
+echo "${UV_PREVIEW[*]} sync -p ${AGI_PYTHON_UV_SPEC:-$AGI_PYTHON_VERSION} --dev"
 remove_incompatible_project_venv "$PWD" "agi-core"
-${UV_PREVIEW[@]} sync -p "$AGI_PYTHON_VERSION" --dev
+${UV_PREVIEW[@]} sync -p "${AGI_PYTHON_UV_SPEC:-$AGI_PYTHON_VERSION}" --dev
 ensure_pip_if_missing
 ${UV_PREVIEW[@]} pip install --upgrade --no-deps -e ../agi-env -e ../agi-node -e ../agi-cluster -e .
 popd > /dev/null

--- a/src/agilab/core/test/test_agi_distributor_deployment_local_support.py
+++ b/src/agilab/core/test/test_agi_distributor_deployment_local_support.py
@@ -1637,12 +1637,13 @@ def test_build_worker_core_add_commands_marks_local_projects_editable(tmp_path):
         [str(env_project), str(node_project)],
         offline_flag="--offline ",
         prefix="PIP_INDEX_URL=https://test.pypi.org/simple; ",
+        python_spec="3.14.6+gil",
     )
 
     assert commands == [
         (
             "PIP_INDEX_URL=https://test.pypi.org/simple; "
-            f'uv --offline --project {wenv} add --editable "{env_project}" "{node_project}"'
+            f'uv --offline --project {wenv} add --python 3.14.6+gil --editable "{env_project}" "{node_project}"'
         )
     ]
 

--- a/src/agilab/core/test/test_agi_distributor_deployment_local_support.py
+++ b/src/agilab/core/test/test_agi_distributor_deployment_local_support.py
@@ -68,6 +68,20 @@ def _write_editable_direct_url(
     )
 
 
+def _has_worker_core_add_command(
+    commands: list[tuple[str, Path]],
+    wenv_abs: Path,
+    *projects: Path,
+) -> bool:
+    return any(
+        " add " in cmd
+        and "--editable" in cmd
+        and str(wenv_abs) in cmd
+        and all(f'"{project}"' in cmd for project in projects)
+        for cmd, _ in commands
+    )
+
+
 def test_editable_install_cache_path_lives_outside_project_venv(tmp_path):
     cache_path = deployment_local_support._editable_install_cache_path(tmp_path)
 
@@ -3107,15 +3121,13 @@ async def test_deploy_local_worker_install_type_zero_non_source_covers_dependenc
     expected_prefix = "../" * relative_levels + "_uv_sources"
     assert pth_content == expected_prefix
     assert agi_cls._install_done_local is True
-    assert any(
-        f'add --editable "{env_project}" "{node_project}"' in cmd
-        and str(wenv_abs) in cmd
-        for cmd, _ in commands
-    )
-    assert not any(
-        f'add --editable "{env_project}" "{node_project}" "{cluster_project}"' in cmd
-        and str(wenv_abs) in cmd
-        for cmd, _ in commands
+    assert _has_worker_core_add_command(commands, wenv_abs, env_project, node_project)
+    assert not _has_worker_core_add_command(
+        commands,
+        wenv_abs,
+        env_project,
+        node_project,
+        cluster_project,
     )
     manager_python = _venv_python(app_path)
     assert not any(
@@ -3394,11 +3406,7 @@ async def test_deploy_local_worker_preserves_existing_dependency_ranges(
     manager_toml = (app_path / "pyproject.toml").read_text(encoding="utf-8")
     assert "scipy>=1.15.2,<1.17" in manager_toml
     assert "scipy==1.16.1" not in manager_toml
-    assert any(
-        f'add --editable "{env_project}" "{node_project}"' in cmd
-        and str(wenv_abs) in cmd
-        for cmd, _ in commands
-    )
+    assert _has_worker_core_add_command(commands, wenv_abs, env_project, node_project)
     assert any("sync --project" in cmd for cmd, _ in commands)
 
 
@@ -3545,11 +3553,7 @@ async def test_deploy_local_worker_infers_repo_root_to_avoid_rewriting_source_ap
     assert "py7zr" in manager_toml
     assert "pip>=1" not in manager_toml
     assert "scipy==1.16.1" not in manager_toml
-    assert any(
-        f'add --editable "{env_project}" "{node_project}"' in cmd
-        and str(wenv_abs) in cmd
-        for cmd, _ in commands
-    )
+    assert _has_worker_core_add_command(commands, wenv_abs, env_project, node_project)
 
 
 @pytest.mark.asyncio
@@ -3669,11 +3673,7 @@ async def test_deploy_local_worker_source_env_branch(tmp_path, monkeypatch):
         f'uv --offline --project "{agi_node}" build --wheel' in cmd
         for cmd, _ in commands
     )
-    assert any(
-        f'uv --offline --project {wenv_abs} add --editable "{agi_env}" "{agi_node}"'
-        in cmd
-        for cmd, _ in commands
-    )
+    assert _has_worker_core_add_command(commands, wenv_abs, agi_env, agi_node)
     worker_python = _venv_python(wenv_abs)
     assert any(
         f'uv --offline venv --allow-existing --python 3.13 "{wenv_abs / ".venv"}"'
@@ -4089,11 +4089,7 @@ path = "../sat_trajectory_project"
         f'pip install --python "{manager_python}" --upgrade "{cluster_project}"' in cmd
         for cmd, _ in commands
     )
-    assert any(
-        f'add --editable "{env_project}" "{node_project}"' in cmd
-        and str(wenv_abs) in cmd
-        for cmd, _ in commands
-    )
+    assert _has_worker_core_add_command(commands, wenv_abs, env_project, node_project)
 
 
 @pytest.mark.asyncio

--- a/src/agilab/install_apps.sh
+++ b/src/agilab/install_apps.sh
@@ -135,6 +135,45 @@ START_TIME=$(date +%s)
 
 UV_PREVIEW=(uv --preview-features extra-build-dependencies)
 
+normalize_agi_python_version() {
+  local raw="${1:-3.14}"
+  raw="$(printf '%s' "$raw" | sed -E 's/^[[:space:]]+//;s/[[:space:]]+$//')"
+  [[ -n "$raw" ]] || raw="3.14"
+
+  case "${AGI_PYTHON_FREE_THREADED:-0}" in
+    1|true|TRUE|yes|YES|on|ON)
+      echo -e "${RED}Unsupported AGI_PYTHON_VERSION '${raw}': install_apps.sh requires a standard GIL Python interpreter. Freethreaded Python can force native dependency builds for binary-heavy packages such as Polars. Re-run with AGI_PYTHON_VERSION=3.14.6 or AGI_PYTHON_VERSION=3.13.14.${NC}" >&2
+      return 1
+      ;;
+  esac
+
+  if [[ "$raw" == *freethreaded* \
+     || "$raw" =~ (^|[^[:alnum:]])python3\.[0-9]+t([^[:alnum:]]|$) \
+     || "$raw" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?t($|[^[:alnum:]]) ]]; then
+    echo -e "${RED}Unsupported AGI_PYTHON_VERSION '${raw}': install_apps.sh requires a standard GIL Python interpreter. Freethreaded Python can force native dependency builds for binary-heavy packages such as Polars. Re-run with AGI_PYTHON_VERSION=3.14.6 or AGI_PYTHON_VERSION=3.13.14.${NC}" >&2
+    return 1
+  fi
+
+  local normalized=""
+  if [[ "$raw" =~ ^([0-9]+\.[0-9]+(\.[0-9]+)?)([^0-9].*)?$ ]]; then
+    normalized="${BASH_REMATCH[1]}"
+  elif [[ "$raw" =~ cpython-([0-9]+\.[0-9]+(\.[0-9]+)?)([^0-9].*)?$ ]]; then
+    normalized="${BASH_REMATCH[1]}"
+  elif [[ "$raw" =~ python([0-9]+\.[0-9]+(\.[0-9]+)?)([^0-9].*)?$ ]]; then
+    normalized="${BASH_REMATCH[1]}"
+  else
+    echo -e "${RED}Invalid AGI_PYTHON_VERSION '${raw}'. Expected versions like 3.14, 3.14.6, or 3.13.14.${NC}" >&2
+    return 1
+  fi
+
+  printf '%s\n' "$normalized"
+}
+
+if ! AGI_PYTHON_VERSION="$(normalize_agi_python_version "${AGI_PYTHON_VERSION:-3.14}")"; then
+  exit 1
+fi
+export AGI_PYTHON_VERSION
+
 configure_uv_link_mode() {
   local requested="${AGILAB_UV_LINK_MODE:-${UV_LINK_MODE:-hardlink}}"
   case "$requested" in
@@ -158,7 +197,6 @@ export AGILAB_SHARED_WORKER_VENV="${AGILAB_SHARED_WORKER_VENV:-1}"
 BUILTIN_PAGES_FROM_ENV="${BUILTIN_PAGES-}"
 BUILTIN_APPS_FROM_ENV="${BUILTIN_APPS_ENV-}"
 
-AGI_PYTHON_VERSION=$(echo "${AGI_PYTHON_VERSION:-}" | sed -E 's/^([0-9]+\.[0-9]+\.[0-9]+(\+freethreaded)?).*/\1/')
 AGILAB_REPO="$(cat "$HOME/.local/share/agilab/.agilab-path")"
 VENV_LINK_REPORT="${AGILAB_VENV_LINK_REPORT:-$HOME/.local/share/agilab/venv_link_report.json}"
 APPS_REPOSITORY="${APPS_REPOSITORY:-}"

--- a/src/agilab/install_apps.sh
+++ b/src/agilab/install_apps.sh
@@ -135,6 +135,22 @@ START_TIME=$(date +%s)
 
 UV_PREVIEW=(uv --preview-features extra-build-dependencies)
 
+python_uv_spec_for_version() {
+  local version="${1:-}"
+  case "$version" in
+    3.14|3.14.*)
+      if [[ "$version" == *+* ]]; then
+        printf '%s\n' "$version"
+      else
+        printf '%s+gil\n' "$version"
+      fi
+      ;;
+    *)
+      printf '%s\n' "$version"
+      ;;
+  esac
+}
+
 normalize_agi_python_version() {
   local raw="${1:-3.14}"
   raw="$(printf '%s' "$raw" | sed -E 's/^[[:space:]]+//;s/[[:space:]]+$//')"
@@ -172,7 +188,9 @@ normalize_agi_python_version() {
 if ! AGI_PYTHON_VERSION="$(normalize_agi_python_version "${AGI_PYTHON_VERSION:-3.14}")"; then
   exit 1
 fi
+AGI_PYTHON_UV_SPEC="${AGI_PYTHON_UV_SPEC:-$(python_uv_spec_for_version "$AGI_PYTHON_VERSION")}"
 export AGI_PYTHON_VERSION
+export AGI_PYTHON_UV_SPEC
 
 configure_uv_link_mode() {
   local requested="${AGILAB_UV_LINK_MODE:-${UV_LINK_MODE:-hardlink}}"
@@ -547,7 +565,7 @@ check_data_mount() {
   DATA_URI_PATH=""
 
   if ! output=$(
-    "${UV_PREVIEW[@]}" -q run -p "$AGI_PYTHON_VERSION" --project ../core/agi-cluster python - "$app_path" <<'PY' 2>&1
+    "${UV_PREVIEW[@]}" -q run -p "${AGI_PYTHON_UV_SPEC:-$AGI_PYTHON_VERSION}" --project ../core/agi-cluster python - "$app_path" <<'PY' 2>&1
 from pathlib import Path
 import sys
 from agi_env import AgiEnv
@@ -788,7 +806,7 @@ link_compatible_venvs() {
 
   mkdir -p -- "$(dirname "$VENV_LINK_REPORT")"
   echo -e "${BLUE}Linking compatible virtual environments...${NC}"
-  if "${UV_PREVIEW[@]}" run -p "$AGI_PYTHON_VERSION" --no-project --with packaging python "$linker" \
+  if "${UV_PREVIEW[@]}" run -p "${AGI_PYTHON_UV_SPEC:-$AGI_PYTHON_VERSION}" --no-project --with packaging python "$linker" \
     --apply \
     --report "$VENV_LINK_REPORT" \
     "${root_args[@]}"; then
@@ -1370,8 +1388,8 @@ for app in ${INCLUDED_APPS+"${INCLUDED_APPS[@]}"}; do
 	    echo "reuse wenv/$worker_env_name (set AGILAB_REFRESH_WORKER_ENVS=1 to rebuild)"
 	  fi
 
-  echo "${UV_PREVIEW[@]} -q run -p \"$AGI_PYTHON_VERSION\" --project ../core/agi-cluster python install.py \"${AGILAB_REPO}/apps/$app_dir_rel\""
-  if "${UV_PREVIEW[@]}" -q run -p "$AGI_PYTHON_VERSION" --project ../core/agi-cluster python install.py \
+  echo "${UV_PREVIEW[@]} -q run -p \"${AGI_PYTHON_UV_SPEC:-$AGI_PYTHON_VERSION}\" --project ../core/agi-cluster python install.py \"${AGILAB_REPO}/apps/$app_dir_rel\""
+  if "${UV_PREVIEW[@]}" -q run -p "${AGI_PYTHON_UV_SPEC:-$AGI_PYTHON_VERSION}" --project ../core/agi-cluster python install.py \
     "${AGILAB_REPO}/apps/$app_dir_rel"; then
       echo -e "${GREEN}✓ '$app_name' successfully installed.${NC}"
       if (( DO_TEST_APPS )); then
@@ -1379,8 +1397,8 @@ for app in ${INCLUDED_APPS+"${INCLUDED_APPS[@]}"}; do
         if pushd -- "$app_dir_rel" >/dev/null; then
         ran_app_test=0
         if [[ -f app_test.py ]]; then
-          echo "${UV_PREVIEW[@]} run -p \"$AGI_PYTHON_VERSION\" ${CORE_EDITABLE_PACKAGES[*]} python app_test.py"
-          "${UV_PREVIEW[@]}" run -p "$AGI_PYTHON_VERSION" "${CORE_EDITABLE_PACKAGES[@]}" python app_test.py
+          echo "${UV_PREVIEW[@]} run -p \"${AGI_PYTHON_UV_SPEC:-$AGI_PYTHON_VERSION}\" ${CORE_EDITABLE_PACKAGES[*]} python app_test.py"
+          "${UV_PREVIEW[@]}" run -p "${AGI_PYTHON_UV_SPEC:-$AGI_PYTHON_VERSION}" "${CORE_EDITABLE_PACKAGES[@]}" python app_test.py
           ran_app_test=1
         else
             if app_has_collectable_pytests .; then
@@ -1440,7 +1458,7 @@ for app in ${INCLUDED_APPS+"${INCLUDED_APPS[@]}"}; do
       popd >/dev/null
       continue
     fi
-    if "${UV_PREVIEW[@]}" run -p "$AGI_PYTHON_VERSION" "${CORE_EDITABLE_PACKAGES[@]}" --project . --with pytest --with pytest-cov pytest; then
+    if "${UV_PREVIEW[@]}" run -p "${AGI_PYTHON_UV_SPEC:-$AGI_PYTHON_VERSION}" "${CORE_EDITABLE_PACKAGES[@]}" --project . --with pytest --with pytest-cov pytest; then
       echo -e "${GREEN}✓ pytest succeeded for '$app_name'.${NC}"
       else
         rc=$?

--- a/src/agilab/orchestrate/orchestrate_execute.py
+++ b/src/agilab/orchestrate/orchestrate_execute.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shutil
 import stat
 import importlib
@@ -76,6 +77,31 @@ def _require_matplotlib(import_module_fn=importlib.import_module):
         _MATPLOTLIB_IMPORT_ERROR = exc
         raise RuntimeError(_matplotlib_unavailable_message()) from exc
     return plt
+
+
+def _major_minor_python_version(python_version: Any) -> tuple[int, int] | None:
+    match = re.match(r"\s*(\d+)\.(\d+)", str(python_version or ""))
+    if not match:
+        return None
+    return int(match.group(1)), int(match.group(2))
+
+
+def profile_report_disabled_reason_for_python(python_version: Any) -> str:
+    version = _major_minor_python_version(python_version)
+    if version is None:
+        return ""
+    if version < (3, 13):
+        return (
+            f"Stats report requires Python 3.13 with ydata-profiling; "
+            f"current Python is {python_version}."
+        )
+    if version >= (3, 14):
+        return (
+            "Stats report is disabled on Python 3.14 because ydata-profiling "
+            "depends on numba, which currently supports Python <3.14. "
+            "Use Python 3.13 for this report."
+        )
+    return ""
 
 
 def _is_networkx_graph(value: object) -> bool:
@@ -1426,6 +1452,17 @@ async def render_execute_section(
                 key="input_df_export_file_main",
             )
             st.session_state.df_export_file = export_file_input.strip()
+            profile_disabled_reason = profile_report_disabled_reason_for_python(
+                getattr(env, "python_version", "")
+            )
+            stats_button_enabled = (
+                artifact_state.stats_action.enabled and not profile_disabled_reason
+            )
+            stats_button_help = (
+                artifact_state.stats_action.disabled_reason
+                or profile_disabled_reason
+                or "Generate a dataframe statistics report."
+            )
 
             action_col_stats, action_col_export = st.columns([1, 1])
             with action_col_stats:
@@ -1433,8 +1470,9 @@ async def render_execute_section(
                     ORCHESTRATE_ACTION_LABELS["stats_report"],
                     key="stats_report_main",
                     type="primary",
-                    disabled=not artifact_state.stats_action.enabled,
+                    disabled=not stats_button_enabled,
                     width="stretch",
+                    help=stats_button_help,
                 )
             with action_col_export:
                 export_clicked_manual = st.button(

--- a/src/agilab/pages/2_ORCHESTRATE.py
+++ b/src/agilab/pages/2_ORCHESTRATE.py
@@ -296,6 +296,7 @@ import_agilab_symbols(
     "agilab.orchestrate_execute",
     {
         "OrchestrateExecuteDeps": "OrchestrateExecuteDeps",
+        "profile_report_disabled_reason_for_python": "profile_report_disabled_reason_for_python",
         "render_execute_section": "render_execute_section",
     },
     current_file=__file__,
@@ -1331,15 +1332,15 @@ async def _install_worker_action(
 @st.cache_data(show_spinner=False)
 def generate_profile_report(df: Any) -> Any:
     env = st.session_state["env"]
-    if env.python_version > "3.12":
-        from ydata_profiling.profile_report import ProfileReport
-
-        return ProfileReport(df, minimal=True)
-    else:
-        st.info(
-            f"Function not available with this version of Python {env.python_version}."
-        )
+    disabled_reason = profile_report_disabled_reason_for_python(
+        getattr(env, "python_version", "")
+    )
+    if disabled_reason:
+        st.info(disabled_reason)
         return None
+    from ydata_profiling.profile_report import ProfileReport
+
+    return ProfileReport(df, minimal=True)
 
 
 # ===========================

--- a/src/agilab/uv_config.toml
+++ b/src/agilab/uv_config.toml
@@ -1,5 +1,5 @@
 
  override-dependencies = [
     "streamlit-pandas-profiling",
-    "ydata-profiling",
+    "ydata-profiling; python_version < '3.14'",
  ]

--- a/test/test_install_apps_discovery.py
+++ b/test/test_install_apps_discovery.py
@@ -220,6 +220,29 @@ printf 'PROMPT_FOR_APPS=%s\n' "$PROMPT_FOR_APPS"
     return result
 
 
+def _run_normalize_agi_python_version(raw: str, *, free_threaded: str = "0") -> subprocess.CompletedProcess[str]:
+    script_text = INSTALL_APPS_SH.read_text(encoding="utf-8")
+    function_body = _extract_function(
+        script_text,
+        "normalize_agi_python_version",
+        "configure_uv_link_mode",
+    )
+    bash_script = f"""#!/usr/bin/env bash
+set -euo pipefail
+RED=""
+NC=""
+AGI_PYTHON_FREE_THREADED="$2"
+{function_body}
+normalize_agi_python_version "$1"
+"""
+    return subprocess.run(
+        ["bash", "-c", bash_script, "normalize_agi_python_version_test", raw, free_threaded],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
 def test_page_discovery_keeps_only_installable_entrypoint_projects(tmp_path: Path) -> None:
     pages_root = tmp_path / "apps-pages"
     _write_page_project(pages_root / "view_demo")
@@ -359,3 +382,40 @@ def test_install_apps_cli_selection_normalization(
 
     assert result["BUILTIN_APPS_FROM_ENV"] == expected_value
     assert result["PROMPT_FOR_APPS"] == expected_prompt
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("3.14", "3.14"),
+        ("3.14.6-macos-aarch64-none", "3.14.6"),
+        ("cpython-3.13.14-macos-aarch64-none", "3.13.14"),
+        ("/opt/homebrew/bin/python3.14", "3.14"),
+    ],
+)
+def test_install_apps_python_version_normalization_accepts_standard_interpreters(
+    raw: str,
+    expected: str,
+) -> None:
+    result = _run_normalize_agi_python_version(raw)
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == expected
+
+
+@pytest.mark.parametrize(
+    ("raw", "free_threaded"),
+    [
+        ("3.14.6+freethreaded-macos-aarch64-none", "0"),
+        ("/Users/agi/.local/bin/python3.14t", "0"),
+        ("3.14.6", "1"),
+    ],
+)
+def test_install_apps_python_version_normalization_rejects_freethreaded_interpreters(
+    raw: str,
+    free_threaded: str,
+) -> None:
+    result = _run_normalize_agi_python_version(raw, free_threaded=free_threaded)
+
+    assert result.returncode == 1
+    assert "standard GIL Python interpreter" in result.stderr

--- a/test/test_install_python_selection.py
+++ b/test/test_install_python_selection.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ROOT_INSTALLER = REPO_ROOT / "install.sh"
+CORE_INSTALLER = REPO_ROOT / "src/agilab/core/install.sh"
+
+
+def _extract_shell_function(text: str, name: str) -> str:
+    match = re.search(rf"^{name}\(\)" + r".*?^}", text, re.MULTILINE | re.DOTALL)
+    assert match, f"{name}() not found"
+    return match.group(0)
+
+
+def test_root_installer_does_not_enable_freethreaded_python_by_default() -> None:
+    choose_python_version = _extract_shell_function(ROOT_INSTALLER.read_text(encoding="utf-8"), "choose_python_version")
+
+    assert "chosen_python_free=" not in choose_python_version
+    assert "AGI_PYTHON_FREE_THREADED=1" not in choose_python_version
+    assert "AGI_PYTHON_FREE_THREADED=0" in choose_python_version
+    assert "No standard CPython interpreter found" in choose_python_version
+
+
+def test_installers_repair_incompatible_generated_virtualenvs() -> None:
+    root_text = ROOT_INSTALLER.read_text(encoding="utf-8")
+    core_text = CORE_INSTALLER.read_text(encoding="utf-8")
+
+    assert "remove_incompatible_project_venv" in root_text
+    assert 'remove_incompatible_project_venv "$AGI_INSTALL_PATH" "repository root"' in root_text
+    assert "remove_incompatible_project_venv" in core_text
+    for package in ("agi-env", "agi-node", "agi-cluster", "agi-core"):
+        assert f'remove_incompatible_project_venv "$PWD" "{package}"' in core_text
+    assert 'rm -rf -- "$venv_dir"' in core_text
+    assert "sys.abiflags" in core_text
+
+
+def test_core_installer_rejects_freethreaded_python_version_text() -> None:
+    core_text = CORE_INSTALLER.read_text(encoding="utf-8")
+    normalize = _extract_shell_function(core_text, "normalize_agi_python_version")
+
+    assert "*freethreaded*" in normalize
+    assert "python3\\.[0-9]+t" in normalize
+    assert "standard GIL Python interpreter" in normalize

--- a/test/test_orchestrate_page_helpers.py
+++ b/test/test_orchestrate_page_helpers.py
@@ -266,6 +266,24 @@ def test_orchestrate_page_raises_mixed_checkout_error(monkeypatch, tmp_path):
         _load_orchestrate_module_with_mixed_checkout(monkeypatch, stale_root)
 
 
+def test_orchestrate_stats_report_is_disabled_on_unsupported_python_versions():
+    module = _load_orchestrate_module()
+
+    assert module.profile_report_disabled_reason_for_python("3.13.14") == ""
+    assert "requires Python 3.13" in module.profile_report_disabled_reason_for_python(
+        "3.12.11"
+    )
+    assert "disabled on Python 3.14" in module.profile_report_disabled_reason_for_python(
+        "3.14.6"
+    )
+
+    execute_source = Path("src/agilab/orchestrate/orchestrate_execute.py").read_text(
+        encoding="utf-8"
+    )
+    assert "stats_button_enabled" in execute_source
+    assert "disabled=not stats_button_enabled" in execute_source
+
+
 def test_page_helpers_delegate_scheduler_worker_and_safe_eval(monkeypatch):
     module = _load_orchestrate_page_helpers_module()
     captured = {}


### PR DESCRIPTION
## Summary

- harden source installers so Python 3.14 installs reject freethreaded interpreters and repair incompatible generated virtual environments
- keep dev-only `ydata-profiling` out of Python 3.14 installs because its `numba` dependency currently supports Python `<3.14`
- disable ORCHESTRATE `STATS report` on Python 3.14 with an explicit help message, while preserving Python 3.13 support
- add `install_private_apps_and_run.sh` for source checkout plus external apps installs and document the Python 3.14 limitation in the README

## Repro

A source install with `AGI_PYTHON_VERSION=3.14.6` selected a freethreaded interpreter during core/app environment creation, causing `polars-runtime-32` to build from source against CPython `3.14t`. After forcing standard Python, the repo-root sync pulled dev-only `ydata-profiling -> numba`, and `numba 0.62.1` rejected Python 3.14 with `only versions >=3.10,<3.14 are supported`.

## Root Cause

The installer allowed freethreaded Python state to leak into generated environments, and the normal source install path pulled dev dependencies that are not Python 3.14-compatible. The profiling report also remained available in the UI even though the optional profiling stack cannot run on Python 3.14.

## Regression Test

Added focused regression coverage for:

- installer Python normalization and freethreaded rejection
- root/core installer generated-venv repair contracts
- Python 3.14 stats-report disablement helper and ORCHESTRATE button wiring

Local targeted tests were not run in this turn; GitHub checks are expected to validate the PR.

## Validation

- `./dev scope` reported the intended mixed installer/UI/docs/test scope
- `python3 tools/agent_commit_provenance_guard.py --check-config` passed
- `uv --preview-features extra-build-dependencies lock` refreshed the lock after the dependency marker change
- local tests not run at user request pace; CI should run on this PR

## Agent Metadata

- Tokki version: `tokki 1.0.19`
- Agent/runtime: Codex CLI, GPT-5 Codex
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used


Follow-up validation after Python 3.14 app-install fix:
- Diagnosed previous `install_apps failed; continuing with PyCharm setup` warning by rerunning install with captured output.
- Root cause: global `UV_PYTHON_PREFERENCE=only-system` prevented uv-managed page Python versions, and worker sync used bare `3.14.6`, allowing Python 3.14 freethreaded selection; `charset-normalizer==3.4.8` also lacked a usable cp314 artifact in this install path.
- Fix: use `AGI_PYTHON_UV_SPEC=3.14.6+gil` for uv selection while preserving `AGI_PYTHON_VERSION=3.14.6` for matching/cache metadata, and constrain `charset-normalizer<3.4.8` only for Python 3.14.
- Validation: `./install_apps.sh --install-apps flight_telemetry_project` with `AGI_PYTHON_VERSION=3.14.6 AGI_PYTHON_UV_SPEC=3.14.6+gil AGILAB_REFRESH_WORKER_ENVS=1` passed, including worker sync and post-install.
- Validation: `bash -n install.sh install_private_apps_and_run.sh src/agilab/install_apps.sh src/agilab/core/install.sh` passed.
- Validation: `uv --preview-features extra-build-dependencies run python -m py_compile ...` for edited Python install/deploy files passed.


Additional follow-up after workflow traceback:
- Root cause: the `worker-core-add-*` deploy stage still ran `uv add --editable ...` without `--python`, so uv relocked with CPython 3.14t even after worker sync used `3.14.6+gil`.
- Fix: `_build_worker_core_add_commands()` now accepts `python_spec` and `deploy_local_worker()` passes the worker uv selector (`3.14.6+gil`).
- Validation: focused regression `pytest -q src/agilab/core/test/test_agi_distributor_deployment_local_support.py -k build_worker_core_add_commands` passed.
- Validation: direct private `flight_trajectory_project` install slice passed with `AGI_PYTHON_VERSION=3.14.6 AGI_PYTHON_UV_SPEC=3.14.6+gil`, including the previously failing `worker-core-add` command, worker sync, and post-install.


Windows CI follow-up:
- Root cause: Windows core tests still asserted a contiguous `uv add --editable ...` substring; the new command correctly inserts `--python 3.14.6+gil` before `--editable`.
- Fix: stabilized worker core-add test assertions to check command semantics instead of brittle option adjacency.
- Validation: `pytest -q src/agilab/core/test/test_agi_distributor_deployment_local_support.py -k 'build_worker_core_add_commands or install_type_zero_non_source_covers_dependency_flow or preserves_existing_dependency_ranges or infers_repo_root_to_avoid_rewriting_source_app or source_env_branch or offline_manager_overlay_preserves_local_sources'` passed.
