### PR TITLE
fix: isolate queue and relay resilience page sessions

### DIFF
--- a/agenticweb.md
+++ b/agenticweb.md
@@ -243,7 +243,7 @@ x_generated_by:
   command: "python3 tools/agenticweb_manifest.py --apply"
   source_manifest: "agilab-capabilities.json"
   source_schema: "agilab.capabilities.v1"
-  source_version: "2026.07.17"
+  source_version: "2026.07.17.1"
   boundary: "Discovery only: this file does not prove runtime success, external service reachability, security certification, or production readiness."
 ---
 

--- a/agilab-capabilities.json
+++ b/agilab-capabilities.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-07-17T13:50:41Z",
+  "generated_at_utc": "2026-07-17T15:49:10Z",
   "schema": "agilab.capabilities.v1",
   "schema_version": 1,
   "generated_by": {
@@ -10,7 +10,7 @@
     "repository": "https://github.com/ThalesGroup/agilab",
     "documentation": "https://thalesgroup.github.io/agilab/",
     "project": "agilab",
-    "version": "2026.07.17"
+    "version": "2026.07.17.1"
   },
   "boundary": {
     "proves": "This manifest proves that public AGILAB surfaces are discoverable from checked-in contracts.",
@@ -397,7 +397,7 @@
       "name": "agi-page-queue-health",
       "role": "page-bundle",
       "status": "PyPI package",
-      "version": "2026.07.17",
+      "version": "2026.07.17.1",
       "description": "AGILAB page bundle for queue health and resilience evidence.",
       "project": "src/agilab/apps-pages/view_queue_resilience",
       "pyproject": "src/agilab/apps-pages/view_queue_resilience/pyproject.toml",
@@ -408,7 +408,7 @@
       "name": "agi-page-relay-health",
       "role": "page-bundle",
       "status": "PyPI package",
-      "version": "2026.07.17",
+      "version": "2026.07.17.1",
       "description": "AGILAB page bundle for relay health and resilience evidence.",
       "project": "src/agilab/apps-pages/view_relay_resilience",
       "pyproject": "src/agilab/apps-pages/view_relay_resilience/pyproject.toml",
@@ -463,7 +463,7 @@
       "name": "agi-pages",
       "role": "page-umbrella",
       "status": "PyPI package",
-      "version": "2026.07.17",
+      "version": "2026.07.17.1",
       "description": "AGILAB public analysis page umbrella and provider package",
       "project": "src/agilab/lib/agi-pages",
       "pyproject": "src/agilab/lib/agi-pages/pyproject.toml",
@@ -650,7 +650,7 @@
       "name": "agilab",
       "role": "top-level-bundle",
       "status": "PyPI package",
-      "version": "2026.07.17",
+      "version": "2026.07.17.1",
       "description": "AGILAB is a reproducible AI/ML workbench for engineering teams.",
       "project": ".",
       "pyproject": "pyproject.toml",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.07.17"
+version = "2026.07.17.1"
 name = "agilab"
 description = "AGILAB is a reproducible AI/ML workbench for engineering teams."
 requires-python = ">=3.12,<3.15"
@@ -67,13 +67,13 @@ agilab-mcp = "agilab_mcp.server:main"
 [project.optional-dependencies]
 ai = ["openai>=2.32.0,<3"]
 core = ["agi-core==2026.07.17"]
-ui = ["agi-apps==2026.07.17", "agi-pages==2026.07.17", "agi-gui==2026.07.17", "agi-web==2026.07.17", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "plotly>=6.8,<7", "sqlalchemy>=2.0.43,<3", "streamlit>=1.58,<2", "starlette>=1.0.1,<2", "tomli_w>=1.2.0,<2", "cryptography>=48.0.1,<50"]
+ui = ["agi-apps==2026.07.17", "agi-pages==2026.07.17.1", "agi-gui==2026.07.17", "agi-web==2026.07.17", "networkx>=3.6.1,<4", "pandas>=2.3.0,<4", "plotly>=6.8,<7", "sqlalchemy>=2.0.43,<3", "streamlit>=1.58,<2", "starlette>=1.0.1,<2", "tomli_w>=1.2.0,<2", "cryptography>=48.0.1,<50"]
 viz = ["matplotlib>=3.10.0,<4", "plotly>=6.8,<7"]
 mlflow = ["mlflow>=3.14,<4", "idna>=3.15,<4", "starlette>=1.0.1,<2"]
 bridges = ["duckdb>=1.4.0,<2"]
 notebook = ["ipykernel>=6.29.0,<8", "nbclient>=0.10.0,<1", "nbformat>=5.10.0,<6"]
 examples = ["agi-apps==2026.07.17", "jupyterlab>=4.4.0,<5", "matplotlib>=3.10.0,<4", "plotly>=6.8,<7", "starlette>=1.0.1,<2", "bleach>=6.4.0,<7"]
-pages = ["agi-pages==2026.07.17", "plotly>=6.8,<7", "sqlalchemy>=2.0.43,<3", "starlette>=1.0.1,<2"]
+pages = ["agi-pages==2026.07.17.1", "plotly>=6.8,<7", "sqlalchemy>=2.0.43,<3", "starlette>=1.0.1,<2"]
 proof = ["cryptography>=48.0.1,<50"]
 agents = ["openai>=2.32.0,<3"]
 local-llm = ["accelerate>=0.34.2,<2; python_version >= '3.12'", "fastapi>=0.124.4,!=0.136.3,<1; python_version >= '3.12'", "gpt-oss>=0.0.8,<0.1; python_version >= '3.12'", "langchain-core>=1.3.3,<2; python_version >= '3.12'", "langsmith>=0.8.0,<1; python_version >= '3.12'", "mlx>=0.31.2,<0.33; sys_platform == 'darwin' and platform_machine == 'arm64'", "mlx-lm>=0.31.3,<0.32; sys_platform == 'darwin' and platform_machine == 'arm64'", "mlx-vlm>=0.5.0,<0.7; sys_platform == 'darwin' and platform_machine == 'arm64'", "requests>=2.32.0,<3; python_version >= '3.12'", "starlette>=1.3.1,<2; python_version >= '3.12'", "torch>=2.8.0,<3; python_version >= '3.12'", "transformers>=4.57.0,<6; python_version >= '3.12'", "universal-offline-ai-chatbot>=0.1.0,<0.2; python_version >= '3.12'", "langchain>=1.3.9,<2; python_version >= '3.12'", "pypdf>=6.13.0,<7; python_version >= '3.12'", "python-multipart>=0.0.31,<1; python_version >= '3.12'", "tornado>=6.5.7,<7; python_version >= '3.12'"]

--- a/src/agilab/apps-pages/view_queue_resilience/pyproject.toml
+++ b/src/agilab/apps-pages/view_queue_resilience/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-queue-health"
-version = "2026.07.17"
+version = "2026.07.17.1"
 description = "AGILAB page bundle for queue health and resilience evidence."
 readme = { text = "AGILAB page bundle for queue health and resilience evidence.", content-type = "text/markdown" }
 requires-python = ">=3.12"
@@ -13,7 +13,7 @@ keywords = [
     "reproducibility",
 ]
 dependencies = [
-    "agi-pages>=2026.05.30.post1,<2027.0",
+    "agi-pages>=2026.07.17.1,<2027.0",
     "agi-env>=2026.05.12.post3,<2027.0",
     "agi-gui>=2026.05.12.post3,<2027.0",
     "agi-node>=2026.05.12.post3,<2027.0",

--- a/src/agilab/apps-pages/view_queue_resilience/src/view_queue_resilience/view_queue_resilience.py
+++ b/src/agilab/apps-pages/view_queue_resilience/src/view_queue_resilience/view_queue_resilience.py
@@ -5,21 +5,17 @@
 from __future__ import annotations
 
 import importlib.util
-import json
 from pathlib import Path
-from typing import Any
 
 import pandas as pd
 import streamlit as st
+from agi_pages.queue_resilience import (
+    load_queue_resilience_run,
+    prepare_queue_resilience_page,
+    render_queue_resilience_run,
+)
 from agi_pages.runtime import (
-    artifact_root as _page_artifact_root,
-    configure_streamlit_page,
-    discover_files as _page_discover_files,
     ensure_repo_on_path as _page_ensure_repo_on_path,
-    render_streamlit_page_header,
-    resolve_active_app_path,
-    reset_scoped_session_state,
-    safe_metric,
 )
 
 
@@ -29,7 +25,7 @@ def _ensure_repo_on_path() -> None:
 
 _ensure_repo_on_path()
 
-from agi_env import AgiEnv
+from agi_env import AgiEnv  # noqa: E402
 
 
 DATA_DIR_KEY = "queue_resilience_datadir"
@@ -48,8 +44,12 @@ def _load_page_meta() -> tuple[str, str]:
         return PAGE_LOGO, PAGE_TITLE
 
     _meta_path = Path(__file__).with_name("page_meta.py")
-    _meta_spec = importlib.util.spec_from_file_location("view_queue_resilience_page_meta", _meta_path)
-    if _meta_spec is None or _meta_spec.loader is None:  # pragma: no cover - defensive fallback
+    _meta_spec = importlib.util.spec_from_file_location(
+        "view_queue_resilience_page_meta", _meta_path
+    )
+    if (
+        _meta_spec is None or _meta_spec.loader is None
+    ):  # pragma: no cover - defensive fallback
         raise RuntimeError(f"Unable to load page metadata from {_meta_path}")
     _meta_module = importlib.util.module_from_spec(_meta_spec)
     _meta_spec.loader.exec_module(_meta_module)
@@ -59,176 +59,39 @@ def _load_page_meta() -> tuple[str, str]:
 PAGE_LOGO, PAGE_TITLE = _load_page_meta()
 
 
-def _resolve_active_app() -> Path:
-    return resolve_active_app_path(error_fn=st.error, stop_fn=st.stop)
-
-
-def _default_artifact_root(env: AgiEnv) -> Path:
-    return _page_artifact_root(env, "queue_analysis")
-
-
-def _discover_files(base: Path, pattern: str) -> list[Path]:
-    return _page_discover_files(base, pattern)
-
-
-def _reset_app_scoped_session_defaults(active_app_path: Path) -> bool:
-    """Clear persisted Queue Resilience defaults when the active app changes."""
-
-    return reset_scoped_session_state(
-        st.session_state,
-        APP_SCOPE_KEY,
-        active_app_path,
-        keys=APP_SCOPED_SESSION_DEFAULT_KEYS,
+def _create_env(active_app_path: Path) -> AgiEnv:
+    env = AgiEnv.session_for_app(
+        apps_path=active_app_path.parent,
+        app=active_app_path.name,
+        verbose=0,
     )
-
-
-def _load_json(path: Path) -> dict[str, Any]:
-    return json.loads(path.read_text(encoding="utf-8"))
-
-
-def _peer_csv(path: Path, suffix: str) -> Path:
-    stem = path.name.removesuffix("_summary_metrics.json")
-    return path.with_name(f"{stem}_{suffix}.csv")
-
-
-def _safe_metric(value: Any) -> str:
-    return safe_metric(value)
-
-
-configure_streamlit_page(st, title=PAGE_TITLE)
-
-active_app_path = _resolve_active_app()
-app_scope_changed = _reset_app_scoped_session_defaults(active_app_path)
-if "env" not in st.session_state or app_scope_changed:
-    env = AgiEnv.session_for_app(apps_path=active_app_path.parent, app=active_app_path.name, verbose=0)
     env.init_done = True
-    st.session_state["env"] = env
-else:
-    env = st.session_state["env"]
+    return env
 
-render_streamlit_page_header(
+
+page_context = prepare_queue_resilience_page(
     st,
+    env_factory=_create_env,
     title=PAGE_TITLE,
     logo_title=PAGE_LOGO,
     caption=(
         "Use exported queue telemetry to inspect backlog, routing pressure, and delivery outcomes "
         "without reopening the producer code."
     ),
+    data_dir_key=DATA_DIR_KEY,
+    summary_glob_key=SUMMARY_GLOB_KEY,
+    app_scope_key=APP_SCOPE_KEY,
+    app_scoped_keys=APP_SCOPED_SESSION_DEFAULT_KEYS,
 )
-st.info(
-    "Each run also writes `pipeline/topology.gml`, `pipeline/allocations_steps.csv`, "
-    "`pipeline/_trajectory_summary.json`, and per-node trajectory CSVs so the same result "
-    "can be explored in `view_maps_network`."
-)
-
-default_root = _default_artifact_root(env)
-st.session_state.setdefault(DATA_DIR_KEY, str(default_root))
-artifact_root_value = st.sidebar.text_input(
-    "Artifact directory",
-    key=DATA_DIR_KEY,
-)
-artifact_root = Path(artifact_root_value).expanduser()
-
-st.session_state.setdefault(SUMMARY_GLOB_KEY, "**/*_summary_metrics.json")
-metrics_pattern = st.sidebar.text_input(
-    "Summary glob",
-    key=SUMMARY_GLOB_KEY,
-)
-
-summary_files = _discover_files(artifact_root, metrics_pattern) if artifact_root.exists() else []
-
-if not artifact_root.exists():
-    st.warning(f"Artifact directory does not exist yet: {artifact_root}")
-    st.stop()
-
-if not summary_files:
-    st.warning(f"No summary metrics file found in {artifact_root} with pattern {metrics_pattern!r}.")
-    st.stop()
 
 summary_path = st.sidebar.selectbox(
     "Run summary",
-    options=summary_files,
-    format_func=lambda path: str(Path(path).relative_to(artifact_root)),
+    options=page_context.summary_files,
+    format_func=lambda path: str(Path(path).relative_to(page_context.artifact_root)),
 )
-
-summary = _load_json(Path(summary_path))
-queue_path = _peer_csv(Path(summary_path), "queue_timeseries")
-packet_path = _peer_csv(Path(summary_path), "packet_events")
-positions_path = _peer_csv(Path(summary_path), "node_positions")
-routing_path = _peer_csv(Path(summary_path), "routing_summary")
-
-missing = [path for path in (queue_path, packet_path, positions_path, routing_path) if not path.is_file()]
-if missing:
-    st.error("Related queue artifacts are missing for the selected summary:")
-    for path in missing:
-        st.code(str(path))
-    st.stop()
-
-queue_df = pd.read_csv(queue_path)
-packet_df = pd.read_csv(packet_path)
-positions_df = pd.read_csv(positions_path)
-routing_df = pd.read_csv(routing_path)
-
-intro_left, intro_right = st.columns([1.6, 1.2])
-with intro_left:
-    st.subheader("Why this run is useful")
-    st.markdown(
-        "- one scenario file becomes a reproducible project\n"
-        "- one routing knob changes queue buildup and delivery outcomes\n"
-        "- the exported packet and queue telemetry stays explorable across reruns\n"
-        "- the producer can later be swapped while preserving the analysis contract"
-    )
-with intro_right:
-    st.subheader("Run metadata")
-    st.json(
-        {
-            "scenario": summary.get("scenario"),
-            "routing_policy": summary.get("routing_policy"),
-            "source_rate_pps": summary.get("source_rate_pps"),
-            "random_seed": summary.get("random_seed"),
-            "bottleneck_relay": summary.get("bottleneck_relay"),
-        }
-    )
-
-metric_columns = st.columns(4)
-metric_specs = [
-    ("PDR", summary.get("pdr")),
-    ("Mean delay (ms)", summary.get("mean_e2e_delay_ms")),
-    ("Queue wait (ms)", summary.get("mean_queue_wait_ms")),
-    ("Max queue", summary.get("max_queue_depth_pkts")),
-]
-for col, (label, value) in zip(metric_columns, metric_specs):
-    col.metric(label, _safe_metric(value))
-
-st.subheader("Queue occupancy over time")
-queue_chart = (
-    queue_df.pivot_table(index="time_s", columns="relay", values="queue_depth_pkts", aggfunc="last")
-    .sort_index()
+run = load_queue_resilience_run(
+    st,
+    Path(summary_path),
+    csv_loader=pd.read_csv,
 )
-st.line_chart(queue_chart)
-
-relay_positions = positions_df.loc[positions_df["role"] == "relay"].copy()
-if not relay_positions.empty:
-    st.subheader("Relay mobility trace (y axis)")
-    relay_chart = relay_positions.pivot_table(index="time_s", columns="node", values="y_m", aggfunc="last").sort_index()
-    st.line_chart(relay_chart)
-
-if not routing_df.empty:
-    st.subheader("Route usage")
-    route_metrics = routing_df.set_index("relay")[["packets_delivered", "packets_dropped"]]
-    st.bar_chart(route_metrics)
-    st.dataframe(routing_df, width="stretch", hide_index=True)
-
-source_packets = packet_df.loc[packet_df["origin_kind"] == "source"].copy()
-delivered_packets = source_packets.loc[source_packets["status"] == "delivered"].copy()
-if not delivered_packets.empty:
-    st.subheader("Highest-delay source packets")
-    slowest = delivered_packets.sort_values("e2e_delay_ms", ascending=False).head(30)
-    st.dataframe(slowest, width="stretch", hide_index=True)
-else:
-    st.info("No delivered source packet is available in this run.")
-
-notes = str(summary.get("notes", "") or "").strip()
-if notes:
-    st.subheader("Notes")
-    st.info(notes)
+render_queue_resilience_run(st, run)

--- a/src/agilab/apps-pages/view_relay_resilience/pyproject.toml
+++ b/src/agilab/apps-pages/view_relay_resilience/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agi-page-relay-health"
-version = "2026.07.17"
+version = "2026.07.17.1"
 description = "AGILAB page bundle for relay health and resilience evidence."
 readme = { text = "AGILAB page bundle for relay health and resilience evidence.", content-type = "text/markdown" }
 requires-python = ">=3.12"
@@ -13,7 +13,7 @@ keywords = [
     "reproducibility",
 ]
 dependencies = [
-    "agi-pages>=2026.05.30.post1,<2027.0",
+    "agi-pages>=2026.07.17.1,<2027.0",
     "agi-env>=2026.05.12.post3,<2027.0",
     "agi-gui>=2026.05.12.post3,<2027.0",
     "agi-node>=2026.05.12.post3,<2027.0",

--- a/src/agilab/apps-pages/view_relay_resilience/src/view_relay_resilience/view_relay_resilience.py
+++ b/src/agilab/apps-pages/view_relay_resilience/src/view_relay_resilience/view_relay_resilience.py
@@ -4,22 +4,22 @@
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 from typing import Any
 
 import pandas as pd
 import streamlit as st
+from agi_pages.queue_resilience import (
+    load_queue_resilience_run,
+    load_queue_summary as _load_json,
+    peer_csv_path as _peer_csv,
+    prepare_queue_resilience_page,
+    render_queue_resilience_run,
+)
 from agi_pages.runtime import (
-    artifact_root as _page_artifact_root,
-    configure_streamlit_page,
-    discover_files as _page_discover_files,
     ensure_repo_on_path as _page_ensure_repo_on_path,
     relative_label as _page_relative_label,
-    render_streamlit_page_header,
-    resolve_active_app_path,
-    reset_scoped_session_state,
-    safe_metric,
+    safe_metric as _safe_metric,
 )
 
 
@@ -29,7 +29,7 @@ def _ensure_repo_on_path() -> None:
 
 _ensure_repo_on_path()
 
-from agi_env import AgiEnv
+from agi_env import AgiEnv  # noqa: E402
 
 RUN_SELECTION_KEY = "relay_resilience_selected_runs"
 DETAIL_RUN_KEY = "relay_resilience_detail_run"
@@ -46,47 +46,13 @@ APP_SCOPED_SESSION_DEFAULT_KEYS = (
 )
 
 
-def _resolve_active_app() -> Path:
-    return resolve_active_app_path(error_fn=st.error, stop_fn=st.stop)
-
-
-def _default_artifact_root(env: AgiEnv) -> Path:
-    return _page_artifact_root(env, "queue_analysis")
-
-
-def _discover_files(base: Path, pattern: str) -> list[Path]:
-    return _page_discover_files(base, pattern)
-
-
-def _reset_app_scoped_session_defaults(active_app_path: Path) -> bool:
-    """Clear persisted Relay Resilience defaults when the active app changes."""
-
-    return reset_scoped_session_state(
-        st.session_state,
-        APP_SCOPE_KEY,
-        active_app_path,
-        keys=APP_SCOPED_SESSION_DEFAULT_KEYS,
-    )
-
-
-def _load_json(path: Path) -> dict[str, Any]:
-    return json.loads(path.read_text(encoding="utf-8"))
-
-
-def _peer_csv(path: Path, suffix: str) -> Path:
-    stem = path.name.removesuffix("_summary_metrics.json")
-    return path.with_name(f"{stem}_{suffix}.csv")
-
-
-def _safe_metric(value: Any) -> str:
-    return safe_metric(value)
-
-
 def _relative_summary_label(path: Path, artifact_root: Path) -> str:
     return _page_relative_label(path, artifact_root)
 
 
-def _coerce_selection(saved_value: Any, options: list[str], *, fallback: str | None = None) -> list[str]:
+def _coerce_selection(
+    saved_value: Any, options: list[str], *, fallback: str | None = None
+) -> list[str]:
     if isinstance(saved_value, str):
         candidates = [saved_value]
     elif isinstance(saved_value, (list, tuple, set)):
@@ -118,7 +84,9 @@ def _comparison_row(summary_path: Path, artifact_root: Path) -> dict[str, Any]:
     }
 
 
-def _build_comparison_frame(selected_paths: dict[str, Path], artifact_root: Path, reference_label: str) -> pd.DataFrame:
+def _build_comparison_frame(
+    selected_paths: dict[str, Path], artifact_root: Path, reference_label: str
+) -> pd.DataFrame:
     rows = [_comparison_row(path, artifact_root) for path in selected_paths.values()]
     if not rows:
         return pd.DataFrame()
@@ -134,7 +102,9 @@ def _build_comparison_frame(selected_paths: dict[str, Path], artifact_root: Path
     for column in numeric_columns:
         comparison_df[column] = pd.to_numeric(comparison_df[column], errors="coerce")
     if reference_label in comparison_df["run_label"].values:
-        reference_row = comparison_df.loc[comparison_df["run_label"] == reference_label].iloc[0]
+        reference_row = comparison_df.loc[
+            comparison_df["run_label"] == reference_label
+        ].iloc[0]
         comparison_df["delta_pdr_vs_ref"] = comparison_df["pdr"] - reference_row["pdr"]
         comparison_df["delta_delay_ms_vs_ref"] = (
             comparison_df["mean_e2e_delay_ms"] - reference_row["mean_e2e_delay_ms"]
@@ -143,7 +113,8 @@ def _build_comparison_frame(selected_paths: dict[str, Path], artifact_root: Path
             comparison_df["mean_queue_wait_ms"] - reference_row["mean_queue_wait_ms"]
         )
         comparison_df["delta_max_queue_vs_ref"] = (
-            comparison_df["max_queue_depth_pkts"] - reference_row["max_queue_depth_pkts"]
+            comparison_df["max_queue_depth_pkts"]
+            - reference_row["max_queue_depth_pkts"]
         )
     ordered_columns = [
         "run_label",
@@ -162,7 +133,9 @@ def _build_comparison_frame(selected_paths: dict[str, Path], artifact_root: Path
         "delta_queue_wait_ms_vs_ref",
         "delta_max_queue_vs_ref",
     ]
-    return comparison_df[[column for column in ordered_columns if column in comparison_df.columns]]
+    return comparison_df[
+        [column for column in ordered_columns if column in comparison_df.columns]
+    ]
 
 
 def _build_max_queue_comparison_frame(selected_paths: dict[str, Path]) -> pd.DataFrame:
@@ -172,10 +145,16 @@ def _build_max_queue_comparison_frame(selected_paths: dict[str, Path]) -> pd.Dat
         if not queue_path.is_file():
             continue
         queue_df = pd.read_csv(queue_path)
-        if "time_s" not in queue_df.columns or "queue_depth_pkts" not in queue_df.columns:
+        if (
+            "time_s" not in queue_df.columns
+            or "queue_depth_pkts" not in queue_df.columns
+        ):
             continue
         queue_series = (
-            queue_df.groupby("time_s", dropna=False)["queue_depth_pkts"].max().sort_index().rename(label)
+            queue_df.groupby("time_s", dropna=False)["queue_depth_pkts"]
+            .max()
+            .sort_index()
+            .rename(label)
         )
         queue_frames.append(queue_series)
     if not queue_frames:
@@ -183,57 +162,35 @@ def _build_max_queue_comparison_frame(selected_paths: dict[str, Path]) -> pd.Dat
     return pd.concat(queue_frames, axis=1).sort_index()
 
 
-configure_streamlit_page(st, title="Relay resilience analysis")
-
-active_app_path = _resolve_active_app()
-app_scope_changed = _reset_app_scoped_session_defaults(active_app_path)
-if "env" not in st.session_state or app_scope_changed:
-    env = AgiEnv.session_for_app(apps_path=active_app_path.parent, app=active_app_path.name, verbose=0)
+def _create_env(active_app_path: Path) -> AgiEnv:
+    env = AgiEnv.session_for_app(
+        apps_path=active_app_path.parent,
+        app=active_app_path.name,
+        verbose=0,
+    )
     env.init_done = True
-    st.session_state["env"] = env
-else:
-    env = st.session_state["env"]
+    return env
 
-render_streamlit_page_header(
+
+page_context = prepare_queue_resilience_page(
     st,
+    env_factory=_create_env,
     title="Relay resilience analysis",
     logo_title="Relay Resilience Analysis",
     caption=(
         "Use exported relay-queue telemetry to compare routing policies, queue hotspots, and delivery outcomes "
         "without reopening the producer code."
     ),
-)
-st.info(
-    "Each run also writes `pipeline/topology.gml`, `pipeline/allocations_steps.csv`, "
-    "`pipeline/_trajectory_summary.json`, and per-node trajectory CSVs so the same result "
-    "can be explored in `view_maps_network`."
-)
-
-default_root = _default_artifact_root(env)
-st.session_state.setdefault(DATA_DIR_KEY, str(default_root))
-artifact_root_value = st.sidebar.text_input(
-    "Artifact directory",
-    key=DATA_DIR_KEY,
-)
-artifact_root = Path(artifact_root_value).expanduser()
-
-st.session_state.setdefault(SUMMARY_GLOB_KEY, "**/*_summary_metrics.json")
-metrics_pattern = st.sidebar.text_input(
-    "Summary glob",
-    key=SUMMARY_GLOB_KEY,
+    data_dir_key=DATA_DIR_KEY,
+    summary_glob_key=SUMMARY_GLOB_KEY,
+    app_scope_key=APP_SCOPE_KEY,
+    app_scoped_keys=APP_SCOPED_SESSION_DEFAULT_KEYS,
 )
 
-summary_files = _discover_files(artifact_root, metrics_pattern) if artifact_root.exists() else []
-
-if not artifact_root.exists():
-    st.warning(f"Artifact directory does not exist yet: {artifact_root}")
-    st.stop()
-
-if not summary_files:
-    st.warning(f"No summary metrics file found in {artifact_root} with pattern {metrics_pattern!r}.")
-    st.stop()
-
-summary_label_to_path = {_relative_summary_label(path, artifact_root): path for path in summary_files}
+summary_label_to_path = {
+    _relative_summary_label(path, page_context.artifact_root): path
+    for path in page_context.summary_files
+}
 summary_labels = list(summary_label_to_path.keys())
 default_selection = summary_labels[-1:] if summary_labels else []
 if RUN_SELECTION_KEY in st.session_state:
@@ -277,7 +234,11 @@ if len(selected_run_labels) > 1:
     )
 
 selected_paths = {label: summary_label_to_path[label] for label in selected_run_labels}
-comparison_df = _build_comparison_frame(selected_paths, artifact_root, reference_run_label)
+comparison_df = _build_comparison_frame(
+    selected_paths,
+    page_context.artifact_root,
+    reference_run_label,
+)
 max_queue_compare_df = _build_max_queue_comparison_frame(selected_paths)
 
 if len(selected_run_labels) > 1 and not comparison_df.empty:
@@ -286,33 +247,47 @@ if len(selected_run_labels) > 1 and not comparison_df.empty:
         "Select several exported runs to compare routing policy, queue buildup, and delivery outcomes "
         "before drilling into one detailed run below."
     )
-    best_pdr_idx = comparison_df["pdr"].idxmax() if comparison_df["pdr"].notna().any() else None
+    best_pdr_idx = (
+        comparison_df["pdr"].idxmax() if comparison_df["pdr"].notna().any() else None
+    )
     lowest_delay_idx = (
-        comparison_df["mean_e2e_delay_ms"].idxmin() if comparison_df["mean_e2e_delay_ms"].notna().any() else None
+        comparison_df["mean_e2e_delay_ms"].idxmin()
+        if comparison_df["mean_e2e_delay_ms"].notna().any()
+        else None
     )
     lowest_queue_idx = (
-        comparison_df["mean_queue_wait_ms"].idxmin() if comparison_df["mean_queue_wait_ms"].notna().any() else None
+        comparison_df["mean_queue_wait_ms"].idxmin()
+        if comparison_df["mean_queue_wait_ms"].notna().any()
+        else None
     )
     comparison_cols = st.columns(4)
     comparison_cols[0].metric("Runs selected", str(len(selected_run_labels)))
     comparison_cols[1].metric(
         "Best PDR",
-        _safe_metric(comparison_df.loc[best_pdr_idx, "pdr"]) if best_pdr_idx is not None else "n/a",
-        comparison_df.loc[best_pdr_idx, "run_label"] if best_pdr_idx is not None else None,
+        _safe_metric(comparison_df.loc[best_pdr_idx, "pdr"])
+        if best_pdr_idx is not None
+        else "n/a",
+        comparison_df.loc[best_pdr_idx, "run_label"]
+        if best_pdr_idx is not None
+        else None,
     )
     comparison_cols[2].metric(
         "Lowest delay (ms)",
         _safe_metric(comparison_df.loc[lowest_delay_idx, "mean_e2e_delay_ms"])
         if lowest_delay_idx is not None
         else "n/a",
-        comparison_df.loc[lowest_delay_idx, "run_label"] if lowest_delay_idx is not None else None,
+        comparison_df.loc[lowest_delay_idx, "run_label"]
+        if lowest_delay_idx is not None
+        else None,
     )
     comparison_cols[3].metric(
         "Lowest queue wait (ms)",
         _safe_metric(comparison_df.loc[lowest_queue_idx, "mean_queue_wait_ms"])
         if lowest_queue_idx is not None
         else "n/a",
-        comparison_df.loc[lowest_queue_idx, "run_label"] if lowest_queue_idx is not None else None,
+        comparison_df.loc[lowest_queue_idx, "run_label"]
+        if lowest_queue_idx is not None
+        else None,
     )
     st.dataframe(comparison_df, width="stretch", hide_index=True)
     st.caption(
@@ -324,88 +299,12 @@ if len(selected_run_labels) > 1 and not comparison_df.empty:
         st.line_chart(max_queue_compare_df)
 
 summary_path = selected_paths[detailed_run_label]
-
-summary = _load_json(Path(summary_path))
-queue_path = _peer_csv(Path(summary_path), "queue_timeseries")
-packet_path = _peer_csv(Path(summary_path), "packet_events")
-positions_path = _peer_csv(Path(summary_path), "node_positions")
-routing_path = _peer_csv(Path(summary_path), "routing_summary")
-
-missing = [path for path in (queue_path, packet_path, positions_path, routing_path) if not path.is_file()]
-if missing:
-    st.error("Related queue artifacts are missing for the selected summary:")
-    for path in missing:
-        st.code(str(path))
-    st.stop()
-
-queue_df = pd.read_csv(queue_path)
-packet_df = pd.read_csv(packet_path)
-positions_df = pd.read_csv(positions_path)
-routing_df = pd.read_csv(routing_path)
+run = load_queue_resilience_run(
+    st,
+    Path(summary_path),
+    csv_loader=pd.read_csv,
+)
 
 st.divider()
 st.subheader(f"Detailed run: {detailed_run_label}")
-
-intro_left, intro_right = st.columns([1.6, 1.2])
-with intro_left:
-    st.subheader("Why this run is useful")
-    st.markdown(
-        "- one scenario file becomes a reproducible project\n"
-        "- one routing knob changes queue buildup and delivery outcomes\n"
-        "- the exported packet and queue telemetry stays explorable across reruns\n"
-        "- the producer can later be swapped while preserving the analysis contract"
-    )
-with intro_right:
-    st.subheader("Run metadata")
-    st.json(
-        {
-            "scenario": summary.get("scenario"),
-            "routing_policy": summary.get("routing_policy"),
-            "source_rate_pps": summary.get("source_rate_pps"),
-            "random_seed": summary.get("random_seed"),
-            "bottleneck_relay": summary.get("bottleneck_relay"),
-        }
-    )
-
-metric_columns = st.columns(4)
-metric_specs = [
-    ("PDR", summary.get("pdr")),
-    ("Mean delay (ms)", summary.get("mean_e2e_delay_ms")),
-    ("Queue wait (ms)", summary.get("mean_queue_wait_ms")),
-    ("Max queue", summary.get("max_queue_depth_pkts")),
-]
-for col, (label, value) in zip(metric_columns, metric_specs):
-    col.metric(label, _safe_metric(value))
-
-st.subheader("Queue occupancy over time")
-queue_chart = (
-    queue_df.pivot_table(index="time_s", columns="relay", values="queue_depth_pkts", aggfunc="last")
-    .sort_index()
-)
-st.line_chart(queue_chart)
-
-relay_positions = positions_df.loc[positions_df["role"] == "relay"].copy()
-if not relay_positions.empty:
-    st.subheader("Relay mobility trace (y axis)")
-    relay_chart = relay_positions.pivot_table(index="time_s", columns="node", values="y_m", aggfunc="last").sort_index()
-    st.line_chart(relay_chart)
-
-if not routing_df.empty:
-    st.subheader("Route usage")
-    route_metrics = routing_df.set_index("relay")[["packets_delivered", "packets_dropped"]]
-    st.bar_chart(route_metrics)
-    st.dataframe(routing_df, width="stretch", hide_index=True)
-
-source_packets = packet_df.loc[packet_df["origin_kind"] == "source"].copy()
-delivered_packets = source_packets.loc[source_packets["status"] == "delivered"].copy()
-if not delivered_packets.empty:
-    st.subheader("Highest-delay source packets")
-    slowest = delivered_packets.sort_values("e2e_delay_ms", ascending=False).head(30)
-    st.dataframe(slowest, width="stretch", hide_index=True)
-else:
-    st.info("No delivered source packet is available in this run.")
-
-notes = str(summary.get("notes", "") or "").strip()
-if notes:
-    st.subheader("Notes")
-    st.info(notes)
+render_queue_resilience_run(st, run)

--- a/src/agilab/lib/agi-pages/pyproject.toml
+++ b/src/agilab/lib/agi-pages/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.07.17"
+version = "2026.07.17.1"
 name = "agi-pages"
 description = "AGILAB public analysis page umbrella and provider package"
 requires-python = ">=3.12"

--- a/src/agilab/lib/agi-pages/src/agi_pages/queue_resilience.py
+++ b/src/agilab/lib/agi-pages/src/agi_pages/queue_resilience.py
@@ -1,0 +1,287 @@
+"""Shared lifecycle and rendering support for queue-resilience pages.
+
+The owning page bundles inject their Streamlit, environment, and dataframe
+implementations so ``agi-pages`` keeps its lightweight dependency boundary.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+from .runtime import (
+    artifact_root,
+    configure_streamlit_page,
+    discover_files,
+    ensure_app_scoped_env,
+    render_streamlit_page_header,
+    resolve_active_app_path,
+    safe_metric,
+)
+
+
+QUEUE_PEER_CSV_SUFFIXES = (
+    "queue_timeseries",
+    "packet_events",
+    "node_positions",
+    "routing_summary",
+)
+QUEUE_ARTIFACT_SUBDIR = "queue_analysis"
+QUEUE_SUMMARY_GLOB = "**/*_summary_metrics.json"
+QUEUE_PIPELINE_INFO = (
+    "Each run also writes `pipeline/topology.gml`, `pipeline/allocations_steps.csv`, "
+    "`pipeline/_trajectory_summary.json`, and per-node trajectory CSVs so the same result "
+    "can be explored in `view_maps_network`."
+)
+
+
+@dataclass(frozen=True, slots=True)
+class QueueResiliencePageContext:
+    """Resolved app environment and queue-summary inventory for one page run."""
+
+    active_app_path: Path
+    env: Any
+    artifact_root: Path
+    summary_files: tuple[Path, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class QueueResilienceRun:
+    """One validated queue run with dataframe objects supplied by the page."""
+
+    summary_path: Path
+    summary: Mapping[str, Any]
+    queue_frame: Any
+    packet_frame: Any
+    positions_frame: Any
+    routing_frame: Any
+
+
+def prepare_queue_resilience_page(
+    streamlit: Any,
+    *,
+    env_factory: Callable[[Path], Any],
+    title: str,
+    logo_title: str,
+    caption: str,
+    data_dir_key: str,
+    summary_glob_key: str,
+    app_scope_key: str,
+    app_scoped_keys: tuple[str, ...],
+) -> QueueResiliencePageContext:
+    """Render common page setup and return the available queue summaries."""
+
+    configure_streamlit_page(streamlit, title=title)
+    active_app_path = resolve_active_app_path(
+        error_fn=streamlit.error,
+        stop_fn=streamlit.stop,
+    )
+    env = ensure_app_scoped_env(
+        streamlit.session_state,
+        active_app_path,
+        scope_key=app_scope_key,
+        env_factory=env_factory,
+        keys=app_scoped_keys,
+    )
+
+    render_streamlit_page_header(
+        streamlit,
+        title=title,
+        logo_title=logo_title,
+        caption=caption,
+    )
+    streamlit.info(QUEUE_PIPELINE_INFO)
+
+    default_root = artifact_root(env, QUEUE_ARTIFACT_SUBDIR)
+    streamlit.session_state.setdefault(data_dir_key, str(default_root))
+    artifact_root_value = streamlit.sidebar.text_input(
+        "Artifact directory",
+        key=data_dir_key,
+    )
+    selected_artifact_root = Path(artifact_root_value).expanduser()
+
+    streamlit.session_state.setdefault(summary_glob_key, QUEUE_SUMMARY_GLOB)
+    summary_pattern = streamlit.sidebar.text_input(
+        "Summary glob",
+        key=summary_glob_key,
+    )
+    summary_files = (
+        tuple(discover_files(selected_artifact_root, summary_pattern))
+        if selected_artifact_root.exists()
+        else ()
+    )
+
+    if not selected_artifact_root.exists():
+        streamlit.warning(
+            f"Artifact directory does not exist yet: {selected_artifact_root}"
+        )
+        streamlit.stop()
+    if not summary_files:
+        streamlit.warning(
+            f"No summary metrics file found in {selected_artifact_root} "
+            f"with pattern {summary_pattern!r}."
+        )
+        streamlit.stop()
+
+    return QueueResiliencePageContext(
+        active_app_path=active_app_path,
+        env=env,
+        artifact_root=selected_artifact_root,
+        summary_files=summary_files,
+    )
+
+
+def peer_csv_path(summary_path: Path, suffix: str) -> Path:
+    """Return one CSV path belonging to a queue summary export."""
+
+    stem = summary_path.name.removesuffix("_summary_metrics.json")
+    return summary_path.with_name(f"{stem}_{suffix}.csv")
+
+
+def queue_peer_csv_paths(summary_path: Path) -> dict[str, Path]:
+    """Return the queue-analysis CSV paths associated with a summary export."""
+
+    return {
+        suffix: peer_csv_path(summary_path, suffix)
+        for suffix in QUEUE_PEER_CSV_SUFFIXES
+    }
+
+
+def load_queue_summary(path: Path) -> dict[str, Any]:
+    """Load one queue summary JSON object."""
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise TypeError(f"Queue summary must contain a JSON object: {path}")
+    return payload
+
+
+def load_queue_resilience_run(
+    streamlit: Any,
+    summary_path: Path,
+    *,
+    csv_loader: Callable[[Path], Any],
+) -> QueueResilienceRun:
+    """Validate and load the detail artifacts associated with one summary."""
+
+    summary_path = Path(summary_path)
+    peer_paths = queue_peer_csv_paths(summary_path)
+    missing = tuple(path for path in peer_paths.values() if not path.is_file())
+    if missing:
+        streamlit.error("Related queue artifacts are missing for the selected summary:")
+        for path in missing:
+            streamlit.code(str(path))
+        streamlit.stop()
+
+    return QueueResilienceRun(
+        summary_path=summary_path,
+        summary=load_queue_summary(summary_path),
+        queue_frame=csv_loader(peer_paths["queue_timeseries"]),
+        packet_frame=csv_loader(peer_paths["packet_events"]),
+        positions_frame=csv_loader(peer_paths["node_positions"]),
+        routing_frame=csv_loader(peer_paths["routing_summary"]),
+    )
+
+
+def render_queue_resilience_run(streamlit: Any, run: QueueResilienceRun) -> None:
+    """Render a validated queue run using the shared detail surface."""
+
+    render_queue_resilience_detail(
+        streamlit,
+        summary=run.summary,
+        queue_frame=run.queue_frame,
+        packet_frame=run.packet_frame,
+        positions_frame=run.positions_frame,
+        routing_frame=run.routing_frame,
+    )
+
+
+def render_queue_resilience_detail(
+    streamlit: Any,
+    *,
+    summary: Mapping[str, Any],
+    queue_frame: Any,
+    packet_frame: Any,
+    positions_frame: Any,
+    routing_frame: Any,
+) -> None:
+    """Render the shared single-run queue and relay evidence surface."""
+
+    intro_left, intro_right = streamlit.columns([1.6, 1.2])
+    with intro_left:
+        streamlit.subheader("Why this run is useful")
+        streamlit.markdown(
+            "- one scenario file becomes a reproducible project\n"
+            "- one routing knob changes queue buildup and delivery outcomes\n"
+            "- the exported packet and queue telemetry stays explorable across reruns\n"
+            "- the producer can later be swapped while preserving the analysis contract"
+        )
+    with intro_right:
+        streamlit.subheader("Run metadata")
+        streamlit.json(
+            {
+                "scenario": summary.get("scenario"),
+                "routing_policy": summary.get("routing_policy"),
+                "source_rate_pps": summary.get("source_rate_pps"),
+                "random_seed": summary.get("random_seed"),
+                "bottleneck_relay": summary.get("bottleneck_relay"),
+            }
+        )
+
+    metric_columns = streamlit.columns(4)
+    metric_specs = (
+        ("PDR", summary.get("pdr")),
+        ("Mean delay (ms)", summary.get("mean_e2e_delay_ms")),
+        ("Queue wait (ms)", summary.get("mean_queue_wait_ms")),
+        ("Max queue", summary.get("max_queue_depth_pkts")),
+    )
+    for column, (label, value) in zip(metric_columns, metric_specs, strict=False):
+        column.metric(label, safe_metric(value))
+
+    streamlit.subheader("Queue occupancy over time")
+    queue_chart = queue_frame.pivot_table(
+        index="time_s",
+        columns="relay",
+        values="queue_depth_pkts",
+        aggfunc="last",
+    ).sort_index()
+    streamlit.line_chart(queue_chart)
+
+    relay_positions = positions_frame.loc[positions_frame["role"] == "relay"].copy()
+    if not relay_positions.empty:
+        streamlit.subheader("Relay mobility trace (y axis)")
+        relay_chart = relay_positions.pivot_table(
+            index="time_s",
+            columns="node",
+            values="y_m",
+            aggfunc="last",
+        ).sort_index()
+        streamlit.line_chart(relay_chart)
+
+    if not routing_frame.empty:
+        streamlit.subheader("Route usage")
+        route_metrics = routing_frame.set_index("relay")[
+            ["packets_delivered", "packets_dropped"]
+        ]
+        streamlit.bar_chart(route_metrics)
+        streamlit.dataframe(routing_frame, width="stretch", hide_index=True)
+
+    source_packets = packet_frame.loc[packet_frame["origin_kind"] == "source"].copy()
+    delivered_packets = source_packets.loc[
+        source_packets["status"] == "delivered"
+    ].copy()
+    if not delivered_packets.empty:
+        streamlit.subheader("Highest-delay source packets")
+        slowest = delivered_packets.sort_values("e2e_delay_ms", ascending=False).head(
+            30
+        )
+        streamlit.dataframe(slowest, width="stretch", hide_index=True)
+    else:
+        streamlit.info("No delivered source packet is available in this run.")
+
+    notes = str(summary.get("notes", "") or "").strip()
+    if notes:
+        streamlit.subheader("Notes")
+        streamlit.info(notes)

--- a/src/agilab/lib/agi-pages/src/agi_pages/runtime.py
+++ b/src/agilab/lib/agi-pages/src/agi_pages/runtime.py
@@ -64,8 +64,8 @@ def active_app_scope_value(active_app: str | Path) -> str:
     return str(Path(active_app).expanduser().resolve())
 
 
-def env_app_scope_value(env: Any) -> str | None:
-    """Infer the active-app session-scope key from an AGILAB environment object."""
+def _env_concrete_app_scope_value(env: Any) -> str | None:
+    """Return the established primary live app identity for an environment."""
 
     app_path = getattr(env, "app_path", None)
     if app_path:
@@ -80,6 +80,126 @@ def env_app_scope_value(env: Any) -> str | None:
     return None
 
 
+def _env_matches_active_app_scope(env: Any, active_scope: str) -> bool:
+    """Return whether live environment fields prove the requested app scope.
+
+    ``AgiEnv`` can intentionally resolve an app to its bundled implementation
+    under its configured ``builtin_apps_path`` (or the legacy
+    ``apps_path / 'builtin'`` location). Those are the sole accepted
+    alternatives to the requested ``apps_path / app`` location. Conflicting
+    live fields are not interchangeable: a stale marker or an ``apps_path`` /
+    ``app`` pair cannot override a different concrete ``active_app``.
+    """
+
+    app_path = getattr(env, "app_path", None)
+    if app_path:
+        return active_app_scope_value(app_path) == active_scope
+
+    active_app = getattr(env, "active_app", None)
+    if active_app:
+        env_active_scope = active_app_scope_value(active_app)
+        if env_active_scope == active_scope:
+            return True
+        apps_path = getattr(env, "apps_path", None)
+        app = getattr(env, "app", None)
+        if not apps_path or not app:
+            return False
+        requested_scope = active_app_scope_value(Path(apps_path) / str(app))
+        builtin_roots = [getattr(env, "builtin_apps_path", None)]
+        builtin_roots.append(Path(apps_path) / "builtin")
+        builtin_scopes = {
+            active_app_scope_value(Path(root) / str(app))
+            for root in builtin_roots
+            if root
+        }
+        return active_scope == requested_scope and env_active_scope in builtin_scopes
+
+    apps_path = getattr(env, "apps_path", None)
+    app = getattr(env, "app", None)
+    return (
+        bool(apps_path and app)
+        and active_app_scope_value(Path(apps_path) / str(app)) == active_scope
+    )
+
+
+def env_app_scope_value(env: Any) -> str | None:
+    """Infer the active-app session-scope key from an AGILAB environment object."""
+
+    concrete_scope = _env_concrete_app_scope_value(env)
+    if concrete_scope is not None:
+        return concrete_scope
+    bound_scope = getattr(env, "_agilab_active_app_scope", None)
+    if bound_scope:
+        return active_app_scope_value(bound_scope)
+    return None
+
+
+def ensure_app_scoped_env(
+    session_state: Any,
+    active_app: str | Path,
+    *,
+    scope_key: str,
+    env_factory: Callable[[Path], Any],
+    env_key: str = "env",
+    keys: tuple[str, ...] = (),
+    prefixes: tuple[str, ...] = (),
+) -> Any:
+    """Return an environment whose app identity matches the active page scope.
+
+    Streamlit pages share one session-state mapping. A page-local scope marker
+    therefore cannot prove that the shared cached environment still belongs to
+    the same app: another page may have replaced it since the marker was set.
+    Reuse is allowed only when the environment exposes a matching app identity.
+    Page-owned state is cleared whenever its recorded scope changes or an
+    unscoped/stale environment must be replaced.
+    """
+
+    active_app_path = Path(active_app).expanduser().resolve()
+    active_scope = active_app_scope_value(active_app_path)
+    cached_env = session_state.get(env_key)
+    cached_matches = cached_env is not None and _env_matches_active_app_scope(
+        cached_env,
+        active_scope,
+    )
+
+    if cached_env is not None and cached_matches:
+        try:
+            cached_env._agilab_active_app_scope = active_scope
+        except (AttributeError, TypeError):
+            pass
+        reset_scoped_session_state(
+            session_state,
+            scope_key,
+            active_app_path,
+            keys=keys,
+            prefixes=prefixes,
+        )
+        session_state[env_key] = cached_env
+        return cached_env
+
+    replacement = env_factory(active_app_path)
+    replacement_scope = env_app_scope_value(replacement)
+    if not _env_matches_active_app_scope(replacement, active_scope):
+        raise ValueError(
+            "Environment factory returned an app scope that does not match "
+            f"the requested app: expected {active_scope!r}, got {replacement_scope!r}"
+        )
+    try:
+        replacement._agilab_active_app_scope = active_scope
+    except (AttributeError, TypeError):
+        pass
+    exact_keys = set((env_key, *keys))
+    for key in list(session_state.keys()):
+        if key == scope_key:
+            continue
+        key_text = str(key)
+        if key in exact_keys or any(key_text.startswith(prefix) for prefix in prefixes):
+            session_state.pop(key, None)
+    session_state[scope_key] = active_scope
+    session_state[env_key] = replacement
+    return replacement
+
+
 def reset_scoped_session_state(
     session_state: Any,
     scope_key: str,
@@ -92,7 +212,9 @@ def reset_scoped_session_state(
 ) -> bool:
     """Clear page-owned session state when the active app scope changes."""
 
-    normalized_scope = active_app_scope_value(scope_value) if normalize_scope else str(scope_value)
+    normalized_scope = (
+        active_app_scope_value(scope_value) if normalize_scope else str(scope_value)
+    )
     previous_scope = session_state.get(scope_key)
     if previous_scope == normalized_scope:
         return False
@@ -104,7 +226,9 @@ def reset_scoped_session_state(
             if key == scope_key:
                 continue
             key_text = str(key)
-            if key in exact_keys or any(key_text.startswith(prefix) for prefix in prefixes):
+            if key in exact_keys or any(
+                key_text.startswith(prefix) for prefix in prefixes
+            ):
                 session_state.pop(key, None)
 
     session_state[scope_key] = normalized_scope
@@ -121,7 +245,10 @@ def discover_files(base: Path, pattern: str) -> list[Path]:
     """Return matching files in deterministic order, swallowing invalid glob roots."""
 
     try:
-        return sorted([path for path in base.glob(pattern) if path.is_file()], key=lambda path: path.as_posix())
+        return sorted(
+            [path for path in base.glob(pattern) if path.is_file()],
+            key=lambda path: path.as_posix(),
+        )
     except (OSError, RuntimeError, TypeError, ValueError):
         return []
 

--- a/test/test_agi_pages_runtime.py
+++ b/test/test_agi_pages_runtime.py
@@ -9,7 +9,9 @@ import pytest
 from agi_pages import runtime
 
 
-def test_agi_pages_runtime_resolves_active_app_and_reports_missing(tmp_path: Path) -> None:
+def test_agi_pages_runtime_resolves_active_app_and_reports_missing(
+    tmp_path: Path,
+) -> None:
     app = tmp_path / "demo_project"
     app.mkdir()
 
@@ -44,17 +46,239 @@ def test_agi_pages_runtime_resolves_active_app_and_reports_missing(tmp_path: Pat
     assert errors == ["Missing --active-app argument."]
 
     with pytest.raises(FileNotFoundError, match="Provided --active-app path not found"):
-        runtime.resolve_active_app_path(["--active-app", str(tmp_path / "missing_without_callbacks")])
+        runtime.resolve_active_app_path(
+            ["--active-app", str(tmp_path / "missing_without_callbacks")]
+        )
 
 
 def test_agi_pages_runtime_scope_helpers_cover_env_fallbacks(tmp_path: Path) -> None:
     app_path = tmp_path / "apps" / "demo_project"
     app_path.mkdir(parents=True)
+    other_path = tmp_path / "apps" / "other_project"
 
-    assert runtime.env_app_scope_value(SimpleNamespace(app_path=app_path)) == str(app_path.resolve())
-    assert runtime.env_app_scope_value(SimpleNamespace(active_app=app_path)) == str(app_path.resolve())
-    assert runtime.env_app_scope_value(SimpleNamespace(apps_path=app_path.parent, app=app_path.name)) == str(app_path.resolve())
+    assert runtime.env_app_scope_value(
+        SimpleNamespace(
+            _agilab_active_app_scope=other_path,
+            apps_path=app_path.parent,
+            app=app_path.name,
+        )
+    ) == str(app_path.resolve())
+    assert runtime.env_app_scope_value(
+        SimpleNamespace(_agilab_active_app_scope=app_path)
+    ) == str(app_path.resolve())
+    assert runtime.env_app_scope_value(SimpleNamespace(app_path=app_path)) == str(
+        app_path.resolve()
+    )
+    assert runtime.env_app_scope_value(SimpleNamespace(active_app=app_path)) == str(
+        app_path.resolve()
+    )
+    assert runtime.env_app_scope_value(
+        SimpleNamespace(apps_path=app_path.parent, app=app_path.name)
+    ) == str(app_path.resolve())
     assert runtime.env_app_scope_value(SimpleNamespace()) is None
+
+
+def test_agi_pages_runtime_reuses_matching_scoped_environment(tmp_path: Path) -> None:
+    app = tmp_path / "apps" / "demo_project"
+    app.mkdir(parents=True)
+    env = SimpleNamespace(apps_path=app.parent, app=app.name)
+    state = {
+        "scope": str(app.resolve()),
+        "env": env,
+        "page:choice": "kept",
+    }
+    created: list[Path] = []
+
+    resolved = runtime.ensure_app_scoped_env(
+        state,
+        app,
+        scope_key="scope",
+        env_factory=lambda active: created.append(active),
+        prefixes=("page:",),
+    )
+
+    assert resolved is env
+    assert created == []
+    assert state["page:choice"] == "kept"
+
+
+def test_agi_pages_runtime_accepts_matching_apps_path_when_active_app_is_builtin(
+    tmp_path: Path,
+) -> None:
+    apps_path = tmp_path / "apps"
+    app = apps_path / "demo_project"
+    builtin_apps_path = tmp_path / "builtin-apps"
+    builtin_app = builtin_apps_path / "demo_project"
+    app.mkdir(parents=True)
+    builtin_app.mkdir(parents=True)
+    env = SimpleNamespace(
+        active_app=builtin_app,
+        apps_path=apps_path,
+        app=app.name,
+        builtin_apps_path=builtin_apps_path,
+    )
+    state = {"scope": str(app.resolve()), "env": env}
+
+    assert runtime.env_app_scope_value(env) == str(builtin_app.resolve())
+    assert (
+        runtime.ensure_app_scoped_env(
+            state,
+            app,
+            scope_key="scope",
+            env_factory=lambda _active: pytest.fail("matching environment was rebuilt"),
+        )
+        is env
+    )
+    assert state["env"] is env
+
+
+def test_agi_pages_runtime_reuses_matching_environment_after_scope_switch(
+    tmp_path: Path,
+) -> None:
+    old_app = tmp_path / "apps" / "old_project"
+    new_app = tmp_path / "apps" / "new_project"
+    old_app.mkdir(parents=True)
+    new_app.mkdir()
+    env = SimpleNamespace(apps_path=new_app.parent, app=new_app.name)
+    state = {
+        "scope": str(old_app.resolve()),
+        "env": env,
+        "page:choice": "stale",
+        "global": "kept",
+    }
+
+    resolved = runtime.ensure_app_scoped_env(
+        state,
+        new_app,
+        scope_key="scope",
+        env_factory=lambda _active: pytest.fail("matching environment was rebuilt"),
+        keys=("env",),
+        prefixes=("page:",),
+    )
+
+    assert resolved is env
+    assert state == {
+        "scope": str(new_app.resolve()),
+        "env": env,
+        "global": "kept",
+    }
+
+
+def test_agi_pages_runtime_rebuilds_stale_environment_despite_matching_marker(
+    tmp_path: Path,
+) -> None:
+    old_app = tmp_path / "apps" / "old_project"
+    new_app = tmp_path / "apps" / "new_project"
+    old_app.mkdir(parents=True)
+    new_app.mkdir()
+    stale_env = SimpleNamespace(
+        apps_path=old_app.parent,
+        app=old_app.name,
+        _agilab_active_app_scope=new_app,
+    )
+    replacement = SimpleNamespace(apps_path=new_app.parent, app=new_app.name)
+    state = {
+        "scope": str(new_app.resolve()),
+        "env": stale_env,
+        "exact": "stale",
+        "page:choice": "stale",
+        "global": "kept",
+    }
+    created: list[Path] = []
+
+    resolved = runtime.ensure_app_scoped_env(
+        state,
+        new_app,
+        scope_key="scope",
+        env_factory=lambda active: created.append(active) or replacement,
+        keys=("exact",),
+        prefixes=("page:",),
+    )
+
+    assert resolved is replacement
+    assert created == [new_app.resolve()]
+    assert state == {
+        "scope": str(new_app.resolve()),
+        "env": replacement,
+        "global": "kept",
+    }
+
+
+def test_agi_pages_runtime_rebuilds_conflicting_live_environment_identity(
+    tmp_path: Path,
+) -> None:
+    apps_path = tmp_path / "apps"
+    old_app = apps_path / "old_project"
+    new_app = apps_path / "new_project"
+    old_app.mkdir(parents=True)
+    new_app.mkdir()
+    stale_env = SimpleNamespace(
+        active_app=old_app,
+        apps_path=apps_path,
+        app=new_app.name,
+        _agilab_active_app_scope=new_app,
+    )
+    replacement = SimpleNamespace(
+        active_app=new_app,
+        apps_path=apps_path,
+        app=new_app.name,
+    )
+    state = {"scope": str(new_app.resolve()), "env": stale_env}
+
+    resolved = runtime.ensure_app_scoped_env(
+        state,
+        new_app,
+        scope_key="scope",
+        env_factory=lambda _active: replacement,
+    )
+
+    assert resolved is replacement
+    assert state["env"] is replacement
+
+
+def test_agi_pages_runtime_rebuilds_unknown_unscoped_environment(
+    tmp_path: Path,
+) -> None:
+    app = tmp_path / "apps" / "demo_project"
+    app.mkdir(parents=True)
+    replacement = SimpleNamespace(apps_path=app.parent, app=app.name)
+    state = {"env": SimpleNamespace(), "page:choice": "stale"}
+
+    resolved = runtime.ensure_app_scoped_env(
+        state,
+        app,
+        scope_key="scope",
+        env_factory=lambda _active: replacement,
+        prefixes=("page:",),
+    )
+
+    assert resolved is replacement
+    assert state == {"scope": str(app.resolve()), "env": replacement}
+
+
+def test_agi_pages_runtime_rejects_factory_environment_for_another_app(
+    tmp_path: Path,
+) -> None:
+    requested_app = tmp_path / "apps" / "requested_project"
+    other_app = tmp_path / "apps" / "other_project"
+    requested_app.mkdir(parents=True)
+    other_app.mkdir()
+    cached_env = SimpleNamespace()
+    state: dict[str, object] = {"env": cached_env, "page:choice": "kept"}
+
+    with pytest.raises(ValueError, match="does not match the requested app"):
+        runtime.ensure_app_scoped_env(
+            state,
+            requested_app,
+            scope_key="scope",
+            env_factory=lambda _active: SimpleNamespace(
+                apps_path=other_app.parent,
+                app=other_app.name,
+            ),
+            prefixes=("page:",),
+        )
+
+    assert state == {"env": cached_env, "page:choice": "kept"}
 
 
 def test_agi_pages_runtime_file_helpers_are_deterministic(tmp_path: Path) -> None:
@@ -74,10 +298,13 @@ def test_agi_pages_runtime_file_helpers_are_deterministic(tmp_path: Path) -> Non
         def glob(self, _pattern: str):
             raise OSError("glob unavailable")
 
-    assert runtime.artifact_root(
-        SimpleNamespace(AGILAB_EXPORT_ABS=tmp_path / "export", target="demo"),
-        "forecast",
-    ) == tmp_path / "export" / "demo" / "forecast"
+    assert (
+        runtime.artifact_root(
+            SimpleNamespace(AGILAB_EXPORT_ABS=tmp_path / "export", target="demo"),
+            "forecast",
+        )
+        == tmp_path / "export" / "demo" / "forecast"
+    )
     assert runtime.discover_files(root, "**/metrics.json") == [a_file, b_file]
     assert runtime.discover_files(root / "missing", "[") == []
     assert runtime.discover_files(BrokenBase(), "*.json") == []
@@ -265,16 +492,30 @@ def test_agi_pages_runtime_infers_env_app_scope(tmp_path: Path) -> None:
     app = tmp_path / "apps" / "demo"
     app.mkdir(parents=True)
 
-    assert runtime.env_app_scope_value(SimpleNamespace(app_path=app)) == str(app.resolve())
-    assert runtime.env_app_scope_value(SimpleNamespace(active_app=app)) == str(app.resolve())
-    assert runtime.env_app_scope_value(SimpleNamespace(apps_path=app.parent, app=app.name)) == str(app.resolve())
+    assert runtime.env_app_scope_value(SimpleNamespace(app_path=app)) == str(
+        app.resolve()
+    )
+    assert runtime.env_app_scope_value(SimpleNamespace(active_app=app)) == str(
+        app.resolve()
+    )
+    assert runtime.env_app_scope_value(
+        SimpleNamespace(apps_path=app.parent, app=app.name)
+    ) == str(app.resolve())
     assert runtime.env_app_scope_value(SimpleNamespace()) is None
 
 
 def test_agi_pages_runtime_ensure_repo_on_path(monkeypatch, tmp_path: Path) -> None:
     repo_root = tmp_path / "repo"
     src_root = repo_root / "src"
-    page_file = src_root / "agilab" / "apps-pages" / "view_demo" / "src" / "view_demo" / "view_demo.py"
+    page_file = (
+        src_root
+        / "agilab"
+        / "apps-pages"
+        / "view_demo"
+        / "src"
+        / "view_demo"
+        / "view_demo.py"
+    )
     page_file.parent.mkdir(parents=True)
     page_file.write_text("# page\n", encoding="utf-8")
 

--- a/test/test_package_split_contract.py
+++ b/test/test_package_split_contract.py
@@ -6,6 +6,7 @@ import tomllib
 from pathlib import Path
 
 from packaging.requirements import Requirement
+from packaging.version import Version
 import pytest
 from setuptools import find_packages
 
@@ -46,7 +47,9 @@ def _requirements(pyproject: Path, section: str) -> list[Requirement]:
 
 
 def _requirement_names(pyproject: Path, section: str) -> set[str]:
-    return {requirement.name.lower() for requirement in _requirements(pyproject, section)}
+    return {
+        requirement.name.lower() for requirement in _requirements(pyproject, section)
+    }
 
 
 def _exact_pin(requirement: Requirement) -> str | None:
@@ -57,12 +60,16 @@ def _exact_pin(requirement: Requirement) -> str | None:
 
 
 def _has_lower_bound(requirement: Requirement) -> bool:
-    return any(specifier.operator in {">=", "~="} for specifier in requirement.specifier)
+    return any(
+        specifier.operator in {">=", "~="} for specifier in requirement.specifier
+    )
 
 
 def _load_pypi_publish():
     module_path = REPO_ROOT / "tools/pypi_publish.py"
-    spec = importlib.util.spec_from_file_location("pypi_publish_contract_test_module", module_path)
+    spec = importlib.util.spec_from_file_location(
+        "pypi_publish_contract_test_module", module_path
+    )
     assert spec and spec.loader
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
@@ -72,7 +79,9 @@ def _load_pypi_publish():
 
 def _load_release_plan():
     module_path = REPO_ROOT / "tools/release_plan.py"
-    spec = importlib.util.spec_from_file_location("release_plan_contract_test_module", module_path)
+    spec = importlib.util.spec_from_file_location(
+        "release_plan_contract_test_module", module_path
+    )
     assert spec and spec.loader
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
@@ -110,7 +119,9 @@ def test_page_package_pyprojects_declare_pypi_discoverability_metadata() -> None
         "Changelog",
     }
 
-    for pyproject in sorted((REPO_ROOT / "src/agilab/apps-pages").glob("*/pyproject.toml")):
+    for pyproject in sorted(
+        (REPO_ROOT / "src/agilab/apps-pages").glob("*/pyproject.toml")
+    ):
         data = _load_toml(pyproject)
         project = data["project"]
         package_name = project["name"]
@@ -127,7 +138,9 @@ def test_page_package_pyprojects_declare_pypi_discoverability_metadata() -> None
 
 def test_internal_dependencies_follow_bundle_or_asset_version_policy() -> None:
     versions = {
-        package.name: _load_toml(pyproject_path(REPO_ROOT, package))["project"]["version"]
+        package.name: _load_toml(pyproject_path(REPO_ROOT, package))["project"][
+            "version"
+        ]
         for package in PACKAGE_CONTRACTS
     }
     internal_names = set(PACKAGE_NAMES)
@@ -148,9 +161,13 @@ def test_internal_dependencies_follow_bundle_or_asset_version_policy() -> None:
                 exact_version = _exact_pin(requirement)
                 if package.name in ASSET_PACKAGE_NAMES:
                     if exact_version is not None:
-                        violations.append(f"{package.name}:{section}:{requirement}: asset payload must not exact-pin internal packages")
+                        violations.append(
+                            f"{package.name}:{section}:{requirement}: asset payload must not exact-pin internal packages"
+                        )
                     if not _has_lower_bound(requirement):
-                        violations.append(f"{package.name}:{section}:{requirement}: asset payload must declare a compatible runtime floor")
+                        violations.append(
+                            f"{package.name}:{section}:{requirement}: asset payload must declare a compatible runtime floor"
+                        )
                     continue
 
                 expected_version = versions[requirement.name.lower()]
@@ -162,6 +179,41 @@ def test_internal_dependencies_follow_bundle_or_asset_version_policy() -> None:
                     )
 
     assert violations == []
+
+
+def test_queue_resilience_pages_require_the_shared_runtime_release() -> None:
+    shared_pyproject = REPO_ROOT / "src/agilab/lib/agi-pages/pyproject.toml"
+    shared_version = _load_toml(shared_pyproject)["project"]["version"]
+    root_pyproject = REPO_ROOT / "pyproject.toml"
+    root_version = _load_toml(root_pyproject)["project"]["version"]
+    shared_module = (
+        REPO_ROOT / "src/agilab/lib/agi-pages/src/agi_pages/queue_resilience.py"
+    )
+
+    assert shared_module.is_file()
+    assert Version(shared_version) > Version("2026.07.17")
+    assert Version(root_version) > Version("2026.07.17")
+    for page_name in ("view_queue_resilience", "view_relay_resilience"):
+        pyproject = REPO_ROOT / "src/agilab/apps-pages" / page_name / "pyproject.toml"
+        requirements = _requirements(pyproject, "dependencies")
+        agi_pages = next(
+            requirement
+            for requirement in requirements
+            if requirement.name.lower() == "agi-pages"
+        )
+        assert any(
+            specifier.operator == ">=" and specifier.version == shared_version
+            for specifier in agi_pages.specifier
+        ), pyproject
+
+    for extra_name in ("ui", "pages"):
+        requirements = _requirements(root_pyproject, extra_name)
+        agi_pages = next(
+            requirement
+            for requirement in requirements
+            if requirement.name.lower() == "agi-pages"
+        )
+        assert _exact_pin(agi_pages) == shared_version
 
 
 def test_root_extras_and_uv_sources_match_package_split_contract() -> None:
@@ -191,7 +243,9 @@ def test_root_extras_and_uv_sources_match_package_split_contract() -> None:
         "starlette",
     }
 
-    sources = _load_toml(root_pyproject).get("tool", {}).get("uv", {}).get("sources", {})
+    sources = (
+        _load_toml(root_pyproject).get("tool", {}).get("uv", {}).get("sources", {})
+    )
     for package in LIBRARY_PACKAGE_CONTRACTS:
         source = sources.get(package.name)
         assert source is not None, package.name
@@ -201,7 +255,9 @@ def test_root_extras_and_uv_sources_match_package_split_contract() -> None:
 
 def test_root_ui_extra_covers_default_source_analysis_view_dependencies() -> None:
     root_pyproject = REPO_ROOT / "pyproject.toml"
-    default_analysis_bundle = REPO_ROOT / "src/agilab/apps-pages/view_maps/pyproject.toml"
+    default_analysis_bundle = (
+        REPO_ROOT / "src/agilab/apps-pages/view_maps/pyproject.toml"
+    )
     required_names = {
         requirement.name.lower()
         for requirement in _requirements(default_analysis_bundle, "dependencies")
@@ -215,7 +271,9 @@ def test_root_ui_extra_covers_default_source_analysis_view_dependencies() -> Non
 def test_publish_tool_uses_the_same_package_split_contract() -> None:
     module = _load_pypi_publish()
 
-    assert [name for name, *_ in module.publishable_libs()] == [package.name for package in LIBRARY_PACKAGE_CONTRACTS]
+    assert [name for name, *_ in module.publishable_libs()] == [
+        package.name for package in LIBRARY_PACKAGE_CONTRACTS
+    ]
     assert module.ALL_PACKAGE_NAMES == list(PACKAGE_NAMES)
     assert module.WHEEL_ONLY_PACKAGES == set(WHEEL_ONLY_PACKAGE_NAMES)
 
@@ -301,13 +359,20 @@ def test_root_wheel_package_discovery_keeps_cli_subpackages() -> None:
 
 
 def test_workflow_and_docs_cover_the_same_package_split() -> None:
-    workflow = (REPO_ROOT / ".github/workflows/pypi-publish.yaml").read_text(encoding="utf-8")
-    docs = (REPO_ROOT / "docs/source/package-publishing-policy.rst").read_text(encoding="utf-8")
+    workflow = (REPO_ROOT / ".github/workflows/pypi-publish.yaml").read_text(
+        encoding="utf-8"
+    )
+    docs = (REPO_ROOT / "docs/source/package-publishing-policy.rst").read_text(
+        encoding="utf-8"
+    )
     readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
     release_plan = _load_release_plan()
 
     assert "tools/release_plan.py" in workflow
-    assert "include: ${{ fromJSON(needs.release-plan.outputs.library_matrix) }}" in workflow
+    assert (
+        "include: ${{ fromJSON(needs.release-plan.outputs.library_matrix) }}"
+        in workflow
+    )
     assert workflow.count("          - package: ") == 0
     assert release_plan.library_matrix() == [
         {
@@ -353,4 +418,6 @@ def test_app_project_package_contracts_match_declared_project_packages() -> None
     assert package_by_name("agi-core").role == "runtime-bundle"
     assert app_project_contracts
     package_names = [package.name for package in LIBRARY_PACKAGE_CONTRACTS]
-    assert max(package_names.index(name) for name, _ in app_project_contracts) < package_names.index("agi-apps")
+    assert max(
+        package_names.index(name) for name, _ in app_project_contracts
+    ) < package_names.index("agi-apps")

--- a/test/test_view_queue_resilience.py
+++ b/test/test_view_queue_resilience.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ast
 import importlib.util
 import json
 import sys
@@ -9,16 +10,22 @@ from unittest.mock import patch
 
 import pytest
 
-PAGE_PATH = (
-    "src/agilab/apps-pages/view_queue_resilience/src/view_queue_resilience/view_queue_resilience.py"
+from agi_pages.queue_resilience import (
+    QUEUE_SUMMARY_GLOB,
+    load_queue_summary,
+    queue_peer_csv_paths,
 )
+
+PAGE_PATH = "src/agilab/apps-pages/view_queue_resilience/src/view_queue_resilience/view_queue_resilience.py"
 PAGE_META_PATH = Path(
     "src/agilab/apps-pages/view_queue_resilience/src/view_queue_resilience/page_meta.py"
 )
 
 
 def _page_title() -> str:
-    spec = importlib.util.spec_from_file_location("view_queue_resilience_page_meta", PAGE_META_PATH)
+    spec = importlib.util.spec_from_file_location(
+        "view_queue_resilience_page_meta", PAGE_META_PATH
+    )
     assert spec and spec.loader
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
@@ -27,7 +34,7 @@ def _page_title() -> str:
 
 def _load_queue_helpers() -> ModuleType:
     source = Path(PAGE_PATH).read_text(encoding="utf-8")
-    prefix = source.split("\nconfigure_streamlit_page(st,", 1)[0]
+    prefix = source.split("\npage_context = prepare_queue_resilience_page(", 1)[0]
     module = ModuleType("view_queue_resilience_test_module")
     module.__file__ = str(Path(PAGE_PATH).resolve())
     module.__package__ = None
@@ -88,9 +95,7 @@ def test_view_queue_resilience_renders_exported_artifacts(
         encoding="utf-8",
     )
     (artifact_dir / f"{stem}_routing_summary.csv").write_text(
-        "relay,packets_delivered,packets_dropped\n"
-        "relay-a,18,2\n"
-        "relay-b,24,1\n",
+        "relay,packets_delivered,packets_dropped\nrelay-a,18,2\nrelay-b,24,1\n",
         encoding="utf-8",
     )
 
@@ -102,6 +107,7 @@ def test_view_queue_resilience_renders_exported_artifacts(
     assert len(at.dataframe) >= 1
     assert len(at.selectbox) >= 1
     assert len(at.text_input) >= 2
+
 
 def test_view_queue_resilience_reports_missing_peer_artifacts(
     tmp_path, create_temp_app_project, run_page_app_test
@@ -129,13 +135,11 @@ def test_view_queue_resilience_reports_missing_peer_artifacts(
         encoding="utf-8",
     )
     (artifact_dir / f"{stem}_packet_events.csv").write_text(
-        "packet_id,origin_kind,status,e2e_delay_ms\n"
-        "1,source,delivered,85.0\n",
+        "packet_id,origin_kind,status,e2e_delay_ms\n1,source,delivered,85.0\n",
         encoding="utf-8",
     )
     (artifact_dir / f"{stem}_node_positions.csv").write_text(
-        "time_s,node,role,y_m\n"
-        "0.0,relay-a,relay,100\n",
+        "time_s,node,role,y_m\n0.0,relay-a,relay,100\n",
         encoding="utf-8",
     )
 
@@ -143,7 +147,9 @@ def test_view_queue_resilience_reports_missing_peer_artifacts(
 
     assert not at.exception
     assert any(title.value == _page_title() for title in at.title)
-    assert any("Related queue artifacts are missing" in error.value for error in at.error)
+    assert any(
+        "Related queue artifacts are missing" in error.value for error in at.error
+    )
     assert len(at.code) >= 1
 
 
@@ -160,7 +166,10 @@ def test_view_queue_resilience_warns_when_artifact_directory_is_missing(
     at = run_page_app_test(PAGE_PATH, project_dir, export_root=tmp_path / "export")
 
     assert not at.exception
-    assert any("Artifact directory does not exist yet" in warning.value for warning in at.warning)
+    assert any(
+        "Artifact directory does not exist yet" in warning.value
+        for warning in at.warning
+    )
 
 
 def test_view_queue_resilience_reports_missing_delivered_source_packets(
@@ -190,8 +199,7 @@ def test_view_queue_resilience_reports_missing_delivered_source_packets(
         encoding="utf-8",
     )
     (artifact_dir / f"{stem}_queue_timeseries.csv").write_text(
-        "time_s,relay,queue_depth_pkts\n"
-        "0.0,relay-a,1\n",
+        "time_s,relay,queue_depth_pkts\n0.0,relay-a,1\n",
         encoding="utf-8",
     )
     (artifact_dir / f"{stem}_packet_events.csv").write_text(
@@ -201,20 +209,21 @@ def test_view_queue_resilience_reports_missing_delivered_source_packets(
         encoding="utf-8",
     )
     (artifact_dir / f"{stem}_node_positions.csv").write_text(
-        "time_s,node,role,y_m\n"
-        "0.0,relay-a,relay,100\n",
+        "time_s,node,role,y_m\n0.0,relay-a,relay,100\n",
         encoding="utf-8",
     )
     (artifact_dir / f"{stem}_routing_summary.csv").write_text(
-        "relay,packets_delivered,packets_dropped\n"
-        "relay-a,0,1\n",
+        "relay,packets_delivered,packets_dropped\nrelay-a,0,1\n",
         encoding="utf-8",
     )
 
     at = run_page_app_test(PAGE_PATH, project_dir, export_root=tmp_path / "export")
 
     assert not at.exception
-    assert any("No delivered source packet is available in this run." in info.value for info in at.info)
+    assert any(
+        "No delivered source packet is available in this run." in info.value
+        for info in at.info
+    )
     assert any(subheader.value == "Notes" for subheader in at.subheader)
 
 
@@ -223,7 +232,15 @@ def test_view_queue_resilience_helper_branches(monkeypatch, tmp_path) -> None:
 
     repo_root = tmp_path / "repo"
     src_root = repo_root / "src"
-    module_path = src_root / "agilab" / "apps-pages" / "view_queue_resilience" / "src" / "view_queue_resilience" / "view_queue_resilience.py"
+    module_path = (
+        src_root
+        / "agilab"
+        / "apps-pages"
+        / "view_queue_resilience"
+        / "src"
+        / "view_queue_resilience"
+        / "view_queue_resilience.py"
+    )
     module_path.parent.mkdir(parents=True)
     module_path.write_text("# stub\n", encoding="utf-8")
     (module_path.parent / "page_meta.py").write_text(
@@ -240,22 +257,16 @@ def test_view_queue_resilience_helper_branches(monkeypatch, tmp_path) -> None:
     assert logo == "queued.svg"
     assert title == "Queue Analysis"
 
-    errors: list[str] = []
-    def stop_now():
-        raise RuntimeError("stop")
-    module.st = SimpleNamespace(error=errors.append, stop=stop_now)
-    monkeypatch.setattr(sys, "argv", [Path(PAGE_PATH).name, "--active-app", str(tmp_path / "missing_app")])
-    with pytest.raises(RuntimeError, match="stop"):
-        module._resolve_active_app()
-    assert any("Provided --active-app path not found" in message for message in errors)
-
-    assert module._discover_files(tmp_path / "missing", "[") == []
-    assert module._safe_metric(object()) == "n/a"
+    peer_paths = queue_peer_csv_paths(tmp_path / "demo_summary_metrics.json")
+    assert peer_paths["queue_timeseries"] == tmp_path / "demo_queue_timeseries.csv"
+    assert peer_paths["routing_summary"] == tmp_path / "demo_routing_summary.csv"
 
 
-def test_view_queue_resilience_package_meta_and_discover_exception(monkeypatch, tmp_path) -> None:
+def test_view_queue_resilience_package_meta(monkeypatch) -> None:
     module = _load_queue_helpers()
-    monkeypatch.setitem(sys.modules, "view_queue_resilience", ModuleType("view_queue_resilience"))
+    monkeypatch.setitem(
+        sys.modules, "view_queue_resilience", ModuleType("view_queue_resilience")
+    )
     page_meta_name = "view_queue_resilience.page_meta"
     monkeypatch.setitem(
         sys.modules,
@@ -265,34 +276,36 @@ def test_view_queue_resilience_package_meta_and_discover_exception(monkeypatch, 
     monkeypatch.setattr(module, "__package__", "view_queue_resilience")
     assert module._load_page_meta() == ("pkg-logo.svg", "Pkg Queue")
 
-    broken_base = SimpleNamespace(glob=lambda _pattern: (_ for _ in ()).throw(RuntimeError("broken glob")))
-    assert module._discover_files(broken_base, "*.json") == []
 
-
-def test_view_queue_resilience_resets_app_scoped_state_on_active_app_change(tmp_path) -> None:
-    module = _load_queue_helpers()
-    first_app = tmp_path / "first_app"
-    second_app = tmp_path / "second_app"
-    first_app.mkdir()
-    second_app.mkdir()
-    module.st = SimpleNamespace(
-        session_state={
-            module.APP_SCOPE_KEY: str(first_app.resolve()),
-            module.DATA_DIR_KEY: "/tmp/old-artifacts",
-            module.SUMMARY_GLOB_KEY: "*old.json",
-        }
+def test_queue_resilience_support_stays_dataframe_and_streamlit_free(tmp_path) -> None:
+    support_path = Path("src/agilab/lib/agi-pages/src/agi_pages/queue_resilience.py")
+    tree = ast.parse(support_path.read_text(encoding="utf-8"))
+    imported_roots = {
+        alias.name.split(".", 1)[0]
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    }
+    imported_roots.update(
+        (node.module or "").split(".", 1)[0]
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.level == 0
     )
+    assert imported_roots.isdisjoint({"pandas", "streamlit"})
 
-    assert module._reset_app_scoped_session_defaults(first_app) is False
-    assert module.DATA_DIR_KEY in module.st.session_state
+    summary_path = tmp_path / "demo_summary_metrics.json"
+    summary_path.write_text('{"pdr": 0.9}', encoding="utf-8")
+    assert load_queue_summary(summary_path) == {"pdr": 0.9}
+    assert QUEUE_SUMMARY_GLOB == "**/*_summary_metrics.json"
 
-    assert module._reset_app_scoped_session_defaults(second_app) is True
-    assert module.st.session_state[module.APP_SCOPE_KEY] == str(second_app.resolve())
-    for key in module.APP_SCOPED_SESSION_DEFAULT_KEYS:
-        assert key not in module.st.session_state
+    summary_path.write_text("[1, 2]", encoding="utf-8")
+    with pytest.raises(TypeError, match="must contain a JSON object"):
+        load_queue_summary(summary_path)
 
 
-def test_view_queue_resilience_reuses_existing_session_env(tmp_path, create_temp_app_project, monkeypatch) -> None:
+def test_view_queue_resilience_reuses_existing_session_env(
+    tmp_path, create_temp_app_project, monkeypatch
+) -> None:
     project_dir = create_temp_app_project(
         "uav_queue_project",
         package_name="uav_queue",
@@ -330,8 +343,12 @@ def test_view_queue_resilience_reuses_existing_session_env(tmp_path, create_temp
             AGILAB_EXPORT_ABS=export_root,
             target="uav_queue",
             st_resources=tmp_path / "resources",
+            apps_path=project_dir.parent,
+            app=project_dir.name,
         )
-        at.session_state["queue_resilience_active_app_scope"] = str(project_dir.resolve())
+        at.session_state["queue_resilience_active_app_scope"] = str(
+            project_dir.resolve()
+        )
         at.run()
 
     assert not at.exception
@@ -353,4 +370,6 @@ def test_view_queue_resilience_warns_when_summary_glob_is_empty(
     at = run_page_app_test(PAGE_PATH, project_dir, export_root=tmp_path / "export")
 
     assert not at.exception
-    assert any("No summary metrics file found" in warning.value for warning in at.warning)
+    assert any(
+        "No summary metrics file found" in warning.value for warning in at.warning
+    )

--- a/test/test_view_relay_resilience.py
+++ b/test/test_view_relay_resilience.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 import json
 import sys
 from pathlib import Path
-from types import ModuleType, SimpleNamespace
-
-import pytest
+from types import ModuleType
 
 PAGE_PATH = (
     "src/agilab/apps-pages/view_relay_resilience/"
@@ -69,16 +67,14 @@ def _write_relay_run(
         encoding="utf-8",
     )
     (artifact_dir / f"{stem}_routing_summary.csv").write_text(
-        "relay,packets_delivered,packets_dropped\n"
-        "relay-a,18,2\n"
-        "relay-b,24,1\n",
+        "relay,packets_delivered,packets_dropped\nrelay-a,18,2\nrelay-b,24,1\n",
         encoding="utf-8",
     )
 
 
 def _load_relay_helpers() -> ModuleType:
     source = Path(PAGE_PATH).read_text(encoding="utf-8")
-    prefix = source.split("\nconfigure_streamlit_page(st,", 1)[0]
+    prefix = source.split("\npage_context = prepare_queue_resilience_page(", 1)[0]
     module = ModuleType("view_relay_resilience_test_module")
     module.__file__ = str(Path(PAGE_PATH).resolve())
     module.__package__ = None
@@ -173,12 +169,18 @@ def test_view_relay_resilience_compares_multiple_runs(
 
     assert not at.exception
     assert len(at.selectbox) >= 2
-    comparison_frames = [frame.value for frame in at.dataframe if "delta_pdr_vs_ref" in frame.value.columns]
+    comparison_frames = [
+        frame.value
+        for frame in at.dataframe
+        if "delta_pdr_vs_ref" in frame.value.columns
+    ]
     assert len(comparison_frames) == 1
     comparison_df = comparison_frames[0]
     assert set(comparison_df["run_label"]) == set(runs_widget.options)
     assert set(comparison_df["routing_policy"]) == {"queue_aware", "shortest_path"}
-    assert any(metric.label == "Runs selected" and metric.value == "2" for metric in at.metric)
+    assert any(
+        metric.label == "Runs selected" and metric.value == "2" for metric in at.metric
+    )
 
 
 def test_view_relay_resilience_reports_missing_peer_artifacts(
@@ -207,13 +209,11 @@ def test_view_relay_resilience_reports_missing_peer_artifacts(
         encoding="utf-8",
     )
     (artifact_dir / f"{stem}_packet_events.csv").write_text(
-        "packet_id,origin_kind,status,e2e_delay_ms\n"
-        "1,source,delivered,85.0\n",
+        "packet_id,origin_kind,status,e2e_delay_ms\n1,source,delivered,85.0\n",
         encoding="utf-8",
     )
     (artifact_dir / f"{stem}_node_positions.csv").write_text(
-        "time_s,node,role,y_m\n"
-        "0.0,relay-a,relay,100\n",
+        "time_s,node,role,y_m\n0.0,relay-a,relay,100\n",
         encoding="utf-8",
     )
 
@@ -221,7 +221,9 @@ def test_view_relay_resilience_reports_missing_peer_artifacts(
 
     assert not at.exception
     assert any(title.value == "Relay resilience analysis" for title in at.title)
-    assert any("Related queue artifacts are missing" in error.value for error in at.error)
+    assert any(
+        "Related queue artifacts are missing" in error.value for error in at.error
+    )
     assert len(at.code) >= 1
 
 
@@ -238,7 +240,10 @@ def test_view_relay_resilience_warns_when_artifact_directory_is_missing(
     at = run_page_app_test(PAGE_PATH, project_dir, export_root=tmp_path / "export")
 
     assert not at.exception
-    assert any("Artifact directory does not exist yet" in warning.value for warning in at.warning)
+    assert any(
+        "Artifact directory does not exist yet" in warning.value
+        for warning in at.warning
+    )
 
 
 def test_view_relay_resilience_reports_missing_delivered_source_packets(
@@ -277,7 +282,10 @@ def test_view_relay_resilience_reports_missing_delivered_source_packets(
     at = run_page_app_test(PAGE_PATH, project_dir, export_root=tmp_path / "export")
 
     assert not at.exception
-    assert any("No delivered source packet is available in this run." in info.value for info in at.info)
+    assert any(
+        "No delivered source packet is available in this run." in info.value
+        for info in at.info
+    )
     assert any(subheader.value == "Notes" for subheader in at.subheader)
 
 
@@ -286,7 +294,15 @@ def test_view_relay_resilience_helper_branches(monkeypatch, tmp_path) -> None:
 
     repo_root = tmp_path / "repo"
     src_root = repo_root / "src"
-    module_path = src_root / "agilab" / "apps-pages" / "view_relay_resilience" / "src" / "view_relay_resilience" / "view_relay_resilience.py"
+    module_path = (
+        src_root
+        / "agilab"
+        / "apps-pages"
+        / "view_relay_resilience"
+        / "src"
+        / "view_relay_resilience"
+        / "view_relay_resilience.py"
+    )
     module_path.parent.mkdir(parents=True)
     module_path.write_text("# stub\n", encoding="utf-8")
     monkeypatch.setattr(module, "__file__", str(module_path))
@@ -295,58 +311,41 @@ def test_view_relay_resilience_helper_branches(monkeypatch, tmp_path) -> None:
     assert str(src_root) in sys.path
     assert str(repo_root) in sys.path
 
-    errors: list[str] = []
-    def stop_now():
-        raise RuntimeError("stop")
-    module.st = SimpleNamespace(error=errors.append, stop=stop_now)
-    monkeypatch.setattr(sys, "argv", [Path(PAGE_PATH).name, "--active-app", str(tmp_path / "missing_app")])
-    with pytest.raises(RuntimeError, match="stop"):
-        module._resolve_active_app()
-    assert any("Provided --active-app path not found" in message for message in errors)
-
-    assert module._discover_files(tmp_path / "missing", "[") == []
     assert module._safe_metric(object()) == "n/a"
-    assert module._relative_summary_label(Path("/tmp/run.json"), tmp_path / "artifact_root") == "run.json"
+    assert (
+        module._peer_csv(
+            tmp_path / "demo_summary_metrics.json",
+            "queue_timeseries",
+        )
+        == tmp_path / "demo_queue_timeseries.csv"
+    )
+    assert (
+        module._relative_summary_label(
+            Path("/tmp/run.json"), tmp_path / "artifact_root"
+        )
+        == "run.json"
+    )
     assert module._coerce_selection("missing", ["a", "b"], fallback="a") == ["a"]
     assert module._coerce_selection(object(), ["a", "b"]) == ["b"]
     assert module._build_comparison_frame({}, tmp_path, "missing").empty
 
     broken_queue = tmp_path / "broken_summary_metrics.json"
     broken_queue.write_text("{}", encoding="utf-8")
-    (tmp_path / "broken_queue_timeseries.csv").write_text("time_s,relay\n0.0,a\n", encoding="utf-8")
+    (tmp_path / "broken_queue_timeseries.csv").write_text(
+        "time_s,relay\n0.0,a\n", encoding="utf-8"
+    )
     assert module._build_max_queue_comparison_frame({"broken": broken_queue}).empty
 
 
-def test_view_relay_resilience_discover_exception(monkeypatch, tmp_path) -> None:
+def test_view_relay_resilience_declares_all_app_scoped_state_keys() -> None:
     module = _load_relay_helpers()
-    broken_base = SimpleNamespace(glob=lambda _pattern: (_ for _ in ()).throw(RuntimeError("broken glob")))
-    assert module._discover_files(broken_base, "*.json") == []
-
-
-def test_view_relay_resilience_resets_app_scoped_state_on_active_app_change(tmp_path) -> None:
-    module = _load_relay_helpers()
-    first_app = tmp_path / "first_app"
-    second_app = tmp_path / "second_app"
-    first_app.mkdir()
-    second_app.mkdir()
-    module.st = SimpleNamespace(
-        session_state={
-            module.APP_SCOPE_KEY: str(first_app.resolve()),
-            module.RUN_SELECTION_KEY: ["old-run"],
-            module.DETAIL_RUN_KEY: "old-detail",
-            module.REFERENCE_RUN_KEY: "old-reference",
-            module.DATA_DIR_KEY: "/tmp/old-artifacts",
-            module.SUMMARY_GLOB_KEY: "*old.json",
-        }
-    )
-
-    assert module._reset_app_scoped_session_defaults(first_app) is False
-    assert module.RUN_SELECTION_KEY in module.st.session_state
-
-    assert module._reset_app_scoped_session_defaults(second_app) is True
-    assert module.st.session_state[module.APP_SCOPE_KEY] == str(second_app.resolve())
-    for key in module.APP_SCOPED_SESSION_DEFAULT_KEYS:
-        assert key not in module.st.session_state
+    assert set(module.APP_SCOPED_SESSION_DEFAULT_KEYS) == {
+        module.RUN_SELECTION_KEY,
+        module.DETAIL_RUN_KEY,
+        module.REFERENCE_RUN_KEY,
+        module.DATA_DIR_KEY,
+        module.SUMMARY_GLOB_KEY,
+    }
 
 
 def test_view_relay_resilience_warns_when_summary_glob_is_empty(
@@ -364,7 +363,9 @@ def test_view_relay_resilience_warns_when_summary_glob_is_empty(
     at = run_page_app_test(PAGE_PATH, project_dir, export_root=tmp_path / "export")
 
     assert not at.exception
-    assert any("No summary metrics file found" in warning.value for warning in at.warning)
+    assert any(
+        "No summary metrics file found" in warning.value for warning in at.warning
+    )
 
 
 def test_view_relay_resilience_requires_a_selected_run(
@@ -397,4 +398,6 @@ def test_view_relay_resilience_requires_a_selected_run(
     at.multiselect(key="relay_resilience_selected_runs").set_value([]).run()
 
     assert not at.exception
-    assert any("Select at least one run in the sidebar." in info.value for info in at.info)
+    assert any(
+        "Select at least one run in the sidebar." in info.value for info in at.info
+    )


### PR DESCRIPTION
## Summary

- Isolate queue- and relay-resilience page runtime sessions by app scope.
- Extract the shared queue resilience presentation helpers into the lightweight `agi-pages` package.
- Publish a coherent four-package hotfix metadata closure for fresh `agilab[ui]` and `agilab[pages]` installs.

## Repro

Opening the queue and relay resilience pages in one Streamlit session could reuse a stale or mismatched `AgiEnv` from another page. A stale private marker could also make a page appear correctly scoped when its live environment identity was not.

## Root Cause

Page-local session-state ownership did not revalidate the live `AgiEnv` identity after an app-scope transition, and the duplicated resilience views made a shared correction harder to apply consistently.

## Regression Test

Added focused coverage for scope transitions, stale private markers, conflicting live app identities, builtin-path equivalence, and both resilience page integrations.

## Validation

- 326 targeted tests passed.
- `workflow_parity.py --profile agi-gui` passed (3,689 passed, 5 skipped across its chunks).
- Dependency policy, app-contract, manifest, release-plan, version-policy, provenance, and wheel-install metadata checks passed.
- `uv lock --check` passed.
- GitHub checks passed: repo guardrails, Windows core tests, GitGuardian; public-demo-smoke was intentionally skipped.

## Release Scope

The next hotfix publish should select only `agilab`, `agi-pages`, `agi-page-queue-health`, and `agi-page-relay-health`, all at `2026.07.17.1`. This PR does not publish a release.

## Shared Core Approval

The user approved the required shared `agi-pages` recovery through the ongoing "doit" / "go on" direction. No `agi-core` path is changed.

## Review Evidence

- `/root/analyze_runtime_helper_recovery` (GPT-5): runtime design review only; no edits.
- `/root/assess_umbrella_hotfix` (GPT-5): package-release scope review only; no edits.
- `/root/final_hotfix_review` (GPT-5): final runtime and packaging review only; no edits; no actionable blocking, high, or medium findings.

## Agent Metadata

- Tokki: `1.0.29`
- Agent/runtime: Codex (version unavailable)
- Model: GPT-5
- Reasoning effort: unknown
- `/fast`: not used
