### PR TITLE
refactor: app-agnostic args codec hook for ORCHESTRATE

### DIFF
--- a/src/agilab/apps/builtin/flight_telemetry_project/src/flight_telemetry/__init__.py
+++ b/src/agilab/apps/builtin/flight_telemetry_project/src/flight_telemetry/__init__.py
@@ -12,6 +12,8 @@ from .flight_args import (  # noqa: F401
     ensure_defaults,
     load_args,
     load_args_from_toml,
+    load_args_payload,
     merge_args,
+    persist_args_payload,
 )
 from .reduction import FLIGHT_REDUCE_CONTRACT  # noqa: F401

--- a/src/agilab/apps/builtin/flight_telemetry_project/src/flight_telemetry/flight_args.py
+++ b/src/agilab/apps/builtin/flight_telemetry_project/src/flight_telemetry/flight_args.py
@@ -196,6 +196,26 @@ def dump_args_to_toml(
     )
 
 
+def load_args_payload(settings_path: str | Path) -> dict[str, Any]:
+    """AGILAB args-codec hook: load, default, and normalize args for the UI."""
+
+    return apply_source_defaults(load_args_from_toml(settings_path)).to_toml_payload()
+
+
+def persist_args_payload(
+    args: dict[str, Any],
+    settings_path: str | Path,
+) -> dict[str, Any]:
+    """AGILAB args-codec hook: validate, persist, and echo the normalized args.
+
+    Raises pydantic ``ValidationError`` (a ``ValueError``) on invalid input.
+    """
+
+    parsed = apply_source_defaults(FlightArgs(**args))
+    dump_args_to_toml(parsed, settings_path)
+    return parsed.to_toml_payload()
+
+
 ArgsModel = FlightArgs
 ArgsOverrides = FlightArgsTD
 

--- a/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/src/flight_telemetry/__init__.py
+++ b/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/src/flight_telemetry/__init__.py
@@ -12,6 +12,8 @@ from .flight_args import (  # noqa: F401
     ensure_defaults,
     load_args,
     load_args_from_toml,
+    load_args_payload,
     merge_args,
+    persist_args_payload,
 )
 from .reduction import FLIGHT_REDUCE_CONTRACT  # noqa: F401

--- a/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/src/flight_telemetry/flight_args.py
+++ b/src/agilab/lib/agi-app-flight-telemetry/src/agi_app_flight_telemetry/project/flight_telemetry_project/src/flight_telemetry/flight_args.py
@@ -196,6 +196,26 @@ def dump_args_to_toml(
     )
 
 
+def load_args_payload(settings_path: str | Path) -> dict[str, Any]:
+    """AGILAB args-codec hook: load, default, and normalize args for the UI."""
+
+    return apply_source_defaults(load_args_from_toml(settings_path)).to_toml_payload()
+
+
+def persist_args_payload(
+    args: dict[str, Any],
+    settings_path: str | Path,
+) -> dict[str, Any]:
+    """AGILAB args-codec hook: validate, persist, and echo the normalized args.
+
+    Raises pydantic ``ValidationError`` (a ``ValueError``) on invalid input.
+    """
+
+    parsed = apply_source_defaults(FlightArgs(**args))
+    dump_args_to_toml(parsed, settings_path)
+    return parsed.to_toml_payload()
+
+
 ArgsModel = FlightArgs
 ArgsOverrides = FlightArgsTD
 

--- a/src/agilab/pages/2_ORCHESTRATE.py
+++ b/src/agilab/pages/2_ORCHESTRATE.py
@@ -369,28 +369,48 @@ def _active_app_import_scope(env: Any):
     )
 
 
