### PR TITLE
Support latest Streamlit launcher

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ agilab-mcp = "agilab_mcp.server:main"
 [project.optional-dependencies]
 ai = ["openai>=2.32.0,<3"]
 core = ["agi-core==2026.07.04"]
-ui = ["agi-apps==2026.07.04", "agi-pages==2026.07.04", "agi-gui==2026.07.04", "agi-web==2026.06.23", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "plotly>=6.8,<7", "sqlalchemy>=2.0.43,<3", "streamlit>=1.57,<1.58", "starlette>=1.0.1,<2", "tomli_w>=1.2.0,<2", "cryptography>=48.0.1,<50"]
+ui = ["agi-apps==2026.07.04", "agi-pages==2026.07.04", "agi-gui==2026.07.04", "agi-web==2026.06.23", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "plotly>=6.8,<7", "sqlalchemy>=2.0.43,<3", "streamlit>=1.58,<2", "starlette>=1.0.1,<2", "tomli_w>=1.2.0,<2", "cryptography>=48.0.1,<50"]
 viz = ["matplotlib>=3.10.0,<4", "plotly>=6.8,<7"]
 mlflow = ["mlflow>=3.14,<4", "idna>=3.15,<4", "starlette>=1.0.1,<2"]
 bridges = ["duckdb>=1.4.0,<2"]

--- a/src/agilab/apps-pages/templates/analysis_page_template/pyproject.toml
+++ b/src/agilab/apps-pages/templates/analysis_page_template/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.12"
 dependencies = [
     "agi-env>=2026.05.18,<2027.0",
     "agi-node>=2026.05.18,<2027.0",
-    "streamlit>=1.57,<1.58",
+    "streamlit>=1.58,<2",
 ]
 
 [build-system]

--- a/src/agilab/apps/builtin/data_quality_gate_project/pyproject.toml
+++ b/src/agilab/apps/builtin/data_quality_gate_project/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.12"
 authors = [
     { name = "Jean-Pierre Morard" }
 ]
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.12,<2.13", "streamlit>=1.57,<1.58"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.12,<2.13", "streamlit>=1.58,<2"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/apps/builtin/execution_pandas_project/pyproject.toml
+++ b/src/agilab/apps/builtin/execution_pandas_project/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.12"
 authors = [
     { name = "Jean-Pierre Morard" }
 ]
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "numpy>=2.2,<3", "pandas>=2.3.0,<4", "pydantic>=2.12,<2.13", "streamlit>=1.57,<1.58"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "numpy>=2.2,<3", "pandas>=2.3.0,<4", "pydantic>=2.12,<2.13", "streamlit>=1.58,<2"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/apps/builtin/execution_polars_project/pyproject.toml
+++ b/src/agilab/apps/builtin/execution_polars_project/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.12"
 authors = [
     { name = "Jean-Pierre Morard" }
 ]
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "polars>=1.35,<2", "pydantic>=2.12,<2.13", "streamlit>=1.57,<1.58"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "polars>=1.35,<2", "pydantic>=2.12,<2.13", "streamlit>=1.58,<2"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/apps/builtin/flight_telemetry_project/pyproject.toml
+++ b/src/agilab/apps/builtin/flight_telemetry_project/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.12"
 authors = [
     { name = "Jean-Pierre Morard" }
 ]
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "polars[rtcompat]>=1.35,<2", "pydantic>=2.12,<2.13", "py7zr>=1.1,<1.2", "streamlit>=1.57,<1.58"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "polars[rtcompat]>=1.35,<2", "pydantic>=2.12,<2.13", "py7zr>=1.1,<1.2", "streamlit>=1.58,<2"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/apps/builtin/minimal_app_project/pyproject.toml
+++ b/src/agilab/apps/builtin/minimal_app_project/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.12"
 authors = [
     { name = "Jean-Pierre Morard" }
 ]
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "polars>=1.35,<2", "pydantic>=2.12,<2.13", "streamlit>=1.57,<1.58"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "polars>=1.35,<2", "pydantic>=2.12,<2.13", "streamlit>=1.58,<2"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/apps/builtin/mission_decision_project/pyproject.toml
+++ b/src/agilab/apps/builtin/mission_decision_project/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.12"
 authors = [
     { name = "Jean-Pierre Morard" }
 ]
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.12,<2.13", "streamlit>=1.57,<1.58"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.12,<2.13", "streamlit>=1.58,<2"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/apps/builtin/multi_app_dag_project/pyproject.toml
+++ b/src/agilab/apps/builtin/multi_app_dag_project/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.12"
 authors = [
     { name = "Jean-Pierre Morard" }
 ]
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "polars>=1.35,<2", "pydantic>=2.12,<2.13", "streamlit>=1.57,<1.58"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "polars>=1.35,<2", "pydantic>=2.12,<2.13", "streamlit>=1.58,<2"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/apps/builtin/pytorch_playground_project/pyproject.toml
+++ b/src/agilab/apps/builtin/pytorch_playground_project/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "pandas>=2.3.0,<4",
     "plotly>=6.8,<7",
     "pydantic>=2.12,<2.13",
