### PR TITLE
docs: mark the Kubernetes job image as a user-supplied placeholder

### DIFF
--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 276,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "647ba5af27aa8aff94f19984e37fa07f14599b91cef1f4eb52d0823f4caa3f10",
+  "source_digest_sha256": "b55b81ba177101794dd154b32f3cfd1ea10a5cd70f20dfe39cb17e0455308230",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "647ba5af27aa8aff94f19984e37fa07f14599b91cef1f4eb52d0823f4caa3f10"
+  "target_digest_sha256": "b55b81ba177101794dd154b32f3cfd1ea10a5cd70f20dfe39cb17e0455308230"
 }

--- a/docs/source/kubernetes-job.rst
+++ b/docs/source/kubernetes-job.rst
@@ -33,6 +33,9 @@ Generate a Job manifest
 -----------------------
 
 Pick an image that already contains AGILAB and the app payload you want to run.
+``--image`` is required and has no default. AGILAB does not publish a container
+image, so this is an image you build and push to your own registry; the
+``registry.example.com`` values below are placeholders, not pullable artifacts.
 The default command is the packaged first proof:
 ``python -m agilab.lab_run first-proof --json --max-seconds 60``.
 
@@ -40,7 +43,7 @@ The default command is the packaged first proof:
 
    agilab kubernetes-job \
      --app flight_telemetry_project \
-     --image ghcr.io/thalesgroup/agilab:2026.07.17.1 \
+     --image registry.example.com/agilab:2026.07.17.1 \
      --namespace agilab \
      --pvc agilab-artifacts \
      --output /tmp/agilab-flight-first-proof-job.yaml
@@ -61,7 +64,7 @@ Pass the container command after ``--``:
 
    agilab kubernetes-job \
      --app flight_telemetry_project \
-     --image ghcr.io/thalesgroup/agilab:2026.07.17.1 \
+     --image registry.example.com/agilab:2026.07.17.1 \
      --env OPENAI_MODEL=gpt-4.1-mini \
      --output /tmp/agilab-job.yaml \
      -- \


### PR DESCRIPTION
Follow-up to #863, correcting a finding in it.

`kubernetes-job.rst` used `ghcr.io/thalesgroup/agilab:<tag>` in both examples, which reads as an official, pullable image. It is not one:

- no workflow in this repo builds or pushes a container (`.github/workflows/` has no docker step; `docker/Dockerfile` only consumes `ghcr.io/astral-sh/uv`)
- the `v2026.07.17` release publishes wheels, hashes, and SHA256SUMS — no image
- `--image` is `required=True` with no default (`src/agilab/cluster/kubernetes_job.py:259`)

The page already said "Pick an image that already contains AGILAB", but the registry path contradicted that.

#863 bumped this tag from `2026.05.25` to the current package version, on the stated rationale that it was a stale pin two releases behind. That rationale was wrong — there is no artifact for it to be stale against — and a current-looking tag made a non-existent image look freshly published.

This switches both examples to `registry.example.com/agilab:<tag>` and states plainly that the image is one the user builds and pushes, so nobody copies the command expecting a pull to work.

Also worth recording: the follow-up guard suggested in #863 — a test pinning documented image tags to `pyproject.toml`'s version — is deliberately **not** included. It would have encoded this false premise as an enforced invariant. The two remaining version strings in docs (`index.rst`, `release-proof.rst`) track the release tag and are already covered by `test_docs_version_label.py`.

## Verification

Canonical edited first, mirror synced (`update: 1`), `--verify-stamp` ok, `workflow_parity.py --profile docs` → `[PASS]`, rendered paragraph confirmed in the built HTML, and zero residual `ghcr.io/thalesgroup` references in either tree.

Canonical half: jpmorard/thales_agilab (branch `docs/kubernetes-image-placeholder`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)