### PR TITLE
Fix first-run app venv targeting

### DIFF
--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_build_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_build_support.py
@@ -19,6 +19,7 @@ from agi_cluster.agi_distributor.deployment.deployment_resolver_env_support impo
     _uv_resolver_mode as _uv_resolver_mode,
 )
 from agi_cluster.agi_distributor.deployment.deployment_venv_support import (
+    project_venv_python as _project_venv_python,
     project_site_packages_dir as _project_site_packages_dir,
 )
 from agi_env import AgiEnv
@@ -85,6 +86,18 @@ def _project_uv(env: Any) -> str:
         return f"{resolver_prefix}{env.uv}"
     cmd_prefix = str(env.envars.get("127.0.0.1_CMD_PREFIX", "")).strip()
     return " ".join(part for part in (resolver_prefix + cmd_prefix, "PYTHON_GIL=0", env.uv) if part)
+
+
+def _command_path_arg(value: str | Path, *, os_name: str = os.name) -> str:
+    path_value = str(value)
+    if os_name == "nt":
+        if any(
+            character in path_value
+            for character in ('"', "\r", "\n", "\0", "%", "!")
+        ):
+            raise ValueError(f"Unsafe Windows command path: {path_value!r}")
+        return f'"{path_value}"'
+    return quote(path_value)
 
 
 def _env_truthy(envars: Any, key: str) -> bool:
@@ -380,27 +393,41 @@ def _worker_pyproject_source(env: Any) -> Path:
     return worker_pyproject_src
 
 
-def _core_install_commands(*, env: Any, uv: str, app_path_arg: str) -> list[str]:
+def _core_install_commands(
+    *,
+    env: Any,
+    uv: str,
+    app_path: Path,
+    os_name: str = os.name,
+) -> list[str]:
     commands: list[str] = []
     offline_flag = _uv_offline_flag(env)
+    app_venv_python = _project_venv_python(app_path, os_name=os_name)
+    if not app_venv_python.is_file():
+        raise FileNotFoundError(
+            "App manager virtualenv Python is missing before the worker build: "
+            f"{app_venv_python}. Run AGI.install for the app before building workers."
+        )
+    app_venv_python_arg = _command_path_arg(app_venv_python, os_name=os_name)
     core_packages = (
         ("agi-env", getattr(env, "agi_env", None)),
         ("agi-node", getattr(env, "agi_node", None)),
     )
     if getattr(env, "is_source_env", False):
         editable_specs = [
-            f"-e '{source_path}'"
+            f"-e {_command_path_arg(source_path, os_name=os_name)}"
             for _package_name, source_path in core_packages
             if source_path
         ]
         if editable_specs:
             commands.append(
-                f"{uv} {offline_flag}--project {app_path_arg} pip install --upgrade --no-deps "
+                f"{uv} {offline_flag}pip install --python {app_venv_python_arg} "
+                "--upgrade --no-deps "
                 + " ".join(editable_specs)
             )
     else:
         commands.append(
-            f"{uv} --project {app_path_arg} pip install "
+            f"{uv} pip install --python {app_venv_python_arg} "
             + " ".join(package_name for package_name, _source_path in core_packages)
         )
     return commands
