### PR TITLE
fix(runtime): reap timed-out worker processes

### DIFF
--- a/src/agilab/core/agi-env/src/agi_env/runtime/execution_support.py
+++ b/src/agilab/core/agi-env/src/agi_env/runtime/execution_support.py
@@ -8,6 +8,7 @@ import logging
 import os
 import re
 import shlex
+import signal
 import subprocess
 import sys
 import traceback
@@ -139,9 +140,29 @@ async def _spawn_process(
     process_env: dict[str, str],
     shell_executable: str | None = None,
     allow_shell: bool = True,
+    start_owned_session: bool = False,
     stdout: int | None = asyncio.subprocess.PIPE,
     stderr: int | None = asyncio.subprocess.PIPE,
 ) -> asyncio.subprocess.Process:
+    # POSIX sessions give cancellation/timeout cleanup a process-group
+    # ownership boundary. Windows deliberately keeps direct-child ownership:
+    # there is no asyncio group-kill equivalent and broad taskkill matching is
+    # unsafe. In both cases the launched child itself is always killed/reaped.
+    session_options = (
+        {"start_new_session": True}
+        if start_owned_session and os.name != "nt"
+        else {}
+    )
+
+    async def _record_owned_session(
+        awaitable: Awaitable[asyncio.subprocess.Process],
+    ) -> asyncio.subprocess.Process:
+        proc = await awaitable
+        if session_options:
+            with contextlib.suppress(AttributeError, TypeError):
+                setattr(proc, "_agilab_started_new_session", True)
+        return proc
+
     # ``VAR=value prog args`` commands need no shell: apply the assignments to
     # the child env and exec directly. This keeps env-prefixed deploy commands
     # working on Windows, where the fallback shell (cmd.exe) cannot parse
