### PR TITLE
[codex] Refresh coverage badges

### DIFF
--- a/badges/coverage-agi-gui.svg
+++ b/badges/coverage-agi-gui.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="153" height="20" role="img" aria-label="agi-gui coverage: 97%">
+<svg xmlns="http://www.w3.org/2000/svg" width="153" height="20" role="img" aria-label="agi-gui coverage: 96%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="61.0" y="15" fill="#010101" fill-opacity=".3">agi-gui coverage</text>
   <text x="61.0" y="14">agi-gui coverage</text>
-  <text x="137.5" y="15" fill="#010101" fill-opacity=".3">97%</text>
-  <text x="137.5" y="14">97%</text>
+  <text x="137.5" y="15" fill="#010101" fill-opacity=".3">96%</text>
+  <text x="137.5" y="14">96%</text>
 </g>
 </svg>

--- a/badges/coverage-agilab.svg
+++ b/badges/coverage-agilab.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="146" height="20" role="img" aria-label="agilab coverage: 97%">
+<svg xmlns="http://www.w3.org/2000/svg" width="146" height="20" role="img" aria-label="agilab coverage: 96%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="57.5" y="15" fill="#010101" fill-opacity=".3">agilab coverage</text>
   <text x="57.5" y="14">agilab coverage</text>
-  <text x="130.5" y="15" fill="#010101" fill-opacity=".3">97%</text>
-  <text x="130.5" y="14">97%</text>
+  <text x="130.5" y="15" fill="#010101" fill-opacity=".3">96%</text>
+  <text x="130.5" y="14">96%</text>
 </g>
 </svg>


### PR DESCRIPTION
## Summary

- Refresh committed coverage badges to match the generated coverage workflow output.
- Update `coverage-agilab.svg` and `coverage-agi-gui.svg` from `97%` to `96%`.

## Repro

`coverage` failed on `main` for commit `6c5411c` in run `28846129420` during `Verify committed badges are up to date`.

The workflow-generated diff changed:

- `badges/coverage-agilab.svg`: `97%` -> `96%`
- `badges/coverage-agi-gui.svg`: `97%` -> `96%`

## Root Cause

The previous code/test changes changed aggregate coverage, but the committed badge SVGs were not refreshed, so `git diff --exit-code -- badges/` failed in the coverage workflow.

## Regression Test

Not applicable: this is a generated badge freshness update. The regression is the existing `coverage` workflow badge freshness check.

## Validation

- `git diff --check`
- `env UV_PROJECT_ENVIRONMENT=.venv-validation-py313 UV_PYTHON=3.13.14 ./dev scope --staged`
- Agent commit provenance guard passed during commit.

## Agent Metadata

- Tokki version: `tokki 1.0.19`
- Agent/runtime: Codex CLI, version unavailable
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used

## GitHub Checks

- GitGuardian Security Checks: passed
- base-python-compat (3.13): passed
- base-python-compat (3.14): passed
- clean-public-install (macos-latest): passed
- clean-public-install (ubuntu-latest): passed
- clean-public-install (windows-latest): passed
- local-only-policy: passed
- public-demo-smoke: skipped by workflow rules