-def _load_flight_args_payload(env: Any) -> dict[str, Any]:
+def _args_codec_package(env: Any) -> str:
+    """Manager package name for the active app (``foo_project`` -> ``foo``)."""
+    return str(getattr(env, "app", "") or "").removesuffix("_project")
+
+
+def _resolve_args_codec_hook(env: Any, hook_name: str) -> Callable[..., Any] | None:
+    """Look up an optional args-codec hook exported by the active app.
+
+    Apps that want typed args validation/normalization in the generic args
+    editor export ``load_args_payload(settings_file)`` and
+    ``persist_args_payload(args, settings_file)`` from their manager package.
+    The generic page stays app-agnostic: no app is imported unless it declares
+    the hooks, and apps without them fall back to the plain TOML path.
+    """
+    package = _args_codec_package(env)
+    if not package:
+        return None
+    try:
+        module = importlib.import_module(package)
+    except ImportError:
+        return None
+    hook = getattr(module, hook_name, None)
+    return hook if callable(hook) else None
+
+
+def _load_args_payload_via_codec(env: Any) -> dict[str, Any] | None:
     with _active_app_import_scope(env):
-        from flight_telemetry import apply_source_defaults, load_args_from_toml
+        hook = _resolve_args_codec_hook(env, "load_args_payload")
+        if hook is None:
+            return None
+        return dict(hook(env.app_settings_file))
 
-        args_model = apply_source_defaults(load_args_from_toml(env.app_settings_file))
-        return args_model.to_toml_payload()
 
-
-def _persist_flight_args_payload(
+def _persist_args_payload_via_codec(
     env: Any,
     args_input: dict[str, Any],
-) -> dict[str, Any]:
+) -> dict[str, Any] | None:
     with _active_app_import_scope(env):
-        from flight_telemetry import (
-            apply_source_defaults,
-            dump_args_to_toml,
-            FlightArgs,
-        )
-
-        parsed_args = apply_source_defaults(FlightArgs(**args_input))
-        dump_args_to_toml(parsed_args, env.app_settings_file)
-        return parsed_args.to_toml_payload()
+        hook = _resolve_args_codec_hook(env, "persist_args_payload")
+        if hook is None:
+            return None
+        return dict(hook(args_input, env.app_settings_file))
 
 
 def background_services_enabled(*args: Any, **kwargs: Any) -> Any:
@@ -1039,20 +1059,21 @@ def initialize_app_settings(args_override: dict[str, Any] | None = None) -> None
     session_settings = st.session_state.get("app_settings")
     app_settings = merge_app_settings_sources(file_settings, session_settings)
 
-    if env.app == "flight_telemetry_project":
-        try:
-            app_settings["args"] = _load_flight_args_payload(env)
-        except (
-            ImportError,
-            AttributeError,
-            OSError,
-            RuntimeError,
-            TypeError,
-            ValueError,
-            tomllib.TOMLDecodeError,
-        ) as exc:
-            st.warning(f"Unable to load Flight args: {exc}")
-            app_settings.setdefault("args", {})
+    try:
+        codec_args = _load_args_payload_via_codec(env)
+    except (
+        ImportError,
+        AttributeError,
+        OSError,
+        RuntimeError,
+        TypeError,
+        ValueError,
+        tomllib.TOMLDecodeError,
+    ) as exc:
+        st.warning(f"Unable to load app args: {exc}")
+        codec_args = None
+    if codec_args is not None:
+        app_settings["args"] = codec_args
     else:
         app_settings.setdefault("args", {})
 
@@ -1531,16 +1552,22 @@ def render_generic_ui() -> None:
     if is_args_reload_required:
         st.session_state["args_input"] = args_input
         app_settings_file = env.app_settings_file
-        if env.app == "flight_telemetry_project":
-            from pydantic import ValidationError
-
+        persisted_args = None
+        codec_error: ValueError | None = None
+        try:
+            # pydantic ValidationError subclasses ValueError, so app codecs can
+            # raise either without the generic page importing pydantic.
+            persisted_args = _persist_args_payload_via_codec(env, args_input)
+        except ValueError as exc:
+            codec_error = exc
+        if codec_error is not None:
             try:
