### PR TITLE
[codex] Fix latest Streamlit template coverage assertion

### DIFF
--- a/test/test_analysis_page_helpers.py
+++ b/test/test_analysis_page_helpers.py
@@ -1949,7 +1949,7 @@ def test_create_analysis_page_bundle_writes_blank_template(tmp_path: Path, monke
     pyproject = tomllib.loads((tmp_path / "demo_view" / "pyproject.toml").read_text(encoding="utf-8"))
     assert pyproject["project"]["name"] == "view-demo-view"
     dependencies = pyproject["project"]["dependencies"]
-    assert "streamlit>=1.57,<1.58" in dependencies
+    assert "streamlit>=1.58,<2" in dependencies
     assert any(dependency.startswith("agi-env>=") for dependency in dependencies)
 
     template_text = entrypoint.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Align the analysis-page blank-template regression with the current latest-Streamlit template contract.
- Restore the expected generated dependency to `streamlit>=1.58,<2` after the `#787` support-latest-Streamlit merge.

## Repro
- `main` coverage workflow run `28856634613` failed in `agi-gui (pipeline)`.
- Failing test: `test/test_analysis_page_helpers.py::test_create_analysis_page_bundle_writes_blank_template`.
- Failure symptom: the test expected `streamlit>=1.57,<1.58`, but the generated template dependency list contained `streamlit>=1.58,<2`.

## Root Cause
PR `#787` changed the generated template contract to support the latest Streamlit window. PR `#788` was based on the earlier pinned state and reintroduced the older assertion when it merged afterward. The generator output is correct for current `main`; the regression assertion was stale again because of merge ordering.

## Regression Test
- `UV_PROJECT_ENVIRONMENT=.venv-py313 uv --preview-features extra-build-dependencies run --python 3.13 --group dev --extra ui --extra viz pytest -q --maxfail=1 --disable-warnings -o addopts='' -m 'not integration' test/test_analysis_page_helpers.py::test_create_analysis_page_bundle_writes_blank_template`
- `git diff --check`
- `UV_PROJECT_ENVIRONMENT=.venv-py313 UV_PYTHON=3.13 ./dev scope`
- `python3 tools/agent_commit_provenance_guard.py --check-config`
- PR checks passed: repo guardrails/base compatibility/clean install/local policy, `windows-core-tests`, and GitGuardian.
- Skipped check: `public-demo-smoke` was GitHub-skipped by workflow.

## Review Evidence
No sub-agent or separate model review was used.

## Agent Metadata
- Tokki version: `tokki 1.0.19`
- Agent/runtime: Codex API assistant
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used
