### PR TITLE
Fix routing comparison active-demand scope and layout

### DIFF
--- a/src/agilab/apps-pages/view_routing_model_comparison/src/view_routing_model_comparison/view_routing_model_comparison.py
+++ b/src/agilab/apps-pages/view_routing_model_comparison/src/view_routing_model_comparison/view_routing_model_comparison.py
@@ -30,6 +30,13 @@ APP_SCOPE_KEY = f"{PAGE_KEY}_active_app_path"
 MIN_MEANINGFUL_DELIVERY_MBPS = 1e-9
 FULFILLED_THRESHOLD = 0.99
 TIME_STEP_S = 60.0
+ACTIVE_DEMAND_KEY_COLUMNS = (
+    "time_index",
+    "source_label",
+    "destination_label",
+)
+ACTIVE_DEMAND_OCCURRENCE_COLUMN = "_active_demand_occurrence"
+ACTIVE_DEMAND_CONFLICT_ATTR = "active_demand_schedule_conflicts"
 
 MODEL_FILES = {
     "ILP": "trainer_fcas_routing_ilp/allocations_steps.json",
@@ -295,6 +302,7 @@ def load_allocations(file_signatures: tuple[tuple[str, str, int], ...]) -> pd.Da
                         "demand": f"{source_label} -> {destination_label}",
                         "requested_mbps": requested,
                         "delivered_mbps": delivered,
+                        "active": safe_bool(allocation.get("active")),
                         "satisfaction_ratio": satisfaction,
                         "routed": routed,
                         "outcome": demand_outcome(routed, satisfaction),
@@ -311,7 +319,88 @@ def load_allocations(file_signatures: tuple[tuple[str, str, int], ...]) -> pd.Da
                         ),
                     }
                 )
-    return pd.DataFrame(rows)
+    return filter_active_demands(pd.DataFrame(rows))
+
+
+def filter_active_demands(alloc_df: pd.DataFrame) -> pd.DataFrame:
+    """Exclude inactive demand-time pairs using the shared model schedule.
+
+    Some routing exporters, notably older PPO-GNN outputs, omit the per-row
+    ``active`` flag. The ILP and Path-AC artifacts carry the same demand
+    schedule, so their explicit flags are broadcast by time/source/destination
+    and stable duplicate-demand occurrence before filtering. Conflicting model
+    evidence is excluded, while unmatched legacy rows are retained rather than
+    having activity inferred from routing or delivery.
+    """
+
+    if alloc_df.empty or "active" not in alloc_df.columns:
+        return alloc_df
+    indexed = alloc_df.copy()
+    indexed[ACTIVE_DEMAND_OCCURRENCE_COLUMN] = indexed.groupby(
+        ["model", *ACTIVE_DEMAND_KEY_COLUMNS],
+        sort=False,
+        dropna=False,
+        observed=False,
+    ).cumcount()
+    reference_columns = [
+        *ACTIVE_DEMAND_KEY_COLUMNS,
+        ACTIVE_DEMAND_OCCURRENCE_COLUMN,
+    ]
+    explicit_rows = indexed.loc[
+        indexed["active"].notna(),
+        [*reference_columns, "active"],
+    ]
+    if explicit_rows.empty:
+        return alloc_df.copy()
+
+    reference_bounds = (
+        explicit_rows.groupby(
+            reference_columns,
+            as_index=False,
+            observed=False,
+            dropna=False,
+        )["active"]
+        .agg(["min", "max"])
+        .reset_index()
+    )
+    conflict_mask = reference_bounds["min"] != reference_bounds["max"]
+    conflict_keys = reference_bounds.loc[conflict_mask, reference_columns]
+    active_reference = reference_bounds.loc[
+        ~conflict_mask,
+        [*reference_columns, "min"],
+    ].rename(columns={"min": "_active_reference"})
+    resolved = indexed.merge(
+        active_reference,
+        on=reference_columns,
+        how="left",
+        validate="many_to_one",
+    )
+    resolved = resolved.merge(
+        conflict_keys.assign(_active_reference_conflict=True),
+        on=reference_columns,
+        how="left",
+        validate="many_to_one",
+    )
+    resolved["active"] = resolved["active"].where(
+        resolved["active"].notna(),
+        resolved["_active_reference"],
+    )
+    keep_mask = ~resolved["_active_reference_conflict"].eq(True) & (
+        resolved["active"].isna() | resolved["active"].eq(True)
+    )
+    filtered = (
+        resolved.loc[keep_mask]
+        .drop(
+            columns=[
+                "_active_reference",
+                "_active_reference_conflict",
+                ACTIVE_DEMAND_OCCURRENCE_COLUMN,
+            ]
+        )
+        .reset_index(drop=True)
+    )
+    filtered.attrs[ACTIVE_DEMAND_CONFLICT_ATTR] = len(conflict_keys)
+    return filtered
 
 
 def add_latency_targets(alloc_df: pd.DataFrame) -> pd.DataFrame:
