### PR TITLE
fix(hooks): run guards without a worktree venv bootstrap

### DIFF
--- a/.githooks/guard_python.sh
+++ b/.githooks/guard_python.sh
@@ -1,0 +1,24 @@
+# Shared interpreter selection for agilab git hooks. Sourced, not executed.
+#
+# Hooks must also work in fresh worktrees that have no .venv yet: a bare
+# `uv run` there bootstraps the full project environment from scratch, which
+# fails on interpreters without prebuilt wheels (e.g. free-threaded CPython
+# building polars from source). Prefer the project environment when it
+# exists, then the main checkout's environment, then plain python3 for the
+# stdlib-only guards.
+run_guard_python() {
+  if [[ -x "$ROOT_DIR/.venv/bin/python" ]]; then
+    uv --preview-features extra-build-dependencies run python "$@"
+    return
+  fi
+  local common_dir main_root
+  common_dir="$(git -C "$ROOT_DIR" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
+  main_root="${common_dir%/.git}"
+  if [[ -n "$main_root" && "$main_root" != "$ROOT_DIR" && -x "$main_root/.venv/bin/python" ]]; then
+    echo "[agilab hooks] no local .venv; using main checkout interpreter at $main_root/.venv" >&2
+    "$main_root/.venv/bin/python" "$@"
+    return
+  fi
+  echo "[agilab hooks] no project venv found; falling back to python3" >&2
+  python3 "$@"
+}

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -9,5 +9,6 @@ if [[ "${AGILAB_SKIP_LOCAL_GUARDS:-}" == "1" ]]; then
 fi
 
 cd "$ROOT_DIR"
-uv --preview-features extra-build-dependencies run python tools/agent_commit_provenance_guard.py \
+. "$(dirname -- "${BASH_SOURCE[0]}")/guard_python.sh"
+run_guard_python tools/agent_commit_provenance_guard.py \
   --check-config

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -9,14 +9,15 @@ if [[ "${AGILAB_SKIP_LOCAL_GUARDS:-}" == "1" ]]; then
 fi
 
 cd "$ROOT_DIR"
+. "$(dirname -- "${BASH_SOURCE[0]}")/guard_python.sh"
 push_spec_file="$(mktemp)"
 trap 'rm -f "$push_spec_file"' EXIT
 cat > "$push_spec_file"
-uv --preview-features extra-build-dependencies run python tools/agent_commit_provenance_guard.py \
+run_guard_python tools/agent_commit_provenance_guard.py \
   --pre-push-spec "$push_spec_file"
 
 guard_state="$(
-  uv --preview-features extra-build-dependencies run python tools/pre_push_changed_files.py \
+  run_guard_python tools/pre_push_changed_files.py \
     --pre-push-spec "$push_spec_file"
 )"
 DOCS_CHANGED=1
@@ -61,7 +62,7 @@ if [[ "${AGI_CORE_PROTECTED_CHANGED:-1}" == "1" ]]; then
   if [[ -z "$agi_core_actor" ]]; then
     agi_core_actor="$(git config --get github.user || true)"
   fi
-  uv --preview-features extra-build-dependencies run python tools/agi_core_change_guard.py \
+  run_guard_python tools/agi_core_change_guard.py \
     --actor "$agi_core_actor" \
     --protected-changed
 else
@@ -69,10 +70,10 @@ else
 fi
 
 if [[ "${DOCS_CHANGED:-1}" == "1" ]]; then
-  uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py \
+  run_guard_python tools/sync_docs_source.py \
     --verify-stamp \
     --quiet
-  uv --preview-features extra-build-dependencies run python tools/sync_docs_source.py \
+  run_guard_python tools/sync_docs_source.py \
     --check \
     --delete \
     --quiet \
@@ -82,7 +83,7 @@ else
 fi
 
 if [[ "${RELEASE_PROOF_CHANGED:-1}" == "1" ]]; then
-  uv --preview-features extra-build-dependencies run python tools/release_proof_report.py \
+  run_guard_python tools/release_proof_report.py \
     --check \
     --quiet
 else
@@ -90,14 +91,14 @@ else
 fi
 
 if [[ "${AGENT_INSTRUCTIONS_CHANGED:-1}" == "1" ]]; then
-  uv --preview-features extra-build-dependencies run python tools/agent_instruction_contract.py \
+  run_guard_python tools/agent_instruction_contract.py \
     --check
 else
   echo "[agilab pre-push] agent instruction inputs unchanged; skipping agent instruction guard." >&2
 fi
 
 if [[ "${APP_CONTRACTS_CHANGED:-1}" == "1" ]]; then
-  uv --preview-features extra-build-dependencies run python tools/app_contract_matrix.py \
+  run_guard_python tools/app_contract_matrix.py \
     --output .pytest_cache/agilab/app-contract-matrix-pre-push.json \
     --quiet
 else


### PR DESCRIPTION
## Summary

Route all `.githooks` Python invocations through a shared `run_guard_python` helper (`.githooks/guard_python.sh`): prefer the local project venv via `uv run`, fall back to the main checkout's venv in worktrees, then plain `python3`.

## Repro

`git worktree add <path> <branch>` then any `git commit` in the fresh worktree. The pre-commit hook runs bare `uv run`, which bootstraps the full project environment from scratch and fails compiling `polars-runtime-32` on free-threaded CPython 3.14 with stable Rust (`foldhash`/`argminmax` nightly-feature errors) — every commit and push from a new worktree is blocked.

## Root Cause

The hooks assumed a synced project environment. A fresh worktree has no `.venv`, so `uv run` attempted a full dependency build instead of just locating an interpreter; the guard tools themselves are stdlib-only (or importable from the sibling checkout's venv) and never needed that build.

## Regression Test

Shell-hook automation is impractical in the pytest suite (it would need a nested git worktree plus hook execution as git runs it). Closest validation, performed on this branch: created a venv-less worktree from this branch and ran `git commit --allow-empty` — the hook logged the main-checkout-interpreter fallback, the provenance guard passed, and the commit succeeded, where the same steps fail on main. Existing `test_pre_push_changed_files.py` / `test_worktree_scope_guard.py` continue to cover the guard tools' logic; `bash -n` passes on all three hook scripts.

## Review Evidence

Authored with Claude Code (Claude Fable 5); no sub-agents. Verified by direct repro in a fresh worktree as described above; local pre-commit and pre-push provenance guards passed on this branch's own commit and push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)