### PR TITLE
Harden shared path resolution

### DIFF
--- a/src/agilab/apps/builtin/data_quality_gate_project/src/app_args_form.py
+++ b/src/agilab/apps/builtin/data_quality_gate_project/src/app_args_form.py
@@ -39,11 +39,16 @@ def _load_current_args(settings_path: Path) -> DataQualityGateArgs:
 
 
 env = _get_env()
-settings_path = Path(env.app_settings_file)
+settings_path = Path(env.app_settings_file).resolve(strict=False)
 current_args = _load_current_args(settings_path)
 current_payload = current_args.model_dump(mode="json")
+artifact_target = str(getattr(env, "target", "") or getattr(env, "app", "") or "data_quality_gate_project")
+export_root = Path(getattr(env, "AGILAB_EXPORT_ABS", Path.home() / "export")).resolve(
+    strict=False
+)
+artifact_target = Path(artifact_target).name
 
-artifact_root = Path(getattr(env, "AGILAB_EXPORT_ABS", Path.home() / "export")) / env.target / "data_quality_gate"
+artifact_root = export_root / artifact_target / "data_quality_gate"
 st.caption(
     "Data Quality Gate validates a candidate dataset against a contract, drift thresholds, "
     f"and a promotion decision. Leave CSV fields empty for the deterministic built-in sample. "

--- a/src/agilab/apps/builtin/execution_pandas_project/src/app_args_form.py
+++ b/src/agilab/apps/builtin/execution_pandas_project/src/app_args_form.py
@@ -60,7 +60,7 @@ def _pool_executor_options_for_platform(system: str | None = None) -> tuple[str,
 
 
 env = _get_env()
-settings_path = Path(env.app_settings_file)
+settings_path = Path(env.app_settings_file).resolve(strict=False)
 current_args = _load_current_args(settings_path)
 current_payload = current_args.model_dump(mode="json")
 

--- a/src/agilab/apps/builtin/execution_polars_project/src/app_args_form.py
+++ b/src/agilab/apps/builtin/execution_polars_project/src/app_args_form.py
@@ -45,7 +45,7 @@ def _safe_rows_per_partition(rows_per_file: int, n_partitions: int) -> int:
 
 
 env = _get_env()
-settings_path = Path(env.app_settings_file)
+settings_path = Path(env.app_settings_file).resolve(strict=False)
 current_args = _load_current_args(settings_path)
 current_payload = current_args.model_dump(mode="json")
 

--- a/src/agilab/apps/builtin/flight_telemetry_project/src/app_args_form.py
+++ b/src/agilab/apps/builtin/flight_telemetry_project/src/app_args_form.py
@@ -138,7 +138,7 @@ def _is_default_file_seed(path_value: Any) -> bool:
 
 
 env = _get_env()
-settings_path = Path(env.app_settings_file)
+settings_path = Path(env.app_settings_file).resolve(strict=False)
 
 current_args = _load_current_args(settings_path)
 current_payload = current_args.to_toml_payload()

--- a/src/agilab/apps/builtin/minimal_app_project/src/app_args_form.py
+++ b/src/agilab/apps/builtin/minimal_app_project/src/app_args_form.py
@@ -39,7 +39,7 @@ def _load_current_args(settings_path: Path) -> MinimalAppArgs:
 
 
 env = _get_env()
-settings_path = Path(env.app_settings_file)
+settings_path = Path(env.app_settings_file).resolve(strict=False)
 current_args = _load_current_args(settings_path)
 current_payload = current_args.model_dump(mode="json")
 

--- a/src/agilab/apps/builtin/mission_decision_project/src/app_args_form.py
+++ b/src/agilab/apps/builtin/mission_decision_project/src/app_args_form.py
@@ -39,7 +39,7 @@ def _load_current_args(settings_path: Path) -> MissionDecisionArgs:
 
 
 env = _get_env()
-settings_path = Path(env.app_settings_file)
+settings_path = Path(env.app_settings_file).resolve(strict=False)
 current_args = _load_current_args(settings_path)
 current_payload = current_args.model_dump(mode="json")
 
@@ -47,8 +47,15 @@ try:
     share_root = env.share_root_path()
 except Exception:
     share_root = None
+artifact_target = str(
+    getattr(env, "target", "") or getattr(env, "app", "") or "mission_decision_project"
+)
+export_root = Path(getattr(env, "AGILAB_EXPORT_ABS", Path.home() / "export")).resolve(
+    strict=False
+)
+artifact_target = Path(artifact_target).name
 
-artifact_root = Path(getattr(env, "AGILAB_EXPORT_ABS", Path.home() / "export")) / env.target / "data_io_decision"
+artifact_root = export_root / artifact_target / "data_io_decision"
 
 st.caption(
     "This built-in app runs the public Mission Decision demo: "

--- a/src/agilab/apps/builtin/multi_app_dag_project/src/app_args_form.py
+++ b/src/agilab/apps/builtin/multi_app_dag_project/src/app_args_form.py
@@ -55,7 +55,7 @@ def _load_current_args(settings_path: Path) -> MultiAppDagArgs:
 
 
 env = _get_env()
-settings_path = Path(env.app_settings_file)
+settings_path = Path(env.app_settings_file).resolve(strict=False)
 current_args = _load_current_args(settings_path)
 current_payload = current_args.model_dump(mode="json")
 

--- a/src/agilab/apps/builtin/pytorch_playground_project/src/app_args_form.py
+++ b/src/agilab/apps/builtin/pytorch_playground_project/src/app_args_form.py
@@ -869,10 +869,12 @@ def render(
         or getattr(active_env, "app", "")
         or "pytorch_playground_project"
     )
+    export_root = Path(
+        getattr(active_env, "AGILAB_EXPORT_ABS", Path.home() / "export")
+    ).resolve(strict=False)
+    artifact_target = Path(artifact_target).name
     artifact_root = (
-        Path(getattr(active_env, "AGILAB_EXPORT_ABS", Path.home() / "export"))
-        / artifact_target
-        / "pytorch_playground"
+        export_root / artifact_target / "pytorch_playground"
     )
     output_container = container or st
     if not compact:

--- a/src/agilab/apps/builtin/r_runtime_bridge_project/src/app_args_form.py
+++ b/src/agilab/apps/builtin/r_runtime_bridge_project/src/app_args_form.py
@@ -43,7 +43,7 @@ def _parse_float_list(value: str) -> list[float]:
 
 
 env = _get_env()
-settings_path = Path(env.app_settings_file)
+settings_path = Path(env.app_settings_file).resolve(strict=False)
 current_args = _load_current_args(settings_path)
 current_payload = current_args.model_dump(mode="json")
 

--- a/src/agilab/apps/builtin/sklearn_pipeline_project/src/app_args_form.py
+++ b/src/agilab/apps/builtin/sklearn_pipeline_project/src/app_args_form.py
@@ -39,11 +39,16 @@ def _load_current_args(settings_path: Path) -> SklearnPipelineArgs:
 
 
 env = _get_env()
-settings_path = Path(env.app_settings_file)
+settings_path = Path(env.app_settings_file).resolve(strict=False)
 current_args = _load_current_args(settings_path)
 current_payload = current_args.model_dump(mode="json")
+artifact_target = str(getattr(env, "target", "") or getattr(env, "app", "") or "sklearn_pipeline_project")
+export_root = Path(getattr(env, "AGILAB_EXPORT_ABS", Path.home() / "export")).resolve(
+    strict=False
+)
+artifact_target = Path(artifact_target).name
 
-artifact_root = Path(getattr(env, "AGILAB_EXPORT_ABS", Path.home() / "export")) / env.target / "sklearn_pipeline"
+artifact_root = export_root / artifact_target / "sklearn_pipeline"
 st.caption(
     "Scikit-Learn Pipeline trains a deterministic local classifier and writes a "
     f"model, metrics, predictions, and hash manifest. Analysis artifacts are exported to `{artifact_root}`."

--- a/src/agilab/apps/builtin/tescia_diagnostic_project/src/app_args_form.py
+++ b/src/agilab/apps/builtin/tescia_diagnostic_project/src/app_args_form.py
@@ -151,10 +151,17 @@ def _render_self_evaluation_contract() -> None:
 
 
 env = _get_env()
-settings_path = Path(env.app_settings_file)
+settings_path = Path(env.app_settings_file).resolve(strict=False)
 current_args = _load_current_args(settings_path)
 current_payload = current_args.model_dump(mode="json")
-artifact_root = Path(getattr(env, "AGILAB_EXPORT_ABS", Path.home() / "export")) / env.target / "tescia_diagnostic"
+artifact_target = str(
+    getattr(env, "target", "") or getattr(env, "app", "") or "tescia_diagnostic_project"
+)
+export_root = Path(getattr(env, "AGILAB_EXPORT_ABS", Path.home() / "export")).resolve(
+    strict=False
+)
+artifact_target = Path(artifact_target).name
+artifact_root = export_root / artifact_target / "tescia_diagnostic"
 
 st.caption(
     "Turn a TeSciA-style diagnostic into repeatable evidence: symptom, evidence quality, "

--- a/src/agilab/apps/builtin/uav_queue_project/src/app_args_form.py
+++ b/src/agilab/apps/builtin/uav_queue_project/src/app_args_form.py
@@ -39,7 +39,7 @@ def _load_current_args(settings_path: Path) -> UavQueueArgs:
 
 
 env = _get_env()
-settings_path = Path(env.app_settings_file)
+settings_path = Path(env.app_settings_file).resolve(strict=False)
 current_args = _load_current_args(settings_path)
 current_payload = current_args.model_dump(mode="json")
 
@@ -47,8 +47,15 @@ try:
     share_root = env.share_root_path()
 except Exception:
     share_root = None
+artifact_target = str(
+    getattr(env, "target", "") or getattr(env, "app", "") or "uav_queue_project"
+)
+export_root = Path(getattr(env, "AGILAB_EXPORT_ABS", Path.home() / "export")).resolve(
+    strict=False
+)
+artifact_target = Path(artifact_target).name
 
-artifact_root = Path(getattr(env, "AGILAB_EXPORT_ABS", Path.home() / "export")) / env.target / "queue_analysis"
+artifact_root = export_root / artifact_target / "queue_analysis"
 
 st.caption(
     "This built-in app runs a lightweight UAV relay queue simulation with explicit "

--- a/src/agilab/apps/builtin/uav_relay_queue_project/src/app_args_form.py
+++ b/src/agilab/apps/builtin/uav_relay_queue_project/src/app_args_form.py
@@ -39,7 +39,7 @@ def _load_current_args(settings_path: Path) -> UavRelayQueueArgs:
 
 
 env = _get_env()
-settings_path = Path(env.app_settings_file)
+settings_path = Path(env.app_settings_file).resolve(strict=False)
 current_args = _load_current_args(settings_path)
 current_payload = current_args.model_dump(mode="json")
 
@@ -47,8 +47,15 @@ try:
     share_root = env.share_root_path()
 except Exception:
     share_root = None
+artifact_target = str(
+    getattr(env, "target", "") or getattr(env, "app", "") or "uav_relay_queue_project"
+)
+export_root = Path(getattr(env, "AGILAB_EXPORT_ABS", Path.home() / "export")).resolve(
+    strict=False
+)
+artifact_target = Path(artifact_target).name
 
-artifact_root = Path(getattr(env, "AGILAB_EXPORT_ABS", Path.home() / "export")) / env.target / "queue_analysis"
+artifact_root = export_root / artifact_target / "queue_analysis"
 
 st.caption(
     "This built-in app runs a lightweight UAV relay queue simulation with explicit "

--- a/src/agilab/apps/builtin/weather_forecast_legacy_project/src/app_args_form.py
+++ b/src/agilab/apps/builtin/weather_forecast_legacy_project/src/app_args_form.py
@@ -39,7 +39,7 @@ def _load_current_args(settings_path: Path) -> WeatherForecastLegacyArgs:
 
 
 env = _get_env()
-settings_path = Path(env.app_settings_file)
+settings_path = Path(env.app_settings_file).resolve(strict=False)
 current_args = _load_current_args(settings_path)
 current_payload = current_args.model_dump(mode="json")
 
@@ -47,8 +47,15 @@ try:
     share_root = env.share_root_path()
 except Exception:
     share_root = None
+artifact_target = str(
+    getattr(env, "target", "") or getattr(env, "app", "") or "weather_forecast_legacy_project"
+)
+export_root = Path(getattr(env, "AGILAB_EXPORT_ABS", Path.home() / "export")).resolve(
+    strict=False
+)
+artifact_target = Path(artifact_target).name
 
-artifact_root = Path(getattr(env, "AGILAB_EXPORT_ABS", Path.home() / "export")) / env.target / "forecast_analysis"
+artifact_root = export_root / artifact_target / "forecast_analysis"
 
 st.caption(
     "This app turns the notebook migration pilot into a reproducible AGILAB workflow. "

--- a/src/agilab/apps/builtin/weather_forecast_project/src/app_args_form.py
+++ b/src/agilab/apps/builtin/weather_forecast_project/src/app_args_form.py
@@ -39,7 +39,7 @@ def _load_current_args(settings_path: Path) -> WeatherForecastArgs:
 
 
 env = _get_env()
-settings_path = Path(env.app_settings_file)
+settings_path = Path(env.app_settings_file).resolve(strict=False)
 current_args = _load_current_args(settings_path)
 current_payload = current_args.model_dump(mode="json")
 
@@ -47,8 +47,15 @@ try:
     share_root = env.share_root_path()
 except Exception:
     share_root = None
+artifact_target = str(
+    getattr(env, "target", "") or getattr(env, "app", "") or "weather_forecast_project"
+)
+export_root = Path(getattr(env, "AGILAB_EXPORT_ABS", Path.home() / "export")).resolve(
+    strict=False
+)
+artifact_target = Path(artifact_target).name
 
-artifact_root = Path(getattr(env, "AGILAB_EXPORT_ABS", Path.home() / "export")) / env.target / "forecast_analysis"
+artifact_root = export_root / artifact_target / "forecast_analysis"
 
 st.caption(
     "This app turns the notebook migration pilot into a reproducible AGILAB workflow. "

--- a/src/agilab/core/agi-env/src/agi_env/shares/share_runtime_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/shares/share_runtime_support.py
@@ -22,15 +22,23 @@ def share_target_name(target: str | None, app: str | None, *, default: str = "ap
 
 
 def resolve_share_path(path: str | Path | None, share_root: Path) -> Path:
-    """Resolve ``path`` relative to ``share_root``."""
+    """Resolve ``path`` relative to ``share_root`` with share-root confinement."""
 
     if path in (None, "", "."):
-        return share_root
+        return share_root.resolve(strict=False)
 
     candidate = Path(path).expanduser()
     if candidate.is_absolute():
-        return candidate.resolve(strict=False)
-    return (share_root / candidate).resolve(strict=False)
+        resolved = candidate.resolve(strict=False)
+    else:
+        resolved = (share_root / candidate).resolve(strict=False)
+
+    share_root_resolved = share_root.resolve(strict=False)
+    if not resolved.is_relative_to(share_root_resolved):
+        raise ValueError(
+            f"Path must stay inside the configured share root {share_root_resolved!r}, got {path!r}."
+        )
+    return resolved
 
 
 def mode_to_str(mode: int, *, hw_rapids_capable: bool = False) -> str:

--- a/src/agilab/core/agi-env/test/test_agi_env.py
+++ b/src/agilab/core/agi-env/test/test_agi_env.py
@@ -2761,12 +2761,8 @@ def test_share_root_resolution_and_mode_helpers(tmp_path: Path, monkeypatch):
         env.resolve_share_path("demo/data")
         == fake_home / "clustershare" / "alice" / "workflow" / "session-1" / "demo" / "data"
     )
-    absolute_share_path = env.resolve_share_path("/tmp/absolute")
-    if os.name == "nt":
-        assert absolute_share_path.is_absolute()
-        assert absolute_share_path.parts[-2:] == ("tmp", "absolute")
-    else:
-        assert absolute_share_path == Path("/tmp/absolute").resolve(strict=False)
+    with pytest.raises(ValueError, match="share root"):
+        env.resolve_share_path("/tmp/absolute")
 
 
 def test_resolve_share_input_path_falls_back_to_share_root(tmp_path: Path, monkeypatch):

--- a/src/agilab/core/agi-env/test/test_share_runtime_support.py
+++ b/src/agilab/core/agi-env/test/test_share_runtime_support.py
@@ -15,12 +15,8 @@ def test_share_runtime_helpers_cover_target_path_modes_and_ip_validation(tmp_pat
 
     assert share_runtime_module.resolve_share_path(None, share_root) == share_root
     assert share_runtime_module.resolve_share_path("demo/data", share_root) == share_root / "demo" / "data"
-    absolute_share_path = share_runtime_module.resolve_share_path("/tmp/absolute", share_root)
-    if os.name == "nt":
-        assert absolute_share_path.is_absolute()
-        assert absolute_share_path.parts[-2:] == ("tmp", "absolute")
-    else:
-        assert absolute_share_path == Path("/tmp/absolute").resolve(strict=False)
+    with pytest.raises(ValueError, match="share root"):
+        share_runtime_module.resolve_share_path("/tmp/absolute", share_root)
 
     assert share_runtime_module.mode_to_str(0b0111, hw_rapids_capable=False) == "_dcp"
     assert share_runtime_module.mode_to_str(0b0111, hw_rapids_capable=True) == "rdcp"

--- a/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/src/app_args_form.py
+++ b/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/src/app_args_form.py
@@ -138,7 +138,7 @@ def _is_default_file_seed(path_value: Any) -> bool:
 
 
 env = _get_env()
-settings_path = Path(env.app_settings_file)
+settings_path = Path(env.app_settings_file).resolve(strict=False)
 
 current_args = _load_current_args(settings_path)
 current_payload = current_args.to_toml_payload()

--- a/src/agilab/lib/agi-app-mission-decision/src/agi_app_mission_decision/project/mission_decision_project/src/app_args_form.py
+++ b/src/agilab/lib/agi-app-mission-decision/src/agi_app_mission_decision/project/mission_decision_project/src/app_args_form.py
@@ -39,7 +39,7 @@ def _load_current_args(settings_path: Path) -> MissionDecisionArgs:
 
 
 env = _get_env()
-settings_path = Path(env.app_settings_file)
+settings_path = Path(env.app_settings_file).resolve(strict=False)
 current_args = _load_current_args(settings_path)
 current_payload = current_args.model_dump(mode="json")
 
@@ -47,8 +47,15 @@ try:
     share_root = env.share_root_path()
 except Exception:
     share_root = None
+artifact_target = str(
+    getattr(env, "target", "") or getattr(env, "app", "") or "mission_decision_project"
+)
+export_root = Path(getattr(env, "AGILAB_EXPORT_ABS", Path.home() / "export")).resolve(
+    strict=False
+)
+artifact_target = Path(artifact_target).name
 
-artifact_root = Path(getattr(env, "AGILAB_EXPORT_ABS", Path.home() / "export")) / env.target / "data_io_decision"
+artifact_root = export_root / artifact_target / "data_io_decision"
 
 st.caption(
     "This built-in app runs the public Mission Decision demo: "

--- a/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/app_args_form.py
+++ b/src/agilab/lib/agi-app-pytorch-playground/src/agi_app_pytorch_playground/project/pytorch_playground_project/src/app_args_form.py
@@ -869,10 +869,12 @@ def render(
         or getattr(active_env, "app", "")
         or "pytorch_playground_project"
     )
+    export_root = Path(
+        getattr(active_env, "AGILAB_EXPORT_ABS", Path.home() / "export")
+    ).resolve(strict=False)
+    artifact_target = Path(artifact_target).name
     artifact_root = (
-        Path(getattr(active_env, "AGILAB_EXPORT_ABS", Path.home() / "export"))
-        / artifact_target
-        / "pytorch_playground"
+        export_root / artifact_target / "pytorch_playground"
     )
     output_container = container or st
     if not compact:

--- a/src/agilab/lib/agi-app-uav-relay-queue/src/agi_app_uav_relay_queue/project/uav_relay_queue_project/src/app_args_form.py
+++ b/src/agilab/lib/agi-app-uav-relay-queue/src/agi_app_uav_relay_queue/project/uav_relay_queue_project/src/app_args_form.py
@@ -39,7 +39,7 @@ def _load_current_args(settings_path: Path) -> UavRelayQueueArgs:
 
 
 env = _get_env()
-settings_path = Path(env.app_settings_file)
+settings_path = Path(env.app_settings_file).resolve(strict=False)
 current_args = _load_current_args(settings_path)
 current_payload = current_args.model_dump(mode="json")
 
@@ -47,8 +47,15 @@ try:
     share_root = env.share_root_path()
 except Exception:
     share_root = None
+artifact_target = str(
+    getattr(env, "target", "") or getattr(env, "app", "") or "uav_relay_queue_project"
+)
+export_root = Path(getattr(env, "AGILAB_EXPORT_ABS", Path.home() / "export")).resolve(
+    strict=False
+)
+artifact_target = Path(artifact_target).name
 
-artifact_root = Path(getattr(env, "AGILAB_EXPORT_ABS", Path.home() / "export")) / env.target / "queue_analysis"
+artifact_root = export_root / artifact_target / "queue_analysis"
 
 st.caption(
     "This built-in app runs a lightweight UAV relay queue simulation with explicit "

--- a/src/agilab/lib/agi-app-weather-forecast/src/agi_app_weather_forecast/project/weather_forecast_project/src/app_args_form.py
+++ b/src/agilab/lib/agi-app-weather-forecast/src/agi_app_weather_forecast/project/weather_forecast_project/src/app_args_form.py
@@ -39,7 +39,7 @@ def _load_current_args(settings_path: Path) -> WeatherForecastArgs:
 
 
 env = _get_env()
-settings_path = Path(env.app_settings_file)
+settings_path = Path(env.app_settings_file).resolve(strict=False)
 current_args = _load_current_args(settings_path)
 current_payload = current_args.model_dump(mode="json")
 
@@ -47,8 +47,15 @@ try:
     share_root = env.share_root_path()
 except Exception:
     share_root = None
+artifact_target = str(
+    getattr(env, "target", "") or getattr(env, "app", "") or "weather_forecast_project"
+)
+export_root = Path(getattr(env, "AGILAB_EXPORT_ABS", Path.home() / "export")).resolve(
+    strict=False
+)
+artifact_target = Path(artifact_target).name
 
-artifact_root = Path(getattr(env, "AGILAB_EXPORT_ABS", Path.home() / "export")) / env.target / "forecast_analysis"
+artifact_root = export_root / artifact_target / "forecast_analysis"
 
 st.caption(
     "This app turns the notebook migration pilot into a reproducible AGILAB workflow. "


### PR DESCRIPTION
## Summary
- Harden `agi-env` share path resolution so absolute paths and traversal outside the share root are rejected.
- Resolve app settings paths and normalize app artifact-root joins across affected app argument forms.
- Update AGI-env tests for the stricter confinement contract.

## Repro
User-provided app path fields could pass absolute paths or `..` traversal through forms into the shared runtime resolver.

## Root Cause
The central share resolver accepted absolute paths verbatim and joined relative paths without resolving and checking confinement under the share root.

## Regression Test
- `uv --preview-features extra-build-dependencies run python -m pytest src/agilab/core/agi-env/test/test_share_runtime_support.py src/agilab/core/agi-env/test/test_agi_env.py`
- `uv --preview-features extra-build-dependencies run python -m compileall -q $(git diff --name-only main...HEAD -- '*.py')`

## Review Evidence
No model or sub-agent review used.

## Agent Metadata
- Tokki version: `tokki 1.0.22`
- Agent/runtime: Codex, version unavailable
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used
