### PR TITLE
fix: restore July runtime safety contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,8 +479,10 @@ For fail-closed evidence, maintainers can run `./dev robust`; it executes the
 fast P0 matrix of synthetic bad states covering cluster shares, public UI binds,
 service health gates, evidence manifests, notebook import, app settings, and
 Streamlit route contracts. Run `./dev robust --profile p1-recovery` for stale
-runner-state conflict rejection, crash-partial agent-trace repair, interrupted
-workflow-evidence publication recovery, and immutable-manifest tamper detection.
+runner-state conflict rejection, crash-partial agent-trace repair after an owned
+child is abruptly terminated (`SIGKILL` on POSIX and `TerminateProcess` on
+Windows), interrupted workflow-evidence publication recovery, and
+immutable-manifest tamper detection.
 `./dev robust --profile all` runs both profiles and is the repository guardrail
 and production-readiness evidence gate. A scenario passes only when the bad
 state is rejected or recovered with a clear remediation and replay command.

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 276,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "077538e3339fa2cbd10e6102c0d4e9eef047b9817176ba7de6f047f1d787098d",
+  "source_digest_sha256": "3f45a141abcbf4793da72c46d7743ce4777e254af7c8e8b362a83bb6bfb45446",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "077538e3339fa2cbd10e6102c0d4e9eef047b9817176ba7de6f047f1d787098d"
+  "target_digest_sha256": "3f45a141abcbf4793da72c46d7743ce4777e254af7c8e8b362a83bb6bfb45446"
 }

--- a/docs/source/environment.rst
+++ b/docs/source/environment.rst
@@ -25,8 +25,11 @@ rather than shown as one of the workflow pages.
      - ``flight_telemetry_project``
      - App loaded when no explicit project is provided.
    * - ``AGI_PYTHON_VERSION``
-     - ``3.14``
-     - Default Python version passed to ``uv`` for the manager environment and as the fallback worker version when no host-specific override is set.
+     - repository ``.python-version`` (currently ``3.13``)
+     - Default Python version passed to ``uv`` for the manager environment and
+       as the fallback worker version when no host-specific override is set.
+       Installers validate the repository pin before creating or replacing an
+       environment.
    * - ``AGI_PYTHON_UV_SPEC``
      - derived from ``AGI_PYTHON_VERSION``
      - Exact uv interpreter selector used by installer sync commands. For Python 3.14 this defaults to the standard GIL build, for example ``3.14+gil``, while page bundles with stricter ``requires-python`` metadata receive a compatible selector such as ``3.12`` for ``==3.12.*``.

--- a/install.ps1
+++ b/install.ps1
@@ -589,16 +589,33 @@ function Test-SymlinkPrivilege {
     }
 }
 
