### PR TITLE
fix(apps): resolve pre-existing input datasets from the cluster share…

### DIFF
--- a/src/agilab/apps/builtin/data_quality_gate_project/src/data_quality_gate_worker/data_quality_gate_worker.py
+++ b/src/agilab/apps/builtin/data_quality_gate_project/src/data_quality_gate_worker/data_quality_gate_worker.py
@@ -49,8 +49,14 @@ def _resolve_optional_share_path(env: object, value: Path | None) -> Path | None
     if value is None:
         return None
     path = Path(value).expanduser()
-    if not path.is_absolute() and callable(getattr(env, "resolve_share_path", None)):
-        path = Path(env.resolve_share_path(path))
+    if not path.is_absolute():
+        # Inputs may be pre-existing files under the cluster share root; prefer
+        # resolve_share_input_path (workflow root with share-root fallback).
+        resolver = getattr(env, "resolve_share_input_path", None) or getattr(
+            env, "resolve_share_path", None
+        )
+        if callable(resolver):
+            path = Path(resolver(path))
     return path
 
 

--- a/src/agilab/apps/builtin/execution_pandas_project/src/execution_pandas/execution_pandas.py
+++ b/src/agilab/apps/builtin/execution_pandas_project/src/execution_pandas/execution_pandas.py
@@ -50,7 +50,10 @@ class ExecutionPandas(BaseWorker):
 
         self.args = ensure_defaults(args, env=env)
         self.args = self._apply_managed_pc_paths(self.args)
-        self.args.data_in = env.resolve_share_path(self.args.data_in)
+        # Inputs may be pre-existing datasets under the cluster share root;
+        # fall back to it when nothing exists under the workflow data root.
+        resolve_input = getattr(env, "resolve_share_input_path", None) or env.resolve_share_path
+        self.args.data_in = resolve_input(self.args.data_in)
         self.args.data_out = env.resolve_share_path(self.args.data_out)
         self.data_out = self.args.data_out
 

--- a/src/agilab/apps/builtin/execution_polars_project/src/execution_polars/execution_polars.py
+++ b/src/agilab/apps/builtin/execution_polars_project/src/execution_polars/execution_polars.py
@@ -50,7 +50,10 @@ class ExecutionPolars(BaseWorker):
 
         self.args = ensure_defaults(args, env=env)
         self.args = self._apply_managed_pc_paths(self.args)
-        self.args.data_in = env.resolve_share_path(self.args.data_in)
+        # Inputs may be pre-existing datasets under the cluster share root;
+        # fall back to it when nothing exists under the workflow data root.
+        resolve_input = getattr(env, "resolve_share_input_path", None) or env.resolve_share_path
+        self.args.data_in = resolve_input(self.args.data_in)
         self.args.data_out = env.resolve_share_path(self.args.data_out)
         self.data_out = self.args.data_out
 

--- a/src/agilab/apps/builtin/flight_telemetry_project/src/app_args_form.py
+++ b/src/agilab/apps/builtin/flight_telemetry_project/src/app_args_form.py
@@ -323,7 +323,8 @@ else:
         st.info("No changes to save.")
 
     if validated.data_source == "file":
-        resolved_data_in = env.resolve_share_path(validated.data_in)
+        _resolve_input = getattr(env, "resolve_share_input_path", None) or env.resolve_share_path
+        resolved_data_in = _resolve_input(validated.data_in)
         resolved_data_out = env.resolve_share_path(validated.data_out)
         if not resolved_data_in.exists():
             if _is_huggingface_space(env) and _is_default_file_seed(validated.data_in):

--- a/src/agilab/apps/builtin/flight_telemetry_project/src/flight_telemetry/flight_telemetry.py
+++ b/src/agilab/apps/builtin/flight_telemetry_project/src/flight_telemetry/flight_telemetry.py
@@ -66,7 +66,11 @@ class FlightTelemetry(BaseWorker):
             except ValidationError as exc:
                 raise ValueError(f"Invalid FlightTelemetry arguments: {exc}") from exc
         self.args = parsed_args
