### PR TITLE
fix: non-loopback public-bind guard + Windows-safe env-prefix execution

### DIFF
--- a/src/agilab/core/agi-env/src/agi_env/runtime/execution_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/runtime/execution_support.py
@@ -96,6 +96,42 @@ def _command_requires_shell(cmd: str) -> bool:
     )
 
 
+_ENV_ASSIGNMENT_TOKEN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+
+
+def _default_shell_executable() -> str | None:
+    """One shell for every run entry point: bash on POSIX, default on Windows."""
+    return None if sys.platform == "win32" else "/bin/bash"
+
+
+def _split_leading_env_assignments(cmd: str) -> tuple[dict[str, str], list[str]] | None:
+    """Split ``VAR=value ... prog args`` into env updates plus argv.
+
+    Returns ``None`` when the command needs real shell handling: it contains
+    shell syntax or builtins, has no leading assignment, cannot be tokenized,
+    or an assignment value references shell expansion (``$``/backtick), which
+    only a shell can resolve.
+    """
+    if SHELL_SYNTAX_PATTERN.search(cmd) or SHELL_BUILTIN_PATTERN.match(cmd):
+        return None
+    if not SHELL_ASSIGNMENT_PATTERN.match(cmd):
+        return None
+    try:
+        tokens = shlex.split(cmd)
+    except ValueError:
+        return None
+    env_updates: dict[str, str] = {}
+    argv = list(tokens)
+    while argv and _ENV_ASSIGNMENT_TOKEN.match(argv[0]):
+        key, _, value = argv.pop(0).partition("=")
+        if "$" in value or "`" in value:
+            return None
+        env_updates[key] = value
+    if not argv:
+        return None
+    return env_updates, argv
+
+
 async def _spawn_process(
     *,
     cmd: str,
@@ -106,6 +142,20 @@ async def _spawn_process(
     stdout: int | None = asyncio.subprocess.PIPE,
     stderr: int | None = asyncio.subprocess.PIPE,
 ) -> asyncio.subprocess.Process:
+    # ``VAR=value prog args`` commands need no shell: apply the assignments to
+    # the child env and exec directly. This keeps env-prefixed deploy commands
+    # working on Windows, where the fallback shell (cmd.exe) cannot parse
+    # POSIX-style leading assignments.
+    assignment_split = _split_leading_env_assignments(cmd)
+    if assignment_split is not None:
+        env_updates, argv = assignment_split
+        return await asyncio.create_subprocess_exec(
+            *argv,
+            stdout=stdout,
+            stderr=stderr,
+            cwd=str(cwd) if cwd else None,
+            env={**process_env, **env_updates},
+        )
     if _command_requires_shell(cmd):
         if not allow_shell:
             raise ValueError(f"Shell syntax is not allowed for this command: {cmd}")
@@ -249,7 +299,7 @@ async def run(
 
     process_env = _create_process_env(venv=venv, build_env_fn=build_env_fn)
     cmd = apply_inline_path_export(cmd, process_env)
-    shell_executable = None if sys.platform == "win32" else "/bin/bash"
+    shell_executable = _default_shell_executable()
 
     if not wait:
         if not cmd:
@@ -347,7 +397,7 @@ async def run_bg(
         cmd=cmd,
         cwd=cwd,
         process_env=process_env,
-        shell_executable=None,
+        shell_executable=_default_shell_executable(),
     )
 
     out_cb, err_cb = _resolve_stream_callbacks(log_callback=log_callback, logger=logger)
@@ -400,7 +450,7 @@ async def run_async(
 
     process_env = _create_process_env(venv=venv, build_env_fn=build_env_fn)
     process_env["PYTHONUNBUFFERED"] = "1"
-    shell_executable = None if os.name == "nt" else "/bin/bash"
+    shell_executable = _default_shell_executable()
 
     if isinstance(cmd, (list, tuple)):
         cmd = " ".join(cmd)

--- a/src/agilab/core/agi-env/test/test_execution_support.py
+++ b/src/agilab/core/agi-env/test/test_execution_support.py
@@ -130,6 +130,64 @@ def test_spawn_process_does_not_shell_fallback_plain_commands(tmp_path: Path, mo
         )
 
 
+def test_spawn_process_execs_env_assignment_prefix_without_shell(
+    tmp_path: Path, monkeypatch
+):
+    # ``VAR=value prog args`` must run via exec with the assignments moved into
+    # the child env: the Windows fallback shell (cmd.exe) cannot parse POSIX
+    # leading assignments.
+    captured: dict[str, object] = {}
+
+    async def _fake_exec(*args, **kwargs):
+        captured["argv"] = args
+        captured["env"] = kwargs["env"]
+        return _FakeProc(stdout_lines=[b""], stderr_lines=[b""])
+
+    async def _unexpected_shell(*_args, **_kwargs):
+        raise AssertionError("assignment prefix must not promote to shell")
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_exec)
+    monkeypatch.setattr(asyncio, "create_subprocess_shell", _unexpected_shell)
+
+    asyncio.run(
+        execution_support._spawn_process(
+            cmd="PIP_INDEX_URL=https://test.pypi.org/simple UV_X=1 uv sync --active",
+            cwd=tmp_path,
+            process_env={"PYTHONUNBUFFERED": "1"},
+            shell_executable="/bin/bash",
+        )
+    )
+
+    assert captured["argv"] == ("uv", "sync", "--active")
+    assert captured["env"]["PIP_INDEX_URL"] == "https://test.pypi.org/simple"
+    assert captured["env"]["UV_X"] == "1"
+    assert captured["env"]["PYTHONUNBUFFERED"] == "1"
+
+
+def test_spawn_process_keeps_shell_for_assignment_values_needing_expansion(
+    tmp_path: Path, monkeypatch
+):
+    async def _unexpected_exec(*_args, **_kwargs):
+        raise AssertionError("values with shell expansion must keep the shell")
+
+    async def _fake_shell(*_args, **_kwargs):
+        return _FakeProc(stdout_lines=[b""], stderr_lines=[b""])
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _unexpected_exec)
+    monkeypatch.setattr(asyncio, "create_subprocess_shell", _fake_shell)
+
+    proc = asyncio.run(
+        execution_support._spawn_process(
+            cmd='PATH="/opt/bin:$PATH" uv sync',
+            cwd=tmp_path,
+            process_env={"PYTHONUNBUFFERED": "1"},
+            shell_executable="/bin/bash",
+        )
+    )
+
+    assert isinstance(proc, _FakeProc)
+
+
 def test_spawn_process_can_disable_shell_syntax(tmp_path: Path):
     with pytest.raises(ValueError, match="Shell syntax is not allowed"):
         asyncio.run(

--- a/src/agilab/security/ui_public_bind_guard.py
+++ b/src/agilab/security/ui_public_bind_guard.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import ipaddress
 import os
 from typing import Callable, Mapping
 
 
 EXPOSED_UI_HOSTS = {"0.0.0.0", "::"}
+LOOPBACK_HOSTNAMES = {"", "localhost", "localhost.localdomain"}
 DEFAULT_STREAMLIT_HOST = "127.0.0.1"
 PUBLIC_BIND_OK_ENV = "AGILAB_PUBLIC_BIND_OK"
 PUBLIC_BIND_EVIDENCE_ENV = "AGILAB_PUBLIC_BIND_EVIDENCE"
@@ -49,6 +51,22 @@ def configured_streamlit_host(
     return DEFAULT_STREAMLIT_HOST
 
 
+def host_is_exposed(host: str) -> bool:
+    """Return True unless ``host`` is verifiably a loopback bind.
+
+    Wildcard binds, LAN/WAN interface IPs, and unresolvable hostnames are all
+    treated as exposed; only loopback addresses and well-known loopback
+    hostnames are exempt from the public-bind controls.
+    """
+    candidate = str(host).strip().strip("[]")
+    if candidate.lower() in LOOPBACK_HOSTNAMES:
+        return False
+    try:
+        return not ipaddress.ip_address(candidate).is_loopback
+    except ValueError:
+        return True
+
+
 def public_bind_has_controls(environ: Mapping[str, str] | None = None) -> bool:
     env = environ or os.environ
     return truthy(env.get(PUBLIC_BIND_OK_ENV)) and any(
@@ -58,10 +76,12 @@ def public_bind_has_controls(environ: Mapping[str, str] | None = None) -> bool:
 
 def public_bind_error_message(host: str) -> str:
     return (
-        f"AGILAB refuses to bind the Streamlit UI publicly on {host!r} without explicit protection. "
+        f"AGILAB refuses to bind the Streamlit UI on non-loopback host {host!r} without explicit protection. "
         "Use the default 127.0.0.1 bind, or set AGILAB_PUBLIC_BIND_OK=1 together with "
-        "an auth/TLS indicator such as AGILAB_TLS_TERMINATED=1. For shared/public deployments, "
-        "also archive AGILAB_PUBLIC_BIND_EVIDENCE for the security-check gate."
+        "an auth/TLS indicator such as AGILAB_TLS_TERMINATED=1. These flags are operator "
+        "attestations, not proof: AGILAB does not verify that authentication or TLS is "
+        "actually in place. For shared/public deployments, also archive "
+        "AGILAB_PUBLIC_BIND_EVIDENCE for the security-check gate."
     )
 
 
@@ -89,7 +109,7 @@ def enforce_public_bind_policy(
     host = configured_streamlit_host(
         environ, streamlit_config_getter=streamlit_config_getter
     )
-    if host in EXPOSED_UI_HOSTS and not public_bind_has_controls(environ):
+    if host_is_exposed(host) and not public_bind_has_controls(environ):
         raise PublicBindPolicyError(public_bind_error_message(host))
     return host
 

--- a/test/test_ui_pages.py
+++ b/test/test_ui_pages.py
@@ -887,7 +887,8 @@ def test_agilab_main_page_refuses_unprotected_public_bind(mock_ui_env):
 
     assert not list(at.exception)
     assert any(
-        "refuses to bind the Streamlit UI publicly" in item.value for item in at.error
+        "refuses to bind the Streamlit UI on non-loopback host" in item.value
+        for item in at.error
     )
 
 

--- a/test/test_ui_public_bind_guard.py
+++ b/test/test_ui_public_bind_guard.py
@@ -74,6 +74,21 @@ def test_direct_streamlit_public_bind_is_refused_without_controls():
 
 
 @pytest.mark.parametrize(
+    "host", ["192.168.1.20", "10.0.0.5", "[2001:db8::1]", "lab-host.example.com"]
+)
+def test_non_loopback_interface_binds_are_refused_without_controls(host):
+    # Regression: binding a specific LAN/WAN interface IP or hostname is just
+    # as exposed as a 0.0.0.0 wildcard bind and must require the same controls.
+    with pytest.raises(PublicBindPolicyError):
+        enforce_public_bind_policy({"AGILAB_UI_HOST": host})
+
+
+@pytest.mark.parametrize("host", ["127.0.0.1", "127.0.1.1", "::1", "[::1]", "localhost"])
+def test_loopback_binds_never_require_controls(host):
+    assert enforce_public_bind_policy({"AGILAB_UI_HOST": host}) == host
+
+
+@pytest.mark.parametrize(
     "environment",
     [
         {"AGILAB_UI_HOST": "0.0.0.0", "AGILAB_PUBLIC_BIND_OK": "1"},


### PR DESCRIPTION
## Summary
Batch B of the deferred deep-audit findings:
- **Public-bind guard**: any non-loopback bind (specific LAN/WAN interface IP, hostname) now requires the same controls as `0.0.0.0`/`::`; the refusal message states the control flags are operator attestations, not verified auth/TLS.
- **Windows env prefixes**: `VAR=value prog args` deploy commands now run via exec with assignments moved into the child env, instead of being promoted to a shell (`cmd.exe` on Windows cannot parse POSIX assignments). Values containing `$`/backtick keep shell semantics.
- Unified the shell-executable choice across `run`/`run_bg`/`run_async` (was bash vs `/bin/sh`).

## Validation
- Core + agi-env suites: 2531 passed, 6 skipped
- `test_lab_run.py` + `test_ui_pages.py`: green after updating the guard-message assertion
- New regressions: LAN-IP/hostname refusal, loopback allowance, assignment-prefix exec path, expansion fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)