### PR TITLE
Add routing demand matrix comparison view

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 277,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "50532f423885934545c6913727109f7623c23480cc7bd120da95519def5dfc6b",
+  "source_digest_sha256": "e54c0fae567bc43d265db066cb48442e8106b02053ea3fed6dd1faecba8d8f86",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "a80f40379dc36410525419092944cd850be8729e20a7c7c8c7edb44b98e28c03"
+  "target_digest_sha256": "e54c0fae567bc43d265db066cb48442e8106b02053ea3fed6dd1faecba8d8f86"
 }

--- a/docs/source/_static/apps-pages-gallery/view_routing_model_comparison.svg
+++ b/docs/source/_static/apps-pages-gallery/view_routing_model_comparison.svg
@@ -14,11 +14,28 @@
   <rect x="52" y="54" width="536" height="252" rx="18" fill="#ffffff" filter="url(#shadow)"/>
   <rect x="52" y="54" width="536" height="58" rx="18" fill="#0d9488"/>
   <text x="84" y="91" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="700" fill="#ffffff">Routing Model Comparison</text>
-  <text x="84" y="136" font-family="Inter, Arial, sans-serif" font-size="13" fill="#334155">Compares baseline and candidate routing allocation decisions.</text>
-  <g fill="none" stroke="#0d9488" stroke-width="9" stroke-linecap="round" stroke-linejoin="round" opacity=".95">
-    <circle cx="150" cy="232" r="14"/><circle cx="310" cy="138" r="14"/><circle cx="500" cy="232" r="14"/><path d="M164 226 L296 146 L324 146 L486 226"/><path d="M164 244 C260 292 390 292 486 244" opacity=".45"/>
+  <text x="84" y="136" font-family="Inter, Arial, sans-serif" font-size="12" fill="#334155">Source-destination matrices expose delivery, unmet demand, and latency hotspots.</text>
+  <g stroke="#cbd5e1" stroke-width="1">
+    <rect x="88" y="158" width="136" height="118" rx="10" fill="#f8fafc"/>
+    <rect x="252" y="158" width="136" height="118" rx="10" fill="#f8fafc"/>
+    <rect x="416" y="158" width="136" height="118" rx="10" fill="#f8fafc"/>
   </g>
-  <g font-family="Inter, Arial, sans-serif" font-size="13" font-weight="700" fill="#0f172a">
-    <text x="132" y="314" class="pill">Baseline</text><text x="292" y="314" class="pill">Candidate</text><text x="452" y="314" class="pill">Delta</text>
+  <g transform="translate(105 176)">
+    <rect width="28" height="22" rx="3" fill="#ccfbf1"/><rect x="36" width="28" height="22" rx="3" fill="#5eead4"/><rect x="72" width="28" height="22" rx="3" fill="#0f766e"/>
+    <rect y="30" width="28" height="22" rx="3" fill="#99f6e4"/><rect x="36" y="30" width="28" height="22" rx="3" fill="#14b8a6"/><rect x="72" y="30" width="28" height="22" rx="3" fill="#115e59"/>
+    <rect y="60" width="28" height="22" rx="3" fill="#f0fdfa"/><rect x="36" y="60" width="28" height="22" rx="3" fill="#2dd4bf"/><rect x="72" y="60" width="28" height="22" rx="3" fill="#134e4a"/>
+  </g>
+  <g transform="translate(269 176)">
+    <rect width="28" height="22" rx="3" fill="#fff7ed"/><rect x="36" width="28" height="22" rx="3" fill="#fdba74"/><rect x="72" width="28" height="22" rx="3" fill="#c2410c"/>
+    <rect y="30" width="28" height="22" rx="3" fill="#ffedd5"/><rect x="36" y="30" width="28" height="22" rx="3" fill="#fb923c"/><rect x="72" y="30" width="28" height="22" rx="3" fill="#9a3412"/>
+    <rect y="60" width="28" height="22" rx="3" fill="#fed7aa"/><rect x="36" y="60" width="28" height="22" rx="3" fill="#f97316"/><rect x="72" y="60" width="28" height="22" rx="3" fill="#7c2d12"/>
+  </g>
+  <g transform="translate(433 176)">
+    <rect width="28" height="22" rx="3" fill="#eef2ff"/><rect x="36" width="28" height="22" rx="3" fill="#a5b4fc"/><rect x="72" width="28" height="22" rx="3" fill="#4338ca"/>
+    <rect y="30" width="28" height="22" rx="3" fill="#e0e7ff"/><rect x="36" y="30" width="28" height="22" rx="3" fill="#818cf8"/><rect x="72" y="30" width="28" height="22" rx="3" fill="#3730a3"/>
+    <rect y="60" width="28" height="22" rx="3" fill="#c7d2fe"/><rect x="36" y="60" width="28" height="22" rx="3" fill="#6366f1"/><rect x="72" y="60" width="28" height="22" rx="3" fill="#312e81"/>
+  </g>
+  <g font-family="Inter, Arial, sans-serif" font-size="13" font-weight="700" fill="#0f172a" text-anchor="middle">
+    <text x="156" y="300">Delivered ratio</text><text x="320" y="300">Unmet ratio</text><text x="484" y="300">Latency</text>
   </g>
 </svg>

--- a/src/agilab/apps-pages/view_routing_model_comparison/README.md
+++ b/src/agilab/apps-pages/view_routing_model_comparison/README.md
@@ -4,11 +4,14 @@
 
 Package: `agi-page-routing-model-comparison`
 
-Compares baseline and candidate routing allocation decisions.
+Compares baseline and candidate routing allocation decisions, including aligned
+source-destination demand matrices for served bandwidth, unmet bandwidth,
+unrouted decisions, and routed latency.
 
 ## When To Use It
 
-Use when routing models need allocation deltas, failure inspection, and side-by-side decision evidence.
+Use when routing models need allocation deltas, failure inspection,
+source-destination hotspots, and side-by-side decision evidence.
 
 ## Expected Inputs
 

