### PR TITLE
Harden post-publish release recovery

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -805,6 +805,8 @@ jobs:
             --repo-root .
             --protect-versions-from-projects
             --min-published-releases "$PYPI_RETENTION_MIN_PUBLISHED_RELEASES"
+            --verify-attempts 17
+            --retry-delay 60
             --confirm-delete
             --direct-web-only
             --json

--- a/test/test_hf_space_release_sync.py
+++ b/test/test_hf_space_release_sync.py
@@ -121,6 +121,65 @@ def test_set_space_visibility_falls_back_to_legacy_hf_api(monkeypatch) -> None:
     ]
 
 
+def test_upload_space_updates_existing_repo_without_create(monkeypatch, tmp_path: Path) -> None:
+    module = _load_module()
+    calls: list[dict[str, object]] = []
+    visibility: list[tuple[str, str, bool]] = []
+
+    class _Commit:
+        oid = "0123456789abcdef0123456789abcdef01234567"
+
+    class _Api:
+        def upload_folder(self, **kwargs):
+            calls.append(kwargs)
+            return _Commit()
+
+    monkeypatch.setitem(
+        sys.modules,
+        "huggingface_hub",
+        types.SimpleNamespace(HfApi=lambda: _Api()),
+    )
+    monkeypatch.setattr(
+        module,
+        "set_space_visibility",
+        lambda space_id, *, token, private: visibility.append((space_id, token, private)),
+    )
+
+    commit = module.upload_space(
+        tmp_path,
+        space_id="jpmorard/agilab",
+        token="hf-token",
+        private=False,
+    )
+
+    assert commit == "0123456789abcdef0123456789abcdef01234567"
+    assert calls == [
+        {
+            "repo_id": "jpmorard/agilab",
+            "folder_path": tmp_path,
+            "repo_type": "space",
+            "token": "hf-token",
+            "commit_message": calls[0]["commit_message"],
+            "delete_patterns": [
+                "src/agilab/apps/builtin/**",
+                "src/agilab/apps-pages/**",
+                "src/agilab/pages/**",
+                "src/.DS_Store",
+                "src/.coverage*",
+                "src/**/.DS_Store",
+                "src/**/.coverage*",
+            ],
+            "ignore_patterns": [
+                "**/.venv/**",
+                "**/__pycache__/**",
+                "**/*.pyc",
+            ],
+        }
+    ]
+    assert str(calls[0]["commit_message"]).startswith("chore: deploy AGILAB release Space (")
+    assert visibility == [("jpmorard/agilab", "hf-token", False)]
+
+
 def test_generated_space_readme_uses_valid_hf_emoji_metadata() -> None:
     module = _load_module()
 

--- a/test/test_pypi_publish_workflow.py
+++ b/test/test_pypi_publish_workflow.py
@@ -446,6 +446,8 @@ def test_pypi_publish_attempts_previous_pypi_release_pruning_before_release_asse
     assert "--direct-web-only" in text
     assert '--min-published-releases "$PYPI_RETENTION_MIN_PUBLISHED_RELEASES"' in text
     assert "--min-published-releases 11" not in text
+    assert "--verify-attempts 17" in retention_block
+    assert "--retry-delay 60" in retention_block
     assert "retention_log=\"$(mktemp)\"" in text
     assert "PyPI redirected back to login while opening the release delete page after password/TOTP authentication." in text
     assert "--github-confirm-login-repository \"$GITHUB_REPOSITORY\"" in text

--- a/test/test_pypi_release_retention.py
+++ b/test/test_pypi_release_retention.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import sys
 from pathlib import Path
 