+function Get-RepoPythonDefault {
+    $pinFile = Join-Path $CurrentPath ".python-version"
+    if (-not (Test-Path -LiteralPath $pinFile)) {
+        return "3.13"
+    }
+    try {
+        $pinned = (Get-Content -LiteralPath $pinFile -Raw -ErrorAction Stop).Trim()
+    } catch {
+        throw "Cannot read repository Python pin: $pinFile."
+    }
+    if ($pinned -notmatch '^\d+\.\d+(?:\.\d+)?$') {
+        throw "Invalid repository Python pin '$pinned' in $pinFile; expected major.minor or major.minor.patch."
+    }
+    return $pinned
+}
+
 function Select-PythonVersion {
     Write-Info "Choosing Python version..."
+    $defaultPython = Get-RepoPythonDefault
     if ($NonInteractiveMode) {
-        $requested = if (-not [string]::IsNullOrWhiteSpace($env:AGI_PYTHON_VERSION)) { $env:AGI_PYTHON_VERSION } else { "3.14" }
+        $requested = if (-not [string]::IsNullOrWhiteSpace($env:AGI_PYTHON_VERSION)) { $env:AGI_PYTHON_VERSION } else { $defaultPython }
         Write-Info "Non-interactive mode; defaulting Python version to $requested"
     } else {
-        $requested = Read-Host "Enter Python major version [3.14]"
+        $requested = Read-Host "Enter Python major version [$defaultPython]"
     }
     if ([string]::IsNullOrWhiteSpace($requested)) {
-        $requested = "3.14"
+        $requested = $defaultPython
     }
     Write-Info "You selected Python version $requested"
 
@@ -791,8 +808,8 @@ function Add-DefaultEnvComments {
 
     $existing = @(Get-Content -LiteralPath $EnvFile -ErrorAction SilentlyContinue)
     $defaults = @(
-        '# AGI_PYTHON_VERSION="3.14"',
-        '# 127.0.0.1_PYTHON_VERSION="3.14"',
+        '# AGI_PYTHON_VERSION="3.13"',
+        '# 127.0.0.1_PYTHON_VERSION="3.13"',
         '# AGI_PYTHON_FREE_THREADED="1"',
         '# IS_SOURCE_ENV="1"',
         '# IS_WORKER_ENV="0"',

--- a/install.sh
+++ b/install.sh
@@ -58,6 +58,27 @@ python_uv_spec_for_version() {
     esac
 }
 
+repo_python_default() {
+    local pin_file="${1:-${CURRENT_PATH:-.}/.python-version}"
+    local fallback="3.13"
+    if [[ ! -e "$pin_file" ]]; then
+        printf '%s\n' "$fallback"
+        return 0
+    fi
+    if [[ ! -r "$pin_file" ]]; then
+        echo -e "${RED}Cannot read repository Python pin: ${pin_file}.${NC}" >&2
+        return 1
+    fi
+
+    local pinned
+    IFS= read -r pinned < "$pin_file" || true
+    if [[ ! "$pinned" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
+        echo -e "${RED}Invalid repository Python pin '${pinned}' in ${pin_file}; expected major.minor or major.minor.patch.${NC}" >&2
+        return 1
+    fi
+    printf '%s\n' "$pinned"
+}
+
 configure_uv_link_mode() {
     local requested="${AGILAB_UV_LINK_MODE:-${UV_LINK_MODE:-hardlink}}"
     case "$requested" in
@@ -926,18 +947,20 @@ install_dependencies() {
 
 choose_python_version() {
     echo -e "${BLUE}Choosing Python version...${NC}"
+    local default_python
+    default_python="$(repo_python_default "${CURRENT_PATH}/.python-version")" || exit 1
     if (( NON_INTERACTIVE )); then
-        PYTHON_VERSION="${AGI_PYTHON_VERSION:-3.14}"
+        PYTHON_VERSION="${AGI_PYTHON_VERSION:-$default_python}"
         echo "Non-interactive mode; defaulting Python version to $PYTHON_VERSION"
     else
         if [[ -t 0 ]]; then
-            read -p "Enter Python major version [3.14]: " PYTHON_VERSION
+            read -p "Enter Python major version [${default_python}]: " PYTHON_VERSION
         else
-            PYTHON_VERSION="${AGI_PYTHON_VERSION:-3.14}"
+            PYTHON_VERSION="${AGI_PYTHON_VERSION:-$default_python}"
             echo "Non-interactive shell; defaulting Python version to $PYTHON_VERSION"
         fi
     fi
-    PYTHON_VERSION=${PYTHON_VERSION:-3.14}
+    PYTHON_VERSION=${PYTHON_VERSION:-$default_python}
     if [[ "$PYTHON_VERSION" == *freethreaded* \
        || "$PYTHON_VERSION" =~ (^|[^[:alnum:]])python3\.[0-9]+t([^[:alnum:]]|$) \
        || "$PYTHON_VERSION" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?t($|[^[:alnum:]]) ]]; then
@@ -1144,8 +1167,8 @@ append_default_env_comments() {
             printf '%s\n' "$line" >> "$env_file"
         fi
     done <<'EOF'
-# AGI_PYTHON_VERSION="3.14"
-# 127.0.0.1_PYTHON_VERSION="3.14"
+# AGI_PYTHON_VERSION="3.13"
+# 127.0.0.1_PYTHON_VERSION="3.13"
 # AGI_PYTHON_FREE_THREADED="1"
 # IS_SOURCE_ENV="1"
 # IS_WORKER_ENV="0"

--- a/src/agilab/apps-pages/autoencoder_latentspace/src/autoencoder_latentspace/autoencoder_latentspace.py
+++ b/src/agilab/apps-pages/autoencoder_latentspace/src/autoencoder_latentspace/autoencoder_latentspace.py
@@ -24,7 +24,12 @@ from agi_pages.runtime import ensure_repo_on_path, resolve_active_app_path
 
 ensure_repo_on_path(__file__)
 
-from agi_pages.runtime import active_app_scope_value, render_streamlit_page_header, reset_scoped_session_state
+from agi_pages.runtime import (
+    active_app_scope_value,
+    configure_streamlit_page,
+    render_streamlit_page_header,
+    reset_scoped_session_state,
+)
 from agi_env import AgiEnv
 from agi_env.app_settings_support import read_app_settings, update_app_settings_owned
 from agi_gui.pagelib import load_df, sidebar_views, initialize_csv_files, _dump_toml_payload
@@ -66,6 +71,7 @@ def _ae_key(name: str) -> str:
     return f"{PAGE_KEY}:{name}"
 
 
+configure_streamlit_page(st, title="Dimension Reduction")
 render_streamlit_page_header(st, title=":chart_with_downwards_trend: Dimension Reduction", show_logo=False)
 
 # Function to lazily import plotly

--- a/src/agilab/apps-pages/templates/analysis_page_template/src/view_demo/view_demo.py
+++ b/src/agilab/apps-pages/templates/analysis_page_template/src/view_demo/view_demo.py
@@ -36,7 +36,11 @@ def _load_project_env(active_app_path: Path) -> Any:
         st.error(f"Import error: {_AGI_ENV_IMPORT_ERROR}")
         st.stop()
 
-    return getattr(AgiEnv, "for_app", AgiEnv)(apps_path=active_app_path.parent, app=active_app_path.name, verbose=0)
+    return AgiEnv.session_for_app(
+        apps_path=active_app_path.parent,
+        app=active_app_path.name,
+        verbose=0,
+    )
 
 
 def _dataset_root(env: Any) -> Path | None:

--- a/src/agilab/apps-pages/view_barycentric/src/view_barycentric/view_barycentric.py
+++ b/src/agilab/apps-pages/view_barycentric/src/view_barycentric/view_barycentric.py
@@ -37,7 +37,11 @@ from agi_pages.runtime import ensure_repo_on_path, resolve_active_app_path
 
 ensure_repo_on_path(__file__)
 
-from agi_pages.runtime import render_streamlit_page_header, reset_scoped_session_state
+from agi_pages.runtime import (
+    configure_streamlit_page,
+    render_streamlit_page_header,
+    reset_scoped_session_state,
+)
 from agi_env import AgiEnv
 from agi_env.app_settings_support import read_app_settings, update_app_settings_owned
 from agi_gui.pagelib import find_files, load_df, JumpToMain, update_datadir, _dump_toml_payload
@@ -47,6 +51,7 @@ logger = logging.getLogger(__name__)
 var = ["discrete", "continuous", "lat", "long"]
 var_default = [0, None]
 
+configure_streamlit_page(st, title="Barycentric Graph")
 render_streamlit_page_header(st, title=":chart_with_upwards_trend: Barycentric Graph", show_logo=False)
 
 

--- a/src/agilab/apps-pages/view_maps/src/view_maps/view_maps.py
+++ b/src/agilab/apps-pages/view_maps/src/view_maps/view_maps.py
@@ -22,7 +22,7 @@ import plotly.express as px
 import plotly.graph_objects as go
 import streamlit as st
 import tomllib as _toml
-from agi_env.app_settings_support import prepare_app_settings_for_write, read_app_settings
+from agi_env.app_settings_support import read_app_settings, update_app_settings_owned
 from agi_pages.runtime import ensure_repo_on_path, resolve_active_app_path
 
 try:
@@ -50,6 +50,7 @@ except ModuleNotFoundError:  # pragma: no cover - fallback for lightweight envs
 ensure_repo_on_path(__file__)
 
 from agi_pages.runtime import (
+    configure_streamlit_page,
     render_app_page_context,
     render_streamlit_page_header,
     reset_scoped_session_state,
@@ -180,6 +181,7 @@ def _visible_dataset_files(datadir: Path, files: list[Path]) -> list[Path]:
         visible_files.append(file_path)
     return visible_files
 
+configure_streamlit_page(st, title="Cartography Visualization")
 render_streamlit_page_header(st, title=":world_map: Cartography Visualization", show_logo=False)
 
 
@@ -367,20 +369,14 @@ def _persist_view_maps_settings(
     env: AgiEnv,
     base_settings: dict,
     view_settings: dict,
-    owned_keys: tuple[str, ...] = (),
+    owned_keys: tuple[str, ...],
 ) -> dict:
     """Write the updated view_maps settings back to disk."""
     payload = dict(base_settings) if isinstance(base_settings, dict) else {}
     payload["view_maps"] = view_settings
     if not owned_keys:
-        try:
-            with open(env.app_settings_file, "wb") as fh:
-                _dump_toml_payload(prepare_app_settings_for_write(payload), fh)
-        except (OSError, RuntimeError):
-            pass
         return payload
     try:
-        from agi_env.app_settings_support import update_app_settings_owned
         latest, _ = update_app_settings_owned(
             env.app_settings_file,
             payload,
@@ -466,7 +462,9 @@ def page(env):
     st.session_state["_view_maps_last_datadir"] = str(datadir)
     if view_settings.get("datadir") != st.session_state["datadir"]:
         view_settings["datadir"] = st.session_state["datadir"]
-        full_settings = _persist_view_maps_settings(env, full_settings, view_settings)
+        full_settings = _persist_view_maps_settings(
+            env, full_settings, view_settings, ("datadir",)
+        )
     datadir_widget_key = _vm_key("input_datadir")
     if st.session_state.get(datadir_widget_key) != st.session_state["datadir"]:
         st.session_state[datadir_widget_key] = st.session_state["datadir"]
@@ -811,7 +809,9 @@ def page(env):
     )
     if overlay_default != show_coordinate_overlay:
         view_settings["show_coordinate_overlay"] = show_coordinate_overlay
-        full_settings = _persist_view_maps_settings(env, full_settings, view_settings)
+        full_settings = _persist_view_maps_settings(
+            env, full_settings, view_settings, ("show_coordinate_overlay",)
+        )
 
     overlay_lat_col = None
     overlay_lon_col = None
@@ -861,7 +861,9 @@ def page(env):
             }.items():
                 if view_settings.get(setting_name) != setting_value:
                     view_settings[setting_name] = setting_value
-                    full_settings = _persist_view_maps_settings(env, full_settings, view_settings)
+                    full_settings = _persist_view_maps_settings(
+                        env, full_settings, view_settings, (setting_name,)
+                    )
         else:
             st.sidebar.caption("No coordinate columns available for overlay.")
 
@@ -891,7 +893,9 @@ def page(env):
     )
     if view_settings.get("unique_threshold", 10) != unique_threshold:
         view_settings["unique_threshold"] = int(unique_threshold)
-        full_settings = _persist_view_maps_settings(env, full_settings, view_settings)
+        full_settings = _persist_view_maps_settings(
+            env, full_settings, view_settings, ("unique_threshold",)
+        )
 
     range_default = int(view_settings.get("range_threshold", 200))
     range_threshold_key = _vm_key("range_threshold")
@@ -909,7 +913,9 @@ def page(env):
     )
     if view_settings.get("range_threshold", 200) != range_threshold:
         view_settings["range_threshold"] = int(range_threshold)
-        full_settings = _persist_view_maps_settings(env, full_settings, view_settings)
+        full_settings = _persist_view_maps_settings(
+            env, full_settings, view_settings, ("range_threshold",)
+        )
 
     # Loop through numeric columns and classify them based on the unique value count.
     for col in numeric_cols:
@@ -1117,16 +1123,18 @@ def page(env):
         "long",
         "coltype",
     ]
-    mutated = False
+    changed_keys: list[str] = []
     for key in persist_keys:
         val = st.session_state.get(key)
         if val is None:
             continue
         if view_settings.get(key) != val:
             view_settings[key] = val
-            mutated = True
-    if mutated:
-        full_settings = _persist_view_maps_settings(env, full_settings, view_settings)
+            changed_keys.append(key)
+    if changed_keys:
+        full_settings = _persist_view_maps_settings(
+            env, full_settings, view_settings, tuple(changed_keys)
+        )
 
 # -------------------- Main Application Entry -------------------- #
 def main():
@@ -1153,7 +1161,7 @@ def main():
         st.session_state["app"] = app
 
         render_app_page_context(st, app, active_app)
-        env = getattr(AgiEnv, "for_app", AgiEnv)(
+        env = AgiEnv.session_for_app(
             apps_path=active_app.parent,
             app=app,
             verbose=1,

--- a/src/agilab/apps-pages/view_maps_3d/src/view_maps_3d/view_maps_3d.py
+++ b/src/agilab/apps-pages/view_maps_3d/src/view_maps_3d/view_maps_3d.py
@@ -31,7 +31,11 @@ logger = AgiLogger.get_logger(__name__)
 
 ensure_repo_on_path(__file__)
 
-from agi_pages.runtime import render_streamlit_page_header, reset_scoped_session_state
+from agi_pages.runtime import (
+    configure_streamlit_page,
+    render_streamlit_page_header,
+    reset_scoped_session_state,
+)
 
 
 def _default_app() -> Path | None:
@@ -172,6 +176,7 @@ def _list_dataset_files(base_dir: Path, ext_choice: str = "all") -> list[Path]:
     return visible
 
 
+configure_streamlit_page(st, title="Cartography-3D Visualization")
 render_streamlit_page_header(st, title=":world_map: Cartography-3D Visualization", show_logo=False)
 
 

--- a/src/agilab/apps-pages/view_maps_network/src/view_maps_network/view_maps_network.py
+++ b/src/agilab/apps-pages/view_maps_network/src/view_maps_network/view_maps_network.py
@@ -27,7 +27,7 @@ import matplotlib.colors as mcolors
 import glob
 import re
 from urllib.parse import quote, urlencode
-from agi_env.app_settings_support import prepare_app_settings_for_write
+from agi_env.app_settings_support import update_app_settings_owned
 try:
     import tomli_w as _toml_writer  # type: ignore[import-not-found]
 
@@ -198,7 +198,9 @@ def _get_cmap(name: str, lut: int | None = None):
 ensure_repo_on_path(__file__)
 
 from agi_pages.runtime import (
+    configure_streamlit_page,
     ensure_app_settings_loaded,
+    ensure_app_scoped_env,
     render_app_page_context,
     render_streamlit_page_header,
     resolve_active_app_path,
@@ -326,18 +328,30 @@ def _sanitize_toml_payload(value: Any) -> Any:
     return value
 
 
-def _persist_app_settings(env: AgiEnv) -> None:
+def _persist_app_settings(env: AgiEnv, owned_keys: tuple[str, ...]) -> None:
     settings = st.session_state.get("app_settings")
     if not isinstance(settings, dict):
         return
+    vm_settings = settings.get("view_maps_network")
+    if not isinstance(vm_settings, dict):
+        vm_settings = {}
+    if not owned_keys:
+        return
     path = Path(env.app_settings_file)
     try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        with open(path, "wb") as handle:
-            _dump_toml(
-                prepare_app_settings_for_write(_sanitize_toml_payload(settings), sanitize=False),
-                handle,
-            )
+        latest, _ = update_app_settings_owned(
+            path,
+            _sanitize_toml_payload(settings),
+            owned_paths=tuple(("view_maps_network", key) for key in owned_keys),
+            dump_fn=_dump_toml,
+        )
+        latest_vm_settings = latest.get("view_maps_network")
+        vm_settings.clear()
+        if isinstance(latest_vm_settings, dict):
+            vm_settings.update(latest_vm_settings)
+        settings.clear()
+        settings.update(latest)
+        settings["view_maps_network"] = vm_settings
     except (OSError, RuntimeError, ValueError) as exc:
         logger.warning(f"Unable to persist app_settings to {path}: {exc}")
 
@@ -378,6 +392,7 @@ def _list_subdirectories(base: Path) -> list[str]:
     return []
 
 
+configure_streamlit_page(st, title="Maps Network Graph")
 render_streamlit_page_header(
     st,
     title=":world_map: Maps Network Graph",
@@ -385,19 +400,31 @@ render_streamlit_page_header(
 )
 
 active_app_path = resolve_active_app_path(error_fn=st.error, stop_fn=st.stop)
-app_scope_changed = _reset_app_scoped_session_state(active_app_path)
-if 'env' not in st.session_state or app_scope_changed:
-    app_name = active_app_path.name
-    env = getattr(AgiEnv, "for_app", AgiEnv)(apps_path=active_app_path.parent, app=app_name, verbose=0)
-    env.init_done = True
-    st.session_state['env'] = env
-    st.session_state['IS_SOURCE_ENV'] = env.is_source_env
-    st.session_state['IS_WORKER_ENV'] = env.is_worker_env
-    st.session_state['apps_path'] = str(active_app_path.parent)
-    st.session_state['app'] = app_name
-else:
-    env = st.session_state['env']
-    app_name, active_app_path = _active_app_context_from_env(env)
+
+
+def _create_env(app_path: Path) -> AgiEnv:
+    scoped_env = AgiEnv.session_for_app(
+        apps_path=app_path.parent,
+        app=app_path.name,
+        verbose=0,
+    )
+    scoped_env.init_done = True
+    return scoped_env
+
+
+env = ensure_app_scoped_env(
+    st.session_state,
+    active_app_path,
+    scope_key=APP_SCOPE_KEY,
+    env_factory=_create_env,
+    keys=APP_SCOPED_SESSION_DEFAULT_KEYS,
+    prefixes=APP_SCOPED_SESSION_KEY_PREFIXES,
+)
+app_name = active_app_path.name
+st.session_state['IS_SOURCE_ENV'] = env.is_source_env
+st.session_state['IS_WORKER_ENV'] = env.is_worker_env
+st.session_state['apps_path'] = str(active_app_path.parent)
+st.session_state['app'] = active_app_path.name
 
 ensure_app_settings_loaded(st.session_state, env)
 render_app_page_context(st, app_name, active_app_path)
@@ -2956,15 +2983,15 @@ def page():
         "layout_type_select": st.session_state.get("layout_type_select", "spring"),
         "metric_type_select": st.session_state.get("metric_type_select", ""),
     }
-    vm_mutated = False
+    vm_changed_keys: list[str] = []
     for key, value in new_vm_settings.items():
         if split_view_mode and key in {"show_map", "show_graph"}:
             continue
         if vm_settings.get(key) != value:
             vm_settings[key] = value
-            vm_mutated = True
-    if vm_mutated:
-        _persist_app_settings(env)
+            vm_changed_keys.append(key)
+    if vm_changed_keys:
+        _persist_app_settings(env, tuple(vm_changed_keys))
 
     datadir_path = Path(st.session_state.datadir).expanduser()
     def _visible_only(paths):
@@ -3310,7 +3337,7 @@ def page():
     st.sidebar.caption(f"{shown_count} / {len(available_node_ids)} flights shown")
     if vm_settings.get("selected_flights_filter") != selected_node_ids:
         vm_settings["selected_flights_filter"] = selected_node_ids
-        _persist_app_settings(env)
+        _persist_app_settings(env, ("selected_flights_filter",))
 
     if selected_node_set:
         df_std = df_std[df_std["id_col"].isin(selected_node_set)].copy()
@@ -3408,7 +3435,7 @@ def page():
 
     if vm_settings.get("edges_file") != edges_clean:
         vm_settings["edges_file"] = edges_clean
-        _persist_app_settings(env)
+        _persist_app_settings(env, ("edges_file",))
 
     link_options = _detect_link_columns(df_std)
     if loaded_edges:
@@ -4178,7 +4205,10 @@ def page():
         vm_settings["allocations_file"] = alloc_clean
         vm_settings["baseline_allocations_file"] = baseline_clean
         vm_settings["traj_glob"] = traj_clean
-        _persist_app_settings(env)
+        _persist_app_settings(
+            env,
+            ("allocations_file", "baseline_allocations_file", "traj_glob"),
+        )
     alloc_df = (
         load_allocations(alloc_path_obj)
         if alloc_path_obj is not None and alloc_path_obj.exists()

--- a/src/agilab/apps-pages/view_queue_resilience/src/view_queue_resilience/view_queue_resilience.py
+++ b/src/agilab/apps-pages/view_queue_resilience/src/view_queue_resilience/view_queue_resilience.py
@@ -54,9 +54,20 @@ def _load_page_meta() -> tuple[str, str]:
 
 PAGE_LOGO, PAGE_TITLE = _load_page_meta()
 
+
+def _create_env(active_app_path: Path) -> AgiEnv:
+    env = AgiEnv.session_for_app(
+        apps_path=active_app_path.parent,
+        app=active_app_path.name,
+        verbose=0,
+    )
+    env.init_done = True
+    return env
+
+
 page_context = prepare_queue_resilience_page(
     st,
-    AgiEnv,
+    env_factory=_create_env,
     title=PAGE_TITLE,
     logo_title=PAGE_LOGO,
     caption=(

--- a/src/agilab/apps-pages/view_relay_resilience/src/view_relay_resilience/view_relay_resilience.py
+++ b/src/agilab/apps-pages/view_relay_resilience/src/view_relay_resilience/view_relay_resilience.py
@@ -158,9 +158,19 @@ def _build_max_queue_comparison_frame(selected_paths: dict[str, Path]) -> pd.Dat
     return pd.concat(queue_frames, axis=1).sort_index()
 
 
+def _create_env(active_app_path: Path) -> AgiEnv:
+    env = AgiEnv.session_for_app(
+        apps_path=active_app_path.parent,
+        app=active_app_path.name,
+        verbose=0,
+    )
+    env.init_done = True
+    return env
+
+
 page_context = prepare_queue_resilience_page(
     st,
-    AgiEnv,
+    env_factory=_create_env,
     title="Relay resilience analysis",
     logo_title="Relay Resilience Analysis",
     caption=(

--- a/src/agilab/apps-pages/view_release_decision/src/view_release_decision/view_release_decision.py
+++ b/src/agilab/apps-pages/view_release_decision/src/view_release_decision/view_release_decision.py
@@ -2066,7 +2066,11 @@ configure_streamlit_page(st, title="Evidence cockpit")
 active_app_path = resolve_active_app_path(error_fn=st.error, stop_fn=st.stop)
 existing_env = st.session_state.get("env")
 if existing_env is None or Path(getattr(existing_env, "active_app", "")).resolve() != active_app_path.resolve():
-    env = getattr(AgiEnv, "for_app", AgiEnv)(apps_path=active_app_path.parent, app=active_app_path.name, verbose=0)
+    env = AgiEnv.session_for_app(
+        apps_path=active_app_path.parent,
+        app=active_app_path.name,
+        verbose=0,
+    )
     env.init_done = True
     st.session_state["env"] = env
 else:

--- a/src/agilab/apps-pages/view_training_analysis/src/view_training_analysis/view_training_analysis.py
+++ b/src/agilab/apps-pages/view_training_analysis/src/view_training_analysis/view_training_analysis.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 from collections import Counter
+import logging
 import math
 from pathlib import Path
 from typing import Any
@@ -14,7 +15,7 @@ import plotly.graph_objects as go
 from plotly.colors import qualitative as plotly_qualitative
 from plotly.subplots import make_subplots
 import streamlit as st
-from agi_env.app_settings_support import prepare_app_settings_for_write
+from agi_env.app_settings_support import update_app_settings_owned
 from agi_pages.runtime import (
     configure_streamlit_page,
     ensure_app_settings_loaded,
@@ -24,6 +25,8 @@ from agi_pages.runtime import (
     render_streamlit_page_header,
     resolve_active_app_path,
 )
+
+logger = logging.getLogger(__name__)
 
 try:
     import tomli_w as _toml_writer  # type: ignore[import-not-found]
@@ -98,7 +101,7 @@ def _ensure_app_scoped_env() -> AgiEnv:
     active_app_path = resolve_active_app_path(error_fn=st.error, stop_fn=st.stop)
 
     def _create_env(app_path: Path) -> AgiEnv:
-        env = getattr(AgiEnv, "for_app", AgiEnv)(
+        env = AgiEnv.session_for_app(
             apps_path=app_path.parent,
             app=app_path.name,
             verbose=0,
@@ -115,21 +118,32 @@ def _ensure_app_scoped_env() -> AgiEnv:
     )
 
 
-def _persist_app_settings(env: AgiEnv) -> None:
+def _persist_app_settings(env: AgiEnv, owned_keys: tuple[str, ...]) -> None:
     settings = st.session_state.get("app_settings")
     if not isinstance(settings, dict):
         return
+    page_settings = settings.get(PAGE_KEY)
+    if not isinstance(page_settings, dict):
+        page_settings = {}
+    if not owned_keys:
+        return
     path = Path(env.app_settings_file)
     try:
-        prepared_settings = prepare_app_settings_for_write(settings)
-    except ValueError:
-        return
-    try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        with path.open("wb") as handle:
-            _dump_toml(prepared_settings, handle)
-    except (OSError, RuntimeError):
-        pass
+        latest, _ = update_app_settings_owned(
+            path,
+            settings,
+            owned_paths=tuple((PAGE_KEY, key) for key in owned_keys),
+            dump_fn=_dump_toml,
+        )
+        latest_page_settings = latest.get(PAGE_KEY)
+        page_settings.clear()
+        if isinstance(latest_page_settings, dict):
+            page_settings.update(latest_page_settings)
+        settings.clear()
+        settings.update(latest)
+        settings[PAGE_KEY] = page_settings
+    except (OSError, RuntimeError) as exc:
+        logger.warning("Unable to persist app_settings to %s: %s", path, exc)
 
 
 def _get_page_state() -> dict[str, Any]:
@@ -702,7 +716,9 @@ def main() -> None:
                 "x_axis": st.session_state.get(X_AXIS_KEY, "step"),
             }
         )
-        _persist_app_settings(env)
+        _persist_app_settings(
+            env, ("base_dir_choice", "input_datadir", "datadir_rel", "x_axis")
+        )
         st.stop()
 
     trainer_roots = _discover_training_roots(data_root)
@@ -716,7 +732,9 @@ def main() -> None:
                 "x_axis": st.session_state.get(X_AXIS_KEY, "step"),
             }
         )
-        _persist_app_settings(env)
+        _persist_app_settings(
+            env, ("base_dir_choice", "input_datadir", "datadir_rel", "x_axis")
+        )
         st.stop()
 
     trainer_labels = {_relative_label(path, data_root): path for path in trainer_roots}
@@ -827,7 +845,20 @@ def main() -> None:
             "x_axis": x_axis_option,
         }
     )
-    _persist_app_settings(env)
+    _persist_app_settings(
+        env,
+        (
+            "base_dir_choice",
+            "input_datadir",
+            "datadir_rel",
+            "trainer_rel",
+            "trainer_rels",
+            "run_rel",
+            "run_rels",
+            "selected_tags",
+            "x_axis",
+        ),
+    )
 
 
 if __name__ == "__main__":  # pragma: no cover - script entrypoint

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime/cleanup_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime/cleanup_support.py
@@ -12,7 +12,7 @@ import stat
 import sys
 import time
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePath, PurePosixPath
 from tempfile import gettempdir
 from typing import Any, Awaitable, Callable, Optional
 
@@ -21,6 +21,7 @@ from asyncssh.process import ProcessError
 
 from agi_cluster.agi_distributor.api.worker_cli_support import resolve_worker_cli_path
 from agi_env import AgiEnv
+from agi_env.process_support import project_virtualenv_script_path
 from agi_env.runtime.destructive_path_support import (
     safe_destructive_path,
     safe_worker_runtime_cleanup_path,
@@ -55,13 +56,58 @@ class RemoteTargetLease:
 
 
 def _remote_arg(value: Any) -> str:
-    if isinstance(value, Path):
+    if isinstance(value, PurePath):
         return shlex.quote(value.as_posix())
     return shlex.quote(str(value))
 
 
 def _remote_words(value: Any) -> str:
     return " ".join(shlex.quote(part) for part in shlex.split(str(value), posix=True))
+
+
+def _bootstrap_uv_python(uv: Any, *, python_version: Any | None = None) -> str:
+    """Return the dependency bootstrap used only when no worker venv exists."""
+
+    version_arg = (
+        f" -p {_remote_arg(python_version)}" if python_version not in (None, "") else ""
+    )
+    # PEP 508 comparison operators trigger AGILAB's shell-aware runner.  Double
+    # quotes preserve this one controlled token under both POSIX shells and
+    # Windows cmd.exe; shlex.quote would emit POSIX-only single quotes.
+    return (
+        f'{_remote_words(uv)} run --no-sync --with "{_BOOTSTRAP_PSUTIL_SPEC}"'
+        f"{version_arg} python"
+    )
+
+
+def _remote_worker_python(wenv: Any) -> PurePosixPath:
+    if isinstance(wenv, PurePath):
+        text = wenv.as_posix()
+    else:
+        text = str(wenv).replace("\\", "/")
+    return PurePosixPath(text) / ".venv" / "bin" / "python"
+
+
+def _remote_process_command(
+    *,
+    cmd_prefix: str,
+    uv: Any,
+    wenv: Any,
+    cli: Any,
+    action: str,
+    arguments: tuple[Any, ...],
+    python_version: Any | None = None,
+) -> str:
+    """Prefer installed worker dependencies and fall back only when absent."""
+
+    worker_python = _remote_worker_python(wenv)
+    rendered_args = "".join(f" {_remote_arg(value)}" for value in arguments)
+    payload = f"{_remote_arg(cli)} {action}{rendered_args}"
+    return (
+        f"{cmd_prefix}if [ -x {_remote_arg(worker_python)} ]; then "
+        f"{_remote_arg(worker_python)} {payload}; else "
+        f"{_bootstrap_uv_python(uv, python_version=python_version)} {payload}; fi"
+    )
 
 
 def _remote_target_key(value: Any) -> str:
@@ -197,6 +243,7 @@ async def kill_processes(
     run_path_fn: Callable[..., Any] = runpy.run_path,
     sys_module: Any = sys,
     path_cls: type[Path] = Path,
+    os_name: str = os.name,
     detect_export_cmd_fn: Optional[Callable[[str], Awaitable[str]]] = None,
     log: Any = logger,
 ) -> Optional[Any]:
@@ -206,7 +253,6 @@ async def kill_processes(
     ip = ip or localhost
     current_pid = current_pid or os.getpid()
 
-    cmds: list[str] = []
     cli_rel = env.wenv_rel.parent / "cli.py"
     cli_abs = env.wenv_abs.parent / cli_rel.name
     cmd_prefix = await _remote_cmd_prefix(
@@ -214,49 +260,65 @@ async def kill_processes(
         ip,
         detect_export_cmd_fn=detect_export_cmd_fn,
     )
-    # This copied bootstrap CLI runs before the worker environment exists.
-    # Process ownership discovery needs psutil, unlike lease and archive commands.
-    kill_prefix = (
-        f"{cmd_prefix}{_remote_words(uv)} run --no-sync "
-        f"--with {_remote_arg(_BOOTSTRAP_PSUTIL_SPEC)} python"
-    )
     if env.is_local(ip):
         if not cli_abs.exists():
             copy_fn(resolve_worker_cli_path(env), cli_abs)
-        if force:
-            exclude_arg = f" {_remote_arg(current_pid)}" if current_pid else ""
-            kill_command = "kill-force" if force_scan else "kill"
-            target_arg = "" if force_scan else f" {_remote_arg(env.wenv_abs)}"
-            cmds.append(
-                f"{kill_prefix} {_remote_arg(cli_abs)} {kill_command}"
-                f"{target_arg}{exclude_arg}"
-            )
-    elif force:
+        if not force:
+            return None
         kill_command = "kill-force" if force_scan else "kill"
-        target_arg = "" if force_scan else f" {_remote_arg(env.wenv_rel)}"
-        cmds.append(
-            f"{kill_prefix} {_remote_arg(cli_rel)} {kill_command}{target_arg}"
+        local_args = [] if force_scan else [env.wenv_abs]
+        if current_pid:
+            local_args.append(current_pid)
+        if env.debug:
+            sys_module.argv = [
+                str(cli_abs),
+                kill_command,
+                *(str(value) for value in local_args),
+            ]
+            run_path_fn(sys_module.argv[0], run_name="__main__")
+            return None
+
+        worker_python = project_virtualenv_script_path(
+            env.wenv_abs,
+            "python",
+            os_name=os_name,
         )
+        # The manager has already imported this module and therefore has a
+        # working psutil/agi-node runtime.  Reuse that interpreter when a
+        # partially installed worker has no venv; this avoids both network
+        # resolution and cmd.exe parsing of PEP 508 comparison operators.
+        python_prefix = (
+            _remote_arg(worker_python)
+            if worker_python.exists()
+            else _remote_arg(getattr(sys_module, "executable", sys.executable))
+        )
+        rendered_args = "".join(f" {_remote_arg(value)}" for value in local_args)
+        cmd = (
+            f"{cmd_prefix}{python_prefix} {_remote_arg(cli_abs)} "
+            f"{kill_command}{rendered_args}"
+        )
+        await run_fn(cmd, str(env.wenv_abs))
+        return None
 
-    last_res = None
-    for cmd in cmds:
-        cwd = str(env.wenv_abs)
-        if env.is_local(ip):
-            if env.debug:
-                sys_module.argv = shlex.split(cmd.split("python ", 1)[1], posix=True)
-                run_path_fn(sys_module.argv[0], run_name="__main__")
-            else:
-                await run_fn(cmd, cwd)
-        else:
-            last_res = await agi_cls.exec_ssh(ip, cmd)
-
-        if isinstance(last_res, dict):
-            out = last_res.get("stdout", "")
-            err = last_res.get("stderr", "")
-            log.info(out)
-            if err:
-                log.error(err)
-
+    if not force:
+        return None
+    kill_command = "kill-force" if force_scan else "kill"
+    remote_args = () if force_scan else (env.wenv_rel,)
+    cmd = _remote_process_command(
+        cmd_prefix=cmd_prefix,
+        uv=uv,
+        wenv=env.wenv_rel,
+        cli=cli_rel,
+        action=kill_command,
+        arguments=remote_args,
+    )
+    last_res = await agi_cls.exec_ssh(ip, cmd)
+    if isinstance(last_res, dict):
+        out = last_res.get("stdout", "")
+        err = last_res.get("stderr", "")
+        log.info(out)
+        if err:
+            log.error(err)
     return last_res
 
 
@@ -797,15 +859,16 @@ async def clean_dirs(
         and getattr(agi_cls, "_lifecycle_call_token", None)
     ):
         lease = await acquire_remote_lease(ip, cmd_prefix=cmd_prefix)
-    token_arg = (
-        f" {_remote_arg(lease.token)}"
-        if isinstance(lease, RemoteTargetLease)
-        else ""
+    command_args = (
+        (wenv, lease.token) if isinstance(lease, RemoteTargetLease) else (wenv,)
     )
-    cmd = (
-        f"{cmd_prefix}{_remote_words(uv)} run --no-sync "
-        f"--with {_remote_arg(_BOOTSTRAP_PSUTIL_SPEC)} "
-        f"-p {_remote_arg(env.python_version)} python "
-        f"{_remote_arg(cli)} clean {_remote_arg(wenv)}{token_arg}"
+    cmd = _remote_process_command(
+        cmd_prefix=cmd_prefix,
+        uv=uv,
+        wenv=wenv,
+        cli=cli,
+        action="clean",
+        arguments=command_args,
+        python_version=env.python_version,
     )
     await agi_cls.exec_ssh(ip, cmd)

--- a/src/agilab/core/agi-env/src/agi_env/resources/.agilab/.env
+++ b/src/agilab/core/agi-env/src/agi_env/resources/.agilab/.env
@@ -3,8 +3,8 @@
 # Secrets stay empty or placeholder values until you intentionally set them.
 
 # Python/runtime
-# AGI_PYTHON_VERSION="3.14"
-# 127.0.0.1_PYTHON_VERSION="3.14"
+# AGI_PYTHON_VERSION="3.13"
+# 127.0.0.1_PYTHON_VERSION="3.13"
 # AGI_PYTHON_FREE_THREADED="1"
 # IS_SOURCE_ENV="1"
 # IS_WORKER_ENV="0"

--- a/src/agilab/core/test/test_agi_distributor_cleanup_support.py
+++ b/src/agilab/core/test/test_agi_distributor_cleanup_support.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import shlex
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
@@ -291,8 +292,10 @@ async def test_kill_processes_cleans_pid_files_and_handles_local_and_remote_path
 
     assert copied
     assert local_runs
-    local_argv = shlex.split(local_runs[0][0].split("python ", 1)[1], posix=True)
+    assert "--with" not in local_runs[0][0]
+    local_argv = shlex.split(local_runs[0][0], posix=True)
     assert local_argv == [
+        Path(sys.executable).as_posix(),
         (wenv_parent / "cli.py").as_posix(),
         "kill",
         wenv_abs.as_posix(),
@@ -301,8 +304,23 @@ async def test_kill_processes_cleans_pid_files_and_handles_local_and_remote_path
     assert all(cwd == str(wenv_abs) for _cmd, cwd in local_runs)
     assert len(remote_runs) == 1
     assert remote_runs[0][0] == "10.0.0.2"
-    remote_argv = shlex.split(remote_runs[0][1].split(";", 1)[1], posix=True)
-    assert remote_argv == [
+    remote_command = remote_runs[0][1].split(";", 1)[1]
+    assert remote_command.startswith("if [ -x ")
+    assert ".venv/bin/python" in remote_command
+    assert "; then " in remote_command
+    assert "; else " in remote_command
+    assert " || " not in remote_command
+    direct_command = remote_command.split("; then ", 1)[1].split("; else ", 1)[0]
+    direct_argv = shlex.split(direct_command, posix=True)
+    assert direct_argv == [
+        "w env's/demo worker/.venv/bin/python",
+        "w env's/cli.py",
+        "kill",
+        "w env's/demo worker",
+    ]
+    fallback_command = remote_command.split("; else ", 1)[1].rsplit("; fi", 1)[0]
+    fallback_argv = shlex.split(fallback_command, posix=True)
+    assert fallback_argv == [
         "uv",
         "run",
         "--no-sync",
@@ -320,6 +338,79 @@ async def test_kill_processes_cleans_pid_files_and_handles_local_and_remote_path
     assert (wenv_parent / "ok.pid").exists()
     assert log.info.called
     assert log.error.called
+
+
+@pytest.mark.asyncio
+async def test_kill_processes_prefers_installed_windows_worker_python(tmp_path):
+    wenv_abs = tmp_path / "worker env"
+    worker_python = wenv_abs / ".venv" / "Scripts" / "python.exe"
+    worker_python.parent.mkdir(parents=True)
+    worker_python.write_text("", encoding="utf-8")
+    cli_abs = wenv_abs.parent / "cli.py"
+    cli_abs.write_text("print('cli')\n", encoding="utf-8")
+    env = SimpleNamespace(
+        uv="uv",
+        wenv_abs=wenv_abs,
+        wenv_rel=Path("wenv/demo worker"),
+        envars={},
+        debug=False,
+        is_local=lambda _ip: True,
+    )
+    runs = []
+
+    async def _run(cmd, cwd):
+        runs.append((cmd, cwd))
+
+    await cleanup_support.kill_processes(
+        SimpleNamespace(env=env),
+        current_pid=321,
+        gethostbyname_fn=lambda _name: "127.0.0.1",
+        run_fn=_run,
+        os_name="nt",
+    )
+
+    assert len(runs) == 1
+    argv = shlex.split(runs[0][0], posix=True)
+    assert argv[0] == worker_python.as_posix()
+    assert argv[-3:] == ["kill", wenv_abs.as_posix(), "321"]
+    assert "--with" not in argv
+
+
+@pytest.mark.asyncio
+async def test_kill_processes_uses_manager_python_for_partial_windows_worker(tmp_path):
+    wenv_abs = tmp_path / "worker env"
+    wenv_abs.mkdir(parents=True)
+    cli_abs = wenv_abs.parent / "cli.py"
+    cli_abs.write_text("print('cli')\n", encoding="utf-8")
+    manager_python = tmp_path / "manager env" / "Scripts" / "python.exe"
+    env = SimpleNamespace(
+        uv="uv",
+        wenv_abs=wenv_abs,
+        wenv_rel=Path("wenv/demo worker"),
+        envars={},
+        debug=False,
+        is_local=lambda _ip: True,
+    )
+    runs = []
+
+    async def _run(cmd, cwd):
+        runs.append((cmd, cwd))
+
+    await cleanup_support.kill_processes(
+        SimpleNamespace(env=env),
+        current_pid=321,
+        gethostbyname_fn=lambda _name: "127.0.0.1",
+        run_fn=_run,
+        os_name="nt",
+        sys_module=SimpleNamespace(executable=str(manager_python), argv=[]),
+    )
+
+    assert len(runs) == 1
+    argv = shlex.split(runs[0][0], posix=True)
+    assert argv[0] == manager_python.as_posix()
+    assert argv[-3:] == ["kill", wenv_abs.as_posix(), "321"]
+    assert "--with" not in argv
+    assert "<" not in runs[0][0]
 
 
 @pytest.mark.asyncio
@@ -351,7 +442,9 @@ async def test_kill_processes_local_debug_uses_run_path_and_skips_current_pid(tm
         agi_cls,
         current_pid=999,
         gethostbyname_fn=lambda _name: "127.0.0.1",
-        run_fn=lambda *_a, **_k: (_ for _ in ()).throw(AssertionError("run_fn should not be used in debug mode")),
+        run_fn=lambda *_a, **_k: (_ for _ in ()).throw(
+            AssertionError("run_fn should not be used in debug mode")
+        ),
         run_path_fn=lambda path, run_name=None: run_path_calls.append((path, run_name)),
         sys_module=SimpleNamespace(argv=[]),
         log=mock.Mock(),
@@ -801,8 +894,24 @@ async def test_clean_dirs_removes_local_wenv_and_execs_remote(tmp_path):
     assert removed == []
     assert made_dirs == []
     assert ssh_calls
-    argv = shlex.split(ssh_calls[0][1].split("&& ", 1)[1], posix=True)
-    assert argv == [
+    command = ssh_calls[0][1].split("&& ", 1)[1]
+    assert command.startswith("if [ -x ")
+    assert " || " not in command
+    direct = shlex.split(
+        command.split("; then ", 1)[1].split("; else ", 1)[0],
+        posix=True,
+    )
+    assert direct == [
+        "w env's/.venv/bin/python",
+        "cli.py",
+        "clean",
+        "w env's",
+    ]
+    fallback = shlex.split(
+        command.split("; else ", 1)[1].rsplit("; fi", 1)[0],
+        posix=True,
+    )
+    assert fallback == [
         "/usr/bin/uv",
         "run",
         "--no-sync",
@@ -828,7 +937,7 @@ async def test_remote_target_lease_token_wraps_remote_clean_lifecycle(tmp_path):
     calls = []
 
     async def _exec(ip, cmd):
-        calls.append((ip, shlex.split(cmd, posix=True)))
+        calls.append((ip, cmd))
         return "ok"
 
     agi_cls = SimpleNamespace(
@@ -848,13 +957,19 @@ async def test_remote_target_lease_token_wraps_remote_clean_lifecycle(tmp_path):
     await cleanup_support.release_remote_target_leases(agi_cls)
 
     assert lease.token == "a" * 32
-    assert [argv[argv.index("python") + 2] for _ip, argv in calls] == [
-        "target-lease-acquire",
-        "clean",
-        "target-lease-release",
-    ]
-    assert calls[1][1][3:5] == ["--with", "psutil>=7,<8"]
-    assert calls[1][1][-1] == "a" * 32
+    acquire_argv = shlex.split(calls[0][1], posix=True)
+    release_argv = shlex.split(calls[2][1], posix=True)
+    assert acquire_argv[acquire_argv.index("python") + 2] == "target-lease-acquire"
+    assert release_argv[release_argv.index("python") + 2] == "target-lease-release"
+    clean_command = calls[1][1]
+    assert " || " not in clean_command
+    assert " clean " in clean_command
+    fallback = shlex.split(
+        clean_command.split("; else ", 1)[1].rsplit("; fi", 1)[0],
+        posix=True,
+    )
+    assert fallback[3:5] == ["--with", "psutil>=7,<8"]
+    assert fallback[-1] == "a" * 32
     assert agi_cls._remote_target_leases == {}
 
 

--- a/src/agilab/core/test/test_agi_distributor_cleanup_support.py
+++ b/src/agilab/core/test/test_agi_distributor_cleanup_support.py
@@ -295,7 +295,7 @@ async def test_kill_processes_cleans_pid_files_and_handles_local_and_remote_path
     assert "--with" not in local_runs[0][0]
     local_argv = shlex.split(local_runs[0][0], posix=True)
     assert local_argv == [
-        Path(sys.executable).as_posix(),
+        str(Path(sys.executable)),
         (wenv_parent / "cli.py").as_posix(),
         "kill",
         wenv_abs.as_posix(),
@@ -407,7 +407,7 @@ async def test_kill_processes_uses_manager_python_for_partial_windows_worker(tmp
 
     assert len(runs) == 1
     argv = shlex.split(runs[0][0], posix=True)
-    assert argv[0] == manager_python.as_posix()
+    assert argv[0] == str(manager_python)
     assert argv[-3:] == ["kill", wenv_abs.as_posix(), "321"]
     assert "--with" not in argv
     assert "<" not in runs[0][0]
@@ -451,7 +451,7 @@ async def test_kill_processes_local_debug_uses_run_path_and_skips_current_pid(tm
     )
 
     assert current_pid_file.exists()
-    assert run_path_calls == [((wenv_parent / "cli.py").as_posix(), "__main__")]
+    assert run_path_calls == [(str(wenv_parent / "cli.py"), "__main__")]
 
 
 def test_clean_dirs_local_kills_dask_processes_before_verified_delete(tmp_path):

--- a/src/agilab/environment/env_default_comments.py
+++ b/src/agilab/environment/env_default_comments.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 USER_ENV_DEFAULT_COMMENT_LINES: tuple[str, ...] = (
-    '# AGI_PYTHON_VERSION="3.14"',
-    '# 127.0.0.1_PYTHON_VERSION="3.14"',
+    '# AGI_PYTHON_VERSION="3.13"',
+    '# 127.0.0.1_PYTHON_VERSION="3.13"',
     '# AGI_PYTHON_FREE_THREADED="1"',
     '# IS_SOURCE_ENV="1"',
     '# IS_WORKER_ENV="0"',

--- a/src/agilab/install_apps.sh
+++ b/src/agilab/install_apps.sh
@@ -135,6 +135,25 @@ START_TIME=$(date +%s)
 
 UV_PREVIEW=(uv --preview-features extra-build-dependencies)
 
+repo_python_default() {
+  local script_dir repo_root pin_file="${1:-}" pinned
+  if [[ -z "$pin_file" ]]; then
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    repo_root="$(cd "${script_dir}/../.." && pwd)"
+    pin_file="${repo_root}/.python-version"
+  fi
+  if [[ ! -e "$pin_file" ]]; then
+    printf '%s\n' "3.13"
+    return 0
+  fi
+  IFS= read -r pinned < "$pin_file" || true
+  if [[ ! "$pinned" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
+    echo -e "${RED}Invalid repository Python pin '${pinned}' in ${pin_file}; expected major.minor or major.minor.patch.${NC}" >&2
+    return 1
+  fi
+  printf '%s\n' "$pinned"
+}
+
 python_uv_spec_for_version() {
   local version="${1:-}"
   case "$version" in
@@ -152,9 +171,14 @@ python_uv_spec_for_version() {
 }
 
 normalize_agi_python_version() {
-  local raw="${1:-3.14}"
+  local raw="${1:-}"
+  if [[ -z "$raw" ]]; then
+    raw="$(repo_python_default)" || return 1
+  fi
   raw="$(printf '%s' "$raw" | sed -E 's/^[[:space:]]+//;s/[[:space:]]+$//')"
-  [[ -n "$raw" ]] || raw="3.14"
+  if [[ -z "$raw" ]]; then
+    raw="$(repo_python_default)" || return 1
+  fi
 
   case "${AGI_PYTHON_FREE_THREADED:-0}" in
     1|true|TRUE|yes|YES|on|ON)
@@ -165,6 +189,7 @@ normalize_agi_python_version() {
 
   if [[ "$raw" == *freethreaded* \
      || "$raw" =~ (^|[^[:alnum:]])python3\.[0-9]+t([^[:alnum:]]|$) \
+     || "$raw" =~ ^cpython-[0-9]+\.[0-9]+(\.[0-9]+)?t($|[^[:alnum:]]) \
      || "$raw" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?t($|[^[:alnum:]]) ]]; then
     echo -e "${RED}Unsupported AGI_PYTHON_VERSION '${raw}': install_apps.sh requires a standard GIL Python interpreter. Freethreaded Python can force native dependency builds for binary-heavy packages such as Polars. Re-run with AGI_PYTHON_VERSION=3.14.6 or AGI_PYTHON_VERSION=3.13.14.${NC}" >&2
     return 1
@@ -187,7 +212,10 @@ normalize_agi_python_version() {
 
 normalize_agi_python_uv_spec() {
   local raw="${1:-}"
-  local python_version="${2:-${AGI_PYTHON_VERSION:-3.14}}"
+  local python_version="${2:-${AGI_PYTHON_VERSION:-}}"
+  if [[ -z "$python_version" ]]; then
+    python_version="$(repo_python_default)" || return 1
+  fi
   local desired_uv_spec
   desired_uv_spec="$(python_uv_spec_for_version "$python_version")"
   raw="$(printf '%s' "$raw" | sed -E 's/^[[:space:]]+//;s/[[:space:]]+$//')"
@@ -196,6 +224,7 @@ normalize_agi_python_uv_spec() {
   fi
   if [[ "$raw" == *freethreaded* \
      || "$raw" =~ (^|[^[:alnum:]])python3\.[0-9]+t([^[:alnum:]]|$) \
+     || "$raw" =~ ^cpython-[0-9]+\.[0-9]+(\.[0-9]+)?t($|[^[:alnum:]]) \
      || "$raw" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?t($|[^[:alnum:]]) ]]; then
     echo -e "${RED}Unsupported AGI_PYTHON_UV_SPEC '${raw}': install_apps.sh requires a standard GIL Python interpreter.${NC}" >&2
     return 1
@@ -213,7 +242,7 @@ run_with_agilab_python_env() {
     "$@"
 }
 
-if ! AGI_PYTHON_VERSION="$(normalize_agi_python_version "${AGI_PYTHON_VERSION:-3.14}")"; then
+if ! AGI_PYTHON_VERSION="$(normalize_agi_python_version "${AGI_PYTHON_VERSION:-}")"; then
   exit 1
 fi
 if ! AGI_PYTHON_UV_SPEC="$(normalize_agi_python_uv_spec "${AGI_PYTHON_UV_SPEC:-}" "$AGI_PYTHON_VERSION")"; then

--- a/src/agilab/lib/agi-pages/src/agi_pages/queue_resilience.py
+++ b/src/agilab/lib/agi-pages/src/agi_pages/queue_resilience.py
@@ -1,7 +1,7 @@
 """Shared lifecycle and rendering support for queue-resilience pages.
 
-The owning page bundles inject their Streamlit and dataframe implementations so
-``agi-pages`` keeps its lightweight dependency boundary.
+The owning page bundles inject their Streamlit, environment, and dataframe
+implementations so ``agi-pages`` keeps its lightweight dependency boundary.
 """
 
 from __future__ import annotations
@@ -61,8 +61,8 @@ class QueueResilienceRun:
 
 def prepare_queue_resilience_page(
     streamlit: Any,
-    env_type: Any,
     *,
+    env_factory: Callable[[Path], Any],
     title: str,
     logo_title: str,
     caption: str,
@@ -71,12 +71,7 @@ def prepare_queue_resilience_page(
     app_scope_key: str,
     app_scoped_keys: tuple[str, ...],
 ) -> QueueResiliencePageContext:
-    """Render common page setup and return the available queue summaries.
-
-    ``env_type`` is injected by the page bundle to avoid importing ``agi-env``
-    from this support package.  The shared runtime also rebuilds a cached
-    environment when the active app changes.
-    """
+    """Render common page setup and return the available queue summaries."""
 
     configure_streamlit_page(streamlit, title=title)
     active_app_path = resolve_active_app_path(
@@ -84,21 +79,11 @@ def prepare_queue_resilience_page(
         stop_fn=streamlit.stop,
     )
 
-    def create_env(app_path: Path) -> Any:
-        factory = getattr(env_type, "for_app", env_type)
-        env = factory(
-            apps_path=app_path.parent,
-            app=app_path.name,
-            verbose=0,
-        )
-        env.init_done = True
-        return env
-
     env = ensure_app_scoped_env(
         streamlit.session_state,
         active_app_path,
         scope_key=app_scope_key,
-        env_factory=create_env,
+        env_factory=env_factory,
         keys=app_scoped_keys,
     )
     render_streamlit_page_header(

--- a/src/agilab/lib/agi-pages/src/agi_pages/runtime.py
+++ b/src/agilab/lib/agi-pages/src/agi_pages/runtime.py
@@ -146,8 +146,8 @@ def active_app_scope_value(active_app: str | Path) -> str:
     return str(Path(active_app).expanduser().resolve())
 
 
-def env_app_scope_value(env: Any) -> str | None:
-    """Infer the active-app session-scope key from an AGILAB environment object."""
+def _env_concrete_app_scope_value(env: Any) -> str | None:
+    """Return the established primary live app identity for an environment."""
 
     app_path = getattr(env, "app_path", None)
     if app_path:
@@ -162,6 +162,60 @@ def env_app_scope_value(env: Any) -> str | None:
     return None
 
 
+def _env_matches_active_app_scope(env: Any, active_scope: str) -> bool:
+    """Return whether live environment fields prove the requested app scope.
+
+    ``AgiEnv`` can resolve an app to its bundled implementation under its
+    configured ``builtin_apps_path`` (or the legacy ``apps_path / 'builtin'``
+    location). Those are the sole accepted alternatives to the requested
+    ``apps_path / app`` location. Conflicting live fields are not
+    interchangeable: a stale marker or an ``apps_path`` / ``app`` pair cannot
+    override a different concrete ``active_app``.
+    """
+
+    app_path = getattr(env, "app_path", None)
+    if app_path:
+        return active_app_scope_value(app_path) == active_scope
+
+    active_app = getattr(env, "active_app", None)
+    if active_app:
+        env_active_scope = active_app_scope_value(active_app)
+        if env_active_scope == active_scope:
+            return True
+        apps_path = getattr(env, "apps_path", None)
+        app = getattr(env, "app", None)
+        if not apps_path or not app:
+            return False
+        requested_scope = active_app_scope_value(Path(apps_path) / str(app))
+        builtin_roots = [getattr(env, "builtin_apps_path", None)]
+        builtin_roots.append(Path(apps_path) / "builtin")
+        builtin_scopes = {
+            active_app_scope_value(Path(root) / str(app))
+            for root in builtin_roots
+            if root
+        }
+        return active_scope == requested_scope and env_active_scope in builtin_scopes
+
+    apps_path = getattr(env, "apps_path", None)
+    app = getattr(env, "app", None)
+    return (
+        bool(apps_path and app)
+        and active_app_scope_value(Path(apps_path) / str(app)) == active_scope
+    )
+
+
+def env_app_scope_value(env: Any) -> str | None:
+    """Infer the active-app session-scope key from an AGILAB environment object."""
+
+    concrete_scope = _env_concrete_app_scope_value(env)
+    if concrete_scope is not None:
+        return concrete_scope
+    bound_scope = getattr(env, "_agilab_active_app_scope", None)
+    if bound_scope:
+        return active_app_scope_value(bound_scope)
+    return None
+
+
 def ensure_app_scoped_env(
     session_state: Any,
     active_app: str | Path,
@@ -172,43 +226,60 @@ def ensure_app_scoped_env(
     keys: tuple[str, ...] = (),
     prefixes: tuple[str, ...] = (),
 ) -> Any:
-    """Return an environment aligned with the active app session scope.
+    """Return an environment whose app identity matches the active page scope.
 
-    Page bundles share one Streamlit session while users switch projects.  A
-    cached environment is reusable only when the recorded page scope and, when
-    available, the environment's own app path both match the requested app.
-    Unknown unscoped environments are rebuilt instead of being trusted.
+    Streamlit pages share one session-state mapping. A page-local scope marker
+    therefore cannot prove that the shared cached environment still belongs to
+    the same app: another page may have replaced it since the marker was set.
+    Reuse is allowed only when the environment exposes a matching app identity.
+    Page-owned state is cleared whenever its recorded scope changes or an
+    unscoped/stale environment must be replaced.
     """
 
     active_app_path = Path(active_app).expanduser().resolve()
     active_scope = active_app_scope_value(active_app_path)
     cached_env = session_state.get(env_key)
-    recorded_scope = session_state.get(scope_key)
-    cached_scope = env_app_scope_value(cached_env) if cached_env is not None else None
-
-    scope_matches = recorded_scope == active_scope
-    env_matches = cached_env is not None and cached_scope in {None, active_scope}
-    if scope_matches and env_matches:
-        return cached_env
-
-    # A warm environment can predate the page-specific scope marker.  Preserve
-    # it only when its own app identity proves that it belongs to this app.
-    if recorded_scope is None and cached_env is not None and cached_scope == active_scope:
-        session_state[scope_key] = active_scope
-        return cached_env
-
-    reset_keys = tuple(dict.fromkeys((env_key, *keys)))
-    reset_scoped_session_state(
-        session_state,
-        scope_key,
-        active_app_path,
-        keys=reset_keys,
-        prefixes=prefixes,
+    cached_matches = cached_env is not None and _env_matches_active_app_scope(
+        cached_env,
+        active_scope,
     )
-    env = env_factory(active_app_path)
-    session_state[env_key] = env
+
+    if cached_env is not None and cached_matches:
+        try:
+            cached_env._agilab_active_app_scope = active_scope
+        except (AttributeError, TypeError):
+            pass
+        reset_scoped_session_state(
+            session_state,
+            scope_key,
+            active_app_path,
+            keys=keys,
+            prefixes=prefixes,
+        )
+        session_state[env_key] = cached_env
+        return cached_env
+
+    replacement = env_factory(active_app_path)
+    replacement_scope = env_app_scope_value(replacement)
+    if not _env_matches_active_app_scope(replacement, active_scope):
+        raise ValueError(
+            "Environment factory returned an app scope that does not match "
+            f"the requested app: expected {active_scope!r}, got {replacement_scope!r}"
+        )
+    try:
+        replacement._agilab_active_app_scope = active_scope
+    except (AttributeError, TypeError):
+        pass
+    exact_keys = set((env_key, *keys))
+    for key in list(session_state.keys()):
+        if key == scope_key:
+            continue
+        key_text = str(key)
+        if key in exact_keys or any(key_text.startswith(prefix) for prefix in prefixes):
+            session_state.pop(key, None)
     session_state[scope_key] = active_scope
-    return env
+    session_state[env_key] = replacement
+    return replacement
 
 
 def reset_scoped_session_state(

--- a/test/test_agi_pages_runtime.py
+++ b/test/test_agi_pages_runtime.py
@@ -167,6 +167,68 @@ def test_agi_pages_runtime_ensures_app_scoped_env_reuses_matching_cache(
     assert state["page:choice"] == "kept"
 
 
+def test_agi_pages_runtime_accepts_matching_apps_path_when_active_app_is_builtin(
+    tmp_path: Path,
+) -> None:
+    apps_path = tmp_path / "apps"
+    app = apps_path / "demo_project"
+    builtin_apps_path = tmp_path / "builtin-apps"
+    builtin_app = builtin_apps_path / "demo_project"
+    app.mkdir(parents=True)
+    builtin_app.mkdir(parents=True)
+    env = SimpleNamespace(
+        active_app=builtin_app,
+        apps_path=apps_path,
+        app=app.name,
+        builtin_apps_path=builtin_apps_path,
+    )
+    state = {"scope": str(app.resolve()), "env": env}
+
+    assert runtime.env_app_scope_value(env) == str(builtin_app.resolve())
+    assert (
+        runtime.ensure_app_scoped_env(
+            state,
+            app,
+            scope_key="scope",
+            env_factory=lambda _active: pytest.fail("matching environment was rebuilt"),
+        )
+        is env
+    )
+    assert state["env"] is env
+
+
+def test_agi_pages_runtime_reuses_matching_environment_after_scope_switch(
+    tmp_path: Path,
+) -> None:
+    old_app = tmp_path / "apps" / "old_project"
+    new_app = tmp_path / "apps" / "new_project"
+    old_app.mkdir(parents=True)
+    new_app.mkdir()
+    env = SimpleNamespace(apps_path=new_app.parent, app=new_app.name)
+    state = {
+        "scope": str(old_app.resolve()),
+        "env": env,
+        "page:choice": "stale",
+        "global": "kept",
+    }
+
+    resolved = runtime.ensure_app_scoped_env(
+        state,
+        new_app,
+        scope_key="scope",
+        env_factory=lambda _active: pytest.fail("matching environment was rebuilt"),
+        keys=("env",),
+        prefixes=("page:",),
+    )
+
+    assert resolved is env
+    assert state == {
+        "scope": str(new_app.resolve()),
+        "env": env,
+        "global": "kept",
+    }
+
+
 def test_agi_pages_runtime_ensures_app_scoped_env_rebuilds_stale_cache(
     tmp_path: Path,
 ) -> None:
@@ -203,25 +265,126 @@ def test_agi_pages_runtime_ensures_app_scoped_env_rebuilds_stale_cache(
     }
 
 
-def test_agi_pages_runtime_ensures_app_scoped_env_rebuilds_unknown_unscoped_cache(
+def test_agi_pages_runtime_rebuilds_stale_environment_despite_matching_marker(
+    tmp_path: Path,
+) -> None:
+    old_app = tmp_path / "apps" / "old_project"
+    new_app = tmp_path / "apps" / "new_project"
+    old_app.mkdir(parents=True)
+    new_app.mkdir()
+    stale_env = SimpleNamespace(
+        apps_path=old_app.parent,
+        app=old_app.name,
+        _agilab_active_app_scope=new_app,
+    )
+    replacement = SimpleNamespace(apps_path=new_app.parent, app=new_app.name)
+    state = {
+        "scope": str(new_app.resolve()),
+        "env": stale_env,
+        "exact": "stale",
+        "page:choice": "stale",
+        "global": "kept",
+    }
+    created: list[Path] = []
+
+    resolved = runtime.ensure_app_scoped_env(
+        state,
+        new_app,
+        scope_key="scope",
+        env_factory=lambda active: created.append(active) or replacement,
+        keys=("exact",),
+        prefixes=("page:",),
+    )
+
+    assert resolved is replacement
+    assert created == [new_app.resolve()]
+    assert state == {
+        "scope": str(new_app.resolve()),
+        "env": replacement,
+        "global": "kept",
+    }
+
+
+def test_agi_pages_runtime_rebuilds_conflicting_live_environment_identity(
+    tmp_path: Path,
+) -> None:
+    apps_path = tmp_path / "apps"
+    old_app = apps_path / "old_project"
+    new_app = apps_path / "new_project"
+    old_app.mkdir(parents=True)
+    new_app.mkdir()
+    stale_env = SimpleNamespace(
+        active_app=old_app,
+        apps_path=apps_path,
+        app=new_app.name,
+        _agilab_active_app_scope=new_app,
+    )
+    replacement = SimpleNamespace(
+        active_app=new_app,
+        apps_path=apps_path,
+        app=new_app.name,
+    )
+    state = {"scope": str(new_app.resolve()), "env": stale_env}
+
+    resolved = runtime.ensure_app_scoped_env(
+        state,
+        new_app,
+        scope_key="scope",
+        env_factory=lambda _active: replacement,
+    )
+
+    assert resolved is replacement
+    assert state["env"] is replacement
+
+
+def test_agi_pages_runtime_rebuilds_unknown_unscoped_cache_even_with_matching_marker(
     tmp_path: Path,
 ) -> None:
     app = tmp_path / "apps" / "demo_project"
     app.mkdir(parents=True)
     unknown_env = SimpleNamespace()
     new_env = SimpleNamespace(apps_path=app.parent, app=app.name)
-    state = {"env": unknown_env}
+    state = {
+        "scope": str(app.resolve()),
+        "env": unknown_env,
+        "page:choice": "stale",
+    }
 
     resolved = runtime.ensure_app_scoped_env(
         state,
         app,
         scope_key="scope",
         env_factory=lambda _active: new_env,
+        prefixes=("page:",),
     )
 
     assert resolved is new_env
-    assert state["env"] is new_env
-    assert state["scope"] == str(app.resolve())
+    assert state == {"scope": str(app.resolve()), "env": new_env}
+
+
+def test_agi_pages_runtime_rejects_factory_environment_for_another_app(
+    tmp_path: Path,
+) -> None:
+    requested_app = tmp_path / "apps" / "requested_project"
+    other_app = tmp_path / "apps" / "other_project"
+    requested_app.mkdir(parents=True)
+    other_app.mkdir()
+    cached_env = SimpleNamespace()
+    state: dict[str, object] = {"env": cached_env, "page:choice": "kept"}
+
+    with pytest.raises(ValueError, match="does not match the requested app"):
+        runtime.ensure_app_scoped_env(
+            state,
+            requested_app,
+            scope_key="scope",
+            env_factory=lambda _active: SimpleNamespace(
+                apps_path=other_app.parent,
+                app=other_app.name,
+            ),
+            prefixes=("page:",),
+        )
+
+    assert state == {"env": cached_env, "page:choice": "kept"}
 
 
 def test_agi_pages_runtime_file_helpers_are_deterministic(tmp_path: Path) -> None:

--- a/test/test_app_installer_packaging.py
+++ b/test/test_app_installer_packaging.py
@@ -10,6 +10,7 @@ import runpy
 import sqlite3
 import subprocess
 import sys
+import textwrap
 import tomllib
 from pathlib import Path
 from types import SimpleNamespace
@@ -1182,6 +1183,30 @@ def _string_constants(script_text: str) -> set[str]:
     }
 
 
+def _source_and_parseable_string_trees(script_text: str) -> list[tuple[str, ast.AST]]:
+    """The live module plus one level of non-docstring literals that contain Python."""
+
+    trees: list[tuple[str, ast.AST]] = [("source", ast.parse(script_text))]
+    for literal in sorted(_string_constants(script_text)):
+        dedented = textwrap.dedent(literal).strip()
+        candidates = [dedented]
+        lines = dedented.splitlines()
+        if (
+            len(lines) >= 2
+            and lines[0].strip().lower() in {"```python", "```py"}
+            and lines[-1].strip() == "```"
+        ):
+            candidates.insert(0, "\n".join(lines[1:-1]))
+        for candidate in dict.fromkeys(candidates):
+            try:
+                literal_tree = ast.parse(candidate)
+            except (SyntaxError, ValueError):
+                continue
+            trees.append(("string literal", literal_tree))
+            break
+    return trees
+
+
 # Examples whose Expected Output section legitimately names no concrete artifact
 # basename (planned/future artifacts only). Every other packaged preview example
 # must yield at least one, so a README that stops matching the extractor fails
@@ -1917,7 +1942,7 @@ _MODE_KEYWORDS = {"mode", "modes_enabled"}
 
 
 def _numeric_mode_keyword_arguments(script_text: str) -> list[str]:
-    """Any `mode=`/`modes_enabled=` keyword bound to a raw numeric literal.
+    """Any source or embedded Python `mode=` keyword bound to a raw numeric literal.
 
     Matching on source text can only ever enumerate the spellings someone
     thought of; `mode=7`, `mode=0x0d` and `mode = 13` all read differently but
@@ -1925,17 +1950,95 @@ def _numeric_mode_keyword_arguments(script_text: str) -> list[str]:
     """
 
     offenders: list[str] = []
-    for node in ast.walk(ast.parse(script_text)):
-        if not isinstance(node, ast.Call):
-            continue
-        for keyword in node.keywords:
-            if keyword.arg not in _MODE_KEYWORDS:
+    for origin, tree in _source_and_parseable_string_trees(script_text):
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
                 continue
-            if isinstance(keyword.value, ast.Constant) and isinstance(
-                keyword.value.value, int
-            ):
-                offenders.append(f"{keyword.arg}={keyword.value.value}")
+            for keyword in node.keywords:
+                if keyword.arg not in _MODE_KEYWORDS:
+                    continue
+                if isinstance(keyword.value, ast.Constant) and isinstance(
+                    keyword.value.value, int
+                ):
+                    offenders.append(f"{origin}: {keyword.arg}={keyword.value.value}")
     return offenders
+
+
+def _deprecated_api_usages(script_text: str) -> list[str]:
+    """Private AGI internals and the legacy event-loop runner, via source/snippet ASTs.
+
+    Substring checks match a single spelling: `from asyncio import
+    get_event_loop` and `AGI as _A; _A._run(...)` both slip past a raw
+    `"asyncio.get_event_loop()" not in text` / `"AGI._" not in text` gate.
+    """
+
+    usages: list[str] = []
+
+    for origin, tree in _source_and_parseable_string_trees(script_text):
+        # Names bound to the AGI class within this source unit, so aliased
+        # access is caught without linking unrelated string literals together.
+        agi_aliases = {"AGI"}
+        loop_aliases: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom):
+                for alias in node.names:
+                    if alias.name == "AGI":
+                        agi_aliases.add(alias.asname or alias.name)
+                    if node.module == "asyncio" and alias.name == "get_event_loop":
+                        loop_aliases.add(alias.asname or alias.name)
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Attribute):
+                value = node.value
+                if isinstance(value, ast.Name) and value.id in agi_aliases:
+                    if node.attr.startswith("_"):
+                        usages.append(f"{origin}: {value.id}.{node.attr}")
+                if (
+                    isinstance(value, ast.Name)
+                    and value.id == "asyncio"
+                    and node.attr == "get_event_loop"
+                ):
+                    usages.append(f"{origin}: asyncio.get_event_loop")
+            elif isinstance(node, ast.Name) and node.id in loop_aliases:
+                usages.append(f"{origin}: get_event_loop (imported as {node.id})")
+    return usages
+
+
+def test_example_ast_gates_inspect_parseable_python_string_literals() -> None:
+    direct_source = "AGI._run(app_env, mode=7)\n"
+    source = '''
+GENERATED = """
+    from agi_env import AGI as _A
+    import asyncio
+    _A._run(app_env, mode=0x0d)
+    asyncio.get_event_loop().run_until_complete(main())
+"""
+FENCED = """```python
+from asyncio import get_event_loop as loop
+loop().run_until_complete(main())
+```"""
+'''
+
+    assert _numeric_mode_keyword_arguments(direct_source) == ["source: mode=7"]
+    assert _deprecated_api_usages(direct_source) == ["source: AGI._run"]
+    assert _numeric_mode_keyword_arguments(source) == ["string literal: mode=13"]
+    usages = set(_deprecated_api_usages(source))
+    assert "string literal: _A._run" in usages
+    assert "string literal: asyncio.get_event_loop" in usages
+    assert "string literal: get_event_loop (imported as loop)" in usages
+
+
+def test_example_ast_gates_ignore_docs_comments_prose_and_non_python_literals() -> None:
+    source = '''
+"""Documentation may mention AGI._run(app_env, mode=13)."""
+# AGI._run(app_env, mode=13)
+GUIDANCE = "Do not copy AGI._run(app_env, mode=13); prefer asyncio.run(main())."
+CONFIG = '{"mode": 13}'
+RUST = "fn mode() { 13 }"
+'''
+
+    assert _numeric_mode_keyword_arguments(source) == []
+    assert _deprecated_api_usages(source) == []
 
 
 def test_packaged_examples_avoid_magic_mode_literals() -> None:
@@ -1948,45 +2051,6 @@ def test_packaged_examples_avoid_magic_mode_literals() -> None:
             f"{script} passes raw numeric mode literals {offenders}; use the public "
             "AGI.PYTHON_MODE / AGI.CYTHON_MODE / AGI.DASK_MODE constants"
         )
-
-
-def _deprecated_api_usages(script_text: str) -> list[str]:
-    """Private AGI internals and the legacy event-loop runner, via AST.
-
-    Substring checks match a single spelling: `from asyncio import
-    get_event_loop` and `AGI as _A; _A._run(...)` both slip past a raw
-    `"asyncio.get_event_loop()" not in text` / `"AGI._" not in text` gate.
-    """
-
-    tree = ast.parse(script_text)
-    usages: list[str] = []
-
-    # Names bound to the AGI class, so aliased access is still caught.
-    agi_aliases = {"AGI"}
-    loop_aliases: set[str] = set()
-    for node in ast.walk(tree):
-        if isinstance(node, ast.ImportFrom):
-            for alias in node.names:
-                if alias.name == "AGI":
-                    agi_aliases.add(alias.asname or alias.name)
-                if node.module == "asyncio" and alias.name == "get_event_loop":
-                    loop_aliases.add(alias.asname or alias.name)
-
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Attribute):
-            value = node.value
-            if isinstance(value, ast.Name) and value.id in agi_aliases:
-                if node.attr.startswith("_"):
-                    usages.append(f"{value.id}.{node.attr}")
-            if (
-                isinstance(value, ast.Name)
-                and value.id == "asyncio"
-                and node.attr == "get_event_loop"
-            ):
-                usages.append("asyncio.get_event_loop")
-        elif isinstance(node, ast.Name) and node.id in loop_aliases:
-            usages.append(f"get_event_loop (imported as {node.id})")
-    return usages
 
 
 def test_packaged_preview_examples_avoid_private_agi_internals() -> None:

--- a/test/test_apps_pages_docs.py
+++ b/test/test_apps_pages_docs.py
@@ -19,6 +19,15 @@ def _page_modules() -> list[str]:
     )
 
 
+def _page_source_files() -> list[Path]:
+    """Return tracked page sources without traversing package-local environments."""
+
+    paths = set(APPS_PAGES_ROOT.glob("*.py"))
+    paths.update(APPS_PAGES_ROOT.glob("*/src/**/*.py"))
+    paths.update(APPS_PAGES_ROOT.glob("templates/**/src/**/*.py"))
+    return sorted(paths)
+
+
 def test_apps_pages_catalog_documents_every_source_bundle() -> None:
     catalog = (DOCS_SOURCE / "apps-pages.rst").read_text(encoding="utf-8")
     page_modules = _page_modules()
@@ -87,17 +96,115 @@ def test_view_prefix_remains_the_generic_page_family() -> None:
 
 
 def test_apps_pages_never_borrow_the_process_agienv_singleton() -> None:
-    source_files = sorted(APPS_PAGES_ROOT.rglob("*.py"))
+    source_files = _page_source_files()
+    source_files.append(
+        REPO_ROOT / "src/agilab/lib/agi-pages/src/agi_pages/queue_resilience.py"
+    )
     offenders: list[str] = []
     for source_file in source_files:
         source = source_file.read_text(encoding="utf-8", errors="ignore")
-        if (
-            "AgiEnv.for_app(" in source
-            or 'getattr(AgiEnv, "for_app"' in source
-            or "AgiEnv.current()" in source
-            or "AgiEnv(" in source
-        ):
+        tree = ast.parse(source)
+        borrows_singleton = False
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            if (
+                isinstance(node.func, ast.Attribute)
+                and node.func.attr == "for_app"
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "AgiEnv"
+            ):
+                borrows_singleton = True
+                break
+            if (
+                isinstance(node.func, ast.Attribute)
+                and node.func.attr == "current"
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "AgiEnv"
+            ):
+                borrows_singleton = True
+                break
+            if isinstance(node.func, ast.Name) and node.func.id == "AgiEnv":
+                borrows_singleton = True
+                break
+            if (
+                isinstance(node.func, ast.Name)
+                and node.func.id == "getattr"
+                and len(node.args) >= 2
+                and isinstance(node.args[0], ast.Name)
+                and node.args[0].id == "AgiEnv"
+                and isinstance(node.args[1], ast.Constant)
+                and node.args[1].value == "for_app"
+            ):
+                borrows_singleton = True
+                break
+        if borrows_singleton:
             offenders.append(str(source_file.relative_to(REPO_ROOT)))
+
+    assert offenders == []
+
+
+def test_apps_pages_configure_streamlit_before_rendering_shared_header() -> None:
+    class _DirectBodyCallVisitor(ast.NodeVisitor):
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, int]] = []
+
+        def visit_Call(self, node: ast.Call) -> None:
+            call_name = getattr(node.func, "id", None) or getattr(
+                node.func, "attr", None
+            )
+            if call_name:
+                self.calls.append((call_name, node.lineno))
+            self.generic_visit(node)
+
+        def visit_FunctionDef(self, _node: ast.FunctionDef) -> None:
+            return
+
+        def visit_AsyncFunctionDef(self, _node: ast.AsyncFunctionDef) -> None:
+            return
+
+        def visit_ClassDef(self, _node: ast.ClassDef) -> None:
+            return
+
+    offenders: list[str] = []
+    for source_file in _page_source_files():
+        tree = ast.parse(source_file.read_text(encoding="utf-8", errors="ignore"))
+        module_visitor = _DirectBodyCallVisitor()
+        for statement in tree.body:
+            module_visitor.visit(statement)
+        module_configure_lines = [
+            line
+            for name, line in module_visitor.calls
+            if name == "configure_streamlit_page"
+        ]
+        owners: list[ast.Module | ast.FunctionDef | ast.AsyncFunctionDef] = [tree]
+        owners.extend(
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        )
+        for owner in owners:
+            visitor = _DirectBodyCallVisitor()
+            for statement in owner.body:
+                visitor.visit(statement)
+            configure_lines = [
+                line for name, line in visitor.calls if name == "configure_streamlit_page"
+            ]
+            if owner is not tree:
+                configure_lines.extend(module_configure_lines)
+            header_lines = [
+                line
+                for name, line in visitor.calls
+                if name == "render_streamlit_page_header"
+            ]
+            if any(
+                not any(configure_line < header_line for configure_line in configure_lines)
+                for header_line in header_lines
+            ):
+                owner_name = getattr(owner, "name", "<module>")
+                offenders.append(
+                    f"{source_file.relative_to(REPO_ROOT)}:{owner_name}"
+                )
 
     assert offenders == []
 

--- a/test/test_architecture_scorecard.py
+++ b/test/test_architecture_scorecard.py
@@ -86,7 +86,7 @@ def test_remote_dask_worker_command_quotes_dynamic_fragments() -> None:
     assert tokens[:2] == ["env", "AGILAB_REMOTE=1"]
     assert "worker env/worker's env" in tokens
     assert "tcp://scheduler.example; touch /tmp/bad" in tokens
-    assert "worker env/worker pid.pid" in tokens
+    assert "worker env/worker's env/worker pid.pid" in tokens
     assert "; touch /tmp/bad --no-nanny" not in command
 
 

--- a/test/test_install_apps_discovery.py
+++ b/test/test_install_apps_discovery.py
@@ -222,22 +222,19 @@ printf 'PROMPT_FOR_APPS=%s\n' "$PROMPT_FOR_APPS"
 
 def _run_normalize_agi_python_version(raw: str, *, free_threaded: str = "0") -> subprocess.CompletedProcess[str]:
     script_text = INSTALL_APPS_SH.read_text(encoding="utf-8")
-    python_uv_spec_body = _extract_function(
-        script_text,
-        "python_uv_spec_for_version",
-        "normalize_agi_python_version",
-    )
     function_body = _extract_function(
         script_text,
         "normalize_agi_python_version",
-        "configure_uv_link_mode",
+        "normalize_agi_python_uv_spec",
     )
     bash_script = f"""#!/usr/bin/env bash
 set -euo pipefail
 RED=""
 NC=""
 AGI_PYTHON_FREE_THREADED="$2"
-{python_uv_spec_body}
+repo_python_default() {{
+  printf '%s\n' "3.13"
+}}
 {function_body}
 normalize_agi_python_version "$1"
 """
@@ -537,6 +534,7 @@ def test_install_apps_cli_selection_normalization(
 @pytest.mark.parametrize(
     ("raw", "expected"),
     [
+        ("", "3.13"),
         ("3.14", "3.14"),
         ("3.14.6-macos-aarch64-none", "3.14.6"),
         ("cpython-3.13.14-macos-aarch64-none", "3.13.14"),
@@ -558,6 +556,7 @@ def test_install_apps_python_version_normalization_accepts_standard_interpreters
     [
         ("3.14.6+freethreaded-macos-aarch64-none", "0"),
         ("/Users/agi/.local/bin/python3.14t", "0"),
+        ("cpython-3.14.0t-macos-aarch64-none", "0"),
         ("3.14.6", "1"),
     ],
 )

--- a/test/test_install_python_selection.py
+++ b/test/test_install_python_selection.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+import shlex
 import subprocess
 import sys
 import tomllib
@@ -9,8 +10,10 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 ROOT_INSTALLER = REPO_ROOT / "install.sh"
+WINDOWS_INSTALLER = REPO_ROOT / "install.ps1"
 CORE_INSTALLER = REPO_ROOT / "src/agilab/core/install.sh"
 ENDUSER_INSTALLER = REPO_ROOT / "tools/install_enduser.sh"
+APPS_INSTALLER = REPO_ROOT / "src/agilab/install_apps.sh"
 REPO_PYTHON_VERSION = REPO_ROOT / ".python-version"
 
 
@@ -51,6 +54,124 @@ def test_repo_default_python_pin_uses_standard_gil_build() -> None:
     assert REPO_PYTHON_VERSION.read_text(encoding="utf-8").strip() == "3.13"
 
 
+def test_windows_installer_default_follows_repo_python_pin() -> None:
+    text = WINDOWS_INSTALLER.read_text(encoding="utf-8")
+
+    assert 'Join-Path $CurrentPath ".python-version"' in text
+    assert "$defaultPython = Get-RepoPythonDefault" in text
+    assert 'Read-Host "Enter Python major version [$defaultPython]"' in text
+    assert '$requested = $defaultPython' in text
+
+
+def test_installers_read_validated_repo_python_default(tmp_path: Path) -> None:
+    pin = tmp_path / ".python-version"
+    pin.write_text("3.12.9\n", encoding="utf-8")
+
+    for installer in (ROOT_INSTALLER, ENDUSER_INSTALLER):
+        function = _extract_shell_function(
+            installer.read_text(encoding="utf-8"),
+            "repo_python_default",
+        )
+        completed = subprocess.run(
+            [
+                "bash",
+                "-c",
+                "\n".join(
+                    (
+                        "set -euo pipefail",
+                        "RED=''",
+                        "NC=''",
+                        function,
+                        f"repo_python_default {shlex.quote(str(pin))}",
+                    )
+                ),
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        assert completed.stdout.strip() == "3.12.9"
+
+        fallback = subprocess.run(
+            [
+                "bash",
+                "-c",
+                "\n".join(
+                    (
+                        "set -euo pipefail",
+                        "RED=''",
+                        "NC=''",
+                        function,
+                        f"repo_python_default {shlex.quote(str(tmp_path / 'missing'))}",
+                    )
+                ),
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        assert fallback.stdout.strip() == "3.13"
+
+
+def test_installers_reject_malformed_repo_python_default(tmp_path: Path) -> None:
+    pin = tmp_path / ".python-version"
+    pin.write_text("python-latest\n", encoding="utf-8")
+
+    for installer in (ROOT_INSTALLER, ENDUSER_INSTALLER):
+        function = _extract_shell_function(
+            installer.read_text(encoding="utf-8"),
+            "repo_python_default",
+        )
+        completed = subprocess.run(
+            [
+                "bash",
+                "-c",
+                "\n".join(
+                    (
+                        "set -euo pipefail",
+                        "RED=''",
+                        "NC=''",
+                        function,
+                        f"repo_python_default {shlex.quote(str(pin))}",
+                    )
+                ),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert completed.returncode != 0
+        assert "Invalid repository Python pin" in completed.stderr
+
+
+def test_standalone_app_installer_uses_repo_python_default(tmp_path: Path) -> None:
+    pin = tmp_path / ".python-version"
+    pin.write_text("3.12.8\n", encoding="utf-8")
+    text = APPS_INSTALLER.read_text(encoding="utf-8")
+    repo_default = _extract_shell_function(text, "repo_python_default")
+    normalize = _extract_shell_function(text, "normalize_agi_python_version")
+    completed = subprocess.run(
+        [
+            "bash",
+            "-c",
+            "\n".join(
+                (
+                    "set -euo pipefail",
+                    "RED=''",
+                    "NC=''",
+                    repo_default,
+                    f"repo_python_default {shlex.quote(str(pin))}",
+                )
+            ),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.stdout.strip() == "3.12.8"
+    assert '${AGI_PYTHON_VERSION:-3.14}' not in text
+    assert 'cpython-[0-9]+\\.[0-9]+' in normalize
+
+
 def test_root_installer_syncs_ui_dependencies_before_root_tests() -> None:
     root_tests = _extract_shell_function(
         ROOT_INSTALLER.read_text(encoding="utf-8"), "run_root_tests"
@@ -78,6 +199,8 @@ def test_core_installer_rejects_freethreaded_python_version_text() -> None:
 def test_enduser_installer_uses_gil_python_for_314_local_source_installs() -> None:
     text = ENDUSER_INSTALLER.read_text(encoding="utf-8")
     python_uv_spec = _extract_shell_function(text, "python_uv_spec_for_version")
+    selector_version = _extract_shell_function(text, "python_selector_version")
+    validate_selector = _extract_shell_function(text, "validate_python_selector")
     normalize_python = _extract_shell_function(text, "normalize_python_selection")
     completed = subprocess.run(
         [
@@ -103,6 +226,8 @@ def test_enduser_installer_uses_gil_python_for_314_local_source_installs() -> No
                     "AGI_PYTHON_VERSION='3.14.6'",
                     "AGI_PYTHON_UV_SPEC='3.14.6'",
                     python_uv_spec,
+                    selector_version,
+                    validate_selector,
                     normalize_python,
                     "normalize_python_selection",
                     "printf '%s\\n' \"$AGI_PYTHON_UV_SPEC\"",
@@ -126,12 +251,104 @@ def test_enduser_installer_uses_gil_python_for_314_local_source_installs() -> No
     assert 'if ! "${VENV}/bin/python" -m pip list | grep' not in text
 
 
+def test_enduser_default_follows_repo_pin_and_mismatch_fails_fast(
+    tmp_path: Path,
+) -> None:
+    pin = tmp_path / ".python-version"
+    pin.write_text("3.13\n", encoding="utf-8")
+    text = ENDUSER_INSTALLER.read_text(encoding="utf-8")
+    functions = "\n\n".join(
+        _extract_shell_function(text, name)
+        for name in (
+            "repo_python_default",
+            "python_uv_spec_for_version",
+            "python_selector_version",
+            "validate_python_selector",
+            "normalize_python_selection",
+        )
+    )
+    common = (
+        "set -euo pipefail",
+        "RED=''",
+        "NC=''",
+        f"REPO_ROOT={shlex.quote(str(tmp_path))}",
+        "unset AGI_PYTHON_VERSION AGI_PYTHON_UV_SPEC AGI_PYTHON_FREE_THREADED || true",
+        functions,
+    )
+    defaulted = subprocess.run(
+        [
+            "bash",
+            "-c",
+            "\n".join(
+                (
+                    *common,
+                    "normalize_python_selection",
+                    'printf "%s|%s\\n" "$AGI_PYTHON_VERSION" "$AGI_PYTHON_UV_SPEC"',
+                )
+            ),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert defaulted.stdout.strip() == "3.13|3.13"
+
+    mismatched = subprocess.run(
+        [
+            "bash",
+            "-c",
+            "\n".join(
+                (
+                    *common,
+                    "AGI_PYTHON_VERSION=3.13",
+                    "AGI_PYTHON_UV_SPEC=3.14+gil",
+                    "normalize_python_selection",
+                    "printf 'must-not-run\\n'",
+                )
+            ),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert mismatched.returncode != 0
+    assert "selects Python 3.14" in mismatched.stderr
+    assert "must-not-run" not in mismatched.stdout
+
+    freethreaded_selector = subprocess.run(
+        [
+            "bash",
+            "-c",
+            "\n".join(
+                (
+                    *common,
+                    "AGI_PYTHON_VERSION=3.13",
+                    "AGI_PYTHON_UV_SPEC=cpython-3.13.9t-windows-x86_64-none",
+                    "normalize_python_selection",
+                    "printf 'must-not-run\\n'",
+                )
+            ),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert freethreaded_selector.returncode != 0
+    assert "standard GIL Python interpreter" in freethreaded_selector.stderr
+    assert "must-not-run" not in freethreaded_selector.stdout
+
+    first_normalize = text.index(
+        "# Validate the interpreter contract before any existing venv can be removed."
+    )
+    assert first_normalize < text.index("rm -fr .venv uv.lock")
+
+
 def test_enduser_bootstrap_repairs_polluted_metadata_and_guarantees_pip(
     tmp_path: Path,
 ) -> None:
     text = ENDUSER_INSTALLER.read_text(encoding="utf-8")
     function_names = (
         "python_uv_spec_for_version",
+        "python_selector_version",
+        "validate_python_selector",
         "normalize_python_selection",
         "remove_incompatible_enduser_venv",
         "ensure_enduser_venv",

--- a/test/test_production_readiness_report.py
+++ b/test/test_production_readiness_report.py
@@ -4,6 +4,7 @@ import importlib.util
 import json
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 
 MODULE_PATH = Path("tools/production_readiness_report.py").resolve()
@@ -144,6 +145,10 @@ def test_runtime_robustness_matrix_executes_fail_closed_and_recovery_profiles() 
     assert check["details"]["scenario_count"] >= 16
     assert check["details"]["failed"] == []
     assert check["details"]["missing_recovery_scenarios"] == []
+    assert check["details"]["missing_recovery_evidence"] == []
+    assert check["details"]["abrupt_child_termination_observed"] is True
+    assert check["details"]["crash_termination_method"] in {"SIGKILL", "TerminateProcess"}
+    assert check["details"]["crash_child_returncode"] not in (None, 0)
     assert {"runner-state", "agent-trace", "workflow-evidence"} <= set(
         check["details"]["domains"]
     )
@@ -151,6 +156,49 @@ def test_runtime_robustness_matrix_executes_fail_closed_and_recovery_profiles() 
         "tools/robustness_matrix.py",
         "test/test_robustness_matrix.py",
     }
+
+
+def test_runtime_robustness_matrix_requires_observed_abrupt_child_termination(
+    monkeypatch,
+) -> None:
+    module = _load_module()
+    scenario_ids = {
+        "stale_runner_state_writer_is_rejected",
+        "crash_partial_agent_trace_tail_is_quarantined",
+        "interrupted_workflow_evidence_publish_recovers",
+        "tampered_workflow_evidence_manifest_is_rejected",
+    }
+    fake_report = {
+        "schema": "agilab.robustness_matrix.v1",
+        "profile": "all",
+        "status": "pass",
+        "available_profiles": ["p0", "p1-recovery", "all"],
+        "summary": {
+            "scenario_count": len(scenario_ids),
+            "domains": ["agent-trace", "runner-state", "workflow-evidence"],
+        },
+        "scenarios": [
+            {
+                "id": scenario_id,
+                "status": "pass",
+                "details": {},
+            }
+            for scenario_id in sorted(scenario_ids)
+        ],
+    }
+    fake_robustness_matrix = SimpleNamespace(
+        SCHEMA="agilab.robustness_matrix.v1",
+        build_report=lambda **_kwargs: fake_report,
+    )
+    monkeypatch.setattr(module, "_load_tool_module", lambda _name: fake_robustness_matrix)
+
+    check = module._check_runtime_robustness_matrix(Path.cwd())
+
+    assert check["status"] == "fail"
+    assert check["details"]["abrupt_child_termination_observed"] is False
+    assert check["details"]["missing_recovery_evidence"] == [
+        "crash_partial_agent_trace_tail_is_quarantined:abrupt_child_termination_observed"
+    ]
 
 
 def test_docs_workflow_profile_check_reports_expected_sphinx_command() -> None:

--- a/test/test_robustness_matrix.py
+++ b/test/test_robustness_matrix.py
@@ -64,6 +64,14 @@ def test_robustness_matrix_p1_recovery_passes_against_current_contracts() -> Non
     assert scenarios["stale_runner_state_writer_is_rejected"]["details"][
         "stale_write_preserved_current_state"
     ] is True
+    crash_details = scenarios["crash_partial_agent_trace_tail_is_quarantined"]["details"]
+    assert crash_details["abrupt_child_termination_observed"] is True
+    assert crash_details["child_ready"] is True
+    assert crash_details["child_returncode"] not in (None, 0)
+    assert crash_details["termination_method"] in {"SIGKILL", "TerminateProcess"}
+    assert crash_details["event_sequences"] == [1, 2]
+    assert crash_details["quarantine_count"] == 1
+    assert module._CHILD_SELF_EXIT_SECONDS > module._CHILD_READY_TIMEOUT_SECONDS
     assert scenarios["interrupted_workflow_evidence_publish_recovers"]["details"][
         "hidden_after_failure"
     ] is True

--- a/test/test_streamlit_156_adoption.py
+++ b/test/test_streamlit_156_adoption.py
@@ -28,6 +28,16 @@ FIRST_PARTY_STREAMLIT_MANIFESTS = [
 ]
 
 
+def _first_party_python_sources(root: Path) -> list[Path]:
+    sources: list[Path] = []
+    for path in sorted(root.rglob("*.py")):
+        relative_parts = path.relative_to(root).parts
+        if any(part == "build" or part.startswith(".venv") for part in relative_parts):
+            continue
+        sources.append(path)
+    return sources
+
+
 def test_first_party_streamlit_manifests_require_156_when_pinned() -> None:
     stale = []
     for manifest in FIRST_PARTY_STREAMLIT_MANIFESTS:
@@ -156,10 +166,21 @@ def test_source_checkout_streamlit_config_matches_packaged_theme() -> None:
 
 def test_first_party_streamlit_code_uses_width_api() -> None:
     offenders = []
-    for path in sorted(Path("src/agilab").rglob("*.py")):
-        if ".venv" in path.parts or "build" in path.parts:
-            continue
+    for path in _first_party_python_sources(Path("src/agilab")):
         if b"use_container_width" in path.read_bytes():
             offenders.append(str(path))
 
     assert offenders == []
+
+
+def test_first_party_streamlit_inventory_ignores_polluted_local_venvs(tmp_path: Path) -> None:
+    first_party = tmp_path / "page.py"
+    linked_venv = tmp_path / ".venv.agilab-linking" / "lib" / "site-packages" / "streamlit.py"
+    first_party.write_text("import streamlit\n", encoding="utf-8")
+    linked_venv.parent.mkdir(parents=True)
+    linked_venv.write_text("use_container_width = True\n", encoding="utf-8")
+
+    sources = _first_party_python_sources(tmp_path)
+
+    assert first_party in sources
+    assert linked_venv not in sources

--- a/test/test_view_maps_network.py
+++ b/test/test_view_maps_network.py
@@ -257,7 +257,10 @@ def test_view_maps_network_persists_app_settings(tmp_path: Path, monkeypatch) ->
         }
     )
 
-    module._persist_app_settings(SimpleNamespace(app_settings_file=settings_path))
+    module._persist_app_settings(
+        SimpleNamespace(app_settings_file=settings_path),
+        ("dataset_base_choice", "df_file", "df_files"),
+    )
 
     written = settings_path.read_text(encoding="utf-8")
     assert "view_maps_network" in written
@@ -266,6 +269,39 @@ def test_view_maps_network_persists_app_settings(tmp_path: Path, monkeypatch) ->
     assert parsed["__meta__"] == {"schema": "agilab.app_settings.v1", "version": 1}
     assert parsed["view_maps_network"]["df_file"] == ""
     assert parsed["view_maps_network"]["df_files"] == ["export.csv", ""]
+
+
+def test_view_maps_network_uses_strict_shared_env_scope_guard() -> None:
+    source = MODULE_PATH.read_text(encoding="utf-8")
+
+    assert "env = ensure_app_scoped_env(" in source
+    assert "env_factory=_create_env" in source
+
+
+def test_view_maps_network_preserves_other_session_leaf_and_local_reference(
+    tmp_path: Path, monkeypatch
+) -> None:
+    module = _load_view_maps_network_module(monkeypatch, tmp_path)
+    settings_path = tmp_path / "app_settings.toml"
+    settings_path.write_text(
+        '[view_maps_network]\nedges_file = "current.csv"\ntraj_glob = "fresh/*.csv"\n',
+        encoding="utf-8",
+    )
+    vm_settings = {"edges_file": "next.csv", "traj_glob": "stale/*.csv"}
+    app_settings = {"view_maps_network": vm_settings}
+    module.st = SimpleNamespace(session_state={"app_settings": app_settings})
+
+    module._persist_app_settings(
+        SimpleNamespace(app_settings_file=settings_path),
+        ("edges_file",),
+    )
+
+    assert module.st.session_state["app_settings"] is app_settings
+    assert module.st.session_state["app_settings"]["view_maps_network"] is vm_settings
+    assert vm_settings == {
+        "edges_file": "next.csv",
+        "traj_glob": "fresh/*.csv",
+    }
 
 
 def test_view_maps_network_drops_ambiguous_index_levels(
@@ -1476,12 +1512,17 @@ def test_view_maps_network_handles_settings_and_active_app_error_paths(
 
     persist_path = tmp_path / "persist.toml"
     module.st = SimpleNamespace(session_state={"app_settings": "bad"})
-    module._persist_app_settings(SimpleNamespace(app_settings_file=persist_path))
+    module._persist_app_settings(
+        SimpleNamespace(app_settings_file=persist_path),
+        ("dataset_base_choice",),
+    )
     assert not persist_path.exists()
 
     warnings: list[str] = []
     module.st = SimpleNamespace(
-        session_state={"app_settings": {"view_maps_network": {}}}
+        session_state={
+            "app_settings": {"view_maps_network": {"probe": "value"}}
+        }
     )
     monkeypatch.setattr(
         module.logger, "warning", lambda message: warnings.append(message)
@@ -1492,7 +1533,8 @@ def test_view_maps_network_handles_settings_and_active_app_error_paths(
         lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("cannot write")),
     )
     module._persist_app_settings(
-        SimpleNamespace(app_settings_file=tmp_path / "nested" / "persist.toml")
+        SimpleNamespace(app_settings_file=tmp_path / "nested" / "persist.toml"),
+        ("probe",),
     )
     assert any("Unable to persist app_settings" in message for message in warnings)
 
@@ -1521,7 +1563,9 @@ def test_view_maps_network_unexpected_helper_errors_propagate(
 
     warnings: list[str] = []
     module.st = SimpleNamespace(
-        session_state={"app_settings": {"view_maps_network": {}}}
+        session_state={
+            "app_settings": {"view_maps_network": {"probe": "value"}}
+        }
     )
     monkeypatch.setattr(
         module.logger, "warning", lambda message: warnings.append(message)
@@ -1532,7 +1576,8 @@ def test_view_maps_network_unexpected_helper_errors_propagate(
         lambda *_args, **_kwargs: (_ for _ in ()).throw(ValueError("bad dump")),
     )
     module._persist_app_settings(
-        SimpleNamespace(app_settings_file=tmp_path / "persist.toml")
+        SimpleNamespace(app_settings_file=tmp_path / "persist.toml"),
+        ("probe",),
     )
     assert any(
         "Unable to persist app_settings" in message and "bad dump" in message

--- a/test/test_view_queue_resilience.py
+++ b/test/test_view_queue_resilience.py
@@ -337,6 +337,8 @@ def test_view_queue_resilience_reuses_existing_session_env(
             AGILAB_EXPORT_ABS=export_root,
             target="uav_queue",
             st_resources=tmp_path / "resources",
+            apps_path=project_dir.parent,
+            app=project_dir.name,
         )
         at.session_state["queue_resilience_active_app_scope"] = str(
             project_dir.resolve()

--- a/test/test_view_training_analysis.py
+++ b/test/test_view_training_analysis.py
@@ -392,7 +392,7 @@ def test_view_training_analysis_loads_and_persists_app_settings(tmp_path: Path) 
     assert module.st.session_state["app_settings"]["view_training_analysis"]["trainer"] == "alpha"
 
     module.st.session_state["app_settings"] = {"view_training_analysis": {"trainer": "beta"}}
-    module._persist_app_settings(env)
+    module._persist_app_settings(env, ("trainer",))
     assert "view_training_analysis" in settings_path.read_text(encoding="utf-8")
 
     module.st = SimpleNamespace(session_state={})
@@ -402,6 +402,29 @@ def test_view_training_analysis_loads_and_persists_app_settings(tmp_path: Path) 
 
     module.st = SimpleNamespace(session_state={"app_settings": {"pages": {module.PAGE_KEY: {"tags": ["x"]}}}})
     assert module._get_page_defaults() == {"tags": ["x"]}
+
+
+def test_view_training_analysis_preserves_other_session_leaf_and_page_reference(
+    tmp_path: Path,
+) -> None:
+    module = _load_module()
+    settings_path = tmp_path / "app_settings.toml"
+    settings_path.write_text(
+        '[view_training_analysis]\ntrainer = "current"\nx_axis = "wall_time"\n',
+        encoding="utf-8",
+    )
+    page_state = {"trainer": "next", "x_axis": "stale"}
+    app_settings = {module.PAGE_KEY: page_state}
+    module.st = SimpleNamespace(session_state={"app_settings": app_settings})
+
+    module._persist_app_settings(
+        SimpleNamespace(app_settings_file=settings_path),
+        ("trainer",),
+    )
+
+    assert module.st.session_state["app_settings"] is app_settings
+    assert module.st.session_state["app_settings"][module.PAGE_KEY] is page_state
+    assert page_state == {"trainer": "next", "x_axis": "wall_time"}
 
 
 def test_view_training_analysis_repo_path_and_setting_helpers(monkeypatch, tmp_path: Path) -> None:
@@ -692,6 +715,14 @@ def test_view_training_analysis_main_bootstraps_env_when_missing(monkeypatch, tm
     warnings_seen: list[str] = []
 
     class FakeEnv:
+        @classmethod
+        def session_for_app(cls, **kwargs):
+            return cls(**kwargs)
+
+        @classmethod
+        def for_app(cls, **_kwargs):
+            raise AssertionError("analysis pages must not borrow the process singleton")
+
         def __init__(self, apps_path, app, verbose):
             self.apps_path = apps_path
             self.app = app
@@ -761,6 +792,14 @@ def test_view_training_analysis_main_resets_state_when_active_app_changes(
     )
 
     class FakeEnv:
+        @classmethod
+        def session_for_app(cls, **kwargs):
+            return cls(**kwargs)
+
+        @classmethod
+        def for_app(cls, **_kwargs):
+            raise AssertionError("analysis pages must not borrow the process singleton")
+
         def __init__(self, apps_path, app, verbose):
             self.apps_path = apps_path
             self.app = app
@@ -812,6 +851,10 @@ def test_view_training_analysis_main_resets_state_when_active_app_changes(
     assert module.st.session_state["env"].app == "new_trainer_project"
     assert module.st.session_state["env"].init_done is True
     assert module.st.session_state["app_settings"] == {
+        "__meta__": {
+            "schema": "agilab.app_settings.v1",
+            "version": 1,
+        },
         "view_training_analysis": {
             "base_dir_choice": "AGILAB_EXPORT",
             "datadir_rel": "",
@@ -1052,16 +1095,33 @@ def test_view_training_analysis_handles_active_app_and_settings_error_paths(monk
     assert module.st.session_state["app_settings"] == {}
 
     module.st = SimpleNamespace(session_state={"app_settings": "bad"})
-    module._persist_app_settings(SimpleNamespace(app_settings_file=tmp_path / "persist.toml"))
+    module._persist_app_settings(
+        SimpleNamespace(app_settings_file=tmp_path / "persist.toml"),
+        ("trainer",),
+    )
     assert not (tmp_path / "persist.toml").exists()
 
-    module.st = SimpleNamespace(session_state={"app_settings": {"view_training_analysis": {}}})
+    warnings: list[str] = []
+    module.st = SimpleNamespace(
+        session_state={
+            "app_settings": {"view_training_analysis": {"probe": "value"}}
+        }
+    )
+    monkeypatch.setattr(
+        module.logger,
+        "warning",
+        lambda message, *args: warnings.append(message % args),
+    )
     monkeypatch.setattr(
         module,
         "_dump_toml",
         lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("dump failed")),
     )
-    module._persist_app_settings(SimpleNamespace(app_settings_file=tmp_path / "persist.toml"))
+    module._persist_app_settings(
+        SimpleNamespace(app_settings_file=tmp_path / "persist.toml"),
+        ("probe",),
+    )
+    assert any("Unable to persist app_settings" in message for message in warnings)
 
     assert module._coerce_str_list(None) == []
     assert module._coerce_str_list(("a", "b", "a")) == ["a", "b"]
@@ -1088,14 +1148,19 @@ def test_view_training_analysis_unexpected_settings_helper_errors_propagate(
             SimpleNamespace(app_settings_file=settings_path),
         )
 
-    module.st = SimpleNamespace(session_state={"app_settings": {module.PAGE_KEY: {}}})
+    module.st = SimpleNamespace(
+        session_state={"app_settings": {module.PAGE_KEY: {"probe": "value"}}}
+    )
     monkeypatch.setattr(
         module,
         "_dump_toml",
         lambda *_args, **_kwargs: (_ for _ in ()).throw(ValueError("bad dump")),
     )
     with pytest.raises(ValueError, match="bad dump"):
-        module._persist_app_settings(SimpleNamespace(app_settings_file=tmp_path / "persist.toml"))
+        module._persist_app_settings(
+            SimpleNamespace(app_settings_file=tmp_path / "persist.toml"),
+            ("probe",),
+        )
 
     monkeypatch.setattr(Path, "resolve", lambda self: (_ for _ in ()).throw(TypeError("bad path")))
     with pytest.raises(TypeError, match="bad path"):

--- a/tools/architecture_scorecard.py
+++ b/tools/architecture_scorecard.py
@@ -111,7 +111,8 @@ def _check_runtime_guardrails(repo_root: Path) -> dict[str, Any]:
         label="Runtime fail-closed guardrails",
         pass_summary=(
             "robustness matrix covers public UI bind, cluster share, evidence manifest, "
-            "notebook import, service, route, stale-state, trace-repair, and evidence-recovery bad states"
+            "notebook import, service, route, stale-state, owned child-process crash recovery, "
+            "trace repair, and evidence-recovery bad states"
         ),
         fail_summary="runtime robustness matrix does not cover the expected architecture guardrails",
         required={
@@ -124,6 +125,8 @@ def _check_runtime_guardrails(repo_root: Path) -> dict[str, Any]:
                 "RECOVERY_PROFILE = \"p1-recovery\"",
                 "stale_runner_state_writer_is_rejected",
                 "crash_partial_agent_trace_tail_is_quarantined",
+                "abrupt_child_termination_observed",
+                "_CHILD_SELF_EXIT_SECONDS",
                 "interrupted_workflow_evidence_publish_recovers",
                 "tampered_workflow_evidence_manifest_is_rejected",
             ],
@@ -131,6 +134,7 @@ def _check_runtime_guardrails(repo_root: Path) -> dict[str, Any]:
                 "test_robustness_matrix_p0_passes_against_current_contracts",
                 "test_robustness_matrix_p1_recovery_passes_against_current_contracts",
                 "test_robustness_matrix_all_profile_combines_fail_closed_and_recovery",
+                "abrupt_child_termination_observed",
             ],
         },
     )

--- a/tools/install_enduser.sh
+++ b/tools/install_enduser.sh
@@ -30,6 +30,27 @@ configure_uv_link_mode() {
 configure_uv_link_mode
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+repo_python_default() {
+  local pin_file="${1:-${REPO_ROOT:-${SCRIPT_DIR}/..}/.python-version}"
+  local fallback="3.13"
+  if [[ ! -e "$pin_file" ]]; then
+    printf '%s\n' "$fallback"
+    return 0
+  fi
+  if [[ ! -r "$pin_file" ]]; then
+    echo -e "${RED}[error] Cannot read repository Python pin: ${pin_file}.${NC}" >&2
+    return 1
+  fi
+
+  local pinned
+  IFS= read -r pinned < "$pin_file" || true
+  if [[ ! "$pinned" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
+    echo -e "${RED}[error] Invalid repository Python pin '${pinned}' in ${pin_file}; expected major.minor or major.minor.patch.${NC}" >&2
+    return 1
+  fi
+  printf '%s\n' "$pinned"
+}
+
 python_uv_spec_for_version() {
   local version="${1:-}"
   case "$version" in
@@ -46,9 +67,57 @@ python_uv_spec_for_version() {
   esac
 }
 
+python_selector_version() {
+  local selector="${1:-}"
+  if [[ "$selector" =~ ^(cpython-|python)?[0-9]+\.[0-9]+(\.[0-9]+)?t($|[^[:alnum:]]) ]]; then
+    return 1
+  fi
+  if [[ -x "$selector" ]]; then
+    "$selector" - <<'PY'
+import sys
+
+if "t" in getattr(sys, "abiflags", "") or not getattr(
+    sys, "_is_gil_enabled", lambda: True
+)():
+    raise SystemExit(1)
+print(".".join(str(part) for part in sys.version_info[:3]))
+PY
+    return
+  fi
+
+  if [[ "$selector" =~ ^([0-9]+\.[0-9]+(\.[0-9]+)?)(\+gil)?$ ]]; then
+    printf '%s\n' "${BASH_REMATCH[1]}"
+  elif [[ "$selector" =~ ^cpython-([0-9]+\.[0-9]+(\.[0-9]+)?)([^0-9].*)?$ ]]; then
+    printf '%s\n' "${BASH_REMATCH[1]}"
+  elif [[ "$selector" =~ ^python([0-9]+\.[0-9]+(\.[0-9]+)?)([^0-9].*)?$ ]]; then
+    printf '%s\n' "${BASH_REMATCH[1]}"
+  else
+    return 1
+  fi
+}
+
+validate_python_selector() {
+  local python_version="$1"
+  local selector="$2"
+  local selector_version
+  if ! selector_version="$(python_selector_version "$selector")"; then
+    echo -e "${RED}[error] Unsupported AGI_PYTHON_UV_SPEC '${selector}': use a standard GIL Python selector or executable path.${NC}" >&2
+    return 1
+  fi
+  case "$selector_version" in
+    "$python_version"|"$python_version".*) return 0 ;;
+    *)
+      echo -e "${RED}[error] AGI_PYTHON_UV_SPEC '${selector}' selects Python ${selector_version}, but AGI_PYTHON_VERSION '${python_version}' requires a matching interpreter. Unset AGI_PYTHON_UV_SPEC or provide a matching selector.${NC}" >&2
+      return 1
+      ;;
+  esac
+}
+
 normalize_python_selection() {
-  local raw="${AGI_PYTHON_VERSION:-3.14}"
-  [[ -n "$raw" ]] || raw="3.14"
+  local raw="${AGI_PYTHON_VERSION:-}"
+  if [[ -z "$raw" ]]; then
+    raw="$(repo_python_default)" || exit 1
+  fi
   if [[ "$raw" == *freethreaded* \
      || "$raw" =~ (^|[^[:alnum:]])python3\.[0-9]+t([^[:alnum:]]|$) \
      || "$raw" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?t($|[^[:alnum:]]) ]]; then
@@ -60,6 +129,10 @@ normalize_python_selection() {
     exit 1
   fi
   AGI_PYTHON_VERSION="${raw%%+*}"
+  if [[ ! "$AGI_PYTHON_VERSION" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
+    echo -e "${RED}[error] Invalid AGI_PYTHON_VERSION '${raw}': expected major.minor or major.minor.patch.${NC}" >&2
+    exit 1
+  fi
   AGI_PYTHON_FREE_THREADED=0
   local desired_uv_spec
   desired_uv_spec="$(python_uv_spec_for_version "$AGI_PYTHON_VERSION")"
@@ -68,10 +141,12 @@ normalize_python_selection() {
   fi
   if [[ "$AGI_PYTHON_UV_SPEC" == *freethreaded* \
      || "$AGI_PYTHON_UV_SPEC" =~ (^|[^[:alnum:]])python3\.[0-9]+t([^[:alnum:]]|$) \
+     || "$AGI_PYTHON_UV_SPEC" =~ ^cpython-[0-9]+\.[0-9]+(\.[0-9]+)?t($|[^[:alnum:]]) \
      || "$AGI_PYTHON_UV_SPEC" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?t($|[^[:alnum:]]) ]]; then
     echo -e "${RED}[error] Unsupported AGI_PYTHON_UV_SPEC '${AGI_PYTHON_UV_SPEC}': end-user installs require a standard GIL Python interpreter.${NC}" >&2
     exit 1
   fi
+  validate_python_selector "$AGI_PYTHON_VERSION" "$AGI_PYTHON_UV_SPEC" || exit 1
   export AGI_PYTHON_VERSION
   export AGI_PYTHON_FREE_THREADED
   export AGI_PYTHON_UV_SPEC
@@ -597,6 +672,9 @@ if (( DRY_RUN )); then
   print_dry_run_plan
   exit 0
 fi
+
+# Validate the interpreter contract before any existing venv can be removed.
+normalize_python_selection
 
 if [[ "$SOURCE" == "local" ]]; then
   if [[ -z "${AGI_INSTALL_PATH}" || ! -d "${AGI_INSTALL_PATH}" ]]; then

--- a/tools/production_readiness_report.py
+++ b/tools/production_readiness_report.py
@@ -298,23 +298,45 @@ def _check_runtime_robustness_matrix(repo_root: Path) -> dict[str, Any]:
             for scenario in scenarios
             if isinstance(scenario, Mapping) and scenario.get("id")
         }
+        scenario_by_id = {
+            str(scenario.get("id")): scenario
+            for scenario in scenarios
+            if isinstance(scenario, Mapping) and scenario.get("id")
+        }
         failed = [
             str(scenario.get("id"))
             for scenario in scenarios
             if isinstance(scenario, Mapping) and scenario.get("status") != "pass"
         ]
         missing_recovery_scenarios = sorted(required_recovery_scenarios - scenario_ids)
+        crash_scenario = scenario_by_id.get("crash_partial_agent_trace_tail_is_quarantined", {})
+        crash_details = crash_scenario.get("details", {})
+        if not isinstance(crash_details, Mapping):
+            crash_details = {}
+        abrupt_child_termination_observed = (
+            crash_details.get("abrupt_child_termination_observed") is True
+        )
+        missing_recovery_evidence = (
+            []
+            if abrupt_child_termination_observed
+            else [
+                "crash_partial_agent_trace_tail_is_quarantined:"
+                "abrupt_child_termination_observed"
+            ]
+        )
         ok = (
             report.get("schema") == robustness_matrix.SCHEMA
             and report.get("profile") == "all"
             and report.get("status") == "pass"
             and not failed
             and not missing_recovery_scenarios
+            and not missing_recovery_evidence
         )
         summary = (
-            "the full fail-closed and crash-recovery robustness matrix passes"
+            "the full fail-closed and owned child-process crash-recovery matrix passes"
             if ok
-            else "the runtime robustness matrix is failing or missing required recovery scenarios"
+            else "the runtime robustness matrix is failing, missing required recovery scenarios, "
+            "or lacks observed abrupt child-process termination evidence"
         )
         details = {
             "schema": report.get("schema"),
@@ -324,6 +346,10 @@ def _check_runtime_robustness_matrix(repo_root: Path) -> dict[str, Any]:
             "domains": report.get("summary", {}).get("domains", []),
             "failed": failed,
             "missing_recovery_scenarios": missing_recovery_scenarios,
+            "missing_recovery_evidence": missing_recovery_evidence,
+            "abrupt_child_termination_observed": abrupt_child_termination_observed,
+            "crash_termination_method": crash_details.get("termination_method", ""),
+            "crash_child_returncode": crash_details.get("child_returncode"),
         }
     except Exception as exc:
         ok = False
@@ -332,6 +358,11 @@ def _check_runtime_robustness_matrix(repo_root: Path) -> dict[str, Any]:
             "error": str(exc),
             "failed": [],
             "missing_recovery_scenarios": sorted(required_recovery_scenarios),
+            "missing_recovery_evidence": [
+                "crash_partial_agent_trace_tail_is_quarantined:"
+                "abrupt_child_termination_observed"
+            ],
+            "abrupt_child_termination_observed": False,
         }
     return _check_result(
         "runtime_robustness_matrix",

--- a/tools/robustness_matrix.py
+++ b/tools/robustness_matrix.py
@@ -8,10 +8,14 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 import importlib.util
 import json
+import os
 from pathlib import Path
 import re
+import signal
+import subprocess
 import sys
 import tempfile
+import time
 from typing import Any, Callable, Mapping, Sequence
 
 
@@ -19,6 +23,10 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 SCHEMA = "agilab.robustness_matrix.v1"
 DEFAULT_PROFILE = "p0"
 RECOVERY_PROFILE = "p1-recovery"
+_AGENT_TRACE_PARTIAL_TAIL = b'{"partial"'
+_CHILD_READY_TIMEOUT_SECONDS = 10.0
+_CHILD_REAP_TIMEOUT_SECONDS = 5.0
+_CHILD_SELF_EXIT_SECONDS = 20.0
 
 
 def _ensure_repo_on_path(repo_root: Path) -> None:
@@ -363,6 +371,80 @@ def _runner_state_stale_writer_rejected(repo_root: Path, tmp_root: Path) -> Scen
     )
 
 
+def _agent_trace_crash_child(
+    repo_root: Path,
+    trace_root: Path,
+    ready_path: Path,
+    expected_parent_pid: int,
+) -> int:
+    """Write a durable partial tail while locked, then wait to be killed by its parent."""
+
+    _ensure_repo_on_path(repo_root)
+    from agilab.agent_runtime.agent_trace import EVENTS_FILENAME, trace_file_lock
+
+    events_path = trace_root / EVENTS_FILENAME
+    with trace_file_lock(events_path):
+        with events_path.open("ab") as handle:
+            handle.write(_AGENT_TRACE_PARTIAL_TAIL)
+            handle.flush()
+            os.fsync(handle.fileno())
+        ready_path.parent.mkdir(parents=True, exist_ok=True)
+        with ready_path.open("w", encoding="utf-8") as handle:
+            handle.write("ready\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        deadline = time.monotonic() + _CHILD_SELF_EXIT_SECONDS
+        while time.monotonic() < deadline:
+            if os.getppid() != expected_parent_pid:
+                return 2
+            time.sleep(0.05)
+        return 3
+
+
+def _wait_for_owned_child_ready(
+    process: subprocess.Popen[str],
+    ready_path: Path,
+) -> bool:
+    deadline = time.monotonic() + _CHILD_READY_TIMEOUT_SECONDS
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            return False
+        try:
+            if ready_path.read_text(encoding="utf-8") == "ready\n":
+                return True
+        except (OSError, UnicodeError):
+            pass
+        time.sleep(0.01)
+    return False
+
+
+def _kill_owned_child(process: subprocess.Popen[str]) -> bool:
+    if process.poll() is not None:
+        return False
+    try:
+        process.kill()
+    except OSError:
+        if process.poll() is None:
+            raise
+        return False
+    return True
+
+
+def _reap_owned_child(process: subprocess.Popen[str]) -> tuple[int | None, str]:
+    """Bound cleanup and diagnostics to the exact child process created by this scenario."""
+
+    try:
+        _stdout, stderr = process.communicate(timeout=_CHILD_REAP_TIMEOUT_SECONDS)
+    except subprocess.TimeoutExpired:
+        _kill_owned_child(process)
+        try:
+            _stdout, stderr = process.communicate(timeout=_CHILD_REAP_TIMEOUT_SECONDS)
+        except subprocess.TimeoutExpired:
+            return process.poll(), "owned child did not exit after bounded kill and reap"
+    stderr_text = (stderr or "").strip()
+    return process.returncode, stderr_text[-500:]
+
+
 def _agent_trace_partial_tail_recovers(repo_root: Path, tmp_root: Path) -> ScenarioObservation:
     _ensure_repo_on_path(repo_root)
     from agilab.agent_runtime.agent_trace import (
@@ -371,30 +453,70 @@ def _agent_trace_partial_tail_recovers(repo_root: Path, tmp_root: Path) -> Scena
         load_trace_events,
     )
 
-    partial_tail = b'{"partial"'
     store = AgentTraceStore(tmp_root, run_id="robustness-recovery", agent="codex")
     first = store.append("session_start")
-    with store.events_path.open("ab") as handle:
-        handle.write(partial_tail)
+    ready_path = tmp_root / "child-ready"
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            str(Path(__file__).resolve()),
+            "--_agent-trace-crash-child",
+            str(repo_root),
+            str(tmp_root),
+            str(ready_path),
+            str(os.getpid()),
+        ],
+        cwd=repo_root,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    child_ready = False
+    scenario_kill_requested = False
+    try:
+        child_ready = _wait_for_owned_child_ready(process, ready_path)
+        if child_ready:
+            scenario_kill_requested = _kill_owned_child(process)
+    finally:
+        _kill_owned_child(process)
+        child_returncode, child_stderr_tail = _reap_owned_child(process)
+
+    termination_method = "SIGKILL" if os.name == "posix" else "TerminateProcess"
+    abrupt_child_termination_observed = (
+        child_ready and scenario_kill_requested and child_returncode not in (None, 0)
+    )
+    if os.name == "posix" and hasattr(signal, "SIGKILL"):
+        abrupt_child_termination_observed = (
+            abrupt_child_termination_observed
+            and child_returncode == -int(signal.SIGKILL)
+        )
 
     second = store.append("session_end", status="pass")
     events = load_trace_events(tmp_root)
     quarantined = sorted(tmp_root.glob(f".{EVENTS_FILENAME}.partial.*.jsonl"))
     passed = (
-        (first.sequence, second.sequence) == (1, 2)
+        abrupt_child_termination_observed
+        and (first.sequence, second.sequence) == (1, 2)
         and [event.sequence for event in events] == [1, 2]
         and len(quarantined) == 1
-        and quarantined[0].read_bytes() == partial_tail
+        and quarantined[0].read_bytes() == _AGENT_TRACE_PARTIAL_TAIL
         and store.events_path.read_bytes().endswith(b"\n")
     )
     return ScenarioObservation(
         passed=passed,
         observed=(
-            "The crash-partial JSONL tail was quarantined and sequence 2 appended cleanly."
+            "An owned child process was abruptly terminated after fsyncing a partial JSONL "
+            "tail; the tail was quarantined and sequence 2 appended cleanly."
             if passed
-            else "The crash-partial JSONL tail was not recovered without trace loss."
+            else "The owned child-process crash was not observed or its partial tail was not "
+            "recovered without trace loss."
         ),
         details={
+            "abrupt_child_termination_observed": abrupt_child_termination_observed,
+            "child_ready": child_ready,
+            "child_returncode": child_returncode,
+            "child_stderr_tail": child_stderr_tail,
+            "termination_method": termination_method if scenario_kill_requested else "",
             "event_sequences": [event.sequence for event in events],
             "quarantine_count": len(quarantined),
             "quarantined_bytes": len(quarantined[0].read_bytes()) if quarantined else 0,
@@ -813,11 +935,27 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--compact", action="store_true", help="Emit compact JSON.")
     parser.add_argument("--json", action="store_true", help="Alias for --compact.")
     parser.add_argument("--list-scenarios", action="store_true", help="List scenario ids and exit.")
+    parser.add_argument(
+        "--_agent-trace-crash-child",
+        nargs=4,
+        help=argparse.SUPPRESS,
+    )
     return parser
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = _build_parser().parse_args(list(argv) if argv is not None else None)
+    if args._agent_trace_crash_child:
+        repo_root, trace_root, ready_path = (
+            Path(value) for value in args._agent_trace_crash_child[:3]
+        )
+        expected_parent_pid = int(args._agent_trace_crash_child[3])
+        return _agent_trace_crash_child(
+            repo_root,
+            trace_root,
+            ready_path,
+            expected_parent_pid,
+        )
     if args.list_scenarios:
         for scenario in SCENARIOS:
             print(f"{scenario.id}\t{scenario.domain}")


### PR DESCRIPTION
## Summary

- Restore transactional owned-key app settings updates, session-scoped environments, strict live scope validation, and wide page configuration across the affected ANALYSIS pages and template.
- Make process cleanup safe on Windows and usable offline by reusing installed worker or manager interpreters before a bounded uv bootstrap.
- Align installer Python defaults with the validated repository pin and strengthen crash-recovery and embedded-snippet evidence gates.

## Linked Issue

- N/A; remediation of the 2026-07-20 merged-commit review.

## Repro

- A long-lived ANALYSIS session could overwrite another process settings because three pages rewrote the complete stale TOML snapshot without the owned-key lock and atomic merge.
- Six page/helper paths borrowed the process-wide AgiEnv singleton, and cached environments with no proven scope were accepted.
- Windows cmd.exe parsed the single-quoted psutil constraint as redirection, while cold cleanup required network resolution even when an installed environment was available.
- The repository pinned Python 3.13 while installer defaults and docs selected 3.14.
- Recovery evidence injected an exception without abruptly terminating a process, and AST example gates skipped parseable Python embedded in strings.

## Root Cause

A stale pre-rebase page implementation replaced newer session and persistence contracts, duplicated installer defaults drifted from the repository pin, and POSIX-only command quoting crossed into Windows shell execution. Evidence gates covered the intended concepts but omitted the actual crash and embedded-snippet paths.

## Regression Test

- Restored multi-writer settings preservation and session/factory scope validation tests.
- Added Windows missing-worker-venv cleanup, installed-worker reuse, selector mismatch, free-threaded selector, and polluted local-venv inventory regressions.
- Added owned-child abrupt termination evidence and dedented/fenced embedded Python AST cases.
- Added structural page configuration and singleton-borrowing guards.

## Scope

- Affected repo areas: ANALYSIS page bundles, agi-pages runtime helper, agi-cluster cleanup, installers and environment defaults, robustness/readiness tooling, canonical docs mirror, focused tests.
- User-facing impact: prevents cross-session settings clobbering, restores wide page layout, repairs Windows cleanup, and removes Python-version churn.
- Runtime / packaging / docs impact: runtime safety and installer behavior change; no new dependency; docs mirror is synchronized from thales_agilab PR #152.
- Stability boundary: runtime core, beta UI, installer, evidence tooling, and docs. This is one coherent review-remediation scope; splitting it would leave shared contracts and their gates temporarily inconsistent.

## Validation

- [x] Targeted local tests ran
- [x] CI-relevant checks considered
- [x] Docs updated if needed

Commands / checks run:

- `./dev impact` — passed for all 38 staged files.
- Full `src/agilab/core/agi-env/test` — 988 passed, 1 skipped.
- Full `src/agilab/core/test` — 1,495 passed, 5 skipped.
- `tools/workflow_parity.py --profile agi-gui` — 3,700 tests passed across seven chunks; 95.87% line and 89.52% branch coverage.
- `tools/workflow_parity.py --profile docs` — passed, including warning-free Sphinx build.
- `./dev app-contracts` — passed with zero failed projects.
- Targeted installer/environment slice — 110 passed.
- Focused page, agi-pages, cleanup, robustness, and readiness suites — passed.
- Shell syntax, PowerShell parsing, mirror-stamp verification, and `git diff --check` — passed.
- Browser robot: not applicable; this restores existing page configuration and runtime contracts without introducing a new visual interaction. Structural guards and the full AGI-GUI profile cover the affected surface.
- GitHub Windows core run 29816203643 exposed three native-path assertion mismatches after 2,500 tests passed. Assertions were normalized to platform-native paths; the focused cleanup suite then passed 32 tests locally. Follow-up Windows run 29816736450 passed 2,503 tests with 16 skips on commit 6b0c100.

## Review Evidence

- Implementation sub-agents: UI/runtime contracts, cleanup/installer, and evidence/AST roles; model unknown because not exposed; each edited only its assigned files.
- Read-only sub-agent reviews: integrated diff, Windows/installer, UI/evidence, and final staged-diff review; model unknown because not exposed; no reviewer edited files.
- Result: reviewers identified Windows bootstrap, orphan lifetime, selector suffix, stale Maps Network env, embedded fenced snippets, source-inventory pollution, and diagnostic gaps. All findings were addressed. Final staged review reported no blockers and confirmed all eight requested review items closed.
- CI follow-up: GitHub Windows core found only POSIX-formatted expectations in three new tests; runtime behavior was correct. The test-only path normalization is included in commit 6b0c100; the follow-up Windows matrix passed.

## Agent Metadata

- Tokki: 1.0.32
- Agent/runtime: Codex; version unavailable
- Model: GPT-5
- Reasoning effort: unknown, not exposed
- `/fast` mode: not used

## Risks

- Known risks or limitations: remote bootstrap remains a fallback for workers without an installed environment; it is bounded to the existing psutil constraint and remains fail-closed.
- Follow-up work if any: none required for this remediation.

## Checklist

- [x] No unrelated changes included
- [x] Shared core touched with explicit approval in the review remediation request and covered by full core suites
- [x] Dependencies updated/removed coherently; no dependency declaration changed
- [x] Release/tag/PyPI impact considered; no release metadata or package version change
- [x] Repository-scope changes stay within the stated remediation boundary
- [x] DCO/CLA status is acceptable for this contribution
- [x] Security checklist considered: exact-process ownership, fail-closed cleanup, shell quoting, filesystem writes, SSH behavior, bounded logs, and evidence artifacts
- [x] No new dependency or optional-profile impact; existing psutil availability is reused
- [x] External app/example acceptance criteria are not applicable