### PR TITLE
view_routing_model_comparison: aggregate satisfaction heatmap cells

### DIFF
--- a/src/agilab/apps-pages/view_routing_model_comparison/src/view_routing_model_comparison/view_routing_model_comparison.py
+++ b/src/agilab/apps-pages/view_routing_model_comparison/src/view_routing_model_comparison/view_routing_model_comparison.py
@@ -599,6 +599,17 @@ def filter_active_demands(alloc_df: pd.DataFrame) -> pd.DataFrame:
     return filtered
 
 
+def _sample_tick_positions(length: int, max_ticks: int = 24) -> list[int]:
+    if length <= 0:
+        return []
+    if length <= max_ticks:
+        return list(range(length))
+    positions = np.unique(
+        np.round(np.linspace(0, length - 1, max_ticks)).astype(int)
+    )
+    return positions.tolist()
+
+
 def add_latency_targets(alloc_df: pd.DataFrame) -> pd.DataFrame:
     if alloc_df.empty:
         return alloc_df
@@ -888,7 +899,7 @@ def build_demand_satisfaction_heatmap_figure(
     alloc_df: pd.DataFrame,
     models: list[str],
 ) -> go.Figure:
-    """Build raw active-demand satisfaction heatmaps over time for each model."""
+    """Build aggregated active-demand satisfaction heatmaps over time."""
 
     plot_df = alloc_df.copy()
     if plot_df.empty:
@@ -907,25 +918,38 @@ def build_demand_satisfaction_heatmap_figure(
             + plot_df["destination_label"].astype(str)
         )
 
-    plot_df = plot_df.sort_values(
-        [
-            "model",
-            "time_index",
-            "demand",
-            "requested_mbps",
-            "source_label",
-            "destination_label",
-        ],
-        ascending=[True, True, True, False, True, True],
-        kind="stable",
-    ).copy()
     available_models = set(plot_df["model"])
     visible_models = [model for model in models if model in available_models]
     if plot_df.empty or not visible_models:
         return go.Figure()
 
