### PR TITLE
docs: fix Primary control path label overlap in global-architecture diagram

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 276,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "fa1a7691bd4133d8c0909c5a4bb7a25c8dec13482f8672005a4a45f5354787b3",
+  "source_digest_sha256": "985d3d4f6d7dbd8acd20c63135b184fa6b43d8a55871755f60e89a8276586f08",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "fa1a7691bd4133d8c0909c5a4bb7a25c8dec13482f8672005a4a45f5354787b3"
+  "target_digest_sha256": "985d3d4f6d7dbd8acd20c63135b184fa6b43d8a55871755f60e89a8276586f08"
 }

--- a/docs/source/diagrams/agilab_global_architecture.svg
+++ b/docs/source/diagrams/agilab_global_architecture.svg
@@ -138,7 +138,7 @@
 
   <rect width="1460" height="900" fill="url(#background)" rx="42" ry="42" />
 
-  <g id="header" transform="translate(58,58)">
+  <g id="header" transform="translate(58,50)">
     <text class="page-title" x="0" y="0">AGILAB global architecture</text>
     <text class="page-subtitle" x="0" y="34">
       <tspan x="0" dy="0">One app contract across UI, notebooks, CLI, local runs, clusters, evidence, and export.</tspan>
@@ -147,7 +147,7 @@
   </g>
 
   <line class="lane" x1="58" y1="406" x2="1402" y2="406" />
-  <text class="section-label" x="58" y="130">Primary control path</text>
+  <text class="section-label" x="58" y="136">Primary control path</text>
   <text class="section-label" x="58" y="444">Runtime split and shared state</text>
   <text class="section-label" x="58" y="674">Operational guardrails</text>
 


### PR DESCRIPTION
Fixes the one real alignment defect found while reviewing docs SVGs: in `agilab_global_architecture.svg` the "Primary control path" lane label sat only 14px below the two-line page subtitle, so its caps collided with the subtitle's descenders (the other two lane labels have ~38px clearance). Lifts the header 8px and drops the label 6px to open a 28px gap; the tight feedback-pill/lane-line spacing below is untouched. Edited canonical (thales_agilab e9cb4b3) and re-synced the mirror (stamp verified).

`Agilab-Overview.svg` was reviewed too and renders correctly — no geometry change made.

🤖 Generated with [Claude Code](https://claude.com/claude-code)