### PR TITLE
fix(dev): restore deterministic quality gates

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -70,10 +70,15 @@ else
 fi
 
 if [[ "${DOCS_CHANGED:-1}" == "1" ]]; then
+  docs_source_args=()
+  if [[ -n "${AGILAB_DOCS_SOURCE:-}" ]]; then
+    docs_source_args=(--source "$AGILAB_DOCS_SOURCE")
+  fi
   run_guard_python tools/sync_docs_source.py \
     --verify-stamp \
     --quiet
   run_guard_python tools/sync_docs_source.py \
+    "${docs_source_args[@]}" \
     --check \
     --delete \
     --quiet \

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -70,8 +70,12 @@ else
 fi
 
 if [[ "${DOCS_CHANGED:-1}" == "1" ]]; then
-  docs_source_args=()
+  docs_source_args=(--skip-missing-source)
   if [[ -n "${AGILAB_DOCS_SOURCE:-}" ]]; then
+    if [[ ! -d "$AGILAB_DOCS_SOURCE" ]]; then
+      echo "[agilab pre-push] AGILAB_DOCS_SOURCE is not a directory: $AGILAB_DOCS_SOURCE" >&2
+      exit 1
+    fi
     docs_source_args=(--source "$AGILAB_DOCS_SOURCE")
   fi
   run_guard_python tools/sync_docs_source.py \
@@ -81,8 +85,7 @@ if [[ "${DOCS_CHANGED:-1}" == "1" ]]; then
     "${docs_source_args[@]}" \
     --check \
     --delete \
-    --quiet \
-    --skip-missing-source
+    --quiet
 else
   echo "[agilab pre-push] docs mirror inputs unchanged; skipping docs mirror guard." >&2
 fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,14 @@ jobs:
           set -euo pipefail
           uv --preview-features extra-build-dependencies run --extra dev ruff --version
 
+      - name: Validate fast repository contracts
+        run: |
+          set -euo pipefail
+          uv --preview-features extra-build-dependencies run --extra dev pytest -q -o addopts='' \
+            test/test_package_split_contract.py \
+            test/test_pypi_publish_workflow.py \
+            test/test_compat_shim_inventory.py
+
       - name: Validate app contract matrix
         run: |
           set -euo pipefail
@@ -223,7 +231,7 @@ jobs:
 
       - name: Confirm extended test policy
         run: |
-          echo "GitHub Actions CI runs repository guardrails plus a minimal first-proof command contract."
+          echo "GitHub Actions CI runs repository guardrails, fast repository contracts, and a minimal first-proof command contract."
           echo "Run local workflow parity profiles before push for full test coverage."
 
   base-python-compat:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,7 +167,11 @@ Use this runbook whenever you:
   release assets. If the guard should ignore them, fix or tighten the guard at
   the inventory layer and add a polluted-workspace regression; if bypassing is
   still necessary, state the exact unrelated guard failure and the targeted
-  check that was run.
+  check that was run. For canonical docs validation from an isolated clean
+  worktree, set `AGILAB_DOCS_SOURCE` to that worktree's `docs/source` directory
+  so the pre-push mirror guard verifies the intended source instead of the
+  conventional sibling checkout; do not bypass the guard merely because the
+  sibling checkout contains unrelated user work.
 - **Reasonable factorization check**: When adding new code, look for nearby
   existing helpers, contracts, or patterns that can reasonably be reused or
   extended instead of duplicating logic. Factor only when it reduces real

--- a/README.md
+++ b/README.md
@@ -143,8 +143,9 @@ notebook / MLflow / UI handoff
 
 The flow is reversible where it matters for long-term reuse: WORKFLOW can export
 the saved pipeline as a runnable `agi-core` supervisor notebook, so the code,
-stage order, runtime hints, and review context remain usable outside the
-workbench.
+stage order, runtime hints, and review context remain usable through the stable,
+release-gated core runtime handoff technology if the AGILAB UI or distributed
+runtime is no longer the right interface for that work.
 
 ## Demo Routes
 

--- a/agenticweb.md
+++ b/agenticweb.md
@@ -1,7 +1,7 @@
 ---
 agenticweb: "1"
 description: "AGILAB is an open-source AI/ML workbench for reproducible experiments, notebook-to-app workflows, run evidence, proof capsules, and local agent evidence review."
-updated: "2026-07-21"
+updated: "2026-07-23"
 organization:
   name: "AGILAB"
   website: "https://thalesgroup.github.io/agilab"

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -8,9 +8,7 @@ the repo root it imports ``test...`` modules from here, so we extend
 
 from pathlib import Path
 from pkgutil import extend_path
-import importlib
 import sys
-import types
 
 __path__ = extend_path(__path__, __name__)  # type: ignore[misc]
 
@@ -36,20 +34,6 @@ def _ensure_source_agilab_package_path() -> None:
     spec = getattr(pkg, "__spec__", None)
     if spec is not None and getattr(spec, "submodule_search_locations", None) is not None:
         spec.submodule_search_locations = list(pkg.__path__)
-
-
-def import_agilab_module(module_name: str):
-    """Import an ``agilab.*`` module from the repo source tree even if another package is already loaded."""
-    pkg = sys.modules.get("agilab")
-    package_root = str(_SRC_ROOT / "agilab")
-    if pkg is None or not hasattr(pkg, "__path__"):
-        pkg = types.ModuleType("agilab")
-        pkg.__path__ = [package_root]
-        sys.modules["agilab"] = pkg
-    else:
-        _ensure_source_agilab_package_path()
-    importlib.invalidate_caches()
-    return importlib.import_module(module_name)
 
 
 _ensure_source_agilab_package_path()

--- a/test/test_agent_commit_provenance_guard.py
+++ b/test/test_agent_commit_provenance_guard.py
@@ -99,6 +99,51 @@ def test_pre_push_allows_explicit_agent_identity_on_agent_branch(tmp_path: Path)
     assert report["issues"] == []
 
 
+def test_pre_push_excludes_public_base_commits_after_branch_update(tmp_path: Path) -> None:
+    module = _load_module()
+    _init_repo(tmp_path)
+    _git(tmp_path, "switch", "-c", "agent/provenance")
+    _git(tmp_path, "config", "user.name", module.DEFAULT_AGENT_NAME)
+    _git(tmp_path, "config", "user.email", module.DEFAULT_AGENT_EMAIL)
+    (tmp_path / "agent.txt").write_text("first agent change\n", encoding="utf-8")
+    _git(tmp_path, "add", "agent.txt")
+    _git(tmp_path, "commit", "-m", "first agent change")
+    remote_head = _git(tmp_path, "rev-parse", "HEAD")
+
+    _git(tmp_path, "switch", "main")
+    _git(tmp_path, "config", "user.name", "Jean-Pierre MORARD")
+    _git(tmp_path, "config", "user.email", "jean-pierre.morard@thalesgroup.com")
+    (tmp_path / "main.txt").write_text("public main change\n", encoding="utf-8")
+    _git(tmp_path, "add", "main.txt")
+    _git(tmp_path, "commit", "-m", "public main change")
+    public_main_head = _git(tmp_path, "rev-parse", "HEAD")
+
+    _git(tmp_path, "switch", "agent/provenance")
+    _git(tmp_path, "config", "user.name", module.DEFAULT_AGENT_NAME)
+    _git(tmp_path, "config", "user.email", module.DEFAULT_AGENT_EMAIL)
+    _git(tmp_path, "merge", "--no-edit", "main")
+    (tmp_path / "agent.txt").write_text("second agent change\n", encoding="utf-8")
+    _git(tmp_path, "add", "agent.txt")
+    _git(tmp_path, "commit", "-m", "second agent change")
+    local_head = _git(tmp_path, "rev-parse", "HEAD")
+    spec = module.PushSpec(
+        "refs/heads/agent/provenance",
+        local_head,
+        "refs/heads/agent/provenance",
+        remote_head,
+    )
+
+    report = module.check_pre_push_specs(tmp_path, [spec], base_ref="main")
+
+    assert report["status"] == "pass"
+    assert report["issues"] == []
+    checked_commits = {
+        commit["sha"] for commit in report["evidence"]["commits"]
+    }
+    assert public_main_head not in checked_commits
+    assert local_head in checked_commits
+
+
 def test_git_history_inventory_flags_direct_guillaume_local_identity(tmp_path: Path) -> None:
     module = _load_module()
     _init_repo(tmp_path)

--- a/test/test_agilab_dev_shortcuts.py
+++ b/test/test_agilab_dev_shortcuts.py
@@ -108,9 +108,20 @@ def test_test_shortcut_keeps_headless_core_tests_free_of_ui_extra():
 def test_test_shortcut_splits_repository_groups_by_dependency_contract():
     commands = agilab_dev.planned_commands(["test"])
 
-    assert len(commands) == len(agilab_dev.PYTEST_PATH_GROUPS)
-    assert commands[0][4:8] == ["--extra", "ui", "--extra", "notebook"]
-    assert commands[0][-1] == "test"
+    assert len(commands) == len(agilab_dev.PYTEST_PATH_GROUPS) + 1
+    assert commands[0][4:10] == [
+        "--extra",
+        "ui",
+        "--extra",
+        "viz",
+        "--extra",
+        "notebook",
+    ]
+    assert commands[0][-3:] == [
+        "python",
+        "-m",
+        "tools.testing.root_test_runner",
+    ]
     assert commands[1][4] == "pytest"
     assert commands[1][-1] == "src/agilab/core/test"
     assert commands[4][4:6] == ["--extra", "ui"]

--- a/test/test_agilab_dev_shortcuts.py
+++ b/test/test_agilab_dev_shortcuts.py
@@ -109,7 +109,9 @@ def test_test_shortcut_splits_repository_groups_by_dependency_contract():
     commands = agilab_dev.planned_commands(["test"])
 
     assert len(commands) == len(agilab_dev.PYTEST_PATH_GROUPS) + 1
