### PR TITLE
Require patched setuptools 83 in agi-node

### DIFF
--- a/src/agilab/core/agi-node/pyproject.toml
+++ b/src/agilab/core/agi-node/pyproject.toml
@@ -34,7 +34,7 @@ keywords = [
     "pandas",
     "polars",
 ]
-dependencies = ["agi-env==2026.07.17", "cython>=3.1,<4", "humanize>=4.10,<5", "numpy>=2.2,<3", "pandas>=2.3,<4", "parso>=0.8,<1", "polars>=1.35,<2", "psutil>=7,<8", "py7zr>=1.1,<1.2", "setuptools>=68,<83"]
+dependencies = ["agi-env==2026.07.17", "cython>=3.1,<4", "humanize>=4.10,<5", "numpy>=2.2,<3", "pandas>=2.3,<4", "parso>=0.8,<1", "polars>=1.35,<2", "psutil>=7,<8", "py7zr>=1.1,<1.2", "setuptools>=83,<84"]
 
 [project.entry-points."agi_env.runtime_packages"]
 agi-node = "agi_node.agi_env_runtime:RUNTIME_PACKAGE_SPEC"


### PR DESCRIPTION
## Summary

- raise the direct `agi-node` setuptools runtime boundary from `>=68,<83` to `>=83,<84`
- allow the resolver to select setuptools 83.0.0, which fixes `GHSA-h35f-9h28-mq5c`
- keep the existing fail-closed supply-chain gate; no vulnerability ignore is added

## Repro

Release workflow run https://github.com/ThalesGroup/agilab/actions/runs/29569154968 passed its repaired preflight but failed in `supply-chain-evidence`:

```text
Found 1 known vulnerability in 1 package
```

The generated UI-profile audit identified `setuptools==82.0.1` with `PYSEC-2026-3447` / `CVE-2026-59890` / `GHSA-h35f-9h28-mq5c`. Package publication, provenance, code-release assets, retention, and Hugging Face sync were skipped; the target tag, GitHub Release, and all 34 target PyPI versions remained absent.

## Root Cause

`agi-node` directly required `setuptools>=68,<83`, forcing the last vulnerable 82.x release into every profile that includes worker build support. Setuptools 83.0.0 fixes the Unicode-normalization exclusion bypass in `MANIFEST.in` processing.

An ignore is not appropriate: a fixed upstream release exists, setuptools is a direct runtime/build dependency, and AGILAB only acknowledges advisories without fixed releases.

References:

- https://github.com/pypa/advisory-database/blob/main/vulns/setuptools/PYSEC-2026-3447.yaml
- https://setuptools.pypa.io/en/latest/history.html#v83-0-0

## Regression Test

The existing `profile_supply_chain_scan.py --profile all --run` gate is the regression that caught this dependency drift. After the boundary update, all 10 profiles resolve setuptools 83.0.0 and report zero vulnerable dependencies. No separate advisory-ignore test is added because the fail-closed scan remains unchanged.

## Shared-Core Approval and Blast Radius

The operator authorized completing all release blockers, including the required shared-core repair. The changed file is `src/agilab/core/agi-node/pyproject.toml`; its blast radius covers `agi-node`, worker build paths, and all app/profile dependency closures that include it. No `agi-core` file is touched.

Compatibility review covered setuptools 83's Python floor and removal notes. AGILAB supports Python 3.12+, `agi_node.agi_dispatcher.build` does not use removed `dry_run` behavior, and its direct setuptools imports work on 83.0.0.

## Validation

- UI supply-chain profile: setuptools 83.0.0, zero vulnerable dependencies
- all-profile supply-chain scan: 10 profiles, zero vulnerable dependencies
- shared-core dispatcher/cluster slice: 1,484 passed, 5 skipped
- dependency policy: 28 passed
- isolated Python 3.13 boundary smoke imported `agi_node.agi_dispatcher.build` with setuptools 83.0.0
- `agi-node` wheel and sdist built; wheel metadata requires `setuptools<84,>=83`
- staged impact validation, scope guard, diff check, and agent provenance guard passed
- repo guardrails run `29572890462`: Python 3.13/3.14 compatibility, Linux/macOS/Windows clean installs, and local-only policy passed; public demo intentionally skipped for dependency-only scope
- Windows core run `29572890519`: passed

The full release workflow is intentionally not retriggered from the feature branch; it publishes only from merged `main`. Required PR CI passed as the integration gate before merge.

## Review Evidence

- `release_run_observer` (model unavailable): read-only run and partial-publication review; identified the failing supply-chain profile and confirmed no code-release artifacts were published
- `supply_chain_failure_review` (model unavailable): read-only security and compatibility review; independently reproduced the advisory, traced it to `agi-node`, rejected an ignore, and confirmed the `>=83,<84` repair
- no sub-agent edited files

## Agent Metadata

- Tokki version: 1.0.27
- Agent/runtime: codex-cli 0.144.5
- Model: GPT-5
- Reasoning effort: unknown
- `/fast` mode: not used
