### PR TITLE
Publish current release proof workflow evidence

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 276,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "562d31e75600918c892ab0754f2781ca8a8bbccc6ee4c0887d5b4a681fa120b6",
+  "source_digest_sha256": "928b54f1cda3de2a24b494d0bc89700e790d9c99297bce804e3ac7a94076e377",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "562d31e75600918c892ab0754f2781ca8a8bbccc6ee4c0887d5b4a681fa120b6"
+  "target_digest_sha256": "928b54f1cda3de2a24b494d0bc89700e790d9c99297bce804e3ac7a94076e377"
 }

--- a/docs/source/data/release_proof.toml
+++ b/docs/source/data/release_proof.toml
@@ -39,40 +39,40 @@ dataset_release_url = "https://github.com/ThalesGroup/agilab/releases/tag/datase
 id = "release-guardrails"
 label = "Public guardrails"
 workflow = "repo-guardrails"
-run_id = "28707372130"
-url = "https://github.com/ThalesGroup/agilab/actions/runs/28707372130"
+run_id = "29581036644"
+url = "https://github.com/ThalesGroup/agilab/actions/runs/29581036644"
 summary = "passed repository guardrails and clean package first-proof jobs"
 
 [[ci_runs]]
 id = "docs-source-guard"
 label = "Docs source guard"
 workflow = "docs-source-guard"
-run_id = "28706985578"
-url = "https://github.com/ThalesGroup/agilab/actions/runs/28706985578"
+run_id = "29578565212"
+url = "https://github.com/ThalesGroup/agilab/actions/runs/29578565212"
 summary = "passed docs mirror and release-proof consistency checks"
 
 [[ci_runs]]
 id = "docs-publish"
 label = "Docs publish"
 workflow = "docs-publish"
-run_id = "28708045395"
-url = "https://github.com/ThalesGroup/agilab/actions/runs/28708045395"
+run_id = "29578565385"
+url = "https://github.com/ThalesGroup/agilab/actions/runs/29578565385"
 summary = "built the public documentation from the managed docs mirror"
 
 [[ci_runs]]
 id = "coverage"
 label = "Coverage"
 workflow = "coverage"
-run_id = "28707372124"
-url = "https://github.com/ThalesGroup/agilab/actions/runs/28707372124"
+run_id = "29581036655"
+url = "https://github.com/ThalesGroup/agilab/actions/runs/29581036655"
 summary = "passed component coverage and badge freshness checks"
 
 [[ci_runs]]
 id = "pypi-publish"
 label = "PyPI publish"
 workflow = "pypi-publish"
-run_id = "28707499103"
-url = "https://github.com/ThalesGroup/agilab/actions/runs/28707499103"
+run_id = "29576361178"
+url = "https://github.com/ThalesGroup/agilab/actions/runs/29576361178"
 summary = "passed the public release proof workflow gate"
 
 [proof_command]

--- a/docs/source/release-proof.rst
+++ b/docs/source/release-proof.rst
@@ -26,15 +26,15 @@ Current public release
    * - Hosted demo
      - `jpmorard/agilab <https://huggingface.co/spaces/jpmorard/agilab>`__ at Space commit ``6bd20209f1e5530979cd8dbb680369978c2af72b``
    * - Public guardrails
-     - `repo-guardrails run 28707372130 <https://github.com/ThalesGroup/agilab/actions/runs/28707372130>`__ passed repository guardrails and clean package first-proof jobs
+     - `repo-guardrails run 29581036644 <https://github.com/ThalesGroup/agilab/actions/runs/29581036644>`__ passed repository guardrails and clean package first-proof jobs
    * - Docs source guard
-     - `docs-source-guard run 28706985578 <https://github.com/ThalesGroup/agilab/actions/runs/28706985578>`__ passed docs mirror and release-proof consistency checks
+     - `docs-source-guard run 29578565212 <https://github.com/ThalesGroup/agilab/actions/runs/29578565212>`__ passed docs mirror and release-proof consistency checks
    * - Docs publish
-     - `docs-publish run 28708045395 <https://github.com/ThalesGroup/agilab/actions/runs/28708045395>`__ built the public documentation from the managed docs mirror
+     - `docs-publish run 29578565385 <https://github.com/ThalesGroup/agilab/actions/runs/29578565385>`__ built the public documentation from the managed docs mirror
    * - Coverage
-     - `coverage run 28707372124 <https://github.com/ThalesGroup/agilab/actions/runs/28707372124>`__ passed component coverage and badge freshness checks
+     - `coverage run 29581036655 <https://github.com/ThalesGroup/agilab/actions/runs/29581036655>`__ passed component coverage and badge freshness checks
    * - PyPI publish
-     - `pypi-publish run 28707499103 <https://github.com/ThalesGroup/agilab/actions/runs/28707499103>`__ passed the public release proof workflow gate
+     - `pypi-publish run 29576361178 <https://github.com/ThalesGroup/agilab/actions/runs/29576361178>`__ passed the public release proof workflow gate
 
 What was proved
 ---------------


### PR DESCRIPTION
## Summary

- sync the canonical release-proof update from private PR jpmorard/thales_agilab#148
- publish successful current guardrails, coverage, docs, and PyPI recovery run IDs
- refresh the managed docs mirror stamp
- preserve the 2026.07.17 release tag, dataset manifest, GitHub release, and Hugging Face commit unchanged

## Repro

The live release-proof page still referenced the 2026.07.04 workflow run IDs even though release 2026.07.17, its recovery publish, and its current coverage proof were complete.

## Root Cause

The earlier docs alignment updated the release identity fields but did not refresh the managed [[ci_runs]] records after the post-publish recovery and coverage repair finished.

## Regression Test

- release proof report: 11/11 checks passed with live GitHub run validation
- docs mirror stamp verification and canonical drift check: passed
- release-proof and sync tests: 23 passed
- docs workflow parity/Sphinx build: passed
- rendered HTML contains guardrails 29581036644, coverage 29581036655, PyPI 29576361178, dataset datasets-2f602a17b4745f05, and Hugging Face commit 6bd20209f1e5530979cd8dbb680369978c2af72b
- scope guard, impact validation, diff checks, and agent provenance guard passed

## Review Evidence

- reviewer: GPT-5 Codex
- result: canonical/private and public mirror diffs match; every pinned workflow was checked live
- findings addressed: yes
- sub-agents: one read-only monitor verified the current coverage/guardrails matrices and final PR checks; no sub-agent edited files

## Final PR Status

- required PR checks: passed
- docs-source-guard run 29581739497: passed
- public-demo-smoke: GitHub skipped; not applicable to docs-only paths
- merge state: clean

## Agent Metadata

- Tokki: 1.0.1
- agent/runtime: Codex CLI 0.144.5
- model: GPT-5
- reasoning effort: unknown
- fast mode: no