@@ -916,7 +1005,11 @@ def _format_summary(summary_df: pd.DataFrame) -> pd.DataFrame:
 
 
 def main() -> None:
-    configure_streamlit_page(st, title="Routing Model Comparison")
+    configure_streamlit_page(
+        st,
+        title="Routing Model Comparison",
+        layout="wide",
+    )
     env = _ensure_app_scoped_env()
     active_app_path = _resolve_active_app()
     settings = _load_app_settings(active_app_path)
@@ -968,9 +1061,16 @@ def main() -> None:
             st.write("\n".join(missing_files))
 
     alloc_df = load_allocations(file_signatures)
+    active_schedule_conflicts = int(alloc_df.attrs.get(ACTIVE_DEMAND_CONFLICT_ATTR, 0))
+    if active_schedule_conflicts:
+        st.warning(
+            f"Excluded {active_schedule_conflicts:,} demand-time pair(s) because "
+            "model artifacts disagree on whether they are active. Regenerate the "
+            "routing model outputs together before comparing them."
+        )
     if alloc_df.empty:
         st.warning(
-            "No allocation data was loaded from the selected pipeline directory."
+            "No active-demand allocation data was loaded from the selected pipeline directory."
         )
         st.stop()
 
@@ -981,6 +1081,8 @@ def main() -> None:
         st.warning("No allocation rows match the selected model filter.")
         st.stop()
 
+    has_active_evidence = alloc_df["active"].notna().any()
+    has_legacy_activity = alloc_df["active"].isna().any()
     summary_df = build_summary(alloc_df)
     models = [model for model in MODEL_ORDER if model in set(alloc_df["model"])]
 
@@ -992,7 +1094,20 @@ def main() -> None:
     with summary_tab:
         st.subheader("Model Summary")
         st.dataframe(_format_summary(summary_df), width="stretch")
