### PR TITLE
refactor: share badge SVG renderer (escaping + proportional widths)

### DIFF
--- a/badges/agent-api.svg
+++ b/badges/agent-api.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="153" height="20" role="img" aria-label="Agent API: CLI Python">
+<svg xmlns="http://www.w3.org/2000/svg" width="155" height="20" role="img" aria-label="Agent API: CLI Python">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -6,17 +6,17 @@
   <stop offset="1" stop-opacity=".5"/>
 </linearGradient>
 <mask id="a">
-  <rect width="153" height="20" rx="3" fill="#fff"/>
+  <rect width="155" height="20" rx="3" fill="#fff"/>
 </mask>
 <g mask="url(#a)">
-  <rect width="73" height="20" fill="#555"/>
-  <rect x="73" width="80" height="20" fill="#5B6CFF"/>
-  <rect width="153" height="20" fill="url(#b)"/>
+  <rect width="74" height="20" fill="#555"/>
+  <rect x="74" width="81" height="20" fill="#5B6CFF"/>
+  <rect width="155" height="20" fill="url(#b)"/>
 </g>
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
-  <text x="36.5" y="15" fill="#010101" fill-opacity=".3">Agent API</text>
-  <text x="36.5" y="14">Agent API</text>
-  <text x="113.0" y="15" fill="#010101" fill-opacity=".3">CLI Python</text>
-  <text x="113.0" y="14">CLI Python</text>
+  <text x="37.0" y="15" fill="#010101" fill-opacity=".3">Agent API</text>
+  <text x="37.0" y="14">Agent API</text>
+  <text x="114.5" y="15" fill="#010101" fill-opacity=".3">CLI Python</text>
+  <text x="114.5" y="14">CLI Python</text>
 </g>
 </svg>

--- a/badges/agent-standard.svg
+++ b/badges/agent-standard.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="160" height="20" role="img" aria-label="Standard: Agent Skills">
+<svg xmlns="http://www.w3.org/2000/svg" width="146" height="20" role="img" aria-label="Standard: Agent Skills">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -6,17 +6,17 @@
   <stop offset="1" stop-opacity=".5"/>
 </linearGradient>
 <mask id="a">
-  <rect width="160" height="20" rx="3" fill="#fff"/>
+  <rect width="146" height="20" rx="3" fill="#fff"/>
 </mask>
 <g mask="url(#a)">
-  <rect width="66" height="20" fill="#555"/>
-  <rect x="66" width="94" height="20" fill="#5B6CFF"/>
-  <rect width="160" height="20" fill="url(#b)"/>
+  <rect width="64" height="20" fill="#555"/>
+  <rect x="64" width="82" height="20" fill="#5B6CFF"/>
+  <rect width="146" height="20" fill="url(#b)"/>
 </g>
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
-  <text x="33.0" y="15" fill="#010101" fill-opacity=".3">Standard</text>
-  <text x="33.0" y="14">Standard</text>
-  <text x="113.0" y="15" fill="#010101" fill-opacity=".3">Agent Skills</text>
-  <text x="113.0" y="14">Agent Skills</text>
+  <text x="32.0" y="15" fill="#010101" fill-opacity=".3">Standard</text>
+  <text x="32.0" y="14">Standard</text>
+  <text x="105.0" y="15" fill="#010101" fill-opacity=".3">Agent Skills</text>
+  <text x="105.0" y="14">Agent Skills</text>
 </g>
 </svg>

--- a/badges/agent-works-with.svg
+++ b/badges/agent-works-with.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="370" height="20" role="img" aria-label="Works with: Codex Claude Aider OpenCode Mistral Vibe">
+<svg xmlns="http://www.w3.org/2000/svg" width="345" height="20" role="img" aria-label="Works with: Codex Claude Aider OpenCode Mistral Vibe">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -6,17 +6,17 @@
   <stop offset="1" stop-opacity=".5"/>
 </linearGradient>
 <mask id="a">
-  <rect width="370" height="20" rx="3" fill="#fff"/>
+  <rect width="345" height="20" rx="3" fill="#fff"/>
 </mask>
 <g mask="url(#a)">
-  <rect width="80" height="20" fill="#555"/>
-  <rect x="80" width="290" height="20" fill="#0F766E"/>
-  <rect width="370" height="20" fill="url(#b)"/>
+  <rect width="78" height="20" fill="#555"/>
+  <rect x="78" width="267" height="20" fill="#0F766E"/>
+  <rect width="345" height="20" fill="url(#b)"/>
 </g>
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
-  <text x="40.0" y="15" fill="#010101" fill-opacity=".3">Works with</text>
-  <text x="40.0" y="14">Works with</text>
-  <text x="225.0" y="15" fill="#010101" fill-opacity=".3">Codex Claude Aider OpenCode Mistral Vibe</text>
-  <text x="225.0" y="14">Codex Claude Aider OpenCode Mistral Vibe</text>
+  <text x="39.0" y="15" fill="#010101" fill-opacity=".3">Works with</text>
+  <text x="39.0" y="14">Works with</text>
+  <text x="211.5" y="15" fill="#010101" fill-opacity=".3">Codex Claude Aider OpenCode Mistral Vibe</text>
+  <text x="211.5" y="14">Codex Claude Aider OpenCode Mistral Vibe</text>
 </g>
 </svg>

