### PR TITLE
feat(view-routing-model-comparison): summarize decision timing by demand load

### DIFF
--- a/src/agilab/apps-pages/view_routing_model_comparison/src/view_routing_model_comparison/view_routing_model_comparison.py
+++ b/src/agilab/apps-pages/view_routing_model_comparison/src/view_routing_model_comparison/view_routing_model_comparison.py
@@ -500,19 +500,68 @@ def build_decision_timing_scaling_figure(
         )
         if rows.empty:
             continue
+        rows = rows.copy()
+        rows["active_demands"] = pd.to_numeric(rows["active_demands"], errors="coerce")
+        rows = rows.dropna(subset=["active_demands"])
+        if rows.empty:
+            continue
+        rows["active_demands"] = rows["active_demands"].round().astype(int)
+        grouped = (
+            rows.groupby("active_demands", as_index=False, observed=False)
+            .agg(
+                sample_count=("decision_time_ms", "count"),
+                median_ms=("decision_time_ms", "median"),
+                lower_ms=(
+                    "decision_time_ms",
+                    lambda values: float(np.percentile(values.to_numpy(dtype=float), 25)),
+                ),
+                upper_ms=(
+                    "decision_time_ms",
+                    lambda values: float(np.percentile(values.to_numpy(dtype=float), 75)),
+                ),
+            )
+            .sort_values("active_demands")
+        )
+        if grouped.empty:
+            continue
+        color = MODEL_COLORS[model]
         fig.add_trace(
             go.Scatter(
-                x=rows["active_demands"],
-                y=rows["decision_time_ms"],
-                mode="markers",
+                x=grouped["active_demands"],
+                y=grouped["median_ms"],
+                mode="lines+markers",
                 name=model,
-                marker=dict(color=MODEL_COLORS[model], size=7, opacity=0.75),
+                legendgroup=model,
+                line=dict(color=color, width=3),
+                marker=dict(color=color, size=7),
+                error_y=dict(
+                    type="data",
+                    symmetric=False,
+                    array=(grouped["upper_ms"] - grouped["median_ms"]).to_numpy(),
+                    arrayminus=(grouped["median_ms"] - grouped["lower_ms"]).to_numpy(),
+                    thickness=1.5,
+                    width=4,
+                    color=color,
+                    visible=True,
+                ),
+                customdata=grouped[["sample_count", "lower_ms", "upper_ms"]].to_numpy(),
+                hovertemplate=(
+                    "active demands=%{x}<br>"
+                    "median decision=%{y:.3f} ms<br>"
+                    "samples=%{customdata[0]}<br>"
+                    "p25=%{customdata[1]:.3f} ms<br>"
+                    "p75=%{customdata[2]:.3f} ms<extra>"
+                    + model
+                    + "</extra>"
+                ),
             )
         )
     fig.update_layout(
         title="Decision Time Versus Active Demands",
         xaxis_title="Active demands",
-        yaxis_title="Total decision time (ms)",
+        yaxis_title="Decision time (ms)",
+        hovermode="x unified",
+        legend_title="Model",
         margin=dict(l=40, r=30, t=60, b=60),
     )
     return fig