@@ -149,31 +170,40 @@ async def _spawn_process(
     assignment_split = _split_leading_env_assignments(cmd)
     if assignment_split is not None:
         env_updates, argv = assignment_split
-        return await asyncio.create_subprocess_exec(
-            *argv,
-            stdout=stdout,
-            stderr=stderr,
-            cwd=str(cwd) if cwd else None,
-            env={**process_env, **env_updates},
+        return await _record_owned_session(
+            asyncio.create_subprocess_exec(
+                *argv,
+                stdout=stdout,
+                stderr=stderr,
+                cwd=str(cwd) if cwd else None,
+                env={**process_env, **env_updates},
+                **session_options,
+            )
         )
     if _command_requires_shell(cmd):
         if not allow_shell:
             raise ValueError(f"Shell syntax is not allowed for this command: {cmd}")
-        return await asyncio.create_subprocess_shell(
-            cmd,
+        return await _record_owned_session(
+            asyncio.create_subprocess_shell(
+                cmd,
+                stdout=stdout,
+                stderr=stderr,
+                cwd=str(cwd) if cwd else None,
+                env=process_env,
+                executable=shell_executable,
+                **session_options,
+            )
+        )
+    cmd_list = shlex.split(cmd)
+    return await _record_owned_session(
+        asyncio.create_subprocess_exec(
+            *cmd_list,
             stdout=stdout,
             stderr=stderr,
             cwd=str(cwd) if cwd else None,
             env=process_env,
-            executable=shell_executable,
+            **session_options,
         )
-    cmd_list = shlex.split(cmd)
-    return await asyncio.create_subprocess_exec(
-        *cmd_list,
-        stdout=stdout,
-        stderr=stderr,
-        cwd=str(cwd) if cwd else None,
-        env=process_env,
     )
 
 
@@ -196,12 +226,39 @@ async def _stream_process_output(
 
 
 async def _kill_and_wait(proc: asyncio.subprocess.Process) -> None:
-    """Terminate a timed-out subprocess and reap it when the platform permits."""
+    """Kill the owned subprocess boundary and reap its direct child.
 
-    kill = getattr(proc, "kill", None)
-    if callable(kill):
-        with contextlib.suppress(ProcessLookupError, OSError):
-            kill()
+    ``run_async`` starts a new POSIX session, so a live child whose process
+    group still equals its PID proves ownership of that group and lets cleanup
+    include descendants. Other launches and Windows fall back to the exact
+    child handle; no PID scanning or broad process matching is performed.
+    """
+
+    killed_owned_group = False
+    if os.name != "nt" and bool(
+        getattr(proc, "_agilab_started_new_session", False)
+    ):
+        try:
+            pid = int(proc.pid)
+            process_group = os.getpgid(pid)
+            if process_group == pid and process_group != os.getpgrp():
+                os.killpg(process_group, signal.SIGKILL)
+                killed_owned_group = True
+        except (
+            AttributeError,
+            ProcessLookupError,
+            PermissionError,
+            TypeError,
+            ValueError,
+            OSError,
+        ):
+            pass
+
+    if not killed_owned_group:
+        kill = getattr(proc, "kill", None)
+        if callable(kill):
+            with contextlib.suppress(ProcessLookupError, OSError):
+                kill()
     with contextlib.suppress(asyncio.TimeoutError, ProcessLookupError, OSError):
         await asyncio.wait_for(proc.wait(), timeout=5)
 
@@ -464,6 +521,7 @@ async def run_async(
             cwd=cwd,
             process_env=process_env,
             shell_executable=shell_executable,
+            start_owned_session=True,
         )
 
         out_cb, err_cb = _resolve_stream_callbacks(log_callback=log_callback, logger=logger)
@@ -475,10 +533,20 @@ async def run_async(
             result=result,
             wait_for_exit=True,
         )
+    except asyncio.CancelledError:
+        if proc is not None:
+            await _kill_and_wait_shielded(proc)
+        raise
+    except asyncio.TimeoutError as err:
+        if proc is not None:
+            await _kill_and_wait(proc)
+        raise RuntimeError(f"Command timed out after {timeout} seconds: {cmd}") from err
     except PROCESS_WRAP_EXCEPTIONS as err:
+        if proc is not None:
+            await _kill_and_wait(proc)
         _raise_process_error(
             err,
-            proc=proc,
+            proc=None,
             logger=logger,
             wrap_message=f"Subprocess execution error for: {cmd}",
             command_context=f"Error during: {cmd}",

--- a/src/agilab/core/agi-env/test/test_execution_support.py
+++ b/src/agilab/core/agi-env/test/test_execution_support.py
@@ -338,10 +338,13 @@ def test_kill_and_wait_terminates_verified_owned_posix_group(monkeypatch):
         ),
         raising=False,
     )
+    monkeypatch.setattr(
+        execution_support.signal, "SIGKILL", 9, raising=False
+    )
 
     asyncio.run(execution_support._kill_and_wait(proc))
 
-    assert killpg_calls == [(4321, execution_support.signal.SIGKILL)]
+    assert killpg_calls == [(4321, 9)]
     assert proc.kill_calls == 0
     assert proc.wait_calls == 1
 

--- a/src/agilab/core/agi-env/test/test_execution_support.py
+++ b/src/agilab/core/agi-env/test/test_execution_support.py
@@ -4,8 +4,10 @@ import asyncio
 from pathlib import Path
 import subprocess
 import sys
+import time
 from unittest import mock
 
+import psutil
 import pytest
 
 import agi_env.execution_support as execution_support
@@ -201,6 +203,43 @@ def test_spawn_process_can_disable_shell_syntax(tmp_path: Path):
         )
 
 
+@pytest.mark.parametrize(
+    ("os_name", "expects_owned_session"),
+    [("posix", True), ("nt", False)],
+)
+def test_spawn_process_marks_owned_session_only_on_posix(
+    tmp_path: Path,
+    monkeypatch,
+    os_name: str,
+    expects_owned_session: bool,
+):
+    captured: dict[str, object] = {}
+    proc = _FakeProc()
+
+    async def _fake_exec(*_args, **kwargs):
+        captured.update(kwargs)
+        return proc
+
+    monkeypatch.setattr(execution_support.os, "name", os_name)
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_exec)
+
+    result = asyncio.run(
+        execution_support._spawn_process(
+            cmd="echo hi",
+            cwd=tmp_path,
+            process_env={"PYTHONUNBUFFERED": "1"},
+            start_owned_session=True,
+        )
+    )
+
+    assert result is proc
+    assert captured.get("start_new_session", False) is expects_owned_session
+    assert (
+        bool(getattr(proc, "_agilab_started_new_session", False))
+        is expects_owned_session
+    )
+
+
 def test_spawn_process_propagates_unexpected_exec_bug(tmp_path: Path, monkeypatch):
     async def _raise_exec(*_args, **_kwargs):
         raise RuntimeError("exec bug")
@@ -277,6 +316,41 @@ def test_run_cancellation_kills_and_reaps_spawned_process(tmp_path: Path, monkey
         assert proc.reaped is True
 
     asyncio.run(_case())
+
+
+def test_kill_and_wait_terminates_verified_owned_posix_group(monkeypatch):
+    proc = _FakeProc()
+    proc.pid = 4321
+    proc._agilab_started_new_session = True
+    killpg_calls: list[tuple[int, int]] = []
+
+    monkeypatch.setattr(execution_support.os, "name", "posix")
+    monkeypatch.setattr(execution_support.os, "getpgid", lambda pid: pid)
+    monkeypatch.setattr(execution_support.os, "getpgrp", lambda: 9876)
+    monkeypatch.setattr(
+        execution_support.os,
+        "killpg",
+        lambda process_group, signal_number: killpg_calls.append(
+            (process_group, signal_number)
+        ),
+    )
+
+    asyncio.run(execution_support._kill_and_wait(proc))
+
+    assert killpg_calls == [(4321, execution_support.signal.SIGKILL)]
+    assert proc.kill_calls == 0
+    assert proc.wait_calls == 1
+
+
+def test_kill_and_wait_windows_uses_exact_child_handle(monkeypatch):
+    proc = _FakeProc()
+    proc._agilab_started_new_session = True
+    monkeypatch.setattr(execution_support.os, "name", "nt")
+
+    asyncio.run(execution_support._kill_and_wait(proc))
+
+    assert proc.kill_calls == 1
+    assert proc.wait_calls == 1
 
 
 def test_stream_process_output_collects_lines_and_waits_for_proc():
@@ -642,6 +716,130 @@ def test_run_async_uses_shell_for_shell_syntax(tmp_path: Path, monkeypatch):
     result = asyncio.run(execution_support.run_async("echo hi; echo bye", venv=tmp_path, cwd=tmp_path))
 
     assert result == "stderr line"
+
+
+def test_run_async_cancellation_kills_and_reaps_spawned_process(
+    tmp_path: Path,
+    monkeypatch,
+):
+    async def _case():
+        proc = _CancellationProc()
+        spawn = mock.AsyncMock(return_value=proc)
+        monkeypatch.setattr(execution_support, "_spawn_process", spawn)
+
+        task = asyncio.create_task(
+            execution_support.run_async("echo ok", venv=tmp_path, cwd=tmp_path)
+        )
+        await proc.wait_started.wait()
+        task.cancel()
+
+        cleanup_observed = False
+        repeated_cancellation_waited_for_cleanup = False
+        try:
+            await asyncio.wait_for(proc.cleanup_started.wait(), timeout=0.2)
+            cleanup_observed = True
+            task.cancel()
+            await asyncio.sleep(0)
+            repeated_cancellation_waited_for_cleanup = not task.done()
+        except asyncio.TimeoutError:
+            pass
+        finally:
+            proc.allow_cleanup.set()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert spawn.await_args.kwargs["start_owned_session"] is True
+        assert cleanup_observed is True
+        assert repeated_cancellation_waited_for_cleanup is True
+        assert proc.kill_calls == 1
+        assert proc.wait_calls == 2
+        assert proc.reaped is True
+
+    asyncio.run(_case())
+
+
+def test_run_async_timeout_kills_reaps_and_reports_command(
+    tmp_path: Path,
+    monkeypatch,
+):
+    proc = _FakeProc()
+    spawn = mock.AsyncMock(return_value=proc)
+    monkeypatch.setattr(execution_support, "_spawn_process", spawn)
+    monkeypatch.setattr(
+        execution_support,
+        "_stream_process_output",
+        mock.AsyncMock(side_effect=asyncio.TimeoutError()),
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"Command timed out after 0\.25 seconds: echo slow",
+    ):
+        asyncio.run(
+            execution_support.run_async(
+                "echo slow",
+                venv=tmp_path,
+                cwd=tmp_path,
+                timeout=0.25,
+            )
+        )
+
+    assert spawn.await_args.kwargs["start_owned_session"] is True
+    assert proc.kill_calls == 1
+    assert proc.wait_calls == 1
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX process-group contract")
+def test_run_async_timeout_terminates_owned_posix_descendant(tmp_path: Path):
+    child_pid_file = tmp_path / "descendant.pid"
+    launcher = tmp_path / "launch_descendant.py"
+    launcher.write_text(
+        "\n".join(
+            [
+                "import subprocess",
+                "import sys",
+                "import time",
+                "child = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(30)'])",
+                "with open(sys.argv[1], 'w', encoding='utf-8') as stream:",
+                "    stream.write(str(child.pid))",
+                "time.sleep(30)",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    cmd = subprocess.list2cmdline(
+        [sys.executable, str(launcher), str(child_pid_file)]
+    )
+
+    def _descendant_is_live(pid: int) -> bool:
+        try:
+            process = psutil.Process(pid)
+            return process.is_running() and process.status() != psutil.STATUS_ZOMBIE
+        except (psutil.NoSuchProcess, psutil.ZombieProcess):
+            return False
+
+    child_pid = None
+    try:
+        with pytest.raises(RuntimeError, match="Command timed out after"):
+            asyncio.run(
+                execution_support.run_async(
+                    cmd,
+                    cwd=tmp_path,
+                    timeout=0.5,
+                    build_env_fn=lambda _venv: {},
+                )
+            )
+        child_pid = int(child_pid_file.read_text(encoding="utf-8"))
+        deadline = time.monotonic() + 2.0
+        while _descendant_is_live(child_pid) and time.monotonic() < deadline:
+            time.sleep(0.02)
+        assert _descendant_is_live(child_pid) is False
+    finally:
+        if child_pid is not None and _descendant_is_live(child_pid):
+            process = psutil.Process(child_pid)
+            process.kill()
+            process.wait(timeout=2.0)
 
 
 def test_run_async_propagates_unexpected_exec_bug(tmp_path: Path, monkeypatch):

--- a/src/agilab/core/agi-env/test/test_execution_support.py
+++ b/src/agilab/core/agi-env/test/test_execution_support.py
@@ -1,16 +1,15 @@
 from __future__ import annotations
 
 import asyncio
-from pathlib import Path
 import subprocess
 import sys
 import time
+from pathlib import Path
 from unittest import mock
 
+import agi_env.execution_support as execution_support
 import psutil
 import pytest
-
-import agi_env.execution_support as execution_support
 
 
 class _FakeStream:
@@ -325,14 +324,19 @@ def test_kill_and_wait_terminates_verified_owned_posix_group(monkeypatch):
     killpg_calls: list[tuple[int, int]] = []
 
     monkeypatch.setattr(execution_support.os, "name", "posix")
-    monkeypatch.setattr(execution_support.os, "getpgid", lambda pid: pid)
-    monkeypatch.setattr(execution_support.os, "getpgrp", lambda: 9876)
+    monkeypatch.setattr(
+        execution_support.os, "getpgid", lambda pid: pid, raising=False
+    )
+    monkeypatch.setattr(
+        execution_support.os, "getpgrp", lambda: 9876, raising=False
+    )
     monkeypatch.setattr(
         execution_support.os,
         "killpg",
         lambda process_group, signal_number: killpg_calls.append(
             (process_group, signal_number)
         ),
+        raising=False,
     )
 
     asyncio.run(execution_support._kill_and_wait(proc))

--- a/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/worker_pool_support.py
+++ b/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/worker_pool_support.py
@@ -79,6 +79,10 @@ _POOL_ITEM_BOUNDARY_EXCEPTIONS: tuple[type[Exception], ...] = (Exception,)
 _POOL_RUNTIME_WORKER: Any = None
 
 
+class _PoolItemTimeoutError(RuntimeError):
+    """Internal marker for an executor that has already been abandoned."""
+
+
 @dataclass(frozen=True)
 class PoolFrameHooks:
     """Per worker-family hooks used by the shared pool engine."""
@@ -325,16 +329,30 @@ def exec_multi_process(
     )
 
     worker.work_init()
-    with executor_factory(
+    executor_manager = executor_factory(
         max_workers=width,
         initializer=_pool_child_init,
         initargs=(worker, worker.pool_vars),
-    ) as executor:
+    )
+    executor = executor_manager.__enter__()
+    try:
         for work_id, work in enumerate(chunks):
             results = _run_chunk(
                 executor, worker, hooks, work_id, list(work), width, item_timeout
             )
             _finish_chunk(worker, hooks, results)
+    except _PoolItemTimeoutError:
+        # _run_chunk already requested non-blocking shutdown. Calling normal
+        # context-manager exit here would call shutdown(wait=True), wait for a
+        # thread straggler, and violate the configured deadline.
+        raise
+    except BaseException:
+        # Preserve normal context-manager cleanup and suppression semantics for
+        # every non-timeout exit.
+        if not executor_manager.__exit__(*sys.exc_info()):
+            raise
+    else:
+        executor_manager.__exit__(None, None, None)
 
 
 def _batches(indexed: list[tuple[int, Any]], chunksize: int) -> list[list[tuple[int, Any]]]:
@@ -351,21 +369,23 @@ def _abandon_stuck_pool(executor: Any) -> None:
     task). Thread pools cannot be force-stopped; their stragglers are left
     running and the caller's error message says so.
     """
+    processes = getattr(executor, "_processes", None)
+    owned_processes = list(processes.values()) if isinstance(processes, dict) else []
     try:
         executor.shutdown(wait=False, cancel_futures=True)
     # Defensive: a stuck pool must not be able to mask the timeout error.
     except Exception:
         pass
-    processes = getattr(executor, "_processes", None)
-    if isinstance(processes, dict):
-        for process in list(processes.values()):
-            terminate = getattr(process, "terminate", None)
-            if callable(terminate):
-                try:
-                    terminate()
-                # Defensive: child reaping is best-effort during abandonment.
-                except Exception:
-                    pass
+    # ProcessPoolExecutor clears its private process table during shutdown,
+    # including wait=False, so retain the exact handles before that call.
+    for process in owned_processes:
+        terminate = getattr(process, "terminate", None)
+        if callable(terminate):
+            try:
+                terminate()
+            # Defensive: child reaping is best-effort during abandonment.
+            except Exception:
+                pass
 
 
 def _run_chunk(
@@ -408,7 +428,7 @@ def _run_chunk(
         preview = ", ".join(repr(item) for item in pending[:3])
         if len(pending) > 3:
             preview += ", ..."
-        raise RuntimeError(
+        raise _PoolItemTimeoutError(
             f"{hooks.family}.work_pool exceeded the {item_timeout}s per-item time "
             f"budget on chunk #{work_id} ({deadline:.1f}s chunk deadline); "
             f"{len(pending)} item(s) still pending: {preview}. Process-pool "

--- a/src/agilab/core/test/test_worker_pool_support.py
+++ b/src/agilab/core/test/test_worker_pool_support.py
@@ -1,6 +1,7 @@
 """Tests for the shared in-worker pool engine (agi_node.agi_dispatcher.worker_pool_support)."""
 
 import logging
+import threading
 import time
 from concurrent.futures import Future
 from concurrent.futures.process import BrokenProcessPool
@@ -308,8 +309,8 @@ def test_timed_out_chunk_raises_and_abandons_pool(monkeypatch):
         worker_pool_support.exec_multi_process(
             worker, {0: [["slow1", "slow2"]]}, None, _pandas_hooks(StuckPool)
         )
-    # The stuck pool was abandoned without waiting, so the with-block exit
-    # cannot hang behind the stuck task.
+    # The stuck pool is abandoned without waiting. The executor lifecycle must
+    # not invoke a second, blocking shutdown after this call.
     assert (False, True) in StuckPool.abandoned
 
 
@@ -328,11 +329,48 @@ def test_abandon_stuck_pool_terminates_process_children():
 
         def shutdown(self, wait=True, cancel_futures=False):
             self.shutdown_calls.append((wait, cancel_futures))
+            # Match ProcessPoolExecutor: shutdown clears the private process
+            # table even when wait=False.
+            self._processes = None
 
     executor = FakeExecutor()
+    processes = list(executor._processes.values())
     worker_pool_support._abandon_stuck_pool(executor)
     assert executor.shutdown_calls == [(False, True)]
-    assert all(p.terminated for p in executor._processes.values())
+    assert all(process.terminated for process in processes)
+
+
+def test_thread_pool_timeout_returns_before_straggler_finishes(monkeypatch):
+    release_work = threading.Event()
+    work_finished = threading.Event()
+
+    class SlowWorker(EngineWorker):
+        def _actual_work_pool(self, x):
+            try:
+                release_work.wait(timeout=1.0)
+                return pd.DataFrame({"col": [x]})
+            finally:
+                work_finished.set()
+
+    monkeypatch.setattr(worker_pool_support, "_POOL_TIMEOUT_GRACE_SECONDS", 0.02)
+    worker = SlowWorker(mode=1)
+    worker.args = {"output_format": "csv", "pool_item_timeout": 0.02}
+
+    started_at = time.perf_counter()
+    try:
+        with pytest.raises(RuntimeError, match="thread-pool stragglers"):
+            worker_pool_support.exec_multi_process(
+                worker,
+                {0: [["slow"]]},
+                None,
+                _pandas_hooks(worker_pool_support.ThreadPoolExecutor),
+            )
+    finally:
+        elapsed = time.perf_counter() - started_at
+        release_work.set()
+        assert work_finished.wait(timeout=1.0)
+
+    assert elapsed < 0.4
 
 
 # --- executor backend selection -------------------------------------------


### PR DESCRIPTION
## Repro
Cancelling or timing out `run_async` could leave the child or its descendants alive. A pool item timeout requested non-blocking shutdown but context-manager exit immediately waited again, defeating the configured deadline.

## Root Cause
Async launches had no owned process-group boundary and exception paths did not consistently kill and reap. Pool timeout cleanup lost process handles during shutdown and then re-entered blocking executor cleanup.

## Regression Test
- Cover cancellation, timeout, repeated cancellation during shielded cleanup, POSIX descendant termination, and the Windows exact-child fallback.
- Cover retained process handles and a real thread-pool wall-clock deadline.
- The first Windows CI run exposed that simulated POSIX `os` functions were patched with `raising=True`; the test now creates absent Windows attributes explicitly.
- The second Windows CI run exposed that `signal.SIGKILL` is absent there; the POSIX simulation now injects a portable numeric signal before exercising the branch.
- Shared-core approval: the user's explicit `fix and merge` instruction covered the audited agi-env and agi-node runtime defect. No agi-core files are changed.

## Validation
- Post-rebase focused lifecycle slice: 66 passed.
- Focused cleanup slice after the Windows test fixes: 1 passed, 33 deselected.
- Full agi-env slice: 997 passed, 1 skipped.
- Full shared-core slice: 1,499 passed, 5 skipped.
- Strict typing, targeted lint, impact validation, and coherent three-scope validation passed.
- GitHub Linux, macOS, Windows, base-Python, install, policy, and security checks passed.

## Review Evidence
- Codex sub-agent `runtime_process_fix` (inherited GPT-5 model; runtime version unavailable) implemented and reviewed the patch.
- GPT-5 Codex root agent reviewed the final diff.
- Both Windows failures were traced to POSIX test-fixture portability, not production behavior; both simulations were tightened and the final rerun passed.

## Agent Metadata
- Tokki version: 1.0.34
- Agent/runtime: Codex (runtime version unavailable)
- Model: GPT-5
- Reasoning effort: unknown
- /fast mode: not used