### PR TITLE
[codex] Fix worker Python floor normalization

### DIFF
--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_local_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_local_support.py
@@ -113,6 +113,7 @@ FORCE_REMOVE_EXCEPTIONS = (OSError, shutil.Error)
 DEPENDENCY_PARSE_EXCEPTIONS = (InvalidRequirement,)
 PYPROJECT_PARSE_EXCEPTIONS = (OSError, tomlkit.exceptions.ParseError)  # ty: ignore[possibly-missing-submodule]
 PERF_TRACE_ENV = "AGILAB_PERF_TRACE"
+MIN_WORKER_REQUIRES_PYTHON = ">=3.12"
 DEPENDENCY_MODULE_ALIASES: dict[str, tuple[str, ...]] = {
     "pillow": ("PIL",),
     "python-dotenv": ("dotenv",),
@@ -133,6 +134,84 @@ def _worker_python_uv_spec(env: Any, fallback: str | None) -> str | None:
         or getattr(env, "python_uv_spec", None)
         or fallback
     )
+
+
+def _python_version_prefix_tuple(version: str) -> tuple[int, ...]:
+    parts: list[int] = []
+    for part in version.strip().split("."):
+        if not part.isdigit():
+            break
+        parts.append(int(part))
+    return tuple(parts)
+
+
+def _raise_requires_python_floor(
+    requires_python: str | None,
+    *,
+    minimum_spec: str = MIN_WORKER_REQUIRES_PYTHON,
+) -> str | None:
+    if not requires_python:
+        return minimum_spec
+
+    minimum_version = minimum_spec.removeprefix(">=")
+    minimum_tuple = _python_version_prefix_tuple(minimum_version)
+    parts = [part.strip() for part in str(requires_python).split(",") if part.strip()]
+    if not parts:
+        return minimum_spec
+
+    changed = False
+    has_floor = False
+    normalized: list[str] = []
+    for part in parts:
+        if part.startswith(">="):
+            has_floor = True
+            current_tuple = _python_version_prefix_tuple(part.removeprefix(">="))
+            if current_tuple and current_tuple < minimum_tuple:
+                normalized.append(minimum_spec)
+                changed = True
+            else:
+                normalized.append(part)
+        else:
+            normalized.append(part)
+
+    if not has_floor:
+        if any(part.startswith(("==", "===", "~=")) for part in parts):
+            return requires_python
+        normalized.insert(0, minimum_spec)
+        changed = True
+
+    result = ",".join(normalized)
+    return result if changed else requires_python
+
+
+def _normalize_worker_requires_python_floor(
+    pyproject_file: Path,
+    *,
+    minimum_spec: str = MIN_WORKER_REQUIRES_PYTHON,
+) -> bool:
+    try:
+        data = tomlkit.parse(pyproject_file.read_text())
+    except PYPROJECT_PARSE_EXCEPTIONS:
+        return False
+
+    project_tbl = data.get("project")
+    if not (
+        hasattr(project_tbl, "get") and hasattr(project_tbl, "__setitem__")
+    ):
+        project_tbl = tomlkit.table()
+
+    current = project_tbl.get("requires-python")
+    updated = _raise_requires_python_floor(
+        str(current) if current is not None else None,
+        minimum_spec=minimum_spec,
+    )
+    if updated is None or updated == current:
+        return False
+
+    project_tbl["requires-python"] = updated
+    data["project"] = project_tbl
+    pyproject_file.write_text(tomlkit.dumps(data))
+    return True
 
 
 def _manager_python_uv_spec(env: Any, fallback: str | None) -> str | None:
