### PR TITLE
Fix view_maps_3d beam directory reset

### DIFF
--- a/src/agilab/apps-pages/view_maps_3d/src/view_maps_3d/view_maps_3d.py
+++ b/src/agilab/apps-pages/view_maps_3d/src/view_maps_3d/view_maps_3d.py
@@ -314,17 +314,36 @@ def initialize_csv_files():
         st.session_state["df_file"] = dataset_files_rel[0] if dataset_files_rel else None
 
 
+def _clear_beam_selection_state() -> None:
+    """Clear cached beam selections after the beam directory changes."""
+    for key in (
+        "beam_file",
+        "beam_files",
+        "beam_csv_files",
+        "dfs_beams",
+        _vm3d_key("beam_files"),
+    ):
+        if key in st.session_state:
+            del st.session_state[key]
+
+
 def initialize_beam_files():
     """Initialize beam CSV files in the session state."""
-    if (
-            "beam_csv_files" not in st.session_state
-            or not st.session_state["beam_csv_files"]
-    ):
-        files = find_files(st.session_state.beamdir)
+    beamdir = Path(st.session_state.beamdir)
+    if not beamdir.exists() or not beamdir.is_dir():
+        st.session_state["beam_csv_files"] = []
+        st.session_state["beam_files"] = []
+        st.session_state[_vm3d_key("beam_files")] = []
+        st.session_state["dfs_beams"] = {}
+        st.session_state["beam_file"] = None
+        return
+
+    if "beam_csv_files" not in st.session_state or not st.session_state["beam_csv_files"]:
+        files = find_files(beamdir)
         visible = []
         for f in files:
             try:
-                parts = f.relative_to(st.session_state.beamdir).parts
+                parts = f.relative_to(beamdir).parts
             except (TypeError, ValueError):
                 parts = f.parts
             if any(part.startswith(".") for part in parts):
@@ -333,7 +352,7 @@ def initialize_beam_files():
         st.session_state["beam_csv_files"] = visible
     if "beam_file" not in st.session_state:
         beam_csv_files_rel = [
-            Path(file).relative_to(st.session_state.beamdir).as_posix()
+            Path(file).relative_to(beamdir).as_posix()
             for file in st.session_state.beam_csv_files
         ]
         st.session_state["beam_file"] = (
@@ -414,10 +433,7 @@ def update_datadir(var_key, widget_key):
 
 def update_beamdir(var_key, widget_key):
     """Update the beam directory and reinitialize beam files."""
-    if "beam_file" in st.session_state:
-        del st.session_state["beam_file"]
-    if "beam_csv_files" in st.session_state:
-        del st.session_state["beam_csv_files"]
+    _clear_beam_selection_state()
     update_var(var_key, widget_key)
     initialize_beam_files()
 

--- a/test/test_view_maps_3d.py
+++ b/test/test_view_maps_3d.py
@@ -330,6 +330,7 @@ def test_view_maps_3d_initializes_visible_dataset_files(monkeypatch, tmp_path) -
 def test_view_maps_3d_initializes_visible_beam_files(monkeypatch, tmp_path) -> None:
     module = _load_view_maps_3d_module()
     beamdir = tmp_path / "beams"
+    beamdir.mkdir()
     visible = beamdir / "beam.csv"
     hidden = beamdir / ".shadow" / "ignored.csv"
 
@@ -399,6 +400,31 @@ def test_view_maps_3d_get_palette_and_update_beamdir(monkeypatch, tmp_path) -> N
     assert "beam_csv_files" not in state
     assert state["beamdir"] == str(tmp_path / "new_beams")
     assert calls == ["called"]
+
+
+def test_view_maps_3d_update_beamdir_handles_invalid_directory(monkeypatch, tmp_path) -> None:
+    module = _load_view_maps_3d_module()
+    invalid_beamdir = tmp_path / "missing_beams"
+    state = _State(
+        beamdir="old",
+        beam_file="old.csv",
+        beam_files=["old.csv"],
+        beam_csv_files=["old.csv"],
+        dfs_beams={"old.csv": pd.DataFrame({"x": [1]})},
+        input_beamdir=str(invalid_beamdir),
+    )
+    state[module._vm3d_key("beam_files")] = ["old.csv"]
+
+    monkeypatch.setattr(module, "st", SimpleNamespace(session_state=state))
+
+    module.update_beamdir("beamdir", "input_beamdir")
+
+    assert state["beamdir"] == str(invalid_beamdir)
+    assert state["beam_csv_files"] == []
+    assert state["beam_files"] == []
+    assert state[module._vm3d_key("beam_files")] == []
+    assert state["dfs_beams"] == {}
+    assert state["beam_file"] is None
 
 
 def test_view_maps_3d_update_datadir_clears_cached_dataset_state(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- clear all cached beam selection state when the view_maps_3d polygon directory changes
- handle missing polygon directories without leaving stale beam files or loaded beam data active
- add a regression for invalid polygon directory resets

## Repro
Set `Polygon Directory` in `view_maps_3d` to a missing path after a previous beam selection exists. The page can retain stale beam selections and cached beam data even though the new directory is invalid.

## Root Cause
`update_beamdir()` only removed `beam_file` and `beam_csv_files`. It did not clear legacy `beam_files`, page-scoped `view_maps_3d:beam_files`, or `dfs_beams`, so later render logic could still treat old beam files as selected.

## Regression Test
`test_view_maps_3d_update_beamdir_handles_invalid_directory` verifies that invalid beam directories clear stale selections, page-scoped selections, cached beam files, and loaded beam data.

## Validation
- `./dev scope --staged`
- `uv --preview-features extra-build-dependencies run pytest test/test_view_maps_3d.py`
- `git diff --cached --check`
- `uv --preview-features extra-build-dependencies run python -m py_compile src/agilab/apps-pages/view_maps_3d/src/view_maps_3d/view_maps_3d.py test/test_view_maps_3d.py`

## Review Evidence
No sub-agent or model review was used.

## Agent Metadata
- Tokki: tokki-protected 1.0.27
- Agent/runtime: Codex CLI, version unknown
- Model: GPT-5 Codex
- Reasoning effort: unknown
- `/fast` mode: not used
