### PR TITLE
[codex] Align orchestrate deploy log widget

### DIFF
--- a/src/agilab/pages/2_ORCHESTRATE.py
+++ b/src/agilab/pages/2_ORCHESTRATE.py
@@ -1005,7 +1005,7 @@ def load_toml_file(file_path: str | Path) -> dict[str, Any]:
 
 
 @st.cache_data(show_spinner=False)
-def load_distribution(file_path: str | Path) -> tuple[list[str], list[Any], list[Any]]:
+def load_distribution(file_path: str | Path) -> tuple[list[str], list[Any], list[Any], str, str, str]:
     with open(file_path, "r") as f:
         data = json.load(f)
     workers = [
@@ -1013,7 +1013,17 @@ def load_distribution(file_path: str | Path) -> tuple[list[str], list[Any], list
         for ip, count in data.get("workers", {}).items()
         for i in range(1, count + 1)
     ]
-    return workers, data.get("work_plan_metadata", []), data.get("work_plan", [])
+    partition_key = str(data.get("partition_key") or "Partition")
+    weights_key = str(data.get("nb_unit") or data.get("weights_key") or "Units")
+    weights_unit = str(data.get("weights_unit") or "Unit")
+    return (
+        workers,
+        data.get("work_plan_metadata", []),
+        data.get("work_plan", []),
+        partition_key,
+        weights_key,
+        weights_unit,
+    )
 
 
 def _apply_distribution_plan_action(
@@ -1098,19 +1108,21 @@ async def _check_distribution_action(
     *,
     cmd: str,
     project_path: Path,
-    on_log: Optional[Callable[[], None]] = None,
+    on_log: Optional[Callable[[str], None]] = None,
 ) -> ActionResult:
     dist_log: list[str] = []
     runtime_root = orchestrate_snippet_runtime_root(env, project_path)
     command = cmd.replace("asyncio.run(main())", env.snippet_tail)
 
+    def _append_distribution_log(message: str) -> None:
+        _append_log_lines(dist_log, message)
+        if on_log is not None:
+            on_log(message)
+
     try:
         stdout, stderr = await env.run_agi(
             command,
-            log_callback=lambda message: (
-                _append_log_lines(dist_log, message),
-                on_log() if on_log is not None else None,
-            ),
+            log_callback=_append_distribution_log,
             venv=runtime_root,
         )
     except (
@@ -1121,7 +1133,7 @@ async def _check_distribution_action(
         AttributeError,
         KeyError,
     ) as exc:
-        _append_log_lines(dist_log, f"ERROR: {exc}")
+        _append_distribution_log(f"ERROR: {exc}")
         return ActionResult.error(
             "Distribution build failed.",
             detail=str(exc),
@@ -1134,9 +1146,9 @@ async def _check_distribution_action(
         )
 
     if stderr:
-        _append_log_lines(dist_log, stderr)
+        _append_distribution_log(stderr)
     if stdout:
-        _append_log_lines(dist_log, stdout)
+        _append_distribution_log(stdout)
 
     data = {
         "command": command,
@@ -1174,14 +1186,14 @@ async def _install_worker_action(
     install_command: str,
     venv: Any,
     local_log: list[str],
-    on_log: Optional[Callable[[], None]] = None,
+    on_log: Optional[Callable[[str], None]] = None,
     workerless: bool = False,
     manager_install_command: str | None = None,
 ) -> ActionResult:
     def _append_install_log(message: str) -> None:
         _append_log_lines(local_log, message)
         if on_log is not None:
-            on_log()
+            on_log(message)
 
     if manager_install_command:
         manager_stdout = ""
@@ -2000,11 +2012,7 @@ async def _render_deployment_panel(
             install_expanded = st.session_state.get("_install_logs_expanded", False)
             with st.expander("Deployment logs", expanded=install_expanded):
                 log_placeholder = st.empty()
-                log_placeholder.code(
-                    existing_log,
-                    language="python",
-                    height=INSTALL_LOG_HEIGHT,
-                )
+                update_log(log_placeholder, "")
         pending_install_requested = consume_pending_install_action(st.session_state)
         install_requested = st.button(
             ORCHESTRATE_ACTION_LABELS["deploy_workers"],
@@ -2036,11 +2044,7 @@ async def _render_deployment_panel(
                 log_placeholder.empty()
                 for line in context_lines:
                     _append_log_lines(local_log, line)
-            log_placeholder.code(
-                "\n".join(local_log[-LOG_DISPLAY_MAX_LINES:]),
-                language="python",
-                height=INSTALL_LOG_HEIGHT,
-            )
+                    update_log(log_placeholder, line)
             elapsed_started = _orchestrate_start_action_elapsed(
                 st.session_state,
                 "orchestrate_deploy_workers",
@@ -2053,15 +2057,8 @@ async def _render_deployment_panel(
                 started_monotonic=elapsed_started,
             )
 
-            def _refresh_deploy_log() -> None:
-                log_placeholder.code(
-                    "\n".join(local_log[-LOG_DISPLAY_MAX_LINES:]),
-                    language="python",
-                    height=INSTALL_LOG_HEIGHT,
-                )
-
-            def _tick_deploy_progress() -> None:
-                _refresh_deploy_log()
+            def _tick_deploy_progress(message: str) -> None:
+                update_log(log_placeholder, message)
                 _orchestrate_update_action_elapsed_status(
                     elapsed_placeholder,
                     st.session_state,
@@ -2102,15 +2099,12 @@ async def _render_deployment_panel(
                     started_monotonic=elapsed_started,
                 )
                 with log_expander:
-                    log_placeholder.code(
-                        "\n".join(
-                            result.data.get("install_log", local_log)[
-                                -LOG_DISPLAY_MAX_LINES:
-                            ]
-                        ),
-                        language="python",
-                        height=INSTALL_LOG_HEIGHT,
-                    )
+                    final_install_log = result.data.get("install_log", local_log)
+                    if final_install_log:
+                        st.session_state["log_text"] = (
+                            "\n".join(str(line) for line in final_install_log) + "\n"
+                        )
+                    update_log(log_placeholder, "")
                 render_action_result(st, result)
                 if result.status == "success":
                     st.session_state["show_run"] = True
@@ -2278,7 +2272,8 @@ async def _render_distribution_panel(
                     started_monotonic=elapsed_started,
                 )
 
-                def _tick_distribution_elapsed() -> None:
+                def _tick_distribution_progress(message: str) -> None:
+                    update_log(live_log_placeholder, message)
                     _orchestrate_update_action_elapsed_status(
                         elapsed_placeholder,
                         st.session_state,
@@ -2288,11 +2283,12 @@ async def _render_distribution_panel(
                     )
 
                 with st.spinner("Building distribution..."):
+                    clear_log()
                     result = await _check_distribution_action(
                         env,
                         cmd=cmd,
                         project_path=project_path,
-                        on_log=_tick_distribution_elapsed,
+                        on_log=_tick_distribution_progress,
                     )
                 _orchestrate_finish_action_elapsed(
                     elapsed_placeholder,
@@ -2303,11 +2299,11 @@ async def _render_distribution_panel(
                     started_monotonic=elapsed_started,
                 )
                 dist_log = list(result.data.get("dist_log", ()))
-                live_log_placeholder.code(
-                    "\n".join(dist_log[-LOG_DISPLAY_MAX_LINES:]),
-                    language="python",
-                    height=LIVE_LOG_MIN_HEIGHT,
-                )
+                if dist_log:
+                    st.session_state["log_text"] = (
+                        "\n".join(str(line) for line in dist_log) + "\n"
+                    )
+                update_log(live_log_placeholder, "")
                 render_action_result(st, result)
                 if result.status == "success":
                     st.session_state.preview_tree = True
@@ -2316,12 +2312,14 @@ async def _render_distribution_panel(
             if st.session_state.get("preview_tree"):
                 dist_tree_path = distribution_state.distribution_path
                 if dist_tree_path is not None and dist_tree_path.exists():
-                    workers, work_plan_metadata, work_plan = load_distribution(
-                        dist_tree_path
-                    )
-                    partition_key = "Partition"
-                    weights_key = "Units"
-                    weights_unit = "Unit"
+                    (
+                        workers,
+                        work_plan_metadata,
+                        work_plan,
+                        partition_key,
+                        weights_key,
+                        weights_unit,
+                    ) = load_distribution(dist_tree_path)
                     tabs = st.tabs(["Tree", "Workload"])
                     with tabs[0]:
                         if is_dag_worker_base(getattr(env, "base_worker_cls", None)):

--- a/test/test_orchestrate_page_helpers.py
+++ b/test/test_orchestrate_page_helpers.py
@@ -1715,6 +1715,57 @@ def test_clear_cached_distribution_calls_clear_when_available():
     assert called["count"] == 1
 
 
+def test_load_distribution_returns_complete_distribution_contract(tmp_path: Path):
+    module = _load_orchestrate_module()
+    dist_tree = tmp_path / "distribution_tree.json"
+    dist_tree.write_text(
+        json.dumps(
+            {
+                "workers": {"10.0.0.1": 2, "10.0.0.2": 1},
+                "work_plan_metadata": [[["A", 2]], [["B", 3]], []],
+                "work_plan": [[["a.csv"]], [["b.csv"]], []],
+                "partition_key": "plane",
+                "nb_unit": "files",
+                "weights_unit": "KB",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert module.load_distribution(str(dist_tree)) == (
+        ["10.0.0.1-1", "10.0.0.1-2", "10.0.0.2-1"],
+        [[["A", 2]], [["B", 3]], []],
+        [[["a.csv"]], [["b.csv"]], []],
+        "plane",
+        "files",
+        "KB",
+    )
+
+
+def test_load_distribution_keeps_legacy_distribution_defaults(tmp_path: Path):
+    module = _load_orchestrate_module()
+    dist_tree = tmp_path / "distribution_tree.json"
+    dist_tree.write_text(
+        json.dumps(
+            {
+                "workers": {"127.0.0.1": 1},
+                "work_plan_metadata": [],
+                "work_plan": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert module.load_distribution(str(dist_tree)) == (
+        ["127.0.0.1-1"],
+        [],
+        [],
+        "Partition",
+        "Units",
+        "Unit",
+    )
+
+
 @pytest.mark.asyncio
 async def test_check_distribution_action_reports_success_and_uses_source_checkout_runtime(
     tmp_path: Path,
@@ -2037,6 +2088,7 @@ async def test_install_worker_action_refreshes_visible_log_during_worker_deploy(
     module = _load_orchestrate_module()
     local_log: list[str] = []
     live_snapshots: list[tuple[str, ...]] = []
+    live_messages: list[str] = []
 
     async def _run_agi(_cmd, log_callback=None, venv=None):
         assert log_callback is not None
@@ -2054,10 +2106,14 @@ async def test_install_worker_action_refreshes_visible_log_during_worker_deploy(
         install_command="install command",
         venv=tmp_path,
         local_log=local_log,
-        on_log=lambda: live_snapshots.append(tuple(local_log)),
+        on_log=lambda message: (
+            live_messages.append(message),
+            live_snapshots.append(tuple(local_log)),
+        ),
     )
 
     assert result.status == "success"
+    assert live_messages[0] == "Remote worker 192.168.20.15 installing dependencies"
     assert live_snapshots[0] == (
         "Remote worker 192.168.20.15 installing dependencies",
     )


### PR DESCRIPTION
## Summary
- Align ORCHESTRATE Deploy scheduler/workers and CHECK distribute live logs with the same shared `update_log(...)` renderer used by RUN.
- Make deploy and distribution callbacks message-aware so each streamed line refreshes the visible log widget consistently.
- Fix distribution plan loading to return the full display contract: workers, metadata, plan, partition key, weight key, and weight unit, with legacy defaults.

## Repro
On ORCHESTRATE, Deploy scheduler/workers and CHECK distribute rendered logs with manual `st.code(...)` list slices while RUN streamed through the shared live log renderer. This produced mismatched log widget behavior and dropped distribution metadata into hard-coded placeholders in the Workplan panel.

## Root Cause
Deploy and CHECK distribute bypassed the shared `update_log(...)` path used by RUN. Their callbacks only signaled elapsed-status refreshes, so the caller re-rendered a separate widget shape from accumulated lists. The distribution loader also returned only three values even though CHECK distribute writes labels in the saved payload.

## Regression Test
Added/updated focused regressions proving:
- `load_distribution(...)` returns the complete distribution display contract.
- legacy distribution payloads still receive safe default labels.
- deploy log callbacks receive the streamed message so callers can render through the shared live-log widget.

## Validation
- `git diff --check`
- Agent provenance guard passed.
- Focused pytest passed: 5 passed, 67 deselected.
- GitHub checks passed: `base-python-compat (3.13)`, `base-python-compat (3.14)`, `clean-public-install (macos-latest)`, `clean-public-install (ubuntu-latest)`, `clean-public-install (windows-latest)`, `local-only-policy`, `windows-core-tests`, and GitGuardian Security Checks.
- GitHub skipped: `public-demo-smoke`.
- Local `./dev scope` and local pre-commit/pre-push guards were blocked/skipped because local guard bootstrap fails building `polars-runtime-32==1.42.1` on CPython 3.14t/stable Rust before reaching this diff's checks.

## Review Evidence
Not used.

## Agent Metadata
- Tokki version: tokki 1.0.19
- Agent/runtime: Codex CLI/API runtime version unknown
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used
