### PR TITLE
Fix self-extra attestation false failure

### DIFF
--- a/src/agilab/evidence/supply_chain_attestation.py
+++ b/src/agilab/evidence/supply_chain_attestation.py
@@ -15,7 +15,7 @@ from typing import Any, Mapping
 
 SCHEMA = "agilab.supply_chain_attestation.v1"
 CREATED_AT = "2026-04-25T00:00:34Z"
-UPDATED_AT = "2026-05-16T00:00:00Z"
+UPDATED_AT = "2026-07-23T00:00:00Z"
 CORE_PYPROJECTS = {
     "agi-core": Path("src/agilab/core/agi-core/pyproject.toml"),
     "agi-env": Path("src/agilab/core/agi-env/pyproject.toml"),
@@ -246,6 +246,12 @@ def _dependency_name(dependency: str) -> str:
     return parts[0] if parts else ""
 
 
+def _normalized_distribution_name(name: str) -> str:
+    """Return the PEP 503-style name used for dependency identity checks."""
+
+    return re.sub(r"[-_.]+", "-", name.strip()).lower()
+
+
 def _agilab_version_key(version: str) -> tuple[tuple[int, ...], int] | None:
     match = _AGILAB_VERSION_RE.match(version)
     if not match:
@@ -299,7 +305,14 @@ def _internal_dependency_constraint_rows(
     include_optional: bool = False,
 ) -> list[dict[str, Any]]:
     rows = []
+    normalized_expected_versions = {
+        _normalized_distribution_name(name): version
+        for name, version in expected_versions.items()
+    }
     for package_name, metadata in sorted(package_metadata.items()):
+        normalized_package_name = _normalized_distribution_name(
+            str(metadata.get("name") or package_name)
+        )
         dependencies = list(metadata.get("dependencies", []))
         if include_optional:
             dependencies.extend(metadata.get("optional_dependencies", []))
@@ -308,13 +321,20 @@ def _internal_dependency_constraint_rows(
             if parts is None:
                 continue
             dependency_name, operator, version = parts
-            expected_version = expected_versions.get(dependency_name)
+            normalized_dependency_name = _normalized_distribution_name(
+                dependency_name
+            )
+            if normalized_dependency_name == normalized_package_name:
+                continue
+            expected_version = normalized_expected_versions.get(
+                normalized_dependency_name
+            )
             if expected_version is None:
                 continue
             rows.append(
                 {
                     "package": package_name,
-                    "dependency": dependency_name,
+                    "dependency": normalized_dependency_name,
                     "operator": operator,
                     "expected_operator": expected_operator,
                     "pinned_version": version,

--- a/test/test_supply_chain_attestation_report.py
+++ b/test/test_supply_chain_attestation_report.py
@@ -288,6 +288,30 @@ agilab = "bad"
         {"agi-core": "1"},
         expected_operator="==",
     ) == []
+    internal_rows = core._internal_dependency_constraint_rows(
+        {
+            "agilab": {
+                "name": "AGILAB",
+                "dependencies": ["agi_core==1"],
+                "optional_dependencies": ["agilab[local-llm]"],
+            }
+        },
+        {"agilab": "2", "agi-core": "1"},
+        expected_operator="==",
+        include_optional=True,
+    )
+    assert internal_rows == [
+        {
+            "package": "agilab",
+            "dependency": "agi-core",
+            "operator": "==",
+            "expected_operator": "==",
+            "pinned_version": "1",
+            "expected_version": "1",
+            "aligned": True,
+            "specifier": "agi_core==1",
+        }
+    ]
 
 
 def test_supply_chain_attestation_reports_release_graph_and_payload_budget_issues(
@@ -387,6 +411,8 @@ def test_supply_chain_attestation_accepts_partial_umbrella_post_release(
             "name = 'agilab'\n"
             f"version = '{root_version}'\n"
             f"dependencies = ['agi-core=={library_version}', 'agi-gui=={library_version}', 'agi-pages=={library_version}', 'agi-apps=={library_version}']\n"
+            "[project.optional-dependencies]\n"
+            "offline = ['agilab[local-llm]']\n"
         ),
         "src/agilab/core/agi-core/pyproject.toml": (
             "[project]\n"


### PR DESCRIPTION
## Summary

- Normalize distribution names with PEP 503-style rules before evaluating internal dependency identities.
- Exclude same-distribution optional-extra references such as `agilab[local-llm]` from inter-package release-graph pin checks.
- Continue enforcing genuine cross-package pins, including normalized spellings such as `agi_core==…` against `agi-core`.
- Refresh the attestation producer metadata date and add focused regressions.

## Repro

Current `main` coverage run [30008174554](https://github.com/ThalesGroup/agilab/actions/runs/30008174554) failed only in `agi-gui (robots)` after 821 passing tests:

`test_supply_chain_attestation_report_passes_contract` expected `report["status"] == "pass"`, but received `"fail"`.

The failure reproduced locally with:

```bash
uv --preview-features extra-build-dependencies run pytest -q test/test_supply_chain_attestation_report.py::test_supply_chain_attestation_report_passes_contract -vv
```

## Root Cause

The root `offline` optional extra now aliases `agilab[local-llm]`. The attestation parser included optional dependencies in its internal release graph and treated that same-package extra alias as an unpinned dependency from `agilab` to `agilab`. That false mismatch invalidated the aggregate internal-pin signal and all three otherwise-valid partial-release graphs.

## Regression Test

- The helper regression proves normalized self aliases are omitted while a genuine `agi_core==1` dependency remains checked as `agi-core`.
- The partial umbrella post-release fixture now includes `offline = ['agilab[local-llm]']` and must remain validated with zero pin mismatches and aligned core/page/app release graphs.
- The real repository attestation report must return `status=pass`, `run_status=validated`, and 13/13 checks passing.

## Validation

- Supply-chain attestation tests plus KPI contract: 9 passed.
- Dependency-hygiene and security-hygiene tests: 38 passed.
- Generated supply-chain attestation: 13 passed, 0 failed, validated.
- AGILAB maintenance dashboard: pass; only the existing TODO-hotspot warning and isolated-worktree canonical-docs availability warning remain.
- Focused Ruff and `git diff --check`: passed.
- Full hosted coverage is intentionally left to this PR's GitHub workflow; the exact failing contract and its adjacent evidence consumers were validated locally first.

## Review Evidence

- Public GitHub-maintenance Codex sub-agent (exact model/version unavailable): read-only workflow-log, branch, and root-cause audit; proposed the same-package exclusion and regression scope; no files edited.
- Private GitHub-maintenance Codex sub-agent (exact model/version unavailable): read-only sibling-repository hygiene audit only; no code review and no files edited.

## Agent Metadata

- Tokki version: 1.0.32
- Agent/runtime: Codex; exact runtime version unavailable
- Model: GPT-5; deployment identifier unavailable
- Reasoning effort: unavailable
- `/fast` mode: not used