-        st.caption(f"Loaded {len(alloc_df):,} allocation decisions from {base_dir}.")
+        if has_active_evidence and not has_legacy_activity:
+            st.caption(
+                f"Loaded {len(alloc_df):,} active-demand allocation decisions from {base_dir}."
+            )
+        elif has_active_evidence:
+            st.caption(
+                f"Loaded {len(alloc_df):,} in-scope allocation decisions from {base_dir}. "
+                "The active-demand schedule was applied where available; unmatched legacy rows were retained."
+            )
+        else:
+            st.caption(
+                f"Loaded {len(alloc_df):,} allocation decisions from {base_dir}. "
+                "Rows without activity evidence were retained for legacy compatibility."
+            )
 
     with dashboard_tab:
         st.plotly_chart(

--- a/test/test_view_routing_model_comparison.py
+++ b/test/test_view_routing_model_comparison.py
@@ -387,6 +387,204 @@ def test_routing_model_comparison_loads_and_summarizes_allocations(
     assert "latency_over_target_ms" in failures.columns
 
 
+def test_routing_model_comparison_filters_to_active_demand_schedule(
+    tmp_path: Path,
+) -> None:
+    module = _load_module()
+    base = tmp_path / "pipeline"
+    _write_allocations(
+        base / "trainer_fcas_routing_ilp" / "allocations_steps.json",
+        [
+            {
+                "source_label": "active-source",
+                "destination_label": "active-destination",
+                "bandwidth": 10.0,
+                "delivered_bandwidth": 10.0,
+                "active": True,
+            },
+            {
+                "source_label": "inactive-source",
+                "destination_label": "inactive-destination",
+                "bandwidth": 20.0,
+                "delivered_bandwidth": 0.0,
+                "active": False,
+            },
+            {
+                "source_label": "active-unrouted-source",
+                "destination_label": "active-unrouted-destination",
+                "bandwidth": 5.0,
+                "delivered_bandwidth": 0.0,
+                "routed": False,
+                "active": True,
+            },
+        ],
+    )
+    _write_allocations(
+        base / "trainer_fcas_routing_ppo_gnn" / "allocations_steps.json",
+        [
+            {
+                "source_label": "active-source",
+                "destination_label": "active-destination",
+                "bandwidth": 10.0,
+                "delivered_bandwidth": 5.0,
+            },
+            {
+                "source_label": "inactive-source",
+                "destination_label": "inactive-destination",
+                "bandwidth": 20.0,
+                "delivered_bandwidth": 0.0,
+            },
+            {
+                "source_label": "unknown-source",
+                "destination_label": "unknown-destination",
+                "bandwidth": 30.0,
+                "delivered_bandwidth": 30.0,
+            },
+        ],
+    )
+
+    alloc_df = module.load_allocations(module.available_file_signatures(base))
+    failures = module.build_failure_table(module.add_latency_targets(alloc_df.copy()))
+
+    assert len(alloc_df) == 4
+    assert set(alloc_df["model"]) == {"ILP", "PPO-GNN"}
+    assert set(alloc_df["source_label"]) == {
+        "active-source",
+        "active-unrouted-source",
+        "unknown-source",
+    }
+    assert alloc_df["requested_mbps"].sum() == 55.0
+    assert alloc_df.loc[alloc_df["source_label"] == "active-source", "active"].all()
+    assert "active-unrouted-source" in set(failures["source_label"])
+    assert "inactive-source" not in set(failures["source_label"])
+
+
+def test_routing_model_comparison_retains_legacy_rows_without_active_evidence(
+    tmp_path: Path,
+) -> None:
+    module = _load_module()
+    base = tmp_path / "pipeline"
+    _write_allocations(
+        base / "trainer_fcas_routing_ilp" / "allocations_steps.json",
+        [
+            {
+                "source_label": "legacy-source",
+                "destination_label": "legacy-destination",
+                "bandwidth": 10.0,
+                "delivered_bandwidth": 10.0,
+            }
+        ],
+    )
+
+    alloc_df = module.load_allocations(module.available_file_signatures(base))
+
+    assert len(alloc_df) == 1
+    assert alloc_df.iloc[0]["source_label"] == "legacy-source"
+    assert alloc_df["active"].isna().all()
+
+
+def test_routing_model_comparison_matches_duplicate_demands_by_occurrence(
+    tmp_path: Path,
+) -> None:
+    module = _load_module()
+    base = tmp_path / "pipeline"
+    ilp_path = base / "trainer_fcas_routing_ilp" / "allocations_steps.json"
+    ppo_path = base / "trainer_fcas_routing_ppo_gnn" / "allocations_steps.json"
+    ilp_path.parent.mkdir(parents=True)
+    ppo_path.parent.mkdir(parents=True)
+    common_pair = {
+        "source_label": "duplicate-source",
+        "destination_label": "duplicate-destination",
+    }
+    ilp_path.write_text(
+        json.dumps(
+            [
+                {
+                    "time_index": 0,
+                    "allocations": [
+                        {**common_pair, "bandwidth": 1.0, "active": True},
+                        {**common_pair, "bandwidth": 2.0, "active": False},
+                    ],
+                },
+                {
+                    "time_index": 1,
+                    "allocations": [
+                        {**common_pair, "bandwidth": 1.0, "active": False},
+                        {**common_pair, "bandwidth": 2.0, "active": True},
+                    ],
+                },
+            ]
+        ),
+        encoding="utf-8",
+    )
+    ppo_path.write_text(
+        json.dumps(
+            [
+                {
+                    "time_index": time_index,
+                    "allocations": [
+                        {**common_pair, "bandwidth": 1.0},
+                        {**common_pair, "bandwidth": 2.0},
+                    ],
+                }
+                for time_index in (0, 1)
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    alloc_df = module.load_allocations(module.available_file_signatures(base))
+    bandwidths_by_model_and_time = {
+        key: values.tolist()
+        for key, values in alloc_df.groupby(["model", "time_index"], observed=False)[
+            "requested_mbps"
+        ]
+    }
+
+    assert bandwidths_by_model_and_time == {
+        ("ILP", 0): [1.0],
+        ("ILP", 1): [2.0],
+        ("PPO-GNN", 0): [1.0],
+        ("PPO-GNN", 1): [2.0],
+    }
+
+
+def test_routing_model_comparison_excludes_conflicting_active_evidence(
+    tmp_path: Path,
+) -> None:
+    module = _load_module()
+    base = tmp_path / "pipeline"
+    conflicting = {
+        "source_label": "conflict-source",
+        "destination_label": "conflict-destination",
+        "bandwidth": 10.0,
+    }
+    _write_allocations(
+        base / "trainer_fcas_routing_ilp" / "allocations_steps.json",
+        [{**conflicting, "active": False}],
+    )
+    _write_allocations(
+        base / "trainer_fcas_routing_path_ac" / "allocations_steps.json",
+        [{**conflicting, "active": True}],
+    )
+    _write_allocations(
+        base / "trainer_fcas_routing_ppo_gnn" / "allocations_steps.json",
+        [
+            conflicting,
+            {
+                "source_label": "legacy-source",
+                "destination_label": "legacy-destination",
+                "bandwidth": 5.0,
+            },
+        ],
+    )
+
+    alloc_df = module.load_allocations(module.available_file_signatures(base))
+
+    assert alloc_df["source_label"].tolist() == ["legacy-source"]
+    assert alloc_df.attrs[module.ACTIVE_DEMAND_CONFLICT_ATTR] == 1
+
+
 def test_routing_model_comparison_figures_handle_empty_and_visible_models() -> None:
     module = _load_module()
     alloc_df = pd.DataFrame(
@@ -639,6 +837,38 @@ def test_routing_model_comparison_main_renders_pipeline(
     )
 
 
+def test_routing_model_comparison_main_requests_wide_layout(
+    monkeypatch, tmp_path: Path
+) -> None:
+    module = _load_module()
+    app = tmp_path / "apps" / "routing_app"
+    app.mkdir(parents=True)
+    streamlit = _StreamlitStub(pipeline_text="")
+    env = type("Env", (), {"agi_share_path_abs": ""})()
+    page_configs: list[dict[str, object]] = []
+
+    monkeypatch.setattr(module, "st", streamlit)
+    monkeypatch.setattr(
+        module,
+        "configure_streamlit_page",
+        lambda _streamlit, **kwargs: page_configs.append(kwargs),
+    )
+    monkeypatch.setattr(
+        module, "render_streamlit_page_header", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(module, "_ensure_app_scoped_env", lambda: env)
+    monkeypatch.setattr(module, "_resolve_active_app", lambda: app)
+
+    module.main()
+
+    assert page_configs == [
+        {
+            "title": "Routing Model Comparison",
+            "layout": "wide",
+        }
+    ]
+
+
 def test_routing_model_comparison_main_renders_without_missing_files_or_model_filter(
     monkeypatch,
     tmp_path: Path,
@@ -716,7 +946,7 @@ def test_routing_model_comparison_main_stops_when_loaded_data_is_empty(
         module.main()
 
     assert any(
-        name == "warning" and "No allocation data was loaded" in args[0]
+        name == "warning" and "No active-demand allocation data was loaded" in args[0]
         for name, args in streamlit.calls
     )
 


### PR DESCRIPTION
## Summary

- make the Routing Model Comparison page explicitly request Streamlit's wide layout
- filter every dashboard tab to the authoritative active-demand schedule before aggregation
- inherit missing PPO-GNN activity flags from aligned ILP/Path-AC rows while preserving unmatched legacy evidence
- distinguish duplicate same-pair demands by stable occurrence and fail closed when model schedules conflict

## Repro

1. Open `view_routing_model_comparison` with ILP, PPO-GNN, and Path-AC allocation artifacts.
2. Include inactive allocation rows (`active = false`) alongside active rows.
3. Observe that inactive requested bandwidth and zero-delivery rows affect Summary, Dashboard, Over Time, Demand Matrix, Paths, Failures, and the loaded-row count.
4. The page layout intent is also implicit rather than declared at the page call site.

## Root Cause

The loader dropped the per-allocation `active` field, so all rows reached every downstream aggregation. Older PPO-GNN artifacts omit that field, requiring activity to be resolved from the aligned ILP/Path-AC demand schedule. A source/destination key alone is insufficient because multiple demands may share the same endpoints, and stale model artifacts can disagree on activity.

## Regression Test

- explicit inactive rows are excluded while active-but-unrouted rows remain failures
- missing PPO-GNN flags inherit by timestep, endpoints, and duplicate-demand occurrence
- unmatched legacy rows remain available without inferring activity from delivery or routing
- conflicting ILP/Path-AC schedules are excluded and reported
- the page explicitly requests `layout="wide"`

## Validation

- focused routing comparison suite: 19 passed with `FutureWarning` treated as an error
- Ruff check and format check passed
- Chromium proof at a 1600 px viewport: 1300 px available main area, 1300 px rendered before and after a widget rerun, no console/page/request failures
- browser fixture retained 3 active-demand decisions across the three models and excluded the inactive pair
- scope guard: one page scope plus its tests
- `agi-gui` profile was run; it reached the unrelated pre-existing `test_live_endpoint_smoke_opensearch_success_and_failure_paths` failure (`skipped` versus `healthy`). That test file is unchanged from `origin/main`.
- GitHub checks after merge: 8 successful, 1 expected demo job skipped, 0 failing or pending

## Review Evidence

- Peirce (`final_private_review`, read-only) audited the private SB3 activity contract and confirmed `allocation["active"]` is authoritative; no files edited.
- Poincare (`final_public_review`, read-only) found duplicate-demand and conflicting-schedule edge cases; both findings were addressed and the final review reported no blocker; no files edited.

## Agent Metadata

- Tokki: 1.0.27
- Agent/runtime: Codex CLI 0.144.4
- Model: GPT-5
- Reasoning effort: unknown
- `/fast`: not used