--- a/badges/skills.svg
+++ b/badges/skills.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="76" height="20" role="img" aria-label="Skills: 33">
+<svg xmlns="http://www.w3.org/2000/svg" width="65" height="20" role="img" aria-label="Skills: 33">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -6,17 +6,17 @@
   <stop offset="1" stop-opacity=".5"/>
 </linearGradient>
 <mask id="a">
-  <rect width="76" height="20" rx="3" fill="#fff"/>
+  <rect width="65" height="20" rx="3" fill="#fff"/>
 </mask>
 <g mask="url(#a)">
-  <rect width="52" height="20" fill="#555"/>
-  <rect x="52" width="24" height="20" fill="#0F766E"/>
-  <rect width="76" height="20" fill="url(#b)"/>
+  <rect width="42" height="20" fill="#555"/>
+  <rect x="42" width="23" height="20" fill="#0F766E"/>
+  <rect width="65" height="20" fill="url(#b)"/>
 </g>
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
-  <text x="26.0" y="15" fill="#010101" fill-opacity=".3">Skills</text>
-  <text x="26.0" y="14">Skills</text>
-  <text x="64.0" y="15" fill="#010101" fill-opacity=".3">33</text>
-  <text x="64.0" y="14">33</text>
+  <text x="21.0" y="15" fill="#010101" fill-opacity=".3">Skills</text>
+  <text x="21.0" y="14">Skills</text>
+  <text x="53.5" y="15" fill="#010101" fill-opacity=".3">33</text>
+  <text x="53.5" y="14">33</text>
 </g>
 </svg>

