### PR TITLE
fix: harden remote worker Python selection

### DIFF
--- a/.claude/skills/plan-before-code/SKILL.md
+++ b/.claude/skills/plan-before-code/SKILL.md
@@ -145,6 +145,13 @@ For substantial tasks, the user should see:
 - a concise plan before edits
 - an update when the diagnosis changes
 - validation before final close-out
+- an explicit interruption checkpoint: if a guard, approval boundary, ambiguity,
+  or environmental limitation blocks the planned fix, state the blocker and the
+  required decision, ask for it, and resume after approval rather than silently
+  substituting a workaround or stopping with a known residual defect
+- close-out must state the outcome as fixed, validated, awaiting approval, or
+  blocked, plus the recurrence guard or regression used when the task exposed a
+  reusable failure class
 
 ## References
 

--- a/.codex/skills/plan-before-code/SKILL.md
+++ b/.codex/skills/plan-before-code/SKILL.md
@@ -145,6 +145,13 @@ For substantial tasks, the user should see:
 - a concise plan before edits
 - an update when the diagnosis changes
 - validation before final close-out
+- an explicit interruption checkpoint: if a guard, approval boundary, ambiguity,
+  or environmental limitation blocks the planned fix, state the blocker and the
+  required decision, ask for it, and resume after approval rather than silently
+  substituting a workaround or stopping with a known residual defect
+- close-out must state the outcome as fixed, validated, awaiting approval, or
+  blocked, plus the recurrence guard or regression used when the task exposed a
+  reusable failure class
 
 ## References
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,16 +75,21 @@ Use this runbook whenever you:
   confirmation after local validation). When a change maps cleanly to one of the repo workflow
   profiles, prefer `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile <name>`
   over handwritten command variants.
-- **Fix prevention close-out / Bug-class sweep contract**: For logged or
-  reproducible failures, preserve the smallest
-  repro first, identify the root cause, choose the right layer, and add the
-  smallest regression, guard, robot scenario, or validation that would have
-  caught it. Sweep only sibling apps, shared helpers, manifests, or generated
-  artifacts that can plausibly share the same failure class. For browser-only
-  failures, validate the browser/dev-log surface rather than stopping at unit
-  tests or AppTest. For agent-process defects, add or tighten the durable rule in
-  `AGENT_LEARNINGS.md`, `AGENTS.md`, a repo skill, or tooling. If automation is
-  not practical, document why and name the closest manual or robot validation.
+- **Completion and prevention contract (Fix prevention close-out / Bug-class sweep)**: Every interruption caused by a guard,
+  approval boundary, ambiguity, or environmental limitation must be made explicit:
+  state what is blocked, why, what decision or authority is needed, and what can
+  continue safely. Ask for the missing decision instead of silently substituting
+  a workaround or stopping with a known residual defect; when approval arrives,
+  resume the original task. For logged or reproducible failures, preserve the
+  smallest repro, identify the root cause, fix the correct layer, and add the
+  smallest regression, guard, robot scenario, or validation that would have caught
+  it. Sweep only sibling apps, shared helpers, manifests, or generated artifacts
+  that plausibly share the same failure class. For browser-only failures, validate
+  the browser/dev-log surface rather than stopping at unit tests or AppTest. For
+  agent-process defects, add or tighten the durable rule in `AGENT_LEARNINGS.md`,
+  `AGENTS.md`, a repo skill, or tooling. If automation is not practical, document
+  why and name the closest manual or robot validation. Close out with a clear
+  status: fixed, validated, awaiting approval, or blocked.
 - **Streamlit duplicate-widget triage**: For duplicate element ID errors, first
   check whether the page, app surface, or entrypoint is being executed twice.
   Add stable widget keys for repeated controls, but do not mask duplicate

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -391,11 +391,12 @@ Use this runbook whenever you:
 - **Shared core approval gate**: Do not edit shared core technology without explicit user approval first.
   Shared core includes `src/agilab/core/agi-env`, `src/agilab/core/agi-node`, `src/agilab/core/agi-cluster`,
   `src/agilab/core/agi-core`, shared installer/build/deploy tooling, and generic helpers reused across apps/pages.
