### PR TITLE
Fix release gate environment isolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,24 @@ cleanup, but retired GitHub release pages are not advertised as live evidence.
 
 ## Unreleased
 
+### Changed
+
+- Aligned clean and source installers with the repository Python pin and
+  validated standard-GIL interpreter selections before replacing an existing
+  environment.
+- Expanded Apple-silicon local/offline model compatibility to MLX 0.32.
+- Hardened post-publish recovery against stale PyPI index data and made
+  Hugging Face Space publication independent of the `hf` CLI.
+
+### Fixed
+
+- Isolated queue and relay resilience runtime sessions by app scope, revalidated
+  live environment identity after page transitions, and centralized their
+  shared presentation helpers in `agi-pages` so stale state cannot leak across
+  analysis pages (#833).
+- Fixed ORCHESTRATE custom argument forms so they import within the selected
+  app source scope, including LinkSim forms.
+
 ## [2026.07.17] - 2026-07-17
 
 GitHub Release: https://github.com/ThalesGroup/agilab/releases/tag/v2026.07.17

--- a/test/test_builtin_app_tests.py
+++ b/test/test_builtin_app_tests.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import sys
 from pathlib import Path
 
 
@@ -57,6 +58,7 @@ def test_build_pytest_command_keeps_forwarded_args_after_separator():
 def test_subprocess_env_uses_isolated_app_environment(monkeypatch, tmp_path):
     monkeypatch.setenv("VIRTUAL_ENV", "/repo/.venv")
     monkeypatch.setenv("UV_PROJECT_ENVIRONMENT", "/repo/.venv-dev")
+    monkeypatch.setenv("UV_PYTHON", "/polluted/project/.venv/bin/python")
     monkeypatch.setenv("UV_RUN_RECURSION_DEPTH", "1")
     monkeypatch.setenv("AGILAB_BUILTIN_APP_TEST_ENV_ROOT", str(tmp_path / "app-envs"))
     target = builtin_app_tests.BuiltinAppTestTarget(
@@ -69,6 +71,7 @@ def test_subprocess_env_uses_isolated_app_environment(monkeypatch, tmp_path):
     assert "VIRTUAL_ENV" not in env
     assert "UV_RUN_RECURSION_DEPTH" not in env
     assert env["UV_PROJECT_ENVIRONMENT"] == str(tmp_path / "app-envs" / target.name)
+    assert env["UV_PYTHON"] == sys.executable
 
 
 def test_app_test_env_root_uses_temporary_directory_by_default(monkeypatch):

--- a/test/test_coverage_badge_guard.py
+++ b/test/test_coverage_badge_guard.py
@@ -69,6 +69,19 @@ def test_changed_coverage_components_ignores_coverage_tooling_tests() -> None:
     assert changed == {}
 
 
+def test_changed_coverage_components_ignores_non_gui_policy_tests() -> None:
+    module = _load_module()
+
+    changed = module.changed_coverage_components(
+        [
+            "test/test_builtin_app_tests.py",
+            "test/test_pyproject_dependency_hygiene.py",
+        ]
+    )
+
+    assert changed == {}
+
+
 def test_changed_coverage_components_ignores_release_and_public_docs_tests() -> None:
     module = _load_module()
 

--- a/test/test_pyproject_dependency_hygiene.py
+++ b/test/test_pyproject_dependency_hygiene.py
@@ -126,15 +126,43 @@ def _marker_excludes_python_below(requirement: Requirement, floor: tuple[int, in
     return not requirement.marker.evaluate(env)
 
 
-def _project_pyprojects() -> list[Path]:
-    ignored_parts = {".venv", "build", "dist", "__pycache__"}
+def _project_pyprojects(
+    repo_root: Path = REPO_ROOT,
+    src_package: Path = SRC_PACKAGE,
+) -> list[Path]:
+    ignored_parts = {"build", "dist", "__pycache__"}
     return [
-        REPO_ROOT / "pyproject.toml",
+        repo_root / "pyproject.toml",
         *[
             path
-            for path in sorted(SRC_PACKAGE.rglob("pyproject.toml"))
-            if not ignored_parts.intersection(path.relative_to(SRC_PACKAGE).parts)
+            for path in sorted(src_package.rglob("pyproject.toml"))
+            if not any(
+                part in ignored_parts or part.startswith(".venv")
+                for part in path.relative_to(src_package).parts
+            )
         ],
+    ]
+
+
+def test_project_pyprojects_ignore_prefixed_virtual_environments(tmp_path: Path) -> None:
+    src_package = tmp_path / "src" / "agilab"
+    root_pyproject = tmp_path / "pyproject.toml"
+    package_pyproject = src_package / "owned" / "pyproject.toml"
+    polluted_pyproject = (
+        src_package
+        / "owned"
+        / ".venv.agilab-linking"
+        / "site-packages"
+        / "third-party"
+        / "pyproject.toml"
+    )
+    for path in (root_pyproject, package_pyproject, polluted_pyproject):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("[project]\nrequires-python = \">=3.12\"\n", encoding="utf-8")
+
+    assert _project_pyprojects(tmp_path, src_package) == [
+        root_pyproject,
+        package_pyproject,
     ]
 
 

--- a/tools/builtin_app_tests.py
+++ b/tools/builtin_app_tests.py
@@ -85,6 +85,8 @@ def subprocess_env(
     if env_root is None:
         env_root = Path(env.get(APP_TEST_ENV_ROOT_ENV, str(DEFAULT_APP_TEST_ENVS_ROOT)))
     env["UV_PROJECT_ENVIRONMENT"] = str(env_root / target.name)
+    # Ignored app-local .venv links must not override the repo test interpreter.
+    env["UV_PYTHON"] = sys.executable
     return env
 
 

--- a/tools/coverage_badge_guard.py
+++ b/tools/coverage_badge_guard.py
@@ -50,6 +50,8 @@ NON_GUI_ROOT_TESTS = {
     "test/test_pypi_distribution_state.py",
     "test/test_pypi_publish.py",
     "test/test_pypi_publish_workflow.py",
+    "test/test_builtin_app_tests.py",
+    "test/test_pyproject_dependency_hygiene.py",
     "test/test_impact_validate.py",
     "test/test_agilab_dev_shortcuts.py",
     "test/test_workflow_parity.py",


### PR DESCRIPTION
## Summary

- pin nested built-in app test environments to the repository test interpreter
- keep dependency-policy project discovery out of ignored `.venv*` trees
- classify release/tooling policy tests as non-GUI coverage inputs
- add polluted-environment regressions for both inventory boundaries
- populate `CHANGELOG.md` Unreleased notes for the four-package `2026.07.17.1` hotfix scope

## Repro

Running `./dev release --release-mode hotfix --impact-base-ref v2026.07.17` exposed three local-pollution failures:

1. A nested built-in app test selected CPython 3.14.6+freethreaded through an ignored app-local `.venv` link. Polars fell back to a Rust source build and failed in `foldhash`.
2. Dependency-policy recursively scanned `.venv.agilab-linking/site-packages` and treated third-party Streamlit template metadata as AGILAB projects.
3. The coverage badge guard classified the two tooling-policy tests as AGILAB GUI coverage changes and required unrelated GUI coverage XML.

## Root Cause

- Built-in app environments isolated `UV_PROJECT_ENVIRONMENT` but did not pin the nested uv interpreter.
- Project discovery ignored only the exact path component `.venv`, not generated names covered by the repository's `.venv*/` ignore contract.
- The coverage guard's non-GUI policy-test inventory did not include the built-in runner and dependency-hygiene tests.

## Regression Test

- `test_subprocess_env_uses_isolated_app_environment` seeds a polluted `UV_PYTHON` and proves the nested environment uses `sys.executable`.
- `test_project_pyprojects_ignore_prefixed_virtual_environments` proves `.venv.agilab-linking` metadata is excluded.
- `test_changed_coverage_components_ignores_non_gui_policy_tests` proves the release-policy tests do not request GUI badge regeneration.

## Release Scope

The impact closure from `v2026.07.17` contains 23 packages. Exact PyPI artifact checks select only these unpublished `2026.07.17.1` distributions:

- `agi-page-queue-health`
- `agi-page-relay-health`
- `agi-pages`
- `agilab`

The Unreleased notes are limited to behavior carried by that partial hotfix and do not claim unchanged-version routing, maps, or shared-core packages.

## Validation

- focused built-in runner, dependency-policy, and coverage-guard tests: passed
- polluted `data_quality_gate_project` reproduction: passed under repository Python 3.13
- full built-in app test matrix: passed
- dependency-policy workflow profile: passed
- shared-core strict typing profile: passed
- docs/release-proof/Sphinx profile: passed
- coverage badge freshness guard: passed
- Ruff, staged impact/scope, changelog contract, and diff checks: passed
- isolated strict audit: passed for a single clean worktree
- all required GitHub PR checks: passed
- full `./dev release --release-mode hotfix --impact-base-ref v2026.07.17` from merged `main`: passed

## Review Evidence

- GPT-5 sub-agent Sagan reviewed hotfix-mode parity, interpreter isolation, and the final six-file diff; no blockers, no files edited.
- GPT-5 sub-agent Godel reviewed changelog/package alignment; notes were narrowed to the four selected artifacts, no files edited.

## Agent Metadata

- Tokki version: 1.0.32
- Agent/runtime: Codex, version unavailable
- Model: GPT-5
- Reasoning effort: unknown
- /fast mode: not used
