### PR TITLE
fix(tests): stabilize spawned evidence workers

### DIFF
--- a/test/_workflow_run_manifest_process_support.py
+++ b/test/_workflow_run_manifest_process_support.py
@@ -1,0 +1,116 @@
+"""Stable spawn targets for workflow evidence multiprocessing tests.
+
+Pytest can collect the repository tests under different package names depending
+on the checkout path.  Spawned processes must import their target by module
+name, so keep the targets in this non-collected module and put the test
+directory on ``sys.path`` before processes start.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import os
+from pathlib import Path
+import sys
+
+
+def _import_workflow_run_manifest():
+    repo_root = Path(__file__).resolve().parents[1]
+    source_root = repo_root / "src"
+    package_root = source_root / "agilab"
+    source_root_text = str(source_root)
+    if source_root_text not in sys.path:
+        sys.path.insert(0, source_root_text)
+
+    package_spec = importlib.util.spec_from_file_location(
+        "agilab",
+        package_root / "__init__.py",
+        submodule_search_locations=[str(package_root)],
+    )
+    package = sys.modules.get("agilab")
+    if package is None or not hasattr(package, "__path__"):
+        assert package_spec is not None and package_spec.loader is not None
+        package = importlib.util.module_from_spec(package_spec)
+        sys.modules["agilab"] = package
+        package_spec.loader.exec_module(package)
+    else:
+        package_paths = list(package.__path__)
+        package_root_text = str(package_root)
+        if package_root_text not in package_paths:
+            package.__path__ = [package_root_text, *package_paths]
+        package.__spec__ = package_spec
+        package.__file__ = str(package_root / "__init__.py")
+        package.__package__ = "agilab"
+
+    importlib.invalidate_caches()
+    return importlib.import_module("agilab.workflow_run_manifest")
+
+
+workflow_run_manifest = _import_workflow_run_manifest()
+
+
+def workflow_evidence_writer(
+    lab_dir: str,
+    state_path: str,
+    state: dict,
+    start,
+    results,
+) -> None:
+    start.wait(timeout=10)
+    try:
+        workflow_run_manifest.write_workflow_run_evidence(
+            state=state,
+            state_path=Path(state_path),
+            repo_root=Path(lab_dir).parent,
+            lab_dir=Path(lab_dir),
+            trigger={"surface": "multiprocess", "action": "write"},
+        )
+    except BaseException as exc:
+        results.put(("error", type(exc).__name__, str(exc)))
+    else:
+        results.put(("ok", "", ""))
+
+
+def workflow_evidence_trigger_writer(
+    lab_dir: str,
+    state_path: str,
+    state: dict,
+    trigger: dict,
+    start,
+    results,
+) -> None:
+    start.wait(timeout=10)
+    try:
+        bundle = workflow_run_manifest.write_workflow_run_evidence(
+            state=state,
+            state_path=Path(state_path),
+            repo_root=Path(lab_dir).parent,
+            lab_dir=Path(lab_dir),
+            trigger=trigger,
+        )
+    except BaseException as exc:
+        results.put(("error", type(exc).__name__, str(exc)))
+    else:
+        results.put(("ok", bundle.manifest["manifest_id"], trigger["action"]))
+
+
+def workflow_evidence_crash_writer(lab_dir: str, state_path: str, state: dict) -> None:
+    real_write = workflow_run_manifest._write_json_fsync
+    calls = 0
+
+    def crash_after_partial_stage(path, payload):
+        nonlocal calls
+        calls += 1
+        real_write(path, payload)
+        if calls == 2:
+            os._exit(23)
+
+    workflow_run_manifest._write_json_fsync = crash_after_partial_stage
+    workflow_run_manifest.write_workflow_run_evidence(
+        state=state,
+        state_path=Path(state_path),
+        repo_root=Path(lab_dir).parent,
+        lab_dir=Path(lab_dir),
+        trigger={"surface": "crash", "action": "write"},
+    )

--- a/test/test_workflow_run_manifest.py
+++ b/test/test_workflow_run_manifest.py
@@ -4,7 +4,6 @@ import importlib
 import importlib.util
 import json
 import multiprocessing
-import os
 from pathlib import Path
 import sys
 
@@ -42,10 +41,15 @@ def _ensure_agilab_package_path() -> None:
 
 
 _ensure_agilab_package_path()
+test_support_root = str(Path(__file__).resolve().parent)
+if test_support_root not in sys.path:
+    sys.path.insert(0, test_support_root)
+
 dag_run_engine = importlib.import_module("agilab.dag_run_engine")
 evidence_graph = importlib.import_module("agilab.evidence_graph")
 workflow_run_manifest = importlib.import_module("agilab.workflow_run_manifest")
 runtime_contract = importlib.import_module("agilab.workflow_runtime_contract")
+process_support = importlib.import_module("_workflow_run_manifest_process_support")
 
 LATEST_WORKFLOW_EVIDENCE_FILENAME = workflow_run_manifest.LATEST_WORKFLOW_EVIDENCE_FILENAME
 WORKFLOW_EVIDENCE_DIRNAME = workflow_run_manifest.WORKFLOW_EVIDENCE_DIRNAME
@@ -54,72 +58,6 @@ load_workflow_run_manifest = workflow_run_manifest.load_workflow_run_manifest
 sha256_payload = workflow_run_manifest.sha256_payload
 workflow_manifest_summary = workflow_run_manifest.workflow_manifest_summary
 write_workflow_run_evidence = workflow_run_manifest.write_workflow_run_evidence
-
-
-def _workflow_evidence_writer(
-    lab_dir: str,
-    state_path: str,
-    state: dict,
-    start,
-    results,
-) -> None:
-    start.wait(timeout=10)
-    try:
-        workflow_run_manifest.write_workflow_run_evidence(
-            state=state,
-            state_path=Path(state_path),
-            repo_root=Path(lab_dir).parent,
-            lab_dir=Path(lab_dir),
-            trigger={"surface": "multiprocess", "action": "write"},
-        )
-    except BaseException as exc:
-        results.put(("error", type(exc).__name__, str(exc)))
-    else:
-        results.put(("ok", "", ""))
-
-
-def _workflow_evidence_trigger_writer(
-    lab_dir: str,
-    state_path: str,
-    state: dict,
-    trigger: dict,
-    start,
-    results,
-) -> None:
-    start.wait(timeout=10)
-    try:
-        bundle = workflow_run_manifest.write_workflow_run_evidence(
-            state=state,
-            state_path=Path(state_path),
-            repo_root=Path(lab_dir).parent,
-            lab_dir=Path(lab_dir),
-            trigger=trigger,
-        )
-    except BaseException as exc:
-        results.put(("error", type(exc).__name__, str(exc)))
-    else:
-        results.put(("ok", bundle.manifest["manifest_id"], trigger["action"]))
-
-
-def _workflow_evidence_crash_writer(lab_dir: str, state_path: str, state: dict) -> None:
-    real_write = workflow_run_manifest._write_json_fsync
-    calls = 0
-
-    def crash_after_partial_stage(path, payload):
-        nonlocal calls
-        calls += 1
-        real_write(path, payload)
-        if calls == 2:
-            os._exit(23)
-
-    workflow_run_manifest._write_json_fsync = crash_after_partial_stage
-    workflow_run_manifest.write_workflow_run_evidence(
-        state=state,
-        state_path=Path(state_path),
-        repo_root=Path(lab_dir).parent,
-        lab_dir=Path(lab_dir),
-        trigger={"surface": "crash", "action": "write"},
-    )
 
 
 def _start_spawn_processes(processes) -> None:
@@ -431,7 +369,7 @@ def test_two_process_state_a_b_publication_rejects_stale_a(tmp_path: Path) -> No
     results = context.Queue()
     processes = [
         context.Process(
-            target=_workflow_evidence_writer,
+            target=process_support.workflow_evidence_writer,
             args=(str(lab_dir), str(state_path), state, start, results),
         )
         for state in (state_a, state_b)
@@ -469,7 +407,7 @@ def test_workflow_evidence_publication_is_multiprocess_safe(tmp_path: Path) -> N
     results = context.Queue()
     processes = [
         context.Process(
-            target=_workflow_evidence_writer,
+            target=process_support.workflow_evidence_writer,
             args=(str(lab_dir), str(state_path), state, start, results),
         )
         for _ in range(2)
@@ -504,7 +442,7 @@ def test_same_state_different_triggers_publish_distinct_bundles_concurrently(tmp
     ]
     processes = [
         context.Process(
-            target=_workflow_evidence_trigger_writer,
+            target=process_support.workflow_evidence_trigger_writer,
             args=(str(lab_dir), str(state_path), state, trigger, start, results),
         )
         for trigger in triggers
@@ -724,7 +662,7 @@ def test_workflow_evidence_process_crash_is_ignored_and_recovered(tmp_path: Path
     state_path.write_text(json.dumps(state, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     context = multiprocessing.get_context("spawn")
     process = context.Process(
-        target=_workflow_evidence_crash_writer,
+        target=process_support.workflow_evidence_crash_writer,
         args=(str(lab_dir), str(state_path), state),
     )
     _start_spawn_processes([process])


### PR DESCRIPTION
## Summary

- move workflow-evidence multiprocessing targets into a stable, non-collected test-support module
- make the support module bootstrap the source `agilab` package independently in spawned children
- update all four spawn scenarios in the manifest test file, leaving production concurrency unchanged

## Repro

[`pypi-publish` run 29560739580](https://github.com/ThalesGroup/agilab/actions/runs/29560739580) stopped in `test (3.13)` before publication. `test_two_process_state_a_b_publication_rejects_stale_a` timed out on its result queue after both spawned children failed with `ModuleNotFoundError: No module named 'agilab.test.test_workflow_run_manifest'`.

No tag, PyPI upload, release asset, dataset publication, Hugging Face sync, or release-proof update ran; all downstream jobs were skipped.

## Root Cause

Pytest can collect the root test module as `agilab.test.test_workflow_run_manifest`. `multiprocessing` with the `spawn` context pickles the worker by module name, but the child bootstrap exposes the source `agilab` package rather than the checkout-root test package. The child therefore could not re-import the test-local target before executing the concurrency scenario.

## Regression Test

All spawn targets now live in `_workflow_run_manifest_process_support`, a stable top-level module on the inherited test-support path. The helper independently exposes the source package, so it is importable under checkout-path and pytest import-mode variations. All four spawn scenarios and the full workflow-manifest test file pass.

## Validation

- exact failed coverage-style scenario: passed
- four workflow-evidence spawn scenarios: 4 passed
- full workflow-manifest test file: 24 passed
- nested release-style coverage/import-mode simulation: passed
- `agi-gui` workflow-parity profile: passed
- Ruff and `py_compile`: passed
- required PR checks, including Windows core tests: passed; `public-demo-smoke` skipped as not applicable to this test-only change

## Review Evidence

- Spawn/import reviewer (model unavailable): read-only root-cause and cross-platform review; no files edited; approved the test-only helper approach and independently reran the focused/import-mode validations
- Main Codex agent: implemented the fix and addressed the review findings

## Agent Metadata

- Tokki: 1.0.27
- Agent/runtime: codex-cli 0.144.5
- Model: GPT-5
- Reasoning effort: unknown
- `/fast`: not used
