### PR TITLE
Align docs with shipped code, and make CLI subcommands discoverable

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 276,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "985d3d4f6d7dbd8acd20c63135b184fa6b43d8a55871755f60e89a8276586f08",
+  "source_digest_sha256": "647ba5af27aa8aff94f19984e37fa07f14599b91cef1f4eb52d0823f4caa3f10",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "985d3d4f6d7dbd8acd20c63135b184fa6b43d8a55871755f60e89a8276586f08"
+  "target_digest_sha256": "647ba5af27aa8aff94f19984e37fa07f14599b91cef1f4eb52d0823f4caa3f10"
 }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -50,9 +50,21 @@ def _should_use_agilab_path_fallback(
     return not current_source_available and not _is_site_packages_path(path)
 
 
+# Checkouts of the public framework that were actually used for this build. When
+# the repo being documented is not the public one, its builtin app projects still
+# have to be importable or their autodoc pages render an empty API Reference.
+framework_roots: list[Path] = []
+
+
+def _note_framework_root(root: Path) -> None:
+    if root.exists() and root not in framework_roots:
+        framework_roots.append(root)
+
+
 # Prefer the pinned public framework submodule when present.
 if (repo_root / ".external/agilab/src").exists():
     _add_path(repo_root / ".external/agilab/src")
+    _note_framework_root(repo_root / ".external/agilab")
 if (repo_root / ".external/agilab/src/agilab").exists():
     _add_agilab_lib_paths(repo_root / ".external/agilab/src/agilab")
 if (repo_root / ".external/agilab/src/agilab/core").exists():
@@ -81,8 +93,11 @@ if agi_path is not None and _should_use_agilab_path_fallback(
     if agi_path.name == "agilab" and (agi_path / "__init__.py").exists():
         _add_path(agi_path.parent)
         _add_agilab_lib_paths(agi_path)
+        # `.agilab-path` points at `<repo>/src/agilab`; the checkout root is two up.
+        _note_framework_root(agi_path.parents[1])
 
     _add_path(agi_path / "src")
+    _note_framework_root(agi_path)
     if (agi_path / "src/agilab/core").exists():
         _add_agilab_lib_paths(agi_path / "src/agilab")
         _add_core_paths(agi_path / "src/agilab/core")
@@ -112,28 +127,36 @@ except Exception as e:
 project_root = repo_root
 
 
-def _is_generated_root_project_src(src: Path) -> bool:
-    """Skip local generated project workspaces accidentally left at repo root."""
+def _is_generated_root_project_src(src: Path, root: Path | None = None) -> bool:
+    """Skip local generated project workspaces accidentally left at a repo root."""
     project_dir = src.parent
-    return project_dir.parent == project_root and project_dir.name.endswith("_project")
+    return project_dir.parent == (root or project_root) and project_dir.name.endswith(
+        "_project"
+    )
 
 
-for proj in [
-    "*project",
-    "agilab/cluster",
-    "agilab/node",
-    "agilab/env",
-]:
-    for src in sorted(project_root.rglob(f"{proj}/src")):
-        if _is_generated_root_project_src(src):
-            continue
-        path = str(src)
-        if not src.exists():
-            print(path, "does not exist; skipping")
-            continue
-        if path not in sys.path:
-            print(f"Adding {path} to sys.path")
-            sys.path.insert(0, path)
+# Scan the repo being documented first, then any public-framework checkout it
+# borrowed code from, so `apps/builtin/*_project` modules are importable even when
+# the public framework is a sibling or submodule rather than this repo.
+scan_roots = [project_root, *(r for r in framework_roots if r != project_root)]
+
+for scan_root in scan_roots:
+    for proj in [
+        "*project",
+        "agilab/cluster",
+        "agilab/node",
+        "agilab/env",
+    ]:
+        for src in sorted(scan_root.rglob(f"{proj}/src")):
+            if _is_generated_root_project_src(src, scan_root):
+                continue
+            path = str(src)
+            if not src.exists():
+                print(path, "does not exist; skipping")
+                continue
+            if path not in sys.path:
+                print(f"Adding {path} to sys.path")
+                sys.path.insert(0, path)
 
 # -- Project Information -----------------------------------------------------
 
@@ -306,6 +329,9 @@ autodoc_mock_imports = [
     "dask",
     "dask.distributed",
     "distributed",
+    # Worker kernels import cython for the ahead-of-execution compilation path;
+    # it is a build-time dep of the workers, not of the docs environment.
+    "cython",
 ]
 
 # -- MyST Parser Configuration -----------------------------------------------

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -40,7 +40,7 @@ agi-core
 
   - **Language Support:**
 
-    - Pure Python on Python 3.12+
+    - Pure Python on Python 3.12, 3.13, or 3.14
     - Cython ahead-of-execution compilation for supported worker kernels
 
   - **Deployment Modes:**

--- a/docs/source/kubernetes-job.rst
+++ b/docs/source/kubernetes-job.rst
@@ -40,7 +40,7 @@ The default command is the packaged first proof:
 
    agilab kubernetes-job \
      --app flight_telemetry_project \
-     --image ghcr.io/thalesgroup/agilab:2026.05.25 \
+     --image ghcr.io/thalesgroup/agilab:2026.07.17.1 \
      --namespace agilab \
      --pvc agilab-artifacts \
      --output /tmp/agilab-flight-first-proof-job.yaml
@@ -61,7 +61,7 @@ Pass the container command after ``--``:
 
    agilab kubernetes-job \
      --app flight_telemetry_project \
-     --image ghcr.io/thalesgroup/agilab:2026.05.25 \
+     --image ghcr.io/thalesgroup/agilab:2026.07.17.1 \
      --env OPENAI_MODEL=gpt-4.1-mini \
      --output /tmp/agilab-job.yaml \
      -- \

--- a/docs/source/quick-start.rst
+++ b/docs/source/quick-start.rst
@@ -36,7 +36,8 @@ Fast adoption path:
 Prerequisites
 -------------
 
-- Python 3.12+ with `uv <https://docs.astral.sh/uv/>`_ installed.
+- Python 3.12, 3.13, or 3.14 (the package declares ``requires-python = ">=3.12,<3.15"``)
+  with `uv <https://docs.astral.sh/uv/>`_ installed.
   Use the installer command for your platform from the uv documentation; the
   common macOS/Linux bootstrap is ``curl -LsSf https://astral.sh/uv/install.sh | sh``.
 - macOS or Linux shell for the source-checkout installer. On native Windows,

--- a/src/agilab/app_management/pypi_app_packages.py
+++ b/src/agilab/app_management/pypi_app_packages.py
@@ -738,9 +738,18 @@ def _app_remove(args: argparse.Namespace) -> int:
     )
 
 
-def _build_parser() -> argparse.ArgumentParser:
+def _build_parser(
+    extra_subcommands: Sequence[tuple[str, str, Callable[[list[str]], int]]] = (),
+) -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Manage AGILAB PyPI app packages.")
     subparsers = parser.add_subparsers(dest="command", required=True)
+
+    # Subcommands owned by a caller (currently `agilab app surface`, which lives in
+    # lab_run). Registered here so one parser is the single source of help truth.
+    for name, help_text, handler in extra_subcommands:
+        extra_parser = subparsers.add_parser(name, help=help_text)
+        extra_parser.add_argument("args", nargs=argparse.REMAINDER)
+        extra_parser.set_defaults(func=lambda parsed, _handler=handler: _handler(parsed.args))
 
     list_parser = subparsers.add_parser("list", help="List installed agi-app-* packages.")
     list_parser.add_argument("--json", action="store_true")
@@ -777,7 +786,11 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def main(argv: Sequence[str] | None = None) -> int:
-    parser = _build_parser()
+def main(
+    argv: Sequence[str] | None = None,
+    *,
+    extra_subcommands: Sequence[tuple[str, str, Callable[[list[str]], int]]] = (),
+) -> int:
+    parser = _build_parser(extra_subcommands)
     args = parser.parse_args(list(sys.argv[1:] if argv is None else argv))
     return args.func(args)

--- a/src/agilab/lab_run.py
+++ b/src/agilab/lab_run.py
@@ -689,12 +689,18 @@ def _run_env(argv: list[str]) -> int:
 
 
 def _run_app(argv: list[str]) -> int:
-    if argv[:1] == ["surface"]:
-        return _run_app_surface(argv[1:])
-
     from agilab import pypi_app_packages
 
-    return pypi_app_packages.main(argv)
+    return pypi_app_packages.main(
+        argv,
+        extra_subcommands=(
+            (
+                "surface",
+                "Open an app UI backend; `--list` shows the available backends.",
+                _run_app_surface,
+            ),
+        ),
+    )
 
 
 def _run_kubernetes_job(argv: list[str]) -> int:
@@ -1065,6 +1071,95 @@ def _load_streamlit_cli():
     return stcli
 
 
+# Subcommands are dispatched from `raw_argv` below, before the argparse parser is
+# built, so argparse cannot advertise them on its own. This table exists purely to
+# make them discoverable from `agilab --help`; test_cli_help_discoverability keeps
+# it in sync with the dispatch ladder.
+_SUBCOMMAND_GROUPS: tuple[tuple[str, tuple[tuple[str, str], ...]], ...] = (
+    (
+        "Getting started",
+        (
+            ("first-proof", "Run the packaged first proof and emit install/run evidence."),
+            ("dry-run", "Plan the first proof without executing it."),
+            ("doctor", "Diagnose the local install, cluster share, and worker setup."),
+            ("app", "Manage app packages; `app surface` opens an app UI backend."),
+            ("pytorch-playground", "Launch the PyTorch playground app surface."),
+        ),
+    ),
+    (
+        "Evidence and proof",
+        (
+            ("prove", "Write a portable AGILAB proof pack."),
+            ("verify", "Verify a run manifest, optionally requiring a signature."),
+            ("sign", "Sign a .agipack proof capsule with Ed25519."),
+            ("replay", "Print or execute a recorded replay command."),
+            ("policy-check", "Evaluate a manifest against a policy."),
+            ("cards", "Generate model/dataset/prompt/eval cards."),
+            ("metadata-store", "Append a run to a local metadata store."),
+            ("export-lineage", "Export lineage/observability formats."),
+            ("export-traces", "Export OpenTelemetry-shaped trace JSON."),
+        ),
+    ),
+    (
+        "Workflows and agents",
+        (
+            ("workflow", "Validate stage, dependency, and artifact-flow contracts."),
+            ("agent-run", "Wrap coding-agent actions with redacted manifests and traces."),
+            ("reuse", "Suggest or validate reusable apps and pages."),
+            ("pages", "`pages suggest` proposes reusable page bundles."),
+            ("projects", "`projects suggest` proposes reusable project layouts."),
+        ),
+    ),
+    (
+        "Reports and release",
+        (
+            ("security-check", "Run the local security hygiene profile."),
+            ("adoption-report", "Summarize adoption/compatibility posture."),
+            ("story", "Render the storyboard walkthrough."),
+            ("promotion-dossier", "Assemble the promotion dossier."),
+            ("publish", "Run the publish path."),
+            ("release", "Run the release path."),
+        ),
+    ),
+    (
+        "Bridges and deployment",
+        (
+            ("export", "Export to Quarto, HF Space, MLflow, Airflow, or Dagster."),
+            ("run", "Run a Quarto doc, DuckDB query, or notebook."),
+            ("init", "Scaffold editor integration, e.g. `init vscode`."),
+            ("import", "Import from an external system, e.g. `import mlflow`."),
+            ("mcp", "Serve the AGILAB MCP endpoint."),
+            ("kubernetes-job", "Render a Kubernetes Job manifest for an app."),
+            ("env", "`env footprint` reports the resolved environment footprint."),
+        ),
+    ),
+)
+
+# Accepted spellings that intentionally do not get their own help line.
+_SUBCOMMAND_ALIASES: dict[str, str] = {
+    "storyboard": "story",
+    "run-story": "story",
+    "dossier": "promotion-dossier",
+    "k8s-job": "kubernetes-job",
+    "project": "projects",
+}
+
+
+def _subcommand_epilog() -> str:
+    lines = ["subcommands:"]
+    width = max(
+        len(name) for _, entries in _SUBCOMMAND_GROUPS for name, _ in entries
+    )
+    for title, entries in _SUBCOMMAND_GROUPS:
+        lines.append("")
+        lines.append(f"  {title}:")
+        for name, help_text in entries:
+            lines.append(f"    {name.ljust(width)}  {help_text}")
+    lines.append("")
+    lines.append("Run `agilab <subcommand> --help` for subcommand options.")
+    return "\n".join(lines)
+
+
 def main(argv: list[str] | None = None) -> int:
     _guard_against_uvx_in_source_tree()
     raw_argv = list(sys.argv[1:] if argv is None else argv)
@@ -1141,7 +1236,9 @@ def main(argv: list[str] | None = None) -> int:
         return _run_pytorch_playground(raw_argv[1:])
 
     parser = argparse.ArgumentParser(
-        description="Run AGILAB application with custom options."
+        description="Run AGILAB application with custom options.",
+        epilog=_subcommand_epilog(),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument(
         "--apps-path",

--- a/test/test_cli_help_discoverability.py
+++ b/test/test_cli_help_discoverability.py
@@ -1,0 +1,93 @@
+"""Every shipped subcommand must be discoverable from `agilab --help`.
+
+lab_run.main dispatches on raw_argv[:1] before building the argparse parser, so
+argparse cannot advertise those verbs on its own. lab_run._SUBCOMMAND_GROUPS
+supplies them as a help epilog; these tests keep that table honest as the
+dispatch ladder changes.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+CAPABILITIES = ROOT / "agilab-capabilities.json"
+LAB_RUN = ROOT / "src" / "agilab" / "lab_run.py"
+
+# `agilab agilab ...` is never a verb; guards against a malformed manifest entry.
+_NOT_A_SUBCOMMAND = {"agilab"}
+
+
+def _documented_subcommands() -> set[str]:
+    manifest = json.loads(CAPABILITIES.read_text(encoding="utf-8"))
+    verbs: set[str] = set()
+    for entry in manifest["cli_commands"]:
+        for invocation in [entry["command"], *entry.get("aliases", [])]:
+            parts = invocation.split()
+            if parts[:1] != ["agilab"] or len(parts) < 2:
+                continue
+            # Some manifest entries pipe-join sibling verbs: "agilab prove|verify|sign".
+            for verb in parts[1].split("|"):
+                if verb.startswith("-") or verb in _NOT_A_SUBCOMMAND:
+                    continue
+                verbs.add(verb)
+    return verbs
+
+
+def _dispatched_subcommands() -> set[str]:
+    """Literal verbs matched in lab_run.main's raw_argv dispatch ladder."""
+    source = LAB_RUN.read_text(encoding="utf-8")
+    body = source[source.index("def main("):]
+    verbs: set[str] = set()
+    # `raw_argv[:1] == ["doctor"]`, `raw_argv[:1] in (["prove"], ["verify"], ...)`,
+    # and `raw_argv[:2] == ["reuse", "suggest"]` — take only the leading verb of
+    # each bracketed form, and allow the `in (...)` tuples to span lines.
+    for match in re.finditer(r"raw_argv\[:([12])\]\s*(?:==|in)\s*(\(.*?\)|\[.*?\])", body, re.S):
+        for form in re.findall(r'\[\s*"([a-z][a-z0-9_-]*)"', match.group(2)):
+            verbs.add(form)
+    return {v.replace("_", "-") for v in verbs}
+
+
+def _help_text(capsys, argv: list[str]) -> str:
+    from agilab import lab_run
+
+    with pytest.raises(SystemExit):
+        lab_run.main(argv)
+    return capsys.readouterr().out
+
+
+def test_capability_manifest_only_lists_dispatched_commands() -> None:
+    """Guards the other direction: no manifest entry for a verb that is gone."""
+    undispatched = _documented_subcommands() - _dispatched_subcommands()
+    assert not undispatched, f"manifest advertises non-dispatched verbs: {sorted(undispatched)}"
+
+
+def test_top_level_help_lists_every_shipped_subcommand(capsys) -> None:
+    from agilab import lab_run
+
+    help_text = _help_text(capsys, ["--help"])
+    aliases = lab_run._SUBCOMMAND_ALIASES
+    missing = sorted(
+        verb
+        for verb in _dispatched_subcommands()
+        # An alias is covered by the help line of the verb it resolves to.
+        if aliases.get(verb, verb) not in help_text
+    )
+    assert not missing, (
+        "`agilab --help` does not advertise these dispatched subcommands: "
+        f"{missing}. Add them to the parser epilog or a subparser group in "
+        "lab_run.main so docs are not the only discovery path."
+    )
+
+
+def test_app_help_lists_surface_backend_launcher(capsys) -> None:
+    """`agilab app surface` is owned by lab_run but registered on the app parser."""
+    help_text = _help_text(capsys, ["app", "--help"])
+    assert "surface" in help_text, (
+        "`agilab app --help` omits `surface`, which quick-start.rst, features.rst, "
+        "pytorch-playground.rst, demos.rst, public-app-catalog.rst and index.rst all document."
+    )


### PR DESCRIPTION
Audit of `docs/source` against the code surface. Four mismatches found; all fixed here.

The mirror contract itself was already sound — `sync_docs_source.py` dry run reported `create: 0, update: 0, delete: 0`, the stamp verified, and 93 docs-alignment tests passed. The drift was in places no guard covered.

## `d57a2e3` — docs alignment

| Finding | Fix |
|---|---|
| `kubernetes-job.rst:43,64` pinned `ghcr.io/thalesgroup/agilab:2026.05.25`, two releases behind the `2026.07.17.1` package version | bumped both |
| `quick-start.rst` and `features.rst` said "Python 3.12+"; `pyproject.toml` declares `requires-python = ">=3.12,<3.15"` | state the supported range |
| `conf.py` scanned only the repo being documented for `*project/src`, so a repo consuming the public framework as a sibling checkout or `.external/agilab` submodule could not import `apps/builtin` app modules | scan `[project_root, *framework_roots]`; `_is_generated_root_project_src` takes an optional per-root arg |
| `flight_telemetry_worker` imports `cython` for the ahead-of-execution kernel path, absent from docs envs | added to `autodoc_mock_imports` |

The last two mattered only for the **canonical** build — the path contributors are told to prefer when validating docs edits. It went from 6 autodoc import failures to 0, and the minimal-app and flight-telemetry API Reference sections from 0 to 36 and 59 signatures. The public build already produced those and is byte-for-byte unchanged.

## `007e8ea` — CLI discoverability

`lab_run.main` dispatches ~36 subcommands off `raw_argv[:1]` before building the argparse parser, so `agilab --help` listed only `--apps-path` and `-V`. Every documented verb — `prove`, `verify`, `doctor`, `first-proof`, `agent-run`, `workflow`, `kubernetes-job` and the rest — was undiscoverable from the CLI, leaving docs as the only entry point.

- `_SUBCOMMAND_GROUPS` / `_SUBCOMMAND_ALIASES` / `_subcommand_epilog()`, rendered as the parser epilog.
- `agilab app surface` had the same problem one level down: intercepted ahead of the app parser and so absent from `agilab app --help`, despite being documented on six pages. `pypi_app_packages.main` now accepts `extra_subcommands` and `lab_run` registers `surface` through it, so one parser is the single source of help truth.
- `test_cli_help_discoverability` derives expected verbs by parsing the dispatch ladder rather than hardcoding, so a new subcommand that skips the epilog fails the build. It also checks the reverse: `agilab-capabilities.json` must not advertise an undispatched verb.

## Verification

- Mirror synced from `../thales_agilab/docs/source`; `--verify-stamp` ok.
- `workflow_parity.py --profile docs` → `[PASS]`.
- 159 tests pass across `lab_run`, `pypi_app_packages`, `app_surface`, the launchers, and the capability manifest. Ruff clean.
- `agilab app surface <project> --list` and `agilab app list --json` behave as before.
- The new test was mutation-checked: deleting one epilog entry fails with that verb named.

Two failures in the regression run — `test_architecture_surface_contract` (`pipeline_lab.py: 6318 > 6200`) and `test_tools_surface_contract` — reproduce on a clean `main` and are unrelated to this branch.

Canonical docs half is in a matching `docs/code-alignment-audit` branch on `thales_agilab`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)