### PR TITLE
Sync docs mirror: page interface contract + skill-visibility docs

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 276,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "928b54f1cda3de2a24b494d0bc89700e790d9c99297bce804e3ac7a94076e377",
+  "source_digest_sha256": "077538e3339fa2cbd10e6102c0d4e9eef047b9817176ba7de6f047f1d787098d",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "928b54f1cda3de2a24b494d0bc89700e790d9c99297bce804e3ac7a94076e377"
+  "target_digest_sha256": "077538e3339fa2cbd10e6102c0d4e9eef047b9817176ba7de6f047f1d787098d"
 }

--- a/docs/source/agent-workflows.rst
+++ b/docs/source/agent-workflows.rst
@@ -121,6 +121,12 @@ Skill catalog and security checks are local-first. Use ``./dev skills`` or the
 ``skills`` workflow-parity profile; AGILAB no longer relies on a dedicated
 GitHub Actions workflow for this agent-skill scan.
 
+Shared skills are canonical under ``.claude/skills`` and mirrored into
+``.codex/skills``. Tokki reads the canonical tree directly
+(``tokki skills list --skills-dir .claude/skills``), so no third repo mirror
+exists; ``python3 tools/sync_agent_skills.py --check`` verifies tree drift and
+Tokki skill visibility as a read-only, model-free validation route.
+
 Context routing
 ---------------
 

--- a/docs/source/apps-pages.rst
+++ b/docs/source/apps-pages.rst
@@ -166,6 +166,71 @@ from the app's versioned ``app_settings.toml`` source file (for example
 use. You can edit it manually (PROJECT → APP-SETTINGS) or use Analysis →
 Choose analysis views, which writes the same list for you.
 
+Page interface contract
+-----------------------
+
+Every page bundle interacts with AGILAB through a small, stable interface.
+Keeping to this contract is what lets one bundle serve many projects without
+app-specific wiring. The shared helpers live in ``agi_pages.runtime``.
+
+**Launch arguments.** ANALYSIS launches a bundle as a Streamlit script and
+passes the active project explicitly:
+
+.. code-block:: bash
+
+   streamlit run src/<page>/<page>.py -- --active-app /path/to/<project>
+
+Pages resolve this with ``agi_pages.runtime.resolve_active_app_path``, which
+falls back to the ``AGILAB_ACTIVE_APP`` environment variable. A page must not
+guess the project from its own location on disk.
+
+**Per-page settings.** Each bundle owns the ``[pages.<module>]`` table in the
+project's workspace ``app_settings.toml`` (seeded as described above). A
+bundle defines and reads its own keys there and must tolerate the table being
+absent:
+
+.. code-block:: toml
+
+   [pages]
+   view_module = ["view_maps_network"]
+
+   [pages.view_maps_network]
+   dataset_base_choice = "AGI_CLUSTER_SHARE"
+   dataset_subpath = "<app>/pipeline"
+
+Other bundles and tools must not repurpose a table owned by another page.
+
+**Session-state scoping.** Streamlit session state persists across the pages a
+user visits. Bundles namespace their widget keys with a stable prefix and
+reset page-owned state when the active app changes, using
+``agi_pages.runtime.reset_scoped_session_state`` together with
+``active_app_scope_value`` (or ``env_app_scope_value`` when an AGILAB
+environment object is available).
+
+**Artifact discovery.** Pages read pipeline outputs through the environment,
+never from hard-coded paths. ``agi_pages.runtime.artifact_root`` returns the
+conventional per-page export root
+(``${AGILAB_EXPORT_ABS}/<target>/<page_subdir>``), and
+``agi_pages.runtime.discover_files`` globs deterministically and returns an
+empty list for invalid roots.
+
+**Page chrome.** ``agi_pages.runtime.configure_streamlit_page`` and
+``agi_pages.runtime.render_streamlit_page_header`` apply the shared page
+configuration, logo, and title so bundles stay visually consistent.
+
+**App-surface handoff.** App-owned surfaces (cockpits) deep-link back to the
+generic ANALYSIS overview with query parameters instead of importing page
+code: ``?active_app=<project>&current_page=main&hide_app_surface=true``.
+List the project's configured pages as plain text (module name plus
+description) and let the user pick one from the ANALYSIS page launcher;
+``current_page`` is matched against a page's *resolved absolute script path*,
+not its module name, so building a working deep link to one specific page
+requires that resolved path, which a cockpit does not have on hand.
+
+A defensive-input rule applies throughout: malformed settings, missing
+artifacts, and absent optional fields must degrade to an explanatory message
+in the page, never a traceback.
+
 Included page bundles
 ---------------------
 


### PR DESCRIPTION
## Summary
- Adds the "Page interface contract" section to `apps-pages.rst`, deferred from #828 (the app_settings.toml schema validation PR) because canonical `thales_agilab` was blocked by an unrelated stray uncommitted edit at the time.
- Adds the Tokki skill-visibility paragraph to `agent-workflows.rst` through the sanctioned mirror-sync path. This content previously only existed as a local, unpushed hand-edit to this file (bypassing the canonical-first docs workflow) plus a mistaken duplicate paste sitting uncommitted in `thales_agilab`'s working tree. Backfilled properly into canonical first (`jpmorard/thales_agilab#150`), now synced here the correct way.
- No other content changes; `release_proof.toml`/`index.rst`/`release-proof.rst` were already in sync on `origin/main`.

## Validation
- [x] `tools/sync_docs_source.py --check --delete --skip-missing-source` — clean, 0 pending
- [x] `tools/workflow_parity.py --profile docs` — PASS (release-proof, diagram wording, Sphinx build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)