### PR TITLE
Align canonical release-proof docs mirror

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 276,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "1c4d1eb20ac5d002e4a82fe712397645a65a4c6ea7da189be2f6509b71b96e15",
+  "source_digest_sha256": "562d31e75600918c892ab0754f2781ca8a8bbccc6ee4c0887d5b4a681fa120b6",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "1c4d1eb20ac5d002e4a82fe712397645a65a4c6ea7da189be2f6509b71b96e15"
+  "target_digest_sha256": "562d31e75600918c892ab0754f2781ca8a8bbccc6ee4c0887d5b4a681fa120b6"
 }

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -179,5 +179,4 @@ Indices and tables
 ==================
 
 * :ref:`genindex`
-* :ref:`modindex`
 * :ref:`search`


### PR DESCRIPTION
## Summary

- mirror the canonical docs cleanup merged in private PR #147
- remove the stale Python module-index link from the public docs landing page
- refresh the generated canonical-mirror stamp

## Repro

The canonical private docs profile reported one broken internal link: `index.html -> py-modindex.html`. The failure reproduces on untouched private main. That build does not generate a Python module-index page, but the shared `index.rst` explicitly linked to it.

## Root Cause

The shared docs landing page unconditionally exposed Sphinx's `modindex` reference even though the canonical build has no corresponding target. The public mirror also needed a new stamp after the canonical source correction for the `2026.07.17` release proof.

## Regression Test

- canonical private docs profile passed: mirror check, build, 128 HTML pages, zero missing links, zero sidebar issues
- public `docs` workflow-parity profile passed, including release-proof checks and Sphinx build
- public mirror stamp verification passed
- staged impact classification: low risk, docs only
- required PR checks passed: docs-source guard, Python 3.13/3.14 compatibility, clean installs on Ubuntu/macOS/Windows, local-only policy, and GitGuardian

## Review Evidence

- no sub-agent edited or reviewed this docs patch
- the broken-link failure was reproduced on untouched canonical main before the dead link was removed
- canonical source fix merged in jpmorard/thales_agilab#147 at `74866c1a46dc80d23ecb20a81f5668e329cc2f86`

## Agent Metadata

- Tokki: `1.0.1`
- Agent/runtime: `codex-cli 0.144.5`
- Model: GPT-5
- Reasoning effort: unknown
- `/fast` mode: no
