### PR TITLE
fix(packaging): pin the self-referential offline extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ pages = ["agi-pages==2026.07.17.1", "plotly>=6.8,<7", "sqlalchemy>=2.0.43,<3", "
 proof = ["cryptography>=48.0.1,<50"]
 agents = ["openai>=2.32.0,<3"]
 local-llm = ["accelerate>=0.34.2,<2; python_version >= '3.12'", "fastapi>=0.124.4,!=0.136.3,<1; python_version >= '3.12'", "gpt-oss>=0.0.8,<0.1; python_version >= '3.12'", "langchain-core>=1.3.3,<2; python_version >= '3.12'", "langsmith>=0.8.0,<1; python_version >= '3.12'", "mlx>=0.31.2,<0.33; sys_platform == 'darwin' and platform_machine == 'arm64'", "mlx-lm>=0.31.3,<0.32; sys_platform == 'darwin' and platform_machine == 'arm64'", "mlx-vlm>=0.5.0,<0.7; sys_platform == 'darwin' and platform_machine == 'arm64'", "requests>=2.32.0,<3; python_version >= '3.12'", "starlette>=1.3.1,<2; python_version >= '3.12'", "torch>=2.8.0,<3; python_version >= '3.12'", "transformers>=4.57.0,<6; python_version >= '3.12'", "universal-offline-ai-chatbot>=0.1.0,<0.2; python_version >= '3.12'", "langchain>=1.3.9,<2; python_version >= '3.12'", "pypdf>=6.13.0,<7; python_version >= '3.12'", "python-multipart>=0.0.31,<1; python_version >= '3.12'", "tornado>=6.5.7,<7; python_version >= '3.12'"]
-offline = ["agilab[local-llm]"]
+offline = ["agilab[local-llm]==2026.07.17.1"]
 dev = ["build>=1.3.0,<2", "cyclonedx-bom>=7.2.1,<8", "pip-audit>=2.9.0,<3", "pytest>=9.0.0,<10", "pytest-asyncio>=1.3.0,<2", "pytest-cov>=7.0.0,<8", "ruff>=0.15.14,<1", "tomlkit>=0.13.0,<1", "twine>=6.2.0,<7", "wheel>=0.45.0,<1"]
 
 [dependency-groups]


### PR DESCRIPTION
Third red check found on `main` while sweeping the guard/contract/policy test family after #869. This one is packaging, not tests.

## What happened

`f0a4d64` (#848, 2026-07-23) deduplicated the `offline` extra, replacing a verbatim copy of the `local-llm` dependency list with a self-reference:

```toml
offline = ["agilab[local-llm]"]
```

That is a genuine simplification, but `test_package_split_contract::test_internal_dependencies_follow_bundle_or_asset_version_policy` requires every internal package reference to carry an exact pin — the rule `core = ["agi-core==2026.07.17"]` and the other bundle extras already follow. This one had none, so the contract has been failing for four days.

## Fix

```toml
offline = ["agilab[local-llm]==2026.07.17.1"]
```

The guard now enforces that a version bump updates this pin too, which is the behaviour it exists to provide.

## Verification

Self-referential pins can break resolution, so I checked past the unit test:

- wheel builds; metadata carries `Requires-Dist: agilab[local-llm]==2026.07.17.1; extra == "offline"`
- clean-venv `uv pip install --dry-run "agilab[offline] @ <local wheel>"` → **Resolved 144 packages**, with `agilab` satisfied by the same distribution rather than refetched from PyPI, and `torch==2.13.0` / `transformers==5.14.1` pulled in through the extra
- PEP 440 normalisation makes `==2026.07.17.1` match the `2026.7.17.1` the wheel declares

`test_package_split_contract` passes (13 tests).

## Sweep result

Ran all 28 guard/contract/policy test modules against `main`: **310 passed, 1 failed** — this one. With #869 merged and this fixed, that family is fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)