-  Default to app-local fixes first. If you believe a core change is required, stop and explain:
-  - why an app-local fix is insufficient
-  - which shared files/modules need to change
-  - the expected blast radius across apps/workflows
-  - the test or regression plan you will use after approval
+  Default to app-local fixes first. If a core change is required, do not silently defer it or substitute an
+  incomplete app-local workaround: explain why the app-local fix is insufficient, name the shared files/modules,
+  state the blast radius, and give the regression/validation plan, then ask the user for an explicit decision.
+  A direct user instruction to fix/do the named shared-core issue is approval to proceed within that stated scope;
+  record the approval and affected files in the plan and PR evidence. If approval is absent, pause only that shared
+  change while continuing independent in-scope work and clearly report the blocker.
 - **agi-core owner gate**: Treat `src/agilab/core/agi-core/**` as owner-protected even after
   shared-core approval. Only GitHub actor `jpmorard` may change this path. The local pre-push
   hook and repo-guardrails CI run `tools/agi_core_change_guard.py`; agents should not stage or

--- a/agenticweb.md
+++ b/agenticweb.md
@@ -1,7 +1,7 @@
 ---
 agenticweb: "1"
 description: "AGILAB is an open-source AI/ML workbench for reproducible experiments, notebook-to-app workflows, run evidence, proof capsules, and local agent evidence review."
-updated: "2026-07-17"
+updated: "2026-07-21"
 organization:
   name: "AGILAB"
   website: "https://thalesgroup.github.io/agilab"

