### PR TITLE
[codex] Fix analysis template Streamlit pin coverage test

### DIFF
--- a/test/test_analysis_page_helpers.py
+++ b/test/test_analysis_page_helpers.py
@@ -1949,7 +1949,7 @@ def test_create_analysis_page_bundle_writes_blank_template(tmp_path: Path, monke
     pyproject = tomllib.loads((tmp_path / "demo_view" / "pyproject.toml").read_text(encoding="utf-8"))
     assert pyproject["project"]["name"] == "view-demo-view"
     dependencies = pyproject["project"]["dependencies"]
-    assert "streamlit>=1.58,<1.59" in dependencies
+    assert "streamlit>=1.57,<1.58" in dependencies
     assert any(dependency.startswith("agi-env>=") for dependency in dependencies)
 
     template_text = entrypoint.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Align the analysis-page bundle template regression with the current pinned Streamlit window.
- Keep the generated blank template assertion consistent with `streamlit>=1.57,<1.58` after the Streamlit 1.58 pin rollback.

## Repro
- `main` coverage workflow run `28856070901` failed in `agi-gui (pipeline)`.
- Failing test: `test/test_analysis_page_helpers.py::test_create_analysis_page_bundle_writes_blank_template`.
- Failure symptom: the test expected `streamlit>=1.58,<1.59`, but the generated template dependency list contained `streamlit>=1.57,<1.58`.

## Root Cause
The Streamlit runtime was pinned back below 1.58, but this template regression still asserted the previous latest-1.x dependency window. The generator output was already consistent with the current pin; the test expectation was stale.

## Regression Test
- `UV_PROJECT_ENVIRONMENT=.venv-py313 uv --preview-features extra-build-dependencies run --python 3.13 --group dev --extra ui --extra viz pytest -q --maxfail=1 --disable-warnings -o addopts='' -m 'not integration' test/test_analysis_page_helpers.py::test_create_analysis_page_bundle_writes_blank_template`
- `git diff --check`
- `UV_PROJECT_ENVIRONMENT=.venv-py313 UV_PYTHON=3.13 ./dev scope`
- `python3 tools/agent_commit_provenance_guard.py --check-config`
- PR checks passed: repo guardrails/base compatibility/clean install/local policy, `windows-core-tests`, and GitGuardian.
- Skipped check: `public-demo-smoke` was GitHub-skipped by workflow.
- Local environment note: the same pytest/scope commands without Python 3.13 selection failed before running AGILAB tests because local CPython 3.14t attempted to build `polars-runtime-32==1.42.1` and failed in Rust `foldhash`.

## Review Evidence
No sub-agent or separate model review was used.

## Agent Metadata
- Tokki version: `tokki 1.0.19`
- Agent/runtime: Codex API assistant
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used
