### PR TITLE
fix(core): restore Windows validation baseline

### DIFF
--- a/src/agilab/core/agi-cluster/pyproject.toml
+++ b/src/agilab/core/agi-cluster/pyproject.toml
@@ -34,7 +34,7 @@ keywords = [
     "job-scheduling",
     "mlops",
 ]
-dependencies = ["agi-env==2026.07.04", "agi-node==2026.07.04", "asyncssh>=2.23,<3", "dask[distributed]>=2026.3,<2027.0", "humanize>=4.10,<5", "numpy>=2.2,<3", "packaging>=25,<27", "polars>=1.35,<2", "psutil>=7,<8", "scikit-learn>=1.7.2,<2", "tomlkit>=0.13,<1"]
+dependencies = ["agi-env==2026.07.04", "agi-node==2026.07.04", "asyncssh>=2.23,<3", "dask[distributed]>=2026.3,<2027.0", "humanize>=4.10,<5", "numpy>=2.2,<3", "packaging>=25,<27", "polars>=1.35,<2", "psutil>=7,<8", "pywin32>=312,<313; sys_platform == 'win32'", "scikit-learn>=1.7.2,<2", "tomlkit>=0.13,<1"]
 
 [project.entry-points."agi_env.runtime_packages"]
 agi-cluster = "agi_cluster.agi_env_runtime:RUNTIME_PACKAGE_SPEC"

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime/runtime_misc_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime/runtime_misc_support.py
@@ -23,11 +23,11 @@ from typing import Any, Callable, List, Optional, cast
 # authenticity/signing control. It is an unsigned sha256 co-located with the
 # model file, so it only detects accidental corruption or truncation of a
 # pickle the operator already trusts on disk. It cannot prove *who* produced
