### PR TITLE
Stabilize release-proof freshness fixture

### DIFF
--- a/test/test_release_proof_report.py
+++ b/test/test_release_proof_report.py
@@ -4,6 +4,7 @@ import importlib.util
 import json
 import shutil
 import sys
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
@@ -286,6 +287,7 @@ def test_release_proof_github_run_check_accepts_workflow_file_fallback_name(monk
         repo_root=Path.cwd(),
         github_repo="ThalesGroup/agilab",
         max_age_days=45,
+        now=datetime(2026, 6, 5, tzinfo=UTC),
     )
 
     assert check["status"] == "pass"


### PR DESCRIPTION
## Summary

- pin the positive GitHub workflow-name fallback test to an explicit UTC clock
- remove wall-clock dependence without changing release-proof production behavior
- restore the post-merge coverage workflow exposed after PR #838

## Repro

The post-merge coverage run [29724244209](https://github.com/ThalesGroup/agilab/actions/runs/29724244209) failed in `agi-gui (robots)`:

`test_release_proof_github_run_check_accepts_workflow_file_fallback_name` expected a pass, but its fixed `2026-06-04` run became older than the 45-day limit on 2026-07-20.

## Root Cause

The positive fallback-name fixture exercised freshness against the real wall clock. The production helper already accepts an injected `now`, but this test did not use it, so an unrelated naming-contract test expired with time.

## Regression Test

The test now supplies a fixed UTC `now` one day after its fake run. This keeps the workflow-name fallback contract isolated while the separate stale-run test continues to exercise freshness rejection.

## Validation

- `test/test_release_proof_report.py`: 14 passed
- focused Ruff: passed
- staged impact and scope guards: low risk, one test file
- commit and pre-push provenance/guard hooks: passed
- GitHub: release-proof verification, repo policy, Python 3.13/3.14 compatibility, Linux/macOS/Windows clean installs, Windows core tests, and GitGuardian passed; public demo smoke was not applicable and skipped by workflow policy
- skipped checks: none for the affected contract; broader product/UI validation is not applicable to this test-only clock fixture

## Review Evidence

- Reviewer: GPT-5 Codex
- Result: self-review completed; confirmed the production helper already exposes the correct clock-injection seam
- Sub-agents: not used; no sub-agent edited or reviewed files

## Agent Metadata

- Tokki version: unavailable (protected binary is stale; it requested `bin/build-protected-rust`)
- Agent/runtime: Codex / version unavailable
- Model: GPT-5 Codex
- Reasoning effort: unknown (not exposed)
- `/fast` mode: not used
- Sub-agents: not used