-    "streamlit>=1.57,<1.58",
+    "streamlit>=1.58,<2",
     "torch>=2.8.0,<3",
 ]
 

--- a/src/agilab/apps/builtin/r_runtime_bridge_project/pyproject.toml
+++ b/src/agilab/apps/builtin/r_runtime_bridge_project/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.12"
 authors = [
     { name = "Jean-Pierre Morard" }
 ]
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.12,<2.13", "streamlit>=1.57,<1.58"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.12,<2.13", "streamlit>=1.58,<2"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/apps/builtin/sklearn_pipeline_project/pyproject.toml
+++ b/src/agilab/apps/builtin/sklearn_pipeline_project/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.12"
 authors = [
     { name = "Jean-Pierre Morard" }
 ]
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "joblib>=1.5,<2", "pandas>=2.3.0,<4", "pydantic>=2.12,<2.13", "scikit-learn>=1.9,<2", "streamlit>=1.57,<1.58"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "joblib>=1.5,<2", "pandas>=2.3.0,<4", "pydantic>=2.12,<2.13", "scikit-learn>=1.9,<2", "streamlit>=1.58,<2"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/apps/builtin/tescia_diagnostic_project/pyproject.toml
+++ b/src/agilab/apps/builtin/tescia_diagnostic_project/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.13"
 authors = [
     { name = "Jean-Pierre Morard" }
 ]
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.12,<2.13", "streamlit>=1.57,<1.58"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.12,<2.13", "streamlit>=1.58,<2"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/apps/builtin/uav_queue_project/pyproject.toml
+++ b/src/agilab/apps/builtin/uav_queue_project/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.13"
 authors = [
     { name = "Jean-Pierre Morard" }
 ]
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "pydantic>=2.12,<2.13", "simpy>=4.1,<5", "streamlit>=1.57,<1.58"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "pydantic>=2.12,<2.13", "simpy>=4.1,<5", "streamlit>=1.58,<2"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/apps/builtin/uav_relay_queue_project/pyproject.toml
+++ b/src/agilab/apps/builtin/uav_relay_queue_project/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.13"
 authors = [
     { name = "Jean-Pierre Morard" }
 ]
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "pydantic>=2.12,<2.13", "simpy>=4.1,<5", "streamlit>=1.57,<1.58"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "pydantic>=2.12,<2.13", "simpy>=4.1,<5", "streamlit>=1.58,<2"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/apps/builtin/weather_forecast_legacy_project/pyproject.toml
+++ b/src/agilab/apps/builtin/weather_forecast_legacy_project/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.13"
 authors = [
     { name = "Jean-Pierre Morard" }
 ]
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.12,<2.13", "scikit-learn>=1.9,<2", "skforecast>=0.19,<0.20", "streamlit>=1.57,<1.58"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.12,<2.13", "scikit-learn>=1.9,<2", "skforecast>=0.19,<0.20", "streamlit>=1.58,<2"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/apps/builtin/weather_forecast_project/pyproject.toml
+++ b/src/agilab/apps/builtin/weather_forecast_project/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.12"
 authors = [
     { name = "Jean-Pierre Morard" }
 ]
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.12,<2.13", "scikit-learn>=1.9,<2", "skforecast>=0.19,<0.20", "streamlit>=1.57,<1.58"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.12,<2.13", "scikit-learn>=1.9,<2", "skforecast>=0.19,<0.20", "streamlit>=1.58,<2"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/apps/templates/dag_app_template/pyproject.toml
+++ b/src/agilab/apps/templates/dag_app_template/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "agi-env>=2026.05.25,<2027.0",
     "agi-node>=2026.05.25,<2027.0",
     "pydantic>=2.12,<2.13",