@@ -1284,6 +1363,7 @@ async def deploy_local_worker(
     uv_worker = resolver_env_prefix + cmd_prefix + env.uv_worker
     pyvers_worker = env.pyvers_worker
     pyvers_worker_uv_spec = _worker_python_uv_spec(env, pyvers_worker)
+    _normalize_worker_requires_python_floor(wenv_abs / "pyproject.toml")
 
     worker_extra_indexes = ""
     if (

--- a/src/agilab/core/test/test_agi_distributor_deployment_local_support.py
+++ b/src/agilab/core/test/test_agi_distributor_deployment_local_support.py
@@ -2237,6 +2237,56 @@ def test_update_pyproject_dependencies_filters_to_worker_sources(tmp_path):
     assert "pip==24.0" not in content
 
 
+def test_normalize_worker_requires_python_floor_raises_stale_lower_bound(tmp_path):
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        """
+[project]
+name = "flight-trajectory-worker"
+requires-python = ">=3.11,<3.15"
+dependencies = ["agi-env", "agi-node"]
+""".strip(),
+        encoding="utf-8",
+    )
+
+    changed = deployment_local_support._normalize_worker_requires_python_floor(pyproject)
+
+    assert changed is True
+    content = pyproject.read_text(encoding="utf-8")
+    assert 'requires-python = ">=3.12,<3.15"' in content
+
+
+def test_normalize_worker_requires_python_floor_bootstraps_missing_value(tmp_path):
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text("[project]\nname='worker'\n", encoding="utf-8")
+
+    changed = deployment_local_support._normalize_worker_requires_python_floor(pyproject)
+
+    assert changed is True
+    content = pyproject.read_text(encoding="utf-8")
+    assert 'requires-python = ">=3.12"' in content
+
+
+def test_normalize_worker_requires_python_floor_preserves_exact_app_requirement(
+    tmp_path,
+):
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        """
+[project]
+name = "autoencoder-latentspace-worker"
+requires-python = "==3.12.*"
+""".strip(),
+        encoding="utf-8",
+    )
+
+    changed = deployment_local_support._normalize_worker_requires_python_floor(pyproject)
+
+    assert changed is False
+    content = pyproject.read_text(encoding="utf-8")
+    assert 'requires-python = "==3.12.*"' in content
+
+
 def test_update_pyproject_dependencies_skips_invalid_existing_specs(tmp_path):
     pyproject = tmp_path / "pyproject.toml"
     pyproject.write_text(


### PR DESCRIPTION
## Summary

Normalizes generated worker-copy `requires-python` metadata before AGILAB adds local `agi-env` and `agi-node` sources during worker deployment.

## Repro

Installing `flight_trajectory_project` failed during worker deployment when `uv add --python 3.14.6+gil --editable .../agi-env .../agi-node` resolved the copied worker project as `requires-python >=3.11` while local AGILAB core packages require `>=3.12`.

## Root Cause

The install path copied or generated worker manifests from apps that still advertised a broad Python floor such as `>=3.11`. `uv add` resolves across the declared project range, so the worker copy became unsatisfiable after AGILAB core dropped Python 3.11 support.

## Fix

The generated worker `pyproject.toml` now raises stale lower bounds to AGILAB's supported floor (`>=3.12`) before worker dependency add/sync stages. Upper bounds are preserved, and exact app requirements such as `==3.12.*` are not broadened.

## Regression Test

Added focused coverage for stale `>=3.11,<3.15` worker manifests, missing `requires-python`, and exact `==3.12.*` preservation.

## Validation

- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --files src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_local_support.py src/agilab/core/test/test_agi_distributor_deployment_local_support.py`
- `uv --preview-features extra-build-dependencies run --no-sync pytest -q -o addopts='' src/agilab/core/test/test_agi_distributor_deployment_local_support.py` failed before running tests because the root project environment collected `src/agilab/core/__init__.py` as `agilab.core`.
- `uv --preview-features extra-build-dependencies run --no-project --with-editable ./src/agilab/core/agi-env --with-editable ./src/agilab/core/agi-node --with-editable ./src/agilab/core/agi-cluster --with pytest --with pytest-asyncio python -m pytest -q --import-mode=importlib -o addopts='' src/agilab/core/test/test_agi_distributor_deployment_local_support.py` passed: 108 passed.
- Explicit temporary Python 3.13 venv broad slice passed: `src/agilab/core/test`, 1202 passed, 3 skipped.

## Agent Metadata

- Tokki version: tokki 1.0.19
- Agent/runtime: Codex, version unavailable
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used
