### PR TITLE
fix(release): bind proof to exact public evidence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,9 +287,9 @@ jobs:
         run: |
           set -euo pipefail
           if [[ "${GITHUB_EVENT_NAME}" != "schedule" && "${GITHUB_EVENT_NAME}" != "workflow_dispatch" ]] && \
-             python tools/install_release_proof_package.py --check-project-newer-than-manifest; then
+             python tools/install_release_proof_package.py --check-source-ahead; then
             echo "available=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::Checkout project version is newer than the public release-proof package; skipping clean public install until the release workflow publishes the new package."
+            echo "::notice::Release proof explicitly declares source-ahead mode; skipping the clean public install until the new package is published."
             exit 0
           fi
           if python tools/install_release_proof_package.py --check-installable-only; then

--- a/.github/workflows/docs-source-guard.yaml
+++ b/.github/workflows/docs-source-guard.yaml
@@ -41,6 +41,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7

--- a/docs/.docs_source_mirror_stamp.json
+++ b/docs/.docs_source_mirror_stamp.json
@@ -2,8 +2,8 @@
   "file_count": 276,
   "format_version": 1,
   "managed_target": "docs/source",
-  "source_digest_sha256": "b55b81ba177101794dd154b32f3cfd1ea10a5cd70f20dfe39cb17e0455308230",
+  "source_digest_sha256": "a84c8b4ba9d3460bf3545e5725aabd8e29eab70cddebc9ca8250a1ebd4d6df0d",
   "source_hint": "../thales_agilab/docs/source",
   "sync_tool": "tools/sync_docs_source.py",
-  "target_digest_sha256": "b55b81ba177101794dd154b32f3cfd1ea10a5cd70f20dfe39cb17e0455308230"
+  "target_digest_sha256": "a84c8b4ba9d3460bf3545e5725aabd8e29eab70cddebc9ca8250a1ebd4d6df0d"
 }

--- a/docs/source/data/release_proof.toml
+++ b/docs/source/data/release_proof.toml
@@ -4,9 +4,9 @@ intro = [
   "This page is the public verification index for the current AGILAB release. It records install, CI, demo, and scope evidence in one place so reviewers can check the release without inferring status from scattered badges.",
 ]
 proof_bullets = [
-  "The public GitHub Actions matrix validated the packaged first proof on Ubuntu, macOS, and Windows runners.",
+  "The pinned GitHub Actions rows record successful repository, documentation, coverage, and release-publication workflows at their exact commits. A successful workflow is not presented as proof for jobs that the workflow skipped.",
   "The release proof records the hosted Hugging Face Space URL and commit. Live public-demo availability is checked only when a public-demo-smoke run is pinned or supplied separately.",
-  "The checked-in ``docs/source/data/ui_robot_evidence.json`` records the pinned release UI robot matrix evidence, including app/page/widget counts and zero detected UI failures for that run. Use ``tools/ui_robot_coverage_contract.py --json`` and the local ``ui-robot-matrix`` profile to verify the current checkout after apps are added or removed.",
+  "The checked-in ``docs/source/data/ui_robot_evidence.json`` records a successful historical UI robot baseline. It is not release-bound UI proof for this release because its commit and 10-app inventory predate the 15-app release inventory. Use ``tools/ui_robot_coverage_contract.py --json`` and the local ``ui-robot-matrix`` profile to verify the current checkout.",
   "The public demo scope includes the lightweight ``flight_telemetry_project`` and ``weather_forecast_project`` routes documented in :doc:`agilab-demo` and aligned with the packaged examples catalog.",
   "The release tag, PyPI package, public documentation, and hosted demo point to the same public product story: browser preview, local first proof, then source-checkout expansion.",
 ]