-    "streamlit>=1.57,<1.58",
+    "streamlit>=1.58,<2",
 ]
 
 [dependency-groups]

--- a/src/agilab/apps/templates/fireducks_app_template/pyproject.toml
+++ b/src/agilab/apps/templates/fireducks_app_template/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "fireducks>=1.4.4,<2",
     "pydantic>=2.12,<2.13",
     "py7zr>=1.1,<1.2",
-    "streamlit>=1.57,<1.58",
+    "streamlit>=1.58,<2",
 ]
 
 [dependency-groups]

--- a/src/agilab/apps/templates/pandas_app_template/pyproject.toml
+++ b/src/agilab/apps/templates/pandas_app_template/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "pandas>=2.3.0,<4",
     "pydantic>=2.12,<2.13",
     "py7zr>=1.1,<1.2",
-    "streamlit>=1.57,<1.58",
+    "streamlit>=1.58,<2",
 ]
 
 [dependency-groups]

--- a/src/agilab/apps/templates/polars_app_template/pyproject.toml
+++ b/src/agilab/apps/templates/polars_app_template/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "polars>=1.35,<2",
     "pydantic>=2.12,<2.13",
     "py7zr>=1.1,<1.2",
-    "streamlit>=1.57,<1.58",
+    "streamlit>=1.58,<2",
 ]
 
 [dependency-groups]

--- a/src/agilab/apps/templates/simple_app_template/pyproject.toml
+++ b/src/agilab/apps/templates/simple_app_template/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 dependencies = [
     "agi-env>=2026.05.25,<2027.0",
     "pydantic>=2.12,<2.13",
-    "streamlit>=1.57,<1.58",
+    "streamlit>=1.58,<2",
 ]
 
 [dependency-groups]

--- a/src/agilab/core/agi-env/test/test_optional_ui_split.py
+++ b/src/agilab/core/agi-env/test/test_optional_ui_split.py
@@ -97,8 +97,8 @@ def test_agi_gui_declares_streamlit_ui_runtime() -> None:
         if _requirement_name(dependency) == "streamlit"
     ]
     assert len(streamlit_dependencies) == 1
-    assert _requirement_has_lower_bound_at_least(streamlit_dependencies[0], "1.57")
-    assert _requirement_has_upper_bound_below(streamlit_dependencies[0], "1.58")
+    assert _requirement_has_lower_bound_at_least(streamlit_dependencies[0], "1.58")
+    assert _requirement_has_upper_bound_below(streamlit_dependencies[0], "2")
     assert "watchdog" in {_requirement_name(dependency) for dependency in dependencies}
 
 

--- a/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/pyproject.toml
+++ b/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.12"
 authors = [
     { name = "Jean-Pierre Morard" }
 ]
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "polars[rtcompat]>=1.35,<2", "pydantic>=2.12,<2.13", "py7zr>=1.1,<1.2", "streamlit>=1.57,<1.58"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "polars[rtcompat]>=1.35,<2", "pydantic>=2.12,<2.13", "py7zr>=1.1,<1.2", "streamlit>=1.58,<2"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/lib/agi-app-mission-decision/src/agi_app_mission_decision/project/mission_decision_project/pyproject.toml
+++ b/src/agilab/lib/agi-app-mission-decision/src/agi_app_mission_decision/project/mission_decision_project/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.12"
 authors = [
     { name = "Jean-Pierre Morard" }
 ]
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.12,<2.13", "streamlit>=1.57,<1.58"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.12,<2.13", "streamlit>=1.58,<2"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/pyproject.toml
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "pandas>=2.3.0,<4",
     "plotly>=6.8,<7",
     "pydantic>=2.12,<2.13",
-    "streamlit>=1.57,<1.58",
+    "streamlit>=1.58,<2",
     "torch>=2.8.0,<3",
 ]
 

