### PR TITLE
fix: refresh coverage badge geometry

### DIFF
--- a/badges/coverage-agi-cluster.svg
+++ b/badges/coverage-agi-cluster.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="181" height="20" role="img" aria-label="agi-cluster coverage: 92%">
+<svg xmlns="http://www.w3.org/2000/svg" width="166" height="20" role="img" aria-label="agi-cluster coverage: 92%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -6,17 +6,17 @@
   <stop offset="1" stop-opacity=".5"/>
 </linearGradient>
 <mask id="a">
-  <rect width="181" height="20" rx="3" fill="#fff"/>
+  <rect width="166" height="20" rx="3" fill="#fff"/>
 </mask>
 <g mask="url(#a)">
-  <rect width="150" height="20" fill="#555"/>
-  <rect x="150" width="31" height="20" fill="#2ea44f"/>
-  <rect width="181" height="20" fill="url(#b)"/>
+  <rect width="134" height="20" fill="#555"/>
+  <rect x="134" width="32" height="20" fill="#2ea44f"/>
+  <rect width="166" height="20" fill="url(#b)"/>
 </g>
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
-  <text x="75.0" y="15" fill="#010101" fill-opacity=".3">agi-cluster coverage</text>
-  <text x="75.0" y="14">agi-cluster coverage</text>
-  <text x="165.5" y="15" fill="#010101" fill-opacity=".3">92%</text>
-  <text x="165.5" y="14">92%</text>
+  <text x="67.0" y="15" fill="#010101" fill-opacity=".3">agi-cluster coverage</text>
+  <text x="67.0" y="14">agi-cluster coverage</text>
+  <text x="150.0" y="15" fill="#010101" fill-opacity=".3">92%</text>
+  <text x="150.0" y="14">92%</text>
 </g>
 </svg>

--- a/badges/coverage-agi-core.svg
+++ b/badges/coverage-agi-core.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="160" height="20" role="img" aria-label="agi-core coverage: 92%">
+<svg xmlns="http://www.w3.org/2000/svg" width="150" height="20" role="img" aria-label="agi-core coverage: 92%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -6,17 +6,17 @@
   <stop offset="1" stop-opacity=".5"/>
 </linearGradient>
 <mask id="a">
-  <rect width="160" height="20" rx="3" fill="#fff"/>
+  <rect width="150" height="20" rx="3" fill="#fff"/>
 </mask>
 <g mask="url(#a)">
-  <rect width="129" height="20" fill="#555"/>
-  <rect x="129" width="31" height="20" fill="#2ea44f"/>
-  <rect width="160" height="20" fill="url(#b)"/>
+  <rect width="118" height="20" fill="#555"/>
+  <rect x="118" width="32" height="20" fill="#2ea44f"/>
+  <rect width="150" height="20" fill="url(#b)"/>
 </g>
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
-  <text x="64.5" y="15" fill="#010101" fill-opacity=".3">agi-core coverage</text>
-  <text x="64.5" y="14">agi-core coverage</text>
-  <text x="144.5" y="15" fill="#010101" fill-opacity=".3">92%</text>
-  <text x="144.5" y="14">92%</text>
+  <text x="59.0" y="15" fill="#010101" fill-opacity=".3">agi-core coverage</text>
+  <text x="59.0" y="14">agi-core coverage</text>
+  <text x="134.0" y="15" fill="#010101" fill-opacity=".3">92%</text>
+  <text x="134.0" y="14">92%</text>
 </g>
 </svg>

--- a/badges/coverage-agi-env.svg
+++ b/badges/coverage-agi-env.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="153" height="20" role="img" aria-label="agi-env coverage: 94%">
+<svg xmlns="http://www.w3.org/2000/svg" width="143" height="20" role="img" aria-label="agi-env coverage: 94%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -6,17 +6,17 @@
   <stop offset="1" stop-opacity=".5"/>
 </linearGradient>
 <mask id="a">
-  <rect width="153" height="20" rx="3" fill="#fff"/>
+  <rect width="143" height="20" rx="3" fill="#fff"/>
 </mask>
 <g mask="url(#a)">