-        self.args.data_in = env.resolve_share_path(self.args.data_in)
+        # Inputs are pre-existing datasets: fall back to the cluster share root
+        # when they are not present under the workflow data root. Outputs stay
+        # workflow-scoped.
+        resolve_input = getattr(env, "resolve_share_input_path", None) or env.resolve_share_path
+        self.args.data_in = resolve_input(self.args.data_in)
         self.args.data_out = env.resolve_share_path(self.args.data_out)
         self.data_out = self.args.data_out
 

--- a/src/agilab/apps/builtin/minimal_app_project/src/app_args_form.py
+++ b/src/agilab/apps/builtin/minimal_app_project/src/app_args_form.py
@@ -123,6 +123,7 @@ else:
         st.info("No changes to save.")
 
     if hasattr(env, "resolve_share_path"):
-        resolved_data_in = env.resolve_share_path(validated.data_in)
+        _resolve_input = getattr(env, "resolve_share_input_path", None) or env.resolve_share_path
+        resolved_data_in = _resolve_input(validated.data_in)
         resolved_data_out = env.resolve_share_path(validated.data_out)
         st.caption(f"Resolved input: `{resolved_data_in}`  •  output: `{resolved_data_out}`")

--- a/src/agilab/apps/builtin/minimal_app_project/src/minimal_app/minimal_app.py
+++ b/src/agilab/apps/builtin/minimal_app_project/src/minimal_app/minimal_app.py
@@ -38,7 +38,10 @@ class MinimalApp(BaseWorker):
             except ValidationError as exc:
                 raise ValueError(f"Invalid MinimalApp arguments: {exc}") from exc
         self.args = args
-        self.args.data_in = env.resolve_share_path(self.args.data_in)
+        # Inputs may be pre-existing datasets under the cluster share root;
+        # fall back to it when nothing exists under the workflow data root.
+        resolve_input = getattr(env, "resolve_share_input_path", None) or env.resolve_share_path
+        self.args.data_in = resolve_input(self.args.data_in)
         self.args.data_out = env.resolve_share_path(self.args.data_out)
         self.data_out = self.args.data_out
 

--- a/src/agilab/apps/builtin/mission_decision_project/src/app_args_form.py
+++ b/src/agilab/apps/builtin/mission_decision_project/src/app_args_form.py
@@ -173,7 +173,8 @@ else:
     else:
         st.info("No changes to save.")
 
-    resolved_data_in = env.resolve_share_path(validated.data_in)
+    _resolve_input = getattr(env, "resolve_share_input_path", None) or env.resolve_share_path
+    resolved_data_in = _resolve_input(validated.data_in)
     resolved_data_out = env.resolve_share_path(validated.data_out)
     if not any(resolved_data_in.glob(validated.files)):
         st.info("No matching scenario file exists yet. The bundled public scenario will be seeded on first run.")

--- a/src/agilab/apps/builtin/mission_decision_project/src/mission_decision/mission_decision.py
+++ b/src/agilab/apps/builtin/mission_decision_project/src/mission_decision/mission_decision.py
@@ -39,7 +39,10 @@ class MissionDecision(BaseWorker):
 
         self.args = ensure_defaults(args, env=env)
         self.args = self._apply_managed_pc_paths(self.args)
-        self.args.data_in = env.resolve_share_path(self.args.data_in)
+        # Inputs may be pre-existing datasets under the cluster share root;
+        # fall back to it when nothing exists under the workflow data root.
+        resolve_input = getattr(env, "resolve_share_input_path", None) or env.resolve_share_path
+        self.args.data_in = resolve_input(self.args.data_in)
         self.args.data_out = env.resolve_share_path(self.args.data_out)
         self.data_out = self.args.data_out
 

--- a/src/agilab/apps/builtin/tescia_diagnostic_project/src/app_args_form.py
+++ b/src/agilab/apps/builtin/tescia_diagnostic_project/src/app_args_form.py
@@ -387,7 +387,8 @@ else:
     else:
         st.info("No changes to save.")
 
-    resolved_data_in = env.resolve_share_path(validated.data_in)
+    _resolve_input = getattr(env, "resolve_share_input_path", None) or env.resolve_share_path
+    resolved_data_in = _resolve_input(validated.data_in)
     resolved_data_out = env.resolve_share_path(validated.data_out)
     resolved_submission_inbox = env.resolve_share_path(validated.submission_inbox)
     if not any(resolved_data_in.glob(validated.files)):