@@ -547,7 +574,7 @@ async def build_lib_local(
     module_cmd = _build_module_command(env)
     app_path_arg = f"\"{app_path}\""
     wenv_arg = f"\"{wenv_abs}\""
-    core_install_commands = _core_install_commands(env=env, uv=uv, app_path_arg=app_path_arg)
+    core_install_commands = _core_install_commands(env=env, uv=uv, app_path=app_path)
     build_overlay_args = _build_run_overlay_args(env)
 
     _stage_worker_build_project(

--- a/src/agilab/core/test/test_agi_distributor_deployment_build_support.py
+++ b/src/agilab/core/test/test_agi_distributor_deployment_build_support.py
@@ -508,6 +508,9 @@ def _build_env(tmp_path: Path, *, base_worker_cls: str = "PandasWorker", free_th
     app_src = app_path / "src" / "demo_worker"
     app_src.mkdir(parents=True, exist_ok=True)
     (app_src / "demo_worker.py").write_text("VALUE = 1\n", encoding="utf-8")
+    app_venv_python = deployment_build_support._project_venv_python(app_path)
+    app_venv_python.parent.mkdir(parents=True, exist_ok=True)
+    app_venv_python.write_text("", encoding="utf-8")
     wenv_abs = tmp_path / "wenv"
     (wenv_abs / "dist").mkdir(parents=True, exist_ok=True)
     worker_pyproject = tmp_path / "worker_pyproject.toml"
@@ -543,6 +546,76 @@ def _build_env(tmp_path: Path, *, base_worker_cls: str = "PandasWorker", free_th
     )
 
 
+def test_core_install_commands_target_existing_manager_venv(tmp_path):
+    env = _build_env(tmp_path)
+    app_path = tmp_path / "app with spaces"
+    app_venv_python = deployment_build_support._project_venv_python(app_path)
+    app_venv_python.parent.mkdir(parents=True)
+    app_venv_python.write_text("", encoding="utf-8")
+
+    commands = deployment_build_support._core_install_commands(
+        env=env,
+        uv="uv",
+        app_path=app_path,
+    )
+
+    assert commands == [
+        "uv pip install --python "
+        f"{deployment_build_support._command_path_arg(app_venv_python)} "
+        "agi-env agi-node"
+    ]
+    assert "--project" not in commands[0]
+
+
+def test_core_install_commands_fail_when_manager_venv_is_missing(tmp_path):
+    env = _build_env(tmp_path)
+    app_path = tmp_path / "missing-app"
+
+    with pytest.raises(FileNotFoundError, match="Run AGI.install"):
+        deployment_build_support._core_install_commands(
+            env=env,
+            uv="uv",
+            app_path=app_path,
+        )
+
+
+def test_core_install_commands_use_cmd_quotes_with_windows_resolver_prefix(tmp_path):
+    env = _build_env(tmp_path)
+    env.is_source_env = True
+    env.agi_env = tmp_path / "core sources" / "agi-env"
+    env.agi_node = tmp_path / "core sources" / "agi-node"
+    app_path = tmp_path / "app with spaces"
+    app_venv_python = deployment_build_support._project_venv_python(
+        app_path,
+        os_name="nt",
+    )
+    app_venv_python.parent.mkdir(parents=True)
+    app_venv_python.write_text("", encoding="utf-8")
+    uv = 'set "UV_INDEX_URL=https://mirror.local/simple" && uv'
+
+    commands = deployment_build_support._core_install_commands(
+        env=env,
+        uv=uv,
+        app_path=app_path,
+        os_name="nt",
+    )
+
+    assert commands == [
+        f'{uv} pip install --python "{app_venv_python}" --upgrade --no-deps '
+        f'-e "{env.agi_env}" -e "{env.agi_node}"'
+    ]
+    assert "'" not in commands[0]
+
+
+@pytest.mark.parametrize("unsafe_character", ["%", "!"])
+def test_command_path_arg_rejects_windows_expansion_characters(unsafe_character):
+    with pytest.raises(ValueError, match="Unsafe Windows command path"):
+        deployment_build_support._command_path_arg(
+            f"C:\\AGILAB{unsafe_character}Work\\app",
+            os_name="nt",
+        )
+
+
 @pytest.mark.asyncio
 async def test_build_lib_local_non_cython_uploads_egg(tmp_path):
     env = _build_env(tmp_path)
@@ -573,8 +646,17 @@ async def test_build_lib_local_non_cython_uploads_egg(tmp_path):
     )
 
     assert (env.wenv_abs / env.worker_pyproject.name).exists()
-    assert any("pip install agi-env agi-node" in cmd for cmd, _ in commands)
-    assert not any("pip install agi-env agi-node agi-cluster" in cmd for cmd, _ in commands)
+    app_venv_python = deployment_build_support._command_path_arg(
+        deployment_build_support._project_venv_python(env.active_app)
+    )
+    assert any(
+        f"pip install --python {app_venv_python} agi-env agi-node" in cmd
+        for cmd, _ in commands
+    )
+    assert not any(
+        f"pip install --python {app_venv_python} agi-env agi-node agi-cluster" in cmd
+        for cmd, _ in commands
+    )
     assert any("bdist_egg" in cmd for cmd, _ in commands)
     assert str(egg_path) in uploads
 
@@ -717,14 +799,17 @@ async def test_build_lib_local_uses_editable_core_installs_in_source_env(monkeyp
     core_runtime_installs = [
         cmd
         for cmd, _ in commands
-        if f'--offline --project "{env.active_app}" pip install --upgrade --no-deps'
-        in cmd
+        if "--offline pip install --python" in cmd and "--upgrade --no-deps" in cmd
     ]
     assert any(
-        f"-e '{env.agi_env}'" in cmd and f"-e '{env.agi_node}'" in cmd
+        f"-e {deployment_build_support._command_path_arg(env.agi_env)}" in cmd
+        and f"-e {deployment_build_support._command_path_arg(env.agi_node)}" in cmd
         for cmd in core_runtime_installs
     )
-    assert not any(f"-e '{env.agi_cluster}'" in cmd for cmd in core_runtime_installs)
+    assert not any(
+        f"-e {deployment_build_support._command_path_arg(env.agi_cluster)}" in cmd
+        for cmd in core_runtime_installs
+    )
     assert any(
         _editable_overlay_arg(env.agi_env) in cmd
         and _editable_overlay_arg(env.agi_node) in cmd
@@ -770,13 +855,17 @@ async def test_build_lib_local_uses_uv_index_url_mirror_when_internet_disabled(
     core_runtime_installs = [
         cmd
         for cmd, _ in commands
-        if f'--project "{env.active_app}" pip install --upgrade --no-deps' in cmd
+        if "pip install --python" in cmd and "--upgrade --no-deps" in cmd
     ]
     assert any(
-        f"-e '{env.agi_env}'" in cmd and f"-e '{env.agi_node}'" in cmd
+        f"-e {deployment_build_support._command_path_arg(env.agi_env)}" in cmd
+        and f"-e {deployment_build_support._command_path_arg(env.agi_node)}" in cmd
         for cmd in core_runtime_installs
     )
-    assert not any(f"-e '{env.agi_cluster}'" in cmd for cmd in core_runtime_installs)
+    assert not any(
+        f"-e {deployment_build_support._command_path_arg(env.agi_cluster)}" in cmd
+        for cmd in core_runtime_installs
+    )
     assert any(
         _editable_overlay_arg(env.agi_env) in cmd
         and _editable_overlay_arg(env.agi_node) in cmd

--- a/test/test_source_clone_regression.py
+++ b/test/test_source_clone_regression.py
@@ -10,10 +10,15 @@ from pathlib import Path
 
 import pytest
 
+from agilab.security.secret_uri import redact_text
+
 
 ROOT = Path(__file__).resolve().parents[1]
 RELEASE_PROOF_ENV = "AGILAB_RUN_RELEASE_PROOF_SLOW"
 UV_PYTHON_SELECTOR = ("AGILAB_RELEASE_PROOF_PYTHON", "AGILAB_SOURCE_CLONE_PYTHON")
+CLONE_PROOF_DIAGNOSTIC_TAIL_LINES = 40
+CLONE_PROOF_DIAGNOSTIC_TAIL_CHARS = 4_000
+CLONE_PROOF_FAILED_STEP_CHARS = 160
 
 
 def _uv_python_args() -> tuple[str, ...]:
@@ -195,6 +200,90 @@ def test_materialize_fresh_source_clone_recovers_from_parent_payload(
     assert (clone_root / "src" / "demo_worker" / "dataset.7z").read_bytes() == b"7z\xbc\xafmaterialized"
 
 
+def _bounded_diagnostic_tail(value: str) -> tuple[str, int, int]:
+    lines = redact_text(value).splitlines()
+    omitted_lines = max(0, len(lines) - CLONE_PROOF_DIAGNOSTIC_TAIL_LINES)
+    tail = "\n".join(lines[-CLONE_PROOF_DIAGNOSTIC_TAIL_LINES:])
+    omitted_chars = max(0, len(tail) - CLONE_PROOF_DIAGNOSTIC_TAIL_CHARS)
+    if omitted_chars:
+        tail = tail[-CLONE_PROOF_DIAGNOSTIC_TAIL_CHARS:]
+    return tail, omitted_lines, omitted_chars
+
+
+def _bounded_failed_step(value: object) -> tuple[str, int]:
+    if value is None:
+        return "unknown", 0
+    normalized = " ".join(redact_text(value).splitlines()).strip() or "unknown"
+    omitted_chars = max(0, len(normalized) - CLONE_PROOF_FAILED_STEP_CHARS)
+    if omitted_chars:
+        normalized = normalized[: CLONE_PROOF_FAILED_STEP_CHARS - 3] + "..."
+    return normalized, omitted_chars
+
+
+def _clone_proof_failure_message(
+    completed: subprocess.CompletedProcess[str],
+) -> str:
+    stdout = completed.stdout or ""
+    stderr = completed.stderr or ""
+    payload: dict[str, object] | None = None
+    try:
+        decoded = json.loads(stdout)
+    except (json.JSONDecodeError, TypeError):
+        decoded = None
+    if isinstance(decoded, dict):
+        payload = decoded
+
+    failed_step = payload.get("failed_step") if payload else None
+    failed_step_label, failed_step_omitted_chars = _bounded_failed_step(failed_step)
+    diagnostic = ""
+    if payload:
+        steps = payload.get("steps")
+        if isinstance(steps, list):
+            failed_result = next(
+                (
+                    step
+                    for step in steps
+                    if isinstance(step, dict)
+                    and (
+                        step.get("label") == failed_step or step.get("status") == "fail"
+                    )
+                ),
+                None,
+            )
+            if isinstance(failed_result, dict):
+                raw_diagnostic = failed_result.get("diagnostic_tail")
+                if isinstance(raw_diagnostic, list):
+                    diagnostic = "\n".join(str(line) for line in raw_diagnostic)
+                elif isinstance(raw_diagnostic, str):
+                    diagnostic = raw_diagnostic
+
+    if not diagnostic:
+        diagnostic = stdout
+    diagnostic_tail, diagnostic_omitted_lines, diagnostic_omitted_chars = (
+        _bounded_diagnostic_tail(diagnostic)
+    )
+    stderr_tail, stderr_omitted_lines, stderr_omitted_chars = _bounded_diagnostic_tail(
+        stderr
+    )
+    stdout_omitted_lines = max(
+        0,
+        len(stdout.splitlines()) - CLONE_PROOF_DIAGNOSTIC_TAIL_LINES,
+    )
+    return (
+        "fresh source clone newcomer proof failed "
+        f"(exit_code={completed.returncode}, failed_step={failed_step_label}, "
+        f"failed_step_omitted_chars={failed_step_omitted_chars}).\n"
+        "diagnostic_tail "
+        f"(omitted_lines={diagnostic_omitted_lines}, "
+        f"omitted_chars={diagnostic_omitted_chars}):\n"
+        f"{diagnostic_tail or '<empty>'}\n"
+        "stderr_tail "
+        f"(omitted_lines={stderr_omitted_lines}, omitted_chars={stderr_omitted_chars}):\n"
+        f"{stderr_tail or '<empty>'}\n"
+        f"captured_stdout_omitted_lines={stdout_omitted_lines}"
+    )
+
+
 def _run_clone_newcomer_proof(clone_root: Path) -> dict[str, object]:
     active_app = (
         clone_root / "src" / "agilab" / "apps" / "builtin" / "flight_telemetry_project"
@@ -226,12 +315,71 @@ def _run_clone_newcomer_proof(clone_root: Path) -> dict[str, object]:
             "--no-manifest",
         ],
         cwd=clone_root,
-        check=True,
+        check=False,
         capture_output=True,
         text=True,
         env=env,
     )
-    return json.loads(completed.stdout)
+    if completed.returncode != 0:
+        raise AssertionError(_clone_proof_failure_message(completed))
+    payload = json.loads(completed.stdout)
+    assert isinstance(payload, dict)
+    return payload
+
+
+def test_run_clone_newcomer_proof_reports_structured_bounded_failure(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    secret = "sk-live-12345678901234567890"
+    failed_step = f"flight install smoke {secret} " + ("x" * 50_000)
+    diagnostic_lines = [
+        "install setup",
+        f"OPENAI_API_KEY={secret} " + ("y" * 6_000),
+        "No virtual environment found for Python 3.13",
+    ]
+    stdout = json.dumps(
+        {
+            "failed_step": failed_step,
+            "steps": [
+                {
+                    "label": failed_step,
+                    "status": "fail",
+                    "diagnostic_tail": diagnostic_lines,
+                }
+            ],
+        },
+        indent=2,
+    )
+    stderr = "\n".join(
+        f"uv stderr {index} token={secret}" for index in range(60)
+    )
+
+    def _fake_run(cmd, **kwargs):
+        assert kwargs["check"] is False
+        return subprocess.CompletedProcess(
+            cmd,
+            returncode=1,
+            stdout=stdout,
+            stderr=stderr,
+        )
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+
+    with pytest.raises(AssertionError) as caught:
+        _run_clone_newcomer_proof(tmp_path / "clone")
+
+    message = str(caught.value)
+    assert "failed_step=flight install smoke" in message
+    assert "failed_step_omitted_chars=" in message
+    assert "No virtual environment found for Python 3.13" in message
+    assert "stderr_tail (omitted_lines=20" in message
+    assert "uv stderr 59" in message
+    assert "uv stderr 0" not in message
+    assert "captured_stdout_omitted_lines=" in message
+    assert secret not in message
+    assert "<redacted>" in message
+    assert len(message) < 10_000
 
 
 def _extract_marked_json(stdout: str, marker: str) -> dict[str, object]:


### PR DESCRIPTION
## Summary

- target the already-created app manager virtualenv explicitly when the shared worker-build path installs `agi-env` and `agi-node`
- fail closed with an actionable error when the manager Python interpreter is missing
- preserve POSIX quoting while using guarded `cmd.exe` quoting for Windows resolver-prefix commands
- surface fresh-clone proof failures as bounded, secret-redacted diagnostics instead of swallowing the inner JSON report

## Repro

The `v2026.07.17` release workflow run `29562298222` failed twice in `test_newcomer_first_proof_passes_from_fresh_source_clone`. The hidden inner failure occurred at `flight install smoke`:

```text
uv --project <flight app> pip install ...
No virtual environment found for Python 3.13
```

A plain `uv sync --project src/agilab/apps/builtin/flight_telemetry_project` succeeds. The failure is specific to the real AGILAB build-stage install path.

## Root Cause

The shared deployment path creates and populates the app manager virtualenv immediately before `build_lib_local()`, but `_core_install_commands()` then asked `uv --project` to rediscover that environment. First-run cache and process state could make that ambient discovery fail even though the manager interpreter already existed.

The outer fresh-clone regression used `check=True` while capturing output, so pytest showed only `CalledProcessError` and discarded the structured failure payload emitted by `newcomer_first_proof.py`.

## Regression Test

- source and packaged core installs assert `uv pip install --python <app manager interpreter>` and no longer use `--project` for this step
- a missing manager interpreter fails before worker build commands run
- a Windows-layout app path plus `set ... &&` resolver prefix uses guarded double quotes and rejects `%` / `!` expansion paths
- structured clone-proof failures report the failed step, relevant diagnostic tail, stderr tail, and omitted counts
- oversized labels and diagnostic streams are bounded and dummy API tokens are redacted
- the exact committed candidate passed the slow fresh-clone proof on its first run with an empty uv cache

## Validation

- focused installer/source-clone slice: 51 passed, 1 intentionally gated slow test skipped
- empty-cache slow fresh-clone proof: 1 passed in 150.84s
- shared core: 1482 passed, 5 skipped
- shared-core strict typing: pass
- dependency policy: 28 passed
- maintenance dashboard: 11 pass, 1 known TODO-hotspot warning, 0 fail
- `./dev release --impact-base-ref v2026.07.04 --release-mode stable`: stopped at the strict audit solely because this PR branch is one commit ahead of `origin/main`; rerun required after merge
- first Windows CI run `29565887439`: production command output was correct; four test expectations still used POSIX quoting, so the assertions were updated to the platform-aware command helper and CI was restarted on `105574e`
- final repo-guardrails run `29566262340`: pass; public-demo smoke intentionally skipped by scope
- final Windows core run `29566262346`: pass (2,461 tests in 4m20s)

## Review Evidence

- `fresh_clone_release_failure_review` sub-agent, model unavailable, read-only: isolated the app-venv discovery failure and recommended explicit interpreter targeting plus bounded diagnostics; addressed
- `explicit_app_venv_fix_review` sub-agent, model unavailable, read-only: found Windows `cmd.exe` quoting and CI secret-redaction gaps; both addressed; final review reported no remaining blockers
- follow-up review of the Windows CI assertion repair confirmed the four failing expectations were corrected without weakening the independent Windows quoting oracle
- sub-agents edited no files

## Agent Metadata

- Tokki version: 1.0.27
- Agent/runtime: codex-cli 0.144.5
- Model: GPT-5
- Reasoning effort: unknown
- `/fast` mode: not used
