### PR TITLE
[codex] Fix page bundle Streamlit template contract test

### DIFF
--- a/test/test_page_bundle_registry.py
+++ b/test/test_page_bundle_registry.py
@@ -913,7 +913,7 @@ def test_repository_analysis_page_template_is_complete() -> None:
     pyproject = tomllib.loads((template.root_path / "pyproject.toml").read_text(encoding="utf-8"))
     dependencies = pyproject["project"]["dependencies"]
     assert pyproject["project"]["requires-python"] == ">=3.12"
-    assert "streamlit>=1.58,<1.59" in dependencies
+    assert "streamlit>=1.58,<2" in dependencies
     assert any(dependency.startswith("agi-env>=") for dependency in dependencies)
 
     entrypoint_text = (template.root_path / template.contract.entrypoint).read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Align the repository page-template contract regression with the current Streamlit template dependency.
- Update the expected analysis template dependency from `streamlit>=1.58,<1.59` to `streamlit>=1.58,<2`.

## Repro
- `main` coverage workflow run `28857080551` failed in `agi-gui (pipeline)`.
- Failing test: `test/test_page_bundle_registry.py::test_repository_analysis_page_template_is_complete`.
- Failure symptom: the test expected `streamlit>=1.58,<1.59`, but the template dependency list contained `streamlit>=1.58,<2`.

## Root Cause
The support-latest-Streamlit template contract now uses the broader validated `>=1.58,<2` window, but this registry regression still asserted the older narrow `>=1.58,<1.59` window. The template was correct; the test assertion was stale.

## Regression Test
- `UV_PROJECT_ENVIRONMENT=.venv-py313 uv --preview-features extra-build-dependencies run --python 3.13 --group dev --extra ui --extra viz pytest -q --maxfail=1 --disable-warnings -o addopts='' -m 'not integration' test/test_page_bundle_registry.py::test_repository_analysis_page_template_is_complete test/test_analysis_page_helpers.py::test_create_analysis_page_bundle_writes_blank_template`
- `git diff --check`
- `UV_PROJECT_ENVIRONMENT=.venv-py313 UV_PYTHON=3.13 ./dev scope`
- `python3 tools/agent_commit_provenance_guard.py --check-config`
- PR checks passed: repo guardrails/base compatibility/clean install/local policy, `windows-core-tests`, and GitGuardian.
- Skipped check: `public-demo-smoke` was GitHub-skipped by workflow.

## Review Evidence
No sub-agent or separate model review was used.

## Agent Metadata
- Tokki version: `tokki 1.0.19`
- Agent/runtime: Codex API assistant
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used