@@ -699,7 +748,10 @@ def available_file_signatures(base_dir: Path) -> tuple[tuple[str, str, int], ...
     return tuple(signatures)
 
 
-def render_metric_row(summary_df: pd.DataFrame) -> None:
+def render_metric_row(
+    summary_df: pd.DataFrame,
+    timing_summary: pd.DataFrame | None = None,
+) -> None:
     if summary_df.empty:
         return
     best_served = summary_df.sort_values(
@@ -715,8 +767,15 @@ def render_metric_row(summary_df: pd.DataFrame) -> None:
         .sort_values("latency_violation_rate")
         .head(1)
     )
-    total_decisions = int(summary_df["routed_count"].sum())
-    cols = st.columns(4)
+    fastest_model = None
+    if timing_summary is not None and not timing_summary.empty:
+        timing_rows = timing_summary.dropna(subset=["total_median_ms"]).sort_values(
+            "total_median_ms"
+        )
+        if not timing_rows.empty:
+            fastest_model = timing_rows.iloc[0]
+
+    cols = st.columns(4 if fastest_model is not None else 3)
     cols[0].metric(
         "Best served ratio",
         str(best_served["model"]),
@@ -734,7 +793,12 @@ def render_metric_row(summary_df: pd.DataFrame) -> None:
             str(row["model"]),
             f"{row['latency_violation_rate']:.3f}",
         )
-    cols[3].metric("Routed decisions", f"{total_decisions:,}")
+    if fastest_model is not None:
+        cols[3].metric(
+            "Fastest model",
+            str(fastest_model["model"]),
+            f"{fastest_model['total_median_ms']:.1f} ms",
+        )
 
 
 def build_overview_figure(
@@ -1454,7 +1518,7 @@ def main() -> None:
     timing_df = build_decision_timing_data(alloc_df)
     timing_summary = build_decision_timing_summary(timing_df)
 
-    render_metric_row(summary_df)
+    render_metric_row(summary_df, timing_summary)
 
     (
         summary_tab,

--- a/test/test_view_routing_model_comparison.py
+++ b/test/test_view_routing_model_comparison.py
@@ -256,10 +256,10 @@ def test_decision_timing_is_deduplicated_and_converted_to_milliseconds() -> None
                 "time_s": 0.0,
                 "active_demands": 2,
                 "active": True,
-                "decision_preparation_time_ns": 100_000_000,
-                "decision_core_time_ns": 20_000_000,
-                "decision_realization_time_ns": 5_000_000,
-                "decision_time_ns": 125_000_000,
+                "decision_preparation_time_ns": 60_000_000,
+                "decision_core_time_ns": 30_000_000,
+                "decision_realization_time_ns": 10_000_000,
+                "decision_time_ns": 100_000_000,
             },
             # The exporter repeats step timing on every allocation row.
             {
@@ -268,10 +268,43 @@ def test_decision_timing_is_deduplicated_and_converted_to_milliseconds() -> None
                 "time_s": 0.0,
                 "active_demands": 2,
                 "active": True,
-                "decision_preparation_time_ns": 100_000_000,
-                "decision_core_time_ns": 20_000_000,
-                "decision_realization_time_ns": 5_000_000,
-                "decision_time_ns": 125_000_000,
+                "decision_preparation_time_ns": 60_000_000,
+                "decision_core_time_ns": 30_000_000,
+                "decision_realization_time_ns": 10_000_000,
+                "decision_time_ns": 100_000_000,
+            },
+            {
+                "model": "ILP",
+                "time_index": 1,
+                "time_s": 60.0,
+                "active_demands": 2,
+                "active": True,
+                "decision_preparation_time_ns": 120_000_000,
+                "decision_core_time_ns": 60_000_000,
+                "decision_realization_time_ns": 20_000_000,
+                "decision_time_ns": 200_000_000,
+            },
+            {
+                "model": "ILP",
+                "time_index": 2,
+                "time_s": 120.0,
+                "active_demands": 5,
+                "active": True,
+                "decision_preparation_time_ns": 240_000_000,
+                "decision_core_time_ns": 120_000_000,
+                "decision_realization_time_ns": 40_000_000,
+                "decision_time_ns": 400_000_000,
+            },
+            {
+                "model": "Path-AC",
+                "time_index": 0,
+                "time_s": 0.0,
+                "active_demands": 3,
+                "active": True,
+                "decision_preparation_time_ns": 90_000_000,
+                "decision_core_time_ns": 45_000_000,
+                "decision_realization_time_ns": 15_000_000,
+                "decision_time_ns": 150_000_000,
             },
             {
                 "model": "Path-AC",
@@ -279,21 +312,32 @@ def test_decision_timing_is_deduplicated_and_converted_to_milliseconds() -> None
                 "time_s": 60.0,
                 "active_demands": 3,
                 "active": True,
-                "decision_preparation_time_ns": 200_000_000,
-                "decision_core_time_ns": 10_000_000,
-                "decision_realization_time_ns": 10_000_000,
-                "decision_time_ns": 220_000_000,
+                "decision_preparation_time_ns": 150_000_000,
+                "decision_core_time_ns": 75_000_000,
+                "decision_realization_time_ns": 25_000_000,
+                "decision_time_ns": 250_000_000,
+            },
+            {
+                "model": "Path-AC",
+                "time_index": 2,
+                "time_s": 120.0,
+                "active_demands": 6,
+                "active": True,
+                "decision_preparation_time_ns": 300_000_000,
+                "decision_core_time_ns": 150_000_000,
+                "decision_realization_time_ns": 50_000_000,
+                "decision_time_ns": 500_000_000,
             },
         ]
     )
     timing = module.build_decision_timing_data(allocations)
