### PR TITLE
fix(docs): prefer current checkout for autodoc

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 276,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "bb39e6444e1b0c8f31245a7bf4cb1af7ae4764bf69aacc118a6fa88513fcd3c3",
+  "source_digest_sha256": "0173974251d5c0cd7379007c5b4ba3e6e82f8df6909732ef28f0bf41c2317995",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "bb39e6444e1b0c8f31245a7bf4cb1af7ae4764bf69aacc118a6fa88513fcd3c3"
+  "target_digest_sha256": "0173974251d5c0cd7379007c5b4ba3e6e82f8df6909732ef28f0bf41c2317995"
 }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -40,10 +40,14 @@ def _is_site_packages_path(path: Path) -> bool:
     return "site-packages" in path.parts
 
 
-def _should_use_agilab_path_fallback(path: Path) -> bool:
-    """Avoid documenting stale installed wheels when a source checkout is built."""
+def _should_use_agilab_path_fallback(
+    path: Path,
+    *,
+    current_source_available: bool = False,
+) -> bool:
+    """Use persisted source only when the checkout being documented has none."""
 
-    return not _is_site_packages_path(path)
+    return not current_source_available and not _is_site_packages_path(path)
 
 
 # Prefer the pinned public framework submodule when present.
@@ -60,14 +64,18 @@ if (repo_root / "core").exists():
 
 # Current public source checkout. Prefer this over any persisted installed path
 # so autodoc does not import stale binary wheels from another Python version.
-if (repo_root / "src/agilab").exists():
+current_source_available = (repo_root / "src/agilab").exists()
+if current_source_available:
     _add_path(repo_root / "src")
     _add_agilab_lib_paths(repo_root / "src/agilab")
     if (repo_root / "src/agilab/core").exists():
         _add_core_paths(repo_root / "src/agilab/core")
 
 # Fallback: use the upstream checkout recorded by `~/.local/share/agilab/.agilab-path`.
-if agi_path is not None and _should_use_agilab_path_fallback(agi_path):
+if agi_path is not None and _should_use_agilab_path_fallback(
+    agi_path,
+    current_source_available=current_source_available,
+):
     # `.agilab-path` commonly points at `<repo>/src/agilab`. Add the parent so
     # `import agilab` works, while still supporting a repo-root path.
     if agi_path.name == "agilab" and (agi_path / "__init__.py").exists():
@@ -81,9 +89,14 @@ if agi_path is not None and _should_use_agilab_path_fallback(agi_path):
     elif (agi_path / "core").exists():
         _add_core_paths(agi_path / "core")
 elif agi_path is not None:
+    reason = (
+        "the current source checkout is available"
+        if current_source_available
+        else "it points into site-packages"
+    )
     print(
-        "Info: ignoring installed AGILAB path for docs build "
-        f"because it points into site-packages: {agi_path}"
+        "Info: ignoring persisted AGILAB path for docs build "
+        f"because {reason}: {agi_path}"
     )
 
 try:

--- a/test/test_docs_version_label.py
+++ b/test/test_docs_version_label.py
@@ -64,3 +64,10 @@ def test_docs_conf_ignores_installed_agilab_path_fallback() -> None:
     assert conf._is_site_packages_path(installed_agilab) is True
     assert conf._should_use_agilab_path_fallback(installed_agilab) is False
     assert conf._should_use_agilab_path_fallback(source_agilab) is True
+    assert (
+        conf._should_use_agilab_path_fallback(
+            source_agilab,
+            current_source_available=True,
+        )
+        is False
+    )


### PR DESCRIPTION
## Summary

- prefer the active docs checkout over a persisted `.agilab-path` fallback
- synchronize the canonical private docs config into the public mirror
- add a polluted-environment regression for checkout precedence

## Repro

With `~/.local/share/agilab/.agilab-path` pointing at another AGILAB checkout, the release docs profile emitted `MixedCheckoutImportError` because Sphinx autodoc imported modules from that stale checkout.

## Root Cause

`docs/source/conf.py` added the active checkout first, then added the persisted fallback. `_add_path` prepends to `sys.path`, so the later fallback silently won despite the stated precedence.

## Regression Test

`test_docs_version_label.py` now proves that a valid persisted source path is rejected whenever the current checkout has an AGILAB source tree. The docs profile was also rerun with the polluted persisted path present.

## Validation

- focused docs-version tests: 4 passed
- canonical/public mirror stamp: verified
- docs workflow-parity profile: passed without `MixedCheckoutImportError`
- canonical config: compiled successfully
- required PR checks: passed; `public-demo-smoke` skipped as not applicable to this docs-only change

## Review Evidence

- Release-baseline reviewer (model unavailable): read-only public evidence review; no files edited
- Release-contract reviewer (model unavailable): read-only workflow sequencing review; no files edited
- Main Codex agent: diagnosed, implemented, and validated this scoped blocker fix; findings addressed

## Agent Metadata

- Tokki: 1.0.27
- Agent/runtime: codex-cli 0.144.5
- Model: GPT-5
- Reasoning effort: unknown
- `/fast`: not used
