### PR TITLE
Prepare AGILAB 2026.07.17 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,16 @@ cleanup, but retired GitHub release pages are not advertised as live evidence.
 - Hardened shared-path resolution and artifact path joins so shared datasets,
   outputs, and evidence stay confined to the resolved cluster-share root and
   reject traversal outside it (#802).
+- Made project/archive replacement transactional and tightened generated-code,
+  connector, SSH transport, and model-loading trust checks so invalid inputs
+  fail closed without replacing live state.
+
+### Added
+
+- Added workflow cockpit/autopilot preflight and machine-readable workflow
+  automation evidence for reviewing dependency-aware execution before a run.
+- Added routing demand-matrix analysis and improved notebook import/export
+  round-trip evidence and safety checks.
 
 ### Changed
 
@@ -40,6 +50,26 @@ cleanup, but retired GitHub release pages are not advertised as live evidence.
 - Routed generated artifacts through the configured output roots so exports
   honor explicit export directories and active workflow data roots before any
   local fallback path (#798).
+- Prepared cluster environments concurrently and exposed bounded live
+  deployment and worker logs through ORCHESTRATE.
+- Updated Streamlit launchers, page templates, and page-config ownership for
+  the current supported Streamlit contract.
+
+### Fixed
+
+- Hardened concurrent distributed-runtime lifecycle access and durable service
+  state publication across start, restart, cleanup, transport, and background
+  job flows, preventing stale ownership and leaked replacement processes
+  (#815).
+- Restored Windows core validation and preserved compatibility-shim module
+  metadata across synchronized runtime namespaces.
+- Corrected workflow run reattachment, app dependency synchronization, and
+  shared-root input/output resolution across built-in projects.
+
+### Removed
+
+- Removed the obsolete inference-analysis page and its public bundle surface
+  (#814).
 
 ## [2026.07.04] - 2026-07-04
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.07.04"
+version = "2026.07.17"
 name = "agilab"
 description = "AGILAB is a reproducible AI/ML workbench for engineering teams."
 requires-python = ">=3.12,<3.15"
@@ -66,14 +66,14 @@ agilab-mcp = "agilab_mcp.server:main"
 
 [project.optional-dependencies]
 ai = ["openai>=2.32.0,<3"]
-core = ["agi-core==2026.07.04"]
-ui = ["agi-apps==2026.07.04", "agi-pages==2026.07.04", "agi-gui==2026.07.04", "agi-web==2026.06.23", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "plotly>=6.8,<7", "sqlalchemy>=2.0.43,<3", "streamlit>=1.58,<2", "starlette>=1.0.1,<2", "tomli_w>=1.2.0,<2", "cryptography>=48.0.1,<50"]
+core = ["agi-core==2026.07.17"]
+ui = ["agi-apps==2026.07.17", "agi-pages==2026.07.17", "agi-gui==2026.07.17", "agi-web==2026.07.17", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "plotly>=6.8,<7", "sqlalchemy>=2.0.43,<3", "streamlit>=1.58,<2", "starlette>=1.0.1,<2", "tomli_w>=1.2.0,<2", "cryptography>=48.0.1,<50"]
 viz = ["matplotlib>=3.10.0,<4", "plotly>=6.8,<7"]
 mlflow = ["mlflow>=3.14,<4", "idna>=3.15,<4", "starlette>=1.0.1,<2"]
 bridges = ["duckdb>=1.4.0,<2"]
 notebook = ["ipykernel>=6.29.0,<8", "nbclient>=0.10.0,<1", "nbformat>=5.10.0,<6"]
-examples = ["agi-apps==2026.07.04", "jupyterlab>=4.4.0,<5", "matplotlib>=3.10.0,<4", "plotly>=6.8,<7", "starlette>=1.0.1,<2", "bleach>=6.4.0,<7"]
-pages = ["agi-pages==2026.07.04", "plotly>=6.8,<7", "sqlalchemy>=2.0.43,<3", "starlette>=1.0.1,<2"]
+examples = ["agi-apps==2026.07.17", "jupyterlab>=4.4.0,<5", "matplotlib>=3.10.0,<4", "plotly>=6.8,<7", "starlette>=1.0.1,<2", "bleach>=6.4.0,<7"]
+pages = ["agi-pages==2026.07.17", "plotly>=6.8,<7", "sqlalchemy>=2.0.43,<3", "starlette>=1.0.1,<2"]
 proof = ["cryptography>=48.0.1,<50"]
 agents = ["openai>=2.32.0,<3"]
 local-llm = ["accelerate>=0.34.2,<2; python_version >= '3.12'", "fastapi>=0.124.4,!=0.136.3,<1; python_version >= '3.12'", "gpt-oss>=0.0.8,<0.1; python_version >= '3.12'", "langchain-core>=1.3.3,<2; python_version >= '3.12'", "langsmith>=0.8.0,<1; python_version >= '3.12'", "mlx>=0.31.2,<0.32; sys_platform == 'darwin' and platform_machine == 'arm64'", "mlx-lm>=0.31.3,<0.32; sys_platform == 'darwin' and platform_machine == 'arm64'", "mlx-vlm>=0.5.0,<0.7; sys_platform == 'darwin' and platform_machine == 'arm64'", "requests>=2.32.0,<3; python_version >= '3.12'", "starlette>=1.3.1,<2; python_version >= '3.12'", "torch>=2.8.0,<3; python_version >= '3.12'", "transformers>=4.57.0,<6; python_version >= '3.12'", "universal-offline-ai-chatbot>=0.1.0,<0.2; python_version >= '3.12'", "langchain>=1.3.9,<2; python_version >= '3.12'", "pypdf>=6.13.0,<7; python_version >= '3.12'", "python-multipart>=0.0.31,<1; python_version >= '3.12'", "tornado>=6.5.7,<7; python_version >= '3.12'"]

--- a/src/agilab/apps-pages/app_ui/pyproject.toml
+++ b/src/agilab/apps-pages/app_ui/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-app-ui"
-version = "2026.07.04"
+version = "2026.07.17"
 description = "AGILAB page bundle for app-owned interactive Streamlit UIs."
 readme = { text = "AGILAB page bundle for app-owned interactive Streamlit UIs.", content-type = "text/markdown" }
 requires-python = ">=3.12"

--- a/src/agilab/apps-pages/view_barycentric/pyproject.toml
+++ b/src/agilab/apps-pages/view_barycentric/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-simplex-map"
-version = "2026.07.04"
+version = "2026.07.17"
 description = "AGILAB page bundle for simplex projection and barycentric analysis."
 readme = { text = "AGILAB page bundle for simplex projection and barycentric analysis.", content-type = "text/markdown" }
 requires-python = ">=3.12"

--- a/src/agilab/apps-pages/view_data_io_decision/pyproject.toml
+++ b/src/agilab/apps-pages/view_data_io_decision/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-decision-evidence"
-version = "2026.06.23"
+version = "2026.07.17"
 description = "AGILAB page bundle for decision evidence review."
 readme = { text = "AGILAB page bundle for decision evidence review.", content-type = "text/markdown" }
 requires-python = ">=3.12"

--- a/src/agilab/apps-pages/view_forecast_analysis/pyproject.toml
+++ b/src/agilab/apps-pages/view_forecast_analysis/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-timeseries-forecast"
-version = "2026.06.23"
+version = "2026.07.17"
 description = "AGILAB page bundle for time-series forecast review."
 readme = { text = "AGILAB page bundle for time-series forecast review.", content-type = "text/markdown" }
 requires-python = ">=3.12"

--- a/src/agilab/apps-pages/view_live_artifacts/pyproject.toml
+++ b/src/agilab/apps-pages/view_live_artifacts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-live-artifacts"
-version = "2026.07.04"
+version = "2026.07.17"
 description = "AGILAB page bundle for live artifact and evidence monitoring."
 readme = { text = "AGILAB page bundle for live artifact and evidence monitoring.", content-type = "text/markdown" }
 requires-python = ">=3.12"

--- a/src/agilab/apps-pages/view_maps/pyproject.toml
+++ b/src/agilab/apps-pages/view_maps/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-geospatial-map"
-version = "2026.07.04"
+version = "2026.07.17"
 description = "AGILAB page bundle for 2D geospatial map exploration."
 readme = { text = "AGILAB page bundle for 2D geospatial map exploration.", content-type = "text/markdown" }
 requires-python = ">=3.12"

--- a/src/agilab/apps-pages/view_maps_3d/pyproject.toml
+++ b/src/agilab/apps-pages/view_maps_3d/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-geospatial-3d"
-version = "2026.07.04"
+version = "2026.07.17"
 description = "AGILAB page bundle for 3D geospatial exploration."
 readme = { text = "AGILAB page bundle for 3D geospatial exploration.", content-type = "text/markdown" }
 requires-python = ">=3.12"

--- a/src/agilab/apps-pages/view_maps_network/pyproject.toml
+++ b/src/agilab/apps-pages/view_maps_network/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-network-map"
-version = "2026.07.04"
+version = "2026.07.17"
 description = "AGILAB page bundle for network-aware geospatial analysis."
 readme = { text = "AGILAB page bundle for network-aware geospatial analysis.", content-type = "text/markdown" }
 requires-python = ">=3.12"

--- a/src/agilab/apps-pages/view_queue_resilience/pyproject.toml
+++ b/src/agilab/apps-pages/view_queue_resilience/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-queue-health"
-version = "2026.06.23"
+version = "2026.07.17"
 description = "AGILAB page bundle for queue health and resilience evidence."
 readme = { text = "AGILAB page bundle for queue health and resilience evidence.", content-type = "text/markdown" }
 requires-python = ">=3.12"

--- a/src/agilab/apps-pages/view_relay_resilience/pyproject.toml
+++ b/src/agilab/apps-pages/view_relay_resilience/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-relay-health"
-version = "2026.06.23"
+version = "2026.07.17"
 description = "AGILAB page bundle for relay health and resilience evidence."
 readme = { text = "AGILAB page bundle for relay health and resilience evidence.", content-type = "text/markdown" }
 requires-python = ">=3.12"

--- a/src/agilab/apps-pages/view_release_decision/pyproject.toml
+++ b/src/agilab/apps-pages/view_release_decision/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-promotion-gate"
-version = "2026.06.23"
+version = "2026.07.17"
 description = "AGILAB page bundle for evidence-cockpit run review and promotion gates."
 readme = { text = "AGILAB page bundle for evidence-cockpit run review and promotion gates.", content-type = "text/markdown" }
 requires-python = ">=3.12"

--- a/src/agilab/apps-pages/view_routing_model_comparison/pyproject.toml
+++ b/src/agilab/apps-pages/view_routing_model_comparison/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-routing-model-comparison"
-version = "2026.06.23"
+version = "2026.07.17"
 description = "AGILAB page bundle for comparing routing model allocation decisions."
 readme = { text = "AGILAB page bundle for comparing routing model allocation decisions.", content-type = "text/markdown" }
 requires-python = ">=3.12"

--- a/src/agilab/apps-pages/view_scenario_cockpit/pyproject.toml
+++ b/src/agilab/apps-pages/view_scenario_cockpit/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-scenario-cockpit"
-version = "2026.06.23"
+version = "2026.07.17"
 description = "AGILAB page bundle for scenario evidence comparison."
 readme = { text = "AGILAB page bundle for scenario evidence comparison.", content-type = "text/markdown" }
 requires-python = ">=3.12"

--- a/src/agilab/apps-pages/view_shap_explanation/pyproject.toml
+++ b/src/agilab/apps-pages/view_shap_explanation/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-feature-attribution"
-version = "2026.06.23"
+version = "2026.07.17"
 description = "AGILAB page bundle for feature-attribution evidence."
 readme = { text = "AGILAB page bundle for feature-attribution evidence.", content-type = "text/markdown" }
 requires-python = ">=3.12"

--- a/src/agilab/apps-pages/view_training_analysis/pyproject.toml
+++ b/src/agilab/apps-pages/view_training_analysis/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-training-report"
-version = "2026.06.23"
+version = "2026.07.17"
 description = "AGILAB page bundle for training run reporting."
 readme = { text = "AGILAB page bundle for training run reporting.", content-type = "text/markdown" }
 requires-python = ">=3.12"

--- a/src/agilab/core/agi-cluster/pyproject.toml
+++ b/src/agilab/core/agi-cluster/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.07.04"
+version = "2026.07.17"
 name = "agi-cluster"
 description = "Distributed cluster orchestration layer for AGILAB workers over local and SSH backends"
 requires-python = ">=3.12"
@@ -34,7 +34,7 @@ keywords = [
     "job-scheduling",
     "mlops",
 ]
-dependencies = ["agi-env==2026.07.04", "agi-node==2026.07.04", "asyncssh>=2.23,<3", "dask[distributed]>=2026.3,<2027.0", "humanize>=4.10,<5", "numpy>=2.2,<3", "packaging>=25,<27", "polars>=1.35,<2", "psutil>=7,<8", "pywin32>=312,<313; sys_platform == 'win32'", "scikit-learn>=1.7.2,<2", "tomlkit>=0.13,<1"]
+dependencies = ["agi-env==2026.07.17", "agi-node==2026.07.17", "asyncssh>=2.23,<3", "dask[distributed]>=2026.3,<2027.0", "humanize>=4.10,<5", "numpy>=2.2,<3", "packaging>=25,<27", "polars>=1.35,<2", "psutil>=7,<8", "pywin32>=312,<313; sys_platform == 'win32'", "scikit-learn>=1.7.2,<2", "tomlkit>=0.13,<1"]
 
 [project.entry-points."agi_env.runtime_packages"]
 agi-cluster = "agi_cluster.agi_env_runtime:RUNTIME_PACKAGE_SPEC"

--- a/src/agilab/core/agi-core/pyproject.toml
+++ b/src/agilab/core/agi-core/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.07.04"
+version = "2026.07.17"
 name = "agi-core"
 description = "Meta-package that installs and wires agi-env, agi-node, and agi-cluster together"
 readme = "README.md"
@@ -29,7 +29,7 @@ keywords = [
   "distributed-computing",
   "distributed-execution",
 ]
-dependencies = ["agi-env==2026.07.04", "agi-node==2026.07.04", "agi-cluster==2026.07.04"]
+dependencies = ["agi-env==2026.07.17", "agi-node==2026.07.17", "agi-cluster==2026.07.17"]
 
 [project.entry-points."agi_env.runtime_packages"]
 agi-core = "agi_core.agi_env_runtime:RUNTIME_PACKAGE_SPEC"

--- a/src/agilab/core/agi-env/pyproject.toml
+++ b/src/agilab/core/agi-env/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.07.04"
+version = "2026.07.17"
 name = "agi-env"
 description = "Environment bootstrap package for AGILAB with virtualenv, path, and runtime helpers"
 requires-python = ">=3.12"

--- a/src/agilab/core/agi-node/pyproject.toml
+++ b/src/agilab/core/agi-node/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.07.04"
+version = "2026.07.17"
 name = "agi-node"
 description = "Distributed worker orchestration and execution support library for AGILAB"
 requires-python = ">=3.12"
@@ -34,7 +34,7 @@ keywords = [
     "pandas",
     "polars",
 ]
-dependencies = ["agi-env==2026.07.04", "cython>=3.1,<4", "humanize>=4.10,<5", "numpy>=2.2,<3", "pandas>=2.3,<4", "parso>=0.8,<1", "polars>=1.35,<2", "psutil>=7,<8", "py7zr>=1.1,<1.2", "setuptools>=68,<83"]
+dependencies = ["agi-env==2026.07.17", "cython>=3.1,<4", "humanize>=4.10,<5", "numpy>=2.2,<3", "pandas>=2.3,<4", "parso>=0.8,<1", "polars>=1.35,<2", "psutil>=7,<8", "py7zr>=1.1,<1.2", "setuptools>=68,<83"]
 
 [project.entry-points."agi_env.runtime_packages"]
 agi-node = "agi_node.agi_env_runtime:RUNTIME_PACKAGE_SPEC"

--- a/src/agilab/lib/agi-app-data-quality-gate/pyproject.toml
+++ b/src/agilab/lib/agi-app-data-quality-gate/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.23"
+version = "2026.07.17"
 name = "agi-app-data-quality-gate"
 description = "AGILAB deterministic data contract, drift, leakage, and promotion gate"
 requires-python = ">=3.12"

--- a/src/agilab/lib/agi-app-flight-telemetry/pyproject.toml
+++ b/src/agilab/lib/agi-app-flight-telemetry/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.24"
+version = "2026.07.17"
 name = "agi-app-flight-telemetry"
 description = "AGILAB flight-telemetry ingestion demo with reusable dataframe and map-analysis outputs"
 requires-python = ">=3.12"

--- a/src/agilab/lib/agi-app-mission-decision/pyproject.toml
+++ b/src/agilab/lib/agi-app-mission-decision/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.24"
+version = "2026.07.17"
 name = "agi-app-mission-decision"
 description = "Deterministic AGILAB mission-decision workflow with scenario scoring and evidence artifacts"
 requires-python = ">=3.12"

--- a/src/agilab/lib/agi-app-multi-dag/pyproject.toml
+++ b/src/agilab/lib/agi-app-multi-dag/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.23"
+version = "2026.07.17"
 name = "agi-app-multi-dag"
 description = "AGILAB cross-app DAG preview showing artifact handoffs between demo projects"
 requires-python = ">=3.12"

--- a/src/agilab/lib/agi-app-pandas-execution/pyproject.toml
+++ b/src/agilab/lib/agi-app-pandas-execution/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.23"
+version = "2026.07.17"
 name = "agi-app-pandas-execution"
 description = "AGILAB Pandas execution benchmark for deterministic worker and reducer validation"
 requires-python = ">=3.12"

--- a/src/agilab/lib/agi-app-polars-execution/pyproject.toml
+++ b/src/agilab/lib/agi-app-polars-execution/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.23"
+version = "2026.07.17"
 name = "agi-app-polars-execution"
 description = "AGILAB Polars execution benchmark for deterministic worker and reducer validation"
 requires-python = ">=3.12"

--- a/src/agilab/lib/agi-app-pytorch-playground/pyproject.toml
+++ b/src/agilab/lib/agi-app-pytorch-playground/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.07.04"
+version = "2026.07.17"
 name = "agi-app-pytorch-playground"
 description = "AGILAB PyTorch playground app for reproducible neural-network experiments"
 requires-python = ">=3.12"

--- a/src/agilab/lib/agi-app-sklearn-pipeline/pyproject.toml
+++ b/src/agilab/lib/agi-app-sklearn-pipeline/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.23"
+version = "2026.07.17"
 name = "agi-app-sklearn-pipeline"
 description = "AGILAB scikit-learn pipeline app with model, metrics, predictions, and evidence manifest"
 requires-python = ">=3.12"

--- a/src/agilab/lib/agi-app-uav-relay-queue/pyproject.toml
+++ b/src/agilab/lib/agi-app-uav-relay-queue/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.24"
+version = "2026.07.17"
 name = "agi-app-uav-relay-queue"
 description = "AGILAB UAV relay queue simulation demo with routing, delay, and resilience artifacts"
 requires-python = ">=3.13"

--- a/src/agilab/lib/agi-app-weather-forecast/pyproject.toml
+++ b/src/agilab/lib/agi-app-weather-forecast/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.24"
+version = "2026.07.17"
 name = "agi-app-weather-forecast"
 description = "AGILAB weather-forecast notebook-migration demo with forecast analysis artifacts"
 requires-python = ">=3.12"

--- a/src/agilab/lib/agi-apps/pyproject.toml
+++ b/src/agilab/lib/agi-apps/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.07.04"
+version = "2026.07.17"
 name = "agi-apps"
 description = "AGILAB public app package umbrella and example assets"
 requires-python = ">=3.12"
@@ -31,7 +31,7 @@ keywords = [
     "workflow-orchestration",
 ]
 
-dependencies = ["agi-core==2026.07.04", "agi-app-mission-decision==2026.06.24", "agi-app-pandas-execution==2026.06.23", "agi-app-polars-execution==2026.06.23", "agi-app-flight-telemetry==2026.06.24", "agi-app-multi-dag==2026.06.23", "agi-app-weather-forecast==2026.06.24", "agi-app-sklearn-pipeline==2026.06.23", "agi-app-data-quality-gate==2026.06.23", "agi-app-pytorch-playground==2026.07.04; python_version >= '3.12'", "agi-app-tescia-diagnostic==2026.06.23; python_version >= '3.13'", "agi-app-uav-relay-queue==2026.06.24; python_version >= '3.13'"]
+dependencies = ["agi-core==2026.07.17", "agi-app-mission-decision==2026.07.17", "agi-app-pandas-execution==2026.07.17", "agi-app-polars-execution==2026.07.17", "agi-app-flight-telemetry==2026.07.17", "agi-app-multi-dag==2026.07.17", "agi-app-weather-forecast==2026.07.17", "agi-app-sklearn-pipeline==2026.07.17", "agi-app-data-quality-gate==2026.07.17", "agi-app-pytorch-playground==2026.07.17; python_version >= '3.12'", "agi-app-tescia-diagnostic==2026.06.23; python_version >= '3.13'", "agi-app-uav-relay-queue==2026.07.17; python_version >= '3.13'"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/lib/agi-gui/pyproject.toml
+++ b/src/agilab/lib/agi-gui/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.07.04"
+version = "2026.07.17"
 name = "agi-gui"
 description = "AGILAB Streamlit UI dependency bundle and compatibility imports"
 requires-python = ">=3.12"
@@ -31,7 +31,7 @@ keywords = [
     "python",
 ]
 
-dependencies = ["agi-env==2026.07.04", "streamlit>=1.58,<2", "starlette>=1.0.1,<2", "streamlit_code_editor>=0.1.22,<0.2", "watchdog>=6,<7"]
+dependencies = ["agi-env==2026.07.17", "streamlit>=1.58,<2", "starlette>=1.0.1,<2", "streamlit_code_editor>=0.1.22,<0.2", "watchdog>=6,<7"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/lib/agi-pages/pyproject.toml
+++ b/src/agilab/lib/agi-pages/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.07.04"
+version = "2026.07.17"
 name = "agi-pages"
 description = "AGILAB public analysis page umbrella and provider package"
 requires-python = ">=3.12"
@@ -34,7 +34,7 @@ keywords = [
     "page-bundles",
 ]
 
-dependencies = ["agi-gui==2026.07.04"]
+dependencies = ["agi-gui==2026.07.17"]
 
 [project.urls]
 Documentation = "https://thalesgroup.github.io/agilab"

--- a/src/agilab/lib/agi-web/pyproject.toml
+++ b/src/agilab/lib/agi-web/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.06.23"
+version = "2026.07.17"
 name = "agi-web"
 description = "AGILAB portable web component contract with static Canvas2D/WebGL adapters for Streamlit and HTML"
 requires-python = ">=3.12"

--- a/test/test_pypi_publish.py
+++ b/test/test_pypi_publish.py
@@ -1191,6 +1191,69 @@ def test_update_public_release_references_updates_docs_changelog_and_test(tmp_pa
     assert refreshed_release_proofs == ["2026.04.24"]
 
 
+def test_changelog_release_entry_moves_unreleased_notes_into_new_release(
+    tmp_path, monkeypatch
+) -> None:
+    module = _load_pypi_publish()
+    monkeypatch.setattr(module, "REPO_ROOT", tmp_path)
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text(
+        "# Changelog\n\n"
+        "## Unreleased\n\n"
+        "### Security\n\n"
+        "- Hardened the runtime boundary.\n\n"
+        "### Changed\n\n"
+        "- Added replay evidence.\n\n"
+        "## [2026.07.04] - 2026-07-04\n\n"
+        "Previous release.\n",
+        encoding="utf-8",
+    )
+
+    module.update_changelog_release_entry(
+        "2026.07.17",
+        "v2026.07.17",
+        ["agi-core", "agilab"],
+    )
+
+    text = changelog.read_text(encoding="utf-8")
+    assert "## Unreleased\n\n## [2026.07.17]" in text
+    release = text.split("## [2026.07.17]", 1)[1].split("## [2026.07.04]", 1)[0]
+    assert "- Hardened the runtime boundary." in release
+    assert "- Added replay evidence." in release
+    assert release.count("### Changed") == 1
+    assert "Published AGILAB `2026.07.17` to PyPI for `agi-core` and `agilab`." in release
+
+
+def test_changelog_release_entry_repair_preserves_existing_notes_and_unreleased(
+    tmp_path, monkeypatch
+) -> None:
+    module = _load_pypi_publish()
+    monkeypatch.setattr(module, "REPO_ROOT", tmp_path)
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text(
+        "# Changelog\n\n"
+        "## Unreleased\n\n"
+        "### Fixed\n\n"
+        "- A fix merged after the release.\n\n"
+        "## [2026.07.17] - 2026-07-17\n\n"
+        "GitHub Release: https://github.com/ThalesGroup/agilab/releases/tag/v2026.07.17\n\n"
+        "### Security\n\n"
+        "- Original detailed release note.\n",
+        encoding="utf-8",
+    )
+
+    module.update_changelog_release_entry(
+        "2026.07.17",
+        "v2026.07.17",
+        ["agilab"],
+    )
+
+    text = changelog.read_text(encoding="utf-8")
+    assert "- A fix merged after the release." in text
+    assert "- Original detailed release note." in text
+    assert text.count("## [2026.07.17]") == 1
+
+
 def test_update_public_demo_release_test_skips_manifest_backed_constant(tmp_path, monkeypatch) -> None:
     module = _load_pypi_publish()
     monkeypatch.setattr(module, "REPO_ROOT", tmp_path)

--- a/tools/pypi_publish.py
+++ b/tools/pypi_publish.py
@@ -2119,6 +2119,8 @@ def _format_package_list(package_names: list[str]) -> str:
         return "the selected packages"
     if len(quoted) == 1:
         return quoted[0]
+    if len(quoted) == 2:
+        return f"{quoted[0]} and {quoted[1]}"
     return ", ".join(quoted[:-1]) + f", and {quoted[-1]}"
 
 
@@ -2132,19 +2134,75 @@ def _release_date_from_tag(tag: str) -> str:
     return f"{year:04d}-{month:02d}-{day:02d}"
 
 
-def _changelog_section(chosen_version: str, tag: str, package_names: list[str]) -> str:
-    release_url = github_release_url(tag)
-    release_date = _release_date_from_tag(tag)
+def _release_changed_notes(package_names: list[str], chosen_version: str) -> str:
     packages = _format_package_list(package_names)
     return (
-        f"## [{chosen_version}] - {release_date}\n\n"
-        f"GitHub Release: {release_url}\n\n"
-        "### Changed\n\n"
         f"- Published AGILAB `{chosen_version}` to PyPI for {packages}.\n"
         "- Updated release metadata so public docs, changelog, PyPI, and GitHub "
         "Releases point to the same source tag.\n"
         "- Kept release automation active so future PyPI publishes create or "
         "update the matching GitHub Release after pushing the tag.\n"
+    )
+
+
+def _merge_release_changed_notes(
+    unreleased_body: str,
+    *,
+    package_names: list[str],
+    chosen_version: str,
+) -> str:
+    body = unreleased_body.strip()
+    notes = _release_changed_notes(package_names, chosen_version)
+    if not body:
+        return f"### Changed\n\n{notes}"
+
+    changed_heading = re.search(r"^### Changed[ \t]*\n", body, flags=re.MULTILINE)
+    if changed_heading:
+        return (
+            body[: changed_heading.end()]
+            + "\n"
+            + notes
+            + body[changed_heading.end() :].lstrip("\n")
+        ).rstrip()
+    return f"{body}\n\n### Changed\n\n{notes}".rstrip()
+
+
+def _consume_unreleased_body(text: str) -> tuple[str, str]:
+    unreleased_re = re.compile(
+        r"^(?P<heading>## Unreleased[^\n]*\n)(?P<body>.*?)(?=^## \[|\Z)",
+        re.MULTILINE | re.DOTALL,
+    )
+    match = unreleased_re.search(text)
+    if not match:
+        return text, ""
+    body = match.group("body").strip()
+    cleared = (
+        text[: match.start()]
+        + match.group("heading").rstrip()
+        + "\n\n"
+        + text[match.end() :]
+    )
+    return cleared, body
+
+
+def _changelog_section(
+    chosen_version: str,
+    tag: str,
+    package_names: list[str],
+    *,
+    unreleased_body: str = "",
+) -> str:
+    release_url = github_release_url(tag)
+    release_date = _release_date_from_tag(tag)
+    release_notes = _merge_release_changed_notes(
+        unreleased_body,
+        package_names=package_names,
+        chosen_version=chosen_version,
+    )
+    return (
+        f"## [{chosen_version}] - {release_date}\n\n"
+        f"GitHub Release: {release_url}\n\n"
+        f"{release_notes}\n"
     )
 
 
@@ -2155,14 +2213,22 @@ def update_changelog_release_entry(chosen_version: str, tag: str, package_names:
         return
 
     text = path.read_text(encoding="utf-8")
-    section = _changelog_section(chosen_version, tag, package_names)
     heading_re = re.compile(
         rf"^## \[{re.escape(chosen_version)}\] - .+?(?=^## \[|\Z)",
         re.MULTILINE | re.DOTALL,
     )
     if heading_re.search(text):
-        updated = heading_re.sub(section.rstrip() + "\n\n", text, count=1)
+        # Repair runs must not erase detailed notes already recorded for the
+        # release or consume newer work that has since entered Unreleased.
+        updated = text
     else:
+        text, unreleased_body = _consume_unreleased_body(text)
+        section = _changelog_section(
+            chosen_version,
+            tag,
+            package_names,
+            unreleased_body=unreleased_body,
+        )
         first_heading = re.search(r"^## \[", text, flags=re.MULTILINE)
         if first_heading:
             updated = text[: first_heading.start()] + section + "\n" + text[first_heading.start():]


### PR DESCRIPTION
## Summary

- bump the 34-package impact closure since `v2026.07.04` to stable version `2026.07.17`
- refresh exact internal dependency pins so every selected bundle resolves the new package graph
- move shipped `Unreleased` notes into the dated release section and preserve detailed notes during repair runs
- expand the pending changelog with the major shipped security, workflow, analysis, compatibility, and concurrency changes

## Release Scope

- Previous release: `v2026.07.04`
- Planned package version: `2026.07.17`
- Planned GitHub release tag: `v2026.07.17`
- Selection: all 34 packages returned by `release_plan.py --impact-base-ref v2026.07.04`
- Publication: one `pypi-publish.yaml` dispatch from merged `main`; no explicit package/role override and no `include_existing_pypi`

## Repro

Before this change, the current source versions already existed on PyPI, so the optimized release plan selected no publication. Separately, `update_changelog_release_entry()` inserted a dated release section without consuming `## Unreleased`; a repair call could replace an existing detailed release section.

## Root Cause

The repository had not yet committed a new stable version/pin graph for the changes since `v2026.07.04`. The changelog helper treated generated publication metadata as a standalone section and did not model the transition from pending notes to shipped notes or distinguish first publication from repair.

## Regression Test

- verifies pending notes move exactly once into a new dated release section
- verifies publication bullets merge into the existing `Changed` subsection
- verifies repair runs preserve both existing detailed release notes and newer `Unreleased` work
- verifies the full release-plan/version-policy closure selects 34 packages at `2026.07.17`

## Validation

- `test/test_pypi_publish.py` + `test/test_pypi_publish_workflow.py`: 104 passed
- focused Ruff checks: passed (the test module retains its pre-existing `E402` path-bootstrap exemption)
- maintenance dashboard: 11 passed, 1 expected TODO-hotspot warning, 0 failed; canonical docs mirror aligned
- PyPI project preflight: 35 checked, 34 to publish, 1 current, 0 blockers
- stable version policy: accepted all 34 selected package versions
- GitHub PR matrix: Python 3.13/3.14, clean installs on Linux/macOS/Windows, Windows core, local-only policy, provenance, and GitGuardian all passed; public-demo smoke was not applicable and skipped by path scope
- full strict release gate will be rerun from an isolated clean checkout of merged `main` before workflow dispatch; the shared local checkout currently contains unrelated user-owned dirty/stale worktrees and is intentionally not cleaned

## Review Evidence

- Release-contract sub-agent: exact model unavailable; read-only workflow/version/tag/dispatch review; no file edits. Findings addressed: required version bump, PR-first sequencing, and changelog transition gap.
- Public-baseline sub-agent: exact model unavailable; read-only PyPI/GitHub/docs/Hugging Face verification; no file edits. Findings addressed: current public version/tag and empty optimized plan before the bump.

## Agent Metadata

- Tokki: `1.0.27`
- Agent/runtime: Codex CLI `0.144.5`
- Model: GPT-5
- Reasoning effort: unknown
- `/fast` mode: not used
