### PR TITLE
[codex] Fix audit runtime installer hardening

### DIFF
--- a/src/agilab/apps/install.py
+++ b/src/agilab/apps/install.py
@@ -591,15 +591,19 @@ def _workerless_uv_sync_command(env: AgiEnv) -> list[str]:
         "--project",
         str(Path(getattr(env, "active_app", "")).expanduser()),
     ]
-    python_version = str(
+    python_version = _install_python_uv_spec(env)
+    if python_version:
+        command.extend(["-p", python_version])
+    return command
+
+
+def _install_python_uv_spec(env: AgiEnv) -> str:
+    return str(
         getattr(env, "python_uv_spec", "")
         or os.environ.get("AGI_PYTHON_UV_SPEC", "")
         or getattr(env, "python_version", "")
         or os.environ.get("AGI_PYTHON_VERSION", "")
     ).strip()
-    if python_version:
-        command.extend(["-p", python_version])
-    return command
 
 
 def _child_uv_env() -> dict[str, str]:
@@ -657,7 +661,11 @@ def _compute_install_fingerprint(
         "is_source_env": bool(getattr(env, "is_source_env", False)),
         "post_install_rel": str(getattr(env, "post_install_rel", "")),
         "python_version": str(getattr(env, "python_version", "")),
+        "python_uv_spec": _install_python_uv_spec(env),
         "pyvers_worker": str(getattr(env, "pyvers_worker", "")),
+        "pyvers_worker_uv_spec": str(
+            getattr(env, "pyvers_worker_uv_spec", "") or _install_python_uv_spec(env)
+        ),
         "uv": str(getattr(env, "uv", "")),
         "uv_worker": str(getattr(env, "uv_worker", "")),
         "uv_version": _uv_version(getattr(env, "uv", "uv")),

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_local_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_local_support.py
@@ -1508,6 +1508,7 @@ async def deploy_local_worker(
         cmd_worker = deployment_dask_support.dask_runtime_install_command(
             uv_worker,
             wenv_abs,
+            pyvers=pyvers_worker_uv_spec,
             offline_flag=offline_flag,
         )
         if env.verbose > 0:

--- a/src/agilab/core/test/test_agi_distributor_deployment_local_support.py
+++ b/src/agilab/core/test/test_agi_distributor_deployment_local_support.py
@@ -2964,7 +2964,7 @@ async def test_deploy_local_worker_rapids_reuses_cli_and_falls_back_from_localho
     )
     wenv_token = wenv_abs.as_posix()
     assert any(
-        f"--project {wenv_token}" in cmd and "add 'dask[distributed]'" in cmd
+        f"--project {wenv_token}" in cmd and "add -p 3.13 'dask[distributed]'" in cmd
         for cmd, _ in commands
     )
     assert not any(

--- a/src/agilab/security/secret_uri.py
+++ b/src/agilab/security/secret_uri.py
@@ -205,6 +205,8 @@ def redact_mapping(values: Mapping[str, Any]) -> dict[str, Any]:
                 redact_mapping(item) if isinstance(item, Mapping) else redact_text(item)
                 for item in value
             ]
+        elif isinstance(value, str):
+            redacted[key_text] = redact_text(value)
         else:
-            redacted[key_text] = redact_text(value) if is_secret_uri(value) else value
+            redacted[key_text] = value
     return redacted

--- a/test/test_app_installer_packaging.py
+++ b/test/test_app_installer_packaging.py
@@ -551,6 +551,12 @@ def test_install_state_cache_hits_only_when_fingerprint_and_venvs_match(
         "install fingerprint unchanged",
     )
 
+    env.python_uv_spec = "3.13+gil"
+    hit, reason = module._install_state_matches(env, modes_enabled=6, scheduler="127.0.0.1")
+    assert hit is False
+    assert reason == "install fingerprint changed"
+    env.python_uv_spec = ""
+
     (app_path / "pyproject.toml").write_text(
         "[project]\nname='demo-project'\ndependencies=['numpy']\n",
         encoding="utf-8",

--- a/test/test_secret_uri.py
+++ b/test/test_secret_uri.py
@@ -157,6 +157,8 @@ def test_redaction_helpers_remove_secret_values_and_secret_refs() -> None:
     payload = {
         "OPENAI_API_KEY": "sk-real-secret",
         "safe": "value",
+        "neutral_model_id": "prefix sk-proj-abcdefghijklmnopqrstuvwxyz1234567890 suffix",
+        "neutral_header": "Bearer github_pat_abcdefghijklmnopqrstuvwxyz1234567890",
         "nested": {"token_ref": "env://OPENAI_API_KEY"},
         "items": ["TOKEN=abc123", standalone, {"password": "abc123"}],
     }
@@ -170,6 +172,8 @@ def test_redaction_helpers_remove_secret_values_and_secret_refs() -> None:
 
     assert redacted["OPENAI_API_KEY"] == "<redacted>"
     assert redacted["safe"] == "value"
+    assert redacted["neutral_model_id"] == "prefix <redacted> suffix"
+    assert redacted["neutral_header"] == "Bearer <redacted>"
     assert redacted["nested"]["token_ref"] == "<redacted>"
     assert redacted["items"][0] == "TOKEN=<redacted>"
     assert redacted["items"][1] == "Bearer <redacted> and <redacted>"


### PR DESCRIPTION
## Summary

- Redact common scalar secrets under neutral manifest keys by applying the existing token redactor to all string mapping values.
- Keep local Dask worker runtime installs on the selected non-free-threaded Python by passing the worker Python selector into the Dask `uv add` command.
- Include resolved manager and worker Python selectors in the app install-state fingerprint so changing `3.14.6` versus `3.14.6+gil` invalidates stale install cache state.

## Repro

- Audit finding: MCP manifest reads used `redact_mapping`, but neutral scalar values containing common API tokens were not redacted unless the key looked secret-like or the value was an explicit secret URI.
- Audit finding: local worker Dask runtime install called `dask_runtime_install_command(...)` without `pyvers`, allowing nested `uv add dask[distributed]` to resolve the wrong Python variant.
- Audit finding: app install-state fingerprints tracked `python_version` and `pyvers_worker`, but not the resolved uv Python selector used by workerless manager syncs and worker installs.

## Root Cause

- `redact_mapping` only called `redact_text` for list items and explicit secret URI scalar values.
- `deployment_local_support.deploy_local_worker` did not pass `pyvers_worker_uv_spec` into the local Dask runtime install helper.
- `_compute_install_fingerprint` did not include the resolved `python_uv_spec` or `pyvers_worker_uv_spec` selectors, even though install commands use them.

## Regression Test

- `test/test_secret_uri.py` now covers common token and bearer-token redaction under neutral keys.
- `test/test_app_installer_packaging.py` now proves changing `python_uv_spec` invalidates the install fingerprint.
- `src/agilab/core/test/test_agi_distributor_deployment_local_support.py` now asserts local Dask runtime installs include `add -p 3.13 'dask[distributed]'`.

## Validation

- `env UV_PROJECT_ENVIRONMENT=.venv-validation-py313 uv --preview-features extra-build-dependencies run -p 3.13.14 pytest -q -o addopts='' test/test_secret_uri.py test/test_app_installer_packaging.py src/agilab/core/test/test_agi_distributor_deployment_local_support.py -k 'redaction_helpers or install_state_cache or rapids_reuses_cli'`
- `env UV_PROJECT_ENVIRONMENT=.venv-validation-py313 uv --preview-features extra-build-dependencies run -p 3.13.14 python tools/impact_validate.py --files src/agilab/security/secret_uri.py src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_local_support.py src/agilab/apps/install.py test/test_secret_uri.py test/test_app_installer_packaging.py src/agilab/core/test/test_agi_distributor_deployment_local_support.py`
- `git diff --check`
- `env UV_PROJECT_ENVIRONMENT=.venv-validation-py313 UV_PYTHON=3.13.14 ./dev scope --staged --allow-scope core:agi-cluster --allow-scope core:test --allow-scope src`

## Scope Note

This PR intentionally spans `core:agi-cluster`, `core:test`, and `src` because it addresses one audit-hardening batch across shared runtime install selection, installer cache state, and evidence redaction. The branch was pushed with `AGILAB_ALLOW_MIXED_SCOPE_PUSH_REASON='audit hardening spans shared runtime installer and secret redaction'`.

## Agent Metadata

- Tokki version: `tokki 1.0.19`
- Agent/runtime: Codex CLI, version unavailable
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used

## GitHub Checks

- GitGuardian Security Checks: passed
- base-python-compat (3.13): passed
- base-python-compat (3.14): passed
- clean-public-install (macos-latest): passed
- clean-public-install (ubuntu-latest): passed
- clean-public-install (windows-latest): passed
- local-only-policy: passed
- windows-core-tests: passed
- public-demo-smoke: skipped by workflow rules
