### PR TITLE
Fix optional-trajectory discovery to search the app's src tree

### DIFF
--- a/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/post_install.py
+++ b/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/post_install.py
@@ -306,7 +306,6 @@ def _execute_post_install(
     try:
         return seed_optional_dataset_fn(
             env=env,
-            dataset_archive=dataset_archive,
             dest_arg=dest_arg,
         )
     except (OSError, shutil.Error, py7zr.Bad7zFile) as exc:
@@ -400,9 +399,31 @@ def _apply_preferred_sat_dataset(
     return None
 
 
+def _find_trajectory_archive(active_app: Path) -> Path | None:
+    """Locate an app-provided Trajectory.7z anywhere under the app's src tree.
+
+    Apps that ship one (e.g. link_sim's optional satellite trajectories) do
+    not all place it as a literal sibling of dataset.7z, so this searches the
+    whole src tree rather than assuming a fixed layout.
+    """
+
+    try:
+        active_src = Path(active_app) / "src"
+        if not active_src.exists():
+            return None
+        for candidate in sorted(
+            active_src.rglob("Trajectory.7z"), key=lambda path: path.as_posix()
+        ):
+            if candidate.is_file():
+                return candidate
+    except OSError:
+        pass
+    return None
+
+
 def _apply_trajectory_sat_dataset(
     *,
-    dataset_archive: Path,
+    trajectory_archive: Path | None,
     dataset_root: Path,
     sat_folder: Path,
     print_fn=None,
@@ -410,10 +431,9 @@ def _apply_trajectory_sat_dataset(
     if print_fn is None:
         print_fn = print
 
-    trajectory_archive = dataset_archive.parent / "Trajectory.7z"
     trajectory_folder = dataset_root / "Trajectory"
 
-    if not _has_samples(trajectory_folder) and trajectory_archive.exists():
+    if not _has_samples(trajectory_folder) and trajectory_archive is not None and trajectory_archive.exists():
         print_fn(f"[post_install] extracting optional trajectories: {trajectory_archive}")
         _extract_archive(trajectory_archive, dataset_root)
 
@@ -440,7 +460,6 @@ def _apply_trajectory_sat_dataset(
 def _seed_optional_dataset(
     *,
     env: AgiEnv,
-    dataset_archive: Path,
     dest_arg: str | Path,
 ) -> int:
     dataset_root = Path(dest_arg) / "dataset"
@@ -468,7 +487,7 @@ def _seed_optional_dataset(
         return 0
 
     return _apply_trajectory_sat_dataset(
-        dataset_archive=dataset_archive,
+        trajectory_archive=_find_trajectory_archive(env.active_app),
         dataset_root=dataset_root,
         sat_folder=sat_folder,
     )

--- a/src/agilab/core/test/test_agi_dispatcher_post_install_support.py
+++ b/src/agilab/core/test/test_agi_dispatcher_post_install_support.py
@@ -126,7 +126,6 @@ def test_execute_post_install_unzips_and_delegates_optional_seed(tmp_path):
     assert seed_calls == [
         {
             "env": env,
-            "dataset_archive": dataset_archive,
             "dest_arg": tmp_path / "share" / "demo",
         }
     ]
@@ -271,9 +270,7 @@ def test_apply_preferred_sat_dataset_preserves_existing_samples_when_requested(t
 
 def test_apply_trajectory_sat_dataset_extracts_archive_and_links_sat_folder(tmp_path, monkeypatch):
     lines = []
-    dataset_archive = tmp_path / "dataset.7z"
     trajectory_archive = tmp_path / "Trajectory.7z"
-    dataset_archive.write_text("x", encoding="utf-8")
     trajectory_archive.write_text("x", encoding="utf-8")
     dataset_root = tmp_path / "dataset"
     sat_folder = dataset_root / "sat"
@@ -290,7 +287,7 @@ def test_apply_trajectory_sat_dataset_extracts_archive_and_links_sat_folder(tmp_
     monkeypatch.setattr(post_mod, "_extract_archive", _fake_extract)
 
     result = post_mod._apply_trajectory_sat_dataset(
-        dataset_archive=dataset_archive,
+        trajectory_archive=trajectory_archive,
         dataset_root=dataset_root,
         sat_folder=sat_folder,
         print_fn=lines.append,
@@ -307,8 +304,8 @@ def test_apply_trajectory_sat_dataset_extracts_archive_and_links_sat_folder(tmp_
 
 def test_apply_trajectory_sat_dataset_copies_when_linking_fails(tmp_path, monkeypatch):
     lines = []
-    dataset_archive = tmp_path / "dataset.7z"
-    dataset_archive.write_text("x", encoding="utf-8")
+    trajectory_archive = tmp_path / "Trajectory.7z"
+    trajectory_archive.write_text("x", encoding="utf-8")
     dataset_root = tmp_path / "dataset"
     trajectory_folder = dataset_root / "Trajectory"
     trajectory_folder.mkdir(parents=True, exist_ok=True)
@@ -319,7 +316,7 @@ def test_apply_trajectory_sat_dataset_copies_when_linking_fails(tmp_path, monkey
     monkeypatch.setattr(post_mod, "_try_link_dir", lambda *_args, **_kwargs: False)
 
     result = post_mod._apply_trajectory_sat_dataset(
-        dataset_archive=dataset_archive,
+        trajectory_archive=trajectory_archive,
         dataset_root=dataset_root,
         sat_folder=sat_folder,
         print_fn=lines.append,
@@ -332,16 +329,53 @@ def test_apply_trajectory_sat_dataset_copies_when_linking_fails(tmp_path, monkey
 
 
 def test_apply_trajectory_sat_dataset_returns_zero_when_no_samples_available(tmp_path):
-    dataset_archive = tmp_path / "dataset.7z"
-    dataset_archive.write_text("x", encoding="utf-8")
+    trajectory_archive = tmp_path / "Trajectory.7z"  # does not exist on disk
     dataset_root = tmp_path / "dataset"
     sat_folder = dataset_root / "sat"
 
     result = post_mod._apply_trajectory_sat_dataset(
-        dataset_archive=dataset_archive,
+        trajectory_archive=trajectory_archive,
         dataset_root=dataset_root,
         sat_folder=sat_folder,
     )
 
     assert result == 0
     assert not sat_folder.exists()
+
+
+def test_apply_trajectory_sat_dataset_returns_zero_when_no_archive_found(tmp_path):
+    dataset_root = tmp_path / "dataset"
+    sat_folder = dataset_root / "sat"
+
+    result = post_mod._apply_trajectory_sat_dataset(
+        trajectory_archive=None,
+        dataset_root=dataset_root,
+        sat_folder=sat_folder,
+    )
+
+    assert result == 0
+    assert not sat_folder.exists()
+
+
+def test_find_trajectory_archive_locates_file_outside_the_worker_subdir(tmp_path):
+    # Regression test: link_sim ships Trajectory.7z under "src/optional sat/",
+    # a different subdirectory than its worker package (and dataset.7z), not
+    # as a literal sibling of dataset.7z. The lookup must search the whole
+    # src tree rather than assume a fixed sibling layout.
+    active_app = tmp_path / "link_sim_project"
+    optional_sat = active_app / "src" / "optional sat"
+    optional_sat.mkdir(parents=True, exist_ok=True)
+    archive = optional_sat / "Trajectory.7z"
+    archive.write_text("x", encoding="utf-8")
+    (active_app / "src" / "link_sim_worker").mkdir(parents=True, exist_ok=True)
+
+    resolved = post_mod._find_trajectory_archive(active_app)
+
+    assert resolved == archive
+
+
+def test_find_trajectory_archive_returns_none_when_absent(tmp_path):
+    active_app = tmp_path / "demo_project"
+    (active_app / "src").mkdir(parents=True, exist_ok=True)
+
+    assert post_mod._find_trajectory_archive(active_app) is None

--- a/src/agilab/core/test/test_agi_dispatcher_scripts.py
+++ b/src/agilab/core/test/test_agi_dispatcher_scripts.py
@@ -1556,6 +1556,7 @@ def test_post_main_copies_trajectory_files_when_linking_fails(tmp_path, monkeypa
         share_target_name="demo",
         dataset_archive=dataset_archive,
         agilab_pck=tmp_path,
+        active_app=tmp_path / "demo_project",
         resolve_share_path=lambda _target: dest_arg,
         unzip_data=lambda *_args, **_kwargs: None,
         share_root_path=lambda: tmp_path / "share-root",
@@ -1577,7 +1578,9 @@ def test_post_main_extracts_optional_trajectory_archive_and_links_sat_folder(tmp
     dataset_archive.write_text("placeholder", encoding="utf-8")
     dest_arg = tmp_path / "share" / "demo"
     dataset_root = dest_arg / "dataset"
-    trajectory_archive = dataset_archive.parent / "Trajectory.7z"
+    active_app = tmp_path / "demo_project"
+    trajectory_archive = active_app / "src" / "Trajectory.7z"
+    trajectory_archive.parent.mkdir(parents=True, exist_ok=True)
     trajectory_archive.write_text("placeholder", encoding="utf-8")
     extracted = {}
 
@@ -1585,6 +1588,7 @@ def test_post_main_extracts_optional_trajectory_archive_and_links_sat_folder(tmp
         share_target_name="demo",
         dataset_archive=dataset_archive,
         agilab_pck=tmp_path,
+        active_app=active_app,
         resolve_share_path=lambda _target: dest_arg,
         unzip_data=lambda *_args, **_kwargs: None,
         share_root_path=lambda: tmp_path / "share-root",
@@ -1621,6 +1625,7 @@ def test_post_main_reports_optional_dataset_seeding_exception(tmp_path, monkeypa
         share_target_name="demo",
         dataset_archive=dataset_archive,
         agilab_pck=tmp_path,
+        active_app=tmp_path / "demo_project",
         resolve_share_path=lambda _target: dest_arg,
         unzip_data=lambda *_args, **_kwargs: None,
         share_root_path=lambda: (_ for _ in ()).throw(
@@ -1750,7 +1755,9 @@ def test_post_main_returns_zero_when_large_cleanup_fails(tmp_path, monkeypatch, 
 def test_post_main_returns_zero_when_trajectory_archive_extracts_no_samples(tmp_path, monkeypatch, capsys):
     dataset_archive = tmp_path / "dataset.7z"
     dataset_archive.write_text("placeholder", encoding="utf-8")
-    trajectory_archive = dataset_archive.parent / "Trajectory.7z"
+    active_app = tmp_path / "demo_project"
+    trajectory_archive = active_app / "src" / "Trajectory.7z"
+    trajectory_archive.parent.mkdir(parents=True, exist_ok=True)
     trajectory_archive.write_text("placeholder", encoding="utf-8")
     dest_arg = tmp_path / "share" / "demo"
 
@@ -1758,6 +1765,7 @@ def test_post_main_returns_zero_when_trajectory_archive_extracts_no_samples(tmp_
         share_target_name="demo",
         dataset_archive=dataset_archive,
         agilab_pck=tmp_path,
+        active_app=active_app,
         resolve_share_path=lambda _target: dest_arg,
         unzip_data=lambda *_args, **_kwargs: None,
         share_root_path=lambda: tmp_path / "share-root",
@@ -1923,6 +1931,7 @@ def test_post_main_copy_fallback_skips_existing_destinations(tmp_path, monkeypat
         share_target_name="demo",
         dataset_archive=dataset_archive,
         agilab_pck=tmp_path / "pkg",
+        active_app=tmp_path / "demo_project",
         resolve_share_path=lambda _target: dest_arg,
         unzip_data=_fake_unzip,
         share_root_path=lambda: tmp_path / "share-root",
@@ -2114,6 +2123,7 @@ def test_post_main_returns_zero_when_preferred_link_fails_without_trajectory_fal
         share_target_name="demo",
         dataset_archive=dataset_archive,
         agilab_pck=tmp_path / "pkg",
+        active_app=tmp_path / "demo_project",
         resolve_share_path=lambda _target: dest_arg,
         unzip_data=_fake_unzip,
         share_root_path=lambda: share_root,
@@ -3549,7 +3559,9 @@ def test_post_main_keeps_existing_preferred_sat_symlink(tmp_path, monkeypatch):
 def test_post_main_extracts_then_copies_when_link_unavailable(tmp_path, monkeypatch):
     dataset_archive = tmp_path / "dataset.7z"
     dataset_archive.write_text("x", encoding="utf-8")
-    trajectory_archive = tmp_path / "Trajectory.7z"
+    active_app = tmp_path / "demo_project"
+    trajectory_archive = active_app / "src" / "Trajectory.7z"
+    trajectory_archive.parent.mkdir(parents=True, exist_ok=True)
     trajectory_archive.write_text("x", encoding="utf-8")
 
     class DummyEnv:
@@ -3557,6 +3569,7 @@ def test_post_main_extracts_then_copies_when_link_unavailable(tmp_path, monkeypa
             self.share_target_name = "demo"
             self.dataset_archive = dataset_archive
             self.agilab_pck = tmp_path / "pkg"
+            self.active_app = active_app
 
         def resolve_share_path(self, _target):
             return tmp_path / "share-dest"
@@ -3593,6 +3606,7 @@ def test_post_main_ignores_optional_seeding_exception(tmp_path, monkeypatch):
             self.share_target_name = "demo"
             self.dataset_archive = dataset_archive
             self.agilab_pck = tmp_path / "pkg"
+            self.active_app = tmp_path / "demo_project"
 
         def resolve_share_path(self, _target):
             return tmp_path / "share-dest"


### PR DESCRIPTION
## Summary
- `_apply_trajectory_sat_dataset` (agi_node's post_install hook, used to seed link_sim's optional satellite trajectory sample) looked for `Trajectory.7z` as a literal sibling of `dataset.7z`. link_sim's real file lives at `src/optional sat/Trajectory.7z`, a different subdirectory than `dataset.7z` (`src/link_sim_worker/dataset.7z`), so the lookup never found it and silently no-opped on every real install.
- Adds `_find_trajectory_archive`, which searches the whole app `src` tree (the same rglob strategy the shared deployer already uses to stage this file), and threads it through instead of deriving the path from `dataset_archive`'s parent.

## How this was scoped
Originally investigated as "surface the deployer's silently-swallowed `except OSError: pass`" (a TODO in `deployment_local_support.py`). Deep tracing — including constructing the real `AgiEnv` for `link_sim_project` and empirically resolving every path involved — showed the deployer's own copy step already works correctly and is fully tested (nothing was actually broken there). The *intended* consumer of that staged archive is this post_install lookup, which had the real, silent bug. The deployer is left untouched; this fix is scoped to the actual defect.

## Validation
- [x] Verified against the real `link_sim_project` checkout that `_find_trajectory_archive` now locates the actual file (previously returned nothing)
- [x] Added a regression test covering the exact layout mismatch (`Trajectory.7z` outside the worker subdirectory)
- [x] Updated 8 existing end-to-end tests in `test_agi_dispatcher_scripts.py` that exercise `post_install.main()` to supply `active_app` and relocate their fixture archives to match the corrected (and now real) search behavior
- [x] `pytest src/agilab/core/test` — 1487 passed, 5 skipped (pre-existing)
- [x] `pytest src/agilab/core/test/test_broad_exception_hygiene.py` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)