### PR TITLE
Respect Python requirements during installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,12 @@ but the ORCHESTRATE dataframe `STATS report` action is disabled on Python 3.14
 because the optional `ydata-profiling` stack currently depends on `numba`, which
 supports Python `<3.14`. Use Python 3.13 when that profiling report is required:
 
+When `AGI_PYTHON_VERSION` resolves to Python 3.14, AGILAB passes a `+gil` uv
+selector internally so app managers, workers, and broadly compatible page bundles
+avoid CPython 3.14 freethreaded builds. Page bundles with stricter
+`requires-python` metadata, such as `==3.12.*`, receive a compatible selector
+such as `3.12` instead of being forced onto the global 3.14 runtime.
+
 ```bash
 AGI_PYTHON_VERSION=3.13.14 APPS_REPO="/path/to/private-or-external-apps-repo" ./install_private_apps_and_run.sh
 ```

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 277,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "e269f8bcb563e43e349451bf59b168ecec24a4d7669336690c2f1cafd59ad585",
+  "source_digest_sha256": "4403df88f1e58b1117d2bbd6aba9c28d6d85b160ca5b54a6b1e0ad36cf01ec38",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "e269f8bcb563e43e349451bf59b168ecec24a4d7669336690c2f1cafd59ad585"
+  "target_digest_sha256": "4403df88f1e58b1117d2bbd6aba9c28d6d85b160ca5b54a6b1e0ad36cf01ec38"
 }

--- a/docs/source/environment.rst
+++ b/docs/source/environment.rst
@@ -27,6 +27,9 @@ rather than shown as one of the workflow pages.
    * - ``AGI_PYTHON_VERSION``
      - ``3.14``
      - Default Python version passed to ``uv`` for the manager environment and as the fallback worker version when no host-specific override is set.
+   * - ``AGI_PYTHON_UV_SPEC``
+     - derived from ``AGI_PYTHON_VERSION``
+     - Exact uv interpreter selector used by installer sync commands. For Python 3.14 this defaults to the standard GIL build, for example ``3.14+gil``, while page bundles with stricter ``requires-python`` metadata receive a compatible selector such as ``3.12`` for ``==3.12.*``.
    * - ``<worker-host>_PYTHON_VERSION``
      - unset
      - Optional worker-specific Python version override written per host (for example ``127.0.0.1_PYTHON_VERSION=3.13``). Use this when workers must run a different Python version than the manager side.

--- a/docs/source/quick-start.rst
+++ b/docs/source/quick-start.rst
@@ -390,6 +390,12 @@ For an external apps repository available on your machine::
       --test-apps \
       --test-core
 
+When ``AGI_PYTHON_VERSION`` resolves to Python 3.14, the source installer uses
+the matching uv ``+gil`` selector for app managers, workers, and page bundles
+whose ``requires-python`` range accepts that runtime. Page bundles that pin or
+cap Python differently, for example ``==3.12.*``, receive a compatible selector
+such as ``3.12`` instead of being forced onto the global runtime.
+
 For a trusted app project published as a PyPI ``agi-app-*`` package, use either
 the web UI or the packaged CLI. In the UI, open ``PROJECT``, expand
 ``agi-app from PyPI``, choose a promoted catalog ``agi-app`` or enter an exact

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_local_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_local_support.py
@@ -135,6 +135,10 @@ def _worker_python_uv_spec(env: Any, fallback: str | None) -> str | None:
     )
 
 
+def _manager_python_uv_spec(env: Any, fallback: str | None) -> str | None:
+    return getattr(env, "python_uv_spec", None) or fallback
+
+
 def _compose_worker_post_install_tool(local_env_prefix: str, uv_worker: Any) -> str:
     uv_fragment = str(uv_worker or "").strip()
     local_prefix = str(local_env_prefix or "").strip()
