### PR TITLE
fix(runtime): invalidate unsafe distribution plans

### DIFF
--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime/capacity_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime/capacity_support.py
@@ -16,6 +16,7 @@ import polars as pl
 from agi_env import AgiEnv
 from agi_cluster.agi_distributor import runtime_misc_support
 from agi_cluster.agi_distributor.run_request_support import RunRequest
+from agi_cluster.agi_distributor.runtime.worker_endpoint_support import worker_host
 from agi_node.agi_dispatcher.base_worker import BaseWorker
 
 
@@ -44,28 +45,23 @@ def _manager_path(env: AgiEnv) -> Path:
 
 
 def _worker_host(worker: Any) -> str:
-    value = str(worker or "").strip()
-    if "://" in value:
-        value = value.rsplit("://", 1)[-1]
-    if "@" in value:
-        value = value.rsplit("@", 1)[-1]
-    if value.startswith("[") and "]" in value:
-        return value[1:value.index("]")]
-    if value.count(":") == 1:
-        value = value.split(":", 1)[0]
-    return value
+    """Compatibility alias for the centralized endpoint parser."""
+
+    return worker_host(worker)
 
 
 def _worker_count_for_host(workers: Mapping[str, int] | None, host: str) -> int | None:
     if not workers:
         return None
-    if host in workers:
-        return int(workers[host])
+    normalized_host = worker_host(host)
     localhost_aliases = {"localhost", "127.0.0.1", "::1"}
-    if host in localhost_aliases:
-        for alias in localhost_aliases:
-            if alias in workers:
-                return int(workers[alias])
+    for worker, count in workers.items():
+        configured_host = worker_host(worker)
+        if configured_host == normalized_host or (
+            configured_host in localhost_aliases
+            and normalized_host in localhost_aliases
+        ):
+            return int(count)
     return None
 
 

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime/runtime_distribution_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime/runtime_distribution_support.py
@@ -15,6 +15,7 @@ from zipfile import BadZipFile, ZipFile
 import psutil
 
 from agi_cluster.agi_distributor import background_jobs_support, deployment_remote_support
+from agi_cluster.agi_distributor.runtime.worker_endpoint_support import worker_host
 from agi_env.process_support import project_virtualenv_script_path
 
 
@@ -705,24 +706,63 @@ def scale_cluster(agi_cls: Any, *, log: Any = logger) -> None:
     if not agi_cls._dask_workers:
         return
 
-    nb_kept_workers = {}
+    configured_workers: dict[str, int] = {}
+    for configured_worker, count in (agi_cls._workers or {}).items():
+        host = worker_host(configured_worker)
+        if host:
+            configured_workers[host] = configured_workers.get(host, 0) + int(count)
+
+    nb_kept_workers: dict[str, int] = {}
     workers_to_remove = []
+    retained_workers: list[tuple[str, str]] = []
     for dask_worker in agi_cls._dask_workers:
-        ip = dask_worker.split(":")[0]
-        if ip in agi_cls._workers:
-            if ip not in nb_kept_workers:
-                nb_kept_workers[ip] = 0
-            if nb_kept_workers[ip] >= agi_cls._workers[ip]:
+        host = worker_host(dask_worker)
+        configured_host = host
+        if host not in configured_workers and host in {"localhost", "127.0.0.1", "::1"}:
+            configured_host = next(
+                (
+                    alias
+                    for alias in ("localhost", "127.0.0.1", "::1")
+                    if alias in configured_workers
+                ),
+                host,
+            )
+        if configured_host in configured_workers:
+            if configured_host not in nb_kept_workers:
+                nb_kept_workers[configured_host] = 0
+            if nb_kept_workers[configured_host] >= configured_workers[configured_host]:
                 workers_to_remove.append(dask_worker)
             else:
-                nb_kept_workers[ip] += 1
+                nb_kept_workers[configured_host] += 1
+                retained_workers.append((configured_host, dask_worker))
         else:
             workers_to_remove.append(dask_worker)
 
     if workers_to_remove:
         log.info(f"unused workers: {len(workers_to_remove)}")
