### PR TITLE
[codex] Fix training analysis page config coverage test

### DIFF
--- a/test/test_view_training_analysis.py
+++ b/test/test_view_training_analysis.py
@@ -548,8 +548,8 @@ def test_view_training_analysis_additional_helper_and_entrypoint_branches(monkey
     assert len(fig.data) == 2
 
     monkeypatch.setattr(
-        "streamlit.set_page_config",
-        lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("skip main")),
+        "agi_pages.runtime.configure_streamlit_page",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("skip main")),
     )
     with pytest.raises(RuntimeError, match="skip main"):
         runpy.run_path(str(MODULE_PATH), run_name="__main__")


### PR DESCRIPTION
## Summary
- Update the training-analysis entrypoint regression to intercept `agi_pages.runtime.configure_streamlit_page` after page-config centralization.
- Keep the coverage regression aligned with the shared page-config ownership contract.

## Repro
- `main` coverage workflow run `28854949822` failed in `agi-gui (pipeline)` and `agi-gui (robots)`.
- Failing test: `test/test_view_training_analysis.py::test_view_training_analysis_additional_helper_and_entrypoint_branches`.
- Failure symptom: the stale monkeypatch no longer stopped the entrypoint, so the app reached `_ensure_app_scoped_env()` and raised `ValueError: Missing --active-app argument`.

## Root Cause
The test still monkeypatched direct `streamlit.set_page_config`, but the page now routes configuration through `agi_pages.runtime.configure_streamlit_page`. After the page-config ownership change, the direct Streamlit monkeypatch no longer aborted the entrypoint at the intended boundary.

## Regression Test
- `uv --preview-features extra-build-dependencies run --group dev --extra ui --extra viz pytest -q --maxfail=1 --disable-warnings -o addopts='' -m 'not integration' test/test_view_training_analysis.py::test_view_training_analysis_additional_helper_and_entrypoint_branches`
- `./dev scope`
- `git diff --check`
- `python3 tools/agent_commit_provenance_guard.py --check-config`
- PR checks passed: repo guardrails/base compatibility/clean install/local policy, `windows-core-tests`, and GitGuardian.
- Skipped check: `public-demo-smoke` was GitHub-skipped by workflow.

## Review Evidence
No sub-agent or separate model review was used.

## Agent Metadata
- Tokki version: `tokki 1.0.19`
- Agent/runtime: Codex API assistant
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used
