### PR TITLE
[codex] Pin Streamlit below broken 1.58 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ agilab-mcp = "agilab_mcp.server:main"
 [project.optional-dependencies]
 ai = ["openai>=2.32.0,<3"]
 core = ["agi-core==2026.07.04"]
-ui = ["agi-apps==2026.07.04", "agi-pages==2026.07.04", "agi-gui==2026.07.04", "agi-web==2026.06.23", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "plotly>=6.8,<7", "sqlalchemy>=2.0.43,<3", "streamlit>=1.58,<1.59", "starlette>=1.0.1,<2", "tomli_w>=1.2.0,<2", "cryptography>=48.0.1,<50"]
+ui = ["agi-apps==2026.07.04", "agi-pages==2026.07.04", "agi-gui==2026.07.04", "agi-web==2026.06.23", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "plotly>=6.8,<7", "sqlalchemy>=2.0.43,<3", "streamlit>=1.57,<1.58", "starlette>=1.0.1,<2", "tomli_w>=1.2.0,<2", "cryptography>=48.0.1,<50"]
 viz = ["matplotlib>=3.10.0,<4", "plotly>=6.8,<7"]
 mlflow = ["mlflow>=3.14,<4", "idna>=3.15,<4", "starlette>=1.0.1,<2"]
 bridges = ["duckdb>=1.4.0,<2"]

--- a/src/agilab/apps-pages/templates/analysis_page_template/pyproject.toml
+++ b/src/agilab/apps-pages/templates/analysis_page_template/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.12"
 dependencies = [
     "agi-env>=2026.05.18,<2027.0",
     "agi-node>=2026.05.18,<2027.0",
-    "streamlit>=1.58,<1.59",
+    "streamlit>=1.57,<1.58",
 ]
 
 [build-system]

--- a/src/agilab/apps/builtin/data_quality_gate_project/pyproject.toml
+++ b/src/agilab/apps/builtin/data_quality_gate_project/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.12"
 authors = [
     { name = "Jean-Pierre Morard" }
 ]
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.12,<2.13", "streamlit>=1.58,<1.59"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.12,<2.13", "streamlit>=1.57,<1.58"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/apps/builtin/execution_pandas_project/pyproject.toml
+++ b/src/agilab/apps/builtin/execution_pandas_project/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.12"
 authors = [
     { name = "Jean-Pierre Morard" }
 ]
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "numpy>=2.2,<3", "pandas>=2.3.0,<4", "pydantic>=2.12,<2.13", "streamlit>=1.58,<1.59"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "numpy>=2.2,<3", "pandas>=2.3.0,<4", "pydantic>=2.12,<2.13", "streamlit>=1.57,<1.58"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/apps/builtin/execution_polars_project/pyproject.toml
+++ b/src/agilab/apps/builtin/execution_polars_project/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.12"
 authors = [
     { name = "Jean-Pierre Morard" }
 ]
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "polars>=1.35,<2", "pydantic>=2.12,<2.13", "streamlit>=1.58,<1.59"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "polars>=1.35,<2", "pydantic>=2.12,<2.13", "streamlit>=1.57,<1.58"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/apps/builtin/flight_telemetry_project/pyproject.toml
+++ b/src/agilab/apps/builtin/flight_telemetry_project/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.12"
 authors = [
     { name = "Jean-Pierre Morard" }
 ]
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "polars[rtcompat]>=1.35,<2", "pydantic>=2.12,<2.13", "py7zr>=1.1,<1.2", "streamlit>=1.58,<1.59"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "polars[rtcompat]>=1.35,<2", "pydantic>=2.12,<2.13", "py7zr>=1.1,<1.2", "streamlit>=1.57,<1.58"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/apps/builtin/minimal_app_project/pyproject.toml
+++ b/src/agilab/apps/builtin/minimal_app_project/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.12"
 authors = [
     { name = "Jean-Pierre Morard" }
 ]
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "polars>=1.35,<2", "pydantic>=2.12,<2.13", "streamlit>=1.58,<1.59"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "polars>=1.35,<2", "pydantic>=2.12,<2.13", "streamlit>=1.57,<1.58"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/apps/builtin/mission_decision_project/pyproject.toml
+++ b/src/agilab/apps/builtin/mission_decision_project/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.12"
 authors = [
     { name = "Jean-Pierre Morard" }
 ]
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.12,<2.13", "streamlit>=1.58,<1.59"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.12,<2.13", "streamlit>=1.57,<1.58"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/apps/builtin/multi_app_dag_project/pyproject.toml
+++ b/src/agilab/apps/builtin/multi_app_dag_project/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.12"
 authors = [
     { name = "Jean-Pierre Morard" }
 ]
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "polars>=1.35,<2", "pydantic>=2.12,<2.13", "streamlit>=1.58,<1.59"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "polars>=1.35,<2", "pydantic>=2.12,<2.13", "streamlit>=1.57,<1.58"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/apps/builtin/pytorch_playground_project/pyproject.toml
+++ b/src/agilab/apps/builtin/pytorch_playground_project/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "pandas>=2.3.0,<4",
     "plotly>=6.8,<7",
     "pydantic>=2.12,<2.13",
