### PR TITLE
Pin fresh-clone release proof to its active Python

### DIFF
--- a/test/test_source_clone_regression.py
+++ b/test/test_source_clone_regression.py
@@ -37,6 +37,20 @@ def _uv_python_args() -> tuple[str, ...]:
     return ("--python", str(sys.executable))
 
 
+def _prepare_clone_proof_home(home_root: Path) -> Path:
+    """Pin nested AGILAB installs to the interpreter running the proof."""
+
+    python_version = f"{sys.version_info.major}.{sys.version_info.minor}"
+    env_file = home_root / ".agilab" / ".env"
+    env_file.parent.mkdir(parents=True, exist_ok=True)
+    env_file.write_text(
+        "AGI_PYTHON_VERSION=" + json.dumps(python_version) + "\n"
+        "AGI_PYTHON_UV_SPEC=" + json.dumps(sys.executable) + "\n",
+        encoding="utf-8",
+    )
+    return home_root
+
+
 def _load_module(path: Path, name: str):
     sys.modules.pop(name, None)
     spec = importlib.util.spec_from_file_location(name, path)
@@ -288,9 +302,10 @@ def _run_clone_newcomer_proof(clone_root: Path) -> dict[str, object]:
     active_app = (
         clone_root / "src" / "agilab" / "apps" / "builtin" / "flight_telemetry_project"
     )
+    proof_home = _prepare_clone_proof_home(clone_root / "home")
     env = {
         **os.environ,
-        "HOME": str(clone_root / "home"),
+        "HOME": str(proof_home),
         "AGILAB_DISABLE_BACKGROUND_SERVICES": "1",
         "OPENAI_API_KEY": "sk-test-source-clone-proof-000000000000",
         "PYTHONUNBUFFERED": "1",
@@ -382,6 +397,18 @@ def test_run_clone_newcomer_proof_reports_structured_bounded_failure(
     assert len(message) < 10_000
 
 
+def test_prepare_clone_proof_home_pins_active_python(tmp_path: Path) -> None:
+    from dotenv import dotenv_values
+
+    home_root = _prepare_clone_proof_home(tmp_path / "isolated-home")
+
+    values = dotenv_values(home_root / ".agilab" / ".env")
+    assert values["AGI_PYTHON_VERSION"] == (
+        f"{sys.version_info.major}.{sys.version_info.minor}"
+    )
+    assert values["AGI_PYTHON_UV_SPEC"] == sys.executable
+
+
 def _extract_marked_json(stdout: str, marker: str) -> dict[str, object]:
     prefix = f"{marker}="
     for line in reversed(stdout.splitlines()):
@@ -393,7 +420,9 @@ def _extract_marked_json(stdout: str, marker: str) -> dict[str, object]:
 
 
 def _run_clone_notebook_import_proof(clone_root: Path) -> dict[str, object]:
-    notebook_home = clone_root / "home-notebook-import"
+    notebook_home = _prepare_clone_proof_home(
+        clone_root / "home-notebook-import"
+    )
     env = {
         **os.environ,
         "HOME": str(notebook_home),


### PR DESCRIPTION
## Summary

- pin each isolated fresh-clone proof home to the Python interpreter executing the release proof
- apply the same runtime configuration to the notebook-import proof home
- add a regression that parses the generated dotenv and checks both the Python version and uv selector

## Repro

Release workflow run https://github.com/ThalesGroup/agilab/actions/runs/29567012056 failed in `test (3.13)` during the fresh-source-clone proof:

```text
error: No interpreter found for Python 3.14+gil in managed installations or search path
```

The failing nested command was the Flight Telemetry manager sync. All publication jobs were skipped, and no target tag, GitHub Release, or PyPI `2026.7.17` artifact was created.

## Root Cause

The release proof itself ran under Python 3.13, but its intentionally isolated `HOME` had no `.agilab/.env`. `AgiEnv` therefore used its separate product runtime default of Python 3.14 and requested `3.14+gil`, which was not provisioned on the Python 3.13 release runner.

The proof harness owns both the isolated home and the selected proof interpreter, so it now writes a temporary `.agilab/.env` that keeps nested manager and worker environments aligned with that interpreter. Product defaults and shared core are unchanged.

## Regression Test

- `test_prepare_clone_proof_home_pins_active_python` parses the generated dotenv and verifies current major/minor plus exact `sys.executable`
- the existing slow release-proof test exercises fresh clone, app install/readiness, notebook import, execution/analysis, and export with the pinned isolated homes

## Validation

- focused source-clone suite: 5 passed, 1 intentionally gated slow test skipped
- exact committed release-proof profile with Python 3.13 and a new empty uv cache: 1 passed in 133.75 seconds
- staged impact validation: low risk, one test-harness file
- `py_compile`, diff check, scope guard, and agent provenance guard passed
- repo guardrails run `29568780959`: Python 3.13/3.14 compatibility, Linux/macOS/Windows clean installs, and local-only policy passed; public demo intentionally skipped for test-only scope
- Windows core run `29568780942`: passed

The full multi-profile release gate was not repeated before opening the PR because this change only affects the isolated release-proof harness and the exact previously failing profile passed from an empty cache. Required PR CI passed as the integration gate.

## Review Evidence

- `release_run_observer` (model unavailable): read-only workflow and partial-publication review; identified the exact failing command and confirmed no public artifacts were created
- `release_python_selector_review` (model unavailable): read-only root-cause and blast-radius review; confirmed the harness-only repair and no shared-core change; findings addressed
- no sub-agent edited files

## Agent Metadata

- Tokki version: 1.0.27
- Agent/runtime: codex-cli 0.144.5
- Model: GPT-5
- Reasoning effort: unknown
- `/fast` mode: not used