--- a/src/agilab/lib/agi-app-uav-relay-queue/src/agi_app_uav_relay_queue/project/uav_relay_queue_project/pyproject.toml
+++ b/src/agilab/lib/agi-app-uav-relay-queue/src/agi_app_uav_relay_queue/project/uav_relay_queue_project/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.13"
 authors = [
     { name = "Jean-Pierre Morard" }
 ]
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "pydantic>=2.12,<2.13", "simpy>=4.1,<5", "streamlit>=1.57,<1.58"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "pydantic>=2.12,<2.13", "simpy>=4.1,<5", "streamlit>=1.58,<2"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/lib/agi-app-weather-forecast/src/agi_app_weather_forecast/project/weather_forecast_project/pyproject.toml
+++ b/src/agilab/lib/agi-app-weather-forecast/src/agi_app_weather_forecast/project/weather_forecast_project/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.12"
 authors = [
     { name = "Jean-Pierre Morard" }
 ]
-dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.12,<2.13", "scikit-learn>=1.9,<2", "skforecast>=0.19,<0.20", "streamlit>=1.57,<1.58"]
+dependencies = ["agi-env>=2026.05.31", "agi-node>=2026.05.31", "pandas>=2.3.0,<4", "pydantic>=2.12,<2.13", "scikit-learn>=1.9,<2", "skforecast>=0.19,<0.20", "streamlit>=1.58,<2"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/lib/agi-gui/pyproject.toml
+++ b/src/agilab/lib/agi-gui/pyproject.toml
@@ -31,7 +31,7 @@ keywords = [
     "python",
 ]
 
-dependencies = ["agi-env==2026.07.04", "streamlit>=1.57,<1.58", "starlette>=1.0.1,<2", "streamlit_code_editor>=0.1.22,<0.2", "watchdog>=6,<7"]
+dependencies = ["agi-env==2026.07.04", "streamlit>=1.58,<2", "starlette>=1.0.1,<2", "streamlit_code_editor>=0.1.22,<0.2", "watchdog>=6,<7"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/test/test_agilab_streamlit_launcher.py
+++ b/test/test_agilab_streamlit_launcher.py
@@ -30,8 +30,7 @@ def test_build_streamlit_command_enables_ui_extra() -> None:
         "--extra",
         "ui",
         "python",
-        "-m",
-        "streamlit",
+        "/repo/tools/streamlit_cli_compat.py",
         "run",
         "/repo/src/agilab/main_page.py",
         "--",
@@ -42,7 +41,24 @@ def test_build_streamlit_command_enables_ui_extra() -> None:
     ]
 
 
-def test_child_environment_removes_parent_uv_sync_controls() -> None:
+def test_build_streamlit_command_can_preserve_no_sync_launches() -> None:
+    root = Path("/repo")
+
+    command = launch_agilab_streamlit.build_streamlit_command(root, [], "/usr/bin/uv", no_sync=True)
+
+    assert command[:8] == [
+        "/usr/bin/uv",
+        "--preview-features",
+        "extra-build-dependencies",
+        "run",
+        "--extra",
+        "ui",
+        "--no-sync",
+        "python",
+    ]
+
+
+def test_child_environment_removes_parent_uv_recursion_controls_but_keeps_no_sync() -> None:
     child_env = launch_agilab_streamlit.build_child_environment(
         {
             "UV_NO_SYNC": "1",
@@ -53,7 +69,14 @@ def test_child_environment_removes_parent_uv_sync_controls() -> None:
         }
     )
 
-    assert child_env == {"IS_SOURCE_ENV": "1"}
+    assert child_env == {"UV_NO_SYNC": "1", "IS_SOURCE_ENV": "1"}
+
+
+def test_uv_no_sync_enabled_parses_truthy_values() -> None:
+    assert launch_agilab_streamlit.uv_no_sync_enabled({"UV_NO_SYNC": "1"}) is True
+    assert launch_agilab_streamlit.uv_no_sync_enabled({"UV_NO_SYNC": "true"}) is True
+    assert launch_agilab_streamlit.uv_no_sync_enabled({"UV_NO_SYNC": "0"}) is False
+    assert launch_agilab_streamlit.uv_no_sync_enabled({}) is False
 
 
 def test_parse_args_preserves_streamlit_args_after_launcher_flag() -> None:
@@ -84,6 +107,7 @@ def test_main_print_command_uses_ui_extra(monkeypatch, capsys, tmp_path: Path) -
 
     output = capsys.readouterr().out.strip()
     assert "--extra ui" in output
+    assert "tools/streamlit_cli_compat.py" in output
     assert str(tmp_path / "src" / "agilab" / "main_page.py") in output
     assert "--server.port 8502" in output
 

--- a/test/test_pyproject_dependency_hygiene.py
+++ b/test/test_pyproject_dependency_hygiene.py
@@ -534,7 +534,7 @@ def test_worker_manifests_do_not_depend_on_streamlit() -> None:
 
 
 def test_streamlit_runtime_allows_validated_latest_1x() -> None:
-    """Streamlit runtime stays inside the currently validated latest 1.x window."""
+    """Streamlit runtime accepts the latest validated Streamlit 1.x releases."""
     pyprojects = [
         REPO_ROOT / "pyproject.toml",
         *(REPO_ROOT / "src/agilab/apps-pages").glob("*/pyproject.toml"),
@@ -561,7 +561,7 @@ def test_streamlit_runtime_allows_validated_latest_1x() -> None:
                 if requirement.name.lower() != "streamlit":
                     continue
                 specifier_text = str(requirement.specifier)
-                if ">=1.57" not in specifier_text or "<1.58" not in specifier_text:
+                if ">=1.58" not in specifier_text or "<2" not in specifier_text:
                     violations.append(f"{pyproject.relative_to(REPO_ROOT)}: {requirement}")
 
     assert violations == []

--- a/tools/launch_agilab_streamlit.py
+++ b/tools/launch_agilab_streamlit.py
@@ -27,8 +27,14 @@ def resolve_uv_binary() -> str | None:
     return None
 
 
-def build_streamlit_command(root: Path, app_args: list[str], uv_bin: str) -> list[str]:
-    return [
+def build_streamlit_command(
+    root: Path,
+    app_args: list[str],
+    uv_bin: str,
+    *,
+    no_sync: bool = False,
+) -> list[str]:
+    command = [
         uv_bin,
         "--preview-features",
         "extra-build-dependencies",
@@ -36,20 +42,26 @@ def build_streamlit_command(root: Path, app_args: list[str], uv_bin: str) -> lis
         "--extra",
         "ui",
         "python",
-        "-m",
-        "streamlit",
+        str(root / "tools" / "streamlit_cli_compat.py"),
         "run",
         str(root / "src" / "agilab" / "main_page.py"),
         "--",
         *app_args,
     ]
+    if no_sync:
+        command.insert(command.index("python"), "--no-sync")
+    return command
 
 
 def build_child_environment(environ: Mapping[str, str]) -> dict[str, str]:
     child_env = dict(environ)
-    for key in ("UV_NO_SYNC", "UV_RUN_RECURSION_DEPTH", "UV_PROJECT_ENVIRONMENT", "VIRTUAL_ENV"):
+    for key in ("UV_RUN_RECURSION_DEPTH", "UV_PROJECT_ENVIRONMENT", "VIRTUAL_ENV"):
         child_env.pop(key, None)
     return child_env
+
+
+def uv_no_sync_enabled(environ: Mapping[str, str]) -> bool:
+    return environ.get("UV_NO_SYNC", "").strip().lower() not in {"", "0", "false", "no"}
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
@@ -73,7 +85,12 @@ def main(argv: list[str] | None = None) -> int:
         print("Unable to locate uv. Install uv or add it to PATH before launching AGILAB.", file=sys.stderr)
         return 127
 
-    command = build_streamlit_command(repo_root(), args.app_args, uv_bin)
+    command = build_streamlit_command(
+        repo_root(),
+        args.app_args,
+        uv_bin,
+        no_sync=uv_no_sync_enabled(os.environ),
+    )
     if args.print_command:
         print(shlex.join(command))
         return 0

--- a/tools/streamlit_cli_compat.py
+++ b/tools/streamlit_cli_compat.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Run Streamlit while repairing the Streamlit 1.58 top-level facade.
+
+Streamlit 1.58.0 shipped with an empty top-level ``streamlit`` module while
+internal CLI modules still import public names such as ``streamlit.secrets``.
+AGILAB launches through this wrapper so source checkouts can keep accepting the
+latest Streamlit release without patching site-packages or downgrading.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.metadata
+import os
+import sys
+from types import ModuleType
+from typing import Any
+
+
+_MAIN_DELTA_METHODS = (
+    "altair_chart",
+    "area_chart",
+    "audio",
+    "audio_input",
+    "badge",
+    "balloons",
+    "bar_chart",
+    "_bidi_component",
+    "bokeh_chart",
+    "button",
+    "caption",
+    "camera_input",
+    "chat_message",
+    "chat_input",
+    "checkbox",
+    "code",
+    "columns",
+    "tabs",
+    "container",
+    "dataframe",
+    "data_editor",
+    "date_input",
+    "datetime_input",
+    "divider",
+    "download_button",
+    "expander",
+    "feedback",
+    "pydeck_chart",
+    "empty",
+    "error",
+    "exception",
+    "file_uploader",
+    "form",
+    "form_submit_button",
+    "graphviz_chart",
+    "header",
+    "help",
+    "html",
+    "iframe",
+    "image",
+    "info",
+    "json",
+    "latex",
+    "line_chart",
+    "link_button",
+    "map",
+    "markdown",
+    "menu_button",
+    "metric",
+    "multiselect",
+    "number_input",
+    "page_link",
+    "pdf",
+    "pills",
+    "plotly_chart",
+    "popover",
+    "progress",
+    "pyplot",
+    "radio",
+    "scatter_chart",
+    "selectbox",
+    "select_slider",
+    "segmented_control",
+    "slider",
+    "snow",
+    "space",
+    "spinner",
+    "subheader",
+    "success",
+    "table",
+    "text",
+    "text_area",
+    "text_input",
+    "toggle",
+    "time_input",
+    "title",
+    "vega_lite_chart",
+    "video",
+    "warning",
+    "write",
+    "write_stream",
+    "color_picker",
+    "status",
+)
+
+
+def _import_attr(module_name: str, attr_name: str) -> Any:
+    return getattr(importlib.import_module(module_name), attr_name)
+
+
+def _streamlit_version() -> str | None:
+    try:
+        return importlib.metadata.version("streamlit")
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+
+def _install_streamlit_facade(streamlit: ModuleType) -> None:
+    os.environ.setdefault("MPLBACKEND", "Agg")
+
+    version = _streamlit_version()
+    if version is not None:
+        streamlit.__version__ = version
+
+    DeltaGeneratorSingleton = _import_attr(
+        "streamlit.delta_generator_singletons",
+        "DeltaGeneratorSingleton",
+    )
+    DeltaGenerator = _import_attr("streamlit.delta_generator", "DeltaGenerator")
+    StatusContainer = _import_attr(
+        "streamlit.elements.lib.mutable_status_container",
+        "StatusContainer",
+    )
+    Dialog = _import_attr("streamlit.elements.lib.dialog", "Dialog")
+    ExpanderContainer = _import_attr(
+        "streamlit.elements.lib.mutable_expander_container",
+        "ExpanderContainer",
+    )
+    TabContainer = _import_attr("streamlit.elements.lib.mutable_tab_container", "TabContainer")
+    PopoverContainer = _import_attr(
+        "streamlit.elements.lib.mutable_popover_container",
+        "PopoverContainer",
+    )
+
+    dg_singleton = DeltaGeneratorSingleton(
+        delta_generator_cls=DeltaGenerator,
+        status_container_cls=StatusContainer,
+        dialog_container_cls=Dialog,
+        expander_container_cls=ExpanderContainer,
+        tab_container_cls=TabContainer,
+        popover_container_cls=PopoverContainer,
+    )
+    streamlit._dg_singleton = dg_singleton
+    streamlit._main = dg_singleton._main_dg
+    streamlit.sidebar = dg_singleton._sidebar_dg
+    streamlit._event = dg_singleton._event_dg
+
+    try:
+        BottomContainerProxy = _import_attr("streamlit.elements.bottom", "BottomContainerProxy")
+        streamlit.bottom = BottomContainerProxy(dg_singleton._bottom_dg)
+    except Exception:
+        streamlit.bottom = dg_singleton._bottom_dg
+    streamlit._bottom = dg_singleton._bottom_dg
+
+    streamlit.echo = _import_attr("streamlit.commands.echo", "echo")
+    streamlit.logo = _import_attr("streamlit.commands.logo", "logo")
+    streamlit.navigation = _import_attr("streamlit.commands.navigation", "navigation")
+    streamlit.Page = _import_attr("streamlit.navigation.page", "Page")
+    streamlit.set_page_config = _import_attr("streamlit.commands.page_config", "set_page_config")
+    streamlit.stop = _import_attr("streamlit.commands.execution_control", "stop")
+    streamlit.rerun = _import_attr("streamlit.commands.execution_control", "rerun")
+    streamlit.switch_page = _import_attr("streamlit.commands.execution_control", "switch_page")
+
+    config = importlib.import_module("streamlit.config")
+    gather_metrics = _import_attr("streamlit.runtime.metrics_util", "gather_metrics")
+    streamlit.get_option = gather_metrics("get_option", config.get_option)
+    streamlit.set_option = gather_metrics("set_option", config.set_user_option)
+
+    streamlit.secrets = _import_attr("streamlit.runtime.secrets", "secrets_singleton")
+    streamlit.session_state = _import_attr("streamlit.runtime.state", "SessionStateProxy")()
+    streamlit.query_params = _import_attr("streamlit.runtime.state", "QueryParamsProxy")()
+    streamlit.context = _import_attr("streamlit.runtime.context", "ContextProxy")()
+    streamlit.cache_data = _import_attr("streamlit.runtime.caching", "cache_data")
+    streamlit.cache_resource = _import_attr("streamlit.runtime.caching", "cache_resource")
+    streamlit.cache = _import_attr("streamlit.runtime.caching", "cache")
+    streamlit.column_config = importlib.import_module("streamlit.column_config")
+    streamlit.connection = _import_attr("streamlit.runtime.connection_factory", "connection_factory")
+    streamlit.dialog = _import_attr("streamlit.elements.dialog_decorator", "dialog_decorator")
+    streamlit.fragment = _import_attr("streamlit.runtime.fragment", "fragment")
+    streamlit.login = _import_attr("streamlit.user_info", "login")
+    streamlit.logout = _import_attr("streamlit.user_info", "logout")
+    streamlit.user = _import_attr("streamlit.user_info", "UserInfoProxy")()
+    streamlit.App = _import_attr("streamlit.starlette", "App")
+
+    for name in _MAIN_DELTA_METHODS:
+        setattr(streamlit, name, getattr(streamlit._main, name))
+    streamlit.toast = streamlit._event.toast
+
+    importlib.import_module("streamlit.components.v1")
+    importlib.import_module("streamlit.components.v2")
+
+
+def patch_streamlit_top_level() -> None:
+    streamlit = importlib.import_module("streamlit")
+    if getattr(streamlit, "__version__", None) and hasattr(streamlit, "secrets") and hasattr(streamlit, "write"):
+        return
+    _install_streamlit_facade(streamlit)
+
+
+def main() -> int:
+    patch_streamlit_top_level()
+    from streamlit.web.cli import main as streamlit_main
+
+    result = streamlit_main()
+    return 0 if result is None else int(result)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a source-launcher compatibility shim for Streamlit 1.58's empty top-level facade
- route `tools/launch_agilab_streamlit.py` through the shim instead of `python -m streamlit`
- restore AGILAB Streamlit dependency policy to latest supported 1.x: `streamlit>=1.58,<2`

## Repro
Running the source launcher with Streamlit 1.58 failed before AGILAB loaded:

```text
ImportError: cannot import name 'secrets' from 'streamlit'
```

## Root Cause
Streamlit 1.58.0 exposes an effectively empty top-level `streamlit` module, while Streamlit's own CLI still imports public top-level names such as `streamlit.secrets`.

## Regression Test
- isolated Streamlit 1.58 shim smoke: imports Streamlit, patches the top-level facade, imports `streamlit.web.cli`, and confirms `secrets` / `write`
- targeted pytest for launcher and dependency policy

## Validation
- `uv --preview-features extra-build-dependencies run --no-project --with 'streamlit==1.58.0' python - <<'PY' ... PY`
- `uv --preview-features extra-build-dependencies run --extra ui pytest -q -o addopts='' test/test_agilab_streamlit_launcher.py src/agilab/core/agi-env/test/test_optional_ui_split.py::test_agi_gui_declares_streamlit_ui_runtime test/test_pyproject_dependency_hygiene.py::test_streamlit_runtime_allows_validated_latest_1x`
- `git diff --check`
- `python3 tools/agent_commit_provenance_guard.py --check-config`

## Skipped Checks
- Full Streamlit browser launch: not run to avoid starting a user-visible long-running dev server; the failure was at CLI import time and is covered by the isolated CLI import smoke.
- Full test suite: not run; targeted launcher and dependency-policy checks cover this change.

## Review Evidence
- Higher-model/sub-agent review: not used.

## Agent Metadata
- Tokki version: `tokki 1.0.19`
- Agent/runtime: Codex CLI, version unknown
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used