-    "streamlit>=1.58,<1.59",
+    "streamlit>=1.57,<1.58",
     "torch>=2.8.0,<3",
 ]
 

--- a/src/agilab/apps/builtin/r_runtime_bridge_project/pyproject.toml
+++ b/src/agilab/apps/builtin/r_runtime_bridge_project/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.12"
 authors = [
     { name = "Jean-Pierre Morard" }
 ]
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.12,<2.13", "streamlit>=1.58,<1.59"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.12,<2.13", "streamlit>=1.57,<1.58"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/apps/builtin/sklearn_pipeline_project/pyproject.toml
+++ b/src/agilab/apps/builtin/sklearn_pipeline_project/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.12"
 authors = [
     { name = "Jean-Pierre Morard" }
 ]
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "joblib>=1.5,<2", "pandas>=2.3.0,<4", "pydantic>=2.12,<2.13", "scikit-learn>=1.9,<2", "streamlit>=1.58,<1.59"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "joblib>=1.5,<2", "pandas>=2.3.0,<4", "pydantic>=2.12,<2.13", "scikit-learn>=1.9,<2", "streamlit>=1.57,<1.58"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/apps/builtin/tescia_diagnostic_project/pyproject.toml
+++ b/src/agilab/apps/builtin/tescia_diagnostic_project/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.13"
 authors = [
     { name = "Jean-Pierre Morard" }
 ]
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.12,<2.13", "streamlit>=1.58,<1.59"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.12,<2.13", "streamlit>=1.57,<1.58"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/apps/builtin/uav_queue_project/pyproject.toml
+++ b/src/agilab/apps/builtin/uav_queue_project/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.13"
 authors = [
     { name = "Jean-Pierre Morard" }
 ]
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "pydantic>=2.12,<2.13", "simpy>=4.1,<5", "streamlit>=1.58,<1.59"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "pydantic>=2.12,<2.13", "simpy>=4.1,<5", "streamlit>=1.57,<1.58"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/apps/builtin/uav_relay_queue_project/pyproject.toml
+++ b/src/agilab/apps/builtin/uav_relay_queue_project/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.13"
 authors = [
     { name = "Jean-Pierre Morard" }
 ]
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "pydantic>=2.12,<2.13", "simpy>=4.1,<5", "streamlit>=1.58,<1.59"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "pydantic>=2.12,<2.13", "simpy>=4.1,<5", "streamlit>=1.57,<1.58"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/apps/builtin/weather_forecast_legacy_project/pyproject.toml
+++ b/src/agilab/apps/builtin/weather_forecast_legacy_project/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.13"
 authors = [
     { name = "Jean-Pierre Morard" }
 ]
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.12,<2.13", "scikit-learn>=1.9,<2", "skforecast>=0.19,<0.20", "streamlit>=1.58,<1.59"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.12,<2.13", "scikit-learn>=1.9,<2", "skforecast>=0.19,<0.20", "streamlit>=1.57,<1.58"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/apps/builtin/weather_forecast_project/pyproject.toml
+++ b/src/agilab/apps/builtin/weather_forecast_project/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.12"
 authors = [
     { name = "Jean-Pierre Morard" }
 ]
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.12,<2.13", "scikit-learn>=1.9,<2", "skforecast>=0.19,<0.20", "streamlit>=1.58,<1.59"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.12,<2.13", "scikit-learn>=1.9,<2", "skforecast>=0.19,<0.20", "streamlit>=1.57,<1.58"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/apps/templates/dag_app_template/pyproject.toml
+++ b/src/agilab/apps/templates/dag_app_template/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "agi-env>=2026.05.25,<2027.0",
     "agi-node>=2026.05.25,<2027.0",
     "pydantic>=2.12,<2.13",