-    assert len(timing) == 2
-    assert timing.loc[timing["model"] == "ILP", "decision_time_ms"].iloc[0] == 125.0
+    assert len(timing) == 6
+    assert timing.loc[timing["model"] == "ILP", "decision_time_ms"].iloc[0] == 100.0
 
     summary = module.build_decision_timing_summary(timing).set_index("model")
-    assert summary.loc["ILP", "decision_count"] == 1
-    assert summary.loc["ILP", "core_median_ms"] == 20.0
-    assert summary.loc["Path-AC", "total_time_s"] == 0.22
+    assert summary.loc["ILP", "decision_count"] == 3
+    assert summary.loc["ILP", "core_median_ms"] == 60.0
+    assert summary.loc["Path-AC", "total_time_s"] == 0.9
 
     distribution = module.build_decision_timing_distribution_figure(
         timing, ["ILP", "Path-AC"]
@@ -307,6 +351,14 @@ def test_decision_timing_is_deduplicated_and_converted_to_milliseconds() -> None
     assert len(distribution.data) == 4
     assert len(over_time.data) == 2
     assert len(scaling.data) == 2
+    assert list(scaling.data[0].x) == [2, 5]
+    assert list(scaling.data[0].y) == [150.0, 400.0]
+    assert list(scaling.data[0].error_y.array) == [25.0, 0.0]
+    assert list(scaling.data[0].error_y.arrayminus) == [25.0, 0.0]
+    assert list(scaling.data[1].x) == [3, 6]
+    assert list(scaling.data[1].y) == [200.0, 500.0]
+    assert list(scaling.data[1].error_y.array) == [25.0, 0.0]
+    assert list(scaling.data[1].error_y.arrayminus) == [25.0, 0.0]
 
 
 def test_decision_timing_summary_handles_legacy_exports() -> None:
@@ -917,7 +969,46 @@ def test_routing_model_comparison_empty_helpers_and_metrics(monkeypatch) -> None
         ]
     )
     module.render_metric_row(sparse_summary)
-    assert [name for name, _args in streamlit.calls].count("metric") == 2
+    assert [name for name, _args in streamlit.calls].count("metric") == 1
+
+
+def test_routing_model_comparison_reports_fastest_model_by_median(monkeypatch) -> None:
+    module = _load_module()
+
+    summary = pd.DataFrame(
+        [
+            {
+                "model": "ILP",
+                "served_bandwidth_ratio": 1.0,
+                "mean_latency_ms": 12.0,
+                "latency_violation_rate": 0.05,
+                "routed_count": 10,
+            },
+            {
+                "model": "PPO-GNN",
+                "served_bandwidth_ratio": 0.8,
+                "mean_latency_ms": 30.0,
+                "latency_violation_rate": 0.20,
+                "routed_count": 10,
+            },
+        ]
+    )
+    timing_summary = pd.DataFrame(
+        [
+            {"model": "ILP", "decision_count": 2, "total_median_ms": 123.4},
+            {"model": "PPO-GNN", "decision_count": 2, "total_median_ms": 180.0},
+        ]
+    )
+
+    streamlit = _StreamlitStub()
+    monkeypatch.setattr(module, "st", streamlit)
+    module.render_metric_row(summary, timing_summary)
+
+    metric_calls = [args for name, args in streamlit.calls if name == "metric"]
+    fastest = next(call for call in metric_calls if call[0] == "Fastest model")
+    assert fastest[1] == "ILP"
+    assert fastest[2] == "123.4 ms"
+    assert len(metric_calls) == 4
 
 
 def test_routing_model_comparison_package_bundle_root() -> None:


### PR DESCRIPTION
Summary:
- Aggregate the decision-time-versus-active-demands chart by demand level and surface the fastest model KPI from median timing.

Validation:
- uv --preview-features extra-build-dependencies run pytest -q -o addopts= test/test_view_routing_model_comparison.py

Repro:
- The scaling chart previously plotted every allocation row directly, which made repeated active-demand levels noisy and hard to read.

Root Cause:
- The over-time chart was using per-row samples instead of grouped medians with whiskers, and the metric row did not expose the fastest model.

Regression Test:
- test/test_view_routing_model_comparison.py

Review Evidence:
- not used

Agent Metadata:
- Tokki: tokki-protected 1.0.34
- Runtime: Codex
- Model: GPT-5
- Reasoning effort: unknown
- /fast: not used