### PR TITLE
Stop installer from rewriting dependency floors

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1299,7 +1299,7 @@ install_core() {
 run_core_tests() {
     local repo_root="$AGI_INSTALL_PATH"
     local -a failures=()
-    local -a uv_run=(uv --preview-features extra-build-dependencies run -p "${AGI_PYTHON_UV_SPEC:-$AGI_PYTHON_VERSION}" --no-sync --preview-features python-upgrade)
+    local -a uv_run=(uv --preview-features extra-build-dependencies run -p "${AGI_PYTHON_UV_SPEC:-$AGI_PYTHON_VERSION}" --no-sync)
 
     echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
     echo -e "${BLUE}RUNNING CORE TEST SUITES${NC}"
@@ -1311,7 +1311,7 @@ run_core_tests() {
     # `uv run --no-sync` assumes dependencies are already installed.
     echo -e "${BLUE}Syncing repository environment for core tests...${NC}"
     remove_incompatible_project_venv "$repo_root" "repository root"
-    $UV sync -p "${AGI_PYTHON_UV_SPEC:-$AGI_PYTHON_VERSION}" --preview-features python-upgrade
+    $UV sync -p "${AGI_PYTHON_UV_SPEC:-$AGI_PYTHON_VERSION}"
 
     if ! "${uv_run[@]}" -m pytest src/agilab/core/agi-env/test --cov=src/agilab/core/agi-env/src/agi_env --cov-report=term-missing --cov-report=xml:coverage-agi-env.xml; then
         failures+=("agi-env tests")
@@ -1348,7 +1348,7 @@ run_root_tests() {
     echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
 
     pushd "$repo_root" > /dev/null
-    if ! $UV run -p "${AGI_PYTHON_UV_SPEC:-$AGI_PYTHON_VERSION}" --no-sync --preview-features python-upgrade -m pytest src/agilab/test --cov=src/agilab --cov-report=term-missing --cov-report=xml:coverage-agilab.xml; then
+    if ! $UV run -p "${AGI_PYTHON_UV_SPEC:-$AGI_PYTHON_VERSION}" --no-sync -m pytest src/agilab/test --cov=src/agilab --cov-report=term-missing --cov-report=xml:coverage-agilab.xml; then
         echo -e "${RED}Agilab unit tests failed. Aborting install.${NC}"
         popd > /dev/null
         exit 1
@@ -1385,7 +1385,7 @@ run_repository_tests_with_coverage() {
         has_app_filter=1
         echo -e "${BLUE}App coverage limited to installed set from ${installed_apps_file}.${NC}"
     fi
-    local -a uv_cmd=(uv --preview-features extra-build-dependencies run -p "${AGI_PYTHON_UV_SPEC:-$AGI_PYTHON_VERSION}" --no-sync --preview-features python-upgrade)
+    local -a uv_cmd=(uv --preview-features extra-build-dependencies run -p "${AGI_PYTHON_UV_SPEC:-$AGI_PYTHON_VERSION}" --no-sync)
     local extra_pythonpath="${repo_root}/src/agilab/core/agi-env/src:${repo_root}/src/agilab/core/agi-node/src:${repo_root}/src/agilab/core/agi-cluster/src"
     local repo_pythonpath="$repo_root"
     if [[ -n "$extra_pythonpath" ]]; then
@@ -1767,7 +1767,7 @@ maybe_run_core_tests
 echo -e "${BLUE}Installing agilab (repo root)...${NC}"
 pushd "$AGI_INSTALL_PATH" > /dev/null
 remove_incompatible_project_venv "$AGI_INSTALL_PATH" "repository root"
-$UV sync -p "${AGI_PYTHON_UV_SPEC:-$AGI_PYTHON_VERSION}" --preview-features python-upgrade
+$UV sync -p "${AGI_PYTHON_UV_SPEC:-$AGI_PYTHON_VERSION}"
 $UV pip install --upgrade --no-deps \
     -e src/agilab/core/agi-env \
     -e src/agilab/core/agi-node \

--- a/pycharm/setup_pycharm.py
+++ b/pycharm/setup_pycharm.py
@@ -274,7 +274,7 @@ def _bootstrap_project_venv(project_dir: Path) -> Optional[Path]:
 
     try:
         subprocess.run(
-            [uv_bin, "sync", "--project", ".", "--preview-features", "python-upgrade"],
+            [uv_bin, "sync", "--project", "."],
             cwd=project_dir,
             check=True,
         )
@@ -376,7 +376,6 @@ def ensure_project_ui_environment(cfg: Config) -> Optional[Path]:
     sync_args = [uv_bin, "sync", "--project", "."]
     for extra in extras:
         sync_args.extend(["--extra", extra])
-    sync_args.extend(["--preview-features", "python-upgrade"])
     try:
         subprocess.run(
             sync_args,

--- a/test/test_install_local_models.py
+++ b/test/test_install_local_models.py
@@ -490,6 +490,12 @@ def test_root_installer_installs_local_core_packages_without_dependency_resoluti
     assert "$UV pip install -e src/agilab/core/agi-env" not in root_text
 
 
+def test_root_installer_does_not_run_uv_python_upgrade_by_default() -> None:
+    root_text = INSTALL_SH.read_text(encoding="utf-8")
+
+    assert "python-upgrade" not in root_text
+
+
 def test_shell_installers_stage_remote_scripts_before_execution() -> None:
     root_text = INSTALL_SH.read_text(encoding="utf-8")
     enduser_text = INSTALL_ENDUSER_SH.read_text(encoding="utf-8")

--- a/test/test_setup_pycharm.py
+++ b/test/test_setup_pycharm.py
@@ -546,13 +546,31 @@ ui = ["agi-gui", "streamlit", "tomli_w"]
                 "ui",
                 "--extra",
                 "mlflow",
-                "--preview-features",
-                "python-upgrade",
             ],
             root,
             True,
         )
     ]
+
+
+def test_bootstrap_project_venv_does_not_run_uv_python_upgrade(tmp_path: Path, monkeypatch) -> None:
+    project = tmp_path / "demo_project"
+    project.mkdir()
+    python_path = project / ".venv" / "bin" / "python"
+    calls: list[tuple[list[str], Path, bool]] = []
+
+    monkeypatch.setattr(setup_pycharm, "_find_uv_binary", lambda: "/usr/bin/uv")
+    monkeypatch.setattr(setup_pycharm, "venv_python_for", lambda _project_dir: python_path)
+
+    def fake_run(argv, cwd, check):
+        calls.append((argv, cwd, check))
+        return subprocess.CompletedProcess(argv, 0)
+
+    monkeypatch.setattr(setup_pycharm.subprocess, "run", fake_run)
+
+    assert setup_pycharm._bootstrap_project_venv(project) == python_path
+    assert calls == [(["/usr/bin/uv", "sync", "--project", "."], project, True)]
+    assert "python-upgrade" not in calls[0][0]
 
 
 def test_ensure_project_ui_environment_skips_when_ui_modules_import(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- remove `--preview-features python-upgrade` from default root installer sync/run commands
- remove `python-upgrade` from PyCharm setup bootstrap and UI-extra sync commands
- add regressions proving default installer/PyCharm setup no longer rewrites dependency floors

## Repro
Running the source install path with app tests started rewriting many committed `pyproject.toml` files, including `requires-python`, Streamlit, Pydantic, Polars, Starlette, and core dependency lower bounds.

## Root Cause
Routine install/PyCharm setup commands passed `uv --preview-features python-upgrade`. That preview feature mutates project metadata and dependency lower bounds. It is not safe for normal install/setup paths.

## Regression Test
- `test_root_installer_does_not_run_uv_python_upgrade_by_default`
- `test_bootstrap_project_venv_does_not_run_uv_python_upgrade`
- updated PyCharm UI-extra sync assertion to exclude `python-upgrade`

## Validation
- `bash -n install.sh src/agilab/install_apps.sh src/agilab/core/install.sh`
- `uv --preview-features extra-build-dependencies run -p 3.14.6+gil pytest -q -o addopts='' test/test_setup_pycharm.py::test_ensure_project_ui_environment_syncs_missing_dev_ui_extra test/test_setup_pycharm.py::test_bootstrap_project_venv_does_not_run_uv_python_upgrade test/test_install_local_models.py::test_root_installer_does_not_run_uv_python_upgrade_by_default`
- `uv --preview-features extra-build-dependencies run -p 3.14.6+gil pytest -q -o addopts='' test/test_install_apps_discovery.py test/test_install_apps_last_session_defaults.py test/test_install_contract_check.py test/test_install_local_models.py test/test_install_python_selection.py test/test_install_release_proof_package.py test/test_setup_pycharm.py`
- `uv --preview-features extra-build-dependencies run -p 3.14.6+gil python tools/impact_validate.py --files install.sh pycharm/setup_pycharm.py test/test_setup_pycharm.py test/test_install_local_models.py`
- `git diff --check`
- `python3 tools/agent_commit_provenance_guard.py --check-config`

## Skipped Checks
- Full root install rerun: not run because a user-owned install process is already active in the original checkout. The fix is covered at the command-construction level and by installer/PyCharm regression tests.

## Review Evidence
- Higher-model/sub-agent review: not used.

## Agent Metadata
- Tokki version: `tokki 1.0.19`
- Agent/runtime: Codex CLI, version unknown
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used
