### PR TITLE
Fix Streamlit test isolation for spawned workers

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -67,6 +67,18 @@ def normalize_agilab_package_spec_for_root_tests():
 
 
 @pytest.fixture(autouse=True)
+def restore_main_module_after_root_tests():
+    """Prevent Streamlit AppTest modules from leaking into later spawn workers."""
+
+    original_main = sys.modules.get("__main__")
+    yield
+    if original_main is None:
+        sys.modules.pop("__main__", None)
+    else:
+        sys.modules["__main__"] = original_main
+
+
+@pytest.fixture(autouse=True)
 def reset_agienv_singleton():
     """Keep singleton state from leaking across tests."""
     AgiEnv.reset()


### PR DESCRIPTION
## Summary

- restore the original Python __main__ module after every root test
- prevent Streamlit AppTest page modules from leaking into later multiprocessing spawn workers
- keep the correction in test isolation without changing production or shared-core code

## Repro

The coverage pipeline failed in job 87871624412 when test_view_scenario_cockpit.py ran before test_global_pipeline_runner_state_report.py. The later multiprocessing test spawned a child that re-executed view_scenario_cockpit.py and raised Missing --active-app argument. The same ordering reproduced locally before the fix.

## Root Cause

Streamlit ScriptRunner replaced sys.modules["__main__"] with its page module and left that module behind after the test. Python multiprocessing spawn then treated the leaked page file as the process entrypoint.

## Regression Test

- exact reproducer order: 8 passed
- both affected files: 22 passed, 1 skipped
- broader UI and pipeline slice: 150 passed, 1 skipped
- impact-selected checks: 13 passed
- Ruff with the existing E402 exemption, py_compile, diff check, scope guard, impact validation, and agent provenance guard passed

The full coverage matrix is delegated to the main-branch coverage workflow because it is the GitHub runner integration surface; the exact failing order was reproduced and validated locally first.

## Review Evidence

- reviewer: GPT-5 Codex
- result: exact failing Actions log inspected; root cause reproduced and corrected
- findings addressed: yes
- sub-agents: one read-only monitor confirmed the final PR check matrix; no sub-agent edited or reviewed the patch

## Final PR Status

- required PR checks: passed
- public-demo-smoke: GitHub skipped; not applicable to this test-only path
- merge state: clean

## Agent Metadata

- Tokki: 1.0.1
- agent/runtime: Codex CLI 0.144.5
- model: GPT-5
- reasoning effort: unknown
- fast mode: no