-  <rect width="122" height="20" fill="#555"/>
-  <rect x="122" width="31" height="20" fill="#2ea44f"/>
-  <rect width="153" height="20" fill="url(#b)"/>
+  <rect width="111" height="20" fill="#555"/>
+  <rect x="111" width="32" height="20" fill="#2ea44f"/>
+  <rect width="143" height="20" fill="url(#b)"/>
 </g>
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
-  <text x="61.0" y="15" fill="#010101" fill-opacity=".3">agi-env coverage</text>
-  <text x="61.0" y="14">agi-env coverage</text>
-  <text x="137.5" y="15" fill="#010101" fill-opacity=".3">94%</text>
-  <text x="137.5" y="14">94%</text>
+  <text x="55.5" y="15" fill="#010101" fill-opacity=".3">agi-env coverage</text>
+  <text x="55.5" y="14">agi-env coverage</text>
+  <text x="127.0" y="15" fill="#010101" fill-opacity=".3">94%</text>
+  <text x="127.0" y="14">94%</text>
 </g>
 </svg>

--- a/badges/coverage-agi-gui.svg
+++ b/badges/coverage-agi-gui.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="153" height="20" role="img" aria-label="agi-gui coverage: 95%">
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="20" role="img" aria-label="agi-gui coverage: 95%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -6,17 +6,17 @@
   <stop offset="1" stop-opacity=".5"/>
 </linearGradient>
 <mask id="a">
-  <rect width="153" height="20" rx="3" fill="#fff"/>
+  <rect width="140" height="20" rx="3" fill="#fff"/>
 </mask>
 <g mask="url(#a)">
-  <rect width="122" height="20" fill="#555"/>
-  <rect x="122" width="31" height="20" fill="#2ea44f"/>
-  <rect width="153" height="20" fill="url(#b)"/>
+  <rect width="108" height="20" fill="#555"/>
+  <rect x="108" width="32" height="20" fill="#2ea44f"/>
+  <rect width="140" height="20" fill="url(#b)"/>
 </g>
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
-  <text x="61.0" y="15" fill="#010101" fill-opacity=".3">agi-gui coverage</text>
-  <text x="61.0" y="14">agi-gui coverage</text>
-  <text x="137.5" y="15" fill="#010101" fill-opacity=".3">95%</text>
-  <text x="137.5" y="14">95%</text>
+  <text x="54.0" y="15" fill="#010101" fill-opacity=".3">agi-gui coverage</text>
+  <text x="54.0" y="14">agi-gui coverage</text>
+  <text x="124.0" y="15" fill="#010101" fill-opacity=".3">95%</text>
+  <text x="124.0" y="14">95%</text>
 </g>
 </svg>

--- a/badges/coverage-agi-node.svg
+++ b/badges/coverage-agi-node.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="160" height="20" role="img" aria-label="agi-node coverage: 92%">
+<svg xmlns="http://www.w3.org/2000/svg" width="150" height="20" role="img" aria-label="agi-node coverage: 92%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -6,17 +6,17 @@
   <stop offset="1" stop-opacity=".5"/>
 </linearGradient>
 <mask id="a">
-  <rect width="160" height="20" rx="3" fill="#fff"/>
+  <rect width="150" height="20" rx="3" fill="#fff"/>
 </mask>
 <g mask="url(#a)">
-  <rect width="129" height="20" fill="#555"/>
-  <rect x="129" width="31" height="20" fill="#2ea44f"/>
-  <rect width="160" height="20" fill="url(#b)"/>
+  <rect width="118" height="20" fill="#555"/>
+  <rect x="118" width="32" height="20" fill="#2ea44f"/>
+  <rect width="150" height="20" fill="url(#b)"/>
 </g>
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
-  <text x="64.5" y="15" fill="#010101" fill-opacity=".3">agi-node coverage</text>
-  <text x="64.5" y="14">agi-node coverage</text>
-  <text x="144.5" y="15" fill="#010101" fill-opacity=".3">92%</text>
-  <text x="144.5" y="14">92%</text>
+  <text x="59.0" y="15" fill="#010101" fill-opacity=".3">agi-node coverage</text>
+  <text x="59.0" y="14">agi-node coverage</text>
+  <text x="134.0" y="15" fill="#010101" fill-opacity=".3">92%</text>
+  <text x="134.0" y="14">92%</text>
 </g>
 </svg>

--- a/badges/coverage-agi-web.svg
+++ b/badges/coverage-agi-web.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="160" height="20" role="img" aria-label="agi-web coverage: 100%">
+<svg xmlns="http://www.w3.org/2000/svg" width="153" height="20" role="img" aria-label="agi-web coverage: 100%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -6,17 +6,17 @@
   <stop offset="1" stop-opacity=".5"/>
 </linearGradient>
 <mask id="a">