-                persisted_args = _persist_flight_args_payload(env, args_input)
-            except ValidationError as exc:
-                messages = env.humanize_validation_errors(exc)
+                messages = env.humanize_validation_errors(codec_error)
                 st.warning("\n".join(messages))
-            else:
-                st.session_state.app_settings["args"] = persisted_args
+            except (AttributeError, TypeError):
+                st.warning(str(codec_error))
+        elif persisted_args is not None:
+            st.session_state.app_settings["args"] = persisted_args
         else:
             existing_app_settings = load_toml_file(app_settings_file)
             existing_app_settings.setdefault("args", {})

--- a/test/test_flight_telemetry_project_runtime_args.py
+++ b/test/test_flight_telemetry_project_runtime_args.py
@@ -634,3 +634,41 @@ def test_flight_telemetry_worker_emits_reduce_artifact(monkeypatch, tmp_path):
     assert artifact.payload["speed_kernel_runtimes"][0] in {"python", "cython"}
     assert artifact.payload["speed_dtype_contracts"] == ["float64-contiguous"]
     assert artifact.payload["speed_kernel_checksum_m"] > 0.0
+
+
+def test_flight_args_codec_hooks_round_trip(monkeypatch, tmp_path):
+    # AGILAB ORCHESTRATE args-codec contract: the manager package exports
+    # load_args_payload / persist_args_payload so the generic page needs no
+    # app-specific imports.
+    repo_root = Path(__file__).resolve().parents[1]
+    app_src = repo_root / "src" / "agilab" / "apps" / "builtin" / "flight_telemetry_project" / "src"
+    monkeypatch.syspath_prepend(str(app_src))
+    existing = sys.modules.get("flight_telemetry")
+    if existing is not None and not hasattr(existing, "__path__"):
+        monkeypatch.delitem(sys.modules, "flight_telemetry", raising=False)
+    import flight_telemetry
+
+    settings_file = tmp_path / "app_settings.toml"
+    payload = flight_telemetry.persist_args_payload(
+        {"data_source": "file"}, settings_file
+    )
+    assert payload["files"] == "*"
+    assert settings_file.is_file()
+
+    loaded = flight_telemetry.load_args_payload(settings_file)
+    assert loaded == payload
+
+    with pytest.raises(ValueError):
+        flight_telemetry.persist_args_payload(
+            {"data_source": "not-a-source"}, settings_file
+        )
+
+
+def test_orchestrate_page_has_no_app_specific_imports():
+    repo_root = Path(__file__).resolve().parents[1]
+    page_source = (repo_root / "src" / "agilab" / "pages" / "2_ORCHESTRATE.py").read_text(
+        encoding="utf-8"
+    )
+    assert "flight_telemetry" not in page_source
+    assert "load_args_payload" in page_source
+    assert "persist_args_payload" in page_source

--- a/test/test_orchestrate_page_helpers.py
+++ b/test/test_orchestrate_page_helpers.py
@@ -226,7 +226,7 @@ def test_orchestrate_readiness_cards_use_compact_path_captions(tmp_path):
     assert module._compact_path_caption("short status") == "short status"
 
 