-        for worker in workers_to_remove:
-            agi_cls._dask_workers.remove(worker)
+    # Group retained Dask endpoints in configured-worker order. WorkDispatcher
+    # expands the worker mapping in this same order, so plan indices, calibrated
+    # capacities, and submitted Dask endpoints stay aligned even when the
+    # scheduler reports workers in a different order.
+    agi_cls._dask_workers = [
+        dask_worker
+        for configured_host in configured_workers
+        for retained_host, dask_worker in retained_workers
+        if retained_host == configured_host
+    ]
+
+
+def _ordered_worker_capacities(
+    dask_workers: list[str],
+    capacity_by_worker: Any,
+) -> list[float] | None:
+    if not dask_workers:
+        return None
+    capacities = capacity_by_worker if isinstance(capacity_by_worker, dict) else {}
+    normalized_capacity = {
+        str(worker).split("/")[-1]: value for worker, value in capacities.items()
+    }
+    return [float(normalized_capacity.get(worker, 1.0)) for worker in dask_workers]
 
 
 async def distribute(
@@ -742,36 +782,63 @@ async def distribute(
     ]
     log.info(f"AGI run mode={agi_cls._mode} on {list(agi_cls._dask_workers)} ... ")
 
+    # First trim unknown/excess scheduler workers using the configured topology.
+    # The calibrated capacity vector must describe exactly the worker order that
+    # the planner will target.
+    agi_cls._scale_cluster()
+    dask_workers = list(agi_cls._dask_workers)
+    client = agi_cls._dask_client
+
+    if dask_workers:
+        await _call_client_blocking(
+            agi_cls._dask_client.gather,
+            [
+                client.submit(
+                    base_worker_cls._new,
+                    env=0 if env.debug else None,
+                    app=_manager_app_name(env),
+                    mode=agi_cls._mode,
+                    verbose=agi_cls.verbose,
+                    worker_id=worker_id,
+                    worker=worker,
+                    args=_worker_startup_args(agi_cls),
+                    workers=[worker],
+                )
+                for worker_id, worker in enumerate(dask_workers)
+            ],
+        )
+
+        # Capacity collection depends on initialized BaseWorker state, but must
+        # precede build_distribution so the normal (non-benchmark) plan uses it.
+        await agi_cls._calibration()
+    else:
+        agi_cls._capacity = {}
+
+    planner_capacities = _ordered_worker_capacities(
+        dask_workers,
+        getattr(agi_cls, "_capacity", None),
+    )
     agi_cls._workers, workers_plan, workers_plan_metadata = await work_dispatcher_cls._do_distrib(
-        env, agi_cls._workers, agi_cls._args
+        env,
+        agi_cls._workers,
+        agi_cls._args,
+        capacities=planner_capacities,
     )
     agi_cls._work_plan = workers_plan
     agi_cls._work_plan_metadata = workers_plan_metadata
 
+    # A planner can return fewer non-empty chunks than the configured topology.
+    # Apply that reduced topology before submission so idle workers are retired.
     agi_cls._scale_cluster()
-
     dask_workers = list(agi_cls._dask_workers)
-    client = agi_cls._dask_client
-
-    await _call_client_blocking(
-        agi_cls._dask_client.gather,
-        [
-            client.submit(
-                base_worker_cls._new,
-                env=0 if env.debug else None,
-                app=_manager_app_name(env),
-                mode=agi_cls._mode,
-                verbose=agi_cls.verbose,
-                worker_id=worker_id,
-                worker=worker,
-                args=_worker_startup_args(agi_cls),
-                workers=[worker],
-            )
-            for worker_id, worker in enumerate(dask_workers)
-        ],
-    )
-
-    await agi_cls._calibration()
+    if workers_plan and not dask_workers:
+        raise RuntimeError(
+            "Distribution produced a non-empty workload but no configured Dask workers were retained"
+        )
+    if len(workers_plan or []) > len(dask_workers):
+        raise RuntimeError(
+            "Distribution produced more non-empty worker chunks than retained Dask workers"
+        )
 
     started_at = time_fn()
     futures = {}
@@ -783,6 +850,11 @@ async def distribute(
             plan_payload,
             metadata_payload,
             workers=[worker_addr],
+        )
+
+    if workers_plan and not futures:
+        raise RuntimeError(
+            "Distribution produced a non-empty workload but submitted no worker futures"
         )
 
     gathered_logs = (

--- a/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime/worker_endpoint_support.py
+++ b/src/agilab/core/agi-cluster/src/agi_cluster/agi_distributor/runtime/worker_endpoint_support.py
@@ -1,0 +1,42 @@
+"""Canonical parsing for configured and Dask worker endpoints."""
+
+from __future__ import annotations
+
+import ipaddress
+from typing import Any
+
+
+def _normalize_host(host: str) -> str:
+    value = host.strip()
+    if not value:
+        return ""
+    try:
+        return ipaddress.ip_address(value).compressed
+    except ValueError:
+        return value.lower()
+
+
+def worker_host(worker: Any) -> str:
+    """Return a normalized host without credentials, scheme, brackets, or port.
+
+    Unbracketed IPv6 values are treated as raw host literals. IPv6 endpoints
+    carrying a port must use the standard bracketed form (``[host]:port``), as
+    an unbracketed IPv6 address ending in decimal text is inherently ambiguous.
+    """
+
+    value = str(worker or "").strip()
+    if "://" in value:
+        value = value.rsplit("://", 1)[-1]
+    if "@" in value:
+        value = value.rsplit("@", 1)[-1]
+    if value.startswith("["):
+        closing_bracket = value.find("]")
+        if closing_bracket < 0:
+            return ""
+        return _normalize_host(value[1:closing_bracket])
+    if value.count(":") == 1:
+        value = value.split(":", 1)[0]
+    return _normalize_host(value)
+
+
+__all__ = ["worker_host"]

--- a/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/agi_dispatcher.py
+++ b/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/agi_dispatcher.py
@@ -23,6 +23,7 @@ import re
 import sys
 import stat
 import json
+from contextvars import ContextVar
 from itertools import zip_longest
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
@@ -33,10 +34,20 @@ import datetime
 import logging
 
 from agi_env import AgiEnv
+from agi_env.runtime.atomic_write_support import atomic_write_text
+
+from .distribution_cache_support import (
+    DISTRIBUTION_CACHE_SCHEMA,
+    build_cache_context,
+)
 
 logger = logging.getLogger(__name__)
 workers_default = {"127.0.0.1": 1}
 RUN_STAGES_KEY = "_agilab_run_stages"
+_ACTIVE_DISTRIBUTION_CAPACITIES: ContextVar[tuple[float, ...] | None] = ContextVar(
+    "agilab_distribution_capacities",
+    default=None,
+)
 
 # Conservative module/distribution name allow-list for runtime auto-install.
 # The auto-install command is executed through a shell, so the name must not
@@ -109,12 +120,101 @@ class WorkDispatcher:
         return _convert(workers_plan)
 
     @staticmethod
-    async def _do_distrib(env, workers, args):
+    def _cache_json_default(obj):
+        if isinstance(obj, (datetime.date, datetime.datetime)):
+            return obj.isoformat()
+        if isinstance(obj, Path):
+            return str(obj)
+        raise TypeError(f"Type {type(obj)} not serializable")
+
+    @staticmethod
+    def _normalize_cache_value(value):
+        return json.loads(
+            json.dumps(
+                value,
+                default=WorkDispatcher._cache_json_default,
+                sort_keys=True,
+            )
+        )
+
+    @staticmethod
+    def _worker_slots(workers):
+        return [
+            str(worker)
+            for worker, count in workers.items()
+            for _ in range(int(count))
+        ]
+
+    @staticmethod
+    def _load_cached_distribution(
+        file,
+        *,
+        workers,
+        worker_slots,
+        cache_args,
+        cache_context,
+    ):
+        try:
+            data = json.loads(file.read_text(encoding="utf-8"))
+        except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+            logger.warning("Ignoring unreadable distribution cache %s: %s", file, exc)
+            return None
+
+        if not isinstance(data, dict):
+            logger.warning("Ignoring malformed distribution cache %s: expected an object", file)
+            return None
+        if data.get("schema") != DISTRIBUTION_CACHE_SCHEMA:
+            return None
+        if (
+            data.get("workers") != workers
+            or data.get("worker_slots") != worker_slots
+            or data.get("target_args") != cache_args
+            or data.get("cache_context") != cache_context
+        ):
+            return None
+
+        workers_plan = data.get("work_plan")
+        workers_plan_metadata = data.get("work_plan_metadata", [])
+        if not isinstance(workers_plan, list) or not isinstance(
+            workers_plan_metadata, list
+        ):
+            logger.warning(
+                "Ignoring malformed distribution cache %s: work plan payloads must be lists",
+                file,
+            )
+            return None
+        return workers_plan, workers_plan_metadata
+
+    @staticmethod
+    def _write_distribution_cache(file, data):
+        serialized = json.dumps(
+            data,
+            default=WorkDispatcher._cache_json_default,
+            indent=2,
+            sort_keys=True,
+        )
+        atomic_write_text(file, f"{serialized}\n", encoding="utf-8")
+
+    @staticmethod
+    async def _do_distrib(env, workers, args, *, capacities=None):
         """Build the distribution plan for ``env`` given worker layout and args."""
         target_args, run_stages = WorkDispatcher._split_dispatch_args(args)
         cache_args = dict(target_args)
         if run_stages:
             cache_args[RUN_STAGES_KEY] = run_stages
+        normalized_cache_args = WorkDispatcher._normalize_cache_value(cache_args)
+        normalized_workers = WorkDispatcher._normalize_cache_value(workers)
+        worker_slots = WorkDispatcher._worker_slots(workers)
+
+        active_capacities = None
+        if capacities is not None:
+            active_capacities = tuple(
+                float(value)
+                for value in WorkDispatcher._normalize_worker_capacities(
+                    capacities,
+                    workers,
+                )
+            )
 
         target_module = await WorkDispatcher._load_module(
             env.target,
@@ -130,32 +230,51 @@ class WorkDispatcher:
         WorkDispatcher._apply_run_stages(target_inst, run_stages)
 
         file = env.distribution_tree
-        workers_plan = []
-        workers_plan_metadata = []
-        rebuild_tree = False
+        cache_context = build_cache_context(
+            target_inst,
+            capacities=active_capacities,
+        )
+        cached_distribution = None
         if file.exists():
-            with open(file, "r") as f:
-                data = json.load(f)
-            workers_plan = data.get("work_plan")
-            workers_plan_metadata = data.get("work_plan_metadata", [])
-            if workers_plan is None or (
-                data["workers"] != workers
-                or data["target_args"] != cache_args
-            ):
-                rebuild_tree = True
+            cached_distribution = WorkDispatcher._load_cached_distribution(
+                file,
+                workers=normalized_workers,
+                worker_slots=worker_slots,
+                cache_args=normalized_cache_args,
+                cache_context=cache_context,
+            )
 
-        if not file.exists() or rebuild_tree:
-            (
-                workers_plan,
-                workers_plan_metadata,
-                part,
-                nb_unit,
-                weight_unit,
-            ) = target_inst.build_distribution(workers)
+        if cached_distribution is not None:
+            workers_plan, workers_plan_metadata = cached_distribution
+        else:
+            capacity_token = _ACTIVE_DISTRIBUTION_CAPACITIES.set(active_capacities)
+            try:
+                (
+                    workers_plan,
+                    workers_plan_metadata,
+                    part,
+                    nb_unit,
+                    weight_unit,
+                ) = target_inst.build_distribution(workers)
+            finally:
+                _ACTIVE_DISTRIBUTION_CAPACITIES.reset(capacity_token)
+
+            cache_context_after = build_cache_context(
+                target_inst,
+                capacities=active_capacities,
+            )
+            if cache_context != cache_context_after:
+                raise RuntimeError(
+                    "distribution inputs changed while the work plan was being built"
+                )
+            cache_context = cache_context_after
 
             data = {
-                "target_args": cache_args,
-                "workers": workers,
+                "schema": DISTRIBUTION_CACHE_SCHEMA,
+                "cache_context": cache_context,
+                "target_args": normalized_cache_args,
+                "workers": normalized_workers,
+                "worker_slots": worker_slots,
                 "work_plan_metadata": workers_plan_metadata,
                 "work_plan": WorkDispatcher._convert_functions_to_names(workers_plan),
                 "partition_key": part,
@@ -163,25 +282,16 @@ class WorkDispatcher:
                 "weights_unit": weight_unit,
             }
 
-            def convert_dates(obj):
-                if isinstance(obj, (datetime.date, datetime.datetime)):
-                    return obj.isoformat()
-                raise TypeError(f"Type {type(obj)} not serializable")
-
-            with open(file, "w") as f:
-                json.dump(data, f, default=convert_dates, indent=2)
+            WorkDispatcher._write_distribution_cache(file, data)
 
             # Normalize the in-memory plan exactly like the cached copy
             # (callables -> names, tuples -> lists, datetimes -> isoformat)
             # so cache-miss and cache-hit runs dispatch identical payloads.
-            normalized = json.loads(
-                json.dumps(
-                    {
-                        "work_plan": data["work_plan"],
-                        "work_plan_metadata": workers_plan_metadata,
-                    },
-                    default=convert_dates,
-                )
+            normalized = WorkDispatcher._normalize_cache_value(
+                {
+                    "work_plan": data["work_plan"],
+                    "work_plan_metadata": workers_plan_metadata,
+                }
             )
             workers_plan = normalized["work_plan"]
             workers_plan_metadata = normalized["work_plan_metadata"]
@@ -249,13 +359,13 @@ class WorkDispatcher:
 
     @staticmethod
     def make_chunks(
-    nchunk2: int,
-    weights: List[Any],
-    capacities: Optional[List[Any]] = None,
-    workers: Dict = None,  # ty: ignore[invalid-parameter-default]
-    verbose: int = 0,
-    threshold: int = 12,
-) -> List[List[List[Any]]]:
+        nchunk2: int,
+        weights: List[Any],
+        capacities: Optional[List[Any]] = None,
+        workers: Dict = None,  # ty: ignore[invalid-parameter-default]
+        verbose: int = 0,
+        threshold: int = 12,
+    ) -> List[List[List[Any]]]:
         """Partitions the nchunk2 weighted into n chuncks, in a smart way
         chunks and chunks_sizes must be left to None
 
@@ -274,6 +384,8 @@ class WorkDispatcher:
         """
         if not workers:
             workers = workers_default
+        if capacities is None:
+            capacities = _ACTIVE_DISTRIBUTION_CAPACITIES.get()
         capacities = WorkDispatcher._normalize_worker_capacities(capacities, workers)  # ty: ignore[invalid-assignment]
 
         if len(weights) > 1:

--- a/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/base_worker.py
+++ b/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/base_worker.py
@@ -151,6 +151,17 @@ class BaseWorker(ArtifactContract, abc.ABC):
     def work_init(self) -> None:
         """Per-works()-call initialization hook; default is a no-op."""
 
+    def distribution_cache_inputs(self) -> Iterable[Path | str]:
+        """Return additional filesystem inputs that determine the work plan.
+
+        ``WorkDispatcher`` automatically fingerprints conventional argument
+        fields such as ``data_in`` and ``submission_inbox``. Applications whose
+        planner reads other filesystem locations can expose those roots here
+        without changing the stable ``build_distribution(workers)`` signature.
+        """
+
+        return ()
+
     def _actual_work_pool(self, x: Any = None) -> Any:
         """Process one work item; dataframe families must override this."""
         raise NotImplementedError(

--- a/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/distribution_cache_support.py
+++ b/src/agilab/core/agi-node/src/agi_node/agi_dispatcher/distribution_cache_support.py
@@ -1,0 +1,283 @@
+"""Versioned fingerprints for persistent worker distribution plans."""
+
+from __future__ import annotations
+
+import hashlib
+import inspect
+import json
+from collections.abc import Iterable, Mapping
+from pathlib import Path
+from types import CodeType
+from typing import Any
+
+
+DISTRIBUTION_CACHE_SCHEMA = "agilab.distribution_tree.v2"
+
+_INPUT_PATH_FIELD_NAMES = {
+    "data_in",
+    "dataset",
+    "dataset_dir",
+    "dataset_file",
+    "dataset_path",
+    "inbox",
+    "input",
+    "input_dir",
+    "input_file",
+    "input_files",
+    "input_path",
+    "input_paths",
+    "input_root",
+    "source_dir",
+    "source_file",
+    "source_path",
+    "source_root",
+    "submission_inbox",
+}
+
+
+def _is_input_path_field(name: Any) -> bool:
+    normalized = str(name or "").strip().lower()
+    return (
+        normalized in _INPUT_PATH_FIELD_NAMES
+        or normalized.endswith("_data_in")
+        or normalized.endswith("_input_dir")
+        or normalized.endswith("_input_file")
+        or normalized.endswith("_input_path")
+        or normalized.endswith("_input_root")
+        or normalized.endswith("_inbox")
+    )
+
+
+def _args_payload(args: Any) -> Any:
+    model_dump = getattr(args, "model_dump", None)
+    if callable(model_dump):
+        return model_dump(mode="python")
+    if isinstance(args, Mapping):
+        return args
+    values = getattr(args, "__dict__", None)
+    return values if isinstance(values, Mapping) else {}
+
+
+def _iter_declared_paths(value: Any) -> Iterable[Path]:
+    if isinstance(value, Path):
+        yield value
+        return
+    if isinstance(value, str):
+        stripped = value.strip()
+        if stripped and "://" not in stripped:
+            yield Path(stripped).expanduser()
+        return
+    if isinstance(value, Mapping):
+        for nested in value.values():
+            yield from _iter_declared_paths(nested)
+        return
+    if isinstance(value, Iterable) and not isinstance(value, (bytes, bytearray)):
+        for nested in value:
+            yield from _iter_declared_paths(nested)
+
+
+def _discover_input_paths(target_inst: Any) -> list[Path]:
+    discovered: list[Path] = []
+
+    def _visit(value: Any) -> None:
+        if not isinstance(value, Mapping):
+            return
+        for field_name, field_value in value.items():
+            if _is_input_path_field(field_name):
+                discovered.extend(_iter_declared_paths(field_value))
+            if isinstance(field_value, Mapping):
+                _visit(field_value)
+
+    _visit(_args_payload(getattr(target_inst, "args", None)))
+
+    declared_inputs = getattr(target_inst, "distribution_cache_inputs", None)
+    if declared_inputs is not None:
+        if not callable(declared_inputs):
+            raise TypeError("distribution_cache_inputs must be callable when defined")
+        hook_value = declared_inputs()
+        if inspect.isawaitable(hook_value):
+            raise TypeError("distribution_cache_inputs must be synchronous")
+        discovered.extend(_iter_declared_paths(hook_value))
+
+    unique: dict[str, Path] = {}
+    for candidate in discovered:
+        resolved = candidate.resolve(strict=False)
+        unique[resolved.as_posix()] = resolved
+    return [unique[key] for key in sorted(unique)]
+
+
+def _file_sha256(path: Path) -> tuple[str, Any]:
+    before = path.stat()
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    after = path.stat()
+    before_identity = (before.st_size, before.st_mtime_ns, before.st_ctime_ns)
+    after_identity = (after.st_size, after.st_mtime_ns, after.st_ctime_ns)
+    if before_identity != after_identity:
+        raise RuntimeError(f"distribution input changed while being fingerprinted: {path}")
+    return digest.hexdigest(), after
+
+
+def _path_fingerprint(path: Path) -> dict[str, Any]:
+    root_payload: dict[str, Any] = {"path": path.as_posix()}
+    if not path.exists():
+        root_payload["kind"] = "missing"
+        return root_payload
+    if path.is_file():
+        digest, stat_result = _file_sha256(path)
+        root_payload.update(
+            {
+                "kind": "file",
+                "size": stat_result.st_size,
+                "sha256": digest,
+            }
+        )
+        return root_payload
+    if not path.is_dir():
+        stat_result = path.stat()
+        root_payload.update(
+            {
+                "kind": "other",
+                "size": stat_result.st_size,
+                "mtime_ns": stat_result.st_mtime_ns,
+            }
+        )
+        return root_payload
+
+    entries: list[dict[str, Any]] = []
+    for candidate in sorted(path.rglob("*"), key=lambda item: item.as_posix()):
+        relative = candidate.relative_to(path).as_posix()
+        if candidate.is_file():
+            digest, stat_result = _file_sha256(candidate)
+            entries.append(
+                {
+                    "path": relative,
+                    "kind": "file",
+                    "size": stat_result.st_size,
+                    "sha256": digest,
+                }
+            )
+        elif candidate.is_dir():
+            entries.append({"path": relative, "kind": "directory"})
+        else:
+            stat_result = candidate.stat()
+            entries.append(
+                {
+                    "path": relative,
+                    "kind": "other",
+                    "size": stat_result.st_size,
+                    "mtime_ns": stat_result.st_mtime_ns,
+                }
+            )
+    root_payload.update({"kind": "directory", "entries": entries})
+    return root_payload
+
+
+def _stable_code_constant(value: Any) -> Any:
+    if isinstance(value, CodeType):
+        return {
+            "kind": "code",
+            "bytecode": value.co_code.hex(),
+            "names": list(value.co_names),
+            "constants": [_stable_code_constant(item) for item in value.co_consts],
+        }
+    if isinstance(value, tuple):
+        return {
+            "kind": "tuple",
+            "items": [_stable_code_constant(item) for item in value],
+        }
+    if isinstance(value, frozenset):
+        items = [_stable_code_constant(item) for item in value]
+        return {
+            "kind": "frozenset",
+            "items": sorted(
+                items,
+                key=lambda item: json.dumps(item, sort_keys=True),
+            ),
+        }
+    if isinstance(value, bytes):
+        return {"kind": "bytes", "hex": value.hex()}
+    if value is Ellipsis:
+        return {"kind": "ellipsis"}
+    if value is None or isinstance(value, (bool, int, float, complex, str)):
+        return {"kind": type(value).__name__, "value": repr(value)}
+    return {"kind": type(value).__name__}
+
+
+def _planner_fingerprint(target_inst: Any) -> dict[str, str]:
+    planner = target_inst.build_distribution
+    callable_obj = getattr(planner, "__func__", planner)
+    digest = hashlib.sha256()
+    digest.update(
+        f"{type(target_inst).__module__}.{type(target_inst).__qualname__}".encode(
+            "utf-8"
+        )
+    )
+
+    try:
+        callable_source = inspect.getsource(callable_obj)
+    except (OSError, TypeError):
+        callable_source = None
+    if callable_source is not None:
+        digest.update(callable_source.encode("utf-8"))
+    else:
+        code = getattr(callable_obj, "__code__", None)
+        if code is not None:
+            code_payload = {
+                "bytecode": code.co_code.hex(),
+                "names": list(code.co_names),
+                "constants": [
+                    _stable_code_constant(value) for value in code.co_consts
+                ],
+            }
+            digest.update(
+                json.dumps(code_payload, sort_keys=True, separators=(",", ":")).encode(
+                    "utf-8"
+                )
+            )
+
+    source_path_raw = inspect.getsourcefile(callable_obj)
+    source_path = Path(source_path_raw).resolve() if source_path_raw else None
+    if source_path is not None and source_path.is_file():
+        source_digest, _stat_result = _file_sha256(source_path)
+        digest.update(source_digest.encode("ascii"))
+
+    return {
+        "callable": f"{callable_obj.__module__}.{callable_obj.__qualname__}",
+        "sha256": digest.hexdigest(),
+    }
+
+
+def build_cache_context(
+    target_inst: Any,
+    *,
+    capacities: Iterable[float] | None,
+) -> dict[str, Any]:
+    """Return the deterministic context that makes a cached plan reusable."""
+
+    input_roots = _discover_input_paths(target_inst)
+    input_fingerprints = [_path_fingerprint(path) for path in input_roots]
+    input_digest = hashlib.sha256(
+        json.dumps(
+            input_fingerprints,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+    payload = {
+        "planner": _planner_fingerprint(target_inst),
+        "inputs": {
+            "roots": [path.as_posix() for path in input_roots],
+            "digest_sha256": input_digest,
+        },
+        "capacities": [] if capacities is None else [float(value) for value in capacities],
+    }
+    digest = hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    return {**payload, "digest_sha256": digest}
+
+
+__all__ = ["DISTRIBUTION_CACHE_SCHEMA", "build_cache_context"]

--- a/src/agilab/core/test/test_agi_distributor_capacity_support.py
+++ b/src/agilab/core/test/test_agi_distributor_capacity_support.py
@@ -75,8 +75,13 @@ def test_capacity_support_private_helper_edges(monkeypatch, tmp_path):
         capacity_support._manager_path(SimpleNamespace(manager_path=str(tmp_path)))
 
     assert capacity_support._worker_host("ssh://user@[fe80::1]:22") == "fe80::1"
+    assert capacity_support._worker_host("fe80::1") == "fe80::1"
     assert capacity_support._worker_host("user@10.0.0.2:8787") == "10.0.0.2"
     assert capacity_support._worker_host("") == ""
+    assert capacity_support._worker_count_for_host(
+        {"ssh://user@localhost:22": 2},
+        "127.0.0.1",
+    ) == 2
     assert capacity_support._node_count(None) == 1
     assert capacity_support._node_count({"user@10.0.0.2:8787": 1, "ssh://user@10.0.0.2": 1}) == 1
 

--- a/src/agilab/core/test/test_agi_distributor_runtime_distribution_support.py
+++ b/src/agilab/core/test/test_agi_distributor_runtime_distribution_support.py
@@ -105,6 +105,21 @@ def test_dask_env_prefix_and_scale_cluster_trim_workers():
     assert AGI._dask_workers == ["10.0.0.1:1001"]
 
 
+def test_scale_cluster_uses_central_parser_for_bracketed_and_raw_ipv6_workers():
+    AGI._workers = {"2001:db8::1": 2}
+    AGI._dask_workers = [
+        "[2001:0db8::1]:1001",
+        "2001:db8::1",
+        "[2001:db8::2]:1002",
+    ]
+
+    runtime_distribution_support.scale_cluster(AGI)
+
+    assert AGI._dask_workers == ["[2001:0db8::1]:1001", "2001:db8::1"]
+    assert runtime_distribution_support.worker_host("tcp://user@[2001:0db8::1]:1001") == "2001:db8::1"
+    assert runtime_distribution_support.worker_host("2001:0db8::1") == "2001:db8::1"
+
+
 def test_sanitize_worker_upload_artifacts_removes_top_level_ui_modules(tmp_path):
     wenv_abs = tmp_path / "worker_env"
     src_dir = wenv_abs / "src"
@@ -1049,7 +1064,7 @@ async def test_distribute_wraps_payloads_and_logs_worker_outputs(monkeypatch):
 
     class _Dispatcher:
         @staticmethod
-        async def _do_distrib(_env, workers, _args):
+        async def _do_distrib(_env, workers, _args, *, capacities=None):
             return workers, [["step"]], [[{"meta": 1}]]
 
     class _Worker:
@@ -1301,7 +1316,7 @@ async def test_distribute_in_debug_mode_backfills_empty_worker_logs(monkeypatch)
 
     class _Dispatcher:
         @staticmethod
-        async def _do_distrib(_env, workers, _args):
+        async def _do_distrib(_env, workers, _args, *, capacities=None):
             return workers, [["step"]], [[{"meta": 1}]]
 
     class _Worker:
@@ -1356,7 +1371,7 @@ async def test_distribute_in_debug_mode_backfills_known_workers_when_no_futures(
 
     class _Dispatcher:
         @staticmethod
-        async def _do_distrib(_env, workers, _args):
+        async def _do_distrib(_env, workers, _args, *, capacities=None):
             return workers, [], []
 
     AGI.env = SimpleNamespace(
@@ -1404,7 +1419,7 @@ async def test_distribute_in_debug_mode_handles_empty_scheduler_worker_list(monk
 
     class _Dispatcher:
         @staticmethod
-        async def _do_distrib(_env, workers, _args):
+        async def _do_distrib(_env, workers, _args, *, capacities=None):
             return workers, [], []
 
     AGI.env = SimpleNamespace(
@@ -1435,6 +1450,38 @@ async def test_distribute_in_debug_mode_handles_empty_scheduler_worker_list(monk
     )
 
     assert result == "mode=4 0.0"
+
+
+@pytest.mark.asyncio
+async def test_distribute_rejects_nonempty_plan_when_no_workers_are_retained():
+    class _Client:
+        def scheduler_info(self):
+            return {"workers": {}}
+
+    class _Dispatcher:
+        @staticmethod
+        async def _do_distrib(_env, workers, _args, *, capacities=None):
+            assert capacities is None
+            return workers, [["orphaned-work"]], [[{"meta": 1}]]
+
+    AGI.env = SimpleNamespace(
+        debug=False,
+        target_worker="demo_worker",
+        target="demo",
+        mode2str=lambda mode: f"mode={mode}",
+    )
+    AGI._dask_client = _Client()
+    AGI._workers = {"127.0.0.1": 1}
+    AGI._args = {}
+    AGI._mode = AGI.DASK_MODE
+    AGI.verbose = 0
+
+    with pytest.raises(RuntimeError, match="non-empty workload"):
+        await runtime_distribution_support.distribute(
+            AGI,
+            work_dispatcher_cls=_Dispatcher,
+            base_worker_cls=BaseWorker,
+        )
 
 
 @pytest.mark.asyncio
@@ -1589,8 +1636,8 @@ async def test_distribute_executes_new_calibration_and_works(monkeypatch):
         def scheduler_info(self):
             return {
                 "workers": {
-                    "tcp://127.0.0.1:8787": {},
                     "tcp://10.0.0.2:8788": {},
+                    "tcp://127.0.0.1:8787": {},
                 }
             }
 
@@ -1615,14 +1662,16 @@ async def test_distribute_executes_new_calibration_and_works(monkeypatch):
     AGI._mode = AGI.DASK_MODE
     AGI.verbose = 0
     AGI.debug = False
-    called = {"calibration": 0}
+    called = {"calibration": 0, "planner_capacities": None}
 
-    async def _fake_distrib(_env, workers, _args):
+    async def _fake_distrib(_env, workers, _args, *, capacities=None):
+        assert called["calibration"] == 1
+        called["planner_capacities"] = capacities
         return workers, [["step-a"], ["step-b"]], [[{"m": 1}], [{"m": 2}]]
 
     async def _fake_calibration():
         called["calibration"] += 1
-        AGI._capacity = {"127.0.0.1:8787": 1.0, "10.0.0.2:8788": 1.0}
+        AGI._capacity = {"127.0.0.1:8787": 1.0, "10.0.0.2:8788": 4.0}
 
     monkeypatch.setattr(WorkDispatcher, "_do_distrib", staticmethod(_fake_distrib))
     monkeypatch.setattr(AGI, "_calibration", staticmethod(_fake_calibration))
@@ -1635,6 +1684,8 @@ async def test_distribute_executes_new_calibration_and_works(monkeypatch):
     )
     assert result.startswith("dask ")
     assert called["calibration"] == 1
+    assert called["planner_capacities"] == [1.0, 4.0]
+    assert AGI._dask_workers == ["127.0.0.1:8787", "10.0.0.2:8788"]
     assert AGI._work_plan == [["step-a"], ["step-b"]]
     assert AGI._work_plan_metadata == [[{"m": 1}], [{"m": 2}]]
     assert "BaseWorker._new" not in AGI._dask_client.submissions

--- a/src/agilab/core/test/test_work_dispatcher.py
+++ b/src/agilab/core/test/test_work_dispatcher.py
@@ -10,8 +10,12 @@ import pytest
 import numpy as np
 
 import agi_node.agi_dispatcher.agi_dispatcher as dispatcher_module
+import agi_env.runtime.atomic_write_support as atomic_write_support
 from agi_node.agi_dispatcher import WorkDispatcher
 from agi_node.agi_dispatcher.agi_dispatcher import RUN_STAGES_KEY
+from agi_node.agi_dispatcher.distribution_cache_support import (
+    DISTRIBUTION_CACHE_SCHEMA,
+)
 
 
 def test_convert_functions_to_names_handles_nested_callables():
@@ -199,6 +203,287 @@ async def test_do_distrib_builds_and_caches_plan(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_do_distrib_invalidates_cache_for_input_add_delete_and_content_mutation(
+    tmp_path,
+    monkeypatch,
+):
+    plan_path = tmp_path / "plan.json"
+    input_dir = tmp_path / "inputs"
+    input_dir.mkdir()
+    first_input = input_dir / "a.txt"
+    first_input.write_text("alpha", encoding="utf-8")
+    planner_state = tmp_path / "planner.state"
+    planner_state.write_text("one", encoding="utf-8")
+    env = SimpleNamespace(
+        target="InputWorker",
+        target_class="InputWorker",
+        app_src=tmp_path / "app",
+        distribution_tree=plan_path,
+    )
+    env.app_src.mkdir()
+
+    class InputWorker:
+        build_calls = 0
+
+        def __init__(self, _env, **kwargs):
+            self.args = SimpleNamespace(data_in=Path(kwargs["data_in"]))
+            self.planner_state = Path(kwargs["planner_state"])
+
+        def distribution_cache_inputs(self):
+            return [self.planner_state]
+
+        def build_distribution(self, assigned_workers):
+            type(self).build_calls += 1
+            assert assigned_workers == {"127.0.0.1": 1}
+            payload = [
+                f"{path.name}:{path.read_text(encoding='utf-8')}"
+                for path in sorted(self.args.data_in.glob("*.txt"))
+            ]
+            return (
+                [[payload]],
+                [[
+                    {
+                        "files": len(payload),
+                        "planner_state": self.planner_state.read_text(encoding="utf-8"),
+                    }
+                ]],
+                "file",
+                len(payload),
+                "items",
+            )
+
+    monkeypatch.setattr(
+        WorkDispatcher,
+        "_load_module",
+        AsyncMock(return_value=SimpleNamespace(InputWorker=InputWorker)),
+    )
+    args = {"data_in": str(input_dir), "planner_state": str(planner_state)}
+    workers = {"127.0.0.1": 1}
+
+    first_result = await WorkDispatcher._do_distrib(env, workers, args)
+    await WorkDispatcher._do_distrib(env, workers, args)
+    assert InputWorker.build_calls == 1
+    assert first_result[1] == [[["a.txt:alpha"]]]
+
+    planner_state.write_text("two", encoding="utf-8")
+    hook_result = await WorkDispatcher._do_distrib(env, workers, args)
+    assert InputWorker.build_calls == 2
+    assert hook_result[2][0][0]["planner_state"] == "two"
+
+    second_input = input_dir / "b.txt"
+    second_input.write_text("bravo", encoding="utf-8")
+    added_result = await WorkDispatcher._do_distrib(env, workers, args)
+    assert InputWorker.build_calls == 3
+    assert added_result[1] == [[["a.txt:alpha", "b.txt:bravo"]]]
+
+    first_input.write_text("ALPHA", encoding="utf-8")
+    mutated_result = await WorkDispatcher._do_distrib(env, workers, args)
+    assert InputWorker.build_calls == 4
+    assert mutated_result[1][0][0][0] == "a.txt:ALPHA"
+
+    second_input.unlink()
+    deleted_result = await WorkDispatcher._do_distrib(env, workers, args)
+    assert InputWorker.build_calls == 5
+    assert deleted_result[1] == [[["a.txt:ALPHA"]]]
+
+
+@pytest.mark.asyncio
+async def test_do_distrib_recovers_from_corrupt_cache_and_publishes_current_schema(
+    tmp_path,
+    monkeypatch,
+):
+    plan_path = tmp_path / "plan.json"
+    plan_path.write_text('{"work_plan":', encoding="utf-8")
+    env = SimpleNamespace(
+        target="DemoWorker",
+        target_class="DemoWorker",
+        app_src=tmp_path / "app",
+        distribution_tree=plan_path,
+    )
+    env.app_src.mkdir()
+
+    class DemoWorker:
+        build_calls = 0
+
+        def __init__(self, _env, **_kwargs):
+            pass
+
+        def build_distribution(self, _assigned_workers):
+            type(self).build_calls += 1
+            return [["fresh"]], [[{"fresh": True}]], "partition", 1, "items"
+
+    monkeypatch.setattr(
+        WorkDispatcher,
+        "_load_module",
+        AsyncMock(return_value=SimpleNamespace(DemoWorker=DemoWorker)),
+    )
+
+    result = await WorkDispatcher._do_distrib(
+        env,
+        {"127.0.0.1": 1},
+        {"alpha": 1},
+    )
+
+    assert result[1] == [["fresh"]]
+    assert DemoWorker.build_calls == 1
+    assert json.loads(plan_path.read_text(encoding="utf-8"))["schema"] == DISTRIBUTION_CACHE_SCHEMA
+
+
+@pytest.mark.asyncio
+async def test_do_distrib_atomic_cache_publication_preserves_previous_plan_on_interruption(
+    tmp_path,
+    monkeypatch,
+):
+    plan_path = tmp_path / "plan.json"
+    input_dir = tmp_path / "inputs"
+    input_dir.mkdir()
+    input_path = input_dir / "payload.txt"
+    input_path.write_text("before", encoding="utf-8")
+    env = SimpleNamespace(
+        target="InputWorker",
+        target_class="InputWorker",
+        app_src=tmp_path / "app",
+        distribution_tree=plan_path,
+    )
+    env.app_src.mkdir()
+
+    class InputWorker:
+        def __init__(self, _env, **kwargs):
+            self.args = SimpleNamespace(data_in=Path(kwargs["data_in"]))
+
+        def build_distribution(self, _assigned_workers):
+            value = input_path.read_text(encoding="utf-8")
+            return [[value]], [[{"value": value}]], "partition", 1, "items"
+
+    monkeypatch.setattr(
+        WorkDispatcher,
+        "_load_module",
+        AsyncMock(return_value=SimpleNamespace(InputWorker=InputWorker)),
+    )
+    args = {"data_in": str(input_dir)}
+    workers = {"127.0.0.1": 1}
+    await WorkDispatcher._do_distrib(env, workers, args)
+    previous_cache = plan_path.read_bytes()
+    input_path.write_text("after", encoding="utf-8")
+
+    def _interrupt_publication(_operation):
+        raise OSError("simulated interrupted publication")
+
+    monkeypatch.setattr(
+        atomic_write_support,
+        "run_with_windows_file_sharing_retry",
+        _interrupt_publication,
+    )
+    with pytest.raises(OSError, match="simulated interrupted publication"):
+        await WorkDispatcher._do_distrib(env, workers, args)
+
+    assert plan_path.read_bytes() == previous_cache
+    assert list(tmp_path.glob(".plan.json.*.tmp")) == []
+
+
+@pytest.mark.asyncio
+async def test_do_distrib_invalidates_cache_when_planner_changes(tmp_path, monkeypatch):
+    plan_path = tmp_path / "plan.json"
+    env = SimpleNamespace(
+        target="DemoWorker",
+        target_class="DemoWorker",
+        app_src=tmp_path / "app",
+        distribution_tree=plan_path,
+    )
+    env.app_src.mkdir()
+    build_calls = []
+
+    class DemoWorker:
+        def __init__(self, _env, **_kwargs):
+            pass
+
+        def build_distribution(self, _assigned_workers):
+            build_calls.append("first")
+            return [["first"]], [[]], "partition", 1, "items"
+
+    monkeypatch.setattr(
+        WorkDispatcher,
+        "_load_module",
+        AsyncMock(return_value=SimpleNamespace(DemoWorker=DemoWorker)),
+    )
+    workers = {"127.0.0.1": 1}
+    first_result = await WorkDispatcher._do_distrib(env, workers, {})
+
+    def _replacement_plan(self, _assigned_workers):
+        build_calls.append("replacement")
+        return [["replacement"]], [[]], "partition", 1, "items"
+
+    monkeypatch.setattr(DemoWorker, "build_distribution", _replacement_plan)
+    replacement_result = await WorkDispatcher._do_distrib(env, workers, {})
+
+    assert first_result[1] == [["first"]]
+    assert replacement_result[1] == [["replacement"]]
+    assert build_calls == ["first", "replacement"]
+
+
+@pytest.mark.asyncio
+async def test_do_distrib_uses_capacity_ratio_and_invalidates_capacity_cache(
+    tmp_path,
+    monkeypatch,
+):
+    plan_path = tmp_path / "plan.json"
+    env = SimpleNamespace(
+        target="CapacityWorker",
+        target_class="CapacityWorker",
+        app_src=tmp_path / "app",
+        distribution_tree=plan_path,
+    )
+    env.app_src.mkdir()
+
+    class CapacityWorker:
+        build_calls = 0
+
+        def __init__(self, _env, **_kwargs):
+            pass
+
+        def build_distribution(self, assigned_workers):
+            type(self).build_calls += 1
+            chunks = WorkDispatcher.make_chunks(
+                5,
+                [(f"job-{index}", 1.0) for index in range(5)],
+                workers=assigned_workers,
+                threshold=0,
+            )
+            return chunks, [[] for _ in chunks], "job", 5, "items"
+
+    monkeypatch.setattr(
+        WorkDispatcher,
+        "_load_module",
+        AsyncMock(return_value=SimpleNamespace(CapacityWorker=CapacityWorker)),
+    )
+    workers = {"node-a": 2}
+
+    first = await WorkDispatcher._do_distrib(
+        env,
+        workers,
+        {},
+        capacities=[1.0, 4.0],
+    )
+    cached = await WorkDispatcher._do_distrib(
+        env,
+        workers,
+        {},
+        capacities=[1.0, 4.0],
+    )
+    reversed_capacity = await WorkDispatcher._do_distrib(
+        env,
+        workers,
+        {},
+        capacities=[4.0, 1.0],
+    )
+
+    assert [len(chunk) for chunk in first[1]] == [1, 4]
+    assert cached == first
+    assert [len(chunk) for chunk in reversed_capacity[1]] == [4, 1]
+    assert CapacityWorker.build_calls == 2
+
+
+@pytest.mark.asyncio
 async def test_do_distrib_preserves_multiple_worker_assignments(tmp_path, monkeypatch):
     plan_path = tmp_path / "plan.json"
     env = SimpleNamespace(
@@ -229,6 +514,53 @@ async def test_do_distrib_preserves_multiple_worker_assignments(tmp_path, monkey
     assert loaded_workers == {"192.168.20.111": 1, "192.168.20.130": 1}
     assert work_plan == [["chunk-a"], ["chunk-b"]]
     assert metadata == [{"meta": 1}, {"meta": 2}]
+
+
+@pytest.mark.asyncio
+async def test_do_distrib_invalidates_cache_when_worker_slot_order_changes(
+    tmp_path,
+    monkeypatch,
+):
+    plan_path = tmp_path / "plan.json"
+    env = SimpleNamespace(
+        target="OrderedWorker",
+        target_class="OrderedWorker",
+        app_src=tmp_path / "app",
+        distribution_tree=plan_path,
+    )
+    env.app_src.mkdir()
+
+    class OrderedWorker:
+        build_calls = 0
+
+        def __init__(self, _env, **_kwargs):
+            pass
+
+        def build_distribution(self, assigned_workers):
+            type(self).build_calls += 1
+            slots = [
+                worker
+                for worker, count in assigned_workers.items()
+                for _ in range(count)
+            ]
+            return [[worker] for worker in slots], [[] for _ in slots], "worker", 1, "items"
+
+    monkeypatch.setattr(
+        WorkDispatcher,
+        "_load_module",
+        AsyncMock(return_value=SimpleNamespace(OrderedWorker=OrderedWorker)),
+    )
+
+    first = await WorkDispatcher._do_distrib(env, {"worker-a": 1, "worker-b": 1}, {})
+    reordered = await WorkDispatcher._do_distrib(
+        env,
+        {"worker-b": 1, "worker-a": 1},
+        {},
+    )
+
+    assert first[1] == [["worker-a"], ["worker-b"]]
+    assert reordered[1] == [["worker-b"], ["worker-a"]]
+    assert OrderedWorker.build_calls == 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Repro
Distribution plans could be reused after planner code, inputs, worker ordering, or worker capacity changed. Capacity calibration happened after planning, malformed endpoints broke IPv6 handling, and an empty or oversized plan could proceed.

## Root Cause
The cache identity covered too little state and cache writes were not atomic. Endpoint parsing was duplicated, and planning was sequenced before runtime capacity was authoritative.

## Regression Test
- Added a versioned cache identity over ordered workers, planner source, declared/conventional input roots, content, and capacities.
- Added atomic durable writes plus malformed/legacy cache rebuild.
- Added centralized IPv4, DNS, bracketed IPv6, and raw IPv6 parsing.
- Calibrate and align capacities before planning; reject zero-worker and excess-plan results.
- Shared-core approval: the user's explicit `fix and merge` instruction covered the audited agi-node and agi-cluster defect. No agi-core files are changed.

## Validation
- Post-rebase focused distribution slice: 155 passed.
- Full shared-core slice: 1,506 passed, 5 skipped.
- Built-in app matrix: 57 passed.
- Strict typing, lint, impact validation, and coherent three-scope validation passed.

## Review Evidence
- Codex sub-agent `distribution_integrity_fix` (inherited GPT-5 model; runtime version unavailable) implemented and reviewed the patch.
- GPT-5 Codex root agent reviewed the final diff. Findings were addressed.

## Agent Metadata
- Tokki version: 1.0.34
- Agent/runtime: Codex (runtime version unavailable)
- Model: GPT-5
- Reasoning effort: unknown
- /fast mode: not used