-  <rect width="160" height="20" rx="3" fill="#fff"/>
+  <rect width="153" height="20" rx="3" fill="#fff"/>
 </mask>
 <g mask="url(#a)">
-  <rect width="122" height="20" fill="#555"/>
-  <rect x="122" width="38" height="20" fill="#2ea44f"/>
-  <rect width="160" height="20" fill="url(#b)"/>
+  <rect width="114" height="20" fill="#555"/>
+  <rect x="114" width="39" height="20" fill="#2ea44f"/>
+  <rect width="153" height="20" fill="url(#b)"/>
 </g>
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
-  <text x="61.0" y="15" fill="#010101" fill-opacity=".3">agi-web coverage</text>
-  <text x="61.0" y="14">agi-web coverage</text>
-  <text x="141.0" y="15" fill="#010101" fill-opacity=".3">100%</text>
-  <text x="141.0" y="14">100%</text>
+  <text x="57.0" y="15" fill="#010101" fill-opacity=".3">agi-web coverage</text>
+  <text x="57.0" y="14">agi-web coverage</text>
+  <text x="133.5" y="15" fill="#010101" fill-opacity=".3">100%</text>
+  <text x="133.5" y="14">100%</text>
 </g>
 </svg>

--- a/badges/coverage-agilab.svg
+++ b/badges/coverage-agilab.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="146" height="20" role="img" aria-label="agilab coverage: 95%">
+<svg xmlns="http://www.w3.org/2000/svg" width="134" height="20" role="img" aria-label="agilab coverage: 95%">
 <linearGradient id="b" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-opacity=".1"/>
@@ -6,17 +6,17 @@
   <stop offset="1" stop-opacity=".5"/>
 </linearGradient>
 <mask id="a">
-  <rect width="146" height="20" rx="3" fill="#fff"/>
+  <rect width="134" height="20" rx="3" fill="#fff"/>
 </mask>
 <g mask="url(#a)">
-  <rect width="115" height="20" fill="#555"/>
-  <rect x="115" width="31" height="20" fill="#2ea44f"/>
-  <rect width="146" height="20" fill="url(#b)"/>
+  <rect width="102" height="20" fill="#555"/>
+  <rect x="102" width="32" height="20" fill="#2ea44f"/>
+  <rect width="134" height="20" fill="url(#b)"/>
 </g>
 <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
-  <text x="57.5" y="15" fill="#010101" fill-opacity=".3">agilab coverage</text>
-  <text x="57.5" y="14">agilab coverage</text>
-  <text x="130.5" y="15" fill="#010101" fill-opacity=".3">95%</text>
-  <text x="130.5" y="14">95%</text>
+  <text x="51.0" y="15" fill="#010101" fill-opacity=".3">agilab coverage</text>
+  <text x="51.0" y="14">agilab coverage</text>
+  <text x="118.0" y="15" fill="#010101" fill-opacity=".3">95%</text>
+  <text x="118.0" y="14">95%</text>
 </g>
 </svg>


### PR DESCRIPTION
## Summary

- regenerate all seven coverage badges with the current shared SVG renderer
- preserve the percentages produced by coverage run 30013079386
- clear the final repository-wide badge drift gate

## Repro

Coverage run 30013079386 completed every component and combine job, then failed in `Verify committed badges are up to date`. The generated SVGs differed only in renderer width and text-position geometry.

## Root Cause

The shared badge renderer changed in PR #853, but the committed static coverage SVGs were not regenerated with that renderer.

## Regression Test

- 65 focused badge generator, badge guard, and coverage workflow tests passed
- the coverage badge guard passed for all seven badges using the exact XML artifacts from run 30013079386
- the `badges` workflow-parity profile passed, including its drift guard

## Validation

- exact source artifacts: coverage run 30013079386, all five component XML artifacts
- `./dev scope --staged`: badges-only scope accepted
- staged impact report: medium, badge artifacts only
- PR checks passed: Python 3.13 and 3.14 compatibility, clean public install on Linux, macOS, and Windows, local-only policy, and GitGuardian
- public demo smoke: GitHub skipped by path condition, not applicable to badge-only changes
- full local coverage suite: not applicable because current CI coverage artifacts are the source of truth

## Review Evidence

- Codex self-review: no findings
- public and private GitHub maintenance audit subagents used inherited GPT-5 for read-only state checks; they did not edit files and did not perform code review

## Agent Metadata

- Tokki version: 1.0.32
- Agent/runtime: Codex CLI 0.145.0
- Model: GPT-5
- Reasoning effort: unknown
- `/fast`: not used