--- a/src/agilab/apps/builtin/tescia_diagnostic_project/src/tescia_diagnostic/runtime/tescia_diagnostic.py
+++ b/src/agilab/apps/builtin/tescia_diagnostic_project/src/tescia_diagnostic/runtime/tescia_diagnostic.py
@@ -51,9 +51,12 @@ class TesciaDiagnostic(BaseWorker):
         self.args = ensure_defaults(args, env=env)
         self.args = self._apply_managed_pc_paths(self.args)
         self._generate_case_file_fn = _generate_case_file_fn
-        self.args.data_in = env.resolve_share_path(self.args.data_in)
+        # Inputs may be pre-existing datasets under the cluster share root;
+        # fall back to it when nothing exists under the workflow data root.
+        resolve_input = getattr(env, "resolve_share_input_path", None) or env.resolve_share_path
+        self.args.data_in = resolve_input(self.args.data_in)
         self.args.data_out = env.resolve_share_path(self.args.data_out)
-        self.args.submission_inbox = env.resolve_share_path(self.args.submission_inbox)
+        self.args.submission_inbox = resolve_input(self.args.submission_inbox)
         self.data_out = self.args.data_out
 
         self.args.data_in.mkdir(parents=True, exist_ok=True)

--- a/src/agilab/apps/builtin/tescia_diagnostic_project/src/tescia_diagnostic/ui/app_surface.py
+++ b/src/agilab/apps/builtin/tescia_diagnostic_project/src/tescia_diagnostic/ui/app_surface.py
@@ -273,9 +273,11 @@ def classroom_submission_inbox_dir(
     inbox = Path(str(getattr(runtime_args, "submission_inbox", "tescia_diagnostic/submissions")))
     if inbox.is_absolute():
         return inbox
-    resolve_share_path = getattr(runtime_env, "resolve_share_path", None)
-    if callable(resolve_share_path):
-        return Path(resolve_share_path(inbox))
+    resolver = getattr(runtime_env, "resolve_share_input_path", None) or getattr(
+        runtime_env, "resolve_share_path", None
+    )
+    if callable(resolver):
+        return Path(resolver(inbox))
     return Path(inbox).expanduser().resolve()
 
 

--- a/src/agilab/apps/builtin/uav_queue_project/src/app_args_form.py
+++ b/src/agilab/apps/builtin/uav_queue_project/src/app_args_form.py
@@ -163,7 +163,8 @@ else:
     else:
         st.info("No changes to save.")
 
-    resolved_data_in = env.resolve_share_path(validated.data_in)
+    _resolve_input = getattr(env, "resolve_share_input_path", None) or env.resolve_share_path
+    resolved_data_in = _resolve_input(validated.data_in)
     resolved_data_out = env.resolve_share_path(validated.data_out)
     if not any(resolved_data_in.glob(validated.files)):
         st.info("No matching scenario file exists yet. The bundled sample scenario will be seeded on first run.")

--- a/src/agilab/apps/builtin/uav_queue_project/src/uav_queue/uav_queue.py
+++ b/src/agilab/apps/builtin/uav_queue_project/src/uav_queue/uav_queue.py
@@ -39,7 +39,10 @@ class UavQueue(BaseWorker):
 
         self.args = ensure_defaults(args, env=env)
         self.args = self._apply_managed_pc_paths(self.args)
-        self.args.data_in = env.resolve_share_path(self.args.data_in)
+        # Inputs may be pre-existing datasets under the cluster share root;
+        # fall back to it when nothing exists under the workflow data root.
+        resolve_input = getattr(env, "resolve_share_input_path", None) or env.resolve_share_path
+        self.args.data_in = resolve_input(self.args.data_in)
         self.args.data_out = env.resolve_share_path(self.args.data_out)
         self.data_out = self.args.data_out
 

--- a/src/agilab/apps/builtin/uav_relay_queue_project/src/app_args_form.py
+++ b/src/agilab/apps/builtin/uav_relay_queue_project/src/app_args_form.py
@@ -163,7 +163,8 @@ else:
     else:
         st.info("No changes to save.")
 
-    resolved_data_in = env.resolve_share_path(validated.data_in)
+    _resolve_input = getattr(env, "resolve_share_input_path", None) or env.resolve_share_path
+    resolved_data_in = _resolve_input(validated.data_in)
     resolved_data_out = env.resolve_share_path(validated.data_out)
     if not any(resolved_data_in.glob(validated.files)):
         st.info("No matching scenario file exists yet. The bundled sample scenario will be seeded on first run.")

--- a/src/agilab/apps/builtin/uav_relay_queue_project/src/uav_relay_queue/uav_relay_queue.py
+++ b/src/agilab/apps/builtin/uav_relay_queue_project/src/uav_relay_queue/uav_relay_queue.py
@@ -39,7 +39,10 @@ class UavRelayQueue(BaseWorker):
 
         self.args = ensure_defaults(args, env=env)
         self.args = self._apply_managed_pc_paths(self.args)
-        self.args.data_in = env.resolve_share_path(self.args.data_in)
+        # Inputs may be pre-existing datasets under the cluster share root;
+        # fall back to it when nothing exists under the workflow data root.
+        resolve_input = getattr(env, "resolve_share_input_path", None) or env.resolve_share_path
+        self.args.data_in = resolve_input(self.args.data_in)
         self.args.data_out = env.resolve_share_path(self.args.data_out)
         self.data_out = self.args.data_out
 

--- a/src/agilab/apps/builtin/weather_forecast_legacy_project/src/app_args_form.py
+++ b/src/agilab/apps/builtin/weather_forecast_legacy_project/src/app_args_form.py
@@ -163,7 +163,8 @@ else:
     else:
         st.info("No changes to save.")
 
-    resolved_data_in = env.resolve_share_path(validated.data_in)
+    _resolve_input = getattr(env, "resolve_share_input_path", None) or env.resolve_share_path
+    resolved_data_in = _resolve_input(validated.data_in)
     resolved_data_out = env.resolve_share_path(validated.data_out)
     if not any(resolved_data_in.glob(validated.files)):
         st.info("No matching CSV file exists yet in the dataset directory. The bundled sample will be seeded on first run.")

--- a/src/agilab/apps/builtin/weather_forecast_legacy_project/src/weather_forecast_legacy/weather_forecast_legacy.py
+++ b/src/agilab/apps/builtin/weather_forecast_legacy_project/src/weather_forecast_legacy/weather_forecast_legacy.py
@@ -46,7 +46,10 @@ class WeatherForecastLegacy(BaseWorker):
 
         self.args = ensure_defaults(args, env=env)
         self.args = self._apply_managed_pc_paths(self.args)
-        self.args.data_in = env.resolve_share_path(self.args.data_in)
+        # Inputs may be pre-existing datasets under the cluster share root;
+        # fall back to it when nothing exists under the workflow data root.
+        resolve_input = getattr(env, "resolve_share_input_path", None) or env.resolve_share_path
+        self.args.data_in = resolve_input(self.args.data_in)
         self.args.data_out = env.resolve_share_path(self.args.data_out)
         self.data_out = self.args.data_out
 

--- a/src/agilab/apps/builtin/weather_forecast_project/src/app_args_form.py
+++ b/src/agilab/apps/builtin/weather_forecast_project/src/app_args_form.py
@@ -163,7 +163,8 @@ else:
     else:
         st.info("No changes to save.")
 
-    resolved_data_in = env.resolve_share_path(validated.data_in)
+    _resolve_input = getattr(env, "resolve_share_input_path", None) or env.resolve_share_path
+    resolved_data_in = _resolve_input(validated.data_in)
     resolved_data_out = env.resolve_share_path(validated.data_out)
     if not any(resolved_data_in.glob(validated.files)):
         st.info("No matching CSV file exists yet in the dataset directory. The bundled sample will be seeded on first run.")

--- a/src/agilab/apps/builtin/weather_forecast_project/src/weather_forecast/weather_forecast.py
+++ b/src/agilab/apps/builtin/weather_forecast_project/src/weather_forecast/weather_forecast.py
@@ -46,7 +46,10 @@ class WeatherForecast(BaseWorker):
 
         self.args = ensure_defaults(args, env=env)
         self.args = self._apply_managed_pc_paths(self.args)
-        self.args.data_in = env.resolve_share_path(self.args.data_in)
+        # Inputs may be pre-existing datasets under the cluster share root;
+        # fall back to it when nothing exists under the workflow data root.
+        resolve_input = getattr(env, "resolve_share_input_path", None) or env.resolve_share_path
+        self.args.data_in = resolve_input(self.args.data_in)
         self.args.data_out = env.resolve_share_path(self.args.data_out)
         self.data_out = self.args.data_out
 

--- a/src/agilab/core/agi-env/src/agi_env/runtime/agi_env.py
+++ b/src/agilab/core/agi-env/src/agi_env/runtime/agi_env.py
@@ -574,6 +574,25 @@ class AgiEnv(metaclass=_AgiEnvMeta):
         """
         return resolve_relative_share_path(path, self.workflow_data_root_path())
 
+    def resolve_share_input_path(self, path: str | Path | None) -> Path:
+        """
+        Resolve an *input* data path, preferring the workflow data root.
+
+        Pre-existing datasets live under the physical cluster share
+        (``AGI_CLUSTER_SHARE``) and are not copied into each workflow/session
+        root: when the workflow-scoped path does not exist, fall back to the
+        same relative path under the share root if it exists there. Output
+        paths must keep using :meth:`resolve_share_path` so workflow isolation
+        is preserved.
+        """
+        resolved = self.resolve_share_path(path)
+        if resolved.exists():
+            return resolved
+        fallback = resolve_relative_share_path(path, self.share_root_path())
+        if fallback != resolved and fallback.exists():
+            return fallback
+        return resolved
+
     def workflow_data_root_path(self) -> Path:
         """Return the active workflow/session data root when configured."""
 

--- a/src/agilab/core/agi-env/test/test_agi_env.py
+++ b/src/agilab/core/agi-env/test/test_agi_env.py
@@ -2769,6 +2769,51 @@ def test_share_root_resolution_and_mode_helpers(tmp_path: Path, monkeypatch):
         assert absolute_share_path == Path("/tmp/absolute").resolve(strict=False)
 
 
+def test_resolve_share_input_path_falls_back_to_share_root(tmp_path: Path, monkeypatch):
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("HOME", str(fake_home))
+
+    env = object.__new__(AgiEnv)
+    env._share_root_cache = None
+    env.agi_share_path = "clustershare"
+    env.home_abs = fake_home
+    env.is_worker_env = False
+    env.target = "demo_project"
+    env.app = "demo_project"
+    env.AGILAB_WORKFLOW_DATA_ROOT = "clustershare/alice/workflow/session-1"
+
+    workflow_root = fake_home / "clustershare" / "alice" / "workflow" / "session-1"
+    share_root = fake_home / "clustershare"
+
+    # Dataset only present at the physical share root -> fallback kicks in.
+    (share_root / "flight_telemetry" / "dataset").mkdir(parents=True)
+    assert (
+        env.resolve_share_input_path("flight_telemetry/dataset")
+        == share_root / "flight_telemetry" / "dataset"
+    )
+
+    # Workflow-scoped copy wins when it exists.
+    (workflow_root / "flight_telemetry" / "dataset").mkdir(parents=True)
+    assert (
+        env.resolve_share_input_path("flight_telemetry/dataset")
+        == workflow_root / "flight_telemetry" / "dataset"
+    )
+
+    # Missing everywhere -> keep the workflow-scoped resolution (same as
+    # resolve_share_path) so error messages point at the active data root.
+    assert (
+        env.resolve_share_input_path("missing/dataset")
+        == workflow_root / "missing" / "dataset"
+    )
+
+    # Outputs must not be affected: resolve_share_path stays workflow-scoped.
+    assert (
+        env.resolve_share_path("flight_telemetry/dataset")
+        == workflow_root / "flight_telemetry" / "dataset"
+    )
+
+
 def test_share_root_resolution_worker_uses_runtime_home_and_init_honours_share_override(tmp_path: Path, monkeypatch):
     fake_home = tmp_path / "worker-home"
     fake_home.mkdir()

--- a/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/src/app_args_form.py
+++ b/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/src/app_args_form.py
@@ -323,7 +323,8 @@ else:
         st.info("No changes to save.")
 
     if validated.data_source == "file":
-        resolved_data_in = env.resolve_share_path(validated.data_in)
+        _resolve_input = getattr(env, "resolve_share_input_path", None) or env.resolve_share_path
+        resolved_data_in = _resolve_input(validated.data_in)
         resolved_data_out = env.resolve_share_path(validated.data_out)
         if not resolved_data_in.exists():
             if _is_huggingface_space(env) and _is_default_file_seed(validated.data_in):

--- a/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/src/flight_telemetry/flight_telemetry.py
+++ b/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/src/flight_telemetry/flight_telemetry.py
@@ -66,7 +66,11 @@ class FlightTelemetry(BaseWorker):
             except ValidationError as exc:
                 raise ValueError(f"Invalid FlightTelemetry arguments: {exc}") from exc
         self.args = parsed_args
-        self.args.data_in = env.resolve_share_path(self.args.data_in)
+        # Inputs are pre-existing datasets: fall back to the cluster share root
+        # when they are not present under the workflow data root. Outputs stay
+        # workflow-scoped.
+        resolve_input = getattr(env, "resolve_share_input_path", None) or env.resolve_share_path
+        self.args.data_in = resolve_input(self.args.data_in)
         self.args.data_out = env.resolve_share_path(self.args.data_out)
         self.data_out = self.args.data_out
 

--- a/src/agilab/lib/agi-app-mission-decision/src/agi_app_mission_decision/project/mission_decision_project/src/app_args_form.py
+++ b/src/agilab/lib/agi-app-mission-decision/src/agi_app_mission_decision/project/mission_decision_project/src/app_args_form.py
@@ -173,7 +173,8 @@ else:
     else:
         st.info("No changes to save.")
 
-    resolved_data_in = env.resolve_share_path(validated.data_in)
+    _resolve_input = getattr(env, "resolve_share_input_path", None) or env.resolve_share_path
+    resolved_data_in = _resolve_input(validated.data_in)
     resolved_data_out = env.resolve_share_path(validated.data_out)
     if not any(resolved_data_in.glob(validated.files)):
         st.info("No matching scenario file exists yet. The bundled public scenario will be seeded on first run.")

--- a/src/agilab/lib/agi-app-mission-decision/src/agi_app_mission_decision/project/mission_decision_project/src/mission_decision/mission_decision.py
+++ b/src/agilab/lib/agi-app-mission-decision/src/agi_app_mission_decision/project/mission_decision_project/src/mission_decision/mission_decision.py
@@ -39,7 +39,10 @@ class MissionDecision(BaseWorker):
 
         self.args = ensure_defaults(args, env=env)
         self.args = self._apply_managed_pc_paths(self.args)
-        self.args.data_in = env.resolve_share_path(self.args.data_in)
+        # Inputs may be pre-existing datasets under the cluster share root;
+        # fall back to it when nothing exists under the workflow data root.
+        resolve_input = getattr(env, "resolve_share_input_path", None) or env.resolve_share_path
+        self.args.data_in = resolve_input(self.args.data_in)
         self.args.data_out = env.resolve_share_path(self.args.data_out)
         self.data_out = self.args.data_out
 

--- a/src/agilab/lib/agi-app-uav-relay-queue/src/agi_app_uav_relay_queue/project/uav_relay_queue_project/src/app_args_form.py
+++ b/src/agilab/lib/agi-app-uav-relay-queue/src/agi_app_uav_relay_queue/project/uav_relay_queue_project/src/app_args_form.py
@@ -163,7 +163,8 @@ else:
     else:
         st.info("No changes to save.")
 
-    resolved_data_in = env.resolve_share_path(validated.data_in)
+    _resolve_input = getattr(env, "resolve_share_input_path", None) or env.resolve_share_path
+    resolved_data_in = _resolve_input(validated.data_in)
     resolved_data_out = env.resolve_share_path(validated.data_out)
     if not any(resolved_data_in.glob(validated.files)):
         st.info("No matching scenario file exists yet. The bundled sample scenario will be seeded on first run.")

--- a/src/agilab/lib/agi-app-uav-relay-queue/src/agi_app_uav_relay_queue/project/uav_relay_queue_project/src/uav_relay_queue/uav_relay_queue.py
+++ b/src/agilab/lib/agi-app-uav-relay-queue/src/agi_app_uav_relay_queue/project/uav_relay_queue_project/src/uav_relay_queue/uav_relay_queue.py
@@ -39,7 +39,10 @@ class UavRelayQueue(BaseWorker):
 
         self.args = ensure_defaults(args, env=env)
         self.args = self._apply_managed_pc_paths(self.args)
-        self.args.data_in = env.resolve_share_path(self.args.data_in)
+        # Inputs may be pre-existing datasets under the cluster share root;
+        # fall back to it when nothing exists under the workflow data root.
+        resolve_input = getattr(env, "resolve_share_input_path", None) or env.resolve_share_path
+        self.args.data_in = resolve_input(self.args.data_in)
         self.args.data_out = env.resolve_share_path(self.args.data_out)
         self.data_out = self.args.data_out
 

--- a/src/agilab/lib/agi-app-weather-forecast/src/agi_app_weather_forecast/project/weather_forecast_project/src/app_args_form.py
+++ b/src/agilab/lib/agi-app-weather-forecast/src/agi_app_weather_forecast/project/weather_forecast_project/src/app_args_form.py
@@ -163,7 +163,8 @@ else:
     else:
         st.info("No changes to save.")
 
-    resolved_data_in = env.resolve_share_path(validated.data_in)
+    _resolve_input = getattr(env, "resolve_share_input_path", None) or env.resolve_share_path
+    resolved_data_in = _resolve_input(validated.data_in)
     resolved_data_out = env.resolve_share_path(validated.data_out)
     if not any(resolved_data_in.glob(validated.files)):
         st.info("No matching CSV file exists yet in the dataset directory. The bundled sample will be seeded on first run.")

--- a/src/agilab/lib/agi-app-weather-forecast/src/agi_app_weather_forecast/project/weather_forecast_project/src/weather_forecast/weather_forecast.py
+++ b/src/agilab/lib/agi-app-weather-forecast/src/agi_app_weather_forecast/project/weather_forecast_project/src/weather_forecast/weather_forecast.py
@@ -46,7 +46,10 @@ class WeatherForecast(BaseWorker):
 
         self.args = ensure_defaults(args, env=env)
         self.args = self._apply_managed_pc_paths(self.args)
-        self.args.data_in = env.resolve_share_path(self.args.data_in)
+        # Inputs may be pre-existing datasets under the cluster share root;
+        # fall back to it when nothing exists under the workflow data root.
+        resolve_input = getattr(env, "resolve_share_input_path", None) or env.resolve_share_path
+        self.args.data_in = resolve_input(self.args.data_in)
         self.args.data_out = env.resolve_share_path(self.args.data_out)
         self.data_out = self.args.data_out
 


### PR DESCRIPTION
When AGILAB_WORKFLOW_DATA_ROOT is active, resolve_share_path() scopes every relative path to the per-workflow root, so apps reading pre-existing datasets (e.g. flight_telemetry at <share>/flight_telemetry/dataset) failed with "Input directory does not exist" even though the data was present under AGI_CLUSTER_SHARE.

Add AgiEnv.resolve_share_input_path(): prefer the workflow data root, fall back to the same relative path under the physical share root when only the latter exists. This mirrors the fallback agi-node's resolve_data_dir already provides. Outputs keep using resolve_share_path() so workflow isolation (and reset_target safety) is preserved.

Apply it to input paths only, in every builtin app that consumes data_in (flight_telemetry, execution_pandas/polars, minimal_app, tescia_diagnostic, mission_decision, uav_queue, uav_relay_queue, weather_forecast(+legacy)), to data_quality_gate's optional input files, to tescia's submission_inbox (runtime + UI so both sides agree), and to the arg forms that preview the resolved input. lib/agi-app-* embedded mirrors are kept in sync.
