### PR TITLE
[codex] Clean app-test uv environment

### DIFF
--- a/src/agilab/install_apps.sh
+++ b/src/agilab/install_apps.sh
@@ -185,10 +185,40 @@ normalize_agi_python_version() {
   printf '%s\n' "$normalized"
 }
 
+normalize_agi_python_uv_spec() {
+  local raw="${1:-}"
+  local python_version="${2:-${AGI_PYTHON_VERSION:-3.14}}"
+  local desired_uv_spec
+  desired_uv_spec="$(python_uv_spec_for_version "$python_version")"
+  raw="$(printf '%s' "$raw" | sed -E 's/^[[:space:]]+//;s/[[:space:]]+$//')"
+  if [[ -z "$raw" || "$raw" == "$python_version" ]]; then
+    raw="$desired_uv_spec"
+  fi
+  if [[ "$raw" == *freethreaded* \
+     || "$raw" =~ (^|[^[:alnum:]])python3\.[0-9]+t([^[:alnum:]]|$) \
+     || "$raw" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?t($|[^[:alnum:]]) ]]; then
+    echo -e "${RED}Unsupported AGI_PYTHON_UV_SPEC '${raw}': install_apps.sh requires a standard GIL Python interpreter.${NC}" >&2
+    return 1
+  fi
+  printf '%s\n' "$raw"
+}
+
+run_with_agilab_python_env() {
+  env \
+    -u VIRTUAL_ENV \
+    -u CONDA_PREFIX \
+    -u UV_PROJECT_ENVIRONMENT \
+    -u UV_RUN_RECURSION_DEPTH \
+    UV_PYTHON="${AGI_PYTHON_UV_SPEC:-$AGI_PYTHON_VERSION}" \
+    "$@"
+}
+
 if ! AGI_PYTHON_VERSION="$(normalize_agi_python_version "${AGI_PYTHON_VERSION:-3.14}")"; then
   exit 1
 fi
-AGI_PYTHON_UV_SPEC="${AGI_PYTHON_UV_SPEC:-$(python_uv_spec_for_version "$AGI_PYTHON_VERSION")}"
+if ! AGI_PYTHON_UV_SPEC="$(normalize_agi_python_uv_spec "${AGI_PYTHON_UV_SPEC:-}" "$AGI_PYTHON_VERSION")"; then
+  exit 1
+fi
 export AGI_PYTHON_VERSION
 export AGI_PYTHON_UV_SPEC
 
@@ -1449,8 +1479,8 @@ for app in ${INCLUDED_APPS+"${INCLUDED_APPS[@]}"}; do
         if pushd -- "$app_dir_rel" >/dev/null; then
         ran_app_test=0
         if [[ -f app_test.py ]]; then
-          echo "${UV_PREVIEW[@]} run -p \"${AGI_PYTHON_UV_SPEC:-$AGI_PYTHON_VERSION}\" ${CORE_EDITABLE_PACKAGES[*]} python app_test.py"
-          "${UV_PREVIEW[@]}" run -p "${AGI_PYTHON_UV_SPEC:-$AGI_PYTHON_VERSION}" "${CORE_EDITABLE_PACKAGES[@]}" python app_test.py
+          echo "env -u VIRTUAL_ENV -u CONDA_PREFIX -u UV_PROJECT_ENVIRONMENT -u UV_RUN_RECURSION_DEPTH UV_PYTHON=\"${AGI_PYTHON_UV_SPEC:-$AGI_PYTHON_VERSION}\" ${UV_PREVIEW[*]} run -p \"${AGI_PYTHON_UV_SPEC:-$AGI_PYTHON_VERSION}\" ${CORE_EDITABLE_PACKAGES[*]} python app_test.py"
+          run_with_agilab_python_env "${UV_PREVIEW[@]}" run -p "${AGI_PYTHON_UV_SPEC:-$AGI_PYTHON_VERSION}" "${CORE_EDITABLE_PACKAGES[@]}" python app_test.py
           ran_app_test=1
         else
             if app_has_collectable_pytests .; then
@@ -1510,7 +1540,7 @@ for app in ${INCLUDED_APPS+"${INCLUDED_APPS[@]}"}; do
       popd >/dev/null
       continue
     fi
-    if "${UV_PREVIEW[@]}" run -p "${AGI_PYTHON_UV_SPEC:-$AGI_PYTHON_VERSION}" "${CORE_EDITABLE_PACKAGES[@]}" --project . --with pytest --with pytest-cov pytest; then
+    if run_with_agilab_python_env "${UV_PREVIEW[@]}" run -p "${AGI_PYTHON_UV_SPEC:-$AGI_PYTHON_VERSION}" "${CORE_EDITABLE_PACKAGES[@]}" --project . --with pytest --with pytest-cov pytest; then
       echo -e "${GREEN}✓ pytest succeeded for '$app_name'.${NC}"
       else
         rc=$?

--- a/test/test_install_apps_discovery.py
+++ b/test/test_install_apps_discovery.py
@@ -249,6 +249,45 @@ normalize_agi_python_version "$1"
     )
 
 