--- a/tools/_badge_svg.py
+++ b/tools/_badge_svg.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Shared shields-style badge SVG renderer for the AGILAB badge generators.
+
+Single source of truth for badge geometry and escaping so
+``generate_skill_badges`` and ``generate_component_coverage_badges`` cannot
+drift. Text is centered with ``text-anchor="middle"`` over each rect, and the
+same width estimate drives both the rect width and the centering ``x`` so the
+label stays centered regardless of the estimate's accuracy.
+"""
+
+from __future__ import annotations
+
+from xml.sax.saxutils import escape
+
+# Per-character advance widths (in px at font-size 11, DejaVu Sans-ish),
+# quantized for stability. Narrow glyphs (i, l, punctuation) and wide glyphs
+# (m, w, %, uppercase) are approximated so the reserved box tracks the rendered
+# run far better than a flat monospace grid, avoiding clipping and excess pad.
+_NARROW = set("ijl.,:;'|!")
+_WIDE = set("mwMW%@_")
+_EXTRA_WIDE = set("—…")
+
+
+def _char_width(char: str) -> float:
+    if char in _NARROW:
+        return 3.5
+    if char in _EXTRA_WIDE:
+        return 11.0
+    if char in _WIDE:
+        return 9.5
+    if char.isupper():
+        return 8.0
+    return 6.5
+
+
+def text_width(text: str) -> int:
+    """Estimate the rendered pixel width of ``text`` plus horizontal padding."""
+    return 10 + round(sum(_char_width(char) for char in text))
+
+
+def render_badge(label: str, value: str, color: str) -> str:
+    """Return a two-segment shields-style badge SVG for ``label``/``value``."""
+    label = str(label)
+    value = str(value)
+    left = text_width(label)
+    right = text_width(value)
+    total = left + right
+    left_mid = left / 2
+    right_mid = left + right / 2
+    aria = escape(f"{label}: {value}", {'"': "&quot;"})
+    label_xml = escape(label)
+    value_xml = escape(value)
+    return f"""<svg xmlns="http://www.w3.org/2000/svg" width="{total}" height="20" role="img" aria-label="{aria}">
+<linearGradient id="b" x2="0" y2="100%">
+  <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
+  <stop offset=".1" stop-opacity=".1"/>
+  <stop offset=".9" stop-opacity=".3"/>
+  <stop offset="1" stop-opacity=".5"/>
+</linearGradient>
+<mask id="a">
+  <rect width="{total}" height="20" rx="3" fill="#fff"/>
+</mask>
+<g mask="url(#a)">
+  <rect width="{left}" height="20" fill="#555"/>
+  <rect x="{left}" width="{right}" height="20" fill="{color}"/>
+  <rect width="{total}" height="20" fill="url(#b)"/>
+</g>
+<g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+  <text x="{left_mid}" y="15" fill="#010101" fill-opacity=".3">{label_xml}</text>
+  <text x="{left_mid}" y="14">{label_xml}</text>
+  <text x="{right_mid}" y="15" fill="#010101" fill-opacity=".3">{value_xml}</text>
+  <text x="{right_mid}" y="14">{value_xml}</text>
+</g>
+</svg>
+"""

--- a/tools/generate_component_coverage_badges.py
+++ b/tools/generate_component_coverage_badges.py
@@ -4,8 +4,12 @@
 from __future__ import annotations
 
 import argparse
+import sys
 import xml.etree.ElementTree as ET
 from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _badge_svg import render_badge  # noqa: E402
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -85,45 +89,10 @@ def badge_color(percent: float) -> str:
     return "#e05d44"
 
 
-def text_width(text: str) -> int:
-    return 10 + len(text) * 7
-
-
 def format_percent(percent: float) -> str:
     # Truncate instead of rounding so badges stay stable across tiny local/CI
     # coverage deltas near threshold boundaries.
     return f"{int(percent)}%"
-
-
-def render_badge(label: str, value: str, color: str) -> str:
-    left = text_width(label)
-    right = text_width(value)
-    total = left + right
-    left_mid = left / 2
-    right_mid = left + right / 2
-    return f"""<svg xmlns="http://www.w3.org/2000/svg" width="{total}" height="20" role="img" aria-label="{label}: {value}">
-<linearGradient id="b" x2="0" y2="100%">
-  <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
-  <stop offset=".1" stop-opacity=".1"/>
-  <stop offset=".9" stop-opacity=".3"/>
-  <stop offset="1" stop-opacity=".5"/>
-</linearGradient>
-<mask id="a">
-  <rect width="{total}" height="20" rx="3" fill="#fff"/>
-</mask>
-<g mask="url(#a)">
-  <rect width="{left}" height="20" fill="#555"/>
-  <rect x="{left}" width="{right}" height="20" fill="{color}"/>
-  <rect width="{total}" height="20" fill="url(#b)"/>
-</g>
-<g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
-  <text x="{left_mid}" y="15" fill="#010101" fill-opacity=".3">{label}</text>
-  <text x="{left_mid}" y="14">{label}</text>
-  <text x="{right_mid}" y="15" fill="#010101" fill-opacity=".3">{value}</text>
-  <text x="{right_mid}" y="14">{value}</text>
-</g>
-</svg>
-"""
 
 
 def compute_from_component_xml(path: Path) -> float | None:

--- a/tools/generate_skill_badges.py
+++ b/tools/generate_skill_badges.py
@@ -4,7 +4,11 @@
 from __future__ import annotations
 
 import argparse
+import sys
 from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _badge_svg import render_badge  # noqa: E402
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -55,41 +59,6 @@ def parse_args() -> argparse.Namespace:
         ),
     )
     return parser.parse_args()
-
-
-def text_width(text: str) -> int:
-    return 10 + len(text) * 7
-
-
-def render_badge(label: str, value: str, color: str) -> str:
-    left = text_width(label)
-    right = text_width(value)
-    total = left + right
-    left_mid = left / 2
-    right_mid = left + right / 2
-    return f"""<svg xmlns="http://www.w3.org/2000/svg" width="{total}" height="20" role="img" aria-label="{label}: {value}">
-<linearGradient id="b" x2="0" y2="100%">
-  <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
-  <stop offset=".1" stop-opacity=".1"/>
-  <stop offset=".9" stop-opacity=".3"/>
-  <stop offset="1" stop-opacity=".5"/>
-</linearGradient>
-<mask id="a">
-  <rect width="{total}" height="20" rx="3" fill="#fff"/>
-</mask>
-<g mask="url(#a)">
-  <rect width="{left}" height="20" fill="#555"/>
-  <rect x="{left}" width="{right}" height="20" fill="{color}"/>
-  <rect width="{total}" height="20" fill="url(#b)"/>
-</g>
-<g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
-  <text x="{left_mid}" y="15" fill="#010101" fill-opacity=".3">{label}</text>
-  <text x="{left_mid}" y="14">{label}</text>
-  <text x="{right_mid}" y="15" fill="#010101" fill-opacity=".3">{value}</text>
-  <text x="{right_mid}" y="14">{value}</text>
-</g>
-</svg>
-"""
 
 
 def visible_skill_names(skills_dir: Path) -> set[str]:


### PR DESCRIPTION
Extracts the duplicated `render_badge`/`text_width` from the two badge generators into `tools/_badge_svg.py`, XML-escapes label/value/aria, and replaces the flat 7px/char width with a proportional per-glyph estimate. Centering was already mathematically correct and is unchanged. Fixes the three LOW findings from the SVG-alignment audit (duplication, no escaping, monospace width model). Badges regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)