-    "streamlit>=1.58,<1.59",
+    "streamlit>=1.57,<1.58",
 ]
 
 [dependency-groups]

--- a/src/agilab/apps/templates/fireducks_app_template/pyproject.toml
+++ b/src/agilab/apps/templates/fireducks_app_template/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "fireducks>=1.4.4,<2",
     "pydantic>=2.12,<2.13",
     "py7zr>=1.1,<1.2",
-    "streamlit>=1.58,<1.59",
+    "streamlit>=1.57,<1.58",
 ]
 
 [dependency-groups]

--- a/src/agilab/apps/templates/pandas_app_template/pyproject.toml
+++ b/src/agilab/apps/templates/pandas_app_template/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "pandas>=2.3.0,<4",
     "pydantic>=2.12,<2.13",
     "py7zr>=1.1,<1.2",
-    "streamlit>=1.58,<1.59",
+    "streamlit>=1.57,<1.58",
 ]
 
 [dependency-groups]

--- a/src/agilab/apps/templates/polars_app_template/pyproject.toml
+++ b/src/agilab/apps/templates/polars_app_template/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "polars>=1.35,<2",
     "pydantic>=2.12,<2.13",
     "py7zr>=1.1,<1.2",
-    "streamlit>=1.58,<1.59",
+    "streamlit>=1.57,<1.58",
 ]
 
 [dependency-groups]

--- a/src/agilab/apps/templates/simple_app_template/pyproject.toml
+++ b/src/agilab/apps/templates/simple_app_template/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 dependencies = [
     "agi-env>=2026.05.25,<2027.0",
     "pydantic>=2.12,<2.13",
-    "streamlit>=1.58,<1.59",
+    "streamlit>=1.57,<1.58",
 ]
 
 [dependency-groups]

--- a/src/agilab/core/agi-env/test/test_optional_ui_split.py
+++ b/src/agilab/core/agi-env/test/test_optional_ui_split.py
@@ -97,8 +97,8 @@ def test_agi_gui_declares_streamlit_ui_runtime() -> None:
         if _requirement_name(dependency) == "streamlit"
     ]
     assert len(streamlit_dependencies) == 1
-    assert _requirement_has_lower_bound_at_least(streamlit_dependencies[0], "1.58")
-    assert _requirement_has_upper_bound_below(streamlit_dependencies[0], "1.59")
+    assert _requirement_has_lower_bound_at_least(streamlit_dependencies[0], "1.57")
+    assert _requirement_has_upper_bound_below(streamlit_dependencies[0], "1.58")
     assert "watchdog" in {_requirement_name(dependency) for dependency in dependencies}
 
 

--- a/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/pyproject.toml
+++ b/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.12"
 authors = [
     { name = "Jean-Pierre Morard" }
 ]
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "polars[rtcompat]>=1.35,<2", "pydantic>=2.12,<2.13", "py7zr>=1.1,<1.2", "streamlit>=1.58,<1.59"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "polars[rtcompat]>=1.35,<2", "pydantic>=2.12,<2.13", "py7zr>=1.1,<1.2", "streamlit>=1.57,<1.58"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/lib/agi-app-mission-decision/src/agi_app_mission_decision/project/mission_decision_project/pyproject.toml
+++ b/src/agilab/lib/agi-app-mission-decision/src/agi_app_mission_decision/project/mission_decision_project/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.12"
 authors = [
     { name = "Jean-Pierre Morard" }
 ]
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.12,<2.13", "streamlit>=1.58,<1.59"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.12,<2.13", "streamlit>=1.57,<1.58"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/pyproject.toml
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "pandas>=2.3.0,<4",
     "plotly>=6.8,<7",
     "pydantic>=2.12,<2.13",
-    "streamlit>=1.58,<1.59",
+    "streamlit>=1.57,<1.58",
     "torch>=2.8.0,<3",
 ]
 