--- a/src/agilab/apps-pages/view_routing_model_comparison/src/view_routing_model_comparison/view_routing_model_comparison.py
+++ b/src/agilab/apps-pages/view_routing_model_comparison/src/view_routing_model_comparison/view_routing_model_comparison.py
@@ -80,7 +80,9 @@ def _ensure_app_scoped_env() -> AgiEnv:
     try:
         env = AgiEnv.current()
     except RuntimeError:
-        env = getattr(AgiEnv, "for_app", AgiEnv)(apps_path=active_app_path.parent, app=active_app_path.name, verbose=0)
+        env = getattr(AgiEnv, "for_app", AgiEnv)(
+            apps_path=active_app_path.parent, app=active_app_path.name, verbose=0
+        )
     env.init_done = True
     st.session_state["env"] = env
     return env
@@ -269,11 +271,12 @@ def load_allocations(file_signatures: tuple[tuple[str, str, int], ...]) -> pd.Da
             for allocation in step.get("allocations", []):
                 if not isinstance(allocation, dict):
                     continue
-                source_label = allocation.get("source_label") or allocation.get("source")
-                destination_label = (
-                    allocation.get("destination_label")
-                    or allocation.get("destination")
+                source_label = allocation.get("source_label") or allocation.get(
+                    "source"
                 )
+                destination_label = allocation.get(
+                    "destination_label"
+                ) or allocation.get("destination")
                 requested = safe_float(allocation.get("bandwidth"))
                 delivered = safe_float(allocation.get("delivered_bandwidth"))
                 satisfaction = get_satisfaction(allocation)
@@ -301,7 +304,11 @@ def load_allocations(file_signatures: tuple[tuple[str, str, int], ...]) -> pd.Da
                         "sat_edge_count": sum(bearer == "SAT" for bearer in bearers),
                         "ivdl_edge_count": sum(bearer == "IVDL" for bearer in bearers),
                         "bearers": " -> ".join(bearers),
-                        "path": str(allocation.get("path") or allocation.get("path_labels") or ""),
+                        "path": str(
+                            allocation.get("path")
+                            or allocation.get("path_labels")
+                            or ""
+                        ),
                     }
                 )
     return pd.DataFrame(rows)
@@ -358,9 +365,13 @@ def build_summary(alloc_df: pd.DataFrame) -> pd.DataFrame:
                 "total_requested_mbps": requested_total,
                 "total_delivered_mbps": delivered_total,
                 "served_bandwidth_ratio": (
-                    delivered_total / requested_total if requested_total > 0 else math.nan
+                    delivered_total / requested_total
+                    if requested_total > 0
+                    else math.nan
                 ),
-                "mean_satisfaction_ratio": group["satisfaction_ratio"].mean(skipna=True),
+                "mean_satisfaction_ratio": group["satisfaction_ratio"].mean(
+                    skipna=True
+                ),
                 "latency_violation_rate": latency_checked["latency_violation"].mean()
                 if len(latency_checked)
                 else math.nan,
@@ -377,7 +388,9 @@ def build_summary(alloc_df: pd.DataFrame) -> pd.DataFrame:
     summary_df = pd.DataFrame(rows)
     if summary_df.empty:
         return summary_df
-    summary_df["model"] = pd.Categorical(summary_df["model"], categories=MODEL_ORDER, ordered=True)
+    summary_df["model"] = pd.Categorical(
+        summary_df["model"], categories=MODEL_ORDER, ordered=True
+    )
     return summary_df.sort_values("model").reset_index(drop=True)
 
 