-def test_orchestrate_flight_imports_are_app_scoped_and_restore_process_state(
+def test_orchestrate_args_codec_imports_are_app_scoped_and_restore_process_state(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
@@ -238,22 +238,16 @@ def test_orchestrate_flight_imports_are_app_scoped_and_restore_process_state(
         app_src.mkdir(parents=True)
         settings_file = app_src / "app_settings.toml"
         settings_file.write_text("", encoding="utf-8")
-        (app_src / "flight_telemetry.py").write_text(
+        (app_src / f"{project}.py").write_text(
             "\n".join(
                 [
                     "from pathlib import Path",
                     f"PROJECT = {project!r}",
-                    "class FlightArgs:",
-                    "    def __init__(self, **payload):",
-                    "        self.payload = payload",
-                    "    def to_toml_payload(self):",
-                    "        return {'project': PROJECT, **self.payload}",
-                    "def apply_source_defaults(args):",
-                    "    return args",
-                    "def load_args_from_toml(_path):",
-                    "    return FlightArgs(loaded=True)",
-                    "def dump_args_to_toml(_args, path):",
+                    "def load_args_payload(_path):",
+                    "    return {'project': PROJECT, 'loaded': True}",
+                    "def persist_args_payload(args, path):",
                     "    Path(path).write_text(PROJECT, encoding='utf-8')",
+                    "    return {'project': PROJECT, **args}",
                     "",
                 ]
             ),
@@ -261,19 +255,20 @@ def test_orchestrate_flight_imports_are_app_scoped_and_restore_process_state(
         )
         return SimpleNamespace(
             active_app=app_root,
+            app=f"{project}_project",
             app_settings_file=settings_file,
         )
 
     alpha_env = _build_app("alpha")
     beta_env = _build_app("beta")
-    sentinel = types.ModuleType("flight_telemetry")
+    sentinel = types.ModuleType("alpha")
     sentinel.PROJECT = "sentinel"
-    monkeypatch.setitem(sys.modules, "flight_telemetry", sentinel)
+    monkeypatch.setitem(sys.modules, "alpha", sentinel)
     original_path = list(sys.path)
 
     def _exercise(env, project: str):
-        loaded = module._load_flight_args_payload(env)
-        persisted = module._persist_flight_args_payload(env, {"value": project})
+        loaded = module._load_args_payload_via_codec(env)
+        persisted = module._persist_args_payload_via_codec(env, {"value": project})
         return loaded, persisted, Path(env.app_settings_file).read_text(encoding="utf-8")
 
     with ThreadPoolExecutor(max_workers=2) as executor:
@@ -293,9 +288,27 @@ def test_orchestrate_flight_imports_are_app_scoped_and_restore_process_state(
         "beta",
     )
     assert sys.path == original_path
-    assert sys.modules["flight_telemetry"] is sentinel
+    assert sys.modules["alpha"] is sentinel
     assert str(alpha_env.active_app / "src") not in sys.path
     assert str(beta_env.active_app / "src") not in sys.path
+
+
+def test_orchestrate_args_codec_returns_none_for_apps_without_hooks(
+    tmp_path: Path,
+) -> None:
+    module = _load_orchestrate_module()
+    app_root = tmp_path / "plain_project"
+    (app_root / "src").mkdir(parents=True)
+    settings_file = app_root / "src" / "app_settings.toml"
+    settings_file.write_text("", encoding="utf-8")
+    env = SimpleNamespace(
+        active_app=app_root,
+        app="plain_project",
+        app_settings_file=settings_file,
+    )
+
+    assert module._load_args_payload_via_codec(env) is None
+    assert module._persist_args_payload_via_codec(env, {"value": 1}) is None
 
 
 def test_orchestrate_workplan_chunk_rendering_accepts_rich_chunk_records():


### PR DESCRIPTION
## Summary
Batch C (final) of the deferred deep-audit findings — removes the generic-page contract violation where ORCHESTRATE hard-coded `flight_telemetry_project`:
- New optional app hook: a manager package may export `load_args_payload(settings_file)` / `persist_args_payload(args, settings_file)`; the generic args editor discovers them inside the existing app-scoped import context. Apps without hooks keep the plain TOML path.
- `flight_telemetry` implements the hooks; the embedded `agi-app-flight-telemetry` payload mirror is synced.
- Any app raising pydantic `ValidationError` (or plain `ValueError`) gets humanized warnings — previously only the flight app had validation at all.

## Validation
- `test_orchestrate_page_helpers.py` (incl. rewritten scoped-import isolation test), `test_orchestrate_page_state.py`, `test_orchestrate_services.py`, `test_flight_telemetry_project_runtime_args.py` (+codec round-trip regressions): 190 passed
- `test_app_contract_matrix.py`: 14 passed after payload sync
- `test_ui_pages.py`: 88 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)