+    plot_df["time_index"] = pd.to_numeric(plot_df["time_index"], errors="coerce")
+    plot_df["requested_mbps"] = pd.to_numeric(
+        plot_df["requested_mbps"], errors="coerce"
+    )
+    plot_df["delivered_mbps"] = pd.to_numeric(
+        plot_df["delivered_mbps"], errors="coerce"
+    )
+    plot_df = plot_df.dropna(subset=["time_index"]).copy()
+    if plot_df.empty:
+        return go.Figure()
+    plot_df["time_index"] = plot_df["time_index"].astype(int)
+
+    cell_kpis = (
+        plot_df.groupby(["model", "demand", "time_index"], as_index=False, observed=False)
+        .agg(
+            requested_mbps=("requested_mbps", "sum"),
+            delivered_mbps=("delivered_mbps", "sum"),
+            raw_rows=("demand", "size"),
+        )
+    )
+    requested_total = cell_kpis["requested_mbps"].replace(0.0, np.nan)
+    cell_kpis["satisfaction_ratio"] = (
+        cell_kpis["delivered_mbps"] / requested_total
+    ).clip(lower=0.0, upper=1.0)
+
     demand_order_df = (
-        plot_df.groupby("demand", as_index=False, observed=False)
+        cell_kpis.groupby("demand", as_index=False, observed=False)
         .agg(
             total_requested_mbps=("requested_mbps", "sum"),
             mean_satisfaction_ratio=("satisfaction_ratio", "mean"),
@@ -936,95 +960,109 @@ def build_demand_satisfaction_heatmap_figure(
         )
     )
     demand_order = demand_order_df["demand"].astype(str).tolist()
+    time_order = (
+        plot_df["time_index"].dropna().astype(int).sort_values().unique().tolist()
+    )
+    if not demand_order or not time_order:
+        return go.Figure()
 
     fig = make_subplots(
         rows=len(visible_models),
         cols=1,
         shared_xaxes=True,
         subplot_titles=tuple(
-            f"{model}: raw active demand satisfaction over time"
+            f"{model}: aggregated active-demand satisfaction over time"
             for model in visible_models
         ),
         vertical_spacing=0.08 if len(visible_models) > 1 else 0.02,
     )
 
-    demand_positions = {
-        demand: position for position, demand in enumerate(demand_order)
-    }
+    time_tick_positions = _sample_tick_positions(len(time_order), max_ticks=24)
+    time_tick_values = [time_order[position] for position in time_tick_positions]
+    y_tick_positions = _sample_tick_positions(len(demand_order), max_ticks=24)
+    y_tick_text = [demand_order[position] for position in y_tick_positions]
 
     for row, model in enumerate(visible_models, start=1):
-        model_rows = plot_df[plot_df["model"] == model].copy()
+        model_rows = cell_kpis[cell_kpis["model"] == model].copy()
         if model_rows.empty:
             continue
-        model_rows["demand_position"] = model_rows["demand"].map(demand_positions)
-        model_rows = model_rows.dropna(subset=["demand_position"]).copy()
-        if model_rows.empty:
-            continue
-        model_rows["demand_position"] = model_rows["demand_position"].astype(float)
-        cell_counts = model_rows.groupby(
-            ["demand", "time_index"], sort=False, dropna=False
-        )["demand"].transform("size")
-        cell_occurrence = model_rows.groupby(
-            ["demand", "time_index"], sort=False, dropna=False
-        ).cumcount()
-        stack_step = 0.26
-        model_rows["y_position"] = model_rows["demand_position"] + (
-            cell_occurrence - (cell_counts - 1) / 2.0
-        ) * stack_step
-        model_rows["cell_occurrence"] = cell_occurrence + 1
-        model_rows["cell_count"] = cell_counts
-        customdata = np.column_stack(
-            [
-                model_rows["satisfaction_ratio"].to_numpy(dtype=float),
-                model_rows["requested_mbps"].to_numpy(dtype=float),
-                model_rows["source_label"].astype(str).to_numpy(),
-                model_rows["destination_label"].astype(str).to_numpy(),
-                model_rows["cell_occurrence"].to_numpy(dtype=float),
-                model_rows["cell_count"].to_numpy(dtype=float),
-            ]
+        subplot_axis_name = "yaxis" if row == 1 else f"yaxis{row}"
+        subplot_domain = fig.layout[subplot_axis_name].domain
+        colorbar_center = (subplot_domain[0] + subplot_domain[1]) / 2.0
+        colorbar_len = subplot_domain[1] - subplot_domain[0]
+        satisfaction_matrix = (
+            model_rows.pivot(
+                index="demand",
+                columns="time_index",
+                values="satisfaction_ratio",
+            )
+            .reindex(index=demand_order, columns=time_order)
         )
+        requested_matrix = (
+            model_rows.pivot(
+                index="demand",
+                columns="time_index",
+                values="requested_mbps",
+            )
+            .reindex(index=demand_order, columns=time_order)
+        )
+        delivered_matrix = (
+            model_rows.pivot(
+                index="demand",
+                columns="time_index",
+                values="delivered_mbps",
+            )
+            .reindex(index=demand_order, columns=time_order)
+        )
+        raw_rows_matrix = (
+            model_rows.pivot(index="demand", columns="time_index", values="raw_rows")
+            .reindex(index=demand_order, columns=time_order)
+        )
+        hover_rows = np.empty((len(demand_order), len(time_order), 5), dtype=object)
+        hover_rows[..., 0] = np.asarray(demand_order, dtype=object)[:, None]
+        hover_rows[..., 1] = satisfaction_matrix.fillna(np.nan).to_numpy(dtype=float)
+        hover_rows[..., 2] = raw_rows_matrix.fillna(0.0).to_numpy(dtype=float)
+        hover_rows[..., 3] = requested_matrix.fillna(0.0).to_numpy(dtype=float)
+        hover_rows[..., 4] = delivered_matrix.fillna(0.0).to_numpy(dtype=float)
         fig.add_trace(
-            go.Scattergl(
-                x=model_rows["time_index"],
-                y=model_rows["y_position"],
-                mode="markers",
+            go.Heatmap(
+                z=satisfaction_matrix.to_numpy(dtype=float),
+                x=time_order,
+                y=list(range(len(demand_order))),
+                xgap=1,
+                ygap=1,
+                colorscale="Viridis",
+                zmin=0.0,
+                zmax=1.0,
+                hoverongaps=False,
+                zsmooth=False,
                 name=model,
-                showlegend=False,
-                customdata=customdata,
-                marker=dict(
-                    symbol="square",
-                    size=5,
-                    color=model_rows["satisfaction_ratio"],
-                    colorscale="Viridis",
-                    cmin=0.0,
-                    cmax=1.0,
-                    showscale=True,
-                    colorbar=dict(title="Satisfaction ratio"),
-                    line=dict(color="#f8fafc", width=0.5),
+                customdata=hover_rows,
+                showscale=True,
+                colorbar=dict(
+                    title="Satisfaction ratio",
+                    y=colorbar_center,
+                    len=colorbar_len,
+                    yanchor="middle",
+                    x=1.02,
+                    thickness=14,
+                    thicknessmode="pixels",
                 ),
                 hovertemplate=(
                     "Time index %{x}<br>"
-                    "Demand %{customdata[2]} -> %{customdata[3]}<br>"
-                    "Raw row %{customdata[4]:.0f} of %{customdata[5]:.0f}<br>"
-                    "Satisfaction %{customdata[0]:.0%}<br>"
-                    "Requested %{customdata[1]:.1f} Mbps<extra>"
+                    "Demand %{customdata[0]}<br>"
+                    "Aggregated satisfaction %{customdata[1]:.0%}<br>"
+                    "Raw rows %{customdata[2]:.0f}<br>"
+                    "Requested %{customdata[3]:.1f} Mbps<br>"
+                    "Delivered %{customdata[4]:.1f} Mbps<extra>"
                     f"{model}</extra>"
                 ),
             ),
             row=row,
             col=1,
         )
-        subplot_axis_name = "yaxis" if row == 1 else f"yaxis{row}"
-        subplot_domain = fig.layout[subplot_axis_name].domain
-        colorbar = fig.data[-1].marker.colorbar
-        colorbar.y = (subplot_domain[0] + subplot_domain[1]) / 2.0
-        colorbar.len = subplot_domain[1] - subplot_domain[0]
-        colorbar.yanchor = "middle"
-        colorbar.x = 1.02
-        colorbar.thickness = 14
-        colorbar.thicknessmode = "pixels"
 
-    panel_height = max(420, 24 * len(demand_order) + 160)
+    panel_height = max(420, min(760, 12 * len(demand_order) + 160))
     fig.update_layout(
         height=panel_height * len(visible_models),
         margin=dict(l=52, r=96, t=88, b=56),
@@ -1049,8 +1087,8 @@ def build_demand_satisfaction_heatmap_figure(
             col=1,
             showticklabels=True,
             tickmode="array",
-            tickvals=list(range(len(demand_order))),
-            ticktext=demand_order,
+            tickvals=y_tick_positions,
+            ticktext=y_tick_text,
             range=[-0.6, len(demand_order) - 0.4],
             showgrid=True,
             gridcolor="rgba(148, 163, 184, 0.30)",
@@ -1062,6 +1100,14 @@ def build_demand_satisfaction_heatmap_figure(
             row=row,
             col=1,
             showticklabels=True,
+            tickmode="array",
+            tickvals=time_tick_values,
+            ticktext=[str(value) for value in time_tick_values],
+            range=[min(time_order) - 0.6, max(time_order) + 0.6],
+            showgrid=True,
+            gridcolor="rgba(148, 163, 184, 0.35)",
+            gridwidth=1.2,
+            zeroline=False,
         )
     return fig
 
@@ -1328,39 +1374,6 @@ def build_demand_matrix_figure(
             )
     return fig
 
-
-def build_failure_table(alloc_df: pd.DataFrame) -> pd.DataFrame:
-    table = alloc_df.copy()
-    table["latency_over_target_ms"] = (
-        table["latency_ms"] - table["latency_target_used_ms"]
-    )
-    failures = table[
-        (table["outcome"] != "fulfilled") | (table["latency_violation"])
-    ].copy()
-    columns = [
-        "model",
-        "time_index",
-        "source_label",
-        "destination_label",
-        "outcome",
-        "requested_mbps",
-        "delivered_mbps",
-        "satisfaction_ratio",
-        "latency_ms",
-        "latency_target_used_ms",
-        "latency_over_target_ms",
-        "hop_count",
-        "bearers",
-        "path",
-    ]
-    if failures.empty:
-        return failures[columns]
-    return failures.sort_values(
-        ["latency_violation", "satisfaction_ratio", "latency_over_target_ms"],
-        ascending=[False, True, False],
-    )[columns]
-
-
 def _format_summary(summary_df: pd.DataFrame) -> pd.DataFrame:
     return summary_df.set_index("model").T
 
@@ -1402,14 +1415,6 @@ def main() -> None:
         options=MODEL_ORDER,
         default=available_models or MODEL_ORDER,
         key=f"{PAGE_KEY}_selected_models",
-    )
-    limit_failures = st.sidebar.number_input(
-        "Failure rows",
-        min_value=10,
-        max_value=500,
-        value=100,
-        step=10,
-        key=f"{PAGE_KEY}_failure_rows",
     )
 
     missing_files = [
@@ -1458,7 +1463,6 @@ def main() -> None:
         timing_tab,
         demand_tab,
         path_tab,
-        failures_tab,
     ) = st.tabs(
         [
             "Summary",
@@ -1467,7 +1471,6 @@ def main() -> None:
             "Decision Timing",
             "Demand Matrix",
             "Paths",
-            "Failures",
         ]
     )
     with summary_tab:
@@ -1502,8 +1505,9 @@ def main() -> None:
         st.plotly_chart(build_time_figure(alloc_df, models), width="stretch")
         st.subheader("Demand Satisfaction Over Time")
         st.caption(
-            "Only active rows are shown. Repeated source/destination/time cells "
-            "are lightly stacked so the raw demand rows remain visible."
+            "Only active rows are shown. Source/destination/time cells are "
+            "aggregated into one heatmap cell so large runs stay readable, and "
+            "hover text still shows how many raw rows contributed."
         )
         st.plotly_chart(
             build_demand_satisfaction_heatmap_figure(alloc_df, models),
@@ -1563,10 +1567,6 @@ def main() -> None:
 
     with path_tab:
         st.plotly_chart(build_path_figure(alloc_df, models), width="stretch")
-
-    with failures_tab:
-        failures = build_failure_table(alloc_df)
-        st.dataframe(failures.head(int(limit_failures)), width="stretch")
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/test/test_view_routing_model_comparison.py
+++ b/test/test_view_routing_model_comparison.py
@@ -63,11 +63,9 @@ class _Sidebar:
         *,
         pipeline_text: str | None = None,
         selected_models: list[str] | None = None,
-        failure_rows: int = 100,
     ) -> None:
         self.pipeline_text = pipeline_text
         self.selected_models = selected_models
-        self.failure_rows = failure_rows
 
     def text_input(self, _label: str, *, value: str, key: str) -> str:
         return value if self.pipeline_text is None else self.pipeline_text
@@ -81,9 +79,6 @@ class _Sidebar:
         key: str,
     ) -> list[str]:
         return default if self.selected_models is None else self.selected_models
-
-    def number_input(self, *args: object, **kwargs: object) -> int:
-        return self.failure_rows
 
 
 class _StreamlitStub:
@@ -447,7 +442,6 @@ def test_routing_model_comparison_loads_and_summarizes_allocations(
     alloc_df = module.add_latency_targets(alloc_df)
     summary = module.build_summary(alloc_df)
     demand_matrix = module.build_demand_matrix_data(alloc_df)
-    failures = module.build_failure_table(alloc_df)
 
     assert set(alloc_df["model"]) == {"ILP", "PPO-GNN"}
     assert alloc_df["outcome"].tolist().count("fulfilled") == 1
@@ -462,8 +456,6 @@ def test_routing_model_comparison_loads_and_summarizes_allocations(
     assert demand_by_pair.loc[("ILP", "C", "D"), "unmet_bandwidth_ratio"] == 1.0
     assert demand_by_pair.loc[("ILP", "C", "D"), "unrouted_rate"] == 1.0
     assert demand_by_pair.loc[("PPO-GNN", "A", "B"), "mean_latency_ms"] == 45.0
-    assert len(failures) == 2
-    assert "latency_over_target_ms" in failures.columns
 
 
 def test_routing_model_comparison_filters_to_active_demand_schedule(
@@ -523,7 +515,6 @@ def test_routing_model_comparison_filters_to_active_demand_schedule(
     )
 
     alloc_df = module.load_allocations(module.available_file_signatures(base))
-    failures = module.build_failure_table(module.add_latency_targets(alloc_df.copy()))
 
     assert len(alloc_df) == 4
     assert set(alloc_df["model"]) == {"ILP", "PPO-GNN"}
@@ -534,8 +525,6 @@ def test_routing_model_comparison_filters_to_active_demand_schedule(
     }
     assert alloc_df["requested_mbps"].sum() == 55.0
     assert alloc_df.loc[alloc_df["source_label"] == "active-source", "active"].all()
-    assert "active-unrouted-source" in set(failures["source_label"])
-    assert "inactive-source" not in set(failures["source_label"])
 
 
 def test_routing_model_comparison_retains_legacy_rows_without_active_evidence(
@@ -741,15 +730,22 @@ def test_routing_model_comparison_figures_handle_empty_and_visible_models() -> N
         alloc_df, models
     )
     assert len(satisfaction_figure.data) == 2
-    assert satisfaction_figure.data[0].mode == "markers"
-    assert satisfaction_figure.data[0].marker.symbol == "square"
-    assert satisfaction_figure.data[0].marker.size == 5
-    assert satisfaction_figure.data[0].marker.cmin == 0.0
-    assert satisfaction_figure.data[0].marker.cmax == 1.0
-    assert satisfaction_figure.data[0].marker.showscale is True
-    assert satisfaction_figure.data[0].marker.line.width == 0.5
-    assert satisfaction_figure.data[1].marker.showscale is True
-    assert satisfaction_figure.data[1].marker.colorbar.title.text == "Satisfaction ratio"
+    assert satisfaction_figure.data[0].type == "heatmap"
+    assert satisfaction_figure.data[0].xgap == 1
+    assert satisfaction_figure.data[0].ygap == 1
+    assert satisfaction_figure.data[0].showscale is True
+    assert satisfaction_figure.data[1].showscale is True
+    assert float(satisfaction_figure.data[0].z[0][0]) == pytest.approx(1.0, rel=1e-6)
+    assert float(satisfaction_figure.data[1].z[0][0]) == pytest.approx(0.5, rel=1e-6)
+    assert float(satisfaction_figure.data[0].customdata[0][0][1]) == pytest.approx(
+        1.0, rel=1e-6
+    )
+    assert float(satisfaction_figure.data[1].customdata[0][0][1]) == pytest.approx(
+        0.5, rel=1e-6
+    )
+    assert satisfaction_figure.data[0].colorbar.title.text == "Satisfaction ratio"
+    assert satisfaction_figure.data[1].colorbar.title.text == "Satisfaction ratio"
+    assert satisfaction_figure.data[0].colorbar.y != satisfaction_figure.data[1].colorbar.y
     assert satisfaction_figure.layout.height == 840
     assert satisfaction_figure.layout.yaxis.tickmode == "array"
     assert satisfaction_figure.layout.yaxis.showticklabels is True
@@ -759,8 +755,8 @@ def test_routing_model_comparison_figures_handle_empty_and_visible_models() -> N
     assert [
         annotation.text for annotation in satisfaction_figure.layout.annotations
     ] == [
-        "ILP: raw active demand satisfaction over time",
-        "PPO-GNN: raw active demand satisfaction over time",
+        "ILP: aggregated active-demand satisfaction over time",
+        "PPO-GNN: aggregated active-demand satisfaction over time",
     ]
     assert satisfaction_figure.layout.xaxis.showgrid is True
     assert satisfaction_figure.layout.xaxis.title.text == "Time index"
@@ -784,6 +780,62 @@ def test_routing_model_comparison_figures_handle_empty_and_visible_models() -> N
     assert module._format_summary(summary).columns.tolist() == models
     assert module.build_demand_matrix_data(pd.DataFrame()).empty
     assert len(module.build_demand_matrix_figure(pd.DataFrame(), models).data) == 0
+
+
+def test_routing_model_comparison_heatmap_aggregates_duplicate_cells_and_caps_height() -> None:
+    module = _load_module()
+    rows: list[dict[str, object]] = []
+    for model, first_delivered, second_delivered in (
+        ("ILP", 10.0, 15.0),
+        ("PPO-GNN", 8.0, 12.0),
+    ):
+        for demand_index in range(60):
+            source_label = f"source-{demand_index}"
+            destination_label = f"destination-{demand_index}"
+            rows.extend(
+                [
+                    {
+                        "model": model,
+                        "time_index": 0,
+                        "source_label": source_label,
+                        "destination_label": destination_label,
+                        "requested_mbps": 10.0,
+                        "delivered_mbps": first_delivered,
+                        "active": True,
+                    },
+                    {
+                        "model": model,
+                        "time_index": 0,
+                        "source_label": source_label,
+                        "destination_label": destination_label,
+                        "requested_mbps": 30.0,
+                        "delivered_mbps": second_delivered,
+                        "active": True,
+                    },
+                ]
+            )
+
+    fig = module.build_demand_satisfaction_heatmap_figure(
+        pd.DataFrame(rows),
+        ["ILP", "PPO-GNN"],
+    )
+
+    assert len(fig.data) == 2
+    assert fig.data[0].type == "heatmap"
+    assert fig.data[0].xgap == 1
+    assert fig.data[0].ygap == 1
+    assert fig.data[0].showscale is True
+    assert fig.data[1].showscale is True
+    assert fig.layout.height == 1520
+    assert len(fig.layout.yaxis.tickvals) <= 24
+    assert float(fig.data[0].z[0][0]) == pytest.approx(0.625, rel=1e-6)
+    assert float(fig.data[0].customdata[0][0][1]) == pytest.approx(0.625, rel=1e-6)
+    assert fig.data[0].customdata[0][0][2] == 2.0
+    assert fig.data[0].customdata[0][0][3] == 40.0
+    assert fig.data[0].customdata[0][0][4] == 25.0
+    assert fig.data[0].colorbar.title.text == "Satisfaction ratio"
+    assert fig.data[1].colorbar.title.text == "Satisfaction ratio"
+    assert fig.data[0].colorbar.y != fig.data[1].colorbar.y
 
 
 def test_demand_matrix_caps_delivery_and_preserves_full_node_identity() -> None:
@@ -847,29 +899,6 @@ def test_routing_model_comparison_empty_helpers_and_metrics(monkeypatch) -> None
     assert module.add_latency_targets(empty) is empty
     empty_allocations = pd.DataFrame(columns=["model"])
     assert module.build_summary(empty_allocations).empty
-    failures = module.build_failure_table(
-        pd.DataFrame(
-            [
-                {
-                    "model": "ILP",
-                    "time_index": 0,
-                    "source_label": "A",
-                    "destination_label": "B",
-                    "outcome": "fulfilled",
-                    "requested_mbps": 1.0,
-                    "delivered_mbps": 1.0,
-                    "satisfaction_ratio": 1.0,
-                    "latency_ms": 10.0,
-                    "latency_target_used_ms": 20.0,
-                    "latency_violation": False,
-                    "hop_count": 1,
-                    "bearers": "SAT",
-                    "path": "A -> B",
-                }
-            ]
-        )
-    )
-    assert failures.empty
 
     streamlit = _StreamlitStub()
     monkeypatch.setattr(module, "st", streamlit)


### PR DESCRIPTION
## Summary
Aggregate demand/time cells in the satisfaction-over-time panel into real heatmap cells, cap tick density for large runs, and remove the now-redundant Failures tab.

## Repro
Open the routing model comparison page on a large allocation export. Before this change, repeated demand/time rows rendered as stacked squares and the panel became unreadable. The Failures tab also duplicated information already available elsewhere.

## Root Cause
The page rendered raw rows directly with scatter markers, so multiple rows for the same demand/time pair were stacked instead of aggregated. That made the visualization noisy and hard to scale. The separate failures table added a second output path without improving the comparison view.

## Regression Test
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_view_routing_model_comparison.py`
- `uv --preview-features extra-build-dependencies run python tools/impact_validate.py --staged`

## Validation
- `uv --preview-features extra-build-dependencies run pytest -q -o addopts='' test/test_view_routing_model_comparison.py` passed.
- `uv --preview-features extra-build-dependencies run python tools/workflow_parity.py --profile agi-gui` failed in `test/test_reuse_catalog.py::test_reuse_catalog_validation_covers_current_source_surfaces` because the reuse catalog is missing `flight_project` and `mycode_project`; unrelated to this page change.

## Agent Metadata
- Tokki: not used
- Runtime: Codex
- Model: GPT-5
- Reasoning effort: unknown
- /fast: not used