--- a/agilab-capabilities.json
+++ b/agilab-capabilities.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-07-17T15:49:10Z",
+  "generated_at_utc": "2026-07-21T15:40:30Z",
   "schema": "agilab.capabilities.v1",
   "schema_version": 1,
   "generated_by": {
@@ -1656,7 +1656,8 @@
       "sources": [
         "src/agilab/global_pipeline/global_pipeline_runner_state.py",
         "src/agilab/pipeline/pipeline_lab.py",
-        "tools/global_pipeline_dispatch_state_report.py"
+        "tools/global_pipeline_dispatch_state_report.py",
+        "tools/robustness_matrix.py"
       ]
     },
     {
@@ -1763,7 +1764,8 @@
         "src/agilab/dag/multi_app_dag.py",
         "src/agilab/dag/multi_app_dag_templates.py",
         "src/agilab/examples/inter_project_dag/preview_inter_project_dag.py",
-        "src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/dag_templates/flight_to_weather.json"
+        "src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/dag_templates/flight_to_weather.json",
+        "tools/robustness_matrix.py"
       ]
     },
     {

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_local_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_local_support.py
@@ -100,6 +100,9 @@ from agi_cluster.agi_distributor.deployment_venv_support import (
     project_venv_root as _project_venv_root,
     python_version_tuple as _python_version_tuple,  # noqa: F401
 )
+from agi_cluster.agi_distributor.deployment.deployment_python_support import (
+    _normalize_worker_requires_python_floor as _normalize_worker_requires_python_floor,
+)
 from agi_cluster.agi_distributor.deployment_worker_venv_cache_support import (
     SHARED_WORKER_VENV_DIR_ENV as SHARED_WORKER_VENV_DIR_ENV,
     SHARED_WORKER_VENV_ENV as SHARED_WORKER_VENV_ENV,
@@ -115,7 +118,6 @@ FORCE_REMOVE_EXCEPTIONS = (OSError, shutil.Error)
 DEPENDENCY_PARSE_EXCEPTIONS = (InvalidRequirement,)
 PYPROJECT_PARSE_EXCEPTIONS = (OSError, tomlkit.exceptions.ParseError)  # ty: ignore[possibly-missing-submodule]
 PERF_TRACE_ENV = "AGILAB_PERF_TRACE"
-MIN_WORKER_REQUIRES_PYTHON = ">=3.12"
 DEPENDENCY_MODULE_ALIASES: dict[str, tuple[str, ...]] = {
     "pillow": ("PIL",),
     "python-dotenv": ("dotenv",),
@@ -136,84 +138,6 @@ def _worker_python_uv_spec(env: Any, fallback: str | None) -> str | None:
         or getattr(env, "python_uv_spec", None)
         or fallback
     )
-
-
-def _python_version_prefix_tuple(version: str) -> tuple[int, ...]:
-    parts: list[int] = []
-    for part in version.strip().split("."):
-        if not part.isdigit():
-            break
-        parts.append(int(part))
-    return tuple(parts)
-
-
-def _raise_requires_python_floor(
-    requires_python: str | None,
-    *,
-    minimum_spec: str = MIN_WORKER_REQUIRES_PYTHON,
-) -> str | None:
-    if not requires_python:
-        return minimum_spec
-
-    minimum_version = minimum_spec.removeprefix(">=")
-    minimum_tuple = _python_version_prefix_tuple(minimum_version)
-    parts = [part.strip() for part in str(requires_python).split(",") if part.strip()]
-    if not parts:
-        return minimum_spec
-
-    changed = False
-    has_floor = False
-    normalized: list[str] = []
-    for part in parts:
-        if part.startswith(">="):
-            has_floor = True
-            current_tuple = _python_version_prefix_tuple(part.removeprefix(">="))
-            if current_tuple and current_tuple < minimum_tuple:
-                normalized.append(minimum_spec)
-                changed = True
-            else:
-                normalized.append(part)
-        else:
-            normalized.append(part)
-
-    if not has_floor:
-        if any(part.startswith(("==", "===", "~=")) for part in parts):
-            return requires_python
-        normalized.insert(0, minimum_spec)
-        changed = True
-
-    result = ",".join(normalized)
-    return result if changed else requires_python
-
-
-def _normalize_worker_requires_python_floor(
-    pyproject_file: Path,
-    *,
-    minimum_spec: str = MIN_WORKER_REQUIRES_PYTHON,
-) -> bool:
-    try:
-        data = tomlkit.parse(pyproject_file.read_text())
-    except PYPROJECT_PARSE_EXCEPTIONS:
-        return False
-
-    project_tbl = data.get("project")
-    if not (
-        hasattr(project_tbl, "get") and hasattr(project_tbl, "__setitem__")
-    ):
-        project_tbl = tomlkit.table()
-
-    current = project_tbl.get("requires-python")
-    updated = _raise_requires_python_floor(
-        str(current) if current is not None else None,
-        minimum_spec=minimum_spec,
-    )
-    if updated is None or updated == current:
-        return False
-
-    project_tbl["requires-python"] = updated
-    data["project"] = project_tbl
-    atomic_write_text(pyproject_file, tomlkit.dumps(data))
-    return True
 
 
 def _manager_python_uv_spec(env: Any, fallback: str | None) -> str | None:

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_prepare_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_prepare_support.py
@@ -12,6 +12,9 @@ from asyncssh.process import ProcessError
 
 from agi_cluster.agi_distributor import cli as distributor_cli, deployment_remote_support
 from agi_cluster.agi_distributor.api.worker_cli_support import resolve_worker_cli_path
+from agi_cluster.agi_distributor.deployment.deployment_python_support import (
+    _normalize_worker_requires_python_floor,
+)
 from agi_env import AgiEnv
 
 
@@ -252,6 +255,9 @@ async def prepare_cluster_env(
     dist_rel = env.dist_rel
     wenv_rel = env.wenv_rel
     pyvers_worker = env.pyvers_worker
+    pyvers_worker_uv_spec = (
+        getattr(env, "pyvers_worker_uv_spec", None) or pyvers_worker
+    )
 
     remote_command_failures = _exception_types(process_error_type, RuntimeError, OSError)
     staged_pyproject_fallback_errors = _exception_types(
@@ -315,7 +321,9 @@ async def prepare_cluster_env(
     # re-running the platform probe over SSH once per worker in the same flow.
     agi_cls._legacy_intel_macos_ips = set(legacy_intel_macos_ips)
 
-    if legacy_intel_macos_ips and pyvers_worker != "3.12":
+    if legacy_intel_macos_ips and (
+        pyvers_worker != "3.12" or pyvers_worker_uv_spec != "3.12"
+    ):
         log.warning(
             "Detected legacy Intel macOS worker(s) %s; selecting Python 3.12 for all worker environments instead of %s",
             ", ".join(sorted(legacy_intel_macos_ips)),
@@ -324,6 +332,8 @@ async def prepare_cluster_env(
         pyvers_worker = "3.12"
         env.pyvers_worker = "3.12"
         env.python_version = "3.12"
+        pyvers_worker_uv_spec = "3.12"
+        env.pyvers_worker_uv_spec = pyvers_worker_uv_spec
         env.uv_worker = env.uv
 
     async def _prepare_remote_worker(ip: str) -> list[tuple[str, Any]]:
@@ -388,11 +398,11 @@ async def prepare_cluster_env(
         if await _remote_uv_python_available(
             ip,
             uv,
-            pyvers_worker,
+            pyvers_worker_uv_spec,
             run_exec_ssh_fn=run_exec_ssh_fn,
             remote_command_failures=remote_command_failures,
         ):
-            log.info("[%s] Python interpreter '%s' is already available to uv; skipping install.", ip, pyvers_worker)
+            log.info("[%s] Python interpreter '%s' is already available to uv; skipping install.", ip, pyvers_worker_uv_spec)
         else:
             try:
                 await run_exec_ssh_fn(
@@ -401,7 +411,7 @@ async def prepare_cluster_env(
                         uv,
                         "python",
                         "install",
-                        pyvers_worker,
+                        pyvers_worker_uv_spec,
                     ),
                 )
             except process_error_type as exc:
@@ -409,7 +419,7 @@ async def prepare_cluster_env(
                     log.warning(
                         "[%s] uv could not download interpreter '%s'; assuming a system interpreter is available",
                         ip,
-                        pyvers_worker,
+                        pyvers_worker_uv_spec,
                     )
                 else:
                     raise
@@ -429,11 +439,17 @@ async def prepare_cluster_env(
         try:
             pyproject_src = env.worker_pyproject if env.worker_pyproject.exists() else env.manager_pyproject
             if pyproject_src.exists():
+                staged_tmp_dir = Path(mkdtemp_fn(prefix=f"agilab_{env.target_worker}_pyproject_"))
+                tmp_pyproject = staged_tmp_dir / "pyproject.toml"
+                shutil.copy(pyproject_src, tmp_pyproject)
+                _normalize_worker_requires_python_floor(
+                    tmp_pyproject,
+                    raise_on_parse_error=True,
+                )
+                normalized_pyproject = tmp_pyproject.read_text(encoding="utf-8")
                 extras_to_seed = set(getattr(agi_cls, "agi_workers", {}).values())
+                staged_entries: list[Path] = []
                 try:
-                    staged_tmp_dir = Path(mkdtemp_fn(prefix=f"agilab_{env.target_worker}_pyproject_"))
-                    tmp_pyproject = staged_tmp_dir / "pyproject.toml"
-                    shutil.copy(pyproject_src, tmp_pyproject)
                     ensure_optional_extras_fn(tmp_pyproject, extras_to_seed)
                     staged_entries = stage_uv_sources_fn(
                         src_pyproject=pyproject_src,
@@ -441,13 +457,14 @@ async def prepare_cluster_env(
                         stage_root=staged_tmp_dir,
                         log_rewrites=bool(getattr(env, "verbose", 0)),
                     )
-                    files_to_send.append(tmp_pyproject)
-                    files_to_send.extend(staged_entries)
                 except staged_pyproject_fallback_errors:
-                    if staged_tmp_dir is not None:
-                        shutil.rmtree(staged_tmp_dir, ignore_errors=True)
-                        staged_tmp_dir = None
-                    files_to_send.append(pyproject_src)
+                    # Optional staging may have partially rewritten the temp
+                    # manifest before failing.  Keep the fallback payload at
+                    # the normalized baseline; never send a half-staged file.
+                    tmp_pyproject.write_text(normalized_pyproject, encoding="utf-8")
+                    staged_entries = []
+                files_to_send.append(tmp_pyproject)
+                files_to_send.extend(staged_entries)
             if env.uvproject.exists():
                 files_to_send.append(env.uvproject)
             await send_files_fn(env, ip, files_to_send, wenv_rel)

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_python_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_python_support.py
@@ -1,0 +1,94 @@
+"""Shared Python contract helpers for AGILAB deployment projects."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import tomlkit
+
+from agi_env.runtime.atomic_write_support import atomic_write_text
+
+
+MIN_WORKER_REQUIRES_PYTHON = ">=3.12"
+PYPROJECT_PARSE_EXCEPTIONS = (OSError, tomlkit.exceptions.ParseError)  # ty: ignore[possibly-missing-submodule]
+
+
+def _python_version_prefix_tuple(version: str) -> tuple[int, ...]:
+    parts: list[int] = []
+    for part in version.strip().split("."):
+        if not part.isdigit():
+            break
+        parts.append(int(part))
+    return tuple(parts)
+
+
+def _raise_requires_python_floor(
+    requires_python: str | None,
+    *,
+    minimum_spec: str = MIN_WORKER_REQUIRES_PYTHON,
+) -> str | None:
+    if not requires_python:
+        return minimum_spec
+
+    minimum_version = minimum_spec.removeprefix(">=")
+    minimum_tuple = _python_version_prefix_tuple(minimum_version)
+    parts = [part.strip() for part in str(requires_python).split(",") if part.strip()]
+    if not parts:
+        return minimum_spec
+
+    changed = False
+    has_floor = False
+    normalized: list[str] = []
+    for part in parts:
+        if part.startswith(">="):
+            has_floor = True
+            current_tuple = _python_version_prefix_tuple(part.removeprefix(">="))
+            if current_tuple and current_tuple < minimum_tuple:
+                normalized.append(minimum_spec)
+                changed = True
+            else:
+                normalized.append(part)
+        else:
+            normalized.append(part)
+
+    if not has_floor:
+        if any(part.startswith(("==", "===", "~=")) for part in parts):
+            return requires_python
+        normalized.insert(0, minimum_spec)
+        changed = True
+
+    result = ",".join(normalized)
+    return result if changed else requires_python
+
+
+def _normalize_worker_requires_python_floor(
+    pyproject_file: Path,
+    *,
+    minimum_spec: str = MIN_WORKER_REQUIRES_PYTHON,
+    raise_on_parse_error: bool = False,
+) -> bool:
+    try:
+        data = tomlkit.parse(pyproject_file.read_text())
+    except PYPROJECT_PARSE_EXCEPTIONS:
+        if raise_on_parse_error:
+            raise
+        return False
+
+    project_tbl = data.get("project")
+    if not (
+        hasattr(project_tbl, "get") and hasattr(project_tbl, "__setitem__")
+    ):
+        project_tbl = tomlkit.table()
+
+    current = project_tbl.get("requires-python")
+    updated = _raise_requires_python_floor(
+        str(current) if current is not None else None,
+        minimum_spec=minimum_spec,
+    )
+    if updated is None or updated == current:
+        return False
+
+    project_tbl["requires-python"] = updated
+    data["project"] = project_tbl
+    atomic_write_text(pyproject_file, tomlkit.dumps(data))
+    return True

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_remote_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/deployment/deployment_remote_support.py
@@ -788,7 +788,7 @@ async def deploy_remote_worker(
 
     wenv_rel = env.wenv_rel
     dist_abs = env.dist_abs
-    pyvers = env.pyvers_worker
+    pyvers = getattr(env, "pyvers_worker_uv_spec", None) or env.pyvers_worker
     # Operator-managed shell prefix; trusted input prepended verbatim.
     cmd_prefix = env.envars.get(f"{ip}_CMD_PREFIX", "")
     uv = _remote_tool(cmd_prefix, env.uv_worker)
@@ -902,7 +902,7 @@ async def deploy_remote_worker(
 
     remote_site_packages = worker_site_packages_dir_fn(
         PurePosixPath(wenv_rel.as_posix()),
-        pyvers,
+        env.pyvers_worker,
         windows=False,
     )
     remote_uv_sources = PurePosixPath(wenv_rel.as_posix()) / "_uv_sources"

--- a/src/agilab/core/test/test_agi_distributor_deployment_prepare_support.py
+++ b/src/agilab/core/test/test_agi_distributor_deployment_prepare_support.py
@@ -37,6 +37,7 @@ def _build_cluster_env(
     *,
     internet_on: str = "1",
     verbose: int = 0,
+    worker_uv_spec: str | None = None,
 ) -> SimpleNamespace:
     cluster_pck = tmp_path / "cluster_pck"
     (cluster_pck / "agi_distributor").mkdir(parents=True, exist_ok=True)
@@ -49,7 +50,7 @@ def _build_cluster_env(
     uvproject = tmp_path / "uv.toml"
     uvproject.write_text("[tool.uv]\n", encoding="utf-8")
 
-    return SimpleNamespace(
+    env = SimpleNamespace(
         dist_rel=Path("wenv/dist"),
         wenv_rel=Path("wenv"),
         pyvers_worker="3.13",
@@ -63,6 +64,9 @@ def _build_cluster_env(
         target_worker="demo_worker",
         verbose=verbose,
     )
+    if worker_uv_spec is not None:
+        env.pyvers_worker_uv_spec = worker_uv_spec
+    return env
 
 
 def _build_agi(
@@ -563,6 +567,7 @@ ilp_worker = { path = "../deps/ilp_worker" }
     payload = sent_to_wenv[0]
     pyproject_item = next(item for item in payload if item["name"] == "pyproject.toml")
     assert "_uv_sources/ilp_worker" in pyproject_item["content"]
+    assert 'requires-python = ">=3.12"' in pyproject_item["content"]
     staged_item = next(item for item in payload if item["name"] == "_uv_sources")
     assert staged_item["is_dir"] is True
     assert "ilp_worker/milp.py" in staged_item["children"]
@@ -942,7 +947,7 @@ async def test_prepare_cluster_env_python_install_unknown_error_bubbles(tmp_path
 
 
 @pytest.mark.asyncio
-async def test_prepare_cluster_env_falls_back_to_original_pyproject_when_extra_seed_fails(tmp_path):
+async def test_prepare_cluster_env_fallback_still_normalizes_python_floor(tmp_path):
     env = _build_cluster_env(tmp_path)
     agi_cls = _build_agi(env)
     sent = []
@@ -975,8 +980,44 @@ async def test_prepare_cluster_env_falls_back_to_original_pyproject_when_extra_s
 
     sent_to_wenv = [items for _ip, items, remote_path in sent if remote_path == "wenv"]
     assert sent_to_wenv
-    assert any("worker_pyproject.toml" == item["name"] for item in sent_to_wenv[0])
-    assert not any(item["name"] == "pyproject.toml" for item in sent_to_wenv[0])
+    pyproject_item = next(item for item in sent_to_wenv[0] if item["name"] == "pyproject.toml")
+    assert 'requires-python = ">=3.12"' in pyproject_item["content"]
+
+
+@pytest.mark.asyncio
+async def test_prepare_cluster_env_uses_qualified_worker_python_selector(tmp_path):
+    env = _build_cluster_env(tmp_path, worker_uv_spec="3.14.6+gil")
+    agi_cls = _build_agi(env)
+    remote_cmds: list[str] = []
+
+    async def _fake_detect(_ip):
+        return ""
+
+    async def _fake_exec(_ip, cmd):
+        remote_cmds.append(cmd)
+        if "python find" in cmd:
+            return "Python 3.14.6"
+        return "ok"
+
+    async def _noop(*_args, **_kwargs):
+        return None
+
+    await deployment_prepare_support.prepare_cluster_env(
+        agi_cls,
+        "127.0.0.1",
+        envar_truthy_fn=_truthy,
+        detect_export_cmd_fn=_fake_detect,
+        ensure_optional_extras_fn=lambda *_a, **_k: None,
+        stage_uv_sources_fn=lambda **_kwargs: [],
+        run_exec_ssh_fn=_fake_exec,
+        send_files_fn=lambda *_a, **_k: _noop(),
+        kill_fn=_noop,
+        clean_dirs_fn=_noop,
+        set_env_var_fn=lambda key, value=None: env.envars.__setitem__(key, value),
+        log=mock.Mock(),
+    )
+
+    assert any("python find 3.14.6+gil" in cmd for cmd in remote_cmds)
 
 
 @pytest.mark.asyncio

--- a/src/agilab/core/test/test_agi_distributor_deployment_remote_support.py
+++ b/src/agilab/core/test/test_agi_distributor_deployment_remote_support.py
@@ -628,6 +628,7 @@ async def test_deploy_remote_worker_non_source_flow(monkeypatch, tmp_path):
         dist_rel=Path("worker_env/dist"),
         dist_abs=dist_abs,
         pyvers_worker="3.13",
+        pyvers_worker_uv_spec="3.14.6+gil",
         envars={},
         uv_worker="uv --quiet",
         is_source_env=False,
@@ -677,7 +678,7 @@ async def test_deploy_remote_worker_non_source_flow(monkeypatch, tmp_path):
 
     assert any("demo_worker-0.0.1.egg" in names for _, names, _ in send_calls)
     assert any("python -c 'import pip'" in cmd for cmd in ssh_calls)
-    assert any("uv --quiet run -p 3.13" in cmd for cmd in ssh_calls)
+    assert any("uv --quiet run -p 3.14.6+gil" in cmd for cmd in ssh_calls)
     assert not any("'uv --quiet'" in cmd for cmd in ssh_calls)
     assert not any("ensurepip" in cmd for cmd in ssh_calls)
     assert not any("dask[distributed]" in cmd for cmd in ssh_calls)


### PR DESCRIPTION
## Summary
- centralize worker manifest Python-floor normalization for local and remote deployment
- use the qualified `pyvers_worker_uv_spec` for remote uv selection while preserving unqualified filesystem paths
- ensure failed optional staging falls back to a clean normalized manifest
- document the explicit shared-core approval checkpoint in `AGENTS.md`

## Repro
LinkSim remote worker deployment staged the app's stale `requires-python >=3.11` manifest and selected an unqualified worker Python version.

## Root Cause
Local deployment normalized the copied worker manifest, but remote deployment sent the original manifest unchanged. Remote selection also used `pyvers_worker` instead of the environment's qualified uv selector.

## Regression Test
- focused deployment tests: 122 passed
- shared core test slice: 1497 passed, 5 skipped
- fallback test proves a failed staging path still sends `requires-python = ">=3.12"`
- selector test proves remote uv uses `3.14.6+gil`

## Approval
The user explicitly approved the required shared-core change after the cause and blast radius were explained.

## Review Evidence
No sub-agent review was used for this patch. Local impact analysis identified shared-core risk and the required validation slice.

## Agent Metadata
- Tokki: unavailable
- Agent/runtime: Codex, version unavailable
- Model: GPT-5 Codex
- Reasoning effort: unavailable
- /fast mode: not used