-    assert commands[0][4:10] == [
+    assert commands[0][4:12] == [
+        "--extra",
+        "dev",
         "--extra",
         "ui",
         "--extra",

--- a/test/test_agilab_dev_shortcuts.py
+++ b/test/test_agilab_dev_shortcuts.py
@@ -74,7 +74,9 @@ def test_test_shortcut_keeps_pytest_arguments():
             "ui",
             "--extra",
             "notebook",
-            "pytest",
+            "python",
+            "-m",
+            "tools.testing.pytest_entrypoint",
             "-q",
             "-o",
             "addopts=",
@@ -95,7 +97,9 @@ def test_test_shortcut_keeps_headless_core_tests_free_of_ui_extra():
             "--preview-features",
             "extra-build-dependencies",
             "run",
-            "pytest",
+            "python",
+            "-m",
+            "tools.testing.pytest_entrypoint",
             "-q",
             "-o",
             "addopts=",
@@ -124,7 +128,11 @@ def test_test_shortcut_splits_repository_groups_by_dependency_contract():
         "-m",
         "tools.testing.root_test_runner",
     ]
-    assert commands[1][4] == "pytest"
+    assert commands[1][4:7] == [
+        "python",
+        "-m",
+        "tools.testing.pytest_entrypoint",
+    ]
     assert commands[1][-1] == "src/agilab/core/test"
     assert commands[4][4:6] == ["--extra", "ui"]
     assert commands[4][-1] == "src/agilab/lib/agi-gui/test"

--- a/test/test_agilab_dev_shortcuts.py
+++ b/test/test_agilab_dev_shortcuts.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 import pytest
 
-
 ROOT = Path(__file__).resolve().parents[1]
 MODULE_PATH = ROOT / "tools" / "agilab_dev.py"
 
@@ -71,6 +70,10 @@ def test_test_shortcut_keeps_pytest_arguments():
             "--preview-features",
             "extra-build-dependencies",
             "run",
+            "--extra",
+            "ui",
+            "--extra",
+            "notebook",
             "pytest",
             "-q",
             "-o",
@@ -81,6 +84,37 @@ def test_test_shortcut_keeps_pytest_arguments():
             "windows",
         ]
     ]
+
+
+def test_test_shortcut_keeps_headless_core_tests_free_of_ui_extra():
+    assert agilab_dev.planned_commands(
+        ["test", "src/agilab/core/agi-env/test/test_optional_ui_split.py"]
+    ) == [
+        [
+            "uv",
+            "--preview-features",
+            "extra-build-dependencies",
+            "run",
+            "pytest",
+            "-q",
+            "-o",
+            "addopts=",
+            "--import-mode=importlib",
+            "src/agilab/core/agi-env/test/test_optional_ui_split.py",
+        ]
+    ]
+
+
+def test_test_shortcut_splits_repository_groups_by_dependency_contract():
+    commands = agilab_dev.planned_commands(["test"])
+
+    assert len(commands) == len(agilab_dev.PYTEST_PATH_GROUPS)
+    assert commands[0][4:8] == ["--extra", "ui", "--extra", "notebook"]
+    assert commands[0][-1] == "test"
+    assert commands[1][4] == "pytest"
+    assert commands[1][-1] == "src/agilab/core/test"
+    assert commands[4][4:6] == ["--extra", "ui"]
+    assert commands[4][-1] == "src/agilab/lib/agi-gui/test"
 
 
 def test_lint_shortcut_provisions_ruff_from_dev_extra_by_default():
@@ -454,6 +488,35 @@ def test_dev_shortcuts_allow_named_isolated_uv_environment(monkeypatch):
     assert env["UV_PROJECT_ENVIRONMENT"] == "/tmp/agilab-dev"
 
 
+def test_test_execution_env_isolates_checkout_state_and_credentials(monkeypatch):
+    for name in (
+        "APPS_REPOSITORY",
+        "AZURE_OPENAI_API_KEY",
+        "CLUSTER_CREDENTIALS",
+        "OPENAI_API_KEY",
+    ):
+        monkeypatch.setenv(name, "must-not-leak")
+
+    with agilab_dev._execution_env("test") as env:
+        isolated_home = Path(env["HOME"])
+        assert env["USERPROFILE"] == str(isolated_home)
+        assert env["AGILAB_DISABLE_BACKGROUND_SERVICES"] == "1"
+        assert all(
+            name not in env
+            for name in (
+                "APPS_REPOSITORY",
+                "AZURE_OPENAI_API_KEY",
+                "CLUSTER_CREDENTIALS",
+                "OPENAI_API_KEY",
+            )
+        )
+        assert (
+            isolated_home / ".local" / "share" / "agilab" / ".agilab-path"
+        ).read_text(encoding="utf-8") == str(agilab_dev.ROOT / "src" / "agilab") + "\n"
+
+    assert not isolated_home.exists()
+
+
 def test_main_keeps_machine_readable_shortcut_stdout_clean(
     capsys, monkeypatch, tmp_path
 ):
