### PR TITLE
Harden concurrent runtime access and evidence publication

### DIFF
--- a/agilab-capabilities.json
+++ b/agilab-capabilities.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-07-16T11:36:39Z",
+  "generated_at_utc": "2026-07-16T23:04:55Z",
   "schema": "agilab.capabilities.v1",
   "schema_version": 1,
   "generated_by": {
@@ -19,10 +19,10 @@
   "summary": {
     "cli_command_count": 13,
     "streamlit_page_count": 6,
-    "package_count": 37,
+    "package_count": 36,
     "public_app_count": 15,
     "agent_skill_count": 33,
-    "evidence_schema_count": 230,
+    "evidence_schema_count": 233,
     "catalog_file_count": 12
   },
   "cli_commands": [
@@ -336,17 +336,6 @@
       "project": "src/agilab/apps-pages/view_forecast_analysis",
       "pyproject": "src/agilab/apps-pages/view_forecast_analysis/pyproject.toml",
       "pypi_environment": "pypi-agi-page-timeseries-forecast",
-      "artifact_policy": "wheel+sdist"
-    },
-    {
-      "name": "agi-page-inference-report",
-      "role": "page-bundle",
-      "status": "PyPI package",
-      "version": "2026.07.04",
-      "description": "AGILAB page bundle for inference result reporting.",
-      "project": "src/agilab/apps-pages/view_inference_analysis",
-      "pyproject": "src/agilab/apps-pages/view_inference_analysis/pyproject.toml",
-      "pypi_environment": "pypi-agi-page-inference-report",
       "artifact_policy": "wheel+sdist"
     },
     {
@@ -1079,6 +1068,18 @@
       ]
     },
     {
+      "schema": "agilab.agent_run.claim.v1",
+      "sources": [
+        "src/agilab/agent_runtime/agent_run.py"
+      ]
+    },
+    {
+      "schema": "agilab.agent_run.termination.v1",
+      "sources": [
+        "src/agilab/agent_runtime/agent_run.py"
+      ]
+    },
+    {
       "schema": "agilab.agent_run.v1",
       "sources": [
         "README.md",
@@ -1120,6 +1121,7 @@
         "README.md",
         "README.pypi.md",
         "docs/source/agent-workflows.rst",
+        "src/agilab/agent_runtime/agent_run.py",
         "src/agilab/agent_runtime/agent_trace.py",
         "tools/agent_workflows.md",
         "tools/agilab_capabilities_manifest.py"
@@ -1321,6 +1323,12 @@
       "schema": "agilab.dag_contract_stage_result.v1",
       "sources": [
         "src/agilab/dag/dag_execution_adapters.py"
+      ]
+    },
+    {
+      "schema": "agilab.dag_stage_idempotency.v1",
+      "sources": [
+        "src/agilab/dag/dag_idempotency.py"
       ]
     },
     {

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -1,9 +1,9 @@
 {
-  "file_count": 277,
+  "file_count": 276,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "cc5a6695ad7438b27d22cea8f89894d73838cde580be8aac77e3658f5b598111",
+  "source_digest_sha256": "bb39e6444e1b0c8f31245a7bf4cb1af7ae4764bf69aacc118a6fa88513fcd3c3",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "cc5a6695ad7438b27d22cea8f89894d73838cde580be8aac77e3658f5b598111"
+  "target_digest_sha256": "bb39e6444e1b0c8f31245a7bf4cb1af7ae4764bf69aacc118a6fa88513fcd3c3"
 }

--- a/maintenance/memory/by-path/src%2Fagilab%2Fpages%2F4_ANALYSIS.py.md
+++ b/maintenance/memory/by-path/src%2Fagilab%2Fpages%2F4_ANALYSIS.py.md
@@ -1,30 +1,51 @@
 ---
 schema: agilab.maintenance_memory.v1
 source: src/agilab/pages/4_ANALYSIS.py
-source_sha256: 6d6e23a019d30ea316b75a16a7573c5bd3120049613fe95a64cdaae739e0f922
-title: ANALYSIS page AgiEnv singleton contract
-verified_commit: e36ef7ed89d97b8422223d7fff2cb92527086f50
+source_sha256: 3675f370822e6d6ff7f15fd6bdf1965a921517ff54200c9c4106492c8f12fc18
+title: ANALYSIS page session environment and sidecar ownership contract
+verified_commit: cf8058b53e5f5decd974038103f1eaf2f39c8a9d
 ---
 
-# ANALYSIS page AgiEnv singleton contract
+# ANALYSIS page session environment and sidecar ownership contract
 
 Hidden invariant: ANALYSIS can be opened before the main navigation bootstrap
 has created `st.session_state["env"]`. It must therefore initialize the runtime
-through `AgiEnv.for_app(...)`, not by direct `AgiEnv(...)` construction. Direct
-construction can leave a process-global singleton initialized with an app-specific
-signature and later make `_ensure_navigation_environment()` fail when it tries to
-bootstrap the generic navigation environment.
+through `AgiEnv.session_for_app(...)`, never `AgiEnv.for_app(...)`, direct
+`AgiEnv(...)` construction, or a borrowed `AgiEnv.current()` singleton. Each
+Streamlit session owns an independently mutable environment, while the legacy
+process singleton remains available to CLI callers only.
 
 When ANALYSIS creates the environment, it must also set
 `st.session_state["first_run"] = False`. Otherwise a later navigation page can
 treat the warm session as cold and re-enter bootstrap.
 
-Regression expectation: tests should cover built-in project shorthand, default
-project selection, `AgiEnv.for_app(...)` usage, and the `first_run` state update.
-For browser-visible changes, run the matching UI robot scenario in addition to
-helper tests.
+Local notebook and view servers must be launched or reused only through the
+signed process-level sidecar registry. A listening port alone is not ownership
+proof: reuse requires the registered PID/start identity, stable command digest,
+and listener ownership by that process tree. Hosted inline views are the one
+compatibility exception; they must acquire the nonblocking process-state lease
+before changing `sys.argv`, `sys.path`, or `sys.modules`, restore all three in a
+`finally` block, and fail fast when another session owns the lease.
 
-2026-07-07 re-verification: centralizing Streamlit page configuration removed
-the inline view `st.set_page_config` monkeypatch in this file, but preserved
-`_initialize_analysis_env(...)` using `AgiEnv.for_app(...)` and setting
-`st.session_state["first_run"] = False`.
+Environment preparation subprocesses are another process-owned boundary. The
+page must retain the exact launch token, process-group identity, launch time,
+and owner until cleanup proves both that the parent was reaped and that no
+owned group or token-matched descendant remains. A wrapper exit is not cleanup
+proof. TERM/KILL and waits must stay bounded, and an inaccessible recent
+same-user process candidate or an unreaped parent must fail closed before the
+preparation guard is released.
+
+Regression expectation: cover built-in/default project selection,
+`AgiEnv.session_for_app(...)`, `first_run=False`, cross-session inline-render
+exclusion and global restoration, sidecar single-launch reuse, stale PID/port
+collision rejection, a fast-exiting preparation wrapper with a surviving child,
+an unreaped parent after bounded kill/wait, inaccessible owned-process evidence,
+and one matching ANALYSIS browser robot scenario.
+
+2026-07-16 re-verification: concurrent-access hardening replaced singleton
+borrowing with session environments, added verified sidecar ownership, and
+contained hosted inline process globals behind a fail-fast lease.
+
+2026-07-17 re-verification: preparation ownership now survives wrapper exit,
+uses bounded process-group/tree termination, and releases the cross-session
+guard only after parent and descendant absence are both proven.

--- a/pycharm/setup_pycharm.py
+++ b/pycharm/setup_pycharm.py
@@ -10,6 +10,8 @@ import xml.etree.ElementTree as ET
 from pathlib import Path
 from typing import Optional, Iterable, Dict, List
 
+from agilab.environment.env_file_utils import read_mutable_env_text
+
 _RUNTIME_TARGET_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
@@ -69,7 +71,7 @@ class Config:
             return data
 
         try:
-            for raw_line in env_path.read_text().splitlines():
+            for raw_line in read_mutable_env_text(env_path).splitlines():
                 line = raw_line.strip()
                 if not line or line.startswith("#") or "=" not in line:
                     continue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -359,10 +359,6 @@ ydata-profiling = ["standard-imghdr"]
     path = "./src/agilab/apps-pages/view_forecast_analysis"
     editable = true
 
-[tool.uv.sources.agi-page-inference-report]
-    path = "./src/agilab/apps-pages/view_inference_analysis"
-    editable = true
-
 [tool.uv.sources.agi-page-live-artifacts]
     path = "./src/agilab/apps-pages/view_live_artifacts"
     editable = true

--- a/src/agilab/about_page/bootstrap.py
+++ b/src/agilab/about_page/bootstrap.py
@@ -9,7 +9,9 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Mapping, MutableMapping, Optional
 
+from agi_env.app_settings_support import update_app_settings
 from agi_env.credential_store_support import CLUSTER_CREDENTIALS_KEY, KEYRING_SENTINEL
+from agi_env.ui.sidecar_registry import hosted_inline_render_guard
 
 try:  # pragma: no cover - optional import fallback is exercised through behavior tests
     import tomli_w as _tomli_writer
@@ -69,7 +71,8 @@ def parse_startup_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="App name or path to select on startup (mirrors ?active_app= query parameter).",
         default=None,
     )
-    args, _ = parser.parse_known_args(argv)
+    with hosted_inline_render_guard():
+        args, _ = parser.parse_known_args(argv)
     return args
 
 
@@ -196,26 +199,29 @@ def _existing_env_matches_apps_path(env: Any, apps_path: Path) -> bool:
     return False
 
 
-def _recover_existing_env_for_apps_path(agi_env_cls: Any, apps_path: Path) -> Any | None:
-    current = getattr(agi_env_cls, "current", None)
-    if not callable(current):
-        return None
-    try:
-        env = current()
-    except RuntimeError:
-        return None
-    return env if _existing_env_matches_apps_path(env, apps_path) else None
+def _streamlit_session_factory(agi_env_cls: Any) -> Callable[..., Any]:
+    """Return the required UI factory or fail with an upgrade path."""
+    session_factory = getattr(agi_env_cls, "session", None)
+    if not callable(session_factory):
+        raise RuntimeError(
+            "This AGILAB UI requires AgiEnv.session() so each Streamlit session "
+            "owns an isolated environment. Upgrade agi-env, restart AGILAB, and "
+            "open a new browser session."
+        )
+    return session_factory
 
 
-def _reset_agi_env_singleton(agi_env_cls: Any) -> bool:
-    reset = getattr(agi_env_cls, "reset", None)
-    if not callable(reset):
-        return False
-    try:
-        reset()
-    except (AttributeError, OSError, RuntimeError, TypeError, ValueError):
-        return False
-    return True
+def _create_streamlit_session_env(agi_env_cls: Any, *, apps_path: Path, verbose: int) -> Any:
+    """Create a UI-owned environment without borrowing the CLI singleton."""
+
+    session_factory = _streamlit_session_factory(agi_env_cls)
+    env = session_factory(apps_path=apps_path, verbose=verbose)
+    if not getattr(env, "_agilab_session_scoped", False):
+        raise RuntimeError(
+            "AgiEnv.session() returned a legacy shared environment. Upgrade agi-env, "
+            "restart AGILAB, and open a new browser session."
+        )
+    return env
 
 
 def persist_preinit_launch_env(
@@ -447,13 +453,33 @@ def _rebootstrap_active_app_path(env: Any, target_path: Path, target_name: str, 
     """Switch to a resolved project path without using name-only change_app."""
     previous_init_done = getattr(env, "init_done", None)
     try:
-        type(env).__init__(
-            env,
-            apps_path=target_path.parent,
-            app=target_name,
-            verbose=getattr(env, "verbose", None),
-            _agilab_reinitialize=True,
-        )
+        reinitialize = getattr(env, "reinitialize_for_app", None)
+        if callable(reinitialize):
+            reinitialize(
+                apps_path=target_path.parent,
+                app=target_name,
+                verbose=getattr(env, "verbose", None),
+            )
+        else:
+            env_cls = type(env)
+            lock = getattr(env_cls, "_lock", None)
+            if lock is None:
+                env_cls.__init__(
+                    env,
+                    apps_path=target_path.parent,
+                    app=target_name,
+                    verbose=getattr(env, "verbose", None),
+                    _agilab_reinitialize=True,
+                )
+            else:
+                with lock:
+                    env_cls.__init__(
+                        env,
+                        apps_path=target_path.parent,
+                        app=target_name,
+                        verbose=getattr(env, "verbose", None),
+                        _agilab_reinitialize=True,
+                    )
         if previous_init_done is not None:
             env.init_done = previous_init_done
     except (AttributeError, OSError, RuntimeError, TypeError, ValueError) as exc:
@@ -637,14 +663,21 @@ def disable_cluster_in_app_settings(settings_path: Path) -> bool:
         raise RuntimeError("Writing settings requires the 'tomli-w' package.")
     if not settings_path.exists():
         return False
-    payload = tomllib.loads(settings_path.read_text(encoding="utf-8"))
-    cluster = payload.get("cluster")
-    if not isinstance(cluster, dict) or cluster.get("cluster_enabled") is False:
-        return False
-    cluster["cluster_enabled"] = False
-    with settings_path.open("wb") as handle:
-        _tomli_writer.dump(payload, handle)
-    return True
+
+    def _disable_cluster(payload: dict[str, Any]) -> bool:
+        cluster = payload.get("cluster")
+        if not isinstance(cluster, dict) or cluster.get("cluster_enabled") is False:
+            return False
+        cluster["cluster_enabled"] = False
+        return True
+
+    _payload, changed = update_app_settings(
+        settings_path,
+        _disable_cluster,
+        create_missing=False,
+        dump_fn=_tomli_writer.dump,
+    )
+    return changed
 
 
 def handle_cluster_share_startup_error(
@@ -723,37 +756,21 @@ def bootstrap_page_environment(
         environ=ports.environ,
     )
 
-    try:
-        env = ports.agi_env_cls(apps_path=apps_path, verbose=1)
-    except RuntimeError as exc:
-        if _is_already_initialised_env_error(exc):
-            env = _recover_existing_env_for_apps_path(ports.agi_env_cls, apps_path)
-            if env is not None:
-                streamlit.session_state["env"] = env
-            elif _reset_agi_env_singleton(ports.agi_env_cls):
-                persist_preinit_launch_env(
-                    ports.agi_env_cls,
-                    preinit_updates,
-                    environ=ports.environ,
-                )
-                try:
-                    env = ports.agi_env_cls(apps_path=apps_path, verbose=1)
-                except RuntimeError as retry_exc:
-                    if handle_data_root_failure(retry_exc, agi_env_cls=ports.agi_env_cls):
-                        return BootstrapResult(env=None, handled_recovery=True)
-                    if is_cluster_share_startup_error(retry_exc):
-                        handle_cluster_share_startup_error(
-                            streamlit=streamlit,
-                            exc=retry_exc,
-                            env_file_path=env_file_path,
-                            args=args,
-                            ports=ports,
-                        )
-                        return BootstrapResult(env=None, handled_recovery=True)
-                    raise
-            else:
-                raise
-        else:
+    _streamlit_session_factory(ports.agi_env_cls)
+    warm_env = streamlit.session_state.get("env")
+    if (
+        getattr(warm_env, "_agilab_session_scoped", False)
+        and _existing_env_matches_apps_path(warm_env, apps_path)
+    ):
+        env = warm_env
+    else:
+        try:
+            env = _create_streamlit_session_env(
+                ports.agi_env_cls,
+                apps_path=apps_path,
+                verbose=1,
+            )
+        except RuntimeError as exc:
             if handle_data_root_failure(exc, agi_env_cls=ports.agi_env_cls):
                 return BootstrapResult(env=None, handled_recovery=True)
             if is_cluster_share_startup_error(exc):
@@ -780,7 +797,9 @@ def bootstrap_page_environment(
     streamlit.session_state["IS_WORKER_ENV"] = env.is_worker_env
 
     services_enabled = ports.background_services_enabled()
-    if services_enabled and not streamlit.session_state.get("server_started"):
+    if services_enabled:
+        # The process registry, not a session boolean, is the ownership source
+        # of truth. Re-entering bootstrap must verify or relaunch the service.
         ports.activate_mlflow(env)
 
     remember_active_app(env, ports.store_last_active_app)

--- a/src/agilab/about_page/env_editor.py
+++ b/src/agilab/about_page/env_editor.py
@@ -17,6 +17,8 @@ from agi_env.credential_store_support import (
     read_cluster_credentials,
     store_cluster_credentials,
 )
+from agi_env.runtime.atomic_write_support import run_with_windows_file_sharing_retry
+from agi_env.runtime.env_config_support import update_env_file_text
 
 _IMPORT_GUARD_PATH = Path(__file__).resolve().parents[1] / "import_guard.py"
 _IMPORT_GUARD_SPEC = importlib.util.spec_from_file_location(
@@ -74,14 +76,17 @@ def _ensure_env_file(path: Path) -> Path:
             logger.info("mkdir %s", bound_log_value(parent, LOG_PATH_LIMIT))
         except FileExistsError:
             pass
+        template_text = ""
         if TEMPLATE_ENV_PATH is not None:
             try:
                 template_text = TEMPLATE_ENV_PATH.read_text(encoding="utf-8")
-                path.write_text(template_text, encoding="utf-8")
-                return path
             except (OSError, UnicodeError):
                 pass
-        path.touch(exist_ok=True)
+        update_env_file_text(
+            path,
+            lambda current: template_text if current is None else None,
+            refuse_symlink_message=f"Refusing to create env file through symlink: {path}",
+        )
     except OSError as exc:
         logger.warning(
             "Unable to create env file at %s: %s",
@@ -213,33 +218,36 @@ def _env_preview_value(key: str, value: str) -> str:
     return value
 
 
+def _parse_env_text(text: str) -> List[Dict[str, str]]:
+    entries: List[Dict[str, str]] = []
+    for raw in text.splitlines():
+        stripped = raw.strip()
+        if not stripped:
+            entries.append({"type": "comment", "raw": raw})
+            continue
+
+        # Treat commented KEY=VAL lines as entries so they can be edited/uncommented.
+        target = stripped.lstrip("#").strip()
+        if "=" in target:
+            key, value = target.split("=", 1)
+            entries.append(
+                {
+                    "type": "entry",
+                    "key": key.strip(),
+                    "value": _strip_dotenv_quotes(value),
+                    "raw": raw,
+                    "commented": stripped.startswith("#"),
+                }
+            )
+        else:
+            entries.append({"type": "comment", "raw": raw})
+    return entries
+
+
 def _read_env_file(path: Path) -> List[Dict[str, str]]:
     path = _ensure_env_file(path)
-    entries: List[Dict[str, str]] = []
-    with path.open("r", encoding="utf-8") as handle:
-        for raw_line in handle.readlines():
-            raw = raw_line.rstrip("\n")
-            stripped = raw.strip()
-            if not stripped:
-                entries.append({"type": "comment", "raw": raw})
-                continue
-
-            # Treat commented KEY=VAL lines as entries so they can be edited/uncommented.
-            target = stripped.lstrip("#").strip()
-            if "=" in target:
-                key, value = target.split("=", 1)
-                entries.append(
-                    {
-                        "type": "entry",
-                        "key": key.strip(),
-                        "value": _strip_dotenv_quotes(value),
-                        "raw": raw,
-                        "commented": stripped.startswith("#"),
-                    }
-                )
-            else:
-                entries.append({"type": "comment", "raw": raw})
-    return entries
+    text = run_with_windows_file_sharing_retry(lambda: path.read_text(encoding="utf-8"))
+    return _parse_env_text(text)
 
 
 def _is_worker_python_override_key(key: str) -> bool:
@@ -298,56 +306,72 @@ def _write_env_file(
 ) -> None:
     """Write the .env file, consolidating duplicate keys (last value wins)."""
     path = _ensure_env_file(path)
-    lines: List[str] = []
-    emitted_keys: set[str] = set()
 
-    file_values: Dict[str, str] = {}
-    for entry in entries:
-        if entry["type"] == "entry":
-            file_values[entry["key"]] = entry["value"]
-    final_values: Dict[str, str] = {**file_values, **updates}
+    def _apply(current_text: str | None) -> str:
+        current_entries = _parse_env_text(current_text or "")
+        if current_text is None:
+            current_entries = entries
+        lines: List[str] = []
+        emitted_keys: set[str] = set()
+        last_entries = {
+            entry["key"]: entry for entry in current_entries if entry["type"] == "entry"
+        }
 
-    for entry in entries:
-        if entry["type"] != "entry":
-            lines.append(entry["raw"])
-            continue
-        key = entry["key"]
-        if key in emitted_keys:
-            continue
-        emitted_keys.add(key)
-        value = final_values.get(key, entry["value"])
-        lines.append(f"{key}={value}")
-
-    for key, value in updates.items():
-        if key not in emitted_keys:
-            lines.append(f"{key}={value}")
+        for entry in current_entries:
+            if entry["type"] != "entry":
+                lines.append(entry["raw"])
+                continue
+            key = entry["key"]
+            if key in emitted_keys:
+                continue
             emitted_keys.add(key)
+            if key in updates:
+                lines.append(f"{key}={updates[key]}")
+            else:
+                lines.append(last_entries[key]["raw"])
 
-    if new_entry and new_entry.get("key") and new_entry["key"] not in emitted_keys:
-        lines.append(f"{new_entry['key']}={new_entry['value']}")
+        for key, value in updates.items():
+            if key not in emitted_keys:
+                lines.append(f"{key}={value}")
+                emitted_keys.add(key)
 
-    content = "\n".join(lines).rstrip() + "\n"
-    path.write_text(content, encoding="utf-8")
+        if new_entry and new_entry.get("key") and new_entry["key"] not in emitted_keys:
+            lines.append(f"{new_entry['key']}={new_entry['value']}")
+
+        return "\n".join(lines).rstrip() + "\n"
+
+    update_env_file_text(
+        path,
+        _apply,
+        refuse_symlink_message=f"Refusing to write env file through symlink: {path}",
+    )
 
 
 def _upsert_env_var(path: Path, key: str, value: str) -> None:
     """Update or append a single KEY=VALUE in the .env file."""
     path = _ensure_env_file(path)
-    lines = path.read_text(encoding="utf-8").splitlines()
-    rewritten: List[str] = []
-    key_eq = f"{key}="
-    updated = False
-    for raw in lines:
-        stripped = raw.strip()
-        target = stripped.lstrip("#").strip()
-        if target.startswith(key_eq):
+
+    def _apply(current_text: str | None) -> str:
+        rewritten: List[str] = []
+        key_eq = f"{key}="
+        updated = False
+        for raw in (current_text or "").splitlines():
+            stripped = raw.strip()
+            target = stripped.lstrip("#").strip()
+            if target.startswith(key_eq):
+                rewritten.append(f"{key}={value}")
+                updated = True
+            else:
+                rewritten.append(raw)
+        if not updated:
             rewritten.append(f"{key}={value}")
-            updated = True
-        else:
-            rewritten.append(raw)
-    if not updated:
-        rewritten.append(f"{key}={value}")
-    path.write_text("\n".join(rewritten).rstrip() + "\n", encoding="utf-8")
+        return "\n".join(rewritten).rstrip() + "\n"
+
+    update_env_file_text(
+        path,
+        _apply,
+        refuse_symlink_message=f"Refusing to write env file through symlink: {path}",
+    )
 
 
 def _refresh_env_from_file(env: Any) -> None:
@@ -361,7 +385,9 @@ def _refresh_env_from_file(env: Any) -> None:
     if last_mtime is not None and last_mtime == current_mtime:
         return
 
-    env_map = _load_env_file_map(ENV_FILE_PATH, include_commented=False)
+    env_map = run_with_windows_file_sharing_retry(
+        lambda: _load_env_file_map(ENV_FILE_PATH, include_commented=False)
+    )
     if not env_map:
         st.session_state["env_file_mtime_ns"] = current_mtime
         return
@@ -566,7 +592,9 @@ def _render_env_editor(env: Any, help_file: Path | None = None) -> None:
                 if key:
                     template_keys.append(key)
 
-        env_lines = ENV_FILE_PATH.read_text(encoding="utf-8").splitlines()
+        env_lines = run_with_windows_file_sharing_retry(
+            lambda: ENV_FILE_PATH.read_text(encoding="utf-8")
+        ).splitlines()
         current: Dict[str, str] = {}
         for raw in env_lines:
             stripped = raw.strip()

--- a/src/agilab/about_page/layout.py
+++ b/src/agilab/about_page/layout.py
@@ -652,10 +652,10 @@ def _active_app_settings_from_file(env: Any) -> dict[str, Any]:
     except (TypeError, ValueError):
         return {}
     try:
-        if not path.is_file():
-            return {}
-        with path.open("rb") as handle:
-            payload = tomllib.load(handle)
+        # Keep agi-env optional for importing the base package.
+        from agi_env.app_settings_support import read_app_settings
+
+        payload = read_app_settings(path)
     except (OSError, RuntimeError, tomllib.TOMLDecodeError):
         return {}
     return payload if isinstance(payload, dict) else {}
@@ -1186,7 +1186,12 @@ def _file_content_signature(path: Path | None) -> tuple[str, str]:
     except (OSError, RuntimeError, TypeError, ValueError):
         return (str(path), "")
     try:
-        payload = resolved.read_bytes()
+        # Keep agi-env optional for importing the base package.
+        from agi_env.runtime.atomic_write_support import (
+            run_with_windows_file_sharing_retry,
+        )
+
+        payload = run_with_windows_file_sharing_retry(resolved.read_bytes)
     except OSError:
         return (str(resolved), "")
     return (str(resolved), hashlib.sha256(payload).hexdigest())

--- a/src/agilab/agent_runtime/agent_run.py
+++ b/src/agilab/agent_runtime/agent_run.py
@@ -10,8 +10,10 @@ import json
 import os
 import platform
 import re
+import socket
 import subprocess
 import sys
+import tempfile
 import time
 from pathlib import Path
 from typing import Callable, Mapping, Sequence
@@ -32,6 +34,7 @@ TRACE_KIND = "agilab.agent_run.v1"
 MANIFEST_FILENAME = "agent_run_manifest.json"
 STDOUT_FILENAME = "stdout.txt"
 STDERR_FILENAME = "stderr.txt"
+RUN_CLAIM_FILENAME = ".agent_run.claim.json"
 DEFAULT_TIMEOUT_SECONDS = 30 * 60
 SECRET_NAME_RE = re.compile(r"(SECRET|TOKEN|PASSWORD|PASSWD|KEY|CREDENTIAL|AUTH)", re.IGNORECASE)
 SAFE_NAME_RE = re.compile(r"[^A-Za-z0-9_.-]+")
@@ -118,6 +121,20 @@ class AgentRunSummary:
     duration_seconds: float
     tags: tuple[str, ...] = ()
     metadata: dict[str, object] = field(default_factory=dict)
+
+
+@dataclass
+class _AgentRunTransaction:
+    """Mutable state needed to close an already-claimed run after an error."""
+
+    started_at: str
+    started: float
+    phase: str = "setup"
+    stdout: str = ""
+    stderr: str = ""
+    permission: dict[str, object] | None = None
+    trace_store: AgentTraceStore | None = None
+    trace_initialized: bool = False
 
 
 def _utc_now() -> str:
@@ -410,10 +427,353 @@ def _environment_payload(cwd: Path) -> dict[str, object]:
 
 def _artifact_paths(output_dir: Path) -> dict[str, Path]:
     return {
+        "claim": output_dir / RUN_CLAIM_FILENAME,
         "manifest": output_dir / MANIFEST_FILENAME,
         "stdout": output_dir / STDOUT_FILENAME,
         "stderr": output_dir / STDERR_FILENAME,
     }
+
+
+def _fsync_directory(path: Path) -> None:
+    try:
+        fd = os.open(path, os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(fd)
+    except OSError:
+        pass
+    finally:
+        os.close(fd)
+
+
+def _atomic_write_text(path: Path, text: str) -> None:
+    """Publish one fixed-name run artifact without exposing partial content."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            stream.write(text)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(tmp_path, path)
+        _fsync_directory(path.parent)
+    finally:
+        try:
+            tmp_path.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def _claim_agent_run_output(config: AgentRunConfig) -> Path:
+    """Exclusively and permanently claim one evidence directory for one command."""
+
+    config.output_dir.mkdir(parents=True, exist_ok=True)
+    claim_path = config.output_dir / RUN_CLAIM_FILENAME
+    if claim_path.exists():
+        raise FileExistsError(
+            f"Agent run output is already claimed; choose a new --run-id or --output-dir: {config.output_dir}"
+        )
+    reserved = [
+        config.output_dir / name
+        for name in (
+            MANIFEST_FILENAME,
+            STDOUT_FILENAME,
+            STDERR_FILENAME,
+            "agent_trace_meta.json",
+            "agent_events.ndjson",
+        )
+        if (config.output_dir / name).exists()
+    ]
+    if reserved:
+        raise FileExistsError(
+            "Agent run output already contains evidence and cannot be resumed implicitly: "
+            + ", ".join(str(path) for path in reserved)
+        )
+    payload = {
+        "schema": "agilab.agent_run.claim.v1",
+        "run_id": config.run_id,
+        "agent": config.agent,
+        "host": socket.gethostname(),
+        "pid": os.getpid(),
+        "claimed_at": _utc_now(),
+    }
+    try:
+        fd = os.open(claim_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+    except FileExistsError as exc:
+        raise FileExistsError(
+            f"Agent run output is already claimed; choose a new --run-id or --output-dir: {config.output_dir}"
+        ) from exc
+    try:
+        encoded = (json.dumps(payload, indent=2, sort_keys=True) + "\n").encode("utf-8")
+        offset = 0
+        while offset < len(encoded):
+            offset += os.write(fd, encoded[offset:])
+        os.fsync(fd)
+    except BaseException:
+        os.close(fd)
+        # Once O_EXCL succeeds, retain the claim even if its fsync/write fails.
+        # Reuse would risk overlapping a run whose ownership publication was
+        # interrupted; operators must choose a fresh evidence directory.
+        raise
+    os.close(fd)
+    _fsync_directory(config.output_dir)
+    return claim_path
+
+
+def _terminal_evidence_semantics(exc: BaseException) -> tuple[int, str, str]:
+    """Return shell code, evidence reason, and status for an abrupt exit."""
+
+    if isinstance(exc, KeyboardInterrupt):
+        return 130, "operator_cancelled", "fail"
+    if isinstance(exc, SystemExit):
+        code = exc.code
+        if code is None:
+            return 0, "system_exit", "pass"
+        if isinstance(code, int) and 0 <= code <= 255:
+            return code, "system_exit", "pass" if code == 0 else "fail"
+        return 1, "system_exit", "fail"
+    if isinstance(exc, FileNotFoundError):
+        return 127, "execution_infrastructure_error", "fail"
+    if isinstance(exc, PermissionError):
+        return 126, "execution_infrastructure_error", "fail"
+    return 125, "execution_infrastructure_error", "fail"
+
+
+def _ensure_atomic_failure_artifact(path: Path, text: str) -> None:
+    """Publish terminal evidence, retaining an already-published artifact.
+
+    The normal atomic writer is retried because replace failures can be
+    transient. If replacement remains unavailable and the fixed-name artifact
+    does not exist yet, an atomic rename from a fully fsynced temporary file is
+    used without overwriting any evidence which may already have committed.
+    """
+
+    last_error: OSError | None = None
+    for _attempt in range(2):
+        try:
+            _atomic_write_text(path, text)
+            return
+        except OSError as exc:
+            last_error = exc
+
+    if path.exists():
+        return
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".terminal.tmp", dir=path.parent)
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            stream.write(text)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.rename(tmp_path, path)
+        _fsync_directory(path.parent)
+    except OSError as exc:
+        raise OSError(f"Could not publish terminal agent-run evidence: {path}") from (last_error or exc)
+    finally:
+        try:
+            tmp_path.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def _safe_file_payload(path: Path) -> dict[str, object]:
+    try:
+        return _file_payload(path)
+    except OSError as exc:
+        return {
+            "path": str(path),
+            "exists": path.exists(),
+            "error": redact_text(str(exc)),
+        }
+
+
+def _safe_trace_artifact_payload(output_dir: Path) -> dict[str, object]:
+    try:
+        return trace_artifact_payload(output_dir)
+    except (OSError, TypeError, ValueError) as exc:
+        events_path = output_dir / "agent_events.ndjson"
+        return {
+            "schema": "agilab.agent_trace.v1",
+            "meta": str(output_dir / "agent_trace_meta.json"),
+            "events": str(events_path),
+            "tool_output_dir": str(output_dir / "tool-output"),
+            "event_count": 0,
+            "event_types": [],
+            "exists": events_path.exists(),
+            "error": redact_text(str(exc)),
+        }
+
+
+def _record_terminal_agent_run_failure(
+    config: AgentRunConfig,
+    transaction: _AgentRunTransaction,
+    exc: BaseException,
+    *,
+    perf_counter: Callable[[], float],
+) -> AgentRunResult:
+    """Close an exclusively claimed run with durable failure evidence."""
+
+    artifacts = _artifact_paths(config.output_dir)
+    returncode, termination_reason, status = _terminal_evidence_semantics(exc)
+    finished_at = _utc_now()
+    try:
+        duration_seconds = max(0.0, perf_counter() - transaction.started)
+    except Exception:
+        duration_seconds = 0.0
+
+    error_type = type(exc).__name__
+    error_message = redact_text(str(exc)) or error_type
+    terminal_message = (
+        f"Agent run terminated during {transaction.phase}: {error_type}: {error_message}"
+    )
+    stderr = "\n".join(part for part in (transaction.stderr.rstrip(), terminal_message) if part)
+
+    trace_recorded = False
+    trace_error = ""
+    if config.trace_enabled:
+        trace_store = transaction.trace_store or AgentTraceStore(
+            config.output_dir,
+            run_id=config.run_id,
+            agent=config.agent,
+            label=config.label,
+            provider=config.provider,
+            model=config.model,
+        )
+        try:
+            if not transaction.trace_initialized:
+                trace_store.initialize(
+                    {
+                        "tags": list(config.tags),
+                        "permission_level": config.permission_level,
+                        "provider": config.provider,
+                        "model": config.model,
+                    }
+                )
+            if status != "pass":
+                trace_store.append(
+                    "error",
+                    status=status,
+                    message=terminal_message,
+                    metadata={
+                        "phase": transaction.phase,
+                        "error_type": error_type,
+                        "returncode": returncode,
+                        "termination_reason": termination_reason,
+                    },
+                )
+            trace_store.append(
+                "session_end",
+                status=status,
+                message="agent runner terminated before returning a completed process",
+                metadata={
+                    "returncode": returncode,
+                    "termination_reason": termination_reason,
+                },
+            )
+            trace_recorded = True
+        except Exception as trace_exc:
+            trace_error = redact_text(str(trace_exc)) or type(trace_exc).__name__
+
+    _ensure_atomic_failure_artifact(artifacts["stdout"], transaction.stdout)
+    _ensure_atomic_failure_artifact(artifacts["stderr"], stderr)
+
+    permission = transaction.permission or {
+        "action": _command_permission_action(config),
+        "allowed": False,
+        "tier": "unresolved",
+        "level": config.permission_level,
+        "reason": "permission resolution did not complete before the run terminated",
+    }
+    events = [
+        _event_payload(
+            1,
+            "agent.run.started",
+            timestamp=transaction.started_at,
+            status="running",
+            protocol_adapters=list(config.protocol_adapters),
+            capabilities=list(config.capabilities),
+        ),
+        _event_payload(
+            2,
+            "agent.run.terminated",
+            timestamp=finished_at,
+            status=status,
+            phase=transaction.phase,
+            error_type=error_type,
+            termination_reason=termination_reason,
+            returncode=returncode,
+        ),
+        _event_payload(
+            3,
+            "agent.artifacts.written",
+            timestamp=finished_at,
+            status=status,
+            artifacts=["stdout", "stderr"],
+        ),
+    ]
+    manifest: dict[str, object] = {
+        "schema_version": 1,
+        "kind": TRACE_KIND,
+        "run_id": config.run_id,
+        "agent": config.agent,
+        "label": config.label,
+        "status": status,
+        "returncode": returncode,
+        "command": _command_payload(config),
+        "context": _context_payload(config),
+        "protocols": _protocol_payload(config),
+        "permission": permission,
+        "environment": _environment_payload(config.cwd),
+        "timing": {
+            "started_at": transaction.started_at,
+            "finished_at": finished_at,
+            "duration_seconds": duration_seconds,
+            "timeout_seconds": config.timeout_seconds,
+        },
+        "termination": {
+            "schema": "agilab.agent_run.termination.v1",
+            "reason": termination_reason,
+            "phase": transaction.phase,
+            "error_type": error_type,
+            "message": error_message,
+            "trace_recorded": trace_recorded,
+            "trace_error": trace_error or None,
+        },
+        "artifacts": {
+            "claim": _safe_file_payload(artifacts["claim"]),
+            "manifest": str(artifacts["manifest"]),
+            "stdout": _safe_file_payload(artifacts["stdout"]),
+            "stderr": _safe_file_payload(artifacts["stderr"]),
+            "agent_trace": _safe_trace_artifact_payload(config.output_dir),
+        },
+        "events": events,
+        "notes": [
+            {
+                "execution_infrastructure_error": (
+                    "The command did not reach normal completion because AGILAB encountered an execution infrastructure error."
+                ),
+                "operator_cancelled": (
+                    "The caller cancelled the agent run before the runner returned a completed process."
+                ),
+                "system_exit": (
+                    "The runner raised SystemExit before returning a completed process; status and returncode preserve that exit."
+                ),
+            }[termination_reason],
+            "The exclusive output claim remains permanent; retry with a new run id or output directory.",
+            "Command arguments are redacted by default; argv_sha256 preserves comparison without exposing prompts.",
+            "Command output artifacts are redacted by default; pass --include-raw-output only for safe local diagnostics.",
+        ],
+    }
+    _ensure_atomic_failure_artifact(
+        artifacts["manifest"],
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+    )
+    return AgentRunResult(manifest=manifest, returncode=returncode)
 
 
 def _command_permission_action(config: AgentRunConfig) -> str:
@@ -542,6 +902,7 @@ def build_planned_manifest(config: AgentRunConfig) -> dict[str, object]:
             "timeout_seconds": config.timeout_seconds,
         },
         "artifacts": {
+            "claim": str(artifacts["claim"]),
             "manifest": str(artifacts["manifest"]),
             "stdout": str(artifacts["stdout"]),
             "stderr": str(artifacts["stderr"]),
@@ -575,11 +936,53 @@ def run_agent_command(
     perf_counter: Callable[[], float] = time.perf_counter,
 ) -> AgentRunResult:
     """Execute an agent command and write a local trace manifest."""
-    config.output_dir.mkdir(parents=True, exist_ok=True)
+
+    transaction = _AgentRunTransaction(started_at=_utc_now(), started=0.0)
+    _claim_agent_run_output(config)
+    try:
+        transaction.started = perf_counter()
+        return _run_claimed_agent_command(
+            config,
+            transaction=transaction,
+            runner=runner,
+            perf_counter=perf_counter,
+        )
+    except BaseException as exc:
+        if isinstance(exc, Exception):
+            return _record_terminal_agent_run_failure(
+                config,
+                transaction,
+                exc,
+                perf_counter=perf_counter,
+            )
+        try:
+            _record_terminal_agent_run_failure(
+                config,
+                transaction,
+                exc,
+                perf_counter=perf_counter,
+            )
+        except BaseException:
+            # Terminal evidence is best-effort during interpreter-level
+            # cancellation; never replace the caller's original interrupt.
+            pass
+        raise
+
+
+def _run_claimed_agent_command(
+    config: AgentRunConfig,
+    *,
+    transaction: _AgentRunTransaction,
+    runner: Callable[..., subprocess.CompletedProcess[str]],
+    perf_counter: Callable[[], float],
+) -> AgentRunResult:
+    """Execute a command after its output directory has been claimed."""
+
     artifacts = _artifact_paths(config.output_dir)
     stdout_path = artifacts["stdout"]
     stderr_path = artifacts["stderr"]
     manifest_path = artifacts["manifest"]
+    transaction.phase = "trace setup"
     trace_store = AgentTraceStore(
         config.output_dir,
         run_id=config.run_id,
@@ -588,6 +991,7 @@ def run_agent_command(
         provider=config.provider,
         model=config.model,
     )
+    transaction.trace_store = trace_store
     if config.trace_enabled:
         trace_store.initialize(
             {
@@ -597,12 +1001,15 @@ def run_agent_command(
                 "model": config.model,
             }
         )
+        transaction.trace_initialized = True
 
     env = os.environ.copy()
     env.update(config.env_overrides)
-    started_at = _utc_now()
-    started = perf_counter()
+    started_at = transaction.started_at
+    started = transaction.started
+    transaction.phase = "permission resolution"
     permission = _permission_payload(config)
+    transaction.permission = permission
     events: list[dict[str, object]] = [
         _event_payload(
             1,
@@ -615,6 +1022,7 @@ def run_agent_command(
     ]
     timed_out = False
     if config.trace_enabled:
+        transaction.phase = "trace start"
         trace_store.append(
             "session_start",
             message=config.label,
@@ -647,10 +1055,13 @@ def run_agent_command(
         stderr = str(permission["reason"])
         if permission.get("confirmation_token"):
             stderr += f"\nconfirmation_token={permission['confirmation_token']}"
+        transaction.stdout = stdout
+        transaction.stderr = stderr
         duration_seconds = perf_counter() - started
         finished_at = _utc_now()
-        stdout_path.write_text(stdout, encoding="utf-8")
-        stderr_path.write_text(stderr, encoding="utf-8")
+        transaction.phase = "artifact publication"
+        _atomic_write_text(stdout_path, stdout)
+        _atomic_write_text(stderr_path, stderr)
         events.append(
             _event_payload(
                 2,
@@ -670,12 +1081,14 @@ def run_agent_command(
             )
         )
         if config.trace_enabled:
+            transaction.phase = "terminal trace publication"
             trace_store.append(
                 "session_end",
                 status="denied",
                 message="agent run denied by permission policy",
                 metadata={"returncode": returncode},
             )
+        transaction.phase = "manifest assembly"
         manifest: dict[str, object] = {
             "schema_version": 1,
             "kind": TRACE_KIND,
@@ -696,6 +1109,7 @@ def run_agent_command(
                 "timeout_seconds": config.timeout_seconds,
             },
             "artifacts": {
+                "claim": _file_payload(artifacts["claim"]),
                 "manifest": str(manifest_path),
                 "stdout": _file_payload(stdout_path),
                 "stderr": _file_payload(stderr_path),
@@ -710,9 +1124,11 @@ def run_agent_command(
                 "Agent trace events are stored as append-only NDJSON when trace_enabled is true.",
             ],
         }
-        manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        transaction.phase = "manifest publication"
+        _atomic_write_text(manifest_path, json.dumps(manifest, indent=2, sort_keys=True) + "\n")
         return AgentRunResult(manifest=manifest, returncode=returncode)
 
+    transaction.phase = "command launch"
     try:
         proc = runner(
             list(config.command),
@@ -735,6 +1151,8 @@ def run_agent_command(
         stdout = raw_stdout if isinstance(raw_stdout, str) else raw_stdout.decode("utf-8", "replace")
         stderr = raw_stderr if isinstance(raw_stderr, str) else raw_stderr.decode("utf-8", "replace")
         stderr = (stderr + f"\nTimed out after {config.timeout_seconds:.0f}s").strip()
+    transaction.stdout = redact_text(stdout) if config.redact_output else stdout
+    transaction.stderr = redact_text(stderr) if config.redact_output else stderr
     duration_seconds = perf_counter() - started
     finished_at = _utc_now()
     events.append(
@@ -748,10 +1166,11 @@ def run_agent_command(
         )
     )
 
-    output_stdout = redact_text(stdout) if config.redact_output else stdout
-    output_stderr = redact_text(stderr) if config.redact_output else stderr
-    stdout_path.write_text(output_stdout, encoding="utf-8")
-    stderr_path.write_text(output_stderr, encoding="utf-8")
+    output_stdout = transaction.stdout
+    output_stderr = transaction.stderr
+    transaction.phase = "artifact publication"
+    _atomic_write_text(stdout_path, output_stdout)
+    _atomic_write_text(stderr_path, output_stderr)
     status = "pass" if returncode == 0 else "timeout" if timed_out else "fail"
     events.append(
         _event_payload(
@@ -763,6 +1182,7 @@ def run_agent_command(
         )
     )
     if config.trace_enabled:
+        transaction.phase = "terminal trace publication"
         trace_store.append(
             "command_done",
             status=status,
@@ -779,6 +1199,7 @@ def run_agent_command(
             message=f"agent run {status}",
             metadata={"returncode": returncode},
         )
+    transaction.phase = "manifest assembly"
     manifest: dict[str, object] = {
         "schema_version": 1,
         "kind": TRACE_KIND,
@@ -799,6 +1220,7 @@ def run_agent_command(
             "timeout_seconds": config.timeout_seconds,
         },
         "artifacts": {
+            "claim": _file_payload(artifacts["claim"]),
             "manifest": str(manifest_path),
             "stdout": _file_payload(stdout_path),
             "stderr": _file_payload(stderr_path),
@@ -813,7 +1235,8 @@ def run_agent_command(
             "Agent trace events are stored as append-only NDJSON when trace_enabled is true.",
         ],
     }
-    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    transaction.phase = "manifest publication"
+    _atomic_write_text(manifest_path, json.dumps(manifest, indent=2, sort_keys=True) + "\n")
     return AgentRunResult(manifest=manifest, returncode=returncode)
 
 
@@ -1765,6 +2188,67 @@ def validate_agent_run(manifest_or_path: dict[str, object] | Path | str) -> dict
         fail("kind", f"unsupported manifest kind: {manifest.get('kind')!r}")
     if summary.status not in {"planned", "pass", "fail", "timeout", "denied"}:
         fail("status", f"unsupported status: {summary.status!r}")
+    termination = manifest.get("termination")
+    terminal_trace_unavailable = False
+    if termination is not None:
+        if not isinstance(termination, dict):
+            fail("termination", "agent run termination evidence must be an object")
+        else:
+            if termination.get("schema") != "agilab.agent_run.termination.v1":
+                fail("termination_schema", "agent run termination evidence schema is invalid")
+            termination_reason = str(termination.get("reason") or "")
+            valid_termination_reasons = {
+                "execution_infrastructure_error",
+                "operator_cancelled",
+                "system_exit",
+            }
+            if termination_reason not in valid_termination_reasons:
+                fail("termination_reason", "agent run termination reason is invalid")
+            if termination_reason == "system_exit":
+                expected_status = "pass" if summary.returncode == 0 else "fail"
+                if summary.returncode is None:
+                    fail("termination_returncode", "system exit termination requires a returncode")
+                elif summary.status != expected_status:
+                    fail(
+                        "termination_status",
+                        "system exit termination status must match its returncode",
+                    )
+                if termination.get("error_type") != "SystemExit":
+                    fail("termination_error_type", "system exit termination must name SystemExit")
+            elif termination_reason == "operator_cancelled":
+                if summary.status != "fail" or summary.returncode != 130:
+                    fail(
+                        "termination_status",
+                        "operator cancellation must have fail status and returncode 130",
+                    )
+                if termination.get("error_type") != "KeyboardInterrupt":
+                    fail(
+                        "termination_error_type",
+                        "operator cancellation must name KeyboardInterrupt",
+                    )
+            else:
+                if summary.status != "fail":
+                    fail(
+                        "termination_status",
+                        "execution infrastructure termination must have fail status",
+                    )
+                if summary.returncode is None or summary.returncode == 0:
+                    fail(
+                        "termination_returncode",
+                        "execution infrastructure termination requires a non-zero returncode",
+                    )
+            if not str(termination.get("phase") or ""):
+                fail("termination_phase", "execution infrastructure termination phase is missing")
+            if not str(termination.get("error_type") or ""):
+                fail("termination_error_type", "execution infrastructure error type is missing")
+            if not isinstance(termination.get("trace_recorded"), bool):
+                fail("termination_trace_state", "execution infrastructure trace state must be boolean")
+            if termination.get("trace_recorded") is False:
+                terminal_trace_unavailable = (
+                    termination.get("schema") == "agilab.agent_run.termination.v1"
+                    and termination_reason in valid_termination_reasons
+                )
+                warn("termination_trace", "terminal trace evidence could not be recorded; manifest evidence is authoritative")
     if summary.manifest_path and not summary.manifest_path.exists():
         fail("manifest_path", f"manifest artifact path is missing: {summary.manifest_path}")
     if summary.status != "planned":
@@ -1776,6 +2260,27 @@ def validate_agent_run(manifest_or_path: dict[str, object] | Path | str) -> dict
             fail("stderr_path", "stderr artifact path is missing from manifest")
         elif not summary.stderr_path.exists():
             fail("stderr_exists", f"stderr artifact does not exist: {summary.stderr_path}")
+        artifacts = manifest.get("artifacts", {})
+        artifact_map = artifacts if isinstance(artifacts, dict) else {}
+        # The ownership claim was added without changing TRACE_KIND, so valid
+        # v1 manifests written before the claim existed remain readable. Once a
+        # manifest declares a claim, however, fail closed on every claim error.
+        if "claim" in artifact_map:
+            claim_path = _path_from_artifact(artifact_map.get("claim"))
+            if not claim_path:
+                fail("claim_path", "agent run ownership claim path is invalid")
+            elif not claim_path.exists():
+                fail("claim_exists", f"agent run ownership claim does not exist: {claim_path}")
+            else:
+                try:
+                    claim_payload = json.loads(claim_path.read_text(encoding="utf-8"))
+                except (OSError, ValueError):
+                    fail("claim_payload", f"agent run ownership claim is invalid: {claim_path}")
+                else:
+                    if not isinstance(claim_payload, dict) or claim_payload.get("schema") != "agilab.agent_run.claim.v1":
+                        fail("claim_schema", f"agent run ownership claim schema is invalid: {claim_path}")
+                    elif str(claim_payload.get("run_id") or "") != summary.run_id:
+                        fail("claim_run_id", f"agent run ownership claim does not match run_id: {claim_path}")
 
     command = manifest.get("command", {})
     command_map = command if isinstance(command, dict) else {}
@@ -1786,10 +2291,16 @@ def validate_agent_run(manifest_or_path: dict[str, object] | Path | str) -> dict
 
     if summary.trace_events_path:
         if summary.trace_events_path.exists():
-            trace_events = load_trace_events(summary.trace_events_path.parent)
-            for issue in validate_event_sequence(trace_events):
-                fail("trace_sequence", issue)
-        else:
+            try:
+                trace_events = load_trace_events(summary.trace_events_path.parent)
+            except (OSError, TypeError, ValueError) as exc:
+                if not terminal_trace_unavailable:
+                    fail("trace_events_invalid", str(exc))
+            else:
+                if not terminal_trace_unavailable:
+                    for issue in validate_event_sequence(trace_events):
+                        fail("trace_sequence", issue)
+        elif not terminal_trace_unavailable:
             fail("trace_events_exists", f"trace events file does not exist: {summary.trace_events_path}")
     else:
         warn("trace_events_path", "trace events path is missing from manifest")

--- a/src/agilab/agent_runtime/agent_tool_safety.py
+++ b/src/agilab/agent_runtime/agent_tool_safety.py
@@ -9,11 +9,13 @@ from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 import hashlib
 import json
+import os
 from pathlib import Path
 import re
 from typing import Any, Callable, Mapping
 
 from agilab.security.secret_uri import redact_mapping, redact_text
+from agilab.agent_runtime.agent_trace import repair_jsonl_tail, trace_file_lock
 
 
 SCHEMA = "agilab.agent_tool_safety.v1"
@@ -335,8 +337,12 @@ class ProgressRecorder:
             metadata=redact_mapping(metadata or {}),
         )
         self.path.parent.mkdir(parents=True, exist_ok=True)
-        with self.path.open("a", encoding="utf-8") as handle:
-            handle.write(json.dumps(asdict(record), sort_keys=True) + "\n")
+        with trace_file_lock(self.path):
+            repair_jsonl_tail(self.path)
+            with self.path.open("a", encoding="utf-8") as handle:
+                handle.write(json.dumps(asdict(record), sort_keys=True) + "\n")
+                handle.flush()
+                os.fsync(handle.fileno())
         return record
 
 
@@ -345,8 +351,20 @@ def load_progress_events(path: Path | str) -> list[dict[str, Any]]:
     progress_path = Path(path).expanduser()
     if not progress_path.exists():
         return []
-    return [
-        json.loads(line)
-        for line in progress_path.read_text(encoding="utf-8").splitlines()
-        if line.strip()
-    ]
+    raw = progress_path.read_bytes()
+    has_unterminated_tail = bool(raw) and not raw.endswith(b"\n")
+    rows: list[dict[str, Any]] = []
+    lines = raw.splitlines()
+    for index, encoded_line in enumerate(lines):
+        if not encoded_line.strip():
+            continue
+        try:
+            payload = json.loads(encoded_line.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            if has_unterminated_tail and index == len(lines) - 1:
+                break
+            raise
+        if not isinstance(payload, dict):
+            raise ValueError(f"Progress JSONL record {index + 1} must be an object")
+        rows.append(payload)
+    return rows

--- a/src/agilab/agent_runtime/agent_trace.py
+++ b/src/agilab/agent_runtime/agent_trace.py
@@ -12,6 +12,7 @@ import json
 import os
 from pathlib import Path
 import socket
+import tempfile
 import time
 from typing import Any, Mapping, Sequence
 
@@ -180,63 +181,252 @@ def _lock_is_stale(path: Path, *, now: float | None = None) -> bool:
 def _clear_stale_lock(path: Path) -> bool:
     if not _lock_is_stale(path):
         return False
+    handle = path.open("a+b")
     try:
-        path.unlink()
-    except FileNotFoundError:
+        if not _try_lock_handle(handle):
+            return False
+        _rewrite_locked_handle(handle, {})
         return True
     except OSError:
         return False
-    return True
+    finally:
+        _unlock_handle(handle)
+        handle.close()
+
+
+def _try_lock_handle(handle) -> bool:
+    if os.name == "nt":  # pragma: no cover - exercised on Windows CI
+        import msvcrt
+
+        try:
+            handle.seek(0, os.SEEK_END)
+            if handle.tell() == 0:
+                handle.write(b"\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+            handle.seek(0)
+            msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+            return True
+        except OSError:
+            return False
+    import fcntl
+
+    try:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        return True
+    except (BlockingIOError, OSError):
+        return False
+
+
+def _unlock_handle(handle) -> None:
+    try:
+        if os.name == "nt":  # pragma: no cover - exercised on Windows CI
+            import msvcrt
+
+            handle.seek(0)
+            msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    except OSError:
+        pass
+
+
+def _rewrite_locked_handle(handle, payload: Mapping[str, Any]) -> None:
+    encoded = (json.dumps(dict(payload), sort_keys=True) + "\n").encode("utf-8")
+    handle.seek(0)
+    handle.truncate(0)
+    handle.write(encoded)
+    handle.flush()
+    os.fsync(handle.fileno())
+
+
+def _atomic_write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            stream.write(text)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(tmp_path, path)
+        _fsync_directory(path.parent)
+    finally:
+        try:
+            tmp_path.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def _validate_trace_run_identity(
+    payload: Mapping[str, Any],
+    *,
+    expected_run_id: str,
+    meta_path: Path,
+) -> None:
+    """Reject missing or mismatched ownership before reusing a trace."""
+
+    existing_run_id = str(payload.get("run_id") or "")
+    if not existing_run_id:
+        raise FileExistsError(
+            f"Agent trace metadata is invalid and cannot be resumed: {meta_path}"
+        )
+    if existing_run_id != expected_run_id:
+        raise FileExistsError(
+            f"Agent trace directory belongs to run {existing_run_id!r}, "
+            f"not {expected_run_id!r}: {meta_path.parent}"
+        )
+
+
+def _fsync_directory(path: Path) -> None:
+    try:
+        fd = os.open(path, os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(fd)
+    except OSError:
+        pass
+    finally:
+        os.close(fd)
 
 
 @contextmanager
 def _event_file_lock(path: Path):
     lock_path = path.with_name(path.name + ".lock")
     deadline = time.monotonic() + LOCK_TIMEOUT_SECONDS
-    fd: int | None = None
-    while fd is None:
-        try:
-            fd = os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
-            payload = {
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    handle = lock_path.open("a+b")
+    while not _try_lock_handle(handle):
+        if time.monotonic() >= deadline:
+            handle.close()
+            raise TimeoutError(f"Timed out waiting for agent trace lock: {lock_path}")
+        time.sleep(0.01)
+    try:
+        _rewrite_locked_handle(
+            handle,
+            {
                 "host": socket.gethostname(),
                 "pid": os.getpid(),
                 "created_at": utc_now(),
-            }
-            os.write(fd, json.dumps(payload, sort_keys=True).encode("utf-8"))
-        except FileExistsError:
-            if _clear_stale_lock(lock_path):
-                continue
-            if time.monotonic() >= deadline:
-                raise TimeoutError(f"Timed out waiting for agent trace lock: {lock_path}")
-            time.sleep(0.01)
+            },
+        )
+    except BaseException:
+        _unlock_handle(handle)
+        handle.close()
+        raise
     try:
         yield
     finally:
-        os.close(fd)
         try:
-            lock_path.unlink()
-        except FileNotFoundError:
-            pass
+            _rewrite_locked_handle(handle, {})
+        finally:
+            _unlock_handle(handle)
+            handle.close()
+
+
+trace_file_lock = _event_file_lock
+
+
+def repair_jsonl_tail(path: Path | str) -> Path | None:
+    """Repair only an unterminated JSONL tail while its file lock is held.
+
+    A complete JSON value which merely lacks its final newline is preserved.
+    An invalid suffix is copied to a unique quarantine artifact and removed
+    from the live stream before a later append can be concatenated onto it.
+    """
+
+    candidate = Path(path).expanduser()
+    if not candidate.exists() or candidate.stat().st_size == 0:
+        return None
+    with candidate.open("r+b") as handle:
+        handle.seek(0, os.SEEK_END)
+        end = handle.tell()
+        handle.seek(end - 1)
+        if handle.read(1) == b"\n":
+            return None
+
+        start = end
+        while start > 0:
+            start -= 1
+            handle.seek(start)
+            if handle.read(1) == b"\n":
+                start += 1
+                break
+        handle.seek(start)
+        tail = handle.read(end - start)
+        try:
+            decoded = tail.decode("utf-8")
+            payload = json.loads(decoded)
+            if not isinstance(payload, Mapping):
+                raise ValueError("JSONL records must be objects")
+        except (UnicodeDecodeError, ValueError):
+            fd, quarantine_name = tempfile.mkstemp(
+                prefix=f".{candidate.name}.partial.",
+                suffix=".jsonl",
+                dir=candidate.parent,
+            )
+            quarantine_path = Path(quarantine_name)
+            try:
+                with os.fdopen(fd, "wb") as quarantine:
+                    quarantine.write(tail)
+                    quarantine.flush()
+                    os.fsync(quarantine.fileno())
+            except BaseException:
+                try:
+                    quarantine_path.unlink()
+                except FileNotFoundError:
+                    pass
+                raise
+            handle.seek(start)
+            handle.truncate()
+            handle.flush()
+            os.fsync(handle.fileno())
+            _fsync_directory(candidate.parent)
+            return quarantine_path
+
+        handle.seek(0, os.SEEK_END)
+        handle.write(b"\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+        return None
 
 
 def load_trace_events(path: Path | str) -> list[AgentTraceEvent]:
-    """Load events from an ``agent_events.ndjson`` file or a trace directory."""
+    """Load trace events, tolerating only an unterminated crash tail."""
 
     candidate = Path(path).expanduser()
     events_path = candidate / EVENTS_FILENAME if candidate.is_dir() else candidate
     if not events_path.exists():
         return []
 
+    raw = events_path.read_bytes()
+    has_unterminated_tail = bool(raw) and not raw.endswith(b"\n")
+    encoded_lines = raw.splitlines()
     events: list[AgentTraceEvent] = []
-    for line in events_path.read_text(encoding="utf-8").splitlines():
-        if not line.strip():
+    for index, encoded_line in enumerate(encoded_lines):
+        if not encoded_line.strip():
             continue
         try:
-            payload = json.loads(line)
-        except ValueError:
-            continue
-        if isinstance(payload, dict):
+            payload = json.loads(encoded_line.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            if has_unterminated_tail and index == len(encoded_lines) - 1:
+                break
+            raise ValueError(
+                f"Invalid agent trace JSONL record {index + 1}: {events_path}"
+            ) from exc
+        if not isinstance(payload, dict):
+            raise ValueError(
+                f"Agent trace JSONL record {index + 1} must be an object: {events_path}"
+            )
+        try:
             events.append(_event_from_mapping(payload))
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ValueError(
+                f"Invalid agent trace event record {index + 1}: {events_path}"
+            ) from exc
     return events
 
 
@@ -277,24 +467,39 @@ class AgentTraceStore:
 
         self.root.mkdir(parents=True, exist_ok=True)
         self.tool_output_dir.mkdir(parents=True, exist_ok=True)
-        if self.meta_path.exists():
-            return _read_json(self.meta_path)
+        with _event_file_lock(self.events_path):
+            if self.meta_path.exists():
+                existing = _read_json(self.meta_path)
+                _validate_trace_run_identity(
+                    existing,
+                    expected_run_id=self.run_id,
+                    meta_path=self.meta_path,
+                )
+                return existing
 
-        payload: dict[str, Any] = {
-            "schema": TRACE_SCHEMA,
-            "run_id": self.run_id,
-            "agent": self.agent,
-            "label": self.label,
-            "provider": self.provider,
-            "model": self.model,
-            "created_at": utc_now(),
-            "events": str(self.events_path),
-            "tool_output_dir": str(self.tool_output_dir),
-            "metadata": redact_mapping(metadata or {}),
-        }
-        self.meta_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-        self.events_path.touch(exist_ok=True)
-        return payload
+            if self.events_path.exists() and self.events_path.stat().st_size:
+                raise FileExistsError(
+                    f"Agent trace events exist without ownership metadata and cannot be resumed: {self.events_path}"
+                )
+
+            payload: dict[str, Any] = {
+                "schema": TRACE_SCHEMA,
+                "run_id": self.run_id,
+                "agent": self.agent,
+                "label": self.label,
+                "provider": self.provider,
+                "model": self.model,
+                "created_at": utc_now(),
+                "events": str(self.events_path),
+                "tool_output_dir": str(self.tool_output_dir),
+                "metadata": redact_mapping(metadata or {}),
+            }
+            _atomic_write_text(
+                self.meta_path,
+                json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            )
+            self.events_path.touch(exist_ok=True)
+            return payload
 
     def append(
         self,
@@ -312,6 +517,12 @@ class AgentTraceStore:
             self.initialize()
 
         with _event_file_lock(self.events_path):
+            _validate_trace_run_identity(
+                _read_json(self.meta_path),
+                expected_run_id=self.run_id,
+                meta_path=self.meta_path,
+            )
+            repair_jsonl_tail(self.events_path)
             sequence = _last_event_sequence(self.events_path) + 1
             record = AgentTraceEvent(
                 schema=TRACE_SCHEMA,
@@ -325,6 +536,8 @@ class AgentTraceStore:
             )
             with self.events_path.open("a", encoding="utf-8") as handle:
                 handle.write(json.dumps(asdict(record), sort_keys=True) + "\n")
+                handle.flush()
+                os.fsync(handle.fileno())
         return record
 
 

--- a/src/agilab/app_management/app_surface.py
+++ b/src/agilab/app_management/app_surface.py
@@ -5,7 +5,6 @@ import importlib.util
 import sys
 import tomllib
 from collections.abc import Mapping
-from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from types import ModuleType
@@ -271,29 +270,6 @@ def configured_app_surface_entrypoint(
     return resolve_app_surface_entrypoint(active_app, spec.entrypoint)
 
 
-@contextmanager
-def _temporary_sys_path(paths: list[Path]):
-    previous = list(sys.path)
-    try:
-        for path in reversed(paths):
-            entry = str(path)
-            sys.path[:] = [existing for existing in sys.path if existing != entry]
-            sys.path.insert(0, entry)
-        yield
-    finally:
-        sys.path[:] = previous
-
-
-@contextmanager
-def _temporary_argv(entrypoint: Path, active_app: Path):
-    previous = list(sys.argv)
-    sys.argv = [str(entrypoint), "--active-app", str(active_app)]
-    try:
-        yield
-    finally:
-        sys.argv = previous
-
-
 def _load_module_from_path(entrypoint: Path) -> ModuleType:
     digest = hashlib.sha1(str(entrypoint).encode("utf-8")).hexdigest()[:12]
     module_name = f"_agilab_app_surface_{digest}"
@@ -304,6 +280,23 @@ def _load_module_from_path(entrypoint: Path) -> ModuleType:
     sys.modules[module_name] = module
     spec.loader.exec_module(module)
     return module
+
+
+def _isolated_import_process_state() -> Any:
+    """Load the optional UI/runtime guard only when inline rendering starts."""
+
+    try:
+        from agi_env.ui.sidecar_registry import isolated_import_process_state
+    except ModuleNotFoundError as exc:
+        if exc.name and not (
+            exc.name == "agi_env" or exc.name.startswith("agi_env.")
+        ):
+            raise
+        raise ModuleNotFoundError(
+            "Inline app-surface rendering requires the AGILAB UI runtime; "
+            "install it with `python -m pip install 'agilab[ui]'`."
+        ) from exc
+    return isolated_import_process_state
 
 
 def render_app_surface(
@@ -326,7 +319,12 @@ def render_app_surface(
     entrypoint = resolve_app_surface_entrypoint(active_app_path, selected.entrypoint)
     if entrypoint is None:
         return False
-    with _temporary_sys_path([active_app_path / "src", entrypoint.parent]), _temporary_argv(entrypoint, active_app_path):
+    import_roots = (active_app_path / "src", entrypoint.parent)
+    with _isolated_import_process_state()(
+        argv=[str(entrypoint), "--active-app", str(active_app_path)],
+        prepend_paths=import_roots,
+        module_roots=import_roots,
+    ):
         module = _load_module_from_path(entrypoint)
         render = getattr(module, "render", None)
         if not callable(render):

--- a/src/agilab/apps-pages/app_ui/pyproject.toml
+++ b/src/agilab/apps-pages/app_ui/pyproject.toml
@@ -14,6 +14,8 @@ keywords = [
 ]
 dependencies = [
     "agi-pages>=2026.05.30.post1,<2027.0",
+    "agi-env>=2026.05.12.post3,<2027.0",
+    "agi-node>=2026.05.12.post3,<2027.0",
     "agi-gui>=2026.05.21,<2027.0",
     "plotly>=6.8,<7",
 ]
@@ -43,3 +45,4 @@ Changelog = "https://github.com/ThalesGroup/agilab/releases"
 agi-pages = { path = "../../lib/agi-pages", editable = true }
 agi-gui = { path = "../../lib/agi-gui", editable = true }
 agi-env = { path = "../../core/agi-env", editable = true }
+agi-node = { path = "../../core/agi-node", editable = true }

--- a/src/agilab/apps-pages/app_ui/src/app_ui/app_ui.py
+++ b/src/agilab/apps-pages/app_ui/src/app_ui/app_ui.py
@@ -12,6 +12,7 @@ from types import ModuleType
 from typing import Any
 
 import streamlit as st
+from agi_env.ui.sidecar_registry import isolated_import_process_state
 from agi_pages.runtime import (
     configure_streamlit_page,
     ensure_repo_on_path as _page_ensure_repo_on_path,
@@ -74,12 +75,6 @@ def _resolve_entrypoint(active_app: Path, entrypoint: object) -> Path | None:
     return None
 
 
-def _prepend_sys_path(path: Path) -> None:
-    entry = str(path)
-    sys.path[:] = [existing for existing in sys.path if existing != entry]
-    sys.path.insert(0, entry)
-
-
 def _load_module(path: Path) -> ModuleType:
     module_name = f"_agilab_app_ui_{abs(hash(str(path.resolve())))}"
     spec = importlib.util.spec_from_file_location(module_name, path)
@@ -96,18 +91,17 @@ def _load_module(path: Path) -> ModuleType:
 
 
 def _run_app_ui(entrypoint: Path, active_app: Path) -> None:
-    _prepend_sys_path(entrypoint.parent)
-    _prepend_sys_path(active_app / "src")
-    previous_argv = list(sys.argv)
-    sys.argv = [str(entrypoint), "--active-app", str(active_app)]
-    try:
+    app_src = active_app / "src"
+    with isolated_import_process_state(
+        argv=[str(entrypoint), "--active-app", str(active_app)],
+        prepend_paths=(app_src, entrypoint.parent),
+        module_roots=(app_src, entrypoint.parent),
+    ):
         module = _load_module(entrypoint)
         main_fn = getattr(module, "main", None)
         if not callable(main_fn):
             raise AttributeError(f"Configured app UI {entrypoint} does not expose main()")
         main_fn()
-    finally:
-        sys.argv = previous_argv
 
 
 def main() -> None:

--- a/src/agilab/apps-pages/autoencoder_latentspace/src/autoencoder_latentspace/autoencoder_latentspace.py
+++ b/src/agilab/apps-pages/autoencoder_latentspace/src/autoencoder_latentspace/autoencoder_latentspace.py
@@ -11,7 +11,6 @@
 #
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import os
 import sys
 import importlib
 import logging
@@ -41,9 +40,8 @@ _ensure_repo_on_path()
 
 from agi_pages.runtime import active_app_scope_value, render_streamlit_page_header, reset_scoped_session_state
 from agi_env import AgiEnv
-from agi_env.app_settings_support import prepare_app_settings_for_write
+from agi_env.app_settings_support import read_app_settings, update_app_settings_owned
 from agi_gui.pagelib import load_df, sidebar_views, initialize_csv_files, _dump_toml_payload
-import tomllib as _toml
 
 logger = logging.getLogger(__name__)
 
@@ -83,9 +81,6 @@ def _ae_key(name: str) -> str:
 
 
 render_streamlit_page_header(st, title=":chart_with_downwards_trend: Dimension Reduction", show_logo=False)
-
-os.environ["TF_ENABLE_ONEDNN_OPTS"] = "0"
-
 
 # Function to lazily import plotly
 def lazy_import_plotly():
@@ -512,9 +507,8 @@ def page(env):
     settings_path = Path(env.app_settings_file)
     persisted = {}
     try:
-        with open(settings_path, "rb") as fh:
-            persisted = _toml.load(fh)
-    except (OSError, _toml.TOMLDecodeError):
+        persisted = read_app_settings(settings_path)
+    except (OSError, ValueError):
         logger.debug("Unable to load autoencoder_latentspace settings from %s", settings_path, exc_info=True)
         persisted = {}
     raw_view_settings = {}
@@ -658,18 +652,22 @@ def page(env):
         "df_file": st.session_state.get("df_file", ""),
         "coltype": st.session_state.get("coltype", ""),
     }
-    mutated = False
+    changed_keys: list[str] = []
     for k, v in persist_keys.items():
         if view_settings.get(k) != v and v not in (None, ""):
             view_settings[k] = v
-            mutated = True
-    if mutated:
+            changed_keys.append(k)
+    if changed_keys:
         persisted[PAGE_KEY] = view_settings
         persisted.pop(LEGACY_PAGE_KEY, None)
         try:
-            settings_path.parent.mkdir(parents=True, exist_ok=True)
-            with open(settings_path, "wb") as fh:
-                _dump_toml_payload(prepare_app_settings_for_write(persisted), fh)
+            persisted, _ = update_app_settings_owned(
+                settings_path,
+                persisted,
+                owned_paths=tuple((PAGE_KEY, key) for key in changed_keys)
+                + ((LEGACY_PAGE_KEY,),),
+                dump_fn=_dump_toml_payload,
+            )
         except Exception:
             logger.warning(
                 "Unable to persist autoencoder_latentspace settings to %s",
@@ -708,7 +706,7 @@ def main():
         st.session_state["apps_path"] = str(active_app.parent)
         st.session_state["app"] = app
 
-        env = getattr(AgiEnv, "for_app", AgiEnv)(
+        env = AgiEnv.session_for_app(
             apps_path=active_app.parent,
             app=app,
             verbose=1,

--- a/src/agilab/apps-pages/templates/analysis_page_template/src/view_demo/view_demo.py
+++ b/src/agilab/apps-pages/templates/analysis_page_template/src/view_demo/view_demo.py
@@ -62,7 +62,7 @@ def _load_project_env(active_app: str) -> Any:
         st.error(f"Provided active project path does not exist: {active_app_path}")
         st.stop()
 
-    return getattr(AgiEnv, "for_app", AgiEnv)(apps_path=active_app_path.parent, app=active_app_path.name, verbose=0)
+    return AgiEnv.session_for_app(apps_path=active_app_path.parent, app=active_app_path.name, verbose=0)
 
 
 def _dataset_root(env: Any) -> Path | None:

--- a/src/agilab/apps-pages/view_barycentric/src/view_barycentric/view_barycentric.py
+++ b/src/agilab/apps-pages/view_barycentric/src/view_barycentric/view_barycentric.py
@@ -28,7 +28,6 @@ import logging
 import numpy as np
 from pathlib import Path
 import pandas as pd
-import toml as toml
 import plotly.graph_objects as go
 from barviz import Simplex, Collection, Scrawler, Attributes
 from math import sqrt, cos, sin
@@ -55,9 +54,8 @@ _ensure_repo_on_path()
 
 from agi_pages.runtime import render_streamlit_page_header, reset_scoped_session_state
 from agi_env import AgiEnv
-from agi_env.app_settings_support import prepare_app_settings_for_write
+from agi_env.app_settings_support import read_app_settings, update_app_settings_owned
 from agi_gui.pagelib import find_files, load_df, JumpToMain, update_datadir, _dump_toml_payload
-import tomllib as _toml
 
 logger = logging.getLogger(__name__)
 
@@ -447,8 +445,7 @@ def page(env):
     settings_path = Path(env.app_settings_file)
     persisted = {}
     try:
-        with open(settings_path, "rb") as fh:
-            persisted = _toml.load(fh)
+        persisted = read_app_settings(settings_path)
     except Exception:
         persisted = {}
     raw_view_settings = persisted.get("view_barycentric", {}) if isinstance(persisted, dict) else {}
@@ -543,17 +540,22 @@ def page(env):
         "datadir": str(st.session_state.get("datadir", "")),
         "df_file": st.session_state.get(DF_FILE_KEY, ""),
     }
-    mutated = False
+    changed_keys: list[str] = []
     for k, v in save_fields.items():
         if view_settings.get(k) != v and v not in (None, ""):
             view_settings[k] = v
-            mutated = True
-    if mutated:
+            changed_keys.append(k)
+    if changed_keys:
         persisted["view_barycentric"] = view_settings
         try:
-            settings_path.parent.mkdir(parents=True, exist_ok=True)
-            with open(settings_path, "wb") as fh:
-                _dump_toml_payload(prepare_app_settings_for_write(persisted), fh)
+            persisted, _ = update_app_settings_owned(
+                settings_path,
+                persisted,
+                owned_paths=tuple(
+                    ("view_barycentric", key) for key in changed_keys
+                ),
+                dump_fn=_dump_toml_payload,
+            )
         except Exception:
             logger.warning("Unable to persist view_barycentric settings to %s", settings_path, exc_info=True)
 
@@ -594,7 +596,7 @@ def page(env):
 
             if "project" in st.session_state:
                 st.markdown(f"{env.target} worker arguments:")
-                settings = toml.load(env.app_settings_file)
+                settings = read_app_settings(env.app_settings_file)
                 current_filename = Path(__file__).stem
                 # set default values
                 if (
@@ -725,7 +727,7 @@ def main():
         st.session_state["apps_path"] = str(active_app.parent)
         st.session_state["app"] = app
 
-        env = getattr(AgiEnv, "for_app", AgiEnv)(
+        env = AgiEnv.session_for_app(
             apps_path=active_app.parent,
             app=app,
             verbose=1,

--- a/src/agilab/apps-pages/view_data_io_decision/src/view_data_io_decision/view_data_io_decision.py
+++ b/src/agilab/apps-pages/view_data_io_decision/src/view_data_io_decision/view_data_io_decision.py
@@ -100,7 +100,7 @@ configure_streamlit_page(st, title="Decision evidence")
 active_app_path = _resolve_active_app()
 app_scope_changed = _reset_app_scoped_session_defaults(active_app_path)
 if "env" not in st.session_state or app_scope_changed:
-    env = getattr(AgiEnv, "for_app", AgiEnv)(apps_path=active_app_path.parent, app=active_app_path.name, verbose=0)
+    env = AgiEnv.session_for_app(apps_path=active_app_path.parent, app=active_app_path.name, verbose=0)
     env.init_done = True
     st.session_state["env"] = env
 else:

--- a/src/agilab/apps-pages/view_forecast_analysis/src/view_forecast_analysis/view_forecast_analysis.py
+++ b/src/agilab/apps-pages/view_forecast_analysis/src/view_forecast_analysis/view_forecast_analysis.py
@@ -67,7 +67,7 @@ def _ensure_app_scoped_env() -> AgiEnv:
         )
 
     if "env" not in st.session_state:
-        env = getattr(AgiEnv, "for_app", AgiEnv)(apps_path=active_app_path.parent, app=active_app_path.name, verbose=0)
+        env = AgiEnv.session_for_app(apps_path=active_app_path.parent, app=active_app_path.name, verbose=0)
         env.init_done = True
         st.session_state["env"] = env
     return st.session_state["env"]

--- a/src/agilab/apps-pages/view_live_artifacts/src/view_live_artifacts/view_live_artifacts.py
+++ b/src/agilab/apps-pages/view_live_artifacts/src/view_live_artifacts/view_live_artifacts.py
@@ -297,7 +297,7 @@ def _active_env(active_app_path: Path) -> AgiEnv:
         and current_apps_root == active_app_path.parent.resolve(strict=False)
     ):
         return current
-    env = getattr(AgiEnv, "for_app", AgiEnv)(apps_path=active_app_path.parent, app=active_app_path.name, verbose=0)
+    env = AgiEnv.session_for_app(apps_path=active_app_path.parent, app=active_app_path.name, verbose=0)
     env.init_done = True
     st.session_state["env"] = env
     return env

--- a/src/agilab/apps-pages/view_maps/src/view_maps/view_maps.py
+++ b/src/agilab/apps-pages/view_maps/src/view_maps/view_maps.py
@@ -24,8 +24,7 @@ from pandas.api.types import is_integer_dtype, is_numeric_dtype
 import plotly.express as px
 import plotly.graph_objects as go
 import streamlit as st
-import tomllib as _toml
-from agi_env.app_settings_support import prepare_app_settings_for_write
+from agi_env.app_settings_support import read_app_settings, update_app_settings_owned
 
 try:
     import tomli_w as _toml_writer  # type: ignore[import-not-found]
@@ -362,8 +361,7 @@ def _load_map_defaults(env: AgiEnv) -> dict[str, float]:
     """Read custom map settings from app_settings.toml when available."""
 
     try:
-        with open(env.app_settings_file, "rb") as fh:
-            data = _toml.load(fh)
+        data = read_app_settings(env.app_settings_file)
     except FileNotFoundError:
         data = {}
     map_cfg = data.get("ui", {}).get(
@@ -380,11 +378,10 @@ def _load_map_defaults(env: AgiEnv) -> dict[str, float]:
 def _load_view_maps_settings(env: AgiEnv) -> tuple[dict, dict]:
     """Return the full TOML payload and the view_maps subsection."""
     try:
-        with open(env.app_settings_file, "rb") as fh:
-            data = _toml.load(fh)
+        data = read_app_settings(env.app_settings_file)
     except FileNotFoundError:
         data = {}
-    except (OSError, _toml.TOMLDecodeError):
+    except (OSError, ValueError):
         data = {}
     view_section = data.get("view_maps")
     if not isinstance(view_section, dict):
@@ -392,13 +389,29 @@ def _load_view_maps_settings(env: AgiEnv) -> tuple[dict, dict]:
     return data, view_section
 
 
-def _persist_view_maps_settings(env: AgiEnv, base_settings: dict, view_settings: dict) -> dict:
+def _persist_view_maps_settings(
+    env: AgiEnv,
+    base_settings: dict,
+    view_settings: dict,
+    owned_keys: tuple[str, ...],
+) -> dict:
     """Write the updated view_maps settings back to disk."""
     payload = dict(base_settings) if isinstance(base_settings, dict) else {}
     payload["view_maps"] = view_settings
+    if not owned_keys:
+        return payload
     try:
-        with open(env.app_settings_file, "wb") as fh:
-            _dump_toml_payload(prepare_app_settings_for_write(payload), fh)
+        latest, _ = update_app_settings_owned(
+            env.app_settings_file,
+            payload,
+            owned_paths=tuple(("view_maps", key) for key in owned_keys),
+            dump_fn=_dump_toml_payload,
+        )
+        merged = dict(payload)
+        merged.update(
+            (key, value) for key, value in latest.items() if key != "__meta__"
+        )
+        return merged
     except (OSError, RuntimeError):
         pass
     return payload
@@ -475,7 +488,9 @@ def page(env):
     st.session_state["_view_maps_last_datadir"] = str(datadir)
     if view_settings.get("datadir") != st.session_state["datadir"]:
         view_settings["datadir"] = st.session_state["datadir"]
-        full_settings = _persist_view_maps_settings(env, full_settings, view_settings)
+        full_settings = _persist_view_maps_settings(
+            env, full_settings, view_settings, ("datadir",)
+        )
     datadir_widget_key = _vm_key("input_datadir")
     if st.session_state.get(datadir_widget_key) != st.session_state["datadir"]:
         st.session_state[datadir_widget_key] = st.session_state["datadir"]
@@ -820,7 +835,9 @@ def page(env):
     )
     if overlay_default != show_coordinate_overlay:
         view_settings["show_coordinate_overlay"] = show_coordinate_overlay
-        full_settings = _persist_view_maps_settings(env, full_settings, view_settings)
+        full_settings = _persist_view_maps_settings(
+            env, full_settings, view_settings, ("show_coordinate_overlay",)
+        )
 
     overlay_lat_col = None
     overlay_lon_col = None
@@ -870,7 +887,9 @@ def page(env):
             }.items():
                 if view_settings.get(setting_name) != setting_value:
                     view_settings[setting_name] = setting_value
-                    full_settings = _persist_view_maps_settings(env, full_settings, view_settings)
+                    full_settings = _persist_view_maps_settings(
+                        env, full_settings, view_settings, (setting_name,)
+                    )
         else:
             st.sidebar.caption("No coordinate columns available for overlay.")
 
@@ -900,7 +919,9 @@ def page(env):
     )
     if view_settings.get("unique_threshold", 10) != unique_threshold:
         view_settings["unique_threshold"] = int(unique_threshold)
-        full_settings = _persist_view_maps_settings(env, full_settings, view_settings)
+        full_settings = _persist_view_maps_settings(
+            env, full_settings, view_settings, ("unique_threshold",)
+        )
 
     range_default = int(view_settings.get("range_threshold", 200))
     range_threshold_key = _vm_key("range_threshold")
@@ -918,7 +939,9 @@ def page(env):
     )
     if view_settings.get("range_threshold", 200) != range_threshold:
         view_settings["range_threshold"] = int(range_threshold)
-        full_settings = _persist_view_maps_settings(env, full_settings, view_settings)
+        full_settings = _persist_view_maps_settings(
+            env, full_settings, view_settings, ("range_threshold",)
+        )
 
     # Loop through numeric columns and classify them based on the unique value count.
     for col in numeric_cols:
@@ -1126,16 +1149,18 @@ def page(env):
         "long",
         "coltype",
     ]
-    mutated = False
+    changed_keys: list[str] = []
     for key in persist_keys:
         val = st.session_state.get(key)
         if val is None:
             continue
         if view_settings.get(key) != val:
             view_settings[key] = val
-            mutated = True
-    if mutated:
-        full_settings = _persist_view_maps_settings(env, full_settings, view_settings)
+            changed_keys.append(key)
+    if changed_keys:
+        full_settings = _persist_view_maps_settings(
+            env, full_settings, view_settings, tuple(changed_keys)
+        )
 
 # -------------------- Main Application Entry -------------------- #
 def main():
@@ -1173,7 +1198,7 @@ def main():
         st.session_state["app"] = app
 
         _render_app_page_context(app, active_app)
-        env = getattr(AgiEnv, "for_app", AgiEnv)(
+        env = AgiEnv.session_for_app(
             apps_path=active_app.parent,
             app=app,
             verbose=1,

--- a/src/agilab/apps-pages/view_maps_3d/src/view_maps_3d/view_maps_3d.py
+++ b/src/agilab/apps-pages/view_maps_3d/src/view_maps_3d/view_maps_3d.py
@@ -62,9 +62,8 @@ def _default_app() -> Path | None:
 
 
 from agi_env import AgiEnv
-from agi_env.app_settings_support import prepare_app_settings_for_write
+from agi_env.app_settings_support import read_app_settings, update_app_settings_owned
 from agi_gui.pagelib import find_files, load_df, render_dataframe_preview, _dump_toml_payload
-import tomllib as _toml
 
 
 # List of available color palettes
@@ -227,7 +226,7 @@ def _bootstrap_env_from_active_app() -> bool:
             continue
         _reset_app_scoped_session_state(candidate)
         try:
-            env = getattr(AgiEnv, "for_app", AgiEnv)(
+            env = AgiEnv.session_for_app(
                 apps_path=candidate.parent,
                 app=candidate.name,
                 verbose=1,
@@ -631,9 +630,8 @@ def page():
     settings_path = Path(env.app_settings_file)
     persisted = {}
     try:
-        with open(settings_path, "rb") as fh:
-            persisted = _toml.load(fh)
-    except (OSError, _toml.TOMLDecodeError):
+        persisted = read_app_settings(settings_path)
+    except (OSError, ValueError):
         logger.debug("Unable to load view_maps_3d settings from %s", settings_path, exc_info=True)
         persisted = {}
     view_settings = persisted.get("view_maps_3d", {}) if isinstance(persisted, dict) else {}
@@ -980,20 +978,23 @@ def page():
         "beam_files": st.session_state.get("beam_files", []),
         "coltype": st.session_state.get("coltype", ""),
     }
-    mutated = False
+    changed_keys: list[str] = []
     view_settings = persisted.get("view_maps_3d", {}) if isinstance(persisted, dict) else {}
     if not isinstance(view_settings, dict):
         view_settings = {}
     for k, v in save_settings.items():
         if view_settings.get(k) != v and v not in (None, ""):
             view_settings[k] = v
-            mutated = True
-    if mutated:
+            changed_keys.append(k)
+    if changed_keys:
         persisted["view_maps_3d"] = view_settings
         try:
-            settings_path.parent.mkdir(parents=True, exist_ok=True)
-            with open(settings_path, "wb") as fh:
-                _dump_toml_payload(prepare_app_settings_for_write(persisted), fh)
+            persisted, _ = update_app_settings_owned(
+                settings_path,
+                persisted,
+                owned_paths=tuple(("view_maps_3d", key) for key in changed_keys),
+                dump_fn=_dump_toml_payload,
+            )
         except Exception:
             logger.warning("Unable to persist view_maps_3d settings to %s", settings_path, exc_info=True)
 
@@ -1405,7 +1406,7 @@ def main():
         st.session_state["apps_path"] = str(active_app.parent)
         st.session_state["app"] = app
 
-        env = getattr(AgiEnv, "for_app", AgiEnv)(
+        env = AgiEnv.session_for_app(
             apps_path=active_app.parent,
             app=app,
             verbose=1,

--- a/src/agilab/apps-pages/view_maps_network/src/view_maps_network/notebook_inline.py
+++ b/src/agilab/apps-pages/view_maps_network/src/view_maps_network/notebook_inline.py
@@ -10,6 +10,7 @@ import networkx as nx
 import pandas as pd
 import plotly.graph_objects as go
 from IPython.display import Markdown
+from agi_env.app_settings_support import read_app_settings
 
 logger = logging.getLogger(__name__)
 
@@ -44,11 +45,8 @@ def _read_toml_dict(path: str | Path | None) -> dict[str, Any]:
     if not candidate.exists():
         return {}
     try:
-        import tomllib
-
-        with open(candidate, "rb") as handle:
-            payload = tomllib.load(handle)
-    except (OSError, ValueError, tomllib.TOMLDecodeError):
+        payload = read_app_settings(candidate)
+    except (OSError, ValueError):
         return {}
     return payload if isinstance(payload, dict) else {}
 

--- a/src/agilab/apps-pages/view_maps_network/src/view_maps_network/view_maps_network.py
+++ b/src/agilab/apps-pages/view_maps_network/src/view_maps_network/view_maps_network.py
@@ -26,11 +26,9 @@ import numpy as np
 import plotly.graph_objects as go
 import matplotlib.colors as mcolors
 import glob
-import json
 import re
-import tomllib
 from urllib.parse import quote, urlencode
-from agi_env.app_settings_support import prepare_app_settings_for_write
+from agi_env.app_settings_support import read_app_settings, update_app_settings_owned
 try:
     import tomli_w as _toml_writer  # type: ignore[import-not-found]
 
@@ -86,12 +84,12 @@ except ModuleNotFoundError:
 
 try:
     from allocation_support import (
-        _coerce_alloc_time_index,
+        _coerce_alloc_time_index as _coerce_alloc_time_index,
         _drop_index_levels_shadowing_columns,
         _nearest_row,
-        _normalize_allocations_frame,
-        _parse_allocations_cell,
-        _pick_ci_column,
+        _normalize_allocations_frame as _normalize_allocations_frame,
+        _parse_allocations_cell as _parse_allocations_cell,
+        _pick_ci_column as _pick_ci_column,
         load_allocations,
         safe_literal_eval,
     )
@@ -101,10 +99,10 @@ try:
         _candidate_node_ids,
         _canonical_edge_pair,
         _coerce_list_cell,
-        _coerce_numeric_float,
-        _coerce_numeric_int,
+        _coerce_numeric_float as _coerce_numeric_float,
+        _coerce_numeric_int as _coerce_numeric_int,
         _filter_allocation_rows_for_selected_nodes,
-        _format_node_label,
+        _format_node_label as _format_node_label,
         _normalize_node_id_series,
         _normalize_node_id_value,
         _preferred_node_id_from_row,
@@ -120,7 +118,7 @@ try:
         _candidate_files_from_globs,
         _choose_existing_declared_path,
         _expand_glob_patterns,
-        _find_latest_allocations,
+        _find_latest_allocations as _find_latest_allocations,
         _is_baseline_alloc_path,
         _quick_share_edges_paths,
         _quick_share_traj_globs,
@@ -133,12 +131,12 @@ except ModuleNotFoundError:
     if page_dir_str not in sys.path:
         sys.path.insert(0, page_dir_str)
     from allocation_support import (
-        _coerce_alloc_time_index,
+        _coerce_alloc_time_index as _coerce_alloc_time_index,
         _drop_index_levels_shadowing_columns,
         _nearest_row,
-        _normalize_allocations_frame,
-        _parse_allocations_cell,
-        _pick_ci_column,
+        _normalize_allocations_frame as _normalize_allocations_frame,
+        _parse_allocations_cell as _parse_allocations_cell,
+        _pick_ci_column as _pick_ci_column,
         load_allocations,
         safe_literal_eval,
     )
@@ -148,10 +146,10 @@ except ModuleNotFoundError:
         _candidate_node_ids,
         _canonical_edge_pair,
         _coerce_list_cell,
-        _coerce_numeric_float,
-        _coerce_numeric_int,
+        _coerce_numeric_float as _coerce_numeric_float,
+        _coerce_numeric_int as _coerce_numeric_int,
         _filter_allocation_rows_for_selected_nodes,
-        _format_node_label,
+        _format_node_label as _format_node_label,
         _normalize_node_id_series,
         _normalize_node_id_value,
         _preferred_node_id_from_row,
@@ -167,7 +165,7 @@ except ModuleNotFoundError:
         _candidate_files_from_globs,
         _choose_existing_declared_path,
         _expand_glob_patterns,
-        _find_latest_allocations,
+        _find_latest_allocations as _find_latest_allocations,
         _is_baseline_alloc_path,
         _quick_share_edges_paths,
         _quick_share_traj_globs,
@@ -410,10 +408,9 @@ def _ensure_app_settings_loaded(env: AgiEnv) -> None:
     path = Path(env.app_settings_file)
     if path.exists():
         try:
-            with open(path, "rb") as handle:
-                st.session_state["app_settings"] = tomllib.load(handle)
-                return
-        except (OSError, tomllib.TOMLDecodeError):
+            st.session_state["app_settings"] = read_app_settings(path)
+            return
+        except (OSError, ValueError):
             pass
     st.session_state["app_settings"] = {}
 
@@ -438,18 +435,32 @@ def _sanitize_toml_payload(value: Any) -> Any:
     return value
 
 
-def _persist_app_settings(env: AgiEnv) -> None:
+def _persist_app_settings(env: AgiEnv, owned_keys: tuple[str, ...]) -> None:
     settings = st.session_state.get("app_settings")
     if not isinstance(settings, dict):
         return
+    vm_settings = settings.get("view_maps_network")
+    if not isinstance(vm_settings, dict):
+        vm_settings = {}
+    if not owned_keys:
+        return
     path = Path(env.app_settings_file)
     try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        with open(path, "wb") as handle:
-            _dump_toml(
-                prepare_app_settings_for_write(_sanitize_toml_payload(settings), sanitize=False),
-                handle,
-            )
+        latest, _ = update_app_settings_owned(
+            path,
+            _sanitize_toml_payload(settings),
+            owned_paths=tuple(
+                ("view_maps_network", key) for key in owned_keys
+            ),
+            dump_fn=_dump_toml,
+        )
+        latest_vm_settings = latest.get("view_maps_network")
+        vm_settings.clear()
+        if isinstance(latest_vm_settings, dict):
+            vm_settings.update(latest_vm_settings)
+        settings.clear()
+        settings.update(latest)
+        settings["view_maps_network"] = vm_settings
     except (OSError, RuntimeError, ValueError) as exc:
         logger.warning(f"Unable to persist app_settings to {path}: {exc}")
 
@@ -500,7 +511,7 @@ active_app_path = _resolve_active_app()
 app_scope_changed = _reset_app_scoped_session_state(active_app_path)
 if 'env' not in st.session_state or app_scope_changed:
     app_name = active_app_path.name
-    env = getattr(AgiEnv, "for_app", AgiEnv)(apps_path=active_app_path.parent, app=app_name, verbose=0)
+    env = AgiEnv.session_for_app(apps_path=active_app_path.parent, app=app_name, verbose=0)
     env.init_done = True
     st.session_state['env'] = env
     st.session_state['IS_SOURCE_ENV'] = env.is_source_env
@@ -3024,13 +3035,13 @@ def page():
         "layout_type_select": st.session_state.get("layout_type_select", "spring"),
         "metric_type_select": st.session_state.get("metric_type_select", ""),
     }
-    vm_mutated = False
+    vm_changed_keys: list[str] = []
     for key, value in new_vm_settings.items():
         if vm_settings.get(key) != value:
             vm_settings[key] = value
-            vm_mutated = True
-    if vm_mutated:
-        _persist_app_settings(env)
+            vm_changed_keys.append(key)
+    if vm_changed_keys:
+        _persist_app_settings(env, tuple(vm_changed_keys))
 
     datadir_path = Path(st.session_state.datadir).expanduser()
     def _visible_only(paths):
@@ -3376,7 +3387,7 @@ def page():
     st.sidebar.caption(f"{shown_count} / {len(available_node_ids)} flights shown")
     if vm_settings.get("selected_flights_filter") != selected_node_ids:
         vm_settings["selected_flights_filter"] = selected_node_ids
-        _persist_app_settings(env)
+        _persist_app_settings(env, ("selected_flights_filter",))
 
     if selected_node_set:
         df_std = df_std[df_std["id_col"].isin(selected_node_set)].copy()
@@ -3474,7 +3485,7 @@ def page():
 
     if vm_settings.get("edges_file") != edges_clean:
         vm_settings["edges_file"] = edges_clean
-        _persist_app_settings(env)
+        _persist_app_settings(env, ("edges_file",))
 
     link_options = _detect_link_columns(df_std)
     if loaded_edges:
@@ -4238,7 +4249,10 @@ def page():
         vm_settings["allocations_file"] = alloc_clean
         vm_settings["baseline_allocations_file"] = baseline_clean
         vm_settings["traj_glob"] = traj_clean
-        _persist_app_settings(env)
+        _persist_app_settings(
+            env,
+            ("allocations_file", "baseline_allocations_file", "traj_glob"),
+        )
     alloc_df = (
         load_allocations(alloc_path_obj)
         if alloc_path_obj is not None and alloc_path_obj.exists()

--- a/src/agilab/apps-pages/view_queue_resilience/src/view_queue_resilience/view_queue_resilience.py
+++ b/src/agilab/apps-pages/view_queue_resilience/src/view_queue_resilience/view_queue_resilience.py
@@ -100,7 +100,7 @@ configure_streamlit_page(st, title=PAGE_TITLE)
 active_app_path = _resolve_active_app()
 app_scope_changed = _reset_app_scoped_session_defaults(active_app_path)
 if "env" not in st.session_state or app_scope_changed:
-    env = getattr(AgiEnv, "for_app", AgiEnv)(apps_path=active_app_path.parent, app=active_app_path.name, verbose=0)
+    env = AgiEnv.session_for_app(apps_path=active_app_path.parent, app=active_app_path.name, verbose=0)
     env.init_done = True
     st.session_state["env"] = env
 else:

--- a/src/agilab/apps-pages/view_relay_resilience/src/view_relay_resilience/view_relay_resilience.py
+++ b/src/agilab/apps-pages/view_relay_resilience/src/view_relay_resilience/view_relay_resilience.py
@@ -188,7 +188,7 @@ configure_streamlit_page(st, title="Relay resilience analysis")
 active_app_path = _resolve_active_app()
 app_scope_changed = _reset_app_scoped_session_defaults(active_app_path)
 if "env" not in st.session_state or app_scope_changed:
-    env = getattr(AgiEnv, "for_app", AgiEnv)(apps_path=active_app_path.parent, app=active_app_path.name, verbose=0)
+    env = AgiEnv.session_for_app(apps_path=active_app_path.parent, app=active_app_path.name, verbose=0)
     env.init_done = True
     st.session_state["env"] = env
 else:

--- a/src/agilab/apps-pages/view_release_decision/src/view_release_decision/view_release_decision.py
+++ b/src/agilab/apps-pages/view_release_decision/src/view_release_decision/view_release_decision.py
@@ -44,7 +44,9 @@ def _ensure_repo_on_path() -> None:
 _ensure_repo_on_path()
 
 from agi_pages.runtime import (
+    active_app_scope_value,
     configure_streamlit_page,
+    env_app_scope_value,
     render_streamlit_page_header,
     reset_scoped_session_state,
 )
@@ -122,6 +124,22 @@ def _resolve_active_app() -> Path:
         st.error(f"Provided --active-app path not found: {active_app_path}")
         st.stop()
     return active_app_path
+
+
+def _ensure_app_scoped_env() -> AgiEnv:
+    active_app_path = _resolve_active_app()
+    env = st.session_state.get("env")
+    if env_app_scope_value(env) == active_app_scope_value(active_app_path):
+        return env
+
+    env = AgiEnv.session_for_app(
+        apps_path=active_app_path.parent,
+        app=active_app_path.name,
+        verbose=0,
+    )
+    env.init_done = True
+    st.session_state["env"] = env
+    return env
 
 
 def _connector_path_registry(env: AgiEnv) -> ConnectorPathRegistry:
@@ -2101,13 +2119,7 @@ def _render_release_decision_connector_live_ui(
 
 configure_streamlit_page(st, title="Evidence cockpit")
 
-if "env" not in st.session_state:
-    active_app_path = _resolve_active_app()
-    env = getattr(AgiEnv, "for_app", AgiEnv)(apps_path=active_app_path.parent, app=active_app_path.name, verbose=0)
-    env.init_done = True
-    st.session_state["env"] = env
-else:
-    env = st.session_state["env"]
+env = _ensure_app_scoped_env()
 _reset_app_scoped_session_defaults(st, env)
 
 render_streamlit_page_header(

--- a/src/agilab/apps-pages/view_routing_model_comparison/src/view_routing_model_comparison/view_routing_model_comparison.py
+++ b/src/agilab/apps-pages/view_routing_model_comparison/src/view_routing_model_comparison/view_routing_model_comparison.py
@@ -17,7 +17,9 @@ from plotly.subplots import make_subplots
 import streamlit as st
 import tomllib
 from agi_pages.runtime import (
+    active_app_scope_value,
     configure_streamlit_page,
+    env_app_scope_value,
     ensure_repo_on_path as _page_ensure_repo_on_path,
     render_streamlit_page_header,
     resolve_active_app_path,
@@ -81,15 +83,16 @@ def _ensure_app_scoped_env() -> AgiEnv:
     )
 
     env = st.session_state.get("env")
-    if env is not None:
+    env_matches_active_app = (
+        env is not None
+        and env_app_scope_value(env) == active_app_scope_value(active_app_path)
+    )
+    if env_matches_active_app:
         return env
 
-    try:
-        env = AgiEnv.current()
-    except RuntimeError:
-        env = getattr(AgiEnv, "for_app", AgiEnv)(
-            apps_path=active_app_path.parent, app=active_app_path.name, verbose=0
-        )
+    env = AgiEnv.session_for_app(
+        apps_path=active_app_path.parent, app=active_app_path.name, verbose=0
+    )
     env.init_done = True
     st.session_state["env"] = env
     return env

--- a/src/agilab/apps-pages/view_scenario_cockpit/src/view_scenario_cockpit/view_scenario_cockpit.py
+++ b/src/agilab/apps-pages/view_scenario_cockpit/src/view_scenario_cockpit/view_scenario_cockpit.py
@@ -145,7 +145,7 @@ configure_streamlit_page(st, title=PAGE_TITLE)
 active_app_path = _resolve_active_app()
 app_scope_changed = _reset_app_scoped_session_defaults(active_app_path)
 if "env" not in st.session_state or app_scope_changed:
-    env = getattr(AgiEnv, "for_app", AgiEnv)(apps_path=active_app_path.parent, app=active_app_path.name, verbose=0)
+    env = AgiEnv.session_for_app(apps_path=active_app_path.parent, app=active_app_path.name, verbose=0)
     env.init_done = True
     st.session_state["env"] = env
 else:

--- a/src/agilab/apps-pages/view_shap_explanation/src/view_shap_explanation/view_shap_explanation.py
+++ b/src/agilab/apps-pages/view_shap_explanation/src/view_shap_explanation/view_shap_explanation.py
@@ -84,7 +84,7 @@ def _ensure_app_scoped_env() -> AgiEnv:
         )
 
     if "env" not in st.session_state:
-        env = getattr(AgiEnv, "for_app", AgiEnv)(apps_path=active_app_path.parent, app=active_app_path.name, verbose=0)
+        env = AgiEnv.session_for_app(apps_path=active_app_path.parent, app=active_app_path.name, verbose=0)
         env.init_done = True
         st.session_state["env"] = env
     return st.session_state["env"]

--- a/src/agilab/apps-pages/view_training_analysis/src/view_training_analysis/view_training_analysis.py
+++ b/src/agilab/apps-pages/view_training_analysis/src/view_training_analysis/view_training_analysis.py
@@ -14,8 +14,7 @@ import plotly.graph_objects as go
 from plotly.colors import qualitative as plotly_qualitative
 from plotly.subplots import make_subplots
 import streamlit as st
-import tomllib
-from agi_env.app_settings_support import prepare_app_settings_for_write
+from agi_env.app_settings_support import read_app_settings, update_app_settings_owned
 from agi_pages.runtime import (
     active_app_scope_value,
     configure_streamlit_page,
@@ -85,7 +84,7 @@ def _ensure_repo_on_path() -> None:
 
 _ensure_repo_on_path()
 
-from agi_env import AgiEnv
+from agi_env import AgiEnv  # noqa: E402
 
 
 def _resolve_active_app() -> Path:
@@ -95,15 +94,16 @@ def _resolve_active_app() -> Path:
 def _ensure_app_scoped_env() -> AgiEnv:
     env = st.session_state.get("env")
     scope_key = st.session_state.get(APP_SCOPE_KEY)
-    if env is not None and scope_key is None:
-        inferred_scope_key = env_app_scope_value(env)
-        if inferred_scope_key is None:
-            return env
-        st.session_state[APP_SCOPE_KEY] = inferred_scope_key
-        scope_key = inferred_scope_key
+    inferred_env_scope = env_app_scope_value(env)
+    if env is not None and scope_key is None and inferred_env_scope is None:
+        # Lightweight embedded callers may provide an app-agnostic facade rather
+        # than a complete AgiEnv. Preserve that explicit injection when neither
+        # side exposes an app scope to compare.
+        return env
 
     active_app_path = _resolve_active_app()
-    if scope_key != active_app_scope_value(active_app_path):
+    active_scope_key = active_app_scope_value(active_app_path)
+    if scope_key != active_scope_key:
         reset_scoped_session_state(
             st.session_state,
             APP_SCOPE_KEY,
@@ -111,11 +111,16 @@ def _ensure_app_scoped_env() -> AgiEnv:
             keys=APP_SCOPED_SESSION_KEYS,
         )
 
-    if "env" not in st.session_state:
-        env = getattr(AgiEnv, "for_app", AgiEnv)(apps_path=active_app_path.parent, app=active_app_path.name, verbose=0)
+    if inferred_env_scope == active_scope_key:
+        # The scope reset above intentionally clears every app-owned key,
+        # including ``env``. Rebind the already-proven matching environment
+        # instead of returning through a now-missing session-state entry.
+        st.session_state["env"] = env
+    else:
+        env = AgiEnv.session_for_app(apps_path=active_app_path.parent, app=active_app_path.name, verbose=0)
         env.init_done = True
         st.session_state["env"] = env
-    return st.session_state["env"]
+    return env
 
 
 def _ensure_app_settings_loaded(env: AgiEnv) -> None:
@@ -124,27 +129,37 @@ def _ensure_app_settings_loaded(env: AgiEnv) -> None:
     path = Path(env.app_settings_file)
     if path.exists():
         try:
-            with path.open("rb") as handle:
-                st.session_state["app_settings"] = tomllib.load(handle)
-                return
-        except (OSError, tomllib.TOMLDecodeError):
+            st.session_state["app_settings"] = read_app_settings(path)
+            return
+        except (OSError, ValueError):
             pass
     st.session_state["app_settings"] = {}
 
 
-def _persist_app_settings(env: AgiEnv) -> None:
+def _persist_app_settings(env: AgiEnv, owned_keys: tuple[str, ...]) -> None:
     settings = st.session_state.get("app_settings")
     if not isinstance(settings, dict):
         return
+    page_settings = settings.get(PAGE_KEY)
+    if not isinstance(page_settings, dict):
+        page_settings = {}
+    if not owned_keys:
+        return
     path = Path(env.app_settings_file)
     try:
-        prepared_settings = prepare_app_settings_for_write(settings)
-    except ValueError:
-        return
-    try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        with path.open("wb") as handle:
-            _dump_toml(prepared_settings, handle)
+        latest, _ = update_app_settings_owned(
+            path,
+            settings,
+            owned_paths=tuple((PAGE_KEY, key) for key in owned_keys),
+            dump_fn=_dump_toml,
+        )
+        latest_page_settings = latest.get(PAGE_KEY)
+        page_settings.clear()
+        if isinstance(latest_page_settings, dict):
+            page_settings.update(latest_page_settings)
+        settings.clear()
+        settings.update(latest)
+        settings[PAGE_KEY] = page_settings
     except (OSError, RuntimeError):
         pass
 
@@ -701,7 +716,9 @@ def main() -> None:
                 "x_axis": st.session_state.get(X_AXIS_KEY, "step"),
             }
         )
-        _persist_app_settings(env)
+        _persist_app_settings(
+            env, ("base_dir_choice", "input_datadir", "datadir_rel", "x_axis")
+        )
         st.stop()
 
     trainer_roots = _discover_training_roots(data_root)
@@ -715,7 +732,9 @@ def main() -> None:
                 "x_axis": st.session_state.get(X_AXIS_KEY, "step"),
             }
         )
-        _persist_app_settings(env)
+        _persist_app_settings(
+            env, ("base_dir_choice", "input_datadir", "datadir_rel", "x_axis")
+        )
         st.stop()
 
     trainer_labels = {_relative_label(path, data_root): path for path in trainer_roots}
@@ -825,7 +844,20 @@ def main() -> None:
             "x_axis": x_axis_option,
         }
     )
-    _persist_app_settings(env)
+    _persist_app_settings(
+        env,
+        (
+            "base_dir_choice",
+            "input_datadir",
+            "datadir_rel",
+            "trainer_rel",
+            "trainer_rels",
+            "run_rel",
+            "run_rels",
+            "selected_tags",
+            "x_axis",
+        ),
+    )
 
 
 if __name__ == "__main__":  # pragma: no cover - script entrypoint

--- a/src/agilab/apps/builtin/flight_telemetry_project/src/app_args_form.py
+++ b/src/agilab/apps/builtin/flight_telemetry_project/src/app_args_form.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import streamlit as st
 from pydantic import ValidationError
+from agi_env.app_settings_support import read_app_settings
 from agi_env.streamlit_args import resolve_app_args_share_paths
 
 _HERE = Path(__file__).resolve().parent
@@ -57,8 +58,7 @@ def _flight_arg_field_names() -> set[str]:
 def _read_stored_args_payload(settings_path: Path) -> dict[str, Any] | None:
     if not settings_path.exists():
         return {}
-    with settings_path.open("rb") as handle:
-        doc = tomllib.load(handle)
+    doc = read_app_settings(settings_path)
     raw_payload = doc.get("args", {})
     if not isinstance(raw_payload, dict):
         return None

--- a/src/agilab/apps/builtin/flight_telemetry_project/src/flight_telemetry/flight_args.py
+++ b/src/agilab/apps/builtin/flight_telemetry_project/src/flight_telemetry/flight_args.py
@@ -7,8 +7,6 @@ from datetime import date
 from pathlib import Path
 from typing import Any, Literal, TypedDict
 
-import tomllib
-
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from agi_env.app_args import (
@@ -189,14 +187,6 @@ def dump_args_to_toml(
     create_missing: bool = True,
 ) -> None:
     """Persist arguments back to the TOML file (overwriting only the section)."""
-
-    settings_path = Path(settings_path)
-    doc: dict[str, Any] = {}
-    if settings_path.exists():
-        with settings_path.open("rb") as handle:
-            doc = tomllib.load(handle)
-    elif not create_missing:
-        raise FileNotFoundError(f"Settings file not found: {settings_path}")
 
     dump_model_to_toml(
         args,

--- a/src/agilab/cluster/cluster_flight_validation.py
+++ b/src/agilab/cluster/cluster_flight_validation.py
@@ -24,6 +24,7 @@ from agilab.cluster.cluster_lan_discovery import (
     print_discovery_report,
 )
 from agilab.environment.env_default_comments import CLUSTER_ENV_DEFAULT_COMMENT_LINES
+from agilab.environment.env_file_utils import load_env_file_map
 
 
 DEFAULT_APP = "flight_telemetry_project"
@@ -451,19 +452,7 @@ def _parse_aircraft(value: str) -> tuple[int, ...]:
 
 
 def _read_dotenv(path: Path) -> dict[str, str]:
-    values: dict[str, str] = {}
-    try:
-        lines = path.read_text(encoding="utf-8").splitlines()
-    except OSError:
-        return values
-    for raw_line in lines:
-        line = raw_line.strip()
-        if not line or line.startswith("#") or "=" not in line:
-            continue
-        key, value = line.split("=", 1)
-        value = value.strip().strip('"').strip("'")
-        values[key.strip()] = value
-    return values
+    return load_env_file_map(path, include_commented=False)
 
 
 def _merged_agilab_env(home: Path, environ: Mapping[str, str]) -> dict[str, str]:
@@ -817,48 +806,16 @@ def _share_check_command(plan: ValidationPlan, *, backend: str | None = None) ->
 
 
 def _remote_env_update_script(plan: ValidationPlan) -> str:
-    return "\n".join(
-        [
-            "from pathlib import Path",
-            f"default_comments = {json.dumps(CLUSTER_ENV_DEFAULT_COMMENT_LINES)}",
-            "updates = (",
-            "    ('IS_SOURCE_ENV', '0'),",
-            "    ('IS_WORKER_ENV', '1'),",
-            "    ('AGI_CLUSTER_ENABLED', '1'),",
-            f"    ('AGI_CLUSTER_SHARE', {json.dumps(plan.remote_cluster_share_setting)}),",
-            ")",
-            "update_keys = {key for key, _value in updates}",
-            "env_path = Path.home() / '.agilab' / '.env'",
-            "env_path.parent.mkdir(parents=True, exist_ok=True)",
-            "lines = []",
-            "existing_keys = set()",
-            "if env_path.exists():",
-            "    for raw_line in env_path.read_text(encoding='utf-8').splitlines():",
-            "        candidate = raw_line.strip()",
-            "        if candidate.startswith('#'):",
-            "            candidate = candidate[1:].strip()",
-            "        if '=' in candidate:",
-            "            existing_keys.add(candidate.split('=', 1)[0].strip())",
-            "        key = raw_line.split('=', 1)[0].strip()",
-            "        if key not in update_keys:",
-            "            lines.append(raw_line)",
-            "missing_comments = []",
-            "for comment_line in default_comments:",
-            "    key = comment_line.lstrip('#').split('=', 1)[0].strip()",
-            "    if key in update_keys or key in existing_keys:",
-            "        continue",
-            "    missing_comments.append(comment_line)",
-            "if missing_comments:",
-            "    if lines and lines[-1] != '':",
-            "        lines.append('')",
-            "    lines.append('# Optional AGILAB cluster env defaults (commented)')",
-            "    lines.extend(missing_comments)",
-            "    lines.append('')",
-            "for key, value in updates:",
-            "    lines.append(f'{key}={value!r}')",
-            "env_path.write_text('\\n'.join(lines) + '\\n', encoding='utf-8')",
-            "print(str(env_path))",
-        ]
+    from agi_env.env_config_support import build_remote_env_update_script
+
+    return build_remote_env_update_script(
+        {
+            "IS_SOURCE_ENV": "0",
+            "IS_WORKER_ENV": "1",
+            "AGI_CLUSTER_ENABLED": "1",
+            "AGI_CLUSTER_SHARE": plan.remote_cluster_share_setting,
+        },
+        default_comments=CLUSTER_ENV_DEFAULT_COMMENT_LINES,
     )
 
 

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/api/agi_distributor.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/api/agi_distributor.py
@@ -39,6 +39,7 @@ from agi_cluster.agi_distributor import (
     deployment_prepare_support,
     deployment_remote_support,
     entrypoint_support,
+    lifecycle_guard_support,
     runtime_distribution_support,
     runtime_misc_support,
     scheduler_io_support,
@@ -165,6 +166,11 @@ class AGI:
     _target: Optional[str] = None
     verbose: Optional[int] = None
     _worker_init_error: bool = False
+    _worker_launch_tasks: Set[Any] = set()
+    _worker_launch_errors: List[BaseException] = []
+    _scheduler_launch_tasks: Set[Any] = set()
+    _scheduler_launch_errors: List[BaseException] = []
+    _startup_in_progress: bool = False
     _workers: Optional[Dict[str, int]] = None
     _workers_data_path: Optional[str] = None
     _capacity: Optional[Dict[str, float]] = None
@@ -205,6 +211,25 @@ class AGI:
     _service_cleanup_heartbeat_max_files: int = 1000
     _service_submit_counter: int = 0
     _service_worker_args: Dict[str, Any] = {}
+    _service_cleanup_unproven: bool = False
+    _service_runtime_shutdown_proven: bool = False
+    # ``AGI`` keeps a class-based compatibility surface.  These fields are
+    # managed by lifecycle_guard_support so concurrent event loops/threads and
+    # separate processes cannot cross-wire that shared mutable state.
+    _lifecycle_state_lock: Any = None
+    _lifecycle_call_token: Optional[str] = None
+    _lifecycle_call_owner: Any = None
+    _lifecycle_call_target: Optional[Path] = None
+    _lifecycle_call_operation: Optional[str] = None
+    _lifecycle_call_depth: int = 0
+    _lifecycle_remote_token: Optional[str] = None
+    _lifecycle_remote_recovery_tokens: tuple[str, ...] = ()
+    _lifecycle_pending_release_lease: Any = None
+    _lifecycle_service_token: Optional[str] = None
+    _lifecycle_service_target: Optional[Path] = None
+    _lifecycle_service_operation: Optional[str] = None
+    _lifecycle_service_lease: Any = None
+    _remote_target_leases: Dict[str, cleanup_support.RemoteTargetLease] = {}
 
     def __init__(self, target: str, verbose: int = 1):
         """
@@ -244,16 +269,17 @@ class AGI:
             ValueError: If `mode` is invalid.
             RuntimeError: If the target module fails to load.
         """
-        return await entrypoint_support.run(
-            AGI,
-            env=env,
-            request=request,
-            workers_default=_workers_default,
-            process_error_type=ProcessError,
-            format_exception_chain_fn=_format_exception_chain,
-            traceback_format_exc_fn=traceback.format_exc,
-            log=logger,
-        )
+        async with lifecycle_guard_support.LifecycleOperation(AGI, env, "run"):
+            return await entrypoint_support.run(
+                AGI,
+                env=env,
+                request=request,
+                workers_default=_workers_default,
+                process_error_type=ProcessError,
+                format_exception_chain_fn=_format_exception_chain,
+                traceback_format_exc_fn=traceback.format_exc,
+                log=logger,
+            )
 
     @staticmethod
     def _wrap_worker_chunk(payload: Any, worker_index: int) -> Any:
@@ -369,6 +395,10 @@ class AGI:
         return service_runtime_support.service_queue_counts(AGI)
 
     @staticmethod
+    def _recover_orphaned_service_tasks() -> Dict[str, int]:
+        return service_runtime_support.recover_orphaned_service_tasks(AGI)
+
+    @staticmethod
     def _service_cleanup_artifacts() -> Dict[str, int]:
         return service_runtime_support.service_cleanup_artifacts(AGI)
 
@@ -474,32 +504,76 @@ class AGI:
             health_output_path: Optional[Union[str, Path]] = None,
             **args: Any,
     ) -> Dict[str, Any]:
-        return await service_runtime_support.serve(
+        command = (action or "start").lower()
+        operation = lifecycle_guard_support.LifecycleOperation(
             AGI,
             env,
-            scheduler=scheduler,
-            workers=workers,
-            verbose=verbose,
-            mode=mode,
-            rapids_enabled=rapids_enabled,
-            action=action,
-            poll_interval=poll_interval,
-            shutdown_on_stop=shutdown_on_stop,
-            stop_timeout=stop_timeout,
-            service_queue_dir=service_queue_dir,
-            heartbeat_timeout=heartbeat_timeout,
-            cleanup_done_ttl_sec=cleanup_done_ttl_sec,
-            cleanup_failed_ttl_sec=cleanup_failed_ttl_sec,
-            cleanup_heartbeat_ttl_sec=cleanup_heartbeat_ttl_sec,
-            cleanup_done_max_files=cleanup_done_max_files,
-            cleanup_failed_max_files=cleanup_failed_max_files,
-            cleanup_heartbeat_max_files=cleanup_heartbeat_max_files,
-            health_output_path=health_output_path,
-            background_job_manager_factory=bg.BackgroundJobManager,
-            wait_fn=wait,
-            log=logger,
-            **args,
+            f"serve:{command}",
+            service_command=True,
         )
+        async with operation:
+            try:
+                result = await service_runtime_support.serve(
+                    AGI,
+                    env,
+                    scheduler=scheduler,
+                    workers=workers,
+                    verbose=verbose,
+                    mode=mode,
+                    rapids_enabled=rapids_enabled,
+                    action=action,
+                    poll_interval=poll_interval,
+                    shutdown_on_stop=shutdown_on_stop,
+                    stop_timeout=stop_timeout,
+                    service_queue_dir=service_queue_dir,
+                    heartbeat_timeout=heartbeat_timeout,
+                    cleanup_done_ttl_sec=cleanup_done_ttl_sec,
+                    cleanup_failed_ttl_sec=cleanup_failed_ttl_sec,
+                    cleanup_heartbeat_ttl_sec=cleanup_heartbeat_ttl_sec,
+                    cleanup_done_max_files=cleanup_done_max_files,
+                    cleanup_failed_max_files=cleanup_failed_max_files,
+                    cleanup_heartbeat_max_files=cleanup_heartbeat_max_files,
+                    health_output_path=health_output_path,
+                    background_job_manager_factory=bg.BackgroundJobManager,
+                    wait_fn=wait,
+                    log=logger,
+                    **args,
+                )
+            except BaseException:
+                if (
+                    AGI._service_cleanup_unproven
+                    or AGI._service_runtime_shutdown_proven
+                    or AGI._service_futures
+                    or AGI._service_workers
+                    or AGI._dask_client is not None
+                    or bool(getattr(getattr(AGI, "_jobs", None), "running", None))
+                ):
+                    operation.retain_for_service_on_error()
+                raise
+            status = str(result.get("status", "")).lower()
+            if command == "stop":
+                jobs = getattr(getattr(AGI, "_jobs", None), "running", None) or []
+                runtime_retained = AGI._dask_client is not None or bool(jobs)
+                stop_unproven = (
+                    status not in {"idle", "stopped"}
+                    or AGI._service_cleanup_unproven
+                    or AGI._service_runtime_shutdown_proven
+                    or bool(AGI._service_futures)
+                    or bool(AGI._service_workers)
+                )
+                if stop_unproven:
+                    operation.retain_for_service()
+                elif shutdown_on_stop or not runtime_retained:
+                    operation.release_service()
+                    AGI._service_cleanup_unproven = False
+                else:
+                    # A stopped service may intentionally retain its Dask
+                    # runtime. Keep serialization until a later stop requests
+                    # shutdown; otherwise a normal run can cross-wire it.
+                    operation.retain_for_service()
+            elif status in {"running", "degraded"} or AGI._service_futures or AGI._service_workers:
+                operation.retain_for_service()
+            return result
 
     @staticmethod
     async def submit(
@@ -511,16 +585,39 @@ class AGI:
             task_name: Optional[str] = None,
             **args: Any,
     ) -> Dict[str, Any]:
-        return await service_runtime_support.submit(
+        effective_env = env or AGI.env
+        if effective_env is None:
+            raise ValueError("env is required when AGI has not been initialised yet")
+        operation = lifecycle_guard_support.LifecycleOperation(
             AGI,
-            env=env,
-            workers=workers,
-            work_plan=work_plan,
-            work_plan_metadata=work_plan_metadata,
-            task_id=task_id,
-            task_name=task_name,
-            **args,
+            effective_env,
+            "submit",
+            service_command=True,
         )
+        async with operation:
+            try:
+                result = await service_runtime_support.submit(
+                    AGI,
+                    env=env,
+                    workers=workers,
+                    work_plan=work_plan,
+                    work_plan_metadata=work_plan_metadata,
+                    task_id=task_id,
+                    task_name=task_name,
+                    **args,
+                )
+            except BaseException:
+                if (
+                    AGI._service_cleanup_unproven
+                    or AGI._service_futures
+                    or AGI._service_workers
+                    or AGI._dask_client is not None
+                    or bool(getattr(getattr(AGI, "_jobs", None), "running", None))
+                ):
+                    operation.retain_for_service_on_error()
+                raise
+            operation.retain_for_service()
+            return result
 
     @staticmethod
     async def _benchmark(
@@ -632,12 +729,19 @@ class AGI:
         )
 
     @staticmethod
-    async def _kill(ip: Optional[str] = None, current_pid: Optional[int] = None, force: bool = True) -> Optional[Any]:
+    async def _kill(
+            ip: Optional[str] = None,
+            current_pid: Optional[int] = None,
+            force: bool = True,
+            *,
+            force_scan: bool = False,
+    ) -> Optional[Any]:
         return await cleanup_support.kill_processes(
             AGI,
             ip=ip,
             current_pid=current_pid,
             force=force,
+            force_scan=force_scan,
             gethostbyname_fn=socket.gethostbyname,
             run_fn=AgiEnv.run,
             copy_fn=shutil.copy,
@@ -669,6 +773,18 @@ class AGI:
             getuser_fn=getpass.getuser,
             getpid_fn=os.getpid,
             rmtree_fn=shutil.rmtree,
+        )
+
+    @staticmethod
+    def _force_clean_dirs_local() -> None:
+        """Explicit operator recovery; ordinary deploy cleanup is target-scoped."""
+
+        cleanup_support.force_clean_dirs_local(
+            AGI,
+            process_iter_fn=psutil.process_iter,
+            getuser_fn=getpass.getuser,
+            getpid_fn=os.getpid,
+            rmtree_fn=shutil.rmtree,
             gettempdir_fn=gettempdir,
         )
 
@@ -680,6 +796,23 @@ class AGI:
             makedirs_fn=os.makedirs,
             remove_dir_forcefully_fn=AGI._remove_dir_forcefully,
         )
+
+    @staticmethod
+    async def _acquire_remote_target_lease(
+            ip: str,
+            *,
+            cmd_prefix: Optional[str] = None,
+    ) -> cleanup_support.RemoteTargetLease:
+        return await cleanup_support.acquire_remote_target_lease(
+            AGI,
+            ip,
+            cmd_prefix=cmd_prefix,
+            detect_export_cmd_fn=AGI._detect_export_cmd,  # ty: ignore[invalid-argument-type]
+        )
+
+    @staticmethod
+    async def _release_remote_target_leases() -> None:
+        await cleanup_support.release_remote_target_leases(AGI)
 
     @staticmethod
     async def _clean_nodes(scheduler_addr: Optional[str], force: bool = True) -> Set[str]:
@@ -729,6 +862,7 @@ class AGI:
             send_files_fn=AGI.send_files,
             kill_fn=AGI._kill,
             clean_dirs_fn=AGI._clean_dirs,
+            acquire_remote_target_lease_fn=AGI._acquire_remote_target_lease,
             mkdtemp_fn=mkdtemp,
             process_error_type=ProcessError,
             set_env_var_fn=AgiEnv.set_env_var,
@@ -810,16 +944,17 @@ class AGI:
             verbose: Optional[int] = None,
             **args: Any,
     ) -> Any:
-        return await entrypoint_support.install(
-            AGI,
-            env=env,
-            scheduler=scheduler,
-            workers=workers,
-            workers_data_path=workers_data_path,
-            modes_enabled=modes_enabled,
-            verbose=verbose,
-            args=args,
-        )
+        async with lifecycle_guard_support.LifecycleOperation(AGI, env, "install"):
+            return await entrypoint_support.install(
+                AGI,
+                env=env,
+                scheduler=scheduler,
+                workers=workers,
+                workers_data_path=workers_data_path,
+                modes_enabled=modes_enabled,
+                verbose=verbose,
+                args=args,
+            )
 
     @staticmethod
     async def update(
@@ -830,15 +965,19 @@ class AGI:
             verbose: Optional[int] = None,
             **args: Any,
     ) -> Any:
-        return await entrypoint_support.update(
-            AGI,
-            env=env,
-            scheduler=scheduler,
-            workers=workers,
-            modes_enabled=modes_enabled,
-            verbose=verbose,
-            args=args,
-        )
+        effective_env = env or AGI.env
+        if effective_env is None:
+            raise ValueError("env is required when AGI has not been initialised yet")
+        async with lifecycle_guard_support.LifecycleOperation(AGI, effective_env, "update"):
+            return await entrypoint_support.update(
+                AGI,
+                env=env,
+                scheduler=scheduler,
+                workers=workers,
+                modes_enabled=modes_enabled,
+                verbose=verbose,
+                args=args,
+            )
 
     @staticmethod
     async def get_distrib(
@@ -848,14 +987,15 @@ class AGI:
             verbose: int = 0,
             **args: Any,
     ) -> Any:
-        return await entrypoint_support.get_distrib(
-            AGI,
-            env=env,
-            scheduler=scheduler,
-            workers=workers,
-            verbose=verbose,
-            args=args,
-        )
+        async with lifecycle_guard_support.LifecycleOperation(AGI, env, "get-distrib"):
+            return await entrypoint_support.get_distrib(
+                AGI,
+                env=env,
+                scheduler=scheduler,
+                workers=workers,
+                verbose=verbose,
+                args=args,
+            )
 
     # Backward compatibility alias
     @staticmethod
@@ -866,14 +1006,15 @@ class AGI:
             verbose: int = 0,
             **args: Any,
     ) -> Any:
-        return await entrypoint_support.distribute(
-            AGI,
-            env=env,
-            scheduler=scheduler,
-            workers=workers,
-            verbose=verbose,
-            args=args,
-        )
+        async with lifecycle_guard_support.LifecycleOperation(AGI, env, "distribute"):
+            return await entrypoint_support.distribute(
+                AGI,
+                env=env,
+                scheduler=scheduler,
+                workers=workers,
+                verbose=verbose,
+                args=args,
+            )
 
     @staticmethod
     async def _start_scheduler(scheduler: Optional[str]) -> bool:

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/api/entrypoint_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/api/entrypoint_support.py
@@ -572,7 +572,7 @@ async def _launch_scheduler_process(
             "--dashboard-address",
             ":0",
             "--pid-file",
-            str(wenv_abs.parent / "dask_scheduler.pid"),
+            str(wenv_abs / "dask_scheduler.pid"),
         ]
         process_env = background_jobs_support.background_env_from_prefixes(local_prefix, dask_env)
         log.info("Starting dask scheduler locally: %s", shlex.join(local_cmd))
@@ -617,9 +617,32 @@ async def _launch_scheduler_process(
         "--dashboard-address",
         ":0",
         "--pid-file",
-        "dask_scheduler.pid",
+        wenv_rel / "dask_scheduler.pid",
     )
-    create_task_fn(agi_cls.exec_ssh_async(agi_cls._scheduler_ip, remote_scheduler_cmd))
+    scheduler_tasks = getattr(agi_cls, "_scheduler_launch_tasks", None)
+    if not isinstance(scheduler_tasks, set):
+        scheduler_tasks = set()
+        agi_cls._scheduler_launch_tasks = scheduler_tasks
+    scheduler_errors = getattr(agi_cls, "_scheduler_launch_errors", None)
+    if not isinstance(scheduler_errors, list):
+        scheduler_errors = []
+        agi_cls._scheduler_launch_errors = scheduler_errors
+
+    scheduler_task = create_task_fn(
+        agi_cls.exec_ssh_async(agi_cls._scheduler_ip, remote_scheduler_cmd)
+    )
+    scheduler_tasks.add(scheduler_task)
+
+    def _on_scheduler_launch_done(task: Any) -> None:
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc is not None:
+            scheduler_errors.append(exc)
+            log.error("Remote scheduler launch failed: %s", exc)
+
+    if hasattr(scheduler_task, "add_done_callback"):
+        scheduler_task.add_done_callback(_on_scheduler_launch_done)
 
 
 async def start_scheduler(
@@ -656,6 +679,9 @@ async def start_scheduler(
     )
 
     await sleep_fn(1)
+    scheduler_errors = getattr(agi_cls, "_scheduler_launch_errors", None) or []
+    if scheduler_errors:
+        raise scheduler_errors[0]
     try:
         client = await agi_cls._connect_scheduler_with_retry(
             agi_cls._scheduler,
@@ -669,6 +695,10 @@ async def start_scheduler(
         if isinstance(exc, RuntimeError):
             raise
         raise RuntimeError("Failed to instantiate Dask Client") from exc
+
+    scheduler_errors = getattr(agi_cls, "_scheduler_launch_errors", None) or []
+    if scheduler_errors:
+        raise scheduler_errors[0]
 
     agi_cls._install_done = True
     if agi_cls._worker_init_error:

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_editable_install_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_editable_install_support.py
@@ -11,6 +11,7 @@ from typing import Any
 from urllib.parse import unquote, urlparse
 
 from agi_cluster.agi_distributor.deployment_stage_cache_support import (
+    _atomic_write_json,
     _deploy_stage_file_fingerprint,
 )
 from agi_cluster.agi_distributor.deployment_venv_support import (
@@ -137,13 +138,7 @@ def _write_editable_install_cache(path: Path, state: dict[str, Any]) -> None:
         else {},
     }
     try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        tmp_path = path.with_name(f"{path.name}.tmp")
-        tmp_path.write_text(
-            json.dumps(payload, indent=2, sort_keys=True) + "\n",
-            encoding="utf-8",
-        )
-        tmp_path.replace(path)
+        _atomic_write_json(path, payload)
     except OSError:
         return
 

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_prepare_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_prepare_support.py
@@ -241,6 +241,7 @@ async def prepare_cluster_env(
     send_files_fn: Callable[..., Any],
     kill_fn: Callable[..., Any],
     clean_dirs_fn: Callable[..., Any],
+    acquire_remote_target_lease_fn: Optional[Callable[..., Any]] = None,
     mkdtemp_fn: Callable[..., str] = mkdtemp,
     process_error_type: type[BaseException] = ProcessError,
     set_env_var_fn: Callable[..., Any] = AgiEnv.set_env_var,
@@ -415,6 +416,8 @@ async def prepare_cluster_env(
 
         await send_files_fn(env, ip, [resolve_worker_cli_path(env)], wenv_rel.parent)
 
+        if acquire_remote_target_lease_fn is not None:
+            await acquire_remote_target_lease_fn(ip, cmd_prefix=cmd_prefix)
         await kill_fn(ip, force=True)
         await clean_dirs_fn(ip)
 

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_remote_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_remote_support.py
@@ -19,6 +19,7 @@ from agi_cluster.agi_distributor.deployment.deployment_build_support import (
 )
 from agi_env import AgiEnv
 from agi_env.cython_build_config import cython_build_overlay_specs
+from agi_env.env_config_support import build_remote_env_update_script
 from agi_env.shares.share_runtime_support import (
     validate_local_share_root,
     validate_worker_share_root,
@@ -466,20 +467,16 @@ def _remote_env_update_command(remote_share: str, workflow_data_root: str | None
     # app outputs through the active share mode, so the share path and cluster
     # flag must be written together; Dask workers also need worker layout flags
     # because AgiEnv reads those from the persisted .env file during startup.
-    source_line = "IS_SOURCE_ENV='0'"
-    worker_line = "IS_WORKER_ENV='1'"
-    enabled_line = "AGI_CLUSTER_ENABLED='1'"
-    share_line = f"AGI_CLUSTER_SHARE={remote_share!r}"
-    workflow_root_line = f"AGILAB_WORKFLOW_DATA_ROOT={(workflow_data_root or remote_share)!r}"
-    return (
-        'mkdir -p "$HOME/.agilab" && touch "$HOME/.agilab/.env" && '
-        "{ grep -Ev '^(IS_SOURCE_ENV|IS_WORKER_ENV|AGI_CLUSTER_ENABLED|AGI_CLUSTER_SHARE|AGILAB_WORKFLOW_DATA_ROOT)=' "
-        "\"$HOME/.agilab/.env\" || true; "
-        f"printf '%s\\n' {quote(source_line)} {quote(worker_line)} "
-        f"{quote(enabled_line)} {quote(share_line)} {quote(workflow_root_line)}; }} "
-        "> \"$HOME/.agilab/.env.tmp\" && "
-        'mv "$HOME/.agilab/.env.tmp" "$HOME/.agilab/.env"'
+    script = build_remote_env_update_script(
+        {
+            "IS_SOURCE_ENV": "0",
+            "IS_WORKER_ENV": "1",
+            "AGI_CLUSTER_ENABLED": "1",
+            "AGI_CLUSTER_SHARE": remote_share,
+            "AGILAB_WORKFLOW_DATA_ROOT": workflow_data_root or remote_share,
+        }
     )
+    return "python3 - <<'PY'\n" + script + "PY"
 
 
 def _remote_share_mount_command(

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_stage_cache_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_stage_cache_support.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import tempfile
 from pathlib import Path
 from typing import Any, Callable
 
@@ -15,6 +16,29 @@ DEPLOY_TIMING_TRACE_SCHEMA = "agilab-deploy-timing-v1"
 DEPLOY_STAGE_CACHE_HASH_LIMIT = 8 * 1024 * 1024
 DEPLOY_COPY_STAMP_SCHEMA = "agilab-deploy-copy-stamp-v1"
 DEPLOY_COPY_STAMP_FILENAME = ".agilab-copy-stamp.json"
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    """Publish JSON through a unique same-directory temporary file."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            stream.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(tmp_path, path)
+    finally:
+        try:
+            tmp_path.unlink()
+        except FileNotFoundError:
+            pass
 
 def _env_value(envars: Any, key: str) -> str | None:
     raw = os.environ.get(key)
@@ -65,13 +89,7 @@ def _write_deploy_stage_cache(path: Path, state: dict[str, Any]) -> None:
         "stages": state.get("stages") if isinstance(state.get("stages"), dict) else {},
     }
     try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        tmp_path = path.with_name(f"{path.name}.tmp")
-        tmp_path.write_text(
-            json.dumps(payload, indent=2, sort_keys=True) + "\n",
-            encoding="utf-8",
-        )
-        tmp_path.replace(path)
+        _atomic_write_json(path, payload)
     except OSError:
         return
 
@@ -96,13 +114,7 @@ def _write_deploy_timing_trace(
         "results": results,
     }
     try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        tmp_path = path.with_name(f"{path.name}.tmp")
-        tmp_path.write_text(
-            json.dumps(payload, indent=2, sort_keys=True) + "\n",
-            encoding="utf-8",
-        )
-        tmp_path.replace(path)
+        _atomic_write_json(path, payload)
     except OSError:
         return
 
@@ -242,13 +254,7 @@ def _deploy_copy_stamp_matches(
 
 def _write_deploy_copy_stamp(stamp_path: Path, payload: dict[str, Any]) -> None:
     try:
-        stamp_path.parent.mkdir(parents=True, exist_ok=True)
-        tmp_path = stamp_path.with_name(f"{stamp_path.name}.tmp")
-        tmp_path.write_text(
-            json.dumps(payload, indent=2, sort_keys=True) + "\n",
-            encoding="utf-8",
-        )
-        tmp_path.replace(stamp_path)
+        _atomic_write_json(stamp_path, payload)
     except OSError:
         return
 

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/lifecycle_guard_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/lifecycle_guard_support.py
@@ -1,0 +1,10 @@
+"""Compatibility shim for AGI lifecycle guard helpers."""
+
+from __future__ import annotations
+
+from agi_cluster.agi_distributor.compat.module_shim import activate_compat_module as _activate_compat_module
+
+_TARGET_MODULE = "agi_cluster.agi_distributor.runtime.lifecycle_guard_support"
+_module = _activate_compat_module(__name__, _TARGET_MODULE)
+if _module is not None:
+    globals().update(_module.__dict__)

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime/background_jobs_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime/background_jobs_support.py
@@ -1,12 +1,15 @@
 import os
+import secrets
 import shlex
 import subprocess
+import time
 from pathlib import Path, PurePosixPath
 from types import SimpleNamespace
 from typing import Mapping, Protocol, Sequence, cast
 
 _NORMALIZE_CWD_EXCEPTIONS = (OSError, RuntimeError, TypeError)
 _SHELL_METACHARS = frozenset(";&|<>\n\r`$")
+BACKGROUND_JOB_TOKEN_ENV = "AGILAB_BACKGROUND_JOB_TOKEN"
 
 
 class _ProcessLike(Protocol):
@@ -17,10 +20,20 @@ class _ProcessLike(Protocol):
 class BackgroundProcessJob:
     """Minimal job record for detached subprocess launches."""
 
-    def __init__(self, process: _ProcessLike):
+    def __init__(
+        self,
+        process: _ProcessLike,
+        *,
+        ownership_token: str | None = None,
+        process_group_id: int | None = None,
+        ownership_started_at: float | None = None,
+    ) -> None:
         self.process = process
         self.result = process
         self.num: int | None = None
+        self.ownership_token = ownership_token
+        self.process_group_id = process_group_id
+        self.ownership_started_at = ownership_started_at
 
 
 class BackgroundProcessManager:
@@ -32,6 +45,9 @@ class BackgroundProcessManager:
         self.running: list[BackgroundProcessJob] = []
         self.completed: list[BackgroundProcessJob] = []
         self.dead: list[BackgroundProcessJob] = []
+        # Keep launch ownership independently from transient execution state.
+        # A wrapper may exit while a descendant in its process group survives.
+        self.owned: list[BackgroundProcessJob] = []
 
     @staticmethod
     def _normalize_cwd(cwd: str | Path | None) -> str | None:
@@ -77,20 +93,41 @@ class BackgroundProcessManager:
         process_env = os.environ.copy()
         if env:
             process_env.update({str(key): str(value) for key, value in env.items() if value is not None})
+        ownership_token = secrets.token_hex(16)
+        ownership_started_at = time.time()
+        process_env[BACKGROUND_JOB_TOKEN_ENV] = ownership_token
+        process_group_options: dict[str, object]
+        if os.name == "nt":
+            process_group_options = {
+                "creationflags": int(getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0))
+            }
+        else:
+            process_group_options = {"start_new_session": True}
         proc = cast(
             _ProcessLike,
             subprocess.Popen(
                 self._command_argv(cmd),
                 shell=False,
                 cwd=self._normalize_cwd(cwd),
-                start_new_session=True,
                 env=process_env,
+                **process_group_options,
             ),
         )
-        job = BackgroundProcessJob(proc)
+        process_group_id = None
+        if os.name != "nt":
+            process_pid = getattr(proc, "pid", None)
+            if isinstance(process_pid, int) and process_pid > 0:
+                process_group_id = process_pid
+        job = BackgroundProcessJob(
+            proc,
+            ownership_token=ownership_token,
+            process_group_id=process_group_id,
+            ownership_started_at=ownership_started_at,
+        )
         job.num = self._current_job_id
         self._current_job_id += 1
         self.running.append(job)
+        self.owned.append(job)
         self.all[job.num] = job
         return job
 

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime/cleanup_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime/cleanup_support.py
@@ -1,5 +1,7 @@
 import asyncio
+import contextlib
 import getpass
+import json
 import logging
 import os
 import runpy
@@ -9,19 +11,46 @@ import socket
 import stat
 import sys
 import time
+from dataclasses import dataclass
 from pathlib import Path
 from tempfile import gettempdir
 from typing import Any, Awaitable, Callable, Optional
 
 import psutil
+from asyncssh.process import ProcessError
 
 from agi_cluster.agi_distributor.api.worker_cli_support import resolve_worker_cli_path
 from agi_env import AgiEnv
+from agi_env.runtime.destructive_path_support import (
+    safe_destructive_path,
+    safe_worker_runtime_cleanup_path,
+)
 
 
 logger = logging.getLogger(__name__)
 REMOVE_DIR_RETRY_EXCEPTIONS = (OSError, shutil.Error)
 CMD_PREFIX_LOOKUP_EXCEPTIONS = (ConnectionError, OSError, RuntimeError, TimeoutError)
+_DASK_CMD_MARKERS = (
+    "dask-scheduler",
+    "dask-worker",
+    "dask scheduler",
+    "dask worker",
+    "dask_scheduler",
+    "dask_worker",
+    "distributed.cli",
+    "distributed.nanny",
+    "distributed.worker",
+)
+
+
+@dataclass(frozen=True)
+class RemoteTargetLease:
+    ip: str
+    target: Path
+    token: str
+    operation: str
+    cmd_prefix: str
+    recovery_tokens: tuple[str, ...] = ()
 
 
 def _remote_arg(value: Any) -> str:
@@ -32,6 +61,37 @@ def _remote_arg(value: Any) -> str:
 
 def _remote_words(value: Any) -> str:
     return " ".join(shlex.quote(part) for part in shlex.split(str(value), posix=True))
+
+
+def _remote_target_key(value: Any) -> str:
+    return os.path.normcase(os.path.normpath(str(value))).replace("\\", "/")
+
+
+def _current_remote_lifecycle_token(agi_cls: Any) -> str:
+    return str(
+        getattr(agi_cls, "_lifecycle_remote_token", "")
+        or getattr(agi_cls, "_lifecycle_call_token", "")
+        or ""
+    )
+
+
+def _validate_cached_remote_lease(
+    agi_cls: Any,
+    ip: str,
+    lease: RemoteTargetLease,
+) -> None:
+    expected_token = _current_remote_lifecycle_token(agi_cls)
+    expected_target = Path(agi_cls.env.wenv_rel)
+    if (
+        not expected_token
+        or lease.ip != ip
+        or lease.token != expected_token
+        or _remote_target_key(lease.target) != _remote_target_key(expected_target)
+    ):
+        raise RuntimeError(
+            f"Cached remote target lease for {ip} does not match the active "
+            "lifecycle token and target"
+        )
 
 
 async def _remote_cmd_prefix(
@@ -82,11 +142,53 @@ def remove_dir_forcefully(
             raise
 
 
+def _snapshot_pid_evidence(pid_files: list[Path]) -> dict[Path, bytes]:
+    evidence: dict[Path, bytes] = {}
+    for pid_file in pid_files:
+        try:
+            evidence[pid_file] = pid_file.read_bytes()
+        except FileNotFoundError:
+            continue
+        except OSError as exc:
+            raise RuntimeError(
+                f"Cannot preserve PID ownership evidence before cleanup: {pid_file}: {exc}"
+            ) from exc
+    return evidence
+
+
+def _restore_pid_evidence(evidence: dict[Path, bytes]) -> None:
+    restore_errors: list[str] = []
+    for pid_file, payload in evidence.items():
+        if pid_file.exists():
+            continue
+        tmp_path = pid_file.with_name(
+            f".{pid_file.name}.restore-{os.getpid()}-{time.time_ns()}.tmp"
+        )
+        try:
+            pid_file.parent.mkdir(parents=True, exist_ok=True)
+            with tmp_path.open("xb") as stream:
+                stream.write(payload)
+                stream.flush()
+                os.fsync(stream.fileno())
+            os.replace(tmp_path, pid_file)
+        except OSError as exc:
+            restore_errors.append(f"{pid_file}: {exc}")
+        finally:
+            with contextlib.suppress(OSError):
+                tmp_path.unlink()
+    if restore_errors:
+        raise RuntimeError(
+            "Worker cleanup failed and PID ownership evidence could not be restored: "
+            + "; ".join(restore_errors)
+        )
+
+
 async def kill_processes(
     agi_cls: Any,
     ip: Optional[str] = None,
     current_pid: Optional[int] = None,
     force: bool = True,
+    force_scan: bool = False,
     *,
     gethostbyname_fn: Callable[[str], str] = socket.gethostbyname,
     run_fn: Callable[[str, str], Awaitable[Any]] = AgiEnv.run,
@@ -103,18 +205,6 @@ async def kill_processes(
     ip = ip or localhost
     current_pid = current_pid or os.getpid()
 
-    for pid_file in sorted(path_cls(env.wenv_abs.parent).glob("*.pid"), key=lambda candidate: candidate.name):
-        try:
-            pid = int(pid_file.read_text().strip())
-            if pid == current_pid:
-                continue
-        except (OSError, ValueError):
-            log.warning("Could not read PID from %s, skipping", pid_file)
-        try:
-            pid_file.unlink()
-        except OSError as exc:
-            log.warning("Failed to remove pid file %s: %s", pid_file, exc)
-
     cmds: list[str] = []
     cli_rel = env.wenv_rel.parent / "cli.py"
     cli_abs = env.wenv_abs.parent / cli_rel.name
@@ -129,9 +219,18 @@ async def kill_processes(
             copy_fn(resolve_worker_cli_path(env), cli_abs)
         if force:
             exclude_arg = f" {_remote_arg(current_pid)}" if current_pid else ""
-            cmds.append(f"{kill_prefix} {_remote_arg(cli_abs)} kill{exclude_arg}")
+            kill_command = "kill-force" if force_scan else "kill"
+            target_arg = "" if force_scan else f" {_remote_arg(env.wenv_abs)}"
+            cmds.append(
+                f"{kill_prefix} {_remote_arg(cli_abs)} {kill_command}"
+                f"{target_arg}{exclude_arg}"
+            )
     elif force:
-        cmds.append(f"{kill_prefix} {_remote_arg(cli_rel)} kill")
+        kill_command = "kill-force" if force_scan else "kill"
+        target_arg = "" if force_scan else f" {_remote_arg(env.wenv_rel)}"
+        cmds.append(
+            f"{kill_prefix} {_remote_arg(cli_rel)} {kill_command}{target_arg}"
+        )
 
     last_res = None
     for cmd in cmds:
@@ -191,7 +290,320 @@ def _normalized_process_username(username: Any) -> str:
     return text.rsplit("\\", 1)[-1]
 
 
+def _is_dask_command(cmdline: Any) -> bool:
+    text = " ".join(str(part) for part in (cmdline or [])).lower()
+    return any(marker in text for marker in _DASK_CMD_MARKERS)
+
+
+def _owned_pid_files(env: Any, *, path_cls: type[Path] = Path) -> list[Path]:
+    wenv_abs = path_cls(env.wenv_abs).expanduser().resolve(strict=False)
+    candidates: set[Path] = set()
+    for root in (wenv_abs.parent, wenv_abs):
+        candidates.update(root.glob("dask_scheduler.pid"))
+        candidates.update(root.glob("dask_worker*.pid"))
+    return sorted(candidates, key=lambda candidate: candidate.as_posix())
+
+
+def _pid_file_is_inside_target(pid_file: Path, wenv_abs: Path) -> bool:
+    try:
+        pid_file.resolve(strict=False).relative_to(wenv_abs)
+    except (OSError, ValueError):
+        return False
+    return True
+
+
+def _validated_local_worker_runtime_target(
+    env: Any,
+    *,
+    path_cls: type[Path] = Path,
+) -> Path:
+    home_value = getattr(env, "home_abs", None)
+    if home_value is None:
+        raise RuntimeError(
+            "Cannot clean AGILAB worker environment without its trusted home root"
+        )
+    home_path = path_cls(home_value).expanduser().resolve(strict=False)
+    try:
+        return safe_worker_runtime_cleanup_path(
+            env.wenv_abs,
+            roots=(home_path / "wenv",),
+            home_path=home_path,
+            cwd_path=path_cls.cwd(),
+        )
+    except (OSError, TypeError, ValueError) as exc:
+        raise RuntimeError(
+            f"Refusing unsafe AGILAB worker environment cleanup target: {exc}"
+        ) from exc
+
+
+def _read_pid_record(pid_file: Path) -> tuple[int, float | None]:
+    text = pid_file.read_text(encoding="utf-8").strip()
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError:
+        return int(text), None
+    if isinstance(payload, int):
+        return int(payload), None
+    if not isinstance(payload, dict):
+        raise ValueError("PID ownership record must be an integer or JSON object")
+    pid = int(payload["pid"])
+    process_start_time = payload.get("process_start_time")
+    return pid, float(process_start_time) if process_start_time not in (None, "") else None
+
+
+def _command_belongs_to_target(
+    cmdline: Any,
+    *,
+    pid_file: Path | None,
+    wenv_abs: Path,
+    wenv_display: Path | None = None,
+) -> bool:
+    """Check parsed path arguments without unsafe prefix/substring matches."""
+
+    if isinstance(cmdline, str):
+        try:
+            parts = shlex.split(cmdline, posix=os.name != "nt")
+        except ValueError:
+            parts = [cmdline]
+    else:
+        parts = [str(part) for part in (cmdline or [])]
+
+    owned_pid = (
+        os.path.normcase(os.path.normpath(str(pid_file.expanduser().resolve(strict=False))))
+        if pid_file is not None
+        else None
+    )
+    owned_roots = {
+        os.path.normcase(os.path.normpath(str(wenv_abs.expanduser().resolve(strict=False))))
+    }
+    if wenv_display is not None:
+        displayed = wenv_display.expanduser()
+        if displayed.is_absolute():
+            owned_roots.add(os.path.normcase(os.path.normpath(str(displayed))))
+
+    candidates: list[str] = []
+    for part in parts:
+        candidates.append(part)
+        if "=" in part:
+            option, value = part.split("=", 1)
+            if option.startswith("-") and value:
+                candidates.append(value)
+
+    for value in candidates:
+        value = value.strip().strip("\"'")
+        if not value or "://" in value:
+            continue
+        candidate_path = Path(value).expanduser()
+        if not candidate_path.is_absolute():
+            continue
+        candidate = os.path.normcase(
+            os.path.normpath(str(candidate_path.resolve(strict=False)))
+        )
+        if owned_pid is not None and candidate == owned_pid:
+            return True
+        for root in owned_roots:
+            try:
+                if os.path.commonpath((candidate, root)) == root:
+                    return True
+            except ValueError:
+                # Paths on different Windows drives cannot establish ownership.
+                continue
+    return False
+
+
+def _process_snapshot(process_iter_fn: Callable[..., Any]) -> dict[int, Any]:
+    processes: dict[int, Any] = {}
+    for proc in process_iter_fn(["pid", "username", "cmdline", "create_time"]):
+        try:
+            processes[int(proc.info["pid"])] = proc
+        except (KeyError, TypeError, ValueError, psutil.NoSuchProcess):
+            continue
+    return processes
+
+
+def _target_dask_pids(
+    processes: dict[int, Any],
+    *,
+    self_pid: int,
+    wenv_abs: Path,
+    wenv_display: Path,
+) -> list[int]:
+    active: list[int] = []
+    for pid, proc in processes.items():
+        if pid == self_pid:
+            continue
+        try:
+            cmdline = proc.info.get("cmdline")
+            if _is_dask_command(cmdline) and _command_belongs_to_target(
+                cmdline,
+                pid_file=None,
+                wenv_abs=wenv_abs,
+                wenv_display=wenv_display,
+            ):
+                active.append(pid)
+        except (AttributeError, psutil.NoSuchProcess):
+            continue
+    return sorted(active)
+
+
 def clean_dirs_local(
+    agi_cls: Any,
+    *,
+    process_iter_fn: Callable[..., Any] = psutil.process_iter,
+    getuser_fn: Callable[[], str] = getpass.getuser,
+    getpid_fn: Callable[[], int] = os.getpid,
+    rmtree_fn: Callable[..., Any] = shutil.rmtree,
+    sleep_fn: Callable[[float], Any] = time.sleep,
+    path_cls: type[Path] = Path,
+    process_wait_timeout: float = 3.0,
+) -> None:
+    """Stop only Dask processes proven to belong to this target, then clean it.
+
+    The lifecycle lease serializes every target sharing this runtime parent.
+    PID files narrow process ownership further and command/start-time
+    validation protects against stale PID reuse.  Ordinary cleanup
+    intentionally leaves the shared Dask scratch root and unrelated Dask
+    processes untouched.
+    """
+
+    me = getuser_fn()
+    self_pid = getpid_fn()
+    wenv_display = path_cls(agi_cls.env.wenv_abs).expanduser()
+    wenv_abs = _validated_local_worker_runtime_target(
+        agi_cls.env,
+        path_cls=path_cls,
+    )
+    processes = _process_snapshot(process_iter_fn)
+
+    blocked_pids: list[int] = []
+    killed_processes: list[tuple[int, Any]] = []
+    pid_files = _owned_pid_files(agi_cls.env, path_cls=path_cls)
+    removable_pid_files: set[Path] = set()
+    for pid_file in pid_files:
+        target_local_evidence = _pid_file_is_inside_target(pid_file, wenv_abs)
+        try:
+            pid, expected_start = _read_pid_record(pid_file)
+        except (OSError, KeyError, TypeError, ValueError):
+            if target_local_evidence:
+                removable_pid_files.add(pid_file)
+            continue
+        if pid == self_pid:
+            continue
+        proc = processes.get(pid)
+        if proc is None:
+            # No live incarnation owns this record, so shared-parent legacy
+            # evidence is stale and safe to remove after target deletion.
+            removable_pid_files.add(pid_file)
+            continue
+        info = proc.info
+        try:
+            actual_start = info.get("create_time")
+            same_start = expected_start is None or (
+                actual_start not in (None, "")
+                and abs(float(actual_start) - expected_start) <= 1.0
+            )
+        except (TypeError, ValueError):
+            same_start = False
+        if expected_start is not None and not same_start:
+            # The PID was reused by another process generation.  The record is
+            # stale even when the newer process remains live.
+            removable_pid_files.add(pid_file)
+        owned = (
+            bool(info.get("username"))
+            and _normalized_process_username(info.get("username")) == me
+            and _is_dask_command(info.get("cmdline"))
+            and _command_belongs_to_target(
+                info.get("cmdline"),
+                # A legacy PID file in the shared parent is not itself target
+                # identity: a live sibling can reference the same parent.
+                pid_file=pid_file if target_local_evidence else None,
+                wenv_abs=wenv_abs,
+                wenv_display=wenv_display,
+            )
+            and same_start
+        )
+        if owned:
+            removable_pid_files.add(pid_file)
+            try:
+                proc.kill()
+                killed_processes.append((pid, proc))
+            except psutil.NoSuchProcess:
+                pass
+            except (psutil.AccessDenied, OSError):
+                blocked_pids.append(pid)
+                continue
+
+    # A killed process can retain files briefly, especially on Windows. Wait a
+    # bounded amount, then refresh the process table before deleting evidence.
+    for pid, proc in killed_processes:
+        wait = getattr(proc, "wait", None)
+        if not callable(wait):
+            continue
+        try:
+            wait(timeout=process_wait_timeout)
+        except psutil.NoSuchProcess:
+            pass
+        except (psutil.TimeoutExpired, psutil.AccessDenied, OSError):
+            blocked_pids.append(pid)
+
+    if blocked_pids:
+        raise RuntimeError(
+            "Cannot clean AGILAB worker environment while owned Dask process(es) "
+            f"remain active: {sorted(blocked_pids)}"
+        )
+
+    # PID files are kill authorization, not permission to erase a live target.
+    # Fail closed when any Dask process still references this exact environment,
+    # including a process whose PID file was lost or stale.
+    residual_pids = _target_dask_pids(
+        _process_snapshot(process_iter_fn),
+        self_pid=self_pid,
+        wenv_abs=wenv_abs,
+        wenv_display=wenv_display,
+    )
+    if residual_pids:
+        raise RuntimeError(
+            "Cannot clean AGILAB worker environment while Dask process(es) "
+            f"still reference the target: {residual_pids}"
+        )
+
+    # Only a failed recursive deletion can remove target-local evidence. Shared
+    # parent records belong to independent sibling sessions and may disappear
+    # legitimately while this cleanup is in flight; restoring those records
+    # would resurrect stale ownership evidence.
+    target_local_pid_files = [
+        pid_file
+        for pid_file in pid_files
+        if _pid_file_is_inside_target(pid_file, wenv_abs)
+    ]
+    pid_evidence = _snapshot_pid_evidence(target_local_pid_files)
+    try:
+        if wenv_abs.exists():
+            remove_dir_forcefully(
+                str(wenv_abs),
+                rmtree_fn=rmtree_fn,
+                sleep_fn=sleep_fn,
+            )
+        if wenv_abs.exists():
+            raise OSError(f"worker environment still exists after deletion: {wenv_abs}")
+    except (OSError, shutil.Error, TypeError) as exc:
+        try:
+            _restore_pid_evidence(pid_evidence)
+        except RuntimeError as restore_exc:
+            raise RuntimeError(str(restore_exc)) from exc
+        raise RuntimeError(
+            f"Could not completely delete AGILAB worker environment {wenv_abs}; "
+            "PID ownership evidence was retained"
+        ) from exc
+
+    # Shared-parent legacy evidence is outside ``wenv_abs`` and is removed only
+    # after the exact target directory has been deleted and verified absent.
+    for pid_file in removable_pid_files:
+        with contextlib.suppress(FileNotFoundError):
+            pid_file.unlink()
+
+
+def force_clean_dirs_local(
     agi_cls: Any,
     *,
     process_iter_fn: Callable[..., Any] = psutil.process_iter,
@@ -200,32 +612,155 @@ def clean_dirs_local(
     rmtree_fn: Callable[..., Any] = shutil.rmtree,
     gettempdir_fn: Callable[[], str] = gettempdir,
 ) -> None:
+    """Operator-only broad cleanup for recovering an abandoned Dask host."""
+
     me = getuser_fn()
     self_pid = getpid_fn()
+    wenv_abs = _validated_local_worker_runtime_target(agi_cls.env)
     for proc in process_iter_fn(["pid", "username", "cmdline"]):
         try:
             if (
-                proc.info["username"]
-                # Exact match (after DOMAIN\ normalization): a suffix match
-                # would let user 'ed' kill processes owned by 'fred'.
-                and _normalized_process_username(proc.info["username"]) == me
-                and proc.info["pid"]
-                and proc.info["pid"] != self_pid
-                and proc.info["cmdline"]
-                and any("dask" in part.lower() for part in proc.info["cmdline"])
+                proc.info.get("username")
+                and _normalized_process_username(proc.info.get("username")) == me
+                and proc.info.get("pid") != self_pid
+                and _is_dask_command(proc.info.get("cmdline"))
             ):
                 proc.kill()
         except (psutil.NoSuchProcess, psutil.AccessDenied):
             pass
-
-    for directory in [
-        f"{gettempdir_fn()}/dask-scratch-space",
-        f"{agi_cls.env.wenv_abs}",
-    ]:
+    temp_root = Path(gettempdir_fn()).expanduser().resolve(strict=False)
+    try:
+        scratch = safe_destructive_path(
+            temp_root / "dask-scratch-space",
+            roots=(temp_root,),
+            label="Dask scratch cleanup",
+        )
+    except (OSError, TypeError, ValueError) as exc:
+        raise RuntimeError(f"Refusing unsafe Dask scratch cleanup target: {exc}") from exc
+    for directory in (str(scratch), str(wenv_abs)):
         try:
             rmtree_fn(directory, ignore_errors=True)
         except (OSError, TypeError):
             pass
+
+
+def _remote_lease_command(
+    env: Any,
+    lease: RemoteTargetLease,
+    action: str,
+) -> str:
+    cli = env.wenv_rel.parent / "cli.py"
+    if action == "acquire" and lease.recovery_tokens:
+        command = "target-lease-recover"
+        suffix = (
+            f" {_remote_arg(','.join(lease.recovery_tokens))}"
+            f" {_remote_arg(lease.operation)}"
+        )
+    else:
+        command = f"target-lease-{action}"
+        suffix = (
+            f" {_remote_arg(lease.operation)}" if action == "acquire" else ""
+        )
+    return (
+        f"{lease.cmd_prefix}{_remote_words(env.uv)} run --no-sync "
+        f"-p {_remote_arg(env.python_version)} python {_remote_arg(cli)} "
+        f"{command} {_remote_arg(lease.target)} {_remote_arg(lease.token)}{suffix}"
+    )
+
+
+async def acquire_remote_target_lease(
+    agi_cls: Any,
+    ip: str,
+    *,
+    cmd_prefix: str | None = None,
+    detect_export_cmd_fn: Optional[Callable[[str], Awaitable[str]]] = None,
+) -> RemoteTargetLease:
+    """Hold a worker-host lease until the surrounding lifecycle operation exits."""
+
+    env = agi_cls.env
+    token = _current_remote_lifecycle_token(agi_cls)
+    raw_recovery_tokens = getattr(
+        agi_cls,
+        "_lifecycle_remote_recovery_tokens",
+        (),
+    )
+    recovery_tokens = tuple(
+        dict.fromkeys(
+            str(item)
+            for item in raw_recovery_tokens
+            if isinstance(item, str) and item
+        )
+    )
+    operation = str(
+        getattr(agi_cls, "_lifecycle_call_operation", "unknown") or "unknown"
+    )
+    if not token:
+        raise RuntimeError("Remote target cleanup/start requires an active lifecycle token")
+
+    leases = getattr(agi_cls, "_remote_target_leases", None)
+    if not isinstance(leases, dict):
+        leases = {}
+        setattr(agi_cls, "_remote_target_leases", leases)
+    existing = leases.get(ip)
+    if existing is not None:
+        if not isinstance(existing, RemoteTargetLease):
+            raise RuntimeError(f"Cached remote target lease evidence for {ip} is invalid")
+        _validate_cached_remote_lease(agi_cls, ip, existing)
+        return existing
+
+    if cmd_prefix is None:
+        cmd_prefix = await _remote_cmd_prefix(
+            env,
+            ip,
+            detect_export_cmd_fn=detect_export_cmd_fn,
+        )
+    lease = RemoteTargetLease(
+        ip=ip,
+        target=Path(env.wenv_rel),
+        token=token,
+        operation=operation,
+        cmd_prefix=str(cmd_prefix or ""),
+        recovery_tokens=recovery_tokens,
+    )
+    # Publish local evidence before the SSH command. If transport or worker
+    # publication fails after claiming the remote directory, lifecycle exit can
+    # still issue exact-token release and retain the local lease on uncertainty.
+    leases[ip] = lease
+    await agi_cls.exec_ssh(ip, _remote_lease_command(env, lease, "acquire"))
+    return lease
+
+
+async def release_remote_target_leases(agi_cls: Any) -> None:
+    """Release verified remote lease generations, retaining failed evidence."""
+
+    leases = getattr(agi_cls, "_remote_target_leases", None)
+    if not isinstance(leases, dict) or not leases:
+        return
+    env = agi_cls.env
+    failures: list[str] = []
+    for ip, lease in sorted(list(leases.items())):
+        if not isinstance(lease, RemoteTargetLease):
+            failures.append(f"{ip}: invalid local lease evidence")
+            continue
+        try:
+            await agi_cls.exec_ssh(
+                ip,
+                _remote_lease_command(env, lease, "release"),
+            )
+        except (
+            ConnectionError,
+            OSError,
+            ProcessError,
+            RuntimeError,
+            TimeoutError,
+        ) as exc:
+            failures.append(f"{ip}: {exc}")
+        else:
+            leases.pop(ip, None)
+    if failures:
+        raise RuntimeError(
+            "Could not prove remote target lease release: " + "; ".join(failures)
+        )
 
 
 async def clean_dirs(
@@ -237,17 +772,33 @@ async def clean_dirs(
 ) -> None:
     env = agi_cls.env
     uv = env.uv
-    wenv_abs = env.wenv_abs
-    if wenv_abs.exists():
-        remover = remove_dir_forcefully_fn or agi_cls._remove_dir_forcefully
-        remover(str(wenv_abs))
-    makedirs_fn(wenv_abs / "src", exist_ok=True)
+    # This helper is invoked once per remote node, often concurrently.  It
+    # must never delete/recreate the manager's local wenv from each remote
+    # task; local cleanup is owned by the single lifecycle operation.
     cmd_prefix = env.envars.get(f"{ip}_CMD_PREFIX", "")
     wenv = env.wenv_rel
     cli = wenv.parent / "cli.py"
+    leases = getattr(agi_cls, "_remote_target_leases", {})
+    lease = leases.get(ip) if isinstance(leases, dict) else None
+    if lease is not None:
+        if not isinstance(lease, RemoteTargetLease):
+            raise RuntimeError(f"Cached remote target lease evidence for {ip} is invalid")
+        _validate_cached_remote_lease(agi_cls, ip, lease)
+    acquire_remote_lease = getattr(agi_cls, "_acquire_remote_target_lease", None)
+    if (
+        not isinstance(lease, RemoteTargetLease)
+        and callable(acquire_remote_lease)
+        and getattr(agi_cls, "_lifecycle_call_token", None)
+    ):
+        lease = await acquire_remote_lease(ip, cmd_prefix=cmd_prefix)
+    token_arg = (
+        f" {_remote_arg(lease.token)}"
+        if isinstance(lease, RemoteTargetLease)
+        else ""
+    )
     cmd = (
         f"{cmd_prefix}{_remote_words(uv)} run --no-sync "
         f"-p {_remote_arg(env.python_version)} python "
-        f"{_remote_arg(cli)} clean {_remote_arg(wenv)}"
+        f"{_remote_arg(cli)} clean {_remote_arg(wenv)}{token_arg}"
     )
     await agi_cls.exec_ssh(ip, cmd)

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime/lifecycle_guard_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime/lifecycle_guard_support.py
@@ -1,0 +1,806 @@
+"""Fail-fast lifecycle serialization and shared-runtime deployment leases.
+
+``AGI`` still exposes a class-based compatibility API whose mutable fields are
+shared by every caller in the interpreter.  Worker targets under one runtime
+parent also share scheduler and remote-worker PID files.  This module makes
+that boundary explicit: one lifecycle operation may mutate the class at a
+time, and one process may own that shared runtime parent at a time.  The
+in-process guard uses a plain thread lock rather than an asyncio primitive so
+it remains safe across event loops and worker threads.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+import shutil
+import socket
+import threading
+import tempfile
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import psutil
+
+
+LEASE_SCHEMA = "agilab-target-operation-lease-v1"
+_PROCESS_START_TOLERANCE_SECONDS = 1.0
+_STATE_LOCK_CREATION_LOCK = threading.Lock()
+
+
+class LifecycleBusyError(RuntimeError):
+    """Raised when another lifecycle call owns shared AGI runtime state."""
+
+
+def _process_start_time(
+    pid: int,
+    *,
+    process_factory: Any = psutil.Process,
+) -> float | None:
+    try:
+        return float(process_factory(pid).create_time())
+    except (psutil.Error, OSError, TypeError, ValueError):
+        return None
+
+
+def _owner_is_live(
+    payload: dict[str, Any],
+    *,
+    process_factory: Any = psutil.Process,
+) -> bool:
+    owner_host = str(payload.get("hostname") or "")
+    if owner_host and owner_host != socket.gethostname():
+        # A shared filesystem can expose a lease created on another host.
+        # Local PID inspection says nothing about that remote owner, so fail
+        # closed and require explicit operator recovery.
+        return True
+    try:
+        pid = int(payload.get("pid"))
+    except (TypeError, ValueError):
+        # Corrupt or partially readable ownership is not evidence of staleness.
+        return True
+    if pid <= 0:
+        return True
+
+    try:
+        process = process_factory(pid)
+    except psutil.NoSuchProcess:
+        return False
+    except (psutil.Error, OSError):
+        # AccessDenied and transient process-table failures cannot prove the
+        # owner is gone. Fail closed so a live deployment is never reclaimed.
+        return True
+
+    try:
+        if not process.is_running():
+            return False
+    except psutil.NoSuchProcess:
+        return False
+    except (psutil.Error, OSError):
+        return True
+
+    expected_start = payload.get("process_start_time")
+    if expected_start in (None, ""):
+        return True
+    try:
+        expected_start_value = float(expected_start)
+    except (TypeError, ValueError):
+        return True
+    try:
+        actual_start = float(process.create_time())
+    except psutil.NoSuchProcess:
+        return False
+    except (psutil.Error, OSError, TypeError, ValueError):
+        return True
+    return (
+        abs(actual_start - expected_start_value)
+        <= _PROCESS_START_TOLERANCE_SECONDS
+    )
+
+
+def _target_path(env: Any) -> Path:
+    raw_path = getattr(env, "wenv_abs", None)
+    if raw_path in (None, ""):
+        # Lightweight test doubles and compatibility callers may not expose a
+        # worker path.  They still receive in-process serialization, with a
+        # stable temp-root lease keyed by their declared target/identity.
+        identity = str(
+            getattr(env, "target", None)
+            or getattr(env, "app", None)
+            or f"object-{id(env)}"
+        )
+        digest = hashlib.sha256(identity.encode("utf-8")).hexdigest()[:16]
+        return Path(tempfile.gettempdir()) / "agilab-operation-targets" / digest
+    return Path(raw_path).expanduser().resolve(strict=False)
+
+
+def _normalized_target_key(
+    target: Path,
+    *,
+    normcase_fn: Any = os.path.normcase,
+) -> str:
+    """Return a filesystem-identity key (including Windows case folding)."""
+
+    normalized = os.path.normpath(str(target.expanduser().resolve(strict=False)))
+    return str(normcase_fn(normalized)).replace("\\", "/")
+
+
+def target_lease_path(env: Any) -> Path:
+    """Return the stable lease for all targets sharing one runtime parent.
+
+    Scheduler and remote-worker PID files live beside target environments, so
+    a target-specific lease would let cleanup for one target unlink or stop a
+    sibling target's live runtime.
+    """
+
+    target = _target_path(env)
+    parent_key = _normalized_target_key(target.parent)
+    digest = hashlib.sha256(parent_key.encode("utf-8")).hexdigest()[:16]
+    return target.parent / ".agilab-operation-leases" / f"runtime-{digest}.lock"
+
+
+def _read_owner(lock_path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads((lock_path / "owner.json").read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _fsync_directory(path: Path) -> None:
+    try:
+        fd = os.open(path, os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(fd)
+    except OSError:
+        pass
+    finally:
+        os.close(fd)
+
+
+def _busy_message(operation: str, target: Path, owner: dict[str, Any]) -> str:
+    owner_operation = str(owner.get("operation") or "unknown")
+    owner_pid = owner.get("pid", "unknown")
+    owner_host = str(owner.get("hostname") or "unknown")
+    return (
+        f"Cannot start AGI {operation!r} for {target}: lifecycle operation "
+        f"{owner_operation!r} is already active (pid={owner_pid}, host={owner_host}). "
+        "Wait for it to finish or stop the active AGI service before retrying."
+    )
+
+
+@dataclass(frozen=True)
+class TargetLease:
+    path: Path
+    token: str
+    operation: str
+    target: Path
+    remote_token: str
+    recovered_remote_tokens: tuple[str, ...]
+
+
+def _valid_lease_token(value: Any) -> bool:
+    token = str(value or "")
+    if len(token) != 32:
+        return False
+    try:
+        int(token, 16)
+    except ValueError:
+        return False
+    return True
+
+
+def _owner_remote_tokens(owner: dict[str, Any]) -> tuple[str, ...]:
+    """Return capabilities belonging to one identity-proven stale owner."""
+
+    candidates = [owner.get("remote_token")]
+    inherited = owner.get("recovered_remote_tokens", ())
+    if isinstance(inherited, list):
+        candidates.extend(inherited)
+    tokens: list[str] = []
+    for candidate in candidates:
+        token = str(candidate or "")
+        if _valid_lease_token(token) and token not in tokens:
+            tokens.append(token)
+    return tuple(tokens)
+
+
+def _target_release_tombstone(lock_path: Path, token: str) -> Path:
+    return lock_path.with_name(f".{lock_path.name}.released-{token}")
+
+
+def _target_generation_owned(lock_path: Path, token: str) -> bool:
+    owner = _read_owner(lock_path)
+    return (
+        lock_path.exists()
+        and owner.get("schema") == LEASE_SCHEMA
+        and str(owner.get("token") or "") == token
+    )
+
+
+def _target_generation_released(lock_path: Path, token: str) -> bool:
+    """Return true only when absence or a valid successor proves release."""
+
+    if not lock_path.exists():
+        return True
+    owner = _read_owner(lock_path)
+    owner_token = str(owner.get("token") or "")
+    return (
+        owner.get("schema") == LEASE_SCHEMA
+        and _valid_lease_token(owner_token)
+        and owner_token != token
+    )
+
+
+def _discard_target_claim(claim: Path) -> None:
+    try:
+        claim.rmdir()
+    except OSError:
+        pass
+
+
+def _retire_claimed_target_generation(
+    lock_path: Path,
+    token: str,
+    claim: Path,
+) -> bool:
+    """Move one exact claimed generation behind a durable no-replace fence."""
+
+    if not _target_generation_owned(lock_path, token):
+        released = _target_generation_released(lock_path, token)
+        if released:
+            _discard_target_claim(claim)
+        return released
+
+    tombstone = _target_release_tombstone(lock_path, token)
+    if tombstone.exists():
+        if not _target_generation_owned(tombstone, token):
+            return False
+        # Another resumer already retired this token. Re-read the public path:
+        # the old generation may have disappeared or a successor may now own it.
+        released = _target_generation_released(lock_path, token)
+        if released:
+            _discard_target_claim(claim)
+        return released
+
+    try:
+        lock_path.rename(tombstone)
+    except OSError:
+        # The deterministic destination retains the old non-empty owner
+        # generation. Therefore an arbitrarily delayed rename cannot replace a
+        # successor: it fails against the existing tombstone and lands here.
+        if tombstone.exists() and not _target_generation_owned(tombstone, token):
+            return False
+        released = _target_generation_released(lock_path, token)
+        if released:
+            _discard_target_claim(claim)
+        return released
+
+    # Keep the non-empty deterministic tombstone indefinitely. It is the
+    # generation fence that makes delayed release/recovery safe for successors.
+    _discard_target_claim(claim)
+    _fsync_directory(lock_path.parent)
+    return True
+
+
+def _remove_stale_lock(lock_path: Path, observed_token: str) -> bool:
+    """Reclaim only the exact lease generation previously observed as stale.
+
+    Moving the observed token marker out of the lock directory is the CAS.
+    A delayed reclaimer cannot claim a replacement generation because its
+    marker has a different token. Competing resumers share the exact claim;
+    the retained deterministic tombstone fences their delayed directory moves.
+    """
+
+    if len(observed_token) != 32:
+        return False
+    try:
+        int(observed_token, 16)
+    except ValueError:
+        return False
+
+    marker = lock_path / f"token-{observed_token}"
+    claim = lock_path.parent / (
+        f".{lock_path.name}.reclaim-{observed_token}-{uuid.uuid4().hex}"
+    )
+    try:
+        marker.rename(claim)
+    except FileNotFoundError:
+        # A prior releaser/reclaimer may have crashed after moving the token
+        # marker but before moving the generation directory. Resume only a
+        # claim for this exact observed token and owner generation.
+        claim_candidates = sorted(
+            [
+                *lock_path.parent.glob(
+                    f".{lock_path.name}.reclaim-{observed_token}-*"
+                ),
+                lock_path.parent / f".release-{observed_token}",
+            ],
+            key=lambda path: path.name,
+        )
+        resumed_claim = next(
+            (candidate for candidate in claim_candidates if candidate.is_dir()),
+            None,
+        )
+        if resumed_claim is None:
+            tombstone = _target_release_tombstone(lock_path, observed_token)
+            return (
+                _target_generation_owned(tombstone, observed_token)
+                and _target_generation_released(lock_path, observed_token)
+            )
+        claim = resumed_claim
+    except OSError:
+        return False
+
+    return _retire_claimed_target_generation(lock_path, observed_token, claim)
+
+
+def acquire_target_lease(
+    env: Any,
+    operation: str,
+    *,
+    remote_token: str | None = None,
+    process_factory: Any = psutil.Process,
+    getpid_fn: Any = os.getpid,
+    time_fn: Any = time.time,
+) -> TargetLease:
+    """Atomically claim one shared worker-runtime parent or fail closed."""
+
+    target = _target_path(env)
+    lock_path = target_lease_path(env)
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    requested_remote_token = str(remote_token or "")
+    if remote_token is not None and not _valid_lease_token(requested_remote_token):
+        raise ValueError("Remote lifecycle token must be exactly 32 hexadecimal characters")
+    recovered_remote_tokens: list[str] = []
+
+    def _reclaim_observed_owner() -> None:
+        owner = _read_owner(lock_path)
+        if not owner and not lock_path.exists():
+            return
+        if _owner_is_live(owner, process_factory=process_factory):
+            raise LifecycleBusyError(_busy_message(operation, target, owner))
+        observed_token = str(owner.get("token") or "")
+        # Whether this succeeds or loses the CAS, retry from a fresh owner
+        # observation. The next iteration will either acquire the empty path or
+        # report the replacement live owner without touching its generation.
+        if _remove_stale_lock(lock_path, observed_token):
+            for token in _owner_remote_tokens(owner):
+                if token not in recovered_remote_tokens:
+                    recovered_remote_tokens.append(token)
+
+    for _attempt in range(3):
+        token = uuid.uuid4().hex
+        effective_remote_token = requested_remote_token or token
+        staging = lock_path.with_name(
+            f".{lock_path.name}.claim-{getpid_fn()}-{token}"
+        )
+        marker_name = f"token-{token}"
+        staging.mkdir()
+        (staging / marker_name).mkdir()
+        pid = int(getpid_fn())
+        payload = {
+            "schema": LEASE_SCHEMA,
+            "token": token,
+            "pid": pid,
+            "process_start_time": _process_start_time(
+                pid,
+                process_factory=process_factory,
+            ),
+            "hostname": socket.gethostname(),
+            "operation": str(operation),
+            "target": target.as_posix(),
+            # The worker-side lifecycle lease uses a separate generation. Keep
+            # its capability beside the manager PID incarnation so only an
+            # identity-proven stale local owner can authorize remote recovery.
+            "remote_token": effective_remote_token,
+            "recovered_remote_tokens": list(recovered_remote_tokens),
+            "created_at": float(time_fn()),
+        }
+        with (staging / "owner.json").open("x", encoding="utf-8") as owner_file:
+            owner_file.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+            owner_file.flush()
+            os.fsync(owner_file.fileno())
+        _fsync_directory(staging)
+        try:
+            staging.rename(lock_path)
+        except FileExistsError:
+            shutil.rmtree(staging, ignore_errors=True)
+            _reclaim_observed_owner()
+            continue
+        except OSError:
+            shutil.rmtree(staging, ignore_errors=True)
+            if lock_path.exists():
+                _reclaim_observed_owner()
+                continue
+            raise
+        _fsync_directory(lock_path.parent)
+        return TargetLease(
+            path=lock_path,
+            token=token,
+            operation=str(operation),
+            target=target,
+            remote_token=effective_remote_token,
+            recovered_remote_tokens=tuple(recovered_remote_tokens),
+        )
+
+    owner = _read_owner(lock_path)
+    raise LifecycleBusyError(_busy_message(operation, target, owner))
+
+
+def _target_lease_still_owned(lease: TargetLease) -> bool:
+    return _target_generation_owned(lease.path, lease.token)
+
+
+def release_target_lease(lease: TargetLease) -> bool:
+    """Release only this generation and report whether ownership is gone."""
+
+    marker = lease.path / f"token-{lease.token}"
+    claim = lease.path.parent / f".release-{lease.token}"
+    try:
+        marker.rename(claim)
+    except FileNotFoundError:
+        if not claim.is_dir():
+            return _target_generation_released(lease.path, lease.token)
+    except OSError:
+        return False
+
+    return _retire_claimed_target_generation(lease.path, lease.token, claim)
+
+
+def _caller_identity() -> tuple[int, int | None]:
+    try:
+        task = asyncio.current_task()
+    except RuntimeError:
+        task = None
+    return threading.get_ident(), id(task) if task is not None else None
+
+
+def _state_lock(agi_cls: Any) -> threading.Lock:
+    lock = getattr(agi_cls, "_lifecycle_state_lock", None)
+    if lock is None:
+        # First use can itself be concurrent.  Serialize creation so no caller
+        # ever enters lifecycle state under a private, losing lock instance.
+        with _STATE_LOCK_CREATION_LOCK:
+            lock = getattr(agi_cls, "_lifecycle_state_lock", None)
+            if lock is None:
+                lock = threading.Lock()
+                setattr(agi_cls, "_lifecycle_state_lock", lock)
+    return lock
+
+
+@dataclass
+class LifecycleOperation:
+    agi_cls: Any
+    env: Any
+    operation: str
+    service_command: bool = False
+    token: str | None = None
+    owner: tuple[int, int | None] | None = None
+    lease: TargetLease | None = None
+    target: Path | None = None
+    reentrant: bool = False
+    reused_service: bool = False
+    _retain_service: bool = False
+    _retain_service_on_error: bool = False
+    _release_service: bool = False
+
+    def _clear_call_state(self) -> None:
+        if getattr(self.agi_cls, "_lifecycle_call_token", None) != self.token:
+            return
+        setattr(self.agi_cls, "_lifecycle_call_token", None)
+        setattr(self.agi_cls, "_lifecycle_call_owner", None)
+        setattr(self.agi_cls, "_lifecycle_call_target", None)
+        setattr(self.agi_cls, "_lifecycle_call_operation", None)
+        setattr(self.agi_cls, "_lifecycle_call_depth", 0)
+        setattr(self.agi_cls, "_lifecycle_remote_token", None)
+        setattr(self.agi_cls, "_lifecycle_remote_recovery_tokens", ())
+
+    async def _finish_pending_release(self) -> None:
+        """Prove a prior remote release before allowing a new lifecycle call."""
+
+        lock = _state_lock(self.agi_cls)
+        with lock:
+            pending = getattr(
+                self.agi_cls,
+                "_lifecycle_pending_release_lease",
+                None,
+            )
+            if pending is None:
+                return
+            if not isinstance(pending, TargetLease):
+                raise LifecycleBusyError(
+                    "Cannot start a new AGI lifecycle operation: pending remote "
+                    "lease evidence is invalid"
+                )
+            active_token = getattr(self.agi_cls, "_lifecycle_call_token", None)
+            if active_token is not None:
+                raise LifecycleBusyError(
+                    "Cannot start a new AGI lifecycle operation while a prior "
+                    "remote lease release is still active"
+                )
+            setattr(self.agi_cls, "_lifecycle_call_token", self.token)
+            setattr(self.agi_cls, "_lifecycle_call_owner", self.owner)
+            setattr(self.agi_cls, "_lifecycle_call_target", pending.target)
+            setattr(
+                self.agi_cls,
+                "_lifecycle_call_operation",
+                f"release-pending:{pending.operation}",
+            )
+            setattr(self.agi_cls, "_lifecycle_call_depth", 1)
+            setattr(self.agi_cls, "_lifecycle_remote_token", pending.remote_token)
+            setattr(
+                self.agi_cls,
+                "_lifecycle_remote_recovery_tokens",
+                pending.recovered_remote_tokens,
+            )
+
+        release_remote_leases = getattr(
+            self.agi_cls,
+            "_release_remote_target_leases",
+            None,
+        )
+        try:
+            if not callable(release_remote_leases):
+                raise RuntimeError("remote lease release callback is unavailable")
+            await release_remote_leases()
+        except BaseException as exc:
+            with lock:
+                self._clear_call_state()
+            if not isinstance(exc, Exception):
+                raise
+            raise LifecycleBusyError(
+                "Cannot start a new AGI lifecycle operation: the prior remote "
+                "target lease release is still unproven"
+            ) from exc
+
+        if not release_target_lease(pending):
+            with lock:
+                self._clear_call_state()
+            raise LifecycleBusyError(
+                "Cannot start a new AGI lifecycle operation: the prior local "
+                "target lease release is still unproven"
+            )
+        with lock:
+            if (
+                getattr(self.agi_cls, "_lifecycle_pending_release_lease", None)
+                == pending
+            ):
+                setattr(self.agi_cls, "_lifecycle_pending_release_lease", None)
+            self._clear_call_state()
+
+    async def __aenter__(self) -> "LifecycleOperation":
+        self.target = _target_path(self.env)
+        self.owner = _caller_identity()
+        self.token = uuid.uuid4().hex
+        await self._finish_pending_release()
+        lock = _state_lock(self.agi_cls)
+        with lock:
+            active_token = getattr(self.agi_cls, "_lifecycle_call_token", None)
+            if active_token is not None:
+                active_owner = getattr(self.agi_cls, "_lifecycle_call_owner", None)
+                active_target = getattr(self.agi_cls, "_lifecycle_call_target", None)
+                if active_owner == self.owner and active_target == self.target:
+                    self.reentrant = True
+                    setattr(
+                        self.agi_cls,
+                        "_lifecycle_call_depth",
+                        int(getattr(self.agi_cls, "_lifecycle_call_depth", 1)) + 1,
+                    )
+                    return self
+                active_operation = getattr(
+                    self.agi_cls,
+                    "_lifecycle_call_operation",
+                    "unknown",
+                )
+                raise LifecycleBusyError(
+                    f"Cannot start AGI {self.operation!r}: lifecycle operation "
+                    f"{active_operation!r} is already active in this process. "
+                    "Wait for it to finish before retrying."
+                )
+
+            service_token = getattr(self.agi_cls, "_lifecycle_service_token", None)
+            if service_token is not None:
+                service_target = getattr(self.agi_cls, "_lifecycle_service_target", None)
+                if (
+                    getattr(self.agi_cls, "_service_cleanup_unproven", False)
+                    and self.operation != "serve:stop"
+                ):
+                    raise LifecycleBusyError(
+                        f"Cannot start AGI {self.operation!r}: the prior service "
+                        "runtime cleanup could not be proven. Call "
+                        "AGI.serve(..., action='stop') before any other operation."
+                    )
+                if not self.service_command or service_target != self.target:
+                    service_operation = getattr(
+                        self.agi_cls,
+                        "_lifecycle_service_operation",
+                        "service",
+                    )
+                    raise LifecycleBusyError(
+                        f"Cannot start AGI {self.operation!r}: persistent "
+                        f"{service_operation!r} owns runtime state for {service_target}. "
+                        "Call AGI.serve(..., action='stop') first."
+                    )
+                self.reused_service = True
+                self.lease = getattr(self.agi_cls, "_lifecycle_service_lease", None)
+            else:
+                self.lease = acquire_target_lease(
+                    self.env,
+                    self.operation,
+                    remote_token=self.token,
+                )
+
+            setattr(self.agi_cls, "_lifecycle_call_token", self.token)
+            setattr(self.agi_cls, "_lifecycle_call_owner", self.owner)
+            setattr(self.agi_cls, "_lifecycle_call_target", self.target)
+            setattr(self.agi_cls, "_lifecycle_call_operation", self.operation)
+            setattr(self.agi_cls, "_lifecycle_call_depth", 1)
+            setattr(
+                self.agi_cls,
+                "_lifecycle_remote_token",
+                self.lease.remote_token if self.lease is not None else self.token,
+            )
+            setattr(
+                self.agi_cls,
+                "_lifecycle_remote_recovery_tokens",
+                self.lease.recovered_remote_tokens if self.lease is not None else (),
+            )
+        return self
+
+    def retain_for_service(self) -> None:
+        self._retain_service = True
+
+    def retain_for_service_on_error(self) -> None:
+        """Retain ownership when an exception leaves runtime state live/uncertain."""
+
+        self._retain_service = True
+        self._retain_service_on_error = True
+
+    def release_service(self) -> None:
+        self._release_service = True
+
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        lock = _state_lock(self.agi_cls)
+        lease_to_release: TargetLease | None = None
+        with lock:
+            if self.reentrant:
+                depth = int(getattr(self.agi_cls, "_lifecycle_call_depth", 1)) - 1
+                setattr(self.agi_cls, "_lifecycle_call_depth", max(depth, 1))
+                return
+
+            self._clear_call_state()
+
+            persistent_lease = getattr(self.agi_cls, "_lifecycle_service_lease", None)
+            if self._release_service:
+                lease_to_release = persistent_lease or self.lease
+                setattr(self.agi_cls, "_lifecycle_service_token", None)
+                setattr(self.agi_cls, "_lifecycle_service_target", None)
+                setattr(self.agi_cls, "_lifecycle_service_operation", None)
+                setattr(self.agi_cls, "_lifecycle_service_lease", None)
+            elif getattr(self.agi_cls, "_service_cleanup_unproven", False):
+                # Runtime shutdown may have been interrupted or failed after
+                # work was already cancelled.  Keep the exact local/remote
+                # authority so only an explicit ``serve:stop`` recovery can
+                # prove cleanup and release it.
+                setattr(
+                    self.agi_cls,
+                    "_lifecycle_service_token",
+                    getattr(self.agi_cls, "_lifecycle_service_token", None)
+                    or self.token,
+                )
+                setattr(self.agi_cls, "_lifecycle_service_target", self.target)
+                setattr(
+                    self.agi_cls,
+                    "_lifecycle_service_operation",
+                    "cleanup-recovery",
+                )
+                setattr(
+                    self.agi_cls,
+                    "_lifecycle_service_lease",
+                    persistent_lease or self.lease,
+                )
+            elif self._retain_service and (
+                exc_type is None or self._retain_service_on_error
+            ):
+                setattr(
+                    self.agi_cls,
+                    "_lifecycle_service_token",
+                    getattr(self.agi_cls, "_lifecycle_service_token", None) or self.token,
+                )
+                setattr(self.agi_cls, "_lifecycle_service_target", self.target)
+                setattr(self.agi_cls, "_lifecycle_service_operation", "service")
+                setattr(self.agi_cls, "_lifecycle_service_lease", persistent_lease or self.lease)
+            elif not self.reused_service:
+                lease_to_release = self.lease
+            if lease_to_release is not None:
+                setattr(
+                    self.agi_cls,
+                    "_lifecycle_pending_release_lease",
+                    lease_to_release,
+                )
+
+        if lease_to_release is not None:
+            release_remote_leases = getattr(
+                self.agi_cls,
+                "_release_remote_target_leases",
+                None,
+            )
+            if callable(release_remote_leases):
+                await release_remote_leases()
+            if not release_target_lease(lease_to_release):
+                raise RuntimeError(
+                    "Could not prove local lifecycle lease release after remote "
+                    "target leases were released"
+                )
+            with lock:
+                if (
+                    getattr(
+                        self.agi_cls,
+                        "_lifecycle_pending_release_lease",
+                        None,
+                    )
+                    == lease_to_release
+                ):
+                    setattr(
+                        self.agi_cls,
+                        "_lifecycle_pending_release_lease",
+                        None,
+                    )
+
+
+def reset_lifecycle_state(agi_cls: Any) -> None:
+    """Best-effort reset for tests and process teardown."""
+
+    lock = _state_lock(agi_cls)
+    with lock:
+        cleanup_task = getattr(agi_cls, "_runtime_cleanup_task", None)
+        leases = {
+            lease
+            for lease in (
+                getattr(agi_cls, "_lifecycle_service_lease", None),
+                getattr(agi_cls, "_lifecycle_pending_release_lease", None),
+            )
+            if isinstance(lease, TargetLease)
+        }
+        for name in (
+            "_lifecycle_call_token",
+            "_lifecycle_call_owner",
+            "_lifecycle_call_target",
+            "_lifecycle_call_operation",
+            "_lifecycle_remote_token",
+            "_lifecycle_pending_release_lease",
+            "_lifecycle_service_token",
+            "_lifecycle_service_target",
+            "_lifecycle_service_operation",
+            "_lifecycle_service_lease",
+        ):
+            setattr(agi_cls, name, None)
+        setattr(agi_cls, "_lifecycle_remote_recovery_tokens", ())
+        setattr(agi_cls, "_lifecycle_call_depth", 0)
+        setattr(agi_cls, "_service_cleanup_unproven", False)
+        setattr(agi_cls, "_service_runtime_shutdown_proven", False)
+        setattr(agi_cls, "_runtime_cleanup_task", None)
+        setattr(agi_cls, "_runtime_cleanup_phase", None)
+    if isinstance(cleanup_task, asyncio.Task) and not cleanup_task.done():
+        cleanup_task.cancel()
+    for lease in leases:
+        release_target_lease(lease)
+
+
+__all__ = [
+    "LifecycleBusyError",
+    "LifecycleOperation",
+    "TargetLease",
+    "acquire_target_lease",
+    "release_target_lease",
+    "reset_lifecycle_state",
+    "target_lease_path",
+]

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime/runtime_distribution_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime/runtime_distribution_support.py
@@ -3,12 +3,16 @@ import contextlib
 import inspect
 import logging
 import os
+import signal
 import shlex
+import subprocess
 import time
 from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path, PurePath
 from typing import Any, Callable, Dict, Optional
 from zipfile import BadZipFile, ZipFile
+
+import psutil
 
 from agi_cluster.agi_distributor import background_jobs_support, deployment_remote_support
 from agi_env.process_support import project_virtualenv_script_path
@@ -16,9 +20,25 @@ from agi_env.process_support import project_virtualenv_script_path
 
 logger = logging.getLogger(__name__)
 
+RUNTIME_CLEANUP_TIMEOUT_SECONDS = 30.0
+
+
+class RuntimeCleanupRequiredError(RuntimeError):
+    """Raised when owned runtime shutdown cannot be proven within its bound."""
+
+
 _CMD_PREFIX_LOOKUP_EXCEPTIONS = (ConnectionError, OSError, RuntimeError, TimeoutError)
 _WORKER_START_EXCEPTIONS = (ConnectionError, FileNotFoundError, OSError, RuntimeError, TimeoutError)
 _SYNC_RETRY_EXCEPTIONS = (ConnectionError, OSError, RuntimeError, TimeoutError)
+_BACKGROUND_TREE_CLEANUP_EXCEPTIONS = (
+    AttributeError,
+    OSError,
+    RuntimeError,
+    subprocess.SubprocessError,
+    TypeError,
+    ValueError,
+    psutil.Error,
+)
 _STOP_RETRY_EXCEPTIONS = (ConnectionError, OSError, RuntimeError, TimeoutError)
 _TOP_LEVEL_UI_MODULE_SUFFIX = "_args_form.py"
 _TOP_LEVEL_UI_BYTECODE_SUFFIX = "_args_form."
@@ -152,7 +172,7 @@ def _remote_dask_worker_command(
         f"{uv_parts} --project {_remote_path(worker_path)} run --no-sync "
         f"dask worker {shlex.quote(f'tcp://{scheduler}')} --no-nanny "
         f"{port_clause}"
-        f"--pid-file {_remote_path(worker_path.parent / pid_file)}"
+        f"--pid-file {_remote_path(worker_path / pid_file)}"
     )
 
 
@@ -366,9 +386,9 @@ async def run_local(
         raise FileNotFoundError("Worker installation (.venv) not found")
     validate_worker_uv_sources_fn(env.wenv_abs / "pyproject.toml")
 
-    # Write the pid file where the cleanup scanners look for it
-    # (env.wenv_abs.parent/*.pid), not the arbitrary launch CWD.
-    pid_file = Path(env.wenv_abs).parent / "dask_worker_0.pid"
+    # Keep ownership evidence inside the exact worker runtime so concurrent
+    # managers cannot consume another target's shared-parent PID record.
+    pid_file = Path(env.wenv_abs) / "dask_worker_0.pid"
     current_pid = os.getpid()
     pid_file.parent.mkdir(parents=True, exist_ok=True)
     with open(pid_file, "w", encoding="utf-8") as stream:
@@ -473,8 +493,29 @@ async def start(
     env = agi_cls.env
     dask_env = dask_env_prefix(agi_cls)
 
+    # Establish task ownership before any scheduler/worker process is spawned
+    # so partial startup can always cancel and await every launch operation.
+    agi_cls._scheduler_launch_tasks = set()
+    agi_cls._scheduler_launch_errors = []
+    agi_cls._worker_launch_tasks = set()
+    agi_cls._worker_launch_errors = []
+
+    acquire_remote_lease = getattr(agi_cls, "_acquire_remote_target_lease", None)
+    if callable(acquire_remote_lease) and getattr(
+        agi_cls, "_lifecycle_call_token", None
+    ):
+        target_ips = set(agi_cls._workers)
+        target_ips.add(agi_cls._get_scheduler(scheduler)[0])
+        for ip in sorted(target_ips):
+            if not env.is_local(ip):
+                await acquire_remote_lease(ip)
+
     if not await agi_cls._start_scheduler(scheduler):
         return False
+
+    scheduler_errors = getattr(agi_cls, "_scheduler_launch_errors", None) or []
+    if scheduler_errors:
+        raise scheduler_errors[0]
 
     await ensure_remote_cluster_shares(agi_cls)
 
@@ -487,7 +528,6 @@ async def start(
     agi_cls._worker_launch_errors = launch_errors
 
     def _on_worker_launch_done(task: Any) -> None:
-        launch_tasks.discard(task)
         if task.cancelled():
             return
         exc = task.exception()
@@ -802,13 +842,17 @@ async def main(
         )
         res = time_fn() - started_at
     elif agi_cls._mode & agi_cls.DASK_MODE:
-        await _run_timed_phase(
-            agi_cls,
-            "start-dask",
-            lambda: agi_cls._start(scheduler),
-            time_fn=time_fn,
-        )
+        agi_cls._startup_in_progress = True
         try:
+            started = await _run_timed_phase(
+                agi_cls,
+                "start-dask",
+                lambda: agi_cls._start(scheduler),
+                time_fn=time_fn,
+            )
+            if started is False:
+                raise RuntimeError("Dask startup did not complete")
+            agi_cls._startup_in_progress = False
             res = await _run_timed_phase(
                 agi_cls,
                 "distribute",
@@ -822,12 +866,15 @@ async def main(
             # _update_capacity raise; otherwise scheduler/workers/ports and
             # SSH connections leak. _stop() still honors the _mode_auto
             # benchmark skip internally.
-            await _run_timed_phase(
-                agi_cls,
-                "stop-dask",
-                lambda: agi_cls._stop(),
-                time_fn=time_fn,
-            )
+            try:
+                await _run_timed_phase(
+                    agi_cls,
+                    "stop-dask",
+                    lambda: agi_cls._stop(),
+                    time_fn=time_fn,
+                )
+            finally:
+                agi_cls._startup_in_progress = False
     else:
         res = await agi_cls._run()
 
@@ -849,53 +896,735 @@ async def stop(
     *,
     sleep_fn: Callable[[float], Any] = asyncio.sleep,
     log: Any = logger,
+    cleanup_timeout: float = RUNTIME_CLEANUP_TIMEOUT_SECONDS,
+) -> None:
+    """Stop owned runtime resources without letting caller cancellation strand them.
+
+    Dask shutdown contains several cancellation points.  Run that cleanup in a
+    separately owned task and keep draining it when the caller is cancelled
+    again, but only for a finite interval.  A timed-out task remains attached to
+    ``agi_cls`` so an explicit lifecycle stop can finish that exact cleanup
+    before any lease or runtime ownership is released.
+    """
+
+    try:
+        timeout = float(cleanup_timeout)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("runtime cleanup timeout must be a positive number") from exc
+    if timeout <= 0:
+        raise ValueError("runtime cleanup timeout must be a positive number")
+
+    agi_cls._service_cleanup_unproven = True
+    cleanup_task = _reusable_runtime_cleanup_task(agi_cls, log=log)
+    if cleanup_task is None:
+        cleanup_task = asyncio.create_task(
+            _stop_runtime_resources(
+                agi_cls,
+                sleep_fn=sleep_fn,
+                log=log,
+            ),
+            name="agilab-stop-owned-runtime",
+        )
+        agi_cls._runtime_cleanup_task = cleanup_task
+
+    try:
+        await _drain_owned_cleanup_task(cleanup_task, timeout=timeout)
+    except TimeoutError as exc:
+        phase = str(getattr(agi_cls, "_runtime_cleanup_phase", None) or "unknown")
+        raise RuntimeCleanupRequiredError(
+            f"AGI runtime cleanup remains unproven after {timeout:.1f}s "
+            f"(phase={phase}). The owned cleanup task and lifecycle lease were "
+            "retained. Call AGI.serve(..., action='stop') to retry cleanup before "
+            "starting another runtime operation."
+        ) from exc
+    finally:
+        cleanup_proven = (
+            cleanup_task.done()
+            and not cleanup_task.cancelled()
+            and cleanup_task.exception() is None
+        )
+        agi_cls._service_cleanup_unproven = not cleanup_proven
+        if cleanup_task.done() and getattr(agi_cls, "_runtime_cleanup_task", None) is cleanup_task:
+            # A completed failure is retryable by a fresh explicit stop.  Only a
+            # still-running task must remain attached so cleanup cannot overlap.
+            agi_cls._runtime_cleanup_task = None
+        if cleanup_proven:
+            agi_cls._runtime_cleanup_phase = None
+
+
+def _reusable_runtime_cleanup_task(
+    agi_cls: Any,
+    *,
+    log: Any,
+) -> asyncio.Task[Any] | None:
+    """Return an in-flight cleanup task, or consume a prior terminal result."""
+
+    cleanup_task = getattr(agi_cls, "_runtime_cleanup_task", None)
+    if not isinstance(cleanup_task, asyncio.Task):
+        return None
+    if cleanup_task.done():
+        if not cleanup_task.cancelled() and cleanup_task.exception() is None:
+            agi_cls._service_cleanup_unproven = False
+            agi_cls._runtime_cleanup_phase = None
+            agi_cls._runtime_cleanup_task = None
+            return cleanup_task
+        if cleanup_task.cancelled():
+            log.warning("Prior owned AGI runtime cleanup task was cancelled; retrying cleanup")
+        else:
+            log.warning(
+                "Prior owned AGI runtime cleanup failed; retrying cleanup: %s",
+                cleanup_task.exception(),
+            )
+        agi_cls._runtime_cleanup_task = None
+        return None
+
+    current_loop = asyncio.get_running_loop()
+    task_loop = cleanup_task.get_loop()
+    if task_loop is not current_loop:
+        raise RuntimeCleanupRequiredError(
+            "AGI runtime cleanup remains active in another event loop. The owned "
+            "cleanup task and lifecycle lease were retained; finish the original "
+            "session or restart the AGILAB process before retrying."
+        )
+    return cleanup_task
+
+
+async def _drain_owned_cleanup_task(
+    cleanup_task: asyncio.Task[Any],
+    *,
+    timeout: float,
+) -> Any:
+    """Drain ``cleanup_task`` through repeated caller cancellation, with a bound."""
+
+    cancellation: asyncio.CancelledError | None = None
+    completion_waiter = asyncio.create_task(
+        asyncio.wait({cleanup_task}, timeout=timeout),
+        name="agilab-stop-cleanup-deadline",
+    )
+    while not completion_waiter.done():
+        try:
+            await asyncio.shield(completion_waiter)
+        except asyncio.CancelledError as exc:
+            if completion_waiter.cancelled():
+                raise
+            cancellation = cancellation or exc
+
+    completed, _pending = completion_waiter.result()
+    if cleanup_task not in completed:
+        raise TimeoutError("owned AGI runtime cleanup exceeded its deadline")
+
+    result = cleanup_task.result()
+    if cancellation is not None:
+        raise cancellation
+    return result
+
+
+def _record_runtime_cleanup_failure(
+    failures: list[tuple[str, BaseException]],
+    phase: str,
+    exc: BaseException,
+    *,
+    log: Any,
+) -> None:
+    failures.append((phase, exc))
+    log.warning("AGI runtime cleanup could not prove %s: %s", phase, exc)
+
+
+def _raise_runtime_cleanup_failures(
+    failures: list[tuple[str, BaseException]],
+) -> None:
+    if not failures:
+        return
+    details = "; ".join(f"{phase}: {exc}" for phase, exc in failures)
+    error = RuntimeCleanupRequiredError(
+        "AGI runtime cleanup remains unproven ("
+        f"{details}). The lifecycle lease must remain retained; call "
+        "AGI.serve(..., action='stop') to retry cleanup before another operation."
+    )
+    for phase, exc in failures[1:]:
+        error.add_note(f"Additional cleanup failure in {phase}: {exc}")
+    raise error from failures[0][1]
+
+
+async def _stop_runtime_resources(
+    agi_cls: Any,
+    *,
+    sleep_fn: Callable[[float], Any],
+    log: Any,
 ) -> None:
     log.info("stop Agi core")
 
-    retire_attempts = 0
-    while retire_attempts < agi_cls._TIMEOUT:
+    failures: list[tuple[str, BaseException]] = []
+    fatal_error: BaseException | None = None
+    client = getattr(agi_cls, "_dask_client", None)
+    shutdown_owned_runtime = not bool(getattr(agi_cls, "_mode_auto", False)) or bool(
+        getattr(agi_cls, "_startup_in_progress", False)
+    )
+    proven_shutdown_client = getattr(agi_cls, "_runtime_shutdown_client", None)
+    if proven_shutdown_client is not None and proven_shutdown_client is not client:
+        agi_cls._runtime_shutdown_client = None
+        proven_shutdown_client = None
+    client_shutdown_proven = client is None or proven_shutdown_client is client
+    if client is not None and not client_shutdown_proven:
+        retire_attempts = 0
         try:
-            scheduler_info = await _scheduler_info_payload(agi_cls._dask_client)
-        except _STOP_RETRY_EXCEPTIONS as exc:
-            log.debug("Unable to fetch scheduler info during shutdown: %s", exc)
-            break
-
-        workers = scheduler_info.get("workers") or {}
-        if not workers:
-            break
-
-        retire_attempts += 1
-        try:
-            await _maybe_await(
-                agi_cls._dask_client.retire_workers(
-                    workers=list(workers.keys()),
-                    close_workers=True,
-                    remove=True,
+            retire_limit = max(int(getattr(agi_cls, "_TIMEOUT", 0)), 0)
+        except (TypeError, ValueError):
+            retire_limit = 0
+        while fatal_error is None:
+            agi_cls._runtime_cleanup_phase = "scheduler-inspection"
+            try:
+                scheduler_info = await _scheduler_info_payload(client)
+            except _STOP_RETRY_EXCEPTIONS as exc:
+                _record_runtime_cleanup_failure(
+                    failures,
+                    "scheduler inspection",
+                    exc,
+                    log=log,
                 )
-            )
-        except _STOP_RETRY_EXCEPTIONS as exc:
-            log.debug("retire_workers failed: %s", exc)
-            break
+                break
+            except BaseException as exc:
+                fatal_error = exc
+                break
 
-        await sleep_fn(1)
+            workers = scheduler_info.get("workers") or {}
+            if not workers:
+                break
+            if retire_attempts >= retire_limit:
+                _record_runtime_cleanup_failure(
+                    failures,
+                    "worker retirement",
+                    RuntimeError(
+                        f"{len(workers)} scheduler worker(s) remained after "
+                        f"{retire_attempts} retirement attempt(s)"
+                    ),
+                    log=log,
+                )
+                break
+
+            agi_cls._runtime_cleanup_phase = "worker-retirement"
+            try:
+                await _maybe_await(
+                    client.retire_workers(
+                        workers=list(workers.keys()),
+                        close_workers=True,
+                        remove=True,
+                    )
+                )
+                retire_attempts += 1
+                await sleep_fn(1)
+            except _STOP_RETRY_EXCEPTIONS as exc:
+                _record_runtime_cleanup_failure(
+                    failures,
+                    "worker retirement",
+                    exc,
+                    log=log,
+                )
+                break
+            except BaseException as exc:
+                fatal_error = exc
+                break
+
+        # A partial startup owns whatever scheduler it managed to create, even
+        # during benchmark mode, and must tear it down.
+        if shutdown_owned_runtime:
+            agi_cls._runtime_cleanup_phase = "client-shutdown"
+            try:
+                await _maybe_await(client.shutdown())
+                agi_cls._runtime_shutdown_client = client
+                client_shutdown_proven = True
+            except _STOP_RETRY_EXCEPTIONS as exc:
+                _record_runtime_cleanup_failure(
+                    failures,
+                    "Dask client shutdown",
+                    exc,
+                    log=log,
+                )
+            except BaseException as exc:
+                fatal_error = fatal_error or exc
+
+    agi_cls._runtime_cleanup_phase = "launch-tasks"
+    try:
+        launch_tasks: list[Any] = []
+        for field in ("_worker_launch_tasks", "_scheduler_launch_tasks"):
+            tasks = getattr(agi_cls, field, None)
+            if tasks:
+                launch_tasks.extend(list(tasks))
+        for task in launch_tasks:
+            if hasattr(task, "done") and task.done():
+                continue
+            if hasattr(task, "cancel"):
+                task.cancel()
+        awaitables = [task for task in launch_tasks if inspect.isawaitable(task)]
+        if awaitables:
+            await asyncio.gather(*awaitables, return_exceptions=True)
+        for field in ("_worker_launch_tasks", "_scheduler_launch_tasks"):
+            tasks = getattr(agi_cls, field, None)
+            if hasattr(tasks, "clear"):
+                tasks.clear()
+    except BaseException as exc:
+        fatal_error = fatal_error or exc
+
+    background_cleanup_proven = not shutdown_owned_runtime
+    if shutdown_owned_runtime:
+        agi_cls._runtime_cleanup_phase = "background-processes"
+        try:
+            await _terminate_owned_background_jobs(agi_cls, log=log)
+            background_cleanup_proven = True
+        except RuntimeCleanupRequiredError as exc:
+            _record_runtime_cleanup_failure(
+                failures,
+                "owned background processes",
+                exc,
+                log=log,
+            )
+        except BaseException as exc:
+            fatal_error = fatal_error or exc
+
+    if shutdown_owned_runtime and client_shutdown_proven and background_cleanup_proven:
+        # Do not retain a successfully closed client across a lifecycle retry.
+        # A service-state unlink may fail after runtime cleanup and keep the
+        # ownership lease; the next stop must not query the already-closed
+        # client before retrying the remaining lifecycle work.
+        if getattr(agi_cls, "_dask_client", None) is client:
+            agi_cls._dask_client = None
+        if getattr(agi_cls, "_runtime_shutdown_client", None) is client:
+            agi_cls._runtime_shutdown_client = None
+
+    agi_cls._runtime_cleanup_phase = "connections"
+    try:
+        await agi_cls._close_all_connections()
+    except _STOP_RETRY_EXCEPTIONS as exc:
+        _record_runtime_cleanup_failure(
+            failures,
+            "connection shutdown",
+            exc,
+            log=log,
+        )
+    except BaseException as exc:
+        fatal_error = fatal_error or exc
+
+    if fatal_error is not None:
+        agi_cls._runtime_cleanup_phase = "recovery-required"
+        for phase, exc in failures:
+            fatal_error.add_note(f"Additional cleanup failure in {phase}: {exc}")
+        raise fatal_error
+    if failures:
+        agi_cls._runtime_cleanup_phase = "recovery-required"
+        _raise_runtime_cleanup_failures(failures)
+    agi_cls._runtime_cleanup_phase = None
+
+
+def _background_job_ownership_token(job: Any) -> str | None:
+    token = getattr(job, "ownership_token", None)
+    return token if isinstance(token, str) and token else None
+
+
+def _owned_token_processes(job: Any) -> tuple[list[psutil.Process], list[int]]:
+    """Return token matches and inaccessible plausible owned candidates."""
+
+    token = _background_job_ownership_token(job)
+    if token is None:
+        return [], []
+    matches: list[psutil.Process] = []
+    uncertain_candidates: list[int] = []
+    current_pid = os.getpid()
+    started_at = getattr(job, "ownership_started_at", None)
+    try:
+        username = psutil.Process(current_pid).username()
+    except (psutil.AccessDenied, psutil.NoSuchProcess, OSError):
+        username = None
+    for process in psutil.process_iter(attrs=["pid"]):
+        if process.pid == current_pid:
+            continue
+        try:
+            if isinstance(started_at, (int, float)) and (
+                process.create_time() < float(started_at) - 1.0
+            ):
+                continue
+            if username is not None and process.username() != username:
+                continue
+        except (psutil.AccessDenied, psutil.NoSuchProcess, psutil.ZombieProcess, OSError):
+            # Identity-inaccessible protected processes cannot yet be narrowed
+            # to this recent same-user launch and remain unrelated.
+            continue
+        try:
+            if process.environ().get(background_jobs_support.BACKGROUND_JOB_TOKEN_ENV) == token:
+                matches.append(process)
+        except (psutil.NoSuchProcess, psutil.ZombieProcess):
+            continue
+        except (psutil.AccessDenied, OSError):
+            uncertain_candidates.append(process.pid)
+    return matches, uncertain_candidates
+
+
+def _known_process_tree(process: Any) -> list[psutil.Process]:
+    """Return the still-addressable tree rooted at a known Popen handle."""
 
     try:
-        # Skip the scheduler shutdown only while a benchmark is still
-        # iterating modes (_mode_auto); benchmark_dask_modes clears the flag
-        # before its final _stop() so partial mode ranges shut down too.
-        if not agi_cls._mode_auto:
-            await _maybe_await(agi_cls._dask_client.shutdown())
-    except _STOP_RETRY_EXCEPTIONS as exc:
-        log.debug("Dask client shutdown raised: %s", exc)
+        if process.poll() is not None:
+            return []
+        pid = int(process.pid)
+        root = psutil.Process(pid)
+        return [*root.children(recursive=True), root]
+    except (
+        AttributeError,
+        ProcessLookupError,
+        TypeError,
+        ValueError,
+        psutil.AccessDenied,
+        psutil.NoSuchProcess,
+        psutil.ZombieProcess,
+    ):
+        return []
 
-    # Cancel any still-pending remote worker launch tasks so they are not
-    # destroyed pending at loop close.
-    for task in list(getattr(agi_cls, "_worker_launch_tasks", None) or []):
-        task.cancel()
-    if getattr(agi_cls, "_worker_launch_tasks", None):
-        agi_cls._worker_launch_tasks.clear()
 
-    await agi_cls._close_all_connections()
+def _unique_processes(processes: list[psutil.Process]) -> list[psutil.Process]:
+    unique: list[psutil.Process] = []
+    seen: set[int] = set()
+    for process in processes:
+        if process.pid in seen:
+            continue
+        seen.add(process.pid)
+        unique.append(process)
+    return unique
+
+
+def _terminate_token_process_tree(job: Any, *, timeout: float) -> None:
+    """Terminate token-owned descendants, including a reparented Windows child."""
+
+    token = _background_job_ownership_token(job)
+    if token is None:
+        raise RuntimeError("owned background job has no ownership token")
+    process = getattr(job, "process", None)
+    token_processes, _token_uncertainties = _owned_token_processes(job)
+    processes = _unique_processes(
+        [*token_processes, *_known_process_tree(process)]
+    )
+
+    signal_failures: list[str] = []
+    terminated: list[psutil.Process] = []
+    for owned_process in processes:
+        try:
+            owned_process.terminate()
+            terminated.append(owned_process)
+        except (psutil.NoSuchProcess, psutil.ZombieProcess):
+            continue
+        except (psutil.AccessDenied, OSError) as exc:
+            signal_failures.append(f"pid {owned_process.pid}: {exc}")
+
+    _gone, alive = psutil.wait_procs(terminated, timeout=timeout)
+    killed: list[psutil.Process] = []
+    for owned_process in alive:
+        try:
+            owned_process.kill()
+            killed.append(owned_process)
+        except (psutil.NoSuchProcess, psutil.ZombieProcess):
+            continue
+        except (psutil.AccessDenied, OSError) as exc:
+            signal_failures.append(f"pid {owned_process.pid}: {exc}")
+    _gone, alive = psutil.wait_procs(killed, timeout=timeout)
+
+    remaining_token_processes, token_uncertainties = _owned_token_processes(job)
+    remaining = _unique_processes([*alive, *remaining_token_processes])
+    if signal_failures or remaining or token_uncertainties:
+        details = "; ".join(signal_failures)
+        if remaining:
+            live_pids = ", ".join(str(process.pid) for process in remaining)
+            details = f"{details}; " if details else ""
+            details += f"owned pid(s) still alive: {live_pids}"
+        if token_uncertainties:
+            details = f"{details}; " if details else ""
+            details += (
+                "ownership token unavailable for recent same-user candidate pid(s): "
+                + ", ".join(str(pid) for pid in token_uncertainties)
+            )
+        raise RuntimeError(f"owned process-tree termination remains unproven ({details})")
+
+
+def _posix_process_group_has_live_member(process_group_id: int) -> bool:
+    getpgid = getattr(os, "getpgid", None)
+    if not callable(getpgid):
+        return True
+    for process in psutil.process_iter(attrs=["pid", "status"]):
+        try:
+            if getpgid(process.pid) != process_group_id:
+                continue
+            if process.info.get("status") != psutil.STATUS_ZOMBIE:
+                return True
+        except (ProcessLookupError, psutil.NoSuchProcess, psutil.ZombieProcess):
+            continue
+        except (PermissionError, OSError, psutil.AccessDenied):
+            return True
+    return False
+
+
+def _posix_process_group_exists(process_group_id: int) -> bool:
+    killpg = getattr(os, "killpg", None)
+    if not callable(killpg):
+        raise RuntimeError("POSIX process-group signaling is unavailable")
+    try:
+        killpg(process_group_id, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError as exc:
+        # macOS may report EPERM while a terminated orphan remains briefly as
+        # a zombie. A zombie is already dead and cannot keep runtime work alive.
+        if not _posix_process_group_has_live_member(process_group_id):
+            return False
+        raise RuntimeError(
+            f"cannot inspect owned process group {process_group_id}: {exc}"
+        ) from exc
+    except OSError as exc:
+        raise RuntimeError(
+            f"cannot inspect owned process group {process_group_id}: {exc}"
+        ) from exc
+    return True
+
+
+def _posix_leader_owns_group(process: Any, process_group_id: int) -> bool:
+    getpgid = getattr(os, "getpgid", None)
+    if not callable(getpgid):
+        return False
+    try:
+        if process.poll() is not None:
+            return False
+        return getpgid(int(process.pid)) == process_group_id
+    except (AttributeError, ProcessLookupError, TypeError, ValueError, OSError):
+        return False
+
+
+def _posix_group_has_ownership_token(process_group_id: int, token: str) -> bool:
+    getpgid = getattr(os, "getpgid", None)
+    if not callable(getpgid):
+        return False
+    inaccessible_members: list[int] = []
+    for process in psutil.process_iter(attrs=["pid"]):
+        try:
+            if getpgid(process.pid) != process_group_id:
+                continue
+        except (ProcessLookupError, psutil.NoSuchProcess, psutil.ZombieProcess):
+            continue
+        except (PermissionError, OSError) as exc:
+            raise RuntimeError(
+                f"cannot inspect member {process.pid} of process group {process_group_id}: {exc}"
+            ) from exc
+        try:
+            if process.environ().get(background_jobs_support.BACKGROUND_JOB_TOKEN_ENV) == token:
+                return True
+        except (psutil.NoSuchProcess, psutil.ZombieProcess):
+            continue
+        except (psutil.AccessDenied, PermissionError, OSError):
+            inaccessible_members.append(process.pid)
+    if inaccessible_members:
+        pids = ", ".join(str(pid) for pid in inaccessible_members)
+        raise RuntimeError(
+            f"cannot prove ownership of process group {process_group_id}; "
+            f"member environment unavailable for pid(s) {pids}"
+        )
+    return False
+
+
+def _prove_posix_process_group_ownership(job: Any, process_group_id: int) -> bool:
+    """Prove a still-existing group is ours before sending a group signal."""
+
+    if not _posix_process_group_exists(process_group_id):
+        return False
+    process = getattr(job, "process", None)
+    if _posix_leader_owns_group(process, process_group_id):
+        return True
+    token = _background_job_ownership_token(job)
+    if token is not None and _posix_group_has_ownership_token(process_group_id, token):
+        return True
+    if not _posix_process_group_exists(process_group_id):
+        return False
+    raise RuntimeError(
+        f"cannot prove ownership of live process group {process_group_id}; refusing to signal it"
+    )
+
+
+def _signal_posix_process_group(job: Any, process_group_id: int, sig: int) -> bool:
+    if not _prove_posix_process_group_ownership(job, process_group_id):
+        return False
+    killpg = getattr(os, "killpg", None)
+    if not callable(killpg):
+        raise RuntimeError("POSIX process-group signaling is unavailable")
+    try:
+        killpg(process_group_id, sig)
+    except ProcessLookupError:
+        return False
+    except (PermissionError, OSError) as exc:
+        raise RuntimeError(
+            f"cannot signal owned process group {process_group_id}: {exc}"
+        ) from exc
+    return True
+
+
+def _wait_for_posix_process_group(
+    process: Any,
+    process_group_id: int,
+    *,
+    timeout: float,
+) -> bool:
+    deadline = time.monotonic() + timeout
+    while True:
+        try:
+            process.poll()
+        except (AttributeError, ProcessLookupError, OSError):
+            pass
+        if not _posix_process_group_exists(process_group_id):
+            return True
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return False
+        time.sleep(min(0.05, remaining))
+
+
+def _terminate_posix_owned_process_tree(job: Any, *, timeout: float) -> None:
+    process_group_id = getattr(job, "process_group_id", None)
+    if not isinstance(process_group_id, int) or process_group_id <= 0:
+        _terminate_token_process_tree(job, timeout=timeout)
+        return
+    getpgrp = getattr(os, "getpgrp", None)
+    if callable(getpgrp) and getpgrp() == process_group_id:
+        raise RuntimeError("refusing to signal the AGILAB process group")
+
+    process = getattr(job, "process", None)
+    if _signal_posix_process_group(job, process_group_id, signal.SIGTERM):
+        if not _wait_for_posix_process_group(
+            process,
+            process_group_id,
+            timeout=timeout,
+        ):
+            _signal_posix_process_group(job, process_group_id, signal.SIGKILL)
+            if not _wait_for_posix_process_group(
+                process,
+                process_group_id,
+                timeout=timeout,
+            ):
+                raise subprocess.TimeoutExpired(
+                    f"owned process group {process_group_id}",
+                    timeout,
+                )
+
+    # The random token also finds descendants that escaped the original group,
+    # and is the safe Windows ownership boundary when killpg is unavailable.
+    _terminate_token_process_tree(job, timeout=timeout)
+
+
+async def _terminate_legacy_background_process(
+    process: Any,
+    *,
+    timeout: float,
+) -> tuple[str, BaseException] | None:
+    process_label = str(getattr(process, "pid", "unknown"))
+    try:
+        if process.poll() is not None:
+            return None
+        process.terminate()
+    except ProcessLookupError:
+        return None
+    except (AttributeError, OSError) as exc:
+        return f"background process {process_label} termination", exc
+    try:
+        await asyncio.to_thread(process.wait, timeout=timeout)
+        return None
+    except subprocess.TimeoutExpired:
+        pass
+    except ProcessLookupError:
+        return None
+    except (AttributeError, OSError) as exc:
+        return f"background process {process_label} wait", exc
+    try:
+        process.kill()
+        await asyncio.to_thread(process.wait, timeout=timeout)
+        return None
+    except ProcessLookupError:
+        return None
+    except (AttributeError, OSError, subprocess.TimeoutExpired) as exc:
+        return f"background process {process_label} kill/wait", exc
+
+
+def _forget_owned_background_job(manager: Any, job: Any) -> None:
+    for field in ("owned", "running", "completed", "dead"):
+        jobs = getattr(manager, field, None)
+        if not isinstance(jobs, list):
+            continue
+        while job in jobs:
+            jobs.remove(job)
+    job_num = getattr(job, "num", None)
+    all_jobs = getattr(manager, "all", None)
+    if isinstance(all_jobs, dict) and all_jobs.get(job_num) is job:
+        all_jobs.pop(job_num, None)
+
+
+async def _terminate_owned_background_jobs(
+    agi_cls: Any,
+    *,
+    timeout: float = 3.0,
+    log: Any = logger,
+) -> None:
+    """Terminate complete process groups/trees owned by this runtime operation."""
+
+    manager = getattr(agi_cls, "_jobs", None)
+    jobs: list[Any] = []
+    seen_jobs: set[int] = set()
+    for field in ("owned", "running"):
+        for job in list(getattr(manager, field, None) or []):
+            if id(job) in seen_jobs:
+                continue
+            seen_jobs.add(id(job))
+            jobs.append(job)
+
+    failures: list[tuple[str, BaseException]] = []
+    seen_processes: set[int] = set()
+    for index, job in enumerate(jobs):
+        process = getattr(job, "process", None)
+        if process is None:
+            _record_runtime_cleanup_failure(
+                failures,
+                f"background job {index}",
+                RuntimeError("owned job has no process handle"),
+                log=log,
+            )
+            continue
+        if id(process) in seen_processes:
+            continue
+        seen_processes.add(id(process))
+
+        token = _background_job_ownership_token(job)
+        if token is None:
+            result = await _terminate_legacy_background_process(process, timeout=timeout)
+            if result is not None:
+                phase, exc = result
+                _record_runtime_cleanup_failure(failures, phase, exc, log=log)
+                continue
+        else:
+            process_label = str(getattr(process, "pid", index))
+            try:
+                if os.name == "posix":
+                    await asyncio.to_thread(
+                        _terminate_posix_owned_process_tree,
+                        job,
+                        timeout=timeout,
+                    )
+                else:
+                    await asyncio.to_thread(
+                        _terminate_token_process_tree,
+                        job,
+                        timeout=timeout,
+                    )
+            except _BACKGROUND_TREE_CLEANUP_EXCEPTIONS as exc:
+                _record_runtime_cleanup_failure(
+                    failures,
+                    f"background process group/tree {process_label}",
+                    exc,
+                    log=log,
+                )
+                continue
+        _forget_owned_background_job(manager, job)
+
+    _raise_runtime_cleanup_failures(failures)
 
 
 def exec_bg(agi_cls: Any, cmd: Any, cwd: str, *, env: Optional[Dict[str, str]] = None) -> None:

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/service/service_lifecycle_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/service/service_lifecycle_support.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import datetime
 import json
 import logging
@@ -48,6 +49,25 @@ def _break_loop_gather_exceptions() -> tuple:
     except ImportError:
         return _SERVICE_BREAK_LOOP_EXCEPTIONS
     return _SERVICE_BREAK_LOOP_EXCEPTIONS + (KilledWorker,)
+
+
+def _service_launch_failures(agi_cls: Any) -> List[str]:
+    failures: List[str] = []
+    for field in ("_scheduler_launch_errors", "_worker_launch_errors"):
+        failures.extend(str(exc) for exc in (getattr(agi_cls, field, None) or []))
+    for label, field in (
+        ("scheduler", "_scheduler_launch_tasks"),
+        ("worker", "_worker_launch_tasks"),
+    ):
+        for task in list(getattr(agi_cls, field, None) or []):
+            if not hasattr(task, "done") or not task.done() or task.cancelled():
+                continue
+            try:
+                exc = task.exception()
+            except (asyncio.CancelledError, RuntimeError):
+                continue
+            failures.append(str(exc) if exc is not None else f"{label} launch task exited")
+    return list(dict.fromkeys(failure for failure in failures if failure))
 
 
 def wrap_worker_chunk(payload: Any, worker_index: int) -> Any:
@@ -117,7 +137,12 @@ def _submit_service_worker_inits(
         )
         initialized.append(worker)
     if init_futures:
-        client.gather(init_futures)
+        try:
+            client.gather(init_futures)
+        except BaseException:
+            if not _cancel_owned_futures(init_futures, log=logger):
+                agi_cls._service_cleanup_unproven = True
+            raise
     return initialized
 
 
@@ -128,18 +153,385 @@ def _submit_service_loops(
     workers: List[str],
     *,
     key_prefix: str,
+    service_futures: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
-    service_futures: Dict[str, Any] = {}
-    for worker in workers:
-        service_futures[worker] = client.submit(
-            BaseWorker.loop,
-            poll_interval=agi_cls._service_poll_interval,
-            workers=[worker],
-            allow_other_workers=False,
-            pure=False,
-            key=f"{key_prefix}-loop-{env.target}-{agi_cls._service_safe_worker_name(worker)}",
-        )
+    cancel_on_failure = service_futures is None
+    if service_futures is None:
+        service_futures = {}
+    loop_generation = uuid.uuid4().hex[:12]
+    try:
+        for worker in workers:
+            service_futures[worker] = client.submit(
+                BaseWorker.loop,
+                poll_interval=agi_cls._service_poll_interval,
+                workers=[worker],
+                allow_other_workers=False,
+                pure=False,
+                key=(
+                    f"{key_prefix}-loop-{env.target}-"
+                    f"{agi_cls._service_safe_worker_name(worker)}-{loop_generation}"
+                ),
+            )
+    except BaseException:
+        # A caller-provided map preserves every submitted loop so an outer
+        # startup transaction can request a graceful break and prove the loop
+        # task actually exited. Cancelling here would discard that proof: a
+        # Dask Future can report cancellation while its worker function keeps
+        # running.
+        if cancel_on_failure and not _cancel_owned_futures(
+            service_futures.values(),
+            log=logger,
+        ):
+            agi_cls._service_cleanup_unproven = True
+        raise
     return service_futures
+
+
+def _cancel_owned_futures(futures: Any, *, log: Any = logger) -> bool:
+    """Request best-effort cancellation without treating it as stop proof."""
+
+    cancellation_proven = True
+    for future in list(futures):
+        cancel = getattr(future, "cancel", None)
+        if not callable(cancel):
+            cancellation_proven = False
+            continue
+        try:
+            cancel()
+        except BaseException as cleanup_exc:
+            cancellation_proven = False
+            log.warning("Failed to cancel service startup future: %s", cleanup_exc)
+    return cancellation_proven
+
+
+def _future_execution_terminal(future: Any) -> bool:
+    """Return whether a service-loop Future proves its function has exited."""
+
+    # ``cancelled`` is deliberately excluded. Distributed cancellation can
+    # detach the client-side Future while the worker function is still
+    # executing, so only a natural completion or error proves loop exit.
+    return str(getattr(future, "status", "")).lower() in {"finished", "error"}
+
+
+def _reacquire_service_future(client: Any, key: str) -> Any:
+    """Rebind one persisted Dask task key to the recovered client."""
+
+    from dask.distributed import Future
+
+    return Future(key, client=client)
+
+
+def _wait_for_execution_terminal(
+    futures: List[Any],
+    *,
+    wait_fn: Any,
+    timeout: Optional[float],
+    log: Any = logger,
+    description: str,
+) -> bool:
+    """Wait for Futures and verify their worker-side executions terminated."""
+
+    if not futures:
+        return True
+    if all(_future_execution_terminal(future) for future in futures):
+        return True
+
+    wait_kwargs: Dict[str, Any] = {}
+    if timeout is not None:
+        wait_kwargs["timeout"] = timeout
+    try:
+        _done, not_done = wait_fn(futures, **wait_kwargs)
+    except TimeoutError:
+        log.warning("Timed out waiting for %s to terminate", description)
+        return False
+    except BaseException as cleanup_exc:
+        log.warning("Failed while waiting for %s to terminate: %s", description, cleanup_exc)
+        return False
+
+    if not_done:
+        log.warning(
+            "%s did not terminate for %s owned Future(s)",
+            description,
+            len(not_done),
+        )
+        return False
+    if not all(_future_execution_terminal(future) for future in futures):
+        log.warning(
+            "%s wait completed without terminal execution status for every owned Future",
+            description,
+        )
+        return False
+    return True
+
+
+async def _stop_owned_service_loops(
+    agi_cls: Any,
+    env: AgiEnv,
+    owned_futures: Dict[str, Any],
+    *,
+    wait_fn: Any,
+    client: Any = None,
+    log: Any = logger,
+) -> Dict[str, Any]:
+    """Gracefully stop loops without tearing down a caller-owned Dask runtime."""
+
+    if not owned_futures:
+        return {}
+
+    client = client or getattr(agi_cls, "_dask_client", None)
+    if client is None:
+        log.warning("Cannot prove service-loop cleanup without the reused Dask client")
+        return dict(owned_futures)
+
+    workers = list(owned_futures)
+    try:
+        connected_workers = await agi_cls._service_connected_workers(client)
+    except BaseException as cleanup_exc:
+        log.warning(
+            "Failed to inspect connected workers during service-loop cleanup: %s",
+            cleanup_exc,
+        )
+        connected_workers = []
+    break_targets = (
+        [worker for worker in workers if worker in connected_workers]
+        if connected_workers
+        else workers
+    )
+
+    break_tasks: List[Any] = []
+    for worker in break_targets:
+        try:
+            break_tasks.append(
+                client.submit(
+                    BaseWorker.break_loop,
+                    workers=[worker],
+                    allow_other_workers=False,
+                    pure=False,
+                    key=(
+                        "agi-serve-startup-cleanup-break-"
+                        f"{env.target}-{agi_cls._service_safe_worker_name(worker)}-"
+                        f"{uuid.uuid4().hex[:8]}"
+                    ),
+                )
+            )
+        except BaseException as cleanup_exc:
+            log.warning(
+                "Failed to submit service-loop break request for %s: %s",
+                worker,
+                cleanup_exc,
+            )
+
+    timeout = getattr(agi_cls, "_service_stop_timeout", 30.0)
+    break_tasks_finished = _wait_for_execution_terminal(
+        break_tasks,
+        wait_fn=wait_fn,
+        timeout=timeout,
+        log=log,
+        description="service-loop break request",
+    )
+    if break_tasks_finished and break_tasks:
+        try:
+            client.gather(break_tasks, errors="raise")
+        except _break_loop_gather_exceptions():
+            log.debug("Ignoring break_loop error during service cleanup", exc_info=True)
+    else:
+        # These control tasks are no longer useful after the bounded wait. Do
+        # not count cancellation as evidence that they executed.
+        _cancel_owned_futures(break_tasks, log=log)
+
+    # The break request is only a signal. The original loop Futures remain the
+    # authority for proving that worker execution ended.
+    _wait_for_execution_terminal(
+        list(owned_futures.values()),
+        wait_fn=wait_fn,
+        timeout=timeout,
+        log=log,
+        description="service loop",
+    )
+    return {
+        worker: future
+        for worker, future in owned_futures.items()
+        if not _future_execution_terminal(future)
+    }
+
+
+async def _ensure_service_runtime_shutdown(agi_cls: Any) -> None:
+    """Prove owned runtime shutdown once across post-shutdown cleanup retries."""
+
+    if getattr(agi_cls, "_service_runtime_shutdown_proven", False):
+        return
+    await agi_cls._stop()
+    agi_cls._service_runtime_shutdown_proven = True
+
+
+async def _cleanup_failed_service_start(
+    agi_cls: Any,
+    env: AgiEnv,
+    *,
+    owned_futures: Any,
+    runtime_started_here: bool,
+    wait_fn: Any = None,
+    log: Any = logger,
+) -> bool:
+    """Release only resources acquired by the failed service-start attempt."""
+
+    prior_cleanup_unproven = bool(
+        getattr(agi_cls, "_service_cleanup_unproven", False)
+    )
+    if isinstance(owned_futures, dict):
+        owned_future_map = dict(owned_futures)
+    else:
+        # Keep compatibility with direct internal callers that predate the
+        # worker-keyed ownership contract. Production startup now always
+        # supplies the mapping so pinned break requests target exact workers.
+        future_list = list(owned_futures)
+        worker_list = list(getattr(agi_cls, "_service_workers", []) or [])
+        owned_future_map = {
+            (
+                worker_list[index]
+                if index < len(worker_list)
+                else f"unknown-startup-worker-{index}"
+            ): future
+            for index, future in enumerate(future_list)
+        }
+    retained_futures = dict(getattr(agi_cls, "_service_futures", {}) or {})
+    retained_futures.update(owned_future_map)
+    retained_workers = list(
+        dict.fromkeys(
+            [*(getattr(agi_cls, "_service_workers", []) or []), *owned_future_map]
+        )
+    )
+
+    cleanup_proven = False
+    pending_futures: Dict[str, Any] = {}
+
+    if runtime_started_here:
+        # Cancellation is useful as a best-effort request before closing the
+        # runtime, but only successful runtime teardown proves execution ended.
+        _cancel_owned_futures(owned_future_map.values(), log=log)
+        try:
+            await _ensure_service_runtime_shutdown(agi_cls)
+        except BaseException as cleanup_exc:
+            log.warning("Service runtime cleanup failed after startup error: %s", cleanup_exc)
+        else:
+            cleanup_proven = True
+    else:
+        pending_futures = dict(owned_future_map)
+        if wait_fn is None:
+            try:
+                from dask.distributed import wait as wait_fn
+            except BaseException as cleanup_exc:
+                log.warning(
+                    "Cannot load the Dask wait helper for service-loop cleanup: %s",
+                    cleanup_exc,
+                )
+        try:
+            pending_futures = (
+                await _stop_owned_service_loops(
+                    agi_cls,
+                    env,
+                    owned_future_map,
+                    wait_fn=wait_fn,
+                    log=log,
+                )
+                if wait_fn
+                else owned_future_map
+            )
+            cleanup_proven = not pending_futures
+        except BaseException as cleanup_exc:
+            cleanup_proven = False
+            log.warning("Service-loop cleanup failed after startup error: %s", cleanup_exc)
+        if not cleanup_proven:
+            # Request cancellation only after the observable stop attempt, and
+            # retain ownership regardless of whether cancel() returns.
+            _cancel_owned_futures(owned_future_map.values(), log=log)
+
+    if prior_cleanup_unproven and not runtime_started_here:
+        cleanup_proven = False
+
+    if (
+        not cleanup_proven
+        and not runtime_started_here
+        and not prior_cleanup_unproven
+        and pending_futures
+    ):
+        pending_ownership = {
+            worker: future
+            for worker, future in pending_futures.items()
+            if not _future_execution_terminal(future)
+        }
+        if pending_ownership:
+            # Initial service loops on a reused runtime have new scheduler keys
+            # but no durable state yet. Publish an exact pending-only map first;
+            # otherwise full runtime teardown is the only crash-safe proof.
+            retained_futures = dict(pending_ownership)
+            retained_workers = list(pending_ownership)
+            agi_cls._service_futures = dict(pending_ownership)
+            agi_cls._service_workers = list(pending_ownership)
+            pending_keys_complete = all(
+                getattr(future, "key", None) not in (None, "")
+                for future in pending_ownership.values()
+            )
+            ownership_published = False
+            if pending_keys_complete:
+                try:
+                    agi_cls._service_write_state(
+                        env,
+                        agi_cls._service_state_payload(env),
+                    )
+                except BaseException as publish_exc:
+                    log.error(
+                        "Failed to persist pending service-start ownership on "
+                        "the reused runtime: %s",
+                        publish_exc,
+                    )
+                else:
+                    ownership_published = True
+            if not ownership_published:
+                try:
+                    await _ensure_service_runtime_shutdown(agi_cls)
+                except BaseException as shutdown_exc:
+                    log.error(
+                        "Full runtime shutdown failed after pending service-"
+                        "start ownership could not be published: %s",
+                        shutdown_exc,
+                    )
+                else:
+                    cleanup_proven = True
+
+    if agi_cls._jobs:
+        try:
+            agi_cls._clean_job(True)
+        except BaseException as cleanup_exc:
+            cleanup_proven = False
+            log.warning("Service job cleanup failed after startup error: %s", cleanup_exc)
+
+    if cleanup_proven:
+        for cleanup_name, cleanup_call in (
+            ("persisted service state", lambda: agi_cls._service_clear_state(env)),
+            ("service queue state", agi_cls._reset_service_queue_state),
+        ):
+            try:
+                cleanup_call()
+            except BaseException as cleanup_exc:
+                cleanup_proven = False
+                log.warning(
+                    "Failed to clear %s after service startup error: %s",
+                    cleanup_name,
+                    cleanup_exc,
+                )
+
+    if cleanup_proven:
+        agi_cls._service_futures = {}
+        agi_cls._service_workers = []
+        agi_cls._service_runtime_shutdown_proven = False
+    else:
+        # Preserve every observable ownership handle so the lifecycle lease is
+        # retained and a later explicit stop can finish cleanup safely.
+        agi_cls._service_futures = retained_futures
+        agi_cls._service_workers = retained_workers
+    agi_cls._service_cleanup_unproven = not cleanup_proven
+    return cleanup_proven
 
 
 async def service_recover(
@@ -149,7 +541,12 @@ async def service_recover(
     allow_stale_cleanup: bool = False,
     log: Any = logger,
 ) -> bool:
-    state = agi_cls._service_read_state(env)
+    try:
+        state = agi_cls._service_read_state(env)
+    except _SERVICE_RECOVERABLE_EXCEPTIONS as exc:
+        log.warning("Failed to inspect persisted AGI service ownership: %s", exc)
+        agi_cls._service_cleanup_unproven = True
+        return False
     if not state:
         return False
 
@@ -245,20 +642,52 @@ async def service_recover(
             if agi_cls._dask_workers
             else [str(w) for w in state.get("service_workers", []) if w]
         )
-        agi_cls._service_futures = {}
 
         if not agi_cls._service_workers:
             raise RuntimeError("Recovered service scheduler has no attached workers.")
+
+        loop_keys = state.get("service_loop_keys")
+        if not isinstance(loop_keys, dict):
+            raise RuntimeError(
+                "Persisted service state does not contain loop Future ownership keys."
+            )
+        missing_loop_keys = [
+            worker
+            for worker in agi_cls._service_workers
+            if not str(loop_keys.get(worker, "")).strip()
+        ]
+        if missing_loop_keys:
+            raise RuntimeError(
+                "Persisted service state is missing loop Future keys for workers: "
+                + ", ".join(missing_loop_keys)
+            )
+        agi_cls._service_futures = {
+            worker: _reacquire_service_future(
+                agi_cls._dask_client,
+                str(loop_keys[worker]),
+            )
+            for worker in agi_cls._service_workers
+        }
+        agi_cls._service_cleanup_unproven = False
+
+        # Persisted recovery is also a controller handoff. Reconcile running
+        # claims while holding the caller's lifecycle lease, just as a fresh
+        # service start does.
+        agi_cls._recover_orphaned_service_tasks()
 
         return True
 
     except _SERVICE_RECOVERABLE_EXCEPTIONS as exc:
         log.warning("Failed to recover persistent AGI service: %s", exc)
-        if allow_stale_cleanup:
-            agi_cls._service_clear_state(env)
-            agi_cls._service_futures = {}
-            agi_cls._service_workers = []
-            agi_cls._reset_service_queue_state()
+        # A transport or reconstruction failure is not evidence that the
+        # persisted worker loops stopped. Preserve every available ownership
+        # handle and require an explicit stop/recovery retry.
+        persisted_workers = [
+            str(worker) for worker in state.get("service_workers", []) if worker
+        ]
+        if not agi_cls._service_workers:
+            agi_cls._service_workers = persisted_workers
+        agi_cls._service_cleanup_unproven = True
         return False
 
 
@@ -268,6 +697,7 @@ async def service_restart_workers(
     client: Client,
     workers_to_restart: List[str],
     *,
+    wait_fn: Any = None,
     log: Any = logger,
 ) -> List[str]:
     if not workers_to_restart:
@@ -276,39 +706,145 @@ async def service_restart_workers(
     connected = await agi_cls._service_connected_workers(client)
     if connected:
         agi_cls._service_workers = list(connected)
+    existing_workers = list(agi_cls._service_workers)
 
-    break_tasks = [
-        client.submit(
-            BaseWorker.break_loop,
-            workers=[worker],
-            allow_other_workers=False,
-            pure=False,
-            key=f"agi-serve-restart-break-{env.target}-{agi_cls._service_safe_worker_name(worker)}",
-        )
-        for worker in workers_to_restart
+    if wait_fn is None:
+        from dask.distributed import wait as wait_fn
+
+    existing_futures = dict(agi_cls._service_futures)
+    missing_futures = [
+        worker for worker in workers_to_restart if worker not in existing_futures
     ]
-    if break_tasks:
-        try:
-            client.gather(break_tasks)
-        except _break_loop_gather_exceptions():
-            log.debug("Ignoring break_loop error during service restart", exc_info=True)
+    if missing_futures:
+        agi_cls._service_cleanup_unproven = True
+        raise RuntimeError(
+            "Cannot restart service workers without their original loop Future "
+            "ownership: " + ", ".join(missing_futures)
+        )
 
-    restarted = _submit_service_worker_inits(
-        agi_cls,
-        env,
-        client,
-        workers_to_restart,
-        key_prefix="agi-serve-restart",
-    )
-    agi_cls._service_futures.update(
+    old_target_futures = {
+        worker: existing_futures[worker] for worker in workers_to_restart
+    }
+    try:
+        pending_old_futures = await _stop_owned_service_loops(
+            agi_cls,
+            env,
+            old_target_futures,
+            wait_fn=wait_fn,
+            client=client,
+            log=log,
+        )
+    except BaseException:
+        agi_cls._service_cleanup_unproven = True
+        agi_cls._service_futures = existing_futures
+        raise
+    if pending_old_futures:
+        agi_cls._service_cleanup_unproven = True
+        agi_cls._service_futures = {
+            **{
+                worker: future
+                for worker, future in existing_futures.items()
+                if worker not in workers_to_restart
+            },
+            **pending_old_futures,
+        }
+        agi_cls._service_workers = list(agi_cls._service_futures)
+        raise RuntimeError(
+            "Cannot restart service workers until their original loops terminate: "
+            + ", ".join(pending_old_futures)
+        )
+
+    restarted: List[str] = []
+    replacement_futures: Dict[str, Any] = {}
+    try:
+        restarted = _submit_service_worker_inits(
+            agi_cls,
+            env,
+            client,
+            workers_to_restart,
+            key_prefix="agi-serve-restart",
+        )
         _submit_service_loops(
             agi_cls,
             env,
             client,
             restarted,
             key_prefix="agi-serve-restart",
+            service_futures=replacement_futures,
         )
-    )
+    except BaseException as restart_exc:
+        pending_replacements = dict(replacement_futures)
+        if replacement_futures:
+            try:
+                pending_replacements = await _stop_owned_service_loops(
+                    agi_cls,
+                    env,
+                    replacement_futures,
+                    wait_fn=wait_fn,
+                    client=client,
+                    log=log,
+                )
+            except BaseException as cleanup_exc:
+                log.warning(
+                    "Replacement service-loop cleanup failed after restart error: %s",
+                    cleanup_exc,
+                )
+        agi_cls._service_futures = {
+            **{
+                worker: future
+                for worker, future in existing_futures.items()
+                if worker not in workers_to_restart
+            },
+            **pending_replacements,
+        }
+        agi_cls._service_workers = list(agi_cls._service_futures)
+        agi_cls._service_cleanup_unproven = bool(pending_replacements)
+        if pending_replacements:
+            try:
+                agi_cls._service_write_state(env, agi_cls._service_state_payload(env))
+            except BaseException as publish_exc:
+                log.error(
+                    "Failed to persist partial service-restart ownership; "
+                    "forcing full runtime shutdown: %s",
+                    publish_exc,
+                )
+                restart_exc.add_note(
+                    "Partial replacement ownership publication also failed: "
+                    f"{type(publish_exc).__name__}: {publish_exc}"
+                )
+                try:
+                    # A replacement Future uses a new scheduler key. If that
+                    # key cannot be published, only full runtime teardown can
+                    # keep a controller crash from orphaning live replacement
+                    # work behind the durable pre-restart ownership record.
+                    await _ensure_service_runtime_shutdown(agi_cls)
+                except BaseException as shutdown_exc:
+                    log.error(
+                        "Full runtime shutdown failed after partial service-"
+                        "restart ownership publication failure: %s",
+                        shutdown_exc,
+                    )
+                    restart_exc.add_note(
+                        "Fail-safe runtime shutdown also failed: "
+                        f"{type(shutdown_exc).__name__}: {shutdown_exc}"
+                    )
+                else:
+                    # Runtime shutdown proves every replacement ended, so the
+                    # durable pre-restart Future keys are authoritative again.
+                    agi_cls._service_futures = existing_futures
+                    agi_cls._service_workers = existing_workers
+                agi_cls._service_cleanup_unproven = True
+        raise
+
+    agi_cls._service_futures = {
+        **{
+            worker: future
+            for worker, future in existing_futures.items()
+            if worker not in workers_to_restart
+        },
+        **replacement_futures,
+    }
+    agi_cls._service_cleanup_unproven = False
     return restarted
 
 
@@ -316,6 +852,9 @@ async def service_auto_restart_unhealthy(
     agi_cls: Any,
     env: AgiEnv,
     client: Client,
+    *,
+    wait_fn: Any = None,
+    log: Any = logger,
 ) -> Dict[str, Any]:
     connected = await agi_cls._service_connected_workers(client)
     if connected:
@@ -328,9 +867,87 @@ async def service_auto_restart_unhealthy(
         return {"restarted": [], "reasons": {}}
 
     workers_to_restart = list(reasons.keys())
+    prior_futures = dict(agi_cls._service_futures)
+    prior_workers = list(agi_cls._service_workers)
+    prior_cleanup_unproven = bool(agi_cls._service_cleanup_unproven)
     restarted = await agi_cls._service_restart_workers(env, client, workers_to_restart)
     if restarted:
-        agi_cls._service_write_state(env, agi_cls._service_state_payload(env))
+        replacement_futures = {
+            worker: agi_cls._service_futures[worker]
+            for worker in restarted
+            if worker in agi_cls._service_futures
+        }
+        try:
+            agi_cls._service_write_state(env, agi_cls._service_state_payload(env))
+        except BaseException as publish_exc:
+            pending_replacements = dict(replacement_futures)
+            if replacement_futures:
+                if wait_fn is None:
+                    try:
+                        from dask.distributed import wait as wait_fn
+                    except BaseException as wait_import_exc:
+                        log.warning(
+                            "Cannot load Dask wait after service-restart state "
+                            "publication failure: %s",
+                            wait_import_exc,
+                        )
+                if wait_fn is not None:
+                    try:
+                        pending_replacements = await _stop_owned_service_loops(
+                            agi_cls,
+                            env,
+                            replacement_futures,
+                            wait_fn=wait_fn,
+                            client=client,
+                            log=log,
+                        )
+                    except BaseException as cleanup_exc:
+                        log.warning(
+                            "Replacement service-loop cleanup failed after state "
+                            "publication error: %s",
+                            cleanup_exc,
+                        )
+                        publish_exc.add_note(
+                            "Replacement cleanup also failed: "
+                            f"{type(cleanup_exc).__name__}: {cleanup_exc}"
+                        )
+
+            rollback_futures = dict(prior_futures)
+            for worker in restarted:
+                if worker in pending_replacements:
+                    rollback_futures[worker] = pending_replacements[worker]
+                elif worker not in prior_futures:
+                    rollback_futures.pop(worker, None)
+            agi_cls._service_futures = rollback_futures
+            agi_cls._service_workers = list(
+                dict.fromkeys([*prior_workers, *pending_replacements])
+            )
+            if pending_replacements:
+                agi_cls._service_cleanup_unproven = True
+                try:
+                    # These replacements have new scheduler keys that could
+                    # not be published. Full runtime shutdown is the only
+                    # crash-safe ownership proof once bounded loop cleanup
+                    # leaves any of them live.
+                    await _ensure_service_runtime_shutdown(agi_cls)
+                except BaseException as shutdown_exc:
+                    log.error(
+                        "Full runtime shutdown failed after service-restart "
+                        "state publication failure: %s",
+                        shutdown_exc,
+                    )
+                    publish_exc.add_note(
+                        "Fail-safe runtime shutdown also failed: "
+                        f"{type(shutdown_exc).__name__}: {shutdown_exc}"
+                    )
+                else:
+                    # Runtime shutdown proves every replacement ended, making
+                    # the durable pre-restart ownership record authoritative.
+                    agi_cls._service_futures = prior_futures
+                    agi_cls._service_workers = prior_workers
+            else:
+                agi_cls._service_cleanup_unproven = prior_cleanup_unproven
+            raise
     return {"restarted": restarted, "reasons": reasons}
 
 
@@ -401,6 +1018,60 @@ async def serve(
             cleanup_failed_max_files=cleanup_failed_max_files,
             cleanup_heartbeat_max_files=cleanup_heartbeat_max_files,
         )
+
+        if (
+            agi_cls._service_cleanup_unproven
+            or agi_cls._service_runtime_shutdown_proven
+        ):
+            workers_snapshot = list(agi_cls._service_workers)
+            return agi_cls._service_finalize_response(
+                env,
+                {
+                    "status": "error",
+                    "workers": workers_snapshot,
+                    "pending": list(
+                        dict.fromkeys(
+                            [*agi_cls._service_futures, *workers_snapshot]
+                        )
+                    ),
+                    "client_status": (
+                        str(getattr(client, "status", "missing") or "missing")
+                        if client is not None
+                        else "missing"
+                    ),
+                    "recovery_required": True,
+                    "message": (
+                        "Service-loop ownership is incomplete; call "
+                        "AGI.serve(..., action='stop') to recover or fully "
+                        "tear down the retained runtime."
+                    ),
+                },
+                health_output_path=health_output_path,
+                health_only=health_only,
+            )
+
+        launch_failures = _service_launch_failures(agi_cls)
+        client_status = str(getattr(client, "status", "") or "").lower() if client else "missing"
+        if (agi_cls._service_futures or agi_cls._service_workers) and (
+            launch_failures or client_status in {"closed", "closing", "failed"}
+        ):
+            workers_snapshot = list(agi_cls._service_workers)
+            return agi_cls._service_finalize_response(
+                env,
+                {
+                    "status": "error",
+                    "workers": workers_snapshot,
+                    "pending": list(agi_cls._service_futures.keys()),
+                    "client_status": client_status,
+                    "launch_errors": launch_failures,
+                    "message": (
+                        "Persistent AGI service ownership is unhealthy; "
+                        "call AGI.serve(..., action='stop') before restarting."
+                    ),
+                },
+                health_output_path=health_output_path,
+                health_only=health_only,
+            )
 
         restart_info: Dict[str, Any] = {"restarted": [], "reasons": {}}
         if client is not None and agi_cls._service_workers:
@@ -510,131 +1181,295 @@ async def serve(
                 cleanup_heartbeat_max_files=cleanup_heartbeat_max_files,
             )
             if not recovered:
+                if agi_cls._service_cleanup_unproven:
+                    pending = list(
+                        dict.fromkeys(
+                            [
+                                *agi_cls._service_futures,
+                                *agi_cls._service_workers,
+                            ]
+                        )
+                    )
+                    if shutdown_on_stop and client is not None:
+                        retained_futures = dict(agi_cls._service_futures)
+                        retained_workers = list(agi_cls._service_workers)
+                        try:
+                            # Legacy v1 state has no Future keys to reacquire.
+                            # A full connected-runtime shutdown is the only
+                            # compatible proof that those loops cannot survive.
+                            await _ensure_service_runtime_shutdown(agi_cls)
+                            if agi_cls._jobs:
+                                agi_cls._clean_job(True)
+                            agi_cls._service_clear_state(env)
+                            agi_cls._reset_service_queue_state()
+                        except BaseException:
+                            agi_cls._service_futures = retained_futures
+                            agi_cls._service_workers = retained_workers
+                            agi_cls._service_cleanup_unproven = True
+                            raise
+                        agi_cls._service_futures = {}
+                        agi_cls._service_workers = []
+                        agi_cls._service_cleanup_unproven = False
+                        agi_cls._service_runtime_shutdown_proven = False
+                        return agi_cls._service_finalize_response(
+                            env,
+                            {
+                                "status": "stopped",
+                                "workers": retained_workers,
+                                "pending": [],
+                                "legacy_full_shutdown": True,
+                            },
+                            health_output_path=health_output_path,
+                        )
+                    return agi_cls._service_finalize_response(
+                        env,
+                        {
+                            "status": "error",
+                            "workers": list(agi_cls._service_workers),
+                            "pending": pending,
+                            "recovery_required": True,
+                            "message": (
+                                "Service ownership could not be recovered; retry "
+                                "AGI.serve(..., action='stop') after scheduler "
+                                "connectivity is restored."
+                            ),
+                        },
+                        health_output_path=health_output_path,
+                    )
                 log.info("AGI.serve(stop): no active service loops to stop.")
-                if shutdown_on_stop and client:
-                    await agi_cls._stop()
-                if agi_cls._jobs:
-                    agi_cls._clean_job(True)
-                agi_cls._service_clear_state(env)
-                agi_cls._reset_service_queue_state()
+                try:
+                    if shutdown_on_stop:
+                        await _ensure_service_runtime_shutdown(agi_cls)
+                    if agi_cls._jobs:
+                        agi_cls._clean_job(True)
+                    agi_cls._service_clear_state(env)
+                    agi_cls._reset_service_queue_state()
+                except BaseException:
+                    agi_cls._service_cleanup_unproven = True
+                    raise
+                agi_cls._service_cleanup_unproven = False
+                agi_cls._service_runtime_shutdown_proven = False
                 return agi_cls._service_finalize_response(
                     env,
                     {"status": "idle", "workers": [], "pending": []},
                     health_output_path=health_output_path,
                 )
 
+        owned_futures = dict(agi_cls._service_futures)
+        owned_workers = list(agi_cls._service_workers)
+
         if client is None:
+            terminal_ownership_complete = bool(owned_futures) and all(
+                _future_execution_terminal(future)
+                for future in owned_futures.values()
+            ) and set(owned_workers).issubset(owned_futures)
+            runtime_shutdown_proven = bool(
+                getattr(agi_cls, "_service_runtime_shutdown_proven", False)
+            )
+            if shutdown_on_stop and (
+                terminal_ownership_complete or runtime_shutdown_proven
+            ):
+                stopped_workers = list(
+                    dict.fromkeys([*owned_futures, *owned_workers])
+                )
+                try:
+                    # A prior stop may have fully shut down the owned runtime
+                    # before persisted-state deletion failed. Runtime cleanup
+                    # is idempotent; retry it without requiring the now-cleared
+                    # client reference, then finish the retained local cleanup.
+                    await _ensure_service_runtime_shutdown(agi_cls)
+                    if agi_cls._jobs:
+                        agi_cls._clean_job(True)
+                    agi_cls._service_clear_state(env)
+                    agi_cls._reset_service_queue_state()
+                except BaseException:
+                    agi_cls._service_futures = owned_futures
+                    agi_cls._service_workers = owned_workers
+                    agi_cls._service_cleanup_unproven = True
+                    raise
+                agi_cls._service_futures = {}
+                agi_cls._service_workers = []
+                agi_cls._service_cleanup_unproven = False
+                agi_cls._service_runtime_shutdown_proven = False
+                return agi_cls._service_finalize_response(
+                    env,
+                    {
+                        "status": "stopped",
+                        "workers": stopped_workers,
+                        "pending": [],
+                        "runtime_cleanup_retry": True,
+                    },
+                    health_output_path=health_output_path,
+                )
+
             log.error("AGI.serve(stop): service state exists but Dask client is unavailable")
-            pending = list(agi_cls._service_futures.keys()) or list(agi_cls._service_workers)
-            agi_cls._service_futures.clear()
-            agi_cls._service_workers = []
-            if agi_cls._jobs:
-                agi_cls._clean_job(True)
-            agi_cls._service_clear_state(env)
-            agi_cls._reset_service_queue_state()
+            pending = list(
+                dict.fromkeys(
+                    [*agi_cls._service_futures, *agi_cls._service_workers]
+                )
+            )
+            agi_cls._service_cleanup_unproven = True
             return agi_cls._service_finalize_response(
                 env,
-                {"status": "error", "workers": [], "pending": pending},
+                {
+                    "status": "error",
+                    "workers": list(agi_cls._service_workers),
+                    "pending": pending,
+                    "recovery_required": True,
+                    "message": (
+                        "The Dask client is unavailable, so service-loop "
+                        "termination cannot be proven. Restore connectivity "
+                        "and retry AGI.serve(..., action='stop')."
+                    ),
+                },
                 health_output_path=health_output_path,
             )
 
-        future_map = {future: worker for worker, future in agi_cls._service_futures.items()}
-        target_workers = list(agi_cls._service_futures.keys()) or list(agi_cls._service_workers)
+        target_workers = list(
+            dict.fromkeys([*owned_futures, *owned_workers])
+        )
         if not target_workers:
             target_workers = await agi_cls._service_connected_workers(client)
             agi_cls._service_workers = list(target_workers)
 
         if not target_workers:
-            if shutdown_on_stop:
-                await agi_cls._stop()
+            try:
+                if shutdown_on_stop:
+                    await _ensure_service_runtime_shutdown(agi_cls)
+                agi_cls._service_clear_state(env)
+                agi_cls._reset_service_queue_state()
+            except BaseException:
+                agi_cls._service_futures = owned_futures
+                agi_cls._service_workers = owned_workers
+                agi_cls._service_cleanup_unproven = True
+                raise
             agi_cls._service_futures.clear()
             agi_cls._service_workers = []
-            agi_cls._service_clear_state(env)
-            agi_cls._reset_service_queue_state()
+            agi_cls._service_cleanup_unproven = False
+            agi_cls._service_runtime_shutdown_proven = False
             return agi_cls._service_finalize_response(
                 env,
                 {"status": "idle", "workers": [], "pending": []},
                 health_output_path=health_output_path,
             )
 
-        # break_loop tasks are pinned (allow_other_workers=False); submitting
-        # them to a dead/disconnected worker would make the gather below hang
-        # forever, so only target workers still attached to the scheduler.
-        try:
-            connected_workers = await agi_cls._service_connected_workers(client)
-        except _SERVICE_BREAK_LOOP_EXCEPTIONS + (AttributeError,):
-            connected_workers = []
-        break_targets = (
-            [worker for worker in target_workers if worker in connected_workers]
-            if connected_workers
-            else list(target_workers)
-        )
-
-        break_tasks = [
-            client.submit(
-                BaseWorker.break_loop,
-                workers=[worker],
-                allow_other_workers=False,
-                pure=False,
-                key=f"agi-serve-break-{env.target}-{worker.replace(':', '-')}",
-            )
-            for worker in break_targets
+        missing_futures = [
+            worker for worker in target_workers if worker not in owned_futures
         ]
-        if break_tasks:
+        if missing_futures:
+            agi_cls._service_cleanup_unproven = True
+            if shutdown_on_stop:
+                try:
+                    await _ensure_service_runtime_shutdown(agi_cls)
+                    if agi_cls._jobs:
+                        agi_cls._clean_job(True)
+                    agi_cls._service_clear_state(env)
+                    agi_cls._reset_service_queue_state()
+                except BaseException:
+                    agi_cls._service_futures = owned_futures
+                    agi_cls._service_workers = owned_workers
+                    agi_cls._service_cleanup_unproven = True
+                    raise
+                agi_cls._service_futures = {}
+                agi_cls._service_workers = []
+                agi_cls._service_cleanup_unproven = False
+                agi_cls._service_runtime_shutdown_proven = False
+                return agi_cls._service_finalize_response(
+                    env,
+                    {
+                        "status": "stopped",
+                        "workers": target_workers,
+                        "pending": [],
+                        "ownership_full_shutdown": True,
+                    },
+                    health_output_path=health_output_path,
+                )
+            return agi_cls._service_finalize_response(
+                env,
+                {
+                    "status": "partial",
+                    "workers": [],
+                    "pending": missing_futures,
+                    "recovery_required": True,
+                    "message": (
+                        "Service-loop Future ownership is incomplete; recover "
+                        "the persisted service state before retrying stop."
+                    ),
+                },
+                health_output_path=health_output_path,
+            )
+
+        try:
+            pending_futures = await _stop_owned_service_loops(
+                agi_cls,
+                env,
+                owned_futures,
+                wait_fn=wait_fn,
+                log=log,
+            )
+        except BaseException:
+            agi_cls._service_futures = owned_futures
+            agi_cls._service_workers = owned_workers
+            agi_cls._service_cleanup_unproven = True
+            raise
+
+        stopped_workers = [
+            worker for worker in target_workers if worker not in pending_futures
+        ]
+        pending_workers = list(pending_futures)
+        if pending_futures:
+            agi_cls._service_futures = pending_futures
+            agi_cls._service_workers = pending_workers
+            agi_cls._service_cleanup_unproven = True
             try:
-                client.gather(break_tasks)
-            except _break_loop_gather_exceptions():
-                log.debug("Ignoring break_loop error during service stop", exc_info=True)
+                agi_cls._service_write_state(env, agi_cls._service_state_payload(env))
+            except BaseException as cleanup_exc:
+                log.warning(
+                    "Failed to persist partial service-stop ownership: %s",
+                    cleanup_exc,
+                )
+            return agi_cls._service_finalize_response(
+                env,
+                {
+                    "status": "partial",
+                    "workers": stopped_workers,
+                    "pending": pending_workers,
+                    "recovery_required": True,
+                },
+                health_output_path=health_output_path,
+            )
 
-        if future_map:
-            wait_kwargs: Dict[str, Any] = {}
-            if stop_timeout is not None:
-                wait_kwargs["timeout"] = stop_timeout
+        try:
+            if shutdown_on_stop:
+                await _ensure_service_runtime_shutdown(agi_cls)
+            if agi_cls._jobs:
+                agi_cls._clean_job(True)
+            agi_cls._service_clear_state(env)
+            agi_cls._reset_service_queue_state()
+        except BaseException:
+            agi_cls._service_futures = owned_futures
+            agi_cls._service_workers = owned_workers
+            agi_cls._service_cleanup_unproven = True
+            raise
 
-            try:
-                done, not_done = wait_fn(list(future_map.keys()), **wait_kwargs)
-            except TimeoutError:
-                # dask.distributed.wait raises TimeoutError instead of
-                # returning a partial tuple; derive done/not_done from future
-                # statuses so cleanup and the 'partial' status still happen.
-                done = {
-                    future
-                    for future in future_map
-                    if str(getattr(future, "status", "pending")).lower() != "pending"
-                }
-                not_done = {future for future in future_map if future not in done}
-
-            stopped_workers = [future_map[f] for f in done]
-            pending_workers = [future_map[f] for f in not_done]
-
-            if done:
-                client.gather(list(done), errors="raise")
-
-            if pending_workers:
-                log.warning("Service loop shutdown timed out on workers: %s", pending_workers)
-        else:
-            stopped_workers = list(target_workers)
-            pending_workers = []
-
-        agi_cls._service_futures.clear()
+        agi_cls._service_futures = {}
         agi_cls._service_workers = []
-        agi_cls._service_clear_state(env)
-        agi_cls._reset_service_queue_state()
-
-        if shutdown_on_stop:
-            await agi_cls._stop()
-
-        if agi_cls._jobs:
-            agi_cls._clean_job(True)
-
-        status = "stopped" if not pending_workers else "partial"
+        agi_cls._service_cleanup_unproven = False
+        agi_cls._service_runtime_shutdown_proven = False
         return agi_cls._service_finalize_response(
             env,
-            {"status": status, "workers": stopped_workers, "pending": pending_workers},
+            {"status": "stopped", "workers": stopped_workers, "pending": []},
             health_output_path=health_output_path,
         )
 
     if agi_cls._service_futures:
+        launch_failures = _service_launch_failures(agi_cls)
+        if launch_failures:
+            raise RuntimeError(
+                "Service launch ownership is unhealthy ("
+                + "; ".join(launch_failures)
+                + "). Call AGI.serve(..., action='stop') before restarting."
+            )
         raise RuntimeError(
             "Service loop already running. Please call AGI.serve(..., action='stop') first."
         )
@@ -672,6 +1507,16 @@ async def serve(
             },
             health_output_path=health_output_path,
             health_only=health_only,
+        )
+
+    if (
+        agi_cls._service_cleanup_unproven
+        or agi_cls._service_runtime_shutdown_proven
+    ):
+        raise RuntimeError(
+            "Persisted service ownership could not be recovered. Restore "
+            "scheduler connectivity and call AGI.serve(..., action='stop') "
+            "before starting a new service runtime."
         )
 
     if not workers:
@@ -712,60 +1557,89 @@ async def serve(
     runtime_misc_support.configure_install_worker_group(agi_cls, env)
 
     client = agi_cls._dask_client
-    if client is None or getattr(client, "status", "") in {"closed", "closing"}:
-        await agi_cls._start(scheduler)
-        client = agi_cls._dask_client
-    else:
-        await agi_cls._sync()
+    runtime_started_here = False
+    owned_service_futures: Dict[str, Any] = {}
+    agi_cls._service_cleanup_unproven = False
+    agi_cls._service_runtime_shutdown_proven = False
+    try:
+        if client is None or getattr(client, "status", "") in {"closed", "closing"}:
+            # This call owns the startup attempt even if _start raises after
+            # constructing only part of the Dask runtime.
+            runtime_started_here = True
+            agi_cls._startup_in_progress = True
+            try:
+                await agi_cls._start(scheduler)
+                client = agi_cls._dask_client
+                if client is None:
+                    raise RuntimeError("Failed to obtain Dask client for service start")
+            finally:
+                agi_cls._startup_in_progress = False
+        else:
+            await agi_cls._sync()
 
-    if client is None:
-        raise RuntimeError("Failed to obtain Dask client for service start")
+        if client is None:
+            raise RuntimeError("Failed to obtain Dask client for service start")
 
-    agi_cls._dask_workers = [
-        worker.split("/")[-1]
-        for worker in list(client.scheduler_info()["workers"].keys())
-    ]
+        agi_cls._dask_workers = [
+            worker.split("/")[-1]
+            for worker in list(client.scheduler_info()["workers"].keys())
+        ]
 
-    dask_workers = list(agi_cls._dask_workers)
-    queue_paths = agi_cls._init_service_queue(env, service_queue_dir=service_queue_dir)
-    cleanup_info = agi_cls._service_cleanup_artifacts()
-    _prepare_service_worker_args(agi_cls, env)
-    _submit_service_worker_inits(
-        agi_cls,
-        env,
-        client,
-        dask_workers,
-        key_prefix="agi-worker",
-    )
-    service_futures = _submit_service_loops(
-        agi_cls,
-        env,
-        client,
-        dask_workers,
-        key_prefix="agi-serve",
-    )
+        dask_workers = list(agi_cls._dask_workers)
+        queue_paths = agi_cls._init_service_queue(env, service_queue_dir=service_queue_dir)
+        recovery_info = agi_cls._recover_orphaned_service_tasks()
+        cleanup_info = agi_cls._service_cleanup_artifacts()
+        _prepare_service_worker_args(agi_cls, env)
+        _submit_service_worker_inits(
+            agi_cls,
+            env,
+            client,
+            dask_workers,
+            key_prefix="agi-worker",
+        )
+        owned_service_futures = _submit_service_loops(
+            agi_cls,
+            env,
+            client,
+            dask_workers,
+            key_prefix="agi-serve",
+            service_futures=owned_service_futures,
+        )
 
-    agi_cls._service_futures = service_futures
-    agi_cls._service_workers = dask_workers
-    agi_cls._service_started_at = time.time()
-    agi_cls._service_heartbeat_timeout = agi_cls._service_heartbeat_timeout_value()
-    agi_cls._service_write_state(env, agi_cls._service_state_payload(env))
+        agi_cls._service_futures = owned_service_futures
+        agi_cls._service_workers = dask_workers
+        agi_cls._service_started_at = time.time()
+        agi_cls._service_heartbeat_timeout = agi_cls._service_heartbeat_timeout_value()
+        agi_cls._service_write_state(env, agi_cls._service_state_payload(env))
 
-    log.info("Service loops started for workers: %s", dask_workers)
-    return agi_cls._service_finalize_response(
-        env,
-        {
-            "status": "running",
-            "workers": dask_workers,
-            "pending": [],
-            "queue_dir": str(queue_paths["root"]),
-            "cleanup": cleanup_info,
-            "heartbeat_timeout_sec": agi_cls._service_heartbeat_timeout_value(),
-            "worker_health": agi_cls._service_worker_health(list(dask_workers)),
-        },
-        health_output_path=health_output_path,
-        health_only=health_only,
-    )
+        log.info("Service loops started for workers: %s", dask_workers)
+        return agi_cls._service_finalize_response(
+            env,
+            {
+                "status": "running",
+                "workers": dask_workers,
+                "pending": [],
+                "queue_dir": str(queue_paths["root"]),
+                "cleanup": cleanup_info,
+                "recovery": recovery_info,
+                "heartbeat_timeout_sec": agi_cls._service_heartbeat_timeout_value(),
+                "worker_health": agi_cls._service_worker_health(list(dask_workers)),
+            },
+            health_output_path=health_output_path,
+            health_only=health_only,
+        )
+    except BaseException:
+        await _cleanup_failed_service_start(
+            agi_cls,
+            env,
+            owned_futures=owned_service_futures,
+            runtime_started_here=runtime_started_here,
+            wait_fn=wait_fn,
+            log=log,
+        )
+        # Cleanup failures are deliberately contained above; preserve the
+        # original queue/startup/publication exception and traceback.
+        raise
 
 
 async def submit(

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/service/service_runtime_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/service/service_runtime_support.py
@@ -10,6 +10,7 @@ from agi_cluster.agi_distributor.service_lifecycle_support import (
 )
 from agi_cluster.agi_distributor.service_state_support import (
     init_service_queue,
+    recover_orphaned_service_tasks,
     reset_service_queue_state,
     service_apply_queue_root,
     service_apply_runtime_config,
@@ -37,6 +38,7 @@ from agi_cluster.agi_distributor.service_state_support import (
 
 __all__ = [
     "init_service_queue",
+    "recover_orphaned_service_tasks",
     "reset_service_queue_state",
     "serve",
     "service_apply_queue_root",

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/service/service_state_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/service/service_state_support.py
@@ -7,6 +7,7 @@ import os
 import re
 import tempfile
 import time
+import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union, cast
 
@@ -16,14 +17,20 @@ if TYPE_CHECKING:
     from dask.distributed import Client
 
 from agi_env import AgiEnv
+from agi_env.runtime.atomic_write_support import run_with_windows_file_sharing_retry
 
 logger = logging.getLogger(__name__)
 
 _SERVICE_IO_EXCEPTIONS = (OSError, ValueError, TypeError, json.JSONDecodeError)
 _SERVICE_FALLBACK_EXCEPTIONS = (AttributeError, OSError, RuntimeError)
 _SERVICE_EXPORT_EXCEPTIONS = _SERVICE_IO_EXCEPTIONS + (RuntimeError,)
+SERVICE_TASK_SCHEMA = "agi.service.task.v1"
 SERVICE_TASK_SUFFIX = ".task.json"
 LEGACY_SERVICE_TASK_SUFFIX = ".task.pkl"
+
+
+class ServiceStateUnavailableError(RuntimeError):
+    """Raised when persisted service ownership exists but cannot be verified."""
 
 
 def _fallback_service_path(env: AgiEnv, relative_path: Path) -> Path:
@@ -95,15 +102,25 @@ def service_state_path(env: AgiEnv) -> Path:
 
 def service_read_state(agi_cls: Any, env: AgiEnv, *, log: Any = logger) -> Optional[Dict[str, Any]]:
     state_path = agi_cls._service_state_path(env)
-    if not state_path.exists():
-        return None
-    try:
+
+    def _read_payload() -> Any:
         with open(state_path, "r", encoding="utf-8") as stream:
-            payload = json.load(stream)
-        return payload if isinstance(payload, dict) else None
+            return json.load(stream)
+
+    try:
+        payload = run_with_windows_file_sharing_retry(_read_payload)
+    except FileNotFoundError:
+        return None
     except _SERVICE_IO_EXCEPTIONS as exc:
         log.warning("Failed to read service state from %s: %s", state_path, exc)
-        return None
+        raise ServiceStateUnavailableError(
+            f"Persisted service state at {state_path} is unreadable"
+        ) from exc
+    if not isinstance(payload, dict):
+        raise ServiceStateUnavailableError(
+            f"Persisted service state at {state_path} is not a JSON object"
+        )
+    return payload
 
 
 def _atomic_write(
@@ -126,7 +143,9 @@ def _atomic_write(
             open_kwargs["encoding"] = encoding
         with os.fdopen(fd, mode, **open_kwargs) as stream:
             write_fn(stream)
-        os.replace(tmp_path, output_path)
+        run_with_windows_file_sharing_retry(
+            lambda: os.replace(tmp_path, output_path)
+        )
     finally:
         if tmp_path.exists():
             try:
@@ -147,11 +166,19 @@ def service_write_state(agi_cls: Any, env: AgiEnv, payload: Dict[str, Any]) -> N
 
 def service_clear_state(agi_cls: Any, env: AgiEnv, *, log: Any = logger) -> None:
     state_path = agi_cls._service_state_path(env)
+
+    def _unlink_state() -> None:
+        state_path.unlink()
+
     try:
-        if state_path.exists():
-            state_path.unlink()
+        run_with_windows_file_sharing_retry(_unlink_state)
+    except FileNotFoundError:
+        return
     except OSError as exc:
-        log.debug("Failed to remove service state file %s: %s", state_path, exc)
+        log.warning("Failed to remove service state file %s: %s", state_path, exc)
+        raise ServiceStateUnavailableError(
+            f"Persisted service state at {state_path} could not be removed"
+        ) from exc
 
 
 def service_health_path(
@@ -340,20 +367,284 @@ def init_service_queue(
         agi_cls._service_apply_queue_root(queue_root, create=True),
     )
 
-    for stale_dir in (queue_paths["pending"], queue_paths["running"]):
-        for pattern in (f"*{SERVICE_TASK_SUFFIX}", f"*{LEGACY_SERVICE_TASK_SUFFIX}"):
-            for stale_task in sorted(stale_dir.glob(pattern), key=lambda candidate: candidate.name):
-                try:
-                    stale_task.unlink()
-                except FileNotFoundError:
-                    continue
-    for heartbeat_file in sorted(queue_paths["heartbeats"].glob("*.json"), key=lambda candidate: candidate.name):
+    # Initialization is intentionally non-destructive.  Pending tasks may
+    # have been accepted by another controller, running tasks need heartbeat-
+    # aware reconciliation, and heartbeats are ownership evidence.  Recovery
+    # is an explicit, conservative step below.
+    return queue_paths
+
+
+def recover_orphaned_service_tasks(
+    agi_cls: Any,
+    *,
+    now: Optional[float] = None,
+    heartbeat_timeout: Optional[float] = None,
+) -> Dict[str, int]:
+    """Move only expired running claims to failed evidence.
+
+    A missing heartbeat alone is not sufficient: a new worker can claim a task
+    just before its next beat.  The running file must also be older than the
+    configured timeout.  For an old claim, a heartbeat preserves it only when
+    its worker-incarnation token matches the claim; a replacement worker using
+    the same scheduler name cannot adopt stale work.  Pending tasks and fresh
+    claims are always preserved. Legacy pickle claims are moved as opaque
+    failed artifacts and are never deserialized.
+    """
+
+    running_dir = agi_cls._service_queue_running
+    failed_dir = agi_cls._service_queue_failed
+    if running_dir is None or failed_dir is None or not running_dir.exists():
+        return {"recovered": 0, "preserved": 0}
+
+    current_time = time.time() if now is None else float(now)
+    timeout = (
+        float(heartbeat_timeout)
+        if heartbeat_timeout is not None
+        else float(agi_cls._service_heartbeat_timeout_value())
+    )
+    timeout = max(timeout, 0.1)
+    heartbeat_payloads = agi_cls._service_read_heartbeat_payloads()
+    failed_dir.mkdir(parents=True, exist_ok=True)
+    recovered = 0
+    preserved = 0
+
+    # A previous controller can crash after atomically renaming a running task
+    # to its hidden recovery claim. Reconcile those claims before scanning the
+    # canonical names: finish an already-published terminal move, or restore an
+    # uncontested claim so normal age/incarnation checks decide its fate.
+    hidden_claim_pattern = re.compile(
+        rf"^\.(?P<name>.+{re.escape(SERVICE_TASK_SUFFIX)})\.recovery-[^.]+\.tmp$"
+    )
+    done_dir = getattr(agi_cls, "_service_queue_done", None)
+    for hidden_claim in sorted(
+        running_dir.glob(".*.recovery-*.tmp"),
+        key=lambda candidate: candidate.name,
+    ):
+        match = hidden_claim_pattern.match(hidden_claim.name)
+        if match is None:
+            continue
+        canonical = running_dir / match.group("name")
+        if canonical.exists():
+            # Never overwrite competing evidence. A later recovery pass can
+            # reconcile this claim after the canonical owner reaches terminal
+            # state.
+            preserved += 1
+            continue
         try:
-            heartbeat_file.unlink()
+            os.replace(hidden_claim, canonical)
         except FileNotFoundError:
             continue
 
-    return queue_paths
+    def _heartbeat_is_live_for_claim(
+        task_payload: Dict[str, Any],
+        heartbeat_payload: Dict[str, Any],
+    ) -> tuple[bool, Optional[float]]:
+        try:
+            heartbeat_age_value = current_time - float(heartbeat_payload.get("timestamp"))
+        except (TypeError, ValueError):
+            heartbeat_age_value = None
+        heartbeat_state_value = str(heartbeat_payload.get("state", "") or "").lower()
+        claim = task_payload.get("claim")
+        claim_payload = claim if isinstance(claim, dict) else {}
+        claim_incarnation = str(claim_payload.get("worker_incarnation", "") or "")
+        heartbeat_incarnation = str(
+            heartbeat_payload.get("worker_incarnation", "") or ""
+        )
+        heartbeat_live_value = (
+            heartbeat_age_value is not None
+            and heartbeat_age_value <= timeout
+            and heartbeat_state_value not in {"stopped", "failed"}
+            and bool(claim_incarnation)
+            and claim_incarnation == heartbeat_incarnation
+        )
+        return heartbeat_live_value, heartbeat_age_value
+
+    def _terminal_task_filename(task_payload: Dict[str, Any], fallback: str) -> str:
+        claim = task_payload.get("claim")
+        claim_payload = claim if isinstance(claim, dict) else {}
+        candidate = str(claim_payload.get("task_filename", "") or "")
+        if (
+            candidate
+            and Path(candidate).name == candidate
+            and candidate.endswith(SERVICE_TASK_SUFFIX)
+        ):
+            return candidate
+        return fallback
+
+    def _terminal_matches_claim(
+        terminal_path: Path,
+        task_payload: Dict[str, Any],
+        *,
+        expected_status: str,
+    ) -> bool:
+        try:
+            terminal_payload = json.loads(terminal_path.read_text(encoding="utf-8"))
+        except (FileNotFoundError, OSError, json.JSONDecodeError):
+            return False
+        if not isinstance(terminal_payload, dict):
+            return False
+        if terminal_payload.get("schema") != SERVICE_TASK_SCHEMA:
+            return False
+        if str(terminal_payload.get("status", "") or "") != expected_status:
+            return False
+
+        task_claim = task_payload.get("claim")
+        terminal_claim = terminal_payload.get("claim")
+        task_claim_payload = task_claim if isinstance(task_claim, dict) else {}
+        terminal_claim_payload = terminal_claim if isinstance(terminal_claim, dict) else {}
+        task_incarnation = str(
+            task_claim_payload.get("worker_incarnation", "") or ""
+        )
+        terminal_incarnation = str(
+            terminal_claim_payload.get("worker_incarnation", "") or ""
+        )
+        task_id = str(task_payload.get("task_id", "") or "")
+        terminal_task_id = str(terminal_payload.get("task_id", "") or "")
+        task_worker = str(task_payload.get("worker", "") or "")
+        terminal_worker = str(terminal_payload.get("worker", "") or "")
+
+        # A filename alone is not enough to discard evidence: require at least
+        # one durable task identity and require every available identity to
+        # match the already-published terminal payload.
+        if not task_incarnation and not task_id:
+            return False
+        if task_incarnation and task_incarnation != terminal_incarnation:
+            return False
+        if task_id and task_id != terminal_task_id:
+            return False
+        if task_worker and task_worker != terminal_worker:
+            return False
+        return True
+
+    for running_path in sorted(
+        running_dir.glob(f"*{SERVICE_TASK_SUFFIX}"),
+        key=lambda candidate: candidate.name,
+    ):
+        try:
+            mtime = running_path.stat().st_mtime
+            payload = json.loads(running_path.read_text(encoding="utf-8"))
+        except (FileNotFoundError, OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+
+        terminal_filename = _terminal_task_filename(payload, running_path.name)
+        terminal_candidates = (
+            (
+                done_dir / terminal_filename if done_dir is not None else None,
+                "done",
+            ),
+            (failed_dir / terminal_filename, "failed"),
+        )
+        terminal_duplicate = False
+        for terminal_path, expected_status in terminal_candidates:
+            if terminal_path is None or not _terminal_matches_claim(
+                terminal_path,
+                payload,
+                expected_status=expected_status,
+            ):
+                continue
+            try:
+                running_path.unlink()
+            except FileNotFoundError:
+                pass
+            else:
+                recovered += 1
+            terminal_duplicate = True
+            break
+        if terminal_duplicate:
+            continue
+
+        task_age = max(0.0, current_time - float(mtime))
+        worker = str(payload.get("worker", "") or "")
+        heartbeat = heartbeat_payloads.get(worker, {})
+        heartbeat_live, heartbeat_age = _heartbeat_is_live_for_claim(payload, heartbeat)
+        if task_age <= timeout or heartbeat_live:
+            preserved += 1
+            continue
+
+        recovery_claim = running_dir / (
+            f".{running_path.name}.recovery-{uuid.uuid4().hex}.tmp"
+        )
+        try:
+            os.replace(running_path, recovery_claim)
+        except FileNotFoundError:
+            # The worker completed or another recovery owner claimed it.
+            continue
+
+        # A heartbeat can race the directory scan. Re-read it after atomically
+        # claiming the task, and restore the claim if the worker is live.
+        latest_heartbeat = agi_cls._service_read_heartbeat_payloads().get(worker, {})
+        latest_live, _ = _heartbeat_is_live_for_claim(payload, latest_heartbeat)
+        if latest_live:
+            try:
+                os.replace(recovery_claim, running_path)
+            except FileNotFoundError:
+                pass
+            preserved += 1
+            continue
+
+        payload.update(
+            {
+                "status": "failed",
+                "finished_at": current_time,
+                "error": "orphaned service task recovered after worker heartbeat expired",
+                "recovery": {
+                    "reason": "expired-worker-heartbeat",
+                    "task_age_sec": round(task_age, 3),
+                    "heartbeat_age_sec": (
+                        round(heartbeat_age, 3) if heartbeat_age is not None else None
+                    ),
+                },
+            }
+        )
+        terminal_filename = _terminal_task_filename(payload, running_path.name)
+        failed_path = failed_dir / terminal_filename
+        if failed_path.exists():
+            base_name = terminal_filename[: -len(SERVICE_TASK_SUFFIX)]
+            failed_path = failed_dir / (
+                f"{base_name}.orphaned-{uuid.uuid4().hex[:8]}{SERVICE_TASK_SUFFIX}"
+            )
+        try:
+            _atomic_write(
+                failed_path,
+                lambda stream, data=payload: json.dump(data, stream, sort_keys=True),
+                mode="w",
+                encoding="utf-8",
+            )
+        except BaseException:
+            # Never strand the only task evidence under a hidden claim name.
+            try:
+                os.replace(recovery_claim, running_path)
+            except FileNotFoundError:
+                pass
+            raise
+        try:
+            recovery_claim.unlink()
+        except FileNotFoundError:
+            pass
+        recovered += 1
+
+    for legacy_path in sorted(
+        running_dir.glob(f"*{LEGACY_SERVICE_TASK_SUFFIX}"),
+        key=lambda candidate: candidate.name,
+    ):
+        try:
+            if current_time - legacy_path.stat().st_mtime <= timeout:
+                preserved += 1
+                continue
+            destination = failed_dir / legacy_path.name
+            if destination.exists():
+                base_name = legacy_path.name[: -len(LEGACY_SERVICE_TASK_SUFFIX)]
+                destination = failed_dir / (
+                    f"{base_name}.orphaned-{uuid.uuid4().hex[:8]}{LEGACY_SERVICE_TASK_SUFFIX}"
+                )
+            os.replace(legacy_path, destination)
+            recovered += 1
+        except FileNotFoundError:
+            continue
+
+    return {"recovered": recovered, "preserved": preserved}
 
 
 def service_queue_counts(agi_cls: Any) -> Dict[str, int]:
@@ -499,6 +790,11 @@ def service_apply_runtime_config(
 
 
 def service_state_payload(agi_cls: Any, env: AgiEnv) -> Dict[str, Any]:
+    service_loop_keys = {
+        worker: str(key)
+        for worker, future in agi_cls._service_futures.items()
+        if (key := getattr(future, "key", None)) not in (None, "")
+    }
     return {
         "schema": "agi.service.state.v1",
         "target": env.target,
@@ -510,6 +806,7 @@ def service_state_payload(agi_cls: Any, env: AgiEnv) -> Dict[str, Any]:
         "scheduler_port": getattr(agi_cls, "_scheduler_port", None),
         "workers": agi_cls._workers,
         "service_workers": list(agi_cls._service_workers),
+        "service_loop_keys": service_loop_keys,
         "queue_dir": str(agi_cls._service_queue_root) if agi_cls._service_queue_root else None,
         "args": agi_cls._args or {},
         "poll_interval": agi_cls._service_poll_interval,

--- a/src/agilab/core/agi-env/src/agi_env/compat/module_shim.py
+++ b/src/agilab/core/agi-env/src/agi_env/compat/module_shim.py
@@ -2,7 +2,7 @@
 
 CANONICAL COPY of the AGILAB module-shim mechanism. Divergent lineages exist at:
   - src/agilab/compat/module_shim.py
-  - src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/compat/module_shim.py
+  - the shared cluster distributor compatibility layer
   - per-app copies under src/agilab/apps/**/compat/module_shim.py
 The shared ``_CompatModule`` proxy must stay structurally identical across all
 copies modulo the per-package sentinel constant name. This is enforced by

--- a/src/agilab/core/agi-env/src/agi_env/project/app_args.py
+++ b/src/agilab/core/agi-env/src/agi_env/project/app_args.py
@@ -6,11 +6,13 @@ from io import BufferedWriter
 from pathlib import Path
 from typing import Any, Callable, Mapping, Type, TypeVar
 
-import tomllib
-
 from pydantic import BaseModel, ValidationError
 
-from agi_env.project.app_settings_support import prepare_app_settings_for_write
+from agi_env.project.app_settings_support import (
+    app_settings_file_lock as _settings_file_lock,
+    prepare_app_settings_for_write,
+    read_app_settings,
+)
 from agi_env.runtime.agi_logger import AgiLogger
 from agi_env.runtime.atomic_write_support import atomic_write_bytes
 
@@ -21,6 +23,7 @@ logger = AgiLogger.get_logger(__name__)
 
 def _is_missing_module(exc: ModuleNotFoundError, module_name: str) -> bool:
     return getattr(exc, "name", None) == module_name
+
 
 def model_to_payload(model: BaseModel) -> dict[str, Any]:
     """Return a JSON/TOML friendly representation of the model."""
@@ -38,7 +41,9 @@ def prefer_persisted_value(persisted_value: Any, fallback_value: Any) -> Any:
     return persisted_value
 
 
-def merge_model_data(model: BaseModel, overrides: Mapping[str, Any] | None = None) -> BaseModel:
+def merge_model_data(
+    model: BaseModel, overrides: Mapping[str, Any] | None = None
+) -> BaseModel:
     """Return a copy of ``model`` with ``overrides`` applied."""
 
     data = model.model_dump()
@@ -58,8 +63,7 @@ def load_model_from_toml(
     settings_path = Path(settings_path)
     payload: dict[str, Any] = {}
     if settings_path.exists():
-        with settings_path.open("rb") as handle:
-            doc = tomllib.load(handle)
+        doc = read_app_settings(settings_path)
         if section in doc:
             payload = dict(doc[section])
 
@@ -81,16 +85,6 @@ def dump_model_to_toml(
     """Persist a Pydantic model into a TOML section."""
 
     settings_path = Path(settings_path)
-    doc: dict[str, Any] = {}
-    if settings_path.exists():
-        with settings_path.open("rb") as handle:
-            doc = tomllib.load(handle)
-    elif not create_missing:
-        raise FileNotFoundError(f"Settings file not found: {settings_path}")
-
-    doc[section] = model_to_payload(model)
-    doc = prepare_app_settings_for_write(doc)
-
     dumper: Callable[[dict[str, Any], BufferedWriter], None] | None = None
     try:
         import tomli_w  # type: ignore[import-not-found]
@@ -117,4 +111,13 @@ def dump_model_to_toml(
         dumper = _dump_with_tomlkit
 
     logger.info(f"mkdir {settings_path.parent}")
-    atomic_write_bytes(settings_path, lambda handle: dumper(doc, handle))
+    with _settings_file_lock(settings_path):
+        doc: dict[str, Any] = {}
+        if settings_path.exists():
+            doc = read_app_settings(settings_path)
+        elif not create_missing:
+            raise FileNotFoundError(f"Settings file not found: {settings_path}")
+
+        doc[section] = model_to_payload(model)
+        doc = prepare_app_settings_for_write(doc)
+        atomic_write_bytes(settings_path, lambda handle: dumper(doc, handle))

--- a/src/agilab/core/agi-env/src/agi_env/project/app_settings_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/project/app_settings_support.py
@@ -1,12 +1,26 @@
-"""Pure app-settings path helpers for AGILAB."""
+"""App-settings contract, transaction, and path helpers for AGILAB."""
 
 from __future__ import annotations
 
+from contextlib import contextmanager
+from copy import deepcopy
+from io import BufferedWriter
+import os
 import shutil
 from pathlib import Path
-from typing import Any, Callable
+import tempfile
+import threading
+import tomllib
+from typing import Any, Callable, Iterable, Iterator, Mapping, Sequence
 
 from agi_env.runtime.env_config_support import clean_envar_value
+from agi_env.runtime.atomic_write_support import (
+    FILE_LOCK_TIMEOUT_SECONDS,
+    acquire_bounded_file_lock,
+    atomic_write_bytes,
+    release_file_lock,
+    run_with_windows_file_sharing_retry,
+)
 
 APP_SETTINGS_META_KEY = "__meta__"
 APP_SETTINGS_SCHEMA = "agilab.app_settings.v1"
@@ -14,6 +28,252 @@ APP_SETTINGS_SCHEMA_VERSION = 1
 PATH_VALUE_EXCEPTIONS = (TypeError, ValueError)
 PATH_PROBE_EXCEPTIONS = (OSError,)
 EXPORT_ROOT_EXCEPTIONS = (OSError, TypeError, ValueError)
+
+_APP_SETTINGS_THREAD_LOCKS: dict[Path, threading.Lock] = {}
+_APP_SETTINGS_THREAD_LOCKS_GUARD = threading.Lock()
+_APP_SETTINGS_LOCK_TIMEOUT_SECONDS = FILE_LOCK_TIMEOUT_SECONDS
+
+
+def _app_settings_thread_lock(settings_path: Path) -> threading.Lock:
+    """Return the process-local lock paired with a settings transaction path."""
+
+    try:
+        lock_key = settings_path.resolve(strict=False)
+    except OSError:
+        lock_key = settings_path.absolute()
+    with _APP_SETTINGS_THREAD_LOCKS_GUARD:
+        return _APP_SETTINGS_THREAD_LOCKS.setdefault(lock_key, threading.Lock())
+
+
+@contextmanager
+def app_settings_file_lock(settings_path: str | Path) -> Iterator[None]:
+    """Serialize thread and process read/merge/write settings transactions."""
+
+    settings_path = Path(settings_path)
+    lock_path = settings_path.with_name(settings_path.name + ".lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    thread_lock = _app_settings_thread_lock(settings_path)
+    thread_locked = thread_lock.acquire(timeout=_APP_SETTINGS_LOCK_TIMEOUT_SECONDS)
+    if not thread_locked:
+        raise TimeoutError(
+            f"Timed out waiting for AGILAB app-settings lock {lock_path}. "
+            "Another session may still be updating these settings; retry after it finishes."
+        )
+    try:
+        handle = lock_path.open("a+b")
+        file_locked = False
+        try:
+            acquire_bounded_file_lock(
+                handle,
+                lock_path,
+                timeout_seconds=_APP_SETTINGS_LOCK_TIMEOUT_SECONDS,
+            )
+            file_locked = True
+            yield
+        finally:
+            try:
+                if file_locked:
+                    release_file_lock(handle)
+            finally:
+                handle.close()
+    finally:
+        thread_lock.release()
+
+
+def _fsync_directory(path: Path) -> None:
+    """Persist a settings-file directory entry after atomic publication."""
+
+    try:
+        directory_fd = os.open(path, os.O_RDONLY)
+    except OSError:
+        if os.name == "nt":  # pragma: no cover - directory fsync is unsupported
+            return
+        raise
+    try:
+        try:
+            os.fsync(directory_fd)
+        except OSError:
+            if os.name != "nt":
+                raise
+    finally:
+        os.close(directory_fd)
+
+
+def _default_app_settings_dumper(
+    payload: dict[str, Any], stream: BufferedWriter
+) -> None:
+    try:
+        import tomli_w  # type: ignore[import-not-found]
+    except ModuleNotFoundError as exc:
+        if getattr(exc, "name", None) != "tomli_w":
+            raise
+        try:
+            from tomlkit import dumps as tomlkit_dumps
+        except ModuleNotFoundError as fallback_exc:
+            if getattr(fallback_exc, "name", None) != "tomlkit":
+                raise
+            raise RuntimeError(
+                "Writing settings requires either 'tomli-w' or 'tomlkit'."
+            ) from fallback_exc
+        stream.write(tomlkit_dumps(payload).encode("utf-8"))
+        return
+    tomli_w.dump(payload, stream)
+
+
+def read_app_settings_text(settings_path: str | Path) -> str:
+    """Read mutable app settings through Windows' bounded sharing retry."""
+
+    path = Path(settings_path)
+    return run_with_windows_file_sharing_retry(
+        lambda: path.read_text(encoding="utf-8")
+    )
+
+
+def read_app_settings(settings_path: str | Path) -> dict[str, Any]:
+    """Parse mutable app settings without hiding TOML or permanent I/O errors."""
+
+    return tomllib.loads(read_app_settings_text(settings_path))
+
+
+def update_app_settings(
+    settings_path: str | Path,
+    update: Callable[[dict[str, Any]], bool],
+    *,
+    create_missing: bool = True,
+    dump_fn: Callable[[dict[str, Any], BufferedWriter], None] | None = None,
+    prepare_fn: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+) -> tuple[dict[str, Any], bool]:
+    """Apply one locked read/update/write transaction to ``app_settings.toml``.
+
+    ``update`` receives the latest payload while the cross-process lock is held.
+    It may mutate only the keys it owns and returns whether publication is needed.
+    The existing file is retained if mutation, serialization, or atomic publication
+    fails.
+    """
+
+    settings_path = Path(settings_path)
+    writer = dump_fn or _default_app_settings_dumper
+    prepare = prepare_fn or prepare_app_settings_for_write
+    with app_settings_file_lock(settings_path):
+        if settings_path.exists():
+            payload = read_app_settings(settings_path)
+        elif create_missing:
+            payload = {}
+        else:
+            raise FileNotFoundError(f"Settings file not found: {settings_path}")
+
+        if not update(payload):
+            return payload, False
+
+        prepared = prepare(payload)
+        atomic_write_bytes(
+            settings_path,
+            lambda handle: writer(prepared, handle),
+        )
+        _fsync_directory(settings_path.parent)
+        return prepared, True
+
+
+_MISSING_APP_SETTINGS_VALUE = object()
+
+
+def _app_settings_path_value(
+    payload: Mapping[str, Any], path: Sequence[str]
+) -> Any:
+    current: Any = payload
+    for part in path:
+        if not isinstance(current, Mapping) or part not in current:
+            return _MISSING_APP_SETTINGS_VALUE
+        current = current[part]
+    return current
+
+
+def _apply_app_settings_path_value(
+    payload: dict[str, Any], path: Sequence[str], value: Any
+) -> bool:
+    if not path or any(not isinstance(part, str) or not part for part in path):
+        raise ValueError("App-settings ownership paths must contain non-empty strings.")
+
+    current: dict[str, Any] = payload
+    for part in path[:-1]:
+        child = current.get(part)
+        if not isinstance(child, dict):
+            if value is _MISSING_APP_SETTINGS_VALUE:
+                return False
+            child = {}
+            current[part] = child
+        current = child
+
+    leaf = path[-1]
+    if value is _MISSING_APP_SETTINGS_VALUE:
+        if leaf not in current:
+            return False
+        del current[leaf]
+        return True
+
+    copied = deepcopy(value)
+    if current.get(leaf, _MISSING_APP_SETTINGS_VALUE) == copied:
+        return False
+    current[leaf] = copied
+    return True
+
+
+def update_app_settings_owned(
+    settings_path: str | Path,
+    payload: Mapping[str, Any],
+    *,
+    owned_paths: Iterable[Sequence[str]],
+    default_paths: Iterable[Sequence[str]] = (),
+    create_missing: bool = True,
+    dump_fn: Callable[[dict[str, Any], BufferedWriter], None] | None = None,
+    prepare_fn: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+) -> tuple[dict[str, Any], bool]:
+    """Publish only explicitly owned paths from a possibly stale payload.
+
+    Each owned value is selected from ``payload`` before the transaction, then
+    applied to the latest on-disk document while its lock is held. A missing owned
+    path means deletion; unrelated leaves written by other sessions remain
+    untouched. ``default_paths`` are applied only when the latest document does not
+    already contain that leaf, so first-render initialization cannot replace a
+    concurrent writer's value.
+    """
+
+    normalized_paths = tuple(tuple(path) for path in owned_paths)
+    normalized_default_paths = tuple(tuple(path) for path in default_paths)
+    if not normalized_paths and not normalized_default_paths:
+        raise ValueError(
+            "At least one app-settings ownership or default path is required."
+        )
+    if set(normalized_paths) & set(normalized_default_paths):
+        raise ValueError("App-settings ownership and default paths must be disjoint.")
+    owned_values = tuple(
+        (path, _app_settings_path_value(payload, path)) for path in normalized_paths
+    )
+    default_values = tuple(
+        (path, _app_settings_path_value(payload, path))
+        for path in normalized_default_paths
+    )
+
+    def _update(latest: dict[str, Any]) -> bool:
+        changed = False
+        for path, value in owned_values:
+            changed = _apply_app_settings_path_value(latest, path, value) or changed
+        for path, value in default_values:
+            if value is _MISSING_APP_SETTINGS_VALUE:
+                continue
+            if _app_settings_path_value(latest, path) is _MISSING_APP_SETTINGS_VALUE:
+                changed = (
+                    _apply_app_settings_path_value(latest, path, value) or changed
+                )
+        return changed
+
+    return update_app_settings(
+        settings_path,
+        _update,
+        create_missing=create_missing,
+        dump_fn=dump_fn,
+        prepare_fn=prepare_fn,
+    )
 
 
 def sanitize_app_settings_for_toml(obj: Any) -> Any:
@@ -279,12 +539,25 @@ def resolve_user_app_settings_file(
         return workspace_file
 
     workspace_file.parent.mkdir(parents=True, exist_ok=True)
-    if workspace_file.exists():
-        return workspace_file
+    with app_settings_file_lock(workspace_file):
+        if workspace_file.exists():
+            return workspace_file
 
-    source_file = find_source_file(target_app)
-    if source_file is not None and source_file.exists():
-        copy_file(source_file, workspace_file)
-    else:
-        workspace_file.touch()
+        source_file = find_source_file(target_app)
+        if source_file is not None and source_file.exists():
+            with tempfile.TemporaryDirectory(
+                prefix=f".{workspace_file.name}.seed.",
+                dir=workspace_file.parent,
+            ) as staging_dir:
+                staged_source = Path(staging_dir) / source_file.name
+                copy_file(source_file, staged_source)
+
+                def _copy_staged(handle: BufferedWriter) -> None:
+                    with staged_source.open("rb") as source_handle:
+                        shutil.copyfileobj(source_handle, handle)
+
+                atomic_write_bytes(workspace_file, _copy_staged)
+        else:
+            atomic_write_bytes(workspace_file, lambda _handle: None)
+        _fsync_directory(workspace_file.parent)
     return workspace_file

--- a/src/agilab/core/agi-env/src/agi_env/runtime/agi_env.py
+++ b/src/agilab/core/agi-env/src/agi_env/runtime/agi_env.py
@@ -48,7 +48,9 @@ import inspect
 import ctypes
 from ctypes import wintypes
 import importlib.util
+from contextlib import contextmanager
 from threading import RLock
+from types import MethodType
 from agi_env.project.app_settings_support import (
     app_settings_aliases,
     app_settings_source_roots,
@@ -64,9 +66,12 @@ from agi_env.runtime.env_config_support import (
 from agi_env.runtime.agi_env_app_switch_support import change_app as _agi_env_change_app
 from agi_env.runtime.agi_env_execution_methods import (
     run as _agi_env_run,
+    run_for_session as _agi_env_run_for_session,
     run_agi as _agi_env_run_agi,
     run_async as _agi_env_run_async,
+    run_async_for_session as _agi_env_run_async_for_session,
     run_bg as _agi_env_run_bg,
+    run_bg_for_session as _agi_env_run_bg_for_session,
 )
 from agi_env.runtime.agi_env_instance_initialization import initialize_agi_env_instance
 from agi_env.runtime.agi_env_meta_support import AgiEnvMeta as _AgiEnvMeta
@@ -233,6 +238,24 @@ def _select_hook(local_candidate: Path, fallback_filename: str, hook_label: str)
         resolve_hook=_resolve_worker_hook,
     )
 
+class AgiEnvBusyError(RuntimeError):
+    """Raised when another session is stuck in process-global initialization."""
+
+
+@contextmanager
+def _bounded_env_initialization_lock(lock: RLock, *, timeout: float):
+    acquired = lock.acquire(timeout=max(float(timeout), 0.0))
+    if not acquired:
+        raise AgiEnvBusyError(
+            "Timed out waiting for AGILAB environment initialization. Another "
+            "session is still bootstrapping or switching an app; retry after it finishes."
+        )
+    try:
+        yield
+    finally:
+        lock.release()
+
+
 class AgiEnv(metaclass=_AgiEnvMeta):
     """Encapsulates filesystem and configuration state for AGILab deployments.
 
@@ -242,12 +265,28 @@ class AgiEnv(metaclass=_AgiEnvMeta):
       to drop it, or :func:`AgiEnv.current` to retrieve it.
     - Reading ``AgiEnv.attr`` proxies to the singleton's attribute when the
       instance exists; callables/properties are always returned from the class.
+    - Streamlit callers must use :meth:`AgiEnv.session` or
+      :meth:`AgiEnv.session_for_app`.  Those factories return an independent
+      environment which is never installed as the process singleton.
     """
     _instance: "AgiEnv | None" = None
     _lock: RLock = RLock()
+    _initialization_lock_timeout_seconds: float = 30.0
+
+    @classmethod
+    def _bounded_construction_guard(cls):
+        """Serialize the complete legacy singleton construction transaction."""
+
+        return _bounded_env_initialization_lock(
+            cls._lock,
+            timeout=cls._initialization_lock_timeout_seconds,
+        )
 
     def __new__(cls, *args, **kwargs):
-        with cls._lock:
+        with _bounded_env_initialization_lock(
+            cls._lock,
+            timeout=cls._initialization_lock_timeout_seconds,
+        ):
             if cls._instance is None:
                 cls._instance = super().__new__(cls)
         return cls._instance
@@ -256,9 +295,54 @@ class AgiEnv(metaclass=_AgiEnvMeta):
     def current(cls) -> "AgiEnv":
         """Return the currently initialised environment instance."""
 
-        if cls._instance is None:
-            raise RuntimeError("AgiEnv has not been initialised yet")
-        return cls._instance
+        with cls._bounded_construction_guard():
+            if cls._instance is None:
+                raise RuntimeError("AgiEnv has not been initialised yet")
+            return cls._instance
+
+    @classmethod
+    def session(cls, *args, **kwargs) -> "AgiEnv":
+        """Return an independently mutable UI/session environment.
+
+        Construction is serialized because initialisation performs a few
+        monotonic process-wide registrations (logger configuration and import
+        path discovery).  The returned object itself is not stored on ``cls``
+        and subsequent app switches cannot mutate another session or the
+        legacy CLI singleton.
+        """
+
+        with _bounded_env_initialization_lock(
+            cls._lock,
+            timeout=cls._initialization_lock_timeout_seconds,
+        ):
+            env = object.__new__(cls)
+            env._agilab_session_scoped = True
+            env.run = MethodType(_agi_env_run_for_session, env)
+            env._run_bg = MethodType(_agi_env_run_bg_for_session, env)
+            env.run_async = MethodType(_agi_env_run_async_for_session, env)
+            cls.__init__(env, *args, **kwargs)
+            return env
+
+    @classmethod
+    def session_for_app(
+        cls,
+        *,
+        apps_path: Path,
+        app: str,
+        verbose: int | None = None,
+        **kwargs,
+    ) -> "AgiEnv":
+        """Return a fresh session environment configured for ``app``."""
+
+        app_name = Path(str(app)).name
+        if not app_name:
+            raise ValueError("app name must be non-empty")
+        return cls.session(
+            apps_path=Path(apps_path).expanduser().resolve(strict=False),
+            app=app_name,
+            verbose=verbose,
+            **kwargs,
+        )
 
     @classmethod
     def for_app(
@@ -276,38 +360,45 @@ class AgiEnv(metaclass=_AgiEnvMeta):
             raise ValueError("app name must be non-empty")
         requested_apps_path = Path(apps_path).expanduser().resolve(strict=False)
 
-        if cls._instance is None:
-            return cls(apps_path=requested_apps_path, app=app_name, verbose=verbose, **kwargs)
-
-        env = cls.current()
-        current_apps_path = Path(getattr(env, "apps_path", "") or "").expanduser().resolve(strict=False)
-        current_app = Path(str(getattr(env, "app", "") or "")).name
-        current_active_app = Path(getattr(env, "active_app", "") or "").expanduser().resolve(strict=False)
-        requested_active_app = (requested_apps_path / app_name).resolve(strict=False)
-        requested_builtin_app = (requested_apps_path / "builtin" / app_name).resolve(strict=False)
-
-        if (
-            current_apps_path == requested_apps_path
-            and current_app == app_name
-            and current_active_app in {requested_active_app, requested_builtin_app}
+        with _bounded_env_initialization_lock(
+            cls._lock,
+            timeout=cls._initialization_lock_timeout_seconds,
         ):
-            return env
+            if cls._instance is None:
+                return cls(apps_path=requested_apps_path, app=app_name, verbose=verbose, **kwargs)
 
-        type(env).__init__(
-            env,
-            apps_path=requested_apps_path,
-            app=app_name,
-            verbose=verbose,
-            _agilab_reinitialize=True,
-            **kwargs,
-        )
-        return env
+            env = cls.current()
+            current_apps_path = Path(getattr(env, "apps_path", "") or "").expanduser().resolve(strict=False)
+            current_app = Path(str(getattr(env, "app", "") or "")).name
+            current_active_app = Path(getattr(env, "active_app", "") or "").expanduser().resolve(strict=False)
+            requested_active_app = (requested_apps_path / app_name).resolve(strict=False)
+            requested_builtin_app = (requested_apps_path / "builtin" / app_name).resolve(strict=False)
+
+            if (
+                current_apps_path == requested_apps_path
+                and current_app == app_name
+                and current_active_app in {requested_active_app, requested_builtin_app}
+            ):
+                return env
+
+            type(env).__init__(
+                env,
+                apps_path=requested_apps_path,
+                app=app_name,
+                verbose=verbose,
+                _agilab_reinitialize=True,
+                **kwargs,
+            )
+            return env
 
     @classmethod
     def reset(cls) -> None:
         """Drop the cached singleton so a fresh environment can be bootstrapped."""
 
-        with cls._lock:
+        with _bounded_env_initialization_lock(
+            cls._lock,
+            timeout=cls._initialization_lock_timeout_seconds,
+        ):
             cls._instance = None
             cls._ip_local_cache = {"127.0.0.1", "::1"}
             cls._pythonpath_entries = []
@@ -397,7 +488,8 @@ class AgiEnv(metaclass=_AgiEnvMeta):
                 "use AgiEnv.reset() for a fresh environment or change_app() to switch apps."
             )
 
-        _install_formatted_traceback_excepthook()
+        if not getattr(self, "_agilab_session_scoped", False):
+            _install_formatted_traceback_excepthook()
         initialize_agi_env_instance(
             self,
             apps_path=apps_path,
@@ -451,7 +543,7 @@ class AgiEnv(metaclass=_AgiEnvMeta):
         return resolve_apps_repository_root(
             envars=self.envars,
             environ=os.environ,
-            logger=AgiEnv.logger,
+            logger=self.logger,
             fix_windows_drive_fn=_fix_windows_drive,
         )
 
@@ -468,6 +560,11 @@ class AgiEnv(metaclass=_AgiEnvMeta):
 
     def _configure_pythonpath(self, entries: list[str]) -> None:
         self._pythonpath_entries = entries
+        if getattr(self, "_agilab_session_scoped", False):
+            # Session construction must not replace another session's process
+            # PYTHONPATH or import precedence. Subprocesses receive the exact
+            # bound-session snapshot via ``_build_env_for_instance``.
+            return
         apply_pythonpath_entries(entries, sys_path=sys.path, environ=os.environ)
 
     def _configure_worker_runtime(
@@ -492,9 +589,38 @@ class AgiEnv(metaclass=_AgiEnvMeta):
             normalize_path_fn=normalize_path,
             parse_int_env_value_fn=parse_int_env_value,
             python_supports_free_threading_fn=python_supports_free_threading,
-            logger=AgiEnv.logger,
-            sys_path=sys.path,
+            logger=self.logger,
+            sys_path=(
+                list(sys.path)
+                if getattr(self, "_agilab_session_scoped", False)
+                else sys.path
+            ),
         )
+
+    def reinitialize_for_app(
+        self,
+        *,
+        apps_path: Path,
+        app: str,
+        verbose: int | None = None,
+        **kwargs,
+    ) -> "AgiEnv":
+        """Serialize a deliberate rebootstrap of this exact environment object."""
+
+        env_cls = type(self)
+        with _bounded_env_initialization_lock(
+            env_cls._lock,
+            timeout=env_cls._initialization_lock_timeout_seconds,
+        ):
+            env_cls.__init__(
+                self,
+                apps_path=apps_path,
+                app=app,
+                verbose=verbose,
+                _agilab_reinitialize=True,
+                **kwargs,
+            )
+        return self
 
     @staticmethod
     def _dedupe_paths(paths) -> list[str]:
@@ -702,7 +828,7 @@ class AgiEnv(metaclass=_AgiEnvMeta):
             src_apps,
             dst_apps,
             ensure_dir_fn=_ensure_dir,
-            logger=AgiEnv.logger,
+            logger=self.logger,
         )
 
     # Simplified: keep single copy_missing implementation defined later using _copy_file
@@ -794,7 +920,7 @@ class AgiEnv(metaclass=_AgiEnvMeta):
             st_resources=self.st_resources,
             is_source_env=self.is_source_env,
             ensure_dir_fn=_ensure_dir,
-            logger=AgiEnv.logger,
+            logger=self.logger,
         )
 
     def _init_projects(self):
@@ -814,7 +940,7 @@ class AgiEnv(metaclass=_AgiEnvMeta):
         return discover_projects(
             paths,
             installed_app_project_paths=getattr(self, "installed_app_project_paths", ()),
-            logger=AgiEnv.logger,
+            logger=self.logger,
         )
 
     def get_base_worker_cls(self, module_path, class_name):
@@ -822,7 +948,7 @@ class AgiEnv(metaclass=_AgiEnvMeta):
         return discover_base_worker_cls(
             module_path,
             class_name,
-            logger=AgiEnv.logger,
+            logger=self.logger,
             get_base_classes_fn=self.get_base_classes,
         )
 
@@ -831,14 +957,14 @@ class AgiEnv(metaclass=_AgiEnvMeta):
         return discover_base_classes(
             module_path,
             class_name,
-            logger=AgiEnv.logger,
+            logger=self.logger,
             import_mapping_fn=self.get_import_mapping,
             extract_base_info_fn=self.extract_base_info,
         )
 
     def get_import_mapping(self, source):
         """Build a mapping of names to modules from ``import`` statements in ``source``."""
-        return build_import_mapping(source, logger=AgiEnv.logger)
+        return build_import_mapping(source, logger=self.logger)
 
     def _ensure_repository_app_link(self) -> bool:
         """Create a symlink to a repository app when the public tree is missing it."""
@@ -860,7 +986,7 @@ class AgiEnv(metaclass=_AgiEnvMeta):
 
         if not AgiEnv.create_symlink(candidate, dest):
             return False
-        AgiEnv.logger.info("Created apps repository symlink: %s -> %s", dest, candidate)  # ty: ignore[unresolved-attribute]
+        self.logger.info("Created apps repository symlink: %s -> %s", dest, candidate)
         return True
 
     @staticmethod
@@ -950,7 +1076,7 @@ class AgiEnv(metaclass=_AgiEnvMeta):
             read_agilab_path_fn=self.read_agilab_path,
             optional_agi_pages_bundles_root_fn=_optional_agi_pages_bundles_root,
             ensure_dir_fn=_ensure_dir,
-            logger=AgiEnv.logger,
+            logger=self.logger,
         )
 
 
@@ -986,6 +1112,24 @@ class AgiEnv(metaclass=_AgiEnvMeta):
             base_env=os.environ.copy(),
             venv=venv,
             pythonpath_entries=extra_paths,
+            sys_prefix=sys.prefix,
+        )
+
+    def _build_env_for_instance(self, venv=None):
+        """Build subprocess state from this environment, not the singleton."""
+
+        base_env = os.environ.copy()
+        for key, value in dict(getattr(self, "envars", {}) or {}).items():
+            if value is not None:
+                base_env[str(key)] = str(value)
+        if self.apps_path is not None:
+            base_env["APPS_PATH"] = str(self.apps_path)
+        if self.app:
+            base_env["APP_DEFAULT"] = str(self.app)
+        return build_subprocess_env(
+            base_env=base_env,
+            venv=venv,
+            pythonpath_entries=list(getattr(self, "_pythonpath_entries", ()) or ()),
             sys_prefix=sys.prefix,
         )
 
@@ -1090,7 +1234,7 @@ class AgiEnv(metaclass=_AgiEnvMeta):
             apps_path=self.apps_path,  # ty: ignore[invalid-argument-type]
             home_abs=self.home_abs,
             projects=self.projects,
-            logger=AgiEnv.logger,
+            logger=self.logger,
             create_rename_map_fn=self.create_rename_map,
             clone_directory_fn=self.clone_directory,
             cleanup_rename_fn=self._cleanup_rename,
@@ -1142,8 +1286,8 @@ class AgiEnv(metaclass=_AgiEnvMeta):
             agi_share_path_abs=Path(self.agi_share_path_abs),
             user=self.user,
             home_abs=Path(self.home_abs),
-            verbose=AgiEnv.verbose or 0,
-            logger=AgiEnv.logger,
+            verbose=self.verbose or 0,
+            logger=self.logger,
             force_extract=force_extract,
             ensure_dir_fn=_ensure_dir,
             sevenzip_file_cls=py7zr.SevenZipFile,

--- a/src/agilab/core/agi-env/src/agi_env/runtime/agi_env_app_switch_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/runtime/agi_env_app_switch_support.py
@@ -30,13 +30,24 @@ def change_app(env, app):
     existed_before = active_app.exists()
     env_cls = type(env)
     try:
-        env_cls.__init__(
-            env,
-            apps_path=active_app.parent,
-            app=requested_name,
-            verbose=env_cls.verbose,
-            _agilab_reinitialize=True,
-        )
+        reinitialize = getattr(env, "reinitialize_for_app", None)
+        if callable(reinitialize):
+            reinitialize(
+                apps_path=active_app.parent,
+                app=requested_name,
+                verbose=getattr(env, "verbose", 0),
+            )
+        else:
+            lock = getattr(env_cls, "_lock", None)
+            context = lock if lock is not None else _NullContext()
+            with context:
+                env_cls.__init__(
+                    env,
+                    apps_path=active_app.parent,
+                    app=requested_name,
+                    verbose=getattr(env, "verbose", 0),
+                    _agilab_reinitialize=True,
+                )
     except BaseException:
         # Catch only THIS reinit's failure — probing sys.exc_info() would also
         # fire for an unrelated exception being handled in an outer frame.
@@ -47,6 +58,14 @@ def change_app(env, app):
             )
             shutil.rmtree(active_app, ignore_errors=True)
         raise
+
+
+class _NullContext:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
 
 
 def _app_name(value):

--- a/src/agilab/core/agi-env/src/agi_env/runtime/agi_env_execution_methods.py
+++ b/src/agilab/core/agi-env/src/agi_env/runtime/agi_env_execution_methods.py
@@ -42,6 +42,38 @@ async def run(cmd, venv, cwd=None, timeout=None, wait=True, log_callback=None):
     )
 
 
+def _require_session_env(env_obj):
+    if not getattr(env_obj, "_agilab_session_scoped", False):
+        raise RuntimeError(
+            "Bound execution is reserved for AgiEnv.session() environments."
+        )
+    return env_obj
+
+
+async def run_for_session(
+    self,
+    cmd,
+    venv,
+    cwd=None,
+    timeout=None,
+    wait=True,
+    log_callback=None,
+):
+    """Run a command using this session's immutable subprocess snapshot."""
+    env_obj = _require_session_env(self)
+    return await run_command_in_env(
+        cmd,
+        venv,
+        cwd=cwd,
+        timeout=timeout,
+        wait=wait,
+        log_callback=log_callback,
+        verbose=getattr(env_obj, "verbose", 0) or 0,
+        logger=env_obj.logger,
+        build_env_fn=env_obj._build_env_for_instance,
+    )
+
+
 async def run_bg(
     cmd,
     cwd=".",
@@ -66,10 +98,49 @@ async def run_bg(
     )
 
 
+async def run_bg_for_session(
+    self,
+    cmd,
+    cwd=".",
+    venv=None,
+    timeout=None,
+    log_callback=None,
+    env_override: dict | None = None,
+    remove_env: set[str] | None = None,
+):
+    """Run a background command using this session's subprocess snapshot."""
+    env_obj = _require_session_env(self)
+    return await run_command_in_background(
+        cmd,
+        cwd=cwd,
+        venv=venv,
+        timeout=timeout,
+        log_callback=log_callback,
+        env_override=env_override,
+        remove_env=remove_env,
+        logger=env_obj.logger,
+        build_env_fn=env_obj._build_env_for_instance,
+    )
+
+
 async def run_agi(self, code, log_callback=None, venv: Path = None, type=None):  # ty: ignore[invalid-parameter-default]
     """Asynchronous version of run_agi for use within an async context."""
     env_cls = _env_class()
     agi_env_module = importlib.import_module("agi_env.agi_env")
+
+    async def _run_bg_for_bound_env(cmd, **kwargs):
+        return await run_command_in_background(
+            cmd,
+            logger=getattr(self, "logger", env_cls.logger),
+            build_env_fn=self._build_env_for_instance,
+            **kwargs,
+        )
+
+    run_bg_fn = (
+        _run_bg_for_bound_env
+        if getattr(self, "_agilab_session_scoped", False)
+        else _class_static_method(env_cls, "_run_bg")
+    )
 
     return await run_agi_snippet(
         code=code,
@@ -77,11 +148,11 @@ async def run_agi(self, code, log_callback=None, venv: Path = None, type=None): 
         target=str(self.target),
         log_callback=log_callback,
         venv=Path(venv) if venv else None,
-        run_bg_fn=_class_static_method(env_cls, "_run_bg"),
-        ensure_dir_fn=agi_env_module._ensure_dir,
-        logger=env_cls.logger,
+        run_bg_fn=run_bg_fn,
+        ensure_dir_fn=getattr(agi_env_module, "_ensure_dir"),
+        logger=getattr(self, "logger", env_cls.logger),
         python_executable=sys.executable,
-        log_info_fn=agi_env_module.logging.info,
+        log_info_fn=getattr(agi_env_module, "logging").info,
         snippet_type=type,
     )
 
@@ -98,4 +169,26 @@ async def run_async(cmd, venv=None, cwd=None, timeout=None, log_callback=None):
         verbose=env_cls.verbose or 0,
         logger=env_cls.logger,
         build_env_fn=env_cls._build_env,
+    )
+
+
+async def run_async_for_session(
+    self,
+    cmd,
+    venv=None,
+    cwd=None,
+    timeout=None,
+    log_callback=None,
+):
+    """Run an async command using this session's subprocess snapshot."""
+    env_obj = _require_session_env(self)
+    return await run_command_async(
+        cmd,
+        venv=venv,
+        cwd=cwd,
+        timeout=timeout,
+        log_callback=log_callback,
+        verbose=getattr(env_obj, "verbose", 0) or 0,
+        logger=env_obj.logger,
+        build_env_fn=env_obj._build_env_for_instance,
     )

--- a/src/agilab/core/agi-env/src/agi_env/runtime/agi_env_instance_initialization.py
+++ b/src/agilab/core/agi-env/src/agi_env/runtime/agi_env_instance_initialization.py
@@ -90,7 +90,8 @@ def initialize_agi_env_instance(
     )
     envars = loaded.envars
 
-    _propagate_streamlit_message_size(envars)
+    if not getattr(env, "_agilab_session_scoped", False):
+        _propagate_streamlit_message_size(envars)
     package = _resolve_package_bootstrap(loaded.repo_agilab_dir)
 
     apps_path, override_builtin_apps_path = _resolve_requested_apps_path_from_env(
@@ -413,7 +414,7 @@ def _sync_repository_app_links(
         copy_existing_projects_fn=env.copy_existing_projects,
         create_symlink_windows_fn=env_cls.create_symlink_windows,
         symlink_fn=os.symlink,
-        logger=env_cls.logger,
+        logger=env.logger,
         os_name=os.name,
         path_cls=Path,
     )
@@ -564,11 +565,11 @@ def _resolve_worker_base_class(env, *, env_cls) -> None:
 
     env.base_worker_cls, env._base_worker_module = (None, None)
     if (not env.is_source_env) and (not env.is_worker_env):
-        env_cls.logger.debug(
+        env.logger.debug(
             f"Missing {env.target_worker_class} definition; expected {env.worker_path} (packaged end-user env)"
         )
     else:
-        env_cls.logger.info(f"Missing {env.target_worker_class} definition; expected {env.worker_path}")
+        env.logger.info(f"Missing {env.target_worker_class} definition; expected {env.worker_path}")
 
 
 def _configure_credentials_and_project_state(env, *, env_cls, envars) -> None:
@@ -582,7 +583,7 @@ def _configure_credentials_and_project_state(env, *, env_cls, envars) -> None:
 
     env.projects = env.get_projects(env.apps_path, env.builtin_apps_path)
     if not env.projects:
-        env_cls.logger.info(f"Could not find any target project app in {env.agilab_pck / 'apps'}.")
+        env.logger.info(f"Could not find any target project app in {env.agilab_pck / 'apps'}.")
 
     env.setup_app = env.active_app / "build.py"
     env.setup_app_module = getattr(env, "worker_setup_app_module", None) or "build"
@@ -627,7 +628,7 @@ def _extract_packaged_dataset_if_needed(env, *, env_cls) -> None:
     try:
         env.unzip_data(Path(dataset_archive), env.app_data_rel, force_extract=True)
     except (OSError, RuntimeError, ValueError, TypeError) as exc:  # pragma: no cover - defensive guard
-        env_cls.logger.warning("Failed to extract packaged dataset %s: %s", dataset_archive, exc)
+        env.logger.warning("Failed to extract packaged dataset %s: %s", dataset_archive, exc)
 
 
 def _finalize_non_worker_runtime(
@@ -639,7 +640,7 @@ def _finalize_non_worker_runtime(
 ) -> None:
     ensure_dir_fn(env.app_src)
     app_src_str = str(env.app_src)
-    if app_src_str not in sys.path:
+    if not getattr(env, "_agilab_session_scoped", False) and app_src_str not in sys.path:
         sys.path.append(app_src_str)
 
     examples_candidates = [

--- a/src/agilab/core/agi-env/src/agi_env/runtime/agi_env_meta_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/runtime/agi_env_meta_support.py
@@ -6,6 +6,18 @@ import inspect
 class AgiEnvMeta(type):
     """Delegate class attribute access to the singleton instance."""
 
+    def __call__(cls, *args, **kwargs):  # type: ignore[override]
+        """Keep singleton allocation and initialization under one bounded guard."""
+
+        try:
+            construction_guard = type.__getattribute__(
+                cls, "_bounded_construction_guard"
+            )
+        except AttributeError:
+            return super().__call__(*args, **kwargs)
+        with construction_guard():
+            return super().__call__(*args, **kwargs)
+
     def __getattribute__(cls, name):  # type: ignore[override]
         if name in {"_instance", "_lock", "current", "reset", "__dict__", "__weakref__"}:
             return super().__getattribute__(name)

--- a/src/agilab/core/agi-env/src/agi_env/runtime/atomic_write_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/runtime/atomic_write_support.py
@@ -4,8 +4,113 @@ from __future__ import annotations
 
 import os
 import tempfile
+import time
 from pathlib import Path
-from typing import BinaryIO, Callable
+from typing import BinaryIO, Callable, TypeVar
+
+
+_T = TypeVar("_T")
+_WINDOWS_FILE_SHARING_RETRY_TIMEOUT_SECONDS = 0.5
+_WINDOWS_FILE_SHARING_RETRY_INTERVAL_SECONDS = 0.01
+FILE_LOCK_TIMEOUT_SECONDS = 5.0
+FILE_LOCK_RETRY_INTERVAL_SECONDS = 0.05
+
+
+def _is_windows() -> bool:
+    return os.name == "nt"
+
+
+def run_with_windows_file_sharing_retry(
+    operation: Callable[[], _T],
+    *,
+    timeout_seconds: float = _WINDOWS_FILE_SHARING_RETRY_TIMEOUT_SECONDS,
+    retry_interval_seconds: float = _WINDOWS_FILE_SHARING_RETRY_INTERVAL_SECONDS,
+) -> _T:
+    """Run a file operation through Windows' transient sharing-denial window.
+
+    Replacing a file on Windows can briefly make the destination reject new opens,
+    while an external reader can likewise make ``os.replace`` reject publication.
+    Retry only that platform-specific ``PermissionError`` for a bounded interval;
+    all other failures retain their original behavior.
+    """
+
+    if timeout_seconds < 0:
+        raise ValueError("timeout_seconds must be non-negative")
+    if retry_interval_seconds <= 0:
+        raise ValueError("retry_interval_seconds must be positive")
+
+    deadline = time.monotonic() + timeout_seconds
+    while True:
+        try:
+            return operation()
+        except PermissionError:
+            if not _is_windows():
+                raise
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise
+            time.sleep(min(retry_interval_seconds, remaining))
+
+
+def acquire_bounded_file_lock(
+    handle: BinaryIO,
+    lock_path: Path,
+    *,
+    timeout_seconds: float = FILE_LOCK_TIMEOUT_SECONDS,
+    retry_interval_seconds: float = FILE_LOCK_RETRY_INTERVAL_SECONDS,
+) -> None:
+    """Acquire an advisory file lock without allowing a session to hang forever."""
+
+    if timeout_seconds < 0:
+        raise ValueError("timeout_seconds must be non-negative")
+    if retry_interval_seconds <= 0:
+        raise ValueError("retry_interval_seconds must be positive")
+
+    if _is_windows():  # pragma: no cover - exercised on Windows CI
+        import msvcrt
+
+        if lock_path.stat().st_size == 0:
+            handle.write(b"\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+
+        def _try_lock() -> None:
+            handle.seek(0)
+            msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+
+    else:
+        import fcntl
+
+        def _try_lock() -> None:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+    deadline = time.monotonic() + timeout_seconds
+    while True:
+        try:
+            _try_lock()
+            return
+        except OSError as exc:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError(
+                    f"Timed out waiting for AGILAB file lock {lock_path}. "
+                    "Another session may still be updating this file; retry after it finishes."
+                ) from exc
+            time.sleep(min(retry_interval_seconds, remaining))
+
+
+def release_file_lock(handle: BinaryIO) -> None:
+    """Release a lock acquired by :func:`acquire_bounded_file_lock`."""
+
+    if _is_windows():  # pragma: no cover - exercised on Windows CI
+        import msvcrt
+
+        handle.seek(0)
+        msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+    else:
+        import fcntl
+
+        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
 
 
 def atomic_write_bytes(
@@ -27,7 +132,7 @@ def atomic_write_bytes(
             write_fn(handle)
             handle.flush()
             os.fsync(handle.fileno())
-        os.replace(tmp_path, output_path)
+        run_with_windows_file_sharing_retry(lambda: os.replace(tmp_path, output_path))
     except BaseException:
         try:
             tmp_path.unlink()

--- a/src/agilab/core/agi-env/src/agi_env/runtime/destructive_path_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/runtime/destructive_path_support.py
@@ -1,0 +1,110 @@
+"""Shared confinement checks for recursive filesystem deletion."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path, PureWindowsPath
+from typing import Iterable
+
+
+def _resolved_path(value: Path | str) -> Path:
+    try:
+        return Path(value).expanduser().resolve(strict=False)
+    except (OSError, TypeError, ValueError) as exc:
+        raise ValueError(f"invalid filesystem path {value!r}: {exc}") from exc
+
+
+def _path_is_relative_to(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        pass
+    else:
+        return True
+
+    # Existing case aliases on case-insensitive filesystems must follow the
+    # same confinement decision as their canonical spelling.
+    try:
+        if not parent.exists():
+            return False
+    except OSError:
+        return False
+    candidate = path
+    while True:
+        try:
+            if candidate.exists() and candidate.samefile(parent):
+                return True
+        except (OSError, ValueError):
+            pass
+        next_candidate = candidate.parent
+        if next_candidate == candidate:
+            return False
+        candidate = next_candidate
+
+
+def safe_destructive_path(
+    path: Path | str,
+    *,
+    roots: Iterable[Path | str],
+    label: str = "destructive operation",
+    protected_paths: Iterable[Path | str] = (),
+) -> Path:
+    """Resolve ``path`` and prove it is a non-root descendant of a trusted root."""
+
+    try:
+        raw_value = os.fspath(path)
+    except TypeError as exc:
+        raise ValueError(f"{label} target must be a filesystem path") from exc
+    if not isinstance(raw_value, str) or not raw_value.strip() or "\x00" in raw_value:
+        raise ValueError(f"{label} target is empty or malformed")
+
+    raw_path = Path(raw_value).expanduser()
+    windows_path = PureWindowsPath(raw_value)
+    if raw_path in (Path("."), Path("..")) or ".." in (
+        raw_path.parts + windows_path.parts
+    ):
+        raise ValueError(f"{label} target must not contain parent traversal")
+    if windows_path.drive and not windows_path.root:
+        raise ValueError(f"{label} target must not be drive-relative")
+
+    target = _resolved_path(raw_path)
+    if target == Path(target.anchor):
+        raise ValueError(f"{label} target must not be the filesystem root")
+
+    resolved_roots = [_resolved_path(root) for root in roots]
+    if not resolved_roots:
+        raise ValueError(f"{label} requires a trusted confinement root")
+    for root in resolved_roots:
+        if _path_is_relative_to(target, root) and _path_is_relative_to(root, target):
+            raise ValueError(f"{label} target must not be the confinement root")
+    if not any(_path_is_relative_to(target, root) for root in resolved_roots):
+        roots_text = ", ".join(str(root) for root in resolved_roots)
+        raise ValueError(
+            f"{label} target must stay under a trusted root ({roots_text}), got {target}"
+        )
+
+    for protected_path in protected_paths:
+        protected = _resolved_path(protected_path)
+        if target == protected:
+            raise ValueError(f"{label} target must not be protected path {protected}")
+    return target
+
+
+def safe_worker_runtime_cleanup_path(
+    path: Path | str,
+    *,
+    roots: Iterable[Path | str],
+    home_path: Path | str | None = None,
+    cwd_path: Path | str | None = None,
+) -> Path:
+    """Validate an AGILAB worker-runtime target before recursive deletion."""
+
+    protected = tuple(
+        item for item in (home_path, cwd_path) if item is not None
+    )
+    return safe_destructive_path(
+        path,
+        roots=roots,
+        label="worker runtime cleanup",
+        protected_paths=protected,
+    )

--- a/src/agilab/core/agi-env/src/agi_env/runtime/env_config_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/runtime/env_config_support.py
@@ -2,13 +2,304 @@
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 import os
+import os as _stdlib_os
+import re
 from collections.abc import Mapping
 from pathlib import Path
+import shutil
+import stat
+import tempfile
+from typing import Callable, Iterable
 
 from dotenv import dotenv_values, set_key, unset_key
 
+from agi_env.runtime.atomic_write_support import (
+    FILE_LOCK_TIMEOUT_SECONDS,
+    acquire_bounded_file_lock,
+    release_file_lock,
+    run_with_windows_file_sharing_retry,
+)
+
 ENV_MAPPING_EXCEPTIONS = (AttributeError, TypeError)
+_ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_ENV_FILE_LOCK_TIMEOUT_SECONDS = FILE_LOCK_TIMEOUT_SECONDS
+
+
+@contextmanager
+def _env_file_lock(env_file: Path):
+    """Hold a stable cross-process lock for one dotenv transaction."""
+
+    lock_path = env_file.with_name(env_file.name + ".lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    handle = lock_path.open("a+b")
+    locked = False
+    try:
+        acquire_bounded_file_lock(
+            handle,
+            lock_path,
+            timeout_seconds=_ENV_FILE_LOCK_TIMEOUT_SECONDS,
+        )
+        locked = True
+        yield
+    finally:
+        try:
+            if locked:
+                release_file_lock(handle)
+        finally:
+            handle.close()
+
+
+def _fsync_directory(path: Path) -> None:
+    try:
+        fd = _stdlib_os.open(path, _stdlib_os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        _stdlib_os.fsync(fd)
+    except OSError:
+        pass
+    finally:
+        _stdlib_os.close(fd)
+
+
+def _transaction_temp_copy(env_file: Path) -> Path:
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{env_file.name}.", suffix=".tmp", dir=env_file.parent
+    )
+    _stdlib_os.close(fd)
+    tmp_path = Path(tmp_name)
+    if env_file.exists():
+        shutil.copyfile(env_file, tmp_path)
+    return tmp_path
+
+
+def _publish_env_temp(tmp_path: Path, env_file: Path) -> None:
+    # Windows' fsync/_commit requires a writable descriptor.
+    with tmp_path.open("r+b") as stream:
+        _stdlib_os.fsync(stream.fileno())
+    run_with_windows_file_sharing_retry(lambda: _stdlib_os.replace(tmp_path, env_file))
+    _fsync_directory(env_file.parent)
+
+
+def update_env_file_text(
+    env_file: Path,
+    update: Callable[[str | None], str | None],
+    *,
+    encoding: str = "utf-8",
+    file_mode: int | None = None,
+    refuse_symlink_message: str | None = None,
+) -> bool:
+    """Apply one read/modify/write dotenv transaction and publish atomically.
+
+    ``update`` receives ``None`` when the file is missing. Returning ``None``
+    leaves an existing file untouched; returning text publishes it. Existing
+    permissions are preserved unless ``file_mode`` is provided, while newly
+    created files default to owner-only permissions.
+    """
+
+    env_file.parent.mkdir(parents=True, exist_ok=True)
+    with _env_file_lock(env_file):
+        if refuse_symlink_message and env_file.is_symlink():
+            raise OSError(refuse_symlink_message)
+
+        exists = env_file.exists()
+        current_text = (
+            run_with_windows_file_sharing_retry(
+                lambda: env_file.read_text(encoding=encoding)
+            )
+            if exists
+            else None
+        )
+        updated_text = update(current_text)
+        if updated_text is None:
+            return False
+
+        mode = file_mode
+        if mode is None:
+            mode = stat.S_IMODE(env_file.stat().st_mode) if exists else 0o600
+
+        fd, tmp_name = tempfile.mkstemp(
+            prefix=f".{env_file.name}.", suffix=".tmp", dir=env_file.parent
+        )
+        tmp_path = Path(tmp_name)
+        try:
+            with _stdlib_os.fdopen(fd, "w", encoding=encoding) as stream:
+                stream.write(updated_text)
+                stream.flush()
+                _stdlib_os.fsync(stream.fileno())
+            tmp_path.chmod(mode)
+            _publish_env_temp(tmp_path, env_file)
+            return True
+        except BaseException:
+            try:
+                tmp_path.unlink()
+            except FileNotFoundError:
+                pass
+            raise
+
+
+def build_remote_env_update_script(
+    updates: Mapping[str, object],
+    *,
+    default_comments: Iterable[str] = (),
+) -> str:
+    """Build a dependency-free remote dotenv transaction script.
+
+    The emitted script cooperates with local AGILAB writers through the same
+    stable ``.env.lock`` file, merges against the latest content under that
+    lock, and publishes through a uniquely named fsynced temporary file.
+    """
+
+    update_rows = [(str(key), str(value)) for key, value in updates.items()]
+    invalid_keys = [key for key, _value in update_rows if not _ENV_VAR_NAME_RE.fullmatch(key)]
+    if invalid_keys:
+        raise ValueError(f"Invalid dotenv key for remote update: {invalid_keys[0]!r}")
+    comment_rows = [str(line) for line in default_comments]
+    managed_key_comments = "\n".join(
+        f"# managed dotenv key: {key}=" for key, _value in update_rows
+    )
+    template = """\
+import os
+import stat
+import tempfile
+import time
+from contextlib import contextmanager
+from pathlib import Path
+
+__MANAGED_KEYS__
+updates = __UPDATES__
+default_comments = __COMMENTS__
+update_keys = {key for key, _value in updates}
+env_path = Path.home() / ".agilab/.env"
+env_path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def _sharing_retry(operation):
+    deadline = time.monotonic() + 0.5
+    while True:
+        try:
+            return operation()
+        except PermissionError:
+            if os.name != "nt":
+                raise
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise
+            time.sleep(min(0.01, remaining))
+
+
+@contextmanager
+def _env_lock():
+    lock_path = env_path.with_name(env_path.name + ".lock")
+    handle = lock_path.open("a+b")
+    locked = False
+    try:
+        if os.name == "nt":
+            import msvcrt
+
+            if lock_path.stat().st_size == 0:
+                handle.write(b"\\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+            def _try_lock():
+                handle.seek(0)
+                msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+        else:
+            import fcntl
+
+            def _try_lock():
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        deadline = time.monotonic() + 5.0
+        while True:
+            try:
+                _try_lock()
+                locked = True
+                break
+            except OSError as exc:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise TimeoutError(
+                        f"Timed out waiting for AGILAB dotenv lock {lock_path}. "
+                        "Another session may still be updating it; retry after it finishes."
+                    ) from exc
+                time.sleep(min(0.05, remaining))
+        yield
+    finally:
+        if locked:
+            if os.name == "nt":
+                import msvcrt
+
+                handle.seek(0)
+                msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        handle.close()
+
+
+with _env_lock():
+    current = (
+        _sharing_retry(lambda: env_path.read_text(encoding="utf-8"))
+        if env_path.exists()
+        else ""
+    )
+    lines = []
+    existing_keys = set()
+    for raw_line in current.splitlines():
+        candidate = raw_line.strip()
+        if candidate.startswith("#"):
+            candidate = candidate[1:].strip()
+        if "=" in candidate:
+            existing_keys.add(candidate.split("=", 1)[0].strip())
+        active_key = raw_line.split("=", 1)[0].strip()
+        if active_key not in update_keys:
+            lines.append(raw_line)
+
+    missing_comments = []
+    for comment_line in default_comments:
+        key = comment_line.lstrip("#").split("=", 1)[0].strip()
+        if key in update_keys or key in existing_keys:
+            continue
+        missing_comments.append(comment_line)
+    if missing_comments:
+        if lines and lines[-1] != "":
+            lines.append("")
+        lines.append("# Optional AGILAB cluster env defaults (commented)")
+        lines.extend(missing_comments)
+        lines.append("")
+    for key, value in updates:
+        lines.append(f"{key}={value!r}")
+    content = "\\n".join(lines).rstrip() + "\\n"
+
+    mode = stat.S_IMODE(env_path.stat().st_mode) if env_path.exists() else 0o600
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{env_path.name}.", suffix=".tmp", dir=env_path.parent
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            stream.write(content)
+            stream.flush()
+            os.fsync(stream.fileno())
+        tmp_path.chmod(mode)
+        _sharing_retry(lambda: os.replace(tmp_path, env_path))
+    except BaseException:
+        try:
+            tmp_path.unlink()
+        except FileNotFoundError:
+            pass
+        raise
+
+print(str(env_path))
+"""
+    return (
+        template.replace("__MANAGED_KEYS__", managed_key_comments)
+        .replace("__UPDATES__", repr(update_rows))
+        .replace("__COMMENTS__", repr(comment_rows))
+    )
 
 
 def _normalize_env_value(value: object) -> str | None:
@@ -42,7 +333,9 @@ def clean_envar_value(
 def load_dotenv_values(dotenv_path: Path, *, verbose: bool = False) -> dict[str, str]:
     """Load dotenv values while treating blank assignments as unset."""
 
-    loaded = dotenv_values(dotenv_path=dotenv_path, verbose=verbose)
+    loaded = run_with_windows_file_sharing_retry(
+        lambda: dotenv_values(dotenv_path=dotenv_path, verbose=verbose)
+    )
     normalized: dict[str, str] = {}
     for key, value in loaded.items():
         if value is None:
@@ -56,9 +349,20 @@ def load_dotenv_values(dotenv_path: Path, *, verbose: bool = False) -> dict[str,
 def write_env_updates(env_file: Path, updates: dict[str, object]) -> None:
     """Persist updates into a dotenv file without shell-style quoting."""
 
+    if not updates:
+        return
     env_file.parent.mkdir(parents=True, exist_ok=True)
-    for key, value in updates.items():
-        set_key(str(env_file), key, str(value), quote_mode="never")
+    with _env_file_lock(env_file):
+        tmp_path = _transaction_temp_copy(env_file)
+        try:
+            for key, value in updates.items():
+                set_key(str(tmp_path), key, str(value), quote_mode="never")
+            _publish_env_temp(tmp_path, env_file)
+        finally:
+            try:
+                tmp_path.unlink()
+            except FileNotFoundError:
+                pass
 
 
 def remove_env_keys(env_file: Path, keys) -> list[str]:
@@ -69,25 +373,36 @@ def remove_env_keys(env_file: Path, keys) -> list[str]:
     entries idempotently without making python-dotenv emit missing-key warnings.
     """
 
-    if not env_file.exists():
-        return []
-    present_keys = [str(key) for key in dotenv_values(dotenv_path=env_file)]
-    case_insensitive = os.name == "nt"
-    removed: list[str] = []
-    for requested_key in keys:
-        requested = str(requested_key)
-        matching_keys = [
-            present
-            for present in present_keys
-            if (
-                present.casefold() == requested.casefold()
-                if case_insensitive
-                else present == requested
-            )
-        ]
-        for actual_key in matching_keys:
-            result, _ = unset_key(str(env_file), actual_key, quote_mode="never")
-            if result:
-                removed.append(actual_key)
-            present_keys.remove(actual_key)
-    return removed
+    env_file.parent.mkdir(parents=True, exist_ok=True)
+    with _env_file_lock(env_file):
+        if not env_file.exists():
+            return []
+        present_keys = [str(key) for key in dotenv_values(dotenv_path=env_file)]
+        case_insensitive = os.name == "nt"
+        removed: list[str] = []
+        tmp_path = _transaction_temp_copy(env_file)
+        try:
+            for requested_key in keys:
+                requested = str(requested_key)
+                matching_keys = [
+                    present
+                    for present in present_keys
+                    if (
+                        present.casefold() == requested.casefold()
+                        if case_insensitive
+                        else present == requested
+                    )
+                ]
+                for actual_key in matching_keys:
+                    result, _ = unset_key(str(tmp_path), actual_key, quote_mode="never")
+                    if result:
+                        removed.append(actual_key)
+                    present_keys.remove(actual_key)
+            if removed:
+                _publish_env_temp(tmp_path, env_file)
+            return removed
+        finally:
+            try:
+                tmp_path.unlink()
+            except FileNotFoundError:
+                pass

--- a/src/agilab/core/agi-env/src/agi_env/runtime/worker_runtime_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/runtime/worker_runtime_support.py
@@ -192,8 +192,6 @@ def _configure_worker_python_runtime(
     python_supports_free_threading_fn,
 ) -> None:
     distribution_tree = env_obj.wenv_abs / "distribution_tree.json"
-    if distribution_tree.exists():
-        distribution_tree.unlink()
     env_obj.distribution_tree = distribution_tree
 
     pythonpath_entries = env_obj._collect_pythonpath_entries()

--- a/src/agilab/core/agi-env/src/agi_env/shares/share_mount_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/shares/share_mount_support.py
@@ -7,6 +7,8 @@ import tempfile
 from pathlib import Path
 from typing import Callable, Mapping
 
+from agi_env.project.app_settings_support import read_app_settings
+
 SETTINGS_READ_EXCEPTIONS = (OSError, ValueError)
 SETTINGS_LOOKUP_EXCEPTIONS = (OSError, TypeError, ValueError)
 DIR_USABILITY_EXCEPTIONS = (OSError,)
@@ -29,12 +31,7 @@ def _parse_bool(value: object) -> bool | None:
 def _read_cluster_setting(path: Path) -> bool | None:
     """Read ``[cluster].cluster_enabled`` from a TOML settings file."""
     try:
-        if not path.is_file() or path.stat().st_size <= 0:
-            return None
-        import tomllib
-
-        with path.open("rb") as handle:
-            doc = tomllib.load(handle)
+        doc = read_app_settings(path)
         cluster_section = doc.get("cluster")
         if isinstance(cluster_section, dict) and "cluster_enabled" in cluster_section:
             return _parse_bool(cluster_section.get("cluster_enabled"))

--- a/src/agilab/core/agi-env/src/agi_env/ui/pagelib.py
+++ b/src/agilab/core/agi-env/src/agi_env/ui/pagelib.py
@@ -28,6 +28,7 @@ import sys
 import logging
 from ._optional_ui import require_streamlit
 from agi_env import mlflow_store
+from .sidecar_registry import DEFAULT_SIDECAR_REGISTRY
 from .pagelib_execution_support import (
     run_agi as _run_agi_impl,
     run_lab as _run_lab_impl,
@@ -1152,6 +1153,7 @@ def activate_mlflow(env=None):
         wait_for_listen_port_fn=_wait_for_listen_port,
         subproc_fn=subproc,
         cwd=os.getcwd(),
+        sidecar_registry=DEFAULT_SIDECAR_REGISTRY,
     )
 
 
@@ -1166,4 +1168,5 @@ def activate_gpt_oss(env=None):
         cwd=os.getcwd(),
         os_module=os,
         sys_module=sys,
+        sidecar_registry=DEFAULT_SIDECAR_REGISTRY,
     )

--- a/src/agilab/core/agi-env/src/agi_env/ui/pagelib_runtime_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/ui/pagelib_runtime_support.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Callable, Sequence
 
 from agi_env import mlflow_store
+from agi_env.ui.sidecar_registry import SidecarRegistryError
 
 
 _SHELL_METACHARS = frozenset(";&|<>\n\r`$")
@@ -235,12 +236,25 @@ def activate_mlflow(
     wait_for_listen_port_fn,
     subproc_fn,
     cwd,
+    sidecar_registry=None,
 ) -> bool | None:
     """Start the local MLflow server and persist its runtime state."""
     if not env:
         return None
+
+    session_state["server_started"] = False
+    for state_key in (
+        "mlflow_port",
+        "mlflow_endpoint",
+        "mlflow_health_signature",
+    ):
+        session_state.pop(state_key, None)
     if session_state.get("mlflow_autostart_disabled"):
-        return False
+        if sidecar_registry is None:
+            return False
+        # Registry contention and ownership checks are transient. A later
+        # rerun must revalidate a service another session may have published.
+        session_state.pop("mlflow_autostart_disabled", None)
 
     session_state["rapids_default"] = True
     tracking_dir = resolve_mlflow_tracking_dir_fn(env)
@@ -248,36 +262,92 @@ def activate_mlflow(
         logger.info(f"mkdir {tracking_dir}")
     tracking_dir.mkdir(parents=True, exist_ok=True)
     env.MLFLOW_TRACKING_DIR = str(tracking_dir)
+    tracking_scope = str(tracking_dir.resolve(strict=False))
+    log_path = tracking_dir / "mlflow-server.log"
 
-    port = next_free_port_fn()
     try:
-        backend_uri = ensure_default_mlflow_experiment_fn(tracking_dir) or ensure_mlflow_backend_ready_fn(
-            tracking_dir
-        )
-        artifact_uri = resolve_mlflow_artifact_dir_fn(tracking_dir).as_uri()
-        cmd = mlflow_store.mlflow_cli_argv(
-            [
-                "server",
-                "--backend-store-uri",
-                backend_uri,
-                "--default-artifact-root",
-                artifact_uri,
-                "--host",
-                "127.0.0.1",
-                "--port",
-                str(port),
-            ],
-            sys_executable=sys.executable,
-        )
-        log_path = tracking_dir / "mlflow-server.log"
-        process = _launch_mlflow_server(subproc_fn, cmd, cwd, log_path=log_path)
-        if not wait_for_listen_port_fn(port):
+        def _command(
+            owned_port: int,
+            *,
+            backend_uri: str,
+            artifact_uri: str,
+        ) -> list[str]:
+            return mlflow_store.mlflow_cli_argv(
+                [
+                    "server",
+                    "--backend-store-uri",
+                    backend_uri,
+                    "--default-artifact-root",
+                    artifact_uri,
+                    "--host",
+                    "127.0.0.1",
+                    "--port",
+                    str(owned_port),
+                ],
+                sys_executable=sys.executable,
+            )
+
+        process = None
+        if sidecar_registry is not None:
+            with sidecar_registry.preparation_guard(
+                service_kind="mlflow",
+                project=tracking_scope,
+                key=tracking_scope,
+            ):
+                lease = sidecar_registry.get(
+                    service_kind="mlflow",
+                    project=tracking_scope,
+                    key=tracking_scope,
+                )
+                if lease is None:
+                    backend_uri = ensure_default_mlflow_experiment_fn(
+                        tracking_dir
+                    ) or ensure_mlflow_backend_ready_fn(tracking_dir)
+                    artifact_uri = resolve_mlflow_artifact_dir_fn(tracking_dir).as_uri()
+                    lease = sidecar_registry.ensure(
+                        service_kind="mlflow",
+                        project=tracking_scope,
+                        key=tracking_scope,
+                        launcher=lambda owned_port, _token: _launch_mlflow_server(
+                            subproc_fn,
+                            _command(
+                                owned_port,
+                                backend_uri=backend_uri,
+                                artifact_uri=artifact_uri,
+                            ),
+                            cwd,
+                            log_path=log_path,
+                        ),
+                    )
+            port = lease.port
+            endpoint = lease.endpoint
+            session_state["mlflow_health_signature"] = lease.health_signature
+        else:
+            backend_uri = ensure_default_mlflow_experiment_fn(
+                tracking_dir
+            ) or ensure_mlflow_backend_ready_fn(tracking_dir)
+            artifact_uri = resolve_mlflow_artifact_dir_fn(tracking_dir).as_uri()
+            port = next_free_port_fn()
+            endpoint = f"http://127.0.0.1:{port}"
+            process = _launch_mlflow_server(
+                subproc_fn,
+                _command(
+                    port,
+                    backend_uri=backend_uri,
+                    artifact_uri=artifact_uri,
+                ),
+                cwd,
+                log_path=log_path,
+            )
+
+        if sidecar_registry is None and not wait_for_listen_port_fn(port):
             session_state["server_started"] = False
             session_state["mlflow_autostart_disabled"] = True
             session_state["mlflow_log_path"] = str(log_path)
             session_state.pop("mlflow_port", None)
-            _terminate_process_tree(process)
-            poll = getattr(process, "poll", None)
+            if process is not None:
+                _terminate_process_tree(process)
+            poll = getattr(process, "poll", None) if process is not None else None
             returncode = poll() if callable(poll) else None
             status = (
                 f"Failed to start the MLflow server: the process did not open its listening port. "
@@ -290,7 +360,10 @@ def activate_mlflow(
             return False
         session_state["server_started"] = True
         session_state["mlflow_port"] = port
+        session_state["mlflow_endpoint"] = endpoint
         session_state["mlflow_log_path"] = str(log_path)
+        session_state.pop("mlflow_autostart_disabled", None)
+        session_state.pop("mlflow_status_message", None)
         return True
     except mlflow_store.MissingMlflowCliError as exc:
         session_state["server_started"] = False
@@ -300,6 +373,16 @@ def activate_mlflow(
         warning = getattr(streamlit, "warning", None)
         if callable(warning):
             warning(f"MLflow is optional and was not started automatically. {exc}")
+        return False
+    except SidecarRegistryError as exc:
+        log_path = tracking_dir / "mlflow-server.log"
+        status = f"{exc}. Startup log: {log_path}"
+        session_state["server_started"] = False
+        session_state.pop("mlflow_autostart_disabled", None)
+        session_state["mlflow_log_path"] = str(log_path)
+        session_state["mlflow_status_message"] = status
+        session_state.pop("mlflow_port", None)
+        streamlit.error(f"Failed to start the server: {status}")
         return False
     except (RuntimeError, OSError, ValueError, AttributeError) as exc:
         session_state["server_started"] = False
@@ -318,14 +401,26 @@ def activate_gpt_oss(
     cwd,
     os_module=os,
     sys_module=sys,
+    sidecar_registry=None,
 ) -> bool:
     """Start a local GPT-OSS Responses API server when the dependency is available."""
     if not env:
         return False
 
-    if session_state.get("gpt_oss_server_started"):
+    if session_state.get("gpt_oss_server_started") and sidecar_registry is None:
         return True
 
+    for state_key in (
+        "gpt_oss_server_started",
+        "gpt_oss_port",
+        "gpt_oss_endpoint",
+        "gpt_oss_health_signature",
+        "gpt_oss_backend_active",
+        "gpt_oss_checkpoint_active",
+        "gpt_oss_extra_args_active",
+    ):
+        session_state.pop(state_key, None)
+    env.envars.pop("GPT_OSS_ENDPOINT", None)
     session_state.pop("gpt_oss_autostart_failed", None)
     try:
         import gpt_oss  # noqa: F401  # ty: ignore[unresolved-import]
@@ -379,28 +474,62 @@ def activate_gpt_oss(
     else:
         env.envars.pop("GPT_OSS_EXTRA_ARGS", None)
 
-    port = next_free_port_fn()
-    cmd = [
-        python_exec,
-        "-m",
-        "gpt_oss.responses_api.serve",
-        "--inference-backend",
-        backend,
-        "--port",
-        str(int(port)),
-    ]
-    if checkpoint and backend != "stub":
-        cmd.extend(["--checkpoint", checkpoint])
-    cmd.extend(extra_argv)
+    def _command(owned_port: int) -> list[str]:
+        cmd = [
+            python_exec,
+            "-m",
+            "gpt_oss.responses_api.serve",
+            "--inference-backend",
+            backend,
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(int(owned_port)),
+        ]
+        if checkpoint and backend != "stub":
+            cmd.extend(["--checkpoint", checkpoint])
+        cmd.extend(extra_argv)
+        return cmd
+
+    active_app = getattr(env, "active_app", None)
+    if active_app:
+        project_scope = str(Path(active_app).expanduser().resolve(strict=False))
+    else:
+        apps_path = getattr(env, "apps_path", None)
+        app_name = str(getattr(env, "app", "") or "").strip()
+        if apps_path and app_name:
+            project_scope = str(
+                (Path(apps_path).expanduser() / app_name).resolve(strict=False)
+            )
+        else:
+            project_scope = str(Path(cwd).expanduser().resolve(strict=False))
 
     try:
-        subproc_fn(cmd, cwd)
+        if sidecar_registry is not None:
+            lease = sidecar_registry.ensure(
+                service_kind="gpt-oss",
+                project=project_scope,
+                key="|".join((backend, checkpoint, extra_args, str(python_exec))),
+                launcher=lambda owned_port, _token: subproc_fn(
+                    _command(owned_port),
+                    cwd,
+                    start_new_session=True,
+                ),
+                endpoint_builder=lambda owned_port: f"http://127.0.0.1:{owned_port}/v1/responses",
+                exclusive_for_project=True,
+            )
+            port = lease.port
+            endpoint = lease.endpoint
+            session_state["gpt_oss_health_signature"] = lease.health_signature
+        else:
+            port = next_free_port_fn()
+            subproc_fn(_command(port), cwd)
+            endpoint = f"http://127.0.0.1:{port}/v1/responses"
     except (RuntimeError, OSError, ValueError) as exc:
         streamlit.error(f"Failed to start GPT-OSS server: {exc}")
         session_state["gpt_oss_autostart_failed"] = True
         return False
 
-    endpoint = f"http://127.0.0.1:{port}/v1/responses"
     session_state["gpt_oss_server_started"] = True
     session_state["gpt_oss_port"] = port
     session_state["gpt_oss_endpoint"] = endpoint

--- a/src/agilab/core/agi-env/src/agi_env/ui/sidecar_registry.py
+++ b/src/agilab/core/agi-env/src/agi_env/ui/sidecar_registry.py
@@ -1,0 +1,1036 @@
+"""Verified process ownership for local UI sidecars and background services."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import asdict, dataclass
+import hashlib
+import hmac
+import json
+import os
+from pathlib import Path
+import secrets
+import socket
+import sys
+import tempfile
+import threading
+import time
+from typing import Any, Callable, Iterator
+from urllib.parse import urlparse
+
+import psutil
+
+
+class SidecarRegistryError(RuntimeError):
+    """Base class for fail-closed sidecar ownership errors."""
+
+
+class SidecarRegistryBusyError(SidecarRegistryError):
+    """Raised when another process is updating the registry."""
+
+
+class SidecarCollisionError(SidecarRegistryError):
+    """Raised when a registered endpoint is owned by an unexpected process."""
+
+
+class SidecarStartError(SidecarRegistryError):
+    """Raised when a launched process cannot prove endpoint ownership."""
+
+
+@dataclass(frozen=True, slots=True)
+class SidecarLease:
+    service_kind: str
+    project: str
+    key: str
+    endpoint: str
+    token: str
+    pid: int
+    process_started_at: float
+    command_digest: str
+    registered_at: float
+    health_signature: str
+
+    @property
+    def host(self) -> str:
+        parsed = urlparse(self.endpoint)
+        if parsed.hostname not in {"127.0.0.1", "localhost"}:
+            raise SidecarRegistryError(f"Invalid loopback sidecar endpoint: {self.endpoint!r}")
+        # Ports are allocated on IPv4 loopback, so ``localhost`` leases must
+        # prove ownership of that same concrete bind address rather than any
+        # address returned by host-name resolution.
+        return "127.0.0.1"
+
+    @property
+    def port(self) -> int:
+        parsed = urlparse(self.endpoint)
+        if self.host != "127.0.0.1" or parsed.port is None:
+            raise SidecarRegistryError(f"Invalid loopback sidecar endpoint: {self.endpoint!r}")
+        return int(parsed.port)
+
+
+_THREAD_GUARD = threading.RLock()
+_ENSURE_THREAD_GUARDS_LOCK = threading.Lock()
+_ENSURE_THREAD_GUARDS: dict[str, threading.RLock] = {}
+_PORT_RESERVATIONS_LOCK = threading.Lock()
+_PORT_RESERVATIONS: set[str] = set()
+_PREPARATION_THREAD_GUARDS_LOCK = threading.Lock()
+_PREPARATION_THREAD_GUARDS: dict[str, threading.RLock] = {}
+HOSTED_INLINE_RENDER_LEASE = threading.RLock()
+HOSTED_INLINE_RENDER_SESSION_LEASE = threading.Lock()
+_HOSTED_INLINE_RENDER_LOCK_TIMEOUT_SECONDS = 5.0
+
+
+@contextmanager
+def _bounded_thread_guard(
+    lock: Any,
+    *,
+    timeout: float,
+    purpose: str,
+) -> Iterator[None]:
+    """Acquire a process-local guard without freezing every peer session."""
+
+    acquired = lock.acquire(timeout=max(float(timeout), 0.0))
+    if not acquired:
+        raise SidecarRegistryBusyError(
+            f"Timed out waiting for {purpose}; another AGILAB session is still using it"
+        )
+    try:
+        yield
+    finally:
+        lock.release()
+
+
+@contextmanager
+def hosted_inline_render_guard(
+    *,
+    timeout: float | None = None,
+) -> Iterator[None]:
+    """Bound process-global mutations shared by hosted inline render paths."""
+
+    effective_timeout = (
+        _HOSTED_INLINE_RENDER_LOCK_TIMEOUT_SECONDS
+        if timeout is None
+        else timeout
+    )
+    with _bounded_thread_guard(
+        HOSTED_INLINE_RENDER_LEASE,
+        timeout=effective_timeout,
+        purpose="hosted inline render lease",
+    ):
+        yield
+
+
+def _importable_root_names(root: Path) -> set[str]:
+    names: set[str] = set()
+    try:
+        children = sorted(root.iterdir(), key=lambda path: path.name)
+    except OSError:
+        return names
+    for child in children:
+        if child.is_file() and child.suffix == ".py" and child.stem != "__init__":
+            names.add(child.stem)
+        elif child.is_dir() and (child / "__init__.py").is_file():
+            names.add(child.name)
+    return names
+
+
+def _module_is_below(module: Any, roots: tuple[Path, ...]) -> bool:
+    raw_path = getattr(module, "__file__", None)
+    if not raw_path:
+        return False
+    try:
+        module_path = Path(raw_path).resolve(strict=False)
+    except (OSError, TypeError, ValueError):
+        return False
+    for root in roots:
+        try:
+            module_path.relative_to(root)
+            return True
+        except ValueError:
+            continue
+    return False
+
+
+@contextmanager
+def isolated_import_process_state(
+    *,
+    argv: list[str] | None = None,
+    prepend_paths: tuple[Path, ...] = (),
+    module_roots: tuple[Path, ...] = (),
+    timeout: float = _HOSTED_INLINE_RENDER_LOCK_TIMEOUT_SECONDS,
+) -> Iterator[None]:
+    """Serialize and restore temporary import globals used by hosted UI code.
+
+    Importable names rooted in the temporary directories are evicted before the
+    import so a helper from another app cannot be reused by name. Newly imported
+    modules from those roots are removed afterwards, and prior modules are restored.
+    """
+
+    with hosted_inline_render_guard(timeout=timeout):
+        original_argv = list(sys.argv)
+        original_path = list(sys.path)
+        roots = tuple(Path(root).resolve(strict=False) for root in module_roots)
+        root_names: set[str] = set()
+        for root in roots:
+            root_names.update(_importable_root_names(root))
+        saved_modules: dict[str, Any] = {}
+        for module_name in tuple(sys.modules):
+            top_level = module_name.partition(".")[0]
+            if top_level in root_names:
+                saved_modules[module_name] = sys.modules.pop(module_name)
+
+        try:
+            if argv is not None:
+                sys.argv = list(argv)
+            for path in reversed(prepend_paths):
+                entry = str(Path(path).resolve(strict=False))
+                sys.path[:] = [existing for existing in sys.path if existing != entry]
+                sys.path.insert(0, entry)
+            yield
+        finally:
+            for module_name, module in tuple(sys.modules.items()):
+                if _module_is_below(module, roots):
+                    sys.modules.pop(module_name, None)
+            sys.modules.update(saved_modules)
+            sys.argv = original_argv
+            sys.path[:] = original_path
+
+
+class ProcessSidecarRegistry:
+    """Cross-session registry backed by signed, process-verified leases."""
+
+    def __init__(self, root: Path | None = None) -> None:
+        self.root = Path(root) if root is not None else Path.home() / ".agilab" / "runtime" / "sidecars"
+        self.registry_path = self.root / "registry.json"
+        self.lock_path = self.root / "registry.lock"
+        self.secret_path = self.root / "registry.secret"
+
+    def ensure(
+        self,
+        *,
+        service_kind: str,
+        project: str,
+        key: str,
+        launcher: Callable[[int, str], Any],
+        token: str | None = None,
+        endpoint_builder: Callable[[int], str] | None = None,
+        replace_existing_for_project: bool = False,
+        exclusive_for_project: bool = False,
+        timeout: float = 24.0,
+    ) -> SidecarLease:
+        """Reuse a verified process or launch and register a new owned service."""
+
+        kind = self._nonempty(service_kind, "service kind")
+        project_id = self._nonempty(project, "project")
+        service_key = self._nonempty(key, "service key")
+        entry_id = self._entry_id(kind, project_id, service_key)
+        endpoint_builder = endpoint_builder or (lambda port: f"http://127.0.0.1:{port}")
+        if replace_existing_for_project and exclusive_for_project:
+            raise ValueError(
+                "A sidecar cannot both replace and reject another project configuration."
+            )
+
+        lock_timeout = max(timeout, 5.0)
+        with self._ensure_guard(
+            service_kind=kind,
+            project=project_id,
+            timeout=lock_timeout,
+        ):
+            with _bounded_thread_guard(
+                _THREAD_GUARD,
+                timeout=lock_timeout,
+                purpose="sidecar registry thread lock",
+            ), self._file_guard(timeout=lock_timeout):
+                entries = self._load_entries()
+                if replace_existing_for_project:
+                    self._retire_project_entries(
+                        entries,
+                        service_kind=kind,
+                        project=project_id,
+                        keep_entry_id=entry_id,
+                    )
+                if exclusive_for_project:
+                    self._reject_project_entry_conflicts(
+                        entries,
+                        service_kind=kind,
+                        project=project_id,
+                        keep_entry_id=entry_id,
+                    )
+                raw_existing = entries.get(entry_id)
+                if raw_existing is not None and not isinstance(raw_existing, dict):
+                    raise SidecarRegistryError(
+                        f"Invalid sidecar registry entry for {kind}/{project_id}"
+                    )
+                if isinstance(raw_existing, dict):
+                    existing = self._verified_lease(raw_existing)
+                    if self._lease_is_healthy(existing):
+                        return existing
+                    identity_status = self._process_identity_status(
+                        existing.pid,
+                        existing.process_started_at,
+                    )
+                    if identity_status is not False:
+                        detail = (
+                            "is still live"
+                            if identity_status is True
+                            else "cannot be verified"
+                        )
+                        raise SidecarCollisionError(
+                            f"Registered sidecar process {existing.pid} {detail}, but endpoint "
+                            f"health for {existing.endpoint} is not proven; refusing to launch a "
+                            "replacement."
+                        )
+                    if self._port_is_open(existing.port):
+                        raise SidecarCollisionError(
+                            f"Sidecar endpoint {existing.endpoint} is listening without its "
+                            "registered PID/start identity; refusing to reuse an unrelated process."
+                        )
+                    entries.pop(entry_id, None)
+                    self._write_entries(entries)
+
+            with self._reserved_loopback_port(timeout=lock_timeout) as port:
+                service_token = token or secrets.token_urlsafe(32)
+                endpoint = endpoint_builder(port)
+                parsed = urlparse(endpoint)
+                if parsed.hostname not in {"127.0.0.1", "localhost"} or parsed.port != port:
+                    raise SidecarRegistryError(
+                        "Sidecar endpoint builder must preserve the allocated loopback port: "
+                        f"{endpoint!r}"
+                    )
+
+                try:
+                    process = launcher(port, service_token)
+                except BaseException as exc:
+                    raise SidecarStartError(f"Failed to launch {kind} sidecar: {exc}") from exc
+
+                pid: int | None = None
+                started_at: float | None = None
+                observed_processes: dict[int, float] = {}
+                try:
+                    raw_pid = getattr(process, "pid", None)
+                    if not isinstance(raw_pid, int) or raw_pid <= 0:
+                        raise SidecarStartError(
+                            f"{kind} launcher did not return an owned process handle"
+                        )
+                    pid = raw_pid
+                    try:
+                        started_at = float(psutil.Process(pid).create_time())
+                    except (psutil.Error, OSError, ValueError) as exc:
+                        raise SidecarStartError(
+                            f"Could not verify {kind} process identity for PID {pid}"
+                        ) from exc
+
+                    deadline = time.monotonic() + max(timeout, 0.1)
+                    observed_processes[pid] = started_at
+                    while time.monotonic() < deadline:
+                        observed_processes.update(
+                            self._process_tree_identities(pid, started_at)
+                        )
+                        poll = getattr(process, "poll", None)
+                        if callable(poll) and poll() is not None:
+                            break
+                        endpoint_host = "127.0.0.1"
+                        if self._process_owns_endpoint(
+                            pid,
+                            started_at,
+                            endpoint_host,
+                            port,
+                        ):
+                            command_digest = self._command_digest(pid, started_at)
+                            unsigned = {
+                                "service_kind": kind,
+                                "project": project_id,
+                                "key": service_key,
+                                "endpoint": endpoint,
+                                "token": service_token,
+                                "pid": pid,
+                                "process_started_at": started_at,
+                                "command_digest": command_digest,
+                                "registered_at": time.time(),
+                            }
+                            with _bounded_thread_guard(
+                                _THREAD_GUARD,
+                                timeout=lock_timeout,
+                                purpose="sidecar registry thread lock",
+                            ), self._file_guard(timeout=lock_timeout):
+                                entries = self._load_entries()
+                                if entry_id in entries:
+                                    raise SidecarCollisionError(
+                                        f"Sidecar registry entry for {kind}/{project_id} changed "
+                                        "while its replacement was starting"
+                                    )
+                                lease = SidecarLease(
+                                    **unsigned,
+                                    health_signature=self._sign(unsigned),
+                                )
+                                entries[entry_id] = asdict(lease)
+                                self._write_entries(entries)
+                            return lease
+                        time.sleep(0.1)
+
+                    raise SidecarStartError(
+                        f"{kind} process PID {pid} did not prove ownership of {endpoint} "
+                        f"within {timeout:.1f}s"
+                    )
+                except BaseException:
+                    try:
+                        self._terminate_process(
+                            process,
+                            root_pid=pid,
+                            root_started_at=started_at,
+                            observed_processes=observed_processes,
+                        )
+                    except BaseException:
+                        # Cleanup must never replace the failure that caused it.
+                        pass
+                    raise
+
+    def _reject_project_entry_conflicts(
+        self,
+        entries: dict[str, Any],
+        *,
+        service_kind: str,
+        project: str,
+        keep_entry_id: str,
+    ) -> None:
+        """Refuse a different live project configuration without terminating it."""
+
+        changed = False
+        for candidate_id, raw_entry in tuple(entries.items()):
+            if candidate_id == keep_entry_id or not isinstance(raw_entry, dict):
+                continue
+            if (
+                raw_entry.get("service_kind") != service_kind
+                or raw_entry.get("project") != project
+            ):
+                continue
+
+            lease = self._verified_lease(raw_entry)
+            if self._lease_is_healthy(lease):
+                raise SidecarCollisionError(
+                    f"A different {service_kind} configuration is already active for "
+                    f"{project} at {lease.endpoint}; refusing to replace another session's service."
+                )
+
+            identity_status = self._process_identity_status(
+                lease.pid,
+                lease.process_started_at,
+            )
+            if identity_status is not False:
+                detail = "is still live" if identity_status is True else "cannot be verified"
+                raise SidecarCollisionError(
+                    f"A different registered {service_kind} process {lease.pid} {detail} "
+                    f"for {project}; refusing to replace another session's service."
+                )
+            if self._port_is_open(lease.port):
+                raise SidecarCollisionError(
+                    f"A different {service_kind} endpoint is listening on port {lease.port} "
+                    f"for {project}; refusing to replace an unrelated process."
+                )
+            entries.pop(candidate_id, None)
+            changed = True
+
+        if changed:
+            self._write_entries(entries)
+
+    def get(self, *, service_kind: str, project: str, key: str) -> SidecarLease | None:
+        """Return a verified lease, deleting dead entries without trusting the port alone."""
+
+        entry_id = self._entry_id(service_kind, project, key)
+        with _bounded_thread_guard(
+            _THREAD_GUARD,
+            timeout=5.0,
+            purpose="sidecar registry thread lock",
+        ), self._file_guard(timeout=5.0):
+            entries = self._load_entries()
+            raw = entries.get(entry_id)
+            if raw is None:
+                return None
+            if not isinstance(raw, dict):
+                raise SidecarRegistryError(
+                    f"Invalid sidecar registry entry for {service_kind}/{project}"
+                )
+            lease = self._verified_lease(raw)
+            if self._lease_is_healthy(lease):
+                return lease
+            identity_status = self._process_identity_status(
+                lease.pid,
+                lease.process_started_at,
+            )
+            if identity_status is not False:
+                detail = "is still live" if identity_status is True else "cannot be verified"
+                raise SidecarCollisionError(
+                    f"Registered sidecar process {lease.pid} {detail}, but endpoint "
+                    f"health for {lease.endpoint} is not proven"
+                )
+            if self._port_is_open(lease.port):
+                raise SidecarCollisionError(
+                    f"Registered sidecar endpoint {lease.endpoint} no longer matches its process identity"
+                )
+            entries.pop(entry_id, None)
+            self._write_entries(entries)
+            return None
+
+    @contextmanager
+    def _ensure_guard(
+        self,
+        *,
+        service_kind: str,
+        project: str,
+        timeout: float,
+    ) -> Iterator[None]:
+        """Serialize one logical service without blocking unrelated launches."""
+
+        scope_id = self._entry_id(service_kind, project, "sidecar-service")
+        guard_key = f"{self.root.resolve(strict=False)}\0{scope_id}"
+        with _ENSURE_THREAD_GUARDS_LOCK:
+            thread_guard = _ENSURE_THREAD_GUARDS.setdefault(
+                guard_key,
+                threading.RLock(),
+            )
+        service_lock = self.root / f"service-{scope_id}.lock"
+        with _bounded_thread_guard(
+            thread_guard,
+            timeout=timeout,
+            purpose="sidecar service thread lock",
+        ), self._locked_file_guard(
+            service_lock,
+            timeout=timeout,
+            purpose="sidecar-service",
+        ):
+            yield
+
+    @contextmanager
+    def _reserved_loopback_port(self, *, timeout: float) -> Iterator[int]:
+        """Reserve an allocated port across concurrent registry launchers."""
+
+        deadline = time.monotonic() + timeout
+        while True:
+            if time.monotonic() >= deadline:
+                raise SidecarRegistryBusyError(
+                    "Timed out reserving a loopback port for sidecar launch"
+                )
+            port = self._allocate_loopback_port()
+            lock_path = self.root / f"port-{port}.lock"
+            reservation_key = str(lock_path.resolve(strict=False))
+            with _PORT_RESERVATIONS_LOCK:
+                if reservation_key in _PORT_RESERVATIONS:
+                    claimed_in_process = False
+                else:
+                    _PORT_RESERVATIONS.add(reservation_key)
+                    claimed_in_process = True
+            if not claimed_in_process:
+                time.sleep(0.01)
+                continue
+
+            handle = None
+            locked = False
+            try:
+                self.root.mkdir(parents=True, exist_ok=True)
+                handle = lock_path.open("a+b")
+                if not self._try_advisory_lock(handle):
+                    time.sleep(0.01)
+                    continue
+                locked = True
+                yield port
+                return
+            finally:
+                if handle is not None:
+                    if locked:
+                        self._unlock_advisory_lock(handle)
+                    handle.close()
+                with _PORT_RESERVATIONS_LOCK:
+                    _PORT_RESERVATIONS.discard(reservation_key)
+
+    @contextmanager
+    def preparation_guard(
+        self,
+        *,
+        service_kind: str,
+        project: str,
+        key: str,
+        timeout: float = 120.0,
+    ) -> Iterator[None]:
+        """Serialize destructive preparation for one shared sidecar resource."""
+
+        entry_id = self._entry_id(
+            self._nonempty(service_kind, "service kind"),
+            self._nonempty(project, "project"),
+            self._nonempty(key, "preparation key"),
+        )
+        with _PREPARATION_THREAD_GUARDS_LOCK:
+            thread_guard = _PREPARATION_THREAD_GUARDS.setdefault(
+                entry_id,
+                threading.RLock(),
+            )
+        preparation_lock = self.root / f"prepare-{entry_id}.lock"
+        with _bounded_thread_guard(
+            thread_guard,
+            timeout=timeout,
+            purpose="sidecar preparation thread lock",
+        ), self._locked_file_guard(
+            preparation_lock,
+            timeout=timeout,
+            purpose="sidecar-preparation",
+        ):
+            yield
+
+    @staticmethod
+    def _nonempty(value: object, label: str) -> str:
+        result = str(value or "").strip()
+        if not result:
+            raise ValueError(f"{label} must be non-empty")
+        return result
+
+    @staticmethod
+    def _entry_id(service_kind: str, project: str, key: str) -> str:
+        payload = "\0".join((str(service_kind), str(project), str(key)))
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+    @contextmanager
+    def _file_guard(self, *, timeout: float) -> Iterator[None]:
+        with self._locked_file_guard(
+            self.lock_path,
+            timeout=timeout,
+            purpose="sidecar-registry",
+        ):
+            yield
+
+    @contextmanager
+    def _locked_file_guard(
+        self,
+        lock_path: Path,
+        *,
+        timeout: float,
+        purpose: str,
+    ) -> Iterator[None]:
+        self.root.mkdir(parents=True, exist_ok=True)
+        deadline = time.monotonic() + timeout
+        handle = lock_path.open("a+b")
+        locked = False
+        try:
+            while not self._try_advisory_lock(handle):
+                if time.monotonic() >= deadline:
+                    raise SidecarRegistryBusyError(
+                        f"Timed out waiting for {purpose} lock {lock_path}"
+                    )
+                time.sleep(0.05)
+            locked = True
+            payload = (
+                json.dumps(
+                    {
+                        "purpose": purpose,
+                        "pid": os.getpid(),
+                        "started_at": self._current_process_start(),
+                    },
+                    sort_keys=True,
+                )
+                + "\n"
+            ).encode("utf-8")
+            handle.seek(0)
+            handle.truncate(0)
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+            yield
+        finally:
+            try:
+                if locked:
+                    self._unlock_advisory_lock(handle)
+            finally:
+                handle.close()
+
+    @staticmethod
+    def _try_advisory_lock(handle) -> bool:
+        if os.name == "nt":  # pragma: no cover - exercised on Windows CI
+            import msvcrt
+
+            try:
+                handle.seek(0, os.SEEK_END)
+                if handle.tell() == 0:
+                    handle.write(b"\n")
+                    handle.flush()
+                    os.fsync(handle.fileno())
+                handle.seek(0)
+                msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+                return True
+            except OSError:
+                return False
+        import fcntl
+
+        try:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            return True
+        except (BlockingIOError, OSError):
+            return False
+
+    @staticmethod
+    def _unlock_advisory_lock(handle) -> None:
+        try:
+            if os.name == "nt":  # pragma: no cover - exercised on Windows CI
+                import msvcrt
+
+                handle.seek(0)
+                msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        except OSError:
+            pass
+
+    def _load_entries(self) -> dict[str, dict[str, Any]]:
+        try:
+            payload = json.loads(self.registry_path.read_text(encoding="utf-8"))
+        except FileNotFoundError:
+            return {}
+        except (OSError, json.JSONDecodeError) as exc:
+            raise SidecarRegistryError(f"Could not read sidecar registry {self.registry_path}: {exc}") from exc
+        entries = payload.get("entries", {}) if isinstance(payload, dict) else {}
+        if not isinstance(entries, dict):
+            raise SidecarRegistryError(f"Invalid sidecar registry structure in {self.registry_path}")
+        return entries
+
+    def _write_entries(self, entries: dict[str, dict[str, Any]]) -> None:
+        self.root.mkdir(parents=True, exist_ok=True)
+        fd, tmp_name = tempfile.mkstemp(prefix="registry-", suffix=".tmp", dir=self.root)
+        tmp_path = Path(tmp_name)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump({"version": 1, "entries": entries}, handle, sort_keys=True)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.chmod(tmp_path, 0o600)
+            os.replace(tmp_path, self.registry_path)
+            self._fsync_directory(self.root)
+        finally:
+            try:
+                tmp_path.unlink()
+            except FileNotFoundError:
+                pass
+
+    def _load_secret(self) -> bytes:
+        self.root.mkdir(parents=True, exist_ok=True)
+        if not self.secret_path.exists():
+            fd, tmp_name = tempfile.mkstemp(
+                prefix=f".{self.secret_path.name}.",
+                suffix=".tmp",
+                dir=self.root,
+            )
+            tmp_path = Path(tmp_name)
+            try:
+                os.chmod(tmp_path, 0o600)
+                secret = secrets.token_bytes(32)
+                offset = 0
+                while offset < len(secret):
+                    offset += os.write(fd, secret[offset:])
+                os.fsync(fd)
+                os.close(fd)
+                fd = -1
+                os.replace(tmp_path, self.secret_path)
+                self._fsync_directory(self.root)
+            finally:
+                if fd >= 0:
+                    os.close(fd)
+                try:
+                    tmp_path.unlink()
+                except FileNotFoundError:
+                    pass
+        try:
+            secret = self.secret_path.read_bytes()
+        except OSError as exc:
+            raise SidecarRegistryError(f"Could not read registry secret {self.secret_path}: {exc}") from exc
+        if len(secret) < 32:
+            raise SidecarRegistryError(f"Registry secret is invalid: {self.secret_path}")
+        return secret
+
+    def _sign(self, payload: dict[str, Any]) -> str:
+        encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        return hmac.new(self._load_secret(), encoded, hashlib.sha256).hexdigest()
+
+    def _lease_from_dict(self, raw: dict[str, Any]) -> SidecarLease | None:
+        try:
+            return SidecarLease(
+                service_kind=str(raw["service_kind"]),
+                project=str(raw["project"]),
+                key=str(raw["key"]),
+                endpoint=str(raw["endpoint"]),
+                token=str(raw["token"]),
+                pid=int(raw["pid"]),
+                process_started_at=float(raw["process_started_at"]),
+                command_digest=str(raw["command_digest"]),
+                registered_at=float(raw["registered_at"]),
+                health_signature=str(raw["health_signature"]),
+            )
+        except (KeyError, TypeError, ValueError):
+            return None
+
+    def _verified_lease(self, raw: dict[str, Any]) -> SidecarLease:
+        lease = self._lease_from_dict(raw)
+        if lease is None:
+            raise SidecarRegistryError(f"Invalid sidecar registry entry in {self.registry_path}")
+        unsigned = asdict(lease)
+        signature = str(unsigned.pop("health_signature"))
+        if not hmac.compare_digest(signature, self._sign(unsigned)):
+            raise SidecarRegistryError(
+                f"Sidecar registry signature validation failed for PID {lease.pid}"
+            )
+        return lease
+
+    def _lease_is_healthy(self, lease: SidecarLease) -> bool:
+        unsigned = asdict(lease)
+        signature = str(unsigned.pop("health_signature"))
+        if not hmac.compare_digest(signature, self._sign(unsigned)):
+            return False
+        if not self._process_matches(lease.pid, lease.process_started_at):
+            return False
+        if self._command_digest(lease.pid, lease.process_started_at) != lease.command_digest:
+            return False
+        return self._process_owns_endpoint(
+            lease.pid,
+            lease.process_started_at,
+            lease.host,
+            lease.port,
+        )
+
+    @staticmethod
+    def _current_process_start() -> float:
+        return float(psutil.Process(os.getpid()).create_time())
+
+    @staticmethod
+    def _process_identity_status(pid: int, started_at: float) -> bool | None:
+        try:
+            process = psutil.Process(pid)
+            if not process.is_running() or process.status() == psutil.STATUS_ZOMBIE:
+                return False
+            return abs(float(process.create_time()) - float(started_at)) < 0.01
+        except psutil.NoSuchProcess:
+            return False
+        except (psutil.Error, OSError, ValueError):
+            return None
+
+    @classmethod
+    def _process_matches(cls, pid: int, started_at: float) -> bool:
+        return cls._process_identity_status(pid, started_at) is True
+
+    def _retire_project_entries(
+        self,
+        entries: dict[str, dict[str, Any]],
+        *,
+        service_kind: str,
+        project: str,
+        keep_entry_id: str,
+    ) -> None:
+        changed = False
+        for candidate_id in sorted(entries):
+            if candidate_id == keep_entry_id:
+                continue
+            raw = entries.get(candidate_id)
+            if not isinstance(raw, dict):
+                continue
+            if (
+                str(raw.get("service_kind", "")) != service_kind
+                or str(raw.get("project", "")) != project
+            ):
+                continue
+            lease = self._verified_lease(raw)
+            identity_status = self._process_identity_status(
+                lease.pid,
+                lease.process_started_at,
+            )
+            if identity_status is None:
+                raise SidecarCollisionError(
+                    f"Cannot verify obsolete {service_kind} sidecar PID {lease.pid}; "
+                    "refusing configuration replacement."
+                )
+            if identity_status is True:
+                try:
+                    process = psutil.Process(lease.pid)
+                except psutil.NoSuchProcess:
+                    process = None
+                except psutil.Error as exc:
+                    raise SidecarCollisionError(
+                        f"Cannot inspect obsolete {service_kind} sidecar PID {lease.pid}"
+                    ) from exc
+                if process is not None:
+                    observed = self._process_tree_identities(
+                        lease.pid,
+                        lease.process_started_at,
+                    )
+                    self._terminate_process(
+                        process,
+                        root_pid=lease.pid,
+                        root_started_at=lease.process_started_at,
+                        observed_processes=observed,
+                    )
+                    if self._process_identity_status(
+                        lease.pid,
+                        lease.process_started_at,
+                    ) is not False:
+                        raise SidecarCollisionError(
+                            f"Could not stop obsolete {service_kind} sidecar PID {lease.pid}"
+                        )
+            if self._port_is_open(lease.port):
+                raise SidecarCollisionError(
+                    f"Obsolete {service_kind} endpoint {lease.endpoint} is still listening"
+                )
+            entries.pop(candidate_id, None)
+            changed = True
+        if changed:
+            self._write_entries(entries)
+
+    @classmethod
+    def _process_tree(cls, pid: int, started_at: float) -> list[psutil.Process]:
+        if not cls._process_matches(pid, started_at):
+            return []
+        try:
+            root = psutil.Process(pid)
+            return [root, *root.children(recursive=True)]
+        except (psutil.Error, OSError):
+            return []
+
+    @classmethod
+    def _process_tree_identities(cls, pid: int, started_at: float) -> dict[int, float]:
+        identities: dict[int, float] = {}
+        for process in cls._process_tree(pid, started_at):
+            try:
+                identities[int(process.pid)] = float(process.create_time())
+            except (psutil.Error, OSError, ValueError):
+                continue
+        return identities
+
+    @classmethod
+    def _process_owns_endpoint(
+        cls,
+        pid: int,
+        started_at: float,
+        host: str,
+        port: int,
+    ) -> bool:
+        if host != "127.0.0.1":
+            return False
+        for process in cls._process_tree(pid, started_at):
+            try:
+                connections = process.net_connections(kind="tcp")
+            except (psutil.Error, OSError):
+                continue
+            for connection in connections:
+                local = getattr(connection, "laddr", None)
+                local_ip = getattr(local, "ip", None) if local else None
+                local_port = getattr(local, "port", None) if local else None
+                if local and (local_ip is None or local_port is None):
+                    try:
+                        local_ip = local[0]
+                        local_port = local[1]
+                    except (IndexError, TypeError):
+                        local_ip = None
+                        local_port = None
+                try:
+                    family = int(getattr(connection, "family"))
+                except (AttributeError, TypeError, ValueError):
+                    continue
+                if family != int(socket.AF_INET):
+                    continue
+                if str(local_ip) != host:
+                    continue
+                if local_port is None or int(local_port) != int(port):
+                    continue
+                status = str(getattr(connection, "status", ""))
+                if status.upper() == "LISTEN":
+                    return True
+        return False
+
+    @classmethod
+    def _command_digest(cls, pid: int, started_at: float) -> str:
+        if not cls._process_matches(pid, started_at):
+            return ""
+        try:
+            command = "\0".join(psutil.Process(pid).cmdline())
+        except (psutil.Error, OSError):
+            return ""
+        # The root process remains stable while launchers such as uv can turn
+        # child processes over. Port ownership is still verified over the full
+        # process tree, so child churn cannot invalidate a legitimate lease.
+        return hashlib.sha256(command.encode("utf-8")).hexdigest()
+
+    @staticmethod
+    def _allocate_loopback_port() -> int:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.bind(("127.0.0.1", 0))
+            return int(sock.getsockname()[1])
+
+    @staticmethod
+    def _port_is_open(port: int) -> bool:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.settimeout(0.2)
+            return sock.connect_ex(("127.0.0.1", int(port))) == 0
+
+    @staticmethod
+    def _fsync_directory(path: Path) -> None:
+        try:
+            directory_fd = os.open(path, os.O_RDONLY)
+        except OSError:
+            return
+        try:
+            os.fsync(directory_fd)
+        except OSError:
+            pass
+        finally:
+            os.close(directory_fd)
+
+    @classmethod
+    def _terminate_process(
+        cls,
+        process: Any,
+        *,
+        root_pid: int | None = None,
+        root_started_at: float | None = None,
+        observed_processes: dict[int, float] | None = None,
+    ) -> None:
+        """Stop only the verified launcher tree, children first, with a bound."""
+
+        identities = dict(observed_processes or {})
+        if root_pid is not None and root_started_at is not None:
+            identities.update(cls._process_tree_identities(root_pid, root_started_at))
+            identities.setdefault(root_pid, root_started_at)
+
+        owned: list[psutil.Process] = []
+        for candidate_pid, candidate_started_at in identities.items():
+            if not cls._process_matches(candidate_pid, candidate_started_at):
+                continue
+            try:
+                owned.append(psutil.Process(candidate_pid))
+            except (psutil.Error, OSError):
+                continue
+
+        if owned:
+            owned.sort(key=lambda item: item.pid == root_pid)
+            for owned_process in owned:
+                try:
+                    owned_process.terminate()
+                except (psutil.Error, OSError):
+                    pass
+            _gone, alive = psutil.wait_procs(owned, timeout=2.0)
+            for owned_process in alive:
+                expected_start = identities.get(owned_process.pid)
+                if expected_start is None or not cls._process_matches(
+                    owned_process.pid, expected_start
+                ):
+                    continue
+                try:
+                    owned_process.kill()
+                except (psutil.Error, OSError):
+                    pass
+            if alive:
+                psutil.wait_procs(alive, timeout=1.0)
+            return
+
+        terminate = getattr(process, "terminate", None)
+        if callable(terminate):
+            try:
+                terminate()
+            except (OSError, ProcessLookupError):
+                pass
+
+
+DEFAULT_SIDECAR_REGISTRY = ProcessSidecarRegistry()

--- a/src/agilab/core/agi-env/src/agi_env/ui/streamlit_args.py
+++ b/src/agilab/core/agi-env/src/agi_env/ui/streamlit_args.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import tomllib
 from pathlib import Path
 from typing import Any, Callable, Literal, get_args, get_origin
 
@@ -10,7 +9,8 @@ from pydantic import BaseModel, ValidationError
 from annotated_types import Ge, Le, MultipleOf
 
 from agi_env.ui._optional_ui import require_streamlit
-from agi_env.project.app_args import prefer_persisted_value
+from agi_env.project.app_args import prefer_persisted_value as prefer_persisted_value
+from agi_env.project.app_settings_support import read_app_settings
 from agi_env.shares.share_runtime_support import resolve_share_path
 
 st = require_streamlit()
@@ -29,8 +29,7 @@ def load_args_state(
     app_settings = st.session_state.get("app_settings")
     if not app_settings or not st.session_state.get("is_args_from_ui"):
         if settings_path.exists():
-            with settings_path.open("rb") as handle:
-                app_settings = tomllib.load(handle)
+            app_settings = read_app_settings(settings_path)
         else:
             app_settings = {}
         st.session_state.app_settings = app_settings

--- a/src/agilab/core/agi-env/test/test_agi_env.py
+++ b/src/agilab/core/agi-env/test/test_agi_env.py
@@ -7,6 +7,7 @@ import shlex
 import shutil
 import subprocess
 import sys
+import threading
 from types import SimpleNamespace
 
 import pytest
@@ -24,6 +25,108 @@ from agi_env.agi_logger import AgiLogger
 from agi_env.defaults import get_default_openai_model
 
 logger = AgiLogger.get_logger(__name__)
+
+
+@pytest.mark.parametrize("operation", ("session", "constructor", "reset"))
+def test_initialization_lock_times_out_for_peer_operations(monkeypatch, operation):
+    outcomes: list[BaseException | str] = []
+    monkeypatch.setattr(AgiEnv, "_initialization_lock_timeout_seconds", 0.01)
+
+    def _contender() -> None:
+        try:
+            if operation == "session":
+                AgiEnv.session()
+            elif operation == "constructor":
+                AgiEnv()
+            else:
+                AgiEnv.reset()
+        except BaseException as exc:
+            outcomes.append(exc)
+        else:
+            outcomes.append("acquired")
+
+    AgiEnv._lock.acquire()
+    try:
+        thread = threading.Thread(target=_contender)
+        thread.start()
+        thread.join(timeout=1)
+    finally:
+        AgiEnv._lock.release()
+
+    assert not thread.is_alive()
+    assert len(outcomes) == 1
+    assert isinstance(outcomes[0], agi_env_module.AgiEnvBusyError)
+
+
+def test_direct_constructors_never_overlap_singleton_initialization(monkeypatch):
+    start = threading.Barrier(3)
+    state_lock = threading.Lock()
+    active = 0
+    max_active = 0
+    outcomes: list[BaseException | AgiEnv] = []
+
+    def _initialize(instance, **_kwargs) -> None:
+        nonlocal active, max_active
+        with state_lock:
+            active += 1
+            max_active = max(max_active, active)
+        threading.Event().wait(0.05)
+        with state_lock:
+            active -= 1
+
+    def _construct() -> None:
+        start.wait(timeout=1)
+        try:
+            outcomes.append(AgiEnv())
+        except BaseException as exc:
+            outcomes.append(exc)
+
+    monkeypatch.setattr(agi_env_module, "initialize_agi_env_instance", _initialize)
+    monkeypatch.setattr(AgiEnv, "_initialization_lock_timeout_seconds", 1.0)
+    threads = [threading.Thread(target=_construct) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    start.wait(timeout=1)
+    for thread in threads:
+        thread.join(timeout=2)
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert len(outcomes) == 2
+    assert all(isinstance(outcome, AgiEnv) for outcome in outcomes)
+    assert outcomes[0] is outcomes[1]
+    assert max_active == 1
+
+
+def test_current_cannot_expose_partially_initialized_singleton(monkeypatch):
+    initializer_entered = threading.Event()
+    release_initializer = threading.Event()
+    constructor_outcomes: list[BaseException | AgiEnv] = []
+
+    def _initialize(instance, **_kwargs) -> None:
+        initializer_entered.set()
+        assert release_initializer.wait(timeout=1)
+
+    def _construct() -> None:
+        try:
+            constructor_outcomes.append(AgiEnv())
+        except BaseException as exc:
+            constructor_outcomes.append(exc)
+
+    monkeypatch.setattr(agi_env_module, "initialize_agi_env_instance", _initialize)
+    monkeypatch.setattr(AgiEnv, "_initialization_lock_timeout_seconds", 0.01)
+    constructor = threading.Thread(target=_construct)
+    constructor.start()
+    assert initializer_entered.wait(timeout=1)
+
+    with pytest.raises(agi_env_module.AgiEnvBusyError):
+        AgiEnv.current()
+
+    release_initializer.set()
+    constructor.join(timeout=1)
+    assert not constructor.is_alive()
+    assert len(constructor_outcomes) == 1
+    assert isinstance(constructor_outcomes[0], AgiEnv)
+    assert AgiEnv.current() is constructor_outcomes[0]
 
 
 _AGIENV_PROCESS_ENV_KEYS = {
@@ -1048,6 +1151,54 @@ def test_reinit_failure_leaves_singleton_uninitialized(monkeypatch):
     assert env._agilab_init_signature is None
 
 
+def test_session_bootstrap_uses_instance_logger_before_singleton_exists(tmp_path):
+    from agi_env.runtime import agi_env_instance_initialization as init_module
+
+    session_logger = mock.Mock()
+    env = SimpleNamespace(
+        worker_path=tmp_path / "missing_worker.py",
+        target_worker_class="DemoWorker",
+        is_source_env=True,
+        is_worker_env=False,
+        logger=session_logger,
+    )
+    env_cls = SimpleNamespace(logger=None)
+
+    init_module._resolve_worker_base_class(env, env_cls=env_cls)
+
+    assert env.base_worker_cls is None
+    assert env._base_worker_module is None
+    session_logger.info.assert_called_once()
+
+
+def test_session_unzip_data_uses_its_own_runtime_context(env, monkeypatch, tmp_path):
+    captured: dict[str, object] = {}
+    session_logger = mock.Mock()
+    session = object.__new__(AgiEnv)
+    session.app_data_rel = tmp_path / "session-data"
+    session.agi_share_path_abs = tmp_path / "share"
+    session.user = "session-user"
+    session.home_abs = tmp_path / "home"
+    session.verbose = 7
+    session.logger = session_logger
+
+    def capture_extract(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(agi_env_module, "extract_dataset_archive", capture_extract)
+
+    session.unzip_data(tmp_path / "dataset.7z", "dataset/demo", force_extract=True)
+
+    kwargs = captured["kwargs"]
+    assert isinstance(kwargs, dict)
+    assert kwargs["logger"] is session_logger
+    assert kwargs["logger"] is not env.logger
+    assert kwargs["verbose"] == 7
+    assert kwargs["user"] == "session-user"
+    assert kwargs["force_extract"] is True
+
+
 def test_agienv_for_app_reuses_matching_singleton(env, monkeypatch):
     def _fail_init(*_args, **_kwargs):  # pragma: no cover - must not run
         raise AssertionError("for_app should not reinitialize matching app state")
@@ -1101,6 +1252,169 @@ def test_agienv_for_app_reinitializes_conflicting_singleton(monkeypatch, env):
 def test_agienv_for_app_rejects_empty_app_name(env):
     with pytest.raises(ValueError, match="app name must be non-empty"):
         AgiEnv.for_app(apps_path=env.apps_path, app="")
+
+
+def test_agienv_session_factories_isolate_concurrent_ui_state(env, monkeypatch, tmp_path):
+    apps_path = tmp_path / "apps"
+    apps_path.mkdir()
+    start = threading.Barrier(3)
+    sessions: list[AgiEnv] = []
+
+    def fake_init(self, *, apps_path: Path, app: str, verbose: int | None = None, **_kwargs):
+        assert getattr(self, "_agilab_session_scoped", False) is True
+        self.apps_path = Path(apps_path)
+        self.app = app
+        self.verbose = int(verbose or 0)
+        self.envars = {"SESSION_NAME": app}
+        self._pythonpath_entries = [str(Path(apps_path) / app / "src")]
+
+    def build(app: str) -> None:
+        start.wait()
+        sessions.append(
+            AgiEnv.session_for_app(apps_path=apps_path, app=app, verbose=0)
+        )
+
+    monkeypatch.setattr(AgiEnv, "__init__", fake_init, raising=True)
+    workers = [
+        threading.Thread(target=build, args=("alpha_project",)),
+        threading.Thread(target=build, args=("beta_project",)),
+    ]
+    for worker in workers:
+        worker.start()
+    start.wait()
+    for worker in workers:
+        worker.join(timeout=5)
+
+    assert len(sessions) == 2
+    assert sessions[0] is not sessions[1]
+    assert {session.app for session in sessions} == {
+        "alpha_project",
+        "beta_project",
+    }
+    assert AgiEnv.current() is env
+
+    original_path = list(sys.path)
+    original_pythonpath = os.environ.get("PYTHONPATH")
+    sessions[0]._configure_pythonpath(["/session-only/pythonpath"])
+    assert sys.path == original_path
+    assert os.environ.get("PYTHONPATH") == original_pythonpath
+    child_envs = [session._build_env_for_instance() for session in sessions]
+    assert {child_env["APP_DEFAULT"] for child_env in child_envs} == {
+        "alpha_project",
+        "beta_project",
+    }
+    assert {child_env["SESSION_NAME"] for child_env in child_envs} == {
+        "alpha_project",
+        "beta_project",
+    }
+
+    rebootstrap_start = threading.Barrier(3)
+    expected_apps = {
+        id(session): f"{session.app.removesuffix('_project')}_next_project"
+        for session in sessions
+    }
+
+    def rebootstrap(session: AgiEnv) -> None:
+        rebootstrap_start.wait()
+        session.reinitialize_for_app(
+            apps_path=apps_path,
+            app=expected_apps[id(session)],
+            verbose=0,
+        )
+
+    rebootstrap_workers = [
+        threading.Thread(target=rebootstrap, args=(session,)) for session in sessions
+    ]
+    for worker in rebootstrap_workers:
+        worker.start()
+    rebootstrap_start.wait()
+    for worker in rebootstrap_workers:
+        worker.join(timeout=5)
+
+    assert {session.app for session in sessions} == set(expected_apps.values())
+    assert all(session.apps_path == apps_path for session in sessions)
+    assert AgiEnv.current() is env
+
+
+def test_session_execution_methods_use_each_sessions_subprocess_snapshot(
+    env, monkeypatch, tmp_path
+):
+    from agi_env.runtime import agi_env_execution_methods as execution_methods
+
+    apps_path = tmp_path / "apps"
+    apps_path.mkdir()
+
+    def fake_init(
+        self,
+        *,
+        apps_path: Path,
+        app: str,
+        verbose: int | None = None,
+        **_kwargs,
+    ):
+        self.apps_path = Path(apps_path)
+        self.app = app
+        self.verbose = int(verbose or 0)
+        self.envars = {"SESSION_NAME": app}
+        self._pythonpath_entries = [str(apps_path / app / "src")]
+        self.logger = SimpleNamespace(session=app)
+
+    async def capture_run(_cmd, _venv, **kwargs):
+        return kwargs["build_env_fn"](None), kwargs["logger"]
+
+    async def capture_run_bg(_cmd, **kwargs):
+        return kwargs["build_env_fn"](None), kwargs["logger"]
+
+    async def capture_run_async(_cmd, **kwargs):
+        return kwargs["build_env_fn"](None), kwargs["logger"]
+
+    monkeypatch.setattr(AgiEnv, "__init__", fake_init, raising=True)
+    monkeypatch.setattr(execution_methods, "run_command_in_env", capture_run)
+    monkeypatch.setattr(
+        execution_methods,
+        "run_command_in_background",
+        capture_run_bg,
+    )
+    monkeypatch.setattr(execution_methods, "run_command_async", capture_run_async)
+
+    sessions = [
+        AgiEnv.session_for_app(apps_path=apps_path, app=app, verbose=0)
+        for app in ("alpha_project", "beta_project")
+    ]
+
+    async def capture_session(session):
+        return await asyncio.gather(
+            session.run("echo run", None),
+            session._run_bg("echo bg"),
+            session.run_async("echo async"),
+        )
+
+    async def capture_all_sessions():
+        return await asyncio.gather(
+            *(capture_session(session) for session in sessions)
+        )
+
+    results = asyncio.run(capture_all_sessions())
+
+    for session, method_results in zip(sessions, results):
+        expected_pythonpath = str(apps_path / session.app / "src")
+        assert len(method_results) == 3
+        method_envs = [child_env for child_env, _logger in method_results]
+        assert {child_env["APP_DEFAULT"] for child_env in method_envs} == {
+            session.app
+        }
+        assert {child_env["PYTHONPATH"] for child_env in method_envs} == {
+            expected_pythonpath
+        }
+        assert {child_env["SESSION_NAME"] for child_env in method_envs} == {
+            session.app
+        }
+        assert all(
+            child_logger is session.logger
+            for _child_env, child_logger in method_results
+        )
+
+    assert AgiEnv.current() is env
 
 
 def test_change_app_marks_reinitialization_as_intentional(monkeypatch, env):

--- a/src/agilab/core/agi-env/test/test_app_args.py
+++ b/src/agilab/core/agi-env/test/test_app_args.py
@@ -1,7 +1,12 @@
 import builtins
 from pathlib import Path
+import subprocess
+import sys
+import time
 from types import SimpleNamespace
 
+import agi_env.app_args as app_args_module
+import agi_env.runtime.atomic_write_support as atomic_write_module
 import tomllib
 import pytest
 from pydantic import BaseModel
@@ -13,12 +18,49 @@ from agi_env.app_args import (
     model_to_payload,
     prefer_persisted_value,
 )
-from agi_env.runtime.atomic_write_support import atomic_write_bytes
+from agi_env.runtime.atomic_write_support import (
+    atomic_write_bytes,
+    run_with_windows_file_sharing_retry,
+)
 
 
 class ExampleModel(BaseModel):
     foo: int = 1
     bar: str = "baz"
+
+
+_MODEL_WRITER = """
+import sys
+import time
+from pathlib import Path
+
+from pydantic import BaseModel
+
+from agi_env.app_args import dump_model_to_toml
+
+
+class Model(BaseModel):
+    foo: int
+    bar: str
+
+
+settings = Path(sys.argv[1])
+section = sys.argv[2]
+offset = int(sys.argv[3])
+start = Path(sys.argv[4])
+deadline = time.monotonic() + 10
+while not start.exists():
+    if time.monotonic() >= deadline:
+        raise TimeoutError("writer start signal was not created")
+    time.sleep(0.001)
+for index in range(20):
+    dump_model_to_toml(
+        Model(foo=offset + index, bar=section),
+        settings,
+        section=section,
+    )
+    time.sleep(0.002)
+"""
 
 
 def test_model_to_payload_round_trip():
@@ -113,6 +155,64 @@ def test_dump_model_to_toml_creates_file_and_section(tmp_path: Path):
     assert data["args"] == {"foo": 7, "bar": "written"}
 
 
+def test_dump_model_to_toml_preserves_disjoint_multiprocess_updates_and_parseability(
+    tmp_path: Path,
+) -> None:
+    settings = tmp_path / "config.toml"
+    start = tmp_path / "start"
+    processes = [
+        subprocess.Popen(
+            [
+                sys.executable,
+                "-c",
+                _MODEL_WRITER,
+                str(settings),
+                section,
+                str(offset),
+                str(start),
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        for section, offset in (("alpha", 100), ("beta", 200))
+    ]
+    start.touch()
+    while any(process.poll() is None for process in processes):
+        if settings.exists():
+            load_model_from_toml(ExampleModel, settings, section="alpha")
+            load_model_from_toml(ExampleModel, settings, section="beta")
+        time.sleep(0.001)
+    for process in processes:
+        stdout, stderr = process.communicate(timeout=10)
+        assert process.returncode == 0, f"stdout:\n{stdout}\nstderr:\n{stderr}"
+
+    payload = tomllib.loads(settings.read_text(encoding="utf-8"))
+    assert payload["alpha"] == {"foo": 119, "bar": "alpha"}
+    assert payload["beta"] == {"foo": 219, "bar": "beta"}
+
+
+def test_dump_model_to_toml_rolls_back_serialization_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = tmp_path / "config.toml"
+    settings.write_text("[preserved]\nvalue = 1\n", encoding="utf-8")
+
+    def failing_atomic(path, writer):
+        def write_then_fail(handle):
+            writer(handle)
+            raise OSError("simulated write failure")
+
+        return atomic_write_bytes(path, write_then_fail)
+
+    monkeypatch.setattr(app_args_module, "atomic_write_bytes", failing_atomic)
+    with pytest.raises(OSError, match="simulated write failure"):
+        dump_model_to_toml(ExampleModel(), settings)
+
+    assert settings.read_text(encoding="utf-8") == "[preserved]\nvalue = 1\n"
+
+
 def test_atomic_write_bytes_preserves_existing_file_on_writer_failure(tmp_path: Path):
     settings = tmp_path / "config.toml"
     settings.write_text("original", encoding="utf-8")
@@ -126,6 +226,119 @@ def test_atomic_write_bytes_preserves_existing_file_on_writer_failure(tmp_path: 
 
     assert settings.read_text(encoding="utf-8") == "original"
     assert list(tmp_path.glob(".config.toml.*.tmp")) == []
+
+
+def test_windows_file_sharing_retry_eventually_succeeds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    attempts = 0
+    sleeps: list[float] = []
+
+    def _transient_operation() -> str:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise PermissionError("sharing violation")
+        return "published"
+
+    monkeypatch.setattr(atomic_write_module, "_is_windows", lambda: True)
+    monkeypatch.setattr(atomic_write_module.time, "sleep", sleeps.append)
+
+    assert run_with_windows_file_sharing_retry(_transient_operation) == "published"
+    assert attempts == 2
+    assert len(sleeps) == 1
+
+
+def test_windows_file_sharing_retry_is_bounded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    attempts = 0
+
+    def _locked_operation() -> None:
+        nonlocal attempts
+        attempts += 1
+        raise PermissionError("sharing violation")
+
+    monkeypatch.setattr(atomic_write_module, "_is_windows", lambda: True)
+
+    with pytest.raises(PermissionError, match="sharing violation"):
+        run_with_windows_file_sharing_retry(
+            _locked_operation,
+            timeout_seconds=0,
+        )
+
+    assert attempts == 1
+
+
+def test_file_sharing_retry_reraises_immediately_off_windows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    attempts = 0
+
+    def _locked_operation() -> None:
+        nonlocal attempts
+        attempts += 1
+        raise PermissionError("permission denied")
+
+    monkeypatch.setattr(atomic_write_module, "_is_windows", lambda: False)
+
+    with pytest.raises(PermissionError, match="permission denied"):
+        run_with_windows_file_sharing_retry(_locked_operation)
+
+    assert attempts == 1
+
+
+def test_load_model_from_toml_retries_windows_sharing_violation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = tmp_path / "config.toml"
+    settings.write_text('[args]\nfoo = 8\nbar = "ready"\n', encoding="utf-8")
+    original_read_text = Path.read_text
+    attempts = 0
+
+    def _transient_read_text(path: Path, *args, **kwargs):
+        nonlocal attempts
+        if path == settings:
+            attempts += 1
+            if attempts == 1:
+                raise PermissionError("sharing violation")
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(atomic_write_module, "_is_windows", lambda: True)
+    monkeypatch.setattr(atomic_write_module.time, "sleep", lambda _delay: None)
+    monkeypatch.setattr(Path, "read_text", _transient_read_text)
+
+    assert load_model_from_toml(ExampleModel, settings) == ExampleModel(
+        foo=8,
+        bar="ready",
+    )
+    assert attempts == 2
+
+
+def test_atomic_write_bytes_retries_windows_sharing_violation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = tmp_path / "config.toml"
+    original_replace = atomic_write_module.os.replace
+    attempts = 0
+
+    def _transient_replace(source, destination) -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise PermissionError("sharing violation")
+        original_replace(source, destination)
+
+    monkeypatch.setattr(atomic_write_module, "_is_windows", lambda: True)
+    monkeypatch.setattr(atomic_write_module.time, "sleep", lambda _delay: None)
+    monkeypatch.setattr(atomic_write_module.os, "replace", _transient_replace)
+
+    atomic_write_bytes(settings, lambda handle: handle.write(b"complete"))
+
+    assert settings.read_bytes() == b"complete"
+    assert attempts == 2
 
 
 def test_dump_model_to_toml_respects_create_missing_flag(tmp_path: Path):
@@ -143,7 +356,9 @@ def test_dump_model_to_toml_rejects_future_app_settings_contract(tmp_path: Path)
     settings = tmp_path / "config.toml"
     settings.write_text("[__meta__]\nversion = 999\n", encoding="utf-8")
 
-    with pytest.raises(ValueError, match="Unsupported app_settings.toml schema version 999"):
+    with pytest.raises(
+        ValueError, match="Unsupported app_settings.toml schema version 999"
+    ):
         dump_model_to_toml(ExampleModel(), settings)
 
 
@@ -161,7 +376,9 @@ def test_dump_model_to_toml_falls_back_to_tomlkit_when_tomli_w_missing(
             err.name = "tomli_w"
             raise err
         if name == "tomlkit":
-            return SimpleNamespace(dumps=lambda data: '[args]\nfoo = 9\nbar = "tomlkit"\n')
+            return SimpleNamespace(
+                dumps=lambda data: '[args]\nfoo = 9\nbar = "tomlkit"\n'
+            )
         return real_import(name, globals, locals, fromlist, level)
 
     monkeypatch.setattr(builtins, "__import__", fake_import)

--- a/src/agilab/core/agi-env/test/test_app_settings_support.py
+++ b/src/agilab/core/agi-env/test/test_app_settings_support.py
@@ -1,8 +1,79 @@
 from pathlib import Path
+import shutil
+import subprocess
+import sys
+import threading
+import time
+import tomllib
 
 import pytest
 
 import agi_env.app_settings_support as app_settings_module
+import agi_env.runtime.atomic_write_support as atomic_write_module
+
+
+def test_app_settings_lock_times_out_instead_of_freezing_session(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = tmp_path / "app_settings.toml"
+    monkeypatch.setattr(app_settings_module, "_APP_SETTINGS_LOCK_TIMEOUT_SECONDS", 0.01)
+
+    with app_settings_module.app_settings_file_lock(settings):
+        with pytest.raises(TimeoutError, match="Another session"):
+            with app_settings_module.app_settings_file_lock(settings):
+                raise AssertionError("nested lock unexpectedly acquired")
+
+
+def test_read_app_settings_retries_transient_windows_sharing_violation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = tmp_path / "app_settings.toml"
+    settings.write_text('[args]\nstatus = "ready"\n', encoding="utf-8")
+    real_read_text = Path.read_text
+    attempts = 0
+
+    def _transient_read_text(path: Path, *args, **kwargs) -> str:
+        nonlocal attempts
+        if path == settings:
+            attempts += 1
+            if attempts == 1:
+                raise PermissionError("sharing violation")
+        return real_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(atomic_write_module, "_is_windows", lambda: True)
+    monkeypatch.setattr(atomic_write_module.time, "sleep", lambda _delay: None)
+    monkeypatch.setattr(Path, "read_text", _transient_read_text)
+
+    assert app_settings_module.read_app_settings(settings) == {
+        "args": {"status": "ready"}
+    }
+    assert attempts == 2
+
+
+def test_read_app_settings_surfaces_parse_errors_without_retry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = tmp_path / "app_settings.toml"
+    settings.write_text("[args\n", encoding="utf-8")
+    real_read_text = Path.read_text
+    attempts = 0
+
+    def _counted_read_text(path: Path, *args, **kwargs) -> str:
+        nonlocal attempts
+        if path == settings:
+            attempts += 1
+        return real_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(atomic_write_module, "_is_windows", lambda: True)
+    monkeypatch.setattr(Path, "read_text", _counted_read_text)
+
+    with pytest.raises(tomllib.TOMLDecodeError):
+        app_settings_module.read_app_settings(settings)
+
+    assert attempts == 1
 
 
 def test_prepare_app_settings_for_write_sanitizes_and_stamps_metadata(tmp_path: Path):
@@ -71,6 +142,253 @@ def test_prepare_app_settings_for_write_rejects_invalid_metadata():
         app_settings_module.prepare_app_settings_for_write(
             {"__meta__": {"schema": "agilab.app_settings.v2", "version": 2}}
         )
+
+
+def test_update_app_settings_serializes_disjoint_thread_updates(tmp_path: Path) -> None:
+    settings = tmp_path / "app_settings.toml"
+    settings.write_text('[unrelated]\nowner = "preserved"\n', encoding="utf-8")
+    first_entered = threading.Event()
+    release_first = threading.Event()
+    second_started = threading.Event()
+    errors: list[BaseException] = []
+
+    def _write_pages() -> None:
+        try:
+            def _update(payload):
+                payload["pages"] = {"view_module": ["view_maps"]}
+                first_entered.set()
+                assert release_first.wait(timeout=5)
+                return True
+
+            app_settings_module.update_app_settings(settings, _update)
+        except BaseException as exc:  # pragma: no cover - asserted below
+            errors.append(exc)
+
+    def _write_cluster() -> None:
+        try:
+            second_started.set()
+
+            def _update(payload):
+                payload["cluster"] = {"cluster_enabled": False}
+                return True
+
+            app_settings_module.update_app_settings(settings, _update)
+        except BaseException as exc:  # pragma: no cover - asserted below
+            errors.append(exc)
+
+    pages_thread = threading.Thread(target=_write_pages)
+    cluster_thread = threading.Thread(target=_write_cluster)
+    pages_thread.start()
+    assert first_entered.wait(timeout=5)
+    cluster_thread.start()
+    assert second_started.wait(timeout=5)
+    time.sleep(0.05)
+    release_first.set()
+    pages_thread.join(timeout=5)
+    cluster_thread.join(timeout=5)
+
+    assert not pages_thread.is_alive()
+    assert not cluster_thread.is_alive()
+    assert errors == []
+    payload = tomllib.loads(settings.read_text(encoding="utf-8"))
+    assert payload["pages"] == {"view_module": ["view_maps"]}
+    assert payload["cluster"] == {"cluster_enabled": False}
+    assert payload["unrelated"] == {"owner": "preserved"}
+
+
+def test_update_app_settings_owned_merges_stale_cross_writer_leaves(
+    tmp_path: Path,
+) -> None:
+    settings = tmp_path / "app_settings.toml"
+    settings.write_text(
+        "[cluster]\nscheduler = \"old\"\n\n"
+        "[cluster.service_health]\nallow_idle = false\n",
+        encoding="utf-8",
+    )
+    service_snapshot = {
+        "cluster": {
+            "scheduler": "old",
+            "service_health": {"allow_idle": True},
+        }
+    }
+    cluster_snapshot = {
+        "cluster": {
+            "scheduler": "new",
+            "service_health": {"allow_idle": False},
+        }
+    }
+
+    app_settings_module.update_app_settings_owned(
+        settings,
+        service_snapshot,
+        owned_paths=(("cluster", "service_health"),),
+    )
+    app_settings_module.update_app_settings_owned(
+        settings,
+        cluster_snapshot,
+        owned_paths=(("cluster", "scheduler"),),
+    )
+
+    payload = tomllib.loads(settings.read_text(encoding="utf-8"))
+    assert payload["cluster"] == {
+        "scheduler": "new",
+        "service_health": {"allow_idle": True},
+    }
+
+
+def test_update_app_settings_owned_defaults_only_fill_missing_latest_leaves(
+    tmp_path: Path,
+) -> None:
+    settings = tmp_path / "app_settings.toml"
+    app_settings_module.update_app_settings_owned(
+        settings,
+        {"cluster": {"scheduler": "remote"}},
+        owned_paths=(),
+        default_paths=(("cluster", "scheduler"),),
+    )
+
+    # A second pre-seeded session may initialize other missing leaves, but its
+    # stale scheduler default must not replace the first session's value.
+    latest, changed = app_settings_module.update_app_settings_owned(
+        settings,
+        {
+            "cluster": {
+                "scheduler": "stale",
+                "cluster_enabled": True,
+            }
+        },
+        owned_paths=(),
+        default_paths=(
+            ("cluster", "scheduler"),
+            ("cluster", "cluster_enabled"),
+        ),
+    )
+
+    assert changed is True
+    assert latest["cluster"] == {
+        "scheduler": "remote",
+        "cluster_enabled": True,
+    }
+    assert tomllib.loads(settings.read_text(encoding="utf-8"))["cluster"] == {
+        "scheduler": "remote",
+        "cluster_enabled": True,
+    }
+
+
+def test_update_app_settings_owned_serializes_disjoint_processes(
+    tmp_path: Path,
+) -> None:
+    settings = tmp_path / "app_settings.toml"
+    settings.write_text('[unrelated]\nowner = "preserved"\n', encoding="utf-8")
+    start_marker = tmp_path / "start"
+    worker_code = (
+        "import sys, time\n"
+        "from pathlib import Path\n"
+        "from agi_env.app_settings_support import update_app_settings_owned\n"
+        "settings, section, value, marker = sys.argv[1:]\n"
+        "while not Path(marker).exists():\n"
+        "    time.sleep(0.01)\n"
+        "update_app_settings_owned(settings, {section: {'value': value}}, "
+        "owned_paths=((section,),))\n"
+    )
+    processes = [
+        subprocess.Popen(
+            [
+                sys.executable,
+                "-c",
+                worker_code,
+                str(settings),
+                section,
+                value,
+                str(start_marker),
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        for section, value in (("pages", "maps"), ("cluster", "local"))
+    ]
+    start_marker.touch()
+    results = [process.communicate(timeout=15) for process in processes]
+
+    assert [process.returncode for process in processes] == [0, 0], results
+    payload = tomllib.loads(settings.read_text(encoding="utf-8"))
+    assert payload["pages"] == {"value": "maps"}
+    assert payload["cluster"] == {"value": "local"}
+    assert payload["unrelated"] == {"owner": "preserved"}
+
+
+def test_update_app_settings_writer_failure_preserves_prior_valid_toml(
+    tmp_path: Path,
+) -> None:
+    settings = tmp_path / "app_settings.toml"
+    original = '[cluster]\ncluster_enabled = true\n'
+    settings.write_text(original, encoding="utf-8")
+
+    def _update(payload):
+        payload["pages"] = {"view_module": ["view_maps"]}
+        return True
+
+    def _broken_writer(_payload, stream):
+        stream.write(b"partial")
+        raise OSError("disk full")
+
+    with pytest.raises(OSError, match="disk full"):
+        app_settings_module.update_app_settings(
+            settings,
+            _update,
+            dump_fn=_broken_writer,
+        )
+
+    assert settings.read_text(encoding="utf-8") == original
+    assert list(tmp_path.glob(".app_settings.toml.*.tmp")) == []
+
+
+def test_update_app_settings_publication_failure_preserves_prior_valid_toml(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = tmp_path / "app_settings.toml"
+    original = '[cluster]\ncluster_enabled = true\n'
+    settings.write_text(original, encoding="utf-8")
+
+    def _update(payload):
+        payload["pages"] = {"view_module": ["view_maps"]}
+        return True
+
+    def _fail_replace(_source, _target):
+        raise OSError("publication failed")
+
+    monkeypatch.setattr(atomic_write_module.os, "replace", _fail_replace)
+    with pytest.raises(OSError, match="publication failed"):
+        app_settings_module.update_app_settings(settings, _update)
+
+    assert settings.read_text(encoding="utf-8") == original
+    assert list(tmp_path.glob(".app_settings.toml.*.tmp")) == []
+
+
+def test_update_app_settings_fsyncs_parent_after_publication(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = tmp_path / "nested" / "app_settings.toml"
+    synced: list[Path] = []
+    monkeypatch.setattr(
+        app_settings_module,
+        "_fsync_directory",
+        lambda path: synced.append(path),
+    )
+
+    def _update(payload):
+        payload["pages"] = {"view_module": ["view_maps"]}
+        return True
+
+    app_settings_module.update_app_settings(settings, _update)
+
+    assert synced == [settings.parent]
+    assert tomllib.loads(settings.read_text(encoding="utf-8"))["pages"] == {
+        "view_module": ["view_maps"]
+    }
 
 
 def test_app_settings_aliases_and_candidate_paths(tmp_path: Path):
@@ -177,6 +495,53 @@ def test_find_source_and_user_app_settings_cover_workspace_seed_paths(tmp_path: 
         find_source_file=lambda _app_name=None: None,
     )
     assert unresolved == tmp_path / "resources" / "apps" / "blank_project" / "app_settings.toml"
+
+
+def test_resolve_user_app_settings_serializes_atomic_first_creation(
+    tmp_path: Path,
+) -> None:
+    resources_path = tmp_path / "resources"
+    source_a = tmp_path / "source-a.toml"
+    source_b = tmp_path / "source-b.toml"
+    source_a.write_text('[owner]\nname = "alpha"\n', encoding="utf-8")
+    source_b.write_text('[owner]\nname = "beta"\n', encoding="utf-8")
+    copy_started = threading.Event()
+    release_copy = threading.Event()
+    errors: list[BaseException] = []
+
+    def _blocking_copy(source: Path, target: Path) -> object:
+        copy_started.set()
+        assert release_copy.wait(timeout=5)
+        return shutil.copy2(source, target)
+
+    def _resolve(source: Path, copy_file=shutil.copy2) -> None:
+        try:
+            app_settings_module.resolve_user_app_settings_file(
+                target_app="demo_project",
+                resources_path=resources_path,
+                find_source_file=lambda _app=None: source,
+                copy_file=copy_file,
+            )
+        except BaseException as exc:  # pragma: no cover - asserted below
+            errors.append(exc)
+
+    first = threading.Thread(target=_resolve, args=(source_a, _blocking_copy))
+    second = threading.Thread(target=_resolve, args=(source_b,))
+    first.start()
+    assert copy_started.wait(timeout=5)
+    second.start()
+    workspace_file = (
+        resources_path / "apps" / "demo_project" / "app_settings.toml"
+    )
+    assert not workspace_file.exists()
+    release_copy.set()
+    first.join(timeout=5)
+    second.join(timeout=5)
+
+    assert errors == []
+    assert workspace_file.read_text(encoding="utf-8") == source_a.read_text(
+        encoding="utf-8"
+    )
 
 
 def test_app_settings_source_roots_collect_aliases_repo_builtin_worker_and_export(tmp_path: Path):

--- a/src/agilab/core/agi-env/test/test_env_config_support.py
+++ b/src/agilab/core/agi-env/test/test_env_config_support.py
@@ -1,13 +1,56 @@
 from pathlib import Path
+import subprocess
+import sys
+import time
 
 import agi_env.env_config_support as env_config_module
+import agi_env.runtime.atomic_write_support as atomic_write_module
 import pytest
+
+
+_ENV_WRITER = """
+import sys
+import time
+from pathlib import Path
+
+from agi_env.env_config_support import write_env_updates
+
+
+env_file = Path(sys.argv[1])
+key = sys.argv[2]
+offset = int(sys.argv[3])
+start = Path(sys.argv[4])
+deadline = time.monotonic() + 10
+while not start.exists():
+    if time.monotonic() >= deadline:
+        raise TimeoutError("writer start signal was not created")
+    time.sleep(0.001)
+for index in range(20):
+    write_env_updates(env_file, {key: offset + index})
+    time.sleep(0.002)
+"""
+
+
+def test_env_file_lock_times_out_instead_of_freezing_session(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    env_file = tmp_path / ".env"
+    monkeypatch.setattr(env_config_module, "_ENV_FILE_LOCK_TIMEOUT_SECONDS", 0.01)
+
+    with env_config_module._env_file_lock(env_file):
+        with pytest.raises(TimeoutError, match="Another session"):
+            with env_config_module._env_file_lock(env_file):
+                raise AssertionError("nested lock unexpectedly acquired")
 
 
 def test_clean_envar_value_handles_blank_values_and_process_fallback(monkeypatch):
     monkeypatch.setenv("AGI_DEMO", " from-process ")
 
-    assert env_config_module.clean_envar_value({"AGI_DEMO": " value "}, "AGI_DEMO") == "value"
+    assert (
+        env_config_module.clean_envar_value({"AGI_DEMO": " value "}, "AGI_DEMO")
+        == "value"
+    )
     assert env_config_module.clean_envar_value({"AGI_DEMO": "   "}, "AGI_DEMO") is None
     assert (
         env_config_module.clean_envar_value(
@@ -22,10 +65,7 @@ def test_clean_envar_value_handles_blank_values_and_process_fallback(monkeypatch
 def test_load_dotenv_values_discards_blank_assignments(tmp_path: Path):
     dotenv_path = tmp_path / ".env"
     dotenv_path.write_text(
-        "OPENAI_MODEL=\n"
-        "APP_DEFAULT=   \n"
-        "AGI_LOG_DIR=/tmp/logs\n"
-        "TABLE_MAX_ROWS=1000\n",
+        "OPENAI_MODEL=\nAPP_DEFAULT=   \nAGI_LOG_DIR=/tmp/logs\nTABLE_MAX_ROWS=1000\n",
         encoding="utf-8",
     )
 
@@ -37,7 +77,37 @@ def test_load_dotenv_values_discards_blank_assignments(tmp_path: Path):
     }
 
 
-def test_clean_envar_value_handles_mapping_errors_and_dotenv_none(monkeypatch, tmp_path: Path):
+def test_load_dotenv_values_retries_windows_sharing_violation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dotenv_path = tmp_path / ".env"
+    dotenv_path.write_text("READY=1\n", encoding="utf-8")
+    real_dotenv_values = env_config_module.dotenv_values
+    attempts = 0
+
+    def _transient_dotenv_values(**kwargs):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise PermissionError("sharing violation")
+        return real_dotenv_values(**kwargs)
+
+    monkeypatch.setattr(atomic_write_module, "_is_windows", lambda: True)
+    monkeypatch.setattr(atomic_write_module.time, "sleep", lambda _delay: None)
+    monkeypatch.setattr(
+        env_config_module,
+        "dotenv_values",
+        _transient_dotenv_values,
+    )
+
+    assert env_config_module.load_dotenv_values(dotenv_path) == {"READY": "1"}
+    assert attempts == 2
+
+
+def test_clean_envar_value_handles_mapping_errors_and_dotenv_none(
+    monkeypatch, tmp_path: Path
+):
     class BadMapping(dict):
         def get(self, key, default=None):
             raise TypeError("boom")
@@ -84,3 +154,140 @@ def test_write_env_updates_creates_parent_and_preserves_unquoted_values(tmp_path
     assert "AGI_DEMO_FLAG=1" in env_text
     assert "AGI_PATH=/tmp/demo path" in env_text
     assert env_file.parent.is_dir()
+
+
+def test_env_updates_preserve_disjoint_multiprocess_writes_and_reader_parseability(
+    tmp_path: Path,
+) -> None:
+    env_file = tmp_path / ".agilab" / ".env"
+    start = tmp_path / "start"
+    processes = [
+        subprocess.Popen(
+            [
+                sys.executable,
+                "-c",
+                _ENV_WRITER,
+                str(env_file),
+                key,
+                str(offset),
+                str(start),
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        for key, offset in (("ALPHA", 100), ("BETA", 200))
+    ]
+    start.touch()
+    while any(process.poll() is None for process in processes):
+        if env_file.exists():
+            env_config_module.load_dotenv_values(env_file)
+        time.sleep(0.001)
+    for process in processes:
+        stdout, stderr = process.communicate(timeout=10)
+        assert process.returncode == 0, f"stdout:\n{stdout}\nstderr:\n{stderr}"
+
+    assert env_config_module.load_dotenv_values(env_file) == {
+        "ALPHA": "119",
+        "BETA": "219",
+    }
+
+
+def test_env_multi_key_update_rolls_back_if_one_mutation_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    env_file = tmp_path / ".env"
+    env_file.write_text("PRESERVED=1\n", encoding="utf-8")
+    real_set_key = env_config_module.set_key
+    calls = 0
+
+    def failing_set_key(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        result = real_set_key(*args, **kwargs)
+        if calls == 2:
+            raise OSError("simulated dotenv failure")
+        return result
+
+    monkeypatch.setattr(env_config_module, "set_key", failing_set_key)
+    with pytest.raises(OSError, match="simulated dotenv failure"):
+        env_config_module.write_env_updates(env_file, {"FIRST": "1", "SECOND": "2"})
+
+    assert env_file.read_text(encoding="utf-8") == "PRESERVED=1\n"
+    assert list(tmp_path.glob("..env.*.tmp")) == []
+
+
+def test_env_update_routes_replace_through_windows_sharing_retry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    env_file = tmp_path / ".env"
+    real_retry = env_config_module.run_with_windows_file_sharing_retry
+    retry_calls = 0
+
+    def _tracking_retry(operation, **kwargs):
+        nonlocal retry_calls
+        retry_calls += 1
+        return real_retry(operation, **kwargs)
+
+    monkeypatch.setattr(
+        env_config_module,
+        "run_with_windows_file_sharing_retry",
+        _tracking_retry,
+    )
+
+    env_config_module.write_env_updates(env_file, {"READY": "1"})
+
+    assert env_file.read_text(encoding="utf-8") == "READY=1\n"
+    assert retry_calls == 1
+
+
+def test_remote_env_update_scripts_serialize_disjoint_process_updates(tmp_path: Path) -> None:
+    env_dir = tmp_path / ".agilab"
+    env_dir.mkdir()
+    env_file = env_dir / ".env"
+    env_file.write_text("PRESERVED=1\n", encoding="utf-8")
+    scripts = [
+        env_config_module.build_remote_env_update_script({"FIRST": "one"}),
+        env_config_module.build_remote_env_update_script({"SECOND": "two"}),
+    ]
+    subprocess_env = {
+        **dict(env_config_module._stdlib_os.environ),
+        # ``Path.home()`` uses HOME on POSIX and USERPROFILE on Windows.
+        "HOME": str(tmp_path),
+        "USERPROFILE": str(tmp_path),
+    }
+    processes = [
+        subprocess.Popen(
+            [sys.executable, "-c", script],
+            env=subprocess_env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        for script in scripts
+    ]
+
+    for process in processes:
+        stdout, stderr = process.communicate(timeout=10)
+        assert process.returncode == 0, (stdout, stderr)
+        assert Path(stdout.strip()).resolve(strict=False) == env_file.resolve(strict=False)
+
+    values = env_config_module.load_dotenv_values(env_file)
+    assert values == {"PRESERVED": "1", "FIRST": "one", "SECOND": "two"}
+    assert list(env_dir.glob("..env.*.tmp")) == []
+    assert (env_dir / ".env.lock").exists()
+
+
+def test_remote_env_update_script_rejects_invalid_dotenv_key() -> None:
+    with pytest.raises(ValueError, match="Invalid dotenv key"):
+        env_config_module.build_remote_env_update_script({"BAD\nKEY": "value"})
+
+
+def test_remote_env_update_script_bounds_lock_wait() -> None:
+    script = env_config_module.build_remote_env_update_script({"READY": "1"})
+
+    assert "deadline = time.monotonic() + 5.0" in script
+    assert "Timed out waiting for AGILAB dotenv lock" in script
+    assert "if locked:" in script

--- a/src/agilab/core/agi-env/test/test_pagelib.py
+++ b/src/agilab/core/agi-env/test/test_pagelib.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import ast
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
 import importlib
 import importlib.util
 import io
@@ -9,6 +11,7 @@ import os
 import sqlite3
 import subprocess
 import sys
+import threading
 import tomllib
 from pathlib import Path
 from types import SimpleNamespace
@@ -18,6 +21,88 @@ import pandas as pd
 import pytest
 
 from agi_env import pagelib, ui_support
+from agi_env.ui.sidecar_registry import SidecarCollisionError, SidecarStartError
+
+
+class _TestSidecarRegistry:
+    """Exercise public wrapper wiring without launching real background services."""
+
+    def __init__(self) -> None:
+        self._leases: dict[tuple[str, str, str], SimpleNamespace] = {}
+        self._registry_lock = threading.RLock()
+        self._preparation_lock = threading.RLock()
+        self._preparation_condition = threading.Condition()
+        self.preparation_calls: list[dict[str, object]] = []
+        self.get_calls: list[dict[str, object]] = []
+        self.ensure_calls: list[dict[str, object]] = []
+
+    @staticmethod
+    def _lease_key(kwargs) -> tuple[str, str, str]:
+        return (
+            str(kwargs["service_kind"]),
+            str(kwargs["project"]),
+            str(kwargs["key"]),
+        )
+
+    @contextmanager
+    def preparation_guard(self, **kwargs):
+        with self._preparation_condition:
+            self.preparation_calls.append(dict(kwargs))
+            self._preparation_condition.notify_all()
+        with self._preparation_lock:
+            yield
+
+    def get(self, **kwargs):
+        self.get_calls.append(dict(kwargs))
+        with self._registry_lock:
+            return self._leases.get(self._lease_key(kwargs))
+
+    def ensure(self, **kwargs):
+        self.ensure_calls.append(dict(kwargs))
+        lease_key = self._lease_key(kwargs)
+        with self._registry_lock:
+            if kwargs.get("exclusive_for_project"):
+                for existing_key in self._leases:
+                    if existing_key[:2] == lease_key[:2] and existing_key != lease_key:
+                        raise SidecarCollisionError(
+                            "different project configuration already active"
+                        )
+            if kwargs.get("replace_existing_for_project"):
+                for existing_key in tuple(self._leases):
+                    if existing_key[:2] == lease_key[:2] and existing_key != lease_key:
+                        self._leases.pop(existing_key, None)
+            existing = self._leases.get(lease_key)
+            if existing is not None:
+                return existing
+
+            port = pagelib._next_free_port()
+            process = kwargs["launcher"](port, kwargs.get("token") or "test-token")
+            if kwargs["service_kind"] == "mlflow" and not pagelib._wait_for_listen_port(port):
+                terminate = getattr(process, "terminate", None)
+                if callable(terminate):
+                    terminate()
+                raise SidecarStartError(
+                    f"MLflow process did not open its listening port {port}"
+                )
+            endpoint_builder = kwargs.get("endpoint_builder")
+            endpoint = (
+                endpoint_builder(port)
+                if callable(endpoint_builder)
+                else f"http://127.0.0.1:{port}"
+            )
+            lease = SimpleNamespace(
+                endpoint=endpoint,
+                port=port,
+                token=kwargs.get("token") or "test-token",
+                health_signature="test-signature",
+            )
+            self._leases[lease_key] = lease
+            return lease
+
+
+@pytest.fixture(autouse=True)
+def _isolate_pagelib_sidecar_registry(monkeypatch):
+    monkeypatch.setattr(pagelib, "DEFAULT_SIDECAR_REGISTRY", _TestSidecarRegistry())
 
 
 def _patch_mlflow_cli(monkeypatch):
@@ -1022,6 +1107,182 @@ def test_activate_mlflow_initializes_default_experiment(tmp_path, monkeypatch):
     assert fake_st.session_state["mlflow_port"] == 50123
 
 
+def test_activate_mlflow_serializes_shared_tracking_dir_preparation_across_apps(
+    tmp_path,
+    monkeypatch,
+):
+    registry = _TestSidecarRegistry()
+    fake_st = SimpleNamespace(
+        session_state={},
+        error=lambda *_args, **_kwargs: None,
+        warning=lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(pagelib, "DEFAULT_SIDECAR_REGISTRY", registry)
+    monkeypatch.setattr(pagelib, "st", fake_st)
+    _patch_mlflow_cli(monkeypatch)
+    monkeypatch.setattr(pagelib, "get_random_port", lambda: 50123)
+    monkeypatch.setattr(pagelib, "is_port_in_use", lambda _port: False)
+    monkeypatch.setattr(pagelib, "_wait_for_listen_port", lambda _port: True)
+    monkeypatch.setattr(
+        pagelib,
+        "_resolve_mlflow_artifact_dir",
+        lambda tracking_dir: tracking_dir / "artifacts",
+    )
+    monkeypatch.setattr(
+        pagelib,
+        "subproc",
+        lambda *_args, **_kwargs: SimpleNamespace(),
+    )
+
+    preparation_started = threading.Event()
+    release_preparation = threading.Event()
+    backend_preparations: list[Path] = []
+
+    def _prepare_backend(tracking_dir):
+        backend_preparations.append(tracking_dir)
+        preparation_started.set()
+        assert release_preparation.wait(timeout=5.0)
+        return "sqlite:///shared/mlflow.db"
+
+    monkeypatch.setattr(pagelib, "_ensure_default_mlflow_experiment", _prepare_backend)
+    monkeypatch.setattr(
+        pagelib,
+        "_ensure_mlflow_backend_ready",
+        lambda _tracking_dir: pytest.fail("fallback backend preparation should not run"),
+    )
+
+    env_a = SimpleNamespace(app="alpha_project", MLFLOW_TRACKING_DIR="", home_abs=tmp_path)
+    env_b = SimpleNamespace(app="beta_project", MLFLOW_TRACKING_DIR="", home_abs=tmp_path)
+    futures = []
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures.append(executor.submit(pagelib.activate_mlflow, env_a))
+        try:
+            assert preparation_started.wait(timeout=5.0)
+            futures.append(executor.submit(pagelib.activate_mlflow, env_b))
+            with registry._preparation_condition:
+                assert registry._preparation_condition.wait_for(
+                    lambda: len(registry.preparation_calls) == 2,
+                    timeout=5.0,
+                )
+        finally:
+            release_preparation.set()
+
+    assert [future.result() for future in futures] == [True, True]
+    expected_scope = str((tmp_path / ".mlflow").resolve())
+    assert backend_preparations == [Path(expected_scope)]
+    assert len(registry.ensure_calls) == 1
+    assert len(registry.get_calls) == 2
+    for call in (*registry.preparation_calls, *registry.get_calls, *registry.ensure_calls):
+        assert call["project"] == expected_scope
+        assert call["key"] == expected_scope
+    assert fake_st.session_state["mlflow_endpoint"] == "http://127.0.0.1:50123"
+
+
+def test_activate_mlflow_failed_revalidation_clears_stale_runtime_state(
+    tmp_path,
+    monkeypatch,
+):
+    class FailingRegistry(_TestSidecarRegistry):
+        def get(self, **kwargs):
+            super().get(**kwargs)
+            raise SidecarStartError("registered MLflow process is not healthy")
+
+    errors: list[str] = []
+    session_state = {
+        "server_started": True,
+        "mlflow_port": 50123,
+        "mlflow_endpoint": "http://127.0.0.1:50123",
+        "mlflow_health_signature": "stale-signature",
+    }
+    monkeypatch.setattr(
+        pagelib,
+        "st",
+        SimpleNamespace(
+            session_state=session_state,
+            error=lambda message: errors.append(str(message)),
+            warning=lambda *_args, **_kwargs: None,
+        ),
+    )
+    monkeypatch.setattr(pagelib, "DEFAULT_SIDECAR_REGISTRY", FailingRegistry())
+    monkeypatch.setattr(
+        pagelib,
+        "_ensure_default_mlflow_experiment",
+        lambda _tracking_dir: pytest.fail("backend preparation must not follow failed revalidation"),
+    )
+
+    started = pagelib.activate_mlflow(
+        SimpleNamespace(app="alpha_project", MLFLOW_TRACKING_DIR="", home_abs=tmp_path)
+    )
+
+    assert started is False
+    assert session_state["server_started"] is False
+    assert "mlflow_autostart_disabled" not in session_state
+    for state_key in ("mlflow_port", "mlflow_endpoint", "mlflow_health_signature"):
+        assert state_key not in session_state
+    assert any("registered MLflow process is not healthy" in message for message in errors)
+
+
+def test_activate_mlflow_retries_registry_revalidation_after_transient_failure(
+    tmp_path,
+    monkeypatch,
+):
+    lease = SimpleNamespace(
+        endpoint="http://127.0.0.1:50123",
+        port=50123,
+        health_signature="healthy-signature",
+    )
+
+    class RetryingRegistry:
+        def __init__(self):
+            self.get_calls = 0
+
+        @contextmanager
+        def preparation_guard(self, **_kwargs):
+            yield
+
+        def get(self, **_kwargs):
+            self.get_calls += 1
+            if self.get_calls == 1:
+                raise SidecarStartError("registry is temporarily busy")
+            return lease
+
+        def ensure(self, **_kwargs):
+            pytest.fail("a healthy revalidated lease must be reused")
+
+    registry = RetryingRegistry()
+    errors: list[str] = []
+    session_state: dict[str, object] = {}
+    monkeypatch.setattr(
+        pagelib,
+        "st",
+        SimpleNamespace(
+            session_state=session_state,
+            error=lambda message: errors.append(str(message)),
+            warning=lambda *_args, **_kwargs: None,
+        ),
+    )
+    monkeypatch.setattr(pagelib, "DEFAULT_SIDECAR_REGISTRY", registry)
+    monkeypatch.setattr(
+        pagelib,
+        "_ensure_default_mlflow_experiment",
+        lambda _tracking_dir: pytest.fail(
+            "healthy lease reuse must not prepare the backend"
+        ),
+    )
+    env = SimpleNamespace(
+        app="alpha_project",
+        MLFLOW_TRACKING_DIR="",
+        home_abs=tmp_path,
+    )
+
+    assert pagelib.activate_mlflow(env) is False
+    assert "mlflow_autostart_disabled" not in session_state
+    assert pagelib.activate_mlflow(env) is True
+    assert registry.get_calls == 2
+    assert session_state["mlflow_endpoint"] == lease.endpoint
+    assert "mlflow_status_message" not in session_state
+
+
 def test_activate_mlflow_migrates_legacy_filestore(tmp_path, monkeypatch):
     tracking_dir = (tmp_path / ".mlflow").resolve()
     (tracking_dir / "0").mkdir(parents=True)
@@ -1998,7 +2259,11 @@ def test_activate_gpt_oss_handles_missing_package_and_success(monkeypatch):
     monkeypatch.setattr(pagelib, "get_random_port", lambda: 50124)
     monkeypatch.setattr(pagelib, "is_port_in_use", lambda _port: False)
     launched = {}
-    monkeypatch.setattr(pagelib, "subproc", lambda command, cwd: launched.setdefault("call", (command, cwd)))
+    monkeypatch.setattr(
+        pagelib,
+        "subproc",
+        lambda command, cwd, **_kwargs: launched.setdefault("call", (command, cwd)),
+    )
 
     assert pagelib.activate_gpt_oss(env) is True
     command = launched["call"][0]
@@ -2007,6 +2272,111 @@ def test_activate_gpt_oss_handles_missing_package_and_success(monkeypatch):
     assert fake_st.session_state["gpt_oss_server_started"] is True
     assert fake_st.session_state["gpt_oss_endpoint"] == "http://127.0.0.1:50124/v1/responses"
     assert env.envars["GPT_OSS_ENDPOINT"] == "http://127.0.0.1:50124/v1/responses"
+
+
+def test_activate_gpt_oss_failed_revalidation_clears_prior_success_state(monkeypatch):
+    class FlakyRegistry:
+        def __init__(self) -> None:
+            self.ensure_calls: list[dict[str, object]] = []
+
+        def ensure(self, **kwargs):
+            self.ensure_calls.append(dict(kwargs))
+            if len(self.ensure_calls) == 1:
+                return SimpleNamespace(
+                    endpoint="http://127.0.0.1:50124/custom-responses",
+                    port=50124,
+                    health_signature="healthy-signature",
+                )
+            raise SidecarStartError("registered GPT-OSS process is not healthy")
+
+    registry = FlakyRegistry()
+    errors: list[str] = []
+    session_state: dict[str, object] = {}
+    monkeypatch.setattr(
+        pagelib,
+        "st",
+        SimpleNamespace(
+            session_state=session_state,
+            warning=lambda *_args, **_kwargs: None,
+            error=lambda message: errors.append(str(message)),
+        ),
+    )
+    monkeypatch.setattr(pagelib, "DEFAULT_SIDECAR_REGISTRY", registry)
+    monkeypatch.setitem(sys.modules, "gpt_oss", SimpleNamespace())
+    env = SimpleNamespace(app="demo_project", envars={})
+
+    assert pagelib.activate_gpt_oss(env) is True
+    assert session_state["gpt_oss_endpoint"] == "http://127.0.0.1:50124/custom-responses"
+    assert env.envars["GPT_OSS_ENDPOINT"] == "http://127.0.0.1:50124/custom-responses"
+    assert registry.ensure_calls[0]["exclusive_for_project"] is True
+    assert "replace_existing_for_project" not in registry.ensure_calls[0]
+
+    assert pagelib.activate_gpt_oss(env) is False
+    for state_key in (
+        "gpt_oss_server_started",
+        "gpt_oss_port",
+        "gpt_oss_endpoint",
+        "gpt_oss_health_signature",
+        "gpt_oss_backend_active",
+        "gpt_oss_checkpoint_active",
+        "gpt_oss_extra_args_active",
+    ):
+        assert state_key not in session_state
+    assert "GPT_OSS_ENDPOINT" not in env.envars
+    assert session_state["gpt_oss_autostart_failed"] is True
+    assert registry.ensure_calls[1]["exclusive_for_project"] is True
+    assert "replace_existing_for_project" not in registry.ensure_calls[1]
+    assert any("registered GPT-OSS process is not healthy" in message for message in errors)
+
+
+def test_activate_gpt_oss_namespaces_same_app_name_by_resolved_project_root(
+    tmp_path,
+    monkeypatch,
+):
+    registry = _TestSidecarRegistry()
+    session_state: dict[str, object] = {}
+    monkeypatch.setattr(
+        pagelib,
+        "st",
+        SimpleNamespace(
+            session_state=session_state,
+            warning=lambda *_args, **_kwargs: None,
+            error=lambda *_args, **_kwargs: None,
+        ),
+    )
+    monkeypatch.setattr(pagelib, "DEFAULT_SIDECAR_REGISTRY", registry)
+    monkeypatch.setitem(sys.modules, "gpt_oss", SimpleNamespace())
+    monkeypatch.setattr(
+        pagelib,
+        "subproc",
+        lambda *_args, **_kwargs: SimpleNamespace(),
+    )
+    first_root = tmp_path / "checkout-a" / "apps" / "demo_project"
+    second_root = tmp_path / "checkout-b" / "apps" / "demo_project"
+    first = SimpleNamespace(
+        app="demo_project",
+        active_app=first_root,
+        envars={},
+    )
+    second = SimpleNamespace(
+        app="demo_project",
+        active_app=second_root,
+        envars={},
+    )
+
+    assert pagelib.activate_gpt_oss(first) is True
+    session_state["gpt_oss_extra_args"] = "--temperature 0.2"
+    assert pagelib.activate_gpt_oss(second) is True
+    session_state["gpt_oss_extra_args"] = "--temperature 0.4"
+    assert pagelib.activate_gpt_oss(first) is False
+
+    projects = [str(call["project"]) for call in registry.ensure_calls]
+    assert projects == [
+        str(first_root.resolve()),
+        str(second_root.resolve()),
+        str(first_root.resolve()),
+    ]
+    assert len(registry._leases) == 2
 
 
 def test_activate_gpt_oss_requires_checkpoint_for_transformers_backend(monkeypatch):
@@ -2200,9 +2570,18 @@ def test_activate_mlflow_and_gpt_oss_cover_no_env_and_runtime_failures(monkeypat
 
     errors.clear()
     fake_st.session_state["gpt_oss_server_started"] = True
+    monkeypatch.setitem(sys.modules, "gpt_oss", SimpleNamespace())
+    reverified_launches: list[object] = []
+    monkeypatch.setattr(
+        pagelib,
+        "subproc",
+        lambda command, _cwd, **_kwargs: reverified_launches.append(command),
+    )
     assert pagelib.activate_gpt_oss(SimpleNamespace(envars={})) is True
+    assert reverified_launches
 
     fake_st.session_state.clear()
+    monkeypatch.setattr(pagelib, "DEFAULT_SIDECAR_REGISTRY", _TestSidecarRegistry())
     monkeypatch.setitem(sys.modules, "gpt_oss", SimpleNamespace())
     monkeypatch.setattr(pagelib, "get_random_port", lambda: 50124)
     monkeypatch.setattr(pagelib, "is_port_in_use", lambda _port: False)
@@ -2776,7 +3155,7 @@ def test_activate_gpt_oss_transformers_backend_retries_busy_port_and_keeps_activ
     monkeypatch.setattr(
         pagelib,
         "subproc",
-        lambda command, cwd: launched.setdefault("call", (command, cwd)),
+        lambda command, cwd, **_kwargs: launched.setdefault("call", (command, cwd)),
     )
 
     env = SimpleNamespace(envars={})
@@ -2843,5 +3222,5 @@ def test_activate_mlflow_public_wrapper_does_not_strip_launch_options(tmp_path, 
     assert launched[0]["stdout"].name == str(tmp_path / ".mlflow" / "mlflow-server.log")
     assert launched[0]["stderr"] == pagelib.subprocess.STDOUT
     assert launched[0]["start_new_session"] is True
-    assert fake_st.session_state["mlflow_autostart_disabled"] is True
+    assert "mlflow_autostart_disabled" not in fake_st.session_state
     assert "mlflow-server.log" in fake_st.session_state["mlflow_status_message"]

--- a/src/agilab/core/agi-env/test/test_pagelib_runtime_support.py
+++ b/src/agilab/core/agi-env/test/test_pagelib_runtime_support.py
@@ -386,6 +386,7 @@ def test_activate_gpt_oss_support_clears_empty_checkpoint_and_extra_args(monkeyp
     command = launched[0][0]
     assert command[:3] == [sys.executable, "-m", "gpt_oss.responses_api.serve"]
     assert command[command.index("--inference-backend") + 1] == "stub"
+    assert command[command.index("--host") + 1] == "127.0.0.1"
 
 
 def test_activate_gpt_oss_support_handles_existing_import_missing_checkpoint_and_start_failure(monkeypatch):

--- a/src/agilab/core/agi-env/test/test_share_mount_support.py
+++ b/src/agilab/core/agi-env/test/test_share_mount_support.py
@@ -22,14 +22,18 @@ def test_read_cluster_setting_handles_empty_and_invalid_files(tmp_path: Path):
 def test_read_cluster_setting_propagates_unexpected_runtime_bug(tmp_path: Path, monkeypatch):
     settings = tmp_path / "app_settings.toml"
     settings.write_text("[cluster]\ncluster_enabled = true\n", encoding="utf-8")
-    original_is_file = Path.is_file
+    real_read_app_settings = share_mount_support.read_app_settings
 
-    def _runtime_is_file(self):
-        if self == settings:
+    def _runtime_read_app_settings(path):
+        if path == settings:
             raise RuntimeError("is_file bug")
-        return original_is_file(self)
+        return real_read_app_settings(path)
 
-    monkeypatch.setattr(Path, "is_file", _runtime_is_file, raising=False)
+    monkeypatch.setattr(
+        share_mount_support,
+        "read_app_settings",
+        _runtime_read_app_settings,
+    )
 
     with pytest.raises(RuntimeError, match="is_file bug"):
         share_mount_support._read_cluster_setting(settings)

--- a/src/agilab/core/agi-env/test/test_sidecar_registry.py
+++ b/src/agilab/core/agi-env/test/test_sidecar_registry.py
@@ -1,0 +1,677 @@
+from __future__ import annotations
+
+import socket
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+import psutil
+import pytest
+
+import agi_env.ui.sidecar_registry as sidecar_registry_module
+
+from agi_env.ui.sidecar_registry import (
+    ProcessSidecarRegistry,
+    SidecarCollisionError,
+    SidecarRegistryBusyError,
+    SidecarStartError,
+)
+
+
+_SERVER_CODE = """
+import socket
+import sys
+sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+sock.bind(("127.0.0.1", int(sys.argv[1])))
+sock.listen()
+while True:
+    conn, _ = sock.accept()
+    conn.close()
+"""
+
+_NON_LISTENING_TREE_CODE = """
+import pathlib
+import subprocess
+import sys
+import time
+child = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(120)"])
+pathlib.Path(sys.argv[1]).write_text(str(child.pid), encoding="utf-8")
+time.sleep(120)
+"""
+
+_CLOSABLE_SERVER_CODE = """
+import pathlib
+import socket
+import sys
+import time
+marker = pathlib.Path(sys.argv[2])
+sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+sock.bind(("127.0.0.1", int(sys.argv[1])))
+sock.listen()
+while not marker.exists():
+    time.sleep(0.02)
+sock.close()
+time.sleep(120)
+"""
+
+
+def test_hosted_import_lease_times_out_for_peer_session() -> None:
+    outcomes: list[BaseException | str] = []
+
+    def _contender() -> None:
+        try:
+            with sidecar_registry_module.isolated_import_process_state(timeout=0.01):
+                outcomes.append("acquired")
+        except BaseException as exc:
+            outcomes.append(exc)
+
+    sidecar_registry_module.HOSTED_INLINE_RENDER_LEASE.acquire()
+    try:
+        thread = threading.Thread(target=_contender)
+        thread.start()
+        thread.join(timeout=1)
+    finally:
+        sidecar_registry_module.HOSTED_INLINE_RENDER_LEASE.release()
+
+    assert not thread.is_alive()
+    assert len(outcomes) == 1
+    assert isinstance(outcomes[0], SidecarRegistryBusyError)
+
+
+def test_preparation_thread_guard_honors_timeout(tmp_path: Path) -> None:
+    registry = ProcessSidecarRegistry(tmp_path / "registry")
+    outcomes: list[BaseException | str] = []
+
+    def _contender() -> None:
+        try:
+            with registry.preparation_guard(
+                service_kind="analysis",
+                project="demo",
+                key="demo",
+                timeout=0.01,
+            ):
+                outcomes.append("acquired")
+        except BaseException as exc:
+            outcomes.append(exc)
+
+    with registry.preparation_guard(
+        service_kind="analysis",
+        project="demo",
+        key="demo",
+        timeout=1,
+    ):
+        thread = threading.Thread(target=_contender)
+        thread.start()
+        thread.join(timeout=1)
+
+    assert not thread.is_alive()
+    assert len(outcomes) == 1
+    assert isinstance(outcomes[0], SidecarRegistryBusyError)
+
+
+def test_file_guard_does_not_unlock_when_acquisition_times_out(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = ProcessSidecarRegistry(tmp_path / "registry")
+    monkeypatch.setattr(registry, "_try_advisory_lock", lambda _handle: False)
+    monkeypatch.setattr(
+        registry,
+        "_unlock_advisory_lock",
+        lambda _handle: (_ for _ in ()).throw(
+            AssertionError("unowned lock must not be released")
+        ),
+    )
+
+    with pytest.raises(SidecarRegistryBusyError, match="Timed out"):
+        with registry._locked_file_guard(
+            registry.lock_path,
+            timeout=0,
+            purpose="test",
+        ):
+            raise AssertionError("unavailable lock unexpectedly acquired")
+
+
+def _launcher(processes: list[subprocess.Popen[bytes]], calls: list[int]):
+    def launch(port: int, _token: str) -> subprocess.Popen[bytes]:
+        calls.append(port)
+        process = subprocess.Popen(
+            [sys.executable, "-c", _SERVER_CODE, str(port)],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        processes.append(process)
+        return process
+
+    return launch
+
+
+def _stop(processes: list[subprocess.Popen[bytes]]) -> None:
+    for process in processes:
+        if process.poll() is None:
+            process.terminate()
+            try:
+                process.wait(timeout=3)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait(timeout=3)
+
+
+def _process_is_live(pid: int) -> bool:
+    try:
+        process = psutil.Process(pid)
+        return process.is_running() and process.status() != psutil.STATUS_ZOMBIE
+    except (psutil.Error, OSError):
+        return False
+
+
+@pytest.mark.parametrize(
+    ("family", "bind_address", "expected"),
+    [
+        pytest.param(socket.AF_INET, "127.0.0.1", True, id="ipv4-loopback"),
+        pytest.param(socket.AF_INET, "0.0.0.0", False, id="ipv4-wildcard"),
+        pytest.param(socket.AF_INET, "192.0.2.10", False, id="ipv4-lan"),
+        pytest.param(socket.AF_INET6, "::1", False, id="ipv6-loopback-mismatch"),
+    ],
+)
+def test_process_endpoint_ownership_requires_exact_ipv4_loopback_bind(
+    monkeypatch,
+    family,
+    bind_address,
+    expected,
+):
+    port = 50123
+    connection = SimpleNamespace(
+        family=family,
+        laddr=SimpleNamespace(ip=bind_address, port=port),
+        status="LISTEN",
+    )
+    process = SimpleNamespace(net_connections=lambda *, kind: [connection])
+    monkeypatch.setattr(
+        ProcessSidecarRegistry,
+        "_process_tree",
+        classmethod(lambda _cls, _pid, _started_at: [process]),
+    )
+
+    assert ProcessSidecarRegistry._process_owns_endpoint(
+        123,
+        456.0,
+        "127.0.0.1",
+        port,
+    ) is expected
+
+
+def test_registry_reuses_one_verified_process_and_token(tmp_path):
+    registry = ProcessSidecarRegistry(tmp_path / "registry")
+    processes: list[subprocess.Popen[bytes]] = []
+    calls: list[int] = []
+    try:
+        first = registry.ensure(
+            service_kind="notebook",
+            project="alpha_project",
+            key="analysis.ipynb",
+            launcher=_launcher(processes, calls),
+            token="owned-token",
+            timeout=5,
+        )
+        second = registry.ensure(
+            service_kind="notebook",
+            project="alpha_project",
+            key="analysis.ipynb",
+            launcher=lambda *_args: (_ for _ in ()).throw(AssertionError("must reuse")),
+            token="different-session-token",
+            timeout=5,
+        )
+
+        assert calls == [first.port]
+        assert second == first
+        assert second.token == "owned-token"
+        assert registry.lock_path.exists()
+    finally:
+        _stop(processes)
+
+
+def test_registry_secret_publication_failure_leaves_no_partial_secret(
+    tmp_path,
+    monkeypatch,
+):
+    registry = ProcessSidecarRegistry(tmp_path / "registry")
+    real_replace = sidecar_registry_module.os.replace
+
+    def fail_secret_replace(source, destination):
+        if Path(destination) == registry.secret_path:
+            raise OSError("simulated secret publication failure")
+        return real_replace(source, destination)
+
+    monkeypatch.setattr(sidecar_registry_module.os, "replace", fail_secret_replace)
+    with pytest.raises(OSError, match="simulated secret publication failure"):
+        registry._load_secret()
+
+    assert not registry.secret_path.exists()
+    assert list(registry.root.glob(f".{registry.secret_path.name}.*.tmp")) == []
+
+
+def test_registry_serializes_concurrent_launchers_without_replacing_lock_file(tmp_path):
+    registry = ProcessSidecarRegistry(tmp_path / "registry")
+    processes: list[subprocess.Popen[bytes]] = []
+    calls: list[int] = []
+    barrier = threading.Barrier(3)
+    results = []
+    errors = []
+
+    def worker() -> None:
+        barrier.wait()
+        try:
+            results.append(
+                registry.ensure(
+                    service_kind="analysis-view",
+                    project="alpha_project",
+                    key="view_maps",
+                    launcher=_launcher(processes, calls),
+                    timeout=5,
+                )
+            )
+        except BaseException as exc:  # pragma: no cover - surfaced by assertion
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker), threading.Thread(target=worker)]
+    for thread in threads:
+        thread.start()
+    barrier.wait()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    try:
+        assert errors == []
+        assert len(results) == 2
+        assert len(calls) == 1
+        assert results[0] == results[1]
+        assert registry.lock_path.exists()
+    finally:
+        _stop(processes)
+
+
+def test_registry_does_not_block_disjoint_service_while_launcher_waits(tmp_path):
+    registry = ProcessSidecarRegistry(tmp_path / "registry")
+    processes: list[subprocess.Popen[bytes]] = []
+    calls: list[int] = []
+    slow_launcher_entered = threading.Event()
+    release_slow_launcher = threading.Event()
+    fast_service_finished = threading.Event()
+    results = {}
+    errors = []
+
+    def slow_launcher(port: int, token: str) -> subprocess.Popen[bytes]:
+        slow_launcher_entered.set()
+        if not release_slow_launcher.wait(timeout=5):
+            raise RuntimeError("timed out waiting to release slow launcher")
+        return _launcher(processes, calls)(port, token)
+
+    def ensure_slow_service() -> None:
+        try:
+            results["slow"] = registry.ensure(
+                service_kind="notebook",
+                project="alpha_project",
+                key="analysis.ipynb",
+                launcher=slow_launcher,
+                timeout=5,
+            )
+        except BaseException as exc:  # pragma: no cover - surfaced by assertion
+            errors.append(exc)
+
+    def ensure_fast_service() -> None:
+        try:
+            results["fast"] = registry.ensure(
+                service_kind="mlflow",
+                project="alpha_project",
+                key="tracking",
+                launcher=_launcher(processes, calls),
+                timeout=5,
+            )
+        except BaseException as exc:  # pragma: no cover - surfaced by assertion
+            errors.append(exc)
+        finally:
+            fast_service_finished.set()
+
+    slow_thread = threading.Thread(target=ensure_slow_service)
+    fast_thread = threading.Thread(target=ensure_fast_service)
+    slow_thread.start()
+    assert slow_launcher_entered.wait(timeout=2)
+    fast_thread.start()
+
+    try:
+        assert fast_service_finished.wait(timeout=3), (
+            "an unrelated service launch was blocked by the slow launcher"
+        )
+        assert slow_thread.is_alive()
+    finally:
+        release_slow_launcher.set()
+        slow_thread.join(timeout=10)
+        fast_thread.join(timeout=10)
+
+    try:
+        assert not slow_thread.is_alive()
+        assert not fast_thread.is_alive()
+        assert errors == []
+        assert registry.get(
+            service_kind="notebook",
+            project="alpha_project",
+            key="analysis.ipynb",
+        ) == results["slow"]
+        assert registry.get(
+            service_kind="mlflow",
+            project="alpha_project",
+            key="tracking",
+        ) == results["fast"]
+    finally:
+        _stop(processes)
+
+
+def test_registry_fails_closed_for_live_owned_process_without_listener(tmp_path):
+    registry = ProcessSidecarRegistry(tmp_path / "registry")
+    marker = tmp_path / "close-listener"
+    processes: list[subprocess.Popen[bytes]] = []
+
+    def launch(port: int, _token: str) -> subprocess.Popen[bytes]:
+        process = subprocess.Popen(
+            [sys.executable, "-c", _CLOSABLE_SERVER_CODE, str(port), str(marker)],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        processes.append(process)
+        return process
+
+    try:
+        lease = registry.ensure(
+            service_kind="analysis-view",
+            project="alpha_project",
+            key="view",
+            launcher=launch,
+            timeout=5,
+        )
+        marker.touch()
+        deadline = time.monotonic() + 3
+        while registry._port_is_open(lease.port) and time.monotonic() < deadline:
+            time.sleep(0.02)
+        assert not registry._port_is_open(lease.port)
+        assert processes[0].poll() is None
+
+        with pytest.raises(SidecarCollisionError, match="still live"):
+            registry.ensure(
+                service_kind="analysis-view",
+                project="alpha_project",
+                key="view",
+                launcher=lambda *_args: (_ for _ in ()).throw(
+                    AssertionError("must not launch replacement")
+                ),
+                timeout=1,
+            )
+    finally:
+        _stop(processes)
+
+
+def test_registry_reaps_listener_when_registry_publication_fails(tmp_path, monkeypatch):
+    registry = ProcessSidecarRegistry(tmp_path / "registry")
+    processes: list[subprocess.Popen[bytes]] = []
+    calls: list[int] = []
+    monkeypatch.setattr(
+        registry,
+        "_write_entries",
+        lambda _entries: (_ for _ in ()).throw(OSError("registry write failed")),
+    )
+
+    with pytest.raises(OSError, match="registry write failed"):
+        registry.ensure(
+            service_kind="analysis-view",
+            project="alpha_project",
+            key="view",
+            launcher=_launcher(processes, calls),
+            timeout=5,
+        )
+
+    assert len(processes) == 1
+    assert processes[0].poll() is not None
+    assert not registry._port_is_open(calls[0])
+    assert not registry.registry_path.exists()
+
+
+def test_registry_interrupt_during_endpoint_wait_reaps_process_and_reraises(
+    tmp_path,
+    monkeypatch,
+):
+    registry = ProcessSidecarRegistry(tmp_path / "registry")
+    processes: list[subprocess.Popen[bytes]] = []
+    calls: list[int] = []
+    cleanup_calls = []
+    real_terminate = registry._terminate_process
+
+    def interrupt_endpoint_wait(*_args) -> bool:
+        raise KeyboardInterrupt("operator interrupted sidecar wait")
+
+    def record_termination(process, **kwargs) -> None:
+        cleanup_calls.append((process, kwargs))
+        real_terminate(process, **kwargs)
+
+    monkeypatch.setattr(registry, "_process_owns_endpoint", interrupt_endpoint_wait)
+    monkeypatch.setattr(registry, "_terminate_process", record_termination)
+
+    try:
+        with pytest.raises(KeyboardInterrupt, match="operator interrupted sidecar wait"):
+            registry.ensure(
+                service_kind="analysis-view",
+                project="alpha_project",
+                key="interrupted-view",
+                launcher=_launcher(processes, calls),
+                timeout=5,
+            )
+
+        assert len(processes) == 1
+        assert len(cleanup_calls) == 1
+        assert cleanup_calls[0][0] is processes[0]
+        assert cleanup_calls[0][1]["root_pid"] == processes[0].pid
+        assert processes[0].poll() is not None
+        assert not registry._port_is_open(calls[0])
+        assert not registry.registry_path.exists()
+    finally:
+        _stop(processes)
+
+
+def test_registry_unexpected_identity_failure_reaps_process_and_reraises(
+    tmp_path,
+    monkeypatch,
+):
+    registry = ProcessSidecarRegistry(tmp_path / "registry")
+    processes: list[subprocess.Popen[bytes]] = []
+    calls: list[int] = []
+    cleanup_calls = []
+    real_terminate = registry._terminate_process
+    real_psutil_process = sidecar_registry_module.psutil.Process
+
+    def fail_identity(pid: int):
+        if processes and pid == processes[0].pid:
+            raise RuntimeError("unexpected process identity failure")
+        return real_psutil_process(pid)
+
+    def record_termination(process, **kwargs) -> None:
+        cleanup_calls.append((process, kwargs))
+        real_terminate(process, **kwargs)
+
+    monkeypatch.setattr(sidecar_registry_module.psutil, "Process", fail_identity)
+    monkeypatch.setattr(registry, "_terminate_process", record_termination)
+
+    try:
+        with pytest.raises(RuntimeError, match="unexpected process identity failure"):
+            registry.ensure(
+                service_kind="analysis-view",
+                project="alpha_project",
+                key="identity-failure-view",
+                launcher=_launcher(processes, calls),
+                timeout=5,
+            )
+
+        assert len(processes) == 1
+        assert len(cleanup_calls) == 1
+        assert cleanup_calls[0][0] is processes[0]
+        processes[0].wait(timeout=3)
+        assert not registry._port_is_open(calls[0])
+        assert not registry.registry_path.exists()
+    finally:
+        _stop(processes)
+
+
+def test_registry_replaces_verified_obsolete_project_configuration(tmp_path):
+    registry = ProcessSidecarRegistry(tmp_path / "registry")
+    processes: list[subprocess.Popen[bytes]] = []
+    calls: list[int] = []
+    try:
+        first = registry.ensure(
+            service_kind="gpt-oss",
+            project="alpha_project",
+            key="config-a",
+            launcher=_launcher(processes, calls),
+            timeout=5,
+        )
+        second = registry.ensure(
+            service_kind="gpt-oss",
+            project="alpha_project",
+            key="config-b",
+            launcher=_launcher(processes, calls),
+            replace_existing_for_project=True,
+            timeout=5,
+        )
+
+        assert first.token != second.token
+        assert processes[0].poll() is not None
+        assert processes[1].poll() is None
+        assert registry.get(
+            service_kind="gpt-oss",
+            project="alpha_project",
+            key="config-a",
+        ) is None
+        assert registry.get(
+            service_kind="gpt-oss",
+            project="alpha_project",
+            key="config-b",
+        ) == second
+    finally:
+        _stop(processes)
+
+
+def test_registry_exclusive_configuration_does_not_kill_another_session(
+    tmp_path,
+):
+    registry = ProcessSidecarRegistry(tmp_path / "registry")
+    processes: list[subprocess.Popen[bytes]] = []
+    calls: list[int] = []
+    try:
+        first = registry.ensure(
+            service_kind="gpt-oss",
+            project="alpha_project",
+            key="config-a",
+            launcher=_launcher(processes, calls),
+            timeout=5,
+        )
+
+        with pytest.raises(
+            SidecarCollisionError,
+            match="refusing to replace another session's service",
+        ):
+            registry.ensure(
+                service_kind="gpt-oss",
+                project="alpha_project",
+                key="config-b",
+                launcher=_launcher(processes, calls),
+                exclusive_for_project=True,
+                timeout=5,
+            )
+
+        assert len(processes) == 1
+        assert processes[0].poll() is None
+        assert registry.get(
+            service_kind="gpt-oss",
+            project="alpha_project",
+            key="config-a",
+        ) == first
+        assert registry.get(
+            service_kind="gpt-oss",
+            project="alpha_project",
+            key="config-b",
+        ) is None
+    finally:
+        _stop(processes)
+
+
+def test_registry_fails_closed_when_live_listener_replaces_registered_pid(tmp_path):
+    registry = ProcessSidecarRegistry(tmp_path / "registry")
+    processes: list[subprocess.Popen[bytes]] = []
+    calls: list[int] = []
+    lease = registry.ensure(
+        service_kind="analysis-view",
+        project="alpha_project",
+        key="view_maps",
+        launcher=_launcher(processes, calls),
+        timeout=5,
+    )
+    _stop(processes)
+
+    deadline = time.monotonic() + 3
+    while time.monotonic() < deadline:
+        try:
+            listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            listener.bind(("127.0.0.1", lease.port))
+            listener.listen()
+            break
+        except OSError:
+            listener.close()
+            time.sleep(0.05)
+    else:  # pragma: no cover - platform refused timely port reuse
+        pytest.skip("could not reuse released loopback port")
+
+    try:
+        with pytest.raises(SidecarCollisionError, match="no longer matches"):
+            registry.get(
+                service_kind="analysis-view",
+                project="alpha_project",
+                key="view_maps",
+            )
+    finally:
+        listener.close()
+
+
+def test_registry_start_failure_stops_only_observed_launcher_descendants(tmp_path):
+    registry = ProcessSidecarRegistry(tmp_path / "registry")
+    child_pid_path = tmp_path / "child.pid"
+    launched: list[subprocess.Popen[bytes]] = []
+
+    def launch(_port: int, _token: str) -> subprocess.Popen[bytes]:
+        process = subprocess.Popen(
+            [sys.executable, "-c", _NON_LISTENING_TREE_CODE, str(child_pid_path)],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        launched.append(process)
+        return process
+
+    with pytest.raises(SidecarStartError, match="did not prove ownership"):
+        registry.ensure(
+            service_kind="analysis-view",
+            project="alpha_project",
+            key="broken-view",
+            launcher=launch,
+            timeout=0.8,
+        )
+
+    assert len(launched) == 1
+    assert launched[0].poll() is not None
+    assert child_pid_path.exists()
+    child_pid = int(Path(child_pid_path).read_text(encoding="utf-8"))
+    deadline = time.monotonic() + 3
+    while _process_is_live(child_pid) and time.monotonic() < deadline:
+        time.sleep(0.05)
+    assert not _process_is_live(child_pid)

--- a/src/agilab/core/agi-env/test/test_worker_runtime_support.py
+++ b/src/agilab/core/agi-env/test/test_worker_runtime_support.py
@@ -124,7 +124,7 @@ def test_configure_worker_runtime_copies_packaged_app_when_worker_is_missing(tmp
     assert env.worker_path == env.active_app / "src" / "demo_worker" / "demo_worker.py"
 
 
-def test_configure_worker_runtime_sets_free_threading_and_clears_distribution_tree(tmp_path: Path):
+def test_configure_worker_runtime_sets_free_threading_and_preserves_distribution_tree(tmp_path: Path):
     env = _dummy_env(tmp_path)
     home_abs = tmp_path / "home"
     worker_dir = home_abs / "wenv" / "demo_worker" / "src" / "demo_worker"
@@ -136,7 +136,8 @@ def test_configure_worker_runtime_sets_free_threading_and_clears_distribution_tr
     )
     stale_plan = home_abs / "wenv" / "demo_worker" / "distribution_tree.json"
     stale_plan.parent.mkdir(parents=True, exist_ok=True)
-    stale_plan.write_text("{}", encoding="utf-8")
+    persisted_plan = '{"workers": ["node-a"]}'
+    stale_plan.write_text(persisted_plan, encoding="utf-8")
 
     sys_path = []
     pythonpath_entries = []
@@ -159,7 +160,7 @@ def test_configure_worker_runtime_sets_free_threading_and_clears_distribution_tr
     )
 
     assert env.distribution_tree == stale_plan
-    assert not stale_plan.exists()
+    assert stale_plan.read_text(encoding="utf-8") == persisted_plan
     assert env.uv_worker == "PYTHON_GIL=0 uv"
     assert env.pyvers_worker == "3.13t"
     assert pythonpath_entries == ["PYTHONPATH-entry"]

--- a/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/base_worker_service_support.py
+++ b/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/base_worker_service_support.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import json
 import os
 import re
+import threading
 import time
 import traceback
+import uuid
 from contextlib import suppress
 from pathlib import Path
 from typing import Any, Callable
@@ -13,6 +15,51 @@ SERVICE_TASK_SCHEMA = "agi.service.task.v1"
 SERVICE_TASK_SUFFIX = ".task.json"
 LEGACY_SERVICE_TASK_SUFFIX = ".task.pkl"
 SERVICE_TASK_EXECUTION_EXCEPTIONS: tuple[type[Exception], ...] = (Exception,)
+
+
+def _flush_and_fsync(stream: Any, *, os_module: Any = os) -> None:
+    """Flush one temp file and fsync it when the platform supports that."""
+
+    stream.flush()
+    fsync = getattr(os_module, "fsync", None)
+    fileno = getattr(stream, "fileno", None)
+    if not callable(fsync) or not callable(fileno):
+        return
+    try:
+        fsync(fileno())
+    except (AttributeError, OSError, TypeError, ValueError):
+        # Some virtual/Windows filesystems do not expose a syncable descriptor.
+        pass
+
+
+def _fsync_directory(path: Path, *, os_module: Any = os) -> None:
+    """Best-effort directory durability after an atomic rename."""
+
+    open_dir = getattr(os_module, "open", None)
+    close_fd = getattr(os_module, "close", None)
+    fsync = getattr(os_module, "fsync", None)
+    read_only = getattr(os_module, "O_RDONLY", None)
+    if (
+        not callable(open_dir)
+        or not callable(close_fd)
+        or not callable(fsync)
+        or read_only is None
+    ):
+        return
+    flags = int(read_only) | int(getattr(os_module, "O_DIRECTORY", 0))
+    try:
+        fd = open_dir(path, flags)
+    except (AttributeError, OSError, TypeError, ValueError):
+        return
+    try:
+        fsync(fd)
+    except (AttributeError, OSError, TypeError, ValueError):
+        pass
+    finally:
+        try:
+            close_fd(fd)
+        except (AttributeError, OSError, TypeError, ValueError):
+            pass
 
 
 def resolve_service_queue_root(
@@ -49,22 +96,29 @@ def make_heartbeat_writer(
     heartbeat_dir.mkdir(parents=True, exist_ok=True)
     safe_worker = re.sub(r"[^a-zA-Z0-9_.-]+", "-", str(worker_name or worker_id)).strip("-")
     heartbeat_file = heartbeat_dir / f"{worker_id:03d}-{safe_worker or 'worker'}.json"
+    worker_incarnation = uuid.uuid4().hex
 
     def _write_heartbeat(state: str) -> None:
+        process_pid = pid_factory()
         payload = {
             "worker_id": worker_id,
             "worker": str(worker_name),
-            "pid": pid_factory(),
+            "pid": process_pid,
+            "worker_incarnation": worker_incarnation,
             "timestamp": time_module.time(),
             "state": state,
         }
-        tmp = heartbeat_file.with_suffix(heartbeat_file.suffix + ".tmp")
+        tmp = heartbeat_file.with_suffix(
+            heartbeat_file.suffix + f".{process_pid}-{uuid.uuid4().hex}.tmp"
+        )
         try:
             with open_fn(tmp, "w", encoding="utf-8") as stream:
                 json_module.dump(payload, stream)
+                _flush_and_fsync(stream, os_module=os_module)
             os_module.replace(tmp, heartbeat_file)
+            _fsync_directory(heartbeat_file.parent, os_module=os_module)
         except OSError:
-            with suppress(FileNotFoundError):
+            with suppress(OSError):
                 tmp.unlink()
             logger_obj.debug(
                 "worker #%s: failed to write service heartbeat",
@@ -72,6 +126,10 @@ def make_heartbeat_writer(
                 exc_info=True,
             )
 
+    # The queue consumer binds every running claim to the same unique token.
+    # Recovery can therefore distinguish a live claimant from a replacement
+    # worker that happens to reuse the same scheduler worker name.
+    setattr(_write_heartbeat, "worker_incarnation", worker_incarnation)
     return _write_heartbeat
 
 
@@ -101,11 +159,19 @@ def _dump_service_payload(
     pickle_module: Any | None = None,
     os_module: Any = os,
 ) -> None:
-    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp = path.with_suffix(path.suffix + f".{uuid.uuid4().hex}.tmp")
     payload.setdefault("schema", SERVICE_TASK_SCHEMA)
-    with open_fn(tmp, "w", encoding="utf-8") as stream:
-        json_module.dump(payload, stream, sort_keys=True)
-    os_module.replace(tmp, path)
+    try:
+        with open_fn(tmp, "w", encoding="utf-8") as stream:
+            json_module.dump(payload, stream, sort_keys=True)
+            _flush_and_fsync(stream, os_module=os_module)
+        os_module.replace(tmp, path)
+        _fsync_directory(path.parent, os_module=os_module)
+    finally:
+        # Publication failures must not leave ambiguous temp artifacts.  The
+        # canonical running claim remains the durable task evidence.
+        with suppress(OSError):
+            tmp.unlink()
 
 
 def _load_service_payload(
@@ -185,6 +251,9 @@ def run_service_queue(
         TypeError,
         json_decode_error,
     )
+    worker_incarnation = str(
+        getattr(write_heartbeat, "worker_incarnation", "") or uuid.uuid4().hex
+    )
 
     write_heartbeat("running")
     while not stop_event.is_set():
@@ -226,16 +295,53 @@ def run_service_queue(
             ):
                 continue
 
-            running_path = queue_dirs["running"] / pending_path.name
+            task_basename = pending_path.name[: -len(SERVICE_TASK_SUFFIX)]
+            running_path = queue_dirs["running"] / (
+                f"{task_basename}.claim-{uuid.uuid4().hex}{SERVICE_TASK_SUFFIX}"
+            )
             try:
                 pending_path.replace(running_path)
             except FileNotFoundError:
                 continue
+            _fsync_directory(running_path.parent, os_module=os_module)
+            _fsync_directory(pending_path.parent, os_module=os_module)
 
             claimed = True
             task_start = time_module.time()
+            payload["claim"] = {
+                "worker_id": worker_id,
+                "worker": str(worker_name),
+                "worker_incarnation": worker_incarnation,
+                "claimed_at": task_start,
+                "task_filename": pending_path.name,
+            }
+            # Publish the ownership binding before work begins.  A crash after
+            # this point leaves a claim that can be matched only by this worker
+            # incarnation, never by a later worker reusing the same name.
+            _dump_service_payload(
+                running_path,
+                payload,
+                open_fn=open_fn,
+                json_module=json_module,
+                pickle_module=pickle_module,
+                os_module=os_module,
+            )
+            heartbeat_stop = threading.Event()
+            heartbeat_interval = min(max(idle_wait, 0.1), 5.0)
+            publication_succeeded = False
+
+            def _pulse_processing_heartbeat() -> None:
+                while not heartbeat_stop.wait(heartbeat_interval):
+                    write_heartbeat("processing")
+
+            heartbeat_thread = threading.Thread(
+                target=_pulse_processing_heartbeat,
+                name=f"agi-service-heartbeat-{worker_id}",
+                daemon=True,
+            )
             try:
                 write_heartbeat("processing")
+                heartbeat_thread.start()
                 logs = do_works_fn(
                     payload.get("plan", []),
                     payload.get("metadata", []),
@@ -246,15 +352,6 @@ def run_service_queue(
                 payload["worker_id"] = worker_id
                 payload["worker_name"] = worker_name
                 payload["logs"] = logs
-                _dump_service_payload(
-                    queue_dirs["done"] / pending_path.name,
-                    payload,
-                    open_fn=open_fn,
-                    json_module=json_module,
-                    pickle_module=pickle_module,
-                    os_module=os_module,
-                )
-                processed += 1
             # Worker code can fail arbitrarily; persist the failure and keep the queue alive.
             except SERVICE_TASK_EXECUTION_EXCEPTIONS as exc:
                 payload["status"] = "failed"
@@ -264,24 +361,45 @@ def run_service_queue(
                 payload["worker_name"] = worker_name
                 payload["error"] = str(exc)
                 payload["traceback"] = traceback_module.format_exc()
+                destination = queue_dirs["failed"] / pending_path.name
+                logger_obj.exception(
+                    "worker #%s: service task failed (%s)",
+                    worker_id,
+                    pending_path.name,
+                )
+            else:
+                destination = queue_dirs["done"] / pending_path.name
+
+            try:
                 _dump_service_payload(
-                    queue_dirs["failed"] / pending_path.name,
+                    destination,
                     payload,
                     open_fn=open_fn,
                     json_module=json_module,
                     pickle_module=pickle_module,
                     os_module=os_module,
                 )
-                failures += 1
+                publication_succeeded = True
+                if payload["status"] == "done":
+                    processed += 1
+                else:
+                    failures += 1
+            except SERVICE_TASK_EXECUTION_EXCEPTIONS:
                 logger_obj.exception(
-                    "worker #%s: service task failed (%s)",
+                    "worker #%s: failed to publish terminal service task %s; "
+                    "preserving the running claim",
                     worker_id,
                     pending_path.name,
                 )
             finally:
+                heartbeat_stop.set()
+                if heartbeat_thread.is_alive():
+                    heartbeat_thread.join(timeout=heartbeat_interval + 0.5)
                 write_heartbeat("running")
-                with suppress(FileNotFoundError):
-                    running_path.unlink()
+                if publication_succeeded:
+                    with suppress(FileNotFoundError):
+                        running_path.unlink()
+                    _fsync_directory(running_path.parent, os_module=os_module)
             break
 
         if not claimed:

--- a/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/cli.py
+++ b/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/cli.py
@@ -2,10 +2,14 @@
 
 import os
 import sys
+import contextlib
 import signal
 import logging
 import json
-from pathlib import Path
+import hashlib
+import shlex
+import uuid
+from pathlib import Path, PureWindowsPath
 from tempfile import gettempdir
 import shutil
 import subprocess
@@ -15,6 +19,8 @@ import threading
 import time
 import faulthandler
 
+import psutil
+
 from agi_env.data_archive_support import validate_archive_members_stay_within_dest
 
 faulthandler.enable()
@@ -23,16 +29,26 @@ USAGE = """
 Usage: python cli.py <cmd> [arg]
 
 Commands:
-  kill [exclude_pids]      Kill processes, excluding comma-separated PIDs (optional)
+  kill <wenv_path> [exclude_pids]
+                           Kill Dask processes proven to own this worker runtime
+  kill-force [exclude_pids] Broad operator recovery for all matching Dask processes
   clean <wenv_path>        Clean the given wenv directory
+  clean-force <wenv_path>  Also remove the host-wide Dask scratch directory
+  target-lease-acquire <wenv_path> <token> [operation]
+                           Acquire the exact remote-target lifecycle lease
+  target-lease-release <wenv_path> <token>
+                           Release only the matching lease generation
+  target-lease-recover <wenv_path> <token> <recovered_tokens> [operation]
+                           Replace only an identity-proven stale generation
   unzip <wenv_path>        Unzip resources into the given wenv directory
   threaded                 Run the Python threads test
   platform                 Show Python platform/version info
   rapids-probe             Probe NVIDIA/RAPIDS hardware capability as JSON
 
 Examples:
-  python cli.py kill
-  python cli.py kill 1234,5678
+  python cli.py kill /path/to/wenv
+  python cli.py kill-force
+  python cli.py kill /path/to/wenv 1234,5678
   python cli.py clean /path/to/wenv
   python cli.py unzip /path/to/wenv
   python cli.py threaded
@@ -52,7 +68,7 @@ RAPIDS_PROBE_TIMEOUT = float(os.environ.get("CLI_RAPIDS_PROBE_TIMEOUT", "3.0"))
 logger = logging.getLogger(__name__)
 
 _PROCESS_LIST_EXCEPTIONS = (OSError, subprocess.SubprocessError)
-_CLEAN_EXCEPTIONS = (OSError,)
+_CLEAN_EXCEPTIONS = (OSError, ValueError)
 _UNZIP_EXCEPTIONS = (OSError, zipfile.BadZipFile)
 _RAPIDS_PROBE_EXCEPTIONS = (OSError, subprocess.SubprocessError, subprocess.TimeoutExpired)
 _NVIDIA_SMI_CANDIDATES = (
@@ -61,18 +77,615 @@ _NVIDIA_SMI_CANDIDATES = (
     "/usr/local/bin/nvidia-smi",
     "/usr/local/cuda/bin/nvidia-smi",
 )
+_PID_RECORD_SCHEMA = "agilab-dask-pid-owner-v1"
+_PID_START_TOLERANCE_SECONDS = 1.0
+_REMOTE_TARGET_LEASE_SCHEMA = "agilab-remote-target-lease-v1"
 
 # ---------------- helpers ----------------
-def clean(wenv=None):
+def _resolved_destructive_path(value):
     try:
-        scratch = Path(gettempdir()) / 'dask-scratch-space'
-        logger.info(f"Cleaning {scratch}")
-        shutil.rmtree(scratch, ignore_errors=True)
-        logger.info(f"Removed {scratch}")
-        if wenv:
-            logger.info(f"Cleaning {wenv}")
-            shutil.rmtree(wenv, ignore_errors=True)
-            logger.info(f"Removed {wenv}")
+        return Path(value).expanduser().resolve(strict=False)
+    except (OSError, TypeError, ValueError) as exc:
+        raise ValueError(f"invalid filesystem path {value!r}: {exc}") from exc
+
+
+def _destructive_path_is_relative_to(path, parent):
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        pass
+    else:
+        return True
+
+    try:
+        if not parent.exists():
+            return False
+    except OSError:
+        return False
+    candidate = path
+    while True:
+        try:
+            if candidate.exists() and candidate.samefile(parent):
+                return True
+        except (OSError, ValueError):
+            pass
+        next_candidate = candidate.parent
+        if next_candidate == candidate:
+            return False
+        candidate = next_candidate
+
+
+def safe_destructive_path(path, *, roots, label="destructive operation", protected_paths=()):
+    """Self-contained confinement for the pre-install worker bootstrap CLI.
+
+    This file is copied and executed before the new worker environment is
+    installed, so it must not import helpers introduced by the incoming
+    ``agi-env`` release.
+    """
+
+    try:
+        raw_value = os.fspath(path)
+    except TypeError as exc:
+        raise ValueError(f"{label} target must be a filesystem path") from exc
+    if not isinstance(raw_value, str) or not raw_value.strip() or "\x00" in raw_value:
+        raise ValueError(f"{label} target is empty or malformed")
+
+    raw_path = Path(raw_value).expanduser()
+    windows_path = PureWindowsPath(raw_value)
+    if raw_path in (Path("."), Path("..")) or ".." in (
+        raw_path.parts + windows_path.parts
+    ):
+        raise ValueError(f"{label} target must not contain parent traversal")
+    if windows_path.drive and not windows_path.root:
+        raise ValueError(f"{label} target must not be drive-relative")
+
+    target = _resolved_destructive_path(raw_path)
+    if target == Path(target.anchor):
+        raise ValueError(f"{label} target must not be the filesystem root")
+
+    resolved_roots = [_resolved_destructive_path(root) for root in roots]
+    if not resolved_roots:
+        raise ValueError(f"{label} requires a trusted confinement root")
+    for root in resolved_roots:
+        if _destructive_path_is_relative_to(
+            target,
+            root,
+        ) and _destructive_path_is_relative_to(root, target):
+            raise ValueError(f"{label} target must not be the confinement root")
+    if not any(
+        _destructive_path_is_relative_to(target, root) for root in resolved_roots
+    ):
+        roots_text = ", ".join(str(root) for root in resolved_roots)
+        raise ValueError(
+            f"{label} target must stay under a trusted root ({roots_text}), got {target}"
+        )
+
+    for protected_path in protected_paths:
+        protected = _resolved_destructive_path(protected_path)
+        if target == protected:
+            raise ValueError(f"{label} target must not be protected path {protected}")
+    return target
+
+
+def safe_worker_runtime_cleanup_path(
+    path,
+    *,
+    roots,
+    home_path=None,
+    cwd_path=None,
+):
+    protected = tuple(item for item in (home_path, cwd_path) if item is not None)
+    return safe_destructive_path(
+        path,
+        roots=roots,
+        label="worker runtime cleanup",
+        protected_paths=protected,
+    )
+
+
+def _remote_target_lease_path(target: Path) -> Path:
+    target = _normalized_path(target)
+    target_key = os.path.normcase(os.path.normpath(str(target))).replace("\\", "/")
+    digest = hashlib.sha256(target_key.encode("utf-8")).hexdigest()[:20]
+    return target.parent / ".agilab-target-leases" / f"target-{digest}.lock"
+
+
+def _read_remote_target_lease(target: Path) -> dict:
+    owner_path = _remote_target_lease_path(target) / "owner.json"
+    try:
+        payload = json.loads(owner_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _valid_remote_target_lease_token(token: str) -> bool:
+    if len(token) != 32:
+        return False
+    try:
+        int(token, 16)
+    except ValueError:
+        return False
+    return True
+
+
+def _remote_target_lease_marker(lock_path: Path, token: str) -> Path:
+    return lock_path / f"token-{token}"
+
+
+def _fsync_directory(path: Path) -> None:
+    try:
+        fd = os.open(path, os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(fd)
+    except OSError:
+        pass
+    finally:
+        os.close(fd)
+
+
+def _remote_release_tombstone(lock_path: Path, token: str) -> Path:
+    return lock_path.with_name(f".{lock_path.name}.released-{token}")
+
+
+def _read_json_file(path: Path) -> dict:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _valid_marker_claim(path: Path, token: str) -> bool:
+    try:
+        return path.is_file() and path.read_text(encoding="ascii").strip() == token
+    except OSError:
+        return False
+
+
+def _release_marker_claims(lock_path: Path, token: str) -> list[Path]:
+    return [
+        candidate
+        for candidate in sorted(
+            lock_path.parent.glob(
+                f".{lock_path.name}.release-claim-{token}-*"
+            ),
+            key=lambda path: path.name,
+        )
+        if _valid_marker_claim(candidate, token)
+    ]
+
+
+def _release_owner_claims(lock_path: Path, token: str) -> list[Path]:
+    claims: list[Path] = []
+    for candidate in sorted(
+        lock_path.parent.glob(
+            f".{lock_path.name}.release-owner-claim-{token}-*"
+        ),
+        key=lambda path: path.name,
+    ):
+        owner = _read_json_file(candidate)
+        if (
+            owner.get("schema") == _REMOTE_TARGET_LEASE_SCHEMA
+            and str(owner.get("token") or "") == token
+        ):
+            claims.append(candidate)
+    return claims
+
+
+def _acquire_publication_claims(lock_path: Path, token: str) -> list[Path]:
+    claims: list[Path] = []
+    for candidate in sorted(
+        lock_path.parent.glob(
+            f".{lock_path.name}.acquire-claim-{token}-*"
+        ),
+        key=lambda path: path.name,
+    ):
+        owner = _read_json_file(candidate)
+        if (
+            owner.get("schema") == _REMOTE_TARGET_LEASE_SCHEMA
+            and str(owner.get("token") or "") == token
+        ):
+            claims.append(candidate)
+    return claims
+
+
+def remote_target_lease_owned(target: Path, token: str) -> bool:
+    if not _valid_remote_target_lease_token(token):
+        return False
+    lock_path = _remote_target_lease_path(target)
+    owner = _read_remote_target_lease(target)
+    return (
+        owner.get("schema") == _REMOTE_TARGET_LEASE_SCHEMA
+        and str(owner.get("token") or "") == str(token)
+        and _remote_target_lease_marker(lock_path, token).is_file()
+    )
+
+
+def acquire_remote_target_lease(target: Path, token: str, operation: str = "unknown") -> bool:
+    """Atomically claim a worker-host target for one manager lifecycle token."""
+
+    if not _valid_remote_target_lease_token(token):
+        logger.error("Remote target lease token must be exactly 32 hexadecimal characters")
+        return False
+    target = _normalized_path(target)
+    lock_path = _remote_target_lease_path(target)
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    owner = {
+        "schema": _REMOTE_TARGET_LEASE_SCHEMA,
+        "token": token,
+        "operation": operation or "unknown",
+        "created_at": time.time(),
+    }
+    publication_claim = lock_path.with_name(
+        f".{lock_path.name}.acquire-claim-{token}-{uuid.uuid4().hex}"
+    )
+    claimed_destination = False
+    published = False
+    try:
+        with publication_claim.open("x", encoding="utf-8") as stream:
+            json.dump(owner, stream, sort_keys=True)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        _fsync_directory(lock_path.parent)
+        # mkdir is the no-replace destination CAS on every supported platform.
+        # The external publication claim makes a crash after this point exactly
+        # recoverable even before owner.json or the token marker is visible.
+        lock_path.mkdir()
+        claimed_destination = True
+        owner_tmp = lock_path / f".owner.{token}.{uuid.uuid4().hex}.tmp"
+        with owner_tmp.open("x", encoding="utf-8") as stream:
+            json.dump(owner, stream, sort_keys=True)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(owner_tmp, lock_path / "owner.json")
+        marker = _remote_target_lease_marker(lock_path, token)
+        with marker.open("x", encoding="ascii") as stream:
+            stream.write(token + "\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        _fsync_directory(lock_path)
+        _fsync_directory(lock_path.parent)
+        published = True
+    except FileExistsError:
+        if remote_target_lease_owned(target, token):
+            return True
+        owner = _read_remote_target_lease(target)
+        logger.error(
+            "Worker runtime %s is already leased by operation %s (token=%s)",
+            target,
+            owner.get("operation", "unknown"),
+            owner.get("token", "unknown"),
+        )
+        return False
+    except OSError as exc:
+        if lock_path.exists():
+            owner = _read_remote_target_lease(target)
+            logger.error(
+                "Worker runtime %s is already leased by operation %s (token=%s)",
+                target,
+                owner.get("operation", "unknown"),
+                owner.get("token", "unknown"),
+            )
+        else:
+            logger.error("Could not persist worker runtime lease for %s: %s", target, exc)
+        return False
+    finally:
+        # Preserve the exact publication capability only when this command won
+        # the destination but failed before publishing a complete generation.
+        if published or not claimed_destination:
+            with contextlib.suppress(OSError):
+                publication_claim.unlink()
+    return True
+
+
+def release_remote_target_lease(target: Path, token: str) -> bool:
+    """Release only the exact lease generation named by ``token``."""
+
+    target = _normalized_path(target)
+    lock_path = _remote_target_lease_path(target)
+    if not _valid_remote_target_lease_token(token):
+        logger.error("Remote target lease token must be exactly 32 hexadecimal characters")
+        return False
+    if not lock_path.exists():
+        return True
+
+    marker = _remote_target_lease_marker(lock_path, token)
+    claim = lock_path.parent / (
+        f".{lock_path.name}.release-claim-{token}-{uuid.uuid4().hex}"
+    )
+    claim_kind = "marker"
+    claimed_owner: dict = {}
+    try:
+        marker.rename(claim)
+    except FileNotFoundError:
+        owner = _read_remote_target_lease(target)
+        owner_token = str(owner.get("token") or "")
+        if not lock_path.exists() or (
+            owner.get("schema") == _REMOTE_TARGET_LEASE_SCHEMA
+            and owner_token != token
+        ):
+            # This generation was already released. A successor generation,
+            # if present, must remain untouched.
+            return True
+        marker_claims = _release_marker_claims(lock_path, token)
+        owner_claims = _release_owner_claims(lock_path, token)
+        publication_claims = _acquire_publication_claims(lock_path, token)
+        if owner.get("schema") == _REMOTE_TARGET_LEASE_SCHEMA and owner_token == token:
+            if marker_claims:
+                claim = marker_claims[0]
+            elif owner_claims:
+                logger.error(
+                    "Refusing to release worker runtime %s: owner publication "
+                    "claim conflicts with a visible owner",
+                    target,
+                )
+                return False
+            else:
+                claim_kind = "owner"
+                claim = lock_path.parent / (
+                    f".{lock_path.name}.release-owner-claim-{token}-{uuid.uuid4().hex}"
+                )
+                try:
+                    (lock_path / "owner.json").rename(claim)
+                except OSError as exc:
+                    logger.error(
+                        "Could not claim partial worker lease publication %s: %s",
+                        target,
+                        exc,
+                    )
+                    return False
+                claimed_owner = _read_json_file(claim)
+        elif not owner and owner_claims:
+            claim_kind = "owner"
+            claim = owner_claims[0]
+            claimed_owner = _read_json_file(claim)
+        elif not owner and publication_claims:
+            claim_kind = "publication"
+            claim = publication_claims[0]
+            claimed_owner = _read_json_file(claim)
+        else:
+            logger.error(
+                "Refusing to release worker runtime %s: token generation "
+                "evidence is missing",
+                target,
+            )
+            return False
+    except OSError as exc:
+        logger.error("Could not claim worker runtime lease for release %s: %s", target, exc)
+        return False
+
+    owner = claimed_owner or _read_remote_target_lease(target)
+    if (
+        owner.get("schema") != _REMOTE_TARGET_LEASE_SCHEMA
+        or str(owner.get("token") or "") != token
+    ):
+        # The marker claim is the authorization generation. If its owner
+        # record disagrees, fail closed and leave the current lock untouched.
+        if lock_path.exists() and str(owner.get("token") or "") == token:
+            with contextlib.suppress(OSError):
+                if claim_kind == "owner":
+                    claim.rename(lock_path / "owner.json")
+                elif claim_kind == "marker":
+                    claim.rename(marker)
+        else:
+            with contextlib.suppress(OSError):
+                claim.unlink()
+        logger.error("Worker runtime lease generation changed before release: %s", target)
+        return False
+
+    # Make the moved generation non-empty even when recovering the historical
+    # owner-before-marker publication window. The deterministic destination is
+    # retained as a tombstone, so a delayed resumer cannot rename a successor
+    # generation after another resumer has completed this token.
+    release_generation = lock_path / f"release-generation-{token}"
+    try:
+        with release_generation.open("a", encoding="ascii") as stream:
+            stream.write(token + "\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+    except OSError as exc:
+        if claim_kind == "owner":
+            with contextlib.suppress(OSError):
+                claim.rename(lock_path / "owner.json")
+        elif claim_kind == "marker":
+            with contextlib.suppress(OSError):
+                claim.rename(marker)
+        logger.error("Could not persist worker lease release claim %s: %s", target, exc)
+        return False
+
+    quarantine = _remote_release_tombstone(lock_path, token)
+    if quarantine.exists():
+        with contextlib.suppress(OSError):
+            claim.unlink()
+        current_owner = _read_remote_target_lease(target)
+        if not lock_path.exists() or str(current_owner.get("token") or "") != token:
+            return True
+        logger.error("Worker runtime lease release is already claimed: %s", target)
+        return False
+    try:
+        lock_path.rename(quarantine)
+    except FileNotFoundError:
+        with contextlib.suppress(OSError):
+            claim.unlink()
+        return True
+    except OSError as exc:
+        if quarantine.exists():
+            with contextlib.suppress(OSError):
+                claim.unlink()
+            current_owner = _read_remote_target_lease(target)
+            if not lock_path.exists() or str(current_owner.get("token") or "") != token:
+                return True
+        current_owner = _read_remote_target_lease(target)
+        if str(current_owner.get("token") or "") == token:
+            with contextlib.suppress(OSError):
+                if claim_kind == "owner":
+                    claim.rename(lock_path / "owner.json")
+                elif claim_kind == "marker":
+                    claim.rename(marker)
+        logger.error("Could not release worker runtime lease for %s: %s", target, exc)
+        return False
+    # Keep the deterministic generation tombstone. It is the durable CAS that
+    # makes an arbitrarily delayed release/resumer harmless to successors.
+    with contextlib.suppress(OSError):
+        claim.unlink()
+    for publication_claim in _acquire_publication_claims(lock_path, token):
+        with contextlib.suppress(OSError):
+            publication_claim.unlink()
+    _fsync_directory(lock_path.parent)
+    return True
+
+
+def recover_remote_target_lease(
+    target: Path,
+    token: str,
+    recovered_tokens: list[str] | tuple[str, ...],
+    operation: str = "unknown",
+) -> bool:
+    """Replace an exact stale generation without using lease age as authority.
+
+    ``recovered_tokens`` are capabilities emitted by the manager-side lifecycle
+    guard only after it proves the prior manager PID incarnation is gone. The
+    worker still performs an exact token-marker CAS. A live or replacement owner
+    with any other generation remains untouched.
+    """
+
+    if not _valid_remote_target_lease_token(token):
+        logger.error("Remote target lease token must be exactly 32 hexadecimal characters")
+        return False
+    authorized_tokens = tuple(
+        dict.fromkeys(
+            str(candidate)
+            for candidate in recovered_tokens
+            if _valid_remote_target_lease_token(str(candidate))
+        )
+    )
+    if not authorized_tokens or len(authorized_tokens) != len(recovered_tokens):
+        logger.error("Remote target recovery requires valid exact generation tokens")
+        return False
+    if token in authorized_tokens:
+        logger.error("Replacement lease token must differ from recovered generations")
+        return False
+
+    target = _normalized_path(target)
+    lock_path = _remote_target_lease_path(target)
+    if remote_target_lease_owned(target, token):
+        return True
+    if not lock_path.exists():
+        return acquire_remote_target_lease(target, token, operation)
+
+    owner = _read_remote_target_lease(target)
+    owner_token = str(owner.get("token") or "")
+    if not owner:
+        for recovered_token in authorized_tokens:
+            owner_claims = _release_owner_claims(lock_path, recovered_token)
+            if owner_claims:
+                owner = _read_json_file(owner_claims[0])
+                owner_token = str(owner.get("token") or "")
+                break
+            publication_claims = _acquire_publication_claims(
+                lock_path,
+                recovered_token,
+            )
+            if publication_claims:
+                owner = _read_json_file(publication_claims[0])
+                owner_token = str(owner.get("token") or "")
+                break
+    if (
+        owner.get("schema") != _REMOTE_TARGET_LEASE_SCHEMA
+        or owner_token not in authorized_tokens
+        or not (
+            remote_target_lease_owned(target, owner_token)
+            or bool(_release_marker_claims(lock_path, owner_token))
+            or bool(_release_owner_claims(lock_path, owner_token))
+            or bool(_acquire_publication_claims(lock_path, owner_token))
+            or str(_read_remote_target_lease(target).get("token") or "")
+            == owner_token
+        )
+    ):
+        logger.error(
+            "Refusing to recover worker runtime %s: current generation is not "
+            "identity-proven stale",
+            target,
+        )
+        return False
+
+    # Exact-generation release is the recovery CAS. A competing manager may
+    # acquire the now-empty path before us; ordinary acquire then fails closed
+    # and never removes that successor.
+    if not release_remote_target_lease(target, owner_token):
+        return False
+    return acquire_remote_target_lease(target, token, operation)
+
+
+def clean(
+    wenv=None,
+    *,
+    force_scratch=False,
+    lease_token=None,
+    home_path=None,
+    cwd_path=None,
+):
+    try:
+        home = Path(home_path).expanduser() if home_path is not None else Path.home()
+        cwd = Path(cwd_path).expanduser() if cwd_path is not None else Path.cwd()
+        target_path = None
+        if wenv is not None:
+            raw_target = Path(wenv).expanduser()
+            if not raw_target.is_absolute():
+                raw_target = cwd / raw_target
+            target_path = safe_worker_runtime_cleanup_path(
+                raw_target,
+                roots=(home / "wenv", cwd / "wenv"),
+                home_path=home,
+                cwd_path=cwd,
+            )
+
+        scratch = None
+        if force_scratch:
+            temp_root = Path(gettempdir()).expanduser().resolve(strict=False)
+            scratch = safe_destructive_path(
+                temp_root / "dask-scratch-space",
+                roots=(temp_root,),
+                label="Dask scratch cleanup",
+            )
+            logger.info(f"Force cleaning {scratch}")
+            shutil.rmtree(scratch, ignore_errors=True)
+            logger.info(f"Removed {scratch}")
+        if target_path is not None:
+            if not force_scratch:
+                lock_path = _remote_target_lease_path(target_path)
+                if lock_path.exists() and not remote_target_lease_owned(
+                    target_path, str(lease_token or "")
+                ):
+                    logger.error(
+                        "Refusing to clean %s without its exact remote lifecycle token",
+                        target_path,
+                    )
+                    return False
+                active = _target_dask_processes(target_path)
+                if active:
+                    logger.error(
+                        "Refusing to clean %s while target Dask process(es) remain: %s",
+                        target_path,
+                        sorted(active),
+                    )
+                    return False
+            logger.info(f"Cleaning {target_path}")
+            if not target_path.exists():
+                logger.info("Worker environment is already absent: %s", target_path)
+                return True
+            shutil.rmtree(target_path)
+            if target_path.exists():
+                logger.error(
+                    "Worker environment still exists after cleanup: %s", target_path
+                )
+                return False
+            logger.info(f"Removed {target_path}")
     except _CLEAN_EXCEPTIONS as e:
         logger.error(f"Error during cleanup: {e}")
         return False
@@ -143,6 +756,202 @@ def _is_dask_command(cmd: str) -> bool:
     cmd = cmd.lower()
     return any(marker in cmd for marker in _DASK_CMD_MARKERS)
 
+
+def _normalized_path(path: Path, *, cwd: Path | None = None) -> Path:
+    candidate = path.expanduser()
+    if not candidate.is_absolute():
+        candidate = (cwd or Path.cwd()) / candidate
+    return candidate.resolve(strict=False)
+
+
+def _command_belongs_to_target(
+    cmdline,
+    target: Path,
+    *,
+    process_cwd: Path | None = None,
+) -> bool:
+    """Require an exact project/executable path, never a PID-file substring."""
+
+    if isinstance(cmdline, str):
+        try:
+            parts = shlex.split(cmdline, posix=os.name != "nt")
+        except ValueError:
+            return False
+    else:
+        parts = [str(part) for part in (cmdline or [])]
+    if not parts:
+        return False
+
+    candidates: list[tuple[str, bool]] = [(parts[0], False)]
+    for index, part in enumerate(parts):
+        if part == "--project" and index + 1 < len(parts):
+            candidates.append((parts[index + 1], True))
+        elif part.startswith("--project="):
+            candidates.append((part.split("=", 1)[1], True))
+
+    target = _normalized_path(target)
+    cwd = process_cwd or Path.cwd()
+    for raw_value, is_project_option in candidates:
+        value = str(raw_value).strip().strip("\"'")
+        if not value or "://" in value:
+            continue
+        value_path = Path(value)
+        if (
+            not is_project_option
+            and not value_path.is_absolute()
+            and "/" not in value
+            and "\\" not in value
+        ):
+            # A bare argv[0] such as "dask" only says which PATH lookup won;
+            # it is not proof that the executable came from this runtime.
+            continue
+        try:
+            candidate = _normalized_path(value_path, cwd=cwd)
+        except (OSError, RuntimeError, ValueError):
+            continue
+        try:
+            if candidate == target or candidate.is_relative_to(target):
+                return True
+        except (OSError, ValueError):
+            continue
+    return False
+
+
+def _read_pid_record(pid_file: Path) -> tuple[int, float | None, str | None]:
+    text = pid_file.read_text(encoding="utf-8").strip()
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError:
+        return int(text), None, None
+    if isinstance(payload, int):
+        return int(payload), None, None
+    if not isinstance(payload, dict):
+        raise ValueError("PID ownership record must be an integer or JSON object")
+    pid = int(payload["pid"])
+    raw_start = payload.get("process_start_time")
+    process_start = float(raw_start) if raw_start not in (None, "") else None
+    raw_target = payload.get("target")
+    record_target = str(raw_target) if raw_target not in (None, "") else None
+    return pid, process_start, record_target
+
+
+def _write_pid_record(
+    pid_file: Path,
+    *,
+    pid: int,
+    process_start_time: float,
+    target: Path,
+) -> None:
+    payload = {
+        "schema": _PID_RECORD_SCHEMA,
+        "pid": int(pid),
+        "process_start_time": float(process_start_time),
+        "target": _normalized_path(target).as_posix(),
+    }
+    tmp_path = pid_file.with_name(f".{pid_file.name}.{uuid.uuid4().hex}.tmp")
+    try:
+        with tmp_path.open("x", encoding="utf-8") as stream:
+            json.dump(payload, stream, sort_keys=True)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(tmp_path, pid_file)
+    finally:
+        try:
+            tmp_path.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def _target_pid_files(target: Path) -> list[Path]:
+    """Return namespaced PID files plus legacy shared-parent candidates."""
+
+    target = _normalized_path(target)
+    candidates: set[Path] = set()
+    for root in (target, target.parent):
+        candidates.update(root.glob("dask_scheduler.pid"))
+        candidates.update(root.glob("dask_worker*.pid"))
+    # Historical remote schedulers wrote this file in the worker account home,
+    # one level above the shared worker-environment directory.
+    candidates.update(target.parent.parent.glob("dask_scheduler.pid"))
+    return sorted(candidates, key=lambda path: path.as_posix())
+
+
+def _process_identity(pid: int) -> tuple[object, float, list[str], Path | None] | None:
+    try:
+        process = psutil.Process(pid)
+        process_start = float(process.create_time())
+        cmdline = [str(part) for part in process.cmdline()]
+        try:
+            process_cwd = Path(process.cwd())
+        except (psutil.AccessDenied, psutil.NoSuchProcess, OSError):
+            process_cwd = None
+        return process, process_start, cmdline, process_cwd
+    except psutil.NoSuchProcess:
+        return None
+    except (psutil.AccessDenied, OSError, TypeError, ValueError):
+        raise RuntimeError(f"Cannot prove process ownership for PID {pid}") from None
+
+
+def _process_incarnation_state(pid: int, expected_start: float) -> bool | None:
+    try:
+        process = psutil.Process(pid)
+        if abs(float(process.create_time()) - expected_start) > _PID_START_TOLERANCE_SECONDS:
+            return False
+        if not process.is_running():
+            return False
+        status = process.status()
+        return status != psutil.STATUS_ZOMBIE
+    except psutil.NoSuchProcess:
+        return False
+    except (psutil.AccessDenied, OSError, TypeError, ValueError):
+        return None
+
+
+def _same_process_incarnation(pid: int, expected_start: float) -> bool:
+    return _process_incarnation_state(pid, expected_start) is True
+
+
+def _poll_process_incarnations_until_dead(
+    process_starts: dict[int, float],
+    total: float = GRACE_TOTAL,
+    interval: float = POLL_INTERVAL,
+) -> set[int]:
+    deadline = time.monotonic() + total
+    remaining = dict(process_starts)
+    while remaining and time.monotonic() < deadline:
+        remaining = {
+            pid: started
+            for pid, started in remaining.items()
+            if _process_incarnation_state(pid, started) is not False
+        }
+        if remaining:
+            time.sleep(interval)
+    return set(remaining)
+
+
+def _target_dask_processes(target: Path) -> dict[int, float]:
+    target = _normalized_path(target)
+    processes: dict[int, float] = {}
+    for process in psutil.process_iter(["pid", "cmdline", "create_time"]):
+        try:
+            info = process.info
+            cmdline = info.get("cmdline") or []
+            command_text = " ".join(str(part) for part in cmdline)
+            if not _is_dask_command(command_text):
+                continue
+            try:
+                process_cwd = Path(process.cwd())
+            except (psutil.AccessDenied, psutil.NoSuchProcess, OSError):
+                process_cwd = None
+            if _command_belongs_to_target(cmdline, target, process_cwd=process_cwd):
+                processes[int(info["pid"])] = float(info["create_time"])
+        except (KeyError, TypeError, ValueError, psutil.NoSuchProcess):
+            continue
+        except (psutil.AccessDenied, OSError):
+            continue
+    return processes
+
 def get_child_pids(parent_pids):
     children = set()
     if not parent_pids:
@@ -156,7 +965,8 @@ def get_child_pids(parent_pids):
             for line in output.strip().splitlines():
                 try:
                     pid_str, ppid_str = line.strip().split(None, 1)
-                    pid = int(pid_str); ppid = int(ppid_str)
+                    pid = int(pid_str)
+                    ppid = int(ppid_str)
                     if ppid in parent_pids:
                         children.add(pid)
                 except ValueError:
@@ -179,9 +989,16 @@ def _is_alive(pid: int) -> bool:
         # Unknown; be conservative.
         return True
 
-def kill_pids(pids, sig):
+def kill_pids(pids, sig, *, process_starts: dict[int, float] | None = None):
     survivors = set()
     for pid in pids:
+        if process_starts is not None:
+            expected_start = process_starts.get(pid)
+            if expected_start is None or not _same_process_incarnation(
+                pid, expected_start
+            ):
+                logger.info("PID %s no longer has the authorized incarnation", pid)
+                continue
         try:
             os.kill(pid, sig)
             logger.info(f"Sent signal {sig} to PID {pid}")
@@ -205,55 +1022,278 @@ def _poll_until_dead(pids, total=GRACE_TOTAL, interval=POLL_INTERVAL):
     return remaining
 
 
-def kill(exclude_pids=None):
-    if exclude_pids is None:
-        exclude_pids = set()
-    current_pid = os.getpid()
-    exclude_pids.add(current_pid)
+def _unlink_pid_files(pid_files: set[Path]) -> bool:
+    removed = True
+    for pid_file in sorted(pid_files, key=lambda path: path.as_posix()):
+        try:
+            pid_file.unlink()
+        except FileNotFoundError:
+            continue
+        except OSError as exc:
+            logger.warning("Could not remove pid file %s: %s", pid_file, exc)
+            removed = False
+    return removed
 
-    # 1) Match dask scheduler/worker entrypoints by command line
-    dask_pids = get_processes_matching(_is_dask_command)
-    dask_pids -= exclude_pids
 
-    sent = kill_pids(dask_pids, signal.SIGTERM)
-    remaining = _poll_until_dead(dask_pids)
+def _force_kill(exclude_pids: set[int]) -> bool:
+    """Broad operator recovery, deliberately outside target ownership rules."""
 
-    if remaining and hasattr(signal, "SIGKILL"):
-        kill_pids(remaining, signal.SIGKILL)
-
-    # 2) Match by *.pid files
+    dask_pids = get_processes_matching(_is_dask_command) - exclude_pids
+    child_pids = get_child_pids(dask_pids)
+    target_pids = (dask_pids | child_pids) - exclude_pids
     module_dir = Path(__file__).parent
     pid_files = (
         set(Path("").glob("*.pid"))
         | set(module_dir.glob("*.pid"))
         | set(module_dir.parent.glob("*.pid"))
     )
-    file_pids = set()
-    for pid_file in pid_files:
-        try:
-            pid = int(pid_file.read_text().strip())
-            if pid not in exclude_pids:
-                file_pids.add(pid)
-            else:
-                logger.info(f"Skipping excluded pid {pid} from file {pid_file}")
-        except (OSError, ValueError) as e:
-            logger.warning(f"Could not read pid from {pid_file}: {e}")
-        try:
-            pid_file.unlink()
-        except OSError as e:
-            logger.warning(f"Could not remove pid file {pid_file}: {e}")
 
-    if file_pids:
-        file_pids |= get_child_pids(file_pids)
-        file_pids -= exclude_pids
-        if file_pids:
-            logger.info(f"PIDs from pid files/children to kill: {file_pids}")
-            kill_pids(file_pids, signal.SIGTERM)
-            survivors = _poll_until_dead(file_pids)
-            if survivors and hasattr(signal, "SIGKILL"):
-                kill_pids(survivors, signal.SIGKILL)
+    if target_pids:
+        logger.info("Force-killing Dask PIDs/children: %s", sorted(target_pids))
+        kill_pids(target_pids, signal.SIGTERM)
+        survivors = _poll_until_dead(target_pids)
+        if survivors and hasattr(signal, "SIGKILL"):
+            kill_pids(survivors, signal.SIGKILL)
+            survivors = _poll_until_dead(survivors)
+        if survivors:
+            logger.error("Dask process(es) survived force cleanup: %s", sorted(survivors))
+            return False
     else:
         logger.info("No Dask process running.")
+
+    return _unlink_pid_files(pid_files)
+
+
+def _pid_file_is_target_namespaced(pid_file: Path, target: Path) -> bool:
+    try:
+        return pid_file.parent.resolve(strict=False) == target
+    except (OSError, RuntimeError, ValueError):
+        return False
+
+
+def _record_targets_runtime(record_target: str | None, target: Path) -> bool:
+    if not record_target:
+        return False
+    try:
+        return _normalized_path(Path(record_target)) == target
+    except (OSError, RuntimeError, ValueError):
+        return False
+
+
+def _plain_pid_record_can_name_process(pid_file: Path, process_start: float) -> bool:
+    """Reject a plain PID record when the PID was created after the record."""
+
+    try:
+        record_time = pid_file.stat().st_mtime
+    except OSError:
+        return False
+    return process_start <= record_time + _PID_START_TOLERANCE_SECONDS
+
+
+def _add_child_incarnations(process_starts: dict[int, float]) -> bool:
+    """Snapshot exact descendants without authorizing a reused child PID."""
+
+    parents = set(process_starts)
+    while parents:
+        next_parents: set[int] = set()
+        for parent_pid in parents:
+            parent_start = process_starts[parent_pid]
+            state = _process_incarnation_state(parent_pid, parent_start)
+            if state is False:
+                continue
+            if state is None:
+                logger.warning(
+                    "Cannot prove parent process incarnation for PID %s", parent_pid
+                )
+                return False
+            try:
+                parent = psutil.Process(parent_pid)
+                children = parent.children(recursive=False)
+            except psutil.NoSuchProcess:
+                continue
+            except (psutil.AccessDenied, OSError, TypeError, ValueError):
+                logger.warning("Cannot inspect child processes for PID %s", parent_pid)
+                return False
+            for child in children:
+                try:
+                    child_pid = int(child.pid)
+                    child_start = float(child.create_time())
+                    # Recheck the relationship after reading the incarnation;
+                    # a PID recycled between children() and create_time() must
+                    # not inherit kill authorization from the former child.
+                    if int(child.ppid()) != parent_pid:
+                        continue
+                except psutil.NoSuchProcess:
+                    continue
+                except (psutil.AccessDenied, OSError, TypeError, ValueError):
+                    logger.warning(
+                        "Cannot prove child process incarnation under PID %s",
+                        parent_pid,
+                    )
+                    return False
+                if child_pid in process_starts:
+                    continue
+                process_starts[child_pid] = child_start
+                next_parents.add(child_pid)
+        parents = next_parents
+    return True
+
+
+def _scoped_kill(target: Path, exclude_pids: set[int]) -> bool:
+    target = _normalized_path(target)
+    process_starts: dict[int, float] = {}
+    evidence_files: set[Path] = set()
+    stale_evidence: set[Path] = set()
+    ownership_uncertain = False
+
+    for pid_file in _target_pid_files(target):
+        target_namespaced = _pid_file_is_target_namespaced(pid_file, target)
+        try:
+            pid, expected_start, record_target = _read_pid_record(pid_file)
+        except (OSError, KeyError, TypeError, ValueError) as exc:
+            logger.warning("Could not read PID ownership record %s: %s", pid_file, exc)
+            ownership_uncertain = ownership_uncertain or target_namespaced
+            continue
+
+        explicitly_targeted = _record_targets_runtime(record_target, target)
+        if record_target and not explicitly_targeted:
+            continue
+        if pid in exclude_pids:
+            logger.info("Skipping excluded PID %s from file %s", pid, pid_file)
+            continue
+
+        try:
+            identity = _process_identity(pid)
+        except RuntimeError as exc:
+            if target_namespaced or explicitly_targeted:
+                ownership_uncertain = True
+            logger.warning("%s", exc)
+            continue
+        if identity is None:
+            if target_namespaced or explicitly_targeted:
+                stale_evidence.add(pid_file)
+            continue
+
+        _process, process_start, cmdline, process_cwd = identity
+        command_owned = _is_dask_command(" ".join(cmdline)) and _command_belongs_to_target(
+            cmdline,
+            target,
+            process_cwd=process_cwd,
+        )
+        same_incarnation = (
+            abs(process_start - expected_start) <= _PID_START_TOLERANCE_SECONDS
+            if expected_start is not None
+            else _plain_pid_record_can_name_process(pid_file, process_start)
+        )
+        if not command_owned or not same_incarnation:
+            if target_namespaced or explicitly_targeted:
+                if expected_start is not None and not same_incarnation:
+                    stale_evidence.add(pid_file)
+                elif expected_start is None and not same_incarnation:
+                    stale_evidence.add(pid_file)
+                else:
+                    ownership_uncertain = True
+            continue
+
+        process_starts[pid] = process_start
+        evidence_files.add(pid_file)
+        try:
+            _write_pid_record(
+                pid_file,
+                pid=pid,
+                process_start_time=process_start,
+                target=target,
+            )
+        except OSError as exc:
+            # The original PID evidence remains in place; do not erase it on a
+            # failed stop merely because the incarnation upgrade was blocked.
+            logger.warning("Could not upgrade PID ownership record %s: %s", pid_file, exc)
+
+    residual_before = _target_dask_processes(target)
+    unauthorized = set(residual_before) - set(process_starts) - exclude_pids
+    excluded_active = set(residual_before) & exclude_pids
+    if unauthorized or excluded_active:
+        ownership_uncertain = True
+        logger.error(
+            "Cannot prove PID ownership for target Dask process(es): %s",
+            sorted(unauthorized | excluded_active),
+        )
+
+    if not _add_child_incarnations(process_starts):
+        ownership_uncertain = True
+    if process_starts:
+        logger.info("Target-owned Dask PIDs/children to kill: %s", sorted(process_starts))
+        kill_pids(
+            set(process_starts),
+            signal.SIGTERM,
+            process_starts=process_starts,
+        )
+        survivors = _poll_process_incarnations_until_dead(process_starts)
+        if survivors and hasattr(signal, "SIGKILL"):
+            kill_pids(
+                survivors,
+                signal.SIGKILL,
+                process_starts=process_starts,
+            )
+            survivors = _poll_process_incarnations_until_dead(
+                {pid: process_starts[pid] for pid in survivors}
+            )
+        if survivors:
+            logger.error("Target Dask process(es) survived cleanup: %s", sorted(survivors))
+            return False
+    else:
+        logger.info("No target-owned Dask process running.")
+
+    residual_after = _target_dask_processes(target)
+    if residual_after:
+        logger.error(
+            "Target Dask process(es) remain after cleanup: %s", sorted(residual_after)
+        )
+        return False
+    if ownership_uncertain:
+        return False
+    return _unlink_pid_files(evidence_files | stale_evidence)
+
+
+def kill(
+    target=None,
+    exclude_pids=None,
+    *,
+    force_scan=False,
+    home_path=None,
+    cwd_path=None,
+) -> bool:
+    """Stop exact target-owned Dask processes, or all Dask processes when forced."""
+
+    exclusions = set(exclude_pids or ())
+    exclusions.add(os.getpid())
+    if force_scan:
+        return _force_kill(exclusions)
+    if target is None:
+        logger.error("Ordinary cleanup requires an exact worker runtime path")
+        return False
+    home = Path(home_path).expanduser() if home_path is not None else Path.home()
+    cwd = Path(cwd_path).expanduser() if cwd_path is not None else Path.cwd()
+    try:
+        raw_target = Path(target).expanduser()
+        if not raw_target.is_absolute():
+            raw_target = cwd / raw_target
+        target_path = safe_worker_runtime_cleanup_path(
+            raw_target,
+            roots=(home / "wenv", cwd / "wenv"),
+            home_path=home,
+            # Ordinary ``kill`` only signals identity-proven processes; it
+            # never deletes the runtime directory.  Local cleanup launches
+            # this bootstrap CLI with cwd equal to the target worker runtime,
+            # so protecting cwd here would reject every production-shaped
+            # scoped kill before ownership discovery.  Recursive ``clean``
+            # keeps the stricter cwd protection above.
+            cwd_path=None,
+        )
+    except (OSError, TypeError, ValueError) as exc:
+        logger.error("Refusing unsafe AGILAB worker kill target: %s", exc)
+        return False
+    return _scoped_kill(target_path, exclusions)
 
 def unzip(wenv=None):
     try:
@@ -310,8 +1350,10 @@ def threaded(nthreads=2, iters=None) -> float:
 
     threads = [threading.Thread(target=worker, name=f"Worker-{i}") for i in range(nthreads)]
     start = time.perf_counter()
-    for t in threads: t.start()
-    for t in threads: t.join()
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
     dt = time.perf_counter() - start
     logger.info(f"Threads={nthreads} wall={dt:.3f}s")
     return dt
@@ -431,23 +1473,73 @@ if __name__ == "__main__":
         sys.exit(1)
 
     cmd = sys.argv[1]
-    arg = sys.argv[2] if len(sys.argv) > 2 else None
+    args = sys.argv[2:]
+    arg = args[0] if args else None
     exclude_pids = set()
 
     if cmd == "kill":
+        if not arg:
+            print("Missing worker runtime path for 'kill'\n" + USAGE)
+            sys.exit(1)
+        exclude_arg = args[1] if len(args) > 1 else None
+        if exclude_arg:
+            for pid_str in exclude_arg.split(","):
+                try:
+                    exclude_pids.add(int(pid_str))
+                except ValueError:
+                    logger.warning(f"Invalid PID to exclude: {pid_str}")
+        if not kill(target=arg, exclude_pids=exclude_pids):
+            sys.exit(1)
+
+    elif cmd == "kill-force":
         if arg:
             for pid_str in arg.split(","):
                 try:
                     exclude_pids.add(int(pid_str))
                 except ValueError:
                     logger.warning(f"Invalid PID to exclude: {pid_str}")
-        kill(exclude_pids=exclude_pids)
+        if not kill(exclude_pids=exclude_pids, force_scan=True):
+            sys.exit(1)
 
-    elif cmd == "clean":
+    elif cmd in {"clean", "clean-force"}:
         if not arg:
             print("Missing argument for 'clean'\n" + USAGE)
             sys.exit(1)
-        if not clean(wenv=arg):
+        lease_token = args[1] if len(args) > 1 else None
+        if not clean(
+            wenv=arg,
+            force_scratch=cmd == "clean-force",
+            lease_token=lease_token,
+        ):
+            sys.exit(1)
+
+    elif cmd == "target-lease-acquire":
+        if len(args) < 2:
+            print("Missing target/token for 'target-lease-acquire'\n" + USAGE)
+            sys.exit(1)
+        operation = args[2] if len(args) > 2 else "unknown"
+        if not acquire_remote_target_lease(Path(args[0]), args[1], operation):
+            sys.exit(1)
+
+    elif cmd == "target-lease-release":
+        if len(args) < 2:
+            print("Missing target/token for 'target-lease-release'\n" + USAGE)
+            sys.exit(1)
+        if not release_remote_target_lease(Path(args[0]), args[1]):
+            sys.exit(1)
+
+    elif cmd == "target-lease-recover":
+        if len(args) < 3:
+            print("Missing target/token/recovery proof for 'target-lease-recover'\n" + USAGE)
+            sys.exit(1)
+        operation = args[3] if len(args) > 3 else "unknown"
+        recovered_tokens = [item for item in args[2].split(",") if item]
+        if not recover_remote_target_lease(
+            Path(args[0]),
+            args[1],
+            recovered_tokens,
+            operation,
+        ):
             sys.exit(1)
 
     elif cmd == "unzip":

--- a/src/agilab/core/test/conftest.py
+++ b/src/agilab/core/test/conftest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import sys
 from pathlib import Path
 
 import pytest
@@ -9,6 +10,23 @@ from agi_env import AgiEnv
 
 
 _ORIGINAL_PATH_HOME = Path.home
+
+
+def _reset_loaded_agi_lifecycle() -> None:
+    module = sys.modules.get(
+        "agi_cluster.agi_distributor.api.agi_distributor"
+    )
+    if module is None:
+        return
+    agi_cls = getattr(module, "AGI", None)
+    lifecycle_support = getattr(module, "lifecycle_guard_support", None)
+    if agi_cls is not None and lifecycle_support is not None:
+        lifecycle_support.reset_lifecycle_state(agi_cls)
+        agi_cls._worker_launch_tasks = set()
+        agi_cls._worker_launch_errors = []
+        agi_cls._scheduler_launch_tasks = set()
+        agi_cls._scheduler_launch_errors = []
+        agi_cls._startup_in_progress = False
 
 
 def _home_from_env() -> Path:
@@ -30,6 +48,7 @@ def _home_from_env() -> Path:
 def isolate_core_test_environment(tmp_path_factory, monkeypatch):
     """Keep core tests independent from developer-local AGILAB state."""
 
+    _reset_loaded_agi_lifecycle()
     monkeypatch.setattr(Path, "home", staticmethod(_home_from_env))
 
     fake_home = tmp_path_factory.mktemp("agilab_fake_home")
@@ -74,6 +93,7 @@ def isolate_core_test_environment(tmp_path_factory, monkeypatch):
     yield
     AgiEnv.logger = original_logger
     AgiEnv.reset()
+    _reset_loaded_agi_lifecycle()
 
 
 @pytest.fixture

--- a/src/agilab/core/test/test_agi_distributor.py
+++ b/src/agilab/core/test/test_agi_distributor.py
@@ -4,6 +4,9 @@ from pathlib import Path
 import pytest
 
 from agi_cluster.agi_distributor import AGI, RunRequest
+from agi_cluster.agi_distributor.runtime.runtime_distribution_support import (
+    RuntimeCleanupRequiredError,
+)
 from agi_env import AgiEnv, normalize_path
 
 # Set AGI verbosity low to avoid extra prints during test.
@@ -66,10 +69,13 @@ async def test_stop_handles_scheduler_info_and_retire_failures(monkeypatch):
             self.shutdown_calls += 1
 
     AGI._mode_auto = False
-    AGI._dask_client = _SchedulerInfoFailsClient()
+    scheduler_info_fails_client = _SchedulerInfoFailsClient()
+    AGI._dask_client = scheduler_info_fails_client
     monkeypatch.setattr(AGI, "_close_all_connections", staticmethod(_fake_close_all))
-    await AGI._stop()
-    assert AGI._dask_client.shutdown_calls == 1
+    with pytest.raises(RuntimeCleanupRequiredError, match="scheduler inspection"):
+        await AGI._stop()
+    assert scheduler_info_fails_client.shutdown_calls == 1
+    assert AGI._dask_client is None
     assert closed["count"] == 1
 
     closed["count"] = 0
@@ -86,10 +92,13 @@ async def test_stop_handles_scheduler_info_and_retire_failures(monkeypatch):
         async def shutdown(self):
             self.shutdown_calls += 1
 
-    AGI._dask_client = _RetireFailsClient()
+    retire_fails_client = _RetireFailsClient()
+    AGI._dask_client = retire_fails_client
     monkeypatch.setattr(AGI, "_close_all_connections", staticmethod(_fake_close_all))
-    await AGI._stop()
-    assert AGI._dask_client.shutdown_calls == 1
+    with pytest.raises(RuntimeCleanupRequiredError, match="worker retirement"):
+        await AGI._stop()
+    assert retire_fails_client.shutdown_calls == 1
+    assert AGI._dask_client is None
     assert closed["count"] == 1
 
 

--- a/src/agilab/core/test/test_agi_distributor_background_jobs_support.py
+++ b/src/agilab/core/test/test_agi_distributor_background_jobs_support.py
@@ -13,22 +13,20 @@ def test_background_process_manager_tracks_running_completed_and_dead_jobs(monke
     popen_calls: list[dict[str, object]] = []
 
     class FakeProcess:
-        def __init__(self, status):
+        def __init__(self, status, pid):
             self._status = status
+            self.pid = pid
 
         def poll(self):
             return self._status
 
-    processes = [FakeProcess(None), FakeProcess(0), FakeProcess(3)]
+    processes = [FakeProcess(None, 101), FakeProcess(0, 102), FakeProcess(3, 103)]
 
-    def fake_popen(cmd, shell, cwd, start_new_session, env):
+    def fake_popen(cmd, **kwargs):
         popen_calls.append(
             {
                 "cmd": cmd,
-                "shell": shell,
-                "cwd": cwd,
-                "start_new_session": start_new_session,
-                "env": env,
+                **kwargs,
             }
         )
         return processes.pop(0)
@@ -47,11 +45,28 @@ def test_background_process_manager_tracks_running_completed_and_dead_jobs(monke
     assert popen_calls[0]["shell"] is False
     assert popen_calls[0]["cwd"] == str(tmp_path)
     assert popen_calls[2]["cwd"] is None
+    ownership_tokens = {
+        popen_call["env"][background_jobs_support.BACKGROUND_JOB_TOKEN_ENV]
+        for popen_call in popen_calls
+    }
+    assert len(ownership_tokens) == 3
+    if os.name == "nt":
+        assert popen_calls[0]["creationflags"] == getattr(
+            background_jobs_support.subprocess,
+            "CREATE_NEW_PROCESS_GROUP",
+            0,
+        )
+        assert running.process_group_id is None
+    else:
+        assert popen_calls[0]["start_new_session"] is True
+        assert running.process_group_id == running.process.pid
     assert manager.result(running.num) is running.process
     assert manager.result(completed.num) is completed.process
     assert manager.result(dead.num) is None
     assert completed in manager.completed
     assert dead in manager.dead
+    assert manager.owned == [running, completed, dead]
+    assert isinstance(running.ownership_started_at, float)
 
     manager.flush()
 
@@ -60,6 +75,7 @@ def test_background_process_manager_tracks_running_completed_and_dead_jobs(monke
     assert running.num in manager.all
     assert manager.completed == []
     assert manager.dead == []
+    assert manager.owned == [running, completed, dead]
 
 
 def test_background_process_manager_normalize_cwd_handles_invalid_values():
@@ -122,7 +138,14 @@ def test_background_job_manager_uses_subprocess_and_real_directories_only(monkey
     assert calls[0][0] == ["echo", "test"]
     assert calls[0][1]["shell"] is False
     assert calls[0][1]["cwd"] is None
-    assert calls[0][1]["start_new_session"] is True
+    if os.name == "nt":
+        assert calls[0][1]["creationflags"] == getattr(
+            background_jobs_support.subprocess,
+            "CREATE_NEW_PROCESS_GROUP",
+            0,
+        )
+    else:
+        assert calls[0][1]["start_new_session"] is True
     assert calls[1][1]["cwd"] == str(tmp_path)
     assert jobs.result(second.num) is second.result
 

--- a/src/agilab/core/test/test_agi_distributor_cleanup_support.py
+++ b/src/agilab/core/test/test_agi_distributor_cleanup_support.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import shlex
 from pathlib import Path
 from types import SimpleNamespace
@@ -9,6 +10,14 @@ import pytest
 import psutil
 
 from agi_cluster.agi_distributor import cleanup_support
+
+
+def _local_cleanup_env(tmp_path, worker_name="demo_worker"):
+    home_abs = tmp_path / "home"
+    return SimpleNamespace(
+        home_abs=home_abs,
+        wenv_abs=home_abs / "wenv" / worker_name,
+    )
 
 
 def test_remove_dir_forcefully_retries_oserror_and_raises(tmp_path):
@@ -283,7 +292,12 @@ async def test_kill_processes_cleans_pid_files_and_handles_local_and_remote_path
     assert copied
     assert local_runs
     local_argv = shlex.split(local_runs[0][0].split("python ", 1)[1], posix=True)
-    assert local_argv == [(wenv_parent / "cli.py").as_posix(), "kill", "999"]
+    assert local_argv == [
+        (wenv_parent / "cli.py").as_posix(),
+        "kill",
+        wenv_abs.as_posix(),
+        "999",
+    ]
     assert all(cwd == str(wenv_abs) for _cmd, cwd in local_runs)
     assert len(remote_runs) == 1
     assert remote_runs[0][0] == "10.0.0.2"
@@ -295,11 +309,13 @@ async def test_kill_processes_cleans_pid_files_and_handles_local_and_remote_path
         "python",
         "w env's/cli.py",
         "kill",
+        "w env's/demo worker",
     ]
     assert detected == ["10.0.0.2"]
     assert env.envars["10.0.0.2_CMD_PREFIX"] == 'export PATH="$HOME/.local/bin:$PATH";'
-    assert not (wenv_parent / "ok.pid").exists()
-    assert log.warning.called
+    # The manager no longer unlinks ownership records before the worker CLI
+    # has validated and acted on them.
+    assert (wenv_parent / "ok.pid").exists()
     assert log.info.called
     assert log.error.called
 
@@ -343,11 +359,19 @@ async def test_kill_processes_local_debug_uses_run_path_and_skips_current_pid(tm
     assert run_path_calls == [((wenv_parent / "cli.py").as_posix(), "__main__")]
 
 
-def test_clean_dirs_local_kills_dask_processes_and_ignores_errors(tmp_path):
-    agi_cls = SimpleNamespace(env=SimpleNamespace(wenv_abs=tmp_path / "wenv"))
+def test_clean_dirs_local_kills_dask_processes_before_verified_delete(tmp_path):
+    agi_cls = SimpleNamespace(env=_local_cleanup_env(tmp_path))
     agi_cls.env.wenv_abs.mkdir(parents=True, exist_ok=True)
+    owned_pid = agi_cls.env.wenv_abs / "dask_worker_0.pid"
+    owned_pid.write_text("4242\n", encoding="utf-8")
     killed: list[int] = []
-    removed: list[tuple[str, bool]] = []
+    waited: list[tuple[int, float]] = []
+    removed: list[str] = []
+    real_rmtree = cleanup_support.shutil.rmtree
+
+    def _remove(path, onerror=None):
+        removed.append(path)
+        real_rmtree(path, onerror=onerror)
 
     class _Proc:
         def __init__(self, info, raise_on_kill=False):
@@ -358,10 +382,15 @@ def test_clean_dirs_local_kills_dask_processes_and_ignores_errors(tmp_path):
             if self._raise_on_kill:
                 raise psutil.AccessDenied(pid=self.info["pid"])
             killed.append(self.info["pid"])
+            self.info["cmdline"] = []
+
+        def wait(self, timeout):
+            waited.append((self.info["pid"], timeout))
+            return 0
 
     procs = [
         _Proc({"pid": 100, "username": "me", "cmdline": ["dask-worker"]}),
-        _Proc({"pid": 4242, "username": "me", "cmdline": ["python", "DASK worker"]}),
+        _Proc({"pid": 4242, "username": "me", "cmdline": ["dask", "worker", str(agi_cls.env.wenv_abs)]}),
         _Proc({"pid": 4343, "username": "me", "cmdline": ["python", "other"]}),
         _Proc({"pid": 4444, "username": "me", "cmdline": ["python", "dask scheduler"]}, raise_on_kill=True),
     ]
@@ -371,24 +400,25 @@ def test_clean_dirs_local_kills_dask_processes_and_ignores_errors(tmp_path):
         process_iter_fn=lambda *_a, **_k: procs,
         getuser_fn=lambda: "me",
         getpid_fn=lambda: 100,
-        rmtree_fn=lambda path, ignore_errors=True: removed.append((path, ignore_errors)),
-        gettempdir_fn=lambda: "/tmp/demo",
+        rmtree_fn=_remove,
     )
 
     assert 4242 in killed
     assert 4343 not in killed
-    assert removed == [
-        ("/tmp/demo/dask-scratch-space", True),
-        (str(agi_cls.env.wenv_abs), True),
-    ]
+    assert waited == [(4242, 3.0)]
+    assert removed == [str(agi_cls.env.wenv_abs.resolve())]
 
 
 def test_clean_dirs_local_only_kills_exact_username_matches(tmp_path):
     # Regression: the suffix match (username.endswith(me)) let user 'ed'
     # kill processes owned by 'fred'; only exact matches (after DOMAIN\
     # normalization) may be killed.
-    agi_cls = SimpleNamespace(env=SimpleNamespace(wenv_abs=tmp_path / "wenv"))
+    agi_cls = SimpleNamespace(env=_local_cleanup_env(tmp_path))
     agi_cls.env.wenv_abs.mkdir(parents=True, exist_ok=True)
+    for pid in (200, 201, 202):
+        (agi_cls.env.wenv_abs / f"dask_worker_{pid}.pid").write_text(
+            f"{pid}\n", encoding="utf-8"
+        )
     killed: list[int] = []
 
     class _Proc:
@@ -397,11 +427,12 @@ def test_clean_dirs_local_only_kills_exact_username_matches(tmp_path):
 
         def kill(self):
             killed.append(self.info["pid"])
+            self.info["cmdline"] = []
 
     procs = [
-        _Proc({"pid": 200, "username": "fred", "cmdline": ["dask-worker"]}),
-        _Proc({"pid": 201, "username": "ed", "cmdline": ["dask-worker"]}),
-        _Proc({"pid": 202, "username": "CORP\\ed", "cmdline": ["dask scheduler"]}),
+        _Proc({"pid": 200, "username": "fred", "cmdline": ["dask-worker", f"{agi_cls.env.wenv_abs}-other"]}),
+        _Proc({"pid": 201, "username": "ed", "cmdline": ["dask-worker", str(agi_cls.env.wenv_abs)]}),
+        _Proc({"pid": 202, "username": "CORP\\ed", "cmdline": ["dask", "scheduler", str(agi_cls.env.wenv_abs)]}),
     ]
 
     cleanup_support.clean_dirs_local(
@@ -409,34 +440,330 @@ def test_clean_dirs_local_only_kills_exact_username_matches(tmp_path):
         process_iter_fn=lambda *_a, **_k: procs,
         getuser_fn=lambda: "ed",
         getpid_fn=lambda: 100,
-        rmtree_fn=lambda *_a, **_k: None,
-        gettempdir_fn=lambda: "/tmp/demo",
     )
 
     assert killed == [201, 202]
 
 
-def test_clean_dirs_local_ignores_rmtree_typeerror(tmp_path):
-    agi_cls = SimpleNamespace(env=SimpleNamespace(wenv_abs=tmp_path / "wenv"))
+def test_clean_dirs_local_preserves_live_sibling_pid_evidence(tmp_path):
+    env = _local_cleanup_env(tmp_path, "target_worker")
+    target = env.wenv_abs
+    sibling = target.parent / "sibling_worker"
+    target.mkdir(parents=True)
+    sibling.mkdir()
+    target_pid_file = target.parent / "dask_worker_target.pid"
+    sibling_pid_file = target.parent / "dask_worker_sibling.pid"
+    target_pid_file.write_text(
+        '{"pid": 321, "process_start_time": 10.0}\n',
+        encoding="utf-8",
+    )
+    sibling_payload = b'{"pid": 654, "process_start_time": 20.0}\n'
+    sibling_pid_file.write_bytes(sibling_payload)
+    killed = []
+
+    class _Proc:
+        def __init__(self, info):
+            self.info = info
+
+        def kill(self):
+            killed.append(self.info["pid"])
+            self.info["cmdline"] = []
+
+        def wait(self, timeout):
+            return 0
+
+    target_proc = _Proc(
+        {
+            "pid": 321,
+            "username": "me",
+            "cmdline": ["dask", "worker", str(target)],
+            "create_time": 10.0,
+        }
+    )
+    sibling_proc = _Proc(
+        {
+            "pid": 654,
+            "username": "me",
+            "cmdline": [
+                "dask",
+                "worker",
+                str(sibling),
+                f"--pid-file={sibling_pid_file}",
+            ],
+            "create_time": 20.0,
+        }
+    )
+    processes = [target_proc, sibling_proc]
+
+    cleanup_support.clean_dirs_local(
+        SimpleNamespace(env=env),
+        process_iter_fn=lambda *_a, **_k: processes,
+        getuser_fn=lambda: "me",
+        getpid_fn=lambda: 999,
+    )
+
+    assert killed == [321]
+    assert not target.exists()
+    assert not target_pid_file.exists()
+    assert sibling.exists()
+    assert sibling_pid_file.read_bytes() == sibling_payload
+
+
+def test_clean_dirs_local_refuses_out_of_scope_target_before_process_mutation(tmp_path):
+    home = tmp_path / "home"
+    unsafe_target = tmp_path / "outside" / "worker"
+    unsafe_target.mkdir(parents=True)
+    env = SimpleNamespace(home_abs=home, wenv_abs=unsafe_target)
+
+    with pytest.raises(RuntimeError, match="Refusing unsafe"):
+        cleanup_support.clean_dirs_local(
+            SimpleNamespace(env=env),
+            process_iter_fn=lambda *_a, **_k: (_ for _ in ()).throw(
+                AssertionError("process scan must follow target validation")
+            ),
+        )
+
+    assert unsafe_target.exists()
+
+
+def test_clean_dirs_local_refuses_symlink_alias_outside_worker_root(tmp_path):
+    env = _local_cleanup_env(tmp_path, "aliased_worker")
+    outside = tmp_path / "outside"
+    env.wenv_abs.parent.mkdir(parents=True)
+    outside.mkdir()
+    try:
+        env.wenv_abs.symlink_to(outside, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"directory symlinks unavailable: {exc}")
+
+    with pytest.raises(RuntimeError, match="Refusing unsafe"):
+        cleanup_support.clean_dirs_local(
+            SimpleNamespace(env=env),
+            process_iter_fn=lambda *_a, **_k: [],
+        )
+
+    assert outside.exists()
+
+
+def test_clean_dirs_local_reports_rmtree_typeerror(tmp_path):
+    agi_cls = SimpleNamespace(env=_local_cleanup_env(tmp_path))
     agi_cls.env.wenv_abs.mkdir(parents=True, exist_ok=True)
     removed = []
 
-    def _fake_rmtree(path, ignore_errors=True):
-        removed.append((path, ignore_errors))
+    def _fake_rmtree(path, onerror=None):
+        removed.append((path, onerror is not None))
         raise TypeError("bad signature")
 
-    cleanup_support.clean_dirs_local(
-        agi_cls,
-        process_iter_fn=lambda *_a, **_k: [],
-        getuser_fn=lambda: "me",
-        getpid_fn=lambda: 100,
-        rmtree_fn=_fake_rmtree,
-        gettempdir_fn=lambda: "/tmp/demo",
+    with pytest.raises(RuntimeError, match="PID ownership evidence was retained"):
+        cleanup_support.clean_dirs_local(
+            agi_cls,
+            process_iter_fn=lambda *_a, **_k: [],
+            getuser_fn=lambda: "me",
+            getpid_fn=lambda: 100,
+            rmtree_fn=_fake_rmtree,
+        )
+
+    assert removed == [(str(agi_cls.env.wenv_abs.resolve()), True)]
+
+
+def test_clean_dirs_local_retries_partial_delete_and_restores_pid_evidence(tmp_path):
+    env = _local_cleanup_env(tmp_path)
+    wenv_abs = env.wenv_abs
+    wenv_abs.mkdir(parents=True)
+    pid_file = wenv_abs / "dask_worker_0.pid"
+    payload = b'{"pid": 321, "process_start_time": 10.0}\n'
+    pid_file.write_bytes(payload)
+    attempts = []
+
+    def _partial_delete(path, onerror=None):
+        attempts.append((path, onerror is not None))
+        pid_file.unlink(missing_ok=True)
+        raise OSError("locked remainder")
+
+    with pytest.raises(RuntimeError, match="PID ownership evidence was retained"):
+        cleanup_support.clean_dirs_local(
+            SimpleNamespace(env=env),
+            process_iter_fn=lambda *_a, **_k: [],
+            getuser_fn=lambda: "me",
+            getpid_fn=lambda: 999,
+            rmtree_fn=_partial_delete,
+            sleep_fn=lambda _seconds: None,
+        )
+
+    assert attempts == [
+        (str(wenv_abs.resolve()), True),
+        (str(wenv_abs.resolve()), True),
+    ]
+    assert pid_file.read_bytes() == payload
+
+
+def test_failed_target_delete_does_not_resurrect_removed_sibling_pid_evidence(
+    tmp_path,
+):
+    env = _local_cleanup_env(tmp_path, "target_worker")
+    wenv_abs = env.wenv_abs
+    wenv_abs.mkdir(parents=True)
+    target_pid_file = wenv_abs / "dask_worker_0.pid"
+    sibling_pid_file = wenv_abs.parent / "dask_worker_sibling.pid"
+    target_payload = b'{"pid": 321, "process_start_time": 10.0}\n'
+    target_pid_file.write_bytes(target_payload)
+    sibling_pid_file.write_bytes(
+        b'{"pid": 654, "process_start_time": 20.0}\n'
     )
 
+    def _partial_delete(_path, onerror=None):
+        target_pid_file.unlink(missing_ok=True)
+        sibling_pid_file.unlink(missing_ok=True)
+        raise OSError("locked remainder")
+
+    with pytest.raises(RuntimeError, match="PID ownership evidence was retained"):
+        cleanup_support.clean_dirs_local(
+            SimpleNamespace(env=env),
+            process_iter_fn=lambda *_a, **_k: [],
+            getuser_fn=lambda: "me",
+            getpid_fn=lambda: 999,
+            rmtree_fn=_partial_delete,
+            sleep_fn=lambda _seconds: None,
+        )
+
+    assert target_pid_file.read_bytes() == target_payload
+    assert not sibling_pid_file.exists()
+
+
+def test_clean_dirs_local_preserves_unowned_dask_and_reused_pid(tmp_path):
+    env = _local_cleanup_env(tmp_path)
+    wenv_abs = env.wenv_abs
+    wenv_abs.mkdir(parents=True)
+    (wenv_abs / "dask_worker_0.pid").write_text(
+        '{"pid": 321, "process_start_time": 10.0}\n',
+        encoding="utf-8",
+    )
+    killed = []
+
+    class _Proc:
+        info = {
+            "pid": 321,
+            "username": "me",
+            "cmdline": ["dask", "worker", str(wenv_abs)],
+            # Same PID now belongs to a later process generation.
+            "create_time": 20.0,
+        }
+
+        def kill(self):
+            killed.append(321)
+
+    removed = []
+    with pytest.raises(RuntimeError, match="still reference the target"):
+        cleanup_support.clean_dirs_local(
+            SimpleNamespace(env=env),
+            process_iter_fn=lambda *_a, **_k: [_Proc()],
+            getuser_fn=lambda: "me",
+            getpid_fn=lambda: 999,
+            rmtree_fn=lambda path, **_kwargs: removed.append(path),
+        )
+
+    assert killed == []
+    assert removed == []
+
+
+def test_command_target_match_rejects_path_prefix_collision(tmp_path):
+    wenv_abs = tmp_path / "wenv"
+    pid_file = wenv_abs / "dask_worker_0.pid"
+
+    assert cleanup_support._command_belongs_to_target(
+        ["dask-worker", f"{wenv_abs}-other/bin/python"],
+        pid_file=pid_file,
+        wenv_abs=wenv_abs,
+    ) is False
+    assert cleanup_support._command_belongs_to_target(
+        ["dask-worker", f"--pid-file={pid_file}"],
+        pid_file=pid_file,
+        wenv_abs=wenv_abs,
+    ) is True
+
+
+def test_clean_dirs_local_refuses_active_target_without_pid_file(tmp_path):
+    env = _local_cleanup_env(tmp_path)
+    wenv_abs = env.wenv_abs
+    wenv_abs.mkdir(parents=True)
+    removed = []
+
+    class _Proc:
+        info = {
+            "pid": 321,
+            "username": "me",
+            "cmdline": [str(wenv_abs / "bin" / "python"), "-m", "distributed.cli.dask_worker"],
+        }
+
+    with pytest.raises(RuntimeError, match="still reference the target"):
+        cleanup_support.clean_dirs_local(
+            SimpleNamespace(env=env),
+            process_iter_fn=lambda *_a, **_k: [_Proc()],
+            getuser_fn=lambda: "me",
+            getpid_fn=lambda: 999,
+            rmtree_fn=lambda path, **_kwargs: removed.append(path),
+        )
+
+    assert removed == []
+
+
+def test_clean_dirs_local_refuses_delete_when_owned_process_cannot_be_stopped(tmp_path):
+    env = _local_cleanup_env(tmp_path)
+    wenv_abs = env.wenv_abs
+    wenv_abs.mkdir(parents=True)
+    (wenv_abs / "dask_worker_0.pid").write_text("321\n", encoding="utf-8")
+    removed = []
+
+    class _Proc:
+        info = {
+            "pid": 321,
+            "username": "me",
+            "cmdline": ["dask", "worker", str(wenv_abs)],
+        }
+
+        def kill(self):
+            raise psutil.AccessDenied(pid=321)
+
+    with pytest.raises(RuntimeError, match="remain active"):
+        cleanup_support.clean_dirs_local(
+            SimpleNamespace(env=env),
+            process_iter_fn=lambda *_a, **_k: [_Proc()],
+            getuser_fn=lambda: "me",
+            getpid_fn=lambda: 999,
+            rmtree_fn=lambda path, ignore_errors=True: removed.append(path),
+        )
+
+    assert removed == []
+
+
+def test_force_clean_dirs_local_is_explicit_broad_operator_path(tmp_path):
+    env = _local_cleanup_env(tmp_path)
+    wenv_abs = env.wenv_abs
+    wenv_abs.mkdir(parents=True)
+    killed = []
+    removed = []
+
+    class _Proc:
+        info = {"pid": 321, "username": "me", "cmdline": ["dask-scheduler"]}
+
+        def kill(self):
+            killed.append(321)
+
+    cleanup_support.force_clean_dirs_local(
+        SimpleNamespace(env=env),
+        process_iter_fn=lambda *_a, **_k: [_Proc()],
+        getuser_fn=lambda: "me",
+        getpid_fn=lambda: 999,
+        rmtree_fn=lambda path, ignore_errors=True: removed.append(path),
+        # A trailing native separator makes raw string concatenation produce a
+        # malformed path on every platform, not only a mixed path on Windows.
+        gettempdir_fn=lambda: f"{tmp_path / 'tmp'}{os.sep}",
+    )
+
+    assert killed == [321]
     assert removed == [
-        ("/tmp/demo/dask-scratch-space", True),
-        (str(agi_cls.env.wenv_abs), True),
+        str(tmp_path / "tmp" / "dask-scratch-space"),
+        str(wenv_abs),
     ]
 
 
@@ -469,8 +796,8 @@ async def test_clean_dirs_removes_local_wenv_and_execs_remote(tmp_path):
         remove_dir_forcefully_fn=lambda path: removed.append(path),
     )
 
-    assert removed == [str(wenv_abs)]
-    assert made_dirs == [(wenv_abs / "src", True)]
+    assert removed == []
+    assert made_dirs == []
     assert ssh_calls
     argv = shlex.split(ssh_calls[0][1].split("&& ", 1)[1], posix=True)
     assert argv == [
@@ -484,3 +811,191 @@ async def test_clean_dirs_removes_local_wenv_and_execs_remote(tmp_path):
         "clean",
         "w env's",
     ]
+
+
+@pytest.mark.asyncio
+async def test_remote_target_lease_token_wraps_remote_clean_lifecycle(tmp_path):
+    env = SimpleNamespace(
+        uv="/usr/bin/uv",
+        wenv_rel=Path("w env's/demo worker"),
+        python_version="3.13",
+        envars={},
+    )
+    calls = []
+
+    async def _exec(ip, cmd):
+        calls.append((ip, shlex.split(cmd, posix=True)))
+        return "ok"
+
+    agi_cls = SimpleNamespace(
+        env=env,
+        exec_ssh=_exec,
+        _lifecycle_call_token="a" * 32,
+        _lifecycle_call_operation="install",
+        _remote_target_leases={},
+    )
+
+    lease = await cleanup_support.acquire_remote_target_lease(
+        agi_cls,
+        "10.0.0.9",
+        cmd_prefix="",
+    )
+    await cleanup_support.clean_dirs(agi_cls, "10.0.0.9")
+    await cleanup_support.release_remote_target_leases(agi_cls)
+
+    assert lease.token == "a" * 32
+    assert [argv[7] for _ip, argv in calls] == [
+        "target-lease-acquire",
+        "clean",
+        "target-lease-release",
+    ]
+    assert calls[1][1][-1] == "a" * 32
+    assert agi_cls._remote_target_leases == {}
+
+
+@pytest.mark.asyncio
+async def test_remote_target_lease_uses_identity_proven_recovery_capabilities():
+    env = SimpleNamespace(
+        uv="/usr/bin/uv",
+        wenv_rel=Path("workers/demo"),
+        python_version="3.13",
+        envars={},
+    )
+    calls = []
+
+    async def _exec(ip, cmd):
+        calls.append((ip, shlex.split(cmd, posix=True)))
+        return "ok"
+
+    agi_cls = SimpleNamespace(
+        env=env,
+        exec_ssh=_exec,
+        _lifecycle_call_token="f" * 32,
+        _lifecycle_remote_token="b" * 32,
+        _lifecycle_remote_recovery_tokens=("a" * 32,),
+        _lifecycle_call_operation="run",
+        _remote_target_leases={},
+    )
+
+    lease = await cleanup_support.acquire_remote_target_lease(
+        agi_cls,
+        "10.0.0.9",
+        cmd_prefix="",
+    )
+
+    argv = calls[0][1]
+    assert lease.token == "b" * 32
+    assert lease.recovery_tokens == ("a" * 32,)
+    assert argv[7:] == [
+        "target-lease-recover",
+        "workers/demo",
+        "b" * 32,
+        "a" * 32,
+        "run",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_remote_acquire_transport_failure_retains_exact_local_evidence():
+    env = SimpleNamespace(
+        uv="/usr/bin/uv",
+        wenv_rel=Path("workers/demo"),
+        python_version="3.13",
+        envars={},
+    )
+    agi_cls = SimpleNamespace(
+        env=env,
+        exec_ssh=lambda *_args: None,
+        _lifecycle_remote_token="b" * 32,
+        _lifecycle_call_operation="run",
+        _remote_target_leases={},
+    )
+
+    async def _failed_exec(*_args):
+        raise RuntimeError("transport failed after remote claim")
+
+    agi_cls.exec_ssh = _failed_exec
+    with pytest.raises(RuntimeError, match="transport failed"):
+        await cleanup_support.acquire_remote_target_lease(
+            agi_cls,
+            "10.0.0.9",
+            cmd_prefix="",
+        )
+
+    retained = agi_cls._remote_target_leases["10.0.0.9"]
+    assert retained.token == "b" * 32
+    assert retained.target == Path("workers/demo")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mismatch", ["token", "target"])
+async def test_acquire_rejects_mismatched_cached_remote_lease(mismatch):
+    env = SimpleNamespace(
+        uv="/usr/bin/uv",
+        wenv_rel=Path("workers/demo"),
+        python_version="3.13",
+        envars={},
+    )
+    active_token = "b" * 32
+    cached = cleanup_support.RemoteTargetLease(
+        ip="10.0.0.9",
+        target=Path("workers/other" if mismatch == "target" else "workers/demo"),
+        token="a" * 32 if mismatch == "token" else active_token,
+        operation="install",
+        cmd_prefix="",
+    )
+    ssh_calls = []
+
+    async def _exec(*args):
+        ssh_calls.append(args)
+
+    agi_cls = SimpleNamespace(
+        env=env,
+        exec_ssh=_exec,
+        _lifecycle_remote_token=active_token,
+        _lifecycle_call_operation="run",
+        _remote_target_leases={"10.0.0.9": cached},
+    )
+
+    with pytest.raises(RuntimeError, match="does not match"):
+        await cleanup_support.acquire_remote_target_lease(
+            agi_cls,
+            "10.0.0.9",
+            cmd_prefix="",
+        )
+
+    assert ssh_calls == []
+
+
+@pytest.mark.asyncio
+async def test_clean_rejects_cached_remote_lease_for_another_target():
+    env = SimpleNamespace(
+        uv="/usr/bin/uv",
+        wenv_rel=Path("workers/demo"),
+        python_version="3.13",
+        envars={},
+    )
+    active_token = "b" * 32
+    cached = cleanup_support.RemoteTargetLease(
+        ip="10.0.0.9",
+        target=Path("workers/other"),
+        token=active_token,
+        operation="install",
+        cmd_prefix="",
+    )
+    ssh_calls = []
+
+    async def _exec(*args):
+        ssh_calls.append(args)
+
+    agi_cls = SimpleNamespace(
+        env=env,
+        exec_ssh=_exec,
+        _lifecycle_remote_token=active_token,
+        _remote_target_leases={"10.0.0.9": cached},
+    )
+
+    with pytest.raises(RuntimeError, match="does not match"):
+        await cleanup_support.clean_dirs(agi_cls, "10.0.0.9")
+
+    assert ssh_calls == []

--- a/src/agilab/core/test/test_agi_distributor_cli.py
+++ b/src/agilab/core/test/test_agi_distributor_cli.py
@@ -1,5 +1,10 @@
+import json
+import os
 import runpy
+import shutil
+import subprocess
 import sys
+import threading
 import zipfile
 from pathlib import Path
 import signal
@@ -8,6 +13,34 @@ from types import SimpleNamespace
 import pytest
 
 from agi_cluster.agi_distributor import cli as cli_mod
+
+
+def test_bootstrap_cli_runs_before_new_agi_env_is_installed(tmp_path):
+    legacy_root = tmp_path / "legacy-site"
+    legacy_agi_env = legacy_root / "agi_env"
+    legacy_agi_env.mkdir(parents=True)
+    (legacy_agi_env / "__init__.py").write_text("", encoding="utf-8")
+    (legacy_agi_env / "data_archive_support.py").write_text(
+        "def validate_archive_members_stay_within_dest(*args, **kwargs):\n"
+        "    return None\n",
+        encoding="utf-8",
+    )
+    bootstrap_cli = tmp_path / "worker-cli.py"
+    shutil.copy2(Path(cli_mod.__file__), bootstrap_cli)
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(legacy_root)
+
+    completed = subprocess.run(
+        [sys.executable, str(bootstrap_cli), "platform"],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+    )
+
+    assert completed.returncode == 0, completed.stderr
 
 
 def test_get_processes_containing_parses_unix_ps(monkeypatch):
@@ -210,6 +243,30 @@ def test_kill_pids_handles_process_lookup(monkeypatch):
     assert cli_mod.kill_pids({1}, signal.SIGTERM) == set()
 
 
+def test_incarnation_access_denied_never_signals_and_remains_a_survivor(monkeypatch):
+    monkeypatch.setattr(
+        cli_mod.psutil,
+        "Process",
+        lambda _pid: (_ for _ in ()).throw(cli_mod.psutil.AccessDenied(pid=321)),
+    )
+    signal_calls = []
+    monkeypatch.setattr(
+        cli_mod.os, "kill", lambda pid, sig: signal_calls.append((pid, sig))
+    )
+
+    assert cli_mod._process_incarnation_state(321, 10.0) is None
+    assert (
+        cli_mod.kill_pids(
+            {321}, signal.SIGTERM, process_starts={321: 10.0}
+        )
+        == set()
+    )
+    assert cli_mod._poll_process_incarnations_until_dead({321: 10.0}, total=0) == {
+        321
+    }
+    assert signal_calls == []
+
+
 @pytest.mark.skipif(not hasattr(signal, "SIGKILL"), reason="SIGKILL is not available on this platform")
 def test_kill_invokes_sigkill_after_grace(monkeypatch):
     calls = []
@@ -223,7 +280,7 @@ def test_kill_invokes_sigkill_after_grace(monkeypatch):
         return set()
 
     monkeypatch.setattr(cli_mod, "kill_pids", _fake_kill_pids)
-    cli_mod.kill(exclude_pids=set())
+    cli_mod.kill(exclude_pids=set(), force_scan=True)
     assert calls[0][1] == signal.SIGTERM
     assert calls[1][1] == signal.SIGKILL
 
@@ -232,7 +289,7 @@ def test_kill_handles_pid_files_and_children(monkeypatch, tmp_path):
     pid_file = tmp_path / "demo.pid"
     pid_file.write_text("321", encoding="utf-8")
 
-    monkeypatch.setattr(cli_mod, "get_processes_matching", lambda _match: set())
+    monkeypatch.setattr(cli_mod, "get_processes_matching", lambda _match: {321})
     monkeypatch.setattr(cli_mod.Path, "glob", lambda self, _pattern: [pid_file])
     monkeypatch.setattr(cli_mod.os, "getpid", lambda: 999)
     monkeypatch.setattr(cli_mod, "get_child_pids", lambda pids: {654} if pids == {321} else set())
@@ -246,7 +303,7 @@ def test_kill_handles_pid_files_and_children(monkeypatch, tmp_path):
     monkeypatch.setattr(cli_mod, "kill_pids", _fake_kill_pids)
     monkeypatch.setattr(cli_mod, "_poll_until_dead", lambda pids: set())
 
-    cli_mod.kill(exclude_pids=set())
+    cli_mod.kill(exclude_pids=set(), force_scan=True)
     assert ({321, 654}, signal.SIGTERM) in calls
 
 
@@ -258,13 +315,13 @@ def test_kill_handles_pid_files_children_and_exclusions(monkeypatch, tmp_path):
     (tmp_path / "broken.pid").write_text("bad\n", encoding="utf-8")
 
     kill_calls = []
-    monkeypatch.setattr(cli_mod, "get_processes_matching", lambda _match: set())
+    monkeypatch.setattr(cli_mod, "get_processes_matching", lambda _match: {111, 999})
     monkeypatch.setattr(cli_mod.os, "getpid", lambda: 999)
     monkeypatch.setattr(cli_mod, "get_child_pids", lambda pids: {222} if 111 in pids else set())
     monkeypatch.setattr(cli_mod, "kill_pids", lambda pids, sig: kill_calls.append((set(pids), sig)) or set())
     monkeypatch.setattr(cli_mod, "_poll_until_dead", lambda pids, **_k: set())
 
-    cli_mod.kill()
+    cli_mod.kill(force_scan=True)
 
     assert kill_calls
     assert any(pids == {111, 222} for pids, _sig in kill_calls)
@@ -279,27 +336,22 @@ def test_kill_logs_no_dask_when_no_processes_or_pid_files(monkeypatch, caplog):
     monkeypatch.setattr(cli_mod.os, "getpid", lambda: 999)
 
     with caplog.at_level("INFO"):
-        cli_mod.kill(exclude_pids=set())
+        cli_mod.kill(exclude_pids=set(), force_scan=True)
 
     assert "No Dask process running." in caplog.text
 
 
 @pytest.mark.skipif(not hasattr(signal, "SIGKILL"), reason="SIGKILL is not available on this platform")
-def test_kill_warns_on_pid_file_cleanup_failure_and_sigkills_survivors(monkeypatch, tmp_path, caplog):
+def test_force_kill_retains_pid_evidence_when_process_survives_sigkill(
+    monkeypatch, tmp_path, caplog
+):
     pid_file = tmp_path / "demo.pid"
     pid_file.write_text("321", encoding="utf-8")
 
-    monkeypatch.setattr(cli_mod, "get_processes_matching", lambda _match: set())
+    monkeypatch.setattr(cli_mod, "get_processes_matching", lambda _match: {321})
     monkeypatch.setattr(cli_mod.Path, "glob", lambda self, _pattern: [pid_file])
     monkeypatch.setattr(cli_mod.os, "getpid", lambda: 999)
     monkeypatch.setattr(cli_mod, "get_child_pids", lambda pids: set())
-
-    original_unlink = Path.unlink
-
-    def _patched_unlink(self, *args, **kwargs):
-        if self == pid_file:
-            raise OSError("unlink boom")
-        return original_unlink(self, *args, **kwargs)
 
     calls = []
 
@@ -307,16 +359,205 @@ def test_kill_warns_on_pid_file_cleanup_failure_and_sigkills_survivors(monkeypat
         calls.append((set(pids), sig))
         return set()
 
-    monkeypatch.setattr(cli_mod.Path, "unlink", _patched_unlink)
     monkeypatch.setattr(cli_mod, "kill_pids", _fake_kill_pids)
     monkeypatch.setattr(cli_mod, "_poll_until_dead", lambda pids: {321})
 
-    with caplog.at_level("WARNING"):
-        cli_mod.kill(exclude_pids=set())
+    with caplog.at_level("ERROR"):
+        result = cli_mod.kill(exclude_pids=set(), force_scan=True)
 
+    assert result is False
     assert ({321}, signal.SIGTERM) in calls
     assert ({321}, signal.SIGKILL) in calls
-    assert "Could not remove pid file" in caplog.text
+    assert pid_file.exists()
+    assert "survived force cleanup" in caplog.text
+
+
+def test_scoped_kill_isolated_across_two_manager_targets(monkeypatch, tmp_path):
+    target_a = tmp_path / "wenv" / "manager-a-worker"
+    target_b = tmp_path / "wenv" / "manager-b-worker"
+    target_a.mkdir(parents=True)
+    target_b.mkdir()
+    pid_file_a = target_a.parent / "dask_worker_a.pid"
+    pid_file_b = target_b.parent / "dask_worker_b.pid"
+    pid_file_a.write_text(
+        '{"pid": 101, "process_start_time": 10.0, '
+        f'"target": "{target_a.as_posix()}"}}\n',
+        encoding="utf-8",
+    )
+    pid_file_b.write_text(
+        '{"pid": 202, "process_start_time": 20.0, '
+        f'"target": "{target_b.as_posix()}"}}\n',
+        encoding="utf-8",
+    )
+    identities = {
+        101: (10.0, target_a),
+        202: (20.0, target_b),
+    }
+    alive = {101, 202}
+    signals = []
+
+    def _identity(pid):
+        if pid not in alive:
+            return None
+        started, target = identities[pid]
+        return (
+            object(),
+            started,
+            [str(target / ".venv" / "bin" / "dask"), "worker"],
+            target,
+        )
+
+    def _target_processes(target):
+        normalized = Path(target).resolve(strict=False)
+        return {
+            pid: started
+            for pid, (started, owner) in identities.items()
+            if pid in alive and owner == normalized
+        }
+
+    def _kill_pids(pids, sig, *, process_starts=None):
+        signals.append((set(pids), sig, dict(process_starts or {})))
+        alive.difference_update(pids)
+        return set()
+
+    monkeypatch.setattr(cli_mod.os, "getpid", lambda: 999)
+    monkeypatch.setattr(cli_mod, "_process_identity", _identity)
+    monkeypatch.setattr(cli_mod, "_target_dask_processes", _target_processes)
+    monkeypatch.setattr(cli_mod, "_add_child_incarnations", lambda _starts: True)
+    monkeypatch.setattr(cli_mod, "kill_pids", _kill_pids)
+    monkeypatch.setattr(
+        cli_mod,
+        "_poll_process_incarnations_until_dead",
+        lambda process_starts: set(process_starts) & alive,
+    )
+
+    assert cli_mod.kill(target_a, home_path=tmp_path, cwd_path=tmp_path) is True
+    assert not pid_file_a.exists()
+    assert pid_file_b.exists()
+    assert alive == {202}
+    assert signals[0][0] == {101}
+
+    assert cli_mod.kill(target_b, home_path=tmp_path, cwd_path=tmp_path) is True
+    assert not pid_file_b.exists()
+    assert alive == set()
+    assert signals[1][0] == {202}
+
+
+@pytest.mark.skipif(
+    not hasattr(signal, "SIGKILL"), reason="SIGKILL is not available on this platform"
+)
+def test_scoped_kill_denied_sigkill_survivor_retains_pid_evidence(
+    monkeypatch, tmp_path
+):
+    target = tmp_path / "wenv" / "worker"
+    target.mkdir(parents=True)
+    pid_file = target / "dask_worker_0.pid"
+    pid_file.write_text(
+        '{"pid": 321, "process_start_time": 10.0, '
+        f'"target": "{target.as_posix()}"}}\n',
+        encoding="utf-8",
+    )
+    signals = []
+
+    monkeypatch.setattr(cli_mod.os, "getpid", lambda: 999)
+    monkeypatch.setattr(
+        cli_mod,
+        "_process_identity",
+        lambda _pid: (
+            object(),
+            10.0,
+            [str(target / ".venv" / "bin" / "dask"), "worker"],
+            target,
+        ),
+    )
+    monkeypatch.setattr(cli_mod, "_target_dask_processes", lambda _target: {321: 10.0})
+    monkeypatch.setattr(cli_mod, "_add_child_incarnations", lambda _starts: True)
+    monkeypatch.setattr(
+        cli_mod,
+        "kill_pids",
+        lambda pids, sig, **_kwargs: signals.append((set(pids), sig)) or set(pids),
+    )
+    monkeypatch.setattr(
+        cli_mod,
+        "_poll_process_incarnations_until_dead",
+        lambda process_starts: set(process_starts),
+    )
+
+    assert cli_mod.kill(target, home_path=tmp_path, cwd_path=tmp_path) is False
+    assert signals == [({321}, signal.SIGTERM), ({321}, signal.SIGKILL)]
+    assert pid_file.exists()
+
+
+def test_scoped_kill_rejects_reused_pid_incarnation(monkeypatch, tmp_path):
+    target = tmp_path / "wenv" / "worker"
+    target.mkdir(parents=True)
+    pid_file = target / "dask_worker_0.pid"
+    original = (
+        '{"pid": 321, "process_start_time": 10.0, '
+        f'"target": "{target.as_posix()}"}}\n'
+    )
+    pid_file.write_text(original, encoding="utf-8")
+    signals = []
+
+    monkeypatch.setattr(cli_mod.os, "getpid", lambda: 999)
+    monkeypatch.setattr(
+        cli_mod,
+        "_process_identity",
+        lambda _pid: (
+            object(),
+            20.0,
+            [str(target / ".venv" / "bin" / "dask"), "worker"],
+            target,
+        ),
+    )
+    monkeypatch.setattr(cli_mod, "_target_dask_processes", lambda _target: {321: 20.0})
+    monkeypatch.setattr(cli_mod, "_add_child_incarnations", lambda _starts: True)
+    monkeypatch.setattr(
+        cli_mod,
+        "kill_pids",
+        lambda pids, sig, **_kwargs: signals.append((set(pids), sig)) or set(),
+    )
+
+    assert cli_mod.kill(target, home_path=tmp_path, cwd_path=tmp_path) is False
+    assert signals == []
+    assert pid_file.read_text(encoding="utf-8") == original
+
+
+def test_kill_allows_production_cwd_equal_to_target(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    target = home / "wenv" / "worker"
+    target.mkdir(parents=True)
+    scoped_calls = []
+    monkeypatch.setattr(
+        cli_mod,
+        "_scoped_kill",
+        lambda *args, **kwargs: scoped_calls.append((args, kwargs)) or True,
+    )
+
+    assert cli_mod.kill(target, home_path=home, cwd_path=target) is True
+    assert scoped_calls == [((target.resolve(strict=False), {os.getpid()}), {})]
+
+
+def test_command_target_match_requires_runtime_path_not_pid_file(tmp_path):
+    target = tmp_path / "worker"
+    sibling = tmp_path / "worker-other"
+
+    assert cli_mod._command_belongs_to_target(
+        [str(target / ".venv" / "bin" / "dask"), "worker"], target
+    )
+    assert cli_mod._command_belongs_to_target(
+        ["uv", "--project", str(target), "run", "dask", "worker"], target
+    )
+    assert not cli_mod._command_belongs_to_target(
+        ["dask-worker", "--pid-file", str(target / "dask_worker_0.pid")],
+        target,
+    )
+    assert not cli_mod._command_belongs_to_target(
+        ["dask", "worker"], target, process_cwd=target
+    )
+    assert not cli_mod._command_belongs_to_target(
+        [str(sibling / ".venv" / "bin" / "dask"), "worker"], target
+    )
 
 
 def test_clean_and_unzip_cover_success_and_failure(monkeypatch, tmp_path):
@@ -324,8 +565,8 @@ def test_clean_and_unzip_cover_success_and_failure(monkeypatch, tmp_path):
     scratch_root.mkdir()
     scratch = scratch_root / "dask-scratch-space"
     scratch.mkdir()
-    wenv = tmp_path / "wenv"
-    wenv.mkdir()
+    wenv = tmp_path / "wenv" / "demo_worker"
+    wenv.mkdir(parents=True)
     egg = wenv / "demo.egg"
     with zipfile.ZipFile(egg, "w") as zf:
         zf.writestr("pkg/module.py", "print('ok')\n")
@@ -335,7 +576,7 @@ def test_clean_and_unzip_cover_success_and_failure(monkeypatch, tmp_path):
     assert (wenv / "src" / "pkg" / "module.py").exists()
 
     monkeypatch.setattr(cli_mod.shutil, "rmtree", lambda *_a, **_k: (_ for _ in ()).throw(OSError("locked")))
-    cli_mod.clean(str(wenv))
+    cli_mod.clean(str(wenv), home_path=tmp_path, cwd_path=tmp_path)
 
 
 def test_signal_helpers_cover_alive_and_permission_paths(monkeypatch):
@@ -383,37 +624,422 @@ def test_threaded_runs_requested_number_of_workers(monkeypatch):
     assert calls["count"] == 3
 
 
-def test_clean_handles_oserror(monkeypatch):
+def test_clean_handles_oserror(monkeypatch, tmp_path):
+    target = tmp_path / "wenv" / "locked-worker"
+    target.mkdir(parents=True)
     monkeypatch.setattr(
         cli_mod.shutil,
         "rmtree",
         lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("fail-clean")),
     )
     # New contract: clean reports failure to its caller.
-    assert cli_mod.clean("/tmp/whatever") is False
+    assert cli_mod.clean(target, home_path=tmp_path, cwd_path=tmp_path) is False
 
 
-def test_clean_propagates_unexpected_runtime_bug(monkeypatch):
+def test_clean_propagates_unexpected_runtime_bug(monkeypatch, tmp_path):
+    target = tmp_path / "wenv" / "worker"
+    target.mkdir(parents=True)
     monkeypatch.setattr(
         cli_mod.shutil,
         "rmtree",
         lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("fail-clean")),
     )
     with pytest.raises(RuntimeError, match="fail-clean"):
-        cli_mod.clean("/tmp/whatever")
+        cli_mod.clean(target, home_path=tmp_path, cwd_path=tmp_path)
+
+
+def test_clean_absent_target_is_successful_fresh_remote_install_noop(tmp_path):
+    target = tmp_path / "wenv" / "fresh-worker"
+
+    assert cli_mod.clean(target, home_path=tmp_path, cwd_path=tmp_path) is True
+    assert not target.exists()
+
+
+@pytest.mark.parametrize(
+    "target_kind",
+    ("filesystem-root", "home", "cwd", "outside", "empty", "traversal"),
+)
+def test_clean_refuses_unsafe_recursive_delete_targets(
+    target_kind,
+    monkeypatch,
+    tmp_path,
+):
+    home = tmp_path / "home"
+    cwd = tmp_path / "cwd"
+    home.mkdir()
+    cwd.mkdir()
+    targets = {
+        "filesystem-root": Path(Path.cwd().anchor),
+        "home": home,
+        "cwd": cwd,
+        "outside": tmp_path / "outside",
+        "empty": "",
+        "traversal": "wenv/../outside",
+    }
+    rmtree_calls = []
+    monkeypatch.setattr(
+        cli_mod.shutil,
+        "rmtree",
+        lambda *args, **kwargs: rmtree_calls.append((args, kwargs)),
+    )
+
+    assert cli_mod.clean(
+        targets[target_kind],
+        home_path=home,
+        cwd_path=cwd,
+    ) is False
+    assert rmtree_calls == []
+
+
+def test_clean_refuses_symlink_alias_outside_worker_root(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    cwd = tmp_path / "cwd"
+    worker_root = home / "wenv"
+    outside = tmp_path / "outside"
+    worker_root.mkdir(parents=True)
+    cwd.mkdir()
+    outside.mkdir()
+    alias = worker_root / "aliased-worker"
+    try:
+        alias.symlink_to(outside, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"directory symlinks unavailable: {exc}")
+    rmtree_calls = []
+    monkeypatch.setattr(
+        cli_mod.shutil,
+        "rmtree",
+        lambda *args, **kwargs: rmtree_calls.append((args, kwargs)),
+    )
+
+    assert cli_mod.clean(alias, home_path=home, cwd_path=cwd) is False
+    assert outside.exists()
+    assert rmtree_calls == []
+
+
+@pytest.mark.parametrize(
+    "target_kind",
+    ("filesystem-root", "home", "cwd", "outside", "empty", "traversal"),
+)
+def test_kill_refuses_unsafe_targets_before_process_discovery(
+    target_kind,
+    monkeypatch,
+    tmp_path,
+):
+    home = tmp_path / "home"
+    cwd = tmp_path / "cwd"
+    home.mkdir()
+    cwd.mkdir()
+    targets = {
+        "filesystem-root": Path(Path.cwd().anchor),
+        "home": home,
+        "cwd": cwd,
+        "outside": tmp_path / "outside",
+        "empty": "",
+        "traversal": "wenv/../outside",
+    }
+    scoped_calls = []
+    monkeypatch.setattr(
+        cli_mod,
+        "_scoped_kill",
+        lambda *args, **kwargs: scoped_calls.append((args, kwargs)) or True,
+    )
+
+    assert cli_mod.kill(
+        targets[target_kind],
+        home_path=home,
+        cwd_path=cwd,
+    ) is False
+    assert scoped_calls == []
+
+
+def test_kill_refuses_symlink_alias_outside_worker_root(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    cwd = tmp_path / "cwd"
+    worker_root = home / "wenv"
+    outside = tmp_path / "outside"
+    worker_root.mkdir(parents=True)
+    cwd.mkdir()
+    outside.mkdir()
+    alias = worker_root / "aliased-worker"
+    try:
+        alias.symlink_to(outside, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"directory symlinks unavailable: {exc}")
+    scoped_calls = []
+    monkeypatch.setattr(
+        cli_mod,
+        "_scoped_kill",
+        lambda *args, **kwargs: scoped_calls.append((args, kwargs)) or True,
+    )
+
+    assert cli_mod.kill(alias, home_path=home, cwd_path=cwd) is False
+    assert scoped_calls == []
+
+
+def test_remote_target_lease_serializes_cross_manager_clean_and_start(tmp_path):
+    target = tmp_path / "wenv" / "worker"
+    target.mkdir(parents=True)
+    (target / "installed.txt").write_text("ready", encoding="utf-8")
+    clean_token = "a" * 32
+    start_token = "b" * 32
+
+    assert cli_mod.acquire_remote_target_lease(target, clean_token, "install") is True
+    assert cli_mod.acquire_remote_target_lease(target, start_token, "run") is False
+    assert cli_mod.clean(
+        target,
+        lease_token=start_token,
+        home_path=tmp_path,
+        cwd_path=tmp_path,
+    ) is False
+    assert target.exists()
+
+    assert cli_mod.clean(
+        target,
+        lease_token=clean_token,
+        home_path=tmp_path,
+        cwd_path=tmp_path,
+    ) is True
+    assert not target.exists()
+    assert cli_mod.release_remote_target_lease(target, clean_token) is True
+    assert cli_mod.acquire_remote_target_lease(target, start_token, "run") is True
+    assert cli_mod.release_remote_target_lease(target, start_token) is True
+
+
+def test_remote_acquire_never_replaces_unknown_empty_destination(tmp_path):
+    target = tmp_path / "worker"
+    token = "a" * 32
+    lock_path = cli_mod._remote_target_lease_path(target)
+    lock_path.mkdir(parents=True)
+
+    assert cli_mod.acquire_remote_target_lease(target, token, "run") is False
+    assert lock_path.is_dir()
+    assert list(lock_path.iterdir()) == []
+    assert cli_mod._acquire_publication_claims(lock_path, token) == []
+
+
+def test_remote_recovery_resumes_empty_token_scoped_publication(
+    monkeypatch,
+    tmp_path,
+):
+    target = tmp_path / "worker"
+    stale_token = "a" * 32
+    replacement_token = "b" * 32
+    real_open = Path.open
+    interrupted = False
+
+    def _interrupt_before_owner_publication(self, *args, **kwargs):
+        nonlocal interrupted
+        if self.name.startswith(f".owner.{stale_token}.") and not interrupted:
+            interrupted = True
+            raise KeyboardInterrupt("publication interrupted before owner")
+        return real_open(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", _interrupt_before_owner_publication)
+    with pytest.raises(KeyboardInterrupt, match="before owner"):
+        cli_mod.acquire_remote_target_lease(target, stale_token, "install")
+
+    lock_path = cli_mod._remote_target_lease_path(target)
+    assert lock_path.is_dir()
+    assert not (lock_path / "owner.json").exists()
+    assert cli_mod._acquire_publication_claims(lock_path, stale_token)
+
+    assert cli_mod.recover_remote_target_lease(
+        target,
+        replacement_token,
+        [stale_token],
+        "run",
+    )
+    assert cli_mod.remote_target_lease_owned(target, replacement_token)
+    assert cli_mod.release_remote_target_lease(target, replacement_token)
+
+
+def test_remote_target_recovery_requires_identity_proven_exact_generation(tmp_path):
+    target = tmp_path / "worker"
+    live_token = "a" * 32
+    replacement_token = "b" * 32
+    unrelated_token = "c" * 32
+
+    assert cli_mod.acquire_remote_target_lease(target, live_token, "install") is True
+
+    # A successor without the exact capability cannot infer staleness from age
+    # or replace the live generation.
+    assert (
+        cli_mod.recover_remote_target_lease(
+            target,
+            replacement_token,
+            [unrelated_token],
+            "run",
+        )
+        is False
+    )
+    assert cli_mod.remote_target_lease_owned(target, live_token) is True
+
+    # Once the manager-side incarnation guard has authorized the exact stale
+    # token, recovery replaces only that generation.
+    assert (
+        cli_mod.recover_remote_target_lease(
+            target,
+            replacement_token,
+            [live_token],
+            "run",
+        )
+        is True
+    )
+    assert cli_mod.remote_target_lease_owned(target, live_token) is False
+    assert cli_mod.remote_target_lease_owned(target, replacement_token) is True
+    assert cli_mod.release_remote_target_lease(target, replacement_token) is True
+
+
+def test_remote_recovery_resumes_interrupted_exact_release_claim(
+    monkeypatch,
+    tmp_path,
+):
+    target = tmp_path / "worker"
+    stale_token = "a" * 32
+    replacement_token = "b" * 32
+    wrong_successor_token = "c" * 32
+    assert cli_mod.acquire_remote_target_lease(target, stale_token, "install")
+
+    lock_path = cli_mod._remote_target_lease_path(target)
+    tombstone = cli_mod._remote_release_tombstone(lock_path, stale_token)
+    real_rename = Path.rename
+    interrupted = False
+
+    def _interrupt_after_marker_claim(self, destination):
+        nonlocal interrupted
+        if self == lock_path and destination == tombstone and not interrupted:
+            interrupted = True
+            raise KeyboardInterrupt("release interrupted after marker claim")
+        return real_rename(self, destination)
+
+    monkeypatch.setattr(Path, "rename", _interrupt_after_marker_claim)
+    with pytest.raises(KeyboardInterrupt, match="after marker claim"):
+        cli_mod.release_remote_target_lease(target, stale_token)
+
+    assert not (lock_path / f"token-{stale_token}").exists()
+    assert cli_mod._release_marker_claims(lock_path, stale_token)
+    assert cli_mod.recover_remote_target_lease(
+        target,
+        replacement_token,
+        [stale_token],
+        "run",
+    )
+    assert tombstone.is_dir()
+    assert cli_mod.remote_target_lease_owned(target, replacement_token)
+
+    # An arbitrarily delayed stale releaser/recoverer observes the successor
+    # and cannot move it into the old deterministic tombstone.
+    assert cli_mod.release_remote_target_lease(target, stale_token)
+    assert not cli_mod.recover_remote_target_lease(
+        target,
+        wrong_successor_token,
+        [stale_token],
+        "run",
+    )
+    assert cli_mod.remote_target_lease_owned(target, replacement_token)
+    assert cli_mod.release_remote_target_lease(target, replacement_token)
+
+
+def test_remote_recovery_handles_historical_owner_before_marker_publication(
+    tmp_path,
+):
+    target = tmp_path / "worker"
+    stale_token = "a" * 32
+    replacement_token = "b" * 32
+    lock_path = cli_mod._remote_target_lease_path(target)
+    lock_path.mkdir(parents=True)
+    (lock_path / "owner.json").write_text(
+        json.dumps(
+            {
+                "schema": cli_mod._REMOTE_TARGET_LEASE_SCHEMA,
+                "token": stale_token,
+                "operation": "install",
+                "created_at": 1.0,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert cli_mod.recover_remote_target_lease(
+        target,
+        replacement_token,
+        [stale_token],
+        "run",
+    )
+    assert cli_mod._remote_release_tombstone(lock_path, stale_token).is_dir()
+    assert cli_mod.remote_target_lease_owned(target, replacement_token)
+    assert cli_mod.release_remote_target_lease(target, replacement_token)
+
+
+def test_delayed_old_remote_lease_release_cannot_remove_successor(
+    monkeypatch, tmp_path
+):
+    target = tmp_path / "worker"
+    old_token = "a" * 32
+    successor_token = "b" * 32
+    assert cli_mod.acquire_remote_target_lease(target, old_token, "install") is True
+
+    delayed_at_claim = threading.Event()
+    resume_delayed = threading.Event()
+    real_rename = Path.rename
+
+    def _controlled_rename(self, destination):
+        if (
+            threading.current_thread().name == "delayed-old-release"
+            and self.name == f"token-{old_token}"
+        ):
+            delayed_at_claim.set()
+            assert resume_delayed.wait(timeout=5.0)
+        return real_rename(self, destination)
+
+    monkeypatch.setattr(Path, "rename", _controlled_rename)
+    delayed_result = []
+
+    def _delayed_release():
+        delayed_result.append(
+            cli_mod.release_remote_target_lease(target, old_token)
+        )
+
+    delayed_thread = threading.Thread(
+        target=_delayed_release,
+        name="delayed-old-release",
+    )
+    delayed_thread.start()
+    assert delayed_at_claim.wait(timeout=5.0)
+
+    assert cli_mod.release_remote_target_lease(target, old_token) is True
+    assert cli_mod.acquire_remote_target_lease(target, successor_token, "run") is True
+    resume_delayed.set()
+    delayed_thread.join(timeout=5.0)
+
+    assert not delayed_thread.is_alive()
+    assert delayed_result == [True]
+    assert cli_mod.remote_target_lease_owned(target, successor_token) is True
+    assert cli_mod.release_remote_target_lease(target, successor_token) is True
 
 
 def test_clean_removes_temp_and_wenv(tmp_path, monkeypatch):
     scratch_root = tmp_path / "tmp"
     scratch_dir = scratch_root / "dask-scratch-space"
-    wenv_dir = tmp_path / "wenv"
+    wenv_dir = tmp_path / "wenv" / "demo_worker"
     scratch_dir.mkdir(parents=True, exist_ok=True)
     wenv_dir.mkdir(parents=True, exist_ok=True)
     (scratch_dir / "a.txt").write_text("x", encoding="utf-8")
     (wenv_dir / "b.txt").write_text("y", encoding="utf-8")
 
     monkeypatch.setattr(cli_mod, "gettempdir", lambda: str(scratch_root))
-    cli_mod.clean(str(wenv_dir))
+    cli_mod.clean(str(wenv_dir), home_path=tmp_path, cwd_path=tmp_path)
+    assert scratch_dir.exists()
+    assert not wenv_dir.exists()
+
+    wenv_dir.mkdir()
+    cli_mod.clean(
+        str(wenv_dir),
+        force_scratch=True,
+        home_path=tmp_path,
+        cwd_path=tmp_path,
+    )
     assert not scratch_dir.exists()
     assert not wenv_dir.exists()
 
@@ -615,9 +1241,36 @@ def test_cli_main_rapids_probe_runs(monkeypatch, capfd):
 
 
 def test_cli_main_clean_runs_with_arg(monkeypatch, tmp_path):
-    target = tmp_path / "to-clean"
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    target = tmp_path / "wenv" / "to-clean"
     target.mkdir(parents=True, exist_ok=True)
     _run_cli_as_main(monkeypatch, ["clean", str(target)])
+
+    assert not target.exists()
+
+
+def test_cli_main_recovers_only_the_authorized_remote_generation(
+    monkeypatch,
+    tmp_path,
+):
+    target = tmp_path / "worker"
+    stale_token = "a" * 32
+    replacement_token = "b" * 32
+    assert cli_mod.acquire_remote_target_lease(target, stale_token, "install")
+
+    _run_cli_as_main(
+        monkeypatch,
+        [
+            "target-lease-recover",
+            str(target),
+            replacement_token,
+            stale_token,
+            "run",
+        ],
+    )
+
+    assert cli_mod.remote_target_lease_owned(target, replacement_token)
+    assert cli_mod.release_remote_target_lease(target, replacement_token)
 
 
 def test_cli_main_unzip_runs_with_arg(monkeypatch, tmp_path):
@@ -684,7 +1337,7 @@ def test_kill_does_not_target_unrelated_dask_named_processes(monkeypatch):
         cli_mod, "kill_pids", lambda pids, sig: killed.append(set(pids)) or set()
     )
 
-    cli_mod.kill(exclude_pids=set())
+    cli_mod.kill(exclude_pids=set(), force_scan=True)
 
     assert killed and killed[0] == {101, 303}
 
@@ -695,6 +1348,18 @@ def test_cli_main_kill_warns_for_invalid_excluded_pid(monkeypatch, caplog):
     monkeypatch.setattr(cli_mod.os, "getpid", lambda: 999)
 
     caplog.set_level("WARNING")
-    _run_cli_as_main(monkeypatch, ["kill", "100,bad"])
+    target = Path.home() / "wenv" / "demo-runtime"
+    _run_cli_as_main(monkeypatch, ["kill", str(target), "100,bad"])
 
     assert "Invalid PID to exclude: bad" in caplog.text
+
+
+def test_cli_main_kill_survivor_contract_exits_nonzero(monkeypatch, tmp_path):
+    target = tmp_path / "worker"
+    target.mkdir()
+    (target / "dask_worker_0.pid").write_text("not-a-pid\n", encoding="utf-8")
+
+    with pytest.raises(SystemExit) as excinfo:
+        _run_cli_as_main(monkeypatch, ["kill", str(target)])
+
+    assert excinfo.value.code == 1

--- a/src/agilab/core/test/test_agi_distributor_deployment_local_support.py
+++ b/src/agilab/core/test/test_agi_distributor_deployment_local_support.py
@@ -4,6 +4,7 @@ import getpass
 import json
 import os
 import shlex
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
@@ -877,6 +878,24 @@ def test_deploy_stage_cache_support_edge_cases(monkeypatch, tmp_path):
         app_path=tmp_path,
         worker_project=tmp_path,
     )
+
+
+def test_deploy_cache_atomic_writers_use_unique_temporary_files(tmp_path):
+    cache_path = tmp_path / "cache" / "stages.json"
+
+    def _write(index: int) -> None:
+        deployment_stage_cache_support._write_deploy_stage_cache(
+            cache_path,
+            {"stages": {f"stage-{index}": {"digest": str(index)}}},
+        )
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        list(executor.map(_write, range(40)))
+
+    payload = json.loads(cache_path.read_text(encoding="utf-8"))
+    assert payload["schema"] == deployment_local_support.DEPLOY_STAGE_CACHE_SCHEMA
+    assert len(payload["stages"]) == 1
+    assert list(cache_path.parent.glob(f".{cache_path.name}.*.tmp")) == []
 
 
 def test_deploy_stage_fingerprints_and_copy_stamps_cover_edge_cases(monkeypatch, tmp_path):

--- a/src/agilab/core/test/test_agi_distributor_deployment_orchestration_support.py
+++ b/src/agilab/core/test/test_agi_distributor_deployment_orchestration_support.py
@@ -100,6 +100,34 @@ async def test_clean_nodes_runs_local_and_remote_cleanup():
 
 
 @pytest.mark.asyncio
+async def test_clean_nodes_does_not_delete_remote_runtime_after_failed_stop():
+    deleted = []
+
+    async def _failed_stop(*, list_ip, force=True):
+        raise RuntimeError(f"survivor on {sorted(list_ip)} force={force}")
+
+    async def _delete_dirs(*, list_ip):
+        deleted.append(set(list_ip))
+
+    agi_cls = SimpleNamespace(
+        _workers={"10.0.0.2": 1},
+        _get_scheduler=lambda _addr=None: ("10.0.0.2", 8786),
+        _clean_dirs_local=lambda: None,
+        _clean_remote_procs=_failed_stop,
+        _clean_remote_dirs=_delete_dirs,
+    )
+
+    with pytest.raises(RuntimeError, match="survivor"):
+        await deployment_orchestration_support.clean_nodes(
+            agi_cls,
+            "10.0.0.2:8786",
+            is_local_fn=lambda _ip: False,
+        )
+
+    assert deleted == []
+
+
+@pytest.mark.asyncio
 async def test_deploy_application_calls_local_and_remote_workers():
     calls = {"local": [], "remote": [], "todo": []}
     env = SimpleNamespace(

--- a/src/agilab/core/test/test_agi_distributor_deployment_prepare_support.py
+++ b/src/agilab/core/test/test_agi_distributor_deployment_prepare_support.py
@@ -1165,6 +1165,7 @@ async def test_prepare_cluster_env_multi_ip_runs_every_step_and_writes_env_in_or
     remote_cmds = []
     kill_ips = []
     clean_ips = []
+    leased_ips = set()
     env_writes = []
 
     async def _fake_detect(_ip):
@@ -1179,10 +1180,16 @@ async def test_prepare_cluster_env_multi_ip_runs_every_step_and_writes_env_in_or
         return "ok"
 
     async def _fake_kill(ip, **_kwargs):
+        assert ip in leased_ips
         kill_ips.append(ip)
 
     async def _fake_clean(ip, **_kwargs):
+        assert ip in leased_ips
         clean_ips.append(ip)
+
+    async def _fake_acquire_lease(ip, *, cmd_prefix=None):
+        assert cmd_prefix == 'export PATH="$HOME/.local/bin:$PATH"; '
+        leased_ips.add(ip)
 
     def _record_set_env(key, value=None):
         env_writes.append((key, value))
@@ -1199,6 +1206,7 @@ async def test_prepare_cluster_env_multi_ip_runs_every_step_and_writes_env_in_or
         send_files_fn=_recording_send(sent),
         kill_fn=_fake_kill,
         clean_dirs_fn=_fake_clean,
+        acquire_remote_target_lease_fn=_fake_acquire_lease,
         set_env_var_fn=_record_set_env,
         log=mock.Mock(),
     )
@@ -1215,6 +1223,7 @@ async def test_prepare_cluster_env_multi_ip_runs_every_step_and_writes_env_in_or
         assert any("python install 3.13" in cmd for cmd in ip_cmds), ip
     assert set(kill_ips) == expected_ips
     assert set(clean_ips) == expected_ips
+    assert leased_ips == expected_ips
     # cli.py + staged pyproject sent to every worker.
     wenv_ips = {ip for ip, _items, remote_path in sent if remote_path == "wenv"}
     assert wenv_ips == expected_ips

--- a/src/agilab/core/test/test_agi_distributor_deployment_remote_support.py
+++ b/src/agilab/core/test/test_agi_distributor_deployment_remote_support.py
@@ -1907,30 +1907,25 @@ async def test_deploy_remote_worker_rapids_runtime_error_is_logged(tmp_path):
 
 
 def test_remote_env_update_command_preserves_other_env_keys():
-    # Regression: the command previously truncated the whole remote
-    # ~/.agilab/.env with '>' redirection; it must merge instead, replacing
-    # only the worker cluster-mode lines.
+    # Regression: concurrent remote deploys previously shared one .env.tmp and
+    # treated a failed read as empty, which could erase operator settings.
     cmd = deployment_remote_support._remote_env_update_command(
         "clustershare/agi",
         "clustershare/agi/workflows/session-123",
     )
 
-    assert (
-        "grep -Ev '^(IS_SOURCE_ENV|IS_WORKER_ENV|AGI_CLUSTER_ENABLED|AGI_CLUSTER_SHARE|AGILAB_WORKFLOW_DATA_ROOT)='"
-        in cmd
-    )
-    assert 'mv "$HOME/.agilab/.env.tmp" "$HOME/.agilab/.env"' in cmd
-    assert "IS_SOURCE_ENV=" in cmd
-    assert "IS_WORKER_ENV=" in cmd
-    assert "AGI_CLUSTER_ENABLED=" in cmd
-    assert "AGI_CLUSTER_SHARE=" in cmd
-    assert "AGILAB_WORKFLOW_DATA_ROOT=" in cmd
+    assert 'env_path.name + ".lock"' in cmd
+    assert "tempfile.mkstemp" in cmd
+    assert "os.replace" in cmd
+    assert "IS_SOURCE_ENV" in cmd
+    assert "IS_WORKER_ENV" in cmd
+    assert "AGI_CLUSTER_ENABLED" in cmd
+    assert "AGI_CLUSTER_SHARE" in cmd
+    assert "AGILAB_WORKFLOW_DATA_ROOT" in cmd
     assert "clustershare/agi/workflows/session-123" in cmd
     assert "AGI_LOCAL_SHARE" not in cmd
-    # No direct truncating redirection of the env file itself.
-    assert '> "$HOME/.agilab/.env"' not in cmd.replace(
-        '> "$HOME/.agilab/.env.tmp"', ""
-    )
+    assert "grep -Ev" not in cmd
+    assert '"$HOME/.agilab/.env.tmp"' not in cmd
 
 
 @pytest.mark.skipif(os.name == "nt", reason="BSD/macOS mount output uses POSIX paths")

--- a/src/agilab/core/test/test_agi_distributor_entrypoint_support.py
+++ b/src/agilab/core/test/test_agi_distributor_entrypoint_support.py
@@ -1222,7 +1222,7 @@ async def test_launch_scheduler_process_local_logs_background_result(
         "[project]\nname='app'\n", encoding="utf-8"
     )
 
-    calls = {"info": []}
+    calls = {"info": [], "bg": []}
     AGI.env = SimpleNamespace(
         active_app=app_path,
         wenv_rel=Path("worker"),
@@ -1237,7 +1237,12 @@ async def test_launch_scheduler_process_local_logs_background_result(
     AGI._scheduler_port = 8786
     monkeypatch.setattr(AGI, "_dask_env_prefix", staticmethod(lambda: ""))
     monkeypatch.setattr(
-        AGI, "_exec_bg", staticmethod(lambda *_args, **_kwargs: "started")
+        AGI,
+        "_exec_bg",
+        staticmethod(
+            lambda command, *_args, **_kwargs: calls["bg"].append(command)
+            or "started"
+        ),
     )
 
     log = SimpleNamespace(
@@ -1258,6 +1263,8 @@ async def test_launch_scheduler_process_local_logs_background_result(
     )
 
     assert "started" in calls["info"]
+    pid_index = calls["bg"][0].index("--pid-file") + 1
+    assert calls["bg"][0][pid_index] == str(AGI.env.wenv_abs / "dask_scheduler.pid")
 
 
 @pytest.mark.asyncio
@@ -1312,6 +1319,7 @@ async def test_launch_scheduler_process_remote_sends_pyproject_and_starts_async_
     assert calls["send"][0][1] == app_path / "pyproject.toml"
     assert calls["send"][0][2] == Path("worker") / "pyproject.toml"
     assert calls["tasks"][0][0] == "exec_ssh_async"
+    assert "--pid-file worker/dask_scheduler.pid" in calls["tasks"][0][2]
 
 
 @pytest.mark.asyncio

--- a/src/agilab/core/test/test_agi_distributor_lifecycle_guard_support.py
+++ b/src/agilab/core/test/test_agi_distributor_lifecycle_guard_support.py
@@ -1,0 +1,814 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import socket
+import threading
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import psutil
+
+from agi_cluster.agi_distributor import AGI, lifecycle_guard_support
+from agi_cluster.agi_distributor import agi_distributor as agi_distributor_module
+from agi_cluster.agi_distributor import service_lifecycle_support
+from agi_cluster.agi_distributor.run_request_support import RunRequest
+
+
+def _env(path: Path, *, target: str = "demo") -> SimpleNamespace:
+    return SimpleNamespace(wenv_abs=path, target=target, app=f"{target}_project")
+
+
+def test_target_lease_rejects_same_and_sibling_target_owners(tmp_path):
+    first_env = _env(tmp_path / "worker-a", target="a")
+    second_env = _env(tmp_path / "worker-b", target="b")
+    first = lifecycle_guard_support.acquire_target_lease(first_env, "install")
+    try:
+        with pytest.raises(lifecycle_guard_support.LifecycleBusyError, match="already active"):
+            lifecycle_guard_support.acquire_target_lease(first_env, "run")
+
+        with pytest.raises(
+            lifecycle_guard_support.LifecycleBusyError,
+            match="already active",
+        ):
+            lifecycle_guard_support.acquire_target_lease(second_env, "install")
+    finally:
+        lifecycle_guard_support.release_target_lease(first)
+
+
+def test_target_lease_allows_targets_with_independent_runtime_parents(tmp_path):
+    first_env = _env(tmp_path / "runtime-a" / "worker", target="a")
+    second_env = _env(tmp_path / "runtime-b" / "worker", target="b")
+    first = lifecycle_guard_support.acquire_target_lease(first_env, "install")
+    try:
+        second = lifecycle_guard_support.acquire_target_lease(second_env, "install")
+        lifecycle_guard_support.release_target_lease(second)
+    finally:
+        lifecycle_guard_support.release_target_lease(first)
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_releases_remote_target_tokens_before_local_lease(tmp_path):
+    released = []
+
+    class _Agi:
+        _lifecycle_state_lock = None
+        _lifecycle_call_token = None
+        _lifecycle_service_token = None
+        _service_cleanup_unproven = False
+
+        @staticmethod
+        async def _release_remote_target_leases():
+            released.append("remote")
+
+    env = _env(tmp_path / "runtime" / "demo_worker")
+    local_path = lifecycle_guard_support.target_lease_path(env)
+    async with lifecycle_guard_support.LifecycleOperation(_Agi, env, "install"):
+        assert local_path.exists()
+
+    assert released == ["remote"]
+    assert not local_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_unproven_runtime_cleanup_retains_lease_for_explicit_stop(tmp_path):
+    released = []
+
+    class _Agi:
+        _lifecycle_state_lock = None
+        _lifecycle_call_token = None
+        _lifecycle_service_token = None
+        _service_cleanup_unproven = False
+
+        @staticmethod
+        async def _release_remote_target_leases():
+            released.append("remote")
+
+    env = _env(tmp_path / "runtime" / "demo_worker")
+    operation = lifecycle_guard_support.LifecycleOperation(_Agi, env, "run")
+    with pytest.raises(asyncio.CancelledError):
+        async with operation:
+            _Agi._service_cleanup_unproven = True
+            raise asyncio.CancelledError
+
+    assert _Agi._lifecycle_service_lease is operation.lease
+    assert operation.lease is not None
+    assert operation.lease.path.exists()
+    assert released == []
+
+    with pytest.raises(
+        lifecycle_guard_support.LifecycleBusyError,
+        match="cleanup could not be proven",
+    ):
+        async with lifecycle_guard_support.LifecycleOperation(_Agi, env, "run"):
+            pass
+
+    recovery = lifecycle_guard_support.LifecycleOperation(
+        _Agi,
+        env,
+        "serve:stop",
+        service_command=True,
+    )
+    async with recovery:
+        _Agi._service_cleanup_unproven = False
+        recovery.release_service()
+
+    assert released == ["remote"]
+    assert not operation.lease.path.exists()
+    assert _Agi._lifecycle_service_lease is None
+
+
+@pytest.mark.asyncio
+async def test_remote_release_failure_keeps_local_lease_for_restart_recovery(
+    tmp_path,
+):
+    class _CrashedManager:
+        _lifecycle_state_lock = None
+        _lifecycle_call_token = None
+        _lifecycle_service_token = None
+        _service_cleanup_unproven = False
+
+        @staticmethod
+        async def _release_remote_target_leases():
+            raise RuntimeError("remote release failed")
+
+    env = _env(tmp_path / "runtime" / "worker")
+    operation = lifecycle_guard_support.LifecycleOperation(
+        _CrashedManager,
+        env,
+        "install",
+    )
+    with pytest.raises(RuntimeError, match="remote release failed"):
+        async with operation:
+            stale_remote_token = _CrashedManager._lifecycle_remote_token
+
+    pending = _CrashedManager._lifecycle_pending_release_lease
+    assert pending is operation.lease
+    assert pending.path.exists()
+    owner_path = pending.path / "owner.json"
+    owner = json.loads(owner_path.read_text(encoding="utf-8"))
+    assert owner["remote_token"] == stale_remote_token
+
+    # Simulate process restart/PID incarnation turnover. The durable local
+    # owner is reclaimed and carries the exact remote recovery capability.
+    owner["process_start_time"] = 1.0
+    owner_path.write_text(json.dumps(owner), encoding="utf-8")
+
+    class _RestartedManager:
+        _lifecycle_state_lock = None
+        _lifecycle_call_token = None
+        _lifecycle_service_token = None
+        _service_cleanup_unproven = False
+
+    restarted = lifecycle_guard_support.LifecycleOperation(
+        _RestartedManager,
+        env,
+        "run",
+    )
+    async with restarted:
+        assert stale_remote_token in restarted.lease.recovered_remote_tokens
+
+    assert not pending.path.exists()
+
+
+@pytest.mark.asyncio
+async def test_next_lifecycle_finishes_pending_remote_release_before_new_work(
+    tmp_path,
+):
+    release_attempts = 0
+
+    class _Agi:
+        _lifecycle_state_lock = None
+        _lifecycle_call_token = None
+        _lifecycle_service_token = None
+        _service_cleanup_unproven = False
+
+        @staticmethod
+        async def _release_remote_target_leases():
+            nonlocal release_attempts
+            release_attempts += 1
+            if release_attempts == 1:
+                raise RuntimeError("first release failed")
+
+    env = _env(tmp_path / "runtime" / "worker")
+    with pytest.raises(RuntimeError, match="first release failed"):
+        async with lifecycle_guard_support.LifecycleOperation(_Agi, env, "install"):
+            pass
+
+    pending = _Agi._lifecycle_pending_release_lease
+    assert pending.path.exists()
+    async with lifecycle_guard_support.LifecycleOperation(_Agi, env, "run"):
+        assert _Agi._lifecycle_pending_release_lease is None
+        assert release_attempts == 2
+
+    assert release_attempts == 3
+    assert not pending.path.exists()
+
+
+@pytest.mark.asyncio
+async def test_pending_authority_survives_unproven_local_release(
+    monkeypatch,
+    tmp_path,
+):
+    class _Agi:
+        _lifecycle_state_lock = None
+        _lifecycle_call_token = None
+        _lifecycle_service_token = None
+        _service_cleanup_unproven = False
+
+        @staticmethod
+        async def _release_remote_target_leases():
+            return None
+
+    env = _env(tmp_path / "runtime" / "worker")
+    operation = lifecycle_guard_support.LifecycleOperation(_Agi, env, "install")
+    await operation.__aenter__()
+    lease = operation.lease
+    marker = lease.path / f"token-{lease.token}"
+    real_rename = Path.rename
+
+    def _deny_local_marker_claim(self, destination):
+        if self == marker:
+            raise OSError("local marker claim denied")
+        return real_rename(self, destination)
+
+    with monkeypatch.context() as scoped:
+        scoped.setattr(Path, "rename", _deny_local_marker_claim)
+        with pytest.raises(RuntimeError, match="local lifecycle lease release"):
+            await operation.__aexit__(None, None, None)
+
+    assert _Agi._lifecycle_pending_release_lease == lease
+    assert lease.path.exists()
+    assert lifecycle_guard_support.release_target_lease(lease)
+
+
+@pytest.mark.asyncio
+async def test_pending_release_retry_preserves_control_flow_base_exceptions(tmp_path):
+    class _Agi:
+        _lifecycle_state_lock = None
+        _lifecycle_call_token = None
+        _lifecycle_service_token = None
+        _service_cleanup_unproven = False
+
+        @staticmethod
+        async def _release_remote_target_leases():
+            raise KeyboardInterrupt("operator interrupt")
+
+    env = _env(tmp_path / "runtime" / "worker")
+    lease = lifecycle_guard_support.acquire_target_lease(
+        env,
+        "install",
+        remote_token="a" * 32,
+    )
+    _Agi._lifecycle_pending_release_lease = lease
+
+    operation = lifecycle_guard_support.LifecycleOperation(_Agi, env, "run")
+    with pytest.raises(KeyboardInterrupt, match="operator interrupt"):
+        await operation.__aenter__()
+
+    assert _Agi._lifecycle_pending_release_lease == lease
+    assert lease.path.exists()
+    assert lifecycle_guard_support.release_target_lease(lease)
+
+
+def test_target_lease_reclaims_reused_local_pid_generation(tmp_path):
+    env = _env(tmp_path / "worker")
+    first = lifecycle_guard_support.acquire_target_lease(env, "install")
+    owner_path = first.path / "owner.json"
+    owner = json.loads(owner_path.read_text(encoding="utf-8"))
+    owner["process_start_time"] = 1.0
+    owner_path.write_text(json.dumps(owner), encoding="utf-8")
+
+    replacement = lifecycle_guard_support.acquire_target_lease(env, "run")
+    try:
+        assert replacement.token != first.token
+    finally:
+        lifecycle_guard_support.release_target_lease(replacement)
+        lifecycle_guard_support.release_target_lease(first)
+
+
+def test_target_lease_exposes_remote_recovery_only_after_owner_incarnation_dies(
+    tmp_path,
+):
+    env = _env(tmp_path / "worker")
+    stale_remote_token = "a" * 32
+    replacement_remote_token = "b" * 32
+    first = lifecycle_guard_support.acquire_target_lease(
+        env,
+        "install",
+        remote_token=stale_remote_token,
+    )
+
+    try:
+        with pytest.raises(lifecycle_guard_support.LifecycleBusyError):
+            lifecycle_guard_support.acquire_target_lease(
+                env,
+                "run",
+                remote_token=replacement_remote_token,
+            )
+
+        owner_path = first.path / "owner.json"
+        owner = json.loads(owner_path.read_text(encoding="utf-8"))
+        owner["process_start_time"] = 1.0
+        owner_path.write_text(json.dumps(owner), encoding="utf-8")
+
+        replacement = lifecycle_guard_support.acquire_target_lease(
+            env,
+            "run",
+            remote_token=replacement_remote_token,
+        )
+        try:
+            assert replacement.remote_token == replacement_remote_token
+            assert replacement.recovered_remote_tokens == (stale_remote_token,)
+        finally:
+            lifecycle_guard_support.release_target_lease(replacement)
+    finally:
+        lifecycle_guard_support.release_target_lease(first)
+
+
+def test_delayed_stale_reclaimer_cannot_remove_replacement_generation(
+    monkeypatch,
+    tmp_path,
+):
+    env = _env(tmp_path / "worker")
+    stale = lifecycle_guard_support.acquire_target_lease(env, "stale")
+    owner_path = stale.path / "owner.json"
+    owner = json.loads(owner_path.read_text(encoding="utf-8"))
+    owner["process_start_time"] = 1.0
+    owner_path.write_text(json.dumps(owner), encoding="utf-8")
+
+    stale_observed = threading.Event()
+    allow_delayed_reclaim = threading.Event()
+    delayed_errors: list[BaseException] = []
+    delayed_results: list[lifecycle_guard_support.TargetLease] = []
+    original_remove = lifecycle_guard_support._remove_stale_lock
+
+    def _delayed_remove(lock_path, observed_token):
+        if threading.current_thread().name == "delayed-reclaimer":
+            stale_observed.set()
+            assert allow_delayed_reclaim.wait(timeout=5)
+        return original_remove(lock_path, observed_token)
+
+    monkeypatch.setattr(
+        lifecycle_guard_support,
+        "_remove_stale_lock",
+        _delayed_remove,
+    )
+
+    def _reclaim_stale() -> None:
+        try:
+            delayed_results.append(
+                lifecycle_guard_support.acquire_target_lease(env, "delayed")
+            )
+        except BaseException as exc:
+            delayed_errors.append(exc)
+
+    delayed_thread = threading.Thread(
+        target=_reclaim_stale,
+        name="delayed-reclaimer",
+    )
+    delayed_thread.start()
+    assert stale_observed.wait(timeout=5)
+
+    replacement = lifecycle_guard_support.acquire_target_lease(env, "replacement")
+    try:
+        allow_delayed_reclaim.set()
+        delayed_thread.join(timeout=5)
+        assert not delayed_thread.is_alive()
+        assert delayed_results == []
+        assert len(delayed_errors) == 1
+        assert isinstance(
+            delayed_errors[0],
+            lifecycle_guard_support.LifecycleBusyError,
+        )
+        replacement_owner = json.loads(owner_path.read_text(encoding="utf-8"))
+        assert replacement_owner["token"] == replacement.token
+        assert (replacement.path / f"token-{replacement.token}").is_dir()
+    finally:
+        allow_delayed_reclaim.set()
+        delayed_thread.join(timeout=5)
+        lifecycle_guard_support.release_target_lease(replacement)
+        lifecycle_guard_support.release_target_lease(stale)
+
+
+def test_delayed_local_release_cannot_remove_successor_generation(
+    monkeypatch,
+    tmp_path,
+):
+    env = _env(tmp_path / "worker")
+    stale = lifecycle_guard_support.acquire_target_lease(env, "stale")
+    tombstone = lifecycle_guard_support._target_release_tombstone(
+        stale.path,
+        stale.token,
+    )
+    delayed_at_rename = threading.Event()
+    allow_delayed_release = threading.Event()
+    delayed_results: list[bool] = []
+    delayed_errors: list[BaseException] = []
+    real_rename = Path.rename
+
+    def _pause_old_generation_rename(self, destination):
+        if (
+            threading.current_thread().name == "delayed-local-release"
+            and self == stale.path
+            and Path(destination) == tombstone
+        ):
+            delayed_at_rename.set()
+            assert allow_delayed_release.wait(timeout=5)
+        return real_rename(self, destination)
+
+    monkeypatch.setattr(Path, "rename", _pause_old_generation_rename)
+
+    def _delayed_release() -> None:
+        try:
+            delayed_results.append(
+                lifecycle_guard_support.release_target_lease(stale)
+            )
+        except BaseException as exc:
+            delayed_errors.append(exc)
+
+    delayed_thread = threading.Thread(
+        target=_delayed_release,
+        name="delayed-local-release",
+    )
+    delayed_thread.start()
+    assert delayed_at_rename.wait(timeout=5)
+
+    # Resume the exact crashed release claim, retire the old generation, and
+    # publish a successor while the first releaser is still arbitrarily late.
+    assert lifecycle_guard_support._remove_stale_lock(stale.path, stale.token)
+    successor = lifecycle_guard_support.acquire_target_lease(env, "successor")
+    try:
+        allow_delayed_release.set()
+        delayed_thread.join(timeout=5)
+        assert not delayed_thread.is_alive()
+        assert delayed_errors == []
+        assert delayed_results == [True]
+
+        successor_owner = json.loads(
+            (successor.path / "owner.json").read_text(encoding="utf-8")
+        )
+        assert successor_owner["token"] == successor.token
+        assert (successor.path / f"token-{successor.token}").is_dir()
+        assert tombstone.is_dir()
+        assert any(tombstone.iterdir())
+        retired_owner = json.loads(
+            (tombstone / "owner.json").read_text(encoding="utf-8")
+        )
+        assert retired_owner["token"] == stale.token
+    finally:
+        allow_delayed_release.set()
+        delayed_thread.join(timeout=5)
+        assert lifecycle_guard_support.release_target_lease(successor)
+
+
+def test_local_release_fails_closed_for_corrupt_owner_generation(tmp_path):
+    env = _env(tmp_path / "worker")
+    lease = lifecycle_guard_support.acquire_target_lease(env, "install")
+    owner_path = lease.path / "owner.json"
+    owner = json.loads(owner_path.read_text(encoding="utf-8"))
+    owner["token"] = "corrupt"
+    owner_path.write_text(json.dumps(owner), encoding="utf-8")
+
+    assert lifecycle_guard_support.release_target_lease(lease) is False
+    assert lease.path.exists()
+    assert (lease.path.parent / f".release-{lease.token}").is_dir()
+
+    owner["token"] = lease.token
+    owner_path.write_text(json.dumps(owner), encoding="utf-8")
+    assert lifecycle_guard_support.release_target_lease(lease) is True
+    tombstone = lifecycle_guard_support._target_release_tombstone(
+        lease.path,
+        lease.token,
+    )
+    assert lifecycle_guard_support._target_generation_owned(tombstone, lease.token)
+
+
+@pytest.mark.parametrize("claim_kind", ["reclaim", "release"])
+def test_stale_reclaim_resumes_crashed_generation_claim(tmp_path, claim_kind):
+    env = _env(tmp_path / "worker")
+    stale = lifecycle_guard_support.acquire_target_lease(env, "stale")
+    owner_path = stale.path / "owner.json"
+    owner = json.loads(owner_path.read_text(encoding="utf-8"))
+    owner["process_start_time"] = 1.0
+    owner_path.write_text(json.dumps(owner), encoding="utf-8")
+    marker = stale.path / f"token-{stale.token}"
+    if claim_kind == "reclaim":
+        stranded_claim = stale.path.parent / (
+            f".{stale.path.name}.reclaim-{stale.token}-crashed"
+        )
+    else:
+        stranded_claim = stale.path.parent / f".release-{stale.token}"
+    marker.rename(stranded_claim)
+
+    replacement = lifecycle_guard_support.acquire_target_lease(env, "replacement")
+    try:
+        assert replacement.token != stale.token
+        assert not stranded_claim.exists()
+        assert (replacement.path / f"token-{replacement.token}").is_dir()
+    finally:
+        lifecycle_guard_support.release_target_lease(replacement)
+
+
+def test_owner_liveness_fails_closed_for_uncertain_process_checks():
+    payload = {
+        "hostname": socket.gethostname(),
+        "pid": 123,
+        "process_start_time": 10.0,
+    }
+
+    def _access_denied(_pid):
+        raise psutil.AccessDenied(pid=123)
+
+    def _transient_os_error(_pid):
+        raise OSError("process table unavailable")
+
+    def _missing(_pid):
+        raise psutil.NoSuchProcess(pid=123)
+
+    assert lifecycle_guard_support._owner_is_live(
+        payload,
+        process_factory=_access_denied,
+    ) is True
+    assert lifecycle_guard_support._owner_is_live(
+        payload,
+        process_factory=_transient_os_error,
+    ) is True
+    assert lifecycle_guard_support._owner_is_live(
+        payload,
+        process_factory=_missing,
+    ) is False
+    assert lifecycle_guard_support._owner_is_live(
+        {**payload, "pid": "invalid"},
+        process_factory=_missing,
+    ) is True
+
+
+def test_owner_liveness_only_marks_dead_or_reused_process_stale():
+    payload = {
+        "hostname": socket.gethostname(),
+        "pid": 123,
+        "process_start_time": 10.0,
+    }
+
+    class _DeadProcess:
+        def is_running(self):
+            return False
+
+    class _ReusedProcess:
+        def is_running(self):
+            return True
+
+        def create_time(self):
+            return 20.0
+
+    class _DeniedCreateTime:
+        def is_running(self):
+            return True
+
+        def create_time(self):
+            raise psutil.AccessDenied(pid=123)
+
+    assert lifecycle_guard_support._owner_is_live(
+        payload,
+        process_factory=lambda _pid: _DeadProcess(),
+    ) is False
+    assert lifecycle_guard_support._owner_is_live(
+        payload,
+        process_factory=lambda _pid: _ReusedProcess(),
+    ) is False
+    assert lifecycle_guard_support._owner_is_live(
+        payload,
+        process_factory=lambda _pid: _DeniedCreateTime(),
+    ) is True
+
+
+def test_target_lease_fails_closed_for_remote_host_owner(tmp_path):
+    env = _env(tmp_path / "worker")
+    first = lifecycle_guard_support.acquire_target_lease(env, "install")
+    owner_path = first.path / "owner.json"
+    owner = json.loads(owner_path.read_text(encoding="utf-8"))
+    owner["hostname"] = f"remote-{socket.gethostname()}"
+    owner_path.write_text(json.dumps(owner), encoding="utf-8")
+
+    try:
+        with pytest.raises(lifecycle_guard_support.LifecycleBusyError, match="remote-"):
+            lifecycle_guard_support.acquire_target_lease(env, "run")
+    finally:
+        # Restore the local hostname so normal token-safe release can clean up.
+        owner["hostname"] = socket.gethostname()
+        owner_path.write_text(json.dumps(owner), encoding="utf-8")
+        lifecycle_guard_support.release_target_lease(first)
+
+
+def test_target_key_case_folds_when_filesystem_normcase_does(tmp_path):
+    upper = tmp_path / "CaseSensitiveSpelling" / "Worker"
+    lower = tmp_path / "casesensitivespelling" / "worker"
+
+    def normcase(value):
+        return str(value).lower()
+
+    assert lifecycle_guard_support._normalized_target_key(
+        upper, normcase_fn=normcase
+    ) == lifecycle_guard_support._normalized_target_key(lower, normcase_fn=normcase)
+
+
+def test_first_use_state_lock_creation_is_singleton_across_threads():
+    class _Agi:
+        _lifecycle_state_lock = None
+
+    barrier = threading.Barrier(8)
+    lock_ids: list[int] = []
+
+    def _resolve_lock() -> None:
+        barrier.wait()
+        lock_ids.append(id(lifecycle_guard_support._state_lock(_Agi)))
+
+    threads = [threading.Thread(target=_resolve_lock) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=5)
+
+    assert len(lock_ids) == 8
+    assert len(set(lock_ids)) == 1
+
+
+@pytest.mark.asyncio
+async def test_concurrent_agi_run_fails_fast_before_state_can_cross_wire(monkeypatch, tmp_path):
+    env = _env(tmp_path / "worker")
+    started = asyncio.Event()
+    finish = asyncio.Event()
+
+    async def _blocked_run(*_args, **_kwargs):
+        started.set()
+        await finish.wait()
+        return "first"
+
+    monkeypatch.setattr(agi_distributor_module.entrypoint_support, "run", _blocked_run)
+    request = RunRequest(workers={"127.0.0.1": 1}, mode=AGI.PYTHON_MODE)
+    first = asyncio.create_task(AGI.run(env, request=request))
+    await started.wait()
+
+    with pytest.raises(lifecycle_guard_support.LifecycleBusyError, match="already active"):
+        await AGI.run(env, request=request)
+
+    finish.set()
+    assert await first == "first"
+
+
+@pytest.mark.asyncio
+async def test_retained_service_blocks_run_and_serializes_service_commands(monkeypatch, tmp_path):
+    env = _env(tmp_path / "worker")
+    submit_started = asyncio.Event()
+    finish_submit = asyncio.Event()
+
+    async def _serve(*_args, action="start", **_kwargs):
+        return {"status": "stopped" if action == "stop" else "running"}
+
+    async def _submit(*_args, **_kwargs):
+        submit_started.set()
+        await finish_submit.wait()
+        return {"status": "queued"}
+
+    async def _run(*_args, **_kwargs):
+        return "ran"
+
+    monkeypatch.setattr(agi_distributor_module.service_runtime_support, "serve", _serve)
+    monkeypatch.setattr(agi_distributor_module.service_runtime_support, "submit", _submit)
+    monkeypatch.setattr(agi_distributor_module.entrypoint_support, "run", _run)
+
+    assert (await AGI.serve(env, action="start"))["status"] == "running"
+    request = RunRequest(workers={"127.0.0.1": 1}, mode=AGI.PYTHON_MODE)
+    with pytest.raises(lifecycle_guard_support.LifecycleBusyError, match="persistent"):
+        await AGI.run(env, request=request)
+
+    submit_task = asyncio.create_task(AGI.submit(env=env, work_plan=[], work_plan_metadata=[]))
+    await submit_started.wait()
+    with pytest.raises(lifecycle_guard_support.LifecycleBusyError, match="already active"):
+        await AGI.serve(env, action="status")
+    finish_submit.set()
+    assert (await submit_task)["status"] == "queued"
+
+    assert (await AGI.serve(env, action="stop"))["status"] == "stopped"
+    assert await AGI.run(env, request=request) == "ran"
+
+
+@pytest.mark.asyncio
+async def test_service_stop_without_runtime_shutdown_keeps_lease(monkeypatch, tmp_path):
+    env = _env(tmp_path / "worker")
+
+    async def _serve(*_args, action="start", **_kwargs):
+        return {"status": "stopped" if action == "stop" else "running"}
+
+    async def _run(*_args, **_kwargs):
+        return "ran"
+
+    monkeypatch.setattr(agi_distributor_module.service_runtime_support, "serve", _serve)
+    monkeypatch.setattr(agi_distributor_module.entrypoint_support, "run", _run)
+
+    assert (await AGI.serve(env, action="start"))["status"] == "running"
+    AGI._dask_client = object()
+    assert (
+        await AGI.serve(env, action="stop", shutdown_on_stop=False)
+    )["status"] == "stopped"
+
+    request = RunRequest(workers={"127.0.0.1": 1}, mode=AGI.PYTHON_MODE)
+    with pytest.raises(lifecycle_guard_support.LifecycleBusyError, match="persistent"):
+        await AGI.run(env, request=request)
+
+    AGI._dask_client = None
+    assert (await AGI.serve(env, action="stop"))["status"] == "stopped"
+    assert await AGI.run(env, request=request) == "ran"
+
+
+@pytest.mark.asyncio
+async def test_failed_service_cleanup_retains_lease_until_explicit_stop(monkeypatch, tmp_path):
+    env = _env(tmp_path / "worker")
+
+    async def _failed_stop():
+        raise RuntimeError("runtime cleanup failed")
+
+    monkeypatch.setattr(AGI, "_stop", staticmethod(_failed_stop))
+    monkeypatch.setattr(AGI, "_service_clear_state", staticmethod(lambda _env: None))
+    monkeypatch.setattr(AGI, "_reset_service_queue_state", staticmethod(lambda: None))
+
+    async def _serve(*_args, action="start", **_kwargs):
+        if action == "stop":
+            AGI._service_cleanup_unproven = False
+            AGI._dask_client = None
+            AGI._service_futures = {}
+            AGI._service_workers = []
+            return {"status": "stopped"}
+        AGI._dask_client = object()
+        AGI._jobs = None
+        await service_lifecycle_support._cleanup_failed_service_start(
+            AGI,
+            env,
+            owned_futures=[],
+            runtime_started_here=True,
+            log=SimpleNamespace(warning=lambda *_args, **_kwargs: None),
+        )
+        raise RuntimeError("primary startup failure")
+
+    async def _run(*_args, **_kwargs):
+        return "ran"
+
+    monkeypatch.setattr(agi_distributor_module.service_runtime_support, "serve", _serve)
+    monkeypatch.setattr(agi_distributor_module.entrypoint_support, "run", _run)
+
+    with pytest.raises(RuntimeError, match="primary startup failure"):
+        await AGI.serve(env, action="start")
+
+    request = RunRequest(workers={"127.0.0.1": 1}, mode=AGI.PYTHON_MODE)
+    with pytest.raises(
+        lifecycle_guard_support.LifecycleBusyError,
+        match="cleanup could not be proven",
+    ):
+        await AGI.run(env, request=request)
+    with pytest.raises(
+        lifecycle_guard_support.LifecycleBusyError,
+        match="cleanup could not be proven",
+    ):
+        await AGI.serve(env, action="status")
+
+    assert (await AGI.serve(env, action="stop"))["status"] == "stopped"
+    assert await AGI.run(env, request=request) == "ran"
+
+
+@pytest.mark.asyncio
+async def test_submit_failure_after_live_recovery_retains_service_lease(monkeypatch, tmp_path):
+    env = _env(tmp_path / "worker")
+
+    async def _submit(*_args, **_kwargs):
+        # Models service_runtime_support.submit() successfully recovering a
+        # persisted service before later distribution/queue publication fails.
+        AGI._service_workers = ["worker-1"]
+        AGI._dask_client = object()
+        raise RuntimeError("queue publication failed")
+
+    async def _serve(*_args, action="start", **_kwargs):
+        assert action == "stop"
+        AGI._service_cleanup_unproven = False
+        AGI._dask_client = None
+        AGI._service_futures = {}
+        AGI._service_workers = []
+        return {"status": "stopped"}
+
+    async def _run(*_args, **_kwargs):
+        return "ran"
+
+    monkeypatch.setattr(agi_distributor_module.service_runtime_support, "submit", _submit)
+    monkeypatch.setattr(agi_distributor_module.service_runtime_support, "serve", _serve)
+    monkeypatch.setattr(agi_distributor_module.entrypoint_support, "run", _run)
+
+    with pytest.raises(RuntimeError, match="queue publication failed"):
+        await AGI.submit(env=env, work_plan=[], work_plan_metadata=[])
+
+    request = RunRequest(workers={"127.0.0.1": 1}, mode=AGI.PYTHON_MODE)
+    with pytest.raises(lifecycle_guard_support.LifecycleBusyError, match="persistent"):
+        await AGI.run(env, request=request)
+
+    assert (await AGI.serve(env, action="stop"))["status"] == "stopped"
+    assert await AGI.run(env, request=request) == "ran"

--- a/src/agilab/core/test/test_agi_distributor_runtime_distribution_support.py
+++ b/src/agilab/core/test/test_agi_distributor_runtime_distribution_support.py
@@ -3,13 +3,22 @@ from __future__ import annotations
 import asyncio
 import os
 import shlex
+import subprocess
+import sys
+import time
 from pathlib import Path
 from types import SimpleNamespace
 from zipfile import ZipFile
 
+import psutil
 import pytest
 
-from agi_cluster.agi_distributor import AGI, runtime_distribution_support, uv_source_support
+from agi_cluster.agi_distributor import (
+    AGI,
+    background_jobs_support,
+    runtime_distribution_support,
+    uv_source_support,
+)
 from agi_node.agi_dispatcher import BaseWorker, WorkDispatcher
 
 
@@ -37,6 +46,13 @@ def _reset_agi_runtime_distribution_state():
         "_dask_log_level",
         "_rapids_enabled",
         "_workers_data_path",
+        "_worker_launch_tasks",
+        "_scheduler_launch_tasks",
+        "_startup_in_progress",
+        "_service_cleanup_unproven",
+        "_runtime_cleanup_task",
+        "_runtime_cleanup_phase",
+        "_runtime_shutdown_client",
     ]
     snapshot = {field: getattr(AGI, field, None) for field in fields}
     try:
@@ -61,8 +77,18 @@ def _reset_agi_runtime_distribution_state():
         AGI._dask_log_level = "critical"
         AGI._rapids_enabled = False
         AGI._workers_data_path = None
+        AGI._worker_launch_tasks = set()
+        AGI._scheduler_launch_tasks = set()
+        AGI._startup_in_progress = False
+        AGI._service_cleanup_unproven = False
+        AGI._runtime_cleanup_task = None
+        AGI._runtime_cleanup_phase = None
+        AGI._runtime_shutdown_client = None
         yield
     finally:
+        cleanup_task = getattr(AGI, "_runtime_cleanup_task", None)
+        if isinstance(cleanup_task, asyncio.Task) and not cleanup_task.done():
+            cleanup_task.cancel()
         for field, value in snapshot.items():
             setattr(AGI, field, value)
 
@@ -289,6 +315,37 @@ def test_worker_port_range_defaults_to_pinned_range(monkeypatch):
 def test_worker_port_range_ephemeral_disables_pinning():
     env = SimpleNamespace(envars={"AGILAB_DASK_WORKER_PORT_RANGE": "ephemeral"})
     assert runtime_distribution_support._worker_port_range(env) is None
+
+
+@pytest.mark.asyncio
+async def test_start_acquires_remote_target_leases_before_scheduler_bootstrap():
+    events = []
+
+    async def _acquire(ip):
+        events.append(f"lease:{ip}")
+
+    async def _start_scheduler(_scheduler):
+        events.append("scheduler")
+        return False
+
+    agi_cls = SimpleNamespace(
+        env=SimpleNamespace(is_local=lambda ip: ip == "127.0.0.1"),
+        _workers={"10.0.0.3": 1, "127.0.0.1": 1},
+        _get_scheduler=lambda _scheduler: ("10.0.0.2", 8786),
+        _lifecycle_call_token="a" * 32,
+        _dask_log_level=None,
+        _acquire_remote_target_lease=_acquire,
+        _start_scheduler=_start_scheduler,
+    )
+
+    started = await runtime_distribution_support.start(
+        agi_cls,
+        "10.0.0.2",
+        set_env_var_fn=lambda *_args, **_kwargs: None,
+    )
+
+    assert started is False
+    assert events == ["lease:10.0.0.2", "lease:10.0.0.3", "scheduler"]
 
 
 @pytest.mark.asyncio
@@ -522,7 +579,8 @@ async def test_stop_retires_workers_and_shutdown(monkeypatch):
         async def shutdown(self):
             self.shutdown_calls += 1
 
-    AGI._dask_client = _Client()
+    client = _Client()
+    AGI._dask_client = client
     AGI._mode_auto = False
     AGI._mode = AGI.DASK_MODE
     AGI._TIMEOUT = 3
@@ -538,8 +596,9 @@ async def test_stop_retires_workers_and_shutdown(monkeypatch):
 
     await runtime_distribution_support.stop(AGI, sleep_fn=_fake_sleep)
 
-    assert AGI._dask_client.retire_calls >= 1
-    assert AGI._dask_client.shutdown_calls == 1
+    assert client.retire_calls >= 1
+    assert client.shutdown_calls == 1
+    assert AGI._dask_client is None
     assert closed["count"] == 1
 
 
@@ -565,7 +624,8 @@ async def test_stop_supports_sync_scheduler_shutdown_calls(monkeypatch):
             self.shutdown_calls += 1
             return {"status": "stopped"}
 
-    AGI._dask_client = _Client()
+    client = _Client()
+    AGI._dask_client = client
     AGI._mode_auto = False
     AGI._mode = AGI.DASK_MODE
     AGI._TIMEOUT = 3
@@ -581,14 +641,114 @@ async def test_stop_supports_sync_scheduler_shutdown_calls(monkeypatch):
 
     await runtime_distribution_support.stop(AGI, sleep_fn=_fake_sleep)
 
-    assert AGI._dask_client.retire_calls >= 1
-    assert AGI._dask_client.shutdown_calls == 1
+    assert client.retire_calls >= 1
+    assert client.shutdown_calls == 1
+    assert AGI._dask_client is None
     assert closed["count"] == 1
 
 
 @pytest.mark.asyncio
+async def test_stop_retry_does_not_query_a_proven_closed_client(monkeypatch):
+    class _Client:
+        def __init__(self):
+            self.closed = False
+            self.info_calls = 0
+            self.shutdown_calls = 0
+
+        async def scheduler_info(self):
+            self.info_calls += 1
+            if self.closed:
+                raise RuntimeError("closed client must not be queried")
+            return {"workers": {}}
+
+        async def shutdown(self):
+            self.shutdown_calls += 1
+            self.closed = True
+
+    client = _Client()
+    AGI._dask_client = client
+    AGI._mode_auto = False
+    closed_connections = {"count": 0}
+
+    async def _fake_close_all():
+        closed_connections["count"] += 1
+
+    monkeypatch.setattr(AGI, "_close_all_connections", staticmethod(_fake_close_all))
+
+    await runtime_distribution_support.stop(AGI)
+    # A retained lifecycle lease may call runtime stop again when state-file
+    # cleanup failed after the first successful runtime shutdown.
+    await runtime_distribution_support.stop(AGI)
+
+    assert client.info_calls == 1
+    assert client.shutdown_calls == 1
+    assert closed_connections["count"] == 2
+    assert AGI._dask_client is None
+
+
+@pytest.mark.asyncio
+async def test_stop_retry_reuses_client_shutdown_proof_until_process_cleanup_succeeds(
+    monkeypatch,
+):
+    class _Client:
+        def __init__(self):
+            self.closed = False
+            self.info_calls = 0
+            self.shutdown_calls = 0
+
+        async def scheduler_info(self):
+            self.info_calls += 1
+            if self.closed:
+                raise RuntimeError("closed client must not be queried")
+            return {"workers": {}}
+
+        async def shutdown(self):
+            self.shutdown_calls += 1
+            self.closed = True
+
+    process_cleanup_calls = {"count": 0}
+
+    async def _terminate_jobs(_agi_cls, *, log):
+        process_cleanup_calls["count"] += 1
+        if process_cleanup_calls["count"] == 1:
+            raise runtime_distribution_support.RuntimeCleanupRequiredError(
+                "owned child is still exiting"
+            )
+
+    async def _fake_close_all():
+        return None
+
+    client = _Client()
+    AGI._dask_client = client
+    AGI._mode_auto = False
+    monkeypatch.setattr(
+        runtime_distribution_support,
+        "_terminate_owned_background_jobs",
+        _terminate_jobs,
+    )
+    monkeypatch.setattr(AGI, "_close_all_connections", staticmethod(_fake_close_all))
+
+    with pytest.raises(
+        runtime_distribution_support.RuntimeCleanupRequiredError,
+        match="owned child is still exiting",
+    ):
+        await runtime_distribution_support.stop(AGI)
+
+    assert AGI._dask_client is client
+    assert AGI._runtime_shutdown_client is client
+
+    await runtime_distribution_support.stop(AGI)
+
+    assert client.info_calls == 1
+    assert client.shutdown_calls == 1
+    assert process_cleanup_calls["count"] == 2
+    assert AGI._dask_client is None
+    assert AGI._runtime_shutdown_client is None
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("phase", ["scheduler_info", "retire_workers", "shutdown"])
-async def test_stop_swallows_expected_operational_errors(monkeypatch, phase):
+async def test_stop_marks_operational_cleanup_errors_unproven(monkeypatch, phase):
     class _Client:
         def __init__(self):
             self.shutdown_calls = 0
@@ -624,9 +784,14 @@ async def test_stop_swallows_expected_operational_errors(monkeypatch, phase):
 
     monkeypatch.setattr(AGI, "_close_all_connections", staticmethod(_fake_close_all))
 
-    await runtime_distribution_support.stop(AGI, sleep_fn=_fake_sleep)
+    with pytest.raises(
+        runtime_distribution_support.RuntimeCleanupRequiredError,
+        match="cleanup remains unproven",
+    ):
+        await runtime_distribution_support.stop(AGI, sleep_fn=_fake_sleep)
 
     assert closed["count"] == 1
+    assert AGI._service_cleanup_unproven is True
 
 
 @pytest.mark.asyncio
@@ -1352,6 +1517,10 @@ async def test_run_debug_branch_returns_list_result(tmp_path, monkeypatch):
 
     async def _fake_run(*_args, **_kwargs):
         calls["run"] += 1
+        calls["pid_namespaced"] = (
+            (wenv_abs / "dask_worker_0.pid").exists()
+            and not (tmp_path / "dask_worker_0.pid").exists()
+        )
         return ["ok", "done"]
 
     async def _fake_kill(*_args, **_kwargs):
@@ -1372,9 +1541,8 @@ async def test_run_debug_branch_returns_list_result(tmp_path, monkeypatch):
     assert calls["new"] == 1
     assert calls["run"] == 1
     assert calls["kill"] == 1
-    # New contract: the pid file is written next to the wenv (the location the
-    # cleanup scanners glob) and removed again when run_local exits.
-    assert not (tmp_path / "dask_worker_0.pid").exists()
+    assert calls["pid_namespaced"] is True
+    assert not (wenv_abs / "dask_worker_0.pid").exists()
 
 
 @pytest.mark.asyncio
@@ -1703,7 +1871,9 @@ def test_remote_dask_worker_command_uses_posix_paths_for_windows_manager():
     )
 
     assert "--project wenv/flight_telemetry_worker" in command
-    assert "--pid-file wenv/dask_worker_0_0.pid" in command
+    assert (
+        "--pid-file wenv/flight_telemetry_worker/dask_worker_0_0.pid" in command
+    )
     assert "\\" not in command
 
 
@@ -1820,16 +1990,20 @@ async def test_stop_shuts_down_client_after_partial_benchmark(monkeypatch):
     monkeypatch.setattr(AGI, "_close_all_connections", staticmethod(_fake_close_all))
     AGI._TIMEOUT = 2
 
-    AGI._dask_client = _Client()
+    owned_client = _Client()
+    AGI._dask_client = owned_client
     AGI._mode_auto = False
     AGI._mode = 5  # partial-range benchmark final mode
     await runtime_distribution_support.stop(AGI, sleep_fn=_fake_sleep)
-    assert AGI._dask_client.shutdown_calls == 1
+    assert owned_client.shutdown_calls == 1
+    assert AGI._dask_client is None
 
-    AGI._dask_client = _Client()
+    deferred_client = _Client()
+    AGI._dask_client = deferred_client
     AGI._mode_auto = True
     await runtime_distribution_support.stop(AGI, sleep_fn=_fake_sleep)
-    assert AGI._dask_client.shutdown_calls == 0
+    assert deferred_client.shutdown_calls == 0
+    assert AGI._dask_client is deferred_client
 
 
 def test_clean_job_respects_cond_and_verbosity():
@@ -1957,3 +2131,421 @@ async def test_main_dask_run_stops_cluster_when_distribute_raises(monkeypatch):
     # _update_capacity is skipped because distribute failed, but _stop must run.
     assert "stop" in calls
     assert "update_capacity" not in calls
+
+
+@pytest.mark.asyncio
+async def test_main_dask_run_stops_cluster_when_startup_raises(monkeypatch):
+    class _Jobs:
+        def flush(self):
+            return None
+
+    calls = []
+
+    async def _fail_start(_scheduler):
+        calls.append("start")
+        raise ConnectionError("scheduler launch failed")
+
+    async def _stop():
+        calls.append("stop")
+
+    monkeypatch.setattr(AGI, "_start", staticmethod(_fail_start))
+    monkeypatch.setattr(AGI, "_stop", staticmethod(_stop))
+    monkeypatch.setattr(AGI, "_clean_job", staticmethod(lambda _cond: None))
+    AGI._mode = AGI.DASK_MODE
+
+    with pytest.raises(ConnectionError, match="scheduler launch failed"):
+        await runtime_distribution_support.main(
+            AGI,
+            "127.0.0.1",
+            background_job_manager_factory=lambda: _Jobs(),
+        )
+
+    assert calls == ["start", "stop"]
+    assert AGI._startup_in_progress is False
+
+
+@pytest.mark.asyncio
+async def test_stop_cancels_and_awaits_scheduler_and_worker_launch_tasks(monkeypatch):
+    cleaned = []
+    blocker = asyncio.Event()
+
+    async def _launch(label):
+        try:
+            await blocker.wait()
+        finally:
+            cleaned.append(label)
+
+    scheduler_task = asyncio.create_task(_launch("scheduler"))
+    worker_task = asyncio.create_task(_launch("worker"))
+    await asyncio.sleep(0)
+    AGI._dask_client = None
+    AGI._scheduler_launch_tasks = {scheduler_task}
+    AGI._worker_launch_tasks = {worker_task}
+
+    async def _close_all():
+        cleaned.append("connections")
+
+    monkeypatch.setattr(AGI, "_close_all_connections", staticmethod(_close_all))
+    await runtime_distribution_support.stop(AGI)
+
+    assert scheduler_task.cancelled()
+    assert worker_task.cancelled()
+    assert set(cleaned) == {"scheduler", "worker", "connections"}
+    assert AGI._scheduler_launch_tasks == set()
+    assert AGI._worker_launch_tasks == set()
+
+
+@pytest.mark.asyncio
+async def test_stop_drains_owned_cleanup_under_repeated_cancellation(monkeypatch):
+    launch_cleanup_started = asyncio.Event()
+    allow_launch_cleanup = asyncio.Event()
+    launch_cleanup_finished = asyncio.Event()
+    connections_started = asyncio.Event()
+    allow_connections = asyncio.Event()
+    connections_finished = asyncio.Event()
+
+    async def _launch():
+        try:
+            await asyncio.Event().wait()
+        finally:
+            launch_cleanup_started.set()
+            await allow_launch_cleanup.wait()
+            launch_cleanup_finished.set()
+
+    launch_task = asyncio.create_task(_launch())
+    await asyncio.sleep(0)
+    AGI._dask_client = None
+    AGI._scheduler_launch_tasks = {launch_task}
+    AGI._worker_launch_tasks = set()
+
+    async def _close_all():
+        connections_started.set()
+        await allow_connections.wait()
+        connections_finished.set()
+
+    monkeypatch.setattr(AGI, "_close_all_connections", staticmethod(_close_all))
+    stop_task = asyncio.create_task(runtime_distribution_support.stop(AGI))
+
+    await launch_cleanup_started.wait()
+    stop_task.cancel()
+    await asyncio.sleep(0)
+    stop_task.cancel()
+    await asyncio.sleep(0)
+    assert not launch_task.done()
+
+    allow_launch_cleanup.set()
+    await connections_started.wait()
+    stop_task.cancel()
+    await asyncio.sleep(0)
+    stop_task.cancel()
+    await asyncio.sleep(0)
+    allow_connections.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await stop_task
+
+    assert launch_task.cancelled()
+    assert launch_cleanup_finished.is_set()
+    assert connections_finished.is_set()
+    assert AGI._scheduler_launch_tasks == set()
+    assert AGI._service_cleanup_unproven is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("blocked_phase", ["client-shutdown", "connections"])
+async def test_stop_times_out_repeated_cancellation_and_reuses_owned_cleanup_task(
+    monkeypatch,
+    blocked_phase,
+):
+    cleanup_entered = asyncio.Event()
+    allow_cleanup = asyncio.Event()
+    connections_finished = asyncio.Event()
+
+    class _Client:
+        async def scheduler_info(self):
+            return {"workers": {}}
+
+        async def shutdown(self):
+            if blocked_phase == "client-shutdown":
+                cleanup_entered.set()
+                await allow_cleanup.wait()
+
+    AGI._dask_client = _Client() if blocked_phase == "client-shutdown" else None
+    AGI._mode_auto = False
+
+    async def _close_all():
+        if blocked_phase == "connections":
+            cleanup_entered.set()
+            await allow_cleanup.wait()
+        connections_finished.set()
+
+    monkeypatch.setattr(AGI, "_close_all_connections", staticmethod(_close_all))
+    stop_task = asyncio.create_task(
+        runtime_distribution_support.stop(AGI, cleanup_timeout=0.05)
+    )
+
+    await asyncio.wait_for(cleanup_entered.wait(), timeout=1)
+    stop_task.cancel()
+    await asyncio.sleep(0)
+    stop_task.cancel()
+
+    with pytest.raises(
+        runtime_distribution_support.RuntimeCleanupRequiredError,
+        match="owned cleanup task and lifecycle lease were retained",
+    ):
+        await stop_task
+
+    owned_cleanup = AGI._runtime_cleanup_task
+    assert isinstance(owned_cleanup, asyncio.Task)
+    assert not owned_cleanup.done()
+    assert AGI._service_cleanup_unproven is True
+    assert AGI._runtime_cleanup_phase == blocked_phase
+
+    allow_cleanup.set()
+    await runtime_distribution_support.stop(AGI, cleanup_timeout=1.0)
+
+    assert owned_cleanup.done()
+    assert AGI._runtime_cleanup_task is None
+    assert AGI._service_cleanup_unproven is False
+    assert connections_finished.is_set()
+
+
+@pytest.mark.asyncio
+async def test_stop_marks_cleanup_unproven_when_connection_cleanup_fails(monkeypatch):
+    AGI._dask_client = None
+    AGI._scheduler_launch_tasks = set()
+    AGI._worker_launch_tasks = set()
+
+    async def _close_all():
+        raise RuntimeError("connection cleanup failed")
+
+    monkeypatch.setattr(AGI, "_close_all_connections", staticmethod(_close_all))
+
+    with pytest.raises(
+        runtime_distribution_support.RuntimeCleanupRequiredError,
+        match="connection cleanup failed",
+    ):
+        await runtime_distribution_support.stop(AGI)
+
+    assert AGI._service_cleanup_unproven is True
+
+
+@pytest.mark.asyncio
+async def test_stop_terminates_owned_local_jobs_after_partial_startup(monkeypatch):
+    calls = []
+
+    class _Process:
+        def poll(self):
+            return None
+
+        def terminate(self):
+            calls.append("terminate")
+
+        def wait(self, timeout):
+            calls.append(("wait", timeout))
+            if calls.count(("wait", timeout)) == 1:
+                raise subprocess.TimeoutExpired("dask-worker", timeout)
+            return 0
+
+        def kill(self):
+            calls.append("kill")
+
+    process = _Process()
+    AGI._jobs = SimpleNamespace(running=[SimpleNamespace(process=process)])
+    AGI._dask_client = None
+    AGI._mode_auto = True
+    AGI._startup_in_progress = True
+
+    async def _close_all():
+        calls.append("connections")
+
+    monkeypatch.setattr(AGI, "_close_all_connections", staticmethod(_close_all))
+
+    await runtime_distribution_support.stop(AGI)
+
+    assert calls == [
+        "terminate",
+        ("wait", 3.0),
+        "kill",
+        ("wait", 3.0),
+        "connections",
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(os.name != "posix", reason="POSIX process-group regression")
+async def test_stop_terminates_child_after_background_wrapper_exits(monkeypatch, tmp_path):
+    child_pid_file = tmp_path / "child.pid"
+    parent_code = "\n".join(
+        [
+            "import subprocess",
+            "import sys",
+            "from pathlib import Path",
+            "child = subprocess.Popen(",
+            "    [sys.executable, '-c', 'import time; time.sleep(120)']",
+            ")",
+            "Path(sys.argv[1]).write_text(str(child.pid), encoding='utf-8')",
+        ]
+    )
+    manager = background_jobs_support.BackgroundProcessManager()
+    job = manager.new(
+        [sys.executable, "-c", parent_code, str(child_pid_file)],
+        cwd=tmp_path,
+    )
+    child_pid: int | None = None
+
+    def _is_live_process(pid: int) -> bool:
+        try:
+            process = psutil.Process(pid)
+            return process.is_running() and process.status() != psutil.STATUS_ZOMBIE
+        except (psutil.NoSuchProcess, psutil.ZombieProcess):
+            return False
+
+    async def _wait_until(predicate, *, timeout: float = 5.0) -> None:
+        deadline = asyncio.get_running_loop().time() + timeout
+        while not predicate():
+            if asyncio.get_running_loop().time() >= deadline:
+                raise TimeoutError("background process condition was not reached")
+            await asyncio.sleep(0.02)
+
+    try:
+        await _wait_until(child_pid_file.is_file)
+        child_pid = int(child_pid_file.read_text(encoding="utf-8"))
+        await _wait_until(lambda: job.process.poll() is not None)
+        assert _is_live_process(child_pid)
+
+        # This refresh retires the successful wrapper from ``running``. The
+        # separate ownership record must still make its child discoverable.
+        assert manager.result(job.num) is job.process
+        assert job not in manager.running
+        assert job in manager.owned
+
+        AGI._jobs = manager
+        AGI._dask_client = None
+        AGI._mode_auto = True
+        AGI._startup_in_progress = True
+
+        async def _fake_close_all():
+            return None
+
+        monkeypatch.setattr(AGI, "_close_all_connections", staticmethod(_fake_close_all))
+
+        await runtime_distribution_support.stop(AGI)
+        await _wait_until(lambda: not _is_live_process(child_pid))
+
+        assert job not in manager.owned
+        assert job.num not in manager.all
+    finally:
+        if child_pid is not None and _is_live_process(child_pid):
+            child = psutil.Process(child_pid)
+            child.kill()
+            try:
+                child.wait(timeout=3)
+            except (psutil.NoSuchProcess, psutil.TimeoutExpired):
+                pass
+
+
+@pytest.mark.asyncio
+async def test_owned_job_cleanup_rejects_inaccessible_token_candidate(monkeypatch):
+    started_at = time.time()
+    username = psutil.Process(os.getpid()).username()
+
+    class _CompletedWrapper:
+        pid = 7101
+
+        @staticmethod
+        def poll():
+            return 0
+
+    class _InaccessibleCandidate:
+        pid = 7102
+
+        @staticmethod
+        def create_time():
+            return started_at
+
+        @staticmethod
+        def username():
+            return username
+
+        def environ(self):
+            raise psutil.AccessDenied(self.pid)
+
+    job = SimpleNamespace(
+        process=_CompletedWrapper(),
+        ownership_token="owned-token",
+        ownership_started_at=started_at,
+        process_group_id=None,
+        num=7,
+    )
+    manager = SimpleNamespace(
+        owned=[job],
+        running=[],
+        completed=[],
+        dead=[],
+        all={7: job},
+    )
+    monkeypatch.setattr(
+        runtime_distribution_support.psutil,
+        "process_iter",
+        lambda attrs: iter([_InaccessibleCandidate()]),
+    )
+
+    with pytest.raises(
+        runtime_distribution_support.RuntimeCleanupRequiredError,
+        match="ownership token unavailable.*7102",
+    ):
+        await runtime_distribution_support._terminate_owned_background_jobs(
+            SimpleNamespace(_jobs=manager)
+        )
+
+    assert manager.owned == [job]
+    assert manager.all == {7: job}
+
+
+@pytest.mark.asyncio
+async def test_stop_marks_kill_wait_timeout_as_recovery_required(monkeypatch):
+    calls = []
+
+    class _Process:
+        pid = 4321
+
+        def poll(self):
+            return None
+
+        def terminate(self):
+            calls.append("terminate")
+
+        def wait(self, timeout):
+            calls.append(("wait", timeout))
+            raise subprocess.TimeoutExpired("dask-worker", timeout)
+
+        def kill(self):
+            calls.append("kill")
+
+    process = _Process()
+    AGI._jobs = SimpleNamespace(running=[SimpleNamespace(process=process)])
+    AGI._dask_client = None
+    AGI._mode_auto = True
+    AGI._startup_in_progress = True
+
+    async def _close_all():
+        calls.append("connections")
+
+    monkeypatch.setattr(AGI, "_close_all_connections", staticmethod(_close_all))
+
+    with pytest.raises(
+        runtime_distribution_support.RuntimeCleanupRequiredError,
+        match="kill/wait",
+    ):
+        await runtime_distribution_support.stop(AGI)
+
+    assert calls == [
+        "terminate",
+        ("wait", 3.0),
+        "kill",
+        ("wait", 3.0),
+        "connections",
+    ]
+    assert AGI._service_cleanup_unproven is True
+    assert AGI._runtime_cleanup_task is None

--- a/src/agilab/core/test/test_agi_distributor_service_lifecycle_support.py
+++ b/src/agilab/core/test/test_agi_distributor_service_lifecycle_support.py
@@ -9,7 +9,7 @@ import pytest
 
 from agi_cluster.agi_distributor import AGI
 import agi_cluster.agi_distributor.agi_distributor as agi_distributor_module
-from agi_cluster.agi_distributor import service_lifecycle_support
+from agi_cluster.agi_distributor import service_lifecycle_support, service_state_support
 from agi_env import AgiEnv
 from agi_node.agi_dispatcher import BaseWorker
 
@@ -44,6 +44,8 @@ def _reset_agi_service_state():
         "_service_cleanup_failed_ttl_sec": AGI._service_cleanup_failed_ttl_sec,
         "_service_cleanup_heartbeat_max_files": AGI._service_cleanup_heartbeat_max_files,
         "_service_cleanup_heartbeat_ttl_sec": AGI._service_cleanup_heartbeat_ttl_sec,
+        "_service_cleanup_unproven": AGI._service_cleanup_unproven,
+        "_service_runtime_shutdown_proven": AGI._service_runtime_shutdown_proven,
         "_service_futures": dict(AGI._service_futures),
         "_service_heartbeat_timeout": AGI._service_heartbeat_timeout,
         "_service_poll_interval": AGI._service_poll_interval,
@@ -86,6 +88,8 @@ def _reset_agi_service_state():
     AGI._service_stop_timeout = 30.0
     AGI._service_poll_interval = None
     AGI._service_heartbeat_timeout = None
+    AGI._service_cleanup_unproven = False
+    AGI._service_runtime_shutdown_proven = False
     AGI._service_started_at = None
     AGI._service_submit_counter = 0
     AGI._service_worker_args = {}
@@ -113,6 +117,10 @@ def _reset_agi_service_state():
     AGI._service_cleanup_failed_ttl_sec = snapshot["_service_cleanup_failed_ttl_sec"]
     AGI._service_cleanup_heartbeat_max_files = snapshot["_service_cleanup_heartbeat_max_files"]
     AGI._service_cleanup_heartbeat_ttl_sec = snapshot["_service_cleanup_heartbeat_ttl_sec"]
+    AGI._service_cleanup_unproven = snapshot["_service_cleanup_unproven"]
+    AGI._service_runtime_shutdown_proven = snapshot[
+        "_service_runtime_shutdown_proven"
+    ]
     AGI._service_futures = snapshot["_service_futures"]
     AGI._service_heartbeat_timeout = snapshot["_service_heartbeat_timeout"]
     AGI._service_poll_interval = snapshot["_service_poll_interval"]
@@ -137,8 +145,21 @@ def _reset_agi_service_state():
 
 
 class _FakeFuture:
-    def __init__(self, status: str = "pending"):
+    def __init__(
+        self,
+        status: str = "pending",
+        *,
+        key: str | None = None,
+        kind: str | None = None,
+    ):
         self.status = status
+        self.key = key
+        self.kind = kind
+        self.cancel_calls = 0
+
+    def cancel(self):
+        self.cancel_calls += 1
+        self.status = "cancelled"
 
 
 class _FakeClient:
@@ -146,6 +167,7 @@ class _FakeClient:
         self._workers = workers
         self.status = "running"
         self.submissions: list[dict[str, object]] = []
+        self.loop_futures: list[_FakeFuture] = []
 
     def submit(self, *args, **kwargs):
         fn = args[0] if args else None
@@ -157,15 +179,35 @@ class _FakeClient:
                 "kwargs": kwargs,
             }
         )
-        return _FakeFuture()
+        future = _FakeFuture(
+            status="running" if fn_name == "loop" else "finished",
+            key=kwargs.get("key"),
+            kind=fn_name,
+        )
+        if fn_name == "loop":
+            self.loop_futures.append(future)
+        return future
 
     def gather(self, futures, errors="raise"):
+        if any(getattr(future, "kind", None) == "break_loop" for future in futures):
+            for loop_future in self.loop_futures:
+                loop_future.status = "finished"
         if isinstance(futures, list):
             return [None for _ in futures]
         return []
 
     def scheduler_info(self):
         return {"workers": {f"tcp://{worker}": {} for worker in self._workers}}
+
+
+def _install_fake_future_reacquisition(monkeypatch, client: _FakeClient) -> None:
+    def _reacquire(_client, key):
+        assert _client is client
+        future = _FakeFuture(status="running", key=str(key), kind="loop")
+        client.loop_futures.append(future)
+        return future
+
+    monkeypatch.setattr(service_lifecycle_support, "_reacquire_service_future", _reacquire)
 
 
 def _real_service_stub_new(**_kwargs):
@@ -261,7 +303,15 @@ def test_submit_service_loops_returns_worker_future_map():
     assert list(futures.keys()) == ["127.0.0.1:8787"]
     loop_call = [entry for entry in client.submissions if entry["fn"] == "loop"][0]
     assert loop_call["kwargs"]["poll_interval"] == 2.5
-    assert loop_call["kwargs"]["key"] == "agi-loop-loop-minimal_app-127.0.0.1-8787"
+    assert str(loop_call["kwargs"]["key"]).startswith(
+        "agi-loop-loop-minimal_app-127.0.0.1-8787-"
+    )
+    AGI._service_workers = ["127.0.0.1:8787"]
+    AGI._service_futures = futures
+    state = AGI._service_state_payload(env)
+    assert state["service_loop_keys"] == {
+        "127.0.0.1:8787": loop_call["kwargs"]["key"]
+    }
 
 
 @pytest.mark.asyncio
@@ -278,25 +328,35 @@ async def test_service_restart_workers_restarts_and_tracks_futures(monkeypatch, 
     AGI._mode = AGI.DASK_MODE
     AGI._service_poll_interval = 0.2
     AGI._service_queue_root = None
-    AGI._service_workers = []
-    AGI._service_futures = {}
+    worker = "127.0.0.1:8787"
+    old_loop = _FakeFuture(status="running", key="old-loop")
+    AGI._service_workers = [worker]
+    AGI._service_futures = {worker: old_loop}
 
     class _RestartClient:
         def __init__(self):
             self.calls = []
-            self._gather_calls = 0
 
         def scheduler_info(self):
-            return {"workers": {"tcp://127.0.0.1:8787": {}}}
+            return {"workers": {f"tcp://{worker}": {}}}
 
         def submit(self, fn, *args, **kwargs):
-            self.calls.append(getattr(fn, "__name__", str(fn)))
-            return _FakeFuture(status="running")
+            fn_name = getattr(fn, "__name__", str(fn))
+            self.calls.append(fn_name)
+            if fn_name == "loop":
+                # The replacement must never be submitted while the prior
+                # worker execution can still overlap it.
+                assert old_loop.status == "finished"
+                return _FakeFuture(
+                    status="running",
+                    key=str(kwargs["key"]),
+                    kind=fn_name,
+                )
+            return _FakeFuture(status="finished", kind=fn_name)
 
         def gather(self, futures, errors="raise"):
-            self._gather_calls += 1
-            if self._gather_calls == 1:
-                raise RuntimeError("ignore break gather failure")
+            if any(future.kind == "break_loop" for future in futures):
+                old_loop.status = "finished"
             return [None for _ in futures]
 
     client = _RestartClient()
@@ -306,9 +366,10 @@ async def test_service_restart_workers_restarts_and_tracks_futures(monkeypatch, 
 
     monkeypatch.setattr(AGI, "_init_service_queue", staticmethod(_fake_init_queue))
 
-    restarted = await AGI._service_restart_workers(env, client, ["127.0.0.1:8787"])
-    assert restarted == ["127.0.0.1:8787"]
-    assert AGI._service_futures["127.0.0.1:8787"].status == "running"
+    restarted = await AGI._service_restart_workers(env, client, [worker])
+    assert restarted == [worker]
+    assert AGI._service_futures[worker] is not old_loop
+    assert AGI._service_futures[worker].status == "running"
     assert {"break_loop", "_new", "loop"}.issubset(set(client.calls))
 
 
@@ -319,15 +380,17 @@ async def test_service_restart_workers_propagates_unexpected_break_loop_bug(monk
     AGI._mode = AGI.DASK_MODE
     AGI._service_poll_interval = 0.2
     AGI._service_queue_root = None
-    AGI._service_workers = []
-    AGI._service_futures = {}
+    worker = "127.0.0.1:8787"
+    old_loop = _FakeFuture(status="running", key="old-loop")
+    AGI._service_workers = [worker]
+    AGI._service_futures = {worker: old_loop}
 
     class _RestartClient:
         def scheduler_info(self):
-            return {"workers": {"tcp://127.0.0.1:8787": {}}}
+            return {"workers": {f"tcp://{worker}": {}}}
 
         def submit(self, fn, *args, **kwargs):
-            return _FakeFuture(status="running")
+            return _FakeFuture(status="finished", kind=getattr(fn, "__name__", ""))
 
         def gather(self, futures, errors="raise"):
             raise ValueError("unexpected break gather bug")
@@ -338,7 +401,188 @@ async def test_service_restart_workers_propagates_unexpected_break_loop_bug(monk
     monkeypatch.setattr(AGI, "_init_service_queue", staticmethod(_fake_init_queue))
 
     with pytest.raises(ValueError, match="unexpected break gather bug"):
-        await AGI._service_restart_workers(env, _RestartClient(), ["127.0.0.1:8787"])
+        await AGI._service_restart_workers(env, _RestartClient(), [worker])
+    assert AGI._service_futures == {worker: old_loop}
+    assert AGI._service_cleanup_unproven is True
+
+
+@pytest.mark.asyncio
+async def test_service_restart_partial_loop_submission_retains_unproven_replacement(
+    monkeypatch,
+    tmp_path,
+):
+    env = _minimal_app_env()
+    workers = ["w1", "w2"]
+    old_futures = {
+        worker: _FakeFuture(status="running", key=f"old-{worker}")
+        for worker in workers
+    }
+    AGI._args = {"sample": 1}
+    AGI._mode = AGI.DASK_MODE
+    AGI._service_workers = list(workers)
+    AGI._service_futures = dict(old_futures)
+    AGI._service_apply_queue_root(tmp_path / "queue", create=True)
+
+    class _PartialRestartClient:
+        def __init__(self):
+            self.break_gathers = 0
+            self.loop_submissions = 0
+            self.replacement: _FakeFuture | None = None
+
+        def scheduler_info(self):
+            return {"workers": {f"tcp://{worker}": {} for worker in workers}}
+
+        def submit(self, fn, *args, **kwargs):
+            fn_name = getattr(fn, "__name__", "")
+            if fn_name == "loop":
+                self.loop_submissions += 1
+                if self.loop_submissions == 2:
+                    raise RuntimeError("injected second replacement submit failure")
+                self.replacement = _FakeFuture(
+                    status="running",
+                    key=str(kwargs["key"]),
+                    kind=fn_name,
+                )
+                return self.replacement
+            return _FakeFuture(status="finished", kind=fn_name)
+
+        def gather(self, futures, errors="raise"):
+            if any(future.kind == "break_loop" for future in futures):
+                self.break_gathers += 1
+                if self.break_gathers == 1:
+                    for future in old_futures.values():
+                        future.status = "finished"
+            return [None for _ in futures]
+
+    client = _PartialRestartClient()
+    monkeypatch.setattr(AGI, "_service_write_state", staticmethod(lambda *_args: None))
+
+    def _wait(futures, **_kwargs):
+        return (
+            {future for future in futures if future.status in {"finished", "error"}},
+            {future for future in futures if future.status not in {"finished", "error"}},
+        )
+
+    with pytest.raises(
+        RuntimeError,
+        match="injected second replacement submit failure",
+    ):
+        await service_lifecycle_support.service_restart_workers(
+            AGI,
+            env,
+            client,
+            workers,
+            wait_fn=_wait,
+        )
+
+    assert client.replacement is not None
+    assert AGI._service_futures == {"w1": client.replacement}
+    assert AGI._service_cleanup_unproven is True
+    assert client.replacement.status == "running"
+
+
+@pytest.mark.asyncio
+async def test_service_restart_partial_publication_failure_forces_runtime_shutdown(
+    monkeypatch,
+    tmp_path,
+):
+    env = _minimal_app_env()
+    workers = ["w1", "w2"]
+    old_futures = {
+        worker: _FakeFuture(status="running", key=f"old-{worker}")
+        for worker in workers
+    }
+    AGI._args = {"sample": 1}
+    AGI._mode = AGI.DASK_MODE
+    AGI._service_workers = list(workers)
+    AGI._service_futures = dict(old_futures)
+    AGI._service_apply_queue_root(tmp_path / "queue", create=True)
+
+    class _PartialRestartClient:
+        def __init__(self):
+            self.break_gathers = 0
+            self.loop_submissions = 0
+            self.replacement: _FakeFuture | None = None
+
+        def scheduler_info(self):
+            return {"workers": {f"tcp://{worker}": {} for worker in workers}}
+
+        def submit(self, fn, *args, **kwargs):
+            fn_name = getattr(fn, "__name__", "")
+            if fn_name == "loop":
+                self.loop_submissions += 1
+                if self.loop_submissions == 2:
+                    raise RuntimeError("injected second replacement submit failure")
+                self.replacement = _FakeFuture(
+                    status="running",
+                    key=str(kwargs["key"]),
+                    kind=fn_name,
+                )
+                return self.replacement
+            return _FakeFuture(status="finished", kind=fn_name)
+
+        def gather(self, futures, errors="raise"):
+            if any(future.kind == "break_loop" for future in futures):
+                self.break_gathers += 1
+                if self.break_gathers == 1:
+                    for future in old_futures.values():
+                        future.status = "finished"
+            return [None for _ in futures]
+
+    client = _PartialRestartClient()
+    AGI._dask_client = client
+    stop_calls = 0
+
+    async def _stop():
+        nonlocal stop_calls
+        stop_calls += 1
+        assert client.replacement is not None
+        client.replacement.status = "finished"
+        AGI._dask_client = None
+
+    def _wait(futures, **_kwargs):
+        return (
+            {future for future in futures if future.status in {"finished", "error"}},
+            {
+                future
+                for future in futures
+                if future.status not in {"finished", "error"}
+            },
+        )
+
+    monkeypatch.setattr(AGI, "_stop", staticmethod(_stop))
+    monkeypatch.setattr(
+        AGI,
+        "_service_write_state",
+        staticmethod(
+            lambda *_args: (_ for _ in ()).throw(
+                service_state_support.ServiceStateUnavailableError(
+                    "partial restart state replace remains locked"
+                )
+            )
+        ),
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="injected second replacement submit failure",
+    ):
+        await service_lifecycle_support.service_restart_workers(
+            AGI,
+            env,
+            client,
+            workers,
+            wait_fn=_wait,
+        )
+
+    assert stop_calls == 1
+    assert client.replacement is not None
+    assert client.replacement.status == "finished"
+    assert AGI._dask_client is None
+    assert AGI._service_futures == old_futures
+    assert AGI._service_workers == workers
+    assert AGI._service_runtime_shutdown_proven is True
+    assert AGI._service_cleanup_unproven is True
 
 
 @pytest.mark.asyncio
@@ -383,7 +627,105 @@ async def test_service_auto_restart_unhealthy_restarts_and_persists(monkeypatch)
 
 
 @pytest.mark.asyncio
-async def test_service_recover_allow_stale_cleanup_clears_state_on_failure(tmp_path, monkeypatch):
+async def test_service_auto_restart_state_publish_failure_forces_runtime_shutdown(
+    monkeypatch,
+):
+    env = _minimal_app_env()
+    old_future = _FakeFuture(status="finished", key="old-loop-w1", kind="loop")
+    replacement = _FakeFuture(status="running", key="new-loop-w1", kind="loop")
+    AGI._service_workers = ["w1"]
+    AGI._service_futures = {"w1": old_future}
+
+    class _PendingReplacementClient(_FakeClient):
+        def gather(self, futures, errors="raise"):
+            if isinstance(futures, list):
+                return [None for _ in futures]
+            return []
+
+    client = _PendingReplacementClient(["w1"])
+    AGI._dask_client = client
+    stop_calls = 0
+
+    async def _connected(_client):
+        assert _client is client
+        return ["w1"]
+
+    async def _restart(_env, _client, _workers):
+        assert _client is client
+        assert _workers == ["w1"]
+        AGI._service_futures = {"w1": replacement}
+        return ["w1"]
+
+    async def _stop():
+        nonlocal stop_calls
+        stop_calls += 1
+        replacement.status = "finished"
+        AGI._dask_client = None
+
+    def _wait(futures, **_kwargs):
+        return (
+            {
+                future
+                for future in futures
+                if future.status in {"finished", "error"}
+            },
+            {
+                future
+                for future in futures
+                if future.status not in {"finished", "error"}
+            },
+        )
+
+    monkeypatch.setattr(AGI, "_service_connected_workers", staticmethod(_connected))
+    monkeypatch.setattr(
+        AGI,
+        "_service_unhealthy_workers",
+        staticmethod(lambda _workers: {"w1": "missing-heartbeat"}),
+    )
+    monkeypatch.setattr(AGI, "_service_restart_workers", staticmethod(_restart))
+    monkeypatch.setattr(AGI, "_stop", staticmethod(_stop))
+    monkeypatch.setattr(
+        AGI,
+        "_service_write_state",
+        staticmethod(
+            lambda *_args: (_ for _ in ()).throw(
+                service_state_support.ServiceStateUnavailableError(
+                    "restart state replace remains locked"
+                )
+            )
+        ),
+    )
+
+    with pytest.raises(
+        service_state_support.ServiceStateUnavailableError,
+        match="restart state replace remains locked",
+    ):
+        await service_lifecycle_support.service_auto_restart_unhealthy(
+            AGI,
+            env,
+            client,
+            wait_fn=_wait,
+        )
+
+    assert stop_calls == 1
+    assert AGI._service_futures == {"w1": old_future}
+    assert AGI._service_workers == ["w1"]
+    assert AGI._service_cleanup_unproven is True
+    assert AGI._service_runtime_shutdown_proven is True
+    assert replacement.status == "finished"
+    assert AGI._dask_client is None
+    break_submissions = [
+        submission
+        for submission in client.submissions
+        if submission["fn"] == "break_loop"
+    ]
+    assert len(break_submissions) == 1
+    assert break_submissions[0]["kwargs"]["workers"] == ["w1"]
+    assert break_submissions[0]["kwargs"]["allow_other_workers"] is False
+
+
+@pytest.mark.asyncio
+async def test_service_recover_preserves_state_on_transient_failure(tmp_path, monkeypatch):
     env = AgiEnv(apps_path=Path("src/agilab/apps/builtin"), app="minimal_app_project", verbose=0)
     queue_dir = tmp_path / "service_queue"
     queue_dir.mkdir(parents=True, exist_ok=True)
@@ -399,6 +741,7 @@ async def test_service_recover_allow_stale_cleanup_clears_state_on_failure(tmp_p
             "scheduler": "127.0.0.1:8786",
             "workers": {"127.0.0.1": 1},
             "service_workers": ["127.0.0.1:8787"],
+            "service_loop_keys": {"127.0.0.1:8787": "persisted-loop-8787"},
             "queue_dir": str(queue_dir),
             "args": {},
         },
@@ -411,10 +754,153 @@ async def test_service_recover_allow_stale_cleanup_clears_state_on_failure(tmp_p
 
     recovered = await AGI._service_recover(env, allow_stale_cleanup=True)
     assert recovered is False
-    assert AGI._service_read_state(env) is None
-    assert AGI._service_queue_root is None
-    assert AGI._service_workers == []
+    assert AGI._service_read_state(env) is not None
+    assert AGI._service_queue_root == queue_dir
+    assert AGI._service_workers == ["127.0.0.1:8787"]
     assert AGI._service_futures == {}
+    assert AGI._service_cleanup_unproven is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("shutdown_on_stop", [False, True])
+async def test_legacy_v1_state_requires_or_performs_full_runtime_shutdown(
+    monkeypatch,
+    tmp_path,
+    shutdown_on_stop,
+):
+    env = _minimal_app_env()
+    worker = "127.0.0.1:8787"
+    queue_dir = tmp_path / "queue"
+    queue_dir.mkdir(parents=True)
+    state_path = AGI._service_state_path(env)
+    AGI._service_write_state(
+        env,
+        {
+            "schema": "agi.service.state.v1",
+            "target": env.target,
+            "app": env.app,
+            "mode": AGI.DASK_MODE,
+            "run_type": "run --no-sync",
+            "scheduler": "127.0.0.1:8786",
+            "workers": {"127.0.0.1": 1},
+            "service_workers": [worker],
+            # Legacy v1 intentionally has no service_loop_keys field.
+            "queue_dir": str(queue_dir),
+            "args": {},
+        },
+    )
+    client = _FakeClient([worker])
+    stops = []
+
+    async def _connect(*_args, **_kwargs):
+        return client
+
+    async def _stop():
+        stops.append("stop")
+        AGI._dask_client = None
+
+    monkeypatch.setattr(AGI, "_connect_scheduler_with_retry", staticmethod(_connect))
+    monkeypatch.setattr(AGI, "_stop", staticmethod(_stop))
+
+    result = await AGI.serve(
+        env,
+        action="stop",
+        shutdown_on_stop=shutdown_on_stop,
+    )
+
+    if shutdown_on_stop:
+        assert result["status"] == "stopped"
+        assert result["legacy_full_shutdown"] is True
+        assert stops == ["stop"]
+        assert not state_path.exists()
+        assert AGI._service_workers == []
+        assert AGI._service_cleanup_unproven is False
+        assert AGI._lifecycle_service_token is None
+    else:
+        assert result["status"] == "error"
+        assert result["recovery_required"] is True
+        assert stops == []
+        assert state_path.exists()
+        assert AGI._service_workers == [worker]
+        assert AGI._service_cleanup_unproven is True
+        assert AGI._lifecycle_service_token is not None
+
+
+@pytest.mark.asyncio
+async def test_legacy_v1_stop_retries_state_clear_from_runtime_shutdown_proof(
+    monkeypatch,
+    tmp_path,
+):
+    env = _minimal_app_env()
+    worker = "127.0.0.1:8787"
+    queue_dir = tmp_path / "queue"
+    queue_dir.mkdir(parents=True)
+    AGI._service_write_state(
+        env,
+        {
+            "schema": "agi.service.state.v1",
+            "target": env.target,
+            "app": env.app,
+            "mode": AGI.DASK_MODE,
+            "run_type": "run --no-sync",
+            "scheduler": "127.0.0.1:8786",
+            "workers": {"127.0.0.1": 1},
+            "service_workers": [worker],
+            "queue_dir": str(queue_dir),
+            "args": {},
+        },
+    )
+    client = _FakeClient([worker])
+    stop_calls = 0
+    clear_calls = 0
+    real_clear_state = AGI._service_clear_state
+
+    async def _connect(*_args, **_kwargs):
+        return client
+
+    async def _stop():
+        nonlocal stop_calls
+        stop_calls += 1
+        AGI._dask_client = None
+
+    def _clear_state(service_env):
+        nonlocal clear_calls
+        clear_calls += 1
+        if clear_calls == 1:
+            raise service_state_support.ServiceStateUnavailableError(
+                "legacy state unlink remains locked"
+            )
+        real_clear_state(service_env)
+
+    monkeypatch.setattr(AGI, "_connect_scheduler_with_retry", staticmethod(_connect))
+    monkeypatch.setattr(AGI, "_stop", staticmethod(_stop))
+    monkeypatch.setattr(AGI, "_service_clear_state", staticmethod(_clear_state))
+
+    with pytest.raises(
+        service_state_support.ServiceStateUnavailableError,
+        match="legacy state unlink remains locked",
+    ):
+        await AGI.serve(env, action="stop", shutdown_on_stop=True)
+
+    assert stop_calls == 1
+    assert AGI._dask_client is None
+    assert AGI._service_futures == {}
+    assert AGI._service_workers == [worker]
+    assert AGI._service_runtime_shutdown_proven is True
+    assert AGI._service_cleanup_unproven is True
+    assert AGI._lifecycle_service_token is not None
+
+    result = await AGI.serve(env, action="stop", shutdown_on_stop=True)
+
+    assert result["status"] == "stopped"
+    assert result["pending"] == []
+    assert stop_calls == 1
+    assert clear_calls == 2
+    assert AGI._service_futures == {}
+    assert AGI._service_workers == []
+    assert AGI._service_runtime_shutdown_proven is False
+    assert AGI._service_cleanup_unproven is False
+    assert AGI._lifecycle_service_token is None
 
 
 @pytest.mark.asyncio
@@ -574,24 +1060,247 @@ async def test_agi_serve_stop_returns_idle_when_nothing_to_stop(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_agi_serve_stop_returns_error_when_client_missing(monkeypatch):
+@pytest.mark.parametrize("shutdown_on_stop", [False, True])
+async def test_agi_serve_stop_retains_ownership_when_client_missing(
+    monkeypatch,
+    shutdown_on_stop,
+):
     env = AgiEnv(apps_path=Path("src/agilab/apps/builtin"), app="minimal_app_project", verbose=0)
+    state_path = AGI._service_state_path(env)
+    AGI._service_write_state(
+        env,
+        {
+            "schema": "agi.service.state.v1",
+            "service_workers": ["w1"],
+            "service_loop_keys": {"w1": "loop-w1"},
+        },
+    )
     AGI._dask_client = None
     AGI._jobs = object()
-    AGI._service_futures = {"w1": _FakeFuture("running")}
+    loop_future = _FakeFuture("running", key="loop-w1")
+    AGI._service_futures = {"w1": loop_future}
     AGI._service_workers = ["w1"]
-    calls = {"clean": 0}
+    calls = {"clean": 0, "stop": 0, "clear": 0, "reset": 0}
 
+    async def _stop():
+        calls["stop"] += 1
+
+    monkeypatch.setattr(AGI, "_stop", staticmethod(_stop))
     monkeypatch.setattr(
         AGI,
         "_clean_job",
         staticmethod(lambda *_a, **_k: calls.__setitem__("clean", calls["clean"] + 1)),
     )
+    monkeypatch.setattr(
+        AGI,
+        "_service_clear_state",
+        staticmethod(lambda _env: calls.__setitem__("clear", calls["clear"] + 1)),
+    )
+    monkeypatch.setattr(
+        AGI,
+        "_reset_service_queue_state",
+        staticmethod(lambda: calls.__setitem__("reset", calls["reset"] + 1)),
+    )
 
-    result = await AGI.serve(env, action="stop", shutdown_on_stop=False)
+    result = await AGI.serve(
+        env,
+        action="stop",
+        shutdown_on_stop=shutdown_on_stop,
+    )
     assert result["status"] == "error"
+    assert result["recovery_required"] is True
     assert "w1" in result["pending"]
-    assert calls["clean"] == 1
+    assert calls == {"clean": 0, "stop": 0, "clear": 0, "reset": 0}
+    assert AGI._service_futures == {"w1": loop_future}
+    assert AGI._service_workers == ["w1"]
+    assert AGI._service_cleanup_unproven is True
+    assert AGI._lifecycle_service_token is not None
+    assert state_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_serve_stop_retains_ownership_when_state_clear_fails(monkeypatch):
+    env = _minimal_app_env()
+    worker = "127.0.0.1:8787"
+    client = _FakeClient([worker])
+    loop_future = _FakeFuture(status="finished", key="loop-8787")
+    AGI._dask_client = client
+    AGI._service_futures = {worker: loop_future}
+    AGI._service_workers = [worker]
+
+    with monkeypatch.context() as scoped:
+        scoped.setattr(
+            AGI,
+            "_service_clear_state",
+            staticmethod(
+                lambda _env: (_ for _ in ()).throw(
+                    service_state_support.ServiceStateUnavailableError(
+                        "state unlink remains locked"
+                    )
+                )
+            ),
+        )
+
+        with pytest.raises(
+            service_state_support.ServiceStateUnavailableError,
+            match="state unlink remains locked",
+        ):
+            await AGI.serve(env, action="stop", shutdown_on_stop=False)
+
+    assert AGI._service_futures == {worker: loop_future}
+    assert AGI._service_workers == [worker]
+    assert AGI._service_cleanup_unproven is True
+    assert AGI._lifecycle_service_token is not None
+
+
+@pytest.mark.asyncio
+async def test_serve_stop_retries_state_clear_after_runtime_already_shut_down(monkeypatch):
+    env = _minimal_app_env()
+    worker = "127.0.0.1:8787"
+
+    class _CloseAwareClient(_FakeClient):
+        def __init__(self):
+            super().__init__([])
+            self.shutdown_calls = 0
+
+        def scheduler_info(self):
+            if self.status == "closed":
+                raise RuntimeError("Dask client is already closed")
+            return super().scheduler_info()
+
+        def submit(self, *args, **kwargs):
+            if self.status == "closed":
+                raise RuntimeError("Dask client is already closed")
+            return super().submit(*args, **kwargs)
+
+        async def shutdown(self):
+            if self.status == "closed":
+                raise RuntimeError("Dask client is already closed")
+            self.shutdown_calls += 1
+            self.status = "closed"
+
+    client = _CloseAwareClient()
+    loop_future = _FakeFuture(status="finished", key="loop-8787")
+    AGI._dask_client = client
+    AGI._service_futures = {worker: loop_future}
+    AGI._service_workers = [worker]
+    AGI._service_write_state(env, AGI._service_state_payload(env))
+
+    async def _close_connections():
+        return None
+
+    monkeypatch.setattr(AGI, "_close_all_connections", staticmethod(_close_connections))
+    monkeypatch.setattr(AGI, "_runtime_cleanup_task", None, raising=False)
+    monkeypatch.setattr(AGI, "_runtime_cleanup_phase", None, raising=False)
+    monkeypatch.setattr(AGI, "_worker_launch_tasks", [], raising=False)
+    monkeypatch.setattr(AGI, "_scheduler_launch_tasks", [], raising=False)
+    monkeypatch.setattr(AGI, "_startup_in_progress", False, raising=False)
+
+    clear_calls = 0
+    real_clear_state = AGI._service_clear_state
+
+    def _clear_state(service_env):
+        nonlocal clear_calls
+        clear_calls += 1
+        if clear_calls == 1:
+            raise service_state_support.ServiceStateUnavailableError(
+                "state unlink remains locked"
+            )
+        real_clear_state(service_env)
+
+    monkeypatch.setattr(AGI, "_service_clear_state", staticmethod(_clear_state))
+
+    with pytest.raises(
+        service_state_support.ServiceStateUnavailableError,
+        match="state unlink remains locked",
+    ):
+        await AGI.serve(env, action="stop", shutdown_on_stop=True)
+
+    assert client.status == "closed"
+    assert client.shutdown_calls == 1
+    assert AGI._dask_client is None
+    assert AGI._service_futures == {worker: loop_future}
+    assert AGI._service_workers == [worker]
+    assert AGI._service_cleanup_unproven is True
+    assert AGI._lifecycle_service_token is not None
+
+    result = await AGI.serve(env, action="stop", shutdown_on_stop=True)
+
+    assert result["status"] == "stopped"
+    assert result["pending"] == []
+    assert client.shutdown_calls == 1
+    assert clear_calls == 2
+    assert AGI._service_futures == {}
+    assert AGI._service_workers == []
+    assert AGI._service_cleanup_unproven is False
+    assert AGI._lifecycle_service_token is None
+
+
+@pytest.mark.asyncio
+async def test_serve_stop_missing_future_retries_state_clear_from_shutdown_proof(
+    monkeypatch,
+):
+    env = _minimal_app_env()
+    worker = "127.0.0.1:8787"
+    client = _FakeClient([worker])
+    AGI._dask_client = client
+    AGI._service_futures = {}
+    AGI._service_workers = [worker]
+    AGI._service_write_state(
+        env,
+        {
+            "schema": "agi.service.state.v1",
+            "service_workers": [worker],
+            "service_loop_keys": {},
+        },
+    )
+
+    stop_calls = 0
+    clear_calls = 0
+    real_clear_state = AGI._service_clear_state
+
+    async def _stop():
+        nonlocal stop_calls
+        stop_calls += 1
+        AGI._dask_client = None
+
+    def _clear_state(service_env):
+        nonlocal clear_calls
+        clear_calls += 1
+        if clear_calls == 1:
+            raise service_state_support.ServiceStateUnavailableError(
+                "missing-Future state unlink remains locked"
+            )
+        real_clear_state(service_env)
+
+    monkeypatch.setattr(AGI, "_stop", staticmethod(_stop))
+    monkeypatch.setattr(AGI, "_service_clear_state", staticmethod(_clear_state))
+
+    with pytest.raises(
+        service_state_support.ServiceStateUnavailableError,
+        match="missing-Future state unlink remains locked",
+    ):
+        await AGI.serve(env, action="stop", shutdown_on_stop=True)
+
+    assert stop_calls == 1
+    assert AGI._dask_client is None
+    assert AGI._service_futures == {}
+    assert AGI._service_workers == [worker]
+    assert AGI._service_runtime_shutdown_proven is True
+    assert AGI._service_cleanup_unproven is True
+    assert AGI._lifecycle_service_token is not None
+
+    result = await AGI.serve(env, action="stop", shutdown_on_stop=True)
+
+    assert result["status"] == "stopped"
+    assert result["pending"] == []
+    assert stop_calls == 1
+    assert clear_calls == 2
+    assert AGI._service_futures == {}
+    assert AGI._service_workers == []
+    assert AGI._service_runtime_shutdown_proven is False
+    assert AGI._service_cleanup_unproven is False
+    assert AGI._lifecycle_service_token is None
 
 
 @pytest.mark.asyncio
@@ -640,6 +1349,7 @@ async def test_agi_serve_start_status_stop_supports_agidataworker(monkeypatch):
     env = AgiEnv(apps_path=Path("src/agilab/apps/builtin"), app="minimal_app_project", verbose=0)
     env.base_worker_cls = "AgiDataWorker"
     fake_client = _FakeClient(["127.0.0.1:8787"])
+    _install_fake_future_reacquisition(monkeypatch, fake_client)
 
     async def _fake_start(_scheduler):
         AGI._dask_client = fake_client
@@ -784,6 +1494,298 @@ async def test_agi_serve_start_uses_sync_when_client_already_running(monkeypatch
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "failure_stage",
+    ["queue-init", "loop-submit", "state-write", "final-response"],
+)
+async def test_serve_start_failure_releases_owned_runtime_and_futures(
+    monkeypatch,
+    tmp_path,
+    failure_stage,
+):
+    env = _minimal_app_env()
+    env.base_worker_cls = "PandasWorker"
+    calls = {"stop": 0, "clear": 0, "reset": 0, "clean_job": 0}
+
+    class _StartupClient(_FakeClient):
+        def __init__(self):
+            super().__init__(["127.0.0.1:8787", "127.0.0.1:8788"])
+            self.loop_futures: list[_FakeFuture] = []
+
+        def submit(self, *args, **kwargs):
+            fn = args[0] if args else None
+            if getattr(fn, "__name__", "") == "loop":
+                if failure_stage == "loop-submit" and self.loop_futures:
+                    raise RuntimeError("injected loop-submit failure")
+                future = _FakeFuture()
+                self.loop_futures.append(future)
+                return future
+            return super().submit(*args, **kwargs)
+
+    client = _StartupClient()
+
+    async def _recover(*_args, **_kwargs):
+        return False
+
+    async def _start(_scheduler):
+        AGI._dask_client = client
+
+    async def _stop():
+        calls["stop"] += 1
+
+    monkeypatch.setattr(AGI, "_service_recover", staticmethod(_recover))
+    monkeypatch.setattr(AGI, "_start", staticmethod(_start))
+    monkeypatch.setattr(AGI, "_stop", staticmethod(_stop))
+    monkeypatch.setattr(
+        AGI,
+        "_service_clear_state",
+        staticmethod(lambda _env: calls.__setitem__("clear", calls["clear"] + 1)),
+    )
+    monkeypatch.setattr(
+        AGI,
+        "_reset_service_queue_state",
+        staticmethod(lambda: calls.__setitem__("reset", calls["reset"] + 1)),
+    )
+    monkeypatch.setattr(
+        AGI,
+        "_clean_job",
+        staticmethod(lambda *_args, **_kwargs: calls.__setitem__("clean_job", calls["clean_job"] + 1)),
+    )
+
+    if failure_stage == "queue-init":
+        monkeypatch.setattr(
+            AGI,
+            "_init_service_queue",
+            staticmethod(
+                lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                    RuntimeError("injected queue-init failure")
+                )
+            ),
+        )
+
+    monkeypatch.setattr(
+        AGI,
+        "_service_write_state",
+        staticmethod(
+            lambda *_args, **_kwargs: (
+                (_ for _ in ()).throw(RuntimeError("injected state-write failure"))
+                if failure_stage == "state-write"
+                else None
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        AGI,
+        "_service_finalize_response",
+        staticmethod(
+            lambda _env, payload, **_kwargs: (
+                (_ for _ in ()).throw(RuntimeError("injected final-response failure"))
+                if failure_stage == "final-response"
+                else payload
+            )
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match=f"injected {failure_stage} failure"):
+        await service_lifecycle_support.serve(
+            AGI,
+            env,
+            workers={"127.0.0.1": 2},
+            mode=AGI.DASK_MODE,
+            action="start",
+            service_queue_dir=tmp_path / "queue",
+            background_job_manager_factory=lambda: object(),
+        )
+
+    assert calls["stop"] == 1
+    assert calls["clear"] == 1
+    assert calls["reset"] == 1
+    assert calls["clean_job"] == 1
+    assert AGI._service_futures == {}
+    assert AGI._service_workers == []
+    if failure_stage == "loop-submit":
+        assert len(client.loop_futures) == 1
+    if failure_stage in {"loop-submit", "state-write", "final-response"}:
+        assert client.loop_futures
+        assert all(future.cancel_calls == 1 for future in client.loop_futures)
+
+
+@pytest.mark.asyncio
+async def test_failed_start_cleanup_retains_ownership_when_runtime_stop_is_unproven():
+    warnings = []
+
+    class _BadFuture:
+        def cancel(self):
+            raise RuntimeError("cancel cleanup failed")
+
+    async def _bad_stop():
+        raise RuntimeError("runtime cleanup failed")
+
+    def _raise(message):
+        raise RuntimeError(message)
+
+    agi = SimpleNamespace(
+        _service_futures={"worker": object()},
+        _service_workers=["worker"],
+        _jobs=object(),
+        _service_clear_state=lambda _env: _raise("state cleanup must remain retained"),
+        _reset_service_queue_state=lambda: _raise("queue cleanup must remain retained"),
+        _stop=_bad_stop,
+        _clean_job=lambda _force: _raise("job cleanup failed"),
+    )
+    future = _BadFuture()
+
+    await service_lifecycle_support._cleanup_failed_service_start(
+        agi,
+        env=object(),
+        owned_futures={"worker": future},
+        runtime_started_here=True,
+        log=SimpleNamespace(
+            warning=lambda message, *args: warnings.append(message % args if args else message)
+        ),
+    )
+
+    assert agi._service_futures == {"worker": future}
+    assert agi._service_workers == ["worker"]
+    assert agi._service_cleanup_unproven is True
+    assert len(warnings) == 3
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("runtime_stop_fails", [False, True])
+async def test_failed_start_on_reused_runtime_uses_shutdown_for_unpublished_future(
+    monkeypatch,
+    tmp_path,
+    runtime_stop_fails,
+):
+    env = _minimal_app_env()
+    env.base_worker_cls = "PandasWorker"
+    cleanup_calls = {"clear": 0, "reset": 0, "stop": 0}
+
+    class _RunningAfterCancelFuture(_FakeFuture):
+        def __init__(self):
+            super().__init__(status="running", key="reused-runtime-loop")
+
+        def cancel(self):
+            self.cancel_calls += 1
+            # Dask can acknowledge client-side cancellation while the worker
+            # function continues to execute. Keep the execution status running
+            # to reproduce that distinction.
+
+    class _ReusedClient(_FakeClient):
+        def __init__(self):
+            super().__init__(["127.0.0.1:8787"])
+            self.loop_future = _RunningAfterCancelFuture()
+            self.break_futures: list[_FakeFuture] = []
+
+        def submit(self, *args, **kwargs):
+            fn = args[0] if args else None
+            fn_name = getattr(fn, "__name__", "")
+            self.submissions.append(
+                {"fn": fn_name, "args": args[1:], "kwargs": kwargs}
+            )
+            if fn_name == "loop":
+                return self.loop_future
+            if fn_name == "break_loop":
+                future = _FakeFuture(status="finished")
+                self.break_futures.append(future)
+                return future
+            return _FakeFuture(status="finished")
+
+    client = _ReusedClient()
+    AGI._dask_client = client
+
+    async def _recover(*_args, **_kwargs):
+        return False
+
+    async def _sync():
+        return None
+
+    async def _stop():
+        cleanup_calls["stop"] += 1
+        if runtime_stop_fails:
+            raise RuntimeError("injected full runtime stop failure")
+        client.loop_future.status = "finished"
+        AGI._dask_client = None
+
+    def _wait(futures, **_kwargs):
+        if all(future in client.break_futures for future in futures):
+            return set(futures), set()
+        return set(), set(futures)
+
+    monkeypatch.setattr(AGI, "_service_recover", staticmethod(_recover))
+    monkeypatch.setattr(AGI, "_sync", staticmethod(_sync))
+    monkeypatch.setattr(AGI, "_stop", staticmethod(_stop))
+    monkeypatch.setattr(
+        AGI,
+        "_service_write_state",
+        staticmethod(
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                RuntimeError("injected state-write failure")
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        AGI,
+        "_service_clear_state",
+        staticmethod(
+            lambda _env: cleanup_calls.__setitem__(
+                "clear",
+                cleanup_calls["clear"] + 1,
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        AGI,
+        "_reset_service_queue_state",
+        staticmethod(
+            lambda: cleanup_calls.__setitem__(
+                "reset",
+                cleanup_calls["reset"] + 1,
+            )
+        ),
+    )
+    monkeypatch.setattr(AGI, "_clean_job", staticmethod(lambda *_args, **_kwargs: None))
+
+    with pytest.raises(RuntimeError, match="injected state-write failure"):
+        await service_lifecycle_support.serve(
+            AGI,
+            env,
+            workers={"127.0.0.1": 1},
+            mode=AGI.DASK_MODE,
+            action="start",
+            service_queue_dir=tmp_path / "queue",
+            background_job_manager_factory=lambda: object(),
+            wait_fn=_wait,
+        )
+
+    break_submissions = [
+        submission
+        for submission in client.submissions
+        if submission["fn"] == "break_loop"
+    ]
+    assert len(break_submissions) == 1
+    assert break_submissions[0]["kwargs"]["workers"] == ["127.0.0.1:8787"]
+    assert break_submissions[0]["kwargs"]["allow_other_workers"] is False
+    assert client.loop_future.cancel_calls == 1
+    assert cleanup_calls["stop"] == 1
+    if runtime_stop_fails:
+        assert client.loop_future.status == "running"
+        assert AGI._service_futures == {"127.0.0.1:8787": client.loop_future}
+        assert AGI._service_workers == ["127.0.0.1:8787"]
+        assert AGI._service_cleanup_unproven is True
+        assert AGI._service_runtime_shutdown_proven is False
+        assert cleanup_calls == {"clear": 0, "reset": 0, "stop": 1}
+    else:
+        assert client.loop_future.status == "finished"
+        assert AGI._service_futures == {}
+        assert AGI._service_workers == []
+        assert AGI._service_cleanup_unproven is False
+        assert AGI._service_runtime_shutdown_proven is False
+        assert cleanup_calls == {"clear": 1, "reset": 1, "stop": 1}
+
+
+@pytest.mark.asyncio
 async def test_agi_serve_start_raises_when_client_not_obtained(monkeypatch):
     env = AgiEnv(apps_path=Path("src/agilab/apps/builtin"), app="minimal_app_project", verbose=0)
     env.base_worker_cls = "PandasWorker"
@@ -795,11 +1797,19 @@ async def test_agi_serve_start_raises_when_client_not_obtained(monkeypatch):
     async def _start(_scheduler):
         return True
 
+    cleanup_calls = []
+
+    async def _stop():
+        cleanup_calls.append("stop")
+
     monkeypatch.setattr(AGI, "_service_recover", staticmethod(_recover))
     monkeypatch.setattr(AGI, "_start", staticmethod(_start))
+    monkeypatch.setattr(AGI, "_stop", staticmethod(_stop))
 
     with pytest.raises(RuntimeError, match=r"Failed to obtain Dask client"):
         await AGI.serve(env, action="start", workers={"127.0.0.1": 1}, mode=AGI.DASK_MODE)
+    assert cleanup_calls == ["stop"]
+    assert AGI._startup_in_progress is False
 
 
 @pytest.mark.asyncio
@@ -994,6 +2004,7 @@ async def test_agi_serve_status_recovers_persistent_state(monkeypatch, tmp_path)
             "scheduler_port": 8786,
             "workers": {"127.0.0.1": 1},
             "service_workers": ["127.0.0.1:8787"],
+            "service_loop_keys": {"127.0.0.1:8787": "persisted-loop-8787"},
             "queue_dir": str(queue_dir),
             "args": {},
             "poll_interval": 1.0,
@@ -1003,16 +2014,96 @@ async def test_agi_serve_status_recovers_persistent_state(monkeypatch, tmp_path)
     )
 
     fake_client = _FakeClient(["127.0.0.1:8787"])
+    _install_fake_future_reacquisition(monkeypatch, fake_client)
 
     async def _fake_connect(*_args, **_kwargs):
         return fake_client
 
     monkeypatch.setattr(AGI, "_connect_scheduler_with_retry", staticmethod(_fake_connect))
+    recovery_calls = []
+    monkeypatch.setattr(
+        AGI,
+        "_recover_orphaned_service_tasks",
+        staticmethod(lambda: recovery_calls.append("recover") or {"recovered": 0, "preserved": 0}),
+    )
 
     status = await AGI.serve(env, action="status")
     assert status["status"] == "running"
     assert status["workers"] == ["127.0.0.1:8787"]
     assert status["queue_dir"] == str(queue_dir)
+    assert recovery_calls == ["recover"]
+    assert AGI._service_futures["127.0.0.1:8787"].key == "persisted-loop-8787"
+
+    stopped = await AGI.serve(env, action="stop", shutdown_on_stop=False)
+    assert stopped["status"] == "stopped"
+    assert stopped["pending"] == []
+    assert AGI._service_read_state(env) is None
+
+
+@pytest.mark.asyncio
+async def test_serve_status_reports_recovery_required_for_legacy_ownership(
+    monkeypatch,
+    tmp_path,
+):
+    env = _minimal_app_env()
+    worker = "127.0.0.1:8787"
+    queue_dir = tmp_path / "service_queue"
+    queue_dir.mkdir(parents=True)
+    AGI._service_write_state(
+        env,
+        {
+            "schema": "agi.service.state.v1",
+            "target": env.target,
+            "app": env.app,
+            "mode": AGI.DASK_MODE,
+            "run_type": "run --no-sync",
+            "scheduler": "127.0.0.1:8786",
+            "workers": {"127.0.0.1": 1},
+            "service_workers": [worker],
+            "queue_dir": str(queue_dir),
+            "args": {},
+        },
+    )
+    client = _FakeClient([worker])
+
+    async def _connect(*_args, **_kwargs):
+        return client
+
+    async def _unexpected_restart(*_args, **_kwargs):
+        raise AssertionError("auto-restart must not run without Future ownership")
+
+    monkeypatch.setattr(AGI, "_connect_scheduler_with_retry", staticmethod(_connect))
+    monkeypatch.setattr(
+        AGI,
+        "_service_auto_restart_unhealthy",
+        staticmethod(_unexpected_restart),
+    )
+
+    status = await AGI.serve(env, action="status")
+
+    assert status["status"] == "error"
+    assert status["recovery_required"] is True
+    assert status["pending"] == [worker]
+    assert AGI._service_workers == [worker]
+    assert AGI._service_futures == {}
+    assert AGI._service_cleanup_unproven is True
+    assert AGI._lifecycle_service_token is not None
+
+
+@pytest.mark.asyncio
+async def test_serve_status_treats_unreadable_state_as_retained_ownership():
+    env = _minimal_app_env()
+    state_path = AGI._service_state_path(env)
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text("{not-json", encoding="utf-8")
+
+    status = await AGI.serve(env, action="status")
+
+    assert status["status"] == "error"
+    assert status["recovery_required"] is True
+    assert AGI._service_cleanup_unproven is True
+    assert AGI._lifecycle_service_token is not None
+    assert state_path.exists()
 
 
 @pytest.mark.asyncio
@@ -1035,6 +2126,7 @@ async def test_agi_submit_recovers_persistent_state(monkeypatch, tmp_path):
             "scheduler_port": 8786,
             "workers": {"127.0.0.1": 1},
             "service_workers": ["127.0.0.1:8787"],
+            "service_loop_keys": {"127.0.0.1:8787": "persisted-loop-8787"},
             "queue_dir": str(queue_dir),
             "args": {},
             "poll_interval": 1.0,
@@ -1044,6 +2136,7 @@ async def test_agi_submit_recovers_persistent_state(monkeypatch, tmp_path):
     )
 
     fake_client = _FakeClient(["127.0.0.1:8787"])
+    _install_fake_future_reacquisition(monkeypatch, fake_client)
 
     async def _fake_connect(*_args, **_kwargs):
         return fake_client
@@ -1083,6 +2176,7 @@ async def test_agi_status_auto_restarts_stale_heartbeat(monkeypatch, tmp_path):
             "scheduler_port": 8786,
             "workers": {"127.0.0.1": 1},
             "service_workers": ["127.0.0.1:8787"],
+            "service_loop_keys": {"127.0.0.1:8787": "persisted-loop-8787"},
             "queue_dir": str(queue_dir),
             "args": {},
             "poll_interval": 0.1,
@@ -1107,6 +2201,7 @@ async def test_agi_status_auto_restarts_stale_heartbeat(monkeypatch, tmp_path):
     )
 
     fake_client = _FakeClient(["127.0.0.1:8787"])
+    _install_fake_future_reacquisition(monkeypatch, fake_client)
 
     async def _fake_connect(*_args, **_kwargs):
         return fake_client
@@ -1228,7 +2323,7 @@ async def test_agi_service_real_dask_e2e_self_heal_submit_stop(monkeypatch, tmp_
 
 
 @pytest.mark.asyncio
-async def test_service_recover_missing_scheduler_cleans_stale_state(monkeypatch, tmp_path):
+async def test_service_recover_missing_scheduler_preserves_ownership(monkeypatch, tmp_path):
     env = AgiEnv(apps_path=Path("src/agilab/apps/builtin"), app="minimal_app_project", verbose=0)
     queue_root = tmp_path / "queue"
     queue_root.mkdir(parents=True, exist_ok=True)
@@ -1261,8 +2356,50 @@ async def test_service_recover_missing_scheduler_cleans_stale_state(monkeypatch,
     recovered = await AGI._service_recover(env, allow_stale_cleanup=True)
 
     assert recovered is False
-    assert calls["cleared"] == 1
-    assert calls["reset"] == 1
+    assert calls == {"cleared": 0, "reset": 0}
+    assert AGI._service_cleanup_unproven is True
+
+
+@pytest.mark.asyncio
+async def test_serve_stop_transient_recovery_failure_preserves_state_and_lease(
+    monkeypatch,
+    tmp_path,
+):
+    env = _minimal_app_env()
+    queue_root = tmp_path / "queue"
+    queue_root.mkdir(parents=True)
+    state_path = AGI._service_state_path(env)
+    AGI._service_write_state(
+        env,
+        {
+            "schema": "agi.service.state.v1",
+            "target": env.target,
+            "app": env.app,
+            "mode": AGI.DASK_MODE,
+            "run_type": "run --no-sync",
+            "scheduler": "127.0.0.1:8786",
+            "workers": {"127.0.0.1": 1},
+            "service_workers": ["127.0.0.1:8787"],
+            "service_loop_keys": {"127.0.0.1:8787": "persisted-loop-8787"},
+            "queue_dir": str(queue_root),
+            "args": {},
+        },
+    )
+
+    async def _fail_connect(*_args, **_kwargs):
+        raise RuntimeError("transient scheduler connection failure")
+
+    monkeypatch.setattr(AGI, "_connect_scheduler_with_retry", staticmethod(_fail_connect))
+
+    result = await AGI.serve(env, action="stop", shutdown_on_stop=True)
+
+    assert result["status"] == "error"
+    assert result["recovery_required"] is True
+    assert result["pending"] == ["127.0.0.1:8787"]
+    assert AGI._service_workers == ["127.0.0.1:8787"]
+    assert AGI._service_cleanup_unproven is True
+    assert AGI._lifecycle_service_token is not None
+    assert state_path.exists()
 
 
 @pytest.mark.asyncio
@@ -1324,31 +2461,101 @@ async def test_serve_status_reports_missing_client_and_future_states(monkeypatch
 
 
 @pytest.mark.asyncio
+async def test_serve_status_reports_dead_retained_launch_ownership(monkeypatch):
+    env = AgiEnv(apps_path=Path("src/agilab/apps/builtin"), app="minimal_app_project", verbose=0)
+
+    class _DoneLaunchTask:
+        def done(self):
+            return True
+
+        def cancelled(self):
+            return False
+
+        def exception(self):
+            return ConnectionError("scheduler transport exited")
+
+    AGI._service_workers = ["w1"]
+    AGI._service_futures = {"w1": _FakeFuture(status="running")}
+    AGI._dask_client = SimpleNamespace(status="running")
+    AGI._scheduler_launch_tasks = {_DoneLaunchTask()}
+    monkeypatch.setattr(
+        AGI,
+        "_service_finalize_response",
+        staticmethod(lambda _env, payload, **_kwargs: payload),
+    )
+
+    result = await service_lifecycle_support.serve(
+        AGI,
+        env,
+        action="status",
+        background_job_manager_factory=lambda: object(),
+    )
+
+    assert result["status"] == "error"
+    assert result["launch_errors"] == ["scheduler transport exited"]
+    assert "action='stop'" in result["message"]
+
+    with pytest.raises(RuntimeError, match="launch ownership is unhealthy"):
+        await service_lifecycle_support.serve(
+            AGI,
+            env,
+            action="start",
+            background_job_manager_factory=lambda: object(),
+        )
+
+
+@pytest.mark.asyncio
 async def test_serve_stop_handles_partial_timeout_and_empty_future_map(monkeypatch):
     env = AgiEnv(apps_path=Path("src/agilab/apps/builtin"), app="minimal_app_project", verbose=0)
-    AGI._dask_client = SimpleNamespace(
-        submit=lambda *_args, **_kwargs: _FakeFuture(status="submitted"),
-        gather=lambda *_args, **_kwargs: None,
-    )
-    AGI._service_futures = {"w1": _FakeFuture(status="running"), "w2": _FakeFuture(status="running")}
+    class _PartialStopClient:
+        def submit(self, fn, *_args, **_kwargs):
+            return _FakeFuture(
+                status="finished",
+                kind=getattr(fn, "__name__", ""),
+            )
+
+        def gather(self, *_args, **_kwargs):
+            return None
+
+        def scheduler_info(self):
+            return {"workers": {"tcp://w1": {}, "tcp://w2": {}}}
+
+    AGI._dask_client = _PartialStopClient()
+    first = _FakeFuture(status="running", key="loop-w1")
+    second = _FakeFuture(status="running", key="loop-w2")
+    AGI._service_futures = {"w1": first, "w2": second}
     AGI._service_workers = ["w1", "w2"]
     warnings = []
     stops = []
+    cleanups = {"clear": 0, "reset": 0}
 
     monkeypatch.setattr(AGI, "_service_finalize_response", staticmethod(lambda _env, payload, **_kwargs: payload))
-    monkeypatch.setattr(AGI, "_service_clear_state", staticmethod(lambda _env: None))
-    monkeypatch.setattr(AGI, "_reset_service_queue_state", staticmethod(lambda: None))
+    monkeypatch.setattr(
+        AGI,
+        "_service_clear_state",
+        staticmethod(lambda _env: cleanups.__setitem__("clear", cleanups["clear"] + 1)),
+    )
+    monkeypatch.setattr(
+        AGI,
+        "_reset_service_queue_state",
+        staticmethod(lambda: cleanups.__setitem__("reset", cleanups["reset"] + 1)),
+    )
+    monkeypatch.setattr(AGI, "_service_write_state", staticmethod(lambda *_args: None))
 
     async def _fake_stop():
         stops.append("stop")
 
     monkeypatch.setattr(AGI, "_stop", staticmethod(_fake_stop))
 
+    def _partial_wait(futures, **_kwargs):
+        futures[0].status = "finished"
+        return {futures[0]}, set(futures[1:])
+
     result = await service_lifecycle_support.serve(
         AGI,
         env,
         action="stop",
-        wait_fn=lambda futures, **_kwargs: ({next(iter(futures))}, set(list(futures)[1:])),
+        wait_fn=_partial_wait,
         log=SimpleNamespace(
             info=lambda *_args, **_kwargs: None,
             warning=lambda message, *args: warnings.append(message % args if args else message),
@@ -1360,10 +2567,15 @@ async def test_serve_stop_handles_partial_timeout_and_empty_future_map(monkeypat
     assert result["status"] == "partial"
     assert result["pending"] == ["w2"]
     assert warnings
-    assert stops == ["stop"]
+    assert stops == []
+    assert cleanups == {"clear": 0, "reset": 0}
+    assert AGI._service_futures == {"w2": second}
+    assert AGI._service_workers == ["w2"]
+    assert AGI._service_cleanup_unproven is True
 
     AGI._service_futures = {}
     AGI._service_workers = ["w3"]
+    AGI._service_cleanup_unproven = False
     result = await service_lifecycle_support.serve(
         AGI,
         env,
@@ -1377,9 +2589,12 @@ async def test_serve_stop_handles_partial_timeout_and_empty_future_map(monkeypat
         background_job_manager_factory=lambda: object(),
     )
 
-    assert result["status"] == "stopped"
-    assert result["workers"] == ["w3"]
-    assert result["pending"] == []
+    assert result["status"] == "partial"
+    assert result["workers"] == []
+    assert result["pending"] == ["w3"]
+    assert result["recovery_required"] is True
+    assert AGI._service_workers == ["w3"]
+    assert AGI._service_cleanup_unproven is True
 
 
 @pytest.mark.asyncio
@@ -1494,7 +2709,10 @@ async def test_serve_stop_handles_wait_timeout_error_as_partial(monkeypatch):
     assert result["status"] == "partial"
     assert result["workers"] == ["w-done"]
     assert result["pending"] == ["w-stuck"]
-    assert cleanups == {"clear_state": 1, "reset_queue": 1}
+    assert cleanups == {"clear_state": 0, "reset_queue": 0}
+    assert AGI._service_futures == {"w-stuck": pending}
+    assert AGI._service_workers == ["w-stuck"]
+    assert AGI._service_cleanup_unproven is True
 
 
 @pytest.mark.asyncio

--- a/src/agilab/core/test/test_agi_distributor_service_runtime_support.py
+++ b/src/agilab/core/test/test_agi_distributor_service_runtime_support.py
@@ -32,6 +32,7 @@ def test_service_runtime_support_reexports_service_helpers(monkeypatch):
     }
     state_exports = {
         "init_service_queue",
+        "recover_orphaned_service_tasks",
         "reset_service_queue_state",
         "service_apply_queue_root",
         "service_apply_runtime_config",

--- a/src/agilab/core/test/test_agi_distributor_service_state_support.py
+++ b/src/agilab/core/test/test_agi_distributor_service_state_support.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import builtins
 import json
 import os
 import time
@@ -24,7 +25,8 @@ def _build_env(
     resolve_share_path=None,
 ):
     if resolve_share_path is None:
-        resolve_share_path = lambda rel: tmp_path / "share" / rel
+        def resolve_share_path(rel):
+            return tmp_path / "share" / rel
     return SimpleNamespace(
         target=target,
         app=app,
@@ -174,17 +176,55 @@ def test_service_safe_worker_name_fallback_and_explicit_timeout():
     assert service_state_support.service_safe_worker_name(":::") == "worker"
 
 
-def test_service_read_state_returns_none_for_invalid_payload(tmp_path):
+def test_service_read_state_raises_for_unreadable_or_invalid_payload(tmp_path):
     agi = _build_agi()
     env = _build_env(tmp_path)
     state_path = tmp_path / "state.json"
     agi._service_state_path = lambda _env: state_path
 
     state_path.write_text("not-json", encoding="utf-8")
-    assert service_state_support.service_read_state(agi, env) is None
+    with pytest.raises(service_state_support.ServiceStateUnavailableError):
+        service_state_support.service_read_state(agi, env)
 
     state_path.write_text(json.dumps(["not-a-dict"]), encoding="utf-8")
+    with pytest.raises(service_state_support.ServiceStateUnavailableError):
+        service_state_support.service_read_state(agi, env)
+
+    state_path.unlink()
     assert service_state_support.service_read_state(agi, env) is None
+
+
+def test_service_read_state_uses_bounded_sharing_retry(monkeypatch, tmp_path):
+    agi = _build_agi()
+    env = _build_env(tmp_path)
+    state_path = tmp_path / "service_state.json"
+    state_path.write_text('{"schema": "x"}', encoding="utf-8")
+    agi._service_state_path = lambda _env: state_path
+    real_open = builtins.open
+    attempts = {"open": 0, "retry": 0}
+
+    def _transient_open(*args, **kwargs):
+        attempts["open"] += 1
+        if attempts["open"] == 1:
+            raise PermissionError("sharing violation")
+        return real_open(*args, **kwargs)
+
+    def _bounded_retry(operation):
+        attempts["retry"] += 1
+        try:
+            return operation()
+        except PermissionError:
+            return operation()
+
+    monkeypatch.setattr(builtins, "open", _transient_open)
+    monkeypatch.setattr(
+        service_state_support,
+        "run_with_windows_file_sharing_retry",
+        _bounded_retry,
+    )
+
+    assert service_state_support.service_read_state(agi, env) == {"schema": "x"}
+    assert attempts == {"open": 2, "retry": 1}
 
 
 def test_service_write_state_roundtrip_and_clear(tmp_path):
@@ -259,7 +299,7 @@ def test_atomic_write_ignores_temp_cleanup_failures(monkeypatch, tmp_path):
         )
 
 
-def test_service_clear_state_logs_oserror(monkeypatch, tmp_path):
+def test_service_clear_state_raises_on_unlink_failure(monkeypatch, tmp_path):
     agi = _build_agi()
     env = _build_env(tmp_path)
     state_path = tmp_path / "service_state.json"
@@ -275,13 +315,22 @@ def test_service_clear_state_logs_oserror(monkeypatch, tmp_path):
 
     monkeypatch.setattr(Path, "unlink", _fake_unlink)
 
-    service_state_support.service_clear_state(
-        agi,
-        env,
-        log=SimpleNamespace(debug=lambda message, *args: logs.append(message % args if args else message)),
-    )
+    with pytest.raises(
+        service_state_support.ServiceStateUnavailableError,
+        match="could not be removed",
+    ):
+        service_state_support.service_clear_state(
+            agi,
+            env,
+            log=SimpleNamespace(
+                warning=lambda message, *args: logs.append(
+                    message % args if args else message
+                )
+            ),
+        )
 
     assert logs and "Failed to remove service state file" in logs[0]
+    assert state_path.exists()
 
 
 def test_service_finalize_response_health_only_adds_export_path():
@@ -420,7 +469,7 @@ def test_service_queue_counts_reads_task_files(tmp_path):
     }
 
 
-def test_init_service_queue_removes_stale_pending_running_and_heartbeats(tmp_path):
+def test_init_service_queue_preserves_pending_running_and_heartbeats(tmp_path):
     agi = _build_agi()
     env = _build_env(tmp_path, target="minimal_app_project", app="minimal_app_project")
     queue_root = tmp_path / "queue"
@@ -437,12 +486,12 @@ def test_init_service_queue_removes_stale_pending_running_and_heartbeats(tmp_pat
     queue_paths = service_state_support.init_service_queue(agi, env, service_queue_dir=queue_root)
 
     assert queue_paths["root"] == queue_root
-    assert stale_pending.exists() is False
-    assert stale_running.exists() is False
-    assert stale_heartbeat.exists() is False
+    assert stale_pending.exists() is True
+    assert stale_running.exists() is True
+    assert stale_heartbeat.exists() is True
 
 
-def test_init_service_queue_ignores_missing_files_during_cleanup(monkeypatch, tmp_path):
+def test_init_service_queue_does_not_unlink_existing_files(monkeypatch, tmp_path):
     agi = _build_agi()
     env = _build_env(tmp_path, target="minimal_app_project", app="minimal_app_project")
     queue_root = tmp_path / "queue"
@@ -467,6 +516,289 @@ def test_init_service_queue_ignores_missing_files_during_cleanup(monkeypatch, tm
     queue_paths = service_state_support.init_service_queue(agi, env, service_queue_dir=queue_root)
 
     assert queue_paths["root"] == queue_root
+
+
+def test_recover_orphaned_service_tasks_preserves_live_and_fails_expired(tmp_path):
+    agi = _build_agi()
+    env = _build_env(tmp_path)
+    paths = service_state_support.init_service_queue(
+        agi,
+        env,
+        service_queue_dir=tmp_path / "queue",
+    )
+    now = time.time()
+    expired = paths["running"] / "expired.task.json"
+    live = paths["running"] / "live.task.json"
+    pending = paths["pending"] / "pending.task.json"
+    expired.write_text(json.dumps({"schema": "agi.service.task.v1", "worker": "dead"}), encoding="utf-8")
+    live.write_text(
+        json.dumps(
+            {
+                "schema": "agi.service.task.v1",
+                "worker": "live",
+                "claim": {"worker_incarnation": "live-incarnation"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    pending.write_text(json.dumps({"schema": "agi.service.task.v1", "worker": "dead"}), encoding="utf-8")
+    os.utime(expired, (now - 30, now - 30))
+    os.utime(live, (now - 30, now - 30))
+    (paths["heartbeats"] / "live.json").write_text(
+        json.dumps(
+            {
+                "worker": "live",
+                "worker_incarnation": "live-incarnation",
+                "timestamp": now - 1,
+                "state": "running",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = service_state_support.recover_orphaned_service_tasks(
+        agi,
+        now=now,
+        heartbeat_timeout=10,
+    )
+
+    assert result == {"recovered": 1, "preserved": 1}
+    assert not expired.exists()
+    assert live.exists()
+    assert pending.exists()
+    failed_payload = json.loads((paths["failed"] / expired.name).read_text(encoding="utf-8"))
+    assert failed_payload["status"] == "failed"
+    assert failed_payload["recovery"]["reason"] == "expired-worker-heartbeat"
+
+
+def test_recover_orphaned_service_tasks_preserves_new_claim_without_heartbeat(tmp_path):
+    agi = _build_agi()
+    env = _build_env(tmp_path)
+    paths = service_state_support.init_service_queue(
+        agi,
+        env,
+        service_queue_dir=tmp_path / "queue",
+    )
+    running = paths["running"] / "new.task.json"
+    running.write_text(
+        json.dumps({"schema": "agi.service.task.v1", "worker": "starting"}),
+        encoding="utf-8",
+    )
+
+    result = service_state_support.recover_orphaned_service_tasks(
+        agi,
+        now=time.time(),
+        heartbeat_timeout=10,
+    )
+
+    assert result == {"recovered": 0, "preserved": 1}
+    assert running.exists()
+
+
+def test_recover_orphaned_service_tasks_rejects_replacement_worker_heartbeat(tmp_path):
+    agi = _build_agi()
+    env = _build_env(tmp_path)
+    paths = service_state_support.init_service_queue(
+        agi,
+        env,
+        service_queue_dir=tmp_path / "queue",
+    )
+    now = time.time()
+    running = paths["running"] / "old-incarnation.task.json"
+    running.write_text(
+        json.dumps(
+            {
+                "schema": "agi.service.task.v1",
+                "worker": "worker-1",
+                "claim": {"worker_incarnation": "old-incarnation"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    os.utime(running, (now - 30, now - 30))
+    (paths["heartbeats"] / "worker-1.json").write_text(
+        json.dumps(
+            {
+                "worker": "worker-1",
+                "worker_incarnation": "replacement-incarnation",
+                "timestamp": now,
+                "state": "processing",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = service_state_support.recover_orphaned_service_tasks(
+        agi,
+        now=now,
+        heartbeat_timeout=10,
+    )
+
+    assert result == {"recovered": 1, "preserved": 0}
+    assert not running.exists()
+    assert (paths["failed"] / running.name).exists()
+
+
+def test_recover_orphaned_service_tasks_rechecks_racing_heartbeat(tmp_path):
+    agi = _build_agi()
+    env = _build_env(tmp_path)
+    paths = service_state_support.init_service_queue(
+        agi,
+        env,
+        service_queue_dir=tmp_path / "queue",
+    )
+    now = time.time()
+    running = paths["running"] / "racing.task.json"
+    running.write_text(
+        json.dumps(
+            {
+                "schema": "agi.service.task.v1",
+                "worker": "worker-1",
+                "claim": {"worker_incarnation": "incarnation-1"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    os.utime(running, (now - 30, now - 30))
+    reads = iter(
+        [
+            {
+                "worker-1": {
+                    "worker_incarnation": "incarnation-1",
+                    "timestamp": now - 30,
+                    "state": "processing",
+                }
+            },
+            {
+                "worker-1": {
+                    "worker_incarnation": "incarnation-1",
+                    "timestamp": now,
+                    "state": "processing",
+                }
+            },
+        ]
+    )
+    agi._service_read_heartbeat_payloads = lambda: next(reads)
+
+    result = service_state_support.recover_orphaned_service_tasks(
+        agi,
+        now=now,
+        heartbeat_timeout=10,
+    )
+
+    assert result == {"recovered": 0, "preserved": 1}
+    assert running.exists()
+    assert list(paths["running"].glob("*.recovery-*.tmp")) == []
+
+
+def test_recover_orphaned_service_tasks_restores_stranded_hidden_claim(tmp_path):
+    agi = _build_agi()
+    env = _build_env(tmp_path)
+    paths = service_state_support.init_service_queue(
+        agi,
+        env,
+        service_queue_dir=tmp_path / "queue",
+    )
+    now = time.time()
+    task_name = "stranded.task.json"
+    hidden_claim = paths["running"] / f".{task_name}.recovery-crashed.tmp"
+    hidden_claim.write_text(
+        json.dumps(
+            {
+                "schema": "agi.service.task.v1",
+                "worker": "worker-1",
+                "claim": {"worker_incarnation": "incarnation-1"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    os.utime(hidden_claim, (now - 30, now - 30))
+
+    result = service_state_support.recover_orphaned_service_tasks(
+        agi,
+        now=now,
+        heartbeat_timeout=10,
+    )
+
+    assert result == {"recovered": 1, "preserved": 0}
+    assert not hidden_claim.exists()
+    assert not (paths["running"] / task_name).exists()
+    assert (paths["failed"] / task_name).exists()
+
+
+def test_recover_orphaned_service_tasks_completes_stranded_terminal_move(tmp_path):
+    agi = _build_agi()
+    env = _build_env(tmp_path)
+    paths = service_state_support.init_service_queue(
+        agi,
+        env,
+        service_queue_dir=tmp_path / "queue",
+    )
+    task_name = "terminal.task.json"
+    hidden_claim = paths["running"] / f".{task_name}.recovery-crashed.tmp"
+    running_payload = {
+        "schema": "agi.service.task.v1",
+        "task_id": "terminal-task",
+        "worker": "worker-1",
+        "claim": {"worker_incarnation": "incarnation-1"},
+    }
+    terminal_payload = {**running_payload, "status": "failed", "error": "work failed"}
+    hidden_claim.write_text(json.dumps(running_payload), encoding="utf-8")
+    (paths["failed"] / task_name).write_text(
+        json.dumps(terminal_payload),
+        encoding="utf-8",
+    )
+
+    result = service_state_support.recover_orphaned_service_tasks(agi)
+
+    assert result == {"recovered": 1, "preserved": 0}
+    assert not hidden_claim.exists()
+    assert json.loads((paths["failed"] / task_name).read_text(encoding="utf-8")) == terminal_payload
+
+
+def test_recover_orphaned_service_tasks_removes_verified_post_terminal_duplicate(tmp_path):
+    agi = _build_agi()
+    env = _build_env(tmp_path)
+    paths = service_state_support.init_service_queue(
+        agi,
+        env,
+        service_queue_dir=tmp_path / "queue",
+    )
+    now = time.time()
+    terminal_name = "completed.task.json"
+    running = paths["running"] / "completed.claim-abc.task.json"
+    claim = {
+        "worker_incarnation": "incarnation-1",
+        "task_filename": terminal_name,
+    }
+    running_payload = {
+        "schema": "agi.service.task.v1",
+        "task_id": "task-1",
+        "worker": "worker-1",
+        "claim": claim,
+    }
+    terminal_payload = {
+        **running_payload,
+        "status": "done",
+        "finished_at": now - 20,
+    }
+    running.write_text(json.dumps(running_payload), encoding="utf-8")
+    os.utime(running, (now - 30, now - 30))
+    (paths["done"] / terminal_name).write_text(
+        json.dumps(terminal_payload),
+        encoding="utf-8",
+    )
+
+    result = service_state_support.recover_orphaned_service_tasks(
+        agi,
+        now=now,
+        heartbeat_timeout=10,
+    )
+
+    assert result == {"recovered": 1, "preserved": 0}
+    assert not running.exists()
+    assert (paths["done"] / terminal_name).exists()
+    assert list(paths["failed"].glob("*.task.json")) == []
 
 
 def test_service_state_path_falls_back_when_resolve_share_path_is_missing(tmp_path):

--- a/src/agilab/core/test/test_base_worker_service_support.py
+++ b/src/agilab/core/test/test_base_worker_service_support.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import threading
 import time
 from pathlib import Path
@@ -74,6 +75,10 @@ def test_make_heartbeat_writer_persists_payload(tmp_path):
     heartbeat_payload = json.loads(heartbeat_files[0].read_text(encoding="utf-8"))
     assert heartbeat_payload["worker_id"] == 2
     assert heartbeat_payload["state"] == "stopped"
+    assert heartbeat_payload["worker_incarnation"] == getattr(
+        write_heartbeat,
+        "worker_incarnation",
+    )
 
 
 def test_service_loop_without_worker_override_stops_cleanly():
@@ -155,6 +160,220 @@ def test_service_loop_consumes_queued_tasks(tmp_path):
     payload_out = result.get("payload")
     assert isinstance(payload_out, dict)
     assert payload_out.get("processed") == 1
+
+
+def test_service_loop_refreshes_heartbeat_during_long_task(tmp_path):
+    worker = DummyWorker()
+    BaseWorker._worker_id = 0
+    BaseWorker._worker = "127.0.0.1:8787"
+    worker.args = SimpleNamespace(_agi_service_queue_dir=str(tmp_path / "service_queue"))
+    work_started = threading.Event()
+    release_work = threading.Event()
+
+    def _works(_plan, _metadata):
+        work_started.set()
+        assert release_work.wait(timeout=2)
+
+    worker.works = _works
+    queue_root = Path(worker.args._agi_service_queue_dir)
+    pending = queue_root / "pending"
+    pending.mkdir(parents=True, exist_ok=True)
+    task_file = pending / "000001-long-task.task.json"
+    _write_task(
+        task_file,
+        {
+            "worker_idx": 0,
+            "worker": "127.0.0.1:8787",
+            "plan": [],
+            "metadata": [],
+        },
+    )
+
+    loop_thread = threading.Thread(
+        target=lambda: BaseWorker.loop(poll_interval=0.05),
+        daemon=True,
+    )
+    loop_thread.start()
+    assert work_started.wait(timeout=2)
+
+    heartbeat_file = next((queue_root / "heartbeats").glob("*.json"))
+    first = json.loads(heartbeat_file.read_text(encoding="utf-8"))
+    deadline = time.time() + 2
+    refreshed = first
+    while time.time() < deadline and refreshed["timestamp"] <= first["timestamp"]:
+        time.sleep(0.05)
+        refreshed = json.loads(heartbeat_file.read_text(encoding="utf-8"))
+
+    assert refreshed["state"] == "processing"
+    assert refreshed["timestamp"] > first["timestamp"]
+    running_file = next((queue_root / "running").glob("*.task.json"))
+    running_payload = json.loads(running_file.read_text(encoding="utf-8"))
+    assert running_payload["claim"]["worker_incarnation"] == refreshed["worker_incarnation"]
+
+    release_work.set()
+    done_file = queue_root / "done" / task_file.name
+    deadline = time.time() + 2
+    while time.time() < deadline and not done_file.exists():
+        time.sleep(0.05)
+    assert done_file.exists()
+    assert BaseWorker.break_loop() is True
+    loop_thread.join(timeout=2)
+    assert not loop_thread.is_alive()
+
+
+@pytest.mark.parametrize("execution_fails", [False, True])
+def test_service_loop_preserves_running_claim_when_terminal_publication_fails(
+    tmp_path,
+    execution_fails,
+):
+    queue_root = tmp_path / "queue"
+    pending = queue_root / "pending"
+    pending.mkdir(parents=True)
+    task_file = pending / "000001-publication.task.json"
+    _write_task(
+        task_file,
+        {
+            "worker_idx": 0,
+            "worker": "worker-1",
+            "plan": [],
+            "metadata": [],
+        },
+    )
+    stop_event = threading.Event()
+    log_messages: list[str] = []
+
+    def _do_works(_plan, _metadata):
+        stop_event.set()
+        if execution_fails:
+            raise RuntimeError("work failed")
+        return ["ok"]
+
+    def _write_heartbeat(_state):
+        return None
+
+    setattr(_write_heartbeat, "worker_incarnation", "incarnation-1")
+
+    class _FailTerminalReplace:
+        @staticmethod
+        def replace(source, destination):
+            if Path(destination).parent.name in {"done", "failed"}:
+                raise OSError("terminal replace denied")
+            return os.replace(source, destination)
+
+    logger_obj = SimpleNamespace(
+        error=lambda *_args, **_kwargs: None,
+        exception=lambda message, *args, **_kwargs: log_messages.append(
+            message % args if args else message
+        ),
+    )
+
+    result = service_support.run_service_queue(
+        stop_event=stop_event,
+        queue_root=queue_root,
+        worker_id=0,
+        worker_name="worker-1",
+        poll=0.01,
+        do_works_fn=_do_works,
+        write_heartbeat=_write_heartbeat,
+        logger_obj=logger_obj,
+        os_module=_FailTerminalReplace,
+    )
+
+    running_path = next((queue_root / "running").glob("*.task.json"))
+    assert result == {"status": "stopped", "processed": 0, "failed": 0}
+    assert running_path.exists()
+    claim = json.loads(running_path.read_text(encoding="utf-8"))["claim"]
+    assert claim["worker_incarnation"] == "incarnation-1"
+    assert list(queue_root.rglob("*.tmp")) == []
+    assert not (queue_root / "done" / task_file.name).exists()
+    assert not (queue_root / "failed" / task_file.name).exists()
+    assert any("preserving the running claim" in message for message in log_messages)
+
+
+def test_service_payload_and_heartbeat_publications_flush_and_fsync(monkeypatch, tmp_path):
+    flush_paths = []
+    synced_dirs = []
+    real_flush = service_support._flush_and_fsync
+
+    def _record_flush(stream, *, os_module=os):
+        flush_paths.append(Path(stream.name))
+        real_flush(stream, os_module=os_module)
+
+    def _record_directory(path, *, os_module=os):
+        synced_dirs.append(Path(path))
+
+    monkeypatch.setattr(service_support, "_flush_and_fsync", _record_flush)
+    monkeypatch.setattr(service_support, "_fsync_directory", _record_directory)
+
+    queue_root = tmp_path / "queue"
+    write_heartbeat = service_support.make_heartbeat_writer(
+        queue_root,
+        worker_id=0,
+        worker_name="worker-1",
+        logger_obj=SimpleNamespace(debug=lambda *_args, **_kwargs: None),
+    )
+    write_heartbeat("running")
+    terminal_path = queue_root / "done" / "task.task.json"
+    terminal_path.parent.mkdir(parents=True)
+    service_support._dump_service_payload(
+        terminal_path,
+        {"schema": SERVICE_TASK_SCHEMA, "status": "done"},
+    )
+
+    assert len(flush_paths) == 2
+    assert all(path.name.endswith(".tmp") for path in flush_paths)
+    assert synced_dirs == [queue_root / "heartbeats", queue_root / "done"]
+
+
+def test_service_loop_unique_running_claim_does_not_overwrite_duplicate_name(tmp_path):
+    queue_root = tmp_path / "queue"
+    pending = queue_root / "pending"
+    running = queue_root / "running"
+    pending.mkdir(parents=True)
+    running.mkdir(parents=True)
+    task_file = pending / "duplicate.task.json"
+    stale_running = running / task_file.name
+    _write_task(
+        task_file,
+        {
+            "task_id": "new-task",
+            "worker_idx": 0,
+            "worker": "worker-1",
+            "plan": [],
+            "metadata": [],
+        },
+    )
+    stale_running.write_text("stale-running-evidence", encoding="utf-8")
+    stop_event = threading.Event()
+
+    def _do_works(_plan, _metadata):
+        stop_event.set()
+        return ["ok"]
+
+    def _write_heartbeat(_state):
+        return None
+
+    setattr(_write_heartbeat, "worker_incarnation", "incarnation-1")
+    result = service_support.run_service_queue(
+        stop_event=stop_event,
+        queue_root=queue_root,
+        worker_id=0,
+        worker_name="worker-1",
+        poll=0.01,
+        do_works_fn=_do_works,
+        write_heartbeat=_write_heartbeat,
+        logger_obj=SimpleNamespace(
+            error=lambda *_args, **_kwargs: None,
+            exception=lambda *_args, **_kwargs: None,
+        ),
+    )
+
+    assert result["processed"] == 1
+    assert stale_running.read_text(encoding="utf-8") == "stale-running-evidence"
+    terminal = json.loads((queue_root / "done" / task_file.name).read_text(encoding="utf-8"))
+    assert terminal["task_id"] == "new-task"
+    assert terminal["claim"]["task_filename"] == task_file.name
+    assert list(running.glob("*.claim-*.task.json")) == []
 
 
 def test_service_loop_moves_unreadable_task_to_failed(tmp_path):

--- a/src/agilab/dag/dag_distributed_submitter.py
+++ b/src/agilab/dag/dag_distributed_submitter.py
@@ -6,10 +6,13 @@ import os
 import subprocess
 import sys
 import threading
+import time
 import tomllib
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Mapping, TextIO
+
+from .dag_idempotency import execute_idempotently, write_json_atomic
 
 from agilab.orchestrate.orchestrate_page_support import compute_run_mode
 
@@ -100,6 +103,7 @@ def build_multi_app_dag_distributed_stage_submitter(
         artifact: dict[str, Any],
         execution_contract: dict[str, Any],
         timestamp: str,
+        idempotency_token: str,
     ) -> Mapping[str, Any]:
         return submit_distributed_stage(
             config=config,
@@ -111,6 +115,7 @@ def build_multi_app_dag_distributed_stage_submitter(
             artifact=artifact,
             execution_contract=execution_contract,
             timestamp=timestamp,
+            idempotency_token=idempotency_token,
         )
 
     return _submit_stage
@@ -164,14 +169,56 @@ def submit_distributed_stage(
     artifact: Mapping[str, Any],
     execution_contract: Mapping[str, Any],
     timestamp: str,
+    idempotency_token: str,
+) -> Mapping[str, Any]:
+    unit_id = str(unit.get("id", "") or "stage").strip() or "stage"
+    token = str(idempotency_token).strip()
+    if not token:
+        raise RuntimeError(f"Distributed DAG stage `{unit_id}` requires an idempotency token.")
+    return execute_idempotently(
+        run_root=run_root,
+        unit_id=unit_id,
+        idempotency_token=token,
+        scope="distributed-submitter",
+        callback=lambda: _submit_distributed_stage_once(
+            config=config,
+            runner_fn=runner_fn,
+            repo_root=repo_root,
+            lab_dir=lab_dir,
+            run_root=run_root,
+            unit=unit,
+            artifact=artifact,
+            execution_contract=execution_contract,
+            timestamp=timestamp,
+            idempotency_token=token,
+        ),
+    )
+
+
+def _submit_distributed_stage_once(
+    *,
+    config: DagDistributedStageConfig,
+    runner_fn: DagStageRunner,
+    repo_root: Path,
+    lab_dir: Path,
+    run_root: Path,
+    unit: Mapping[str, Any],
+    artifact: Mapping[str, Any],
+    execution_contract: Mapping[str, Any],
+    timestamp: str,
+    idempotency_token: str,
 ) -> Mapping[str, Any]:
     unit_id = str(unit.get("id", "") or "stage").strip() or "stage"
     app_name = str(unit.get("app", "") or "").strip()
     if not app_name:
         raise RuntimeError(f"Distributed DAG stage `{unit_id}` is missing its app name.")
+    token = str(idempotency_token).strip()
+    if not token:
+        raise RuntimeError(f"Distributed DAG stage `{unit_id}` requires an idempotency token.")
 
     apps_path = resolve_stage_apps_path(repo_root, app_name)
     request_payload = request_payload_from_execution_contract(execution_contract)
+    request_payload["idempotency_token"] = token
     run_root.mkdir(parents=True, exist_ok=True)
 
     runner_result = dict(
@@ -187,6 +234,7 @@ def submit_distributed_stage(
             execution_contract=dict(execution_contract),
             request_payload=request_payload,
             timestamp=timestamp,
+            idempotency_token=token,
         )
     )
     evidence_path = _distributed_evidence_path(run_root, artifact)
@@ -197,6 +245,7 @@ def submit_distributed_stage(
         "apps_path": str(apps_path),
         "artifact": dict(artifact),
         "created_at": timestamp,
+        "idempotency_token": token,
         "execution_contract": dict(execution_contract),
         "request_payload": request_payload,
         "cluster": {
@@ -209,8 +258,7 @@ def submit_distributed_stage(
         },
         "runner_result": _jsonable(runner_result),
     }
-    evidence_path.parent.mkdir(parents=True, exist_ok=True)
-    evidence_path.write_text(json.dumps(evidence_payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_json_atomic(evidence_path, evidence_payload)
 
     default_metrics = {
         "stage_completed": 1,
@@ -235,7 +283,9 @@ def submit_distributed_stage(
             "workers": config.workers,
             "workers_data_path": config.workers_data_path,
             "mode": config.mode,
+            "idempotency_token": token,
         },
+        "idempotency_token": token,
     }
     result.update(runner_result)
     result["summary_metrics"] = default_metrics
@@ -252,8 +302,53 @@ def run_agilab_stage_subprocess(
     app_name: str,
     request_payload: Mapping[str, Any],
     timestamp: str,
+    idempotency_token: str,
+    **kwargs: Any,
+) -> Mapping[str, Any]:
+    token = str(idempotency_token).strip()
+    if not token:
+        raise RuntimeError(f"Distributed DAG stage `{app_name}` requires an idempotency token.")
+    return execute_idempotently(
+        run_root=run_root,
+        unit_id=app_name,
+        idempotency_token=token,
+        scope="distributed-subprocess",
+        callback=lambda: _run_agilab_stage_subprocess_once(
+            config=config,
+            repo_root=repo_root,
+            run_root=run_root,
+            apps_path=apps_path,
+            app_name=app_name,
+            request_payload=request_payload,
+            timestamp=timestamp,
+            idempotency_token=token,
+            **kwargs,
+        ),
+    )
+
+
+def _run_agilab_stage_subprocess_once(
+    *,
+    config: DagDistributedStageConfig,
+    repo_root: Path,
+    run_root: Path,
+    apps_path: Path,
+    app_name: str,
+    request_payload: Mapping[str, Any],
+    timestamp: str,
+    idempotency_token: str,
     **_kwargs: Any,
 ) -> Mapping[str, Any]:
+    token = str(idempotency_token).strip()
+    if not token:
+        raise RuntimeError(f"Distributed DAG stage `{app_name}` requires an idempotency token.")
+    stage_request = dict(request_payload)
+    recorded_token = str(stage_request.get("idempotency_token", "")).strip()
+    if recorded_token and recorded_token != token:
+        raise RuntimeError(
+            f"Distributed DAG stage `{app_name}` request token does not match its execution token."
+        )
+    stage_request["idempotency_token"] = token
     run_root.mkdir(parents=True, exist_ok=True)
     script_path = run_root / "run_distributed_stage.py"
     script_path.write_text(
@@ -261,7 +356,7 @@ def run_agilab_stage_subprocess(
             config=config,
             apps_path=apps_path,
             app_name=app_name,
-            request_payload=request_payload,
+            request_payload=stage_request,
         ),
         encoding="utf-8",
     )
@@ -283,10 +378,12 @@ def run_agilab_stage_subprocess(
         )
         log_tee_thread.start()
         try:
+            command_env = os.environ.copy()
+            command_env["AGILAB_IDEMPOTENCY_TOKEN"] = token
             completed = subprocess.run(
                 command,
                 cwd=repo_root,
-                env=os.environ.copy(),
+                env=command_env,
                 text=True,
                 stdout=stdout_handle,
                 stderr=stderr_handle,
@@ -309,17 +406,18 @@ def run_agilab_stage_subprocess(
         "stderr_log": str(stderr_path),
         "stdout_tail": stdout_tail,
         "stderr_tail": stderr_tail,
+        "idempotency_token": token,
     }
     if completed.returncode:
         detail = stderr_tail.strip() or stdout_tail.strip() or f"exit {completed.returncode}"
-        raise RuntimeError(f"Distributed DAG stage `{app_name}` failed: {_tail(detail, max_chars=4000)}")
+        raise RuntimeError(f"Distributed DAG stage `{app_name}` failed: {_tail(detail, max_chars=3800)}")
     failure_detail = _stage_result_failure(stdout_tail)
     if failure_detail:
         # Defense in depth: AGI.run can swallow ProcessError/ConnectionError
         # and the script may still print a null/error result; never record
         # success evidence for such a stage.
         raise RuntimeError(
-            f"Distributed DAG stage `{app_name}` failed: {_tail(failure_detail, max_chars=4000)}"
+            f"Distributed DAG stage `{app_name}` failed: {_tail(failure_detail, max_chars=3800)}"
         )
     return payload
 
@@ -440,6 +538,7 @@ def _stage_run_script(
     return f'''\
 import asyncio
 import json
+import os
 import sys
 
 from agi_cluster.agi_distributor import AGI, RunRequest, StageRequest
@@ -450,6 +549,7 @@ APPS_PATH = {str(apps_path)!r}
 APP = {app_name!r}
 REQUEST_PAYLOAD = json.loads({request_json!r})
 WORKERS = json.loads({workers_json!r})
+os.environ["AGILAB_IDEMPOTENCY_TOKEN"] = str(REQUEST_PAYLOAD["idempotency_token"])
 
 
 async def main():
@@ -508,11 +608,38 @@ def _load_settings_file(path_value: Any) -> dict[str, Any]:
         return {}
     path = Path(path_value)
     try:
-        with path.open("rb") as handle:
-            loaded = tomllib.load(handle)
-    except (OSError, tomllib.TOMLDecodeError):
-        return {}
+        # Keep the optional agi-env dependency out of base-package imports.
+        from agi_env.app_settings_support import read_app_settings
+    except ModuleNotFoundError as exc:
+        if not str(getattr(exc, "name", "") or "").startswith("agi_env"):
+            raise
+        loaded = _read_settings_file_stdlib(path)
+    else:
+        try:
+            loaded = read_app_settings(path)
+        except (OSError, ValueError):
+            return {}
     return dict(loaded) if isinstance(loaded, Mapping) else {}
+
+
+def _read_settings_file_stdlib(path: Path) -> dict[str, Any]:
+    """Read settings when the optional ``agi-env`` package is unavailable."""
+
+    deadline = time.monotonic() + 0.5
+    while True:
+        try:
+            with path.open("rb") as stream:
+                loaded = tomllib.load(stream)
+            return dict(loaded) if isinstance(loaded, Mapping) else {}
+        except PermissionError:
+            if os.name != "nt":
+                return {}
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return {}
+            time.sleep(min(0.01, remaining))
+        except (OSError, tomllib.TOMLDecodeError):
+            return {}
 
 
 def _coerce_workers(value: Any) -> dict[str, int]:

--- a/src/agilab/dag/dag_execution_adapters.py
+++ b/src/agilab/dag/dag_execution_adapters.py
@@ -4,13 +4,19 @@ from copy import deepcopy
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from datetime import datetime, timezone
-import json
+import os
 from pathlib import Path
 import re
 import shlex
 import subprocess
 from typing import Any, Callable, Mapping, Protocol
 
+from .dag_idempotency import (
+    DagExternalExecutionUncertainError,
+    execute_idempotently as _execute_idempotently,
+    fsync_directory,
+    write_json_atomic,
+)
 from .dag_execution_registry import (
     CONTROLLED_CONTRACT_ADAPTER,
     CONTROLLED_CONTRACT_RUNNER_STATUS,
@@ -29,6 +35,7 @@ GLOBAL_DAG_CONTRACT_EXECUTION_SCOPE = "controlled_contract_dag_stage"
 GLOBAL_DAG_DISTRIBUTED_EXECUTION_SCOPE = "controlled_contract_dag_stage_distributed"
 DAG_STAGE_BACKEND_LOCAL = "local"
 DAG_STAGE_BACKEND_DISTRIBUTED = "distributed"
+_DURABLE_CLAIM_RECEIPT = object()
 
 
 def _now_iso() -> str:
@@ -61,12 +68,49 @@ class DagExecutionContext:
     stage_run_fns: Mapping[str, Callable[..., Mapping[str, Any]]] | None = None
     stage_submit_fn: Callable[..., Mapping[str, Any]] | None = None
     now_fn: Callable[[], str] = _now_iso
+    execution_attempt_id: str = ""
+    persist_execution_claim_fn: Callable[[Mapping[str, Any]], object] | None = None
 
 
-class DagExecutionAdapter(Protocol):
+def _persist_execution_claim(context: DagExecutionContext, state: dict[str, Any]) -> None:
+    """Persist the running claim before invoking any external execution boundary."""
+
+    _refresh_summary(state)
+    if context.persist_execution_claim_fn is None:
+        raise RuntimeError(
+            "Controlled DAG execution requires a durable claim persistence callback; "
+            "use the runner-state transaction API."
+        )
+    receipt = context.persist_execution_claim_fn(state)
+    if receipt is not _DURABLE_CLAIM_RECEIPT:
+        raise RuntimeError(
+            "Controlled DAG execution did not receive a durable claim receipt; "
+            "use the runner-state transaction API."
+        )
+
+
+def _unit_idempotency_token(context: DagExecutionContext, unit_id: str) -> str:
+    attempt_id = str(context.execution_attempt_id).strip()
+    if not attempt_id:
+        raise RuntimeError(
+            f"Controlled DAG stage `{unit_id}` requires a durable execution attempt and idempotency token."
+        )
+    return f"{attempt_id}:{unit_id}"
+
+
+def _unit_persisted_idempotency_token(unit: Mapping[str, Any]) -> str:
+    attempt = unit.get("execution_attempt")
+    token = str(attempt.get("idempotency_token", "")).strip() if isinstance(attempt, Mapping) else ""
+    if not token:
+        unit_id = str(unit.get("id", "")).strip() or "stage"
+        raise RuntimeError(f"Controlled DAG stage `{unit_id}` is missing its persisted idempotency token.")
+    return token
+
+
+class _DagExecutionAdapter(Protocol):
     adapter_id: str
 
-    def run_next(
+    def _run_next_uncommitted(
         self,
         state: Mapping[str, Any],
         context: DagExecutionContext,
@@ -74,10 +118,10 @@ class DagExecutionAdapter(Protocol):
         ...
 
 
-class UavQueueToRelayExecutionAdapter:
+class _UavQueueToRelayExecutionAdapter:
     adapter_id = UAV_QUEUE_ADAPTER
 
-    def run_next(
+    def _run_next_uncommitted(
         self,
         state: Mapping[str, Any],
         context: DagExecutionContext,
@@ -85,10 +129,10 @@ class UavQueueToRelayExecutionAdapter:
         return _run_next_uav_queue_to_relay_stage(state, context=context)
 
 
-class ControlledContractDagExecutionAdapter:
+class _ControlledContractDagExecutionAdapter:
     adapter_id = CONTROLLED_CONTRACT_ADAPTER
 
-    def run_next(
+    def _run_next_uncommitted(
         self,
         state: Mapping[str, Any],
         context: DagExecutionContext,
@@ -96,14 +140,14 @@ class ControlledContractDagExecutionAdapter:
         return _run_next_controlled_contract_dag_stage(state, context=context)
 
 
-DAG_EXECUTION_ADAPTERS_BY_ID: Mapping[str, DagExecutionAdapter] = {
-    UavQueueToRelayExecutionAdapter.adapter_id: UavQueueToRelayExecutionAdapter(),
-    ControlledContractDagExecutionAdapter.adapter_id: ControlledContractDagExecutionAdapter(),
+_DAG_EXECUTION_ADAPTERS_BY_ID: Mapping[str, _DagExecutionAdapter] = {
+    _UavQueueToRelayExecutionAdapter.adapter_id: _UavQueueToRelayExecutionAdapter(),
+    _ControlledContractDagExecutionAdapter.adapter_id: _ControlledContractDagExecutionAdapter(),
 }
 
 
 def registered_execution_adapter_ids() -> tuple[str, ...]:
-    return tuple(sorted(DAG_EXECUTION_ADAPTERS_BY_ID))
+    return tuple(sorted(_DAG_EXECUTION_ADAPTERS_BY_ID))
 
 
 def run_next_adapter_stage(
@@ -111,17 +155,50 @@ def run_next_adapter_stage(
     state: Mapping[str, Any],
     context: DagExecutionContext,
 ) -> DagStageExecutionResult:
-    adapter = DAG_EXECUTION_ADAPTERS_BY_ID.get(adapter_id)
+    """Reject public execution that cannot own the runner-state transaction."""
+
+    del adapter_id, state, context
+    raise RuntimeError(
+        "Direct DAG adapter execution is disabled; use "
+        "DagRunEngine.run_next_controlled_stage() so the durable claim and "
+        "CAS finalization cannot be bypassed."
+    )
+
+
+def _run_next_adapter_stage_uncommitted(
+    adapter_id: str,
+    state: Mapping[str, Any],
+    context: DagExecutionContext,
+) -> DagStageExecutionResult:
+    adapter = _DAG_EXECUTION_ADAPTERS_BY_ID.get(adapter_id)
     if adapter is None:
         return DagStageExecutionResult(
             ok=False,
             message=f"No DAG execution adapter is registered for `{adapter_id}`.",
             state=dict(state),
         )
-    return adapter.run_next(state, context)
+    return adapter._run_next_uncommitted(state, context)
 
 
 def run_ready_adapter_stages(
+    adapter_id: str,
+    state: Mapping[str, Any],
+    context: DagExecutionContext,
+    *,
+    max_workers: int | None = None,
+    execution_backend: str = DAG_STAGE_BACKEND_LOCAL,
+) -> DagBatchExecutionResult:
+    """Reject public batch execution that cannot own the state transaction."""
+
+    del adapter_id, state, context, max_workers, execution_backend
+    raise RuntimeError(
+        "Direct DAG adapter batch execution is disabled; use "
+        "DagRunEngine.run_ready_controlled_stages() so the durable claim and "
+        "CAS finalization cannot be bypassed."
+    )
+
+
+def _run_ready_adapter_stages_uncommitted(
     adapter_id: str,
     state: Mapping[str, Any],
     context: DagExecutionContext,
@@ -137,7 +214,7 @@ def run_ready_adapter_stages(
             execution_backend=execution_backend,
         )
 
-    result = run_next_adapter_stage(adapter_id, state, context)
+    result = _run_next_adapter_stage_uncommitted(adapter_id, state, context)
     if result.ok:
         return DagBatchExecutionResult(
             ok=True,
@@ -275,8 +352,29 @@ def _run_next_uav_queue_to_relay_stage(
     relay_status = str(relay.get("dispatch_status", ""))
     timestamp = context.now_fn()
     if queue_status == "runnable":
+        idempotency_token = _unit_idempotency_token(context, QUEUE_UNIT_ID)
+        _mark_controlled_stage_running(
+            mutable_state,
+            queue,
+            timestamp=timestamp,
+            execution_mode="real_app_entry",
+            operator_message=f"{QUEUE_UNIT_ID} is running through the controlled AGILAB app entrypoint.",
+            event_detail=f"{QUEUE_UNIT_ID} claimed before controlled AGILAB app execution",
+            execution_attempt_id=context.execution_attempt_id,
+            idempotency_token=idempotency_token,
+        )
+        _persist_execution_claim(context, mutable_state)
         run_root = _real_run_root(context.lab_dir, QUEUE_UNIT_ID)
-        result = dict(run_queue_fn(repo_root=context.repo_root, run_root=run_root))
+        result = _execute_idempotently(
+            run_root=run_root,
+            unit_id=QUEUE_UNIT_ID,
+            idempotency_token=idempotency_token,
+            callback=lambda: run_queue_fn(
+                repo_root=context.repo_root,
+                run_root=run_root,
+                idempotency_token=idempotency_token,
+            ),
+        )
         _mark_controlled_stage_execution(
             mutable_state,
             queue,
@@ -302,9 +400,31 @@ def _run_next_uav_queue_to_relay_stage(
     if relay_status in {"runnable", "blocked"} and "queue_metrics" in available_artifact_ids(mutable_state):
         if relay_status == "blocked":
             _unblock_relay_after_queue(mutable_state, timestamp=timestamp)
+        idempotency_token = _unit_idempotency_token(context, RELAY_UNIT_ID)
+        _mark_controlled_stage_running(
+            mutable_state,
+            relay,
+            timestamp=timestamp,
+            execution_mode="real_app_entry",
+            operator_message=f"{RELAY_UNIT_ID} is running through the controlled AGILAB app entrypoint.",
+            event_detail=f"{RELAY_UNIT_ID} claimed before controlled AGILAB app execution",
+            execution_attempt_id=context.execution_attempt_id,
+            idempotency_token=idempotency_token,
+        )
+        _persist_execution_claim(context, mutable_state)
         run_root = _real_run_root(context.lab_dir, RELAY_UNIT_ID)
         queue_result = _queue_result_for_relay(mutable_state)
-        result = dict(run_relay_fn(repo_root=context.repo_root, run_root=run_root, queue_result=queue_result))
+        result = _execute_idempotently(
+            run_root=run_root,
+            unit_id=RELAY_UNIT_ID,
+            idempotency_token=idempotency_token,
+            callback=lambda: run_relay_fn(
+                repo_root=context.repo_root,
+                run_root=run_root,
+                queue_result=queue_result,
+                idempotency_token=idempotency_token,
+            ),
+        )
         _mark_controlled_stage_execution(
             mutable_state,
             relay,
@@ -358,6 +478,15 @@ def _run_next_controlled_contract_dag_stage(
         artifact_id = artifact["artifact"]
         artifact_kind = artifact["kind"]
         artifact_path_key = _artifact_path_result_key(artifact_kind)
+        idempotency_token = _unit_idempotency_token(context, unit_id)
+        _mark_controlled_stage_running(
+            mutable_state,
+            unit,
+            timestamp=timestamp,
+            execution_attempt_id=context.execution_attempt_id,
+            idempotency_token=idempotency_token,
+        )
+        _persist_execution_claim(context, mutable_state)
         try:
             result = _contract_stage_result(
                 context,
@@ -365,6 +494,8 @@ def _run_next_controlled_contract_dag_stage(
                 artifact=artifact,
                 timestamp=timestamp,
             )
+        except DagExternalExecutionUncertainError:
+            raise
         except RuntimeError as exc:
             _mark_controlled_stage_failure(
                 mutable_state,
@@ -456,6 +587,7 @@ def _run_ready_controlled_contract_dag_stages(
             failure_messages_by_unit_id[unit_id] = contract_issue
             continue
         artifact = _primary_contract_artifact(mutable_state, unit)
+        idempotency_token = _unit_idempotency_token(context, unit_id)
         _mark_controlled_stage_running(
             mutable_state,
             unit,
@@ -463,6 +595,8 @@ def _run_ready_controlled_contract_dag_stages(
             execution_mode=_stage_backend_execution_mode(backend),
             operator_message=_stage_backend_running_message(unit_id, backend),
             event_detail=_stage_backend_dispatch_detail(unit_id, backend),
+            execution_attempt_id=context.execution_attempt_id,
+            idempotency_token=idempotency_token,
         )
         jobs.append(
             (
@@ -474,7 +608,9 @@ def _run_ready_controlled_contract_dag_stages(
         )
 
     results_by_unit_id: dict[str, dict[str, Any]] = {}
+    uncertain_errors: list[DagExternalExecutionUncertainError] = []
     if jobs:
+        _persist_execution_claim(context, mutable_state)
         worker_count = max(1, min(max_workers or len(jobs), len(jobs)))
         with ThreadPoolExecutor(max_workers=worker_count) as executor:
             futures = {
@@ -491,8 +627,16 @@ def _run_ready_controlled_contract_dag_stages(
             for future, unit_id in futures.items():
                 try:
                     results_by_unit_id[unit_id] = dict(future.result())
+                except DagExternalExecutionUncertainError as exc:
+                    uncertain_errors.append(exc)
                 except Exception as exc:
                     failure_messages_by_unit_id[unit_id] = str(exc)
+
+    if uncertain_errors:
+        # Every batch unit remains under the durable top-level claim. Even units
+        # whose callback returned cannot be finalized independently once one
+        # sibling side effect has an unknown outcome.
+        raise uncertain_errors[0]
 
     executed_unit_ids: list[str] = []
     for unit, artifact, artifact_kind, artifact_path_key in jobs:
@@ -651,11 +795,14 @@ def _distributed_stage_result(
             "Use the local contract backend or provide a stage submitter."
         )
     unit_id = str(unit.get("id", "")).strip() or "stage"
+    idempotency_token = _unit_persisted_idempotency_token(unit)
     contract = _unit_execution_contract(unit)
     run_root = _real_run_root(context.lab_dir, unit_id)
-    run_root.mkdir(parents=True, exist_ok=True)
-    result = dict(
-        submitter(
+    result = _execute_idempotently(
+        run_root=run_root,
+        unit_id=unit_id,
+        idempotency_token=idempotency_token,
+        callback=lambda: submitter(
             repo_root=context.repo_root,
             lab_dir=context.lab_dir,
             run_root=run_root,
@@ -663,7 +810,8 @@ def _distributed_stage_result(
             artifact=dict(artifact),
             execution_contract=contract,
             timestamp=timestamp,
-        )
+            idempotency_token=idempotency_token,
+        ),
     )
     result.setdefault("execution_contract", contract)
     result.setdefault("stage_backend", DAG_STAGE_BACKEND_DISTRIBUTED)
@@ -678,15 +826,48 @@ def _contract_stage_result(
     timestamp: str,
 ) -> dict[str, Any]:
     unit_id = str(unit.get("id", "")).strip() or "stage"
+    idempotency_token = _unit_persisted_idempotency_token(unit)
+    run_root = _real_run_root(context.lab_dir, unit_id)
+    return _execute_idempotently(
+        run_root=run_root,
+        unit_id=unit_id,
+        idempotency_token=idempotency_token,
+        callback=lambda: _contract_stage_result_once(
+            context,
+            unit=unit,
+            artifact=artifact,
+            timestamp=timestamp,
+            idempotency_token=idempotency_token,
+            run_root=run_root,
+        ),
+    )
+
+
+def _contract_stage_result_once(
+    context: DagExecutionContext,
+    *,
+    unit: Mapping[str, Any],
+    artifact: Mapping[str, str],
+    timestamp: str,
+    idempotency_token: str,
+    run_root: Path,
+) -> dict[str, Any]:
+    unit_id = str(unit.get("id", "")).strip() or "stage"
     artifact_id = str(artifact.get("artifact", "")).strip() or f"{unit_id}_contract_artifact"
     artifact_kind = str(artifact.get("kind", "")).strip() or _contract_artifact_kind(artifact_id, "")
     artifact_path = str(artifact.get("path", "")).strip()
     contract = _unit_execution_contract(unit)
-    run_root = _real_run_root(context.lab_dir, unit_id)
     runner = _stage_contract_runner(context, unit_id=unit_id, contract=contract)
     if runner is not None:
-        result = dict(runner(repo_root=context.repo_root, run_root=run_root))
+        result = dict(
+            runner(
+                repo_root=context.repo_root,
+                run_root=run_root,
+                idempotency_token=idempotency_token,
+            )
+        )
         result.setdefault("execution_contract", contract)
+        result.setdefault("idempotency_token", idempotency_token)
         return result
 
     run_root.mkdir(parents=True, exist_ok=True)
@@ -694,8 +875,21 @@ def _contract_stage_result(
     command = _contract_command(contract)
     command_result: dict[str, Any] = {}
     if command:
-        command_result = _run_contract_command(command, run_root=run_root)
-    output_path.parent.mkdir(parents=True, exist_ok=True)
+        if output_path.is_dir():
+            raise RuntimeError(f"Controlled contract artifact path is a directory: {output_path}")
+        try:
+            output_path.unlink()
+        except FileNotFoundError:
+            pass
+        else:
+            # A retry must prove that its command produced the declared output;
+            # retaining a prior attempt's file would make evidence/token state lie.
+            fsync_directory(output_path.parent)
+        command_result = _run_contract_command(
+            command,
+            run_root=run_root,
+            idempotency_token=idempotency_token,
+        )
     artifact_payload = {
         "schema": "agilab.dag_contract_stage_result.v1",
         "unit_id": unit_id,
@@ -704,15 +898,19 @@ def _contract_stage_result(
         "created_at": timestamp,
         "execution_mode": "controlled_contract_stage_execution",
         "execution_contract": contract,
+        "idempotency_token": idempotency_token,
         **command_result,
     }
-    if not output_path.exists():
-        output_path.write_text(json.dumps(artifact_payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if not command or not output_path.exists():
+        # Fallback evidence belongs to this attempt. Reset/retry reuses the run
+        # root, so preserving a previous token would make state and evidence lie.
+        write_json_atomic(output_path, artifact_payload)
     result = {
         "contract_artifact_path": str(output_path),
         "reduce_artifact_path": str(output_path),
         "summary_metrics_path": str(output_path),
         "execution_contract": contract,
+        "idempotency_token": idempotency_token,
         "summary_metrics": {
             "contract_artifacts": 1,
             "stage_completed": 1,
@@ -782,9 +980,43 @@ def _stage_contract_runner(
     return stage_run_fns.get(entrypoint) if entrypoint else None
 
 
-def _run_contract_command(command: list[str], *, run_root: Path) -> dict[str, Any]:
+def _run_contract_command(
+    command: list[str],
+    *,
+    run_root: Path,
+    idempotency_token: str,
+) -> dict[str, Any]:
+    return _execute_idempotently(
+        run_root=run_root,
+        unit_id="contract-command",
+        idempotency_token=idempotency_token,
+        scope="contract-command",
+        callback=lambda: _run_contract_command_once(
+            command,
+            run_root=run_root,
+            idempotency_token=idempotency_token,
+        ),
+    )
+
+
+def _run_contract_command_once(
+    command: list[str],
+    *,
+    run_root: Path,
+    idempotency_token: str,
+) -> dict[str, Any]:
     try:
-        completed = subprocess.run(command, cwd=run_root, text=True, capture_output=True, check=False, timeout=300)
+        command_env = os.environ.copy()
+        command_env["AGILAB_IDEMPOTENCY_TOKEN"] = idempotency_token
+        completed = subprocess.run(
+            command,
+            cwd=run_root,
+            env=command_env,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=300,
+        )
     except subprocess.TimeoutExpired as exc:
         raise RuntimeError("Controlled contract command timed out after 300 seconds.") from exc
     if completed.returncode:
@@ -966,11 +1198,14 @@ def _mark_controlled_stage_running(
     execution_mode: str = "contract_adapter",
     operator_message: str | None = None,
     event_detail: str | None = None,
+    execution_attempt_id: str = "",
+    idempotency_token: str = "",
 ) -> None:
     unit_id = str(unit.get("id", ""))
     previous_status = str(unit.get("dispatch_status", ""))
     unit["dispatch_status"] = "running"
     unit["execution_mode"] = execution_mode
+    state["updated_at"] = timestamp
     timestamps = unit.setdefault("timestamps", {})
     if isinstance(timestamps, dict):
         timestamps.setdefault("created_at", state.get("created_at", timestamp))
@@ -982,6 +1217,14 @@ def _mark_controlled_stage_running(
         "message": operator_message or f"{unit_id} is running through the controlled DAG contract adapter.",
         "blocked_by_artifacts": [],
     }
+    if execution_attempt_id:
+        unit["execution_attempt"] = {
+            "id": execution_attempt_id,
+            "idempotency_token": idempotency_token,
+            "status": "running",
+            "started_at": timestamp,
+            "recovery_policy": "explicit_recovery_required_before_retry",
+        }
     _append_event(
         state,
         timestamp=timestamp,
@@ -1025,6 +1268,10 @@ def _mark_controlled_stage_execution(
         "message": operator_message or f"{unit_id} executed through the controlled AGILAB app entrypoint.",
         "blocked_by_artifacts": [],
     }
+    execution_attempt = unit.get("execution_attempt")
+    if isinstance(execution_attempt, dict):
+        execution_attempt["status"] = "completed"
+        execution_attempt["completed_at"] = timestamp
     unit[execution_payload_key] = result
     produces: list[dict[str, Any]] = []
     artifact_attached = False
@@ -1132,6 +1379,10 @@ def _mark_controlled_stage_failure(
         "message": message,
         "blocked_by_artifacts": [],
     }
+    execution_attempt = unit.get("execution_attempt")
+    if isinstance(execution_attempt, dict):
+        execution_attempt["status"] = "failed"
+        execution_attempt["completed_at"] = timestamp
     _append_event(
         state,
         timestamp=timestamp,
@@ -1141,6 +1392,67 @@ def _mark_controlled_stage_failure(
         to_status="failed",
         detail=message,
     )
+
+
+def recover_execution_attempt(
+    state: Mapping[str, Any],
+    *,
+    unit_id: str,
+    idempotency_token: str,
+    timestamp: str,
+) -> dict[str, Any]:
+    """Mark one exact ambiguous unit claim failed after explicit operator recovery."""
+
+    mutable_state = deepcopy(dict(state))
+    active = mutable_state.get("active_execution")
+    unit_tokens = active.get("unit_tokens") if isinstance(active, dict) else None
+    recorded_token = (
+        str(unit_tokens.get(unit_id, "")).strip()
+        if isinstance(unit_tokens, Mapping)
+        else ""
+    )
+    if not recorded_token or recorded_token != idempotency_token:
+        raise ValueError(f"Active execution token does not match unit `{unit_id}`.")
+    unit = _dag_unit(mutable_state, unit_id)
+    if not isinstance(unit, dict):
+        raise ValueError(f"Active execution unit `{unit_id}` is missing from runner state.")
+    attempt = unit.get("execution_attempt")
+    unit_token = str(attempt.get("idempotency_token", "")).strip() if isinstance(attempt, dict) else ""
+    if unit.get("dispatch_status") != "running" or unit_token != idempotency_token:
+        raise ValueError(f"Unit `{unit_id}` no longer has the claimed running token.")
+
+    _mark_controlled_stage_failure(
+        mutable_state,
+        unit,
+        timestamp=timestamp,
+        message=(
+            f"Execution attempt for {unit_id} was explicitly recovered with its exact "
+            "idempotency token; reset is required before retry."
+        ),
+        execution_mode=str(unit.get("execution_mode", "contract_adapter")),
+    )
+    recovered_attempt = unit.get("execution_attempt")
+    if isinstance(recovered_attempt, dict):
+        recovered_attempt["status"] = "recovered_failed"
+        recovered_attempt["recovered_at"] = timestamp
+    remaining_tokens = dict(unit_tokens) if isinstance(unit_tokens, Mapping) else {}
+    remaining_tokens.pop(unit_id, None)
+    if remaining_tokens and isinstance(active, dict):
+        active["unit_tokens"] = remaining_tokens
+        active["status"] = "recovery_required"
+    else:
+        mutable_state.pop("active_execution", None)
+    _append_event(
+        mutable_state,
+        timestamp=timestamp,
+        kind="unit_recovered",
+        unit_id=unit_id,
+        from_status="running",
+        to_status="failed",
+        detail=f"operator recovered exact idempotency token {idempotency_token}",
+    )
+    _refresh_summary(mutable_state)
+    return mutable_state
 
 
 def _unblock_unit_when_artifacts_available(

--- a/src/agilab/dag/dag_idempotency.py
+++ b/src/agilab/dag/dag_idempotency.py
@@ -1,0 +1,265 @@
+"""Crash-durable idempotency guards for DAG side-effect boundaries."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import tempfile
+from typing import Any, Callable, Mapping
+
+from agilab.global_pipeline.global_pipeline_runner_state import (
+    _ensure_directory_hierarchy_durable,
+    _fsync_runner_state_directory,
+)
+
+
+class DagExternalExecutionUncertainError(RuntimeError):
+    """Raised when a callback may have produced a side effect before failing."""
+
+    def __init__(
+        self,
+        *,
+        unit_id: str,
+        idempotency_token: str,
+        detail: str,
+    ) -> None:
+        self.unit_id = unit_id
+        self.idempotency_token = idempotency_token
+        self.detail = detail
+        super().__init__(
+            f"DAG stage `{unit_id}` may have produced a side effect for token "
+            f"`{idempotency_token}`: {detail}. Exact-token recovery is required."
+        )
+
+
+def fsync_directory(path: Path) -> None:
+    """Flush one directory or fail before a guarded callback may start."""
+
+    if not _fsync_runner_state_directory(path):
+        raise OSError(f"Could not durably flush directory metadata: {path}")
+
+
+def write_json_atomic(path: Path, payload: Mapping[str, Any]) -> Path:
+    """Atomically replace JSON and durably flush its parent directory."""
+
+    if not _ensure_directory_hierarchy_durable(path.parent):
+        raise OSError(f"Could not durably create directory hierarchy: {path.parent}")
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+    tmp_path = Path(tmp_name)
+    try:
+        stream = os.fdopen(fd, "w", encoding="utf-8")
+        fd = -1
+        with stream:
+            json.dump(payload, stream, indent=2, sort_keys=True, default=str)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(tmp_path, path)
+        fsync_directory(path.parent)
+    finally:
+        if fd >= 0:
+            os.close(fd)
+        try:
+            tmp_path.unlink()
+        except FileNotFoundError:
+            pass
+    return path
+
+
+def execute_idempotently(
+    *,
+    run_root: Path,
+    unit_id: str,
+    idempotency_token: str,
+    callback: Callable[[], Mapping[str, Any]],
+    scope: str = "adapter",
+) -> dict[str, Any]:
+    """Execute a callback once per durable scope/token ledger claim."""
+
+    token = str(idempotency_token).strip()
+    guard_scope = str(scope).strip()
+    if not token:
+        raise RuntimeError(f"DAG stage `{unit_id}` requires an idempotency token.")
+    if not guard_scope:
+        raise RuntimeError(f"DAG stage `{unit_id}` requires an idempotency guard scope.")
+    ledger_path, cached_result = _begin_execution(
+        run_root=run_root,
+        unit_id=unit_id,
+        idempotency_token=token,
+        scope=guard_scope,
+    )
+    if cached_result is not None:
+        return cached_result
+    try:
+        result = dict(callback())
+    except DagExternalExecutionUncertainError as exc:
+        try:
+            _write_ledger(
+                ledger_path,
+                unit_id=unit_id,
+                idempotency_token=token,
+                scope=guard_scope,
+                status="failed",
+                error=str(exc),
+            )
+        finally:
+            # Preserve the original side-effect boundary and token instead of
+            # obscuring it under nested adapter/submitter guards.
+            raise
+    except BaseException as exc:
+        detail = str(exc).strip() or type(exc).__name__
+        try:
+            _write_ledger(
+                ledger_path,
+                unit_id=unit_id,
+                idempotency_token=token,
+                scope=guard_scope,
+                status="failed",
+                error=detail,
+            )
+        finally:
+            raise DagExternalExecutionUncertainError(
+                unit_id=unit_id,
+                idempotency_token=token,
+                detail=detail,
+            ) from exc
+    result_token = str(result.get("idempotency_token", "")).strip()
+    if result_token and result_token != token:
+        detail = "execution result returned a mismatched idempotency token"
+        _write_ledger(
+            ledger_path,
+            unit_id=unit_id,
+            idempotency_token=token,
+            scope=guard_scope,
+            status="failed",
+            error=detail,
+        )
+        raise DagExternalExecutionUncertainError(
+            unit_id=unit_id,
+            idempotency_token=token,
+            detail=detail,
+        )
+    result["idempotency_token"] = token
+    _write_ledger(
+        ledger_path,
+        unit_id=unit_id,
+        idempotency_token=token,
+        scope=guard_scope,
+        status="completed",
+        result=result,
+    )
+    return result
+
+
+def _begin_execution(
+    *,
+    run_root: Path,
+    unit_id: str,
+    idempotency_token: str,
+    scope: str,
+) -> tuple[Path, dict[str, Any] | None]:
+    ledger_dir = run_root / ".agilab-idempotency"
+    if not _ensure_directory_hierarchy_durable(ledger_dir):
+        raise OSError(f"Could not durably create idempotency ledger directory: {ledger_dir}")
+    token_digest = hashlib.sha256(f"{scope}\0{idempotency_token}".encode()).hexdigest()
+    ledger_path = ledger_dir / f"{token_digest}.json"
+    try:
+        fd = os.open(ledger_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    except FileExistsError as exc:
+        try:
+            recorded = json.loads(ledger_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            recorded = {}
+        matches_claim = (
+            isinstance(recorded, Mapping)
+            and recorded.get("unit_id") == unit_id
+            and recorded.get("idempotency_token") == idempotency_token
+            and recorded.get("scope") == scope
+        )
+        if matches_claim and recorded.get("status") == "completed":
+            result = recorded.get("result")
+            if isinstance(result, Mapping):
+                return ledger_path, dict(result)
+        status = str(recorded.get("status", "running")) if isinstance(recorded, Mapping) else "running"
+        raise DagExternalExecutionUncertainError(
+            unit_id=unit_id,
+            idempotency_token=idempotency_token,
+            detail=f"the durable `{scope}` ledger is already {status}",
+        ) from exc
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            json.dump(
+                _ledger_payload(
+                    unit_id=unit_id,
+                    idempotency_token=idempotency_token,
+                    scope=scope,
+                    status="running",
+                ),
+                stream,
+                indent=2,
+                sort_keys=True,
+            )
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        fsync_directory(ledger_dir)
+    except BaseException:
+        # Retain even a partial exclusive claim so a second process fails closed.
+        raise
+    return ledger_path, None
+
+
+def _write_ledger(
+    path: Path,
+    *,
+    unit_id: str,
+    idempotency_token: str,
+    scope: str,
+    status: str,
+    result: Mapping[str, Any] | None = None,
+    error: str = "",
+) -> None:
+    write_json_atomic(
+        path,
+        _ledger_payload(
+            unit_id=unit_id,
+            idempotency_token=idempotency_token,
+            scope=scope,
+            status=status,
+            result=result,
+            error=error,
+        ),
+    )
+
+
+def _ledger_payload(
+    *,
+    unit_id: str,
+    idempotency_token: str,
+    scope: str,
+    status: str,
+    result: Mapping[str, Any] | None = None,
+    error: str = "",
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "schema": "agilab.dag_stage_idempotency.v1",
+        "unit_id": unit_id,
+        "idempotency_token": idempotency_token,
+        "scope": scope,
+        "status": status,
+    }
+    if result is not None:
+        payload["result"] = dict(result)
+    if error:
+        payload["error"] = error
+    return payload
+
+
+__all__ = [
+    "DagExternalExecutionUncertainError",
+    "execute_idempotently",
+    "fsync_directory",
+    "write_json_atomic",
+]

--- a/src/agilab/dag/dag_run_engine.py
+++ b/src/agilab/dag/dag_run_engine.py
@@ -1,9 +1,16 @@
 from __future__ import annotations
 
+from copy import deepcopy
 from dataclasses import dataclass
 from datetime import datetime, timezone
+import os
 from pathlib import Path
-from typing import Any, Callable, Mapping
+import socket
+import subprocess
+import sys
+import threading
+from typing import Any, Callable, Mapping, Protocol, TypeVar
+from uuid import uuid4
 
 from .dag_execution_adapters import (
     DAG_STAGE_BACKEND_DISTRIBUTED,
@@ -14,12 +21,15 @@ from .dag_execution_adapters import (
     DagBatchExecutionResult,
     DagExecutionContext,
     DagStageExecutionResult,
+    _DURABLE_CLAIM_RECEIPT,
     available_artifact_ids,  # noqa: F401 - re-exported for pipeline_lab compatibility
     dag_units,
+    recover_execution_attempt,
     registered_execution_adapter_ids,
-    run_ready_adapter_stages,
-    run_next_adapter_stage,
+    _run_next_adapter_stage_uncommitted,
+    _run_ready_adapter_stages_uncommitted,
 )
+from .dag_idempotency import DagExternalExecutionUncertainError  # noqa: F401 - public failure contract
 from .dag_execution_registry import (
     CONTROLLED_CONTRACT_ADAPTER,
     CONTROLLED_CONTRACT_RUNNER_STATUS,
@@ -42,10 +52,20 @@ from agilab.global_pipeline.global_pipeline_app_dispatch_smoke import (
 )
 from agilab.global_pipeline.global_pipeline_runner_state import (
     RunnerDispatchResult,
+    RunnerStateAttemptConflictError,  # noqa: F401 - re-exported for Streamlit compatibility
+    RunnerStateConflictError,  # noqa: F401 - re-exported for Streamlit compatibility
+    RunnerStateDurabilityError,  # noqa: F401 - re-exported for Streamlit compatibility
+    RunnerStateRecoveryRequiredError,  # noqa: F401 - re-exported for Streamlit compatibility
+    build_persisted_runner_state,
     dispatch_next_runnable as dispatch_next_runnable_state,
-    load_runner_state,
-    persist_runner_state,
-    write_runner_state,
+    load_runner_state,  # noqa: F401 - re-exported for pipeline_lab compatibility
+    load_runner_state_snapshot,
+    persist_runner_state,  # noqa: F401 - re-exported for pipeline_lab compatibility
+    runner_state_active_attempt,
+    runner_state_revision,
+    runner_state_transaction,
+    runner_state_write_transaction,
+    write_runner_state,  # noqa: F401 - re-exported for pipeline_lab compatibility
 )
 from agilab.workflow.workflow_run_manifest import WorkflowEvidenceBundle, write_workflow_run_evidence
 
@@ -70,8 +90,245 @@ dispatch_next_runnable = dispatch_next_runnable_state
 registered_dag_execution_adapter_ids = registered_execution_adapter_ids
 
 
+class DagExecutionRecoveryBlockedError(RuntimeError):
+    """Raised when the original execution owner may still be running."""
+
+
+class _RunnerStateResult(Protocol):
+    state: dict[str, Any]
+
+
+_RunnerStateResultT = TypeVar("_RunnerStateResultT", bound=_RunnerStateResult)
+_ACTIVE_EXECUTION_OWNERS: dict[tuple[str, str], int] = {}
+_FINISHED_EXECUTION_OWNERS: set[tuple[str, str]] = set()
+_ACTIVE_EXECUTION_OWNERS_LOCK = threading.Lock()
+
+
 def _now_iso() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _process_incarnation(pid: int) -> str | None:
+    """Return a stable process start proof, None when dead, or empty when unknown."""
+
+    if os.name != "nt":
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return None
+        except PermissionError:
+            pass
+
+    if sys.platform.startswith("linux"):
+        try:
+            stat_text = Path(f"/proc/{pid}/stat").read_text(encoding="utf-8")
+        except FileNotFoundError:
+            return None
+        except OSError:
+            return ""
+        command_end = stat_text.rfind(")")
+        fields = stat_text[command_end + 2 :].split() if command_end >= 0 else []
+        return f"procfs:{fields[19]}" if len(fields) > 19 else ""
+
+    if os.name == "nt":  # pragma: no cover - exercised on Windows CI
+        try:
+            import ctypes
+            from ctypes import wintypes
+
+            class _FileTime(ctypes.Structure):
+                _fields_ = (("low", wintypes.DWORD), ("high", wintypes.DWORD))
+
+            kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+            open_process = kernel32.OpenProcess
+            open_process.argtypes = (wintypes.DWORD, wintypes.BOOL, wintypes.DWORD)
+            open_process.restype = wintypes.HANDLE
+            get_process_times = kernel32.GetProcessTimes
+            get_process_times.argtypes = (
+                wintypes.HANDLE,
+                ctypes.POINTER(_FileTime),
+                ctypes.POINTER(_FileTime),
+                ctypes.POINTER(_FileTime),
+                ctypes.POINTER(_FileTime),
+            )
+            get_process_times.restype = wintypes.BOOL
+            close_handle = kernel32.CloseHandle
+            close_handle.argtypes = (wintypes.HANDLE,)
+            close_handle.restype = wintypes.BOOL
+            handle = open_process(0x1000, False, pid)  # PROCESS_QUERY_LIMITED_INFORMATION
+            if not handle:
+                return None if ctypes.get_last_error() == 87 else ""
+            try:
+                created = _FileTime()
+                exited = _FileTime()
+                kernel = _FileTime()
+                user = _FileTime()
+                if not get_process_times(
+                    handle,
+                    ctypes.byref(created),
+                    ctypes.byref(exited),
+                    ctypes.byref(kernel),
+                    ctypes.byref(user),
+                ):
+                    return ""
+                return f"filetime:{(created.high << 32) | created.low}"
+            finally:
+                close_handle(handle)
+        except (AttributeError, OSError, TypeError, ValueError):
+            return ""
+
+    try:
+        completed = subprocess.run(
+            ["ps", "-o", "lstart=", "-p", str(pid)],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    started = completed.stdout.strip()
+    if completed.returncode != 0 or not started:
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return None
+        except (PermissionError, OSError):
+            return ""
+        return ""
+    return f"ps:{started}"
+
+
+_CURRENT_PROCESS_PID = os.getpid()
+_CURRENT_PROCESS_INCARNATION = _process_incarnation(_CURRENT_PROCESS_PID)
+
+
+def _current_execution_owner() -> dict[str, Any]:
+    pid = os.getpid()
+    incarnation = (
+        _CURRENT_PROCESS_INCARNATION
+        if pid == _CURRENT_PROCESS_PID
+        else _process_incarnation(pid)
+    )
+    if not incarnation:
+        raise RuntimeError("Could not prove the DAG execution owner process incarnation.")
+    return {
+        "host": socket.gethostname(),
+        "pid": pid,
+        "process_incarnation": incarnation,
+        "thread_id": threading.get_ident(),
+    }
+
+
+def _execution_owner_key(path: Path, attempt_id: str) -> tuple[str, str]:
+    return str(path.expanduser().resolve(strict=False)), attempt_id
+
+
+def _register_execution_owner(path: Path, attempt_id: str, thread_id: int) -> None:
+    with _ACTIVE_EXECUTION_OWNERS_LOCK:
+        key = _execution_owner_key(path, attempt_id)
+        _FINISHED_EXECUTION_OWNERS.discard(key)
+        _ACTIVE_EXECUTION_OWNERS[key] = thread_id
+
+
+def _unregister_execution_owner(
+    path: Path,
+    attempt_id: str,
+    *,
+    callback_finished: bool = False,
+) -> None:
+    with _ACTIVE_EXECUTION_OWNERS_LOCK:
+        key = _execution_owner_key(path, attempt_id)
+        _ACTIVE_EXECUTION_OWNERS.pop(key, None)
+        if callback_finished:
+            _FINISHED_EXECUTION_OWNERS.add(key)
+
+
+def _clear_finished_execution_owner(path: Path, attempt_id: str) -> None:
+    with _ACTIVE_EXECUTION_OWNERS_LOCK:
+        _FINISHED_EXECUTION_OWNERS.discard(_execution_owner_key(path, attempt_id))
+
+
+def _execution_owner_liveness(
+    path: Path,
+    active_execution: Mapping[str, Any],
+) -> bool | None:
+    """Return True for live, False for dead, and None when proof is unavailable."""
+
+    if str(active_execution.get("status", "")) == "recovery_required":
+        return False
+    owner = active_execution.get("owner")
+    if not isinstance(owner, Mapping) or str(owner.get("host", "")) != socket.gethostname():
+        return None
+    try:
+        pid = int(owner.get("pid"))
+        thread_id = int(owner.get("thread_id"))
+    except (TypeError, ValueError):
+        return None
+    recorded_incarnation = str(owner.get("process_incarnation", ""))
+    if not recorded_incarnation:
+        return None
+    current_incarnation = (
+        _CURRENT_PROCESS_INCARNATION
+        if pid == _CURRENT_PROCESS_PID
+        else _process_incarnation(pid)
+    )
+    if current_incarnation is None or (
+        current_incarnation and current_incarnation != recorded_incarnation
+    ):
+        return False
+    if not current_incarnation:
+        return None
+    if pid != os.getpid():
+        return True
+    owner_key = _execution_owner_key(
+        path,
+        str(active_execution.get("attempt_id", "")),
+    )
+    with _ACTIVE_EXECUTION_OWNERS_LOCK:
+        if owner_key in _FINISHED_EXECUTION_OWNERS:
+            return False
+        registered_thread = _ACTIVE_EXECUTION_OWNERS.get(owner_key)
+    if registered_thread is None:
+        return None
+    return registered_thread == thread_id
+
+
+def _active_attempt_id(state: Mapping[str, Any]) -> str:
+    active = runner_state_active_attempt(state)
+    return str(active.get("attempt_id", "")).strip() if active is not None else ""
+
+
+def _active_unit_tokens(state: Mapping[str, Any]) -> dict[str, str]:
+    active = runner_state_active_attempt(state)
+    values = active.get("unit_tokens") if active is not None else None
+    if not isinstance(values, Mapping):
+        return {}
+    return {
+        str(unit_id): str(token)
+        for unit_id, token in values.items()
+        if str(unit_id) and str(token)
+    }
+
+
+def _claimed_unit_tokens(state: Mapping[str, Any], attempt_id: str) -> dict[str, str]:
+    tokens: dict[str, str] = {}
+    for unit in dag_units(state):
+        attempt = unit.get("execution_attempt")
+        if not isinstance(attempt, Mapping) or str(attempt.get("id", "")) != attempt_id:
+            continue
+        if unit.get("dispatch_status") != "running" or attempt.get("status") != "running":
+            continue
+        token = str(attempt.get("idempotency_token", "")).strip()
+        unit_id = str(unit.get("id", "")).strip()
+        if unit_id and token:
+            tokens[unit_id] = token
+    return tokens
+
+
+def _raise_if_active_attempt(path: Path, state: Mapping[str, Any]) -> None:
+    attempt_id = _active_attempt_id(state)
+    if attempt_id:
+        raise RunnerStateRecoveryRequiredError(path, attempt_id=attempt_id)
 
 
 @dataclass(frozen=True)
@@ -85,30 +342,73 @@ class DagRunEngine:
     stage_run_fns: Mapping[str, Callable[..., Mapping[str, Any]]] | None = None
     stage_submit_fn: Callable[..., Mapping[str, Any]] | None = None
     now_fn: Callable[[], str] = lambda: _now_iso()
+    attempt_id_fn: Callable[[], str] = lambda: uuid4().hex
 
     @property
     def state_path(self) -> Path:
         return self.lab_dir / ".agilab" / self.state_filename
 
     def load_or_create_state(self, *, reset: bool = False) -> tuple[dict[str, Any], Path, Path | None]:
-        if self.state_path.is_file() and not reset:
-            state = load_runner_state(self.state_path)
+        state, observed_revision = load_runner_state_snapshot(self.state_path)
+        if state is not None and not reset:
             if runner_state_dag_matches(state, self.dag_path, self.repo_root):
                 return state, self.state_path, self.dag_path
-        proof = persist_runner_state(
+        if state is not None:
+            _raise_if_active_attempt(self.state_path, state)
+
+        replacement = build_persisted_runner_state(
             repo_root=self.repo_root,
-            output_path=self.state_path,
             dag_path=self.dag_path,
         )
-        self.write_evidence(
-            proof.runner_state,
-            state_path=self.state_path,
-            trigger={"surface": "workflow", "action": "state_created"},
-        )
-        return proof.runner_state, self.state_path, self.dag_path
+        try:
+            with runner_state_write_transaction(
+                self.state_path,
+                replacement,
+                expected_revision=observed_revision,
+            ) as state_path:
+                pass
+            self.write_evidence(
+                replacement,
+                state_path=state_path,
+                trigger={"surface": "workflow", "action": "state_created"},
+            )
+        except RunnerStateConflictError:
+            if not reset:
+                current, _current_revision = load_runner_state_snapshot(self.state_path)
+                if current is not None and runner_state_dag_matches(
+                    current,
+                    self.dag_path,
+                    self.repo_root,
+                ):
+                    return current, self.state_path, self.dag_path
+            raise
+        return replacement, self.state_path, self.dag_path
 
-    def write_state(self, state: Mapping[str, Any]) -> Path:
-        state_path = write_runner_state(self.state_path, state)
+    def write_state(
+        self,
+        state: Mapping[str, Any],
+        *,
+        expected_revision: str | None = None,
+    ) -> Path:
+        current, current_revision = load_runner_state_snapshot(self.state_path)
+        if current is not None:
+            _raise_if_active_attempt(self.state_path, current)
+            if expected_revision is None:
+                raise ValueError(
+                    "Writing an existing DAG runner state requires the revision observed "
+                    "with the caller's snapshot."
+                )
+        effective_revision = (
+            expected_revision
+            if expected_revision is not None
+            else current_revision
+        )
+        with runner_state_write_transaction(
+            self.state_path,
+            state,
+            expected_revision=effective_revision,
+        ) as state_path:
+            pass
         self.write_evidence(
             state,
             state_path=state_path,
@@ -135,14 +435,38 @@ class DagRunEngine:
     def dispatch_next_runnable(self, state: Mapping[str, Any]) -> RunnerDispatchResult:
         return dispatch_next_runnable_state(state)
 
+    def dispatch_next_runnable_transaction(
+        self,
+        state: Mapping[str, Any],
+    ) -> RunnerDispatchResult:
+        return self._run_state_transaction(
+            state,
+            action=self.dispatch_next_runnable,
+            trigger_action="preview_dispatched",
+        )
+
     def real_run_supported(self, state: Mapping[str, Any]) -> bool:
         return self.real_run_support(state).supported
 
     def real_run_support(self, state: Mapping[str, Any]) -> DagRealRunSupport:
         return controlled_real_run_support(state, self.dag_path, self.repo_root)
 
-    def run_next_controlled_stage(self, state: Mapping[str, Any]) -> DagStageExecutionResult:
-        return run_next_controlled_stage(
+    def run_next_controlled_stage(
+        self,
+        state: Mapping[str, Any],
+    ) -> DagStageExecutionResult:
+        """Run one stage through the durable runner-state transaction boundary."""
+
+        return self.run_next_controlled_stage_transaction(state)
+
+    def _run_next_controlled_stage_uncommitted(
+        self,
+        state: Mapping[str, Any],
+        *,
+        execution_attempt_id: str,
+        persist_execution_claim_fn: Callable[[Mapping[str, Any]], object],
+    ) -> DagStageExecutionResult:
+        return _run_next_controlled_stage_uncommitted(
             state,
             repo_root=self.repo_root,
             dag_path=self.dag_path,
@@ -151,6 +475,22 @@ class DagRunEngine:
             run_relay_fn=self.run_relay_fn,
             stage_run_fns=self.stage_run_fns,
             now_fn=self.now_fn,
+            execution_attempt_id=execution_attempt_id,
+            persist_execution_claim_fn=persist_execution_claim_fn,
+        )
+
+    def run_next_controlled_stage_transaction(
+        self,
+        state: Mapping[str, Any],
+    ) -> DagStageExecutionResult:
+        return self._run_execution_state_transaction(
+            state,
+            action=lambda current, attempt_id, persist_claim: self._run_next_controlled_stage_uncommitted(
+                current,
+                execution_attempt_id=attempt_id,
+                persist_execution_claim_fn=persist_claim,
+            ),
+            trigger_action="controlled_stage_executed",
         )
 
     def run_ready_controlled_stages(
@@ -160,7 +500,24 @@ class DagRunEngine:
         max_workers: int | None = None,
         execution_backend: str = GLOBAL_DAG_STAGE_BACKEND_LOCAL,
     ) -> DagBatchExecutionResult:
-        return run_ready_controlled_stages(
+        """Run all ready stages through the durable runner-state transaction boundary."""
+
+        return self.run_ready_controlled_stages_transaction(
+            state,
+            max_workers=max_workers,
+            execution_backend=execution_backend,
+        )
+
+    def _run_ready_controlled_stages_uncommitted(
+        self,
+        state: Mapping[str, Any],
+        *,
+        max_workers: int | None,
+        execution_backend: str,
+        execution_attempt_id: str,
+        persist_execution_claim_fn: Callable[[Mapping[str, Any]], object],
+    ) -> DagBatchExecutionResult:
+        return _run_ready_controlled_stages_uncommitted(
             state,
             repo_root=self.repo_root,
             dag_path=self.dag_path,
@@ -172,7 +529,323 @@ class DagRunEngine:
             now_fn=self.now_fn,
             max_workers=max_workers,
             execution_backend=execution_backend,
+            execution_attempt_id=execution_attempt_id,
+            persist_execution_claim_fn=persist_execution_claim_fn,
         )
+
+    def run_ready_controlled_stages_transaction(
+        self,
+        state: Mapping[str, Any],
+        *,
+        max_workers: int | None = None,
+        execution_backend: str = GLOBAL_DAG_STAGE_BACKEND_LOCAL,
+    ) -> DagBatchExecutionResult:
+        return self._run_execution_state_transaction(
+            state,
+            action=lambda current, attempt_id, persist_claim: self._run_ready_controlled_stages_uncommitted(
+                current,
+                max_workers=max_workers,
+                execution_backend=execution_backend,
+                execution_attempt_id=attempt_id,
+                persist_execution_claim_fn=persist_claim,
+            ),
+            trigger_action="controlled_stages_executed",
+        )
+
+    def _run_execution_state_transaction(
+        self,
+        state: Mapping[str, Any],
+        *,
+        action: Callable[
+            [Mapping[str, Any], str, Callable[[Mapping[str, Any]], object]],
+            _RunnerStateResultT,
+        ],
+        trigger_action: str,
+    ) -> _RunnerStateResultT:
+        attempt_id = self.attempt_id_fn()
+        expected_revision = runner_state_revision(state)
+        _raise_if_active_attempt(self.state_path, state)
+        claim_persisted = False
+        claim_revision = ""
+        claimed_tokens: dict[str, str] = {}
+        owner_registered = False
+
+        def _persist_claim(claim_state: Mapping[str, Any]) -> object:
+            nonlocal claim_persisted, claim_revision, claimed_tokens, owner_registered
+            if claim_persisted:
+                raise RuntimeError("A DAG execution attempt may persist only one pre-execution claim.")
+            mutable_claim = claim_state if isinstance(claim_state, dict) else dict(claim_state)
+            claimed_tokens = _claimed_unit_tokens(mutable_claim, attempt_id)
+            if not claimed_tokens:
+                raise RuntimeError("A DAG execution attempt must claim at least one unique unit token.")
+            if len(set(claimed_tokens.values())) != len(claimed_tokens):
+                raise RuntimeError("A DAG execution attempt produced duplicate per-unit idempotency tokens.")
+            owner = _current_execution_owner()
+            mutable_claim["active_execution"] = {
+                "attempt_id": attempt_id,
+                "status": "running",
+                "claimed_at": str(mutable_claim.get("updated_at", "")),
+                "unit_tokens": claimed_tokens,
+                "recovery_policy": "exact_unit_token_required",
+                "owner": owner,
+            }
+            with runner_state_write_transaction(
+                self.state_path,
+                mutable_claim,
+                expected_revision=expected_revision,
+                require_directory_fsync=True,
+            ) as state_path:
+                pass
+            claim_revision = runner_state_revision(mutable_claim)
+            claim_persisted = True
+            _register_execution_owner(
+                self.state_path,
+                attempt_id,
+                int(owner["thread_id"]),
+            )
+            owner_registered = True
+            self.write_evidence(
+                mutable_claim,
+                state_path=state_path,
+                trigger={
+                    "surface": "workflow",
+                    "action": "controlled_stage_claimed",
+                    "attempt_id": attempt_id,
+                    "idempotency_tokens": claimed_tokens,
+                },
+            )
+            return _DURABLE_CLAIM_RECEIPT
+
+        def _persist_recovery_required(exc: BaseException) -> None:
+            error_detail = (
+                exc.detail
+                if isinstance(exc, DagExternalExecutionUncertainError)
+                else (str(exc).strip() or type(exc).__name__)
+            )
+            if not claim_persisted:
+                return
+            try:
+                # The exact attempt/tokens are the ownership proof. Do not let
+                # an unrelated revision bump prevent fail-closed recovery state.
+                with runner_state_transaction(self.state_path) as transaction:
+                    latest_attempt_id = _active_attempt_id(transaction.state)
+                    if (
+                        latest_attempt_id != attempt_id
+                        or _active_unit_tokens(transaction.state) != claimed_tokens
+                    ):
+                        raise RunnerStateAttemptConflictError(
+                            self.state_path,
+                            expected_attempt_id=attempt_id,
+                            actual_attempt_id=latest_attempt_id,
+                        )
+                    recovery_state = deepcopy(transaction.state)
+                    active_execution = recovery_state.get("active_execution")
+                    if not isinstance(active_execution, dict):
+                        raise RunnerStateAttemptConflictError(
+                            self.state_path,
+                            expected_attempt_id=attempt_id,
+                            actual_attempt_id="",
+                        )
+                    active_execution["status"] = "recovery_required"
+                    active_execution["recovery_required_at"] = self.now_fn()
+                    active_execution["error"] = error_detail
+                    state_path = transaction.commit(recovery_state)
+                self.write_evidence(
+                    recovery_state,
+                    state_path=state_path,
+                    trigger={
+                        "surface": "workflow",
+                        "action": "controlled_stage_recovery_required",
+                        "attempt_id": attempt_id,
+                        "idempotency_tokens": claimed_tokens,
+                        "error": error_detail,
+                    },
+                )
+            except BaseException as status_exc:
+                exc.add_note(
+                    "AGILAB could not persist the recovery-required status update: "
+                    f"{status_exc}"
+                )
+
+        try:
+            result = action(state, attempt_id, _persist_claim)
+        except BaseException as exc:
+            _persist_recovery_required(exc)
+            if owner_registered:
+                _unregister_execution_owner(
+                    self.state_path,
+                    attempt_id,
+                    callback_finished=claim_persisted,
+                )
+            raise
+        finalization_succeeded = False
+        try:
+            if claim_persisted:
+                final_state = deepcopy(result.state)
+                result_tokens = _active_unit_tokens(final_state)
+                if (
+                    result_tokens != claimed_tokens
+                    or _active_attempt_id(final_state) != attempt_id
+                ):
+                    raise RunnerStateAttemptConflictError(
+                        self.state_path,
+                        expected_attempt_id=attempt_id,
+                        actual_attempt_id=_active_attempt_id(final_state),
+                    )
+                for unit in dag_units(final_state):
+                    unit_id = str(unit.get("id", ""))
+                    if unit_id not in claimed_tokens:
+                        continue
+                    attempt = unit.get("execution_attempt")
+                    token = (
+                        str(attempt.get("idempotency_token", ""))
+                        if isinstance(attempt, Mapping)
+                        else ""
+                    )
+                    if token != claimed_tokens[unit_id] or unit.get(
+                        "dispatch_status"
+                    ) not in {"completed", "failed"}:
+                        raise RunnerStateAttemptConflictError(
+                            self.state_path,
+                            expected_attempt_id=attempt_id,
+                            actual_attempt_id=(
+                                str(attempt.get("id", ""))
+                                if isinstance(attempt, Mapping)
+                                else ""
+                            ),
+                        )
+                final_state.pop("active_execution", None)
+                with runner_state_transaction(
+                    self.state_path,
+                    expected_revision=claim_revision,
+                ) as transaction:
+                    latest_attempt_id = _active_attempt_id(transaction.state)
+                    if (
+                        latest_attempt_id != attempt_id
+                        or _active_unit_tokens(transaction.state) != claimed_tokens
+                    ):
+                        raise RunnerStateAttemptConflictError(
+                            self.state_path,
+                            expected_attempt_id=attempt_id,
+                            actual_attempt_id=latest_attempt_id,
+                        )
+                    state_path = transaction.commit(final_state)
+                result.state.clear()
+                result.state.update(final_state)
+                self.write_evidence(
+                    final_state,
+                    state_path=state_path,
+                    trigger={
+                        "surface": "workflow",
+                        "action": trigger_action,
+                        "attempt_id": attempt_id,
+                        "idempotency_tokens": claimed_tokens,
+                    },
+                )
+                finalization_succeeded = True
+                return result
+
+            if runner_state_revision(result.state) != expected_revision:
+                with runner_state_transaction(
+                    self.state_path,
+                    expected_revision=expected_revision,
+                ) as transaction:
+                    state_path = transaction.commit(result.state)
+                self.write_evidence(
+                    result.state,
+                    state_path=state_path,
+                    trigger={"surface": "workflow", "action": trigger_action},
+                )
+            finalization_succeeded = True
+            return result
+        except BaseException as exc:
+            _persist_recovery_required(exc)
+            raise
+        finally:
+            if owner_registered:
+                _unregister_execution_owner(
+                    self.state_path,
+                    attempt_id,
+                    callback_finished=claim_persisted and not finalization_succeeded,
+                )
+
+    def _run_state_transaction(
+        self,
+        state: Mapping[str, Any],
+        *,
+        action: Callable[[Mapping[str, Any]], _RunnerStateResultT],
+        trigger_action: str,
+    ) -> _RunnerStateResultT:
+        expected_revision = runner_state_revision(state)
+        _raise_if_active_attempt(self.state_path, state)
+        with runner_state_transaction(
+            self.state_path,
+            expected_revision=expected_revision,
+        ) as transaction:
+            result = action(transaction.state)
+            if runner_state_revision(result.state) != transaction.revision:
+                state_path = transaction.commit(result.state)
+            else:
+                state_path = None
+        if state_path is not None:
+            self.write_evidence(
+                result.state,
+                state_path=state_path,
+                trigger={"surface": "workflow", "action": trigger_action},
+            )
+        return result
+
+    def recover_execution_attempt_transaction(
+        self,
+        state: Mapping[str, Any],
+        *,
+        unit_id: str,
+        idempotency_token: str,
+    ) -> dict[str, Any]:
+        expected_revision = runner_state_revision(state)
+        with runner_state_transaction(
+            self.state_path,
+            expected_revision=expected_revision,
+        ) as transaction:
+            active_attempt_id = _active_attempt_id(transaction.state)
+            recorded_token = _active_unit_tokens(transaction.state).get(unit_id, "")
+            if recorded_token != idempotency_token:
+                raise RunnerStateAttemptConflictError(
+                    self.state_path,
+                    expected_attempt_id=idempotency_token,
+                    actual_attempt_id=recorded_token,
+                )
+            active_execution = runner_state_active_attempt(transaction.state)
+            owner_liveness = (
+                _execution_owner_liveness(self.state_path, active_execution)
+                if active_execution is not None
+                else None
+            )
+            if owner_liveness is not False:
+                detail = "is still live" if owner_liveness else "cannot be proven stopped"
+                raise DagExecutionRecoveryBlockedError(
+                    f"Execution attempt `{_active_attempt_id(transaction.state)}` owner {detail}; "
+                    "exact-token recovery is denied until the callback has stopped."
+                )
+            recovered = recover_execution_attempt(
+                transaction.state,
+                unit_id=unit_id,
+                idempotency_token=idempotency_token,
+                timestamp=self.now_fn(),
+            )
+            state_path = transaction.commit(recovered)
+        _clear_finished_execution_owner(self.state_path, active_attempt_id)
+        self.write_evidence(
+            recovered,
+            state_path=state_path,
+            trigger={
+                "surface": "workflow",
+                "action": "controlled_stage_recovered",
+                "unit_id": unit_id,
+                "idempotency_token": idempotency_token,
+            },
+        )
+        return recovered
 
     def distributed_stage_supported(self) -> bool:
         return self.stage_submit_fn is not None
@@ -257,6 +930,32 @@ def run_next_controlled_stage(
     stage_run_fns: Mapping[str, Callable[..., Mapping[str, Any]]] | None = None,
     now_fn: Callable[[], str] = _now_iso,
 ) -> DagStageExecutionResult:
+    """Run one controlled stage with a durable claim and CAS finalization."""
+
+    return DagRunEngine(
+        repo_root=repo_root,
+        lab_dir=lab_dir,
+        dag_path=dag_path,
+        run_queue_fn=run_queue_fn,
+        run_relay_fn=run_relay_fn,
+        stage_run_fns=stage_run_fns,
+        now_fn=now_fn,
+    ).run_next_controlled_stage(state)
+
+
+def _run_next_controlled_stage_uncommitted(
+    state: Mapping[str, Any],
+    *,
+    repo_root: Path,
+    dag_path: Path | None,
+    lab_dir: Path,
+    execution_attempt_id: str,
+    persist_execution_claim_fn: Callable[[Mapping[str, Any]], object],
+    run_queue_fn: Callable[..., Mapping[str, Any]] | None = None,
+    run_relay_fn: Callable[..., Mapping[str, Any]] | None = None,
+    stage_run_fns: Mapping[str, Callable[..., Mapping[str, Any]]] | None = None,
+    now_fn: Callable[[], str] = _now_iso,
+) -> DagStageExecutionResult:
     support = controlled_real_run_support(state, dag_path, repo_root)
     if not support.supported:
         return DagStageExecutionResult(
@@ -265,7 +964,7 @@ def run_next_controlled_stage(
             state=dict(state),
         )
 
-    return run_next_adapter_stage(
+    return _run_next_adapter_stage_uncommitted(
         support.adapter,
         state,
         DagExecutionContext(
@@ -275,6 +974,8 @@ def run_next_controlled_stage(
             run_relay_fn=run_relay_fn or run_multi_app_dag_relay_followup_app,
             stage_run_fns=stage_run_fns,
             now_fn=now_fn,
+            execution_attempt_id=execution_attempt_id,
+            persist_execution_claim_fn=persist_execution_claim_fn,
         ),
     )
 
@@ -293,6 +994,40 @@ def run_ready_controlled_stages(
     max_workers: int | None = None,
     execution_backend: str = GLOBAL_DAG_STAGE_BACKEND_LOCAL,
 ) -> DagBatchExecutionResult:
+    """Run ready controlled stages with one durable multi-unit transaction."""
+
+    return DagRunEngine(
+        repo_root=repo_root,
+        lab_dir=lab_dir,
+        dag_path=dag_path,
+        run_queue_fn=run_queue_fn,
+        run_relay_fn=run_relay_fn,
+        stage_run_fns=stage_run_fns,
+        stage_submit_fn=stage_submit_fn,
+        now_fn=now_fn,
+    ).run_ready_controlled_stages(
+        state,
+        max_workers=max_workers,
+        execution_backend=execution_backend,
+    )
+
+
+def _run_ready_controlled_stages_uncommitted(
+    state: Mapping[str, Any],
+    *,
+    repo_root: Path,
+    dag_path: Path | None,
+    lab_dir: Path,
+    execution_attempt_id: str,
+    persist_execution_claim_fn: Callable[[Mapping[str, Any]], object],
+    run_queue_fn: Callable[..., Mapping[str, Any]] | None = None,
+    run_relay_fn: Callable[..., Mapping[str, Any]] | None = None,
+    stage_run_fns: Mapping[str, Callable[..., Mapping[str, Any]]] | None = None,
+    stage_submit_fn: Callable[..., Mapping[str, Any]] | None = None,
+    now_fn: Callable[[], str] = _now_iso,
+    max_workers: int | None = None,
+    execution_backend: str = GLOBAL_DAG_STAGE_BACKEND_LOCAL,
+) -> DagBatchExecutionResult:
     support = controlled_real_run_support(state, dag_path, repo_root)
     if not support.supported:
         return DagBatchExecutionResult(
@@ -301,7 +1036,7 @@ def run_ready_controlled_stages(
             state=dict(state),
         )
 
-    return run_ready_adapter_stages(
+    return _run_ready_adapter_stages_uncommitted(
         support.adapter,
         state,
         DagExecutionContext(
@@ -312,6 +1047,8 @@ def run_ready_controlled_stages(
             stage_run_fns=stage_run_fns,
             stage_submit_fn=stage_submit_fn,
             now_fn=now_fn,
+            execution_attempt_id=execution_attempt_id,
+            persist_execution_claim_fn=persist_execution_claim_fn,
         ),
         max_workers=max_workers,
         execution_backend=execution_backend,

--- a/src/agilab/diagnostics/runtime_diagnostics.py
+++ b/src/agilab/diagnostics/runtime_diagnostics.py
@@ -154,8 +154,10 @@ def load_settings_file(settings_path: Path | str | None) -> dict[str, Any]:
     if not path.exists():
         return {}
     try:
-        with path.open("rb") as stream:
-            loaded = tomllib.load(stream)
+        # Keep agi-env optional for importing the base package.
+        from agi_env.app_settings_support import read_app_settings
+
+        loaded = read_app_settings(path)
     except (OSError, tomllib.TOMLDecodeError):
         return {}
     return dict(loaded) if isinstance(loaded, dict) else {}
@@ -165,9 +167,17 @@ def persist_diagnostics_verbose(settings_path: Path | str | None, verbose: Any) 
     if settings_path in (None, ""):
         return {}
     path = Path(settings_path)
-    settings = load_settings_file(path)
-    update_settings_diagnostics(settings, verbose)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("wb") as stream:
-        tomli_w.dump(settings, stream)
+    # Keep agi-env optional for importing the base package.
+    from agi_env.app_settings_support import update_app_settings
+
+    def _update(settings: dict[str, Any]) -> bool:
+        update_settings_diagnostics(settings, verbose)
+        return True
+
+    settings, _changed = update_app_settings(
+        path,
+        _update,
+        dump_fn=tomli_w.dump,
+        prepare_fn=lambda payload: payload,
+    )
     return settings

--- a/src/agilab/environment/env_file_utils.py
+++ b/src/agilab/environment/env_file_utils.py
@@ -1,6 +1,37 @@
 from __future__ import annotations
 
+import os
+import time
 from pathlib import Path
+
+
+_WINDOWS_FILE_SHARING_RETRY_TIMEOUT_SECONDS = 0.5
+_WINDOWS_FILE_SHARING_RETRY_INTERVAL_SECONDS = 0.01
+
+
+def _is_windows() -> bool:
+    return os.name == "nt"
+
+
+def read_mutable_env_text(path: Path, *, errors: str | None = None) -> str:
+    """Read a replace-in-place dotenv file across Windows sharing windows.
+
+    This base-package helper intentionally keeps its retry local: importing the
+    equivalent agi-env helper here would make the optional UI/core package a
+    base-package dependency.
+    """
+
+    deadline = time.monotonic() + _WINDOWS_FILE_SHARING_RETRY_TIMEOUT_SECONDS
+    while True:
+        try:
+            return path.read_text(encoding="utf-8", errors=errors)
+        except PermissionError:
+            if not _is_windows():
+                raise
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise
+            time.sleep(min(_WINDOWS_FILE_SHARING_RETRY_INTERVAL_SECONDS, remaining))
 
 
 def _strip_env_value_quotes(value: str) -> str:
@@ -14,7 +45,7 @@ def load_env_file_map(path: Path, *, include_commented: bool = True) -> dict[str
     """Return a key/value mapping from a .env-like file."""
     env_map: dict[str, str] = {}
     try:
-        for raw in path.read_text(encoding="utf-8").splitlines():
+        for raw in read_mutable_env_text(path).splitlines():
             stripped = raw.strip()
             if not stripped or "=" not in stripped:
                 continue

--- a/src/agilab/global_pipeline/global_pipeline_app_dispatch_smoke.py
+++ b/src/agilab/global_pipeline/global_pipeline_app_dispatch_smoke.py
@@ -12,6 +12,7 @@ import sys
 from types import SimpleNamespace
 from typing import Any, Mapping
 
+from agilab.dag.dag_idempotency import execute_idempotently
 from agilab.global_pipeline.global_pipeline_dispatch_state import (
     PERSISTENCE_FORMAT,
     SCHEMA as DISPATCH_STATE_SCHEMA,
@@ -205,7 +206,7 @@ def _make_env(run_root: Path, *, target: str) -> SimpleNamespace:
     )
 
 
-def _run_queue_family_app(
+def _run_queue_family_app_once(
     *,
     repo_root: Path,
     run_root: Path,
@@ -217,7 +218,11 @@ def _run_queue_family_app(
     worker_class_name: str,
     target: str,
     app_entry: str,
+    idempotency_token: str,
 ) -> dict[str, Any]:
+    token = str(idempotency_token).strip()
+    if not token:
+        raise ValueError("A non-empty idempotency token is required before real app execution.")
     _ensure_app_project_on_path(repo_root, project_name)
     _drop_app_module_cache((manager_package, worker_package))
     manager_module = importlib.import_module(manager_package)
@@ -269,13 +274,53 @@ def _run_queue_family_app(
         "summary_metrics_path": _relative(summary_path, run_root),
         "reduce_artifact_path": _relative(reduce_path, run_root),
         "summary_metrics": metrics,
+        "idempotency_token": token,
     }
+
+
+def _run_queue_family_app(
+    *,
+    repo_root: Path,
+    run_root: Path,
+    project_name: str,
+    manager_package: str,
+    worker_package: str,
+    manager_class_name: str,
+    args_class_name: str,
+    worker_class_name: str,
+    target: str,
+    app_entry: str,
+    idempotency_token: str,
+) -> dict[str, Any]:
+    token = str(idempotency_token).strip()
+    if not token:
+        raise ValueError("A non-empty idempotency token is required before real app execution.")
+    return execute_idempotently(
+        run_root=run_root,
+        unit_id=target,
+        idempotency_token=token,
+        scope="queue-family-app",
+        callback=lambda: _run_queue_family_app_once(
+            repo_root=repo_root,
+            run_root=run_root,
+            project_name=project_name,
+            manager_package=manager_package,
+            worker_package=worker_package,
+            manager_class_name=manager_class_name,
+            args_class_name=args_class_name,
+            worker_class_name=worker_class_name,
+            target=target,
+            app_entry=app_entry,
+            idempotency_token=token,
+        ),
+    )
 
 
 def run_queue_baseline_app(
     *,
     repo_root: Path,
     run_root: Path,
+    idempotency_token: str,
 ) -> dict[str, Any]:
     return _run_queue_family_app(
         repo_root=repo_root,
@@ -288,6 +333,7 @@ def run_queue_baseline_app(
         worker_class_name="UavQueueWorker",
         target="multi_app_dag_dispatch_smoke_queue",
         app_entry="uav_queue.UavQueue + uav_queue_worker.UavQueueWorker",
+        idempotency_token=idempotency_token,
     )
 
 
@@ -296,6 +342,7 @@ def run_relay_followup_app(
     repo_root: Path,
     run_root: Path,
     queue_result: Mapping[str, Any],
+    idempotency_token: str,
 ) -> dict[str, Any]:
     result = _run_queue_family_app(
         repo_root=repo_root,
@@ -308,6 +355,7 @@ def run_relay_followup_app(
         worker_class_name="UavRelayQueueWorker",
         target="multi_app_dag_dispatch_smoke_relay",
         app_entry="uav_relay_queue.UavRelayQueue + uav_relay_queue_worker.UavRelayQueueWorker",
+        idempotency_token=idempotency_token,
     )
     result["consumed_artifacts"] = [
         {
@@ -390,11 +438,16 @@ def build_app_dispatch_smoke_state(
     run_root = run_root.resolve()
     plan = build_execution_plan(repo_root=repo_root, dag_path=dag_path)
     runner_state = build_runner_state(repo_root=repo_root, dag_path=dag_path)
-    queue_result = run_queue_baseline_app(repo_root=repo_root, run_root=run_root)
+    queue_result = run_queue_baseline_app(
+        repo_root=repo_root,
+        run_root=run_root,
+        idempotency_token=f"{run_id}:{QUEUE_UNIT_ID}",
+    )
     relay_result = run_relay_followup_app(
         repo_root=repo_root,
         run_root=run_root,
         queue_result=queue_result,
+        idempotency_token=f"{run_id}:{RELAY_UNIT_ID}",
     )
     produces_by_id = _produces_by_id(plan.runnable_units)
 

--- a/src/agilab/global_pipeline/global_pipeline_operator_actions.py
+++ b/src/agilab/global_pipeline/global_pipeline_operator_actions.py
@@ -195,11 +195,13 @@ def build_operator_actions(
     queue_result = run_queue_baseline_app(
         repo_root=repo_root,
         run_root=action_workspace / "retry_queue_baseline",
+        idempotency_token=queue_retry_action_id,
     )
     relay_result = run_relay_followup_app(
         repo_root=repo_root,
         run_root=action_workspace / "partial_rerun_relay_followup",
         queue_result=queue_result,
+        idempotency_token=relay_partial_action_id,
     )
     queue_metrics = queue_result.get("summary_metrics", {})
     relay_metrics = relay_result.get("summary_metrics", {})

--- a/src/agilab/global_pipeline/global_pipeline_runner_state.py
+++ b/src/agilab/global_pipeline/global_pipeline_runner_state.py
@@ -1,17 +1,23 @@
 # BSD 3-Clause License
 #
 # Copyright (c) 2026, Jean-Pierre Morard, THALES SIX GTS France SAS
-"""Read-only runner-state helpers for AGILAB global pipeline DAGs."""
+"""Runner-state helpers for AGILAB global pipeline DAGs."""
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 from copy import deepcopy
 from dataclasses import dataclass
 from datetime import datetime, timezone
+import hashlib
 import json
+import os
 from pathlib import Path
 import sys
-from typing import Any, Mapping
+import tempfile
+import threading
+import time
+from typing import Any, Callable, Iterator, Mapping, TypeVar
 
 _src_root = Path(__file__).resolve().parents[1]
 if str(_src_root) not in sys.path:
@@ -23,7 +29,10 @@ if _agilab_pkg is not None:
     if package_path not in package_paths:
         _agilab_pkg.__path__ = [*package_paths, package_path]
 
-from agilab.global_pipeline.global_pipeline_execution_plan import ExecutionPlan, build_execution_plan
+from agilab.global_pipeline.global_pipeline_execution_plan import (  # noqa: E402
+    ExecutionPlan,
+    build_execution_plan,
+)
 
 
 SCHEMA = "agilab.global_pipeline_runner_state.v1"
@@ -37,6 +46,85 @@ FAILED_STATUS = "failed"
 PLANNED_STATUS = "planned"
 PERSISTENCE_FORMAT = "json"
 DEFAULT_RUN_ID = "multi-app-dag-runner-state"
+MISSING_RUNNER_STATE_REVISION = "<missing-runner-state>"
+_WINDOWS_FILE_SHARING_RETRY_TIMEOUT_SECONDS = 0.5
+_WINDOWS_FILE_SHARING_RETRY_INTERVAL_SECONDS = 0.01
+_RUNNER_STATE_LOCK_TIMEOUT_SECONDS = 5.0
+_RUNNER_STATE_LOCK_RETRY_INTERVAL_SECONDS = 0.05
+_T = TypeVar("_T")
+
+
+def _is_windows() -> bool:
+    return os.name == "nt"
+
+
+def _run_with_windows_file_sharing_retry(operation: Callable[[], _T]) -> _T:
+    """Retry only transient Windows sharing denials for mutable runner state."""
+
+    deadline = time.monotonic() + _WINDOWS_FILE_SHARING_RETRY_TIMEOUT_SECONDS
+    while True:
+        try:
+            return operation()
+        except PermissionError:
+            if not _is_windows():
+                raise
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise
+            time.sleep(min(_WINDOWS_FILE_SHARING_RETRY_INTERVAL_SECONDS, remaining))
+
+
+class RunnerStateConflictError(RuntimeError):
+    """Raised before a stale runner-state snapshot can overwrite newer state."""
+
+    def __init__(self, path: Path, *, expected_revision: str, actual_revision: str) -> None:
+        self.path = path
+        self.expected_revision = expected_revision
+        self.actual_revision = actual_revision
+        super().__init__(
+            f"Runner state changed in another session: {path}; expected revision "
+            f"{expected_revision}, found {actual_revision}. Reload the workflow state and retry."
+        )
+
+
+class RunnerStateDurabilityError(RuntimeError):
+    """Raised when a pre-execution claim cannot be proven crash-durable."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        super().__init__(
+            f"Runner-state claim was replaced at {path}, but its directory could not be fsynced. "
+            "External execution was aborted; recover the recorded attempt explicitly before retrying."
+        )
+
+
+class RunnerStateRecoveryRequiredError(RuntimeError):
+    """Raised when an ambiguous execution claim must be recovered explicitly."""
+
+    def __init__(self, path: Path, *, attempt_id: str) -> None:
+        self.path = path
+        self.attempt_id = attempt_id
+        super().__init__(
+            f"Runner state {path} contains active attempt {attempt_id!r}. "
+            "Recover that exact attempt before reset, source switch, preview dispatch, or another run."
+        )
+
+
+class RunnerStateAttemptConflictError(RuntimeError):
+    """Raised when recovery or finalization presents the wrong attempt token."""
+
+    def __init__(self, path: Path, *, expected_attempt_id: str, actual_attempt_id: str) -> None:
+        self.path = path
+        self.expected_attempt_id = expected_attempt_id
+        self.actual_attempt_id = actual_attempt_id
+        super().__init__(
+            f"Runner-state attempt changed at {path}; expected {expected_attempt_id!r}, "
+            f"found {actual_attempt_id!r}. Reload the state before recovery or finalization."
+        )
+
+
+_RUNNER_STATE_THREAD_LOCKS: dict[Path, threading.RLock] = {}
+_RUNNER_STATE_THREAD_LOCKS_GUARD = threading.Lock()
 
 
 @dataclass(frozen=True)
@@ -410,15 +498,403 @@ def build_persisted_runner_state(
     return _refresh_persisted_summary(state)
 
 
-def write_runner_state(path: Path, state: Mapping[str, Any]) -> Path:
+def runner_state_revision(state: Mapping[str, Any]) -> str:
+    """Return a deterministic revision used for optimistic state checks."""
+
+    payload = json.dumps(
+        state,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def load_runner_state_snapshot(path: Path) -> tuple[dict[str, Any] | None, str]:
+    """Load one atomic state snapshot and its revision, including a missing-file token."""
+
+    try:
+        state = load_runner_state(path)
+    except FileNotFoundError:
+        return None, MISSING_RUNNER_STATE_REVISION
+    return state, runner_state_revision(state)
+
+
+def runner_state_active_attempt(state: Mapping[str, Any]) -> dict[str, Any] | None:
+    """Return the durable active-execution claim, when one is present."""
+
+    active = state.get("active_execution")
+    if not isinstance(active, Mapping):
+        return None
+    attempt_id = str(active.get("attempt_id", "")).strip()
+    if not attempt_id:
+        return None
+    return dict(active)
+
+
+def _runner_state_thread_lock(path: Path) -> threading.RLock:
+    key = path.expanduser().resolve(strict=False)
+    with _RUNNER_STATE_THREAD_LOCKS_GUARD:
+        return _RUNNER_STATE_THREAD_LOCKS.setdefault(key, threading.RLock())
+
+
+def _runner_state_lock_path(path: Path) -> Path:
+    return path.with_name(f".{path.name}.lock")
+
+
+def _ensure_directory_hierarchy_durable(path: Path) -> bool:
+    """Create a directory tree and durably retain every new parent entry."""
+
+    target = path.expanduser()
+    missing: list[Path] = []
+    cursor = target
+    while not cursor.exists():
+        missing.append(cursor)
+        parent = cursor.parent
+        if parent == cursor:
+            break
+        cursor = parent
+    if cursor.exists() and not cursor.is_dir():
+        raise NotADirectoryError(cursor)
+
+    durable = True
+    if missing:
+        for directory in reversed(missing):
+            directory.mkdir(exist_ok=True)
+            if not directory.is_dir():
+                raise NotADirectoryError(directory)
+            # The directory flush covers its initial contents; the parent flush
+            # makes the new directory entry survive a power loss.
+            durable = _fsync_runner_state_directory(directory) and durable
+            durable = _fsync_runner_state_directory(directory.parent) and durable
+    else:
+        # A prior best-effort write may have created this entry without proving
+        # it durable. Re-establish that proof before a strict execution claim.
+        durable = _fsync_runner_state_directory(target) and durable
+        if target.parent != target:
+            durable = _fsync_runner_state_directory(target.parent) and durable
+    return durable
+
+
+@contextmanager
+def _exclusive_runner_state_lock(
+    path: Path,
+    *,
+    require_directory_fsync: bool = False,
+) -> Iterator[None]:
+    """Hold the stable per-state process and cross-process writer lock."""
+
+    state_path = path.expanduser()
+    hierarchy_durable = _ensure_directory_hierarchy_durable(state_path.parent)
+    if require_directory_fsync and not hierarchy_durable:
+        raise RunnerStateDurabilityError(state_path)
+    lock_path = _runner_state_lock_path(state_path)
+    thread_lock = _runner_state_thread_lock(lock_path)
+    thread_locked = thread_lock.acquire(timeout=_RUNNER_STATE_LOCK_TIMEOUT_SECONDS)
+    if not thread_locked:
+        raise TimeoutError(
+            f"Timed out waiting for runner-state lock {lock_path}. "
+            "Another session may still be updating this workflow; retry after it finishes."
+        )
+    try:
+        handle = lock_path.open("a+b")
+        locked = False
+        try:
+            if os.name == "nt":  # pragma: no cover - exercised on Windows CI
+                import msvcrt
+
+                if lock_path.stat().st_size == 0:
+                    handle.write(b"\n")
+                    handle.flush()
+                    os.fsync(handle.fileno())
+                def _try_lock() -> None:
+                    handle.seek(0)
+                    msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+            else:
+                import fcntl
+
+                def _try_lock() -> None:
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+            deadline = time.monotonic() + _RUNNER_STATE_LOCK_TIMEOUT_SECONDS
+            while True:
+                try:
+                    _try_lock()
+                    locked = True
+                    break
+                except OSError as exc:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        raise TimeoutError(
+                            f"Timed out waiting for runner-state lock {lock_path}. "
+                            "Another session may still be updating this workflow; "
+                            "retry after it finishes."
+                        ) from exc
+                    time.sleep(min(_RUNNER_STATE_LOCK_RETRY_INTERVAL_SECONDS, remaining))
+            yield
+        finally:
+            try:
+                if locked and os.name == "nt":  # pragma: no cover - exercised on Windows CI
+                    import msvcrt
+
+                    handle.seek(0)
+                    msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+                elif locked:
+                    import fcntl
+
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+            finally:
+                handle.close()
+    finally:
+        thread_lock.release()
+
+
+def _fsync_runner_state_directory(path: Path) -> bool:
+    if os.name == "nt":  # pragma: no cover - exercised on Windows CI
+        return _flush_windows_directory(path)
+    try:
+        directory_fd = os.open(path, os.O_RDONLY)
+    except OSError:
+        # The atomic replace has already committed. Directory fsync is a best-effort
+        # durability hardening step and must not report the committed state as failed.
+        return False
+    durable = True
+    try:
+        try:
+            os.fsync(directory_fd)
+        except OSError:
+            # Keep post-rename semantics unambiguous: callers may continue to publish
+            # evidence for the state that is now visible at ``path``.
+            durable = False
+    finally:
+        try:
+            os.close(directory_fd)
+        except OSError:
+            pass
+    return durable
+
+
+def _flush_windows_directory(path: Path) -> bool:
+    """Flush rename metadata through a Windows directory handle or fail closed."""
+
+    try:
+        import ctypes
+        from ctypes import wintypes
+
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        create_file = kernel32.CreateFileW
+        create_file.argtypes = (
+            wintypes.LPCWSTR,
+            wintypes.DWORD,
+            wintypes.DWORD,
+            wintypes.LPVOID,
+            wintypes.DWORD,
+            wintypes.DWORD,
+            wintypes.HANDLE,
+        )
+        create_file.restype = wintypes.HANDLE
+        close_handle = kernel32.CloseHandle
+        close_handle.argtypes = (wintypes.HANDLE,)
+        close_handle.restype = wintypes.BOOL
+        flush_file_buffers = kernel32.FlushFileBuffers
+        flush_file_buffers.argtypes = (wintypes.HANDLE,)
+        flush_file_buffers.restype = wintypes.BOOL
+
+        handle = create_file(
+            str(path),
+            0x40000000,  # GENERIC_WRITE is required by FlushFileBuffers
+            0x00000001 | 0x00000002 | 0x00000004,  # share read/write/delete
+            None,
+            3,  # OPEN_EXISTING
+            0x02000000,  # FILE_FLAG_BACKUP_SEMANTICS for directory handles
+            None,
+        )
+        invalid_handle = ctypes.c_void_p(-1).value
+        if handle in (None, invalid_handle):
+            return False
+        try:
+            return bool(flush_file_buffers(handle))
+        finally:
+            close_handle(handle)
+    except (AttributeError, OSError, TypeError, ValueError):
+        return False
+
+
+def _write_runner_state_atomic(
+    path: Path,
+    state: Mapping[str, Any],
+    *,
+    require_directory_fsync: bool = False,
+) -> Path:
     path = path.expanduser()
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(state, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    hierarchy_durable = _ensure_directory_hierarchy_durable(path.parent)
+    if require_directory_fsync and not hierarchy_durable:
+        raise RunnerStateDurabilityError(path)
+    text = json.dumps(state, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+    tmp_path = Path(tmp_name)
+    try:
+        if path.exists():
+            os.chmod(tmp_path, path.stat().st_mode & 0o777)
+        stream = os.fdopen(fd, "w", encoding="utf-8")
+        fd = -1
+        with stream:
+            stream.write(text)
+            stream.flush()
+            os.fsync(stream.fileno())
+        _run_with_windows_file_sharing_retry(lambda: os.replace(tmp_path, path))
+        directory_durable = _fsync_runner_state_directory(path.parent)
+        if require_directory_fsync and not directory_durable:
+            raise RunnerStateDurabilityError(path)
+    finally:
+        if fd >= 0:
+            os.close(fd)
+        try:
+            tmp_path.unlink()
+        except FileNotFoundError:
+            pass
     return path
 
 
+def _raise_runner_state_conflict(
+    path: Path,
+    *,
+    expected_revision: str,
+    actual_revision: str,
+) -> None:
+    if actual_revision != expected_revision:
+        raise RunnerStateConflictError(
+            path,
+            expected_revision=expected_revision,
+            actual_revision=actual_revision,
+        )
+
+
+@dataclass
+class RunnerStateTransaction:
+    """A locked runner-state snapshot that may be committed with CAS semantics."""
+
+    path: Path
+    state: dict[str, Any]
+    revision: str
+    _active: bool = True
+
+    def commit(
+        self,
+        state: Mapping[str, Any],
+        *,
+        require_directory_fsync: bool = False,
+    ) -> Path:
+        if not self._active:
+            raise RuntimeError("Runner-state transaction is no longer active.")
+        current = load_runner_state(self.path)
+        actual_revision = runner_state_revision(current)
+        _raise_runner_state_conflict(
+            self.path,
+            expected_revision=self.revision,
+            actual_revision=actual_revision,
+        )
+        path = _write_runner_state_atomic(
+            self.path,
+            state,
+            require_directory_fsync=require_directory_fsync,
+        )
+        self.state = dict(state)
+        self.revision = runner_state_revision(state)
+        return path
+
+
+@contextmanager
+def runner_state_transaction(
+    path: Path,
+    *,
+    expected_revision: str | None = None,
+) -> Iterator[RunnerStateTransaction]:
+    """Lock, reload, and optionally reject a stale runner-state revision."""
+
+    state_path = path.expanduser()
+    with _exclusive_runner_state_lock(state_path):
+        state = load_runner_state(state_path)
+        revision = runner_state_revision(state)
+        if expected_revision is not None:
+            _raise_runner_state_conflict(
+                state_path,
+                expected_revision=expected_revision,
+                actual_revision=revision,
+            )
+        transaction = RunnerStateTransaction(
+            path=state_path,
+            state=state,
+            revision=revision,
+        )
+        try:
+            yield transaction
+        finally:
+            transaction._active = False
+
+
+@contextmanager
+def runner_state_write_transaction(
+    path: Path,
+    state: Mapping[str, Any],
+    *,
+    expected_revision: str | None = None,
+    require_directory_fsync: bool = False,
+) -> Iterator[Path]:
+    """Atomically write state under the stable runner-state lock.
+
+    ``MISSING_RUNNER_STATE_REVISION`` is an explicit compare-and-swap token for
+    first creation. A normal revision protects reset and source-replacement
+    writers from overwriting a state changed while they waited for the lock.
+    """
+
+    state_path = path.expanduser()
+    with _exclusive_runner_state_lock(
+        state_path,
+        require_directory_fsync=require_directory_fsync,
+    ):
+        if expected_revision is not None:
+            _current, actual_revision = load_runner_state_snapshot(state_path)
+            _raise_runner_state_conflict(
+                state_path,
+                expected_revision=expected_revision,
+                actual_revision=actual_revision,
+            )
+        written_path = _write_runner_state_atomic(
+            state_path,
+            state,
+            require_directory_fsync=require_directory_fsync,
+        )
+        yield written_path
+
+
+def write_runner_state(
+    path: Path,
+    state: Mapping[str, Any],
+    *,
+    expected_revision: str | None = None,
+) -> Path:
+    """Atomically write runner state after an optional revision check."""
+
+    state_path = path.expanduser()
+    with _exclusive_runner_state_lock(state_path):
+        if expected_revision is not None:
+            current = load_runner_state(state_path)
+            _raise_runner_state_conflict(
+                state_path,
+                expected_revision=expected_revision,
+                actual_revision=runner_state_revision(current),
+            )
+        return _write_runner_state_atomic(state_path, state)
+
+
 def load_runner_state(path: Path) -> dict[str, Any]:
-    state = json.loads(path.expanduser().read_text(encoding="utf-8"))
+    state_path = path.expanduser()
+    state = json.loads(
+        _run_with_windows_file_sharing_retry(
+            lambda: state_path.read_text(encoding="utf-8")
+        )
+    )
     if not isinstance(state, dict):
         raise ValueError(f"runner state must be a JSON object: {path}")
     return state
@@ -575,6 +1051,7 @@ __all__ = [
     "COMPLETED_STATUS",
     "DEFAULT_RUN_ID",
     "FAILED_STATUS",
+    "MISSING_RUNNER_STATE_REVISION",
     "PERSISTENCE_FORMAT",
     "PLANNED_STATUS",
     "RUNNER_MODE",
@@ -582,6 +1059,10 @@ __all__ = [
     "RUNNABLE_STATUS",
     "RUN_STATUS",
     "RunnerDispatchResult",
+    "RunnerStateAttemptConflictError",
+    "RunnerStateConflictError",
+    "RunnerStateDurabilityError",
+    "RunnerStateRecoveryRequiredError",
     "RunnerState",
     "RunnerStateIssue",
     "RunnerStatePersistenceProof",
@@ -590,6 +1071,11 @@ __all__ = [
     "build_runner_state",
     "dispatch_next_runnable",
     "load_runner_state",
+    "load_runner_state_snapshot",
     "persist_runner_state",
+    "runner_state_revision",
+    "runner_state_active_attempt",
+    "runner_state_transaction",
+    "runner_state_write_transaction",
     "write_runner_state",
 ]

--- a/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/src/app_args_form.py
+++ b/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/src/app_args_form.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import streamlit as st
 from pydantic import ValidationError
+from agi_env.app_settings_support import read_app_settings
 from agi_env.streamlit_args import resolve_app_args_share_paths
 
 _HERE = Path(__file__).resolve().parent
@@ -57,8 +58,7 @@ def _flight_arg_field_names() -> set[str]:
 def _read_stored_args_payload(settings_path: Path) -> dict[str, Any] | None:
     if not settings_path.exists():
         return {}
-    with settings_path.open("rb") as handle:
-        doc = tomllib.load(handle)
+    doc = read_app_settings(settings_path)
     raw_payload = doc.get("args", {})
     if not isinstance(raw_payload, dict):
         return None

--- a/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/src/flight_telemetry/flight_args.py
+++ b/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/src/flight_telemetry/flight_args.py
@@ -7,8 +7,6 @@ from datetime import date
 from pathlib import Path
 from typing import Any, Literal, TypedDict
 
-import tomllib
-
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from agi_env.app_args import (
@@ -189,14 +187,6 @@ def dump_args_to_toml(
     create_missing: bool = True,
 ) -> None:
     """Persist arguments back to the TOML file (overwriting only the section)."""
-
-    settings_path = Path(settings_path)
-    doc: dict[str, Any] = {}
-    if settings_path.exists():
-        with settings_path.open("rb") as handle:
-            doc = tomllib.load(handle)
-    elif not create_missing:
-        raise FileNotFoundError(f"Settings file not found: {settings_path}")
 
     dump_model_to_toml(
         args,

--- a/src/agilab/main_page.py
+++ b/src/agilab/main_page.py
@@ -15,11 +15,15 @@ import importlib.resources as importlib_resources
 import importlib.util
 import textwrap
 import sys
+import threading
 import time
+from collections.abc import MutableMapping
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 from urllib.parse import urlencode
 from agi_env.agi_logger import AgiLogger
+from agi_env.ui.sidecar_registry import isolated_import_process_state
 from agilab.ui.page_bootstrap import configure_page_config
 
 try:
@@ -431,12 +435,76 @@ FIRST_PROOF_HELPER_SCRIPT_PREFIXES = (
     "AGI_run_",
     "AGI_get_",
 )
-_NAVIGATION_PAGE_ROUTES: Dict[str, Any] = {}
+_NAVIGATION_PAGE_ROUTES_SESSION_KEY = "_agilab_navigation_page_routes"
+
+
+def _session_navigation_routes(*, create: bool = True) -> dict[str, Any]:
+    """Return only this Streamlit session's registered page objects."""
+
+    session_state = getattr(st, "session_state", None)
+    if session_state is None:
+        return {}
+    routes = session_state.get(_NAVIGATION_PAGE_ROUTES_SESSION_KEY)
+    if isinstance(routes, dict):
+        return routes
+    if not create:
+        return {}
+    routes = {}
+    session_state[_NAVIGATION_PAGE_ROUTES_SESSION_KEY] = routes
+    return routes
+
+
+class _SessionNavigationRoutes(MutableMapping[str, Any]):
+    """Compatibility mapping which resolves against the active session."""
+
+    def __getitem__(self, key: str) -> Any:
+        return _session_navigation_routes()[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        _session_navigation_routes()[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del _session_navigation_routes()[key]
+
+    def __iter__(self):
+        return iter(_session_navigation_routes(create=False))
+
+    def __len__(self) -> int:
+        return len(_session_navigation_routes(create=False))
+
+
+# Compatibility surface consumed by page helpers. It never owns a Page itself;
+# every operation delegates to the currently active Streamlit session.
+_NAVIGATION_PAGE_ROUTES: MutableMapping[str, Any] = _SessionNavigationRoutes()
+
+
+@dataclass(frozen=True)
+class _NavigationPageSpec:
+    source: Any
+    title: str
+    url_path: str
+    route_ids: tuple[str, ...] = ()
+    default: bool = False
+    visibility: str | None = None
+
+    def instantiate(self) -> Any:
+        kwargs: dict[str, Any] = {
+            "title": self.title,
+            "url_path": self.url_path,
+        }
+        if self.default:
+            kwargs["default"] = True
+        if self.visibility is not None:
+            kwargs["visibility"] = self.visibility
+        return st.Page(self.source, **kwargs)
+
+
 _NAVIGATION_PAGE_CACHE: Dict[
     tuple[tuple[tuple[str, int, int], ...], str],
-    tuple[list[Any], Dict[str, Any]],
+    tuple[_NavigationPageSpec, ...],
 ] = {}
 _PAGE_MODULE_CACHE: Dict[Path, tuple[int, int, str, Any]] = {}
+_PAGE_MODULE_LOAD_LOCK = threading.RLock()
 _PAGE_RUNNER_CACHE: Dict[Path, Callable[[], None]] = {}
 _PAGE_MODULE_NAME_CACHE: Dict[str, str] = {}
 _RESOLVED_PAGE_PATH_CACHE: Dict[str, Path] = {}
@@ -1185,13 +1253,12 @@ def _render_settings_page_entry() -> None:
 
 
 def _navigation_pages() -> list[Any]:
-    """Return the supported navigation pages."""
+    """Return fresh Streamlit pages built from cached immutable specifications."""
     root = _AGILAB_ROOT
     if (
         os.environ.get("AGILAB_DISABLE_NAVIGATION_PAGE_CACHE") == "1"
         or _page_caching_disabled()
     ):
-        _NAVIGATION_PAGE_ROUTES.clear()
         _NAVIGATION_PAGE_CACHE.clear()
     if _page_caching_disabled():
         _PAGE_MODULE_CACHE.clear()
@@ -1206,91 +1273,77 @@ def _navigation_pages() -> list[Any]:
     cached = _NAVIGATION_PAGE_CACHE.get(navigation_signature)
     if cached is not None:
         _record_page_cache_stat("navigation_hit")
-        page_list, route_map = cached
-        _NAVIGATION_PAGE_ROUTES.clear()
-        _NAVIGATION_PAGE_ROUTES.update(route_map)
-        return page_list
-    _record_page_cache_stat("navigation_miss")
+        specs = cached
+    else:
+        _record_page_cache_stat("navigation_miss")
+        specs = (
+            _NavigationPageSpec(
+                _render_about_page_entry,
+                title="ABOUT",
+                url_path="",
+                default=True,
+                visibility="hidden",
+            ),
+            _NavigationPageSpec(
+                _SETTINGS_PAGE_FILE,
+                title="SETTINGS",
+                url_path="SETTINGS",
+                route_ids=("settings",),
+                visibility="hidden",
+            ),
+            _NavigationPageSpec(
+                _page_file_runner(_PROJECT_STATUS_PAGE_FILE),
+                title="PROJECT",
+                url_path="PROJECT",
+                route_ids=("project", "project_status"),
+            ),
+            _NavigationPageSpec(
+                _page_file_runner(_PROJECT_PAGE_FILE),
+                title="PROJECT EDITOR",
+                url_path="PROJECT_EDITOR",
+                route_ids=("project_editor",),
+                visibility="hidden",
+            ),
+            _NavigationPageSpec(
+                _page_file_runner(_PROJECT_PAGE_FILE),
+                title="PROJECT EDITOR",
+                url_path="PROJECT_EDIT",
+                route_ids=("project_edit",),
+                visibility="hidden",
+            ),
+            _NavigationPageSpec(
+                _page_file_runner(_PROJECT_STATUS_PAGE_FILE),
+                title="PROJECT",
+                url_path="PROJECT_STATUS",
+                visibility="hidden",
+            ),
+            _NavigationPageSpec(
+                _page_file_runner(_ORCHESTRATE_PAGE_FILE),
+                title="ORCHESTRATE",
+                url_path="ORCHESTRATE",
+                route_ids=("orchestrate",),
+            ),
+            _NavigationPageSpec(
+                _page_file_runner(_WORKFLOW_PAGE_FILE),
+                title="WORKFLOW",
+                url_path="WORKFLOW",
+                route_ids=("workflow",),
+            ),
+            _NavigationPageSpec(
+                _page_file_runner(_ANALYSIS_PAGE_FILE),
+                title="ANALYSIS",
+                url_path="ANALYSIS",
+                route_ids=("analysis",),
+            ),
+        )
+        _NAVIGATION_PAGE_CACHE[navigation_signature] = specs
 
-    main_page = st.Page(
-        _render_about_page_entry,
-        title="ABOUT",
-        url_path="",
-        default=True,
-        visibility="hidden",
-    )
-    settings_nav_page = st.Page(
-        _SETTINGS_PAGE_FILE,
-        title="SETTINGS",
-        url_path="SETTINGS",
-        visibility="hidden",
-    )
-    project_page = st.Page(
-        _page_file_runner(_PROJECT_STATUS_PAGE_FILE),
-        title="PROJECT",
-        url_path="PROJECT",
-    )
-    project_editor_page = st.Page(
-        _page_file_runner(_PROJECT_PAGE_FILE),
-        title="PROJECT EDITOR",
-        url_path="PROJECT_EDITOR",
-        visibility="hidden",
-    )
-    project_edit_legacy_page = st.Page(
-        _page_file_runner(_PROJECT_PAGE_FILE),
-        title="PROJECT EDITOR",
-        url_path="PROJECT_EDIT",
-        visibility="hidden",
-    )
-    project_status_legacy_page = st.Page(
-        _page_file_runner(_PROJECT_STATUS_PAGE_FILE),
-        title="PROJECT",
-        url_path="PROJECT_STATUS",
-        visibility="hidden",
-    )
-    orchestrate_page = st.Page(
-        _page_file_runner(_ORCHESTRATE_PAGE_FILE),
-        title="ORCHESTRATE",
-        url_path="ORCHESTRATE",
-    )
-    workflow_page = st.Page(
-        _page_file_runner(_WORKFLOW_PAGE_FILE),
-        title="WORKFLOW",
-        url_path="WORKFLOW",
-    )
-    analysis_page = st.Page(
-        _page_file_runner(_ANALYSIS_PAGE_FILE),
-        title="ANALYSIS",
-        url_path="ANALYSIS",
-    )
-    _NAVIGATION_PAGE_ROUTES.clear()
-    _NAVIGATION_PAGE_ROUTES.update(
-        {
-            "settings": settings_nav_page,
-            "project": project_page,
-            "project_status": project_page,
-            "project_editor": project_editor_page,
-            "project_edit": project_edit_legacy_page,
-            "orchestrate": orchestrate_page,
-            "workflow": workflow_page,
-            "analysis": analysis_page,
-        }
-    )
-    page_list = [
-        main_page,
-        settings_nav_page,
-        project_page,
-        project_editor_page,
-        project_edit_legacy_page,
-        project_status_legacy_page,
-        orchestrate_page,
-        workflow_page,
-        analysis_page,
-    ]
-    _NAVIGATION_PAGE_CACHE[navigation_signature] = (
-        page_list,
-        dict(_NAVIGATION_PAGE_ROUTES),
-    )
+    page_list = [spec.instantiate() for spec in specs]
+    session_routes = _session_navigation_routes()
+    session_routes.clear()
+    for spec, page in zip(specs, page_list):
+        for route_id in spec.route_ids:
+            session_routes[route_id] = page
     return page_list
 
 
@@ -1313,42 +1366,43 @@ def _page_module_name(page_file: Path) -> str:
 
 def _load_page_module(page_file: Path) -> Any:
     """Load a Streamlit page module once per source version to reduce rerun latency."""
-    resolved_page = _resolve_page_path(page_file)
-    stat = resolved_page.stat()
-    module_cache_disabled = (
-        _page_caching_disabled()
-        or os.environ.get("AGILAB_DISABLE_PAGE_MODULE_CACHE") == "1"
-    )
-    cached = _PAGE_MODULE_CACHE.get(resolved_page)
-    if (
-        not module_cache_disabled
-        and cached is not None
-        and cached[0] == stat.st_mtime_ns
-        and cached[1] == stat.st_size
-    ):
-        _record_page_cache_stat("page_module_hit")
-        return cached[3]
-    _record_page_cache_stat("page_module_miss")
-
-    module_name = cached[2] if cached is not None else _page_module_name(resolved_page)
-    spec = importlib.util.spec_from_file_location(module_name, resolved_page)
-    if spec is None or spec.loader is None:
-        raise ModuleNotFoundError(f"Unable to load page from {resolved_page}")
-    module = importlib.util.module_from_spec(spec)
-    sys.modules[module_name] = module
-    try:
-        spec.loader.exec_module(module)
-    except Exception:
-        sys.modules.pop(module_name, None)
-        raise
-    if not module_cache_disabled:
-        _PAGE_MODULE_CACHE[resolved_page] = (
-            stat.st_mtime_ns,
-            stat.st_size,
-            module_name,
-            module,
+    with isolated_import_process_state(), _PAGE_MODULE_LOAD_LOCK:
+        resolved_page = _resolve_page_path(page_file)
+        stat = resolved_page.stat()
+        module_cache_disabled = (
+            _page_caching_disabled()
+            or os.environ.get("AGILAB_DISABLE_PAGE_MODULE_CACHE") == "1"
         )
-    return module
+        cached = _PAGE_MODULE_CACHE.get(resolved_page)
+        if (
+            not module_cache_disabled
+            and cached is not None
+            and cached[0] == stat.st_mtime_ns
+            and cached[1] == stat.st_size
+        ):
+            _record_page_cache_stat("page_module_hit")
+            return cached[3]
+        _record_page_cache_stat("page_module_miss")
+
+        module_name = cached[2] if cached is not None else _page_module_name(resolved_page)
+        spec = importlib.util.spec_from_file_location(module_name, resolved_page)
+        if spec is None or spec.loader is None:
+            raise ModuleNotFoundError(f"Unable to load page from {resolved_page}")
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+        try:
+            spec.loader.exec_module(module)
+        except Exception:
+            sys.modules.pop(module_name, None)
+            raise
+        if not module_cache_disabled:
+            _PAGE_MODULE_CACHE[resolved_page] = (
+                stat.st_mtime_ns,
+                stat.st_size,
+                module_name,
+                module,
+            )
+        return module
 
 
 def _page_file_runner(page_file: Path) -> Callable[[], None]:
@@ -1386,21 +1440,22 @@ def _page_file_runner(page_file: Path) -> Callable[[], None]:
         _record_ui_timing_span(
             f"{page_label}:bootstrap", bootstrap_started_at, category="bootstrap"
         )
-        import_started_at = time.perf_counter()
-        module = _load_page_module(resolved_page)
-        _record_ui_timing_span(
-            f"{page_label}:import", import_started_at, category="import"
-        )
-        main_fn = getattr(module, "main", None)
-        if main_fn is None:
-            raise AttributeError(
-                f"Page {resolved_page} does not expose a main() function"
+        with isolated_import_process_state():
+            import_started_at = time.perf_counter()
+            module = _load_page_module(resolved_page)
+            _record_ui_timing_span(
+                f"{page_label}:import", import_started_at, category="import"
             )
-        render_started_at = time.perf_counter()
-        if inspect.iscoroutinefunction(main_fn):
-            asyncio.run(main_fn())
-        else:
-            main_fn()
+            main_fn = getattr(module, "main", None)
+            if main_fn is None:
+                raise AttributeError(
+                    f"Page {resolved_page} does not expose a main() function"
+                )
+            render_started_at = time.perf_counter()
+            if inspect.iscoroutinefunction(main_fn):
+                asyncio.run(main_fn())
+            else:
+                main_fn()
         _record_ui_timing_span(
             f"{page_label}:render", render_started_at, category="render"
         )

--- a/src/agilab/notebooks/notebook_export_support.py
+++ b/src/agilab/notebooks/notebook_export_support.py
@@ -15,6 +15,7 @@ from typing import Any, Dict, Iterable, Mapping, Sequence
 import tomllib
 
 from agi_env.app_provider_registry import app_name_aliases
+from agi_env.app_settings_support import read_app_settings
 
 from agilab.ui.page_bundle_registry import discover_page_bundle
 
@@ -459,8 +460,7 @@ def _load_related_pages_from_settings(settings_path: Path | None) -> tuple[str, 
     if settings_path is None or not settings_path.exists():
         return ()
     try:
-        with open(settings_path, "rb") as stream:
-            payload = tomllib.load(stream)
+        payload = read_app_settings(settings_path)
     except (OSError, TypeError, ValueError, tomllib.TOMLDecodeError):
         return ()
     raw_pages = payload.get("pages", {}).get("view_module", [])
@@ -2039,6 +2039,7 @@ def _helper_cell(payload: dict[str, Any]) -> str:
         import subprocess
         import sys
         import tempfile
+        import time
         import tomllib
         import traceback
         from pathlib import Path
@@ -2223,6 +2224,21 @@ def _helper_cell(payload: dict[str, Any]) -> str:
             )
 
 
+        def _read_mutable_toml(candidate):
+            deadline = time.monotonic() + 0.5
+            while True:
+                try:
+                    with candidate.open("rb") as stream:
+                        return tomllib.load(stream)
+                except PermissionError:
+                    if os.name != "nt":
+                        raise
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        raise
+                    time.sleep(min(0.01, remaining))
+
+
         def _load_app_settings_args(active_app):
             settings_candidates = []
 
@@ -2242,8 +2258,7 @@ def _helper_cell(payload: dict[str, Any]) -> str:
                 try:
                     if not candidate.exists():
                         continue
-                    with candidate.open("rb") as stream:
-                        payload = tomllib.load(stream)
+                    payload = _read_mutable_toml(candidate)
                 except (OSError, TypeError, ValueError, tomllib.TOMLDecodeError):
                     continue
                 args_payload = payload.get("args")

--- a/src/agilab/orchestrate/orchestrate_cluster.py
+++ b/src/agilab/orchestrate/orchestrate_cluster.py
@@ -3,6 +3,7 @@ import json
 import os
 import platform
 import re
+from copy import deepcopy
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -13,6 +14,12 @@ import streamlit as st
 
 from agilab.cluster.cluster_lan_discovery import DiscoveryOptions, discover_lan_nodes
 from agilab.orchestrate.orchestrate_page_support import ORCHESTRATE_ACTION_LABELS
+from agilab.orchestrate.orchestrate_support import (
+    changed_app_settings_paths,
+    owned_app_settings_payload,
+    reconcile_untouched_widget_values,
+    remember_rendered_widget_values,
+)
 
 # Keep in sync with orchestrate_page_support.RUN_MODE_LABELS: the dask bit (4)
 # keeps the historical in-worker pooling behavior, so "dask" modes pool
@@ -106,9 +113,75 @@ def cluster_widget_keys(app_state_name: str) -> dict[str, str]:
     }
 
 
+def cluster_widget_baseline_key(app_state_name: str) -> str:
+    return f"cluster_widget_values__{app_state_name}"
+
+
+def cluster_widget_values(
+    app_state_name: str,
+    cluster_params: dict[str, Any],
+    *,
+    is_managed_pc: bool,
+) -> dict[str, Any]:
+    """Return persisted cluster values in their Streamlit widget representation."""
+
+    widget_keys = cluster_widget_keys(app_state_name)
+    workers_value = cluster_params.get("workers", {})
+    if isinstance(workers_value, dict):
+        workers_widget_value = json.dumps(workers_value, indent=2)
+    elif workers_value in (None, ""):
+        workers_widget_value = ""
+    else:
+        workers_widget_value = str(workers_value)
+
+    auth_method = cluster_params.get("auth_method")
+    use_key = bool(cluster_params.get("ssh_key_path"))
+    if isinstance(auth_method, str):
+        use_key = auth_method.lower() == "ssh_key"
+
+    return {
+        widget_keys["cluster_enabled"]: bool(
+            cluster_params.get("cluster_enabled", False)
+        ),
+        widget_keys["cython"]: bool(cluster_params.get("cython", False)),
+        widget_keys["pool"]: bool(cluster_params.get("pool", False)),
+        widget_keys["rapids"]: False
+        if is_managed_pc
+        else bool(cluster_params.get("rapids", False)),
+        widget_keys["pool_max_workers"]: _optional_positive_int(
+            cluster_params.get("pool_max_workers")
+        )
+        or 0,
+        widget_keys["pool_item_timeout"]: _optional_positive_float(
+            cluster_params.get("pool_item_timeout")
+        )
+        or 0.0,
+        widget_keys["pool_executor"]: _pool_executor_value(
+            cluster_params.get("pool_executor")
+        ),
+        widget_keys["scheduler"]: str(cluster_params.get("scheduler", "") or ""),
+        widget_keys["user"]: str(cluster_params.get("user", "") or ""),
+        widget_keys["use_key"]: use_key,
+        widget_keys["ssh_key_path"]: str(
+            cluster_params.get("ssh_key_path", "") or ""
+        ),
+        widget_keys["workflow_session_policy"]: _workflow_session_policy(
+            cluster_params.get("workflow_session_policy")
+        ),
+        widget_keys["workflow_session"]: _safe_workflow_component(
+            cluster_params.get("workflow_session"), ""
+        ),
+        widget_keys["workers_data_path"]: str(
+            cluster_params.get("workers_data_path", "") or ""
+        ),
+        widget_keys["workers"]: workers_widget_value,
+    }
+
+
 def clear_cluster_widget_state(session_state, app_state_name: str) -> None:
     for widget_key in cluster_widget_keys(app_state_name).values():
         session_state.pop(widget_key, None)
+    session_state.pop(cluster_widget_baseline_key(app_state_name), None)
 
 
 def hydrate_cluster_widget_state(
@@ -119,54 +192,12 @@ def hydrate_cluster_widget_state(
     is_managed_pc: bool,
 ) -> None:
     widget_keys = cluster_widget_keys(app_state_name)
-    session_state.setdefault(widget_keys["cluster_enabled"], bool(cluster_params.get("cluster_enabled", False)))
-    session_state.setdefault(widget_keys["cython"], bool(cluster_params.get("cython", False)))
-    session_state.setdefault(widget_keys["pool"], bool(cluster_params.get("pool", False)))
-    session_state.setdefault(
-        widget_keys["pool_max_workers"],
-        _optional_positive_int(cluster_params.get("pool_max_workers")) or 0,
-    )
-    session_state.setdefault(
-        widget_keys["pool_item_timeout"],
-        _optional_positive_float(cluster_params.get("pool_item_timeout")) or 0.0,
-    )
-    session_state.setdefault(
-        widget_keys["pool_executor"],
-        _pool_executor_value(cluster_params.get("pool_executor")),
-    )
-    session_state.setdefault(
-        widget_keys["workflow_session_policy"],
-        _workflow_session_policy(cluster_params.get("workflow_session_policy")),
-    )
-    session_state.setdefault(
-        widget_keys["workflow_session"],
-        _safe_workflow_component(cluster_params.get("workflow_session"), ""),
-    )
-    if is_managed_pc:
-        session_state[widget_keys["rapids"]] = False
-    else:
-        session_state.setdefault(widget_keys["rapids"], bool(cluster_params.get("rapids", False)))
-
-    session_state.setdefault(widget_keys["scheduler"], str(cluster_params.get("scheduler", "") or ""))
-    session_state.setdefault(widget_keys["user"], str(cluster_params.get("user", "") or ""))
-    session_state.setdefault(widget_keys["ssh_key_path"], str(cluster_params.get("ssh_key_path", "") or ""))
-    session_state.setdefault(widget_keys["workers_data_path"], str(cluster_params.get("workers_data_path", "") or ""))
-
-    workers_value = cluster_params.get("workers", {})
-    workers_key = widget_keys["workers"]
-    if workers_key not in session_state:
-        if isinstance(workers_value, dict):
-            session_state[workers_key] = json.dumps(workers_value, indent=2)
-        elif workers_value in (None, ""):
-            session_state[workers_key] = ""
-        else:
-            session_state[workers_key] = str(workers_value)
-
-    auth_method = cluster_params.get("auth_method")
-    use_key = bool(cluster_params.get("ssh_key_path"))
-    if isinstance(auth_method, str):
-        use_key = auth_method.lower() == "ssh_key"
-    session_state.setdefault(widget_keys["use_key"], use_key)
+    for widget_key, value in cluster_widget_values(
+        app_state_name,
+        cluster_params,
+        is_managed_pc=is_managed_pc,
+    ).items():
+        session_state.setdefault(widget_key, value)
     session_state.pop(widget_keys["password"], None)
 
 
@@ -1144,10 +1175,26 @@ def render_cluster_settings_ui(env: Any, deps: OrchestrateClusterDeps, *, show_r
         st.session_state["app_settings"] = app_settings
 
     cluster_params = app_settings.setdefault("cluster", {})
+    cluster_before_render = deepcopy(cluster_params)
     app_state_name = Path(str(env.app)).name if env.app else ""
+    widget_keys = cluster_widget_keys(app_state_name)
+    widget_baseline_key = cluster_widget_baseline_key(app_state_name)
+    is_initial_widget_render = widget_baseline_key not in st.session_state
+    persisted_widget_values = cluster_widget_values(
+        app_state_name,
+        cluster_params,
+        is_managed_pc=bool(env.is_managed_pc),
+    )
+    reconcile_untouched_widget_values(
+        st.session_state,
+        baseline_key=widget_baseline_key,
+        desired_values={
+            widget_keys[name]: persisted_widget_values[widget_keys[name]]
+            for name in ("cluster_enabled", "cython", "pool", "rapids")
+        },
+    )
     workflow_id = _orchestrate_workflow_id(cluster_params, env)
     cluster_params["workflow_id"] = workflow_id
-    widget_keys = cluster_widget_keys(app_state_name)
     env_home = _env_home_path(env)
     lan_cache_path = _default_lan_discovery_cache_path(env_home)
 
@@ -1171,6 +1218,18 @@ def render_cluster_settings_ui(env: Any, deps: OrchestrateClusterDeps, *, show_r
 
     pool_enabled = bool(cluster_params.get("pool", False))
     if pool_enabled:
+        reconcile_untouched_widget_values(
+            st.session_state,
+            baseline_key=widget_baseline_key,
+            desired_values={
+                widget_keys[name]: persisted_widget_values[widget_keys[name]]
+                for name in (
+                    "pool_max_workers",
+                    "pool_item_timeout",
+                    "pool_executor",
+                )
+            },
+        )
         with st.container():
             st.markdown("**Pool parameters**")
             pool_cols = st.columns(3)
@@ -1288,6 +1347,39 @@ def render_cluster_settings_ui(env: Any, deps: OrchestrateClusterDeps, *, show_r
         cluster_params["cluster_enabled"] = bool(cluster_enabled)
 
     if cluster_enabled:
+        active_widget_values = dict(persisted_widget_values)
+        if cluster_params.get("user") in (None, ""):
+            active_widget_values[widget_keys["user"]] = str(env.user or "")
+        active_widget_values[widget_keys["workflow_session_policy"]] = (
+            _workflow_session_policy(
+                cluster_params.get("workflow_session_policy")
+                or _env_value(env, WORKFLOW_SESSION_POLICY_ENV)
+            )
+        )
+        active_widget_values[widget_keys["workflow_session"]] = (
+            _safe_workflow_component(
+                cluster_params.get("workflow_session")
+                or _env_value(env, WORKFLOW_SESSION_ENV),
+                "",
+            )
+        )
+        reconcile_untouched_widget_values(
+            st.session_state,
+            baseline_key=widget_baseline_key,
+            desired_values={
+                widget_keys[name]: active_widget_values[widget_keys[name]]
+                for name in (
+                    "scheduler",
+                    "user",
+                    "use_key",
+                    "ssh_key_path",
+                    "workflow_session_policy",
+                    "workflow_session",
+                    "workers_data_path",
+                    "workers",
+                )
+            },
+        )
         scheduler_widget_key = widget_keys["scheduler"]
         cluster_share_candidate = _env_cluster_share_candidate(env)
         lan_action_cols = st.columns(3)
@@ -1747,12 +1839,50 @@ def render_cluster_settings_ui(env: Any, deps: OrchestrateClusterDeps, *, show_r
     if show_run_mode_info:
         st.info(f"Run mode {RUN_MODE_LABELS[mode_value]}")
     st.session_state.app_settings["cluster"] = cluster_params
-
-    st.session_state.app_settings = deps.write_app_settings_toml(
-        env.app_settings_file,
-        st.session_state.app_settings,
+    remember_rendered_widget_values(
+        st.session_state,
+        baseline_key=widget_baseline_key,
+        widget_keys=cluster_widget_values(
+            app_state_name,
+            cluster_params,
+            is_managed_pc=bool(env.is_managed_pc),
+        ),
     )
-    try:
-        deps.clear_load_toml_cache()
-    except (AttributeError, RuntimeError):
-        pass
+
+    cluster_owned_paths = tuple(
+        path
+        for path in changed_app_settings_paths(
+            cluster_before_render,
+            cluster_params,
+            prefix=("cluster",),
+        )
+        if path[:2] != ("cluster", "service_health")
+    )
+    cluster_default_paths = (
+        tuple(
+            path
+            for path in changed_app_settings_paths(
+                {},
+                cluster_params,
+                prefix=("cluster",),
+            )
+            if path not in cluster_owned_paths
+            and path[:2] != ("cluster", "service_health")
+        )
+        if is_initial_widget_render
+        else ()
+    )
+    if cluster_owned_paths or cluster_default_paths:
+        st.session_state.app_settings = deps.write_app_settings_toml(
+            env.app_settings_file,
+            owned_app_settings_payload(
+                st.session_state.app_settings,
+                *cluster_owned_paths,
+                default_paths=cluster_default_paths,
+                preserved_paths=(("args",),),
+            ),
+        )
+        try:
+            deps.clear_load_toml_cache()
+        except (AttributeError, RuntimeError):
+            pass

--- a/src/agilab/orchestrate/orchestrate_services.py
+++ b/src/agilab/orchestrate/orchestrate_services.py
@@ -21,6 +21,12 @@ from agilab.orchestrate.orchestrate_page_support import (
     ORCHESTRATE_ACTION_LABELS,
     orchestrate_snippet_runtime_root,
 )
+from agilab.orchestrate.orchestrate_support import (
+    changed_app_settings_paths,
+    owned_app_settings_payload,
+    reconcile_untouched_widget_values,
+    remember_rendered_widget_values,
+)
 from agilab.workflow.action_execution import ActionResult, render_action_result
 
 SERVICE_MODE_POOL = 1
@@ -150,6 +156,45 @@ def service_health_gate_keys(app: str) -> ServiceHealthGateKeys:
         allow_idle=f"service_health_allow_idle__{app}",
         max_unhealthy=f"service_health_max_unhealthy__{app}",
         max_restart_rate=f"service_health_max_restart_rate__{app}",
+    )
+
+
+def service_health_widget_baseline_key(app: str) -> str:
+    return f"service_health_widget_values__{app}"
+
+
+def service_health_widget_values(
+    app: str,
+    defaults: Mapping[str, Any],
+) -> dict[str, Any]:
+    keys = service_health_gate_keys(app)
+    return {
+        keys.allow_idle: bool(defaults["allow_idle"]),
+        keys.max_unhealthy: int(defaults["max_unhealthy"]),
+        keys.max_restart_rate: float(defaults["max_restart_rate"]),
+    }
+
+
+def changed_service_health_widget_paths(
+    session_state: Mapping[str, Any],
+    *,
+    app: str,
+    rendered_baseline: Mapping[str, Any],
+) -> tuple[tuple[str, ...], ...]:
+    """Return health leaves explicitly changed since this session rendered."""
+
+    keys = service_health_gate_keys(app)
+    fields_by_widget = {
+        keys.allow_idle: "allow_idle",
+        keys.max_unhealthy: "max_unhealthy",
+        keys.max_restart_rate: "max_restart_rate",
+    }
+    return tuple(
+        ("cluster", "service_health", field)
+        for widget_key, field in fields_by_widget.items()
+        if widget_key in rendered_baseline
+        and widget_key in session_state
+        and session_state[widget_key] != rendered_baseline[widget_key]
     )
 
 
@@ -631,6 +676,33 @@ async def render_service_panel(
 
         service_health_defaults = resolve_service_health_defaults(cluster_params, deps)
 
+        service_health_baseline_key = service_health_widget_baseline_key(env.app)
+        rendered_health_baseline = st.session_state.get(
+            service_health_baseline_key
+        )
+        has_rendered_health_baseline = isinstance(
+            rendered_health_baseline,
+            Mapping,
+        )
+        service_health_owned_paths = (
+            changed_service_health_widget_paths(
+                st.session_state,
+                app=env.app,
+                rendered_baseline=rendered_health_baseline,
+            )
+            if has_rendered_health_baseline
+            else ()
+        )
+        service_health_values = service_health_widget_values(
+            env.app,
+            service_health_defaults,
+        )
+        reconcile_untouched_widget_values(
+            st.session_state,
+            baseline_key=service_health_baseline_key,
+            desired_values=service_health_values,
+        )
+
         gate_keys = ensure_service_health_gate_defaults(
             st.session_state,
             app=env.app,
@@ -667,12 +739,34 @@ async def render_service_panel(
             "max_unhealthy": int(service_health_max_unhealthy),
             "max_restart_rate": float(service_health_max_restart_rate),
         }
-        if cluster_params.get("service_health") != updated_service_health_settings:
+        remember_rendered_widget_values(
+            st.session_state,
+            baseline_key=service_health_baseline_key,
+            widget_keys=service_health_values,
+        )
+        existing_service_health = cluster_params.get("service_health")
+        service_health_default_paths = (
+            changed_app_settings_paths(
+                existing_service_health
+                if isinstance(existing_service_health, Mapping)
+                else {},
+                updated_service_health_settings,
+                prefix=("cluster", "service_health"),
+            )
+            if not has_rendered_health_baseline
+            else ()
+        )
+        if service_health_owned_paths or service_health_default_paths:
             cluster_params["service_health"] = updated_service_health_settings
             st.session_state.app_settings["cluster"] = cluster_params
             st.session_state.app_settings = deps.write_app_settings_toml(
                 env.app_settings_file,
-                st.session_state.app_settings,
+                owned_app_settings_payload(
+                    st.session_state.app_settings,
+                    *service_health_owned_paths,
+                    default_paths=service_health_default_paths,
+                    preserved_paths=(("args",),),
+                ),
             )
             try:
                 deps.clear_load_toml_cache()

--- a/src/agilab/orchestrate/orchestrate_support.py
+++ b/src/agilab/orchestrate/orchestrate_support.py
@@ -4,15 +4,17 @@ import os
 import re
 import subprocess
 import sys
+from copy import deepcopy
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Mapping, MutableMapping, Optional
 
 import tomli_w
 from agi_env.app_settings_support import (
     app_settings_contract_error,
     ensure_app_settings_metadata,
     sanitize_app_settings_for_toml,
+    update_app_settings_owned,
 )
 
 
@@ -22,8 +24,165 @@ def sanitize_for_toml(obj: Any) -> Any:
     return sanitize_app_settings_for_toml(obj)
 
 
+class OwnedAppSettingsPayload(dict):
+    """A normal settings snapshot carrying its precise writer ownership paths."""
+
+    def __init__(
+        self,
+        payload: dict,
+        owned_paths: tuple[tuple[str, ...], ...],
+        *,
+        default_paths: tuple[tuple[str, ...], ...] = (),
+        preserved_paths: tuple[tuple[str, ...], ...] = (),
+    ):
+        super().__init__(payload)
+        self.owned_paths = owned_paths
+        self.default_paths = default_paths
+        self.preserved_paths = preserved_paths
+
+
+def owned_app_settings_payload(
+    payload: dict,
+    *owned_paths: tuple[str, ...],
+    default_paths: tuple[tuple[str, ...], ...] = (),
+    preserved_paths: tuple[tuple[str, ...], ...] = (),
+) -> OwnedAppSettingsPayload:
+    """Annotate a snapshot without changing two-argument writer adapters."""
+
+    normalized_owned_paths = tuple(tuple(path) for path in owned_paths)
+    normalized_default_paths = tuple(tuple(path) for path in default_paths)
+    normalized_preserved_paths = tuple(tuple(path) for path in preserved_paths)
+    if not normalized_owned_paths and not normalized_default_paths:
+        raise ValueError(
+            "At least one app-settings ownership or default path is required."
+        )
+    return OwnedAppSettingsPayload(
+        payload,
+        normalized_owned_paths,
+        default_paths=normalized_default_paths,
+        preserved_paths=normalized_preserved_paths,
+    )
+
+
+_MISSING_APP_SETTINGS_VALUE = object()
+
+
+def changed_app_settings_paths(
+    before: Mapping[str, Any],
+    after: Mapping[str, Any],
+    *,
+    prefix: tuple[str, ...] = (),
+) -> tuple[tuple[str, ...], ...]:
+    """Return the leaf ownership paths changed between two settings snapshots."""
+
+    def _changed_paths(
+        before_value: Any,
+        after_value: Any,
+        path: tuple[str, ...],
+    ) -> list[tuple[str, ...]]:
+        if before_value is _MISSING_APP_SETTINGS_VALUE and isinstance(
+            after_value, Mapping
+        ):
+            before_value = {}
+        if before_value == after_value:
+            return []
+        if isinstance(before_value, Mapping) and isinstance(after_value, Mapping):
+            changed: list[tuple[str, ...]] = []
+            for child_key in sorted(set(before_value) | set(after_value)):
+                if not isinstance(child_key, str) or not child_key:
+                    raise ValueError(
+                        "App-settings ownership paths require non-empty string keys."
+                    )
+                changed.extend(
+                    _changed_paths(
+                        before_value.get(child_key, _MISSING_APP_SETTINGS_VALUE),
+                        after_value.get(child_key, _MISSING_APP_SETTINGS_VALUE),
+                        (*path, child_key),
+                    )
+                )
+            return changed
+        if not path:
+            raise ValueError("App-settings ownership paths cannot be empty.")
+        return [path]
+
+    return tuple(_changed_paths(before, after, prefix))
+
+
+def reconcile_untouched_widget_values(
+    session_state: MutableMapping[str, Any],
+    *,
+    baseline_key: str,
+    desired_values: Mapping[str, Any],
+) -> None:
+    """Refresh widgets that still equal this session's prior rendered values.
+
+    Streamlit widget state survives reruns independently from a settings snapshot.
+    When a locked settings write merges another session's leaves, unchanged widget
+    values must follow that merged snapshot before the widgets are instantiated;
+    otherwise a later no-op rerun can falsely claim and restore stale values.
+    """
+
+    previous = session_state.get(baseline_key)
+    previous = previous if isinstance(previous, Mapping) else {}
+    for widget_key, desired_value in desired_values.items():
+        if widget_key not in session_state:
+            session_state[widget_key] = deepcopy(desired_value)
+            continue
+        if widget_key in previous and session_state[widget_key] == previous[widget_key]:
+            session_state[widget_key] = deepcopy(desired_value)
+
+
+def remember_rendered_widget_values(
+    session_state: MutableMapping[str, Any],
+    *,
+    baseline_key: str,
+    widget_keys: Mapping[str, Any] | tuple[str, ...],
+) -> None:
+    """Remember values rendered by this session for next-rerun reconciliation."""
+
+    keys = tuple(widget_keys)
+    session_state[baseline_key] = {
+        key: deepcopy(session_state[key]) for key in keys if key in session_state
+    }
+
+
+def _preserve_app_settings_paths(
+    latest: dict[str, Any],
+    session_snapshot: Mapping[str, Any],
+    paths: tuple[tuple[str, ...], ...],
+) -> dict[str, Any]:
+    """Overlay explicitly session-owned values onto a persisted write result."""
+
+    result = deepcopy(latest)
+    for path in paths:
+        if not path or any(not isinstance(part, str) or not part for part in path):
+            raise ValueError(
+                "Preserved app-settings paths must contain non-empty strings."
+            )
+        source: Any = session_snapshot
+        for part in path:
+            if not isinstance(source, Mapping) or part not in source:
+                source = _MISSING_APP_SETTINGS_VALUE
+                break
+            source = source[part]
+        if source is _MISSING_APP_SETTINGS_VALUE:
+            continue
+        target = result
+        for part in path[:-1]:
+            child = target.get(part)
+            if not isinstance(child, dict):
+                child = {}
+                target[part] = child
+            target = child
+        target[path[-1]] = deepcopy(source)
+    return result
+
+
 def write_app_settings_toml(settings_path: Path, payload: dict) -> dict:
-    """Persist ``payload`` after converting it to a TOML-serializable object."""
+    """Transactionally persist the explicitly owned portion of ``payload``."""
+    owned_paths = getattr(payload, "owned_paths", tuple((key,) for key in payload))
+    default_paths = getattr(payload, "default_paths", ())
+    preserved_paths = getattr(payload, "preserved_paths", ())
     sanitized = sanitize_app_settings_for_toml(payload)
     if not isinstance(sanitized, dict):
         raise ValueError("app_settings.toml payload must be a TOML table.")
@@ -31,9 +190,28 @@ def write_app_settings_toml(settings_path: Path, payload: dict) -> dict:
     if error:
         raise ValueError(error)
     sanitized = ensure_app_settings_metadata(sanitized)
-    with open(settings_path, "wb") as file:
-        tomli_w.dump(sanitized, file)
-    return sanitized
+    def _prepare_latest(latest: dict[str, Any]) -> dict[str, Any]:
+        prepared = sanitize_app_settings_for_toml(latest)
+        if not isinstance(prepared, dict):
+            raise ValueError("app_settings.toml payload must be a TOML table.")
+        latest_error = app_settings_contract_error(prepared)
+        if latest_error:
+            raise ValueError(latest_error)
+        return ensure_app_settings_metadata(prepared)
+
+    latest, _ = update_app_settings_owned(
+        settings_path,
+        sanitized,
+        owned_paths=owned_paths,
+        default_paths=default_paths,
+        dump_fn=tomli_w.dump,
+        prepare_fn=_prepare_latest,
+    )
+    return _preserve_app_settings_paths(
+        latest,
+        sanitized,
+        preserved_paths,
+    )
 
 
 SHARED_FILESYSTEM_TYPES: set[str] = {

--- a/src/agilab/pages/1_PROJECT.py
+++ b/src/agilab/pages/1_PROJECT.py
@@ -3277,10 +3277,12 @@ def _render_app_settings(env):
         pass
 
     if app_settings_file.exists():
+        from agi_env.app_settings_support import read_app_settings_text
+
         env.app_settings_file = app_settings_file
         render_code_editor(
             app_settings_file,
-            app_settings_file.read_text(),
+            read_app_settings_text(app_settings_file),
             "toml",
             "set",
             comp_props,

--- a/src/agilab/pages/2_ORCHESTRATE.py
+++ b/src/agilab/pages/2_ORCHESTRATE.py
@@ -24,6 +24,8 @@ os.environ.setdefault(
 )
 import streamlit as st
 from streamlit.errors import StreamlitAPIException
+from agi_env.app_settings_support import read_app_settings
+from agi_env.ui.sidecar_registry import isolated_import_process_state
 
 _import_guard_path = Path(__file__).resolve().parents[1] / "import_guard.py"
 _import_guard_spec = importlib.util.spec_from_file_location(
@@ -328,6 +330,7 @@ import_agilab_symbols(
         "fstype_for_path": "_fstype_for_path",
         "macos_autofs_hint": "_macos_autofs_hint",
         "mount_table": "_mount_table",
+        "owned_app_settings_payload": "_owned_app_settings_payload",
         "parse_benchmark": "parse_benchmark",
         "sanitize_for_toml": "_sanitize_for_toml",
         "write_app_settings_toml": "_write_app_settings_toml",
@@ -356,6 +359,38 @@ class _LazyAgiEnv:
 
 
 AgiEnv = _LazyAgiEnv()
+
+
+def _active_app_import_scope(env: Any):
+    app_src = Path(env.active_app).expanduser().resolve(strict=False) / "src"
+    return isolated_import_process_state(
+        prepend_paths=(app_src,),
+        module_roots=(app_src,),
+    )
+
+
+def _load_flight_args_payload(env: Any) -> dict[str, Any]:
+    with _active_app_import_scope(env):
+        from flight_telemetry import apply_source_defaults, load_args_from_toml
+
+        args_model = apply_source_defaults(load_args_from_toml(env.app_settings_file))
+        return args_model.to_toml_payload()
+
+
+def _persist_flight_args_payload(
+    env: Any,
+    args_input: dict[str, Any],
+) -> dict[str, Any]:
+    with _active_app_import_scope(env):
+        from flight_telemetry import (
+            apply_source_defaults,
+            dump_args_to_toml,
+            FlightArgs,
+        )
+
+        parsed_args = apply_source_defaults(FlightArgs(**args_input))
+        dump_args_to_toml(parsed_args, env.app_settings_file)
+        return parsed_args.to_toml_payload()
 
 
 def background_services_enabled(*args: Any, **kwargs: Any) -> Any:
@@ -1006,12 +1041,7 @@ def initialize_app_settings(args_override: dict[str, Any] | None = None) -> None
 
     if env.app == "flight_telemetry_project":
         try:
-            from flight_telemetry import apply_source_defaults, load_args_from_toml
-
-            args_model = apply_source_defaults(
-                load_args_from_toml(env.app_settings_file)
-            )
-            app_settings["args"] = args_model.to_toml_payload()
+            app_settings["args"] = _load_flight_args_payload(env)
         except (
             ImportError,
             AttributeError,
@@ -1048,8 +1078,7 @@ def load_toml_file(file_path: str | Path) -> dict[str, Any]:
     file_path = Path(file_path)
     if file_path.exists():
         try:
-            with file_path.open("rb") as f:
-                return tomllib.load(f)
+            return read_app_settings(file_path)
         except tomllib.TOMLDecodeError as exc:
             st.warning(f"Invalid TOML detected in {file_path.name}: {exc}")
             logger.warning("Failed to parse %s: %s", file_path, exc)
@@ -1503,22 +1532,15 @@ def render_generic_ui() -> None:
         st.session_state["args_input"] = args_input
         app_settings_file = env.app_settings_file
         if env.app == "flight_telemetry_project":
-            try:
-                from flight_telemetry import (
-                    apply_source_defaults,
-                    dump_args_to_toml,
-                    FlightArgs,
-                )
-                from pydantic import ValidationError
+            from pydantic import ValidationError
 
-                parsed_args = FlightArgs(**args_input)
+            try:
+                persisted_args = _persist_flight_args_payload(env, args_input)
             except ValidationError as exc:
                 messages = env.humanize_validation_errors(exc)
                 st.warning("\n".join(messages))
             else:
-                parsed_args = apply_source_defaults(parsed_args)
-                dump_args_to_toml(parsed_args, app_settings_file)
-                st.session_state.app_settings["args"] = parsed_args.to_toml_payload()
+                st.session_state.app_settings["args"] = persisted_args
         else:
             existing_app_settings = load_toml_file(app_settings_file)
             existing_app_settings.setdefault("args", {})
@@ -1526,7 +1548,7 @@ def render_generic_ui() -> None:
             existing_app_settings["args"] = args_input
             st.session_state.app_settings = _write_app_settings_toml(
                 app_settings_file,
-                existing_app_settings,
+                _owned_app_settings_payload(existing_app_settings, ("args",)),
             )
 
     if st.session_state.get("args_remove_arg"):

--- a/src/agilab/pages/4_ANALYSIS.py
+++ b/src/agilab/pages/4_ANALYSIS.py
@@ -13,7 +13,9 @@
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 from __future__ import annotations
 
+import contextlib
 import os
+import signal
 import sys
 import socket
 import time
@@ -23,6 +25,7 @@ import json
 import re
 import secrets
 import inspect
+from copy import deepcopy
 from collections.abc import Sequence
 from typing import Any, Union
 import asyncio
@@ -41,7 +44,15 @@ os.environ.setdefault(
 )
 import streamlit as st
 import logging
+import psutil
 import subprocess
+from agi_env.ui.sidecar_registry import (
+    DEFAULT_SIDECAR_REGISTRY,
+    HOSTED_INLINE_RENDER_SESSION_LEASE,
+    isolated_import_process_state,
+    SidecarLease,
+    SidecarRegistryError,
+)
 
 _import_guard_path = Path(__file__).resolve().parents[1] / "import_guard.py"
 _import_guard_spec = importlib.util.spec_from_file_location(
@@ -155,7 +166,7 @@ import_agilab_symbols(
 # Use modern TOML libraries
 import tomllib  # For reading TOML files (read as binary)
 
-from agi_env.app_settings_support import prepare_app_settings_for_write
+from agi_env.app_settings_support import read_app_settings, update_app_settings_owned
 from agi_env.process_support import apply_inline_path_export
 
 logger = logging.getLogger(__name__)
@@ -592,15 +603,40 @@ def _page_sync_is_fresh(project_root: Path) -> bool:
     return saved == _page_sync_fingerprint(project_root)
 
 
+def _write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
+    """Durably replace one JSON file without exposing a partial payload."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(
+        f".{path.name}.{os.getpid()}.{secrets.token_hex(8)}.tmp"
+    )
+    try:
+        with temporary.open("x", encoding="utf-8") as handle:
+            json.dump(payload, handle, sort_keys=True, separators=(",", ":"))
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+        try:
+            directory_fd = os.open(
+                path.parent,
+                os.O_RDONLY | getattr(os, "O_DIRECTORY", 0),
+            )
+        except OSError:
+            directory_fd = -1
+        if directory_fd >= 0:
+            try:
+                os.fsync(directory_fd)
+            finally:
+                os.close(directory_fd)
+    finally:
+        try:
+            temporary.unlink()
+        except FileNotFoundError:
+            pass
+
+
 def _write_page_sync_stamp(project_root: Path) -> None:
     stamp_path = _page_sync_stamp_path(project_root)
-    stamp_path.parent.mkdir(parents=True, exist_ok=True)
-    stamp_path.write_text(
-        json.dumps(
-            _page_sync_fingerprint(project_root), sort_keys=True, separators=(",", ":")
-        ),
-        encoding="utf-8",
-    )
+    _write_json_atomic(stamp_path, _page_sync_fingerprint(project_root))
 
 
 def _source_bootstrap_stamp_path(project_root: Path) -> Path:
@@ -635,14 +671,9 @@ def _source_bootstrap_is_fresh(project_root: Path, source_root: Path) -> bool:
 
 def _write_source_bootstrap_stamp(project_root: Path, source_root: Path) -> None:
     stamp_path = _source_bootstrap_stamp_path(project_root)
-    stamp_path.parent.mkdir(parents=True, exist_ok=True)
-    stamp_path.write_text(
-        json.dumps(
-            _source_bootstrap_fingerprint(project_root, source_root),
-            sort_keys=True,
-            separators=(",", ":"),
-        ),
-        encoding="utf-8",
+    _write_json_atomic(
+        stamp_path,
+        _source_bootstrap_fingerprint(project_root, source_root),
     )
 
 
@@ -859,7 +890,13 @@ def _initialize_analysis_env(requested_app: str | None) -> AgiEnv:
 
     apps_path = _apps_path_for_active_app(active_app_path)
     app_name = active_app_path.name
-    env = AgiEnv.for_app(
+    session_factory = getattr(AgiEnv, "session_for_app", None)
+    if not callable(session_factory):
+        raise RuntimeError(
+            "This ANALYSIS page requires an AgiEnv version with session_for_app(); "
+            "upgrade AGILAB before opening concurrent UI sessions."
+        )
+    env = session_factory(
         apps_path=apps_path,
         app=app_name,
         verbose=0,
@@ -879,6 +916,7 @@ def _initialize_analysis_env(requested_app: str | None) -> AgiEnv:
 
 
 BgCommand = str | Sequence[str]
+_ANALYSIS_PREPARATION_TOKEN_ENV = "AGILAB_ANALYSIS_PREPARATION_TOKEN"
 
 
 def _split_local_command(value: str) -> list[str]:
@@ -906,8 +944,13 @@ def _format_bg_command(cmd: BgCommand) -> str:
 
 
 def exec_bg(
-    agi_env: AgiEnv, cmd: BgCommand, cwd: str, process_env: dict[str, str] | None = None
-) -> None:
+    agi_env: AgiEnv,
+    cmd: BgCommand,
+    cwd: str,
+    process_env: dict[str, str] | None = None,
+    *,
+    owned_process_group: bool = False,
+) -> subprocess.Popen[Any]:
     """
     Execute background command
     Args:
@@ -919,7 +962,8 @@ def exec_bg(
     """
     stdout = open(agi_env.out_log, "ab", buffering=0)
     stderr = open(agi_env.err_log, "ab", buffering=0)
-    env = dict(os.environ)
+    build_env = getattr(agi_env, "_build_env_for_instance", None)
+    env = build_env() if callable(build_env) else dict(os.environ)
     env.pop("PYTHONPATH", None)
     env.pop("VIRTUAL_ENV", None)
     if process_env:
@@ -933,47 +977,496 @@ def exec_bg(
     else:
         command = [str(part) for part in cmd]
         shell = False
-    return subprocess.Popen(
+    popen_kwargs: dict[str, Any] = {}
+    ownership_token: str | None = None
+    ownership_started_at: float | None = None
+    ownership_username: str | None = None
+    if owned_process_group:
+        ownership_token = secrets.token_hex(16)
+        ownership_started_at = time.time()
+        with contextlib.suppress(psutil.Error, OSError):
+            ownership_username = psutil.Process(os.getpid()).username()
+        env[_ANALYSIS_PREPARATION_TOKEN_ENV] = ownership_token
+        if os.name == "nt":  # pragma: no cover - exercised on Windows CI
+            popen_kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+        else:
+            popen_kwargs["start_new_session"] = True
+    process = subprocess.Popen(
         command,
         shell=shell,
         cwd=cwd,
         stdout=stdout,
         stderr=stderr,
         env=env,
+        **popen_kwargs,
     )
+    setattr(process, "_agilab_owned_process_group", owned_process_group)
+    setattr(
+        process,
+        "_agilab_owned_process_group_id",
+        process.pid if owned_process_group and os.name != "nt" else None,
+    )
+    setattr(process, "_agilab_owned_process_token", ownership_token)
+    setattr(process, "_agilab_owned_process_started_at", ownership_started_at)
+    setattr(process, "_agilab_owned_process_username", ownership_username)
+    return process
 
 
-def _terminate_process_quietly(process: subprocess.Popen[Any]) -> None:
-    """Terminate a background process without surfacing timeout noise in the UI."""
-    process.terminate()
+def _sidecar_session_key(service_kind: str, key: str) -> str:
+    digest = hashlib.sha256(f"{service_kind}\0{key}".encode("utf-8")).hexdigest()[:20]
+    return f"sidecar_lease__{service_kind}__{digest}"
+
+
+_ANALYSIS_PREPARATION_PROCESS_TIMEOUT_SECONDS = 300.0
+_ANALYSIS_PREPARATION_TERMINATE_TIMEOUT_SECONDS = 1.0
+
+
+def _remember_sidecar_lease(service_kind: str, key: str, lease: SidecarLease) -> None:
+    st.session_state[_sidecar_session_key(service_kind, key)] = {
+        "endpoint": lease.endpoint,
+        "token": lease.token,
+        "pid": lease.pid,
+        "process_started_at": lease.process_started_at,
+        "health_signature": lease.health_signature,
+    }
+
+
+def _remembered_sidecar_lease(service_kind: str, key: str) -> dict[str, Any] | None:
+    value = st.session_state.get(_sidecar_session_key(service_kind, key))
+    return value if isinstance(value, dict) else None
+
+
+def _preparation_process_token(process: subprocess.Popen[Any]) -> str | None:
+    token = getattr(process, "_agilab_owned_process_token", None)
+    return token if isinstance(token, str) and token else None
+
+
+def _owned_preparation_token_processes(
+    process: subprocess.Popen[Any],
+) -> tuple[list[psutil.Process], list[int]]:
+    token = _preparation_process_token(process)
+    if token is None:
+        return [], []
+    started_at = getattr(process, "_agilab_owned_process_started_at", None)
+    username = getattr(process, "_agilab_owned_process_username", None)
+    matches: list[psutil.Process] = []
+    uncertain_candidates: list[int] = []
+    for candidate in psutil.process_iter(attrs=["pid"]):
+        if candidate.pid == os.getpid():
+            continue
+        try:
+            if isinstance(started_at, (int, float)) and (
+                candidate.create_time() < float(started_at) - 1.0
+            ):
+                continue
+            if isinstance(username, str) and username and candidate.username() != username:
+                continue
+        except (psutil.AccessDenied, psutil.NoSuchProcess, psutil.ZombieProcess, OSError):
+            # Without basic time/owner identity this remains an unrelated
+            # protected system process, not a plausible token candidate.
+            continue
+        try:
+            if candidate.environ().get(_ANALYSIS_PREPARATION_TOKEN_ENV) == token:
+                matches.append(candidate)
+        except (psutil.NoSuchProcess, psutil.ZombieProcess):
+            continue
+        except (psutil.AccessDenied, OSError):
+            # The launch time and OS owner narrow this to a plausible owned
+            # candidate without treating unrelated protected system processes
+            # as fatal. Its environment cannot be silently treated as no match.
+            uncertain_candidates.append(candidate.pid)
+    return matches, uncertain_candidates
+
+
+def _known_preparation_descendants(
+    process: subprocess.Popen[Any],
+) -> list[psutil.Process]:
     try:
-        process.wait(timeout=1)
-    except subprocess.TimeoutExpired:
+        if process.poll() is not None:
+            return []
+        return psutil.Process(int(process.pid)).children(recursive=True)
+    except (
+        AttributeError,
+        ProcessLookupError,
+        TypeError,
+        ValueError,
+        psutil.AccessDenied,
+        psutil.NoSuchProcess,
+        psutil.ZombieProcess,
+    ):
+        return []
+
+
+def _unique_preparation_processes(
+    processes: Sequence[psutil.Process],
+) -> list[psutil.Process]:
+    unique: list[psutil.Process] = []
+    seen: set[int] = set()
+    for candidate in processes:
+        if candidate.pid in seen:
+            continue
+        seen.add(candidate.pid)
+        unique.append(candidate)
+    return unique
+
+
+def _live_preparation_processes(
+    processes: Sequence[psutil.Process],
+) -> list[psutil.Process]:
+    live: list[psutil.Process] = []
+    for candidate in _unique_preparation_processes(processes):
+        try:
+            if candidate.is_running() and candidate.status() != psutil.STATUS_ZOMBIE:
+                live.append(candidate)
+        except (psutil.NoSuchProcess, psutil.ZombieProcess):
+            continue
+        except (psutil.AccessDenied, OSError):
+            live.append(candidate)
+    return live
+
+
+def _preparation_group_has_live_member(process_group_id: int) -> bool:
+    getpgid = getattr(os, "getpgid", None)
+    if not callable(getpgid):
+        return True
+    for candidate in psutil.process_iter(attrs=["pid", "status"]):
+        try:
+            if getpgid(candidate.pid) != process_group_id:
+                continue
+            if candidate.info.get("status") != psutil.STATUS_ZOMBIE:
+                return True
+        except (ProcessLookupError, psutil.NoSuchProcess, psutil.ZombieProcess):
+            continue
+        except (PermissionError, OSError, psutil.AccessDenied):
+            return True
+    return False
+
+
+def _preparation_group_exists(process_group_id: int) -> bool:
+    killpg = getattr(os, "killpg", None)
+    if not callable(killpg):
+        raise RuntimeError("POSIX process-group signaling is unavailable")
+    try:
+        killpg(process_group_id, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError as exc:
+        if not _preparation_group_has_live_member(process_group_id):
+            return False
+        raise RuntimeError(
+            f"cannot inspect preparation process group {process_group_id}: {exc}"
+        ) from exc
+    except OSError as exc:
+        raise RuntimeError(
+            f"cannot inspect preparation process group {process_group_id}: {exc}"
+        ) from exc
+    return True
+
+
+def _preparation_group_has_token(process_group_id: int, token: str) -> bool:
+    getpgid = getattr(os, "getpgid", None)
+    if not callable(getpgid):
+        return False
+    inaccessible_members: list[int] = []
+    for candidate in psutil.process_iter(attrs=["pid"]):
+        try:
+            if getpgid(candidate.pid) != process_group_id:
+                continue
+        except (ProcessLookupError, psutil.NoSuchProcess, psutil.ZombieProcess):
+            continue
+        except (PermissionError, OSError) as exc:
+            raise RuntimeError(
+                f"cannot inspect preparation group member {candidate.pid}: {exc}"
+            ) from exc
+        try:
+            if candidate.environ().get(_ANALYSIS_PREPARATION_TOKEN_ENV) == token:
+                return True
+        except (psutil.NoSuchProcess, psutil.ZombieProcess):
+            continue
+        except (psutil.AccessDenied, PermissionError, OSError):
+            inaccessible_members.append(candidate.pid)
+    if inaccessible_members:
+        raise RuntimeError(
+            "cannot prove preparation process-group ownership; member environment "
+            f"unavailable for pid(s) {inaccessible_members}"
+        )
+    return False
+
+
+def _preparation_parent_owns_group(
+    process: subprocess.Popen[Any],
+    process_group_id: int,
+) -> bool:
+    getpgid = getattr(os, "getpgid", None)
+    if not callable(getpgid):
+        return False
+    try:
+        return process.poll() is None and getpgid(int(process.pid)) == process_group_id
+    except (AttributeError, ProcessLookupError, TypeError, ValueError, OSError):
+        return False
+
+
+def _signal_owned_preparation_group(
+    process: subprocess.Popen[Any],
+    process_group_id: int,
+    sig: int,
+) -> bool:
+    if not _preparation_group_exists(process_group_id):
+        return False
+    token = _preparation_process_token(process)
+    if not _preparation_parent_owns_group(process, process_group_id) and not (
+        token is not None and _preparation_group_has_token(process_group_id, token)
+    ):
+        if not _preparation_group_exists(process_group_id):
+            return False
+        raise RuntimeError(
+            f"cannot prove ownership of live preparation process group {process_group_id}"
+        )
+    killpg = getattr(os, "killpg", None)
+    if not callable(killpg):
+        raise RuntimeError("POSIX process-group signaling is unavailable")
+    try:
+        killpg(process_group_id, sig)
+    except ProcessLookupError:
+        return False
+    except (PermissionError, OSError) as exc:
+        raise RuntimeError(
+            f"cannot signal preparation process group {process_group_id}: {exc}"
+        ) from exc
+    return True
+
+
+def _wait_for_preparation_group_exit(
+    process: subprocess.Popen[Any],
+    process_group_id: int,
+    *,
+    timeout: float,
+) -> bool:
+    deadline = time.monotonic() + timeout
+    while True:
+        with contextlib.suppress(AttributeError, ProcessLookupError, OSError):
+            process.poll()
+        if not _preparation_group_exists(process_group_id):
+            return True
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return False
+        time.sleep(min(0.05, remaining))
+
+
+def _terminate_process_quietly(
+    process: subprocess.Popen[Any],
+    *,
+    parent_reaped: bool = False,
+) -> None:
+    """Terminate and prove absence of one owned preparation process tree."""
+
+    timeout = _ANALYSIS_PREPARATION_TERMINATE_TIMEOUT_SECONDS
+    owns_group = bool(getattr(process, "_agilab_owned_process_group", False))
+    process_group_id = getattr(process, "_agilab_owned_process_group_id", None)
+    if owns_group and os.name != "nt" and not isinstance(process_group_id, int):
+        process_group_id = getattr(process, "pid", None)
+    token = _preparation_process_token(process)
+
+    if not parent_reaped:
+        try:
+            parent_reaped = process.poll() is not None
+        except (AttributeError, OSError):
+            parent_reaped = False
+    if parent_reaped and not owns_group and token is None:
         return
 
+    token_processes, _token_uncertainties = _owned_preparation_token_processes(
+        process
+    )
+    descendants = _unique_preparation_processes(
+        [
+            *_known_preparation_descendants(process),
+            *token_processes,
+        ]
+    )
+    cleanup_errors: list[str] = []
 
-def _ensure_sidecar(view_key: str, view_page: Path, port: int, active_app: str) -> bool:
-    """Start the view's Streamlit in a separate process (one per session)."""
-    if _is_port_open(port):
-        return True
-    env = st.session_state["env"]
-    ip = "127.0.0.1"
-    uv, uv_process_env = _local_uv_command(env, ip)
-    attempts: list[str] = []
-    last_error = ""
-    project_roots = _iter_page_project_roots(view_page)
-    if not project_roots:
-        env.logger.error("Could not determine project root for page: %s", view_page)
-        attempts.append(f"No uv project root with pyproject.toml for {view_page}")
-        last_error = f"No uv project root with pyproject.toml for {view_page}"
-    log_file, err_file = _page_log_paths(view_page, env.AGILAB_LOG_ABS)
-    env.out_log = log_file
-    env.err_log = err_file
+    group_gone = True
+    if owns_group and os.name != "nt" and isinstance(process_group_id, int):
+        try:
+            _signal_owned_preparation_group(process, process_group_id, signal.SIGTERM)
+            group_gone = _wait_for_preparation_group_exit(
+                process,
+                process_group_id,
+                timeout=timeout,
+            )
+        except RuntimeError as exc:
+            cleanup_errors.append(str(exc))
+            group_gone = False
 
-    for page_root in project_roots:
-        page_home = str(page_root)
-        env.logger.info("Trying analysis page sidecar project root: %s", page_home)
-        attempts.append(f"Trying uv project root: {page_home}")
+    terminated: list[psutil.Process] = []
+    for descendant in descendants:
+        try:
+            descendant.terminate()
+            terminated.append(descendant)
+        except (psutil.NoSuchProcess, psutil.ZombieProcess):
+            continue
+        except (psutil.AccessDenied, OSError) as exc:
+            cleanup_errors.append(f"could not terminate pid {descendant.pid}: {exc}")
+
+    if not parent_reaped:
+        try:
+            process.terminate()
+        except ProcessLookupError:
+            parent_reaped = True
+        except (AttributeError, OSError) as exc:
+            cleanup_errors.append(f"could not terminate parent: {exc}")
+        if not parent_reaped:
+            try:
+                process.wait(timeout=timeout)
+                parent_reaped = True
+            except ProcessLookupError:
+                parent_reaped = True
+            except subprocess.TimeoutExpired:
+                pass
+            except (AttributeError, OSError) as exc:
+                cleanup_errors.append(f"could not reap parent: {exc}")
+
+    _gone, alive = psutil.wait_procs(terminated, timeout=timeout)
+    if not parent_reaped or alive or not group_gone:
+        if owns_group and os.name != "nt" and isinstance(process_group_id, int):
+            try:
+                _signal_owned_preparation_group(process, process_group_id, signal.SIGKILL)
+            except RuntimeError as exc:
+                cleanup_errors.append(str(exc))
+
+        kill_token_processes, _token_uncertainties = (
+            _owned_preparation_token_processes(process)
+        )
+        kill_candidates = _unique_preparation_processes(
+            [
+                *alive,
+                *kill_token_processes,
+            ]
+        )
+        killed: list[psutil.Process] = []
+        for descendant in kill_candidates:
+            try:
+                descendant.kill()
+                killed.append(descendant)
+            except (psutil.NoSuchProcess, psutil.ZombieProcess):
+                continue
+            except (psutil.AccessDenied, OSError) as exc:
+                cleanup_errors.append(f"could not kill pid {descendant.pid}: {exc}")
+
+        if not parent_reaped:
+            try:
+                process.kill()
+            except ProcessLookupError:
+                parent_reaped = True
+            except (AttributeError, OSError) as exc:
+                cleanup_errors.append(f"could not kill parent: {exc}")
+            if not parent_reaped:
+                try:
+                    process.wait(timeout=timeout)
+                    parent_reaped = True
+                except ProcessLookupError:
+                    parent_reaped = True
+                except subprocess.TimeoutExpired:
+                    pass
+                except (AttributeError, OSError) as exc:
+                    cleanup_errors.append(f"could not reap killed parent: {exc}")
+
+        _gone, alive = psutil.wait_procs(killed, timeout=timeout)
+        if owns_group and os.name != "nt" and isinstance(process_group_id, int):
+            try:
+                group_gone = _wait_for_preparation_group_exit(
+                    process,
+                    process_group_id,
+                    timeout=timeout,
+                )
+            except RuntimeError as exc:
+                cleanup_errors.append(str(exc))
+                group_gone = False
+
+    if not parent_reaped:
+        with contextlib.suppress(AttributeError, OSError):
+            parent_reaped = process.poll() is not None
+    remaining_token_processes, token_uncertainties = (
+        _owned_preparation_token_processes(process)
+    )
+    remaining = _live_preparation_processes(
+        [
+            *alive,
+            *remaining_token_processes,
+        ]
+    )
+    if not parent_reaped or not group_gone or remaining or token_uncertainties:
+        details = list(cleanup_errors)
+        if not parent_reaped:
+            details.append(
+                f"parent pid {getattr(process, 'pid', 'unknown')} was not reaped"
+            )
+        if not group_gone:
+            details.append(f"process group {process_group_id} remains live")
+        if remaining:
+            details.append(
+                f"remaining descendant PIDs {[child.pid for child in remaining]}"
+            )
+        if token_uncertainties:
+            details.append(
+                "ownership token unavailable for recent same-user candidate pid(s) "
+                f"{token_uncertainties}"
+            )
+        raise RuntimeError(
+            "Could not prove analysis environment-preparation subprocess cleanup: "
+            + "; ".join(details)
+        )
+
+
+def _wait_owned_preparation_process(process: subprocess.Popen[Any]) -> int:
+    """Wait for an environment-preparation child and reap it on interruption."""
+
+    try:
+        return_code = process.wait(
+            timeout=_ANALYSIS_PREPARATION_PROCESS_TIMEOUT_SECONDS
+        )
+        _terminate_process_quietly(process, parent_reaped=True)
+        return return_code
+    except subprocess.TimeoutExpired as exc:
+        _terminate_process_quietly(process)
+        raise RuntimeError(
+            "Analysis environment preparation timed out; its owned subprocess "
+            "tree was stopped before another session may retry."
+        ) from exc
+    except BaseException:
+        _terminate_process_quietly(process)
+        raise
+
+
+def _ensure_prepared_analysis_sidecar(
+    *,
+    env: Any,
+    view_page: Path,
+    active_app: str,
+    page_root: Path,
+    project: str,
+    registry_key: str,
+    uv: list[str],
+    uv_process_env: dict[str, str],
+) -> SidecarLease:
+    """Prepare one page environment and publish its sidecar under one lease."""
+    page_root = page_root.resolve(strict=False)
+    page_home = str(page_root)
+    preparation_scope = page_home
+    with DEFAULT_SIDECAR_REGISTRY.preparation_guard(
+        service_kind="analysis-view-preparation",
+        project=preparation_scope,
+        key=preparation_scope,
+    ):
+        existing = DEFAULT_SIDECAR_REGISTRY.get(
+            service_kind="analysis-view",
+            project=project,
+            key=registry_key,
+        )
+        if existing is not None:
+            return existing
 
         if _page_sync_is_fresh(page_root):
             env.logger.info(
@@ -991,13 +1484,17 @@ def _ensure_sidecar(view_key: str, view_page: Path, port: int, active_app: str) 
             ]
             env.logger.info(_format_bg_command(sync_cmd))
             sync_process = exec_bg(
-                env, sync_cmd, cwd=page_home, process_env=uv_process_env
+                env,
+                sync_cmd,
+                cwd=page_home,
+                process_env=uv_process_env,
+                owned_process_group=True,
             )
-            sync_code = sync_process.wait()
+            sync_code = _wait_owned_preparation_process(sync_process)
             if sync_code != 0:
-                last_error = f"sync failed with code {sync_code} for {page_home}"
-                env.logger.error(last_error)
-                continue
+                raise RuntimeError(
+                    f"sync failed with code {sync_code} for {page_home}"
+                )
             try:
                 _write_page_sync_stamp(page_root)
             except OSError as exc:
@@ -1028,9 +1525,13 @@ def _ensure_sidecar(view_key: str, view_page: Path, port: int, active_app: str) 
                 ]
                 env.logger.info(_format_bg_command(pip_probe_cmd))
                 pip_probe_process = exec_bg(
-                    env, pip_probe_cmd, cwd=page_home, process_env=uv_process_env
+                    env,
+                    pip_probe_cmd,
+                    cwd=page_home,
+                    process_env=uv_process_env,
+                    owned_process_group=True,
                 )
-                if pip_probe_process.wait() != 0:
+                if _wait_owned_preparation_process(pip_probe_process) != 0:
                     ensure_cmd = [
                         *uv,
                         "--preview-features",
@@ -1044,15 +1545,17 @@ def _ensure_sidecar(view_key: str, view_page: Path, port: int, active_app: str) 
                     ]
                     env.logger.info(_format_bg_command(ensure_cmd))
                     ensure_process = exec_bg(
-                        env, ensure_cmd, cwd=page_home, process_env=uv_process_env
+                        env,
+                        ensure_cmd,
+                        cwd=page_home,
+                        process_env=uv_process_env,
+                        owned_process_group=True,
                     )
-                    ensure_code = ensure_process.wait()
+                    ensure_code = _wait_owned_preparation_process(ensure_process)
                     if ensure_code != 0:
-                        last_error = (
+                        raise RuntimeError(
                             f"ensurepip failed with code {ensure_code} for {page_home}"
                         )
-                        env.logger.error(last_error)
-                        continue
 
                 install_cmd = [
                     *uv,
@@ -1070,15 +1573,17 @@ def _ensure_sidecar(view_key: str, view_page: Path, port: int, active_app: str) 
                 ]
                 env.logger.info(_format_bg_command(install_cmd))
                 install_process = exec_bg(
-                    env, install_cmd, cwd=page_home, process_env=uv_process_env
+                    env,
+                    install_cmd,
+                    cwd=page_home,
+                    process_env=uv_process_env,
+                    owned_process_group=True,
                 )
-                install_code = install_process.wait()
+                install_code = _wait_owned_preparation_process(install_process)
                 if install_code != 0:
-                    last_error = (
+                    raise RuntimeError(
                         f"pip install failed with code {install_code} for {page_home}"
                     )
-                    env.logger.error(last_error)
-                    continue
                 try:
                     _write_source_bootstrap_stamp(page_root, source_root)
                 except OSError as exc:
@@ -1088,60 +1593,111 @@ def _ensure_sidecar(view_key: str, view_page: Path, port: int, active_app: str) 
                         exc,
                     )
 
-        run_cmd = [
-            *uv,
-            "run",
-            "--project",
-            page_home,
-            "python",
-            "-m",
-            "streamlit",
-            "run",
-            str(view_page),
-            "--server.port",
-            str(port),
-            "--server.address",
-            "127.0.0.1",
-            "--server.headless",
-            "true",
-            "--server.enableCORS",
-            "false",
-            "--server.enableXsrfProtection",
-            "false",
-            "--browser.gatherUsageStats",
-            "false",
-        ]
-        if active_app:
-            run_cmd.extend(["--", "--active-app", active_app])
-        env.logger.info(_format_bg_command(run_cmd))
-        run_process = exec_bg(env, run_cmd, cwd=page_home, process_env=uv_process_env)
+        def _launch_page(allocated_port: int, _token: str):
+            run_cmd = [
+                *uv,
+                "run",
+                "--project",
+                page_home,
+                "python",
+                "-m",
+                "streamlit",
+                "run",
+                str(view_page),
+                "--server.port",
+                str(allocated_port),
+                "--server.address",
+                "127.0.0.1",
+                "--server.headless",
+                "true",
+                "--server.enableCORS",
+                "false",
+                "--server.enableXsrfProtection",
+                "false",
+                "--browser.gatherUsageStats",
+                "false",
+            ]
+            if active_app:
+                run_cmd.extend(["--", "--active-app", active_app])
+            env.logger.info(_format_bg_command(run_cmd))
+            return exec_bg(
+                env,
+                run_cmd,
+                cwd=page_home,
+                process_env=uv_process_env,
+            )
 
-        # Wait a bit for the port to come up
-        for _ in range(240):
-            if _is_port_open(port):
-                return True
-            if run_process.poll() is not None:
-                break
-            time.sleep(0.1)
+        return DEFAULT_SIDECAR_REGISTRY.ensure(
+            service_kind="analysis-view",
+            project=project,
+            key=registry_key,
+            launcher=_launch_page,
+        )
 
-        if run_process.poll() is not None and run_process.returncode != 0:
-            last_error = f"Sidecar process exited with code {run_process.returncode} for {page_home}"
+
+def _ensure_sidecar(view_key: str, view_page: Path, port: int, active_app: str) -> bool:
+    """Start or reuse a process-verified Streamlit sidecar."""
+    _ = port  # retained for compatibility; the registry allocates the endpoint.
+    env = st.session_state["env"]
+    ip = "127.0.0.1"
+    uv, uv_process_env = _local_uv_command(env, ip)
+    attempts: list[str] = []
+    last_error = ""
+    registry_key = f"{view_key}|{view_page.resolve(strict=False)}|{active_app}"
+    project = str(active_app or getattr(env, "app", "") or view_page.parent)
+
+    try:
+        existing = DEFAULT_SIDECAR_REGISTRY.get(
+            service_kind="analysis-view",
+            project=project,
+            key=registry_key,
+        )
+    except SidecarRegistryError as exc:
+        attempts.append(str(exc))
+        st.session_state[f"sidecar_attempts__{view_key}"] = attempts
+        env.logger.error("Analysis sidecar ownership check failed: %s", exc)
+        return False
+    if existing is not None:
+        _remember_sidecar_lease("analysis-view", view_key, existing)
+        return True
+
+    project_roots = _iter_page_project_roots(view_page)
+    if not project_roots:
+        env.logger.error("Could not determine project root for page: %s", view_page)
+        attempts.append(f"No uv project root with pyproject.toml for {view_page}")
+        last_error = f"No uv project root with pyproject.toml for {view_page}"
+    log_file, err_file = _page_log_paths(view_page, env.AGILAB_LOG_ABS)
+    env.out_log = log_file
+    env.err_log = err_file
+
+    for page_root in project_roots:
+        page_home = str(page_root)
+        env.logger.info("Trying analysis page sidecar project root: %s", page_home)
+        attempts.append(f"Trying uv project root: {page_home}")
+        try:
+            lease = _ensure_prepared_analysis_sidecar(
+                env=env,
+                view_page=view_page,
+                active_app=active_app,
+                page_root=page_root,
+                project=project,
+                registry_key=registry_key,
+                uv=uv,
+                uv_process_env=uv_process_env,
+            )
+        except RuntimeError as exc:
+            last_error = f"Sidecar launch failed for {page_home}: {exc}"
             env.logger.error(last_error)
             attempts.append(last_error)
             continue
-        if _is_port_open(port):
-            return True
-
-        if run_process.poll() is None:
-            _terminate_process_quietly(run_process)
-        last_error = f"Sidecar streamlit did not open port {port} for {page_home}"
-        attempts.append(last_error)
+        _remember_sidecar_lease("analysis-view", view_key, lease)
+        return True
 
     if last_error:
         env.logger.error("Failed to start analysis sidecar for %s", view_page)
         env.logger.error(last_error)
         page_venv = _find_venv_for(view_page)
-        fallback_targets = []
+        fallback_targets: list[tuple[str, list[str], str]] = []
         if page_venv is not None:
             python = _python_in_venv(page_venv)
             fallback_targets.append(
@@ -1154,7 +1710,7 @@ def _ensure_sidecar(view_key: str, view_page: Path, port: int, active_app: str) 
                         "run",
                         str(view_page),
                         "--server.port",
-                        str(port),
+                        "{port}",
                         "--server.address",
                         "127.0.0.1",
                         "--server.headless",
@@ -1180,7 +1736,7 @@ def _ensure_sidecar(view_key: str, view_page: Path, port: int, active_app: str) 
                     "run",
                     str(view_page),
                     "--server.port",
-                    str(port),
+                    "{port}",
                     "--server.address",
                     "127.0.0.1",
                     "--server.headless",
@@ -1199,33 +1755,32 @@ def _ensure_sidecar(view_key: str, view_page: Path, port: int, active_app: str) 
 
         for label, fallback_cmd, fallback_pythonpath in fallback_targets:
             attempts.append(f"Trying fallback command: {label}")
-            run_process = exec_bg(
-                env,
-                fallback_cmd,
-                cwd=str(view_page.parent),
-                process_env={"PYTHONPATH": fallback_pythonpath},
-            )
-            for _ in range(240):
-                if _is_port_open(port):
-                    return True
-                if run_process.poll() is not None:
-                    break
-                time.sleep(0.1)
-            if run_process.poll() is not None and run_process.returncode != 0:
-                last_error = (
-                    f"Fallback command '{label}' exited with code "
-                    f"{run_process.returncode} for {view_page}"
+            def _launch_fallback(allocated_port: int, _token: str):
+                command = [
+                    str(allocated_port) if part == "{port}" else part
+                    for part in fallback_cmd
+                ]
+                return exec_bg(
+                    env,
+                    command,
+                    cwd=str(view_page.parent),
+                    process_env={"PYTHONPATH": fallback_pythonpath},
                 )
-                env.logger.error(last_error)
-                attempts.append(last_error)
-                continue
 
-            if run_process.poll() is None:
-                _terminate_process_quietly(run_process)
-            if not _is_port_open(port):
-                last_error = f"Fallback command '{label}' did not open port {port} for {view_page}"
+            try:
+                lease = DEFAULT_SIDECAR_REGISTRY.ensure(
+                    service_kind="analysis-view",
+                    project=project,
+                    key=registry_key,
+                    launcher=_launch_fallback,
+                )
+            except SidecarRegistryError as exc:
+                last_error = f"Fallback command '{label}' failed for {view_page}: {exc}"
                 attempts.append(last_error)
                 env.logger.error(last_error)
+                continue
+            _remember_sidecar_lease("analysis-view", view_key, lease)
+            return True
         st.session_state[f"sidecar_attempts__{view_key}"] = attempts
     return False
 
@@ -2886,49 +3441,64 @@ def _is_hosted_analysis_runtime(env: AgiEnv) -> bool:
     return bool(space_host or space_id)
 
 
+class HostedAnalysisBusyError(RuntimeError):
+    """Raised when another hosted inline view owns process import state."""
+
+
+_HOSTED_INLINE_RENDER_LEASE = HOSTED_INLINE_RENDER_SESSION_LEASE
+
+
 async def _render_view_page_inline(view_path: Path, active_app: str) -> None:
-    """Render an apps-page inline in the current Streamlit process."""
+    """Render one hosted apps-page under a fail-fast process-state lease.
+
+    Generic apps-pages still depend on ``sys.argv`` and import-path compatibility.
+    The nonblocking lease prevents those globals from interleaving across
+    Streamlit sessions; a future hosted subprocess/proxy renderer can replace
+    this single compatibility boundary.
+    """
+    if not _HOSTED_INLINE_RENDER_LEASE.acquire(blocking=False):
+        raise HostedAnalysisBusyError(
+            "Another hosted analysis view is rendering. Wait for it to finish, then retry."
+        )
+
     resolved_view = Path(view_path).resolve()
-    if not resolved_view.exists():
-        raise FileNotFoundError(f"Analysis view does not exist: {resolved_view}")
-
-    module_name = f"agilab_analysis_inline_{resolved_view.stem}_{_short_page_token(resolved_view)}"
-    module_dir = str(resolved_view.parent)
-    original_argv = list(sys.argv)
-    inserted_path = False
-    sys.modules.pop(module_name, None)
-
-    if module_dir not in sys.path:
-        sys.path.insert(0, module_dir)
-        inserted_path = True
-
     try:
-        sys.argv = [resolved_view.name]
-        if active_app:
-            sys.argv.extend(["--active-app", active_app])
+        if not resolved_view.exists():
+            raise FileNotFoundError(f"Analysis view does not exist: {resolved_view}")
 
-        spec = importlib.util.spec_from_file_location(module_name, resolved_view)
-        if spec is None or spec.loader is None:
-            raise ModuleNotFoundError(
-                f"Unable to load analysis view from {resolved_view}"
-            )
-        module = importlib.util.module_from_spec(spec)
-        sys.modules[module_name] = module
-        spec.loader.exec_module(module)
+        module_name = f"agilab_analysis_inline_{resolved_view.stem}_{_short_page_token(resolved_view)}"
+        original_module = sys.modules.get(module_name)
+        try:
+            render_argv = [resolved_view.name]
+            if active_app:
+                render_argv.extend(["--active-app", active_app])
 
-        entrypoint = getattr(module, "main", None)
-        if callable(entrypoint):
-            result = entrypoint()
-            if inspect.isawaitable(result):
-                await result
+            with isolated_import_process_state(
+                argv=render_argv,
+                prepend_paths=(resolved_view.parent,),
+                module_roots=(resolved_view.parent,),
+            ):
+                spec = importlib.util.spec_from_file_location(module_name, resolved_view)
+                if spec is None or spec.loader is None:
+                    raise ModuleNotFoundError(
+                        f"Unable to load analysis view from {resolved_view}"
+                    )
+                module = importlib.util.module_from_spec(spec)
+                sys.modules[module_name] = module
+                spec.loader.exec_module(module)
+
+                entrypoint = getattr(module, "main", None)
+                if callable(entrypoint):
+                    result = entrypoint()
+                    if inspect.isawaitable(result):
+                        await result
+        finally:
+            if original_module is None:
+                sys.modules.pop(module_name, None)
+            else:
+                sys.modules[module_name] = original_module
     finally:
-        sys.argv = original_argv
-        if inserted_path:
-            try:
-                sys.path.remove(module_dir)
-            except ValueError:
-                pass
-        sys.modules.pop(module_name, None)
+        _HOSTED_INLINE_RENDER_LEASE.release()
 
 
 def _project_root_for_notebook(
@@ -2978,6 +3548,11 @@ def _notebook_sidecar_token_key(notebook_key: str) -> str:
 
 
 def _notebook_sidecar_token(notebook_key: str) -> str:
+    remembered = _remembered_sidecar_lease("notebook", notebook_key)
+    if remembered:
+        registered_token = remembered.get("token")
+        if isinstance(registered_token, str) and registered_token:
+            return registered_token
     session_key = _notebook_sidecar_token_key(notebook_key)
     token = st.session_state.get(session_key)
     if not isinstance(token, str) or not token:
@@ -3004,14 +3579,12 @@ def _ensure_notebook_sidecar(
     project_root: Path,
     token: str | None = None,
 ) -> bool:
-    """Start a local JupyterLab sidecar rooted at the active project."""
-    if _is_port_open(port):
-        return True
+    """Start or reuse a process-verified JupyterLab sidecar."""
+    _ = port  # retained for compatibility; the registry allocates the endpoint.
     env = st.session_state["env"]
     ip = "127.0.0.1"
     uv, uv_process_env = _local_uv_command(env, ip)
     attempts: list[str] = []
-    last_error = ""
 
     log_file, err_file = _notebook_log_paths(notebook_path, env.AGILAB_LOG_ABS)
     env.out_log = log_file
@@ -3020,56 +3593,66 @@ def _ensure_notebook_sidecar(
     project_home = str(project_root.resolve())
     sidecar_token = token or _notebook_sidecar_token(notebook_key)
     tornado_settings = _notebook_iframe_tornado_settings_arg()
-    run_cmd = [
-        *uv,
-        "--preview-features",
-        "extra-build-dependencies",
-        "run",
-        "--project",
-        project_home,
-        "--with",
-        "jupyterlab",
-        "--with",
-        "ipykernel",
-        "jupyter",
-        "lab",
-        "--no-browser",
-        "--ServerApp.ip=127.0.0.1",
-        f"--ServerApp.port={port}",
-        "--ServerApp.open_browser=False",
-        f"--ServerApp.token={sidecar_token}",
-        "--ServerApp.password=",
-        f"--ServerApp.allow_origin_pat={_NOTEBOOK_ALLOW_ORIGIN_PAT}",
-        f"--ServerApp.root_dir={project_home}",
-        f"--ServerApp.tornado_settings={tornado_settings}",
-    ]
-    env.logger.info(
-        "Starting project notebook sidecar: %s", _format_bg_command(run_cmd)
-    )
     attempts.append(f"Trying JupyterLab sidecar rooted at: {project_home}")
-    run_process = exec_bg(env, run_cmd, cwd=project_home, process_env=uv_process_env)
 
-    for _ in range(240):
-        if _is_port_open(port):
-            return True
-        if run_process.poll() is not None:
-            break
-        time.sleep(0.1)
+    def _launch_notebook(allocated_port: int, registered_token: str):
+        run_cmd = [
+            *uv,
+            "--preview-features",
+            "extra-build-dependencies",
+            "run",
+            "--project",
+            project_home,
+            "--with",
+            "jupyterlab",
+            "--with",
+            "ipykernel",
+            "jupyter",
+            "lab",
+            "--no-browser",
+            "--ServerApp.ip=127.0.0.1",
+            f"--ServerApp.port={allocated_port}",
+            "--ServerApp.open_browser=False",
+            f"--ServerApp.token={registered_token}",
+            "--ServerApp.password=",
+            f"--ServerApp.allow_origin_pat={_NOTEBOOK_ALLOW_ORIGIN_PAT}",
+            f"--ServerApp.root_dir={project_home}",
+            f"--ServerApp.tornado_settings={tornado_settings}",
+        ]
+        logged_cmd = [
+            "--ServerApp.token=<redacted>"
+            if part.startswith("--ServerApp.token=")
+            else part
+            for part in run_cmd
+        ]
+        env.logger.info(
+            "Starting project notebook sidecar: %s", _format_bg_command(logged_cmd)
+        )
+        return exec_bg(
+            env,
+            run_cmd,
+            cwd=project_home,
+            process_env=uv_process_env,
+        )
 
-    if run_process.poll() is not None and run_process.returncode != 0:
-        last_error = f"Notebook sidecar exited with code {run_process.returncode} for {project_home}"
+    try:
+        lease = DEFAULT_SIDECAR_REGISTRY.ensure(
+            service_kind="notebook",
+            project=project_home,
+            key=project_home,
+            launcher=_launch_notebook,
+            token=sidecar_token,
+        )
+    except SidecarRegistryError as exc:
+        last_error = f"Notebook sidecar ownership/start check failed: {exc}"
         attempts.append(last_error)
         env.logger.error(last_error)
-    elif run_process.poll() is None:
-        _terminate_process_quietly(run_process)
-        last_error = f"Notebook sidecar did not open port {port} for {project_home}"
-        attempts.append(last_error)
-        env.logger.error(last_error)
+        st.session_state[f"notebook_sidecar_attempts__{notebook_key}"] = attempts
+        return False
 
-    if last_error:
-        env.logger.error("Failed to start notebook sidecar for %s", notebook_path)
-    st.session_state[f"notebook_sidecar_attempts__{notebook_key}"] = attempts
-    return False
+    _remember_sidecar_lease("notebook", notebook_key, lease)
+    st.session_state[_notebook_sidecar_token_key(notebook_key)] = lease.token
+    return True
 
 
 # --- helper: hide the parent (this page's) Streamlit sidebar when embedding a child ---
@@ -3095,11 +3678,13 @@ def _hide_parent_sidebar():
 def _read_config(path: Path) -> dict:
     try:
         if path.exists():
-            with open(path, "rb") as f:
-                return tomllib.load(f)
+            return read_app_settings(path)
     except (OSError, tomllib.TOMLDecodeError) as e:
         st.error(f"Error loading configuration: {e}")
     return {}
+
+
+_ANALYSIS_APP_SETTINGS_KEYS = ("pages", "notebooks", "app_surface")
 
 
 def _normalize_view_name(value: str) -> str:
@@ -3107,11 +3692,63 @@ def _normalize_view_name(value: str) -> str:
     return _analysis_normalize_view_name(value)
 
 
-def _write_config(path: Path, cfg: dict):
+def _write_config(
+    path: Path,
+    cfg: dict,
+    *,
+    keys: Sequence[str] | None = None,
+    previous: dict | None = None,
+) -> None:
+    """Merge this session's owned leaf changes into the latest settings."""
+
+    patch_keys = tuple(cfg) if keys is None else tuple(keys)
+
+    missing = object()
+
+    def _changed_paths(
+        before_value: Any,
+        after_value: Any,
+        prefix: tuple[str, ...],
+    ) -> list[tuple[str, ...]]:
+        if before_value is missing and isinstance(after_value, dict):
+            before_value = {}
+        if before_value == after_value:
+            return []
+        if isinstance(before_value, dict) and isinstance(after_value, dict):
+            paths: list[tuple[str, ...]] = []
+            for child_key in sorted(set(before_value) | set(after_value)):
+                paths.extend(
+                    _changed_paths(
+                        before_value.get(child_key, missing),
+                        after_value.get(child_key, missing),
+                        (*prefix, child_key),
+                    )
+                )
+            return paths or [prefix]
+        return [prefix]
+
+    if previous is None:
+        owned_paths = [(key,) for key in patch_keys]
+    else:
+        owned_paths = []
+        for key in patch_keys:
+            owned_paths.extend(
+                _changed_paths(
+                    previous.get(key, missing),
+                    cfg.get(key, missing),
+                    (key,),
+                )
+            )
+    if not owned_paths:
+        return
+
     try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        with open(path, "wb") as f:
-            tomli_w.dump(prepare_app_settings_for_write(cfg), f)
+        update_app_settings_owned(
+            path,
+            cfg,
+            owned_paths=owned_paths,
+            dump_fn=tomli_w.dump,
+        )
     except (OSError, ValueError) as e:
         st.error(f"Error updating configuration: {e}")
 
@@ -3205,6 +3842,7 @@ async def main():
 
     # Load config and ensure structure
     cfg = _read_config(app_settings)
+    config_before_migrations = deepcopy(cfg)
     if "pages" not in cfg:
         cfg["pages"] = {}
     migrated_cfg = False
@@ -3231,7 +3869,13 @@ async def main():
                 )
                 migrated_cfg = True
     if migrated_cfg:
-        _write_config(app_settings, cfg)
+        _write_config(
+            app_settings,
+            cfg,
+            keys=_ANALYSIS_APP_SETTINGS_KEYS,
+            previous=config_before_migrations,
+        )
+    config_before_selection = deepcopy(cfg)
     _render_analysis_project_sidebar_label(project, active_app_path, cfg)
     configured_views: list[str] = [
         str(v)
@@ -3490,7 +4134,12 @@ async def main():
             persisted_notebooks["selected"] = selected_notebooks
             config_changed = True
     if config_changed:
-        _write_config(app_settings, cfg)
+        _write_config(
+            app_settings,
+            cfg,
+            keys=_ANALYSIS_APP_SETTINGS_KEYS,
+            previous=config_before_selection,
+        )
 
     _render_sidebar_launchers(
         sidebar_selected_views=selected_views,
@@ -3627,6 +4276,14 @@ async def render_notebook_page(notebook_path: Path):
     sidecar_ready = _ensure_notebook_sidecar(
         notebook_key, resolved_notebook, port, project_root, token=sidecar_token
     )
+    registered_notebook = _remembered_sidecar_lease("notebook", notebook_key)
+    if registered_notebook:
+        endpoint = str(registered_notebook.get("endpoint", "") or "").rstrip("/")
+        registered_token = registered_notebook.get("token")
+        if isinstance(registered_token, str) and registered_token:
+            sidecar_token = registered_token
+    else:
+        endpoint = f"http://127.0.0.1:{port}"
 
     qp = st.query_params
     extras = {}
@@ -3673,7 +4330,7 @@ async def render_notebook_page(notebook_path: Path):
                 st.markdown("Attempt summary:")
                 st.code("\n".join(sidecar_attempts), language="bash")
         return
-    url = f"http://127.0.0.1:{port}/lab/tree/{notebook_url_path}?{query}"
+    url = f"{endpoint}/lab/tree/{notebook_url_path}?{query}"
     env.logger.info(
         "notebook url: http://127.0.0.1:%s/lab/tree/%s?token=<redacted>",
         port,
@@ -3714,7 +4371,11 @@ async def render_view_page(
         env.logger.info(
             "Hosted runtime detected; rendering analysis view inline: %s", view_path
         )
-        await _render_view_page_inline(view_path, active_app_arg)
+        try:
+            await _render_view_page_inline(view_path, active_app_arg)
+        except HostedAnalysisBusyError as exc:
+            st.error("This hosted analysis renderer is busy with another session.")
+            st.caption(str(exc))
         return
 
     try:
@@ -3762,7 +4423,13 @@ async def render_view_page(
                 st.markdown("Attempt summary:")
                 st.code("\n".join(sidecar_attempts), language="bash")
         return
-    url = f"http://127.0.0.1:{port}/?{query}"
+    registered_view = _remembered_sidecar_lease("analysis-view", view_key)
+    endpoint = (
+        str(registered_view.get("endpoint", "") or "").rstrip("/")
+        if registered_view
+        else f"http://127.0.0.1:{port}"
+    )
+    url = f"{endpoint}/?{query}"
     env.logger.info("page url: %s", url)
     st.iframe(url, height=900)
 

--- a/src/agilab/pipeline/pipeline_lab.py
+++ b/src/agilab/pipeline/pipeline_lab.py
@@ -685,6 +685,9 @@ _dag_run_engine_module = import_agilab_module(
     fallback_name="agilab_dag_run_engine_fallback",
 )
 DagRunEngine = _dag_run_engine_module.DagRunEngine
+RunnerStateConflictError = _dag_run_engine_module.RunnerStateConflictError
+RunnerStateAttemptConflictError = _dag_run_engine_module.RunnerStateAttemptConflictError
+RunnerStateRecoveryRequiredError = _dag_run_engine_module.RunnerStateRecoveryRequiredError
 MultiAppDagBatchExecutionResult = _dag_run_engine_module.DagBatchExecutionResult
 MultiAppDagStageExecutionResult = _dag_run_engine_module.DagStageExecutionResult
 GLOBAL_DAG_QUEUE_UNIT_ID = _dag_run_engine_module.GLOBAL_DAG_QUEUE_UNIT_ID
@@ -702,6 +705,7 @@ controlled_real_run_supported = _dag_run_engine_module.controlled_real_run_suppo
 dispatch_next_runnable = _dag_run_engine_module.dispatch_next_runnable
 execution_history_rows = _dag_run_engine_module.execution_history_rows
 load_runner_state = _dag_run_engine_module.load_runner_state
+load_runner_state_snapshot = _dag_run_engine_module.load_runner_state_snapshot
 persist_runner_state = _dag_run_engine_module.persist_runner_state
 repo_relative_text_for_dag = _dag_run_engine_module.repo_relative_text
 run_multi_app_dag_queue_baseline_app = _dag_run_engine_module.run_multi_app_dag_queue_baseline_app
@@ -709,6 +713,9 @@ run_multi_app_dag_relay_followup_app = _dag_run_engine_module.run_multi_app_dag_
 run_next_controlled_multi_app_dag_stage = _dag_run_engine_module.run_next_controlled_stage
 run_ready_controlled_multi_app_dag_stages = _dag_run_engine_module.run_ready_controlled_stages
 runner_state_dag_matches = _dag_run_engine_module.runner_state_dag_matches
+runner_state_active_attempt = _dag_run_engine_module.runner_state_active_attempt
+runner_state_revision = _dag_run_engine_module.runner_state_revision
+runner_state_write_transaction = _dag_run_engine_module.runner_state_write_transaction
 write_runner_state = _dag_run_engine_module.write_runner_state
 
 _workflow_run_manifest_module = import_agilab_module(
@@ -3107,8 +3114,14 @@ def _write_pipeline_stages_runner_state_with_evidence(
     *,
     lab_dir: Path,
     trigger: Mapping[str, Any],
+    expected_revision: str | None = None,
 ) -> Path:
-    written_path = write_runner_state(state_path, state)
+    with runner_state_write_transaction(
+        state_path,
+        state,
+        expected_revision=expected_revision,
+    ) as written_path:
+        pass
     write_workflow_run_evidence(
         state=state,
         state_path=written_path,
@@ -3131,14 +3144,22 @@ def _load_or_create_pipeline_stages_runner_state(
     reset: bool = False,
 ) -> tuple[dict[str, Any], Path]:
     state_path = lab_dir / ".agilab" / GLOBAL_RUNNER_STATE_FILENAME
+    observed_state, observed_revision = load_runner_state_snapshot(state_path)
+    if observed_state is not None:
+        active = runner_state_active_attempt(observed_state)
+        if active is not None:
+            raise RunnerStateRecoveryRequiredError(
+                state_path,
+                attempt_id=str(active.get("attempt_id", "")),
+            )
     evidence = _pipeline_stages_execution_evidence(
         index_page=index_page,
         session_state=session_state,
         stages_file=stages_file,
         stage_count=len(pipeline_stages),
     )
-    if state_path.is_file() and not reset:
-        state = load_runner_state(state_path)
+    if observed_state is not None and not reset:
+        state = observed_state
         if _pipeline_stages_state_matches(
             state,
             stages_file=stages_file,
@@ -3173,6 +3194,7 @@ def _load_or_create_pipeline_stages_runner_state(
                 stale_state,
                 lab_dir=lab_dir,
                 trigger={"surface": "workflow", "action": "project_stages_stale"},
+                expected_revision=observed_revision,
             )
             return stale_state, state_path
 
@@ -3199,6 +3221,7 @@ def _load_or_create_pipeline_stages_runner_state(
         state,
         lab_dir=lab_dir,
         trigger={"surface": "workflow", "action": "project_stages_state_written"},
+        expected_revision=observed_revision,
     )
     return state, state_path
 
@@ -3307,6 +3330,46 @@ def _render_global_runner_state_view(
     else:
         st.caption("Execution history: no step has been started yet.")
 
+    active_attempt = runner_state_active_attempt(state)
+    if active_attempt is not None:
+        attempt_id = str(active_attempt.get("attempt_id", ""))
+        unit_tokens = active_attempt.get("unit_tokens")
+        token_rows = dict(unit_tokens) if isinstance(unit_tokens, Mapping) else {}
+        st.warning(
+            "This workflow has a durable execution claim whose final outcome is unknown. "
+            "Do not reset or switch plans until each exact unit token is explicitly recovered."
+        )
+        st.caption(f"Attempt: `{attempt_id}`")
+        for unit_id, token_value in sorted(token_rows.items()):
+            token = str(token_value)
+            recover_clicked = action_button(
+                st,
+                f"Recover {unit_id}",
+                key=f"{index_page_str}_global_runner_recover_{_multi_app_dag_source_token(token)}",
+                kind="reset",
+                help=(
+                    "Acknowledge that this exact token may already have produced a side effect, "
+                    "mark it failed, and require a separate reset before retry."
+                ),
+            )
+            if not recover_clicked:
+                continue
+            try:
+                dag_engine.recover_execution_attempt_transaction(
+                    state,
+                    unit_id=str(unit_id),
+                    idempotency_token=token,
+                )
+            except (RunnerStateAttemptConflictError, RunnerStateConflictError) as exc:
+                st.warning("The recovery token changed in another session. Reloading the latest state.")
+                st.caption(str(exc))
+                st.rerun()
+                return
+            st.success(f"Recovered `{unit_id}`. Reset the plan explicitly before retrying it.")
+            st.rerun()
+            return
+        return
+
     real_run_supported = real_run_support.supported
     if real_run_supported:
         stage_backend = GLOBAL_DAG_STAGE_BACKEND_LOCAL
@@ -3363,28 +3426,47 @@ def _render_global_runner_state_view(
             )
         if run_stage_clicked:
             try:
-                result = dag_engine.run_next_controlled_stage(state)
+                result = dag_engine.run_next_controlled_stage_transaction(state)
+            except RunnerStateRecoveryRequiredError as exc:
+                st.warning("An active workflow attempt must be recovered before changing this preview.")
+                st.caption(str(exc))
+                return
+            except RunnerStateConflictError as exc:
+                st.warning("Workflow state changed in another session. Reloading the latest state.")
+                st.caption(str(exc))
+                st.rerun()
+                return
             except Exception as exc:
                 st.error("Controlled workflow step execution failed.")
                 st.caption("Full diagnostic")
                 st.code(str(exc), language="text", height=400)
                 return
             if result.ok:
-                dag_engine.write_state(result.state)
                 st.success(result.message)
                 st.rerun()
             else:
                 st.warning(result.message)
         if run_ready_clicked:
             try:
-                result = dag_engine.run_ready_controlled_stages(state, execution_backend=stage_backend)
+                result = dag_engine.run_ready_controlled_stages_transaction(
+                    state,
+                    execution_backend=stage_backend,
+                )
+            except RunnerStateRecoveryRequiredError as exc:
+                st.warning("An active workflow attempt must be recovered before reset or source switch.")
+                st.caption(str(exc))
+                return
+            except RunnerStateConflictError as exc:
+                st.warning("Workflow state changed in another session. Reloading the latest state.")
+                st.caption(str(exc))
+                st.rerun()
+                return
             except Exception as exc:
                 st.error("Controlled DAG batch execution failed.")
                 st.caption("Full diagnostic")
                 st.code(str(exc), language="text", height=400)
                 return
             if result.executed_unit_ids or result.failed_unit_ids:
-                dag_engine.write_state(result.state)
                 if result.ok:
                     st.success(result.message)
                 else:
@@ -3417,9 +3499,14 @@ def _render_global_runner_state_view(
         disabled=dispatch_disabled,
     )
     if dispatch_clicked:
-        result = dag_engine.dispatch_next_runnable(state)
+        try:
+            result = dag_engine.dispatch_next_runnable_transaction(state)
+        except RunnerStateConflictError as exc:
+            st.warning("Workflow state changed in another session. Reloading the latest state.")
+            st.caption(str(exc))
+            st.rerun()
+            return
         if result.ok:
-            dag_engine.write_state(result.state)
             st.success(result.message)
             st.rerun()
         else:
@@ -3548,6 +3635,11 @@ def _render_global_runner_state_panel(
                     session_state=st.session_state,
                     reset=reset_clicked,
                 )
+            except RunnerStateConflictError as exc:
+                st.warning("Workflow state changed in another session. Reloading the latest state.")
+                st.caption(str(exc))
+                st.rerun()
+                return
             except Exception as exc:
                 st.error("Project stages DAG preview is unavailable.")
                 st.caption("Full diagnostic")
@@ -3644,6 +3736,11 @@ def _render_global_runner_state_panel(
                     reset=reset_clicked,
                 )
                 dag_engine = _multi_app_dag_engine(repo_root, lab_dir, dag_path, env=env)
+            except RunnerStateConflictError as exc:
+                st.warning("Workflow state changed in another session. Reloading the latest state.")
+                st.caption(str(exc))
+                st.rerun()
+                return
             except Exception as exc:
                 st.error("Multi-app plan preview is unavailable.")
                 st.caption("Full diagnostic")

--- a/src/agilab/pipeline/pipeline_openai.py
+++ b/src/agilab/pipeline/pipeline_openai.py
@@ -1,12 +1,12 @@
 import os
 from pathlib import Path
 import re
-import tempfile
 from typing import Any, Callable, Dict, Optional
 
 import streamlit as st
 
 from agi_env.defaults import get_default_openai_model
+from agi_env.runtime.env_config_support import update_env_file_text
 
 _ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
@@ -38,35 +38,23 @@ def persist_env_var(name: str, value: str) -> None:
     env_dir.mkdir(parents=True, exist_ok=True)
     env_dir.chmod(0o700)
     env_file = env_dir / ".env"
-    if env_file.is_symlink():
-        raise OSError(f"Refusing to write API credentials through symlink: {env_file}")
-    lines: list[str] = []
-    if env_file.exists():
+    symlink_error = f"Refusing to write API credentials through symlink: {env_file}"
+
+    def _apply(current_text: str | None) -> str:
         lines = [
             line
-            for line in env_file.read_text(encoding="utf-8").splitlines()
+            for line in (current_text or "").splitlines()
             if not line.strip().startswith(f"{name}=")
         ]
-    lines.append(f"{name}={_dotenv_quote(value)}")
+        lines.append(f"{name}={_dotenv_quote(value)}")
+        return "\n".join(lines) + "\n"
 
-    tmp_path: Optional[Path] = None
-    try:
-        with tempfile.NamedTemporaryFile(
-            "w",
-            encoding="utf-8",
-            dir=env_dir,
-            prefix=".env.",
-            delete=False,
-        ) as handle:
-            tmp_path = Path(handle.name)
-            handle.write("\n".join(lines) + "\n")
-        tmp_path.chmod(0o600)
-        tmp_path.replace(env_file)
-        env_file.chmod(0o600)
-    except Exception:
-        if tmp_path is not None:
-            tmp_path.unlink(missing_ok=True)
-        raise
+    update_env_file_text(
+        env_file,
+        _apply,
+        file_mode=0o600,
+        refuse_symlink_message=symlink_error,
+    )
 
 
 def prompt_for_openai_api_key(message: str) -> None:

--- a/src/agilab/pipeline/pipeline_run_controls.py
+++ b/src/agilab/pipeline/pipeline_run_controls.py
@@ -5,8 +5,10 @@ import hashlib
 import json
 import logging
 import os
+import posixpath
 import socket
 import subprocess
+import threading
 import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -152,7 +154,15 @@ def _apply_stage_profile(entry: Mapping[str, Any], profile: str) -> tuple[Dict[s
 
 def _stage_automation(entry: Mapping[str, Any]) -> Dict[str, Any]:
     automation = _mapping_payload(entry.get("automation"))
-    for key in ("skip_if_outputs_exist", "skip_if_outputs_current", "outputs", "output_paths", "inputs", "input_paths"):
+    for key in (
+        "skip_if_outputs_exist",
+        "skip_if_outputs_current",
+        "outputs",
+        "output_paths",
+        "inputs",
+        "input_paths",
+        "parallel_safe",
+    ):
         if key in entry and key not in automation:
             automation[key] = entry[key]
     return automation
@@ -568,12 +578,12 @@ def _literal_stage_paths(entry: Mapping[str, Any]) -> List[str]:
 
 def _stage_declared_outputs(entry: Mapping[str, Any]) -> List[str]:
     outputs: List[str] = []
-    d_value = _normalize_dependency_path(entry.get("D", ""))
+    d_value = _normalize_output_path_spec(entry.get("D", ""))
     if d_value and not d_value.endswith("/install"):
         outputs.append(d_value)
     automation = _stage_automation(entry)
     for item in _iter_path_specs(automation.get("outputs", automation.get("output_paths", []))):
-        normalized = _normalize_dependency_path(item)
+        normalized = _normalize_output_path_spec(item)
         if normalized:
             outputs.append(normalized)
     code = str(entry.get("C", "") or "")
@@ -584,10 +594,103 @@ def _stage_declared_outputs(entry: Mapping[str, Any]) -> List[str]:
         r"['\"]output_dir['\"]\s*:\s*(['\"])(?P<path>[^'\"]+)\1",
     ):
         for match in re.finditer(pattern, code):
-            normalized = _normalize_dependency_path(match.group("path"))
+            normalized = _normalize_output_path_spec(match.group("path"))
             if normalized:
                 outputs.append(normalized)
     return sorted(set(outputs))
+
+
+def _parallel_output_leaf_values(value: Any) -> tuple[List[str], bool]:
+    """Return explicit output leaves and whether the declaration is incomplete."""
+
+    if isinstance(value, (str, Path)):
+        text = str(value).strip()
+        return ([text], False) if text else ([], True)
+    if isinstance(value, Mapping):
+        if not value:
+            return [], True
+        values: List[str] = []
+        invalid = False
+        for key in sorted(value, key=str):
+            nested, nested_invalid = _parallel_output_leaf_values(value[key])
+            values.extend(nested)
+            invalid = invalid or nested_invalid
+        return values, invalid
+    if isinstance(value, (list, tuple, set)):
+        if not value:
+            return [], True
+        values = []
+        invalid = False
+        items = sorted(value, key=str) if isinstance(value, set) else value
+        for item in items:
+            nested, nested_invalid = _parallel_output_leaf_values(item)
+            values.extend(nested)
+            invalid = invalid or nested_invalid
+        return values, invalid
+    return [], True
+
+
+def _is_static_parallel_output_spec(raw: str) -> bool:
+    """Return whether an output root is one literal path, not a runtime pattern."""
+
+    text = str(raw or "").strip().strip("\"'")
+    if not text or "://" in text or "`" in text:
+        return False
+    if any(marker in text for marker in ("$", "{", "}", "*", "?", "[", "]")):
+        return False
+    if re.search(r"%[A-Za-z_][A-Za-z0-9_]*%", text):
+        return False
+    return bool(_normalize_output_path_spec(text))
+
+
+def _stage_parallel_output_contract(
+    entry: Mapping[str, Any],
+    *,
+    env: AgiEnv | None = None,
+    stages_file: Path | None = None,
+) -> tuple[List[str], Optional[str]]:
+    """Validate the explicit, exhaustive output-root contract for parallel AGI work."""
+
+    automation = _stage_automation(entry)
+    if not _truthy_pipeline_flag(automation.get("parallel_safe")):
+        return [], (
+            "set `automation.parallel_safe = true` only after listing every output root "
+            "in `automation.outputs`"
+        )
+
+    raw_values: List[str] = []
+    invalid = False
+    found_declaration = False
+    for key in ("outputs", "output_paths"):
+        if key not in automation:
+            continue
+        found_declaration = True
+        values, values_invalid = _parallel_output_leaf_values(automation.get(key))
+        raw_values.extend(values)
+        invalid = invalid or values_invalid
+    if not found_declaration or invalid or not raw_values:
+        return [], (
+            "`automation.parallel_safe = true` requires a non-empty, complete "
+            "`automation.outputs` list of literal output roots"
+        )
+
+    output_specs: List[str] = []
+    for raw in raw_values:
+        if not _is_static_parallel_output_spec(raw):
+            return [], (
+                f"parallel output root `{raw}` is dynamic or invalid; declare one literal "
+                "path root in `automation.outputs`"
+            )
+        normalized = _normalize_output_path_spec(raw)
+        if env is not None and stages_file is not None:
+            try:
+                resolved = _resolve_stage_output_path(normalized, env=env, stages_file=stages_file)
+            except (OSError, RuntimeError, TypeError, ValueError):
+                resolved = None
+            if resolved is None:
+                return [], f"parallel output root `{raw}` could not be resolved to a canonical path"
+        output_specs.append(normalized)
+    return sorted(set(output_specs)), None
 
 
 def _path_depends_on_output(path: str, output: str) -> bool:
@@ -642,6 +745,9 @@ def _build_stage_waves(
     sequence: List[int],
     profile: str,
     dependency_overrides: Mapping[str, List[str]] | None = None,
+    *,
+    env: AgiEnv | None = None,
+    stages_file: Path | None = None,
 ) -> tuple[List[List[int]], Optional[str], Dict[int, str], Dict[int, List[str]]]:
     dependency_overrides = dependency_overrides or {}
     entries_by_idx: Dict[int, Dict[str, Any]] = {}
@@ -687,11 +793,118 @@ def _build_stage_waves(
         if not ready:
             cycle_ids = ", ".join(ids_by_idx.get(idx, f"stage_{idx + 1}") for idx in remaining)
             return [], f"Workflow stage dependencies contain a cycle or unresolved chain: {cycle_ids}.", ids_by_idx, deps_by_idx
+        output_conflict = _parallel_wave_output_conflict(
+            ready,
+            entries_by_idx=entries_by_idx,
+            stage_ids=ids_by_idx,
+            env=env,
+            stages_file=stages_file,
+        )
+        if output_conflict:
+            return [], output_conflict, ids_by_idx, deps_by_idx
         waves.append(ready)
         for idx in ready:
             remaining.remove(idx)
             completed.add(ids_by_idx[idx])
     return waves, None, ids_by_idx, deps_by_idx
+
+
+def _normalized_output_parts(path: str) -> tuple[str, ...]:
+    """Return lexical POSIX path parts used for declared-output conflict checks."""
+
+    normalized = posixpath.normpath(str(path or "").replace("\\", "/").strip())
+    if not normalized or normalized == ".":
+        return (".",)
+    parts = tuple(part for part in normalized.split("/") if part)
+    return tuple(part.casefold() for part in parts)
+
+
+def _canonical_declared_output(
+    path: str,
+    *,
+    env: AgiEnv | None,
+    stages_file: Path | None,
+) -> str:
+    """Resolve declared outputs against the workflow root when context is available."""
+
+    if env is not None and stages_file is not None:
+        try:
+            resolved = _resolve_stage_output_path(path, env=env, stages_file=stages_file)
+        except (OSError, RuntimeError, TypeError, ValueError):
+            resolved = None
+        if resolved is not None:
+            return resolved.as_posix()
+    return posixpath.normpath(str(path or "").replace("\\", "/").strip())
+
+
+def _declared_outputs_overlap(
+    left: str,
+    right: str,
+    *,
+    env: AgiEnv | None = None,
+    stages_file: Path | None = None,
+) -> bool:
+    """Return whether two declared output paths are equal or nested."""
+
+    left_raw = str(left or "").replace("\\", "/").strip()
+    right_raw = str(right or "").replace("\\", "/").strip()
+    if not left_raw or not right_raw:
+        return False
+    left_text = _canonical_declared_output(left_raw, env=env, stages_file=stages_file)
+    right_text = _canonical_declared_output(right_raw, env=env, stages_file=stages_file)
+    if left_text.startswith("/") != right_text.startswith("/"):
+        return False
+    left_parts = _normalized_output_parts(left_text)
+    right_parts = _normalized_output_parts(right_text)
+    if left_parts == (".",) or right_parts == (".",):
+        return True
+    common = min(len(left_parts), len(right_parts))
+    return left_parts[:common] == right_parts[:common]
+
+
+def _parallel_wave_output_conflict(
+    wave: List[int],
+    *,
+    entries_by_idx: Mapping[int, Mapping[str, Any]],
+    stage_ids: Mapping[int, str],
+    env: AgiEnv | None,
+    stages_file: Path | None,
+) -> Optional[str]:
+    """Describe a conflicting explicit parallel-output pair in one wave."""
+
+    for position, left_idx in enumerate(wave):
+        left_outputs, left_error = _stage_parallel_output_contract(
+            entries_by_idx.get(left_idx, {}),
+            env=env,
+            stages_file=stages_file,
+        )
+        if left_error:
+            continue
+        for right_idx in wave[position + 1 :]:
+            right_outputs, right_error = _stage_parallel_output_contract(
+                entries_by_idx.get(right_idx, {}),
+                env=env,
+                stages_file=stages_file,
+            )
+            if right_error:
+                continue
+            for left_output in left_outputs:
+                for right_output in right_outputs:
+                    if _declared_outputs_overlap(
+                        left_output,
+                        right_output,
+                        env=env,
+                        stages_file=stages_file,
+                    ):
+                        left_id = stage_ids.get(left_idx, f"stage_{left_idx + 1}")
+                        right_id = stage_ids.get(right_idx, f"stage_{right_idx + 1}")
+                        return (
+                            "Parallel workflow stages declare overlapping output paths: "
+                            f"`{left_id}` writes `{left_output}` and `{right_id}` writes "
+                            f"`{right_output}`. Add a dependency to serialize these stages "
+                            "or use disjoint outputs."
+                        )
+    return None
 
 
 def _dot_escape(value: object) -> str:
@@ -793,6 +1006,51 @@ def _run_stage_subprocess(
     return output
 
 
+def _parallel_agi_wave_ineligibility_reason(
+    stages: List[Dict[str, Any]],
+    wave: List[int],
+    *,
+    profile: str,
+    env: AgiEnv,
+    stages_file: Path,
+    selected_map: Mapping[int, str],
+    engine_map: Mapping[int, str],
+    default_runtime: str,
+) -> Optional[str]:
+    if len(wave) < 2:
+        return "the wave contains fewer than two stages"
+    for idx in wave:
+        entry, _override = _apply_stage_profile(stages[idx], profile)
+        stage_id = _stage_id(entry, idx)
+        if _stage_disabled(entry):
+            return f"stage `{stage_id}` is disabled or skipped"
+        skip_current, _outputs = _should_skip_current_outputs(entry, env=env, stages_file=stages_file)
+        if skip_current:
+            return f"stage `{stage_id}` is already satisfied by its output-skip rule"
+        _parallel_outputs, contract_error = _stage_parallel_output_contract(
+            entry,
+            env=env,
+            stages_file=stages_file,
+        )
+        if contract_error:
+            return f"stage `{stage_id}` has no complete parallel output contract: {contract_error}"
+        code, _normalized = _normalize_legacy_agi_run_request_code(str(entry.get("C", "") or ""))
+        candidate = {**entry, "C": code}
+        if not _pipeline_stages.is_runnable_stage(candidate):
+            return f"stage `{stage_id}` is not runnable"
+        engine, runtime_root = _resolve_stage_engine_runtime(
+            candidate,
+            env=env,
+            idx=idx,
+            selected_map=selected_map,
+            engine_map=engine_map,
+            default_runtime=default_runtime,
+        )
+        if not engine.startswith("agi.") or not runtime_root:
+            return f"stage `{stage_id}` does not use an explicit AGI runtime"
+    return None
+
+
 def _parallel_agi_wave_eligible(
     stages: List[Dict[str, Any]],
     wave: List[int],
@@ -804,30 +1062,16 @@ def _parallel_agi_wave_eligible(
     engine_map: Mapping[int, str],
     default_runtime: str,
 ) -> bool:
-    if len(wave) < 2:
-        return False
-    for idx in wave:
-        entry, _override = _apply_stage_profile(stages[idx], profile)
-        if _stage_disabled(entry):
-            return False
-        skip_current, _outputs = _should_skip_current_outputs(entry, env=env, stages_file=stages_file)
-        if skip_current:
-            return False
-        code, _normalized = _normalize_legacy_agi_run_request_code(str(entry.get("C", "") or ""))
-        candidate = {**entry, "C": code}
-        if not _pipeline_stages.is_runnable_stage(candidate):
-            return False
-        engine, runtime_root = _resolve_stage_engine_runtime(
-            candidate,
-            env=env,
-            idx=idx,
-            selected_map=selected_map,
-            engine_map=engine_map,
-            default_runtime=default_runtime,
-        )
-        if not engine.startswith("agi.") or not runtime_root:
-            return False
-    return True
+    return _parallel_agi_wave_ineligibility_reason(
+        stages,
+        wave,
+        profile=profile,
+        env=env,
+        stages_file=stages_file,
+        selected_map=selected_map,
+        engine_map=engine_map,
+        default_runtime=default_runtime,
+    ) is None
 
 
 def _run_parallel_agi_wave(
@@ -1375,6 +1619,85 @@ def _read_pipeline_lock_payload(path: Path) -> Dict[str, Any]:
     return {}
 
 
+def _try_pipeline_file_lock(fd: int) -> bool:
+    """Acquire an exclusive non-blocking OS lock on ``fd``."""
+
+    if os.name == "nt":  # pragma: no cover - exercised on Windows CI
+        import msvcrt
+
+        try:
+            if os.fstat(fd).st_size == 0:
+                os.write(fd, b"\n")
+                os.fsync(fd)
+            os.lseek(fd, 0, os.SEEK_SET)
+            msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+            return True
+        except OSError:
+            return False
+    import fcntl
+
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        return True
+    except (BlockingIOError, OSError):
+        return False
+
+
+def _unlock_pipeline_file(fd: int) -> None:
+    """Release the OS lock held on ``fd``."""
+
+    if os.name == "nt":  # pragma: no cover - exercised on Windows CI
+        import msvcrt
+
+        os.lseek(fd, 0, os.SEEK_SET)
+        msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+        return
+    import fcntl
+
+    fcntl.flock(fd, fcntl.LOCK_UN)
+
+
+def _write_pipeline_lock_payload(fd: int, payload: Mapping[str, Any]) -> None:
+    """Rewrite lock metadata on the holder's stable, locked inode."""
+
+    encoded = (json.dumps(dict(payload), indent=2, sort_keys=True) + "\n").encode("utf-8")
+    os.lseek(fd, 0, os.SEEK_SET)
+    os.ftruncate(fd, 0)
+    offset = 0
+    while offset < len(encoded):
+        offset += os.write(fd, encoded[offset:])
+    os.fsync(fd)
+
+
+def _stop_pipeline_lock_heartbeat(lock_handle: Mapping[str, Any]) -> None:
+    stop = lock_handle.get("heartbeat_stop")
+    thread = lock_handle.get("heartbeat_thread")
+    if isinstance(stop, threading.Event):
+        stop.set()
+    if isinstance(thread, threading.Thread) and thread is not threading.current_thread():
+        thread.join(timeout=2.0)
+
+
+def _start_pipeline_lock_heartbeat(lock_handle: Dict[str, Any]) -> None:
+    """Keep lock metadata fresh for the complete workflow lifetime."""
+
+    stop = threading.Event()
+    interval = max(0.05, min(_pipeline_lock_ttl_seconds() / 3.0, 30.0))
+
+    def _heartbeat() -> None:
+        while not stop.wait(interval):
+            _refresh_pipeline_run_lock(lock_handle)
+
+    thread = threading.Thread(
+        target=_heartbeat,
+        name="agilab-pipeline-lock-heartbeat",
+        daemon=True,
+    )
+    lock_handle["heartbeat_stop"] = stop
+    lock_handle["heartbeat_thread"] = thread
+    thread.start()
+
+
 def _pipeline_lock_owner_text(payload: Dict[str, Any], age_sec: Optional[float]) -> str:
     """Format a concise lock owner description for logs and UI."""
     owner_host = str(payload.get("host", "?"))
@@ -1412,6 +1735,8 @@ def _inspect_pipeline_run_lock(env: AgiEnv) -> Optional[Dict[str, Any]]:
     if not lock_path.exists():
         return None
     payload = _read_pipeline_lock_payload(lock_path)
+    if not payload:
+        return None
     try:
         age_sec: Optional[float] = max(time.time() - lock_path.stat().st_mtime, 0.0)
     except OSError:
@@ -1441,26 +1766,43 @@ def _clear_pipeline_run_lock(
     *,
     reason: str,
 ) -> bool:
-    """Remove the current workflow lock, if any, and log why."""
-    lock_state = _inspect_pipeline_run_lock(env)
-    if not lock_state:
-        return True
-    lock_path = Path(lock_state["path"])
+    """Clear inactive metadata without unlinking the stable lock inode."""
+    lock_path = _pipeline_lock_path(env)
+    fd: Optional[int] = None
+    locked = False
     try:
-        lock_path.unlink()
+        fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+        if not _try_pipeline_file_lock(fd):
+            lock_state = _inspect_pipeline_run_lock(env)
+            owner_text = str((lock_state or {}).get("owner_text") or "unknown")
+            msg = (
+                "Refusing to clear a live workflow lock. "
+                f"Owner: {owner_text}. Wait for that run to finish or stop its verified process."
+            )
+            st.warning(msg)
+            _push_run_log(index_page, msg, placeholder)
+            return False
+        locked = True
+        _write_pipeline_lock_payload(fd, {})
         _push_run_log(
             index_page,
-            f"Removed workflow lock ({reason}): {lock_path}",
+            f"Cleared inactive workflow lock metadata ({reason}): {lock_path}",
             placeholder,
         )
         return True
-    except FileNotFoundError:
-        return True
     except OSError as exc:
-        msg = f"Unable to remove workflow lock `{lock_path}`: {exc}"
+        msg = f"Unable to clear workflow lock `{lock_path}`: {exc}"
         st.error(msg)
         _push_run_log(index_page, msg, placeholder)
         return False
+    finally:
+        if fd is not None:
+            if locked:
+                try:
+                    _unlock_pipeline_file(fd)
+                except OSError:
+                    logger.debug("Failed to unlock workflow lock %s", lock_path, exc_info=True)
+            os.close(fd)
 
 
 def _acquire_pipeline_run_lock(
@@ -1497,12 +1839,30 @@ def _acquire_pipeline_run_lock(
         return None
 
     for _ in range(2):
+        fd: Optional[int] = None
         try:
-            fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
-            with os.fdopen(fd, "w", encoding="utf-8") as stream:
-                json.dump(payload, stream, indent=2)
-            _push_run_log(index_page, f"Workflow lock acquired: {lock_path}", placeholder)
-            return {"path": lock_path, "token": token}
+            fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+            if not _try_pipeline_file_lock(fd):
+                os.close(fd)
+                fd = None
+                raise FileExistsError(lock_path)
+            _write_pipeline_lock_payload(fd, payload)
+            handle: Dict[str, Any] = {
+                "path": lock_path,
+                "token": token,
+                "fd": fd,
+                "payload": payload,
+                "io_lock": threading.Lock(),
+            }
+            try:
+                _start_pipeline_lock_heartbeat(handle)
+                _push_run_log(index_page, f"Workflow lock acquired: {lock_path}", placeholder)
+            except BaseException:
+                _stop_pipeline_lock_heartbeat(handle)
+                handle["fd"] = None
+                raise
+            fd = None
+            return handle
         except FileExistsError:
             lock_state = _inspect_pipeline_run_lock(env) or {
                 "path": lock_path,
@@ -1532,6 +1892,13 @@ def _acquire_pipeline_run_lock(
             st.error(msg)
             _push_run_log(index_page, msg, placeholder)
             return None
+        finally:
+            if fd is not None:
+                try:
+                    _unlock_pipeline_file(fd)
+                except OSError:
+                    pass
+                os.close(fd)
 
     msg = f"Unable to acquire workflow lock after stale cleanup retries: {lock_path}"
     st.warning(msg)
@@ -1545,21 +1912,19 @@ def _refresh_pipeline_run_lock(lock_handle: Optional[Dict[str, Any]]) -> None:
         return
     lock_path_raw = lock_handle.get("path")
     token = lock_handle.get("token")
-    if not lock_path_raw or not token:
+    fd = lock_handle.get("fd")
+    payload = lock_handle.get("payload")
+    if not lock_path_raw or not token or not isinstance(fd, int) or not isinstance(payload, dict):
         return
     lock_path = Path(lock_path_raw)
-    if not lock_path.exists():
-        return
-
-    payload = _read_pipeline_lock_payload(lock_path)
     if payload.get("token") != token:
         return
-    payload["heartbeat_at"] = time.time()
-    tmp_path = lock_path.with_suffix(lock_path.suffix + ".tmp")
+    io_lock = lock_handle.get("io_lock")
+    guard = io_lock if isinstance(io_lock, type(threading.Lock())) else threading.Lock()
     try:
-        with open(tmp_path, "w", encoding="utf-8") as stream:
-            json.dump(payload, stream, indent=2)
-        os.replace(tmp_path, lock_path)
+        with guard:
+            payload["heartbeat_at"] = time.time()
+            _write_pipeline_lock_payload(fd, payload)
     except (OSError, TypeError, ValueError):
         logger.debug("Failed to refresh workflow lock heartbeat for %s", lock_path, exc_info=True)
 
@@ -1574,21 +1939,35 @@ def _release_pipeline_run_lock(
         return
     lock_path_raw = lock_handle.get("path")
     token = lock_handle.get("token")
-    if not lock_path_raw or not token:
+    fd = lock_handle.get("fd")
+    if not lock_path_raw or not token or not isinstance(fd, int):
         return
     lock_path = Path(lock_path_raw)
+    _stop_pipeline_lock_heartbeat(lock_handle)
+    io_lock = lock_handle.get("io_lock")
+    guard = io_lock if isinstance(io_lock, type(threading.Lock())) else threading.Lock()
+    release_error: Optional[OSError] = None
     try:
-        if not lock_path.exists():
-            return
-        payload = _read_pipeline_lock_payload(lock_path)
-        if payload and payload.get("token") != token:
-            return
-        lock_path.unlink()
-        _push_run_log(index_page, f"Workflow lock released: {lock_path}", placeholder)
-    except FileNotFoundError:
-        return
+        with guard:
+            payload = lock_handle.get("payload")
+            if isinstance(payload, dict) and payload.get("token") == token:
+                _write_pipeline_lock_payload(fd, {})
     except OSError as exc:
-        logger.debug("Failed to release workflow lock %s: %s", lock_path, exc)
+        release_error = exc
+    finally:
+        try:
+            _unlock_pipeline_file(fd)
+        except OSError as exc:
+            release_error = release_error or exc
+        try:
+            os.close(fd)
+        except OSError as exc:
+            release_error = release_error or exc
+        lock_handle["fd"] = None
+    if release_error is None:
+        _push_run_log(index_page, f"Workflow lock released: {lock_path}", placeholder)
+    else:
+        logger.debug("Failed to release workflow lock %s: %s", lock_path, release_error)
 
 
 def _format_legacy_stage_refs(stale_stages: List[Dict[str, Any]]) -> str:
@@ -1703,6 +2082,8 @@ def run_all_stages(
         sequence,
         pipeline_profile,
         dependency_overrides=pipeline_stage_deps,
+        env=env,
+        stages_file=stages_file,
     )
     if dependency_error:
         st.error(dependency_error)
@@ -1789,9 +2170,9 @@ def run_all_stages(
                         target_base = target_base.parent
                     target_base.mkdir(parents=True, exist_ok=True)
                     default_runtime = st.session_state.get("lab_selected_venv", "")
-                    if (
-                        pipeline_max_workers > 1
-                        and _parallel_agi_wave_eligible(
+                    parallel_ineligibility = None
+                    if pipeline_max_workers > 1 and len(wave) > 1:
+                        parallel_ineligibility = _parallel_agi_wave_ineligibility_reason(
                             stages,
                             wave,
                             profile=pipeline_profile,
@@ -1801,6 +2182,10 @@ def run_all_stages(
                             engine_map=engine_map,
                             default_runtime=default_runtime,
                         )
+                    if (
+                        pipeline_max_workers > 1
+                        and len(wave) > 1
+                        and parallel_ineligibility is None
                     ):
                         _push_run_log(
                             index_page_str,
@@ -1824,6 +2209,12 @@ def run_all_stages(
                             log_placeholder=log_placeholder,
                         )
                         continue
+                    if parallel_ineligibility:
+                        _push_run_log(
+                            index_page_str,
+                            f"Wave {wave_number}: serialized because {parallel_ineligibility}.",
+                            log_placeholder,
+                        )
                     for idx in wave:
                         _refresh_pipeline_run_lock(lock_handle)
                         base_entry = stages[idx]

--- a/src/agilab/pipeline/pipeline_runtime_execution_support.py
+++ b/src/agilab/pipeline/pipeline_runtime_execution_support.py
@@ -5,11 +5,11 @@ import os
 import shlex
 import subprocess
 import sys
-import tomllib
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Pattern, Sequence, Type
 
 from agi_env import AgiEnv
+from agi_env.app_settings_support import read_app_settings
 from agi_env.snippet_contract import (
     is_supported_snippet_api,
     is_generated_agi_snippet,
@@ -55,11 +55,10 @@ def safe_service_start_template(env: AgiEnv, marker: str) -> str:
     try:
         app_settings_path = Path(env.app_settings_file)
         if app_settings_path.exists():
-            with app_settings_path.open("rb") as stream:
-                loaded = tomllib.load(stream)
+            loaded = read_app_settings(app_settings_path)
             if isinstance(loaded, dict):
                 settings = loaded
-    except (AttributeError, OSError, RuntimeError, TypeError, ValueError, tomllib.TOMLDecodeError):
+    except (AttributeError, OSError, RuntimeError, TypeError, ValueError):
         settings = {}
 
     cluster = settings.get("cluster", {}) if isinstance(settings.get("cluster"), dict) else {}

--- a/src/agilab/security/security_check.py
+++ b/src/agilab/security/security_check.py
@@ -13,6 +13,8 @@ import re
 import tomllib
 from typing import Any, Mapping, Sequence
 
+from agilab.environment.env_file_utils import read_mutable_env_text
+
 try:
     from .untrusted_content_boundary import build_external_source_boundary
 except ImportError:  # pragma: no cover - supports direct script execution.
@@ -95,7 +97,7 @@ def _parse_env_file(path: Path) -> dict[str, str]:
     if not path.is_file():
         return {}
     result: dict[str, str] = {}
-    for raw_line in path.read_text(encoding="utf-8", errors="ignore").splitlines():
+    for raw_line in read_mutable_env_text(path, errors="ignore").splitlines():
         line = raw_line.strip()
         if not line or line.startswith("#") or "=" not in line:
             continue

--- a/src/agilab/ui/page_project_selector.py
+++ b/src/agilab/ui/page_project_selector.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import sys
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, Callable, Iterable
 
 from agilab.ui.ui_performance import path_stat_signature, ui_discovery_cache_enabled
 
 NAVIGATION_PAGE_ROUTES_ATTR = "_NAVIGATION_PAGE_ROUTES"
+NAVIGATION_PAGE_ROUTES_SESSION_KEY = "_agilab_navigation_page_routes"
 PROJECT_EDITOR_ROUTE_ID = "project_editor"
 PROJECT_EDITOR_PAGE_PATH = Path("pages/1_PROJECT.py")
 PROJECT_ROUTE_ID = PROJECT_EDITOR_ROUTE_ID
@@ -102,12 +104,20 @@ def _refresh_project_names(streamlit: Any, projects: Iterable[Any]) -> list[str]
         return _unique_project_names(projects)
 
 
-def _registered_navigation_page(route_id: str) -> Any | None:
+def _registered_navigation_page(route_id: str, streamlit: Any | None = None) -> Any | None:
     """Return a registered ``st.Page`` object from the active main navigation run."""
+    session_state = getattr(streamlit, "session_state", None)
+    if session_state is not None:
+        try:
+            session_routes = session_state.get(NAVIGATION_PAGE_ROUTES_SESSION_KEY)
+        except (AttributeError, RuntimeError, TypeError):
+            session_routes = None
+        if isinstance(session_routes, Mapping) and session_routes.get(route_id) is not None:
+            return session_routes[route_id]
     for module_name in MAIN_NAVIGATION_MODULES:
         module = sys.modules.get(module_name)
         routes = getattr(module, NAVIGATION_PAGE_ROUTES_ATTR, None)
-        if isinstance(routes, dict) and routes.get(route_id) is not None:
+        if isinstance(routes, Mapping) and routes.get(route_id) is not None:
             return routes[route_id]
     return None
 
@@ -115,7 +125,7 @@ def _registered_navigation_page(route_id: str) -> Any | None:
 def switch_to_project_page(streamlit: Any, *, active_app: str | None = None) -> bool:
     """Switch to PROJECT_EDITOR using the registered ``st.navigation`` page only."""
     switch_page = getattr(streamlit, "switch_page", None)
-    project_page = _registered_navigation_page(PROJECT_ROUTE_ID)
+    project_page = _registered_navigation_page(PROJECT_ROUTE_ID, streamlit)
     if not callable(switch_page) or project_page is None:
         return False
     if active_app is not None:

--- a/src/agilab/workflow/workflow_run_manifest.py
+++ b/src/agilab/workflow/workflow_run_manifest.py
@@ -2,13 +2,19 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from contextlib import contextmanager
 import hashlib
 import json
+import os
 import platform
 from pathlib import Path
 import re
+import shutil
 import sys
-from typing import Any, Mapping, Sequence
+import tempfile
+import time
+from typing import Any, Callable, Mapping, Sequence, TypeVar
+from uuid import uuid4
 
 from agilab.evidence.evidence_graph import (
     EVIDENCE_GRAPH_KIND,
@@ -21,8 +27,8 @@ from agilab.workflow.workflow_runtime_contract import (
 )
 
 
-WORKFLOW_RUN_MANIFEST_SCHEMA_VERSION = 3
-SUPPORTED_WORKFLOW_RUN_MANIFEST_SCHEMAS = {2, WORKFLOW_RUN_MANIFEST_SCHEMA_VERSION}
+WORKFLOW_RUN_MANIFEST_SCHEMA_VERSION = 4
+SUPPORTED_WORKFLOW_RUN_MANIFEST_SCHEMAS = {2, 3, WORKFLOW_RUN_MANIFEST_SCHEMA_VERSION}
 WORKFLOW_RUN_MANIFEST_KIND = "agilab.workflow_run_manifest"
 EVIDENCE_LEDGER_SCHEMA_VERSION = 1
 EVIDENCE_LEDGER_KIND = "agilab.evidence_ledger"
@@ -30,8 +36,36 @@ WORKFLOW_EVIDENCE_DIRNAME = "workflow_evidence"
 WORKFLOW_RUN_MANIFEST_FILENAME = "workflow_run_manifest.json"
 EVIDENCE_LEDGER_FILENAME = "evidence_ledger.json"
 EVIDENCE_GRAPH_FILENAME = "evidence_graph.json"
+RUNNER_STATE_SNAPSHOT_FILENAME = "runner_state_snapshot.json"
 LATEST_WORKFLOW_EVIDENCE_FILENAME = "latest_workflow_evidence.json"
+WORKFLOW_EVIDENCE_COMPLETION_FILENAME = ".complete.json"
+WORKFLOW_EVIDENCE_PUBLICATION_LOCK_FILENAME = ".publish.lock"
 SUPPORTED_STATUSES = {"pass", "fail", "unknown"}
+_PUBLICATION_LOCK_TIMEOUT_SECONDS = 5.0
+_PUBLICATION_LOCK_RETRY_INTERVAL_SECONDS = 0.05
+_WINDOWS_SHARING_RETRY_TIMEOUT_SECONDS = 0.5
+_WINDOWS_SHARING_RETRY_INTERVAL_SECONDS = 0.01
+_T = TypeVar("_T")
+
+
+def _is_windows() -> bool:
+    return os.name == "nt"
+
+
+def _run_with_windows_sharing_retry(operation: Callable[[], _T]) -> _T:
+    """Retry only transient Windows sharing denials for mutable evidence files."""
+
+    deadline = time.monotonic() + _WINDOWS_SHARING_RETRY_TIMEOUT_SECONDS
+    while True:
+        try:
+            return operation()
+        except PermissionError:
+            if not _is_windows():
+                raise
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise
+            time.sleep(min(_WINDOWS_SHARING_RETRY_INTERVAL_SECONDS, remaining))
 
 
 @dataclass(frozen=True)
@@ -39,6 +73,7 @@ class WorkflowEvidenceBundle:
     manifest_path: Path
     ledger_path: Path
     graph_path: Path
+    state_snapshot_path: Path
     latest_path: Path
     manifest: dict[str, Any]
     ledger: dict[str, Any]
@@ -95,12 +130,31 @@ def build_workflow_run_manifest(
     created_at: str | None = None,
 ) -> dict[str, Any]:
     """Build a stable workflow/DAG run manifest from persisted runner state."""
+    persisted_state = _read_matching_runner_state(state=state, state_path=state_path)
+    return _build_workflow_run_manifest(
+        state=persisted_state,
+        state_path=state_path,
+        repo_root=repo_root,
+        lab_dir=lab_dir,
+        dag_path=dag_path,
+        trigger=trigger,
+        created_at=created_at,
+    )
+
+
+def _build_workflow_run_manifest(
+    *,
+    state: Mapping[str, Any],
+    state_path: Path,
+    repo_root: Path,
+    lab_dir: Path,
+    dag_path: Path | None = None,
+    trigger: Mapping[str, Any] | None = None,
+    created_at: str | None = None,
+) -> dict[str, Any]:
     state_snapshot = _json_safe(dict(state))
     state_sha256 = workflow_state_digest(state)
     run_id = _safe_id(str(state.get("run_id", "") or "workflow-run"))
-    manifest_id = f"{run_id}-v{WORKFLOW_RUN_MANIFEST_SCHEMA_VERSION}-{state_sha256[:12]}"
-    manifest_path, ledger_path, _latest_path = workflow_evidence_paths(lab_dir, manifest_id)
-    graph_path = workflow_evidence_graph_path(lab_dir, manifest_id)
     units = _unit_rows(state)
     produced_artifacts, consumed_artifacts = _artifact_contracts(units)
     status = _manifest_status(state, units)
@@ -110,6 +164,35 @@ def build_workflow_run_manifest(
     summary = state.get("summary", {})
     summary = summary if isinstance(summary, Mapping) else {}
     timestamp = created_at or _state_timestamp(state)
+    workflow_source_path = _workflow_source_path(source, dag_path, repo_root)
+    runtime = {
+        "python_version": platform.python_version(),
+        "python_executable": sys.executable,
+        "platform": platform.platform(),
+        "repo_root": str(repo_root.expanduser().resolve(strict=False)),
+        "lab_dir": str(lab_dir.expanduser().resolve(strict=False)),
+    }
+    trigger_payload = _json_safe(dict(trigger or {}))
+    identity_sha256 = sha256_payload(
+        {
+            "schema_version": WORKFLOW_RUN_MANIFEST_SCHEMA_VERSION,
+            "state": state_snapshot,
+            "state_path": str(state_path.expanduser()),
+            "created_at": timestamp,
+            "workflow_source_path": workflow_source_path,
+            "runtime": runtime,
+            "trigger": trigger_payload,
+        }
+    )
+    manifest_id = (
+        f"{run_id}-v{WORKFLOW_RUN_MANIFEST_SCHEMA_VERSION}-"
+        f"{state_sha256[:12]}-{identity_sha256[:12]}"
+    )
+    manifest_path, ledger_path, _latest_path = workflow_evidence_paths(lab_dir, manifest_id)
+    graph_path = workflow_evidence_graph_path(lab_dir, manifest_id)
+    state_snapshot_path = manifest_path.parent / RUNNER_STATE_SNAPSHOT_FILENAME
+    state_snapshot_bytes = _json_document_text(state_snapshot).encode("utf-8")
+    state_snapshot_file_sha256 = hashlib.sha256(state_snapshot_bytes).hexdigest()
 
     validations = _manifest_validations(
         state=state,
@@ -121,12 +204,13 @@ def build_workflow_run_manifest(
         "schema_version": WORKFLOW_RUN_MANIFEST_SCHEMA_VERSION,
         "kind": WORKFLOW_RUN_MANIFEST_KIND,
         "manifest_id": manifest_id,
+        "identity_sha256": identity_sha256,
         "run_id": str(state.get("run_id", "") or ""),
         "status": status,
         "created_at": timestamp,
         "workflow": {
             "source_type": str(source.get("source_type", "") or "multi_app_dag"),
-            "dag_path": _workflow_source_path(source, dag_path, repo_root),
+            "dag_path": workflow_source_path,
             "stages_file": str(source.get("stages_file", "") or ""),
             "plan_schema": str(source.get("plan_schema", "") or ""),
             "plan_runner_status": str(source.get("plan_runner_status", "") or ""),
@@ -135,18 +219,14 @@ def build_workflow_run_manifest(
             else [str(unit.get("id", "")) for unit in units if str(unit.get("id", ""))],
             "unit_count": len(units),
         },
-        "runtime": {
-            "python_version": platform.python_version(),
-            "python_executable": sys.executable,
-            "platform": platform.platform(),
-            "repo_root": str(repo_root.expanduser().resolve(strict=False)),
-            "lab_dir": str(lab_dir.expanduser().resolve(strict=False)),
-        },
-        "trigger": _json_safe(dict(trigger or {})),
+        "runtime": runtime,
+        "trigger": trigger_payload,
         "runner_state": {
             "path": str(state_path.expanduser()),
-            "exists": state_path.expanduser().is_file(),
-            "sha256": _sha256_file_or_empty(state_path),
+            "source_path": str(state_path.expanduser()),
+            "snapshot_path": str(state_snapshot_path),
+            "exists": True,
+            "sha256": state_snapshot_file_sha256,
             "snapshot_sha256": state_sha256,
             "schema": str(state.get("schema", "") or ""),
             "run_status": str(state.get("run_status", "") or ""),
@@ -159,7 +239,17 @@ def build_workflow_run_manifest(
             "consumed": consumed_artifacts,
         },
         "stages": [_stage_record(unit) for unit in units],
-        "artifacts": [_file_record(state_path, name="runner_state", kind="runner_state")],
+        "artifacts": [
+            {
+                "name": RUNNER_STATE_SNAPSHOT_FILENAME,
+                "path": str(state_snapshot_path),
+                "source_path": str(state_path.expanduser()),
+                "kind": "runner_state_snapshot",
+                "exists": True,
+                "size_bytes": len(state_snapshot_bytes),
+                "sha256": state_snapshot_file_sha256,
+            }
+        ],
         "validations": validations,
         "runtime_contract": runtime_contract,
         "evidence_ledger": {
@@ -171,6 +261,7 @@ def build_workflow_run_manifest(
             "kind": EVIDENCE_GRAPH_KIND,
         },
         "state_snapshot": {
+            "path": str(state_snapshot_path),
             "sha256": state_sha256,
             "event_count": len(state_snapshot.get("events", []))
             if isinstance(state_snapshot.get("events"), list)
@@ -245,8 +336,9 @@ def write_workflow_run_evidence(
     trigger: Mapping[str, Any] | None = None,
     created_at: str | None = None,
 ) -> WorkflowEvidenceBundle:
-    manifest = build_workflow_run_manifest(
-        state=state,
+    persisted_state = _read_matching_runner_state(state=state, state_path=state_path)
+    manifest = _build_workflow_run_manifest(
+        state=persisted_state,
         state_path=state_path,
         repo_root=repo_root,
         lab_dir=lab_dir,
@@ -259,6 +351,7 @@ def write_workflow_run_evidence(
         str(manifest["manifest_id"]),
     )
     graph_path = workflow_evidence_graph_path(lab_dir, str(manifest["manifest_id"]))
+    state_snapshot_path = manifest_path.parent / RUNNER_STATE_SNAPSHOT_FILENAME
     graph = build_evidence_graph_from_workflow_manifest(manifest)
     graph_issues = validate_evidence_graph(graph)
     if graph_issues:
@@ -273,29 +366,92 @@ def write_workflow_run_evidence(
                 "kind": EVIDENCE_GRAPH_KIND,
                 "path": str(graph_path),
                 "sha256": sha256_payload(graph),
+            },
+            {
+                "name": RUNNER_STATE_SNAPSHOT_FILENAME,
+                "kind": "runner_state_snapshot",
+                "path": str(state_snapshot_path),
+                "sha256": _json_document_sha256(persisted_state),
             }
         ],
     )
-    _write_immutable_json(manifest_path, manifest)
-    _write_immutable_json(graph_path, graph)
-    _write_immutable_json(ledger_path, ledger)
-    _write_json(
-        latest_path,
-        {
-            "schema_version": 1,
-            "kind": "agilab.latest_workflow_evidence",
-            "manifest_id": manifest["manifest_id"],
-            "status": manifest["status"],
-            "manifest_path": str(manifest_path),
-            "ledger_path": str(ledger_path),
-            "graph_path": str(graph_path),
+    root = workflow_evidence_root(lab_dir)
+    root.mkdir(parents=True, exist_ok=True)
+    latest_payload = {
+        "schema_version": 1,
+        "kind": "agilab.latest_workflow_evidence",
+        "manifest_id": manifest["manifest_id"],
+        "status": manifest["status"],
+        "manifest_path": str(manifest_path),
+        "ledger_path": str(ledger_path),
+        "graph_path": str(graph_path),
+        "updated_at": manifest["created_at"],
+        "revision": {
+            "run_created_at": str(
+                persisted_state.get("created_at", "") or manifest["created_at"]
+            ),
             "updated_at": manifest["created_at"],
+            "event_count": manifest["state_snapshot"]["event_count"],
+            "tie_breaker": manifest["manifest_id"],
         },
-    )
+    }
+    final_dir = manifest_path.parent
+    stage_dir = root / f".{final_dir.name}.{uuid4().hex}.staging"
+    with _exclusive_publication_lock(root / WORKFLOW_EVIDENCE_PUBLICATION_LOCK_FILENAME):
+        _cleanup_stale_staging_dirs(root)
+        if final_dir.exists():
+            _verify_existing_bundle(
+                manifest_path=manifest_path,
+                manifest=manifest,
+                graph_path=graph_path,
+                graph=graph,
+                ledger_path=ledger_path,
+                ledger=ledger,
+                state_snapshot_path=state_snapshot_path,
+                state_snapshot=persisted_state,
+            )
+        else:
+            stage_dir.mkdir(mode=0o700)
+            try:
+                _write_json_fsync(stage_dir / RUNNER_STATE_SNAPSHOT_FILENAME, persisted_state)
+                _write_json_fsync(stage_dir / WORKFLOW_RUN_MANIFEST_FILENAME, manifest)
+                _write_json_fsync(stage_dir / EVIDENCE_GRAPH_FILENAME, graph)
+                _write_json_fsync(stage_dir / EVIDENCE_LEDGER_FILENAME, ledger)
+                _write_json_fsync(
+                    stage_dir / WORKFLOW_EVIDENCE_COMPLETION_FILENAME,
+                    {
+                        "schema_version": 1,
+                        "kind": "agilab.workflow_evidence.complete",
+                        "manifest_id": manifest["manifest_id"],
+                        "files": {
+                            WORKFLOW_RUN_MANIFEST_FILENAME: _sha256_file_or_empty(
+                                stage_dir / WORKFLOW_RUN_MANIFEST_FILENAME
+                            ),
+                            EVIDENCE_GRAPH_FILENAME: _sha256_file_or_empty(
+                                stage_dir / EVIDENCE_GRAPH_FILENAME
+                            ),
+                            EVIDENCE_LEDGER_FILENAME: _sha256_file_or_empty(
+                                stage_dir / EVIDENCE_LEDGER_FILENAME
+                            ),
+                            RUNNER_STATE_SNAPSHOT_FILENAME: _sha256_file_or_empty(
+                                stage_dir / RUNNER_STATE_SNAPSHOT_FILENAME
+                            ),
+                        },
+                    },
+                )
+                _validate_completion_marker(stage_dir, str(manifest["manifest_id"]))
+                _fsync_directory(stage_dir)
+                os.rename(stage_dir, final_dir)
+                _fsync_directory(root)
+            finally:
+                if stage_dir.exists():
+                    shutil.rmtree(stage_dir, ignore_errors=True)
+        _write_latest_if_newer(latest_path, latest_payload)
     return WorkflowEvidenceBundle(
         manifest_path=manifest_path,
         ledger_path=ledger_path,
         graph_path=graph_path,
+        state_snapshot_path=state_snapshot_path,
         latest_path=latest_path,
         manifest=manifest,
         ledger=ledger,
@@ -304,10 +460,13 @@ def write_workflow_run_evidence(
 
 
 def load_workflow_run_manifest(path: Path) -> dict[str, Any]:
-    payload = json.loads(path.expanduser().read_text(encoding="utf-8"))
+    expanded_path = path.expanduser()
+    manifest_bytes = expanded_path.read_bytes()
+    payload = json.loads(manifest_bytes)
     if not isinstance(payload, dict):
         raise ValueError(f"workflow run manifest must be a JSON object: {path}")
-    if int(payload.get("schema_version", 0)) not in SUPPORTED_WORKFLOW_RUN_MANIFEST_SCHEMAS:
+    schema_version = int(payload.get("schema_version", 0))
+    if schema_version not in SUPPORTED_WORKFLOW_RUN_MANIFEST_SCHEMAS:
         raise ValueError(f"Unsupported workflow run manifest schema: {payload.get('schema_version')!r}")
     if str(payload.get("kind", "")) != WORKFLOW_RUN_MANIFEST_KIND:
         raise ValueError(f"Unsupported workflow run manifest kind: {payload.get('kind')!r}")
@@ -324,6 +483,23 @@ def load_workflow_run_manifest(path: Path) -> dict[str, Any]:
     evidence_graph = payload.get("evidence_graph")
     if evidence_graph is not None and not isinstance(evidence_graph, Mapping):
         raise ValueError("workflow run manifest evidence_graph must be a JSON object")
+    completion_path = expanded_path.parent / WORKFLOW_EVIDENCE_COMPLETION_FILENAME
+    requires_completion = (
+        schema_version >= 4
+        or completion_path.exists()
+        or bool(payload.get("identity_sha256"))
+        or (expanded_path.parent / RUNNER_STATE_SNAPSHOT_FILENAME).exists()
+    )
+    if requires_completion:
+        manifest_id = str(payload.get("manifest_id", "") or "")
+        if not manifest_id:
+            raise ValueError("workflow run manifest manifest_id is required for completed evidence")
+        _validate_completion_marker(
+            expanded_path.parent,
+            manifest_id,
+            captured_files={WORKFLOW_RUN_MANIFEST_FILENAME: manifest_bytes},
+            manifest_payload=payload,
+        )
     return payload
 
 
@@ -370,24 +546,377 @@ def _json_safe(value: Any) -> Any:
     return str(value)
 
 
+def _read_matching_runner_state(
+    *,
+    state: Mapping[str, Any],
+    state_path: Path,
+) -> dict[str, Any]:
+    """Read persisted runner state once and reject stale caller snapshots."""
+
+    expanded = state_path.expanduser()
+    try:
+        raw_payload = _run_with_windows_sharing_retry(expanded.read_bytes)
+    except OSError as exc:
+        raise ValueError(f"Runner state could not be read for evidence: {expanded}") from exc
+    try:
+        persisted = json.loads(raw_payload)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"Runner state is not valid JSON: {expanded}") from exc
+    if not isinstance(persisted, Mapping):
+        raise ValueError(f"Runner state must be a JSON object: {expanded}")
+
+    persisted_snapshot = _json_safe(dict(persisted))
+    caller_snapshot = _json_safe(dict(state))
+    if canonical_json_bytes(persisted_snapshot) != canonical_json_bytes(caller_snapshot):
+        raise ValueError(
+            f"Runner state changed before evidence publication: {expanded}; "
+            "reload the persisted state and retry"
+        )
+    return dict(persisted_snapshot)
+
+
+def _json_document_text(payload: Mapping[str, Any]) -> str:
+    return json.dumps(_json_safe(payload), indent=2, sort_keys=True) + "\n"
+
+
+def _json_document_sha256(payload: Mapping[str, Any]) -> str:
+    return hashlib.sha256(_json_document_text(payload).encode("utf-8")).hexdigest()
+
+
 def _write_json(path: Path, payload: Mapping[str, Any]) -> Path:
     path = path.expanduser()
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(_json_safe(payload), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    text = _json_document_text(payload)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            stream.write(text)
+            stream.flush()
+            os.fsync(stream.fileno())
+        _run_with_windows_sharing_retry(lambda: os.replace(tmp_path, path))
+        _fsync_directory(path.parent)
+    finally:
+        try:
+            tmp_path.unlink()
+        except FileNotFoundError:
+            pass
     return path
 
 
 def _write_immutable_json(path: Path, payload: Mapping[str, Any]) -> Path:
     path = path.expanduser()
-    text = json.dumps(_json_safe(payload), indent=2, sort_keys=True) + "\n"
+    text = _json_document_text(payload)
+    path.parent.mkdir(parents=True, exist_ok=True)
     if path.exists():
         existing = path.read_text(encoding="utf-8")
         if existing != text:
             raise FileExistsError(f"Refusing to overwrite immutable workflow evidence: {path}")
         return path
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(text, encoding="utf-8")
+
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        dir=path.parent,
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            stream.write(text)
+            stream.flush()
+            os.fsync(stream.fileno())
+        # Actual callers hold the stable publication lock. ``os.replace`` keeps
+        # backfill portable to Windows, FAT/exFAT, and shared filesystems which
+        # do not support hard links, while never exposing a partial marker.
+        if path.exists():
+            existing = path.read_text(encoding="utf-8")
+            if existing != text:
+                raise FileExistsError(f"Refusing to overwrite immutable workflow evidence: {path}")
+        else:
+            os.replace(tmp_path, path)
+        _fsync_directory(path.parent)
+    finally:
+        try:
+            tmp_path.unlink()
+        except FileNotFoundError:
+            pass
     return path
+
+
+def _write_json_fsync(path: Path, payload: Mapping[str, Any]) -> None:
+    text = _json_document_text(payload)
+    with path.open("x", encoding="utf-8") as stream:
+        stream.write(text)
+        stream.flush()
+        os.fsync(stream.fileno())
+
+
+def _write_latest_if_newer(path: Path, payload: Mapping[str, Any]) -> bool:
+    """Advance the mutable latest pointer without allowing an older run to win."""
+
+    try:
+        _run_with_windows_sharing_retry(path.stat)
+    except FileNotFoundError:
+        current_exists = False
+    else:
+        current_exists = True
+    if current_exists:
+        try:
+            current = json.loads(
+                _run_with_windows_sharing_retry(
+                    lambda: path.read_text(encoding="utf-8")
+                )
+            )
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ValueError(f"Invalid latest workflow evidence pointer: {path}") from exc
+        if not isinstance(current, Mapping):
+            raise ValueError(f"Invalid latest workflow evidence pointer: {path}")
+        if str(current.get("kind", "")) != "agilab.latest_workflow_evidence":
+            raise ValueError(f"Invalid latest workflow evidence pointer kind: {path}")
+        if _latest_revision(payload) <= _latest_revision(current):
+            return False
+    _write_json(path, payload)
+    return True
+
+
+def _latest_revision(
+    payload: Mapping[str, Any],
+) -> tuple[tuple[int, str], int, tuple[int, str], str]:
+    revision = payload.get("revision", {})
+    revision = revision if isinstance(revision, Mapping) else {}
+    updated_at = str(
+        revision.get("updated_at", "")
+        or revision.get("created_at", "")
+        or payload.get("updated_at", "")
+        or ""
+    )
+    run_created_at = str(
+        revision.get("run_created_at", "")
+        or revision.get("created_at", "")
+        or payload.get("updated_at", "")
+        or ""
+    )
+    try:
+        event_count = int(revision.get("event_count", 0) or 0)
+    except (TypeError, ValueError):
+        event_count = 0
+    tie_breaker = str(
+        revision.get("tie_breaker", "") or payload.get("manifest_id", "") or ""
+    )
+    return (
+        _comparable_timestamp(run_created_at),
+        event_count,
+        _comparable_timestamp(updated_at),
+        tie_breaker,
+    )
+
+
+def _comparable_timestamp(value: str) -> tuple[int, str]:
+    text = value.strip()
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return 0, text
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    normalized = parsed.astimezone(timezone.utc).isoformat(timespec="microseconds")
+    return 1, normalized
+
+
+def _cleanup_stale_staging_dirs(root: Path) -> None:
+    for candidate in sorted(root.glob(".*.staging"), key=lambda path: path.name):
+        if candidate.is_dir() and not candidate.is_symlink():
+            shutil.rmtree(candidate, ignore_errors=True)
+
+
+def _fsync_directory(path: Path) -> None:
+    try:
+        fd = os.open(path, os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(fd)
+    except OSError:
+        pass
+    finally:
+        os.close(fd)
+
+
+def _verify_existing_bundle(
+    *,
+    manifest_path: Path,
+    manifest: Mapping[str, Any],
+    graph_path: Path,
+    graph: Mapping[str, Any],
+    ledger_path: Path,
+    ledger: Mapping[str, Any],
+    state_snapshot_path: Path,
+    state_snapshot: Mapping[str, Any],
+) -> None:
+    expected = (
+        (state_snapshot_path, state_snapshot),
+        (manifest_path, manifest),
+        (graph_path, graph),
+        (ledger_path, ledger),
+    )
+    for path, payload in expected:
+        text = _json_document_text(payload)
+        try:
+            existing = path.read_text(encoding="utf-8")
+        except FileNotFoundError as exc:
+            raise FileExistsError(f"Incomplete immutable workflow evidence bundle: {path.parent}") from exc
+        if existing != text:
+            raise FileExistsError(f"Refusing to overwrite immutable workflow evidence: {path}")
+    completion_path = manifest_path.parent / WORKFLOW_EVIDENCE_COMPLETION_FILENAME
+    manifest_id = str(manifest.get("manifest_id", ""))
+    if completion_path.exists():
+        try:
+            _validate_completion_marker(manifest_path.parent, manifest_id)
+        except ValueError:
+            # The immutable payloads were byte-verified above, so an
+            # invalid marker can only describe an incomplete/failed publish.
+            completion_path.unlink()
+            _fsync_directory(completion_path.parent)
+    if not completion_path.exists():
+        _backfill_completion_marker(manifest_path.parent, manifest_id)
+    _validate_completion_marker(manifest_path.parent, manifest_id)
+
+
+def _backfill_completion_marker(bundle_dir: Path, manifest_id: str) -> Path:
+    completion_path = bundle_dir / WORKFLOW_EVIDENCE_COMPLETION_FILENAME
+    payload = {
+        "schema_version": 1,
+        "kind": "agilab.workflow_evidence.complete",
+        "manifest_id": manifest_id,
+        "files": {
+            filename: _sha256_file_or_empty(bundle_dir / filename)
+            for filename in _completion_filenames(bundle_dir)
+        },
+    }
+    return _write_immutable_json(completion_path, payload)
+
+
+def _completion_filenames(
+    bundle_dir: Path,
+    *,
+    manifest_payload: Mapping[str, Any] | None = None,
+) -> tuple[str, ...]:
+    filenames = [
+        WORKFLOW_RUN_MANIFEST_FILENAME,
+        EVIDENCE_GRAPH_FILENAME,
+        EVIDENCE_LEDGER_FILENAME,
+    ]
+    manifest_path = bundle_dir / WORKFLOW_RUN_MANIFEST_FILENAME
+    if manifest_payload is None:
+        try:
+            loaded_manifest = json.loads(manifest_path.read_bytes())
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ValueError(f"Invalid workflow evidence manifest: {manifest_path}") from exc
+        manifest_payload = loaded_manifest if isinstance(loaded_manifest, Mapping) else {}
+    state_snapshot = (
+        manifest_payload.get("state_snapshot", {})
+        if isinstance(manifest_payload, Mapping)
+        else {}
+    )
+    if isinstance(manifest_payload, Mapping) and (
+        int(manifest_payload.get("schema_version", 0) or 0) >= 4
+        or isinstance(state_snapshot, Mapping) and bool(state_snapshot.get("path"))
+    ):
+        filenames.append(RUNNER_STATE_SNAPSHOT_FILENAME)
+    return tuple(filenames)
+
+
+def _validate_completion_marker(
+    bundle_dir: Path,
+    manifest_id: str,
+    *,
+    captured_files: Mapping[str, bytes] | None = None,
+    manifest_payload: Mapping[str, Any] | None = None,
+) -> None:
+    completion_path = bundle_dir / WORKFLOW_EVIDENCE_COMPLETION_FILENAME
+    try:
+        payload = json.loads(completion_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise ValueError(f"Invalid workflow evidence completion marker: {completion_path}") from exc
+    if not isinstance(payload, Mapping):
+        raise ValueError(f"Invalid workflow evidence completion marker: {completion_path}")
+    if int(payload.get("schema_version", 0) or 0) != 1:
+        raise ValueError(f"Invalid workflow evidence completion marker schema: {completion_path}")
+    if str(payload.get("kind", "")) != "agilab.workflow_evidence.complete":
+        raise ValueError(f"Invalid workflow evidence completion marker kind: {completion_path}")
+    if str(payload.get("manifest_id", "")) != manifest_id:
+        raise ValueError(f"Workflow evidence completion marker manifest mismatch: {completion_path}")
+    files = payload.get("files")
+    if not isinstance(files, Mapping):
+        raise ValueError(f"Workflow evidence completion marker files are missing: {completion_path}")
+    captured = dict(captured_files or {})
+    for filename in _completion_filenames(
+        bundle_dir,
+        manifest_payload=manifest_payload,
+    ):
+        expected = str(files.get(filename, ""))
+        if filename in captured:
+            actual = hashlib.sha256(captured[filename]).hexdigest()
+        else:
+            actual = _sha256_file_or_empty(bundle_dir / filename)
+        if not expected or actual != expected:
+            raise ValueError(
+                f"Workflow evidence completion hash mismatch for {bundle_dir / filename}"
+            )
+
+
+@contextmanager
+def _exclusive_publication_lock(path: Path):
+    """Hold a stable cross-process file lock for workflow evidence publication."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    handle = path.open("a+b")
+    locked = False
+    try:
+        if os.name == "nt":  # pragma: no cover - exercised on Windows CI
+            import msvcrt
+
+            if path.stat().st_size == 0:
+                handle.write(b"\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+            def _try_lock() -> None:
+                handle.seek(0)
+                msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+        else:
+            import fcntl
+
+            def _try_lock() -> None:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+        deadline = time.monotonic() + _PUBLICATION_LOCK_TIMEOUT_SECONDS
+        while True:
+            try:
+                _try_lock()
+                locked = True
+                break
+            except OSError as exc:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise TimeoutError(
+                        f"Timed out waiting for workflow-evidence publication lock {path}. "
+                        "Another session may still be publishing evidence; retry after it finishes."
+                    ) from exc
+                time.sleep(min(_PUBLICATION_LOCK_RETRY_INTERVAL_SECONDS, remaining))
+        yield
+    finally:
+        try:
+            if locked and os.name == "nt":  # pragma: no cover - exercised on Windows CI
+                import msvcrt
+
+                handle.seek(0)
+                msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+            elif locked:
+                import fcntl
+
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        finally:
+            handle.close()
 
 
 def _safe_id(value: str) -> str:

--- a/test/test_about_agilab_helpers.py
+++ b/test/test_about_agilab_helpers.py
@@ -6,10 +6,14 @@ import importlib.util
 import json
 import os
 from pathlib import Path
+import threading
+import tomllib
 from types import SimpleNamespace
 from urllib.parse import parse_qs, urlparse
 
 import pytest
+
+from agi_env.ui import sidecar_registry as sidecar_registry_module
 
 MODULE_PATH = Path(__file__).resolve().parents[1] / "src" / "agilab" / "main_page.py"
 SPEC = importlib.util.spec_from_file_location("agilab_about_helpers", MODULE_PATH)
@@ -252,8 +256,19 @@ def _make_bootstrap_ports(
     services_enabled: bool = False,
     last_app: object = None,
     environ: dict[str, str] | None = None,
+    add_session_factory: bool = True,
 ):
     bootstrap = about_agilab._about_bootstrap
+    if add_session_factory and isinstance(agi_env_cls, type) and not callable(
+        getattr(agi_env_cls, "session", None)
+    ):
+        @classmethod
+        def session(cls, *args, **kwargs):
+            env = cls(*args, **kwargs)
+            env._agilab_session_scoped = True
+            return env
+
+        agi_env_cls.session = session
     calls = SimpleNamespace(activated=[], stored=[])
     ports = bootstrap.BootstrapPorts(
         agi_env_cls=agi_env_cls,
@@ -1131,6 +1146,34 @@ def test_bootstrap_resolve_apps_path_prefers_cli_then_env(tmp_path):
     )
 
 
+def test_parse_startup_args_times_out_behind_peer_hosted_render(monkeypatch):
+    bootstrap = about_agilab._about_bootstrap
+    outcomes: list[BaseException | object] = []
+    monkeypatch.setattr(
+        sidecar_registry_module,
+        "_HOSTED_INLINE_RENDER_LOCK_TIMEOUT_SECONDS",
+        0.01,
+    )
+
+    def _parse() -> None:
+        try:
+            outcomes.append(bootstrap.parse_startup_args([]))
+        except BaseException as exc:
+            outcomes.append(exc)
+
+    sidecar_registry_module.HOSTED_INLINE_RENDER_LEASE.acquire()
+    try:
+        peer = threading.Thread(target=_parse)
+        peer.start()
+        peer.join(timeout=1)
+    finally:
+        sidecar_registry_module.HOSTED_INLINE_RENDER_LEASE.release()
+
+    assert not peer.is_alive()
+    assert len(outcomes) == 1
+    assert isinstance(outcomes[0], sidecar_registry_module.SidecarRegistryBusyError)
+
+
 def test_bootstrap_resolve_apps_path_from_agilab_path_file(tmp_path):
     bootstrap = about_agilab._about_bootstrap
     install_root = tmp_path / "agi-space"
@@ -1793,6 +1836,9 @@ user = "agi"
 
     payload = settings_path.read_text(encoding="utf-8")
     assert "cluster_enabled = false" in payload
+    parsed_payload = tomllib.loads(payload)
+    assert parsed_payload["args"] == {"data_in": "flight_telemetry/dataset"}
+    assert parsed_payload["cluster"]["user"] == "agi"
     assert ("success", f"Disabled cluster mode in `{settings_path}`.") in fake_st.events
     assert ("rerun", "") in fake_st.events
     assert fake_st.stopped is False
@@ -1997,7 +2043,9 @@ def test_bootstrap_page_environment_success_path(tmp_path, monkeypatch):
     assert fake_st.warnings == []
 
 
-def test_bootstrap_page_environment_reuses_warm_env_singleton(tmp_path, monkeypatch):
+def test_bootstrap_page_environment_replaces_legacy_warm_env_without_borrowing_singleton(
+    tmp_path, monkeypatch
+):
     bootstrap = about_agilab._about_bootstrap
     apps_path = tmp_path / "apps"
     app_path = apps_path / "sb3_trainer_project"
@@ -2017,28 +2065,46 @@ def test_bootstrap_page_environment_reuses_warm_env_singleton(tmp_path, monkeypa
         CLUSTER_CREDENTIALS="",
         envars={},
         init_done=False,
+        _agilab_session_scoped=False,
     )
 
     class WarmAgiEnv:
+        current_calls = 0
+        session_calls = 0
+
         @classmethod
         def current(cls):
+            cls.current_calls += 1
             return existing_env
+
+        @classmethod
+        def session(cls, *, apps_path: Path, verbose: int):
+            cls.session_calls += 1
+            return SimpleNamespace(
+                apps_path=apps_path,
+                app="sb3_trainer_project",
+                active_app=apps_path / "sb3_trainer_project",
+                projects={"sb3_trainer_project"},
+                is_source_env=True,
+                is_worker_env=False,
+                OPENAI_API_KEY="",
+                CLUSTER_CREDENTIALS="",
+                envars={},
+                init_done=False,
+                verbose=verbose,
+                _agilab_session_scoped=True,
+            )
 
         @staticmethod
         def set_env_var(key: str, value: str) -> None:
             set_env_calls.append((key, value))
-
-        def __init__(self, *, apps_path: Path, verbose: int):
-            raise RuntimeError(
-                "AgiEnv is already initialised with a different configuration; "
-                "use AgiEnv.reset() for a fresh environment or change_app() to switch apps."
-            )
 
     def apply_request(env, requested):
         requested_apps.append(requested)
         return False
 
     fake_st = _FakeStreamlit()
+    fake_st.session_state["env"] = existing_env
     monkeypatch.setattr(
         bootstrap,
         "default_agilab_path_file",
@@ -2059,16 +2125,122 @@ def test_bootstrap_page_environment_reuses_warm_env_singleton(tmp_path, monkeypa
         ports=ports,
     )
 
-    assert result.env is existing_env
-    assert fake_st.session_state["env"] is existing_env
+    assert result.env is not existing_env
+    assert fake_st.session_state["env"] is result.env
+    assert result.env._agilab_session_scoped is True
     assert fake_st.session_state["first_run"] is False
-    assert existing_env.init_done is True
+    assert result.env.init_done is True
     assert requested_apps == [None]
-    assert refreshed_envs == [existing_env]
+    assert refreshed_envs == [result.env]
     assert port_calls.activated == []
+    assert WarmAgiEnv.current_calls == 0
+    assert WarmAgiEnv.session_calls == 1
 
 
-def test_bootstrap_page_environment_reuses_warm_source_builtin_singleton(
+def test_bootstrap_session_factory_failure_never_borrows_cli_singleton(
+    tmp_path, monkeypatch
+):
+    bootstrap = about_agilab._about_bootstrap
+    apps_path = tmp_path / "apps"
+    apps_path.mkdir()
+    current_calls: list[str] = []
+
+    class SessionAgiEnv:
+        @staticmethod
+        def set_env_var(_key: str, _value: str) -> None:
+            return None
+
+        @classmethod
+        def session(cls, *, apps_path: Path, verbose: int):
+            assert apps_path == tmp_path / "apps"
+            assert verbose == 1
+            raise RuntimeError(
+                "AgiEnv is already initialised with a different configuration; "
+                "the UI session factory must not borrow it."
+            )
+
+        @classmethod
+        def current(cls):
+            current_calls.append("current")
+            return object()
+
+    fake_st = _FakeStreamlit()
+    monkeypatch.setattr(
+        bootstrap,
+        "default_agilab_path_file",
+        lambda **_kwargs: tmp_path / "missing-agilab-path",
+    )
+    ports, _calls = _make_bootstrap_ports(SessionAgiEnv, environ={})
+
+    with pytest.raises(RuntimeError, match="UI session factory"):
+        bootstrap.bootstrap_page_environment(
+            streamlit=fake_st,
+            env_file_path=tmp_path / ".env",
+            load_env_file_map=lambda _path: {"APPS_PATH": str(apps_path)},
+            logger=None,
+            apply_active_app_request=lambda *_args: False,
+            handle_data_root_failure=lambda _exc, **_kwargs: False,
+            refresh_env_from_file=lambda _env: None,
+            clean_openai_key=lambda value: value,
+            store_cluster_credentials=lambda *_args, **_kwargs: True,
+            ports=ports,
+        )
+
+    assert current_calls == []
+    assert "env" not in fake_st.session_state
+
+
+def test_bootstrap_requires_session_factory_with_actionable_upgrade_error(
+    tmp_path, monkeypatch
+):
+    bootstrap = about_agilab._about_bootstrap
+    apps_path = tmp_path / "apps"
+    apps_path.mkdir()
+
+    class LegacyAgiEnv:
+        init_calls = 0
+
+        @staticmethod
+        def set_env_var(_key: str, _value: str) -> None:
+            return None
+
+        def __init__(self, **_kwargs):
+            type(self).init_calls += 1
+
+    fake_st = _FakeStreamlit()
+    monkeypatch.setattr(
+        bootstrap,
+        "default_agilab_path_file",
+        lambda **_kwargs: tmp_path / "missing-agilab-path",
+    )
+    ports, _calls = _make_bootstrap_ports(
+        LegacyAgiEnv,
+        environ={},
+        add_session_factory=False,
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"requires AgiEnv\.session\(\).*new browser session",
+    ):
+        bootstrap.bootstrap_page_environment(
+            streamlit=fake_st,
+            env_file_path=tmp_path / ".env",
+            load_env_file_map=lambda _path: {"APPS_PATH": str(apps_path)},
+            logger=None,
+            apply_active_app_request=lambda *_args: False,
+            handle_data_root_failure=lambda _exc, **_kwargs: False,
+            refresh_env_from_file=lambda _env: None,
+            clean_openai_key=lambda value: value,
+            store_cluster_credentials=lambda *_args, **_kwargs: True,
+            ports=ports,
+        )
+
+    assert LegacyAgiEnv.init_calls == 0
+    assert "env" not in fake_st.session_state
+
+
+def test_bootstrap_page_environment_reuses_matching_session_scoped_warm_env(
     tmp_path, monkeypatch
 ):
     bootstrap = about_agilab._about_bootstrap
@@ -2089,24 +2261,20 @@ def test_bootstrap_page_environment_reuses_warm_source_builtin_singleton(
         CLUSTER_CREDENTIALS="",
         envars={},
         init_done=False,
+        _agilab_session_scoped=True,
     )
 
     class WarmBuiltinAgiEnv:
         @classmethod
-        def current(cls):
-            return existing_env
+        def session(cls, **_kwargs):
+            raise AssertionError("matching session-scoped env must be reused")
 
         @staticmethod
         def set_env_var(_key: str, _value: str) -> None:
             return None
 
-        def __init__(self, *, apps_path: Path, verbose: int):
-            raise RuntimeError(
-                "AgiEnv is already initialised with a different configuration; "
-                "use AgiEnv.reset() for a fresh environment or change_app() to switch apps."
-            )
-
     fake_st = _FakeStreamlit()
+    fake_st.session_state["env"] = existing_env
     monkeypatch.setattr(
         bootstrap,
         "default_agilab_path_file",
@@ -2133,7 +2301,7 @@ def test_bootstrap_page_environment_reuses_warm_source_builtin_singleton(
     assert refreshed_envs == [existing_env]
 
 
-def test_bootstrap_page_environment_rejects_warm_env_with_different_apps_path(
+def test_bootstrap_page_environment_replaces_warm_env_with_different_apps_path(
     tmp_path, monkeypatch
 ):
     bootstrap = about_agilab._about_bootstrap
@@ -2146,7 +2314,7 @@ def test_bootstrap_page_environment_rejects_warm_env_with_different_apps_path(
     existing_env = SimpleNamespace(
         apps_path=stale_apps_path,
         app="sb3_trainer_project",
-        active_app=app_path,
+        active_app=stale_apps_path / "sb3_trainer_project",
         projects={"sb3_trainer_project"},
         is_source_env=True,
         is_worker_env=False,
@@ -2154,24 +2322,40 @@ def test_bootstrap_page_environment_rejects_warm_env_with_different_apps_path(
         CLUSTER_CREDENTIALS="",
         envars={},
         init_done=False,
+        _agilab_session_scoped=True,
     )
 
     class WarmAgiEnv:
+        current_calls = 0
+
         @classmethod
         def current(cls):
+            cls.current_calls += 1
             return existing_env
+
+        @classmethod
+        def session(cls, *, apps_path: Path, verbose: int):
+            return SimpleNamespace(
+                apps_path=apps_path,
+                app="sb3_trainer_project",
+                active_app=apps_path / "sb3_trainer_project",
+                projects={"sb3_trainer_project"},
+                is_source_env=True,
+                is_worker_env=False,
+                OPENAI_API_KEY="",
+                CLUSTER_CREDENTIALS="",
+                envars={},
+                init_done=False,
+                verbose=verbose,
+                _agilab_session_scoped=True,
+            )
 
         @staticmethod
         def set_env_var(_key: str, _value: str) -> None:
             return None
 
-        def __init__(self, *, apps_path: Path, verbose: int):
-            raise RuntimeError(
-                "AgiEnv is already initialised with a different configuration; "
-                "use AgiEnv.reset() for a fresh environment or change_app() to switch apps."
-            )
-
     fake_st = _FakeStreamlit()
+    fake_st.session_state["env"] = existing_env
     monkeypatch.setattr(
         bootstrap,
         "default_agilab_path_file",
@@ -2179,22 +2363,26 @@ def test_bootstrap_page_environment_rejects_warm_env_with_different_apps_path(
     )
     ports, _port_calls = _make_bootstrap_ports(WarmAgiEnv, environ={})
 
-    with pytest.raises(RuntimeError, match="already initialised"):
-        bootstrap.bootstrap_page_environment(
-            streamlit=fake_st,
-            env_file_path=tmp_path / ".env",
-            load_env_file_map=lambda _path: {"APPS_PATH": str(apps_path)},
-            logger=None,
-            apply_active_app_request=lambda *_args: False,
-            handle_data_root_failure=lambda _exc, **_kwargs: False,
-            refresh_env_from_file=lambda _env: None,
-            clean_openai_key=lambda value: value,
-            store_cluster_credentials=lambda *_args, **_kwargs: True,
-            ports=ports,
-        )
+    result = bootstrap.bootstrap_page_environment(
+        streamlit=fake_st,
+        env_file_path=tmp_path / ".env",
+        load_env_file_map=lambda _path: {"APPS_PATH": str(apps_path)},
+        logger=None,
+        apply_active_app_request=lambda *_args: False,
+        handle_data_root_failure=lambda _exc, **_kwargs: False,
+        refresh_env_from_file=lambda _env: None,
+        clean_openai_key=lambda value: value,
+        store_cluster_credentials=lambda *_args, **_kwargs: True,
+        ports=ports,
+    )
+
+    assert result.env is not existing_env
+    assert result.env.apps_path == apps_path
+    assert result.env._agilab_session_scoped is True
+    assert WarmAgiEnv.current_calls == 0
 
 
-def test_bootstrap_page_environment_resets_unusable_warm_env_singleton(
+def test_bootstrap_page_environment_never_resets_or_borrows_unusable_warm_singleton(
     tmp_path, monkeypatch
 ):
     bootstrap = about_agilab._about_bootstrap
@@ -2218,13 +2406,16 @@ def test_bootstrap_page_environment_resets_unusable_warm_env_singleton(
         CLUSTER_CREDENTIALS="",
         envars={},
         init_done=False,
+        _agilab_session_scoped=False,
     )
 
     class ResettableWarmAgiEnv:
         reset_called = False
+        current_calls = 0
 
         @classmethod
         def current(cls):
+            cls.current_calls += 1
             return existing_env
 
         @classmethod
@@ -2235,25 +2426,25 @@ def test_bootstrap_page_environment_resets_unusable_warm_env_singleton(
         def set_env_var(key: str, value: str) -> None:
             set_env_calls.append((key, value))
 
-        def __init__(self, *, apps_path: Path, verbose: int):
-            if not type(self).reset_called:
-                raise RuntimeError(
-                    "AgiEnv is already initialised with a different configuration; "
-                    "use AgiEnv.reset() for a fresh environment or change_app() to switch apps."
-                )
-            self.apps_path = apps_path
-            self.app = "flight_telemetry_project"
-            self.active_app = apps_path / self.app
-            self.projects = {"flight_telemetry_project"}
-            self.is_source_env = True
-            self.is_worker_env = False
-            self.OPENAI_API_KEY = ""
-            self.CLUSTER_CREDENTIALS = ""
-            self.envars = {}
-            self.init_done = False
-            self.verbose = verbose
+        @classmethod
+        def session(cls, *, apps_path: Path, verbose: int):
+            return SimpleNamespace(
+                apps_path=apps_path,
+                app="flight_telemetry_project",
+                active_app=apps_path / "flight_telemetry_project",
+                projects={"flight_telemetry_project"},
+                is_source_env=True,
+                is_worker_env=False,
+                OPENAI_API_KEY="",
+                CLUSTER_CREDENTIALS="",
+                envars={},
+                init_done=False,
+                verbose=verbose,
+                _agilab_session_scoped=True,
+            )
 
     fake_st = _FakeStreamlit()
+    fake_st.session_state["env"] = existing_env
     monkeypatch.setattr(
         bootstrap,
         "default_agilab_path_file",
@@ -2278,7 +2469,8 @@ def test_bootstrap_page_environment_resets_unusable_warm_env_singleton(
     assert result.env.apps_path == apps_path
     assert fake_st.session_state["env"] is result.env
     assert result.env.init_done is True
-    assert ResettableWarmAgiEnv.reset_called is True
+    assert ResettableWarmAgiEnv.reset_called is False
+    assert ResettableWarmAgiEnv.current_calls == 0
     assert refreshed_envs == [result.env]
     assert ("APPS_PATH", str(apps_path)) in set_env_calls
 
@@ -2590,15 +2782,6 @@ def test_bootstrap_path_matching_and_payload_project_edges(tmp_path):
         )
         is False
     )
-    assert bootstrap._recover_existing_env_for_apps_path(SimpleNamespace(current=None), apps_path) is None
-
-    class RaisingCurrent:
-        @staticmethod
-        def current():
-            raise RuntimeError("not initialised")
-
-    assert bootstrap._recover_existing_env_for_apps_path(RaisingCurrent, apps_path) is None
-
     package_project = (
         tmp_path
         / "agi-app-demo"
@@ -2880,6 +3063,7 @@ def test_bootstrap_page_environment_uses_injected_ports_and_services(tmp_path):
         return bool(requested)
 
     fake_st = _FakeStreamlit()
+    fake_st.session_state["server_started"] = True
     ports, port_calls = _make_bootstrap_ports(
         FakeAgiEnv,
         services_enabled=True,
@@ -3243,7 +3427,7 @@ def test_env_file_helpers_parse_write_preview_and_upsert(tmp_path, monkeypatch):
     assert env_file.read_text(encoding="utf-8").splitlines() == [
         "",
         "# plain comment",
-        "AGI_PYTHON_VERSION=3.12",
+        "#AGI_PYTHON_VERSION='3.12'",
         "OPENAI_API_KEY=secret",
         "DUP=updated",
         "BROKEN LINE",
@@ -3256,6 +3440,27 @@ def test_env_file_helpers_parse_write_preview_and_upsert(tmp_path, monkeypatch):
     rewritten = env_file.read_text(encoding="utf-8")
     assert "OPENAI_API_KEY=new-secret" in rewritten
     assert rewritten.endswith("APPENDED=yes\n")
+
+
+def test_env_editor_write_reloads_file_and_preserves_disjoint_update(tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        '# preserved comment\nQUOTED="keep value"\nEDIT=old\n',
+        encoding="utf-8",
+    )
+    stale_entries = about_agilab._read_env_file(env_file)
+
+    about_agilab._upsert_env_var(env_file, "CONCURRENT", "added")
+    about_agilab._write_env_file(
+        env_file,
+        stale_entries,
+        {"EDIT": "new"},
+        None,
+    )
+
+    assert env_file.read_text(encoding="utf-8") == (
+        '# preserved comment\nQUOTED="keep value"\nEDIT=new\nCONCURRENT=added\n'
+    )
 
 
 def test_handle_data_root_failure_renders_share_recovery_paths(tmp_path, monkeypatch):
@@ -4530,6 +4735,27 @@ def test_main_page_sidebar_keeps_settings_link_without_execution_context(monkeyp
     assert not any(
         "OS:" in body for kind, body in fake_st.events if kind == "sidebar.caption"
     )
+
+
+def test_main_page_sidebar_uses_current_session_settings_page(monkeypatch):
+    fake_st = _FakeStreamlit()
+    current_settings_page = SimpleNamespace(url_path="SETTINGS")
+    monkeypatch.setattr(about_agilab, "st", fake_st)
+    monkeypatch.setattr(
+        about_agilab,
+        "docs_menu_url",
+        lambda _html_file: "https://docs.example/agilab-help.html",
+    )
+    about_agilab._NAVIGATION_PAGE_ROUTES["settings"] = current_settings_page
+
+    about_agilab.render_sidebar_settings_link()
+
+    page_links = [
+        value for kind, value in fake_st.events if kind == "sidebar.page_link"
+    ]
+    assert page_links == [
+        {"page": current_settings_page, "kwargs": {"label": "Settings"}}
+    ]
 
 
 def test_main_page_sidebar_links_active_app_readme(tmp_path, monkeypatch):

--- a/test/test_agent_run.py
+++ b/test/test_agent_run.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import multiprocessing
 import subprocess
 import sys
 import types
@@ -12,6 +13,10 @@ import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 MODULE_PATH = ROOT / "src" / "agilab" / "agent_run.py"
+if str(ROOT) not in sys.path:
+    # Spawned workers must be able to import this test module even when
+    # pytest's importlib mode omits the checkout root from sys.path.
+    sys.path.insert(0, str(ROOT))
 
 
 def _load_module():
@@ -34,6 +39,25 @@ def _load_module():
         else:
             sys.modules["agilab"] = previous_package
     return module
+
+
+def _agent_run_process(output_dir: str, start, results) -> None:
+    module = _load_module()
+    start.wait(timeout=10)
+    try:
+        result = module.trace_agent_run(
+            [sys.executable, "-c", "import time; time.sleep(0.2)"],
+            agent="codex",
+            label="Concurrent claim",
+            cwd=ROOT,
+            output_dir=Path(output_dir),
+            run_id="same-run",
+            permission_level="standard",
+        )
+    except BaseException as exc:
+        results.put(("error", type(exc).__name__, str(exc)))
+    else:
+        results.put(("ok", result.returncode, ""))
 
 
 def test_agent_run_print_only_json_is_redacted(tmp_path: Path, capsys) -> None:
@@ -235,6 +259,301 @@ def test_trace_agent_run_public_python_api_executes_and_redacts(tmp_path: Path, 
     assert "session_start" in events
     assert "command_done" in events
     assert "sk-secret" not in events
+
+
+def test_agent_run_output_directory_is_exclusively_claimed_across_processes(tmp_path: Path) -> None:
+    context = multiprocessing.get_context("spawn")
+    start = context.Event()
+    results = context.Queue()
+    processes = [
+        context.Process(target=_agent_run_process, args=(str(tmp_path), start, results))
+        for _ in range(2)
+    ]
+    for process in processes:
+        process.start()
+    start.set()
+    outcomes = [results.get(timeout=15) for _ in processes]
+    for process in processes:
+        process.join(timeout=15)
+        assert process.exitcode == 0
+
+    assert sum(outcome[0] == "ok" for outcome in outcomes) == 1
+    collision = next(outcome for outcome in outcomes if outcome[0] == "error")
+    assert collision[1] == "FileExistsError"
+    assert "already claimed" in collision[2]
+    module = _load_module()
+    claim = json.loads((tmp_path / module.RUN_CLAIM_FILENAME).read_text(encoding="utf-8"))
+    manifest = module.load_agent_run_manifest(tmp_path)
+    assert claim["run_id"] == "same-run"
+    assert manifest["run_id"] == "same-run"
+    claim["schema"] = "agilab.agent_run.claim.invalid"
+    (tmp_path / module.RUN_CLAIM_FILENAME).write_text(
+        json.dumps(claim),
+        encoding="utf-8",
+    )
+    validation = module.validate_agent_run(tmp_path)
+    assert any(issue["code"] == "claim_schema" for issue in validation["issues"])
+    claim["schema"] = "agilab.agent_run.claim.v1"
+    claim["run_id"] = "other-run"
+    (tmp_path / module.RUN_CLAIM_FILENAME).write_text(
+        json.dumps(claim),
+        encoding="utf-8",
+    )
+    validation = module.validate_agent_run(tmp_path)
+    assert any(issue["code"] == "claim_run_id" for issue in validation["issues"])
+
+
+def test_agent_run_fixed_artifact_atomic_write_rolls_back_on_replace_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_module()
+    target = tmp_path / "stdout.txt"
+    target.write_text("original", encoding="utf-8")
+    monkeypatch.setattr(module.os, "replace", lambda *_args: (_ for _ in ()).throw(OSError("replace failed")))
+
+    with pytest.raises(OSError, match="replace failed"):
+        module._atomic_write_text(target, "partial")
+
+    assert target.read_text(encoding="utf-8") == "original"
+    assert list(tmp_path.glob(".stdout.txt.*.tmp")) == []
+
+
+def test_agent_run_missing_executable_commits_terminal_failure_evidence(tmp_path: Path) -> None:
+    module = _load_module()
+
+    result = module.trace_agent_run(
+        [str(tmp_path / "missing-agent-executable")],
+        agent="codex",
+        label="Missing executable",
+        cwd=ROOT,
+        output_dir=tmp_path / "run",
+        run_id="missing-executable",
+        permission_level="standard",
+    )
+
+    assert result.returncode == 127
+    assert result.manifest["status"] == "fail"
+    assert result.manifest["termination"]["phase"] == "command launch"
+    assert result.manifest["termination"]["error_type"] == "FileNotFoundError"
+    run_dir = tmp_path / "run"
+    assert (run_dir / module.RUN_CLAIM_FILENAME).is_file()
+    assert (run_dir / module.MANIFEST_FILENAME).is_file()
+    assert "Agent run terminated during command launch" in (run_dir / module.STDERR_FILENAME).read_text(
+        encoding="utf-8"
+    )
+    summary = module.summarize_agent_run(run_dir)
+    assert summary.status == "fail"
+    assert summary.returncode == 127
+    assert module.validate_agent_run(run_dir)["ok"] is True
+
+    with pytest.raises(FileExistsError, match="already claimed"):
+        module.trace_agent_run(
+            [sys.executable, "-c", "print('must not reuse')"],
+            cwd=ROOT,
+            output_dir=run_dir,
+            run_id="missing-executable",
+            permission_level="standard",
+        )
+
+
+def test_agent_run_trace_setup_failure_commits_terminal_failure_evidence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_module()
+    original_initialize = module.AgentTraceStore.initialize
+    initialize_calls = 0
+    runner_called = False
+
+    def fail_first_initialize(store, metadata=None):
+        nonlocal initialize_calls
+        initialize_calls += 1
+        if initialize_calls == 1:
+            raise OSError("injected trace setup failure")
+        return original_initialize(store, metadata)
+
+    def runner(*_args, **_kwargs):
+        nonlocal runner_called
+        runner_called = True
+        return subprocess.CompletedProcess([], 0, stdout="", stderr="")
+
+    monkeypatch.setattr(module.AgentTraceStore, "initialize", fail_first_initialize)
+    result = module.trace_agent_run(
+        [sys.executable, "-c", "print('must not run')"],
+        cwd=ROOT,
+        output_dir=tmp_path,
+        run_id="trace-setup-failure",
+        permission_level="standard",
+        runner=runner,
+    )
+
+    assert runner_called is False
+    assert result.returncode == 125
+    assert result.manifest["status"] == "fail"
+    assert result.manifest["termination"]["phase"] == "trace setup"
+    assert result.manifest["termination"]["trace_recorded"] is True
+    assert module.summarize_agent_run(tmp_path).status == "fail"
+    assert module.validate_agent_run(tmp_path)["ok"] is True
+
+
+@pytest.mark.parametrize(
+    ("raised", "expected_returncode", "expected_status", "expected_reason"),
+    [
+        (KeyboardInterrupt("operator cancelled"), 130, "fail", "operator_cancelled"),
+        (SystemExit(17), 17, "fail", "system_exit"),
+        (SystemExit(0), 0, "pass", "system_exit"),
+        (SystemExit(None), 0, "pass", "system_exit"),
+    ],
+)
+def test_agent_run_interrupt_commits_terminal_evidence_before_reraise(
+    tmp_path: Path,
+    raised: BaseException,
+    expected_returncode: int,
+    expected_status: str,
+    expected_reason: str,
+) -> None:
+    module = _load_module()
+    config = module.AgentRunConfig(
+        agent="codex",
+        label="interrupted",
+        command=(sys.executable, "-c", "print('must not run')"),
+        cwd=ROOT,
+        output_dir=tmp_path,
+        run_id="interrupted-run",
+        timeout_seconds=30.0,
+        permission_level="standard",
+    )
+
+    def interrupted_runner(*_args, **_kwargs):
+        raise raised
+
+    with pytest.raises(type(raised)) as caught:
+        module.run_agent_command(config, runner=interrupted_runner)
+
+    if isinstance(raised, SystemExit):
+        assert caught.value.code == raised.code
+    manifest = module.load_agent_run_manifest(tmp_path)
+    assert manifest["status"] == expected_status
+    assert manifest["returncode"] == expected_returncode
+    assert manifest["termination"]["reason"] == expected_reason
+    assert manifest["termination"]["phase"] == "command launch"
+    assert manifest["termination"]["error_type"] == type(raised).__name__
+    assert (tmp_path / module.RUN_CLAIM_FILENAME).is_file()
+    assert (tmp_path / module.STDOUT_FILENAME).is_file()
+    assert type(raised).__name__ in (tmp_path / module.STDERR_FILENAME).read_text(
+        encoding="utf-8"
+    )
+    assert module.validate_agent_run(tmp_path)["ok"] is True
+
+    with pytest.raises(FileExistsError, match="already claimed"):
+        module.run_agent_command(config, runner=interrupted_runner)
+
+
+def test_agent_run_interrupt_is_not_masked_when_terminal_evidence_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_module()
+    config = module.AgentRunConfig(
+        agent="codex",
+        label="interrupted",
+        command=(sys.executable, "-c", "print('must not run')"),
+        cwd=ROOT,
+        output_dir=tmp_path,
+        run_id="interrupted-evidence-failure",
+        timeout_seconds=30.0,
+        permission_level="standard",
+    )
+    interrupt = KeyboardInterrupt("operator cancelled")
+
+    def interrupted_runner(*_args, **_kwargs):
+        raise interrupt
+
+    monkeypatch.setattr(
+        module,
+        "_record_terminal_agent_run_failure",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            OSError("evidence unavailable")
+        ),
+    )
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        module.run_agent_command(config, runner=interrupted_runner)
+
+    assert caught.value is interrupt
+    assert (tmp_path / module.RUN_CLAIM_FILENAME).is_file()
+
+
+def test_agent_run_persistent_trace_failure_uses_terminal_manifest_as_authority(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_module()
+    monkeypatch.setattr(
+        module.AgentTraceStore,
+        "initialize",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("trace storage unavailable")),
+    )
+
+    result = module.trace_agent_run(
+        [sys.executable, "-c", "print('must not run')"],
+        cwd=ROOT,
+        output_dir=tmp_path,
+        run_id="persistent-trace-failure",
+        permission_level="standard",
+    )
+
+    assert result.returncode == 125
+    assert result.manifest["status"] == "fail"
+    assert result.manifest["termination"]["phase"] == "trace setup"
+    assert result.manifest["termination"]["trace_recorded"] is False
+    assert result.manifest["termination"]["trace_error"] == "trace storage unavailable"
+    validation = module.validate_agent_run(tmp_path)
+    assert validation["ok"] is True
+    assert validation["issue_count"] == 0
+    assert {warning["code"] for warning in validation["warnings"]} == {"termination_trace"}
+    assert module.summarize_agent_run(tmp_path).status == "fail"
+
+
+def test_agent_run_publication_failure_recommits_terminal_failure_evidence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_module()
+    original_atomic_write = module._atomic_write_text
+    publication_failed = False
+
+    def fail_first_stdout_publication(path, text):
+        nonlocal publication_failed
+        if path.name == module.STDOUT_FILENAME and not publication_failed:
+            publication_failed = True
+            raise OSError("injected stdout publication failure")
+        return original_atomic_write(path, text)
+
+    monkeypatch.setattr(module, "_atomic_write_text", fail_first_stdout_publication)
+    result = module.trace_agent_run(
+        [sys.executable, "-c", "print('captured before publication failed')"],
+        cwd=ROOT,
+        output_dir=tmp_path,
+        run_id="publication-failure",
+        permission_level="standard",
+    )
+
+    assert publication_failed is True
+    assert result.returncode == 125
+    assert result.manifest["status"] == "fail"
+    assert result.manifest["termination"]["phase"] == "artifact publication"
+    assert "captured before publication failed" in (tmp_path / module.STDOUT_FILENAME).read_text(
+        encoding="utf-8"
+    )
+    assert "injected stdout publication failure" in (tmp_path / module.STDERR_FILENAME).read_text(
+        encoding="utf-8"
+    )
+    summary = module.summarize_agent_run(tmp_path)
+    assert summary.status == "fail"
+    assert summary.returncode == 125
+    assert module.validate_agent_run(tmp_path)["ok"] is True
 
 
 def test_agent_run_stamps_provider_config_and_permission_level(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1025,6 +1344,33 @@ def test_agent_run_validate_checks_artifact_presence_and_trace(tmp_path: Path, c
     assert payload["run"]["run_id"] == "agent-validate"
     assert "validation private output" not in json.dumps(payload)
 
+    trace_path = tmp_path / "agent_events.ndjson"
+    original_trace = trace_path.read_text(encoding="utf-8")
+    trace_path.write_text(
+        original_trace
+        + "{corrupt-interior-record\n"
+        + json.dumps(
+            {
+                "schema": "agilab.agent_trace.v1",
+                "event": "session_end",
+                "run_id": "agent-validate",
+                "sequence": 999,
+                "created_at": "later",
+                "status": "pass",
+                "message": "",
+                "metadata": {},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    corrupt = module.validate_agent_run(tmp_path)
+    assert corrupt["ok"] is False
+    assert "trace_events_invalid" in {
+        issue["code"] for issue in corrupt["issues"]
+    }
+    trace_path.write_text(original_trace, encoding="utf-8")
+
     assert module.main(["validate", str(tmp_path), "--json"]) == 0
     cli_payload = json.loads(capsys.readouterr().out)
     assert cli_payload["ok"] is True
@@ -1037,6 +1383,34 @@ def test_agent_run_validate_checks_artifact_presence_and_trace(tmp_path: Path, c
     markdown = capsys.readouterr().out
     assert "# AGILAB agent-run validation" in markdown
     assert "stdout artifact does not exist" in markdown
+
+
+def test_agent_run_validate_accepts_legacy_v1_manifest_without_claim(tmp_path: Path) -> None:
+    module = _load_module()
+
+    result = module.trace_agent_run(
+        [sys.executable, "-c", "print('legacy')"],
+        agent="codex",
+        label="Legacy v1 validation",
+        cwd=ROOT,
+        output_dir=tmp_path,
+        run_id="legacy-v1",
+        permission_level="standard",
+    )
+    assert result.returncode == 0
+
+    manifest_path = tmp_path / module.MANIFEST_FILENAME
+    manifest = module.load_agent_run_manifest(manifest_path)
+    manifest["artifacts"].pop("claim")
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (tmp_path / module.RUN_CLAIM_FILENAME).unlink()
+
+    validation = module.validate_agent_run(tmp_path)
+    assert validation["ok"] is True
+    assert validation["issue_count"] == 0
 
 
 def test_agent_run_timeout_records_timeout_status(tmp_path: Path) -> None:

--- a/test/test_agent_tool_safety.py
+++ b/test/test_agent_tool_safety.py
@@ -223,6 +223,32 @@ def test_progress_recorder_writes_append_only_redacted_ndjson(tmp_path) -> None:
     assert "env://OPENAI_API_KEY" not in raw
 
 
+def test_progress_recorder_recovers_only_an_unterminated_crash_tail(tmp_path) -> None:
+    module = _load_module()
+    log_path = tmp_path / "progress.ndjson"
+    recorder = module.ProgressRecorder(log_path, run_id="agent-run")
+    recorder.emit("tool_start")
+    with log_path.open("ab") as handle:
+        handle.write(b'{"partial"')
+
+    assert [row["event"] for row in module.load_progress_events(log_path)] == [
+        "tool_start"
+    ]
+    recorder.emit("tool_end", status="pass")
+
+    assert [row["event"] for row in module.load_progress_events(log_path)] == [
+        "tool_start",
+        "tool_end",
+    ]
+    quarantined = list(tmp_path.glob(f".{log_path.name}.partial.*.jsonl"))
+    assert len(quarantined) == 1
+    assert quarantined[0].read_bytes() == b'{"partial"'
+
+    log_path.write_text('{}\n{broken}\n{}\n', encoding="utf-8")
+    with pytest.raises(json.JSONDecodeError):
+        module.load_progress_events(log_path)
+
+
 def test_load_progress_events_returns_empty_list_for_missing_path(tmp_path) -> None:
     module = _load_module()
 

--- a/test/test_agent_trace.py
+++ b/test/test_agent_trace.py
@@ -126,7 +126,8 @@ def test_agent_trace_store_clears_stale_append_lock(tmp_path: Path) -> None:
     event = store.append("session_start", message="after stale lock")
 
     assert event.sequence == 1
-    assert not lock_path.exists()
+    assert lock_path.exists()
+    assert module._read_lock_payload(lock_path) == {}
     assert module.load_trace_events(tmp_path)[0].message == "after stale lock"
 
 
@@ -171,15 +172,19 @@ def test_agent_trace_rejects_unknown_events_and_validates_sequence(tmp_path: Pat
     assert any("expected sequence 2" in issue for issue in issues)
 
 
-def test_load_trace_events_ignores_invalid_lines(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    "corrupt_record",
+    ["{not-json", json.dumps(["not", "an", "event"])],
+)
+def test_load_trace_events_rejects_corrupt_interior_records(
+    tmp_path: Path,
+    corrupt_record: str,
+) -> None:
     module = _load_module()
     events_path = tmp_path / module.EVENTS_FILENAME
     events_path.write_text(
         "\n".join(
             [
-                "",
-                "{not-json",
-                json.dumps(["not", "an", "event"]),
                 json.dumps(
                     {
                         "schema": module.TRACE_SCHEMA,
@@ -192,8 +197,49 @@ def test_load_trace_events_ignores_invalid_lines(tmp_path: Path) -> None:
                         "metadata": {},
                     }
                 ),
+                corrupt_record,
+                json.dumps(
+                    {
+                        "schema": module.TRACE_SCHEMA,
+                        "event": "session_end",
+                        "run_id": "run",
+                        "sequence": 2,
+                        "created_at": "later",
+                        "status": "pass",
+                        "message": "",
+                        "metadata": {},
+                    }
+                ),
+                "",
             ]
         ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="record 2"):
+        module.load_trace_events(tmp_path)
+
+
+def test_load_trace_events_tolerates_only_invalid_unterminated_tail(
+    tmp_path: Path,
+) -> None:
+    module = _load_module()
+    events_path = tmp_path / module.EVENTS_FILENAME
+    events_path.write_text(
+        json.dumps(
+            {
+                "schema": module.TRACE_SCHEMA,
+                "event": "session_start",
+                "run_id": "run",
+                "sequence": 1,
+                "created_at": "now",
+                "status": "running",
+                "message": "",
+                "metadata": {},
+            }
+        )
+        + "\n"
+        + '{"schema":',
         encoding="utf-8",
     )
 
@@ -287,26 +333,61 @@ def test_agent_trace_event_lock_timeout_and_finally_edges(tmp_path: Path, monkey
     events_path = tmp_path / module.EVENTS_FILENAME
     events_path.touch()
     lock_path = events_path.with_name(events_path.name + ".lock")
-    lock_path.write_text("{}", encoding="utf-8")
-
     monotonic_values = iter([0.0, module.LOCK_TIMEOUT_SECONDS + 1.0])
     monkeypatch.setattr(module.time, "monotonic", lambda: next(monotonic_values))
     monkeypatch.setattr(module.time, "sleep", lambda _seconds: None)
-    monkeypatch.setattr(module, "_clear_stale_lock", lambda _path: False)
+    monkeypatch.setattr(module, "_try_lock_handle", lambda _handle: False)
 
     with pytest.raises(TimeoutError, match="Timed out waiting"):
         with module._event_file_lock(events_path):
             pass
 
-    lock_path.unlink()
+    monkeypatch.setattr(module, "_try_lock_handle", lambda _handle: True)
     monkeypatch.setattr(module.time, "monotonic", lambda: 0.0)
-    original_unlink = module.Path.unlink
-
-    def unlink_missing(self):
-        if self == lock_path:
-            raise FileNotFoundError
-        return original_unlink(self)
-
-    monkeypatch.setattr(module.Path, "unlink", unlink_missing)
     with module._event_file_lock(events_path):
         assert lock_path.exists()
+    assert module._read_lock_payload(lock_path) == {}
+
+
+def test_agent_trace_rejects_mismatched_run_identity(tmp_path: Path) -> None:
+    module = _load_module()
+    first = module.AgentTraceStore(tmp_path, run_id="first-run", agent="codex")
+    first.initialize()
+
+    with pytest.raises(FileExistsError, match="belongs to run"):
+        module.AgentTraceStore(tmp_path, run_id="second-run", agent="codex").initialize()
+
+    with pytest.raises(FileExistsError, match="belongs to run"):
+        module.AgentTraceStore(tmp_path, run_id="second-run", agent="codex").append(
+            "session_start"
+        )
+
+    assert module.load_trace_events(tmp_path) == []
+
+
+def test_agent_trace_quarantines_crash_partial_tail_before_next_append(tmp_path: Path) -> None:
+    module = _load_module()
+    store = module.AgentTraceStore(tmp_path, run_id="run", agent="codex")
+    first = store.append("session_start")
+    with store.events_path.open("ab") as handle:
+        handle.write(b'{"partial"')
+
+    second = store.append("session_end", status="pass")
+
+    assert (first.sequence, second.sequence) == (1, 2)
+    assert [event.sequence for event in module.load_trace_events(tmp_path)] == [1, 2]
+    quarantined = list(tmp_path.glob(f".{module.EVENTS_FILENAME}.partial.*.jsonl"))
+    assert len(quarantined) == 1
+    assert quarantined[0].read_bytes() == b'{"partial"'
+    assert store.events_path.read_bytes().endswith(b"\n")
+
+
+def test_agent_trace_meta_publication_rolls_back_on_replace_failure(tmp_path: Path, monkeypatch) -> None:
+    module = _load_module()
+    monkeypatch.setattr(module.os, "replace", lambda *_args: (_ for _ in ()).throw(OSError("replace failed")))
+
+    with pytest.raises(OSError, match="replace failed"):
+        module.AgentTraceStore(tmp_path, run_id="run", agent="codex").initialize()
+
+    assert not (tmp_path / module.META_FILENAME).exists()
+    assert list(tmp_path.glob(f".{module.META_FILENAME}.*.tmp")) == []

--- a/test/test_analysis_page_helpers.py
+++ b/test/test_analysis_page_helpers.py
@@ -1,13 +1,22 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
+from contextlib import contextmanager
 import importlib.util
 import os
+import signal
+import subprocess
 import sys
+import threading
+import time
 import tomllib
 import types
 from pathlib import Path
 from types import SimpleNamespace
+
+import pytest
+import psutil
 
 
 MODULE_PATH = Path("src/agilab/pages/4_ANALYSIS.py")
@@ -108,6 +117,61 @@ def test_write_config_creates_parent_and_persists_toml(tmp_path: Path):
         "__meta__": {"schema": "agilab.app_settings.v1", "version": 1},
         "title": "demo",
     }
+
+
+def test_write_config_preserves_unowned_app_settings_sections(tmp_path: Path):
+    module = _load_analysis_module()
+    config_path = tmp_path / "app_settings.toml"
+    config_path.write_text(
+        "[cluster]\ncluster_enabled = false\nuser = \"agi\"\n\n"
+        "[pages]\nview_module = [\"old\"]\n",
+        encoding="utf-8",
+    )
+
+    module._write_config(
+        config_path,
+        {"pages": {"view_module": ["view_maps"]}},
+        keys=module._ANALYSIS_APP_SETTINGS_KEYS,
+    )
+
+    payload = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    assert payload["cluster"] == {"cluster_enabled": False, "user": "agi"}
+    assert payload["pages"] == {"view_module": ["view_maps"]}
+
+
+def test_write_config_applies_stale_snapshot_leaf_delta_to_latest_table(
+    tmp_path: Path,
+) -> None:
+    module = _load_analysis_module()
+    config_path = tmp_path / "app_settings.toml"
+    config_path.write_text(
+        "[pages]\nview_module = [\"old\"]\n\n"
+        "[pages.app_ui]\nentrypoint = \"concurrent.py\"\n",
+        encoding="utf-8",
+    )
+    previous = {
+        "pages": {
+            "view_module": ["old"],
+            "app_ui": {"entrypoint": "stale.py"},
+        }
+    }
+    updated = {
+        "pages": {
+            "view_module": ["view_maps"],
+            "app_ui": {"entrypoint": "stale.py"},
+        }
+    }
+
+    module._write_config(
+        config_path,
+        updated,
+        keys=module._ANALYSIS_APP_SETTINGS_KEYS,
+        previous=previous,
+    )
+
+    payload = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    assert payload["pages"]["view_module"] == ["view_maps"]
+    assert payload["pages"]["app_ui"] == {"entrypoint": "concurrent.py"}
 
 
 def test_write_config_reports_oserror(tmp_path: Path, monkeypatch):
@@ -983,7 +1047,6 @@ def test_ensure_notebook_sidecar_starts_lab_root_and_allows_iframe(tmp_path: Pat
     notebook_path.parent.mkdir(parents=True)
     notebook_path.write_text("{}", encoding="utf-8")
     commands: list[tuple[object, str, dict[str, str] | None]] = []
-    port_checks = iter([False, True])
 
     class _FakeProcess:
         returncode = None
@@ -991,7 +1054,13 @@ def test_ensure_notebook_sidecar_starts_lab_root_and_allows_iframe(tmp_path: Pat
         def poll(self):
             return None
 
-    fake_logger = SimpleNamespace(info=lambda *_args, **_kwargs: None, error=lambda *_args, **_kwargs: None)
+    log_messages: list[str] = []
+    fake_logger = SimpleNamespace(
+        info=lambda message, *args, **_kwargs: log_messages.append(
+            str(message) % args if args else str(message)
+        ),
+        error=lambda *_args, **_kwargs: None,
+    )
     fake_env = SimpleNamespace(
         envars={"127.0.0.1_CMD_PREFIX": 'export PATH="$HOME/.local/bin:$PATH";'},
         uv="uv --quiet",
@@ -1000,8 +1069,25 @@ def test_ensure_notebook_sidecar_starts_lab_root_and_allows_iframe(tmp_path: Pat
     )
     fake_st = SimpleNamespace(session_state={"env": fake_env})
 
+    registry_calls: list[dict[str, object]] = []
+
+    class FakeRegistry:
+        @staticmethod
+        def ensure(**kwargs):
+            registry_calls.append(dict(kwargs))
+            process = kwargs["launcher"](8766, kwargs.get("token") or "sidecar-token")
+            assert isinstance(process, _FakeProcess)
+            return SimpleNamespace(
+                endpoint="http://127.0.0.1:8766",
+                port=8766,
+                token="sidecar-token",
+                pid=123,
+                process_started_at=1.0,
+                health_signature="signed",
+            )
+
     monkeypatch.setattr(module, "st", fake_st)
-    monkeypatch.setattr(module, "_is_port_open", lambda _port: next(port_checks))
+    monkeypatch.setattr(module, "DEFAULT_SIDECAR_REGISTRY", FakeRegistry())
     monkeypatch.setattr(module, "_notebook_sidecar_token", lambda _key: "sidecar-token")
 
     def _fake_exec_bg(_env, cmd, cwd: str, process_env=None):
@@ -1038,6 +1124,9 @@ def test_ensure_notebook_sidecar_starts_lab_root_and_allows_iframe(tmp_path: Pat
         for part in command
     )
     assert not any("'" in part for part in command)
+    assert registry_calls[0]["key"] == str(project_root.resolve())
+    assert all("sidecar-token" not in message for message in log_messages)
+    assert any("<redacted>" in message for message in log_messages)
 
 
 def test_exec_bg_clears_parent_python_environment(tmp_path: Path, monkeypatch):
@@ -1075,6 +1164,47 @@ def test_exec_bg_clears_parent_python_environment(tmp_path: Path, monkeypatch):
     assert child_env["PATH"] == "/tool/bin"
     assert "PYTHONPATH" not in child_env
     assert "VIRTUAL_ENV" not in child_env
+
+
+def test_exec_bg_retains_owned_process_identity(tmp_path: Path, monkeypatch):
+    module = _load_analysis_module()
+    captured: dict[str, object] = {}
+
+    class _FakeProcess:
+        pid = 4242
+
+    def _fake_popen(command, **kwargs):
+        captured["command"] = command
+        captured.update(kwargs)
+        return _FakeProcess()
+
+    monkeypatch.setattr(module.subprocess, "Popen", _fake_popen)
+    fake_env = SimpleNamespace(
+        out_log=str(tmp_path / "prepare.log"),
+        err_log=str(tmp_path / "prepare.err"),
+    )
+
+    process = module.exec_bg(
+        fake_env,
+        ["uv", "sync"],
+        cwd=str(tmp_path),
+        owned_process_group=True,
+    )
+
+    assert process._agilab_owned_process_group is True
+    assert process._agilab_owned_process_token
+    assert isinstance(process._agilab_owned_process_started_at, float)
+    child_env = captured["env"]
+    assert (
+        child_env[module._ANALYSIS_PREPARATION_TOKEN_ENV]
+        == process._agilab_owned_process_token
+    )
+    if os.name == "nt":
+        assert process._agilab_owned_process_group_id is None
+        assert captured["creationflags"] == module.subprocess.CREATE_NEW_PROCESS_GROUP
+    else:
+        assert process._agilab_owned_process_group_id == process.pid
+        assert captured["start_new_session"] is True
 
 
 def test_source_bootstrap_stamp_invalidates_when_core_path_changes(tmp_path: Path):
@@ -1117,12 +1247,10 @@ def test_ensure_sidecar_skips_source_bootstrap_when_stamp_is_fresh(tmp_path: Pat
     module._write_source_bootstrap_stamp(project_root, core_root)
 
     commands: list[tuple[object, str, dict[str, str] | None]] = []
-    port_checks = iter([False, True])
-
     class _FakeProcess:
         returncode = None
 
-        def wait(self):
+        def wait(self, timeout=None):
             return 0
 
         def poll(self):
@@ -1143,8 +1271,31 @@ def test_ensure_sidecar_skips_source_bootstrap_when_stamp_is_fresh(tmp_path: Pat
     )
     fake_st = SimpleNamespace(session_state={"env": fake_env})
 
+    class FakeRegistry:
+        @staticmethod
+        def get(**_kwargs):
+            return None
+
+        @staticmethod
+        @contextmanager
+        def preparation_guard(**_kwargs):
+            yield
+
+        @staticmethod
+        def ensure(**kwargs):
+            process = kwargs["launcher"](8765, "unused-token")
+            assert isinstance(process, _FakeProcess)
+            return SimpleNamespace(
+                endpoint="http://127.0.0.1:8765",
+                port=8765,
+                token="unused-token",
+                pid=124,
+                process_started_at=2.0,
+                health_signature="signed",
+            )
+
     monkeypatch.setattr(module, "st", fake_st)
-    monkeypatch.setattr(module, "_is_port_open", lambda _port: next(port_checks))
+    monkeypatch.setattr(module, "DEFAULT_SIDECAR_REGISTRY", FakeRegistry())
 
     def _fake_exec_bg(_env, cmd, cwd: str, process_env=None):
         commands.append((cmd, cwd, process_env))
@@ -1171,6 +1322,140 @@ def test_ensure_sidecar_skips_source_bootstrap_when_stamp_is_fresh(tmp_path: Pat
     assert "ensurepip" not in command
     assert "pip" not in command
     assert not any("'" in part for part in command)
+
+
+def test_concurrent_analysis_sidecars_prepare_and_launch_project_once(
+    tmp_path: Path,
+    monkeypatch,
+):
+    module = _load_analysis_module()
+    project_root = tmp_path / "page_project"
+    (project_root / ".venv" / "bin").mkdir(parents=True)
+    (project_root / ".venv" / "bin" / "python").write_text("", encoding="utf-8")
+    (project_root / "pyproject.toml").write_text(
+        "[project]\nname='page-project'\n",
+        encoding="utf-8",
+    )
+    view_path = project_root / "src" / "view_demo.py"
+    view_path.parent.mkdir()
+    view_path.write_text("", encoding="utf-8")
+
+    commands: list[list[str]] = []
+    commands_lock = threading.Lock()
+
+    class _FakeProcess:
+        pid = 123
+
+        def wait(self, timeout=None):
+            return 0
+
+        def poll(self):
+            return None
+
+    logger = SimpleNamespace(
+        info=lambda *_args, **_kwargs: None,
+        warning=lambda *_args, **_kwargs: None,
+        error=lambda *_args, **_kwargs: None,
+    )
+    env = SimpleNamespace(
+        envars={},
+        uv="uv",
+        is_source_env=False,
+        AGILAB_LOG_ABS=tmp_path,
+        logger=logger,
+    )
+    monkeypatch.setattr(module, "st", SimpleNamespace(session_state={"env": env}))
+
+    class FakeRegistry:
+        def __init__(self):
+            self.guard = threading.Lock()
+            self.get_barrier = threading.Barrier(2)
+            self.get_calls = 0
+            self.get_calls_lock = threading.Lock()
+            self.lease = None
+            self.ensure_calls = 0
+
+        def get(self, **_kwargs):
+            with self.get_calls_lock:
+                self.get_calls += 1
+                call_number = self.get_calls
+                observed = self.lease
+            if call_number <= 2:
+                self.get_barrier.wait(timeout=5)
+            return observed
+
+        @contextmanager
+        def preparation_guard(self, **_kwargs):
+            with self.guard:
+                yield
+
+        def ensure(self, **kwargs):
+            self.ensure_calls += 1
+            kwargs["launcher"](8765, "unused-token")
+            self.lease = SimpleNamespace(
+                endpoint="http://127.0.0.1:8765",
+                port=8765,
+                token="unused-token",
+                pid=123,
+                process_started_at=1.0,
+                health_signature="signed",
+            )
+            return self.lease
+
+    registry = FakeRegistry()
+    monkeypatch.setattr(module, "DEFAULT_SIDECAR_REGISTRY", registry)
+
+    def _fake_exec_bg(_env, cmd, **_kwargs):
+        with commands_lock:
+            commands.append(list(cmd))
+        return _FakeProcess()
+
+    monkeypatch.setattr(module, "exec_bg", _fake_exec_bg)
+
+    results: list[bool] = []
+    result_lock = threading.Lock()
+
+    def _run() -> None:
+        result = module._ensure_sidecar(
+            "view-key",
+            view_path,
+            8765,
+            "flight_telemetry_project",
+        )
+        with result_lock:
+            results.append(result)
+
+    threads = [threading.Thread(target=_run) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert results == [True, True]
+    assert registry.ensure_calls == 1
+    assert sum("sync" in command for command in commands) == 1
+    assert sum("streamlit" in command for command in commands) == 1
+
+
+def test_atomic_sync_stamp_failure_preserves_previous_payload(
+    tmp_path: Path,
+    monkeypatch,
+):
+    module = _load_analysis_module()
+    destination = tmp_path / "stamp.json"
+    destination.write_text('{"old":true}', encoding="utf-8")
+
+    def _fail_replace(_source, _destination):
+        raise OSError("publication failed")
+
+    monkeypatch.setattr(module.os, "replace", _fail_replace)
+
+    with pytest.raises(OSError, match="publication failed"):
+        module._write_json_atomic(destination, {"new": True})
+
+    assert destination.read_text(encoding="utf-8") == '{"old":true}'
+    assert list(tmp_path.glob(".*.tmp")) == []
 
 
 def test_resolve_default_view_accepts_named_view(tmp_path: Path):
@@ -1575,12 +1860,16 @@ def test_initialize_analysis_env_uses_builtin_flight_for_query_shorthand(
     stored_apps: list[Path] = []
 
     class FakeAgiEnv:
-        for_app_calls: list[tuple[Path, str, int]] = []
+        session_for_app_calls: list[tuple[Path, str, int]] = []
 
         @classmethod
-        def for_app(cls, *, apps_path: Path, app: str, verbose: int):
-            cls.for_app_calls.append((apps_path, app, verbose))
+        def session_for_app(cls, *, apps_path: Path, app: str, verbose: int):
+            cls.session_for_app_calls.append((apps_path, app, verbose))
             return cls(apps_path=apps_path, app=app, verbose=verbose)
+
+        @classmethod
+        def for_app(cls, **_kwargs):
+            raise AssertionError("ANALYSIS must not borrow the process singleton")
 
         def __init__(self, *, apps_path: Path, app: str, verbose: int):
             self.apps_path = apps_path
@@ -1606,7 +1895,9 @@ def test_initialize_analysis_env_uses_builtin_flight_for_query_shorthand(
 
     assert env.apps_path == apps_path.resolve()
     assert env.app == "flight_telemetry_project"
-    assert FakeAgiEnv.for_app_calls == [(apps_path.resolve(), "flight_telemetry_project", 0)]
+    assert FakeAgiEnv.session_for_app_calls == [
+        (apps_path.resolve(), "flight_telemetry_project", 0)
+    ]
     assert fake_st.session_state["first_run"] is False
     assert fake_st.session_state["apps_path"] == str(apps_path.resolve())
     assert fake_st.session_state["app"] == "flight_telemetry_project"
@@ -1623,8 +1914,15 @@ def test_initialize_analysis_env_defaults_to_builtin_flight_telemetry_project(
     flight_telemetry_project.mkdir(parents=True)
 
     class FakeAgiEnv:
+        session_for_app_calls: list[tuple[Path, str, int]] = []
+
         @classmethod
         def for_app(cls, *, apps_path: Path, app: str, verbose: int):
+            raise AssertionError("analysis must not borrow the CLI singleton")
+
+        @classmethod
+        def session_for_app(cls, *, apps_path: Path, app: str, verbose: int):
+            cls.session_for_app_calls.append((apps_path, app, verbose))
             return cls(apps_path=apps_path, app=app, verbose=verbose)
 
         def __init__(self, *, apps_path: Path, app: str, verbose: int):
@@ -1651,6 +1949,9 @@ def test_initialize_analysis_env_defaults_to_builtin_flight_telemetry_project(
 
     assert env.apps_path == apps_path.resolve()
     assert env.app == "flight_telemetry_project"
+    assert FakeAgiEnv.session_for_app_calls == [
+        (apps_path.resolve(), "flight_telemetry_project", 0)
+    ]
     assert fake_st.session_state["first_run"] is False
 
 
@@ -2007,27 +2308,337 @@ def test_scan_analysis_artifacts_counts_supported_outputs(tmp_path: Path):
     assert summary["exists"] is True
 
 
-def test_terminate_process_quietly_ignores_timeout():
+def test_terminate_process_quietly_kills_and_reaps_after_timeout():
     module = _load_analysis_module()
 
     class _FakeProcess:
         def __init__(self):
             self.terminated = False
+            self.killed = False
             self.wait_calls = 0
+
+        def poll(self):
+            return None
 
         def terminate(self):
             self.terminated = True
 
+        def kill(self):
+            self.killed = True
+
         def wait(self, timeout: int):
             self.wait_calls += 1
-            raise module.subprocess.TimeoutExpired(cmd="demo", timeout=timeout)
+            if self.wait_calls == 1:
+                raise module.subprocess.TimeoutExpired(cmd="demo", timeout=timeout)
+            return -9
 
     process = _FakeProcess()
 
     module._terminate_process_quietly(process)
 
     assert process.terminated is True
-    assert process.wait_calls == 1
+    assert process.killed is True
+    assert process.wait_calls == 2
+
+
+def test_wait_owned_preparation_process_times_out_and_reaps(monkeypatch):
+    module = _load_analysis_module()
+
+    class _NeverFinishes:
+        def __init__(self):
+            self.terminated = False
+            self.reaped = False
+
+        def poll(self):
+            return None
+
+        def wait(self, timeout=None):
+            if not self.terminated:
+                raise module.subprocess.TimeoutExpired(cmd="uv sync", timeout=timeout)
+            self.reaped = True
+            return -15
+
+        def terminate(self):
+            self.terminated = True
+
+        def kill(self):
+            raise AssertionError("terminate should be sufficient")
+
+    process = _NeverFinishes()
+    monkeypatch.setattr(
+        module,
+        "_ANALYSIS_PREPARATION_PROCESS_TIMEOUT_SECONDS",
+        0.01,
+    )
+
+    with pytest.raises(RuntimeError, match="preparation timed out"):
+        module._wait_owned_preparation_process(process)
+
+    assert process.terminated is True
+    assert process.reaped is True
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX process-group regression")
+def test_terminate_process_quietly_stops_owned_descendant_tree(tmp_path):
+    module = _load_analysis_module()
+    child_pid_path = tmp_path / "child.pid"
+    parent_code = (
+        "import subprocess, sys, time\n"
+        "from pathlib import Path\n"
+        "child = subprocess.Popen([sys.executable, '-c', "
+        "'import time; time.sleep(30)'])\n"
+        f"Path({str(child_pid_path)!r}).write_text(str(child.pid), encoding='utf-8')\n"
+        "time.sleep(30)\n"
+    )
+    process = subprocess.Popen(
+        [sys.executable, "-c", parent_code],
+        start_new_session=True,
+    )
+    setattr(process, "_agilab_owned_process_group", True)
+    try:
+        deadline = time.monotonic() + 5
+        while not child_pid_path.exists():
+            if time.monotonic() >= deadline:
+                raise TimeoutError("descendant PID was not published")
+            time.sleep(0.01)
+        child_pid = int(child_pid_path.read_text(encoding="utf-8"))
+
+        module._terminate_process_quietly(process)
+
+        assert process.poll() is not None
+        try:
+            child = psutil.Process(child_pid)
+            child.wait(timeout=3)
+        except psutil.NoSuchProcess:
+            pass
+        else:
+            assert not child.is_running() or child.status() == psutil.STATUS_ZOMBIE
+    finally:
+        if process.poll() is None:
+            with contextlib.suppress(OSError):
+                os.killpg(process.pid, signal.SIGKILL)
+            process.wait(timeout=5)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX process-group regression")
+def test_wait_owned_preparation_process_stops_child_after_wrapper_exits(tmp_path):
+    module = _load_analysis_module()
+    child_pid_path = tmp_path / "detached-child.pid"
+    ownership_token = f"analysis-test-{os.getpid()}-{time.monotonic_ns()}"
+    parent_code = (
+        "import subprocess, sys\n"
+        "from pathlib import Path\n"
+        "child = subprocess.Popen([sys.executable, '-c', "
+        "'import time; time.sleep(30)'])\n"
+        f"Path({str(child_pid_path)!r}).write_text(str(child.pid), encoding='utf-8')\n"
+    )
+    process_env = dict(os.environ)
+    process_env[module._ANALYSIS_PREPARATION_TOKEN_ENV] = ownership_token
+    process = subprocess.Popen(
+        [sys.executable, "-c", parent_code],
+        start_new_session=True,
+        env=process_env,
+    )
+    setattr(process, "_agilab_owned_process_group", True)
+    setattr(process, "_agilab_owned_process_group_id", process.pid)
+    setattr(process, "_agilab_owned_process_token", ownership_token)
+    setattr(process, "_agilab_owned_process_started_at", time.time())
+    setattr(
+        process,
+        "_agilab_owned_process_username",
+        psutil.Process(os.getpid()).username(),
+    )
+    child_pid: int | None = None
+    try:
+        deadline = time.monotonic() + 5
+        while not child_pid_path.exists():
+            if time.monotonic() >= deadline:
+                raise TimeoutError("descendant PID was not published")
+            time.sleep(0.01)
+        child_pid = int(child_pid_path.read_text(encoding="utf-8"))
+        process.wait(timeout=5)
+        assert process.poll() == 0
+        assert psutil.Process(child_pid).is_running()
+
+        assert module._wait_owned_preparation_process(process) == 0
+
+        try:
+            child = psutil.Process(child_pid)
+            child.wait(timeout=3)
+        except psutil.NoSuchProcess:
+            pass
+        else:
+            assert not child.is_running() or child.status() == psutil.STATUS_ZOMBIE
+    finally:
+        if child_pid is not None:
+            with contextlib.suppress(psutil.NoSuchProcess):
+                child = psutil.Process(child_pid)
+                if child.is_running() and child.status() != psutil.STATUS_ZOMBIE:
+                    child.kill()
+                    child.wait(timeout=3)
+        with contextlib.suppress(OSError, subprocess.TimeoutExpired):
+            os.killpg(process.pid, signal.SIGKILL)
+            process.wait(timeout=5)
+
+
+def test_terminate_process_quietly_rejects_unreaped_parent_after_kill_timeout(
+    monkeypatch,
+):
+    module = _load_analysis_module()
+    monkeypatch.setattr(
+        module,
+        "_ANALYSIS_PREPARATION_TERMINATE_TIMEOUT_SECONDS",
+        0.01,
+    )
+
+    class _UnreapedProcess:
+        pid = 999_999_999
+
+        def __init__(self):
+            self.terminate_calls = 0
+            self.kill_calls = 0
+            self.wait_calls = 0
+
+        def poll(self):
+            return None
+
+        def terminate(self):
+            self.terminate_calls += 1
+
+        def kill(self):
+            self.kill_calls += 1
+
+        def wait(self, timeout=None):
+            self.wait_calls += 1
+            raise module.subprocess.TimeoutExpired(cmd="uv sync", timeout=timeout)
+
+    process = _UnreapedProcess()
+
+    with pytest.raises(RuntimeError, match="parent pid 999999999 was not reaped"):
+        module._terminate_process_quietly(process)
+
+    assert process.terminate_calls == 1
+    assert process.kill_calls == 1
+    assert process.wait_calls == 2
+
+
+def test_terminate_process_quietly_rejects_inaccessible_owned_token_candidate(
+    monkeypatch,
+):
+    module = _load_analysis_module()
+    started_at = time.time()
+
+    class _CompletedWrapper:
+        pid = 7001
+        _agilab_owned_process_group = False
+        _agilab_owned_process_token = "owned-token"
+        _agilab_owned_process_started_at = started_at
+        _agilab_owned_process_username = "analysis-owner"
+
+        @staticmethod
+        def poll():
+            return 0
+
+    class _InaccessibleCandidate:
+        pid = 7002
+
+        @staticmethod
+        def create_time():
+            return started_at
+
+        @staticmethod
+        def username():
+            return "analysis-owner"
+
+        def environ(self):
+            raise module.psutil.AccessDenied(self.pid)
+
+    monkeypatch.setattr(
+        module.psutil,
+        "process_iter",
+        lambda attrs: iter([_InaccessibleCandidate()]),
+    )
+
+    with pytest.raises(RuntimeError, match="ownership token unavailable.*7002"):
+        module._terminate_process_quietly(_CompletedWrapper())
+
+
+def test_analysis_preparation_interruption_terminates_and_reaps_owned_process(
+    tmp_path: Path,
+    monkeypatch,
+):
+    module = _load_analysis_module()
+    project_root = tmp_path / "page_project"
+    project_root.mkdir()
+    (project_root / "pyproject.toml").write_text(
+        "[project]\nname='page-project'\n",
+        encoding="utf-8",
+    )
+    view_path = project_root / "view_demo.py"
+    view_path.write_text("", encoding="utf-8")
+
+    class _InterruptedProcess:
+        def __init__(self):
+            self.terminated = False
+            self.reaped = False
+
+        def wait(self, timeout=None):
+            if not self.terminated:
+                raise KeyboardInterrupt
+            self.reaped = True
+            return -15
+
+        def poll(self):
+            return None
+
+        def terminate(self):
+            self.terminated = True
+
+        def kill(self):
+            raise AssertionError("terminate should be sufficient")
+
+    process = _InterruptedProcess()
+    guard_exited = False
+
+    class _Registry:
+        @staticmethod
+        def get(**_kwargs):
+            return None
+
+        @staticmethod
+        @contextmanager
+        def preparation_guard(**_kwargs):
+            nonlocal guard_exited
+            try:
+                yield
+            finally:
+                guard_exited = True
+
+    env = SimpleNamespace(
+        is_source_env=False,
+        logger=SimpleNamespace(
+            info=lambda *_args, **_kwargs: None,
+            warning=lambda *_args, **_kwargs: None,
+        ),
+    )
+    monkeypatch.setattr(module, "DEFAULT_SIDECAR_REGISTRY", _Registry())
+    monkeypatch.setattr(module, "exec_bg", lambda *_args, **_kwargs: process)
+
+    with pytest.raises(KeyboardInterrupt):
+        module._ensure_prepared_analysis_sidecar(
+            env=env,
+            view_page=view_path,
+            active_app="demo_project",
+            page_root=project_root,
+            project="demo_project",
+            registry_key="demo",
+            uv=["uv"],
+            uv_process_env={},
+        )
+
+    assert process.terminated is True
+    assert process.reaped is True
+    assert guard_exited is True
 
 
 def test_is_hosted_analysis_runtime_uses_agi_env_envars():
@@ -2132,3 +2743,92 @@ def main():
     asyncio.run(module._render_view_page_inline(page_path, str(active_app)))
 
     assert fake_streamlit.session_state["inline_active_app"] == str(active_app)
+
+
+def test_render_view_page_inline_fails_fast_and_restores_process_state(tmp_path: Path, monkeypatch):
+    module = _load_analysis_module()
+    coordination = types.ModuleType("agilab_inline_test_coordination")
+    monkeypatch.setitem(sys.modules, coordination.__name__, coordination)
+    slow_page = tmp_path / "slow_view.py"
+    slow_page.write_text(
+        """
+import agilab_inline_test_coordination as coordination
+
+async def main():
+    coordination.started.set()
+    await coordination.release.wait()
+""",
+        encoding="utf-8",
+    )
+    other_page = tmp_path / "other_view.py"
+    other_page.write_text("def main():\n    return None\n", encoding="utf-8")
+    failing_page = tmp_path / "failing_view.py"
+    failing_page.write_text(
+        "async def main():\n    raise RuntimeError('inline boom')\n",
+        encoding="utf-8",
+    )
+    original_argv = list(sys.argv)
+    original_path = list(sys.path)
+
+    async def exercise() -> None:
+        coordination.started = asyncio.Event()
+        coordination.release = asyncio.Event()
+        first = asyncio.create_task(
+            module._render_view_page_inline(slow_page, "alpha_project")
+        )
+        await asyncio.wait_for(coordination.started.wait(), timeout=2)
+        with pytest.raises(module.HostedAnalysisBusyError, match="Another hosted analysis"):
+            await module._render_view_page_inline(other_page, "beta_project")
+        coordination.release.set()
+        await asyncio.wait_for(first, timeout=2)
+
+        with pytest.raises(RuntimeError, match="inline boom"):
+            await module._render_view_page_inline(failing_page, "alpha_project")
+        # The failing render must release the lease for the next session.
+        await module._render_view_page_inline(other_page, "beta_project")
+
+    asyncio.run(exercise())
+
+    assert sys.argv == original_argv
+    assert sys.path == original_path
+
+
+def test_render_view_page_inline_isolates_transitive_helper_modules(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    module = _load_analysis_module()
+    coordination = types.ModuleType("agilab_inline_helper_coordination")
+    monkeypatch.setitem(sys.modules, coordination.__name__, coordination)
+    alpha_dir = tmp_path / "alpha"
+    beta_dir = tmp_path / "beta"
+    alpha_dir.mkdir()
+    beta_dir.mkdir()
+    alpha_helper = alpha_dir / "helper.py"
+    alpha_helper.write_text('VALUE = "alpha"\n', encoding="utf-8")
+    beta_helper = beta_dir / "helper.py"
+    beta_helper.write_text('VALUE = "beta"\n', encoding="utf-8")
+    beta_page = beta_dir / "view.py"
+    beta_page.write_text(
+        "import helper\n"
+        "import agilab_inline_helper_coordination as coordination\n\n"
+        "def main():\n"
+        "    coordination.value = helper.VALUE\n",
+        encoding="utf-8",
+    )
+    helper_spec = importlib.util.spec_from_file_location("helper", alpha_helper)
+    assert helper_spec is not None and helper_spec.loader is not None
+    original_helper = importlib.util.module_from_spec(helper_spec)
+    helper_spec.loader.exec_module(original_helper)
+    monkeypatch.setitem(sys.modules, "helper", original_helper)
+    inline_modules_before = {
+        name for name in sys.modules if name.startswith("agilab_analysis_inline_")
+    }
+
+    asyncio.run(module._render_view_page_inline(beta_page, "beta_project"))
+
+    assert coordination.value == "beta"
+    assert sys.modules["helper"] is original_helper
+    assert {
+        name for name in sys.modules if name.startswith("agilab_analysis_inline_")
+    } == inline_modules_before

--- a/test/test_app_surface.py
+++ b/test/test_app_surface.py
@@ -1,11 +1,17 @@
 from __future__ import annotations
 
+import builtins
 import importlib.util
 import sys
+import threading
+import time
 from pathlib import Path
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
+
+import pytest
 
 MODULE_PATH = Path("src/agilab/app_surface.py")
+IMPLEMENTATION_MODULE_PATH = Path("src/agilab/app_management/app_surface.py")
 
 
 def _load_app_surface_module():
@@ -15,6 +21,30 @@ def _load_app_surface_module():
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)
     return module
+
+
+def test_base_app_surface_import_does_not_require_optional_agi_env(
+    monkeypatch,
+) -> None:
+    real_import = builtins.__import__
+
+    def _without_agi_env(name, *args, **kwargs):
+        if name == "agi_env" or name.startswith("agi_env."):
+            raise ModuleNotFoundError("No module named 'agi_env'", name="agi_env")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _without_agi_env)
+    spec = importlib.util.spec_from_file_location(
+        "agilab_app_surface_base_import_test",
+        IMPLEMENTATION_MODULE_PATH,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+
+    with pytest.raises(ModuleNotFoundError, match=r"agilab\[ui\]"):
+        module._isolated_import_process_state()
 
 
 def _write_app_surface_project(tmp_path: Path) -> Path:
@@ -156,6 +186,103 @@ def test_render_app_surface_calls_project_render_hook_and_restores_argv(tmp_path
         }
     ]
     assert sys.argv == before_argv
+
+
+def test_render_app_surface_serializes_and_restores_project_import_state(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    module = _load_app_surface_module()
+    coordination = ModuleType("agilab_app_surface_test_coordination")
+    coordination.lock = threading.Lock()
+    coordination.alpha_started = threading.Event()
+    coordination.release_alpha = threading.Event()
+    coordination.records = []
+    coordination.active = 0
+    coordination.max_active = 0
+
+    def _enter(value: str, argv: list[str]) -> None:
+        with coordination.lock:
+            coordination.active += 1
+            coordination.max_active = max(
+                coordination.max_active,
+                coordination.active,
+            )
+            coordination.records.append((value, list(argv)))
+        if value == "alpha":
+            coordination.alpha_started.set()
+            assert coordination.release_alpha.wait(timeout=5)
+
+    def _exit() -> None:
+        with coordination.lock:
+            coordination.active -= 1
+
+    coordination.enter = _enter
+    coordination.exit = _exit
+    monkeypatch.setitem(sys.modules, coordination.__name__, coordination)
+
+    apps: list[tuple[Path, Path]] = []
+    for app_name in ("alpha", "beta"):
+        active_app = tmp_path / f"{app_name}_project"
+        source_root = active_app / "src"
+        source_root.mkdir(parents=True)
+        (source_root / "helper.py").write_text(
+            f'VALUE = "{app_name}"\n',
+            encoding="utf-8",
+        )
+        entrypoint = source_root / "app_surface.py"
+        entrypoint.write_text(
+            "import sys\n"
+            "import helper\n"
+            "import agilab_app_surface_test_coordination as coordination\n\n"
+            "def render(**_kwargs):\n"
+            "    coordination.enter(helper.VALUE, sys.argv)\n"
+            "    coordination.exit()\n",
+            encoding="utf-8",
+        )
+        apps.append((entrypoint, active_app))
+
+    original_argv = list(sys.argv)
+    original_path = list(sys.path)
+    original_helper = sys.modules.get("helper")
+    errors: list[BaseException] = []
+
+    def _render(entrypoint: Path, active_app: Path) -> None:
+        try:
+            assert module.render_app_surface(
+                active_app,
+                mode="analysis",
+                config={"app_surface": {"entrypoint": entrypoint.name}},
+            )
+        except BaseException as exc:  # pragma: no cover - asserted below
+            errors.append(exc)
+
+    first = threading.Thread(target=_render, args=apps[0])
+    second = threading.Thread(target=_render, args=apps[1])
+    first.start()
+    assert coordination.alpha_started.wait(timeout=5)
+    second.start()
+    time.sleep(0.05)
+    assert coordination.max_active == 1
+    coordination.release_alpha.set()
+    first.join(timeout=5)
+    second.join(timeout=5)
+
+    assert all(not worker.is_alive() for worker in (first, second))
+    assert errors == []
+    assert [record[0] for record in coordination.records] == ["alpha", "beta"]
+    for (entrypoint, active_app), (_value, argv) in zip(
+        apps,
+        coordination.records,
+    ):
+        assert argv == [str(entrypoint), "--active-app", str(active_app)]
+    assert coordination.max_active == 1
+    assert sys.argv == original_argv
+    assert sys.path == original_path
+    assert sys.modules.get("helper") is original_helper
+    assert not any(
+        name.startswith("_agilab_app_surface_") for name in sys.modules
+    )
 
 
 def test_app_surface_config_and_selection_edge_cases(tmp_path: Path) -> None:

--- a/test/test_app_ui_concurrency.py
+++ b/test/test_app_ui_concurrency.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import threading
+import time
+from pathlib import Path
+from types import ModuleType
+
+
+APP_UI_PATH = Path(
+    "src/agilab/apps-pages/app_ui/src/app_ui/app_ui.py"
+)
+
+
+def _load_app_ui_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "agilab_app_ui_concurrency_test_module",
+        APP_UI_PATH,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_run_app_ui_serializes_and_restores_process_import_state(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    module = _load_app_ui_module()
+    coordination = ModuleType("agilab_app_ui_test_coordination")
+    coordination.lock = threading.Lock()
+    coordination.alpha_started = threading.Event()
+    coordination.release_alpha = threading.Event()
+    coordination.records = []
+    coordination.active = 0
+    coordination.max_active = 0
+
+    def _enter(value: str, argv: list[str]) -> None:
+        with coordination.lock:
+            coordination.active += 1
+            coordination.max_active = max(
+                coordination.max_active,
+                coordination.active,
+            )
+            coordination.records.append((value, list(argv)))
+        if value == "alpha":
+            coordination.alpha_started.set()
+            assert coordination.release_alpha.wait(timeout=5)
+
+    def _exit() -> None:
+        with coordination.lock:
+            coordination.active -= 1
+
+    coordination.enter = _enter
+    coordination.exit = _exit
+    monkeypatch.setitem(sys.modules, coordination.__name__, coordination)
+
+    apps: list[tuple[Path, Path]] = []
+    for app_name in ("alpha", "beta"):
+        active_app = tmp_path / f"{app_name}_project"
+        source_root = active_app / "src"
+        source_root.mkdir(parents=True)
+        (source_root / "helper.py").write_text(
+            f'VALUE = "{app_name}"\n',
+            encoding="utf-8",
+        )
+        entrypoint = source_root / "app_ui_entry.py"
+        entrypoint.write_text(
+            "import sys\n"
+            "import helper\n"
+            "import agilab_app_ui_test_coordination as coordination\n\n"
+            "def main():\n"
+            "    coordination.enter(helper.VALUE, sys.argv)\n"
+            "    coordination.exit()\n",
+            encoding="utf-8",
+        )
+        apps.append((entrypoint, active_app))
+
+    original_argv = list(sys.argv)
+    original_path = list(sys.path)
+    original_helper = sys.modules.get("helper")
+    errors: list[BaseException] = []
+
+    def _run(entrypoint: Path, active_app: Path) -> None:
+        try:
+            module._run_app_ui(entrypoint, active_app)
+        except BaseException as exc:  # pragma: no cover - asserted below
+            errors.append(exc)
+
+    first = threading.Thread(target=_run, args=apps[0])
+    second = threading.Thread(target=_run, args=apps[1])
+    first.start()
+    assert coordination.alpha_started.wait(timeout=5)
+    second.start()
+    time.sleep(0.05)
+    assert coordination.max_active == 1
+    coordination.release_alpha.set()
+    first.join(timeout=5)
+    second.join(timeout=5)
+
+    assert errors == []
+    assert [record[0] for record in coordination.records] == ["alpha", "beta"]
+    for (entrypoint, active_app), (_value, argv) in zip(
+        apps,
+        coordination.records,
+    ):
+        assert argv == [str(entrypoint), "--active-app", str(active_app)]
+    assert coordination.max_active == 1
+    assert sys.argv == original_argv
+    assert sys.path == original_path
+    assert sys.modules.get("helper") is original_helper

--- a/test/test_apps_pages_docs.py
+++ b/test/test_apps_pages_docs.py
@@ -86,6 +86,22 @@ def test_view_prefix_remains_the_generic_page_family() -> None:
         assert "autoencoder_latentspace" in text
 
 
+def test_apps_pages_never_borrow_the_process_agienv_singleton() -> None:
+    source_files = sorted(APPS_PAGES_ROOT.rglob("*.py"))
+    offenders: list[str] = []
+    for source_file in source_files:
+        source = source_file.read_text(encoding="utf-8", errors="ignore")
+        if (
+            "AgiEnv.for_app(" in source
+            or 'getattr(AgiEnv, "for_app"' in source
+            or "AgiEnv.current()" in source
+            or "AgiEnv(" in source
+        ):
+            offenders.append(str(source_file.relative_to(REPO_ROOT)))
+
+    assert offenders == []
+
+
 def test_barycentric_dataframe_selector_avoids_session_state_double_init() -> None:
     source = (
         APPS_PAGES_ROOT

--- a/test/test_autoencoder_latentspace.py
+++ b/test/test_autoencoder_latentspace.py
@@ -576,8 +576,11 @@ def test_page_persistence_tolerates_invalid_settings_and_write_failures(monkeypa
         lambda X_train, ndim, ndim_inter, ndim_middle: SimpleNamespace(layers=["enc1", "enc2", "latent", "dec1", "dec2"]),
     )
     monkeypatch.setattr(module, "__bary_visualisation", lambda *args, **kwargs: None)
-    monkeypatch.setattr(module.Path, "mkdir", lambda *args, **kwargs: None, raising=False)
-    monkeypatch.setattr(module, "open", lambda *args, **kwargs: (_ for _ in ()).throw(OSError("disk full")), raising=False)
+    monkeypatch.setattr(
+        module,
+        "_dump_toml_payload",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("disk full")),
+    )
     monkeypatch.setattr(
         module,
         "st",
@@ -779,6 +782,10 @@ def test_main_resets_page_state_when_active_app_changes(monkeypatch, tmp_path: P
             self.projects = ["new_autoencoder_project"]
             self.app_settings_file = tmp_path / "new_settings.toml"
             self.init_done = False
+
+        @classmethod
+        def session_for_app(cls, *, apps_path, app, verbose):
+            return cls(apps_path, app, verbose)
 
     session_state = _State(
         {

--- a/test/test_cluster_flight_validation.py
+++ b/test/test_cluster_flight_validation.py
@@ -332,8 +332,13 @@ def test_remote_env_update_script_enables_cluster_mode_without_clobbering_env(tm
         environ={"USER": "agi"},
     )
 
+    script = cfv._remote_env_update_script(plan)
+    assert 'env_path.name + ".lock"' in script
+    assert "tempfile.mkstemp" in script
+    assert "os.replace" in script
+
     subprocess.run(
-        [sys.executable, "-c", cfv._remote_env_update_script(plan)],
+        [sys.executable, "-c", script],
         check=True,
         env={**os.environ, "HOME": str(tmp_path)},
         text=True,

--- a/test/test_dag_distributed_submitter.py
+++ b/test/test_dag_distributed_submitter.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import builtins
 import importlib.util
 import json
 import subprocess
@@ -161,6 +162,40 @@ workers_data_path = "clustershare/agi"
     assert merged["cluster"]["workers"] == {"127.0.0.1": 1}
 
 
+def test_load_distributed_settings_uses_stdlib_without_optional_agi_env(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    settings_file = tmp_path / "app_settings.toml"
+    settings_file.write_text(
+        '[cluster]\ncluster_enabled = true\nscheduler = "127.0.0.1:8786"\n',
+        encoding="utf-8",
+    )
+    real_import = builtins.__import__
+
+    def _without_agi_env(name, *args, **kwargs):
+        if name.startswith("agi_env"):
+            raise ModuleNotFoundError(
+                "No module named 'agi_env'",
+                name="agi_env",
+            )
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _without_agi_env)
+
+    loaded = dag_distributed_submitter.load_dag_distributed_settings(
+        SimpleNamespace(app_settings_file=settings_file),
+        None,
+    )
+
+    assert loaded == {
+        "cluster": {
+            "cluster_enabled": True,
+            "scheduler": "127.0.0.1:8786",
+        }
+    }
+
+
 def test_build_global_submitter_runs_configured_runner(tmp_path: Path) -> None:
     repo_root = tmp_path / "repo"
     _write_app(repo_root, "src/agilab/apps/builtin", "flight_telemetry_project")
@@ -194,9 +229,14 @@ def test_build_global_submitter_runs_configured_runner(tmp_path: Path) -> None:
         artifact={"artifact": "stage_result"},
         execution_contract={"params": {}, "stages": []},
         timestamp="2026-05-07T00:00:00Z",
+        idempotency_token="factory-attempt:flight_context",
     )
 
     assert calls[0]["config"].verbose == 3
+    assert calls[0]["idempotency_token"] == "factory-attempt:flight_context"
+    assert calls[0]["request_payload"]["idempotency_token"] == (
+        "factory-attempt:flight_context"
+    )
     assert result["summary_metrics"]["factory_runner"] == 1
 
 
@@ -239,21 +279,55 @@ def test_submit_distributed_stage_runs_fake_runner_and_writes_evidence(tmp_path:
             "stages": [{"name": "prepare", "args": {"n": 2}}],
         },
         timestamp="2026-05-07T00:00:00Z",
+        idempotency_token="distributed-attempt:flight_context",
+    )
+    duplicate = dag_distributed_submitter.submit_distributed_stage(
+        config=config,
+        runner_fn=_runner,
+        repo_root=repo_root,
+        lab_dir=tmp_path / "lab",
+        run_root=tmp_path / "lab/.agilab/multi_app_dag_real_runs/flight_context",
+        unit={"id": "flight_context", "app": "flight_telemetry_project"},
+        artifact={
+            "artifact": "flight_reduce_summary",
+            "kind": "reduce_summary",
+            "path": "flight/reduce.json",
+        },
+        execution_contract={
+            "entrypoint": "flight_telemetry_project.flight_context",
+            "params": {"scenario": "demo"},
+            "stages": [{"name": "prepare", "args": {"n": 2}}],
+        },
+        timestamp="2026-05-07T00:00:00Z",
+        idempotency_token="distributed-attempt:flight_context",
     )
 
     assert len(calls) == 1
+    assert duplicate == result
     assert calls[0]["apps_path"] == repo_root / "src/agilab/apps/builtin"
     assert calls[0]["app_name"] == "flight_telemetry_project"
     assert calls[0]["request_payload"]["params"] == {"scenario": "demo"}
     assert calls[0]["request_payload"]["stages"] == [{"name": "prepare", "args": {"n": 2}}]
+    assert calls[0]["request_payload"]["idempotency_token"] == (
+        "distributed-attempt:flight_context"
+    )
+    assert calls[0]["idempotency_token"] == "distributed-attempt:flight_context"
     evidence_path = Path(result["submission_evidence_path"])
     evidence = json.loads(evidence_path.read_text(encoding="utf-8"))
     assert evidence["schema"] == "agilab.distributed_dag_stage_submission.v1"
     assert evidence["app"] == "flight_telemetry_project"
+    assert evidence["idempotency_token"] == "distributed-attempt:flight_context"
+    assert evidence["request_payload"]["idempotency_token"] == (
+        "distributed-attempt:flight_context"
+    )
     assert evidence["cluster"]["worker_nodes"] == 2
     assert result["reduce_artifact_path"] == str(evidence_path)
     assert result["summary_metrics"]["worker_slots"] == 3
     assert result["summary_metrics"]["runner_confirmed"] == 1
+    assert result["idempotency_token"] == "distributed-attempt:flight_context"
+    assert result["distributed_submission"]["idempotency_token"] == (
+        "distributed-attempt:flight_context"
+    )
 
     non_mapping_result = dag_distributed_submitter.submit_distributed_stage(
         config=config,
@@ -265,6 +339,7 @@ def test_submit_distributed_stage_runs_fake_runner_and_writes_evidence(tmp_path:
         artifact={"artifact": "default_metrics"},
         execution_contract={},
         timestamp="2026-05-07T00:00:01Z",
+        idempotency_token="distributed-attempt:default_metrics",
     )
     assert non_mapping_result["summary_metrics"] == {
         "stage_completed": 1,
@@ -402,6 +477,7 @@ def test_submit_distributed_stage_rejects_missing_or_unknown_app(tmp_path: Path)
             artifact={},
             execution_contract={},
             timestamp="2026-05-07T00:00:00Z",
+            idempotency_token="bad-attempt:bad_stage",
         )
 
     with pytest.raises(RuntimeError, match="was not found"):
@@ -457,8 +533,11 @@ def test_tail_file_trims_and_handles_unreadable_paths(tmp_path: Path) -> None:
 
 def test_stage_subprocess_runner_generates_isolated_agilab_run_script(monkeypatch, tmp_path: Path) -> None:
     captured: dict[str, object] = {}
+    call_count = 0
 
     def _fake_run(command, **kwargs):
+        nonlocal call_count
+        call_count += 1
         captured["command"] = command
         captured["kwargs"] = kwargs
         kwargs["stdout"].write('{"result": "ok"}\n')
@@ -481,6 +560,17 @@ def test_stage_subprocess_runner_generates_isolated_agilab_run_script(monkeypatc
         app_name="flight_telemetry_project",
         request_payload={"params": {}, "stages": []},
         timestamp="2026-05-07T00:00:00Z",
+        idempotency_token="subprocess-attempt:flight_context",
+    )
+    duplicate = dag_distributed_submitter.run_agilab_stage_subprocess(
+        config=config,
+        repo_root=tmp_path,
+        run_root=tmp_path / "run",
+        apps_path=tmp_path / "src/agilab/apps/builtin",
+        app_name="flight_telemetry_project",
+        request_payload={"params": {}, "stages": []},
+        timestamp="2026-05-07T00:00:00Z",
+        idempotency_token="subprocess-attempt:flight_context",
     )
 
     script = (tmp_path / "run/run_distributed_stage.py").read_text(encoding="utf-8")
@@ -488,6 +578,10 @@ def test_stage_subprocess_runner_generates_isolated_agilab_run_script(monkeypatc
     assert "modes_enabled=7" in script
     assert "await AGI.run(app_env, request=request)" in script
     assert "workers_data_path='clustershare/agi'" in script
+    assert 'os.environ["AGILAB_IDEMPOTENCY_TOKEN"]' in script
+    assert captured["kwargs"]["env"]["AGILAB_IDEMPOTENCY_TOKEN"] == (
+        "subprocess-attempt:flight_context"
+    )
     assert captured["command"][0] == sys.executable
     assert captured["kwargs"]["stdout"] is not subprocess.PIPE
     assert captured["kwargs"]["stderr"] is not subprocess.PIPE
@@ -498,6 +592,9 @@ def test_stage_subprocess_runner_generates_isolated_agilab_run_script(monkeypatc
     assert result["stdout_tail"] == '{"result": "ok"}\n'
     assert result["stdout_log"].endswith("distributed_stage.stdout.log")
     assert result["stderr_log"].endswith("distributed_stage.stderr.log")
+    assert result["idempotency_token"] == "subprocess-attempt:flight_context"
+    assert duplicate == result
+    assert call_count == 1
 
 
 def test_stage_subprocess_runner_streams_worker_logs_before_completion(monkeypatch, tmp_path: Path) -> None:
@@ -547,6 +644,7 @@ def test_stage_subprocess_runner_streams_worker_logs_before_completion(monkeypat
         app_name="flight_telemetry_project",
         request_payload={"params": {}, "stages": []},
         timestamp="2026-05-07T00:00:00Z",
+        idempotency_token="stream-attempt:flight_context",
     )
 
     assert streamed_before_return == {"stdout": True, "stderr": True}
@@ -592,6 +690,7 @@ def test_stage_subprocess_runner_rejects_null_or_error_results(
             app_name="flight_telemetry_project",
             request_payload={"params": {}, "stages": []},
             timestamp="2026-05-07T00:00:00Z",
+            idempotency_token="failure-attempt:flight_context",
         )
 
     script = (tmp_path / "run/run_distributed_stage.py").read_text(encoding="utf-8")
@@ -620,6 +719,7 @@ def test_stage_subprocess_runner_raises_with_trimmed_failure(monkeypatch, tmp_pa
             app_name="flight_telemetry_project",
             request_payload={},
             timestamp="2026-05-07T00:00:00Z",
+            idempotency_token="exit-attempt:flight_context",
         )
 
     message = str(err.value)

--- a/test/test_dag_execution_adapters.py
+++ b/test/test_dag_execution_adapters.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 from pathlib import Path
 import subprocess
 import sys
@@ -54,7 +55,7 @@ def test_adapter_registry_exposes_uav_queue_to_relay_adapter():
 
 
 def test_adapter_dispatch_reports_unknown_adapter(tmp_path):
-    result = dag_execution_adapters.run_next_adapter_stage(
+    result = dag_execution_adapters._run_next_adapter_stage_uncommitted(
         "missing-adapter",
         {"units": []},
         dag_execution_adapters.DagExecutionContext(repo_root=Path.cwd(), lab_dir=tmp_path),
@@ -66,7 +67,7 @@ def test_adapter_dispatch_reports_unknown_adapter(tmp_path):
 
 
 def test_ready_adapter_dispatch_reports_unknown_adapter(tmp_path):
-    result = dag_execution_adapters.run_ready_adapter_stages(
+    result = dag_execution_adapters._run_ready_adapter_stages_uncommitted(
         "missing-adapter",
         {"units": []},
         dag_execution_adapters.DagExecutionContext(repo_root=Path.cwd(), lab_dir=tmp_path),
@@ -74,6 +75,44 @@ def test_ready_adapter_dispatch_reports_unknown_adapter(tmp_path):
 
     assert not result.ok
     assert "No DAG execution adapter is registered" in result.message
+
+
+def test_public_adapter_entrypoints_cannot_accept_a_forged_claim_receipt(tmp_path):
+    callback_count = 0
+
+    def _unexpected_callback(**_kwargs):
+        nonlocal callback_count
+        callback_count += 1
+        return {}
+
+    context = dag_execution_adapters.DagExecutionContext(
+        repo_root=Path.cwd(),
+        lab_dir=tmp_path,
+        run_queue_fn=_unexpected_callback,
+        execution_attempt_id="forged-receipt",
+        persist_execution_claim_fn=lambda _state: (
+            dag_execution_adapters._DURABLE_CLAIM_RECEIPT
+        ),
+    )
+    with pytest.raises(RuntimeError, match="Direct DAG adapter execution is disabled"):
+        dag_execution_adapters.run_next_adapter_stage(
+            "uav_queue_to_relay_controlled",
+            {"units": []},
+            context,
+        )
+    with pytest.raises(RuntimeError, match="Direct DAG adapter batch execution is disabled"):
+        dag_execution_adapters.run_ready_adapter_stages(
+            "controlled_contract_dag",
+            {"units": []},
+            context,
+        )
+    assert not hasattr(dag_execution_adapters, "UavQueueToRelayExecutionAdapter")
+    assert not hasattr(dag_execution_adapters, "ControlledContractDagExecutionAdapter")
+    assert not hasattr(dag_execution_adapters, "DAG_EXECUTION_ADAPTERS_BY_ID")
+    for adapter in dag_execution_adapters._DAG_EXECUTION_ADAPTERS_BY_ID.values():
+        assert not hasattr(adapter, "run_next")
+
+    assert callback_count == 0
 
 
 def test_controlled_contract_adapter_executes_declared_contract_stages(tmp_path):
@@ -135,11 +174,19 @@ def test_controlled_contract_adapter_executes_declared_contract_stages(tmp_path)
         repo_root=Path.cwd(),
         lab_dir=tmp_path,
         now_fn=lambda: "2026-05-07T00:00:00Z",
+        execution_attempt_id="contract-sequence",
+        persist_execution_claim_fn=lambda _state: dag_execution_adapters._DURABLE_CLAIM_RECEIPT,
     )
 
-    first = dag_execution_adapters.run_next_adapter_stage("controlled_contract_dag", state, context)
-    second = dag_execution_adapters.run_next_adapter_stage("controlled_contract_dag", first.state, context)
-    third = dag_execution_adapters.run_next_adapter_stage("controlled_contract_dag", second.state, context)
+    first = dag_execution_adapters._run_next_adapter_stage_uncommitted(
+        "controlled_contract_dag", state, context
+    )
+    second = dag_execution_adapters._run_next_adapter_stage_uncommitted(
+        "controlled_contract_dag", first.state, context
+    )
+    third = dag_execution_adapters._run_next_adapter_stage_uncommitted(
+        "controlled_contract_dag", second.state, context
+    )
 
     assert first.ok
     assert first.executed_unit_id == "extract_context"
@@ -171,7 +218,13 @@ def test_controlled_contract_adapter_executes_declared_contract_stages(tmp_path)
 def test_controlled_contract_adapter_uses_entrypoint_runner(tmp_path):
     calls: list[Path] = []
 
-    def _runner(*, repo_root: Path, run_root: Path) -> dict[str, object]:
+    def _runner(
+        *,
+        repo_root: Path,
+        run_root: Path,
+        idempotency_token: str,
+    ) -> dict[str, object]:
+        assert idempotency_token == "custom-runner:extract_context"
         calls.append(run_root)
         return {
             "summary_metrics_path": "alpha/summary.json",
@@ -211,9 +264,13 @@ def test_controlled_contract_adapter_uses_entrypoint_runner(tmp_path):
         lab_dir=tmp_path,
         stage_run_fns={"alpha.extract_context": _runner},
         now_fn=lambda: "2026-05-07T00:00:00Z",
+        execution_attempt_id="custom-runner",
+        persist_execution_claim_fn=lambda _state: dag_execution_adapters._DURABLE_CLAIM_RECEIPT,
     )
 
-    result = dag_execution_adapters.run_next_adapter_stage("controlled_contract_dag", state, context)
+    result = dag_execution_adapters._run_next_adapter_stage_uncommitted(
+        "controlled_contract_dag", state, context
+    )
 
     assert result.ok
     assert calls == [tmp_path / ".agilab" / "multi_app_dag_real_runs" / "extract_context"]
@@ -260,9 +317,13 @@ def test_controlled_contract_adapter_runs_declared_command(tmp_path):
         repo_root=Path.cwd(),
         lab_dir=tmp_path,
         now_fn=lambda: "2026-05-07T00:00:00Z",
+        execution_attempt_id="command-runner",
+        persist_execution_claim_fn=lambda _state: dag_execution_adapters._DURABLE_CLAIM_RECEIPT,
     )
 
-    result = dag_execution_adapters.run_next_adapter_stage("controlled_contract_dag", state, context)
+    result = dag_execution_adapters._run_next_adapter_stage_uncommitted(
+        "controlled_contract_dag", state, context
+    )
 
     assert result.ok
     artifact_path = tmp_path / ".agilab" / "multi_app_dag_real_runs" / "extract_context" / "context" / "context.json"
@@ -284,7 +345,7 @@ def test_controlled_contract_adapter_rejects_stage_without_execution_contract(tm
         "summary": {},
     }
 
-    result = dag_execution_adapters.run_next_adapter_stage(
+    result = dag_execution_adapters._run_next_adapter_stage_uncommitted(
         "controlled_contract_dag",
         state,
         dag_execution_adapters.DagExecutionContext(repo_root=Path.cwd(), lab_dir=tmp_path),
@@ -295,7 +356,7 @@ def test_controlled_contract_adapter_rejects_stage_without_execution_contract(tm
 
 
 def test_uav_queue_adapter_reports_missing_required_stages(tmp_path):
-    result = dag_execution_adapters.run_next_adapter_stage(
+    result = dag_execution_adapters._run_next_adapter_stage_uncommitted(
         "uav_queue_to_relay_controlled",
         {"units": [{"id": "queue_baseline", "dispatch_status": "runnable"}]},
         dag_execution_adapters.DagExecutionContext(repo_root=Path.cwd(), lab_dir=tmp_path),
@@ -330,7 +391,9 @@ def test_uav_queue_adapter_runs_blocked_relay_from_available_artifact(tmp_path):
         repo_root: Path,
         run_root: Path,
         queue_result: dict[str, object],
+        idempotency_token: str,
     ) -> dict[str, object]:
+        assert idempotency_token == "relay-run:relay_followup"
         relay_calls.append({"run_root": run_root, "queue_result": queue_result})
         return {
             "summary_metrics_path": "relay/summary.json",
@@ -338,7 +401,7 @@ def test_uav_queue_adapter_runs_blocked_relay_from_available_artifact(tmp_path):
             "summary_metrics": {"packets_generated": 2, "packets_delivered": 2},
         }
 
-    result = dag_execution_adapters.run_next_adapter_stage(
+    result = dag_execution_adapters._run_next_adapter_stage_uncommitted(
         "uav_queue_to_relay_controlled",
         state,
         dag_execution_adapters.DagExecutionContext(
@@ -346,6 +409,8 @@ def test_uav_queue_adapter_runs_blocked_relay_from_available_artifact(tmp_path):
             lab_dir=tmp_path,
             run_relay_fn=_relay_run,
             now_fn=lambda: "2026-05-07T00:00:00Z",
+            execution_attempt_id="relay-run",
+            persist_execution_claim_fn=lambda _state: dag_execution_adapters._DURABLE_CLAIM_RECEIPT,
         ),
     )
 
@@ -372,7 +437,7 @@ def test_uav_queue_adapter_reports_no_ready_stage(tmp_path):
         "summary": {},
     }
 
-    result = dag_execution_adapters.run_next_adapter_stage(
+    result = dag_execution_adapters._run_next_adapter_stage_uncommitted(
         "uav_queue_to_relay_controlled",
         state,
         dag_execution_adapters.DagExecutionContext(repo_root=Path.cwd(), lab_dir=tmp_path),
@@ -398,7 +463,7 @@ def test_controlled_contract_adapter_reports_no_ready_stage(tmp_path):
         "summary": {},
     }
 
-    result = dag_execution_adapters.run_next_adapter_stage(
+    result = dag_execution_adapters._run_next_adapter_stage_uncommitted(
         "controlled_contract_dag",
         state,
         dag_execution_adapters.DagExecutionContext(repo_root=Path.cwd(), lab_dir=tmp_path),
@@ -409,7 +474,7 @@ def test_controlled_contract_adapter_reports_no_ready_stage(tmp_path):
     assert result.state["run_status"] == "completed"
 
 
-def test_controlled_contract_adapter_records_command_failure(tmp_path):
+def test_controlled_contract_command_failure_requires_exact_token_recovery(tmp_path):
     state = {
         "created_at": "2026-05-07T00:00:00Z",
         "units": [
@@ -427,35 +492,48 @@ def test_controlled_contract_adapter_records_command_failure(tmp_path):
         "summary": {},
     }
 
-    result = dag_execution_adapters.run_next_adapter_stage(
-        "controlled_contract_dag",
-        state,
-        dag_execution_adapters.DagExecutionContext(
-            repo_root=Path.cwd(),
-            lab_dir=tmp_path,
-            now_fn=lambda: "2026-05-07T00:00:00Z",
-        ),
-    )
-
-    assert not result.ok
-    assert "Controlled contract command failed (3): bad command" in result.message
-    unit = result.state["units"][0]
-    assert unit["dispatch_status"] == "failed"
-    assert unit["operator_ui"]["message"] == result.message
-    assert result.state["run_status"] == "failed"
+    with pytest.raises(
+        dag_execution_adapters.DagExternalExecutionUncertainError,
+        match=r"Controlled contract command failed \(3\): bad command",
+    ):
+        dag_execution_adapters._run_next_adapter_stage_uncommitted(
+            "controlled_contract_dag",
+            state,
+            dag_execution_adapters.DagExecutionContext(
+                repo_root=Path.cwd(),
+                lab_dir=tmp_path,
+                now_fn=lambda: "2026-05-07T00:00:00Z",
+                execution_attempt_id="command-failure",
+                persist_execution_claim_fn=lambda _state: (
+                    dag_execution_adapters._DURABLE_CLAIM_RECEIPT
+                ),
+            ),
+        )
 
 
 def test_controlled_contract_adapter_uses_unit_id_runner_before_entrypoint_runner(tmp_path):
     calls: list[str] = []
 
-    def _unit_runner(*, repo_root: Path, run_root: Path) -> dict[str, object]:
+    def _unit_runner(
+        *,
+        repo_root: Path,
+        run_root: Path,
+        idempotency_token: str,
+    ) -> dict[str, object]:
+        del repo_root, run_root, idempotency_token
         calls.append("unit")
         return {
             "summary_metrics_path": "unit/summary.json",
             "summary_metrics": {"stage_completed": 1, "runner": "unit"},
         }
 
-    def _entrypoint_runner(*, repo_root: Path, run_root: Path) -> dict[str, object]:
+    def _entrypoint_runner(
+        *,
+        repo_root: Path,
+        run_root: Path,
+        idempotency_token: str,
+    ) -> dict[str, object]:
+        del repo_root, run_root, idempotency_token
         calls.append("entrypoint")
         return {
             "summary_metrics_path": "entrypoint/summary.json",
@@ -477,7 +555,7 @@ def test_controlled_contract_adapter_uses_unit_id_runner_before_entrypoint_runne
         "summary": {},
     }
 
-    result = dag_execution_adapters.run_next_adapter_stage(
+    result = dag_execution_adapters._run_next_adapter_stage_uncommitted(
         "controlled_contract_dag",
         state,
         dag_execution_adapters.DagExecutionContext(
@@ -488,6 +566,8 @@ def test_controlled_contract_adapter_uses_unit_id_runner_before_entrypoint_runne
                 "alpha.extract_context": _entrypoint_runner,
             },
             now_fn=lambda: "2026-05-07T00:00:00Z",
+            execution_attempt_id="runner-priority",
+            persist_execution_claim_fn=lambda _state: dag_execution_adapters._DURABLE_CLAIM_RECEIPT,
         ),
     )
 
@@ -512,13 +592,15 @@ def test_controlled_contract_adapter_sanitizes_unsafe_artifact_path(tmp_path):
         "summary": {},
     }
 
-    result = dag_execution_adapters.run_next_adapter_stage(
+    result = dag_execution_adapters._run_next_adapter_stage_uncommitted(
         "controlled_contract_dag",
         state,
         dag_execution_adapters.DagExecutionContext(
             repo_root=Path.cwd(),
             lab_dir=tmp_path,
             now_fn=lambda: "2026-05-07T00:00:00Z",
+            execution_attempt_id="unsafe-path",
+            persist_execution_claim_fn=lambda _state: dag_execution_adapters._DURABLE_CLAIM_RECEIPT,
         ),
     )
 
@@ -612,7 +694,7 @@ def test_run_ready_contract_batch_marks_invalid_runnable_stage_failure(tmp_path)
         "artifacts": [],
     }
 
-    result = dag_execution_adapters.run_ready_adapter_stages(
+    result = dag_execution_adapters._run_ready_adapter_stages_uncommitted(
         "controlled_contract_dag",
         state,
         dag_execution_adapters.DagExecutionContext(
@@ -634,7 +716,11 @@ def test_run_contract_command_timeout_and_state_mutation_edges(monkeypatch, tmp_
 
     monkeypatch.setattr(dag_execution_adapters.subprocess, "run", _raise_timeout)
     with pytest.raises(RuntimeError, match="timed out"):
-        dag_execution_adapters._run_contract_command(["demo"], run_root=tmp_path)
+        dag_execution_adapters._run_contract_command(
+            ["demo"],
+            run_root=tmp_path,
+            idempotency_token="timeout:demo",
+        )
 
     state = {"events": "bad", "artifacts": "bad", "created_at": "created"}
     events = dag_execution_adapters._events(state)
@@ -684,3 +770,129 @@ def test_relay_queue_result_and_provenance_edge_paths():
     )
     assert provenance_state["provenance"]["real_executed_unit_ids"] == ["alpha"]
     assert provenance_state["provenance"]["controlled_executed_unit_ids"] == ["alpha"]
+
+
+def test_idempotency_ledger_reuses_completed_result_without_repeating_callback(tmp_path):
+    callback_count = 0
+
+    def _callback() -> dict[str, object]:
+        nonlocal callback_count
+        callback_count += 1
+        return {"summary_metrics": {"stage_completed": 1}}
+
+    first = dag_execution_adapters._execute_idempotently(
+        run_root=tmp_path / "run",
+        unit_id="queue_context",
+        idempotency_token="duplicate-attempt:queue_context",
+        callback=_callback,
+    )
+    second = dag_execution_adapters._execute_idempotently(
+        run_root=tmp_path / "run",
+        unit_id="queue_context",
+        idempotency_token="duplicate-attempt:queue_context",
+        callback=_callback,
+    )
+
+    assert callback_count == 1
+    assert first == second
+    assert second["idempotency_token"] == "duplicate-attempt:queue_context"
+
+
+def test_idempotency_ledger_hierarchy_failure_aborts_before_callback(monkeypatch, tmp_path):
+    callback_count = 0
+
+    def _callback() -> dict[str, object]:
+        nonlocal callback_count
+        callback_count += 1
+        return {}
+
+    idempotency_module = sys.modules[
+        dag_execution_adapters._execute_idempotently.__module__
+    ]
+    monkeypatch.setattr(
+        idempotency_module,
+        "_ensure_directory_hierarchy_durable",
+        lambda _path: False,
+    )
+
+    with pytest.raises(OSError, match="ledger directory"):
+        dag_execution_adapters._execute_idempotently(
+            run_root=tmp_path / "new" / "run",
+            unit_id="queue_context",
+            idempotency_token="non-durable:queue_context",
+            callback=_callback,
+        )
+
+    assert callback_count == 0
+
+
+@pytest.mark.parametrize("with_command", [False, True])
+def test_fallback_contract_artifact_is_replaced_with_retry_token(tmp_path, with_command):
+    context = dag_execution_adapters.DagExecutionContext(
+        repo_root=Path.cwd(),
+        lab_dir=tmp_path,
+    )
+    artifact = {
+        "artifact": "context_artifact",
+        "kind": "contract_artifact",
+        "path": "context/context.json",
+    }
+
+    def _unit(token: str) -> dict[str, object]:
+        contract: dict[str, object] = {"entrypoint": "alpha.extract_context"}
+        if with_command:
+            contract["command"] = [sys.executable, "-c", "pass"]
+        return {
+            "id": "extract_context",
+            "execution_contract": contract,
+            "execution_attempt": {"idempotency_token": token},
+        }
+
+    first = dag_execution_adapters._contract_stage_result(
+        context,
+        unit=_unit("attempt-one:extract_context"),
+        artifact=artifact,
+        timestamp="2026-05-07T00:00:00Z",
+    )
+    output_path = Path(first["contract_artifact_path"])
+    assert json.loads(output_path.read_text(encoding="utf-8"))["idempotency_token"] == (
+        "attempt-one:extract_context"
+    )
+
+    second = dag_execution_adapters._contract_stage_result(
+        context,
+        unit=_unit("attempt-two:extract_context"),
+        artifact=artifact,
+        timestamp="2026-05-07T00:00:01Z",
+    )
+
+    assert Path(second["contract_artifact_path"]) == output_path
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert payload["idempotency_token"] == "attempt-two:extract_context"
+    assert payload["created_at"] == "2026-05-07T00:00:01Z"
+
+
+def test_external_execution_claim_fails_closed_without_persistence_callback(tmp_path):
+    context = dag_execution_adapters.DagExecutionContext(
+        repo_root=Path.cwd(),
+        lab_dir=tmp_path,
+        execution_attempt_id="unsafe-direct-call",
+    )
+
+    with pytest.raises(RuntimeError, match="runner-state transaction API"):
+        dag_execution_adapters._persist_execution_claim(
+            context,
+            {"units": [], "events": [], "artifacts": []},
+        )
+
+    no_op_context = dag_execution_adapters.DagExecutionContext(
+        repo_root=Path.cwd(),
+        lab_dir=tmp_path,
+        execution_attempt_id="unsafe-no-op-callback",
+        persist_execution_claim_fn=lambda _state: None,
+    )
+    with pytest.raises(RuntimeError, match="durable claim receipt"):
+        dag_execution_adapters._persist_execution_claim(
+            no_op_context,
+            {"units": [], "events": [], "artifacts": []},
+        )

--- a/test/test_dag_run_engine.py
+++ b/test/test_dag_run_engine.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
+from contextlib import contextmanager
+from copy import deepcopy
 import importlib.util
 import json
+import os
 from pathlib import Path
+import subprocess
 import sys
 import threading
+
+import pytest
 
 
 def _ensure_agilab_package_path() -> None:
@@ -171,6 +177,7 @@ def test_dag_run_engine_reuses_matching_persisted_state(tmp_path):
     )
 
     state, state_path, dag_path = engine.load_or_create_state()
+    observed_revision = dag_run_engine.runner_state_revision(state)
     state["events"].append(
         {
             "timestamp": "2026-05-07T00:01:00Z",
@@ -181,13 +188,37 @@ def test_dag_run_engine_reuses_matching_persisted_state(tmp_path):
             "detail": "keep me",
         }
     )
-    engine.write_state(state)
+    engine.write_state(state, expected_revision=observed_revision)
 
     reloaded, reloaded_path, reloaded_dag_path = engine.load_or_create_state()
 
     assert state_path == reloaded_path == tmp_path / ".agilab" / "runner_state.json"
     assert dag_path == reloaded_dag_path == _sample_dag_path(repo_root)
     assert reloaded["events"][-1]["detail"] == "keep me"
+
+
+def test_write_state_rejects_two_stale_session_snapshots(tmp_path):
+    repo_root = Path.cwd()
+    engine = dag_run_engine.DagRunEngine(
+        repo_root=repo_root,
+        lab_dir=tmp_path,
+        dag_path=_sample_dag_path(repo_root),
+    )
+    state, _state_path, _dag_path = engine.load_or_create_state()
+    observed_revision = dag_run_engine.runner_state_revision(state)
+    first = deepcopy(state)
+    second = deepcopy(state)
+    first["events"].append({"kind": "first-session"})
+    second["events"].append({"kind": "stale-second-session"})
+
+    with pytest.raises(ValueError, match="revision observed"):
+        engine.write_state(first)
+    engine.write_state(first, expected_revision=observed_revision)
+    with pytest.raises(dag_run_engine.RunnerStateConflictError, match="another session"):
+        engine.write_state(second, expected_revision=observed_revision)
+
+    persisted = dag_run_engine.load_runner_state(engine.state_path)
+    assert persisted["events"][-1] == {"kind": "first-session"}
 
 
 def test_dag_run_engine_recreates_mismatched_persisted_state(tmp_path):
@@ -198,6 +229,7 @@ def test_dag_run_engine_recreates_mismatched_persisted_state(tmp_path):
         dag_path=_sample_dag_path(repo_root),
     )
     state, _state_path, _dag_path = engine.load_or_create_state()
+    observed_revision = dag_run_engine.runner_state_revision(state)
     state["source"]["dag_path"] = "different/dag.json"
     state["events"].append(
         {
@@ -206,7 +238,7 @@ def test_dag_run_engine_recreates_mismatched_persisted_state(tmp_path):
             "detail": "discard me",
         }
     )
-    engine.write_state(state)
+    engine.write_state(state, expected_revision=observed_revision)
 
     recreated, recreated_path, recreated_dag_path = engine.load_or_create_state()
 
@@ -220,7 +252,10 @@ def test_dag_run_engine_executes_controlled_queue_stage(tmp_path):
     repo_root = Path.cwd()
     calls: list[Path] = []
 
-    def _fake_queue_run(*, repo_root: Path, run_root: Path) -> dict[str, object]:
+    def _fake_queue_run(
+        *, repo_root: Path, run_root: Path, idempotency_token: str
+    ) -> dict[str, object]:
+        assert idempotency_token == "queue-stage:queue_baseline"
         calls.append(run_root)
         return {
             "summary_metrics_path": "queue/summary.json",
@@ -234,6 +269,7 @@ def test_dag_run_engine_executes_controlled_queue_stage(tmp_path):
         dag_path=_sample_dag_path(repo_root),
         run_queue_fn=_fake_queue_run,
         now_fn=lambda: "2026-05-07T00:00:00Z",
+        attempt_id_fn=lambda: "queue-stage",
     )
     state, _state_path, _dag_path = engine.load_or_create_state()
 
@@ -250,11 +286,562 @@ def test_dag_run_engine_executes_controlled_queue_stage(tmp_path):
     assert queue["real_execution"]["summary_metrics"]["packets_delivered"] == 11
 
 
+def test_dag_run_engine_transaction_prevents_duplicate_two_session_stage_execution(tmp_path):
+    repo_root = Path.cwd()
+    calls: list[Path] = []
+    calls_lock = threading.Lock()
+    session_barrier = threading.Barrier(2)
+    outcomes: list[str] = []
+    failures: list[BaseException] = []
+    outcomes_lock = threading.Lock()
+
+    def _fake_queue_run(
+        *, repo_root: Path, run_root: Path, idempotency_token: str
+    ) -> dict[str, object]:
+        assert idempotency_token.endswith(":queue_baseline")
+        with calls_lock:
+            calls.append(run_root)
+        return {
+            "summary_metrics_path": "queue/summary.json",
+            "reduce_artifact_path": "queue/reduce.json",
+            "summary_metrics": {"packets_generated": 13, "packets_delivered": 11},
+        }
+
+    def _engine() -> dag_run_engine.DagRunEngine:
+        return dag_run_engine.DagRunEngine(
+            repo_root=repo_root,
+            lab_dir=tmp_path,
+            dag_path=_sample_dag_path(repo_root),
+            run_queue_fn=_fake_queue_run,
+            now_fn=lambda: "2026-05-07T00:00:00Z",
+        )
+
+    first_engine = _engine()
+    second_engine = _engine()
+    state, _state_path, _dag_path = first_engine.load_or_create_state()
+
+    def _run_session(engine, snapshot: dict[str, object]) -> None:
+        session_barrier.wait(timeout=2)
+        try:
+            result = engine.run_next_controlled_stage(snapshot)
+        except dag_run_engine.RunnerStateConflictError:
+            outcome = "conflict"
+        except BaseException as exc:
+            with outcomes_lock:
+                failures.append(exc)
+            return
+        else:
+            assert result.ok
+            outcome = "ok"
+        with outcomes_lock:
+            outcomes.append(outcome)
+
+    sessions = [
+        threading.Thread(target=_run_session, args=(first_engine, deepcopy(state))),
+        threading.Thread(target=_run_session, args=(second_engine, deepcopy(state))),
+    ]
+    for session in sessions:
+        session.start()
+    for session in sessions:
+        session.join(timeout=10)
+
+    assert all(not session.is_alive() for session in sessions)
+    assert failures == []
+    assert sorted(outcomes) == ["conflict", "ok"]
+    assert calls == [tmp_path / ".agilab" / "multi_app_dag_real_runs" / "queue_baseline"]
+    persisted = dag_run_engine.load_runner_state(first_engine.state_path)
+    assert persisted["summary"]["completed_unit_ids"] == ["queue_baseline"]
+    assert sum(
+        event.get("kind") == "unit_completed" and event.get("unit_id") == "queue_baseline"
+        for event in persisted["events"]
+    ) == 1
+
+
+@pytest.mark.parametrize("replacement_action", ["reset", "source_switch"])
+def test_active_stage_cannot_be_overwritten_by_reset_or_source_switch(
+    tmp_path,
+    replacement_action,
+):
+    repo_root = Path.cwd()
+    callback_started = threading.Event()
+    release_callback = threading.Event()
+    run_failures: list[BaseException] = []
+    replacement_failures: list[BaseException] = []
+
+    def _blocking_queue_run(
+        *, repo_root: Path, run_root: Path, idempotency_token: str
+    ) -> dict[str, object]:
+        del repo_root, run_root
+        assert idempotency_token == "active-attempt:queue_baseline"
+        callback_started.set()
+        assert release_callback.wait(timeout=5)
+        return {
+            "summary_metrics_path": "queue/summary.json",
+            "reduce_artifact_path": "queue/reduce.json",
+            "summary_metrics": {"packets_generated": 1, "packets_delivered": 1},
+        }
+
+    active_engine = dag_run_engine.DagRunEngine(
+        repo_root=repo_root,
+        lab_dir=tmp_path,
+        dag_path=_sample_dag_path(repo_root),
+        run_queue_fn=_blocking_queue_run,
+        attempt_id_fn=lambda: "active-attempt",
+    )
+    state, _state_path, _dag_path = active_engine.load_or_create_state()
+
+    def _run_active_stage() -> None:
+        try:
+            active_engine.run_next_controlled_stage_transaction(deepcopy(state))
+        except BaseException as exc:
+            run_failures.append(exc)
+
+    def _replace_state() -> None:
+        try:
+            if replacement_action == "reset":
+                active_engine.load_or_create_state(reset=True)
+            else:
+                dag_run_engine.DagRunEngine(
+                    repo_root=repo_root,
+                    lab_dir=tmp_path,
+                    dag_path=_flight_template_dag_path(repo_root),
+                ).load_or_create_state()
+        except BaseException as exc:
+            replacement_failures.append(exc)
+
+    run_session = threading.Thread(target=_run_active_stage, name="active-session")
+    replacement_session = threading.Thread(target=_replace_state, name="replacement-session")
+    run_session.start()
+    assert callback_started.wait(timeout=5)
+    replacement_session.start()
+    try:
+        replacement_session.join(timeout=5)
+        assert not replacement_session.is_alive()
+    finally:
+        release_callback.set()
+    run_session.join(timeout=10)
+
+    assert not run_session.is_alive()
+    assert run_failures == []
+    assert len(replacement_failures) == 1
+    assert isinstance(
+        replacement_failures[0],
+        dag_run_engine.RunnerStateRecoveryRequiredError,
+    )
+    persisted = dag_run_engine.load_runner_state(active_engine.state_path)
+    assert persisted["summary"]["completed_unit_ids"] == [dag_run_engine.GLOBAL_DAG_QUEUE_UNIT_ID]
+    assert dag_run_engine.runner_state_dag_matches(
+        persisted,
+        _sample_dag_path(repo_root),
+        repo_root,
+    )
+
+
+def test_external_callback_runs_without_holding_runner_state_lock(tmp_path):
+    repo_root = Path.cwd()
+    callback_started = threading.Event()
+    release_callback = threading.Event()
+    lock_acquired = threading.Event()
+    failures: list[BaseException] = []
+
+    def _blocking_queue_run(
+        *, repo_root: Path, run_root: Path, idempotency_token: str
+    ) -> dict[str, object]:
+        del repo_root, run_root
+        assert idempotency_token == "lock-free-attempt:queue_baseline"
+        callback_started.set()
+        assert release_callback.wait(timeout=5)
+        return {
+            "summary_metrics_path": "queue/summary.json",
+            "reduce_artifact_path": "queue/reduce.json",
+            "summary_metrics": {"packets_generated": 1, "packets_delivered": 1},
+        }
+
+    engine = dag_run_engine.DagRunEngine(
+        repo_root=repo_root,
+        lab_dir=tmp_path,
+        dag_path=_sample_dag_path(repo_root),
+        run_queue_fn=_blocking_queue_run,
+        attempt_id_fn=lambda: "lock-free-attempt",
+    )
+    state, _state_path, _dag_path = engine.load_or_create_state()
+
+    def _run_stage() -> None:
+        try:
+            engine.run_next_controlled_stage_transaction(state)
+        except BaseException as exc:
+            failures.append(exc)
+
+    def _acquire_lock() -> None:
+        try:
+            with dag_run_engine.runner_state_transaction(engine.state_path):
+                lock_acquired.set()
+        except BaseException as exc:
+            failures.append(exc)
+
+    run_thread = threading.Thread(target=_run_stage)
+    run_thread.start()
+    assert callback_started.wait(timeout=5)
+    lock_thread = threading.Thread(target=_acquire_lock)
+    lock_thread.start()
+    try:
+        assert lock_acquired.wait(timeout=5)
+    finally:
+        release_callback.set()
+    run_thread.join(timeout=10)
+    lock_thread.join(timeout=10)
+
+    assert not run_thread.is_alive()
+    assert not lock_thread.is_alive()
+    assert failures == []
+
+
+def test_exact_token_recovery_cannot_clear_a_live_callback(tmp_path):
+    repo_root = Path.cwd()
+    callback_started = threading.Event()
+    release_callback = threading.Event()
+    run_failures: list[BaseException] = []
+
+    def _blocking_queue_run(
+        *, repo_root: Path, run_root: Path, idempotency_token: str
+    ) -> dict[str, object]:
+        del repo_root, run_root
+        assert idempotency_token == "live-owner-attempt:queue_baseline"
+        callback_started.set()
+        assert release_callback.wait(timeout=5)
+        return {
+            "summary_metrics_path": "queue/summary.json",
+            "reduce_artifact_path": "queue/reduce.json",
+            "summary_metrics": {"packets_generated": 1, "packets_delivered": 1},
+        }
+
+    engine = dag_run_engine.DagRunEngine(
+        repo_root=repo_root,
+        lab_dir=tmp_path,
+        dag_path=_sample_dag_path(repo_root),
+        run_queue_fn=_blocking_queue_run,
+        attempt_id_fn=lambda: "live-owner-attempt",
+    )
+    state, _state_path, _dag_path = engine.load_or_create_state()
+
+    def _run_stage() -> None:
+        try:
+            engine.run_next_controlled_stage(state)
+        except BaseException as exc:
+            run_failures.append(exc)
+
+    run_thread = threading.Thread(target=_run_stage)
+    run_thread.start()
+    assert callback_started.wait(timeout=5)
+    persisted = dag_run_engine.load_runner_state(engine.state_path)
+    token = "live-owner-attempt:queue_baseline"
+    try:
+        with pytest.raises(
+            dag_run_engine.DagExecutionRecoveryBlockedError,
+            match="owner is still live",
+        ):
+            engine.recover_execution_attempt_transaction(
+                persisted,
+                unit_id=dag_run_engine.GLOBAL_DAG_QUEUE_UNIT_ID,
+                idempotency_token=token,
+            )
+        still_active = dag_run_engine.load_runner_state(engine.state_path)
+        assert still_active["active_execution"]["status"] == "running"
+        assert still_active["active_execution"]["unit_tokens"] == {
+            dag_run_engine.GLOBAL_DAG_QUEUE_UNIT_ID: token
+        }
+    finally:
+        release_callback.set()
+    run_thread.join(timeout=10)
+
+    assert not run_thread.is_alive()
+    assert run_failures == []
+    finalized = dag_run_engine.load_runner_state(engine.state_path)
+    assert "active_execution" not in finalized
+    assert finalized["summary"]["completed_unit_ids"] == [
+        dag_run_engine.GLOBAL_DAG_QUEUE_UNIT_ID
+    ]
+
+
+def test_post_callback_finalization_failure_is_immediately_recoverable(
+    monkeypatch,
+    tmp_path,
+):
+    repo_root = Path.cwd()
+    callback_tokens: list[str] = []
+
+    def _queue_run(
+        *, repo_root: Path, run_root: Path, idempotency_token: str
+    ) -> dict[str, object]:
+        del repo_root, run_root
+        callback_tokens.append(idempotency_token)
+        return {
+            "summary_metrics_path": "queue/summary.json",
+            "reduce_artifact_path": "queue/reduce.json",
+            "summary_metrics": {"packets_generated": 1, "packets_delivered": 1},
+        }
+
+    engine = dag_run_engine.DagRunEngine(
+        repo_root=repo_root,
+        lab_dir=tmp_path,
+        dag_path=_sample_dag_path(repo_root),
+        run_queue_fn=_queue_run,
+        attempt_id_fn=lambda: "post-callback-finalize",
+    )
+    state, _state_path, _dag_path = engine.load_or_create_state()
+    real_transaction = dag_run_engine.runner_state_transaction
+    finalization_failed = False
+
+    @contextmanager
+    def _fail_finalization_once(path, *, expected_revision=None):
+        nonlocal finalization_failed
+        if expected_revision is not None and not finalization_failed:
+            finalization_failed = True
+            raise OSError("synthetic finalization failure")
+        with real_transaction(path, expected_revision=expected_revision) as transaction:
+            yield transaction
+
+    monkeypatch.setattr(
+        dag_run_engine,
+        "runner_state_transaction",
+        _fail_finalization_once,
+    )
+
+    with pytest.raises(OSError, match="synthetic finalization failure"):
+        engine.run_next_controlled_stage_transaction(state)
+
+    token = "post-callback-finalize:queue_baseline"
+    assert callback_tokens == [token]
+    persisted = dag_run_engine.load_runner_state(engine.state_path)
+    assert persisted["active_execution"]["status"] == "recovery_required"
+    recovered = engine.recover_execution_attempt_transaction(
+        persisted,
+        unit_id=dag_run_engine.GLOBAL_DAG_QUEUE_UNIT_ID,
+        idempotency_token=token,
+    )
+    assert "active_execution" not in recovered
+
+
+def test_execution_owner_liveness_uses_cross_process_incarnation(tmp_path):
+    child = subprocess.Popen(
+        [sys.executable, "-c", "import sys; sys.stdin.read()"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+    try:
+        incarnation = dag_run_engine._process_incarnation(child.pid)
+        assert incarnation
+        active_execution = {
+            "attempt_id": "cross-process-owner",
+            "status": "running",
+            "owner": {
+                "host": dag_run_engine.socket.gethostname(),
+                "pid": child.pid,
+                "process_incarnation": incarnation,
+                "thread_id": 1,
+            },
+        }
+        assert dag_run_engine._execution_owner_liveness(
+            tmp_path / "runner_state.json",
+            active_execution,
+        ) is True
+        remote_owner = deepcopy(active_execution)
+        remote_owner["owner"]["host"] = "unverifiable-remote-host"
+        assert dag_run_engine._execution_owner_liveness(
+            tmp_path / "runner_state.json",
+            remote_owner,
+        ) is None
+    finally:
+        assert child.stdin is not None
+        child.stdin.close()
+        child.wait(timeout=5)
+
+    assert dag_run_engine._execution_owner_liveness(
+        tmp_path / "runner_state.json",
+        active_execution,
+    ) is False
+
+
+def test_claim_directory_fsync_failure_aborts_before_external_callback(monkeypatch, tmp_path):
+    repo_root = Path.cwd()
+    callback_tokens: list[str] = []
+
+    def _unexpected_queue_run(
+        *, repo_root: Path, run_root: Path, idempotency_token: str
+    ) -> dict[str, object]:
+        del repo_root, run_root
+        callback_tokens.append(idempotency_token)
+        return {}
+
+    engine = dag_run_engine.DagRunEngine(
+        repo_root=repo_root,
+        lab_dir=tmp_path,
+        dag_path=_sample_dag_path(repo_root),
+        run_queue_fn=_unexpected_queue_run,
+        attempt_id_fn=lambda: "non-durable-attempt",
+    )
+    state, _state_path, _dag_path = engine.load_or_create_state()
+    persistence_module = sys.modules[dag_run_engine.runner_state_write_transaction.__module__]
+    monkeypatch.setattr(persistence_module, "_fsync_runner_state_directory", lambda _path: False)
+
+    with pytest.raises(dag_run_engine.RunnerStateDurabilityError):
+        engine.run_next_controlled_stage_transaction(state)
+
+    assert callback_tokens == []
+    persisted = dag_run_engine.load_runner_state(engine.state_path)
+    assert "active_execution" not in persisted
+    queue = _unit_by_id(persisted, dag_run_engine.GLOBAL_DAG_QUEUE_UNIT_ID)
+    assert queue["dispatch_status"] == "runnable"
+    assert "execution_attempt" not in queue
+
+
+def test_process_death_after_side_effect_leaves_exact_token_recovery_claim(tmp_path):
+    repo_root = Path.cwd()
+    dag_path = _sample_dag_path(repo_root)
+    lab_dir = tmp_path / "lab"
+    engine = dag_run_engine.DagRunEngine(
+        repo_root=repo_root,
+        lab_dir=lab_dir,
+        dag_path=dag_path,
+    )
+    engine.load_or_create_state()
+    harness_path = tmp_path / "process_death_harness.py"
+    harness_path.write_text(
+        """\
+from pathlib import Path
+import os
+import sys
+
+from agilab.dag.dag_run_engine import DagRunEngine, load_runner_state
+
+repo_root, lab_dir, dag_path = (Path(value) for value in sys.argv[1:4])
+
+def side_effect_then_exit(*, repo_root, run_root, idempotency_token):
+    del repo_root
+    assert idempotency_token == "process-death-attempt:queue_baseline"
+    run_root.mkdir(parents=True, exist_ok=True)
+    (run_root / "side-effect.txt").write_text("submitted\\n", encoding="utf-8")
+    os._exit(23)
+
+engine = DagRunEngine(
+    repo_root=repo_root,
+    lab_dir=lab_dir,
+    dag_path=dag_path,
+    run_queue_fn=side_effect_then_exit,
+    attempt_id_fn=lambda: "process-death-attempt",
+)
+engine.run_next_controlled_stage_transaction(load_runner_state(engine.state_path))
+raise SystemExit(99)
+""",
+        encoding="utf-8",
+    )
+    environment = dict(os.environ)
+    python_path = str((repo_root / "src").resolve())
+    if environment.get("PYTHONPATH"):
+        python_path = os.pathsep.join([python_path, environment["PYTHONPATH"]])
+    environment["PYTHONPATH"] = python_path
+    process = subprocess.run(
+        [sys.executable, str(harness_path), str(repo_root), str(lab_dir), str(dag_path)],
+        cwd=repo_root,
+        env=environment,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+
+    assert process.returncode == 23, process.stderr
+    side_effect_path = (
+        lab_dir
+        / ".agilab"
+        / "multi_app_dag_real_runs"
+        / dag_run_engine.GLOBAL_DAG_QUEUE_UNIT_ID
+        / "side-effect.txt"
+    )
+    assert side_effect_path.read_text(encoding="utf-8") == "submitted\n"
+    persisted = dag_run_engine.load_runner_state(engine.state_path)
+    queue = _unit_by_id(persisted, dag_run_engine.GLOBAL_DAG_QUEUE_UNIT_ID)
+    assert queue["dispatch_status"] == "running"
+    assert queue["execution_attempt"] == {
+        "id": "process-death-attempt",
+        "idempotency_token": "process-death-attempt:queue_baseline",
+        "recovery_policy": "explicit_recovery_required_before_retry",
+        "started_at": queue["execution_attempt"]["started_at"],
+        "status": "running",
+    }
+    active_execution = persisted["active_execution"]
+    assert active_execution["attempt_id"] == "process-death-attempt"
+    assert active_execution["status"] == "running"
+    assert active_execution["recovery_policy"] == "exact_unit_token_required"
+    assert active_execution["unit_tokens"] == {
+        dag_run_engine.GLOBAL_DAG_QUEUE_UNIT_ID: (
+            "process-death-attempt:queue_baseline"
+        )
+    }
+    assert isinstance(active_execution["owner"]["pid"], int)
+    assert active_execution["owner"]["pid"] != os.getpid()
+    assert active_execution["owner"]["process_incarnation"]
+
+    retry_calls: list[Path] = []
+
+    def _unexpected_retry(
+        *, repo_root: Path, run_root: Path, idempotency_token: str
+    ) -> dict[str, object]:
+        del repo_root
+        del idempotency_token
+        retry_calls.append(run_root)
+        return {}
+
+    recovery_engine = dag_run_engine.DagRunEngine(
+        repo_root=repo_root,
+        lab_dir=lab_dir,
+        dag_path=dag_path,
+        run_queue_fn=_unexpected_retry,
+    )
+
+    with pytest.raises(dag_run_engine.RunnerStateRecoveryRequiredError):
+        recovery_engine.run_next_controlled_stage_transaction(persisted)
+    with pytest.raises(dag_run_engine.RunnerStateRecoveryRequiredError):
+        recovery_engine.load_or_create_state(reset=True)
+    with pytest.raises(dag_run_engine.RunnerStateRecoveryRequiredError):
+        dag_run_engine.DagRunEngine(
+            repo_root=repo_root,
+            lab_dir=lab_dir,
+            dag_path=_flight_template_dag_path(repo_root),
+        ).load_or_create_state()
+    with pytest.raises(dag_run_engine.RunnerStateAttemptConflictError):
+        recovery_engine.recover_execution_attempt_transaction(
+            persisted,
+            unit_id=dag_run_engine.GLOBAL_DAG_QUEUE_UNIT_ID,
+            idempotency_token="wrong-token",
+        )
+
+    recovered = recovery_engine.recover_execution_attempt_transaction(
+        persisted,
+        unit_id=dag_run_engine.GLOBAL_DAG_QUEUE_UNIT_ID,
+        idempotency_token="process-death-attempt:queue_baseline",
+    )
+    recovered_queue = _unit_by_id(recovered, dag_run_engine.GLOBAL_DAG_QUEUE_UNIT_ID)
+    assert recovered_queue["dispatch_status"] == "failed"
+    assert recovered_queue["execution_attempt"]["status"] == "recovered_failed"
+    assert "active_execution" not in recovered
+    reset, _state_path, _dag_path = recovery_engine.load_or_create_state(reset=True)
+
+    assert retry_calls == []
+    assert reset["run_status"] == "planned"
+    assert reset["summary"]["completed_unit_ids"] == []
+
+
 def test_dag_run_engine_executes_app_owned_uav_template_queue_stage(tmp_path):
     repo_root = Path.cwd()
     calls: list[Path] = []
 
-    def _fake_queue_run(*, repo_root: Path, run_root: Path) -> dict[str, object]:
+    def _fake_queue_run(
+        *, repo_root: Path, run_root: Path, idempotency_token: str
+    ) -> dict[str, object]:
+        assert idempotency_token == "uav-template:queue_baseline"
         calls.append(run_root)
         return {
             "summary_metrics_path": "queue/summary.json",
@@ -268,6 +855,7 @@ def test_dag_run_engine_executes_app_owned_uav_template_queue_stage(tmp_path):
         dag_path=_app_template_dag_path(repo_root),
         run_queue_fn=_fake_queue_run,
         now_fn=lambda: "2026-05-07T00:00:00Z",
+        attempt_id_fn=lambda: "uav-template",
     )
     state, _state_path, _dag_path = engine.load_or_create_state()
     support = engine.real_run_support(state)
@@ -286,7 +874,10 @@ def test_dag_run_engine_executes_app_owned_flight_template_contract_stage(tmp_pa
     repo_root = Path.cwd()
     calls: list[Path] = []
 
-    def _fake_flight_contract(*, repo_root: Path, run_root: Path) -> dict[str, object]:
+    def _fake_flight_contract(
+        *, repo_root: Path, run_root: Path, idempotency_token: str
+    ) -> dict[str, object]:
+        assert idempotency_token == "flight-template:flight_context"
         calls.append(run_root)
         return {
             "summary_metrics_path": "flight/summary.json",
@@ -300,6 +891,7 @@ def test_dag_run_engine_executes_app_owned_flight_template_contract_stage(tmp_pa
         dag_path=_flight_template_dag_path(repo_root),
         stage_run_fns={"flight_telemetry_project.flight_context": _fake_flight_contract},
         now_fn=lambda: "2026-05-07T00:00:00Z",
+        attempt_id_fn=lambda: "flight-template",
     )
     state, _state_path, _dag_path = engine.load_or_create_state()
     support = engine.real_run_support(state)
@@ -338,7 +930,10 @@ def test_dag_run_engine_runs_ready_contract_stages_as_parallel_batch(tmp_path):
     started: list[str] = []
 
     def _stage(unit_id: str):
-        def _run(*, repo_root: Path, run_root: Path) -> dict[str, object]:
+        def _run(
+            *, repo_root: Path, run_root: Path, idempotency_token: str
+        ) -> dict[str, object]:
+            assert idempotency_token == f"parallel-batch:{unit_id}"
             with lock:
                 started.append(unit_id)
             barrier.wait(timeout=1.0)
@@ -359,6 +954,7 @@ def test_dag_run_engine_runs_ready_contract_stages_as_parallel_batch(tmp_path):
             "flight_telemetry_project.flight_context": _stage("flight_context"),
         },
         now_fn=lambda: "2026-05-07T00:00:00Z",
+        attempt_id_fn=lambda: "parallel-batch",
     )
     state, _state_path, _dag_path = engine.load_or_create_state()
 
@@ -379,11 +975,63 @@ def test_dag_run_engine_runs_ready_contract_stages_as_parallel_batch(tmp_path):
     assert flight["execution_mode"] == "contract_adapter"
 
 
+def test_parallel_batch_transaction_uses_distinct_durable_unit_tokens(tmp_path):
+    dag_path = _write_parallel_contract_repo(tmp_path)
+    repo_root = tmp_path / "repo"
+    observed_tokens: dict[str, str] = {}
+    observed_lock = threading.Lock()
+
+    def _stage(unit_id: str):
+        def _run(
+            *, repo_root: Path, run_root: Path, idempotency_token: str
+        ) -> dict[str, object]:
+            del repo_root, run_root
+            with observed_lock:
+                observed_tokens[unit_id] = idempotency_token
+            return {
+                "summary_metrics_path": f"{unit_id}/summary.json",
+                "summary_metrics": {"stage_completed": 1},
+            }
+
+        return _run
+
+    engine = dag_run_engine.DagRunEngine(
+        repo_root=repo_root,
+        lab_dir=tmp_path / "lab",
+        dag_path=dag_path,
+        stage_run_fns={
+            "uav_queue_project.queue_context": _stage("queue_context"),
+            "flight_telemetry_project.flight_context": _stage("flight_context"),
+        },
+        attempt_id_fn=lambda: "transaction-batch",
+    )
+    state, _state_path, _dag_path = engine.load_or_create_state()
+
+    result = engine.run_ready_controlled_stages_transaction(state)
+
+    assert result.ok
+    assert observed_tokens == {
+        "flight_context": "transaction-batch:flight_context",
+        "queue_context": "transaction-batch:queue_context",
+    }
+    assert len(set(observed_tokens.values())) == 2
+    assert "active_execution" not in result.state
+    for unit_id, token in observed_tokens.items():
+        unit = _unit_by_id(result.state, unit_id)
+        assert unit["execution_attempt"]["id"] == "transaction-batch"
+        assert unit["execution_attempt"]["idempotency_token"] == token
+        assert unit["execution_attempt"]["status"] == "completed"
+    assert dag_run_engine.load_runner_state(engine.state_path) == result.state
+
+
 def test_dag_run_engine_run_ready_wraps_single_stage_adapter(tmp_path):
     repo_root = Path.cwd()
     calls: list[Path] = []
 
-    def _fake_queue_run(*, repo_root: Path, run_root: Path) -> dict[str, object]:
+    def _fake_queue_run(
+        *, repo_root: Path, run_root: Path, idempotency_token: str
+    ) -> dict[str, object]:
+        assert idempotency_token == "single-batch:queue_baseline"
         calls.append(run_root)
         return {
             "summary_metrics_path": "queue/summary.json",
@@ -397,6 +1045,7 @@ def test_dag_run_engine_run_ready_wraps_single_stage_adapter(tmp_path):
         dag_path=_sample_dag_path(repo_root),
         run_queue_fn=_fake_queue_run,
         now_fn=lambda: "2026-05-07T00:00:00Z",
+        attempt_id_fn=lambda: "single-batch",
     )
     state, _state_path, _dag_path = engine.load_or_create_state()
 
@@ -418,8 +1067,10 @@ def test_dag_run_engine_run_ready_contract_batch_reports_no_ready_stage(tmp_path
         dag_path=dag_path,
     )
     state, _state_path, _dag_path = engine.load_or_create_state()
+    observed_revision = dag_run_engine.runner_state_revision(state)
     for unit in state["units"]:
         unit["dispatch_status"] = "completed"
+    engine.write_state(state, expected_revision=observed_revision)
 
     result = engine.run_ready_controlled_stages(state)
 
@@ -434,17 +1085,26 @@ def test_dag_run_engine_run_ready_contract_batch_reports_no_ready_stage(tmp_path
     }
 
 
-def test_dag_run_engine_run_ready_contract_batch_reports_partial_failure(tmp_path):
+def test_batch_callback_failure_preserves_claim_for_exact_token_recovery(tmp_path):
     dag_path = _write_parallel_contract_repo(tmp_path)
     repo_root = tmp_path / "repo"
+    side_effects: list[str] = []
 
-    def _pass_stage(*, repo_root: Path, run_root: Path) -> dict[str, object]:
+    def _pass_stage(
+        *, repo_root: Path, run_root: Path, idempotency_token: str
+    ) -> dict[str, object]:
+        assert idempotency_token == "partial-batch:queue_context"
+        side_effects.append("queue_context")
         return {
             "summary_metrics_path": "queue/summary.json",
             "summary_metrics": {"stage_completed": 1},
         }
 
-    def _fail_stage(*, repo_root: Path, run_root: Path) -> dict[str, object]:
+    def _fail_stage(
+        *, repo_root: Path, run_root: Path, idempotency_token: str
+    ) -> dict[str, object]:
+        assert idempotency_token == "partial-batch:flight_context"
+        side_effects.append("flight_context")
         raise RuntimeError("synthetic flight failure")
 
     engine = dag_run_engine.DagRunEngine(
@@ -456,21 +1116,46 @@ def test_dag_run_engine_run_ready_contract_batch_reports_partial_failure(tmp_pat
             "flight_telemetry_project.flight_context": _fail_stage,
         },
         now_fn=lambda: "2026-05-07T00:00:00Z",
+        attempt_id_fn=lambda: "partial-batch",
     )
     state, _state_path, _dag_path = engine.load_or_create_state()
 
-    result = engine.run_ready_controlled_stages(state, max_workers=2)
+    with pytest.raises(
+        dag_run_engine.DagExternalExecutionUncertainError,
+        match="synthetic flight failure",
+    ):
+        engine.run_ready_controlled_stages(state, max_workers=2)
 
-    assert not result.ok
-    assert set(result.executed_unit_ids) == {"queue_context"}
-    assert set(result.failed_unit_ids) == {"flight_context"}
-    assert "synthetic flight failure" in result.message
-    queue = _unit_by_id(result.state, "queue_context")
-    flight = _unit_by_id(result.state, "flight_context")
-    assert queue["dispatch_status"] == "completed"
-    assert flight["dispatch_status"] == "failed"
-    assert flight["operator_ui"]["message"] == "synthetic flight failure"
-    assert result.state["summary"]["failed_unit_ids"] == ["flight_context"]
+    assert set(side_effects) == {"flight_context", "queue_context"}
+    persisted = dag_run_engine.load_runner_state(engine.state_path)
+    assert persisted is not None
+    assert persisted["active_execution"]["attempt_id"] == "partial-batch"
+    assert persisted["active_execution"]["status"] == "recovery_required"
+    assert persisted["active_execution"]["unit_tokens"] == {
+        "flight_context": "partial-batch:flight_context",
+        "queue_context": "partial-batch:queue_context",
+    }
+    assert _unit_by_id(persisted, "flight_context")["dispatch_status"] == "running"
+    assert _unit_by_id(persisted, "queue_context")["dispatch_status"] == "running"
+    with pytest.raises(dag_run_engine.RunnerStateRecoveryRequiredError):
+        engine.load_or_create_state(reset=True)
+
+    recovered = engine.recover_execution_attempt_transaction(
+        persisted,
+        unit_id="flight_context",
+        idempotency_token="partial-batch:flight_context",
+    )
+    assert recovered["active_execution"]["unit_tokens"] == {
+        "queue_context": "partial-batch:queue_context"
+    }
+    recovered = engine.recover_execution_attempt_transaction(
+        recovered,
+        unit_id="queue_context",
+        idempotency_token="partial-batch:queue_context",
+    )
+    assert "active_execution" not in recovered
+    replacement, _state_path, _dag_path = engine.load_or_create_state(reset=True)
+    assert replacement["run_status"] == "planned"
 
 
 def test_dag_run_engine_runs_ready_contract_stages_through_distributed_submitter(tmp_path):
@@ -487,6 +1172,7 @@ def test_dag_run_engine_runs_ready_contract_stages_through_distributed_submitter
         artifact: dict[str, object],
         execution_contract: dict[str, object],
         timestamp: str,
+        idempotency_token: str,
     ) -> dict[str, object]:
         unit_id = str(unit["id"])
         submissions.append(
@@ -497,6 +1183,7 @@ def test_dag_run_engine_runs_ready_contract_stages_through_distributed_submitter
                 "run_root": run_root,
                 "entrypoint": execution_contract["entrypoint"],
                 "timestamp": timestamp,
+                "idempotency_token": idempotency_token,
             }
         )
         return {
@@ -511,6 +1198,7 @@ def test_dag_run_engine_runs_ready_contract_stages_through_distributed_submitter
         dag_path=dag_path,
         stage_submit_fn=_submit_stage,
         now_fn=lambda: "2026-05-07T00:00:00Z",
+        attempt_id_fn=lambda: "distributed-batch",
     )
     state, _state_path, _dag_path = engine.load_or_create_state()
 
@@ -551,6 +1239,7 @@ def test_dag_run_engine_distributed_batch_fails_when_submitter_is_missing(tmp_pa
         lab_dir=tmp_path / "lab",
         dag_path=dag_path,
         now_fn=lambda: "2026-05-07T00:00:00Z",
+        attempt_id_fn=lambda: "missing-distributed-submitter",
     )
     state, _state_path, _dag_path = engine.load_or_create_state()
 
@@ -593,7 +1282,10 @@ def test_dag_run_engine_executes_controlled_relay_stage_after_queue(tmp_path):
     repo_root = Path.cwd()
     relay_calls: list[dict[str, object]] = []
 
-    def _fake_queue_run(*, repo_root: Path, run_root: Path) -> dict[str, object]:
+    def _fake_queue_run(
+        *, repo_root: Path, run_root: Path, idempotency_token: str
+    ) -> dict[str, object]:
+        assert idempotency_token == "queue-relay-queue:queue_baseline"
         return {
             "summary_metrics_path": "queue/summary.json",
             "reduce_artifact_path": "queue/reduce.json",
@@ -605,7 +1297,9 @@ def test_dag_run_engine_executes_controlled_relay_stage_after_queue(tmp_path):
         repo_root: Path,
         run_root: Path,
         queue_result: dict[str, object],
+        idempotency_token: str,
     ) -> dict[str, object]:
+        assert idempotency_token == "queue-relay-relay:relay_followup"
         relay_calls.append({"run_root": run_root, "queue_result": queue_result})
         return {
             "summary_metrics_path": "relay/summary.json",
@@ -620,6 +1314,7 @@ def test_dag_run_engine_executes_controlled_relay_stage_after_queue(tmp_path):
             ],
         }
 
+    attempt_ids = iter(("queue-relay-queue", "queue-relay-relay"))
     engine = dag_run_engine.DagRunEngine(
         repo_root=repo_root,
         lab_dir=tmp_path,
@@ -627,6 +1322,7 @@ def test_dag_run_engine_executes_controlled_relay_stage_after_queue(tmp_path):
         run_queue_fn=_fake_queue_run,
         run_relay_fn=_fake_relay_run,
         now_fn=lambda: "2026-05-07T00:00:00Z",
+        attempt_id_fn=lambda: next(attempt_ids),
     )
     state, _state_path, _dag_path = engine.load_or_create_state()
     queue_result = engine.run_next_controlled_stage(state)
@@ -757,7 +1453,10 @@ def test_dag_engine_loads_saved_draft_and_dispatches_first_runnable_stage(tmp_pa
 
     state, state_path, loaded_dag_path = engine.load_or_create_state()
     dispatched = engine.dispatch_next_runnable(state)
-    engine.write_state(dispatched.state)
+    engine.write_state(
+        dispatched.state,
+        expected_revision=dag_run_engine.runner_state_revision(state),
+    )
     reloaded, _state_path, _dag_path = engine.load_or_create_state()
 
     assert state_path == tmp_path / "lab" / ".agilab" / "runner_state.json"

--- a/test/test_data_connector_live_endpoint_smoke_report.py
+++ b/test/test_data_connector_live_endpoint_smoke_report.py
@@ -160,6 +160,11 @@ def test_live_endpoint_smoke_covers_target_and_credential_edge_cases(tmp_path: P
 
 def test_live_endpoint_smoke_opensearch_success_and_failure_paths(monkeypatch, tmp_path: Path) -> None:
     core = _load_module(CORE_PATH, "data_connector_live_smoke_opensearch_core")
+    monkeypatch.setattr(
+        core,
+        "_resolve_host_addresses",
+        lambda _host: [core.ipaddress.ip_address("93.184.216.34")],
+    )
     connector = {
         "id": "ops",
         "kind": "opensearch",
@@ -251,8 +256,13 @@ def test_live_endpoint_smoke_blocks_unsafe_opensearch_targets_before_authorizati
         assert "unsafe live endpoint target" in row["message"]
 
 
-def test_live_endpoint_smoke_redirects_must_keep_same_safe_origin() -> None:
+def test_live_endpoint_smoke_redirects_must_keep_same_safe_origin(monkeypatch) -> None:
     core = _load_module(CORE_PATH, "data_connector_live_smoke_redirect_policy_core")
+    monkeypatch.setattr(
+        core,
+        "_resolve_host_addresses",
+        lambda _host: [core.ipaddress.ip_address("93.184.216.34")],
+    )
     handler = core._SameOriginRedirectHandler()
     req = core.request.Request("https://opensearch.example.invalid/runs-*", method="HEAD")
 

--- a/test/test_env_file_utils.py
+++ b/test/test_env_file_utils.py
@@ -65,3 +65,25 @@ def test_load_env_file_map_ignores_assignments_without_key(tmp_path: Path):
 
 def test_load_env_file_map_returns_empty_mapping_for_missing_file(tmp_path: Path):
     assert load_env_file_map(tmp_path / "missing.env") == {}
+
+
+def test_load_env_file_map_retries_windows_sharing_violation(tmp_path: Path, monkeypatch):
+    env_file = tmp_path / ".env"
+    env_file.write_text("READY=1\n", encoding="utf-8")
+    real_read_text = Path.read_text
+    attempts = 0
+
+    def _transient_read_text(path: Path, *args, **kwargs):
+        nonlocal attempts
+        if path == env_file:
+            attempts += 1
+            if attempts == 1:
+                raise PermissionError("sharing violation")
+        return real_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(env_file_utils, "_is_windows", lambda: True)
+    monkeypatch.setattr(env_file_utils.time, "sleep", lambda _delay: None)
+    monkeypatch.setattr(Path, "read_text", _transient_read_text)
+
+    assert load_env_file_map(env_file) == {"READY": "1"}
+    assert attempts == 2

--- a/test/test_global_pipeline_app_dispatch_smoke_report.py
+++ b/test/test_global_pipeline_app_dispatch_smoke_report.py
@@ -162,6 +162,41 @@ def test_app_dispatch_smoke_moves_target_project_first(
     assert module.sys.path.count(str(src_root)) == 1
 
 
+def test_app_entrypoint_reuses_completed_token_without_repeating_callback(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    module = _load_core_module()
+    callback_count = 0
+
+    def _run_once(**_kwargs):
+        nonlocal callback_count
+        callback_count += 1
+        return {"summary_metrics": {"stage_completed": 1}}
+
+    monkeypatch.setattr(module, "_run_queue_family_app_once", _run_once)
+    kwargs = {
+        "repo_root": tmp_path,
+        "run_root": tmp_path / "run",
+        "project_name": "uav_queue_project",
+        "manager_package": "uav_queue",
+        "worker_package": "uav_queue_worker",
+        "manager_class_name": "UavQueue",
+        "args_class_name": "UavQueueArgs",
+        "worker_class_name": "UavQueueWorker",
+        "target": "queue_baseline",
+        "app_entry": "fake",
+        "idempotency_token": "direct-app:queue_baseline",
+    }
+
+    first = module._run_queue_family_app(**kwargs)
+    second = module._run_queue_family_app(**kwargs)
+
+    assert callback_count == 1
+    assert second == first
+    assert second["idempotency_token"] == "direct-app:queue_baseline"
+
+
 def test_app_dispatch_smoke_report_handles_load_failure(tmp_path: Path) -> None:
     module = _load_report_module()
     missing = tmp_path / "missing.json"
@@ -285,7 +320,7 @@ def test_app_dispatch_smoke_queue_runner_requires_expected_outputs(
         UavQueueWorker=FakeWorker,
     ))
 
-    with pytest.raises(FileNotFoundError, match="summary metrics"):
+    with pytest.raises(RuntimeError, match="summary metrics"):
         module._run_queue_family_app(
             repo_root=tmp_path,
             run_root=tmp_path / "run",
@@ -297,6 +332,7 @@ def test_app_dispatch_smoke_queue_runner_requires_expected_outputs(
             worker_class_name="UavQueueWorker",
             target="target",
             app_entry="fake",
+            idempotency_token="missing-summary:queue_baseline",
         )
 
 
@@ -334,7 +370,7 @@ def test_app_dispatch_smoke_queue_runner_requires_reduce_artifact(
         UavQueueWorker=FakeWorker,
     ))
 
-    with pytest.raises(FileNotFoundError, match="reduce artifact"):
+    with pytest.raises(RuntimeError, match="reduce artifact"):
         module._run_queue_family_app(
             repo_root=tmp_path,
             run_root=run_root,
@@ -346,4 +382,5 @@ def test_app_dispatch_smoke_queue_runner_requires_reduce_artifact(
             worker_class_name="UavQueueWorker",
             target="target",
             app_entry="fake",
+            idempotency_token="missing-reduce:queue_baseline",
         )

--- a/test/test_global_pipeline_runner_state_report.py
+++ b/test/test_global_pipeline_runner_state_report.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
 import importlib.util
+import multiprocessing
+import os
+import stat
 import sys
 from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
 
 
 REPORT_PATH = Path("tools/global_pipeline_runner_state_report.py").resolve()
@@ -25,6 +31,52 @@ def _load_core_module():
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)
     return module
+
+
+def _read_runner_state_until_stopped(
+    state_path: str,
+    stop_event,
+    result_queue,
+) -> None:
+    module = _load_core_module()
+    reads = 0
+    try:
+        while not stop_event.is_set() or reads < 25:
+            state = module.load_runner_state(Path(state_path))
+            generation = int(state["generation"])
+            values = state["values"]
+            if len(values) != 4096 or any(value != generation for value in values):
+                raise AssertionError(f"partial runner-state generation observed: {generation}")
+            reads += 1
+    except BaseException as exc:
+        result_queue.put((False, reads, repr(exc)))
+        return
+    result_queue.put((True, reads, ""))
+
+
+def _attempt_runner_state_transaction(
+    state_path: str,
+    expected_revision: str,
+    start_event,
+    execution_count,
+    result_queue,
+) -> None:
+    module = _load_core_module()
+    start_event.wait(timeout=5)
+    try:
+        with module.runner_state_transaction(
+            Path(state_path),
+            expected_revision=expected_revision,
+        ) as transaction:
+            with execution_count.get_lock():
+                execution_count.value += 1
+            next_state = dict(transaction.state)
+            next_state["events"] = [*transaction.state.get("events", []), {"kind": "completed"}]
+            transaction.commit(next_state)
+    except module.RunnerStateConflictError:
+        result_queue.put("conflict")
+        return
+    result_queue.put("committed")
 
 
 def test_runner_state_report_builds_dispatch_projection() -> None:
@@ -291,3 +343,227 @@ def test_runner_state_helper_and_failure_edges(tmp_path: Path, monkeypatch) -> N
     proof = module.persist_runner_state(repo_root=tmp_path, output_path=tmp_path / "state.json")
     assert proof.ok is False
     assert proof.issues[0].location == "persistence.round_trip"
+
+
+def test_runner_state_atomic_replace_prevents_multiprocess_partial_reads(tmp_path: Path) -> None:
+    module = _load_core_module()
+    state_path = tmp_path / "runner_state.json"
+    module.write_runner_state(state_path, {"generation": 0, "values": [0] * 4096})
+    context = multiprocessing.get_context("spawn")
+    stop_event = context.Event()
+    result_queue = context.Queue()
+    reader = context.Process(
+        target=_read_runner_state_until_stopped,
+        args=(str(state_path), stop_event, result_queue),
+    )
+    reader.start()
+    try:
+        for generation in range(1, 41):
+            module.write_runner_state(
+                state_path,
+                {"generation": generation, "values": [generation] * 4096},
+            )
+    finally:
+        stop_event.set()
+        reader.join(timeout=15)
+        if reader.is_alive():
+            reader.terminate()
+            reader.join(timeout=5)
+
+    assert reader.exitcode == 0
+    ok, reads, error = result_queue.get(timeout=2)
+    assert ok, error
+    assert reads >= 25
+
+
+def test_runner_state_read_retries_windows_sharing_violation(monkeypatch, tmp_path: Path) -> None:
+    module = _load_core_module()
+    state_path = tmp_path / "runner_state.json"
+    state_path.write_text('{"generation": 1}\n', encoding="utf-8")
+    real_read_text = Path.read_text
+    attempts = 0
+
+    def _transient_read_text(path: Path, *args, **kwargs):
+        nonlocal attempts
+        if path == state_path:
+            attempts += 1
+            if attempts == 1:
+                raise PermissionError("sharing violation")
+        return real_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(module, "_is_windows", lambda: True)
+    monkeypatch.setattr(module.time, "sleep", lambda _delay: None)
+    monkeypatch.setattr(Path, "read_text", _transient_read_text)
+
+    assert module.load_runner_state(state_path) == {"generation": 1}
+    assert attempts == 2
+
+
+def test_runner_state_replace_retries_windows_sharing_violation(monkeypatch, tmp_path: Path) -> None:
+    module = _load_core_module()
+    state_path = tmp_path / "runner_state.json"
+    real_replace = module.os.replace
+    attempts = 0
+
+    def _transient_replace(source, destination):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise PermissionError("sharing violation")
+        return real_replace(source, destination)
+
+    monkeypatch.setattr(module, "_is_windows", lambda: True)
+    monkeypatch.setattr(module.time, "sleep", lambda _delay: None)
+    monkeypatch.setattr(module.os, "replace", _transient_replace)
+
+    module.write_runner_state(state_path, {"generation": 1})
+
+    assert module.load_runner_state(state_path) == {"generation": 1}
+    assert attempts == 2
+
+
+def test_runner_state_lock_times_out_instead_of_freezing_session(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    module = _load_core_module()
+    state_path = tmp_path / "runner_state.json"
+    monkeypatch.setattr(module, "_RUNNER_STATE_LOCK_TIMEOUT_SECONDS", 0.01)
+
+    with module._exclusive_runner_state_lock(state_path):
+        with pytest.raises(TimeoutError, match="Another session"):
+            with module._exclusive_runner_state_lock(state_path):
+                raise AssertionError("nested lock unexpectedly acquired")
+
+
+def test_runner_state_write_refuses_stale_revision(tmp_path: Path) -> None:
+    module = _load_core_module()
+    state_path = tmp_path / "runner_state.json"
+    initial = {"generation": 1, "events": [{"kind": "created"}]}
+    module.write_runner_state(state_path, initial)
+    stale_revision = module.runner_state_revision(initial)
+    current = {"generation": 2, "events": [{"kind": "created"}, {"kind": "completed"}]}
+    module.write_runner_state(
+        state_path,
+        current,
+        expected_revision=stale_revision,
+    )
+
+    with pytest.raises(module.RunnerStateConflictError, match="another session"):
+        module.write_runner_state(
+            state_path,
+            {"generation": 3, "events": [{"kind": "stale overwrite"}]},
+            expected_revision=stale_revision,
+        )
+
+    assert module.load_runner_state(state_path) == current
+
+
+def test_runner_state_directory_fsync_failure_keeps_committed_write_successful(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    module = _load_core_module()
+    state_path = tmp_path / "runner_state.json"
+    state = {"generation": 1, "events": [{"kind": "created"}]}
+    real_fsync = module.os.fsync
+
+    def _fail_directory_fsync(fd):
+        if stat.S_ISDIR(module.os.fstat(fd).st_mode):
+            raise OSError("directory fsync unavailable")
+        return real_fsync(fd)
+
+    monkeypatch.setattr(module.os, "fsync", _fail_directory_fsync)
+    evidence_published = False
+    with module.runner_state_write_transaction(
+        state_path,
+        state,
+        expected_revision=module.MISSING_RUNNER_STATE_REVISION,
+    ) as written_path:
+        assert written_path == state_path
+        evidence_published = True
+
+    assert evidence_published
+    assert module.load_runner_state(state_path) == state
+
+
+def test_windows_directory_flush_fails_closed_when_durability_is_unproven(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    module = _load_core_module()
+    observed_paths: list[Path] = []
+    monkeypatch.setattr(module, "os", SimpleNamespace(name="nt"))
+    monkeypatch.setattr(
+        module,
+        "_flush_windows_directory",
+        lambda path: observed_paths.append(path) or False,
+    )
+
+    assert module._fsync_runner_state_directory(tmp_path) is False
+    assert observed_paths == [tmp_path]
+
+
+def test_new_directory_hierarchy_flushes_each_parent_entry(monkeypatch, tmp_path: Path) -> None:
+    module = _load_core_module()
+    flushed: list[Path] = []
+    monkeypatch.setattr(
+        module,
+        "_fsync_runner_state_directory",
+        lambda path: flushed.append(path) or True,
+    )
+    target = tmp_path / "new-lab" / ".agilab"
+
+    assert module._ensure_directory_hierarchy_durable(target) is True
+    assert target.is_dir()
+    assert target in flushed
+    assert target.parent in flushed
+    assert tmp_path in flushed
+
+
+@pytest.mark.skipif(os.name != "nt", reason="real Windows directory handle required")
+def test_windows_directory_flush_real_helper_succeeds(tmp_path: Path) -> None:
+    module = _load_core_module()
+
+    assert module._flush_windows_directory(tmp_path) is True
+
+
+def test_runner_state_transaction_serializes_stale_multiprocess_sessions(tmp_path: Path) -> None:
+    module = _load_core_module()
+    state_path = tmp_path / "runner_state.json"
+    initial = {"events": [{"kind": "created"}]}
+    module.write_runner_state(state_path, initial)
+    expected_revision = module.runner_state_revision(initial)
+    context = multiprocessing.get_context("spawn")
+    start_event = context.Event()
+    execution_count = context.Value("i", 0)
+    result_queue = context.Queue()
+    sessions = [
+        context.Process(
+            target=_attempt_runner_state_transaction,
+            args=(
+                str(state_path),
+                expected_revision,
+                start_event,
+                execution_count,
+                result_queue,
+            ),
+        )
+        for _index in range(2)
+    ]
+    for session in sessions:
+        session.start()
+    start_event.set()
+    for session in sessions:
+        session.join(timeout=15)
+        if session.is_alive():
+            session.terminate()
+            session.join(timeout=5)
+
+    assert [session.exitcode for session in sessions] == [0, 0]
+    assert sorted(result_queue.get(timeout=2) for _index in sessions) == ["committed", "conflict"]
+    assert execution_count.value == 1
+    assert module.load_runner_state(state_path)["events"] == [
+        {"kind": "created"},
+        {"kind": "completed"},
+    ]

--- a/test/test_orchestrate_page_helpers.py
+++ b/test/test_orchestrate_page_helpers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import builtins
+from concurrent.futures import ThreadPoolExecutor
 import importlib
 import importlib.util
 import json
@@ -223,6 +224,78 @@ def test_orchestrate_readiness_cards_use_compact_path_captions(tmp_path):
         == "3 files"
     )
     assert module._compact_path_caption("short status") == "short status"
+
+
+def test_orchestrate_flight_imports_are_app_scoped_and_restore_process_state(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    module = _load_orchestrate_module()
+
+    def _build_app(project: str):
+        app_root = tmp_path / f"{project}_project"
+        app_src = app_root / "src"
+        app_src.mkdir(parents=True)
+        settings_file = app_src / "app_settings.toml"
+        settings_file.write_text("", encoding="utf-8")
+        (app_src / "flight_telemetry.py").write_text(
+            "\n".join(
+                [
+                    "from pathlib import Path",
+                    f"PROJECT = {project!r}",
+                    "class FlightArgs:",
+                    "    def __init__(self, **payload):",
+                    "        self.payload = payload",
+                    "    def to_toml_payload(self):",
+                    "        return {'project': PROJECT, **self.payload}",
+                    "def apply_source_defaults(args):",
+                    "    return args",
+                    "def load_args_from_toml(_path):",
+                    "    return FlightArgs(loaded=True)",
+                    "def dump_args_to_toml(_args, path):",
+                    "    Path(path).write_text(PROJECT, encoding='utf-8')",
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        return SimpleNamespace(
+            active_app=app_root,
+            app_settings_file=settings_file,
+        )
+
+    alpha_env = _build_app("alpha")
+    beta_env = _build_app("beta")
+    sentinel = types.ModuleType("flight_telemetry")
+    sentinel.PROJECT = "sentinel"
+    monkeypatch.setitem(sys.modules, "flight_telemetry", sentinel)
+    original_path = list(sys.path)
+
+    def _exercise(env, project: str):
+        loaded = module._load_flight_args_payload(env)
+        persisted = module._persist_flight_args_payload(env, {"value": project})
+        return loaded, persisted, Path(env.app_settings_file).read_text(encoding="utf-8")
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        alpha_future = executor.submit(_exercise, alpha_env, "alpha")
+        beta_future = executor.submit(_exercise, beta_env, "beta")
+        alpha_result = alpha_future.result(timeout=5)
+        beta_result = beta_future.result(timeout=5)
+
+    assert alpha_result == (
+        {"project": "alpha", "loaded": True},
+        {"project": "alpha", "value": "alpha"},
+        "alpha",
+    )
+    assert beta_result == (
+        {"project": "beta", "loaded": True},
+        {"project": "beta", "value": "beta"},
+        "beta",
+    )
+    assert sys.path == original_path
+    assert sys.modules["flight_telemetry"] is sentinel
+    assert str(alpha_env.active_app / "src") not in sys.path
+    assert str(beta_env.active_app / "src") not in sys.path
 
 
 def test_orchestrate_workplan_chunk_rendering_accepts_rich_chunk_records():

--- a/test/test_orchestrate_services.py
+++ b/test/test_orchestrate_services.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+from copy import deepcopy
 import importlib
 from types import SimpleNamespace
+import tomllib
 
 from pathlib import Path
 import sys
@@ -30,6 +32,7 @@ def _import_agilab_module(module_name: str):
 
 
 orchestrate_services = _import_agilab_module("agilab.orchestrate_services")
+orchestrate_support = _import_agilab_module("agilab.orchestrate_support")
 
 
 def _deps():
@@ -1401,3 +1404,214 @@ def test_render_service_panel_skips_redundant_service_health_write(monkeypatch, 
     )
 
     assert writes == []
+
+
+def test_stale_service_widgets_adopt_health_merged_by_another_session(
+    monkeypatch,
+    tmp_path,
+):
+    writes: list[tuple[object, object]] = []
+    old_health = {
+        "allow_idle": False,
+        "max_unhealthy": 0,
+        "max_restart_rate": 0.25,
+    }
+    latest_health = {
+        "allow_idle": True,
+        "max_unhealthy": 2,
+        "max_restart_rate": 0.5,
+    }
+    latest_cluster = {
+        "cluster_enabled": True,
+        "service_health": dict(latest_health),
+    }
+    old_widget_values = orchestrate_services.service_health_widget_values(
+        "demo",
+        old_health,
+    )
+    baseline_key = orchestrate_services.service_health_widget_baseline_key("demo")
+    session_state = _SessionState(
+        {
+            "args_serialized": "foo=1",
+            "app_settings": {"cluster": latest_cluster},
+            **old_widget_values,
+            baseline_key: dict(old_widget_values),
+        }
+    )
+    fake_st = _service_st(session_state)
+    monkeypatch.setattr(orchestrate_services, "st", fake_st)
+
+    deps = orchestrate_services.OrchestrateServiceDeps(
+        reset_traceback_skip=lambda: None,
+        append_log_lines=lambda lines, payload: lines.append(payload),
+        extract_result_dict_from_output=lambda raw: None,
+        evaluate_service_health_gate=lambda *args, **kwargs: (0, "ok", {}),
+        coerce_bool_setting=lambda value, default: default if value is None else bool(value),
+        coerce_int_setting=lambda value, default, minimum=0: max(
+            minimum,
+            default if value is None else int(value),
+        ),
+        coerce_float_setting=lambda value, default, minimum=0.0, maximum=1.0: min(
+            maximum,
+            max(minimum, default if value is None else float(value)),
+        ),
+        write_app_settings_toml=lambda path, payload: writes.append((path, payload)) or payload,
+        clear_load_toml_cache=lambda: None,
+        log_display_max_lines=100,
+        install_log_height=320,
+    )
+    env = SimpleNamespace(
+        app="demo",
+        apps_path=tmp_path,
+        app_settings_file=tmp_path / "app_settings.toml",
+    )
+
+    asyncio.run(
+        orchestrate_services.render_service_panel(
+            env=env,
+            project_path=tmp_path,
+            cluster_params=latest_cluster,
+            verbose=1,
+            scheduler='"127.0.0.1:8786"',
+            workers="{'127.0.0.1': 1}",
+            deps=deps,
+        )
+    )
+
+    latest_widget_values = orchestrate_services.service_health_widget_values(
+        "demo",
+        latest_health,
+    )
+    assert writes == []
+    assert latest_cluster["service_health"] == latest_health
+    assert {
+        key: session_state[key] for key in latest_widget_values
+    } == latest_widget_values
+    assert session_state[baseline_key] == latest_widget_values
+
+
+def test_stale_service_sessions_merge_distinct_health_widget_leaves(
+    monkeypatch,
+    tmp_path,
+):
+    settings_file = tmp_path / "app_settings.toml"
+    initial_health = {
+        "allow_idle": False,
+        "max_unhealthy": 0,
+        "max_restart_rate": 0.25,
+    }
+    initial_settings = {
+        "args": {},
+        "cluster": {
+            "cluster_enabled": True,
+            "service_health": dict(initial_health),
+        },
+    }
+    orchestrate_support.write_app_settings_toml(
+        settings_file,
+        initial_settings,
+    )
+
+    baseline_key = orchestrate_services.service_health_widget_baseline_key("demo")
+    initial_widget_values = orchestrate_services.service_health_widget_values(
+        "demo",
+        initial_health,
+    )
+
+    def _stale_session():
+        app_settings = deepcopy(initial_settings)
+        session_state = _SessionState(
+            {
+                "args_serialized": "foo=1",
+                "app_settings": app_settings,
+                **initial_widget_values,
+                baseline_key: dict(initial_widget_values),
+            }
+        )
+        return session_state, app_settings["cluster"]
+
+    writes: list[tuple[str, tuple[tuple[str, ...], ...]]] = []
+
+    def _deps_for(session_name: str):
+        def _write(path, payload):
+            writes.append((session_name, payload.owned_paths))
+            return orchestrate_support.write_app_settings_toml(path, payload)
+
+        return orchestrate_services.OrchestrateServiceDeps(
+            reset_traceback_skip=lambda: None,
+            append_log_lines=lambda lines, payload: lines.append(payload),
+            extract_result_dict_from_output=lambda raw: None,
+            evaluate_service_health_gate=lambda *args, **kwargs: (0, "ok", {}),
+            coerce_bool_setting=lambda value, default: (
+                default if value is None else bool(value)
+            ),
+            coerce_int_setting=lambda value, default, minimum=0: max(
+                minimum,
+                default if value is None else int(value),
+            ),
+            coerce_float_setting=lambda value, default, minimum=0.0, maximum=1.0: min(
+                maximum,
+                max(minimum, default if value is None else float(value)),
+            ),
+            write_app_settings_toml=_write,
+            clear_load_toml_cache=lambda: None,
+            log_display_max_lines=100,
+            install_log_height=320,
+        )
+
+    env = SimpleNamespace(
+        app="demo",
+        apps_path=tmp_path,
+        app_settings_file=settings_file,
+    )
+    gate_keys = orchestrate_services.service_health_gate_keys("demo")
+
+    session_a, cluster_a = _stale_session()
+    session_a[gate_keys.allow_idle] = True
+    monkeypatch.setattr(orchestrate_services, "st", _service_st(session_a))
+    asyncio.run(
+        orchestrate_services.render_service_panel(
+            env=env,
+            project_path=tmp_path,
+            cluster_params=cluster_a,
+            verbose=1,
+            scheduler='"127.0.0.1:8786"',
+            workers="{'127.0.0.1': 1}",
+            deps=_deps_for("session-a"),
+        )
+    )
+
+    session_b, cluster_b = _stale_session()
+    session_b[gate_keys.max_unhealthy] = 2
+    monkeypatch.setattr(orchestrate_services, "st", _service_st(session_b))
+    asyncio.run(
+        orchestrate_services.render_service_panel(
+            env=env,
+            project_path=tmp_path,
+            cluster_params=cluster_b,
+            verbose=1,
+            scheduler='"127.0.0.1:8786"',
+            workers="{'127.0.0.1': 1}",
+            deps=_deps_for("session-b"),
+        )
+    )
+
+    persisted = tomllib.loads(settings_file.read_text(encoding="utf-8"))
+    assert writes == [
+        (
+            "session-a",
+            (("cluster", "service_health", "allow_idle"),),
+        ),
+        (
+            "session-b",
+            (("cluster", "service_health", "max_unhealthy"),),
+        ),
+    ]
+    assert persisted["cluster"]["service_health"] == {
+        "allow_idle": True,
+        "max_unhealthy": 2,
+        "max_restart_rate": 0.25,
+    }
+    assert session_b["app_settings"]["cluster"]["service_health"] == persisted[
+        "cluster"
+    ]["service_health"]

--- a/test/test_orchestrate_support.py
+++ b/test/test_orchestrate_support.py
@@ -88,6 +88,156 @@ def test_prepare_app_settings_for_write_rejects_future_metadata_version(tmp_path
     assert not settings_file.exists()
 
 
+def test_owned_cluster_write_preserves_session_args_without_persisting_them(
+    tmp_path,
+):
+    settings_file = tmp_path / "app_settings.toml"
+    orchestrate_support.write_app_settings_toml(
+        settings_file,
+        {
+            "args": {"persisted": True},
+            "cluster": {"scheduler": "old:8780"},
+        },
+    )
+
+    session_snapshot = {
+        "args": {"persisted": True, "staged": "session-only"},
+        "cluster": {
+            "scheduler": "new:8780",
+            "cluster_enabled": True,
+        },
+    }
+    merged = orchestrate_support.write_app_settings_toml(
+        settings_file,
+        orchestrate_support.owned_app_settings_payload(
+            session_snapshot,
+            ("cluster", "scheduler"),
+            default_paths=(("cluster", "cluster_enabled"),),
+            preserved_paths=(("args",),),
+        ),
+    )
+
+    persisted = tomllib.loads(settings_file.read_text(encoding="utf-8"))
+    assert merged["args"] == session_snapshot["args"]
+    assert merged["cluster"] == {
+        "scheduler": "new:8780",
+        "cluster_enabled": True,
+    }
+    assert persisted["args"] == {"persisted": True}
+    assert persisted["cluster"] == merged["cluster"]
+
+
+def test_stale_orchestrate_sessions_merge_only_their_changed_cluster_leaves(
+    tmp_path,
+):
+    settings_file = tmp_path / "app_settings.toml"
+    initial = {
+        "cluster": {
+            "scheduler": "old:8780",
+            "user": "old-user",
+            "service_health": {"allow_idle": False},
+        }
+    }
+    orchestrate_support.write_app_settings_toml(settings_file, initial)
+    session_a_before = {"cluster": dict(initial["cluster"])}
+    session_b_before = {"cluster": dict(initial["cluster"])}
+    scheduler_widget = "cluster_scheduler__demo"
+    user_widget = "cluster_user__demo"
+    baseline_key = "cluster_widget_values__demo"
+    session_b_widgets = {}
+    orchestrate_support.reconcile_untouched_widget_values(
+        session_b_widgets,
+        baseline_key=baseline_key,
+        desired_values={
+            scheduler_widget: "old:8780",
+            user_widget: "old-user",
+        },
+    )
+    orchestrate_support.remember_rendered_widget_values(
+        session_b_widgets,
+        baseline_key=baseline_key,
+        widget_keys=(scheduler_widget, user_widget),
+    )
+
+    session_a_after = {"cluster": dict(session_a_before["cluster"])}
+    session_a_after["cluster"]["scheduler"] = "new:8780"
+    session_a_paths = orchestrate_support.changed_app_settings_paths(
+        session_a_before["cluster"],
+        session_a_after["cluster"],
+        prefix=("cluster",),
+    )
+    orchestrate_support.write_app_settings_toml(
+        settings_file,
+        orchestrate_support.owned_app_settings_payload(
+            session_a_after,
+            *session_a_paths,
+        ),
+    )
+
+    # Session B changes only its user field while its scheduler widget still
+    # carries the stale value rendered before session A's write.
+    session_b_widgets[user_widget] = "new-user"
+    orchestrate_support.reconcile_untouched_widget_values(
+        session_b_widgets,
+        baseline_key=baseline_key,
+        desired_values={
+            scheduler_widget: session_b_before["cluster"]["scheduler"],
+            user_widget: session_b_before["cluster"]["user"],
+        },
+    )
+    session_b_after = {"cluster": dict(session_b_before["cluster"])}
+    session_b_after["cluster"]["scheduler"] = session_b_widgets[scheduler_widget]
+    session_b_after["cluster"]["user"] = session_b_widgets[user_widget]
+    session_b_paths = orchestrate_support.changed_app_settings_paths(
+        session_b_before["cluster"],
+        session_b_after["cluster"],
+        prefix=("cluster",),
+    )
+    orchestrate_support.remember_rendered_widget_values(
+        session_b_widgets,
+        baseline_key=baseline_key,
+        widget_keys=(scheduler_widget, user_widget),
+    )
+    session_b_merged = orchestrate_support.write_app_settings_toml(
+        settings_file,
+        orchestrate_support.owned_app_settings_payload(
+            session_b_after,
+            *session_b_paths,
+        ),
+    )
+
+    # The next session-B rerun is a no-op. Untouched widgets must adopt the
+    # merged values before change ownership is computed, or B would restore
+    # its stale scheduler and erase session A's update.
+    orchestrate_support.reconcile_untouched_widget_values(
+        session_b_widgets,
+        baseline_key=baseline_key,
+        desired_values={
+            scheduler_widget: session_b_merged["cluster"]["scheduler"],
+            user_widget: session_b_merged["cluster"]["user"],
+        },
+    )
+    session_b_noop = {"cluster": dict(session_b_merged["cluster"])}
+    session_b_noop["cluster"]["scheduler"] = session_b_widgets[scheduler_widget]
+    session_b_noop["cluster"]["user"] = session_b_widgets[user_widget]
+    session_b_noop_paths = orchestrate_support.changed_app_settings_paths(
+        session_b_merged["cluster"],
+        session_b_noop["cluster"],
+        prefix=("cluster",),
+    )
+
+    persisted = tomllib.loads(settings_file.read_text(encoding="utf-8"))
+    assert session_a_paths == (("cluster", "scheduler"),)
+    assert session_b_paths == (("cluster", "user"),)
+    assert session_b_noop_paths == ()
+    assert session_b_widgets[scheduler_widget] == "new:8780"
+    assert persisted["cluster"] == {
+        "scheduler": "new:8780",
+        "user": "new-user",
+        "service_health": {"allow_idle": False},
+    }
+
+
 def test_evaluate_service_health_gate_detects_restart_rate():
     code, message, details = orchestrate_support.evaluate_service_health_gate(
         {

--- a/test/test_page_project_selector.py
+++ b/test/test_page_project_selector.py
@@ -291,6 +291,32 @@ def test_registered_navigation_page_prefers_main_module_route(monkeypatch) -> No
     assert module._registered_navigation_page(module.PROJECT_ROUTE_ID) is main_route
 
 
+def test_switch_to_project_page_prefers_current_session_page(monkeypatch) -> None:
+    module = _load_module()
+    current_page = SimpleNamespace(url_path="PROJECT_EDITOR")
+    other_session_page = SimpleNamespace(url_path="PROJECT_EDIT")
+    switched: list[object] = []
+    monkeypatch.setattr(
+        sys.modules["__main__"],
+        "_NAVIGATION_PAGE_ROUTES",
+        {module.PROJECT_ROUTE_ID: other_session_page},
+        raising=False,
+    )
+    streamlit = SimpleNamespace(
+        session_state={
+            module.NAVIGATION_PAGE_ROUTES_SESSION_KEY: {
+                module.PROJECT_ROUTE_ID: current_page
+            }
+        },
+        query_params={},
+        switch_page=switched.append,
+    )
+
+    assert module.switch_to_project_page(streamlit, active_app="alpha_project") is True
+    assert streamlit.query_params == {"active_app": "alpha_project"}
+    assert switched == [current_page]
+
+
 def test_registered_navigation_page_ignores_missing_or_invalid_routes(monkeypatch) -> None:
     module = _load_module()
 

--- a/test/test_pagelib.py
+++ b/test/test_pagelib.py
@@ -199,6 +199,7 @@ def test_resolve_mlflow_tracking_dir_falls_back_to_home(tmp_path):
 def test_activate_mlflow_initializes_default_experiment(tmp_path, monkeypatch):
     calls = {}
     _patch_mlflow_cli(monkeypatch)
+    monkeypatch.setattr(pagelib, "DEFAULT_SIDECAR_REGISTRY", None)
 
     class FakeSessionState(dict):
         def __getattr__(self, name):
@@ -273,6 +274,7 @@ def test_activate_mlflow_migrates_legacy_filestore(tmp_path, monkeypatch):
     (tracking_dir / "meta.yaml").write_text("legacy", encoding="utf-8")
     migrate = {}
     _patch_mlflow_cli(monkeypatch)
+    monkeypatch.setattr(pagelib, "DEFAULT_SIDECAR_REGISTRY", None)
 
     class FakeSessionState(dict):
         def __getattr__(self, name):
@@ -324,6 +326,7 @@ def test_activate_mlflow_migrates_legacy_filestore(tmp_path, monkeypatch):
 
 
 def test_activate_mlflow_reports_port_start_failure(tmp_path, monkeypatch):
+    monkeypatch.setattr(pagelib, "DEFAULT_SIDECAR_REGISTRY", None)
     errors = []
     _patch_mlflow_cli(monkeypatch)
 

--- a/test/test_pipeline_lab.py
+++ b/test/test_pipeline_lab.py
@@ -1562,7 +1562,10 @@ def test_global_runner_panel_real_run_executes_controlled_queue_stage(monkeypatc
     monkeypatch.setattr(pipeline_lab, "st", fake_st)
     calls: list[Path] = []
 
-    def _fake_queue_run(*, repo_root: Path, run_root: Path) -> dict[str, object]:
+    def _fake_queue_run(
+        *, repo_root: Path, run_root: Path, idempotency_token: str
+    ) -> dict[str, object]:
+        assert idempotency_token.endswith(":queue_baseline")
         calls.append(run_root)
         run_root.mkdir(parents=True, exist_ok=True)
         return {
@@ -1603,7 +1606,10 @@ def test_global_runner_panel_real_run_executes_active_app_template_queue_stage(m
     monkeypatch.setattr(pipeline_lab, "st", fake_st)
     calls: list[Path] = []
 
-    def _fake_queue_run(*, repo_root: Path, run_root: Path) -> dict[str, object]:
+    def _fake_queue_run(
+        *, repo_root: Path, run_root: Path, idempotency_token: str
+    ) -> dict[str, object]:
+        assert idempotency_token.endswith(":queue_baseline")
         calls.append(run_root)
         run_root.mkdir(parents=True, exist_ok=True)
         return {
@@ -1688,7 +1694,9 @@ def test_global_runner_panel_runs_ready_batch_with_distributed_backend(monkeypat
         artifact: dict[str, object],
         execution_contract: dict[str, object],
         timestamp: str,
+        idempotency_token: str,
     ) -> dict[str, object]:
+        assert idempotency_token.endswith(f":{unit['id']}")
         submissions.append(str(unit["id"]))
         return {
             "summary_metrics_path": "flight/distributed-summary.json",
@@ -1829,7 +1837,14 @@ def test_global_runner_panel_real_run_executes_controlled_relay_stage(monkeypatc
     pipeline_lab.write_runner_state(state_path, state)
     relay_calls: list[dict[str, object]] = []
 
-    def _fake_relay_run(*, repo_root: Path, run_root: Path, queue_result: dict[str, object]) -> dict[str, object]:
+    def _fake_relay_run(
+        *,
+        repo_root: Path,
+        run_root: Path,
+        queue_result: dict[str, object],
+        idempotency_token: str,
+    ) -> dict[str, object]:
+        assert idempotency_token.endswith(":relay_followup")
         relay_calls.append({"run_root": run_root, "queue_result": queue_result})
         return {
             "summary_metrics_path": "relay/summary.json",
@@ -2873,7 +2888,7 @@ def test_pipeline_lab_remaining_multi_app_dag_helper_edges(monkeypatch, tmp_path
         def distributed_stage_supported(self):
             return False
 
-        def dispatch_next_runnable(self, _state):
+        def dispatch_next_runnable_transaction(self, _state):
             return SimpleNamespace(ok=False, message="No preview step.")
 
     preview_state = {
@@ -3110,6 +3125,38 @@ def test_pipeline_lab_rebuilds_stale_synced_pipeline_state(monkeypatch, tmp_path
     assert any(event["kind"] == "run_stale" for event in state["events"])
 
 
+def test_project_preview_writer_rejects_stale_state_before_publishing_evidence(
+    monkeypatch,
+    tmp_path,
+):
+    lab_dir = tmp_path / "lab"
+    state_path = lab_dir / ".agilab" / pipeline_lab.GLOBAL_RUNNER_STATE_FILENAME
+    observed = {"generation": 1, "run_status": "planned"}
+    completed = {"generation": 2, "run_status": "completed"}
+    replacement = {"generation": 3, "run_status": "planned"}
+    pipeline_lab.write_runner_state(state_path, observed)
+    observed_revision = pipeline_lab.runner_state_revision(observed)
+    pipeline_lab.write_runner_state(state_path, completed)
+    evidence_calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        pipeline_lab,
+        "write_workflow_run_evidence",
+        lambda **kwargs: evidence_calls.append(kwargs),
+    )
+
+    with pytest.raises(pipeline_lab.RunnerStateConflictError, match="another session"):
+        pipeline_lab._write_pipeline_stages_runner_state_with_evidence(
+            state_path,
+            replacement,
+            lab_dir=lab_dir,
+            trigger={"surface": "workflow", "action": "project_stages_state_written"},
+            expected_revision=observed_revision,
+        )
+
+    assert pipeline_lab.load_runner_state(state_path) == completed
+    assert evidence_calls == []
+
+
 def test_global_runner_state_view_covers_live_action_failure_branches(monkeypatch, tmp_path):
     base_state = {
         "summary": {
@@ -3144,27 +3191,34 @@ def test_global_runner_state_view_covers_live_action_failure_branches(monkeypatc
         def distributed_stage_supported(self):
             return self._distributed
 
-        def run_next_controlled_stage(self, _state):
+        def run_next_controlled_stage_transaction(self, _state):
             if isinstance(self._run_next, BaseException):
                 raise self._run_next
-            return self._run_next or SimpleNamespace(ok=False, message="No stage is ready.", state=base_state)
+            result = self._run_next or SimpleNamespace(
+                ok=False,
+                message="No stage is ready.",
+                state=base_state,
+            )
+            if result.ok:
+                self.written.append(result.state)
+            return result
 
-        def run_ready_controlled_stages(self, _state, *, execution_backend):
+        def run_ready_controlled_stages_transaction(self, _state, *, execution_backend):
             if isinstance(self._run_ready, BaseException):
                 raise self._run_ready
-            return self._run_ready or SimpleNamespace(
+            result = self._run_ready or SimpleNamespace(
                 ok=True,
                 message="No batch work.",
                 state=base_state,
                 executed_unit_ids=(),
                 failed_unit_ids=(),
             )
+            if result.executed_unit_ids or result.failed_unit_ids:
+                self.written.append(result.state)
+            return result
 
-        def dispatch_next_runnable(self, _state):
+        def dispatch_next_runnable_transaction(self, _state):
             return self._dispatch or SimpleNamespace(ok=False, message="No preview step.")
-
-        def write_state(self, state):
-            self.written.append(state)
 
     def _render(fake_st, engine):
         monkeypatch.setattr(pipeline_lab, "st", fake_st)
@@ -3182,6 +3236,19 @@ def test_global_runner_state_view_covers_live_action_failure_branches(monkeypatc
     _render(run_next_error_st, _Engine(run_next=RuntimeError("boom")))
     assert ("error", "Controlled workflow step execution failed.") in run_next_error_st.messages
     assert ("code", "boom") in run_next_error_st.messages
+
+    stale_state_st = _FakeStreamlit(buttons={"demo_global_runner_run_next_stage": True})
+    stale_state_error = pipeline_lab.RunnerStateConflictError(
+        tmp_path / ".agilab" / "runner_state.json",
+        expected_revision="old",
+        actual_revision="new",
+    )
+    _render(stale_state_st, _Engine(run_next=stale_state_error))
+    assert (
+        "warning",
+        "Workflow state changed in another session. Reloading the latest state.",
+    ) in stale_state_st.messages
+    assert ("rerun", "called") in stale_state_st.messages
 
     run_next_warning_st = _FakeStreamlit(buttons={"demo_global_runner_run_next_stage": True})
     _render(run_next_warning_st, _Engine(run_next=SimpleNamespace(ok=False, message="No stage.", state=base_state)))

--- a/test/test_pipeline_openai.py
+++ b/test/test_pipeline_openai.py
@@ -91,6 +91,30 @@ def test_persist_env_var_refuses_env_symlink(monkeypatch, tmp_path):
         pipeline_openai.persist_env_var("OPENAI_API_KEY", "created-key")
 
 
+def test_persist_env_var_applies_update_to_latest_disjoint_content(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    env_file = tmp_path / ".agilab" / ".env"
+    env_file.parent.mkdir(parents=True)
+    env_file.write_text('# comment\nEXISTING="quoted value"\n', encoding="utf-8")
+    real_update = pipeline_openai.update_env_file_text
+
+    def _interleaved_update(path, update, **kwargs):
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write('MISTRAL_API_KEY="concurrent"\n')
+        return real_update(path, update, **kwargs)
+
+    monkeypatch.setattr(pipeline_openai, "update_env_file_text", _interleaved_update)
+
+    pipeline_openai.persist_env_var("OPENAI_API_KEY", "new-key")
+
+    assert env_file.read_text(encoding="utf-8") == (
+        '# comment\nEXISTING="quoted value"\n'
+        'MISTRAL_API_KEY="concurrent"\nOPENAI_API_KEY="new-key"\n'
+    )
+
+
 def test_make_openai_client_and_model_prefers_azure(monkeypatch):
     captured = {}
 

--- a/test/test_pipeline_run_controls.py
+++ b/test/test_pipeline_run_controls.py
@@ -3,21 +3,25 @@ from __future__ import annotations
 from contextlib import contextmanager
 import importlib
 import json
+import multiprocessing
 import os
 from pathlib import Path
 import socket
 import sys
+import time
 import types
 from types import SimpleNamespace
 
 
 def _import_pipeline_run_controls():
+    repo_root = Path(__file__).resolve().parents[1]
     src_root = Path(__file__).resolve().parents[1] / "src"
     package_root = src_root / "agilab"
     src_root_str = str(src_root)
     package_root_str = str(package_root)
-    if src_root_str not in sys.path:
-        sys.path.insert(0, src_root_str)
+    for import_root in (str(repo_root), src_root_str):
+        if import_root not in sys.path:
+            sys.path.insert(0, import_root)
     pkg = sys.modules.get("agilab")
     if pkg is None or not hasattr(pkg, "__path__"):
         pkg = types.ModuleType("agilab")
@@ -27,7 +31,25 @@ def _import_pipeline_run_controls():
     elif package_root_str not in list(pkg.__path__):
         pkg.__path__ = [package_root_str, *list(pkg.__path__)]
     importlib.invalidate_caches()
-    return importlib.import_module("agilab.pipeline_run_controls")
+    # Import the implementation directly so another test importing the legacy
+    # compatibility shim first cannot leave copied helper globals behind.
+    return importlib.import_module("agilab.pipeline.pipeline_run_controls")
+
+
+def _pipeline_lock_process(root: str, ready, release) -> None:
+    module = _import_pipeline_run_controls()
+    module.st = _FakeStreamlit()
+    root_path = Path(root)
+    env = SimpleNamespace(
+        app="demo",
+        target="demo",
+        home_abs=root_path,
+        resolve_share_path=lambda relative: root_path / "share" / relative,
+    )
+    handle = module._acquire_pipeline_run_lock(env, "page")
+    ready.put(bool(handle))
+    release.wait(timeout=10)
+    module._release_pipeline_run_lock(handle, "page")
 
 
 class _FakePlaceholder:
@@ -183,7 +205,8 @@ def test_pipeline_run_controls_lock_helpers_cover_owner_and_lifecycle_edges(tmp_
     assert "host=remote" in state["owner_text"]
 
     assert module._clear_pipeline_run_lock(env, "page", reason="test") is True
-    assert not direct_lock.exists()
+    assert direct_lock.exists()
+    assert module._read_pipeline_lock_payload(direct_lock) == {}
     assert module._clear_pipeline_run_lock(env, "page", reason="already gone") is True
 
 
@@ -212,14 +235,18 @@ def test_pipeline_run_controls_acquire_refresh_release_and_busy_lock(tmp_path, m
     assert refreshed["heartbeat_at"] >= before
 
     module._release_pipeline_run_lock(handle, "page")
-    assert not lock_path.exists()
+    assert lock_path.exists()
+    assert module._read_pipeline_lock_payload(lock_path) == {}
     assert any("Workflow lock released" in line for line in fake_st.session_state["page__run_logs"])
 
-    lock_path.write_text(json.dumps({"host": "remote", "pid": 123, "app": "demo"}), encoding="utf-8")
+    owner = module._acquire_pipeline_run_lock(env, "page")
+    assert owner is not None
     busy = module._acquire_pipeline_run_lock(env, "page")
     assert busy is None
     assert any(kind == "warning" and "already running" in message for kind, message in fake_st.messages)
+    module._release_pipeline_run_lock(owner, "page")
 
+    lock_path.write_text(json.dumps({"host": "remote", "pid": 123, "app": "demo"}), encoding="utf-8")
     old = module.time.time() - 10
     os.utime(lock_path, (old, old))
     stale_handle = module._acquire_pipeline_run_lock(env, "page")
@@ -293,9 +320,9 @@ def test_pipeline_run_controls_lock_failure_branches(tmp_path, monkeypatch):
 
     locked_dir = tmp_path / "lock-as-dir"
     locked_dir.mkdir()
-    monkeypatch.setattr(module, "_inspect_pipeline_run_lock", lambda _env: {"path": locked_dir})
+    monkeypatch.setattr(module, "_pipeline_lock_path", lambda _env: locked_dir)
     assert module._clear_pipeline_run_lock(env, "page", reason="unit-test") is False
-    assert any(kind == "error" and "Unable to remove workflow lock" in msg for kind, msg in fake_st.messages)
+    assert any(kind == "error" and "Unable to clear workflow lock" in msg for kind, msg in fake_st.messages)
 
     lock_path = tmp_path / "cannot-open.lock"
     monkeypatch.setattr(module, "_pipeline_lock_path", lambda _env: lock_path)
@@ -309,12 +336,6 @@ def test_pipeline_run_controls_lock_failure_branches(tmp_path, monkeypatch):
     module._refresh_pipeline_run_lock({"path": tmp_path / "missing.lock", "token": "token"})
 
     refresh_lock = tmp_path / "refresh.lock"
-    refresh_lock.write_text(json.dumps({"token": "other"}), encoding="utf-8")
-    module._refresh_pipeline_run_lock({"path": refresh_lock, "token": "token"})
-    assert json.loads(refresh_lock.read_text(encoding="utf-8")) == {"token": "other"}
-
-    refresh_lock.write_text(json.dumps({"token": "token"}), encoding="utf-8")
-    monkeypatch.setattr(module.os, "replace", lambda *_args: (_ for _ in ()).throw(OSError("replace failed")))
     module._refresh_pipeline_run_lock({"path": refresh_lock, "token": "token"})
 
     module._release_pipeline_run_lock(None, "page")
@@ -354,12 +375,13 @@ def test_pipeline_run_controls_stale_owner_and_retry_exhaustion_branches(tmp_pat
     assert state["stale_reason"] == "owner process is no longer running on this host"
 
     missing_lock = tmp_path / "missing-clear.lock"
-    monkeypatch.setattr(module, "_inspect_pipeline_run_lock", lambda _env: {"path": missing_lock})
+    monkeypatch.setattr(module, "_pipeline_lock_path", lambda _env: missing_lock)
     assert module._clear_pipeline_run_lock(env, "page", reason="race") is True
 
     sticky_lock = tmp_path / "sticky.lock"
     sticky_lock.write_text("{}", encoding="utf-8")
     monkeypatch.setattr(module, "_pipeline_lock_path", lambda _env: sticky_lock)
+    monkeypatch.setattr(module, "_try_pipeline_file_lock", lambda _fd: False)
     monkeypatch.setattr(
         module,
         "_inspect_pipeline_run_lock",
@@ -380,6 +402,309 @@ def test_pipeline_run_controls_stale_owner_and_retry_exhaustion_branches(tmp_pat
 
     monkeypatch.setattr(module, "_clear_pipeline_run_lock", lambda *_args, **_kwargs: False)
     assert module._acquire_pipeline_run_lock(env, "page") is None
+
+
+def test_clear_pipeline_lock_does_not_unlock_unowned_file(tmp_path, monkeypatch):
+    module = _import_pipeline_run_controls()
+    fake_st = _FakeStreamlit()
+    monkeypatch.setattr(module, "st", fake_st)
+    lock_path = tmp_path / "busy.lock"
+    monkeypatch.setattr(module, "_pipeline_lock_path", lambda _env: lock_path)
+    monkeypatch.setattr(module, "_try_pipeline_file_lock", lambda _fd: False)
+    monkeypatch.setattr(
+        module,
+        "_inspect_pipeline_run_lock",
+        lambda _env: {"owner_text": "another session"},
+    )
+    unlocks: list[int] = []
+    monkeypatch.setattr(module, "_unlock_pipeline_file", unlocks.append)
+
+    assert module._clear_pipeline_run_lock(
+        SimpleNamespace(app="demo", target="demo"),
+        "page",
+        reason="unit test",
+    ) is False
+    assert unlocks == []
+
+
+def test_pipeline_lock_holds_identity_across_refresh_release_and_stale_clear(tmp_path, monkeypatch):
+    module = _import_pipeline_run_controls()
+    fake_st = _FakeStreamlit()
+    monkeypatch.setattr(module, "st", fake_st)
+    monkeypatch.setenv("AGILAB_PIPELINE_LOCK_TTL_SEC", "0.15")
+    env = SimpleNamespace(
+        app="demo",
+        target="demo",
+        home_abs=tmp_path,
+        resolve_share_path=lambda relative: tmp_path / "share" / relative,
+    )
+
+    first = module._acquire_pipeline_run_lock(env, "page")
+    assert first is not None
+    initial_heartbeat = module._read_pipeline_lock_payload(Path(first["path"]))["heartbeat_at"]
+    target_base = tmp_path / "parallel-wave"
+    target_base.mkdir()
+    stages_file = target_base / "lab_stages.toml"
+    stages_file.write_text("", encoding="utf-8")
+    monkeypatch.setattr(module, "_resolve_stage_engine_runtime", lambda *_args, **_kwargs: ("agi.run", str(tmp_path)))
+    monkeypatch.setattr(module._pipeline_stages, "stage_summary", lambda *_args, **_kwargs: "stage")
+    monkeypatch.setattr(module._pipeline_runtime, "label_for_stage_runtime", lambda *_args, **_kwargs: "runtime")
+    monkeypatch.setattr(module._pipeline_runtime, "wrap_code_with_mlflow_resume", lambda code: code)
+    monkeypatch.setattr(module._pipeline_runtime, "python_for_stage", lambda *_args, **_kwargs: "python")
+    monkeypatch.setattr(module, "_stage_output_records", lambda *_args, **_kwargs: [])
+
+    def slow_stage(*_args, **_kwargs):
+        time.sleep(0.22)
+        return "ok"
+
+    monkeypatch.setattr(module, "_run_stage_subprocess", slow_stage)
+    records: list[dict] = []
+    assert module._run_parallel_agi_wave(
+        stages=[{"C": "print(1)"}, {"C": "print(2)"}],
+        wave=[0, 1],
+        profile="balanced",
+        env=env,
+        index_page="page",
+        stages_file=stages_file,
+        run_id="heartbeat",
+        selected_map={},
+        engine_map={},
+        default_runtime="",
+        target_base=target_base,
+        max_workers=2,
+        manifest_stage_records=records,
+        log_placeholder=None,
+    ) == 2
+    heartbeat = module._read_pipeline_lock_payload(Path(first["path"]))["heartbeat_at"]
+    assert heartbeat > initial_heartbeat
+    assert module._clear_pipeline_run_lock(env, "page", reason="expired-looking metadata") is False
+    module._release_pipeline_run_lock(first, "page")
+
+    second = module._acquire_pipeline_run_lock(env, "page")
+    assert second is not None
+    second_token = module._read_pipeline_lock_payload(Path(second["path"]))["token"]
+    module._refresh_pipeline_run_lock(first)
+    module._release_pipeline_run_lock(first, "page")
+    assert module._read_pipeline_lock_payload(Path(second["path"]))["token"] == second_token
+    module._release_pipeline_run_lock(second, "page")
+
+
+def test_pipeline_lock_is_exclusive_across_processes(tmp_path, monkeypatch):
+    module = _import_pipeline_run_controls()
+    monkeypatch.setattr(module, "st", _FakeStreamlit())
+    context = multiprocessing.get_context("spawn")
+    ready = context.Queue()
+    release = context.Event()
+    process = context.Process(target=_pipeline_lock_process, args=(str(tmp_path), ready, release))
+    process.start()
+    assert ready.get(timeout=10) is True
+    env = SimpleNamespace(
+        app="demo",
+        target="demo",
+        home_abs=tmp_path,
+        resolve_share_path=lambda relative: tmp_path / "share" / relative,
+    )
+    assert module._acquire_pipeline_run_lock(env, "page") is None
+    release.set()
+    process.join(timeout=10)
+    assert process.exitcode == 0
+
+
+def test_parallel_wave_rejects_equal_nested_and_aliased_declared_outputs(tmp_path):
+    module = _import_pipeline_run_controls()
+    env = SimpleNamespace(share_root=tmp_path)
+    stages_file = tmp_path / "lab_stages.toml"
+    stages = [
+        {
+            "id": "left",
+            "deps": ["seed"],
+            "C": "print('left')",
+            "automation": {"parallel_safe": True, "outputs": ["out/data"]},
+        },
+        {
+            "id": "right",
+            "deps": ["seed"],
+            "C": "print('right')",
+            "automation": {"parallel_safe": True, "outputs": ["out/data/result.csv"]},
+        },
+        {"id": "seed", "C": "print('seed')"},
+    ]
+
+    waves, error, _ids, _deps = module._build_stage_waves(
+        stages,
+        [2, 0, 1],
+        "balanced",
+        env=env,
+        stages_file=stages_file,
+    )
+
+    assert waves == []
+    assert error is not None
+    assert "overlapping output paths" in error
+    assert "Add a dependency to serialize" in error
+    assert module._declared_outputs_overlap("out/data", "out/data/result.csv") is True
+    assert module._declared_outputs_overlap("out/data", "out/database") is False
+    assert module._declared_outputs_overlap("a/../b", "b/result.json") is True
+    assert module._declared_outputs_overlap("Case/Output", "case/output/result.json") is True
+
+    real_dir = tmp_path / "real-output"
+    real_dir.mkdir()
+    alias_dir = tmp_path / "output-alias"
+    try:
+        alias_dir.symlink_to(real_dir, target_is_directory=True)
+    except OSError:
+        return
+    assert module._declared_outputs_overlap(
+        "output-alias/result",
+        "real-output/result/file.json",
+        env=env,
+        stages_file=stages_file,
+    ) is True
+
+
+def test_parallel_wave_serializes_stages_without_complete_output_contracts(tmp_path, monkeypatch):
+    module = _import_pipeline_run_controls()
+    env = SimpleNamespace(share_root=tmp_path)
+    stages_file = tmp_path / "lab_stages.toml"
+    stages_file.write_text("", encoding="utf-8")
+    monkeypatch.setattr(
+        module,
+        "_resolve_stage_engine_runtime",
+        lambda *_args, **_kwargs: ("agi.run", str(tmp_path / "runtime")),
+    )
+
+    unknown_stages = [
+        {"id": "seed", "C": "print('seed')"},
+        {"id": "left", "deps": ["seed"], "C": "print('left')"},
+        {"id": "right", "deps": ["seed"], "C": "print('right')"},
+    ]
+    waves, error, _ids, _deps = module._build_stage_waves(
+        unknown_stages,
+        [0, 1, 2],
+        "balanced",
+        env=env,
+        stages_file=stages_file,
+    )
+    assert error is None
+    assert waves == [[0], [1, 2]]
+    reason = module._parallel_agi_wave_ineligibility_reason(
+        unknown_stages,
+        [1, 2],
+        profile="balanced",
+        env=env,
+        stages_file=stages_file,
+        selected_map={},
+        engine_map={},
+        default_runtime="",
+    )
+
+    assert reason is not None
+    assert "parallel_safe" in reason
+    assert module._parallel_agi_wave_eligible(
+        unknown_stages,
+        [1, 2],
+        profile="balanced",
+        env=env,
+        stages_file=stages_file,
+        selected_map={},
+        engine_map={},
+        default_runtime="",
+    ) is False
+
+    safe_stage = {
+        "id": "safe",
+        "C": "print('safe')",
+        "automation": {"parallel_safe": True, "outputs": ["out/safe"]},
+    }
+    unsafe_stages = [
+        {
+            "id": "default_output",
+            "D": "out/inferred-default",
+            "C": "print('default')",
+            "automation": {"parallel_safe": True},
+        },
+        {
+            "id": "dynamic_output",
+            "C": "print('dynamic')",
+            "automation": {"parallel_safe": True, "outputs": ["out/{run_id}"]},
+        },
+        {
+            "id": "shell_variable_output",
+            "C": "print('dynamic')",
+            "automation": {"parallel_safe": True, "outputs": ["$RUN_ROOT/out"]},
+        },
+    ]
+    for unsafe_stage, expected in (
+        (unsafe_stages[0], "complete `automation.outputs`"),
+        (unsafe_stages[1], "dynamic or invalid"),
+        (unsafe_stages[2], "dynamic or invalid"),
+    ):
+        reason = module._parallel_agi_wave_ineligibility_reason(
+            [unsafe_stage, safe_stage],
+            [0, 1],
+            profile="balanced",
+            env=env,
+            stages_file=stages_file,
+            selected_map={},
+            engine_map={},
+            default_runtime="",
+        )
+        assert reason is not None
+        assert expected in reason
+
+
+def test_parallel_wave_accepts_explicit_disjoint_output_contracts(tmp_path, monkeypatch):
+    module = _import_pipeline_run_controls()
+    env = SimpleNamespace(share_root=tmp_path)
+    stages_file = tmp_path / "lab_stages.toml"
+    stages_file.write_text("", encoding="utf-8")
+    stages = [
+        {"id": "seed", "C": "print('seed')"},
+        {
+            "id": "left",
+            "deps": ["seed"],
+            "C": "print('left')",
+            "automation": {"parallel_safe": True, "outputs": ["out/left"]},
+        },
+        {
+            "id": "right",
+            "deps": ["seed"],
+            "C": "print('right')",
+            "automation": {"parallel_safe": True, "outputs": ["out/right"]},
+        },
+    ]
+    monkeypatch.setattr(
+        module,
+        "_resolve_stage_engine_runtime",
+        lambda *_args, **_kwargs: ("agi.run", str(tmp_path / "runtime")),
+    )
+
+    waves, error, _ids, _deps = module._build_stage_waves(
+        stages,
+        [0, 1, 2],
+        "balanced",
+        env=env,
+        stages_file=stages_file,
+    )
+    assert error is None
+    assert waves == [[0], [1, 2]]
+    assert module._parallel_wave_output_conflict(
+        [1, 2],
+        entries_by_idx={1: stages[1], 2: stages[2]},
+        stage_ids={1: "left", 2: "right"},
+        env=env,
+        stages_file=stages_file,
+    ) is None
+    assert module._parallel_agi_wave_eligible(
+        stages,
+        [1, 2],
+        profile="balanced",
+        env=env,
+        stages_file=stages_file,
+        selected_map={},
+        engine_map={},
+        default_runtime="",
+    ) is True
 
 
 def test_pipeline_run_controls_legacy_stage_formatting_and_clean_abort(tmp_path, monkeypatch):
@@ -449,18 +774,23 @@ def test_pipeline_run_controls_run_all_stages_executes_runpy_and_agi_run(tmp_pat
     saved_exports: list[str] = []
     mlflow_calls: list[dict] = []
 
+    class FakeTracker:
+        def __init__(self, run_id: str) -> None:
+            self.run_id = run_id
+
+        def __bool__(self) -> bool:
+            return True
+
+        def log_artifacts(self, **kwargs) -> None:
+            artifact_calls.append(kwargs)
+
     @contextmanager
-    def fake_start_mlflow_run(_env, **kwargs):
+    def fake_start_tracker_run(_env, **kwargs):
         mlflow_calls.append(kwargs)
-        yield {"run": SimpleNamespace(info=SimpleNamespace(run_id=f"run-{len(mlflow_calls)}"))}
+        yield FakeTracker(f"run-{len(mlflow_calls)}")
 
     monkeypatch.setattr(module._pipeline_runtime, "mlflow_tracking_uri", lambda _env: "sqlite:///mlflow.db")
-    monkeypatch.setattr(module._pipeline_runtime, "start_mlflow_run", fake_start_mlflow_run)
-    monkeypatch.setattr(
-        module._pipeline_runtime,
-        "log_mlflow_artifacts",
-        lambda _tracking, **kwargs: artifact_calls.append(kwargs),
-    )
+    monkeypatch.setattr(module._pipeline_runtime, "start_tracker_run", fake_start_tracker_run)
     monkeypatch.setattr(
         module._pipeline_runtime,
         "build_mlflow_process_env",

--- a/test/test_pipeline_service_guard.py
+++ b/test/test_pipeline_service_guard.py
@@ -120,7 +120,7 @@ def test_ensure_safe_service_template_preserves_manual_file(tmp_path):
     assert template_path.read_text(encoding="utf-8") == manual_content
 
 
-def test_pipeline_lock_rejects_parallel_and_recycles_stale(tmp_path, monkeypatch):
+def test_pipeline_lock_rejects_parallel_and_preserves_live_stale_looking_owner(tmp_path, monkeypatch):
     module = _load_pipeline_module()
     monkeypatch.setattr(module, "_push_run_log", lambda *args, **kwargs: None)
     monkeypatch.setattr(module.st, "warning", lambda *args, **kwargs: None)
@@ -150,6 +150,14 @@ def test_pipeline_lock_rejects_parallel_and_recycles_stale(tmp_path, monkeypatch
     os.utime(lock_path, (stale_time, stale_time))
     monkeypatch.setenv("AGILAB_PIPELINE_LOCK_TTL_SEC", "1")
 
+    # Metadata age alone must never evict a process that still holds the OS
+    # lock; the heartbeat can race with an observer changing file timestamps.
+    assert module._acquire_pipeline_run_lock(env, "idx") is None
+
+    module._release_pipeline_run_lock(first, "idx")
+    assert lock_path.exists()
+    assert module._read_pipeline_lock_payload(lock_path) == {}
+
     recycled = module._acquire_pipeline_run_lock(env, "idx")
     assert recycled is not None
     assert recycled["token"] != first["token"]
@@ -160,7 +168,8 @@ def test_pipeline_lock_rejects_parallel_and_recycles_stale(tmp_path, monkeypatch
     assert Path(recycled["path"]).exists()
 
     module._release_pipeline_run_lock(recycled, "idx")
-    assert not Path(recycled["path"]).exists()
+    assert Path(recycled["path"]).exists()
+    assert module._read_pipeline_lock_payload(Path(recycled["path"])) == {}
 
 
 def test_pipeline_lock_ttl_seconds_falls_back_on_invalid_env(monkeypatch):

--- a/test/test_ui_pages.py
+++ b/test/test_ui_pages.py
@@ -7,6 +7,8 @@ import json
 import os
 import shutil
 import sys
+import threading
+import time
 import tomllib
 import types
 from types import SimpleNamespace
@@ -17,6 +19,7 @@ from unittest.mock import patch, MagicMock
 from streamlit.testing.v1 import AppTest
 
 from agi_env import AgiEnv
+from agi_env.app_settings_support import update_app_settings_owned
 import agi_env.credential_store_support as credential_store_support
 from pydantic import BaseModel, model_validator
 
@@ -730,8 +733,8 @@ from pydantic import BaseModel
 from datetime import date
 class FlightArgs(BaseModel):
     data_source: str = "file"
-    data_in: str = ""
-    data_out: str = ""
+    data_in: str = "flight_telemetry/dataset"
+    data_out: str = "flight_telemetry/dataframe"
     files: str = "*"
     nfile: int = 1
     nskip: int = 0
@@ -963,46 +966,28 @@ def test_agilab_navigation_hides_about_and_settings_from_visible_page_list():
         encoding="utf-8"
     )
     pipeline_source = Path("src/agilab/pages/3_WORKFLOW.py").read_text(encoding="utf-8")
-    about_block = source.split("main_page = st.Page(", 1)[1].split(
-        "settings_nav_page", 1
-    )[0]
-    settings_block = source.split("settings_nav_page = st.Page(", 1)[1].split(
-        "project_page", 1
-    )[0]
-
     assert "st.navigation(_navigation_pages()).run()" in source
-    assert 'title="ABOUT"' in about_block
-    assert "default=True" in about_block
-    assert 'visibility="hidden"' in about_block
-    assert 'title="SETTINGS"' in settings_block
-    assert 'url_path="SETTINGS"' in settings_block
-    assert "_SETTINGS_PAGE_FILE" in settings_block
+    assert "_render_about_page_entry" in source
+    assert 'title="ABOUT"' in source
+    assert "default=True" in source
+    assert 'title="SETTINGS"' in source
+    assert 'url_path="SETTINGS"' in source
+    assert "_SETTINGS_PAGE_FILE" in source
+    assert 'route_ids=("settings",)' in source
     assert '_PROJECT_STATUS_PAGE_FILE = _NAVIGATION_PAGE_FILES[1]' in source
     assert '_PROJECT_PAGE_FILE = _NAVIGATION_PAGE_FILES[2]' in source
-    assert 'visibility="hidden"' in settings_block
+    assert 'visibility="hidden"' in source
     assert 'page_label="ABOUT"' not in source
     assert 'page_label="MAIN_PAGE"' in source
     assert 'page_label="SETTINGS"' in source
     assert 'title="PROJECT"' in source
     assert 'url_path="PROJECT"' in source
-    project_block = source.split("project_page = st.Page(", 1)[1].split(
-        "project_editor_page", 1
-    )[0]
-    project_editor_block = source.split("project_editor_page = st.Page(", 1)[1].split(
-        "project_status_legacy_page", 1
-    )[0]
-    project_status_legacy_block = source.split("project_status_legacy_page = st.Page(", 1)[1].split(
-        "orchestrate_page", 1
-    )[0]
-    assert "_page_file_runner(_PROJECT_STATUS_PAGE_FILE)" in project_block
-    assert 'title="PROJECT"' in project_block
-    assert 'url_path="PROJECT"' in project_block
-    assert "_page_file_runner(_PROJECT_PAGE_FILE)" in project_editor_block
-    assert 'url_path="PROJECT_EDITOR"' in project_editor_block
-    assert 'visibility="hidden"' in project_editor_block
-    assert "_page_file_runner(_PROJECT_STATUS_PAGE_FILE)" in project_status_legacy_block
-    assert 'url_path="PROJECT_STATUS"' in project_status_legacy_block
-    assert 'visibility="hidden"' in project_status_legacy_block
+    assert "_page_file_runner(_PROJECT_STATUS_PAGE_FILE)" in source
+    assert 'route_ids=("project", "project_status")' in source
+    assert "_page_file_runner(_PROJECT_PAGE_FILE)" in source
+    assert 'url_path="PROJECT_EDITOR"' in source
+    assert 'route_ids=("project_editor",)' in source
+    assert 'url_path="PROJECT_STATUS"' in source
     assert 'visibility="hidden"' in source
     assert 'title="ORCHESTRATE"' in source
     assert 'title="WORKFLOW"' in source
@@ -1042,7 +1027,7 @@ def test_review_context_expanders_render_after_primary_page_evidence():
 
 def test_orchestrate_page_exposes_analysis_preview_expander(mock_ui_env):
     at = _app_test("src/agilab/pages/2_ORCHESTRATE.py")
-    env = AgiEnv(
+    env = AgiEnv.session(
         apps_path=mock_ui_env["apps_dir"],
         app="flight_telemetry_project",
         verbose=0,
@@ -1153,6 +1138,138 @@ def test_page_module_cache_disable_does_not_store_loaded_module(tmp_path, monkey
     assert not main_page._PAGE_MODULE_CACHE
 
 
+def test_page_module_cold_load_is_published_once_across_threads(tmp_path, monkeypatch):
+    main_page = _import_agilab_module("agilab.main_page")
+    main_page._PAGE_MODULE_CACHE.clear()
+    main_page._PAGE_MODULE_NAME_CACHE.clear()
+    main_page._RESOLVED_PAGE_PATH_CACHE.clear()
+    monkeypatch.delenv("AGILAB_DISABLE_PAGE_MODULE_CACHE", raising=False)
+    monkeypatch.delenv("AGILAB_DISABLE_ALL_PAGE_CACHES", raising=False)
+
+    execution_counter = tmp_path / "page-executions.txt"
+    page_file = tmp_path / "cold_page.py"
+    page_file.write_text(
+        "from pathlib import Path\n"
+        "import time\n"
+        f"counter = Path({str(execution_counter)!r})\n"
+        "current = int(counter.read_text() or '0') if counter.exists() else 0\n"
+        "time.sleep(0.05)\n"
+        "counter.write_text(str(current + 1))\n"
+        "VALUE = object()\n",
+        encoding="utf-8",
+    )
+
+    start = threading.Barrier(3)
+    modules: list[object] = []
+    errors: list[Exception] = []
+
+    def load() -> None:
+        start.wait()
+        try:
+            modules.append(main_page._load_page_module(page_file))
+        except Exception as exc:  # pragma: no cover - asserted below
+            errors.append(exc)
+
+    workers = [threading.Thread(target=load) for _ in range(2)]
+    for worker in workers:
+        worker.start()
+    start.wait()
+    for worker in workers:
+        worker.join(timeout=5)
+
+    assert all(not worker.is_alive() for worker in workers)
+    assert errors == []
+    assert len(modules) == 2
+    assert modules[0] is modules[1]
+    assert modules[0].VALUE is modules[1].VALUE
+    assert execution_counter.read_text(encoding="utf-8") == "1"
+
+
+def test_page_file_runner_serializes_and_restores_main_process_state(
+    tmp_path, monkeypatch
+):
+    main_page = _import_agilab_module("agilab.main_page")
+    main_page._PAGE_RUNNER_CACHE.clear()
+    main_page._RESOLVED_PAGE_PATH_CACHE.clear()
+    monkeypatch.setattr(
+        main_page, "_about_resources_path", lambda: tmp_path / "resources"
+    )
+    monkeypatch.setattr(
+        main_page, "_ensure_navigation_environment", lambda *_args, **_kwargs: object()
+    )
+    monkeypatch.setattr(main_page, "_record_ui_timing_span", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(main_page, "_render_page_load_timing", lambda *_args, **_kwargs: None)
+
+    lock = threading.Lock()
+    alpha_started = threading.Event()
+    release_alpha = threading.Event()
+    records: list[tuple[str, list[str], list[str]]] = []
+    active = 0
+    max_active = 0
+
+    def _main(name: str) -> None:
+        nonlocal active, max_active
+        sys.argv = [name]
+        sys.path.insert(0, name)
+        with lock:
+            active += 1
+            max_active = max(max_active, active)
+            records.append((name, list(sys.argv), list(sys.path)))
+        if name == "alpha":
+            alpha_started.set()
+            assert release_alpha.wait(timeout=5)
+        with lock:
+            active -= 1
+
+    modules = {
+        (tmp_path / "alpha.py").resolve(): SimpleNamespace(
+            main=lambda: _main("alpha")
+        ),
+        (tmp_path / "beta.py").resolve(): SimpleNamespace(
+            main=lambda: _main("beta")
+        ),
+    }
+    monkeypatch.setattr(main_page, "_load_page_module", lambda path: modules[path])
+
+    original_argv = list(sys.argv)
+    original_path = list(sys.path)
+    errors: list[BaseException] = []
+
+    def _run(runner) -> None:
+        try:
+            runner()
+        except BaseException as exc:  # pragma: no cover - asserted below
+            errors.append(exc)
+
+    first = threading.Thread(
+        target=_run,
+        args=(main_page._page_file_runner(tmp_path / "alpha.py"),),
+    )
+    second = threading.Thread(
+        target=_run,
+        args=(main_page._page_file_runner(tmp_path / "beta.py"),),
+    )
+    first.start()
+    assert alpha_started.wait(timeout=5)
+    second.start()
+    time.sleep(0.05)
+    assert max_active == 1
+    release_alpha.set()
+    first.join(timeout=5)
+    second.join(timeout=5)
+
+    assert all(not worker.is_alive() for worker in (first, second))
+    assert errors == []
+    assert [record[0] for record in records] == ["alpha", "beta"]
+    assert records[0][1] == ["alpha"]
+    assert records[1][1] == ["beta"]
+    assert records[0][2][0] == "alpha"
+    assert records[1][2][0] == "beta"
+    assert max_active == 1
+    assert sys.argv == original_argv
+    assert sys.path == original_path
+
+
 def test_all_page_caches_disable_does_not_store_runner_or_module_name(
     tmp_path, monkeypatch
 ):
@@ -1189,7 +1306,7 @@ def test_page_module_name_is_deterministic_for_resolved_path(tmp_path):
     assert len(relative_name.rsplit("_", 1)[-1]) == 16
 
 
-def test_navigation_pages_reuses_cached_page_list_until_disabled(monkeypatch, request):
+def test_navigation_pages_reuses_cached_specs_but_returns_fresh_pages(monkeypatch, request):
     main_page = _import_agilab_module("agilab.main_page")
     main_page._NAVIGATION_PAGE_ROUTES.clear()
     main_page._NAVIGATION_PAGE_CACHE.clear()
@@ -1217,9 +1334,17 @@ def test_navigation_pages_reuses_cached_page_list_until_disabled(monkeypatch, re
 
     pages = main_page._navigation_pages()
     routes = dict(main_page._NAVIGATION_PAGE_ROUTES)
-    assert main_page._navigation_pages() is pages
-    assert main_page._NAVIGATION_PAGE_ROUTES == routes
-    assert len(created_pages) == len(pages)
+    second_pages = main_page._navigation_pages()
+    second_routes = dict(main_page._NAVIGATION_PAGE_ROUTES)
+    assert second_pages is not pages
+    assert all(second is not first for first, second in zip(pages, second_pages))
+    assert set(second_routes) == set(routes)
+    assert all(second_routes[key] is not routes[key] for key in routes)
+    assert second_routes["project_editor"] is second_pages[3]
+    assert second_routes["settings"] is second_pages[1]
+    assert second_routes["project_status"] is second_routes["project"]
+    assert second_routes["workflow"].kwargs["url_path"] == "WORKFLOW"
+    assert len(created_pages) == len(pages) * 2
     assert main_page._PAGE_CACHE_STATS["navigation_miss"] == 1
     assert main_page._PAGE_CACHE_STATS["navigation_hit"] == 1
 
@@ -1227,9 +1352,44 @@ def test_navigation_pages_reuses_cached_page_list_until_disabled(monkeypatch, re
     sentinel_page = main_page._PROJECT_PAGE_FILE.resolve()
     main_page._PAGE_MODULE_CACHE[sentinel_page] = (1, 1, "sentinel", object())
     assert main_page._navigation_pages() is not pages
-    assert len(created_pages) == len(pages) * 2
+    assert len(created_pages) == len(pages) * 3
     assert main_page._PAGE_CACHE_STATS["navigation_miss"] == 2
     assert sentinel_page in main_page._PAGE_MODULE_CACHE
+
+
+def test_navigation_page_registry_is_isolated_between_streamlit_sessions(monkeypatch):
+    main_page = _import_agilab_module("agilab.main_page")
+    main_page._NAVIGATION_PAGE_CACHE.clear()
+    main_page._PAGE_RUNNER_CACHE.clear()
+
+    def session_host(name):
+        created = []
+
+        def page(*args, **kwargs):
+            value = SimpleNamespace(session=name, args=args, kwargs=kwargs)
+            created.append(value)
+            return value
+
+        return SimpleNamespace(session_state={}, Page=page), created
+
+    first_st, first_created = session_host("first")
+    second_st, second_created = session_host("second")
+
+    monkeypatch.setattr(main_page, "st", first_st)
+    first_pages = main_page._navigation_pages()
+    first_routes = dict(main_page._NAVIGATION_PAGE_ROUTES)
+
+    monkeypatch.setattr(main_page, "st", second_st)
+    second_pages = main_page._navigation_pages()
+    second_routes = dict(main_page._NAVIGATION_PAGE_ROUTES)
+
+    assert first_created == first_pages
+    assert second_created == second_pages
+    assert all(second_routes[key] is not first_routes[key] for key in first_routes)
+    assert second_routes["analysis"] is second_pages[-1]
+
+    monkeypatch.setattr(main_page, "st", first_st)
+    assert dict(main_page._NAVIGATION_PAGE_ROUTES) == first_routes
 
 
 def test_navigation_page_signature_uses_passed_paths(tmp_path):
@@ -1357,7 +1517,7 @@ def test_execute_page_cluster_settings(mock_ui_env):
     at = _app_test("src/agilab/pages/2_ORCHESTRATE.py")
 
     # Pre-inject environment into session state
-    env = AgiEnv(
+    env = AgiEnv.session(
         apps_path=mock_ui_env["apps_dir"], app="flight_telemetry_project", verbose=0
     )
     env.init_done = True
@@ -1386,6 +1546,15 @@ def test_execute_page_cluster_settings(mock_ui_env):
             "scheduler": "127.0.0.1:8786",
         },
     }
+    update_app_settings_owned(
+        env.app_settings_file,
+        at.session_state["app_settings"],
+        owned_paths=(
+            ("cluster", "cluster_enabled"),
+            ("cluster", "pool"),
+            ("cluster", "scheduler"),
+        ),
+    )
     _seed_env_editor_state(at, env)
 
     at.run()
@@ -1693,17 +1862,26 @@ def test_execute_page_install_robot_allows_benign_uv_self_update_warning(mock_ui
     env.envars = dict(getattr(env, "envars", {}) or {})
     env.envars["AGI_CLUSTER_SHARE"] = str(cluster_share)
     at.session_state["env"] = env
-    at.session_state["app_settings"] = {
-        "args": {},
-        "cluster": {
-            "cluster_enabled": True,
-            "cython": True,
-            "pool": True,
-            "scheduler": "192.168.20.111:8786",
-            "workers": {"192.168.20.111": 1, "192.168.20.15": 1},
-            "workers_data_path": str(cluster_share),
-        },
+    cluster_settings = {
+        "cluster_enabled": True,
+        "cython": True,
+        "pool": True,
+        "scheduler": "192.168.20.111:8786",
+        "workers": {"192.168.20.111": 1, "192.168.20.15": 1},
+        "workers_data_path": str(cluster_share),
     }
+    update_app_settings_owned(
+        env.app_settings_file,
+        {"cluster": cluster_settings},
+        owned_paths=(
+            ("cluster", "cluster_enabled"),
+            ("cluster", "cython"),
+            ("cluster", "pool"),
+            ("cluster", "scheduler"),
+            ("cluster", "workers"),
+            ("cluster", "workers_data_path"),
+        ),
+    )
     _seed_env_editor_state(at, env)
     calls: list[dict[str, object]] = []
 
@@ -2890,10 +3068,11 @@ def test_execute_page_workers_data_path(mock_ui_env):
     ).resolve()
     app_state_name = Path(str(env.app)).name
     at.session_state["env"] = env
-    at.session_state["app_settings"] = {
-        "args": {},
-        "cluster": {"cluster_enabled": True},
-    }
+    update_app_settings_owned(
+        env.app_settings_file,
+        {"cluster": {"cluster_enabled": True}},
+        owned_paths=(("cluster", "cluster_enabled"),),
+    )
     _seed_env_editor_state(at, env)
 
     at.run()
@@ -2909,10 +3088,7 @@ def test_execute_page_workers_data_path(mock_ui_env):
     cluster_state = (
         app_settings.get("cluster", {}) if isinstance(app_settings, dict) else {}
     )
-    assert (
-        cluster_state.get("workers_data_path", at.session_state[wdp_key])
-        == "/data/shared"
-    )
+    assert cluster_state["workers_data_path"] == "/data/shared"
     with open(env.app_settings_file, "rb") as file:
         persisted_settings = tomllib.load(file)
     assert persisted_settings["cluster"]["workers_data_path"] == "/data/shared"

--- a/test/test_view_barycentric.py
+++ b/test/test_view_barycentric.py
@@ -762,6 +762,10 @@ def test_view_barycentric_main_reports_missing_app_and_page_errors(monkeypatch, 
             self.is_source_env = True
             self.is_worker_env = False
 
+        @classmethod
+        def session_for_app(cls, *, apps_path, app, verbose):
+            return cls(apps_path, app, verbose)
+
     monkeypatch.setattr(module, "AgiEnv", FakeEnv)
     monkeypatch.setattr(module, "page", lambda env: (_ for _ in ()).throw(RuntimeError("page boom")))
     monkeypatch.setattr(

--- a/test/test_view_data_io_decision.py
+++ b/test/test_view_data_io_decision.py
@@ -180,12 +180,13 @@ def test_view_data_io_decision_full_page_renders_artifact_evidence(monkeypatch, 
     fake_agi_env = ModuleType("agi_env")
 
     class _FakeAgiEnv:
-        for_app = None
-
         def __init__(self, **kwargs):
             self.__dict__.update(kwargs)
 
-    _FakeAgiEnv.for_app = _FakeAgiEnv
+        @classmethod
+        def session_for_app(cls, **kwargs):
+            return cls(**kwargs)
+
     fake_agi_env.AgiEnv = _FakeAgiEnv
 
     fake_pagelib = ModuleType("agi_gui.pagelib")

--- a/test/test_view_live_artifacts.py
+++ b/test/test_view_live_artifacts.py
@@ -269,6 +269,10 @@ def test_live_artifacts_rebuilds_env_when_session_env_points_to_another_apps_roo
             created.append((apps_path, app, verbose))
             super().__init__(apps_path=apps_path, app=app, verbose=verbose)
 
+        @classmethod
+        def session_for_app(cls, **kwargs):
+            return cls(**kwargs)
+
     fake_streamlit = SimpleNamespace(session_state={"env": stale_env})
     monkeypatch.setattr(module, "st", fake_streamlit)
     monkeypatch.setattr(module, "AgiEnv", FakeAgiEnv)

--- a/test/test_view_maps.py
+++ b/test/test_view_maps.py
@@ -461,6 +461,7 @@ def test_view_maps_persists_view_settings(tmp_path) -> None:
         env,
         {"ui": {"map": {"center_lat": 0.0}}},
         {"datadir": "/tmp/export", "file_ext_choice": "csv"},
+        ("datadir", "file_ext_choice"),
     )
 
     assert payload["ui"]["map"]["center_lat"] == 0.0
@@ -468,6 +469,28 @@ def test_view_maps_persists_view_settings(tmp_path) -> None:
     written = settings_path.read_text(encoding="utf-8")
     assert "view_maps" in written
     assert 'datadir = "/tmp/export"' in written
+
+
+def test_view_maps_persists_only_changed_view_leaf(tmp_path) -> None:
+    module = _load_view_maps_module()
+    settings_path = tmp_path / "app_settings.toml"
+    settings_path.write_text(
+        '[view_maps]\ndatadir = "/current"\nfile_ext_choice = "parquet"\n',
+        encoding="utf-8",
+    )
+    env = SimpleNamespace(app_settings_file=settings_path)
+
+    payload = module._persist_view_maps_settings(
+        env,
+        {"view_maps": {"datadir": "/stale", "file_ext_choice": "csv"}},
+        {"datadir": "/next", "file_ext_choice": "csv"},
+        ("datadir",),
+    )
+
+    assert payload["view_maps"] == {
+        "datadir": "/next",
+        "file_ext_choice": "parquet",
+    }
 
 
 def test_view_maps_continuous_and_discrete_helpers_set_session_state(
@@ -638,7 +661,9 @@ def test_view_maps_persist_view_maps_settings_accepts_non_dict_base(tmp_path) ->
     settings_path = tmp_path / "app_settings.toml"
     env = SimpleNamespace(app_settings_file=settings_path)
 
-    payload = module._persist_view_maps_settings(env, None, {"datadir": "/tmp/export"})
+    payload = module._persist_view_maps_settings(
+        env, None, {"datadir": "/tmp/export"}, ("datadir",)
+    )
 
     assert payload == {"view_maps": {"datadir": "/tmp/export"}}
     assert "view_maps" in settings_path.read_text(encoding="utf-8")
@@ -656,7 +681,7 @@ def test_view_maps_persist_view_maps_settings_tolerates_write_failure(
     )
 
     payload = module._persist_view_maps_settings(
-        env, {"ui": {}}, {"datadir": "/tmp/export"}
+        env, {"ui": {}}, {"datadir": "/tmp/export"}, ("datadir",)
     )
 
     assert payload["view_maps"]["datadir"] == "/tmp/export"
@@ -669,8 +694,8 @@ def test_view_maps_unexpected_helper_errors_propagate(monkeypatch, tmp_path) -> 
     settings_path.write_text('[view_maps]\ndatadir = "/tmp/export"\n', encoding="utf-8")
 
     monkeypatch.setattr(
-        module._toml,
-        "load",
+        module,
+        "read_app_settings",
         lambda *_args, **_kwargs: (_ for _ in ()).throw(TypeError("bad load")),
     )
     with pytest.raises(TypeError, match="bad load"):
@@ -688,6 +713,7 @@ def test_view_maps_unexpected_helper_errors_propagate(monkeypatch, tmp_path) -> 
             SimpleNamespace(app_settings_file=tmp_path / "persist.toml"),
             {"ui": {}},
             {"datadir": "/tmp/export"},
+            ("datadir",),
         )
 
     class _BadRelativePath:
@@ -748,6 +774,8 @@ def test_view_maps_main_initializes_env_and_invokes_page(tmp_path, monkeypatch) 
             init_done=False,
         )
         return env
+
+    fake_agi_env.session_for_app = fake_agi_env
 
     monkeypatch.setattr(module, "st", fake_st)
     monkeypatch.setattr(module, "AgiEnv", fake_agi_env)

--- a/test/test_view_maps_3d.py
+++ b/test/test_view_maps_3d.py
@@ -620,10 +620,15 @@ def test_view_maps_3d_page_bootstrap_reuses_active_app_argument(monkeypatch, tmp
         GUI_SAMPLING=4,
     )
 
-    def _fake_agi_env(apps_path, app, verbose):
-        return fake_env
+    class _FakeAgiEnv:
+        @classmethod
+        def session_for_app(cls, *, apps_path, app, verbose):
+            assert apps_path == active_app.parent
+            assert app == active_app.name
+            assert verbose == 1
+            return fake_env
 
-    monkeypatch.setattr(module, "AgiEnv", _fake_agi_env)
+    monkeypatch.setattr(module, "AgiEnv", _FakeAgiEnv)
     monkeypatch.setattr(module.sys, "argv", ["view_maps_3d.py", "--active-app", str(active_app)])
     monkeypatch.setattr(module, "st", fake_st)
     monkeypatch.setattr(module, "_list_dataset_files", lambda *_args, **_kwargs: [])
@@ -993,7 +998,8 @@ def test_view_maps_3d_bootstrap_active_app_edge_cases(monkeypatch, tmp_path) -> 
     app_dir.mkdir(parents=True)
 
     class _BrokenAgiEnv:
-        def __init__(self, **_kwargs) -> None:
+        @classmethod
+        def session_for_app(cls, **_kwargs):
             raise RuntimeError("no env")
 
     monkeypatch.setattr(module, "AgiEnv", _BrokenAgiEnv)
@@ -1134,7 +1140,7 @@ def test_view_maps_3d_page_handles_persist_and_default_color_fallbacks(monkeypat
     module.page()
 
     assert settings_path.exists()
-    assert settings_path.read_text(encoding="utf-8") == ""
+    assert settings_path.read_text(encoding="utf-8") == 'view_maps_3d = "bad"\n'
     assert fake_st.session_state[module._vm3d_key("table_max_rows")] >= 10
     assert any(fake_st.calls["pydeck_chart"])
 

--- a/test/test_view_maps_network.py
+++ b/test/test_view_maps_network.py
@@ -230,7 +230,10 @@ def test_view_maps_network_persists_app_settings(tmp_path: Path, monkeypatch) ->
         }
     )
 
-    module._persist_app_settings(SimpleNamespace(app_settings_file=settings_path))
+    module._persist_app_settings(
+        SimpleNamespace(app_settings_file=settings_path),
+        ("dataset_base_choice", "df_file", "df_files"),
+    )
 
     written = settings_path.read_text(encoding="utf-8")
     assert "view_maps_network" in written
@@ -239,6 +242,32 @@ def test_view_maps_network_persists_app_settings(tmp_path: Path, monkeypatch) ->
     assert parsed["__meta__"] == {"schema": "agilab.app_settings.v1", "version": 1}
     assert parsed["view_maps_network"]["df_file"] == ""
     assert parsed["view_maps_network"]["df_files"] == ["export.csv", ""]
+
+
+def test_view_maps_network_preserves_other_session_leaf_and_local_reference(
+    tmp_path: Path, monkeypatch
+) -> None:
+    module = _load_view_maps_network_module(monkeypatch, tmp_path)
+    settings_path = tmp_path / "app_settings.toml"
+    settings_path.write_text(
+        '[view_maps_network]\nedges_file = "current.csv"\ntraj_glob = "fresh/*.csv"\n',
+        encoding="utf-8",
+    )
+    vm_settings = {"edges_file": "next.csv", "traj_glob": "stale/*.csv"}
+    app_settings = {"view_maps_network": vm_settings}
+    module.st = SimpleNamespace(session_state={"app_settings": app_settings})
+
+    module._persist_app_settings(
+        SimpleNamespace(app_settings_file=settings_path),
+        ("edges_file",),
+    )
+
+    assert module.st.session_state["app_settings"] is app_settings
+    assert module.st.session_state["app_settings"]["view_maps_network"] is vm_settings
+    assert vm_settings == {
+        "edges_file": "next.csv",
+        "traj_glob": "fresh/*.csv",
+    }
 
 
 def test_view_maps_network_drops_ambiguous_index_levels(
@@ -1473,12 +1502,14 @@ def test_view_maps_network_handles_settings_and_active_app_error_paths(
 
     persist_path = tmp_path / "persist.toml"
     module.st = SimpleNamespace(session_state={"app_settings": "bad"})
-    module._persist_app_settings(SimpleNamespace(app_settings_file=persist_path))
+    module._persist_app_settings(
+        SimpleNamespace(app_settings_file=persist_path), ()
+    )
     assert not persist_path.exists()
 
     warnings: list[str] = []
     module.st = SimpleNamespace(
-        session_state={"app_settings": {"view_maps_network": {}}}
+        session_state={"app_settings": {"view_maps_network": {"probe": "value"}}}
     )
     monkeypatch.setattr(
         module.logger, "warning", lambda message: warnings.append(message)
@@ -1489,7 +1520,8 @@ def test_view_maps_network_handles_settings_and_active_app_error_paths(
         lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("cannot write")),
     )
     module._persist_app_settings(
-        SimpleNamespace(app_settings_file=tmp_path / "nested" / "persist.toml")
+        SimpleNamespace(app_settings_file=tmp_path / "nested" / "persist.toml"),
+        ("probe",),
     )
     assert any("Unable to persist app_settings" in message for message in warnings)
 
@@ -1506,8 +1538,8 @@ def test_view_maps_network_unexpected_helper_errors_propagate(
 
     module.st = SimpleNamespace(session_state={})
     monkeypatch.setattr(
-        module.tomllib,
-        "load",
+        module,
+        "read_app_settings",
         lambda *_args, **_kwargs: (_ for _ in ()).throw(TypeError("bad load")),
     )
     with pytest.raises(TypeError, match="bad load"):
@@ -1517,7 +1549,7 @@ def test_view_maps_network_unexpected_helper_errors_propagate(
 
     warnings: list[str] = []
     module.st = SimpleNamespace(
-        session_state={"app_settings": {"view_maps_network": {}}}
+        session_state={"app_settings": {"view_maps_network": {"probe": "value"}}}
     )
     monkeypatch.setattr(
         module.logger, "warning", lambda message: warnings.append(message)
@@ -1528,7 +1560,8 @@ def test_view_maps_network_unexpected_helper_errors_propagate(
         lambda *_args, **_kwargs: (_ for _ in ()).throw(ValueError("bad dump")),
     )
     module._persist_app_settings(
-        SimpleNamespace(app_settings_file=tmp_path / "persist.toml")
+        SimpleNamespace(app_settings_file=tmp_path / "persist.toml"),
+        ("probe",),
     )
     assert any(
         "Unable to persist app_settings" in message and "bad dump" in message

--- a/test/test_view_release_decision.py
+++ b/test/test_view_release_decision.py
@@ -1601,6 +1601,7 @@ def test_view_release_decision_surfaces_reduce_artifacts_without_metrics(tmp_pat
 
     env = SimpleNamespace(
         app="execution_pandas_project",
+        active_app=project_dir,
         target="execution_pandas_project",
         AGILAB_EXPORT_ABS=str(tmp_path / "export"),
         st_resources=tmp_path,
@@ -1633,6 +1634,7 @@ def test_view_release_decision_reuses_existing_session_env(tmp_path, monkeypatch
 
     env = SimpleNamespace(
         app="weather_forecast_project",
+        active_app=project_dir,
         target="weather_forecast",
         AGILAB_EXPORT_ABS=str(tmp_path / "export"),
         AGILAB_LOG_ABS=tmp_path / "log",
@@ -1651,3 +1653,43 @@ def test_view_release_decision_reuses_existing_session_env(tmp_path, monkeypatch
         at.run()
 
     assert not at.exception
+    assert at.session_state["env"] is env
+
+
+def test_view_release_decision_replaces_env_after_active_app_switch(
+    tmp_path, monkeypatch
+) -> None:
+    project_dir = _create_forecast_project(tmp_path)
+    worker_path = (
+        project_dir
+        / "src"
+        / "weather_forecast_worker"
+        / "weather_forecast_worker.py"
+    )
+    worker_path.parent.mkdir()
+    worker_path.write_text("", encoding="utf-8")
+    stale_project = tmp_path / "apps" / "stale_project"
+    stale_project.mkdir()
+    stale_env = SimpleNamespace(
+        app="stale_project",
+        active_app=stale_project,
+        target="stale",
+        AGILAB_EXPORT_ABS=str(tmp_path / "export"),
+        AGILAB_LOG_ABS=tmp_path / "log",
+        st_resources=tmp_path,
+    )
+    argv = [Path(PAGE_PATH).name, "--active-app", str(project_dir)]
+    with patch.object(sys, "argv", argv):
+        monkeypatch.setenv("AGI_EXPORT_DIR", str(tmp_path / "export"))
+        monkeypatch.setenv("AGI_LOCAL_SHARE", str(tmp_path / "localshare"))
+        monkeypatch.setenv("AGI_CLUSTER_SHARE", str(tmp_path / "clustershare"))
+        monkeypatch.setenv("AGI_LOG_DIR", str(tmp_path / "log"))
+        monkeypatch.setenv("OPENAI_API_KEY", "dummy")
+        monkeypatch.setenv("IS_SOURCE_ENV", "1")
+        at = AppTest.from_file(PAGE_PATH, default_timeout=20)
+        at.session_state["env"] = stale_env
+        at.run()
+
+    assert not at.exception
+    assert at.session_state["env"] is not stale_env
+    assert Path(at.session_state["env"].active_app) == project_dir

--- a/test/test_view_routing_model_comparison.py
+++ b/test/test_view_routing_model_comparison.py
@@ -258,7 +258,7 @@ def test_routing_model_comparison_scoped_env_reuses_or_initializes(
     app_path = tmp_path / "apps" / "routing_app"
     app_path.mkdir(parents=True)
     streamlit = _StreamlitStub()
-    reused_env = object()
+    reused_env = SimpleNamespace(apps_path=app_path.parent, app=app_path.name)
     streamlit.session_state["env"] = reused_env
     resets: list[tuple[dict[str, object], Path]] = []
 
@@ -267,33 +267,39 @@ def test_routing_model_comparison_scoped_env_reuses_or_initializes(
     monkeypatch.setattr(
         module,
         "reset_scoped_session_state",
-        lambda state, scope_key, active, prefixes: resets.append((state, active)),
+        lambda state, scope_key, active, prefixes: (
+            resets.append((state, active)) or False
+        ),
     )
 
     assert module._ensure_app_scoped_env() is reused_env
     assert resets == [(streamlit.session_state, app_path)]
 
-    streamlit.session_state.clear()
+    stale_env = SimpleNamespace(
+        apps_path=app_path.parent,
+        app="other_routing_app",
+    )
+    streamlit.session_state["env"] = stale_env
     created: list[dict[str, object]] = []
 
     class FakeAgiEnv:
         @staticmethod
-        def current():
-            raise RuntimeError("no current env")
-
-        @staticmethod
-        def for_app(**kwargs):
+        def session_for_app(**kwargs):
             env = type("Env", (), {})()
             created.append(kwargs)
             return env
 
     monkeypatch.setattr(module, "AgiEnv", FakeAgiEnv)
+    monkeypatch.setattr(
+        module, "reset_scoped_session_state", lambda *_args, **_kwargs: False
+    )
 
     env = module._ensure_app_scoped_env()
 
     assert created == [
         {"apps_path": app_path.parent, "app": app_path.name, "verbose": 0}
     ]
+    assert env is not stale_env
     assert getattr(env, "init_done") is True
     assert streamlit.session_state["env"] is env
 
@@ -1060,6 +1066,8 @@ def test_routing_model_comparison_app_test_renders_demand_matrix(
         monkeypatch.setenv("IS_SOURCE_ENV", "1")
         at = AppTest.from_file(str(MODULE_PATH), default_timeout=30)
         at.session_state["env"] = SimpleNamespace(
+            apps_path=app.parent,
+            app=app.name,
             agi_share_path_abs="",
             st_resources=tmp_path / "resources",
         )

--- a/test/test_view_training_analysis.py
+++ b/test/test_view_training_analysis.py
@@ -367,7 +367,7 @@ def test_view_training_analysis_loads_and_persists_app_settings(tmp_path: Path) 
     assert module.st.session_state["app_settings"]["view_training_analysis"]["trainer"] == "alpha"
 
     module.st.session_state["app_settings"] = {"view_training_analysis": {"trainer": "beta"}}
-    module._persist_app_settings(env)
+    module._persist_app_settings(env, ("trainer",))
     assert "view_training_analysis" in settings_path.read_text(encoding="utf-8")
 
     module.st = SimpleNamespace(session_state={})
@@ -377,6 +377,29 @@ def test_view_training_analysis_loads_and_persists_app_settings(tmp_path: Path) 
 
     module.st = SimpleNamespace(session_state={"app_settings": {"pages": {module.PAGE_KEY: {"tags": ["x"]}}}})
     assert module._get_page_defaults() == {"tags": ["x"]}
+
+
+def test_view_training_analysis_preserves_other_session_leaf_and_page_reference(
+    tmp_path: Path,
+) -> None:
+    module = _load_module()
+    settings_path = tmp_path / "app_settings.toml"
+    settings_path.write_text(
+        '[view_training_analysis]\ntrainer = "current"\nx_axis = "wall_time"\n',
+        encoding="utf-8",
+    )
+    page_state = {"trainer": "next", "x_axis": "stale"}
+    app_settings = {module.PAGE_KEY: page_state}
+    module.st = SimpleNamespace(session_state={"app_settings": app_settings})
+
+    module._persist_app_settings(
+        SimpleNamespace(app_settings_file=settings_path),
+        ("trainer",),
+    )
+
+    assert module.st.session_state["app_settings"] is app_settings
+    assert module.st.session_state["app_settings"][module.PAGE_KEY] is page_state
+    assert page_state == {"trainer": "next", "x_axis": "wall_time"}
 
 
 def test_view_training_analysis_repo_path_and_setting_helpers(monkeypatch, tmp_path: Path) -> None:
@@ -670,6 +693,10 @@ def test_view_training_analysis_main_bootstraps_env_when_missing(monkeypatch, tm
             self.AGILAB_EXPORT_ABS = str(export_root)
             self.init_done = False
 
+        @classmethod
+        def session_for_app(cls, *, apps_path, app, verbose):
+            return cls(apps_path, app, verbose)
+
     module.st = SimpleNamespace(
         session_state={},
         sidebar=SimpleNamespace(
@@ -739,6 +766,10 @@ def test_view_training_analysis_main_resets_state_when_active_app_changes(
             self.AGILAB_EXPORT_ABS = str(new_export)
             self.init_done = False
 
+        @classmethod
+        def session_for_app(cls, *, apps_path, app, verbose):
+            return cls(apps_path, app, verbose)
+
     module.st = SimpleNamespace(
         session_state={
             "env": old_env,
@@ -781,6 +812,10 @@ def test_view_training_analysis_main_resets_state_when_active_app_changes(
     assert module.st.session_state["env"].app == "new_trainer_project"
     assert module.st.session_state["env"].init_done is True
     assert module.st.session_state["app_settings"] == {
+        "__meta__": {
+            "schema": "agilab.app_settings.v1",
+            "version": 1,
+        },
         "view_training_analysis": {
             "base_dir_choice": "AGILAB_EXPORT",
             "datadir_rel": "",
@@ -794,7 +829,91 @@ def test_view_training_analysis_main_resets_state_when_active_app_changes(
     assert module.TRAINERS_KEY not in module.st.session_state
     assert module.RUN_ROOTS_KEY not in module.st.session_state
     assert module.TAGS_KEY not in module.st.session_state
-    assert any("No TensorBoard or training-history outputs found" in message for message in warnings_seen)
+    assert any(
+        "No TensorBoard or training-history outputs found" in message
+        for message in warnings_seen
+    )
+
+
+def test_view_training_analysis_replaces_stale_env_when_scope_key_is_current(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    module = _load_module()
+    active_app = tmp_path / "apps" / "trainer_project"
+    stale_app = tmp_path / "apps" / "other_trainer_project"
+    active_app.mkdir(parents=True)
+    stale_app.mkdir(parents=True)
+    stale_env = SimpleNamespace(apps_path=stale_app.parent, app=stale_app.name)
+    created: list[dict[str, object]] = []
+
+    class FakeEnv:
+        @classmethod
+        def session_for_app(cls, **kwargs):
+            env = SimpleNamespace(
+                apps_path=kwargs["apps_path"],
+                app=kwargs["app"],
+                init_done=False,
+            )
+            created.append(kwargs)
+            return env
+
+    module.st = SimpleNamespace(
+        session_state={
+            "env": stale_env,
+            module.APP_SCOPE_KEY: str(active_app.resolve()),
+        }
+    )
+    monkeypatch.setattr(module, "_resolve_active_app", lambda: active_app)
+    monkeypatch.setattr(module, "AgiEnv", FakeEnv)
+    monkeypatch.setattr(
+        module,
+        "reset_scoped_session_state",
+        lambda *_args, **_kwargs: pytest.fail("current page scope must not reset"),
+    )
+
+    env = module._ensure_app_scoped_env()
+
+    assert created == [
+        {"apps_path": active_app.parent, "app": active_app.name, "verbose": 0}
+    ]
+    assert env is not stale_env
+    assert env.init_done is True
+    assert module.st.session_state["env"] is env
+
+
+def test_view_training_analysis_rebinds_matching_env_after_scope_reset(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    module = _load_module()
+    active_app = tmp_path / "apps" / "trainer_project"
+    active_app.mkdir(parents=True)
+    matching_env = SimpleNamespace(
+        apps_path=active_app.parent,
+        app=active_app.name,
+    )
+    module.st = SimpleNamespace(
+        session_state={
+            "env": matching_env,
+            module.TAGS_KEY: ["stale-tag"],
+        }
+    )
+
+    class UnexpectedEnvFactory:
+        @classmethod
+        def session_for_app(cls, **_kwargs):
+            pytest.fail("matching environment must be rebound, not recreated")
+
+    monkeypatch.setattr(module, "_resolve_active_app", lambda: active_app)
+    monkeypatch.setattr(module, "AgiEnv", UnexpectedEnvFactory)
+
+    env = module._ensure_app_scoped_env()
+
+    assert env is matching_env
+    assert module.st.session_state["env"] is matching_env
+    assert module.st.session_state[module.APP_SCOPE_KEY] == str(active_app.resolve())
+    assert module.TAGS_KEY not in module.st.session_state
 
 
 def test_view_training_analysis_main_plots_selected_metrics(monkeypatch, tmp_path: Path) -> None:
@@ -1018,16 +1137,25 @@ def test_view_training_analysis_handles_active_app_and_settings_error_paths(monk
     assert module.st.session_state["app_settings"] == {}
 
     module.st = SimpleNamespace(session_state={"app_settings": "bad"})
-    module._persist_app_settings(SimpleNamespace(app_settings_file=tmp_path / "persist.toml"))
+    module._persist_app_settings(
+        SimpleNamespace(app_settings_file=tmp_path / "persist.toml"), ()
+    )
     assert not (tmp_path / "persist.toml").exists()
 
-    module.st = SimpleNamespace(session_state={"app_settings": {"view_training_analysis": {}}})
+    module.st = SimpleNamespace(
+        session_state={
+            "app_settings": {"view_training_analysis": {"probe": "value"}}
+        }
+    )
     monkeypatch.setattr(
         module,
         "_dump_toml",
         lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("dump failed")),
     )
-    module._persist_app_settings(SimpleNamespace(app_settings_file=tmp_path / "persist.toml"))
+    module._persist_app_settings(
+        SimpleNamespace(app_settings_file=tmp_path / "persist.toml"),
+        ("probe",),
+    )
 
     assert module._coerce_str_list(None) == []
     assert module._coerce_str_list(("a", "b", "a")) == ["a", "b"]
@@ -1044,21 +1172,26 @@ def test_view_training_analysis_unexpected_settings_helper_errors_propagate(
 
     module.st = SimpleNamespace(session_state={})
     monkeypatch.setattr(
-        module.tomllib,
-        "load",
+        module,
+        "read_app_settings",
         lambda *_args, **_kwargs: (_ for _ in ()).throw(TypeError("bad load")),
     )
     with pytest.raises(TypeError, match="bad load"):
         module._ensure_app_settings_loaded(SimpleNamespace(app_settings_file=settings_path))
 
-    module.st = SimpleNamespace(session_state={"app_settings": {module.PAGE_KEY: {}}})
+    module.st = SimpleNamespace(
+        session_state={"app_settings": {module.PAGE_KEY: {"probe": "value"}}}
+    )
     monkeypatch.setattr(
         module,
         "_dump_toml",
         lambda *_args, **_kwargs: (_ for _ in ()).throw(ValueError("bad dump")),
     )
     with pytest.raises(ValueError, match="bad dump"):
-        module._persist_app_settings(SimpleNamespace(app_settings_file=tmp_path / "persist.toml"))
+        module._persist_app_settings(
+            SimpleNamespace(app_settings_file=tmp_path / "persist.toml"),
+            ("probe",),
+        )
 
     monkeypatch.setattr(Path, "resolve", lambda self: (_ for _ in ()).throw(TypeError("bad path")))
     with pytest.raises(TypeError, match="bad path"):

--- a/test/test_workflow_run_manifest.py
+++ b/test/test_workflow_run_manifest.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import importlib
 import importlib.util
 import json
+import multiprocessing
+import os
 from pathlib import Path
 import sys
 
@@ -10,7 +12,13 @@ import pytest
 
 
 def _ensure_agilab_package_path() -> None:
-    package_root = Path("src/agilab").resolve()
+    repo_root = Path(__file__).resolve().parents[1]
+    repo_root_text = str(repo_root)
+    if repo_root_text not in sys.path:
+        # Spawned test workers must be able to import this test package even
+        # when pytest's importlib mode omits the checkout root from sys.path.
+        sys.path.insert(0, repo_root_text)
+    package_root = repo_root / "src" / "agilab"
     package_spec = importlib.util.spec_from_file_location(
         "agilab",
         package_root / "__init__.py",
@@ -46,6 +54,188 @@ load_workflow_run_manifest = workflow_run_manifest.load_workflow_run_manifest
 sha256_payload = workflow_run_manifest.sha256_payload
 workflow_manifest_summary = workflow_run_manifest.workflow_manifest_summary
 write_workflow_run_evidence = workflow_run_manifest.write_workflow_run_evidence
+
+
+def _workflow_evidence_writer(
+    lab_dir: str,
+    state_path: str,
+    state: dict,
+    start,
+    results,
+) -> None:
+    start.wait(timeout=10)
+    try:
+        workflow_run_manifest.write_workflow_run_evidence(
+            state=state,
+            state_path=Path(state_path),
+            repo_root=Path(lab_dir).parent,
+            lab_dir=Path(lab_dir),
+            trigger={"surface": "multiprocess", "action": "write"},
+        )
+    except BaseException as exc:
+        results.put(("error", type(exc).__name__, str(exc)))
+    else:
+        results.put(("ok", "", ""))
+
+
+def _workflow_evidence_trigger_writer(
+    lab_dir: str,
+    state_path: str,
+    state: dict,
+    trigger: dict,
+    start,
+    results,
+) -> None:
+    start.wait(timeout=10)
+    try:
+        bundle = workflow_run_manifest.write_workflow_run_evidence(
+            state=state,
+            state_path=Path(state_path),
+            repo_root=Path(lab_dir).parent,
+            lab_dir=Path(lab_dir),
+            trigger=trigger,
+        )
+    except BaseException as exc:
+        results.put(("error", type(exc).__name__, str(exc)))
+    else:
+        results.put(("ok", bundle.manifest["manifest_id"], trigger["action"]))
+
+
+def _workflow_evidence_crash_writer(lab_dir: str, state_path: str, state: dict) -> None:
+    real_write = workflow_run_manifest._write_json_fsync
+    calls = 0
+
+    def crash_after_partial_stage(path, payload):
+        nonlocal calls
+        calls += 1
+        real_write(path, payload)
+        if calls == 2:
+            os._exit(23)
+
+    workflow_run_manifest._write_json_fsync = crash_after_partial_stage
+    workflow_run_manifest.write_workflow_run_evidence(
+        state=state,
+        state_path=Path(state_path),
+        repo_root=Path(lab_dir).parent,
+        lab_dir=Path(lab_dir),
+        trigger={"surface": "crash", "action": "write"},
+    )
+
+
+def _start_spawn_processes(processes) -> None:
+    """Start spawn workers without inheriting another test's synthetic main file."""
+    main_module = sys.modules.get("__main__")
+    if main_module is None:
+        for process in processes:
+            process.start()
+        return
+
+    missing = object()
+    original_file = getattr(main_module, "__file__", missing)
+    main_module.__file__ = __file__
+    try:
+        for process in processes:
+            process.start()
+    finally:
+        if original_file is missing:
+            delattr(main_module, "__file__")
+        else:
+            main_module.__file__ = original_file
+
+
+def test_workflow_evidence_lock_times_out_instead_of_freezing_session(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    lock_path = tmp_path / ".publish.lock"
+    monkeypatch.setattr(workflow_run_manifest, "_PUBLICATION_LOCK_TIMEOUT_SECONDS", 0.01)
+
+    with workflow_run_manifest._exclusive_publication_lock(lock_path):
+        with pytest.raises(TimeoutError, match="Another session"):
+            with workflow_run_manifest._exclusive_publication_lock(lock_path):
+                raise AssertionError("nested lock unexpectedly acquired")
+
+
+def test_workflow_evidence_mutable_reads_retry_windows_sharing_violation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state_path = tmp_path / "runner_state.json"
+    state = {"run_id": "demo", "updated_at": "2026-07-16T10:00:00Z"}
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    real_read_bytes = Path.read_bytes
+    attempts = 0
+
+    def _transient_read_bytes(path: Path):
+        nonlocal attempts
+        if path == state_path:
+            attempts += 1
+            if attempts == 1:
+                raise PermissionError("sharing violation")
+        return real_read_bytes(path)
+
+    monkeypatch.setattr(workflow_run_manifest, "_is_windows", lambda: True)
+    monkeypatch.setattr(workflow_run_manifest.time, "sleep", lambda _delay: None)
+    monkeypatch.setattr(Path, "read_bytes", _transient_read_bytes)
+
+    assert workflow_run_manifest._read_matching_runner_state(
+        state=state,
+        state_path=state_path,
+    ) == state
+    assert attempts == 2
+
+
+def test_latest_workflow_evidence_retries_windows_stat_read_and_replace(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    latest_path = tmp_path / "latest_workflow_evidence.json"
+    current = {
+        "kind": "agilab.latest_workflow_evidence",
+        "manifest_id": "current",
+        "revision": {"updated_at": "2026-07-16T10:00:00Z", "event_count": 1},
+    }
+    newer = {
+        "kind": "agilab.latest_workflow_evidence",
+        "manifest_id": "newer",
+        "revision": {"updated_at": "2026-07-16T10:01:00Z", "event_count": 2},
+    }
+    latest_path.write_text(json.dumps(current), encoding="utf-8")
+    real_stat = Path.stat
+    real_read_text = Path.read_text
+    real_replace = workflow_run_manifest.os.replace
+    attempts = {"stat": 0, "read": 0, "replace": 0}
+
+    def _transient_stat(path: Path, *args, **kwargs):
+        if path == latest_path:
+            attempts["stat"] += 1
+            if attempts["stat"] == 1:
+                raise PermissionError("sharing violation")
+        return real_stat(path, *args, **kwargs)
+
+    def _transient_read(path: Path, *args, **kwargs):
+        if path == latest_path:
+            attempts["read"] += 1
+            if attempts["read"] == 1:
+                raise PermissionError("sharing violation")
+        return real_read_text(path, *args, **kwargs)
+
+    def _transient_replace(source, destination):
+        if Path(destination) == latest_path:
+            attempts["replace"] += 1
+            if attempts["replace"] == 1:
+                raise PermissionError("sharing violation")
+        return real_replace(source, destination)
+
+    monkeypatch.setattr(workflow_run_manifest, "_is_windows", lambda: True)
+    monkeypatch.setattr(workflow_run_manifest.time, "sleep", lambda _delay: None)
+    monkeypatch.setattr(Path, "stat", _transient_stat)
+    monkeypatch.setattr(Path, "read_text", _transient_read)
+    monkeypatch.setattr(workflow_run_manifest.os, "replace", _transient_replace)
+
+    assert workflow_run_manifest._write_latest_if_newer(latest_path, newer) is True
+    assert json.loads(real_read_text(latest_path, encoding="utf-8"))["manifest_id"] == "newer"
+    assert attempts == {"stat": 2, "read": 2, "replace": 2}
 
 
 def _sample_state(*, run_status: str = "completed") -> dict[str, object]:
@@ -148,7 +338,7 @@ def test_workflow_run_manifest_writes_immutable_manifest_and_ledger(tmp_path: Pa
     summary = workflow_manifest_summary(manifest)
 
     assert manifest["schema_version"] == workflow_run_manifest.WORKFLOW_RUN_MANIFEST_SCHEMA_VERSION
-    assert "-v3-" in manifest["manifest_id"]
+    assert "-v4-" in manifest["manifest_id"]
     assert manifest["status"] == "pass"
     assert first.graph == graph
     assert first.graph_path == first.manifest_path.parent / workflow_run_manifest.EVIDENCE_GRAPH_FILENAME
@@ -164,18 +354,498 @@ def test_workflow_run_manifest_writes_immutable_manifest_and_ledger(tmp_path: Pa
     assert runtime_contract.enabled_workflow_control_labels(manifest["runtime_contract"]) == ()
     assert manifest["runner_state"]["sha256"]
     assert manifest["runner_state"]["snapshot_sha256"]
+    assert manifest["runner_state"]["path"] == str(state_path)
+    assert manifest["runner_state"]["source_path"] == str(state_path)
+    assert manifest["runner_state"]["snapshot_path"] == str(first.state_snapshot_path)
+    assert json.loads(first.state_snapshot_path.read_text(encoding="utf-8")) == state
+    assert manifest["runner_state"]["sha256"] == workflow_run_manifest._sha256_file_or_empty(
+        first.state_snapshot_path
+    )
+    state_artifact = next(
+        artifact
+        for artifact in manifest["artifacts"]
+        if artifact["name"] == workflow_run_manifest.RUNNER_STATE_SNAPSHOT_FILENAME
+    )
+    assert state_artifact["path"] == str(first.state_snapshot_path)
+    assert state_artifact["source_path"] == str(state_path)
+    assert state_artifact["sha256"] == manifest["runner_state"]["sha256"]
     assert ledger["manifest_id"] == manifest["manifest_id"]
     assert ledger["claims"]
     assert {
         artifact["name"]
         for artifact in ledger["artifacts"]
     } >= {workflow_run_manifest.EVIDENCE_GRAPH_FILENAME, workflow_run_manifest.WORKFLOW_RUN_MANIFEST_FILENAME}
+    assert workflow_run_manifest.RUNNER_STATE_SNAPSHOT_FILENAME in {
+        artifact["name"] for artifact in ledger["artifacts"]
+    }
     assert {
         evidence["sha256"]
         for claim in ledger["claims"]
         for evidence in claim["evidence"]
         if evidence["kind"] == "agilab.workflow_run_manifest"
     } == {sha256_payload(manifest)}
+    completion = json.loads(
+        (first.manifest_path.parent / workflow_run_manifest.WORKFLOW_EVIDENCE_COMPLETION_FILENAME).read_text(
+            encoding="utf-8"
+        )
+    )
+    assert completion["manifest_id"] == manifest["manifest_id"]
+    assert completion["files"][workflow_run_manifest.RUNNER_STATE_SNAPSHOT_FILENAME] == (
+        manifest["runner_state"]["sha256"]
+    )
+    workflow_run_manifest._validate_completion_marker(first.manifest_path.parent, manifest["manifest_id"])
+
+
+def test_workflow_evidence_rejects_state_that_differs_from_single_persisted_read(
+    tmp_path: Path,
+) -> None:
+    lab_dir = tmp_path / "lab"
+    state_path = lab_dir / ".agilab" / "runner_state.json"
+    state_path.parent.mkdir(parents=True)
+    persisted_state = _sample_state()
+    stale_state = json.loads(json.dumps(persisted_state))
+    stale_state["updated_at"] = "2026-05-12T07:59:00Z"
+    state_path.write_text(json.dumps(persisted_state, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Runner state changed before evidence publication"):
+        write_workflow_run_evidence(
+            state=stale_state,
+            state_path=state_path,
+            repo_root=tmp_path,
+            lab_dir=lab_dir,
+        )
+
+    assert not workflow_run_manifest.workflow_evidence_root(lab_dir).exists()
+
+
+def test_two_process_state_a_b_publication_rejects_stale_a(tmp_path: Path) -> None:
+    lab_dir = tmp_path / "lab"
+    state_path = lab_dir / ".agilab" / "runner_state.json"
+    state_path.parent.mkdir(parents=True)
+    state_a = _sample_state()
+    state_b = json.loads(json.dumps(state_a))
+    state_b["updated_at"] = "2026-05-12T08:02:00Z"
+    state_path.write_text(json.dumps(state_b, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    context = multiprocessing.get_context("spawn")
+    start = context.Event()
+    results = context.Queue()
+    processes = [
+        context.Process(
+            target=_workflow_evidence_writer,
+            args=(str(lab_dir), str(state_path), state, start, results),
+        )
+        for state in (state_a, state_b)
+    ]
+    _start_spawn_processes(processes)
+    start.set()
+    outcomes = [results.get(timeout=15) for _ in processes]
+    for process in processes:
+        process.join(timeout=15)
+        assert process.exitcode == 0
+
+    assert sum(outcome[0] == "ok" for outcome in outcomes) == 1
+    errors = [outcome for outcome in outcomes if outcome[0] == "error"]
+    assert len(errors) == 1
+    assert errors[0][1] == "ValueError"
+    assert "Runner state changed before evidence publication" in errors[0][2]
+    latest = json.loads(
+        (
+            workflow_run_manifest.workflow_evidence_root(lab_dir)
+            / LATEST_WORKFLOW_EVIDENCE_FILENAME
+        ).read_text(encoding="utf-8")
+    )
+    manifest = load_workflow_run_manifest(Path(latest["manifest_path"]))
+    assert manifest["created_at"] == state_b["updated_at"]
+
+
+def test_workflow_evidence_publication_is_multiprocess_safe(tmp_path: Path) -> None:
+    lab_dir = tmp_path / "lab"
+    state_path = lab_dir / ".agilab" / "runner_state.json"
+    state_path.parent.mkdir(parents=True)
+    state = _sample_state()
+    state_path.write_text(json.dumps(state, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    context = multiprocessing.get_context("spawn")
+    start = context.Event()
+    results = context.Queue()
+    processes = [
+        context.Process(
+            target=_workflow_evidence_writer,
+            args=(str(lab_dir), str(state_path), state, start, results),
+        )
+        for _ in range(2)
+    ]
+    _start_spawn_processes(processes)
+    start.set()
+    outcomes = [results.get(timeout=15) for _ in processes]
+    for process in processes:
+        process.join(timeout=15)
+        assert process.exitcode == 0
+
+    assert outcomes == [("ok", "", ""), ("ok", "", "")]
+    root = workflow_run_manifest.workflow_evidence_root(lab_dir)
+    assert list(root.glob(".*.staging")) == []
+    latest = json.loads((root / LATEST_WORKFLOW_EVIDENCE_FILENAME).read_text(encoding="utf-8"))
+    bundle_dir = Path(latest["manifest_path"]).parent
+    workflow_run_manifest._validate_completion_marker(bundle_dir, latest["manifest_id"])
+
+
+def test_same_state_different_triggers_publish_distinct_bundles_concurrently(tmp_path: Path) -> None:
+    lab_dir = tmp_path / "lab"
+    state_path = lab_dir / ".agilab" / "runner_state.json"
+    state_path.parent.mkdir(parents=True)
+    state = _sample_state()
+    state_path.write_text(json.dumps(state, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    context = multiprocessing.get_context("spawn")
+    start = context.Event()
+    results = context.Queue()
+    triggers = [
+        {"surface": "test", "action": "one"},
+        {"surface": "test", "action": "two"},
+    ]
+    processes = [
+        context.Process(
+            target=_workflow_evidence_trigger_writer,
+            args=(str(lab_dir), str(state_path), state, trigger, start, results),
+        )
+        for trigger in triggers
+    ]
+
+    _start_spawn_processes(processes)
+    start.set()
+    outcomes = [results.get(timeout=15) for _ in processes]
+    for process in processes:
+        process.join(timeout=15)
+        assert process.exitcode == 0
+
+    assert {outcome[0] for outcome in outcomes} == {"ok"}
+    manifest_ids = {outcome[1] for outcome in outcomes}
+    assert len(manifest_ids) == 2
+    assert {outcome[2] for outcome in outcomes} == {"one", "two"}
+    root = workflow_run_manifest.workflow_evidence_root(lab_dir)
+    for manifest_id in manifest_ids:
+        manifest_path = root / manifest_id / workflow_run_manifest.WORKFLOW_RUN_MANIFEST_FILENAME
+        manifest = load_workflow_run_manifest(manifest_path)
+        assert manifest["trigger"]["action"] in {"one", "two"}
+
+
+@pytest.mark.parametrize(
+    ("filename", "mutate"),
+    [
+        (
+            workflow_run_manifest.WORKFLOW_RUN_MANIFEST_FILENAME,
+            lambda payload: {**payload, "status": "fail"},
+        ),
+        (
+            workflow_run_manifest.EVIDENCE_LEDGER_FILENAME,
+            lambda payload: {**payload, "tampered": True},
+        ),
+        (
+            workflow_run_manifest.EVIDENCE_GRAPH_FILENAME,
+            lambda payload: {**payload, "tampered": True},
+        ),
+    ],
+)
+def test_v4_manifest_load_rejects_valid_json_bundle_tampering(
+    tmp_path: Path,
+    filename: str,
+    mutate,
+) -> None:
+    lab_dir = tmp_path / "lab"
+    state_path = lab_dir / ".agilab" / "runner_state.json"
+    state_path.parent.mkdir(parents=True)
+    state = _sample_state()
+    state_path.write_text(json.dumps(state, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    bundle = write_workflow_run_evidence(
+        state=state,
+        state_path=state_path,
+        repo_root=tmp_path,
+        lab_dir=lab_dir,
+    )
+    tampered_path = bundle.manifest_path.parent / filename
+    payload = json.loads(tampered_path.read_text(encoding="utf-8"))
+    tampered_path.write_text(
+        json.dumps(mutate(payload), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match=f"completion hash mismatch for .*{filename}"):
+        load_workflow_run_manifest(bundle.manifest_path)
+
+
+def test_v4_manifest_load_rejects_schema_downgrade_tampering(tmp_path: Path) -> None:
+    lab_dir = tmp_path / "lab"
+    state_path = lab_dir / ".agilab" / "runner_state.json"
+    state_path.parent.mkdir(parents=True)
+    state = _sample_state()
+    state_path.write_text(json.dumps(state, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    bundle = write_workflow_run_evidence(
+        state=state,
+        state_path=state_path,
+        repo_root=tmp_path,
+        lab_dir=lab_dir,
+    )
+    payload = json.loads(bundle.manifest_path.read_text(encoding="utf-8"))
+    payload["schema_version"] = 3
+    bundle.manifest_path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=f"completion hash mismatch for .*{workflow_run_manifest.WORKFLOW_RUN_MANIFEST_FILENAME}",
+    ):
+        load_workflow_run_manifest(bundle.manifest_path)
+
+
+def test_manifest_load_hashes_the_same_bytes_it_parses(tmp_path: Path, monkeypatch) -> None:
+    lab_dir = tmp_path / "lab"
+    state_path = lab_dir / ".agilab" / "runner_state.json"
+    state_path.parent.mkdir(parents=True)
+    state = _sample_state()
+    state_path.write_text(json.dumps(state, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    bundle = write_workflow_run_evidence(
+        state=state,
+        state_path=state_path,
+        repo_root=tmp_path,
+        lab_dir=lab_dir,
+    )
+    original_bytes = bundle.manifest_path.read_bytes()
+    tampered = json.loads(original_bytes)
+    tampered["status"] = "fail"
+    bundle.manifest_path.write_text(
+        json.dumps(tampered, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    original_validator = workflow_run_manifest.validate_workflow_runtime_contract
+
+    def restore_manifest_during_validation(runtime_contract):
+        bundle.manifest_path.write_bytes(original_bytes)
+        return original_validator(runtime_contract)
+
+    monkeypatch.setattr(
+        workflow_run_manifest,
+        "validate_workflow_runtime_contract",
+        restore_manifest_during_validation,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=f"completion hash mismatch for .*{workflow_run_manifest.WORKFLOW_RUN_MANIFEST_FILENAME}",
+    ):
+        load_workflow_run_manifest(bundle.manifest_path)
+
+
+def test_delayed_older_bundle_cannot_replace_newer_latest_pointer(tmp_path: Path) -> None:
+    lab_dir = tmp_path / "lab"
+    state_path = lab_dir / ".agilab" / "runner_state.json"
+    state_path.parent.mkdir(parents=True)
+    state_a = _sample_state()
+    state_a["updated_at"] = "2026-05-12T08:01:00Z"
+    state_b = json.loads(json.dumps(state_a))
+    state_b["updated_at"] = "2026-05-12T08:02:00Z"
+
+    state_path.write_text(json.dumps(state_b, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    newer = write_workflow_run_evidence(
+        state=state_b,
+        state_path=state_path,
+        repo_root=tmp_path,
+        lab_dir=lab_dir,
+    )
+    state_path.write_text(json.dumps(state_a, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    older = write_workflow_run_evidence(
+        state=state_a,
+        state_path=state_path,
+        repo_root=tmp_path,
+        lab_dir=lab_dir,
+    )
+
+    assert older.manifest_path.is_file()
+    latest = json.loads(newer.latest_path.read_text(encoding="utf-8"))
+    assert latest["manifest_id"] == newer.manifest["manifest_id"]
+    assert latest["manifest_id"] != older.manifest["manifest_id"]
+    assert latest["revision"] == {
+        "run_created_at": state_b["created_at"],
+        "updated_at": state_b["updated_at"],
+        "event_count": len(state_b["events"]),
+        "tie_breaker": newer.manifest["manifest_id"],
+    }
+
+
+def test_workflow_evidence_crash_before_publish_leaves_no_visible_partial_bundle(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    lab_dir = tmp_path / "lab"
+    state_path = lab_dir / ".agilab" / "runner_state.json"
+    state_path.parent.mkdir(parents=True)
+    state = _sample_state()
+    state_path.write_text(json.dumps(state, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    manifest = workflow_run_manifest.build_workflow_run_manifest(
+        state=state,
+        state_path=state_path,
+        repo_root=tmp_path,
+        lab_dir=lab_dir,
+    )
+    final_dir = workflow_run_manifest.workflow_evidence_paths(
+        lab_dir, str(manifest["manifest_id"])
+    )[0].parent
+    real_write = workflow_run_manifest._write_json_fsync
+    calls = 0
+
+    def fail_during_stage(path, payload):
+        nonlocal calls
+        calls += 1
+        real_write(path, payload)
+        if calls == 2:
+            raise OSError("simulated publication crash")
+
+    monkeypatch.setattr(workflow_run_manifest, "_write_json_fsync", fail_during_stage)
+    with pytest.raises(OSError, match="simulated publication crash"):
+        write_workflow_run_evidence(
+            state=state,
+            state_path=state_path,
+            repo_root=tmp_path,
+            lab_dir=lab_dir,
+        )
+
+    root = workflow_run_manifest.workflow_evidence_root(lab_dir)
+    assert not final_dir.exists()
+    assert not (root / LATEST_WORKFLOW_EVIDENCE_FILENAME).exists()
+    assert list(root.glob(".*.staging")) == []
+
+
+def test_workflow_evidence_process_crash_is_ignored_and_recovered(tmp_path: Path) -> None:
+    lab_dir = tmp_path / "lab"
+    state_path = lab_dir / ".agilab" / "runner_state.json"
+    state_path.parent.mkdir(parents=True)
+    state = _sample_state()
+    state_path.write_text(json.dumps(state, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    context = multiprocessing.get_context("spawn")
+    process = context.Process(
+        target=_workflow_evidence_crash_writer,
+        args=(str(lab_dir), str(state_path), state),
+    )
+    _start_spawn_processes([process])
+    process.join(timeout=15)
+    assert process.exitcode == 23
+
+    root = workflow_run_manifest.workflow_evidence_root(lab_dir)
+    assert not (root / LATEST_WORKFLOW_EVIDENCE_FILENAME).exists()
+    assert list(root.glob(".*.staging"))
+
+    bundle = write_workflow_run_evidence(
+        state=state,
+        state_path=state_path,
+        repo_root=tmp_path,
+        lab_dir=lab_dir,
+        trigger={"surface": "crash", "action": "write"},
+    )
+
+    assert list(root.glob(".*.staging")) == []
+    workflow_run_manifest._validate_completion_marker(bundle.manifest_path.parent, bundle.manifest["manifest_id"])
+
+
+def test_workflow_evidence_repairs_partial_legacy_completion_marker(tmp_path: Path) -> None:
+    lab_dir = tmp_path / "lab"
+    state_path = lab_dir / ".agilab" / "runner_state.json"
+    state_path.parent.mkdir(parents=True)
+    state = _sample_state()
+    state_path.write_text(json.dumps(state, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    bundle = write_workflow_run_evidence(
+        state=state,
+        state_path=state_path,
+        repo_root=tmp_path,
+        lab_dir=lab_dir,
+    )
+    completion_path = (
+        bundle.manifest_path.parent / workflow_run_manifest.WORKFLOW_EVIDENCE_COMPLETION_FILENAME
+    )
+    completion_path.write_text('{"schema_version":', encoding="utf-8")
+
+    repaired = write_workflow_run_evidence(
+        state=state,
+        state_path=state_path,
+        repo_root=tmp_path,
+        lab_dir=lab_dir,
+    )
+
+    workflow_run_manifest._validate_completion_marker(
+        repaired.manifest_path.parent,
+        repaired.manifest["manifest_id"],
+    )
+    assert list(completion_path.parent.glob(f".{completion_path.name}.*.tmp")) == []
+
+
+def test_legacy_bundle_completion_backfill_does_not_require_state_snapshot(
+    tmp_path: Path,
+) -> None:
+    bundle_dir = tmp_path / "legacy-v3"
+    bundle_dir.mkdir()
+    manifest_id = "legacy-v3-run"
+    workflow_run_manifest._write_json(
+        bundle_dir / workflow_run_manifest.WORKFLOW_RUN_MANIFEST_FILENAME,
+        {
+            "schema_version": 3,
+            "kind": workflow_run_manifest.WORKFLOW_RUN_MANIFEST_KIND,
+            "manifest_id": manifest_id,
+            "state_snapshot": {"sha256": "legacy-digest", "event_count": 1},
+        },
+    )
+    workflow_run_manifest._write_json(
+        bundle_dir / workflow_run_manifest.EVIDENCE_GRAPH_FILENAME,
+        {"kind": "legacy-graph"},
+    )
+    workflow_run_manifest._write_json(
+        bundle_dir / workflow_run_manifest.EVIDENCE_LEDGER_FILENAME,
+        {"kind": "legacy-ledger"},
+    )
+
+    completion_path = workflow_run_manifest._backfill_completion_marker(
+        bundle_dir,
+        manifest_id,
+    )
+
+    completion = json.loads(completion_path.read_text(encoding="utf-8"))
+    assert set(completion["files"]) == {
+        workflow_run_manifest.WORKFLOW_RUN_MANIFEST_FILENAME,
+        workflow_run_manifest.EVIDENCE_GRAPH_FILENAME,
+        workflow_run_manifest.EVIDENCE_LEDGER_FILENAME,
+    }
+    workflow_run_manifest._validate_completion_marker(bundle_dir, manifest_id)
+
+
+def test_immutable_json_publish_failure_leaves_no_partial_final_path(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    immutable_path = tmp_path / workflow_run_manifest.WORKFLOW_EVIDENCE_COMPLETION_FILENAME
+
+    def fail_publish(_source, _destination):
+        raise OSError("simulated atomic publish failure")
+
+    monkeypatch.setattr(workflow_run_manifest.os, "replace", fail_publish)
+    with pytest.raises(OSError, match="simulated atomic publish failure"):
+        workflow_run_manifest._write_immutable_json(immutable_path, {"a": 1})
+
+    assert not immutable_path.exists()
+    assert list(tmp_path.glob(f".{immutable_path.name}.*.tmp")) == []
+
+
+def test_immutable_json_publication_does_not_require_hard_links(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    immutable_path = tmp_path / "immutable.json"
+
+    def reject_hard_link(_source, _destination):
+        raise AssertionError("hard links must not be used")
+
+    monkeypatch.setattr(workflow_run_manifest.os, "link", reject_hard_link)
+    workflow_run_manifest._write_immutable_json(immutable_path, {"a": 1})
+
+    assert json.loads(immutable_path.read_text(encoding="utf-8")) == {"a": 1}
 
 
 def test_workflow_run_manifest_loads_legacy_schema_v2_without_graph(tmp_path: Path) -> None:
@@ -357,13 +1027,14 @@ def test_workflow_manifest_loaders_and_helpers_cover_error_paths(tmp_path: Path,
 
 def test_write_workflow_evidence_rejects_invalid_generated_graph(tmp_path: Path, monkeypatch) -> None:
     state_path = tmp_path / "state.json"
-    state_path.write_text("{}", encoding="utf-8")
+    state = {"run_id": "demo"}
+    state_path.write_text(json.dumps(state), encoding="utf-8")
     monkeypatch.setattr(workflow_run_manifest, "build_evidence_graph_from_workflow_manifest", lambda _manifest: {})
     monkeypatch.setattr(workflow_run_manifest, "validate_evidence_graph", lambda _graph: ("bad graph",))
 
     with pytest.raises(ValueError, match="Invalid workflow evidence graph: bad graph"):
         write_workflow_run_evidence(
-            state={"run_id": "demo"},
+            state=state,
             state_path=state_path,
             repo_root=tmp_path,
             lab_dir=tmp_path,
@@ -373,7 +1044,10 @@ def test_write_workflow_evidence_rejects_invalid_generated_graph(tmp_path: Path,
 def test_dag_run_engine_emits_workflow_evidence_on_state_writes(tmp_path: Path) -> None:
     repo_root = Path.cwd()
 
-    def _fake_queue_run(*, repo_root: Path, run_root: Path) -> dict[str, object]:
+    def _fake_queue_run(
+        *, repo_root: Path, run_root: Path, idempotency_token: str
+    ) -> dict[str, object]:
+        assert idempotency_token.endswith(":queue_baseline")
         return {
             "summary_metrics_path": str(run_root / "queue_metrics.json"),
             "reduce_artifact_path": str(run_root / "queue_reduce.json"),
@@ -394,9 +1068,8 @@ def test_dag_run_engine_emits_workflow_evidence_on_state_writes(tmp_path: Path) 
     planned_manifest = load_workflow_run_manifest(Path(planned_latest["manifest_path"]))
     assert planned_manifest["status"] == "unknown"
 
-    result = engine.run_next_controlled_stage(state)
+    result = engine.run_next_controlled_stage_transaction(state)
     assert result.ok is True
-    engine.write_state(result.state)
 
     executed_latest = json.loads(latest_path.read_text(encoding="utf-8"))
     executed_manifest = load_workflow_run_manifest(Path(executed_latest["manifest_path"]))

--- a/test/test_workflow_ui.py
+++ b/test/test_workflow_ui.py
@@ -264,6 +264,18 @@ def test_workflow_link_buttons_do_not_require_key_support(monkeypatch) -> None:
     ) in fake_st.events
 
 
+def test_navigation_page_slug_uses_registered_page_url_path(monkeypatch) -> None:
+    route = SimpleNamespace(url_path="PROJECT_EDIT_SESSION")
+    monkeypatch.setattr(
+        sys.modules["__main__"],
+        "_NAVIGATION_PAGE_ROUTES",
+        {"project_editor": route},
+        raising=False,
+    )
+
+    assert workflow_ui._navigation_page_slug("PROJECT_EDITOR") == "PROJECT_EDIT_SESSION"
+
+
 def test_project_widget_key_is_scoped_by_page_and_project() -> None:
     env = SimpleNamespace(app="flight_telemetry_project", target="flight_telemetry_worker")
 

--- a/tools/agilab_widget_robot.py
+++ b/tools/agilab_widget_robot.py
@@ -43,6 +43,8 @@ from agilab.page_bundle_registry import (  # noqa: E402
     discover_page_bundles,
     resolve_page_bundles,
 )
+from agilab.environment.env_file_utils import load_env_file_map  # noqa: E402
+from agi_env.app_settings_support import read_app_settings  # noqa: E402
 from agi_env.app_provider_registry import aliased_app_runtime_target, app_name_aliases  # noqa: E402
 
 logger = logging.getLogger(__name__)
@@ -2473,26 +2475,12 @@ def _strip_config_value(value: Any) -> str:
 
 
 def _load_dotenv_map(path: Path) -> dict[str, str]:
-    values: dict[str, str] = {}
-    try:
-        for raw in path.read_text(encoding="utf-8").splitlines():
-            stripped = raw.strip()
-            if not stripped or "=" not in stripped:
-                continue
-            key, value = stripped.lstrip("#").strip().split("=", 1)
-            key = key.strip()
-            if key:
-                values[key] = _strip_config_value(value)
-    except OSError:
-        pass
-    return values
+    return load_env_file_map(path)
 
 
 def _read_cluster_enabled_setting(path: Path) -> bool | None:
     try:
-        if not path.is_file() or path.stat().st_size <= 0:
-            return None
-        data = tomllib.loads(path.read_text(encoding="utf-8"))
+        data = read_app_settings(path)
     except (OSError, tomllib.TOMLDecodeError):
         return None
     cluster = data.get("cluster")
@@ -2779,7 +2767,7 @@ def _load_app_settings_args_for_artifact_context(context: OrchestrateArtifactCon
         if settings_path is None or not settings_path.is_file():
             continue
         try:
-            payload = tomllib.loads(settings_path.read_text(encoding="utf-8"))
+            payload = read_app_settings(settings_path)
         except (OSError, tomllib.TOMLDecodeError):
             continue
         args = payload.get("args")

--- a/tools/package_split_contract.py
+++ b/tools/package_split_contract.py
@@ -58,7 +58,6 @@ PAGE_BUNDLE_PACKAGE_SPECS: tuple[tuple[str, str], ...] = (
     ("agi-page-simplex-map", "src/agilab/apps-pages/view_barycentric"),
     ("agi-page-decision-evidence", "src/agilab/apps-pages/view_data_io_decision"),
     ("agi-page-timeseries-forecast", "src/agilab/apps-pages/view_forecast_analysis"),
-    ("agi-page-inference-report", "src/agilab/apps-pages/view_inference_analysis"),
     ("agi-page-live-artifacts", "src/agilab/apps-pages/view_live_artifacts"),
     ("agi-page-geospatial-map", "src/agilab/apps-pages/view_maps"),
     ("agi-page-geospatial-3d", "src/agilab/apps-pages/view_maps_3d"),

--- a/tools/service_health_check.py
+++ b/tools/service_health_check.py
@@ -10,10 +10,9 @@ import sys
 from pathlib import Path
 from typing import Any, Sequence
 
-import tomllib
-
 from agi_cluster.agi_distributor import AGI
 from agi_env import AgiEnv
+from agi_env.app_settings_support import read_app_settings
 
 DEFAULT_ALLOW_IDLE = False
 DEFAULT_MAX_UNHEALTHY = 0
@@ -119,8 +118,7 @@ def _load_service_health_settings(env: AgiEnv) -> dict[str, Any]:
     if not settings_path.exists():
         return {}
     try:
-        with settings_path.open("rb") as stream:
-            settings = tomllib.load(stream)
+        settings = read_app_settings(settings_path)
     except Exception:
         return {}
     cluster = settings.get("cluster")

--- a/tools/ui_robot_coverage_contract.py
+++ b/tools/ui_robot_coverage_contract.py
@@ -129,10 +129,6 @@ APPS_PAGE_RENDER_ONLY_DISPOSITIONS: dict[str, tuple[str, str]] = {
         "decision panels render only after the artifact directory and pipeline exist",
         "test/test_view_data_io_decision.py",
     ),
-    "view_inference_analysis": (
-        "diagnostics render only when an active project and inference runs are passed in",
-        "test/test_view_inference_analysis.py",
-    ),
     "view_live_artifacts": (
         "manifest candidates render only when live artifacts are present",
         "test/test_view_live_artifacts.py",


### PR DESCRIPTION
## Summary

- harden concurrent AGI runtime, cleanup, deployment, service-loop, worker-host, settings, sidecar, navigation, and hosted-view ownership boundaries across threads and processes
- make cleanup proof-based and fail-closed: retain exact leases, Futures, process groups, tokens, state, and PID evidence until termination/publication is durably proven
- add bounded lock, Windows sharing-retry, transactional config/state publication, and crash-recovery contracts for mutable shared files
- make DAG submission/execution idempotency transactional and immediately recoverable after finalization failures
- isolate Streamlit session environments and temporary import state; make ANALYSIS preparation own and terminate its complete process tree
- confine worker cleanup/kill paths to validated runtime roots while preserving sibling evidence and legacy bootstrap compatibility
- preserve dependency-light base-package imports and reconcile the upstream inference-page deletion across package, robot, capability, and docs contracts

## Repro

Before this change, concurrent or interrupted callers could reproduce one or more of these failure classes:

- lifecycle, cleanup, or service operations could release a lease while an exact worker, Future, child process, or state file was still live or unreadable
- a fast-exiting `uv`/shell wrapper could disappear from the job list while a Dask or environment-preparation child survived in the owned process group
- service restart/start publication failures could leave live loop Futures whose exact keys were never durably recorded
- repeated cancellation or a stalled lock could freeze peers indefinitely or strand an owned cleanup task
- Windows file-sharing denial could turn valid config/state into an apparent absence, lose an update, or fail a replace without bounded recovery
- a failed target cleanup could erase or resurrect sibling PID evidence, or an unsafe worker target could reach process discovery/deletion
- concurrent settings, dotenv, app pages, or hosted inline imports could overwrite newer state or leak process-global environment/import state
- DAG finalization failure could retain ambiguous ownership and block immediate exact retry
- clean Python 3.13/3.14 base imports could cross into the optional UI environment

The regressions exercise these interleavings directly, including delayed releaser versus successor publication, corrupt/unreadable state, partial service replacement, state-write failure, wrapper exit with a surviving child, inaccessible process evidence, repeated cancellation, PID reuse, sibling cleanup, Windows sharing denial, and DAG post-callback finalization failure.

## Root Cause

The affected paths mixed process-local locks, mutable singleton/class state, check-then-act filesystem operations, best-effort cancellation, and non-generation-scoped cleanup. Several recovery paths treated cancellation, absence, age, a closed wrapper, or a moved marker as sufficient proof without retaining the exact owner generation or proving that worker-side execution had ended. Mutable state publication was not consistently transactional or retryable under Windows sharing semantics. UI and evidence surfaces also mutated process-global or shared filesystem state without a bounded session/process ownership contract.

## Regression Test

- runtime/service tests cover exact loop-Future keys, partial start/restart, durable publication failure, legacy state recovery, lost clients, repeated stop, full-runtime fallback, cancellation, and lease retention
- real process tests cover fast-exiting wrappers, surviving descendants, process-group TERM/KILL, unreaped parents, inaccessible recent same-user candidates, and retry-safe cleanup
- cleanup/CLI tests cover path confinement, traversal/symlink rejection, production `cwd == target` kill geometry, PID incarnation, sibling evidence, rollback, and pre-install legacy bootstrap execution
- `agi-env` tests cover bounded constructor/current/reset/session locks, non-overlapping singleton initialization, transactional settings/dotenv, Windows sharing retry, sidecar ownership, and hosted-render exclusion
- Analysis/UI tests cover owned preparation trees, time-bounded interruption, transactional settings helpers, session-local environments, and cross-page/app behavior
- DAG/evidence tests cover durable ownership, exact retry, compare-and-swap transitions, immutable snapshots, atomic latest pointers, and Windows directory/file sharing behavior
- base-import tests prove `agilab.lab_run` imports without optional `agi_env` on Python 3.13 and 3.14

## Validation

- full AGI GUI workflow parity: **3,680 passed, 5 skipped**
- full shared-core tree: **1,479 passed, 5 skipped**
- full `agi-env` tree: **957 passed, 1 skipped**
- final core/runtime/service/cleanup/CLI/Analysis integration slice: **524 passed**
- changed public/UI/DAG/evidence slice: **387 passed, 1 skipped**
- complete views slice: **305 passed**
- Flight runtime/form/cluster regressions: **109 passed**
- DAG/idempotency/evidence slice: **106 passed, 1 skipped**
- strict shared-core typing: **21 source files, no issues**
- dependency policy: **28 passed**
- clean base-package imports: Python **3.13.14** and **3.14.6**
- staged impact validation, ANALYSIS maintenance memory, provenance guard, Ruff, compile, and diff checks: passed
- GitHub CI: passed, including Windows core, local-only policy, docs guard, Python 3.13/3.14 compatibility, GitGuardian, and clean public installs on Ubuntu, macOS, and Windows

Known baseline: the impact-inferred narrow slice passed 274 tests and hit only `test_setup_pycharm.py::test_gen_app_script_preserves_builtin_app_venv_bindings`; the same failure was reproduced unchanged on clean `origin/main`, so it is excluded as unrelated. The generated built-in-app recommendation for `flight_telemetry_project` is not runnable because that app is not registered by `tools/builtin_app_tests.py`; the actual affected Flight regressions passed as listed above. Windows-only skips remain covered by the Windows CI matrix.

## Review Evidence

- `cluster_cleanup_followup` (Curie, GPT-5 Codex): cluster cleanup/lifecycle implementation and review; edits incorporated
- `remote_worker_lease_recovery` (GPT-5 Codex): remote lease recovery implementation; edits incorporated
- `lifecycle_cancel_drain` (GPT-5 Codex): runtime cancellation/process-tree and ANALYSIS ownership implementation; edits incorporated
- `service_start_cleanup_proof` (GPT-5 Codex): service start/restart/stop/state proof implementation; edits incorporated
- `final_concurrency_diff_review` (Ptolemy, GPT-5 Codex): review-only; findings addressed
- `independent_ui_rereview` (Erdos, GPT-5 Codex): review-only; findings addressed
- `followup_lease_review` and `final_scope_integrity_review` (GPT-5 Codex): review-only; findings addressed
- `final_concurrency_review2` (GPT-5 Codex): final read-only integrated review; result **CLEAR**, no merge-blocking findings

## Agent Metadata

- Tokki version: `1.0.27`
- agent/runtime: OpenAI Codex CLI `0.144.5`
- model: GPT-5
- reasoning effort: unknown
- `/fast` mode: not used