@@ -1023,6 +1027,12 @@ async def deploy_local_worker(
     uv = resolver_env_prefix + cmd_prefix + env.uv
     offline_flag = _uv_offline_flag(envars)
     pyvers = env.python_version
+    pyvers_manager_uv_spec = _manager_python_uv_spec(env, pyvers)
+    manager_python_arg = (
+        f" --python {_shell_arg(pyvers_manager_uv_spec)}"
+        if pyvers_manager_uv_spec
+        else ""
+    )
     stage_cache_enabled = _deploy_stage_cache_enabled(getattr(env, "envars", {}))
     stage_cache_path = _deploy_stage_cache_path(wenv_abs)
     stage_cache_state = (
@@ -1126,12 +1136,12 @@ async def deploy_local_worker(
             )
             if hw_rapids_capable:
                 cmd_manager = (
-                    f"{extra_indexes}{uv} {offline_flag}{run_type} --config-file uv_config.toml "
+                    f"{extra_indexes}{uv} {offline_flag}{run_type}{manager_python_arg} --config-file uv_config.toml "
                     f"--project '{manager_sync_project}' --active --no-install-project"
                 )
             else:
                 cmd_manager = (
-                    f"{extra_indexes}{uv} {offline_flag}{run_type} --project '{manager_sync_project}' "
+                    f"{extra_indexes}{uv} {offline_flag}{run_type}{manager_python_arg} --project '{manager_sync_project}' "
                     f"--active --no-install-project"
                 )
             if env.verbose > 0:
@@ -1139,10 +1149,10 @@ async def deploy_local_worker(
             await run_fn(cmd_manager, app_path)
     else:
         if hw_rapids_capable:
-            cmd_manager = f"{extra_indexes}{uv} {offline_flag}{run_type} --config-file uv_config.toml --project '{app_path}'"
+            cmd_manager = f"{extra_indexes}{uv} {offline_flag}{run_type}{manager_python_arg} --config-file uv_config.toml --project '{app_path}'"
         else:
             cmd_manager = (
-                f"{extra_indexes}{uv} {offline_flag}{run_type} --project '{app_path}'"
+                f"{extra_indexes}{uv} {offline_flag}{run_type}{manager_python_arg} --project '{app_path}'"
             )
         if env.verbose > 0:
             log.info(f"Installing manager: {cmd_manager}")

--- a/src/agilab/core/test/test_agi_distributor_deployment_local_support.py
+++ b/src/agilab/core/test/test_agi_distributor_deployment_local_support.py
@@ -2953,7 +2953,8 @@ async def test_deploy_local_worker_rapids_reuses_cli_and_falls_back_from_localho
         for cmd, _ in commands
     )
     assert any(
-        "uv sync --config-file uv_config.toml --project" in cmd and str(app_path) in cmd
+        "uv sync --python 3.13 --config-file uv_config.toml --project" in cmd
+        and str(app_path) in cmd
         for cmd, _ in commands
     )
     assert any(

--- a/src/agilab/core/test/test_agi_distributor_deployment_local_support.py
+++ b/src/agilab/core/test/test_agi_distributor_deployment_local_support.py
@@ -4069,7 +4069,8 @@ path = "../sat_trajectory_project"
     )
     assert "sb3_trainer_project" not in overlay_sources
     assert any(
-        "sync --project" in cmd
+        "sync " in cmd
+        and "--project" in cmd
         and "--active --no-install-project" in cmd
         and str(staged_overlay_root) in cmd
         for cmd, _ in commands

--- a/src/agilab/install_apps.sh
+++ b/src/agilab/install_apps.sh
@@ -520,6 +520,7 @@ page_sync_fingerprint() {
   local page_dir="$1"
   local rel file
   printf 'python=%s\n' "${AGI_PYTHON_VERSION:-}"
+  printf 'python-sync-spec=%s\n' "$(page_sync_python_spec "$page_dir")"
   for rel in pyproject.toml uv.lock uv.toml; do
     file="$page_dir/$rel"
     if [[ -f "$file" ]]; then
@@ -529,6 +530,52 @@ page_sync_fingerprint() {
       printf '%s:missing\n' "$rel"
     fi
   done
+}
+
+page_sync_python_spec() {
+  local page_dir="$1"
+  local pyproject="$page_dir/pyproject.toml"
+  local requires_python=""
+  local selected_major="" selected_minor=""
+  local exact_re='==[[:space:]]*([0-9]+)\.([0-9]+)'
+  local upper_re='<[[:space:]]*([0-9]+)\.([0-9]+)'
+
+  if [[ -f "$pyproject" ]]; then
+    requires_python="$(
+      sed -n -E 's/^[[:space:]]*requires-python[[:space:]]*=[[:space:]]*"([^"]*)".*/\1/p' "$pyproject" | head -n 1
+    )"
+  fi
+
+  if [[ "${AGI_PYTHON_VERSION:-}" =~ ^([0-9]+)\.([0-9]+) ]]; then
+    selected_major="${BASH_REMATCH[1]}"
+    selected_minor="${BASH_REMATCH[2]}"
+  fi
+
+  if [[ -n "$requires_python" && "$requires_python" =~ $exact_re ]]; then
+    local exact_major="${BASH_REMATCH[1]}"
+    local exact_minor="${BASH_REMATCH[2]}"
+    if [[ -n "$selected_major" && "${exact_major}.${exact_minor}" != "${selected_major}.${selected_minor}" ]]; then
+      printf '%s.%s\n' "$exact_major" "$exact_minor"
+      return 0
+    fi
+  fi
+
+  if [[ -n "$requires_python" && "$requires_python" =~ $upper_re ]]; then
+    if [[ -n "$selected_major" ]]; then
+      local upper_major="${BASH_REMATCH[1]}"
+      local upper_minor="${BASH_REMATCH[2]}"
+      if (( selected_major > upper_major || (selected_major == upper_major && selected_minor >= upper_minor) )); then
+        if (( upper_minor > 0 )); then
+          printf '%s.%s\n' "$upper_major" "$((upper_minor - 1))"
+        elif (( upper_major > 0 )); then
+          printf '%s\n' "$((upper_major - 1))"
+        fi
+        return 0
+      fi
+    fi
+  fi
+
+  printf '%s\n' "${AGI_PYTHON_UV_SPEC:-$AGI_PYTHON_VERSION}"
 }
 
 page_sync_is_fresh() {
@@ -1332,7 +1379,12 @@ for page in ${INCLUDED_PAGES+"${INCLUDED_PAGES[@]}"}; do
     if page_sync_is_fresh "$page_dir"; then
         echo -e "${GREEN}✓ '$page' page environment already up to date.${NC}"
     else
-        if ${UV_PREVIEW[@]} sync -p "${AGI_PYTHON_UV_SPEC:-$AGI_PYTHON_VERSION}" --project . --preview-features python-upgrade; then
+        page_python_spec="$(page_sync_python_spec "$page_dir")"
+        page_python_args=()
+        if [[ -n "$page_python_spec" ]]; then
+            page_python_args=(-p "$page_python_spec")
+        fi
+        if ${UV_PREVIEW[@]} sync "${page_python_args[@]}" --project . --preview-features python-upgrade; then
             write_page_sync_stamp "$page_dir"
         else
             status=$?

--- a/src/agilab/install_apps.sh
+++ b/src/agilab/install_apps.sh
@@ -1332,7 +1332,7 @@ for page in ${INCLUDED_PAGES+"${INCLUDED_PAGES[@]}"}; do
     if page_sync_is_fresh "$page_dir"; then
         echo -e "${GREEN}✓ '$page' page environment already up to date.${NC}"
     else
-        if ${UV_PREVIEW[@]} sync --project . --preview-features python-upgrade; then
+        if ${UV_PREVIEW[@]} sync -p "${AGI_PYTHON_UV_SPEC:-$AGI_PYTHON_VERSION}" --project . --preview-features python-upgrade; then
             write_page_sync_stamp "$page_dir"
         else
             status=$?

--- a/test/test_install_apps_discovery.py
+++ b/test/test_install_apps_discovery.py
@@ -222,6 +222,11 @@ printf 'PROMPT_FOR_APPS=%s\n' "$PROMPT_FOR_APPS"
 
 def _run_normalize_agi_python_version(raw: str, *, free_threaded: str = "0") -> subprocess.CompletedProcess[str]:
     script_text = INSTALL_APPS_SH.read_text(encoding="utf-8")
+    python_uv_spec_body = _extract_function(
+        script_text,
+        "python_uv_spec_for_version",
+        "normalize_agi_python_version",
+    )
     function_body = _extract_function(
         script_text,
         "normalize_agi_python_version",
@@ -232,6 +237,7 @@ set -euo pipefail
 RED=""
 NC=""
 AGI_PYTHON_FREE_THREADED="$2"
+{python_uv_spec_body}
 {function_body}
 normalize_agi_python_version "$1"
 """
@@ -241,6 +247,42 @@ normalize_agi_python_version "$1"
         capture_output=True,
         text=True,
     )
+
+
+def _run_page_sync_python_spec(
+    page_dir: Path,
+    *,
+    agi_python_version: str = "3.14.6",
+    agi_python_uv_spec: str = "3.14.6+gil",
+) -> str:
+    script_text = INSTALL_APPS_SH.read_text(encoding="utf-8")
+    function_body = _extract_function(
+        script_text,
+        "page_sync_python_spec",
+        "page_sync_is_fresh",
+    )
+    bash_script = f"""#!/usr/bin/env bash
+set -euo pipefail
+AGI_PYTHON_VERSION="$2"
+AGI_PYTHON_UV_SPEC="$3"
+{function_body}
+page_sync_python_spec "$1"
+"""
+    completed = subprocess.run(
+        [
+            "bash",
+            "-c",
+            bash_script,
+            "page_sync_python_spec_test",
+            str(page_dir),
+            agi_python_version,
+            agi_python_uv_spec,
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout.strip()
 
 
 def test_page_discovery_keeps_only_installable_entrypoint_projects(tmp_path: Path) -> None:
@@ -253,6 +295,34 @@ def test_page_discovery_keeps_only_installable_entrypoint_projects(tmp_path: Pat
     (pages_root / "view_notes").mkdir(parents=True)
 
     assert _run_discover_page_projects(pages_root) == ["view_demo"]
+
+
+@pytest.mark.parametrize(
+    ("requires_python", "expected"),
+    [
+        (">=3.11", "3.14.6+gil"),
+        ("==3.14.*", "3.14.6+gil"),
+        ("==3.12.*", "3.12"),
+        (">=3.11,<3.14", "3.13"),
+    ],
+)
+def test_page_sync_python_spec_respects_page_python_requirements(
+    tmp_path: Path,
+    requires_python: str,
+    expected: str,
+) -> None:
+    page_dir = tmp_path / "view_demo"
+    _write_page_project(page_dir)
+    pyproject = page_dir / "pyproject.toml"
+    pyproject.write_text(
+        pyproject.read_text(encoding="utf-8").replace(
+            'requires-python = ">=3.11"',
+            f'requires-python = "{requires_python}"',
+        ),
+        encoding="utf-8",
+    )
+
+    assert _run_page_sync_python_spec(page_dir) == expected
 
 
 def test_app_discovery_accepts_declared_workerless_projects(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- make apps-pages installation choose an explicit Python selector per page project
- pass the resolved AGILAB Python selector into app manager `uv sync` so external app managers do not select CPython 3.14 freethreaded
- document the Python 3.14 `+gil` behavior and page-specific `requires-python` exception

## Repro

Installing private apps/pages on Python 3.14 exposed two selector leaks:

- page sync for `view_relay_resilience` used bare `uv sync --project .`, so uv could select CPython `3.14t` and build `polars-runtime-32` from source
- forcing every page to `3.14.6+gil` broke pages such as `autoencoder_latentspace` that declare `requires-python = "==3.12.*"`
- app manager sync for projects such as `link_sim_project` still ran bare `uv sync --dev --project <app>`, so manager installs could also select `3.14t`

## Root Cause

The earlier Python 3.14 fix covered core, worker sync, and worker core-add paths, but not all installer sync surfaces. Apps-pages need a page-aware selector because page bundles can have stricter Python requirements than the global AGILAB runtime. External app managers need the manager-side AGILAB selector to avoid freethreaded Python 3.14 resolution.

## Regression Test

Added focused regression coverage for:

- page selector selection: broad pages use `3.14.6+gil`, `==3.12.*` pages use `3.12`, and `<3.14` pages use a compatible pre-3.14 selector
- manager sync command construction includes the manager Python selector

## Validation

- `bash -n src/agilab/install_apps.sh` passed
- `pytest -q test/test_install_apps_discovery.py -k 'page_sync_python_spec or python_version_normalization'` passed
- `pytest -q src/agilab/core/test/test_agi_distributor_deployment_local_support.py -k 'rapids_reuses_cli_and_falls_back_from_localhost_ssh or build_worker_core_add_commands'` passed
- `python tools/sync_docs_source.py --verify-stamp` passed

## Agent Metadata

- Tokki version: `tokki 1.0.19`
- Agent/runtime: Codex CLI, GPT-5 Codex
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used


Windows CI follow-up:
- Root cause: one Windows core test still asserted the contiguous substring `sync --project`; the manager sync command now correctly inserts `--python 3.13` before `--project`.
- Fix: stabilized the assertion to check command semantics instead of option adjacency.
- Validation: `pytest -q src/agilab/core/test/test_agi_distributor_deployment_local_support.py -k 'offline_manager_overlay_preserves_local_sources'` passed.
