### PR TITLE
Resolve workflow inputs from shared dataset root

### DIFF
--- a/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/base_worker.py
+++ b/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/base_worker.py
@@ -204,6 +204,10 @@ class BaseWorker(ArtifactContract, abc.ABC):
     def _share_root_path(env: AgiEnv | None) -> Path | None:
         return path_support.share_root_path(env, path_cls=Path)
 
+    @staticmethod
+    def _physical_share_root_path(env: AgiEnv | None) -> Path | None:
+        return path_support.physical_share_root_path(env, path_cls=Path)
+
     @classmethod
     def _resolve_data_dir(
         cls,

--- a/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/base_worker_path_support.py
+++ b/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/base_worker_path_support.py
@@ -116,6 +116,44 @@ def share_root_path(
     return path_cls(env.home_abs).expanduser()
 
 
+def physical_share_root_path(
+    env: Any | None,
+    *,
+    path_cls: type[Path] = Path,
+) -> Path | None:
+    """Return the physical cluster/share root, ignoring workflow-session scoping."""
+
+    if env is None:
+        return None
+
+    share_root_method = getattr(env, "share_root_path", None)
+    if callable(share_root_method):
+        try:
+            return path_cls(share_root_method()).expanduser().resolve(strict=False)
+        except SHARE_ROOT_FALLBACK_EXCEPTIONS:
+            pass
+
+    for candidate, use_runtime_home in (
+        (getattr(env, "agi_share_path_abs", None), False),
+        (getattr(env, "agi_share_path", None), bool(getattr(env, "is_worker_env", False))),
+    ):
+        if not candidate:
+            continue
+        try:
+            base = path_cls(candidate).expanduser()
+            if not base.is_absolute():
+                if use_runtime_home:
+                    home = path_cls.home()
+                else:
+                    home_abs = getattr(env, "home_abs", None)
+                    home = path_cls(home_abs).expanduser() if home_abs else path_cls.home()
+                base = home / base
+            return base.resolve(strict=False)
+        except SHARE_ROOT_FALLBACK_EXCEPTIONS:
+            continue
+    return None
+
+
 def _relative_share_prefixes(
     env: Any | None,
     share_base: Path,
@@ -195,6 +233,13 @@ def _resolve_relative_data_path(
     return path_cls(share_base).expanduser() / raw
 
 
+def _path_exists(path: Path) -> bool:
+    try:
+        return path.exists()
+    except OSError:
+        return False
+
+
 def resolve_data_dir(
     env: Any | None,
     data_path: Path | str | None,
@@ -211,13 +256,31 @@ def resolve_data_dir(
     raw = path_cls(str(data_path)).expanduser()
     if not raw.is_absolute():
         base = share_root_path_fn(env) or home_factory()
-        raw = _resolve_relative_data_path(
+        session_candidate = _resolve_relative_data_path(
             raw,
             path_cls(base).expanduser(),
             env,
             path_cls=path_cls,
             home_factory=home_factory,
         )
+        raw = session_candidate
+
+        physical_base = physical_share_root_path(env, path_cls=path_cls)
+        if physical_base is not None:
+            try:
+                same_base = path_cls(base).expanduser().resolve(strict=False) == physical_base
+            except SHARE_ROOT_FALLBACK_EXCEPTIONS:
+                same_base = False
+            if not same_base:
+                physical_candidate = _resolve_relative_data_path(
+                    path_cls(str(data_path)).expanduser(),
+                    physical_base,
+                    env,
+                    path_cls=path_cls,
+                    home_factory=home_factory,
+                )
+                if not _path_exists(session_candidate) and _path_exists(physical_candidate):
+                    raw = physical_candidate
 
     remapped = remap_managed_pc_path_fn(raw)
     try:

--- a/src/agilab/core/test/test_base_worker.py
+++ b/src/agilab/core/test/test_base_worker.py
@@ -298,6 +298,34 @@ def test_baseworker_uses_workflow_session_share_root_for_manager_relative_paths(
     assert "workflows/20260618T093102Z-492de776/flight_trajectory/dataset" in resolved.as_posix()
 
 
+def test_baseworker_data_in_falls_back_to_physical_share_root(tmp_path):
+    session_root = tmp_path / "clustershare" / "agi" / "workflows" / "run-1"
+    physical_root = tmp_path / "clustershare" / "agi"
+    seeded_input = physical_root / "uav_relay_queue" / "scenarios"
+    seeded_input.mkdir(parents=True)
+
+    env = SimpleNamespace(
+        AGILAB_WORKFLOW_DATA_ROOT=session_root,
+        share_root_path=lambda: physical_root,
+        agi_share_path_abs=physical_root,
+        agi_share_path=Path("clustershare") / "agi",
+        home_abs=tmp_path,
+        _is_managed_pc=False,
+    )
+
+    assert BaseWorker._resolve_data_dir(
+        env,
+        Path("uav_relay_queue") / "scenarios",
+    ) == seeded_input.resolve(strict=False)
+
+    session_input = session_root / "uav_relay_queue" / "scenarios"
+    session_input.mkdir(parents=True)
+    assert BaseWorker._resolve_data_dir(
+        env,
+        Path("uav_relay_queue") / "scenarios",
+    ) == session_input.resolve(strict=False)
+
+
 def test_baseworker_collect_share_aliases_and_data_dir_fallbacks(monkeypatch, tmp_path):
     class _BrokenPath:
         def __fspath__(self):

--- a/src/agilab/core/test/test_base_worker_path_support.py
+++ b/src/agilab/core/test/test_base_worker_path_support.py
@@ -136,6 +136,44 @@ def test_manager_data_dir_uses_active_workflow_data_root_not_cluster_share(tmp_p
     assert path_support.share_root_path(env) == session_root.resolve(strict=False)
 
 
+def test_input_data_dir_falls_back_to_physical_share_when_session_input_missing(tmp_path):
+    session_root = tmp_path / "clustershare" / "agi" / "workflows" / "run-1"
+    physical_root = tmp_path / "clustershare" / "agi"
+    seeded_input = physical_root / "uav_relay_queue" / "scenarios"
+    seeded_input.mkdir(parents=True)
+
+    env = SimpleNamespace(
+        AGILAB_WORKFLOW_DATA_ROOT=session_root,
+        share_root_path=lambda: physical_root,
+        agi_share_path_abs=physical_root,
+        agi_share_path=Path("clustershare") / "agi",
+        home_abs=tmp_path,
+        _is_managed_pc=False,
+    )
+
+    resolved = path_support.resolve_data_dir(
+        env,
+        Path("uav_relay_queue") / "scenarios",
+        share_root_path_fn=lambda current_env: path_support.share_root_path(current_env),
+        remap_managed_pc_path_fn=lambda value: Path(value),
+        normalized_path_fn=lambda value: Path(value),
+    )
+
+    assert resolved == seeded_input.resolve(strict=False)
+
+    session_input = session_root / "uav_relay_queue" / "scenarios"
+    session_input.mkdir(parents=True)
+    resolved = path_support.resolve_data_dir(
+        env,
+        Path("uav_relay_queue") / "scenarios",
+        share_root_path_fn=lambda current_env: path_support.share_root_path(current_env),
+        remap_managed_pc_path_fn=lambda value: Path(value),
+        normalized_path_fn=lambda value: Path(value),
+    )
+
+    assert resolved == session_input.resolve(strict=False)
+
+
 def test_artifact_dir_prefers_export_root_then_share_resolver(tmp_path):
     export_root = tmp_path / "explicit-export"
     env = SimpleNamespace(

--- a/src/agilab/core/test/test_pipeline_workflow_insights.py
+++ b/src/agilab/core/test/test_pipeline_workflow_insights.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from agilab.pipeline.pipeline_workflow_insights import build_data_availability
+
+
+def test_data_availability_uses_separate_input_roots_without_leaking_outputs(tmp_path):
+    session_root = tmp_path / "clustershare" / "agi" / "workflows" / "run-1"
+    physical_root = tmp_path / "clustershare" / "agi"
+    shared_input = physical_root / "uav_relay_queue" / "scenarios"
+    shared_output = physical_root / "uav_relay_queue" / "dataframe"
+    shared_input.mkdir(parents=True)
+    shared_output.mkdir(parents=True)
+
+    report = build_data_availability(
+        [
+            {
+                "data_in": "uav_relay_queue/scenarios",
+                "data_out": "uav_relay_queue/dataframe",
+            }
+        ],
+        [0],
+        [session_root],
+        input_roots=[session_root, physical_root],
+    )
+
+    rows = {(row["kind"], row["path"]): row for row in report["rows"]}
+    input_row = rows[("input", "uav_relay_queue/scenarios")]
+    output_row = rows[("output", "uav_relay_queue/dataframe")]
+
+    assert input_row["status"] == "present"
+    assert Path(input_row["resolved_path"]) == shared_input
+    assert output_row["status"] == "missing"
+    assert output_row["resolved_path"] == ""

--- a/src/agilab/pipeline/pipeline_lab.py
+++ b/src/agilab/pipeline/pipeline_lab.py
@@ -359,6 +359,12 @@ def _render_pipeline_automation_manifest_summary(path: str, *, key_prefix: str) 
 
 def _workflow_cockpit_roots(env: AgiEnv, lab_dir: Path, stages_file: Path) -> List[Path]:
     roots: List[Path] = [lab_dir, stages_file.parent]
+    workflow_root_path = getattr(env, "workflow_data_root_path", None)
+    if callable(workflow_root_path):
+        try:
+            roots.append(Path(workflow_root_path()).expanduser())
+        except (OSError, RuntimeError, TypeError, ValueError):
+            pass
     for attr in ("runenv", "localshare", "cluster_share", "share_path"):
         raw = getattr(env, attr, None)
         if raw:
@@ -368,6 +374,26 @@ def _workflow_cockpit_roots(env: AgiEnv, lab_dir: Path, stages_file: Path) -> Li
     roots.append(localshare_root)
     if app_name:
         roots.append(localshare_root / app_name)
+    unique: List[Path] = []
+    seen: set[str] = set()
+    for root in roots:
+        root_text = str(root)
+        if root_text not in seen:
+            seen.add(root_text)
+            unique.append(root)
+    return unique
+
+
+def _workflow_cockpit_input_roots(env: AgiEnv, lab_dir: Path, stages_file: Path) -> List[Path]:
+    roots: List[Path] = list(_workflow_cockpit_roots(env, lab_dir, stages_file))
+    for method_name in ("workflow_data_root_path", "share_root_path"):
+        method = getattr(env, method_name, None)
+        if callable(method):
+            try:
+                roots.append(Path(method()).expanduser())
+            except (OSError, RuntimeError, TypeError, ValueError):
+                pass
+
     unique: List[Path] = []
     seen: set[str] = set()
     for root in roots:
@@ -410,6 +436,7 @@ def _render_workflow_cockpit(
         stage_ids=stage_ids_by_idx,
         stage_deps=deps_by_stage_id,
         roots=_workflow_cockpit_roots(env, lab_dir, stages_file),
+        input_roots=_workflow_cockpit_input_roots(env, lab_dir, stages_file),
         manifest=manifest,
         pandas_paths=_workflow_cockpit_pandas_paths(),
         dependency_error=dependency_error,

--- a/src/agilab/pipeline/pipeline_workflow_insights.py
+++ b/src/agilab/pipeline/pipeline_workflow_insights.py
@@ -148,6 +148,8 @@ def build_data_availability(
     stages: Sequence[Mapping[str, Any]],
     sequence: Sequence[int],
     roots: Sequence[Path],
+    *,
+    input_roots: Sequence[Path] | None = None,
 ) -> dict[str, Any]:
     rows: list[dict[str, Any]] = []
     for idx in sequence:
@@ -155,7 +157,8 @@ def build_data_availability(
             continue
         stage = stages[int(idx)]
         for spec in stage_path_specs(stage):
-            existing = _first_existing_path(spec["path"], roots)
+            spec_roots = input_roots if spec["kind"] == "input" and input_roots is not None else roots
+            existing = _first_existing_path(spec["path"], spec_roots)
             rows.append(
                 {
                     "stage": int(idx) + 1,
@@ -731,6 +734,7 @@ def build_workflow_cockpit_model(
     stage_ids: Mapping[int, str],
     stage_deps: Mapping[str, Sequence[str]],
     roots: Sequence[Path],
+    input_roots: Sequence[Path] | None = None,
     manifest: Mapping[str, Any] | None = None,
     pandas_paths: Sequence[Path] = (),
     dependency_error: str | None = None,
@@ -744,7 +748,12 @@ def build_workflow_cockpit_model(
         stage_deps,
         dependency_error=dependency_error,
     )
-    data_availability = build_data_availability(stages, sequence, roots)
+    data_availability = build_data_availability(
+        stages,
+        sequence,
+        roots,
+        input_roots=input_roots,
+    )
     model_artifacts = discover_model_artifacts(roots)
     pandas_compat = audit_pandas_compat(pandas_paths) if pandas_paths else {"total": 0, "by_kind": {}, "findings": [], "truncated": False}
     evidence = build_evidence_score(


### PR DESCRIPTION
## Summary

- Resolve relative worker `data_in` paths against the active workflow/session root first, then fall back to the physical shared dataset root when the session copy is absent.
- Keep output resolution session-scoped; workflow cockpit preflight now accepts separate input roots so shared install-seeded datasets do not unblock or mark outputs as present.
- Add focused regressions for path support, `BaseWorker`, and workflow cockpit data availability.

## Repro

A workflow stage can declare an install-seeded input such as `uav_relay_queue/scenarios`. During workflow execution, `workers_data_path` scopes the active workflow root to `clustershare/<user>/<workflow>/<session>`, while install seeding placed the dataset once under the physical cluster-share root. The cockpit preflight and worker resolver then looked only under the session root and reported `missing-input` even when the seeded dataset existed in the physical share.

## Root Cause

Input and output paths were resolved through the same active workflow/session-root path contract. That is correct for outputs, but too narrow for inputs because inputs may be either same-session upstream outputs or install-seeded shared datasets.

## Regression Test

- `test_input_data_dir_falls_back_to_physical_share_when_session_input_missing`
- `test_baseworker_data_in_falls_back_to_physical_share_root`
- `test_data_availability_uses_separate_input_roots_without_leaking_outputs`

## Validation

- `uv --preview-features extra-build-dependencies run -p 3.14.6+gil --no-project --with pytest --with-editable ./src/agilab/core/agi-env --with-editable ./src/agilab/core/agi-node --with-editable . pytest -q -o addopts='' src/agilab/core/test/test_base_worker_path_support.py src/agilab/core/test/test_base_worker.py src/agilab/core/test/test_pipeline_workflow_insights.py` -> 69 passed
- `uv --preview-features extra-build-dependencies run -p 3.14.6+gil --no-project --with pytest --with-editable ./src/agilab/core/agi-env --with-editable ./src/agilab/core/agi-node --with-editable . pytest -q -o addopts='' src/agilab/core/test/test_base_worker.py src/agilab/core/test/test_base_worker_execution_support.py src/agilab/core/test/test_base_worker_path_support.py src/agilab/core/test/test_base_worker_runtime_support.py src/agilab/core/test/test_base_worker_service_support.py src/agilab/core/test/test_pipeline_workflow_insights.py` -> 145 passed
- `uv --preview-features extra-build-dependencies run -p 3.14.6+gil python tools/impact_validate.py --files ...` -> high-risk shared-core classification, expected for this approved shared-runtime fix
- `python3 tools/agent_commit_provenance_guard.py --check-config` -> pass
- pre-push guard -> pass with `AGILAB_ALLOW_MIXED_SCOPE_PUSH=1` because the approved fix intentionally spans shared worker runtime, pipeline preflight, and tests

## Skipped Checks

- Full `src/agilab/core/test` was not run; the impact-selected dispatcher/worker slice was run instead.
- Browser robot validation was not run; the UI change is in the Streamlit-free cockpit model/preflight data resolver and has a focused pure regression.
- Initial `./dev scope` without `UV_PYTHON=3.14.6+gil` hit the known freethreaded Python 3.14 Polars build failure. Re-running with GIL Python completed and classified the intended mixed scope.

## Review Evidence

- Model or sub-agent review: not used.

## Agent Metadata

- Tokki version: tokki 1.0.19
- Agent/runtime: Codex CLI 0.142.5
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used
