### PR TITLE
test: tolerate transient Windows heartbeat locks

### DIFF
--- a/src/agilab/core/test/test_base_worker_service_support.py
+++ b/src/agilab/core/test/test_base_worker_service_support.py
@@ -4,6 +4,7 @@ import json
 import os
 import threading
 import time
+from collections.abc import Callable
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -21,6 +22,28 @@ def _write_task(path: Path, payload: dict[str, object]) -> None:
         json.dumps({"schema": SERVICE_TASK_SCHEMA, **payload}, sort_keys=True),
         encoding="utf-8",
     )
+
+
+def _read_json_with_permission_retry(
+    path: Path,
+    *,
+    timeout: float = 0.5,
+    read_text_fn: Callable[[Path], str] | None = None,
+    monotonic_fn: Callable[[], float] = time.monotonic,
+    sleep_fn: Callable[[float], None] = time.sleep,
+) -> dict[str, object]:
+    """Read concurrently replaced JSON while tolerating Windows sharing races."""
+
+    reader = read_text_fn or (lambda source: source.read_text(encoding="utf-8"))
+    deadline = monotonic_fn() + max(timeout, 0.0)
+    while True:
+        try:
+            return json.loads(reader(path))
+        except PermissionError:
+            remaining = deadline - monotonic_fn()
+            if remaining <= 0:
+                raise
+            sleep_fn(min(0.01, remaining))
 
 
 class DummyWorker(BaseWorker):
@@ -79,6 +102,53 @@ def test_make_heartbeat_writer_persists_payload(tmp_path):
         write_heartbeat,
         "worker_incarnation",
     )
+
+
+def test_heartbeat_json_reader_retries_only_transient_permission_errors(tmp_path):
+    heartbeat_file = tmp_path / "heartbeat.json"
+    heartbeat_file.write_text('{"state": "processing"}', encoding="utf-8")
+    attempts = 0
+
+    def _deny_once(path: Path) -> str:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise PermissionError("heartbeat replacement in progress")
+        return path.read_text(encoding="utf-8")
+
+    assert _read_json_with_permission_retry(
+        heartbeat_file,
+        read_text_fn=_deny_once,
+        sleep_fn=lambda _delay: None,
+    ) == {"state": "processing"}
+    assert attempts == 2
+
+    denied_attempts = 0
+    monotonic_values = iter((10.0, 10.1, 10.5))
+    sleep_delays: list[float] = []
+
+    def _always_denied(_path: Path) -> str:
+        nonlocal denied_attempts
+        denied_attempts += 1
+        raise PermissionError("heartbeat remains locked")
+
+    with pytest.raises(PermissionError, match="remains locked"):
+        _read_json_with_permission_retry(
+            heartbeat_file,
+            timeout=0.5,
+            read_text_fn=_always_denied,
+            monotonic_fn=lambda: next(monotonic_values),
+            sleep_fn=sleep_delays.append,
+        )
+    assert denied_attempts == 2
+    assert sleep_delays == [0.01]
+
+    with pytest.raises(json.JSONDecodeError):
+        _read_json_with_permission_retry(
+            heartbeat_file,
+            read_text_fn=lambda _path: "{",
+            sleep_fn=lambda _delay: None,
+        )
 
 
 def test_service_loop_without_worker_override_stops_cleanly():
@@ -197,12 +267,15 @@ def test_service_loop_refreshes_heartbeat_during_long_task(tmp_path):
     assert work_started.wait(timeout=2)
 
     heartbeat_file = next((queue_root / "heartbeats").glob("*.json"))
-    first = json.loads(heartbeat_file.read_text(encoding="utf-8"))
-    deadline = time.time() + 2
+    first = _read_json_with_permission_retry(heartbeat_file)
+    deadline = time.monotonic() + 2
     refreshed = first
-    while time.time() < deadline and refreshed["timestamp"] <= first["timestamp"]:
+    while (
+        time.monotonic() < deadline
+        and refreshed["timestamp"] <= first["timestamp"]
+    ):
         time.sleep(0.05)
-        refreshed = json.loads(heartbeat_file.read_text(encoding="utf-8"))
+        refreshed = _read_json_with_permission_retry(heartbeat_file)
 
     assert refreshed["state"] == "processing"
     assert refreshed["timestamp"] > first["timestamp"]


### PR DESCRIPTION
## Summary

- add a test-local, monotonic, bounded retry for transient `PermissionError` while reading an atomically replaced heartbeat JSON file
- preserve the existing state, timestamp, and worker-incarnation assertions
- add deterministic regression coverage for one transient denial, positive-budget expiry, and malformed JSON propagation

## Linked Issue

N/A — follow-up to the Windows main-branch failure in [run 29817117748](https://github.com/ThalesGroup/agilab/actions/runs/29817117748).

## Repro

The Windows core suite failed in `test_service_loop_refreshes_heartbeat_during_long_task` when `Path.read_text()` raced with the heartbeat writer's atomic `os.replace()` and raised `PermissionError`.

The identical Git tree had already passed the PR Windows run [29816736450](https://github.com/ThalesGroup/agilab/actions/runs/29816736450), which isolates this as a nondeterministic Windows sharing race in the test reader.

## Root Cause

The test assumed that a concurrent read of an atomically replaced JSON file could not be transiently denied. Windows may briefly deny that read while the replacement is in progress. The runtime's atomic-write behavior and production missed-sample handling are intentional, so the correction belongs in the concurrent test reader rather than production code.

## Regression Test

The new test-local helper:

- retries only `PermissionError`
- uses a fixed monotonic 0.5-second budget
- succeeds after one injected sharing denial
- propagates persistent denial after a deterministic positive timeout
- propagates malformed JSON without retrying it

The original long-task test continues to assert refreshed timestamp, `processing` state, and unchanged worker incarnation.

## Scope

One test file only. No production runtime, shared helper, dependency, workflow, or documentation changes.

## Validation

- impact validation: low risk, one file
- CI-parity focused slice: 2 passed
- focused tests in 10 fresh pytest processes: 10/10 passed
- full test file: 24 passed
- `git diff --check`, fatal Ruff (`E9,F821`), provenance guard, staged-scope guard, and pre-push guards passed
- [PR Windows core run 29819408030](https://github.com/ThalesGroup/agilab/actions/runs/29819408030): passed in 4m16s
- [repository guardrails run 29819407959](https://github.com/ThalesGroup/agilab/actions/runs/29819407959): passed
- [post-merge main Windows run 29819778569](https://github.com/ThalesGroup/agilab/actions/runs/29819778569): passed on `43166e0` in 4m05s
- full-file default Ruff is not a green gate because it reports the pre-existing unchanged `F841` assignment in `test_service_loop_without_worker_override_stops_cleanly`

## Review Evidence

- Tesla sub-agent (model unavailable): reviewed Windows CI history; read-only, no file edits
- Volta sub-agent (model unavailable): diagnosed the Windows `os.replace` / read sharing race; read-only, no file edits
- independent Codex sub-agent (model unavailable): reviewed the final patch for scope, exception handling, boundedness, and determinism; no blocking findings, read-only, no file edits
- the review's optional request to prove positive-budget expiry was addressed before commit

## Agent Metadata

- Tokki: 1.0.32
- Agent/runtime: Codex CLI 0.144.6
- Model: GPT-5
- Reasoning effort: unavailable
- `/fast` mode: not used
