### PR TITLE
Fix LinkSim worker deployment bootstrap

### DIFF
--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime/cleanup_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime/cleanup_support.py
@@ -30,6 +30,7 @@ from agi_env.runtime.destructive_path_support import (
 logger = logging.getLogger(__name__)
 REMOVE_DIR_RETRY_EXCEPTIONS = (OSError, shutil.Error)
 CMD_PREFIX_LOOKUP_EXCEPTIONS = (ConnectionError, OSError, RuntimeError, TimeoutError)
+_BOOTSTRAP_PSUTIL_SPEC = "psutil>=7,<8"
 _DASK_CMD_MARKERS = (
     "dask-scheduler",
     "dask-worker",
@@ -213,7 +214,12 @@ async def kill_processes(
         ip,
         detect_export_cmd_fn=detect_export_cmd_fn,
     )
-    kill_prefix = f"{cmd_prefix}{_remote_words(uv)} run --no-sync python"
+    # This copied bootstrap CLI runs before the worker environment exists.
+    # Process ownership discovery needs psutil, unlike lease and archive commands.
+    kill_prefix = (
+        f"{cmd_prefix}{_remote_words(uv)} run --no-sync "
+        f"--with {_remote_arg(_BOOTSTRAP_PSUTIL_SPEC)} python"
+    )
     if env.is_local(ip):
         if not cli_abs.exists():
             copy_fn(resolve_worker_cli_path(env), cli_abs)
@@ -798,6 +804,7 @@ async def clean_dirs(
     )
     cmd = (
         f"{cmd_prefix}{_remote_words(uv)} run --no-sync "
+        f"--with {_remote_arg(_BOOTSTRAP_PSUTIL_SPEC)} "
         f"-p {_remote_arg(env.python_version)} python "
         f"{_remote_arg(cli)} clean {_remote_arg(wenv)}{token_arg}"
     )

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime/transport_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime/transport_support.py
@@ -279,6 +279,17 @@ def _verbose_logging_enabled() -> bool:
     return verbose > 0 or bool(getattr(AgiEnv, "debug", False))
 
 
+def _loggable_ssh_command(cmd: str) -> str:
+    """Keep generated heredoc commands readable without changing execution."""
+
+    marker = "python3 - <<'PY'"
+    if marker not in cmd:
+        return cmd
+
+    prefix, _body = cmd.split(marker, 1)
+    return f"{prefix}{marker} [heredoc body omitted]"
+
+
 def is_private_ssh_key_file(path: Path) -> bool:
     """Return True when ``path`` looks like a usable private SSH key."""
 
@@ -614,7 +625,7 @@ async def exec_ssh(
 ) -> str:
     try:
         async with agi_cls.get_ssh_connection(ip) as conn:
-            msg = f"[{ip}] {cmd}"
+            msg = f"[{ip}] {_loggable_ssh_command(cmd)}"
             if _verbose_logging_enabled():
                 log.info(msg)
             result = await conn.run(cmd, check=True)

--- a/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/cli.py
+++ b/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/cli.py
@@ -3,13 +3,14 @@
 import os
 import sys
 import contextlib
+import importlib
 import signal
 import logging
 import json
 import hashlib
 import shlex
 import uuid
-from pathlib import Path, PureWindowsPath
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from tempfile import gettempdir
 import shutil
 import subprocess
@@ -18,10 +19,6 @@ import platform
 import threading
 import time
 import faulthandler
-
-import psutil
-
-from agi_env.data_archive_support import validate_archive_members_stay_within_dest
 
 faulthandler.enable()
 
@@ -81,7 +78,70 @@ _PID_RECORD_SCHEMA = "agilab-dask-pid-owner-v1"
 _PID_START_TOLERANCE_SECONDS = 1.0
 _REMOTE_TARGET_LEASE_SCHEMA = "agilab-remote-target-lease-v1"
 
+
+class _LazyPsutil:
+    """Load psutil only for process-management commands.
+
+    This module is copied to ``~/wenv/cli.py`` and lease commands execute it
+    before the worker environment, including optional third-party packages,
+    exists.
+    """
+
+    def __init__(self) -> None:
+        object.__setattr__(self, "_module", None)
+
+    def _load(self):
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            try:
+                module = importlib.import_module("psutil")
+            except ImportError as exc:
+                raise RuntimeError(
+                    "psutil is required for AGILAB process-management commands."
+                ) from exc
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+    def __setattr__(self, name, value) -> None:
+        if name == "_module":
+            object.__setattr__(self, name, value)
+            return
+        setattr(self._load(), name, value)
+
+    def __delattr__(self, name) -> None:
+        delattr(self._load(), name)
+
+
+psutil = _LazyPsutil()
+
 # ---------------- helpers ----------------
+def validate_archive_members_stay_within_dest(archive, dest: Path) -> None:
+    """Reject ZIP entries that escape ``dest`` without importing ``agi_env``."""
+
+    member_names = None
+    for method_name in ("getnames", "namelist"):
+        getnames = getattr(archive, method_name, None)
+        if callable(getnames):
+            member_names = [str(name) for name in getnames()]
+            break
+    if member_names is None:
+        return
+
+    resolved_dest = dest.resolve()
+    for member_name in member_names:
+        normalized = member_name.replace("\\", "/")
+        posix_member = PurePosixPath(normalized)
+        windows_member = PureWindowsPath(member_name)
+        if posix_member.is_absolute() or windows_member.is_absolute() or windows_member.drive:
+            raise RuntimeError(f"Unsafe archive member path in '{member_name}'")
+        target = (resolved_dest / Path(*posix_member.parts)).resolve()
+        if not target.is_relative_to(resolved_dest):
+            raise RuntimeError(f"Unsafe archive member path in '{member_name}'")
+
+
 def _resolved_destructive_path(value):
     try:
         return Path(value).expanduser().resolve(strict=False)

--- a/src/agilab/core/test/test_agi_distributor_cleanup_support.py
+++ b/src/agilab/core/test/test_agi_distributor_cleanup_support.py
@@ -306,6 +306,8 @@ async def test_kill_processes_cleans_pid_files_and_handles_local_and_remote_path
         "uv",
         "run",
         "--no-sync",
+        "--with",
+        "psutil>=7,<8",
         "python",
         "w env's/cli.py",
         "kill",
@@ -804,6 +806,8 @@ async def test_clean_dirs_removes_local_wenv_and_execs_remote(tmp_path):
         "/usr/bin/uv",
         "run",
         "--no-sync",
+        "--with",
+        "psutil>=7,<8",
         "-p",
         "3.13",
         "python",
@@ -844,11 +848,12 @@ async def test_remote_target_lease_token_wraps_remote_clean_lifecycle(tmp_path):
     await cleanup_support.release_remote_target_leases(agi_cls)
 
     assert lease.token == "a" * 32
-    assert [argv[7] for _ip, argv in calls] == [
+    assert [argv[argv.index("python") + 2] for _ip, argv in calls] == [
         "target-lease-acquire",
         "clean",
         "target-lease-release",
     ]
+    assert calls[1][1][3:5] == ["--with", "psutil>=7,<8"]
     assert calls[1][1][-1] == "a" * 32
     assert agi_cls._remote_target_leases == {}
 

--- a/src/agilab/core/test/test_agi_distributor_cli.py
+++ b/src/agilab/core/test/test_agi_distributor_cli.py
@@ -15,25 +15,13 @@ import pytest
 from agi_cluster.agi_distributor import cli as cli_mod
 
 
-def test_bootstrap_cli_runs_before_new_agi_env_is_installed(tmp_path):
-    legacy_root = tmp_path / "legacy-site"
-    legacy_agi_env = legacy_root / "agi_env"
-    legacy_agi_env.mkdir(parents=True)
-    (legacy_agi_env / "__init__.py").write_text("", encoding="utf-8")
-    (legacy_agi_env / "data_archive_support.py").write_text(
-        "def validate_archive_members_stay_within_dest(*args, **kwargs):\n"
-        "    return None\n",
-        encoding="utf-8",
-    )
+def test_bootstrap_cli_runs_without_worker_dependencies(tmp_path):
     bootstrap_cli = tmp_path / "worker-cli.py"
     shutil.copy2(Path(cli_mod.__file__), bootstrap_cli)
-    env = os.environ.copy()
-    env["PYTHONPATH"] = str(legacy_root)
 
     completed = subprocess.run(
-        [sys.executable, str(bootstrap_cli), "platform"],
+        [sys.executable, "-S", str(bootstrap_cli), "platform"],
         cwd=tmp_path,
-        env=env,
         capture_output=True,
         text=True,
         check=False,
@@ -41,6 +29,48 @@ def test_bootstrap_cli_runs_before_new_agi_env_is_installed(tmp_path):
     )
 
     assert completed.returncode == 0, completed.stderr
+
+
+def test_bootstrap_cli_manages_remote_lease_without_worker_dependencies(tmp_path):
+    bootstrap_cli = tmp_path / "worker-cli.py"
+    shutil.copy2(Path(cli_mod.__file__), bootstrap_cli)
+    target = tmp_path / "wenv" / "demo_worker"
+    token = "a" * 32
+
+    acquire = subprocess.run(
+        [
+            sys.executable,
+            "-S",
+            str(bootstrap_cli),
+            "target-lease-acquire",
+            str(target),
+            token,
+            "install",
+        ],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+    )
+    release = subprocess.run(
+        [
+            sys.executable,
+            "-S",
+            str(bootstrap_cli),
+            "target-lease-release",
+            str(target),
+            token,
+        ],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+    )
+
+    assert acquire.returncode == 0, acquire.stderr
+    assert release.returncode == 0, release.stderr
 
 
 def test_get_processes_containing_parses_unix_ps(monkeypatch):
@@ -1106,6 +1136,20 @@ def test_unzip_extracts_egg_contents(tmp_path):
     extracted = root / "src" / "demo_pkg" / "data.txt"
     assert extracted.exists()
     assert extracted.read_text(encoding="utf-8") == "hello"
+
+
+@pytest.mark.parametrize("member_name", ("../escape.txt", "/escape.txt", "C:\\escape.txt"))
+def test_unzip_rejects_archive_members_outside_worker_source(tmp_path, member_name):
+    root = tmp_path / "worker"
+    root.mkdir(parents=True, exist_ok=True)
+    egg_path = root / "unsafe.egg"
+    with zipfile.ZipFile(egg_path, "w") as zf:
+        zf.writestr(member_name, "unsafe")
+
+    with pytest.raises(RuntimeError, match="Unsafe archive member path"):
+        cli_mod.unzip(str(root))
+
+    assert not (tmp_path / "escape.txt").exists()
 
 
 def test_python_version_returns_structured_tag():

--- a/src/agilab/core/test/test_agi_distributor_transport_support.py
+++ b/src/agilab/core/test/test_agi_distributor_transport_support.py
@@ -12,6 +12,19 @@ import pytest
 from agi_cluster.agi_distributor import transport_support
 
 
+def test_loggable_ssh_command_omits_heredoc_body():
+    command = "export PATH=$PATH; python3 - <<'PY'\nsecret_body\nPY"
+
+    rendered = transport_support._loggable_ssh_command(command)
+
+    assert rendered == "export PATH=$PATH; python3 - <<'PY' [heredoc body omitted]"
+    assert "secret_body" not in rendered
+
+
+def test_loggable_ssh_command_preserves_regular_commands():
+    assert transport_support._loggable_ssh_command("uname -s") == "uname -s"
+
+
 @pytest.mark.asyncio
 async def test_send_file_local_relative_destination(monkeypatch, tmp_path):
     home = tmp_path / "home"

--- a/src/agilab/pages/2_ORCHESTRATE.py
+++ b/src/agilab/pages/2_ORCHESTRATE.py
@@ -2253,7 +2253,11 @@ async def _render_distribution_panel(
             else:
                 if snippet_exists and snippet_not_empty:
                     try:
-                        with _with_app_args_env(args_env):
+                        # External app forms commonly import their app package
+                        # directly (for example ``import link_sim``). Run them
+                        # from the selected app's source scope, not just the
+                        # AGILAB UI environment.
+                        with _active_app_import_scope(env), _with_app_args_env(args_env):
                             runpy.run_path(
                                 app_args_form,
                                 init_globals={**globals(), "env": args_env},

--- a/src/agilab/test/test_orchestrate_app_args_import_scope.py
+++ b/src/agilab/test/test_orchestrate_app_args_import_scope.py
@@ -1,0 +1,54 @@
+"""Regression coverage for external custom app argument forms."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+ORCHESTRATE_PAGE = (
+    Path(__file__).resolve().parents[2] / "agilab" / "pages" / "2_ORCHESTRATE.py"
+)
+
+
+def _is_call(expression: ast.expr, name: str) -> bool:
+    return (
+        isinstance(expression, ast.Call)
+        and isinstance(expression.func, ast.Name)
+        and expression.func.id == name
+    )
+
+
+def _contains_runpy_execution(node: ast.AST) -> bool:
+    return any(
+        isinstance(candidate, ast.Call)
+        and isinstance(candidate.func, ast.Attribute)
+        and isinstance(candidate.func.value, ast.Name)
+        and candidate.func.value.id == "runpy"
+        and candidate.func.attr == "run_path"
+        for candidate in ast.walk(node)
+    )
+
+
+def test_custom_app_args_form_execution_uses_active_app_import_scope():
+    """External forms can import their app package without an editable UI install."""
+
+    page_tree = ast.parse(ORCHESTRATE_PAGE.read_text(encoding="utf-8"))
+    scoped_form_execution = False
+    for node in ast.walk(page_tree):
+        if not isinstance(node, ast.With):
+            continue
+        context_expressions = [item.context_expr for item in node.items]
+        has_app_scope = any(
+            _is_call(expression, "_active_app_import_scope")
+            for expression in context_expressions
+        )
+        has_ui_scope = any(
+            _is_call(expression, "_with_app_args_env")
+            for expression in context_expressions
+        )
+        if has_app_scope and has_ui_scope and _contains_runpy_execution(node):
+            scoped_form_execution = True
+            break
+
+    assert scoped_form_execution


### PR DESCRIPTION
## Summary
- make the copied worker bootstrap CLI safe before the worker environment exists
- supply constrained `psutil` only to process-management commands
- scope custom app-form imports to the active external app and redact SSH heredoc bodies from logs

## Repro
Deploying LinkSim workers failed before installation because `wenv/cli.py` imported `psutil` at module import time, although the command runs before the worker virtual environment exists.

## Root Cause
The pre-install copied CLI had a top-level `psutil` dependency. LinkSim custom-form imports also lacked the external app import scope, and form defaults converted workflow-relative paths to the global share root.

## Regression Test
- bootstrap lease acquire/release succeeds under `python -S` without worker dependencies
- unsafe archive paths remain rejected
- cleanup commands request `psutil>=7,<8`
- custom forms execute inside the active app import scope
- SSH heredoc logging preserves execution while redacting only the emitted command body

## Validation
- focused AGILAB runtime, CLI, transport, and Orchestrate tests

## Review Evidence
- Reviewer: Codex GPT-5
- Result: reviewed; findings addressed
- Sub-agents: none

## Agent Metadata
- Tokki: `tokki-protected 1.0.29`
- Agent/runtime: Codex CLI, version unavailable
- Model: GPT-5
- Reasoning effort: unknown
- `/fast` mode: not used
