### PR TITLE
Add crash-recovery robustness evidence gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,8 @@ jobs:
             tools/agilab_web_robot.py \
             tools/newcomer_first_proof.py \
             tools/first_launch_robot.py \
+            tools/robustness_matrix.py \
+            tools/production_readiness_report.py \
             tools/security_hygiene_report.py \
             tools/install_release_proof_package.py \
             tools/public_proof_scenarios.py \
@@ -140,6 +142,14 @@ jobs:
         run: |
           set -euo pipefail
           python tools/public_proof_scenarios.py --compact
+
+      - name: Validate robustness recovery matrix
+        run: |
+          set -euo pipefail
+          uv --preview-features extra-build-dependencies run python tools/robustness_matrix.py \
+            --profile all \
+            --output robustness-matrix.json \
+            --compact
 
       - name: Validate Ruff local tool availability
         run: |
@@ -204,6 +214,7 @@ jobs:
           name: local-proof-artifacts
           path: |
             first-launch-robot.json
+            robustness-matrix.json
             app-contract-matrix.json
             frontend-smoke-robot.json
             frontend-smoke-screenshots/**

--- a/README.md
+++ b/README.md
@@ -475,11 +475,15 @@ hash-verifiable `.agipack` archive for portable handoff with
 signing with `agilab sign proof.agipack --key signer.pem --signature
 proof.agipack.sig.json` and trust-policy verification with `agilab verify
 proof.agipack --signature proof.agipack.sig.json --trust-policy policy.toml`.
-For fail-closed evidence, maintainers can run `./dev robust`; it executes a P0
-robustness matrix of synthetic bad states covering cluster shares, public UI
-binds, service health gates, evidence manifests, notebook import, app settings,
-and Streamlit route contracts. A scenario passes only when the bad state is
-rejected with a clear remediation and replay command.
+For fail-closed evidence, maintainers can run `./dev robust`; it executes the
+fast P0 matrix of synthetic bad states covering cluster shares, public UI binds,
+service health gates, evidence manifests, notebook import, app settings, and
+Streamlit route contracts. Run `./dev robust --profile p1-recovery` for stale
+runner-state conflict rejection, crash-partial agent-trace repair, interrupted
+workflow-evidence publication recovery, and immutable-manifest tamper detection.
+`./dev robust --profile all` runs both profiles and is the repository guardrail
+and production-readiness evidence gate. A scenario passes only when the bad
+state is rejected or recovered with a clear remediation and replay command.
 For adoption-surface evidence, maintainers can run `./dev app-contracts`; it
 checks that built-in apps, worker manifests, reducer expectations, promoted PyPI
 app packages, the app catalog, and public app docs stay aligned. The same guard

--- a/test/test_agilab_dev_shortcuts.py
+++ b/test/test_agilab_dev_shortcuts.py
@@ -223,6 +223,12 @@ def test_robust_shortcut_keeps_matrix_arguments():
     ]
 
 
+def test_robust_shortcut_usage_names_recovery_profiles():
+    usage = agilab_dev._usage()
+
+    assert "--profile p1-recovery or all" in usage
+
+
 def test_parallel_stage_shortcut_runs_parallel_stage_tool():
     assert agilab_dev.planned_commands(
         ["parallel-stage", "--check", "parallel_stage.toml"]

--- a/test/test_ci_workflow.py
+++ b/test/test_ci_workflow.py
@@ -197,6 +197,11 @@ def test_ci_workflow_includes_minimal_first_proof_contract() -> None:
     assert "uv --preview-features extra-build-dependencies run --extra dev ruff --version" in text
     assert "tools/app_contract_matrix.py --output app-contract-matrix.json --quiet" in text
     assert "app-contract-matrix.json" in text
+    assert "Validate robustness recovery matrix" in text
+    assert "tools/robustness_matrix.py" in text
+    assert "--profile all" in text
+    assert "--output robustness-matrix.json" in text
+    assert "robustness-matrix.json" in text
     assert "tools/ui_robot_matrix_aggregate.py" in text
     assert "Guard agi-core owner" in text
     assert "tools/agi_core_change_guard.py" in text
@@ -252,7 +257,7 @@ def test_windows_core_tests_workflow_matches_failure_tracker_command() -> None:
     assert "test-results/windows-core-warning-report.json" in text
     assert "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2" in text
     assert "actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6" in text
-    assert "astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0" in text
+    assert "astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2" in text
     assert "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7" in text
 
 

--- a/test/test_production_readiness_report.py
+++ b/test/test_production_readiness_report.py
@@ -35,6 +35,7 @@ def test_build_report_passes_static_production_readiness_contracts() -> None:
         "docs_workflow_parity_profile",
         "production_readiness_workflow_profile",
         "architecture_scorecard",
+        "runtime_robustness_matrix",
         "compatibility_matrix_validated_paths",
         "service_health_json_prometheus",
         "controlled_pilot_readiness_gate",
@@ -63,6 +64,7 @@ def test_build_report_includes_shared_adoption_hardening_controls() -> None:
         "cluster_share_fail_fast",
         "controlled_pilot_readiness_gate",
         "architecture_scorecard",
+        "runtime_robustness_matrix",
         "production_boundary_docs",
     }:
         check = checks[check_id]
@@ -126,6 +128,28 @@ def test_architecture_scorecard_is_scoped_and_evidence_backed() -> None:
         "architecture_capacity_model_trust_boundary",
         "architecture_hardening_gap_register",
         "architecture_claim_boundary",
+    }
+
+
+def test_runtime_robustness_matrix_executes_fail_closed_and_recovery_profiles() -> None:
+    module = _load_module()
+
+    report = module.build_report(run_docs_profile=False)
+    check = next(
+        check for check in report["checks"] if check["id"] == "runtime_robustness_matrix"
+    )
+
+    assert check["status"] == "pass"
+    assert check["details"]["profile"] == "all"
+    assert check["details"]["scenario_count"] >= 16
+    assert check["details"]["failed"] == []
+    assert check["details"]["missing_recovery_scenarios"] == []
+    assert {"runner-state", "agent-trace", "workflow-evidence"} <= set(
+        check["details"]["domains"]
+    )
+    assert set(check["evidence"]) == {
+        "tools/robustness_matrix.py",
+        "test/test_robustness_matrix.py",
     }
 
 

--- a/test/test_robustness_matrix.py
+++ b/test/test_robustness_matrix.py
@@ -37,6 +37,50 @@ def test_robustness_matrix_p0_passes_against_current_contracts() -> None:
     assert scenarios["invalid_notebook_import_fails_preflight"]["status"] == "pass"
     assert scenarios["streamlit_routes_do_not_hardcode_pages_directory"]["status"] == "pass"
     assert "replay_command" in scenarios["invalid_run_manifest_fails_verification"]
+    assert all(scenario["profiles"] == ["p0"] for scenario in scenarios.values())
+
+
+def test_robustness_matrix_p1_recovery_passes_against_current_contracts() -> None:
+    module = _load_module()
+
+    report = module.build_report(repo_root=Path.cwd(), profile=module.RECOVERY_PROFILE)
+
+    assert report["schema"] == module.SCHEMA
+    assert report["status"] == "pass"
+    assert report["profile"] == "p1-recovery"
+    assert report["available_profiles"] == ["p0", "p1-recovery", "all"]
+    assert report["summary"]["scenario_count"] >= 4
+    assert report["summary"]["failed"] == 0
+    scenarios = {scenario["id"]: scenario for scenario in report["scenarios"]}
+    assert {
+        "stale_runner_state_writer_is_rejected",
+        "crash_partial_agent_trace_tail_is_quarantined",
+        "interrupted_workflow_evidence_publish_recovers",
+        "tampered_workflow_evidence_manifest_is_rejected",
+    } <= set(scenarios)
+    assert all(
+        scenario["profiles"] == ["p1-recovery"] for scenario in scenarios.values()
+    )
+    assert scenarios["stale_runner_state_writer_is_rejected"]["details"][
+        "stale_write_preserved_current_state"
+    ] is True
+    assert scenarios["interrupted_workflow_evidence_publish_recovers"]["details"][
+        "hidden_after_failure"
+    ] is True
+
+
+def test_robustness_matrix_all_profile_combines_fail_closed_and_recovery() -> None:
+    module = _load_module()
+
+    report = module.build_report(repo_root=Path.cwd(), profile="all")
+
+    assert report["status"] == "pass"
+    assert report["profile"] == "all"
+    assert report["summary"]["scenario_count"] == len(module.SCENARIOS)
+    assert {scenario["profiles"][0] for scenario in report["scenarios"]} == {
+        "p0",
+        "p1-recovery",
+    }
 
 
 def test_robustness_matrix_reports_synthetic_failed_scenario() -> None:
@@ -112,3 +156,4 @@ def test_robustness_matrix_lists_scenarios(capsys) -> None:
     assert code == 0
     assert "cluster_share_same_as_local_fails_closed\tcluster" in captured.out
     assert "streamlit_routes_do_not_hardcode_pages_directory\tui-routing" in captured.out
+    assert "interrupted_workflow_evidence_publish_recovers\tworkflow-evidence" in captured.out

--- a/tools/agilab_dev.py
+++ b/tools/agilab_dev.py
@@ -562,7 +562,7 @@ High-frequency mappings:
   test      -> Run targeted pytest with -q and repo-wide coverage disabled, while keeping all extra pytest arguments.
   lint      -> Run Ruff through the repo dev extra on the default clean guardrail slice; pass paths for custom scope.
   regress   -> Use the GA regression selector on staged files and run the selected pytest subset.
-  robust    -> Run the P0 robustness matrix of fail-closed bad-state scenarios.
+  robust    -> Run P0 fail-closed scenarios; use --profile p1-recovery or all for recovery evidence.
   parallel-stage -> Create or validate a function + split rule + reducer contract for parallel execution.
   app-contracts -> Check built-in app, PyPI package, app catalog, and public-doc alignment.
   builtin-app-tests -> Run built-in app tests inside each app's own uv project environment.

--- a/tools/architecture_scorecard.py
+++ b/tools/architecture_scorecard.py
@@ -111,7 +111,7 @@ def _check_runtime_guardrails(repo_root: Path) -> dict[str, Any]:
         label="Runtime fail-closed guardrails",
         pass_summary=(
             "robustness matrix covers public UI bind, cluster share, evidence manifest, "
-            "notebook import, service, and route bad states"
+            "notebook import, service, route, stale-state, trace-repair, and evidence-recovery bad states"
         ),
         fail_summary="runtime robustness matrix does not cover the expected architecture guardrails",
         required={
@@ -121,9 +121,16 @@ def _check_runtime_guardrails(repo_root: Path) -> dict[str, Any]:
                 "missing_run_manifest_fails_verification",
                 "invalid_notebook_import_fails_preflight",
                 "service_unhealthy_workers_block_promotion",
+                "RECOVERY_PROFILE = \"p1-recovery\"",
+                "stale_runner_state_writer_is_rejected",
+                "crash_partial_agent_trace_tail_is_quarantined",
+                "interrupted_workflow_evidence_publish_recovers",
+                "tampered_workflow_evidence_manifest_is_rejected",
             ],
             "test/test_robustness_matrix.py": [
                 "test_robustness_matrix_p0_passes_against_current_contracts",
+                "test_robustness_matrix_p1_recovery_passes_against_current_contracts",
+                "test_robustness_matrix_all_profile_combines_fail_closed_and_recovery",
             ],
         },
     )

--- a/tools/production_readiness_report.py
+++ b/tools/production_readiness_report.py
@@ -282,6 +282,67 @@ def _check_architecture_scorecard(repo_root: Path) -> dict[str, Any]:
     )
 
 
+def _check_runtime_robustness_matrix(repo_root: Path) -> dict[str, Any]:
+    required_recovery_scenarios = {
+        "stale_runner_state_writer_is_rejected",
+        "crash_partial_agent_trace_tail_is_quarantined",
+        "interrupted_workflow_evidence_publish_recovers",
+        "tampered_workflow_evidence_manifest_is_rejected",
+    }
+    try:
+        robustness_matrix = _load_tool_module("robustness_matrix")
+        report = robustness_matrix.build_report(repo_root=repo_root, profile="all")
+        scenarios = report.get("scenarios", [])
+        scenario_ids = {
+            str(scenario.get("id"))
+            for scenario in scenarios
+            if isinstance(scenario, Mapping) and scenario.get("id")
+        }
+        failed = [
+            str(scenario.get("id"))
+            for scenario in scenarios
+            if isinstance(scenario, Mapping) and scenario.get("status") != "pass"
+        ]
+        missing_recovery_scenarios = sorted(required_recovery_scenarios - scenario_ids)
+        ok = (
+            report.get("schema") == robustness_matrix.SCHEMA
+            and report.get("profile") == "all"
+            and report.get("status") == "pass"
+            and not failed
+            and not missing_recovery_scenarios
+        )
+        summary = (
+            "the full fail-closed and crash-recovery robustness matrix passes"
+            if ok
+            else "the runtime robustness matrix is failing or missing required recovery scenarios"
+        )
+        details = {
+            "schema": report.get("schema"),
+            "profile": report.get("profile"),
+            "available_profiles": report.get("available_profiles", []),
+            "scenario_count": report.get("summary", {}).get("scenario_count", 0),
+            "domains": report.get("summary", {}).get("domains", []),
+            "failed": failed,
+            "missing_recovery_scenarios": missing_recovery_scenarios,
+        }
+    except Exception as exc:
+        ok = False
+        summary = str(exc)
+        details = {
+            "error": str(exc),
+            "failed": [],
+            "missing_recovery_scenarios": sorted(required_recovery_scenarios),
+        }
+    return _check_result(
+        "runtime_robustness_matrix",
+        "Runtime robustness matrix",
+        ok,
+        summary,
+        evidence=["tools/robustness_matrix.py", "test/test_robustness_matrix.py"],
+        details=details,
+    )
+
+
 def _check_compatibility_matrix(repo_root: Path) -> dict[str, Any]:
     matrix_path = repo_root / "docs" / "source" / "data" / "compatibility_matrix.toml"
     required_validated_ids = {
@@ -835,6 +896,7 @@ def build_report(*, repo_root: Path = REPO_ROOT, run_docs_profile: bool = False)
         _check_docs_workflow_profile(repo_root),
         _check_production_readiness_workflow_profile(repo_root),
         _check_architecture_scorecard(repo_root),
+        _check_runtime_robustness_matrix(repo_root),
         _check_compatibility_matrix(repo_root),
         _check_service_health_contract(repo_root),
         _check_controlled_pilot_readiness_gate(repo_root),

--- a/tools/robustness_matrix.py
+++ b/tools/robustness_matrix.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Run AGILAB P0 robustness scenarios against known bad states."""
+"""Run AGILAB fail-closed and crash-recovery robustness scenarios."""
 
 from __future__ import annotations
 
@@ -12,12 +12,13 @@ from pathlib import Path
 import re
 import sys
 import tempfile
-from typing import Any, Callable, Sequence
+from typing import Any, Callable, Mapping, Sequence
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCHEMA = "agilab.robustness_matrix.v1"
 DEFAULT_PROFILE = "p0"
+RECOVERY_PROFILE = "p1-recovery"
 
 
 def _ensure_repo_on_path(repo_root: Path) -> None:
@@ -317,6 +318,232 @@ def _streamlit_route_static_guard(repo_root: Path, tmp_root: Path) -> ScenarioOb
     )
 
 
+def _runner_state_stale_writer_rejected(repo_root: Path, tmp_root: Path) -> ScenarioObservation:
+    _ensure_repo_on_path(repo_root)
+    from agilab.global_pipeline.global_pipeline_runner_state import (
+        RunnerStateConflictError,
+        load_runner_state,
+        runner_state_revision,
+        write_runner_state,
+    )
+
+    state_path = tmp_root / "runner_state.json"
+    initial = {"generation": 1, "events": [{"kind": "created"}]}
+    current = {
+        "generation": 2,
+        "events": [{"kind": "created"}, {"kind": "completed"}],
+    }
+    write_runner_state(state_path, initial)
+    stale_revision = runner_state_revision(initial)
+    write_runner_state(state_path, current, expected_revision=stale_revision)
+
+    try:
+        write_runner_state(
+            state_path,
+            {"generation": 3, "events": [{"kind": "stale overwrite"}]},
+            expected_revision=stale_revision,
+        )
+    except RunnerStateConflictError as exc:
+        preserved = load_runner_state(state_path) == current
+        return ScenarioObservation(
+            passed=preserved and "another session" in str(exc),
+            observed=str(exc),
+            details={
+                "conflict_type": type(exc).__name__,
+                "current_generation": load_runner_state(state_path).get("generation"),
+                "stale_write_preserved_current_state": preserved,
+            },
+            evidence=("src/agilab/global_pipeline/global_pipeline_runner_state.py",),
+        )
+    return ScenarioObservation(
+        passed=False,
+        observed="A stale runner-state revision overwrote newer state.",
+        details={"current_state": load_runner_state(state_path)},
+        evidence=("src/agilab/global_pipeline/global_pipeline_runner_state.py",),
+    )
+
+
+def _agent_trace_partial_tail_recovers(repo_root: Path, tmp_root: Path) -> ScenarioObservation:
+    _ensure_repo_on_path(repo_root)
+    from agilab.agent_runtime.agent_trace import (
+        EVENTS_FILENAME,
+        AgentTraceStore,
+        load_trace_events,
+    )
+
+    partial_tail = b'{"partial"'
+    store = AgentTraceStore(tmp_root, run_id="robustness-recovery", agent="codex")
+    first = store.append("session_start")
+    with store.events_path.open("ab") as handle:
+        handle.write(partial_tail)
+
+    second = store.append("session_end", status="pass")
+    events = load_trace_events(tmp_root)
+    quarantined = sorted(tmp_root.glob(f".{EVENTS_FILENAME}.partial.*.jsonl"))
+    passed = (
+        (first.sequence, second.sequence) == (1, 2)
+        and [event.sequence for event in events] == [1, 2]
+        and len(quarantined) == 1
+        and quarantined[0].read_bytes() == partial_tail
+        and store.events_path.read_bytes().endswith(b"\n")
+    )
+    return ScenarioObservation(
+        passed=passed,
+        observed=(
+            "The crash-partial JSONL tail was quarantined and sequence 2 appended cleanly."
+            if passed
+            else "The crash-partial JSONL tail was not recovered without trace loss."
+        ),
+        details={
+            "event_sequences": [event.sequence for event in events],
+            "quarantine_count": len(quarantined),
+            "quarantined_bytes": len(quarantined[0].read_bytes()) if quarantined else 0,
+        },
+        evidence=("src/agilab/agent_runtime/agent_trace.py",),
+    )
+
+
+def _recovery_workflow_state() -> dict[str, Any]:
+    return {
+        "schema": "agilab.global_pipeline_runner_state.v1",
+        "run_id": "robustness-recovery",
+        "run_status": "completed",
+        "created_at": "2026-07-20T00:00:00Z",
+        "updated_at": "2026-07-20T00:00:01Z",
+        "source": {
+            "source_type": "multi_app_dag",
+            "dag_path": "",
+            "plan_schema": "agilab.multi_app_dag.v1",
+            "plan_runner_status": "controlled_contract_stage_execution",
+            "execution_order": [],
+        },
+        "summary": {
+            "unit_count": 0,
+            "completed_count": 0,
+            "failed_count": 0,
+            "available_artifact_ids": [],
+        },
+        "units": [],
+        "artifacts": [],
+        "events": [],
+    }
+
+
+def _write_recovery_runner_state(tmp_root: Path) -> tuple[Path, Path, dict[str, Any]]:
+    state = _recovery_workflow_state()
+    lab_dir = tmp_root / "lab"
+    state_path = lab_dir / ".agilab" / "runner_state.json"
+    state_path.parent.mkdir(parents=True)
+    state_path.write_text(json.dumps(state, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return lab_dir, state_path, state
+
+
+def _workflow_evidence_interrupted_publish_recovers(
+    repo_root: Path,
+    tmp_root: Path,
+) -> ScenarioObservation:
+    _ensure_repo_on_path(repo_root)
+    from agilab.workflow import workflow_run_manifest
+
+    lab_dir, state_path, state = _write_recovery_runner_state(tmp_root)
+    real_write = workflow_run_manifest._write_json_fsync
+    write_count = 0
+    injected_failure = False
+    failure_message = ""
+
+    def _fail_during_staging(path: Path, payload: Mapping[str, Any]) -> None:
+        nonlocal write_count
+        write_count += 1
+        real_write(path, payload)
+        if write_count == 2:
+            raise OSError("simulated evidence publication interruption")
+
+    workflow_run_manifest._write_json_fsync = _fail_during_staging
+    try:
+        workflow_run_manifest.write_workflow_run_evidence(
+            state=state,
+            state_path=state_path,
+            repo_root=repo_root,
+            lab_dir=lab_dir,
+            trigger={"surface": "robustness-matrix", "fault": "interrupted-publish"},
+        )
+    except OSError as exc:
+        injected_failure = "simulated evidence publication interruption" in str(exc)
+        failure_message = str(exc)
+    finally:
+        workflow_run_manifest._write_json_fsync = real_write
+
+    evidence_root = workflow_run_manifest.workflow_evidence_root(lab_dir)
+    latest_path = evidence_root / workflow_run_manifest.LATEST_WORKFLOW_EVIDENCE_FILENAME
+    partial_manifests = list(
+        evidence_root.glob(f"*/{workflow_run_manifest.WORKFLOW_RUN_MANIFEST_FILENAME}")
+    )
+    staging_dirs = list(evidence_root.glob(".*.staging"))
+    hidden_after_failure = not latest_path.exists() and not partial_manifests and not staging_dirs
+
+    bundle = workflow_run_manifest.write_workflow_run_evidence(
+        state=state,
+        state_path=state_path,
+        repo_root=repo_root,
+        lab_dir=lab_dir,
+        trigger={"surface": "robustness-matrix", "fault": "interrupted-publish"},
+    )
+    recovered = workflow_run_manifest.load_workflow_run_manifest(bundle.manifest_path)
+    passed = injected_failure and hidden_after_failure and recovered.get("status") == "pass"
+    return ScenarioObservation(
+        passed=passed,
+        observed=(
+            "Interrupted evidence staging stayed invisible and the same publication recovered cleanly."
+            if passed
+            else "Interrupted evidence staging leaked partial state or failed to recover."
+        ),
+        details={
+            "injected_failure": injected_failure,
+            "failure_message": failure_message,
+            "hidden_after_failure": hidden_after_failure,
+            "recovered_status": recovered.get("status"),
+            "staging_dirs_after_failure": len(staging_dirs),
+        },
+        evidence=("src/agilab/workflow/workflow_run_manifest.py",),
+    )
+
+
+def _workflow_evidence_tampering_rejected(repo_root: Path, tmp_root: Path) -> ScenarioObservation:
+    _ensure_repo_on_path(repo_root)
+    from agilab.workflow import workflow_run_manifest
+
+    lab_dir, state_path, state = _write_recovery_runner_state(tmp_root)
+    bundle = workflow_run_manifest.write_workflow_run_evidence(
+        state=state,
+        state_path=state_path,
+        repo_root=repo_root,
+        lab_dir=lab_dir,
+        trigger={"surface": "robustness-matrix", "fault": "manifest-tampering"},
+    )
+    manifest = json.loads(bundle.manifest_path.read_text(encoding="utf-8"))
+    manifest["status"] = "fail"
+    bundle.manifest_path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    try:
+        workflow_run_manifest.load_workflow_run_manifest(bundle.manifest_path)
+    except ValueError as exc:
+        message = str(exc)
+        return ScenarioObservation(
+            passed="completion hash mismatch" in message,
+            observed=message,
+            details={"exception_type": type(exc).__name__},
+            evidence=("src/agilab/workflow/workflow_run_manifest.py",),
+        )
+    return ScenarioObservation(
+        passed=False,
+        observed="A modified immutable workflow manifest passed verification.",
+        evidence=("src/agilab/workflow/workflow_run_manifest.py",),
+    )
+
+
 SCENARIOS: tuple[RobustnessScenario, ...] = (
     RobustnessScenario(
         id="cluster_share_same_as_local_fails_closed",
@@ -426,6 +653,46 @@ SCENARIOS: tuple[RobustnessScenario, ...] = (
         replay_command=_replay_command("streamlit_routes_do_not_hardcode_pages_directory"),
         runner=_streamlit_route_static_guard,
     ),
+    RobustnessScenario(
+        id="stale_runner_state_writer_is_rejected",
+        domain="runner-state",
+        fault="A stale session tries to overwrite a newer durable runner-state revision.",
+        expected_behavior="Reject the stale compare-and-swap write and preserve current state.",
+        remediation="Reload runner state and retry from the current revision.",
+        replay_command=_replay_command("stale_runner_state_writer_is_rejected"),
+        runner=_runner_state_stale_writer_rejected,
+        profiles=(RECOVERY_PROFILE,),
+    ),
+    RobustnessScenario(
+        id="crash_partial_agent_trace_tail_is_quarantined",
+        domain="agent-trace",
+        fault="An agent process stops after writing an unterminated partial JSONL record.",
+        expected_behavior="Quarantine only the partial tail and continue the event sequence without loss.",
+        remediation="Inspect the quarantine artifact, then replay from the preserved complete events.",
+        replay_command=_replay_command("crash_partial_agent_trace_tail_is_quarantined"),
+        runner=_agent_trace_partial_tail_recovers,
+        profiles=(RECOVERY_PROFILE,),
+    ),
+    RobustnessScenario(
+        id="interrupted_workflow_evidence_publish_recovers",
+        domain="workflow-evidence",
+        fault="Workflow evidence publication stops after only part of the staging bundle is written.",
+        expected_behavior="Expose no partial bundle and allow a clean retry of the same publication.",
+        remediation="Retry evidence publication; investigate the original filesystem interruption.",
+        replay_command=_replay_command("interrupted_workflow_evidence_publish_recovers"),
+        runner=_workflow_evidence_interrupted_publish_recovers,
+        profiles=(RECOVERY_PROFILE,),
+    ),
+    RobustnessScenario(
+        id="tampered_workflow_evidence_manifest_is_rejected",
+        domain="workflow-evidence",
+        fault="A completed immutable workflow manifest is modified after publication.",
+        expected_behavior="Reject the bundle because its completion-marker hash no longer matches.",
+        remediation="Restore or regenerate the workflow evidence bundle from trusted run state.",
+        replay_command=_replay_command("tampered_workflow_evidence_manifest_is_rejected"),
+        runner=_workflow_evidence_tampering_rejected,
+        profiles=(RECOVERY_PROFILE,),
+    ),
 )
 
 
@@ -442,6 +709,7 @@ def _scenario_to_result(
         "observed": observation.observed,
         "remediation": scenario.remediation,
         "replay_command": scenario.replay_command,
+        "profiles": list(scenario.profiles),
         "evidence": list(observation.evidence),
         "details": observation.details or {},
         "cleanup_status": "pending",
@@ -510,6 +778,7 @@ def build_report(
         "status": "pass" if not failed and results else "fail",
         "generated_at": datetime.now(timezone.utc).isoformat(),
         "profile": profile,
+        "available_profiles": [DEFAULT_PROFILE, RECOVERY_PROFILE, "all"],
         "summary": {
             "scenario_count": len(results),
             "passed": len(results) - len(failed),
@@ -524,13 +793,13 @@ def build_report(
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description=(
-            "Run synthetic P0 robustness scenarios. A scenario passes when the "
-            "known bad state is rejected with a clear recovery contract."
+            "Run fail-closed P0 or crash-recovery P1 robustness scenarios. A scenario "
+            "passes when the known bad state is rejected or recovered with a clear contract."
         )
     )
     parser.add_argument(
         "--profile",
-        choices=(DEFAULT_PROFILE, "all"),
+        choices=(DEFAULT_PROFILE, RECOVERY_PROFILE, "all"),
         default=DEFAULT_PROFILE,
         help="Scenario profile to run.",
     )


### PR DESCRIPTION
## Summary

- add a `p1-recovery` robustness profile covering stale runner-state compare-and-swap rejection, crash-partial agent-trace quarantine, interrupted workflow-evidence publication recovery, and immutable-manifest tamper rejection
- make `--profile all` executable production-readiness evidence and a CI artifact, while keeping the fast P0 profile as the default
- align README, shortcut help, architecture evidence, and focused regression tests
- repair the existing Windows workflow test assertion so it matches the setup-uv v8.3.2 pin introduced by Dependabot PR #804

## Repro

- `./dev robust` selected only the 12 synthetic P0 fail-closed scenarios; no crash/recovery scenario was available.
- The production-readiness report and repository CI could pass without executing recovery behavior.
- `test_windows_core_tests_workflow_matches_failure_tracker_command` expected setup-uv v8.1.0 although the workflow has used v8.3.2 since PR #804.

## Root Cause

The robustness registry had a single implicit P0 profile, and readiness/CI checked surrounding contracts without executing a full recovery matrix. The setup-uv test pin was not updated with the earlier automated workflow dependency bump.

## Regression Test

- added direct P1 and combined-profile matrix tests with state-preservation, partial-tail quarantine, invisible interrupted staging, clean retry, and tamper-detection assertions
- added executable production-readiness coverage for the full matrix
- added CI workflow assertions for the full-profile JSON artifact
- updated the stale setup-uv pin assertion to the workflow's current immutable SHA

## Validation

- `./dev robust --profile all --compact`: 16/16 scenarios passed across 10 domains
- production-readiness report: 16/16 checks passed
- architecture scorecard: 7/7 checks passed
- impact-selected pytest slice: 86 passed, 1 explicitly deselected
- focused Ruff and Python compilation: passed
- staged impact and scope guards: low risk, coherent scope
- commit and pre-push provenance/guard hooks: passed using the repo Python 3.13 dev environment
- GitHub: repo guardrails, Python 3.13/3.14 compatibility, Linux/macOS/Windows clean installs, Windows core tests, and GitGuardian passed; public demo smoke was not applicable and skipped by workflow policy
- skipped locally: `test_remote_dask_worker_command_quotes_dynamic_fragments` reproduces against unchanged `origin/main` because the protected agi-cluster implementation currently emits a different PID token. This PR does not touch shared core, and changing that protected path requires separate explicit approval.

## Review Evidence

- Reviewer: GPT-5 Codex
- Result: self-review completed; type-contract, extensibility, and CI-pin findings were addressed
- Sub-agents: not used; no sub-agent edited or reviewed files

## Agent Metadata

- Tokki version: unavailable (protected binary is stale; it requested `bin/build-protected-rust`)
- Agent/runtime: Codex / version unavailable
- Model: GPT-5 Codex
- Reasoning effort: unknown (not exposed)
- `/fast` mode: not used
- Sub-agents: not used