@@ -11,12 +12,20 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 MODULE_PATH = REPO_ROOT / "tools" / "pypi_release_retention.py"
 
 
-def _load_module():
+def _load_module(*, stub_network: bool = True):
     spec = importlib.util.spec_from_file_location("pypi_release_retention_test_module", MODULE_PATH)
     assert spec and spec.loader
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)
+    if stub_network:
+        module.fetch_exact_release_version = (
+            lambda package, repo, version: module.normalize_version(version)
+        )
+        module.probe_exact_release_version = lambda package, repo, version: (
+            module.EXACT_RELEASE_PRESENT,
+            module.normalize_version(version),
+        )
     return module
 
 
@@ -34,6 +43,199 @@ def test_retention_plan_keeps_only_protected_normalized_version(monkeypatch) -> 
     assert plan.protect_version == "2026.5.17"
     assert plan.delete_versions == ["2026.04.16", "2026.04.17"]
     assert plan.missing_protected_version is False
+
+
+def test_exact_release_probe_uses_distinct_cache_busted_requests(monkeypatch) -> None:
+    module = _load_module(stub_network=False)
+    requests = []
+    nonces = iter([101, 102])
+
+    class _Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self):
+            return json.dumps({"info": {"version": "2026.7.17"}}).encode()
+
+    def fake_urlopen(request, *, timeout):
+        requests.append((request, timeout))
+        return _Response()
+
+    monkeypatch.setattr(module.time, "time_ns", lambda: next(nonces))
+    monkeypatch.setattr(module.urllib.request, "urlopen", fake_urlopen)
+
+    assert module.fetch_exact_release_version("agi-web", "pypi", "2026.07.17") == "2026.7.17"
+    assert module.fetch_exact_release_version("agi-web", "pypi", "2026.07.17") == "2026.7.17"
+    assert [request.full_url for request, _timeout in requests] == [
+        "https://pypi.org/pypi/agi-web/2026.7.17/json?agilab_cache_bust=101",
+        "https://pypi.org/pypi/agi-web/2026.7.17/json?agilab_cache_bust=102",
+    ]
+    headers = dict(requests[0][0].header_items())
+    assert headers["Accept"] == "application/json"
+    assert headers["Cache-control"] == "no-cache, no-store, max-age=0"
+    assert headers["Pragma"] == "no-cache"
+    assert headers["User-agent"] == "agilab-pypi-retention/1.0"
+    assert [timeout for _request, timeout in requests] == [15, 15]
+
+
+def test_retention_plan_accepts_matching_exact_release_when_project_json_is_stale(monkeypatch) -> None:
+    module = _load_module()
+    monkeypatch.setattr(module, "fetch_releases", lambda package, repo: ["2026.7.4"])
+    monkeypatch.setattr(
+        module,
+        "fetch_exact_release_version",
+        lambda package, repo, version: "2026.7.17",
+    )
+
+    plan = module.build_plan(
+        "agi-web",
+        "pypi",
+        "2026.7.17",
+        min_published_releases=2,
+    )
+
+    assert plan.published_versions == ["2026.7.4", "2026.7.17"]
+    assert plan.delete_versions == ["2026.7.4"]
+    assert plan.missing_protected_version is False
+
+
+def test_retention_plan_stays_fail_closed_when_exact_release_is_missing(monkeypatch) -> None:
+    module = _load_module(stub_network=False)
+    monkeypatch.setattr(module, "fetch_releases", lambda package, repo: ["2026.7.4"])
+
+    def missing_exact_release(request, *, timeout):
+        raise module.urllib.error.HTTPError(
+            request.full_url,
+            404,
+            "Not Found",
+            hdrs=None,
+            fp=None,
+        )
+
+    monkeypatch.setattr(module.urllib.request, "urlopen", missing_exact_release)
+
+    plan = module.build_plan("agi-web", "pypi", "2026.7.17")
+
+    assert plan.published_versions == ["2026.7.4"]
+    assert plan.delete_versions == []
+    assert plan.retained_versions == ["2026.7.4"]
+    assert plan.missing_protected_version is True
+
+
+def test_retention_plan_refuses_deletion_when_only_aggregate_confirms_protected_release(
+    monkeypatch,
+) -> None:
+    module = _load_module()
+    monkeypatch.setattr(
+        module,
+        "fetch_releases",
+        lambda package, repo: ["2026.7.4", "2026.7.17"],
+    )
+    monkeypatch.setattr(module, "fetch_exact_release_version", lambda package, repo, version: None)
+
+    plan = module.build_plan("agi-web", "pypi", "2026.7.17")
+
+    assert plan.delete_versions == []
+    assert plan.retained_versions == ["2026.7.4"]
+    assert plan.missing_protected_version is True
+
+
+def test_post_delete_verification_accepts_exact_404_with_stale_aggregate(monkeypatch) -> None:
+    module = _load_module()
+    monkeypatch.setattr(
+        module,
+        "fetch_releases",
+        lambda package, repo: ["2026.7.4", "2026.7.17"],
+    )
+    monkeypatch.setattr(
+        module,
+        "probe_exact_release_version",
+        lambda package, repo, version: (
+            (module.EXACT_RELEASE_PRESENT, "2026.7.17")
+            if version == "2026.7.17"
+            else (module.EXACT_RELEASE_ABSENT, None)
+        ),
+    )
+
+    plans = module.verify_package_retention(
+        package_versions={"agi-web": "2026.7.17"},
+        repo="pypi",
+        attempts=1,
+        retry_delay=60,
+    )
+
+    assert plans[0].published_versions == ["2026.7.17"]
+    assert plans[0].delete_versions == []
+
+
+def test_post_delete_verification_retries_exact_endpoint_errors(monkeypatch) -> None:
+    module = _load_module()
+    attempts = 0
+    sleeps: list[float] = []
+    monkeypatch.setattr(
+        module,
+        "fetch_releases",
+        lambda package, repo: ["2026.7.4", "2026.7.17"],
+    )
+
+    def probe(package, repo, version):
+        nonlocal attempts
+        if version == "2026.7.17":
+            return module.EXACT_RELEASE_PRESENT, "2026.7.17"
+        attempts += 1
+        if attempts == 1:
+            return module.EXACT_RELEASE_ERROR, None
+        return module.EXACT_RELEASE_ABSENT, None
+
+    monkeypatch.setattr(module, "probe_exact_release_version", probe)
+    monkeypatch.setattr(module.time, "sleep", lambda seconds: sleeps.append(seconds))
+
+    plans = module.verify_package_retention(
+        package_versions={"agi-web": "2026.7.17"},
+        repo="pypi",
+        attempts=2,
+        retry_delay=60,
+    )
+
+    assert attempts == 2
+    assert sleeps == [60]
+    assert plans[0].delete_versions == []
+
+
+def test_protected_release_wait_allows_full_pypi_cache_window(monkeypatch) -> None:
+    module = _load_module()
+    calls = 0
+    sleeps: list[float] = []
+
+    def fake_build_plan(package, repo, protect_version, *, min_published_releases):
+        nonlocal calls
+        calls += 1
+        missing = calls < 17
+        return module.ReleasePlan(
+            package=package,
+            protect_version=protect_version,
+            published_versions=[] if missing else [protect_version],
+            delete_versions=[],
+            retained_versions=[],
+            missing_protected_version=missing,
+        )
+
+    monkeypatch.setattr(module, "build_plan", fake_build_plan)
+    monkeypatch.setattr(module.time, "sleep", lambda seconds: sleeps.append(seconds))
+
+    plans = module.wait_for_package_protected_releases(
+        package_versions={"agi-web": "2026.7.17"},
+        repo="pypi",
+        attempts=17,
+        retry_delay=60,
+    )
+
+    assert calls == 17
+    assert sleeps == [60] * 16
+    assert plans[0].missing_protected_version is False
 
 
 def test_retention_plan_retains_old_versions_below_publish_threshold(monkeypatch) -> None:
@@ -211,6 +413,13 @@ def test_main_auto_selects_packages_with_visible_protected_version(monkeypatch, 
         },
     )
     monkeypatch.setattr(module, "fetch_releases", lambda package, repo: releases[package])
+    monkeypatch.setattr(
+        module,
+        "fetch_exact_release_version",
+        lambda package, repo, version: (
+            None if package == "agi-old-only" else module.normalize_version(version)
+        ),
+    )
 
     status = module.main(
         [
@@ -248,6 +457,7 @@ def test_main_auto_select_fails_when_no_protected_package_is_visible(monkeypatch
         lambda repo_root: {"agi-old-only": "2026.06.12"},
     )
     monkeypatch.setattr(module, "fetch_releases", lambda package, repo: ["2026.06.12"])
+    monkeypatch.setattr(module, "fetch_exact_release_version", lambda package, repo, version: None)
 
     with pytest.raises(SystemExit, match="visible on PyPI"):
         module.main(
@@ -316,14 +526,15 @@ def test_main_retries_until_protected_release_is_visible(monkeypatch, capsys) ->
     module = _load_module()
     calls = 0
 
-    def fake_fetch_releases(package, repo):
+    def fake_fetch_exact_release(package, repo, version):
         nonlocal calls
         calls += 1
         if calls == 1:
-            return ["2026.04.16"]
-        return ["2026.04.16", "2026.05.17"]
+            return None
+        return module.normalize_version(version)
 
-    monkeypatch.setattr(module, "fetch_releases", fake_fetch_releases)
+    monkeypatch.setattr(module, "fetch_releases", lambda package, repo: ["2026.04.16"])
+    monkeypatch.setattr(module, "fetch_exact_release_version", fake_fetch_exact_release)
 
     status = module.main(
         [
@@ -589,7 +800,11 @@ def test_direct_pypi_delete_treats_missing_manage_release_as_already_deleted(
                 text="<html></html>",
             )
 
-    monkeypatch.setattr(module, "fetch_releases", lambda package, repo: ["2026.5.26"])
+    monkeypatch.setattr(
+        module,
+        "probe_exact_release_version",
+        lambda package, repo, version: (module.EXACT_RELEASE_ABSENT, None),
+    )
     session = FakeSession()
 
     module.delete_release_via_pypi_web(
@@ -1312,6 +1527,7 @@ def test_main_rejects_missing_protected_release(monkeypatch) -> None:
     module = _load_module()
 
     monkeypatch.setattr(module, "fetch_releases", lambda package, repo: ["2026.04.16"])
+    monkeypatch.setattr(module, "fetch_exact_release_version", lambda package, repo, version: None)
 
     with pytest.raises(SystemExit, match="agilab=2026.5.17"):
         module.main(

--- a/tools/hf_space_release_sync.py
+++ b/tools/hf_space_release_sync.py
@@ -500,43 +500,35 @@ def set_space_visibility(space_id: str, *, token: str, private: bool) -> None:
 
 
 def upload_space(stage_dir: Path, *, space_id: str, token: str, private: bool) -> str:
-    env = os.environ.copy()
-    env["HF_TOKEN"] = token
-    output = run_command(
-        [
-            "hf",
-            "upload",
-            space_id,
-            str(stage_dir),
-            "--type",
-            "space",
-            "--commit-message",
-            f"chore: deploy AGILAB release Space ({time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())})",
-            "--delete",
+    from huggingface_hub import HfApi
+
+    commit = HfApi().upload_folder(
+        repo_id=space_id,
+        folder_path=stage_dir,
+        repo_type="space",
+        token=token,
+        commit_message=(
+            "chore: deploy AGILAB release Space "
+            f"({time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())})"
+        ),
+        delete_patterns=[
             "src/agilab/apps/builtin/**",
-            "--delete",
             "src/agilab/apps-pages/**",
-            "--delete",
             "src/agilab/pages/**",
-            "--delete",
             "src/.DS_Store",
-            "--delete",
             "src/.coverage*",
-            "--delete",
             "src/**/.DS_Store",
-            "--delete",
             "src/**/.coverage*",
-            "--exclude",
+        ],
+        ignore_patterns=[
             "**/.venv/**",
-            "--exclude",
             "**/__pycache__/**",
-            "--exclude",
             "**/*.pyc",
         ],
-        env=env,
     )
     set_space_visibility(space_id, token=token, private=private)
-    return parse_commit_sha(output) or current_space_sha(space_id, token=token)
+    commit_sha = str(getattr(commit, "oid", "") or "")
+    return commit_sha or current_space_sha(space_id, token=token)
 
 
 def wait_for_runtime(
@@ -621,9 +613,6 @@ def main(argv: Sequence[str] | None = None) -> int:
         raise SystemExit("HF_TOKEN is required for release HF Space sync")
     if "/" not in args.space:
         raise SystemExit("--space must be NAMESPACE/SPACE_NAME")
-    if shutil.which("hf") is None and not args.dry_run:
-        raise SystemExit("hf CLI is required; install huggingface_hub[cli]")
-
     with tempfile.TemporaryDirectory(prefix="agilab-hf-release-") as tmp:
         stage_dir = Path(tmp)
         staged = stage_space_tree(repo_root, stage_dir, profile=args.profile)

--- a/tools/pypi_release_retention.py
+++ b/tools/pypi_release_retention.py
@@ -20,10 +20,10 @@ import time
 import urllib.error
 import urllib.request
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any, Sequence
-from urllib.parse import urljoin, urlparse
+from urllib.parse import quote, urljoin, urlparse
 
 from packaging.version import InvalidVersion, Version
 
@@ -38,6 +38,10 @@ PYPI_JSON_URLS = {
     "pypi": "https://pypi.org/pypi/{package}/json",
     "testpypi": "https://test.pypi.org/pypi/{package}/json",
 }
+PYPI_RELEASE_JSON_URLS = {
+    "pypi": "https://pypi.org/pypi/{package}/{version}/json",
+    "testpypi": "https://test.pypi.org/pypi/{package}/{version}/json",
+}
 PYPI_HOSTS = {
     "pypi": "https://pypi.org/",
     "testpypi": "https://test.pypi.org/",
@@ -46,6 +50,9 @@ SCHEMA_VERSION = "agilab.pypi_release_retention.v1"
 PYPI_PROJECT_NAME_RE = re.compile(
     r"^[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?$"
 )
+EXACT_RELEASE_PRESENT = "present"
+EXACT_RELEASE_ABSENT = "absent"
+EXACT_RELEASE_ERROR = "error"
 
 
 @dataclass(frozen=True)
@@ -272,6 +279,64 @@ def fetch_releases(package: str, repo: str, *, timeout: int = 15) -> list[str]:
     return sorted(releases, key=lambda value: Version(value))
 
 
+def probe_exact_release_version(
+    package: str,
+    repo: str,
+    version: str,
+    *,
+    timeout: int = 15,
+) -> tuple[str, str | None]:
+    """Return present, absent, or error from a cache-isolated release endpoint."""
+    normalized = normalize_version(version)
+    url = PYPI_RELEASE_JSON_URLS[repo].format(
+        package=quote(package, safe=""),
+        version=quote(normalized, safe=""),
+    )
+    request = urllib.request.Request(
+        f"{url}?agilab_cache_bust={time.time_ns()}",
+        headers={
+            "Accept": "application/json",
+            "Cache-Control": "no-cache, no-store, max-age=0",
+            "Pragma": "no-cache",
+            "User-Agent": "agilab-pypi-retention/1.0",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            data = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        return (EXACT_RELEASE_ABSENT, None) if exc.code == 404 else (EXACT_RELEASE_ERROR, None)
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError):
+        return EXACT_RELEASE_ERROR, None
+    info = data.get("info") if isinstance(data, dict) else None
+    observed = info.get("version") if isinstance(info, dict) else None
+    if not isinstance(observed, str):
+        return EXACT_RELEASE_ERROR, None
+    try:
+        observed_normalized = str(Version(observed))
+    except InvalidVersion:
+        return EXACT_RELEASE_ERROR, None
+    if observed_normalized != normalized:
+        return EXACT_RELEASE_ERROR, None
+    return EXACT_RELEASE_PRESENT, normalized
+
+
+def fetch_exact_release_version(
+    package: str,
+    repo: str,
+    version: str,
+    *,
+    timeout: int = 15,
+) -> str | None:
+    state, observed = probe_exact_release_version(
+        package,
+        repo,
+        version,
+        timeout=timeout,
+    )
+    return observed if state == EXACT_RELEASE_PRESENT else None
+
+
 def build_plan(
     package: str,
     repo: str,
@@ -281,12 +346,22 @@ def build_plan(
 ) -> ReleasePlan:
     protected = Version(normalize_version(protect_version))
     releases = fetch_releases(package, repo)
+    exact_release = fetch_exact_release_version(package, repo, str(protected))
+    if exact_release is not None and all(
+        Version(normalize_version(version)) != protected for version in releases
+    ):
+        releases = sorted([*releases, exact_release], key=lambda value: Version(value))
     old_versions = [
         version
         for version in releases
         if Version(normalize_version(version)) != protected
     ]
-    if len(releases) < min_published_releases:
+    missing_protected = exact_release is None
+    if missing_protected:
+        delete_versions = []
+        retained_versions = old_versions
+        retention_skipped_reason = "protected release is not confirmed by its exact PyPI endpoint"
+    elif len(releases) < min_published_releases:
         delete_versions: list[str] = []
         retained_versions = old_versions
         retention_skipped_reason = (
@@ -299,9 +374,6 @@ def build_plan(
         delete_versions = old_versions
         retained_versions = []
         retention_skipped_reason = None
-    missing_protected = all(
-        Version(normalize_version(version)) != protected for version in releases
-    )
     return ReleasePlan(
         package=package,
         protect_version=str(protected),
@@ -310,6 +382,31 @@ def build_plan(
         retained_versions=retained_versions,
         missing_protected_version=missing_protected,
         retention_skipped_reason=retention_skipped_reason,
+    )
+
+
+def reconcile_exact_deleted_releases(plan: ReleasePlan, *, repo: str) -> ReleasePlan:
+    """Clear stale aggregate entries only after exact endpoints confirm deletion."""
+    if not plan.delete_versions:
+        return plan
+    unresolved: list[str] = []
+    confirmed_absent: set[str] = set()
+    for version in plan.delete_versions:
+        state, _observed = probe_exact_release_version(plan.package, repo, version)
+        if state == EXACT_RELEASE_ABSENT:
+            confirmed_absent.add(normalize_version(version))
+        else:
+            unresolved.append(version)
+    if not confirmed_absent:
+        return plan
+    return replace(
+        plan,
+        published_versions=[
+            version
+            for version in plan.published_versions
+            if normalize_version(version) not in confirmed_absent
+        ],
+        delete_versions=unresolved,
     )
 
 
@@ -460,11 +557,8 @@ def _http_status_from_exception(exc: BaseException) -> int | None:
 
 
 def _version_is_absent_from_public_index(*, package: str, version: str, repo: str) -> bool:
-    target = Version(normalize_version(version))
-    return all(
-        Version(normalize_version(candidate)) != target
-        for candidate in fetch_releases(package, repo)
-    )
+    state, _observed = probe_exact_release_version(package, repo, version)
+    return state == EXACT_RELEASE_ABSENT
 
 
 def _release_absent_after_not_found(
@@ -1028,11 +1122,14 @@ def verify_retention(
     latest: list[ReleasePlan] = []
     for attempt in range(1, max(1, attempts) + 1):
         latest = [
-            build_plan(
-                package,
-                repo,
-                protect_version,
-                min_published_releases=min_published_releases,
+            reconcile_exact_deleted_releases(
+                build_plan(
+                    package,
+                    repo,
+                    protect_version,
+                    min_published_releases=min_published_releases,
+                ),
+                repo=repo,
             )
             for package in packages
         ]
@@ -1059,11 +1156,14 @@ def verify_package_retention(
     latest: list[ReleasePlan] = []
     for attempt in range(1, max(1, attempts) + 1):
         latest = [
-            build_plan(
-                package,
-                repo,
-                protect_version,
-                min_published_releases=min_published_releases,
+            reconcile_exact_deleted_releases(
+                build_plan(
+                    package,
+                    repo,
+                    protect_version,
+                    min_published_releases=min_published_releases,
+                ),
+                repo=repo,
             )
             for package, protect_version in package_versions.items()
         ]


### PR DESCRIPTION
## Summary

- require cache-isolated exact PyPI release confirmation before retention can delete older versions
- use exact release endpoints to verify deletion without trusting stale aggregate project metadata
- extend the release retention propagation window beyond PyPI's observed cache lifetime
- update an existing Hugging Face Space through `HfApi.upload_folder` without invoking repository creation

## Repro

Release run `29573292360` published all 34 package versions and provenance, then failed retention with:

`ERROR: protected package versions are not visible on pypi: agi-web=2026.7.17`

The version appeared shortly afterward. Failed-job recovery then completed retention and the 140-asset GitHub Release, but HF sync failed because `hf upload` called `https://huggingface.co/api/repos/create` for the existing Docker Space and received HTTP 402.

## Root Cause

PyPI retention retried one aggregate project JSON URL for only 50 seconds even though that endpoint advertised a 900-second cache lifetime. Aggregate and exact-version endpoints can also disagree during propagation, so aggregate metadata alone is not a safe deletion authority.

The HF CLI's upload command performs an idempotent-looking repository creation request before committing. Hugging Face's current Docker Space subscription policy rejects that request even when the target Space already exists and is running.

## Regression Test

- exact PyPI probes use unique version-scoped URLs and no-cache headers
- aggregate-only protected visibility cannot authorize deletion
- exact 404 confirms deleted releases while transport/server errors remain retryable failures
- the workflow provides a 17-attempt, 60-second propagation window
- HF upload uses an API fake with no `create_repo` method and preserves delete, ignore, visibility, and commit contracts

## Validation

- 75 focused tests passed
- Ruff, Python compilation, YAML parsing, release-plan workflow validation, trusted-publisher validation, and stable release-version policy passed
- live exact PyPI probes returned `present` for `agi-web==2026.7.17` and `absent` for a nonexistent version
- first-proof HF staging dry-run passed with 1,144 files and the expected three apps/pages
- authenticated HF upload intentionally deferred to the existing-artifact recovery workflow after merge
- required PR checks passed: repo guardrails across Python 3.13/3.14 and clean installs on Ubuntu, macOS, and Windows; Windows core tests; local-only policy; GitGuardian

## Review Evidence

- `retention_propagation_review`: propagation diagnosis and recovery sequencing; model unavailable; read-only, no edits
- `pypi_retention_patch_review`: retention safety review; model unavailable; read-only, no edits; findings addressed
- `hf_existing_space_patch_review`: existing-Space API review; model unavailable; read-only, no edits; no blockers
- `release_post_verify_prep`: post-release verification checklist; model unavailable; read-only, no edits

## Agent Metadata

- Tokki: `1.0.1`
- Agent/runtime: `codex-cli 0.144.5`
- Model: GPT-5
- Reasoning effort: unknown
- `/fast` mode: no