-# the model. The authenticity guarantee comes from the permission gate in
-# _capacity_model_trust_error (trusted-root containment + owner-only writable,
-# no shared-group/world write, verified ownership on Windows), which must keep
-# a hostile actor from planting a malicious pickle in the first place. Do not
-# treat manifest verification alone as a defense against a tampered model.
+# the model. Loading is additionally constrained to a trusted root, rejects
+# shared-group/world-writable files on POSIX, and verifies Windows owner SID
+# identity. These controls reduce the pickle-planting surface but do not prove
+# who produced the model. Do not treat manifest verification alone as a defense
+# against a tampered model.
 CAPACITY_MODEL_MANIFEST_SCHEMA = "agilab.capacity_model_manifest.v1"
 CAPACITY_MODEL_HASH_ALGORITHM = "sha256"
 _CAPACITY_LOAD_EXCEPTIONS = (
@@ -299,6 +299,93 @@ def _posix_group_is_user_private(stat_result: os.stat_result) -> bool:
         return False
 
 
+def _windows_capacity_model_identities(
+    model_path: Path,
+) -> tuple[str, tuple[str, ...], str | None]:
+    """Return the file SID, trusted process-token SIDs, and an owner label."""
+
+    try:
+        import win32api
+        import win32con
+        import win32security
+    except ImportError as exc:
+        raise RuntimeError(
+            "pywin32 is required to verify capacity model ownership on Windows"
+        ) from exc
+
+    security_descriptor = win32security.GetFileSecurity(
+        str(model_path),
+        win32security.OWNER_SECURITY_INFORMATION,
+    )
+    owner_sid = security_descriptor.GetSecurityDescriptorOwner()
+    if owner_sid is None:
+        raise OSError("model file has no owner SID")
+
+    token = win32security.OpenProcessToken(
+        win32api.GetCurrentProcess(),
+        win32con.TOKEN_QUERY,
+    )
+    try:
+        current_sid, _attributes = win32security.GetTokenInformation(
+            token,
+            win32security.TokenUser,
+        )
+        token_owner = win32security.GetTokenInformation(
+            token,
+            win32security.TokenOwner,
+        )
+        default_owner_sid = (
+            token_owner[0] if isinstance(token_owner, tuple) else token_owner
+        )
+        owner_sid_text = win32security.ConvertSidToStringSid(owner_sid)
+        current_sid_text = win32security.ConvertSidToStringSid(current_sid)
+        default_owner_sid_text = win32security.ConvertSidToStringSid(
+            default_owner_sid
+        )
+    finally:
+        token.Close()
+
+    owner_label: str | None = None
+    try:
+        owner_name, owner_domain, _account_type = win32security.LookupAccountSid(
+            None,
+            owner_sid,
+        )
+        owner_label = (
+            f"{owner_domain}\\{owner_name}" if owner_domain else owner_name
+        )
+    except Exception:
+        # Best-effort diagnostic only; SID equality remains the trust decision.
+        pass
+    trusted_sids = tuple(dict.fromkeys((current_sid_text, default_owner_sid_text)))
+    return owner_sid_text, trusted_sids, owner_label
+
+
+def _windows_capacity_model_owner_error(
+    model_path: Path,
+    *,
+    identities_fn: Callable[[Path], tuple[str, tuple[str, ...], str | None]]
+    | None = None,
+) -> str | None:
+    """Return a fail-closed error unless the owner matches the process token."""
+
+    identity_provider = identities_fn or _windows_capacity_model_identities
+    try:
+        owner_sid, trusted_sids, owner_label = identity_provider(model_path)
+    except Exception as exc:
+        # pywin32 raises several exception types across versions. This boundary
+        # must turn every lookup failure into refusal to deserialize the pickle.
+        return f"cannot verify model file ownership on Windows: {exc}"
+
+    normalized_trusted_sids = {sid.casefold() for sid in trusted_sids if sid}
+    if not owner_sid or not normalized_trusted_sids:
+        return "cannot verify model file ownership on Windows: an owner SID is missing"
+    if owner_sid.casefold() not in normalized_trusted_sids:
+        owner = owner_label or owner_sid
+        return f"model file is owned by {owner}, not the current Windows token"
+    return None
+
+
 def _capacity_model_trust_error(model_path: Path, trusted_root: Path) -> str | None:
     path = Path(model_path).expanduser().resolve(strict=False)
     root = Path(trusted_root).expanduser().resolve(strict=False)
@@ -312,21 +399,9 @@ def _capacity_model_trust_error(model_path: Path, trusted_root: Path) -> str | N
     mode = stat_result.st_mode
 
     if os.name == "nt":
-        # POSIX permission bits are not authoritative on Windows; verify the
-        # file is owned by the current user instead of skipping the gate. If
-        # ownership cannot be determined, refuse to load rather than trust a
-        # pickle we cannot attribute.
-        try:
-            owner_sid = path.owner()
-        except (OSError, NotImplementedError, AttributeError) as exc:
-            return f"cannot verify model file ownership on Windows: {exc}"
-        try:
-            current_user = getpass.getuser()
-        except OSError as exc:
-            return f"cannot determine current Windows user: {exc}"
-        if owner_sid and current_user and owner_sid.split("\\")[-1].lower() != current_user.lower():
-            return f"model file is owned by {owner_sid}, not the current user"
-        return None
+        # POSIX permission bits are not authoritative on Windows. Compare the
+        # native file-owner SID with the token user/default-owner SIDs instead.
+        return _windows_capacity_model_owner_error(path)
 
     if mode & stat.S_IWOTH:
         return "model file is world-writable"

--- a/src/agilab/core/agi-env/src/agi_env/runtime/agi_env.py
+++ b/src/agilab/core/agi-env/src/agi_env/runtime/agi_env.py
@@ -315,7 +315,7 @@ class AgiEnv(metaclass=_AgiEnvMeta):
             # singleton exists). Resetting them to their sentinels forces a clean
             # rebuild on the next bootstrap instead of leaking stale state.
             type.__setattr__(cls, "envars", {})
-            type.__setattr__(cls, "resources_path", Path.home() / ".agilab")
+            type.__setattr__(cls, "resources_path", None)
             type.__setattr__(cls, "logger", None)
     install_type: int | None = None  # deprecated: derived from flags for backward compatibility
     apps_path: Path | None = None

--- a/src/agilab/core/agi-env/src/agi_env/runtime/env_config_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/runtime/env_config_support.py
@@ -65,17 +65,29 @@ def remove_env_keys(env_file: Path, keys) -> list[str]:
     """Remove ``keys`` from a dotenv file, returning the keys that were present.
 
     Counterpart to :func:`write_env_updates`, which only ever adds. Missing
-    files and missing keys are treated as no-ops (``unset_key`` handles both
-    without raising), so callers can prune stale entries idempotently.
+    files and missing keys are treated as no-ops, so callers can prune stale
+    entries idempotently without making python-dotenv emit missing-key warnings.
     """
 
     if not env_file.exists():
         return []
+    present_keys = [str(key) for key in dotenv_values(dotenv_path=env_file)]
+    case_insensitive = os.name == "nt"
     removed: list[str] = []
-    for key in keys:
-        # ``unset_key`` returns ``(True, key)`` only when the key existed and was
-        # rewritten out; ``(None, key)`` when the file/key was absent.
-        result, _ = unset_key(str(env_file), key, quote_mode="never")
-        if result:
-            removed.append(key)
+    for requested_key in keys:
+        requested = str(requested_key)
+        matching_keys = [
+            present
+            for present in present_keys
+            if (
+                present.casefold() == requested.casefold()
+                if case_insensitive
+                else present == requested
+            )
+        ]
+        for actual_key in matching_keys:
+            result, _ = unset_key(str(env_file), actual_key, quote_mode="never")
+            if result:
+                removed.append(actual_key)
+            present_keys.remove(actual_key)
     return removed

--- a/src/agilab/core/agi-env/test/conftest.py
+++ b/src/agilab/core/agi-env/test/conftest.py
@@ -8,6 +8,7 @@ import sys
 import types
 from collections.abc import Callable
 from datetime import date
+from ipaddress import AddressValueError, IPv4Address
 from pathlib import Path
 from typing import Any, TypeVar
 
@@ -15,6 +16,16 @@ import pytest
 
 
 _ORIGINAL_PATH_HOME = Path.home
+
+
+def _is_node_env_key(key: str) -> bool:
+    """Return whether an environment key begins with an IPv4 node address."""
+
+    try:
+        IPv4Address(key.partition("_")[0])
+    except AddressValueError:
+        return False
+    return True
 
 
 def _home_from_env() -> Path:
@@ -136,6 +147,10 @@ def _posix_marker_path(
 def isolate_agi_env_test_environment(tmp_path_factory, monkeypatch):
     """Keep agi-env tests independent from developer-local AGILAB state."""
 
+    saved_node_keys = tuple(key for key in os.environ if _is_node_env_key(key))
+    for key in saved_node_keys:
+        monkeypatch.delenv(key, raising=False)
+
     monkeypatch.setattr(Path, "home", staticmethod(_home_from_env))
 
     fake_home = tmp_path_factory.mktemp("agilab_fake_home")
@@ -192,3 +207,6 @@ def isolate_agi_env_test_environment(tmp_path_factory, monkeypatch):
     AgiEnv.reset()
     ui_support._GLOBAL_STATE_FILE = original_global_state_file
     ui_support._LEGACY_LAST_APP_FILE = original_legacy_last_app_file
+    for key in tuple(os.environ):
+        if _is_node_env_key(key):
+            os.environ.pop(key, None)

--- a/src/agilab/core/agi-env/test/test_agi_env.py
+++ b/src/agilab/core/agi-env/test/test_agi_env.py
@@ -1,6 +1,7 @@
 import asyncio
 import ast
 import getpass
+import logging
 import os
 import shlex
 import shutil
@@ -3406,8 +3407,22 @@ def test_reset_clears_runtime_class_caches():
     assert AgiEnv._pythonpath_entries == []
     assert not hasattr(AgiEnv, "_share_mount_warning_keys")
     assert AgiEnv.envars == {}
-    assert AgiEnv.resources_path == Path.home() / ".agilab"
+    assert AgiEnv.resources_path is None
     assert AgiEnv.logger is None
+
+    AgiEnv._ensure_defaults()
+    assert AgiEnv.resources_path == Path.home() / ".agilab"
+
+
+def test_reset_keeps_resources_path_lazy_while_path_factory_is_patched(monkeypatch):
+    class _PathWithoutHome:
+        pass
+
+    monkeypatch.setattr(agi_env_module, "Path", _PathWithoutHome)
+
+    AgiEnv.reset()
+
+    assert AgiEnv.resources_path is None
 
 
 def test_create_symlink_windows_hits_success_and_failure_branches(tmp_path: Path, monkeypatch):
@@ -3455,18 +3470,27 @@ def test_create_symlink_windows_hits_success_and_failure_branches(tmp_path: Path
 
 
 def _prime_home_for_env_file(tmp_path: Path, monkeypatch) -> Path:
-    """Point HOME at a fresh tmp home and reset AgiEnv so resources_path follows."""
+    """Point HOME at a fresh tmp home and reset lazy AGILAB defaults."""
 
     fake_home = tmp_path / "fake_home"
     (fake_home / ".agilab").mkdir(parents=True, exist_ok=True)
     monkeypatch.setenv("HOME", str(fake_home))
-    # reset() recomputes resources_path = Path.home() / ".agilab" against the
-    # freshly patched HOME so set_env_var writes into the tmp dotenv file.
+    # reset() restores a lazy sentinel; set_env_var resolves it against the
+    # freshly patched HOME before writing into the tmp dotenv file.
     AgiEnv.reset()
     return fake_home
 
 
-def test_remove_env_keys_removes_present_keys_and_ignores_absent(tmp_path: Path):
+def _set_test_env_var(monkeypatch, key: str, value: str) -> None:
+    """Persist a test value while registering failure-safe process cleanup."""
+
+    monkeypatch.setenv(key, value)
+    AgiEnv.set_env_var(key, value)
+
+
+def test_remove_env_keys_removes_present_keys_and_ignores_absent(
+    tmp_path: Path, caplog
+):
     from agi_env.runtime.env_config_support import remove_env_keys, write_env_updates
 
     env_file = tmp_path / ".env"
@@ -3475,9 +3499,14 @@ def test_remove_env_keys_removes_present_keys_and_ignores_absent(tmp_path: Path)
         {"KEEP": "1", "192.168.0.1_CMD_PREFIX": "prefix", "192.168.0.1": "hw_rapids_capable"},
     )
 
-    removed = remove_env_keys(env_file, ["192.168.0.1_CMD_PREFIX", "192.168.0.1", "MISSING"])
+    with caplog.at_level(logging.WARNING, logger="dotenv.main"):
+        removed = remove_env_keys(
+            env_file,
+            ["192.168.0.1_CMD_PREFIX", "192.168.0.1", "MISSING"],
+        )
 
     assert set(removed) == {"192.168.0.1_CMD_PREFIX", "192.168.0.1"}
+    assert not [record for record in caplog.records if "MISSING" in record.message]
     contents = env_file.read_text(encoding="utf-8")
     assert "KEEP" in contents
     assert "192.168.0.1_CMD_PREFIX" not in contents
@@ -3494,6 +3523,23 @@ def test_remove_env_keys_missing_file_is_noop(tmp_path: Path):
     assert not env_file.exists()
 
 
+def test_remove_env_keys_matches_windows_dotenv_keys_case_insensitively(
+    tmp_path: Path, monkeypatch, caplog
+):
+    from agi_env.runtime import env_config_support
+
+    env_file = tmp_path / ".env"
+    env_file.write_text("Mixed_Node_Key=value\n", encoding="utf-8")
+    monkeypatch.setattr(env_config_support, "os", SimpleNamespace(name="nt"))
+
+    with caplog.at_level(logging.WARNING, logger="dotenv.main"):
+        removed = env_config_support.remove_env_keys(env_file, ["MIXED_NODE_KEY"])
+
+    assert removed == ["Mixed_Node_Key"]
+    assert env_file.read_text(encoding="utf-8") == ""
+    assert caplog.records == []
+
+
 def test_prune_node_env_keys_removes_stale_and_keeps_current(tmp_path: Path, monkeypatch):
     fake_home = _prime_home_for_env_file(tmp_path, monkeypatch)
     env_file = fake_home / ".agilab" / ".env"
@@ -3502,15 +3548,15 @@ def test_prune_node_env_keys_removes_stale_and_keeps_current(tmp_path: Path, mon
     current_ip = "10.0.0.1"
 
     # Stale per-node keys across all three shapes.
-    AgiEnv.set_env_var(stale_ip, "hw_rapids_capable")  # bare-IP capability sentinel
-    AgiEnv.set_env_var(f"{stale_ip}_CMD_PREFIX", "stale-prefix")
-    AgiEnv.set_env_var(f"{stale_ip}_PYTHON_VERSION", "3.11")
+    _set_test_env_var(monkeypatch, stale_ip, "hw_rapids_capable")
+    _set_test_env_var(monkeypatch, f"{stale_ip}_CMD_PREFIX", "stale-prefix")
+    _set_test_env_var(monkeypatch, f"{stale_ip}_PYTHON_VERSION", "3.11")
     # Current per-node keys that must survive.
-    AgiEnv.set_env_var(current_ip, "no_rapids_hw")
-    AgiEnv.set_env_var(f"{current_ip}_CMD_PREFIX", "live-prefix")
-    AgiEnv.set_env_var(f"{current_ip}_PYTHON_VERSION", "3.14")
+    _set_test_env_var(monkeypatch, current_ip, "no_rapids_hw")
+    _set_test_env_var(monkeypatch, f"{current_ip}_CMD_PREFIX", "live-prefix")
+    _set_test_env_var(monkeypatch, f"{current_ip}_PYTHON_VERSION", "3.14")
     # A non-node key that must never be touched.
-    AgiEnv.set_env_var("OPENAI_MODEL", "gpt-x")
+    _set_test_env_var(monkeypatch, "OPENAI_MODEL", "gpt-x")
 
     removed = AgiEnv.prune_node_env_keys({current_ip})
 
@@ -3546,11 +3592,6 @@ def test_prune_node_env_keys_removes_stale_and_keeps_current(tmp_path: Path, mon
     assert f"{current_ip}_CMD_PREFIX" in contents
     assert "OPENAI_MODEL" in contents
 
-    # Clean up process env leakage created by this test.
-    for key in (current_ip, f"{current_ip}_CMD_PREFIX", f"{current_ip}_PYTHON_VERSION", "OPENAI_MODEL"):
-        os.environ.pop(key, None)
-
-
 def test_prune_node_env_keys_removes_leaked_os_environ_only_keys(tmp_path: Path, monkeypatch):
     """Bare-IP keys that leaked into os.environ but not envars are still pruned."""
 
@@ -3574,9 +3615,9 @@ def test_prune_node_env_keys_empty_current_ips_removes_all_node_keys(tmp_path: P
     fake_home = _prime_home_for_env_file(tmp_path, monkeypatch)
     env_file = fake_home / ".agilab" / ".env"
 
-    AgiEnv.set_env_var("192.0.2.10", "hw_rapids_capable")
-    AgiEnv.set_env_var("192.0.2.10_CMD_PREFIX", "p")
-    AgiEnv.set_env_var("NON_NODE_KEY", "value")
+    _set_test_env_var(monkeypatch, "192.0.2.10", "hw_rapids_capable")
+    _set_test_env_var(monkeypatch, "192.0.2.10_CMD_PREFIX", "p")
+    _set_test_env_var(monkeypatch, "NON_NODE_KEY", "value")
 
     removed = AgiEnv.prune_node_env_keys(set())
 
@@ -3587,14 +3628,11 @@ def test_prune_node_env_keys_empty_current_ips_removes_all_node_keys(tmp_path: P
     assert "NON_NODE_KEY" in contents
     assert "192.0.2.10_CMD_PREFIX" not in contents
 
-    os.environ.pop("NON_NODE_KEY", None)
-
-
 def test_prune_node_env_keys_noop_when_nothing_stale(tmp_path: Path, monkeypatch):
     _prime_home_for_env_file(tmp_path, monkeypatch)
 
-    AgiEnv.set_env_var("203.0.113.7", "no_rapids_hw")
-    AgiEnv.set_env_var("SOME_GLOBAL", "x")
+    _set_test_env_var(monkeypatch, "203.0.113.7", "no_rapids_hw")
+    _set_test_env_var(monkeypatch, "SOME_GLOBAL", "x")
 
     removed = AgiEnv.prune_node_env_keys({"203.0.113.7"})
 
@@ -3602,23 +3640,20 @@ def test_prune_node_env_keys_noop_when_nothing_stale(tmp_path: Path, monkeypatch
     assert AgiEnv.envars["203.0.113.7"] == "no_rapids_hw"
     assert AgiEnv.envars["SOME_GLOBAL"] == "x"
 
-    os.environ.pop("203.0.113.7", None)
-    os.environ.pop("SOME_GLOBAL", None)
-
-
 def test_prune_node_env_keys_ignores_non_ip_underscore_keys(tmp_path: Path, monkeypatch):
     """Keys like 'FOO_CMD_PREFIX' whose head is not an IPv4 must be preserved."""
 
     _prime_home_for_env_file(tmp_path, monkeypatch)
 
-    AgiEnv.set_env_var("FOO_CMD_PREFIX", "not-a-node-key")
-    AgiEnv.set_env_var("999.999.999.999_CMD_PREFIX", "invalid-ip-head")
+    _set_test_env_var(monkeypatch, "FOO_CMD_PREFIX", "not-a-node-key")
+    _set_test_env_var(
+        monkeypatch,
+        "999.999.999.999_CMD_PREFIX",
+        "invalid-ip-head",
+    )
 
     removed = AgiEnv.prune_node_env_keys(set())
 
     assert removed == []
     assert AgiEnv.envars["FOO_CMD_PREFIX"] == "not-a-node-key"
     assert AgiEnv.envars["999.999.999.999_CMD_PREFIX"] == "invalid-ip-head"
-
-    os.environ.pop("FOO_CMD_PREFIX", None)
-    os.environ.pop("999.999.999.999_CMD_PREFIX", None)

--- a/src/agilab/core/test/test_agi_distributor_deployment_prepare_support.py
+++ b/src/agilab/core/test/test_agi_distributor_deployment_prepare_support.py
@@ -788,6 +788,7 @@ async def test_prepare_cluster_env_offline_missing_uv_raises_environment_error(t
             send_files_fn=lambda *_a, **_k: None,
             kill_fn=lambda *_a, **_k: None,
             clean_dirs_fn=lambda *_a, **_k: None,
+            set_env_var_fn=lambda key, value=None: env.envars.__setitem__(key, value),
             log=log,
         )
 
@@ -859,6 +860,7 @@ async def test_prepare_cluster_env_powershell_connection_error_bubbles(tmp_path)
             send_files_fn=lambda *_a, **_k: None,
             kill_fn=lambda *_a, **_k: None,
             clean_dirs_fn=lambda *_a, **_k: None,
+            set_env_var_fn=lambda key, value=None: env.envars.__setitem__(key, value),
             log=mock.Mock(),
         )
 
@@ -933,6 +935,7 @@ async def test_prepare_cluster_env_python_install_unknown_error_bubbles(tmp_path
             send_files_fn=lambda *_a, **_k: None,
             kill_fn=lambda *_a, **_k: None,
             clean_dirs_fn=lambda *_a, **_k: None,
+            set_env_var_fn=lambda key, value=None: env.envars.__setitem__(key, value),
             process_error_type=_ProcError,
             log=mock.Mock(),
         )

--- a/src/agilab/core/test/test_agi_distributor_runtime_misc_support.py
+++ b/src/agilab/core/test/test_agi_distributor_runtime_misc_support.py
@@ -499,6 +499,105 @@ def test_load_capacity_predictor_rejects_model_outside_trusted_root(tmp_path):
     assert "outside trusted resource root" in calls["warnings"][0][2]
 
 
+def test_windows_capacity_model_owner_error_accepts_matching_sid(tmp_path):
+    model_path = tmp_path / "balancer_model.pkl"
+    model_path.write_bytes(b"pickle-bytes")
+
+    error = runtime_misc_support._windows_capacity_model_owner_error(
+        model_path,
+        identities_fn=lambda _path: (
+            "S-1-5-21-1000",
+            ("S-1-5-21-1000",),
+            "DOMAIN\\runner",
+        ),
+    )
+
+    assert error is None
+
+
+def test_windows_capacity_model_owner_error_rejects_mismatched_sid(tmp_path):
+    model_path = tmp_path / "balancer_model.pkl"
+    model_path.write_bytes(b"pickle-bytes")
+
+    error = runtime_misc_support._windows_capacity_model_owner_error(
+        model_path,
+        identities_fn=lambda _path: (
+            "S-1-5-21-2000",
+            ("S-1-5-21-1000",),
+            "DOMAIN\\other",
+        ),
+    )
+
+    assert error == "model file is owned by DOMAIN\\other, not the current Windows token"
+
+
+def test_windows_capacity_model_owner_error_accepts_token_default_owner(tmp_path):
+    model_path = tmp_path / "balancer_model.pkl"
+    model_path.write_bytes(b"pickle-bytes")
+
+    error = runtime_misc_support._windows_capacity_model_owner_error(
+        model_path,
+        identities_fn=lambda _path: (
+            "S-1-5-32-544",
+            ("S-1-5-21-1000", "S-1-5-32-544"),
+            "BUILTIN\\Administrators",
+        ),
+    )
+
+    assert error is None
+
+
+def test_windows_capacity_model_owner_error_fails_closed_on_lookup_error(tmp_path):
+    model_path = tmp_path / "balancer_model.pkl"
+    model_path.write_bytes(b"pickle-bytes")
+
+    def _raise_lookup(_path):
+        raise OSError("access denied")
+
+    error = runtime_misc_support._windows_capacity_model_owner_error(
+        model_path,
+        identities_fn=_raise_lookup,
+    )
+
+    assert error == "cannot verify model file ownership on Windows: access denied"
+
+
+@pytest.mark.skipif(os.name != "nt", reason="native Windows ownership semantics")
+def test_windows_capacity_model_owner_error_accepts_current_user_file(tmp_path):
+    model_path = tmp_path / "balancer_model.pkl"
+    model_path.write_bytes(b"pickle-bytes")
+
+    assert runtime_misc_support._windows_capacity_model_owner_error(model_path) is None
+
+
+def test_load_capacity_predictor_rejects_windows_owner_mismatch(
+    tmp_path, monkeypatch
+):
+    model_path = tmp_path / "resources" / "balancer_model.pkl"
+    model_path.parent.mkdir()
+    model_path.write_bytes(b"pickle-bytes")
+    runtime_misc_support.write_capacity_model_manifest(model_path)
+    calls = {"load": 0, "retrain": 0}
+
+    monkeypatch.setattr(runtime_misc_support, "os", SimpleNamespace(name="nt"))
+    monkeypatch.setattr(
+        runtime_misc_support,
+        "_windows_capacity_model_owner_error",
+        lambda _path: "model file owner SID does not match the current Windows user",
+    )
+
+    loaded = runtime_misc_support.load_capacity_predictor(
+        model_path,
+        load_fn=lambda _stream: calls.__setitem__("load", calls["load"] + 1),
+        retrain_fn=lambda: calls.__setitem__("retrain", calls["retrain"] + 1),
+        trusted_root=model_path.parent,
+    )
+
+    assert loaded is None
+    assert calls == {"load": 0, "retrain": 1}
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX world-write semantics")
 def test_load_capacity_predictor_rejects_world_writable_trusted_model(tmp_path):
     model_path = tmp_path / "resources" / "balancer_model.pkl"
     model_path.parent.mkdir()


### PR DESCRIPTION
## Summary

- restore lazy `AgiEnv.resources_path` reset semantics so teardown never resolves a monkeypatched or platform-incompatible `Path`
- isolate per-node environment tests, prevent deployment tests from mutating process-global state, and remove dotenv keys without missing-key warnings or Windows casing drift
- replace unsupported `WindowsPath.owner()` checks with fail-closed native `TokenUser` / `TokenOwner` SID verification through an explicit Windows-only pywin32 dependency

This intentionally spans agi-env and agi-cluster because the required Windows tracker runs both in one process. Either half by itself remains red on the other baseline regression, so one prerequisite baseline PR is the smallest mergeable unit. Shared-core repair approval was explicitly granted for this merge sequence; no owner-protected agi-core files are touched.

## Repro

The current `origin/main` Windows tracker reproduces `7 failed, 13 errors`:

- five capacity predictor tests reject every model because `WindowsPath.owner()` is unsupported
- thirteen fixture teardowns call `Path.home()` while tests still have `Path` or `os.name` monkeypatched
- three deployment-preparation tests leak per-node keys into `os.environ`, causing two later pruning assertions to fail and a python-dotenv warning

PR #807 has the same Windows result as the `main` baseline and changes no shared-core files.

## Root Cause

Three independent upstream commits introduced Windows-only assumptions or shared-process test pollution:

- the pickle trust gate used a POSIX-oriented pathlib ownership API on Windows
- `AgiEnv.reset()` eagerly rebuilt the resource path during fixture teardown instead of restoring the existing lazy sentinel
- deployment tests omitted their injectable environment writer, while pruning tests relied on success-path manual cleanup and dotenv removal called `unset_key` for absent keys

## Regression Test

- native and injected SID tests cover `TokenUser`, elevated/default `TokenOwner`, mismatch, and lookup failure; mismatch and lookup failure remain fail-closed
- reset is exercised with a path factory that has no `home()` implementation and then verified to rehydrate lazily
- dotenv removal covers absent-key silence and case-insensitive Windows matching using the actual file spelling
- the original three writer tests followed by both pruning tests now pass in one ordered pytest process, with failure-safe restoration of pre-existing node variables

## Validation

- complete cross-platform core tracker slice: 2,114 passed, 4 skipped
- focused affected suites: 193 passed, 1 skipped
- ordered pollution repro: 5 passed
- shared-core strict typing: passed
- Ruff changed-file checks, Python compile smoke, lock consistency, staged impact, and diff checks: passed
- independent warning-sensitive review slice: 4 passed with warnings treated as errors

Native Windows SID behavior and the Windows-only dependency install require the GitHub Windows runner and are the final integration proof for this PR.

The dependency-policy profile has one unrelated pre-existing failure on `origin/main`: the agi-env compatibility shim contains upper-core package-name tokens. Its other 27 checks pass; this patch neither changes that shim nor weakens the policy. Full-file Ruff formatting was not applied because six touched legacy files are already unformatted on `origin/main`; the changed-file lint and diff checks are clean.

## Review Evidence

- GPT-5 Windows baseline sub-agent, diagnosis and full-diff review only, no edits: found the `TokenOwner` edge; addressed; final review clean
- GPT-5 predictor security sub-agent, review only, no edits: native SID API, fail-closed behavior, dependency, and regressions clean
- GPT-5 environment-pollution sub-agent, review only, no edits: found fixture restoration ordering issue; addressed; final review clean

## Agent Metadata

- Tokki: 1.0.27
- Agent/runtime: Codex, version unavailable
- Model: GPT-5
- Reasoning effort: unknown
- `/fast` mode: unknown