@@ -20,60 +20,71 @@ related_pages = [
 
 [release]
 package_name = "agilab"
-package_version = "2026.07.17"
+package_version = "2026.07.17.1"
+source_version_relation = "exact"
 package_extras = [
   "examples",
 ]
 pypi_url = "https://pypi.org/project/agilab/"
-github_release_tag = "v2026.07.17"
-github_release_url = "https://github.com/ThalesGroup/agilab/releases/tag/v2026.07.17"
+github_release_tag = "v2026.07.17_1"
+github_release_url = "https://github.com/ThalesGroup/agilab/releases/tag/v2026.07.17_1"
+github_release_commit = "1e13a4eec5e1fdddf4d89c9d39deba4c6c322abd"
 hf_space_label = "jpmorard/agilab"
 hf_space_url = "https://huggingface.co/spaces/jpmorard/agilab"
-hf_space_commit = "6bd20209f1e5530979cd8dbb680369978c2af72b"
+hf_space_commit = "2fe632da08dad04cd24f15af153e4d37ab3f1894"
 dataset_release_tag = "datasets-2f602a17b4745f05"
 dataset_manifest_sha256 = "2f602a17b4745f05cf3b2612d720675b7063cabf90164326a25bc080b2396a0f"
 dataset_count = 13
 dataset_release_url = "https://github.com/ThalesGroup/agilab/releases/tag/datasets-2f602a17b4745f05"
 
+[ui_robot]
+mode = "historical"
+expected_app_count = 15
+
 [[ci_runs]]
 id = "release-guardrails"
 label = "Public guardrails"
 workflow = "repo-guardrails"
-run_id = "29581036644"
-url = "https://github.com/ThalesGroup/agilab/actions/runs/29581036644"
-summary = "passed repository guardrails and clean package first-proof jobs"
+run_id = "30244336462"
+url = "https://github.com/ThalesGroup/agilab/actions/runs/30244336462"
+head_sha = "411267613c11109af85d6139a180bf72e9e999a8"
+summary = "passed repository guardrails at the recorded post-release main commit; clean-install jobs were skipped and are not claimed as release proof"
 
 [[ci_runs]]
 id = "docs-source-guard"
 label = "Docs source guard"
 workflow = "docs-source-guard"
-run_id = "29578565212"
-url = "https://github.com/ThalesGroup/agilab/actions/runs/29578565212"
+run_id = "30244336406"
+url = "https://github.com/ThalesGroup/agilab/actions/runs/30244336406"
+head_sha = "411267613c11109af85d6139a180bf72e9e999a8"
 summary = "passed docs mirror and release-proof consistency checks"
 
 [[ci_runs]]
 id = "docs-publish"
 label = "Docs publish"
 workflow = "docs-publish"
-run_id = "29578565385"
-url = "https://github.com/ThalesGroup/agilab/actions/runs/29578565385"
+run_id = "30244336436"
+url = "https://github.com/ThalesGroup/agilab/actions/runs/30244336436"
+head_sha = "411267613c11109af85d6139a180bf72e9e999a8"
 summary = "built the public documentation from the managed docs mirror"
 
 [[ci_runs]]
 id = "coverage"
 label = "Coverage"
 workflow = "coverage"
-run_id = "29581036655"
-url = "https://github.com/ThalesGroup/agilab/actions/runs/29581036655"
+run_id = "30244336419"
+url = "https://github.com/ThalesGroup/agilab/actions/runs/30244336419"
+head_sha = "411267613c11109af85d6139a180bf72e9e999a8"
 summary = "passed component coverage and badge freshness checks"
 
 [[ci_runs]]
 id = "pypi-publish"
 label = "PyPI publish"
 workflow = "pypi-publish"
-run_id = "29576361178"
-url = "https://github.com/ThalesGroup/agilab/actions/runs/29576361178"
-summary = "passed the public release proof workflow gate"
+run_id = "29984947394"
+url = "https://github.com/ThalesGroup/agilab/actions/runs/29984947394"
+head_sha = "1e13a4eec5e1fdddf4d89c9d39deba4c6c322abd"
+summary = "tested and published the release artifacts from the recorded release commit"
 
 [proof_command]
 summary = "A clean package install can run the public first proof:"
@@ -99,7 +110,7 @@ commands = [
   "uv --preview-features extra-build-dependencies run python tools/ui_robot_evidence.py --compact",
   "uv --preview-features extra-build-dependencies run python tools/release_proof_report.py --refresh-from-local --refresh-from-github --render --check --check-github-runs --compact",
 ]
-follow_up = "Pass ``--github-release-tag``, ``--github-release-url``, ``--hf-space-commit``, or ``--github-head-sha`` only when public evidence changes outside the default local repository and latest successful ``main`` workflow state. Use ``tools/ui_robot_evidence.py --run-id <run>`` when the release should pin a specific UI robot evidence run."
+follow_up = "Pass ``--github-release-tag``, ``--github-release-url``, ``--hf-space-commit``, or ``--github-head-sha`` only when public evidence changes outside the default local repository and latest successful ``main`` workflow state. Set ``ui_robot.mode = \"release\"`` only when the evidence head commit and app count match the represented release; otherwise keep the artifact labeled as a historical baseline."
 
 [scope]
-paragraph = "This evidence proves the public package smoke, hosted demo identity, and documented first-proof routes. It proves live hosted-demo availability only when a public-demo-smoke run is pinned or supplied separately. It does not certify every remote cluster topology, every GPU stack, private app repositories, cloud accounts, security posture, or long-running production operations. Those areas remain environment-dependent and are tracked in :doc:`compatibility-matrix`."
+paragraph = "This evidence proves the public package smoke, hosted demo identity, and documented first-proof routes. It proves live hosted-demo availability only when a public-demo-smoke run is pinned or supplied separately. The checked-in UI robot artifact is a historical baseline and does not prove the current release UI matrix. This page does not certify every remote cluster topology, every GPU stack, private app repositories, cloud accounts, security posture, or long-running production operations. Those areas remain environment-dependent and are tracked in :doc:`compatibility-matrix`."

--- a/docs/source/release-proof.rst
+++ b/docs/source/release-proof.rst
@@ -18,23 +18,23 @@ Current public release
    * - Item
      - Public evidence
    * - Package version
-     - ``agilab[examples]==2026.07.17`` on `PyPI <https://pypi.org/project/agilab/>`__
+     - ``agilab[examples]==2026.07.17.1`` on `PyPI <https://pypi.org/project/agilab/>`__
    * - GitHub release
-     - `v2026.07.17 <https://github.com/ThalesGroup/agilab/releases/tag/v2026.07.17>`__
+     - `v2026.07.17_1 <https://github.com/ThalesGroup/agilab/releases/tag/v2026.07.17_1>`__
    * - Dataset release
      - `datasets-2f602a17b4745f05 <https://github.com/ThalesGroup/agilab/releases/tag/datasets-2f602a17b4745f05>`__ for ``13`` tracked dataset files; manifest ``2f602a17b4745f05cf3b2612d720675b7063cabf90164326a25bc080b2396a0f``
    * - Hosted demo
-     - `jpmorard/agilab <https://huggingface.co/spaces/jpmorard/agilab>`__ at Space commit ``6bd20209f1e5530979cd8dbb680369978c2af72b``
+     - `jpmorard/agilab <https://huggingface.co/spaces/jpmorard/agilab>`__ at Space commit ``2fe632da08dad04cd24f15af153e4d37ab3f1894``
    * - Public guardrails
-     - `repo-guardrails run 29581036644 <https://github.com/ThalesGroup/agilab/actions/runs/29581036644>`__ passed repository guardrails and clean package first-proof jobs
+     - `repo-guardrails run 30244336462 <https://github.com/ThalesGroup/agilab/actions/runs/30244336462>`__ at commit ``411267613c11`` passed repository guardrails at the recorded post-release main commit; clean-install jobs were skipped and are not claimed as release proof
    * - Docs source guard
-     - `docs-source-guard run 29578565212 <https://github.com/ThalesGroup/agilab/actions/runs/29578565212>`__ passed docs mirror and release-proof consistency checks
+     - `docs-source-guard run 30244336406 <https://github.com/ThalesGroup/agilab/actions/runs/30244336406>`__ at commit ``411267613c11`` passed docs mirror and release-proof consistency checks
    * - Docs publish
-     - `docs-publish run 29578565385 <https://github.com/ThalesGroup/agilab/actions/runs/29578565385>`__ built the public documentation from the managed docs mirror
+     - `docs-publish run 30244336436 <https://github.com/ThalesGroup/agilab/actions/runs/30244336436>`__ at commit ``411267613c11`` built the public documentation from the managed docs mirror
    * - Coverage
-     - `coverage run 29581036655 <https://github.com/ThalesGroup/agilab/actions/runs/29581036655>`__ passed component coverage and badge freshness checks
+     - `coverage run 30244336419 <https://github.com/ThalesGroup/agilab/actions/runs/30244336419>`__ at commit ``411267613c11`` passed component coverage and badge freshness checks
    * - PyPI publish
-     - `pypi-publish run 29576361178 <https://github.com/ThalesGroup/agilab/actions/runs/29576361178>`__ passed the public release proof workflow gate
+     - `pypi-publish run 29984947394 <https://github.com/ThalesGroup/agilab/actions/runs/29984947394>`__ at commit ``1e13a4eec5e1`` tested and published the release artifacts from the recorded release commit
 
 What was proved
 ---------------
@@ -43,20 +43,24 @@ What was proved
 
   .. code-block:: bash
 
-     python -m pip install "agilab[examples]==2026.07.17"
+     python -m pip install "agilab[examples]==2026.07.17.1"
      python -m agilab.lab_run first-proof --json --max-seconds 60
 
-- The public GitHub Actions matrix validated the packaged first proof on
-  Ubuntu, macOS, and Windows runners.
+- The pinned GitHub Actions rows record successful repository, documentation,
+  coverage, and release-publication workflows at their exact commits. A
+  successful workflow is not presented as proof for jobs that the workflow
+  skipped.
 - The release proof records the hosted Hugging Face Space URL and commit. Live
   public-demo availability is checked only when a public-demo-smoke run is
   pinned or supplied separately.
-- The checked-in ``docs/source/data/ui_robot_evidence.json`` records the pinned
-  release UI robot matrix evidence, including app/page/widget counts and zero
-  detected UI failures for that run. Use ``tools/ui_robot_coverage_contract.py
-  --json`` and the local ``ui-robot-matrix`` profile to verify the current
-  checkout after apps are added or removed. Pinned UI robot evidence: run
-  ``25577485125``, commit ``2a36df530b48``, generated ``2026-05-08T20:34:30Z``.
+- The checked-in ``docs/source/data/ui_robot_evidence.json`` records a
+  successful historical UI robot baseline. It is not release-bound UI proof for
+  this release because its commit and 10-app inventory predate the 15-app
+  release inventory. Use ``tools/ui_robot_coverage_contract.py --json`` and the
+  local ``ui-robot-matrix`` profile to verify the current checkout. Historical
+  UI robot baseline: run ``25577485125``, commit ``2a36df530b48``, generated
+  ``2026-05-08T20:34:30Z``. It records ``10`` apps while this release expects
+  ``15``; it is not UI proof for this release.
 - The public demo scope includes the lightweight ``flight_telemetry_project``
   and ``weather_forecast_project`` routes documented in :doc:`agilab-demo` and
   aligned with the packaged examples catalog.
@@ -75,7 +79,7 @@ the current source checkout:
    python -m venv .venv
    . .venv/bin/activate
    python -m pip install --upgrade pip
-   python -m pip install "agilab[examples]==2026.07.17"
+   python -m pip install "agilab[examples]==2026.07.17.1"
    python -m agilab.lab_run first-proof --json --max-seconds 60
 
 Use :doc:`quick-start` when you want the fuller source-checkout path with the
@@ -95,20 +99,22 @@ command:
 
 Pass ``--github-release-tag``, ``--github-release-url``, ``--hf-space-commit``,
 or ``--github-head-sha`` only when public evidence changes outside the default
-local repository and latest successful ``main`` workflow state. Use
-``tools/ui_robot_evidence.py --run-id <run>`` when the release should pin a
-specific UI robot evidence run.
+local repository and latest successful ``main`` workflow state. Set
+``ui_robot.mode = "release"`` only when the evidence head commit and app count
+match the represented release; otherwise keep the artifact labeled as a
+historical baseline.
 
 Scope and limits
 ----------------
 
 This evidence proves the public package smoke, hosted demo identity, and
 documented first-proof routes. It proves live hosted-demo availability only
-when a public-demo-smoke run is pinned or supplied separately. It does not
-certify every remote cluster topology, every GPU stack, private app
-repositories, cloud accounts, security posture, or long-running production
-operations. Those areas remain environment-dependent and are tracked in
-:doc:`compatibility-matrix`.
+when a public-demo-smoke run is pinned or supplied separately. The checked-in
+UI robot artifact is a historical baseline and does not prove the current
+release UI matrix. This page does not certify every remote cluster topology,
+every GPU stack, private app repositories, cloud accounts, security posture, or
+long-running production operations. Those areas remain environment-dependent
+and are tracked in :doc:`compatibility-matrix`.
 
 Related pages
 -------------

--- a/test/test_ci_workflow.py
+++ b/test/test_ci_workflow.py
@@ -188,6 +188,9 @@ def test_ci_workflow_includes_minimal_first_proof_contract() -> None:
     assert "os: [ubuntu-latest, macos-latest, windows-latest]" in text
     assert "tools/install_release_proof_package.py" in text
     assert "Check release package is installable from PyPI" in text
+    assert "python tools/install_release_proof_package.py --check-source-ahead" in text
+    assert "--check-project-newer-than-manifest" not in text
+    assert "Release proof explicitly declares source-ahead mode" in text
     assert "python tools/install_release_proof_package.py --check-installable-only" in text
     assert "steps.release-package.outputs.available == 'true'" in text
     assert "GITHUB_EVENT_NAME" in text

--- a/test/test_ci_workflow.py
+++ b/test/test_ci_workflow.py
@@ -285,6 +285,15 @@ def test_docs_workflows_block_stale_release_proof_github_runs() -> None:
     assert "run --extra ui pytest -q -o addopts='' test/test_sync_docs_source.py" not in guard_text
 
 
+def test_docs_source_guard_fetches_release_tags_for_exact_proof() -> None:
+    guard_text = DOCS_SOURCE_GUARD_WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    checkout_block = guard_text.split("- name: Checkout", 1)[1].split(
+        "- name: Setup Python", 1
+    )[0]
+    assert "fetch-depth: 0" in checkout_block
+
+
 def test_ui_robot_matrix_workflow_is_opt_in_or_weekly_only() -> None:
     text = UI_ROBOT_MATRIX_WORKFLOW_PATH.read_text(encoding="utf-8")
 

--- a/test/test_install_release_proof_package.py
+++ b/test/test_install_release_proof_package.py
@@ -97,6 +97,84 @@ def test_project_version_newer_than_manifest_rejects_same_version(tmp_path: Path
     assert not module.project_version_newer_than_manifest(project, manifest)
 
 
+def test_public_install_skip_requires_explicit_source_ahead_mode(
+    tmp_path: Path,
+) -> None:
+    module = _load_module()
+    manifest = tmp_path / "release_proof.toml"
+    project = tmp_path / "pyproject.toml"
+    project.write_text(
+        '[project]\nname = "agilab"\nversion = "2026.07.17.1"\n',
+        encoding="utf-8",
+    )
+    manifest.write_text(
+        "[release]\n"
+        'package_name = "agilab"\n'
+        'package_version = "2026.07.17"\n'
+        'source_version_relation = "exact"\n',
+        encoding="utf-8",
+    )
+
+    assert module.project_version_newer_than_manifest(project, manifest)
+    assert not module.should_skip_public_install(project, manifest)
+    assert (
+        module.main(
+            [
+                "--project",
+                str(project),
+                "--manifest",
+                str(manifest),
+                "--check-source-ahead",
+            ]
+        )
+        == 1
+    )
+
+    manifest.write_text(
+        "[release]\n"
+        'package_name = "agilab"\n'
+        'package_version = "2026.07.17"\n'
+        'source_version_relation = "ahead"\n',
+        encoding="utf-8",
+    )
+
+    assert module.should_skip_public_install(project, manifest)
+    assert (
+        module.main(
+            [
+                "--project",
+                str(project),
+                "--manifest",
+                str(manifest),
+                "--check-source-ahead",
+            ]
+        )
+        == 0
+    )
+
+
+def test_public_install_skip_rejects_same_version_in_source_ahead_mode(
+    tmp_path: Path,
+) -> None:
+    module = _load_module()
+    manifest = tmp_path / "release_proof.toml"
+    manifest.write_text(
+        "[release]\n"
+        'package_name = "agilab"\n'
+        'package_version = "2026.07.17.1"\n'
+        'source_version_relation = "ahead"\n',
+        encoding="utf-8",
+    )
+    project = tmp_path / "pyproject.toml"
+    project.write_text(
+        '[project]\nname = "agilab"\nversion = "2026.07.17.1"\n',
+        encoding="utf-8",
+    )
+
+    assert module.source_version_relation(manifest) == "ahead"
+    assert not module.should_skip_public_install(project, manifest)
+
+
 def test_current_release_proof_installs_public_example_payload() -> None:
     module = _load_module()
 

--- a/test/test_release_proof_report.py
+++ b/test/test_release_proof_report.py
@@ -38,11 +38,19 @@ def test_release_proof_manifest_renders_checked_in_page() -> None:
     assert {check["id"] for check in report["checks"]} >= {
         "pyproject_version",
         "pypi_badge_version",
+        "release_app_inventory",
         "dataset_manifest",
         "changelog_release",
         "readme_release_proof_link",
         "ui_robot_evidence",
         "rendered_page",
+    }
+    release_apps = next(
+        check for check in report["checks"] if check["id"] == "release_app_inventory"
+    )
+    assert release_apps["details"] == {
+        "expected_app_count": 15,
+        "local_release_app_count": 15,
     }
 
 
@@ -58,6 +66,7 @@ def test_release_proof_renders_ui_robot_run_provenance(tmp_path: Path) -> None:
                     "run_id": "25577485125",
                     "head_sha": "2a36df530b48ce992fdd1c388d47ab0f46b5239a",
                 },
+                "result": {"app_count": 10},
             }
         ),
         encoding="utf-8",
