### PR TITLE
Route generated artifacts through output roots

### DIFF
--- a/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/base_worker.py
+++ b/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/base_worker.py
@@ -290,6 +290,21 @@ class BaseWorker(ArtifactContract, abc.ABC):
         )
 
     @classmethod
+    def resolve_generated_artifact_path(
+        cls,
+        data_in_root: Path | str,
+        data_out_root: Path | str,
+        artifact_path: Path | str,
+    ) -> Path:
+        return path_support.resolve_generated_artifact_path(
+            data_in_root,
+            data_out_root,
+            artifact_path,
+            normalized_path_fn=cls._normalized_path,
+            path_cls=Path,
+        )
+
+    @classmethod
     def resolve_input_folder(
         cls,
         env: AgiEnv | None,

--- a/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/base_worker_path_support.py
+++ b/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/base_worker_path_support.py
@@ -294,6 +294,69 @@ def resolve_data_dir(
         return path_cls(os.path.normpath(str(resolved)))
 
 
+def _safe_resolved_path(path: Path, *, path_cls: type[Path] = Path) -> Path:
+    try:
+        return path.expanduser().resolve(strict=False)
+    except PATH_FALLBACK_EXCEPTIONS:
+        return path_cls(os.path.normpath(str(path.expanduser())))
+
+
+def _path_is_relative_to(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+        return True
+    except ValueError:
+        return False
+
+
+def resolve_generated_artifact_path(
+    data_in_root: Path | str,
+    data_out_root: Path | str,
+    artifact_path: Path | str,
+    *,
+    normalized_path_fn: Callable[[Path | str], Path] | None = None,
+    path_cls: type[Path] = Path,
+) -> Path:
+    """Resolve generated content under ``data_out`` instead of read-only input data.
+
+    Relative artifact paths are anchored under ``data_out_root``. If a caller
+    accidentally passes a path already rooted under ``data_in_root`` or prefixed
+    by the dataset leaf, the dataset prefix is replaced with ``data_out_root``.
+    The final path must not remain under ``data_in_root``.
+    """
+
+    if artifact_path is None:
+        raise ValueError("artifact_path must be provided")
+
+    normalize = normalized_path_fn or (lambda value: path_cls(value).expanduser())
+    data_in = _safe_resolved_path(normalize(data_in_root), path_cls=path_cls)
+    data_out = _safe_resolved_path(normalize(data_out_root), path_cls=path_cls)
+    raw = path_cls(str(artifact_path)).expanduser()
+
+    if raw == path_cls("."):
+        candidate = data_out
+    elif raw.is_absolute():
+        resolved_raw = _safe_resolved_path(raw, path_cls=path_cls)
+        if _path_is_relative_to(resolved_raw, data_in):
+            relative = resolved_raw.relative_to(data_in)
+            candidate = data_out / relative
+        else:
+            candidate = resolved_raw
+    else:
+        parts = tuple(part for part in raw.parts if part not in {"", "."})
+        if parts and parts[0] == data_in.name:
+            raw = path_cls(*parts[1:]) if len(parts) > 1 else path_cls(".")
+        candidate = data_out if raw == path_cls(".") else data_out / raw
+
+    resolved = _safe_resolved_path(candidate, path_cls=path_cls)
+    if _path_is_relative_to(resolved, data_in):
+        raise ValueError(
+            "Generated artifact path resolves under read-only data_in: "
+            f"{resolved} (data_in={data_in}, data_out={data_out})"
+        )
+    return resolved
+
+
 def _env_value(env: Any | None, name: str) -> Any:
     if env is None:
         return None

--- a/src/agilab/core/test/test_base_worker.py
+++ b/src/agilab/core/test/test_base_worker.py
@@ -326,6 +326,28 @@ def test_baseworker_data_in_falls_back_to_physical_share_root(tmp_path):
     ) == session_input.resolve(strict=False)
 
 
+def test_baseworker_generated_artifact_path_uses_data_out(tmp_path):
+    dataset_root = tmp_path / "flight_trajectory" / "dataset"
+    output_root = tmp_path / "flight_trajectory" / "dataframe"
+    dataset_root.mkdir(parents=True)
+    output_root.mkdir(parents=True)
+
+    relative = BaseWorker.resolve_generated_artifact_path(
+        dataset_root,
+        output_root,
+        Path("dataset") / "waypoints_split" / "001.geojson",
+    )
+    absolute = BaseWorker.resolve_generated_artifact_path(
+        dataset_root,
+        output_root,
+        dataset_root / "waypoints.geojson",
+    )
+
+    assert relative == (output_root / "waypoints_split" / "001.geojson").resolve(strict=False)
+    assert absolute == (output_root / "waypoints.geojson").resolve(strict=False)
+    assert "dataset" not in relative.relative_to(output_root).parts
+
+
 def test_baseworker_collect_share_aliases_and_data_dir_fallbacks(monkeypatch, tmp_path):
     class _BrokenPath:
         def __fspath__(self):

--- a/src/agilab/core/test/test_base_worker_path_support.py
+++ b/src/agilab/core/test/test_base_worker_path_support.py
@@ -174,6 +174,47 @@ def test_input_data_dir_falls_back_to_physical_share_when_session_input_missing(
     assert resolved == session_input.resolve(strict=False)
 
 
+def test_generated_artifact_path_uses_output_root_not_dataset(tmp_path):
+    dataset_root = tmp_path / "flight_trajectory" / "dataset"
+    output_root = tmp_path / "flight_trajectory" / "dataframe"
+    dataset_root.mkdir(parents=True)
+    output_root.mkdir(parents=True)
+
+    assert path_support.resolve_generated_artifact_path(
+        dataset_root,
+        output_root,
+        "waypoints_split/001.geojson",
+        normalized_path_fn=lambda value: Path(value).expanduser(),
+    ) == (output_root / "waypoints_split" / "001.geojson").resolve(strict=False)
+
+    assert path_support.resolve_generated_artifact_path(
+        dataset_root,
+        output_root,
+        Path("dataset") / "waypoints.geojson",
+        normalized_path_fn=lambda value: Path(value).expanduser(),
+    ) == (output_root / "waypoints.geojson").resolve(strict=False)
+
+    assert path_support.resolve_generated_artifact_path(
+        dataset_root,
+        output_root,
+        dataset_root / "CloudMapIvdl.npz",
+        normalized_path_fn=lambda value: Path(value).expanduser(),
+    ) == (output_root / "CloudMapIvdl.npz").resolve(strict=False)
+
+
+def test_generated_artifact_path_rejects_output_root_inside_dataset(tmp_path):
+    dataset_root = tmp_path / "link_sim" / "dataset"
+    output_root = dataset_root / "generated"
+
+    with pytest.raises(ValueError, match="read-only data_in"):
+        path_support.resolve_generated_artifact_path(
+            dataset_root,
+            output_root,
+            "CloudMapSat.npz",
+            normalized_path_fn=lambda value: Path(value).expanduser(),
+        )
+
+
 def test_artifact_dir_prefers_export_root_then_share_resolver(tmp_path):
     export_root = tmp_path / "explicit-export"
     env = SimpleNamespace(


### PR DESCRIPTION
## Summary

- Add a shared `BaseWorker.resolve_generated_artifact_path` contract for generated files.
- Route dataset-prefixed or absolute-under-dataset generated paths to `data_out` instead of read-only `data_in`.
- Add focused regressions for path support and the `BaseWorker` wrapper.

## Repro

`flight_trajectory_project` and `link_sim_project` had app-local generated artifacts that could be built by manually joining paths near `data_in`/`dataset` instead of using a shared output-root contract.

## Root Cause

The shared worker path layer resolved input data directories and output directories, but did not expose a reusable generated-artifact resolver. App code therefore had to remember the dataset/output boundary itself.

## Regression Test

Validation passed locally for the shared path slice and the affected private app slices.

## Validation

- `src/agilab/core/test/test_base_worker_path_support.py`
- `src/agilab/core/test/test_base_worker.py`
- `flight_trajectory_project/test/test_flight_trajectory_manager.py` against local shared core
- `link_sim_worker.py` py_compile against local shared core

## Agent Metadata

- Tokki version: `tokki 1.0.22`
- Agent/runtime: Codex CLI / GPT-5 Codex
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: unknown
