### PR TITLE
[codex] Fix page config contract follow-up

### DIFF
--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground/ui/app_surface.py
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground/ui/app_surface.py
@@ -17,8 +17,9 @@ def _configure_page(streamlit: Any, **config: Any) -> None:
         from agilab.ui.page_bootstrap import configure_page_config
     except (ImportError, ModuleNotFoundError):
         getattr(streamlit, "set_page_config")(**config)
-    else:
-        configure_page_config(streamlit, **config)
+        return
+
+    configure_page_config(streamlit, **config)
 
 
 def _prepend_sys_path(path: Path) -> None:

--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground/ui/playground_ui.py
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/pytorch_playground/ui/playground_ui.py
@@ -49,8 +49,9 @@ def _configure_page(streamlit: Any, **config: Any) -> None:
         from agilab.ui.page_bootstrap import configure_page_config
     except (ImportError, ModuleNotFoundError):
         getattr(streamlit, "set_page_config")(**config)
-    else:
-        configure_page_config(streamlit, **config)
+        return
+
+    configure_page_config(streamlit, **config)
 
 
 def _prepend_sys_path(path: Path) -> None:

--- a/src/agilab/main_page.py
+++ b/src/agilab/main_page.py
@@ -369,17 +369,22 @@ def render_page_context(*args: Any, **kwargs: Any) -> Any:
 
 # --- minimal session-state safety (add this block) ---
 def _pre_render_reset() -> None:
+    session_state = getattr(st, "session_state", None)
+    if session_state is None:
+        return
     # If last run asked for a reset, clear BEFORE widgets are created this run
-    if st.session_state.pop("env_editor_reset", False):
-        st.session_state["env_editor_new_key"] = ""
-        st.session_state["env_editor_new_value"] = ""
+    if session_state.pop("env_editor_reset", False):
+        session_state["env_editor_new_key"] = ""
+        session_state["env_editor_new_value"] = ""
 
 
 # One-time safe defaults (ok to run every time)
-st.session_state.setdefault("env_editor_new_key", "")
-st.session_state.setdefault("env_editor_new_value", "")
-st.session_state.setdefault("env_editor_reset", False)
-st.session_state.setdefault("env_editor_feedback", None)
+_SESSION_STATE = getattr(st, "session_state", None)
+if _SESSION_STATE is not None:
+    _SESSION_STATE.setdefault("env_editor_new_key", "")
+    _SESSION_STATE.setdefault("env_editor_new_value", "")
+    _SESSION_STATE.setdefault("env_editor_reset", False)
+    _SESSION_STATE.setdefault("env_editor_feedback", None)
 
 _LAZY_IMPORT_ATTR_CACHE: Dict[tuple[str, str], Any] = {}
 

--- a/src/agilab/ui/page_bootstrap.py
+++ b/src/agilab/ui/page_bootstrap.py
@@ -77,7 +77,12 @@ def configure_page_config(
     if initial_sidebar_state is not None:
         config["initial_sidebar_state"] = initial_sidebar_state
 
-    streamlit.set_page_config(**config)
+    set_page_config = getattr(streamlit, "set_page_config", None)
+    if not callable(set_page_config):
+        _mark_page_configured(streamlit)
+        return False
+
+    set_page_config(**config)
     _mark_page_configured(streamlit)
     return True
 

--- a/test/test_ui_pages.py
+++ b/test/test_ui_pages.py
@@ -98,11 +98,23 @@ def test_streamlit_page_config_is_owned_by_bootstrap() -> None:
         Path("src/agilab/bridge_cli.py"),
         Path("src/agilab/lib/agi-pages/src/agi_pages/runtime.py"),
     }
+    ignored_parts = {
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".venv",
+        "__pycache__",
+        "build",
+        "dist",
+        "site-packages",
+    }
     direct_calls: list[str] = []
     for path in Path("src").rglob("*.py"):
         if path in allowed:
             continue
-        source = path.read_text(encoding="utf-8")
+        if any(part in ignored_parts for part in path.parts):
+            continue
+        source = path.read_text(encoding="utf-8", errors="ignore")
         if ".set_page_config" in source:
             direct_calls.append(path.as_posix())
 


### PR DESCRIPTION
## Summary

- Follow up PR #782 with the residual Streamlit page-config contract fixes that were left after the squash merge.
- Harden page-config bootstrap handling for polluted/local Streamlit import surfaces.
- Sync the checked-in PyTorch playground embedded package payload with the canonical built-in app source.

## Repro

- PR #782 merged while `repo-guardrails / local-only-policy` failed in the app-contract matrix step.
- The failed contract reported PyTorch playground embedded payload drift in `src/pytorch_playground/ui/app_surface.py` and `src/pytorch_playground/ui/playground_ui.py`.
- The landed `main` app-contract matrix still failed on that generated-payload mismatch before this follow-up.

## Root Cause

The canonical built-in PyTorch playground source and checked-in embedded `agi-app-pytorch-playground` package payload had byte-different `_configure_page` helper bodies. The app-contract matrix requires the embedded payload to match the generated built-in source payload exactly.

## Regression Test

- `./dev scope` passed.
- `uv --preview-features extra-build-dependencies run python tools/app_contract_matrix.py --quiet` passed.
- `python3 tools/agent_commit_provenance_guard.py --check-config` passed.

Skipped checks: broad UI pytest is not part of this payload-drift repair; the relevant failed gate is the app-contract matrix. Earlier local broad UI pytest was also unreliable in this checkout because the local Python 3.14 `.venv` exposed an incomplete `streamlit` module, while isolated project-env creation was blocked by native `polars-runtime-32` build failure on Python 3.14t.

## Review Evidence

No model or sub-agent review was used.

## Agent Metadata

- Tokki version: `tokki 1.0.19`
- Agent/runtime: Codex API assistant
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used