@@ -67,12 +76,14 @@ def test_release_proof_renders_ui_robot_run_provenance(tmp_path: Path) -> None:
     with_prov = " ".join(module.render_release_proof(manifest, ui_robot_evidence_path=evidence_path).split())
     without_prov = module.render_release_proof(manifest)
 
-    # The pinned run id, short sha, and date are surfaced on the page...
-    assert "Pinned UI robot evidence: run ``25577485125``" in with_prov
+    # Historical evidence is surfaced without claiming it proves this release.
+    assert "Historical UI robot baseline: run ``25577485125``" in with_prov
     assert "commit ``2a36df530b48``" in with_prov
     assert "generated ``2026-05-08T20:34:30Z``" in with_prov
-    # ...and absent when no evidence file is available.
-    assert "Pinned UI robot evidence" not in without_prov
+    assert "records ``10`` apps" in with_prov
+    assert "not UI proof for this release" in with_prov
+    # Provenance is absent when no evidence file is available.
+    assert "Historical UI robot baseline" not in without_prov
 
 
 def test_release_proof_cli_check_emits_machine_readable_report(capsys) -> None:
@@ -102,6 +113,11 @@ def test_release_proof_refresh_from_local_updates_manifest_and_page(
 
     monkeypatch.setattr(module, "_text_contains", _text_contains)
     monkeypatch.setattr(module, "_local_tag_exists", lambda _repo_root, _tag: True)
+    monkeypatch.setattr(
+        module,
+        "_local_tag_commit",
+        lambda _repo_root, _tag: "test-release-commit",
+    )
     docs_source = tmp_path / "docs" / "source"
     data_dir = docs_source / "data"
     data_dir.mkdir(parents=True)
@@ -127,8 +143,10 @@ def test_release_proof_refresh_from_local_updates_manifest_and_page(
     assert exit_code == 0
     assert payload["release"]["package_version"] == module._load_project_version(Path.cwd())
     assert refreshed["release"]["package_version"] == module._load_project_version(Path.cwd())
+    assert refreshed["release"]["source_version_relation"] == "exact"
     assert refreshed["release"]["github_release_tag"] == "v2026.05.01-2"
     assert refreshed["release"]["github_release_url"].endswith("/releases/tag/v2026.05.01-2")
+    assert refreshed["release"]["github_release_commit"] == "test-release-commit"
     dataset_release_tag = refreshed["release"]["dataset_release_tag"]
     assert dataset_release_tag.startswith("datasets-")
     assert refreshed["release"]["dataset_release_url"].endswith(
@@ -140,6 +158,23 @@ def test_release_proof_refresh_from_local_updates_manifest_and_page(
         refreshed,
         ui_robot_evidence_path=data_dir / "ui_robot_evidence.json",
     )
+
+
+def test_release_proof_refresh_drops_stale_commit_for_unresolved_new_tag(
+    tmp_path: Path,
+) -> None:
+    module = _load_module()
+    manifest = module.load_manifest(Path("docs/source/data/release_proof.toml"))
+    manifest["release"]["github_release_commit"] = "stale-commit"
+
+    refreshed = module.refresh_manifest_from_local(
+        manifest,
+        repo_root=tmp_path,
+        github_release_tag="v2099.01.01",
+    )
+
+    assert refreshed["release"]["github_release_tag"] == "v2099.01.01"
+    assert "github_release_commit" not in refreshed["release"]
 
 
 def test_release_proof_refresh_from_github_updates_ci_runs(monkeypatch) -> None:
@@ -216,6 +251,7 @@ def test_release_proof_refresh_from_github_updates_ci_runs(monkeypatch) -> None:
     by_workflow = {run["workflow"]: run for run in refreshed["ci_runs"]}
     assert by_workflow["repo-guardrails"]["id"] == "release-guardrails"
     assert by_workflow["repo-guardrails"]["run_id"] == "102"
+    assert by_workflow["repo-guardrails"]["head_sha"] == "abc123"
     assert by_workflow["docs-source-guard"]["run_id"] == "103"
     assert by_workflow["docs-publish"]["run_id"] == "104"
     assert by_workflow["coverage"]["run_id"] == "105"
@@ -246,6 +282,7 @@ def test_release_proof_github_run_check_detects_failed_or_stale_runs(monkeypatch
                 "workflow": "repo-guardrails",
                 "run_id": "42",
                 "url": "https://github.com/ThalesGroup/agilab/actions/runs/42",
+                "head_sha": "abc123",
             }
         ],
         repo_root=Path.cwd(),
@@ -282,6 +319,7 @@ def test_release_proof_github_run_check_accepts_workflow_file_fallback_name(monk
                 "workflow": "pypi-publish",
                 "run_id": "42",
                 "url": "https://github.com/ThalesGroup/agilab/actions/runs/42",
+                "head_sha": "abc123",
             }
         ],
         repo_root=Path.cwd(),
@@ -291,6 +329,23 @@ def test_release_proof_github_run_check_accepts_workflow_file_fallback_name(monk
     )
 
     assert check["status"] == "pass"
+
+    mismatch = module._github_ci_runs_check(
+        [
+            {
+                "workflow": "pypi-publish",
+                "run_id": "42",
+                "url": "https://github.com/ThalesGroup/agilab/actions/runs/42",
+                "head_sha": "different",
+            }
+        ],
+        repo_root=Path.cwd(),
+        github_repo="ThalesGroup/agilab",
+        max_age_days=45,
+        now=datetime(2026, 6, 5, tzinfo=UTC),
+    )
+    assert mismatch["status"] == "fail"
+    assert "head_sha differs" in " ".join(mismatch["details"]["failures"])
 
 
 def test_release_proof_ui_robot_evidence_check_validates_github_run(
@@ -372,6 +427,8 @@ def test_release_proof_ui_robot_evidence_check_validates_github_run(
 
     check = module._ui_robot_evidence_check(
         evidence_path,
+        release={"github_release_commit": "abc123"},
+        ui_robot={"mode": "release", "expected_app_count": 10},
         repo_root=Path.cwd(),
         github_repo="ThalesGroup/agilab",
         check_github_runs=True,
@@ -380,6 +437,42 @@ def test_release_proof_ui_robot_evidence_check_validates_github_run(
     assert check["status"] == "pass"
     assert check["details"]["run_id"] == "25577485125"
     assert check["details"]["failed_count"] == 0
+
+
+def test_release_proof_ui_robot_historical_mode_is_not_release_proof() -> None:
+    module = _load_module()
+    manifest = module.load_manifest(Path("docs/source/data/release_proof.toml"))
+    release = manifest["release"]
+    ui_robot = manifest["ui_robot"]
+    evidence_path = Path("docs/source/data/ui_robot_evidence.json")
+
+    historical_check = module._ui_robot_evidence_check(
+        evidence_path,
+        release=release,
+        ui_robot=ui_robot,
+        repo_root=Path.cwd(),
+        github_repo=None,
+        check_github_runs=False,
+    )
+    release_check = module._ui_robot_evidence_check(
+        evidence_path,
+        release=release,
+        ui_robot={"mode": "release", "expected_app_count": 15},
+        repo_root=Path.cwd(),
+        github_repo=None,
+        check_github_runs=False,
+    )
+
+    assert historical_check["status"] == "pass"
+    assert historical_check["details"]["mode"] == "historical"
+    assert historical_check["details"]["app_count"] == 10
+    assert historical_check["details"]["expected_app_count"] == 15
+    assert historical_check["details"]["represents_release"] is False
+    assert "not proof for the current release" in historical_check["summary"]
+    assert release_check["status"] == "fail"
+    failures = " ".join(release_check["details"]["failures"])
+    assert "head SHA" in failures
+    assert "app_count" in failures
 
 
 def test_release_proof_renderer_fails_unknown_template_key(tmp_path: Path) -> None:
@@ -441,7 +534,7 @@ def test_release_proof_manifest_and_toml_helpers_fail_clearly(tmp_path: Path) ->
     assert wrapped == ["-"]
 
 
-def test_release_proof_version_comparison_accepts_package_lag() -> None:
+def test_release_proof_version_comparison_helpers() -> None:
     module = _load_module()
 
     assert module._version_key("2026.05.11-2") == (2026, 5, 11, 2)
@@ -452,6 +545,92 @@ def test_release_proof_version_comparison_accepts_package_lag() -> None:
     assert not module._version_not_newer("2026.05.12", "2026.05.11")
     assert module._version_not_newer("snapshot", "snapshot")
     assert not module._version_not_newer("snapshot", "release")
+    assert not module._version_is_newer("snapshot", "release")
+
+
+def test_release_proof_requires_exact_version_unless_source_ahead_is_explicit() -> None:
+    module = _load_module()
+
+    exact_release = {
+        "package_version": "2026.07.17",
+        "source_version_relation": "exact",
+    }
+    source_ahead_release = {
+        "package_version": "2026.07.17",
+        "source_version_relation": "ahead",
+    }
+
+    exact_passed, _summary, exact_details = module._source_version_check(
+        exact_release,
+        "2026.07.17",
+    )
+    stale_passed, _summary, _details = module._source_version_check(
+        exact_release,
+        "2026.07.17.1",
+    )
+    ahead_passed, _summary, ahead_details = module._source_version_check(
+        source_ahead_release,
+        "2026.07.17.1",
+    )
+    ahead_same_passed, _summary, _details = module._source_version_check(
+        source_ahead_release,
+        "2026.07.17",
+    )
+
+    assert exact_passed
+    assert exact_details["exact_match"] is True
+    assert not stale_passed
+    assert ahead_passed
+    assert ahead_details["source_version_relation"] == "ahead"
+    assert not ahead_same_passed
+
+
+def test_release_proof_source_ahead_rendering_is_explicit() -> None:
+    module = _load_module()
+    manifest = module.load_manifest(Path("docs/source/data/release_proof.toml"))
+    manifest["release"]["source_version_relation"] = "ahead"
+
+    rendered = " ".join(module.render_release_proof(manifest).split())
+
+    assert "source checkout is intentionally ahead" in rendered
+    assert "still describe that exact published release" in rendered
+
+
+def test_release_proof_badge_version_does_not_accept_substring_collision(
+    tmp_path: Path,
+) -> None:
+    module = _load_module()
+    badge = tmp_path / "badge.svg"
+    badge.write_text(
+        '<svg role="img" aria-label="pypi: v2026.07.17.11"></svg>',
+        encoding="utf-8",
+    )
+
+    assert module._pypi_badge_version(badge) == "2026.07.17.11"
+    assert module._pypi_badge_version(badge) != "2026.07.17.1"
+
+
+def test_release_proof_changelog_requires_latest_release_section() -> None:
+    module = _load_module()
+    historical_url = "https://example.test/releases/tag/v2026.07.17"
+    changelog = (
+        "# Changelog\n\n"
+        "## Unreleased\n\n"
+        "## [2026.07.17.1] - 2026-07-23\n\n"
+        "GitHub Release: https://example.test/releases/tag/v2026.07.17_1\n\n"
+        "## [2026.07.17] - 2026-07-17\n\n"
+        f"GitHub Release: {historical_url}\n"
+    )
+
+    version, section = module._latest_changelog_release(changelog)
+
+    assert version == "2026.07.17.1"
+    assert f"GitHub Release: {historical_url}" not in section.splitlines()
+    assert not module._changelog_section_has_release_url(section, historical_url)
+    assert module._changelog_section_has_release_url(
+        section,
+        "https://example.test/releases/tag/v2026.07.17_1",
+    )
 
 
 def test_release_proof_load_project_version_handles_missing_or_invalid_pyproject(

--- a/tools/install_release_proof_package.py
+++ b/tools/install_release_proof_package.py
@@ -87,7 +87,32 @@ def project_version(project_path: Path) -> str:
 def project_version_newer_than_manifest(project_path: Path, manifest_path: Path) -> bool:
     """Return whether the checkout version is ahead of public release proof."""
     _package_name, package_version, _package_spec = release_package_spec(manifest_path)
-    return _version_sort_key(project_version(project_path)) > _version_sort_key(package_version)
+    checkout_version = project_version(project_path)
+    if not any(char.isdigit() for char in checkout_version) or not any(
+        char.isdigit() for char in package_version
+    ):
+        return False
+    return _version_sort_key(checkout_version) > _version_sort_key(package_version)
+
+
+def source_version_relation(manifest_path: Path) -> str:
+    """Return the manifest's explicit source-to-release version relation."""
+
+    with manifest_path.open("rb") as stream:
+        manifest = tomllib.load(stream)
+    release = manifest.get("release", {})
+    if not isinstance(release, dict):
+        return ""
+    return str(release.get("source_version_relation", "") or "").strip()
+
+
+def should_skip_public_install(project_path: Path, manifest_path: Path) -> bool:
+    """Return whether explicit source-ahead mode permits a non-strict install skip."""
+
+    return (
+        source_version_relation(manifest_path) == "ahead"
+        and project_version_newer_than_manifest(project_path, manifest_path)
+    )
 
 
 def pypi_release_visible(
@@ -229,12 +254,14 @@ def main(argv: Sequence[str] | None = None) -> int:
         ),
     )
     parser.add_argument(
+        "--check-source-ahead",
         "--check-project-newer-than-manifest",
+        dest="check_source_ahead",
         action="store_true",
         help=(
-            "Exit 0 when pyproject.toml declares a version newer than the "
-            "release-proof manifest. CI uses this to skip stale public-package "
-            "checks during non-strict pre-release branches."
+            "Exit 0 only when the manifest explicitly declares source_version_relation "
+            "= 'ahead' and pyproject.toml is newer. CI uses this explicit mode to "
+            "skip public-package checks during non-strict pre-release branches."
         ),
     )
     args = parser.parse_args(argv)
@@ -243,21 +270,23 @@ def main(argv: Sequence[str] | None = None) -> int:
     check_modes = [
         args.check_available_only,
         args.check_installable_only,
-        args.check_project_newer_than_manifest,
+        args.check_source_ahead,
     ]
     if sum(bool(mode) for mode in check_modes) > 1:
         parser.error(
             "--check-available-only, --check-installable-only, and "
-            "--check-project-newer-than-manifest are mutually exclusive"
+            "--check-source-ahead are mutually exclusive"
         )
-    if args.check_project_newer_than_manifest:
-        if project_version_newer_than_manifest(args.project, args.manifest):
+    if args.check_source_ahead:
+        if should_skip_public_install(args.project, args.manifest):
             print(
-                f"[install] {args.project} version is newer than {args.manifest} release proof"
+                f"[install] {args.manifest} explicitly declares source-ahead mode "
+                f"and {args.project} is newer"
             )
             return 0
         print(
-            f"[install] {args.project} version is not newer than {args.manifest} release proof",
+            f"[install] explicit source-ahead mode does not permit skipping the "
+            f"public install for {args.project}",
             file=sys.stderr,
         )
         return 1

--- a/tools/release_proof_report.py
+++ b/tools/release_proof_report.py
@@ -37,6 +37,8 @@ GITHUB_RUN_FIELDS = (
 DEFAULT_GITHUB_BRANCH = "main"
 DEFAULT_GITHUB_RUN_LIMIT = 50
 DEFAULT_GITHUB_MAX_AGE_DAYS = 45
+SOURCE_VERSION_RELATIONS = frozenset({"exact", "ahead"})
+UI_ROBOT_EVIDENCE_MODES = frozenset({"release", "historical"})
 DEFAULT_GITHUB_WORKFLOWS = (
     "repo-guardrails",
     "docs-source-guard",
@@ -44,7 +46,10 @@ DEFAULT_GITHUB_WORKFLOWS = (
     "coverage",
 )
 GITHUB_WORKFLOW_SUMMARIES = {
-    "repo-guardrails": "passed repository guardrails and clean package first-proof jobs",
+    "repo-guardrails": (
+        "passed repository guardrails; skipped jobs remain out of scope unless "
+        "separately evidenced"
+    ),
     "docs-source-guard": "passed docs mirror and release-proof consistency checks",
     "docs-publish": "built the public documentation from the managed docs mirror",
     "coverage": "passed component coverage and badge freshness checks",
@@ -227,8 +232,11 @@ def _required_list(name: str, manifest: Mapping[str, Any]) -> list[Any]:
     return value
 
 
-def _ui_robot_provenance_suffix(evidence_path: Path | None) -> str:
-    """Return a sentence pinning the UI-robot run date/id/sha, or "" if absent.
+def _ui_robot_provenance_suffix(
+    evidence_path: Path | None,
+    ui_robot: Mapping[str, Any],
+) -> str:
+    """Return an honest UI-robot provenance and release-binding sentence.
 
     The provenance lives in ui_robot_evidence.json (the single source of truth),
     so the rendered page surfaces the evidence age instead of hiding it.
@@ -241,6 +249,7 @@ def _ui_robot_provenance_suffix(evidence_path: Path | None) -> str:
         return ""
     generated_at = str(evidence.get("generated_at") or "").strip()
     source = evidence.get("source") or {}
+    result = evidence.get("result") or {}
     run_id = str(source.get("run_id") or "").strip()
     head_sha = str(source.get("head_sha") or "").strip()
     parts: list[str] = []
@@ -250,9 +259,24 @@ def _ui_robot_provenance_suffix(evidence_path: Path | None) -> str:
         parts.append(f"commit ``{head_sha[:12]}``")
     if generated_at:
         parts.append(f"generated ``{generated_at}``")
-    if not parts:
-        return ""
-    return " Pinned UI robot evidence: " + ", ".join(parts) + "."
+    mode = str(ui_robot.get("mode", "") or "").strip()
+    prefix = (
+        " Release-bound UI robot evidence: "
+        if mode == "release"
+        else " Historical UI robot baseline: "
+    )
+    suffix = prefix + (", ".join(parts) if parts else "provenance unavailable") + "."
+    if mode == "historical":
+        actual_app_count = result.get("app_count")
+        expected_app_count = ui_robot.get("expected_app_count")
+        if actual_app_count is not None and expected_app_count is not None:
+            suffix += (
+                f" It records ``{actual_app_count}`` apps while this release expects "
+                f"``{expected_app_count}``; it is not UI proof for this release."
+            )
+        else:
+            suffix += " It is not UI proof for this release."
+    return suffix
 
 
 def render_release_proof(
@@ -262,6 +286,7 @@ def render_release_proof(
 ) -> str:
     context = _template_context(manifest)
     release = _required_table("release", manifest)
+    ui_robot = _required_table("ui_robot", manifest)
     proof_command = _required_table("proof_command", manifest)
     verification = _required_table("verification", manifest)
     scope = _required_table("scope", manifest)
@@ -280,6 +305,18 @@ def render_release_proof(
         ]
     )
     _append_paragraphs(lines, _required_list("intro", manifest), context)
+    if str(release.get("source_version_relation", "") or "").strip() == "ahead":
+        lines.extend(["", ".. note::", ""])
+        _append_wrapped(
+            lines,
+            (
+                "The source checkout is intentionally ahead of the public release "
+                f"``{context['package_version']}``. The package and links below still "
+                "describe that exact published release."
+            ),
+            initial_indent="   ",
+            subsequent_indent="   ",
+        )
 
     lines.extend(
         [
@@ -346,10 +383,12 @@ def render_release_proof(
         run_id = str(run["run_id"])
         url = str(run["url"])
         summary = _format_template(str(run["summary"]), context)
+        head_sha = str(run.get("head_sha", "") or "").strip()
+        commit_suffix = f" at commit ``{head_sha[:12]}``" if head_sha else ""
         lines.extend(
             [
                 f"   * - {label}",
-                f"     - `{workflow} run {run_id} <{url}>`__ {summary}",
+                f"     - `{workflow} run {run_id} <{url}>`__{commit_suffix} {summary}",
             ]
         )
 
@@ -357,7 +396,7 @@ def render_release_proof(
     _append_wrapped(lines, _format_template(str(proof_command["summary"]), context), initial_indent="- ")
     _append_code_block(lines, proof_command.get("commands", []), context, indent="  ")
     lines.append("")
-    provenance_suffix = _ui_robot_provenance_suffix(ui_robot_evidence_path)
+    provenance_suffix = _ui_robot_provenance_suffix(ui_robot_evidence_path, ui_robot)
     for bullet in _format_templates(proof_bullets, context):
         if provenance_suffix and "ui_robot_evidence.json" in bullet:
             bullet = bullet + provenance_suffix
@@ -439,6 +478,58 @@ def _version_not_newer(left: str, right: str) -> bool:
     return padded_left <= padded_right
 
 
+def _version_is_newer(left: str, right: str) -> bool:
+    """Return True when left is strictly newer than right."""
+
+    if _version_key(left) is None or _version_key(right) is None:
+        return False
+    return left != right and not _version_not_newer(left, right)
+
+
+def _source_version_check(
+    release: Mapping[str, Any],
+    project_version: str | None,
+) -> tuple[bool, str, dict[str, Any]]:
+    manifest_version = str(release.get("package_version", "") or "")
+    relation = str(release.get("source_version_relation", "") or "").strip()
+    relation_is_valid = relation in SOURCE_VERSION_RELATIONS
+    if project_version is None:
+        passed = relation_is_valid
+        summary = (
+            "pyproject.toml not present; source-version relation is valid"
+            if passed
+            else "release source-version relation is missing or invalid"
+        )
+    elif relation == "exact":
+        passed = project_version == manifest_version
+        summary = (
+            "manifest package version exactly matches pyproject.toml"
+            if passed
+            else "exact release proof does not match pyproject.toml"
+        )
+    elif relation == "ahead":
+        passed = _version_is_newer(project_version, manifest_version)
+        summary = (
+            "source checkout is explicitly and strictly ahead of the public release"
+            if passed
+            else "source-ahead mode requires pyproject.toml to be newer than the manifest"
+        )
+    else:
+        passed = False
+        summary = "release source-version relation is missing or invalid"
+    return (
+        passed,
+        summary,
+        {
+            "pyproject_version": project_version,
+            "manifest_version": manifest_version,
+            "source_version_relation": relation,
+            "allowed_relations": sorted(SOURCE_VERSION_RELATIONS),
+            "exact_match": project_version == manifest_version,
+        },
+    )
+
+
 def _run_git(repo_root: Path, args: Sequence[str]) -> str | None:
     completed = subprocess.run(
         ["git", *args],
@@ -470,6 +561,24 @@ def _latest_local_release_tag(repo_root: Path, package_version: str) -> str | No
 def _local_tag_exists(repo_root: Path, tag: str) -> bool:
     output = _run_git(repo_root, ["tag", "--list", tag])
     return bool(output and output.splitlines())
+
+
+def _local_tag_commit(repo_root: Path, tag: str) -> str | None:
+    if not tag:
+        return None
+    return _run_git(repo_root, ["rev-list", "-n", "1", tag])
+
+
+def _local_release_app_count(repo_root: Path, release_ref: str) -> int | None:
+    if not release_ref:
+        return None
+    output = _run_git(
+        repo_root,
+        ["ls-tree", "-d", "--name-only", f"{release_ref}:src/agilab/apps/builtin"],
+    )
+    if output is None:
+        return None
+    return len([line for line in output.splitlines() if line.strip()])
 
 
 def _github_repo_base_url(repo_root: Path) -> str | None:
@@ -682,6 +791,7 @@ def refresh_manifest_from_github(
             by_workflow[workflow] = entry
         entry["run_id"] = _github_run_id(run)
         entry["url"] = str(run["url"])
+        entry["head_sha"] = str(run["headSha"])
         entry["summary"] = GITHUB_WORKFLOW_SUMMARIES.get(
             workflow,
             "passed the public release proof workflow gate",
@@ -707,7 +817,9 @@ def refresh_manifest_from_local(
     package_version = _load_project_version(repo_root) or str(release.get("package_version", ""))
     if package_version:
         release["package_version"] = package_version
+        release["source_version_relation"] = "exact"
 
+    previous_tag = str(release.get("github_release_tag", "") or "")
     tag = github_release_tag or _latest_local_release_tag(repo_root, package_version)
     if tag:
         release["github_release_tag"] = tag
@@ -715,6 +827,11 @@ def refresh_manifest_from_local(
         release["github_release_url"] = github_release_url or (
             f"{base_url}/releases/tag/{tag}" if base_url else str(release.get("github_release_url", ""))
         )
+        tag_commit = _local_tag_commit(repo_root, tag)
+        if tag_commit:
+            release["github_release_commit"] = tag_commit
+        elif tag != previous_tag:
+            release.pop("github_release_commit", None)
     elif github_release_url:
         release["github_release_url"] = github_release_url
 
@@ -735,13 +852,41 @@ def _text_contains(path: Path, expected: str) -> bool | None:
     return expected in path.read_text(encoding="utf-8")
 
 
+def _pypi_badge_version(path: Path) -> str | None:
+    if not path.exists():
+        return None
+    text = path.read_text(encoding="utf-8")
+    match = re.search(r"""aria-label=["']pypi:\s*v([^"']+)["']""", text)
+    return match.group(1).strip() if match else ""
+
+
+def _latest_changelog_release(text: str) -> tuple[str | None, str]:
+    matches = list(re.finditer(r"(?m)^## \[([^\]]+)\][^\n]*$", text))
+    if not matches:
+        return None, ""
+    latest = matches[0]
+    section_end = matches[1].start() if len(matches) > 1 else len(text)
+    return latest.group(1).strip(), text[latest.start() : section_end]
+
+
+def _changelog_section_has_release_url(section: str, release_url: str) -> bool:
+    return f"GitHub Release: {release_url}" in {
+        line.strip() for line in section.splitlines()
+    }
+
+
 def _ci_run_urls_are_consistent(ci_runs: Sequence[Any]) -> bool:
     for run in ci_runs:
         if not isinstance(run, Mapping):
             return False
         run_id = str(run.get("run_id", ""))
         url = str(run.get("url", ""))
-        if not run_id or not url.endswith(f"/actions/runs/{run_id}"):
+        head_sha = str(run.get("head_sha", ""))
+        if (
+            not run_id
+            or not url.endswith(f"/actions/runs/{run_id}")
+            or re.fullmatch(r"[0-9a-f]{40}", head_sha) is None
+        ):
             return False
     return True
 
@@ -813,6 +958,11 @@ def _github_ci_runs_check(
         expected_url = str(run.get("url", "") or "")
         if expected_url and github_run["url"] and expected_url != github_run["url"]:
             run_failures.append("manifest URL differs from GitHub run URL")
+        expected_head_sha = str(run.get("head_sha", "") or "")
+        if not expected_head_sha:
+            run_failures.append("manifest head_sha is missing")
+        elif github_run["headSha"] != expected_head_sha:
+            run_failures.append("manifest head_sha differs from GitHub run head SHA")
         if age_days is None:
             run_failures.append("run createdAt timestamp is missing or invalid")
         elif age_days > max_age_days:
@@ -826,6 +976,7 @@ def _github_ci_runs_check(
                 "status": github_run["status"],
                 "conclusion": github_run["conclusion"],
                 "head_sha": github_run["headSha"],
+                "expected_head_sha": expected_head_sha,
                 "created_at": github_run["createdAt"],
                 "age_days": age_days,
                 "url": github_run["url"],
@@ -867,6 +1018,8 @@ def _load_ui_robot_evidence_module() -> Any:
 def _ui_robot_evidence_check(
     evidence_path: Path,
     *,
+    release: Mapping[str, Any],
+    ui_robot: Mapping[str, Any],
     repo_root: Path,
     github_repo: str | None,
     check_github_runs: bool,
@@ -891,6 +1044,41 @@ def _ui_robot_evidence_check(
         for check in validation_checks
         if check.get("status") != "pass"
     ]
+    mode = str(ui_robot.get("mode", "") or "").strip()
+    expected_release_commit = str(
+        release.get("github_release_commit", "") or ""
+    ).strip()
+    expected_app_count = ui_robot.get("expected_app_count")
+    evidence_head_sha = str(source.get("head_sha", "") or "").strip()
+    evidence_app_count = result.get("app_count")
+    if mode not in UI_ROBOT_EVIDENCE_MODES:
+        failures.append(
+            "manifest: ui_robot.mode must be one of "
+            + ", ".join(sorted(UI_ROBOT_EVIDENCE_MODES))
+        )
+    if type(expected_app_count) is not int or expected_app_count < 0:
+        failures.append(
+            "manifest: ui_robot.expected_app_count must be a non-negative integer"
+        )
+    represented_release = (
+        mode == "release"
+        and bool(expected_release_commit)
+        and evidence_head_sha == expected_release_commit
+        and evidence_app_count == expected_app_count
+    )
+    if mode == "release":
+        if not expected_release_commit:
+            failures.append(
+                "release: github_release_commit is required for release-bound UI evidence"
+            )
+        elif evidence_head_sha != expected_release_commit:
+            failures.append(
+                "release: UI evidence head SHA does not match github_release_commit"
+            )
+        if evidence_app_count != expected_app_count:
+            failures.append(
+                "release: UI evidence app_count does not match ui_robot.expected_app_count"
+            )
     github_run: dict[str, Any] | None = None
     if check_github_runs:
         try:
@@ -927,20 +1115,30 @@ def _ui_robot_evidence_check(
         except Exception as exc:
             failures.append(f"github: {exc}")
 
+    if failures:
+        summary = "UI robot matrix evidence is missing, failed, or inconsistent"
+    elif mode == "historical":
+        summary = "UI robot historical baseline is healthy but is not proof for the current release"
+    else:
+        summary = "UI robot evidence is bound to the release commit and expected app inventory"
     return _check_result(
         "ui_robot_evidence",
         not failures,
-        (
-            "UI robot matrix evidence is present, successful, and references a valid run"
-            if not failures
-            else "UI robot matrix evidence is missing, failed, or inconsistent"
-        ),
-        evidence=[str(evidence_path.relative_to(repo_root)) if evidence_path.is_relative_to(repo_root) else str(evidence_path)],
+        summary,
+        evidence=[
+            str(evidence_path.relative_to(repo_root))
+            if evidence_path.is_relative_to(repo_root)
+            else str(evidence_path)
+        ],
         details={
             "run_id": source.get("run_id", ""),
             "run_url": source.get("run_url", ""),
             "head_sha": source.get("head_sha", ""),
             "app_count": result.get("app_count", 0),
+            "mode": mode,
+            "expected_release_commit": expected_release_commit,
+            "expected_app_count": expected_app_count,
+            "represents_release": represented_release,
             "page_count": result.get("page_count", 0),
             "widget_count": result.get("widget_count", 0),
             "interacted_count": result.get("interacted_count", 0),
@@ -968,10 +1166,12 @@ def build_report(
         ui_robot_evidence_path=manifest_path.parent / UI_ROBOT_EVIDENCE_RELATIVE_PATH.name,
     )
     release = _required_table("release", manifest)
+    ui_robot = _required_table("ui_robot", manifest)
     ci_runs = _required_list("ci_runs", manifest)
     package_version = str(release["package_version"])
     github_release_url = str(release["github_release_url"])
     github_release_tag = str(release["github_release_tag"])
+    github_release_commit = str(release.get("github_release_commit", "") or "").strip()
     dataset_release_tag = str(release.get("dataset_release_tag", "") or "")
     dataset_release_url = str(release.get("dataset_release_url", "") or "")
     dataset_manifest_sha256 = str(release.get("dataset_manifest_sha256", "") or "")
@@ -979,33 +1179,83 @@ def build_report(
     checks: list[dict[str, Any]] = []
 
     project_version = _load_project_version(repo_root)
-    version_is_not_newer = (
-        project_version is None or _version_not_newer(package_version, project_version)
+    version_matches, version_summary, version_details = _source_version_check(
+        release,
+        project_version,
     )
     checks.append(
         _check_result(
             "pyproject_version",
-            version_is_not_newer,
-            (
-                "manifest package version is not newer than pyproject.toml"
-                if project_version is not None
-                else "pyproject.toml not present; skipped package version cross-check"
-            ),
+            version_matches,
+            version_summary,
             evidence=["pyproject.toml", str(manifest_path)],
-            details={
-                "pyproject_version": project_version,
-                "manifest_version": package_version,
-                "exact_match": project_version == package_version,
-            },
+            details=version_details,
         )
     )
+    expected_release_url_suffix = f"/releases/tag/{github_release_tag}"
     checks.append(
         _check_result(
             "github_release_url",
-            github_release_tag in github_release_url,
-            "manifest GitHub release URL contains the release tag",
+            github_release_url.rstrip("/").endswith(expected_release_url_suffix),
+            "manifest GitHub release URL ends with the exact release tag",
             evidence=[str(manifest_path)],
             details={"tag": github_release_tag, "url": github_release_url},
+        )
+    )
+    local_release_commit = _local_tag_commit(repo_root, github_release_tag)
+    release_commit_matches = bool(github_release_commit) and (
+        local_release_commit is None or local_release_commit == github_release_commit
+    )
+    if not github_release_commit:
+        release_commit_summary = "manifest does not record the release commit"
+    elif local_release_commit is None:
+        release_commit_summary = "manifest records the release commit; local tag is unavailable"
+    elif release_commit_matches:
+        release_commit_summary = "manifest release commit matches the local tag"
+    else:
+        release_commit_summary = "manifest release commit differs from the local tag"
+    checks.append(
+        _check_result(
+            "github_release_commit",
+            release_commit_matches,
+            release_commit_summary,
+            evidence=[str(manifest_path), github_release_tag],
+            details={
+                "manifest_commit": github_release_commit,
+                "local_tag_commit": local_release_commit,
+            },
+        )
+    )
+    expected_app_count = ui_robot.get("expected_app_count")
+    local_release_app_count = _local_release_app_count(repo_root, github_release_tag)
+    release_app_count_matches = (
+        type(expected_app_count) is int
+        and expected_app_count >= 0
+        and (
+            local_release_app_count is None
+            or local_release_app_count == expected_app_count
+        )
+    )
+    if type(expected_app_count) is not int or expected_app_count < 0:
+        release_app_count_summary = "manifest release app count is missing or invalid"
+    elif local_release_app_count is None:
+        release_app_count_summary = (
+            "manifest records the release app count; local tag tree is unavailable"
+        )
+    elif release_app_count_matches:
+        release_app_count_summary = "manifest app count matches the release tag inventory"
+    else:
+        release_app_count_summary = "manifest app count differs from the release tag inventory"
+    checks.append(
+        _check_result(
+            "release_app_inventory",
+            release_app_count_matches,
+            release_app_count_summary,
+            evidence=[str(manifest_path), github_release_tag],
+            details={
+                "expected_app_count": expected_app_count,
+                "local_release_app_count": local_release_app_count,
+            },
         )
     )
     if dataset_release_url:
@@ -1034,28 +1284,61 @@ def build_report(
             )
         )
     badge_path = repo_root / "badges" / "pypi-version-agilab.svg"
-    badge_contains = _text_contains(badge_path, f"v{package_version}")
+    badge_version = _pypi_badge_version(badge_path)
+    badge_matches = badge_path.exists() and badge_version == package_version
+    if not badge_path.exists():
+        badge_summary = "PyPI badge is missing"
+    elif not badge_version:
+        badge_summary = "PyPI badge does not expose a version in its aria-label"
+    elif badge_matches:
+        badge_summary = "PyPI badge exactly matches manifest package version"
+    else:
+        badge_summary = "PyPI badge version differs from the manifest"
     checks.append(
         _check_result(
             "pypi_badge_version",
-            badge_contains is not False,
-            (
-                "PyPI badge contains manifest package version"
-                if badge_contains is not None
-                else "PyPI badge not present; skipped badge cross-check"
-            ),
-            evidence=[str(badge_path.relative_to(repo_root)) if badge_path.exists() else str(badge_path)],
+            badge_matches,
+            badge_summary,
+            evidence=[
+                str(badge_path.relative_to(repo_root))
+                if badge_path.exists()
+                else str(badge_path)
+            ],
+            details={
+                "badge_version": badge_version,
+                "manifest_version": package_version,
+            },
         )
     )
     changelog = repo_root / "CHANGELOG.md"
     changelog_text = changelog.read_text(encoding="utf-8") if changelog.exists() else ""
+    latest_changelog_version, latest_changelog_section = _latest_changelog_release(
+        changelog_text
+    )
+    changelog_release_url_matches = _changelog_section_has_release_url(
+        latest_changelog_section,
+        github_release_url,
+    )
+    changelog_matches = changelog.exists() and (
+        latest_changelog_version == package_version
+        and changelog_release_url_matches
+    )
+    changelog_summary = (
+        "CHANGELOG latest release entry exactly matches the manifest"
+        if changelog_matches
+        else "CHANGELOG latest release entry is missing or differs from the manifest"
+    )
     checks.append(
         _check_result(
             "changelog_release",
-            not changelog.exists()
-            or (f"## [{package_version}]" in changelog_text and github_release_url in changelog_text),
-            "CHANGELOG current release entry matches the manifest",
+            changelog_matches,
+            changelog_summary,
             evidence=["CHANGELOG.md", str(manifest_path)],
+            details={
+                "latest_changelog_version": latest_changelog_version,
+                "manifest_version": package_version,
+                "release_url_in_latest_section": changelog_release_url_matches,
+            },
         )
     )
     readme = repo_root / "README.md"
@@ -1076,13 +1359,15 @@ def build_report(
         _check_result(
             "ci_run_urls",
             _ci_run_urls_are_consistent(ci_runs),
-            "CI run URLs match their run IDs",
+            "CI run URLs match their run IDs and record exact commit identities",
             evidence=[str(manifest_path)],
         )
     )
     checks.append(
         _ui_robot_evidence_check(
             manifest_path.parent / UI_ROBOT_EVIDENCE_RELATIVE_PATH.name,
+            release=release,
+            ui_robot=ui_robot,
             repo_root=repo_root,
             github_repo=github_repo,
             check_github_runs=check_github_runs,
@@ -1119,6 +1404,11 @@ def build_report(
             "package_version": package_version,
             "github_release_tag": github_release_tag,
             "github_release_url": github_release_url,
+            "github_release_commit": github_release_commit,
+            "source_version_relation": str(
+                release.get("source_version_relation", "") or ""
+            ),
+            "expected_app_count": expected_app_count,
             "dataset_release_tag": dataset_release_tag,
             "dataset_release_url": dataset_release_url,
             "hf_space_url": str(release["hf_space_url"]),


### PR DESCRIPTION
## Repro
The checked-in release proof still described 2026.07.17 while the project, PyPI package, and GitHub release are 2026.07.17.1. Badge and changelog checks allowed substring/historical matches, workflow rows were not commit-bound, and a 10-app historical UI robot run was described as proof for a 15-app release.

## Root Cause
The proof contract allowed package lag implicitly and verified presence rather than exact identity. GitHub evidence omitted head commits, release inventory was not checked at the tag, UI robot evidence had no release-vs-historical mode, and the docs guard used a shallow checkout that omitted the release tag tree required by the stronger proof.

## Regression Test
- Require exact source/package equality unless the manifest explicitly declares a strictly newer source checkout.
- Parse the exact PyPI badge version and latest changelog release section.
- Bind workflow rows and GitHub release to commits.
- Verify the built-in app count at the release tag.
- Distinguish release-bound UI evidence from an honest historical baseline.
- Require explicit source-ahead mode before clean-install CI may skip a public package.
- Require the docs-source guard checkout to fetch release tags.
- Update canonical docs first in jpmorard/thales_agilab#180, then synchronize the managed public mirror.

## Validation
- 73 focused tests passed.
- The CI-specific repair passed 42 focused tests; live release-proof report passed 13/13.
- Isolated install of `agilab[examples]==2026.07.17.1` and first proof passed in 4.1 seconds.
- Public docs profile, Ruff, impact, scope, mirror stamp, and canonical-source parity passed.
- GitHub's initial docs-source guard failure was reproduced exactly as a shallow-checkout tag omission; `fetch-depth: 0` plus a workflow-contract regression was added, and the final GitHub rerun passed.
- The normal initial pre-push hook correctly rejected the user-owned stale canonical checkout. After private PR #180 merged, exact mirror, release-proof, and app-contract guards were rerun against its isolated canonical worktree before the documented guard bypass. The CI-only follow-up pushed normally.
- All final GitHub checks passed across Linux, macOS, Windows, docs proof, base Python, install, policy, and security.

## Review Evidence
- Codex sub-agent `quality_systems` (inherited GPT-5 model; runtime version unavailable) implemented and reviewed the patch.
- GPT-5 Codex root agent reviewed the final public and canonical diffs. Findings were addressed.
- GitHub Actions failure `docs-source-guard` was inspected at the exact assertion before the CI checkout fix.

## Agent Metadata
- Tokki version: 1.0.34
- Agent/runtime: Codex (runtime version unavailable)
- Model: GPT-5
- Reasoning effort: unknown
- /fast mode: not used