@@ -393,7 +406,9 @@ def available_file_signatures(base_dir: Path) -> tuple[tuple[str, str, int], ...
 def render_metric_row(summary_df: pd.DataFrame) -> None:
     if summary_df.empty:
         return
-    best_served = summary_df.sort_values("served_bandwidth_ratio", ascending=False).iloc[0]
+    best_served = summary_df.sort_values(
+        "served_bandwidth_ratio", ascending=False
+    ).iloc[0]
     lowest_latency = (
         summary_df.dropna(subset=["mean_latency_ms"])
         .sort_values("mean_latency_ms")
@@ -413,7 +428,9 @@ def render_metric_row(summary_df: pd.DataFrame) -> None:
     )
     if not lowest_latency.empty:
         row = lowest_latency.iloc[0]
-        cols[1].metric("Lowest mean latency", str(row["model"]), f"{row['mean_latency_ms']:.1f} ms")
+        cols[1].metric(
+            "Lowest mean latency", str(row["model"]), f"{row['mean_latency_ms']:.1f} ms"
+        )
     if not lowest_violation.empty:
         row = lowest_violation.iloc[0]
         cols[2].metric(
@@ -512,7 +529,9 @@ def build_overview_figure(
         legend=dict(orientation="h", yanchor="bottom", y=1.02, xanchor="right", x=1),
     )
     fig.update_yaxes(range=[0, 1.05], row=1, col=1, title_text="Delivered / requested")
-    fig.update_yaxes(range=[0, 1.05], row=1, col=2, title_text="Proportion of demand outcomes")
+    fig.update_yaxes(
+        range=[0, 1.05], row=1, col=2, title_text="Proportion of demand outcomes"
+    )
     fig.update_yaxes(title_text="Latency (ms)", row=2, col=1)
     fig.update_yaxes(title_text="Violation rate", row=2, col=2)
     return fig
@@ -521,14 +540,13 @@ def build_overview_figure(
 def build_time_figure(alloc_df: pd.DataFrame, models: list[str]) -> go.Figure:
     time_df = alloc_df.copy()
     time_df["latency_ms_routed"] = time_df["latency_ms"].where(time_df["routed"])
-    time_kpi = (
-        time_df.groupby(["model", "time_index"], as_index=False, observed=False)
-        .agg(
-            mean_satisfaction=("satisfaction_ratio", "mean"),
-            total_delivered_mbps=("delivered_mbps", "sum"),
-            mean_latency_ms=("latency_ms_routed", "mean"),
-            latency_violation_rate=("latency_violation", "mean"),
-        )
+    time_kpi = time_df.groupby(
+        ["model", "time_index"], as_index=False, observed=False
+    ).agg(
+        mean_satisfaction=("satisfaction_ratio", "mean"),
+        total_delivered_mbps=("delivered_mbps", "sum"),
+        mean_latency_ms=("latency_ms_routed", "mean"),
+        latency_violation_rate=("latency_violation", "mean"),
     )
     fig = make_subplots(
         rows=2,
@@ -588,7 +606,9 @@ def build_time_figure(alloc_df: pd.DataFrame, models: list[str]) -> go.Figure:
             col=2,
         )
     fig.update_layout(height=720, margin=dict(l=20, r=20, t=70, b=30))
-    fig.update_yaxes(range=[0, 1.05], row=1, col=1, title_text="Mean delivered / requested")
+    fig.update_yaxes(
+        range=[0, 1.05], row=1, col=1, title_text="Mean delivered / requested"
+    )
     fig.update_yaxes(title_text="Delivered bandwidth (Mbps)", row=1, col=2)
     fig.update_yaxes(title_text="Latency (ms)", row=2, col=1)
     fig.update_yaxes(range=[0, 1.05], row=2, col=2, title_text="Violation rate")
@@ -612,7 +632,9 @@ def build_path_figure(alloc_df: pd.DataFrame, models: list[str]) -> go.Figure:
             .unstack(fill_value=0)
             .reindex(index=models, columns=hop_counts, fill_value=0)
         )
-        hop_pivot = hop_pivot.div(hop_pivot.sum(axis=1).replace(0, np.nan), axis=0).fillna(0.0)
+        hop_pivot = hop_pivot.div(
+            hop_pivot.sum(axis=1).replace(0, np.nan), axis=0
+        ).fillna(0.0)
         palette = ["#0f766e", "#2563eb", "#7c3aed", "#db2777", "#64748b"]
         for index, hop in enumerate(hop_counts):
             fig.add_trace(
@@ -629,7 +651,10 @@ def build_path_figure(alloc_df: pd.DataFrame, models: list[str]) -> go.Figure:
 
     bearer_summary = (
         alloc_df.groupby("model", as_index=False, observed=False)
-        .agg(sat_edge_count=("sat_edge_count", "sum"), ivdl_edge_count=("ivdl_edge_count", "sum"))
+        .agg(
+            sat_edge_count=("sat_edge_count", "sum"),
+            ivdl_edge_count=("ivdl_edge_count", "sum"),
+        )
         .set_index("model")
         .reindex(models)
         .fillna(0)
@@ -655,17 +680,212 @@ def build_path_figure(alloc_df: pd.DataFrame, models: list[str]) -> go.Figure:
         col=2,
     )
     fig.update_layout(height=430, barmode="stack", margin=dict(l=20, r=20, t=65, b=30))
-    fig.update_yaxes(range=[0, 1.05], row=1, col=1, title_text="Proportion of routed demands")
+    fig.update_yaxes(
+        range=[0, 1.05], row=1, col=1, title_text="Proportion of routed demands"
+    )
     fig.update_yaxes(title_text="Selected bearer edges", row=1, col=2)
+    return fig
+
+
+def build_demand_matrix_data(alloc_df: pd.DataFrame) -> pd.DataFrame:
+    """Aggregate source-destination delivery, rejection, and latency evidence."""
+
+    columns = [
+        "model",
+        "source_label",
+        "destination_label",
+        "served_bandwidth_ratio",
+        "unmet_bandwidth_ratio",
+        "unrouted_rate",
+        "mean_latency_ms",
+    ]
+    if alloc_df.empty:
+        return pd.DataFrame(columns=columns)
+
+    matrix_df = alloc_df.copy()
+    matrix_df["requested_mbps_valid"] = (
+        pd.to_numeric(matrix_df["requested_mbps"], errors="coerce")
+        .clip(lower=0.0)
+        .fillna(0.0)
+    )
+    delivered = (
+        pd.to_numeric(matrix_df["delivered_mbps"], errors="coerce")
+        .clip(lower=0.0)
+        .fillna(0.0)
+    )
+    matrix_df["delivered_mbps_valid"] = pd.concat(
+        [delivered, matrix_df["requested_mbps_valid"]], axis=1
+    ).min(axis=1)
+    matrix_df["unmet_mbps"] = (
+        matrix_df["requested_mbps_valid"] - matrix_df["delivered_mbps_valid"]
+    ).clip(lower=0.0)
+    routed = matrix_df["routed"].fillna(False).astype(bool)
+    matrix_df["unrouted_decision"] = ~routed
+    matrix_df["routed_latency_ms"] = pd.to_numeric(
+        matrix_df["latency_ms"], errors="coerce"
+    ).where(routed)
+
+    pair_kpis = matrix_df.groupby(
+        ["model", "source_label", "destination_label"],
+        as_index=False,
+        observed=False,
+    ).agg(
+        requested_mbps=("requested_mbps_valid", "sum"),
+        delivered_mbps=("delivered_mbps_valid", "sum"),
+        unmet_mbps=("unmet_mbps", "sum"),
+        unrouted_rate=("unrouted_decision", "mean"),
+        mean_latency_ms=("routed_latency_ms", "mean"),
+    )
+    requested = pair_kpis["requested_mbps"].replace(0.0, np.nan)
+    pair_kpis["served_bandwidth_ratio"] = (
+        pair_kpis["delivered_mbps"] / requested
+    ).clip(lower=0.0, upper=1.0)
+    pair_kpis["unmet_bandwidth_ratio"] = (pair_kpis["unmet_mbps"] / requested).clip(
+        lower=0.0, upper=1.0
+    )
+    return pair_kpis[columns]
+
+
+def build_demand_matrix_figure(
+    alloc_df: pd.DataFrame,
+    models: list[str],
+) -> go.Figure:
+    """Build aligned source-destination heatmaps for each selected model."""
+
+    pair_kpis = build_demand_matrix_data(alloc_df)
+    visible_models = [model for model in models if model in set(pair_kpis["model"])]
+    if pair_kpis.empty or not visible_models:
+        return go.Figure()
+
+    sources = sorted(pair_kpis["source_label"].dropna().astype(str).unique())
+    destinations = sorted(pair_kpis["destination_label"].dropna().astype(str).unique())
+    visible_rows = pair_kpis[pair_kpis["model"].isin(visible_models)]
+    finite_latency = pd.to_numeric(
+        visible_rows["mean_latency_ms"], errors="coerce"
+    ).replace([np.inf, -np.inf], np.nan)
+    latency_max = finite_latency.max()
+    shared_latency_max = (
+        float(latency_max)
+        if math.isfinite(latency_max) and float(latency_max) > 0.0
+        else 1.0
+    )
+    metrics = (
+        ("served_bandwidth_ratio", "Served bandwidth", "Greens", 0.0, 1.0, "%{z:.0%}"),
+        ("unmet_bandwidth_ratio", "Unmet bandwidth", "OrRd", 0.0, 1.0, "%{z:.0%}"),
+        ("unrouted_rate", "Unrouted decisions", "OrRd", 0.0, 1.0, "%{z:.0%}"),
+        (
+            "mean_latency_ms",
+            "Mean routed latency (ms)",
+            "Viridis",
+            0.0,
+            shared_latency_max,
+            "%{z:.1f}",
+        ),
+    )
+    subplot_titles = [
+        f"{model} · {title}"
+        for model in visible_models
+        for _metric, title, _colorscale, _zmin, _zmax, _texttemplate in metrics
+    ]
+    fig = make_subplots(
+        rows=2 * len(visible_models),
+        cols=2,
+        subplot_titles=subplot_titles,
+        horizontal_spacing=0.12,
+        vertical_spacing=min(0.16, 0.4 / (2 * len(visible_models))),
+    )
+
+    for model_index, model in enumerate(visible_models):
+        model_rows = pair_kpis[pair_kpis["model"] == model]
+        for metric_index, (
+            metric,
+            title,
+            colorscale,
+            zmin,
+            zmax,
+            texttemplate,
+        ) in enumerate(metrics):
+            matrix = model_rows.pivot(
+                index="destination_label",
+                columns="source_label",
+                values=metric,
+            ).reindex(index=destinations, columns=sources)
+            row_index = model_index * 2 + metric_index // 2 + 1
+            column_index = metric_index % 2 + 1
+            fig.add_trace(
+                go.Heatmap(
+                    z=matrix.to_numpy(),
+                    x=sources,
+                    y=destinations,
+                    colorscale=colorscale,
+                    zmin=zmin,
+                    zmax=zmax,
+                    showscale=False,
+                    texttemplate=texttemplate,
+                    textfont=dict(size=12),
+                    hovertemplate=(
+                        "Source %{x}<br>Destination %{y}<br>"
+                        f"{title}: %{{z:.3f}}<extra>{model}</extra>"
+                    ),
+                ),
+                row=row_index,
+                col=column_index,
+            )
+
+    fig.update_layout(
+        height=max(800, 760 * len(visible_models)),
+        margin=dict(l=30, r=30, t=70, b=90),
+    )
+    fig.update_annotations(font_size=13)
+    fig.update_xaxes(
+        tickangle=-35,
+        tickfont=dict(size=10),
+        automargin=True,
+    )
+    fig.update_yaxes(
+        title_text="Destination",
+        tickfont=dict(size=10),
+        automargin=True,
+    )
+    for model_index in range(len(visible_models)):
+        top_row = model_index * 2 + 1
+        bottom_row = top_row + 1
+        for column_index in (1, 2):
+            fig.update_xaxes(
+                title_text=None,
+                showticklabels=False,
+                row=top_row,
+                col=column_index,
+            )
+            fig.update_xaxes(
+                title_text="Source",
+                showticklabels=True,
+                row=bottom_row,
+                col=column_index,
+            )
+        for row_index in (top_row, bottom_row):
+            fig.update_yaxes(
+                title_text="Destination",
+                showticklabels=True,
+                row=row_index,
+                col=1,
+            )
+            fig.update_yaxes(
+                title_text=None,
+                showticklabels=False,
+                row=row_index,
+                col=2,
+            )
     return fig
 
 
 def build_failure_table(alloc_df: pd.DataFrame) -> pd.DataFrame:
     table = alloc_df.copy()
-    table["latency_over_target_ms"] = table["latency_ms"] - table["latency_target_used_ms"]
+    table["latency_over_target_ms"] = (
+        table["latency_ms"] - table["latency_target_used_ms"]
+    )
     failures = table[
-        (table["outcome"] != "fulfilled")
-        | (table["latency_violation"])
+        (table["outcome"] != "fulfilled") | (table["latency_violation"])
     ].copy()
     columns = [
         "model",
@@ -719,7 +939,9 @@ def main() -> None:
     base_dir = Path(pipeline_dir_text).expanduser()
     file_signatures = available_file_signatures(base_dir)
     available_models = [
-        model for model, path_text, _mtime in file_signatures if Path(path_text).exists()
+        model
+        for model, path_text, _mtime in file_signatures
+        if Path(path_text).exists()
     ]
     selected_models = st.sidebar.multiselect(
         "Models",
@@ -747,7 +969,9 @@ def main() -> None:
 
     alloc_df = load_allocations(file_signatures)
     if alloc_df.empty:
-        st.warning("No allocation data was loaded from the selected pipeline directory.")
+        st.warning(
+            "No allocation data was loaded from the selected pipeline directory."
+        )
         st.stop()
 
     alloc_df = add_latency_targets(alloc_df)
@@ -762,8 +986,8 @@ def main() -> None:
 
     render_metric_row(summary_df)
 
-    summary_tab, dashboard_tab, time_tab, path_tab, failures_tab = st.tabs(
-        ["Summary", "Dashboard", "Over Time", "Paths", "Failures"]
+    summary_tab, dashboard_tab, time_tab, demand_tab, path_tab, failures_tab = st.tabs(
+        ["Summary", "Dashboard", "Over Time", "Demand Matrix", "Paths", "Failures"]
     )
     with summary_tab:
         st.subheader("Model Summary")
@@ -778,6 +1002,16 @@ def main() -> None:
 
     with time_tab:
         st.plotly_chart(build_time_figure(alloc_df, models), width="stretch")
+
+    with demand_tab:
+        st.caption(
+            "Compare served and unmet bandwidth, unrouted decisions, and routed latency "
+            "for each source-destination pair."
+        )
+        st.plotly_chart(
+            build_demand_matrix_figure(alloc_df, models),
+            width="stretch",
+        )
 
     with path_tab:
         st.plotly_chart(build_path_figure(alloc_df, models), width="stretch")

--- a/test/test_view_routing_model_comparison.py
+++ b/test/test_view_routing_model_comparison.py
@@ -5,11 +5,14 @@ import importlib
 import json
 import sys
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
 
 import math
 
 import pandas as pd
 import pytest
+from streamlit.testing.v1 import AppTest
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -172,7 +175,9 @@ def test_routing_model_comparison_parses_allocation_helpers() -> None:
     assert module.demand_outcome(True, 0.5) == "partial"
 
 
-def test_routing_model_comparison_covers_fallback_helper_branches(tmp_path: Path) -> None:
+def test_routing_model_comparison_covers_fallback_helper_branches(
+    tmp_path: Path,
+) -> None:
     module = _load_module()
     active_app = tmp_path / "active_app"
 
@@ -191,11 +196,13 @@ def test_routing_model_comparison_covers_fallback_helper_branches(tmp_path: Path
     assert module.has_path({"routed": "yes"}) is True
     assert module.has_path({"delivered_bandwidth": 0.5}) is True
     assert module.has_path({"delivered_bandwidth": 0.0}) is False
-    assert module.is_routed(
-        {"path_labels": ["A", "B"], "served_fraction": 0.25}
-    ) is True
+    assert (
+        module.is_routed({"path_labels": ["A", "B"], "served_fraction": 0.25}) is True
+    )
     assert module.is_routed({"path_labels": ["A", "B"], "served_fraction": 0}) is False
-    assert math.isnan(module.get_satisfaction({"bandwidth": 0, "delivered_bandwidth": 1}))
+    assert math.isnan(
+        module.get_satisfaction({"bandwidth": 0, "delivered_bandwidth": 1})
+    )
     assert module.get_latency_ms({"latency": "42"}) == 42.0
     assert math.isnan(module.get_latency_ms({}))
     assert module.get_latency_target_ms({"latency_target": "20"}) == 20.0
@@ -221,7 +228,9 @@ def test_routing_model_comparison_covers_fallback_helper_branches(tmp_path: Path
         encoding="utf-8",
     )
     settings = module._load_app_settings(app)
-    assert module._page_defaults(settings)["dataset_custom_base"] == "/tmp/agilab-routing"
+    assert (
+        module._page_defaults(settings)["dataset_custom_base"] == "/tmp/agilab-routing"
+    )
     settings_file.write_text("[pages\n", encoding="utf-8")
     assert module._load_app_settings(app) == {}
     assert module._page_defaults({}) == {}
@@ -229,7 +238,10 @@ def test_routing_model_comparison_covers_fallback_helper_branches(tmp_path: Path
     assert module._page_defaults({"pages": {module.PAGE_KEY: "bad"}}) == {}
 
     env = type("Env", (), {"agi_share_path_abs": str(tmp_path / "share")})()
-    assert module._default_pipeline_root(env, {}) == tmp_path / "share" / "sb3_trainer/pipeline"
+    assert (
+        module._default_pipeline_root(env, {})
+        == tmp_path / "share" / "sb3_trainer/pipeline"
+    )
     custom_root = module._default_pipeline_root(
         env,
         {"dataset_custom_base": str(tmp_path), "dataset_subpath": "pipeline"},
@@ -239,7 +251,9 @@ def test_routing_model_comparison_covers_fallback_helper_branches(tmp_path: Path
     assert module._default_pipeline_root(empty_env, {}) is None
 
 
-def test_routing_model_comparison_scoped_env_reuses_or_initializes(monkeypatch, tmp_path: Path) -> None:
+def test_routing_model_comparison_scoped_env_reuses_or_initializes(
+    monkeypatch, tmp_path: Path
+) -> None:
     module = _load_module()
     app_path = tmp_path / "apps" / "routing_app"
     app_path.mkdir(parents=True)
@@ -284,7 +298,9 @@ def test_routing_model_comparison_scoped_env_reuses_or_initializes(monkeypatch, 
     assert streamlit.session_state["env"] is env
 
 
-def test_routing_model_comparison_loads_and_summarizes_allocations(tmp_path: Path) -> None:
+def test_routing_model_comparison_loads_and_summarizes_allocations(
+    tmp_path: Path,
+) -> None:
     module = _load_module()
     base = tmp_path / "pipeline"
     ilp_path = base / "trainer_fcas_routing_ilp" / "allocations_steps.json"
@@ -351,6 +367,7 @@ def test_routing_model_comparison_loads_and_summarizes_allocations(tmp_path: Pat
     alloc_df = module.load_allocations(signatures)
     alloc_df = module.add_latency_targets(alloc_df)
     summary = module.build_summary(alloc_df)
+    demand_matrix = module.build_demand_matrix_data(alloc_df)
     failures = module.build_failure_table(alloc_df)
 
     assert set(alloc_df["model"]) == {"ILP", "PPO-GNN"}
@@ -359,6 +376,13 @@ def test_routing_model_comparison_loads_and_summarizes_allocations(tmp_path: Pat
     assert alloc_df["outcome"].tolist().count("partial") == 1
     assert summary.set_index("model").loc["ILP", "routed_count"] == 1
     assert summary.set_index("model").loc["PPO-GNN", "latency_violation_rate"] == 1.0
+    demand_by_pair = demand_matrix.set_index(
+        ["model", "source_label", "destination_label"]
+    )
+    assert demand_by_pair.loc[("ILP", "A", "B"), "served_bandwidth_ratio"] == 1.0
+    assert demand_by_pair.loc[("ILP", "C", "D"), "unmet_bandwidth_ratio"] == 1.0
+    assert demand_by_pair.loc[("ILP", "C", "D"), "unrouted_rate"] == 1.0
+    assert demand_by_pair.loc[("PPO-GNN", "A", "B"), "mean_latency_ms"] == 45.0
     assert len(failures) == 2
     assert "latency_over_target_ms" in failures.columns
 
@@ -370,6 +394,9 @@ def test_routing_model_comparison_figures_handle_empty_and_visible_models() -> N
             {
                 "model": "ILP",
                 "time_index": 0,
+                "source_label": "A",
+                "destination_label": "B",
+                "requested_mbps": 10.0,
                 "satisfaction_ratio": 1.0,
                 "delivered_mbps": 10.0,
                 "latency_ms": 20.0,
@@ -383,6 +410,9 @@ def test_routing_model_comparison_figures_handle_empty_and_visible_models() -> N
             {
                 "model": "PPO-GNN",
                 "time_index": 0,
+                "source_label": "A",
+                "destination_label": "B",
+                "requested_mbps": 10.0,
                 "satisfaction_ratio": 0.5,
                 "delivered_mbps": 5.0,
                 "latency_ms": 45.0,
@@ -417,10 +447,76 @@ def test_routing_model_comparison_figures_handle_empty_and_visible_models() -> N
 
     assert len(module.build_overview_figure(alloc_df, summary, models).data) >= 4
     assert len(module.build_time_figure(alloc_df, models).data) == 8
+    demand_figure = module.build_demand_matrix_figure(alloc_df, models)
+    assert len(demand_figure.data) == 8
+    ratio_traces = [
+        trace for index, trace in enumerate(demand_figure.data) if index % 4 != 3
+    ]
+    assert {trace.zmin for trace in ratio_traces} == {0.0}
+    assert {trace.zmax for trace in ratio_traces} == {1.0}
+    latency_traces = demand_figure.data[3::4]
+    assert {trace.zmin for trace in latency_traces} == {0.0}
+    assert {trace.zmax for trace in latency_traces} == {45.0}
     assert len(module.build_path_figure(alloc_df, models).data) >= 2
     no_routed = alloc_df.assign(routed=False)
     assert len(module.build_path_figure(no_routed, models).data) == 2
     assert module._format_summary(summary).columns.tolist() == models
+    assert module.build_demand_matrix_data(pd.DataFrame()).empty
+    assert len(module.build_demand_matrix_figure(pd.DataFrame(), models).data) == 0
+
+
+def test_demand_matrix_caps_delivery_and_preserves_full_node_identity() -> None:
+    module = _load_module()
+    alloc_df = pd.DataFrame(
+        [
+            {
+                "model": "ILP",
+                "source_label": "A-S1",
+                "destination_label": "destination",
+                "requested_mbps": 10.0,
+                "delivered_mbps": 20.0,
+                "routed": True,
+                "latency_ms": 10.0,
+            },
+            {
+                "model": "ILP",
+                "source_label": "A-S1",
+                "destination_label": "destination",
+                "requested_mbps": 10.0,
+                "delivered_mbps": 0.0,
+                "routed": False,
+                "latency_ms": math.nan,
+            },
+            {
+                "model": "ILP",
+                "source_label": "A-S1",
+                "destination_label": "destination",
+                "requested_mbps": math.nan,
+                "delivered_mbps": 100.0,
+                "routed": True,
+                "latency_ms": 12.0,
+            },
+            {
+                "model": "ILP",
+                "source_label": "B-S1",
+                "destination_label": "destination",
+                "requested_mbps": 5.0,
+                "delivered_mbps": 5.0,
+                "routed": True,
+                "latency_ms": 8.0,
+            },
+        ]
+    )
+
+    matrix = module.build_demand_matrix_data(alloc_df).set_index("source_label")
+    figure = module.build_demand_matrix_figure(alloc_df, ["ILP"])
+
+    assert matrix.loc["A-S1", "served_bandwidth_ratio"] == 0.5
+    assert matrix.loc["A-S1", "unmet_bandwidth_ratio"] == 0.5
+    assert list(figure.data[0].x) == ["A-S1", "B-S1"]
+    assert all(trace.showscale is False for trace in figure.data)
+    assert figure.layout.xaxis3.domain == figure.layout.xaxis.domain
+    assert figure.layout.yaxis3.domain != figure.layout.yaxis.domain
 
 
 def test_routing_model_comparison_empty_helpers_and_metrics(monkeypatch) -> None:
@@ -475,10 +571,7 @@ def test_routing_model_comparison_empty_helpers_and_metrics(monkeypatch) -> None
 
 
 def test_routing_model_comparison_package_bundle_root() -> None:
-    package_src = str(
-        ROOT
-        / "src/agilab/apps-pages/view_routing_model_comparison/src"
-    )
+    package_src = str(ROOT / "src/agilab/apps-pages/view_routing_model_comparison/src")
     if package_src not in sys.path:
         sys.path.insert(0, package_src)
 
@@ -487,7 +580,9 @@ def test_routing_model_comparison_package_bundle_root() -> None:
     assert package.bundle_root().name == "view_routing_model_comparison"
 
 
-def test_routing_model_comparison_main_renders_pipeline(monkeypatch, tmp_path: Path) -> None:
+def test_routing_model_comparison_main_renders_pipeline(
+    monkeypatch, tmp_path: Path
+) -> None:
     module = _load_module()
     pipeline_dir = tmp_path / "pipeline"
     app = tmp_path / "apps" / "routing_app"
@@ -520,8 +615,12 @@ def test_routing_model_comparison_main_renders_pipeline(monkeypatch, tmp_path: P
     env = type("Env", (), {"agi_share_path_abs": ""})()
 
     monkeypatch.setattr(module, "st", streamlit)
-    monkeypatch.setattr(module, "configure_streamlit_page", lambda *args, **kwargs: None)
-    monkeypatch.setattr(module, "render_streamlit_page_header", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        module, "configure_streamlit_page", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        module, "render_streamlit_page_header", lambda *args, **kwargs: None
+    )
     monkeypatch.setattr(module, "_ensure_app_scoped_env", lambda: env)
     monkeypatch.setattr(module, "_resolve_active_app", lambda: app)
 
@@ -529,9 +628,15 @@ def test_routing_model_comparison_main_renders_pipeline(monkeypatch, tmp_path: P
 
     call_names = [name for name, _args in streamlit.calls]
     assert "expander" in call_names
-    assert call_names.count("plotly_chart") == 3
+    assert call_names.count("plotly_chart") == 4
     assert "dataframe" in call_names
-    assert any(name == "caption" and "Loaded 1 allocation" in args[0] for name, args in streamlit.calls)
+    assert any(
+        name == "tabs" and "Demand Matrix" in args for name, args in streamlit.calls
+    )
+    assert any(
+        name == "caption" and "Loaded 1 allocation" in args[0]
+        for name, args in streamlit.calls
+    )
 
 
 def test_routing_model_comparison_main_renders_without_missing_files_or_model_filter(
@@ -565,18 +670,27 @@ def test_routing_model_comparison_main_renders_without_missing_files_or_model_fi
     env = type("Env", (), {"agi_share_path_abs": ""})()
 
     monkeypatch.setattr(module, "st", streamlit)
-    monkeypatch.setattr(module, "configure_streamlit_page", lambda *args, **kwargs: None)
-    monkeypatch.setattr(module, "render_streamlit_page_header", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        module, "configure_streamlit_page", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        module, "render_streamlit_page_header", lambda *args, **kwargs: None
+    )
     monkeypatch.setattr(module, "_ensure_app_scoped_env", lambda: env)
     monkeypatch.setattr(module, "_resolve_active_app", lambda: app)
 
     module.main()
 
     assert all(name != "expander" for name, _args in streamlit.calls)
-    assert any(name == "caption" and "Loaded 3 allocation" in args[0] for name, args in streamlit.calls)
+    assert any(
+        name == "caption" and "Loaded 3 allocation" in args[0]
+        for name, args in streamlit.calls
+    )
 
 
-def test_routing_model_comparison_main_stops_when_loaded_data_is_empty(monkeypatch, tmp_path: Path) -> None:
+def test_routing_model_comparison_main_stops_when_loaded_data_is_empty(
+    monkeypatch, tmp_path: Path
+) -> None:
     module = _load_module()
     pipeline_dir = tmp_path / "pipeline"
     app = tmp_path / "apps" / "routing_app"
@@ -589,8 +703,12 @@ def test_routing_model_comparison_main_stops_when_loaded_data_is_empty(monkeypat
     env = type("Env", (), {"agi_share_path_abs": ""})()
 
     monkeypatch.setattr(module, "st", streamlit)
-    monkeypatch.setattr(module, "configure_streamlit_page", lambda *args, **kwargs: None)
-    monkeypatch.setattr(module, "render_streamlit_page_header", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        module, "configure_streamlit_page", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        module, "render_streamlit_page_header", lambda *args, **kwargs: None
+    )
     monkeypatch.setattr(module, "_ensure_app_scoped_env", lambda: env)
     monkeypatch.setattr(module, "_resolve_active_app", lambda: app)
 
@@ -603,7 +721,9 @@ def test_routing_model_comparison_main_stops_when_loaded_data_is_empty(monkeypat
     )
 
 
-def test_routing_model_comparison_main_warns_when_filter_removes_rows(monkeypatch, tmp_path: Path) -> None:
+def test_routing_model_comparison_main_warns_when_filter_removes_rows(
+    monkeypatch, tmp_path: Path
+) -> None:
     module = _load_module()
     pipeline_dir = tmp_path / "pipeline"
     app = tmp_path / "apps" / "routing_app"
@@ -628,8 +748,12 @@ def test_routing_model_comparison_main_warns_when_filter_removes_rows(monkeypatc
     env = type("Env", (), {"agi_share_path_abs": ""})()
 
     monkeypatch.setattr(module, "st", streamlit)
-    monkeypatch.setattr(module, "configure_streamlit_page", lambda *args, **kwargs: None)
-    monkeypatch.setattr(module, "render_streamlit_page_header", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        module, "configure_streamlit_page", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        module, "render_streamlit_page_header", lambda *args, **kwargs: None
+    )
     monkeypatch.setattr(module, "_ensure_app_scoped_env", lambda: env)
     monkeypatch.setattr(module, "_resolve_active_app", lambda: app)
 
@@ -642,7 +766,9 @@ def test_routing_model_comparison_main_warns_when_filter_removes_rows(monkeypatc
     )
 
 
-def test_routing_model_comparison_main_returns_without_pipeline(monkeypatch, tmp_path: Path) -> None:
+def test_routing_model_comparison_main_returns_without_pipeline(
+    monkeypatch, tmp_path: Path
+) -> None:
     module = _load_module()
     app = tmp_path / "apps" / "routing_app"
     app.mkdir(parents=True)
@@ -650,8 +776,12 @@ def test_routing_model_comparison_main_returns_without_pipeline(monkeypatch, tmp
     env = type("Env", (), {"agi_share_path_abs": ""})()
 
     monkeypatch.setattr(module, "st", streamlit)
-    monkeypatch.setattr(module, "configure_streamlit_page", lambda *args, **kwargs: None)
-    monkeypatch.setattr(module, "render_streamlit_page_header", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        module, "configure_streamlit_page", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        module, "render_streamlit_page_header", lambda *args, **kwargs: None
+    )
     monkeypatch.setattr(module, "_ensure_app_scoped_env", lambda: env)
     monkeypatch.setattr(module, "_resolve_active_app", lambda: app)
 
@@ -660,4 +790,52 @@ def test_routing_model_comparison_main_returns_without_pipeline(monkeypatch, tmp
     assert any(
         name == "info" and "Data directory not configured" in args[0]
         for name, args in streamlit.calls
+    )
+
+
+def test_routing_model_comparison_app_test_renders_demand_matrix(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    pipeline_dir = tmp_path / "pipeline"
+    app = tmp_path / "apps" / "routing_app"
+    settings_path = app / "src" / "app_settings.toml"
+    settings_path.parent.mkdir(parents=True)
+    settings_path.write_text(
+        "[pages.view_routing_model_comparison]\n"
+        f"dataset_custom_base = {json.dumps(str(tmp_path))}\n"
+        "dataset_subpath = 'pipeline'\n",
+        encoding="utf-8",
+    )
+    _write_allocations(
+        pipeline_dir / "trainer_fcas_routing_ilp" / "allocations_steps.json",
+        [
+            {
+                "source_label": "flight-000-S001",
+                "destination_label": "flight-001-S002",
+                "bandwidth": 10.0,
+                "delivered_bandwidth": 7.5,
+                "latency_ms": 22.0,
+                "latency_target_ms": 30.0,
+                "routed": True,
+            }
+        ],
+    )
+
+    argv = [MODULE_PATH.name, "--active-app", str(app)]
+    with patch.object(sys, "argv", argv):
+        monkeypatch.setenv("AGI_EXPORT_DIR", str(tmp_path / "export"))
+        monkeypatch.setenv("AGI_LOCAL_SHARE", str(tmp_path / "localshare"))
+        monkeypatch.setenv("AGI_CLUSTER_SHARE", str(tmp_path / "clustershare"))
+        monkeypatch.setenv("IS_SOURCE_ENV", "1")
+        at = AppTest.from_file(str(MODULE_PATH), default_timeout=30)
+        at.session_state["env"] = SimpleNamespace(
+            agi_share_path_abs="",
+            st_resources=tmp_path / "resources",
+        )
+        at.run()
+
+    assert not at.exception
+    assert any(
+        "Compare served and unmet bandwidth" in caption.value for caption in at.caption
     )


### PR DESCRIPTION
## Summary

- add a generic Demand Matrix tab to `view_routing_model_comparison`
- aggregate served bandwidth, unmet bandwidth, unrouted decisions, and routed latency by full source/destination identity
- render each selected model as a readable two-by-two heatmap block with in-cell values and a shared latency scale
- refresh the page README, canonical gallery mirror, and generated mirror stamp

## Repro

The SB3 routing notebooks contained reusable source/destination matrix analysis, but the public comparison page exposed only summary, time, path, and failure views. Reviewers had to reopen notebook plotting cells to compare demand-level hotspots.

## Root Cause

The generic page had no pair-level aggregation or matrix renderer. The initial implementation also squeezed four panels into one row and independently normalized latency colors, which made the live comparison hard to read and potentially misleading across models.

## Regression Test

- verifies per-decision bandwidth conservation for repeated, over-delivered, and missing-request rows
- preserves distinct full node identities that share suffixes
- asserts ratio scales and shared latency bounds across multiple models
- exercises empty, one-model, and multi-model figure behavior
- runs the page through Streamlit AppTest with a real allocation artifact

## Validation

- focused page suite: 14 passed
- compatibility checks `test_agilab_main_page_shows_agilab_version` and `test_app_surface_specs_support_multiple_backends`: 2 passed from the task-owned Python 3.13 environment
- three-model real-browser validation: 12 heatmaps, shared latency bounds `0..100`, HTTP 200, no console warnings/errors, page errors, failed requests, or HTTP 4xx/5xx responses
- docs workflow parity: passed; Sphinx build completed and the mirror stamp verifies
- `agi-gui` view/UI slices passed, including 1,441 + 852 + 418 + 16 + 179 + 365 tests before the reports slice
- GitHub CI: docs-source guard, repo guardrails, Python 3.13/3.14 compatibility, macOS/Ubuntu/Windows clean installs, Windows core tests, and GitGuardian all passed; `public-demo-smoke` was skipped by workflow policy

Skipped/known unrelated: the full `agi-gui` profile stops in its reports slice at `test_live_endpoint_smoke_opensearch_success_and_failure_paths`. The same connector report and test are byte-identical to `origin/main`; this PR does not carry or modify that regression.

## Review Evidence

- Codex read-only public review found bandwidth-conservation, identifier-collision, preview, layout, and shared-latency-scale issues; all were addressed.
- Codex read-only private and cross-repository reviews verified the SB3 notebook handoff boundary, three-model subplot geometry, docs mirror parity, and absence of shared-core/domain leakage.
- Sub-agents reviewed only and did not edit files.

## Agent Metadata

- Tokki version: 1.0.27
- Agent/runtime: Codex, version unavailable
- Model: GPT-5
- Reasoning effort: unknown
- `/fast` mode: not used