+def _run_normalize_agi_python_uv_spec(
+    raw: str,
+    *,
+    agi_python_version: str = "3.14.6",
+) -> subprocess.CompletedProcess[str]:
+    script_text = INSTALL_APPS_SH.read_text(encoding="utf-8")
+    python_uv_spec_body = _extract_function(
+        script_text,
+        "python_uv_spec_for_version",
+        "normalize_agi_python_version",
+    )
+    function_body = _extract_function(
+        script_text,
+        "normalize_agi_python_uv_spec",
+        "run_with_agilab_python_env",
+    )
+    bash_script = f"""#!/usr/bin/env bash
+set -euo pipefail
+RED=""
+NC=""
+{python_uv_spec_body}
+{function_body}
+normalize_agi_python_uv_spec "$1" "$2"
+"""
+    return subprocess.run(
+        [
+            "bash",
+            "-c",
+            bash_script,
+            "normalize_agi_python_uv_spec_test",
+            raw,
+            agi_python_version,
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
 def _run_page_sync_python_spec(
     page_dir: Path,
     *,
@@ -283,6 +322,47 @@ page_sync_python_spec "$1"
         text=True,
     )
     return completed.stdout.strip()
+
+
+@pytest.mark.parametrize(
+    ("raw", "version", "expected"),
+    [
+        ("", "3.14.6", "3.14.6+gil"),
+        ("3.14.6", "3.14.6", "3.14.6+gil"),
+        ("3.14.6+gil", "3.14.6", "3.14.6+gil"),
+        ("3.13.14", "3.13.14", "3.13.14"),
+    ],
+)
+def test_install_apps_python_uv_spec_uses_gil_python_for_314(
+    raw: str,
+    version: str,
+    expected: str,
+) -> None:
+    completed = _run_normalize_agi_python_uv_spec(
+        raw,
+        agi_python_version=version,
+    )
+
+    assert completed.returncode == 0
+    assert completed.stdout.strip() == expected
+
+
+def test_install_apps_rejects_freethreaded_uv_spec_and_cleans_app_test_env() -> None:
+    rejected = _run_normalize_agi_python_uv_spec(
+        "3.14.6+freethreaded",
+        agi_python_version="3.14.6",
+    )
+    script_text = INSTALL_APPS_SH.read_text(encoding="utf-8")
+
+    assert rejected.returncode != 0
+    assert "standard GIL Python interpreter" in rejected.stderr
+    assert "run_with_agilab_python_env" in script_text
+    assert "-u VIRTUAL_ENV" in script_text
+    assert "-u UV_PROJECT_ENVIRONMENT" in script_text
+    assert "-u UV_RUN_RECURSION_DEPTH" in script_text
+    assert 'UV_PYTHON="${AGI_PYTHON_UV_SPEC:-$AGI_PYTHON_VERSION}"' in script_text
+    assert 'run_with_agilab_python_env "${UV_PREVIEW[@]}" run -p "${AGI_PYTHON_UV_SPEC:-$AGI_PYTHON_VERSION}" "${CORE_EDITABLE_PACKAGES[@]}" python app_test.py' in script_text
+    assert 'run_with_agilab_python_env "${UV_PREVIEW[@]}" run -p "${AGI_PYTHON_UV_SPEC:-$AGI_PYTHON_VERSION}" "${CORE_EDITABLE_PACKAGES[@]}" --project . --with pytest --with pytest-cov pytest' in script_text
 
 
 def test_page_discovery_keeps_only_installable_entrypoint_projects(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
Fixes the app-test/check-install phase of `install_apps.sh` so nested `uv` commands cannot inherit an ambient build or virtual environment and silently choose Python 3.14 freethreaded.

## Repro
A source app install can complete successfully with `3.14.6+gil`, then fail during the installation check when `app_test.py` or nested app-local sync runs under an inherited `VIRTUAL_ENV` and resolves `CPython 3.14t`, forcing `polars-runtime-32` to build from source.

## Root Cause
`install_apps.sh` normalized the main AGI Python version, but app-test subprocesses still inherited `VIRTUAL_ENV`, `UV_PROJECT_ENVIRONMENT`, and uv recursion state from the caller. The visible command used `-p 3.14.6+gil`, while nested uv execution could still resolve the freethreaded interpreter.

## Fix
Add a shared installer helper that clears inherited virtualenv/uv recursion variables and sets `UV_PYTHON` to the normalized GIL uv spec. Use it for app-test and app pytest execution. Reject explicit freethreaded `AGI_PYTHON_UV_SPEC` values early.

## Regression Test
Added install-apps discovery coverage for Python 3.14 GIL uv-spec normalization, freethreaded rejection, and sanitized app-test/app-pytest command execution.

## Validation
- `bash -n src/agilab/install_apps.sh`
- `uv --preview-features extra-build-dependencies run --no-project -p 3.14.6+gil python tools/impact_validate.py --files src/agilab/install_apps.sh test/test_install_apps_discovery.py`
- `bash -n install.sh src/agilab/install_apps.sh src/agilab/core/install.sh`
- `uv --preview-features extra-build-dependencies run --no-project -p 3.14.6+gil --with pytest --with psutil --with-editable ./src/agilab/core/agi-env python -m pytest -q -o addopts='' test/test_install_apps_discovery.py test/test_install_apps_last_session_defaults.py`

## Agent Metadata
- Tokki version: `tokki 1.0.19`
- Agent/runtime: Codex, version unavailable
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used