--- a/src/agilab/lib/agi-app-uav-relay-queue/src/agi_app_uav_relay_queue/project/uav_relay_queue_project/pyproject.toml
+++ b/src/agilab/lib/agi-app-uav-relay-queue/src/agi_app_uav_relay_queue/project/uav_relay_queue_project/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.13"
 authors = [
     { name = "Jean-Pierre Morard" }
 ]
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "pydantic>=2.12,<2.13", "simpy>=4.1,<5", "streamlit>=1.58,<1.59"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "pydantic>=2.12,<2.13", "simpy>=4.1,<5", "streamlit>=1.57,<1.58"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/lib/agi-app-weather-forecast/src/agi_app_weather_forecast/project/weather_forecast_project/pyproject.toml
+++ b/src/agilab/lib/agi-app-weather-forecast/src/agi_app_weather_forecast/project/weather_forecast_project/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.12"
 authors = [
     { name = "Jean-Pierre Morard" }
 ]
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.12,<2.13", "scikit-learn>=1.9,<2", "skforecast>=0.19,<0.20", "streamlit>=1.58,<1.59"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.12,<2.13", "scikit-learn>=1.9,<2", "skforecast>=0.19,<0.20", "streamlit>=1.57,<1.58"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/lib/agi-gui/pyproject.toml
+++ b/src/agilab/lib/agi-gui/pyproject.toml
@@ -31,7 +31,7 @@ keywords = [
     "python",
 ]
 
-dependencies = ["agi-env==2026.07.04", "streamlit>=1.58,<1.59", "starlette>=1.0.1,<2", "streamlit_code_editor>=0.1.22,<0.2", "watchdog>=6,<7"]
+dependencies = ["agi-env==2026.07.04", "streamlit>=1.57,<1.58", "starlette>=1.0.1,<2", "streamlit_code_editor>=0.1.22,<0.2", "watchdog>=6,<7"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/test/test_pyproject_dependency_hygiene.py
+++ b/test/test_pyproject_dependency_hygiene.py
@@ -561,7 +561,7 @@ def test_streamlit_runtime_allows_validated_latest_1x() -> None:
                 if requirement.name.lower() != "streamlit":
                     continue
                 specifier_text = str(requirement.specifier)
-                if ">=1.58" not in specifier_text or "<1.59" not in specifier_text:
+                if ">=1.57" not in specifier_text or "<1.58" not in specifier_text:
                     violations.append(f"{pyproject.relative_to(REPO_ROOT)}: {requirement}")
 
     assert violations == []


### PR DESCRIPTION
## Summary
- cap AGILAB Streamlit requirements to `>=1.57,<1.58`
- apply the cap consistently across the root UI extra, built-in apps, app templates, packaged app payloads, and `agi-gui`
- repair the source UI launch path by avoiding `streamlit==1.58.0`, whose installed package exposes an incomplete top-level API for the CLI import path

## Repro
Running the source UI launch failed with:

```text
ImportError: cannot import name 'secrets' from 'streamlit'
```

Local inspection showed `streamlit==1.58.0` had no top-level `__version__`, `secrets`, `session_state`, or `set_page_config`, while `streamlit.web.bootstrap` imports `secrets` from the top-level package.

## Root Cause
`streamlit==1.58.0` is internally inconsistent for the current AGILAB CLI launch path. `streamlit==1.57.0` exposes the expected top-level API and imports `streamlit.web.cli` correctly on Python 3.14.

## Regression Test
- `uv run --no-project --with 'streamlit>=1.57,<1.58' python -c 'import streamlit, streamlit.web.cli; print(streamlit.__version__)'`
- `uv --preview-features extra-build-dependencies sync --extra ui --reinstall-package streamlit`
- `.venv/bin/python -c 'import streamlit, streamlit.web.cli; assert streamlit.__version__ == "1.57.0"; assert hasattr(streamlit, "secrets"); assert hasattr(streamlit, "set_page_config")'`
- `git diff --check`

## Agent Metadata
- Tokki version: `tokki 1.0.19`
- Agent/runtime: Codex, version unavailable
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used


## CI Follow-up
- First Windows core run failed because `test_optional_ui_split.py` still asserted a `streamlit>=1.58` lower bound.
- Updated dependency guard tests to enforce the new `>=1.57,<1.58` contract.
- Local targeted regression after the test update: `2 passed` for `test_agi_gui_declares_streamlit_ui_runtime` and `test_streamlit_runtime_allows_validated_latest_1x`.
- GitHub checks passed after the update: base Python compatibility, clean public installs on macOS/Ubuntu/Windows, local-only policy, Windows core tests, and GitGuardian.