@@ -463,7 +526,7 @@ def test_main_keeps_machine_readable_shortcut_stdout_clean(
         returncode = 0
         stdout = "ok\n"
 
-    def fake_run(command, *, cwd, env, stdout, stderr, text, errors):
+    def fake_run(command, *, cwd, env, stdout, stderr, text, errors, check):
         calls.append(
             (
                 command,
@@ -520,18 +583,16 @@ def test_main_compact_output_prints_signal_summary_and_writes_full_log(
 ):
     class Completed:
         returncode = 1
-        stdout = "\n".join(
-            [
-                "collecting tests",
-                "line that should stay only in the artifact",
-                "ERROR first failure",
-                "Traceback (most recent call last)",
-                "FAILED test_demo.py::test_demo",
-                "short tail",
-            ]
+        stdout = (
+            "collecting tests\n"
+            "line that should stay only in the artifact\n"
+            "ERROR first failure\n"
+            "Traceback (most recent call last)\n"
+            "FAILED test_demo.py::test_demo\n"
+            "short tail"
         )
 
-    def fake_run(command, *, cwd, env, stdout, stderr, text, errors):
+    def fake_run(command, *, cwd, env, stdout, stderr, text, errors, check):
         assert env["UV_PROJECT_ENVIRONMENT"] == str(
             agilab_dev.DEFAULT_DEV_UV_PROJECT_ENVIRONMENT
         )
@@ -562,7 +623,7 @@ def test_main_raw_output_keeps_streaming_subprocess_call(capsys, monkeypatch):
     class Completed:
         returncode = 0
 
-    def fake_run(command, *, cwd, env):
+    def fake_run(command, *, cwd, env, check):
         calls.append(
             (
                 command,

--- a/test/test_ci_workflow.py
+++ b/test/test_ci_workflow.py
@@ -5,7 +5,6 @@ import tomllib
 from pathlib import Path
 from types import SimpleNamespace
 
-
 WORKFLOW_PATH = Path(".github/workflows/ci.yml")
 COVERAGE_WORKFLOW_PATH = Path(".github/workflows/coverage.yml")
 DOCS_SOURCE_GUARD_WORKFLOW_PATH = Path(".github/workflows/docs-source-guard.yaml")
@@ -195,6 +194,10 @@ def test_ci_workflow_includes_minimal_first_proof_contract() -> None:
     assert "python -m pip install agilab" not in text
     assert "agilab first-proof --json --no-manifest --max-seconds 60" in text
     assert "uv --preview-features extra-build-dependencies run --extra dev ruff --version" in text
+    assert "Validate fast repository contracts" in text
+    assert "test/test_package_split_contract.py" in text
+    assert "test/test_pypi_publish_workflow.py" in text
+    assert "test/test_compat_shim_inventory.py" in text
     assert "tools/app_contract_matrix.py --output app-contract-matrix.json --quiet" in text
     assert "app-contract-matrix.json" in text
     assert "Validate robustness recovery matrix" in text

--- a/test/test_compat_shim_inventory.py
+++ b/test/test_compat_shim_inventory.py
@@ -18,6 +18,11 @@ def test_compat_shim_inventory_is_capped() -> None:
     inventory = compat_shim_inventory.build_inventory()
 
     assert inventory["total"] <= compat_shim_inventory.DEFAULT_MAX_COUNT
+    assert inventory["baseline"] == compat_shim_inventory.COMPAT_SHIM_BASELINE
+    assert inventory["baseline"]["owner"]
+    assert inventory["baseline"]["removal_milestone"] == (
+        "2027.01 compatibility cleanup"
+    )
     assert inventory["total"] > 0
     assert "src/agilab" in inventory["by_area"]
     assert inventory["files"] == sorted(inventory["files"])

--- a/test/test_dependencies.py
+++ b/test/test_dependencies.py
@@ -1,6 +1,6 @@
 import json
-import urllib.request
 import urllib.error
+import urllib.request
 from typing import Dict, List, Optional, Tuple
 
 import pytest
@@ -47,12 +47,6 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         default="https://pypi.org",
         help="Base index URL to read metadata from (default: PyPI).",
     )
-    group.addoption(
-        "--allow-mismatch",
-        action="store_true",
-        default=False,
-        help="Allow differing published versions, only enforce inter-package requirement compatibility.",
-    )
 
 
 # test_dependencies.py
@@ -61,7 +55,6 @@ def settings(pytestconfig) -> Dict[str, Optional[str]]:
     return {
         "target_version": pytestconfig.getoption("target_version", default=None),  # None => use latest
         "index_url": pytestconfig.getoption("index_url", default="https://pypi.org"),
-        "allow_mismatch": pytestconfig.getoption("allow_mismatch", default=False),
     }
 
 
@@ -85,10 +78,6 @@ def versions_and_requires(settings) -> Dict[str, Tuple[str, List[str]]]:
     return out
 
 
-def _all_equal(values: List[str]) -> bool:
-    return all(v == values[0] for v in values)
-
-
 def _parse_requirements(reqs: List[str]) -> List[Requirement]:
     parsed = []
     for r in reqs:
@@ -101,18 +90,22 @@ def _parse_requirements(reqs: List[str]) -> List[Requirement]:
     return parsed
 
 
-def test_versions_aligned(versions_and_requires, settings):
-    """
-    Ensures all packages share the same version (unless --allow-mismatch),
-    using either the explicitly provided --version or each package's latest.
-    """
-    versions = {pkg: ver for pkg, (ver, _) in versions_and_requires.items()}
-    if settings["allow_mismatch"]:
-        pytest.skip("Version equality check skipped due to --allow-mismatch.")
-    assert _all_equal(list(versions.values())), (
-        "Versions are not aligned across packages.\n"
-        + "\n".join(f"- {pkg}: {ver}" for pkg, ver in versions.items())
-    )
+def test_versions_are_valid_and_respect_an_explicit_target(
+    versions_and_requires,
+    settings,
+):
+    """Allow impact-scoped releases while still validating resolved versions."""
+
+    versions = {
+        pkg: Version(version)
+        for pkg, (version, _) in versions_and_requires.items()
+    }
+    assert set(versions) == set(PKGS)
+
+    target = settings["target_version"]
+    if target is not None:
+        expected = Version(target)
+        assert all(version == expected for version in versions.values())
 
 
 @pytest.mark.parametrize("pkg", PKGS)

--- a/test/test_execution_playground_forms.py
+++ b/test/test_execution_playground_forms.py
@@ -33,9 +33,16 @@ def _make_env(
         "reset_target = false\n",
         encoding="utf-8",
     )
+    share_root = tmp_path / "share"
+
+    def _resolve_share_path(value: str) -> Path:
+        return share_root / value
+
     return SimpleNamespace(
         app_settings_file=str(settings_file),
         humanize_validation_errors=lambda exc: [str(item) for item in exc.errors()],
+        resolve_share_path=_resolve_share_path,
+        resolve_share_input_path=_resolve_share_path,
     )
 
 

--- a/test/test_notebook_export_overwrite.py
+++ b/test/test_notebook_export_overwrite.py
@@ -7,10 +7,7 @@ from types import SimpleNamespace
 import pytest
 
 from agilab.notebooks.notebook_export_support import NotebookExportContext
-from test import import_agilab_module
-
-
-pipeline_editor = import_agilab_module("agilab.pipeline.pipeline_editor")
+from agilab.pipeline import pipeline_editor
 
 
 class _State(dict):

--- a/test/test_notebook_import_persistence.py
+++ b/test/test_notebook_import_persistence.py
@@ -1,19 +1,16 @@
 from __future__ import annotations
 
 import json
+import tomllib
 from types import SimpleNamespace
 
 import pytest
-import tomllib
 
 from agilab.notebooks.notebook_export_support import (
     NotebookExportContext,
     build_notebook_document,
 )
-from test import import_agilab_module
-
-
-pipeline_editor = import_agilab_module("agilab.pipeline.pipeline_editor")
+from agilab.pipeline import pipeline_editor
 
 
 class _State(dict):

--- a/test/test_package_split_contract.py
+++ b/test/test_package_split_contract.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import subprocess
 import sys
 import tomllib
 from pathlib import Path
@@ -30,6 +31,18 @@ from package_split_contract import (  # noqa: E402
     project_path,
     pyproject_path,
 )
+
+
+def test_package_split_contract_imports_without_site_packages() -> None:
+    completed = subprocess.run(
+        [sys.executable, "-S", str(TOOLS_ROOT / "package_split_contract.py")],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
 
 
 def _load_toml(path: Path) -> dict:

--- a/test/test_package_split_contract.py
+++ b/test/test_package_split_contract.py
@@ -30,6 +30,7 @@ from package_split_contract import (  # noqa: E402
     package_by_name,
     project_path,
     pyproject_path,
+    self_extra_alias_constraint_allows_project,
 )
 
 
@@ -171,7 +172,16 @@ def test_internal_dependencies_follow_bundle_or_asset_version_policy() -> None:
                 requirement = Requirement(dependency)
                 if is_self_extra_alias(requirement, project_name=package.name):
                     # Alias extras are policy-neutral indirections. Their concrete
-                    # requirements are validated in the referenced extra itself.
+                    # requirements are validated in the referenced extra itself,
+                    # but a supplied exact self-pin must still match this project.
+                    if not self_extra_alias_constraint_allows_project(
+                        requirement,
+                        project_name=package.name,
+                        project_version=str(project.get("version", "")),
+                    ):
+                        violations.append(
+                            f"{package.name}:{section}:{requirement}: self-extra constraint must allow {project.get('version')}"
+                        )
                     continue
                 if requirement.name.lower() not in internal_names:
                     continue
@@ -196,6 +206,30 @@ def test_internal_dependencies_follow_bundle_or_asset_version_policy() -> None:
                     )
 
     assert violations == []
+
+
+@pytest.mark.parametrize(
+    ("requirement", "expected"),
+    [
+        ("agilab[local-llm]", True),
+        ("agilab[local-llm]==2026.07.17.1", True),
+        ("agilab[local-llm]==0", False),
+        ("agilab[local-llm]<1", False),
+        ("agilab[local-llm]==2026.07.17.1,!=2026.07.17.1", False),
+    ],
+)
+def test_self_extra_alias_exact_pin_must_match_project(
+    requirement: str,
+    expected: bool,
+) -> None:
+    assert (
+        self_extra_alias_constraint_allows_project(
+            Requirement(requirement),
+            project_name="agilab",
+            project_version="2026.07.17.1",
+        )
+        is expected
+    )
 
 
 def test_queue_resilience_pages_require_the_shared_runtime_release() -> None:

--- a/test/test_package_split_contract.py
+++ b/test/test_package_split_contract.py
@@ -5,11 +5,10 @@ import sys
 import tomllib
 from pathlib import Path
 
+import pytest
 from packaging.requirements import Requirement
 from packaging.version import Version
-import pytest
 from setuptools import find_packages
-
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 TOOLS_ROOT = REPO_ROOT / "tools"
@@ -26,6 +25,7 @@ from package_split_contract import (  # noqa: E402
     ROOT_EXTRA_INTERNAL_REQUIREMENTS,
     UMBRELLA_PACKAGE_CONTRACT,
     WHEEL_ONLY_PACKAGE_NAMES,
+    is_self_extra_alias,
     package_by_name,
     project_path,
     pyproject_path,
@@ -156,6 +156,10 @@ def test_internal_dependencies_follow_bundle_or_asset_version_policy() -> None:
         for section, dependencies in dependency_sections.items():
             for dependency in dependencies:
                 requirement = Requirement(dependency)
+                if is_self_extra_alias(requirement, project_name=package.name):
+                    # Alias extras are policy-neutral indirections. Their concrete
+                    # requirements are validated in the referenced extra itself.
+                    continue
                 if requirement.name.lower() not in internal_names:
                     continue
                 exact_version = _exact_pin(requirement)

--- a/test/test_pre_push_changed_files.py
+++ b/test/test_pre_push_changed_files.py
@@ -91,6 +91,14 @@ def test_classify_infra_scopes_do_not_count_as_mixed_push_scope():
     assert state.scope_count == 0
 
 
+def test_pre_push_docs_guard_accepts_an_isolated_canonical_source():
+    hook = (ROOT / ".githooks" / "pre-push").read_text(encoding="utf-8")
+
+    assert 'if [[ -n "${AGILAB_DOCS_SOURCE:-}" ]]' in hook
+    assert 'docs_source_args=(--source "$AGILAB_DOCS_SOURCE")' in hook
+    assert '"${docs_source_args[@]}" \\' in hook
+
+
 def test_classify_agent_instruction_change_runs_agent_instruction_guard_only():
     state = pre_push_changed_files.classify_changed_files(["AGENTS.md"])
 

--- a/test/test_pre_push_changed_files.py
+++ b/test/test_pre_push_changed_files.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import importlib.util
+import os
+import subprocess
 import sys
 from pathlib import Path
-
 
 ROOT = Path(__file__).resolve().parents[1]
 MODULE_PATH = ROOT / "tools" / "pre_push_changed_files.py"
@@ -97,6 +98,47 @@ def test_pre_push_docs_guard_accepts_an_isolated_canonical_source():
     assert 'if [[ -n "${AGILAB_DOCS_SOURCE:-}" ]]' in hook
     assert 'docs_source_args=(--source "$AGILAB_DOCS_SOURCE")' in hook
     assert '"${docs_source_args[@]}" \\' in hook
+
+
+def test_pre_push_docs_source_override_fails_closed_when_missing(
+    tmp_path: Path,
+) -> None:
+    hook_root = tmp_path / "repo"
+    hooks_dir = hook_root / ".githooks"
+    hooks_dir.mkdir(parents=True)
+    hook_path = hooks_dir / "pre-push"
+    hook_path.write_text(
+        (ROOT / ".githooks" / "pre-push").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    hook_path.chmod(0o755)
+    (hooks_dir / "guard_python.sh").write_text(
+        """run_guard_python() {
+  if [[ "$1" == "tools/pre_push_changed_files.py" ]]; then
+    printf '%s\\n' 'DOCS_CHANGED=1' 'RELEASE_PROOF_CHANGED=0' \\
+      'APP_CONTRACTS_CHANGED=0' 'AGI_CORE_PROTECTED_CHANGED=0' \\
+      'AGENT_INSTRUCTIONS_CHANGED=0' 'MIXED_SCOPE=0' 'DETECTION_FAILED=0'
+  fi
+}
+""",
+        encoding="utf-8",
+    )
+    missing_source = tmp_path / "missing-canonical-source"
+    env = dict(os.environ)
+    env["AGILAB_DOCS_SOURCE"] = str(missing_source)
+
+    completed = subprocess.run(
+        [str(hook_path)],
+        cwd=hook_root,
+        input="",
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+    assert completed.returncode == 1
+    assert f"AGILAB_DOCS_SOURCE is not a directory: {missing_source}" in completed.stderr
 
 
 def test_classify_agent_instruction_change_runs_agent_instruction_guard_only():

--- a/test/test_pre_push_changed_files.py
+++ b/test/test_pre_push_changed_files.py
@@ -177,18 +177,48 @@ def test_classify_many_product_scopes_blocks_mixed_push_scope():
     assert state.scope_count == 3
 
 
-def test_pre_push_records_use_remote_sha_as_diff_base():
+def test_pre_push_records_use_default_branch_merge_base_for_topic_update():
     calls = []
 
     def fake_git(args):
         calls.append(list(args))
+        if args[:2] == ["merge-base", "localsha"]:
+            return "default-base-sha"
         return "docs/source/getting-started.rst\nsrc/agilab/main_page.py"
 
     stdin_text = "refs/heads/topic localsha refs/heads/topic remotesha\n"
     changed = pre_push_changed_files.changed_files_from_pre_push(stdin_text, git=fake_git)
 
     assert changed == ("docs/source/getting-started.rst", "src/agilab/main_page.py")
-    assert calls == [["diff", "--name-only", "--diff-filter=ACMR", "remotesha", "localsha"]]
+    assert calls == [
+        ["merge-base", "localsha", "origin/main"],
+        [
+            "diff",
+            "--name-only",
+            "--diff-filter=ACMR",
+            "default-base-sha",
+            "localsha",
+        ],
+    ]
+
+
+def test_pre_push_records_keep_remote_sha_for_main_update():
+    calls = []
+
+    def fake_git(args):
+        calls.append(list(args))
+        return "tools/release_plan.py"
+
+    stdin_text = "refs/heads/main localsha refs/heads/main remotesha\n"
+    changed = pre_push_changed_files.changed_files_from_pre_push(
+        stdin_text,
+        git=fake_git,
+    )
+
+    assert changed == ("tools/release_plan.py",)
+    assert calls == [
+        ["diff", "--name-only", "--diff-filter=ACMR", "remotesha", "localsha"]
+    ]
 
 
 def test_main_reads_pre_push_spec_file_for_hook_guard_state(tmp_path, monkeypatch, capsys):

--- a/test/test_pypi_publish_workflow.py
+++ b/test/test_pypi_publish_workflow.py
@@ -1,17 +1,19 @@
 from __future__ import annotations
 
-from pathlib import Path
 import re
 import sys
+from pathlib import Path
 
 import yaml
-
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT / "tools"))
 
-from package_split_contract import LIBRARY_PACKAGE_CONTRACTS, PACKAGE_NAMES, UMBRELLA_PACKAGE_CONTRACT  # noqa: E402
-
+from package_split_contract import (  # noqa: E402
+    LIBRARY_PACKAGE_CONTRACTS,
+    PACKAGE_NAMES,
+    UMBRELLA_PACKAGE_CONTRACT,
+)
 
 WORKFLOW_PATH = REPO_ROOT / ".github/workflows/pypi-publish.yaml"
 TEST_PYPI_WORKFLOW_PATH = REPO_ROOT / ".github/workflows/test-pypi-publish.yaml"
@@ -351,7 +353,7 @@ def test_pypi_publish_attests_and_uploads_release_supply_chain_assets() -> None:
     assert "pypi-provenance-evidence" in text
     assert "publish-release-assets:" in text
     assert "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c" in text
-    assert "actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26" in text
+    assert re.search(r"actions/attest@[0-9a-f]{40}\s+# v4\b", text)
     assert "attestations: write" in text
     assert "artifact-metadata: write" in text
     assert "subject-path: github-release-assets/**" in text

--- a/test/test_pyproject_dependency_hygiene.py
+++ b/test/test_pyproject_dependency_hygiene.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
+import sys
 import tomllib
 from pathlib import Path
-import sys
 
 from packaging.markers import default_environment
 from packaging.requirements import Requirement
 from packaging.specifiers import SpecifierSet
-
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SRC_ROOT = REPO_ROOT / "src"
@@ -21,8 +20,15 @@ import agilab as _agilab_package  # noqa: E402
 if str(SRC_PACKAGE) not in _agilab_package.__path__:
     _agilab_package.__path__.insert(0, str(SRC_PACKAGE))
 
-from agilab.app_management.app_template_registry import discover_app_templates  # noqa: E402
-from package_split_contract import PACKAGE_NAMES, ROOT_EXTRA_INTERNAL_REQUIREMENTS  # noqa: E402
+from package_split_contract import (  # noqa: E402
+    PACKAGE_NAMES,
+    ROOT_EXTRA_INTERNAL_REQUIREMENTS,
+    is_self_extra_alias,
+)
+
+from agilab.app_management.app_template_registry import (
+    discover_app_templates,  # noqa: E402
+)
 
 
 def _load_pyproject(path: Path) -> dict:
@@ -75,7 +81,7 @@ def _optional_dependencies(path: Path, extra: str, _seen: frozenset[str] = froze
         requirement = Requirement(dependency)
         # Expand self-referential extras (e.g. offline = ["agilab[local-llm]"])
         # into the aliased extra's concrete requirements.
-        if requirement.name.lower() == project_name and requirement.extras:
+        if is_self_extra_alias(requirement, project_name=project_name):
             for aliased_extra in requirement.extras:
                 if aliased_extra in _seen:
                     continue

--- a/test/test_pytest_entrypoint.py
+++ b/test/test_pytest_entrypoint.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import os
+import sys
+from types import SimpleNamespace
+
+from tools.testing import pytest_entrypoint
+
+
+def test_cleaned_environment_removes_only_uv_target_controls() -> None:
+    cleaned = pytest_entrypoint.cleaned_test_environment(
+        {
+            "UV_PROJECT_ENVIRONMENT": "/unsafe/shared-venv",
+            "UV_RUN_RECURSION_DEPTH": "1",
+            "VIRTUAL_ENV": "/unsafe/active-venv",
+            "AGILAB_TEST_SENTINEL": "preserved",
+        }
+    )
+
+    assert "UV_PROJECT_ENVIRONMENT" not in cleaned
+    assert "UV_RUN_RECURSION_DEPTH" not in cleaned
+    assert "VIRTUAL_ENV" not in cleaned
+    assert cleaned["AGILAB_TEST_SENTINEL"] == "preserved"
+
+
+def test_main_clears_uv_target_before_pytest_runs(monkeypatch) -> None:
+    seen: dict[str, object] = {}
+
+    def _pytest_main(argv):
+        seen["argv"] = list(argv)
+        seen["environment"] = dict(os.environ)
+        return 0
+
+    monkeypatch.setitem(sys.modules, "pytest", SimpleNamespace(main=_pytest_main))
+    monkeypatch.setenv("UV_PROJECT_ENVIRONMENT", "/unsafe/shared-venv")
+    monkeypatch.setenv("UV_RUN_RECURSION_DEPTH", "1")
+    monkeypatch.setenv("VIRTUAL_ENV", "/unsafe/active-venv")
+    monkeypatch.setenv("AGILAB_TEST_SENTINEL", "preserved")
+
+    assert pytest_entrypoint.main(["-q", "test/example.py"]) == 0
+
+    assert seen["argv"] == ["-q", "test/example.py"]
+    environment = seen["environment"]
+    assert isinstance(environment, dict)
+    assert "UV_PROJECT_ENVIRONMENT" not in environment
+    assert "UV_RUN_RECURSION_DEPTH" not in environment
+    assert "VIRTUAL_ENV" not in environment
+    assert environment["AGILAB_TEST_SENTINEL"] == "preserved"

--- a/test/test_root_test_runner.py
+++ b/test/test_root_test_runner.py
@@ -35,10 +35,14 @@ def test_root_test_plan_covers_every_root_file_in_stable_groups() -> None:
     }
     planned = {path for group in groups for path in group.test_files}
     by_name = {group.name: group for group in groups}
+    general_groups = [
+        group for group in groups if group.name.startswith("general:")
+    ]
 
     assert discovered <= planned
-    assert [group.name for group in groups] == [
-        "general",
+    assert len(general_groups) > 100
+    assert all(len(group.test_files) == 1 for group in general_groups)
+    assert [group.name for group in groups[-7:]] == [
         "support",
         "pipeline",
         "robots",
@@ -48,7 +52,13 @@ def test_root_test_plan_covers_every_root_file_in_stable_groups() -> None:
         "reports",
     ]
     assert "test/test_view_training_analysis.py" in by_name["views"].test_files
-    assert "test/test_view_training_analysis.py" not in by_name["general"].test_files
+    assert not any(
+        "test/test_view_training_analysis.py" in group.test_files
+        for group in general_groups
+    )
+    assert by_name["general:test_execution_playground_forms"].test_files == (
+        "test/test_execution_playground_forms.py",
+    )
     assert by_name["pages-flow"].pytest_args[-2:] == (
         "-k",
         "execute_page or experiment_page or pipeline_page_project_selectbox",
@@ -85,5 +95,5 @@ def test_root_test_runner_list_mode_is_side_effect_free(capsys) -> None:
     assert module.main(["--list"]) == 0
 
     output = capsys.readouterr().out
-    assert "general\t" in output
+    assert "general:test_agenticweb_manifest\t1" in output
     assert "views\t" in output

--- a/test/test_root_test_runner.py
+++ b/test/test_root_test_runner.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TOOLS_ROOT = REPO_ROOT / "tools"
+MODULE_PATH = TOOLS_ROOT / "testing" / "root_test_runner.py"
+
+
+def _load_module():
+    sys.path.insert(0, str(TOOLS_ROOT))
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "agilab_root_test_runner_tests", MODULE_PATH
+        )
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.path.remove(str(TOOLS_ROOT))
+
+
+def test_root_test_plan_covers_every_root_file_in_stable_groups() -> None:
+    module = _load_module()
+
+    groups = module.build_root_test_groups()
+    discovered = {
+        path.resolve().relative_to(REPO_ROOT).as_posix()
+        for path in (REPO_ROOT / "test").glob("test_*.py")
+    }
+    planned = {path for group in groups for path in group.test_files}
+    by_name = {group.name: group for group in groups}
+
+    assert discovered <= planned
+    assert [group.name for group in groups] == [
+        "general",
+        "support",
+        "pipeline",
+        "robots",
+        "pages-flow",
+        "pages-rest",
+        "views",
+        "reports",
+    ]
+    assert "test/test_view_training_analysis.py" in by_name["views"].test_files
+    assert "test/test_view_training_analysis.py" not in by_name["general"].test_files
+    assert by_name["pages-flow"].pytest_args[-2:] == (
+        "-k",
+        "execute_page or experiment_page or pipeline_page_project_selectbox",
+    )
+
+
+def test_root_test_runner_continues_after_failure_and_aggregates_exit(
+    capsys,
+) -> None:
+    module = _load_module()
+    groups = (
+        module.RootTestGroup("first", ("test/test_first.py",), ("test/test_first.py",)),
+        module.RootTestGroup("second", ("test/test_second.py",), ("test/test_second.py",)),
+    )
+    calls: list[tuple[tuple[str, ...], Path, bool]] = []
+    returncodes = iter((3, 0))
+
+    def runner(command, *, cwd, check):
+        calls.append((tuple(command), cwd, check))
+        return SimpleNamespace(returncode=next(returncodes))
+
+    assert module.run_root_test_groups(groups, runner=runner) == 3
+    assert len(calls) == 2
+    assert all(call[0][:3] == (sys.executable, "-m", "pytest") for call in calls)
+    assert all(call[1:] == (REPO_ROOT, False) for call in calls)
+    captured = capsys.readouterr().err
+    assert "[root-test] first: failed exit=3" in captured
+    assert "[root-test] second: passed" in captured
+
+
+def test_root_test_runner_list_mode_is_side_effect_free(capsys) -> None:
+    module = _load_module()
+
+    assert module.main(["--list"]) == 0
+
+    output = capsys.readouterr().out
+    assert "general\t" in output
+    assert "views\t" in output

--- a/test/test_root_test_runner.py
+++ b/test/test_root_test_runner.py
@@ -67,23 +67,34 @@ def test_root_test_plan_covers_every_root_file_in_stable_groups() -> None:
 
 def test_root_test_runner_continues_after_failure_and_aggregates_exit(
     capsys,
+    monkeypatch,
 ) -> None:
     module = _load_module()
     groups = (
         module.RootTestGroup("first", ("test/test_first.py",), ("test/test_first.py",)),
         module.RootTestGroup("second", ("test/test_second.py",), ("test/test_second.py",)),
     )
-    calls: list[tuple[tuple[str, ...], Path, bool]] = []
+    calls: list[tuple[tuple[str, ...], Path, bool, dict[str, str]]] = []
     returncodes = iter((3, 0))
 
-    def runner(command, *, cwd, check):
-        calls.append((tuple(command), cwd, check))
+    monkeypatch.setenv("UV_PROJECT_ENVIRONMENT", "/unsafe/shared-venv")
+    monkeypatch.setenv("UV_RUN_RECURSION_DEPTH", "1")
+    monkeypatch.setenv("VIRTUAL_ENV", "/unsafe/active-venv")
+    monkeypatch.setenv("AGILAB_TEST_SENTINEL", "preserved")
+
+    def runner(command, *, cwd, check, env):
+        calls.append((tuple(command), cwd, check, env))
         return SimpleNamespace(returncode=next(returncodes))
 
     assert module.run_root_test_groups(groups, runner=runner) == 3
     assert len(calls) == 2
     assert all(call[0][:3] == (sys.executable, "-m", "pytest") for call in calls)
-    assert all(call[1:] == (REPO_ROOT, False) for call in calls)
+    assert all(call[1:3] == (REPO_ROOT, False) for call in calls)
+    for _, _, _, env in calls:
+        assert "UV_PROJECT_ENVIRONMENT" not in env
+        assert "UV_RUN_RECURSION_DEPTH" not in env
+        assert "VIRTUAL_ENV" not in env
+        assert env["AGILAB_TEST_SENTINEL"] == "preserved"
     captured = capsys.readouterr().err
     assert "[root-test] first: failed exit=3" in captured
     assert "[root-test] second: passed" in captured

--- a/test/test_root_test_runner.py
+++ b/test/test_root_test_runner.py
@@ -88,7 +88,11 @@ def test_root_test_runner_continues_after_failure_and_aggregates_exit(
 
     assert module.run_root_test_groups(groups, runner=runner) == 3
     assert len(calls) == 2
-    assert all(call[0][:3] == (sys.executable, "-m", "pytest") for call in calls)
+    assert all(
+        call[0][:3]
+        == (sys.executable, "-m", "tools.testing.pytest_entrypoint")
+        for call in calls
+    )
     assert all(call[1:3] == (REPO_ROOT, False) for call in calls)
     for _, _, _, env in calls:
         assert "UV_PROJECT_ENVIRONMENT" not in env

--- a/test/test_setup_pycharm.py
+++ b/test/test_setup_pycharm.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 import importlib.util
 import logging
-from pathlib import Path
+import shutil
 import subprocess
 import sys
-from types import SimpleNamespace
 import xml.etree.ElementTree as ET
-
+from pathlib import Path
+from types import SimpleNamespace
 
 MODULE_PATH = Path("pycharm/setup_pycharm.py")
 SPEC = importlib.util.spec_from_file_location("setup_pycharm_test_module", MODULE_PATH)
@@ -621,7 +621,39 @@ def _option(config: ET.Element, name: str) -> str:
 
 
 def test_gen_app_script_preserves_builtin_app_venv_bindings(tmp_path: Path) -> None:
-    script = Path.cwd() / "pycharm" / "gen_app_script.py"
+    source_root = Path.cwd()
+    sandbox_root = tmp_path / "repo"
+    sandbox_pycharm = sandbox_root / "pycharm"
+    sandbox_pycharm.mkdir(parents=True)
+    shutil.copy2(
+        source_root / "pycharm" / "gen_app_script.py",
+        sandbox_pycharm / "gen_app_script.py",
+    )
+    shutil.copytree(
+        source_root / "pycharm" / "app-scripts",
+        sandbox_pycharm / "app-scripts",
+    )
+    sandbox_app = (
+        sandbox_root
+        / "src"
+        / "agilab"
+        / "apps"
+        / "builtin"
+        / "flight_telemetry_project"
+    )
+    sandbox_app.mkdir(parents=True)
+    shutil.copy2(
+        source_root
+        / "src"
+        / "agilab"
+        / "apps"
+        / "builtin"
+        / "flight_telemetry_project"
+        / "pyproject.toml",
+        sandbox_app / "pyproject.toml",
+    )
+    (sandbox_root / ".idea" / "runConfigurations").mkdir(parents=True)
+    script = sandbox_pycharm / "gen_app_script.py"
 
     subprocess.run(
         [sys.executable, str(script), "builtin/flight_telemetry_project"],
@@ -631,7 +663,7 @@ def test_gen_app_script_preserves_builtin_app_venv_bindings(tmp_path: Path) -> N
         text=True,
     )
 
-    run_config = _read_generated_config(tmp_path, "_flight_telemetry_run.xml")
+    run_config = _read_generated_config(sandbox_root, "_flight_telemetry_run.xml")
     run_module = run_config.find("module")
     assert run_module is not None
     assert run_module.get("name") == "flight_telemetry_project"
@@ -639,25 +671,31 @@ def test_gen_app_script_preserves_builtin_app_venv_bindings(tmp_path: Path) -> N
     assert _option(run_config, "IS_MODULE_SDK") == "false"
     assert _option(run_config, "WORKING_DIRECTORY") == "$ProjectFileDir$/src/agilab/apps/builtin/flight_telemetry_project"
 
-    worker_config = _read_generated_config(tmp_path, "_flight_telemetry_lib_worker.xml")
+    worker_config = _read_generated_config(sandbox_root, "_flight_telemetry_lib_worker.xml")
     assert _option(worker_config, "SDK_NAME") == "uv (flight_telemetry_worker)"
     assert _option(worker_config, "WORKING_DIRECTORY") == "$USER_HOME$/wenv/flight_telemetry_worker"
     assert "$USER_HOME$/wenv/flight_telemetry_worker" in _option(worker_config, "PARAMETERS")
     assert "wenv/builtin" not in _option(worker_config, "PARAMETERS")
 
-    install_config = _read_generated_config(tmp_path, "_flight_telemetry_install.xml")
+    install_config = _read_generated_config(sandbox_root, "_flight_telemetry_install.xml")
     install_module = install_config.find("module")
     assert install_module is not None
     assert install_module.get("name") == "agi-cluster"
     assert _option(install_config, "SDK_NAME") == "uv (agi-cluster)"
 
-    preinstall_config = _read_generated_config(tmp_path, "_flight_telemetry_preinstall_manager.xml")
+    preinstall_config = _read_generated_config(
+        sandbox_root,
+        "_flight_telemetry_preinstall_manager.xml",
+    )
     assert "$USER_HOME$/wenv/flight_telemetry_worker/src/flight_telemetry_worker/flight_telemetry_worker.py" in _option(
         preinstall_config,
         "PARAMETERS",
     )
 
-    manager_test = _read_generated_config(tmp_path, "_flight_telemetry_test_manager.xml")
+    manager_test = _read_generated_config(
+        sandbox_root,
+        "_flight_telemetry_test_manager.xml",
+    )
     assert _option(manager_test, "SCRIPT_NAME").endswith("/test/test_flight_telemetry_manager.py")
 
 

--- a/tools/agent_commit_provenance_guard.py
+++ b/tools/agent_commit_provenance_guard.py
@@ -241,8 +241,17 @@ def _commit_evidence(root: Path, branch: str, sha: str) -> CommitEvidence:
     )
 
 
-def _rev_list(root: Path, rev_range: str) -> tuple[str, ...]:
-    output = _run_git(root, ["rev-list", "--reverse", rev_range], check=False)
+def _rev_list(
+    root: Path,
+    rev_range: str,
+    *,
+    excluded_refs: Iterable[str] = (),
+) -> tuple[str, ...]:
+    args = ["rev-list", "--reverse", rev_range]
+    excluded = tuple(ref for ref in excluded_refs if ref)
+    if excluded:
+        args.extend(("--not", *excluded))
+    output = _run_git(root, args, check=False)
     return tuple(line for line in output.splitlines() if line.strip())
 
 
@@ -344,7 +353,11 @@ def check_pre_push_specs(
         rev_range = _rev_range_for_spec(root, spec, base_ref=base_ref)
         if not rev_range:
             continue
-        for sha in _rev_list(root, rev_range):
+        # An existing agent branch may merge an updated default branch before
+        # its next push. Those already-public base commits retain their human
+        # provenance and are not agent-authored branch work; only inspect the
+        # pushed commits that are not already reachable from the base ref.
+        for sha in _rev_list(root, rev_range, excluded_refs=(base_ref,)):
             evidence = _commit_evidence(root, branch, sha)
             commits.append(evidence)
             issues.extend(evidence.issues)

--- a/tools/agilab_dev.py
+++ b/tools/agilab_dev.py
@@ -75,7 +75,9 @@ def _pytest_command(*args: str, extras: Sequence[str] = ()) -> list[str]:
     return [
         *UV_RUN,
         *extra_args,
-        "pytest",
+        "python",
+        "-m",
+        "tools.testing.pytest_entrypoint",
         "-q",
         "-o",
         "addopts=",

--- a/tools/agilab_dev.py
+++ b/tools/agilab_dev.py
@@ -52,8 +52,8 @@ DEFAULT_UNDEFINED_NAME_LINT_TARGETS = (
     "src/agilab/core/agi-env/src/agi_env/ui/pagelib.py",
     "src/agilab/core/agi-env/test/test_pagelib.py",
 )
+ROOT_TEST_EXTRAS = ("ui", "viz", "notebook")
 PYTEST_PATH_GROUPS: tuple[tuple[tuple[str, ...], str], ...] = (
-    (("ui", "notebook"), "test"),
     ((), "src/agilab/core/test"),
     ((), "src/agilab/core/agi-cluster/test"),
     ((), "src/agilab/core/agi-env/test"),
@@ -81,6 +81,17 @@ def _pytest_command(*args: str, extras: Sequence[str] = ()) -> list[str]:
         "addopts=",
         "--import-mode=importlib",
         *args,
+    ]
+
+
+def _root_test_command() -> list[str]:
+    extra_args = [item for extra in ROOT_TEST_EXTRAS for item in ("--extra", extra)]
+    return [
+        *UV_RUN,
+        *extra_args,
+        "python",
+        "-m",
+        "tools.testing.root_test_runner",
     ]
 
 
@@ -379,8 +390,11 @@ def planned_commands(argv: Sequence[str]) -> list[list[str]]:
             extras = ("ui", "notebook") if root_tests_selected else ()
             return [_pytest_command(*args, extras=extras)]
         return [
+            _root_test_command(),
+            *(
             _pytest_command(path, extras=extras)
             for extras, path in PYTEST_PATH_GROUPS
+            ),
         ]
 
     if command == "lint":

--- a/tools/agilab_dev.py
+++ b/tools/agilab_dev.py
@@ -52,7 +52,7 @@ DEFAULT_UNDEFINED_NAME_LINT_TARGETS = (
     "src/agilab/core/agi-env/src/agi_env/ui/pagelib.py",
     "src/agilab/core/agi-env/test/test_pagelib.py",
 )
-ROOT_TEST_EXTRAS = ("ui", "viz", "notebook")
+ROOT_TEST_EXTRAS = ("dev", "ui", "viz", "notebook")
 PYTEST_PATH_GROUPS: tuple[tuple[tuple[str, ...], str], ...] = (
     ((), "src/agilab/core/test"),
     ((), "src/agilab/core/agi-cluster/test"),

--- a/tools/agilab_dev.py
+++ b/tools/agilab_dev.py
@@ -3,15 +3,16 @@
 
 from __future__ import annotations
 
+import os
 import shlex
 import subprocess
 import sys
-import os
-from datetime import datetime, timezone
+import tempfile
+from collections.abc import Sequence
+from contextlib import contextmanager
+from datetime import UTC, datetime
 from hashlib import sha256
 from pathlib import Path
-from typing import Sequence
-
 
 ROOT = Path(__file__).resolve().parents[1]
 UV_RUN = ("uv", "--preview-features", "extra-build-dependencies", "run")
@@ -51,6 +52,14 @@ DEFAULT_UNDEFINED_NAME_LINT_TARGETS = (
     "src/agilab/core/agi-env/src/agi_env/ui/pagelib.py",
     "src/agilab/core/agi-env/test/test_pagelib.py",
 )
+PYTEST_PATH_GROUPS: tuple[tuple[tuple[str, ...], str], ...] = (
+    (("ui", "notebook"), "test"),
+    ((), "src/agilab/core/test"),
+    ((), "src/agilab/core/agi-cluster/test"),
+    ((), "src/agilab/core/agi-env/test"),
+    (("ui",), "src/agilab/lib/agi-gui/test"),
+    ((), "src/agilab/lib/agi-web/test"),
+)
 
 
 def _uv_python(*args: str) -> list[str]:
@@ -59,6 +68,20 @@ def _uv_python(*args: str) -> list[str]:
 
 def _uv_dev(*args: str) -> list[str]:
     return [*UV_RUN, "--extra", "dev", *args]
+
+
+def _pytest_command(*args: str, extras: Sequence[str] = ()) -> list[str]:
+    extra_args = [item for extra in extras for item in ("--extra", extra)]
+    return [
+        *UV_RUN,
+        *extra_args,
+        "pytest",
+        "-q",
+        "-o",
+        "addopts=",
+        "--import-mode=importlib",
+        *args,
+    ]
 
 
 def _subprocess_env() -> dict[str, str]:
@@ -70,6 +93,54 @@ def _subprocess_env() -> dict[str, str]:
         env.get(DEV_UV_PROJECT_ENVIRONMENT_ENV, str(DEFAULT_DEV_UV_PROJECT_ENVIRONMENT)),
     )
     return env
+
+
+@contextmanager
+def _execution_env(shortcut: str):
+    """Yield an isolated environment for collection-sensitive repository tests."""
+
+    if shortcut != "test":
+        yield _subprocess_env()
+        return
+
+    with tempfile.TemporaryDirectory(prefix="agilab-dev-test-home-") as raw_home:
+        test_home = Path(raw_home)
+        state_root = test_home / ".local" / "share" / "agilab"
+        config_root = test_home / ".agilab"
+        state_root.mkdir(parents=True)
+        config_root.mkdir(parents=True)
+        (state_root / ".agilab-path").write_text(
+            str(ROOT / "src" / "agilab") + "\n", encoding="utf-8"
+        )
+        (config_root / ".env").write_text(
+            "AGI_CLUSTER_SHARE=\nAGI_LOCAL_SHARE=\nAPPS_REPOSITORY=\nOPENAI_API_KEY=\n",
+            encoding="utf-8",
+        )
+        env = _subprocess_env()
+        for sensitive_name in (
+            "APPS_REPOSITORY",
+            "AZURE_OPENAI_API_KEY",
+            "CLUSTER_CREDENTIALS",
+            "OPENAI_API_KEY",
+        ):
+            env.pop(sensitive_name, None)
+        home_drive = test_home.drive
+        home_path = (
+            str(test_home)[len(home_drive) :] if home_drive else str(test_home)
+        )
+        env.update(
+            {
+                "AGILAB_DISABLE_BACKGROUND_SERVICES": "1",
+                "HOME": str(test_home),
+                "USERPROFILE": str(test_home),
+                "HOMEDRIVE": home_drive,
+                "HOMEPATH": home_path,
+                "XDG_DATA_HOME": str(test_home / ".local" / "share"),
+                "LOCALAPPDATA": str(test_home / "AppData" / "Local"),
+                "APPDATA": str(test_home / "AppData" / "Roaming"),
+            }
+        )
+        yield env
 
 
 def _split_leading_values(
@@ -185,7 +256,7 @@ def _dedupe_keep_order(lines: Sequence[str]) -> list[str]:
 
 def _compact_log_path(command: Sequence[str], output: str) -> Path:
     DEV_LOG_DIR.mkdir(parents=True, exist_ok=True)
-    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
     family = Path(command[0]).name if command else "command"
     digest = sha256(
         ("\0".join(command) + "\n" + output).encode("utf-8", "replace")
@@ -212,7 +283,7 @@ def _summary_lines(
     tail_budget = max(1, max_lines - min(len(signals), signal_budget))
 
     selected: list[str] = []
-    if len(signals) > signal_budget and signal_budget > 1:
+    if len(signals) > signal_budget > 1:
         signal_sample = [signals[0], *signals[-(signal_budget - 1) :]]
     else:
         signal_sample = signals[-signal_budget:]
@@ -260,15 +331,18 @@ def _print_compact_result(
         )
 
 
-def _run_compact(command: Sequence[str], *, max_lines: int) -> int:
+def _run_compact(
+    command: Sequence[str], *, max_lines: int, env: dict[str, str] | None = None
+) -> int:
     completed = subprocess.run(
         command,
         cwd=ROOT,
-        env=_subprocess_env(),
+        env=env or _subprocess_env(),
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,
         errors="replace",
+        check=False,
     )
     _print_compact_result(
         command,
@@ -298,16 +372,15 @@ def planned_commands(argv: Sequence[str]) -> list[list[str]]:
         return [_uv_python("tools/bugfix_validate.py", *helper_args)]
 
     if command == "test":
+        if args:
+            root_tests_selected = any(
+                item == "test" or item.startswith("test/") for item in args
+            )
+            extras = ("ui", "notebook") if root_tests_selected else ()
+            return [_pytest_command(*args, extras=extras)]
         return [
-            [
-                *UV_RUN,
-                "pytest",
-                "-q",
-                "-o",
-                "addopts=",
-                "--import-mode=importlib",
-                *args,
-            ]
+            _pytest_command(path, extras=extras)
+            for extras, path in PYTEST_PATH_GROUPS
         ]
 
     if command == "lint":
@@ -618,20 +691,30 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 0
 
     commands = planned_commands(args)
-    for command in commands:
-        output = sys.stdout if print_only else sys.stderr
-        print(shlex.join(command), file=output, flush=True)
-        if print_only:
-            continue
-        if raw_output:
-            completed = subprocess.run(command, cwd=ROOT, env=_subprocess_env())
-            if completed.returncode:
-                return completed.returncode
-        else:
-            returncode = _run_compact(command, max_lines=summary_lines)
+    aggregate_returncode = 0
+    keep_going = args[0] == "test" and len(commands) > 1
+    with _execution_env(args[0]) as execution_env:
+        for command in commands:
+            output = sys.stdout if print_only else sys.stderr
+            print(shlex.join(command), file=output, flush=True)
+            if print_only:
+                continue
+            if raw_output:
+                completed = subprocess.run(
+                    command, cwd=ROOT, env=execution_env, check=False
+                )
+                returncode = completed.returncode
+            else:
+                returncode = _run_compact(
+                    command,
+                    max_lines=summary_lines,
+                    env=execution_env,
+                )
             if returncode:
-                return returncode
-    return 0
+                if not keep_going:
+                    return returncode
+                aggregate_returncode = returncode
+    return aggregate_returncode
 
 
 if __name__ == "__main__":

--- a/tools/compat_shim_inventory.py
+++ b/tools/compat_shim_inventory.py
@@ -3,15 +3,24 @@
 from __future__ import annotations
 
 import argparse
-from collections import Counter
 import json
-from pathlib import Path
 import subprocess
 import sys
+from collections import Counter
+from pathlib import Path
 from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-DEFAULT_MAX_COUNT = 254
+COMPAT_SHIM_BASELINE = {
+    "max_count": 256,
+    "owner": "AGILAB maintainers",
+    "removal_milestone": "2027.01 compatibility cleanup",
+    "rationale": (
+        "Existing legacy import paths remain supported while first-party callers "
+        "move to the classified package layout. New shims remain blocked."
+    ),
+}
+DEFAULT_MAX_COUNT = COMPAT_SHIM_BASELINE["max_count"]
 SHIM_MARKERS = (
     "Compatibility shim",
     "Compatibility import",
@@ -60,6 +69,7 @@ def build_inventory(repo_root: Path = REPO_ROOT) -> dict[str, Any]:
     by_area = Counter(_area_for(repo_root / rel, repo_root) for rel in shims)
     return {
         "schema_version": "agilab.compat_shim_inventory.v1",
+        "baseline": dict(COMPAT_SHIM_BASELINE),
         "total": len(shims),
         "max_allowed": DEFAULT_MAX_COUNT,
         "by_area": dict(sorted(by_area.items())),

--- a/tools/package_split_contract.py
+++ b/tools/package_split_contract.py
@@ -231,6 +231,25 @@ def is_self_extra_alias(
     )
 
 
+def self_extra_alias_constraint_allows_project(
+    requirement: object,
+    *,
+    project_name: str,
+    project_version: str,
+) -> bool:
+    """Reject self-extra constraints that exclude the project being installed."""
+
+    if not is_self_extra_alias(requirement, project_name=project_name):
+        return True
+    specifier_set = getattr(requirement, "specifier", None)
+    if specifier_set is None or not str(specifier_set):
+        return True
+    contains = getattr(specifier_set, "contains", None)
+    if not callable(contains):
+        return False
+    return bool(contains(project_version, prereleases=True))
+
+
 def package_by_name(name: str) -> PackageContract:
     for package in PACKAGE_CONTRACTS:
         if package.name == name:

--- a/tools/package_split_contract.py
+++ b/tools/package_split_contract.py
@@ -3,11 +3,9 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from pathlib import Path
-
-from packaging.requirements import Requirement
-from packaging.utils import canonicalize_name
 
 
 @dataclass(frozen=True)
@@ -215,14 +213,21 @@ ROOT_EXTRA_INTERNAL_REQUIREMENTS: dict[str, tuple[str, ...]] = {
 }
 
 
+def _canonicalize_distribution_name(value: str) -> str:
+    return re.sub(r"[-_.]+", "-", value).lower()
+
+
 def is_self_extra_alias(
-    requirement: Requirement, *, project_name: str
+    requirement: object, *, project_name: str
 ) -> bool:
     """Return whether a requirement aliases an extra of its own project."""
 
+    extras = getattr(requirement, "extras", ())
+    requirement_name = str(getattr(requirement, "name", ""))
     return bool(
-        requirement.extras
-        and canonicalize_name(requirement.name) == canonicalize_name(project_name)
+        extras
+        and _canonicalize_distribution_name(requirement_name)
+        == _canonicalize_distribution_name(project_name)
     )
 
 

--- a/tools/package_split_contract.py
+++ b/tools/package_split_contract.py
@@ -6,6 +6,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 
+from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
+
 
 @dataclass(frozen=True)
 class PackageContract:
@@ -210,6 +213,17 @@ ROOT_EXTRA_INTERNAL_REQUIREMENTS: dict[str, tuple[str, ...]] = {
     "examples": ("agi-apps",),
     "pages": ("agi-pages",),
 }
+
+
+def is_self_extra_alias(
+    requirement: Requirement, *, project_name: str
+) -> bool:
+    """Return whether a requirement aliases an extra of its own project."""
+
+    return bool(
+        requirement.extras
+        and canonicalize_name(requirement.name) == canonicalize_name(project_name)
+    )
 
 
 def package_by_name(name: str) -> PackageContract:

--- a/tools/pre_push_changed_files.py
+++ b/tools/pre_push_changed_files.py
@@ -139,6 +139,22 @@ def _new_branch_base(local_sha: str, git: GitRunner) -> str:
     return f"{local_sha}^"
 
 
+def _push_diff_base(
+    *,
+    local_sha: str,
+    remote_ref: str,
+    remote_sha: str,
+    git: GitRunner,
+) -> str:
+    """Return a base that represents the pushed branch, not merged main drift."""
+
+    if remote_sha == ZERO_SHA:
+        return _new_branch_base(local_sha, git)
+    if remote_ref.startswith("refs/heads/") and remote_ref != "refs/heads/main":
+        return _new_branch_base(local_sha, git)
+    return remote_sha
+
+
 def parse_pre_push_records(stdin_text: str) -> tuple[tuple[str, str, str, str], ...]:
     records: list[tuple[str, str, str, str]] = []
     for raw_line in stdin_text.splitlines():
@@ -157,10 +173,15 @@ def changed_files_from_pre_push(stdin_text: str, *, git: GitRunner = _run_git) -
         base = _remote_default_base(git)
         return tuple(sorted(_split_lines(git(["diff", "--name-only", "--diff-filter=ACMR", f"{base}...HEAD"]))))
 
-    for _local_ref, local_sha, _remote_ref, remote_sha in records:
+    for _local_ref, local_sha, remote_ref, remote_sha in records:
         if local_sha == ZERO_SHA:
             continue
-        base = _new_branch_base(local_sha, git) if remote_sha == ZERO_SHA else remote_sha
+        base = _push_diff_base(
+            local_sha=local_sha,
+            remote_ref=remote_ref,
+            remote_sha=remote_sha,
+            git=git,
+        )
         changed.update(_split_lines(git(["diff", "--name-only", "--diff-filter=ACMR", base, local_sha])))
     return tuple(sorted(changed))
 

--- a/tools/testing/pytest_entrypoint.py
+++ b/tools/testing/pytest_entrypoint.py
@@ -1,0 +1,42 @@
+"""Run pytest without leaking the shared uv target into nested test commands."""
+
+from __future__ import annotations
+
+import os
+import sys
+from collections.abc import Mapping, Sequence
+
+UV_TARGET_ENVIRONMENT_KEYS = (
+    "UV_PROJECT_ENVIRONMENT",
+    "UV_RUN_RECURSION_DEPTH",
+    "VIRTUAL_ENV",
+)
+
+
+def cleaned_test_environment(
+    source: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    """Return an environment safe for tests that invoke uv recursively."""
+
+    env = dict(os.environ if source is None else source)
+    for name in UV_TARGET_ENVIRONMENT_KEYS:
+        env.pop(name, None)
+    return env
+
+
+def clear_uv_target_environment() -> None:
+    """Stop nested uv commands from syncing the shared test environment."""
+
+    for name in UV_TARGET_ENVIRONMENT_KEYS:
+        os.environ.pop(name, None)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    clear_uv_target_environment()
+    import pytest
+
+    return int(pytest.main(list(sys.argv[1:] if argv is None else argv)))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/testing/root_test_runner.py
+++ b/tools/testing/root_test_runner.py
@@ -93,9 +93,13 @@ def build_root_test_groups() -> tuple[RootTestGroup, ...]:
         _repo_relative(path) for path in sorted(ROOT_TEST_DIR.glob("test_*.py"))
     )
     general = tuple(path for path in discovered if path not in classified)
-    groups: list[RootTestGroup] = []
-    if general:
-        groups.append(RootTestGroup("general", general, general))
+    # The unclassified root tests contain several dynamic-import and Streamlit
+    # harnesses that intentionally replace process-global modules. Give each
+    # file its own interpreter so one test module cannot corrupt a later one.
+    groups = [
+        RootTestGroup(f"general:{Path(path).stem}", (path,), (path,))
+        for path in general
+    ]
     groups.extend(chunk_groups)
 
     planned = {path for group in groups for path in group.test_files}

--- a/tools/testing/root_test_runner.py
+++ b/tools/testing/root_test_runner.py
@@ -10,7 +10,6 @@ runs the remaining root files in a separate process.
 from __future__ import annotations
 
 import argparse
-import os
 import subprocess
 import sys
 from collections.abc import Callable, Sequence
@@ -18,6 +17,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from tools.coverage_shard_plan import static_chunk_args
+from tools.testing.pytest_entrypoint import cleaned_test_environment
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 ROOT_TEST_DIR = REPO_ROOT / "test"
@@ -116,7 +116,7 @@ def _pytest_command(group: RootTestGroup) -> tuple[str, ...]:
     return (
         sys.executable,
         "-m",
-        "pytest",
+        "tools.testing.pytest_entrypoint",
         "-q",
         "-o",
         "addopts=",
@@ -128,10 +128,7 @@ def _pytest_command(group: RootTestGroup) -> tuple[str, ...]:
 def _pytest_environment() -> dict[str, str]:
     """Keep nested uv operations from mutating the runner's environment."""
 
-    env = dict(os.environ)
-    for name in ("UV_PROJECT_ENVIRONMENT", "UV_RUN_RECURSION_DEPTH", "VIRTUAL_ENV"):
-        env.pop(name, None)
-    return env
+    return cleaned_test_environment()
 
 
 def run_root_test_groups(

--- a/tools/testing/root_test_runner.py
+++ b/tools/testing/root_test_runner.py
@@ -10,6 +10,7 @@ runs the remaining root files in a separate process.
 from __future__ import annotations
 
 import argparse
+import os
 import subprocess
 import sys
 from collections.abc import Callable, Sequence
@@ -124,6 +125,15 @@ def _pytest_command(group: RootTestGroup) -> tuple[str, ...]:
     )
 
 
+def _pytest_environment() -> dict[str, str]:
+    """Keep nested uv operations from mutating the runner's environment."""
+
+    env = dict(os.environ)
+    for name in ("UV_PROJECT_ENVIRONMENT", "UV_RUN_RECURSION_DEPTH", "VIRTUAL_ENV"):
+        env.pop(name, None)
+    return env
+
+
 def run_root_test_groups(
     groups: Sequence[RootTestGroup],
     *,
@@ -138,7 +148,12 @@ def run_root_test_groups(
             file=sys.stderr,
             flush=True,
         )
-        completed = runner(_pytest_command(group), cwd=REPO_ROOT, check=False)
+        completed = runner(
+            _pytest_command(group),
+            cwd=REPO_ROOT,
+            check=False,
+            env=_pytest_environment(),
+        )
         if completed.returncode:
             aggregate_returncode = aggregate_returncode or completed.returncode
             print(

--- a/tools/testing/root_test_runner.py
+++ b/tools/testing/root_test_runner.py
@@ -1,0 +1,173 @@
+"""Run root tests in existing coverage-contract process boundaries.
+
+Many root tests intentionally replace imported modules while exercising optional
+dependencies and dynamic app loading. Running every file in one interpreter lets
+that state leak into later files. The coverage workflow already maintains stable
+GUI-oriented chunks, so the local canonical gate reuses those boundaries and
+runs the remaining root files in a separate process.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+from tools.coverage_shard_plan import static_chunk_args
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ROOT_TEST_DIR = REPO_ROOT / "test"
+PYTEST_OPTIONS_WITH_VALUES = frozenset({"-k", "-m", "-o"})
+
+
+@dataclass(frozen=True)
+class RootTestGroup:
+    name: str
+    pytest_args: tuple[str, ...]
+    test_files: tuple[str, ...]
+
+
+def _repo_relative(path: Path) -> str:
+    return path.resolve().relative_to(REPO_ROOT).as_posix()
+
+
+def _expand_test_target(target: str) -> tuple[str, ...]:
+    if any(token in target for token in "*?["):
+        matches = sorted(REPO_ROOT.glob(target))
+    else:
+        path = REPO_ROOT / target
+        if path.is_dir():
+            matches = sorted(path.rglob("test*.py"))
+        elif path.is_file():
+            matches = [path]
+        else:
+            matches = []
+    return tuple(
+        _repo_relative(path)
+        for path in matches
+        if path.is_file() and _repo_relative(path).startswith("test/")
+    )
+
+
+def _expand_chunk_args(
+    args: Sequence[str],
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    expanded: list[str] = []
+    test_files: list[str] = []
+    index = 0
+    while index < len(args):
+        arg = args[index]
+        if arg in PYTEST_OPTIONS_WITH_VALUES:
+            if index + 1 >= len(args):
+                raise ValueError(f"pytest option {arg} is missing its value")
+            expanded.extend((arg, args[index + 1]))
+            index += 2
+            continue
+        if arg.startswith("-"):
+            expanded.append(arg)
+            index += 1
+            continue
+        paths = _expand_test_target(arg)
+        expanded.extend(paths)
+        test_files.extend(paths)
+        index += 1
+    return tuple(expanded), tuple(dict.fromkeys(test_files))
+
+
+def build_root_test_groups() -> tuple[RootTestGroup, ...]:
+    """Return deterministic root-test groups with complete file coverage."""
+
+    chunk_groups: list[RootTestGroup] = []
+    classified: set[str] = set()
+    for name, args in static_chunk_args().items():
+        expanded_args, test_files = _expand_chunk_args(args)
+        if not test_files:
+            continue
+        classified.update(test_files)
+        chunk_groups.append(RootTestGroup(name, expanded_args, test_files))
+
+    discovered = tuple(
+        _repo_relative(path) for path in sorted(ROOT_TEST_DIR.glob("test_*.py"))
+    )
+    general = tuple(path for path in discovered if path not in classified)
+    groups: list[RootTestGroup] = []
+    if general:
+        groups.append(RootTestGroup("general", general, general))
+    groups.extend(chunk_groups)
+
+    planned = {path for group in groups for path in group.test_files}
+    missing = sorted(set(discovered) - planned)
+    if missing:
+        raise RuntimeError(
+            "root test plan omitted files: " + ", ".join(missing)
+        )
+    return tuple(groups)
+
+
+def _pytest_command(group: RootTestGroup) -> tuple[str, ...]:
+    return (
+        sys.executable,
+        "-m",
+        "pytest",
+        "-q",
+        "-o",
+        "addopts=",
+        "--import-mode=importlib",
+        *group.pytest_args,
+    )
+
+
+def run_root_test_groups(
+    groups: Sequence[RootTestGroup],
+    *,
+    runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+) -> int:
+    """Run every group in a fresh interpreter and aggregate failures."""
+
+    aggregate_returncode = 0
+    for group in groups:
+        print(
+            f"[root-test] {group.name}: {len(group.test_files)} file(s)",
+            file=sys.stderr,
+            flush=True,
+        )
+        completed = runner(_pytest_command(group), cwd=REPO_ROOT, check=False)
+        if completed.returncode:
+            aggregate_returncode = aggregate_returncode or completed.returncode
+            print(
+                f"[root-test] {group.name}: failed exit={completed.returncode}",
+                file=sys.stderr,
+                flush=True,
+            )
+        else:
+            print(
+                f"[root-test] {group.name}: passed",
+                file=sys.stderr,
+                flush=True,
+            )
+    return aggregate_returncode
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Run root tests in isolated coverage-contract groups."
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="Print the group names and test-file counts without running pytest.",
+    )
+    args = parser.parse_args(argv)
+    groups = build_root_test_groups()
+    if args.list:
+        for group in groups:
+            print(f"{group.name}\t{len(group.test_files)}")
+        return 0
+    return run_root_test_groups(groups)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Repro

- The canonical `./dev test` path shared one dependency environment and inherited user checkout state. Nested `uv` tests could prune `.venv-dev`, while collection-sensitive root tests leaked process-global imports into later files.
- Targeted root-test invocations bypassed the isolated runner.
- Self-extra aliases were compared by name only, so incompatible version constraints could pass the package-split contract.
- An explicit missing canonical docs source could be skipped instead of failing closed.
- Updating an existing agent branch with current `main` made the pre-push provenance and mixed-scope guards treat already-public maintainer commits as new branch work.

## Root Cause

The test shortcut lacked stable process boundaries and did not clear nested-`uv` environment variables at the pytest entrypoint. Package policy normalized self-extra names without evaluating their specifiers. The docs hook did not distinguish an explicit operator path from a missing conventional sibling. Both pre-push inventories based existing feature-branch updates on the stale remote branch SHA instead of excluding or diffing from the current default branch.

## Regression Test

- Added a deterministic root-test runner using the established coverage chunks plus per-file isolation for unclassified root tests.
- Added a pytest entrypoint that clears `UV_PROJECT_ENVIRONMENT`, `UV_RUN_RECURSION_DEPTH`, and `VIRTUAL_ENV` before nested test execution.
- Added shortcut regressions for dependency partitions, isolated HOME and credential state, aggregate exits, and targeted invocations.
- Added exact self-extra constraint checks against the current project version, including contradictory and mismatched ranges.
- Added fail-closed explicit docs-source tests.
- Added polluted-history regressions proving public `main` commits are excluded from agent provenance and feature-scope classification while direct `main` pushes still use the remote SHA.

## Validation

- Full `./dev test` passed on current `origin/main` across root, core, cluster, environment, GUI, and web groups.
- Public demo link contract: 49 passed.
- Pre-push/provenance focused slice: 25 passed.
- Independent focused quality/contracts slice: 157 passed.
- Exact nested-`uv` regression passed and `.venv-dev` retained pytest.
- Impact validation, agent provenance, scope classification, and all local pre-push guards passed.
- Hosted checks passed: repository policy, Windows core, Python 3.13/3.14 compatibility, clean public installs on Ubuntu/macOS/Windows, and GitGuardian. `public-demo-smoke` was skipped by path policy.

## Review Evidence

- Codex sub-agent `quality_systems` used inherited GPT-5 and edited the initial quality-gate lane.
- Codex sub-agent `quality_pr_review` used inherited GPT-5 for read-only review. It found targeted-runner bypass, nested-`uv` mutation, explicit docs-source fail-open behavior, and self-extra constraint gaps. All findings were addressed; the follow-up review was clean.
- The root agent found and fixed two polluted-history pre-push inventory defects during final publication.
- No reviewer sub-agent edited files.

## Agent Metadata

- Tokki version: 1.0.34
- Agent/runtime: Codex; runtime version unavailable
- Model: GPT-5
- Reasoning effort: unknown
- /fast mode: not used