### PR TITLE
Refresh current release coverage badges

### DIFF
--- a/badges/coverage-agi-cluster.svg
+++ b/badges/coverage-agi-cluster.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="181" height="20" role="img" aria-label="agi-cluster coverage: 97%">
+<svg xmlns="http://www.w3.org/2000/svg" width="181" height="20" role="img" aria-label="agi-cluster coverage: 92%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="75.0" y="15" fill="#010101" fill-opacity=".3">agi-cluster coverage</text>
   <text x="75.0" y="14">agi-cluster coverage</text>
-  <text x="165.5" y="15" fill="#010101" fill-opacity=".3">97%</text>
-  <text x="165.5" y="14">97%</text>
+  <text x="165.5" y="15" fill="#010101" fill-opacity=".3">92%</text>
+  <text x="165.5" y="14">92%</text>
 </g>
 </svg>

--- a/badges/coverage-agi-core.svg
+++ b/badges/coverage-agi-core.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="160" height="20" role="img" aria-label="agi-core coverage: 97%">
+<svg xmlns="http://www.w3.org/2000/svg" width="160" height="20" role="img" aria-label="agi-core coverage: 92%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="64.5" y="15" fill="#010101" fill-opacity=".3">agi-core coverage</text>
   <text x="64.5" y="14">agi-core coverage</text>
-  <text x="144.5" y="15" fill="#010101" fill-opacity=".3">97%</text>
-  <text x="144.5" y="14">97%</text>
+  <text x="144.5" y="15" fill="#010101" fill-opacity=".3">92%</text>
+  <text x="144.5" y="14">92%</text>
 </g>
 </svg>

--- a/badges/coverage-agi-env.svg
+++ b/badges/coverage-agi-env.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="153" height="20" role="img" aria-label="agi-env coverage: 98%">
+<svg xmlns="http://www.w3.org/2000/svg" width="153" height="20" role="img" aria-label="agi-env coverage: 94%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="61.0" y="15" fill="#010101" fill-opacity=".3">agi-env coverage</text>
   <text x="61.0" y="14">agi-env coverage</text>
-  <text x="137.5" y="15" fill="#010101" fill-opacity=".3">98%</text>
-  <text x="137.5" y="14">98%</text>
+  <text x="137.5" y="15" fill="#010101" fill-opacity=".3">94%</text>
+  <text x="137.5" y="14">94%</text>
 </g>
 </svg>

--- a/badges/coverage-agi-gui.svg
+++ b/badges/coverage-agi-gui.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="153" height="20" role="img" aria-label="agi-gui coverage: 96%">
+<svg xmlns="http://www.w3.org/2000/svg" width="153" height="20" role="img" aria-label="agi-gui coverage: 95%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="61.0" y="15" fill="#010101" fill-opacity=".3">agi-gui coverage</text>
   <text x="61.0" y="14">agi-gui coverage</text>
-  <text x="137.5" y="15" fill="#010101" fill-opacity=".3">96%</text>
-  <text x="137.5" y="14">96%</text>
+  <text x="137.5" y="15" fill="#010101" fill-opacity=".3">95%</text>
+  <text x="137.5" y="14">95%</text>
 </g>
 </svg>

--- a/badges/coverage-agi-node.svg
+++ b/badges/coverage-agi-node.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="160" height="20" role="img" aria-label="agi-node coverage: 97%">
+<svg xmlns="http://www.w3.org/2000/svg" width="160" height="20" role="img" aria-label="agi-node coverage: 92%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="64.5" y="15" fill="#010101" fill-opacity=".3">agi-node coverage</text>
   <text x="64.5" y="14">agi-node coverage</text>
-  <text x="144.5" y="15" fill="#010101" fill-opacity=".3">97%</text>
-  <text x="144.5" y="14">97%</text>
+  <text x="144.5" y="15" fill="#010101" fill-opacity=".3">92%</text>
+  <text x="144.5" y="14">92%</text>
 </g>
 </svg>

--- a/badges/coverage-agilab.svg
+++ b/badges/coverage-agilab.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="146" height="20" role="img" aria-label="agilab coverage: 96%">
+<svg xmlns="http://www.w3.org/2000/svg" width="146" height="20" role="img" aria-label="agilab coverage: 95%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -16,7 +16,7 @@
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
   <text x="57.5" y="15" fill="#010101" fill-opacity=".3">agilab coverage</text>
   <text x="57.5" y="14">agilab coverage</text>
-  <text x="130.5" y="15" fill="#010101" fill-opacity=".3">96%</text>
-  <text x="130.5" y="14">96%</text>
+  <text x="130.5" y="15" fill="#010101" fill-opacity=".3">95%</text>
+  <text x="130.5" y="14">95%</text>
 </g>
 </svg>


### PR DESCRIPTION
## Summary

- refresh six committed coverage badges from the exact XML artifacts produced by coverage run 29580228029
- record current measured coverage without changing code, tests, or thresholds
- leave agi-web unchanged at 100%

## Repro

Coverage run 29580228029 passed all component and combine jobs, then failed final job 87884421362 at git diff --exit-code -- badges/ because six committed badge values were stale.

## Root Cause

The release added covered and uncovered lines after the last badge refresh. Earlier coverage runs were blocked by the Streamlit test-isolation failure, so the aggregate job had not reached the freshness gate that exposed the drift.

## Regression Test

- downloaded the exact five coverage XML artifacts from run 29580228029
- regenerated badges with tools/generate_component_coverage_badges.py
- test_generate_component_coverage_badges.py: 10 passed
- coverage badge guard: passed
- badges workflow parity profile: passed with zero unstaged drift
- scope guard, impact validation, diff checks, and agent provenance guard passed

AGILAB_ALLOW_BADGE_ONLY_UPDATE=1 was used only after regeneration from the current CI artifacts, which is the explicit guard contract for this recovery. The next main-branch coverage run will re-run the same generator and freshness comparison.

## Review Evidence

- reviewer: GPT-5 Codex
- result: exact Actions step and generated diff inspected; update matches CI byte-for-byte
- findings addressed: yes
- sub-agents: one read-only monitor independently confirmed the failing job, six-value drift, and final PR checks; no sub-agent edited files

## Final PR Status

- required PR checks: passed
- public-demo-smoke: GitHub skipped; not applicable to badge-only paths
- merge state: clean

## Agent Metadata

- Tokki: 1.0.1
- agent/runtime: Codex CLI 0.144.5
- model: GPT-5
- reasoning effort: unknown
- fast mode: no
